### PR TITLE
chore: use unique index (namespace, version) instead of (namespace, source, version) because version should be unique within a namespace

### DIFF
--- a/plugin/db/mysql/mysql_migration_schema.sql
+++ b/plugin/db/mysql/mysql_migration_schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE bytebase.migration_history (
 
 CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_sequence ON bytebase.migration_history (namespace(256), sequence);
 
-CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_source_version ON bytebase.migration_history (namespace(256), source(256), version(256));
+CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_version ON bytebase.migration_history (namespace(256), version(256));
 
 CREATE INDEX bytebase_idx_migration_history_namespace_source_type ON bytebase.migration_history(namespace(256), source(256), type(256));
 

--- a/plugin/db/pg/pg_migration_schema.sql
+++ b/plugin/db/pg/pg_migration_schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE migration_history (
 
 CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_sequence ON migration_history (namespace, sequence);
 
-CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_source_version ON migration_history (namespace, source, version);
+CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_version ON migration_history (namespace, version);
 
 CREATE INDEX bytebase_idx_migration_history_namespace_source_type ON migration_history(namespace, source, type);
 

--- a/plugin/db/sqlite/sqlite_migration_schema.sql
+++ b/plugin/db/sqlite/sqlite_migration_schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE bytebase_migration_history (
 
 CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_sequence ON bytebase_migration_history (namespace, sequence);
 
-CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_source_version ON bytebase_migration_history (namespace, source, version);
+CREATE UNIQUE INDEX bytebase_idx_unique_migration_history_namespace_version ON bytebase_migration_history (namespace, version);
 
 CREATE INDEX bytebase_idx_migration_history_namespace_source_type ON bytebase_migration_history(namespace, source, type);
 


### PR DESCRIPTION
This will also improve the query with the where clause of "version < xxxx" without a source.