### PR TITLE
chore: add force option to migration

### DIFF
--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -253,6 +253,10 @@ type MigrationInfo struct {
 	// SemanticVersionSuffix should be set to timestamp format of "20060102150405" (common.DefaultMigrationVersion) if UseSemanticVersion is set.
 	// Since stored version should be unique, we have to append a suffix if we allow users to baseline to the same semantic version for fixing schema drift.
 	SemanticVersionSuffix string
+	// Force is used to execute migration disregarding any migration history with PENDING or FAILED status.
+	// This applies to BASELINE and MIGRATE types of migrations because most of these migrations are retriable.
+	// We don't use force option for DATA type of migrations yet till there's customer needs.
+	Force bool
 }
 
 // ParseMigrationInfo matches filePath against filePathTemplate

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -207,11 +207,21 @@ func BeginMigration(ctx context.Context, executor MigrationExecutor, m *db.Migra
 			return -1, common.Errorf(common.MigrationAlreadyApplied,
 				fmt.Errorf("database %q has already applied version %s", m.Database, m.Version))
 		case db.Pending:
-			return -1, common.Errorf(common.MigrationPending,
-				fmt.Errorf("database %q version %s migration is already in progress", m.Database, m.Version))
+			err := fmt.Errorf("database %q version %s migration is already in progress", m.Database, m.Version)
+			log.Debug(err.Error())
+			// For force migration, we will ignore the existing migration history and continue to migration.
+			if m.Force {
+				return int64(list[0].ID), nil
+			}
+			return -1, common.Errorf(common.MigrationPending, err)
 		case db.Failed:
-			return -1, common.Errorf(common.MigrationFailed,
-				fmt.Errorf("database %q version %s migration has failed, please check your database to make sure things are fine and then start a new migration using a new version ", m.Database, m.Version))
+			err := fmt.Errorf("database %q version %s migration has failed, please check your database to make sure things are fine and then start a new migration using a new version ", m.Database, m.Version)
+			log.Debug(err.Error())
+			// For force migration, we will ignore the existing migration history and continue to migration.
+			if m.Force {
+				return int64(list[0].ID), nil
+			}
+			return -1, common.Errorf(common.MigrationFailed, err)
 		}
 	}
 

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -118,6 +118,7 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 		return nil, fmt.Errorf("empty statement")
 	}
 	// We will force migration for baseline and migrate type of migrations.
+	// This usually happens when the previous attempt fails and the client retries the migration.
 	if mi.Type == db.Baseline || mi.Type == db.Migrate {
 		mi.Force = true
 	}

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -117,6 +117,10 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 	if mi.Type != db.Baseline && statement == "" {
 		return nil, fmt.Errorf("empty statement")
 	}
+	// We will force migration for baseline and migrate type of migrations.
+	if mi.Type == db.Baseline || mi.Type == db.Migrate {
+		mi.Force = true
+	}
 
 	return mi, nil
 }

--- a/server/task_executor_database_create.go
+++ b/server/task_executor_database_create.go
@@ -59,6 +59,7 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 		Type:           db.Baseline,
 		Description:    "Create database",
 		CreateDatabase: true,
+		Force:          true,
 	}
 	creator, err := server.store.GetPrincipalByID(ctx, task.CreatorID)
 	if err != nil {


### PR DESCRIPTION
This allows users to retry the migration by well-considering the existing migration history record. In most cases, the statement execution is executed with an error or not executed yet. In rare cases, the execution was successful but the status is PENDING since the status update wasn't completed previously. Users should inspect the database and differentiate these two cases. The force option provides an option for users to retry the migration for the former case.