### PR TITLE
refactor(frontend): replace moment using dayjs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "release-docker": "export NODE_OPTIONS=--max_old_space_size=4096 && vite build --mode release",
     "lint": "eslint --cache --ext .js,.ts,.tsx,.vue src",
     "lint:summary": "SORT_BY=rule DESC=true eslint -f summary --cache --ext .js,.ts,.tsx,.vue src",
-    "lint:fix": "eslint --cache --ext .js,.ts,.tsx,.vue --fix src"
+    "lint:fix": "eslint --cache --ext .js,.ts,.tsx,.vue --fix src",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
   },
   "dependencies": {
     "@bytebase/vue-kbar": "^0.1.5",
@@ -63,6 +65,7 @@
     "vite": "^2.6.14",
     "vite-plugin-components": "^0.13.3",
     "vite-plugin-icons": "^0.6.5",
+    "vitest": "^0.0.139",
     "vue-tsc": "^0.29.6"
   }
 }

--- a/frontend/src/components/DatabaseBackupCreateForm.vue
+++ b/frontend/src/components/DatabaseBackupCreateForm.vue
@@ -41,17 +41,20 @@
 </template>
 
 <script lang="ts">
-import { computed, PropType, reactive } from "vue";
+import { computed, PropType, reactive, defineComponent } from "vue";
 import { Database } from "../types";
 import { isEmpty } from "lodash-es";
-import moment from "moment";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import slug from "slug";
+
+dayjs.extend(utc);
 
 interface LocalState {
   backupName: string;
 }
 
