### PR TITLE
fix: tenant mode VSC with DatebaseNameTemplate task execute error

### DIFF
--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -279,6 +279,9 @@ func ParseMigrationInfo(filePath string, filePathTemplate string) (*MigrationInf
 				mi.Environment = matchList[index]
 			case "VERSION":
 				mi.Version = matchList[index]
+			case "DB_NAME":
+				mi.Namespace = matchList[index]
+				mi.Database = matchList[index]
 			case "TYPE":
 				switch matchList[index] {
 				case "baseline":

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -279,9 +279,6 @@ func ParseMigrationInfo(filePath string, filePathTemplate string) (*MigrationInf
 				mi.Environment = matchList[index]
 			case "VERSION":
 				mi.Version = matchList[index]
-			case "DB_NAME":
-				mi.Namespace = matchList[index]
-				mi.Database = matchList[index]
 			case "TYPE":
 				switch matchList[index] {
 				case "baseline":

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -156,8 +156,9 @@ func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.
 	// If VCS based and schema path template is specified, then we will write back the latest schema file after migration.
 	writeBack := (vcsPushEvent != nil) && (repoRawOutter.SchemaPathTemplate != "")
 	// For tenant mode project, we will only write back latest schema file on the last task.
+	var project *api.Project
 	if writeBack && issue != nil {
-		project, err := server.composeProjectByID(ctx, task.Database.ProjectID)
+		project, err = server.composeProjectByID(ctx, task.Database.ProjectID)
 		if err != nil {
 			return true, nil, err
 		}
@@ -178,9 +179,13 @@ func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.
 	}
 
 	if writeBack {
+		dbName, err := api.GetBaseDatabaseName(mi.Database, project.DBNameTemplate, task.Database.Labels)
+		if err != nil {
+			return true, nil, fmt.Errorf("failed to get BaseDatabaseName for instance %q, database %q: %w", task.Instance.Name, task.Database.Name, err)
+		}
 		latestSchemaFile := filepath.Join(repoRawOutter.BaseDirectory, repoRawOutter.SchemaPathTemplate)
 		latestSchemaFile = strings.ReplaceAll(latestSchemaFile, "{{ENV_NAME}}", mi.Environment)
-		latestSchemaFile = strings.ReplaceAll(latestSchemaFile, "{{DB_NAME}}", mi.Database)
+		latestSchemaFile = strings.ReplaceAll(latestSchemaFile, "{{DB_NAME}}", dbName)
 
 		// TODO(dragonly): revisit the usage of a not-fully-composed Repository here
 		repo := repoRawOutter.ToRepository()
@@ -239,7 +244,7 @@ func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.
 				Level:       api.ActivityInfo,
 				Comment: fmt.Sprintf("Committed the latest schema after applying migration version %s to %q.",
 					mi.Version,
-					mi.Database,
+					dbName,
 				),
 				Payload: string(payload),
 			}

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -156,12 +156,11 @@ func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.
 	// If VCS based and schema path template is specified, then we will write back the latest schema file after migration.
 	writeBack := (vcsPushEvent != nil) && (repoRawOutter.SchemaPathTemplate != "")
 	// For tenant mode project, we will only write back latest schema file on the last task.
-	var project *api.Project
+	project, err := server.composeProjectByID(ctx, task.Database.ProjectID)
+	if err != nil {
+		return true, nil, err
+	}
 	if writeBack && issue != nil {
-		project, err = server.composeProjectByID(ctx, task.Database.ProjectID)
-		if err != nil {
-			return true, nil, err
-		}
 		if project.TenantMode == api.TenantModeTenant {
 			var lastTask *api.Task
 			for i := len(issue.Pipeline.StageList) - 1; i >= 0; i-- {

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -57,8 +57,6 @@ func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.
 		}
 		// TODO(d): support semantic versioning.
 		mi.Version = schemaVersion
-		mi.Database = databaseName
-		mi.Namespace = databaseName
 		mi.Description = task.Name
 	} else {
 		repoFind := &api.RepositoryFind{
@@ -92,6 +90,9 @@ func runMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.
 		}
 		mi.Payload = string(bytes)
 	}
+
+	mi.Database = databaseName
+	mi.Namespace = databaseName
 
 	issueFind := &api.IssueFind{
 		PipelineID: &task.PipelineID,

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -265,3 +265,21 @@ func (gl *GitLab) AddFiles(gitlabProjectID string, files map[string]string) erro
 	}
 	return nil
 }
+
+// GetFiles get files from repository.
+func (gl *GitLab) GetFiles(gitlabProjectID string, filePaths ...string) (map[string]string, error) {
+	pd, ok := gl.projects[gitlabProjectID]
+	if !ok {
+		return nil, fmt.Errorf("gitlab project %q doesn't exist", gitlabProjectID)
+	}
+
+	// Get files
+	files := make(map[string]string, len(filePaths))
+	for _, path := range filePaths {
+
+		if content, ok := pd.files[path]; ok {
+			files[path] = content
+		}
+	}
+	return files, nil
+}

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -276,7 +276,6 @@ func (gl *GitLab) GetFiles(gitlabProjectID string, filePaths ...string) (map[str
 	// Get files
 	files := make(map[string]string, len(filePaths))
 	for _, path := range filePaths {
-
 		if content, ok := pd.files[path]; ok {
 			files[path] = content
 		}

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -570,3 +570,246 @@ func TestTenantDatabaseNameTemplate(t *testing.T) {
 		require.Equal(t, bookSchemaSQLResult, result)
 	}
 }
+
+func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ctl := &controller{}
+	dataDir := t.TempDir()
+	err := ctl.StartMain(ctx, dataDir, getTestPort(t.Name()))
+	require.NoError(t, err)
+	defer ctl.Close()
+	err = ctl.Login()
+	require.NoError(t, err)
+	err = ctl.setLicense()
+	require.NoError(t, err)
+
+	// Create a VCS.
+	applicationID := "testApplicationID"
+	applicationSecret := "testApplicationSecret"
+	vcs, err := ctl.createVCS(api.VCSCreate{
+		Name:          "TestVCS",
+		Type:          vcs.GitLabSelfHost,
+		InstanceURL:   ctl.gitURL,
+		APIURL:        ctl.gitAPIURL,
+		ApplicationID: applicationID,
+		Secret:        applicationSecret,
+	})
+	require.NoError(t, err)
+
+	// Create a project.
+	project, err := ctl.createProject(api.ProjectCreate{
+		Name:           "Test Project",
+		Key:            "TestSchemaUpdate",
+		TenantMode:     api.TenantModeTenant,
+		DBNameTemplate: "{{DB_NAME}}_{{TENANT}}",
+	})
+	require.NoError(t, err)
+
+	// Create a repository.
+	repositoryPath := "test/schemaUpdate"
+	accessToken := "accessToken1"
+	refreshToken := "refreshToken1"
+	gitlabProjectID := 121
+	gitlabProjectIDStr := fmt.Sprintf("%d", gitlabProjectID)
+	// create a gitlab project.
+	ctl.gitlab.CreateProject(gitlabProjectIDStr)
+	_, err = ctl.createRepository(api.RepositoryCreate{
+		VCSID:              vcs.ID,
+		ProjectID:          project.ID,
+		Name:               "Test Repository",
+		FullPath:           repositoryPath,
+		WebURL:             fmt.Sprintf("%s/%s", ctl.gitURL, repositoryPath),
+		BranchFilter:       "feature/foo",
+		BaseDirectory:      "bbtest",
+		FilePathTemplate:   "{{DB_NAME}}__{{VERSION}}__{{TYPE}}__{{DESCRIPTION}}.sql",
+		SchemaPathTemplate: ".{{DB_NAME}}__LATEST.sql",
+		ExternalID:         gitlabProjectIDStr,
+		AccessToken:        accessToken,
+		ExpiresTs:          0,
+		RefreshToken:       refreshToken,
+	})
+	require.NoError(t, err)
+
+	// Provision instances.
+	instanceRootDir := t.TempDir()
+
+	var stagingInstanceDirs []string
+	var prodInstanceDirs []string
+	for i := 0; i < stagingTenantNumber; i++ {
+		instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, fmt.Sprintf("%s-%d", stagingInstanceName, i))
+		require.NoError(t, err)
+		stagingInstanceDirs = append(stagingInstanceDirs, instanceDir)
+	}
+	for i := 0; i < prodTenantNumber; i++ {
+		instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, fmt.Sprintf("%s-%d", prodInstanceName, i))
+		require.NoError(t, err)
+		prodInstanceDirs = append(prodInstanceDirs, instanceDir)
+	}
+	environments, err := ctl.getEnvironments()
+	require.NoError(t, err)
+	stagingEnvironment, err := findEnvironment(environments, "Staging")
+	require.NoError(t, err)
+	prodEnvironment, err := findEnvironment(environments, "Prod")
+	require.NoError(t, err)
+
+	// Add the provisioned instances.
+	var stagingInstances []*api.Instance
+	var prodInstances []*api.Instance
+	for i, stagingInstanceDir := range stagingInstanceDirs {
+		instance, err := ctl.addInstance(api.InstanceCreate{
+			EnvironmentID: stagingEnvironment.ID,
+			Name:          fmt.Sprintf("%s-%d", stagingInstanceName, i),
+			Engine:        db.SQLite,
+			Host:          stagingInstanceDir,
+		})
+		require.NoError(t, err)
+		stagingInstances = append(stagingInstances, instance)
+	}
+	for i, prodInstanceDir := range prodInstanceDirs {
+		instance, err := ctl.addInstance(api.InstanceCreate{
+			EnvironmentID: prodEnvironment.ID,
+			Name:          fmt.Sprintf("%s-%d", prodInstanceName, i),
+			Engine:        db.SQLite,
+			Host:          prodInstanceDir,
+		})
+		require.NoError(t, err)
+		prodInstances = append(prodInstances, instance)
+	}
+
+	// Set up label values for tenants.
+	// Prod and staging are using the same tenant values. Use prodInstancesNumber because it's larger than stagingInstancesNumber.
+	var tenants []string
+	for i := 0; i < prodTenantNumber; i++ {
+		tenants = append(tenants, fmt.Sprintf("tenant%d", i))
+	}
+	err = ctl.addLabelValues(api.TenantLabelKey, tenants)
+	require.NoError(t, err)
+
+	// Create deployment configuration.
+	_, err = ctl.upsertDeploymentConfig(
+		api.DeploymentConfigUpsert{
+			ProjectID: project.ID,
+		},
+		deploymentSchedule,
+	)
+	require.NoError(t, err)
+
+	// Create issues that create databases.
+	baseDatabaseName := "testTenantVCSSchemaUpdate"
+
+	for i, stagingInstance := range stagingInstances {
+		tenant := fmt.Sprintf("tenant%d", i)
+		databaseName := baseDatabaseName + "_" + tenant
+		err := ctl.createDatabase(project, stagingInstance, databaseName, map[string]string{api.TenantLabelKey: tenant})
+		require.NoError(t, err)
+	}
+	for i, prodInstance := range prodInstances {
+		tenant := fmt.Sprintf("tenant%d", i)
+		databaseName := baseDatabaseName + "_" + tenant
+		err := ctl.createDatabase(project, prodInstance, databaseName, map[string]string{api.TenantLabelKey: tenant})
+		require.NoError(t, err)
+	}
+
+	// Getting databases for each environment.
+	databases, err := ctl.getDatabases(api.DatabaseFind{
+		ProjectID: &project.ID,
+	})
+	require.NoError(t, err)
+
+	var stagingDatabases []*api.Database
+	var prodDatabases []*api.Database
+	for _, stagingInstance := range stagingInstances {
+		for _, database := range databases {
+			if database.Instance.ID == stagingInstance.ID {
+				stagingDatabases = append(stagingDatabases, database)
+				break
+			}
+		}
+	}
+	for _, prodInstance := range prodInstances {
+		for _, database := range databases {
+			if database.Instance.ID == prodInstance.ID {
+				prodDatabases = append(prodDatabases, database)
+				break
+			}
+		}
+	}
+	require.Equal(t, len(stagingDatabases), stagingTenantNumber)
+	require.Equal(t, len(prodDatabases), prodTenantNumber)
+
+	// Simulate Git commits.
+	gitFile := "bbtest/testTenantVCSSchemaUpdate__ver1__migrate__create_a_test_table.sql"
+	pushEvent := &gitlab.WebhookPushEvent{
+		ObjectKind: gitlab.WebhookPush,
+		Ref:        "refs/heads/feature/foo",
+		Project: gitlab.WebhookProject{
+			ID: gitlabProjectID,
+		},
+		CommitList: []gitlab.WebhookCommit{
+			{
+				Timestamp: "2021-01-13T13:14:00Z",
+				AddedList: []string{
+					gitFile,
+				},
+			},
+		},
+	}
+	err = ctl.gitlab.AddFiles(gitlabProjectIDStr, map[string]string{gitFile: migrationStatement})
+	require.NoError(t, err)
+	err = ctl.gitlab.SendCommits(gitlabProjectIDStr, pushEvent)
+	require.NoError(t, err)
+
+	// Get schema update issue.
+	openStatus := []api.IssueStatus{api.IssueOpen}
+	issues, err := ctl.getIssues(api.IssueFind{ProjectID: &project.ID, StatusList: &openStatus})
+	require.NoError(t, err)
+	require.Equal(t, len(issues), 1)
+	issue := issues[0]
+	status, err := ctl.waitIssuePipeline(issue.ID)
+	require.NoError(t, err)
+	require.Equal(t, status, api.TaskDone)
+
+	// Query schema.
+	for i, stagingInstance := range stagingInstances {
+		tenant := fmt.Sprintf("tenant%d", i)
+		databaseName := baseDatabaseName + "_" + tenant
+		result, err := ctl.query(stagingInstance, databaseName, bookTableQuery)
+		require.NoError(t, err)
+		require.Equal(t, bookSchemaSQLResult, result)
+	}
+	for i, prodInstance := range prodInstances {
+		tenant := fmt.Sprintf("tenant%d", i)
+		databaseName := baseDatabaseName + "_" + tenant
+		result, err := ctl.query(prodInstance, databaseName, bookTableQuery)
+		require.NoError(t, err)
+		require.Equal(t, bookSchemaSQLResult, result)
+	}
+
+	// Query migration history
+	hm1 := map[string]bool{}
+	hm2 := map[string]bool{}
+	for i, instance := range stagingInstances {
+		tenant := fmt.Sprintf("tenant%d", i)
+		databaseName := baseDatabaseName + "_" + tenant
+		histories, err := ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID, Database: &databaseName})
+		require.NoError(t, err)
+		require.Equal(t, len(histories), 2)
+		require.Equal(t, histories[0].Version, "ver1")
+		require.NotEqual(t, histories[1].Version, "")
+		hm1[histories[0].Version] = true
+	}
+	for i, instance := range prodInstances {
+		tenant := fmt.Sprintf("tenant%d", i)
+		databaseName := baseDatabaseName + "_" + tenant
+		histories, err := ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID, Database: &databaseName})
+		require.NoError(t, err)
+		require.Equal(t, len(histories), 2)
+		require.Equal(t, histories[0].Version, "ver1")
+		require.NotEqual(t, histories[1].Version, "")
+		hm2[histories[0].Version] = true
+	}
+
+	require.Equal(t, len(hm1), 1)
+	require.Equal(t, len(hm2), 1)
+}

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -20,6 +20,8 @@ var (
 	prodInstanceName    = "testInstanceProd"
 )
 
