### PR TITLE
fix(PITR): we only support MySQL version >= 8.0 for MySQL PITR

### DIFF
--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -452,15 +452,15 @@ func getSafeName(baseName, suffix string) string {
 	return fmt.Sprintf("%s_%s", baseName[0:len(baseName)-extraCharacters], suffix)
 }
 
-// checks the MySQL version is >=5.7
+// checks the MySQL version is >=8.0
 func checkVersionForPITR(version string) error {
 	v, err := semver.Parse(version)
 	if err != nil {
 		return err
 	}
-	v57 := semver.MustParse("5.7.0")
-	if v.LT(v57) {
-		return fmt.Errorf("version %s is not supported for PITR; the minimum supported version is 5.7", version)
+	v8 := semver.MustParse("8.0.0")
+	if v.LT(v8) {
+		return fmt.Errorf("version %s is not supported for PITR; the minimum supported version is 8.0", version)
 	}
 	return nil
 }

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -100,7 +100,7 @@ func TestCheckVersionForPITR(t *testing.T) {
 		},
 		{
 			version: "5.7.0",
-			err:     false,
+			err:     true,
 		},
 		{
 			version: "8.0.28",


### PR DESCRIPTION
As discussed offline, we are not yet sure whether MySQL 8.0 clients can support MySQL 5.7 servers.
Completing BYT-449