### PR TITLE
chore: update gh-ost fork version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/labstack/echo-contrib v0.12.0
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/mattn/go-sqlite3 v1.14.7
-	github.com/openark/golib v0.0.0-20210531070646-355f37940af8
 	github.com/pingcap/tidb v1.1.0-beta.0.20211209055157-9f744cdf8266
 	github.com/pingcap/tidb/parser v0.0.0-20211209055157-9f744cdf8266
 	github.com/pkg/errors v0.9.1
@@ -44,4 +43,4 @@ require (
 // fix potential security issue(CVE-2020-26160) introduced by indirect dependency.
 replace github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.20210809144907-32ab6a8243d7+incompatible
 
-replace github.com/github/gh-ost => github.com/bytebase/gh-ost v1.1.3-0.20220628072952-d497834632ba
+replace github.com/github/gh-ost => github.com/bytebase/gh-ost v1.1.3-0.20220630053012-aac285eb72df

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/bytebase/gh-ost v1.1.3-0.20220628072952-d497834632ba h1:CmOUUIKJ+A7x2P1dNN4POgOeAhu9ko8wKYSrOhIRiVA=
-github.com/bytebase/gh-ost v1.1.3-0.20220628072952-d497834632ba/go.mod h1:KapUFjHOhrrWRyXCV7iZXfL3FGhTfe8Z6UQupU1MxoU=
+github.com/bytebase/gh-ost v1.1.3-0.20220630053012-aac285eb72df h1:dATyXNsy6bf2ReGpkX8BerHOzsQNWGfGnr0wq0m06ho=
+github.com/bytebase/gh-ost v1.1.3-0.20220630053012-aac285eb72df/go.mod h1:ejl5ywyKoObDIh0yWDIvU2JFS9I3c12jQPgdSm13sfM=
 github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 h1:BjkPE3785EwPhhyuFkbINB+2a1xATwk8SNDWnJiD41g=
 github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5/go.mod h1:jtAfVaU/2cu1+wdSRPWE2c1N2qeAA3K4RH9pYgqwets=
 github.com/carlmjohnson/flagext v0.21.0/go.mod h1:Eenv0epIUAr4NuedNmkzI8WmBmjIxZC239XcKxYS2ac=

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -19,7 +19,6 @@ import (
 	"github.com/github/gh-ost/go/base"
 	"github.com/github/gh-ost/go/logic"
 	ghostsql "github.com/github/gh-ost/go/sql"
-	ghostlog "github.com/openark/golib/log"
 	"go.uber.org/zap"
 )
 
@@ -92,7 +91,6 @@ func newMigrationContext(config ghostConfig) (*base.MigrationContext, error) {
 	)
 	statement := strings.Join(strings.Fields(config.alterStatement), " ")
 	migrationContext := base.NewMigrationContext()
-	migrationContext.Log.SetLevel(ghostlog.ERROR)
 	migrationContext.InspectorConnectionConfig.Key.Hostname = config.host
 	port := 3306
 	if config.port != "" {


### PR DESCRIPTION
Update to this commit https://github.com/bytebase/gh-ost/commit/aac285eb72df5f82e7cfb22a65b733e2c703b527.
The previous version is this commit https://github.com/bytebase/gh-ost/commit/d497834632ba92ca2e61646c5e13c6833ce11bc5

The changes are
- change gh-ost logger to `zap.Logger`
- `panic` in `Log.Fatal` because we use gh-ost as a library and dont't want to bring down the whole process.

Close BYT-818