### PR TITLE
chore: modify GitHub release page

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,3 +65,18 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+release:
+  draft: true
+  name_template: "Release {{.Tag}}"
+  header: |
+    # What's Changed
+
+    ## 🚀 Features
+
+    ## 🎄 Enhancements
+
+    ## 🎠 Community
+
+    ## New Contributors
+
+    **Full Changelog**:


### PR DESCRIPTION
suit goreleaser to our release flow

<img width="1167" alt="CleanShot 2022-04-03 at 14 43 57@2x" src="https://user-images.githubusercontent.com/57934883/161415520-1ccd75d4-2bc8-4a07-9c84-d041ed347f54.png">
