### PR TITLE
feat(frontend): introducing help panel

### DIFF
--- a/frontend/src/components/HelpPanel.vue
+++ b/frontend/src/components/HelpPanel.vue
@@ -53,10 +53,11 @@
           target="_blank"
           class="flex justify-between items-center flex-shrink-0 w-full text-main group"
         >
-          <div class="flex items-center py-1">
+          <div class="flex items-center flex-1 py-1">
             <heroicons-outline:document-text class="w-5 h-5 mr-2" />
             <span class="text-sm">{{ $t("common.documents") }}</span>
           </div>
+          <heroicons-outline:external-link class="w-4 h-4 text-gray-500" />
         </a>
       </template>
     </NDrawerContent>

--- a/frontend/src/components/HelpPanel.vue
+++ b/frontend/src/components/HelpPanel.vue
@@ -1,0 +1,118 @@
+<template>
+  <NDrawer
+    v-model:show="state.visible"
+    placement="left"
+    closeable
+    width="18rem"
+  >
+    <!-- drawer width is 18rem(w-72) -->
+    <NDrawerContent :title="$t('common.help')">
+      <!-- keyboard shortcut maps -->
+      <h3 class="mb-2">{{ $t("common.keyboard-shortcuts") }}</h3>
+      <ul role="list" class="divide-y divide-gray-200">
+        <li
+          v-for="action in shortcuts"
+          :key="action.id"
+          class="py-2 px-1 cursor-pointer hover:bg-gray-100"
+        >
+          <div
+            class="flex items-center space-x-4"
+            @click="() => action.perform?.(action)"
+          >
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium truncate">
+                {{ action.name }}
+              </p>
+              <p v-if="action.subtitle" class="text-xs text-gray-500 truncate">
+                {{ action.subtitle }}
+              </p>
+            </div>
+
+            <div
+              v-if="!!action.shortcut?.length"
+              aria-hidden
+              class="grid grid-flow-col gap-1 justify-self-end text-gray-500"
+            >
+              <kbd
+                v-for="(sc, j) in action.shortcut"
+                :key="j"
+                class="w-6 h-6 flex items-center justify-center bg-black bg-opacity-10 rounded text-sm"
+              >
+                {{ sc }}
+              </kbd>
+            </div>
+          </div>
+        </li>
+      </ul>
+
+      <!-- dynamically registered contents in the future -->
+
+      <template #footer>
+        <a
+          href="https://docs.bytebase.com"
+          target="_blank"
+          class="flex justify-between items-center flex-shrink-0 w-full text-main group"
+        >
+          <div class="flex items-center py-1">
+            <heroicons-outline:document-text class="w-5 h-5 mr-2" />
+            <span class="text-sm">{{ $t("common.documents") }}</span>
+          </div>
+        </a>
+      </template>
+    </NDrawerContent>
+  </NDrawer>
+</template>
+
+<script lang="ts" setup>
+import { defineProps, defineEmits, reactive, watch, computed } from "vue";
+import { NDrawer, NDrawerContent } from "naive-ui";
+import { useKBarEvent, useKBarState } from "@bytebase/vue-kbar";
+import { useRoute, useRouter } from "vue-router";
+
+const props = defineProps<{
+  visible: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: "update:visible", visible: boolean): void;
+}>();
+
+const state = reactive({
+  visible: props.visible,
+});
+
+const route = useRoute();
+const router = useRouter();
+
+watch(
+  () => props.visible,
+  (visible) => (state.visible = visible)
+);
+
+watch(
+  () => state.visible,
+  (visible) => emit("update:visible", visible)
+);
+
+// close panel when k-bar opens
+useKBarEvent("open", () => {
+  state.visible = false;
+});
+
+// close panel when page redirects
+watch(
+  () => route.fullPath,
+  () => {
+    state.visible = false;
+  }
+);
+
+const kbarState = useKBarState();
+const shortcuts = computed(() => {
+  return kbarState.value.actions.filter((act) => !!act.shortcut?.length);
+});
+
+const goto = (url: string) => {
+  router.push(url);
+};
+</script>

--- a/frontend/src/components/Issue/PipelineSimpleFlow.vue
+++ b/frontend/src/components/Issue/PipelineSimpleFlow.vue
@@ -11,7 +11,7 @@
         <div
           class="cursor-default group flex items-center justify-between w-full"
         >
-          <span class="pl-4 py-2 flex items-center text-sm font-medium">
+          <span class="w-full pl-4 py-2 flex items-center text-sm font-medium">
             <div
               class="relative w-6 h-6 flex flex-shrink-0 items-center justify-center rounded-full select-none"
               :class="flowItemIconClass(item)"
@@ -60,12 +60,12 @@
               <span class="text-sm">{{ item.taskName }}</span>
             </div>
             <div
-              class="ml-4 group cursor-pointer grid grid-cols-2 lg:hidden"
+              class="ml-4 w-full group cursor-pointer grid grid-cols-3 lg:hidden"
               :class="flowItemTextClass(item)"
               @click.prevent="clickItem(item)"
             >
