### PR TITLE
feat(frontend): make the running status icon more obvious

### DIFF
--- a/frontend/src/components/Issue/IssueStatusIcon.vue
+++ b/frontend/src/components/Issue/IssueStatusIcon.vue
@@ -1,15 +1,22 @@
 <template>
   <span
-    class="flex items-center justify-center rounded-full select-none"
+    class="flex items-center justify-center rounded-full select-none overflow-hidden"
     :class="issueIconClass()"
   >
     <template v-if="issueStatus === `OPEN`">
-      <span
-        v-if="taskStatus === 'RUNNING'"
-        class="h-2 w-2 bg-info rounded-full"
-        style="animation: pulse 2.5s cubic-bezier(0.4, 0, 0.6, 1) infinite"
-        aria-hidden="true"
-      ></span>
+      <template v-if="taskStatus === 'RUNNING'">
+        <div class="flex h-2 w-2 relative overflow-visible">
+          <span
+            class="w-full h-full rounded-full z-0 absolute animate-ping-slow"
+            style="background-color: rgba(37, 99, 235, 0.5); /* bg-info/50 */"
+            aria-hidden="true"
+          ></span>
+          <span
+            class="w-full h-full rounded-full z-[1] bg-info"
+            aria-hidden="true"
+          ></span>
+        </div>
+      </template>
       <span
         v-else-if="taskStatus === 'FAILED'"
         class="h-2 w-2 rounded-full text-center pb-6 font-normal text-base"

--- a/frontend/src/components/Issue/TaskStatusIcon.vue
+++ b/frontend/src/components/Issue/TaskStatusIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative flex flex-shrink-0 items-center justify-center rounded-full select-none w-6 h-6"
+    class="relative flex flex-shrink-0 items-center justify-center rounded-full select-none w-6 h-6 overflow-hidden"
     :class="classes"
   >
     <template v-if="status === 'PENDING'">
@@ -19,11 +19,17 @@
       <heroicons-outline:user class="w-4 h-4" />
     </template>
     <template v-else-if="status === 'RUNNING'">
-      <span
-        class="h-2.5 w-2.5 bg-info rounded-full"
-        style="animation: pulse 2.5s cubic-bezier(0.4, 0, 0.6, 1) infinite"
-        aria-hidden="true"
-      ></span>
+      <div class="flex h-2.5 w-2.5 relative overflow-visible">
+        <span
+          class="w-full h-full rounded-full z-0 absolute animate-ping-slow"
+          style="background-color: rgba(37, 99, 235, 0.5); /* bg-info/50 */"
+          aria-hidden="true"
+        ></span>
+        <span
+          class="w-full h-full rounded-full z-[1] bg-info"
+          aria-hidden="true"
+        ></span>
+      </div>
     </template>
     <template v-else-if="status === 'DONE'">
       <heroicons-solid:check class="w-5 h-5" />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -80,6 +80,21 @@ module.exports = {
         192: "48rem",
         208: "52rem",
       },
+      animation: {
+        "ping-slow": "ping-slow 2500ms cubic-bezier(0.4, 0, 0.6, 1) infinite",
+      },
+      keyframes: {
+        "ping-slow": {
+          "50%": {
+            transform: "scale(3)",
+            opacity: "0.05",
+          },
+          "100%": {
+            transform: "scale(3)",
+            opacity: "0",
+          },
+        },
+      },
     },
   },
   variants: {


### PR DESCRIPTION
Close BYT-704

The screenshot GIF's quality is quite low to show the actual effect.

![running-icon](https://user-images.githubusercontent.com/2749742/173977515-baddba15-8696-4839-83d7-aaec547e20db.gif)
