### PR TITLE
fix: return the project activity in created_ts DESC order

### DIFF
--- a/api/activity.go
+++ b/api/activity.go
@@ -296,6 +296,10 @@ type ActivityFind struct {
 	Level       *ActivityLevel
 	ContainerID *int
 	Limit       *int
+	// If specified, sorts the returned list by created_ts in <<ORDER>>
+	// Different use cases want different orders.
+	// e.g. Issue activity list wants ASC, while view recent activity list wants DESC.
+	Order *SortOrder
 }
 
 func (find *ActivityFind) String() string {

--- a/api/api.go
+++ b/api/api.go
@@ -22,3 +22,23 @@ func (e RowStatus) String() string {
 	}
 	return ""
 }
+
+// SortOrder is the sort order for the returned list.
+type SortOrder string
+
+const (
+	// ASC is the sort order to return in ascending order.
+	ASC SortOrder = "ASC"
+	// DESC is the sort order to return in descending order.
+	DESC SortOrder = "DESC"
+)
+
+func (e SortOrder) String() string {
+	switch e {
+	case ASC:
+		return "ASC"
+	case DESC:
+		return "DESC"
+	}
+	return ""
+}

--- a/frontend/src/store/modules/activity.ts
+++ b/frontend/src/store/modules/activity.ts
@@ -73,7 +73,7 @@ export const useActivityStore = defineStore("activity", {
       this.activityListByIssue.set(issueId, activityList);
     },
     async fetchActivityListForUser(userId: PrincipalId) {
-      const data = (await axios.get(`/api/activity`)).data;
+      const data = (await axios.get(`/api/activity?order=DESC`)).data;
       const activityList: Activity[] = data.data.map(
         (activity: ResourceObject) => {
           return convert(activity, data.included);
@@ -84,7 +84,11 @@ export const useActivityStore = defineStore("activity", {
       return activityList;
     },
     async fetchActivityListForIssue(issueId: IssueId) {
-      const queryList = ["typePrefix=bb.issue.", `container=${issueId}`];
+      const queryList = [
+        "typePrefix=bb.issue.",
+        `container=${issueId}`,
+        `order=ASC`,
+      ];
       const data = (await axios.get(`/api/activity?${queryList.join("&")}`))
         .data;
       const activityList: Activity[] = data.data.map(
@@ -104,7 +108,11 @@ export const useActivityStore = defineStore("activity", {
       projectId: ProjectId;
       limit?: number;
     }) {
-      const queryList = ["typePrefix=bb.project.", `container=${projectId}`];
+      const queryList = [
+        "typePrefix=bb.project.",
+        `container=${projectId}`,
+        `order=DESC`,
+      ];
       if (limit) {
         queryList.push(`limit=${limit}`);
       }
@@ -123,6 +131,7 @@ export const useActivityStore = defineStore("activity", {
       const queryList = [
         "typePrefix=bb.sql-editor.query",
         `user=${currentUser.id}`,
+        `order=DESC`,
         `limit=${limit}`,
         // only fetch the successful query history
         `level=INFO`,

--- a/server/activity.go
+++ b/server/activity.go
@@ -88,6 +88,10 @@ func (s *Server) registerActivityRoutes(g *echo.Group) {
 			}
 			activityFind.Limit = &limit
 		}
+		if orderStr := c.QueryParams().Get("order"); orderStr != "" {
+			order := api.SortOrder(orderStr)
+			activityFind.Order = &order
+		}
 		activityList, err := s.store.FindActivity(ctx, activityFind)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch activity list").SetInternal(err)

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -68,12 +68,18 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 		}
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 		s.l.Debug("Processing gitlab webhook push event...",
 			zap.String("project", repo.Project.Name),
 		)
 =======
 		s.l.Debug("Processing gitlab webhook push event...")
 >>>>>>> 4fe2f1ab (chore: verbose logging for VCS workflow)
+=======
+		s.l.Debug("Processing gitlab webhook push event...",
+			zap.String("project", repo.Project.Name),
+		)
+>>>>>>> 0a310dd9 (chore: address comment)
 
 		createdMessageList := []string{}
 		for _, commit := range pushEvent.CommitList {
@@ -237,14 +243,20 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 
 		if len(createdMessageList) == 0 {
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 0a310dd9 (chore: address comment)
 			msg := "Ignored push event. No applicable file found in the commit list."
 			s.l.Warn(msg,
 				zap.String("project", repo.Project.Name),
 			)
 			return c.String(http.StatusOK, msg)
+<<<<<<< HEAD
 =======
 			return c.String(http.StatusOK, "Ignored push event. No applicable file found in the commit list.")
 >>>>>>> 4fe2f1ab (chore: verbose logging for VCS workflow)
+=======
+>>>>>>> 0a310dd9 (chore: address comment)
 		}
 		return c.String(http.StatusOK, strings.Join(createdMessageList, "\n"))
 	})

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -67,19 +67,9 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Project mismatch, got %d, want %s", pushEvent.Project.ID, repo.ExternalID))
 		}
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 		s.l.Debug("Processing gitlab webhook push event...",
 			zap.String("project", repo.Project.Name),
 		)
-=======
-		s.l.Debug("Processing gitlab webhook push event...")
->>>>>>> 4fe2f1ab (chore: verbose logging for VCS workflow)
-=======
-		s.l.Debug("Processing gitlab webhook push event...",
-			zap.String("project", repo.Project.Name),
-		)
->>>>>>> 0a310dd9 (chore: address comment)
 
 		createdMessageList := []string{}
 		for _, commit := range pushEvent.CommitList {
@@ -242,21 +232,10 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 		}
 
 		if len(createdMessageList) == 0 {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 0a310dd9 (chore: address comment)
 			msg := "Ignored push event. No applicable file found in the commit list."
 			s.l.Warn(msg,
 				zap.String("project", repo.Project.Name),
 			)
-			return c.String(http.StatusOK, msg)
-<<<<<<< HEAD
-=======
-			return c.String(http.StatusOK, "Ignored push event. No applicable file found in the commit list.")
->>>>>>> 4fe2f1ab (chore: verbose logging for VCS workflow)
-=======
->>>>>>> 0a310dd9 (chore: address comment)
 		}
 		return c.String(http.StatusOK, strings.Join(createdMessageList, "\n"))
 	})

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -67,9 +67,13 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Project mismatch, got %d, want %s", pushEvent.Project.ID, repo.ExternalID))
 		}
 
+<<<<<<< HEAD
 		s.l.Debug("Processing gitlab webhook push event...",
 			zap.String("project", repo.Project.Name),
 		)
+=======
+		s.l.Debug("Processing gitlab webhook push event...")
+>>>>>>> 4fe2f1ab (chore: verbose logging for VCS workflow)
 
 		createdMessageList := []string{}
 		for _, commit := range pushEvent.CommitList {
@@ -232,11 +236,15 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 		}
 
 		if len(createdMessageList) == 0 {
+<<<<<<< HEAD
 			msg := "Ignored push event. No applicable file found in the commit list."
 			s.l.Warn(msg,
 				zap.String("project", repo.Project.Name),
 			)
 			return c.String(http.StatusOK, msg)
+=======
+			return c.String(http.StatusOK, "Ignored push event. No applicable file found in the commit list.")
+>>>>>>> 4fe2f1ab (chore: verbose logging for VCS workflow)
 		}
 		return c.String(http.StatusOK, strings.Join(createdMessageList, "\n"))
 	})

--- a/store/activity.go
+++ b/store/activity.go
@@ -319,8 +319,11 @@ func findActivityImpl(ctx context.Context, tx *sql.Tx, find *api.ActivityFind) (
 			payload
 		FROM activity
 		WHERE ` + strings.Join(where, " AND ")
+	if v := find.Order; v != nil {
+		query += fmt.Sprintf(" ORDER BY created_ts %s", *v)
+	}
 	if v := find.Limit; v != nil {
-		query += fmt.Sprintf(" ORDER BY updated_ts DESC LIMIT %d", *v)
+		query += fmt.Sprintf(" LIMIT %d", *v)
 	}
 
 	rows, err := tx.QueryContext(ctx, query,


### PR DESCRIPTION
![CleanShot 2022-05-25 at 19 26 33](https://user-images.githubusercontent.com/230323/170254044-5881f447-97a6-406d-b65d-d9d8c48d229e.png)


The previous implementation only returns the `updated_ts DESC` order if `limit` is specified. This is only used when fetching the recent 5 activities for the project overview. The current implementation has couple of problems:

1. Sort order varies among different use cases, issue activity wants ASC while view recent activities wants DESC
2. We don't have `updated_ts` index on the activity table, we only have `created_ts` index
<img width="593" alt="CleanShot 2022-05-25 at 19 45 23@2x" src="https://user-images.githubusercontent.com/230323/170254622-3eaa9947-1b21-4b19-93ba-a2fe95f0f631.png">

So the fix is to let client specify the sort order and if specified, we order it on `created_ts` instead of `updated_ts`

