### PR TITLE
chore: add vscode config to attach to running golang process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Process",
+            "type": "go",
+            "request": "attach",
+            "mode": "local",
+            "processId": 0
+        }
+    ]
+}

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = ".air"
 
 [build]
   bin = "./.air/bytebase --port 8080 --frontend-port 3000 --data ."
-  cmd = "go build -o ./.air/bytebase ./bin/server/main.go"
+  cmd = "go build -gcflags=all=\"-N -l\" -o ./.air/bytebase ./bin/server/main.go"
   delay = 1000
   exclude_dir = [".air", "vendor", "frontend", "docs"]
   exclude_file = []


### PR DESCRIPTION
We can now easily attach to a running bytebase server and debug it on the fly!

<video src="https://user-images.githubusercontent.com/8433465/170415155-b53d237a-4fd5-4b92-a11f-c5296f32c55b.mov" />