### PR TITLE
refactor: Fix method comment, simplify code and fix tests

### DIFF
--- a/plugin/advisor/mysql/mysql_migration_compatibility_advisor.go
+++ b/plugin/advisor/mysql/mysql_migration_compatibility_advisor.go
@@ -24,7 +24,7 @@ func init() {
 type CompatibilityAdvisor struct {
 }
 
-// A fake advisor to report 1 advice for each severity.
+// Check checks schema backward compatibility.
 func (adv *CompatibilityAdvisor) Check(ctx advisor.AdvisorContext, statement string) ([]advisor.Advice, error) {
 	p := parser.New()
 
@@ -60,59 +60,59 @@ type compatibilityChecker struct {
 
 func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
 	code := common.Ok
+	switch node := in.(type) {
 	// DROP DATABASE
-	if _, ok := in.(*ast.DropDatabaseStmt); ok {
+	case *ast.DropDatabaseStmt:
 		code = common.CompatibilityDropDatabase
-		goto END
-	}
 	// RENAME TABLE
-	if _, ok := in.(*ast.RenameTableStmt); ok {
+	case *ast.RenameTableStmt:
 		code = common.CompatibilityRenameTable
-		goto END
-	}
 	// DROP TABLE/VIEW
-	if _, ok := in.(*ast.DropTableStmt); ok {
+	case *ast.DropTableStmt:
 		code = common.CompatibilityDropTable
-		goto END
-	}
+	// CREATE UNIQUE INDEX
+	case *ast.CreateIndexStmt:
+		if node.KeyType == ast.IndexKeyTypeUnique {
+			code = common.CompatibilityAddUniqueKey
+		}
 	// ALTER TABLE
-	if node, ok := in.(*ast.AlterTableStmt); ok {
+	case *ast.AlterTableStmt:
 		for _, spec := range node.Specs {
 			fmt.Printf("spec %d: %+v\n\n", spec.Tp, spec)
 			// RENAME COLUMN
 			if spec.Tp == ast.AlterTableRenameColumn {
 				code = common.CompatibilityRenameColumn
-				goto END
+				break
 			}
 			// DROP COLUMN
 			if spec.Tp == ast.AlterTableDropColumn {
 				code = common.CompatibilityDropColumn
-				goto END
+				break
 			}
 
 			if spec.Tp == ast.AlterTableAddConstraint {
 				// ADD PRIMARY KEY
 				if spec.Constraint.Tp == ast.ConstraintPrimaryKey {
 					code = common.CompatibilityAddPrimaryKey
-					goto END
+					break
 				}
 				// ADD UNIQUE/UNIQUE KEY/UNIQUE INDEX
 				if spec.Constraint.Tp == ast.ConstraintPrimaryKey ||
 					spec.Constraint.Tp == ast.ConstraintUniq ||
 					spec.Constraint.Tp == ast.ConstraintUniqKey {
 					code = common.CompatibilityAddUniqueKey
-					goto END
+					break
 				}
 				// ADD FOREIGN KEY
 				if spec.Constraint.Tp == ast.ConstraintForeignKey {
 					code = common.CompatibilityAddForeignKey
-					goto END
+					break
 				}
 				// Check is only supported after 8.0.16 https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html
 				// ADD CHECK ENFORCED
 				if spec.Constraint.Tp == ast.ConstraintCheck && spec.Constraint.Enforced {
 					code = common.CompatibilityAddCheck
-					goto END
+					break
 				}
 			}
 
@@ -121,7 +121,7 @@ func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
 			if spec.Tp == ast.AlterTableAlterCheck {
 				if spec.Constraint.Enforced {
 					code = common.CompatibilityAlterCheck
-					goto END
+					break
 				}
 			}
 
@@ -132,23 +132,13 @@ func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
 			// 2. Change property like comment, change it to NULL
 			if spec.Tp == ast.AlterTableModifyColumn || spec.Tp == ast.AlterTableChangeColumn {
 				code = common.CompatibilityAlterColumn
-				goto END
+				break
 			}
 		}
-	}
-	// ALTER VIEW TBD: https://github.com/pingcap/parser/pull/1252
-	// if node, ok := in.(*ast.AlterViewStmt); ok {
-	// }
-
-	// CREATE UNIQUE INDEX
-	if node, ok := in.(*ast.CreateIndexStmt); ok {
-		if node.KeyType == ast.IndexKeyTypeUnique {
-			code = common.CompatibilityAddUniqueKey
-			goto END
-		}
+		// ALTER VIEW TBD: https://github.com/pingcap/parser/pull/1252
+		// case *ast.AlterViewStmt:
 	}
 
-END:
 	if code != common.Ok {
 		v.advisorList = append(v.advisorList, advisor.Advice{
 			Status:  advisor.Warn,

--- a/plugin/advisor/mysql/mysql_migration_compatibility_advisor.go
+++ b/plugin/advisor/mysql/mysql_migration_compatibility_advisor.go
@@ -70,11 +70,6 @@ func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
 	// DROP TABLE/VIEW
 	case *ast.DropTableStmt:
 		code = common.CompatibilityDropTable
-	// CREATE UNIQUE INDEX
-	case *ast.CreateIndexStmt:
-		if node.KeyType == ast.IndexKeyTypeUnique {
-			code = common.CompatibilityAddUniqueKey
-		}
 	// ALTER TABLE
 	case *ast.AlterTableStmt:
 		for _, spec := range node.Specs {
@@ -135,8 +130,15 @@ func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
 				break
 			}
 		}
-		// ALTER VIEW TBD: https://github.com/pingcap/parser/pull/1252
-		// case *ast.AlterViewStmt:
+
+	// ALTER VIEW TBD: https://github.com/pingcap/parser/pull/1252
+	// case *ast.AlterViewStmt:
+
+	// CREATE UNIQUE INDEX
+	case *ast.CreateIndexStmt:
+		if node.KeyType == ast.IndexKeyTypeUnique {
+			code = common.CompatibilityAddUniqueKey
+		}
 	}
 
 	if code != common.Ok {

--- a/plugin/advisor/mysql/mysql_migration_compatibility_advisor_test.go
+++ b/plugin/advisor/mysql/mysql_migration_compatibility_advisor_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bytebase/bytebase/common"
+
 	"github.com/bytebase/bytebase/plugin/advisor"
 	"go.uber.org/zap"
 )
@@ -40,6 +42,7 @@ func TestBasic(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityDropDatabase,
 					Title:   "Potential incompatible migration",
 					Content: "\"DROP DATABASE d1\" may cause incompatibility with the existing data and code",
 				},
@@ -50,6 +53,7 @@ func TestBasic(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityDropTable,
 					Title:   "Potential incompatible migration",
 					Content: "\"DROP TABLE t1\" may cause incompatibility with the existing data and code",
 				},
@@ -60,6 +64,7 @@ func TestBasic(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityRenameTable,
 					Title:   "Potential incompatible migration",
 					Content: "\"RENAME TABLE t1 to t2\" may cause incompatibility with the existing data and code",
 				},
@@ -70,6 +75,7 @@ func TestBasic(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityDropTable,
 					Title:   "Potential incompatible migration",
 					Content: "\"DROP VIEW v1\" may cause incompatibility with the existing data and code",
 				},
@@ -80,6 +86,7 @@ func TestBasic(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddUniqueKey,
 					Title:   "Potential incompatible migration",
 					Content: "\"CREATE UNIQUE INDEX idx1 ON t1 (f1)\" may cause incompatibility with the existing data and code",
 				},
@@ -90,11 +97,13 @@ func TestBasic(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityDropTable,
 					Title:   "Potential incompatible migration",
 					Content: "\"DROP TABLE t1;\" may cause incompatibility with the existing data and code",
 				},
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityDropTable,
 					Title:   "Potential incompatible migration",
 					Content: "\"DROP TABLE t2;\" may cause incompatibility with the existing data and code",
 				},
@@ -112,6 +121,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Success,
+					Code:    common.Ok,
 					Title:   "OK",
 					Content: "Migration is backward compatible",
 				},
@@ -122,6 +132,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityRenameColumn,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 RENAME COLUMN f1 to f2\" may cause incompatibility with the existing data and code",
 				},
@@ -132,6 +143,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityDropColumn,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 DROP COLUMN f1\" may cause incompatibility with the existing data and code",
 				},
@@ -142,6 +154,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddPrimaryKey,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ADD PRIMARY KEY (f1)\" may cause incompatibility with the existing data and code",
 				},
