### PR TITLE
fix(frontend): fix moment type importing

### DIFF
--- a/frontend/src/shims-vue-globals.d.ts
+++ b/frontend/src/shims-vue-globals.d.ts
@@ -11,14 +11,14 @@ import type {
   sizeToFit,
   urlfy,
 } from "./utils";
-import type { Moment } from "moment";
+import type moment from "moment";
 import type { isEmpty } from "lodash";
 
 declare module "@vue/runtime-core" {
   export interface ComponentCustomProperties {
     window: Window & typeof globalThis;
     console: Console;
-    moment: Moment;
+    moment: typeof moment;
     humanizeTs: typeof humanizeTs;
     isDev: boolean;
     isRelease: boolean;


### PR DESCRIPTION
This will fix a TypeScript complaint when using `moment` in vue templates.
Before:
![image](https://user-images.githubusercontent.com/2749742/145972744-65c35a56-413a-4c10-9f2a-5d235b9acd14.png)
After:
![image](https://user-images.githubusercontent.com/2749742/145972709-cdf37def-e623-4c97-89da-4c2aedf20aa7.png)
