### PR TITLE
feat: make sync schema optional after adding/patching the instance connection info

### DIFF
--- a/api/data_source.go
+++ b/api/data_source.go
@@ -92,6 +92,10 @@ type DataSourceCreate struct {
 	Type     DataSourceType `jsonapi:"attr,type"`
 	Username string         `jsonapi:"attr,username"`
 	Password string         `jsonapi:"attr,password"`
+	// If true, syncs the schema after creating the data source. The client
+	// may set to false if the target data source's instance contains too many databases
+	// to avoid the request timeout.
+	SyncSchema bool `jsonapi:"attr,syncSchema"`
 }
 
 // DataSourceFind is the API message for finding data sources.
@@ -126,4 +130,8 @@ type DataSourcePatch struct {
 	Username         *string `jsonapi:"attr,username"`
 	Password         *string `jsonapi:"attr,password"`
 	UseEmptyPassword *bool   `jsonapi:"attr,useEmptyPassword"`
+	// If true, syncs the schema after patching the data source. The client
+	// may set to false if the target data source's instance contains too many databases
+	// to avoid the request timeout.
+	SyncSchema bool `jsonapi:"attr,syncSchema"`
 }

--- a/api/instance.go
+++ b/api/instance.go
@@ -55,6 +55,10 @@ type InstanceCreate struct {
 	Port         string  `jsonapi:"attr,port"`
 	Username     string  `jsonapi:"attr,username"`
 	Password     string  `jsonapi:"attr,password"`
+	// If true, syncs the schema after adding the instance. The client
+	// may set to false if the target instance contains too many databases
+	// to avoid the request timeout.
+	SyncSchema bool `jsonapi:"attr,syncSchema"`
 }
 
 // InstanceFind is the API message for finding instances.
@@ -83,14 +87,15 @@ type InstancePatch struct {
 	UpdaterID int
 
 	// Domain specific fields
-	Name             *string `jsonapi:"attr,name"`
-	EngineVersion    *string
-	ExternalLink     *string `jsonapi:"attr,externalLink"`
-	Host             *string `jsonapi:"attr,host"`
-	Port             *string `jsonapi:"attr,port"`
-	Username         *string `jsonapi:"attr,username"`
-	Password         *string `jsonapi:"attr,password"`
-	UseEmptyPassword bool    `jsonapi:"attr,useEmptyPassword"`
+	Name          *string `jsonapi:"attr,name"`
+	EngineVersion *string
+	ExternalLink  *string `jsonapi:"attr,externalLink"`
+	Host          *string `jsonapi:"attr,host"`
+	Port          *string `jsonapi:"attr,port"`
+	// If true, syncs the schema after patching the instance. The client
+	// may set to false if the target instance contains too many databases
+	// to avoid the request timeout.
+	SyncSchema bool `jsonapi:"attr,syncSchema"`
 }
 
 // DataSourceFromInstanceWithType gets a typed data source from a instance.

--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -181,32 +181,37 @@
     </div>
 
     <!-- Action Button Group -->
-    <div class="pt-4">
+    <div class="pt-4 px-2">
       <!-- Create button group -->
-      <div class="flex justify-end items-center">
-        <div>
+      <div class="flex justify-between items-center">
+        <BBCheckbox
+          :title="$t('instance.sync-schema-afterward')"
+          :value="state.instance.syncSchema"
+          @toggle="state.instance.syncSchema = !state.instance.syncSchema"
+        />
+        <div class="flex justify-end items-center">
           <BBSpin
             v-if="state.isCreatingInstance"
             :title="$t('common.creating')"
           />
