### PR TITLE
fix: vue global properties's type shims

### DIFF
--- a/frontend/src/shims-vue-globals.d.ts
+++ b/frontend/src/shims-vue-globals.d.ts
@@ -14,7 +14,7 @@ import type {
 import type dayjs from "dayjs";
 import type { isEmpty } from "lodash-es";
 
-declare module "@vue/runtime-core" {
+declare module "vue" {
   export interface ComponentCustomProperties {
     window: Window & typeof globalThis;
     console: Console;


### PR DESCRIPTION
After switching to pmpm we cannot resolve "@vue/runtime-core" as a phantom dependency. So this breaks the vscode's type hints of our custom global properties in vue templates.

In the latest [Vue's doc](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties) it's recommended to augment `vue` instead of `@vue/runtime-core`.