### PR TITLE
fix(frontend): default ping SSL parameters when creating clickhouse instance

### DIFF
--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -425,14 +425,11 @@ const tryCreate = () => {
     port: instance.port,
   };
 
-  if (typeof instance.sslCa !== "undefined") {
-    connectionInfo.sslCa = instance.sslCa;
-  }
-  if (typeof instance.sslKey !== "undefined") {
-    connectionInfo.sslKey = instance.sslKey;
-  }
-  if (typeof instance.sslCert !== "undefined") {
-    connectionInfo.sslCert = instance.sslCert;
+  if (showSSL.value) {
+    // Default to "NONE"
+    connectionInfo.sslCa = instance.sslCa ?? "";
+    connectionInfo.sslKey = instance.sslKey ?? "";
+    connectionInfo.sslCert = instance.sslCert ?? "";
   }
 
   sqlStore.ping(connectionInfo).then((resultSet: SQLResultSet) => {

--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -485,14 +485,11 @@ const testConnection = () => {
     instanceId: undefined,
   };
 
-  if (typeof instance.sslCa !== "undefined") {
-    connectionInfo.sslCa = instance.sslCa;
-  }
-  if (typeof instance.sslKey !== "undefined") {
-    connectionInfo.sslKey = instance.sslKey;
-  }
-  if (typeof instance.sslCert !== "undefined") {
-    connectionInfo.sslCert = instance.sslCert;
+  if (showSSL.value) {
+    // Default to "NONE"
+    connectionInfo.sslCa = instance.sslCa || "";
+    connectionInfo.sslKey = instance.sslKey || "";
+    connectionInfo.sslCert = instance.sslCert || "";
   }
 
   sqlStore.ping(connectionInfo).then((resultSet: SQLResultSet) => {

--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -487,9 +487,9 @@ const testConnection = () => {
 
   if (showSSL.value) {
     // Default to "NONE"
-    connectionInfo.sslCa = instance.sslCa || "";
-    connectionInfo.sslKey = instance.sslKey || "";
-    connectionInfo.sslCert = instance.sslCert || "";
+    connectionInfo.sslCa = instance.sslCa ?? "";
+    connectionInfo.sslKey = instance.sslKey ?? "";
+    connectionInfo.sslCert = instance.sslCert ?? "";
   }
 
   sqlStore.ping(connectionInfo).then((resultSet: SQLResultSet) => {


### PR DESCRIPTION
fix: if a user didn't touch anything about SSL Connection, we should fall back to NONE (using 3 empty strings).