-export default {
+export default defineComponent({
   name: "DatabaseBackupCreateForm",
   props: {
     database: {
@@ -65,7 +68,7 @@ export default {
       // The default format is consistent with the default automatic backup name format used in the server.
       backupName: `${slug(props.database.project.name)}-${slug(
         props.database.instance.environment.name
-      )}-${moment.utc().local().format("YYYYMMDDTHHmmss")}`,
+      )}-${dayjs.utc().local().format("YYYYMMDDTHHmmss")}`,
     });
 
     const allowCreate = computed(() => {
@@ -77,5 +80,5 @@ export default {
       allowCreate,
     };
   },
-};
+});
 </script>

--- a/frontend/src/components/InboxList.vue
+++ b/frontend/src/components/InboxList.vue
@@ -70,7 +70,7 @@ import { useRouter } from "vue-router";
 import { isEmpty } from "lodash-es";
 import { issueActivityActionSentence } from "../utils";
 import { useI18n } from "vue-i18n";
-import moment from "moment";
+import dayjs from "dayjs";
 
 export default defineComponent({
   name: "InboxList",
@@ -181,10 +181,10 @@ export default defineComponent({
           return t("activity.sentence.changed-from-to", {
             name: "earliest allowed time",
             oldValue: oldTs
-              ? moment(oldTs * 1000)
+              ? dayjs(oldTs * 1000)
               : t("task.earliest-allowed-time-unset"),
             newValue: newTs
-              ? moment(newTs * 1000)
+              ? dayjs(newTs * 1000)
               : t("task.earliest-allowed-time-unset"),
           });
         }

--- a/frontend/src/components/IssueActivityPanel.vue
+++ b/frontend/src/components/IssueActivityPanel.vue
@@ -367,7 +367,7 @@ import {
 } from "../utils";
 import { IssueTemplate, IssueBuiltinFieldId } from "../plugins";
 import { useI18n } from "vue-i18n";
-import moment from "moment";
+import dayjs from "dayjs";
 
 interface LocalState {
   showDeleteCommentModal: boolean;
@@ -692,8 +692,8 @@ export default defineComponent({
           const oldVal = payload.oldEarliestAllowedTs;
           return t("activity.sentence.changed-from-to", {
             name: "earliest allowed time",
-            oldValue: oldVal ? moment(oldVal * 1000) : "Unset",
-            newValue: newVal ? moment(newVal * 1000) : "Unset",
+            oldValue: oldVal ? dayjs(oldVal * 1000) : "Unset",
+            newValue: newVal ? dayjs(newVal * 1000) : "Unset",
           });
         }
       }

--- a/frontend/src/components/IssueHighlightPanel.vue
+++ b/frontend/src/components/IssueHighlightPanel.vue
@@ -36,7 +36,7 @@
               </router-link>
             </template>
             <template #time>
-              {{ moment(issue.updatedTs * 1000).format("LLL") }}
+              {{ dayjs(issue.updatedTs * 1000).format("LLL") }}
             </template>
           </i18n-t>
           <p
@@ -65,9 +65,7 @@
               </template>
               <template #author>{{ pushEvent.authorName }}</template>
               <template #time>
-                {{
-                  moment(pushEvent.fileCommit.createdTs * 1000).format("LLL")
-                }}
+                {{ dayjs(pushEvent.fileCommit.createdTs * 1000).format("LLL") }}
               </template>
             </i18n-t>
           </p>

--- a/frontend/src/components/IssueSidebar.vue
+++ b/frontend/src/components/IssueSidebar.vue
@@ -113,7 +113,7 @@
           {{
             task.earliestAllowedTs === 0
               ? $t("task.earliest-allowed-time-unset")
-              : moment(task.earliestAllowedTs * 1000).format("LLL")
+              : dayjs(task.earliestAllowedTs * 1000).format("LLL")
           }}</span
         >
       </div>
@@ -181,14 +181,14 @@
           {{ $t("common.updated-at") }}
         </h2>
         <span class="textfield col-span-2">
-          {{ moment(issue.updatedTs * 1000).format("LLL") }}</span
+          {{ dayjs(issue.updatedTs * 1000).format("LLL") }}</span
         >
 
         <h2 class="textlabel flex items-center col-span-1 col-start-1">
           {{ $t("common.created-at") }}
         </h2>
         <span class="textfield col-span-2">
-          {{ moment(issue.createdTs * 1000).format("LLL") }}</span
+          {{ dayjs(issue.createdTs * 1000).format("LLL") }}</span
         >
         <h2 class="textlabel flex items-center col-span-1 col-start-1">
           {{ $t("common.creator") }}
@@ -251,7 +251,9 @@ import {
 } from "../types";
 import { allTaskList, databaseSlug, isDBAOrOwner } from "../utils";
 import { useRouter } from "vue-router";
-import moment from "moment";
+import dayjs from "dayjs";
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
+dayjs.extend(isSameOrAfter);
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface LocalState {
@@ -474,7 +476,7 @@ export default defineComponent({
       }
     };
 
-    const isDayPassed = (ts: number) => !moment(ts).isSameOrAfter(now, "day");
+    const isDayPassed = (ts: number) => !dayjs(ts).isSameOrAfter(now, "day");
 
     return {
       EMPTY_ID,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,11 +1,12 @@
 import axios from "axios";
 import isEmpty from "lodash-es/isEmpty";
-import moment from "moment";
 import { createApp } from "vue";
+
 import App from "./App.vue";
 import i18n from "./plugins/i18n";
 import splitpanes from "./plugins/splitpanes";
 import NaiveUI from "./plugins/naive-ui";
+import dayjs from "./plugins/dayjs";
 import "./assets/css/inter.css";
 import "./assets/css/tailwind.css";
 
@@ -117,7 +118,7 @@ Promise.all([
   // Allow template to access various function
   app.config.globalProperties.window = window;
   app.config.globalProperties.console = console;
-  app.config.globalProperties.moment = moment;
+  app.config.globalProperties.dayjs = dayjs;
   app.config.globalProperties.humanizeTs = humanizeTs;
   app.config.globalProperties.isDev = isDev();
   app.config.globalProperties.isRelease = isRelease();

--- a/frontend/src/plugins/dayjs.ts
+++ b/frontend/src/plugins/dayjs.ts
@@ -1,0 +1,6 @@
+import dayjs from "dayjs";
+
+import LocalizedFormat from "dayjs/plugin/LocalizedFormat";
+dayjs.extend(LocalizedFormat);
+
+export default dayjs;

--- a/frontend/src/shims-vue-globals.d.ts
+++ b/frontend/src/shims-vue-globals.d.ts
@@ -11,14 +11,14 @@ import type {
   sizeToFit,
   urlfy,
 } from "./utils";
-import type moment from "moment";
+import type dayjs from "dayjs";
 import type { isEmpty } from "lodash-es";
 
 declare module "@vue/runtime-core" {
   export interface ComponentCustomProperties {
     window: Window & typeof globalThis;
     console: Console;
-    moment: typeof moment;
+    dayjs: typeof dayjs;
     humanizeTs: typeof humanizeTs;
     isDev: boolean;
     isRelease: boolean;

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -1,4 +1,11 @@
-import moment from "moment";
+import dayjs from "dayjs";
+import dayOfYear from "dayjs/plugin/dayOfYear";
+import duration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+dayjs.extend(dayOfYear);
+dayjs.extend(duration);
+dayjs.extend(relativeTime);
 
 export function isDev(): boolean {
   return import.meta.env.DEV;
@@ -9,12 +16,12 @@ export function isRelease(): boolean {
 }
 
 export function humanizeTs(ts: number): string {
-  const time = moment.utc(ts * 1000);
-  if (moment().year() == time.year()) {
-    if (moment().dayOfYear() == time.dayOfYear()) {
+  const time = dayjs.utc(ts * 1000);
+  if (dayjs().year() == time.year()) {
+    if (dayjs().dayOfYear() == time.dayOfYear()) {
       return time.local().format("HH:mm");
     }
-    if (moment().diff(time, "days") < 3) {
+    if (dayjs().diff(time, "days") < 3) {
       return time.local().format("MMM D HH:mm");
     }
     return time.local().format("MMM D");
@@ -35,7 +42,7 @@ export function bytesToString(size: number): string {
 }
 
 export function secondsToString(second: number): string {
-  return moment.duration(second).humanize();
+  return dayjs.duration(second).humanize();
 }
 
 export function timezoneString(zoneName: string, offset: number): string {

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -2,10 +2,12 @@ import dayjs from "dayjs";
 import dayOfYear from "dayjs/plugin/dayOfYear";
 import duration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
+import utc from "dayjs/plugin/utc";
 
 dayjs.extend(dayOfYear);
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 export function isDev(): boolean {
   return import.meta.env.DEV;

--- a/frontend/src/views/MigrationHistoryDetail.vue
+++ b/frontend/src/views/MigrationHistoryDetail.vue
@@ -3,19 +3,14 @@
     <main class="flex-1 relative pb-8 overflow-y-auto">
       <!-- Highlight Panel -->
       <div
-        class="
-          px-4
-          pb-4
-          border-b border-block-border
-          md:flex md:items-center md:justify-between
-        "
+        class="px-4 pb-4 border-b border-block-border md:flex md:items-center md:justify-between"
       >
         <div class="flex-1 min-w-0 space-y-3">
           <!-- Summary -->
           <div class="pt-2 flex items-center space-x-2">
             <MigrationHistoryStatusIcon :status="migrationHistory.status" />
             <h1 class="text-xl font-bold leading-6 text-main truncate">
-              {{ $t('common.version') }} {{ migrationHistory.version }}
+              {{ $t("common.version") }} {{ migrationHistory.version }}
             </h1>
           </div>
           <p class="text-control">
@@ -23,15 +18,13 @@
             {{ migrationHistory.description }}
           </p>
           <dl
-            class="
-              flex flex-col
-              space-y-1
-              md:space-y-0 md:flex-row md:flex-wrap
-            "
+            class="flex flex-col space-y-1 md:space-y-0 md:flex-row md:flex-wrap"
           >
-            <dt class="sr-only">{{ $t('common.issue') }}</dt>
+            <dt class="sr-only">{{ $t("common.issue") }}</dt>
             <dd class="flex items-center text-sm md:mr-4">
-              <span class="textlabel">{{ $t('common.issue') }}&nbsp;-&nbsp;</span>
+              <span class="textlabel"
+                >{{ $t("common.issue") }}&nbsp;-&nbsp;</span
+              >
               <router-link
                 :to="`/issue/${migrationHistory.issueId}`"
                 class="normal-link"
@@ -39,32 +32,32 @@
                 {{ migrationHistory.issueId }}
               </router-link>
             </dd>
-            <dt class="sr-only">{{ $t('common.duration') }}</dt>
+            <dt class="sr-only">{{ $t("common.duration") }}</dt>
             <dd class="flex items-center text-sm md:mr-4">
-              <span class="textlabel">{{ $t('common.duration') }}&nbsp;-&nbsp;</span>
+              <span class="textlabel"
+                >{{ $t("common.duration") }}&nbsp;-&nbsp;</span
+              >
               {{ secondsToString(migrationHistory.executionDuration) }}
             </dd>
-            <dt class="sr-only">{{ $t('common.creator') }}</dt>
+            <dt class="sr-only">{{ $t("common.creator") }}</dt>
             <dd class="flex items-center text-sm md:mr-4">
-              <span class="textlabel">{{ $t('common.creator') }}&nbsp;-&nbsp;</span>
+              <span class="textlabel"
+                >{{ $t("common.creator") }}&nbsp;-&nbsp;</span
+              >
               {{ migrationHistory.creator }}
             </dd>
-            <dt class="sr-only">{{ $t('common.created-at') }}</dt>
+            <dt class="sr-only">{{ $t("common.created-at") }}</dt>
             <dd class="flex items-center text-sm md:mr-4">
-              <span class="textlabel">{{ $t('common.created-at') }}&nbsp;-&nbsp;</span>
+              <span class="textlabel"
+                >{{ $t("common.created-at") }}&nbsp;-&nbsp;</span
+              >
               {{ humanizeTs(migrationHistory.createdTs) }} by
               {{ `version ${migrationHistory.releaseVersion}` }}
             </dd>
           </dl>
           <div
             v-if="pushEvent"
-            class="
-              mt-1
-              text-sm text-control-light
-              flex flex-row
-              items-center
-              space-x-1
-            "
+            class="mt-1 text-sm text-control-light flex flex-row items-center space-x-1"
           >
             <template v-if="pushEvent?.vcsType.startsWith('GITLAB')">
               <img class="h-4 w-auto" src="../assets/gitlab-logo.svg" />
@@ -73,7 +66,7 @@
               {{ `${vcsBranch}@${pushEvent.repositoryFullPath}` }}
             </a>
             <span>
-              {{ $t('common.commit') }}
+              {{ $t("common.commit") }}
               <a
                 :href="pushEvent.fileCommit.url"
                 target="_blank"
@@ -82,13 +75,15 @@
                 {{ pushEvent.fileCommit.id.substring(0, 7) }}:
               </a>
               <span class="text-main">{{ pushEvent.fileCommit.title }}</span>
-              <i18n-t keypath="migration-history.commit-info" >
-                <template v-slot:author>
+              <i18n-t keypath="migration-history.commit-info">
+                <template #author>
                   {{ pushEvent.authorName }}
-                 </template>
-                <template v-slot:time>
-                  {{ moment(pushEvent.fileCommit.createdTs * 1000).format("LLL")  }}
-                 </template>
+                </template>
+                <template #time>
+                  {{
+                    dayjs(pushEvent.fileCommit.createdTs * 1000).format("LLL")
+                  }}
+                </template>
               </i18n-t>
             </span>
           </div>
@@ -101,7 +96,7 @@
           href="#statement"
           class="flex items-center text-lg text-main mb-2 hover:underline"
         >
-          {{ $t('common.statement') }}
+          {{ $t("common.statement") }}
           <button
             tabindex="-1"
             class="btn-icon ml-1"
@@ -118,7 +113,7 @@
           href="#schema"
           class="flex items-center text-lg text-main mt-6 hover:underline capitalize"
         >
-          Schema {{ $t('common.snapshot') }}
+          Schema {{ $t("common.snapshot") }}
           <button
             tabindex="-1"
             class="btn-icon ml-1"
@@ -133,7 +128,7 @@
             :label="$t('migration-history.show-diff')"
             :value="state.showDiff"
             @toggle="
-              (on) => {
+              (on: any) => {
                 state.showDiff = on;
               }
             "
@@ -141,15 +136,15 @@
           <div class="textinfolabel">
             {{
               state.showDiff
-                ? $t('migration-history.left-vs-right')
-                : $t('migration-history.schema-snapshot-after-migration')
+                ? $t("migration-history.left-vs-right")
+                : $t("migration-history.schema-snapshot-after-migration")
             }}
           </div>
           <div
             v-if="migrationHistory.schemaPrev == migrationHistory.schema"
             class="text-sm font-normal text-accent"
           >
-            ({{ $t('migration-history.no-schema-change') }})
+            ({{ $t("migration-history.no-schema-change") }})
           </div>
         </div>
         <code-diff
@@ -172,7 +167,7 @@
 </template>
 
 <script lang="ts">
-import { computed, reactive } from "vue";
+import { computed, reactive, defineComponent } from "vue";
 import { useStore } from "vuex";
 import { toClipboard } from "@soerenmartius/vue3-clipboard";
 import { CodeDiff } from "v-code-diff";
@@ -188,7 +183,7 @@ interface LocalState {
   showDiff: boolean;
 }
 
-export default {
+export default defineComponent({
   name: "MigrationHistoryDetail",
   components: { CodeDiff, MigrationHistoryStatusIcon },
   props: {
@@ -277,5 +272,5 @@ export default {
       copySchema,
     };
   },
-};
+});
 </script>

--- a/frontend/test/dayjs.test.ts
+++ b/frontend/test/dayjs.test.ts
@@ -1,0 +1,70 @@
+import moment from "moment";
+import dayjs from "dayjs";
+
+import utc from "dayjs/plugin/utc";
+import LocalizedFormat from "dayjs/plugin/LocalizedFormat";
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
+import dayOfYear from "dayjs/plugin/dayOfYear";
+import duration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+dayjs.extend(utc);
+dayjs.extend(LocalizedFormat);
+dayjs.extend(isSameOrAfter);
+dayjs.extend(dayOfYear);
+dayjs.extend(duration);
+dayjs.extend(relativeTime);
+
+const TS = 60 * 1000;
+const now = new Date();
+
+test("UTC Local format", () => {
+  expect(dayjs.utc().local().format("YYYYMMDDTHHmmss")).toEqual(
+    moment.utc().local().format("YYYYMMDDTHHmmss")
+  );
+  expect(dayjs.utc(TS).local().format("HH:mm")).toEqual(
+    moment.utc(TS).local().format("HH:mm")
+  );
+  expect(dayjs.utc(TS).local().format("MMM D HH:mm")).toEqual(
+    moment.utc(TS).local().format("MMM D HH:mm")
+  );
+  expect(dayjs.utc(TS).local().format("MMM D")).toEqual(
+    moment.utc(TS).local().format("MMM D")
+  );
+  expect(dayjs.utc(TS).local().format("MMM D YYYY")).toEqual(
+    moment.utc(TS).local().format("MMM D YYYY")
+  );
+});
+
+test("year", () => {
+  expect(dayjs().year()).toEqual(moment().year());
+});
+
+test("dayOfYear", () => {
+  expect(dayjs().dayOfYear()).toEqual(moment().dayOfYear());
+});
+
+test("diff", () => {
+  expect(dayjs().diff(dayjs("2021-12-25"), "days")).toEqual(
+    moment().diff(moment("2021-12-25"), "days")
+  );
+});
+
+test("format LLL", () => {
+  expect(dayjs(TS).format("LLL")).toEqual(moment(TS).format("LLL"));
+});
+
+test("isSameOrAfter", () => {
+  // expect false
+  expect(dayjs("2021-12-25").isSameOrAfter(now, "day")).toEqual(
+    moment(moment("2021-12-25")).isSameOrAfter(now, "day")
+  );
+  // expect true
+  expect(dayjs("2022-02-01").isSameOrAfter(now, "day")).toEqual(
+    moment(moment("2022-02-01")).isSameOrAfter(now, "day")
+  );
+});
+
+test("duration", () => {
+  expect(dayjs.duration(TS).humanize()).toEqual(moment.duration(TS).humanize());
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -57,5 +57,9 @@ export default defineConfig(() => {
         "@/": `${resolve(__dirname, "src")}/`,
       },
     },
+    test: {
+      global: true,
+      environment: "node",
+    },
   };
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -298,6 +298,18 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
+  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
+
 "@types/http-cache-semantics@*":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
@@ -872,6 +884,11 @@ assert-never@^1.2.1:
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 async-exit-hook@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
@@ -1049,6 +1066,18 @@ caniuse-lite@^1.0.30001272, caniuse-lite@^1.0.30001280:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz#8573685bdae4d733ef18f78d44ba0ca5fe9e896b"
   integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
 
+chai@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
+  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1088,6 +1117,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chokidar@^3.5.2:
   version "3.5.2"
@@ -1364,6 +1398,13 @@ decompress-response@^5.0.0:
   integrity sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==
   dependencies:
     mimic-response "^2.0.0"
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1655,7 +1696,7 @@ esbuild-windows-arm64@0.13.15:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz#482173070810df22a752c686509c370c3be3b3c3"
   integrity sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==
 
-esbuild@^0.13.2:
+esbuild@^0.13.12, esbuild@^0.13.2:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.13.15.tgz#db56a88166ee373f87dbb2d8798ff449e0450cdf"
   integrity sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==
@@ -2054,6 +2095,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-intrinsic@^1.0.2:
   version "1.1.1"
@@ -2882,6 +2928,11 @@ listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
+local-pkg@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.1.tgz#e7b0d7aa0b9c498a1110a5ac5b00ba66ef38cfff"
+  integrity sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -3564,6 +3615,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -3643,6 +3699,15 @@ postcss@^8.3.8:
   version "8.4.4"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.4.tgz#d53d4ec6a75fd62557a66bb41978bf47ff0c2869"
   integrity sha512-joU6fBsN6EIer28Lj6GDFoC/5yOZzLCfn0zHAn/MYXI7aPt4m4hK5KC5ovEZXy+lnCjmYIbQWngvju2ddyEr8Q==
+  dependencies:
+    nanoid "^3.1.30"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.1"
+
+postcss@^8.4.5:
+  version "8.4.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95"
+  integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
   dependencies:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
@@ -4025,6 +4090,13 @@ rollup@^2.57.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rollup@^2.59.0:
+  version "2.63.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.63.0.tgz#fe2f7fec2133f3fab9e022b9ac245628d817c6bb"
+  integrity sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -4373,6 +4445,16 @@ tiny-invariant@^1.2.0:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
 
+tinypool@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.1.tgz#99eaf29d030feeca2da6c1d6b33f90fc18093bc7"
+  integrity sha512-sW2fQZ2BRb/GX5v55NkHiTrbMLx0eX0xNpP+VGhOe2f7Oo04+LeClDyM19zCE/WCy7jJ8kzIJ0Ojrxj3UhN9Sg==
+
+tinyspy@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.2.8.tgz#b821b3d43a7d5ae47bc575a5d8627e84fdf4e809"
+  integrity sha512-4VXqQzzh9gC5uOLk77cLr9R3wqJq07xJlgM9IUdCNJCet139r+046ETKbU1x7mGs7B0k7eopyH5U6yflbBXNyA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -4442,6 +4524,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.10.0:
   version "0.10.0"
@@ -4617,6 +4704,18 @@ vite-plugin-icons@^0.6.5:
     "@iconify/json-tools" "^1.0.10"
     vue-template-es2015-compiler "^1.9.1"
 
+vite@>=2.7.10:
+  version "2.7.10"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.7.10.tgz#d12c4c10e56a0ecf7890cb529c15996c6111218f"
+  integrity sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==
+  dependencies:
+    esbuild "^0.13.12"
+    postcss "^8.4.5"
+    resolve "^1.20.0"
+    rollup "^2.59.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 vite@^2.6.14:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.6.14.tgz#35c09a15e4df823410819a2a239ab11efb186271"
@@ -4628,6 +4727,19 @@ vite@^2.6.14:
     rollup "^2.57.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+vitest@^0.0.139:
+  version "0.0.139"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.0.139.tgz#5a0a29181be27e27fe9582e12d41685c0d4095fe"
+  integrity sha512-5AXMaEOJXgQpobgXkzBPGP8o4NpAhT2yczeRD1V94U0VWGxRObI1zjqtxBPEtgda8Q4rQKw0SVlHCR0P76h9QA==
+  dependencies:
+    "@types/chai" "^4.3.0"
+    "@types/chai-subset" "^1.3.3"
+    chai "^4.3.4"
+    local-pkg "^0.4.1"
+    tinypool "^0.1.1"
+    tinyspy "^0.2.8"
+    vite ">=2.7.10"
 
 void-elements@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Add the complete test case in `/frontend/test/dayjs.test.ts`

After installing `vitest`, we can use the script: `yarn test` to test the API conformance of `dayjs` with `moment.js`

When merging this PR. Next time I will remove the dependency of moment.