### PR TITLE
chore(ci): add build release image workflow

### DIFF
--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           push: true
           # Extract the version from the tag
-          tags: bytebase/bytebase:${GITHUB_REF##*/}
+          tags: bytebase/bytebase:${{ github.ref_name }}
       - name: Image digest
-        run: echo "Successfully pushed bytebase/bytebase:" ${GITHUB_REF##*/} " " ${{ steps.docker_build.outputs.digest }}
+        run: echo "Successfully pushed bytebase/bytebase:${{ github.ref_name }} ${{ steps.docker_build.outputs.digest }}"

--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -1,0 +1,27 @@
+name: build release image and push to docker hub
+
+on:
+  push:
+    tags:
+      # Run on pushing version tag like `1.0.0`
+      - '*.*.*'
+
+jobs:
+  build-release-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          # Extract the version from the tag
+          tags: bytebase/bytebase:${GITHUB_REF##*/}
+      - name: Image digest
+        run: echo "Successfully pushed bytebase/bytebase:" ${GITHUB_REF##*/} " " ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This action builds and pushes Docker images with the tag that triggers it, which is like `*.*.*` (e.g. `1.0.0`).

I've tested it in my repo, see https://github.com/qsliu2017/bytebase/actions/runs/1711168368.