### PR TITLE
fix: signin word error in i18n

### DIFF
--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -18,7 +18,7 @@ common:
   unread: 未读
   read: 已读
   inbox: 通知
-  sign-in: 登陆
+  sign-in: 登录
   sign-up: 注册
   email: 邮箱
   username: 用户名
@@ -482,18 +482,18 @@ auth:
     password-mismatch: 不匹配
     existing-user: 已有账号?
   sign-in:
-    title: 登陆您的账号
+    title: 登录您的账号
     forget-password: 忘记密码?
     new-user: 第一次使用 Bytebase?
   password-forget:
     title: 忘记了您的密码？
     content: 请联系的您的 Bytebase 管理员重置密码
-    return-to-sign-in: 返回登陆
+    return-to-sign-in: 返回登录
   password-reset:
     title: 重置您的密码
     content: 我们会将重置密码链接发送到您的邮箱
     send-reset-link: 发送重置链接
-    return-to-sign-in: 返回登陆
+    return-to-sign-in: 返回登录
   activate:
     title: 激活您的 {type} 账号
 policy:
@@ -789,7 +789,7 @@ version-control:
       oauth-info:
         self: OAuth 应用信息
         register-oauth-application: 注册 Bytebase 为一个 GitLab 实例级别 (instance-wide) 的 OAuth 应用。
-        login-as-admin: 以管理员身份登陆 GitLab 实例。这个账号必须是整个 GitLab 实例的管理员 (会看到小扳手在顶栏)。
+        login-as-admin: 以管理员身份登录 GitLab 实例。这个账号必须是整个 GitLab 实例的管理员 (会看到小扳手在顶栏)。
         visit-admin-page: 通过点击小扳手访问管理员界面，然后导航到「应用」分区，再点击「创建应用」。
         direct-link: 直达链接
         create-oauth-app: 使用如下信息来创建您的 Bytebase OAuth 应用。


### PR DESCRIPTION
`Sign in` should be translate to `登录` or `登入` but not `登陆`.