### PR TITLE
feat(PITR): implement the logical backup process

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -151,6 +151,7 @@ type BackupPatch struct {
 	// Domain specific fields
 	Status  string
 	Comment string
+	Payload string
 }
 
 // BackupSetting is the backup setting for a database.

--- a/bin/bb/cmd/dump.go
+++ b/bin/bb/cmd/dump.go
@@ -55,7 +55,7 @@ func dumpDatabase(ctx context.Context, u *dburl.URL, out io.Writer, schemaOnly b
 	}
 	defer db.Close(ctx)
 
-	if err := db.Dump(ctx, getDatabase(u), out, schemaOnly); err != nil {
+	if _, err := db.Dump(ctx, getDatabase(u), out, schemaOnly); err != nil {
 		return fmt.Errorf("failed to create dump, got error: %w", err)
 	}
 	return nil

--- a/docs/design/pitr-mysql.md
+++ b/docs/design/pitr-mysql.md
@@ -168,13 +168,13 @@ An example of the PITR information is like this:
     "binlog_info": {
         "binlog_name": "binlog.000001",
         "binlog_position": 1234,
-        "timestamp": 1650957790,
+        "ts": 1650957790,
     },
     "file_size": 10240
 }
 ```
 
-where the timestamp is a UNIX timestamp in seconds, indicating the binlog event time in binlog.000001 at the position 1234.
+where the `ts` field is a UNIX timestamp in seconds, indicating the binlog event time in binlog.000001 at the position 1234.
 
 We will add a field in api.Backup:
 

--- a/docs/design/pitr-mysql.md
+++ b/docs/design/pitr-mysql.md
@@ -168,11 +168,13 @@ An example of the PITR information is like this:
     "binlog_info": {
         "binlog_name": "binlog.000001",
         "binlog_position": 1234,
+        "timestamp": 1650957790,
     },
-    "created_ts": 1650957790,  // UNIX timestamp in seconds
-    "file_size": 10240  // Bytes
+    "file_size": 10240
 }
 ```
+
+where the timestamp is a UNIX timestamp in seconds, indicating the binlog event time in binlog.000001 at the position 1234.
 
 We will add a field in api.Backup:
 

--- a/docs/design/pitr-mysql.md
+++ b/docs/design/pitr-mysql.md
@@ -88,7 +88,7 @@ Currently, we keep the logical backup and binlog together in the local disk wher
 
 The partial backup dump should be discarded if Bytebase encounters an unrecoverable error during the full backup process. The system should report a failed backup, and the user could choose to start another backup task manually. The partially dumped logical backup file will be automatically deleted by Bytebase.
 
-To check the integrity of the logical dump, Bytebase will write file size along with the table data into the backup file. When using a logical backup to recover, we should first validate the file size.
+To check the integrity of the logical dump, Bytebase will save file size in the backup metadata. When using a logical backup to recover, we should first validate the file size of the dump file and the metadata matches.
 
 ## Incremental Backup
 
