### PR TITLE
chore: ux fix and optimize for schema review policy

### DIFF
--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewConfig.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewConfig.vue
@@ -1,46 +1,53 @@
 <template>
-  <div>
-    <SchemaReviewTemplates
-      :required="true"
-      v-if="selectRuleList.length === 0"
-      :template-list="templateList"
-      :title="$t('schema-review-policy.create.basic-info.choose-template')"
-      @select="(index) => onTemplateApply(index)"
-    />
-    <div class="mb-5" v-if="selectRuleList.length > 0">
-      <div
-        class="flex cursor-pointer items-center px-2 text-indigo-500"
-        @click="state.openTemplate = !state.openTemplate"
-      >
-        <heroicons-solid:chevron-right
-          class="w-5 h-5 transform transition-all"
-          :class="state.openTemplate ? 'rotate-90' : ''"
-        />
-        <span class="ml-1 text-sm font-medium">
-          {{ $t("schema-review-policy.create.configure-rule.change-template") }}
-        </span>
-      </div>
+  <div class="flex gap-x-20">
+    <SchemaReviewSidebar :selected-rule-list="selectedRuleList" />
+    <div class="flex-1">
       <SchemaReviewTemplates
-        v-if="state.openTemplate"
-        :required="false"
+        :required="true"
+        v-if="selectedRuleList.length === 0"
         :template-list="templateList"
-        :selected-template-index="selectedTemplateIndex"
+        :title="$t('schema-review-policy.create.basic-info.choose-template')"
         @select="(index) => onTemplateApply(index)"
-        class="mx-8 mt-5"
       />
-    </div>
-    <div :class="selectRuleList.length > 0 ? 'border-b-1 border-gray-200' : ''">
-      <ul role="list" class="divide-y divide-gray-200">
-        <li v-for="rule in selectRuleList" :key="rule.type">
-          <SchemaRuleConfig
-            :selected-rule="rule"
-            :active="rule.type === state.activeRuleType"
-            @activate="onRuleActivate"
-            @level-change="(level) => onLevelChange(rule, level)"
-            @payload-change="(val) => onPayloadChange(rule, val)"
+      <div class="mb-5" v-if="selectedRuleList.length > 0">
+        <div
+          class="flex cursor-pointer items-center px-2 text-indigo-500"
+          @click="state.openTemplate = !state.openTemplate"
+        >
+          <heroicons-solid:chevron-right
+            class="w-5 h-5 transform transition-all"
+            :class="state.openTemplate ? 'rotate-90' : ''"
           />
