### PR TITLE
fix: fixed marshal payload

### DIFF
--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -243,7 +243,9 @@ func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *ap
 		}
 
 		if flag {
-			taskCheckPayload, err := json.Marshal(task)
+			taskCheckPayload, err := json.Marshal(api.TaskCheckEarliestAllowedTimePayload{
+				EarliestAllowedTs: task.EarliestAllowedTs,
+			})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
changed payload field from marshal entire `task` to `api.TaskCheckEarliestAllowedTimePayload`