### PR TITLE
refactor(sql-editor): show the sheet icon when sheet is not `PRIVATE`

### DIFF
--- a/frontend/src/views/SqlEditor/EditorPanel/SharePopover.vue
+++ b/frontend/src/views/SqlEditor/EditorPanel/SharePopover.vue
@@ -30,7 +30,7 @@
           >
             <div class="access-content--prefix flex">
               <div v-if="idx === 0" class="mt-1">
-                <heroicons-outline:user class="h-5 w-5" />
+                <heroicons-outline:lock-closed class="h-5 w-5" />
               </div>
               <div v-if="idx === 1" class="mt-1">
                 <heroicons-outline:user-group class="h-5 w-5" />

--- a/frontend/src/views/SqlEditor/TabListContainer.vue
+++ b/frontend/src/views/SqlEditor/TabListContainer.vue
@@ -42,8 +42,16 @@
                 Edit {{ labelState.currentLabelName }}
               </span>
             </div>
-            <span v-else>
-              {{ tab.name }}
+            <span v-else class="flex items-center space-x-2">
+              <heroicons-outline:user-group
+                v-if="currentSheet.visibility === 'PROJECT'"
+                class="w-4 h-4"
+              />
+              <heroicons-outline:globe
+                v-if="currentSheet.visibility === 'PUBLIC'"
+                class="w-4 h-4"
+              />
+              <span>{{ tab.name }}</span>
             </span>
           </div>
           <template v-if="enterTabId === tab.id && tabList.length > 1">
@@ -134,6 +142,7 @@ import {
   TabGetters,
   TabState,
   TabActions,
+  SheetGetters,
   SheetActions,
 } from "@/types";
 import { getDefaultTab } from "@/utils/tab";
@@ -146,6 +155,9 @@ const { currentTab, hasTabs } = useNamespacedGetters<TabGetters>("tab", [
 ]);
 const { isDisconnected } = useNamespacedGetters<SqlEditorGetters>("sqlEditor", [
   "isDisconnected",
+]);
+const { currentSheet } = useNamespacedGetters<SheetGetters>("sheet", [
+  "currentSheet",
 ]);
 
 // state map


### PR DESCRIPTION
related [issue](https://linear.app/bbteam/issue/BYT-323/consider-using-a-lock-icon-for-the-private-sheet-and-also-show-the)

## using `lock` icon for private sheet

<img width="346" alt="CleanShot 2022-03-22 at 18 17 50@2x" src="https://user-images.githubusercontent.com/6118824/159458611-2966a4ca-00bc-4e96-835f-9a655d041409.png">

## show the sheet icon when sheet is not `PRIVATE`

<img width="456" alt="CleanShot 2022-03-22 at 18 15 23@2x" src="https://user-images.githubusercontent.com/6118824/159458253-012ea0db-c558-4166-baf0-e1fe8783ddc4.png">
