### PR TITLE
fix: quote database name in dump statement

### DIFF
--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -1074,7 +1074,7 @@ func getDatabases(txn *sql.Tx) ([]string, error) {
 
 // getDatabaseStmt gets the create statement of a database.
 func getDatabaseStmt(txn *sql.Tx, dbName string) (string, error) {
-	query := fmt.Sprintf("SHOW CREATE DATABASE IF NOT EXISTS %s;", dbName)
+	query := fmt.Sprintf("SHOW CREATE DATABASE IF NOT EXISTS `%s`;", dbName)
 	rows, err := txn.Query(query)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
If we have a database name with space in it like "some db name", then `go run bin/bb/main.go dump` will fail on that database because of SQL syntax error.