### PR TITLE
fix: skip scheduled backup job for wildcard database *

### DIFF
--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -73,6 +73,10 @@ func (s *BackupRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 					mu.Unlock()
 
 					db := backupSetting.Database
+					if db.Name == api.AllDatabaseName {
+						// Skip backup job for wildcard database `*`.
+						continue
+					}
 					backupName := fmt.Sprintf("%s-%s-%s-autobackup", api.ProjectShortSlug(db.Project), api.EnvSlug(db.Instance.Environment), t.Format("20060102T030405"))
 					go func(database *api.Database, backupSettingID int, backupName string, hookURL string) {
 						log.Debug("Schedule auto backup",


### PR DESCRIPTION
There are ERROR logs like this.
```
2022-06-01T12:53:02.779+0800	ERROR	Failed to create automatic backup for database	{"databaseID": 7048, "error": "failed to connect database at 127.0.0.1: with user \"root\": Error 1049: Unknown database '*'", "stack": ""}
```