### PR TITLE
chore: add backward compatibility to schema review policy

### DIFF
--- a/api/plan.go
+++ b/api/plan.go
@@ -37,6 +37,7 @@ const (
 	// See https://bytebase.com/docs/features/sql-advisor/backward-compatibility-migration-check
 	//
 	// Currently, we only support MySQL/TiDB thanks to github.com/pingcap/parser
+	// TODO(ed): remove this after TaskCheckDatabaseStatementCompatibility is entirely moved into schema review policy
 	FeatureBackwardCompatibility FeatureType = "bb.feature.backward-compatibility"
 	// FeatureSchemaDrift detects if there occurs schema drift.
 	// See https://bytebase.com/docs/features/drift-detection

--- a/api/schema_system.go
+++ b/api/schema_system.go
@@ -44,6 +44,9 @@ const (
 	SchemaRuleRequiredColumn SchemaReviewRuleType = "column.required"
 	// SchemaRuleColumnNotNull enforce the columns cannot have NULL value.
 	SchemaRuleColumnNotNull SchemaReviewRuleType = "column.no-null"
+
+	// SchemaRuleSchemaBackwardCompatibility enforce the MySQL and TiDB support check whether the schema change is backward compatible.
+	SchemaRuleSchemaBackwardCompatibility SchemaReviewRuleType = "schema.backward-compatibility"
 )
 
 // SchemaReviewPolicy is the policy configuration for schema review.

--- a/server/server.go
+++ b/server/server.go
@@ -143,6 +143,7 @@ func NewServer(logger *zap.Logger, storeInstance *store.Store, loggerLevel *zap.
 		statementSimpleExecutor := NewTaskCheckStatementAdvisorSimpleExecutor(logger)
 		taskCheckScheduler.Register(string(api.TaskCheckDatabaseStatementFakeAdvise), statementSimpleExecutor)
 		taskCheckScheduler.Register(string(api.TaskCheckDatabaseStatementSyntax), statementSimpleExecutor)
+		// TODO(ed): remove this after TaskCheckDatabaseStatementCompatibility is entirely moved into schema review policy
 		taskCheckScheduler.Register(string(api.TaskCheckDatabaseStatementCompatibility), statementSimpleExecutor)
 
 		statementCompositeExecutor := NewTaskCheckStatementAdvisorCompositeExecutor(logger)

--- a/server/task.go
+++ b/server/task.go
@@ -611,14 +611,13 @@ func (s *Server) triggerDatabaseStatementAdviseTask(ctx context.Context, stateme
 		return fmt.Errorf("failed to marshal statement advise payload: %v, err: %w", task.Name, err)
 	}
 
-	_, err = s.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+	if _, err := s.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 		CreatorID:               api.SystemBotID,
 		TaskID:                  task.ID,
 		Type:                    api.TaskCheckDatabaseStatementAdvise,
 		Payload:                 string(payload),
 		SkipIfAlreadyTerminated: false,
-	})
-	if err != nil {
+	}); err != nil {
 		// It's OK if we failed to trigger a check, just emit an error log
 		s.l.Error("Failed to trigger compatibility check after changing task statement",
 			zap.Int("task_id", task.ID),

--- a/server/task.go
+++ b/server/task.go
@@ -619,7 +619,7 @@ func (s *Server) triggerDatabaseStatementAdviseTask(ctx context.Context, stateme
 		SkipIfAlreadyTerminated: false,
 	}); err != nil {
 		// It's OK if we failed to trigger a check, just emit an error log
-		s.l.Error("Failed to trigger compatibility check after changing task statement",
+		s.l.Error("Failed to trigger statement advise task after changing task statement",
 			zap.Int("task_id", task.ID),
 			zap.String("task_name", task.Name),
 			zap.Error(err),

--- a/server/task.go
+++ b/server/task.go
@@ -213,6 +213,12 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 							)
 						}
 					}
+
+					if s.feature(api.FeatureSchemaReviewPolicy) {
+						if err := s.triggerDatabaseStatementAdviseTask(ctx, *taskPatch.Statement, taskPatched); err != nil {
+							return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to trigger database statement advise task, err: %w", err)).SetInternal(err)
+						}
+					}
 				}
 			}
 
@@ -578,4 +584,48 @@ func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, 
 	}
 
 	return taskPatched, nil
