### PR TITLE
feat: backend support for data migration (DML change)

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -29,8 +29,10 @@ const (
 	IssueDatabaseCreate IssueType = "bb.issue.database.create"
 	// IssueDatabaseGrant is the issue type for granting databases.
 	IssueDatabaseGrant IssueType = "bb.issue.database.grant"
-	// IssueDatabaseSchemaUpdate is the issue type for updating database schemas.
+	// IssueDatabaseSchemaUpdate is the issue type for updating database schemas (DDL).
 	IssueDatabaseSchemaUpdate IssueType = "bb.issue.database.schema.update"
+	// IssueDatabaseDataUpdate is the issue type for updating database data (DML).
+	IssueDatabaseDataUpdate IssueType = "bb.issue.database.data.update"
 	// IssueDataSourceRequest is the issue type for requesting database sources.
 	IssueDataSourceRequest IssueType = "bb.issue.data-source.request"
 )

--- a/api/task.go
+++ b/api/task.go
@@ -63,6 +63,8 @@ const (
 	TaskDatabaseCreate TaskType = "bb.task.database.create"
 	// TaskDatabaseSchemaUpdate is the task type for updating database schemas.
 	TaskDatabaseSchemaUpdate TaskType = "bb.task.database.schema.update"
+	// TaskDatabaseDataUpdate is the task type for updating database data.
+	TaskDatabaseDataUpdate TaskType = "bb.task.database.data.update"
 	// TaskDatabaseBackup is the task type for creating database backups.
 	TaskDatabaseBackup TaskType = "bb.task.database.backup"
 	// TaskDatabaseRestore is the task type for restoring databases.
@@ -85,9 +87,16 @@ type TaskDatabaseCreatePayload struct {
 	SchemaVersion string `json:"schemaVersion,omitempty"`
 }
 
-// TaskDatabaseSchemaUpdatePayload is the task payload for database schema update.
+// TaskDatabaseSchemaUpdatePayload is the task payload for database schema update (DDL).
 type TaskDatabaseSchemaUpdatePayload struct {
 	MigrationType     db.MigrationType  `json:"migrationType,omitempty"`
+	Statement         string            `json:"statement,omitempty"`
+	RollbackStatement string            `json:"rollbackStatement,omitempty"`
+	VCSPushEvent      *vcs.VCSPushEvent `json:"pushEvent,omitempty"`
+}
+
+// TaskDatabaseDataUpdatePayload is the task payload for database data update (DML).
+type TaskDatabaseDataUpdatePayload struct {
 	Statement         string            `json:"statement,omitempty"`
 	RollbackStatement string            `json:"rollbackStatement,omitempty"`
 	VCSPushEvent      *vcs.VCSPushEvent `json:"pushEvent,omitempty"`

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -376,6 +376,7 @@ type Driver interface {
 	// Create or upgrade migration related tables
 	SetupMigrationIfNeeded(ctx context.Context) error
 	// Execute migration will apply the statement and record the migration history, the schema after migration on success.
+	// The migration type is determined by m.Type. Note, it can also perform data migration (DML) in addition to schema migration (DDL).
 	// It returns the migration history id and the schema after migration on success.
 	ExecuteMigration(ctx context.Context, m *MigrationInfo, statement string) (int64, string, error)
 	// Find the migration history list and return most recent item first.

--- a/plugin/db/mysql/mysql_migration_schema.sql
+++ b/plugin/db/mysql/mysql_migration_schema.sql
@@ -45,8 +45,8 @@ CREATE TABLE bytebase.migration_history (
 
 CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_sequence ON bytebase.migration_history (namespace(256), sequence);
 
-CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_engine_version ON bytebase.migration_history (namespace(256), engine, version(256));
+CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_engine_version ON bytebase.migration_history (namespace(256), engine(256), version(256));
 
-CREATE INDEX bytebase_idx_migration_history_namespace_engine_type ON bytebase.migration_history(namespace(256), engine, type);
+CREATE INDEX bytebase_idx_migration_history_namespace_engine_type ON bytebase.migration_history(namespace(256), engine(256), type(256));
 
 CREATE INDEX bytebase_idx_migration_history_namespace_created ON bytebase.migration_history(namespace(256), `created_ts`);

--- a/server/issue.go
+++ b/server/issue.go
@@ -375,12 +375,8 @@ func (s *Server) createIssue(ctx context.Context, issueCreate *api.IssueCreate, 
 					payload := api.TaskDatabaseSchemaUpdatePayload{}
 					payload.MigrationType = taskCreate.MigrationType
 					payload.Statement = taskCreate.Statement
-					if taskCreate.RollbackStatement != "" {
-						payload.RollbackStatement = taskCreate.RollbackStatement
-					}
-					if taskCreate.VCSPushEvent != nil {
-						payload.VCSPushEvent = taskCreate.VCSPushEvent
-					}
+					payload.RollbackStatement = taskCreate.RollbackStatement
+					payload.VCSPushEvent = taskCreate.VCSPushEvent
 					bytes, err := json.Marshal(payload)
 					if err != nil {
 						return nil, fmt.Errorf("failed to create schema update task, unable to marshal payload %w", err)
@@ -389,12 +385,8 @@ func (s *Server) createIssue(ctx context.Context, issueCreate *api.IssueCreate, 
 				} else if taskCreate.Type == api.TaskDatabaseDataUpdate {
 					payload := api.TaskDatabaseDataUpdatePayload{}
 					payload.Statement = taskCreate.Statement
-					if taskCreate.RollbackStatement != "" {
-						payload.RollbackStatement = taskCreate.RollbackStatement
-					}
-					if taskCreate.VCSPushEvent != nil {
-						payload.VCSPushEvent = taskCreate.VCSPushEvent
-					}
+					payload.RollbackStatement = taskCreate.RollbackStatement
+					payload.VCSPushEvent = taskCreate.VCSPushEvent
 					bytes, err := json.Marshal(payload)
 					if err != nil {
 						return nil, fmt.Errorf("failed to create data update task, unable to marshal payload %w", err)
@@ -767,7 +759,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 
 		// Tenant mode project pipeline has its own generation.
 		if project.TenantMode == api.TenantModeTenant {
-			if m.MigrationType != db.Migrate || m.MigrationType != db.Data {
+			if m.MigrationType != db.Migrate {
 				return nil, echo.NewHTTPError(http.StatusBadRequest, "Only Migrate type migration can be performed on tenant mode project")
 			}
 			if len(m.UpdateSchemaDetailList) != 1 {

--- a/server/issue.go
+++ b/server/issue.go
@@ -386,6 +386,20 @@ func (s *Server) createIssue(ctx context.Context, issueCreate *api.IssueCreate, 
 						return nil, fmt.Errorf("failed to create schema update task, unable to marshal payload %w", err)
 					}
 					taskCreate.Payload = string(bytes)
+				} else if taskCreate.Type == api.TaskDatabaseDataUpdate {
+					payload := api.TaskDatabaseDataUpdatePayload{}
+					payload.Statement = taskCreate.Statement
+					if taskCreate.RollbackStatement != "" {
+						payload.RollbackStatement = taskCreate.RollbackStatement
+					}
+					if taskCreate.VCSPushEvent != nil {
+						payload.VCSPushEvent = taskCreate.VCSPushEvent
+					}
+					bytes, err := json.Marshal(payload)
+					if err != nil {
+						return nil, fmt.Errorf("failed to create data update task, unable to marshal payload %w", err)
+					}
+					taskCreate.Payload = string(bytes)
 				} else if taskCreate.Type == api.TaskDatabaseRestore {
 					// Snowflake needs to use upper case of DatabaseName.
 					if instance.Engine == db.Snowflake {
@@ -730,6 +744,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 			}
 		}
 	case api.IssueDatabaseSchemaUpdate:
+	case api.IssueDatabaseDataUpdate:
 		m := api.UpdateSchemaContext{}
 		if err := json.Unmarshal([]byte(issueCreate.CreateContext), &m); err != nil {
 			return nil, err
@@ -740,6 +755,8 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 			pc.Name = "Establish database baseline pipeline"
 		case db.Migrate:
 			pc.Name = "Update database schema pipeline"
+		case db.Data:
+			pc.Name = "Update database data pipeline"
 		default:
 			return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid migration type %q", m.MigrationType))
 		}
@@ -750,7 +767,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 
 		// Tenant mode project pipeline has its own generation.
 		if project.TenantMode == api.TenantModeTenant {
-			if m.MigrationType != db.Migrate {
+			if m.MigrationType != db.Migrate || m.MigrationType != db.Data {
 				return nil, echo.NewHTTPError(http.StatusBadRequest, "Only Migrate type migration can be performed on tenant mode project")
 			}
 			if len(m.UpdateSchemaDetailList) != 1 {
@@ -780,7 +797,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 				for _, database := range stage {
 					environmentSet[database.Instance.Environment.Name] = true
 					environmentID = database.Instance.EnvironmentID
-					taskCreate, err := getSchemaUpdateTask(database, m.MigrationType, m.VCSPushEvent, d)
+					taskCreate, err := getUpdateTask(database, m.MigrationType, m.VCSPushEvent, d)
 					if err != nil {
 						return nil, err
 					}
@@ -791,7 +808,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 					for k := range environmentSet {
 						environments = append(environments, k)
 					}
-					err := fmt.Errorf("All databases in a stage should have the same environment; got %s", strings.Join(environments, ","))
+					err := fmt.Errorf("all databases in a stage should have the same environment; got %s", strings.Join(environments, ","))
 					return nil, echo.NewHTTPError(http.StatusInternalServerError, err.Error()).SetInternal(err)
 				}
 
@@ -818,7 +835,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 					return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database ID not found: %d", d.DatabaseID))
 				}
 
-				taskCreate, err := getSchemaUpdateTask(database, m.MigrationType, m.VCSPushEvent, d)
+				taskCreate, err := getUpdateTask(database, m.MigrationType, m.VCSPushEvent, d)
 				if err != nil {
 					return nil, err
 				}
@@ -866,10 +883,12 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 	return createdPipeline, nil
 }
 
-func getSchemaUpdateTask(database *api.Database, migrationType db.MigrationType, vcsPushEvent *vcs.VCSPushEvent, d *api.UpdateSchemaDetail) (*api.TaskCreate, error) {
+func getUpdateTask(database *api.Database, migrationType db.MigrationType, vcsPushEvent *vcs.VCSPushEvent, d *api.UpdateSchemaDetail) (*api.TaskCreate, error) {
 	taskName := fmt.Sprintf("Establish %q baseline", database.Name)
 	if migrationType == db.Migrate {
 		taskName = fmt.Sprintf("Update %q schema", database.Name)
+	} else if migrationType == db.Data {
+		taskName = fmt.Sprintf("Update %q data", database.Name)
 	}
 	payload := api.TaskDatabaseSchemaUpdatePayload{}
 	payload.MigrationType = migrationType
@@ -882,15 +901,23 @@ func getSchemaUpdateTask(database *api.Database, migrationType db.MigrationType,
 	}
 	bytes, err := json.Marshal(payload)
 	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to marshal database schema update payload: %v", err))
+		errMsg := fmt.Sprintf("Failed to marshal database schema update payload: %v", err)
+		if migrationType == db.Data {
+			errMsg = fmt.Sprintf("Failed to marshal database data update payload: %v", err)
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, errMsg)
 	}
 
+	taskType := api.TaskDatabaseSchemaUpdate
+	if migrationType == db.Data {
+		taskType = api.TaskDatabaseDataUpdate
+	}
 	return &api.TaskCreate{
 		Name:              taskName,
 		InstanceID:        database.Instance.ID,
 		DatabaseID:        &database.ID,
 		Status:            api.TaskPendingApproval,
-		Type:              api.TaskDatabaseSchemaUpdate,
+		Type:              taskType,
 		Statement:         d.Statement,
 		RollbackStatement: d.RollbackStatement,
 		EarliestAllowedTs: d.EarliestAllowedTs,

--- a/server/server.go
+++ b/server/server.go
@@ -135,8 +135,11 @@ func NewServer(logger *zap.Logger, version string, host string, port int, fronte
 		createDBExecutor := NewDatabaseCreateTaskExecutor(logger)
 		taskScheduler.Register(string(api.TaskDatabaseCreate), createDBExecutor)
 
-		sqlExecutor := NewSchemaUpdateTaskExecutor(logger)
-		taskScheduler.Register(string(api.TaskDatabaseSchemaUpdate), sqlExecutor)
+		schemaUpdateExecutor := NewSchemaUpdateTaskExecutor(logger)
+		taskScheduler.Register(string(api.TaskDatabaseSchemaUpdate), schemaUpdateExecutor)
+
+		dataUpdateExecutor := NewDataUpdateTaskExecutor(logger)
+		taskScheduler.Register(string(api.TaskDatabaseDataUpdate), dataUpdateExecutor)
 
 		backupDBExecutor := NewDatabaseBackupTaskExecutor(logger)
 		taskScheduler.Register(string(api.TaskDatabaseBackup), backupDBExecutor)

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -2,11 +2,18 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/bytebase/bytebase/plugin/vcs"
+	"go.uber.org/zap"
 )
 
 // TaskExecutor is the task executor.
@@ -25,4 +32,323 @@ type TaskExecutor interface {
 // Use the concatenation of current time and the task id to guarantee uniqueness in a monotonic increasing way.
 func defaultMigrationVersionFromTaskID(taskID int) string {
 	return strings.Join([]string{time.Now().Format("20060102150405"), strconv.Itoa(taskID)}, ".")
+}
+
+func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.Task, migrationType db.MigrationType, statement string, vcsPushEvent *vcs.VCSPushEvent) (terminated bool, result *api.TaskRunResultPayload, err error) {
+	if task.Database == nil {
+		msg := "missing database when updating schema"
+		if migrationType == db.Data {
+			msg = "missing database when updating data"
+		}
+		return true, nil, fmt.Errorf(msg)
+	}
+	databaseName := task.Database.Name
+
+	var repository *api.Repository
+	mi := &db.MigrationInfo{
+		ReleaseVersion: server.version,
+		Type:           migrationType,
+	}
+	if vcsPushEvent == nil {
+		mi.Engine = db.UI
+		creator, err := server.composePrincipalByID(ctx, task.CreatorID)
+		if err != nil {
+			// If somehow we unable to find the principal, we just emit the error since it's not
+			// critical enough to fail the entire operation.
+			l.Error("Failed to fetch creator for composing the migration info",
+				zap.Int("task_id", task.ID),
+				zap.Error(err),
+			)
+		} else {
+			mi.Creator = creator.Name
+		}
+		mi.Version = defaultMigrationVersionFromTaskID(task.ID)
+		mi.Database = databaseName
+		mi.Namespace = databaseName
+		mi.Description = task.Name
+	} else {
+		repositoryFind := &api.RepositoryFind{
+			ProjectID: &task.Database.ProjectID,
+		}
+		repository, err = server.RepositoryService.FindRepository(ctx, repositoryFind)
+		if err != nil {
+			return true, nil, fmt.Errorf("failed to find linked repository for database %q", databaseName)
+		}
+		if repository == nil {
+			return true, nil, fmt.Errorf("repository not found with project ID %v", task.Database.ProjectID)
+		}
+
+		mi, err = db.ParseMigrationInfo(
+			vcsPushEvent.FileCommit.Added,
+			filepath.Join(vcsPushEvent.BaseDirectory, repository.FilePathTemplate),
+		)
+		// This should not happen normally as we already check this when creating the issue. Just in case.
+		if err != nil {
+			return true, nil, fmt.Errorf("failed to start migration, error: %w", err)
+		}
+		mi.Creator = vcsPushEvent.FileCommit.AuthorName
+
+		miPayload := &db.MigrationInfoPayload{
+			VCSPushEvent: vcsPushEvent,
+		}
+		bytes, err := json.Marshal(miPayload)
+		if err != nil {
+			return true, nil, fmt.Errorf("failed to start migration, unable to marshal vcs push event payload %w", err)
+		}
+		mi.Payload = string(bytes)
+	}
+
+	issueFind := &api.IssueFind{
+		PipelineID: &task.PipelineID,
+	}
+	issue, err := server.IssueService.FindIssue(ctx, issueFind)
+	if err != nil {
+		// If somehow we unable to find the issue, we just emit the error since it's not
+		// critical enough to fail the entire operation.
+		l.Error("Failed to fetch containing issue for composing the migration info",
+			zap.Int("task_id", task.ID),
+			zap.Error(err),
+		)
+	}
+
+	if issue == nil {
+		err := fmt.Errorf("failed to fetch containing issue for composing the migration info, issue not found with pipeline ID %v", task.PipelineID)
+		l.Error(err.Error(),
+			zap.Int("task_id", task.ID),
+			zap.Error(err),
+		)
+	} else {
+		mi.IssueID = strconv.Itoa(issue.ID)
+	}
+
+	statement = strings.TrimSpace(statement)
+	// Only baseline can have empty sql statement, which indicates empty database.
+	if mi.Type != db.Baseline && statement == "" {
+		return true, nil, fmt.Errorf("empty statement")
+	}
+
+	if err := server.composeTaskRelationship(ctx, task); err != nil {
+		return true, nil, err
+	}
+
+	driver, err := getDatabaseDriver(ctx, task.Instance, databaseName, l)
+	if err != nil {
+		return true, nil, err
+	}
+	defer driver.Close(ctx)
+
+	l.Debug("Start sql migration...",
+		zap.String("instance", task.Instance.Name),
+		zap.String("database", databaseName),
+		zap.String("engine", mi.Engine.String()),
+		zap.String("type", mi.Type.String()),
+		zap.String("statement", statement),
+	)
+
+	setup, err := driver.NeedsSetupMigration(ctx)
+	if err != nil {
+		return true, nil, fmt.Errorf("failed to check migration setup for instance %q: %w", task.Instance.Name, err)
+	}
+	if setup {
+		return true, nil, common.Errorf(common.MigrationSchemaMissing, fmt.Errorf("missing migration schema for instance %q", task.Instance.Name))
+	}
+
+	migrationID, schema, err := driver.ExecuteMigration(ctx, mi, statement)
+	if err != nil {
+		return true, nil, err
+	}
+
+	// If VCS based and schema path template is specified, then we will write back the latest schema file after migration.
+	if vcsPushEvent != nil && repository.SchemaPathTemplate != "" {
+		latestSchemaFile := filepath.Join(repository.BaseDirectory, repository.SchemaPathTemplate)
+		latestSchemaFile = strings.ReplaceAll(latestSchemaFile, "{{ENV_NAME}}", mi.Environment)
+		latestSchemaFile = strings.ReplaceAll(latestSchemaFile, "{{DB_NAME}}", mi.Database)
+
+		repository.VCS, err = server.composeVCSByID(ctx, repository.VCSID)
+		if err != nil {
+			return true, nil, fmt.Errorf("failed to sync schema file %s after applying migration %s to %q", latestSchemaFile, mi.Version, databaseName)
+		}
+		if repository.VCS == nil {
+			return true, nil, fmt.Errorf("VCS ID not found: %d", repository.VCSID)
+		}
+
+		// Writes back the latest schema file to the same branch as the push event.
+		// Ref format refs/heads/<<branch>>
+		refComponents := strings.Split(vcsPushEvent.Ref, "/")
+		branch := refComponents[len(refComponents)-1]
+
+		bytebaseURL := ""
+		if issue != nil {
+			bytebaseURL = fmt.Sprintf("%s:%d/issue/%s?stage=%d", server.frontendHost, server.frontendPort, api.IssueSlug(issue), task.StageID)
+		}
+
+		commitID, err := writeBackLatestSchema(ctx, server, repository, vcsPushEvent, mi, branch, latestSchemaFile, schema, bytebaseURL)
+		if err != nil {
+			return true, nil, err
+		}
+
+		// Create file commit activity
+		{
+			payload, err := json.Marshal(api.ActivityPipelineTaskFileCommitPayload{
+				TaskID:             task.ID,
+				VCSInstanceURL:     repository.VCS.InstanceURL,
+				RepositoryFullPath: vcsPushEvent.RepositoryFullPath,
+				Branch:             branch,
+				FilePath:           latestSchemaFile,
+				CommitID:           commitID,
+			})
+			if err != nil {
+				l.Error("Failed to marshal file commit activity after writing back the latest schema",
+					zap.Int("task_id", task.ID),
+					zap.String("repository", repository.WebURL),
+					zap.String("file_path", latestSchemaFile),
+					zap.Error(err),
+				)
+			}
+
+			containerID := task.PipelineID
+			if issue != nil {
+				containerID = issue.ID
+			}
+			activityCreate := &api.ActivityCreate{
+				CreatorID:   task.CreatorID,
+				ContainerID: containerID,
+				Type:        api.ActivityPipelineTaskFileCommit,
+				Level:       api.ActivityInfo,
+				Comment: fmt.Sprintf("Committed the latest schema after applying migration version %s to %q.",
+					mi.Version,
+					mi.Database,
+				),
+				Payload: string(payload),
+			}
+
+			_, err = server.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{})
+			if err != nil {
+				l.Error("Failed to create file commit activity after writing back the latest schema",
+					zap.Int("task_id", task.ID),
+					zap.String("repository", repository.WebURL),
+					zap.String("file_path", latestSchemaFile),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+
+	detail := fmt.Sprintf("Applied migration version %s to database %q.", mi.Version, databaseName)
+	if mi.Type == db.Baseline {
+		detail = fmt.Sprintf("Established baseline version %s for database %q.", mi.Version, databaseName)
+	}
+
+	return true, &api.TaskRunResultPayload{
+		Detail:      detail,
+		MigrationID: migrationID,
+		Version:     mi.Version,
+	}, nil
+}
+
+// Writes back the latest schema to the repository after migration
+// Returns the commit id on success.
+func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.Repository, pushEvent *vcs.VCSPushEvent, mi *db.MigrationInfo, branch string, latestSchemaFile string, schema string, bytebaseURL string) (string, error) {
+	schemaFileMeta, err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).ReadFileMeta(
+		ctx,
+		common.OauthContext{
+			ClientID:     repository.VCS.ApplicationID,
+			ClientSecret: repository.VCS.Secret,
+			AccessToken:  repository.AccessToken,
+			RefreshToken: repository.RefreshToken,
+			Refresher:    server.refreshToken(ctx, repository.ID),
+		},
+		repository.VCS.InstanceURL,
+		repository.ExternalID,
+		latestSchemaFile,
+		branch,
+	)
+
+	createSchemaFile := false
+	verb := "Update"
+	if err != nil {
+		if common.ErrorCode(err) == common.NotFound {
+			createSchemaFile = true
+			verb = "Create"
+		} else {
+			return "", fmt.Errorf("failed to fetch latest schema: %w", err)
+		}
+	}
+
+	commitTitle := fmt.Sprintf("[Bytebase] %s latest schema for %q after migration %s", verb, mi.Database, mi.Version)
+	commitBody := "THIS COMMIT IS AUTO-GENERATED BY BTYEBASE"
+	if bytebaseURL != "" {
+		commitBody += "\n\n" + bytebaseURL
+	}
+	commitBody += "\n\n--------Original migration change--------\n\n"
+	commitBody += fmt.Sprintf("%s\n\n%s",
+		pushEvent.FileCommit.URL,
+		pushEvent.FileCommit.Message,
+	)
+
+	schemaFileCommit := vcs.FileCommitCreate{
+		Branch:        branch,
+		CommitMessage: fmt.Sprintf("%s\n\n%s", commitTitle, commitBody),
+		Content:       schema,
+	}
+	if createSchemaFile {
+		err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).CreateFile(
+			ctx,
+			common.OauthContext{
+				ClientID:     repository.VCS.ApplicationID,
+				ClientSecret: repository.VCS.Secret,
+				AccessToken:  repository.AccessToken,
+				RefreshToken: repository.RefreshToken,
+				Refresher:    server.refreshToken(ctx, repository.ID),
+			},
+			repository.VCS.InstanceURL,
+			repository.ExternalID,
+			latestSchemaFile,
+			schemaFileCommit,
+		)
+
+		if err != nil {
+			return "", fmt.Errorf("failed to create file after applying migration %s to %q: %w", mi.Version, mi.Database, err)
+		}
+	} else {
+		schemaFileCommit.LastCommitID = schemaFileMeta.LastCommitID
+		err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).OverwriteFile(
+			ctx,
+			common.OauthContext{
+				ClientID:     repository.VCS.ApplicationID,
+				ClientSecret: repository.VCS.Secret,
+				AccessToken:  repository.AccessToken,
+				RefreshToken: repository.RefreshToken,
+				Refresher:    server.refreshToken(ctx, repository.ID),
+			},
+			repository.VCS.InstanceURL,
+			repository.ExternalID,
+			latestSchemaFile,
+			schemaFileCommit,
+		)
+		if err != nil {
+			return "", fmt.Errorf("failed to create file after applying migration %s to %q: %w", mi.Version, mi.Database, err)
+		}
+	}
+
+	// VCS such as GitLab API doesn't return the commit on write, so we have to call ReadFileMeta again
+	schemaFileMeta, err = vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).ReadFileMeta(
+		ctx,
+		common.OauthContext{
+			ClientID:     repository.VCS.ApplicationID,
+			ClientSecret: repository.VCS.Secret,
+			AccessToken:  repository.AccessToken,
+			RefreshToken: repository.RefreshToken,
+			Refresher:    server.refreshToken(ctx, repository.ID),
+		},
+		repository.VCS.InstanceURL,
+		repository.ExternalID,
+		latestSchemaFile,
+		branch,
+	)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch latest schema file %s after update: %w", latestSchemaFile, err)
+	}
+	return schemaFileMeta.LastCommitID, nil
 }

--- a/server/task_executor_data_update.go
+++ b/server/task_executor_data_update.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/plugin/db"
+	"go.uber.org/zap"
+)
+
+// NewDataUpdateTaskExecutor creates a data update (DML) task executor.
+func NewDataUpdateTaskExecutor(logger *zap.Logger) TaskExecutor {
+	return &SchemaUpdateTaskExecutor{
+		l: logger,
+	}
+}
+
+// NewDataUpdateTaskExecutor is the data update (DML) task executor.
+type DataUpdateTaskExecutor struct {
+	l *zap.Logger
+}
+
+// RunOnce will run the data update (DML) task executor once.
+func (exec *DataUpdateTaskExecutor) RunOnce(ctx context.Context, server *Server, task *api.Task) (terminated bool, result *api.TaskRunResultPayload, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicErr, ok := r.(error)
+			if !ok {
+				panicErr = fmt.Errorf("%v", r)
+			}
+			exec.l.Error("DataUpdateTaskExecutor PANIC RECOVER", zap.Error(panicErr))
+			terminated = true
+			err = fmt.Errorf("encounter internal error when executing sql")
+		}
+	}()
+
+	payload := &api.TaskDatabaseDataUpdatePayload{}
+	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
+		return true, nil, fmt.Errorf("invalid database data update payload: %w", err)
+	}
+
+	return runMigration(ctx, exec.l, server, task, db.Data, payload.Statement, payload.VCSPushEvent)
+}

--- a/server/task_executor_schema_update.go
+++ b/server/task_executor_schema_update.go
@@ -4,30 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/plugin/db"
-	"github.com/bytebase/bytebase/plugin/vcs"
 	"go.uber.org/zap"
 )
 
-// NewSchemaUpdateTaskExecutor creates a schema update task executor.
+// NewSchemaUpdateTaskExecutor creates a schema update (DDL) task executor.
 func NewSchemaUpdateTaskExecutor(logger *zap.Logger) TaskExecutor {
 	return &SchemaUpdateTaskExecutor{
 		l: logger,
 	}
 }
 
-// SchemaUpdateTaskExecutor is the schema update task executor.
+// SchemaUpdateTaskExecutor is the schema update (DDL) task executor.
 type SchemaUpdateTaskExecutor struct {
 	l *zap.Logger
 }
 
-// RunOnce will run the schema update task executor once.
+// RunOnce will run the schema update (DDL) task executor once.
 func (exec *SchemaUpdateTaskExecutor) RunOnce(ctx context.Context, server *Server, task *api.Task) (terminated bool, result *api.TaskRunResultPayload, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -41,321 +35,10 @@ func (exec *SchemaUpdateTaskExecutor) RunOnce(ctx context.Context, server *Serve
 		}
 	}()
 
-	if task.Database == nil {
-		return true, nil, fmt.Errorf("missing database when updating schema")
-	}
-	databaseName := task.Database.Name
-
 	payload := &api.TaskDatabaseSchemaUpdatePayload{}
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
 		return true, nil, fmt.Errorf("invalid database schema update payload: %w", err)
 	}
 
-	var repository *api.Repository
-	mi := &db.MigrationInfo{
-		ReleaseVersion: server.version,
-		Type:           payload.MigrationType,
-	}
-	if payload.VCSPushEvent == nil {
-		mi.Engine = db.UI
-		creator, err := server.composePrincipalByID(ctx, task.CreatorID)
-		if err != nil {
-			// If somehow we unable to find the principal, we just emit the error since it's not
-			// critical enough to fail the entire operation.
-			exec.l.Error("Failed to fetch creator for composing the migration info",
-				zap.Int("task_id", task.ID),
-				zap.Error(err),
-			)
-		} else {
-			mi.Creator = creator.Name
-		}
-		mi.Version = defaultMigrationVersionFromTaskID(task.ID)
-		mi.Database = databaseName
-		mi.Namespace = databaseName
-		mi.Description = task.Name
-	} else {
-		repositoryFind := &api.RepositoryFind{
-			ProjectID: &task.Database.ProjectID,
-		}
-		repository, err = server.RepositoryService.FindRepository(ctx, repositoryFind)
-		if err != nil {
-			return true, nil, fmt.Errorf("failed to find linked repository for database %q", databaseName)
-		}
-		if repository == nil {
-			return true, nil, fmt.Errorf("repository not found with project ID %v", task.Database.ProjectID)
-		}
-
-		mi, err = db.ParseMigrationInfo(
-			payload.VCSPushEvent.FileCommit.Added,
-			filepath.Join(payload.VCSPushEvent.BaseDirectory, repository.FilePathTemplate),
-		)
-		// This should not happen normally as we already check this when creating the issue. Just in case.
-		if err != nil {
-			return true, nil, fmt.Errorf("failed to start schema migration, error: %w", err)
-		}
-		mi.Creator = payload.VCSPushEvent.FileCommit.AuthorName
-
-		miPayload := &db.MigrationInfoPayload{
-			VCSPushEvent: payload.VCSPushEvent,
-		}
-		bytes, err := json.Marshal(miPayload)
-		if err != nil {
-			return true, nil, fmt.Errorf("failed to start schema migration, unable to marshal vcs push event payload %w", err)
-		}
-		mi.Payload = string(bytes)
-	}
-
-	issueFind := &api.IssueFind{
-		PipelineID: &task.PipelineID,
-	}
-	issue, err := server.IssueService.FindIssue(ctx, issueFind)
-	if err != nil {
-		// If somehow we unable to find the issue, we just emit the error since it's not
-		// critical enough to fail the entire operation.
-		exec.l.Error("Failed to fetch containing issue for composing the migration info",
-			zap.Int("task_id", task.ID),
-			zap.Error(err),
-		)
-	}
-
-	if issue == nil {
-		err := fmt.Errorf("Failed to fetch containing issue for composing the migration info, issue not found with pipeline ID %v", task.PipelineID)
-		exec.l.Error(err.Error(),
-			zap.Int("task_id", task.ID),
-			zap.Error(err),
-		)
-	} else {
-		mi.IssueID = strconv.Itoa(issue.ID)
-	}
-
-	statement := strings.TrimSpace(payload.Statement)
-	// Only baseline can have empty sql statement, which indicates empty database.
-	if mi.Type != db.Baseline && statement == "" {
-		return true, nil, fmt.Errorf("empty statement")
-	}
-
-	if err := server.composeTaskRelationship(ctx, task); err != nil {
-		return true, nil, err
-	}
-
-	driver, err := getDatabaseDriver(ctx, task.Instance, databaseName, exec.l)
-	if err != nil {
-		return true, nil, err
-	}
-	defer driver.Close(ctx)
-
-	exec.l.Debug("Start sql migration...",
-		zap.String("instance", task.Instance.Name),
-		zap.String("database", databaseName),
-		zap.String("engine", mi.Engine.String()),
-		zap.String("type", mi.Type.String()),
-		zap.String("statement", statement),
-	)
-
-	setup, err := driver.NeedsSetupMigration(ctx)
-	if err != nil {
-		return true, nil, fmt.Errorf("failed to check migration setup for instance %q: %w", task.Instance.Name, err)
-	}
-	if setup {
-		return true, nil, common.Errorf(common.MigrationSchemaMissing, fmt.Errorf("missing migration schema for instance %q", task.Instance.Name))
-	}
-
-	migrationID, schema, err := driver.ExecuteMigration(ctx, mi, statement)
-	if err != nil {
-		return true, nil, err
-	}
-
-	// If VCS based and schema path template is specified, then we will write back the latest schema file after migration.
-	if payload.VCSPushEvent != nil && repository.SchemaPathTemplate != "" {
-		latestSchemaFile := filepath.Join(repository.BaseDirectory, repository.SchemaPathTemplate)
-		latestSchemaFile = strings.ReplaceAll(latestSchemaFile, "{{ENV_NAME}}", mi.Environment)
-		latestSchemaFile = strings.ReplaceAll(latestSchemaFile, "{{DB_NAME}}", mi.Database)
-
-		repository.VCS, err = server.composeVCSByID(ctx, repository.VCSID)
-		if err != nil {
-			return true, nil, fmt.Errorf("failed to sync schema file %s after applying migration %s to %q", latestSchemaFile, mi.Version, databaseName)
-		}
-		if repository.VCS == nil {
-			return true, nil, fmt.Errorf("VCS ID not found: %d", repository.VCSID)
-		}
-
-		// Writes back the latest schema file to the same branch as the push event.
-		// Ref format refs/heads/<<branch>>
-		refComponents := strings.Split(payload.VCSPushEvent.Ref, "/")
-		branch := refComponents[len(refComponents)-1]
-
-		bytebaseURL := ""
-		if issue != nil {
-			bytebaseURL = fmt.Sprintf("%s:%d/issue/%s?stage=%d", server.frontendHost, server.frontendPort, api.IssueSlug(issue), task.StageID)
-		}
-
-		commitID, err := writeBackLatestSchema(ctx, server, repository, payload.VCSPushEvent, mi, branch, latestSchemaFile, schema, bytebaseURL)
-		if err != nil {
-			return true, nil, err
-		}
-
-		// Create file commit activity
-		{
-			payload, err := json.Marshal(api.ActivityPipelineTaskFileCommitPayload{
-				TaskID:             task.ID,
-				VCSInstanceURL:     repository.VCS.InstanceURL,
-				RepositoryFullPath: payload.VCSPushEvent.RepositoryFullPath,
-				Branch:             branch,
-				FilePath:           latestSchemaFile,
-				CommitID:           commitID,
-			})
-			if err != nil {
-				exec.l.Error("Failed to marshal file commit activity after writing back the latest schema",
-					zap.Int("task_id", task.ID),
-					zap.String("repository", repository.WebURL),
-					zap.String("file_path", latestSchemaFile),
-					zap.Error(err),
-				)
-			}
-
-			containerID := task.PipelineID
-			if issue != nil {
-				containerID = issue.ID
-			}
-			activityCreate := &api.ActivityCreate{
-				CreatorID:   task.CreatorID,
-				ContainerID: containerID,
-				Type:        api.ActivityPipelineTaskFileCommit,
-				Level:       api.ActivityInfo,
-				Comment: fmt.Sprintf("Committed the latest schema after applying migration version %s to %q.",
-					mi.Version,
-					mi.Database,
-				),
-				Payload: string(payload),
-			}
-
-			_, err = server.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{})
-			if err != nil {
-				exec.l.Error("Failed to create file commit activity after writing back the latest schema",
-					zap.Int("task_id", task.ID),
-					zap.String("repository", repository.WebURL),
-					zap.String("file_path", latestSchemaFile),
-					zap.Error(err),
-				)
-			}
-		}
-	}
-
-	detail := fmt.Sprintf("Applied migration version %s to database %q.", mi.Version, databaseName)
-	if mi.Type == db.Baseline {
-		detail = fmt.Sprintf("Established baseline version %s for database %q.", mi.Version, databaseName)
-	}
-
-	return true, &api.TaskRunResultPayload{
-		Detail:      detail,
-		MigrationID: migrationID,
-		Version:     mi.Version,
-	}, nil
-}
-
-// Writes back the latest schema to the repository after migration
-// Returns the commit id on success.
-func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.Repository, pushEvent *vcs.VCSPushEvent, mi *db.MigrationInfo, branch string, latestSchemaFile string, schema string, bytebaseURL string) (string, error) {
-	schemaFileMeta, err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).ReadFileMeta(
-		ctx,
-		common.OauthContext{
-			ClientID:     repository.VCS.ApplicationID,
-			ClientSecret: repository.VCS.Secret,
-			AccessToken:  repository.AccessToken,
-			RefreshToken: repository.RefreshToken,
-			Refresher:    server.refreshToken(ctx, repository.ID),
-		},
-		repository.VCS.InstanceURL,
-		repository.ExternalID,
-		latestSchemaFile,
-		branch,
-	)
-
-	createSchemaFile := false
-	verb := "Update"
-	if err != nil {
-		if common.ErrorCode(err) == common.NotFound {
-			createSchemaFile = true
-			verb = "Create"
-		} else {
-			return "", fmt.Errorf("failed to fetch latest schema: %w", err)
-		}
-	}
-
-	commitTitle := fmt.Sprintf("[Bytebase] %s latest schema for %q after migration %s", verb, mi.Database, mi.Version)
-	commitBody := "THIS COMMIT IS AUTO-GENERATED BY BTYEBASE"
-	if bytebaseURL != "" {
-		commitBody += "\n\n" + bytebaseURL
-	}
-	commitBody += "\n\n--------Original migration change--------\n\n"
-	commitBody += fmt.Sprintf("%s\n\n%s",
-		pushEvent.FileCommit.URL,
-		pushEvent.FileCommit.Message,
-	)
-
-	schemaFileCommit := vcs.FileCommitCreate{
-		Branch:        branch,
-		CommitMessage: fmt.Sprintf("%s\n\n%s", commitTitle, commitBody),
-		Content:       schema,
-	}
-	if createSchemaFile {
-		err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).CreateFile(
-			ctx,
-			common.OauthContext{
-				ClientID:     repository.VCS.ApplicationID,
-				ClientSecret: repository.VCS.Secret,
-				AccessToken:  repository.AccessToken,
-				RefreshToken: repository.RefreshToken,
-				Refresher:    server.refreshToken(ctx, repository.ID),
-			},
-			repository.VCS.InstanceURL,
-			repository.ExternalID,
-			latestSchemaFile,
-			schemaFileCommit,
-		)
-
-		if err != nil {
-			return "", fmt.Errorf("failed to create file after applying migration %s to %q: %w", mi.Version, mi.Database, err)
-		}
-	} else {
-		schemaFileCommit.LastCommitID = schemaFileMeta.LastCommitID
-		err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).OverwriteFile(
-			ctx,
-			common.OauthContext{
-				ClientID:     repository.VCS.ApplicationID,
-				ClientSecret: repository.VCS.Secret,
-				AccessToken:  repository.AccessToken,
-				RefreshToken: repository.RefreshToken,
-				Refresher:    server.refreshToken(ctx, repository.ID),
-			},
-			repository.VCS.InstanceURL,
-			repository.ExternalID,
-			latestSchemaFile,
-			schemaFileCommit,
-		)
-		if err != nil {
-			return "", fmt.Errorf("failed to create file after applying migration %s to %q: %w", mi.Version, mi.Database, err)
-		}
-	}
-
-	// VCS such as GitLab API doesn't return the commit on write, so we have to call ReadFileMeta again
-	schemaFileMeta, err = vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: server.l}).ReadFileMeta(
-		ctx,
-		common.OauthContext{
-			ClientID:     repository.VCS.ApplicationID,
-			ClientSecret: repository.VCS.Secret,
-			AccessToken:  repository.AccessToken,
-			RefreshToken: repository.RefreshToken,
-			Refresher:    server.refreshToken(ctx, repository.ID),
-		},
-		repository.VCS.InstanceURL,
-		repository.ExternalID,
-		latestSchemaFile,
-		branch,
-	)
-
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch latest schema file %s after update: %w", latestSchemaFile, err)
-	}
-	return schemaFileMeta.LastCommitID, nil
+	return runMigration(ctx, exec.l, server, task, payload.MigrationType, payload.Statement, payload.VCSPushEvent)
 }

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -244,8 +244,8 @@ func (s *TaskScheduler) ScheduleIfNeeded(ctx context.Context, task *api.Task) (*
 		}
 	}
 
-	// only schema update task has required task check
-	if task.Type == api.TaskDatabaseSchemaUpdate {
+	// only schema update or data update task has required task check
+	if task.Type == api.TaskDatabaseSchemaUpdate || task.Type == api.TaskDatabaseDataUpdate {
 		pass, err := s.server.passCheck(ctx, s.server, task, api.TaskCheckDatabaseConnect)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Add the dedicated data update issue and task type. It's mostly similar to the corresponding schema update issue and task type. We make them separate so it's easier to extend them individually later.

The leftover is tenant mode doesn't support data migration. We need to do some refactoring to make it work (the current logic is kind of coupled with scheme update)

Part of supporting https://github.com/bytebase/bytebase/issues/337