### PR TITLE
docs: link the install to the doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,23 +86,9 @@ Regardless of working as an IC in a team or managing your own side project, deve
 
 ![Screenshot](https://raw.githubusercontent.com/bytebase/bytebase/main/docs/assets/sql-editor.webp)
 
-## Installation
-
-[Detailed installation guide](https://bytebase.com/docs/install/install-with-docker?source=github)
-
-### Run on localhost:8080
-
-```bash
-docker run --init --name bytebase --restart always --publish 8080:8080 --volume ~/.bytebase/data:/var/opt/bytebase bytebase/bytebase:1.2.0 --data /var/opt/bytebase --host http://localhost --port 8080
-```
-
-### Run on https://bytebase.example.com
-
-```bash
-docker run --init --name bytebase --restart always --publish 80:80 --volume ~/.bytebase/data:/var/opt/bytebase bytebase/bytebase:1.2.0 --data /var/opt/bytebase --host https://bytebase.example.com --port 80
-```
-
 ## 📕 Docs
+
+### [Installation](https://bytebase.com/docs/install/install-with-docker?source=github)
 
 ### [User doc](https://bytebase.com/docs?source=github)
 


### PR DESCRIPTION
The main reason is to reduce the work of changing version string during upgrade