### PR TITLE
fix: avoid EmptySchemaReviewPolicy warning blocking the automatic run

### DIFF
--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -404,7 +404,9 @@ func (s *Server) passCheck(ctx context.Context, server *Server, task *api.Task, 
 		return false, err
 	}
 	for _, result := range checkResult.ResultList {
-		if result.Status == api.TaskCheckStatusError || result.Status == api.TaskCheckStatusWarn {
+		if result.Status == api.TaskCheckStatusError ||
+			// Skip empty schema review policy warning cause it is only used to remind the user to use schema system.
+			(result.Status == api.TaskCheckStatusWarn && result.Code != common.TaskCheckEmptySchemaReviewPolicy) {
 			server.l.Debug("Task is waiting for check to pass",
 				zap.Int("task_id", task.ID),
 				zap.String("task_name", task.Name),


### PR DESCRIPTION
The `EmptySchemaReviewPolicy` warning blocks the automatic run. We should skip this warning.

See details https://github.com/bytebase/bytebase/pull/1322