### PR TITLE
fix: ui fix for member selector

### DIFF
--- a/frontend/src/components/MemberTable.vue
+++ b/frontend/src/components/MemberTable.vue
@@ -79,8 +79,10 @@
           </template>
         </div>
       </BBTableCell>
-      <BBTableCell class="tooltip-wrapper">
-        <span class="tooltip">{{ changeRoleTooltip(member) }}</span>
+      <BBTableCell class="whitespace-nowrap tooltip-wrapper">
+        <span v-if="changeRoleTooltip(member)" class="tooltip">
+          {{ changeRoleTooltip(member) }}
+        </span>
         <RoleSelect
           :selected-role="member.role"
           :disabled="!allowChangeRole(member)"


### PR DESCRIPTION
Find two small bugs need to fix:

- The role column in the member table need to add `whitespace-nowrap` class, otherwise Chinese string will force to wrap

English looks good:
<img width="234" alt="图片" src="https://user-images.githubusercontent.com/10706318/145334444-8ba3664a-2607-4d9d-b92f-04a32d34f2cc.png">

But Chinese will force to wrap:
<img width="192" alt="图片" src="https://user-images.githubusercontent.com/10706318/145334620-487ca7b6-ac12-4e33-973f-52fb08e3c49b.png">

After add the class:
<img width="187" alt="图片" src="https://user-images.githubusercontent.com/10706318/145334659-d0b5feb3-82dd-467b-b6c3-d440c7c08a4f.png">

- The tooltip in the role column should hidden if no content to show

Before: you can get a empty tooltip, pretty like a strange bug
<img width="186" alt="图片" src="https://user-images.githubusercontent.com/10706318/145334753-8ce5c384-c23b-43da-ba42-461aec3df775.png">

After:
<img width="193" alt="图片" src="https://user-images.githubusercontent.com/10706318/145334858-d44b0736-7ae8-401f-8e31-eb320176f824.png">
