### PR TITLE
feat: new database matrix UI

### DIFF
--- a/frontend/src/components/TenantDatabaseTable/DatabaseMatrix.vue
+++ b/frontend/src/components/TenantDatabaseTable/DatabaseMatrix.vue
@@ -50,8 +50,7 @@
             v-for="db in dbList"
             :key="db.id"
             :database="db"
-            :custom-click="customClick"
-            @select-database="(db) => $emit('select-database', db)"
+            :label-list="labelList"
           />
           <span v-if="dbList.length === 0">-</span>
         </div>
@@ -86,10 +85,6 @@ export default defineComponent({
       default: true,
       type: Boolean,
     },
-    customClick: {
-      default: false,
-      type: Boolean,
-    },
     name: {
       type: String,
       default: "",
@@ -119,7 +114,6 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ["select-database"],
   setup(props) {
     /**
      * databases are grouped by `yAxisLabel` then by `xAxisLabel`

--- a/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
+++ b/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
@@ -77,7 +77,7 @@
               v-for="db in dbList"
               :key="db.id"
               :database="db"
-              :clickable="false"
+              :label-list="labelList"
             />
             <span v-if="dbList.length === 0">-</span>
           </div>
@@ -89,7 +89,7 @@
               v-for="db in matrix.rest"
               :key="db.id"
               :database="db"
-              :clickable="false"
+              :label-list="labelList"
             />
             <span v-if="matrix.rest.length === 0">-</span>
           </div>

--- a/frontend/src/components/TenantDatabaseTable/TenantDatabaseTable.vue
+++ b/frontend/src/components/TenantDatabaseTable/TenantDatabaseTable.vue
@@ -46,10 +46,6 @@ export default defineComponent({
       default: "ALL",
       type: String as PropType<Mode>,
     },
-    customClick: {
-      default: false,
-      type: Boolean,
-    },
     labelList: {
       type: Array as PropType<Label[]>,
       required: true,
@@ -71,7 +67,6 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ["select-database"],
   setup(props) {
     const store = useStore();
 

--- a/frontend/src/components/TenantDatabaseTable/YAxisRadioGroup.vue
+++ b/frontend/src/components/TenantDatabaseTable/YAxisRadioGroup.vue
@@ -1,8 +1,6 @@
 <template>
   <div v-if="label" class="flex items-center space-x-2">
-    <slot name="title">
-      <label for="group-by">Group by</label>
-    </slot>
+    <slot name="title"> </slot>
 
     <label v-for="lbl in labelList" :key="lbl.key">
       <input


### PR DESCRIPTION
- The card is simplified, with more concentration on db's status by the larger icon.
- The whole card is not clickable anymore. The db name and schema version are clickable instead, redirecting to different tabs of db detail page.
- The labels in popover is rendered as normal db properties, with better text alignment.
- Last successful sync time is no longer displayed on the card. It's only displayed on the popover.
- "Group by" label is removed. Users will learn it after 1st use.

Screenshot
<img width="640" alt="image" src="https://user-images.githubusercontent.com/2749742/155484353-798c4141-1076-4ef8-96b6-a364a46179f0.png">
