### PR TITLE
fix: trim statement for gh-ost parser

### DIFF
--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/bytebase/bytebase/api"
@@ -41,8 +40,7 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 		return true, nil, fmt.Errorf("invalid database schema update gh-ost sync payload: %w", err)
 	}
 
-	statement := strings.TrimSpace(payload.Statement)
-	tableName, err := getTableNameFromStatement(statement)
+	tableName, err := getTableNameFromStatement(payload.Statement)
 	if err != nil {
 		return true, nil, fmt.Errorf("failed to parse table name from statement, error: %w", err)
 	}

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -52,6 +52,8 @@ func getPostponeFlagFilename(taskID int, databaseID int, databaseName string, ta
 }
 
 func getTableNameFromStatement(statement string) (string, error) {
+	// Trim the statement for the parser.
+	// This in effect removes all leading and trailing spaces, substitute multiple spaces with one.
 	statement = strings.Join(strings.Fields(statement), " ")
 	parser := ghostsql.NewParserFromAlterStatement(statement)
 	if !parser.HasExplicitTable() {

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -52,7 +52,7 @@ func getPostponeFlagFilename(taskID int, databaseID int, databaseName string, ta
 }
 
 func getTableNameFromStatement(statement string) (string, error) {
-	statement = strings.TrimSpace(statement)
+	statement = strings.Join(strings.Fields(statement), " ")
 	parser := ghostsql.NewParserFromAlterStatement(statement)
 	if !parser.HasExplicitTable() {
 		return "", fmt.Errorf("failed to parse table name from statement, statement: %v", statement)
@@ -90,6 +90,7 @@ func newMigrationContext(config ghostConfig) (*base.MigrationContext, error) {
 		cutoverLockTimoutSeconds            = 3
 		exponentialBackoffMaxInterval       = 64
 	)
+	statement := strings.Join(strings.Fields(config.alterStatement), " ")
 	migrationContext := base.NewMigrationContext()
 	migrationContext.InspectorConnectionConfig.Key.Hostname = config.host
 	port := 3306
@@ -105,7 +106,7 @@ func newMigrationContext(config ghostConfig) (*base.MigrationContext, error) {
 	migrationContext.CliPassword = config.password
 	migrationContext.DatabaseName = config.database
 	migrationContext.OriginalTableName = config.table
-	migrationContext.AlterStatement = config.alterStatement
+	migrationContext.AlterStatement = statement
 	migrationContext.Noop = config.noop
 	migrationContext.ReplicaServerId = config.serverID
 	// set defaults

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestGhostParser(t *testing.T) {
+	t.Parallel()
 	a := require.New(t)
 	const statement = `
 	ALTER TABLE
@@ -27,12 +28,18 @@ func TestGhostParser(t *testing.T) {
 	ADD
 		COLUMN ghost_play_2 int;
 	`
-	s := strings.Join(strings.Fields(statement), " ")
-	parser := ghostsql.NewParserFromAlterStatement(s)
-	a.Equal(true, parser.HasExplicitTable())
-	a.Equal("test", parser.GetExplicitTable())
-	parser = ghostsql.NewParserFromAlterStatement(statement)
-	a.Equal(false, parser.HasExplicitTable())
+	t.Run("fail to parse", func(t *testing.T) {
+		t.Parallel()
+		parser := ghostsql.NewParserFromAlterStatement(statement)
+		a.Equal(false, parser.HasExplicitTable())
+	})
+	t.Run("succeed to parse", func(t *testing.T) {
+		t.Parallel()
+		s := strings.Join(strings.Fields(statement), " ")
+		parser := ghostsql.NewParserFromAlterStatement(s)
+		a.Equal(true, parser.HasExplicitTable())
+		a.Equal("test", parser.GetExplicitTable())
+	})
 }
 
 func TestGhostSchemaUpdate(t *testing.T) {

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -8,14 +8,32 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/resources/mysql"
+	ghostsql "github.com/github/gh-ost/go/sql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGhostParser(t *testing.T) {
+	a := require.New(t)
+	const statement = `
+	ALTER TABLE
+  		test
+	ADD
+		COLUMN ghost_play_2 int;
+	`
+	s := strings.Join(strings.Fields(statement), " ")
+	parser := ghostsql.NewParserFromAlterStatement(s)
+	a.Equal(true, parser.HasExplicitTable())
+	a.Equal("test", parser.GetExplicitTable())
+	parser = ghostsql.NewParserFromAlterStatement(statement)
+	a.Equal(false, parser.HasExplicitTable())
+}
 
 func TestGhostSchemaUpdate(t *testing.T) {
 	const (


### PR DESCRIPTION
The gh-ost parser cannot parse the following SQL statement, so we have to trim the string for it.
```sql
ALTER TABLE
  	test
ADD
	COLUMN ghost_play_2 int;
```