### PR TITLE
fix: query result column type name

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -34,9 +34,9 @@ var (
 		name TEXT NULL
 	);`
 	bookTableQuery      = "SELECT * FROM sqlite_schema WHERE type = 'table' AND tbl_name = 'book';"
-	bookSchemaSQLResult = `[["type","name","tbl_name","rootpage","sql"],[["table","book","book","2","CREATE TABLE book (\n\t\tid INTEGER PRIMARY KEY AUTOINCREMENT,\n\t\tname TEXT NULL\n\t)"]]]`
+	bookSchemaSQLResult = `[["type","name","tbl_name","rootpage","sql"],[["table","book","book",2,"CREATE TABLE book (\n\t\tid INTEGER PRIMARY KEY AUTOINCREMENT,\n\t\tname TEXT NULL\n\t)"]]]`
 	bookDataQuery       = `SELECT * FROM book;`
-	bookDataSQLResult   = `[["id","name"],[["1","byte"],["2",null]]]`
+	bookDataSQLResult   = `[["id","name"],[[1,"byte"],[2,null]]]`
 
 	dataUpdateStatement = `
 	INSERT INTO book(name) VALUES


### PR DESCRIPTION
Fix query result column type name.
For example, the primary key with number type should be `1` not `"1"`.