### PR TITLE
chore: use "malformed" consistently

### DIFF
--- a/plugin/webhook/custom.go
+++ b/plugin/webhook/custom.go
@@ -81,7 +81,7 @@ func (receiver *CustomReceiver) post(context Context) error {
 
 	webhookResponse := &CustomWebhookResponse{}
 	if err := json.Unmarshal(b, webhookResponse); err != nil {
-		return fmt.Errorf("malformatted webhook response %v (%w)", context.URL, err)
+		return fmt.Errorf("malformed webhook response %v (%w)", context.URL, err)
 	}
 
 	if webhookResponse.Code != 0 {

--- a/plugin/webhook/dingtalk.go
+++ b/plugin/webhook/dingtalk.go
@@ -87,7 +87,7 @@ func (receiver *DingTalkReceiver) post(context Context) error {
 
 	webhookResponse := &DingTalkWebhookResponse{}
 	if err := json.Unmarshal(b, webhookResponse); err != nil {
-		return fmt.Errorf("malformatted webhook response %v (%w)", context.URL, err)
+		return fmt.Errorf("malformed webhook response %v (%w)", context.URL, err)
 	}
 
 	if webhookResponse.ErrorCode != 0 {

--- a/plugin/webhook/discord.go
+++ b/plugin/webhook/discord.go
@@ -113,7 +113,7 @@ func (receiver *DiscordReceiver) post(context Context) error {
 
 	webhookResponse := &DiscordWebhookResponse{}
 	if err := json.Unmarshal(b, webhookResponse); err != nil {
-		return fmt.Errorf("malformatted webhook response %v (%w)", context.URL, err)
+		return fmt.Errorf("malformed webhook response %v (%w)", context.URL, err)
 	}
 
 	if webhookResponse.Code != 0 {

--- a/plugin/webhook/feishu.go
+++ b/plugin/webhook/feishu.go
@@ -154,7 +154,7 @@ func (receiver *FeishuReceiver) post(context Context) error {
 
 	webhookResponse := &FeishuWebhookResponse{}
 	if err := json.Unmarshal(b, webhookResponse); err != nil {
-		return fmt.Errorf("malformatted webhook response %v (%w)", context.URL, err)
+		return fmt.Errorf("malformed webhook response %v (%w)", context.URL, err)
 	}
 
 	if webhookResponse.Code != 0 {

--- a/plugin/webhook/wecom.go
+++ b/plugin/webhook/wecom.go
@@ -94,7 +94,7 @@ func (receiver *WeComReceiver) post(context Context) error {
 
 	webhookResponse := &WeComWebhookResponse{}
 	if err := json.Unmarshal(b, webhookResponse); err != nil {
-		return fmt.Errorf("malformatted webhook response %v (%w)", context.URL, err)
+		return fmt.Errorf("malformed webhook response %v (%w)", context.URL, err)
 	}
 
 	if webhookResponse.ErrorCode != 0 {

--- a/server/activity.go
+++ b/server/activity.go
@@ -6,10 +6,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerActivityRoutes(g *echo.Group) {
@@ -17,7 +18,7 @@ func (s *Server) registerActivityRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		activityCreate := &api.ActivityCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, activityCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create activity request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create activity request").SetInternal(err)
 		}
 
 		activityCreate.Level = api.ActivityInfo
@@ -114,7 +115,7 @@ func (s *Server) registerActivityRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, activityPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch activity request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch activity request").SetInternal(err)
 		}
 
 		activity, err := s.store.PatchActivity(ctx, activityPatch)

--- a/server/auth.go
+++ b/server/auth.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/plugin/vcs"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/vcs"
 )
 
 func (s *Server) registerAuthRoutes(g *echo.Group) {
@@ -55,7 +56,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 			{
 				login := &api.Login{}
 				if err := jsonapi.UnmarshalPayload(c.Request().Body, login); err != nil {
-					return echo.NewHTTPError(http.StatusBadRequest, "Malformatted login request").SetInternal(err)
+					return echo.NewHTTPError(http.StatusBadRequest, "Malformed login request").SetInternal(err)
 				}
 
 				var err error
@@ -77,7 +78,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 			{
 				gitlabLogin := &api.GitlabLogin{}
 				if err := jsonapi.UnmarshalPayload(c.Request().Body, gitlabLogin); err != nil {
-					return echo.NewHTTPError(http.StatusBadRequest, "Malformatted gitlab login request").SetInternal(err)
+					return echo.NewHTTPError(http.StatusBadRequest, "Malformed gitlab login request").SetInternal(err)
 				}
 				vcsFound, err := s.store.GetVCSByID(ctx, gitlabLogin.VCSID)
 				if err != nil {
@@ -196,7 +197,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		signUp := &api.SignUp{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, signUp); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sign up request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sign up request").SetInternal(err)
 		}
 
 		user, err := trySignUp(ctx, s, signUp, api.SystemBotID)

--- a/server/bookmark.go
+++ b/server/bookmark.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerBookmarkRoutes(g *echo.Group) {
@@ -16,7 +17,7 @@ func (s *Server) registerBookmarkRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		bookmarkCreate := &api.BookmarkCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, bookmarkCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create bookmark request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create bookmark request").SetInternal(err)
 		}
 
 		bookmarkCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)

--- a/server/database.go
+++ b/server/database.go
@@ -8,12 +8,13 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/db"
 )
 
 func (s *Server) registerDatabaseRoutes(g *echo.Group) {
@@ -21,7 +22,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		databaseCreate := &api.DatabaseCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, databaseCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create database request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create database request").SetInternal(err)
 		}
 
 		databaseCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)
@@ -171,7 +172,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, dbPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch database request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch database request").SetInternal(err)
 		}
 
 		database, err := s.store.GetDatabase(ctx, &api.DatabaseFind{ID: &id})
@@ -467,7 +468,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 
 		backupCreate := &api.BackupCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, backupCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create backup request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create backup request").SetInternal(err)
 		}
 		backupCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)
 
@@ -591,7 +592,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 
 		backupSettingUpsert := &api.BackupSettingUpsert{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, backupSettingUpsert); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted set backup setting request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed set backup setting request").SetInternal(err)
 		}
 		backupSettingUpsert.UpdaterID = c.Get(getPrincipalIDContextKey()).(int)
 
@@ -707,7 +708,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 
 		dataSourceCreate := &api.DataSourceCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, dataSourceCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create data source request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create data source request").SetInternal(err)
 		}
 
 		dataSourceCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)
@@ -770,7 +771,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 
 		dataSourcePatch := &api.DataSourcePatch{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, dataSourcePatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch data source request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch data source request").SetInternal(err)
 		}
 
 		dataSourcePatch.ID = dataSourceID

--- a/server/environment.go
+++ b/server/environment.go
@@ -7,10 +7,11 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerEnvironmentRoutes(g *echo.Group) {
@@ -18,7 +19,7 @@ func (s *Server) registerEnvironmentRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		envCreate := &api.EnvironmentCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, envCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create environment request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create environment request").SetInternal(err)
 		}
 
 		envCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)
@@ -69,7 +70,7 @@ func (s *Server) registerEnvironmentRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, envPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch environment request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch environment request").SetInternal(err)
 		}
 
 		env, err := s.store.PatchEnvironment(ctx, envPatch)
