### PR TITLE
fix(issue-108): refresh access token and update repository when it's expired

### DIFF
--- a/api/repository.go
+++ b/api/repository.go
@@ -109,6 +109,9 @@ type RepositoryPatch struct {
 	BaseDirectory      *string `jsonapi:"attr,baseDirectory"`
 	FilePathTemplate   *string `jsonapi:"attr,filePathTemplate"`
 	SchemaPathTemplate *string `jsonapi:"attr,schemaPathTemplate"`
+	AccessToken        *string
+	ExpiresTs          *int64
+	RefreshToken       *string
 }
 
 // RepositoryDelete is the API message for deleting a repository.

--- a/external/gitlab/gitlab.go
+++ b/external/gitlab/gitlab.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 )
@@ -110,136 +109,100 @@ type File struct {
 
 // POST sends a POST request.
 func POST(instanceURL string, resourcePath string, token *string, body io.Reader, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
-	retries := 0
-RETRY:
-	retries++
-
-	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
-	req, err := http.NewRequest("POST",
-		url, body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct POST %v (%w)", url, err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+*token)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed POST %v (%w)", url, err)
-	}
-	err = getErrorDetails(resp)
-	if retriableError(err) && retries < maxRetries {
-		// Refresh and store the token.
-		log.Printf("refreshing oauth token")
-		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
-			return nil, err
+	return retry(instanceURL, token, oauthContext, refresher, func() (*http.Response, error) {
+		url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
+		req, err := http.NewRequest("POST",
+			url, body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct POST %v (%w)", url, err)
 		}
-		goto RETRY
-	}
-	if err != nil {
-		return nil, err
-	}
 
-	return resp, nil
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *token))
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed POST %v (%w)", url, err)
+		}
+		return resp, nil
+	})
 }
 
 // GET sends a GET request.
 func GET(instanceURL string, resourcePath string, token *string, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
-	retries := 0
-RETRY:
-	retries++
-
-	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
-	req, err := http.NewRequest("GET",
-		url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct GET %v (%w)", url, err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+*token)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed GET %v (%w)", url, err)
-	}
-	err = getErrorDetails(resp)
-	if retriableError(err) && retries < maxRetries {
-		// Refresh and store the token.
-		log.Printf("refreshing oauth token")
-		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
-			return nil, err
+	return retry(instanceURL, token, oauthContext, refresher, func() (*http.Response, error) {
+		url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
+		req, err := http.NewRequest("GET",
+			url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct GET %v (%w)", url, err)
 		}
-		goto RETRY
-	}
-	if err != nil {
-		return nil, err
-	}
 
-	return resp, nil
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *token))
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed GET %v (%w)", url, err)
+		}
+		return resp, nil
+	})
 }
 
 // PUT sends a PUT request.
 func PUT(instanceURL string, resourcePath string, token *string, body io.Reader, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
-	retries := 0
-RETRY:
-	retries++
-
-	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
-	req, err := http.NewRequest("PUT",
-		url, body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct PUT %v (%w)", url, err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+*token)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed PUT %v (%w)", url, err)
-	}
-	err = getErrorDetails(resp)
-	if retriableError(err) && retries < maxRetries {
-		// Refresh and store the token.
-		log.Printf("refreshing oauth token")
-		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
-			return nil, err
+	return retry(instanceURL, token, oauthContext, refresher, func() (*http.Response, error) {
+		url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
+		req, err := http.NewRequest("PUT",
+			url, body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct PUT %v (%w)", url, err)
 		}
-		goto RETRY
-	}
-	if err != nil {
-		return nil, err
-	}
 
-	return resp, nil
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *token))
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed PUT %v (%w)", url, err)
+		}
+		return resp, nil
+	})
 }
 
 // DELETE sends a DELETE request.
 func DELETE(instanceURL string, resourcePath string, token *string, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
+	return retry(instanceURL, token, oauthContext, refresher, func() (*http.Response, error) {
+		url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
+		req, err := http.NewRequest("DELETE",
+			url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct DELETE %v (%w)", url, err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *token))
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed DELETE %v (%w)", url, err)
+		}
+		return resp, nil
+	})
+}
+
+func retry(instanceURL string, token *string, oauthContext OauthContext, refresher TokenRefresher, f func() (*http.Response, error)) (*http.Response, error) {
 	retries := 0
 RETRY:
 	retries++
 
-	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
-	req, err := http.NewRequest("DELETE",
-		url, nil)
+	resp, err := f()
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct DELETE %v (%w)", url, err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+*token)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed DELETE %v (%w)", url, err)
+		return nil, err
 	}
 	err = getErrorDetails(resp)
