### PR TITLE
refactor(db-driver): reduce switch driver type

### DIFF
--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -27,8 +27,8 @@ var (
 		"system": true,
 	}
 
-	_ db.Driver   = (*Driver)(nil)
-	_ util.Driver = (*Driver)(nil)
+	_ db.Driver                      = (*Driver)(nil)
+	_ util.MigrationExecutableDriver = (*Driver)(nil)
 )
 
 func init() {
@@ -435,6 +435,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// RecordPendingMigrationHistory adapts Driver to util.MigrationExecutableDriver.
 func (driver *Driver) RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
 	const (
 		maxIDQuery         = "SELECT MAX(id)+1 FROM bytebase.migration_history"

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -389,6 +389,11 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 	return util.Query(ctx, driver.l, driver.db, statement, limit)
 }
 
+// QueryString returns the query where clause string for the query parameters.
+func (*Driver) QueryString(p *db.QueryParams) string {
+	return util.StandardQueryString(p)
+}
+
 // NeedsSetupMigration returns whether it needs to setup migration.
 func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 	const query = `
@@ -506,7 +511,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 		issue_id,
 		payload
 		FROM bytebase.migration_history `
-	return util.FindMigrationHistoryList(ctx, db.MySQL, driver, find, baseQuery)
+	return util.FindMigrationHistoryList(ctx, driver, find, baseQuery)
 }
 
 // Dump and restore

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -392,7 +392,7 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 
 // QueryString returns the query where clause string for the query parameters.
 func (*Driver) QueryString(p *db.QueryParams) string {
-	return util.StandardQueryString(p)
+	return util.QueryString(p)
 }
 
 // NeedsSetupMigration returns whether it needs to setup migration.

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -546,6 +546,11 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 	return util.Query(ctx, driver.l, driver.db, statement, limit)
 }
 
+// QueryString returns the query where clause string for the query parameters.
+func (*Driver) QueryString(p *db.QueryParams) string {
+	return util.StandardQueryString(p)
+}
+
 // NeedsSetupMigration returns whether it needs to setup migration.
 func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 	const query = `
@@ -666,7 +671,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 		issue_id,
 		payload
 		FROM bytebase.migration_history `
