### PR TITLE
feat: support controllable issue retries

### DIFF
--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -720,7 +720,7 @@ func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.Migra
 	UPDATE
 		migration_history
 	SET
-		status = $1,
+		status = $1
 	WHERE id = $2
 	`
 	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -714,6 +714,19 @@ const (
 		"%s;\n"
 )
 
+// PatchMigrationHistory patches the migration history.
+func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.MigrationHistoryPatch) error {
+	const patchMigrationHistoryQuery = `
+	UPDATE
+		migration_history
+	SET
+		status = $1,
+	WHERE id = $2
+	`
+	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)
+	return err
+}
+
 // Dump dumps the database.
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -568,6 +568,20 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 	return err
 }
 
+// UpdateHistoryAsPending will update the migration record as pending.
+func (Driver) UpdateHistoryAsPending(ctx context.Context, tx *sql.Tx, insertedID int64) error {
+	const updateHistoryAsFailedQuery = `
+		ALTER TABLE
+			bytebase.migration_history
+		UPDATE
+			status = 'PENDING',
+			execution_duration_ns = 0
+		WHERE id = $1
+	`
+	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, insertedID)
+	return err
+}
+
 // ExecuteMigration will execute the migration.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
 	return util.ExecuteMigration(ctx, driver, m, statement, db.BytebaseDatabase)

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -210,6 +210,8 @@ const (
 	Done MigrationStatus = "DONE"
 	// Failed is the migration status for FAILED.
 	Failed MigrationStatus = "FAILED"
+	// WaitRetry is the migration status for WAIT_RETRY.
+	WaitRetry MigrationStatus = "WAIT_RETRY"
 )
 
 func (e MigrationStatus) String() string {
@@ -220,6 +222,8 @@ func (e MigrationStatus) String() string {
 		return "DONE"
 	case Failed:
 		return "FAILED"
+	case WaitRetry:
+		return "WAIT_RETRY"
 	}
 	return "UNKNOWN"
 }
@@ -375,6 +379,13 @@ type MigrationHistoryFind struct {
 	Limit *int
 }
 
+// MigrationHistoryPatch is the API message for patching migration history.
+type MigrationHistoryPatch struct {
+	ID *int
+
+	Status MigrationStatus
+}
+
 // ConnectionConfig is the configuration for connections.
 type ConnectionConfig struct {
 	Host      string
@@ -425,6 +436,8 @@ type Driver interface {
 	ExecuteMigration(ctx context.Context, m *MigrationInfo, statement string) (int64, string, error)
 	// Find the migration history list and return most recent item first.
 	FindMigrationHistoryList(ctx context.Context, find *MigrationHistoryFind) ([]*MigrationHistory, error)
+	// Patch the migration history status with the given id.
+	PatchMigrationHistory(ctx context.Context, patch *MigrationHistoryPatch) error
 
 	// Dump and restore
 	// Dump the database, if dbName is empty, then dump all databases.

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -727,6 +727,20 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 	return err
 }
 
+// UpdateHistoryAsPending will update the migration record as pending.
+func (Driver) UpdateHistoryAsPending(ctx context.Context, tx *sql.Tx, insertedID int64) error {
+	const updateHistoryAsFailedQuery = `
+		UPDATE
+			bytebase.migration_history
+		SET
+			status = 'PENDING',
+			execution_duration_ns = 0
+		WHERE id = ?
+		`
+	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, insertedID)
+	return err
+}
+
 // ExecuteMigration will execute the migration.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
 	return util.ExecuteMigration(ctx, driver, m, statement, db.BytebaseDatabase)

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -860,7 +860,7 @@ func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.Migra
 	UPDATE
 		migration_history
 	SET
-		status = ?,
+		status = ?
 	WHERE id = ?
 	`
 	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -854,6 +854,19 @@ func (driver *Driver) updateMigrationHistoryStorageVersion(ctx context.Context) 
 	return nil
 }
 