-	if retriableError(err) && retries < maxRetries {
+	if expiredTokenError(err) && retries < maxRetries {
 		// Refresh and store the token.
-		log.Printf("refreshing oauth token")
 		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
 			return nil, err
 		}
@@ -258,11 +221,11 @@ type oauthError struct {
 }
 
 func (e *oauthError) Error() string {
-	return fmt.Sprintf("git oauth response error %q description %q", e.Err, e.ErrorDescription)
+	return fmt.Sprintf("gitlab oauth response error %q description %q", e.Err, e.ErrorDescription)
 }
 
 func getErrorDetails(resp *http.Response) error {
-	if resp.StatusCode == http.StatusOK {
+	if 200 <= resp.StatusCode && resp.StatusCode < 300 {
 		return nil
 	}
 	body, err := io.ReadAll(resp.Body)
@@ -276,10 +239,10 @@ func getErrorDetails(resp *http.Response) error {
 	if oe.Err != "" || oe.ErrorDescription != "" {
 		return &oe
 	}
-	return fmt.Errorf("git response code %v error %q", resp.StatusCode, body)
+	return fmt.Errorf("gitlab response code %v error %q", resp.StatusCode, body)
 }
 
-func retriableError(e error) bool {
+func expiredTokenError(e error) bool {
 	if e == nil {
 		return false
 	}

--- a/external/gitlab/gitlab.go
+++ b/external/gitlab/gitlab.go
@@ -15,6 +15,8 @@ const (
 	APIPath = "api/v4"
 	// SecretTokenLength is the length of secret token.
 	SecretTokenLength = 16
+
+	maxRetries = 3
 )
 
 // WebhookType is the gitlab webhook type.
@@ -127,7 +129,7 @@ RETRY:
 		return nil, fmt.Errorf("failed POST %v (%w)", url, err)
 	}
 	err = getErrorDetails(resp)
-	if retriableError(err) && retries < 3 {
+	if retriableError(err) && retries < maxRetries {
 		// Refresh and store the token.
 		log.Printf("refreshing oauth token")
 		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
@@ -163,7 +165,7 @@ RETRY:
 		return nil, fmt.Errorf("failed GET %v (%w)", url, err)
 	}
 	err = getErrorDetails(resp)
-	if retriableError(err) && retries < 3 {
+	if retriableError(err) && retries < maxRetries {
 		// Refresh and store the token.
 		log.Printf("refreshing oauth token")
 		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
@@ -199,7 +201,7 @@ RETRY:
 		return nil, fmt.Errorf("failed PUT %v (%w)", url, err)
 	}
 	err = getErrorDetails(resp)
-	if retriableError(err) && retries < 3 {
+	if retriableError(err) && retries < maxRetries {
 		// Refresh and store the token.
 		log.Printf("refreshing oauth token")
 		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
@@ -235,7 +237,7 @@ RETRY:
 		return nil, fmt.Errorf("failed DELETE %v (%w)", url, err)
 	}
 	err = getErrorDetails(resp)
-	if retriableError(err) && retries < 3 {
+	if retriableError(err) && retries < maxRetries {
 		// Refresh and store the token.
 		log.Printf("refreshing oauth token")
 		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {

--- a/external/gitlab/gitlab.go
+++ b/external/gitlab/gitlab.go
@@ -1,9 +1,13 @@
 package gitlab
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -103,7 +107,11 @@ type File struct {
 }
 
 // POST sends a POST request.
-func POST(instanceURL string, resourcePath string, token string, body io.Reader) (*http.Response, error) {
+func POST(instanceURL string, resourcePath string, token *string, body io.Reader, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
+	retries := 0
+RETRY:
+	retries++
+
 	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
 	req, err := http.NewRequest("POST",
 		url, body)
@@ -112,18 +120,34 @@ func POST(instanceURL string, resourcePath string, token string, body io.Reader)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Bearer "+*token)
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed POST %v (%w)", url, err)
+	}
+	err = getErrorDetails(resp)
+	if retriableError(err) && retries < 3 {
+		// Refresh and store the token.
+		log.Printf("refreshing oauth token")
+		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
+			return nil, err
+		}
+		goto RETRY
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return resp, nil
 }
 
 // GET sends a GET request.
-func GET(instanceURL string, resourcePath string, token string) (*http.Response, error) {
+func GET(instanceURL string, resourcePath string, token *string, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
+	retries := 0
+RETRY:
+	retries++
+
 	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
 	req, err := http.NewRequest("GET",
 		url, nil)
@@ -132,18 +156,34 @@ func GET(instanceURL string, resourcePath string, token string) (*http.Response,
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Bearer "+*token)
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed GET %v (%w)", url, err)
+	}
+	err = getErrorDetails(resp)
+	if retriableError(err) && retries < 3 {
+		// Refresh and store the token.
+		log.Printf("refreshing oauth token")
+		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
+			return nil, err
+		}
+		goto RETRY
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return resp, nil
 }
 
 // PUT sends a PUT request.
-func PUT(instanceURL string, resourcePath string, token string, body io.Reader) (*http.Response, error) {
+func PUT(instanceURL string, resourcePath string, token *string, body io.Reader, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
+	retries := 0
+RETRY:
+	retries++
+
 	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
 	req, err := http.NewRequest("PUT",
 		url, body)
@@ -152,18 +192,34 @@ func PUT(instanceURL string, resourcePath string, token string, body io.Reader) 
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Bearer "+*token)
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed PUT %v (%w)", url, err)
+	}
+	err = getErrorDetails(resp)
+	if retriableError(err) && retries < 3 {
+		// Refresh and store the token.
+		log.Printf("refreshing oauth token")
+		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
+			return nil, err
+		}
+		goto RETRY
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return resp, nil
 }
 
 // DELETE sends a DELETE request.
-func DELETE(instanceURL string, resourcePath string, token string) (*http.Response, error) {
+func DELETE(instanceURL string, resourcePath string, token *string, oauthContext OauthContext, refresher TokenRefresher) (*http.Response, error) {
+	retries := 0
+RETRY:
+	retries++
+
 	url := fmt.Sprintf("%s/%s/%s", instanceURL, APIPath, resourcePath)
 	req, err := http.NewRequest("DELETE",
 		url, nil)
@@ -172,12 +228,131 @@ func DELETE(instanceURL string, resourcePath string, token string) (*http.Respon
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Bearer "+*token)
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed DELETE %v (%w)", url, err)
 	}
+	err = getErrorDetails(resp)
+	if retriableError(err) && retries < 3 {
+		// Refresh and store the token.
+		log.Printf("refreshing oauth token")
+		if err := refreshToken(instanceURL, token, oauthContext, refresher); err != nil {
+			return nil, err
+		}
+		goto RETRY
+	}
+	if err != nil {
+		return nil, err
+	}
 
 	return resp, nil
+}
+
+type oauthError struct {
+	Err              string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func (e *oauthError) Error() string {
+	return fmt.Sprintf("git oauth response error %q description %q", e.Err, e.ErrorDescription)
+}
+
+func getErrorDetails(resp *http.Response) error {
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var oe oauthError
+	if err = json.Unmarshal([]byte(body), &oe); err != nil {
+		return err
+	}
+	if oe.Err != "" || oe.ErrorDescription != "" {
+		return &oe
+	}
+	return fmt.Errorf("git response code %v error %q", resp.StatusCode, body)
+}
+
+func retriableError(e error) bool {
+	if e == nil {
+		return false
+	}
+	oe, ok := e.(*oauthError)
+	if !ok {
+		return false
+	}
+	// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+	// {"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}
+	return oe.Err == "invalid_token" && strings.Contains(oe.ErrorDescription, "expired")
+}
+
+// TokenRefresher is a function refreshes the oauth token and updates the repository.
+type TokenRefresher func(token, refreshToken string, expiresTs int64) error
+
+// OauthContext is the request context for refreshing oauth token.
+type OauthContext struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+	GrantType    string `json:"grant_type"`
+}
+
+type refreshOauthResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	CreatedAt    int64  `json:"created_at"`
+	// token_type, scope are not used.
+}
+
+func refreshToken(instanceURL string, oldToken *string, oauthContext OauthContext, refresher TokenRefresher) error {
+	url := fmt.Sprintf("%s/oauth/token", instanceURL)
+	oauthContext.GrantType = "refresh_token"
+	body, err := json.Marshal(oauthContext)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to construct refresh token POST %v (%w)", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send refresh token POST %v (%w)", url, err)
+	}
+	if err := getErrorDetails(resp); err != nil {
+		return err
+	}
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body from refresh token POST %v (%w)", url, err)
+	}
+
+	var r refreshOauthResponse
+	if err := json.Unmarshal([]byte(body), &r); err != nil {
+		return fmt.Errorf("failed to unmarshal body from refresh token POST %v (%w)", url, err)
+	}
+
+	// Update the old token to new value for retries.
+	*oldToken = r.AccessToken
+
+	// For GitLab, as of 13.12, the default config won't expire the access token, thus this field is 0.
+	// see https://gitlab.com/gitlab-org/gitlab/-/issues/21745.
+	var expireAt int64
+	if r.ExpiresIn != 0 {
+		expireAt = r.CreatedAt + r.ExpiresIn
+	}
+	if err := refresher(r.AccessToken, r.RefreshToken, expireAt); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -157,7 +157,13 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 				resp, err := gitlab.GET(
 					repository.VCS.InstanceURL,
 					fmt.Sprintf("projects/%s/repository/files/%s/raw?ref=%s", repository.ExternalID, url.QueryEscape(added), commit.ID),
-					repository.AccessToken,
+					&repository.AccessToken,
+					gitlab.OauthContext{
+						ClientID:     repository.VCS.ApplicationID,
+						ClientSecret: repository.VCS.Secret,
+						RefreshToken: repository.RefreshToken,
+					},
+					s.refreshToken(ctx, repository.ID),
 				)
 				if err != nil {
 					createIgnoredFileActivity(fmt.Errorf("failed to read file: %w", err))

--- a/store/repository.go
+++ b/store/repository.go
@@ -328,6 +328,15 @@ func patchRepository(ctx context.Context, tx *Tx, patch *api.RepositoryPatch) (*
 	if v := patch.SchemaPathTemplate; v != nil {
 		set, args = append(set, "schema_path_template = ?"), append(args, *v)
 	}
+	if v := patch.AccessToken; v != nil {
+		set, args = append(set, "access_token = ?"), append(args, *v)
+	}
+	if v := patch.ExpiresTs; v != nil {
+		set, args = append(set, "expires_ts = ?"), append(args, *v)
+	}
+	if v := patch.RefreshToken; v != nil {
+		set, args = append(set, "refresh_token = ?"), append(args, *v)
+	}
 
 	args = append(args, patch.ID)
 


### PR DESCRIPTION
https://github.com/bytebase/bytebase/issues/108

GitLab has implemented the access token expiration with 2h duration since version 14.X. The issue above happens when we use an expired token to call GitLab with oauth errors in the HTTP response. Then we would use the error response for actual usage such as schema migration. The fix is to refresh access token on token expiration oauth error and write through repository.