@@ -168,8 +168,9 @@ An example of the PITR information is like this:
     "binlog_info": {
         "binlog_name": "binlog.000001",
         "binlog_position": 1234,
-        "created_ts": 1650957790
-    }
+    },
+    "created_ts": 1650957790,  // UNIX timestamp in seconds
+    "file_size": 10240  // Bytes
 }
 ```
 

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -703,22 +703,22 @@ const (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) error {
+func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer txn.Rollback()
 
 	if err := dumpTxn(ctx, txn, database, out, schemaOnly); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return "", nil
 }
 
 // dumpTxn will dump the input database. schemaOnly isn't supported yet and true by default.

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -706,19 +706,19 @@ const (
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return "", err
+		return "{}", err
 	}
 	defer txn.Rollback()
 
 	if err := dumpTxn(ctx, txn, database, out, schemaOnly); err != nil {
-		return "", err
+		return "{}", err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return "", err
+		return "{}", err
 	}
 
-	return "", nil
+	return "{}", nil
 }
 
 // dumpTxn will dump the input database. schemaOnly isn't supported yet and true by default.

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -706,19 +706,19 @@ const (
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return "{}", err
+		return "", err
 	}
 	defer txn.Rollback()
 
 	if err := dumpTxn(ctx, txn, database, out, schemaOnly); err != nil {
-		return "{}", err
+		return "", err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return "{}", err
+		return "", err
 	}
 
-	return "{}", nil
+	return "", nil
 }
 
 // dumpTxn will dump the input database. schemaOnly isn't supported yet and true by default.

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -428,7 +428,9 @@ type Driver interface {
 
 	// Dump and restore
 	// Dump the database, if dbName is empty, then dump all databases.
-	Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) error
+	// The returned string is the JSON encoded metadata for the logical dump.
+	// For MySQL, the payload contains the binlog filename and position when the dump is generated.
+	Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error)
 	// Restore the database from sc, which is a full backup.
 	Restore(ctx context.Context, sc *bufio.Scanner) error
 }

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -997,7 +997,7 @@ func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error
 
 func mysqlNowUnix(ctx context.Context, db *sql.DB) (int64, error) {
 	var timestamp int64
-	rows, err := db.QueryContext(ctx, "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())")
+	rows, err := db.QueryContext(ctx, "SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP())")
 	if err != nil {
 		return 0, err
 	}
@@ -1186,7 +1186,8 @@ func showMasterStatus(ctx context.Context, conn *sql.Conn) (*BinlogInfo, error) 
 	rows.Next()
 	// TODO(dragonly): Fill the `Timestamp` field.
 	binlogConfig := BinlogInfo{}
-	if err := rows.Scan(&binlogConfig.Filename, &binlogConfig.Position); err != nil {
+	var unused interface{}
+	if err := rows.Scan(&binlogConfig.Filename, &binlogConfig.Position, &unused, &unused, &unused); err != nil {
 		return nil, err
 	}
 

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -997,7 +997,7 @@ func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error
 
 func mysqlNowUnix(ctx context.Context, db *sql.DB) (int64, error) {
 	var timestamp int64
-	rows, err := db.QueryContext(ctx, "SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP())")
+	rows, err := db.QueryContext(ctx, "SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP());")
 	if err != nil {
 		return 0, err
 	}
@@ -1029,7 +1029,7 @@ func flushTablesWithReadLock(ctx context.Context, conn *sql.Conn, database strin
 	for _, table := range tables {
 		tableNames = append(tableNames, table.Name)
 	}
-	flushTableStmt := fmt.Sprintf("FLUSH TABLES %s WITH READ LOCK", strings.Join(tableNames, ", "))
+	flushTableStmt := fmt.Sprintf("FLUSH TABLES %s WITH READ LOCK;", strings.Join(tableNames, ", "))
 
 	if _, err := txn.ExecContext(ctxWithTimeout, flushTableStmt); err != nil {
 		return err
@@ -1177,7 +1177,7 @@ func getDatabases(ctx context.Context, txn *sql.Tx) ([]string, error) {
 }
 
 func showMasterStatus(ctx context.Context, conn *sql.Conn) (*BinlogInfo, error) {
-	rows, err := conn.QueryContext(ctx, "SHOW MASTER STATUS")
+	rows, err := conn.QueryContext(ctx, "SHOW MASTER STATUS;")
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -57,7 +57,7 @@ type backupPayload struct {
 	BinlogInfo BinlogInfo `json:"binlog_info"`
 	// Imprecise UNIX timestamp to the second which is the rough time when this backup is taken.
 	// Mainly for UI purpose.
-	ImpreciseTs int64 `json:"imprecise_ts"`
+	Ts int64 `json:"ts"`
 }
 
 // Driver is the MySQL driver.
@@ -935,8 +935,8 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	}
 
 	payload := backupPayload{
-		BinlogInfo:  *binlog,
-		ImpreciseTs: nowMySQL,
+		BinlogInfo: *binlog,
+		Ts:         nowMySQL,
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -48,13 +48,13 @@ func init() {
 
 // BinlogInfo is the binlog coordination for MySQL.
 type BinlogInfo struct {
-	Filename string `json:"file_name"`
+	Filename string `json:"fileName"`
 	Position int64  `json:"position"`
 }
 
 // This is encoded in JSON and stored in the backup table, representing PITR related info.
 type backupPayload struct {
-	BinlogInfo BinlogInfo `json:"binlog_info"`
+	BinlogInfo BinlogInfo `json:"binlogInfo"`
 	// Imprecise UNIX timestamp to the second which is the rough time when this backup is taken.
 	// Mainly for UI purpose.
 	Ts int64 `json:"ts"`

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -911,19 +911,19 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	// We must use the same MySQL connection to lock and unlock tables.
 	conn, err := driver.db.Conn(ctx)
 	if err != nil {
-		return "", err
+		return "{}", err
 	}
 	defer conn.Close()
 
 	driver.l.Debug("FLUSH TABLES WITH READ LOCK",
 		zap.String("database", database))
 	if err := flushTablesWithReadLock(ctx, conn, database); err != nil {
-		return "", err
+		return "{}", err
 	}
 
 	binlog, err := showMasterStatus(ctx, conn)
 	if err != nil {
-		return "", err
+		return "{}", err
 	}
 	driver.l.Debug("binlog config at dump time",
 		zap.String("filename", binlog.Filename),
@@ -931,7 +931,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 
 	nowMySQL, err := mysqlNowUnix(ctx, driver.db)
 	if err != nil {
-		return "", err
+		return "{}", err
 	}
 
 	payload := backupPayload{
@@ -940,7 +940,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return "", err
+		return "{}", err
 	}
 
 	options := sql.TxOptions{}
@@ -953,17 +953,17 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	// ref: https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html, section "Interaction of Table Locking and Transactions".
 	txn, err := conn.BeginTx(ctx, &options)
 	if err != nil {
-		return "", err
+		return "{}", err
 	}
 	defer txn.Rollback()
 
 	driver.l.Debug("begin to dump database")
 	if err := dumpTxn(ctx, txn, database, out, schemaOnly); err != nil {
-		return "", err
+		return "{}", err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return "", err
+		return "{}", err
 	}
 
 	return string(payloadBytes), nil

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -944,7 +944,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 		options.ReadOnly = true
 	}
 	// Now we are still holding the tables' exclusive locks.
-	// Begining a transaction in the same session will implicitly release existing table locks.
+	// Beginning a transaction in the same session will implicitly release existing table locks.
 	// ref: https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html, section "Interaction of Table Locking and Transactions".
 	txn, err := conn.BeginTx(ctx, &options)
 	if err != nil {

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -812,7 +812,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	// Find all dumpable databases
 	databases, err := driver.getDatabases()
 	if err != nil {
-		return "{}", fmt.Errorf("failed to get databases: %s", err)
+		return "", fmt.Errorf("failed to get databases: %s", err)
 	}
 
 	var dumpableDbNames []string
@@ -825,7 +825,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 			}
 		}
 		if !exist {
-			return "{}", fmt.Errorf("database %s not found", database)
+			return "", fmt.Errorf("database %s not found", database)
 		}
 		dumpableDbNames = []string{database}
 	} else {
@@ -840,11 +840,11 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	for _, dbName := range dumpableDbNames {
 		includeUseDatabase := len(dumpableDbNames) > 1
 		if err := driver.dumpOneDatabase(ctx, dbName, out, schemaOnly, includeUseDatabase); err != nil {
-			return "{}", err
+			return "", err
 		}
 	}
 
-	return "{}", nil
+	return "", nil
 }
 
 // Restore restores a database.

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -812,7 +812,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	// Find all dumpable databases
 	databases, err := driver.getDatabases()
 	if err != nil {
-		return "", fmt.Errorf("failed to get databases: %s", err)
+		return "{}", fmt.Errorf("failed to get databases: %s", err)
 	}
 
 	var dumpableDbNames []string
@@ -825,7 +825,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 			}
 		}
 		if !exist {
-			return "", fmt.Errorf("database %s not found", database)
+			return "{}", fmt.Errorf("database %s not found", database)
 		}
 		dumpableDbNames = []string{database}
 	} else {
@@ -840,11 +840,11 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	for _, dbName := range dumpableDbNames {
 		includeUseDatabase := len(dumpableDbNames) > 1
 		if err := driver.dumpOneDatabase(ctx, dbName, out, schemaOnly, includeUseDatabase); err != nil {
-			return "", err
+			return "{}", err
 		}
 	}
 
-	return "", nil
+	return "{}", nil
 }
 
 // Restore restores a database.

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -806,13 +806,13 @@ func (driver *Driver) updateMigrationHistoryStorageVersion(ctx context.Context) 
 // Dump and restore
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) error {
+func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	// pg_dump -d dbName --schema-only+
 
 	// Find all dumpable databases
 	databases, err := driver.getDatabases()
 	if err != nil {
-		return fmt.Errorf("failed to get databases: %s", err)
+		return "", fmt.Errorf("failed to get databases: %s", err)
 	}
 
 	var dumpableDbNames []string
@@ -825,7 +825,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 			}
 		}
 		if !exist {
-			return fmt.Errorf("database %s not found", database)
+			return "", fmt.Errorf("database %s not found", database)
 		}
 		dumpableDbNames = []string{database}
 	} else {
@@ -840,11 +840,11 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 	for _, dbName := range dumpableDbNames {
 		includeUseDatabase := len(dumpableDbNames) > 1
 		if err := driver.dumpOneDatabase(ctx, dbName, out, schemaOnly, includeUseDatabase); err != nil {
-			return err
+			return "", err
 		}
 	}
 
-	return nil
+	return "", nil
 }
 
 // Restore restores a database.

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -868,22 +868,22 @@ const (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) error {
+func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer txn.Rollback()
 
 	if err := dumpTxn(ctx, txn, database, out, schemaOnly); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return "", nil
 }
 
 // dumpTxn will dump the input database. schemaOnly isn't supported yet and true by default.

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -871,19 +871,19 @@ const (
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return "{}", err
+		return "", err
 	}
 	defer txn.Rollback()
 
 	if err := dumpTxn(ctx, txn, database, out, schemaOnly); err != nil {
-		return "{}", err
+		return "", err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return "{}", err
+		return "", err
 	}
 
-	return "{}", nil
+	return "", nil
 }
 
 // dumpTxn will dump the input database. schemaOnly isn't supported yet and true by default.

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -871,19 +871,19 @@ const (
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return "", err
+		return "{}", err
 	}
 	defer txn.Rollback()
 
 	if err := dumpTxn(ctx, txn, database, out, schemaOnly); err != nil {
-		return "", err
+		return "{}", err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return "", err
+		return "{}", err
 	}
 
-	return "", nil
+	return "{}", nil
 }
 
 // dumpTxn will dump the input database. schemaOnly isn't supported yet and true by default.

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -634,13 +634,13 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 // Dump dumps the database.
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	if database == "" {
-		return "{}", fmt.Errorf("SQLite can dump one database only at a time")
+		return "", fmt.Errorf("SQLite can dump one database only at a time")
 	}
 
 	// Find all dumpable databases and make sure the existence of the database to be dumped.
 	databases, err := driver.getDatabases()
 	if err != nil {
-		return "{}", fmt.Errorf("failed to get databases: %s", err)
+		return "", fmt.Errorf("failed to get databases: %s", err)
 	}
 	exist := false
 	for _, n := range databases {
@@ -650,14 +650,14 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 		}
 	}
 	if !exist {
-		return "{}", fmt.Errorf("database %s not found", database)
+		return "", fmt.Errorf("database %s not found", database)
 	}
 
 	if err := driver.dumpOneDatabase(ctx, database, out, schemaOnly); err != nil {
-		return "{}", err
+		return "", err
 	}
 
-	return "{}", nil
+	return "", nil
 }
 
 type sqliteSchema struct {

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -632,15 +632,15 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 }
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) error {
+func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	if database == "" {
-		return fmt.Errorf("SQLite can dump one database only at a time")
+		return "", fmt.Errorf("SQLite can dump one database only at a time")
 	}
 
 	// Find all dumpable databases and make sure the existence of the database to be dumped.
 	databases, err := driver.getDatabases()
 	if err != nil {
-		return fmt.Errorf("failed to get databases: %s", err)
+		return "", fmt.Errorf("failed to get databases: %s", err)
 	}
 	exist := false
 	for _, n := range databases {
@@ -650,14 +650,14 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 		}
 	}
 	if !exist {
-		return fmt.Errorf("database %s not found", database)
+		return "", fmt.Errorf("database %s not found", database)
 	}
 
 	if err := driver.dumpOneDatabase(ctx, database, out, schemaOnly); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return "", nil
 }
 
 type sqliteSchema struct {

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -634,13 +634,13 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 // Dump dumps the database.
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	if database == "" {
-		return "", fmt.Errorf("SQLite can dump one database only at a time")
+		return "{}", fmt.Errorf("SQLite can dump one database only at a time")
 	}
 
 	// Find all dumpable databases and make sure the existence of the database to be dumped.
 	databases, err := driver.getDatabases()
 	if err != nil {
-		return "", fmt.Errorf("failed to get databases: %s", err)
+		return "{}", fmt.Errorf("failed to get databases: %s", err)
 	}
 	exist := false
 	for _, n := range databases {
@@ -650,14 +650,14 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 		}
 	}
 	if !exist {
-		return "", fmt.Errorf("database %s not found", database)
+		return "{}", fmt.Errorf("database %s not found", database)
 	}
 
 	if err := driver.dumpOneDatabase(ctx, database, out, schemaOnly); err != nil {
-		return "", err
+		return "{}", err
 	}
 
-	return "", nil
+	return "{}", nil
 }
 
 type sqliteSchema struct {

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -131,7 +131,7 @@ func ExecuteMigration(ctx context.Context, l *zap.Logger, executor MigrationExec
 	if !m.CreateDatabase {
 		// For baseline migration, we also record the live schema to detect the schema drift.
 		// See https://bytebase.com/blog/what-is-database-schema-drift
-		if err := executor.Dump(ctx, m.Database, &prevSchemaBuf, true /*schemaOnly*/); err != nil {
+		if _, err := executor.Dump(ctx, m.Database, &prevSchemaBuf, true /*schemaOnly*/); err != nil {
 			return -1, "", FormatError(err)
 		}
 	}
@@ -172,7 +172,7 @@ func ExecuteMigration(ctx context.Context, l *zap.Logger, executor MigrationExec
 
 	// Phase 4 - Dump the schema after migration
 	var afterSchemaBuf bytes.Buffer
-	if err := executor.Dump(ctx, m.Database, &afterSchemaBuf, true /*schemaOnly*/); err != nil {
+	if _, err := executor.Dump(ctx, m.Database, &afterSchemaBuf, true /*schemaOnly*/); err != nil {
 		return -1, "", FormatError(err)
 	}
 

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -14,12 +14,6 @@ const (
 	MaxDatabaseNameLength = 64
 )
 
-// BinlogConfig is the binlog coordination for MySQL.
-type BinlogConfig struct {
-	Filename string
-	Position int64
-}
-
 // Restore implements recovery functions for MySQL
 type Restore struct {
 	driver *mysql.Driver
@@ -33,12 +27,12 @@ func New(driver *mysql.Driver) *Restore {
 }
 
 // RestoreBinlog restores the database using incremental backup in time range of [config.Start, config.End).
-func (r *Restore) RestoreBinlog(ctx context.Context, config BinlogConfig) error {
+func (r *Restore) RestoreBinlog(ctx context.Context, config mysql.BinlogInfo) error {
 	return fmt.Errorf("Unimplemented")
 }
 
 // RestorePITR is a wrapper for restore a full backup and a range of incremental backup
-func (r *Restore) RestorePITR(ctx context.Context, fullBackup *bufio.Scanner, config BinlogConfig, database string, timestamp int64) error {
+func (r *Restore) RestorePITR(ctx context.Context, fullBackup *bufio.Scanner, binlog mysql.BinlogInfo, database string, timestamp int64) error {
 	pitrDatabaseName := GetPITRDatabaseName(database, timestamp)
 	query := fmt.Sprintf(""+
 		// Create the pitr database.
@@ -69,7 +63,7 @@ func (r *Restore) RestorePITR(ctx context.Context, fullBackup *bufio.Scanner, co
 	}
 
 	// TODO(dragonly): implement RestoreBinlog in mysql driver
-	_ = r.RestoreBinlog(ctx, config)
+	_ = r.RestoreBinlog(ctx, binlog)
 
 	return nil
 }

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,18 +58,4 @@ func TestGetPITRDatabaseName(t *testing.T) {
 		name := GetPITRDatabaseName(test.database, int64(test.timestamp))
 		a.Equal(test.expected, name)
 	}
-}
-
-func TestJSON(t *testing.T) {
-	type in struct {
-		Val int `json:"val"`
-	}
-	type out struct {
-		In  in
-		Key int `json:"key"`
-	}
-	o := out{In: in{Val: 1}, Key: 1}
-
-	bytes, _ := json.Marshal(o)
-	t.Log(string(bytes))
 }

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,4 +59,18 @@ func TestGetPITRDatabaseName(t *testing.T) {
 		name := GetPITRDatabaseName(test.database, int64(test.timestamp))
 		a.Equal(test.expected, name)
 	}
+}
+
+func TestJSON(t *testing.T) {
+	type in struct {
+		Val int `json:"val"`
+	}
+	type out struct {
+		In  in
+		Key int `json:"key"`
+	}
+	o := out{In: in{Val: 1}, Key: 1}
+
+	bytes, _ := json.Marshal(o)
+	t.Log(string(bytes))
 }

--- a/server/anomaly_scanner.go
+++ b/server/anomaly_scanner.go
@@ -286,7 +286,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 			goto SchemaDriftEnd
 		}
 		var schemaBuf bytes.Buffer
-		if err := driver.Dump(ctx, database.Name, &schemaBuf, true /*schemaOnly*/); err != nil {
+		if _, err := driver.Dump(ctx, database.Name, &schemaBuf, true /*schemaOnly*/); err != nil {
 			if common.ErrorCode(err) == common.NotFound {
 				s.l.Debug("Failed to check anomaly",
 					zap.String("instance", instance.Name),

--- a/server/database.go
+++ b/server/database.go
@@ -239,7 +239,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 					}
 
 					var schemaBuf bytes.Buffer
-					if err := driver.Dump(ctx, database.Name, &schemaBuf, true /* schemaOnly */); err != nil {
+					if _, err := driver.Dump(ctx, database.Name, &schemaBuf, true /* schemaOnly */); err != nil {
 						return fmt.Errorf("failed to get database schema for database %q: %w", database.Name, err)
 					}
 					if peerSchema != schemaBuf.String() {

--- a/server/issue.go
+++ b/server/issue.go
@@ -1248,7 +1248,7 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 	}
 
 	var schemaBuf bytes.Buffer
-	if err := driver.Dump(ctx, similarDB.Name, &schemaBuf, true /* schemaOnly */); err != nil {
+	if _, err := driver.Dump(ctx, similarDB.Name, &schemaBuf, true /* schemaOnly */); err != nil {
 		return "", "", err
 	}
 	return schemaVersion, schemaBuf.String(), nil

--- a/server/task_executor_database_backup.go
+++ b/server/task_executor_database_backup.go
@@ -55,7 +55,7 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 		zap.String("backup", backup.Name),
 	)
 
-	backupErr := exec.backupDatabase(ctx, task.Instance, task.Database.Name, backup, server.profile.DataDir)
+	backupPayload, backupErr := exec.backupDatabase(ctx, task.Instance, task.Database.Name, backup, server.profile.DataDir)
 	// Update the status of the backup.
 	newBackupStatus := string(api.BackupStatusDone)
 	comment := ""
@@ -68,6 +68,7 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 		Status:    newBackupStatus,
 		UpdaterID: api.SystemBotID,
 		Comment:   comment,
+		Payload:   backupPayload,
 	}); err != nil {
 		return true, nil, fmt.Errorf("failed to patch backup: %w", err)
 	}
@@ -82,24 +83,25 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 }
 
 // backupDatabase will take a backup of a database.
-func (exec *DatabaseBackupTaskExecutor) backupDatabase(ctx context.Context, instance *api.Instance, databaseName string, backup *api.Backup, dataDir string) error {
+func (exec *DatabaseBackupTaskExecutor) backupDatabase(ctx context.Context, instance *api.Instance, databaseName string, backup *api.Backup, dataDir string) (string, error) {
 	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, exec.l)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer driver.Close(ctx)
 
 	f, err := os.Create(filepath.Join(dataDir, backup.Path))
 	if err != nil {
-		return fmt.Errorf("failed to open backup path: %s", backup.Path)
+		return "", fmt.Errorf("failed to open backup path: %s", backup.Path)
 	}
 	defer f.Close()
 
-	if err := driver.Dump(ctx, databaseName, f, false /* schemaOnly */); err != nil {
-		return err
+	payload, err := driver.Dump(ctx, databaseName, f, false /* schemaOnly */)
+	if err != nil {
+		return "", err
 	}
 
-	return nil
+	return payload, nil
 }
 
 // getAndCreateBackupDirectory returns the path of a database backup.

--- a/server/task_executor_database_backup.go
+++ b/server/task_executor_database_backup.go
@@ -62,6 +62,7 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	if backupErr != nil {
 		newBackupStatus = string(api.BackupStatusFailed)
 		comment = backupErr.Error()
+		backupPayload = "{}"
 	}
 	if _, err := server.store.PatchBackup(ctx, &api.BackupPatch{
 		ID:        backup.ID,

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -173,7 +173,7 @@ func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.Migr
 	executor := driver.(util.MigrationExecutor)
 
 	var prevSchemaBuf bytes.Buffer
-	if err := driver.Dump(ctx, mi.Database, &prevSchemaBuf, true); err != nil {
+	if _, err := driver.Dump(ctx, mi.Database, &prevSchemaBuf, true); err != nil {
 		return -1, "", err
 	}
 
@@ -198,7 +198,7 @@ func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.Migr
 	}
 
 	var afterSchemaBuf bytes.Buffer
-	if err := executor.Dump(ctx, mi.Database, &afterSchemaBuf, true /*schemaOnly*/); err != nil {
+	if _, err := executor.Dump(ctx, mi.Database, &afterSchemaBuf, true /*schemaOnly*/); err != nil {
 		return -1, "", util.FormatError(err)
 	}
 

--- a/store/backup.go
+++ b/store/backup.go
@@ -513,6 +513,9 @@ func (s *Store) patchBackupImpl(ctx context.Context, tx *sql.Tx, patch *api.Back
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	set, args = append(set, "status = $2"), append(args, patch.Status)
 	set, args = append(set, "comment = $3"), append(args, patch.Comment)
+	if patch.Payload == "" {
+		patch.Payload = "{}"
+	}
 	set, args = append(set, "payload = $4"), append(args, patch.Payload)
 
 	args = append(args, patch.ID)

--- a/store/backup.go
+++ b/store/backup.go
@@ -32,6 +32,7 @@ type backupRaw struct {
 	MigrationHistoryVersion string
 	Path                    string
 	Comment                 string
+	Payload                 string
 }
 
 // toBackup creates an instance of Backup based on the backupRaw.
@@ -512,6 +513,7 @@ func (s *Store) patchBackupImpl(ctx context.Context, tx *sql.Tx, patch *api.Back
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	set, args = append(set, "status = $2"), append(args, patch.Status)
 	set, args = append(set, "comment = $3"), append(args, patch.Comment)
+	set, args = append(set, "payload = $4"), append(args, patch.Payload)
 
 	args = append(args, patch.ID)
 
@@ -520,7 +522,7 @@ func (s *Store) patchBackupImpl(ctx context.Context, tx *sql.Tx, patch *api.Back
 		UPDATE backup
 		SET `+strings.Join(set, ", ")+`
 		WHERE id = $4
-		RETURNING id, creator_id, created_ts, updater_id, updated_ts, database_id, name, status, type, storage_backend, migration_history_version, path, comment
+		RETURNING id, creator_id, created_ts, updater_id, updated_ts, database_id, name, status, type, storage_backend, migration_history_version, path, comment, payload
 	`,
 		args...,
 	)
