### PR TITLE
fix: don't parse binlog event timestamp of backup which binlogInfo field is empty

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -85,6 +85,11 @@ type BinlogInfo struct {
 	Position int64  `json:"position"`
 }
 
+// IsEmpty return true if the BinlogInfo is empty.
+func (b BinlogInfo) IsEmpty() bool {
+	return b == BinlogInfo{}
+}
+
 // BackupPayload contains backup related database specific info, it differs for different database types.
 // It is encoded in JSON and stored in the backup table.
 type BackupPayload struct {

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -340,6 +340,9 @@ func getLatestBackupBeforeOrEqualTsImpl(backupList []*api.Backup, eventTsList []
 	var backup *api.Backup
 	for i, b := range backupList {
 		// Parse the binlog files and convert binlog positions into MySQL server timestamps.
+		if b.Payload.BinlogInfo.IsEmpty() {
+			continue
+		}
 		eventTs := eventTsList[i]
 		if eventTs <= targetTs && eventTs > maxEventTsLETargetTs {
 			maxEventTsLETargetTs = eventTs

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -310,13 +310,13 @@ func (r *Restore) GetLatestBackupBeforeOrEqualTs(ctx context.Context, backupList
 	}
 
 	var eventTsList []int64
-	var backupWithValidBinlogInfoList []*api.Backup
+	var validBackupList []*api.Backup
 	for _, b := range backupList {
 		if b.Payload.BinlogInfo.IsEmpty() {
 			log.Debug("Skip parse binlog event timestamp of backup which binlogInfo field in payload field is empty", zap.Int("Id", b.ID))
 			continue
 		}
-		backupWithValidBinlogInfoList = append(backupWithValidBinlogInfoList, b)
+		validBackupList = append(validBackupList, b)
 		eventTs, err := r.parseBinlogEventTimestamp(ctx, b.Payload.BinlogInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse binlog event timestamp, error[%w]", err)
@@ -325,7 +325,7 @@ func (r *Restore) GetLatestBackupBeforeOrEqualTs(ctx context.Context, backupList
 	}
 	log.Debug("Binlog event ts list of backups", zap.Int64s("eventTsList", eventTsList))
 
-	backup, err := getLatestBackupBeforeOrEqualTsImpl(backupWithValidBinlogInfoList, eventTsList, targetTs)
+	backup, err := getLatestBackupBeforeOrEqualTsImpl(validBackupList, eventTsList, targetTs)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/restore/mysql/mysql.go
+++ b/plugin/restore/mysql/mysql.go
@@ -313,7 +313,7 @@ func (r *Restore) GetLatestBackupBeforeOrEqualTs(ctx context.Context, backupList
 	var validBackupList []*api.Backup
 	for _, b := range backupList {
 		if b.Payload.BinlogInfo.IsEmpty() {
-			log.Debug("Skip parse binlog event timestamp of backup which binlogInfo field in payload field is empty", zap.Int("Id", b.ID))
+			log.Debug("Skip parsing binlog event timestamp of the backup where BinlogInfo is empty", zap.Int("backupId", b.ID), zap.String("backupName", b.Name))
 			continue
 		}
 		validBackupList = append(validBackupList, b)

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -256,6 +256,20 @@ func TestGetLatestBackupBeforeOrEqualTsImpl(t *testing.T) {
 			},
 			err: false,
 		},
+		// backup with empty binlog info does not count
+		{
+			backupList: []*api.Backup{
+				{Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{FileName: "binlog.000001", Position: 10}}},
+				{Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{}}},
+				{Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{FileName: "binlog.000002", Position: 10}}},
+			},
+			eventTsList: []int64{1, 2, 3},
+			targetTs:    2,
+			targetBackup: &api.Backup{
+				Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{FileName: "binlog.000001", Position: 10}},
+			},
+			err: false,
+		},
 		// no valid backup found
 		{
 			backupList: []*api.Backup{

--- a/plugin/restore/mysql/mysql_test.go
+++ b/plugin/restore/mysql/mysql_test.go
@@ -256,20 +256,6 @@ func TestGetLatestBackupBeforeOrEqualTsImpl(t *testing.T) {
 			},
 			err: false,
 		},
-		// backup with empty binlog info does not count
-		{
-			backupList: []*api.Backup{
-				{Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{FileName: "binlog.000001", Position: 10}}},
-				{Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{}}},
-				{Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{FileName: "binlog.000002", Position: 10}}},
-			},
-			eventTsList: []int64{1, 2, 3},
-			targetTs:    2,
-			targetBackup: &api.Backup{
-				Payload: api.BackupPayload{BinlogInfo: api.BinlogInfo{FileName: "binlog.000001", Position: 10}},
-			},
-			err: false,
-		},
 		// no valid backup found
 		{
 			backupList: []*api.Backup{

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -66,7 +66,8 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 		return err
 	}
 
-	backupList, err := store.FindBackup(ctx, &api.BackupFind{DatabaseID: task.DatabaseID})
+	backupStatus := api.BackupStatusDone
+	backupList, err := store.FindBackup(ctx, &api.BackupFind{DatabaseID: task.DatabaseID, Status: &backupStatus})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We update the schema of the backup table. The payload field of stale full backup is empty. And backup of database with binlog disabled also has empty payload.
So that we need to skip it when parsing the event timestamp.
Completing BYT-699.