### PR TITLE
fix: allow force word break to prevent text overlapping

### DIFF
--- a/frontend/src/components/Issue/TaskRunTable.vue
+++ b/frontend/src/components/Issue/TaskRunTable.vue
@@ -39,7 +39,7 @@
           </div>
         </div>
       </BBTableCell>
-      <BBTableCell class="table-cell w-36">
+      <BBTableCell class="table-cell w-36 whitespace-pre-wrap break-words">
         {{ comment(taskRun) }}
         <template v-if="commentLink(task, taskRun).link">
           <router-link


### PR DESCRIPTION
This should fix [BYT-483](https://linear.app/bbteam/issue/BYT-483/text-overlapping-happens-when-the-comments-is-too-long)