### PR TITLE
fix(ci): trigger `notify-dependency-changes` on `pull_request_target`

### DIFF
--- a/.github/workflows/notify-dependency-changes.yml
+++ b/.github/workflows/notify-dependency-changes.yml
@@ -1,10 +1,13 @@
 name: Change dependency needs admin approval
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "frontend/package.json"
       - "go.mod"
+
+env:
+  REVIEWERS: tianzhou,d-bytebase
 
 jobs:
   request-dependency-reviewers:
@@ -12,8 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REVIEWERS: ${{ secrets.DEPENDENCY_REVIEWERS }}
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
           gh pr edit $PR_NUMBER --add-reviewer $REVIEWERS


### PR DESCRIPTION
This grants access to the GITHUB_TOKEN so the action can make calls to GitHub's rest API