### PR TITLE
chore: append release note if exists

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,7 @@ changelog:
       - "^test:"
 release:
   draft: true
+  mode: append
   name_template: "Release {{.Tag}}"
   header: |
     # What's Changed


### PR DESCRIPTION
goreleaser release mode `append` appends the current release notes to the existing notes
https://goreleaser.com/customization/release/#:~:text=is%20%60keep%2Dexisting%60.-,mode%3A%20append,-%23%20Header%20template%20for