### PR TITLE
feat: render db labels as if they are normal props

### DIFF
--- a/frontend/src/components/DatabaseLabels/DatabaseLabelPropItem.vue
+++ b/frontend/src/components/DatabaseLabels/DatabaseLabelPropItem.vue
@@ -1,0 +1,62 @@
+<template>
+  <span class="textlabel relative inline-flex items-center">
+    <template v-if="!editable">
+      {{ value || $t("label.empty-label-value") }}
+    </template>
+    <template v-else>
+      <select
+        class="absolute inset-0 opacity-0 m-0 p-0"
+        :value="value"
+        @change="onChange"
+      >
+        <option :value="''" :selected="!!value">
+          {{ $t("label.empty-label-value") }}
+        </option>
+        <option
+          v-for="(labelValue, i) in label.valueList"
+          :key="i"
+          :value="labelValue"
+        >
+          {{ labelValue }}
+        </option>
+      </select>
+      {{ value || $t("label.empty-label-value") }}
+      <heroicons-outline:chevron-down class="w-4 h-4 ml-0.5" />
+    </template>
+  </span>
+</template>
+
+<script lang="ts" setup>
+import { computed, defineProps, defineEmits } from "vue";
+import { Database, Label, LabelValueType } from "../../types";
+
+const props = defineProps<{
+  label: Label;
+  labelList: Label[];
+  requiredLabelList: Label[];
+  value: LabelValueType | undefined;
+  database: Database;
+  allowEdit: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:value", value: LabelValueType): void;
+}>();
+
+const editable = computed((): boolean => {
+  if (!props.allowEdit) return false;
+
+  // Not editable if this is a required label in `dbNameTemplate`
+  // e.g. tenant in "{{DB_NAME}}_{{TENANT}}"
+  const isRequired = !!props.requiredLabelList.find(
+    (label) => label.key === props.label.key
+  );
+  return !isRequired;
+});
+
+const onChange = (e: Event) => {
+  const select = e.target as HTMLSelectElement;
+  const { value } = select;
+  emit("update:value", value);
+};
+</script>

--- a/frontend/src/components/DatabaseLabels/DatabaseLabelProps.vue
+++ b/frontend/src/components/DatabaseLabels/DatabaseLabelProps.vue
@@ -1,0 +1,113 @@
+<template>
+  <template v-for="label in availableLabelList" :key="label.key">
+    <dd class="flex items-center text-sm md:mr-4">
+      <slot name="label" :label="label"></slot>
+      <DatabaseLabelPropItem
+        :label="label"
+        :value="getLabelValue(label.key)"
+        :label-list="availableLabelList"
+        :required-label-list="requiredLabelList"
+        :database="database"
+        :allow-edit="allowEdit"
+        @update:value="(value) => onUpdateValue(label.key, value)"
+      />
+    </dd>
+  </template>
+</template>
+
+<script lang="ts" setup>
+import { cloneDeep } from "lodash-es";
+import {
+  computed,
+  defineProps,
+  defineEmits,
+  withDefaults,
+  watch,
+  watchEffect,
+  reactive,
+} from "vue";
+import { useStore } from "vuex";
+import {
+  Database,
+  DatabaseLabel,
+  Label,
+  LabelKeyType,
+  LabelValueType,
+} from "../../types";
+import { isReservedLabel, parseLabelListInTemplate } from "../../utils";
+import DatabaseLabelPropItem from "./DatabaseLabelPropItem.vue";
+
+const props = withDefaults(
+  defineProps<{
+    labelList: DatabaseLabel[];
+    database: Database;
+    allowEdit?: boolean;
+  }>(),
+  {
+    allowEdit: false,
+  }
+);
+
+const emit = defineEmits<{
+  (event: "update:labelList", labels: DatabaseLabel[]): void;
+}>();
+
+const state = reactive({
+  labelList: cloneDeep(props.labelList),
+});
+
+const store = useStore();
+
+const prepareLabelList = () => {
+  store.dispatch("label/fetchLabelList");
+};
+watchEffect(prepareLabelList);
+
+watch(
+  () => props.labelList,
+  (list) => (state.labelList = cloneDeep(list))
+);
+
+const availableLabelList = computed(() => {
+  const allList = store.getters["label/labelList"]() as Label[];
+  return allList.filter((label) => !isReservedLabel(label));
+});
+
+const requiredLabelList = computed(() => {
+  const { project } = props.database;
+  if (project.tenantMode !== "TENANT") return [];
+  if (!project.dbNameTemplate) return [];
+
+  return parseLabelListInTemplate(
+    project.dbNameTemplate,
+    availableLabelList.value
+  );
+});
+
+const getLabelValue = (key: LabelKeyType): LabelValueType | undefined => {
+  return state.labelList.find((label) => label.key === key)?.value || "";
+};
+
+const setLabelValue = (key: LabelKeyType, value: LabelValueType) => {
+  const index = state.labelList.findIndex((label) => label.key === key);
+
+  if (index < 0) {
+    if (value) {
+      // push new value
+      state.labelList.push({ key, value });
+    }
+  } else {
+    if (value) {
+      state.labelList[index].value = value;
+    } else {
+      // remove empty value from the list
+      state.labelList.splice(index, 1);
+    }
+  }
+};
+
+const onUpdateValue = (key: LabelKeyType, value: LabelValueType) => {
+  setLabelValue(key, value);
+  emit("update:labelList", state.labelList);
+};
+</script>

