### PR TITLE
WIP: for embed mode, create the bytebase metadata database upon initdb

### DIFF
--- a/resources/postgres/postgres.go
+++ b/resources/postgres/postgres.go
@@ -211,6 +211,25 @@ func initDB(pgBinDir, pgDataDir, pgUser string) error {
 		return fmt.Errorf("failed to initdb %q, error %v", p.String(), err)
 	}
 
+	database := pgUser
+	if database != "postgres" {
+		createDBArgs := []string {
+			database,
+			"-U", pgUser,
+			"-h", common.GetPostgresSocketDir(),
+			"-p", "8081",
+			"-l", "en_US.UTF-8",
+		}
+		createDBBinary := filepath.Join(pgBinDir, "bin", "createdb")
+		createDBCmd := exec.Command(createDBBinary, createDBArgs...)
+		createDBCmd.Stderr = os.Stderr
+		createDBCmd.Stdout = os.Stdout
+		if err := createDBCmd.Run(); err != nil {
+			return fmt.Errorf("failed to create database %q, error %v", database, err)
+		}
+		fmt.Printf("created database %s\n***", database)
+	}
+
 	return nil
 }
 

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -305,8 +305,8 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 		if err != nil {
 			return fmt.Errorf("failed to read latest data %q, error %w", latestSchemaPath, err)
 		}
-		// We will create the database together with initial schema and data migration.
-		stmt := fmt.Sprintf("CREATE DATABASE %s;\n\\connect \"%s\";\n%s\n%s", databaseName, databaseName, buf, dataBuf)
+		// We create the initial schema and data migration.
+		stmt := fmt.Sprintf("%s\n%s", buf, dataBuf)
 		if _, _, err := d.ExecuteMigration(
 			ctx,
 			&dbdriver.MigrationInfo{
@@ -320,7 +320,6 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 				Source:                dbdriver.LIBRARY,
 				Type:                  dbdriver.Migrate,
 				Description:           fmt.Sprintf("Initial migration version %s server version %s with file %s.", cutoffSchemaVersion, serverVersion, latestSchemaPath),
-				CreateDatabase:        true,
 			},
 			stmt,
 		); err != nil {


### PR DESCRIPTION
The background is to support external postgres, in such case, we need to allow user to specify the database storing the bytebase metadata.

Say user specifies --pg postgresql://foo:secret@host:5432/bar

User expects to store the metadata under "bar", this means we can't create the database in migrate because the database needs to be created beforehand.

So for the embedded case, we need to create that database beforehand. The best place I think is at initDB right after we call "initDB".  

I am inclined to use the "createdb" binary, but that requires we put it into our tarball, so this requires help @d-bytebase.

You may wonder can we just issue "CREATE DATABASE" query, it's possible, but it will make the code messy, because that requires us to pass down a lot of info into initDB to construct our driver to talk to postgres.

