### PR TITLE
fix: fixed the reactive api is not worked bug

### DIFF
--- a/frontend/src/bbkit/BBAttention.vue
+++ b/frontend/src/bbkit/BBAttention.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script lang="ts">
-import { computed, PropType } from "@vue/runtime-core";
+import { computed, PropType } from "vue";
 import { BBAttentionStyle } from "./types";
 export default {
   name: "BBAttention",

--- a/frontend/src/bbkit/BBStepTab.vue
+++ b/frontend/src/bbkit/BBStepTab.vue
@@ -126,7 +126,7 @@
 </template>
 
 <script lang="ts">
-import { PropType, reactive } from "@vue/runtime-core";
+import { PropType, reactive } from "vue";
 import { BBStepTabItem } from "./types";
 
 interface LocalState {

--- a/frontend/src/components/DatabaseMigrationHistoryPanel.vue
+++ b/frontend/src/components/DatabaseMigrationHistoryPanel.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script lang="ts">
-import { computed, PropType, reactive, watchEffect } from "@vue/runtime-core";
+import { computed, PropType, reactive, watchEffect } from "vue";
 import { useStore } from "vuex";
 import MigrationHistoryTable from "../components/MigrationHistoryTable.vue";
 import {

--- a/frontend/src/components/InboxList.vue
+++ b/frontend/src/components/InboxList.vue
@@ -82,7 +82,7 @@
 </template>
 
 <script lang="ts">
-import { computed, PropType } from "@vue/runtime-core";
+import { computed, PropType } from "vue";
 import PrincipalAvatar from "../components/PrincipalAvatar.vue";
 import {
   ActivityIssueCommentCreatePayload,

--- a/frontend/src/components/PrincipalAvatar.vue
+++ b/frontend/src/components/PrincipalAvatar.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { computed, PropType } from "@vue/runtime-core";
+import { computed, PropType } from "vue";
 import { BBAvatarSizeType } from "../bbkit/types";
 import { Principal, UNKNOWN_ID } from "../types";
 

--- a/frontend/src/components/ProjectMigrationHistoryPanel.vue
+++ b/frontend/src/components/ProjectMigrationHistoryPanel.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script lang="ts">
-import { PropType, reactive, ref, watchEffect } from "@vue/runtime-core";
+import { PropType, reactive, ref, watchEffect } from "vue";
 import { useStore } from "vuex";
 import MigrationHistoryTable from "../components/MigrationHistoryTable.vue";
 import {

--- a/frontend/src/components/ProjectVersionControlPanel.vue
+++ b/frontend/src/components/ProjectVersionControlPanel.vue
@@ -110,7 +110,7 @@
 
 <script lang="ts">
 import { reactive, watchEffect, watch } from "vue";
-import { computed, PropType } from "@vue/runtime-core";
+import { computed, PropType } from "vue";
 import RepositorySetupWizard from "./RepositorySetupWizard.vue";
 import RepositoryPanel from "./RepositoryPanel.vue";
 import { Project, ProjectWorkflowType, Repository, UNKNOWN_ID } from "../types";

--- a/frontend/src/components/ProjectWebhookForm.vue
+++ b/frontend/src/components/ProjectWebhookForm.vue
@@ -208,8 +208,7 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
-import { computed, PropType, watch } from "@vue/runtime-core";
+import { reactive, computed, PropType, watch } from "vue";
 import {
   ActivityType,
   Project,

--- a/frontend/src/components/ProjectWebhookPanel.vue
+++ b/frontend/src/components/ProjectWebhookPanel.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script lang="ts">
-import { computed, PropType, watchEffect } from "@vue/runtime-core";
+import { computed, PropType, watchEffect } from "vue";
 import { useRouter } from "vue-router";
 import ProjectWebhookCard from "./ProjectWebhookCard.vue";
 import { Project } from "../types";

--- a/frontend/src/components/RepositoryConfigPanel.vue
+++ b/frontend/src/components/RepositoryConfigPanel.vue
@@ -9,8 +9,7 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
-import { PropType } from "@vue/runtime-core";
+import { reactive, PropType } from "vue";
 import RepositoryForm from "./RepositoryForm.vue";
 import { ProjectRepositoryConfig } from "../types";
 

--- a/frontend/src/components/RepositoryForm.vue
+++ b/frontend/src/components/RepositoryForm.vue
@@ -169,8 +169,7 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
-import { PropType } from "@vue/runtime-core";
+import { reactive, PropType } from "vue";
 import { ExternalRepositoryInfo, RepositoryConfig, VCSType } from "../types";
 
 const FILE_REQUIRED_PLACEHOLDER = "{{DB_NAME}}, {{VERSION}}, {{TYPE}}";

--- a/frontend/src/components/RepositorySelectionPanel.vue
+++ b/frontend/src/components/RepositorySelectionPanel.vue
@@ -61,9 +61,8 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
 import { useStore } from "vuex";
-import { computed, PropType, watchEffect } from "@vue/runtime-core";
+import { reactive, computed, PropType, watchEffect } from "vue";
 import { ExternalRepositoryInfo, ProjectRepositoryConfig } from "../types";
 
 interface LocalState {

--- a/frontend/src/components/RepositorySetupWizard.vue
+++ b/frontend/src/components/RepositorySetupWizard.vue
@@ -31,8 +31,7 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
-import { computed, PropType } from "@vue/runtime-core";
+import { reactive, computed, PropType } from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import isEmpty from "lodash-es/isEmpty";

--- a/frontend/src/components/RepositoryVCSProviderPanel.vue
+++ b/frontend/src/components/RepositoryVCSProviderPanel.vue
@@ -35,14 +35,8 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
 import { useStore } from "vuex";
-import {
-  computed,
-  onUnmounted,
-  PropType,
-  watchEffect,
-} from "@vue/runtime-core";
+import { reactive, computed, onUnmounted, PropType, watchEffect } from "vue";
 import isEmpty from "lodash-es/isEmpty";
 import {
   OAuthConfig,

--- a/frontend/src/components/VCSProviderBasicInfoPanel.vue
+++ b/frontend/src/components/VCSProviderBasicInfoPanel.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script lang="ts">
-import { computed, onUnmounted, PropType, reactive } from "@vue/runtime-core";
+import { computed, onUnmounted, PropType, reactive } from "vue";
 import isEmpty from "lodash-es/isEmpty";
 import { TEXT_VALIDATION_DELAY, VCSConfig } from "../types";
 import { isUrl } from "../utils";

--- a/frontend/src/components/VCSProviderConfirmPanel.vue
+++ b/frontend/src/components/VCSProviderConfirmPanel.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script lang="ts">
-import { PropType, reactive } from "@vue/runtime-core";
+import { PropType, reactive } from "vue";
 import { VCSConfig, redirectUrl } from "../types";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/frontend/src/components/VCSProviderOAuthPanel.vue
+++ b/frontend/src/components/VCSProviderOAuthPanel.vue
@@ -131,7 +131,7 @@
 </template>
 
 <script lang="ts">
-import { computed, onUnmounted, PropType, reactive } from "@vue/runtime-core";
+import { computed, onUnmounted, PropType, reactive } from "vue";
 import isEmpty from "lodash-es/isEmpty";
 import { toClipboard } from "@soerenmartius/vue3-clipboard";
 import {

--- a/frontend/src/components/VCSSetupWizard.vue
+++ b/frontend/src/components/VCSSetupWizard.vue
@@ -26,8 +26,7 @@
 </template>
 
 <script lang="ts">
-import { computed } from "@vue/runtime-core";
-import { reactive } from "@vue/reactivity";
+import { reactive, computed } from "vue";
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";
 import isEmpty from "lodash-es/isEmpty";

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -54,7 +54,7 @@ import ProvideDashboardContext from "../components/ProvideDashboardContext.vue";
 import DashboardHeader from "../views/DashboardHeader.vue";
 import BannerDemo from "../views/BannerDemo.vue";
 import { ServerInfo } from "../types";
-import { computed } from "@vue/runtime-core";
+import { computed } from "vue";
 
 export default {
   name: "DashboardLayout",

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -47,14 +47,13 @@
 </template>
 
 <script lang="ts">
-import { reactive, ref } from "@vue/reactivity";
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";
 import EnvironmentTabFilter from "../components/EnvironmentTabFilter.vue";
 import IssueTable from "../components/IssueTable.vue";
 import MemberSelect from "../components/MemberSelect.vue";
 import { Environment, Issue, PrincipalId, ProjectId } from "../types";
-import { computed, onMounted, watchEffect } from "@vue/runtime-core";
+import { reactive, ref, computed, onMounted, watchEffect } from "vue";
 import { activeEnvironment, projectSlug } from "../utils";
 import { BBTableSectionDataSource } from "../bbkit/types";
 

--- a/frontend/src/views/MigrationHistoryDetail.vue
+++ b/frontend/src/views/MigrationHistoryDetail.vue
@@ -193,7 +193,7 @@
 </template>
 
 <script lang="ts">
-import { computed, reactive } from "@vue/runtime-core";
+import { computed, reactive } from "vue";
 import { useStore } from "vuex";
 import { toClipboard } from "@soerenmartius/vue3-clipboard";
 import { CodeDiff } from "v-code-diff";

--- a/frontend/src/views/OAuthCallback.vue
+++ b/frontend/src/views/OAuthCallback.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
+import { reactive } from "vue";
 import { useRouter } from "vue-router";
 import {
   OAuthStateSessionKey,

--- a/frontend/src/views/ProjectWebhookCreate.vue
+++ b/frontend/src/views/ProjectWebhookCreate.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script lang="ts">
-import { computed } from "@vue/runtime-core";
+import { computed } from "vue";
 import { useStore } from "vuex";
 import ProjectWebhookForm from "../components/ProjectWebhookForm.vue";
 import { idFromSlug } from "../utils";

--- a/frontend/src/views/ProjectWebhookDetail.vue
+++ b/frontend/src/views/ProjectWebhookDetail.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script lang="ts">
-import { computed } from "@vue/runtime-core";
+import { computed } from "vue";
 import ProjectWebhookForm from "../components/ProjectWebhookForm.vue";
 import { idFromSlug } from "../utils";
 import { useStore } from "vuex";

--- a/frontend/src/views/SettingWorkspaceGeneral.vue
+++ b/frontend/src/views/SettingWorkspaceGeneral.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script lang="ts">
-import { computed, reactive } from "@vue/runtime-core";
+import { computed, reactive } from "vue";
 import { useStore } from "vuex";
 import { isOwner } from "../utils";
 import { Setting } from "../types/setting";

--- a/frontend/src/views/SettingWorkspaceVCS.vue
+++ b/frontend/src/views/SettingWorkspaceVCS.vue
@@ -31,8 +31,7 @@
 </template>
 
 <script lang="ts">
-import { computed, watchEffect } from "@vue/runtime-core";
-import { reactive } from "@vue/reactivity";
+import { reactive, computed, watchEffect } from "vue";
 import { useRouter } from "vue-router";
 import VCSCard from "../components/VCSCard.vue";
 import VCSSetupWizard from "../components/VCSSetupWizard.vue";

--- a/frontend/src/views/SettingWorkspaceVCSCreate.vue
+++ b/frontend/src/views/SettingWorkspaceVCSCreate.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts">
-import { reactive } from "@vue/reactivity";
+import { reactive } from "vue";
 import VCSSetupWizard from "../components/VCSSetupWizard.vue";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/frontend/src/views/TableDetail.vue
+++ b/frontend/src/views/TableDetail.vue
@@ -218,7 +218,7 @@
 </template>
 
 <script lang="ts">
-import { computed } from "@vue/runtime-core";
+import { computed } from "vue";
 import { useStore } from "vuex";
 import ColumnTable from "../components/ColumnTable.vue";
 import IndexTable from "../components/IndexTable.vue";


### PR DESCRIPTION
Also fixed some potential bugs.

* `import xxx from "@vue/runtime-core"` -> `import xxx from "vue"`
* `import xxx from "@vue/reactivity"` -> `import xxx from "vue"`

Recommend alway import from `"vue"` when we use some Vue's API

