### PR TITLE
chore: remove version from package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "bytebase",
-  "version": "1.2.1",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "dev": "vite --mode dev",


### PR DESCRIPTION
We won't export out package, and it reduces the workload of updating version string during upgrade.