### PR TITLE
refactor: remove stores from `useMonaco`

### DIFF
--- a/frontend/src/components/MonacoEditor/AutoCompletion.ts
+++ b/frontend/src/components/MonacoEditor/AutoCompletion.ts
@@ -1,33 +1,28 @@
 import * as monaco from "monaco-editor";
-
 import {
-  Instance,
   Database,
   Table,
   EditorModel,
   EditorPosition,
   SortText,
   CompletionItems,
-} from "../../types";
+} from "@/types";
 import { keywords } from "./keywords";
 
 export default class AutoCompletion {
   model: EditorModel;
   position: EditorPosition;
-  instanceList: Instance[];
   databaseList: Database[];
   tableList: Table[];
 
   constructor(
     model: EditorModel,
     position: EditorPosition,
-    instanceList: Instance[],
     databaseList: Database[],
     tableList: Table[]
   ) {
     this.model = model;
     this.position = position;
-    this.instanceList = instanceList;
     this.databaseList = databaseList;
     this.tableList = tableList;
   }
@@ -46,7 +41,6 @@ export default class AutoCompletion {
 
   getCompletionItemsForKeywords() {
     const suggestions: CompletionItems = [];
-
     const range = this.getWordRange();
 
     keywords.forEach((keyword) => {
@@ -65,8 +59,7 @@ export default class AutoCompletion {
   }
 
   getCompletionItemsForDatabaseList(): CompletionItems {
-    let suggestions: CompletionItems = [];
-
+    const suggestions: CompletionItems = [];
     const range = this.getWordRange();
 
     this.databaseList.forEach((database) => {
@@ -80,9 +73,7 @@ export default class AutoCompletion {
         range,
       });
 
-      suggestions = suggestions.concat(
-        this.getCompletionItemsForTableList(database)
-      );
+      suggestions.push(...this.getCompletionItemsForTableList(database));
     });
 
     return suggestions;
@@ -92,8 +83,7 @@ export default class AutoCompletion {
     db?: Database,
     withDatabasePrefix = true
   ): CompletionItems {
-    let suggestions: CompletionItems = [];
-
+    const suggestions: CompletionItems = [];
     const range = this.getWordRange();
 
     const filterTableListByDB = this.tableList.filter((table: Table) => {
@@ -115,9 +105,7 @@ export default class AutoCompletion {
         range,
       });
       if (table.columnList && table.columnList.length > 0) {
-        suggestions = suggestions.concat(
-          this.getCompletionItemsForTableColumnList(table)
-        );
+        suggestions.push(...this.getCompletionItemsForTableColumnList(table));
       }
     });
 
@@ -129,7 +117,6 @@ export default class AutoCompletion {
     withTablePrefix = true
   ): CompletionItems {
     const suggestions: CompletionItems = [];
-
     const range = this.getWordRange();
 
     table.columnList.forEach((column) => {

--- a/frontend/src/components/MonacoEditor/AutoCompletion.ts
+++ b/frontend/src/components/MonacoEditor/AutoCompletion.ts
@@ -1,3 +1,4 @@
+import { uniqBy } from "lodash-es";
 import * as monaco from "monaco-editor";
 import {
   Database,
@@ -55,7 +56,7 @@ export default class AutoCompletion {
       });
     });
 
-    return suggestions;
+    return uniqBy(suggestions, "label");
   }
 
   getCompletionItemsForDatabaseList(): CompletionItems {
@@ -76,7 +77,7 @@ export default class AutoCompletion {
       suggestions.push(...this.getCompletionItemsForTableList(database));
     });
 
-    return suggestions;
+    return uniqBy(suggestions, "label");
   }
 
   getCompletionItemsForTableList(
@@ -109,7 +110,7 @@ export default class AutoCompletion {
       }
     });
 
-    return suggestions;
+    return uniqBy(suggestions, "label");
   }
 
   getCompletionItemsForTableColumnList(
@@ -135,6 +136,6 @@ export default class AutoCompletion {
       });
     });
 
