### PR TITLE
refactor(PITR): use single db session to swap in cutover task

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1729,6 +1729,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/mysql v1.0.6/go.mod h1:KdrTanmfLPPyAOeYGyG+UpDys7/7eeWT1zCq+oekYnU=

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -254,7 +254,7 @@ type MigrationInfo struct {
 	// Since stored version should be unique, we have to append a suffix if we allow users to baseline to the same semantic version for fixing schema drift.
 	SemanticVersionSuffix string
 	// Force is used to execute migration disregarding any migration history with PENDING or FAILED status.
-	// This applies to BASELINE and MIGRATE types of migrations because most of these migrations are retriable.
+	// This applies to BASELINE and MIGRATE types of migrations because most of these migrations are retry-able.
 	// We don't use force option for DATA type of migrations yet till there's customer needs.
 	Force bool
 }
@@ -437,7 +437,7 @@ type Driver interface {
 	Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error)
 	// Restore the database from sc, which is a full backup.
 	Restore(ctx context.Context, sc *bufio.Scanner) error
-	// RestoreTx resotres the database from sc in the given transaction.
+	// RestoreTx restores the database from sc in the given transaction.
 	RestoreTx(ctx context.Context, tx *sql.Tx, sc *bufio.Scanner) error
 }
 

--- a/server/sql.go
+++ b/server/sql.go
@@ -749,9 +749,9 @@ func validateSQLSelectStatement(sqlStatement string) bool {
 
 	// Allow SELECT and EXPLAIN queries only.
 	whiteListRegs := []string{`^SELECT\s+?`, `^EXPLAIN\s+?`}
-	formatedStr := strings.ToUpper(strings.TrimSpace(sqlStatement))
+	formattedStr := strings.ToUpper(strings.TrimSpace(sqlStatement))
 	for _, reg := range whiteListRegs {
-		matchResult, _ := regexp.MatchString(reg, formatedStr)
+		matchResult, _ := regexp.MatchString(reg, formattedStr)
 		if matchResult {
 			return true
 		}

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -86,6 +86,16 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 		return true, nil, err
 	}
 
+	driverDB, err := driver.GetDbConnection(ctx, "")
+	if err != nil {
+		return true, nil, err
+	}
+	conn, err := driverDB.Conn(ctx)
+	if err != nil {
+		return true, nil, err
+	}
+	defer conn.Close()
+
 	mysqlDriver, ok := driver.(*mysql.Driver)
 	if !ok {
 		log.Error("failed to cast driver to mysql.Driver")
@@ -93,25 +103,15 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 	}
 	mysqlDriver.SetUpForPITR(exec.mysqlutil, binlogDir)
 
-	log.Info("Start swapping the original and PITR database",
-		zap.String("instance", task.Instance.Name),
-		zap.String("original_database", task.Database.Name),
-	)
-	pitrDatabaseName, pitrOldDatabaseName, err := mysqlDriver.SwapPITRDatabase(ctx, task.Database.Name, issue.CreatedTs)
+	log.Debug("Swapping the original and PITR database...", zap.String("instance", task.Instance.Name), zap.String("originalDatabase", task.Database.Name))
+	pitrDatabaseName, pitrOldDatabaseName, err := mysql.SwapPITRDatabase(ctx, conn, task.Database.Name, issue.CreatedTs)
 	if err != nil {
-		log.Error("Failed to swap the original and PITR database",
-			zap.Int("issueID", issue.ID),
-			zap.String("database", task.Database.Name),
-			zap.Error(err))
+		log.Error("Failed to swap databases and backup the original database", zap.Error(err))
 		return true, nil, fmt.Errorf("failed to swap the original and PITR database, error: %w", err)
 	}
+	log.Debug("Finish swapping the original and PITR database", zap.String("original_database", task.Database.Name), zap.String("pitr_database", pitrDatabaseName), zap.String("old_database", pitrOldDatabaseName))
 
-	log.Info("Finish swapping the original and PITR database",
-		zap.String("original_database", task.Database.Name),
-		zap.String("pitr_database", pitrDatabaseName),
-		zap.String("old_database", pitrOldDatabaseName))
-
-	log.Info("Appending new migration history record...")
+	log.Debug("Appending new migration history record...")
 	m := &db.MigrationInfo{
 		ReleaseVersion: server.profile.Version,
 		Version:        common.DefaultMigrationVersion(),
@@ -120,6 +120,7 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 		Environment:    task.Database.Instance.Environment.Name,
 		Source:         db.MigrationSource(task.Database.Project.WorkflowType),
 		Type:           db.Baseline,
+		Status:         db.Done,
 		Description:    fmt.Sprintf("PITR: restoring database %s", task.Database.Name),
 		Creator:        task.Creator.Name,
 		IssueID:        strconv.Itoa(issue.ID),

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -103,7 +103,7 @@ func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.
 	}
 	mysqlDriver.SetUpForPITR(exec.mysqlutil, binlogDir)
 
-	log.Debug("Swapping the original and PITR database...", zap.String("instance", task.Instance.Name), zap.String("originalDatabase", task.Database.Name))
+	log.Debug("Swapping the original and PITR database.", zap.String("instance", task.Instance.Name), zap.String("originalDatabase", task.Database.Name))
 	pitrDatabaseName, pitrOldDatabaseName, err := mysql.SwapPITRDatabase(ctx, conn, task.Database.Name, issue.CreatedTs)
 	if err != nil {
 		log.Error("Failed to swap databases and backup the original database", zap.Error(err))


### PR DESCRIPTION
This change is for the later PITR algorithm fix, which needs to perform locking in the same DB session during the cutover.