### PR TITLE
feat: enable label related features for standard mode projects

### DIFF
--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -115,7 +115,6 @@
 
       <!-- Providing other dropdowns for optional labels as if they are normal optional props of DB -->
       <DatabaseLabelForm
-        v-if="isTenantProject"
         :project="project"
         :label-list="state.labelList"
         filter="optional"
@@ -485,11 +484,11 @@ export default defineComponent({
           state.showFeatureModal = true;
           return;
         }
-        const context = newIssue.createContext as CreateDatabaseContext;
-        // Do not submit non-selected optional labels
-        const labelList = state.labelList.filter((label) => !!label.value);
-        context.labels = JSON.stringify(labelList);
       }
+      const context = newIssue.createContext as CreateDatabaseContext;
+      // Do not submit non-selected optional labels
+      const labelList = state.labelList.filter((label) => !!label.value);
+      context.labels = JSON.stringify(labelList);
       store.dispatch("issue/createIssue", newIssue).then((createdIssue) => {
         router.push(`/issue/${issueSlug(createdIssue.name, createdIssue.id)}`);
       });

--- a/frontend/src/components/Issue/IssueSidebar.vue
+++ b/frontend/src/components/Issue/IssueSidebar.vue
@@ -432,12 +432,7 @@ export default defineComponent({
       return (props.issue as Issue).project;
     });
 
-    const isTenantProject = computed((): boolean => {
-      return project.value.tenantMode === "TENANT";
-    });
-
     const prepareLabelList = () => {
-      if (!isTenantProject.value) return;
       store.dispatch("label/fetchLabelList");
     };
 
@@ -449,7 +444,6 @@ export default defineComponent({
 
     const visibleLabelList = computed((): DatabaseLabel[] => {
       // transform non-reserved labels to db properties
-      if (project.value.tenantMode !== "TENANT") return [];
       if (!props.database) return [];
       if (labelList.value.length === 0) return [];
 

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -88,7 +88,6 @@
               </button>
             </dd>
             <DatabaseLabelProps
-              v-if="isTenantProject"
               :label-list="database.labels"
               :database="database"
               :allow-edit="allowEditDatabaseLabels"


### PR DESCRIPTION
Enable label-related features for standard mode projects.
**This is a proposal PR**, so feel free to reject if it's not good.

These features are now also available for standard mode projects.
- Allow to set Tenant and Location as optional props when creating database.
- Allow to display and edit Tenant and Location in the upper area of database detail page.
- Display Tenant and Location in issue sidebar.