-              <span class="col-span-1 text-sm w-32">{{ item.stageName }}</span>
-              <span class="col-span-1 text-sm">{{ item.taskName }}</span>
+              <span class="col-span-1 text-sm">{{ item.stageName }}</span>
+              <span class="col-span-2 text-sm ml-4">{{ item.taskName }}</span>
             </div>
             <div class="tooltip-wrapper" @click.prevent="clickItem(item)">
               <span class="tooltip">Missing SQL statement</span>

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -77,7 +77,7 @@
         <div class="flex-shrink-0 flex border-t border-block-border px-4 py-2">
           <span
             class="flex justify-between items-center flex-shrink-0 w-full text-main group cursor-pointer"
-            @click.prevent="state.showHelpPanel = true"
+            @click.prevent.stop="state.showHelpPanel = true"
           >
             <div class="flex items-center py-1">
               <heroicons-outline:question-mark-circle class="w-5 h-5 mr-2" />

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -75,17 +75,16 @@
           <Quickstart />
         </div>
         <div class="flex-shrink-0 flex border-t border-block-border px-4 py-2">
-          <a
-            href="https://docs.bytebase.com"
-            target="_blank"
-            class="flex justify-between items-center flex-shrink-0 w-full text-main group"
+          <span
+            class="flex justify-between items-center flex-shrink-0 w-full text-main group cursor-pointer"
+            @click.prevent="state.showHelpPanel = true"
           >
             <div class="flex items-center py-1">
               <heroicons-outline:question-mark-circle class="w-5 h-5 mr-2" />
               <span class="text-sm">{{ $t("common.help") }}</span>
             </div>
             <div class="text-sm">{{ version }}</div>
-          </a>
+          </span>
         </div>
       </div>
     </aside>
@@ -134,31 +133,36 @@
         <!-- End main area -->
       </div>
     </div>
+
+    <HelpPanel v-model:visible="state.showHelpPanel" />
   </div>
 </template>
 
 <script lang="ts">
-import { computed, reactive } from "vue";
+import { computed, defineComponent, reactive } from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import Breadcrumb from "../components/Breadcrumb.vue";
 import IntroBanner from "../components/IntroBanner.vue";
 import Quickstart from "../components/Quickstart.vue";
 import QuickActionPanel from "../components/QuickActionPanel.vue";
+import HelpPanel from "../components/HelpPanel.vue";
 import { QuickActionType } from "../types";
 import { isDBA, isDeveloper, isOwner } from "../utils";
 
 interface LocalState {
   showMobileOverlay: boolean;
+  showHelpPanel: boolean;
 }
 
-export default {
+export default defineComponent({
   name: "BodyLayout",
   components: {
     Breadcrumb,
     IntroBanner,
     Quickstart,
     QuickActionPanel,
+    HelpPanel,
   },
   setup() {
     const store = useStore();
@@ -166,6 +170,7 @@ export default {
 
     const state = reactive<LocalState>({
       showMobileOverlay: false,
+      showHelpPanel: false,
     });
 
     const currentUser = computed(() => store.getters["auth/currentUser"]());
@@ -247,5 +252,5 @@ export default {
       version,
     };
   },
-};
+});
 </script>

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -174,6 +174,8 @@ common:
   manage: Manage
   table: Table
   search: Search
+  keyboard-shortcuts: Keyboard Shortcuts
+  documents: Documents
 error-page:
   go-back-home: Go back home
 anomaly-center: Anomaly Center

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -174,6 +174,8 @@ common:
   manage: 管理
   table: 表
   search: 搜索
+  keyboard-shortcuts: 快捷键
+  documents: 文档
 error-page:
   go-back-home: 回到主页
 anomaly-center: 异常中心

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -321,7 +321,7 @@ export default defineComponent({
         shortcut: ["g", "m"],
         section: t("kbar.navigation"),
         keywords: "navigation",
-        perform: () => router.push({ name: "setting.inbox" }),
+        perform: () => router.push({ name: "workspace.inbox" }),
       }),
     ]);
     useRegisterActions(kbarActions);

--- a/frontend/src/views/SqlEditor/EditorHeader.vue
+++ b/frontend/src/views/SqlEditor/EditorHeader.vue
@@ -196,7 +196,7 @@ export default defineComponent({
         shortcut: ["g", "m"],
         section: t("kbar.navigation"),
         keywords: "navigation",
-        perform: () => router.push({ name: "setting.inbox" }),
+        perform: () => router.push({ name: "workspace.inbox" }),
       }),
     ]);
     useRegisterActions(kbarActions);


### PR DESCRIPTION
Introducing help panel.

- Clicking "Help" in the left bottom corner will open help panel instead of opening the document site. (not available in mobile side menu)
- Help panel now displays all keyboard shortcuts provided by k-bar.
- It may display more dynamically registered contents by different routes.

How do you like it?

Screenshot
![help-panel-3](https://user-images.githubusercontent.com/2749742/156288857-4ea44b97-daad-47ba-b259-817eda1d612c.gif)
