### PR TITLE
fix: only allow to create the webhook when activity list is non-empty

### DIFF
--- a/frontend/src/components/ProjectWebhookForm.vue
+++ b/frontend/src/components/ProjectWebhookForm.vue
@@ -369,7 +369,8 @@ export default defineComponent({
       return (
         !isEmpty(state.webhook.type) &&
         !isEmpty(state.webhook.name) &&
-        !isEmpty(state.webhook.url)
+        !isEmpty(state.webhook.url) &&
+        !isEmpty(state.webhook.activityList)
       );
     });
 


### PR DESCRIPTION
Reproduce:

https://user-images.githubusercontent.com/87714218/168457626-38ab62ce-bc52-4067-ba4d-c66ef6335001.mp4

Fix:

https://user-images.githubusercontent.com/87714218/168457629-e91bae42-1b8e-4ab0-a2b6-daa189a1798b.mp4

**Still allows the user to cancel the activity on modification to temporarily stop the webhook**
