### PR TITLE
fix: fixed inconsistent in bbswitch

### DIFF
--- a/frontend/src/bbkit/BBSwitch.vue
+++ b/frontend/src/bbkit/BBSwitch.vue
@@ -3,13 +3,15 @@
     <button
       type="button"
       class="relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent disabled:cursor-not-allowed select-none"
-      :class="on ? 'bg-accent disabled:bg-accent-disabled' : 'bg-gray-200'"
+      :class="dirtyOn ? 'bg-accent disabled:bg-accent-disabled' : 'bg-gray-200'"
       :disabled="disabled"
       aria-pressed="false"
       @click.prevent="
         () => {
-          on = !on;
-          $emit('toggle', on);
+          dirtyOn = !dirtyOn;
+          $emit('toggle', dirtyOn);
+
+          dirtyOn = props.value;
         }
       "
     >
@@ -18,7 +20,7 @@
       <span
         aria-hidden="true"
         class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"
-        :class="on ? 'translate-x-5' : 'translate-x-0'"
+        :class="dirtyOn ? 'translate-x-5' : 'translate-x-0'"
       ></span>
     </button>
     <span
@@ -48,15 +50,16 @@ const props = withDefaults(
 );
 
 defineEmits<{
-  (event: "toggle", on: boolean): void;
+  (event: "toggle", dirtyOn: boolean): void;
 }>();
 
-const on = ref(props.value);
+const dirtyOn = ref(props.value);
 
 watch(
   () => props.value,
   (cur) => {
-    on.value = cur;
+    console.log(dirtyOn, props.value);
+    dirtyOn.value = cur;
   }
 );
 </script>

--- a/frontend/src/bbkit/BBSwitch.vue
+++ b/frontend/src/bbkit/BBSwitch.vue
@@ -3,15 +3,17 @@
     <button
       type="button"
       class="relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent disabled:cursor-not-allowed select-none"
-      :class="dirtyOn ? 'bg-accent disabled:bg-accent-disabled' : 'bg-gray-200'"
+      :class="
+        state.dirtyOn ? 'bg-accent disabled:bg-accent-disabled' : 'bg-gray-200'
+      "
       :disabled="disabled"
       aria-pressed="false"
       @click.prevent="
         () => {
-          dirtyOn = !dirtyOn;
-          $emit('toggle', dirtyOn);
+          state.dirtyOn = !state.dirtyOn;
+          $emit('toggle', state.dirtyOn);
 
-          dirtyOn = props.value;
+          state.dirtyOn = props.value;
         }
       "
     >
@@ -20,7 +22,7 @@
       <span
         aria-hidden="true"
         class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"
-        :class="dirtyOn ? 'translate-x-5' : 'translate-x-0'"
+        :class="state.dirtyOn ? 'translate-x-5' : 'translate-x-0'"
       ></span>
     </button>
     <span
@@ -34,7 +36,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch, defineProps, defineEmits, withDefaults } from "vue";
+import { watch, defineProps, defineEmits, withDefaults, reactive } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -53,13 +55,14 @@ defineEmits<{
   (event: "toggle", dirtyOn: boolean): void;
 }>();
 
-const dirtyOn = ref(props.value);
+const state = reactive({
+  dirtyOn: props.value,
+});
 
 watch(
   () => props.value,
   (cur) => {
-    console.log(dirtyOn, props.value);
-    dirtyOn.value = cur;
+    state.dirtyOn = cur;
   }
 );
 </script>


### PR DESCRIPTION
BBSwitch maintains an inner state (`on`) to update its appearance, which violates the principle that child-component should be rendered according to its properties passed by its parent.