### PR TITLE
fix: patch task race condition

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -439,20 +439,6 @@ func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, 
 		return nil, err
 	}
 
-	// Schedule the task if it's being just approved
-	if task.Status == api.TaskPendingApproval && taskPatched.Status == api.TaskPending {
-		skipIfAlreadyTerminated := false
-		if _, err := s.TaskCheckScheduler.ScheduleCheckIfNeeded(ctx, taskPatched, api.SystemBotID, skipIfAlreadyTerminated); err != nil {
-			return nil, fmt.Errorf("failed to schedule task check \"%v\" after approval", taskPatched.Name)
-		}
-
-		scheduledTask, err := s.TaskScheduler.ScheduleIfNeeded(ctx, taskPatched)
-		if err != nil {
-			return nil, fmt.Errorf("failed to schedule task \"%v\" after approval", taskPatched.Name)
-		}
-		taskPatched = scheduledTask
-	}
-
 	// If create database or schema update task completes, we sync the corresponding instance schema immediately.
 	if (taskPatched.Type == api.TaskDatabaseCreate || taskPatched.Type == api.TaskDatabaseSchemaUpdate) &&
 		taskPatched.Status == api.TaskDone {


### PR DESCRIPTION
The deleted codes in this PR will cause race conditions with https://github.com/bytebase/bytebase/blob/05ea4d8eb741ccd9416320faa98caf7c81272809/server/task_scheduler.go#L82

Both will try to patch task status from `PENDING` to `RUNNING` thus causing a race condition.