### PR TITLE
feat(frontend): auto generate and save default deployment config after a tenant project created

### DIFF
--- a/frontend/src/components/QuickActionPanel.vue
+++ b/frontend/src/components/QuickActionPanel.vue
@@ -175,6 +175,7 @@
   </div>
   <BBModal
     v-if="state.showModal"
+    class="relative overflow-hidden"
     :title="state.modalTitle"
     :subtitle="state.modalSubtitle"
     @close="state.showModal = false"


### PR DESCRIPTION
[BYT-544](https://linear.app/bbteam/issue/BYT-544/cannot-set-the-default-deployment-config-on-a-newly-created-tenant)

- Generate and save the default deployment config (by environments) when a tenant mode project is successfully created.
- Add a mask with a spinning indicator when requesting network APIs.