### PR TITLE
feat(frontend): display applicable conditions for Environment policies

### DIFF
--- a/frontend/src/assets/css/tailwind.css
+++ b/frontend/src/assets/css/tailwind.css
@@ -122,6 +122,10 @@
   @apply text-sm font-normal text-control-light;
 }
 
+.textlabeltip {
+  @apply text-xs font-normal text-red-500 ml-2;
+}
+
 .textfield {
   @apply text-main disabled:text-control disabled:bg-gray-50 focus:ring-control focus:border-control sm:text-sm border-control-border rounded-md;
 }

--- a/frontend/src/components/EnvironmentForm.vue
+++ b/frontend/src/components/EnvironmentForm.vue
@@ -15,6 +15,9 @@
       </div>
       <div class="col-span-1">
         <label class="textlabel"> {{ $t("policy.approval.name") }} </label>
+        <span v-show="valueChanged('approvalPolicy')" class="textlabeltip">{{
+          $t("policy.approval.tip")
+        }}</span>
         <div class="mt-1 textinfolabel">
           {{ $t("policy.approval.info") }}
         </div>
@@ -63,6 +66,9 @@
       </div>
       <div class="col-span-1">
         <label class="textlabel"> {{ $t("policy.backup.name") }} </label>
+        <span v-show="valueChanged('backupPolicy')" class="textlabeltip">{{
+          $t("policy.backup.tip")
+        }}</span>
         <div class="mt-4 flex flex-col space-y-4">
           <div class="flex space-x-4">
             <input
@@ -128,7 +134,7 @@
           </div>
         </div>
       </div>
-      <div class="col-span-1" v-if="!create">
+      <div v-if="!create" class="col-span-1">
         <label class="textlabel">
           {{ $t("schema-review-policy.title") }}
         </label>
@@ -211,7 +217,7 @@
         <button
           type="button"
           class="btn-normal py-2 px-4"
-          :disabled="!valueChanged"
+          :disabled="!valueChanged()"
           @click.prevent="revertEnvironment"
         >
           {{ $t("common.revert") }}
@@ -219,7 +225,7 @@
         <button
           type="submit"
           class="btn-primary ml-3 inline-flex justify-center py-2 px-4"
-          :disabled="!valueChanged"
+          :disabled="!valueChanged()"
           @click.prevent="updateEnvironment"
         >
           {{ $t("common.update") }}
@@ -386,17 +392,29 @@ export default defineComponent({
       );
     });
 
-    const valueChanged = computed(() => {
-      return (
-        !isEqual(props.environment, state.environment) ||
-        !isEqual(props.approvalPolicy, state.approvalPolicy) ||
-        !isEqual(props.backupPolicy, state.backupPolicy)
-      );
-    });
-
     const allowCreate = computed(() => {
       return !isEmpty(state.environment?.name);
     });
+
+    const valueChanged = (
+      field?: "environment" | "approvalPolicy" | "backupPolicy"
+    ): boolean => {
+      switch (field) {
+        case "environment":
+          return !isEqual(props.environment, state.environment);
+        case "approvalPolicy":
+          return !isEqual(props.approvalPolicy, state.approvalPolicy);
+        case "backupPolicy":
+          return !isEqual(props.backupPolicy, state.backupPolicy);
+
+        default:
+          return (
+            !isEqual(props.environment, state.environment) ||
+            !isEqual(props.approvalPolicy, state.approvalPolicy) ||
+            !isEqual(props.backupPolicy, state.backupPolicy)
+          );
+      }
+    };
 
     const revertEnvironment = () => {
       state.environment = cloneDeep(props.environment!);

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -685,6 +685,7 @@
   "policy": {
     "approval": {
       "name": "Approval Policy",
+      "tip": "The policy is not applied retroactively.",
       "info": "For updating schema on the existing database, this setting controls whether the task requires manual approval.",
       "manual": "Require manual approval",
       "manual-info": "Pending schema migration task will only be executed after it's manually approved.",
@@ -693,6 +694,7 @@
     },
     "backup": {
       "name": "Database backup schedule policy",
+      "tip": "The policy is not applied retroactively.",
       "not-enforced": "Not enforced",
       "not-enforced-info": "No backup schedule is enforced.",
       "daily": "Daily backup",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -685,6 +685,7 @@
   "policy": {
     "approval": {
       "name": "审批策略",
+      "tip": "新策略仅对新建工单生效",
       "info": "要更改数据库 schema，该选项控制了是否需要手动审批。",
       "manual": "需要人工审批",
       "manual-info": "进行中的 schema 改动任务只有被人工审批后才会执行。",
@@ -693,6 +694,7 @@
     },
     "backup": {
       "name": "数据库备份策略",
+      "tip": "新策略仅对新添加的数据库生效",
       "not-enforced": "无策略",
       "not-enforced-info": "无备份策略。",
       "daily": "每日",

--- a/frontend/src/views/EnvironmentDetail.vue
+++ b/frontend/src/views/EnvironmentDetail.vue
@@ -167,7 +167,11 @@ export default defineComponent({
           },
         })
         .then((policy: Policy) => {
-          state.backupPolicy = policy;
+          if (type === "bb.policy.pipeline-approval") {
+            state.approvalPolicy = policy;
+          } else if (type === "bb.policy.backup-plan") {
+            state.backupPolicy = policy;
+          }
         });
     };
 


### PR DESCRIPTION
- Fixes: Updating Approval Policy will lose selection on Database backup schedule policy
- Feat: Display applicable conditions for Environment policies. Add a tip in red "The policy is not applied retroactively" when users are updating Environment policies.

| before | after |
| :---: | :---: |
| ![CleanShot 2022-06-07 at 11 17 35](https://user-images.githubusercontent.com/56376387/172288366-174f7b51-c3af-49b3-bb58-f85d760e4327.gif) | ![CleanShot 2022-06-07 at 11 14 51](https://user-images.githubusercontent.com/56376387/172288272-e9ec2688-745f-44b4-aa54-8de54bfdd76f.gif) |