### PR TITLE
fix: add sleep time between issues in tests

### DIFF
--- a/bin/bb/cmd/migrate.go
+++ b/bin/bb/cmd/migrate.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"os/user"
 	"strings"
-	"time"
 
+	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 
 	// install mysql driver.
@@ -126,7 +126,7 @@ func migrateDatabase(ctx context.Context, databaseType, username, password, host
 	// TODO(d): support semantic versioning.
 	if _, _, err := driver.ExecuteMigration(ctx, &db.MigrationInfo{
 		ReleaseVersion: version,
-		Version:        defaultMigrationVersion(),
+		Version:        common.DefaultMigrationVersion(),
 		Database:       database,
 		Source:         db.LIBRARY,
 		Type:           db.Migrate,
@@ -138,8 +138,4 @@ func migrateDatabase(ctx context.Context, databaseType, username, password, host
 		return fmt.Errorf("failed to migrate database, got error: %w", err)
 	}
 	return nil
-}
-
-func defaultMigrationVersion() string {
-	return time.Now().Format("20060102150405")
 }

--- a/common/util.go
+++ b/common/util.go
@@ -54,8 +54,8 @@ func GetPostgresSocketDir() string {
 }
 
 // DefaultMigrationVersion returns the default migration version string.
-// Use the concatenation of current time and uuid to guarantee uniqueness in a monotonic increasing way.
+// Use the concatenation of current time in second and uuid to guarantee uniqueness in a monotonic increasing way.
 // We cannot add task ID because tenant mode databases should use the same migration version string when applying a schema update.
 func DefaultMigrationVersion() string {
-	return fmt.Sprintf("%s.%s", time.Now().Format("20060102150405010203"), uuid.New())
+	return fmt.Sprintf("%s.%s", time.Now().Format("20060102150405"), uuid.New())
 }

--- a/common/util.go
+++ b/common/util.go
@@ -1,10 +1,14 @@
 package common
 
 import (
+	"fmt"
 	"math/rand"
 	"path"
 	"sort"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 // FindString returns the search index of sorted strings.
@@ -47,4 +51,11 @@ func GetPostgresDataDir(dataDir string) string {
 // GetPostgresSocketDir returns the postgres socket directory of Bytebase.
 func GetPostgresSocketDir() string {
 	return "/tmp"
+}
+
+// DefaultMigrationVersion returns the default migration version string.
+// Use the concatenation of current time and uuid to guarantee uniqueness in a monotonic increasing way.
+// We cannot add task ID because tenant mode databases should use the same migration version string when applying a schema update.
+func DefaultMigrationVersion() string {
+	return fmt.Sprintf("%s.%s", time.Now().Format("20060102150405010203"), uuid.New())
 }

--- a/common/util.go
+++ b/common/util.go
@@ -1,14 +1,11 @@
 package common
 
 import (
-	"fmt"
 	"math/rand"
 	"path"
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // FindString returns the search index of sorted strings.
@@ -54,8 +51,8 @@ func GetPostgresSocketDir() string {
 }
 
 // DefaultMigrationVersion returns the default migration version string.
-// Use the concatenation of current time in second and uuid to guarantee uniqueness in a monotonic increasing way.
+// Use the concatenation of current time in second to guarantee uniqueness in a monotonic increasing way.
 // We cannot add task ID because tenant mode databases should use the same migration version string when applying a schema update.
 func DefaultMigrationVersion() string {
-	return fmt.Sprintf("%s.%s", time.Now().Format("20060102150405"), uuid.New())
+	return time.Now().Format("20060102150405")
 }

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -236,9 +236,9 @@ type MigrationInfo struct {
 	// UseSemanticVersion is whether version is a semantic version.
 	// When UseSemanticVersion is set, version should be set to the format specified in Semantic Versioning 2.0.0 (https://semver.org/).
 	// For example, for setting non-semantic version "hello", the values should be Version = "hello", UseSemanticVersion = false, SemanticVersionSuffix = "".
-	// For setting semantic version "1.2.0", the values should be Version = "1.2.0", UseSemanticVersion = true, SemanticVersionSuffix = "20060102150405".
+	// For setting semantic version "1.2.0", the values should be Version = "1.2.0", UseSemanticVersion = true, SemanticVersionSuffix = "20060102150405010203.uuid" (common.DefaultMigrationVersion).
 	UseSemanticVersion bool
-	// SemanticVersionSuffix should be set to timestamp format of "20060102150405" if UseSemanticVersion is set.
+	// SemanticVersionSuffix should be set to timestamp format of "20060102150405010203.uuid" (common.DefaultMigrationVersion) if UseSemanticVersion is set.
 	// Since stored version should be unique, we have to append a suffix if we allow users to baseline to the same semantic version for fixing schema drift.
 	SemanticVersionSuffix string
 }

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -236,9 +236,9 @@ type MigrationInfo struct {
 	// UseSemanticVersion is whether version is a semantic version.
 	// When UseSemanticVersion is set, version should be set to the format specified in Semantic Versioning 2.0.0 (https://semver.org/).
 	// For example, for setting non-semantic version "hello", the values should be Version = "hello", UseSemanticVersion = false, SemanticVersionSuffix = "".
-	// For setting semantic version "1.2.0", the values should be Version = "1.2.0", UseSemanticVersion = true, SemanticVersionSuffix = "20060102150405010203.uuid" (common.DefaultMigrationVersion).
+	// For setting semantic version "1.2.0", the values should be Version = "1.2.0", UseSemanticVersion = true, SemanticVersionSuffix = "20060102150405.uuid" (common.DefaultMigrationVersion).
 	UseSemanticVersion bool
-	// SemanticVersionSuffix should be set to timestamp format of "20060102150405010203.uuid" (common.DefaultMigrationVersion) if UseSemanticVersion is set.
+	// SemanticVersionSuffix should be set to timestamp format of "20060102150405.uuid" (common.DefaultMigrationVersion) if UseSemanticVersion is set.
 	// Since stored version should be unique, we have to append a suffix if we allow users to baseline to the same semantic version for fixing schema drift.
 	SemanticVersionSuffix string
 }

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -236,9 +236,9 @@ type MigrationInfo struct {
 	// UseSemanticVersion is whether version is a semantic version.
 	// When UseSemanticVersion is set, version should be set to the format specified in Semantic Versioning 2.0.0 (https://semver.org/).
 	// For example, for setting non-semantic version "hello", the values should be Version = "hello", UseSemanticVersion = false, SemanticVersionSuffix = "".
-	// For setting semantic version "1.2.0", the values should be Version = "1.2.0", UseSemanticVersion = true, SemanticVersionSuffix = "20060102150405.uuid" (common.DefaultMigrationVersion).
+	// For setting semantic version "1.2.0", the values should be Version = "1.2.0", UseSemanticVersion = true, SemanticVersionSuffix = "20060102150405" (common.DefaultMigrationVersion).
 	UseSemanticVersion bool
-	// SemanticVersionSuffix should be set to timestamp format of "20060102150405.uuid" (common.DefaultMigrationVersion) if UseSemanticVersion is set.
+	// SemanticVersionSuffix should be set to timestamp format of "20060102150405" (common.DefaultMigrationVersion) if UseSemanticVersion is set.
 	// Since stored version should be unique, we have to append a suffix if we allow users to baseline to the same semantic version for fixing schema drift.
 	SemanticVersionSuffix string
 }

--- a/server/issue.go
+++ b/server/issue.go
@@ -648,7 +648,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 			schemaVersion, schema = sv, s
 		}
 		if schemaVersion == "" {
-			schemaVersion = defaultMigrationVersionFromTaskID()
+			schemaVersion = common.DefaultMigrationVersion()
 		}
 
 		payload := api.TaskDatabaseCreatePayload{}
@@ -771,7 +771,7 @@ func (s *Server) createPipelineFromIssue(ctx context.Context, issueCreate *api.I
 			return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch project ID: %v", issueCreate.ProjectID)).SetInternal(err)
 		}
 
-		schemaVersion := defaultMigrationVersionFromTaskID()
+		schemaVersion := common.DefaultMigrationVersion()
 		// Tenant mode project pipeline has its own generation.
 		if project.TenantMode == api.TenantModeTenant {
 			if !s.feature(api.FeatureMultiTenancy) {

--- a/server/task.go
+++ b/server/task.go
@@ -105,7 +105,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 				payload.Statement = *taskPatch.Statement
 				// We should update the schema version if we've updated the SQL, otherwise we will
 				// get migration history version conflict if the previous task has been attempted.
-				payload.SchemaVersion = defaultMigrationVersionFromTaskID()
+				payload.SchemaVersion = common.DefaultMigrationVersion()
 				bytes, err := json.Marshal(payload)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to construct updated task payload").SetInternal(err)
@@ -121,7 +121,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 				payload.Statement = *taskPatch.Statement
 				// We should update the schema version if we've updated the SQL, otherwise we will
 				// get migration history version conflict if the previous task has been attempted.
-				payload.SchemaVersion = defaultMigrationVersionFromTaskID()
+				payload.SchemaVersion = common.DefaultMigrationVersion()
 				bytes, err := json.Marshal(payload)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to construct updated task payload").SetInternal(err)

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
@@ -26,12 +25,6 @@ type TaskExecutor interface {
 	// usually indicates a transient error and will make scheduler retry later.
 	// 2. If err is non-nil, then the detail field will be ignored since info is provided in the err.
 	RunOnce(ctx context.Context, server *Server, task *api.Task) (terminated bool, result *api.TaskRunResultPayload, err error)
-}
-
-// defaultMigrationVersion returns the default migration version string
-// Use the concatenation of current time and the task id to guarantee uniqueness in a monotonic increasing way.
-func defaultMigrationVersionFromTaskID() string {
-	return time.Now().Format("20060102150405")
 }
 
 func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.Task, migrationType db.MigrationType, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent) ( /*terminated*/ bool /*result*/, *api.TaskRunResultPayload, error) {

--- a/server/task_executor_database_restore.go
+++ b/server/task_executor_database_restore.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	"go.uber.org/zap"
 )
@@ -176,7 +177,7 @@ func createBranchMigrationHistory(ctx context.Context, server *Server, sourceDat
 	// TODO(d): support semantic versioning.
 	m := &db.MigrationInfo{
 		ReleaseVersion: server.version,
-		Version:        defaultMigrationVersionFromTaskID(),
+		Version:        common.DefaultMigrationVersion(),
 		Namespace:      targetDatabase.Name,
 		Database:       targetDatabase.Name,
 		Environment:    targetDatabase.Instance.Environment.Name,

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -313,7 +313,7 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 				ReleaseVersion:        serverVersion,
 				UseSemanticVersion:    true,
 				Version:               cutoffSchemaVersion.String(),
-				SemanticVersionSuffix: time.Now().Format("20060102150405"),
+				SemanticVersionSuffix: common.DefaultMigrationVersion(),
 				Namespace:             databaseName,
 				Database:              databaseName,
 				Environment:           "", /* unused in execute migration */
@@ -375,7 +375,7 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 						ReleaseVersion:        serverVersion,
 						UseSemanticVersion:    true,
 						Version:               pv.version.String(),
-						SemanticVersionSuffix: time.Now().Format("20060102150405"),
+						SemanticVersionSuffix: common.DefaultMigrationVersion(),
 						Namespace:             databaseName,
 						Database:              databaseName,
 						Environment:           "", /* unused in execute migration */

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -676,7 +676,7 @@ func getAggregatedTaskStatus(issue *api.Issue) (api.TaskStatus, error) {
 
 // waitIssuePipeline waits for pipeline to finish and approves tasks when necessary.
 func (ctl *controller) waitIssuePipeline(id int) (api.TaskStatus, error) {
-	// Sleep for two seconds between issues so that we don't get migration version conflict because we are using second-level timestamp for the version string.
+	// Sleep for two seconds between issues so that we don't get migration version conflict because we are using second-level timestamp for the version string. We choose sleep because it mimics the user's behavior.
 	time.Sleep(2 * time.Second)
 
 	ticker := time.NewTicker(100 * time.Millisecond)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -676,6 +676,9 @@ func getAggregatedTaskStatus(issue *api.Issue) (api.TaskStatus, error) {
 
 // waitIssuePipeline waits for pipeline to finish and approves tasks when necessary.
 func (ctl *controller) waitIssuePipeline(id int) (api.TaskStatus, error) {
+	// Sleep for two seconds between issues so that we don't get migration version conflict because we are using second-level timestamp for the version string.
+	time.Sleep(2 * time.Second)
+
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 


### PR DESCRIPTION
We were using second-level timestamp precision which is the source of the flaky test where consecutive migrations will receive version string conflict error if they are processed within the same second.