### PR TITLE
feat(PITR): add a baseline migration history at the end of PITR cutover

### DIFF
--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -40,6 +40,8 @@ func EnabledLevel(level zapcore.Level) bool {
 
 // Debug wraps the zap Logger's Debug method.
 func Debug(msg string, fields ...zap.Field) {
+	// See notes of function Error.
+	fields = append(fields, zap.StackSkip("stack", 2))
 	gl.Debug(msg, fields...)
 }
 
@@ -55,6 +57,9 @@ func Warn(msg string, fields ...zap.Field) {
 
 // Error wraps the zap Logger's Error method.
 func Error(msg string, fields ...zap.Field) {
+	// Append the stack info in Error logging for better debugging experience.
+	// Note that we should skip 2 stack frames so that the top frame start at the caller of log.Error.
+	fields = append(fields, zap.StackSkip("stack", 2))
 	gl.Error(msg, fields...)
 }
 

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -242,6 +242,7 @@ type MigrationInfo struct {
 	Description    string
 	Creator        string
 	IssueID        string
+	// Payload contains JSON-encoded string of VCS push event if the migration is triggered by a VCS push event.
 	Payload        string
 	CreateDatabase bool
 	// UseSemanticVersion is whether version is a semantic version.

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -188,7 +188,7 @@ func BeginMigration(ctx context.Context, executor MigrationExecutor, m *db.Migra
 		return 0, fmt.Errorf("failed to convert to stored version, error %w", err)
 	}
 	// Phase 1 - Pre-check before executing migration
-	// Check if the same migration version has already been applied
+	// Check if the same migration version has already been applied.
 	if list, err := executor.FindMigrationHistoryList(ctx, &db.MigrationHistoryFind{
 		Database: &m.Namespace,
 		Version:  &m.Version,

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -87,7 +87,7 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 		)
 		// This should not happen normally as we already check this when creating the issue. Just in case.
 		if err != nil {
-			return nil, fmt.Errorf("failed to start migration, error: %w", err)
+			return nil, fmt.Errorf("failed to prepare for database migration, error[%w]", err)
 		}
 		mi.Creator = vcsPushEvent.FileCommit.AuthorName
 
@@ -96,7 +96,7 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 		}
 		bytes, err := json.Marshal(miPayload)
 		if err != nil {
-			return nil, fmt.Errorf("failed to start migration, unable to marshal vcs push event payload %w", err)
+			return nil, fmt.Errorf("failed to prepare for database migration, unable to marshal vcs push event payload, error[%w]", err)
 		}
 		mi.Payload = string(bytes)
 	}

--- a/server/task_executor_database_restore.go
+++ b/server/task_executor_database_restore.go
@@ -167,7 +167,6 @@ func createBranchMigrationHistory(ctx context.Context, server *Server, sourceDat
 		Description:    description,
 		Creator:        task.Creator.Name,
 		IssueID:        issueID,
-		Payload:        "",
 	}
 	migrationID, _, err := targetDriver.ExecuteMigration(ctx, m, "")
 	if err != nil {

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -90,7 +90,7 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 		Database:       task.Database.Name,
 		Environment:    task.Database.Instance.Environment.Name,
 		Source:         db.MigrationSource(task.Database.Project.WorkflowType),
-		Type:           db.Branch,
+		Type:           db.Baseline,
 		Description:    fmt.Sprintf("pitr: swap database %s and %s", task.Database.Name, pitrDatabaseName),
 		Creator:        task.Creator.Name,
 		IssueID:        strconv.Itoa(issue.ID),

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -88,7 +88,7 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 		Environment:    task.Database.Instance.Environment.Name,
 		Source:         db.MigrationSource(task.Database.Project.WorkflowType),
 		Type:           db.Baseline,
-		Description:    fmt.Sprintf("pitr: swap database %s and %s", task.Database.Name, pitrDatabaseName),
+		Description:    fmt.Sprintf("PITR: restoring database %s", task.Database.Name),
 		Creator:        task.Creator.Name,
 		IssueID:        strconv.Itoa(issue.ID),
 	}

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -41,8 +41,6 @@ func (exec *PITRRestoreTaskExecutor) RunOnce(ctx context.Context, server *Server
 	return exec.pitrRestore(ctx, task, server)
 }
 
-// TODO(dragonly): Should establish a BASELINE migration in the swap database task.
-// And what's the right schema version in tenant mode?
 func (exec *PITRRestoreTaskExecutor) pitrRestore(ctx context.Context, task *api.Task, server *Server) (terminated bool, result *api.TaskRunResultPayload, err error) {
 	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", "" /* pgInstanceDir */)
 	if err != nil {


### PR DESCRIPTION
After we successfully swapped the pitr/original database, we also insert a BASELINE migration record.

Closes BYT-557.