@@ -91,13 +92,13 @@ func (s *Server) registerEnvironmentRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		patchList, err := jsonapi.UnmarshalManyPayload(c.Request().Body, reflect.TypeOf(new(api.EnvironmentPatch)))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted environment reorder request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed environment reorder request").SetInternal(err)
 		}
 
 		for _, item := range patchList {
 			envPatch, ok := item.(*api.EnvironmentPatch)
 			if !ok {
-				return echo.NewHTTPError(http.StatusBadRequest, "Malformatted environment reorder request").SetInternal(errors.New("failed to convert request item to *api.EnvironmentPatch"))
+				return echo.NewHTTPError(http.StatusBadRequest, "Malformed environment reorder request").SetInternal(errors.New("failed to convert request item to *api.EnvironmentPatch"))
 			}
 			envPatch.UpdaterID = c.Get(getPrincipalIDContextKey()).(int)
 			if _, err := s.store.PatchEnvironment(ctx, envPatch); err != nil {

--- a/server/inbox.go
+++ b/server/inbox.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerInboxRoutes(g *echo.Group) {
@@ -69,7 +70,7 @@ func (s *Server) registerInboxRoutes(g *echo.Group) {
 			ID: id,
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, inboxPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch inbox request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch inbox request").SetInternal(err)
 		}
 
 		inbox, err := s.store.PatchInbox(ctx, inboxPatch)

--- a/server/instance.go
+++ b/server/instance.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/db"
 )
 
 func (s *Server) registerInstanceRoutes(g *echo.Group) {
@@ -24,7 +25,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 
 		instanceCreate := &api.InstanceCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, instanceCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create instance request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create instance request").SetInternal(err)
 		}
 		instanceCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)
 		if err := s.disallowBytebaseStore(instanceCreate.Engine, instanceCreate.Host, instanceCreate.Port); err != nil {
@@ -116,7 +117,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, instancePatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch instance request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch instance request").SetInternal(err)
 		}
 
 		instance, err := s.store.GetInstanceByID(ctx, id)

--- a/server/issue.go
+++ b/server/issue.go
@@ -10,14 +10,15 @@ import (
 	"strings"
 	"time"
 
+	ghostsql "github.com/github/gh-ost/go/sql"
+	"github.com/google/jsonapi"
+	"github.com/labstack/echo/v4"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	restoremysql "github.com/bytebase/bytebase/plugin/restore/mysql"
 	"github.com/bytebase/bytebase/plugin/vcs"
-	ghostsql "github.com/github/gh-ost/go/sql"
-	"github.com/google/jsonapi"
-	"github.com/labstack/echo/v4"
 )
 
 func (s *Server) registerIssueRoutes(g *echo.Group) {
@@ -25,7 +26,7 @@ func (s *Server) registerIssueRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		issueCreate := &api.IssueCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, issueCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create issue request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create issue request").SetInternal(err)
 		}
 
 		issue, err := s.createIssue(ctx, issueCreate, c.Get(getPrincipalIDContextKey()).(int))
@@ -120,7 +121,7 @@ func (s *Server) registerIssueRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, issuePatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted update issue request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed update issue request").SetInternal(err)
 		}
 
 		if issuePatch.AssigneeID != nil {
@@ -215,7 +216,7 @@ func (s *Server) registerIssueRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, issueStatusPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted update issue status request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed update issue status request").SetInternal(err)
 		}
 
 		issue, err := s.store.GetIssue(ctx, &api.IssueFind{ID: &id})

