### PR TITLE
fix: missing timezone file in alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,11 @@ LABEL org.opencontainers.image.revision=${GIT_COMMIT}
 LABEL org.opencontainers.image.created=${BUILD_TIME}
 LABEL org.opencontainers.image.authors=${BUILD_USER}
 
+# We need copy timezone file from backend layer.
+# Otherwise, clickhouse cannot be connected due to the missing time zone file in alpine.
+COPY --from=backend /usr/local/go/lib/time/zoneinfo.zip /opt/zoneinfo.zip
+ENV ZONEINFO /opt/zoneinfo.zip
+
 COPY --from=backend /backend-build/bytebase /usr/local/bin/
 
 # Copy utility scripts, we have


### PR DESCRIPTION
We need to copy the timezone file from the backend stage in the docker file.