@@ -152,6 +165,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddUniqueKey,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ADD UNIQUE (f1)\" may cause incompatibility with the existing data and code",
 				},
@@ -162,6 +176,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddUniqueKey,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ADD UNIQUE KEY (f1)\" may cause incompatibility with the existing data and code",
 				},
@@ -172,6 +187,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddUniqueKey,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ADD UNIQUE INDEX (f1)\" may cause incompatibility with the existing data and code",
 				},
@@ -182,6 +198,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddForeignKey,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ADD FOREIGN KEY (f1) REFERENCES t2(f2)\" may cause incompatibility with the existing data and code",
 				},
@@ -192,6 +209,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddCheck,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ADD CHECK (f1 > 0)\" may cause incompatibility with the existing data and code",
 				},
@@ -212,6 +230,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAlterCheck,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ALTER CHECK chk1 ENFORCED\" may cause incompatibility with the existing data and code",
 				},
@@ -232,6 +251,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAddCheck,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 ADD CONSTRAINT CHECK (f1 > 0)\" may cause incompatibility with the existing data and code",
 				},
@@ -242,6 +262,7 @@ func TestAlterTable(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Success,
+					Code:    common.Ok,
 					Title:   "OK",
 					Content: "Migration is backward compatible",
 				},