-        </div>
-        <div class="ml-2">
-          <button
-            type="button"
-            class="btn-normal py-2 px-4"
-            :disabled="state.isCreatingInstance"
-            @click.prevent="cancel"
-          >
-            {{ $t("common.cancel") }}
-          </button>
-          <button
-            type="button"
-            class="btn-primary ml-3 inline-flex justify-center py-2 px-4"
-            :disabled="!allowCreate || state.isCreatingInstance"
-            @click.prevent="tryCreate"
-          >
-            {{ $t("common.create") }}
-          </button>
+          <div class="ml-2">
+            <button
+              type="button"
+              class="btn-normal py-2 px-4"
+              :disabled="state.isCreatingInstance"
+              @click.prevent="cancel"
+            >
+              {{ $t("common.cancel") }}
+            </button>
+            <button
+              type="button"
+              class="btn-primary ml-3 inline-flex justify-center py-2 px-4"
+              :disabled="!allowCreate || state.isCreatingInstance"
+              @click.prevent="tryCreate"
+            >
+              {{ $t("common.create") }}
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -282,6 +287,7 @@ const state = reactive<LocalState>({
     // In release mode, Bytebase is likely run inside docker and access the local network via host.docker.internal.
     host: isDev() ? "127.0.0.1" : "host.docker.internal",
     username: "",
+    syncSchema: true,
   },
   showCreateInstanceWarningModal: false,
   createInstanceWarning: "",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -529,6 +529,7 @@
     "new-database": "New Database",
     "syncing": "Syncing ...",
     "sync-now": "Sync Now",
+    "sync-schema-afterward": "Sync schema afterward",
     "create-migration-schema": "Create migration schema",
     "missing-migration-schema": "Missing migration schema",
     "unable-to-connect-instance-to-check-migration-schema": "Unable to connect instance to check migration schema",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -529,6 +529,7 @@
     "new-database": "@:common.new@:common.database",
     "syncing": "同步中 ...",
     "sync-now": "现在同步",
+    "sync-schema-afterward": "随即同步 schema",
     "create-migration-schema": "@:common.create@:common.migration @:{'common.schema'}",
     "missing-migration-schema": "缺少@:common.migration @:common.schema",
     "unable-to-connect-instance-to-check-migration-schema": "无法连接到@:{'common.instance'}以检查@:{'common.migration'} @:{'common.schema'}",

--- a/frontend/src/types/dataSource.ts
+++ b/frontend/src/types/dataSource.ts
@@ -44,6 +44,7 @@ export type DataSourceCreate = {
   type: DataSourceType;
   username?: string;
   password?: string;
+  syncSchema: boolean;
 };
 
 export type DataSourcePatch = {
@@ -52,6 +53,7 @@ export type DataSourcePatch = {
   username?: string;
   password?: string;
   useEmptyPassword?: boolean;
+  syncSchema: boolean;
 };
 
 export type DataSourceMember = {

--- a/frontend/src/types/instance.ts
+++ b/frontend/src/types/instance.ts
@@ -79,6 +79,7 @@ export type InstanceCreate = {
   // In mysql, username can be empty which means anonymous user
   username?: string;
   password?: string;
+  syncSchema: boolean;
 };
 
 export type InstancePatch = {
@@ -90,6 +91,7 @@ export type InstancePatch = {
   externalLink?: string;
   host?: string;
   port?: string;
+  syncSchema: boolean;
 };
 
 export type MigrationSchemaStatus = "UNKNOWN" | "OK" | "NOT_EXIST";

--- a/server/instance.go
+++ b/server/instance.go
@@ -51,8 +51,9 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 					zap.String("engine", string(instance.Engine)),
 					zap.Error(err))
 			}
-			// Try immediately sync the engine version and schema after instance creation.
-			s.syncEngineVersionAndSchema(ctx, instance)
+			if instanceCreate.SyncSchema {
+				s.syncEngineVersionAndSchema(ctx, instance)
+			}
 		}
 
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
@@ -166,7 +167,9 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 						zap.String("engine", string(instancePatched.Engine)),
 						zap.Error(err))
 				}
-				s.syncEngineVersionAndSchema(ctx, instancePatched)
+				if instancePatch.SyncSchema {
+					s.syncEngineVersionAndSchema(ctx, instancePatched)
+				}
 			}
 		}
 


### PR DESCRIPTION
Currently, we sync the schema upon adding/patching the instance, this provides a better UX since the user will see the schema after adding the instance.

However, for instances having large schemas, the request will timeout and prevents them from adding the instance at all.

The solution is to add a "Sync schema afterward" checkbox to allow users to disable the sync if needed. The checkbox only appears if connection-related info is changed.


![CleanShot 2022-05-12 at 00 45 14](https://user-images.githubusercontent.com/230323/167903553-39061230-2d47-4e3b-8ed1-f3f15b244d02.png)

![CleanShot 2022-05-12 at 00 45 27](https://user-images.githubusercontent.com/230323/167903582-cab4f0d4-25f5-4c2e-9973-03cf264a1e88.png)


Also improve existing logic:

1. Add the syncing schema logic after adding/patching the data source.
2. Remove the unneeded Username, Password, UseEmptyPassword field in instancePatch since it has been moved to data source.
3. Also refetch the user info after adding/patching the instance.



