### PR TITLE
chore(gitpod): make it usable on restarting workspace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,11 @@
 tasks:
   - name: Init Frontend
-    init: cd ./frontend && pnpm i
+    before: cd ./frontend
+    init: pnpm i
     command: pnpm dev
   - name: Init Backend
     init: curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s
-    command: ./bin/air -c scripts/.air.toml
+    command: rm -fv .air/pgdata/postmaster.pid && ./bin/air -c scripts/.air.toml
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports:


### PR DESCRIPTION
## Init Frontend
As `init` will be skipped when restarting a Gitpod workspace, the current configuration does not work. `cd frontend` command should be done in `before` to execute both on launching a new workspace and on restarting the stopped workspace.

https://www.gitpod.io/docs/config-start-tasks#restart-a-workspace

## Init Backend
On terminating the workspace (after 30/60 min inactive, for example), PostgreSQL server does not always stop correctly but remains `postmaster.pid` file. We should make sure the file does not exist on launching a new/existing workspace.

## How to test
1. Open https://gitpod.io/#github.com/tnir/bytebase/tree/tnir/gitpod-rework to launch a new workspace on Gitpod cloud.
2. Make sure the Go/JS server launched successfully by confirming the login UI. 👀 
3. Stop the workspace from command palette like `Gitpod: Stop Workspace`.
4. After completely stopped, restart the stopped workspace to see the login UI again. 🎉 

## Resources
- Updates #52

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>