### PR TITLE
chore: add vscode launch option to debug golang binary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Debug Binary",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "program": "${file}"
+        },
+        {
             "name": "Attach to Process",
             "type": "go",
             "request": "attach",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,11 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Binary",
+            "name": "Debug Dev Binary",
             "type": "go",
             "request": "launch",
             "mode": "exec",
-            "program": "${file}"
+            "program": "${workspaceFolder}/.air/bytebase"
         },
         {
             "name": "Attach to Process",


### PR DESCRIPTION
This enables us to debug the compiled dev binary by `air`.