### PR TITLE
fix(frontend): fix kbar word wrapping and overflowing

### DIFF
--- a/frontend/src/components/KBar/RenderResults.vue
+++ b/frontend/src/components/KBar/RenderResults.vue
@@ -15,7 +15,7 @@
               {{ findParent(item).name }}
             </span>
 
-            <span>{{ item.name }}</span>
+            <span class="name">{{ item.name }}</span>
 
             <span v-for="(tag, i) in item.data?.tags" :key="i" class="tag">
               {{ tag }}
@@ -80,7 +80,7 @@ export default defineComponent({
   @apply bg-control-bg-hover border-current;
 }
 .content {
-  @apply flex flex-col;
+  @apply flex flex-col overflow-x-hidden;
 }
 .main {
   @apply flex items-center text-base gap-1;
@@ -88,8 +88,11 @@ export default defineComponent({
 .tag {
   @apply inline-block text-xs px-1 py-0.5 bg-black bg-opacity-10 rounded-sm;
 }
+.name {
+  @apply overflow-x-hidden overflow-ellipsis whitespace-nowrap;
+}
 .subtitle {
-  @apply text-xs text-gray-500;
+  @apply text-xs text-gray-500 overflow-x-hidden overflow-ellipsis whitespace-nowrap;
 }
 .parent {
   @apply text-gray-500;


### PR DESCRIPTION
Before:
<img width="531" alt="Snipaste_2021-12-23_09-22-21" src="https://user-images.githubusercontent.com/2749742/147173589-290c6510-b44e-41b7-9dde-7e011e4f95d9.png">

After:
<img width="559" alt="Snipaste_2021-12-23_09-23-59" src="https://user-images.githubusercontent.com/2749742/147173600-a1ad0fb2-6695-4acc-a6df-d2c0a84f6fd1.png">

