### PR TITLE
chore: get rid of CGO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ ARG GIT_COMMIT="unknown"
 ARG BUILD_TIME="unknown"
 ARG BUILD_USER="unknown"
 
-# Need gcc musl-dev for CGO_ENABLED=1
-RUN apk --no-cache add gcc musl-dev
-
 WORKDIR /backend-build
 
 COPY . .
@@ -39,8 +36,7 @@ COPY . .
 COPY --from=frontend /frontend-build/dist ./server/dist
 
 # -ldflags="-w -s" means omit DWARF symbol table and the symbol table and debug information
-# go-sqlite3 requires CGO_ENABLED
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN GOOS=linux GOARCH=amd64 go build \
     --tags "release alpine" \
     -ldflags="-w -s -X 'github.com/bytebase/bytebase/bin/server/cmd.version=${VERSION}' -X 'github.com/bytebase/bytebase/bin/server/cmd.goversion=${GO_VERSION}' -X 'github.com/bytebase/bytebase/bin/server/cmd.gitcommit=${GIT_COMMIT}' -X 'github.com/bytebase/bytebase/bin/server/cmd.buildtime=${BUILD_TIME}' -X 'github.com/bytebase/bytebase/bin/server/cmd.builduser=${BUILD_USER}'" \
     -o bytebase \


### PR DESCRIPTION
we don't use go-sqlite3 anymore