### PR TITLE
fix: test connection in instance detail page

### DIFF
--- a/api/sql.go
+++ b/api/sql.go
@@ -16,9 +16,9 @@ type ConnectionInfo struct {
 	Password         string  `jsonapi:"attr,password"`
 	UseEmptyPassword bool    `jsonapi:"attr,useEmptyPassword"`
 	InstanceID       *int    `jsonapi:"attr,instanceId"`
-	SslCa            string  `jsonapi:"attr,sslCa"`
-	SslCert          string  `jsonapi:"attr,sslCert"`
-	SslKey           string  `jsonapi:"attr,sslKey"`
+	SslCa            *string `jsonapi:"attr,sslCa"`
+	SslCert          *string `jsonapi:"attr,sslCert"`
+	SslKey           *string `jsonapi:"attr,sslKey"`
 }
 
 // SQLSyncSchema is the API message for sync schemas.

--- a/server/sql.go
+++ b/server/sql.go
@@ -47,20 +47,37 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			password = adminPassword
 		}
 
+		var tlsConfig db.TLSConfig
+		if connectionInfo.Engine == db.ClickHouse {
+			if connectionInfo.SslCa == nil && connectionInfo.SslCert == nil && connectionInfo.SslKey == nil && connectionInfo.InstanceID != nil {
+				// Frontend will not pass ssl related field if user don't modify ssl suite, we need get ssl suite from database for this case.
+				tc, err := s.store.GetInstanceSslSuiteByID(ctx, *connectionInfo.InstanceID)
+				if err != nil {
+					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to retrieve ssl suite for instance: %d", *connectionInfo.InstanceID)).SetInternal(err)
+				}
+				tlsConfig = tc
+			} else if connectionInfo.SslCa != nil && connectionInfo.SslCert != nil && connectionInfo.SslKey != nil {
+				// Users may add instance and click test connection button now, we need get ssl suite from request for this case.
+				tlsConfig = db.TLSConfig{
+					SslCA:   *connectionInfo.SslCa,
+					SslCert: *connectionInfo.SslCert,
+					SslKey:  *connectionInfo.SslKey,
+				}
+			} else {
+				// Unexpected case
+				return echo.NewHTTPError(http.StatusBadRequest, "TLS/SSL suite must all be set or not be set")
+			}
+		}
 		db, err := db.Open(
 			ctx,
 			connectionInfo.Engine,
 			db.DriverConfig{},
 			db.ConnectionConfig{
-				Username: connectionInfo.Username,
-				Password: password,
-				Host:     connectionInfo.Host,
-				Port:     connectionInfo.Port,
-				TLSConfig: db.TLSConfig{
-					SslCA:   connectionInfo.SslCa,
-					SslCert: connectionInfo.SslCert,
-					SslKey:  connectionInfo.SslKey,
-				},
+				Username:  connectionInfo.Username,
+				Password:  password,
+				Host:      connectionInfo.Host,
+				Port:      connectionInfo.Port,
+				TLSConfig: tlsConfig,
 			},
 			db.ConnectionContext{},
 		)

--- a/store/instance.go
+++ b/store/instance.go
@@ -203,6 +203,25 @@ func (s *Store) GetInstanceAdminPasswordByID(ctx context.Context, instanceID int
 	return "", &common.Error{Code: common.NotFound, Err: fmt.Errorf("missing admin password for instance with ID %d", instanceID)}
 }
 
+// GetInstanceSslSuiteByID gets ssl suite of instance.
+func (s *Store) GetInstanceSslSuiteByID(ctx context.Context, instanceID int) (db.TLSConfig, error) {
+	dataSourceFind := &api.DataSourceFind{
+		InstanceID: &instanceID,
+	}
+	dataSourceRawList, err := s.FindDataSource(ctx, dataSourceFind)
+	if err != nil {
+		return db.TLSConfig{}, err
+	}
+	for _, dataSourceRaw := range dataSourceRawList {
+		return db.TLSConfig{
+			SslCA:   dataSourceRaw.SslCa,
+			SslKey:  dataSourceRaw.SslKey,
+			SslCert: dataSourceRaw.SslCert,
+		}, nil
+	}
+	return db.TLSConfig{}, &common.Error{Code: common.NotFound, Err: fmt.Errorf("missing ssl suite for instance with ID %d", instanceID)}
+}
+
 //
 // private function
 //


### PR DESCRIPTION
The server can handle the request for the test connection in the ClickHouse instance detail page now.
Fix BYT-713