### PR TITLE
fix: create sheet with unknown database_id

### DIFF
--- a/frontend/src/store/modules/sheet.ts
+++ b/frontend/src/store/modules/sheet.ts
@@ -164,6 +164,10 @@ export const useSheetStore = defineStore("sheet", {
       });
     },
     async createSheet(sheetCreate: SheetCreate): Promise<Sheet> {
+      if (sheetCreate.databaseId === UNKNOWN_ID) {
+        sheetCreate.databaseId = undefined;
+      }
+
       const resData = (
         await axios.post(`/api/sheet`, {
           data: {


### PR DESCRIPTION
If `sheetCreate.database_id` is `unknown_id`, then we should set the value with `undefined`.