### PR TITLE
feat: add git commit hash of the build and display it as the tooltip when hovering on the version

### DIFF
--- a/api/actuator.go
+++ b/api/actuator.go
@@ -4,6 +4,7 @@ package api
 // Actuator concept is similar to the Spring Boot Actuator
 type ServerInfo struct {
 	Version        string `json:"version"`
+	GitCommit      string `json:"gitCommit"`
 	Readonly       bool   `json:"readonly"`
 	Demo           bool   `json:"demo"`
 	Host           string `json:"host"`

--- a/bin/server/cmd/profile_dev.go
+++ b/bin/server/cmd/profile_dev.go
@@ -29,6 +29,7 @@ func activeProfile(dataDir string) server.Profile {
 		DemoDataDir:          fmt.Sprintf("demo/%s", common.ReleaseModeDev),
 		BackupRunnerInterval: 10 * time.Second,
 		Version:              version,
+		GitCommit:            gitcommit,
 		PgURL:                flags.pgURL,
 		MetricConnectionKey:  "3zcZLeX3ahvlueEJqNyJysGfVAErsjjT",
 	}

--- a/bin/server/cmd/profile_release.go
+++ b/bin/server/cmd/profile_release.go
@@ -33,6 +33,7 @@ func activeProfile(dataDir string) server.Profile {
 		DemoDataDir:          demoDataDir,
 		BackupRunnerInterval: 10 * time.Minute,
 		Version:              version,
+		GitCommit:            gitcommit,
 		PgURL:                flags.pgURL,
 		MetricConnectionKey:  "so9lLwj5zLjH09sxNabsyVNYSsAHn68F",
 	}

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -44,7 +44,10 @@
               <heroicons-solid:sparkles class="w-5 h-5" />
               {{ $t(currentPlan) }}
             </router-link>
-            <div class="text-sm ml-auto text-control-light">{{ version }}</div>
+            <div class="text-sm ml-auto text-control-light tooltip-wrapper">
+              {{ version }}
+              <span v-if="gitCommit" class="tooltip">{{ gitCommit }}</span>
+            </div>
           </div>
         </div>
         <div class="flex-shrink-0 w-14" aria-hidden="true">
@@ -83,8 +86,9 @@
             <heroicons-outline:sparkles class="w-5 h-5" />
             {{ $t(currentPlan) }}
           </router-link>
-          <div class="text-sm ml-auto text-control-light">
+          <div class="text-sm ml-auto text-control-light tooltip-wrapper">
             {{ version }}
+            <span v-if="gitCommit" class="tooltip">{{ gitCommit }}</span>
           </div>
         </div>
       </div>
@@ -245,6 +249,10 @@ export default defineComponent({
       return v;
     });
 
+    const gitCommit = computed(() => {
+      return `Git hash ${actuatorStore.gitCommit.substring(0, 7)}`;
+    });
+
     const currentPlan = computed((): string => {
       const plan = subscriptionStore.currentPlan;
       switch (plan) {
@@ -269,6 +277,7 @@ export default defineComponent({
       showIntro,
       showQuickstart,
       version,
+      gitCommit,
       currentPlan,
       isFreePlan,
     };

--- a/frontend/src/store/modules/actuator.ts
+++ b/frontend/src/store/modules/actuator.ts
@@ -13,6 +13,9 @@ export const useActuatorStore = defineStore("actuator", {
     version: (state) => {
       return state.serverInfo?.version || "";
     },
+    gitCommit: (state) => {
+      return state.serverInfo?.gitCommit || "";
+    },
     isDemo: (state) => {
       return state.serverInfo?.demo || false;
     },

--- a/frontend/src/types/actuator.ts
+++ b/frontend/src/types/actuator.ts
@@ -1,5 +1,6 @@
 export type ServerInfo = {
   version: string;
+  gitCommit: string;
   readonly: boolean;
   demo: boolean;
   host: string;

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -3,7 +3,16 @@ tmp_dir = ".air"
 
 [build]
   bin = "./.air/bytebase --port 8080 --frontend-port 3000 --data ."
-  cmd = "go build -gcflags=all=\"-N -l\" -o ./.air/bytebase ./bin/server/main.go"
+  cmd = """
+  go build -gcflags=all=\"-N -l\" \
+  -ldflags " \
+  -X 'github.com/bytebase/bytebase/bin/server/cmd.version=development' \
+  -X 'github.com/bytebase/bytebase/bin/server/cmd.goversion=$(go version)' \
+  -X 'github.com/bytebase/bytebase/bin/server/cmd.gitcommit=$(git rev-parse HEAD)' \
+  -X 'github.com/bytebase/bytebase/bin/server/cmd.buildtime=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' \
+  -X 'github.com/bytebase/bytebase/bin/server/cmd.builduser=$(id -u -n)' \
+  " \
+  -o ./.air/bytebase ./bin/server/main.go"""
   delay = 1000
   exclude_dir = [".air", "vendor", "frontend", "docs"]
   exclude_file = []

--- a/scripts/.air_bb.toml
+++ b/scripts/.air_bb.toml
@@ -3,7 +3,16 @@ tmp_dir = ".air"
 
 [build]
   bin = "./.air/bb version"
-  cmd = "go build -o ./.air/bb ./bin/bb/main.go"
+  cmd = """
+  go build \
+  -ldflags " \
+  -X 'github.com/bytebase/bytebase/bin/bb/cmd.version=development' \
+  -X 'github.com/bytebase/bytebase/bin/bb/cmd.goversion=$(go version)' \
+  -X 'github.com/bytebase/bytebase/bin/bb/cmd.gitcommit=$(git rev-parse HEAD)' \
+  -X 'github.com/bytebase/bytebase/bin/bb/cmd.buildtime=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' \
+  -X 'github.com/bytebase/bytebase/bin/bb/cmd.builduser=$(id -u -n)' \
+  " \
+  -o ./.air/bb ./bin/bb/main.go"""
   delay = 1000
   exclude_dir = [".air", "vendor", "frontend", "docs"]
   exclude_file = []

--- a/server/actuator.go
+++ b/server/actuator.go
@@ -12,11 +12,12 @@ func (s *Server) registerActuatorRoutes(g *echo.Group) {
 	g.GET("/actuator/info", func(c echo.Context) error {
 		ctx := c.Request().Context()
 		serverInfo := api.ServerInfo{
-			Version:  s.profile.Version,
-			Readonly: s.profile.Readonly,
-			Demo:     s.profile.Demo,
-			Host:     s.profile.BackendHost,
-			Port:     strconv.Itoa(s.profile.BackendPort),
+			Version:   s.profile.Version,
+			GitCommit: s.profile.GitCommit,
+			Readonly:  s.profile.Readonly,
+			Demo:      s.profile.Demo,
+			Host:      s.profile.BackendHost,
+			Port:      strconv.Itoa(s.profile.BackendPort),
 		}
 
 		findRole := api.Owner

--- a/server/config.go
+++ b/server/config.go
@@ -53,6 +53,8 @@ type Profile struct {
 	BackupRunnerInterval time.Duration
 	// Version is the bytebase's version
 	Version string
+	// Git commit hash of the build
+	GitCommit string
 	// PgURL is the optional external PostgreSQL instance connection url
 	PgURL string
 	// MetricConnectionKey is the connection key for metric.


### PR DESCRIPTION
![CleanShot 2022-06-19 at 00 45 22](https://user-images.githubusercontent.com/230323/174448565-7ef70afd-8f8e-4d9d-927f-c4ce9980e7d9.png)

This is for locating the revision, especially for development builds.

Also pass the build info when building bytebase/bb via air