### PR TITLE
fix: ignore error and log warning when pipeline belongs to no issue

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -404,11 +404,13 @@ func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, 
 	// TODO(tianzhou): Refactor the followup code into chained onTaskStatusChange hook.
 	issue, err := s.store.GetIssueByPipelineID(ctx, task.PipelineID)
 	if err != nil {
-		// Not all pipelines belong to an issue, so it's OK if ENOTFOUND
 		return nil, fmt.Errorf("failed to fetch containing issue after changing the task status: %v, err: %w", task.Name, err)
 	}
+	// Not all pipelines belong to an issue, so it's OK if issue is not found.
 	if issue == nil {
-		return nil, fmt.Errorf("failed to find issue with pipeline ID %d, task: %s", task.PipelineID, task.Name)
+		s.l.Warn("failed to find issue with pipeline ID",
+			zap.Int("pipelineID", task.PipelineID),
+			zap.String("task", task.Name))
 	}
 
 	// Create an activity

--- a/server/task.go
+++ b/server/task.go
@@ -408,7 +408,7 @@ func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, 
 	}
 	// Not all pipelines belong to an issue, so it's OK if issue is not found.
 	if issue == nil {
-		s.l.Warn("failed to find issue with pipeline ID",
+		s.l.Info("Pipeline has no linking issue",
 			zap.Int("pipelineID", task.PipelineID),
 			zap.String("task", task.Name))
 	}


### PR DESCRIPTION
When clicking the "Backup Now" button, the server logs errors.
![origin_img_v2_9b070116-db5a-41ca-93dc-209b203a83cg](https://user-images.githubusercontent.com/8433465/170166006-7a663511-2194-4b45-83fb-8b0821c59338.png)
```
{"time":"2022-05-25T09:49:29+08:00","method":"POST","uri":"/api/database/7034/backup","status":200,"error":""}
2022-05-25T09:49:30.100+0800	ERROR	Failed to change task status.	{"id": 11023, "name": "backup-task-default-prod-20220525T094928", "old_status": "PENDING", "new_status": "RUNNING", "error": "failed to find issue with pipeline ID 9012, task: backup-task-default-prod-20220525T094928"}
2022-05-25T09:49:30.100+0800	ERROR	Failed to schedule next running task	{"pipeline_id": 9012, "error": "failed to find issue with pipeline ID 9012, task: backup-task-default-prod-20220525T094928"}
```

And the pipeline status will be stuck at "OPEN", though the task status will be eventually pushed to "DONE", and the backup file is created.

This PR fixes the case that the pipeline has no linking issue.
