### PR TITLE
style(sql-editor): use node active color instead the underline style

### DIFF
--- a/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
@@ -214,6 +214,16 @@ const handleSelectedKeysChange = (
 };
 </script>
 
+<style>
+.n-tree
+  .n-tree-node.n-tree-node--highlight
+  .n-tree-node-content
+  .n-tree-node-content__text {
+  border-bottom: none;
+  background-color: var(--n-node-color-active);
+}
+</style>
+
 <style scoped>
 .databases-tree--tree {
   height: calc(100% - 40px);

--- a/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
@@ -215,7 +215,7 @@ const handleSelectedKeysChange = (
   }
 };
 
-function renderLabel({ option }: { option: TreeOption }) {
+const renderLabel = ({ option }: { option: TreeOption }) => {
   const renderLabelHTML = searchPattern.value
     ? h("span", {
         innerHTML: getHighlightHTMLByKeyWords(
@@ -226,7 +226,7 @@ function renderLabel({ option }: { option: TreeOption }) {
     : escape(option.label);
 
   return renderLabelHTML;
-}
+};
 </script>
 
 <style>

--- a/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
@@ -225,14 +225,6 @@ function renderLabel({ option }: { option: TreeOption }) {
       })
     : escape(option.label);
 
-  // return h(
-  //   "span",
-  //   {
-  //     class: "text-accent",
-  //   },
-  //   { default: () => label }
-  // );
-  // return h("span", ["hello", h("b", "hello"), label]);
   return renderLabelHTML;
 }
 </script>
@@ -244,8 +236,6 @@ function renderLabel({ option }: { option: TreeOption }) {
   .n-tree-node-content__text {
   border-bottom: none;
   border-bottom-color: transparent;
-  /* background-color: var(--n-node-color-active);
-  padding: 0 0.25rem; */
 }
 </style>
 

--- a/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/SqlEditor/AsidePanel/DatabaseTree.vue
@@ -21,6 +21,7 @@
         :default-expanded-keys="defaultExpanedKeys"
         :default-selected-keys="defaultSelectedKeys"
         :on-update:selected-keys="handleSelectedKeysChange"
+        :render-label="renderLabel"
       />
     </div>
   </div>
@@ -35,9 +36,10 @@ import {
   useNamespacedState,
   useNamespacedActions,
 } from "vuex-composition-helpers";
-import { cloneDeep, omit } from "lodash-es";
+import { cloneDeep, omit, escape } from "lodash-es";
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";
+import { TreeOption } from "naive-ui";
 
 import {
   SqlEditorState,
@@ -46,7 +48,7 @@ import {
   ConnectionContext,
   UNKNOWN_ID,
 } from "../../../types";
-import { connectionSlug } from "../../../utils";
+import { connectionSlug, getHighlightHTMLByKeyWords } from "../../../utils";
 import InstanceEngineIconVue from "../../../components/InstanceEngineIcon.vue";
 import HeroiconsOutlineDatabase from "~icons/heroicons-outline/database.vue";
 import HeroiconsOutlineTable from "~icons/heroicons-outline/table.vue";
@@ -212,6 +214,27 @@ const handleSelectedKeysChange = (
     }
   }
 };
+
+function renderLabel({ option }: { option: TreeOption }) {
+  const renderLabelHTML = searchPattern.value
+    ? h("span", {
+        innerHTML: getHighlightHTMLByKeyWords(
+          escape(option.label),
+          escape(searchPattern.value)
+        ),
+      })
+    : escape(option.label);
+
+  // return h(
+  //   "span",
+  //   {
+  //     class: "text-accent",
+  //   },
+  //   { default: () => label }
+  // );
+  // return h("span", ["hello", h("b", "hello"), label]);
+  return renderLabelHTML;
+}
 </script>
 
 <style>
@@ -220,7 +243,9 @@ const handleSelectedKeysChange = (
   .n-tree-node-content
   .n-tree-node-content__text {
   border-bottom: none;
-  background-color: var(--n-node-color-active);
+  border-bottom-color: transparent;
+  /* background-color: var(--n-node-color-active);
+  padding: 0 0.25rem; */
 }
 </style>
 


### PR DESCRIPTION
[Linear Issue](https://linear.app/bbteam/issue/BYT-264/[sql-editor]-unnecessary-separator-shown-when-using-database-search-bo)

The search result highlights the node uses the CSS Variables `--n-node-color-active` which `naive-ui` provided.

<img width="378" alt="CleanShot 2022-03-07 at 14 14 58@2x" src="https://user-images.githubusercontent.com/6118824/156978409-55547857-79e5-400b-bc40-d39b28a04eb5.png">