-    return suggestions;
+    return uniqBy(suggestions, "label");
   }
 }

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -1,34 +1,13 @@
-import { computed } from "vue";
+import { ref } from "vue";
 import * as monaco from "monaco-editor";
 import type { editor as Editor } from "monaco-editor";
-
+import { Database, Table, CompletionItems, SQLDialect } from "@/types";
 import AutoCompletion from "./AutoCompletion";
-import { Database, Table, CompletionItems, SQLDialect } from "../../types";
 import sqlFormatter from "./sqlFormatter";
-import {
-  useDatabaseStore,
-  useTableStore,
-  useSQLEditorStore,
-  useInstanceList,
-} from "@/store";
 
 const useMonaco = async (lang: string) => {
-  const dataSourceStore = useDatabaseStore();
-  const tableStore = useTableStore();
-  const sqlEditorStore = useSQLEditorStore();
-
-  const instanceList = useInstanceList();
-
-  const databaseList = computed(() => {
-    const currentInstanceId = sqlEditorStore.connectionContext.instanceId;
-    return dataSourceStore.getDatabaseListByInstanceId(currentInstanceId);
-  });
-
-  const tableList = computed(() => {
-    return databaseList.value
-      .map((item) => tableStore.getTableListByDatabaseId(item.id))
-      .flat();
-  });
+  const databaseList = ref<Database[]>([]);
+  const tableList = ref<Table[]>([]);
 
   monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
     ...monaco.languages.typescript.typescriptDefaults.getCompilerOptions(),
@@ -40,109 +19,107 @@ const useMonaco = async (lang: string) => {
     allowJs: true,
   });
 
