### PR TITLE
fix: wrong `filteredTaskCheckRunList`

### DIFF
--- a/frontend/src/components/Issue/TaskCheckBadgeBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBadgeBar.vue
@@ -155,10 +155,10 @@ export default defineComponent({
       const result: TaskCheckRun[] = [];
       for (const run of props.taskCheckRunList) {
         const index = result.findIndex((item) => item.type == run.type);
-        if (index >= 0 && result[index].updatedTs < run.updatedTs) {
-          result[index] = run;
-        } else {
+        if (index < 0) {
           result.push(run);
+        } else if (result[index].updatedTs < run.updatedTs) {
+          result[index] = run;
         }
       }
 


### PR DESCRIPTION
The current logic to generate `filteredTaskCheckRUnList` is wrong, it results in the duplicate `task check run`.

Close CON-133