### PR TITLE
fix: bbkit modal mask is not prevent clicking on elements below the mask layer

### DIFF
--- a/frontend/src/bbkit/BBModalStack.vue
+++ b/frontend/src/bbkit/BBModalStack.vue
@@ -73,7 +73,7 @@ export default defineComponent({
 
 <style scope>
 .bb-modal-mask {
-  @apply fixed inset-0 w-full h-screen flex items-center justify-center z-40 pointer-events-none;
+  @apply fixed inset-0 w-full h-screen flex items-center justify-center z-40;
   background-color: rgba(209, 213, 219, 0.8); /* bg-gray-300 */
 }
 </style>


### PR DESCRIPTION

https://github.com/bytebase/bytebase/pull/176#issuecomment-1051602532