@@ -545,6 +547,7 @@ func (s *Store) patchBackupImpl(ctx context.Context, tx *sql.Tx, patch *api.Back
 			&backupRaw.MigrationHistoryVersion,
 			&backupRaw.Path,
 			&backupRaw.Comment,
+			&backupRaw.Payload,
 		); err != nil {
 			return nil, FormatError(err)
 		}

--- a/store/backup.go
+++ b/store/backup.go
@@ -521,7 +521,7 @@ func (s *Store) patchBackupImpl(ctx context.Context, tx *sql.Tx, patch *api.Back
 	row, err := tx.QueryContext(ctx, `
 		UPDATE backup
 		SET `+strings.Join(set, ", ")+`
-		WHERE id = $4
+		WHERE id = $5
 		RETURNING id, creator_id, created_ts, updater_id, updated_ts, database_id, name, status, type, storage_backend, migration_history_version, path, comment, payload
 	`,
 		args...,

--- a/store/migration/dev/20220516000000__backup.sql
+++ b/store/migration/dev/20220516000000__backup.sql
@@ -1,1 +1,1 @@
-ALTER TABLE backup ADD payload JSON NOT NULL DEFAULT '{}';
+ALTER TABLE backup ADD payload JSONB NOT NULL DEFAULT '{}';

--- a/store/migration/dev/20220516000000__backup.sql
+++ b/store/migration/dev/20220516000000__backup.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backup ADD payload JSON NOT NULL DEFAULT '{}';

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -514,7 +514,7 @@ CREATE TABLE backup (
     migration_history_version TEXT NOT NULL,
     path TEXT NOT NULL,
     comment TEXT NOT NULL DEFAULT '',
-    payload JSON NOT NULL DEFAULT '{}'
+    payload JSONB NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX idx_backup_database_id ON backup(database_id);

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -513,7 +513,8 @@ CREATE TABLE backup (
     storage_backend TEXT NOT NULL CHECK (storage_backend IN ('LOCAL', 'S3', 'GCS', 'OSS')),
     migration_history_version TEXT NOT NULL,
     path TEXT NOT NULL,
-    comment TEXT NOT NULL DEFAULT ''
+    comment TEXT NOT NULL DEFAULT '',
+    payload JSON NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX idx_backup_database_id ON backup(database_id);

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -161,7 +161,7 @@ func TestPITR(t *testing.T) {
 		mysqlDriver, ok := driver.(*pluginmysql.Driver)
 		a.Equal(true, ok)
 		mysqlRestore := restoremysql.New(mysqlDriver)
-		config := restoremysql.BinlogConfig{}
+		config := pluginmysql.BinlogInfo{}
 		err := mysqlRestore.RestorePITR(ctx, bufio.NewScanner(buf), config, database, timestamp)
 		a.NoError(err)
 
@@ -288,7 +288,7 @@ func doBackup(ctx context.Context, t *testing.T, driver dbplugin.Driver, databas
 	a := require.New(t)
 
 	var buf bytes.Buffer
-	err := driver.Dump(ctx, database, &buf, false)
+	_, err := driver.Dump(ctx, database, &buf, false)
 	a.NoError(err)
 
 	return &buf


### PR DESCRIPTION
Improve the logical backup process to also get the current binlog position as is described in the [design doc](https://github.com/bytebase/bytebase/blob/main/docs/design/pitr-mysql.md#full-backup).

Closes BYT-468.
