### PR TITLE
fix: create issue error when DBNameTemplate include regex string

### DIFF
--- a/api/project.go
+++ b/api/project.go
@@ -252,6 +252,17 @@ func ValidateProjectDBNameTemplate(template string) error {
 
 // FormatTemplate formats the template.
 func FormatTemplate(template string, tokens map[string]string) (string, error) {
+	keys, _ := getTemplateTokens(template)
+	for _, key := range keys {
+		if _, ok := tokens[key]; !ok {
+			return "", fmt.Errorf("token %q not found", key)
+		}
+		template = strings.ReplaceAll(template, key, tokens[key])
+	}
+	return template, nil
+}
+
+func buildTemplateExpr(template string, tokens map[string]string) (string, error) {
 	keys, fixed := getTemplateTokens(template)
 	for _, key := range keys {
 		if _, ok := tokens[key]; !ok {
@@ -264,7 +275,6 @@ func FormatTemplate(template string, tokens map[string]string) (string, error) {
 		if quoteKey != key {
 			template = strings.Replace(template, key, quoteKey, 1)
 		}
-
 	}
 	return template, nil
 }
@@ -291,7 +301,7 @@ func GetBaseDatabaseName(databaseName, dbNameTemplate, labelsJSON string) (strin
 	}
 	labelMap["{{DB_NAME}}"] = "(?P<NAME>.+)"
 
-	expr, err := FormatTemplate(dbNameTemplate, labelMap)
+	expr, err := buildTemplateExpr(dbNameTemplate, labelMap)
 	if err != nil {
 		return "", fmt.Errorf("FormatTemplate(%q, %+v) failed with error: %v", dbNameTemplate, labelMap, err)
 	}

--- a/server/issue.go
+++ b/server/issue.go
@@ -645,9 +645,6 @@ func (s *Server) getPipelineCreate(ctx context.Context, issueCreate *api.IssueCr
 			}
 
 			baseDBName := d.DatabaseName
-			if err != nil {
-				return nil, fmt.Errorf("api.GetBaseDatabaseName(%q, %q) failed, error: %v", d.DatabaseName, project.DBNameTemplate, err)
-			}
 			deployments, matrix, err := s.getTenantDatabaseMatrix(ctx, issueCreate.ProjectID, project.DBNameTemplate, dbList, baseDBName)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
When the project DBNameTemplate contains regular characters, due to https://github.com/bytebase/bytebase/blob/4da6d230309c8274b7638da7560172cc1ec60b7e/server/deploy.go#L132 
if return name with regular escape, it causes a mismatch.