### PR TITLE
feat(frontend): refactor BBSelect using naive-ui components

### DIFF
--- a/frontend/src/bbkit/BBSelect.vue
+++ b/frontend/src/bbkit/BBSelect.vue
@@ -86,7 +86,7 @@ interface LocalState {
   selectedItem: any;
 }
 
-type ItemType = any;
+type ItemType = number | string | any;
 
 export default defineComponent({
   name: "BBSelect",

--- a/frontend/src/bbkit/BBSelect.vue
+++ b/frontend/src/bbkit/BBSelect.vue
@@ -1,148 +1,109 @@
 <template>
-  <div
-    v-click-inside-outside="
-      (_, inside) => {
-        if (!inside) {
-          close();
-        }
-      }
-    "
-    class="relative flex flex-shrink-0"
-  >
-    <button
-      type="button"
-      aria-haspopup="listbox"
-      aria-expanded="true"
-      aria-labelledby="listbox-label"
-      class="btn-select relative w-full pl-3 pr-10 py-1.5"
-      :disabled="disabled"
-      @click="toggle"
-    >
-      <template v-if="state.selectedItem">
-        <slot name="menuItem" :item="state.selectedItem" />
-      </template>
-      <template v-else>
-        <slot name="placeholder" :placeholder="placeholder">{{
-          placeholder
-        }}</slot>
-      </template>
-      <span
-        class="
-          ml-3
-          absolute
-          inset-y-0
-          right-0
-          flex
-          items-center
-          pr-2
-          pointer-events-none
-        "
+  <VBinder>
+    <VTarget>
+      <button
+        ref="button"
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded="true"
+        aria-labelledby="listbox-label"
+        class="btn-select relative w-full pl-3 pr-10 py-1.5"
+        :disabled="disabled"
+        v-bind="$attrs"
+        @click="toggle"
       >
-        <!-- Heroicon name: solid/selector -->
-        <heroicons-solid:selector class="h-5 w-5 text-control-light" />
-      </span>
-    </button>
-
-    <!--
-      Select popover, show/hide based on select state.
-
-      Entering: ""
-        From: ""
-        To: ""
-      Leaving: "transition ease-in duration-100"
-        From: "opacity-100"
-        To: "opacity-0"
-    -->
-    <transition
-      enter-active-class=""
-      enter-class=""
-      enter-to-class=""
-      leave-active-class="transition ease-in duration-100"
-      leave-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
-      <div
-        v-show="state.showMenu"
-        class="z-50 absolute w-full rounded-md bg-white shadow-lg"
-      >
-        <ul
-          tabindex="-1"
-          role="listbox"
-          aria-labelledby="listbox-label"
-          aria-activedescendant="listbox-item-3"
-          class="
-            max-h-56
-            rounded-md
-            py-1
-            ring-1 ring-black ring-opacity-5
-            overflow-auto
-            focus:outline-none
-            sm:text-sm
-          "
+        <template v-if="state.selectedItem">
+          <slot name="menuItem" :item="state.selectedItem" />
+        </template>
+        <template v-else>
+          <slot name="placeholder" :placeholder="placeholder">
+            {{ placeholder }}
+          </slot>
+        </template>
+        <span
+          class="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none"
         >
-          <!--
-          Select option, manage highlight styles based on mouseenter/mouseleave and keyboard navigation.
-
-          Highlighted: "text-white bg-indigo-600", Not Highlighted: "text-gray-900"
-        -->
-          <li
-            v-for="(item, index) in itemList"
-            :key="index"
-            role="option"
-            class="
-              text-main
-              hover:text-main-text hover:bg-main-hover
-              cursor-default
-              select-none
-              relative
-              py-2
-              pl-3
-              pr-9
-            "
-            @click="
-              if (item !== state.selectedItem) {
-                $emit('select-item', item, () => {
-                  state.selectedItem = item;
-                });
-              }
-              close();
-            "
+          <heroicons-solid:selector class="h-5 w-5 text-control-light" />
+        </span>
+      </button>
+    </VTarget>
+    <VFollower :show="state.showMenu" placement="bottom-start">
+      <transition :appear="true" name="fade-fast">
+        <div
+          v-if="state.showMenu"
+          ref="popup"
+          class="z-50 rounded-md bg-white shadow-lg"
+          :style="{ width: `${width}px` }"
+        >
+          <ul
+            tabindex="-1"
+            role="listbox"
+            aria-labelledby="listbox-label"
+            aria-activedescendant="listbox-item-3"
+            class="max-h-56 rounded-md py-1 ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm"
           >
-            <slot name="menuItem" :item="item" />
-            <span
-              v-if="item === state.selectedItem"
-              class="absolute inset-y-0 right-0 flex items-center pr-4"
+            <!--
+              Select option, manage highlight styles based on mouseenter/mouseleave and keyboard navigation.
+              Highlighted: "text-white bg-indigo-600", Not Highlighted: "text-gray-900"
+            -->
+            <li
+              v-for="(item, index) in itemList"
+              :key="index"
+              role="option"
+              class="text-main hover:text-main-text hover:bg-main-hover cursor-default select-none relative py-2 pl-3 pr-9"
+              @click="
+                if (item !== state.selectedItem) {
+                  $emit('select-item', item, () => {
+                    state.selectedItem = item;
+                  });
+                }
+                close();
+              "
             >
-              <!-- Heroicon name: solid/check -->
-              <heroicons-solid:check class="h-5 w-5" />
-            </span>
-          </li>
-        </ul>
-      </div>
-    </transition>
-  </div>
+              <slot name="menuItem" :item="item" />
+              <span
+                v-if="item === state.selectedItem"
+                class="absolute inset-y-0 right-0 flex items-center pr-4"
+              >
+                <!-- Heroicon name: solid/check -->
+                <heroicons-solid:check class="h-5 w-5" />
+              </span>
+            </li>
+          </ul>
+        </div>
+      </transition>
+    </VFollower>
+  </VBinder>
 </template>
 
 <script lang="ts">
-import { reactive, PropType, watch } from "vue";
-import clickInsideOutside from "./directives/click-inside-outside";
+import { reactive, PropType, watch, defineComponent, ref } from "vue";
+import { VBinder, VTarget, VFollower } from "vueuc";
+import { onClickOutside, useElementBounding } from "@vueuse/core";
 
 interface LocalState {
   showMenu: boolean;
   selectedItem: any;
 }
 
-export default {
+type ItemType = any;
+
+export default defineComponent({
   name: "BBSelect",
-  directives: {
-    "click-inside-outside": clickInsideOutside,
+  components: {
+    VBinder,
+    VTarget,
+    VFollower,
   },
-  components: {},
+  inheritAttrs: false,
   props: {
-    selectedItem: {},
+    selectedItem: {
+      type: [Object, Number, String] as PropType<ItemType>,
+      default: undefined,
+    },
     itemList: {
       required: true,
-      type: Object as PropType<any[]>,
+      type: Array as PropType<ItemType[]>,
     },
     placeholder: {
       default: "",
@@ -160,6 +121,11 @@ export default {
       selectedItem: props.selectedItem,
     });
 
+    const button = ref<HTMLButtonElement | null>(null);
+    const popup = ref<HTMLElement | null>(null);
+
+    const { width } = useElementBounding(button);
+
     watch(
       () => props.selectedItem,
       (cur) => {
@@ -175,11 +141,16 @@ export default {
       state.showMenu = false;
     };
 
+    onClickOutside(popup, close);
+
     return {
       state,
       toggle,
       close,
+      button,
+      popup,
+      width,
     };
   },
-};
+});
 </script>


### PR DESCRIPTION
Refactor `<BBSelect>` using naive-ui components.

Components effected by this change: `<IssueStatusSelect>`, `<MemberSelect>`, `<ProjectRoleSelect>`, `<RoleSelect>`, `<DatabaseLebelForm>`.

This benefits us by:

- Moving the popup out of the `<div>` wrapping `<button>` to the `<body>`, allowing `<button>` to be "overflow:hidden".
- naive-ui will manage the popup's placement dynamically when it is closed to the edge of window.

Why do not we use `<NSelect>` of naive-ui?

- Hard to overwrite the button's style of `<NSelect>`.
- Complex data type conversion.

Why do not we use `<NPopselect>` of naive-ui?

- Hard to overwrite the popup's style of `<NPopselect>`.
- Complex data type conversion.
- Currently existing a bug that the popup's width can't follow to the button's. (Posted to the author already)
