### PR TITLE
fix: highlight navbar items for nested routes

### DIFF
--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -16,29 +16,42 @@
             v-if="showDBAItem"
             to="/issue"
             class="bar-link px-2 py-2 rounded-md"
+            :class="getRouteLinkClass('/issue')"
             >{{ $t("common.issues") }}</router-link
           >
 
-          <router-link to="/project" class="bar-link px-2 py-2 rounded-md">
+          <router-link
+            to="/project"
+            class="bar-link px-2 py-2 rounded-md"
+            :class="getRouteLinkClass('/project')"
+          >
             {{ $t("common.projects") }}
           </router-link>
 
-          <router-link to="/db" class="bar-link px-2 py-2 rounded-md">{{
-            $t("common.databases")
-          }}</router-link>
+          <router-link
+            to="/db"
+            class="bar-link px-2 py-2 rounded-md"
+            :class="getRouteLinkClass('/db')"
+            >{{ $t("common.databases") }}</router-link
+          >
 
-          <router-link to="/instance" class="bar-link px-2 py-2 rounded-md">{{
-            $t("common.instances")
-          }}</router-link>
+          <router-link
+            to="/instance"
+            class="bar-link px-2 py-2 rounded-md"
+            :class="getRouteLinkClass('/instance')"
+            >{{ $t("common.instances") }}</router-link
+          >
 
           <router-link
             to="/environment"
             class="bar-link px-2 py-2 rounded-md"
+            :class="getRouteLinkClass('/environment')"
             >{{ $t("common.environments") }}</router-link
           >
           <router-link
             to="/setting/member"
             class="bar-link px-2 py-2 rounded-md"
+            :class="getRouteLinkClass('/setting')"
             >{{ $t("common.settings") }}</router-link
           >
         </div>
@@ -190,7 +203,7 @@
 <script lang="ts">
 import { defineAction, useRegisterActions } from "@bytebase/vue-kbar";
 import { computed, reactive, watchEffect, defineComponent } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 
 import ProfileDropdown from "../components/ProfileDropdown.vue";
@@ -221,6 +234,7 @@ export default defineComponent({
     const settingStore = useSettingStore();
     const subscriptionStore = useSubscriptionStore();
     const router = useRouter();
+    const route = useRoute();
     const { setLocale, toggleLocales } = useLanguage();
 
     const state = reactive<LocalState>({
@@ -230,6 +244,16 @@ export default defineComponent({
     const currentUser = useCurrentUser();
 
     const { currentPlan } = storeToRefs(subscriptionStore);
+
+    const getRouteLinkClass = (prefix: string): string[] => {
+      const { path } = route;
+      const isActiveRoute = path === prefix || path.startsWith(`${prefix}/`);
+      const classes: string[] = [];
+      if (isActiveRoute) {
+        classes.push("router-link-active", "bg-link-hover");
+      }
+      return classes;
+    };
 
     const showDBAItem = computed((): boolean => {
       return isDBAOrOwner(currentUser.value.role);
@@ -382,6 +406,7 @@ export default defineComponent({
 
     return {
       state,
+      getRouteLinkClass,
       logoUrl,
       currentUser,
       currentPlan,


### PR DESCRIPTION
We have highlight for navbar items.
![image](https://user-images.githubusercontent.com/2749742/165696955-949e9309-bee3-4ff3-a5bb-e51809ce08f8.png)
But it failed when diving into nested routes.
![image](https://user-images.githubusercontent.com/2749742/165697060-b41ee9d5-365d-47dc-ba49-60d28468c8e0.png)
And this PR will fix
![image](https://user-images.githubusercontent.com/2749742/165697096-6d530e7f-9f3a-425f-8c43-8ef1e569373d.png)

P.S. this is a very ugly workaround fix. Since if we want to fix it gracefully, we may need a dangerous refactor to our router structure definitions.