### PR TITLE
feat(frontend): support single tenant data change

### DIFF
--- a/frontend/src/components/Issue/logic/base.ts
+++ b/frontend/src/components/Issue/logic/base.ts
@@ -22,7 +22,7 @@ import {
   taskSlug,
 } from "@/utils";
 import { useIssueStore, useProjectStore } from "@/store";
-import { TaskTypeWithStatement } from "./common";
+import { flattenTaskList, TaskTypeWithStatement } from "./common";
 
 export const useBaseIssueLogic = (params: {
   create: Ref<boolean>;
@@ -147,10 +147,17 @@ export const useBaseIssueLogic = (params: {
 
   const isTenantMode = computed((): boolean => {
     if (project.value.tenantMode !== "TENANT") return false;
-    return (
-      issue.value.type === "bb.issue.database.schema.update" ||
-      issue.value.type === "bb.issue.database.data.update"
-    );
+    const { type } = issue.value;
+    if (type === "bb.issue.database.schema.update") {
+      return true;
+    }
+    if (type === "bb.issue.database.data.update") {
+      // We support single database data change in tenant mode projects.
+      // So a data change pipeline should be tenant mode when it contains more
+      // than one tasks.
+      return flattenTaskList(issue.value).length > 1;
+    }
+    return false;
   });
 
   const isGhostMode = computed((): boolean => {

--- a/frontend/src/components/Issue/logic/common.ts
+++ b/frontend/src/components/Issue/logic/common.ts
@@ -186,7 +186,7 @@ export const useCommonLogic = () => {
       const db = databaseStore.getDatabaseById(task.databaseId!);
       return {
         databaseId: task.databaseId!,
-        databaseName: task.databaseName!,
+        databaseName: "", // Only `databaseId` is needed in standard pipeline.
         statement: maybeFormatStatementOnSave(task.statement, db),
         earliestAllowedTs: task.earliestAllowedTs,
       };

--- a/frontend/src/plugins/issue/logic/initialize/standard.ts
+++ b/frontend/src/plugins/issue/logic/initialize/standard.ts
@@ -33,7 +33,7 @@ export const buildNewStandardIssue = async (
     updateSchemaDetailList: databaseList.map((db) => {
       return {
         databaseId: db.id,
-        databaseName: db.name,
+        databaseName: "", // Only `databaseId` is needed in standard pipeline.
         statement,
       };
     }),

--- a/frontend/src/store/modules/instance.ts
+++ b/frontend/src/store/modules/instance.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import axios from "axios";
-import { computed, watchEffect } from "vue";
+import { computed, onBeforeMount } from "vue";
 import {
   Anomaly,
   DataSource,
@@ -490,6 +490,6 @@ export const useInstanceStore = defineStore("instance", {
 
 export const useInstanceList = (rowStatusList?: RowStatus[]) => {
   const store = useInstanceStore();
-  watchEffect(() => store.fetchInstanceList(rowStatusList));
+  onBeforeMount(() => store.fetchInstanceList(rowStatusList));
   return computed(() => store.getInstanceList(rowStatusList));
 };

--- a/frontend/src/store/modules/instance.ts
+++ b/frontend/src/store/modules/instance.ts
@@ -490,6 +490,10 @@ export const useInstanceStore = defineStore("instance", {
 
 export const useInstanceList = (rowStatusList?: RowStatus[]) => {
   const store = useInstanceStore();
+  // SQL Editor will visit instanceList very early.
+  // Using `watchEffect` here might get a data race here, which leads a vue's
+  // internal error.
+  // So we fetch data when "before mount" - trying to be early but not too early.
   onBeforeMount(() => store.fetchInstanceList(rowStatusList));
   return computed(() => store.getInstanceList(rowStatusList));
 };

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -114,11 +114,10 @@
               class="-mr-1 ml-2 h-5 w-5 text-control-light"
             />
           </button>
-          <BBTooltipButton
+          <button
             v-if="allowEdit"
-            type="normal"
-            tooltip-mode="DISABLED-ONLY"
-            :disabled="!allowMigrate"
+            type="button"
+            class="btn-normal"
             @click="changeData"
           >
             <span>{{ changeDataText }}</span>
@@ -126,16 +125,7 @@
               v-if="database.project.workflowType == 'VCS'"
               class="-mr-1 ml-2 h-5 w-5 text-control-light"
             />
-            <template v-if="!allowMigrate" #tooltip>
-              <div class="w-48 whitespace-pre-wrap">
-                {{
-                  $t("issue.not-allowed-to-single-database-in-tenant-mode", {
-                    operation: changeDataText.toLowerCase(),
-                  })
-                }}
-              </div>
-            </template>
-          </BBTooltipButton>
+          </button>
           <BBTooltipButton
             v-if="allowEdit"
             type="normal"


### PR DESCRIPTION
This PR follows #1357 

- Do not pass `databaseName` in `createContext` when creating standard pipelines. The server-side won't use it.
- Fallback to standard pipeline view when 
  - The issue type is `"bb.issue.database.data.update"`.
  - There's only one task in the pipeline.
- Enable the "Change Data" button on the DB detail page.
- Changing data from SQL Editor is also supported now.