### PR TITLE
feat(schema): added task_version to TABLE task_check_run

### DIFF
--- a/api/task_check_run.go
+++ b/api/task_check_run.go
@@ -114,7 +114,8 @@ type TaskCheckRun struct {
 	UpdatedTs int64      `jsonapi:"attr,updatedTs"`
 
 	// Related fields
-	TaskID int `jsonapi:"attr,taskId"`
+	TaskID      int   `jsonapi:"attr,taskId"`
+	TaskVersion int64 `jsonapi:"attr,taskVersion"`
 
 	// Domain specific fields
 	Status  TaskCheckRunStatus `jsonapi:"attr,status"`
@@ -132,7 +133,8 @@ type TaskCheckRunCreate struct {
 	CreatorID int
 
 	// Related fields
-	TaskID int
+	TaskID      int
+	TaskVersion int64
 
 	// Domain specific fields
 	Type    TaskCheckType `jsonapi:"attr,type"`

--- a/server/task.go
+++ b/server/task.go
@@ -101,6 +101,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 				_, err = s.TaskCheckRunService.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 					CreatorID:               api.SystemBotID,
 					TaskID:                  task.ID,
+					TaskVersion:             task.UpdatedTs,
 					Type:                    api.TaskCheckDatabaseStatementSyntax,
 					Payload:                 string(payload),
 					SkipIfAlreadyTerminated: false,
@@ -117,6 +118,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 				_, err = s.TaskCheckRunService.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 					CreatorID:               api.SystemBotID,
 					TaskID:                  task.ID,
+					TaskVersion:             task.UpdatedTs,
 					Type:                    api.TaskCheckDatabaseStatementCompatibility,
 					Payload:                 string(payload),
 					SkipIfAlreadyTerminated: false,

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -196,6 +196,7 @@ func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *ap
 		_, err = s.server.TaskCheckRunService.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 			CreatorID:               creatorID,
 			TaskID:                  task.ID,
+			TaskVersion:             task.UpdatedTs,
 			Type:                    api.TaskCheckDatabaseConnect,
 			SkipIfAlreadyTerminated: skipIfAlreadyTerminated,
 		})
@@ -206,6 +207,7 @@ func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *ap
 		_, err = s.server.TaskCheckRunService.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 			CreatorID:               creatorID,
 			TaskID:                  task.ID,
+			TaskVersion:             task.UpdatedTs,
 			Type:                    api.TaskCheckInstanceMigrationSchema,
 			SkipIfAlreadyTerminated: skipIfAlreadyTerminated,
 		})
@@ -227,6 +229,7 @@ func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *ap
 			_, err = s.server.TaskCheckRunService.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 				CreatorID:               creatorID,
 				TaskID:                  task.ID,
+				TaskVersion:             task.UpdatedTs,
 				Type:                    api.TaskCheckDatabaseStatementSyntax,
 				Payload:                 string(payload),
 				SkipIfAlreadyTerminated: skipIfAlreadyTerminated,
@@ -238,6 +241,7 @@ func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *ap
 			_, err = s.server.TaskCheckRunService.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 				CreatorID:               creatorID,
 				TaskID:                  task.ID,
+				TaskVersion:             task.UpdatedTs,
 				Type:                    api.TaskCheckDatabaseStatementCompatibility,
 				Payload:                 string(payload),
 				SkipIfAlreadyTerminated: skipIfAlreadyTerminated,

--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -922,6 +922,7 @@ CREATE TABLE task_check_run (
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT (strftime('%s', 'now')),
     task_id INTEGER NOT NULL REFERENCES task (id),
+    task_version BIGINT NOT NULL REFERENCES task (updated_ts),
     `status` TEXT NOT NULL CHECK (
         `status` IN (
             'RUNNING',

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -96,17 +96,19 @@ func (s *TaskCheckRunService) CreateTaskCheckRunTx(ctx context.Context, tx *sql.
 			creator_id,
 			updater_id,
 			task_id,
+			task_version,
 			`+"`status`,"+`
 			`+"`type`,"+`
 			comment,
 			payload
 		)
 		VALUES (?, ?, ?, 'RUNNING', ?, ?, ?)
-		RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, `+"`status`, `type`, code, comment, result, payload"+`
+		RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, task_version, `+"`status`, `type`, code, comment, result, payload"+`
 	`,
 		create.CreatorID,
 		create.CreatorID,
 		create.TaskID,
+		create.TaskVersion,
 		create.Type,
 		create.Comment,
 		create.Payload,
@@ -126,6 +128,7 @@ func (s *TaskCheckRunService) CreateTaskCheckRunTx(ctx context.Context, tx *sql.
 		&taskCheckRun.UpdaterID,
 		&taskCheckRun.UpdatedTs,
 		&taskCheckRun.TaskID,
+		&taskCheckRun.TaskVersion,
 		&taskCheckRun.Status,
 		&taskCheckRun.Type,
 		&taskCheckRun.Code,
@@ -218,7 +221,7 @@ func (s *TaskCheckRunService) PatchTaskCheckRunStatusTx(ctx context.Context, tx 
 		UPDATE task_check_run
 		SET `+strings.Join(set, ", ")+`
 		WHERE `+strings.Join(where, " AND ")+`
-		RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, `+"`status`, `type`, code, comment, result, payload"+`
+		RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, task_version, `+"`status`, `type`, code, comment, result, payload"+`
 	`,
 		args...,
 	)
@@ -237,6 +240,7 @@ func (s *TaskCheckRunService) PatchTaskCheckRunStatusTx(ctx context.Context, tx 
 		&taskCheckRun.UpdaterID,
 		&taskCheckRun.UpdatedTs,
 		&taskCheckRun.TaskID,
+		&taskCheckRun.TaskVersion,
 		&taskCheckRun.Status,
 		&taskCheckRun.Type,
 		&taskCheckRun.Code,
@@ -284,6 +288,7 @@ func (s *TaskCheckRunService) findTaskCheckRunList(ctx context.Context, tx *sql.
 			updater_id,
 		    updated_ts,
 			task_id,
+			task_version,
 			`+"`status`,"+`
 			`+"`type`,"+`
 			code,
@@ -310,6 +315,7 @@ func (s *TaskCheckRunService) findTaskCheckRunList(ctx context.Context, tx *sql.
 			&taskCheckRun.UpdaterID,
 			&taskCheckRun.UpdatedTs,
 			&taskCheckRun.TaskID,
+			&taskCheckRun.TaskVersion,
 			&taskCheckRun.Status,
 			&taskCheckRun.Type,
 			&taskCheckRun.Code,


### PR DESCRIPTION
The rationale behind this Schema change:

Facts:
    1.  Every `task_check` is scheduled according to a specific `task` version
    2. Users are allowed to modify `task` after creating them. 

Unwanted results:
    1. Given the facts, rare it may be, but a mismatch may still happen.
    2. The reference key `task_id` is useless since the task could be modified.
    3. The `task`, fetched from `task_id`, may not be the same as the `task` when we execute the `taskCheck`
    
Solution:
    Added another reference key name 'task_version' to table `task_check_run`

