### PR TITLE
fix: explicitly use GitLab wording since we already prepend its logo

### DIFF
--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -593,8 +593,8 @@ auth:
     admin-account: admin account
     forget-password: Forgot your password?
     new-user: New to Bytebase?
-    third-party: You can reach to your Admin to enable third party login.
     gitlab: Login with GitLab
+    gitlab-oauth: Reach to your Admin to enable GitLab login
   password-forget:
     title: Forgot your password?
     content: Please contact your Bytebase Admin to reset your password.

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -541,8 +541,8 @@ auth:
     title: 登录您的账号
     forget-password: 忘记密码?
     new-user: 第一次使用 Bytebase?
-    third-party: 您可联系管理员开启第三方认证登录
     gitlab: 通过 GitLab 登录
+    gitlab-oauth: 您可联系管理员开启 GitLab 登录
   password-forget:
     title: 忘记了您的密码？
     content: 请联系的您的 Bytebase 管理员重置密码

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -35,12 +35,8 @@
 
       <template v-if="authProviderList.length == 0">
         <n-button class="w-full h-10 mb-2" disabled>
-          <img
-            class="w-5 mr-1"
-            :src="AuthProviderConfig['GITLAB_SELF_HOST'].iconPath"
-          /><span class="text-center font-semibold align-middle">
-            {{ $t("auth.sign-in.third-party") }}
-          </span>
+          <img class="w-5 mr-1" :src="AuthProviderConfig['GITLAB_SELF_HOST'].iconPath" />
+          <span class="text-center font-semibold align-middle">{{ $t("auth.sign-in.gitlab-oauth") }}</span>
         </n-button>
       </template>
     </div>

--- a/server/auth.go
+++ b/server/auth.go
@@ -111,8 +111,8 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 				// create a new user if not exist
 				if user == nil {
 					// if user login via gitlab at the first time, we will generate a random password.
-					// The random password is supposed to be not guessable.
-					// If user signs up via 3rd party login like GitLab, we will disallow bytebase builtin password/email login unless user manually set up her password later.
+					// The random password is supposed to be not guessable. If user wants to login
+					// via password, she needs to set the new password from the profile page.
 					signup := &api.Signup{
 						Email:    GitlabUserInfo.Email,
 						Password: common.RandomString(20),


### PR DESCRIPTION
Also change the user login comment 