### PR TITLE
fix(deprecation): replace deprecated highlightBlock with highlightElement

### DIFF
--- a/frontend/src/directives/highlight.js
+++ b/frontend/src/directives/highlight.js
@@ -7,7 +7,7 @@ hljs.configure({
 
 const directive = {
   beforeMount(el) {
-    hljs.highlightBlock(el);
+    hljs.highlightElement(el);
   },
 };
 


### PR DESCRIPTION
Suppresses warnings from browser console:

```
Deprecated as of 10.7.0. highlightBlock will be removed entirely in v12.0
Deprecated as of 10.7.0. Please use highlightElement now.
```

https://github.com/highlightjs/highlight.js/releases/tag/10.7.0

> Deprecations:
> [...]
> - highlightBlock(el) deprecated as of 10.7.
>    - Please use highlightElement(el) instead.
>    - Plugin callbacks renamed before/after:highlightBlock => before/after:highlightElement
>    - Plugin callback now takes el vs block attribute
>    - The old API and callbacks will be supported until v12.

Follows up 3cdfc37c0484a1caccd77fa8cab20f238b1b797e

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>