### PR TITLE
fix: enabled timing task check only for schema update

### DIFF
--- a/server/task_check_executor_timing.go
+++ b/server/task_check_executor_timing.go
@@ -32,17 +32,6 @@ func (exec *TaskCheckTimingExecutor) Run(ctx context.Context, server *Server, ta
 		return []api.TaskCheckResult{}, common.Errorf(common.Invalid, fmt.Errorf("invalid check timing payload: %w", err))
 	}
 
-	if time.Now().Before(time.Unix(payload.EarliestAllowedTs, 0)) {
-		return []api.TaskCheckResult{
-			{
-				Status:  api.TaskCheckStatusError,
-				Code:    common.TaskTimingNotAllowed,
-				Title:   "Not ready to run",
-				Content: fmt.Sprintf("Need to wait until the configured earliest running time: %s", time.Unix(payload.EarliestAllowedTs, 0).Format(dataFormat)),
-			},
-		}, nil
-	}
-
 	if payload.EarliestAllowedTs == 0 {
 		return []api.TaskCheckResult{
 			{
@@ -50,6 +39,17 @@ func (exec *TaskCheckTimingExecutor) Run(ctx context.Context, server *Server, ta
 				Code:    common.Ok,
 				Title:   "OK",
 				Content: "Earliest allowed time unset",
+			},
+		}, nil
+	}
+
+	if time.Now().Before(time.Unix(payload.EarliestAllowedTs, 0)) {
+		return []api.TaskCheckResult{
+			{
+				Status:  api.TaskCheckStatusError,
+				Code:    common.TaskTimingNotAllowed,
+				Title:   "Not ready to run",
+				Content: fmt.Sprintf("Need to wait until the configured earliest running time: %s", time.Unix(payload.EarliestAllowedTs, 0).Format(dataFormat)),
 			},
 		}, nil
 	}

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -353,7 +353,7 @@ func (s *Server) passCheck(ctx context.Context, server *Server, task *api.Task, 
 			zap.Int("task_id", task.ID),
 			zap.String("task_name", task.Name),
 			zap.String("task_type", string(task.Type)),
-			zap.String("task_check_type", string(api.TaskCheckDatabaseConnect)),
+			zap.String("task_check_type", string(checkType)),
 		)
 		return false, nil
 	}

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -233,18 +233,18 @@ func (s *TaskScheduler) Register(taskType string, executor TaskExecutor) {
 
 // ScheduleIfNeeded schedules the task if its required check does not contain error in the latest run
 func (s *TaskScheduler) ScheduleIfNeeded(ctx context.Context, task *api.Task) (*api.Task, error) {
-	// timing task check
-	pass, err := s.server.passCheck(ctx, s.server, task, api.TaskCheckGeneralEarliestAllowedTime)
-	if err != nil {
-		return nil, err
-	}
-	if !pass {
-		return task, nil
-	}
-
 	// only schema update task has required task check
 	if task.Type == api.TaskDatabaseSchemaUpdate {
-		pass, err := s.server.passCheck(ctx, s.server, task, api.TaskCheckDatabaseConnect)
+		// timing task check
+		pass, err := s.server.passCheck(ctx, s.server, task, api.TaskCheckGeneralEarliestAllowedTime)
+		if err != nil {
+			return nil, err
+		}
+		if !pass {
+			return task, nil
+		}
+
+		pass, err = s.server.passCheck(ctx, s.server, task, api.TaskCheckDatabaseConnect)
 		if err != nil {
 			return nil, err
 		}

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -233,9 +233,8 @@ func (s *TaskScheduler) Register(taskType string, executor TaskExecutor) {
 
 // ScheduleIfNeeded schedules the task if its required check does not contain error in the latest run
 func (s *TaskScheduler) ScheduleIfNeeded(ctx context.Context, task *api.Task) (*api.Task, error) {
-	// only schema update task has required task check
-	if task.Type == api.TaskDatabaseSchemaUpdate {
-		// timing task check
+	// timing task check
+	if task.EarliestAllowedTs != 0 {
 		pass, err := s.server.passCheck(ctx, s.server, task, api.TaskCheckGeneralEarliestAllowedTime)
 		if err != nil {
 			return nil, err
@@ -243,8 +242,11 @@ func (s *TaskScheduler) ScheduleIfNeeded(ctx context.Context, task *api.Task) (*
 		if !pass {
 			return task, nil
 		}
+	}
 
-		pass, err = s.server.passCheck(ctx, s.server, task, api.TaskCheckDatabaseConnect)
+	// only schema update task has required task check
+	if task.Type == api.TaskDatabaseSchemaUpdate {
+		pass, err := s.server.passCheck(ctx, s.server, task, api.TaskCheckDatabaseConnect)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Before this PR, all tasks need to pass timing task check during scheduling, and the logic in the task check will block this task from being scheduled. 



