### PR TITLE
chore: optimize UX for schema review policy

### DIFF
--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewCreation.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewCreation.vue
@@ -312,7 +312,7 @@ const tryFinishSetup = (allowChangeCallback: () => void) => {
     module: "bytebase",
     style: "SUCCESS",
     title: t(
-      `schema-review-policy.${props.policyId ? "update" : "create"}-review`
+      `schema-review-policy.policy-${props.policyId ? "updated" : "created"}`
     ),
   });
 

--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewEmptyView.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewEmptyView.vue
@@ -14,7 +14,7 @@
             class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             @click="$emit('create')"
           >
-            {{ $t("schema-review-policy.add-review") }}
+            {{ $t("schema-review-policy.create-policy") }}
           </button>
         </div>
       </div>

--- a/frontend/src/components/EnvironmentForm.vue
+++ b/frontend/src/components/EnvironmentForm.vue
@@ -148,7 +148,7 @@
             @click.prevent="onSchemaReviewPolicyClick"
           >
             <heroicons-solid:plus class="h-4 w-4" />
-            {{ $t("schema-review-policy.add-review") }}
+            {{ $t("schema-review-policy.create-policy") }}
           </button>
           <span v-else class="textinfolabel">
             {{ $t("schema-review-policy.no-policy-set") }}

--- a/frontend/src/components/Issue/TaskCheckRunPanel.vue
+++ b/frontend/src/components/Issue/TaskCheckRunPanel.vue
@@ -59,6 +59,7 @@ import {
   TaskCheckResult,
   ErrorCode,
   ERROR_LIST,
+  GeneralErrorCode,
   SchemaReviewPolicyErrorCode,
 } from "../../types";
 
