### PR TITLE
feat: find sheet with `PrincipalID`

### DIFF
--- a/api/sheet.go
+++ b/api/sheet.go
@@ -215,12 +215,10 @@ type SheetFind struct {
 
 	// Standard fields
 	RowStatus *RowStatus
-	// Value is assigned from the jwt subject field passed by the client.
 	CreatorID *int
 
 	// Related fields
-	ProjectID *int
-	// Query all related sheets with databaseId can be used for database transfer checking.
+	ProjectID  *int
 	DatabaseID *int
 
 	// Domain fields
@@ -229,6 +227,8 @@ type SheetFind struct {
 	Source     *SheetSource
 	Type       *SheetType
 	Payload    *string
+	// If present, will only find sheet which related project containing PrincipalID as an active member.
+	PrincipalID *int
 }
 
 func (find *SheetFind) String() string {

--- a/server/sheet.go
+++ b/server/sheet.go
@@ -312,7 +312,7 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 		}
 		// When getting private/project sheet list, we should set the PrincipalID to ensure only
 		// the sheet which related project containing PrincipalID as an active member could be found.
-		if sheetFind.Visibility != nil && *sheetFind.Visibility != api.PublicSheet {
+		if sheetFind.Visibility != nil && (*sheetFind.Visibility == api.PrivateSheet || *sheetFind.Visibility == api.ProjectSheet) {
 			principalID := c.Get(getPrincipalIDContextKey()).(int)
 			sheetFind.PrincipalID = &principalID
 		}

--- a/server/sheet.go
+++ b/server/sheet.go
@@ -281,14 +281,11 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 	g.GET("/sheet", func(c echo.Context) error {
 		ctx := context.Background()
 		sheetFind := &api.SheetFind{}
-		creatorID := c.Get(getPrincipalIDContextKey()).(int)
-		sheetFind.CreatorID = &creatorID
 
-		if rowStatusStr := c.QueryParam("rowstatus"); rowStatusStr != "" {
+		if rowStatusStr := c.QueryParam("rowStatus"); rowStatusStr != "" {
 			rowStatus := api.RowStatus(rowStatusStr)
 			sheetFind.RowStatus = &rowStatus
 		}
-
 		if projectIDStr := c.QueryParam("projectId"); projectIDStr != "" {
 			projectID, err := strconv.Atoi(projectIDStr)
 			if err != nil {
@@ -296,7 +293,6 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 			}
 			sheetFind.ProjectID = &projectID
 		}
-
 		if databaseIDStr := c.QueryParam("databaseId"); databaseIDStr != "" {
 			databaseID, err := strconv.Atoi(databaseIDStr)
 			if err != nil {
@@ -304,9 +300,21 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 			}
 			sheetFind.DatabaseID = &databaseID
 		}
-
 		if visibility := api.SheetVisibility(c.QueryParam("visibility")); visibility != "" {
 			sheetFind.Visibility = &visibility
+		}
+		if creatorIDStr := c.QueryParam("creatorId"); creatorIDStr != "" {
+			creatorID, err := strconv.Atoi(creatorIDStr)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("creatorID ID is not a number: %s", c.QueryParam("creatorId"))).SetInternal(err)
+			}
+			sheetFind.CreatorID = &creatorID
+		}
+		// When getting private/project sheet list, we should set the PrincipalID to ensure only
+		// the sheet which related project containing PrincipalID as an active member could be found.
+		if sheetFind.Visibility != nil && *sheetFind.Visibility != api.PublicSheet {
+			principalID := c.Get(getPrincipalIDContextKey()).(int)
+			sheetFind.PrincipalID = &principalID
 		}
 
 		sheetRawList, err := s.SheetService.FindSheetList(ctx, sheetFind)

--- a/store/demo/dev/10220__sheet.sql
+++ b/store/demo/dev/10220__sheet.sql
@@ -7,9 +7,7 @@ INSERT INTO
         project_id,
         database_id,
         name,
-        statement,
-        source,
-        type
+        statement
     )
 VALUES
     (
@@ -18,10 +16,69 @@ VALUES
         101,
         3001,
         7019,
-        'my-sheet',
-        'SELECT * FROM demo',
-        'BYTEBASE',
-        'SQL'
+        'demo data',
+        'SELECT * FROM demo'
     );
 
-ALTER SEQUENCE sheet_id_seq RESTART WITH 22002;
+INSERT INTO
+    sheet (
+        id,
+        creator_id,
+        updater_id,
+        project_id,
+        name,
+        statement
+    )
+VALUES
+    (
+        22002,
+        101,
+        101,
+        3002,
+        'all employee',
+        'SELECT * FROM employee'
+    );
+
+INSERT INTO
+    sheet (
+        id,
+        creator_id,
+        updater_id,
+        project_id,
+        name,
+        statement,
+        visibility
+    )
+VALUES
+    (
+        22003,
+        102,
+        102,
+        3002,
+        'shared employee with project',
+        'SELECT * FROM employee',
+        'PROJECT'
+    );
+
+INSERT INTO
+    sheet (
+        id,
+        creator_id,
+        updater_id,
+        project_id,
+        name,
+        statement,
+        visibility
+    )
+VALUES
+    (
+        22004,
+        103,
+        103,
+        3003,
+        'shared all employee',
+        'SELECT * FROM employee',
+        'PUBLIC'
+    );
+
+ALTER SEQUENCE sheet_id_seq RESTART WITH 22005;

--- a/store/demo/dev/10220__sheet.sql
+++ b/store/demo/dev/10220__sheet.sql
@@ -1,4 +1,3 @@
--- Sheet for principal 101 "Demo Owner"
 INSERT INTO
     sheet (
         id,
@@ -7,7 +6,8 @@ INSERT INTO
         project_id,
         database_id,
         name,
-        statement
+        statement,
+        visibility
     )
 VALUES
     (
@@ -16,27 +16,32 @@ VALUES
         101,
         3001,
         7019,
-        'demo data',
-        'SELECT * FROM demo'
+        'My test cases',
+        'SELECT * FROM test_case',
+        'PRIVATE'
     );
 
 INSERT INTO
     sheet (
         id,
+        row_status,
         creator_id,
         updater_id,
         project_id,
         name,
-        statement
+        statement,
+        visibility
     )
 VALUES
     (
         22002,
+        'ARCHIVED',
         101,
         101,
         3002,
-        'all employee',
-        'SELECT * FROM employee'
+        'My starred items',
+        'SELECT * FROM item WHERE starred=true',
+        'PRIVATE'
     );
 
 INSERT INTO
@@ -55,8 +60,8 @@ VALUES
         102,
         102,
         3002,
-        'shared employee with project',
-        'SELECT * FROM employee',
+        'All coupon of our shop',
+        'SELECT * FROM coupon WHERE shop_id=101',
         'PROJECT'
     );
 
@@ -76,8 +81,8 @@ VALUES
         103,
         103,
         3003,
-        'shared all employee',
-        'SELECT * FROM employee',
+        'All blogs from Alex',
+        'SELECT * FROM blog WHERE author="Alex"',
         'PUBLIC'
     );
 

--- a/store/sheet.go
+++ b/store/sheet.go
@@ -388,6 +388,9 @@ func findSheetList(ctx context.Context, tx *sql.Tx, find *api.SheetFind, mode co
 	if v := find.Visibility; v != nil {
 		where, args = append(where, fmt.Sprintf("visibility = $%d", len(args)+1)), append(args, *v)
 	}
+	if v := find.PrincipalID; v != nil {
+		where, args = append(where, fmt.Sprintf("project_id IN (SELECT project_id FROM project_member WHERE principal_id = $%d)", len(args)+1)), append(args, *v)
+	}
 	if mode == common.ReleaseModeDev {
 		if v := find.Source; v != nil {
 			where, args = append(where, fmt.Sprintf("source = $%d", len(args)+1)), append(args, *v)


### PR DESCRIPTION
* Add `PrincipalID` to make sure that we only find private/project sheets which related project containing PrincipalID as an active member;
* Make `CreatorID` optional to find public sheets.