### PR TITLE
fix: using new application secret to process oauth 

### DIFF
--- a/frontend/src/store/modules/oauth.ts
+++ b/frontend/src/store/modules/oauth.ts
@@ -15,11 +15,15 @@ export const useOAuthStore = defineStore("oauth", {
   actions: {
     // exchangeVCSTokenWithID uses "vcsId" to let the backend infer the details from an existing VCS provider.
     async exchangeVCSTokenWithID({
-      vcsId,
       code,
+      vcsId,
+      clientId,
+      clientSecret,
     }: {
-      vcsId: VCSId;
       code: string;
+      vcsId: VCSId;
+      clientId: string;
+      clientSecret: string;
     }): Promise<OAuthToken> {
       const data = (
         await axios.post(`/api/oauth/vcs/exchange-token`, {
@@ -28,6 +32,8 @@ export const useOAuthStore = defineStore("oauth", {
             attributes: {
               code,
               vcsId,
+              clientId,
+              clientSecret,
             },
           },
         })

--- a/frontend/src/views/SettingWorkspaceVCSDetail.vue
+++ b/frontend/src/views/SettingWorkspaceVCSDetail.vue
@@ -232,8 +232,10 @@ export default defineComponent({
         ) {
           useOAuthStore()
             .exchangeVCSTokenWithID({
-              vcsId: idFromSlug(props.vcsSlug),
               code: payload.code,
+              vcsId: idFromSlug(props.vcsSlug),
+              clientId: state.applicationId,
+              clientSecret: state.secret,
             })
             .then((token: OAuthToken) => {
               state.oAuthResultCallback!(token);

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) registerOAuthRoutes(g *echo.Group) {
 	// This is a generic endpoint of exchanging access token for VCS providers. It
-	// requires either the "vcsId" to infer the details from an existing VCS
-	// provider or "vcsType", "instanceURL", "clientId" and "clientSecret" to
-	// directly compose the request to the VCS host.
+	// requires either the "vcsId", "clientId", "clientSecret" to infer the other details
+	// from an existing VCS provider or "vcsType", "instanceURL", "clientId" and "clientSecret"
+	// to directly compose the request to the VCS host.
 	g.POST("/oauth/vcs/exchange-token", func(c echo.Context) error {
 		req := &api.VCSExchangeToken{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, req); err != nil {
@@ -39,8 +39,8 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 			vcsType = vcs.Type
 			instanceURL = vcs.InstanceURL
 			oauthExchange = &common.OAuthExchange{
-				ClientID:     vcs.ApplicationID,
-				ClientSecret: vcs.Secret,
+				ClientID:     req.ClientID,
+				ClientSecret: req.ClientSecret,
 				Code:         req.Code,
 			}
 		} else {


### PR DESCRIPTION
https://github.com/bytebase/bytebase/issues/1263
When the user provides a new `application secret`, we need to use the old application secret to perform the oauth process to verify the validity of the `application secret`. So the front-end needs to pass the application secret to the back-end so that the back-end can use the new `application secret` **instead of the back-end using the old `application secret` that fetches from db.**