### PR TITLE
feat: implement methods of VCS provider workflow for GITHUB_COM

### DIFF
--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -1,0 +1,279 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/vcs"
+)
+
+const (
+	maxRetries = 3
+
+	apiURL = "https://api.github.com"
+)
+
+var _ vcs.Provider = (*Provider)(nil)
+
+func init() {
+	vcs.Register(vcs.GitHubCom, newProvider)
+}
+
+// Provider is the GitLab self host provider.
+type Provider struct {
+	l      *zap.Logger
+	client *http.Client
+}
+
+func newProvider(config vcs.ProviderConfig) vcs.Provider {
+	if config.Client == nil {
+		config.Client = &http.Client{}
+	}
+	return &Provider{
+		l:      config.Logger,
+		client: config.Client,
+	}
+}
+
+func (p *Provider) APIURL(string) string {
+	return apiURL
+}
+
+// fetchUserInfo fetches user information from the given resourceURI, which
+// should be either "user" or "users/{username}".
+func (p *Provider) fetchUserInfo(ctx context.Context, oauthCtx common.OauthContext, resourceURI string) (*vcs.UserInfo, error) {
+	code, body, err := httpGet(
+		ctx,
+		p.client,
+		resourceURI,
+		&oauthCtx.AccessToken,
+		oauthContext{
+			ClientID:     oauthCtx.ClientID,
+			ClientSecret: oauthCtx.ClientSecret,
+			RefreshToken: oauthCtx.RefreshToken,
+		},
+		oauthCtx.Refresher,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "GET")
+	}
+
+	if code == http.StatusNotFound {
+		errInfo := []string{"failed to fetch user info from GitHub.com"}
+		resourceURISplit := strings.Split(resourceURI, "/")
+		if len(resourceURI) > 1 {
+			errInfo = append(errInfo, fmt.Sprintf("UserID: %v", resourceURISplit[1]))
+		}
+		return nil, common.Errorf(common.NotFound, fmt.Errorf(strings.Join(errInfo, ", ")))
+	} else if code >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("failed to read user info from GitHub.com, status code: %d",
+			code,
+		)
+	}
+
+	userInfo := &vcs.UserInfo{}
+	if err = json.Unmarshal([]byte(body), userInfo); err != nil {
+		return nil, errors.Wrap(err, "Unmarshal")
+	}
+	return userInfo, err
+}
+
+func (p *Provider) TryLogin(ctx context.Context, oauthCtx common.OauthContext, _ string) (*vcs.UserInfo, error) {
+	return p.fetchUserInfo(ctx, oauthCtx, "user")
+}
+
+func (p *Provider) FetchUserInfo(ctx context.Context, oauthCtx common.OauthContext, _, username string) (*vcs.UserInfo, error) {
+	return p.fetchUserInfo(ctx, oauthCtx, fmt.Sprintf("users/%s", username))
+}
+
+func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string) ([]*vcs.RepositoryMember, error) {
+	return nil, errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*vcs.RepositoryTreeNode, error) {
+	return nil, errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit vcs.FileCommitCreate) error {
+	return errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit vcs.FileCommitCreate) error {
+	return errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) ReadFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, commitID string) (string, error) {
+	return "", errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, branch string) (*vcs.FileMeta, error) {
+	return nil, errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error) {
+	return "", errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error {
+	return errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string) error {
+	return errors.New("not implemented yet") // TODO: https://github.com/bytebase/bytebase/issues/928
+}
+
+func httpGet(ctx context.Context, client *http.Client, resourcePath string, token *string, oauthCtx oauthContext, refresher common.TokenRefresher) (code int, respBody string, err error) {
+	return retry(ctx, token, oauthCtx, refresher, func() (*http.Response, error) {
+		url := fmt.Sprintf("%s/%s", apiURL, resourcePath)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "construct GET %q", url)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *token))
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, errors.Wrapf(err, "GET %q", url)
+		}
+		return resp, nil
+	})
+}
+
+func retry(ctx context.Context, token *string, oauthCtx oauthContext, refresher common.TokenRefresher, f func() (*http.Response, error)) (code int, respBody string, err error) {
+	retries := 0
+retry:
+	retries++
+
+	resp, err := f()
+	if err != nil {
+		return 0, "", err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to read gitlab response body, code %v, error: %v", resp.StatusCode, err)
+	}
+
+	if err := getOAuthErrorDetails(resp.StatusCode, string(body)); err != nil {
+		if _, ok := err.(oauthError); ok && retries < maxRetries {
+			// Refresh and store the token.
+			if err := refreshToken(token, oauthCtx, refresher); err != nil {
+				return 0, "", err
+			}
+			goto retry // todo ???
+
+		}
+		// err must be oauthError. So this happens only when the number of retries has exceeded.
+		return 0, "", fmt.Errorf("retries exceeded for oauth refresher; original code %v body %s; oauth error: %v", resp.StatusCode, string(body), err)
+	}
+
+	return resp.StatusCode, string(body), nil
+}
+
+type oauthError struct {
+	Err              string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func (e oauthError) Error() string {
+	return fmt.Sprintf("GitHub oauth response error %q description %q", e.Err, e.ErrorDescription)
+}
+
+// Only returns error if it's an oauth error. For other errors like 404 we don't return error.
+// We do this because this method is only intended to be used by oauth to refresh access token
+// on expiration. When it's error like 404, GitLab api doesn't return it as error so we keep the
+// similar behavior and let caller check the response status code.
+func getOAuthErrorDetails(code int, body string) error {
+	if 200 <= code && code < 300 {
+		return nil
+	}
+
+	var oe oauthError
+	if err := json.Unmarshal([]byte(body), &oe); err != nil {
+		// If we failed to unmarshal body with oauth error, it's not oauthError and we should return nil.
+		return nil
+	}
+	// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+	// {"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}
+	if oe.Err == "invalid_token" && strings.Contains(oe.ErrorDescription, "expired") {
+		return &oe
+	}
+	return nil
+}
+
+// oauthContext is the request context for refreshing oauth token.
+type oauthContext struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+	GrantType    string `json:"grant_type"`
+}
+
+type refreshOauthResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	CreatedAt    int64  `json:"created_at"`
+	// token_type, scope are not used.
+}
+
+func refreshToken(oldToken *string, oauthContext oauthContext, refresher common.TokenRefresher) error {
+	url := fmt.Sprintf("%s/oauth/token", apiURL)
+	oauthContext.GrantType = "refresh_token"
+	body, err := json.Marshal(oauthContext)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to construct refresh token POST %v (%w)", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send refresh token POST %v (%w)", url, err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body from refresh token POST %v (%w)", url, err)
+	}
+
+	// We should not call getOAuthErrorDetails.
+	// In the sequence of 1) get file content with oauth error, 2) refresh token.
+	// If step 2) failed still with oauth error, we should stop retries because we should always expect refreshing token request to succeed unless we're holding any invalid refresh token already.
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch refresh token, response code %v body %s", resp.StatusCode, body)
+	}
+
+	var r refreshOauthResponse
+	if err := json.Unmarshal([]byte(body), &r); err != nil {
+		return fmt.Errorf("failed to unmarshal body from refresh token POST %v (%w)", url, err)
+	}
+
+	// Update the old token to new value for retries.
+	*oldToken = r.AccessToken
+
+	// For GitLab, as of 13.12, the default config won't expire the access token, thus this field is 0.
+	// see https://gitlab.com/gitlab-org/gitlab/-/issues/21745.
+	var expireAt int64
+	if r.ExpiresIn != 0 {
+		expireAt = r.CreatedAt + r.ExpiresIn
+	}
+	if err := refresher(r.AccessToken, r.RefreshToken, expireAt); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/plugin/vcs/github/github_test.go
+++ b/plugin/vcs/github/github_test.go
@@ -1,0 +1,186 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/vcs"
+)
+
+type mockRoundTripper struct {
+	roundTrip func(r *http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return m.roundTrip(r)
+}
+
+func TestProvider_FetchUserInfo(t *testing.T) {
+	p := newProvider(
+		vcs.ProviderConfig{
+			Client: &http.Client{
+				Transport: &mockRoundTripper{
+					roundTrip: func(r *http.Request) (*http.Response, error) {
+						assert.Equal(t, "/users/octocat", r.URL.Path)
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body: io.NopCloser(strings.NewReader(`
+{
+  "login": "octocat",
+  "id": 1,
+  "node_id": "MDQ6VXNlcjE=",
+  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+  "gravatar_id": "",
+  "url": "https://api.github.com/users/octocat",
+  "html_url": "https://github.com/octocat",
+  "followers_url": "https://api.github.com/users/octocat/followers",
+  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+  "organizations_url": "https://api.github.com/users/octocat/orgs",
+  "repos_url": "https://api.github.com/users/octocat/repos",
+  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+  "received_events_url": "https://api.github.com/users/octocat/received_events",
+  "type": "User",
+  "site_admin": false,
+  "name": "monalisa octocat",
+  "company": "GitHub",
+  "blog": "https://github.com/blog",
+  "location": "San Francisco",
+  "email": "octocat@github.com",
+  "hireable": false,
+  "bio": "There once was...",
+  "twitter_username": "monatheoctocat",
+  "public_repos": 2,
+  "public_gists": 1,
+  "followers": 20,
+  "following": 0,
+  "created_at": "2008-01-14T04:33:35Z",
+  "updated_at": "2008-01-14T04:33:35Z",
+  "private_gists": 81,
+  "total_private_repos": 100,
+  "owned_private_repos": 100,
+  "disk_usage": 10000,
+  "collaborators": 8,
+  "two_factor_authentication": true,
+  "plan": {
+    "name": "Medium",
+    "space": 400,
+    "private_repos": 20,
+    "collaborators": 0
+  }
+}
+`)),
+							Request: r,
+						}, nil
+					},
+				},
+			},
+		},
+	)
+
+	ctx := context.Background()
+	got, err := p.FetchUserInfo(ctx, common.OauthContext{}, "", "octocat")
+	require.NoError(t, err)
+
+	want := &vcs.UserInfo{
+		PublicEmail: "octocat@github.com",
+		Name:        "monalisa octocat",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestOAuth_RefreshToken(t *testing.T) {
+	ctx := context.Background()
+	client := &http.Client{
+		Transport: &mockRoundTripper{
+			roundTrip: func(r *http.Request) (*http.Response, error) {
+				assert.Equal(t, "/login/oauth/access_token", r.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+{
+  "access_token": "ghu_16C7e42F292c6912E7710c838347Ae178B4a",
+  "expires_in": "28800",
+  "refresh_token": "ghr_1B4a2e77838347a7E420ce178F2E7c6912E169246c34E1ccbF66C46812d16D5B1A9Dc86A1498",
+  "refresh_token_expires_in": "15811200",
+  "scope": "",
+  "token_type": "bearer"
+}
+`)),
+					Request: r,
+				}, nil
+			},
+		},
+	}
+	token := "old"
+
+	calledRefresher := false
+	refresher := func(_, _ string, _ int64) error {
+		calledRefresher = true
+		return nil
+	}
+
+	called := 0
+	_, _, err := retry(ctx, client, &token, oauthContext{}, refresher,
+		func() (*http.Response, error) {
+			called++
+			if called == 1 {
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body: io.NopCloser(strings.NewReader(`
+{"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}
+`)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+			}, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "ghu_16C7e42F292c6912E7710c838347Ae178B4a", token)
+	assert.True(t, calledRefresher)
+}
+
+func TestRetry_Exceeded(t *testing.T) {
+	ctx := context.Background()
+	client := &http.Client{
+		Transport: &mockRoundTripper{
+			roundTrip: func(r *http.Request) (*http.Response, error) {
+				assert.Equal(t, "/login/oauth/access_token", r.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{}`)),
+					Request:    r,
+				}, nil
+			},
+		},
+	}
+	_ = client
+	token := "old"
+	_, _, err := retry(ctx, client, &token, oauthContext{},
+		func(_, _ string, _ int64) error { return nil },
+		func() (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body: io.NopCloser(strings.NewReader(`
+{"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}
+`)),
+			}, nil
+		},
+	)
+	wantErr := `retries exceeded for oauth refresher with status code 400 and body ""`
+	gotErr := fmt.Sprintf("%v", err)
+	assert.Equal(t, wantErr, gotErr)
+}

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -11,9 +11,10 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/vcs"
-	"go.uber.org/zap"
 )
 
 const (
@@ -229,8 +230,8 @@ func (provider *Provider) TryLogin(ctx context.Context, oauthCtx common.OauthCon
 }
 
 // FetchUserInfo will fetch user info from GitLab. If userID is set to nil, the user info of the current oauth would be returned.
-func (provider *Provider) FetchUserInfo(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, userID int) (*vcs.UserInfo, error) {
-	return fetchUserInfo(ctx, oauthCtx, instanceURL, fmt.Sprintf("users/%d", userID))
+func (provider *Provider) FetchUserInfo(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, userID string) (*vcs.UserInfo, error) {
+	return fetchUserInfo(ctx, oauthCtx, instanceURL, fmt.Sprintf("users/%s", userID))
 }
 
 func getRoleAndMappedRole(accessLevel int32) (gitLabRole ProjectRole, bytebaseRole common.ProjectRole) {
@@ -296,7 +297,7 @@ func (provider *Provider) FetchRepositoryActiveMemberList(ctx context.Context, o
 			// And since most callers are not GitLab admins, thus we fetch public email
 			// TODO: need to work around this if the user does not set public email. For now, we just return an error listing users not having public emails.
 			// TODO: if the number of the member is too large, fetching sequentially may cause performance issue
-			userInfo, err := provider.FetchUserInfo(ctx, oauthCtx, instanceURL, gitLabMember.ID)
+			userInfo, err := provider.FetchUserInfo(ctx, oauthCtx, instanceURL, strconv.Itoa(gitLabMember.ID))
 			if err != nil {
 				return nil, err
 			}

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -2,24 +2,28 @@ package vcs
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
-	"github.com/bytebase/bytebase/common"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/common"
 )
 
 // Type is the type of a VCS.
 type Type string
 
 const (
-	// GitLabSelfHost is the VCS type for gitlab self host.
+	// GitLabSelfHost is the VCS type for GitLab self host.
 	GitLabSelfHost Type = "GITLAB_SELF_HOST"
+	// GitHubCom is the VCS type for GitHub.com.
+	GitHubCom Type = "GITHUB_COM"
 )
 
 func (e Type) String() string {
 	switch e {
-	case GitLabSelfHost:
-		return "GITLAB_SELF_HOST"
+	case GitLabSelfHost, GitHubCom:
+		return string(e)
 	}
 	return "UNKNOWN"
 }
@@ -111,14 +115,14 @@ type Provider interface {
 	//
 	// oauthCtx: OAuth context to write the file content
 	// instanceURL: VCS instance URL
-	// userID: the ID of the desired user
-	FetchUserInfo(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, userID int) (*UserInfo, error)
+	// user: the ID or username of the desired user
+	FetchUserInfo(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, user string) (*UserInfo, error)
 	// Fetch all active members of a given repository
 	//
 	// oauthCtx: OAuth context to write the file content
 	// instanceURL: VCS instance URL
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
-	FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string) ([]*RepositoryMember, error)
+	FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string) ([]*RepositoryMember, error)
 	// Fetch the repository file list
 	//
 	// oauthCtx: OAuth context to read the repository tree
@@ -126,7 +130,7 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// ref: the unique name of a repository tree, could be a branch name in GitLab or a tree sha in GitHub
 	// filePath: the path inside repository, used to get content of subdirectories
-	FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, ref string, filePath string) ([]*RepositoryTreeNode, error)
+	FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*RepositoryTreeNode, error)
 	// Commits a new file
 	//
 	// oauthCtx: OAuth context to write the file content