+// PatchMigrationHistory patches the migration history.
+func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.MigrationHistoryPatch) error {
+	const patchMigrationHistoryQuery = `
+	UPDATE
+		migration_history
+	SET
+		status = ?,
+	WHERE id = ?
+	`
+	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)
+	return err
+}
+
 // Dump and restore
 const (
 	databaseHeaderFmt = "" +

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -755,6 +755,20 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 	return err
 }
 
+// UpdateHistoryAsPending will update the migration record as pending.
+func (Driver) UpdateHistoryAsPending(ctx context.Context, tx *sql.Tx, insertedID int64) error {
+	const updateHistoryAsFailedQuery = `
+	UPDATE
+		migration_history
+	SET
+		status = 'PENDING',
+		execution_duration_ns = 0
+	WHERE id = $1
+	`
+	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, insertedID)
+	return err
+}
+
 // ExecuteMigration will execute the migration.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
 	if driver.strictUseDb() {

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -896,6 +896,19 @@ func (driver *Driver) updateMigrationHistoryStorageVersion(ctx context.Context) 
 	return nil
 }
 
+// PatchMigrationHistory patches the migration history.
+func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.MigrationHistoryPatch) error {
+	const patchMigrationHistoryQuery = `
+	UPDATE
+		migration_history
+	SET
+		status = $1,
+	WHERE id = $2
+	`
+	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)
+	return err
+}
+
 // Dump and restore
 
 // Dump dumps the database.

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -902,7 +902,7 @@ func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.Migra
 	UPDATE
 		migration_history
 	SET
-		status = $1,
+		status = $1
 	WHERE id = $2
 	`
 	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -886,7 +886,7 @@ func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.Migra
 	UPDATE
 		migration_history
 	SET
-		status = ?,
+		status = ?
 	WHERE id = ?
 	`
 	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -880,6 +880,19 @@ const (
 		"--\n"
 )
 
+// PatchMigrationHistory patches the migration history.
+func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.MigrationHistoryPatch) error {
+	const patchMigrationHistoryQuery = `
+	UPDATE
+		migration_history
+	SET
+		status = ?,
+	WHERE id = ?
+	`
+	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)
+	return err
+}
+
 // Dump dumps the database.
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -742,6 +742,20 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 	return err
 }
 
+// UpdateHistoryAsPending will update the migration record as pending.
+func (Driver) UpdateHistoryAsPending(ctx context.Context, tx *sql.Tx, insertedID int64) error {
+	const updateHistoryAsFailedQuery = `
+		UPDATE
+			bytebase.public.migration_history
+		SET
+			status = 'PENDING',
+			execution_duration_ns = 0
+		WHERE id = ?
+	`
+	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, insertedID)
+	return err
+}
+
 // ExecuteMigration will execute the migration.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
 	if err := driver.useRole(ctx, sysAdminRole); err != nil {

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -573,6 +573,20 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 	return err
 }
 
+// UpdateHistoryAsPending will update the migration record as pending.
+func (Driver) UpdateHistoryAsPending(ctx context.Context, tx *sql.Tx, insertedID int64) error {
+	const updateHistoryAsFailedQuery = `
+	UPDATE
+		bytebase_migration_history
+	SET
+		status = 'PENDING',
+		execution_duration_ns = 0
+	WHERE id = ?
+	`
+	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, insertedID)
+	return err
+}
+
 // ExecuteMigration will execute the migration.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
 	return util.ExecuteMigration(ctx, driver, m, statement, bytebaseDatabase)

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -649,7 +649,7 @@ func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.Migra
 	UPDATE
 		migration_history
 	SET
