### PR TITLE
refactor(frontend): fetch label list globally

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
@@ -88,22 +88,22 @@
 /* eslint-disable vue/no-mutating-props */
 
 import { computed, watchEffect, watch, ref } from "vue";
-
-import {
+import { NCollapse, NCollapseItem } from "naive-ui";
+import { groupBy } from "lodash-es";
+import type {
   Database,
   DatabaseId,
   Environment,
   LabelKeyType,
   Project,
-  UNKNOWN_ID,
-} from "../../types";
-import { NCollapse, NCollapseItem } from "naive-ui";
-import { groupBy } from "lodash-es";
+} from "@/types";
+import { UNKNOWN_ID } from "@/types";
 import { DeployDatabaseTable } from "../TenantDatabaseTable";
-import { parseDatabaseNameByTemplate } from "../../utils";
-import { getPipelineFromDeploymentSchedule } from "../../utils";
-import { useDeploymentStore, useLabelStore } from "@/store";
-import { storeToRefs } from "pinia";
+import {
+  parseDatabaseNameByTemplate,
+  getPipelineFromDeploymentSchedule,
+} from "@/utils";
+import { useDeploymentStore, useLabelList } from "@/store";
 
 export type State = {
   selectedDatabaseName: string | undefined;
@@ -122,10 +122,8 @@ defineEmits<{
 }>();
 
 const deploymentStore = useDeploymentStore();
-const labelStore = useLabelStore();
 
 const fetchData = () => {
-  labelStore.fetchLabelList();
   if (props.project) {
     deploymentStore.fetchDeploymentConfigByProjectId(props.project.id);
   }
@@ -134,7 +132,7 @@ const fetchData = () => {
 watchEffect(fetchData);
 
 const label = ref<LabelKeyType>("bb.environment");
-const { labelList } = storeToRefs(labelStore);
+const labelList = useLabelList();
 
 const deployment = computed(() => {
   if (props.project) {

--- a/frontend/src/components/CreateDatabasePrepForm/DatabaseLabelForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm/DatabaseLabelForm.vue
@@ -28,23 +28,23 @@
 <script lang="ts" setup>
 /* eslint-disable vue/no-mutating-props */
 
-import { useLabelStore } from "@/store";
 import { capitalize } from "lodash-es";
-import { computed, watchEffect } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import {
+import type {
   DatabaseLabel,
   Label,
   LabelKeyType,
   LabelValueType,
   Project,
-} from "../../types";
+} from "@/types";
 import {
   isReservedLabel,
   parseLabelListInTemplate,
   hidePrefix,
   validateLabelsWithTemplate,
-} from "../../utils";
+} from "@/utils";
+import { useLabelList } from "@/store";
 
 const props = defineProps<{
   project: Project;
@@ -52,22 +52,16 @@ const props = defineProps<{
   filter: "required" | "optional";
 }>();
 
-const labelStore = useLabelStore();
+const allLabelList = useLabelList();
 const { t } = useI18n();
-
-const prepare = () => {
-  labelStore.fetchLabelList();
-};
-watchEffect(prepare);
 
 const isDbNameTemplateMode = computed((): boolean => {
   return !!props.project.dbNameTemplate;
 });
 
 const availableLabelList = computed(() => {
-  const allLabelList = labelStore.labelList;
   // ignore reserved labels (e.g. bb.environment)
-  return allLabelList.filter((label) => !isReservedLabel(label));
+  return allLabelList.value.filter((label) => !isReservedLabel(label));
 });
 
 const requiredLabelDict = computed((): Set<LabelKeyType> => {

--- a/frontend/src/components/DatabaseLabels/DatabaseLabelProps.vue
+++ b/frontend/src/components/DatabaseLabels/DatabaseLabelProps.vue
@@ -16,16 +16,16 @@
 </template>
 
 <script lang="ts" setup>
-import { useLabelStore } from "@/store";
 import { cloneDeep } from "lodash-es";
-import { computed, withDefaults, watch, watchEffect, reactive } from "vue";
-import {
+import { computed, withDefaults, watch, reactive } from "vue";
+import type {
   Database,
   DatabaseLabel,
   LabelKeyType,
   LabelValueType,
-} from "../../types";
-import { isReservedLabel, parseLabelListInTemplate } from "../../utils";
+} from "@/types";
+import { isReservedLabel, parseLabelListInTemplate } from "@/utils";
+import { useLabelList } from "@/store";
 import DatabaseLabelPropItem from "./DatabaseLabelPropItem.vue";
 
 const props = withDefaults(
@@ -47,12 +47,7 @@ const state = reactive({
   labelList: cloneDeep(props.labelList),
 });
 
-const labelStore = useLabelStore();
-
-const prepareLabelList = () => {
-  labelStore.fetchLabelList();
-};
-watchEffect(prepareLabelList);
+const allLabelList = useLabelList();
 
 watch(
   () => props.labelList,
@@ -60,8 +55,7 @@ watch(
 );
 
 const availableLabelList = computed(() => {
-  const allList = labelStore.labelList;
-  return allList.filter((label) => !isReservedLabel(label));
+  return allLabelList.value.filter((label) => !isReservedLabel(label));
 });
 
 const requiredLabelList = computed(() => {

--- a/frontend/src/components/DatabaseLabels/DatabaseLabels.vue
+++ b/frontend/src/components/DatabaseLabels/DatabaseLabels.vue
@@ -35,12 +35,11 @@
 <script lang="ts">
 /* eslint-disable vue/no-mutating-props */
 
-import { computed, defineComponent, PropType, watchEffect } from "vue";
-import { DatabaseLabel } from "../../types";
+import { computed, defineComponent, PropType } from "vue";
 import { NPopover } from "naive-ui";
-import { isReservedLabel, isReservedDatabaseLabel } from "../../utils";
-import { useLabelStore } from "@/store";
-import { storeToRefs } from "pinia";
+import type { DatabaseLabel } from "@/types";
+import { isReservedLabel, isReservedDatabaseLabel } from "@/utils";
+import { useLabelList } from "@/store";
 
 const MAX_DATABASE_LABEL_COUNT = 4;
 
@@ -58,20 +57,11 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const labelStore = useLabelStore();
-
     const allowAdd = computed(
       () => props.labelList.length < MAX_DATABASE_LABEL_COUNT
     );
 
-    const prepareLabelList = () => {
-      // need not to fetchLabelList if not editable
-      if (!props.editable) return;
-      labelStore.fetchLabelList();
-    };
-    watchEffect(prepareLabelList);
-
-    const { labelList } = storeToRefs(labelStore);
+    const labelList = useLabelList();
 
     const availableLabelList = computed(() =>
       labelList.value.filter((label) => !isReservedLabel(label))

--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -10,31 +10,29 @@
 <script lang="ts">
 import { computed, defineComponent, watchEffect } from "vue";
 import { cloneDeep, groupBy, uniqBy } from "lodash-es";
-import { Database, Environment, EnvironmentId, UNKNOWN_ID } from "../types";
+import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { Action, defineAction, useRegisterActions } from "@bytebase/vue-kbar";
+import type { BBOutlineItem } from "@/bbkit/types";
+import { Database, Environment, EnvironmentId, UNKNOWN_ID } from "@/types";
 import {
   databaseSlug,
   environmentName,
   parseDatabaseNameByTemplate,
   projectSlug,
-} from "../utils";
-import { BBOutlineItem } from "../bbkit/types";
-import { Action, defineAction, useRegisterActions } from "@bytebase/vue-kbar";
-import { useRouter } from "vue-router";
-import { useI18n } from "vue-i18n";
+} from "@/utils";
 import {
   useEnvironmentList,
   useCurrentUser,
-  useLabelStore,
   useDatabaseStore,
+  useLabelList,
 } from "@/store";
-import { storeToRefs } from "pinia";
 
 export default defineComponent({
   name: "DatabaseListSidePanel",
   setup() {
     const { t } = useI18n();
     const databaseStore = useDatabaseStore();
-    const labelStore = useLabelStore();
     const router = useRouter();
 
     const currentUser = useCurrentUser();
@@ -49,8 +47,6 @@ export default defineComponent({
       if (currentUser.value.id != UNKNOWN_ID) {
         databaseStore.fetchDatabaseList();
       }
-
-      labelStore.fetchLabelList();
     };
 
     watchEffect(prepareList);
@@ -61,7 +57,7 @@ export default defineComponent({
     });
 
     // Use this to parse database name from name template
-    const { labelList } = storeToRefs(labelStore);
+    const labelList = useLabelList();
 
     const databaseListByEnvironment = computed(() => {
       const envToDbMap: Map<EnvironmentId, BBOutlineItem[]> = new Map();

--- a/frontend/src/components/Issue/IssueSidebar.vue
+++ b/frontend/src/components/Issue/IssueSidebar.vue
@@ -273,13 +273,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, PropType, reactive, watch, watchEffect } from "vue";
+import { computed, PropType, reactive, watch } from "vue";
 import { isEqual } from "lodash-es";
 import { NDatePicker } from "naive-ui";
 import { useRouter } from "vue-router";
 import dayjs from "dayjs";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
-import { storeToRefs } from "pinia";
 import StageSelect from "./StageSelect.vue";
 import TaskSelect from "./TaskSelect.vue";
 import IssueStatusIcon from "./IssueStatusIcon.vue";
@@ -320,7 +319,7 @@ import {
   useCurrentUser,
   useDatabaseStore,
   useEnvironmentStore,
-  useLabelStore,
+  useLabelList,
   useProjectStore,
 } from "@/store";
 
@@ -381,7 +380,6 @@ const emit = defineEmits<{
 }>();
 
 const router = useRouter();
-const labelStore = useLabelStore();
 const projectStore = useProjectStore();
 
 const now = new Date();
@@ -440,13 +438,7 @@ const project = computed((): Project => {
   return (props.issue as Issue).project;
 });
 
-const prepareLabelList = () => {
-  labelStore.fetchLabelList();
-};
-
-watchEffect(prepareLabelList);
-
-const { labelList } = storeToRefs(labelStore);
+const labelList = useLabelList();
 
 const visibleLabelList = computed((): DatabaseLabel[] => {
   // transform non-reserved labels to db properties

--- a/frontend/src/components/ProjectDeploymentConfigPanel.vue
+++ b/frontend/src/components/ProjectDeploymentConfigPanel.vue
@@ -125,6 +125,9 @@ import {
   watch,
   watchEffect,
 } from "vue";
+import { cloneDeep, isEqual } from "lodash-es";
+import { useI18n } from "vue-i18n";
+import { NPopover, useDialog } from "naive-ui";
 import {
   Project,
   AvailableLabel,
@@ -136,9 +139,6 @@ import {
   LabelSelectorRequirement,
 } from "../types";
 import DeploymentConfigTool, { DeploymentMatrix } from "./DeploymentConfigTool";
-import { cloneDeep, isEqual } from "lodash-es";
-import { useI18n } from "vue-i18n";
-import { NPopover, useDialog } from "naive-ui";
 import { generateDefaultSchedule, validateDeploymentConfig } from "../utils";
 import {
   pushNotification,
@@ -146,9 +146,8 @@ import {
   useDeploymentStore,
   useEnvironmentList,
   useEnvironmentStore,
-  useLabelStore,
+  useLabelList,
 } from "@/store";
-import { storeToRefs } from "pinia";
 
 type LocalState = {
   deployment: DeploymentConfig | undefined;
@@ -173,7 +172,6 @@ export default defineComponent({
   setup(props) {
     const databaseStore = useDatabaseStore();
     const deploymentStore = useDeploymentStore();
-    const labelStore = useLabelStore();
     const { t } = useI18n();
     const dialog = useDialog();
 
@@ -196,13 +194,12 @@ export default defineComponent({
 
     const prepareList = () => {
       useEnvironmentStore().fetchEnvironmentList();
-      labelStore.fetchLabelList();
       databaseStore.fetchDatabaseListByProjectId(props.project.id);
     };
 
     const environmentList = useEnvironmentList();
 
-    const { labelList } = storeToRefs(labelStore);
+    const labelList = useLabelList();
 
     const databaseList = computed(() =>
       databaseStore.getDatabaseListByProjectId(props.project.id)

--- a/frontend/src/components/ProjectOverviewPanel.vue
+++ b/frontend/src/components/ProjectOverviewPanel.vue
@@ -114,15 +114,14 @@ import {
   computed,
   defineComponent,
 } from "vue";
+import { NSpin } from "naive-ui";
 import ActivityTable from "../components/ActivityTable.vue";
 import DatabaseTable from "../components/DatabaseTable.vue";
 import TenantDatabaseTable, { YAxisRadioGroup } from "./TenantDatabaseTable";
 import { IssueTable } from "../components/Issue";
 import { Activity, Database, Issue, Project, LabelKeyType } from "../types";
 import { findDefaultGroupByLabel } from "../utils";
-import { NSpin } from "naive-ui";
-import { useActivityStore, useIssueStore, useLabelStore } from "@/store";
-import { storeToRefs } from "pinia";
+import { useActivityStore, useIssueStore, useLabelList } from "@/store";
 
 // Show at most 5 activity
 const ACTIVITY_LIMIT = 5;
@@ -157,8 +156,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const labelStore = useLabelStore();
-
     const state = reactive<LocalState>({
       activityList: [],
       progressIssueList: [],
@@ -204,20 +201,14 @@ export default defineComponent({
       return props.project.tenantMode === "TENANT";
     });
 
-    const prepareLabelList = () => {
-      if (!isTenantProject.value) return;
-      labelStore.fetchLabelList();
-    };
-
     const prepare = () => {
       prepareActivityList();
       prepareIssueList();
-      prepareLabelList();
     };
 
     watchEffect(prepare);
 
-    const { labelList } = storeToRefs(labelStore);
+    const labelList = useLabelList();
 
     const filteredDatabaseList = computed(() => {
       const filter = state.databaseNameFilter.toLocaleLowerCase();

--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -10,6 +10,7 @@ import {
   useSettingStore,
   useUIStateStore,
   useProjectStore,
+  useLabelStore,
 } from "@/store";
 import { defineComponent } from "vue";
 import { DEFAULT_PROJECT_ID } from "../types";
@@ -29,6 +30,7 @@ export default defineComponent({
       useEnvironmentStore().fetchEnvironmentList(),
       // The default project hosts databases not explicitly assigned to other users project.
       useProjectStore().fetchProjectById(DEFAULT_PROJECT_ID),
+      useLabelStore().fetchLabelList(),
       useUIStateStore().restoreState(),
     ]);
   },

--- a/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
+++ b/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
@@ -66,7 +66,9 @@ export default {
 <script lang="ts" setup>
 import { computed, reactive, watchEffect, watch } from "vue";
 import { capitalize, cloneDeep } from "lodash-es";
-import {
+import { useI18n } from "vue-i18n";
+import { storeToRefs } from "pinia";
+import type {
   Database,
   DatabaseLabel,
   Label,
@@ -74,16 +76,14 @@ import {
   LabelValueType,
   Project,
   ProjectId,
-} from "../../types";
+} from "@/types";
 import {
   buildDatabaseNameRegExpByTemplate,
   isReservedLabel,
   parseLabelListInTemplate,
   hidePrefix,
-} from "../../utils";
-import { useI18n } from "vue-i18n";
-import { useLabelStore, useProjectStore } from "@/store";
-import { storeToRefs } from "pinia";
+} from "@/utils";
+import { useLabelList, useProjectStore } from "@/store";
 
 const props = defineProps<{
   database: Database;
@@ -98,7 +98,6 @@ const state = reactive({
   databaseLabelList: cloneDeep(props.database.labels),
 });
 
-const labelStore = useLabelStore();
 const projectStore = useProjectStore();
 
 const { t } = useI18n();
@@ -107,7 +106,7 @@ const targetProject = computed(() => {
   return projectStore.getProjectById(props.targetProjectId) as Project;
 });
 
-const { labelList } = storeToRefs(labelStore);
+const labelList = useLabelList();
 
 const availableLabelList = computed(() => {
   return labelList.value.filter((label) => !isReservedLabel(label));
@@ -115,7 +114,6 @@ const availableLabelList = computed(() => {
 
 const prepare = () => {
   projectStore.fetchProjectById(props.targetProjectId);
-  labelStore.fetchLabelList();
 };
 
 watchEffect(prepare);

--- a/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
+++ b/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
@@ -67,7 +67,6 @@ export default {
 import { computed, reactive, watchEffect, watch } from "vue";
 import { capitalize, cloneDeep } from "lodash-es";
 import { useI18n } from "vue-i18n";
-import { storeToRefs } from "pinia";
 import type {
   Database,
   DatabaseLabel,

--- a/frontend/src/store/modules/label.ts
+++ b/frontend/src/store/modules/label.ts
@@ -1,4 +1,4 @@
-import { defineStore } from "pinia";
+import { defineStore, storeToRefs } from "pinia";
 import axios from "axios";
 import {
   Label,
@@ -73,3 +73,8 @@ export const useLabelStore = defineStore("label", {
     },
   },
 });
+
+export const useLabelList = () => {
+  const store = useLabelStore();
+  return storeToRefs(store).labelList;
+};

--- a/frontend/src/views/SettingWorkspaceLabel.vue
+++ b/frontend/src/views/SettingWorkspaceLabel.vue
@@ -65,15 +65,15 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, watchEffect } from "vue";
-import { isDBAOrOwner, hidePrefix } from "../utils";
-import { Label, LabelPatch } from "../types";
-import { BBTableColumn } from "../bbkit/types";
-import { BBTable, BBTableCell } from "../bbkit";
+import { computed, defineComponent } from "vue";
 import { useI18n } from "vue-i18n";
-import AddLabelValue from "../components/AddLabelValue.vue";
-import { useCurrentUser, useLabelStore } from "@/store";
 import { storeToRefs } from "pinia";
+import { isDBAOrOwner, hidePrefix } from "@/utils";
+import type { Label, LabelPatch } from "@/types";
+import type { BBTableColumn } from "@/bbkit/types";
+import { BBTable, BBTableCell } from "@/bbkit";
+import AddLabelValue from "@/components/AddLabelValue.vue";
+import { useCurrentUser, useLabelStore } from "@/store";
 
 export default defineComponent({
   name: "SettingWorkspaceLabels",
@@ -86,12 +86,6 @@ export default defineComponent({
     const { t } = useI18n();
     const labelStore = useLabelStore();
     const currentUser = useCurrentUser();
-
-    const prepareLabelList = () => {
-      labelStore.fetchLabelList();
-    };
-
-    watchEffect(prepareLabelList);
 
     const { labelList } = storeToRefs(labelStore);
 


### PR DESCRIPTION
The label list is widely shared in many components. We do not need to fetch it repeatedly. So we

- Keep only one copy of the label list globally.
- Fetch the label list in the global scope (DashboardContextProvider).
- This will also fix a bug that when we sign out an error notification says "Missing access token". (see screenshot below)
- Re-order imports, 3rd-party go upper.

![Snipaste_2022-05-06_08-46-38](https://user-images.githubusercontent.com/2749742/167054230-c975aed5-4087-49d7-bb11-42c7e6c4855d.png)
