### PR TITLE
feat: feature guard for schema drift

### DIFF
--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -1161,3 +1161,6 @@ subscription:
     bb-feature-backward-compatibility:
       title: Backward compatibility
       remind: MySQL and TiDB support schema change with backward compatibility. {upgrade} to open this feature.
+    bb-feature-schema-drift:
+      title: Schema drift
+      desc: "@:{'subscription.upgrade'} to unlock schema dirft auto-detection"

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -1030,3 +1030,6 @@ subscription:
     bb-feature-backward-compatibility:
       title: 向后兼容
       remind: MySQL 和 TiDB 支持向后兼容的 schema 迁移，可以通过{upgrade}来开启该功能。
+    bb-feature-schema-drift:
+      title: Schema 偏差
+      desc: "@:{'subscription.upgrade'}来解锁 schema 偏差异常的自动检测。"

--- a/frontend/src/views/AnomalyCenterDashboard.vue
+++ b/frontend/src/views/AnomalyCenterDashboard.vue
@@ -6,14 +6,11 @@
       :description="$t('anomaly.attention-desc')"
     />
 
-    <BBAttention
+    <FeatureAttention
       v-if="!hasSchemaDriftFeature"
-      :style="`WARN`"
-      class="mt-5"
-      :title="$t('subscription.features.bb-feature-schema-drift.title')"
+      custom-class="mt-5"
+      feature="bb.feature.schema-drift"
       :description="$t('subscription.features.bb-feature-schema-drift.desc')"
-      :action-text="$t('subscription.upgrade')"
-      @click-action="$router.push('/setting/subscription')"
     />
 
     <div class="mt-4 space-y-4">

--- a/frontend/src/views/AnomalyCenterDashboard.vue
+++ b/frontend/src/views/AnomalyCenterDashboard.vue
@@ -5,7 +5,17 @@
       :title="$t('anomaly.attention-title')"
       :description="$t('anomaly.attention-desc')"
     />
-    <!-- This example requires Tailwind CSS v2.0+ -->
+
+    <BBAttention
+      v-if="!hasSchemaDriftFeature"
+      :style="`WARN`"
+      class="mt-5"
+      :title="$t('subscription.features.bb-feature-schema-drift.title')"
+      :description="$t('subscription.features.bb-feature-schema-drift.desc')"
+      :action-text="$t('subscription.upgrade')"
+      @click-action="$router.push('/setting/subscription')"
+    />
+
     <div class="mt-4 space-y-4">
       <div
         v-for="(item, i) in [
@@ -370,6 +380,10 @@ export default {
       state.searchText = searchText;
     };
 
+    const hasSchemaDriftFeature = computed((): boolean => {
+      return store.getters["subscription/feature"]("bb.feature.schema-drift");
+    });
+
     return {
       DATABASE_TAB,
       INSTANCE_TAB,
@@ -380,6 +394,7 @@ export default {
       instanceAnomalySummaryList,
       tabItemList,
       changeSearchText,
+      hasSchemaDriftFeature,
     };
   },
 };

--- a/server/anomaly_scanner.go
+++ b/server/anomaly_scanner.go
@@ -278,7 +278,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 	}
 
 	// Check schema drift
-	{
+	if s.server.feature(api.FeatureSchemaDrift) {
 		setup, err := driver.NeedsSetupMigration(ctx)
 		if err != nil {
 			s.l.Debug("Failed to check anomaly",


### PR DESCRIPTION
Add feature guard for schema drift.

<img width="1703" alt="图片" src="https://user-images.githubusercontent.com/10706318/151954475-565513f7-5f3d-4a1c-9215-7bc29deb3be9.png">
<img width="1709" alt="图片" src="https://user-images.githubusercontent.com/10706318/151954521-40188fa7-c57a-4ea8-b7c3-772f54012835.png">

But I'm confused about this feature, seems users cannot config it in the UX? It's hard to show what this feature is and what it can bring to users.
