### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/plugin/db/ssl.go
+++ b/plugin/db/ssl.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // TLSConfig is the configuration for SSL connection.
@@ -20,7 +20,7 @@ func (tc TLSConfig) GetSslConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 	rootCertPool := x509.NewCertPool()
-	pem, err := ioutil.ReadFile(tc.SslCA)
+	pem, err := os.ReadFile(tc.SslCA)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/webhook/dingtalk.go
+++ b/plugin/webhook/dingtalk.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -75,7 +75,7 @@ func (receiver *DingTalkReceiver) post(context Context) error {
 		return fmt.Errorf("failed to POST webhook %v (%w)", context.URL, err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read POST webhook response %v (%w)", context.URL, err)
 	}

--- a/plugin/webhook/discord.go
+++ b/plugin/webhook/discord.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -100,7 +100,7 @@ func (receiver *DiscordReceiver) post(context Context) error {
 		return fmt.Errorf("failed to POST webhook %+v (%w)", context.URL, err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read POST webhook response %v (%w)", context.URL, err)
 	}

--- a/plugin/webhook/feishu.go
+++ b/plugin/webhook/feishu.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -142,7 +142,7 @@ func (receiver *FeishuReceiver) post(context Context) error {
 		return fmt.Errorf("failed to POST webhook %+v (%w)", context.URL, err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read POST webhook response %v (%w)", context.URL, err)
 	}

--- a/plugin/webhook/slack.go
+++ b/plugin/webhook/slack.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -141,7 +141,7 @@ func (receiver *SlackReceiver) post(context Context) error {
 		return fmt.Errorf("failed to POST webhook %+v (%w)", context.URL, err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read POST webhook response %v (%w)", context.URL, err)
 	}

--- a/plugin/webhook/teams.go
+++ b/plugin/webhook/teams.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -109,7 +109,7 @@ func (receiver *TeamsReceiver) post(context Context) error {
 		return fmt.Errorf("failed to POST webhook %+v (%w)", context.URL, err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read POST webhook response %v (%w)", context.URL, err)
 	}

--- a/plugin/webhook/wecom.go
+++ b/plugin/webhook/wecom.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -81,7 +81,7 @@ func (receiver *WeComReceiver) post(context Context) error {
 		return fmt.Errorf("failed to POST webhook %v (%w)", context.URL, err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read POST webhook response %v (%w)", context.URL, err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.