### PR TITLE
fix: ignore fake binlog event header of mysqlbinlog output

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+
+	"go.uber.org/zap/zapcore"
 )
 
 // BackupStatus is the status of a backup.
@@ -120,6 +123,21 @@ type Backup struct {
 	// Payload contains data such as binlog position info which will not be created at first.
 	// It is filled when the backup task executor takes database backups.
 	Payload BackupPayload `jsonapi:"attr,payload"`
+}
+
+// ZapBackupArray is a helper to format zap.Array
+type ZapBackupArray []*Backup
+
+// MarshalLogArray implements the zapcore.ArrayMarshaler interface
+func (backups ZapBackupArray) MarshalLogArray(arr zapcore.ArrayEncoder) error {
+	for _, backup := range backups {
+		payload, err := json.Marshal(backup.Payload)
+		if err != nil {
+			return err
+		}
+		arr.AppendString(fmt.Sprintf("{name:%s, id:%d, payload:%s}", backup.Name, backup.ID, payload))
+	}
+	return nil
 }
 
 // BackupCreate is the API message for creating a backup.

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -281,6 +281,11 @@ func parseBinlogEventTimestampImpl(output string) (int64, error) {
 	// The first occurrence is the target.
 	for _, line := range lines {
 		if strings.Contains(line, "server id") {
+			if strings.Contains(line, "end_log_pos 0") {
+				// https://github.com/mysql/mysql-server/blob/8.0/client/mysqlbinlog.cc#L1209-L1212
+				// Fake events with end_log_pos=0 could be generated and we need to ignore them.
+				continue
+			}
 			fields := strings.Fields(line)
 			// fields should starts with ["#220421", "14:49:26", "server", "id"]
 			if len(fields) < 4 ||
@@ -312,6 +317,7 @@ func (r *Restore) GetLatestBackupBeforeOrEqualTs(ctx context.Context, backupList
 		}
 		eventTsList = append(eventTsList, eventTs)
 	}
+	log.Debug("Binlog event ts list of backups", zap.Int64s("eventTsList", eventTsList))
 
 	backup, err := getLatestBackupBeforeOrEqualTsImpl(backupList, eventTsList, targetTs)
 	if err != nil {

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -197,7 +197,7 @@ DELIMITER ;
 # End of log file
 /*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
 /*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
-			timestamp: time.Date(2022, 4, 21, 14, 49, 26, 0, time.Local).Unix(),
+			timestamp: time.Date(2022, 4, 25, 17, 32, 13, 0, time.Local).Unix(),
 			err:       false,
 		},
 		// Edge case: invalid mysqlbinlog option

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -96,7 +96,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 		return err
 	}
 
-	log.Debug("Get latest backup before or equal to targetTs", zap.Time("targetTs", time.Unix(targetTs, 0)))
+	log.Debug("Getting latest backup before or equal to targetTs...", zap.Time("targetTs", time.Unix(targetTs, 0)))
 	backup, err := mysqlRestore.GetLatestBackupBeforeOrEqualTs(ctx, backupList, targetTs)
 	if err != nil {
 		log.Error("Failed to get backup before or equal to targetTs",

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -70,6 +70,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 	if err != nil {
 		return err
 	}
+	log.Debug("Found backup list", zap.Array("backups", api.ZapBackupArray(backupList)))
 
 	connCfg, err := getConnectionConfig(ctx, instance, database.Name)
 	if err != nil {
@@ -103,6 +104,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 			zap.Error(err))
 		return fmt.Errorf("failed to get latest backup before or equal to targetTs[%d], error[%w]", targetTs, err)
 	}
+	log.Debug("Got latest backup before or equal to targetTs", zap.String("backup", backup.Name))
 	backupFileName := getBackupAbsFilePath(dataDir, backup.DatabaseID, backup.Name)
 	backupFile, err := os.OpenFile(backupFileName, os.O_RDONLY, os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
According to the mysqlbinlog source code, there would be fake binlog events in the output.
https://github.com/mysql/mysql-server/blob/8.0/client/mysqlbinlog.cc#L1209-L1212

And the output format is `end_log_pos %s`.
https://github.com/mysql/mysql-server/blob/8.0/sql/log_event.cc#L1407

So the fix is ignore lines with `end_log_pos 0`.
Completing BYT-696.