### PR TITLE
fix: remove default replicaServerId

### DIFF
--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -114,7 +114,6 @@ func newMigrationContext(config ghostConfig) (*base.MigrationContext, error) {
 	migrationContext.AllowedRunningOnMaster = allowedRunningOnMaster
 	migrationContext.ConcurrentCountTableRows = concurrentCountTableRows
 	migrationContext.HooksStatusIntervalSec = hooksStatusIntervalSec
-	migrationContext.ReplicaServerId = replicaServerID
 	migrationContext.CutOverType = base.CutOverAtomic
 
 	if migrationContext.AlterStatement == "" {

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -80,7 +80,6 @@ func newMigrationContext(config ghostConfig) (*base.MigrationContext, error) {
 		allowedRunningOnMaster              = true
 		concurrentCountTableRows            = true
 		hooksStatusIntervalSec              = 60
-		replicaServerID                     = 99999
 		heartbeatIntervalMilliseconds       = 100
 		niceRatio                           = 0
 		chunkSize                           = 1000


### PR DESCRIPTION
Line 112 sets the ReplicaServerId to config.serverID, and then line 117 sets it back to the default.
It must be that I forgot to remove this line.

This should fix BYT-776.