### PR TITLE
fix(frontend): TaskCheckRunBar improvement

### DIFF
--- a/frontend/src/components/Issue/TaskCheckBadgeBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBadgeBar.vue
@@ -7,7 +7,7 @@
       <button
         class="inline-flex items-center px-3 py-0.5 rounded-full text-sm border border-control-border"
         :class="buttonStyle(checkRun)"
-        @click.prevent="selectTaskCheckRun(checkRun)"
+        @click.prevent="selectTaskCheckType(checkRun.type)"
       >
         <template v-if="checkRun.status == 'RUNNING'">
           <TaskSpinner class="-ml-1 mr-1.5 h-4 w-4 text-info" />
@@ -53,7 +53,7 @@ import { TaskCheckRun, TaskCheckStatus, TaskCheckType } from "../../types";
 import TaskSpinner from "./TaskSpinner.vue";
 
 interface LocalState {
-  selectedTaskCheckRun?: TaskCheckRun;
+  selectedTaskCheckType: TaskCheckType | undefined;
 }
 
 export default defineComponent({
@@ -72,22 +72,22 @@ export default defineComponent({
       default: false,
       type: Boolean,
     },
-    selectedTaskCheckRun: {
-      type: Object as PropType<TaskCheckRun>,
+    selectedTaskCheckType: {
+      type: String as PropType<TaskCheckType>,
       default: undefined,
     },
   },
-  emits: ["select-task-check-run"],
+  emits: ["select-task-check-type"],
   setup(props, { emit }) {
     const { t } = useI18n();
     const state = reactive<LocalState>({
-      selectedTaskCheckRun: props.selectedTaskCheckRun,
+      selectedTaskCheckType: props.selectedTaskCheckType,
     });
 
     watch(
-      () => props.selectedTaskCheckRun,
+      () => props.selectedTaskCheckType,
       (curNew, _) => {
-        state.selectedTaskCheckRun = curNew;
+        state.selectedTaskCheckType = curNew;
       }
     );
 
@@ -137,7 +137,7 @@ export default defineComponent({
         styleList.push("cursor-pointer", `hover:${bgHoverColor}`);
         if (
           props.stickySelection &&
-          checkRun.type == state.selectedTaskCheckRun?.type
+          checkRun.type == state.selectedTaskCheckType
         ) {
           styleList.push(bgHoverColor);
         } else {
@@ -209,8 +209,8 @@ export default defineComponent({
       return type;
     };
 
-    const selectTaskCheckRun = (taskCheckRun: TaskCheckRun) => {
-      emit("select-task-check-run", taskCheckRun);
+    const selectTaskCheckType = (type: TaskCheckType) => {
+      emit("select-task-check-type", type);
     };
 
     return {
@@ -219,7 +219,7 @@ export default defineComponent({
       filteredTaskCheckRunList,
       taskCheckStatus,
       name,
-      selectTaskCheckRun,
+      selectTaskCheckType,
     };
   },
 });

--- a/frontend/src/components/Issue/TaskCheckBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBar.vue
@@ -11,11 +11,7 @@
     </button>
     <TaskCheckBadgeBar
       :task-check-run-list="task.taskCheckRunList"
-      @select-task-check-run="
-        (checkRun) => {
-          viewCheckRunDetail(checkRun);
-        }
-      "
+      @select-task-check-type="viewCheckRunDetail"
     />
     <BBModal
       v-if="state.showModal"
@@ -28,12 +24,8 @@
             :task-check-run-list="task.taskCheckRunList"
             :allow-selection="true"
             :sticky-selection="true"
-            :selected-task-check-run="state.selectedTaskCheckRun"
-            @select-task-check-run="
-              (checkRun) => {
-                viewCheckRunDetail(checkRun);
-              }
-            "
+            :selected-task-check-type="state.selectedTaskCheckType"
+            @select-task-check-type="viewCheckRunDetail"
           />
         </div>
         <BBTabFilter
@@ -42,12 +34,14 @@
           :selected-index="state.selectedTabIndex"
           @select-index="
             (index: number) => {
-              state.selectedTaskCheckRun = tabTaskCheckRunList[index];
               state.selectedTabIndex = index;
             }
           "
         />
-        <TaskCheckRunPanel :task-check-run="state.selectedTaskCheckRun!" />
+        <TaskCheckRunPanel
+          v-if="selectedTaskCheckRun"
+          :task-check-run="selectedTaskCheckRun"
+        />
         <div class="pt-4 flex justify-end">
           <button
             type="button"
@@ -64,17 +58,17 @@
 
 <script lang="ts">
 import { computed, defineComponent, PropType, reactive } from "vue";
-import { Task, TaskCheckRun, TaskCheckStatus } from "../../types";
+import { useI18n } from "vue-i18n";
+import { cloneDeep } from "lodash-es";
+import { Task, TaskCheckRun, TaskCheckStatus, TaskCheckType } from "@/types";
 import TaskCheckBadgeBar from "./TaskCheckBadgeBar.vue";
 import TaskCheckRunPanel from "./TaskCheckRunPanel.vue";
-import { BBTabFilterItem } from "../../bbkit/types";
-import { cloneDeep } from "lodash-es";
-import { humanizeTs } from "../../utils";
-import { useI18n } from "vue-i18n";
+import { BBTabFilterItem } from "@/bbkit/types";
+import { humanizeTs } from "@/utils";
 
 interface LocalState {
   showModal: boolean;
-  selectedTaskCheckRun?: TaskCheckRun;
+  selectedTaskCheckType: TaskCheckType | undefined;
   selectedTabIndex: number;
 }
 
@@ -97,17 +91,18 @@ export default defineComponent({
 
     const state = reactive<LocalState>({
       showModal: false,
+      selectedTaskCheckType: undefined,
       selectedTabIndex: 0,
     });
 
     const tabTaskCheckRunList = computed((): TaskCheckRun[] => {
-      if (!state.selectedTaskCheckRun) {
+      if (!state.selectedTaskCheckType) {
         return [];
       }
 
       const list: TaskCheckRun[] = [];
       for (const check of props.task.taskCheckRunList) {
-        if (check.type == state.selectedTaskCheckRun.type) {
+        if (check.type == state.selectedTaskCheckType) {
           list.push(check);
         }
       }
@@ -125,6 +120,13 @@ export default defineComponent({
           alert: false,
         };
       });
+    });
+
+    const selectedTaskCheckRun = computed(() => {
+      const type = state.selectedTaskCheckType;
+      const index = state.selectedTabIndex;
+      if (!type) return undefined;
+      return tabTaskCheckRunList.value[index];
     });
 
     const showRunCheckButton = computed((): boolean => {
@@ -162,15 +164,15 @@ export default defineComponent({
       return value;
     };
 
-    const viewCheckRunDetail = (taskCheckRun: TaskCheckRun) => {
-      state.selectedTaskCheckRun = taskCheckRun;
-      state.showModal = true;
+    const viewCheckRunDetail = (type: TaskCheckType) => {
+      state.selectedTaskCheckType = type;
       state.selectedTabIndex = 0;
+      state.showModal = true;
     };
 
     const dismissDialog = () => {
       state.showModal = false;
-      state.selectedTaskCheckRun = undefined;
+      state.selectedTaskCheckType = undefined;
     };
 
     const runChecks = () => {
@@ -181,6 +183,7 @@ export default defineComponent({
       state,
       tabTaskCheckRunList,
       tabItemList,
+      selectedTaskCheckRun,
       showRunCheckButton,
       hasRunningTaskCheck,
       taskCheckStatus,

--- a/frontend/src/components/Issue/TaskCheckBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBar.vue
@@ -165,6 +165,7 @@ export default defineComponent({
     const viewCheckRunDetail = (taskCheckRun: TaskCheckRun) => {
       state.selectedTaskCheckRun = taskCheckRun;
       state.showModal = true;
+      state.selectedTabIndex = 0;
     };
 
     const dismissDialog = () => {


### PR DESCRIPTION
- Reset the selected tab index when re-opening the modal dialog. (Fix [BYT-599](https://linear.app/bbteam/issue/BYT-599/bug-wrong-version-state))
- Make the selected TaskCheckRun item reactive when it's still running. (Fix [BYT-594](https://linear.app/bbteam/issue/BYT-594/bug-status-not-synced))
- chore: reorder the imports, 3rd-party on the top.