### PR TITLE
feat: disable auto removing the old table

### DIFF
--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -135,8 +135,6 @@ func newMigrationContext(config ghostConfig) (*base.MigrationContext, error) {
 	}
 	migrationContext.ServeSocketFile = config.socketFilename
 	migrationContext.PostponeCutOverFlagFile = config.postponeFlagFilename
-	// TODO(p0ny): set OkToDropTable to false and drop table in dropOriginalTable Task.
-	migrationContext.OkToDropTable = true
 	migrationContext.SetHeartbeatIntervalMilliseconds(heartbeatIntervalMilliseconds)
 	migrationContext.SetNiceRatio(niceRatio)
 	migrationContext.SetChunkSize(chunkSize)


### PR DESCRIPTION
Disable auto removing the old table. We require the user to manually drop the old table.