### PR TITLE
feat: added not_before_ts to TABLE task

### DIFF
--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -848,6 +848,8 @@ CREATE INDEX idx_task_pipeline_id_stage_id ON task(pipeline_id, stage_id);
 
 CREATE INDEX idx_task_status ON task(`status`);
 
+CREATE INDEX idx_task_not_before_ts ON task(not_before_ts);
+
 INSERT INTO
     sqlite_sequence (name, seq)
 VALUES

--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -840,7 +840,8 @@ CREATE TABLE task (
         )
     ),
     `type` TEXT NOT NULL CHECK (`type` LIKE 'bb.task.%'),
-    payload TEXT NOT NULL DEFAULT ''
+    payload TEXT NOT NULL DEFAULT '',
+    `not_before_ts` BIGINT NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_task_pipeline_id_stage_id ON task(pipeline_id, stage_id);


### PR DESCRIPTION
This is the `shema` change for allowing users to specify the earliest allowed execution time for a task