### PR TITLE
fix: relax the time parse check

### DIFF
--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -701,7 +701,7 @@ func parseBinlogEventTsInLine(line string) (eventTs int64, found bool, err error
 	fields := strings.Fields(line)
 	// fields should starts with ["#220421", "14:49:26", "server", "id", "1", "end_log_pos", "34794"]
 	if len(fields) < 7 ||
-		(len(fields[0]) != 7 || len(fields[1]) != 8 || fields[2] != "server" || fields[3] != "id" || fields[5] != "end_log_pos") {
+		(len(fields[0]) != 7 || fields[2] != "server" || fields[3] != "id" || fields[5] != "end_log_pos") {
 		return 0, false, fmt.Errorf("found unexpected mysqlbinlog output line %q when parsing binlog event timestamp", line)
 	}
 	datetime, err := time.ParseInLocation("060102 15:04:05", fmt.Sprintf("%s %s", fields[0][1:], fields[1]), time.Local)


### PR DESCRIPTION
![origin_img_v2_74c910ec-bd97-46e3-9e0f-7f9a375b4c3g](https://user-images.githubusercontent.com/8433465/176152763-76f9b354-d129-4a07-9501-4583d2e113ac.jpg)

This bug is reported by @LiuJi-Jim .
The current check is too strict and cannot let go of "9:58:06".
Leave the time format errors to `time.ParseInLocation`.