### PR TITLE
feat(PITR): add task executor for PITR restore task

### DIFF
--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -33,7 +33,7 @@ func (r *Restore) RestoreBinlog(ctx context.Context, config mysql.BinlogInfo) er
 
 // RestorePITR is a wrapper for restore a full backup and a range of incremental backup
 func (r *Restore) RestorePITR(ctx context.Context, fullBackup *bufio.Scanner, binlog mysql.BinlogInfo, database string, timestamp int64) error {
-	pitrDatabaseName := GetPITRDatabaseName(database, timestamp)
+	pitrDatabaseName := getPITRDatabaseName(database, timestamp)
 	query := fmt.Sprintf(""+
 		// Create the pitr database.
 		"CREATE DATABASE `%s`;"+
@@ -81,7 +81,7 @@ func (r *Restore) SwapPITRDatabase(ctx context.Context, database string, timesta
 	defer txn.Rollback()
 
 	pitrOldDatabase := getSafeName(database, "old")
-	pitrDatabaseName := GetPITRDatabaseName(database, timestamp)
+	pitrDatabaseName := getPITRDatabaseName(database, timestamp)
 
 	if _, err := txn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", pitrOldDatabase)); err != nil {
 		return err
@@ -117,8 +117,8 @@ func (r *Restore) SwapPITRDatabase(ctx context.Context, database string, timesta
 	return nil
 }
 
-// GetPITRDatabaseName composes a pitr database name
-func GetPITRDatabaseName(database string, timestamp int64) string {
+// getPITRDatabaseName composes a pitr database name
+func getPITRDatabaseName(database string, timestamp int64) string {
 	suffix := fmt.Sprintf("pitr_%d", timestamp)
 	return getSafeName(database, suffix)
 }

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -32,8 +32,8 @@ func (r *Restore) RestoreBinlog(ctx context.Context, config mysql.BinlogInfo) er
 }
 
 // RestorePITR is a wrapper for restore a full backup and a range of incremental backup
-func (r *Restore) RestorePITR(ctx context.Context, fullBackup *bufio.Scanner, binlog mysql.BinlogInfo, database string, timestamp int64) error {
-	pitrDatabaseName := getPITRDatabaseName(database, timestamp)
+func (r *Restore) RestorePITR(ctx context.Context, fullBackup *bufio.Scanner, binlog mysql.BinlogInfo, database string, suffixTs int64) error {
+	pitrDatabaseName := getPITRDatabaseName(database, suffixTs)
 	query := fmt.Sprintf(""+
 		// Create the pitr database.
 		"CREATE DATABASE `%s`;"+

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -55,7 +55,7 @@ func TestGetPITRDatabaseName(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		name := GetPITRDatabaseName(test.database, int64(test.timestamp))
+		name := getPITRDatabaseName(test.database, int64(test.timestamp))
 		a.Equal(test.expected, name)
 	}
 }

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -192,7 +192,7 @@ type Provider interface {
 	CreateFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
 	// Overwrites an existing file
 	//
-	// Similar to CreateFile except it overwrites an existing file. The fileCommit shoud includes the "LastCommitID" field which is used to detect conflicting writes.
+	// Similar to CreateFile except it overwrites an existing file. The fileCommit should includes the "LastCommitID" field which is used to detect conflicting writes.
 	OverwriteFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
 	// Reads the file metadata
 	//
@@ -210,7 +210,7 @@ type Provider interface {
 	// filePath: file path to be read
 	// ref: the specific file version to be read, could be a name of branch, tag or commit
 	ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (string, error)
-	// Creates a webhook. Returns the created webhook ID on succeess.
+	// Creates a webhook. Returns the created webhook ID on success.
 	//
 	// oauthCtx: OAuth context to create the webhook
 	// instanceURL: VCS instance URL

--- a/server/server.go
+++ b/server/server.go
@@ -182,6 +182,9 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 		schemaUpdateGhostDropOriginalTableExecutor := NewSchemaUpdateGhostDropOriginalTableTaskExecutor(logger)
 		taskScheduler.Register(string(api.TaskDatabaseSchemaUpdateGhostDropOriginalTable), schemaUpdateGhostDropOriginalTableExecutor)
 
+		pitrRestoreExecutor := NewPITRRestoreTaskExecutor(logger)
+		taskScheduler.Register(string(api.TaskDatabasePITRRestore), pitrRestoreExecutor)
+
 		s.TaskScheduler = taskScheduler
 
 		// Task check scheduler

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/plugin/db"
+	pluginmysql "github.com/bytebase/bytebase/plugin/db/mysql"
+	"github.com/bytebase/bytebase/plugin/db/util"
+	restoremysql "github.com/bytebase/bytebase/plugin/restore/mysql"
+	"github.com/bytebase/bytebase/store"
+	"go.uber.org/zap"
+)
+
+// NewPITRRestoreTaskExecutor creates a PITR restore task executor.
+func NewPITRRestoreTaskExecutor(logger *zap.Logger) TaskExecutor {
+	return &PITRRestoreTaskExecutor{
+		l: logger,
+	}
+}
+
+// PITRRestoreTaskExecutor is the PITR restore task executor.
+type PITRRestoreTaskExecutor struct {
+	l *zap.Logger
+}
+
+// RunOnce will run the PITR restore task executor once.
+func (exec *PITRRestoreTaskExecutor) RunOnce(ctx context.Context, server *Server, task *api.Task) (terminated bool, result *api.TaskRunResultPayload, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicErr, ok := r.(error)
+			if !ok {
+				panicErr = fmt.Errorf("%v", r)
+			}
+			exec.l.Error("PITRRestoreTaskExecutor PANIC RECOVER", zap.Error(panicErr), zap.Stack("stack"))
+			terminated = true
+			err = fmt.Errorf("encounter internal error when executing sql")
+		}
+	}()
+	exec.l.Info("Run PITR restore task", zap.String("task", task.Name))
+
+	payload := api.TaskDatabasePITRRestorePayload{}
+	if err := json.Unmarshal([]byte(task.Payload), &payload); err != nil {
+		return true, nil, fmt.Errorf("invalid PITR restore payload[%s], error[%w]", task.Payload, err)
+	}
+
+	return exec.pitrRestore(ctx, task, server)
+}
+
+func (exec *PITRRestoreTaskExecutor) pitrRestore(ctx context.Context, task *api.Task, server *Server) (terminated bool, result *api.TaskRunResultPayload, err error) {
+	schemaVersion := common.DefaultMigrationVersion()
+	migrationInfo, err := preMigration(ctx, exec.l, server, task, db.Baseline, "", schemaVersion, nil)
+	if err != nil {
+		exec.l.Error("failed in preMigration stage", zap.Error(err))
+		return true, nil, fmt.Errorf("failed in preMigration stage, error[%w]", err)
+	}
+
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", exec.l)
+	if err != nil {
+		return true, nil, err
+	}
+	defer driver.Close(ctx)
+
+	needsSetup, err := driver.NeedsSetupMigration(ctx)
+	if err != nil {
+		return true, nil, fmt.Errorf("failed to check migration setup for instance %q, error[%w]", task.Instance.Name, err)
+	}
+	if needsSetup {
+		return true, nil, common.Errorf(common.MigrationSchemaMissing, fmt.Errorf("missing migration schema for instance %q", task.Instance.Name))
+	}
+
+	executor := driver.(util.MigrationExecutor)
+	var prevSchemaBuf bytes.Buffer
+	if err := driver.Dump(ctx, migrationInfo.Database, &prevSchemaBuf, true); err != nil {
+		return true, nil, err
+	}
+
+	// Insert a pending baseline migration record into the migration_history table.
+	// The whole PITR process can be regarded as a data change followed by a schema sync.
+	migrationHistoryID, err := util.BeginMigration(ctx, executor, migrationInfo, prevSchemaBuf.String(), "", migrationInfo.Database)
+	if err != nil {
+		return true, nil, err
+	}
+	startedNs := time.Now().UnixNano()
+
+	var updatedSchemaBuf bytes.Buffer
+	if err := executor.Dump(ctx, migrationInfo.Database, &updatedSchemaBuf, true /*schemaOnly*/); err != nil {
+		return true, nil, util.FormatError(err)
+	}
+	updatedSchema := updatedSchemaBuf.String()
+
+	if err := exec.doPITRRestore(ctx, task, server.store, driver); err != nil {
+		return true, nil, err
+	}
+
+	// TODO(dragonly): Fix this using shared context between tasks.
+	if err := util.EndMigration(ctx, exec.l, executor, startedNs, migrationHistoryID, updatedSchema, db.BytebaseDatabase, true /*isDone*/); err != nil {
+		exec.l.Error("failed to update migration history record",
+			zap.Int64("migration_id", migrationHistoryID),
+			zap.Error(err),
+		)
+	}
+
+	exec.l.Info("created PITR database", zap.String("target database", migrationInfo.Database))
+
+	return true, &api.TaskRunResultPayload{
+		Detail:      fmt.Sprintf("Created PITR database for target database %q", migrationInfo.Database),
+		MigrationID: migrationHistoryID,
+		Version:     migrationInfo.Version,
+	}, nil
+}
+
+func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *api.Task, store *store.Store, driver db.Driver) error {
+	instance := task.Instance
+	database := task.Database
+
+	issue, err := store.GetIssueByPipelineID(ctx, task.PipelineID)
+	if err != nil || issue == nil {
+		exec.l.Error("failed to get issue by PipelineID",
+			zap.Int("PipelineID", task.PipelineID),
+			zap.Any("issue", *issue),
+			zap.Error(err))
+		return fmt.Errorf("failed to get issue by PipelineID[%d], error[%w]", task.PipelineID, err)
+	}
+
+	mysqlDriver, ok := driver.(*pluginmysql.Driver)
+	if !ok {
+		exec.l.Error("failed to cast driver to mysql.Driver", zap.Stack("stack"))
+		return fmt.Errorf("[internal] cast driver to mysql.Driver failed")
+	}
+
+	mysqlRestore := restoremysql.New(mysqlDriver)
+	config := restoremysql.BinlogConfig{}
+	// TODO(dragonly): Search and put the file io of the logical backup file here.
+	// Currently, let's just use the empty backup dump as a placeholder.
+	var buf bytes.Buffer
+	buf.WriteString("-- This is a fake backup dump")
+
+	exec.l.Debug("Start creating and restoring PITR database",
+		zap.String("instance", instance.Name),
+		zap.String("database", database.Name),
+	)
+
+	// RestorePITR will create the pitr database.
+	// Since it's ephemeral and will be renamed to the original database soon, we will reuse the original
+	// database's migration history, and append a new BASELINE migration.
+	if err := mysqlRestore.RestorePITR(ctx, bufio.NewScanner(&buf), config, database.Name, issue.CreatedTs); err != nil {
+		exec.l.Error("failed to perform a PITR restore in the PITR database",
+			zap.Int("issueID", issue.ID),
+			zap.String("database", database.Name),
+			zap.Stack("stack"),
+			zap.Error(err))
+		return fmt.Errorf("failed to perform a PITR restore in the PITR database, error[%w]", err)
+	}
+
+	return nil
+}

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -124,7 +124,6 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 	if err != nil || issue == nil {
 		exec.l.Error("failed to get issue by PipelineID",
 			zap.Int("PipelineID", task.PipelineID),
-			zap.Any("issue", *issue),
 			zap.Error(err))
 		return fmt.Errorf("failed to get issue by PipelineID[%d], error[%w]", task.PipelineID, err)
 	}

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -77,7 +77,7 @@ func (exec *PITRRestoreTaskExecutor) pitrRestore(ctx context.Context, task *api.
 
 	executor := driver.(util.MigrationExecutor)
 	var prevSchemaBuf bytes.Buffer
-	if err := driver.Dump(ctx, migrationInfo.Database, &prevSchemaBuf, true); err != nil {
+	if _, err := driver.Dump(ctx, migrationInfo.Database, &prevSchemaBuf, true); err != nil {
 		return true, nil, err
 	}
 
@@ -90,7 +90,7 @@ func (exec *PITRRestoreTaskExecutor) pitrRestore(ctx context.Context, task *api.
 	startedNs := time.Now().UnixNano()
 
 	var updatedSchemaBuf bytes.Buffer
-	if err := executor.Dump(ctx, migrationInfo.Database, &updatedSchemaBuf, true /*schemaOnly*/); err != nil {
+	if _, err := executor.Dump(ctx, migrationInfo.Database, &updatedSchemaBuf, true /*schemaOnly*/); err != nil {
 		return true, nil, util.FormatError(err)
 	}
 	updatedSchema := updatedSchemaBuf.String()
@@ -136,7 +136,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 	}
 
 	mysqlRestore := restoremysql.New(mysqlDriver)
-	config := restoremysql.BinlogConfig{}
+	config := pluginmysql.BinlogInfo{}
 	// TODO(dragonly): Search and put the file io of the logical backup file here.
 	// Currently, let's just use the empty backup dump as a placeholder.
 	var buf bytes.Buffer

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -32,17 +32,6 @@ type PITRRestoreTaskExecutor struct {
 
 // RunOnce will run the PITR restore task executor once.
 func (exec *PITRRestoreTaskExecutor) RunOnce(ctx context.Context, server *Server, task *api.Task) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			panicErr, ok := r.(error)
-			if !ok {
-				panicErr = fmt.Errorf("%v", r)
-			}
-			exec.l.Error("PITRRestoreTaskExecutor PANIC RECOVER", zap.Error(panicErr), zap.Stack("stack"))
-			terminated = true
-			err = fmt.Errorf("encounter internal error when executing sql")
-		}
-	}()
 	exec.l.Info("Run PITR restore task", zap.String("task", task.Name))
 
 	payload := api.TaskDatabasePITRRestorePayload{}

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -155,18 +155,17 @@ func runGhostMigration(ctx context.Context, l *zap.Logger, server *Server, task 
 
 func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.MigrationInfo, statement string) (migrationHistoryID int64, updatedSchema string, resErr error) {
 	statement = strings.TrimSpace(statement)
-	databaseName := db.BytebaseDatabase
 
 	driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, l)
 	if err != nil {
 		return -1, "", err
 	}
 	defer driver.Close(ctx)
-	setup, err := driver.NeedsSetupMigration(ctx)
+	needsSetup, err := driver.NeedsSetupMigration(ctx)
 	if err != nil {
 		return -1, "", fmt.Errorf("failed to check migration setup for instance %q: %w", task.Instance.Name, err)
 	}
-	if setup {
+	if needsSetup {
 		return -1, "", common.Errorf(common.MigrationSchemaMissing, fmt.Errorf("missing migration schema for instance %q", task.Instance.Name))
 	}
 
@@ -177,14 +176,14 @@ func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.Migr
 		return -1, "", err
 	}
 
-	insertedID, err := util.BeginMigration(ctx, executor, mi, prevSchemaBuf.String(), statement, databaseName)
+	insertedID, err := util.BeginMigration(ctx, executor, mi, prevSchemaBuf.String(), statement, db.BytebaseDatabase)
 	if err != nil {
 		return -1, "", err
 	}
 	startedNs := time.Now().UnixNano()
 
 	defer func() {
-		if err := util.EndMigration(ctx, l, executor, startedNs, insertedID, updatedSchema, databaseName, resErr == nil /*isDone*/); err != nil {
+		if err := util.EndMigration(ctx, l, executor, startedNs, insertedID, updatedSchema, db.BytebaseDatabase, resErr == nil /*isDone*/); err != nil {
 			l.Error("failed to update migration history record",
 				zap.Error(err),
 				zap.Int64("migration_id", migrationHistoryID),
@@ -192,8 +191,7 @@ func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.Migr
 		}
 	}()
 
-	err = executeGhost(task.Instance, task.Database.Name, statement)
-	if err != nil {
+	if err := executeGhost(task.Instance, task.Database.Name, statement); err != nil {
 		return -1, "", err
 	}
 

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -236,7 +236,7 @@ func TestPITR(t *testing.T) {
 		mysqlDriver, ok := driver.(*pluginmysql.Driver)
 		a.Equal(true, ok)
 		mysqlRestore := restoremysql.New(mysqlDriver)
-		config := restoremysql.BinlogConfig{}
+		config := pluginmysql.BinlogInfo{}
 		err = mysqlRestore.RestorePITR(ctx, bufio.NewScanner(buf), config, database, timestamp)
 		a.NoError(err)
 


### PR DESCRIPTION
Now we can create a PITR restore issue, and the first task will be performed.

Some detailed implementations like applying binlog is still TODO.

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/8433465/168807083-33e0ffeb-2587-449c-a724-9d026088235b.png">

```
mysql> show databases;
+----------------------+
| Database             |
+----------------------+
| bytebase             |
| information_schema   |
| mysql                |
| performance_schema   |
| sbtest               |
| sys                  |
| test                 |
| test2                |
| test_pitr_1652788936 |
+----------------------+
9 rows in set (0.00 sec)
```