--- a/server/issue_subscriber.go
+++ b/server/issue_subscriber.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerIssueSubscriberRoutes(g *echo.Group) {
@@ -21,7 +22,7 @@ func (s *Server) registerIssueSubscriberRoutes(g *echo.Group) {
 
 		issueSubscriberCreate := &api.IssueSubscriberCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, issueSubscriberCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create issueSubscriber request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create issueSubscriber request").SetInternal(err)
 		}
 
 		issueSubscriberCreate.IssueID = issueID

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -7,12 +7,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/store"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/store"
 )
 
 const (
@@ -221,7 +222,7 @@ func JWTMiddleware(l *zap.Logger, principalStore *store.Store, next echo.Handler
 			ctx := c.Request().Context()
 			principalID, err := strconv.Atoi(claims.Subject)
 			if err != nil {
-				return echo.NewHTTPError(http.StatusUnauthorized, "Malformatted ID in the token.")
+				return echo.NewHTTPError(http.StatusUnauthorized, "Malformed ID in the token.")
 			}
 
 			// Even if there is no error, we still need to make sure the user still exists.

--- a/server/label.go
+++ b/server/label.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerLabelRoutes(g *echo.Group) {
@@ -53,7 +54,7 @@ func (s *Server) registerLabelRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, patch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch label key request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch label key request").SetInternal(err)
 		}
 
 		if err := patch.Validate(); err != nil {

--- a/server/member.go
+++ b/server/member.go
@@ -6,10 +6,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerMemberRoutes(g *echo.Group) {
@@ -17,7 +18,7 @@ func (s *Server) registerMemberRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		memberCreate := &api.MemberCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, memberCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create member request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create member request").SetInternal(err)
 		}
 
 		memberCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)
@@ -105,7 +106,7 @@ func (s *Server) registerMemberRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, memberPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch member request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch member request").SetInternal(err)
 		}
 
 		updatedMember, err := s.store.PatchMember(ctx, memberPatch)

--- a/server/policy.go
+++ b/server/policy.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 // hasAccessToUpdatePolicy checks if user can access to policy control feature.
@@ -54,7 +55,7 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 
 		policyUpsert := &api.PolicyUpsert{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, policyUpsert); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted set policy request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed set policy request").SetInternal(err)
 		}
 		pType := api.PolicyType(c.QueryParam("type"))
 		if err := api.ValidatePolicy(pType, ""); err != nil {

--- a/server/principal.go
+++ b/server/principal.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 func (s *Server) registerPrincipalRoutes(g *echo.Group) {
@@ -17,7 +18,7 @@ func (s *Server) registerPrincipalRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		principalCreate := &api.PrincipalCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, principalCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create principal request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create principal request").SetInternal(err)
 		}
 
 		principalCreate.CreatorID = c.Get(getPrincipalIDContextKey()).(int)
@@ -93,7 +94,7 @@ func (s *Server) registerPrincipalRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, principalPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch principal request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch principal request").SetInternal(err)
 		}
 		if principalPatch.Password != nil && *principalPatch.Password != "" {
 			passwordHash, err := bcrypt.GenerateFromPassword([]byte(*principalPatch.Password), bcrypt.DefaultCost)

--- a/server/project.go
+++ b/server/project.go
@@ -11,11 +11,12 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 
-	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
-	"github.com/bytebase/bytebase/plugin/vcs/gitlab"
 	"github.com/google/jsonapi"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+
+	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
+	"github.com/bytebase/bytebase/plugin/vcs/gitlab"
 )
 
 func (s *Server) registerProjectRoutes(g *echo.Group) {
@@ -23,7 +24,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		projectCreate := &api.ProjectCreate{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, projectCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create project request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create project request").SetInternal(err)
 		}
 		if projectCreate.TenantMode == api.TenantModeTenant && !s.feature(api.FeatureMultiTenancy) {
 			return echo.NewHTTPError(http.StatusForbidden, api.FeatureMultiTenancy.AccessErrorMessage())
@@ -33,7 +34,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			projectCreate.TenantMode = api.TenantModeDisabled
 		}
 		if err := api.ValidateProjectDBNameTemplate(projectCreate.DBNameTemplate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformatted create project request: %s", err.Error()))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformed create project request: %s", err.Error()))
 		}
 		if projectCreate.TenantMode != api.TenantModeTenant && projectCreate.DBNameTemplate != "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "database name template can only be set for tenant mode project")
