### PR TITLE
feat: database incorrect project warning

### DIFF
--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -757,6 +757,7 @@ database:
   indexes: Indexes
   row-count-est: Row count est.
   incorrect-project-warning: SQL editor can only query databases in projects available to the user. You should first transfer this database into a project.
+  go-to-transfer: Go to transfer
 repository:
   branch-observe-file-change: The branch where Bytebase observes the file change.
   branch-specify-tip: 'Tip: You can also use wildcard like ''feature/*'

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -174,6 +174,7 @@ common:
   manage: Manage
   table: Table
   search: Search
+  warning: Warning
 error-page:
   go-back-home: Go back home
 anomaly-center: Anomaly Center
@@ -755,6 +756,7 @@ database:
   columns: Columns
   indexes: Indexes
   row-count-est: Row count est.
+  incorrect-project-warning: SQL editor can only query databases in projects available to the user. You should first transfer this database into a project.
 repository:
   branch-observe-file-change: The branch where Bytebase observes the file change.
   branch-specify-tip: 'Tip: You can also use wildcard like ''feature/*'

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -693,6 +693,7 @@ database:
   indexes: 索引
   row-count-est: 估计行数
   incorrect-project-warning: SQL 编辑器只能查询用户可用的项目中的数据库。您应该首先将此数据库转移到一个可用的项目中。
+  go-to-transfer: 前去转移
 repository:
   branch-observe-file-change: Bytebase 跟踪文件变更的分支。
   branch-specify-tip: '诀窍: 可以使用诸如 "feature/*" 这样的通配符'

--- a/frontend/src/locales/zh-CN.yml
+++ b/frontend/src/locales/zh-CN.yml
@@ -174,6 +174,7 @@ common:
   manage: 管理
   table: 表
   search: 搜索
+  warning: 警告
 error-page:
   go-back-home: 回到主页
 anomaly-center: 异常中心
@@ -691,6 +692,7 @@ database:
   columns: 列
   indexes: 索引
   row-count-est: 估计行数
+  incorrect-project-warning: SQL 编辑器只能查询用户可用的项目中的数据库。您应该首先将此数据库转移到一个可用的项目中。
 repository:
   branch-observe-file-change: Bytebase 跟踪文件变更的分支。
   branch-specify-tip: '诀窍: 可以使用诸如 "feature/*" 这样的通配符'

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -235,13 +235,12 @@
         <button
           type="button"
           class="btn-primary ml-3 inline-flex justify-center py-2 px-4"
-          :disabled="state.editingProjectId == database.project.id"
           @click.prevent="
             state.showIncorrectProjectModal = false;
             state.showTransferDatabaseModal = true;
           "
         >
-          {{ $t("common.transfer") }}
+          {{ $t("database.go-to-transfer") }}
         </button>
       </div>
     </BBModal>


### PR DESCRIPTION
SQL editors can only query databases in the projects available to the user. For databases in the default project, we should disable or put a warning if the user wants to navigate from database console to SQL editor.
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/24653555/156539805-8b0f11a9-2b83-4951-95be-b13c649b903f.png">
