### PR TITLE
fix: fixed a security issue caused by fake VCS

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -4,6 +4,7 @@ import "github.com/bytebase/bytebase/plugin/vcs"
 
 // AuthProvider is the authentication provider which only supports GitLab for now.
 type AuthProvider struct {
+	ID            int      `jsonapi:"attr,id"`
 	Type          vcs.Type `jsonapi:"attr,type"`
 	Name          string   `jsonapi:"attr,name"`
 	InstanceURL   string   `jsonapi:"attr,instanceUrl"`
@@ -14,10 +15,9 @@ type AuthProvider struct {
 
 // GitlabLogin is the API message for logins via Gitlab.
 type GitlabLogin struct {
-	InstanceURL   string `jsonapi:"attr,instanceUrl"`
-	ApplicationID string `jsonapi:"attr,applicationId"`
-	Secret        string `jsonapi:"attr,secret"`
-	AccessToken   string `jsonapi:"attr,accessToken"`
+	ID          int    `jsonapi:"attr,id"`
+	Name        string `jsonapi:"attr,name"`
+	AccessToken string `jsonapi:"attr,accessToken"`
 }
 
 // Login is the API message for logins.

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,5 +1,7 @@
 // Auth
 
+import { VCSId } from "./id";
+
 // For now, a single user's auth provider should either belong to  GITLAB_SELF_HOST or BYTEBASE
 export type AuthProviderType = "GITLAB_SELF_HOST" | "BYTEBASE";
 
@@ -27,6 +29,7 @@ export type BytebaseLoginInfo = {
 };
 
 export type AuthProvider = {
+  id: VCSId;
   type: AuthProviderType;
   name: string;
   instanceUrl: string;
@@ -35,6 +38,7 @@ export type AuthProvider = {
 };
 
 export const EmptyAuthProvider: AuthProvider = {
+  id: 0,
   type: "BYTEBASE",
   name: "",
   instanceUrl: "",
@@ -43,8 +47,7 @@ export const EmptyAuthProvider: AuthProvider = {
 };
 
 export type VCSLoginInfo = {
-  applicationId: string;
-  secret: string;
-  instanceUrl: string;
+  id: VCSId;
+  name: string;
   accessToken: string;
 };

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -236,9 +236,8 @@ export default {
         })
         .then((token: OAuthToken) => {
           const gitlabLoginInfo: VCSLoginInfo = {
-            applicationId: state.activeAuthProvider!.applicationId,
-            secret: state.activeAuthProvider.secret,
-            instanceUrl: state.activeAuthProvider.instanceUrl,
+            id: state.activeAuthProvider.id,
+            name: state.activeAuthProvider.name,
             accessToken: token.accessToken,
           };
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/vcs"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
@@ -88,10 +89,10 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch vcs, name: %v, ID: %v", gitlabLogin.Name, gitlabLogin.Name)).SetInternal(err)
 				}
 				if vcsFound == nil {
-					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("vcs do not exist, name: %v, ID: %v", gitlabLogin.Name, gitlabLogin.Name)).SetInternal(err)
+					return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("vcs do not exist, name: %v, ID: %v", gitlabLogin.Name, gitlabLogin.Name)).SetInternal(err)
 				}
 
-				gitlabUserInfo, err := vcsPlugin.Get("GITLAB_SELF_HOST", vcsPlugin.ProviderConfig{Logger: s.l}).TryLogin(ctx,
+				gitlabUserInfo, err := vcsPlugin.Get(vcs.GitLabSelfHost, vcsPlugin.ProviderConfig{Logger: s.l}).TryLogin(ctx,
 					common.OauthContext{
 						ClientID:     vcsFound.ApplicationID,
 						ClientSecret: vcsFound.Secret,


### PR DESCRIPTION
Before, we pass the oauth content directly from the frontend, making it possible for a middleman attack.
After this PR, we will fetch the oauth content at the backend via an ID provided by the frontend.