### PR TITLE
fix: pg schema failure of comparison due to different exported comments

### DIFF
--- a/server/database.go
+++ b/server/database.go
@@ -1024,7 +1024,6 @@ func stripComment(schema string) (string, error) {
 		}
 		if _, err := io.WriteString(&schemaBuf, scanner.Text()); err != nil {
 			return "", err
-
 		}
 	}
 	return schemaBuf.String(), nil


### PR DESCRIPTION
Fix the failure of comparison due to different exported comments.

https://github.com/bytebase/bytebase/blob/fb918e058a6d59c774f7fe652f65de31aadc8bb9/server/database.go#L243

@d-bytebase 