### PR TITLE
fix(vcs): fix the broken VCS integration

### DIFF
--- a/server/project.go
+++ b/server/project.go
@@ -357,8 +357,9 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			err = vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).PatchWebhook(
 				ctx,
 				common.OauthContext{
-					ClientID:     repository.VCS.ApplicationID,
-					ClientSecret: repository.VCS.Secret,
+					// Need to get ApplicationID, Secret from vcs instead of repository.vcs since the latter is not composed.
+					ClientID:     vcs.ApplicationID,
+					ClientSecret: vcs.Secret,
 					AccessToken:  repository.AccessToken,
 					RefreshToken: repository.RefreshToken,
 					Refresher:    s.refreshToken(ctx, repository.ID),
@@ -434,9 +435,10 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		// If we delete it before we delete the repository, then if the repository deletion fails, we will have a broken repository with no webhook.
 		err = vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).DeleteWebhook(
 			ctx,
+			// Need to get ApplicationID, Secret from vcs instead of repository.vcs since the latter is not composed.
 			common.OauthContext{
-				ClientID:     repository.VCS.ApplicationID,
-				ClientSecret: repository.VCS.Secret,
+				ClientID:     vcs.ApplicationID,
+				ClientSecret: vcs.Secret,
 				AccessToken:  repository.AccessToken,
 				RefreshToken: repository.RefreshToken,
 				Refresher:    s.refreshToken(ctx, repository.ID),

--- a/server/task_executor_schema_update.go
+++ b/server/task_executor_schema_update.go
@@ -261,6 +261,7 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 		common.OauthContext{
 			ClientID:     repository.VCS.ApplicationID,
 			ClientSecret: repository.VCS.Secret,
+			AccessToken:  repository.AccessToken,
 			RefreshToken: repository.RefreshToken,
 			Refresher:    server.refreshToken(ctx, repository.ID),
 		},
@@ -303,6 +304,7 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 			common.OauthContext{
 				ClientID:     repository.VCS.ApplicationID,
 				ClientSecret: repository.VCS.Secret,
+				AccessToken:  repository.AccessToken,
 				RefreshToken: repository.RefreshToken,
 				Refresher:    server.refreshToken(ctx, repository.ID),
 			},
@@ -322,6 +324,7 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 			common.OauthContext{
 				ClientID:     repository.VCS.ApplicationID,
 				ClientSecret: repository.VCS.Secret,
+				AccessToken:  repository.AccessToken,
 				RefreshToken: repository.RefreshToken,
 				Refresher:    server.refreshToken(ctx, repository.ID),
 			},
@@ -341,6 +344,7 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 		common.OauthContext{
 			ClientID:     repository.VCS.ApplicationID,
 			ClientSecret: repository.VCS.Secret,
+			AccessToken:  repository.AccessToken,
 			RefreshToken: repository.RefreshToken,
 			Refresher:    server.refreshToken(ctx, repository.ID),
 		},

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -146,6 +146,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 					common.OauthContext{
 						ClientID:     repository.VCS.ApplicationID,
 						ClientSecret: repository.VCS.Secret,
+						AccessToken:  repository.AccessToken,
 						RefreshToken: repository.RefreshToken,
 						Refresher:    s.refreshToken(ctx, repository.ID),
 					},


### PR DESCRIPTION
There are 2 bugs fixed in this PR

1. Add the missing access token when passing to the underlying vcs method; Also use the full path when creating/overwriting the schema file during schema file writeback. This was broken when doing the vcs refactor at https://github.com/bytebase/bytebase/pull/312

2. Only return error during token refresh if it's an oauth error from the response body. For response body returning status code like 404, we do not return error, and instead just return the resp as is. This behavior was accidentally changed when adding the refresh token logic at https://github.com/bytebase/bytebase/pull/173