@@ -154,7 +155,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, projectPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch project request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch project request").SetInternal(err)
 		}
 
 		project, err := s.store.PatchProject(ctx, projectPatch)
@@ -184,7 +185,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			CreatorID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, repositoryCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create linked repository request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create linked repository request").SetInternal(err)
 		}
 
 		project, err := s.store.GetProjectByID(ctx, projectID)
@@ -196,11 +197,11 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		}
 
 		if err := api.ValidateRepositoryFilePathTemplate(repositoryCreate.FilePathTemplate, project.TenantMode); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformatted create linked repository request: %s", err.Error()))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformed create linked repository request: %s", err.Error()))
 		}
 
 		if err := api.ValidateRepositorySchemaPathTemplate(repositoryCreate.SchemaPathTemplate, project.TenantMode); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformatted create linked repository request: %s", err.Error()))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformed create linked repository request: %s", err.Error()))
 		}
 
 		vcs, err := s.store.GetVCSByID(ctx, repositoryCreate.VCSID)
@@ -307,7 +308,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, repoPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch linked repository request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch linked repository request").SetInternal(err)
 		}
 		project, err := s.store.GetProjectByID(ctx, projectID)
 		if err != nil {
@@ -319,13 +320,13 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 
 		if repoPatch.FilePathTemplate != nil {
 			if err := api.ValidateRepositoryFilePathTemplate(*repoPatch.FilePathTemplate, project.TenantMode); err != nil {
-				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformatted patch linked repository request: %s", err.Error()))
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformed patch linked repository request: %s", err.Error()))
 			}
 		}
 
 		if repoPatch.SchemaPathTemplate != nil {
 			if err := api.ValidateRepositorySchemaPathTemplate(*repoPatch.SchemaPathTemplate, project.TenantMode); err != nil {
-				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformatted create linked repository request: %s", err.Error()))
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformed create linked repository request: %s", err.Error()))
 			}
 		}
 
@@ -485,7 +486,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 
 		deploymentConfigUpsert := &api.DeploymentConfigUpsert{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, deploymentConfigUpsert); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted set deployment configuration request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed set deployment configuration request").SetInternal(err)
 		}
 		deploymentConfigUpsert.UpdaterID = c.Get(getPrincipalIDContextKey()).(int)
 

