### PR TITLE
fix: localization for schema review rules

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1414,10 +1414,6 @@
         "title": "Column naming check",
         "description": "Enforce the column name format. Default snake_lower_case."
       },
-      "naming-index-pk": {
-        "title": "Primary key naming check",
-        "description": "Enforce the primary key name format. Default pk_{table_name}_{column_name}."
-      },
       "naming-index-uk": {
         "title": "Unique key naming check",
         "description": "Enforce the unique key name format. Default uk_{table_name}_{column_name}."
@@ -1458,9 +1454,9 @@
     "payload-config": {
       "table-name-format": "Table name format (regex)",
       "column-name-format": "Column name format (regex)",
-      "pk-name-format": "Primary key name format",
       "uk-name-format": "Unique key name format",
       "idx-name-format": "Index name format",
+      "fk-name-format": "Foreign key name format",
       "required-column": "Required column names",
       "input-then-press-enter": "Input the value then press enter to add",
       "template": {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1416,15 +1416,15 @@
       },
       "naming-index-uk": {
         "title": "Unique key naming check",
-        "description": "Enforce the unique key name format. Default uk_{table_name}_{column_name}."
+        "description": "Enforce the unique key name format. Default uk_<table_name>_<column_list>."
       },
       "naming-index-fk": {
         "title": "Foreign key naming check",
-        "description": "Enforce the foreign key name format. Default fk_{referencing_table}_{referencing_column}_{referenced_table}_{referenced_column}."
+        "description": "Enforce the foreign key name format. Default fk_<referencing_table>_<referencing_column>_<referenced_table>_<referenced_column>."
       },
       "naming-index-idx": {
         "title": "Index naming check",
-        "description": "Enforce the index name format. Default idx_{table_name}_{column_name}."
+        "description": "Enforce the index name format. Default idx_<table_name>_<column_list>."
       },
       "column-required": {
         "title": "Required columns",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1414,21 +1414,17 @@
         "title": "列名命名检查",
         "description": "限制列名命名风格，默认为小写字母_下划线。"
       },
-      "naming-index-pk": {
-        "title": "主键命名检查",
-        "description": "限制主键命名风格，默认为 pk_表名_主键包含的字段名组合。"
-      },
       "naming-index-uk": {
         "title": "唯一键命名检查",
-        "description": "限制唯一键命名风格，默认为 uk_表名_主键包含的字段名组合。"
+        "description": "限制唯一键命名风格，默认为 uk_<表名>_<主键包含的字段名组合>。"
       },
       "naming-index-fk": {
         "title": "外键命名检查",
-        "description": "限制外键命名风格，默认为 fk_目标表名_目标字段名_被引用表名_被引用字段名。"
+        "description": "限制外键命名风格，默认为 fk_<目标表名>_<目标字段名>_<被引用表名>_<被引用字段名>。"
       },
       "naming-index-idx": {
         "title": "索引命名检查",
-        "description": "限制索引命名风格，默认为 idx_表名_主键包含的字段名组合。"
+        "description": "限制索引命名风格，默认为 idx_<表名>_<索引包含的字段名组合>。"
       },
       "column-required": {
         "title": "必须包含的字段",
@@ -1458,9 +1454,9 @@
     "payload-config": {
       "table-name-format": "表命名规则（正则）",
       "column-name-format": "列命名规则（正则）",
-      "pk-name-format": "主键命名规则",
       "uk-name-format": "唯一键命名规则",
       "idx-name-format": "索引命名规则",
+      "fk-name-format": "外键命名规则",
       "required-column": "必须包含的字段名",
       "input-then-press-enter": "输入后按下回车来添加",
       "template": {


### PR DESCRIPTION
- Add missing localization for the foreign key
- Remove localization for the primary key
-  I found the `{` and `}` will be treated as the variable template after we switch to JSON from YAML. Haven't found ways to render the bracket yet, so I just change to the `<` and `>`

Before:
<img width="651" alt="图片" src="https://user-images.githubusercontent.com/10706318/169774034-64e3e76c-78e9-46b8-9642-4a1f39ab1a52.png">

After:
<img width="1158" alt="图片" src="https://user-images.githubusercontent.com/10706318/169774070-a521f70d-191e-486d-9dd2-c1e94baf6275.png">
