### PR TITLE
feat(frontend): support SSL connection for clickhouse

### DIFF
--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -388,15 +388,27 @@ const cancel = () => {
 };
 
 const tryCreate = () => {
+  const { instance } = state;
   const connectionInfo: ConnectionInfo = {
-    engine: state.instance.engine,
-    username: state.instance.username,
-    password: state.instance.password,
+    engine: instance.engine,
+    username: instance.username,
+    password: instance.password,
     // When creating instance, the password is always needed.
     useEmptyPassword: false,
-    host: state.instance.host,
-    port: state.instance.port,
+    host: instance.host,
+    port: instance.port,
   };
+
+  if (typeof instance.sslCa !== "undefined") {
+    connectionInfo.sslCa = instance.sslCa;
+  }
+  if (typeof instance.sslKey !== "undefined") {
+    connectionInfo.sslKey = instance.sslKey;
+  }
+  if (typeof instance.sslCert !== "undefined") {
+    connectionInfo.sslCert = instance.sslCert;
+  }
+
   sqlStore.ping(connectionInfo).then((resultSet: SQLResultSet) => {
     if (isEmpty(resultSet.error)) {
       doCreate();
@@ -435,15 +447,28 @@ const doCreate = () => {
 };
 
 const testConnection = () => {
+  const { instance } = state;
+
   const connectionInfo: ConnectionInfo = {
-    host: state.instance.host,
-    port: state.instance.port,
-    engine: state.instance.engine,
-    username: state.instance.username,
-    password: state.instance.password,
+    host: instance.host,
+    port: instance.port,
+    engine: instance.engine,
+    username: instance.username,
+    password: instance.password,
     useEmptyPassword: false,
     instanceId: undefined,
   };
+
+  if (typeof instance.sslCa !== "undefined") {
+    connectionInfo.sslCa = instance.sslCa;
+  }
+  if (typeof instance.sslKey !== "undefined") {
+    connectionInfo.sslKey = instance.sslKey;
+  }
+  if (typeof instance.sslCert !== "undefined") {
+    connectionInfo.sslCert = instance.sslCert;
+  }
+
   sqlStore.ping(connectionInfo).then((resultSet: SQLResultSet) => {
     if (isEmpty(resultSet.error)) {
       pushNotification({

--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -164,6 +164,18 @@
             @input="handleInstancePasswordInput"
           />
         </div>
+
+        <div v-if="showSSL" class="sm:col-span-3 sm:col-start-1">
+          <div class="flex flex-row items-center space-x-2">
+            <label class="textlabel block">{{
+              $t("datasource.ssl-connection")
+            }}</label>
+          </div>
+          <SslCertificateForm
+            :value="state.instance"
+            @change="Object.assign(state.instance, $event)"
+          />
+        </div>
       </div>
 
       <div class="mt-6 border-none">
@@ -233,10 +245,11 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, reactive } from "vue";
+import { computed, reactive, watch } from "vue";
 import { useRouter } from "vue-router";
 import EnvironmentSelect from "./EnvironmentSelect.vue";
 import CreateDataSourceExample from "./CreateDataSourceExample.vue";
+import { SslCertificateForm } from "./InstanceForm";
 import { instanceSlug, isDev } from "../utils";
 import {
   InstanceCreate,
@@ -313,6 +326,19 @@ const defaultPort = computed(() => {
     return "4000";
   }
   return "3306";
+});
+
+const showSSL = computed((): boolean => {
+  return state.instance.engine === "CLICKHOUSE";
+});
+
+watch(showSSL, (ssl) => {
+  // Clean up SSL options when they are not needed.
+  if (!ssl) {
+    state.instance.sslCa = "";
+    state.instance.sslKey = "";
+    state.instance.sslCert = "";
+  }
 });
 
 const engineName = (type: EngineType): string => {

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -236,6 +236,42 @@
             @input="handleCurrentDataSourcePasswordInput"
           />
         </div>
+
+        <div v-if="showSSL" class="mt-2 sm:col-span-3 sm:col-start-1">
+          <div class="flex flex-row items-center">
+            <label for="password" class="textlabel block">
+              {{ $t("datasource.ssl-connection") }}
+            </label>
+          </div>
+          <template v-if="currentDataSource.id === UNKNOWN_ID">
+            <SslCertificateForm
+              :value="currentDataSource"
+              @change="handleCurrentDataSourceSslChange"
+            />
+          </template>
+          <template v-else>
+            <template v-if="currentDataSource.updateSsl">
+              <SslCertificateForm
+                :value="currentDataSource"
+                @change="handleCurrentDataSourceSslChange"
+              />
+              <button
+                class="btn-normal mt-2"
+                @click.prevent="handleEditSsl(false)"
+              >
+                {{ $t("common.revert") }}
+              </button>
+            </template>
+            <template v-else>
+              <button
+                class="btn-normal mt-2"
+                @click.prevent="handleEditSsl(true)"
+              >
+                {{ $t("common.edit") }} - {{ $t("common.write-only") }}
+              </button>
+            </template>
+          </template>
+        </div>
       </div>
       <div class="mt-6 pt-0 border-none">
         <div class="flex flex-row space-x-2">
@@ -289,6 +325,7 @@ import cloneDeep from "lodash-es/cloneDeep";
 import isEqual from "lodash-es/isEqual";
 import EnvironmentSelect from "../components/EnvironmentSelect.vue";
 import InstanceEngineIcon from "../components/InstanceEngineIcon.vue";
+import { SslCertificateForm } from "./InstanceForm";
 import { isDBAOrOwner } from "../utils";
 import {
   InstancePatch,
@@ -298,6 +335,7 @@ import {
   ConnectionInfo,
   DataSource,
   UNKNOWN_ID,
+  DataSourceCreate,
 } from "../types";
 import isEmpty from "lodash-es/isEmpty";
 import { useI18n } from "vue-i18n";
@@ -431,6 +469,10 @@ const instanceLink = (instance: Instance): string => {
   return instance.host;
 };
 
+const showSSL = computed((): boolean => {
+  return state.instance.engine === "CLICKHOUSE";
+});
+
 const handleInstanceNameInput = (event: Event) => {
   updateInstance("name", (event.target as HTMLInputElement).value);
 };
@@ -468,17 +510,48 @@ const handleCurrentDataSourcePasswordInput = (event: Event) => {
   updateInstanceDataSource();
 };
 
+const handleEditSsl = (edit: boolean) => {
+  const curr = currentDataSource.value;
+  if (!edit) {
+    delete curr.sslCa;
+    delete curr.sslCert;
+    delete curr.sslKey;
+    delete curr.updateSsl;
+  } else {
+    curr.sslCa = "";
+    curr.sslCert = "";
+    curr.sslKey = "";
+    curr.updateSsl = true;
+  }
+  updateInstanceDataSource();
+};
+
+const handleCurrentDataSourceSslChange = (
+  value: Pick<DataSource, "sslCa" | "sslCert" | "sslKey">
+) => {
+  Object.assign(currentDataSource.value, value);
+  currentDataSource.value.updateSsl = true;
+  updateInstanceDataSource();
+};
+
 const updateInstanceDataSource = () => {
-  const index = state.dataSourceList.findIndex(
-    (ds) => ds === currentDataSource.value
-  );
-  state.instance.dataSourceList[index] = {
+  const curr = currentDataSource.value;
+  const index = state.dataSourceList.findIndex((ds) => ds === curr);
+  const newValue = {
     ...state.instance.dataSourceList[index],
-    username: currentDataSource.value.username,
-    password: currentDataSource.value.useEmptyPassword
-      ? ""
-      : currentDataSource.value.updatedPassword,
+    username: curr.username,
+    password: curr.useEmptyPassword ? "" : curr.updatedPassword,
   };
+  if (curr.updateSsl) {
+    newValue.sslCa = curr.sslCa;
+    newValue.sslKey = curr.sslKey;
+    newValue.sslCert = curr.sslCert;
+  } else {
+    delete newValue.sslCa;
+    delete newValue.sslCert;
+    delete newValue.sslKey;
+  }
+  state.instance.dataSourceList[index] = newValue;
 };
 
 const handleCreateDataSource = (type: DataSourceType) => {
@@ -570,17 +643,25 @@ const doUpdate = () => {
         if (dataSource.id === UNKNOWN_ID) {
           // Only used to create ReadOnly data source right now.
           if (dataSource.type === "RO") {
-            requests.push(
-              dataSourceStore.createDataSource({
-                databaseId: dataSource.databaseId,
-                instanceId: state.instance.id,
-                name: dataSource.name,
-                type: dataSource.type,
-                username: dataSource.username,
-                password: dataSource.password,
-                syncSchema: state.syncSchema,
-              })
-            );
+            const dataSourceCreate: DataSourceCreate = {
+              databaseId: dataSource.databaseId,
+              instanceId: state.instance.id,
+              name: dataSource.name,
+              type: dataSource.type,
+              username: dataSource.username,
+              password: dataSource.password,
+              syncSchema: state.syncSchema,
+            };
+            if (typeof dataSource.sslCa !== "undefined") {
+              dataSourceCreate.sslCa = dataSource.sslCa;
+            }
+            if (typeof dataSource.sslKey !== "undefined") {
+              dataSourceCreate.sslKey = dataSource.sslKey;
+            }
+            if (typeof dataSource.sslCert !== "undefined") {
+              dataSourceCreate.sslCert = dataSource.sslCert;
+            }
+            requests.push(dataSourceStore.createDataSource(dataSourceCreate));
           }
         } else if (
           !isEqual(dataSource, state.originalInstance.dataSourceList[i])

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -641,17 +641,28 @@ const doUpdate = () => {
 };
 
 const testConnection = () => {
+  const instance = state.instance;
+  const dataSource = currentDataSource.value;
   const connectionInfo: ConnectionInfo = {
-    engine: state.instance.engine,
-    username: currentDataSource.value.username,
-    password: currentDataSource.value.useEmptyPassword
-      ? ""
-      : currentDataSource.value.updatedPassword,
-    useEmptyPassword: currentDataSource.value.useEmptyPassword,
-    host: state.instance.host,
-    port: state.instance.port,
-    instanceId: state.instance.id,
+    engine: instance.engine,
+    username: dataSource.username,
+    password: dataSource.useEmptyPassword ? "" : dataSource.updatedPassword,
+    useEmptyPassword: dataSource.useEmptyPassword,
+    host: instance.host,
+    port: instance.port,
+    instanceId: instance.id,
   };
+
+  if (typeof dataSource.sslCa !== "undefined") {
+    connectionInfo.sslCa = dataSource.sslCa;
+  }
+  if (typeof dataSource.sslKey !== "undefined") {
+    connectionInfo.sslKey = dataSource.sslKey;
+  }
+  if (typeof dataSource.sslCert !== "undefined") {
+    connectionInfo.sslCert = dataSource.sslCert;
+  }
+
   sqlStore.ping(connectionInfo).then((resultSet: SQLResultSet) => {
     if (isEmpty(resultSet.error)) {
       pushNotification({

--- a/frontend/src/components/InstanceForm/SslCertificateForm.vue
+++ b/frontend/src/components/InstanceForm/SslCertificateForm.vue
@@ -21,6 +21,7 @@
       <textarea
         v-model="state.value.sslCa"
         class="textarea block w-full resize-none whitespace-pre-wrap h-24"
+        placeholder="YOUR_CA_CERTIFICATE"
       />
     </NTabPane>
     <NTabPane
@@ -32,6 +33,7 @@
       <textarea
         v-model="state.value.sslKey"
         class="textarea block w-full resize-none whitespace-pre-wrap h-24"
+        placeholder="YOUR_CLIENT_KEY"
       />
     </NTabPane>
     <NTabPane
@@ -43,6 +45,7 @@
       <textarea
         v-model="state.value.sslCert"
         class="textarea block w-full resize-none whitespace-pre-wrap h-24"
+        placeholder="YOUR_CLIENT_CERT"
       />
     </NTabPane>
   </NTabs>

--- a/frontend/src/components/InstanceForm/SslCertificateForm.vue
+++ b/frontend/src/components/InstanceForm/SslCertificateForm.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="radio-set-row mt-2">
+    <label v-for="type in SslTypes" :key="type" class="radio">
+      <input v-model="state.type" type="radio" class="btn" :value="type" />
+      <span class="label">
+        {{ getSslTypeLabel(type) }}
+      </span>
+    </label>
+  </div>
+  <NTabs
+    v-if="state.type === 'CA' || state.type === 'CA+KEY+CERT'"
+    v-model:value="state.tab"
+    class="mt-2"
+    pane-style="padding-top: 0.25rem"
+  >
+    <NTabPane
+      name="CA"
+      :tab="$t('datasource.ssl.ca-cert')"
+      display-directive="show"
+    >
+      <textarea
+        v-model="state.value.sslCa"
+        class="textarea block w-full resize-none whitespace-pre-wrap h-24"
+      />
+    </NTabPane>
+    <NTabPane
+      v-if="state.type === 'CA+KEY+CERT'"
+      name="KEY"
+      :tab="$t('datasource.ssl.client-key')"
+      display-directive="show"
+    >
+      <textarea
+        v-model="state.value.sslKey"
+        class="textarea block w-full resize-none whitespace-pre-wrap h-24"
+      />
+    </NTabPane>
+    <NTabPane
+      v-if="state.type === 'CA+KEY+CERT'"
+      name="CERT"
+      :tab="$t('datasource.ssl.client-cert')"
+      display-directive="show"
+    >
+      <textarea
+        v-model="state.value.sslCert"
+        class="textarea block w-full resize-none whitespace-pre-wrap h-24"
+      />
+    </NTabPane>
+  </NTabs>
+</template>
+
+<script lang="ts" setup>
+import { PropType, reactive, watch } from "vue";
+import { NTabs, NTabPane } from "naive-ui";
+import { useI18n } from "vue-i18n";
+import { cloneDeep } from "lodash-es";
+
+const SslTypes = ["NONE", "CA", "CA+KEY+CERT"] as const;
+
+type SslType = "NONE" | "CA" | "CA+KEY+CERT";
+
+type WithSslOptions = {
+  sslCa?: string;
+  sslCert?: string;
+  sslKey?: string;
+};
+
+type LocalState = {
+  type: SslType;
+  value: WithSslOptions;
+  tab: "CA" | "KEY" | "CERT";
+};
+
+const props = defineProps({
+  value: {
+    type: Object as PropType<WithSslOptions>,
+    required: true,
+  },
+});
+
+const emit = defineEmits<{
+  (e: "change", value: WithSslOptions): void;
+}>();
+
+const { t } = useI18n();
+
+const state = reactive<LocalState>({
+  type: guessSslType(props.value),
+  value: {
+    sslCa: props.value.sslCa,
+    sslCert: props.value.sslCert,
+    sslKey: props.value.sslKey,
+  },
+  tab: "CA",
+});
+
+// Sync the latest version to local state when props.value changed.
+watch(
+  () => props.value,
+  (newValue) => {
+    state.type = guessSslType(newValue);
+    state.value = {
+      sslCa: newValue.sslCa,
+      sslCert: newValue.sslCert,
+      sslKey: newValue.sslKey,
+    };
+  }
+);
+
+// Emit the latest lo the parent when local value has been edited.
+watch(
+  () => state.value,
+  (localValue) => {
+    emit("change", cloneDeep(localValue));
+  },
+  { deep: true }
+);
+
+watch(
+  () => state.type,
+  (type) => {
+    if (type === "NONE") {
+      state.value.sslCa = "";
+      state.value.sslCert = "";
+      state.value.sslKey = "";
+    } else if (type === "CA") {
+      state.value.sslCert = "";
+      state.value.sslKey = "";
+      state.tab = "CA";
+    }
+  }
+);
+
+function getSslTypeLabel(type: SslType): string {
+  if (type === "CA") {
+    return t("datasource.ssl-type.ca");
+  }
+  if (type === "CA+KEY+CERT") {
+    return t("datasource.ssl-type.ca-and-key-and-cert");
+  }
+  return t("datasource.ssl-type.none");
+}
+
+function guessSslType(value: WithSslOptions): SslType {
+  if (value.sslCa) {
+    if (value.sslCert && value.sslKey) return "CA+KEY+CERT";
+    return "CA";
+  }
+  return "NONE";
+}
+</script>

--- a/frontend/src/components/InstanceForm/index.ts
+++ b/frontend/src/components/InstanceForm/index.ts
@@ -1,0 +1,3 @@
+import SslCertificateForm from "./SslCertificateForm.vue";
+
+export { SslCertificateForm };

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -198,7 +198,8 @@
     "enable": "Enable",
     "disable": "Disable",
     "view-doc": "View doc",
-    "backup-and-restore": "Backup and restore"
+    "backup-and-restore": "Backup and restore",
+    "write-only": "write only"
   },
   "error-page": {
     "go-back-home": "Go back home"
@@ -1112,7 +1113,18 @@
     "we-also-linked-the-granted-database-to-the-requested-issue-linkedissue-name": "We also linked the granted database to the requested issue '{0}'.",
     "new-data-source": "New data source",
     "connection-name-string-copied-to-clipboard": "{0} string copied to clipboard.",
-    "jdbc-cant-connect-to-socket-database-value-instance-host": "JDBC can't connect to socket {0} "
+    "jdbc-cant-connect-to-socket-database-value-instance-host": "JDBC can't connect to socket {0} ",
+    "ssl-type": {
+      "ca": "@:{'datasource.ssl.ca-cert'}",
+      "ca-and-key-and-cert": "@:{'datasource.ssl.ca-cert'} + @:{'datasource.ssl.client-key'} + @:{'datasource.ssl.client-cert'}",
+      "none": "None"
+    },
+    "ssl": {
+      "ca-cert": "CA Certificate",
+      "client-key": "Client Key",
+      "client-cert": "Client Certificate"
+    },
+    "ssl-connection": "SSL Connection"
   },
   "setting": {
     "project": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -198,7 +198,8 @@
     "enable": "开启",
     "disable": "禁用",
     "view-doc": "查看文档",
-    "backup-and-restore": "备份与恢复"
+    "backup-and-restore": "备份与恢复",
+    "write-only": "仅写入"
   },
   "error-page": {
     "go-back-home": "回到主页"
@@ -1112,7 +1113,18 @@
     "we-also-linked-the-granted-database-to-the-requested-issue-linkedissue-name": "我们也把被授予的数据库链接到了申请工单 '{0}'。",
     "new-data-source": "新数据源",
     "connection-name-string-copied-to-clipboard": "{0} 字符串已复制到剪贴板。",
-    "jdbc-cant-connect-to-socket-database-value-instance-host": "JDBC 无法连接到 socket {0} "
+    "jdbc-cant-connect-to-socket-database-value-instance-host": "JDBC 无法连接到 socket {0} ",
+    "ssl-type": {
+      "ca": "@:{'datasource.ssl.ca-cert'}",
+      "ca-and-key-and-cert": "@:{'datasource.ssl.ca-cert'} + @:{'datasource.ssl.client-key'} + @:{'datasource.ssl.client-cert'}",
+      "none": "不使用"
+    },
+    "ssl": {
+      "ca-cert": "CA 证书",
+      "client-key": "客户端密钥",
+      "client-cert": "客户端证书"
+    },
+    "ssl-connection": "SSL 连接"
   },
   "setting": {
     "project": {

--- a/frontend/src/types/dataSource.ts
+++ b/frontend/src/types/dataSource.ts
@@ -32,6 +32,12 @@ export type DataSource = {
   // In mysql, username can be empty which means anonymous user
   username?: string;
   password?: string;
+  sslCa?: string;
+  sslCert?: string;
+  sslKey?: string;
+
+  // UI-only fields
+  updateSsl?: boolean;
 };
 
 export type DataSourceCreate = {
@@ -44,6 +50,10 @@ export type DataSourceCreate = {
   type: DataSourceType;
   username?: string;
   password?: string;
+  sslCa?: string;
+  sslCert?: string;
+  sslKey?: string;
+
   syncSchema: boolean;
 };
 
@@ -53,6 +63,10 @@ export type DataSourcePatch = {
   username?: string;
   password?: string;
   useEmptyPassword?: boolean;
+  sslCa?: string;
+  sslCert?: string;
+  sslKey?: string;
+
   syncSchema: boolean;
 };
 

--- a/frontend/src/types/instance.ts
+++ b/frontend/src/types/instance.ts
@@ -79,6 +79,10 @@ export type InstanceCreate = {
   // In mysql, username can be empty which means anonymous user
   username?: string;
   password?: string;
+  sslCa?: string;
+  sslCert?: string;
+  sslKey?: string;
+
   syncSchema: boolean;
 };
 

--- a/frontend/src/types/sql.ts
+++ b/frontend/src/types/sql.ts
@@ -14,6 +14,9 @@ export type ConnectionInfo = {
   // not transfer the password back to client, thus we here pass the instanceId so the server
   // can fetch the corresponding password.
   instanceId?: InstanceId;
+  sslCa?: string;
+  sslCert?: string;
+  sslKey?: string;
 };
 
 export type QueryInfo = {


### PR DESCRIPTION
Close BYT-739

Currently, we provide text boxes for users to copy/paste the cert like what GitHub did. We may ship to file uploaders in the future if needed.

Screenshot
![ssl-1](https://user-images.githubusercontent.com/2749742/174924032-093c3898-ad8a-4a4f-b456-eb8a1c04c7f2.gif)
