### PR TITLE
chore: rename variables in plugin/advisor

### DIFF
--- a/plugin/advisor/advisor.go
+++ b/plugin/advisor/advisor.go
@@ -59,8 +59,8 @@ const (
 	MySQLMigrationCompatibility Type = "bb.plugin.advisor.mysql.migration-compatibility"
 	// MySQLWhereRequirement is an advisor type for MySQL WHERE clause requirement.
 	MySQLWhereRequirement Type = "bb.plugin.advisor.mysql.where.require"
-	// MySQLTableNamingConvention is an advisor type for MySQL table naming convention.
-	MySQLTableNamingConvention Type = "bb.plugin.advisor.mysql.naming.table"
+	// MySQLNamingTableConvention is an advisor type for MySQL table naming convention.
+	MySQLNamingTableConvention Type = "bb.plugin.advisor.mysql.naming.table"
 	// MySQLColumnRequirement is an advisor type for MySQL column requirement.
 	MySQLColumnRequirement Type = "bb.plugin.advisor.mysql.column.require"
 )

--- a/plugin/advisor/mysql/advisor_column_required.go
+++ b/plugin/advisor/mysql/advisor_column_required.go
@@ -61,7 +61,7 @@ type columnSet map[string]bool
 type tableState map[string]columnSet
 
 type columnRequirementChecker struct {
-	advisorList     []advisor.Advice
+	adviceList      []advisor.Advice
 	level           advisor.Status
 	requiredColumns columnSet
 	tables          tableState
@@ -119,7 +119,7 @@ func (v *columnRequirementChecker) generateAdvisorList() []advisor.Advice {
 		if len(missingColumns) > 0 {
 			// Order it cause the random iteration order in Go, see https://go.dev/blog/maps
 			sort.Strings(missingColumns)
-			v.advisorList = append(v.advisorList, advisor.Advice{
+			v.adviceList = append(v.adviceList, advisor.Advice{
 				Status:  v.level,
 				Code:    common.NoRequiredColumn,
 				Title:   "Require columns",
@@ -128,15 +128,15 @@ func (v *columnRequirementChecker) generateAdvisorList() []advisor.Advice {
 		}
 	}
 
-	if len(v.advisorList) == 0 {
-		v.advisorList = append(v.advisorList, advisor.Advice{
+	if len(v.adviceList) == 0 {
+		v.adviceList = append(v.adviceList, advisor.Advice{
 			Status:  advisor.Success,
 			Code:    common.Ok,
 			Title:   "OK",
 			Content: "",
 		})
 	}
-	return v.advisorList
+	return v.adviceList
 }
 
 // initEmptyTable will initialize a table without any required columns.

--- a/plugin/advisor/mysql/advisor_migration_compatibility.go
+++ b/plugin/advisor/mysql/advisor_migration_compatibility.go
@@ -35,18 +35,18 @@ func (adv *CompatibilityAdvisor) Check(ctx advisor.Context, statement string) ([
 		(stmtNode).Accept(c)
 	}
 
-	if len(c.advisorList) == 0 {
-		c.advisorList = append(c.advisorList, advisor.Advice{
+	if len(c.adviceList) == 0 {
+		c.adviceList = append(c.adviceList, advisor.Advice{
 			Status:  advisor.Success,
 			Code:    common.Ok,
 			Title:   "OK",
 			Content: "Migration is backward compatible"})
 	}
-	return c.advisorList, nil
+	return c.adviceList, nil
 }
 
 type compatibilityChecker struct {
-	advisorList []advisor.Advice
+	adviceList []advisor.Advice
 }
 
 func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
@@ -137,7 +137,7 @@ func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
 	}
 
 	if code != common.Ok {
-		v.advisorList = append(v.advisorList, advisor.Advice{
+		v.adviceList = append(v.adviceList, advisor.Advice{
 			Status:  advisor.Warn,
 			Code:    code,
 			Title:   "Potential incompatible migration",

--- a/plugin/advisor/mysql/advisor_naming_table_test.go
+++ b/plugin/advisor/mysql/advisor_naming_table_test.go
@@ -83,7 +83,7 @@ func TestTableNamingRequirement(t *testing.T) {
 		Format: "^[a-z]+(_[a-z]+)?$",
 	})
 	require.NoError(t, err)
-	runSchemaReviewRuleTests(t, tests, &TableNamingConventionAdvisor{}, &api.SchemaReviewRule{
+	runSchemaReviewRuleTests(t, tests, &NamingTableConventionAdvisor{}, &api.SchemaReviewRule{
 		Type:    api.SchemaRuleTableNaming,
 		Level:   api.SchemaRuleLevelError,
 		Payload: string(payload),

--- a/plugin/advisor/mysql/advisor_stmt_where_required.go
+++ b/plugin/advisor/mysql/advisor_stmt_where_required.go
@@ -39,20 +39,20 @@ func (adv *WhereRequirementAdvisor) Check(ctx advisor.Context, statement string)
 		(stmtNode).Accept(we)
 	}
 
-	if len(we.advisorList) == 0 {
-		we.advisorList = append(we.advisorList, advisor.Advice{
+	if len(we.adviceList) == 0 {
+		we.adviceList = append(we.adviceList, advisor.Advice{
 			Status:  advisor.Success,
 			Code:    common.Ok,
 			Title:   "OK",
 			Content: "",
 		})
 	}
-	return we.advisorList, nil
+	return we.adviceList, nil
 }
 
 type whereRequirementChecker struct {
-	advisorList []advisor.Advice
-	level       advisor.Status
+	adviceList []advisor.Advice
+	level      advisor.Status
 }
 
 func (v *whereRequirementChecker) Enter(in ast.Node) (ast.Node, bool) {
@@ -71,7 +71,7 @@ func (v *whereRequirementChecker) Enter(in ast.Node) (ast.Node, bool) {
 	}
 
 	if code != common.Ok {
-		v.advisorList = append(v.advisorList, advisor.Advice{
+		v.adviceList = append(v.adviceList, advisor.Advice{
 			Status:  v.level,
 			Code:    code,
 			Title:   "Require WHERE clause",

--- a/plugin/advisor/mysql/advisor_syntax.go
+++ b/plugin/advisor/mysql/advisor_syntax.go
@@ -35,9 +35,9 @@ func (adv *SyntaxAdvisor) Check(ctx advisor.Context, statement string) ([]adviso
 		}, nil
 	}
 
-	var advisorList []advisor.Advice
+	var adviceList []advisor.Advice
 	for _, warn := range warns {
-		advisorList = append(advisorList, advisor.Advice{
+		adviceList = append(adviceList, advisor.Advice{
 			Status:  advisor.Warn,
 			Code:    common.DbStatementSyntaxError,
 			Title:   "Syntax Warning",
@@ -45,10 +45,10 @@ func (adv *SyntaxAdvisor) Check(ctx advisor.Context, statement string) ([]adviso
 		})
 	}
 
-	advisorList = append(advisorList, advisor.Advice{
+	adviceList = append(adviceList, advisor.Advice{
 		Status:  advisor.Success,
 		Code:    common.Ok,
 		Title:   "Syntax OK",
 		Content: "OK"})
-	return advisorList, nil
+	return adviceList, nil
 }

--- a/server/task_check_executor_statement_advisor_composite.go
+++ b/server/task_check_executor_statement_advisor_composite.go
@@ -126,7 +126,7 @@ func getAdvisorTypeByRule(ruleType api.SchemaReviewRuleType, engine db.Type) (ad
 	case api.SchemaRuleTableNaming:
 		switch engine {
 		case db.MySQL, db.TiDB:
-			return advisor.MySQLTableNamingConvention, nil
+			return advisor.MySQLNamingTableConvention, nil
 		}
 	case api.SchemaRuleRequiredColumn:
 		switch engine {


### PR DESCRIPTION
- rename `advisorList` to `adviceList` (typo).
- rename `MySQLTableNamingConvention` to `MySQLNamingTableConvention`.
  - Let all naming rules have the same prefix `MySQLNamingXxx`.