### PR TITLE
feat: enable the commitlint

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,7 @@
+#!/bin/sh
+# https://github.com/typicode/husky/issues/390#issuecomment-792619315
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "$1"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    // need to use relative path case our node project isn't in the same folder level as git
+    // similar problem: https://github.com/conventional-changelog/commitlint/issues/613
+    extends: ['./frontend/node_modules/@commitlint/config-conventional']
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,8 @@
     "vuex": "^4.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^15.0.0",
+    "@commitlint/config-conventional": "^15.0.0",
     "@iconify/json": "^1.1.432",
     "@intlify/vite-plugin-vue-i18n": "^3.2.1",
     "@types/lodash-es": "^4.17.4",
@@ -49,6 +51,7 @@
     "eslint-formatter-summary": "^1.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.1.1",
+    "husky": "^7.0.4",
     "prettier": "^2.4.1",
     "typescript": "^4.5.2",
     "vite": "^2.6.14",


### PR DESCRIPTION
Add the commit lint check.

Currently, we're using the standard `@commitlint/config-conventional` rules, do you think we need to create our own?