-		status = ?,
+		status = ?
 	WHERE id = ?
 	`
 	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -643,6 +643,19 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 	return util.FindMigrationHistoryList(ctx, query, params, driver, bytebaseDatabase, find, baseQuery)
 }
 
+// PatchMigrationHistory patches the migration history.
+func (driver *Driver) PatchMigrationHistory(ctx context.Context, patch *db.MigrationHistoryPatch) error {
+	const patchMigrationHistoryQuery = `
+	UPDATE
+		migration_history
+	SET
+		status = ?,
+	WHERE id = ?
+	`
+	_, err := driver.db.ExecContext(ctx, patchMigrationHistoryQuery, patch.Status, patch.ID)
+	return err
+}
+
 // Dump dumps the database.
 func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
 	if database == "" {

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -217,6 +217,9 @@ func BeginMigration(ctx context.Context, executor MigrationExecutor, m *db.Migra
 			return -1, common.Errorf(common.MigrationPending,
 				fmt.Errorf("database %q version %s migration is already in progress", m.Database, m.Version))
 		case db.Failed:
+			return -1, common.Errorf(common.MigrationFailed,
+				fmt.Errorf("database %q version %s migration has failed, please check your database to make sure things are fine and then start a new migration using a new version ", m.Database, m.Version))
+		case db.WaitRetry:
 			isRetry = true
 			retryID = int64(list[0].ID)
 		}

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -159,7 +159,7 @@ func ExecuteMigration(ctx context.Context, executor MigrationExecutor, m *db.Mig
 	// Branch migration type always has empty sql.
 	// Baseline migration type could has non-empty sql but will not execute, except for CreateDatabase.
 	// https://github.com/bytebase/bytebase/issues/394
-	doMigrate := true
+	var doMigrate = true
 	if statement == "" {
 		doMigrate = false
 	}
@@ -209,9 +209,6 @@ func BeginMigration(ctx context.Context, executor MigrationExecutor, m *db.Migra
 		case db.Pending:
 			return -1, common.Errorf(common.MigrationPending,
 				fmt.Errorf("database %q version %s migration is already in progress", m.Database, m.Version))
-		case db.Failed:
-			return -1, common.Errorf(common.MigrationFailed,
-				fmt.Errorf("database %q version %s migration has failed, please check your database to make sure things are fine and then start a new migration using a new version ", m.Database, m.Version))
 		}
 	}
 

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -161,7 +161,7 @@ func ExecuteMigration(ctx context.Context, executor MigrationExecutor, m *db.Mig
 	// Branch migration type always has empty sql.
 	// Baseline migration type could has non-empty sql but will not execute, except for CreateDatabase.
 	// https://github.com/bytebase/bytebase/issues/394
-	var doMigrate = true
+	doMigrate := true
 	if statement == "" {
 		doMigrate = false
 	}

--- a/server/task.go
+++ b/server/task.go
@@ -472,7 +472,7 @@ func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, 
 	}
 
 	database := taskPatched.Database
-	// If patch status is running, we need to mark migration_history as wait_retry.
+	// If patch status is running, we need to mark migration_history as db.WaitRetry.
 	if taskPatched.Status == api.TaskRunning {
 		driver, err := getAdminDatabaseDriver(ctx, database.Instance, "", s.pgInstanceDir)
 		if err != nil {
@@ -488,7 +488,7 @@ func (s *Server) changeTaskStatusWithPatch(ctx context.Context, task *api.Task, 
 		if err != nil || len(histories) == 0 {
 			return nil, fmt.Errorf("failed to find latest migration_history: %w", err)
 		}
-		// mark migration_history status as wait_retry
+		// mark migration_history status as db.WaitRetry
 		if err := driver.PatchMigrationHistory(ctx, &db.MigrationHistoryPatch{
 			ID:     &histories[0].ID,
 			Status: db.WaitRetry,


### PR DESCRIPTION
@d-bytebase PTAL

If the failure is due to some network timeout or other reason, the user should be allowed to retry instead of having to create a new issue each time.

This PR adds two `API`s to support controllable issue retries scenarios: 
- `Driver.PatchMigrationHistory`, which marks migration_history as intermediate status `WAIT_RETRY`.
- `MigrationExecutor.UpdateHistoryAsPending` is used to mark `latest_migration_history` as PENDING if it needs to be retried. 

And a new MigrationStatus called `WAIT_RETRY`, which is an intermediate status that marks which tasks can be reset to `PENDING`. The core logic is that when the front-end initiates a Retry request, the `latest_migration_history` of the target database is marked as `WAIT_RETRY`, and then task scheduling checks this status and updates it to `PENDING` to support controllable issue retries.