### PR TITLE
feat: check issue/task status transition again before patching

### DIFF
--- a/frontend/src/bbkit/BBModal.vue
+++ b/frontend/src/bbkit/BBModal.vue
@@ -2,6 +2,7 @@
   <teleport to="#bb-modal-stack">
     <div class="fixed inset-0 bg-transparent" :style="style" />
     <div
+      v-bind="$attrs"
       class="bb-modal"
       :style="style"
       :data-bb-modal-id="id"

--- a/frontend/src/components/Issue/logic/index.ts
+++ b/frontend/src/components/Issue/logic/index.ts
@@ -7,6 +7,7 @@ import StandardModeProvider from "./StandardModeProvider";
 export * from "./base";
 export * from "./common";
 export * from "./extra";
+export * from "./transition";
 
 export {
   IssueLogic,

--- a/frontend/src/components/Issue/logic/transition.ts
+++ b/frontend/src/components/Issue/logic/transition.ts
@@ -1,0 +1,113 @@
+import { useCurrentUser } from "@/store";
+import {
+  Issue,
+  SYSTEM_BOT_ID,
+  ONBOARDING_ISSUE_ID,
+  IssueStatusTransitionType,
+  ASSIGNEE_APPLICABLE_ACTION_LIST,
+  CREATOR_APPLICABLE_ACTION_LIST,
+  ISSUE_STATUS_TRANSITION_LIST,
+  IssueStatusTransition,
+} from "@/types";
+import {
+  allTaskList,
+  applicableTaskTransition,
+  isDBAOrOwner,
+  TaskStatusTransition,
+} from "@/utils";
+import { useIssueLogic } from ".";
+
+export const getApplicableIssueStatusTransitionList = (
+  issue: Issue
+): IssueStatusTransition[] => {
+  const currentUser = useCurrentUser();
+  const { activeTaskOfPipeline } = useIssueLogic();
+  const currentTask = activeTaskOfPipeline(issue.pipeline);
+
+  const issueEntity = issue as Issue;
+  if (issueEntity.id == ONBOARDING_ISSUE_ID) {
+    return [];
+  }
+  const list: IssueStatusTransitionType[] = [];
+  // Allow assignee, or assignee is the system bot and current user is DBA or owner
+  if (
+    currentUser.value.id === issueEntity.assignee?.id ||
+    (issueEntity.assignee?.id == SYSTEM_BOT_ID &&
+      isDBAOrOwner(currentUser.value.role))
+  ) {
+    list.push(...ASSIGNEE_APPLICABLE_ACTION_LIST.get(issueEntity.status)!);
+  }
+  if (currentUser.value.id === issueEntity.creator.id) {
+    CREATOR_APPLICABLE_ACTION_LIST.get(issueEntity.status)!.forEach((item) => {
+      if (list.indexOf(item) == -1) {
+        list.push(item);
+      }
+    });
+  }
+
+  return list
+    .filter((item) => {
+      const pipeline = issueEntity.pipeline;
+      // Disallow any issue status transition if the active task is in RUNNING state.
+      if (currentTask.status == "RUNNING") {
+        return false;
+      }
+
+      const taskList = allTaskList(pipeline);
+      // Don't display the Resolve action if the last task is NOT in DONE status.
+      if (
+        item == "RESOLVE" &&
+        taskList.length > 0 &&
+        (currentTask.id != taskList[taskList.length - 1].id ||
+          currentTask.status != "DONE")
+      ) {
+        return false;
+      }
+
+      return true;
+    })
+    .map(
+      (type: IssueStatusTransitionType) =>
+        ISSUE_STATUS_TRANSITION_LIST.get(type)!
+    )
+    .reverse();
+};
+
+export const getApplicableTaskStatusTransitionList = (
+  issue: Issue
+): TaskStatusTransition[] => {
+  const currentUser = useCurrentUser();
+  if (issue.id == ONBOARDING_ISSUE_ID) {
+    return [];
+  }
+  switch (issue.status) {
+    case "DONE":
+    case "CANCELED":
+      return [];
+    case "OPEN": {
+      let list: TaskStatusTransition[] = [];
+
+      // Allow assignee, or assignee is the system bot and current user is DBA or owner
+      if (
+        currentUser.value.id === issue.assignee?.id ||
+        (issue.assignee?.id == SYSTEM_BOT_ID &&
+          isDBAOrOwner(currentUser.value.role))
+      ) {
+        list = applicableTaskTransition(issue.pipeline);
+      }
+
+      return list;
+    }
+  }
+  console.assert(false, "Should never reach this line");
+};
+
+export function isApplicableTransition<
+  T extends IssueStatusTransition | TaskStatusTransition
+>(target: T, list: T[]): boolean {
+  return (
+    list.findIndex((applicable) => {
+      return applicable.to === target.to && applicable.type === target.type;
+    }) >= 0
+  );
+}


### PR DESCRIPTION
This might somehow help to avoid concurrency and race conditions when patching an issue or a task.

When a user clicked the issue/task status transition button:

- Fetch the latest issue entity from the server-side before doing a PATCH.
- Check whether the patching is applicable via the latest issue and pipeline status.
- Preventing the user from clicking the "Approve" or "Run" button in a very short time again via a mask layer with a spinning icon.
- 
![image](https://user-images.githubusercontent.com/2749742/170615483-ff22d265-bdea-46e8-b5e1-258c2b17060e.png)

