### PR TITLE
feat: project member with multiple role provider

### DIFF
--- a/api/project.go
+++ b/api/project.go
@@ -114,7 +114,7 @@ type ProjectFind struct {
 	RowStatus *RowStatus
 
 	// Domain specific fields
-	// If present, will only find project containing PrincipalID as a member
+	// If present, will only find project containing PrincipalID as an active member
 	PrincipalID *int
 }
 

--- a/api/project_member.go
+++ b/api/project_member.go
@@ -112,15 +112,17 @@ type ProjectMemberDelete struct {
 	DeleterID int
 }
 
-// ProjectMemberSet is the API message for seting project member.
-type ProjectMemberSet struct {
+// ProjectMemberBatchUpdate is the API message for batch updating project member.
+type ProjectMemberBatchUpdate struct {
 	ID int
 
 	// Standard fields
 	// Value is assigned from the jwt subject field passed by the client.
 	UpdaterID int
 
-	List []*ProjectMemberCreate
+	// All the Member to be update should have the same role provider as this field
+	RoleProvider ProjectRoleProvider
+	List         []*ProjectMemberCreate
 }
 
 // ProjectMemberService is the service for project members.
@@ -130,5 +132,5 @@ type ProjectMemberService interface {
 	FindProjectMember(ctx context.Context, find *ProjectMemberFind) (*ProjectMember, error)
 	PatchProjectMember(ctx context.Context, patch *ProjectMemberPatch) (*ProjectMember, error)
 	DeleteProjectMember(ctx context.Context, delete *ProjectMemberDelete) error
-	SetProjectMember(ctx context.Context, set *ProjectMemberSet) (createdMember, deletedMember []*ProjectMember, err error)
+	BatchUpdateProjectMember(ctx context.Context, set *ProjectMemberBatchUpdate) (createdMember, deletedMember []*ProjectMember, err error)
 }

--- a/api/project_member.go
+++ b/api/project_member.go
@@ -78,7 +78,8 @@ type ProjectMemberFind struct {
 	ID *int
 
 	// Related fields
-	ProjectID *int
+	ProjectID    *int
+	RoleProvider *ProjectRoleProvider
 }
 
 func (find *ProjectMemberFind) String() string {

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -44,15 +44,7 @@
       :mask-closable="false"
       preset="dialog"
       :title="$t('settings.members.toggle-role-provider.title')"
-      :content="modalContent"
-      :on-after-enter="
-        () => {
-          modalContent =
-            project.roleProvider === 'BYTEBASE'
-              ? $t('settings.members.change-role-provider-to-vcs.content')
-              : '';
-        }
-      "
+      :content="$t('settings.members.change-role-provider-to-vcs.content')"
       :on-after-leave="
         () => {
           previewMember = false;
@@ -209,7 +201,6 @@ interface LocalState {
   showModal: boolean;
   roleProvider: boolean;
   previewMember: boolean;
-  modalContent: string;
 }
 
 export default defineComponent({
@@ -234,7 +225,6 @@ export default defineComponent({
       showModal: false,
       roleProvider: false,
       previewMember: false,
-      modalContent: "",
     });
 
     const hasRBACFeature = computed(() =>

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -65,11 +65,11 @@
           } else if (project.roleProvider === 'GITLAB_SELF_HOST') {
             // the current role provider is GITLAB_SELF_HOST, meaning switching role provider to BYTEBASE
             patchProjectRoleProvider('BYTEBASE').then(() => {
-              store
+              $store
                 .dispatch('notification/pushNotification', {
                   module: 'bytebase',
                   style: 'SUCCESS',
-                  title: t(
+                  title: $t(
                     'project.settings.switch-role-provider-to-bytebase-success-prompt'
                   ),
                 })

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -30,7 +30,7 @@
               state.showModal = true;
               if (!on) {
                 // we preview member if user try to switch role provider to Bytebase
-                previewMember = true;
+                state.previewMember = true;
               }
             }
           "
@@ -47,7 +47,7 @@
       :content="$t('settings.members.change-role-provider-to-vcs.content')"
       :on-after-leave="
         () => {
-          previewMember = false;
+          state.previewMember = false;
         }
       "
       :positive-text="$t('common.confirm')"
@@ -84,7 +84,7 @@
         }
       "
     >
-      <template v-if="previewMember">
+      <template v-if="state.previewMember">
         <div class="mx-1">
           {{ $t("settings.members.change-role-provider-to-bytebase.content") }}
         </div>

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -88,7 +88,7 @@
         <div class="mx-1">
           {{ $t("settings.members.change-role-provider-to-bytebase.content") }}
         </div>
-        <div class="overflow-y-auto h-64">
+        <div class="overflow-y-auto max-h-72">
           <ProjectMemberTable
             :project="project"
             :active-role-provider="'BYTEBASE'"

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -248,6 +248,7 @@ export default defineComponent({
       for (const member of props.project.memberList) {
         if (
           member.principal.id == currentUser.value.id &&
+          // only member with the same role provider as that of the project will be consider a valid member
           member.roleProvider === props.project.roleProvider
         ) {
           if (isProjectOwner(member.role)) {

--- a/frontend/src/components/ProjectMemberTable.vue
+++ b/frontend/src/components/ProjectMemberTable.vue
@@ -130,6 +130,7 @@ import {
   ProjectRoleType,
   MemberId,
   ProjectMemberPatch,
+  ProjectRoleProvider,
 } from "../types";
 import { BBTableColumn, BBTableSectionDataSource } from "../bbkit/types";
 import { isOwner, isProjectOwner } from "../utils";
@@ -145,6 +146,11 @@ export default {
     project: {
       required: true,
       type: Object as PropType<Project>,
+    },
+    activeRoleProvider: {
+      require: false,
+      default: null,
+      type: Object as PropType<ProjectRoleProvider>,
     },
   },
   setup(props) {
@@ -175,6 +181,18 @@ export default {
         const ownerList: ProjectMember[] = [];
         const developerList: ProjectMember[] = [];
         for (const member of props.project.memberList) {
+          if (
+            !props.activeRoleProvider &&
+            member.roleProvider !== props.project.roleProvider
+          ) {
+            continue;
+          } else if (
+            props.activeRoleProvider &&
+            member.roleProvider !== props.activeRoleProvider
+          ) {
+            continue;
+          }
+
           if (member.role == "OWNER") {
             ownerList.push(member);
           }
@@ -206,7 +224,6 @@ export default {
         return dataSource;
       }
     );
-
     const columnList = computed((): BBTableColumn[] => {
       return hasRBACFeature.value
         ? [

--- a/frontend/src/components/ProjectMemberTable.vue
+++ b/frontend/src/components/ProjectMemberTable.vue
@@ -137,7 +137,9 @@ import { isOwner, isProjectOwner } from "../utils";
 import { useI18n } from "vue-i18n";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface LocalState {}
+interface LocalState {
+  activeRoleProvider: ProjectRoleProvider;
+}
 
 export default {
   name: "ProjectMemberTable",
@@ -163,7 +165,11 @@ export default {
       store.getters["subscription/feature"]("bb.feature.rbac")
     );
 
-    const state = reactive<LocalState>({});
+    const state = reactive<LocalState>({
+      activeRoleProvider: props.activeRoleProvider
+        ? props.activeRoleProvider
+        : props.project.roleProvider,
+    });
 
     const RoleProviderConfig = {
       GITLAB_SELF_HOST: {
@@ -181,15 +187,7 @@ export default {
         const ownerList: ProjectMember[] = [];
         const developerList: ProjectMember[] = [];
         for (const member of props.project.memberList) {
-          if (
-            !props.activeRoleProvider &&
-            member.roleProvider !== props.project.roleProvider
-          ) {
-            continue;
-          } else if (
-            props.activeRoleProvider &&
-            member.roleProvider !== props.activeRoleProvider
-          ) {
+          if (member.roleProvider !== state.activeRoleProvider) {
             continue;
           }
 

--- a/frontend/src/components/ProjectMemberTable.vue
+++ b/frontend/src/components/ProjectMemberTable.vue
@@ -137,9 +137,7 @@ import { isOwner, isProjectOwner } from "../utils";
 import { useI18n } from "vue-i18n";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface LocalState {
-  activeRoleProvider: ProjectRoleProvider;
-}
+interface LocalState {}
 
 export default {
   name: "ProjectMemberTable",
@@ -165,10 +163,12 @@ export default {
       store.getters["subscription/feature"]("bb.feature.rbac")
     );
 
-    const state = reactive<LocalState>({
-      activeRoleProvider: props.activeRoleProvider
+    const state = reactive<LocalState>({});
+
+    const activeRoleProvider = computed(() => {
+      return props.activeRoleProvider
         ? props.activeRoleProvider
-        : props.project.roleProvider,
+        : props.project.roleProvider;
     });
 
     const RoleProviderConfig = {
@@ -187,7 +187,7 @@ export default {
         const ownerList: ProjectMember[] = [];
         const developerList: ProjectMember[] = [];
         for (const member of props.project.memberList) {
-          if (member.roleProvider !== state.activeRoleProvider) {
+          if (member.roleProvider !== activeRoleProvider.value) {
             continue;
           }
 

--- a/frontend/src/components/ProjectMemberTable.vue
+++ b/frontend/src/components/ProjectMemberTable.vue
@@ -150,7 +150,7 @@ export default {
     activeRoleProvider: {
       require: false,
       default: null,
-      type: Object as PropType<ProjectRoleProvider>,
+      type: String as PropType<ProjectRoleProvider>,
     },
   },
   setup(props) {

--- a/frontend/src/components/ProjectMemberTable.vue
+++ b/frontend/src/components/ProjectMemberTable.vue
@@ -166,6 +166,7 @@ export default {
     const state = reactive<LocalState>({});
 
     const activeRoleProvider = computed(() => {
+      // if props.activeRoleProvider is not passed as a property, we will use props.project.roleProvider by default
       return props.activeRoleProvider
         ? props.activeRoleProvider
         : props.project.roleProvider;
@@ -187,6 +188,7 @@ export default {
         const ownerList: ProjectMember[] = [];
         const developerList: ProjectMember[] = [];
         for (const member of props.project.memberList) {
+          // only member with the same role provider as the active one would be consider a valid member
           if (member.roleProvider !== activeRoleProvider.value) {
             continue;
           }

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -295,9 +295,17 @@ settings:
       role-provider: This role is mapped from {rawRole} provided by {roleProvider}
     toggle-role-provider:
       title: Are you sure?
+    change-role-provider-to-vcs:
       content: >-
         Changing role provider to VCS will replace all existing members with the
         members from the corresponding VCS project.
+
+        The existing members will be set to an inactive state. You can reset
+        role provider to Bytebase to restore this change.
+    change-role-provider-to-bytebase:
+      content: >-
+        You are about to restore the following member. All member provided by
+        VCS will be put into an inactive state.
 activity:
   name: Name
   comment: Comment
@@ -1168,7 +1176,9 @@ label:
     description: >-
       A label is a key-value pair that helps you identify the tenant for a
       database. {link}.
-  db-name-template-tips: Allow you to group databases with the same {placeholder} from different tenants. {link}.
+  db-name-template-tips: >-
+    Allow you to group databases with the same {placeholder} from different
+    tenants. {link}.
 oauth:
   unknown-event: Unexpeted event type, OAuth failed.
 subscription:

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -300,8 +300,8 @@ settings:
         Changing role provider to VCS will replace all existing members with the
         members from the corresponding VCS project.
 
-        The existing members will be set to an inactive state. You can reset
-        role provider to Bytebase to restore this change.
+        The existing members will become inactive. You can reset
+        role provider to Bytebase to restore those members.
     change-role-provider-to-bytebase:
       content: >-
         You are about to restore the following members. All existing members synced from VCS will be removed.

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -972,7 +972,7 @@ project:
       btn-text: Restore this @.lower:{'common.project'}
     sync-from-vcs: Sync from VCS
     success-member-sync-prompt: Sync member from VCS Succeeded
-    view-vcs-member: view member at VCS
+    view-vcs-member: view members at VCS
     switch-role-provider-to-bytebase-success-prompt: Successfully switching project role provider to Bytebase.
   mode:
     standard: Standard

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -304,8 +304,7 @@ settings:
         role provider to Bytebase to restore this change.
     change-role-provider-to-bytebase:
       content: >-
-        You are about to restore the following member. All member provided by
-        VCS will be put into an inactive state.
+        You are about to restore the following members. All existing members synced from VCS will be removed.
 activity:
   name: Name
   comment: Comment

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -972,7 +972,7 @@ project:
       btn-text: Restore this @.lower:{'common.project'}
     sync-from-vcs: Sync from VCS
     success-member-sync-prompt: Sync member from VCS Succeeded
-    view-vcs-member: view members at VCS
+    view-vcs-member: View members at VCS
     switch-role-provider-to-bytebase-success-prompt: Successfully switching project role provider to Bytebase.
   mode:
     standard: Standard

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -289,7 +289,12 @@ settings:
       role-provider: 该角色同步自 {roleProvider} 的 {rawRole}
     toggle-role-provider:
       title: 您确认吗？
-      content: 将角色权限提供方切换至 VCS 将会用 VCS 中对应仓库的成员列表替换现存的所有成员。
+    change-role-provider-to-vcs:
+      content: |-
+        将角色权限提供方切换至 VCS 将会用 VCS 中对应仓库的成员列表替换现存的所有成员。
+        原来的成员将会被设置成闲置状态。您可以切换回 Bytebase 来撤销这一操作。
+    change-role-provider-to-bytebase:
+      content: 你将会恢复以下成员的权限。所有由 VCS 提供的成员将会被闲置。
 activity:
   name: 名称
   comment: 评论

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -294,7 +294,7 @@ settings:
         将角色权限提供方切换至 VCS 将会用 VCS 中对应仓库的成员列表替换现存的所有成员。
         原来的成员将会被设置成闲置状态。您可以切换回 Bytebase 来撤销这一操作。
     change-role-provider-to-bytebase:
-      content: 你将会恢复以下成员的权限。所有由 VCS 提供的成员将会被闲置。
+      content: 将会恢复成以下成员的权限。所有由 VCS 提供的成员将会被移除。
 activity:
   name: 名称
   comment: 评论

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -292,7 +292,7 @@ settings:
     change-role-provider-to-vcs:
       content: |-
         将角色权限提供方切换至 VCS 将会用 VCS 中对应仓库的成员列表替换现存的所有成员。
-        原来的成员将会被设置成闲置状态。您可以切换回 Bytebase 来撤销这一操作。
+        原来的成员将会无效，您之后可以将角色权限切换回 Bytebase 来撤销这一操作。
     change-role-provider-to-bytebase:
       content: 将会恢复成以下成员的权限。所有由 VCS 提供的成员将会被移除。
 activity:

--- a/server/project.go
+++ b/server/project.go
@@ -104,6 +104,12 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 				}
 			}
 		}
+
+		// if principalID is not passed, we will disable the filter logic
+		if projectFind.PrincipalID == nil {
+			activeProjectList = list
+		}
+
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
 		if err := jsonapi.MarshalPayload(c.Response().Writer, activeProjectList); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal project list response").SetInternal(err)

--- a/server/project.go
+++ b/server/project.go
@@ -77,7 +77,6 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			if err != nil {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Query parameter user is not a number: %s", userIDStr)).SetInternal(err)
 			}
-
 			projectFind.PrincipalID = &userID
 		}
 		if rowStatusStr := c.QueryParam("rowstatus"); rowStatusStr != "" {
@@ -89,7 +88,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch project list").SetInternal(err)
 		}
 
-		activeProjectList := make([]*api.Project, 0)
+		var activeProjectList []*api.Project
 		for _, project := range list {
 			if err := s.composeProjectRelationship(ctx, project); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch project relationship: %v", project.Name)).SetInternal(err)

--- a/server/project_member.go
+++ b/server/project_member.go
@@ -119,12 +119,13 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 			createList = append(createList, createProjectMember)
 		}
 
-		setProjectMEmber := &api.ProjectMemberSet{
-			ID:        projectID,
-			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
-			List:      createList,
+		batchUpdateProjectMember := &api.ProjectMemberBatchUpdate{
+			ID:           projectID,
+			UpdaterID:    c.Get(getPrincipalIDContextKey()).(int),
+			RoleProvider: "GITLAB_SELF_HOST", /* we only support gitlab for now */
+			List:         createList,
 		}
-		createdMemberList, deletedMemberList, err := s.ProjectMemberService.SetProjectMember(ctx, setProjectMEmber)
+		createdMemberList, deletedMemberList, err := s.ProjectMemberService.BatchUpdateProjectMember(ctx, batchUpdateProjectMember)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to sync project member from VCS").SetInternal(err)
 		}

--- a/server/project_member.go
+++ b/server/project_member.go
@@ -122,7 +122,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 		batchUpdateProjectMember := &api.ProjectMemberBatchUpdate{
 			ID:           projectID,
 			UpdaterID:    c.Get(getPrincipalIDContextKey()).(int),
-			RoleProvider: "GITLAB_SELF_HOST", /* we only support gitlab for now */
+			RoleProvider: api.ProjectRoleProviderGitLabSelfHost, /* we only support gitlab for now */
 			List:         createList,
 		}
 		createdMemberList, deletedMemberList, err := s.ProjectMemberService.BatchUpdateProjectMember(ctx, batchUpdateProjectMember)

--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -236,7 +236,7 @@ CREATE TABLE project_member (
     payload JSONB NOT NULL DEFAULT '{}'
 );
 
-CREATE UNIQUE INDEX idx_project_member_unique_project_id_principal_id_role_provider ON project_member(project_id, principal_id, role_provider));
+CREATE UNIQUE INDEX idx_project_member_unique_project_id_role_provider_principal_id ON project_member(project_id, role_provider, principal_id);
 
 ALTER SEQUENCE project_member_id_seq RESTART WITH 100;
 

--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -233,7 +233,8 @@ CREATE TABLE project_member (
     -- allowed role_provider are 'BYTEBASE', 'GITLAB_SELF_HOST'.
     role_provider TEXT NOT NULL DEFAULT 'BYTEBASE',
     -- payload is determined by the type of role_provider
-    payload TEXT NOT NULL DEFAULT ''
+    payload TEXT NOT NULL DEFAULT '',
+    UNIQUE(project_id, principal_id, role_provider)
 );
 
 CREATE UNIQUE INDEX idx_project_member_unique_project_id_principal_id ON project_member(project_id, principal_id);

--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -234,7 +234,6 @@ CREATE TABLE project_member (
     role_provider TEXT NOT NULL DEFAULT 'BYTEBASE',
     -- payload is determined by the type of role_provider
     payload TEXT NOT NULL DEFAULT '',
-    UNIQUE(project_id, principal_id, role_provider)
 );
 
 CREATE UNIQUE INDEX idx_project_member_unique_project_id_principal_id_role_provider ON project_member(project_id, principal_id, role_provider));

--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -237,7 +237,7 @@ CREATE TABLE project_member (
     UNIQUE(project_id, principal_id, role_provider)
 );
 
-CREATE UNIQUE INDEX idx_project_member_unique_project_id_principal_id ON project_member(project_id, principal_id);
+CREATE UNIQUE INDEX idx_project_member_unique_project_id_principal_id_role_provider ON project_member(project_id, principal_id, role_provider));
 
 ALTER SEQUENCE project_member_id_seq RESTART WITH 100;
 

--- a/store/migration/10001__init_schema.sql
+++ b/store/migration/10001__init_schema.sql
@@ -26,7 +26,7 @@ CREATE TABLE principal (
 CREATE UNIQUE INDEX idx_principal_unique_email ON principal(email);
 
 CREATE TRIGGER update_principal_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON principal FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -74,7 +74,7 @@ CREATE UNIQUE INDEX idx_setting_unique_name ON setting(name);
 ALTER SEQUENCE setting_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_setting_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON setting FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -101,7 +101,7 @@ CREATE UNIQUE INDEX idx_member_unique_principal_id ON member(principal_id);
 ALTER SEQUENCE member_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_member_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON member FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -124,7 +124,7 @@ CREATE UNIQUE INDEX idx_environment_unique_name ON environment(name);
 ALTER SEQUENCE environment_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_environment_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON environment FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -153,7 +153,7 @@ CREATE UNIQUE INDEX idx_policy_unique_environment_id_type ON policy(environment_
 ALTER SEQUENCE policy_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_policy_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON policy FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -212,7 +212,7 @@ VALUES
 ALTER SEQUENCE project_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_project_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON project FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -241,7 +241,7 @@ CREATE UNIQUE INDEX idx_project_member_unique_project_id_principal_id ON project
 ALTER SEQUENCE project_member_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_project_member_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON project_member FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -271,7 +271,7 @@ CREATE UNIQUE INDEX idx_project_webhook_unique_project_id_url ON project_webhook
 ALTER SEQUENCE project_webhook_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_project_webhook_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON project_webhook FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -298,7 +298,7 @@ CREATE TABLE instance (
 ALTER SEQUENCE instance_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_instance_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON instance FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -322,7 +322,7 @@ ALTER SEQUENCE instance_user_id_seq RESTART WITH 100;
 CREATE UNIQUE INDEX idx_instance_user_unique_instance_id_name ON instance_user(instance_id, name);
 
 CREATE TRIGGER update_instance_user_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON instance_user FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -357,7 +357,7 @@ CREATE UNIQUE INDEX idx_db_unique_instance_id_name ON db(instance_id, name);
 ALTER SEQUENCE db_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_db_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON db FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -392,7 +392,7 @@ CREATE UNIQUE INDEX idx_tbl_unique_database_id_name ON tbl(database_id, name);
 ALTER SEQUENCE tbl_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_tbl_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON tbl FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -426,7 +426,7 @@ CREATE UNIQUE INDEX idx_col_unique_database_id_table_id_name ON col(database_id,
 ALTER SEQUENCE col_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_col_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON col FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -459,7 +459,7 @@ CREATE UNIQUE INDEX idx_idx_unique_database_id_table_id_name_expression ON idx(d
 ALTER SEQUENCE idx_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_idx_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON idx FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -487,7 +487,7 @@ CREATE UNIQUE INDEX idx_vw_unique_database_id_name ON vw(database_id, name);
 ALTER SEQUENCE vw_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_vw_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON vw FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -520,7 +520,7 @@ CREATE UNIQUE INDEX idx_data_source_unique_database_id_name ON data_source(datab
 ALTER SEQUENCE data_source_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_data_source_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON data_source FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -554,7 +554,7 @@ CREATE UNIQUE INDEX idx_backup_unique_database_id_name ON backup(database_id, na
 ALTER SEQUENCE backup_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_backup_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON backup FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -586,7 +586,7 @@ CREATE UNIQUE INDEX idx_backup_setting_unique_database_id ON backup_setting(data
 ALTER SEQUENCE backup_setting_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_backup_setting_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON backup_setting FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -612,7 +612,7 @@ CREATE INDEX idx_pipeline_status ON pipeline(status);
 ALTER SEQUENCE pipeline_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_pipeline_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON pipeline FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -636,7 +636,7 @@ CREATE INDEX idx_stage_pipeline_id ON stage(pipeline_id);
 ALTER SEQUENCE stage_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_stage_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON stage FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -673,7 +673,7 @@ CREATE INDEX idx_task_earliest_allowed_ts ON task(earliest_allowed_ts);
 ALTER SEQUENCE task_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_task_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON task FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -703,7 +703,7 @@ CREATE INDEX idx_task_run_task_id ON task_run(task_id);
 ALTER SEQUENCE task_run_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_task_run_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON task_run FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -732,7 +732,7 @@ CREATE INDEX idx_task_check_run_task_id ON task_check_run(task_id);
 ALTER SEQUENCE task_check_run_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_task_check_run_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON task_check_run FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -775,7 +775,7 @@ CREATE INDEX idx_issue_created_ts ON issue(created_ts);
 ALTER SEQUENCE issue_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_issue_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON issue FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -817,7 +817,7 @@ CREATE INDEX idx_activity_created_ts ON activity(created_ts);
 ALTER SEQUENCE activity_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_activity_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON activity FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -859,7 +859,7 @@ CREATE UNIQUE INDEX idx_bookmark_unique_creator_id_link ON bookmark(creator_id, 
 ALTER SEQUENCE bookmark_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_bookmark_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON bookmark FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -887,7 +887,7 @@ CREATE TABLE vcs (
 ALTER SEQUENCE vcs_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_vcs_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON vcs FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -949,7 +949,7 @@ CREATE UNIQUE INDEX idx_repository_unique_webhook_endpoint_id ON repository(webh
 ALTER SEQUENCE repository_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_repository_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON repository FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -979,7 +979,7 @@ CREATE INDEX idx_anomaly_database_id_row_status_type ON anomaly(database_id, row
 ALTER SEQUENCE anomaly_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_anomaly_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON anomaly FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -1003,7 +1003,7 @@ CREATE UNIQUE INDEX idx_label_key_unique_key ON label_key(key);
 ALTER SEQUENCE label_key_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_label_key_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON label_key FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -1027,7 +1027,7 @@ CREATE UNIQUE INDEX idx_label_value_unique_key_value ON label_value(key, value);
 ALTER SEQUENCE label_value_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_label_value_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON label_value FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -1053,7 +1053,7 @@ CREATE UNIQUE INDEX idx_db_label_unique_database_id_key ON db_label(database_id,
 ALTER SEQUENCE db_label_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_db_label_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON db_label FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -1078,7 +1078,7 @@ CREATE UNIQUE INDEX idx_deployment_config_unique_project_id ON deployment_config
 ALTER SEQUENCE deployment_config_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_deployment_config_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON deployment_config FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();
@@ -1109,7 +1109,7 @@ CREATE INDEX idx_sheet_database_id_row_status ON sheet(database_id, row_status);
 ALTER SEQUENCE sheet_id_seq RESTART WITH 100;
 
 CREATE TRIGGER update_sheet_updated_ts
-AFTER
+BEFORE
 UPDATE
     ON sheet FOR EACH ROW
 EXECUTE FUNCTION trigger_after_update_updated_ts();

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -362,7 +362,7 @@ func FormatError(err error) error {
 			return common.Errorf(common.Conflict, fmt.Errorf("policy environment and type already exists"))
 		case strings.Contains(err.Error(), "idx_project_unique_key"):
 			return common.Errorf(common.Conflict, fmt.Errorf("project key already exists"))
-		case strings.Contains(err.Error(), "idx_project_member_unique_project_id_principal_id"):
+		case strings.Contains(err.Error(), "idx_project_member_unique_project_id_role_provider_principal_id"):
 			return common.Errorf(common.Conflict, fmt.Errorf("project member already exists"))
 		case strings.Contains(err.Error(), "idx_project_webhook_unique_project_id_url"):
 			return common.Errorf(common.Conflict, fmt.Errorf("webhook url already exists"))

--- a/store/project_member.go
+++ b/store/project_member.go
@@ -124,7 +124,7 @@ func (s *ProjectMemberService) DeleteProjectMember(ctx context.Context, delete *
 }
 
 // getBatchUpdatePrincipalIDList return the principal ID for each operation (this function may be a litter overhead, but it is easy to be tested)
-func getBatchUpdatePrincipalIDList(ctx context.Context, oldPrincipalIDList []int, newPrincipalIDList []int) (createPrincipalIDList, patchPrincipalIDList, deletePrincipalIDList []int, err error) {
+func getBatchUpdatePrincipalIDList(oldPrincipalIDList []int, newPrincipalIDList []int) (createPrincipalIDList, patchPrincipalIDList, deletePrincipalIDList []int, err error) {
 	oldPrincipalIDSet := make(map[int]bool)
 	for _, id := range oldPrincipalIDList {
 		oldPrincipalIDSet[id] = true
@@ -192,7 +192,7 @@ func (s *ProjectMemberService) BatchUpdateProjectMember(ctx context.Context, bat
 		newPrincipalIDList = append(newPrincipalIDList, newMember.PrincipalID)
 	}
 
-	createPrincipalIDList, patchPrincipalIDList, deletePrincipalIDList, err := getBatchUpdatePrincipalIDList(ctx, oldPrincipalIDList, newPrincipalIDList)
+	createPrincipalIDList, patchPrincipalIDList, deletePrincipalIDList, err := getBatchUpdatePrincipalIDList(oldPrincipalIDList, newPrincipalIDList)
 	if err != nil {
 		return nil, nil, FormatError(err)
 	}

--- a/store/project_member.go
+++ b/store/project_member.go
@@ -142,11 +142,6 @@ func (s *ProjectMemberService) SetProjectMember(ctx context.Context, set *api.Pr
 		oldMemberMap[existingMember.PrincipalID] = existingMember
 	}
 
-	newMemberMap := make(map[int]bool)
-	for _, createMember := range set.List {
-		newMemberMap[createMember.PrincipalID] = true
-	}
-
 	createdMemberList := make([]*api.ProjectMember, 0)
 	deletedMemberList := make([]*api.ProjectMember, 0)
 	for _, memberCreate := range set.List {

--- a/store/project_member.go
+++ b/store/project_member.go
@@ -159,7 +159,7 @@ func (s *ProjectMemberService) BatchUpdateProjectMember(ctx context.Context, bat
 		// if the member exists (NOTICE: a member with the same principal ID but different role provider will be considered as separate member)
 		//  we will try to update its field
 		if memberBefore, ok := oldMemberMap[memberCreate.PrincipalID]; ok {
-			// if we update a member, we will the member in both createdMemberList and deletedMemberList
+			// if we update a member, we will add the member in both createdMemberList and deletedMemberList
 			updatedMember, err := patchProjectMember(ctx, tx.PTx, &api.ProjectMemberPatch{
 				ID:           memberBefore.ID,
 				UpdaterID:    memberCreate.CreatorID,

--- a/store/project_member.go
+++ b/store/project_member.go
@@ -148,7 +148,7 @@ func getBatchUpdatePrincipalIDList(ctx context.Context, oldPrincipalIDList []int
 
 	deletePrincipalIDList = make([]int, 0)
 	for _, oldID := range oldPrincipalIDList {
-		// if the ID dose exist on the create list we will update it (done above)
+		// if the old ID also exists on the new id list, then it has already been added to the patch list above.
 		if _, ok := newPrincipalIDSet[oldID]; ok {
 			continue
 		}

--- a/store/project_member.go
+++ b/store/project_member.go
@@ -138,8 +138,7 @@ func getBatchUpdatePrincipalIDList(ctx context.Context, oldPrincipalIDList []int
 	createPrincipalIDList = make([]int, 0)
 	patchPrincipalIDList = make([]int, 0)
 	for _, newID := range newPrincipalIDList {
-		// if the ID exists (NOTICE: a member with the same principal ID but different role provider will be considered as separate member)
-		// 	we will try to update it
+		// if the ID exists, we will try to update it (NOTICE: a member with the same principal ID but different role provider will be considered as separate member)
 		if _, ok := oldPrincipalIDSet[newID]; ok {
 			patchPrincipalIDList = append(patchPrincipalIDList, newID)
 		} else {

--- a/store/project_member_test.go
+++ b/store/project_member_test.go
@@ -119,8 +119,8 @@ func TestGetBatchUpdatePrincipalIDList(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var got Result
-			got.createIDList, got.patchIDList, got.deleteIDList, _ = getBatchUpdatePrincipalIDList(tc.input.oldIDList, tc.input.newIDList)
-			if diff := cmp.Diff(tc.expect.createIDList, got.createIDList, opt); diff != "" {
+			got.createIDList, got.patchIDList, got.deleteIDList = getBatchUpdatePrincipalIDList(tc.input.oldIDList, tc.input.newIDList)
+			if diff := cmp.Diff(tc.expect.createIDList, got.createIDList, opt); len(diff) != 0 {
 				t.Errorf("\ncreateIDList: %v", diff)
 			}
 			if diff := cmp.Diff(tc.expect.patchIDList, got.patchIDList, opt); diff != "" {

--- a/store/project_member_test.go
+++ b/store/project_member_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/kr/pretty"
 )
 
 func TestGetBatchUpdatePrincipalIDList(t *testing.T) {
@@ -100,33 +100,17 @@ func TestGetBatchUpdatePrincipalIDList(t *testing.T) {
 		},
 	}
 
-	opt := cmp.Comparer(func(l1, l2 []int) bool {
-		if len(l1) != len(l2) {
-			return false
-		}
-		set1 := make(map[int]bool)
-		for _, i := range l1 {
-			set1[i] = true
-		}
-		for _, i := range l2 {
-			if _, ok := set1[i]; !ok {
-				return false
-			}
-		}
-		return true
-	})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var got Result
 			got.createIDList, got.patchIDList, got.deleteIDList = getBatchUpdatePrincipalIDList(tc.input.oldIDList, tc.input.newIDList)
-			if diff := cmp.Diff(tc.expect.createIDList, got.createIDList, opt); len(diff) != 0 {
+			if diff := pretty.Diff(tc.expect.createIDList, got.createIDList); len(diff) != 0 {
 				t.Errorf("\ncreateIDList: %v", diff)
 			}
-			if diff := cmp.Diff(tc.expect.patchIDList, got.patchIDList, opt); diff != "" {
+			if diff := pretty.Diff(tc.expect.patchIDList, got.patchIDList); len(diff) != 0 {
 				t.Errorf("\npatchIDList: %v", diff)
 			}
-			if diff := cmp.Diff(tc.expect.deleteIDList, got.deleteIDList, opt); diff != "" {
+			if diff := pretty.Diff(tc.expect.deleteIDList, got.deleteIDList); len(diff) != 0 {
 				t.Errorf("\ndeleteIDList: %v", diff)
 			}
 		})

--- a/store/project_member_test.go
+++ b/store/project_member_test.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetBatchUpdatePrincipalIDList(t *testing.T) {
+	type Input struct {
+		oldIDList []int
+		newIDList []int
+	}
+	type Result struct {
+		createIDList []int
+		patchIDList  []int
+		deleteIDList []int
+	}
+
+	testCases := map[string]struct {
+		input  Input
+		expect Result
+	}{
+		"single_patch": {
+			input: Input{
+				oldIDList: []int{1, 2, 3},
+				newIDList: []int{1, 2, 3},
+			},
+			expect: Result{
+				createIDList: []int{},
+				patchIDList:  []int{1, 2, 3},
+				deleteIDList: []int{},
+			},
+		},
+		"single_delete": {
+			input: Input{
+				oldIDList: []int{1, 2, 3},
+				newIDList: []int{},
+			},
+			expect: Result{
+				createIDList: []int{},
+				patchIDList:  []int{},
+				deleteIDList: []int{1, 2, 3},
+			},
+		},
+		"single_create": {
+			input: Input{
+				oldIDList: []int{},
+				newIDList: []int{1, 2, 3},
+			},
+			expect: Result{
+				createIDList: []int{1, 2, 3},
+				patchIDList:  []int{},
+				deleteIDList: []int{},
+			},
+		},
+		"create_delete": {
+			input: Input{
+				oldIDList: []int{1, 2},
+				newIDList: []int{3, 4},
+			},
+			expect: Result{
+				createIDList: []int{3, 4},
+				patchIDList:  []int{},
+				deleteIDList: []int{1, 2},
+			},
+		},
+		"create_patch": {
+			input: Input{
+				oldIDList: []int{1, 2},
+				newIDList: []int{1, 2, 3},
+			},
+			expect: Result{
+				createIDList: []int{3},
+				patchIDList:  []int{1, 2},
+				deleteIDList: []int{},
+			},
+		},
+		"delete_patch": {
+			input: Input{
+				oldIDList: []int{1, 2},
+				newIDList: []int{2},
+			},
+			expect: Result{
+				createIDList: []int{},
+				patchIDList:  []int{2},
+				deleteIDList: []int{1},
+			},
+		},
+		"mixed": {
+			input: Input{
+				oldIDList: []int{1, 2},
+				newIDList: []int{2, 3},
+			},
+			expect: Result{
+				createIDList: []int{3},
+				patchIDList:  []int{2},
+				deleteIDList: []int{1},
+			},
+		},
+	}
+
+	opt := cmp.Comparer(func(x, y Result) bool {
+		compareTwoList := func(l1, l2 []int) bool {
+			if len(l1) != len(l2) {
+				return false
+			}
+			set1 := make(map[int]bool)
+			for _, i := range l1 {
+				set1[i] = true
+			}
+			for _, i := range l2 {
+				if _, ok := set1[i]; !ok {
+					return false
+				}
+			}
+			return true
+		}
+		return compareTwoList(x.createIDList, y.createIDList) && compareTwoList(x.deleteIDList, y.deleteIDList) && compareTwoList(x.patchIDList, y.patchIDList)
+
+	})
+
+	ctx := context.Background()
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var got Result
+			got.createIDList, got.patchIDList, got.deleteIDList, _ = getBatchUpdatePrincipalIDList(ctx, tc.input.oldIDList, tc.input.newIDList)
+			if diff := cmp.Diff(tc.expect, got, opt); diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For project_member table, instead for UNIQUE(project_id, principal_id), we would use UNIQUE(project_id, principal_id, role_provider)

Thus during syncing the role provider, we don't remove the existing member, we just add new members from the new providers.

At at point in time, only members whose role_provider is the same as the project current role_provider is active.

By doing this, switching the role_provider back and forth is just flipping which parts of the project members are active.

The existing behavior of deleting project members would be painful if existing project has a lot of members.