-        </li>
-      </ul>
+          <span class="ml-1 text-sm font-medium">
+            {{
+              $t("schema-review-policy.create.configure-rule.change-template")
+            }}
+          </span>
+        </div>
+        <SchemaReviewTemplates
+          v-if="state.openTemplate"
+          :required="false"
+          :template-list="templateList"
+          :selected-template-index="selectedTemplateIndex"
+          @select="(index) => onTemplateApply(index)"
+          class="mx-8 mt-5"
+        />
+      </div>
+      <div
+        :class="selectedRuleList.length > 0 ? 'border-b-1 border-gray-200' : ''"
+      >
+        <ul role="list" class="divide-y divide-gray-200">
+          <li v-for="rule in selectedRuleList" :key="rule.type">
+            <SchemaRuleConfig
+              :selected-rule="rule"
+              :active="rule.type === state.activeRuleType"
+              @activate="onRuleActivate"
+              @level-change="(level) => onLevelChange(rule, level)"
+              @payload-change="(val) => onPayloadChange(rule, val)"
+            />
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </template>
@@ -61,7 +68,7 @@ interface LocalState {
 }
 
 const props = defineProps({
-  selectRuleList: {
+  selectedRuleList: {
     required: true,
     type: Object as PropType<RuleTemplate[]>,
   },

--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewCreation.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewCreation.vue
@@ -26,7 +26,7 @@
       <template #1>
         <SchemaReviewConfig
           class="py-5"
-          :select-rule-list="state.selectedRuleList"
+          :selected-rule-list="state.selectedRuleList"
           :template-list="TEMPLATE_LIST"
           :selected-template-index="state.templateIndex"
           @change="onRuleChange"

--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewEmptyView.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewEmptyView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-white rounded-lg px-5 py-6 sm:px-6">
+  <div class="bg-white rounded-lg py-6">
     <div
       class="border-4 border-dashed border-gray-200 rounded-lg h-96 flex justify-center items-center"
     >

--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewInfo.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewInfo.vue
@@ -55,7 +55,11 @@
           <label
             :for="`${env.id}`"
             class="ml-2 items-center text-sm"
-            :class="env.disabled ? 'cursor-not-allowed' : 'cursor-pointer'"
+            :class="
+              env.disabled
+                ? 'cursor-not-allowed text-gray-400'
+                : 'cursor-pointer'
+            "
           >
             {{ env.displayName }}
           </label>

--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewInfo.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewInfo.vue
@@ -49,7 +49,7 @@
             :disabled="env.disabled"
             :checked="env.id === selectedEnvironment?.id"
             @change="$emit('env-change', env)"
-            class="h-4 w-4 border-gray-300 rounded text-indigo-600 focus:ring-indigo-500"
+            class="text-accent disabled:text-accent-disabled focus:ring-accent"
             :class="env.disabled ? 'cursor-not-allowed' : 'cursor-pointer'"
           />
           <label

--- a/frontend/src/components/DatabaseSchemaReview/SchemaReviewPreview.vue
+++ b/frontend/src/components/DatabaseSchemaReview/SchemaReviewPreview.vue
@@ -1,31 +1,6 @@
 <template>
   <div class="flex gap-x-20">
-    <aside class="hidden lg:block">
-      <div class="space-y-6">
-        <h1 class="text-left text-2xl font-semibold">
-          {{ $t("schema-review-policy.rules") }}
-        </h1>
-        <fieldset v-for="(category, index) in categoryList" :key="index">
-          <div class="block text-sm font-medium text-gray-900">
-            {{
-              $t(`schema-review-policy.category.${category.id.toLowerCase()}`)
-            }}
-          </div>
-          <div
-            v-for="(rule, ruleIndex) in category.ruleList"
-            :key="ruleIndex"
-            class="pt-2 flex items-center text-sm group"
-          >
-            <a
-              :href="`#${rule.type.replace(/\./g, '-')}`"
-              class="text-gray-600 hover:underline cursor-pointer"
-            >
-              {{ getRuleLocalization(rule.type).title }}
-            </a>
-          </div>
-        </fieldset>
-      </div>
-    </aside>
+    <SchemaReviewSidebar :selected-rule-list="selectedRuleList" />
     <div class="flex-1">
       <div class="mb-5" v-if="name">
         <h1 class="text-left text-3xl font-bold mb-2">

--- a/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewCard.vue
+++ b/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewCard.vue
@@ -29,11 +29,13 @@
             {{ $t("common.environment") }}
           </dt>
           <dd class="mt-1 flex gap-x-2 text-sm text-main col-span-2">
-            <BBBadge
+            <router-link
               v-if="reviewPolicy.environment"
-              :text="environmentName(reviewPolicy.environment)"
-              :can-remove="false"
-            />
+              :to="`/environment/${environmentSlug(reviewPolicy.environment)}`"
+              class="col-span-2 text-sm font-medium text-main hover:underline"
+            >
+              {{ environmentName(reviewPolicy.environment) }}
+            </router-link>
             <span class="text-yellow-700" v-else>
               {{
                 $t(

--- a/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewCard.vue
+++ b/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewCard.vue
@@ -9,9 +9,9 @@
         </h3>
         <BBBadge
           v-if="reviewPolicy.rowStatus == 'ARCHIVED'"
-          :text="$t('common.disable')"
+          :text="$t('schema-review-policy.disabled')"
           :can-remove="false"
-          :style="'WARN'"
+          :style="'DISABLED'"
         />
       </div>
       <button

--- a/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewSidebar.vue
+++ b/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewSidebar.vue
@@ -1,0 +1,48 @@
+<template>
+  <aside class="hidden lg:block">
+    <div class="space-y-6">
+      <h1 class="text-left text-2xl font-semibold">
+        {{ $t("schema-review-policy.rules") }}
+      </h1>
+      <fieldset v-for="(category, index) in categoryList" :key="index">
+        <div class="block text-sm font-medium text-gray-900">
+          {{ $t(`schema-review-policy.category.${category.id.toLowerCase()}`) }}
+        </div>
+        <div
+          v-for="(rule, ruleIndex) in category.ruleList"
+          :key="ruleIndex"
+          class="pt-2 flex items-center text-sm group"
+        >
+          <a
+            :href="`#${rule.type.replace(/\./g, '-')}`"
+            class="text-gray-600 hover:underline cursor-pointer"
+          >
+            {{ getRuleLocalization(rule.type).title }}
+          </a>
+        </div>
+      </fieldset>
+    </div>
+  </aside>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import {
+  RuleTemplate,
+  getRuleLocalization,
+  convertToCategoryList,
+} from "@/types";
+
+const props = withDefaults(
+  defineProps<{
+    selectedRuleList?: RuleTemplate[];
+  }>(),
+  {
+    selectedRuleList: () => [],
+  }
+);
+
+const categoryList = computed(() => {
+  return convertToCategoryList(props.selectedRuleList);
+});
+</script>

--- a/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewTemplates.vue
+++ b/frontend/src/components/DatabaseSchemaReview/components/SchemaReviewTemplates.vue
@@ -19,7 +19,7 @@
         @click="$emit('select', index)"
       >
         <img class="h-24" :src="template.imagePath" alt="" />
-        <span class="text-lg lg:text-xl mt-4">{{ template.title }}</span>
+        <span class="text-sm lg:text-base mt-4">{{ template.title }}</span>
         <heroicons-solid:check-circle
           v-if="index == selectedTemplateIndex"
           class="w-7 h-7 text-gray-500 absolute top-3 left-3"

--- a/frontend/src/components/DatabaseSchemaReview/components/SchemaRuleConfig.vue
+++ b/frontend/src/components/DatabaseSchemaReview/components/SchemaRuleConfig.vue
@@ -40,7 +40,7 @@
               type="radio"
               :checked="level === selectedRule.level"
               @input="emit('level-change', level)"
-              class="h-4 w-4 border-gray-300 rounded text-indigo-600 focus:ring-indigo-500"
+              class="text-accent disabled:text-accent-disabled focus:ring-accent"
             />
             <label
               :for="`level-${level}`"

--- a/frontend/src/components/DatabaseSchemaReview/components/SchemaRuleConfig.vue
+++ b/frontend/src/components/DatabaseSchemaReview/components/SchemaRuleConfig.vue
@@ -5,13 +5,12 @@
       :class="active ? 'bg-gray-100' : ''"
       @click="$emit('activate', selectedRule.type)"
     >
-      <heroicons-solid:chevron-right
-        class="w-5 h-5 transform transition-all"
-        :class="active ? 'rotate-90' : ''"
-      />
-
-      <div class="flex-1 flex flex-col ml-3">
+      <div class="flex-1 flex flex-col">
         <div class="flex mb-2 items-center space-x-2">
+          <heroicons-solid:chevron-right
+            class="w-5 h-5 transform transition-all"
+            :class="active ? 'rotate-90' : ''"
+          />
           <h1 class="text-base font-semibold text-gray-900">
             {{ getRuleLocalization(selectedRule.type).title }}
           </h1>
@@ -21,7 +20,7 @@
           />
           <SchemaRuleLevelBadge :level="selectedRule.level" />
         </div>
-        <div class="text-sm text-gray-400">
+        <div class="text-sm text-gray-400 ml-7">
           {{ getRuleLocalization(selectedRule.type).description }}
         </div>
       </div>
@@ -57,7 +56,7 @@
       <div
         v-for="(config, index) in selectedRule.componentList"
         :key="index"
-        class="mb-7"
+        class="mb-1"
       >
         <p class="mb-3">
           {{ $t(`schema-review-policy.payload-config.${config.title}`) }}

--- a/frontend/src/components/EnvironmentForm.vue
+++ b/frontend/src/components/EnvironmentForm.vue
@@ -140,6 +140,9 @@
             @click.prevent="onSchemaReviewPolicyClick"
           >
             {{ schemaReviewPolicy.name }}
+            <span v-if="schemaReviewPolicy.rowStatus == 'ARCHIVED'">
+              ({{ $t("schema-review-policy.disabled") }})
+            </span>
           </button>
           <button
             v-else-if="hasPermission"

--- a/frontend/src/components/EnvironmentForm.vue
+++ b/frontend/src/components/EnvironmentForm.vue
@@ -150,7 +150,6 @@
             class="btn-normal py-2 px-4 gap-x-1 items-center"
             @click.prevent="onSchemaReviewPolicyClick"
           >
-            <heroicons-solid:plus class="h-4 w-4" />
             {{ $t("schema-review-policy.configure-policy") }}
           </button>
           <span v-else class="textinfolabel">

--- a/frontend/src/components/EnvironmentForm.vue
+++ b/frontend/src/components/EnvironmentForm.vue
@@ -148,7 +148,7 @@
             @click.prevent="onSchemaReviewPolicyClick"
           >
             <heroicons-solid:plus class="h-4 w-4" />
-            {{ $t("schema-review-policy.create-policy") }}
+            {{ $t("schema-review-policy.configure-policy") }}
           </button>
           <span v-else class="textinfolabel">
             {{ $t("schema-review-policy.no-policy-set") }}

--- a/frontend/src/components/InputWithTemplate/InputWithTemplate.vue
+++ b/frontend/src/components/InputWithTemplate/InputWithTemplate.vue
@@ -4,7 +4,7 @@
       <div
         v-for="template in templateList"
         :key="template.id"
-        class="px-4 py-1 rounded text-sm font-sm font-normal border border-gray-300 bg-gray-100 cursor-pointer tooltip-wrapper"
+        class="px-4 py-1 rounded text-sm font-sm font-normal border border-gray-300 bg-gray-100 cursor-pointer tooltip-wrapper hover:bg-gray-200"
         @click="() => onTemplateAdd(template)"
       >
         {{ template.id }}

--- a/frontend/src/components/Issue/TaskCheckRunPanel.vue
+++ b/frontend/src/components/Issue/TaskCheckRunPanel.vue
@@ -136,7 +136,7 @@ export default defineComponent({
           return;
         case SchemaReviewPolicyErrorCode.EMPTY_POLICY:
           return {
-            title: t("schema-review-policy.create-policy"),
+            title: t("schema-review-policy.configure-policy"),
             target: "_self",
             url: "/setting/schema-review-policy",
           };

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1398,10 +1398,10 @@
     },
     "template": {
       "policy-for-prod": {
-        "title": "Production environment template"
+        "title": "Production Environment Template"
       },
       "policy-for-dev": {
-        "title": "Development environment template"
+        "title": "Development Environment Template"
       }
     },
     "rule": {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1385,8 +1385,8 @@
     "rules": "Rules",
     "filter": "Filter",
     "no-permission": "Only DBA or Owner has permission to create or update review policy.",
-    "disable": "Disable schema review policy",
-    "enable": "Enable schema review policy",
+    "disable": "Disable",
+    "enable": "Enable",
     "delete": "Delete schema review policy",
     "category": {
       "engine": "Engine",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1376,6 +1376,7 @@
     "title": "Schema Review",
     "no-policy-set": "No schema review policy",
     "create-policy": "Create policy",
+    "configure-policy": "Configure policy",
     "search-rule-name": "Search rule name",
     "policy-removed": "Successfully removed the review policy.",
     "policy-created": "Successfully created the review policy.",
@@ -1396,10 +1397,10 @@
     },
     "template": {
       "policy-for-prod": {
-        "title": "Schema review for Prod"
+        "title": "Production environment template"
       },
       "policy-for-dev": {
-        "title": "Schema review for Dev"
+        "title": "Development environment template"
       }
     },
     "rule": {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1374,6 +1374,7 @@
   },
   "schema-review-policy": {
     "title": "Schema Review",
+    "disabled": "Disabled",
     "no-policy-set": "No schema review policy",
     "create-policy": "Create policy",
     "configure-policy": "Configure policy",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1374,6 +1374,7 @@
   },
   "schema-review-policy": {
     "title": "Schema 审核策略",
+    "disabled": "已禁用",
     "no-policy-set": "没有 schema 审核策略",
     "create-policy": "创建审核策略",
     "configure-policy": "配置审核策略",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1376,6 +1376,7 @@
     "title": "Schema 审核策略",
     "no-policy-set": "没有 schema 审核策略",
     "create-policy": "创建审核策略",
+    "configure-policy": "配置审核策略",
     "search-rule-name": "搜索规则名称",
     "policy-removed": "审核策略已删除",
     "policy-created": "审核策略已创建",
@@ -1396,10 +1397,10 @@
     },
     "template": {
       "policy-for-prod": {
-        "title": "针对生产环境的审核策略"
+        "title": "针对生产环境的审核策略模板"
       },
       "policy-for-dev": {
-        "title": "针对开发环境的审核策略"
+        "title": "针对开发环境的审核策略模板"
       }
     },
     "rule": {

--- a/frontend/src/types/schemaSystem.ts
+++ b/frontend/src/types/schemaSystem.ts
@@ -143,7 +143,7 @@ export const RULE_TEMPLATE_PAYLOAD_MAP: Map<RuleType, RuleConfigComponent[]> =
           description: "",
           payload: {
             type: "STRING",
-            default: "^[a-z]+(_[a-z]+)?$",
+            default: "^[a-z]+(_[a-z]+)*$",
           },
         },
       ],
@@ -156,7 +156,7 @@ export const RULE_TEMPLATE_PAYLOAD_MAP: Map<RuleType, RuleConfigComponent[]> =
           description: "",
           payload: {
             type: "STRING",
-            default: "^[a-z]+(_[a-z]+)?$",
+            default: "^[a-z]+(_[a-z]+)*$",
           },
         },
       ],

--- a/frontend/src/views/SettingWorkspaceSchemaReview.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReview.vue
@@ -9,18 +9,14 @@
       "
     />
     <div v-if="store.reviewPolicyList.length > 0" class="space-y-6 my-5">
-      <div class="flex justify-start mt-4" v-if="hasPermission">
-        <div class="flex flex-col items-center w-28">
-          <button
-            class="btn-icon-primary p-3"
-            @click.prevent="goToCreationView"
-          >
-            <heroicons-outline:plus-sm class="w-6 h-6" />
-          </button>
-          <h3 class="mt-1 text-base font-normal text-main tracking-tight">
-            {{ $t("schema-review-policy.create-policy") }}
-          </h3>
-        </div>
+      <div class="flex items-center justify-end" v-if="hasPermission">
+        <button
+          type="button"
+          class="btn-primary ml-3 inline-flex justify-center py-2 px-4"
+          @click.prevent="goToCreationView"
+        >
+          {{ $t("schema-review-policy.create-policy") }}
+        </button>
       </div>
       <template v-for="review in store.reviewPolicyList" :key="review.id">
         <SchemaReviewCard :review-policy="review" @click="onClick" />

--- a/frontend/src/views/SettingWorkspaceSchemaReviewCreate.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewCreate.vue
@@ -16,17 +16,26 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
-import { useEnvironmentStore, featureToRef } from "@/store";
+import { computed, watchEffect } from "vue";
+import {
+  useEnvironmentStore,
+  featureToRef,
+  useSchemaSystemStore,
+} from "@/store";
 import { EMPTY_ID } from "@/types";
 
 const url = new URL(window.location.href);
 const params = new URLSearchParams(url.search);
 const environmentId = params.get("environmentId") ?? "";
+const store = useSchemaSystemStore();
 
 const hasSchemaReviewPolicyFeature = featureToRef(
   "bb.feature.schema-review-policy"
 );
+
+watchEffect(() => {
+  store.fetchReviewPolicyList();
+});
 
 const environment = computed(() => {
   if (!environmentId || Number.isNaN(environmentId)) {

--- a/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
@@ -17,7 +17,9 @@
       @cancel="state.editMode = false"
     />
     <div class="my-5" v-else>
-      <div class="flex flex-col items-center justify-center md:flex-row">
+      <div
+        class="flex flex-col items-center space-x-2 justify-center md:flex-row"
+      >
         <div class="flex-1 flex space-x-3 items-center justify-start">
           <h1 class="text-xl md:text-3xl font-semibold">
             {{ reviewPolicy.name }}
@@ -49,7 +51,7 @@
         <button
           v-if="hasPermission"
           type="button"
-          class="btn-primary ml-5"
+          class="btn-primary"
           @click="onEdit"
         >
           {{ $t("common.edit") }}

--- a/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
@@ -30,26 +30,22 @@
             />
           </div>
         </div>
-        <BBButtonConfirm
+        <button
           v-if="reviewPolicy.rowStatus === 'NORMAL'"
-          :style="'ARCHIVE'"
-          :button-text="$t('schema-review-policy.disable')"
-          confirm-description=""
-          :ok-text="$t('common.disable')"
-          :confirm-title="$t('common.disable') + ` '${reviewPolicy.name}'?`"
-          :require-confirm="true"
-          @confirm="onArchive"
-        />
-        <BBButtonConfirm
+          type="button"
+          class="btn-normal py-2 px-4"
+          @click.prevent="state.showDisableModal = true"
+        >
+          {{ $t("common.disable") }}
+        </button>
+        <button
           v-else
-          :style="'RESTORE'"
-          :button-text="$t('schema-review-policy.enable')"
-          confirm-description=""
-          :ok-text="$t('common.enable')"
-          :confirm-title="$t('common.enable') + ` '${reviewPolicy.name}'?`"
-          :require-confirm="true"
-          @confirm="onRestore"
-        />
+          type="button"
+          class="btn-normal py-2 px-4"
+          @click.prevent="state.showEnableModal = true"
+        >
+          {{ $t("common.enable") }}
+        </button>
         <button
           v-if="hasPermission"
           type="button"
@@ -169,6 +165,36 @@
       />
     </div>
   </transition>
+  <BBAlert
+    v-if="state.showDisableModal"
+    :style="'CRITICAL'"
+    :ok-text="$t('common.disable')"
+    :title="$t('common.disable') + ` '${reviewPolicy.name}'?`"
+    description=""
+    @ok="
+      () => {
+        state.showDisableModal = false;
+        onArchive();
+      }
+    "
+    @cancel="state.showDisableModal = false"
+  >
+  </BBAlert>
+  <BBAlert
+    v-if="state.showEnableModal"
+    :style="'INFO'"
+    :ok-text="$t('common.enable')"
+    :title="$t('common.enable') + ` '${reviewPolicy.name}'?`"
+    description=""
+    @ok="
+      () => {
+        state.showEnableModal = false;
+        onRestore();
+      }
+    "
+    @cancel="state.showEnableModal = false"
+  >
+  </BBAlert>
 </template>
 
 <script lang="ts" setup>
@@ -204,6 +230,8 @@ const props = defineProps({
 });
 
 interface LocalState {
+  showDisableModal: boolean;
+  showEnableModal: boolean;
   searchText: string;
   selectedCategory?: string;
   editMode: boolean;
@@ -218,6 +246,8 @@ const currentUser = useCurrentUser();
 const ROUTE_NAME = "setting.workspace.schema-review-policy";
 
 const state = reactive<LocalState>({
+  showDisableModal: false,
+  showEnableModal: false,
   searchText: "",
   selectedCategory: router.currentRoute.value.query.category
     ? (router.currentRoute.value.query.category as string)

--- a/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
@@ -24,9 +24,9 @@
           </h1>
           <div v-if="reviewPolicy.rowStatus == 'ARCHIVED'">
             <BBBadge
-              :text="$t('common.disable')"
+              :text="$t('schema-review-policy.disabled')"
               :can-remove="false"
-              :style="'WARN'"
+              :style="'DISABLED'"
             />
           </div>
         </div>
@@ -39,12 +39,17 @@
           {{ $t("common.edit") }}
         </button>
       </div>
-      <div class="flex flex-wrap gap-x-3 my-5" v-if="reviewPolicy.environment">
+      <div
+        class="flex items-center flex-wrap gap-x-3 my-5"
+        v-if="reviewPolicy.environment"
+      >
         <span class="font-semibold">{{ $t("common.environment") }}</span>
-        <BBBadge
-          :text="environmentName(reviewPolicy.environment)"
-          :can-remove="false"
-        />
+        <router-link
+          :to="`/environment/${environmentSlug(reviewPolicy.environment)}`"
+          class="col-span-2 font-medium text-main underline"
+        >
+          {{ environmentName(reviewPolicy.environment) }}
+        </router-link>
       </div>
       <BBAttention
         v-else

--- a/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSchemaReviewDetail.vue
@@ -30,6 +30,26 @@
             />
           </div>
         </div>
+        <BBButtonConfirm
+          v-if="reviewPolicy.rowStatus === 'NORMAL'"
+          :style="'ARCHIVE'"
+          :button-text="$t('schema-review-policy.disable')"
+          confirm-description=""
+          :ok-text="$t('common.disable')"
+          :confirm-title="$t('common.disable') + ` '${reviewPolicy.name}'?`"
+          :require-confirm="true"
+          @confirm="onArchive"
+        />
+        <BBButtonConfirm
+          v-else
+          :style="'RESTORE'"
+          :button-text="$t('schema-review-policy.enable')"
+          confirm-description=""
+          :ok-text="$t('common.enable')"
+          :confirm-title="$t('common.enable') + ` '${reviewPolicy.name}'?`"
+          :require-confirm="true"
+          @confirm="onRestore"
+        />
         <button
           v-if="hasPermission"
           type="button"
@@ -139,34 +159,14 @@
         class="py-5"
       />
       <BBButtonConfirm
-        v-if="reviewPolicy.rowStatus === 'NORMAL'"
-        :style="'ARCHIVE'"
-        :button-text="$t('schema-review-policy.disable')"
-        confirm-description=""
-        :ok-text="$t('common.disable')"
-        :confirm-title="$t('common.disable') + ` '${reviewPolicy.name}'?`"
+        v-if="reviewPolicy.rowStatus === 'ARCHIVED'"
+        :style="'DELETE'"
+        :button-text="$t('schema-review-policy.delete')"
+        :ok-text="$t('common.delete')"
+        :confirm-title="$t('common.delete') + ` '${reviewPolicy.name}'?`"
         :require-confirm="true"
-        @confirm="onArchive"
+        @confirm="onRemove"
       />
-      <div class="flex gap-x-5" v-else>
-        <BBButtonConfirm
-          :style="'RESTORE'"
-          :button-text="$t('schema-review-policy.enable')"
-          confirm-description=""
-          :ok-text="$t('common.enable')"
-          :confirm-title="$t('common.enable') + ` '${reviewPolicy.name}'?`"
-          :require-confirm="true"
-          @confirm="onRestore"
-        />
-        <BBButtonConfirm
-          :style="'DELETE'"
-          :button-text="$t('schema-review-policy.delete')"
-          :ok-text="$t('common.delete')"
-          :confirm-title="$t('common.delete') + ` '${reviewPolicy.name}'?`"
-          :require-confirm="true"
-          @confirm="onRemove"
-        />
-      </div>
     </div>
   </transition>
 </template>

--- a/plugin/advisor/mysql/advisor_naming_column_test.go
+++ b/plugin/advisor/mysql/advisor_naming_column_test.go
@@ -19,7 +19,7 @@ func TestNamingColumnConvention(t *testing.T) {
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`book`.`creatorId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`book`.`creatorId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -42,7 +42,7 @@ func TestNamingColumnConvention(t *testing.T) {
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`book`.`creatorId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`book`.`creatorId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -70,7 +70,7 @@ func TestNamingColumnConvention(t *testing.T) {
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`book`.`creatorId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`book`.`creatorId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -108,7 +108,7 @@ func TestNamingColumnConvention(t *testing.T) {
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`book`.`contentString` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`book`.`contentString` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -127,32 +127,32 @@ func TestNamingColumnConvention(t *testing.T) {
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`book`.`createdTs` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`book`.`createdTs` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 				{
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`book`.`updaterId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`book`.`updaterId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 				{
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`student`.`createdTs` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`student`.`createdTs` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 				{
 					Status:  advisor.Warn,
 					Code:    common.NamingColumnConventionMismatch,
 					Title:   "Mismatch column naming convention",
-					Content: "`student`.`updatedTs` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`student`.`updatedTs` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
 	}
 
 	payload, err := json.Marshal(api.NamingRulePayload{
-		Format: "^[a-z]+(_[a-z]+)?$",
+		Format: "^[a-z]+(_[a-z]+)*$",
 	})
 	require.NoError(t, err)
 	runSchemaReviewRuleTests(t, tests, &NamingColumnConventionAdvisor{}, &api.SchemaReviewRule{

--- a/plugin/advisor/mysql/advisor_naming_table_test.go
+++ b/plugin/advisor/mysql/advisor_naming_table_test.go
@@ -19,7 +19,7 @@ func TestNamingTableConvention(t *testing.T) {
 					Status:  advisor.Error,
 					Code:    common.NamingTableConventionMismatch,
 					Title:   "Mismatch table naming convention",
-					Content: "`techBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`techBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -41,7 +41,7 @@ func TestNamingTableConvention(t *testing.T) {
 					Status:  advisor.Error,
 					Code:    common.NamingTableConventionMismatch,
 					Title:   "Mismatch table naming convention",
-					Content: "`TechBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`TechBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -63,7 +63,7 @@ func TestNamingTableConvention(t *testing.T) {
 					Status:  advisor.Error,
 					Code:    common.NamingTableConventionMismatch,
 					Title:   "Mismatch table naming convention",
-					Content: "`LiteraryBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`LiteraryBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -74,13 +74,13 @@ func TestNamingTableConvention(t *testing.T) {
 					Status:  advisor.Error,
 					Code:    common.NamingTableConventionMismatch,
 					Title:   "Mismatch table naming convention",
-					Content: "`TechBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`TechBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 				{
 					Status:  advisor.Error,
 					Code:    common.NamingTableConventionMismatch,
 					Title:   "Mismatch table naming convention",
-					Content: "`LiteraryBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+					Content: "`LiteraryBook` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 				},
 			},
 		},
@@ -97,7 +97,7 @@ func TestNamingTableConvention(t *testing.T) {
 		},
 	}
 	payload, err := json.Marshal(api.NamingRulePayload{
-		Format: "^[a-z]+(_[a-z]+)?$",
+		Format: "^[a-z]+(_[a-z]+)*$",
 	})
 	require.NoError(t, err)
 	runSchemaReviewRuleTests(t, tests, &NamingTableConventionAdvisor{}, &api.SchemaReviewRule{

--- a/tests/schema_system_test.go
+++ b/tests/schema_system_test.go
@@ -95,13 +95,13 @@ func TestSchemaSystem(t *testing.T) {
 						Status:  api.TaskCheckStatusWarn,
 						Code:    common.NamingTableConventionMismatch,
 						Title:   "Mismatch table naming convention",
-						Content: "`userTable` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+						Content: "`userTable` mismatches table naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 					},
 					{
 						Status:  api.TaskCheckStatusWarn,
 						Code:    common.NamingColumnConventionMismatch,
 						Title:   "Mismatch column naming convention",
-						Content: "`userTable`.`roomId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)?$\"",
+						Content: "`userTable`.`roomId` mismatches column naming convention, naming format should be \"^[a-z]+(_[a-z]+)*$\"",
 					},
 					{
 						Status:  api.TaskCheckStatusWarn,

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1352,7 +1352,7 @@ func setDefaultSchemaReviewRulePayload(ruleTp api.SchemaReviewRuleType) (string,
 		fallthrough
 	case api.SchemaRuleColumnNaming:
 		payload, err = json.Marshal(api.NamingRulePayload{
-			Format: "^[a-z]+(_[a-z]+)?$",
+			Format: "^[a-z]+(_[a-z]+)*$",
 		})
 	case api.SchemaRuleIDXNaming:
 		payload, err = json.Marshal(api.NamingRulePayload{


### PR DESCRIPTION
Updated:
- https://linear.app/bbteam/issue/BYT-598/show-the-rule-sidebar-in-the-configure-rule-step-as-well
<img width="1032" alt="图片" src="https://user-images.githubusercontent.com/10706318/171440835-3706895f-ffa0-46d6-96e3-596a104b245f.png">

- https://linear.app/bbteam/issue/BYT-589/the-control-for-linking-environment-to-policy-should-use-radio-button
<img width="687" alt="图片" src="https://user-images.githubusercontent.com/10706318/171440913-1b73f5c9-ddbc-4f29-b939-314bdd366d3e.png">

- https://linear.app/bbteam/issue/BYT-591/schema-review-template-wording
<img width="732" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441008-557b242c-a405-4367-8d4b-8252c6ad143e.png">

- https://linear.app/bbteam/issue/BYT-593/expand-icon-should-be-top-aligned-instead-of-central-aligned】
<img width="387" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441083-d8fbd762-9d07-4301-8472-2b77fa5312ae.png">

- https://linear.app/bbteam/issue/BYT-595/too-much-bottom-padding-for-the-expanded-policy
<img width="991" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441171-e6315972-dd8e-4369-bfda-f44845da6777.png">

- https://linear.app/bbteam/issue/BYT-597/add-the-hover-effect-when-mouse-over-the-field-template
<img width="395" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441228-3953bcfb-34c1-4654-904b-e2ae1c76656e.png">

- https://linear.app/bbteam/issue/BYT-600/disabled-review-policy-wording
<img width="370" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441285-d3c8d1ef-006e-446a-bc3f-20a6eb3b3e8c.png">

- https://linear.app/bbteam/issue/BYT-601/the-environment-field-should-be-a-link-to-the-particular-environment
<img width="478" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441355-137ebaa8-febd-4eed-b818-f908bc6d91b8.png">

- https://linear.app/bbteam/issue/BYT-603/the-create-policy-button-should-be-consistent-with-version-control
<img width="1587" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441443-74c47244-b401-4cbe-af45-806e8b3c219f.png">

- https://linear.app/bbteam/issue/BYT-604/the-disabled-schema-review-policy-should-show-the-disabled-state-in
<img width="264" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441519-a30354f5-593d-46d7-a32f-0c00c5311a31.png">

- https://linear.app/bbteam/issue/BYT-605/wording-create-policy-configure-policy
<img width="410" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441674-e046fd75-ce27-484a-9f82-36e81e6a5182.png">

- https://linear.app/bbteam/issue/BYT-606/enabledisable-policy-button-could-be-put-on-the-top-right
<img width="219" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441744-5575bb50-cfe5-48c3-b361-1e94f58b6b5c.png">
<img width="468" alt="图片" src="https://user-images.githubusercontent.com/10706318/171441788-2482c949-0fd6-4349-b96c-e0f0b6c80382.png">

Fixed:
- https://linear.app/bbteam/issue/BYT-602/the-already-linked-environment-would-allow-to-be-linked-again-after
- https://linear.app/bbteam/issue/BYT-592/[sql-review]-a-column-named-snake-lower-case-violates-column-name