### PR TITLE
feat: add query result column types

### DIFF
--- a/frontend/src/types/tab.ts
+++ b/frontend/src/types/tab.ts
@@ -7,8 +7,8 @@ export interface TabInfo {
   savedAt: string;
   statement: string;
   selectedStatement: string;
-  // [columns: string[], data: any[][]]
-  queryResult?: [string[], any[][]];
+  // [columnNames: string[], types: string[], data: any[][]]
+  queryResult?: [string[], string[], any[][]];
   sheetId?: SheetId;
 }
 

--- a/frontend/src/views/SqlEditor/TablePanel/TableView.vue
+++ b/frontend/src/views/SqlEditor/TablePanel/TableView.vue
@@ -101,7 +101,7 @@ const columns = computed(() => {
     return [];
   }
 
-  const [columns] = queryResult.value;
+  const columns = queryResult.value[0];
   return columns.map((d) => {
     return {
       title: d,
@@ -114,7 +114,7 @@ const data = computed(() => {
     return [];
   }
 
-  const [_, data] = queryResult.value;
+  const data = queryResult.value[2];
   const temp = data
     .filter((d) => {
       let t = false;
@@ -142,7 +142,7 @@ const notifyMessage = computed(() => {
   if (isExecuting.value) {
     return t("sql-editor.loading-data");
   }
-  const [_, data] = queryResult.value;
+  const data = queryResult.value[2];
   if (data.length === 0) {
     return t("sql-editor.no-rows-found");
   }

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -281,9 +281,9 @@ func endMigration(ctx context.Context, l *zap.Logger, executor MigrationExecutor
 }
 
 // Query will execute a readonly / SELECT query.
-func Query(ctx context.Context, l *zap.Logger, db *sql.DB, statement string, limit int) ([]interface{}, error) {
+func Query(ctx context.Context, l *zap.Logger, sqldb *sql.DB, statement string, limit int) ([]interface{}, error) {
 	// Not all sql engines support ReadOnly flag, so we will use tx rollback semantics to enforce readonly.
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	tx, err := sqldb.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func Query(ctx context.Context, l *zap.Logger, db *sql.DB, statement string, lim
 	}
 	defer rows.Close()
 
-	columns, err := rows.Columns()
+	columnNames, err := rows.Columns()
 	if err != nil {
 		return nil, formatError(err)
 	}
@@ -371,7 +371,7 @@ func Query(ctx context.Context, l *zap.Logger, db *sql.DB, statement string, lim
 		}
 	}
 
-	return []interface{}{columns, data}, nil
+	return []interface{}{columnNames, columnTypeNames, data}, nil
 }
 
 // FindMigrationHistoryList will find the list of migration history.

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -277,7 +277,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 			return err
 		}
 		if bookDataSQLResult != result {
-			return fmt.Errorf("SQL result want %q, got %q, diff %q", bookSchemaSQLResult, result, pretty.Diff(bookSchemaSQLResult, result))
+			return fmt.Errorf("SQL result want %q, got %q, diff %q", bookDataSQLResult, result, pretty.Diff(bookDataSQLResult, result))
 		}
 		// Query clone migration history.
 		histories, err = ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID, Database: &cloneDatabaseName})

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -34,9 +34,9 @@ var (
 		name TEXT NULL
 	);`
 	bookTableQuery      = "SELECT * FROM sqlite_schema WHERE type = 'table' AND tbl_name = 'book';"
-	bookSchemaSQLResult = `[["type","name","tbl_name","rootpage","sql"],[["table","book","book",2,"CREATE TABLE book (\n\t\tid INTEGER PRIMARY KEY AUTOINCREMENT,\n\t\tname TEXT NULL\n\t)"]]]`
+	bookSchemaSQLResult = `[["type","name","tbl_name","rootpage","sql"],["TEXT","TEXT","TEXT","INT","TEXT"],[["table","book","book",2,"CREATE TABLE book (\n\t\tid INTEGER PRIMARY KEY AUTOINCREMENT,\n\t\tname TEXT NULL\n\t)"]]]`
 	bookDataQuery       = `SELECT * FROM book;`
-	bookDataSQLResult   = `[["id","name"],[[1,"byte"],[2,null]]]`
+	bookDataSQLResult   = `[["id","name"],["INTEGER","TEXT"],[[1,"byte"],[2,null]]]`
 
 	dataUpdateStatement = `
 	INSERT INTO book(name) VALUES


### PR DESCRIPTION
Now we only show the column name in the result table. So it will be pretty nice that if we can display its type.

This PR is to add the column types in backend API for future usage.

(BTW, we now use NDataTable to show the query result. But it might be unable to display `type` into it. Maybe I need to write our DataTable component to strengthen the result viewer.)