### PR TITLE
fix: remove tag step since we have altered the release steps

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -22,8 +22,6 @@ jobs:
         working-directory: frontend
       - run: pnpm release
         working-directory: frontend
-      - name: Extract version
-        run: git tag ${GITHUB_REF_NAME#release/}
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16


### PR DESCRIPTION
We now create tag in advance, and this workflow is triggered on tag push. So creating tag inside the workflow will trigger error.