@@ -259,6 +280,7 @@ func TestAlterTableChangeColumnType(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAlterColumn,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 CHANGE f1 f2 TEXT\" may cause incompatibility with the existing data and code",
 				},
@@ -269,6 +291,7 @@ func TestAlterTableChangeColumnType(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAlterColumn,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 MODIFY f1 TEXT\" may cause incompatibility with the existing data and code",
 				},
@@ -279,6 +302,7 @@ func TestAlterTableChangeColumnType(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAlterColumn,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 MODIFY f1 TEXT NULL\" may cause incompatibility with the existing data and code",
 				},
@@ -289,6 +313,7 @@ func TestAlterTableChangeColumnType(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAlterColumn,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 MODIFY f1 TEXT NOT NULL\" may cause incompatibility with the existing data and code",
 				},
@@ -299,6 +324,7 @@ func TestAlterTableChangeColumnType(t *testing.T) {
 			want: []advisor.Advice{
 				{
 					Status:  advisor.Warn,
+					Code:    common.CompatibilityAlterColumn,
 					Title:   "Potential incompatible migration",
 					Content: "\"ALTER TABLE t1 MODIFY f1 TEXT COMMENT 'bla'\" may cause incompatibility with the existing data and code",
 				},

--- a/plugin/advisor/mysql/mysql_syntax_advisor.go
+++ b/plugin/advisor/mysql/mysql_syntax_advisor.go
@@ -22,7 +22,7 @@ func init() {
 type SyntaxAdvisor struct {
 }
 
-// A fake advisor to report 1 advice for each severity.
+// Check parses the given statement and checks for warnings and errors.
 func (adv *SyntaxAdvisor) Check(ctx advisor.AdvisorContext, statement string) ([]advisor.Advice, error) {
 	p := parser.New()
 
@@ -38,7 +38,7 @@ func (adv *SyntaxAdvisor) Check(ctx advisor.AdvisorContext, statement string) ([
 		}, nil
 	}
 
-	advisorList := []advisor.Advice{}
+	advisorList := make([]advisor.Advice, 0, len(warns)+1)
 	for _, warn := range warns {
 		advisorList = append(advisorList, advisor.Advice{
 			Status:  advisor.Warn,


### PR DESCRIPTION
All failed Go tests are fixed, now we can run `go test ./...`.