### PR TITLE
fix: using bash syntax instead of sh

### DIFF
--- a/Dockerfile.render
+++ b/Dockerfile.render
@@ -61,7 +61,8 @@ LABEL org.opencontainers.image.revision=${RENDER_GIT_COMMIT}
 LABEL org.opencontainers.image.created=${BUILD_TIME}
 LABEL org.opencontainers.image.authors=${BUILD_USER}
 
-RUN apt-get update && apt-get install -y locales
+# Our HEALTHCHECK instruction in dockerfile needs curl.
+RUN apt-get update && apt-get install -y locales curl
 # Generate en_US.UTF-8 locale which is needed to start postgres server.
 # Fix the posgres server issue (invalid value for parameter "lc_messages": "en_US.UTF-8").
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen

--- a/Dockerfile.render-preview
+++ b/Dockerfile.render-preview
@@ -63,7 +63,8 @@ LABEL org.opencontainers.image.revision=${RENDER_GIT_COMMIT}
 LABEL org.opencontainers.image.created=${BUILD_TIME}
 LABEL org.opencontainers.image.authors=${BUILD_USER}
 
-RUN apt-get update && apt-get install -y locales
+# Our HEALTHCHECK instruction in dockerfile needs curl.
+RUN apt-get update && apt-get install -y locales curl
 # Generate en_US.UTF-8 locale which is needed to start postgres server.
 # Fix the posgres server issue (invalid value for parameter "lc_messages": "en_US.UTF-8").
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -23,7 +23,7 @@ if [ $1 ]; then
     fi
 fi
 
-function seedDemoData() {
+seedDemoData() {
     echo 'Seeding data for online demo'
 
     bytebase --host ${ONLINE_DEMO_HOST} --port ${ONLINE_DEMO_PORT} --demo --data /var/opt/bytebase &
@@ -42,7 +42,7 @@ function seedDemoData() {
     sleep 20
 }
 
-function startReadonly() {
+startReadonly() {
     echo "Starting Bytebase in readonly and demo mode at ${ONLINE_DEMO_HOST}:${ONLINE_DEMO_PORT}..."
 
     bytebase --host ${ONLINE_DEMO_HOST} --port ${ONLINE_DEMO_PORT} --readonly --demo --data /var/opt/bytebase

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -12,9 +12,9 @@
 ONLINE_DEMO_HOST='https://demo.bytebase.com'
 ONLINE_DEMO_PORT='443'
 if [ $1 ]; then
-    PROTOCAL=`echo $1 | awk -F ':' '{ print $1 }'`
-    URI=`echo $1 | awk -F '[/:]' '{ print $4; }'`
-    PORT=`echo $1 | awk -F '[/:]' '{ print $5; }'`
+    PROTOCAL=$(echo $1 | awk -F ':' '{ print $1 }')
+    URI=$(echo $1 | awk -F '[/:]' '{ print $4; }')
+    PORT=$(echo $1 | awk -F '[/:]' '{ print $5; }')
 
     ONLINE_DEMO_HOST=$PROTOCAL://$URI
 
@@ -23,13 +23,12 @@ if [ $1 ]; then
     fi
 fi
 
-function seedDemoData(){
+function seedDemoData() {
     echo 'Seeding data for online demo'
 
     bytebase --host ${ONLINE_DEMO_HOST} --port ${ONLINE_DEMO_PORT} --demo --data /var/opt/bytebase &
 
-    until [ -f /var/opt/bytebase/pgdata/PG_VERSION ]
-    do
+    until [ -f /var/opt/bytebase/pgdata/PG_VERSION ]; do
         echo "waiting..."
         sleep 1
     done
@@ -43,10 +42,11 @@ function seedDemoData(){
     sleep 20
 }
 
-function startReadonly(){
+function startReadonly() {
     echo "Starting Bytebase in readonly and demo mode at ${ONLINE_DEMO_HOST}:${ONLINE_DEMO_PORT}..."
 
     bytebase --host ${ONLINE_DEMO_HOST} --port ${ONLINE_DEMO_PORT} --readonly --demo --data /var/opt/bytebase
 }
 
-seedDemoData; startReadonly
+seedDemoData
+startReadonly

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # For now, we use this script to start our demo on render
 # by changing the ENTRYPOINT and CMD at the dockerfile to this.

--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # For now, we use this script to start our staging preview on render
 # by changing the ENTRYPOINT and CMD at the dockerfile to this.
@@ -12,9 +12,9 @@
 ONLINE_DEMO_HOST='https://staging.bytebase.com'
 ONLINE_DEMO_PORT='443'
 if [ $1 ]; then
-    PROTOCAL=`echo $1 | awk -F ':' '{ print $1 }'`
-    URI=`echo $1 | awk -F '[/:]' '{ print $4; }'`
-    PORT=`echo $1 | awk -F '[/:]' '{ print $5; }'`
+    PROTOCAL=$(echo $1 | awk -F ':' '{ print $1 }')
+    URI=$(echo $1 | awk -F '[/:]' '{ print $4; }')
+    PORT=$(echo $1 | awk -F '[/:]' '{ print $5; }')
 
     ONLINE_DEMO_HOST=$PROTOCAL://$URI
 


### PR DESCRIPTION
In Debian, `sh` is soft linked to bash by default.
Demo of deploying after fixed: https://zpdev-bytebase-demo.onrender.com/