### PR TITLE
fix: re-mapping db label values

### DIFF
--- a/store/seed/test/10200__label.sql
+++ b/store/seed/test/10200__label.sql
@@ -298,7 +298,7 @@ VALUES
         20027,
         1,
         1,
-        7026,
+        7027,
         'bb.tenant',
         'dev'
     );
@@ -317,7 +317,7 @@ VALUES
         20028,
         1,
         1,
-        7027,
+        7028,
         'bb.tenant',
         'public_test'
     );
@@ -336,7 +336,7 @@ VALUES
         20029,
         1,
         1,
-        7028,
+        7029,
         'bb.tenant',
         'turtle_rock'
     );
@@ -355,7 +355,7 @@ VALUES
         20030,
         1,
         1,
-        7028,
+        7029,
         'bb.location',
         'east'
     );
@@ -374,7 +374,7 @@ VALUES
         20031,
         1,
         1,
-        7029,
+        7030,
         'bb.tenant',
         'echo_island'
     );
@@ -393,7 +393,7 @@ VALUES
         20032,
         1,
         1,
-        7029,
+        7030,
         'bb.location',
         'west'
     );


### PR DESCRIPTION
Seed DB ID's have been shifted since new DB was inserted.
This PR will fix the ID mapping relationship.