### PR TITLE
feat(frontend): better kbar experience

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint --cache --ext .js,.ts,.tsx,.vue --fix src"
   },
   "dependencies": {
-    "@bytebase/vue-kbar": "^0.1.2",
+    "@bytebase/vue-kbar": "^0.1.3",
     "@soerenmartius/vue3-clipboard": "^0.1.2",
     "@tailwindcss/forms": "^0.2.1",
     "@tailwindcss/typography": "^0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint --cache --ext .js,.ts,.tsx,.vue --fix src"
   },
   "dependencies": {
-    "@bytebase/vue-kbar": "^0.1.3",
+    "@bytebase/vue-kbar": "^0.1.4",
     "@soerenmartius/vue3-clipboard": "^0.1.2",
     "@tailwindcss/forms": "^0.2.1",
     "@tailwindcss/typography": "^0.4.0",

--- a/frontend/src/components/BookmarkListSidePanel.vue
+++ b/frontend/src/components/BookmarkListSidePanel.vue
@@ -19,10 +19,12 @@ import { useStore } from "vuex";
 import { UNKNOWN_ID } from "../types";
 import { Action, defineAction, useRegisterActions } from "@bytebase/vue-kbar";
 import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
 
 export default {
   name: "BookmarkListSidePanel",
   setup() {
+    const { t } = useI18n();
     const store = useStore();
     const router = useRouter();
 
@@ -53,7 +55,7 @@ export default {
         defineAction({
           // here `id` looks like "bb.bookmark.12345"
           id: `bb.bookmark.${item.id}`,
-          section: "Bookmarks",
+          section: t("common.bookmarks"),
           name: item.name,
           keywords: "bookmark",
           perform: () => {

--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -17,10 +17,12 @@ import { databaseSlug, environmentName } from "../utils";
 import { BBOutlineItem } from "../bbkit/types";
 import { Action, defineAction, useRegisterActions } from "@bytebase/vue-kbar";
 import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
 
 export default {
   name: "DatabaseListSidePanel",
   setup() {
+    const { t } = useI18n();
     const store = useStore();
     const router = useRouter();
 
@@ -90,9 +92,11 @@ export default {
             // `db.id` is global unique, so need not to specify `env.id`
             // so here `id` looks like "bb.database.1234"
             id: `bb.database.${db.id}`,
-            section: "Databases",
+            section: t("common.databases"),
             name: db.name,
-            keywords: "database db",
+            // env.name is also a keyword to provide better search
+            // e.g. "Blog" under "staged" now can be searched by "bl st"
+            keywords: `database db ${env.name}`,
             data: {
               tags: [env.name],
             },

--- a/frontend/src/components/KBar/KBarFooter.vue
+++ b/frontend/src/components/KBar/KBarFooter.vue
@@ -14,7 +14,7 @@
           </g>
         </svg>
       </kbd>
-      <span>to perform</span>
+      <span>{{ $t("kbar.help.perform") }}</span>
     </div>
     <div class="key">
       <kbd>
@@ -43,7 +43,7 @@
           </g>
         </svg>
       </kbd>
-      <span>to navigate</span>
+      <span>{{ $t("kbar.help.navigate") }}</span>
     </div>
     <div class="key">
       <kbd>
@@ -61,7 +61,7 @@
           </g>
         </svg>
       </kbd>
-      <span>to close</span>
+      <span>{{ $t("kbar.help.close") }}</span>
     </div>
   </footer>
 </template>

--- a/frontend/src/components/KBar/KBarFooter.vue
+++ b/frontend/src/components/KBar/KBarFooter.vue
@@ -45,6 +45,22 @@
       </kbd>
       <span>{{ $t("kbar.help.navigate") }}</span>
     </div>
+    <div v-if="isDeepAction" class="key">
+      <kbd>
+        <svg width="15" height="15" class="transform rotate-90">
+          <g
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.2"
+          >
+            <path d="M7.5 3.5v8M10.5 8.5l-3 3-3-3"></path>
+          </g>
+        </svg>
+      </kbd>
+      <span>{{ $t("kbar.help.back") }}</span>
+    </div>
     <div class="key">
       <kbd>
         <svg width="15" height="15">
@@ -67,10 +83,20 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { useKBarState } from "@bytebase/vue-kbar";
+import { computed, defineComponent } from "vue";
 
 export default defineComponent({
   name: "KBarFooter",
+  setup() {
+    const state = useKBarState();
+
+    const isDeepAction = computed(() => {
+      return !!state.value.currentRootActionId;
+    });
+
+    return { isDeepAction };
+  },
 });
 </script>
 

--- a/frontend/src/components/KBar/KBarHelper.vue
+++ b/frontend/src/components/KBar/KBarHelper.vue
@@ -6,7 +6,7 @@
 import { useKBarHandler } from "@bytebase/vue-kbar";
 import { defineComponent, watch } from "vue";
 import { useRoute } from "vue-router";
-import { useRecentVisitActions } from "./useRecentVisit";
+import { useRecentVisit } from "./useRecentVisit";
 
 export default defineComponent({
   name: "KBarFooter",
@@ -21,9 +21,7 @@ export default defineComponent({
       }
     );
 
-    // dynamically create Recent Visit kbar actions
-    // recorded by `useRecentVisitHistory`
-    useRecentVisitActions();
+    useRecentVisit();
   },
 });
 </script>

--- a/frontend/src/components/KBar/KBarHelper.vue
+++ b/frontend/src/components/KBar/KBarHelper.vue
@@ -6,6 +6,7 @@
 import { useKBarHandler } from "@bytebase/vue-kbar";
 import { defineComponent, watch } from "vue";
 import { useRoute } from "vue-router";
+import { useRecentVisitActions } from "./useRecentVisit";
 
 export default defineComponent({
   name: "KBarFooter",
@@ -19,6 +20,10 @@ export default defineComponent({
         handler.value.hide();
       }
     );
+
+    // dynamically create Recent Visit kbar actions
+    // recorded by `useRecentVisitHistory`
+    useRecentVisitActions();
   },
 });
 </script>

--- a/frontend/src/components/KBar/KBarWrapper.vue
+++ b/frontend/src/components/KBar/KBarWrapper.vue
@@ -1,16 +1,19 @@
 <template>
-  <KBarProvider :actions="globalActions" :options="{ disabled }">
+  <KBarProvider
+    :actions="globalActions"
+    :options="{ placeholder, disabled, compare }"
+  >
     <KBarPortal>
       <KBarPositioner class="mask">
         <KBarAnimator class="container">
           <KBarSearch class="searchbox" />
-          <KBarHelper />
           <RenderResults />
           <KBarFooter />
         </KBarAnimator>
       </KBarPositioner>
     </KBarPortal>
 
+    <KBarHelper />
     <slot />
   </KBarProvider>
 </template>
@@ -25,13 +28,13 @@ import {
   KBarSearch,
   defineAction,
 } from "@bytebase/vue-kbar";
+import { compareAction as compare } from "./utils";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import RenderResults from "./RenderResults.vue";
 import KBarHelper from "./KBarHelper.vue";
 import KBarFooter from "./KBarFooter.vue";
 import { useI18n } from "vue-i18n";
-import { useRecentVisitHistory } from "./useRecentVisit";
 
 export default defineComponent({
   name: "KBarWrapper",
@@ -50,6 +53,8 @@ export default defineComponent({
     const store = useStore();
     const router = useRouter();
 
+    const placeholder = computed(() => t("kbar.options.placeholder"));
+
     const disabled = computed(() => {
       const currentUser = store.getters["auth/currentUser"]();
       // totally disable kbar when not logged in
@@ -57,7 +62,7 @@ export default defineComponent({
       return !currentUser || currentUser.id < 0;
     });
 
-    const globalActions = [
+    const globalActions = computed(() => [
       defineAction({
         id: "bb.navigation.home",
         name: "Home",
@@ -74,15 +79,13 @@ export default defineComponent({
         keywords: "navigation",
         perform: () => router.push({ name: "workspace.anomaly-center" }),
       }),
-    ];
-
-    // recording page navigation history
-    // for `useRecentVisitActions`
-    useRecentVisitHistory();
+    ]);
 
     return {
       globalActions,
+      placeholder,
       disabled,
+      compare,
     };
   },
 });

--- a/frontend/src/components/KBar/KBarWrapper.vue
+++ b/frontend/src/components/KBar/KBarWrapper.vue
@@ -30,6 +30,8 @@ import { useRouter } from "vue-router";
 import RenderResults from "./RenderResults.vue";
 import KBarHelper from "./KBarHelper.vue";
 import KBarFooter from "./KBarFooter.vue";
+import { useI18n } from "vue-i18n";
+import { useRecentVisitHistory } from "./useRecentVisit";
 
 export default defineComponent({
   name: "KBarWrapper",
@@ -44,6 +46,7 @@ export default defineComponent({
     KBarFooter,
   },
   setup() {
+    const { t } = useI18n();
     const store = useStore();
     const router = useRouter();
 
@@ -59,17 +62,23 @@ export default defineComponent({
         id: "bb.navigation.home",
         name: "Home",
         shortcut: ["g", "h"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation",
         perform: () => router.push({ name: "workspace.home" }),
       }),
       defineAction({
         id: "bb.navigation.anomaly-center",
         name: "Anomaly Center",
         shortcut: ["g", "a", "c"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation",
         perform: () => router.push({ name: "workspace.anomaly-center" }),
       }),
     ];
+
+    // recording page navigation history
+    // for `useRecentVisitActions`
+    useRecentVisitHistory();
 
     return {
       globalActions,

--- a/frontend/src/components/KBar/RenderResults.vue
+++ b/frontend/src/components/KBar/RenderResults.vue
@@ -11,6 +11,10 @@
       <div v-else class="item" :class="{ active }" :data-index="index">
         <div class="content">
           <div class="main">
+            <span v-if="isDeepAction(item)" class="parent">
+              {{ findParent(item).name }}
+            </span>
+
             <span>{{ item.name }}</span>
 
             <span v-for="(tag, i) in item.data?.tags" :key="i" class="tag">
@@ -32,19 +36,35 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { useKBarMatches, KBarResults } from "@bytebase/vue-kbar";
+import {
+  useKBarMatches,
+  KBarResults,
+  ActionImpl,
+  useKBarState,
+} from "@bytebase/vue-kbar";
 
 export default defineComponent({
   name: "RenderResults",
   components: { KBarResults },
   setup() {
+    const state = useKBarState();
     const matches = useKBarMatches();
     const itemHeight = (params: { item: any; index: number }) => {
       if (typeof params.item === "string") return 32;
       return 48;
     };
 
-    return { matches, itemHeight };
+    const isDeepAction = (action: ActionImpl): boolean => {
+      return (
+        !!action.parent && action.parent !== state.value.currentRootActionId
+      );
+    };
+
+    const findParent = (child: ActionImpl): ActionImpl => {
+      return state.value.actions.find((action) => action.id === child.parent)!;
+    };
+
+    return { matches, itemHeight, isDeepAction, findParent };
   },
 });
 </script>
@@ -70,6 +90,13 @@ export default defineComponent({
 }
 .subtitle {
   @apply text-xs text-gray-500;
+}
+.parent {
+  @apply text-gray-500;
+}
+.parent::after {
+  content: "›";
+  @apply text-gray-500 mx-1;
 }
 .shortcut {
   @apply grid grid-flow-col gap-1 justify-self-end text-gray-500;

--- a/frontend/src/components/KBar/useRecentVisit.ts
+++ b/frontend/src/components/KBar/useRecentVisit.ts
@@ -9,7 +9,7 @@ type RecentVisit = {
   url: string;
 };
 
-const STORAGE_KEY = "ui.kbar.recent_visit";
+const STORAGE_KEY = "ui.kbar.recently_visited";
 const MAX_HISTORY = 3;
 
 export function useRecentVisit() {
@@ -99,12 +99,12 @@ export function useRecentVisit() {
       .map(({ title, url }, index) =>
         defineAction({
           // here `id` looks like "bb.recent_visited.1"
-          id: `bb.recent_visited.${index + 1}`,
-          section: t("kbar.recent-visited"),
+          id: `bb.recently_visited.${index + 1}`,
+          section: t("kbar.recently-visited"),
           name: title,
           subtitle: url,
           shortcut: ["g", `${index + 1}`],
-          keywords: "recent visited",
+          keywords: "recently visited",
           perform: () => router.push({ path: url }),
         })
       );

--- a/frontend/src/components/KBar/useRecentVisit.ts
+++ b/frontend/src/components/KBar/useRecentVisit.ts
@@ -1,0 +1,123 @@
+import { useRoute, useRouter } from "vue-router";
+import { defineAction, useRegisterActions } from "@bytebase/vue-kbar";
+import { useStorage, useDebounce } from "@vueuse/core";
+import { computed, ref, watch, nextTick } from "vue";
+import { useI18n } from "vue-i18n";
+
+type RecentVisit = {
+  title: string;
+  url: string;
+};
+
+const STORAGE_KEY = "ui.kbar.recent_visit";
+const MAX_HISTORY = 3;
+
+export function useRecentVisitHistory() {
+  const route = useRoute();
+  const recentVisit = useStorage(STORAGE_KEY, [] as RecentVisit[]);
+  const url = computed(() => {
+    if (route.matched.length === 0) {
+      // When the application is landing, vue router will
+      //   perform a redirection from "/" to current path
+      //   e.g. if landing URL is "/instance", this redirection
+      //   will be "/" -> "/instance".
+      // This even happens when "/" -> "/".
+      // `route.matched` is an empty array means this kind
+      //   of redirection is going to be performed right now.
+      // We don't want to record the first "/" as a visit
+      //   because Home page is not shown at this time.
+      return undefined;
+    }
+    return route.fullPath;
+  });
+  const currentPage = ref<RecentVisit>();
+
+  watch(
+    // Debounce the listener so we can skip internal immediate redirections
+    useDebounce(url, 50),
+    async (url) => {
+      if (!url) return;
+      if (url.startsWith("/auth")) {
+        // ignore auth related pages
+        // kbar is invisible on these pages
+        // and navigating to these pages does not make sense
+        return;
+      }
+      // wait for vue flushing
+      // otherwise `document.title` will not be dynamically updated
+      await nextTick();
+      const { title } = document;
+      currentPage.value = {
+        url,
+        title,
+      };
+    },
+    { immediate: true }
+  );
+
+  watch(
+    currentPage,
+    (curr) => {
+      if (!curr) return;
+      const list = recentVisit.value;
+      const index = list.findIndex((item) => {
+        // We treat the two URLs "the same" when their urls'
+        //   `path` are the same (means ignoring querystring and hash).
+        //   e.g. "/db?environment=5003" & "/db?environment=5005"
+        //   e.g. "/environment#5001" & "/environment#5005"
+        // Because usually they are just different tab-panes
+        //   or filters on the page.
+        return getPath(item.url) === getPath(curr.url);
+      });
+      if (index >= 0) {
+        // current page exists in the history already
+        // pull it out before next step
+        list.splice(index, 1);
+      }
+      // then prepend the latest item to the queue
+      list.unshift(curr);
+
+      // ensure the queue's length
+      // should be no more than (MAX_HISTORY + 1)
+      // because current page will always be the first one in the list
+      // but it will be not shown in kbar
+      while (list.length > MAX_HISTORY + 1) {
+        list.pop();
+      }
+    },
+    {
+      immediate: true,
+    }
+  );
+}
+
+export function useRecentVisitActions() {
+  const { t } = useI18n();
+  const router = useRouter();
+  const recentVisit = useStorage(STORAGE_KEY, [] as RecentVisit[]);
+
+  const actions = computed(() => {
+    return recentVisit.value
+      .slice(1) // The first item is current page, just skip it.
+      .filter(({ title, url }) => title && url)
+      .map(({ title, url }, index) =>
+        defineAction({
+          // here `id` looks like "bb.recent_visited.1"
+          id: `bb.recent_visited.${index + 1}`,
+          section: t("kbar.recent-visited"),
+          name: title,
+          subtitle: url,
+          shortcut: ["g", `${index + 1}`],
+          keywords: "recent visited",
+          perform: () => router.push({ path: url }),
+        })
+      );
+  });
+
+  // prepend recent visit actions to kbar
+  useRegisterActions(actions, true);
+}
+
+function getPath(url: string): string {
+  return url.replace(/[?#].*$/, "");
+}

--- a/frontend/src/components/KBar/useRecentVisit.ts
+++ b/frontend/src/components/KBar/useRecentVisit.ts
@@ -12,8 +12,10 @@ type RecentVisit = {
 const STORAGE_KEY = "ui.kbar.recent_visit";
 const MAX_HISTORY = 3;
 
-export function useRecentVisitHistory() {
+export function useRecentVisit() {
+  const { t } = useI18n();
   const route = useRoute();
+  const router = useRouter();
   const recentVisit = useStorage(STORAGE_KEY, [] as RecentVisit[]);
   const url = computed(() => {
     if (route.matched.length === 0) {
@@ -89,12 +91,6 @@ export function useRecentVisitHistory() {
       immediate: true,
     }
   );
-}
-
-export function useRecentVisitActions() {
-  const { t } = useI18n();
-  const router = useRouter();
-  const recentVisit = useStorage(STORAGE_KEY, [] as RecentVisit[]);
 
   const actions = computed(() => {
     return recentVisit.value

--- a/frontend/src/components/KBar/utils.ts
+++ b/frontend/src/components/KBar/utils.ts
@@ -1,0 +1,34 @@
+import { Action, CompareFn } from "@bytebase/vue-kbar";
+
+const MAX_RANKING = Infinity;
+
+export const ACTION_RANKINGS = [
+  "bb.recent_visited.",
+  "bb.quickaction.",
+  "bb.navigation.",
+  "bb.bookmark.",
+  "bb.project.",
+  "bb.database.",
+  "bb.preferences.",
+];
+
+export const compareAction: CompareFn = (a, b) => {
+  const ar = getActionRankingById(a.item);
+  const br = getActionRankingById(b.item);
+
+  // Sort by original index if they have same ranks.
+  if (ar === br) return a.index - b.index;
+
+  // Otherwise sort by ranking.
+  return ar - br;
+};
+
+function getActionRankingById(action: Action) {
+  const rank = ACTION_RANKINGS.findIndex((prefix) =>
+    action.id.startsWith(prefix)
+  );
+  // non-specified namespaces should always rank behind specified ones.
+  if (rank < 0) return MAX_RANKING;
+
+  return rank;
+}

--- a/frontend/src/components/KBar/utils.ts
+++ b/frontend/src/components/KBar/utils.ts
@@ -3,7 +3,7 @@ import { Action, CompareFn } from "@bytebase/vue-kbar";
 const MAX_RANKING = Infinity;
 
 export const ACTION_RANKINGS = [
-  "bb.recent_visited.",
+  "bb.recently_visited.",
   "bb.quickaction.",
   "bb.navigation.",
   "bb.bookmark.",

--- a/frontend/src/components/ProjectListSidePanel.vue
+++ b/frontend/src/components/ProjectListSidePanel.vue
@@ -16,11 +16,13 @@ import { projectName, projectSlug } from "../utils";
 import { BBOutlineItem } from "../bbkit/types";
 import { Action, defineAction, useRegisterActions } from "@bytebase/vue-kbar";
 import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
 
 export default {
   name: "ProjectListSidePanel",
   props: {},
   setup() {
+    const { t } = useI18n();
     const store = useStore();
     const router = useRouter();
 
@@ -60,7 +62,7 @@ export default {
         defineAction({
           // here `id` looks like "bb.project.1234"
           id: `bb.project.${proj.id}`,
-          section: "Projects",
+          section: t("common.projects"),
           name: proj.name,
           keywords: "project",
           perform: () => {

--- a/frontend/src/components/QuickActionPanel.vue
+++ b/frontend/src/components/QuickActionPanel.vue
@@ -1,12 +1,6 @@
 <template>
   <div
-    class="
-      pt-1
-      overflow-hidden
-      grid grid-cols-4
-      gap-x-2 gap-y-4
-      md:inline-flex md:gap-x-0
-    "
+    class="pt-1 overflow-hidden grid grid-cols-4 gap-x-2 gap-y-4 md:inline-flex md:gap-x-0"
   >
     <template v-for="(quickAction, index) in quickActionList" :key="index">
       <div
@@ -55,13 +49,7 @@
           </svg>
         </router-link>
         <h3
-          class="
-            mt-1
-            text-center text-base
-            font-normal
-            text-main
-            tracking-tight
-          "
+          class="mt-1 text-center text-base font-normal text-main tracking-tight"
         >
           Manage User
         </h3>
@@ -88,13 +76,7 @@
           </svg>
         </button>
         <h3
-          class="
-            mt-1
-            text-center text-base
-            font-normal
-            text-main
-            tracking-tight
-          "
+          class="mt-1 text-center text-base font-normal text-main tracking-tight"
         >
           Query
         </h3>
@@ -121,13 +103,7 @@
           </svg>
         </button>
         <h3
-          class="
-            mt-1
-            text-center text-base
-            font-normal
-            text-main
-            tracking-tight
-          "
+          class="mt-1 text-center text-base font-normal text-main tracking-tight"
         >
           Edit Data
         </h3>
@@ -154,13 +130,7 @@
           </svg>
         </button>
         <h3
-          class="
-            mt-1
-            text-base text-center
-            font-normal
-            text-main
-            tracking-tight
-          "
+          class="mt-1 text-base text-center font-normal text-main tracking-tight"
         >
           New DB
         </h3>
@@ -187,13 +157,7 @@
           </svg>
         </button>
         <h3
-          class="
-            mt-1
-            text-base text-center
-            font-normal
-            text-main
-            tracking-tight
-          "
+          class="mt-1 text-base text-center font-normal text-main tracking-tight"
         >
           Request DB
         </h3>
@@ -444,6 +408,7 @@ import TransferDatabaseForm from "../components/TransferDatabaseForm.vue";
 import { DEFAULT_PROJECT_ID, ProjectId, QuickActionType } from "../types";
 import { idFromSlug } from "../utils";
 import { Action, defineAction, useRegisterActions } from "@bytebase/vue-kbar";
+import { useI18n } from "vue-i18n";
 
 interface LocalState {
   showModal: boolean;
@@ -469,6 +434,7 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const { t } = useI18n();
     const router = useRouter();
     const store = useStore();
 
@@ -603,7 +569,8 @@ export default defineComponent({
           const id = qa.replace(/^quickaction\.bb\.(.+)$/, "bb.quickaction.$1");
           return defineAction({
             id,
-            section: "Quick Action",
+            section: t("common.quick-action"),
+            keywords: "quick action",
             ...QuickActionMap[qa],
           });
         });

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -15,7 +15,7 @@ common:
 not-found: Not Found
 anomaly-center: Anomaly Center
 kbar:
-  recent-visited: Recent Visited
+  recently-visited: Recently Visited
   navigation: Navigation
   help:
     navigate: to navigate
@@ -26,4 +26,4 @@ kbar:
     placeholder: Type a command or search…
   preferences:
     common: Preferences
-    change_language: Change Language…
+    change-language: Change Language…

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -13,3 +13,12 @@ not-found: Not Found
 kbar:
   recent-visited: Recent Visited
   navigation: Navigation
+  help:
+    navigate: to navigate
+    perform: to perform
+    close: to close
+  options:
+    placeholder: Type a command or search…
+  preferences:
+    common: Preferences
+    change_language: Change Language…

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -17,6 +17,7 @@ kbar:
     navigate: to navigate
     perform: to perform
     close: to close
+    back: to back
   options:
     placeholder: Type a command or search…
   preferences:

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -7,4 +7,9 @@ common:
   databases: Databases
   instances: Instances
   environments: Environments
+  bookmarks: Bookmarks
+  quick-action: Quick Action
 not-found: Not Found
+kbar:
+  recent-visited: Recent Visited
+  navigation: Navigation

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -9,7 +9,6 @@ common:
   environments: Environments
   bookmarks: Bookmarks
   quick-action: Quick Action
-not-found: Not Found
   archive: Archive
   quickstart: Quickstart
   logout: Logout

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -7,4 +7,9 @@ common:
   databases: 数据库
   instances: 实例
   environments: 环境
+  bookmarks: 书签
+  quick-action: 快捷操作
 not-found: 未找到
+kbar:
+  recent-visited: 最近访问
+  navigation: 导航

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -15,7 +15,7 @@ common:
 not-found: 未找到
 anomaly-center: 异常中心
 kbar:
-  recent-visited: 最近访问
+  recently-visited: 最近访问
   navigation: 导航
   help:
     navigate: 选择
@@ -26,4 +26,4 @@ kbar:
     placeholder: 输入命令或搜索…
   preferences:
     common: 偏好设置
-    change_language: 更改语言…
+    change-language: 更改语言…

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -17,6 +17,7 @@ kbar:
     navigate: 选择
     perform: 执行
     close: 关闭
+    back: 返回
   options:
     placeholder: 输入命令或搜索…
   preferences:

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -13,3 +13,12 @@ not-found: 未找到
 kbar:
   recent-visited: 最近访问
   navigation: 导航
+  help:
+    navigate: 选择
+    perform: 执行
+    close: 关闭
+  options:
+    placeholder: 输入命令或搜索…
+  preferences:
+    common: 偏好设置
+    change_language: 更改语言…

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -277,7 +277,7 @@ export default {
       store.dispatch("plan/changePlan", PlanType.ENTERPRISE);
     };
 
-    const kbarActions = [
+    const kbarActions = computed(() => [
       defineAction({
         id: "bb.navigation.projects",
         name: "Projects",
@@ -326,22 +326,49 @@ export default {
         keywords: "navigation",
         perform: () => router.push({ name: "setting.inbox" }),
       }),
-    ];
+    ]);
     useRegisterActions(kbarActions);
 
     const storage = useLocalStorage("bytebase_options", {}) as any;
 
-    const toggleLocales = () => {
-      // TODO change to some real logic
-      const locales = availableLocales;
-      locale.value =
-        locales[(locales.indexOf(locale.value) + 1) % locales.length];
+    const setLocale = (lang: string) => {
+      locale.value = lang;
       storage.value = {
         appearance: {
           language: locale.value,
         },
       };
     };
+
+    const toggleLocales = () => {
+      // TODO change to some real logic
+      const locales = availableLocales;
+      const nextLocale =
+        locales[(locales.indexOf(locale.value) + 1) % locales.length];
+      setLocale(nextLocale);
+    };
+
+    const i18nChangeAction = computed(() =>
+      defineAction({
+        id: "bb.preferences.locale",
+        section: t("kbar.preferences.common"),
+        name: t("kbar.preferences.change_language"),
+        keywords: `language lang locale`,
+      })
+    );
+    const i18nActions = computed(() => [
+      i18nChangeAction.value,
+      ...availableLocales.map((lang) => {
+        return defineAction({
+          id: `bb.preferences.locale.${lang}`,
+          name: lang,
+          parent: "bb.preferences.locale",
+          keywords: `language lang locale ${lang}`,
+          perform: () => setLocale(lang),
+        });
+      }),
+    ]);
+    useRegisterActions(i18nActions);
 
     return {
       state,
@@ -357,6 +384,7 @@ export default {
       switchToTeam,
       switchToEnterprise,
       toggleLocales,
+      i18nActions,
     };
   },
 };

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -348,9 +348,11 @@ export default {
       setLocale(nextLocale);
     };
 
+    const I18N_CHANGE_ACTION_ID_NAMESPACE = "bb.preferences.locale";
     const i18nChangeAction = computed(() =>
       defineAction({
-        id: "bb.preferences.locale",
+        // here `id` is "bb.preferences.locale"
+        id: I18N_CHANGE_ACTION_ID_NAMESPACE,
         section: t("kbar.preferences.common"),
         name: t("kbar.preferences.change-language"),
         keywords: "language lang locale",
@@ -360,9 +362,10 @@ export default {
       i18nChangeAction.value,
       ...availableLocales.map((lang) => {
         return defineAction({
-          id: `bb.preferences.locale.${lang}`,
+          // here `id` looks like "bb.preferences.locale.en"
+          id: `${I18N_CHANGE_ACTION_ID_NAMESPACE}.${lang}`,
           name: lang,
-          parent: "bb.preferences.locale",
+          parent: I18N_CHANGE_ACTION_ID_NAMESPACE,
           keywords: `language lang locale ${lang}`,
           perform: () => setLocale(lang),
         });

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -335,7 +335,7 @@ export default {
       locale.value = lang;
       storage.value = {
         appearance: {
-          language: locale.value,
+          language: lang,
         },
       };
     };
@@ -353,7 +353,7 @@ export default {
         id: "bb.preferences.locale",
         section: t("kbar.preferences.common"),
         name: t("kbar.preferences.change_language"),
-        keywords: `language lang locale`,
+        keywords: "language lang locale",
       })
     );
     const i18nActions = computed(() => [
@@ -384,7 +384,6 @@ export default {
       switchToTeam,
       switchToEnterprise,
       toggleLocales,
-      i18nActions,
     };
   },
 };

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -352,7 +352,7 @@ export default {
       defineAction({
         id: "bb.preferences.locale",
         section: t("kbar.preferences.common"),
-        name: t("kbar.preferences.change_language"),
+        name: t("kbar.preferences.change-language"),
         keywords: "language lang locale",
       })
     );

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -47,15 +47,7 @@
       <div class="flex items-center space-x-3">
         <div
           v-if="showSwitchPlan"
-          class="
-            hidden
-            md:flex
-            sm:flex-row
-            items-center
-            space-x-2
-            text-sm
-            font-medium
-          "
+          class="hidden md:flex sm:flex-row items-center space-x-2 text-sm font-medium"
         >
           <span class="hidden lg:block font-normal text-accent">Plan</span>
           <div
@@ -85,15 +77,7 @@
         </div>
         <div
           v-if="!isRelease"
-          class="
-            hidden
-            md:flex
-            sm:flex-row
-            items-center
-            space-x-2
-            text-sm
-            font-medium
-          "
+          class="hidden md:flex sm:flex-row items-center space-x-2 text-sm font-medium"
         >
           <span class="hidden lg:block font-normal text-accent">Role</span>
           <div
@@ -124,16 +108,7 @@
         <router-link to="/inbox" exact-active-class="">
           <span
             v-if="inboxSummary.hasUnread"
-            class="
-              absolute
-              rounded-full
-              ml-4
-              -mt-1
-              h-2.5
-              w-2.5
-              bg-accent
-              opacity-75
-            "
+            class="absolute rounded-full ml-4 -mt-1 h-2.5 w-2.5 bg-accent opacity-75"
           ></span>
           <heroicons-outline:bell class="w-6 h-6" />
         </router-link>
@@ -233,6 +208,7 @@ export default {
   name: "DashboardHeader",
   components: { ProfileDropdown },
   setup() {
+    const { t, availableLocales, locale } = useI18n();
     const store = useStore();
     const router = useRouter();
 
@@ -306,49 +282,53 @@ export default {
         id: "bb.navigation.projects",
         name: "Projects",
         shortcut: ["g", "p"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation",
         perform: () => router.push({ name: "workspace.project" }),
       }),
       defineAction({
         id: "bb.navigation.databases",
         name: "Databases",
-        keywords: "db",
         shortcut: ["g", "d"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation db",
         perform: () => router.push({ name: "workspace.database" }),
       }),
       defineAction({
         id: "bb.navigation.instances",
         name: "Instances",
         shortcut: ["g", "i"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation",
         perform: () => router.push({ name: "workspace.instance" }),
       }),
       defineAction({
         id: "bb.navigation.environments",
         name: "Environments",
         shortcut: ["g", "e"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation",
         perform: () => router.push({ name: "workspace.environment" }),
       }),
       defineAction({
         id: "bb.navigation.settings",
         name: "Settings",
         shortcut: ["g", "s"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation",
         perform: () => router.push({ name: "setting.workspace.general" }),
       }),
       defineAction({
         id: "bb.navigation.inbox",
         name: "Inbox",
         shortcut: ["g", "m"],
-        section: "Navigation",
+        section: t("kbar.navigation"),
+        keywords: "navigation",
         perform: () => router.push({ name: "setting.inbox" }),
       }),
     ];
     useRegisterActions(kbarActions);
 
-    const { availableLocales, locale } = useI18n();
     const storage = useLocalStorage("bytebase_options", {}) as any;
 
     const toggleLocales = () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -43,10 +43,10 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@bytebase/vue-kbar@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@bytebase/vue-kbar/-/vue-kbar-0.1.3.tgz#5bd2108b2ffc803ca9b58ae0eb3571c101339445"
-  integrity sha512-gTtXyZfT7lZ8eEYzxvs2bpvIsN18m1vxlmW9tecSb47AmyZT/52L42fd1pbI3XymGLU7yq75eL1VpHjWS1+KTg==
+"@bytebase/vue-kbar@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@bytebase/vue-kbar/-/vue-kbar-0.1.4.tgz#5ce6e36142b7d35a59e4db9dac9f49bf73ce8777"
+  integrity sha512-teYoVjbE3aSHptHl0evqCugOOhqJg6CLgQCmvC8j11Qau6Pq9kMeoMb7nrVIgo0sZbknf52VZsHdy/sTUQF2Rw==
   dependencies:
     "@vueuse/core" "^7.1.2"
     match-sorter "^6.3.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -43,10 +43,10 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@bytebase/vue-kbar@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@bytebase/vue-kbar/-/vue-kbar-0.1.2.tgz#9b325d1a5a366d1fe68c983a85400651b1436ce7"
-  integrity sha512-cKBv61M1LkCibpxy5WFOzd15uqka1XYYM91Pm1Wo57ojgljZJPJhmu2+oE9pGYr+NSAIryIw2Hglgv0b6E/8Vg==
+"@bytebase/vue-kbar@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@bytebase/vue-kbar/-/vue-kbar-0.1.3.tgz#5bd2108b2ffc803ca9b58ae0eb3571c101339445"
+  integrity sha512-gTtXyZfT7lZ8eEYzxvs2bpvIsN18m1vxlmW9tecSb47AmyZT/52L42fd1pbI3XymGLU7yq75eL1VpHjWS1+KTg==
   dependencies:
     "@vueuse/core" "^7.1.2"
     match-sorter "^6.3.1"


### PR DESCRIPTION
- Introduce Recent Visit actions to kbar, with `g, 1|2|3` shortcuts.
- Introduce i18n selection actions in kbar, with nested actions UI experience.
- Majority of kbar actions now supports i18n.

screenshots

![image](https://user-images.githubusercontent.com/2749742/145132828-45dc6adb-d77f-42f2-8017-6d2cb1c0dbfe.png)

![image](https://user-images.githubusercontent.com/2749742/145132886-f9d4fb51-cb12-4699-bc5a-5be5bf1adbda.png)

