### PR TITLE
fix(frontend): validate database owner name 🔥 

### DIFF
--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -66,10 +66,7 @@
         </span>
       </div>
 
-      <div
-        v-if="selectedInstance.engine == 'POSTGRES'"
-        class="col-span-2 col-start-2 w-64"
-      >
+      <div v-if="requireDatabaseOwnerName" class="col-span-2 col-start-2 w-64">
         <label for="name" class="textlabel">
           {{ $t("create-db.database-owner-name") }}
           <span class="text-red-600">*</span>
@@ -399,7 +396,7 @@ export default defineComponent({
         : true;
       return (
         !isEmpty(state.databaseName) &&
-        !isEmpty(state.databaseOwnerName) &&
+        validDatabaseOwnerName.value &&
         !isReservedName.value &&
         isLabelValid &&
         state.projectId &&
@@ -428,6 +425,22 @@ export default defineComponent({
       return state.instanceId
         ? instanceStore.getInstanceById(state.instanceId)
         : (unknown("INSTANCE") as Instance);
+    });
+
+    const requireDatabaseOwnerName = computed((): boolean => {
+      const instance = selectedInstance.value;
+      if (instance.id === UNKNOWN_ID) {
+        return false;
+      }
+      return instance.engine === "POSTGRES";
+    });
+
+    const validDatabaseOwnerName = computed((): boolean => {
+      if (!requireDatabaseOwnerName.value) {
+        return true;
+      }
+
+      return !isEmpty(state.databaseOwnerName);
     });
 
     const selectProject = (projectId: ProjectId) => {
@@ -557,6 +570,7 @@ export default defineComponent({
       allowEditEnvironment,
       allowEditInstance,
       selectedInstance,
+      requireDatabaseOwnerName,
       showAssigneeSelect,
       selectProject,
       selectEnvironment,

--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -469,6 +469,9 @@ export default defineComponent({
       const databaseName = isDbNameTemplateMode.value
         ? generatedDatabaseName.value
         : state.databaseName;
+      const owner = requireDatabaseOwnerName.value
+        ? state.databaseOwnerName
+        : "";
 
       if (props.backup) {
         newIssue = {
@@ -484,7 +487,7 @@ export default defineComponent({
           createContext: {
             instanceId: state.instanceId!,
             databaseName: databaseName,
-            owner: state.databaseOwnerName,
+            owner,
             characterSet:
               state.characterSet ||
               defaultCharset(selectedInstance.value.engine),
@@ -510,7 +513,7 @@ export default defineComponent({
           createContext: {
             instanceId: state.instanceId!,
             databaseName: databaseName,
-            owner: state.databaseOwnerName,
+            owner,
             characterSet:
               state.characterSet ||
               defaultCharset(selectedInstance.value.engine),


### PR DESCRIPTION
- Check `databaseOwnerName` only when necessary.
  - Otherwise when we creating a non-PG database the "Create" button will always be disabled.
- Pass `owner` value to [POST] /api/issue only when necessary.
  - When we change the "Instance" dropdown value the `state.databaseOwnerName` might be dirty. So we pass it via the POST body only when necessary.