### PR TITLE
fix(tenancy): fix SetDatabaseLabelList return

### DIFF
--- a/store/label.go
+++ b/store/label.go
@@ -382,7 +382,6 @@ func (s *LabelService) SetDatabaseLabelList(ctx context.Context, labels []*api.D
 		if err != nil {
 			return nil, err
 		}
-		ret = append(ret, label)
 	}
 
 	for _, label := range labels {


### PR DESCRIPTION
Should not include old labels in return values.