### PR TITLE
fix(ui): tweak warning message in readonly mode

### DIFF
--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -11,7 +11,7 @@
     </template>
     <template v-else-if="isReadonly">
       <div
-        class="h-12 w-full text-lg font-medium bg-yellow-500 text-white flex justify-center items-center"
+        class="px-3 py-1 w-full text-lg font-medium bg-yellow-500 text-white flex justify-center items-center"
       >
         Server is in readonly mode. You can still view the console, but any
         change attempt will fail.


### PR DESCRIPTION
| screen size | before | after |
|-|-|-|
| mobile | ![readonly-mode-mobile-before](https://user-images.githubusercontent.com/10229505/167237504-9752c81a-a15b-4231-a9be-0be6e951a269.png) | ![readonly-mode-mobile-after](https://user-images.githubusercontent.com/10229505/167237500-652cef83-dd9f-4a12-aa3a-fe911c750081.png) |
| PC (no regression should be confirmed) | ![readonly-mode-pc-after](https://user-images.githubusercontent.com/10229505/167237502-2f3f6a0a-7f55-4a11-9ab3-9b3702e98a1a.png) | ![readonly-mode-pc-before](https://user-images.githubusercontent.com/10229505/167237503-9ab68d5c-15e2-47bf-b90e-3395459af08d.png) |

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>