### PR TITLE
chore: verbose logging for VCS workflow and schema migration

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -67,7 +67,9 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Project mismatch, got %d, want %s", pushEvent.Project.ID, repo.ExternalID))
 		}
 
-		s.l.Debug("Processing gitlab webhook push event...")
+		s.l.Debug("Processing gitlab webhook push event...",
+			zap.String("project", repo.Project.Name),
+		)
 
 		createdMessageList := []string{}
 		for _, commit := range pushEvent.CommitList {
@@ -230,7 +232,11 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 		}
 
 		if len(createdMessageList) == 0 {
-			return c.String(http.StatusOK, "Ignored push event. No applicable file found in the commit list.")
+			msg := "Ignored push event. No applicable file found in the commit list."
+			s.l.Warn(msg,
+				zap.String("project", repo.Project.Name),
+			)
+			return c.String(http.StatusOK, msg)
 		}
 		return c.String(http.StatusOK, strings.Join(createdMessageList, "\n"))
 	})

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -67,9 +67,20 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Project mismatch, got %d, want %s", pushEvent.Project.ID, repo.ExternalID))
 		}
 
+		s.l.Debug("Processing gitlab webhook push event...")
+
 		createdMessageList := []string{}
 		for _, commit := range pushEvent.CommitList {
+			s.l.Debug("Processing commit...",
+				zap.String("id", commit.ID),
+				zap.String("title", commit.Title),
+			)
+
 			for _, added := range commit.AddedList {
+				s.l.Debug("Processing added file...",
+					zap.String("file", added),
+				)
+
 				if !strings.HasPrefix(added, repo.BaseDirectory) {
 					s.l.Debug("Ignored committed file, not under base directory.", zap.String("file", added), zap.String("base_directory", repo.BaseDirectory))
 					continue
@@ -80,8 +91,9 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 					s.l.Warn("Ignored committed file, failed to parse commit timestamp.", zap.String("file", added), zap.String("timestamp", commit.Timestamp), zap.Error(err))
 				}
 
-				// Ignored the schema file we auto generated to the repository.
+				// Ignore the schema file we auto generated to the repository.
 				if isSkipGeneratedSchemaFile(repo, added, s.l) {
+					s.l.Debug("Ignored generated latest schema file.", zap.String("file", added))
 					continue
 				}
 
@@ -217,6 +229,9 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			}
 		}
 
+		if len(createdMessageList) == 0 {
+			return c.String(http.StatusOK, "Ignored push event. No applicable file found in the commit list.")
+		}
 		return c.String(http.StatusOK, strings.Join(createdMessageList, "\n"))
 	})
 }
@@ -318,6 +333,8 @@ func (s *Server) createTenantSchemaUpdateIssue(ctx context.Context, repository *
 	return string(createContext), nil
 }
 
+// We may write back the latest schema file to the repository after migration and we need to ignore
+// this file from the webhook push event.
 func isSkipGeneratedSchemaFile(repository *api.Repository, added string, logger *zap.Logger) bool {
 	if repository.SchemaPathTemplate != "" {
 		placeholderList := []string{


### PR DESCRIPTION
* Return more readable messages so we know why the webhook event is ignored
![CleanShot 2022-05-25 at 18 05 39](https://user-images.githubusercontent.com/230323/170239960-930663e7-7c4f-463c-b79f-1d996ef79fbb.png)

* Add debug logging when responding to the webhook event

<img width="1339" alt="CleanShot 2022-05-25 at 18 06 06@2x" src="https://user-images.githubusercontent.com/230323/170240047-69b56fa2-5c0e-40b9-a38b-38553f24798e.png">

* Add debug logging when executing migration

![CleanShot 2022-05-25 at 18 12 31@2x](https://user-images.githubusercontent.com/230323/170240223-8151bd94-f81f-4149-ad32-000c876d6944.png)

