### PR TITLE
feat(frontend): allow approve/run all tasks in a stage for tenant mode issue

### DIFF
--- a/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
+++ b/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
@@ -20,10 +20,37 @@
       >
         <button
           type="button"
+          class="flex items-center gap-x-3 group relative overflow-visible"
           :class="transition.buttonClass"
           @click.prevent="tryStartTaskStatusTransition(transition)"
         >
-          {{ $t(transition.buttonName) }}
+          <span>
+            {{ $t(transition.buttonName) }}
+          </span>
+          <template v-if="allowApplyTaskTransitionToStage(transition)">
+            <span class="border-l pl-2 -mr-2">
+              <heroicons-outline:chevron-down />
+            </span>
+            <div
+              class="hidden group-hover:flex whitespace-nowrap absolute right-0 -bottom-[2px] transform translate-y-[100%] z-50 rounded-md bg-white shadow-lg"
+              @click.prevent.stop="tryStartStageStatusTransition(transition)"
+            >
+              <div
+                class="flex flex-col items-end py-1"
+                role="menu"
+                aria-orientation="vertical"
+                aria-labelledby="user-menu"
+              >
+                <div class="menu-item">
+                  {{
+                    $t("issue.action-to-current-stage", {
+                      action: $t(transition.buttonName),
+                    })
+                  }}
+                </div>
+              </div>
+            </div>
+          </template>
         </button>
       </template>
       <template v-if="applicableIssueStatusTransitionList.length > 0">
@@ -108,12 +135,13 @@
 import { computed, reactive, Ref, ref } from "vue";
 import { isEmpty } from "lodash-es";
 import { useI18n } from "vue-i18n";
-import type { TaskStatusTransition } from "@/utils";
+import type { StageStatusTransition, TaskStatusTransition } from "@/utils";
 import type {
   Issue,
   IssueCreate,
   IssueStatusTransition,
   Principal,
+  Stage,
   Task,
   TaskCreate,
 } from "@/types";
@@ -138,13 +166,16 @@ export type IssueContext = {
 };
 
 interface UpdateStatusModalState {
-  mode: "ISSUE" | "TASK";
+  mode: "ISSUE" | "STAGE" | "TASK";
   show: boolean;
   style: string;
   okText: string;
   title: string;
-  transition?: IssueStatusTransition | TaskStatusTransition;
-  payload?: Task;
+  transition?:
+    | IssueStatusTransition
+    | StageStatusTransition
+    | TaskStatusTransition;
+  payload?: Task | Stage;
   isTransiting: boolean;
 }
 
@@ -157,8 +188,10 @@ const {
   template: issueTemplate,
   activeTaskOfPipeline,
   doCreate,
+  isTenantMode,
 } = useIssueLogic();
