### PR TITLE
feat: move oauth token exchange logic to the backend

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -15,9 +15,9 @@ type AuthProvider struct {
 
 // GitlabLogin is the API message for logins via Gitlab.
 type GitlabLogin struct {
-	ID          int    `jsonapi:"attr,id"`
-	Name        string `jsonapi:"attr,name"`
-	AccessToken string `jsonapi:"attr,accessToken"`
+	VCSID int    `jsonapi:"attr,vcsId"`
+	Name  string `jsonapi:"attr,name"`
+	Code  string `jsonapi:"attr,code"`
 }
 
 // Login is the API message for logins.

--- a/api/auth.go
+++ b/api/auth.go
@@ -15,9 +15,13 @@ type AuthProvider struct {
 
 // GitlabLogin is the API message for logins via Gitlab.
 type GitlabLogin struct {
-	VCSID int    `jsonapi:"attr,vcsId"`
-	Name  string `jsonapi:"attr,name"`
-	Code  string `jsonapi:"attr,code"`
+	// VCSID is the ID of the chosen role provider(a VCS also).
+	VCSID int `jsonapi:"attr,vcsId"`
+	// Name is the user configured name of the role provider.
+	Name string `jsonapi:"attr,name"`
+	// Code is the authentication message granted by GitLab server,
+	// we will use this code to fetch OAuth token.
+	Code string `jsonapi:"attr,code"`
 }
 
 // Login is the API message for logins.

--- a/api/auth.go
+++ b/api/auth.go
@@ -15,7 +15,7 @@ type AuthProvider struct {
 
 // GitlabLogin is the API message for logins via Gitlab.
 type GitlabLogin struct {
-	// VCSID is the ID of the chosen role provider(a VCS also).
+	// VCSID is the ID of the chosen VCS role provider.
 	VCSID int `jsonapi:"attr,vcsId"`
 	// Name is the user configured name of the role provider.
 	Name string `jsonapi:"attr,name"`

--- a/api/auth.go
+++ b/api/auth.go
@@ -19,7 +19,7 @@ type GitlabLogin struct {
 	VCSID int `jsonapi:"attr,vcsId"`
 	// Name is the user configured name of the role provider.
 	Name string `jsonapi:"attr,name"`
-	// Code is the authentication message granted by GitLab server,
+	// Code is the authentication code granted by GitLab server,
 	// we will use this code to fetch OAuth token.
 	Code string `jsonapi:"attr,code"`
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -20,7 +20,7 @@ type GitlabLogin struct {
 	// Name is the user configured name of the role provider.
 	Name string `jsonapi:"attr,name"`
 	// Code is the authentication code granted by GitLab server,
-	// we will use this code to fetch OAuth token.
+	// we will use this code to exchange the OAuth token.
 	Code string `jsonapi:"attr,code"`
 }
 

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -1,0 +1,8 @@
+package api
+
+// OAuthToken is the API message for OAuthToken.
+type OAuthToken struct {
+	AccessToken  string `jsonapi:"attr,accessToken" `
+	RefreshToken string `jsonapi:"attr,refreshToken"`
+	ExpiresTs    int64  `jsonapi:"attr,expiresAt"`
+}

--- a/api/repository.go
+++ b/api/repository.go
@@ -197,6 +197,14 @@ type RepositoryDelete struct {
 	DeleterID int
 }
 
+// ExternalRepository is the API message for external repository
+type ExternalRepository struct {
+	ID       int64  `jsonapi:"primary,id"`
+	Name     string `jsonapi:"attr,name"`
+	FullPath string `jsonapi:"attr,fullPath"`
+	WebURL   string `jsonapi:"attr,webUrl"`
+}
+
 // RepositoryService is the service for repositories.
 type RepositoryService interface {
 	CreateRepository(ctx context.Context, create *RepositoryCreate) (*RepositoryRaw, error)

--- a/api/repository.go
+++ b/api/repository.go
@@ -197,14 +197,6 @@ type RepositoryDelete struct {
 	DeleterID int
 }
 
-// ExternalRepository is the API message for external repository
-type ExternalRepository struct {
-	ID       int64  `jsonapi:"primary,id"`
-	Name     string `jsonapi:"attr,name"`
-	FullPath string `jsonapi:"attr,fullPath"`
-	WebURL   string `jsonapi:"attr,webUrl"`
-}
-
 // RepositoryService is the service for repositories.
 type RepositoryService interface {
 	CreateRepository(ctx context.Context, create *RepositoryCreate) (*RepositoryRaw, error)

--- a/api/vcs.go
+++ b/api/vcs.go
@@ -79,3 +79,11 @@ type VCSDelete struct {
 	// Value is assigned from the jwt subject field passed by the client.
 	DeleterID int
 }
+
+// ExternalRepository is the API message for external repository
+type ExternalRepository struct {
+	ID       int64  `jsonapi:"primary,id"`
+	Name     string `jsonapi:"attr,name"`
+	FullPath string `jsonapi:"attr,fullPath"`
+	WebURL   string `jsonapi:"attr,webUrl"`
+}

--- a/api/vcs.go
+++ b/api/vcs.go
@@ -24,7 +24,7 @@ type VCS struct {
 	InstanceURL   string   `jsonapi:"attr,instanceUrl"`
 	APIURL        string   `jsonapi:"attr,apiUrl"`
 	ApplicationID string   `jsonapi:"attr,applicationId"`
-	// For safety concern, we will no return secret, and all relevant logic should be dealed in the backend.
+	// For safety concerns, we will not return the secret, and all relevant logic is dealt in the backend.
 	Secret string
 }
 

--- a/api/vcs.go
+++ b/api/vcs.go
@@ -24,9 +24,8 @@ type VCS struct {
 	InstanceURL   string   `jsonapi:"attr,instanceUrl"`
 	APIURL        string   `jsonapi:"attr,apiUrl"`
 	ApplicationID string   `jsonapi:"attr,applicationId"`
-	// Secret will be used for OAuth on the client side when setting up project GitOps workflow.
-	// So it should be returned to the response.
-	Secret string `jsonapi:"attr,secret"`
+	// For safety concern, we will no return secret, and all relevant logic should be dealed in the backend.
+	Secret string
 }
 
 // VCSCreate is the API message for creating a VCS.

--- a/common/oauth.go
+++ b/common/oauth.go
@@ -12,19 +12,8 @@ type OauthContext struct {
 	Refresher    TokenRefresher
 }
 
-// OAuthExchange is the API message for exchange OAuth context.
+// OAuthExchange encapsulated the exchange OAuth context.
 type OAuthExchange struct {
 	ClientID     string
 	ClientSecret string
-}
-
-// OAuthToken is the API message for OAuthToken.
-type OAuthToken struct {
-	AccessToken  string `json:"access_token" `
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    int64  `json:"expires_in"`
-	CreatedAt    int64  `json:"created_at"`
-	// ExpiresTs is a derivative from ExpresIn and CreatedAt.
-	// ExpiresTs = ExpiresIn == 0 ? 0 : CreatedAt + ExpiresIn
-	ExpiresTs int64 `json:"expires_ts"`
 }

--- a/common/oauth.go
+++ b/common/oauth.go
@@ -16,4 +16,6 @@ type OauthContext struct {
 type OAuthExchange struct {
 	ClientID     string
 	ClientSecret string
+	Code         string
+	RedirectURL  string
 }

--- a/common/oauth.go
+++ b/common/oauth.go
@@ -12,15 +12,19 @@ type OauthContext struct {
 	Refresher    TokenRefresher
 }
 
-// ExchangeOAuth is the API message for ExchangeOAuth context
-type ExchangeOAuth struct {
-	Code string `jsonapi:"attr,code"`
+// OAuthExchange is the API message for exchange OAuth context.
+type OAuthExchange struct {
+	ClientID     string
+	ClientSecret string
 }
 
-// OAuthToken is the API message for OAuthToken
+// OAuthToken is the API message for OAuthToken.
 type OAuthToken struct {
 	AccessToken  string `json:"access_token" jsonapi:"attr,accessToken"`
 	RefreshToken string `json:"refresh_token" jsonapi:"attr,refreshToken"`
-	ExpiresIn    int64  `json:"expires_token" jsonapi:"attr,expiresIn"`
-	CreatedAt    int64  `json:"created_token" jsonapi:"attr,createdAt"`
+	ExpiresIn    int64  `json:"expires_in"`
+	CreatedAt    int64  `json:"created_at"`
+	// ExpiresTs is a derivative from ExpresIn and CreatedAt.
+	// ExpiresTs = ExpiresIn == 0 ? 0 : CreatedAt + ExpiresIn
+	ExpiresTs int64 `jsonapi:"attr,expiresTs"`
 }

--- a/common/oauth.go
+++ b/common/oauth.go
@@ -20,11 +20,11 @@ type OAuthExchange struct {
 
 // OAuthToken is the API message for OAuthToken.
 type OAuthToken struct {
-	AccessToken  string `json:"access_token" jsonapi:"attr,accessToken"`
-	RefreshToken string `json:"refresh_token" jsonapi:"attr,refreshToken"`
+	AccessToken  string `json:"access_token" `
+	RefreshToken string `json:"refresh_token"`
 	ExpiresIn    int64  `json:"expires_in"`
 	CreatedAt    int64  `json:"created_at"`
 	// ExpiresTs is a derivative from ExpresIn and CreatedAt.
 	// ExpiresTs = ExpiresIn == 0 ? 0 : CreatedAt + ExpiresIn
-	ExpiresTs int64 `jsonapi:"attr,expiresTs"`
+	ExpiresTs int64 `json:"expires_ts"`
 }

--- a/common/oauth.go
+++ b/common/oauth.go
@@ -11,3 +11,16 @@ type OauthContext struct {
 	RefreshToken string
 	Refresher    TokenRefresher
 }
+
+// ExchangeOAuth is the API message for ExchangeOAuth context
+type ExchangeOAuth struct {
+	Code string `jsonapi:"attr,code"`
+}
+
+// OAuthToken is the API message for OAuthToken
+type OAuthToken struct {
+	AccessToken  string `json:"access_token" jsonapi:"attr,accessToken"`
+	RefreshToken string `json:"refresh_token" jsonapi:"attr,refreshToken"`
+	ExpiresIn    int64  `json:"expires_token" jsonapi:"attr,expiresIn"`
+	CreatedAt    int64  `json:"created_token" jsonapi:"attr,createdAt"`
+}

--- a/frontend/src/components/RepositorySelectionPanel.vue
+++ b/frontend/src/components/RepositorySelectionPanel.vue
@@ -69,22 +69,33 @@ const state = reactive<LocalState>({
 
 const prepareRepositoryList = () => {
   if (props.config.vcs.type == "GITLAB_SELF_HOST") {
-    store
-      .dispatch("auth/exchangeOAuthToken", {
-        vcsId: props.config.vcs.id,
-        code: props.config.code,
-      })
-      .then((token: OAuthToken) => {
-        emit("set-token", token);
-        store
-          .dispatch("gitlab/fetchProjectList", {
-            vcs: props.config.vcs,
-            token: props.config.token,
-          })
-          .then((list) => {
-            state.repositoryList = list;
-          });
-      });
+    if (props.config.token.accessToken !== "") {
+      store
+        .dispatch("gitlab/fetchProjectList", {
+          vcs: props.config.vcs,
+          token: props.config.token,
+        })
+        .then((list) => {
+          state.repositoryList = list;
+        });
+    } else {
+      store
+        .dispatch("auth/exchangeOAuthToken", {
+          vcsId: props.config.vcs.id,
+          code: props.config.code,
+        })
+        .then((token: OAuthToken) => {
+          emit("set-token", token);
+          store
+            .dispatch("gitlab/fetchProjectList", {
+              vcs: props.config.vcs,
+              token: props.config.token,
+            })
+            .then((list) => {
+              state.repositoryList = list;
+            });
+        });
+    }
   }
 };
 

--- a/frontend/src/components/RepositorySelectionPanel.vue
+++ b/frontend/src/components/RepositorySelectionPanel.vue
@@ -50,6 +50,7 @@ import {
 
 interface LocalState {
   repositoryList: ExternalRepositoryInfo[];
+  lastAccessToken: string;
   searchText: string;
 }
 
@@ -64,12 +65,13 @@ const emit = defineEmits<{
 const store = useStore();
 const state = reactive<LocalState>({
   repositoryList: [],
+  lastAccessToken: "none",
   searchText: "",
 });
 
 const prepareRepositoryList = () => {
   if (props.config.vcs.type == "GITLAB_SELF_HOST") {
-    if (props.config.token.accessToken !== "") {
+    if (props.config.token.accessToken === state.lastAccessToken) {
       store
         .dispatch("gitlab/fetchProjectList", {
           vcs: props.config.vcs,
@@ -86,6 +88,7 @@ const prepareRepositoryList = () => {
         })
         .then((token: OAuthToken) => {
           emit("set-token", token);
+          state.lastAccessToken = token.accessToken;
           store
             .dispatch("gitlab/fetchProjectList", {
               vcs: props.config.vcs,

--- a/frontend/src/components/RepositorySelectionPanel.vue
+++ b/frontend/src/components/RepositorySelectionPanel.vue
@@ -50,7 +50,6 @@ import {
 
 interface LocalState {
   repositoryList: ExternalRepositoryInfo[];
-  lastAccessToken: string;
   searchText: string;
 }
 
@@ -65,7 +64,6 @@ const emit = defineEmits<{
 const store = useStore();
 const state = reactive<LocalState>({
   repositoryList: [],
-  lastAccessToken: "none",
   searchText: "",
 });
 
@@ -76,12 +74,11 @@ onMounted(() => {
 const prepareRepositoryList = () => {
   if (props.config.vcs.type == "GITLAB_SELF_HOST") {
     store
-      .dispatch("oauth/exchangeToken", {
+      .dispatch("oauth/exchangeVCSToken", {
         vcsId: props.config.vcs.id,
         code: props.config.code,
       })
       .then((token: OAuthToken) => {
-        state.lastAccessToken = token.accessToken;
         emit("set-token", token);
         store
           .dispatch("gitlab/fetchProjectList", {

--- a/frontend/src/components/RepositorySelectionPanel.vue
+++ b/frontend/src/components/RepositorySelectionPanel.vue
@@ -86,7 +86,7 @@ const prepareRepositoryList = () => {
         store
           .dispatch("gitlab/fetchProjectList", {
             vcs: props.config.vcs,
-            token: props.config.token,
+            token: token,
           })
           .then((list) => {
             state.repositoryList = list;

--- a/frontend/src/components/RepositorySetupWizard.vue
+++ b/frontend/src/components/RepositorySetupWizard.vue
@@ -22,10 +22,19 @@
       @cancel="cancel"
     >
       <template #0="{ next }">
-        <RepositoryVCSProviderPanel :config="state.config" @next="next()" />
+        <RepositoryVCSProviderPanel
+          @next="next()"
+          @set-vcs="setVCS"
+          @set-code="setCode"
+        />
       </template>
       <template #1="{ next }">
-        <RepositorySelectionPanel :config="state.config" @next="next()" />
+        <RepositorySelectionPanel
+          :config="state.config"
+          @next="next()"
+          @set-token="setToken"
+          @set-repository="setRepository"
+        />
       </template>
       <template #2>
         <RepositoryConfigPanel :config="state.config" :project="project" />
@@ -44,6 +53,8 @@ import RepositoryVCSProviderPanel from "./RepositoryVCSProviderPanel.vue";
 import RepositorySelectionPanel from "./RepositorySelectionPanel.vue";
 import RepositoryConfigPanel from "./RepositoryConfigPanel.vue";
 import {
+  ExternalRepositoryInfo,
+  OAuthToken,
   Project,
   ProjectRepositoryConfig,
   RepositoryCreate,
@@ -207,6 +218,22 @@ export default defineComponent({
       });
     };
 
+    const setCode = (code: string) => {
+      state.config.code = code;
+    };
+
+    const setToken = (token: OAuthToken) => {
+      state.config.token = token;
+    };
+
+    const setVCS = (vcs: VCS) => {
+      state.config.vcs = vcs;
+    };
+
+    const setRepository = (repository: ExternalRepositoryInfo) => {
+      state.config.repositoryInfo = repository;
+    };
+
     return {
       state,
       stepList,
@@ -214,6 +241,10 @@ export default defineComponent({
       tryChangeStep,
       tryFinishSetup,
       cancel,
+      setCode,
+      setVCS,
+      setToken,
+      setRepository,
     };
   },
 });

--- a/frontend/src/components/RepositoryVCSProviderPanel.vue
+++ b/frontend/src/components/RepositoryVCSProviderPanel.vue
@@ -34,116 +34,73 @@
 </template>
 
 <script lang="ts">
+export default { name: "RepositoryVCSProviderPanel" };
+</script>
+
+<script setup lang="ts">
 import { useStore } from "vuex";
-import {
-  reactive,
-  computed,
-  PropType,
-  watchEffect,
-  onUnmounted,
-  onMounted,
-} from "vue";
+import { reactive, computed, watchEffect, onUnmounted, onMounted } from "vue";
 import isEmpty from "lodash-es/isEmpty";
-import {
-  OAuthConfig,
-  OAuthToken,
-  OAuthWindowEventPayload,
-  openWindowForOAuth,
-  ProjectRepositoryConfig,
-  redirectUrl,
-  VCS,
-} from "../types";
+import { OAuthWindowEventPayload, openWindowForOAuth, VCS } from "../types";
 import { isOwner } from "../utils";
 
 interface LocalState {
   selectedVCS?: VCS;
 }
 
-export default {
-  name: "RepositoryVCSProviderPanel",
-  props: {
-    config: {
-      required: true,
-      type: Object as PropType<ProjectRepositoryConfig>,
-    },
-  },
-  emits: ["next"],
-  setup(props, { emit }) {
-    const store = useStore();
-    const state = reactive<LocalState>({});
+const emit = defineEmits<{
+  (event: "next"): void;
+  (event: "set-vcs", payload: VCS): void;
+  (event: "set-code", payload: string): void;
+}>();
 
-    const currentUser = computed(() => store.getters["auth/currentUser"]());
+const store = useStore();
+const state = reactive<LocalState>({});
 
-    const prepareVCSList = () => {
-      store.dispatch("vcs/fetchVCSList");
-    };
+const currentUser = computed(() => store.getters["auth/currentUser"]());
 
-    watchEffect(prepareVCSList);
+const prepareVCSList = () => {
+  store.dispatch("vcs/fetchVCSList");
+};
 
-    onMounted(() => {
-      window.addEventListener(
-        "bb.oauth.link-vcs-repository",
-        eventListener,
-        false
-      );
+watchEffect(prepareVCSList);
+
+onMounted(() => {
+  window.addEventListener("bb.oauth.link-vcs-repository", eventListener, false);
+});
+onUnmounted(() => {
+  window.removeEventListener("bb.oauth.link-vcs-repository", eventListener);
+});
+
+const vcsList = computed(() => {
+  return store.getters["vcs/vcsList"]();
+});
+
+const eventListener = (event: Event) => {
+  const payload = (event as CustomEvent).detail as OAuthWindowEventPayload;
+  if (isEmpty(payload.error)) {
+    emit("set-code", payload.code);
+    emit("next");
+  } else {
+    store.dispatch("notification/pushNotification", {
+      module: "bytebase",
+      style: "CRITICAL",
+      title: payload.error,
     });
-    onUnmounted(() => {
-      window.removeEventListener("bb.oauth.link-vcs-repository", eventListener);
-    });
+  }
+};
 
-    const vcsList = computed(() => {
-      return store.getters["vcs/vcsList"]();
-    });
+const isCurrentUserOwner = computed(() => {
+  return isOwner(currentUser.value.role);
+});
 
-    const eventListener = (event: Event) => {
-      const payload = (event as CustomEvent).detail as OAuthWindowEventPayload;
-      if (isEmpty(payload.error)) {
-        props.config.code = payload.code;
-        const oAuthConfig: OAuthConfig = {
-          endpoint: `${state.selectedVCS!.instanceUrl}/oauth/token`,
-          applicationId: state.selectedVCS!.applicationId,
-          secret: state.selectedVCS!.secret,
-          redirectUrl: redirectUrl(),
-        };
-        store
-          .dispatch("gitlab/exchangeToken", {
-            oAuthConfig,
-            code: payload.code,
-          })
-          .then((token: OAuthToken) => {
-            props.config.vcs = state.selectedVCS!;
-            props.config.token = token;
-            emit("next");
-          });
-      } else {
-        store.dispatch("notification/pushNotification", {
-          module: "bytebase",
-          style: "CRITICAL",
-          title: payload.error,
-        });
-      }
-    };
-
-    const isCurrentUserOwner = computed(() => {
-      return isOwner(currentUser.value.role);
-    });
-
-    const selectVCS = (vcs: VCS) => {
-      state.selectedVCS = vcs;
-      openWindowForOAuth(
-        `${vcs.instanceUrl}/oauth/authorize`,
-        vcs.applicationId,
-        "bb.oauth.link-vcs-repository"
-      );
-    };
-
-    return {
-      state,
-      currentUser,
-      vcsList,
-      isCurrentUserOwner,
-      selectVCS,
-    };
-  },
+const selectVCS = (vcs: VCS) => {
+  state.selectedVCS = vcs;
+  emit("set-vcs", vcs);
+  openWindowForOAuth(
+    `${vcs.instanceUrl}/oauth/authorize`,
+    vcs.applicationId,
+    "bb.oauth.link-vcs-repository"
+  );
 };
 </script>

--- a/frontend/src/components/VCSSetupWizard.vue
+++ b/frontend/src/components/VCSSetupWizard.vue
@@ -26,7 +26,13 @@
 </template>
 
 <script lang="ts">
-import { reactive, computed, onUnmounted, onMounted } from "vue";
+import {
+  reactive,
+  computed,
+  defineComponent,
+  onUnmounted,
+  onMounted,
+} from "vue";
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";
 import isEmpty from "lodash-es/isEmpty";
@@ -58,7 +64,7 @@ interface LocalState {
   oAuthResultCallback?: (token: OAuthToken | undefined) => void;
 }
 
-export default {
+export default defineComponent({
   name: "VCSSetupWizard",
   components: {
     VCSProviderBasicInfoPanel,
@@ -235,5 +241,5 @@ export default {
       cancelSetup,
     };
   },
-};
+});
 </script>

--- a/frontend/src/store/modules/auth.ts
+++ b/frontend/src/store/modules/auth.ts
@@ -54,16 +54,14 @@ const actions = {
     }
   ): Promise<OAuthToken> {
     const data = (
-      await axios.get(`/api/auth/exchange-oauth-token/${vcsId}`, {
-        headers: {
-          code: code,
-        },
+      await axios.post(`/api/oauth/vcs/${vcsId}/exchange-oauth-token`, null, {
+        headers: { code },
       })
-    ).data.data.attributes;
+    ).data;
     const oAuthToken: OAuthToken = {
-      accessToken: data.accessToken,
-      expiresTs: data.expiresTs,
-      refreshToken: data.refreshToken,
+      accessToken: data.access_token,
+      expiresTs: data.expires_ts,
+      refreshToken: data.refresh_token,
     };
 
     return oAuthToken;

--- a/frontend/src/store/modules/auth.ts
+++ b/frontend/src/store/modules/auth.ts
@@ -54,18 +54,15 @@ const actions = {
     }
   ): Promise<OAuthToken> {
     const data = (
-      await axios.post(`/api/auth/exchange-oauth-token/${vcsId}`, {
-        data: {
-          type: "exchangeOAuthToken",
-          attributes: { code },
+      await axios.get(`/api/auth/exchange-oauth-token/${vcsId}`, {
+        headers: {
+          code: code,
         },
       })
     ).data.data.attributes;
     const oAuthToken: OAuthToken = {
       accessToken: data.accessToken,
-      // For GitLab, as of 13.12, the default config won't expire the access token, thus this field is 0.
-      // see https://gitlab.com/gitlab-org/gitlab/-/issues/21745.
-      expiresTs: data.expiresIn == 0 ? 0 : data.createdAt + data.expiresIn,
+      expiresTs: data.expiresTs,
       refreshToken: data.refreshToken,
     };
 

--- a/frontend/src/store/modules/auth.ts
+++ b/frontend/src/store/modules/auth.ts
@@ -10,8 +10,6 @@ import {
   unknown,
   PrincipalId,
   AuthProvider,
-  VCSId,
-  OAuthToken,
 } from "../../types";
 import { getIntCookie } from "../../utils";
 
@@ -43,30 +41,6 @@ const getters = {
 };
 
 const actions = {
-  async exchangeOAuthToken(
-    {}: any,
-    {
-      vcsId,
-      code,
-    }: {
-      vcsId: VCSId;
-      code: string;
-    }
-  ): Promise<OAuthToken> {
-    const data = (
-      await axios.post(`/api/oauth/vcs/${vcsId}/exchange-oauth-token`, null, {
-        headers: { code },
-      })
-    ).data;
-    const oAuthToken: OAuthToken = {
-      accessToken: data.access_token,
-      expiresTs: data.expires_ts,
-      refreshToken: data.refresh_token,
-    };
-
-    return oAuthToken;
-  },
-
   async fetchProviderList({ commit }: any) {
     const providerList = (await axios.get("/api/auth/provider")).data.data;
     const convertedProviderList = providerList.map(

--- a/frontend/src/store/modules/gitlab.ts
+++ b/frontend/src/store/modules/gitlab.ts
@@ -9,17 +9,18 @@ import {
 const getters = {};
 
 function convertGitLabProject(project: any): ExternalRepositoryInfo {
+  const attributes = project.attributes;
   return {
     externalId: project.id.toString(),
-    name: project.name,
-    fullPath: project.path_with_namespace,
-    webUrl: project.web_url,
+    name: attributes.name,
+    fullPath: attributes.fullPath,
+    webUrl: attributes.webUrl,
   };
 }
 
 const actions = {
   // this actions is for initiating vcs ONLY
-  // after creation, the frontend should in no case access the secret
+  // after creation, the frontend should in no case access the secret.
   async exchangeToken(
     {}: any,
     {
@@ -51,7 +52,6 @@ const actions = {
     {}: any,
     { vcs, token }: { vcs: VCS; token: OAuthToken }
   ): Promise<ExternalRepositoryInfo[]> {
-    console.log("token", token);
     const data = (
       await axios.get(`/api/vcs/${vcs.id}/external-repository`, {
         headers: {
@@ -59,8 +59,7 @@ const actions = {
           refreshToken: token.refreshToken,
         },
       })
-    ).data;
-
+    ).data.data;
     return data.map((item: any) => convertGitLabProject(item));
   },
 };

--- a/frontend/src/store/modules/gitlab.ts
+++ b/frontend/src/store/modules/gitlab.ts
@@ -6,8 +6,6 @@ import {
   OAuthToken,
 } from "../../types";
 
-const GITLAB_API_PATH = "api/v4";
-
 const getters = {};
 
 function convertGitLabProject(project: any): ExternalRepositoryInfo {
@@ -20,6 +18,8 @@ function convertGitLabProject(project: any): ExternalRepositoryInfo {
 }
 
 const actions = {
+  // this actions is for initiating vcs ONLY
+  // after creation, the frontend should in no case access the secret
   async exchangeToken(
     {}: any,
     {
@@ -46,21 +46,19 @@ const actions = {
     return oAuthToken;
   },
 
+  // TODO(zilong): here we still store the access token at the frontend, we may move this to the backend
   async fetchProjectList(
     {}: any,
-    { vcs, token }: { vcs: VCS; token: string }
+    { vcs, token }: { vcs: VCS; token: OAuthToken }
   ): Promise<ExternalRepositoryInfo[]> {
-    // We will use user's token to create webhook in the project, which requires the token owner to
-    // be at least the project maintainer(40)
+    console.log("token", token);
     const data = (
-      await axios.get(
-        `${vcs.instanceUrl}/${GITLAB_API_PATH}/projects?membership=true&simple=true&min_access_level=40`,
-        {
-          headers: {
-            Authorization: "Bearer " + token,
-          },
-        }
-      )
+      await axios.get(`/api/vcs/${vcs.id}/external-repository`, {
+        headers: {
+          accessToken: token.accessToken,
+          refreshToken: token.refreshToken,
+        },
+      })
     ).data;
 
     return data.map((item: any) => convertGitLabProject(item));

--- a/frontend/src/store/modules/oauth.ts
+++ b/frontend/src/store/modules/oauth.ts
@@ -5,13 +5,13 @@ const convert = (raw: ResourceObject): OAuthToken => {
   const attr = raw.attributes;
   return {
     accessToken: attr.accessToken as string,
-    expiresTs: attr.expiresTs as number,
     refreshToken: attr.refreshToken as string,
+    expiresTs: attr.expiresTs as number,
   };
 };
 
 const actions = {
-  async exchangeToken(
+  async exchangeVCSToken(
     {}: any,
     {
       vcsId,

--- a/frontend/src/store/modules/oauth.ts
+++ b/frontend/src/store/modules/oauth.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+import { VCSId, OAuthToken, ResourceObject } from "../../types";
+
+const convert = (raw: ResourceObject): OAuthToken => {
+  const attr = raw.attributes;
+  return {
+    accessToken: attr.accessToken as string,
+    expiresTs: attr.expiresTs as number,
+    refreshToken: attr.refreshToken as string,
+  };
+};
+
+const actions = {
+  async exchangeToken(
+    {}: any,
+    {
+      vcsId,
+      code,
+    }: {
+      vcsId: VCSId;
+      code: string;
+    }
+  ): Promise<OAuthToken> {
+    const data = (
+      await axios.post(`/api/oauth/vcs/${vcsId}/exchange-token`, null, {
+        headers: { code },
+      })
+    ).data.data;
+
+    const token = convert(data);
+    return token;
+  },
+};
+export default {
+  namespaced: true,
+  actions,
+};

--- a/frontend/src/store/modules/vcs.ts
+++ b/frontend/src/store/modules/vcs.ts
@@ -124,7 +124,7 @@ const actions = {
     const data = (
       await axios.patch(`/api/vcs/${vcsId}`, {
         data: {
-          type: "VCSCreate",
+          type: "VCSPatch",
           attributes: vcsPatch,
         },
       })

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -47,7 +47,7 @@ export const EmptyAuthProvider: AuthProvider = {
 };
 
 export type VCSLoginInfo = {
-  id: VCSId;
+  vcsId: VCSId;
   name: string;
-  accessToken: string;
+  code: string;
 };

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -103,7 +103,7 @@ export type ProjectMemberPatch = {
 
 export type ProjectRepositoryConfig = {
   vcs: VCS;
-  // TODO(zilong): move this token completely inaccessible by the frontend
+  // TODO(zilong): get rid of the token in the frontend.
   token: OAuthToken;
   code: string;
   repositoryInfo: ExternalRepositoryInfo;

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -103,8 +103,9 @@ export type ProjectMemberPatch = {
 
 export type ProjectRepositoryConfig = {
   vcs: VCS;
-  code: string;
+  // TODO(zilong): move this token completely inaccessible by the frontend
   token: OAuthToken;
+  code: string;
   repositoryInfo: ExternalRepositoryInfo;
   repositoryConfig: RepositoryConfig;
 };

--- a/frontend/src/views/SettingWorkspaceVCSDetail.vue
+++ b/frontend/src/views/SettingWorkspaceVCSDetail.vue
@@ -201,7 +201,7 @@ export default defineComponent({
       if (isEmpty(payload.error)) {
         if (vcs.value.type == "GITLAB_SELF_HOST") {
           store
-            .dispatch("oauth/exchangeToken", {
+            .dispatch("oauth/exchangeVCSToken", {
               vcsId: idFromSlug(props.vcsSlug),
               code: payload.code,
             })

--- a/frontend/src/views/SettingWorkspaceVCSDetail.vue
+++ b/frontend/src/views/SettingWorkspaceVCSDetail.vue
@@ -137,7 +137,14 @@
 </template>
 
 <script lang="ts">
-import { reactive, computed, watchEffect, onMounted, onUnmounted } from "vue";
+import {
+  reactive,
+  computed,
+  watchEffect,
+  onMounted,
+  onUnmounted,
+  defineComponent,
+} from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import RepositoryTable from "../components/RepositoryTable.vue";
@@ -158,7 +165,7 @@ interface LocalState {
   oAuthResultCallback?: (token: OAuthToken | undefined) => void;
 }
 
-export default {
+export default defineComponent({
   name: "SettingWorkspaceVCSDetail",
   components: { RepositoryTable },
   props: {
@@ -195,7 +202,7 @@ export default {
         if (vcs.value.type == "GITLAB_SELF_HOST") {
           store
             .dispatch("auth/exchangeOAuthToken", {
-              vcsId: state.applicationId,
+              vcsId: idFromSlug(props.vcsSlug),
               code: payload.code,
             })
             .then((token: OAuthToken) => {
@@ -338,5 +345,5 @@ export default {
       deleteVCS,
     };
   },
-};
+});
 </script>

--- a/frontend/src/views/SettingWorkspaceVCSDetail.vue
+++ b/frontend/src/views/SettingWorkspaceVCSDetail.vue
@@ -201,7 +201,7 @@ export default defineComponent({
       if (isEmpty(payload.error)) {
         if (vcs.value.type == "GITLAB_SELF_HOST") {
           store
-            .dispatch("auth/exchangeOAuthToken", {
+            .dispatch("oauth/exchangeToken", {
               vcsId: idFromSlug(props.vcsSlug),
               code: payload.code,
             })

--- a/frontend/src/views/SettingWorkspaceVCSDetail.vue
+++ b/frontend/src/views/SettingWorkspaceVCSDetail.vue
@@ -148,8 +148,6 @@ import {
   VCSPatch,
   openWindowForOAuth,
   OAuthWindowEventPayload,
-  OAuthConfig,
-  redirectUrl,
   OAuthToken,
 } from "../types";
 
@@ -195,15 +193,9 @@ export default {
       const payload = (event as CustomEvent).detail as OAuthWindowEventPayload;
       if (isEmpty(payload.error)) {
         if (vcs.value.type == "GITLAB_SELF_HOST") {
-          const oAuthConfig: OAuthConfig = {
-            endpoint: `${vcs.value.instanceUrl}/oauth/token`,
-            applicationId: state.applicationId,
-            secret: state.secret,
-            redirectUrl: redirectUrl(),
-          };
           store
-            .dispatch("gitlab/exchangeToken", {
-              oAuthConfig,
+            .dispatch("auth/exchangeOAuthToken", {
+              vcsId: state.applicationId,
               code: payload.code,
             })
             .then((token: OAuthToken) => {

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -166,8 +166,6 @@ import {
   EmptyAuthProvider,
   VCSLoginInfo,
   LoginInfo,
-  OAuthConfig,
-  OAuthToken,
   OAuthWindowEventPayload,
   openWindowForOAuth,
   redirectUrl,
@@ -228,32 +226,18 @@ export default {
       if (payload.error) {
         return;
       }
-      const oAuthConfig: OAuthConfig = {
-        endpoint: `${state.activeAuthProvider.instanceUrl}/oauth/token`,
-        applicationId: state.activeAuthProvider.applicationId,
-        secret: state.activeAuthProvider.secret,
-        redirectUrl: redirectUrl(),
+      const gitlabLoginInfo: VCSLoginInfo = {
+        vcsId: state.activeAuthProvider.id,
+        name: state.activeAuthProvider.name,
+        code: payload.code,
       };
       store
-        .dispatch("gitlab/exchangeToken", {
-          oAuthConfig,
-          code: payload.code,
+        .dispatch("auth/login", {
+          authProvider: "GITLAB_SELF_HOST",
+          payload: gitlabLoginInfo,
         })
-        .then((token: OAuthToken) => {
-          const gitlabLoginInfo: VCSLoginInfo = {
-            id: state.activeAuthProvider.id,
-            name: state.activeAuthProvider.name,
-            accessToken: token.accessToken,
-          };
-
-          store
-            .dispatch("auth/login", {
-              authProvider: "GITLAB_SELF_HOST",
-              payload: gitlabLoginInfo,
-            })
-            .then(() => {
-              router.push("/");
-            });
+        .then(() => {
+          router.push("/");
         });
     };
 

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -107,6 +107,14 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 	return nil, errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
 }
 
+func (p *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange *common.OAuthExchange) (*vcs.OAuthToken, error) {
+	return nil, errors.New("not implemented yet")
+}
+
+func (p *Provider) FetchRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]*vcs.Repository, error) {
+	return nil, errors.New("not implemented yet")
+}
+
 func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*vcs.RepositoryTreeNode, error) {
 	return nil, errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
 }

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -218,7 +218,6 @@ func (provider *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL st
 	}
 
 	body, err := io.ReadAll(resp.Body)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to read oauth response body, code %v, error: %v", resp.StatusCode, err)
 	}

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -192,12 +192,12 @@ func (provider *Provider) APIURL(instanceURL string) string {
 }
 
 // ExchangeOAuthToken exchange oauth content with the provdied authentication code
-func (provider *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange common.OAuthExchange, code string, redirectURL string) (*vcs.OAuthToken, error) {
+func (provider *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange *common.OAuthExchange) (*vcs.OAuthToken, error) {
 	urlParams := &url.Values{}
 	urlParams.Set("client_id", oauthExchange.ClientID)
 	urlParams.Set("client_secret", oauthExchange.ClientSecret)
-	urlParams.Set("code", code)
-	urlParams.Set("redirect_uri", redirectURL)
+	urlParams.Set("code", oauthExchange.Code)
+	urlParams.Set("redirect_uri", oauthExchange.RedirectURL)
 	urlParams.Set("grant_type", "authorization_code")
 	url := fmt.Sprintf("%s/oauth/token?%s", instanceURL, urlParams.Encode())
 

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -192,7 +192,7 @@ func (provider *Provider) APIURL(instanceURL string) string {
 }
 
 // ExchangeOAuthToken exchange oauth content with the provdied authentication code
-func (provider *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange common.OAuthExchange, code string, redirectURL string) (*common.OAuthToken, error) {
+func (provider *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange common.OAuthExchange, code string, redirectURL string) (*vcs.OAuthToken, error) {
 	urlParams := &url.Values{}
 	urlParams.Set("client_id", oauthExchange.ClientID)
 	urlParams.Set("client_secret", oauthExchange.ClientSecret)
@@ -223,7 +223,7 @@ func (provider *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL st
 		return nil, fmt.Errorf("failed to read oauth response body, code %v, error: %v", resp.StatusCode, err)
 	}
 
-	oauthToken := &common.OAuthToken{}
+	oauthToken := &vcs.OAuthToken{}
 	if err := json.Unmarshal(body, oauthToken); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal oauth response body, code %v, error: %v", resp.StatusCode, err)
 	}

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -238,7 +238,7 @@ func (provider *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL st
 	return oauthToken, nil
 }
 
-// FetchRepositoryList will fetch all repository within a given user's scope
+// FetchRepositoryList will fetch all repository in which the authenticated user has a maintainer role
 func (provider *Provider) FetchRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]*vcs.Repository, error) {
 	code, body, err := httpGet(
 		instanceURL,

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -163,7 +163,7 @@ type gitLabRepositoryMember struct {
 	AccessLevel int32     `json:"access_level"`
 }
 
-// gitLabRepositoryMember is the API message for repository in GitLab
+// gitLabRepository is the API message for repository in GitLab
 type gitLabRepository struct {
 	ID                int64  `json:"id"`
 	Name              string `json:"name"`

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -132,7 +132,7 @@ type Provider interface {
 	// instanceURL: VCS instance URL
 	// code: authentication code of a given user
 	// redirectURL: redirect url configured at the VCS application
-	ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange common.OAuthExchange, code string, redirectURL string) (*OAuthToken, error)
+	ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange *common.OAuthExchange) (*OAuthToken, error)
 
 	// Try to use this provider as an auth provider and fetch the user info from the OAuth context
 	//

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -102,6 +102,14 @@ type RepositoryMember struct {
 	RoleProvider Type               `json:"roleProvider"`
 }
 
+// Repository is the API message for  repository info.
+type Repository struct {
+	ID       int64  `jsonapi:"primary,id"`
+	Name     string `jsonapi:"attr,name"`
+	FullPath string `jsonapi:"attr,fullPath"`
+	WebURL   string `jsonapi:"attr,webUrl"`
+}
+
 // Provider is the interface for VCS provider.
 type Provider interface {
 	// Returns the API URL for a given VCS instance URL
@@ -113,7 +121,7 @@ type Provider interface {
 	// instanceURL: VCS instance URL
 	// code: authentication code of a given user
 	// redirectURL: redirect url configured at the VCS application
-	ExchangeOauthContent(ctx context.Context, instanceURL string, oauthCtx common.OauthContext, code string, redirectURL string) (*common.OAuthToken, error)
+	ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange common.OAuthExchange, code string, redirectURL string) (*common.OAuthToken, error)
 
 	// Try to use this provider as an auth provider and fetch the user info from the OAuth context
 	//
@@ -133,11 +141,11 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string) ([]*RepositoryMember, error)
 
-	// Fetch all repository list within the scope of the given user
+	// Fetch all repository in which the authenticated user has a maintainer role
 	//
 	// oauthCtx: OAuth context to write the file content
 	// instanceURL: VCS instance URL
-	FetchRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]byte, error)
+	FetchRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]*Repository, error)
 
 	// Fetch the repository file list
 	//

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -28,6 +28,17 @@ func (e Type) String() string {
 	return "UNKNOWN"
 }
 
+// OAuthToken is the API message for OAuthToken.
+type OAuthToken struct {
+	AccessToken  string `json:"access_token" `
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	CreatedAt    int64  `json:"created_at"`
+	// ExpiresTs is a derivative from ExpresIn and CreatedAt.
+	// ExpiresTs = ExpiresIn == 0 ? 0 : CreatedAt + ExpiresIn
+	ExpiresTs int64 `json:"expires_ts"`
+}
+
 // These payload types are only used when marshalling to the json format for saving into the database.
 // So we annotate with json tag using camelCase naming which is consistent with normal
 // json naming convention
@@ -104,10 +115,10 @@ type RepositoryMember struct {
 
 // Repository is the API message for  repository info.
 type Repository struct {
-	ID       int64  `jsonapi:"primary,id"`
-	Name     string `jsonapi:"attr,name"`
-	FullPath string `jsonapi:"attr,fullPath"`
-	WebURL   string `jsonapi:"attr,webUrl"`
+	ID       int64  `json:"id"`
+	Name     string `json:"name"`
+	FullPath string `json:"fullPath"`
+	WebURL   string `json:"webUrl"`
 }
 
 // Provider is the interface for VCS provider.
@@ -121,7 +132,7 @@ type Provider interface {
 	// instanceURL: VCS instance URL
 	// code: authentication code of a given user
 	// redirectURL: redirect url configured at the VCS application
-	ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange common.OAuthExchange, code string, redirectURL string) (*common.OAuthToken, error)
+	ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange common.OAuthExchange, code string, redirectURL string) (*OAuthToken, error)
 
 	// Try to use this provider as an auth provider and fetch the user info from the OAuth context
 	//

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -106,6 +106,15 @@ type RepositoryMember struct {
 type Provider interface {
 	// Returns the API URL for a given VCS instance URL
 	APIURL(instanceURL string) string
+
+	// Exchange oauth content with the provided code and return the access token retrieved
+	//
+	// oauthCtx: OAuth context to write the file content
+	// instanceURL: VCS instance URL
+	// code: authentication code of a given user
+	// redirectURL: redirect url configured at the VCS application
+	ExchangeOauthContent(ctx context.Context, instanceURL string, oauthCtx common.OauthContext, code string, redirectURL string) (*common.OAuthToken, error)
+
 	// Try to use this provider as an auth provider and fetch the user info from the OAuth context
 	//
 	// oauthCtx: OAuth context to write the file content
@@ -123,6 +132,13 @@ type Provider interface {
 	// instanceURL: VCS instance URL
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string) ([]*RepositoryMember, error)
+
+	// Fetch all repository list within the scope of the given user
+	//
+	// oauthCtx: OAuth context to write the file content
+	// instanceURL: VCS instance URL
+	FetchRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]byte, error)
+
 	// Fetch the repository file list
 	//
 	// oauthCtx: OAuth context to read the repository tree
@@ -131,6 +147,8 @@ type Provider interface {
 	// ref: the unique name of a repository tree, could be a branch name in GitLab or a tree sha in GitHub
 	// filePath: the path inside repository, used to get content of subdirectories
 	FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*RepositoryTreeNode, error)
+
+
 	// Commits a new file
 	//
 	// oauthCtx: OAuth context to write the file content

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -113,7 +113,7 @@ type RepositoryMember struct {
 	RoleProvider Type               `json:"roleProvider"`
 }
 
-// Repository is the API message for  repository info.
+// Repository is the API message for repository info.
 type Repository struct {
 	ID       int64  `json:"id"`
 	Name     string `json:"name"`

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -126,12 +126,10 @@ type Provider interface {
 	// Returns the API URL for a given VCS instance URL
 	APIURL(instanceURL string) string
 
-	// Exchange oauth content with the provided code and return the access token retrieved
+	// Exchange oauth token with the provided code
 	//
-	// oauthCtx: OAuth context to write the file content
 	// instanceURL: VCS instance URL
-	// code: authentication code of a given user
-	// redirectURL: redirect url configured at the VCS application
+	// oauthExchange: api message for exchanging oauth token
 	ExchangeOAuthToken(ctx context.Context, instanceURL string, oauthExchange *common.OAuthExchange) (*OAuthToken, error)
 
 	// Try to use this provider as an auth provider and fetch the user info from the OAuth context

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -141,7 +141,7 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string) ([]*RepositoryMember, error)
 
-	// Fetch all repository in which the authenticated user has a maintainer role
+	// Fetch all repository within a given user's scope
 	//
 	// oauthCtx: OAuth context to write the file content
 	// instanceURL: VCS instance URL

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -165,7 +165,6 @@ type Provider interface {
 	// filePath: the path inside repository, used to get content of subdirectories
 	FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*RepositoryTreeNode, error)
 
-
 	// Commits a new file
 	//
 	// oauthCtx: OAuth context to write the file content

--- a/server/acl.go
+++ b/server/acl.go
@@ -27,7 +27,7 @@ func aclMiddleware(l *zap.Logger, s *Server, ce *casbin.Enforcer, next echo.Hand
 	return func(c echo.Context) error {
 		ctx := context.Background()
 		// Skips auth, actuator, plan
-		if common.HasPrefixes(c.Path(), "/api/auth", "/api/actuator", "/api/plan") {
+		if common.HasPrefixes(c.Path(), "/api/auth", "/api/actuator", "/api/plan", "/api/oauth") {
 			return next(c)
 		}
 

--- a/server/acl_casbin_policy_dba.csv
+++ b/server/acl_casbin_policy_dba.csv
@@ -80,6 +80,7 @@ p, DBA, /vcs/{id}, GET
 p, DBA, /vcs/{id}, PATCH
 p, DBA, /vcs/{id}, DELETE
 p, DBA, /vcs/{id}/repository, GET
+p, DBA, /vcs/{id}/external-repository, GET
 p, DBA, /plan, GET
 p, DBA, /plan, PATCH
 p, DBA, /setting, GET

--- a/server/acl_casbin_policy_developer.csv
+++ b/server/acl_casbin_policy_developer.csv
@@ -70,6 +70,7 @@ p, DEVELOPER, /sql/ping, POST
 p, DEVELOPER, /sql/execute, POST
 p, DEVELOPER, /vcs, GET
 p, DEVELOPER, /vcs/{id}, GET
+p, DEVELOPER, /vcs/{id}/external-repository, GET
 p, DEVELOPER, /plan, GET
 p, DEVELOPER, /plan, PATCH
 p, DEVELOPER, /setting, GET

--- a/server/acl_casbin_policy_owner.csv
+++ b/server/acl_casbin_policy_owner.csv
@@ -84,6 +84,7 @@ p, OWNER, /vcs/{id}, GET
 p, OWNER, /vcs/{id}, PATCH
 p, OWNER, /vcs/{id}, DELETE
 p, OWNER, /vcs/{id}/repository, GET
+p, OWNER, /vcs/{id}/external-repository, GET
 p, OWNER, /plan, GET
 p, OWNER, /plan, PATCH
 p, OWNER, /setting, GET

--- a/server/auth.go
+++ b/server/auth.go
@@ -83,7 +83,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 				if err := jsonapi.UnmarshalPayload(c.Request().Body, gitlabLogin); err != nil {
 					return echo.NewHTTPError(http.StatusBadRequest, "Malformatted gitlab login request").SetInternal(err)
 				}
-				vcsFound, err := s.store.GetVCSByID(ctx, gitlabLogin.ID)
+				vcsFound, err := s.store.GetVCSByID(ctx, gitlabLogin.VCSID)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch vcs, name: %v, ID: %v", gitlabLogin.Name, gitlabLogin.Name)).SetInternal(err)
 				}

--- a/server/auth.go
+++ b/server/auth.go
@@ -93,7 +93,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("vcs do not exist, name: %v, ID: %v", gitlabLogin.Name, gitlabLogin.Name)).SetInternal(err)
 				}
 
-				// exchange Oauth Token
+				// exchange OAuth Token
 				oauthToken, err := vcsPlugin.Get(vcsFound.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
 					ctx,
 					vcsFound.InstanceURL,

--- a/server/auth.go
+++ b/server/auth.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
@@ -213,49 +212,6 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 		}
 		return nil
 	})
-
-	// TODO(zilong): we may not need to return access token back to the frontend
-	g.GET("/auth/exchange-oauth-token/:vcsID", func(c echo.Context) error {
-		ctx := context.Background()
-
-		vcsID64, err := strconv.ParseInt(c.Param("vcsID"), 10, 32)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to marshal oauth provider's ID: %v", c.Param("id"))).SetInternal(err)
-		}
-		vcsID := int(vcsID64)
-		code := c.Request().Header.Get("code")
-
-		findVCS := &api.VCSFind{ID: &vcsID}
-		vcs, err := s.VCSService.FindVCS(ctx, findVCS)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
-		}
-		if vcs == nil {
-			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Failed to find VCS, ID: %v", vcsID)).SetInternal(err)
-		}
-
-		oauthToken, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
-			ctx,
-			vcs.InstanceURL,
-			common.OAuthExchange{
-				ClientID:     vcs.ApplicationID,
-				ClientSecret: vcs.Secret,
-			},
-			code,
-			fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
-		)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to exchange OAuth token").SetInternal(err)
-		}
-
-		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
-		if err := jsonapi.MarshalPayload(c.Response().Writer, oauthToken); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal exchange OAuth token response").SetInternal(err)
-		}
-
-		return nil
-	})
-
 }
 
 func trySignUp(ctx context.Context, s *Server, signUp *api.SignUp, CreatorID int) (*api.Principal, *echo.HTTPError) {

--- a/server/auth.go
+++ b/server/auth.go
@@ -34,8 +34,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 				Name:          vcs.Name,
 				InstanceURL:   vcs.InstanceURL,
 				ApplicationID: vcs.ApplicationID,
-				// we do not return secret to the frontend for safety
-				Secret: "",
+				// we do not return secret to the frontend for safety concern
 			}
 			authProviderList = append(authProviderList, newProvider)
 		}
@@ -96,12 +95,12 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 				oauthToken, err := vcsPlugin.Get(vcsFound.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
 					ctx,
 					vcsFound.InstanceURL,
-					common.OAuthExchange{
+					&common.OAuthExchange{
 						ClientID:     vcsFound.ApplicationID,
 						ClientSecret: vcsFound.Secret,
+						Code:         gitlabLogin.Code,
+						RedirectURL:  fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
 					},
-					gitlabLogin.Code,
-					fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
 				)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to exchange OAuth token").SetInternal(err)

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -17,11 +17,10 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 	g.POST("/oauth/vcs/:vcsID/exchange-token", func(c echo.Context) error {
 		ctx := context.Background()
 
-		vcsID64, err := strconv.ParseInt(c.Param("vcsID"), 10, 32)
+		vcsID, err := strconv.Atoi(c.Param("vcsID"))
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to marshal oauth provider's ID: %v", c.Param("id"))).SetInternal(err)
 		}
-		vcsID := int(vcsID64)
 		code := c.Request().Header.Get("code")
 
 		findVCS := &api.VCSFind{ID: &vcsID}

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
+	"github.com/labstack/echo/v4"
+)
+
+func (s *Server) registerOAuthRoutes(g *echo.Group) {
+	g.POST("/oauth/vcs/:vcsID/exchange-oauth-token", func(c echo.Context) error {
+		ctx := context.Background()
+
+		vcsID64, err := strconv.ParseInt(c.Param("vcsID"), 10, 32)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to marshal oauth provider's ID: %v", c.Param("id"))).SetInternal(err)
+		}
+		vcsID := int(vcsID64)
+		code := c.Request().Header.Get("code")
+
+		findVCS := &api.VCSFind{ID: &vcsID}
+		vcs, err := s.VCSService.FindVCS(ctx, findVCS)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+		if vcs == nil {
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Failed to find VCS, ID: %v", vcsID)).SetInternal(err)
+		}
+
+		oauthToken, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
+			ctx,
+			vcs.InstanceURL,
+			common.OAuthExchange{
+				ClientID:     vcs.ApplicationID,
+				ClientSecret: vcs.Secret,
+			},
+			code,
+			fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
+		)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to exchange OAuth token").SetInternal(err)
+		}
+
+		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
+		oauthTokenByte, err := json.Marshal(oauthToken)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal exchange OAuth token response").SetInternal(err)
+		}
+		if _, err := c.Response().Write(oauthTokenByte); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to write exchange OAuth token to the response body").SetInternal(err)
+		}
+
+		return nil
+	})
+
+}

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -39,12 +39,12 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 			oauthTokenRaw, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
 				ctx,
 				vcs.InstanceURL,
-				common.OAuthExchange{
+				&common.OAuthExchange{
 					ClientID:     vcs.ApplicationID,
 					ClientSecret: vcs.Secret,
+					Code:         code,
+					RedirectURL:  fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
 				},
-				code,
-				fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
 			)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to exchange OAuth token").SetInternal(err)

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -23,8 +23,7 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 		}
 		code := c.Request().Header.Get("code")
 
-		findVCS := &api.VCSFind{ID: &vcsID}
-		vcs, err := s.VCSService.FindVCS(ctx, findVCS)
+		vcs, err := s.store.GetVCSByID(ctx, vcsID)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -10,11 +9,12 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
+	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 )
 
 func (s *Server) registerOAuthRoutes(g *echo.Group) {
-	g.POST("/oauth/vcs/:vcsID/exchange-oauth-token", func(c echo.Context) error {
+	g.POST("/oauth/vcs/:vcsID/exchange-token", func(c echo.Context) error {
 		ctx := context.Background()
 
 		vcsID64, err := strconv.ParseInt(c.Param("vcsID"), 10, 32)
@@ -33,28 +33,30 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Failed to find VCS, ID: %v", vcsID)).SetInternal(err)
 		}
 
-		oauthToken, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
-			ctx,
-			vcs.InstanceURL,
-			common.OAuthExchange{
-				ClientID:     vcs.ApplicationID,
-				ClientSecret: vcs.Secret,
-			},
-			code,
-			fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
-		)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to exchange OAuth token").SetInternal(err)
+		oauthToken := &api.OAuthToken{}
+		switch vcs.Type {
+		case vcsPlugin.GitLabSelfHost:
+			oauthTokenRaw, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
+				ctx,
+				vcs.InstanceURL,
+				common.OAuthExchange{
+					ClientID:     vcs.ApplicationID,
+					ClientSecret: vcs.Secret,
+				},
+				code,
+				fmt.Sprintf("%s:%d/oauth/callback", s.frontendHost, s.frontendPort),
+			)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to exchange OAuth token").SetInternal(err)
+			}
+			oauthToken.AccessToken = oauthTokenRaw.AccessToken
+			oauthToken.RefreshToken = oauthTokenRaw.RefreshToken
+			oauthToken.ExpiresTs = oauthTokenRaw.ExpiresTs
 		}
 
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
-
-		oauthTokenByte, err := json.Marshal(oauthToken)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal exchange OAuth token response").SetInternal(err)
-		}
-		if _, err := c.Response().Write(oauthTokenByte); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to write exchange OAuth token to the response body").SetInternal(err)
+		if err := jsonapi.MarshalPayload(c.Response().Writer, oauthToken); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal oauth token response").SetInternal(err)
 		}
 
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -221,6 +221,7 @@ func NewServer(logger *zap.Logger, storeInstance *store.Store, loggerLevel *zap.
 	s.registerSettingRoutes(apiGroup)
 	s.registerActuatorRoutes(apiGroup)
 	s.registerAuthRoutes(apiGroup)
+	s.registerOAuthRoutes(apiGroup)
 	s.registerPrincipalRoutes(apiGroup)
 	s.registerMemberRoutes(apiGroup)
 	s.registerPolicyRoutes(apiGroup)

--- a/server/vcs.go
+++ b/server/vcs.go
@@ -32,8 +32,6 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create VCS").SetInternal(err)
 		}
-
-		vcs, err := s.composeVCSRelationship(ctx, vcsRaw)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch created VCS relationship").SetInternal(err)
 		}
@@ -169,8 +167,7 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 		accessToken := c.Request().Header.Get("accessToken")
 		refreshToken := c.Request().Header.Get("refreshToken")
 
-		vcsFind := &api.VCSFind{ID: &id}
-		vcsFound, err := s.VCSService.FindVCS(ctx, vcsFind)
+		vcsFound, err := s.store.GetVCSByID(ctx, id)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch VCS, ID: %v", id)).SetInternal(err)
 		}

--- a/server/vcs.go
+++ b/server/vcs.go
@@ -32,9 +32,6 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create VCS").SetInternal(err)
 		}
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch created VCS relationship").SetInternal(err)
-		}
 
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
 		if err := jsonapi.MarshalPayload(c.Response().Writer, vcs); err != nil {

--- a/server/vcs.go
+++ b/server/vcs.go
@@ -178,7 +178,7 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Failed to find VCS, ID: %v", id))
 		}
 
-		externalRepoList, err := vcsPlugin.Get(vcsFound.Type, vcsPlugin.ProviderConfig{Logger: s.l}).FetchRepositoryList(
+		externalRepoListRaw, err := vcsPlugin.Get(vcsFound.Type, vcsPlugin.ProviderConfig{Logger: s.l}).FetchRepositoryList(
 			ctx,
 			common.OauthContext{
 				ClientID:     vcsFound.ApplicationID,
@@ -191,6 +191,16 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 		)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to find external repository, instance URL: %s", vcsFound.InstanceURL)).SetInternal(err)
+		}
+
+		var externalRepoList []*api.ExternalRepository
+		for _, repo := range externalRepoListRaw {
+			externalRepoList = append(externalRepoList, &api.ExternalRepository{
+				ID:       repo.ID,
+				FullPath: repo.FullPath,
+				Name:     repo.Name,
+				WebURL:   repo.WebURL,
+			})
 		}
 
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)

--- a/store/principal.go
+++ b/store/principal.go
@@ -206,7 +206,7 @@ func (s *Store) findPrincipalRaw(ctx context.Context, find *api.PrincipalFind) (
 	}
 
 	if len(list) == 0 {
-		return nil, &common.Error{Code: common.NotFound, Err: fmt.Errorf("principal not found with PrincipalFind[%+v]", find)}
+		return nil, nil
 	} else if len(list) > 1 {
 		return nil, &common.Error{Code: common.Conflict, Err: fmt.Errorf("found %d principals with PrincipalFind[%+v], expect 1", len(list), find)}
 	}


### PR DESCRIPTION
function effected:
1. `login via VCS` **both access token and application secret is invisible to the frontend**
2. `set up a VCS for the workspace` **for the user need to set up the secret for the first time, no logic changed**
3. `set up a VCS repo for the project`  **application secret is invisible to the frontend, the access token will still return by the backend for we may still need the token to access VCS resource** 
      Possible improvement: store the gitlab token in the cookie just like how we store our access token 