### PR TITLE
feat(frontend): allow modal dialogs stacking

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,16 @@
 <template>
-  <KBarWrapper>
-    <router-view />
-    <template v-if="state.notificationList.length > 0">
-      <BBNotification
-        :placement="'BOTTOM_RIGHT'"
-        :notification-list="state.notificationList"
-        @close="removeNotification"
-      />
-    </template>
-  </KBarWrapper>
+  <BBModalStack>
+    <KBarWrapper>
+      <router-view />
+      <template v-if="state.notificationList.length > 0">
+        <BBNotification
+          :placement="'BOTTOM_RIGHT'"
+          :notification-list="state.notificationList"
+          @close="removeNotification"
+        />
+      </template>
+    </KBarWrapper>
+  </BBModalStack>
 </template>
 
 <script lang="ts">
@@ -19,6 +21,7 @@ import { isDev } from "./utils";
 import { Notification } from "./types";
 import { BBNotificationItem } from "./bbkit/types";
 import KBarWrapper from "./components/KBar/KBarWrapper.vue";
+import BBModalStack from "./bbkit/BBModalStack.vue";
 
 // Show at most 3 notifications to prevent excessive notification when shit hits the fan.
 const MAX_NOTIFICATION_DISPLAY_COUNT = 3;
@@ -38,6 +41,7 @@ export default {
   name: "App",
   components: {
     KBarWrapper,
+    BBModalStack,
   },
   setup() {
     const store = useStore();

--- a/frontend/src/bbkit/BBModal.vue
+++ b/frontend/src/bbkit/BBModal.vue
@@ -1,25 +1,11 @@
-<!--
-  rgba(209, 213, 219, 0.8) is bg-gray-300
--->
 <template>
-  <div
-    class="fixed inset-0 w-full h-screen flex items-center justify-center z-40"
-    style="background-color: rgba(209, 213, 219, 0.8)"
-  >
+  <teleport to="#bb-modal-stack">
     <div
-      class="
-        relative
-        max-h-screen
-        w-full
-        max-w-max
-        bg-white
-        shadow-lg
-        rounded-lg
-        p-8
-        flex
-        space-y-6
-        divide-y divide-block-border
-      "
+      class="bb-modal"
+      :style="style"
+      :data-bb-modal-id="id"
+      :data-bb-modal-index="index"
+      :data-bb-modal-active="active"
     >
       <div>
         <div class="absolute left-0 top-0 my-4 mx-8 text-xl text-main">
@@ -46,13 +32,14 @@
         <slot />
       </div>
     </div>
-  </div>
+  </teleport>
 </template>
 
 <script lang="ts">
-import { onMounted, onUnmounted } from "vue";
+import { computed, defineComponent, onMounted, onUnmounted } from "vue";
+import { useModalStack } from "./BBModalStack.vue";
 
-export default {
+export default defineComponent({
   name: "BBModal",
   props: {
     title: {
@@ -70,11 +57,21 @@ export default {
   },
   emits: ["close"],
   setup(props, { emit }) {
+    const { stack, id, index, active } = useModalStack();
+
+    const style = computed(() => ({
+      "z-index": 40 + index.value, // "40 + " because the container in BBModalStack is z-40
+    }));
+
     const close = () => {
       emit("close");
     };
 
     const escHandler = (e: KeyboardEvent) => {
+      if (!active.value) {
+        // only to close the topmost modal when pressing ESC
+        return;
+      }
       if (e.code == "Escape") {
         close();
       }
@@ -89,8 +86,19 @@ export default {
     });
 
     return {
+      style,
       close,
+      stack,
+      id,
+      index,
+      active,
     };
   },
-};
+});
 </script>
+
+<style scoped>
+.bb-modal {
+  @apply absolute max-h-screen w-full max-w-max bg-white shadow-lg rounded-lg p-8 flex space-y-6 divide-y divide-block-border pointer-events-auto;
+}
+</style>

--- a/frontend/src/bbkit/BBModalStack.vue
+++ b/frontend/src/bbkit/BBModalStack.vue
@@ -1,0 +1,79 @@
+<template>
+  <teleport to="body">
+    <!-- use v-show, not v-if. we need to keep this element in dom tree -->
+    <!-- because it is used as teleport target -->
+    <!-- removing it from tree may cause teleport error-->
+    <div
+      v-show="stack.length > 0"
+      id="bb-modal-stack"
+      class="bb-modal-mask"
+      :data-bb-modal-stack="stack.join('|')"
+    />
+  </teleport>
+  <slot />
+</template>
+
+<script lang="ts">
+import {
+  computed,
+  defineComponent,
+  inject,
+  onUnmounted,
+  provide,
+  Ref,
+  ref,
+} from "vue";
+
+export type ModalStackContext = {
+  stack: Ref<number[]>;
+  autoIncrement: number;
+};
+
+const CONTEXT_KEY = "$bbModalStack";
+
+export function useModalStack() {
+  const context = inject<ModalStackContext>(CONTEXT_KEY)!;
+  const { stack } = context;
+
+  const id = context.autoIncrement++;
+  stack.value.push(id);
+  const index = computed(() => stack.value.indexOf(id));
+  const active = computed(() => index.value === stack.value.length - 1);
+
+  onUnmounted(() => {
+    if (index.value >= 0) {
+      stack.value.splice(index.value, 1);
+    }
+  });
+
+  return { stack, id, index, active };
+}
+
+export function useModalStackStatus() {
+  const { stack } = inject<ModalStackContext>(CONTEXT_KEY)!;
+  return stack;
+}
+
+export default defineComponent({
+  name: "BBModalStack",
+  setup() {
+    const stack = ref<number[]>([]);
+
+    provide<ModalStackContext>(CONTEXT_KEY, {
+      stack,
+      autoIncrement: 0,
+    });
+
+    return {
+      stack,
+    };
+  },
+});
+</script>
+
+<style scope>
+.bb-modal-mask {
+  @apply fixed inset-0 w-full h-screen flex items-center justify-center z-40 pointer-events-none;
+  background-color: rgba(209, 213, 219, 0.8); /* bg-gray-300 */
+}
+</style>

--- a/frontend/src/bbkit/BBModalStack.vue
+++ b/frontend/src/bbkit/BBModalStack.vue
@@ -29,7 +29,7 @@ export type ModalStackContext = {
   autoIncrement: number;
 };
 
-const CONTEXT_KEY = "$bbModalStack";
+const CONTEXT_KEY = "bb.modal-stack";
 
 export function useModalStack() {
   const context = inject<ModalStackContext>(CONTEXT_KEY)!;

--- a/frontend/src/components/KBar/KBarWrapper.vue
+++ b/frontend/src/components/KBar/KBarWrapper.vue
@@ -4,9 +4,9 @@
     :options="{ placeholder, disabled, compare }"
   >
     <KBarPortal>
-      <KBarPositioner class="mask">
-        <KBarAnimator class="container">
-          <KBarSearch class="searchbox" />
+      <KBarPositioner class="bb-kbar-mask">
+        <KBarAnimator class="bb-kbar-container">
+          <KBarSearch class="bb-kbar-searchbox" />
           <RenderResults />
           <KBarFooter />
         </KBarAnimator>
@@ -35,6 +35,7 @@ import RenderResults from "./RenderResults.vue";
 import KBarHelper from "./KBarHelper.vue";
 import KBarFooter from "./KBarFooter.vue";
 import { useI18n } from "vue-i18n";
+import { useModalStackStatus } from "../../bbkit/BBModalStack.vue";
 
 export default defineComponent({
   name: "KBarWrapper",
@@ -52,10 +53,19 @@ export default defineComponent({
     const { t } = useI18n();
     const store = useStore();
     const router = useRouter();
+    const modalStack = useModalStackStatus();
 
     const placeholder = computed(() => t("kbar.options.placeholder"));
 
     const disabled = computed(() => {
+      if (modalStack.value.length > 0) {
+        // Disable kbar when any modal dialog is shown
+        // We don't want to show modal dialogs and kbar at the same time
+        // This also avoids navigating through kbar, which may
+        // cause unexpected results
+        return true;
+      }
+
       const currentUser = store.getters["auth/currentUser"]();
       // totally disable kbar when not logged in
       // since there is no point to show it on signin/signup pages
@@ -92,13 +102,13 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.mask {
+.bb-kbar-mask {
   @apply bg-gray-300 bg-opacity-80;
 }
-.container {
+.bb-kbar-container {
   @apply bg-white shadow-lg rounded-lg w-128 overflow-hidden divide-y;
 }
-.searchbox {
+.bb-kbar-searchbox {
   @apply px-4 py-4 text-lg w-full box-border outline-none border-none;
 }
 </style>

--- a/frontend/src/components/StatusTransitionForm.vue
+++ b/frontend/src/components/StatusTransitionForm.vue
@@ -71,10 +71,7 @@
             :title="`Check found ${checkSummary.warnCount} warning(s)`"
           />
         </template>
-        <TaskCheckBadgeBar
-          :task-check-run-list="task.taskCheckRunList"
-          :allow-selection="false"
-        />
+        <TaskCheckBar :task="task!" :allow-run-task="false" />
       </div>
 
       <div class="sm:col-span-4 w-112 min-w-full">
@@ -129,7 +126,7 @@
 import { computed, reactive, ref, PropType, defineComponent } from "vue";
 import cloneDeep from "lodash-es/cloneDeep";
 import DatabaseSelect from "./DatabaseSelect.vue";
-import TaskCheckBadgeBar from "./TaskCheckBadgeBar.vue";
+import TaskCheckBar from "./TaskCheckBar.vue";
 import { Issue, IssueStatusTransition, Task, TaskCheckRun } from "../types";
 import { OutputField } from "../plugins";
 import { activeEnvironment, TaskStatusTransition } from "../utils";
@@ -147,7 +144,7 @@ interface LocalState {
 
 export default defineComponent({
   name: "StatusTransitionForm",
-  components: { DatabaseSelect, TaskCheckBadgeBar },
+  components: { DatabaseSelect, TaskCheckBar },
   props: {
     mode: {
       required: true,

--- a/frontend/src/components/TaskCheckBar.vue
+++ b/frontend/src/components/TaskCheckBar.vue
@@ -82,6 +82,10 @@ export default defineComponent({
   name: "TaskCheckBar",
   components: { TaskCheckBadgeBar, TaskCheckRunPanel },
   props: {
+    allowRunTask: {
+      type: Boolean,
+      default: true,
+    },
     task: {
       required: true,
       type: Object as PropType<Task>,
@@ -124,6 +128,7 @@ export default defineComponent({
     });
 
     const showRunCheckButton = computed((): boolean => {
+      if (!props.allowRunTask) return false;
       return (
         props.task.type == "bb.task.database.schema.update" &&
         (props.task.status == "PENDING" ||


### PR DESCRIPTION
Now, `BBModal` can stack.
- Introducing a new component `BBModalStack` to manage all `BBModal` instances.
- Only the foremost `BBModal` will response to `ESC` keypress.
- The semitransparent mask of `BBModal` has been moved to `BBModalStack`. It's now global unique no matter how many modal dialogs are visible at the same time. (Otherwise the background will become dimmer and dimmer when we have more and more modal dialogs)
- Disable kbar when any `BBModal` is shown.
- Allow to check alter schema check detail status when approving the issue. (this is a first-step practicing of this feature)

![image](https://user-images.githubusercontent.com/2749742/146164400-a34fba3f-19ad-4e46-9eb9-6cb6ea069567.png)
