### PR TITLE
fix: error should be passed down to the caller,  NOT be negelected in the interceptor

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -74,9 +74,7 @@ axios.interceptors.response.use(
           try {
             await store.dispatch("auth/logout");
           } finally {
-            {
-              router.push({ name: "auth.signin" });
-            }
+            router.push({ name: "auth.signin" });
           }
       }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -83,14 +83,12 @@ axios.interceptors.response.use(
           title: error.response.data.message,
         });
       }
-      return;
     } else if (error.code == "ECONNABORTED") {
       store.dispatch("notification/pushNotification", {
         module: "bytebase",
         style: "CRITICAL",
         title: "Connecting server timeout. Make sure the server is running.",
       });
-      return;
     }
 
     throw error;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -62,7 +62,7 @@ axios.interceptors.response.use(
     }
     return response;
   },
-  (error) => {
+  async (error) => {
     if (error.response) {
       // When receiving 401 and is returned by our server, it means the current
       // login user's token becomes invalid. Thus we force a logout.
@@ -71,9 +71,13 @@ axios.interceptors.response.use(
       if (error.response.status == 401) {
         const host = store.getters["actuator/info"]().host;
         if (error.response.request.responseURL.startsWith(host))
-          store.dispatch("auth/logout").then(() => {
-            router.push({ name: "auth.signin" });
-          });
+          try {
+            await store.dispatch("auth/logout");
+          } finally {
+            {
+              router.push({ name: "auth.signin" });
+            }
+          }
       }
 
       if (error.response.data.message) {

--- a/frontend/src/store/modules/auth.ts
+++ b/frontend/src/store/modules/auth.ts
@@ -50,9 +50,11 @@ const actions = {
   },
 
   async logout({ commit }: any) {
-    await axios.post("/api/auth/logout");
-
-    commit("setCurrentUser", unknown("PRINCIPAL") as Principal);
+    try {
+      await axios.post("/api/auth/logout");
+    } finally {
+      commit("setCurrentUser", unknown("PRINCIPAL") as Principal);
+    }
     return unknown("PRINCIPAL") as Principal;
   },
 

--- a/frontend/src/store/modules/issueSubscriber.ts
+++ b/frontend/src/store/modules/issueSubscriber.ts
@@ -89,9 +89,11 @@ const actions = {
       subscriberId: PrincipalId;
     }
   ) {
-    await axios.delete(`/api/issue/${issueId}/subscriber/${subscriberId}`);
-
-    commit("deleteIssueSubscriberByIssueId", { issueId, subscriberId });
+    axios
+      .delete(`/api/issue/${issueId}/subscriber/${subscriberId}`)
+      .then(() => {
+        commit("deleteIssueSubscriberByIssueId", { issueId, subscriberId });
+      });
   },
 };
 

--- a/frontend/src/store/modules/issueSubscriber.ts
+++ b/frontend/src/store/modules/issueSubscriber.ts
@@ -89,11 +89,9 @@ const actions = {
       subscriberId: PrincipalId;
     }
   ) {
-    axios
-      .delete(`/api/issue/${issueId}/subscriber/${subscriberId}`)
-      .then(() => {
-        commit("deleteIssueSubscriberByIssueId", { issueId, subscriberId });
-      });
+    axios.delete(`/api/issue/${issueId}/subscriber/${subscriberId}`);
+
+    commit("deleteIssueSubscriberByIssueId", { issueId, subscriberId });
   },
 };
 

--- a/frontend/src/store/modules/issueSubscriber.ts
+++ b/frontend/src/store/modules/issueSubscriber.ts
@@ -89,7 +89,7 @@ const actions = {
       subscriberId: PrincipalId;
     }
   ) {
-    axios.delete(`/api/issue/${issueId}/subscriber/${subscriberId}`);
+    await axios.delete(`/api/issue/${issueId}/subscriber/${subscriberId}`);
 
     commit("deleteIssueSubscriberByIssueId", { issueId, subscriberId });
   },


### PR DESCRIPTION
This may cause some wrong state update at the frontend.
I spotted this bug when I started Bytebase in demo + readonly mode. 
Most HTTP methods are forbidden under readonly mode, however, I was still able to update some states at the frontend.