### PR TITLE
chore: remove the version check for transferring database into tenant mode project

### DIFF
--- a/server/database.go
+++ b/server/database.go
@@ -235,13 +235,6 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 						return err
 					}
 					defer driver.Close(ctx)
-					schemaVersion, err := getLatestSchemaVersion(ctx, driver, database.Name)
-					if err != nil {
-						return fmt.Errorf("failed to get migration history for database %q: %w", database.Name, err)
-					}
-					if peerSchemaVersion != schemaVersion {
-						return fmt.Errorf("the schema version %q does not match the peer database schema version %q in the target tenant mode project %q", schemaVersion, peerSchemaVersion, toProject.Name)
-					}
 
 					var schemaBuf bytes.Buffer
 					if _, err := driver.Dump(ctx, database.Name, &schemaBuf, true /* schemaOnly */); err != nil {


### PR DESCRIPTION
The check was too restricted.