### PR TITLE
chore: use empty db password in seed

### DIFF
--- a/store/seed/release/10001__init_seed.sql
+++ b/store/seed/release/10001__init_seed.sql
@@ -270,7 +270,7 @@ VALUES
         'Admin data source',
         'ADMIN',
         'root',
-        'testpwd1'
+        ''
     );
 
 INSERT INTO
@@ -295,7 +295,7 @@ VALUES
         'Admin data source',
         'ADMIN',
         'root',
-        'testpwd1'
+        ''
     );
 
 ALTER SEQUENCE data_source_id_seq RESTART WITH 103;


### PR DESCRIPTION
in MySQL quickstart, we start a MySQL instance with the empty root password. change this might reduce confuse.