### PR TITLE
refactor: Extract methods to the Driver interface

### DIFF
--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -40,6 +40,10 @@ type Driver struct {
 	db *sql.DB
 }
 
+func (driver *Driver) TablePrefix() string {
+	return "bytebase."
+}
+
 func (driver *Driver) MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error {
 	updateHistoryAsDoneQuery := `
 		ALTER TABLE
@@ -520,10 +524,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 
 // ExecuteMigration will execute the migration for MySQL.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
-	args := util.MigrationExecutionArgs{
-		TablePrefix: "bytebase.",
-	}
-	return util.ExecuteMigration(ctx, driver.l, db.ClickHouse, driver, m, statement, args)
+	return util.ExecuteMigration(ctx, driver.l, db.ClickHouse, driver, m, statement)
 }
 
 func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -40,7 +40,7 @@ type Driver struct {
 	db *sql.DB
 }
 
-func (driver *Driver) TablePrefix() string {
+func (driver *Driver) BytebaseTablePrefix() string {
 	return "bytebase."
 }
 

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -338,8 +338,8 @@ type Driver interface {
 	MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error
 	// MarkMigrationAsFailed marks the last inserted migration record to be FAILED.
 	MarkMigrationAsFailed(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64) error
-	// TablePrefix returns the prefix to be added to the migration history table.
-	TablePrefix() string
+	// BytebaseTablePrefix returns the prefix to be added to the migration history table.
+	BytebaseTablePrefix() string
 
 	// Dump and restore
 	// Dump the database, if dbName is empty, then dump all databases.

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -338,6 +338,8 @@ type Driver interface {
 	MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error
 	// MarkMigrationAsFailed marks the last inserted migration record to be FAILED.
 	MarkMigrationAsFailed(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64) error
+	// TablePrefix returns the prefix to be added to the migration history table.
+	TablePrefix() string
 
 	// Dump and restore
 	// Dump the database, if dbName is empty, then dump all databases.

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -332,6 +332,12 @@ type Driver interface {
 	ExecuteMigration(ctx context.Context, m *MigrationInfo, statement string) (int64, string, error)
 	// Find the migration history list and return most recent item first.
 	FindMigrationHistoryList(ctx context.Context, find *MigrationHistoryFind) ([]*MigrationHistory, error)
+	// InsertPendingMigration inserts a PENDING migration record.
+	InsertPendingMigration(ctx context.Context, tx *sql.Tx, m *MigrationInfo, sequence int, statement string, prevSchema string) (int64, error)
+	// MarkMigrationAsDone marks the last inserted migration record to be DONE.
+	MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error
+	// MarkMigrationAsFailed marks the last inserted migration record to be FAILED.
+	MarkMigrationAsFailed(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64) error
 
 	// Dump and restore
 	// Dump the database, if dbName is empty, then dump all databases.

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -45,7 +45,7 @@ type Driver struct {
 	db *sql.DB
 }
 
-func (driver *Driver) TablePrefix() string {
+func (driver *Driver) BytebaseTablePrefix() string {
 	return "bytebase."
 }
 

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -45,6 +45,10 @@ type Driver struct {
 	db *sql.DB
 }
 
+func (driver *Driver) TablePrefix() string {
+	return "bytebase."
+}
+
 func (driver *Driver) MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error {
 	updateHistoryAsDoneQuery := `
 	UPDATE
@@ -658,10 +662,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 
 // ExecuteMigration will execute the migration for MySQL.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
-	args := util.MigrationExecutionArgs{
-		TablePrefix: "bytebase.",
-	}
-	return util.ExecuteMigration(ctx, driver.l, db.MySQL, driver, m, statement, args)
+	return util.ExecuteMigration(ctx, driver.l, db.MySQL, driver, m, statement)
 }
 
 func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -197,7 +197,7 @@ type Driver struct {
 	baseDSN string
 }
 
