### PR TITLE
feat(PITR): add connection config as an argument to new mysql restore

### DIFF
--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/mysql"
 	"github.com/bytebase/bytebase/resources/mysqlutil"
 
@@ -35,13 +36,15 @@ const (
 type Restore struct {
 	driver    *mysql.Driver
 	mysqlutil *mysqlutil.Instance
+	connCfg   db.ConnectionConfig
 }
 
 // New creates a new instance of Restore
-func New(driver *mysql.Driver, instance *mysqlutil.Instance) *Restore {
+func New(driver *mysql.Driver, instance *mysqlutil.Instance, connCfg db.ConnectionConfig) *Restore {
 	return &Restore{
 		driver:    driver,
 		mysqlutil: instance,
+		connCfg:   connCfg,
 	}
 }
 

--- a/server/database.go
+++ b/server/database.go
@@ -905,7 +905,8 @@ func getConnectionConfig(ctx context.Context, instance *api.Instance, databaseNa
 		return db.ConnectionConfig{}, common.Errorf(common.Internal, fmt.Errorf("admin data source not found for instance %d", instance.ID))
 	}
 
-	return db.ConnectionConfig{Username: adminDataSource.Username,
+	return db.ConnectionConfig{
+		Username: adminDataSource.Username,
 		Password: adminDataSource.Password,
 		Host:     instance.Host,
 		Port:     instance.Port,

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -46,12 +46,17 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 		return true, nil, err
 	}
 
+	connCfg, err := getConnectionConfig(ctx, task.Instance, task.Database.Name)
+	if err != nil {
+		return true, nil, err
+	}
+
 	mysqlDriver, ok := driver.(*pluginmysql.Driver)
 	if !ok {
 		exec.l.Error("failed to cast driver to mysql.Driver", zap.Stack("stack"))
 		return true, nil, fmt.Errorf("[internal] cast driver to mysql.Driver failed")
 	}
-	mysqlRestore := restoremysql.New(mysqlDriver, exec.mysqlutil)
+	mysqlRestore := restoremysql.New(mysqlDriver, exec.mysqlutil, connCfg)
 
 	exec.l.Info("Start swapping the original and PITR database",
 		zap.String("instance", task.Instance.Name),

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -71,13 +71,18 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 		return err
 	}
 
+	connCfg, err := getConnectionConfig(ctx, instance, database.Name)
+	if err != nil {
+		return err
+	}
+
 	mysqlDriver, ok := driver.(*pluginmysql.Driver)
 	if !ok {
 		exec.l.Error("failed to cast driver to mysql.Driver", zap.Stack("stack"))
 		return fmt.Errorf("[internal] cast driver to mysql.Driver failed")
 	}
 
-	mysqlRestore := restoremysql.New(mysqlDriver, exec.mysqlutil)
+	mysqlRestore := restoremysql.New(mysqlDriver, exec.mysqlutil, connCfg)
 
 	binlogInfo := api.BinlogInfo{}
 	// TODO(dragonly): Search and put the file io of the logical backup file here.

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -124,7 +124,7 @@ func TestPITR(t *testing.T) {
 
 	t.Log("install mysqlbinlog binary")
 	tmpDir := t.TempDir()
-	mysqlutilIns, err := mysqlutil.Install(tmpDir)
+	mysqlutilInstance, err := mysqlutil.Install(tmpDir)
 	a.NoError(err)
 
 	// test cases
@@ -147,6 +147,8 @@ func TestPITR(t *testing.T) {
 		a.NoError(err)
 		defer driver.Close(ctx)
 
+		connCfg := getMySQLConnectionConfig(strconv.Itoa(mysqlPort), database)
+
 		buf, err := doBackup(ctx, driver, database)
 		a.NoError(err)
 		t.Logf("backup content:\n%s", buf.String())
@@ -162,7 +164,7 @@ func TestPITR(t *testing.T) {
 		createPITRIssueTimestamp := time.Now().Unix()
 		mysqlDriver, ok := driver.(*pluginmysql.Driver)
 		a.Equal(true, ok)
-		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilIns)
+		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilInstance, connCfg)
 		binlogInfo := api.BinlogInfo{}
 		err = mysqlRestore.RestorePITR(ctx, bufio.NewScanner(buf), binlogInfo, database, createPITRIssueTimestamp)
 		a.NoError(err)
@@ -206,6 +208,8 @@ func TestPITR(t *testing.T) {
 		a.NoError(err)
 		defer driver.Close(ctx)
 
+		connCfg := getMySQLConnectionConfig(strconv.Itoa(mysqlPort), database)
+
 		buf, err := doBackup(ctx, driver, database)
 		a.NoError(err)
 		t.Logf("backup content:\n%s", buf.String())
@@ -235,7 +239,7 @@ func TestPITR(t *testing.T) {
 		createPITRIssueTimestamp := time.Now().Unix()
 		mysqlDriver, ok := driver.(*pluginmysql.Driver)
 		a.Equal(true, ok)
-		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilIns)
+		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilInstance, connCfg)
 		binlogInfo := api.BinlogInfo{}
 		err = mysqlRestore.RestorePITR(ctx, bufio.NewScanner(buf), binlogInfo, database, createPITRIssueTimestamp)
 		a.NoError(err)
@@ -264,6 +268,8 @@ func TestPITR(t *testing.T) {
 		a.NoError(err)
 		defer driver.Close(ctx)
 
+		connCfg := getMySQLConnectionConfig(strconv.Itoa(mysqlPort), database)
+
 		buf, err := doBackup(ctx, driver, database)
 		a.NoError(err)
 		t.Logf("backup content:\n%s\n", buf.String())
@@ -285,7 +291,7 @@ func TestPITR(t *testing.T) {
 		t.Log("restore to pitr database")
 		mysqlDriver, ok := driver.(*pluginmysql.Driver)
 		a.Equal(true, ok)
-		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilIns)
+		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilInstance, connCfg)
 		binlogInfo := api.BinlogInfo{}
 		err = mysqlRestore.RestorePITR(ctx, bufio.NewScanner(buf), binlogInfo, database, createPITRIssueTimestamp)
 		a.NoError(err)

--- a/tests/mysql.go
+++ b/tests/mysql.go
@@ -8,10 +8,22 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/bytebase/bytebase/plugin/db"
 	dbplugin "github.com/bytebase/bytebase/plugin/db"
 
 	"go.uber.org/zap"
 )
+
+func getMySQLConnectionConfig(port string, database string) dbplugin.ConnectionConfig {
+	return db.ConnectionConfig{
+		Host:      "localhost",
+		Port:      port,
+		Username:  "root",
+		Password:  "",
+		Database:  database,
+		TLSConfig: dbplugin.TLSConfig{},
+	}
+}
 
 // connectTestMySQL connects to the test mysql instance.
 func connectTestMySQL(port int, database string) (*sql.DB, error) {
@@ -26,18 +38,12 @@ func getTestMySQLDriver(ctx context.Context, port, database string) (dbplugin.Dr
 	if err != nil {
 		return nil, err
 	}
+	connCfg := getMySQLConnectionConfig(port, database)
 	return dbplugin.Open(
 		ctx,
 		dbplugin.MySQL,
 		dbplugin.DriverConfig{Logger: logger},
-		dbplugin.ConnectionConfig{
-			Host:      "localhost",
-			Port:      port,
-			Username:  "root",
-			Password:  "",
-			Database:  database,
-			TLSConfig: dbplugin.TLSConfig{},
-		},
+		connCfg,
 		dbplugin.ConnectionContext{},
 	)
 }

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -22,7 +22,7 @@ func TestCheckEngineInnoDB(t *testing.T) {
 
 	t.Log("install mysqlbinlog binary")
 	tmpDir := t.TempDir()
-	mysqlbinlogIns, err := mysqlutil.Install(tmpDir)
+	mysqlutilInstance, err := mysqlutil.Install(tmpDir)
 	a.NoError(err)
 
 	t.Run("success", func(t *testing.T) {
@@ -46,9 +46,12 @@ func TestCheckEngineInnoDB(t *testing.T) {
 		driver, err := getTestMySQLDriver(ctx, strconv.Itoa(port), database)
 		a.NoError(err)
 		defer driver.Close(ctx)
+
+		connCfg := getMySQLConnectionConfig(strconv.Itoa(port), database)
+
 		mysqlDriver, ok := driver.(*pluginmysql.Driver)
 		a.Equal(true, ok)
-		mysqlRestore := restoremysql.New(mysqlDriver, mysqlbinlogIns)
+		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilInstance, connCfg)
 		err = mysqlRestore.CheckEngineInnoDB(ctx, database)
 		a.NoError(err)
 	})
@@ -77,9 +80,13 @@ func TestCheckEngineInnoDB(t *testing.T) {
 		driver, err := getTestMySQLDriver(ctx, strconv.Itoa(port), database)
 		a.NoError(err)
 		defer driver.Close(ctx)
+
+		connCfg := getMySQLConnectionConfig(strconv.Itoa(port), database)
+
 		mysqlDriver, ok := driver.(*pluginmysql.Driver)
 		a.Equal(true, ok)
-		mysqlRestore := restoremysql.New(mysqlDriver, mysqlbinlogIns)
+		mysqlRestore := restoremysql.New(mysqlDriver, mysqlutilInstance, connCfg)
+
 		err = mysqlRestore.CheckEngineInnoDB(ctx, database)
 		a.Error(err)
 	})


### PR DESCRIPTION
To complete MySQL PITR, we embed the MySQL client, we need to pass the connection config to the MySQL client so that it can connect to the MySQL server. If we do the same way when focusing on the PostgreSQL PITR, we can add a function signature likes `getConnectionConfig()` in `Driver` interface.
Completing BYT-521