### PR TITLE
feat: show the schema review in the env page

### DIFF
--- a/frontend/src/components/EnvironmentForm.vue
+++ b/frontend/src/components/EnvironmentForm.vue
@@ -132,7 +132,7 @@
         <label class="textlabel">
           {{ $t("schema-review-policy.title") }}
         </label>
-        <div class="mt-4">
+        <div class="mt-3">
           <button
             v-if="schemaReviewPolicy"
             type="button"

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -411,9 +411,11 @@ const routes: Array<RouteRecordRaw> = [
                 meta: {
                   title: (route: RouteLocationNormalized) => {
                     const slug = route.params.schemaReviewPolicySlug as string;
-                    return useSchemaSystemStore().getReviewPolicyByEnvironmentId(
-                      idFromSlug(slug)
-                    ).name;
+                    return (
+                      useSchemaSystemStore().getReviewPolicyByEnvironmentId(
+                        idFromSlug(slug)
+                      )?.name ?? ""
+                    );
                   },
                 },
                 component: () =>

--- a/frontend/src/store/modules/schemaSystem.ts
+++ b/frontend/src/store/modules/schemaSystem.ts
@@ -23,6 +23,10 @@ const convertToSchemaReviewPolicy = (
     return;
   }
   const payload = policy.payload as SchemaReviewPolicyPayload;
+  if (!Array.isArray(payload.ruleList) || !payload.name) {
+    return;
+  }
+
   const ruleList = payload.ruleList.map((r) => {
     const rule: SchemaPolicyRule = {
       type: r.type,
@@ -194,14 +198,13 @@ export const useSchemaSystemStore = defineStore("schemaSystem", {
     },
     getReviewPolicyByEnvironmentId(
       environmentId: EnvironmentId
-    ): DatabaseSchemaReviewPolicy {
+    ): DatabaseSchemaReviewPolicy | undefined {
       if (environmentId === EMPTY_ID) {
         return empty("SCHEMA_REVIEW") as DatabaseSchemaReviewPolicy;
       }
 
-      return (
-        this.reviewPolicyList.find((g) => g.environment.id === environmentId) ||
-        (unknown("SCHEMA_REVIEW") as DatabaseSchemaReviewPolicy)
+      return this.reviewPolicyList.find(
+        (g) => g.environment.id === environmentId
       );
     },
 
@@ -230,6 +233,9 @@ export const useSchemaSystemStore = defineStore("schemaSystem", {
         type: "bb.policy.schema-review",
       });
 
+      if (!policy) {
+        return;
+      }
       const reviewPolicy = convertToSchemaReviewPolicy(policy);
       if (reviewPolicy) {
         this.setReviewPolicy(reviewPolicy);

--- a/frontend/src/views/SettingWorkspaceSchemaReview.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReview.vue
@@ -34,7 +34,7 @@ import {
   useCurrentUser,
 } from "@/store";
 import { DatabaseSchemaReviewPolicy } from "@/types/schemaSystem";
-import { schemaReviewPolicySlug, isOwner, isDBA } from "@/utils";
+import { schemaReviewPolicySlug, isDBAOrOwner } from "@/utils";
 
 const router = useRouter();
 const store = useSchemaSystemStore();
@@ -47,7 +47,7 @@ watchEffect(() => {
 });
 
 const hasPermission = computed(() => {
-  return isOwner(currentUser.value.role) || isDBA(currentUser.value.role);
+  return isDBAOrOwner(currentUser.value.role);
 });
 
 const goToCreationView = () => {

--- a/frontend/src/views/SettingWorkspaceSchemaReviewCreate.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewCreate.vue
@@ -1,5 +1,24 @@
 <template>
   <div class="my-4 space-y-4 divide-y divide-block-border">
-    <SchemaReviewCreation :selected-rule-list="[]" />
+    <SchemaReviewCreation
+      :selected-rule-list="[]"
+      :selected-environment="environment"
+    />
   </div>
 </template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useEnvironmentStore } from "@/store";
+
+const url = new URL(window.location.href);
+const params = new URLSearchParams(url.search);
+const environmentId = params.get("environmentId") ?? "";
+
+const environment = computed(() => {
+  if (Number.isNaN(environmentId)) {
+    return;
+  }
+  return useEnvironmentStore().getEnvironmentById(parseInt(environmentId, 10));
+});
+</script>

--- a/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
@@ -162,8 +162,9 @@
 import { computed, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
-import { idFromSlug, environmentName, isOwner, isDBA } from "@/utils";
+import { idFromSlug, environmentName, isDBAOrOwner } from "@/utils";
 import {
+  unknown,
   RuleType,
   LEVEL_LIST,
   RuleLevel,
@@ -213,12 +214,14 @@ const state = reactive<LocalState>({
 });
 
 const hasPermission = computed(() => {
-  return isOwner(currentUser.value.role) || isDBA(currentUser.value.role);
+  return isDBAOrOwner(currentUser.value.role);
 });
 
 const reviewPolicy = computed((): DatabaseSchemaReviewPolicy => {
-  return store.getReviewPolicyByEnvironmentId(
-    idFromSlug(props.schemaReviewPolicySlug)
+  return (
+    store.getReviewPolicyByEnvironmentId(
+      idFromSlug(props.schemaReviewPolicySlug)
+    ) || (unknown("SCHEMA_REVIEW") as DatabaseSchemaReviewPolicy)
   );
 });
 


### PR DESCRIPTION
**Users can redirect to the schema review detail page from the environment page**

![CleanShot 2022-04-26 at 15 14 53](https://user-images.githubusercontent.com/10706318/165243965-f1f3860b-9763-496e-8cd2-c4322a97be63.gif)


**If the environment doesn't have the schema review policy:**

- If the user has permission (is owner or DBA), he can redirect to the creation page with the selected environment:
![CleanShot 2022-04-26 at 15 17 15](https://user-images.githubusercontent.com/10706318/165244233-0da20e21-e480-4ff4-bbdc-e5f48cf6a3d4.gif)

- Otherwise just show the "no schema review policy" label:
![CleanShot 2022-04-26 at 15 17 54](https://user-images.githubusercontent.com/10706318/165244343-5bdda509-4393-480f-a785-3eb1dd891fa9.gif)

Note:
Add the `isDev` check. This feature is not available for users yet.