--- a/frontend/src/components/DatabaseLabels/index.ts
+++ b/frontend/src/components/DatabaseLabels/index.ts
@@ -1,6 +1,7 @@
 import DatabaseLabels from "./DatabaseLabels.vue";
 import DatabaseLabelsEditor from "./DatabaseLabelsEditor.vue";
+import DatabaseLabelProps from "./DatabaseLabelProps.vue";
 
 export default DatabaseLabels;
 
-export { DatabaseLabels, DatabaseLabelsEditor };
+export { DatabaseLabels, DatabaseLabelsEditor, DatabaseLabelProps };

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -87,17 +87,20 @@
                 <heroicons-outline:terminal class="w-4 h-4" />
               </button>
             </dd>
-          </dl>
-          <div v-if="isTenantProject" class="flex items-center mt-2 h-7">
-            <label class="textlabel"
-              >{{ $t("common.labels") }}&nbsp;-&nbsp;</label
-            >
-            <DatabaseLabelsEditor
+            <DatabaseLabelProps
+              v-if="isTenantProject"
               :label-list="database.labels"
+              :database="database"
               :allow-edit="allowEditDatabaseLabels"
-              @save="updateLabels"
-            />
-          </div>
+              @update:label-list="updateLabels"
+            >
+              <template #label="{ label }">
+                <span class="textlabel capitalize">
+                  {{ hidePrefix(label.key) }}&nbsp;-&nbsp;
+                </span>
+              </template>
+            </DatabaseLabelProps>
+          </dl>
         </div>
         <div class="flex items-center space-x-2">
           <button
@@ -224,8 +227,8 @@ import DatabaseBackupPanel from "../components/DatabaseBackupPanel.vue";
 import DatabaseMigrationHistoryPanel from "../components/DatabaseMigrationHistoryPanel.vue";
 import DatabaseOverviewPanel from "../components/DatabaseOverviewPanel.vue";
 import InstanceEngineIcon from "../components/InstanceEngineIcon.vue";
-import { DatabaseLabelsEditor } from "../components/DatabaseLabels";
-import { idFromSlug, isDBAOrOwner, connectionSlug } from "../utils";
+import { DatabaseLabelProps } from "../components/DatabaseLabels";
+import { idFromSlug, isDBAOrOwner, connectionSlug, hidePrefix } from "../utils";
 import {
   ProjectId,
   UNKNOWN_ID,
@@ -261,7 +264,7 @@ export default defineComponent({
     DatabaseMigrationHistoryPanel,
     DatabaseBackupPanel,
     InstanceEngineIcon,
-    DatabaseLabelsEditor,
+    DatabaseLabelProps,
   },
   props: {
     databaseSlug: {
@@ -371,10 +374,7 @@ export default defineComponent({
 
     const allowEditDatabaseLabels = computed((): boolean => {
       // only allowed to edit database labels when allowAdmin
-      if (!allowAdmin.value) return false;
-
-      // not allowed to edit in db name template mode
-      return database.value.project.dbNameTemplate === "";
+      return allowAdmin.value;
     });
 
     const alterSchemaText = computed(() => {
@@ -546,6 +546,7 @@ export default defineComponent({
       updateLabels,
       selectTab,
       gotoSqlEditor,
+      hidePrefix,
     };
   },
 });


### PR DESCRIPTION
- Render db labels as if they are normal props.
- A label is not editable if it's a placeholder in dbNameTemplate.

Screenshot
![label-edit](https://user-images.githubusercontent.com/2749742/153979998-c246f884-747f-442c-9332-c321d351b590.gif)
