### PR TITLE
feat(sql-editor): run non-SELECT SQL navigate to the different workflow

### DIFF
--- a/frontend/src/components/MonacoEditor/sqlParser.ts
+++ b/frontend/src/components/MonacoEditor/sqlParser.ts
@@ -6,6 +6,10 @@ type ParseResult = {
   error: Error | null;
 };
 
+const DDL_TYPE = ["create", "alter", "drop"];
+const DML_TYPE = ["insert", "update", "delete"];
+const SELECT = "select";
+
 export const parseSQL = (sql: string): ParseResult => {
   if (sql === "") {
     return { data: [], error: null };
@@ -29,17 +33,43 @@ export const isValidStatement = (data: ParseResult["data"]) => {
 export const isSelectStatement = (data: ParseResult["data"]) => {
   // if the sql statement is an object, it's a single sql statement
   if (isObject(data) && !isArray(data)) {
-    return data.type.toLowerCase() === "select";
+    return data.type.toLowerCase() === SELECT;
   }
   // if the sql statement is an array, it's a multiple sql statements
   if (isArray(data)) {
-    return data.every((statement) => statement.type.toLowerCase() === "select");
+    return data.every((statement) => statement.type.toLowerCase() === SELECT);
   }
 };
 
 export const isMultipleStatements = (data: ParseResult["data"]) => {
   // if the sql statement is an array and it's more than one statement
   return isArray(data) && data.length > 1;
+};
+
+export const isDDLStatement = (data: ParseResult["data"]) => {
+  // if the sql statement is an object, it's a single sql statement
+  if (isObject(data) && !isArray(data)) {
+    return DDL_TYPE.includes(data.type.toLowerCase());
+  }
+  // if the sql statement is an array, it's a multiple sql statements
+  if (isArray(data)) {
+    return data.every((statement) =>
+      DDL_TYPE.includes(statement.type.toLowerCase())
+    );
+  }
+};
+
+export const isDMLStatement = (data: ParseResult["data"]) => {
+  // if the sql statement is an object, it's a single sql statement
+  if (isObject(data) && !isArray(data)) {
+    return DML_TYPE.includes(data.type.toLowerCase());
+  }
+  // if the sql statement is an array, it's a multiple sql statements
+  if (isArray(data)) {
+    return data.every((statement) =>
+      DML_TYPE.includes(statement.type.toLowerCase())
+    );
+  }
 };
 
 export const transformSQL = (data: AST | AST[], database = "MySQL") => {

--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -8,6 +8,8 @@ import {
   transformSQL,
   isSelectStatement,
   isMultipleStatements,
+  isDDLStatement,
+  isDMLStatement,
 } from "../components/MonacoEditor/sqlParser";
 
 const useExecuteSQL = () => {
@@ -49,11 +51,19 @@ const useExecuteSQL = () => {
       return;
     }
 
-    if (data !== null && !isSelectStatement(data)) {
-      store.dispatch("sqlEditor/setSqlEditorState", {
-        isShowExecutingHint: true,
-      });
+    if (data === undefined) {
+      notify("CRITICAL", t("sql-editor.notify-invalid-sql-statement"));
       return;
+    }
+
+    if (data !== null && !isSelectStatement(data)) {
+      // only DDL and DML statements are allowed
+      if (isDDLStatement(data) || isDMLStatement(data)) {
+        store.dispatch("sqlEditor/setSqlEditorState", {
+          isShowExecutingHint: true,
+        });
+        return;
+      }
     }
 
     if (isMultipleStatements(data)) {

--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -57,6 +57,14 @@ const useExecuteSQL = () => {
     }
 
     if (data !== null && !isSelectStatement(data)) {
+      if (isMultipleStatements(data)) {
+        notify(
+          "INFO",
+          t("common.tips"),
+          t("sql-editor.notify-multiple-statements")
+        );
+        return;
+      }
       // only DDL and DML statements are allowed
       if (isDDLStatement(data) || isDMLStatement(data)) {
         store.dispatch("sqlEditor/setSqlEditorState", {

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -1099,6 +1099,7 @@ sql-editor:
     Multiple SQL statements detected. SQL Editor only executes the first
     statement. You can select another statement and execute it individually.
   goto-alter-schema-hint: Please select a database connection from the top of the editor
+  notify-invalid-sql-statement: Invalid SQL statement.
   can-not-execute-query: Can not execute query when loading data.
   rows: row | rows
   no-history-found: No history found

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -969,6 +969,7 @@ sql-editor:
   table-schema-placeholder: 选择一个表进行查看 Schema
   notify-empty-statement: 请在编辑器中输入 SQL 语句
   notify-multiple-statements: 检测到您输入了多条 SQL 语句。SQL 编辑器只支持执行第一条语句。您可以选择其他语句单独执行。
+  notify-invalid-sql-statement: 请检查您的 SQL 语句。
   goto-alter-schema-hint: 请从编辑器顶部选择一个数据库连接
   can-not-execute-query: 加载数据时无法执行查询
   rows: 条记录


### PR DESCRIPTION
Resolve the issue: https://linear.app/bbteam/issue/BYT-155/run-non-select-dml-should-navigate-to-the-data-change-dml-workflow

We distinguish whether the SQL statement is a DDL or a DML statement by the keywords:

DDL: `create`、`alter`、`drop`
DML: `insert`、`update`、`delete`