### PR TITLE
fix: return only one syntax error for composite advisor

### DIFF
--- a/plugin/advisor/advisor.go
+++ b/plugin/advisor/advisor.go
@@ -23,6 +23,9 @@ const (
 	Warn Status = "WARN"
 	// Error is the advisor status for errors.
 	Error Status = "ERROR"
+
+	// SyntaxErrorTitle is the error title for syntax error.
+	SyntaxErrorTitle string = "Syntax error"
 )
 
 func (e Status) String() string {

--- a/plugin/advisor/mysql/parser.go
+++ b/plugin/advisor/mysql/parser.go
@@ -25,7 +25,7 @@ func parseStatement(statement string, charset string, collation string) ([]ast.S
 		return nil, []advisor.Advice{
 			{
 				Status:  advisor.Error,
-				Title:   "Syntax error",
+				Title:   advisor.SyntaxErrorTitle,
 				Content: err.Error(),
 			},
 		}

--- a/server/task_check_executor_statement_advisor_composite.go
+++ b/server/task_check_executor_statement_advisor_composite.go
@@ -106,6 +106,10 @@ func (exec *TaskCheckStatementAdvisorCompositeExecutor) Run(ctx context.Context,
 
 		}
 	}
+	// There may be multiple syntax errors, return one only.
+	if len(result) > 0 && result[0].Title == advisor.SyntaxErrorTitle {
+		return result[:1], nil
+	}
 	if len(result) == 0 {
 		result = append(result, api.TaskCheckResult{
 			Status:  api.TaskCheckStatusSuccess,


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/20775801/167801489-0d7e4e64-12f2-40dd-85aa-c69d954f1b6d.png)

After:

![gs9LRpJIBT](https://user-images.githubusercontent.com/20775801/167801546-0de4a3ca-f025-4ba8-9169-fec115c40fd9.png)
