### PR TITLE
fix: filter database list with `syncStatus: 'OK'` for SQL editor

### DIFF
--- a/api/database.go
+++ b/api/database.go
@@ -97,12 +97,13 @@ type DatabaseFind struct {
 	ID *int
 
 	// Related fields
-	InstanceID *int
 	ProjectID  *int
+	InstanceID *int
 
 	// Domain specific fields
 	Name               *string
 	IncludeAllDatabase bool
+	SyncStatus         *SyncStatus
 }
 
 func (find *DatabaseFind) String() string {

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -62,10 +62,15 @@ const prepareAccessibleConnectionByProject = async () => {
       project.id
     );
     if (databaseList.length >= 0) {
-      databaseList.forEach((database: Database) => {
-        state.databaseIdList.set(database.id, database.name);
-        state.instanceIdList.set(database.instance.id, database.instance.name);
-      });
+      databaseList
+        .filter((d) => d.syncStatus === "OK")
+        .forEach((database: Database) => {
+          state.databaseIdList.set(database.id, database.name);
+          state.instanceIdList.set(
+            database.instance.id,
+            database.instance.name
+          );
+        });
     }
   });
 

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -58,19 +58,15 @@ const prepareAccessibleConnectionByProject = async () => {
   }
 
   const promises = state.projectList.map(async (project) => {
-    const databaseList = await databaseStore.fetchDatabaseListByProjectId(
-      project.id
-    );
+    const databaseList = await databaseStore.fetchDatabaseList({
+      projectId: project.id,
+      syncStatus: "OK",
+    });
     if (databaseList.length >= 0) {
-      databaseList
-        .filter((d) => d.syncStatus === "OK")
-        .forEach((database: Database) => {
-          state.databaseIdList.set(database.id, database.name);
-          state.instanceIdList.set(
-            database.instance.id,
-            database.instance.name
-          );
-        });
+      databaseList.forEach((database: Database) => {
+        state.databaseIdList.set(database.id, database.name);
+        state.instanceIdList.set(database.instance.id, database.instance.name);
+      });
     }
   });
 
@@ -102,9 +98,10 @@ const prepareSQLEditorContext = async () => {
   connectionTree = filteredInstanceList.map(mapConnectionAtom("instance", 0));
 
   for (const instance of filteredInstanceList) {
-    const databaseList = await databaseStore.fetchDatabaseListByInstanceId(
-      instance.id
-    );
+    const databaseList = await databaseStore.fetchDatabaseList({
+      instanceId: instance.id,
+      syncStatus: "OK",
+    });
 
     const instanceItem = connectionTree.find(
       (item: ConnectionAtom) => item.id === instance.id

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -184,8 +184,8 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
         hasSlug: true,
         instanceId,
         instanceName: instance.name,
-        databaseId,
-        databaseName: database.name,
+        databaseId: database.syncStatus === "OK" ? database.id : undefined,
+        databaseName: database.syncStatus === "OK" ? database.name : undefined,
         databaseType: instance.engine,
       });
     },

--- a/frontend/src/types/database.ts
+++ b/frontend/src/types/database.ts
@@ -56,6 +56,16 @@ export type DatabaseCreate = {
   labels?: DatabaseLabel[];
 };
 
+export type DatabaseFind = {
+  // Related fields
+  projectId?: ProjectId;
+  instanceId?: InstanceId;
+
+  // Domain specific fields
+  name?: string;
+  syncStatus?: DatabaseSyncStatus;
+};
+
 export type DatabasePatch = {
   // Related fields
   projectId?: ProjectId;

--- a/frontend/src/types/sqlEditor.ts
+++ b/frontend/src/types/sqlEditor.ts
@@ -34,6 +34,8 @@ export enum SortText {
   KEYWORD = "3",
 }
 
+// TODO(Steven): ConnectionContext should be refactored later,
+// because it has some extra not required fields: instanceName, databaseName...
 export type ConnectionContext = {
   hasSlug: boolean;
   projectId: ProjectId;

--- a/server/database.go
+++ b/server/database.go
@@ -90,6 +90,10 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 		if name := c.QueryParam("name"); name != "" {
 			databaseFind.Name = &name
 		}
+		if syncStatusStr := c.QueryParam("syncStatus"); syncStatusStr != "" {
+			syncStatus := api.SyncStatus(syncStatusStr)
+			databaseFind.SyncStatus = &syncStatus
+		}
 		projectIDStr := c.QueryParams().Get("project")
 		if projectIDStr != "" {
 			projectID, err := strconv.Atoi(projectIDStr)

--- a/store/database.go
+++ b/store/database.go
@@ -498,6 +498,9 @@ func (s *Store) findDatabaseImpl(ctx context.Context, tx *sql.Tx, find *api.Data
 	if v := find.Name; v != nil {
 		where, args = append(where, fmt.Sprintf("name = $%d", len(args)+1)), append(args, *v)
 	}
+	if v := find.SyncStatus; v != nil {
+		where, args = append(where, fmt.Sprintf("sync_status = $%d", len(args)+1)), append(args, *v)
+	}
 	if !find.IncludeAllDatabase {
 		where = append(where, "name != '"+api.AllDatabaseName+"'")
 	}


### PR DESCRIPTION
* filter database when fetch database in SQL editor with `syncStatus=OK`;
* update `fetchDatabaseList` module action with `DatabaseFind` which could be more useful;
* add `syncStatus` queryparam to GET `/api/database` (I just put the changes into this PR because it's so simple);