### PR TITLE
fix: handle gitlab error case

### DIFF
--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -207,6 +207,7 @@ func tokenRefresher(oauthCtx oauthContext, refresher common.TokenRefresher) oaut
 		if err != nil {
 			return errors.Wrapf(err, "read body of POST %s", url)
 		}
+		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			return errors.Errorf("non-200 status code %d with body %q", resp.StatusCode, body)

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -225,7 +225,7 @@ type oauthResponse struct {
 	ErrorDescription string `json:"error_description,omitempty"`
 }
 
-// transform to *vcs.OAuthToken
+// convert to *vcs.OAuthToken
 func (o oauthResponse) toVCSOAuthToken() *vcs.OAuthToken {
 	return &vcs.OAuthToken{
 		AccessToken:  o.AccessToken,


### PR DESCRIPTION
If the address of the host is not the same as the one actually filled in, the error here is not caught and the token actually fails to be fetched, the gitlab returned error is as follows :
```json
{
     "error": "invalid_grant",
     "error_description": "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
}
```

This PR  catches such errors. 
Fixed a few bugs in passing, `http.Response.Body` forget `Close()`