-func (driver *Driver) TablePrefix() string {
+func (driver *Driver) BytebaseTablePrefix() string {
 	return ""
 }
 

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -197,6 +197,10 @@ type Driver struct {
 	baseDSN string
 }
 
+func (driver *Driver) TablePrefix() string {
+	return ""
+}
+
 func (driver *Driver) MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error {
 	updateHistoryAsDoneQuery := `
 	UPDATE
@@ -689,10 +693,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 }
 
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
-	args := util.MigrationExecutionArgs{
-		TablePrefix: "",
-	}
-	return util.ExecuteMigration(ctx, driver.l, db.Postgres, driver, m, statement, args)
+	return util.ExecuteMigration(ctx, driver.l, db.Postgres, driver, m, statement)
 }
 
 func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -203,13 +203,13 @@ func (driver *Driver) BytebaseTablePrefix() string {
 
 func (driver *Driver) MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error {
 	updateHistoryAsDoneQuery := `
-	UPDATE
-		migration_history
-	SET
-    status = 'DONE',
-	  execution_duration = $1,
-		"schema" = $2
-	WHERE id = $3
+    UPDATE
+    	migration_history
+    SET
+        status = 'DONE',
+        execution_duration = $1,
+        "schema" = $2
+    WHERE id = $3
 `
 	_, err := tx.ExecContext(ctx, updateHistoryAsDoneQuery,
 		duration,
@@ -221,12 +221,12 @@ func (driver *Driver) MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, durat
 
 func (driver *Driver) MarkMigrationAsFailed(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64) error {
 	updateHistoryAsFailedQuery := `
-	UPDATE
-		migration_history
-	SET
-    status = 'FAILED',
-	  execution_duration = $1
-	WHERE id = $2
+    UPDATE
+    	migration_history
+    SET
+        status = 'FAILED',
+        execution_duration = $1
+    WHERE id = $2
 `
 	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery,
 		duration,

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -41,6 +41,10 @@ type Driver struct {
 	db *sql.DB
 }
 
+func (driver *Driver) TablePrefix() string {
+	return "bytebase.public."
+}
+
 func (driver *Driver) MarkMigrationAsDone(ctx context.Context, tx *sql.Tx, duration int64, insertedID int64, updatedSchema string) error {
 	updateHistoryAsDoneQuery := `
 		UPDATE
@@ -674,11 +678,7 @@ func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo,
 	if err := driver.UseRole(ctx, sysAdminRole); err != nil {
 		return int64(0), "", err
 	}
-
-	args := util.MigrationExecutionArgs{
-		TablePrefix: "bytebase.public.",
-	}
-	return util.ExecuteMigration(ctx, driver.l, db.Snowflake, driver, m, statement, args)
+	return util.ExecuteMigration(ctx, driver.l, db.Snowflake, driver, m, statement)
 }
 
 func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -41,7 +41,7 @@ type Driver struct {
 	db *sql.DB
 }
 
-func (driver *Driver) TablePrefix() string {
+func (driver *Driver) BytebaseTablePrefix() string {
 	return "bytebase.public."
 }
 

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -132,7 +132,7 @@ func ExecuteMigration(ctx context.Context, l *zap.Logger, dbType db.Type, driver
 
 	// Phase 1 - Precheck before executing migration
 	// Check if the same migration version has already been applied
-	duplicate, err := checkDuplicateVersion(ctx, dbType, tx, m.Namespace, m.Engine, m.Version, driver.TablePrefix())
+	duplicate, err := checkDuplicateVersion(ctx, dbType, tx, m.Namespace, m.Engine, m.Version, driver.BytebaseTablePrefix())
 	if err != nil {
 		return -1, "", err
 	}
@@ -141,7 +141,7 @@ func ExecuteMigration(ctx context.Context, l *zap.Logger, dbType db.Type, driver
 	}
 
 	// Check if there is any higher version already been applied
-	version, err := checkOutofOrderVersion(ctx, dbType, tx, m.Namespace, m.Engine, m.Version, driver.TablePrefix())
+	version, err := checkOutofOrderVersion(ctx, dbType, tx, m.Namespace, m.Engine, m.Version, driver.BytebaseTablePrefix())
 	if err != nil {
 		return -1, "", err
 	}
@@ -154,7 +154,7 @@ func ExecuteMigration(ctx context.Context, l *zap.Logger, dbType db.Type, driver
 	// This check is also wrapped in transaction to avoid edge case where two baselinings are running concurrently.
 	requireBaseline := m.Engine == db.VCS && m.Type == db.Migrate
 	if requireBaseline {
-		hasBaseline, err := findBaseline(ctx, dbType, tx, m.Namespace, driver.TablePrefix())
+		hasBaseline, err := findBaseline(ctx, dbType, tx, m.Namespace, driver.BytebaseTablePrefix())
 		if err != nil {
 			return -1, "", err
 		}
@@ -164,7 +164,7 @@ func ExecuteMigration(ctx context.Context, l *zap.Logger, dbType db.Type, driver
 		}
 	}
 
-	sequence, err := findNextSequence(ctx, dbType, tx, m.Namespace, requireBaseline, driver.TablePrefix())
+	sequence, err := findNextSequence(ctx, dbType, tx, m.Namespace, requireBaseline, driver.BytebaseTablePrefix())
 	if err != nil {
 		return -1, "", err
 	}


### PR DESCRIPTION
Add methods to the Driver interface and push down implementation details.

1. By shortening the `ExecuteMigration` function, we can make the 3 phases of migration stand out, and thus make it easier to get an overview of the process;
2. Make sure queries and parameters are near each other to make it easier to see which parameter should match which columns;
3. The whole point of the `Driver` interface is to encapsulate the differences of different drivers, so we'd better take advantage of it and push implementations back to the different driver implementations, instead of adding `if .. else` branches in the long function.

Follow up: By adding another method `GetMigrationTablePrefix` to the `Driver` interface, we can get rid of the `MigrationExecutionArgs` struct.