### PR TITLE
chore: update pricing page url

### DIFF
--- a/frontend/src/components/PricingTable.vue
+++ b/frontend/src/components/PricingTable.vue
@@ -398,7 +398,7 @@ export default defineComponent({
     const onButtonClick = (plan: Plan) => {
       if (plan.type === PlanType.TEAM) {
         window.open(
-          "https://hub.bytebase.com/pricing?plan=team&source=console.subscription",
+          "https://bytebase.com/pricing?source=console.subscription",
           "__blank"
         );
       } else if (plan.type === PlanType.ENTERPRISE) {

--- a/frontend/src/views/SettingWorkspaceSubscription.vue
+++ b/frontend/src/views/SettingWorkspaceSubscription.vue
@@ -4,7 +4,7 @@
       {{ $t("subscription.description") }}
       <a
         class="text-accent"
-        href="https://hub.bytebase.com/pricing?plan=team&source=console.subscription"
+        href="https://bytebase.com/pricing?source=console.subscription"
         target="__blank"
       >
         {{ $t("subscription.description-highlight") }}
@@ -73,7 +73,6 @@
 <script lang="ts">
 import { computed, defineComponent, reactive } from "vue";
 import { useI18n } from "vue-i18n";
-import dayjs from "dayjs";
 import PricingTable from "../components/PricingTable.vue";
 import { PlanType } from "../types";
 import { pushNotification, useSubscriptionStore } from "@/store";


### PR DESCRIPTION
As we will remove the /pricing page in the hub in the future, we need to update the URL in the console first.