### PR TITLE
fix(issue11):only display table label if there is any migration history

### DIFF
--- a/frontend/src/components/ProjectMigrationHistoryPanel.vue
+++ b/frontend/src/components/ProjectMigrationHistoryPanel.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="flex flex-col space-y-4">
-    <div class="text-center textinfolabel">
-      For database having migration history, we list up to 5 most recent
-      histories below. You can click the database name to view all histories.
-    </div>
     <template v-if="state.migrationHistorySectionList.length > 0">
+      <div class="text-center textinfolabel">
+        For database having migration history, we list up to 5 most recent
+        histories below. You can click the database name to view all histories.
+      </div>
       <MigrationHistoryTable
         :mode="'PROJECT'"
         :databaseSectionList="state.databaseSectionList"


### PR DESCRIPTION
#11
Only display table label if there is any migration history 