### PR TITLE
chore: turn on PostgreSQL syntax check

### DIFF
--- a/plugin/advisor/advisor.go
+++ b/plugin/advisor/advisor.go
@@ -202,7 +202,7 @@ func Check(dbType DBType, advType Type, ctx Context, statement string) ([]Advice
 
 // IsSyntaxCheckSupported checks the engine type if syntax check supports it.
 func IsSyntaxCheckSupported(dbType DBType) bool {
-	if dbType == MySQL || dbType == TiDB {
+	if dbType == MySQL || dbType == TiDB || dbType == Postgres {
 		return true
 	}
 	return false


### PR DESCRIPTION
We use `pg_query_go` as the PostgreSQL parser instead of https://github.com/auxten/postgresql-parser. Now we can turn on the PostgreSQL syntax check.

related PR: #1698 

![ipkSCxU0yC](https://user-images.githubusercontent.com/20775801/176808850-51daf258-b09b-4237-9b7c-5f4a6381f44b.png)