-const { changeIssueStatus, changeTaskStatus } = useExtraIssueLogic();
+const { changeIssueStatus, changeStageAllTaskStatus, changeTaskStatus } =
+  useExtraIssueLogic();
 
 const updateStatusModalState = reactive<UpdateStatusModalState>({
   mode: "ISSUE",
@@ -184,38 +217,52 @@ const {
   applicableStageStatusTransitionList,
   applicableIssueStatusTransitionList,
   getApplicableIssueStatusTransitionList,
+  getApplicableStageStatusTransitionList,
   getApplicableTaskStatusTransitionList,
 } = useIssueTransitionLogic(issue as Ref<Issue>);
 
-const tryStartTaskStatusTransition = (transition: TaskStatusTransition) => {
-  updateStatusModalState.mode = "TASK";
+const tryStartStageOrTaskStatusTransition = (
+  transition: TaskStatusTransition | StageStatusTransition,
+  mode: "STAGE" | "TASK"
+) => {
+  updateStatusModalState.mode = mode;
   updateStatusModalState.okText = t(transition.buttonName);
   const task = currentTask.value;
+  const payload = mode === "TASK" ? task : task.stage;
+  const name = payload.name;
   switch (transition.type) {
     case "RUN":
       updateStatusModalState.style = "INFO";
-      updateStatusModalState.title = `${t("common.run")} '${task.name}'?`;
+      updateStatusModalState.title = `${t("common.run")} '${name}'?`;
       break;
     case "APPROVE":
       updateStatusModalState.style = "INFO";
-      updateStatusModalState.title = `${t("common.approve")} '${task.name}'?`;
+      updateStatusModalState.title = `${t("common.approve")} '${name}'?`;
       break;
     case "RETRY":
       updateStatusModalState.style = "INFO";
-      updateStatusModalState.title = `${t("common.retry")} '${task.name}'?`;
+      updateStatusModalState.title = `${t("common.retry")} '${name}'?`;
       break;
     case "CANCEL":
       updateStatusModalState.style = "INFO";
-      updateStatusModalState.title = `${t("common.cancel")} '${task.name}'?`;
+      updateStatusModalState.title = `${t("common.cancel")} '${name}'?`;
       break;
     case "SKIP":
       updateStatusModalState.style = "INFO";
-      updateStatusModalState.title = `${t("common.skip")} '${task.name}'?`;
+      updateStatusModalState.title = `${t("common.skip")} '${name}'?`;
       break;
   }
   updateStatusModalState.transition = transition;
-  updateStatusModalState.payload = task;
+  updateStatusModalState.payload = payload;
   updateStatusModalState.show = true;
+};
+
+const tryStartTaskStatusTransition = (transition: TaskStatusTransition) => {
+  tryStartStageOrTaskStatusTransition(transition, "TASK");
+};
+
+const tryStartStageStatusTransition = (transition: StageStatusTransition) => {
+  tryStartStageOrTaskStatusTransition(transition, "STAGE");
 };
 
 const doTaskStatusTransition = (
@@ -224,6 +271,14 @@ const doTaskStatusTransition = (
   comment: string
 ) => {
   changeTaskStatus(task, transition.to, comment);
+};
+
+const doStageStatusTransition = (
+  transition: StageStatusTransition,
+  stage: Stage,
+  comment: string
+) => {
+  changeStageAllTaskStatus(stage, transition.to, comment);
 };
 
 const currentTask = computed(() => {
@@ -331,6 +386,18 @@ const onSubmit = async (comment: string) => {
       return cleanup();
     }
     doIssueStatusTransition(targetTransition, comment);
+  } else if (updateStatusModalState.mode === "STAGE") {
+    const targetTransition =
+      updateStatusModalState.transition as StageStatusTransition;
+    const applicableList = getApplicableStageStatusTransitionList(latestIssue);
+    if (!isApplicableTransition(targetTransition, applicableList)) {
+      return cleanup();
+    }
+    doStageStatusTransition(
+      targetTransition,
+      updateStatusModalState.payload as Stage,
+      comment
+    );
   } else if (updateStatusModalState.mode == "TASK") {
     const targetTransition =
       updateStatusModalState.transition as TaskStatusTransition;
@@ -340,7 +407,7 @@ const onSubmit = async (comment: string) => {
     }
     doTaskStatusTransition(
       targetTransition,
-      updateStatusModalState.payload!,
+      updateStatusModalState.payload as Task,
       comment
     );
   }
@@ -348,7 +415,14 @@ const onSubmit = async (comment: string) => {
   cleanup();
 };
 
-const allowApplyTransitionToStage = (transition: TaskStatusTransition) => {
+const allowApplyTaskTransitionToStage = (transition: TaskStatusTransition) => {
+  // Only available for tenant mode, Which means
+  // 1. the project is tenant mode
+  // 2. the issue type is schema.update or data.update
+  if (!isTenantMode.value) {
+    return false;
+  }
+
   const stage = currentTask.value.stage;
 
   // Only available when the stage has multiple tasks.

--- a/frontend/src/components/Issue/StatusTransitionForm.vue
+++ b/frontend/src/components/Issue/StatusTransitionForm.vue
@@ -45,10 +45,7 @@
         </template>
       </template>
 
-      <div
-        v-if="mode == 'TASK' && task.taskCheckRunList.length > 0"
-        class="sm:col-span-4 mb-4 space-y-4"
-      >
+      <div v-if="showTaskCheckBar" class="sm:col-span-4 mb-4 space-y-4">
         <template v-if="runningCheckCount > 0">
           <BBAttention
             :style="'INFO'"
@@ -148,7 +145,7 @@ export default defineComponent({
   props: {
     mode: {
       required: true,
-      type: String as PropType<"ISSUE" | "TASK">,
+      type: String as PropType<"ISSUE" | "STAGE" | "TASK">,
     },
     okText: {
       type: String,
@@ -202,6 +199,7 @@ export default defineComponent({
           }
           break; // only to make eslint happy
         }
+        case "STAGE": // fallthrough the same as TASK
         case "TASK": {
           switch ((props.transition as TaskStatusTransition).type) {
             case "RUN":
@@ -220,6 +218,12 @@ export default defineComponent({
       return ""; // only to make eslint happy
     });
 
+    const showTaskCheckBar = computed((): boolean => {
+      if (props.mode !== "TASK") return false;
+      const taskCheckCount = props.task?.taskCheckRunList.length ?? 0;
+      return taskCheckCount > 0;
+    });
+
     // Code block below will raise an eslint ERROR.
     // But I won't change it this time.
     // Disable submit if in TASK mode and there exists RUNNING check or check error and we are transitioning to RUNNING
@@ -228,6 +232,7 @@ export default defineComponent({
         case "ISSUE": {
           return true;
         }
+        case "STAGE": // fallthrough the same as TASK
         case "TASK": {
           switch ((props.transition as TaskStatusTransition).to) {
             case "RUNNING":
@@ -292,6 +297,7 @@ export default defineComponent({
     return {
       state,
       environmentId,
+      showTaskCheckBar,
       commentTextArea,
       submitButtonStyle,
       allowSubmit,

--- a/frontend/src/components/Issue/logic/transition.ts
+++ b/frontend/src/components/Issue/logic/transition.ts
@@ -21,12 +21,16 @@ import {
 import { useIssueLogic } from ".";
 
 export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
-  const { activeTaskOfPipeline } = useIssueLogic();
+  const { create, activeTaskOfPipeline } = useIssueLogic();
   const currentUser = useCurrentUser();
 
   const getApplicableIssueStatusTransitionList = (
     issue: Issue
   ): IssueStatusTransition[] => {
+    if (create.value) {
+      return [];
+    }
+
     const currentTask = activeTaskOfPipeline(issue.pipeline);
 
     const issueEntity = issue as Issue;
@@ -81,6 +85,9 @@ export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
   };
 
   const getApplicableStageStatusTransitionList = (issue: Issue) => {
+    if (create.value) {
+      return [];
+    }
     if (issue.id == ONBOARDING_ISSUE_ID) {
       return [];
     }
@@ -109,6 +116,9 @@ export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
   const getApplicableTaskStatusTransitionList = (
     issue: Issue
   ): TaskStatusTransition[] => {
+    if (create.value) {
+      return [];
+    }
     if (issue.id == ONBOARDING_ISSUE_ID) {
       return [];
     }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -480,7 +480,8 @@
       }
     },
     "new-issue": "@:common.new @:common.issue",
-    "format-on-save": "Format on save"
+    "format-on-save": "Format on save",
+    "action-to-current-stage": "{action} current stage"
   },
   "alter-schema": {
     "vcs-enabled": "This project has enabled VCS based version control and selecting database below will navigate you to the corresponding Git repository to initiate the change process.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -480,7 +480,8 @@
       }
     },
     "new-issue": "@:common.new@:common.issue",
-    "format-on-save": "保存时格式化"
+    "format-on-save": "保存时格式化",
+    "action-to-current-stage": "{action}当前阶段"
   },
   "alter-schema": {
     "vcs-enabled": "该项目开启了基于 VCS 的版本管理，选择下面的数据库会将您导航到相应的 Git 仓库以发起变更流程。",


### PR DESCRIPTION
### Known issues

- The server-side will run tasks sequentially, so the frontend will still see outdated task status like in #1535 .

### Screenshot
![approve-all](https://user-images.githubusercontent.com/2749742/174212481-8757c1b2-ce23-475f-a7b3-08fd7955be33.gif)

Close BYT-722
