### PR TITLE
fix: css reset conflicts between tailwindcss v3 and naive-ui

### DIFF
--- a/frontend/src/plugins/naive-ui.ts
+++ b/frontend/src/plugins/naive-ui.ts
@@ -54,6 +54,16 @@ const naive = create({
   ],
 });
 
-const install = (app: App) => app.use(naive);
+const install = (app: App) => {
+  app.use(naive);
+  reAppendMetaTag("naive-ui-style");
+  reAppendMetaTag("vueuc-style");
+};
 
 export default install;
+
+const reAppendMetaTag = (name: string) => {
+  const meta = document.createElement("meta");
+  meta.name = name;
+  document.head.appendChild(meta);
+};


### PR DESCRIPTION
This solution comes from [样式元素位置 - Naive UI](https://www.naiveui.com/zh-CN/light/docs/style-position).