### PR TITLE
fix: all project description typo

### DIFF
--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -1168,7 +1168,7 @@ datasource:
   jdbc-cant-connect-to-socket-database-value-instance-host: "JDBC can't connect to socket {0} "
 setting:
   project:
-    description: This is the Admin project panel listting all projects in Bytebase.
+    description: This is the Admin project panel listing all projects in Bytebase.
   label:
     key: Key
     values: Values


### PR DESCRIPTION
Fix typo: `listting` to `listing`.