### PR TITLE
fix: typescript-eslint/eslint-plugin@5.4.0 requires ^14.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 # $ docker run --init --rm --name bytebase --publish 8080:8080 --volume ~/.bytebase/data:/var/opt/bytebase bytebase/bytebase
 
-FROM mhart/alpine-node:14.16.1 as frontend
+FROM mhart/alpine-node:14.17.3 as frontend
 
 WORKDIR /frontend-build
 


### PR DESCRIPTION
The "Build and push" step has been broken since the introduction of `typescript-eslint/eslint-plugin@5.4.0` in this [commit](https://github.com/bytebase/bytebase/commit/4449dcdce6e5a137bd4914a427863bf3b04a1701).

In this PR, the base Docker image is changed to use node 14.17.3.