### PR TITLE
chore: add release guard to pitr restore button

### DIFF
--- a/frontend/src/components/DatabaseBackupPanel.vue
+++ b/frontend/src/components/DatabaseBackupPanel.vue
@@ -101,7 +101,7 @@
 
         <div class="flex-1 flex items-center justify-end">
           <PITRRestoreButton
-            v-if="allowAdmin"
+            v-if="isDev && allowAdmin"
             :database="database"
             :allow-admin="allowAdmin"
           />


### PR DESCRIPTION
Per discussion, we need to remove PITR button from this release.
And this PR should also be cherry-picked to release 1.2.0.