### PR TITLE
feat(frontend): deployment config improvement

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
@@ -38,11 +38,35 @@
           </i18n-t>
         </div>
         <template v-else>
+          <i18n-t
+            tag="p"
+            class="textinfolabel"
+            keypath="deployment-config.pipeline-generated-from-deployment-config"
+          >
+            <template #deployment_config>
+              <router-link
+                :to="{
+                  path: `/project/${projectSlug(project)}`,
+                  hash: '#deployment-config',
+                }"
+                active-class=""
+                exact-active-class=""
+                class="underline hover:bg-link-hover"
+                @click="$emit('dismiss')"
+              >
+                {{ $t("common.deployment-config") }}
+              </router-link>
+            </template>
+          </i18n-t>
           <YAxisRadioGroup
             v-model:label="label"
             :label-list="labelList"
-            class="text-sm pt-2 pb-1"
-          />
+            class="text-sm mt-2 pt-2 pb-1"
+          >
+            <template #title>
+              <span class="textlabel mr-1">Group by:</span>
+            </template>
+          </YAxisRadioGroup>
           <NCollapse
             display-directive="if"
             accordion

--- a/frontend/src/components/ProjectDeploymentConfigPanel.vue
+++ b/frontend/src/components/ProjectDeploymentConfigPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-w-3xl mx-auto">
+  <div class="max-w-[60rem] mx-auto">
     <template v-if="project.dbNameTemplate">
       <div class="text-lg font-medium leading-7 text-main">
         {{ $t("project.db-name-template") }}
@@ -44,25 +44,17 @@
     >
     </BBAttention>
 
-    <div v-if="state.deployment" class="divide-y">
+    <div v-if="state.deployment">
       <DeploymentConfigTool
         :schedule="state.deployment.schedule"
         :allow-edit="allowEdit"
         :label-list="availableLabelList"
         :database-list="databaseList"
       />
-      <div class="pt-4 flex justify-between items-center">
+      <div class="pt-4 border-t flex justify-between items-center">
         <div class="flex items-center space-x-2">
           <button v-if="allowEdit" class="btn-normal" @click="addStage">
             {{ $t("deployment-config.add-stage") }}
-          </button>
-
-          <button
-            class="btn-normal"
-            :disabled="!!state.error"
-            @click="state.showPreview = true"
-          >
-            {{ $t("common.preview") }}
           </button>
         </div>
         <div class="flex items-center space-x-2">
@@ -93,25 +85,25 @@
           </NPopover>
         </div>
       </div>
+
+      <div class="mt-6">
+        <div class="text-lg font-medium leading-7 text-main border-t pt-4">
+          {{ $t("deployment-config.preview-deployment-stages") }}
+        </div>
+        <DeploymentMatrix
+          class="w-full mt-4 !px-0 overflow-x-auto"
+          :project="project"
+          :deployment="state.deployment"
+          :database-list="databaseList"
+          :environment-list="environmentList"
+          :label-list="labelList"
+        />
+      </div>
     </div>
 
     <div v-else class="flex justify-center items-center py-10">
       <BBSpin />
     </div>
-
-    <BBModal
-      v-if="state.deployment && state.showPreview"
-      :title="$t('deployment-config.preview-deployment-config')"
-      @close="state.showPreview = false"
-    >
-      <DeploymentMatrix
-        :project="project"
-        :deployment="state.deployment"
-        :database-list="databaseList"
-        :environment-list="environmentList"
-        :label-list="labelList"
-      />
-    </BBModal>
   </div>
 </template>
 
