### PR TITLE
fix: run goreleaser on push tags

### DIFF
--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -1,4 +1,4 @@
-name: build release image and push to docker hub
+name: build release image and push to docker hub.
 
 on:
   push:
@@ -54,31 +54,3 @@ jobs:
             BUILD_USER=${{ env.BUILD_USER }}
       - name: Image digest
         run: echo "Successfully pushed bytebase/bb:${{ env.RELEASE_VERSION }} ${{ steps.bb_build.outputs.digest }}"
-
-  release-binary:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.1.0
-        with:
-          version: 6.10.0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "14"
-          cache: pnpm
-          cache-dependency-path: "frontend/pnpm-lock.yaml"
-      - run: pnpm install --frozen-lockfile
-        working-directory: frontend
-      - run: pnpm release
-        working-directory: frontend
-      - name: Extract version
-        run: git tag ${GITHUB_REF_NAME#release/v}
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-      - name: Release
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          args: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,35 @@
+name: build release binaries and create release notes.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release-binary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 6.10.0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "14"
+          cache: pnpm
+          cache-dependency-path: "frontend/pnpm-lock.yaml"
+      - run: pnpm install --frozen-lockfile
+        working-directory: frontend
+      - run: pnpm release
+        working-directory: frontend
+      - name: Extract version
+        run: git tag ${GITHUB_REF_NAME#release/v}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -3,7 +3,7 @@ name: build release binaries and create release notes.
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*.*.*"
 
 jobs:
   release-binary:


### PR DESCRIPTION
The example from the official doc runs the action on tags creation. Many other examples from source graph did the same thing.
https://github.com/goreleaser/goreleaser-action#run-on-new-tag