### PR TITLE
fix: task-check-bar with more items and lower screen resolution

### DIFF
--- a/frontend/src/components/Issue/TaskCheckBadgeBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBadgeBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center space-x-2">
+  <div class="flex items-center flex-wrap gap-2 flex-1">
     <template
       v-for="(checkRun, index) in filteredTaskCheckRunList"
       :key="index"

--- a/frontend/src/components/Issue/TaskCheckBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center space-x-4">
+  <div class="flex items-start space-x-4">
     <button
       v-if="showRunCheckButton"
       type="button"


### PR DESCRIPTION
This should provide a better style when we have more taskCheck items but low screen width. (reported by @dragonly )

Screenshot
Before
![task-check-run-1](https://user-images.githubusercontent.com/2749742/167591091-d5bf4237-7f3d-451d-9fe7-dd2ba2a993e9.png)
After
![task-check-bar-2](https://user-images.githubusercontent.com/2749742/167591108-65515be4-8f83-4b18-abaf-74bbfb9daadb.png)