@@ -131,6 +132,8 @@ export default defineComponent({
 
     const errorCodeLink = (code: ErrorCode): ErrorCodeLink | undefined => {
       switch (code) {
+        case GeneralErrorCode.OK:
+          return;
         case SchemaReviewPolicyErrorCode.EMPTY_POLICY:
           return {
             title: t("schema-review-policy.create-policy"),

--- a/frontend/src/components/Issue/TaskCheckRunPanel.vue
+++ b/frontend/src/components/Issue/TaskCheckRunPanel.vue
@@ -11,8 +11,8 @@
       :row-clickable="false"
     >
       <template #body="{ rowData: checkResult }">
-        <BBTableCell :left-padding="4" class="table-cell w-4">
-          <div class="flex flex-row space-x-2">
+        <BBTableCell :left-padding="4" class="w-16">
+          <div class="flex gap-x-3">
             <div
               class="relative w-5 h-5 flex flex-shrink-0 items-center justify-center rounded-full select-none"
               :class="statusIconClass(checkResult.status)"
@@ -31,19 +31,17 @@
                 >
               </template>
             </div>
+            {{ checkResult.title }}
           </div>
         </BBTableCell>
-        <BBTableCell class="table-cell w-16">
-          {{ checkResult.title }}
-        </BBTableCell>
-        <BBTableCell class="table-cell w-48">
+        <BBTableCell class="w-64">
           {{ checkResult.content }}
           <a
             v-if="errorCodeLink(checkResult.code)"
             class="normal-link"
-            :href="errorCodeLink(checkResult.code)"
-            target="__blank"
-            >view doc</a
+            :href="errorCodeLink(checkResult.code)?.url"
+            :target="errorCodeLink(checkResult.code)?.target"
+            >{{ errorCodeLink(checkResult.code)?.title }}</a
           >
         </BBTableCell>
       </template>
@@ -61,6 +59,7 @@ import {
   TaskCheckResult,
   ErrorCode,
   ERROR_LIST,
+  SchemaReviewPolicyErrorCode,
 } from "../../types";
 
 const columnList: BBTableColumn[] = [
@@ -74,6 +73,12 @@ const columnList: BBTableColumn[] = [
     title: "Detail",
   },
 ];
+
+interface ErrorCodeLink {
+  title: string;
+  target: string;
+  url: string;
+}
 
 export default defineComponent({
   name: "TaskCheckRunPanel",
@@ -124,9 +129,25 @@ export default defineComponent({
       return [];
     });
 
-    const errorCodeLink = (code: ErrorCode): string => {
-      const error = ERROR_LIST.find((item) => item.code == code);
-      return error ? `https://bytebase.com/docs/error-code#${error.hash}` : "";
+    const errorCodeLink = (code: ErrorCode): ErrorCodeLink | undefined => {
+      switch (code) {
+        case SchemaReviewPolicyErrorCode.EMPTY_POLICY:
+          return {
+            title: t("schema-review-policy.create-policy"),
+            target: "_self",
+            url: "/setting/schema-review-policy",
+          };
+        default:
+          const error = ERROR_LIST.find((item) => item.code == code);
+          if (!error) {
+            return;
+          }
+          return {
+            title: t("common.view-doc"),
+            target: "__blank",
+            url: `https://bytebase.com/docs/error-code#${error.hash}`,
+          };
+      }
     };
 
     return {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -196,7 +196,8 @@
     "duplicate": "Duplicate",
     "clear-search": "Clear search",
     "enable": "Enable",
-    "disable": "Disable"
+    "disable": "Disable",
+    "view-doc": "View doc"
   },
   "error-page": {
     "go-back-home": "Go back home"
@@ -1368,11 +1369,11 @@
   "schema-review-policy": {
     "title": "Schema Review",
     "no-policy-set": "No schema review policy",
-    "add-review": "Add policy",
+    "create-policy": "Create policy",
     "search-rule-name": "Search rule name",
-    "remove-review": "Successfully removed the review policy.",
-    "create-review": "Successfully created the review policy.",
-    "update-review": "Successfully updated the review policy.",
+    "policy-removed": "Successfully removed the review policy.",
+    "policy-created": "Successfully created the review policy.",
+    "policy-updated": "Successfully updated the review policy.",
     "rules": "Rules",
     "filter": "Filter",
     "no-permission": "Only DBA or Owner has permission to create or update review policy.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -196,7 +196,8 @@
     "duplicate": "拷贝",
     "clear-search": "清空搜索",
     "enable": "开启",
-    "disable": "禁用"
+    "disable": "禁用",
+    "view-doc": "查看文档"
   },
   "error-page": {
     "go-back-home": "回到主页"
@@ -1368,11 +1369,11 @@
   "schema-review-policy": {
     "title": "Schema 审核策略",
     "no-policy-set": "没有 schema 审核策略",
-    "add-review": "新增审核策略",
+    "create-policy": "创建审核策略",
     "search-rule-name": "搜索规则名称",
-    "remove-review": "审核策略已删除",
-    "create-review": "审核策略已创建",
-    "update-review": "审核策略已更新",
+    "policy-removed": "审核策略已删除",
+    "policy-created": "审核策略已创建",
+    "policy-updated": "审核策略已更新",
     "rules": "规则",
     "filter": "筛选",
     "no-permission": "仅 DBA 或所有者有权限创建或更新审核策略。",

--- a/frontend/src/types/error.ts
+++ b/frontend/src/types/error.ts
@@ -21,6 +21,19 @@ export enum MigrationErrorCode {
   MIGRATION_BASELINE_MISSING = 204,
 }
 
+export enum SchemaReviewPolicyErrorCode {
+  EMPTY_POLICY = 401,
+  TABLE_NAMING_DISMATCH = 10201,
+  COLUMN_NAMING_DISMATCH = 10202,
+  INDEX_NAMING_DISMATCH = 10203,
+  UK_NAMING_DISMATCH = 10204,
+  FK_NAMING_DISMATCH = 10205,
+  NO_REQUIRED_COLUMN = 10301,
+  COLUMN_CANBE_NULL = 10302,
+  NOT_INNODB_ENGINE = 10401,
+  NO_PK_IN_TABLE = 10501,
+}
+
 export enum CompatibilityErrorCode {
   COMPATIBILITY_DROP_DATABASE = 10001,
   COMPATIBILITY_RENAME_TABLE = 10002,
@@ -39,7 +52,8 @@ export type ErrorCode =
   | GeneralErrorCode
   | DBErrorCode
   | MigrationErrorCode
-  | CompatibilityErrorCode;
+  | CompatibilityErrorCode
+  | SchemaReviewPolicyErrorCode;
 
 export type ErrorTag = "General" | "Compatibility";
 

--- a/frontend/src/views/SettingWorkspaceSchemaReview.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReview.vue
@@ -10,7 +10,7 @@
             <heroicons-outline:plus-sm class="w-6 h-6" />
           </button>
           <h3 class="mt-1 text-base font-normal text-main tracking-tight">
-            {{ $t("schema-review-policy.add-review") }}
+            {{ $t("schema-review-policy.create-policy") }}
           </h3>
         </div>
       </div>

--- a/frontend/src/views/SettingWorkspaceSchemaReviewCreate.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewCreate.vue
@@ -10,15 +10,22 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 import { useEnvironmentStore } from "@/store";
+import { EMPTY_ID } from "@/types";
 
 const url = new URL(window.location.href);
 const params = new URLSearchParams(url.search);
 const environmentId = params.get("environmentId") ?? "";
 
 const environment = computed(() => {
-  if (Number.isNaN(environmentId)) {
+  if (!environmentId || Number.isNaN(environmentId)) {
     return;
   }
-  return useEnvironmentStore().getEnvironmentById(parseInt(environmentId, 10));
+  const env = useEnvironmentStore().getEnvironmentById(
+    parseInt(environmentId, 10)
+  );
+  if (env.id === EMPTY_ID) {
+    return;
+  }
+  return env;
 });
 </script>

--- a/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
@@ -370,7 +370,7 @@ const onRemove = () => {
   pushNotification({
     module: "bytebase",
     style: "SUCCESS",
-    title: t("schema-review-policy.remove-review"),
+    title: t("schema-review-policy.policy-removed"),
   });
 };
 </script>


### PR DESCRIPTION
- Fix: environment validation while editing or creating the schema review policy
- Optimize: Users can redirect to schema review policy setting view from `TaskCheckRunPanel`
![CleanShot 2022-05-20 at 10 00 41](https://user-images.githubusercontent.com/10706318/169434396-64f14eac-dfca-4ec4-8923-c8d6ca7470d2.gif)

- Optimize: The table in `TaskCheckRunPanel` is a little strange, update the table cell there. We can also find other better ways to optimize the UI later.

Before:
<img width="911" alt="图片" src="https://user-images.githubusercontent.com/10706318/169434342-5ed7e03a-69d1-4d8e-86ae-1363ef03f1c9.png">
<img width="918" alt="图片" src="https://user-images.githubusercontent.com/10706318/169434351-5f2b6dcf-943b-45db-aaf0-02f7aaa50d5b.png">

After:
<img width="928" alt="图片" src="https://user-images.githubusercontent.com/10706318/169434366-91602157-5008-41e5-b2bc-db0d7e004100.png">
<img width="911" alt="图片" src="https://user-images.githubusercontent.com/10706318/169434377-d0ac987d-d7e1-4054-ad95-1dfe5f6cb3fa.png">
