### PR TITLE
fix: perform correctly when table.indexList is empty

### DIFF
--- a/frontend/src/store/modules/table.ts
+++ b/frontend/src/store/modules/table.ts
@@ -1,10 +1,12 @@
 import axios from "axios";
 import {
+  Column,
   Database,
   DatabaseId,
   ResourceIdentifier,
   ResourceObject,
   Table,
+  TableIndex,
   TableState,
   unknown,
 } from "../../types";
@@ -26,10 +28,13 @@ function convert(
     }
   }
 
+  const columnList = (table.attributes.columnList as Column[]) || [];
+  const indexList = (table.attributes.indexList as TableIndex[]) || [];
+
   return {
     ...(table.attributes as Omit<
       Table,
-      "id" | "database" | "creator" | "updater"
+      "id" | "database" | "creator" | "updater" | "columnList" | "indexList"
     >),
     id: parseInt(table.id),
     creator: getPrincipalFromIncludedList(
@@ -40,6 +45,8 @@ function convert(
       table.relationships!.updater.data,
       includedList
     ),
+    columnList,
+    indexList,
     database,
   };
 }

--- a/frontend/src/types/table.ts
+++ b/frontend/src/types/table.ts
@@ -2,6 +2,7 @@ import { Column } from "./column";
 import { Database } from "./database";
 import { TableId } from "./id";
 import { Principal } from "./principal";
+import { TableIndex } from "./tableIndex";
 
 export type TableType = "BASE TABLE" | "VIEW";
 export type TableEngineType = "InnoDB";
@@ -26,6 +27,7 @@ export type Table = {
   collation: string;
   rowCount: number;
   dataSize: number;
+  indexList: TableIndex[];
   indexSize: number;
   dataFree: number;
   createOptions: string;


### PR DESCRIPTION
# Internal error when index list is empty in the table detail view

## how to re-produce

1. Create a table via Bytebase
2. Go to the created table
3. Get exception due to empty indexList

![image](https://user-images.githubusercontent.com/2749742/162859000-c09a1181-4fe2-4566-b7eb-a23f2f204438.png)