@@ -153,7 +145,6 @@ type LocalState = {
   deployment: DeploymentConfig | undefined;
   originalDeployment: DeploymentConfig | undefined;
   error: string | undefined;
-  showPreview: boolean;
 };
 
 export default defineComponent({
@@ -179,7 +170,6 @@ export default defineComponent({
       deployment: undefined,
       originalDeployment: undefined,
       error: undefined,
-      showPreview: false,
     });
 
     const dirty = computed((): boolean => {

--- a/frontend/src/components/ProjectDeploymentConfigPanel.vue
+++ b/frontend/src/components/ProjectDeploymentConfigPanel.vue
@@ -88,7 +88,7 @@
 
       <div class="mt-6">
         <div class="text-lg font-medium leading-7 text-main border-t pt-4">
-          {{ $t("deployment-config.preview-deployment-stages") }}
+          {{ $t("deployment-config.preview-deployment-pipeline") }}
         </div>
         <DeploymentMatrix
           class="w-full mt-4 !px-0 overflow-x-auto"

--- a/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
+++ b/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
@@ -50,7 +50,7 @@
                   {{ $t("deployment-config.wont-be-deployed") }}
                 </span>
               </template>
-              <div class="flex items-center text-sm">
+              <div class="flex items-center text-sm max-w-[16rem]">
                 {{ $t("deployment-config.wont-be-deployed-explanation") }}
               </div>
             </NPopover>

--- a/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
+++ b/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
@@ -47,14 +47,11 @@
                 <span
                   class="px-1.5 py-1 relative rounded inline-flex items-center hover:bg-control-bg-hover cursor-pointer select-none"
                 >
-                  <heroicons-outline:exclamation
-                    class="h-4 w-4 mr-1 text-warning"
-                  />
-                  {{ $t("common.others") }}
+                  {{ $t("deployment-config.wont-be-deployed") }}
                 </span>
               </template>
               <div class="flex items-center text-sm">
-                {{ $t("deployment-config.wont-be-deployed") }}
+                {{ $t("deployment-config.wont-be-deployed-explanation") }}
               </div>
             </NPopover>
           </BBTableHeaderCell>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1057,7 +1057,6 @@
     "this-is-example-deployment-config": "This is the deployment config example. You need to edit and save it.",
     "n-databases": "{n} database | {n} databases",
     "selectors": "Selectors",
-    "wont-be-deployed": "Will not be deployed",
     "add-stage": "Add stage",
     "confirm-to-revert": "Confirm to revert your editing?",
     "name-placeholder": "Stage name...",
@@ -1072,7 +1071,9 @@
     },
     "project-has-no-deployment-config": "This project has no deployment config yet. Please {go} first.",
     "go-and-config": "Go and config",
-    "preview-deployment-config": "Preview Deployment Config"
+    "wont-be-deployed-explanation": "These databases won't be deployed, since they hit none of the selectors.",
+    "wont-be-deployed": "Won't be deployed",
+    "preview-deployment-stages": "Preview Deployment Stages"
   },
   "datasource": {
     "role-type": "Role Type",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1073,7 +1073,8 @@
     "go-and-config": "Go and config",
     "wont-be-deployed-explanation": "These databases won't be deployed, since they hit none of the selectors.",
     "wont-be-deployed": "Won't be deployed",
-    "preview-deployment-stages": "Preview Deployment Stages"
+    "preview-deployment-stages": "Preview Deployment Stages",
+    "pipeline-generated-from-deployment-config": "The deployment pipeline is generated according to the project's {deployment_config}."
   },
   "datasource": {
     "role-type": "Role Type",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1073,8 +1073,8 @@
     "go-and-config": "Go and config",
     "wont-be-deployed-explanation": "These databases won't be deployed, since they hit none of the selectors.",
     "wont-be-deployed": "Won't be deployed",
-    "preview-deployment-stages": "Preview Deployment Stages",
-    "pipeline-generated-from-deployment-config": "The deployment pipeline is generated according to the project's {deployment_config}."
+    "pipeline-generated-from-deployment-config": "The deployment pipeline is generated according to the project's {deployment_config}.",
+    "preview-deployment-pipeline": "Preview Deployment Pipeline"
   },
   "datasource": {
     "role-type": "Role Type",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1073,7 +1073,8 @@
     "go-and-config": "去配置",
     "wont-be-deployed-explanation": "这些数据库不会被部署，因为没有命中任何选择条件。",
     "wont-be-deployed": "不参与部署",
-    "preview-deployment-stages": "预览部署阶段"
+    "preview-deployment-stages": "预览部署阶段",
+    "pipeline-generated-from-deployment-config": "部署的流水线根据项目的 {deployment_config} 生成。"
   },
   "datasource": {
     "role-type": "权限类型",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1057,7 +1057,6 @@
     "this-is-example-deployment-config": "这是部署配置的样例，你需要在此基础上编辑并保存。",
     "n-databases": "{n} 个数据库",
     "selectors": "选择条件",
-    "wont-be-deployed": "不会被部署",
     "add-stage": "添加阶段",
     "confirm-to-revert": "确定撤销编辑？",
     "name-placeholder": "阶段名称…",
@@ -1072,7 +1071,9 @@
     },
     "project-has-no-deployment-config": "这个项目还没有部署配置。请先{go}。",
     "go-and-config": "去配置",
-    "preview-deployment-config": "预览部署配置"
+    "wont-be-deployed-explanation": "这些数据库不会被部署，因为没有命中任何选择条件。",
+    "wont-be-deployed": "不参与部署",
+    "preview-deployment-stages": "预览部署阶段"
   },
   "datasource": {
     "role-type": "权限类型",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1073,8 +1073,8 @@
     "go-and-config": "去配置",
     "wont-be-deployed-explanation": "这些数据库不会被部署，因为没有命中任何选择条件。",
     "wont-be-deployed": "不参与部署",
-    "preview-deployment-stages": "预览部署阶段",
-    "pipeline-generated-from-deployment-config": "部署的流水线根据项目的 {deployment_config} 生成。"
+    "pipeline-generated-from-deployment-config": "部署的流水线根据项目的{deployment_config}生成。",
+    "preview-deployment-pipeline": "预览部署流水线"
   },
   "datasource": {
     "role-type": "权限类型",


### PR DESCRIPTION
### 1. Preview deployment pipeline when configuring
Provide an immediate live preview section below the config tool instead of the Preview button which opens a preview dialog.
![image](https://user-images.githubusercontent.com/2749742/170944334-bb5fcfd6-495f-4771-95db-f0213a778dc8.png)

### 2. Explain why some of the databases are classified as "won't be deployed"
![image](https://user-images.githubusercontent.com/2749742/170941632-57fd9ac3-20ab-43e7-9d10-6798c6b0bd8e.png)

### 3. Explain how the pipeline was generated when preparing for a deployment
![image](https://user-images.githubusercontent.com/2749742/170943367-022b8646-70d6-4de6-b67d-8dbecf4f17a6.png)

We still need more systematic design to improve the UX of the tenancy mode. 😅