### PR TITLE
style: wrap input in labels

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm.vue
@@ -20,24 +20,26 @@
     >
       <div class="radio-set-row">
         <div class="radio">
-          <input
-            v-model="state.alterType"
-            tabindex="-1"
-            type="radio"
-            class="btn"
-            value="SINGLE_DB"
-          />
-          <label class="label"> {{ $t('alter-schema.alter-single-db') }} </label>
+          <label class="label">
+            <input
+              v-model="state.alterType"
+              tabindex="-1"
+              type="radio"
+              class="btn"
+              value="SINGLE_DB"
+            />
+           {{ $t('alter-schema.alter-single-db') }}</label>
         </div>
         <div class="radio">
-          <input
-            v-model="state.alterType"
-            tabindex="-1"
-            type="radio"
-            class="btn"
-            value="MULTI_DB"
-          />
-          <label class="label"> {{ $t('alter-schema.alter-multiple-db') }} </label>
+          <label class="label">
+            <input
+              v-model="state.alterType"
+              tabindex="-1"
+              type="radio"
+              class="btn"
+              value="MULTI_DB"
+            />
+           {{ $t('alter-schema.alter-multiple-db') }} </label>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -29,26 +29,28 @@
             </div>
             <div v-if="hasAdminFeature" class="radio-set-row">
               <div class="radio">
-                <input
-                  v-model="state.role"
-                  :name="`member_role`"
-                  tabindex="-1"
-                  type="radio"
-                  class="btn"
-                  value="OWNER"
-                />
-                <label class="label"> {{ $t("common.role.owner") }} </label>
+                <label class="label">
+                  <input
+                    v-model="state.role"
+                    :name="`member_role`"
+                    tabindex="-1"
+                    type="radio"
+                    class="btn"
+                    value="OWNER"
+                  />
+                 {{ $t("common.role.owner") }} </label>
               </div>
               <div class="radio">
-                <input
-                  v-model="state.role"
-                  :name="`member_role`"
-                  tabindex="-1"
-                  type="radio"
-                  class="btn"
-                  value="DEVELOPER"
-                />
-                <label class="label"> {{ $t("common.role.developer") }} </label>
+                <label class="label">
+                  <input
+                    v-model="state.role"
+                    :name="`member_role`"
+                    tabindex="-1"
+                    type="radio"
+                    class="btn"
+                    value="DEVELOPER"
+                  />
+                 {{ $t("common.role.developer") }} </label>
               </div>
             </div>
             <button


### PR DESCRIPTION
Wrap inputs in labels to make them easier to click on.

I have encountered a problem though:
<img width="730" alt="Screen Shot 2021-12-06 at 8 21 24 PM" src="https://user-images.githubusercontent.com/116473/144845370-92aaab07-a435-40d3-a28a-c37b7c344a84.png">

When the `input` elements are moved inside the `label` element, they get moved down a little bit and are not aligned vertically with the labels. Any idea how to fix this?

