### PR TITLE
feat(frontend): remove "Cancel" button for task status transition

### DIFF
--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -217,7 +217,7 @@ const APPLICABLE_TASK_TRANSITION_LIST: Map<
 > = new Map([
   ["PENDING", ["RUN"]],
   ["PENDING_APPROVAL", ["APPROVE"]],
-  ["RUNNING", ["CANCEL"]],
+  ["RUNNING", []],
   ["DONE", []],
   ["FAILED", ["RETRY"]],
 ]);


### PR DESCRIPTION
Close BYT-747

Canceling a task is somehow meaningless. While canceling an issue is meaningful.