### PR TITLE
chore: create Helm chart for Bytebase

### DIFF
--- a/helm-charts/bytebase/.helmignore
+++ b/helm-charts/bytebase/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/bytebase/Chart.yaml
+++ b/helm-charts/bytebase/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: bytebase
+description: Web-based, zero-config, dependency-free database schema change and version control tool for teams.
+type: application
+version: 0.0.1
+appVersion: "0.9.0"
+home: https://bytebase.com/
+icon: https://bytebase.com/_nuxt/img/logo-icon.ca8220c.svg
+sources:
+  - https://github.com/bytebase/bytebase

--- a/helm-charts/bytebase/README.md
+++ b/helm-charts/bytebase/README.md
@@ -1,0 +1,15 @@
+# Bytebase Helm Chart
+
+Install the web-based schema change and version control tool [Bytebase](https://bytebase.com/).
+
+## Installing
+
+`helm -n <YOUR_NAMESPACE> install <RELEASE_NAME> helm-charts/bytebase`
+
+## Uninstalling
+
+`helm delete <RELEASE_NAME>`
+
+## TODO
+- [ ] Add support for [Litestream](https://litestream.io/guides/kubernetes/).
+- [ ] Create GitHub Pages for [Helm chart repo](https://medium.com/@mattiaperi/create-a-public-helm-chart-repository-with-github-pages-49b180dbb417).

--- a/helm-charts/bytebase/templates/_helpers.tpl
+++ b/helm-charts/bytebase/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "bytebase.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/helm-charts/bytebase/templates/service.yaml
+++ b/helm-charts/bytebase/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bytebase
+  namespace: {{ template "bytebase.namespace" . }}
+  labels:
+    app: bytebase
+spec:
+  ports:
+    - port: 80
+      name: web
+  clusterIP: None
+  selector:
+    app: bytebase

--- a/helm-charts/bytebase/templates/statefulset.yaml
+++ b/helm-charts/bytebase/templates/statefulset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: bytebase
+  namespace: {{ template "bytebase.namespace" . }}
+spec:
+  selector:
+    matchLabels:
+      app: bytebase
+  serviceName: "bytebase"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: bytebase
+    spec:
+      containers:
+        - name: bytebase
+          image: "bytebase/bytebase:{{ .Chart.AppVersion }}"
+          ports:
+            - containerPort: 80
+              name: web
+          volumeMounts:
+            - mountPath: /var/opt/bytebase
+              name: sqlite
+          readinessProbe:
+            httpGet:
+              path: /api/actuator/info
+              port: web
+            initialDelaySeconds: 2
+            periodSeconds: 2
+  volumeClaimTemplates:
+    - metadata:
+        name: sqlite
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "{{ .Values.bytebase.storage }}"

--- a/helm-charts/bytebase/values.yaml
+++ b/helm-charts/bytebase/values.yaml
@@ -1,0 +1,6 @@
+# Default values for bytebase.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+bytebase:
+  storage: 256Mi


### PR DESCRIPTION
Create a Helm chart for Bytebase so that it can be installed into a Kubernetes cluster in one command.

The attached screenshot shows Bytebase running inside my Kubernetes cluster, accessed through a forwarded port to my host.

<img width="1534" alt="Screen Shot 2021-12-13 at 5 29 15 PM" src="https://user-images.githubusercontent.com/116473/145964033-8df9242b-b367-4d80-9893-91325694833c.png">