@@ -134,11 +138,11 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// filePath: file path to be written
 	// fileCommit: the new file commit info
-	CreateFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, filePath string, fileCommit FileCommitCreate) error
+	CreateFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
 	// Overwrites an existing file
 	//
 	// Similar to CreateFile except it overwrites an existing file. The fileCommit shoud includes the "LastCommitID" field which is used to detect conflicting writes.
-	OverwriteFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, filePath string, fileCommit FileCommitCreate) error
+	OverwriteFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
 	// Reads the file content. Returns an io.ReadCloser on success. If file does not exist, returns NotFound error.
 	//
 	// oauthCtx: OAuth context to read the file content
@@ -146,24 +150,24 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// filePath: file path to be read
 	// commitID: the specific version to be read
-	ReadFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, filePath string, commitID string) (string, error)
+	ReadFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, commitID string) (string, error)
 	// Reads the file metadata. Returns the file meta on success.
 	//
 	// Similar to ReadFile except it specifies a branch instead of a commitID.
-	ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, filePath string, branch string) (*FileMeta, error)
+	ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, branch string) (*FileMeta, error)
 	// Creates a webhook. Returns the created webhook ID on succeess.
 	//
 	// oauthCtx: OAuth context to create the webhook
 	// instanceURL: VCS instance URL
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// payload: the webhook payload
-	CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, payload []byte) (string, error)
+	CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error)
 	// Patches a webhook.
 	//
 	// The payload stores the patched field(s).
-	PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, webhookID string, payload []byte) error
+	PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error
 	// Deletes a webhook.
-	DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, webhookID string) error
+	DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string) error
 }
 
 var (
@@ -174,6 +178,7 @@ var (
 // ProviderConfig is the provider configuration.
 type ProviderConfig struct {
 	Logger *zap.Logger
+	Client *http.Client
 }
 
 type providerFunc func(ProviderConfig) Provider


### PR DESCRIPTION
This PR implements the necessary methods of [vcs.Provider](https://github.com/bytebase/bytebase/blob/4dd938f3a58d960bb42576f8ff569c51aa1f0df5/plugin/vcs/vcs.go#L96) interface to support adding GitHub.com as a VCS provider.

### Notes

1. `retry` is re-structured without `goto`, and respects context cancellation.
1. Signature of `FetchUserInfo` is changed to be provider-agnostic.
1. Functions like `retry`, `refreshToken` and `getOAuthErrorDetails` could be factored out to be used for both GitLab and GitHub, if we want to do that, I can send a followup PR.

---

Part of https://github.com/bytebase/bytebase/issues/928