### PR TITLE
feat(schema): added task_version to TABLE task_check_run

### DIFF
--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -922,6 +922,8 @@ CREATE TABLE task_check_run (
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT (strftime('%s', 'now')),
     task_id INTEGER NOT NULL REFERENCES task (id),
+    -- task_version specified the task version of this task_check, since we allowed users to modify task --
+    task_version BIGINT NOT NULL DEFAULT 0
     `status` TEXT NOT NULL CHECK (
         `status` IN (
             'RUNNING',


### PR DESCRIPTION
The rationale behind this Schema change:

Facts:
1. Every task_check is scheduled according to a specific task version
2. Users are allowed to modify task after creating them.

Unwanted results:
1. Given the facts, rare it may be, but a mismatch may still happen.
2. The reference key task_id is useless since the task could be modified.
3. The task, fetched from task_id, may not be the same as the task when we execute the taskCheck

Solution:
Added another reference key name 'task_version' to table task_check_run