### PR TITLE
feat(frontend): show Bytebase as a system bot in member list

### DIFF
--- a/frontend/src/components/MemberTable.vue
+++ b/frontend/src/components/MemberTable.vue
@@ -218,6 +218,9 @@ export default defineComponent({
     });
 
     const allowChangeRole = (member: Member) => {
+      if (member.principal.id === SYSTEM_BOT_ID) {
+        return false;
+      }
       return (
         hasRBACFeature.value &&
         allowEdit.value &&
@@ -229,6 +232,9 @@ export default defineComponent({
     const changeRoleTooltip = (member: Member): string => {
       if (allowChangeRole(member)) {
         return "";
+      }
+      if (member.principal.id === SYSTEM_BOT_ID) {
+        return t("settings.members.tooltip.cannot-change-role-of-systembot");
       }
 
       if (!hasRBACFeature.value) {

--- a/frontend/src/components/MemberTable.vue
+++ b/frontend/src/components/MemberTable.vue
@@ -50,8 +50,18 @@
                   class="inline-flex items-center px-2 py-0.5 rounded-lg text-xs font-semibold bg-green-100 text-green-800"
                   >{{ $t("settings.members.yourself") }}</span
                 >
+                <span
+                  v-if="member.principal.id === SYSTEM_BOT_ID"
+                  class="inline-flex items-center px-2 py-0.5 rounded-lg text-xs font-semibold bg-green-100 text-green-800"
+                >
+                  {{ $t("settings.members.system-administrator") }}
+                </span>
               </div>
-              <span class="textlabel">{{ member.principal.email }}</span>
+              <span
+                v-if="member.principal.id !== SYSTEM_BOT_ID"
+                class="textlabel"
+                >{{ member.principal.email }}</span
+              >
             </div>
           </template>
         </div>
@@ -71,7 +81,10 @@
         />
       </BBTableCell>
       <BBTableCell class="table-cell">
-        <div class="flex flex-row items-center space-x-1">
+        <div
+          v-if="member.principal.id !== SYSTEM_BOT_ID"
+          class="flex flex-row items-center space-x-1"
+        >
           <span>{{ humanizeTs(member.updatedTs) }}</span>
           <span>by</span>
           <router-link :to="`/u/${member.updater.id}`" class="normal-link">{{
@@ -114,7 +127,14 @@ import { computed, defineComponent, PropType, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import RoleSelect from "../components/RoleSelect.vue";
 import PrincipalAvatar from "../components/PrincipalAvatar.vue";
-import { MemberId, RoleType, MemberPatch, Member, RowStatus } from "../types";
+import {
+  MemberId,
+  RoleType,
+  MemberPatch,
+  Member,
+  RowStatus,
+  SYSTEM_BOT_ID,
+} from "../types";
 import { BBTableColumn, BBTableSectionDataSource } from "../bbkit/types";
 import { isOwner } from "../utils";
 import { featureToRef, useCurrentUser, useMemberStore } from "@/store";
@@ -223,6 +243,9 @@ export default defineComponent({
     };
 
     const allowDeactivateMember = (member: Member) => {
+      if (member.principal.id === SYSTEM_BOT_ID) {
+        return false;
+      }
       return (
         allowEdit.value &&
         member.rowStatus == "NORMAL" &&
@@ -255,6 +278,7 @@ export default defineComponent({
     };
 
     return {
+      SYSTEM_BOT_ID,
       COLUMN_LIST,
       state,
       currentUser,

--- a/frontend/src/components/MemberTable.vue
+++ b/frontend/src/components/MemberTable.vue
@@ -54,7 +54,7 @@
                   v-if="member.principal.id === SYSTEM_BOT_ID"
                   class="inline-flex items-center px-2 py-0.5 rounded-lg text-xs font-semibold bg-green-100 text-green-800"
                 >
-                  {{ $t("settings.members.system-administrator") }}
+                  {{ $t("settings.members.system-bot") }}
                 </span>
               </div>
               <span

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -335,7 +335,7 @@
         "not-allow-edit": "Only Owner can change the role",
         "not-allow-remove": "Can not remove the last Owner",
         "project-role-provider-gitlab": "Mapped from the {rawRole} role in the corresponding GitLab project.",
-        "cannot-change-role-of-systembot": "Can not change the role of system administrator"
+        "cannot-change-role-of-systembot": "Can not change the role of system bot"
       },
       "toggle-role-provider": {
         "title": "Are you sure?"
@@ -347,7 +347,7 @@
       "change-role-provider-to-bytebase": {
         "content": "You are about to restore the following members. All existing members synced from VCS will be removed."
       },
-      "system-administrator": "System Administrator"
+      "system-bot": "System Bot"
     },
     "general": {
       "workspace": {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -345,7 +345,8 @@
       },
       "change-role-provider-to-bytebase": {
         "content": "You are about to restore the following members. All existing members synced from VCS will be removed."
-      }
+      },
+      "system-administrator": "System Administrator"
     },
     "general": {
       "workspace": {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -334,7 +334,8 @@
         "upgrade": "Upgrade to enable role management",
         "not-allow-edit": "Only Owner can change the role",
         "not-allow-remove": "Can not remove the last Owner",
-        "project-role-provider-gitlab": "Mapped from the {rawRole} role in the corresponding GitLab project."
+        "project-role-provider-gitlab": "Mapped from the {rawRole} role in the corresponding GitLab project.",
+        "cannot-change-role-of-systembot": "Can not change the role of system administrator"
       },
       "toggle-role-provider": {
         "title": "Are you sure?"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -334,7 +334,8 @@
         "upgrade": "升级到付费方案来解锁角色管理",
         "not-allow-edit": "只有所有者才能改变角色",
         "not-allow-remove": "不能移除最后一个所有者",
-        "project-role-provider-gitlab": "同步自对应 GitLab 项目的 {rawRole} 角色"
+        "project-role-provider-gitlab": "同步自对应 GitLab 项目的 {rawRole} 角色",
+        "cannot-change-role-of-systembot": "不能修改系统管理员的角色"
       },
       "toggle-role-provider": {
         "title": "您确认吗？"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -335,7 +335,7 @@
         "not-allow-edit": "只有所有者才能改变角色",
         "not-allow-remove": "不能移除最后一个所有者",
         "project-role-provider-gitlab": "同步自对应 GitLab 项目的 {rawRole} 角色",
-        "cannot-change-role-of-systembot": "不能修改系统管理员的角色"
+        "cannot-change-role-of-systembot": "不能修改机器人助手的角色"
       },
       "toggle-role-provider": {
         "title": "您确认吗？"
@@ -347,7 +347,7 @@
       "change-role-provider-to-bytebase": {
         "content": "将会恢复成以下成员的权限。所有由 VCS 提供的成员将会被移除。"
       },
-      "system-administrator": "系统管理员"
+      "system-bot": "机器人助手"
     },
     "general": {
       "workspace": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -345,7 +345,8 @@
       },
       "change-role-provider-to-bytebase": {
         "content": "将会恢复成以下成员的权限。所有由 VCS 提供的成员将会被移除。"
-      }
+      },
+      "system-administrator": "系统管理员"
     },
     "general": {
       "workspace": {

--- a/frontend/src/views/SettingWorkspaceMember.vue
+++ b/frontend/src/views/SettingWorkspaceMember.vue
@@ -35,8 +35,13 @@ import { computed, defineComponent } from "vue";
 import MemberAddOrInvite from "../components/MemberAddOrInvite.vue";
 import MemberTable from "../components/MemberTable.vue";
 import { isOwner } from "../utils";
-import { Member } from "../types";
-import { featureToRef, useCurrentUser, useMemberList } from "@/store";
+import { Member, SYSTEM_BOT_ID, unknown } from "../types";
+import {
+  featureToRef,
+  useCurrentUser,
+  useMemberList,
+  usePrincipalStore,
+} from "@/store";
 
 export default defineComponent({
   name: "SettingWorkspaceMember",
@@ -49,9 +54,18 @@ export default defineComponent({
     const memberList = useMemberList();
 
     const activeMemberList = computed(() => {
-      return memberList.value.filter(
-        (member: Member) => member.rowStatus == "NORMAL"
-      );
+      const systemBotMember: Member = {
+        ...unknown("MEMBER"),
+        id: SYSTEM_BOT_ID,
+        role: "OWNER",
+        principal: usePrincipalStore().principalById(SYSTEM_BOT_ID),
+      };
+      return [
+        systemBotMember,
+        ...memberList.value.filter(
+          (member: Member) => member.rowStatus == "NORMAL"
+        ),
+      ];
     });
 
     const inactiveMemberList = computed(() => {


### PR DESCRIPTION
### Background
[BYT-478](https://linear.app/bbteam/issue/BYT-478/the-issue-is-assigned-to-a-unknown-user-bytebase-when-i-create-a)

### Features

- Show [Bytebase] as a "System Bot" in Settings -> Workspace -> Members.
- Not showing the "Updated Time" because [Bytebase]'s updated time timestamp is 0 (1970/1/1), which makes it meaningless.

### Screenshot
![image](https://user-images.githubusercontent.com/2749742/171123094-875a281d-fac0-4918-b7a3-253340a9c062.png)
