### PR TITLE
feat(schema-system): init schema review policy for each existing environment

### DIFF
--- a/api/schema_system.go
+++ b/api/schema_system.go
@@ -134,6 +134,56 @@ func (rule *SchemaReviewRule) Validate() error {
 	return nil
 }
 
+// SetDefaultPayload sets the default payload for this rule.
+func (rule *SchemaReviewRule) SetDefaultPayload() error {
+	var payload []byte
+	var err error
+	switch rule.Type {
+	case SchemaRuleMySQLEngine:
+	case SchemaRuleStatementNoSelectAll:
+	case SchemaRuleStatementRequireWhere:
+	case SchemaRuleStatementNoLeadingWildcardLike:
+	case SchemaRuleTableRequirePK:
+	case SchemaRuleColumnNotNull:
+	case SchemaRuleTableNaming:
+		fallthrough
+	case SchemaRuleColumnNaming:
+		payload, err = json.Marshal(NamingRulePayload{
+			Format: "^[a-z]+(_[a-z]+)?$",
+		})
+	case SchemaRuleIDXNaming:
+		payload, err = json.Marshal(NamingRulePayload{
+			Format: "^idx_{{table}}_{{column_list}}$",
+		})
+	case SchemaRuleUKNaming:
+		payload, err = json.Marshal(NamingRulePayload{
+			Format: "^uk_{{table}}_{{column_list}}$",
+		})
+	case SchemaRuleFKNaming:
+		payload, err = json.Marshal(NamingRulePayload{
+			Format: "^fk_{{referencing_table}}_{{referencing_column}}_{{referenced_table}}_{{referenced_column}}$",
+		})
+	case SchemaRuleRequiredColumn:
+		payload, err = json.Marshal(RequiredColumnRulePayload{
+			ColumnList: []string{
+				"id",
+				"created_ts",
+				"updated_ts",
+				"creator_id",
+				"updater_id",
+			},
+		})
+	default:
+		return fmt.Errorf("Unknow schema review type for default payload: %s", rule.Type)
+	}
+
+	if err != nil {
+		return err
+	}
+	rule.Payload = string(payload)
+	return nil
+}
+
 // NamingRulePayload is the payload for naming rule.
 type NamingRulePayload struct {
 	Format string `json:"format"`
@@ -188,4 +238,73 @@ func UnmarshalRequiredColumnRulePayload(payload string) (*RequiredColumnRulePayl
 		return nil, fmt.Errorf("invalid required column rule payload, column list cannot be empty")
 	}
 	return &rcr, nil
+}
+
+// ProdTemplateSchemaReviewPolicy returns the default schema review policy.
+func ProdTemplateSchemaReviewPolicy() (string, error) {
+	policy := SchemaReviewPolicy{
+		Name: "Prod",
+		RuleList: []*SchemaReviewRule{
+			{
+				Type:  SchemaRuleMySQLEngine,
+				Level: SchemaRuleLevelError,
+			},
+			{
+				Type:  SchemaRuleTableNaming,
+				Level: SchemaRuleLevelWarning,
+			},
+			{
+				Type:  SchemaRuleColumnNaming,
+				Level: SchemaRuleLevelWarning,
+			},
+			{
+				Type:  SchemaRuleIDXNaming,
+				Level: SchemaRuleLevelWarning,
+			},
+			{
+				Type:  SchemaRuleUKNaming,
+				Level: SchemaRuleLevelWarning,
+			},
+			{
+				Type:  SchemaRuleFKNaming,
+				Level: SchemaRuleLevelWarning,
+			},
+			{
+				Type:  SchemaRuleStatementNoSelectAll,
+				Level: SchemaRuleLevelError,
+			},
+			{
+				Type:  SchemaRuleStatementRequireWhere,
+				Level: SchemaRuleLevelError,
+			},
+			{
+				Type:  SchemaRuleStatementNoLeadingWildcardLike,
+				Level: SchemaRuleLevelError,
+			},
+			{
+				Type:  SchemaRuleTableRequirePK,
+				Level: SchemaRuleLevelError,
+			},
+			{
+				Type:  SchemaRuleRequiredColumn,
+				Level: SchemaRuleLevelWarning,
+			},
+			{
+				Type:  SchemaRuleColumnNotNull,
+				Level: SchemaRuleLevelWarning,
+			},
+		},
+	}
+
+	for _, rule := range policy.RuleList {
+		if err := rule.SetDefaultPayload(); err != nil {
+			return "", err
+		}
+	}
+
+	s, err := json.Marshal(policy)
+	if err != nil {
+		return "", err
+	}
+	return string(s), nil
 }

--- a/api/setting.go
+++ b/api/setting.go
@@ -12,6 +12,8 @@ const (
 	SettingAuthSecret SettingName = "bb.auth.secret"
 	// SettingBrandingLogo is the setting name for branding logo.
 	SettingBrandingLogo SettingName = "bb.branding.logo"
+	// SettingSchemaSystemBoot it the setting name for schema system that needs to boot.
+	SettingSchemaSystemBoot SettingName = "bb.schema-system.boot"
 )
 
 // Setting is the API message for a setting.

--- a/api/setting.go
+++ b/api/setting.go
@@ -12,7 +12,7 @@ const (
 	SettingAuthSecret SettingName = "bb.auth.secret"
 	// SettingBrandingLogo is the setting name for branding logo.
 	SettingBrandingLogo SettingName = "bb.branding.logo"
-	// SettingSchemaSystemBoot it the setting name for schema system that needs to boot.
+	// SettingSchemaSystemBoot is the setting name for schema system that needs to boot.
 	SettingSchemaSystemBoot SettingName = "bb.schema-system.boot"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -139,7 +139,7 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 	}
 
 	if err := s.store.BootSchemaReviewPolicyIfNeeded(ctx); err != nil {
-		return nil, fmt.Errorf("faild to boot schema review policy: %w", err)
+		return nil, fmt.Errorf("failed to boot schema review policy: %w", err)
 	}
 
 	e := echo.New()

--- a/server/server.go
+++ b/server/server.go
@@ -138,6 +138,10 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 		return nil, fmt.Errorf("failed to init branding: %w", err)
 	}
 
+	if err := s.store.BootSchemaReviewPolicyIfNeeded(ctx); err != nil {
+		return nil, fmt.Errorf("faild to boot schema review policy: %w", err)
+	}
+
 	e := echo.New()
 	e.Debug = prof.Debug
 	e.HideBanner = true

--- a/store/policy.go
+++ b/store/policy.go
@@ -481,7 +481,7 @@ func (s *Store) bootSchemaReviewPolicy(ctx context.Context) error {
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.Rollback()
+	defer tx.PTx.Rollback()
 
 	rowStatus := api.Normal
 	envList, err := s.findEnvironmentImpl(ctx, tx.PTx, &api.EnvironmentFind{RowStatus: &rowStatus})

--- a/store/policy.go
+++ b/store/policy.go
@@ -481,6 +481,7 @@ func (s *Store) bootSchemaReviewPolicy(ctx context.Context) error {
 	if err != nil {
 		return FormatError(err)
 	}
+	defer tx.Rollback()
 
 	rowStatus := api.Normal
 	envList, err := s.findEnvironmentImpl(ctx, tx.PTx, &api.EnvironmentFind{RowStatus: &rowStatus})


### PR DESCRIPTION
https://www.loom.com/share/41de0a481d78437d9ee50a511dba42c9

## Details

- Only init schema review policy for each existing environment once.
- Init as `Prod Template Review Policy`. See [bytebase database review guide](www.bytebase.com/database-review-guide)