### PR TITLE
fix: use a more moderate way to set body's font-size

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
   <title>Bytebase</title>
 </head>
 
-<body>
+<body class="text-base">
   <div id="app"></div>
   <script type="module" src="/src/main.ts"></script>
   <script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -139,9 +139,3 @@ window.addEventListener("bb.oauth.unknown", (event) => {
   });
 });
 </script>
-
-<style>
-body {
-  @apply !text-base;
-}
-</style>


### PR DESCRIPTION
I'm a little bit scared to use `!important` on `<body>`, so I changed a way to set body's font-size, PTAL.