### PR TITLE
feat: add stack trace to recover middleware

### DIFF
--- a/server/recover.go
+++ b/server/recover.go
@@ -15,7 +15,7 @@ func recoverMiddleware(l *zap.Logger, next echo.HandlerFunc) echo.HandlerFunc {
 				if !ok {
 					err = fmt.Errorf("%v", r)
 				}
-				l.Error("Middleware PANIC RECOVER", zap.Error(err))
+				l.Error("Middleware PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
 
 				c.Error(err)
 			}


### PR DESCRIPTION
When panic occurs, currently it's difficult to point out the line of code that triggers the panic.

# Showcase
1. Add a panic in some route, for example, `GET /project`
2. Run `go test -run ^TestServiceRestart$ ./...`

## Results

### Before
`
2022-03-04T14:48:57.228+0800    ERROR   Middleware PANIC RECOVER        {"error": "oops"}
{"time":"2022-03-04T14:48:57+08:00","method":"GET","uri":"/api/project","status":500,"error":""}
    /Users/dragonly/bb/bytebase/tests/start_test.go:23: http response error code 500 body "{\"message\":\"Internal Server Error\"}\n"
`

### Now
`
2022-03-04T14:50:01.293+0800    ERROR   Middleware PANIC RECOVER        {"error": "oops", "stack": "github.com/bytebase/bytebase/server.recoverMiddleware.func1.1\n\t/Users/dragonly/bb/bytebase/server/recover.go:18\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:1038\ngithub.com/bytebase/bytebase/server.(*Server).registerProjectRoutes.func2\n\t/Users/dragonly/bb/bytebase/server/project.go:73\ngithub.com/bytebase/bytebase/server.aclMiddleware.func1\n\t/Users/dragonly/bb/bytebase/server/acl.go:93\ngithub.com/bytebase/bytebase/server.JWTMiddleware.func1\n\t/Users/dragonly/bb/bytebase/server/jwt.go:295\ngithub.com/labstack/echo/v4.(*Echo).add.func1\n\t/Users/dragonly/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:552\ngithub.com/bytebase/bytebase/server.recoverMiddleware.func1\n\t/Users/dragonly/bb/bytebase/server/recover.go:23\ngithub.com/labstack/echo/v4/middleware.LoggerWithConfig.func2.1\n\t/Users/dragonly/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/logger.go:117\ngithub.com/labstack/echo/v4/middleware.SecureWithConfig.func1.1\n\t/Users/dragonly/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/secure.go:142\ngithub.com/labstack/echo/v4.(*Echo).ServeHTTP\n\t/Users/dragonly/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:662\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2879\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1930"}
{"time":"2022-03-04T14:50:01+08:00","method":"GET","uri":"/api/project","status":500,"error":""}
    /Users/dragonly/bb/bytebase/tests/start_test.go:23: http response error code 500 body "{\"message\":\"Internal Server Error\"}\n"
`