+const baseDirectory = "bbtest"
+
 func TestTenant(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -246,7 +248,7 @@ func TestTenantVCS(t *testing.T) {
 		FullPath:           repositoryPath,
 		WebURL:             fmt.Sprintf("%s/%s", ctl.gitURL, repositoryPath),
 		BranchFilter:       "feature/foo",
-		BaseDirectory:      "bbtest",
+		BaseDirectory:      baseDirectory,
 		FilePathTemplate:   "{{DB_NAME}}__{{VERSION}}__{{TYPE}}__{{DESCRIPTION}}.sql",
 		SchemaPathTemplate: ".{{DB_NAME}}__LATEST.sql",
 		ExternalID:         gitlabProjectIDStr,
@@ -812,4 +814,10 @@ func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
 
 	require.Equal(t, len(hm1), 1)
 	require.Equal(t, len(hm2), 1)
+
+	// Check latestSchemaFile
+	files, err := ctl.gitlab.GetFiles(gitlabProjectIDStr, fmt.Sprintf("%s/.%s__LATEST.sql", baseDirectory, baseDatabaseName))
+	require.NoError(t, err)
+	require.Equal(t, len(files), 1)
+
 }

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -118,6 +118,8 @@ func getTestPort(testName string) int {
 		return 1246
 	case "TestTenantDatabaseNameTemplate":
 		return 1249
+	case "TestTenantVCSDatabaseNameTemplate":
+		return 1252
 	}
 	panic(fmt.Sprintf("test %q doesn't have assigned port, please set it in getTestPort()", testName))
 }
@@ -405,7 +407,7 @@ func (ctl *controller) getEnvironments() ([]*api.Environment, error) {
 
 func findEnvironment(envs []*api.Environment, name string) (*api.Environment, error) {
 	for _, env := range envs {
-		if env.Name == "Prod" {
+		if env.Name == name {
 			return env, nil
 		}
 	}


### PR DESCRIPTION
Signed-off-by: cluas <cluas@live.cn>

case:
  - tenant template: `{{DB_NAME}}_{{TENTANT}}`
  - tenants: `a, b`
  - demo db: `demo`
  - file path template: `{{DB_NAME}}__{{VERSION}}__{{TYPE}}__{{DESCRIPTION}}.sql`
  - example push file: `demo__v0.1.0__migrate__demo.sql`
  - tasks after gitops webhook: `task1 {database: demo_a, namespace: demo_a}},  task2 {database: demo_b, namespace: demo_b}}`

but here it parse `{{DB_NAME}}`, in this case,  always is `demo`. so subsequent tasks will immediately go wrong.