-  const completionItemProvider =
-    monaco.languages.registerCompletionItemProvider(lang, {
-      triggerCharacters: [" ", "."],
-      provideCompletionItems: (model, position) => {
-        let suggestions: CompletionItems = [];
+  monaco.languages.registerCompletionItemProvider(lang, {
+    triggerCharacters: [" ", "."],
+    provideCompletionItems: (model, position) => {
+      let suggestions: CompletionItems = [];
 
-        const { lineNumber, column } = position;
-        // The text before the cursor pointer
-        const textBeforePointer = model.getValueInRange({
-          startLineNumber: lineNumber,
-          startColumn: 0,
-          endLineNumber: lineNumber,
-          endColumn: column,
-        });
-        // The multi-text before the cursor pointer
-        const textBeforePointerMulti = model.getValueInRange({
-          startLineNumber: 1,
-          startColumn: 0,
-          endLineNumber: lineNumber,
-          endColumn: column,
-        });
-        // The text after the cursor pointer
-        const textAfterPointerMulti = model.getValueInRange({
-          startLineNumber: lineNumber,
-          startColumn: column,
-          endLineNumber: model.getLineCount(),
-          endColumn: model.getLineMaxColumn(model.getLineCount()),
-        });
-        const tokens = textBeforePointer.trim().split(/\s+/);
-        const lastToken = tokens[tokens.length - 1].toLowerCase();
+      const { lineNumber, column } = position;
+      // The text before the cursor pointer
+      const textBeforePointer = model.getValueInRange({
+        startLineNumber: lineNumber,
+        startColumn: 0,
+        endLineNumber: lineNumber,
+        endColumn: column,
+      });
+      // The multi-text before the cursor pointer
+      const textBeforePointerMulti = model.getValueInRange({
+        startLineNumber: 1,
+        startColumn: 0,
+        endLineNumber: lineNumber,
+        endColumn: column,
+      });
+      // The text after the cursor pointer
+      const textAfterPointerMulti = model.getValueInRange({
+        startLineNumber: lineNumber,
+        startColumn: column,
+        endLineNumber: model.getLineCount(),
+        endColumn: model.getLineMaxColumn(model.getLineCount()),
+      });
+      const tokens = textBeforePointer.trim().split(/\s+/);
+      const lastToken = tokens[tokens.length - 1].toLowerCase();
 
-        const autoCompletion = new AutoCompletion(
-          model,
-          position,
-          instanceList.value,
-          databaseList.value,
-          tableList.value
+      const autoCompletion = new AutoCompletion(
+        model,
+        position,
+        databaseList.value,
+        tableList.value
+      );
+
+      // MySQL allows to query different databases, so we provide the database name suggestion for MySQL.
+      const suggestionsForDatabase =
+        lang === "mysql"
+          ? autoCompletion.getCompletionItemsForDatabaseList()
+          : [];
+      const suggestionsForTable =
+        autoCompletion.getCompletionItemsForTableList();
+      const suggestionsForKeyword =
+        autoCompletion.getCompletionItemsForKeywords();
+
+      // if enter a dot
+      if (lastToken.endsWith(".")) {
+        /**
+         * tokenLevel = 1 stands for the database.table or table.column
+         * tokenLevel = 2 stands for the database.table.column
+         */
+        const tokenLevel = lastToken.split(".").length - 1;
+        const lastTokenBeforeDot = lastToken.slice(0, -1);
+        let [databaseName, tableName] = ["", ""];
+        if (tokenLevel === 1) {
+          databaseName = lastTokenBeforeDot;
+          tableName = lastTokenBeforeDot;
+        }
+        if (tokenLevel === 2) {
+          databaseName = lastTokenBeforeDot.split(".").shift() as string;
+          tableName = lastTokenBeforeDot.split(".").pop() as string;
+        }
+        const dbIdx = databaseList.value.findIndex(
+          (item: Database) => item.name === databaseName
+        );
+        const tableIdx = tableList.value.findIndex(
+          (item: Table) => item.name === tableName
         );
 
-        // MySQL allows to query different databases, so we provide the database name suggestion for MySQL.
-        const suggestionsForDatabase =
-          lang === "mysql"
-            ? autoCompletion.getCompletionItemsForDatabaseList()
-            : [];
-
-        const suggestionsForTable =
-          autoCompletion.getCompletionItemsForTableList();
-
-        const suggestionsForKeyword =
-          autoCompletion.getCompletionItemsForKeywords();
-
-        // if enter a dot
-        if (lastToken.endsWith(".")) {
-          /**
-           * tokenLevel = 1 stands for the database.table or table.column
-           * tokenLevel = 2 stands for the database.table.column
-           */
-          const tokenLevel = lastToken.split(".").length - 1;
-          const lastTokenBeforeDot = lastToken.slice(0, -1);
-          let [databaseName, tableName] = ["", ""];
-          if (tokenLevel === 1) {
-            databaseName = lastTokenBeforeDot;
-            tableName = lastTokenBeforeDot;
-          }
-          if (tokenLevel === 2) {
-            databaseName = lastTokenBeforeDot.split(".").shift() as string;
-            tableName = lastTokenBeforeDot.split(".").pop() as string;
-          }
-          const dbIdx = databaseList.value.findIndex(
-            (item: Database) => item.name === databaseName
+        // if the last token is a database name
+        if (lang === "mysql" && dbIdx !== -1 && tokenLevel === 1) {
+          suggestions = autoCompletion.getCompletionItemsForTableList(
+            databaseList.value[dbIdx],
+            true
           );
-          const tableIdx = tableList.value.findIndex(
-            (item: Table) => item.name === tableName
-          );
-
-          // if the last token is a database name
-          if (lang === "mysql" && dbIdx !== -1 && tokenLevel === 1) {
-            suggestions = autoCompletion.getCompletionItemsForTableList(
-              databaseList.value[dbIdx],
-              true
+        }
+        // if the last token is a table name
+        if (tableIdx !== -1 || tokenLevel === 2) {
+          const table = tableList.value[tableIdx];
+          if (table.columnList && table.columnList.length > 0) {
+            suggestions = autoCompletion.getCompletionItemsForTableColumnList(
+              tableList.value[tableIdx],
+              false
             );
           }
-          // if the last token is a table name
-          if (tableIdx !== -1 || tokenLevel === 2) {
-            const table = tableList.value[tableIdx];
-            if (table.columnList && table.columnList.length > 0) {
-              suggestions = autoCompletion.getCompletionItemsForTableColumnList(
-                tableList.value[tableIdx],
-                false
-              );
-            }
-          }
-        } else {
-          suggestions = [
-            ...suggestionsForKeyword,
-            ...suggestionsForTable,
-            ...suggestionsForDatabase,
-          ];
         }
+      } else {
+        suggestions = [
+          ...suggestionsForKeyword,
+          ...suggestionsForTable,
+          ...suggestionsForDatabase,
+        ];
+      }
 
-        return { suggestions };
-      },
-    });
+      return {
+        suggestions,
+      };
+    },
+  });
 
   await Promise.all([
     // load workers
@@ -171,49 +148,43 @@ const useMonaco = async (lang: string) => {
     editorInstance: Editor.IStandaloneCodeEditor,
     content: string
   ) => {
-    if (editorInstance) {
-      const range = editorInstance?.getModel()?.getFullModelRange();
-      // get the current endLineNumber, or use 100000 as the default
-      const endLineNumber =
-        range && range?.endLineNumber > 0 ? range.endLineNumber + 1 : 100000;
-      editorInstance.executeEdits("delete-content", [
-        {
-          range: new monaco.Range(1, 1, endLineNumber, 1),
-          text: "",
-          forceMoveMarkers: true,
-        },
-      ]);
-      // set the new content
-      editorInstance.executeEdits("insert-content", [
-        {
-          range: new monaco.Range(1, 1, 1, 1),
-          text: content,
-          forceMoveMarkers: true,
-        },
-      ]);
-      // reset the selection
-      editorInstance.setSelection(new monaco.Range(0, 0, 0, 0));
-    }
+    const range = editorInstance.getModel()?.getFullModelRange();
+    // get the current endLineNumber, or use 100000 as the default
+    const endLineNumber =
+      range && range?.endLineNumber > 0 ? range.endLineNumber + 1 : 100000;
+    editorInstance.executeEdits("delete-content", [
+      {
+        range: new monaco.Range(1, 1, endLineNumber, 1),
+        text: "",
+        forceMoveMarkers: true,
+      },
+    ]);
+    // set the new content
+    editorInstance.executeEdits("insert-content", [
+      {
+        range: new monaco.Range(1, 1, 1, 1),
+        text: content,
+        forceMoveMarkers: true,
+      },
+    ]);
+    // reset the selection
+    editorInstance.setSelection(new monaco.Range(0, 0, 0, 0));
   };
 
   const formatContent = (
     editorInstance: Editor.IStandaloneCodeEditor,
     language: SQLDialect
   ) => {
-    if (editorInstance) {
-      const sql = editorInstance.getValue();
-      const { data } = sqlFormatter(sql, language);
-      setContent(editorInstance, data);
-    }
+    const sql = editorInstance.getValue();
+    const { data } = sqlFormatter(sql, language);
+    setContent(editorInstance, data);
   };
 
   const setPositionAtEndOfLine = (
     editorInstance: Editor.IStandaloneCodeEditor
   ) => {
-    if (editorInstance) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      const range = editorInstance.getModel().getFullModelRange();
+    const range = editorInstance.getModel()?.getFullModelRange();
+    if (range) {
       editorInstance.setPosition({
         lineNumber: range?.endLineNumber,
         column: range?.endColumn,
@@ -221,11 +192,16 @@ const useMonaco = async (lang: string) => {
     }
   };
 
+  const setAutoCompletionContext = (databases: Database[], tables: Table[]) => {
+    databaseList.value = databases;
+    tableList.value = tables;
+  };
+
   return {
     monaco,
-    completionItemProvider,
-    formatContent,
     setContent,
+    formatContent,
+    setAutoCompletionContext,
     setPositionAtEndOfLine,
   };
 };

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -1,4 +1,5 @@
 import { ref } from "vue";
+import { uniqBy } from "lodash-es";
 import * as monaco from "monaco-editor";
 import type { editor as Editor } from "monaco-editor";
 import { Database, Table, CompletionItems, SQLDialect } from "@/types";
@@ -116,7 +117,7 @@ const useMonaco = async (lang: string) => {
       }
 
       return {
-        suggestions,
+        suggestions: uniqBy(suggestions, "label"),
       };
     },
   });

--- a/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
@@ -3,7 +3,7 @@
     <EditorAction @save-sheet="handleSaveSheet" />
 
     <template v-if="!sqlEditorStore.isDisconnected">
-      <QueryEditor @save-sheet="handleSaveSheet" />
+      <SQLEditor @save-sheet="handleSaveSheet" />
     </template>
     <template v-else>
       <ConnectionHolder />
@@ -30,12 +30,12 @@
 import { ref } from "vue";
 
 import { useTabStore, useSQLEditorStore, useSheetStore } from "@/store";
+import { defaultTabName } from "@/utils/tab";
 import EditorAction from "./EditorAction.vue";
-import QueryEditor from "./QueryEditor.vue";
+import SQLEditor from "./SQLEditor.vue";
 import ExecuteHint from "./ExecuteHint.vue";
 import ConnectionHolder from "./ConnectionHolder.vue";
 import SaveSheetModal from "./SaveSheetModal.vue";
-import { defaultTabName } from "../../../utils/tab";
 
 const tabStore = useTabStore();
 const sqlEditorStore = useSQLEditorStore();

--- a/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
@@ -1,20 +1,27 @@
 <template>
   <MonacoEditor
+    ref="editorRef"
     v-model:value="sqlCode"
     :language="selectedLanguage"
     @change="handleChange"
     @change-selection="handleChangeSelection"
     @run-query="handleRunQuery"
-    @save="(e) => emit('save-sheet')"
+    @save="handleSaveSheet"
   />
 </template>
 
 <script lang="ts" setup>
 import { debounce } from "lodash-es";
-import { computed, defineEmits } from "vue";
-
-import { useInstanceStore, useTabStore, useSQLEditorStore } from "@/store";
+import { computed, defineEmits, ref, watch } from "vue";
+import {
+  useInstanceStore,
+  useTabStore,
+  useSQLEditorStore,
+  useDatabaseStore,
+  useTableStore,
+} from "@/store";
 import { useExecuteSQL } from "@/composables/useExecuteSQL";
+import MonacoEditor from "@/components/MonacoEditor/MonacoEditor.vue";
 
 const emit = defineEmits<{
   (e: "save-sheet", content?: string): void;
@@ -22,7 +29,11 @@ const emit = defineEmits<{
 
 const instanceStore = useInstanceStore();
 const tabStore = useTabStore();
+const databaseStore = useDatabaseStore();
+const tableStore = useTableStore();
 const sqlEditorStore = useSQLEditorStore();
+
+const editorRef = ref<InstanceType<typeof MonacoEditor>>();
 
 const { execute } = useExecuteSQL();
 
@@ -46,6 +57,19 @@ const selectedLanguage = computed(() => {
   return "sql";
 });
 
+watch(selectedInstance, () => {
+  if (selectedInstance.value) {
+    const databaseList = databaseStore.getDatabaseListByInstanceId(
+      selectedInstance.value.id
+    );
+    const tableList = databaseList
+      .map((item) => tableStore.getTableListByDatabaseId(item.id))
+      .flat();
+
+    editorRef.value?.setAutoCompletionContext(databaseList, tableList);
+  }
+});
+
 const handleChange = debounce((value: string) => {
   tabStore.updateCurrentTab({
     statement: value,
@@ -67,5 +91,9 @@ const handleRunQuery = ({
   query: string;
 }) => {
   execute({ databaseType: selectedInstanceEngine.value }, { explain });
+};
+
+const handleSaveSheet = () => {
+  emit("save-sheet");
 };
 </script>


### PR DESCRIPTION
The `MonacoEditor` and `useMonaco` should not depend on any store, so that it can be used elsewhere. e.g. issueDetailPage