### PR TITLE
feat: add migration for GITHUB_COM to be a valid Git and role provider

### DIFF
--- a/bin/server/cmd/profile_dev.go
+++ b/bin/server/cmd/profile_dev.go
@@ -23,7 +23,7 @@ func activeProfile(dataDir string, port, datastorePort int, isDemo bool) Profile
 		seedDir:              "seed/test",
 		forceResetSeed:       true,
 		backupRunnerInterval: 10 * time.Second,
-		schemaVersion:        10001,
+		schemaVersion:        10002,
 	}
 }
 
@@ -39,6 +39,6 @@ func GetTestProfile(dataDir string, port, datastorePort int) Profile {
 		seedDir:              "seed/test",
 		forceResetSeed:       true,
 		backupRunnerInterval: 10 * time.Second,
-		schemaVersion:        10001,
+		schemaVersion:        10002,
 	}
 }

--- a/store/migration/10002__add_vcs_github_com.sql
+++ b/store/migration/10002__add_vcs_github_com.sql
@@ -1,8 +1,8 @@
 ALTER TABLE project DROP CONSTRAINT project_role_provider_check;
-ALTER TABLE project ADD CONSTRAINT project_role_provider_check CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_DOT_COM'));
+ALTER TABLE project ADD CONSTRAINT project_role_provider_check CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_COM'));
 
 ALTER TABLE project_member DROP CONSTRAINT project_member_role_provider_check;
-ALTER TABLE project_member ADD CONSTRAINT project_member_role_provider_check CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_DOT_COM'));
+ALTER TABLE project_member ADD CONSTRAINT project_member_role_provider_check CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_COM'));
 
 ALTER TABLE vcs DROP CONSTRAINT vcs_type_check;
-ALTER TABLE vcs ADD CONSTRAINT vcs_type_check CHECK (type IN ('GITLAB_SELF_HOST', 'GITHUB_DOT_COM'));
+ALTER TABLE vcs ADD CONSTRAINT vcs_type_check CHECK (type IN ('GITLAB_SELF_HOST', 'GITHUB_COM'));

--- a/store/migration/10002__add_vcs_github_com.sql
+++ b/store/migration/10002__add_vcs_github_com.sql
@@ -1,0 +1,8 @@
+ALTER TABLE project DROP CONSTRAINT project_role_provider_check;
+ALTER TABLE project ADD CONSTRAINT project_role_provider_check CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_DOT_COM'));
+
+ALTER TABLE project_member DROP CONSTRAINT project_member_role_provider_check;
+ALTER TABLE project_member ADD CONSTRAINT project_member_role_provider_check CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_DOT_COM'));
+
+ALTER TABLE vcs DROP CONSTRAINT vcs_type_check;
+ALTER TABLE vcs ADD CONSTRAINT vcs_type_check CHECK (type IN ('GITLAB_SELF_HOST', 'GITHUB_DOT_COM'));


### PR DESCRIPTION
Adds a migration script to make `GITHUB_COM` be a valid value for both Git and role provider. 

---

Part of https://github.com/bytebase/bytebase/issues/928