### PR TITLE
refactor: add temp dir as data dir for external pg in test

### DIFF
--- a/bin/server/cmd/profile_dev.go
+++ b/bin/server/cmd/profile_dev.go
@@ -54,12 +54,13 @@ func GetTestProfile(dataDir string, port int) server.Profile {
 // GetTestProfileWithExternalPg will return a profile for testing with external Postgres.
 // We require port as an argument of GetTestProfile so that test can run in parallel in different ports,
 // pgURL for connect to Postgres.
-func GetTestProfileWithExternalPg(port int, pgUser string, pgURL string) server.Profile {
+func GetTestProfileWithExternalPg(dataDir string, port int, pgUser string, pgURL string) server.Profile {
 	return server.Profile{
 		Mode:                 common.ReleaseModeDev,
 		BackendHost:          flags.host,
 		BackendPort:          port,
 		PgUser:               pgUser,
+		DataDir:              dataDir,
 		DemoDataDir:          fmt.Sprintf("demo/%s", common.ReleaseModeDev),
 		BackupRunnerInterval: 10 * time.Second,
 		PgURL:                pgURL,

--- a/tests/external_pg_test.go
+++ b/tests/external_pg_test.go
@@ -63,7 +63,8 @@ func TestBootWithExternalPg(t *testing.T) {
 	}()
 
 	ctl := &controller{}
-	err = ctl.StartServerWithExternalPg(ctx, serverPort, externalPg.pgUser, externalPg.pgURL)
+	dataTmpDir := t.TempDir()
+	err = ctl.StartServerWithExternalPg(ctx, dataTmpDir, serverPort, externalPg.pgUser, externalPg.pgURL)
 	a.NoError(err)
 	defer ctl.Close(ctx)
 }

--- a/tests/external_pg_test.go
+++ b/tests/external_pg_test.go
@@ -57,7 +57,7 @@ func TestBootWithExternalPg(t *testing.T) {
 	a.NoError(err)
 	defer func() {
 		if err = externalPg.Destroy(); err != nil {
-			fmt.Printf("cannot destroy pginstance, error: %s", err.Error())
+			fmt.Printf("cannot destroy postgres instance, error: %s", err.Error())
 			t.FailNow()
 		}
 	}()

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -143,14 +143,14 @@ func getTestPort(testName string) int {
 }
 
 // StartServerWithExternalPg starts the main server with external Postgres.
-func (ctl *controller) StartServerWithExternalPg(ctx context.Context, port int, pgUser, pgURL string) error {
+func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir string, port int, pgUser, pgURL string) error {
 	logger, lvl, err := cmd.GetLogger()
 	if err != nil {
 		return fmt.Errorf("failed to get logger, error: %w", err)
 	}
 	defer logger.Sync()
 
-	profile := cmd.GetTestProfileWithExternalPg(port, pgUser, pgURL)
+	profile := cmd.GetTestProfileWithExternalPg(dataDir, port, pgUser, pgURL)
 	ctl.server, err = server.NewServer(ctx, profile, logger, lvl)
 	if err != nil {
 		return err


### PR DESCRIPTION
Otherwise, if we run `TestBootWithExternalPg`, there will be a `tests/resources` dir created in the codebase.