### PR TITLE
fix: update golangcli-lint to 1.45.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44
+          version: v1.45.2
   go-tidy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We're failing tests with
  panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

https://github.com/golangci/golangci-lint/issues/2649