+}
+
+func (s *Server) triggerDatabaseStatementAdviseTask(ctx context.Context, statement string, task *api.Task) error {
+	policyID, err := s.store.GetSchemaReviewPolicyIDByEnvID(ctx, task.Instance.EnvironmentID)
+
+	if err != nil {
+		// It's OK if we failed to find the schema review policy, just emit an error log
+		s.l.Error("Failed to found schema review policy id for task",
+			zap.Int("task_id", task.ID),
+			zap.String("task_name", task.Name),
+			zap.Int("environment_id", task.Instance.EnvironmentID),
+			zap.Error(err),
+		)
+		return nil
+	}
+
+	payload, err := json.Marshal(api.TaskCheckDatabaseStatementAdvisePayload{
+		Statement: statement,
+		DbType:    task.Database.Instance.Engine,
+		Charset:   task.Database.CharacterSet,
+		Collation: task.Database.Collation,
+		PolicyID:  policyID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal statement advise payload: %v, err: %w", task.Name, err)
+	}
+
+	_, err = s.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+		CreatorID:               api.SystemBotID,
+		TaskID:                  task.ID,
+		Type:                    api.TaskCheckDatabaseStatementAdvise,
+		Payload:                 string(payload),
+		SkipIfAlreadyTerminated: false,
+	})
+	if err != nil {
+		// It's OK if we failed to trigger a check, just emit an error log
+		s.l.Error("Failed to trigger compatibility check after changing task statement",
+			zap.Int("task_id", task.ID),
+			zap.String("task_name", task.Name),
+			zap.Error(err),
+		)
+	}
+
+	return nil
 }

--- a/server/task_check_executor_statement_advisor_composite.go
+++ b/server/task_check_executor_statement_advisor_composite.go
@@ -118,7 +118,11 @@ func getAdvisorTypeByRule(ruleType api.SchemaReviewRuleType, engine db.Type) (ad
 		case db.MySQL, db.TiDB:
 			return advisor.MySQLWhereRequirement, nil
 		}
-		return advisor.Fake, fmt.Errorf("unknown schema review rule type %v for %v", ruleType, engine)
+	case api.SchemaRuleSchemaBackwardCompatibility:
+		switch engine {
+		case db.MySQL, db.TiDB:
+			return advisor.MySQLMigrationCompatibility, nil
+		}
 	}
 	return advisor.Fake, fmt.Errorf("unknown schema review rule type %v for %v", ruleType, engine)
 }

--- a/server/task_check_executor_statement_advisor_simple.go
+++ b/server/task_check_executor_statement_advisor_simple.go
@@ -32,6 +32,7 @@ func (exec *TaskCheckStatementAdvisorSimpleExecutor) Run(ctx context.Context, se
 	case api.TaskCheckDatabaseStatementSyntax:
 		advisorType = advisor.MySQLSyntax
 	case api.TaskCheckDatabaseStatementCompatibility:
+		// TODO(ed): remove this after TaskCheckDatabaseStatementCompatibility is entirely moved into schema review policy
 		if !server.feature(api.FeatureBackwardCompatibility) {
 			return nil, common.Errorf(common.NotAuthorized, fmt.Errorf(api.FeatureBackwardCompatibility.AccessErrorMessage()))
 		}

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -316,6 +316,7 @@ func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *ap
 				return nil, err
 			}
 
+			// TODO(ed): remove this after TaskCheckDatabaseStatementCompatibility is entirely moved into schema review policy
 			if s.server.feature(api.FeatureBackwardCompatibility) {
 				_, err = s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 					CreatorID:               creatorID,

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -282,8 +282,19 @@ func (s *TaskScheduler) ScheduleIfNeeded(ctx context.Context, task *api.Task) (*
 				return task, nil
 			}
 
+			// TODO(ed): remove this after TaskCheckDatabaseStatementCompatibility is entirely moved into schema review policy
 			if s.server.feature(api.FeatureBackwardCompatibility) {
 				pass, err = s.server.passCheck(ctx, s.server, task, api.TaskCheckDatabaseStatementCompatibility)
+				if err != nil {
+					return nil, err
+				}
+				if !pass {
+					return task, nil
+				}
+			}
+
+			if s.server.feature(api.FeatureSchemaReviewPolicy) {
+				pass, err = s.server.passCheck(ctx, s.server, task, api.TaskCheckDatabaseStatementAdvise)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Next step, we need to remove the existed code for `api.TaskCheckDatabaseStatementCompatibility` after we initial the schema review policy for users' environments.