### PR TITLE
fix: use tailwind css for button in signin page

### DIFF
--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -13,8 +13,9 @@
         v-for="authProvider in authProviderList"
         :key="authProvider.type"
       >
-        <n-button
-          class="w-full h-10 mb-2 tooltip-wrapper"
+        <button
+          type="button"
+          class="btn-normal flex justify-center w-full h-10 mb-2 tooltip-wrapper"
           :disabled="!has3rdPartyLoginFeature"
           @click.prevent="
             () => {
@@ -40,11 +41,15 @@
           <span v-else-if="!has3rdPartyLoginFeature" class="tooltip">{{
             $t("subscription.features.bb-feature-3rd-party-auth.login")
           }}</span>
-        </n-button>
+        </button>
       </template>
 
       <template v-if="authProviderList.length == 0">
-        <n-button class="w-full h-10 mb-2" disabled>
+        <button
+          disabled
+          type="button"
+          class="btn-normal flex justify-center w-full h-10 mb-2"
+        >
           <img
             class="w-5 mr-1"
             :src="AuthProviderConfig['GITLAB_SELF_HOST'].iconPath"
@@ -52,7 +57,7 @@
           <span class="text-center font-semibold align-middle">
             {{ $t("auth.sign-in.gitlab-oauth") }}
           </span>
-        </n-button>
+        </button>
       </template>
     </div>
 


### PR DESCRIPTION
<img width="568" alt="图片" src="https://user-images.githubusercontent.com/10706318/161035394-06270ea1-43a1-46e6-a038-c021baa88888.png">

The sign-in button is broken because of the CSS conflicts between tailwindcss and naive-ui.
Seems this PR gives naive-ui a higher priority https://github.com/bytebase/bytebase/pull/947