-	return util.FindMigrationHistoryList(ctx, db.MySQL, driver, find, baseQuery)
+	return util.FindMigrationHistoryList(ctx, driver, find, baseQuery)
 }
 
 // Dump and restore

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -549,7 +549,7 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 
 // QueryString returns the query where clause string for the query parameters.
 func (*Driver) QueryString(p *db.QueryParams) string {
-	return util.StandardQueryString(p)
+	return util.QueryString(p)
 }
 
 // NeedsSetupMigration returns whether it needs to setup migration.

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -34,8 +34,8 @@ var (
 	baseTableType        = "BASE TABLE"
 	excludeAutoIncrement = regexp.MustCompile(`AUTO_INCREMENT=\d+ `)
 
-	_ db.Driver   = (*Driver)(nil)
-	_ util.Driver = (*Driver)(nil)
+	_ db.Driver                      = (*Driver)(nil)
+	_ util.MigrationExecutableDriver = (*Driver)(nil)
 )
 
 func init() {
@@ -595,8 +595,9 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// RecordPendingMigrationHistory adapts Driver to util.MigrationExecutableDriver.
 func (*Driver) RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
-	return util.StandardRecordPendingMigrationHistory(ctx, l, tx, m, statement, sequence, prevSchema)
+	return util.RecordPendingMigrationHistory(ctx, l, tx, m, statement, sequence, prevSchema)
 }
 
 // ExecuteMigration will execute the migration.

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -34,7 +34,8 @@ var (
 	baseTableType        = "BASE TABLE"
 	excludeAutoIncrement = regexp.MustCompile(`AUTO_INCREMENT=\d+ `)
 
-	_ db.Driver = (*Driver)(nil)
+	_ db.Driver   = (*Driver)(nil)
+	_ util.Driver = (*Driver)(nil)
 )
 
 func init() {
@@ -592,6 +593,10 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (*Driver) RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
+	return util.StandardRecordPendingMigrationHistory(ctx, l, tx, m, statement, sequence, prevSchema)
 }
 
 // ExecuteMigration will execute the migration.

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -185,8 +185,8 @@ var (
 	bytebaseDatabase           = "bytebase"
 	createBytebaseDatabaseStmt = "CREATE DATABASE bytebase;"
 
-	_ db.Driver   = (*Driver)(nil)
-	_ util.Driver = (*Driver)(nil)
+	_ db.Driver                      = (*Driver)(nil)
+	_ util.MigrationExecutableDriver = (*Driver)(nil)
 )
 
 func init() {
@@ -668,6 +668,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// RecordPendingMigrationHistory adapts Driver to util.MigrationExecutableDriver.
 func (driver *Driver) RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
 	const insertHistoryQuery = `
 	INSERT INTO migration_history (

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -517,6 +517,11 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 	return util.Query(ctx, driver.l, driver.db, statement, limit)
 }
 
+// QueryString returns the query where clause string for the query parameters.
+func (*Driver) QueryString(p *db.QueryParams) string {
+	return util.StandardQueryString(p)
+}
+
 // NeedsSetupMigration returns whether it needs to setup migration.
 func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 	exist, err := driver.hasBytebaseDatabase(ctx)
@@ -661,7 +666,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 		issue_id,
 		payload
 		FROM bytebase.public.migration_history `
-	return util.FindMigrationHistoryList(ctx, db.Snowflake, driver, find, baseQuery)
+	return util.FindMigrationHistoryList(ctx, driver, find, baseQuery)
 }
 
 // Dump and restore

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -520,7 +520,7 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 
 // QueryString returns the query where clause string for the query parameters.
 func (*Driver) QueryString(p *db.QueryParams) string {
-	return util.StandardQueryString(p)
+	return util.QueryString(p)
 }
 
 // NeedsSetupMigration returns whether it needs to setup migration.

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -28,8 +28,8 @@ var (
 	sysAdminRole     = "SYSADMIN"
 	accountAdminRole = "ACCOUNTADMIN"
 
-	_ db.Driver   = (*Driver)(nil)
-	_ util.Driver = (*Driver)(nil)
+	_ db.Driver                      = (*Driver)(nil)
+	_ util.MigrationExecutableDriver = (*Driver)(nil)
 )
 
 func init() {
@@ -587,6 +587,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// RecordPendingMigrationHistory adapts Driver to util.MigrationExecutableDriver.
 func (driver *Driver) RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
 	const (
 		maxIDQuery         = "SELECT MAX(id)+1 FROM bytebase.public.migration_history"

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -199,7 +199,7 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 
 // QueryString returns the query where clause string for the query parameters.
 func (*Driver) QueryString(p *db.QueryParams) string {
-	return util.StandardQueryString(p)
+	return util.QueryString(p)
 }
 
 // NeedsSetupMigration returns whether it needs to setup migration.

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -28,8 +28,8 @@ var (
 		bytebaseDatabase: true,
 	}
 
-	_ db.Driver   = (*Driver)(nil)
-	_ util.Driver = (*Driver)(nil)
+	_ db.Driver                      = (*Driver)(nil)
+	_ util.MigrationExecutableDriver = (*Driver)(nil)
 )
 
 func init() {
@@ -263,8 +263,9 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// RecordPendingMigrationHistory adapts Driver to util.MigrationExecutableDriver.
 func (*Driver) RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
-	return util.StandardRecordPendingMigrationHistory(ctx, l, tx, m, statement, sequence, prevSchema)
+	return util.RecordPendingMigrationHistory(ctx, l, tx, m, statement, sequence, prevSchema)
 }
 
 // ExecuteMigration will execute the migration.

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -196,6 +196,11 @@ func (driver *Driver) Query(ctx context.Context, statement string, limit int) ([
 	return util.Query(ctx, driver.l, driver.db, statement, limit)
 }
 
+// QueryString returns the query where clause string for the query parameters.
+func (*Driver) QueryString(p *db.QueryParams) string {
+	return util.StandardQueryString(p)
+}
+
 // NeedsSetupMigration returns whether it needs to setup migration.
 func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 	exist, err := driver.hasBytebaseDatabase()
@@ -334,7 +339,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 		issue_id,
 		payload
 		FROM bytebase_migration_history `
-	return util.FindMigrationHistoryList(ctx, db.Postgres, driver, find, baseQuery)
+	return util.FindMigrationHistoryList(ctx, driver, find, baseQuery)
 }
 
 // Dump dumps the database.

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -28,7 +28,8 @@ var (
 		bytebaseDatabase: true,
 	}
 
-	_ db.Driver = (*Driver)(nil)
+	_ db.Driver   = (*Driver)(nil)
+	_ util.Driver = (*Driver)(nil)
 )
 
 func init() {
@@ -260,6 +261,10 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (*Driver) RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
+	return util.StandardRecordPendingMigrationHistory(ctx, l, tx, m, statement, sequence, prevSchema)
 }
 
 // ExecuteMigration will execute the migration.

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -117,9 +117,66 @@ type MigrationExecutionArgs struct {
 	TablePrefix                string
 }
 
+type Driver interface {
+	db.Driver
+	RecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error)
+}
+
+func StandardRecordPendingMigrationHistory(ctx context.Context, l *zap.Logger, tx *sql.Tx, m *db.MigrationInfo, statement string, sequence int, prevSchema string) (insertedID int64, err error) {
+	const insertHistoryQuery = `
+	INSERT INTO bytebase.migration_history (
+		created_by,
+		created_ts,
+		updated_by,
+		updated_ts,
+		release_version,
+		namespace,
+		sequence,
+		engine,
+		type,
+		status,
+		version,
+		description,
+		statement,
+		` + "`schema`," + `
+		schema_prev,
+		execution_duration_ns,
+		issue_id,
+		payload
+	)
+	VALUES (?, unix_timestamp(), ?, unix_timestamp(), ?, ?, ?, ?,  ?, 'PENDING', ?, ?, ?, ?, ?, 0, ?, ?)
+`
+	res, err := tx.ExecContext(ctx, insertHistoryQuery,
+		m.Creator,
+		m.Creator,
+		m.ReleaseVersion,
+		m.Namespace,
+		sequence,
+		m.Engine,
+		m.Type,
+		m.Version,
+		m.Description,
+		statement,
+		prevSchema,
+		prevSchema,
+		m.IssueID,
+		m.Payload,
+	)
+
+	if err != nil {
+		return -1, FormatErrorWithQuery(err, insertHistoryQuery)
+	}
+
+	insertedID, err = res.LastInsertId()
+	if err != nil {
+		return -1, FormatErrorWithQuery(err, insertHistoryQuery)
+	}
+	return insertedID, nil
+}
+
 // ExecuteMigration will execute the database migration.
 // Returns the created migraiton history id and the updated schema on success.
-func ExecuteMigration(ctx context.Context, l *zap.Logger, dbType db.Type, driver db.Driver, m *db.MigrationInfo, statement string, args MigrationExecutionArgs) (migrationHistoryID int64, updatedSchema string, resErr error) {
+func ExecuteMigration(ctx context.Context, l *zap.Logger, dbType db.Type, driver Driver, m *db.MigrationInfo, statement string, args MigrationExecutionArgs) (migrationHistoryID int64, updatedSchema string, resErr error) {
 	var prevSchemaBuf bytes.Buffer
 	// Don't record schema if the database hasn't exist yet.
 	if !m.CreateDatabase {
@@ -182,136 +239,9 @@ func ExecuteMigration(ctx context.Context, l *zap.Logger, dbType db.Type, driver
 	// MySQL runs DDL in its own transaction, so we can't commit migration history together with DDL in a single transaction.
 	// Thus we sort of doing a 2-phase commit, where we first write a PENDING migration record, and after migration completes, we then
 	// update the record to DONE together with the updated schema.
-	insertedID := int64(-1)
-	if dbType == db.Postgres {
-		tx.QueryRowContext(ctx, args.InsertHistoryQuery,
-			m.Creator,
-			m.Creator,
-			m.ReleaseVersion,
-			m.Namespace,
-			sequence,
-			m.Engine,
-			m.Type,
-			m.Version,
-			m.Description,
-			statement,
-			prevSchemaBuf.String(),
-			prevSchemaBuf.String(),
-			m.IssueID,
-			m.Payload,
-		).Scan(&insertedID)
-	} else if dbType == db.ClickHouse {
-		maxIDQuery := "SELECT MAX(id)+1 FROM bytebase.migration_history"
-		rows, err := tx.QueryContext(ctx, maxIDQuery)
-		if err != nil {
-			return -1, "", FormatErrorWithQuery(err, maxIDQuery)
-		}
-		defer rows.Close()
-		for rows.Next() {
-			if err := rows.Scan(
-				&insertedID,
-			); err != nil {
-				return -1, "", FormatErrorWithQuery(err, maxIDQuery)
-			}
-		}
-		if err := rows.Err(); err != nil {
-			return -1, "", FormatErrorWithQuery(err, maxIDQuery)
-		}
-		// Clickhouse sql driver doesn't support taking now() as prepared value.
-		now := time.Now().Unix()
-		_, err = tx.ExecContext(ctx, args.InsertHistoryQuery,
-			insertedID,
-			m.Creator,
-			now,
-			m.Creator,
-			now,
-			m.ReleaseVersion,
-			m.Namespace,
-			sequence,
-			m.Engine,
-			m.Type,
-			"PENDING",
-			m.Version,
-			m.Description,
-			statement,
-			prevSchemaBuf.String(),
-			prevSchemaBuf.String(),
-			0,
-			m.IssueID,
-			m.Payload,
-		)
-		if err != nil {
-			return -1, "", FormatErrorWithQuery(err, args.InsertHistoryQuery)
-		}
-	} else if dbType == db.Snowflake {
-		maxIDQuery := "SELECT MAX(id)+1 FROM bytebase.public.migration_history"
-		rows, err := tx.QueryContext(ctx, maxIDQuery)
-		if err != nil {
-			return -1, "", FormatErrorWithQuery(err, maxIDQuery)
-		}
-		defer rows.Close()
-		var id sql.NullInt64
-		for rows.Next() {
-			if err := rows.Scan(
-				&id,
-			); err != nil {
-				return -1, "", FormatErrorWithQuery(err, maxIDQuery)
-			}
-		}
-		if err := rows.Err(); err != nil {
-			return -1, "", FormatErrorWithQuery(err, maxIDQuery)
-		}
-		if id.Valid {
-			insertedID = id.Int64
-		} else {
-			insertedID = 1
-		}
-
-		_, err = tx.ExecContext(ctx, args.InsertHistoryQuery,
-			m.Creator,
-			m.Creator,
-			m.ReleaseVersion,
-			m.Namespace,
-			sequence,
-			m.Engine,
-			m.Type,
-			m.Version,
-			m.Description,
-			statement,
-			prevSchemaBuf.String(),
-			prevSchemaBuf.String(),
-			m.IssueID,
-			m.Payload,
-		)
-		if err != nil {
-			return -1, "", FormatErrorWithQuery(err, args.InsertHistoryQuery)
-		}
-	} else {
-		res, err := tx.ExecContext(ctx, args.InsertHistoryQuery,
-			m.Creator,
-			m.Creator,
-			m.ReleaseVersion,
-			m.Namespace,
-			sequence,
-			m.Engine,
-			m.Type,
-			m.Version,
-			m.Description,
-			statement,
-			prevSchemaBuf.String(),
-			prevSchemaBuf.String(),
-			m.IssueID,
-			m.Payload,
-		)
-
-		if err != nil {
-			return -1, "", FormatErrorWithQuery(err, args.InsertHistoryQuery)
-		}
-
-		insertedID, err = res.LastInsertId()
-		if err != nil {
-			return -1, "", FormatErrorWithQuery(err, args.InsertHistoryQuery)
-		}
+	insertedID, err := driver.RecordPendingMigrationHistory(ctx, l, tx, m, statement, sequence, prevSchemaBuf.String())
+	if err != nil {
+		return -1, "", err
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -401,8 +401,8 @@ func Query(ctx context.Context, l *zap.Logger, db *sql.DB, statement string, lim
 	return resultSet, nil
 }
 
-// StandardQueryString is a helper function to implement Driver.QueryString() for MySQL.
-func StandardQueryString(p *db.QueryParams) string {
+// QueryString is a helper function to implement Driver.QueryString() for MySQL.
+func QueryString(p *db.QueryParams) string {
 	params := p.Names
 	if len(params) == 0 {
 		return ""


### PR DESCRIPTION
IMO, `db.Driver` and `db.util` should not dependent on db type. And `db.util` should provide some default implements.