### PR TITLE
feat: trigger graceful shutdown on both SIGINT and SIGTERM

### DIFF
--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/bytebase/bytebase/api"
@@ -190,7 +191,10 @@ func start() {
 	// Setup signal handlers.
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	// Trigger graceful shutdown on SIGINT or SIGTERM.
+	// The default signal sent by the `kill` command is SIGTERM,
+	// which is taken as the graceful shutdown signal for many systems, eg., Kubernetes, Gunicorn.
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
 		m.l.Info("SIGINT received.")


### PR DESCRIPTION
Systems like Kubernetes expect containers to trigger graceful shutdown within some period after receiving a SIGTERM.

As discussed in https://github.com/bytebase/bytebase/discussions/165, Windows is not a target system of Bytebase, so it's OK to just use `syscall.SIGTERM`. Otherwise, we'll have to use conditional build based on operating systems.