### PR TITLE
chore: improve beta label style

### DIFF
--- a/frontend/src/bbkit/BBBetaBadge.vue
+++ b/frontend/src/bbkit/BBBetaBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    class="text-white text-xs px-[6px] rounded-lg select-none"
+    class="text-white text-xs px-[6px] py-[2px] rounded-lg select-none"
     style="background-color: var(--color-control)"
     :class="
       corner


### PR DESCRIPTION
Before

<img width="506" alt="CleanShot 2022-06-24 at 17 58 58@2x" src="https://user-images.githubusercontent.com/230323/175512334-188adb7a-317b-478e-ae7c-6c5456509d41.png">

After

<img width="466" alt="CleanShot 2022-06-24 at 17 57 41@2x" src="https://user-images.githubusercontent.com/230323/175512244-2fd2bf98-bf14-4d4b-ad95-5b2cc9a84663.png">