--- a/server/project_member.go
+++ b/server/project_member.go
@@ -7,12 +7,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
 )
 
 func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
@@ -230,7 +231,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 			CreatorID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, projectMemberCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create project membership request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create project membership request").SetInternal(err)
 		}
 
 		projectMember, err := s.store.CreateProjectMember(ctx, projectMemberCreate)
@@ -293,7 +294,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, projectMemberPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted change project membership").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed change project membership").SetInternal(err)
 		}
 
 		projectMember, err := s.store.PatchProjectMember(ctx, projectMemberPatch)

--- a/server/project_webhook.go
+++ b/server/project_webhook.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/jsonapi"
+	"github.com/labstack/echo/v4"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	webhookPlugin "github.com/bytebase/bytebase/plugin/webhook"
-	"github.com/google/jsonapi"
-	"github.com/labstack/echo/v4"
 )
 
 func (s *Server) registerProjectWebhookRoutes(g *echo.Group) {
@@ -48,7 +49,7 @@ func (s *Server) registerProjectWebhookRoutes(g *echo.Group) {
 			ProjectID: projectID,
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, hookCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create project webhook request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create project webhook request").SetInternal(err)
 		}
 
 		webhook, err := s.store.CreateProjectWebhook(ctx, hookCreate)
@@ -110,7 +111,7 @@ func (s *Server) registerProjectWebhookRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, hookPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted change project webhook").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed change project webhook").SetInternal(err)
 		}
 
 		webhook, err := s.store.PatchProjectWebhook(ctx, hookPatch)

--- a/server/setting.go
+++ b/server/setting.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 var (
@@ -55,7 +56,7 @@ func (s *Server) registerSettingRoutes(g *echo.Group) {
 		}
 
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, settingPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted update setting request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed update setting request").SetInternal(err)
 		}
 
 		setting, err := s.store.PatchSetting(ctx, settingPatch)

--- a/server/sheet.go
+++ b/server/sheet.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/jsonapi"
+	"github.com/labstack/echo/v4"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
-	"github.com/google/jsonapi"
-	"github.com/labstack/echo/v4"
 )
 
 func (s *Server) registerSheetRoutes(g *echo.Group) {
@@ -26,11 +27,11 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 			CreatorID: currentPrincipalID,
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, sheetCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create sheet request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create sheet request").SetInternal(err)
 		}
 
 		if sheetCreate.Name == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sheet request, missing name")
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sheet request, missing name")
 		}
 
 		// If sheetCreate.DatabaseID is not nil, use its associated ProjectID as the new sheet's ProjectID.
@@ -402,7 +403,7 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 			UpdaterID: currentPrincipalID,
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, sheetPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch sheet request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch sheet request").SetInternal(err)
 		}
 
 		sheet, err := s.store.PatchSheet(ctx, sheetPatch)

--- a/server/sheet_organizer.go
+++ b/server/sheet_organizer.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+
+	"github.com/bytebase/bytebase/api"
 )
 
 func (s *Server) registerSheetOrganizerRoutes(g *echo.Group) {
@@ -24,7 +25,7 @@ func (s *Server) registerSheetOrganizerRoutes(g *echo.Group) {
 			PrincipalID: principalID,
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, sheetOrganizerUpsert); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted patch sheet organizer request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch sheet organizer request").SetInternal(err)
 		}
 
 		if _, err := s.store.UpsertSheetOrganizer(ctx, sheetOrganizerUpsert); err != nil {

--- a/server/sql.go
+++ b/server/sql.go
@@ -10,13 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/jsonapi"
+	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
-	"github.com/google/jsonapi"
-	"github.com/labstack/echo/v4"
-	"go.uber.org/zap"
 )
 
 func (s *Server) registerSQLRoutes(g *echo.Group) {
@@ -24,7 +25,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		connectionInfo := &api.ConnectionInfo{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, connectionInfo); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sql ping request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sql ping request").SetInternal(err)
 		}
 		if err := s.disallowBytebaseStore(connectionInfo.Engine, connectionInfo.Host, connectionInfo.Port); err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
@@ -81,7 +82,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		sync := &api.SQLSyncSchema{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, sync); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sql sync schema request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sql sync schema request").SetInternal(err)
 		}
 
 		instance, err := s.store.GetInstanceByID(ctx, sync.InstanceID)
