### PR TITLE
refactor: unify the logging interface using global logger

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,7 @@ run:
   timeout: 5m
   build-tags:
     - mysql
+    - release
 
 linters-settings:
   revive:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,6 @@ run:
   timeout: 5m
   build-tags:
     - mysql
-    - release
 
 linters-settings:
   revive:

--- a/bin/bb/cmd/dump.go
+++ b/bin/bb/cmd/dump.go
@@ -49,7 +49,7 @@ func newDumpCmd() *cobra.Command {
 // dumpDatabase exports the schema of a database instance.
 // When file isn't specified, the schema will be exported to stdout.
 func dumpDatabase(ctx context.Context, u *dburl.URL, out io.Writer, schemaOnly bool) error {
-	db, err := open(ctx, logger, u)
+	db, err := open(ctx, u)
 	if err != nil {
 		return err
 	}

--- a/bin/bb/cmd/migrate.go
+++ b/bin/bb/cmd/migrate.go
@@ -61,7 +61,7 @@ func newMigrateCmd() *cobra.Command {
 }
 
 func migrateDatabase(ctx context.Context, u *dburl.URL, description, issueID string, createDatabase bool, sqlReader io.Reader) error {
-	driver, err := open(ctx, logger, u)
+	driver, err := open(ctx, u)
 	if err != nil {
 		return err
 	}

--- a/bin/bb/cmd/restore.go
+++ b/bin/bb/cmd/restore.go
@@ -45,7 +45,7 @@ func restoreDatabase(ctx context.Context, u *dburl.URL, file string) error {
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 
-	db, err := open(ctx, logger, u)
+	db, err := open(ctx, u)
 	if err != nil {
 		return err
 	}

--- a/bin/bb/cmd/root.go
+++ b/bin/bb/cmd/root.go
@@ -2,10 +2,8 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 // NewRootCmd creates the root command.
@@ -25,18 +23,7 @@ func NewRootCmd() *cobra.Command {
 
 // Execute is the execute command for root command.
 func Execute() error {
-	logConfig := zap.NewProductionConfig()
-	// Always set encoding to "console" for now since we do not redirect to file.
-	logConfig.Encoding = "console"
-	// "console" encoding needs to use the corresponding development encoder config.
-	logConfig.EncoderConfig = zap.NewDevelopmentEncoderConfig()
-	logConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-
-	myLogger, err := logConfig.Build()
-	if err != nil {
-		panic(fmt.Errorf("failed to create logger. %w", err))
-	}
-	logger = myLogger
-
+	log.MustInitializeBB()
+	defer log.Sync()
 	return NewRootCmd().Execute()
 }

--- a/bin/bb/cmd/root.go
+++ b/bin/bb/cmd/root.go
@@ -22,7 +22,7 @@ func NewRootCmd() *cobra.Command {
 }
 
 // Execute is the execute command for root command.
-func Execute() error {
+func Execute() (err error) {
 	log.MustInitializeBB()
 	defer log.Sync()
 	return NewRootCmd().Execute()

--- a/bin/bb/cmd/root.go
+++ b/bin/bb/cmd/root.go
@@ -23,7 +23,7 @@ func NewRootCmd() *cobra.Command {
 
 // Execute is the execute command for root command.
 func Execute() (err error) {
-	log.MustInitializeBB()
+	log.Init()
 	defer log.Sync()
 	return NewRootCmd().Execute()
 }

--- a/bin/bb/cmd/root_test.go
+++ b/bin/bb/cmd/root_test.go
@@ -10,7 +10,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 const (
@@ -18,10 +17,6 @@ const (
 	PortTestMigrate
 	PortTestCreateDatabase
 )
-
-func init() {
-	logger = zap.NewNop()
-}
 
 func execute(t *testing.T, cmd *cobra.Command, args ...string) (string, error) {
 	t.Helper()

--- a/bin/bb/cmd/root_test.go
+++ b/bin/bb/cmd/root_test.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 const (
@@ -38,7 +39,8 @@ type testTable struct {
 }
 
 func tableTest(t *testing.T, tables []testTable) {
-	log.MustInitializeBB()
+	log.Init()
+	log.SetLevel(zap.DebugLevel)
 	t.Helper()
 	for _, tc := range tables {
 		actual, err := execute(t, NewRootCmd(), tc.args...)

--- a/bin/bb/cmd/root_test.go
+++ b/bin/bb/cmd/root_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bytebase/bytebase/common/log"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
@@ -37,6 +38,7 @@ type testTable struct {
 }
 
 func tableTest(t *testing.T, tables []testTable) {
+	log.MustInitializeBB()
 	t.Helper()
 	for _, tc := range tables {
 		actual, err := execute(t, NewRootCmd(), tc.args...)

--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -10,7 +10,6 @@ import (
 	// install pg driver.
 	_ "github.com/bytebase/bytebase/plugin/db/pg"
 	"github.com/xo/dburl"
-	"go.uber.org/zap"
 )
 
 func getDatabase(u *dburl.URL) string {
@@ -20,7 +19,7 @@ func getDatabase(u *dburl.URL) string {
 	return u.Path[1:]
 }
 
-func open(ctx context.Context, logger *zap.Logger, u *dburl.URL) (db.Driver, error) {
+func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 	var dbType db.Type
 	switch u.Driver {
 	case "mysql":
@@ -34,7 +33,7 @@ func open(ctx context.Context, logger *zap.Logger, u *dburl.URL) (db.Driver, err
 	}
 
 	passwd, _ := u.User.Password()
-	driver, err := db.Open(ctx, dbType, db.DriverConfig{Logger: logger}, db.ConnectionConfig{
+	driver, err := db.Open(ctx, dbType, db.DriverConfig{}, db.ConnectionConfig{
 		Host:     u.Hostname(),
 		Port:     u.Port(),
 		Username: u.User.Username(),

--- a/bin/bb/cmd/var.go
+++ b/bin/bb/cmd/var.go
@@ -1,12 +1,6 @@
 // Package cmd is the command surface of Bytebase bb tool provided by bytebase.com.
 package cmd
 
-import "go.uber.org/zap"
-
-var (
-	logger *zap.Logger
-)
-
 const dsnUsage = `Database connection string.
 
 DSN format:

--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/server"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	// Register clickhouse driver.
 	_ "github.com/bytebase/bytebase/plugin/db/clickhouse"
@@ -150,7 +151,10 @@ func checkDataDir() error {
 }
 
 func start() {
-	log.MustInitialize(flags.debug)
+	log.Init()
+	if flags.debug {
+		log.SetLevel(zap.DebugLevel)
+	}
 	defer log.Sync()
 
 	// check flags

--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -11,10 +11,9 @@ import (
 	"syscall"
 
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/server"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	// Register clickhouse driver.
 	_ "github.com/bytebase/bytebase/plugin/db/clickhouse"
@@ -150,34 +149,17 @@ func checkDataDir() error {
 	return nil
 }
 
-// GetLogger will return a logger.
-func GetLogger() (*zap.Logger, *zap.AtomicLevel, error) {
-	atom := zap.NewAtomicLevelAt(zap.InfoLevel)
-	if flags.debug {
-		atom.SetLevel(zap.DebugLevel)
-	}
-	logger := zap.New(zapcore.NewCore(
-		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
-		zapcore.Lock(os.Stdout),
-		atom,
-	))
-	return logger, &atom, nil
-}
-
 func start() {
-	logger, level, err := GetLogger()
-	if err != nil {
-		panic(fmt.Errorf("failed to create logger, %w", err))
-	}
-	defer logger.Sync()
+	log.MustInitialize(flags.debug)
+	defer log.Sync()
 
 	// check flags
 	if !common.HasPrefixes(flags.host, "http://", "https://") {
-		logger.Error(fmt.Sprintf("--host %s must start with http:// or https://", flags.host))
+		log.Error(fmt.Sprintf("--host %s must start with http:// or https://", flags.host))
 		return
 	}
 	if err := checkDataDir(); err != nil {
-		logger.Error(err.Error())
+		log.Error(err.Error())
 		return
 	}
 
@@ -193,14 +175,14 @@ func start() {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		sig := <-c
-		logger.Info(fmt.Sprintf("%s received.", sig.String()))
+		log.Info(fmt.Sprintf("%s received.", sig.String()))
 		if s != nil {
 			_ = s.Shutdown(ctx)
 		}
 		cancel()
 	}()
 
-	s, err = server.NewServer(ctx, activeProfile, logger, level)
+	s, err := server.NewServer(ctx, activeProfile)
 	if err != nil {
 		fmt.Printf("cannot new server, error: %v\n", err)
 		return
@@ -209,7 +191,7 @@ func start() {
 	// Execute program.
 	if err := s.Run(ctx); err != nil {
 		if err != http.ErrServerClosed {
-			logger.Error(err.Error())
+			log.Error(err.Error())
 			_ = s.Shutdown(ctx)
 			cancel()
 		}

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -16,39 +15,17 @@ var (
 	gLevel zap.AtomicLevel
 )
 
-// MustInitialize initializes the global logger for the bytebase server.
-func MustInitialize(debug bool) {
+// Init initializes the global console logger.
+func Init() {
 	if gl != nil {
 		return
 	}
 	gLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
-	if debug {
-		gLevel.SetLevel(zap.DebugLevel)
-	}
 	gl = zap.New(zapcore.NewCore(
 		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
 		zapcore.Lock(os.Stdout),
 		gLevel,
 	))
-}
-
-// MustInitializeBB initializes the global logger for the BB CLI.
-func MustInitializeBB() {
-	if gl != nil {
-		return
-	}
-	logConfig := zap.NewProductionConfig()
-	// Always set encoding to "console" for now since we do not redirect to file.
-	logConfig.Encoding = "console"
-	// "console" encoding needs to use the corresponding development encoder config.
-	logConfig.EncoderConfig = zap.NewDevelopmentEncoderConfig()
-	logConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-
-	logger, err := logConfig.Build()
-	if err != nil {
-		panic(fmt.Errorf("failed to create logger. %w", err))
-	}
-	gl = logger
 }
 
 // SetLevel wraps the zap Level's SetLevel method.

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -76,6 +76,6 @@ func Error(msg string, fields ...zap.Field) {
 }
 
 // Sync wraps the zap Logger's Sync method.
-func Sync() error {
-	return gl.Sync()
+func Sync() {
+	_ = gl.Sync()
 }

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -1,0 +1,81 @@
+package log
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	// `gl` is the global logger.
+	// Other packages should use public methods like Info/Error to do the logging.
+	// If special logging is required (like log to a separate file for some special operations), we need to add other loggers.
+	gl     *zap.Logger
+	gLevel zap.AtomicLevel
+)
+
+// MustInitialize initializes the global logger for the bytebase server.
+func MustInitialize(debug bool) {
+	gLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
+	if debug {
+		gLevel.SetLevel(zap.DebugLevel)
+	}
+	gl = zap.New(zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+		zapcore.Lock(os.Stdout),
+		gLevel,
+	))
+}
+
+// MustInitializeBB initializes the global logger for the BB CLI.
+func MustInitializeBB() {
+	logConfig := zap.NewProductionConfig()
+	// Always set encoding to "console" for now since we do not redirect to file.
+	logConfig.Encoding = "console"
+	// "console" encoding needs to use the corresponding development encoder config.
+	logConfig.EncoderConfig = zap.NewDevelopmentEncoderConfig()
+	logConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+
+	logger, err := logConfig.Build()
+	if err != nil {
+		panic(fmt.Errorf("failed to create logger. %w", err))
+	}
+	gl = logger
+}
+
+// SetLevel wraps the zap Level's SetLevel method.
+func SetLevel(level zapcore.Level) {
+	gLevel.SetLevel(level)
+}
+
+// EnabledLevel wraps the zap Level's Enabled method.
+func EnabledLevel(level zapcore.Level) bool {
+	return gLevel.Enabled(level)
+}
+
+// Debug wraps the zap Logger's Debug method.
+func Debug(msg string, fields ...zap.Field) {
+	gl.Debug(msg, fields...)
+}
+
+// Info wraps the zap Logger's Info method.
+func Info(msg string, fields ...zap.Field) {
+	gl.Info(msg, fields...)
+}
+
+// Warn wraps the zap Logger's Warn method.
+func Warn(msg string, fields ...zap.Field) {
+	gl.Warn(msg, fields...)
+}
+
+// Error wraps the zap Logger's Error method.
+func Error(msg string, fields ...zap.Field) {
+	gl.Error(msg, fields...)
+}
+
+// Sync wraps the zap Logger's Sync method.
+func Sync() error {
+	return gl.Sync()
+}

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -18,6 +18,9 @@ var (
 
 // MustInitialize initializes the global logger for the bytebase server.
 func MustInitialize(debug bool) {
+	if gl != nil {
+		return
+	}
 	gLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
 	if debug {
 		gLevel.SetLevel(zap.DebugLevel)
@@ -31,6 +34,9 @@ func MustInitialize(debug bool) {
 
 // MustInitializeBB initializes the global logger for the BB CLI.
 func MustInitializeBB() {
+	if gl != nil {
+		return
+	}
 	logConfig := zap.NewProductionConfig()
 	// Always set encoding to "console" for now since we do not redirect to file.
 	logConfig.Encoding = "console"

--- a/enterprise/config/config.go
+++ b/enterprise/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
@@ -40,15 +41,15 @@ const (
 )
 
 // NewConfig will create a new enterprise config instance.
-func NewConfig(l *zap.Logger, dataDir string, mode common.ReleaseMode) (*Config, error) {
-	l.Info("get project env", zap.String("env", string(mode)))
+func NewConfig(dataDir string, mode common.ReleaseMode) (*Config, error) {
+	log.Info("get project env", zap.String("env", string(mode)))
 
 	filename := fmt.Sprintf("keys/%s.pub.pem", mode)
 	licensePubKey, err := fs.ReadFile(keysFS, fmt.Sprintf("keys/%s.pub.pem", mode))
 	if err != nil {
 		return nil, fmt.Errorf("cannot read license public key for env %s", mode)
 	}
-	l.Info("load public pem", zap.String("file", filename))
+	log.Info("load public pem", zap.String("file", filename))
 
 	storefile := "license"
 	if mode != common.ReleaseModeProd {

--- a/enterprise/service/license.go
+++ b/enterprise/service/license.go
@@ -9,12 +9,10 @@ import (
 	enterpriseAPI "github.com/bytebase/bytebase/enterprise/api"
 	"github.com/bytebase/bytebase/enterprise/config"
 	"github.com/golang-jwt/jwt/v4"
-	"go.uber.org/zap"
 )
 
 // LicenseService is the service for enterprise license.
 type LicenseService struct {
-	l      *zap.Logger
 	config *config.Config
 }
 
@@ -28,15 +26,14 @@ type Claims struct {
 }
 
 // NewLicenseService will create a new enterprise license service.
-func NewLicenseService(l *zap.Logger, dataDir string, mode common.ReleaseMode) (*LicenseService, error) {
-	config, err := config.NewConfig(l, dataDir, mode)
+func NewLicenseService(dataDir string, mode common.ReleaseMode) (*LicenseService, error) {
+	config, err := config.NewConfig(dataDir, mode)
 	if err != nil {
 		return nil, err
 	}
 
 	return &LicenseService{
 		config: config,
-		l:      l,
 	}, nil
 }
 

--- a/metric/collector/database_count.go
+++ b/metric/collector/database_count.go
@@ -7,21 +7,18 @@ import (
 	metricAPI "github.com/bytebase/bytebase/metric"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/store"
-	"go.uber.org/zap"
 )
 
 var _ metric.Collector = (*databaseCountCollector)(nil)
 
 // databaseCountCollector is the metric data collector for database.
 type databaseCountCollector struct {
-	l     *zap.Logger
 	store *store.Store
 }
 
 // NewDatabaseCountCollector creates a new instance of databaseCountCollector
-func NewDatabaseCountCollector(l *zap.Logger, store *store.Store) metric.Collector {
+func NewDatabaseCountCollector(store *store.Store) metric.Collector {
 	return &databaseCountCollector{
-		l:     l,
 		store: store,
 	}
 }

--- a/metric/collector/instance_count.go
+++ b/metric/collector/instance_count.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	metricAPI "github.com/bytebase/bytebase/metric"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/store"
@@ -14,14 +15,12 @@ var _ metric.Collector = (*instanceCountCollector)(nil)
 
 // instanceCountCollector is the metric data collector for instance.
 type instanceCountCollector struct {
-	l     *zap.Logger
 	store *store.Store
 }
 
 // NewInstanceCountCollector creates a new instance of instanceCollector
-func NewInstanceCountCollector(l *zap.Logger, store *store.Store) metric.Collector {
+func NewInstanceCountCollector(store *store.Store) metric.Collector {
 	return &instanceCountCollector{
-		l:     l,
 		store: store,
 	}
 }
@@ -38,7 +37,7 @@ func (c *instanceCountCollector) Collect(ctx context.Context) ([]*metric.Metric,
 	for _, instanceCountMetric := range instanceCountMetricList {
 		env, err := c.store.GetEnvironmentByID(ctx, instanceCountMetric.EnvironmentID)
 		if err != nil {
-			c.l.Debug("failed to get environment by id", zap.Int("id", instanceCountMetric.EnvironmentID))
+			log.Debug("failed to get environment by id", zap.Int("id", instanceCountMetric.EnvironmentID))
 			continue
 		}
 

--- a/metric/collector/issue_count.go
+++ b/metric/collector/issue_count.go
@@ -6,21 +6,18 @@ import (
 	metricAPI "github.com/bytebase/bytebase/metric"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/store"
-	"go.uber.org/zap"
 )
 
 var _ metric.Collector = (*issueCountCollector)(nil)
 
 // issueCountCollector is the metric data collector for issue.
 type issueCountCollector struct {
-	l     *zap.Logger
 	store *store.Store
 }
 
 // NewIssueCountCollector creates a new instance of issueCollector
-func NewIssueCountCollector(l *zap.Logger, store *store.Store) metric.Collector {
+func NewIssueCountCollector(store *store.Store) metric.Collector {
 	return &issueCountCollector{
-		l:     l,
 		store: store,
 	}
 }

--- a/metric/collector/policy_count.go
+++ b/metric/collector/policy_count.go
@@ -8,21 +8,18 @@ import (
 	metricAPI "github.com/bytebase/bytebase/metric"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/store"
-	"go.uber.org/zap"
 )
 
 var _ metric.Collector = (*policyCountCollector)(nil)
 
 // policyCountCollector is the metric data collector for policy.
 type policyCountCollector struct {
-	l     *zap.Logger
 	store *store.Store
 }
 
 // NewPolicyCountCollector creates a new instance of policyCollector
-func NewPolicyCountCollector(l *zap.Logger, store *store.Store) metric.Collector {
+func NewPolicyCountCollector(store *store.Store) metric.Collector {
 	return &policyCountCollector{
-		l:     l,
 		store: store,
 	}
 }

--- a/metric/collector/project_count.go
+++ b/metric/collector/project_count.go
@@ -6,21 +6,18 @@ import (
 	metricAPI "github.com/bytebase/bytebase/metric"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/store"
-	"go.uber.org/zap"
 )
 
 var _ metric.Collector = (*projectCountCollector)(nil)
 
 // projectCountCollector is the metric data collector for project.
 type projectCountCollector struct {
-	l     *zap.Logger
 	store *store.Store
 }
 
 // NewProjectCountCollector creates a new instance of projectCollector
-func NewProjectCountCollector(l *zap.Logger, store *store.Store) metric.Collector {
+func NewProjectCountCollector(store *store.Store) metric.Collector {
 	return &projectCountCollector{
-		l:     l,
 		store: store,
 	}
 }

--- a/metric/collector/task_count.go
+++ b/metric/collector/task_count.go
@@ -6,21 +6,18 @@ import (
 	metricAPI "github.com/bytebase/bytebase/metric"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/store"
-	"go.uber.org/zap"
 )
 
 var _ metric.Collector = (*taskCountCollector)(nil)
 
 // taskCountCollector is the metric data collector for task.
 type taskCountCollector struct {
-	l     *zap.Logger
 	store *store.Store
 }
 
 // NewTaskCountCollector creates a new instance of taskCollector.
-func NewTaskCountCollector(l *zap.Logger, store *store.Store) metric.Collector {
+func NewTaskCountCollector(store *store.Store) metric.Collector {
 	return &taskCountCollector{
-		l:     l,
 		store: store,
 	}
 }

--- a/plugin/advisor/advisor.go
+++ b/plugin/advisor/advisor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/catalog"
 	"github.com/bytebase/bytebase/plugin/db"
-	"go.uber.org/zap"
 )
 
 // Status is the advisor result status.
@@ -111,7 +110,6 @@ type Advice struct {
 
 // Context is the context for advisor.
 type Context struct {
-	Logger    *zap.Logger
 	Charset   string
 	Collation string
 

--- a/plugin/advisor/mysql/advisor_naming_index_convention.go
+++ b/plugin/advisor/mysql/advisor_naming_index_convention.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/advisor"
 	"github.com/bytebase/bytebase/plugin/catalog"
 	"github.com/bytebase/bytebase/plugin/db"
@@ -49,7 +50,6 @@ func (check *NamingIndexConventionAdvisor) Check(ctx advisor.Context, statement 
 		format:       format,
 		templateList: templateList,
 		catalog:      ctx.Catalog,
-		logger:       ctx.Logger,
 	}
 	for _, stmtNode := range root {
 		(stmtNode).Accept(checker)
@@ -73,7 +73,6 @@ type namingIndexConventionChecker struct {
 	format       string
 	templateList []string
 	catalog      catalog.Service
-	logger       *zap.Logger
 }
 
 // Enter implements the ast.Visitor interface
@@ -148,7 +147,7 @@ func (checker *namingIndexConventionChecker) getMetaDataList(in ast.Node) []*ind
 					IndexName: spec.FromKey.String(),
 				})
 				if err != nil {
-					checker.logger.Error(
+					log.Error(
 						"Cannot find index in table",
 						zap.String("table_name", node.Table.Name.String()),
 						zap.String("index_name", spec.FromKey.String()),

--- a/plugin/advisor/mysql/advisor_naming_unique_key_convention.go
+++ b/plugin/advisor/mysql/advisor_naming_unique_key_convention.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/advisor"
 	"github.com/bytebase/bytebase/plugin/catalog"
 	"github.com/bytebase/bytebase/plugin/db"
@@ -48,7 +49,6 @@ func (check *NamingUKConventionAdvisor) Check(ctx advisor.Context, statement str
 		format:       format,
 		templateList: templateList,
 		catalog:      ctx.Catalog,
-		logger:       ctx.Logger,
 	}
 	for _, stmtNode := range root {
 		(stmtNode).Accept(checker)
@@ -71,7 +71,6 @@ type namingUKConventionChecker struct {
 	format       string
 	templateList []string
 	catalog      catalog.Service
-	logger       *zap.Logger
 }
 
 // Enter implements the ast.Visitor interface
@@ -141,7 +140,7 @@ func (checker *namingUKConventionChecker) getMetaDataList(in ast.Node) []*indexM
 					IndexName: spec.FromKey.String(),
 				})
 				if err != nil {
-					checker.logger.Error(
+					log.Error(
 						"Cannot find index in table",
 						zap.String("table_name", node.Table.Name.String()),
 						zap.String("index_name", spec.FromKey.String()),

--- a/plugin/advisor/mysql/advisor_table_require_pk.go
+++ b/plugin/advisor/mysql/advisor_table_require_pk.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/advisor"
 	"github.com/bytebase/bytebase/plugin/catalog"
 	"github.com/bytebase/bytebase/plugin/db"
@@ -45,7 +46,6 @@ func (adv *TableRequirePKAdvisor) Check(ctx advisor.Context, statement string) (
 		level:   level,
 		tables:  make(tablePK),
 		catalog: ctx.Catalog,
-		logger:  ctx.Logger,
 	}
 
 	for _, stmtNode := range root {
@@ -60,7 +60,6 @@ type tableRequirePKChecker struct {
 	level      advisor.Status
 	tables     tablePK
 	catalog    catalog.Service
-	logger     *zap.Logger
 }
 
 // Enter implements the ast.Visitor interface
@@ -166,7 +165,7 @@ func (v *tableRequirePKChecker) dropColumn(table string, column string) {
 			IndexName: primaryKeyName,
 		})
 		if err != nil {
-			v.logger.Error(
+			log.Error(
 				"Cannot find primary key in table",
 				zap.String("table_name", table),
 				zap.Error(err),

--- a/plugin/advisor/mysql/utils_for_test.go
+++ b/plugin/advisor/mysql/utils_for_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bytebase/bytebase/plugin/catalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 type MockCatalogService struct{}
@@ -60,9 +59,7 @@ func runSchemaReviewRuleTests(
 	rule *api.SchemaReviewRule,
 	catalog catalog.Service,
 ) {
-	logger, _ := zap.NewDevelopmentConfig().Build()
 	ctx := advisor.Context{
-		Logger:    logger,
 		Charset:   "",
 		Collation: "",
 		Rule:      rule,

--- a/plugin/catalog/catalog.go
+++ b/plugin/catalog/catalog.go
@@ -6,13 +6,10 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/store"
-	"go.uber.org/zap"
 )
 
 // Catalog is the database catalog.
 type Catalog struct {
-	logger *zap.Logger
-
 	// catalog special fields.
 	databaseID *int
 	store      *store.Store
@@ -39,9 +36,8 @@ type IndexFind struct {
 }
 
 // NewService creates a new instance of Catalog
-func NewService(logger *zap.Logger, databaseID *int, store *store.Store) *Catalog {
+func NewService(databaseID *int, store *store.Store) *Catalog {
 	return &Catalog{
-		logger:     logger,
 		databaseID: databaseID,
 		store:      store,
 	}

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/bytebase/bytebase/plugin/vcs"
-	"go.uber.org/zap"
 )
 
 // Type is the type of a database.
@@ -138,7 +137,6 @@ var (
 
 // DriverConfig is the driver configuration.
 type DriverConfig struct {
-	Logger *zap.Logger
 }
 
 type driverFunc func(DriverConfig) Driver

--- a/plugin/metric/segment/reporter.go
+++ b/plugin/metric/segment/reporter.go
@@ -6,14 +6,12 @@ import (
 	"github.com/bytebase/bytebase/plugin/metric"
 
 	"github.com/segmentio/analytics-go"
-	"go.uber.org/zap"
 )
 
 var _ metric.Reporter = (*reporter)(nil)
 
 // reporter is the metrics collector https://segment.com/.
 type reporter struct {
-	l          *zap.Logger
 	identifier string
 	client     analytics.Client
 }
@@ -24,11 +22,10 @@ const (
 )
 
 // NewReporter creates a new instance of segment
-func NewReporter(l *zap.Logger, key string, identifier string) metric.Reporter {
+func NewReporter(key string, identifier string) metric.Reporter {
 	client := analytics.New(key)
 
 	return &reporter{
-		l:          l,
 		identifier: identifier,
 		client:     client,
 	}

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -124,7 +124,6 @@ func (r *Restore) parseBinlogEventTimestamp(ctx context.Context, binlogInfo api.
 	return timestamp, nil
 }
 
-// nolint
 func parseBinlogEventTimestampImpl(output string) (int64, error) {
 	lines := strings.Split(output, "\n")
 	// The mysqlbinlog output will contains a line starting with "#220421 14:49:26 server id 1",

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -124,6 +124,7 @@ func (r *Restore) parseBinlogEventTimestamp(ctx context.Context, binlogInfo api.
 	return timestamp, nil
 }
 
+// nolint
 func parseBinlogEventTimestampImpl(output string) (int64, error) {
 	lines := strings.Split(output, "\n")
 	// The mysqlbinlog output will contains a line starting with "#220421 14:49:26 server id 1",

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -155,7 +155,7 @@ DELIMITER ;
 # End of log file
 /*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
 /*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
-			timestamp: time.Date(2022, 4, 21, 14, 49, 26, 0, time.UTC).Unix(),
+			timestamp: time.Date(2022, 4, 21, 14, 49, 26, 0, time.Local).Unix(),
 			err:       false,
 		},
 		// Edge case: invalid mysqlbinlog option

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -2,7 +2,6 @@ package mysql
 
 import (
 	"testing"
-	"time"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/stretchr/testify/require"
@@ -118,57 +117,6 @@ func TestCheckVersionForPITR(t *testing.T) {
 
 	for _, test := range tests {
 		err := checkVersionForPITR(test.version)
-		if test.err {
-			a.Error(err)
-		} else {
-			a.NoError(err)
-		}
-	}
-}
-
-func TestParseBinlogEventTimestampImpl(t *testing.T) {
-	a := require.New(t)
-	tests := []struct {
-		binlogText string
-		timestamp  int64
-		err        bool
-	}{
-		// This is a real one from mysqlbinlog output.
-		{
-			binlogText: `# The proper term is pseudo_replica_mode, but we use this compatibility alias
-# to make the statement usable on server versions 8.0.24 and older.
-/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
-/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
-DELIMITER /*!*/;
-# at 24500
-#220421 14:49:26 server id 1  end_log_pos 0 CRC32 0xbb5866d6 	Start: binlog v 4, server v 8.0.28 created 220421 14:49:26
-BINLOG '
-dv5gYg8BAAAAegAAAAAAAAAAAAQAOC4wLjI4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAAAAAAAAAAAAAAAAAAAAEwANAAgAAAAABAAEAAAAYgAEGggAAAAICAgCAAAACgoKKioAEjQA
-CigAAdZmWLs=
-'/*!*/;
-# at 24500
-#220425 17:32:13 server id 1  end_log_pos 24604 CRC32 0x6a465388 	Table_map: ` + "`bytebase`.`migration_history`" + ` mapped to number 172
-WARNING: The range of printed events ends with a row event or a table map event that does not have the STMT_END_F flag set. This might be because the last statement was not fully written to the log, or because you are using a --stop-position or --stop-datetime that refers to an event in the middle of a statement. The event(s) from the partial statement have not been written to output.
-SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
-DELIMITER ;
-# End of log file
-/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
-/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
-			timestamp: time.Date(2022, 4, 21, 14, 49, 26, 0, time.Local).Unix(),
-			err:       false,
-		},
-		// Edge case: invalid mysqlbinlog option
-		{
-			binlogText: "mysqlbinlog: [ERROR] mysqlbinlog: unknown option '-n'.",
-			timestamp:  0,
-			err:        true,
-		},
-	}
-
-	for _, test := range tests {
-		timestamp, err := parseBinlogEventTimestampImpl(test.binlogText)
-		a.Equal(test.timestamp, timestamp)
 		if test.err {
 			a.Error(err)
 		} else {

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/stretchr/testify/require"
@@ -117,6 +118,57 @@ func TestCheckVersionForPITR(t *testing.T) {
 
 	for _, test := range tests {
 		err := checkVersionForPITR(test.version)
+		if test.err {
+			a.Error(err)
+		} else {
+			a.NoError(err)
+		}
+	}
+}
+
+func TestParseBinlogEventTimestampImpl(t *testing.T) {
+	a := require.New(t)
+	tests := []struct {
+		binlogText string
+		timestamp  int64
+		err        bool
+	}{
+		// This is a real one from mysqlbinlog output.
+		{
+			binlogText: `# The proper term is pseudo_replica_mode, but we use this compatibility alias
+# to make the statement usable on server versions 8.0.24 and older.
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
+/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
+DELIMITER /*!*/;
+# at 24500
+#220421 14:49:26 server id 1  end_log_pos 0 CRC32 0xbb5866d6 	Start: binlog v 4, server v 8.0.28 created 220421 14:49:26
+BINLOG '
+dv5gYg8BAAAAegAAAAAAAAAAAAQAOC4wLjI4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAEwANAAgAAAAABAAEAAAAYgAEGggAAAAICAgCAAAACgoKKioAEjQA
+CigAAdZmWLs=
+'/*!*/;
+# at 24500
+#220425 17:32:13 server id 1  end_log_pos 24604 CRC32 0x6a465388 	Table_map: ` + "`bytebase`.`migration_history`" + ` mapped to number 172
+WARNING: The range of printed events ends with a row event or a table map event that does not have the STMT_END_F flag set. This might be because the last statement was not fully written to the log, or because you are using a --stop-position or --stop-datetime that refers to an event in the middle of a statement. The event(s) from the partial statement have not been written to output.
+SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
+DELIMITER ;
+# End of log file
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
+			timestamp: time.Date(2022, 4, 21, 14, 49, 26, 0, time.Local).Unix(),
+			err:       false,
+		},
+		// Edge case: invalid mysqlbinlog option
+		{
+			binlogText: "mysqlbinlog: [ERROR] mysqlbinlog: unknown option '-n'.",
+			timestamp:  0,
+			err:        true,
+		},
+	}
+
+	for _, test := range tests {
+		timestamp, err := parseBinlogEventTimestampImpl(test.binlogText)
+		a.Equal(test.timestamp, timestamp)
 		if test.err {
 			a.Error(err)
 		} else {

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/vcs"
@@ -29,7 +28,6 @@ var _ vcs.Provider = (*Provider)(nil)
 
 // Provider is a GitHub.com VCS provider.
 type Provider struct {
-	l      *zap.Logger
 	client *http.Client
 }
 
@@ -38,7 +36,6 @@ func newProvider(config vcs.ProviderConfig) vcs.Provider {
 		config.Client = &http.Client{}
 	}
 	return &Provider{
-		l:      config.Logger,
 		client: config.Client,
 	}
 }

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/vcs"
@@ -196,7 +195,6 @@ func init() {
 
 // Provider is a GitLab self host VCS provider.
 type Provider struct {
-	l      *zap.Logger
 	client *http.Client
 }
 
@@ -205,7 +203,6 @@ func newProvider(config vcs.ProviderConfig) vcs.Provider {
 		config.Client = &http.Client{}
 	}
 	return &Provider{
-		l:      config.Logger,
 		client: config.Client,
 	}
 }

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"github.com/bytebase/bytebase/common"
 )
 
@@ -232,7 +230,6 @@ var (
 
 // ProviderConfig is the provider configuration.
 type ProviderConfig struct {
-	Logger *zap.Logger
 	Client *http.Client
 }
 

--- a/server/acl.go
+++ b/server/acl.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/casbin/casbin/v2"
-	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
@@ -23,7 +22,7 @@ func getRoleContextKey() string {
 	return roleContextKey
 }
 
-func aclMiddleware(l *zap.Logger, s *Server, ce *casbin.Enforcer, next echo.HandlerFunc, readonly bool) echo.HandlerFunc {
+func aclMiddleware(s *Server, ce *casbin.Enforcer, next echo.HandlerFunc, readonly bool) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		ctx := c.Request().Context()
 		// Skips auth, actuator, plan

--- a/server/activity_manager.go
+++ b/server/activity_manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/webhook"
 	"github.com/bytebase/bytebase/store"
 
@@ -86,7 +87,7 @@ func (m *ActivityManager) CreateActivity(ctx context.Context, create *api.Activi
 			webhookCtx.CreatedTs = time.Now().Unix()
 			if err := webhook.Post(hook.Type, webhookCtx); err != nil {
 				// The external webhook endpoint might be invalid which is out of our code control, so we just emit a warning
-				m.s.l.Warn("Failed to post webhook event after changing the issue status",
+				log.Warn("Failed to post webhook event after changing the issue status",
 					zap.String("webhook_type", hook.Type),
 					zap.String("webhook_name", hook.Name),
 					zap.String("issue_name", meta.issue.Name),
@@ -123,7 +124,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 	case api.ActivityIssueFieldUpdate:
 		update := new(api.ActivityIssueFieldUpdatePayload)
 		if err := json.Unmarshal([]byte(activity.Payload), update); err != nil {
-			m.s.l.Warn("Failed to post webhook event after changing the issue field, failed to unmarshal payload",
+			log.Warn("Failed to post webhook event after changing the issue field, failed to unmarshal payload",
 				zap.String("issue_name", meta.issue.Name),
 				zap.Error(err))
 			return webhookCtx, err
@@ -135,7 +136,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 				if update.OldValue != "" {
 					oldID, err := strconv.Atoi(update.OldValue)
 					if err != nil {
-						m.s.l.Warn("Failed to post webhook event after changing the issue assignee, old assignee id is not number",
+						log.Warn("Failed to post webhook event after changing the issue assignee, old assignee id is not number",
 							zap.String("issue_name", meta.issue.Name),
 							zap.String("old_assignee_id", update.OldValue),
 							zap.Error(err))
@@ -143,7 +144,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 					}
 					oldAssignee, err = m.s.store.GetPrincipalByID(ctx, oldID)
 					if err != nil {
-						m.s.l.Warn("Failed to post webhook event after changing the issue assignee, failed to find old assignee",
+						log.Warn("Failed to post webhook event after changing the issue assignee, failed to find old assignee",
 							zap.String("issue_name", meta.issue.Name),
 							zap.String("old_assignee_id", update.OldValue),
 							zap.Error(err))
@@ -151,7 +152,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 					}
 					if oldAssignee == nil {
 						err := fmt.Errorf("failed to post webhook event after changing the issue assignee, old assignee not found for ID %v", oldID)
-						m.s.l.Warn(err.Error(),
+						log.Warn(err.Error(),
 							zap.String("issue_name", meta.issue.Name),
 							zap.String("old_assignee_id", update.OldValue),
 							zap.Error(err))
@@ -162,7 +163,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 				if update.NewValue != "" {
 					newID, err := strconv.Atoi(update.NewValue)
 					if err != nil {
-						m.s.l.Warn("Failed to post webhook event after changing the issue assignee, new assignee id is not number",
+						log.Warn("Failed to post webhook event after changing the issue assignee, new assignee id is not number",
 							zap.String("issue_name", meta.issue.Name),
 							zap.String("new_assignee_id", update.NewValue),
 							zap.Error(err))
@@ -170,7 +171,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 					}
 					newAssignee, err = m.s.store.GetPrincipalByID(ctx, newID)
 					if err != nil {
-						m.s.l.Warn("Failed to post webhook event after changing the issue assignee, failed to find new assignee",
+						log.Warn("Failed to post webhook event after changing the issue assignee, failed to find new assignee",
 							zap.String("issue_name", meta.issue.Name),
 							zap.String("new_assignee_id", update.NewValue),
 							zap.Error(err))
@@ -178,7 +179,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 					}
 					if newAssignee == nil {
 						err := fmt.Errorf("failed to post webhook event after changing the issue assignee, new assignee not found for ID %v", newID)
-						m.s.l.Warn(err.Error(),
+						log.Warn(err.Error(),
 							zap.String("issue_name", meta.issue.Name),
 							zap.String("new_assignee_id", update.NewValue),
 							zap.Error(err))
@@ -204,7 +205,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 	case api.ActivityPipelineTaskStatusUpdate:
 		update := &api.ActivityPipelineTaskStatusUpdatePayload{}
 		if err := json.Unmarshal([]byte(activity.Payload), update); err != nil {
-			m.s.l.Warn("Failed to post webhook event after changing the issue task status, failed to unmarshal payload",
+			log.Warn("Failed to post webhook event after changing the issue task status, failed to unmarshal payload",
 				zap.String("issue_name", meta.issue.Name),
 				zap.Error(err))
 			return webhookCtx, err
@@ -212,7 +213,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 
 		task, err := m.s.store.GetTaskByID(ctx, update.TaskID)
 		if err != nil {
-			m.s.l.Warn("Failed to post webhook event after changing the issue task status, failed to find task",
+			log.Warn("Failed to post webhook event after changing the issue task status, failed to find task",
 				zap.String("issue_name", meta.issue.Name),
 				zap.Int("task_id", update.TaskID),
 				zap.Error(err))
@@ -220,7 +221,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 		}
 		if task == nil {
 			err := fmt.Errorf("failed to post webhook event after changing the issue task status, task not found for ID %v", update.TaskID)
-			m.s.l.Warn(err.Error(),
+			log.Warn(err.Error(),
 				zap.String("issue_name", meta.issue.Name),
 				zap.Int("task_id", update.TaskID),
 				zap.Error(err))

--- a/server/anomaly_scanner.go
+++ b/server/anomaly_scanner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"go.uber.org/zap"
 )
@@ -20,16 +21,15 @@ const (
 )
 
 // NewAnomalyScanner creates a anomaly scanner
-func NewAnomalyScanner(logger *zap.Logger, server *Server) *AnomalyScanner {
+func NewAnomalyScanner(server *Server) *AnomalyScanner {
 	return &AnomalyScanner{
-		l:      logger,
+
 		server: server,
 	}
 }
 
 // AnomalyScanner is the anomaly scanner.
 type AnomalyScanner struct {
-	l      *zap.Logger
 	server *Server
 }
 
@@ -38,13 +38,13 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 	ticker := time.NewTicker(anomalyScanInterval)
 	defer ticker.Stop()
 	defer wg.Done()
-	s.l.Debug(fmt.Sprintf("Anomaly scanner started and will run every %v", anomalyScanInterval))
+	log.Debug(fmt.Sprintf("Anomaly scanner started and will run every %v", anomalyScanInterval))
 	runningTasks := make(map[int]bool)
 	mu := sync.RWMutex{}
 	for {
 		select {
 		case <-ticker.C:
-			s.l.Debug("New anomaly scanner round started...")
+			log.Debug("New anomaly scanner round started...")
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
@@ -52,7 +52,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 						if !ok {
 							err = fmt.Errorf("%v", r)
 						}
-						s.l.Error("Anomaly scanner PANIC RECOVER", zap.Error(err))
+						log.Error("Anomaly scanner PANIC RECOVER", zap.Error(err))
 					}
 				}()
 
@@ -60,7 +60,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 				envList, err := s.server.store.FindEnvironment(ctx, &api.EnvironmentFind{})
 				if err != nil {
-					s.l.Error("Failed to retrieve instance list", zap.Error(err))
+					log.Error("Failed to retrieve instance list", zap.Error(err))
 					return
 				}
 
@@ -68,7 +68,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 				for _, env := range envList {
 					policy, err := s.server.store.GetBackupPlanPolicyByEnvID(ctx, env.ID)
 					if err != nil {
-						s.l.Error("Failed to retrieve backup policy",
+						log.Error("Failed to retrieve backup policy",
 							zap.String("environment", env.Name),
 							zap.Error(err))
 						return
@@ -82,7 +82,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 				}
 				instanceList, err := s.server.store.FindInstance(ctx, instanceFind)
 				if err != nil {
-					s.l.Error("Failed to retrieve instance list", zap.Error(err))
+					log.Error("Failed to retrieve instance list", zap.Error(err))
 					return
 				}
 
@@ -112,7 +112,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 					// Do NOT use go-routine otherwise would cause "database locked" in underlying SQLite
 					func(instance *api.Instance) {
-						s.l.Debug("Scan instance anomaly", zap.String("instance", instance.Name))
+						log.Debug("Scan instance anomaly", zap.String("instance", instance.Name))
 						defer func() {
 							mu.Lock()
 							delete(runningTasks, instance.ID)
@@ -126,7 +126,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 						}
 						dbList, err := s.server.store.FindDatabase(ctx, databaseFind)
 						if err != nil {
-							s.l.Error("Failed to retrieve database list",
+							log.Error("Failed to retrieve database list",
 								zap.String("instance", instance.Name),
 								zap.Error(err))
 							return
@@ -148,7 +148,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api.Instance) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.l)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "")
 
 	// Check connection
 	if err != nil {
@@ -157,7 +157,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 		}
 		payload, err := json.Marshal(anomalyPayload)
 		if err != nil {
-			s.l.Error("Failed to marshal anomaly payload",
+			log.Error("Failed to marshal anomaly payload",
 				zap.String("instance", instance.Name),
 				zap.String("type", string(api.AnomalyInstanceConnection)),
 				zap.Error(err))
@@ -168,7 +168,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 				Type:       api.AnomalyInstanceConnection,
 				Payload:    string(payload),
 			}); err != nil {
-				s.l.Error("Failed to create anomaly",
+				log.Error("Failed to create anomaly",
 					zap.String("instance", instance.Name),
 					zap.String("type", string(api.AnomalyInstanceConnection)),
 					zap.Error(err))
@@ -183,7 +183,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 		Type:       api.AnomalyInstanceConnection,
 	})
 	if err != nil && common.ErrorCode(err) != common.NotFound {
-		s.l.Error("Failed to close anomaly",
+		log.Error("Failed to close anomaly",
 			zap.String("instance", instance.Name),
 			zap.String("type", string(api.AnomalyInstanceConnection)),
 			zap.Error(err))
@@ -193,7 +193,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 	{
 		setup, err := driver.NeedsSetupMigration(ctx)
 		if err != nil {
-			s.l.Error("Failed to check migration schema",
+			log.Error("Failed to check migration schema",
 				zap.String("instance", instance.Name),
 				zap.String("type", string(api.AnomalyInstanceMigrationSchema)),
 				zap.Error(err))
@@ -204,7 +204,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 					InstanceID: instance.ID,
 					Type:       api.AnomalyInstanceMigrationSchema,
 				}); err != nil {
-					s.l.Error("Failed to create anomaly",
+					log.Error("Failed to create anomaly",
 						zap.String("instance", instance.Name),
 						zap.String("type", string(api.AnomalyInstanceMigrationSchema)),
 						zap.Error(err))
@@ -215,7 +215,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 					Type:       api.AnomalyInstanceMigrationSchema,
 				})
 				if err != nil && common.ErrorCode(err) != common.NotFound {
-					s.l.Error("Failed to close anomaly",
+					log.Error("Failed to close anomaly",
 						zap.String("instance", instance.Name),
 						zap.String("type", string(api.AnomalyInstanceMigrationSchema)),
 						zap.Error(err))
@@ -226,7 +226,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 }
 
 func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api.Instance, database *api.Database) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, database.Name, s.l)
+	driver, err := getAdminDatabaseDriver(ctx, instance, database.Name)
 
 	// Check connection
 	if err != nil {
@@ -235,7 +235,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 		}
 		payload, err := json.Marshal(anomalyPayload)
 		if err != nil {
-			s.l.Error("Failed to marshal anomaly payload",
+			log.Error("Failed to marshal anomaly payload",
 				zap.String("instance", instance.Name),
 				zap.String("database", database.Name),
 				zap.String("type", string(api.AnomalyDatabaseConnection)),
@@ -248,7 +248,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 				Type:       api.AnomalyDatabaseConnection,
 				Payload:    string(payload),
 			}); err != nil {
-				s.l.Error("Failed to create anomaly",
+				log.Error("Failed to create anomaly",
 					zap.String("instance", instance.Name),
 					zap.String("database", database.Name),
 					zap.String("type", string(api.AnomalyDatabaseConnection)),
@@ -263,7 +263,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 		Type:       api.AnomalyDatabaseConnection,
 	})
 	if err != nil && common.ErrorCode(err) != common.NotFound {
-		s.l.Error("Failed to close anomaly",
+		log.Error("Failed to close anomaly",
 			zap.String("instance", instance.Name),
 			zap.String("database", database.Name),
 			zap.String("type", string(api.AnomalyDatabaseConnection)),
@@ -274,7 +274,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 	if s.server.feature(api.FeatureSchemaDrift) {
 		setup, err := driver.NeedsSetupMigration(ctx)
 		if err != nil {
-			s.l.Debug("Failed to check anomaly",
+			log.Debug("Failed to check anomaly",
 				zap.String("instance", instance.Name),
 				zap.String("database", database.Name),
 				zap.String("type", string(api.AnomalyDatabaseSchemaDrift)),
@@ -288,13 +288,13 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 		var schemaBuf bytes.Buffer
 		if _, err := driver.Dump(ctx, database.Name, &schemaBuf, true /*schemaOnly*/); err != nil {
 			if common.ErrorCode(err) == common.NotFound {
-				s.l.Debug("Failed to check anomaly",
+				log.Debug("Failed to check anomaly",
 					zap.String("instance", instance.Name),
 					zap.String("database", database.Name),
 					zap.String("type", string(api.AnomalyDatabaseSchemaDrift)),
 					zap.Error(err))
 			} else {
-				s.l.Error("Failed to check anomaly",
+				log.Error("Failed to check anomaly",
 					zap.String("instance", instance.Name),
 					zap.String("database", database.Name),
 					zap.String("type", string(api.AnomalyDatabaseSchemaDrift)),
@@ -308,7 +308,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 			Limit:    &limit,
 		})
 		if err != nil {
-			s.l.Error("Failed to check anomaly",
+			log.Error("Failed to check anomaly",
 				zap.String("instance", instance.Name),
 				zap.String("database", database.Name),
 				zap.String("type", string(api.AnomalyDatabaseSchemaDrift)),
@@ -324,7 +324,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 				}
 				payload, err := json.Marshal(anomalyPayload)
 				if err != nil {
-					s.l.Error("Failed to marshal anomaly payload",
+					log.Error("Failed to marshal anomaly payload",
 						zap.String("instance", instance.Name),
 						zap.String("database", database.Name),
 						zap.String("type", string(api.AnomalyDatabaseSchemaDrift)),
@@ -337,7 +337,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 						Type:       api.AnomalyDatabaseSchemaDrift,
 						Payload:    string(payload),
 					}); err != nil {
-						s.l.Error("Failed to create anomaly",
+						log.Error("Failed to create anomaly",
 							zap.String("instance", instance.Name),
 							zap.String("database", database.Name),
 							zap.String("type", string(api.AnomalyDatabaseSchemaDrift)),
@@ -350,7 +350,7 @@ func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api
 					Type:       api.AnomalyDatabaseConnection,
 				})
 				if err != nil && common.ErrorCode(err) != common.NotFound {
-					s.l.Error("Failed to close anomaly",
+					log.Error("Failed to close anomaly",
 						zap.String("instance", instance.Name),
 						zap.String("database", database.Name),
 						zap.String("type", string(api.AnomalyDatabaseSchemaDrift)),
@@ -366,7 +366,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 	schedule := api.BackupPlanPolicyScheduleUnset
 	backupSetting, err := s.server.store.GetBackupSettingByDatabaseID(ctx, database.ID)
 	if err != nil {
-		s.l.Error("Failed to retrieve backup setting",
+		log.Error("Failed to retrieve backup setting",
 			zap.String("instance", instance.Name),
 			zap.String("database", database.Name),
 			zap.Error(err))
@@ -405,7 +405,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 		if backupPolicyAnomalyPayload != nil {
 			payload, err := json.Marshal(*backupPolicyAnomalyPayload)
 			if err != nil {
-				s.l.Error("Failed to marshal anomaly payload",
+				log.Error("Failed to marshal anomaly payload",
 					zap.String("instance", instance.Name),
 					zap.String("database", database.Name),
 					zap.String("type", string(api.AnomalyDatabaseBackupPolicyViolation)),
@@ -418,7 +418,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 					Type:       api.AnomalyDatabaseBackupPolicyViolation,
 					Payload:    string(payload),
 				}); err != nil {
-					s.l.Error("Failed to create anomaly",
+					log.Error("Failed to create anomaly",
 						zap.String("instance", instance.Name),
 						zap.String("database", database.Name),
 						zap.String("type", string(api.AnomalyDatabaseBackupPolicyViolation)),
@@ -431,7 +431,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 				Type:       api.AnomalyDatabaseBackupPolicyViolation,
 			})
 			if err != nil && common.ErrorCode(err) != common.NotFound {
-				s.l.Error("Failed to close anomaly",
+				log.Error("Failed to close anomaly",
 					zap.String("instance", instance.Name),
 					zap.String("database", database.Name),
 					zap.String("type", string(api.AnomalyDatabaseBackupPolicyViolation)),
@@ -461,7 +461,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 				}
 				backupList, err := s.server.store.FindBackup(ctx, backupFind)
 				if err != nil {
-					s.l.Error("Failed to retrieve backup list",
+					log.Error("Failed to retrieve backup list",
 						zap.String("instance", instance.Name),
 						zap.String("database", database.Name),
 						zap.Error(err))
@@ -488,7 +488,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 		if backupMissingAnomalyPayload != nil {
 			payload, err := json.Marshal(*backupMissingAnomalyPayload)
 			if err != nil {
-				s.l.Error("Failed to marshal anomaly payload",
+				log.Error("Failed to marshal anomaly payload",
 					zap.String("instance", instance.Name),
 					zap.String("database", database.Name),
 					zap.String("type", string(api.AnomalyDatabaseBackupMissing)),
@@ -501,7 +501,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 					Type:       api.AnomalyDatabaseBackupMissing,
 					Payload:    string(payload),
 				}); err != nil {
-					s.l.Error("Failed to create anomaly",
+					log.Error("Failed to create anomaly",
 						zap.String("instance", instance.Name),
 						zap.String("database", database.Name),
 						zap.String("type", string(api.AnomalyDatabaseBackupMissing)),
@@ -514,7 +514,7 @@ func (s *AnomalyScanner) checkBackupAnomaly(ctx context.Context, instance *api.I
 				Type:       api.AnomalyDatabaseBackupMissing,
 			})
 			if err != nil && common.ErrorCode(err) != common.NotFound {
-				s.l.Error("Failed to close anomaly",
+				log.Error("Failed to close anomaly",
 					zap.String("instance", instance.Name),
 					zap.String("database", database.Name),
 					zap.String("type", string(api.AnomalyDatabaseBackupMissing)),

--- a/server/auth.go
+++ b/server/auth.go
@@ -99,7 +99,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					redirectURL = fmt.Sprintf("%s:%d/oauth/callback", s.profile.FrontendHost, s.profile.FrontendPort)
 				}
 				// exchange OAuth Token
-				oauthToken, err := vcs.Get(vcsFound.Type, vcs.ProviderConfig{Logger: s.l}).ExchangeOAuthToken(
+				oauthToken, err := vcs.Get(vcsFound.Type, vcs.ProviderConfig{}).ExchangeOAuthToken(
 					ctx,
 					vcsFound.InstanceURL,
 					&common.OAuthExchange{
@@ -113,7 +113,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to exchange OAuth token").SetInternal(err)
 				}
 
-				gitlabUserInfo, err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{Logger: s.l}).TryLogin(ctx,
+				gitlabUserInfo, err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{}).TryLogin(ctx,
 					common.OauthContext{
 						ClientID:     vcsFound.ApplicationID,
 						ClientSecret: vcsFound.Secret,

--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
 // NewBackupRunner creates a new backup runner.
-func NewBackupRunner(logger *zap.Logger, server *Server, backupRunnerInterval time.Duration) *BackupRunner {
+func NewBackupRunner(server *Server, backupRunnerInterval time.Duration) *BackupRunner {
 	return &BackupRunner{
-		l:                    logger,
 		server:               server,
 		backupRunnerInterval: backupRunnerInterval,
 	}
@@ -24,7 +24,6 @@ func NewBackupRunner(logger *zap.Logger, server *Server, backupRunnerInterval ti
 
 // BackupRunner is the backup runner scheduling automatic backups.
 type BackupRunner struct {
-	l                    *zap.Logger
 	server               *Server
 	backupRunnerInterval time.Duration
 }
@@ -34,13 +33,13 @@ func (s *BackupRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 	ticker := time.NewTicker(s.backupRunnerInterval)
 	defer ticker.Stop()
 	defer wg.Done()
-	s.l.Debug("Auto backup runner started", zap.Duration("interval", s.backupRunnerInterval))
+	log.Debug("Auto backup runner started", zap.Duration("interval", s.backupRunnerInterval))
 	runningTasks := make(map[int]bool)
 	var mu sync.RWMutex
 	for {
 		select {
 		case <-ticker.C:
-			s.l.Debug("New auto backup round started...")
+			log.Debug("New auto backup round started...")
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
@@ -48,7 +47,7 @@ func (s *BackupRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 						if !ok {
 							err = fmt.Errorf("%v", r)
 						}
-						s.l.Error("Auto backup runner PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
+						log.Error("Auto backup runner PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
 					}
 				}()
 
@@ -60,7 +59,7 @@ func (s *BackupRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 				}
 				backupSettingList, err := s.server.store.FindBackupSettingsMatch(ctx, match)
 				if err != nil {
-					s.l.Error("Failed to retrieve backup settings match", zap.Error(err))
+					log.Error("Failed to retrieve backup settings match", zap.Error(err))
 					return
 				}
 
@@ -76,7 +75,7 @@ func (s *BackupRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 					db := backupSetting.Database
 					backupName := fmt.Sprintf("%s-%s-%s-autobackup", api.ProjectShortSlug(db.Project), api.EnvSlug(db.Instance.Environment), t.Format("20060102T030405"))
 					go func(database *api.Database, backupSettingID int, backupName string, hookURL string) {
-						s.l.Debug("Schedule auto backup",
+						log.Debug("Schedule auto backup",
 							zap.String("database", database.Name),
 							zap.String("backup", backupName),
 						)
@@ -87,7 +86,7 @@ func (s *BackupRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 						}()
 						err := s.scheduleBackupTask(ctx, database, backupName)
 						if err != nil {
-							s.l.Error("Failed to create automatic backup for database",
+							log.Error("Failed to create automatic backup for database",
 								zap.Int("databaseID", database.ID),
 								zap.Error(err))
 							return
@@ -98,7 +97,7 @@ func (s *BackupRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 						}
 						_, err = http.PostForm(hookURL, nil)
 						if err != nil {
-							s.l.Warn("Failed to POST hook URL",
+							log.Warn("Failed to POST hook URL",
 								zap.String("hookURL", hookURL),
 								zap.Int("databaseID", database.ID),
 								zap.Error(err))
@@ -119,7 +118,7 @@ func (s *BackupRunner) scheduleBackupTask(ctx context.Context, database *api.Dat
 	}
 
 	// Store the migration history version if exists.
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.l)
+	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name)
 	if err != nil {
 		return err
 	}

--- a/server/database.go
+++ b/server/database.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 )
 
@@ -225,7 +226,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 
 				// Tenant database exists when peerSchemaVersion or peerSchema are not empty.
 				if peerSchemaVersion != "" || peerSchema != "" {
-					driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.l)
+					driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name)
 					if err != nil {
 						return err
 					}
@@ -300,7 +301,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 				}
 
 				if err != nil {
-					s.l.Warn("Failed to create project activity after transferring database",
+					log.Warn("Failed to create project activity after transferring database",
 						zap.Int("database_id", dbPatched.ID),
 						zap.String("database_name", dbPatched.Name),
 						zap.Int("old_project_id", dbExisting.ProjectID),
@@ -319,7 +320,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 					}
 					_, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{})
 					if err != nil {
-						s.l.Warn("Failed to create project activity after transferring database",
+						log.Warn("Failed to create project activity after transferring database",
 							zap.Int("database_id", dbPatched.ID),
 							zap.String("database_name", dbPatched.Name),
 							zap.Int("old_project_id", dbExisting.ProjectID),
@@ -507,7 +508,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to create backup directory for database ID: %v", id)).SetInternal(err)
 		}
 
-		driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.l)
+		driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name)
 		if err != nil {
 			return err
 		}
@@ -875,7 +876,7 @@ func (s *Server) setDatabaseLabels(ctx context.Context, labelsJSON string, datab
 
 // Try to get database driver using the instance's admin data source.
 // Upon successful return, caller MUST call driver.Close, otherwise, it will leak the database connection.
-func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName string, logger *zap.Logger) (db.Driver, error) {
+func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName string) (db.Driver, error) {
 	adminDataSource := api.DataSourceFromInstanceWithType(instance, api.Admin)
 	if adminDataSource == nil {
 		return nil, common.Errorf(common.Internal, fmt.Errorf("admin data source not found for instance %d", instance.ID))
@@ -884,7 +885,7 @@ func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databas
 	driver, err := getDatabaseDriver(
 		ctx,
 		instance.Engine,
-		db.DriverConfig{Logger: logger},
+		db.DriverConfig{},
 		db.ConnectionConfig{
 			Username: adminDataSource.Username,
 			Password: adminDataSource.Password,
@@ -906,7 +907,7 @@ func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databas
 
 // We'd like to use read-only data source whenever possible, but fallback to admin data source if there's no read-only data source.
 // Upon successful return, caller MUST call driver.Close, otherwise, it will leak the database connection.
-func tryGetReadOnlyDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName string, logger *zap.Logger) (db.Driver, error) {
+func tryGetReadOnlyDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName string) (db.Driver, error) {
 	dataSource := api.DataSourceFromInstanceWithType(instance, api.RO)
 	// If there are no read-only data source, fall back to admin data source.
 	if dataSource == nil {
@@ -919,7 +920,7 @@ func tryGetReadOnlyDatabaseDriver(ctx context.Context, instance *api.Instance, d
 	driver, err := getDatabaseDriver(
 		ctx,
 		instance.Engine,
-		db.DriverConfig{Logger: logger},
+		db.DriverConfig{},
 		db.ConnectionConfig{
 			Username: dataSource.Username,
 			Password: dataSource.Password,

--- a/server/debug.go
+++ b/server/debug.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
@@ -24,7 +25,7 @@ func (s *Server) registerDebugRoutes(g *echo.Group) {
 		if debugPatch.IsDebug {
 			lvl = zap.DebugLevel
 		}
-		s.lvl.SetLevel(lvl)
+		log.SetLevel(lvl)
 
 		s.e.Debug = debugPatch.IsDebug
 
@@ -34,7 +35,7 @@ func (s *Server) registerDebugRoutes(g *echo.Group) {
 
 func (s *Server) currentDebugState(c echo.Context) error {
 	c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
-	if err := jsonapi.MarshalPayload(c.Response().Writer, &api.Debug{IsDebug: s.lvl.Enabled(zap.DebugLevel)}); err != nil {
+	if err := jsonapi.MarshalPayload(c.Response().Writer, &api.Debug{IsDebug: log.EnabledLevel(zap.DebugLevel)}); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal debug info response").SetInternal(err)
 	}
 	return nil

--- a/server/instance.go
+++ b/server/instance.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 )
 
@@ -43,11 +44,11 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		// Try creating the "bytebase" db in the added instance if needed.
 		// Since we allow user to add new instance upfront even providing the incorrect username/password,
 		// thus it's OK if it fails. Frontend will surface relevant info suggesting the "bytebase" db hasn't created yet.
-		db, err := getAdminDatabaseDriver(ctx, instance, "", s.l)
+		db, err := getAdminDatabaseDriver(ctx, instance, "")
 		if err == nil {
 			defer db.Close(ctx)
 			if err := db.SetupMigrationIfNeeded(ctx); err != nil {
-				s.l.Warn("Failed to setup migration schema on instance creation",
+				log.Warn("Failed to setup migration schema on instance creation",
 					zap.String("instance_name", instance.Name),
 					zap.String("engine", string(instance.Engine)),
 					zap.Error(err))
@@ -159,11 +160,11 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 
 		// Try immediately setup the migration schema, sync the engine version and schema after updating any connection related info.
 		if instancePatch.Host != nil || instancePatch.Port != nil {
-			db, err := getAdminDatabaseDriver(ctx, instancePatched, "", s.l)
+			db, err := getAdminDatabaseDriver(ctx, instancePatched, "")
 			if err == nil {
 				defer db.Close(ctx)
 				if err := db.SetupMigrationIfNeeded(ctx); err != nil {
-					s.l.Warn("Failed to setup migration schema on instance update",
+					log.Warn("Failed to setup migration schema on instance update",
 						zap.String("instance_name", instancePatched.Name),
 						zap.String("engine", string(instancePatched.Engine)),
 						zap.Error(err))
@@ -216,7 +217,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		resultSet := &api.SQLResultSet{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "", s.l)
+		db, err := getAdminDatabaseDriver(ctx, instance, "")
 		if err != nil {
 			resultSet.Error = err.Error()
 		} else {
@@ -249,7 +250,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		instanceMigration := &api.InstanceMigration{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "", s.l)
+		db, err := getAdminDatabaseDriver(ctx, instance, "")
 		if err != nil {
 			instanceMigration.Status = api.InstanceMigrationSchemaUnknown
 			instanceMigration.Error = err.Error()
@@ -294,7 +295,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		find := &db.MigrationHistoryFind{ID: &historyID}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "", s.l)
+		driver, err := getAdminDatabaseDriver(ctx, instance, "")
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history ID %d for instance %q", id, instance.Name)).SetInternal(err)
 		}
@@ -369,7 +370,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		historyList := []*api.MigrationHistory{}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "", s.l)
+		driver, err := getAdminDatabaseDriver(ctx, instance, "")
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history for instance %q", instance.Name)).SetInternal(err)
 		}

--- a/server/issue.go
+++ b/server/issue.go
@@ -1234,7 +1234,7 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 		return "", "", nil
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name, s.l)
+	driver, err := getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name)
 	if err != nil {
 		return "", "", err
 	}

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo/v4"
-	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
@@ -165,7 +164,7 @@ func removeUserCookie(c echo.Context) {
 // JWTMiddleware validates the access token.
 // If the access token is about to expire or has expired and the request has a valid refresh token, it
 // will try to generate new access token and refresh token.
-func JWTMiddleware(l *zap.Logger, principalStore *store.Store, next echo.HandlerFunc, mode common.ReleaseMode, secret string) echo.HandlerFunc {
+func JWTMiddleware(principalStore *store.Store, next echo.HandlerFunc, mode common.ReleaseMode, secret string) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// Skips auth, actuator, plan
 		if common.HasPrefixes(c.Path(), "/api/auth", "/api/actuator", "/api/plan") {

--- a/server/metric_reporter.go
+++ b/server/metric_reporter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	enterpriseAPI "github.com/bytebase/bytebase/enterprise/api"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/plugin/metric/segment"
@@ -24,8 +25,6 @@ const (
 
 // MetricReporter is the metric reporter.
 type MetricReporter struct {
-	l *zap.Logger
-
 	// subscription is the pointer to the server.subscription.
 	// the subscription can be updated by users so we need the pointer to get the latest value.
 	subscription *enterpriseAPI.Subscription
@@ -37,11 +36,10 @@ type MetricReporter struct {
 }
 
 // NewMetricReporter creates a new metric scheduler.
-func NewMetricReporter(logger *zap.Logger, server *Server, workspaceID string) *MetricReporter {
-	r := segment.NewReporter(logger, server.profile.MetricConnectionKey, workspaceID)
+func NewMetricReporter(server *Server, workspaceID string) *MetricReporter {
+	r := segment.NewReporter(server.profile.MetricConnectionKey, workspaceID)
 
 	return &MetricReporter{
-		l:            logger,
 		subscription: &server.subscription,
 		version:      server.profile.Version,
 		workspaceID:  workspaceID,
@@ -56,7 +54,7 @@ func (m *MetricReporter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	defer ticker.Stop()
 	defer wg.Done()
 
-	m.l.Debug(fmt.Sprintf("Metrics reporter started and will run every %v", metricSchedulerInterval))
+	log.Debug(fmt.Sprintf("Metrics reporter started and will run every %v", metricSchedulerInterval))
 
 	for {
 		select {
@@ -68,7 +66,7 @@ func (m *MetricReporter) Run(ctx context.Context, wg *sync.WaitGroup) {
 						if !ok {
 							err = fmt.Errorf("%v", r)
 						}
-						m.l.Error("Metrics reporter PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
+						log.Error("Metrics reporter PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
 					}
 				}()
 
@@ -77,11 +75,11 @@ func (m *MetricReporter) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 				ctx := context.Background()
 				for name, collector := range m.collectors {
-					m.l.Debug("Run metric collector", zap.String("collector", name))
+					log.Debug("Run metric collector", zap.String("collector", name))
 
 					metricList, err := collector.Collect(ctx)
 					if err != nil {
-						m.l.Error(
+						log.Error(
 							"Failed to collect metric",
 							zap.String("collector", name),
 							zap.Error(err),
@@ -91,7 +89,7 @@ func (m *MetricReporter) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 					for _, metric := range metricList {
 						if err := m.reporter.Report(metric); err != nil {
-							m.l.Error(
+							log.Error(
 								"Failed to report metric",
 								zap.String("metric", string(metric.Name)),
 								zap.Error(err),
@@ -129,6 +127,6 @@ func (m *MetricReporter) identify() {
 			identifyTraitForVersion: m.version,
 		},
 	}); err != nil {
-		m.l.Debug("reporter identify failed", zap.Error(err))
+		log.Debug("reporter identify failed", zap.Error(err))
 	}
 }

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -77,7 +77,7 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 			oauthExchange.RedirectURL = fmt.Sprintf("%s:%d/oauth/callback", s.profile.FrontendHost, s.profile.FrontendPort)
 		}
 
-		oauthToken, err := vcsPlugin.Get(vcsType, vcsPlugin.ProviderConfig{Logger: s.l}).
+		oauthToken, err := vcsPlugin.Get(vcsType, vcsPlugin.ProviderConfig{}).
 			ExchangeOAuthToken(
 				c.Request().Context(),
 				instanceURL,

--- a/server/project.go
+++ b/server/project.go
@@ -229,7 +229,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			}
 		}
 
-		webhookID, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).CreateWebhook(
+		webhookID, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).CreateWebhook(
 			ctx,
 			common.OauthContext{
 				AccessToken: repositoryCreate.AccessToken,
@@ -377,7 +377,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 				}
 			}
 
-			err = vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).PatchWebhook(
+			err = vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).PatchWebhook(
 				ctx,
 				common.OauthContext{
 					// Need to get ApplicationID, Secret from vcs instead of repository.vcs since the latter is not composed.
@@ -448,7 +448,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		// Delete the webhook after we successfully delete the repository.
 		// This is because in case the webhook deletion fails, we can still have a cleanup process to cleanup the orphaned webhook.
 		// If we delete it before we delete the repository, then if the repository deletion fails, we will have a broken repository with no webhook.
-		err = vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).DeleteWebhook(
+		err = vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).DeleteWebhook(
 			ctx,
 			// Need to get ApplicationID, Secret from vcs instead of repository.vcs since the latter is not composed.
 			common.OauthContext{

--- a/server/project_member.go
+++ b/server/project_member.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
 )
 
@@ -48,7 +49,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 		if vcs == nil {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("VCS not found with ID: %d", repo.VCSID))
 		}
-		vcsProjectMemberList, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).FetchRepositoryActiveMemberList(ctx,
+		vcsProjectMemberList, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).FetchRepositoryActiveMemberList(ctx,
 			common.OauthContext{
 				ClientID:     vcs.ApplicationID,
 				ClientSecret: vcs.Secret,
@@ -154,7 +155,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 						principal.Name, principal.Email, deletedMember.Role, deletedMember.RoleProvider, createdMember.Role, createdMember.RoleProvider),
 				}
 				if _, err = s.ActivityManager.CreateActivity(ctx, activityUpdateMember, &ActivityMeta{}); err != nil {
-					s.l.Warn("Failed to create project activity after updating member role",
+					log.Warn("Failed to create project activity after updating member role",
 						zap.Int("project_id", projectID),
 						zap.Int("principal_id", principal.ID),
 						zap.String("principal_name", principal.Name),
@@ -177,7 +178,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 						principal.Name, principal.Email, createdMember.Role),
 				}
 				if _, err = s.ActivityManager.CreateActivity(ctx, activityCreateMember, &ActivityMeta{}); err != nil {
-					s.l.Warn("Failed to create project activity after creating member",
+					log.Warn("Failed to create project activity after creating member",
 						zap.Int("project_id", projectID),
 						zap.Int("principal_id", principal.ID),
 						zap.String("principal_name", principal.Name),
@@ -206,7 +207,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 					principal.Name, principal.Email, deletedMember.Role),
 			}
 			if _, err = s.ActivityManager.CreateActivity(ctx, activityDeleteMember, &ActivityMeta{}); err != nil {
-				s.l.Warn("Failed to create project activity after creating member",
+				log.Warn("Failed to create project activity after creating member",
 					zap.Int("project_id", projectID),
 					zap.Int("principal_id", principal.ID),
 					zap.String("principal_name", principal.Name),
@@ -253,7 +254,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 			}
 			_, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{})
 			if err != nil {
-				s.l.Warn("Failed to create project activity after creating member",
+				log.Warn("Failed to create project activity after creating member",
 					zap.Int("project_id", projectID),
 					zap.Int("principal_id", projectMember.Principal.ID),
 					zap.String("principal_name", projectMember.Principal.Name),
@@ -316,7 +317,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 			}
 			_, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{})
 			if err != nil {
-				s.l.Warn("Failed to create project activity after updating member role",
+				log.Warn("Failed to create project activity after updating member role",
 					zap.Int("project_id", projectID),
 					zap.Int("principal_id", projectMember.Principal.ID),
 					zap.String("principal_name", projectMember.Principal.Name),
@@ -375,7 +376,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 				_, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{})
 			}
 			if err != nil {
-				s.l.Warn("Failed to create project activity after deleting member",
+				log.Warn("Failed to create project activity after deleting member",
 					zap.Int("project_id", projectID),
 					zap.Int("principal_id", projectMember.Principal.ID),
 					zap.String("principal_name", projectMember.Principal.Name),

--- a/server/recover.go
+++ b/server/recover.go
@@ -3,11 +3,12 @@ package server
 import (
 	"fmt"
 
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
 )
 
-func recoverMiddleware(l *zap.Logger, next echo.HandlerFunc) echo.HandlerFunc {
+func recoverMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		defer func() {
 			if r := recover(); r != nil {
@@ -15,7 +16,7 @@ func recoverMiddleware(l *zap.Logger, next echo.HandlerFunc) echo.HandlerFunc {
 				if !ok {
 					err = fmt.Errorf("%v", r)
 				}
-				l.Error("Middleware PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
+				log.Error("Middleware PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
 
 				c.Error(err)
 			}

--- a/server/schema_syncer.go
+++ b/server/schema_syncer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
@@ -15,16 +16,14 @@ const (
 )
 
 // NewSchemaSyncer creates a schema syncer.
-func NewSchemaSyncer(logger *zap.Logger, server *Server) *SchemaSyncer {
+func NewSchemaSyncer(server *Server) *SchemaSyncer {
 	return &SchemaSyncer{
-		l:      logger,
 		server: server,
 	}
 }
 
 // SchemaSyncer is the schema syncer.
 type SchemaSyncer struct {
-	l      *zap.Logger
 	server *Server
 }
 
@@ -33,13 +32,13 @@ func (s *SchemaSyncer) Run(ctx context.Context, wg *sync.WaitGroup) {
 	ticker := time.NewTicker(schemaSyncInterval)
 	defer ticker.Stop()
 	defer wg.Done()
-	s.l.Debug(fmt.Sprintf("Schema syncer started and will run every %v", schemaSyncInterval))
+	log.Debug(fmt.Sprintf("Schema syncer started and will run every %v", schemaSyncInterval))
 	runningTasks := make(map[int]bool)
 	mu := sync.RWMutex{}
 	for {
 		select {
 		case <-ticker.C:
-			s.l.Debug("New schema syncer round started...")
+			log.Debug("New schema syncer round started...")
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
@@ -47,7 +46,7 @@ func (s *SchemaSyncer) Run(ctx context.Context, wg *sync.WaitGroup) {
 						if !ok {
 							err = fmt.Errorf("%v", r)
 						}
-						s.l.Error("Schema syncer PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
+						log.Error("Schema syncer PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
 					}
 				}()
 
@@ -59,7 +58,7 @@ func (s *SchemaSyncer) Run(ctx context.Context, wg *sync.WaitGroup) {
 				}
 				instanceList, err := s.server.store.FindInstance(ctx, instanceFind)
 				if err != nil {
-					s.l.Error("Failed to retrieve instances", zap.Error(err))
+					log.Error("Failed to retrieve instances", zap.Error(err))
 					return
 				}
 
@@ -73,7 +72,7 @@ func (s *SchemaSyncer) Run(ctx context.Context, wg *sync.WaitGroup) {
 					mu.Unlock()
 
 					go func(instance *api.Instance) {
-						s.l.Debug("Sync instance schema", zap.String("instance", instance.Name))
+						log.Debug("Sync instance schema", zap.String("instance", instance.Name))
 						defer func() {
 							mu.Lock()
 							delete(runningTasks, instance.ID)
@@ -81,7 +80,7 @@ func (s *SchemaSyncer) Run(ctx context.Context, wg *sync.WaitGroup) {
 						}()
 						resultSet := s.server.syncEngineVersionAndSchema(ctx, instance)
 						if resultSet.Error != "" {
-							s.l.Debug("Failed to sync instance",
+							log.Debug("Failed to sync instance",
 								zap.Int("id", instance.ID),
 								zap.String("name", instance.Name),
 								zap.String("error", resultSet.Error))

--- a/server/server.go
+++ b/server/server.go
@@ -18,10 +18,10 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	scas "github.com/qiangmzsx/string-adapter/v2"
-	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	enterpriseAPI "github.com/bytebase/bytebase/enterprise/api"
 	enterpriseService "github.com/bytebase/bytebase/enterprise/service"
 	"github.com/bytebase/bytebase/metric"
@@ -52,8 +52,6 @@ type Server struct {
 	metaDB    *store.MetadataDB
 	db        *store.DB
 	store     *store.Store
-	l         *zap.Logger
-	lvl       *zap.AtomicLevel
 	startedTs int64
 	secret    string
 
@@ -74,11 +72,9 @@ var casbinDBAPolicy string
 var casbinDeveloperPolicy string
 
 // NewServer creates a server.
-func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLevel *zap.AtomicLevel) (*Server, error) {
+func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 	s := &Server{
 		profile:   prof,
-		l:         logger,
-		lvl:       loggerLevel,
 		startedTs: time.Now().Unix(),
 	}
 
@@ -114,9 +110,9 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 
 	// New MetadataDB instance.
 	if prof.useEmbedDB() {
-		s.metaDB, err = store.NewMetadataDBWithEmbedPg(logger, prof.PgUser, prof.DataDir, prof.DemoDataDir, prof.Mode)
+		s.metaDB, err = store.NewMetadataDBWithEmbedPg(prof.PgUser, prof.DataDir, prof.DemoDataDir, prof.Mode)
 	} else {
-		s.metaDB, err = store.NewMetadataDBWithExternalPg(logger, prof.PgURL, prof.DemoDataDir, prof.Mode)
+		s.metaDB, err = store.NewMetadataDBWithExternalPg(prof.PgURL, prof.DemoDataDir, prof.Mode)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cannot create MetadataDB instance, error: %w", err)
@@ -136,7 +132,7 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 	}
 
 	cacheService := NewCacheService()
-	storeInstance := store.New(logger, storeDB, cacheService)
+	storeInstance := store.New(storeDB, cacheService)
 	s.store = storeInstance
 
 	config, err := s.initSetting(ctx, storeInstance)
@@ -155,77 +151,77 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 		XFrameOptions: "DENY",
 	}))
 
-	embedFrontend(logger, e)
+	embedFrontend(e)
 	s.e = e
 
 	if !prof.Readonly {
 		// Task scheduler
-		taskScheduler := NewTaskScheduler(logger, s)
+		taskScheduler := NewTaskScheduler(s)
 
-		defaultExecutor := NewDefaultTaskExecutor(logger)
+		defaultExecutor := NewDefaultTaskExecutor()
 		taskScheduler.Register(string(api.TaskGeneral), defaultExecutor)
 
-		createDBExecutor := NewDatabaseCreateTaskExecutor(logger)
+		createDBExecutor := NewDatabaseCreateTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseCreate), createDBExecutor)
 
-		schemaUpdateExecutor := NewSchemaUpdateTaskExecutor(logger)
+		schemaUpdateExecutor := NewSchemaUpdateTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseSchemaUpdate), schemaUpdateExecutor)
 
-		dataUpdateExecutor := NewDataUpdateTaskExecutor(logger)
+		dataUpdateExecutor := NewDataUpdateTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseDataUpdate), dataUpdateExecutor)
 
-		backupDBExecutor := NewDatabaseBackupTaskExecutor(logger)
+		backupDBExecutor := NewDatabaseBackupTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseBackup), backupDBExecutor)
 
-		restoreDBExecutor := NewDatabaseRestoreTaskExecutor(logger)
+		restoreDBExecutor := NewDatabaseRestoreTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseRestore), restoreDBExecutor)
 
-		schemaUpdateGhostSyncExecutor := NewSchemaUpdateGhostSyncTaskExecutor(logger)
+		schemaUpdateGhostSyncExecutor := NewSchemaUpdateGhostSyncTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseSchemaUpdateGhostSync), schemaUpdateGhostSyncExecutor)
 
-		schemaUpdateGhostCutoverExecutor := NewSchemaUpdateGhostCutoverTaskExecutor(logger)
+		schemaUpdateGhostCutoverExecutor := NewSchemaUpdateGhostCutoverTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseSchemaUpdateGhostCutover), schemaUpdateGhostCutoverExecutor)
 
-		schemaUpdateGhostDropOriginalTableExecutor := NewSchemaUpdateGhostDropOriginalTableTaskExecutor(logger)
+		schemaUpdateGhostDropOriginalTableExecutor := NewSchemaUpdateGhostDropOriginalTableTaskExecutor()
 		taskScheduler.Register(string(api.TaskDatabaseSchemaUpdateGhostDropOriginalTable), schemaUpdateGhostDropOriginalTableExecutor)
 
-		pitrRestoreExecutor := NewPITRRestoreTaskExecutor(logger, s.mysqlutil)
+		pitrRestoreExecutor := NewPITRRestoreTaskExecutor(s.mysqlutil)
 		taskScheduler.Register(string(api.TaskDatabasePITRRestore), pitrRestoreExecutor)
 
-		pitrCutoverExecutor := NewPITRCutoverTaskExecutor(logger, s.mysqlutil)
+		pitrCutoverExecutor := NewPITRCutoverTaskExecutor(s.mysqlutil)
 		taskScheduler.Register(string(api.TaskDatabasePITRCutover), pitrCutoverExecutor)
 
 		s.TaskScheduler = taskScheduler
 
 		// Task check scheduler
-		taskCheckScheduler := NewTaskCheckScheduler(logger, s)
+		taskCheckScheduler := NewTaskCheckScheduler(s)
 
-		statementSimpleExecutor := NewTaskCheckStatementAdvisorSimpleExecutor(logger)
+		statementSimpleExecutor := NewTaskCheckStatementAdvisorSimpleExecutor()
 		taskCheckScheduler.Register(string(api.TaskCheckDatabaseStatementFakeAdvise), statementSimpleExecutor)
 		taskCheckScheduler.Register(string(api.TaskCheckDatabaseStatementSyntax), statementSimpleExecutor)
 
-		statementCompositeExecutor := NewTaskCheckStatementAdvisorCompositeExecutor(logger)
+		statementCompositeExecutor := NewTaskCheckStatementAdvisorCompositeExecutor()
 		taskCheckScheduler.Register(string(api.TaskCheckDatabaseStatementAdvise), statementCompositeExecutor)
 
-		databaseConnectExecutor := NewTaskCheckDatabaseConnectExecutor(logger)
+		databaseConnectExecutor := NewTaskCheckDatabaseConnectExecutor()
 		taskCheckScheduler.Register(string(api.TaskCheckDatabaseConnect), databaseConnectExecutor)
 
-		migrationSchemaExecutor := NewTaskCheckMigrationSchemaExecutor(logger)
+		migrationSchemaExecutor := NewTaskCheckMigrationSchemaExecutor()
 		taskCheckScheduler.Register(string(api.TaskCheckInstanceMigrationSchema), migrationSchemaExecutor)
 
-		timingExecutor := NewTaskCheckTimingExecutor(logger)
+		timingExecutor := NewTaskCheckTimingExecutor()
 		taskCheckScheduler.Register(string(api.TaskCheckGeneralEarliestAllowedTime), timingExecutor)
 
 		s.TaskCheckScheduler = taskCheckScheduler
 
 		// Schema syncer
-		s.SchemaSyncer = NewSchemaSyncer(logger, s)
+		s.SchemaSyncer = NewSchemaSyncer(s)
 
 		// Backup runner
-		s.BackupRunner = NewBackupRunner(logger, s, prof.BackupRunnerInterval)
+		s.BackupRunner = NewBackupRunner(s, prof.BackupRunnerInterval)
 
 		// Anomaly scanner
-		s.AnomalyScanner = NewAnomalyScanner(logger, s)
+		s.AnomalyScanner = NewAnomalyScanner(s)
 
 		// Metric reporter
 		s.initMetricReporter(config.workspaceID)
@@ -243,7 +239,7 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 		}))
 	}
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return recoverMiddleware(logger, next)
+		return recoverMiddleware(next)
 	})
 
 	webhookGroup := e.Group("/hook")
@@ -252,7 +248,7 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 	apiGroup := e.Group("/api")
 
 	apiGroup.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return JWTMiddleware(logger, s.store, next, prof.Mode, config.secret)
+		return JWTMiddleware(s.store, next, prof.Mode, config.secret)
 	})
 
 	m, err := model.NewModelFromString(casbinModel)
@@ -265,7 +261,7 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 		return nil, err
 	}
 	apiGroup.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return aclMiddleware(logger, s, ce, next, prof.Readonly)
+		return aclMiddleware(s, ce, next, prof.Readonly)
 	})
 	s.registerDebugRoutes(apiGroup)
 	s.registerSettingRoutes(apiGroup)
@@ -306,39 +302,39 @@ func NewServer(ctx context.Context, prof Profile, logger *zap.Logger, loggerLeve
 	}
 
 	s.ActivityManager = NewActivityManager(s, storeInstance)
-	s.LicenseService, err = enterpriseService.NewLicenseService(logger, prof.DataDir, prof.Mode)
+	s.LicenseService, err = enterpriseService.NewLicenseService(prof.DataDir, prof.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create license service, error: %w", err)
 	}
 
 	s.initSubscription()
 
-	logger.Debug(fmt.Sprintf("All registered routes: %v", string(allRoutes)))
+	log.Debug(fmt.Sprintf("All registered routes: %v", string(allRoutes)))
 	serverStarted = true
 	return s, nil
 }
 
 // initSubscription will initial the subscription cache in memory.
-func (server *Server) initSubscription() {
-	server.subscription = server.loadSubscription()
+func (s *Server) initSubscription() {
+	s.subscription = s.loadSubscription()
 }
 
 // initMetricReporter will initial the metric scheduler.
-func (server *Server) initMetricReporter(workspaceID string) {
-	enabled := server.profile.Mode == common.ReleaseModeProd && !server.profile.Demo
+func (s *Server) initMetricReporter(workspaceID string) {
+	enabled := s.profile.Mode == common.ReleaseModeProd && !s.profile.Demo
 	if enabled {
-		metricReporter := NewMetricReporter(server.l, server, workspaceID)
-		metricReporter.Register(metric.InstanceCountMetricName, metricCollector.NewInstanceCountCollector(server.l, server.store))
-		metricReporter.Register(metric.IssueCountMetricName, metricCollector.NewIssueCountCollector(server.l, server.store))
-		metricReporter.Register(metric.ProjectCountMetricName, metricCollector.NewProjectCountCollector(server.l, server.store))
-		metricReporter.Register(metric.PolicyCountMetricName, metricCollector.NewPolicyCountCollector(server.l, server.store))
-		metricReporter.Register(metric.TaskCountMetricName, metricCollector.NewTaskCountCollector(server.l, server.store))
-		metricReporter.Register(metric.DatabaseCountMetricName, metricCollector.NewDatabaseCountCollector(server.l, server.store))
-		server.MetricReporter = metricReporter
+		metricReporter := NewMetricReporter(s, workspaceID)
+		metricReporter.Register(metric.InstanceCountMetricName, metricCollector.NewInstanceCountCollector(s.store))
+		metricReporter.Register(metric.IssueCountMetricName, metricCollector.NewIssueCountCollector(s.store))
+		metricReporter.Register(metric.ProjectCountMetricName, metricCollector.NewProjectCountCollector(s.store))
+		metricReporter.Register(metric.PolicyCountMetricName, metricCollector.NewPolicyCountCollector(s.store))
+		metricReporter.Register(metric.TaskCountMetricName, metricCollector.NewTaskCountCollector(s.store))
+		metricReporter.Register(metric.DatabaseCountMetricName, metricCollector.NewDatabaseCountCollector(s.store))
+		s.MetricReporter = metricReporter
 	}
 }
 
-func (server *Server) initSetting(ctx context.Context, store *store.Store) (*config, error) {
+func (s *Server) initSetting(ctx context.Context, store *store.Store) (*config, error) {
 	// initial branding
 	_, err := store.CreateSettingIfNotExist(ctx, &api.SettingCreate{
 		CreatorID:   api.SystemBotID,
@@ -380,80 +376,80 @@ func (server *Server) initSetting(ctx context.Context, store *store.Store) (*con
 }
 
 // Run will run the server.
-func (server *Server) Run(ctx context.Context) error {
+func (s *Server) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
-	server.cancel = cancel
-	if !server.profile.Readonly {
+	s.cancel = cancel
+	if !s.profile.Readonly {
 		// runnerWG waits for all goroutines to complete.
-		go server.TaskScheduler.Run(ctx, &server.runnerWG)
-		server.runnerWG.Add(1)
-		go server.TaskCheckScheduler.Run(ctx, &server.runnerWG)
-		server.runnerWG.Add(1)
-		go server.SchemaSyncer.Run(ctx, &server.runnerWG)
-		server.runnerWG.Add(1)
-		go server.BackupRunner.Run(ctx, &server.runnerWG)
-		server.runnerWG.Add(1)
-		go server.AnomalyScanner.Run(ctx, &server.runnerWG)
-		server.runnerWG.Add(1)
+		go s.TaskScheduler.Run(ctx, &s.runnerWG)
+		s.runnerWG.Add(1)
+		go s.TaskCheckScheduler.Run(ctx, &s.runnerWG)
+		s.runnerWG.Add(1)
+		go s.SchemaSyncer.Run(ctx, &s.runnerWG)
+		s.runnerWG.Add(1)
+		go s.BackupRunner.Run(ctx, &s.runnerWG)
+		s.runnerWG.Add(1)
+		go s.AnomalyScanner.Run(ctx, &s.runnerWG)
+		s.runnerWG.Add(1)
 
-		if server.MetricReporter != nil {
-			go server.MetricReporter.Run(ctx, &server.runnerWG)
-			server.runnerWG.Add(1)
+		if s.MetricReporter != nil {
+			go s.MetricReporter.Run(ctx, &s.runnerWG)
+			s.runnerWG.Add(1)
 		}
 	}
 
 	// Sleep for 1 sec to make sure port is released between runs.
 	time.Sleep(time.Duration(1) * time.Second)
 
-	return server.e.Start(fmt.Sprintf(":%d", server.profile.BackendPort))
+	return s.e.Start(fmt.Sprintf(":%d", s.profile.BackendPort))
 }
 
 // Shutdown will shut down the server.
-func (server *Server) Shutdown(ctx context.Context) error {
-	server.l.Info("Trying to stop Bytebase ....")
-	server.l.Info("Trying to gracefully shutdown server")
+func (s *Server) Shutdown(ctx context.Context) error {
+	log.Info("Trying to stop Bytebase ....")
+	log.Info("Trying to gracefully shutdown server")
 
 	// Close the metric reporter
-	if server.MetricReporter != nil {
-		server.MetricReporter.Close()
+	if s.MetricReporter != nil {
+		s.MetricReporter.Close()
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	// Cancel the worker
-	if server.cancel != nil {
-		server.cancel()
+	if s.cancel != nil {
+		s.cancel()
 	}
 
 	// Shutdown echo
-	if server.e != nil {
-		if err := server.e.Shutdown(ctx); err != nil {
-			server.e.Logger.Fatal(err)
+	if s.e != nil {
+		if err := s.e.Shutdown(ctx); err != nil {
+			s.e.Logger.Fatal(err)
 		}
 	}
 
 	// Wait for all runners to exit.
-	server.runnerWG.Wait()
+	s.runnerWG.Wait()
 
 	// Close db connection
-	if server.db != nil {
-		server.l.Info("Trying to close database connections")
-		if err := server.db.Close(); err != nil {
+	if s.db != nil {
+		log.Info("Trying to close database connections")
+		if err := s.db.Close(); err != nil {
 			return err
 		}
 	}
 
 	// Shutdown postgres server if embed.
-	if server.metaDB != nil {
-		server.metaDB.Close()
+	if s.metaDB != nil {
+		s.metaDB.Close()
 	}
-	server.l.Info("Bytebase stopped properly")
+	log.Info("Bytebase stopped properly")
 
 	return nil
 }
 
 // GetEcho returns the echo server.
-func (server *Server) GetEcho() *echo.Echo {
-	return server.e
+func (s *Server) GetEcho() *echo.Echo {
+	return s.e
 }

--- a/server/server.go
+++ b/server/server.go
@@ -238,9 +238,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 				`"status":${status},"error":"${error}"}` + "\n",
 		}))
 	}
-	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return recoverMiddleware(next)
-	})
+	e.Use(recoverMiddleware)
 
 	webhookGroup := e.Group("/hook")
 	s.registerWebhookRoutes(webhookGroup)

--- a/server/server_embed_dev.go
+++ b/server/server_embed_dev.go
@@ -4,10 +4,10 @@
 package server
 
 import (
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/labstack/echo/v4"
-	"go.uber.org/zap"
 )
 
-func embedFrontend(logger *zap.Logger, _ *echo.Echo) {
-	logger.Info("Dev mode, skip embedding frontend")
+func embedFrontend(_ *echo.Echo) {
+	log.Info("Dev mode, skip embedding frontend")
 }

--- a/server/server_embed_release.go
+++ b/server/server_embed_release.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"go.uber.org/zap"
 )
 
 //go:embed dist
@@ -19,15 +18,15 @@ var embeddedFiles embed.FS
 var indexContent string
 
 func getFileSystem() http.FileSystem {
-	fsys, err := fs.Sub(embeddedFiles, "dist")
+	fs, err := fs.Sub(embeddedFiles, "dist")
 	if err != nil {
 		panic(err)
 	}
 
-	return http.FS(fsys)
+	return http.FS(fs)
 }
 
-func embedFrontend(logger *zap.Logger, e *echo.Echo) {
+func embedFrontend(e *echo.Echo) {
 	// Catch-all route to return index.html, this is to prevent 404 when accessing non-root url.
 	// See https://stackoverflow.com/questions/27928372/react-router-urls-dont-work-when-refreshing-or-writing-manually
 	e.GET("/*", func(c echo.Context) error {

--- a/server/sheet.go
+++ b/server/sheet.go
@@ -106,7 +106,7 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 
 		basePath := filepath.Dir(repo.SheetPathTemplate)
 		// TODO(Steven): The repo.branchFilter could be `test/*` which cannot be the ref value.
-		fileList, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).FetchRepositoryFileList(ctx,
+		fileList, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).FetchRepositoryFileList(ctx,
 			common.OauthContext{
 				ClientID:     vcs.ApplicationID,
 				ClientSecret: vcs.Secret,
@@ -132,7 +132,7 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("sheet name cannot be empty from sheet path %s with template %s", file.Path, repo.SheetPathTemplate)).SetInternal(err)
 			}
 
-			fileContent, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ReadFileContent(ctx,
+			fileContent, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).ReadFileContent(ctx,
 				common.OauthContext{
 					ClientID:     vcs.ApplicationID,
 					ClientSecret: vcs.Secret,
@@ -149,7 +149,7 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch file content from VCS, instance URL: %s, repo ID: %s, file path: %s, branch: %s", vcs.InstanceURL, repo.ExternalID, file.Path, repo.BranchFilter)).SetInternal(err)
 			}
 
-			fileMeta, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).ReadFileMeta(ctx,
+			fileMeta, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).ReadFileMeta(ctx,
 				common.OauthContext{
 					ClientID:     vcs.ApplicationID,
 					ClientSecret: vcs.Secret,
@@ -166,7 +166,7 @@ func (s *Server) registerSheetRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch file meta from VCS, instance URL: %s, repo ID: %s, file path: %s, branch: %s", vcs.InstanceURL, repo.ExternalID, file.Path, repo.BranchFilter)).SetInternal(err)
 			}
 
-			lastCommit, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{Logger: s.l}).FetchCommitByID(ctx,
+			lastCommit, err := vcsPlugin.Get(vcs.Type, vcsPlugin.ProviderConfig{}).FetchCommitByID(ctx,
 				common.OauthContext{
 					ClientID:     vcs.ApplicationID,
 					ClientSecret: vcs.Secret,

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	enterpriseAPI "github.com/bytebase/bytebase/enterprise/api"
 )
 
@@ -70,14 +71,14 @@ func (s *Server) loadLicense() (*enterpriseAPI.License, error) {
 	license, err := s.LicenseService.LoadLicense()
 	if err != nil {
 		if common.ErrorCode(err) == common.NotFound {
-			s.l.Debug("Failed to find license", zap.String("error", err.Error()))
+			log.Debug("Failed to find license", zap.String("error", err.Error()))
 		} else {
-			s.l.Warn("Failed to load valid license", zap.String("error", err.Error()))
+			log.Warn("Failed to load valid license", zap.String("error", err.Error()))
 		}
 		return nil, err
 	}
 
-	s.l.Info(
+	log.Info(
 		"Load valid license",
 		zap.String("plan", license.Plan.String()),
 		zap.Time("expiresAt", time.Unix(license.ExpiresTs, 0)),

--- a/server/task.go
+++ b/server/task.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 )
 
@@ -183,7 +184,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 					})
 					if err != nil {
 						// It's OK if we failed to trigger a check, just emit an error log
-						s.l.Error("Failed to trigger syntax check after changing task statement",
+						log.Error("Failed to trigger syntax check after changing task statement",
 							zap.Int("task_id", task.ID),
 							zap.String("task_name", task.Name),
 							zap.Error(err),
@@ -247,7 +248,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			})
 			if err != nil {
 				// It's OK if we failed to trigger a check, just emit an error log
-				s.l.Error("Failed to trigger timing check after changing task earliest allowed time",
+				log.Error("Failed to trigger timing check after changing task earliest allowed time",
 					zap.Int("task_id", task.ID),
 					zap.String("task_name", task.Name),
 					zap.Error(err),
@@ -361,7 +362,7 @@ func (s *Server) changeTaskStatus(ctx context.Context, task *api.Task, newStatus
 func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, taskStatusPatch *api.TaskStatusPatch) (_ *api.Task, err error) {
 	defer func() {
 		if err != nil {
-			s.l.Error("Failed to change task status.",
+			log.Error("Failed to change task status.",
 				zap.Int("id", task.ID),
 				zap.String("name", task.Name),
 				zap.String("old_status", string(task.Status)),
@@ -390,7 +391,7 @@ func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, 
 	}
 	// Not all pipelines belong to an issue, so it's OK if issue is not found.
 	if issue == nil {
-		s.l.Info("Pipeline has no linking issue",
+		log.Info("Pipeline has no linking issue",
 			zap.Int("pipelineID", task.PipelineID),
 			zap.String("task", task.Name))
 	}
@@ -490,7 +491,7 @@ func (s *Server) triggerDatabaseStatementAdviseTask(ctx context.Context, stateme
 
 	if err != nil {
 		// It's OK if we failed to find the schema review policy, just emit an error log
-		s.l.Error("Failed to found schema review policy id for task",
+		log.Error("Failed to found schema review policy id for task",
 			zap.Int("task_id", task.ID),
 			zap.String("task_name", task.Name),
 			zap.Int("environment_id", task.Instance.EnvironmentID),
@@ -518,7 +519,7 @@ func (s *Server) triggerDatabaseStatementAdviseTask(ctx context.Context, stateme
 		SkipIfAlreadyTerminated: false,
 	}); err != nil {
 		// It's OK if we failed to trigger a check, just emit an error log
-		s.l.Error("Failed to trigger statement advise task after changing task statement",
+		log.Error("Failed to trigger statement advise task after changing task statement",
 			zap.Int("task_id", task.ID),
 			zap.String("task_name", task.Name),
 			zap.Error(err),

--- a/server/task_check_executor_database_connect.go
+++ b/server/task_check_executor_database_connect.go
@@ -6,19 +6,15 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
-	"go.uber.org/zap"
 )
 
 // NewTaskCheckDatabaseConnectExecutor creates a task check database connect executor.
-func NewTaskCheckDatabaseConnectExecutor(logger *zap.Logger) TaskCheckExecutor {
-	return &TaskCheckDatabaseConnectExecutor{
-		l: logger,
-	}
+func NewTaskCheckDatabaseConnectExecutor() TaskCheckExecutor {
+	return &TaskCheckDatabaseConnectExecutor{}
 }
 
 // TaskCheckDatabaseConnectExecutor is the task check database connect executor.
 type TaskCheckDatabaseConnectExecutor struct {
-	l *zap.Logger
 }
 
 // Run will run the task check database connector executor once.
@@ -46,7 +42,7 @@ func (exec *TaskCheckDatabaseConnectExecutor) Run(ctx context.Context, server *S
 		return []api.TaskCheckResult{}, common.Errorf(common.Internal, fmt.Errorf("database ID not found %v", task.DatabaseID))
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, exec.l)
+	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name)
 	if err != nil {
 		return []api.TaskCheckResult{
 			{

--- a/server/task_check_executor_migration_schema.go
+++ b/server/task_check_executor_migration_schema.go
@@ -6,19 +6,15 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
-	"go.uber.org/zap"
 )
 
 // NewTaskCheckMigrationSchemaExecutor creates a task check migration schema executor.
-func NewTaskCheckMigrationSchemaExecutor(logger *zap.Logger) TaskCheckExecutor {
-	return &TaskCheckMigrationSchemaExecutor{
-		l: logger,
-	}
+func NewTaskCheckMigrationSchemaExecutor() TaskCheckExecutor {
+	return &TaskCheckMigrationSchemaExecutor{}
 }
 
 // TaskCheckMigrationSchemaExecutor is the task check migration schema executor.
 type TaskCheckMigrationSchemaExecutor struct {
-	l *zap.Logger
 }
 
 // Run will run the task check migration schema executor once.
@@ -43,7 +39,7 @@ func (exec *TaskCheckMigrationSchemaExecutor) Run(ctx context.Context, server *S
 		return []api.TaskCheckResult{}, err
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", exec.l)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "")
 	if err != nil {
 		return []api.TaskCheckResult{}, err
 	}

--- a/server/task_check_executor_statement_advisor_simple.go
+++ b/server/task_check_executor_statement_advisor_simple.go
@@ -8,19 +8,15 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/advisor"
-	"go.uber.org/zap"
 )
 
 // NewTaskCheckStatementAdvisorSimpleExecutor creates a task check statement simple advisor executor.
-func NewTaskCheckStatementAdvisorSimpleExecutor(logger *zap.Logger) TaskCheckExecutor {
-	return &TaskCheckStatementAdvisorSimpleExecutor{
-		l: logger,
-	}
+func NewTaskCheckStatementAdvisorSimpleExecutor() TaskCheckExecutor {
+	return &TaskCheckStatementAdvisorSimpleExecutor{}
 }
 
 // TaskCheckStatementAdvisorSimpleExecutor is the task check statement advisor simple executor.
 type TaskCheckStatementAdvisorSimpleExecutor struct {
-	l *zap.Logger
 }
 
 // Run will run the task check statement advisor executor once.
@@ -42,7 +38,6 @@ func (exec *TaskCheckStatementAdvisorSimpleExecutor) Run(ctx context.Context, se
 		payload.DbType,
 		advisorType,
 		advisor.Context{
-			Logger:    exec.l,
 			Charset:   payload.Charset,
 			Collation: payload.Collation,
 		},

--- a/server/task_check_executor_timing.go
+++ b/server/task_check_executor_timing.go
@@ -8,19 +8,15 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
-	"go.uber.org/zap"
 )
 
 // NewTaskCheckTimingExecutor creates a task check timing executor.
-func NewTaskCheckTimingExecutor(logger *zap.Logger) TaskCheckExecutor {
-	return &TaskCheckTimingExecutor{
-		l: logger,
-	}
+func NewTaskCheckTimingExecutor() TaskCheckExecutor {
+	return &TaskCheckTimingExecutor{}
 }
 
 // TaskCheckTimingExecutor is the task check timing executor.
 type TaskCheckTimingExecutor struct {
-	l *zap.Logger
 }
 
 const dataFormat = "2006-01-02 15:04:05"

--- a/server/task_executor_data_update.go
+++ b/server/task_executor_data_update.go
@@ -7,19 +7,15 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/plugin/db"
-	"go.uber.org/zap"
 )
 
 // NewDataUpdateTaskExecutor creates a data update (DML) task executor.
-func NewDataUpdateTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &SchemaUpdateTaskExecutor{
-		l: logger,
-	}
+func NewDataUpdateTaskExecutor() TaskExecutor {
+	return &SchemaUpdateTaskExecutor{}
 }
 
 // DataUpdateTaskExecutor is the data update (DML) task executor.
 type DataUpdateTaskExecutor struct {
-	l *zap.Logger
 }
 
 // RunOnce will run the data update (DML) task executor once.
@@ -29,5 +25,5 @@ func (exec *DataUpdateTaskExecutor) RunOnce(ctx context.Context, server *Server,
 		return true, nil, fmt.Errorf("invalid database data update payload: %w", err)
 	}
 
-	return runMigration(ctx, exec.l, server, task, db.Data, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
+	return runMigration(ctx, server, task, db.Data, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
 }

--- a/server/task_executor_database_backup.go
+++ b/server/task_executor_database_backup.go
@@ -8,19 +8,17 @@ import (
 	"path/filepath"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
 // NewDatabaseBackupTaskExecutor creates a new database backup task executor.
-func NewDatabaseBackupTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &DatabaseBackupTaskExecutor{
-		l: logger,
-	}
+func NewDatabaseBackupTaskExecutor() TaskExecutor {
+	return &DatabaseBackupTaskExecutor{}
 }
 
 // DatabaseBackupTaskExecutor is the task executor for database backup.
 type DatabaseBackupTaskExecutor struct {
-	l *zap.Logger
 }
 
 // RunOnce will run database backup once.
@@ -37,7 +35,7 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	if backup == nil {
 		return true, nil, fmt.Errorf("backup %v not found", payload.BackupID)
 	}
-	exec.l.Debug("Start database backup...",
+	log.Debug("Start database backup...",
 		zap.String("instance", task.Instance.Name),
 		zap.String("database", task.Database.Name),
 		zap.String("backup", backup.Name),
@@ -73,7 +71,7 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 
 // backupDatabase will take a backup of a database.
 func (exec *DatabaseBackupTaskExecutor) backupDatabase(ctx context.Context, instance *api.Instance, databaseName string, backup *api.Backup, dataDir string) (string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, exec.l)
+	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName)
 	if err != nil {
 		return "", err
 	}

--- a/server/task_executor_database_create.go
+++ b/server/task_executor_database_create.go
@@ -8,20 +8,18 @@ import (
 	"strings"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"go.uber.org/zap"
 )
 
 // NewDatabaseCreateTaskExecutor creates a database create task executor.
-func NewDatabaseCreateTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &DatabaseCreateTaskExecutor{
-		l: logger,
-	}
+func NewDatabaseCreateTaskExecutor() TaskExecutor {
+	return &DatabaseCreateTaskExecutor{}
 }
 
 // DatabaseCreateTaskExecutor is the database create task executor.
 type DatabaseCreateTaskExecutor struct {
-	l *zap.Logger
 }
 
 // RunOnce will run the database create task executor once.
@@ -37,13 +35,13 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	}
 
 	instance := task.Instance
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", exec.l)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "")
 	if err != nil {
 		return true, nil, err
 	}
 	defer driver.Close(ctx)
 
-	exec.l.Debug("Start creating database...",
+	log.Debug("Start creating database...",
 		zap.String("instance", instance.Name),
 		zap.String("database", payload.DatabaseName),
 		zap.String("statement", statement),
@@ -66,7 +64,7 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	if err != nil {
 		// If somehow we unable to find the principal, we just emit the error since it's not
 		// critical enough to fail the entire operation.
-		exec.l.Error("Failed to fetch creator for composing the migration info",
+		log.Error("Failed to fetch creator for composing the migration info",
 			zap.Int("task_id", task.ID),
 			zap.Error(err),
 		)
@@ -78,14 +76,14 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	if err != nil {
 		// If somehow we unable to find the issue, we just emit the error since it's not
 		// critical enough to fail the entire operation.
-		exec.l.Error("Failed to fetch containing issue for composing the migration info",
+		log.Error("Failed to fetch containing issue for composing the migration info",
 			zap.Int("task_id", task.ID),
 			zap.Error(err),
 		)
 	}
 	if issue == nil {
 		err := fmt.Errorf("failed to fetch containing issue for composing the migration info, issue not found with pipeline ID %v", task.PipelineID)
-		exec.l.Error(err.Error(),
+		log.Error(err.Error(),
 			zap.Int("task_id", task.ID),
 			zap.Error(err),
 		)

--- a/server/task_executor_default.go
+++ b/server/task_executor_default.go
@@ -5,24 +5,22 @@ import (
 	"fmt"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
 // NewDefaultTaskExecutor creates a default task executor.
-func NewDefaultTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &DefaultTaskExecutor{
-		l: logger,
-	}
+func NewDefaultTaskExecutor() TaskExecutor {
+	return &DefaultTaskExecutor{}
 }
 
 // DefaultTaskExecutor is the default task executor.
 type DefaultTaskExecutor struct {
-	l *zap.Logger
 }
 
 // RunOnce will run the default task executor once.
 func (exec *DefaultTaskExecutor) RunOnce(ctx context.Context, server *Server, task *api.Task) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	exec.l.Info("Run default task type", zap.String("task", task.Name))
+	log.Info("Run default task type", zap.String("task", task.Name))
 
 	return true, &api.TaskRunResultPayload{Detail: fmt.Sprintf("No-op task %s", task.Name)}, nil
 }

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common/log"
 	pluginmysql "github.com/bytebase/bytebase/plugin/db/mysql"
 	restoremysql "github.com/bytebase/bytebase/plugin/restore/mysql"
 	"github.com/bytebase/bytebase/resources/mysqlutil"
@@ -12,22 +13,21 @@ import (
 )
 
 // NewPITRCutoverTaskExecutor creates a PITR cutover task executor.
-func NewPITRCutoverTaskExecutor(logger *zap.Logger, instance *mysqlutil.Instance) TaskExecutor {
+func NewPITRCutoverTaskExecutor(instance *mysqlutil.Instance) TaskExecutor {
 	return &PITRCutoverTaskExecutor{
-		l:         logger,
+
 		mysqlutil: instance,
 	}
 }
 
 // PITRCutoverTaskExecutor is the PITR cutover task executor.
 type PITRCutoverTaskExecutor struct {
-	l         *zap.Logger
 	mysqlutil *mysqlutil.Instance
 }
 
 // RunOnce will run the PITR cutover task executor once.
 func (exec *PITRCutoverTaskExecutor) RunOnce(ctx context.Context, server *Server, task *api.Task) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	exec.l.Info("Run PITR cutover task", zap.String("task", task.Name))
+	log.Info("Run PITR cutover task", zap.String("task", task.Name))
 
 	// Currently api.TaskDatabasePITRCutoverPayload is empty, so we do not need to unmarshal from task.Payload.
 
@@ -35,31 +35,31 @@ func (exec *PITRCutoverTaskExecutor) RunOnce(ctx context.Context, server *Server
 }
 
 func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.Task, server *Server) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", exec.l)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "")
 	if err != nil {
 		return true, nil, err
 	}
 	defer driver.Close(ctx)
 
-	issue, err := getIssueByPipelineID(ctx, server.store, exec.l, task.PipelineID)
+	issue, err := getIssueByPipelineID(ctx, server.store, task.PipelineID)
 	if err != nil {
 		return true, nil, err
 	}
 
 	mysqlDriver, ok := driver.(*pluginmysql.Driver)
 	if !ok {
-		exec.l.Error("failed to cast driver to mysql.Driver", zap.Stack("stack"))
+		log.Error("failed to cast driver to mysql.Driver", zap.Stack("stack"))
 		return true, nil, fmt.Errorf("[internal] cast driver to mysql.Driver failed")
 	}
 	mysqlRestore := restoremysql.New(mysqlDriver, exec.mysqlutil)
 
-	exec.l.Info("Start swapping the original and PITR database",
+	log.Info("Start swapping the original and PITR database",
 		zap.String("instance", task.Instance.Name),
 		zap.String("original_database", task.Database.Name),
 	)
 	pitrDatabaseName, pitrOldDatabaseName, err := mysqlRestore.SwapPITRDatabase(ctx, task.Database.Name, issue.CreatedTs)
 	if err != nil {
-		exec.l.Error("failed to swap the original and PITR database",
+		log.Error("failed to swap the original and PITR database",
 			zap.Int("issueID", issue.ID),
 			zap.String("database", task.Database.Name),
 			zap.Stack("stack"),
@@ -67,7 +67,7 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 		return true, nil, fmt.Errorf("failed to swap the original and PITR database, error[%w]", err)
 	}
 
-	exec.l.Info("Finish swapping the original and PITR database",
+	log.Info("Finish swapping the original and PITR database",
 		zap.String("original_database", task.Database.Name),
 		zap.String("pitr_database", pitrDatabaseName),
 		zap.String("old_database", pitrOldDatabaseName))

--- a/server/task_executor_schema_update.go
+++ b/server/task_executor_schema_update.go
@@ -6,19 +6,15 @@ import (
 	"fmt"
 
 	"github.com/bytebase/bytebase/api"
-	"go.uber.org/zap"
 )
 
 // NewSchemaUpdateTaskExecutor creates a schema update (DDL) task executor.
-func NewSchemaUpdateTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &SchemaUpdateTaskExecutor{
-		l: logger,
-	}
+func NewSchemaUpdateTaskExecutor() TaskExecutor {
+	return &SchemaUpdateTaskExecutor{}
 }
 
 // SchemaUpdateTaskExecutor is the schema update (DDL) task executor.
 type SchemaUpdateTaskExecutor struct {
-	l *zap.Logger
 }
 
 // RunOnce will run the schema update (DDL) task executor once.
@@ -28,5 +24,5 @@ func (exec *SchemaUpdateTaskExecutor) RunOnce(ctx context.Context, server *Serve
 		return true, nil, fmt.Errorf("invalid database schema update payload: %w", err)
 	}
 
-	return runMigration(ctx, exec.l, server, task, payload.MigrationType, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
+	return runMigration(ctx, server, task, payload.MigrationType, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
 }

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -8,19 +8,15 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/api"
-	"go.uber.org/zap"
 )
 
 // NewSchemaUpdateGhostCutoverTaskExecutor creates a schema update (gh-ost) cutover task executor.
-func NewSchemaUpdateGhostCutoverTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &SchemaUpdateGhostCutoverTaskExecutor{
-		l: logger,
-	}
+func NewSchemaUpdateGhostCutoverTaskExecutor() TaskExecutor {
+	return &SchemaUpdateGhostCutoverTaskExecutor{}
 }
 
 // SchemaUpdateGhostCutoverTaskExecutor is the schema update (gh-ost) cutover task executor.
 type SchemaUpdateGhostCutoverTaskExecutor struct {
-	l *zap.Logger
 }
 
 // RunOnce will run SchemaUpdateGhostCutover task once.

--- a/server/task_executor_schema_update_ghost_drop_original_table.go
+++ b/server/task_executor_schema_update_ghost_drop_original_table.go
@@ -4,19 +4,15 @@ import (
 	"context"
 
 	"github.com/bytebase/bytebase/api"
-	"go.uber.org/zap"
 )
 
 // NewSchemaUpdateGhostDropOriginalTableTaskExecutor creates a schema update (gh-ost) drop original table task executor.
-func NewSchemaUpdateGhostDropOriginalTableTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &SchemaUpdateGhostDropOriginalTableTaskExecutor{
-		l: logger,
-	}
+func NewSchemaUpdateGhostDropOriginalTableTaskExecutor() TaskExecutor {
+	return &SchemaUpdateGhostDropOriginalTableTaskExecutor{}
 }
 
 // SchemaUpdateGhostDropOriginalTableTaskExecutor is the schema update (gh-ost) drop original table task executor.
 type SchemaUpdateGhostDropOriginalTableTaskExecutor struct {
-	l *zap.Logger //nolint
 }
 
 // RunOnce will run SchemaUpdateGhostDropOriginalTable task once.

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
@@ -23,15 +24,12 @@ import (
 )
 
 // NewSchemaUpdateGhostSyncTaskExecutor creates a schema update (gh-ost) sync task executor.
-func NewSchemaUpdateGhostSyncTaskExecutor(logger *zap.Logger) TaskExecutor {
-	return &SchemaUpdateGhostSyncTaskExecutor{
-		l: logger,
-	}
+func NewSchemaUpdateGhostSyncTaskExecutor() TaskExecutor {
+	return &SchemaUpdateGhostSyncTaskExecutor{}
 }
 
 // SchemaUpdateGhostSyncTaskExecutor is the schema update (gh-ost) sync task executor.
 type SchemaUpdateGhostSyncTaskExecutor struct {
-	l *zap.Logger
 }
 
 // RunOnce will run SchemaUpdateGhostSync task once.
@@ -40,7 +38,7 @@ func (exec *SchemaUpdateGhostSyncTaskExecutor) RunOnce(ctx context.Context, serv
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
 		return true, nil, fmt.Errorf("invalid database schema update gh-ost sync payload: %w", err)
 	}
-	return runGhostMigration(ctx, exec.l, server, task, db.Migrate, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
+	return runGhostMigration(ctx, server, task, db.Migrate, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
 }
 
 func getSocketFilename(taskID int, databaseID int, databaseName string, tableName string) string {
@@ -156,8 +154,8 @@ func newMigrationContext(config ghostConfig) (*base.MigrationContext, error) {
 	return migrationContext, nil
 }
 
-func runGhostMigration(ctx context.Context, l *zap.Logger, server *Server, task *api.Task, migrationType db.MigrationType, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	mi, err := preMigration(ctx, l, server, task, migrationType, statement, schemaVersion, vcsPushEvent)
+func runGhostMigration(ctx context.Context, server *Server, task *api.Task, migrationType db.MigrationType, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent) (terminated bool, result *api.TaskRunResultPayload, err error) {
+	mi, err := preMigration(ctx, server, task, migrationType, statement, schemaVersion, vcsPushEvent)
 	if err != nil {
 		return true, nil, err
 	}
@@ -166,14 +164,14 @@ func runGhostMigration(ctx context.Context, l *zap.Logger, server *Server, task 
 	waitSync.Add(1)
 
 	go func(waitSync *sync.WaitGroup) {
-		migrationID, schema, err := executeSync(ctx, l, task, mi, statement, waitSync)
+		migrationID, schema, err := executeSync(ctx, task, mi, statement, waitSync)
 		if err != nil {
-			l.Error("failed to execute schema update gh-ost sync executeSync", zap.Error(err))
+			log.Error("failed to execute schema update gh-ost sync executeSync", zap.Error(err))
 			return
 		}
-		_, _, err = postMigration(ctx, l, server, task, vcsPushEvent, mi, migrationID, schema)
+		_, _, err = postMigration(ctx, server, task, vcsPushEvent, mi, migrationID, schema)
 		if err != nil {
-			l.Error("failed to execute schema update gh-ost sync postMigration", zap.Error(err))
+			log.Error("failed to execute schema update gh-ost sync postMigration", zap.Error(err))
 		}
 	}(waitSync)
 
@@ -182,10 +180,10 @@ func runGhostMigration(ctx context.Context, l *zap.Logger, server *Server, task 
 	return true, &api.TaskRunResultPayload{Detail: "sync done"}, nil
 }
 
-func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.MigrationInfo, statement string, waitSync *sync.WaitGroup) (migrationHistoryID int64, updatedSchema string, resErr error) {
+func executeSync(ctx context.Context, task *api.Task, mi *db.MigrationInfo, statement string, waitSync *sync.WaitGroup) (migrationHistoryID int64, updatedSchema string, resErr error) {
 	statement = strings.TrimSpace(statement)
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, l)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name)
 	if err != nil {
 		return -1, "", err
 	}
@@ -212,14 +210,14 @@ func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.Migr
 	startedNs := time.Now().UnixNano()
 
 	defer func() {
-		if err := util.EndMigration(ctx, l, executor, startedNs, insertedID, updatedSchema, db.BytebaseDatabase, resErr == nil /*isDone*/); err != nil {
-			l.Error("failed to update migration history record",
+		if err := util.EndMigration(ctx, executor, startedNs, insertedID, updatedSchema, db.BytebaseDatabase, resErr == nil /*isDone*/); err != nil {
+			log.Error("failed to update migration history record",
 				zap.Error(err),
 				zap.Int64("migration_id", migrationHistoryID),
 			)
 		}
 	}()
-	if err = executeGhost(l, task, startedNs, statement, waitSync); err != nil {
+	if err = executeGhost(task, startedNs, statement, waitSync); err != nil {
 		return -1, "", err
 	}
 
@@ -231,7 +229,7 @@ func executeSync(ctx context.Context, l *zap.Logger, task *api.Task, mi *db.Migr
 	return insertedID, afterSchemaBuf.String(), nil
 }
 
-func executeGhost(l *zap.Logger, task *api.Task, startedNs int64, statement string, waitSync *sync.WaitGroup) error {
+func executeGhost(task *api.Task, startedNs int64, statement string, waitSync *sync.WaitGroup) error {
 	instance := task.Instance
 	databaseName := task.Database.Name
 
@@ -269,7 +267,7 @@ func executeGhost(l *zap.Logger, task *api.Task, startedNs int64, statement stri
 	defer cancel()
 	migrator := logic.NewMigrator(migrationContext)
 
-	go func(ctx context.Context, migrationContext *base.MigrationContext, l *zap.Logger, waitSync *sync.WaitGroup) {
+	go func(ctx context.Context, migrationContext *base.MigrationContext, waitSync *sync.WaitGroup) {
 		ticker := time.NewTicker(1 * time.Second)
 		defer waitSync.Done()
 		for {
@@ -283,7 +281,7 @@ func executeGhost(l *zap.Logger, task *api.Task, startedNs int64, statement stri
 				return
 			}
 		}
-	}(ctx, migrationContext, l, waitSync)
+	}(ctx, migrationContext, waitSync)
 
 	if err = migrator.Migrate(); err != nil {
 		return fmt.Errorf("failed to run gh-ost, error: %w", err)

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
+
 	"go.uber.org/zap"
 )
 
@@ -19,9 +21,8 @@ const (
 )
 
 // NewTaskScheduler creates a new task scheduler.
-func NewTaskScheduler(logger *zap.Logger, server *Server) *TaskScheduler {
+func NewTaskScheduler(server *Server) *TaskScheduler {
 	return &TaskScheduler{
-		l:         logger,
 		executors: make(map[string]TaskExecutor),
 		server:    server,
 	}
@@ -29,7 +30,6 @@ func NewTaskScheduler(logger *zap.Logger, server *Server) *TaskScheduler {
 
 // TaskScheduler is the task scheduler.
 type TaskScheduler struct {
-	l         *zap.Logger
 	executors map[string]TaskExecutor
 
 	server *Server
@@ -40,7 +40,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 	ticker := time.NewTicker(taskSchedulerInterval)
 	defer ticker.Stop()
 	defer wg.Done()
-	s.l.Debug(fmt.Sprintf("Task scheduler started and will run every %v", taskSchedulerInterval))
+	log.Debug(fmt.Sprintf("Task scheduler started and will run every %v", taskSchedulerInterval))
 	tasks := struct {
 		running map[int]bool // task id set
 		mu      sync.RWMutex
@@ -58,7 +58,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 						if !ok {
 							err = fmt.Errorf("%v", r)
 						}
-						s.l.Error("Task scheduler PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
+						log.Error("Task scheduler PANIC RECOVER", zap.Error(err), zap.Stack("stack"))
 					}
 				}()
 
@@ -71,7 +71,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 				}
 				pipelineList, err := s.server.store.FindPipeline(ctx, pipelineFind, false)
 				if err != nil {
-					s.l.Error("Failed to retrieve open pipelines", zap.Error(err))
+					log.Error("Failed to retrieve open pipelines", zap.Error(err))
 					return
 				}
 				for _, pipeline := range pipelineList {
@@ -80,7 +80,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 					}
 
 					if _, err := s.server.ScheduleNextTaskIfNeeded(ctx, pipeline); err != nil {
-						s.l.Error("Failed to schedule next running task",
+						log.Error("Failed to schedule next running task",
 							zap.Int("pipeline_id", pipeline.ID),
 							zap.Error(err),
 						)
@@ -96,7 +96,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 				// We may optimize this in the future since only some relationship info is needed by the executor
 				taskList, err := s.server.store.FindTask(ctx, taskFind, false)
 				if err != nil {
-					s.l.Error("Failed to retrieve running tasks", zap.Error(err))
+					log.Error("Failed to retrieve running tasks", zap.Error(err))
 					return
 				}
 
@@ -107,7 +107,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 					executor, ok := s.executors[string(task.Type)]
 					if !ok {
-						s.l.Error("Skip running task with unknown type",
+						log.Error("Skip running task with unknown type",
 							zap.Int("id", task.ID),
 							zap.String("name", task.Name),
 							zap.String("type", string(task.Type)),
@@ -118,7 +118,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 					// Skip execution if has any dependency not finished.
 					isBlocked, err := s.isTaskBlocked(ctx, task)
 					if err != nil {
-						s.l.Error("failed to check if task is blocked",
+						log.Error("failed to check if task is blocked",
 							zap.Int("id", task.ID),
 							zap.Error(err))
 						continue
@@ -141,12 +141,12 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 							delete(tasks.running, task.ID)
 							tasks.mu.Unlock()
 						}()
-						done, result, err := RunTaskExecutorOnce(ctx, s.l, executor, s.server, task)
+						done, result, err := RunTaskExecutorOnce(ctx, executor, s.server, task)
 						if done {
 							if err == nil {
 								bytes, err := json.Marshal(*result)
 								if err != nil {
-									s.l.Error("Failed to marshal task run result",
+									log.Error("Failed to marshal task run result",
 										zap.Int("task_id", task.ID),
 										zap.String("type", string(task.Type)),
 										zap.Error(err),
@@ -164,14 +164,14 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 								}
 								_, err = s.server.changeTaskStatusWithPatch(ctx, task, taskStatusPatch)
 								if err != nil {
-									s.l.Error("Failed to mark task as DONE",
+									log.Error("Failed to mark task as DONE",
 										zap.Int("id", task.ID),
 										zap.String("name", task.Name),
 										zap.Error(err),
 									)
 								}
 							} else {
-								s.l.Debug("Failed to run task",
+								log.Debug("Failed to run task",
 									zap.Int("id", task.ID),
 									zap.String("name", task.Name),
 									zap.String("type", string(task.Type)),
@@ -181,7 +181,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 									Detail: err.Error(),
 								})
 								if marshalErr != nil {
-									s.l.Error("Failed to marshal task run result",
+									log.Error("Failed to marshal task run result",
 										zap.Int("task_id", task.ID),
 										zap.String("type", string(task.Type)),
 										zap.Error(marshalErr),
@@ -199,7 +199,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 								}
 								_, err = s.server.changeTaskStatusWithPatch(ctx, task, taskStatusPatch)
 								if err != nil {
-									s.l.Error("Failed to mark task as FAILED",
+									log.Error("Failed to mark task as FAILED",
 										zap.Int("id", task.ID),
 										zap.String("name", task.Name),
 										zap.Error(err),
@@ -207,7 +207,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 								}
 							}
 						} else if err != nil {
-							s.l.Debug("Encountered transient error running task, will retry",
+							log.Debug("Encountered transient error running task, will retry",
 								zap.Int("id", task.ID),
 								zap.String("name", task.Name),
 								zap.String("type", string(task.Type)),

--- a/server/vcs.go
+++ b/server/vcs.go
@@ -25,7 +25,7 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 		}
 		// Trim ending "/"
 		vcsCreate.InstanceURL = strings.TrimRight(vcsCreate.InstanceURL, "/")
-		vcsCreate.APIURL = vcs.Get(vcsCreate.Type, vcs.ProviderConfig{Logger: s.l}).APIURL(vcsCreate.InstanceURL)
+		vcsCreate.APIURL = vcs.Get(vcsCreate.Type, vcs.ProviderConfig{}).APIURL(vcsCreate.InstanceURL)
 
 		vcs, err := s.store.CreateVCS(ctx, vcsCreate)
 		if err != nil {
@@ -162,7 +162,7 @@ func (s *Server) registerVCSRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Failed to find VCS, ID: %v", id))
 		}
 
-		repoList, err := vcs.Get(vcsFound.Type, vcs.ProviderConfig{Logger: s.l}).FetchAllRepositoryList(
+		repoList, err := vcs.Get(vcsFound.Type, vcs.ProviderConfig{}).FetchAllRepositoryList(
 			ctx,
 			common.OauthContext{
 				ClientID:     vcsFound.ApplicationID,

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	dbdriver "github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/resources/postgres"
 	"go.uber.org/zap"
@@ -14,7 +15,6 @@ import (
 
 // MetadataDB abstracts the underlying Postgres instance
 type MetadataDB struct {
-	l           *zap.Logger
 	mode        common.ReleaseMode
 	demoDataDir string
 
@@ -29,9 +29,8 @@ type MetadataDB struct {
 }
 
 // NewMetadataDBWithEmbedPg install postgres in `datadir` returns an instance of MetadataDB
-func NewMetadataDBWithEmbedPg(logger *zap.Logger, pgUser, dataDir, demoDataDir string, mode common.ReleaseMode) (*MetadataDB, error) {
+func NewMetadataDBWithEmbedPg(pgUser, dataDir, demoDataDir string, mode common.ReleaseMode) (*MetadataDB, error) {
 	mgr := &MetadataDB{
-		l:           logger,
 		mode:        mode,
 		demoDataDir: demoDataDir,
 		embed:       true,
@@ -39,12 +38,12 @@ func NewMetadataDBWithEmbedPg(logger *zap.Logger, pgUser, dataDir, demoDataDir s
 	}
 	resourceDir := common.GetResourceDir(dataDir)
 	pgDataDir := common.GetPostgresDataDir(dataDir)
-	logger.Info("-----Embedded Postgres Config BEGIN-----")
-	logger.Info(fmt.Sprintf("resourceDir=%s\n", resourceDir))
-	logger.Info(fmt.Sprintf("pgdataDir=%s\n", pgDataDir))
-	logger.Info("-----Embedded Postgres Config END-----")
+	log.Info("-----Embedded Postgres Config BEGIN-----")
+	log.Info(fmt.Sprintf("resourceDir=%s\n", resourceDir))
+	log.Info(fmt.Sprintf("pgdataDir=%s\n", pgDataDir))
+	log.Info("-----Embedded Postgres Config END-----")
 
-	logger.Info("Preparing embedded PostgreSQL instance...")
+	log.Info("Preparing embedded PostgreSQL instance...")
 	// Installs the Postgres binary and creates the 'activeProfile.pgUser' user/database
 	// to store Bytebase's own metadata.
 	var err error
@@ -57,9 +56,8 @@ func NewMetadataDBWithEmbedPg(logger *zap.Logger, pgUser, dataDir, demoDataDir s
 }
 
 // NewMetadataDBWithExternalPg constructs a new MetadataDB instance pointing to an external Postgres instance
-func NewMetadataDBWithExternalPg(logger *zap.Logger, pgURL, demoDataDir string, mode common.ReleaseMode) (*MetadataDB, error) {
+func NewMetadataDBWithExternalPg(pgURL, demoDataDir string, mode common.ReleaseMode) (*MetadataDB, error) {
 	return &MetadataDB{
-		l:           logger,
 		mode:        mode,
 		demoDataDir: demoDataDir,
 		embed:       false,
@@ -92,7 +90,7 @@ func (m *MetadataDB) connectEmbed(datastorePort int, pgUser string, readonly boo
 		Port:        fmt.Sprintf("%d", datastorePort),
 		StrictUseDb: false,
 	}
-	db := NewDB(m.l, connCfg, demoDataDir, readonly, version, mode)
+	db := NewDB(connCfg, demoDataDir, readonly, version, mode)
 	return db, nil
 }
 
@@ -105,7 +103,7 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 
 	q := u.Query()
 
-	m.l.Info("Establishing external PostgreSQL connection...", zap.String("pgURL", u.Redacted()))
+	log.Info("Establishing external PostgreSQL connection...", zap.String("pgURL", u.Redacted()))
 
 	if u.Scheme != "postgresql" {
 		return nil, fmt.Errorf("invalid connection protocol: %s", u.Scheme)
@@ -158,7 +156,7 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 		SslCert: q.Get("sslcert"),
 	}
 
-	db := NewDB(m.l, connCfg, m.demoDataDir, readonly, version, m.mode)
+	db := NewDB(connCfg, m.demoDataDir, readonly, version, m.mode)
 	return db, nil
 }
 
@@ -168,7 +166,7 @@ func (m *MetadataDB) Close() error {
 		return nil
 	}
 
-	m.l.Info("Trying to shutdown postgresql server...")
+	log.Info("Trying to shutdown postgresql server...")
 	if err := m.pgInstance.Stop(os.Stdout, os.Stderr); err != nil {
 		return err
 	}

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/bytebase/bytebase/common/log"
 	dbdriver "github.com/bytebase/bytebase/plugin/db"
 	"github.com/pkg/errors"
 
@@ -20,7 +21,6 @@ import (
 	_ "github.com/bytebase/bytebase/plugin/db/pg"
 
 	"github.com/bytebase/bytebase/common"
-	"go.uber.org/zap"
 )
 
 const (
@@ -56,8 +56,6 @@ var demoFS embed.FS
 type DB struct {
 	db *sql.DB
 
-	l *zap.Logger
-
 	// db.connCfg is the connection configuration to a Postgres database.
 	// The user has superuser privilege to the database.
 	connCfg dbdriver.ConnectionConfig
@@ -80,9 +78,8 @@ type DB struct {
 }
 
 // NewDB returns a new instance of DB associated with the given datasource name.
-func NewDB(logger *zap.Logger, connCfg dbdriver.ConnectionConfig, demoDataDir string, readonly bool, serverVersion string, mode common.ReleaseMode) *DB {
+func NewDB(connCfg dbdriver.ConnectionConfig, demoDataDir string, readonly bool, serverVersion string, mode common.ReleaseMode) *DB {
 	db := &DB{
-		l:             logger,
 		connCfg:       connCfg,
 		demoDataDir:   demoDataDir,
 		readonly:      readonly,
@@ -98,7 +95,7 @@ func (db *DB) Open(ctx context.Context) (err error) {
 	d, err := dbdriver.Open(
 		ctx,
 		dbdriver.Postgres,
-		dbdriver.DriverConfig{Logger: db.l},
+		dbdriver.DriverConfig{},
 		db.connCfg,
 		dbdriver.ConnectionContext{},
 	)
@@ -114,7 +111,7 @@ func (db *DB) Open(ctx context.Context) (err error) {
 	}
 
 	if db.readonly {
-		db.l.Info("Database is opened in readonly mode. Skip migration and demo data setup.")
+		log.Info("Database is opened in readonly mode. Skip migration and demo data setup.")
 		// The database storing metadata is the same as user name.
 		db.db, err = d.GetDbConnection(ctx, databaseName)
 		if err != nil {
@@ -137,7 +134,7 @@ func (db *DB) Open(ctx context.Context) (err error) {
 			if !strings.Contains(err.Error(), "invalid stored version") {
 				return err
 			}
-			db.l.Info("Migrating migration history version storage format to semantic version.")
+			log.Info("Migrating migration history version storage format to semantic version.")
 			db, err := d.GetDbConnection(ctx, "bytebase")
 			if err != nil {
 				return err
@@ -162,7 +159,7 @@ func (db *DB) Open(ctx context.Context) (err error) {
 		return fmt.Errorf("failed to get current schema version: %w", err)
 	}
 
-	if err := migrate(ctx, d, verBefore, db.mode, db.connCfg.StrictUseDb, db.serverVersion, databaseName, db.l); err != nil {
+	if err := migrate(ctx, d, verBefore, db.mode, db.connCfg.StrictUseDb, db.serverVersion, databaseName); err != nil {
 		return fmt.Errorf("failed to migrate: %w", err)
 	}
 
@@ -170,7 +167,7 @@ func (db *DB) Open(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to get current schema version: %w", err)
 	}
-	db.l.Info(fmt.Sprintf("Current schema version after migration: %s", verAfter))
+	log.Info(fmt.Sprintf("Current schema version after migration: %s", verAfter))
 
 	db.db, err = d.GetDbConnection(ctx, databaseName)
 	if err != nil {
@@ -215,10 +212,10 @@ func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (
 // setupDemoData loads the setupDemoData data for testing
 func (db *DB) setupDemoData() error {
 	if db.demoDataDir == "" {
-		db.l.Debug("Skip setting up demo data. Demo data directory not specified.")
+		log.Debug("Skip setting up demo data. Demo data directory not specified.")
 		return nil
 	}
-	db.l.Info(fmt.Sprintf("Setting up demo data from %q...", db.demoDataDir))
+	log.Info(fmt.Sprintf("Setting up demo data from %q...", db.demoDataDir))
 	names, err := fs.Glob(demoFS, fmt.Sprintf("%s/*.sql", db.demoDataDir))
 	if err != nil {
 		return err
@@ -236,13 +233,13 @@ func (db *DB) setupDemoData() error {
 			return fmt.Errorf("applyDataFile error: name=%q err=%w", name, err)
 		}
 	}
-	db.l.Info("Completed demo data setup.")
+	log.Info("Completed demo data setup.")
 	return nil
 }
 
 // applyDataFile runs a single demo data file within a transaction.
 func (db *DB) applyDataFile(name string) error {
-	db.l.Info(fmt.Sprintf("Applying data file %s...", name))
+	log.Info(fmt.Sprintf("Applying data file %s...", name))
 	tx, err := db.db.Begin()
 	if err != nil {
 		return err
@@ -273,12 +270,12 @@ const (
 // file run in a transaction to prevent partial migrations.
 //
 // The procedure follows https://github.com/bytebase/bytebase/blob/main/docs/schema-update-guide.md.
-func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mode common.ReleaseMode, strictDb bool, serverVersion, databaseName string, l *zap.Logger) error {
-	l.Info("Apply database migration if needed...")
+func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mode common.ReleaseMode, strictDb bool, serverVersion, databaseName string) error {
+	log.Info("Apply database migration if needed...")
 	if curVer == nil {
-		l.Info("The database schema has not been setup.")
+		log.Info("The database schema has not been setup.")
 	} else {
-		l.Info(fmt.Sprintf("Current schema version before migration: %s", curVer))
+		log.Info(fmt.Sprintf("Current schema version before migration: %s", curVer))
 		major := curVer.Major
 		if major != majorSchemaVersion {
 			return fmt.Errorf("current major schema version %d is different from the major schema version %d this release %s expects", major, majorSchemaVersion, serverVersion)
@@ -290,7 +287,7 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 	if err != nil {
 		return errors.Wrapf(err, "failed to get cutoff version")
 	}
-	l.Info(fmt.Sprintf("The prod cutoff schema version: %s", cutoffSchemaVersion))
+	log.Info(fmt.Sprintf("The prod cutoff schema version: %s", cutoffSchemaVersion))
 
 	var histories []*dbdriver.MigrationHistory
 	// Because dev migrations don't use semantic versioning, we have to look at all migration history to
@@ -346,7 +343,7 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 		); err != nil {
 			return fmt.Errorf("failed to migrate initial schema version %q, error: %v", latestSchemaPath, err)
 		}
-		l.Info(fmt.Sprintf("Completed database initial migration with version %s.", cutoffSchemaVersion))
+		log.Info(fmt.Sprintf("Completed database initial migration with version %s.", cutoffSchemaVersion))
 	} else {
 		// Apply migrations if needed.
 		retVersion := *curVer
@@ -360,11 +357,11 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 			return err
 		}
 		for _, message := range messages {
-			l.Info(message)
+			log.Info(message)
 		}
 
 		for _, minorVersion := range minorVersions {
-			l.Info(fmt.Sprintf("Starting minor version migration cycle from %s ...", minorVersion))
+			log.Info(fmt.Sprintf("Starting minor version migration cycle from %s ...", minorVersion))
 			names, err := fs.Glob(migrationFS, fmt.Sprintf("migration/%s/%d.%d/*.sql", common.ReleaseModeProd, minorVersion.Major, minorVersion.Minor))
 			if err != nil {
 				return err
@@ -385,10 +382,10 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 				//   after - prod 1.3 with 123.sql; dev: something else.
 				// When dev starts, it will try to apply version 1.3 including 123.sql. If we don't skip, the same statement will be re-applied and most likely to fail.
 				if mode == common.ReleaseModeDev && migrationExists(string(buf), histories) {
-					l.Info(fmt.Sprintf("Skip migrating migration file %s that's already migrated.", pv.filename))
+					log.Info(fmt.Sprintf("Skip migrating migration file %s that's already migrated.", pv.filename))
 					continue
 				}
-				l.Info(fmt.Sprintf("Migrating %s...", pv.version))
+				log.Info(fmt.Sprintf("Migrating %s...", pv.version))
 				if _, _, err := d.ExecuteMigration(
 					ctx,
 					&dbdriver.MigrationInfo{
@@ -411,14 +408,14 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 			}
 		}
 		if retVersion.EQ(*curVer) {
-			l.Info(fmt.Sprintf("Database schema is at version %s; nothing to migrate.", *curVer))
+			log.Info(fmt.Sprintf("Database schema is at version %s; nothing to migrate.", *curVer))
 		} else {
-			l.Info(fmt.Sprintf("Completed database migration from version %s to %s.", *curVer, retVersion))
+			log.Info(fmt.Sprintf("Completed database migration from version %s to %s.", *curVer, retVersion))
 		}
 	}
 
 	if mode == common.ReleaseModeDev {
-		if err := migrateDev(ctx, d, serverVersion, databaseName, cutoffSchemaVersion, histories, l); err != nil {
+		if err := migrateDev(ctx, d, serverVersion, databaseName, cutoffSchemaVersion, histories); err != nil {
 			return errors.Wrapf(err, "failed to migrate dev schema")
 		}
 	}
@@ -456,7 +453,7 @@ func getProdCutoffVersion() (semver.Version, error) {
 	return patchVersions[len(patchVersions)-1].version, nil
 }
 
-func migrateDev(ctx context.Context, d dbdriver.Driver, serverVersion, databaseName string, cutoffSchemaVersion semver.Version, histories []*dbdriver.MigrationHistory, l *zap.Logger) error {
+func migrateDev(ctx context.Context, d dbdriver.Driver, serverVersion, databaseName string, cutoffSchemaVersion semver.Version, histories []*dbdriver.MigrationHistory) error {
 	devMigrations, err := getDevMigrations()
 	if err != nil {
 		return err
@@ -466,18 +463,18 @@ func migrateDev(ctx context.Context, d dbdriver.Driver, serverVersion, databaseN
 	// Skip migrations that are already applied, otherwise the migration reattempt will most likely to fail with already exists error.
 	for _, m := range devMigrations {
 		if migrationExists(m.statement, histories) {
-			l.Info(fmt.Sprintf("Skip migrating dev migration file %s that's already migrated.", m.filename))
+			log.Info(fmt.Sprintf("Skip migrating dev migration file %s that's already migrated.", m.filename))
 		} else {
 			migrations = append(migrations, m)
 		}
 	}
 	if len(migrations) == 0 {
-		l.Info("Skip dev mode migration; no new version.")
+		log.Info("Skip dev mode migration; no new version.")
 		return nil
 	}
 
 	for _, m := range migrations {
-		l.Info(fmt.Sprintf("Migrating dev %s...", m.filename))
+		log.Info(fmt.Sprintf("Migrating dev %s...", m.filename))
 		// We expect to use semantic versioning for dev environment too because getLatestVersion() always expect to get the latest version in semantic format.
 		if _, _, err := d.ExecuteMigration(
 			ctx,

--- a/store/pg_engine_test.go
+++ b/store/pg_engine_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	dbdriver "github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/resources/postgres"
 	"github.com/stretchr/testify/require"
@@ -141,6 +142,7 @@ var (
 )
 
 func TestMigrationCompatibility(t *testing.T) {
+	log.MustInitialize(true)
 	pgDir := t.TempDir()
 	pgInstance, err := postgres.Install(path.Join(pgDir, "resource"), path.Join(pgDir, "data"), pgUser)
 	require.NoError(t, err)

--- a/store/pg_engine_test.go
+++ b/store/pg_engine_test.go
@@ -13,6 +13,7 @@ import (
 	dbdriver "github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/resources/postgres"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestGetMinorMigrationVersions(t *testing.T) {
@@ -142,7 +143,8 @@ var (
 )
 
 func TestMigrationCompatibility(t *testing.T) {
-	log.MustInitialize(true)
+	log.Init()
+	log.SetLevel(zap.DebugLevel)
 	pgDir := t.TempDir()
 	pgInstance, err := postgres.Install(path.Join(pgDir, "resource"), path.Join(pgDir, "data"), pgUser)
 	require.NoError(t, err)

--- a/store/pipeline.go
+++ b/store/pipeline.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
@@ -88,7 +89,7 @@ func (s *Store) FindPipeline(ctx context.Context, find *api.PipelineFind, return
 			if returnOnErr {
 				return nil, fmt.Errorf("failed to compose Pipeline with pipelineRaw[%+v], error[%w]", raw, err)
 			}
-			s.l.Error("failed to compose pipeline",
+			log.Error("failed to compose pipeline",
 				zap.Any("pipelineRaw", raw),
 				zap.Error(err),
 			)

--- a/store/principal.go
+++ b/store/principal.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
@@ -255,7 +256,7 @@ func (s *Store) composePrincipal(ctx context.Context, raw *principalRaw) (*api.P
 			return nil, err
 		}
 		if memberRaw == nil {
-			s.l.Error("Principal has not been assigned a role.",
+			log.Error("Principal has not been assigned a role.",
 				zap.Int("id", principal.ID),
 				zap.String("name", principal.Name),
 			)

--- a/store/store.go
+++ b/store/store.go
@@ -2,20 +2,17 @@ package store
 
 import (
 	"github.com/bytebase/bytebase/api"
-	"go.uber.org/zap"
 )
 
 // Store provides database access to all raw objects
 type Store struct {
-	l     *zap.Logger
 	db    *DB
 	cache api.CacheService
 }
 
 // New creates a new instance of Store
-func New(l *zap.Logger, db *DB, cache api.CacheService) *Store {
+func New(db *DB, cache api.CacheService) *Store {
 	return &Store{
-		l:     l,
 		db:    db,
 		cache: cache,
 	}

--- a/store/task.go
+++ b/store/task.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/metric"
 	"go.uber.org/zap"
 )
@@ -122,7 +123,7 @@ func (s *Store) FindTask(ctx context.Context, find *api.TaskFind, returnOnErr bo
 			if returnOnErr {
 				return nil, fmt.Errorf("failed to compose Task with taskRaw[%+v], error[%w]", raw, err)
 			}
-			s.l.Error("failed to compose Task",
+			log.Error("failed to compose Task",
 				zap.Any("taskRaw", raw),
 				zap.Error(err))
 			continue

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
 
@@ -167,7 +168,7 @@ func (s *Store) createTaskCheckRunRawIfNeeded(ctx context.Context, create *api.T
 	if runningCount > 0 {
 		if runningCount > 1 {
 			// Normally, this should not happen, if it occurs, emit a warning
-			s.l.Warn(fmt.Sprintf("Found %d task check run, expect at most 1", len(taskCheckRunList)),
+			log.Warn(fmt.Sprintf("Found %d task check run, expect at most 1", len(taskCheckRunList)),
 				zap.Int("task_id", create.TaskID),
 				zap.String("task_check_type", string(create.Type)),
 			)

--- a/tests/mysql.go
+++ b/tests/mysql.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 
 	dbplugin "github.com/bytebase/bytebase/plugin/db"
-
-	"go.uber.org/zap"
 )
 
 // connectTestMySQL connects to the test mysql instance.
@@ -22,14 +20,10 @@ func connectTestMySQL(port int, database string) (*sql.DB, error) {
 }
 
 func getTestMySQLDriver(ctx context.Context, port, database string) (dbplugin.Driver, error) {
-	logger, err := zap.NewDevelopment()
-	if err != nil {
-		return nil, err
-	}
 	return dbplugin.Open(
 		ctx,
 		dbplugin.MySQL,
-		dbplugin.DriverConfig{Logger: logger},
+		dbplugin.DriverConfig{},
 		dbplugin.ConnectionConfig{
 			Host:      "localhost",
 			Port:      port,

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bytebase/bytebase/server"
 	"github.com/bytebase/bytebase/tests/fake"
 	"github.com/google/jsonapi"
+	"go.uber.org/zap"
 )
 
 //go:embed fake
@@ -140,7 +141,8 @@ func getTestPort(testName string) int {
 
 // StartServerWithExternalPg starts the main server with external Postgres.
 func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir string, port int, pgUser, pgURL string) error {
-	log.MustInitialize(true)
+	log.Init()
+	log.SetLevel(zap.DebugLevel)
 	profile := cmd.GetTestProfileWithExternalPg(dataDir, port, pgUser, pgURL)
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {
@@ -154,7 +156,8 @@ func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir st
 // StartServer starts the main server with embed Postgres.
 func (ctl *controller) StartServer(ctx context.Context, dataDir string, port int) error {
 	// start main server.
-	log.MustInitialize(true)
+	log.Init()
+	log.SetLevel(zap.DebugLevel)
 	profile := cmd.GetTestProfile(dataDir, port)
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/bin/server/cmd"
+	"github.com/bytebase/bytebase/common/log"
 	enterpriseAPI "github.com/bytebase/bytebase/enterprise/api"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/server"
@@ -139,6 +140,7 @@ func getTestPort(testName string) int {
 
 // StartServerWithExternalPg starts the main server with external Postgres.
 func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir string, port int, pgUser, pgURL string) error {
+	log.MustInitialize(true)
 	profile := cmd.GetTestProfileWithExternalPg(dataDir, port, pgUser, pgURL)
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {
@@ -152,7 +154,7 @@ func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir st
 // StartServer starts the main server with embed Postgres.
 func (ctl *controller) StartServer(ctx context.Context, dataDir string, port int) error {
 	// start main server.
-
+	log.MustInitialize(true)
 	profile := cmd.GetTestProfile(dataDir, port)
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -139,17 +139,12 @@ func getTestPort(testName string) int {
 
 // StartServerWithExternalPg starts the main server with external Postgres.
 func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir string, port int, pgUser, pgURL string) error {
-	logger, lvl, err := cmd.GetLogger()
-	if err != nil {
-		return fmt.Errorf("failed to get logger, error: %w", err)
-	}
-	defer logger.Sync()
-
 	profile := cmd.GetTestProfileWithExternalPg(dataDir, port, pgUser, pgURL)
-	ctl.server, err = server.NewServer(ctx, profile, logger, lvl)
+	server, err := server.NewServer(ctx, profile)
 	if err != nil {
 		return err
 	}
+	ctl.server = server
 
 	return ctl.start(ctx, port)
 }
@@ -157,17 +152,13 @@ func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir st
 // StartServer starts the main server with embed Postgres.
 func (ctl *controller) StartServer(ctx context.Context, dataDir string, port int) error {
 	// start main server.
-	logger, lvl, err := cmd.GetLogger()
-	if err != nil {
-		return fmt.Errorf("failed to get logger, error: %w", err)
-	}
-	defer logger.Sync()
 
 	profile := cmd.GetTestProfile(dataDir, port)
-	ctl.server, err = server.NewServer(ctx, profile, logger, lvl)
+	server, err := server.NewServer(ctx, profile)
 	if err != nil {
 		return err
 	}
+	ctl.server = server
 
 	return ctl.start(ctx, port)
 }


### PR DESCRIPTION
When the bytebase server or bb CLI starts, it will initialize a global logger, and all other logging code will just call the global logger. No more logger passing around.

Closes BYT-476.