### PR TITLE
fix #30: skip internal databases from cloud service providers

### DIFF
--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -327,6 +327,11 @@ func (driver *Driver) SyncSchema(ctx context.Context) ([]*db.DBUser, []*db.DBSch
 	excludedDatabaseList := map[string]bool{
 		// Skip our internal "bytebase" database
 		"bytebase": true,
+		// Skip internal databases from cloud service providers
+		// aws
+		"rdsadmin": true,
+		// gcp
+		"cloudsql": true,
 	}
 	// Skip all system databases
 	for k := range systemDatabases {

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -328,6 +328,7 @@ func (driver *Driver) SyncSchema(ctx context.Context) ([]*db.DBUser, []*db.DBSch
 		// Skip our internal "bytebase" database
 		"bytebase": true,
 		// Skip internal databases from cloud service providers
+		// see https://github.com/bytebase/bytebase/issues/30
 		// aws
 		"rdsadmin": true,
 		// gcp


### PR DESCRIPTION
Skip providers created databases used for monitoring, audit and etc. when using PostgreSQL.