@@ -105,20 +106,20 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		ctx := c.Request().Context()
 		exec := &api.SQLExecute{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, exec); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sql execute request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sql execute request").SetInternal(err)
 		}
 
 		if exec.InstanceID == 0 {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sql execute request, missing instanceId")
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sql execute request, missing instanceId")
 		}
 		if len(exec.Statement) == 0 {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sql execute request, missing sql statement")
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sql execute request, missing sql statement")
 		}
 		if !exec.Readonly {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sql execute request, only support readonly sql statement")
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sql execute request, only support readonly sql statement")
 		}
 		if !validateSQLSelectStatement(exec.Statement) {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted sql execute request, only support SELECT sql statement")
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed sql execute request, only support SELECT sql statement")
 		}
 
 		instance, err := s.store.GetInstanceByID(ctx, exec.InstanceID)

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	enterpriseAPI "github.com/bytebase/bytebase/enterprise/api"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	enterpriseAPI "github.com/bytebase/bytebase/enterprise/api"
 )
 
 func (s *Server) registerSubscriptionRoutes(g *echo.Group) {
@@ -24,7 +25,7 @@ func (s *Server) registerSubscriptionRoutes(g *echo.Group) {
 	g.PATCH("/subscription", func(c echo.Context) error {
 		patch := &enterpriseAPI.SubscriptionPatch{}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, patch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create subscription request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create subscription request").SetInternal(err)
 		}
 
 		if err := s.LicenseService.StoreLicense(patch.License); err != nil {

--- a/server/task.go
+++ b/server/task.go
@@ -7,12 +7,13 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/db"
 )
 
 var (
@@ -48,7 +49,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, taskPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted update task request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed update task request").SetInternal(err)
 		}
 
 		if taskPatch.EarliestAllowedTs != nil && !s.feature(api.FeatureTaskScheduleTime) {
@@ -93,7 +94,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			case api.TaskDatabaseSchemaUpdate:
 				payload := &api.TaskDatabaseSchemaUpdatePayload{}
 				if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
-					return echo.NewHTTPError(http.StatusBadRequest, "Malformatted database schema update payload").SetInternal(err)
+					return echo.NewHTTPError(http.StatusBadRequest, "Malformed database schema update payload").SetInternal(err)
 				}
 				oldStatement = payload.Statement
 				payload.Statement = *taskPatch.Statement
@@ -110,7 +111,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 
 				payload := &api.TaskDatabaseDataUpdatePayload{}
 				if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
-					return echo.NewHTTPError(http.StatusBadRequest, "Malformatted database data update payload").SetInternal(err)
+					return echo.NewHTTPError(http.StatusBadRequest, "Malformed database data update payload").SetInternal(err)
 				}
 				oldStatement = payload.Statement
 				payload.Statement = *taskPatch.Statement
@@ -295,7 +296,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			UpdaterID: currentPrincipalID,
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, taskStatusPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted update task status request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed update task status request").SetInternal(err)
 		}
 
 		task, err := s.store.GetTaskByID(ctx, taskID)

--- a/server/vcs.go
+++ b/server/vcs.go
@@ -21,7 +21,7 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 			CreatorID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, vcsCreate); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted create VCS request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create VCS request").SetInternal(err)
 		}
 		// Trim ending "/"
 		vcsCreate.InstanceURL = strings.TrimRight(vcsCreate.InstanceURL, "/")
@@ -85,7 +85,7 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 			UpdaterID: c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, vcsPatch); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted change VCS request").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed change VCS request").SetInternal(err)
 		}
 
 		vcs, err := s.store.PatchVCS(ctx, vcsPatch)

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/vcs"
 	"github.com/bytebase/bytebase/plugin/vcs/gitlab"
-	"github.com/labstack/echo/v4"
-	"go.uber.org/zap"
 )
 
 var (
@@ -36,7 +37,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 
 		pushEvent := &gitlab.WebhookPushEvent{}
 		if err := json.Unmarshal(b, pushEvent); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Malformatted push event").SetInternal(err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Malformed push event").SetInternal(err)
 		}
 
 		// This shouldn't happen as we only setup webhook to receive push event, just in case.


### PR DESCRIPTION
Use "[Mm]alformed" consistently across the codebase to replace "[Mm]alformatted".

---

Follow up of https://github.com/bytebase/bytebase/pull/998#discussion_r863824174