### PR TITLE
feat(frontend): specify prettier printWidth to 80

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -2,5 +2,6 @@
   "useTabs": false,
   "tabWidth": 2,
   "singleQuote": false,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "printWidth": 80
 }


### PR DESCRIPTION
To ensure the same formatting result in every developer's editor