### PR TITLE
feat(cli): replace db flags with dsn flag

### DIFF
--- a/bin/bb/cmd/dump.go
+++ b/bin/bb/cmd/dump.go
@@ -16,18 +16,9 @@ import (
 
 func newDumpCmd() *cobra.Command {
 	var (
-		databaseType string
-		username     string
-		password     string
-		hostname     string
-		port         string
-		database     string
-		file         string
-
-		// SSL flags.
-		sslCA   string // server-ca.pem
-		sslCert string // client-cert.pem
-		sslKey  string // client-key.pem
+		ds   dataSource
+		dsn  string
+		file string
 
 		// Dump options.
 		schemaOnly bool
@@ -36,10 +27,12 @@ func newDumpCmd() *cobra.Command {
 		Use:   "dump",
 		Short: "Exports the schema of a database instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tlsCfg := db.TLSConfig{
-				SslCA:   sslCA,
-				SslCert: sslCert,
-				SslKey:  sslKey,
+			if len(dsn) != 0 {
+				datasource, err := parseDSN(dsn)
+				if err != nil {
+					return err
+				}
+				ds = *datasource
 			}
 			out := cmd.OutOrStdout()
 			if file != "" {
@@ -50,21 +43,23 @@ func newDumpCmd() *cobra.Command {
 				defer f.Close()
 				out = f
 			}
-			return dumpDatabase(context.Background(), databaseType, username, password, hostname, port, database, out, tlsCfg, schemaOnly)
+			return dumpDatabase(context.Background(), ds, out, schemaOnly)
 		},
 	}
-	dumpCmd.Flags().StringVar(&databaseType, "type", "mysql", "Database type. (mysql or pg).")
-	dumpCmd.Flags().StringVar(&username, "username", "", "Username to login database. (default mysql:root pg:postgres).")
-	dumpCmd.Flags().StringVar(&password, "password", "", "Password to login database.")
-	dumpCmd.Flags().StringVar(&hostname, "hostname", "", "Hostname of database.")
-	dumpCmd.Flags().StringVar(&port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
-	dumpCmd.Flags().StringVar(&database, "database", "", "Database to connect and export.")
+
+	dumpCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
+	dumpCmd.Flags().StringVar(&ds.driver, "type", "mysql", "Database type. (mysql or pg).")
+	dumpCmd.Flags().StringVar(&ds.username, "username", "", "Username to login database. (default mysql:root pg:postgres).")
+	dumpCmd.Flags().StringVar(&ds.password, "password", "", "Password to login database.")
+	dumpCmd.Flags().StringVar(&ds.host, "hostname", "", "Hostname of database.")
+	dumpCmd.Flags().StringVar(&ds.port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
+	dumpCmd.Flags().StringVar(&ds.database, "database", "", "Database to connect and export.")
 	dumpCmd.Flags().StringVar(&file, "file", "", "File to store the dump. Output to stdout if unspecified")
 
 	// tls flags for SSL connection.
-	dumpCmd.Flags().StringVar(&sslCA, "ssl-ca", "", "CA file in PEM format.")
-	dumpCmd.Flags().StringVar(&sslCert, "ssl-cert", "", "X509 cert in PEM format.")
-	dumpCmd.Flags().StringVar(&sslKey, "ssl-key", "", "X509 key in PEM format.")
+	dumpCmd.Flags().StringVar(&ds.sslCA, "ssl-ca", "", "CA file in PEM format.")
+	dumpCmd.Flags().StringVar(&ds.sslCert, "ssl-cert", "", "X509 cert in PEM format.")
+	dumpCmd.Flags().StringVar(&ds.sslKey, "ssl-key", "", "X509 key in PEM format.")
 
 	dumpCmd.Flags().BoolVar(&schemaOnly, "schema-only", false, "Schema only dump.")
 
@@ -73,18 +68,18 @@ func newDumpCmd() *cobra.Command {
 
 // dumpDatabase exports the schema of a database instance.
 // When file isn't specified, the schema will be exported to stdout.
-func dumpDatabase(ctx context.Context, databaseType, username, password, hostname, port, database string, out io.Writer, tlsCfg db.TLSConfig, schemaOnly bool) error {
+func dumpDatabase(ctx context.Context, ds dataSource, out io.Writer, schemaOnly bool) error {
 	var dbType db.Type
-	switch databaseType {
+	switch ds.driver {
 	case "mysql":
 		dbType = db.MySQL
-		if username == "" {
-			username = "root"
+		if ds.username == "" {
+			ds.username = "root"
 		}
 	case "pg":
 		dbType = db.Postgres
 	default:
-		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", databaseType)
+		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", ds.driver)
 	}
 
 	db, err := db.Open(
@@ -92,12 +87,16 @@ func dumpDatabase(ctx context.Context, databaseType, username, password, hostnam
 		dbType,
 		db.DriverConfig{Logger: logger},
 		db.ConnectionConfig{
-			Host:      hostname,
-			Port:      port,
-			Username:  username,
-			Password:  password,
-			Database:  database,
-			TLSConfig: tlsCfg,
+			Host:     ds.host,
+			Port:     ds.port,
+			Username: ds.username,
+			Password: ds.password,
+			Database: ds.database,
+			TLSConfig: db.TLSConfig{
+				SslCA:   ds.sslCA,
+				SslCert: ds.sslCert,
+				SslKey:  ds.sslKey,
+			},
 		},
 		db.ConnectionContext{},
 	)
@@ -106,7 +105,7 @@ func dumpDatabase(ctx context.Context, databaseType, username, password, hostnam
 	}
 	defer db.Close(ctx)
 
-	if err := db.Dump(ctx, database, out, schemaOnly); err != nil {
+	if err := db.Dump(ctx, ds.database, out, schemaOnly); err != nil {
 		return fmt.Errorf("failed to create dump, got error: %w", err)
 	}
 	return nil

--- a/bin/bb/cmd/dump.go
+++ b/bin/bb/cmd/dump.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/xo/dburl"
 
 	// install mysql driver.
 	_ "github.com/bytebase/bytebase/plugin/db/mysql"
@@ -16,7 +16,6 @@ import (
 
 func newDumpCmd() *cobra.Command {
 	var (
-		ds   dataSource
 		dsn  string
 		file string
 
@@ -27,12 +26,9 @@ func newDumpCmd() *cobra.Command {
 		Use:   "dump",
 		Short: "Exports the schema of a database instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(dsn) != 0 {
-				datasource, err := parseDSN(dsn)
-				if err != nil {
-					return err
-				}
-				ds = *datasource
+			u, err := dburl.Parse(dsn)
+			if err != nil {
+				return fmt.Errorf("failed to parse dsn, got error: %w", err)
 			}
 			out := cmd.OutOrStdout()
 			if file != "" {
@@ -43,69 +39,26 @@ func newDumpCmd() *cobra.Command {
 				defer f.Close()
 				out = f
 			}
-			return dumpDatabase(context.Background(), ds, out, schemaOnly)
+			return dumpDatabase(context.Background(), u, out, schemaOnly)
 		},
 	}
 
 	dumpCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
-	dumpCmd.Flags().StringVar(&ds.driver, "type", "mysql", "Database type. (mysql or pg).")
-	dumpCmd.Flags().StringVar(&ds.username, "username", "", "Username to login database. (default mysql:root pg:postgres).")
-	dumpCmd.Flags().StringVar(&ds.password, "password", "", "Password to login database.")
-	dumpCmd.Flags().StringVar(&ds.host, "hostname", "", "Hostname of database.")
-	dumpCmd.Flags().StringVar(&ds.port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
-	dumpCmd.Flags().StringVar(&ds.database, "database", "", "Database to connect and export.")
 	dumpCmd.Flags().StringVar(&file, "file", "", "File to store the dump. Output to stdout if unspecified")
-
-	// tls flags for SSL connection.
-	dumpCmd.Flags().StringVar(&ds.sslCA, "ssl-ca", "", "CA file in PEM format.")
-	dumpCmd.Flags().StringVar(&ds.sslCert, "ssl-cert", "", "X509 cert in PEM format.")
-	dumpCmd.Flags().StringVar(&ds.sslKey, "ssl-key", "", "X509 key in PEM format.")
-
 	dumpCmd.Flags().BoolVar(&schemaOnly, "schema-only", false, "Schema only dump.")
-
 	return dumpCmd
 }
 
 // dumpDatabase exports the schema of a database instance.
 // When file isn't specified, the schema will be exported to stdout.
-func dumpDatabase(ctx context.Context, ds dataSource, out io.Writer, schemaOnly bool) error {
-	var dbType db.Type
-	switch ds.driver {
-	case "mysql":
-		dbType = db.MySQL
-		if ds.username == "" {
-			ds.username = "root"
-		}
-	case "pg":
-		dbType = db.Postgres
-	default:
-		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", ds.driver)
-	}
-
-	db, err := db.Open(
-		ctx,
-		dbType,
-		db.DriverConfig{Logger: logger},
-		db.ConnectionConfig{
-			Host:     ds.host,
-			Port:     ds.port,
-			Username: ds.username,
-			Password: ds.password,
-			Database: ds.database,
-			TLSConfig: db.TLSConfig{
-				SslCA:   ds.sslCA,
-				SslCert: ds.sslCert,
-				SslKey:  ds.sslKey,
-			},
-		},
-		db.ConnectionContext{},
-	)
+func dumpDatabase(ctx context.Context, u *dburl.URL, out io.Writer, schemaOnly bool) error {
+	db, err := open(ctx, logger, u)
 	if err != nil {
 		return err
 	}
 	defer db.Close(ctx)
 
-	if err := db.Dump(ctx, ds.database, out, schemaOnly); err != nil {
+	if err := db.Dump(ctx, getDatabase(u), out, schemaOnly); err != nil {
 		return fmt.Errorf("failed to create dump, got error: %w", err)
 	}
 	return nil

--- a/bin/bb/cmd/dump.go
+++ b/bin/bb/cmd/dump.go
@@ -43,7 +43,7 @@ func newDumpCmd() *cobra.Command {
 		},
 	}
 
-	dumpCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
+	dumpCmd.Flags().StringVar(&dsn, "dsn", "", "Database connection string. e.g. mysql://username:password@host:port/dbname?ssl-ca=value1&ssl-cert=value2&ssl-key=value3")
 	dumpCmd.Flags().StringVar(&file, "file", "", "File to store the dump. Output to stdout if unspecified")
 	dumpCmd.Flags().BoolVar(&schemaOnly, "schema-only", false, "Schema only dump.")
 	return dumpCmd

--- a/bin/bb/cmd/dump_test.go
+++ b/bin/bb/cmd/dump_test.go
@@ -32,11 +32,7 @@ func TestDump(t *testing.T) {
 		{
 			args: []string{
 				"dump",
-				"--type", "mysql",
-				"--username", "root",
-				"--hostname", "localhost",
-				"--port", fmt.Sprint(mysql.Port()),
-				"--database", "bytebase_test_todo",
+				"--dsn", fmt.Sprintf("mysql://root@localhost:%d/bytebase_test_todo", mysql.Port()),
 			},
 			expected: _TestDump,
 		},

--- a/bin/bb/cmd/migrate.go
+++ b/bin/bb/cmd/migrate.go
@@ -19,30 +19,23 @@ import (
 
 func newMigrateCmd() *cobra.Command {
 	var (
-		databaseType string
-		username     string
-		password     string
-		hostname     string
-		port         string
-		database     string
-		fileList     []string
-		commandList  []string
-		description  string
-		issueID      string
-
-		// SSL flags.
-		sslCA   string // server-ca.pem
-		sslCert string // client-cert.pem
-		sslKey  string // client-key.pem
+		ds          dataSource
+		dsn         string
+		fileList    []string
+		commandList []string
+		description string
+		issueID     string
 	)
 	migrateCmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Migrate the database schema",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tlsCfg := db.TLSConfig{
-				SslCA:   sslCA,
-				SslCert: sslCert,
-				SslKey:  sslKey,
+			if len(dsn) != 0 {
+				datasource, err := parseDSN(dsn)
+				if err != nil {
+					return err
+				}
+				ds = *datasource
 			}
 
 			var sqlReaders []io.Reader
@@ -62,48 +55,50 @@ func newMigrateCmd() *cobra.Command {
 			}
 
 			sqlReader := io.MultiReader(sqlReaders...)
-			return migrateDatabase(context.Background(), databaseType, username, password, hostname, port, database, description, issueID, false /*createDatabase*/, sqlReader, tlsCfg)
+			return migrateDatabase(context.Background(), ds, description, issueID, false /*createDatabase*/, sqlReader)
 		}}
 
-	migrateCmd.Flags().StringVar(&databaseType, "type", "mysql", "Database type. (mysql or pg).")
-	migrateCmd.Flags().StringVar(&username, "username", "", "Database username. (default mysql:root pg:postgres).")
-	migrateCmd.Flags().StringVar(&password, "password", "", "Database password.")
-	migrateCmd.Flags().StringVar(&hostname, "host", "", "Database host.")
-	migrateCmd.Flags().StringVar(&port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
-	migrateCmd.Flags().StringVar(&database, "database", "", "Target database to execute migration.")
+	migrateCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
+	migrateCmd.Flags().StringVar(&ds.driver, "type", "mysql", "Database type. (mysql or pg).")
+	migrateCmd.Flags().StringVar(&ds.username, "username", "", "Database username. (default mysql:root pg:postgres).")
+	migrateCmd.Flags().StringVar(&ds.password, "password", "", "Database password.")
+	migrateCmd.Flags().StringVar(&ds.host, "host", "", "Database host.")
+	migrateCmd.Flags().StringVar(&ds.port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
+	migrateCmd.Flags().StringVar(&ds.database, "database", "", "Target database to execute migration.")
 	migrateCmd.Flags().StringSliceVarP(&fileList, "file", "f", []string{}, "SQL file to execute.")
 	migrateCmd.Flags().StringSliceVarP(&commandList, "command", "c", []string{}, "SQL command to execute.")
 	migrateCmd.Flags().StringVar(&description, "description", "", "Description of migration.")
 	migrateCmd.Flags().StringVar(&issueID, "issue-id", "", "Issue ID of migration.")
 	// tls flags for SSL connection.
-	migrateCmd.Flags().StringVar(&sslCA, "ssl-ca", "", "CA file in PEM format.")
-	migrateCmd.Flags().StringVar(&sslCert, "ssl-cert", "", "X509 cert in PEM format.")
-	migrateCmd.Flags().StringVar(&sslKey, "ssl-key", "", "X509 key in PEM format.")
+	migrateCmd.Flags().StringVar(&ds.sslCA, "ssl-ca", "", "CA file in PEM format.")
+	migrateCmd.Flags().StringVar(&ds.sslCert, "ssl-cert", "", "X509 cert in PEM format.")
+	migrateCmd.Flags().StringVar(&ds.sslKey, "ssl-key", "", "X509 key in PEM format.")
 
 	return migrateCmd
 }
 
-func migrateDatabase(ctx context.Context, databaseType, username, password, hostname, port, database, description, issueID string, createDatabase bool, sqlReader io.Reader, tlsCfg db.TLSConfig) error {
+func migrateDatabase(ctx context.Context, ds dataSource, description, issueID string, createDatabase bool, sqlReader io.Reader) error {
 	var dbType db.Type
-	switch databaseType {
+	switch ds.driver {
 	case "mysql":
 		dbType = db.MySQL
-		if username == "" {
-			username = "root"
-		}
 	case "pg":
 		dbType = db.Postgres
 	default:
-		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", databaseType)
+		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", ds.driver)
 	}
 
 	driver, err := db.Open(ctx, dbType, db.DriverConfig{Logger: logger}, db.ConnectionConfig{
-		Host:      hostname,
-		Port:      port,
-		Username:  username,
-		Password:  password,
-		Database:  database,
-		TLSConfig: tlsCfg,
+		Host:     ds.host,
+		Port:     ds.port,
+		Username: ds.username,
+		Password: ds.password,
+		Database: ds.database,
+		TLSConfig: db.TLSConfig{
+			SslCA:   ds.sslCA,
+			SslCert: ds.sslCert,
+			SslKey:  ds.sslKey,
+		},
 	}, db.ConnectionContext{})
 	if err != nil {
 		return fmt.Errorf("failed to open database, got error: %w", err)
@@ -127,7 +122,7 @@ func migrateDatabase(ctx context.Context, databaseType, username, password, host
 	if _, _, err := driver.ExecuteMigration(ctx, &db.MigrationInfo{
 		ReleaseVersion: version,
 		Version:        common.DefaultMigrationVersion(),
-		Database:       database,
+		Database:       ds.database,
 		Source:         db.LIBRARY,
 		Type:           db.Migrate,
 		Description:    description,

--- a/bin/bb/cmd/migrate.go
+++ b/bin/bb/cmd/migrate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/xo/dburl"
 
 	// install mysql driver.
 	_ "github.com/bytebase/bytebase/plugin/db/mysql"
@@ -19,7 +20,6 @@ import (
 
 func newMigrateCmd() *cobra.Command {
 	var (
-		ds          dataSource
 		dsn         string
 		fileList    []string
 		commandList []string
@@ -30,12 +30,9 @@ func newMigrateCmd() *cobra.Command {
 		Use:   "migrate",
 		Short: "Migrate the database schema",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(dsn) != 0 {
-				datasource, err := parseDSN(dsn)
-				if err != nil {
-					return err
-				}
-				ds = *datasource
+			u, err := dburl.Parse(dsn)
+			if err != nil {
+				return fmt.Errorf("failed to parse dsn, got error: %w", err)
 			}
 
 			var sqlReaders []io.Reader
@@ -55,53 +52,21 @@ func newMigrateCmd() *cobra.Command {
 			}
 
 			sqlReader := io.MultiReader(sqlReaders...)
-			return migrateDatabase(context.Background(), ds, description, issueID, false /*createDatabase*/, sqlReader)
+			return migrateDatabase(context.Background(), u, description, issueID, false /*createDatabase*/, sqlReader)
 		}}
 
 	migrateCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
-	migrateCmd.Flags().StringVar(&ds.driver, "type", "mysql", "Database type. (mysql or pg).")
-	migrateCmd.Flags().StringVar(&ds.username, "username", "", "Database username. (default mysql:root pg:postgres).")
-	migrateCmd.Flags().StringVar(&ds.password, "password", "", "Database password.")
-	migrateCmd.Flags().StringVar(&ds.host, "host", "", "Database host.")
-	migrateCmd.Flags().StringVar(&ds.port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
-	migrateCmd.Flags().StringVar(&ds.database, "database", "", "Target database to execute migration.")
 	migrateCmd.Flags().StringSliceVarP(&fileList, "file", "f", []string{}, "SQL file to execute.")
 	migrateCmd.Flags().StringSliceVarP(&commandList, "command", "c", []string{}, "SQL command to execute.")
 	migrateCmd.Flags().StringVar(&description, "description", "", "Description of migration.")
 	migrateCmd.Flags().StringVar(&issueID, "issue-id", "", "Issue ID of migration.")
-	// tls flags for SSL connection.
-	migrateCmd.Flags().StringVar(&ds.sslCA, "ssl-ca", "", "CA file in PEM format.")
-	migrateCmd.Flags().StringVar(&ds.sslCert, "ssl-cert", "", "X509 cert in PEM format.")
-	migrateCmd.Flags().StringVar(&ds.sslKey, "ssl-key", "", "X509 key in PEM format.")
-
 	return migrateCmd
 }
 
-func migrateDatabase(ctx context.Context, ds dataSource, description, issueID string, createDatabase bool, sqlReader io.Reader) error {
-	var dbType db.Type
-	switch ds.driver {
-	case "mysql":
-		dbType = db.MySQL
-	case "pg":
-		dbType = db.Postgres
-	default:
-		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", ds.driver)
-	}
-
-	driver, err := db.Open(ctx, dbType, db.DriverConfig{Logger: logger}, db.ConnectionConfig{
-		Host:     ds.host,
-		Port:     ds.port,
-		Username: ds.username,
-		Password: ds.password,
-		Database: ds.database,
-		TLSConfig: db.TLSConfig{
-			SslCA:   ds.sslCA,
-			SslCert: ds.sslCert,
-			SslKey:  ds.sslKey,
-		},
-	}, db.ConnectionContext{})
+func migrateDatabase(ctx context.Context, u *dburl.URL, description, issueID string, createDatabase bool, sqlReader io.Reader) error {
+	driver, err := open(ctx, logger, u)
 	if err != nil {
-		return fmt.Errorf("failed to open database, got error: %w", err)
+		return err
 	}
 	defer driver.Close(ctx)
 
@@ -122,7 +87,7 @@ func migrateDatabase(ctx context.Context, ds dataSource, description, issueID st
 	if _, _, err := driver.ExecuteMigration(ctx, &db.MigrationInfo{
 		ReleaseVersion: version,
 		Version:        common.DefaultMigrationVersion(),
-		Database:       ds.database,
+		Database:       getDatabase(u),
 		Source:         db.LIBRARY,
 		Type:           db.Migrate,
 		Description:    description,

--- a/bin/bb/cmd/migrate.go
+++ b/bin/bb/cmd/migrate.go
@@ -55,7 +55,7 @@ func newMigrateCmd() *cobra.Command {
 			return migrateDatabase(context.Background(), u, description, issueID, false /*createDatabase*/, sqlReader)
 		}}
 
-	migrateCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
+	migrateCmd.Flags().StringVar(&dsn, "dsn", "", "Database connection string. e.g. mysql://username:password@host:port/dbname?ssl-ca=value1&ssl-cert=value2&ssl-key=value3")
 	migrateCmd.Flags().StringSliceVarP(&fileList, "file", "f", []string{}, "SQL file to execute.")
 	migrateCmd.Flags().StringSliceVarP(&commandList, "command", "c", []string{}, "SQL command to execute.")
 	migrateCmd.Flags().StringVar(&description, "description", "", "Description of migration.")

--- a/bin/bb/cmd/migrate_test.go
+++ b/bin/bb/cmd/migrate_test.go
@@ -42,27 +42,19 @@ func TestMigrate(t *testing.T) {
 		{
 			args: []string{
 				"migrate",
-				"--type", "mysql",
-				"--username", "root",
-				"--host", "localhost",
-				"--port", fmt.Sprint(mysql.Port()),
+				"--dsn", fmt.Sprintf("mysql://root@localhost:%d/bytebase_test_todo", mysql.Port()),
 				"-c", `"
 	CREATE TABLE bytebase_test_todo.book (
 		id INTEGER PRIMARY KEY,
 		name TEXT NULL
 	);"`,
-				"--database", "bytebase_test_todo",
 			},
 			expected: _TestMigrate02,
 		},
 		{
 			args: []string{
 				"dump",
-				"--type", "mysql",
-				"--username", "root",
-				"--hostname", "localhost",
-				"--port", fmt.Sprint(mysql.Port()),
-				"--database", "bytebase_test_todo",
+				"--dsn", fmt.Sprintf("mysql://root@localhost:%d/bytebase_test_todo", mysql.Port()),
 			},
 			expected: _TestMigrate03,
 		},
@@ -85,10 +77,7 @@ func TestCreateDatabase(t *testing.T) {
 		{
 			args: []string{
 				"migrate",
-				"--type", "mysql",
-				"--username", "root",
-				"--host", "localhost",
-				"--port", fmt.Sprint(mysql.Port()),
+				"--dsn", fmt.Sprintf("mysql://root@localhost:%d/", mysql.Port()),
 				"-f", "testdata/mysql_test_schema/1_todo.sql",
 			},
 			expected: _TestCreateDatabase01,
@@ -96,11 +85,7 @@ func TestCreateDatabase(t *testing.T) {
 		{
 			args: []string{
 				"dump",
-				"--type", "mysql",
-				"--username", "root",
-				"--hostname", "localhost",
-				"--port", fmt.Sprint(mysql.Port()),
-				"--database", "bytebase_test_todo",
+				"--dsn", fmt.Sprintf("mysql://root@localhost:%d/bytebase_test_todo", mysql.Port()),
 			},
 			expected: _TestCreateDatabase02,
 		},

--- a/bin/bb/cmd/migrate_test.go
+++ b/bin/bb/cmd/migrate_test.go
@@ -35,11 +35,7 @@ func TestMigrate(t *testing.T) {
 		{
 			args: []string{
 				"dump",
-				"--type", "mysql",
-				"--username", "root",
-				"--hostname", "localhost",
-				"--port", fmt.Sprint(mysql.Port()),
-				"--database", "bytebase_test_todo",
+				"--dsn", fmt.Sprintf("mysql://root@localhost:%d/bytebase_test_todo", mysql.Port()),
 			},
 			expected: _TestMigrate01,
 		},

--- a/bin/bb/cmd/restore.go
+++ b/bin/bb/cmd/restore.go
@@ -27,7 +27,7 @@ func newRestoreCmd() *cobra.Command {
 			return restoreDatabase(context.Background(), u, file)
 		},
 	}
-	restoreCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
+	restoreCmd.Flags().StringVar(&dsn, "dsn", "", "Database connection string. e.g. mysql://username:password@host:port/dbname?ssl-ca=value1&ssl-cert=value2&ssl-key=value3")
 	restoreCmd.Flags().StringVar(&file, "file", "", "File to store the dump.")
 	if err := restoreCmd.MarkFlagRequired("file"); err != nil {
 		panic(err)

--- a/bin/bb/cmd/restore.go
+++ b/bin/bb/cmd/restore.go
@@ -13,37 +13,31 @@ import (
 
 func newRestoreCmd() *cobra.Command {
 	var (
-		databaseType string
-		username     string
-		password     string
-		hostname     string
-		port         string
-		database     string
-		file         string
-
-		// SSL flags.
-		sslCA   string // server-ca.pem
-		sslCert string // client-cert.pem
-		sslKey  string // client-key.pem
+		ds   dataSource
+		dsn  string
+		file string
 	)
 	restoreCmd := &cobra.Command{
 		Use:   "restore",
 		Short: "restores the schema of a database instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tlsCfg := db.TLSConfig{
-				SslCA:   sslCA,
-				SslCert: sslCert,
-				SslKey:  sslKey,
+			if len(dsn) != 0 {
+				datasource, err := parseDSN(dsn)
+				if err != nil {
+					return err
+				}
+				ds = *datasource
 			}
-			return restoreDatabase(context.Background(), databaseType, username, password, hostname, port, database, file, tlsCfg)
+			return restoreDatabase(context.Background(), ds, file)
 		},
 	}
-	restoreCmd.Flags().StringVar(&databaseType, "type", "mysql", "Database type. (mysql, or pg).")
-	restoreCmd.Flags().StringVar(&username, "username", "", "Username to login database. (default mysql:root pg:postgres).")
-	restoreCmd.Flags().StringVar(&password, "password", "", "Password to login database.")
-	restoreCmd.Flags().StringVar(&hostname, "hostname", "", "Hostname of database.")
-	restoreCmd.Flags().StringVar(&port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
-	restoreCmd.Flags().StringVar(&database, "database", "", "Database to connect and export.")
+	restoreCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
+	restoreCmd.Flags().StringVar(&ds.driver, "type", "mysql", "Database type. (mysql, or pg).")
+	restoreCmd.Flags().StringVar(&ds.username, "username", "", "Username to login database. (default mysql:root pg:postgres).")
+	restoreCmd.Flags().StringVar(&ds.password, "password", "", "Password to login database.")
+	restoreCmd.Flags().StringVar(&ds.host, "host", "", "Hostname of database.")
+	restoreCmd.Flags().StringVar(&ds.port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
+	restoreCmd.Flags().StringVar(&ds.database, "database", "", "Database to connect and export.")
 	restoreCmd.Flags().StringVar(&file, "file", "", "File to store the dump.")
 	if err := restoreCmd.MarkFlagRequired("database"); err != nil {
 		panic(err)
@@ -53,15 +47,15 @@ func newRestoreCmd() *cobra.Command {
 	}
 
 	// tls flags for SSL connection.
-	restoreCmd.Flags().StringVar(&sslCA, "ssl-ca", "", "CA file in PEM format.")
-	restoreCmd.Flags().StringVar(&sslCert, "ssl-cert", "", "X509 cert in PEM format.")
-	restoreCmd.Flags().StringVar(&sslKey, "ssl-key", "", "X509 key in PEM format.")
+	restoreCmd.Flags().StringVar(&ds.sslCA, "ssl-ca", "", "CA file in PEM format.")
+	restoreCmd.Flags().StringVar(&ds.sslCert, "ssl-cert", "", "X509 cert in PEM format.")
+	restoreCmd.Flags().StringVar(&ds.sslKey, "ssl-key", "", "X509 key in PEM format.")
 
 	return restoreCmd
 }
 
 // restoreDatabase restores the schema of a database instance.
-func restoreDatabase(ctx context.Context, databaseType, username, password, hostname, port, database, file string, tlsCfg db.TLSConfig) error {
+func restoreDatabase(ctx context.Context, ds dataSource, file string) error {
 	f, err := os.OpenFile(file, os.O_RDONLY, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("os.OpenFile(%q) error: %v", file, err)
@@ -70,28 +64,32 @@ func restoreDatabase(ctx context.Context, databaseType, username, password, host
 	sc := bufio.NewScanner(f)
 
 	var dbType db.Type
-	switch databaseType {
+	switch ds.driver {
 	case "mysql":
 		dbType = db.MySQL
-		if username == "" {
-			username = "root"
+		if ds.username == "" {
+			ds.username = "root"
 		}
 	case "pg":
 		dbType = db.Postgres
 	default:
-		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", databaseType)
+		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", ds.driver)
 	}
 	db, err := db.Open(
 		ctx,
 		dbType,
 		db.DriverConfig{Logger: logger},
 		db.ConnectionConfig{
-			Host:      hostname,
-			Port:      port,
-			Username:  username,
-			Password:  password,
-			Database:  database,
-			TLSConfig: tlsCfg,
+			Host:     ds.host,
+			Port:     ds.port,
+			Username: ds.username,
+			Password: ds.password,
+			Database: ds.database,
+			TLSConfig: db.TLSConfig{
+				SslCA:   ds.sslCA,
+				SslCert: ds.sslCert,
+				SslKey:  ds.sslKey,
+			},
 		},
 		db.ConnectionContext{},
 	)

--- a/bin/bb/cmd/restore.go
+++ b/bin/bb/cmd/restore.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/spf13/cobra"
+	"github.com/xo/dburl"
 )
 
 func newRestoreCmd() *cobra.Command {
 	var (
-		ds   dataSource
 		dsn  string
 		file string
 	)
@@ -21,41 +20,24 @@ func newRestoreCmd() *cobra.Command {
 		Use:   "restore",
 		Short: "restores the schema of a database instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(dsn) != 0 {
-				datasource, err := parseDSN(dsn)
-				if err != nil {
-					return err
-				}
-				ds = *datasource
+			u, err := dburl.Parse(dsn)
+			if err != nil {
+				return fmt.Errorf("failed to parse dsn, got error: %w", err)
 			}
-			return restoreDatabase(context.Background(), ds, file)
+			return restoreDatabase(context.Background(), u, file)
 		},
 	}
 	restoreCmd.Flags().StringVar(&dsn, "dsn", "", "database connection string. e.g. mysql://root@localhost:3306/bytebase")
-	restoreCmd.Flags().StringVar(&ds.driver, "type", "mysql", "Database type. (mysql, or pg).")
-	restoreCmd.Flags().StringVar(&ds.username, "username", "", "Username to login database. (default mysql:root pg:postgres).")
-	restoreCmd.Flags().StringVar(&ds.password, "password", "", "Password to login database.")
-	restoreCmd.Flags().StringVar(&ds.host, "host", "", "Hostname of database.")
-	restoreCmd.Flags().StringVar(&ds.port, "port", "", "Port of database. (default mysql:3306 pg:5432).")
-	restoreCmd.Flags().StringVar(&ds.database, "database", "", "Database to connect and export.")
 	restoreCmd.Flags().StringVar(&file, "file", "", "File to store the dump.")
-	if err := restoreCmd.MarkFlagRequired("database"); err != nil {
-		panic(err)
-	}
 	if err := restoreCmd.MarkFlagRequired("file"); err != nil {
 		panic(err)
 	}
-
-	// tls flags for SSL connection.
-	restoreCmd.Flags().StringVar(&ds.sslCA, "ssl-ca", "", "CA file in PEM format.")
-	restoreCmd.Flags().StringVar(&ds.sslCert, "ssl-cert", "", "X509 cert in PEM format.")
-	restoreCmd.Flags().StringVar(&ds.sslKey, "ssl-key", "", "X509 key in PEM format.")
 
 	return restoreCmd
 }
 
 // restoreDatabase restores the schema of a database instance.
-func restoreDatabase(ctx context.Context, ds dataSource, file string) error {
+func restoreDatabase(ctx context.Context, u *dburl.URL, file string) error {
 	f, err := os.OpenFile(file, os.O_RDONLY, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("os.OpenFile(%q) error: %v", file, err)
@@ -63,36 +45,7 @@ func restoreDatabase(ctx context.Context, ds dataSource, file string) error {
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 
-	var dbType db.Type
-	switch ds.driver {
-	case "mysql":
-		dbType = db.MySQL
-		if ds.username == "" {
-			ds.username = "root"
-		}
-	case "pg":
-		dbType = db.Postgres
-	default:
-		return fmt.Errorf("database type %q not supported; supported types: mysql, pg", ds.driver)
-	}
-	db, err := db.Open(
-		ctx,
-		dbType,
-		db.DriverConfig{Logger: logger},
-		db.ConnectionConfig{
-			Host:     ds.host,
-			Port:     ds.port,
-			Username: ds.username,
-			Password: ds.password,
-			Database: ds.database,
-			TLSConfig: db.TLSConfig{
-				SslCA:   ds.sslCA,
-				SslCert: ds.sslCert,
-				SslKey:  ds.sslKey,
-			},
-		},
-		db.ConnectionContext{},
-	)
+	db, err := open(ctx, logger, u)
 	if err != nil {
 		return err
 	}

--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// driver://[username[:password]@]host[:port]/[database][?param1=value1&...&paramN=valueN]
+var dsnPattern *regexp.Regexp
+
+func init() {
+	dsnPattern = regexp.MustCompile(
+		`^(?P<driver>.+?)(?::\/\/)` + // driver://
+			`(?:(?P<username>.+?)(?::(?P<password>.+?))?@)?` + // [username[:password]@]
+			`(?P<host>.+?)(?::(?P<port>.+?))?` + // host[:port]
+			`\/(?P<database>.+?)` + // /[database]
+			`(?:\?(?P<params>[^\?]*))?$`) // [?param1=value1&...&paramN=valueN]
+}
+
+type dataSource struct {
+	driver   string
+	username string
+	password string
+	host     string
+	port     string
+	database string
+	params   map[string]string
+
+	sslCA   string // server-ca.pem
+	sslCert string // client-cert.pem
+	sslKey  string // client-key.pem
+}
+
+func parseDSN(dsn string) (*dataSource, error) {
+	if !dsnPattern.MatchString(dsn) {
+		return nil, fmt.Errorf("invalid dsn: %s", dsn)
+	}
+
+	ds := new(dataSource)
+	ds.params = make(map[string]string)
+
+	matches := dsnPattern.FindStringSubmatch(dsn)
+	names := dsnPattern.SubexpNames()
+
+	for i, match := range matches {
+		switch names[i] {
+		case "driver":
+			ds.driver = match
+		case "username":
+			ds.username = match
+		case "password":
+			ds.password = match
+		case "host":
+			ds.host = match
+		case "port":
+			ds.port = match
+		case "database":
+			ds.database = match
+		case "params":
+			if len(match) == 0 {
+				// no params
+				continue
+			}
+			for _, v := range strings.Split(match, "&") {
+				param := strings.SplitN(v, "=", 2)
+				if len(param) != 2 {
+					return nil, fmt.Errorf("invalid param: %s", v)
+				}
+				switch value := param[1]; param[0] {
+				case "ssl-ca":
+					ds.sslCA = value
+				case "ssl-cert":
+					ds.sslCert = value
+				case "ssl-key":
+					ds.sslKey = value
+				default:
+					ds.params[param[0]] = value
+				}
+			}
+		}
+	}
+
+	return ds, nil
+}

--- a/bin/bb/cmd/utils_test.go
+++ b/bin/bb/cmd/utils_test.go
@@ -1,24 +1,26 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/xo/dburl"
 )
 
-func TestParseDns(t *testing.T) {
-	for _, test := range []struct {
-		dsn     string
-		want    *dataSource
-		wantErr error
+func TestGetDatabase(t *testing.T) {
+	for _, tt := range []struct {
+		u   string
+		exp string
 	}{
-		{"", nil, fmt.Errorf("invalid dsn: ")},
-		{"mysql://user:pass@localhost:3306/db?param1=value1&param2=value2", &dataSource{driver: "mysql", username: "user", password: "pass", host: "localhost", port: "3306", database: "db", params: map[string]string{"param1": "value1", "param2": "value2"}}, nil},
-		{"postgres://user@localhost/db", &dataSource{driver: "postgres", username: "user", host: "localhost", database: "db", params: map[string]string{}}, nil},
+		{"mysql://root@localhost:3306/bytebase_test_todo", "bytebase_test_todo"},
+		{"mysql://root@localhost:13308/", ""},
+		{"mysql://root@localhost:13308/bytebase_test_todo?ssl-rs=", "bytebase_test_todo"},
 	} {
-		ds, err := parseDSN(test.dsn)
-		require.Equal(t, test.want, ds)
-		require.Equal(t, test.wantErr, err)
+		u, err := dburl.Parse(tt.u)
+		if err != nil {
+			t.Error(err)
+		}
+		if getDatabase(u) != tt.exp {
+			t.Error("expected", tt.exp, "got", getDatabase(u))
+		}
 	}
 }

--- a/bin/bb/cmd/utils_test.go
+++ b/bin/bb/cmd/utils_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDns(t *testing.T) {
+	for _, test := range []struct {
+		dsn     string
+		want    *dataSource
+		wantErr error
+	}{
+		{"", nil, fmt.Errorf("invalid dsn: ")},
+		{"mysql://user:pass@localhost:3306/db?param1=value1&param2=value2", &dataSource{driver: "mysql", username: "user", password: "pass", host: "localhost", port: "3306", database: "db", params: map[string]string{"param1": "value1", "param2": "value2"}}, nil},
+		{"postgres://user@localhost/db", &dataSource{driver: "postgres", username: "user", host: "localhost", database: "db", params: map[string]string{}}, nil},
+	} {
+		ds, err := parseDSN(test.dsn)
+		require.Equal(t, test.want, ds)
+		require.Equal(t, test.wantErr, err)
+	}
+}

--- a/bin/bb/cmd/utils_test.go
+++ b/bin/bb/cmd/utils_test.go
@@ -13,7 +13,7 @@ func TestGetDatabase(t *testing.T) {
 	}{
 		{"mysql://root@localhost:3306/bytebase_test_todo", "bytebase_test_todo"},
 		{"mysql://root@localhost:13308/", ""},
-		{"mysql://root@localhost:13308/bytebase_test_todo?ssl-rs=", "bytebase_test_todo"},
+		{"mysql://root@localhost:13308/bytebase_test_todo?ssl-key=a", "bytebase_test_todo"},
 	} {
 		u, err := dburl.Parse(tt.u)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/cobra v1.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
+	github.com/xo/dburl v0.9.1 // indirect
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/cobra v1.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
-	github.com/xo/dburl v0.9.1 // indirect
+	github.com/xo/dburl v0.9.1
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -940,6 +940,8 @@ github.com/xitongsys/parquet-go v1.5.1/go.mod h1:xUxwM8ELydxh4edHGegYq1pA8NnMKDx
 github.com/xitongsys/parquet-go v1.5.5-0.20201110004701-b09c49d6d457/go.mod h1:pheqtXeHQFzxJk45lRQ0UIGIivKnLXvialZSFWs81A8=
 github.com/xitongsys/parquet-go-source v0.0.0-20190524061010-2b72cbee77d5/go.mod h1:xxCx7Wpym/3QCo6JhujJX51dzSXrwmb0oH6FQb39SEA=
 github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0/go.mod h1:HYhIKsdns7xz80OgkbgJYrtQY7FjHWHKH6cvN7+czGE=
+github.com/xo/dburl v0.9.1 h1:y771capKup7TLEQBbc1NzY+NkHRD5DdHITeswr79JpM=
+github.com/xo/dburl v0.9.1/go.mod h1:7Uupe87dIDxNrbKFRrpw6bAf2l3/rqU42iwlpq1nyjY=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=


### PR DESCRIPTION
Support DSN flag like `--dsn mysql://bytebase@localhost:3306/`

This flag can simplify database settings. Replace
`bb migrate --dbType mysql --username bytebase --password passwd --host localhost --port 3306 --database todo`
with just
`bb migrate --dsn mysql://bytebase:passwd@localhost:3306/todo`.

This simplicity is useful when more than one database is needed in one command, e.g. `bb diff`(coming soon).

we use `xo/dburl` to parse dsn, so that all formats of it are supported. (see https://pkg.go.dev/github.com/xo/dburl#hdr-Example_URLs)