### PR TITLE
feat(gh-ost): task blocked by implementation

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -162,6 +162,7 @@ type TaskRaw struct {
 	DatabaseID          *int
 	TaskRunRawList      []*TaskRunRaw
 	TaskCheckRunRawList []*TaskCheckRunRaw
+	BlockedBy           []*Task
 
 	// Domain specific fields
 	Name              string
@@ -196,6 +197,7 @@ func (raw *TaskRaw) ToTask() *Task {
 		Type:              raw.Type,
 		Payload:           raw.Payload,
 		EarliestAllowedTs: raw.EarliestAllowedTs,
+		BlockedBy:         raw.BlockedBy,
 	}
 	for _, taskRunRaw := range raw.TaskRunRawList {
 		task.TaskRunList = append(task.TaskRunList, taskRunRaw.ToTaskRun())
@@ -229,6 +231,7 @@ type Task struct {
 	Database         *Database       `jsonapi:"relation,database"`
 	TaskRunList      []*TaskRun      `jsonapi:"relation,taskRun"`
 	TaskCheckRunList []*TaskCheckRun `jsonapi:"relation,taskCheckRun"`
+	BlockedBy        []*Task         `jsonapi:"relation,blockedBy"`
 
 	// Domain specific fields
 	Name              string     `jsonapi:"attr,name"`
@@ -262,6 +265,7 @@ func (task *Task) ToRaw() *TaskRaw {
 		Type:              task.Type,
 		Payload:           task.Payload,
 		EarliestAllowedTs: task.EarliestAllowedTs,
+		BlockedBy:         task.BlockedBy,
 	}
 }
 

--- a/api/task.go
+++ b/api/task.go
@@ -169,9 +169,7 @@ type TaskRaw struct {
 	Type              TaskType
 	Payload           string
 	EarliestAllowedTs int64
-	// BlockedBy is an array of Task ID.
-	// We use string here to workaround jsonapi limitations. https://github.com/google/jsonapi/issues/209
-	BlockedBy []string
+	BlockedBy         []string
 }
 
 // ToTask creates an instance of Task based on the TaskRaw.
@@ -240,7 +238,9 @@ type Task struct {
 	Type              TaskType   `jsonapi:"attr,type"`
 	Payload           string     `jsonapi:"attr,payload"`
 	EarliestAllowedTs int64      `jsonapi:"attr,earliestAllowedTs"`
-	BlockedBy         []string   `jsonapi:"attr,blockedBy"`
+	// BlockedBy is an array of Task ID.
+	// We use string here to workaround jsonapi limitations. https://github.com/google/jsonapi/issues/209
+	BlockedBy []string `jsonapi:"attr,blockedBy"`
 }
 
 // ToRaw converts a Task to TaskRaw.

--- a/api/task.go
+++ b/api/task.go
@@ -169,7 +169,9 @@ type TaskRaw struct {
 	Type              TaskType
 	Payload           string
 	EarliestAllowedTs int64
-	BlockedBy         []string
+	// BlockedBy is an array of Task ID.
+	// We use string here to workaround jsonapi limitations. https://github.com/google/jsonapi/issues/209
+	BlockedBy []string
 }
 
 // ToTask creates an instance of Task based on the TaskRaw.

--- a/api/task.go
+++ b/api/task.go
@@ -162,7 +162,6 @@ type TaskRaw struct {
 	DatabaseID          *int
 	TaskRunRawList      []*TaskRunRaw
 	TaskCheckRunRawList []*TaskCheckRunRaw
-	BlockedBy           []*Task
 
 	// Domain specific fields
 	Name              string
@@ -170,6 +169,7 @@ type TaskRaw struct {
 	Type              TaskType
 	Payload           string
 	EarliestAllowedTs int64
+	BlockedBy         []string
 }
 
 // ToTask creates an instance of Task based on the TaskRaw.
@@ -231,7 +231,6 @@ type Task struct {
 	Database         *Database       `jsonapi:"relation,database"`
 	TaskRunList      []*TaskRun      `jsonapi:"relation,taskRun"`
 	TaskCheckRunList []*TaskCheckRun `jsonapi:"relation,taskCheckRun"`
-	BlockedBy        []*Task         `jsonapi:"relation,blockedBy"`
 
 	// Domain specific fields
 	Name              string     `jsonapi:"attr,name"`
@@ -239,6 +238,7 @@ type Task struct {
 	Type              TaskType   `jsonapi:"attr,type"`
 	Payload           string     `jsonapi:"attr,payload"`
 	EarliestAllowedTs int64      `jsonapi:"attr,earliestAllowedTs"`
+	BlockedBy         []string   `jsonapi:"attr,blockedBy"`
 }
 
 // ToRaw converts a Task to TaskRaw.

--- a/server/task.go
+++ b/server/task.go
@@ -458,17 +458,13 @@ func (s *Server) composeTaskRelationship(ctx context.Context, raw *api.TaskRaw) 
 		taskCheckRun.Updater = updater
 	}
 
-	blockedBy := []*api.Task{}
+	blockedBy := []string{}
 	taskDAGList, err := s.store.FindTaskDAGList(ctx, &api.TaskDAGFind{FromTaskID: raw.ID})
 	if err != nil {
 		return nil, err
 	}
 	for _, taskDAG := range taskDAGList {
-		task, err := s.TaskService.FindTask(ctx, &api.TaskFind{ID: &taskDAG.ToTaskID})
-		if err != nil {
-			return nil, err
-		}
-		blockedBy = append(blockedBy, task.ToTask())
+		blockedBy = append(blockedBy, strconv.Itoa(taskDAG.ToTaskID))
 	}
 	task.BlockedBy = blockedBy
 


### PR DESCRIPTION
In https://github.com/bytebase/bytebase/pull/1051, the type of`BlockedBy` is `[]int`, which is enough but is unfortunately not supported by jsonapi (https://github.com/google/jsonapi/issues/209). So in this PR, I change the type to `[]*Task`.