### PR TITLE
fix: add link to our mysql setup guide and trim the enclosing whitespace

### DIFF
--- a/frontend/src/components/InstanceConnectionForm.vue
+++ b/frontend/src/components/InstanceConnectionForm.vue
@@ -31,6 +31,11 @@
                 </span>
               </template>
             </i18n-t>
+            <a
+              href="https://docs.bytebase.com/install/docker#start-a-local-mysql-server-for-testing"
+              target="_blank"
+              class="normal-link"
+            >{{ $t("common.detailed-guide") }}</a>
           </template>
           <template v-else-if="instance.engine == 'CLICKHOUSE'">
             <i18n-t tag="p" keypath="instance.sentence.create-user-example.clickhouse.template">
@@ -109,7 +114,7 @@
               : ''
           "
           :value="instance.username"
-          @input="$emit('update-username', $event.target.value)"
+          @input="$emit('update-username', $event.target.value.trim())"
         />
       </div>
 

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -442,7 +442,11 @@ export default {
     };
 
     const updateInstance = (field: string, value: string) => {
-      (state.instance as any)[field] = value;
+      let str = value;
+      if (field == "name" || field == "host" || field == "port" || field == "externalLink") {
+        str = value.trim()
+      }
+      (state.instance as any)[field] = str;
     };
 
     const cancel = () => {

--- a/frontend/src/views/SettingSidebar.vue
+++ b/frontend/src/views/SettingSidebar.vue
@@ -64,7 +64,7 @@
             class="outline-item group w-full flex items-center pl-11 pr-2 py-2"
           >{{ $t("settings.sidebar.version-control") }}</router-link>
           <router-link
-            v-if="isDev"
+            v-if="isDev()"
             to="/setting/subscription"
             class="outline-item group w-full flex items-center pl-11 pr-2 py-2"
           >{{ $t("settings.sidebar.subscription") }}</router-link>


### PR DESCRIPTION
Noticed this when observing peers setting up the instance.

1. Provide guidance on how to start a MySQL instance.
2. Trim hard to find whitespace