### PR TITLE
chore: upgrade codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,9 +55,10 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+        with:
+          output: sarif-results
 
       - name: Upload SARIF File
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: results.sarif
-          category: language-${{ matrix.language }}
+          sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,11 +55,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
-        with:
-          output: sarif-results
-
-      - name: Upload SARIF File
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: sarif-results/${{ matrix.language }}.sarif
-          category: analyze-${{ matrix.language }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,3 +58,6 @@ jobs:
 
       - name: Upload SARIF File
         uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif
+          category: language-${{ matrix.language }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,31 +45,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      #- run: |
-      #   make bootstrap
-      #   make release
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2
+
+      - name: Upload SARIF File
+        uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,3 +62,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
+          category: analyze-${{ matrix.language }}

--- a/common/security.go
+++ b/common/security.go
@@ -1,0 +1,10 @@
+package common
+
+import "strings"
+
+// EscapeForLogging escapes characters for logging to prevent injection.
+func EscapeForLogging(input string) string {
+	escaped := strings.ReplaceAll(input, "\n", "")
+	escaped = strings.ReplaceAll(escaped, "\t", "")
+	return escaped
+}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -74,13 +74,12 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 		createdMessageList := []string{}
 		for _, commit := range pushEvent.CommitList {
 			s.l.Debug("Processing commit...",
-				zap.String("id", commit.ID),
-				zap.String("title", commit.Title),
+				zap.String("id", common.EscapeForLogging(commit.ID)),
+				zap.String("title", common.EscapeForLogging(commit.Title)),
 			)
 
 			for _, added := range commit.AddedList {
-				addedEscaped := strings.ReplaceAll(added, "\n", "")
-				addedEscaped = strings.ReplaceAll(addedEscaped, "\t", "")
+				addedEscaped := common.EscapeForLogging(added)
 				s.l.Debug("Processing added file...",
 					zap.String("file", addedEscaped),
 				)
@@ -92,7 +91,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 
 				createdTime, err := time.Parse(time.RFC3339, commit.Timestamp)
 				if err != nil {
-					s.l.Warn("Ignored committed file, failed to parse commit timestamp.", zap.String("file", addedEscaped), zap.String("timestamp", commit.Timestamp), zap.Error(err))
+					s.l.Warn("Ignored committed file, failed to parse commit timestamp.", zap.String("file", addedEscaped), zap.String("timestamp", common.EscapeForLogging(commit.Timestamp)), zap.Error(err))
 				}
 
 				// Ignore the schema file we auto generated to the repository.

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -79,23 +79,25 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			)
 
 			for _, added := range commit.AddedList {
+				addedEscaped := strings.ReplaceAll(added, "\n", "")
+				addedEscaped = strings.ReplaceAll(addedEscaped, "\t", "")
 				s.l.Debug("Processing added file...",
-					zap.String("file", added),
+					zap.String("file", addedEscaped),
 				)
 
-				if !strings.HasPrefix(added, repo.BaseDirectory) {
-					s.l.Debug("Ignored committed file, not under base directory.", zap.String("file", added), zap.String("base_directory", repo.BaseDirectory))
+				if !strings.HasPrefix(addedEscaped, repo.BaseDirectory) {
+					s.l.Debug("Ignored committed file, not under base directory.", zap.String("file", addedEscaped), zap.String("base_directory", repo.BaseDirectory))
 					continue
 				}
 
 				createdTime, err := time.Parse(time.RFC3339, commit.Timestamp)
 				if err != nil {
-					s.l.Warn("Ignored committed file, failed to parse commit timestamp.", zap.String("file", added), zap.String("timestamp", commit.Timestamp), zap.Error(err))
+					s.l.Warn("Ignored committed file, failed to parse commit timestamp.", zap.String("file", addedEscaped), zap.String("timestamp", commit.Timestamp), zap.Error(err))
 				}
 
 				// Ignore the schema file we auto generated to the repository.
-				if isSkipGeneratedSchemaFile(repo, added, s.l) {
-					s.l.Debug("Ignored generated latest schema file.", zap.String("file", added))
+				if isSkipGeneratedSchemaFile(repo, addedEscaped, s.l) {
+					s.l.Debug("Ignored generated latest schema file.", zap.String("file", addedEscaped))
 					continue
 				}
 
@@ -114,13 +116,13 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 						CreatedTs:  createdTime.Unix(),
 						URL:        commit.URL,
 						AuthorName: commit.Author.Name,
-						Added:      added,
+						Added:      addedEscaped,
 					},
 				}
 
 				// Create a WARNING project activity if committed file is ignored
 				var createIgnoredFileActivity = func(err error) {
-					s.l.Warn("Ignored committed file", zap.String("file", added), zap.Error(err))
+					s.l.Warn("Ignored committed file", zap.String("file", addedEscaped), zap.Error(err))
 					bytes, marshalErr := json.Marshal(api.ActivityProjectRepositoryPushPayload{
 						VCSPushEvent: vcsPushEvent,
 					})
@@ -134,7 +136,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 						ContainerID: repo.ProjectID,
 						Type:        api.ActivityProjectRepositoryPush,
 						Level:       api.ActivityWarn,
-						Comment:     fmt.Sprintf("Ignored committed file %q, %s.", added, err.Error()),
+						Comment:     fmt.Sprintf("Ignored committed file %q, %s.", addedEscaped, err.Error()),
 						Payload:     string(bytes),
 					}
 					_, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{})
@@ -143,7 +145,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 					}
 				}
 
-				mi, err := db.ParseMigrationInfo(added, filepath.Join(repo.BaseDirectory, repo.FilePathTemplate))
+				mi, err := db.ParseMigrationInfo(addedEscaped, filepath.Join(repo.BaseDirectory, repo.FilePathTemplate))
 				if err != nil {
 					createIgnoredFileActivity(err)
 					continue
@@ -161,7 +163,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 					},
 					repo.VCS.InstanceURL,
 					repo.ExternalID,
-					added,
+					addedEscaped,
 					commit.ID,
 				)
 				if err != nil {
@@ -175,9 +177,9 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 					if !s.feature(api.FeatureMultiTenancy) {
 						return echo.NewHTTPError(http.StatusForbidden, api.FeatureMultiTenancy.AccessErrorMessage())
 					}
-					createContext, err = s.createTenantSchemaUpdateIssue(ctx, repo, mi, vcsPushEvent, commit, added, content)
+					createContext, err = s.createTenantSchemaUpdateIssue(ctx, repo, mi, vcsPushEvent, commit, addedEscaped, content)
 				} else {
-					createContext, err = s.createSchemaUpdateIssue(ctx, repo, mi, vcsPushEvent, commit, added, content)
+					createContext, err = s.createSchemaUpdateIssue(ctx, repo, mi, vcsPushEvent, commit, addedEscaped, content)
 				}
 				if err != nil {
 					createIgnoredFileActivity(err)
@@ -205,7 +207,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusInternalServerError, errMsg).SetInternal(err)
 				}
 
-				createdMessageList = append(createdMessageList, fmt.Sprintf("Created issue %q on adding %s", issue.Name, added))
+				createdMessageList = append(createdMessageList, fmt.Sprintf("Created issue %q on adding %s", issue.Name, addedEscaped))
 
 				// Create a project activity after successfully creating the issue as the result of the push event
 				bytes, err := json.Marshal(api.ActivityProjectRepositoryPushPayload{

--- a/store/activity.go
+++ b/store/activity.go
@@ -320,7 +320,7 @@ func findActivityImpl(ctx context.Context, tx *sql.Tx, find *api.ActivityFind) (
 		FROM activity
 		WHERE ` + strings.Join(where, " AND ")
 	if v := find.Order; v != nil {
-		query += fmt.Sprintf(" ORDER BY created_ts %s", *v)
+		query += fmt.Sprintf(" ORDER BY created_ts %s", v.String())
 	}
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)


### PR DESCRIPTION
ref: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

> On March 30, 2022, we released CodeQL Action v2, which runs on the Node.js 16 runtime. The CodeQL Action v1 will be deprecated at the same time as GHES 3.3, which is currently scheduled for December 2022.
