### PR TITLE
fix: send SIGINT to clean up resources

### DIFF
--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -10,4 +10,6 @@ tmp_dir = ".air"
   exclude_regex = []
   exclude_unchanged = false
   follow_symlink = false
+  send_interrupt = true
+  kill_delay = 1000
   full_bin = ""


### PR DESCRIPTION
Send SIGINT to backend when restarting to make sure the sqlite database is closed properly.

This PR is blocked by [a PR for air](https://github.com/cosmtrek/air/pull/223).

After this change, I start to see the "BYE" banner when I make a change:
<img width="812" alt="Screen Shot 2021-12-02 at 8 46 46 PM" src="https://user-images.githubusercontent.com/116473/144424821-db9fb0ba-5f72-4123-bfc4-0eaa33384bad.png">

