### PR TITLE
feat(frontend): add type shims to vue custom globals

### DIFF
--- a/frontend/src/shims-vue-globals.d.ts
+++ b/frontend/src/shims-vue-globals.d.ts
@@ -1,0 +1,37 @@
+import type {
+  databaseSlug,
+  dataSourceSlug,
+  environmentName,
+  environmentSlug,
+  humanizeTs,
+  instanceName,
+  instanceSlug,
+  projectName,
+  projectSlug,
+  sizeToFit,
+  urlfy,
+} from "./utils";
+import type { Moment } from "moment";
+import type { isEmpty } from "lodash";
+
+declare module "@vue/runtime-core" {
+  export interface ComponentCustomProperties {
+    window: Window & typeof globalThis;
+    console: Console;
+    moment: Moment;
+    humanizeTs: typeof humanizeTs;
+    isDev: boolean;
+    isRelease: boolean;
+    sizeToFit: typeof sizeToFit;
+    urlfy: typeof urlfy;
+    isEmpty: typeof isEmpty;
+    environmentName: typeof environmentName;
+    environmentSlug: typeof environmentSlug;
+    projectName: typeof projectName;
+    projectSlug: typeof projectSlug;
+    instanceName: typeof instanceName;
+    instanceSlug: typeof instanceSlug;
+    databaseSlug: typeof databaseSlug;
+    dataSourceSlug: typeof dataSourceSlug;
+  }
+}


### PR DESCRIPTION
Now volar will complain no more about custom variables and function in templates.
e.g. humanizeTs(), isRelease
Before:
![image](https://user-images.githubusercontent.com/2749742/145322175-eeef396f-99d4-4ef8-95a9-6572078c7a0b.png)
After:
![image](https://user-images.githubusercontent.com/2749742/145322084-d4cf04fa-0d1d-48f2-891a-8e2ee4f28eca.png)
