### PR TITLE
feat(frontend): reset default pitr restore time to "now" every time when opening the dialog

### DIFF
--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -3,7 +3,7 @@
     type="normal"
     tooltip-mode="DISABLED-ONLY"
     :disabled="!allowAdmin || !pitrAvailable.result"
-    @click="state.showDatabasePITRModal = true"
+    @click="openDialog"
   >
     {{ $t("common.restore") }}
     <template v-if="allowAdmin && !pitrAvailable.result" #tooltip>
@@ -142,6 +142,11 @@ const isDateDisabled = (tsInMS: number) => {
 const resetUI = () => {
   state.loading = false;
   state.showDatabasePITRModal = false;
+  state.pitrTimestampMS = Date.now();
+};
+
+const openDialog = () => {
+  state.showDatabasePITRModal = true;
   state.pitrTimestampMS = Date.now();
 };
 


### PR DESCRIPTION
Before: the default time is the timestamp when the user visited the page.
After: reset the default time to "now" every time when the user opening the dialog.