### PR TITLE
chore: rename sync schema 'afterwards' to 'now'

### DIFF
--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -185,7 +185,7 @@
       <!-- Create button group -->
       <div class="flex justify-between items-center">
         <BBCheckbox
-          :title="$t('instance.sync-schema-afterward')"
+          :title="$t('instance.sync-schema-now')"
           :value="state.instance.syncSchema"
           @toggle="state.instance.syncSchema = !state.instance.syncSchema"
         />

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -257,7 +257,7 @@
         <div>
           <BBCheckbox
             v-if="connectionInfoChanged"
-            :title="$t('instance.sync-schema-afterward')"
+            :title="$t('instance.sync-schema-now')"
             :value="state.syncSchema"
             @toggle="state.syncSchema = !state.syncSchema"
           />

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -532,7 +532,7 @@
     "new-database": "New Database",
     "syncing": "Syncing ...",
     "sync-now": "Sync Now",
-    "sync-schema-afterward": "Sync schema afterward",
+    "sync-schema-now": "Sync schema now",
     "create-migration-schema": "Create migration schema",
     "missing-migration-schema": "Missing migration schema",
     "unable-to-connect-instance-to-check-migration-schema": "Unable to connect instance to check migration schema",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -532,7 +532,7 @@
     "new-database": "@:common.new@:common.database",
     "syncing": "同步中 ...",
     "sync-now": "现在同步",
-    "sync-schema-afterward": "随即同步 schema",
+    "sync-schema-now": "随即同步 schema",
     "create-migration-schema": "@:common.create@:common.migration @:{'common.schema'}",
     "missing-migration-schema": "缺少@:common.migration @:common.schema",
     "unable-to-connect-instance-to-check-migration-schema": "无法连接到@:{'common.instance'}以检查@:{'common.migration'} @:{'common.schema'}",


### PR DESCRIPTION
World 'afterward' sounds more like syncing schema long time later.