### PR TITLE
fix: vcs oauth error in project configure vcs page

### DIFF
--- a/server/oauth.go
+++ b/server/oauth.go
@@ -38,9 +38,19 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 
 			vcsType = vcs.Type
 			instanceURL = vcs.InstanceURL
+			clientID := req.ClientID
+			clientSecret := req.ClientSecret
+			// Since we may not pass in ClientID and ClientSecret in the request, we will use the client ID and secret from VCS store even if it's stale.
+			// If it's stale, we should return better error messages and ask users to update the VCS secrets.
+			// https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/frontend/src/components/RepositorySelectionPanel.vue?L77:8&subtree=true
+			// https://github.com/bytebase/bytebase/issues/1372
+			if clientID == "" || clientSecret == "" {
+				clientID = vcs.ApplicationID
+				clientSecret = vcs.Secret
+			}
 			oauthExchange = &common.OAuthExchange{
-				ClientID:     vcs.ApplicationID,
-				ClientSecret: vcs.Secret,
+				ClientID:     clientID,
+				ClientSecret: clientSecret,
 				Code:         req.Code,
 			}
 		} else {

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -39,8 +39,8 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 			vcsType = vcs.Type
 			instanceURL = vcs.InstanceURL
 			oauthExchange = &common.OAuthExchange{
-				ClientID:     req.ClientID,
-				ClientSecret: req.ClientSecret,
+				ClientID:     vcs.ApplicationID,
+				ClientSecret: vcs.Secret,
 				Code:         req.Code,
 			}
 		} else {


### PR DESCRIPTION
![origin_img_v2_19cc264e-5ca1-41e0-8379-8a8640e7914g](https://user-images.githubusercontent.com/24653555/170037294-66e5755f-d89b-45a4-b0ed-916ea7fffbd0.jpg)

Because it's possible to have no `clientId` or `clientSecret` in the request body, we should get them with `vcsId` even if it's stale. When the vcs information is stale, we should ask users to update them.
<img width="388" alt="image" src="https://user-images.githubusercontent.com/24653555/170037143-b2a2bd78-2c0b-45dd-beab-87112991b022.png">
