### PR TITLE
refactor(frontend): IssueDetail part.4

### DIFF
--- a/frontend/src/components/Issue/IssueBanner.vue
+++ b/frontend/src/components/Issue/IssueBanner.vue
@@ -20,24 +20,23 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
-import { Issue } from "../../types";
-import { activeTask } from "../../utils";
+import { computed, Ref } from "vue";
+import { Issue } from "@/types";
+import { activeTask } from "@/utils";
+import { useIssueLogic } from "./logic";
 
-const props = defineProps<{
-  issue: Issue;
-}>();
+const issue = useIssueLogic().issue as Ref<Issue>;
 
 const showCancelBanner = computed(() => {
-  return props.issue.status == "CANCELED";
+  return issue.value.status == "CANCELED";
 });
 
 const showSuccessBanner = computed(() => {
-  return props.issue.status == "DONE";
+  return issue.value.status == "DONE";
 });
 
 const showPendingApproval = computed(() => {
-  const task = activeTask(props.issue.pipeline);
+  const task = activeTask(issue.value.pipeline);
   return task.status == "PENDING_APPROVAL";
 });
 </script>

--- a/frontend/src/components/Issue/IssueDetailLayout.vue
+++ b/frontend/src/components/Issue/IssueDetailLayout.vue
@@ -190,6 +190,13 @@ const {
 
 const issueLogic = ref<IssueLogic>();
 
+// Determine which type of IssueLogicProvider should be used
+const logicProviderType = computed(() => {
+  if (isTenantMode.value) return TenantModeProvider;
+  if (isGhostMode.value) return GhostModeProvider;
+  return StandardModeProvider;
+});
+
 watchEffect(() => {
   if (props.create) {
     projectStore.fetchProjectById((props.issue as IssueCreate).projectId);
@@ -291,13 +298,6 @@ const hasBackwardCompatibilityFeature = featureToRef(
 const supportBackwardCompatibilityFeature = computed((): boolean => {
   const engine = database.value?.instance.engine;
   return engine === "MYSQL" || engine === "TIDB";
-});
-
-// Determine which type of IssueLogicProvider should be used
-const logicProviderType = computed(() => {
-  if (isTenantMode.value) return TenantModeProvider;
-  if (isGhostMode.value) return GhostModeProvider;
-  return StandardModeProvider;
 });
 
 watch(

--- a/frontend/src/components/Issue/IssueDetailLayout.vue
+++ b/frontend/src/components/Issue/IssueDetailLayout.vue
@@ -1,10 +1,10 @@
 <template>
-  <div
-    id="issue-detail-top"
-    class="flex-1 overflow-auto focus:outline-none"
-    tabindex="0"
-  >
-    <component :is="logicProviderType" ref="issueLogic">
+  <component :is="logicProviderType" ref="issueLogic">
+    <div
+      id="issue-detail-top"
+      class="flex-1 overflow-auto focus:outline-none"
+      tabindex="0"
+    >
       <IssueBanner v-if="!create" />
 
       <!-- Highlight Panel -->
@@ -96,8 +96,8 @@
           </div>
         </div>
       </main>
-    </component>
-  </div>
+    </div>
+  </component>
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/components/Issue/IssueDetailLayout.vue
+++ b/frontend/src/components/Issue/IssueDetailLayout.vue
@@ -101,8 +101,6 @@
 </template>
 
 <script lang="ts" setup>
-/* eslint-disable vue/no-mutating-props */
-
 import { computed, onMounted, PropType, ref, watch, watchEffect } from "vue";
 import { useRoute } from "vue-router";
 import {

--- a/frontend/src/components/Issue/IssueStagePanel.vue
+++ b/frontend/src/components/Issue/IssueStagePanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-4">
     <template v-if="mode === 'single'">
-      <TaskRunTable :task-list="[selectedTask || stage.taskList[0]]" />
+      <TaskRunTable :task-list="[task || stage.taskList[0]]" />
     </template>
     <template v-else-if="mode === 'merged'">
       <TaskRunTable :task-list="stage.taskList" />
@@ -26,55 +26,36 @@
   </div>
 </template>
 
-<script lang="ts">
-import { PropType, computed, defineComponent } from "vue";
+<script lang="ts" setup>
+import { computed, Ref } from "vue";
 import TaskRunTable from "./TaskRunTable.vue";
-import { Stage, Task } from "../../types";
-import { activeTaskInStage } from "../../utils";
+import { Stage, Task } from "@/types";
+import { useIssueLogic } from "./logic";
 
 type Mode = "normal" | "single" | "merged";
 
-export default defineComponent({
-  name: "IssueStagePanel",
-  components: { TaskRunTable },
-  props: {
-    stage: {
-      required: true,
-      type: Object as PropType<Stage>,
-    },
-    selectedTask: {
-      type: Object as PropType<Task>,
-      default: undefined,
-    },
-    isTenantMode: {
-      type: Boolean,
-      default: false,
-    },
-    isGhostMode: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  setup(props) {
-    const activeTask = computed((): Task => {
-      return activeTaskInStage(props.stage);
-    });
+const {
+  selectedStage,
+  selectedTask,
+  isGhostMode,
+  isTenantMode,
+  activeTaskOfStage,
+} = useIssueLogic();
+const stage = selectedStage as Ref<Stage>;
+const task = selectedTask as Ref<Task>;
 
-    /**
-     * normal mode: display multiple tables for each task in stage.taskList
-     * merged mode: merge all tasks' activities into one table
-     * single mode: show only selected task's activities
-     */
-    const mode = computed((): Mode => {
-      if (props.isGhostMode) return "merged";
-      if (props.isTenantMode) return "single";
-      return "normal";
-    });
+const activeTask = computed((): Task => {
+  return activeTaskOfStage(stage.value);
+});
 
-    return {
-      activeTask,
-      mode,
-    };
-  },
+/**
+ * normal mode: display multiple tables for each task in stage.taskList
+ * merged mode: merge all tasks' activities into one table
+ * single mode: show only selected task's activities
+ */
+const mode = computed((): Mode => {
+  if (isGhostMode.value) return "merged";
+  if (isTenantMode.value) return "single";
+  return "normal";
 });
 </script>

--- a/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
+++ b/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
@@ -140,6 +140,7 @@ import {
   flattenTaskList,
   IssueTypeWithStatement,
   TaskTypeWithStatement,
+  useExtraIssueLogic,
   useIssueLogic,
 } from "./logic";
 
@@ -159,8 +160,6 @@ interface UpdateStatusModalState {
   payload?: Task;
 }
 
-const emit = defineEmits(["change-issue-status", "change-task-status"]);
-
 const { t } = useI18n();
 const menu = ref<InstanceType<typeof BBContextMenu>>();
 
@@ -171,6 +170,7 @@ const {
   activeTaskOfPipeline,
   doCreate,
 } = useIssueLogic();
+const { changeIssueStatus, changeTaskStatus } = useExtraIssueLogic();
 
 const updateStatusModalState = reactive<UpdateStatusModalState>({
   mode: "ISSUE",
@@ -255,7 +255,7 @@ const doTaskStatusTransition = (
   task: Task,
   comment: string
 ) => {
-  emit("change-task-status", task, transition.to, comment);
+  changeTaskStatus(task, transition.to, comment);
 };
 
 const applicableIssueStatusTransitionList = computed(
@@ -358,7 +358,7 @@ const doIssueStatusTransition = (
   transition: IssueStatusTransition,
   comment: string
 ) => {
-  emit("change-issue-status", transition.to, comment);
+  changeIssueStatus(transition.to, comment);
 };
 
 const allowCreate = computed(() => {

--- a/frontend/src/components/Issue/logic/IssueLogic.ts
+++ b/frontend/src/components/Issue/logic/IssueLogic.ts
@@ -59,10 +59,12 @@ type IssueLogic = {
   doCreate(): any;
 
   // events
+  onStatusChanged: (eager: boolean) => void;
   selectStageOrTask: (
     stageIdOrIndex: number,
     taskSlug?: string | undefined
   ) => void;
+  selectTask: (task: Task) => void;
 };
 
 export default IssueLogic;

--- a/frontend/src/components/Issue/logic/base.ts
+++ b/frontend/src/components/Issue/logic/base.ts
@@ -1,0 +1,196 @@
+import { computed, Ref } from "vue";
+import { isEmpty } from "lodash-es";
+import {
+  Issue,
+  IssueCreate,
+  Project,
+  Stage,
+  StageCreate,
+  StageId,
+  Task,
+  TaskCreate,
+} from "@/types";
+import { useRoute, useRouter } from "vue-router";
+import {
+  activeStage,
+  activeTaskInStage,
+  idFromSlug,
+  indexFromSlug,
+  isDev,
+  issueSlug,
+  stageSlug,
+  taskSlug,
+} from "@/utils";
+import { useIssueStore, useProjectStore } from "@/store";
+import { TaskTypeWithStatement } from "./common";
+
+export const useBaseIssueLogic = (params: {
+  create: Ref<boolean>;
+  issue: Ref<Issue | IssueCreate>;
+}) => {
+  const { create, issue } = params;
+  const route = useRoute();
+  const router = useRouter();
+  const issueStore = useIssueStore();
+  const projectStore = useProjectStore();
+
+  const project = computed((): Project => {
+    if (create.value) {
+      return projectStore.getProjectById(
+        (issue.value as IssueCreate).projectId
+      );
+    }
+    return (issue.value as Issue).project;
+  });
+
+  const createIssue = (issue: IssueCreate) => {
+    // Set issue.pipeline and issue.payload to empty
+    // because we are no longer passing parameters via issue.pipeline
+    // we are using issue.createContext instead
+    delete issue.pipeline;
+    issue.payload = {};
+
+    issueStore.createIssue(issue).then((createdIssue) => {
+      // Use replace to omit the new issue url in the navigation history.
+      router.replace(`/issue/${issueSlug(createdIssue.name, createdIssue.id)}`);
+    });
+  };
+
+  const selectedStage = computed((): Stage | StageCreate => {
+    const stageSlug = router.currentRoute.value.query.stage as string;
+    const taskSlug = router.currentRoute.value.query.task as string;
+    // For stage slug, we support both index based and id based.
+    // Index based is used when creating the new task and is the one used when clicking the UI.
+    // Id based is used when the context only has access to the stage id (e.g. Task only contains StageId)
+    if (stageSlug) {
+      const index = indexFromSlug(stageSlug);
+      if (index < issue.value.pipeline!.stageList.length) {
+        return issue.value.pipeline!.stageList[index];
+      }
+      const stageId = idFromSlug(stageSlug);
+      const stageList = (issue.value as Issue).pipeline.stageList;
+      for (const stage of stageList) {
+        if (stage.id == stageId) {
+          return stage;
+        }
+      }
+    } else if (!create.value && taskSlug) {
+      const taskId = idFromSlug(taskSlug);
+      const stageList = (issue.value as Issue).pipeline.stageList;
+      for (const stage of stageList) {
+        for (const task of stage.taskList) {
+          if (task.id == taskId) {
+            return stage;
+          }
+        }
+      }
+    }
+    if (create.value) {
+      return issue.value.pipeline!.stageList[0];
+    }
+    return activeStage((issue.value as Issue).pipeline);
+  });
+
+  const selectStageOrTask = (
+    stageId: StageId,
+    taskSlug: string | undefined = undefined
+  ) => {
+    const stageList = issue.value.pipeline!.stageList;
+    const index = stageList.findIndex((item, index) => {
+      if (create.value) {
+        return index === stageId;
+      }
+      return (item as Stage).id == stageId;
+    });
+    router.replace({
+      name: "workspace.issue.detail",
+      query: {
+        ...router.currentRoute.value.query,
+        stage: stageSlug(stageList[index].name, index),
+        task: taskSlug,
+      },
+    });
+  };
+
+  const selectTask = (task: Task) => {
+    if (!create.value) return;
+
+    const stage = (issue.value as Issue).pipeline?.stageList.find(
+      (t) => t.id === task.id
+    );
+    if (!stage) {
+      return;
+    }
+    const slug = taskSlug(task.name, task.id);
+    selectStageOrTask(stage.id, slug);
+  };
+
+  const selectedTask = computed((): Task | TaskCreate => {
+    const taskSlug = route.query.task as string;
+    const { taskList } = selectedStage.value;
+    if (taskSlug) {
+      const index = indexFromSlug(taskSlug);
+      if (index < taskList.length) {
+        return taskList[index];
+      }
+      const id = idFromSlug(taskSlug);
+      for (let i = 0; i < taskList.length; i++) {
+        const task = taskList[i] as Task;
+        if (task.id === id) {
+          return task;
+        }
+      }
+    }
+    return taskList[0];
+  });
+
+  const isTenantMode = computed((): boolean => {
+    if (project.value.tenantMode !== "TENANT") return false;
+    return (
+      issue.value.type === "bb.issue.database.schema.update" ||
+      issue.value.type === "bb.issue.database.data.update"
+    );
+  });
+
+  const isGhostMode = computed((): boolean => {
+    if (!isDev()) return false;
+
+    return issue.value.type === "bb.issue.database.schema.update.ghost";
+  });
+
+  const taskStatusOfStage = (stage: Stage | StageCreate) => {
+    if (create.value) {
+      return stage.taskList[0].status;
+    }
+    const activeTask = activeTaskInStage(stage as Stage);
+    return activeTask.status;
+  };
+
+  const isValidStage = (stage: Stage | StageCreate) => {
+    if (!create.value) {
+      return true;
+    }
+
+    for (const task of stage.taskList) {
+      if (TaskTypeWithStatement.includes(task.type)) {
+        if (isEmpty((task as TaskCreate).statement)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  return {
+    project,
+    isTenantMode,
+    isGhostMode,
+    createIssue,
+    selectedStage,
+    selectedTask,
+    selectStageOrTask,
+    selectTask,
+    taskStatusOfStage,
+    isValidStage,
+  };
+};

--- a/frontend/src/components/Issue/logic/extra.ts
+++ b/frontend/src/components/Issue/logic/extra.ts
@@ -1,0 +1,227 @@
+import { cloneDeep, isEqual } from "lodash-es";
+import { InputField, OutputField } from "@/plugins";
+import {
+  useCurrentUser,
+  useIssueStore,
+  useIssueSubscriberStore,
+  useTaskStore,
+} from "@/store";
+import {
+  Issue,
+  IssueCreate,
+  IssueStatus,
+  IssueStatusPatch,
+  PrincipalId,
+  Task,
+  TaskCreate,
+  TaskPatch,
+  TaskStatus,
+  TaskStatusPatch,
+} from "@/types";
+import { useIssueLogic } from "./index";
+import { computed, nextTick } from "vue";
+
+export const useExtraIssueLogic = () => {
+  const {
+    create,
+    issue,
+    isGhostMode,
+    selectedStage,
+    selectedTask,
+    selectStageOrTask,
+    selectTask,
+    onStatusChanged,
+    patchIssue,
+    patchTask,
+  } = useIssueLogic();
+  const issueStore = useIssueStore();
+  const issueSubscriberStore = useIssueSubscriberStore();
+  const taskStore = useTaskStore();
+  const currentUser = useCurrentUser();
+
+  const allowEditOutput = computed(() => {
+    if (create.value) {
+      return true;
+    }
+
+    const issueEntity = issue.value as Issue;
+    return (
+      issueEntity.status == "OPEN" &&
+      issueEntity.assignee?.id == currentUser.value.id
+    );
+  });
+
+  const allowEditNameAndDescription = computed(() => {
+    if (create.value) {
+      return true;
+    }
+
+    const issueEntity = issue.value as Issue;
+    return (
+      issueEntity.status == "OPEN" &&
+      (issueEntity.assignee.id == currentUser.value.id ||
+        issueEntity.creator.id == currentUser.value.id)
+    );
+  });
+
+  const updateName = (
+    newName: string,
+    postUpdated?: (updatedIssue: Issue) => void
+  ) => {
+    if (create.value) {
+      issue.value.name = newName;
+    } else {
+      patchIssue(
+        {
+          name: newName,
+        },
+        postUpdated
+      );
+    }
+  };
+
+  const updateDescription = (
+    newDescription: string,
+    postUpdated?: (updatedIssue: Issue) => void
+  ) => {
+    if (create.value) {
+      issue.value.description = newDescription;
+    } else {
+      patchIssue(
+        {
+          description: newDescription,
+        },
+        postUpdated
+      );
+    }
+  };
+
+  const updateAssigneeId = (newAssigneeId: PrincipalId) => {
+    if (create.value) {
+      (issue.value as IssueCreate).assigneeId = newAssigneeId;
+    } else {
+      patchIssue({
+        assigneeId: newAssigneeId,
+      });
+    }
+  };
+
+  const updateEarliestAllowedTime = (newEarliestAllowedTsMs: number) => {
+    if (create.value) {
+      if (isGhostMode.value) {
+        // In gh-ost mode, when creating an issue, all sub-tasks in a stage
+        // share the same earliestAllowedTs.
+        // So updates on any one of them will be applied to others.
+        // (They can be updated independently after creation)
+        const taskList = selectedStage.value.taskList as TaskCreate[];
+        taskList.forEach((task) => {
+          task.earliestAllowedTs = newEarliestAllowedTsMs;
+        });
+      } else {
+        selectedTask.value.earliestAllowedTs = newEarliestAllowedTsMs;
+      }
+    } else {
+      const taskPatch: TaskPatch = {
+        earliestAllowedTs: newEarliestAllowedTsMs,
+      };
+      patchTask((selectedTask.value as Task).id, taskPatch);
+    }
+  };
+
+  const addSubscriberId = (subscriberId: PrincipalId) => {
+    issueSubscriberStore.createSubscriber({
+      issueId: (issue.value as Issue).id,
+      subscriberId,
+    });
+  };
+
+  const removeSubscriberId = (subscriberId: PrincipalId) => {
+    issueSubscriberStore.deleteSubscriber({
+      issueId: (issue.value as Issue).id,
+      subscriberId,
+    });
+  };
+
+  const updateCustomField = (field: InputField | OutputField, value: any) => {
+    if (!isEqual(issue.value.payload[field.id], value)) {
+      if (create.value) {
+        issue.value.payload[field.id] = value;
+      } else {
+        const newPayload = cloneDeep(issue.value.payload);
+        newPayload[field.id] = value;
+        patchIssue({
+          payload: newPayload,
+        });
+      }
+    }
+  };
+
+  const changeIssueStatus = (newStatus: IssueStatus, comment: string) => {
+    const issueStatusPatch: IssueStatusPatch = {
+      status: newStatus,
+      comment: comment,
+    };
+    issueStore
+      .updateIssueStatus({
+        issueId: (issue.value as Issue).id,
+        issueStatusPatch,
+      })
+      .then(() => {
+        // pollIssue(POST_CHANGE_POLL_INTERVAL);
+      });
+  };
+
+  const changeTaskStatus = (
+    task: Task,
+    newStatus: TaskStatus,
+    comment: string
+  ) => {
+    // Switch to the stage view containing this task
+    selectStageOrTask(task.stage.id);
+    nextTick().then(() => {
+      selectTask(task);
+    });
+
+    const taskStatusPatch: TaskStatusPatch = {
+      status: newStatus,
+      comment: comment,
+    };
+    taskStore
+      .updateStatus({
+        issueId: (issue.value as Issue).id,
+        pipelineId: (issue.value as Issue).pipeline.id,
+        taskId: task.id,
+        taskStatusPatch,
+      })
+      .then(() => {
+        onStatusChanged(true);
+      });
+  };
+
+  const runTaskChecks = (task: Task) => {
+    taskStore
+      .runChecks({
+        issueId: (issue.value as Issue).id,
+        pipelineId: (issue.value as Issue).pipeline.id,
+        taskId: task.id,
+      })
+      .then(() => {
+        onStatusChanged(true);
+      });
+  };
+
+  return {
+    allowEditOutput,
+    allowEditNameAndDescription,
+    updateName,
+    updateDescription,
+    updateAssigneeId,
+    updateEarliestAllowedTime,
+    addSubscriberId,
+    removeSubscriberId,
+    updateCustomField,
+    changeIssueStatus,
+    changeTaskStatus,
+    runTaskChecks,
+  };
+};

--- a/frontend/src/components/Issue/logic/index.ts
+++ b/frontend/src/components/Issue/logic/index.ts
@@ -5,6 +5,7 @@ import GhostModeProvider from "./GhostModeProvider";
 import StandardModeProvider from "./StandardModeProvider";
 
 export * from "./common";
+export * from "./extra";
 
 export {
   IssueLogic,

--- a/frontend/src/components/Issue/logic/index.ts
+++ b/frontend/src/components/Issue/logic/index.ts
@@ -4,6 +4,7 @@ import TenantModeProvider from "./TenantModeProvider";
 import GhostModeProvider from "./GhostModeProvider";
 import StandardModeProvider from "./StandardModeProvider";
 
+export * from "./base";
 export * from "./common";
 export * from "./extra";
 


### PR DESCRIPTION
This is the last part of the IssueDetail refactor. This time we extract some less-important logic to logic/extra.ts. And extract some base logic to logic/base.ts.

Now IssueDetailLayout.vue has very less logic, and becomes almost a pure view component.

The nested components such as IssueActivityPanel, IssueBanner, IssueSidebar, etc. now can get states and logic from `useExtraIssueLogic()` and `useIssueLogic()`, instead of passing by properties and emitting events.