### PR TITLE
fix: sql formatter language checker

### DIFF
--- a/frontend/src/components/MonacoEditor/sqlFormatter.ts
+++ b/frontend/src/components/MonacoEditor/sqlFormatter.ts
@@ -11,6 +11,10 @@ const formatSQL = (sql: string, dialect: SQLDialect): FormatResult => {
   const options: FormatOptions = {
     language: dialect,
   };
+  if (dialect !== "mysql" && dialect !== "postgresql") {
+    options.language = "mysql";
+  }
+
   try {
     const formatted = format(sql, options);
     return { data: formatted, error: null };


### PR DESCRIPTION
Fix unexpected behavior of clearing editor when language is not normal for `sql-formatter`.
refer: https://github.com/zeroturnaround/sql-formatter/blob/master/docs/language.md#options