### PR TITLE
feat(frontend): support build frontend package with dev tag

### DIFF
--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -11,11 +11,14 @@ dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
 export function isDev(): boolean {
-  return import.meta.env.DEV;
+  // When building a package vite provides us env.DEV=undefined.
+  // But we want to provide canary developing features.
+  // So isDev() is true if FE_MODE === 'dev'
+  return FE_MODE === "dev" || import.meta.env.DEV;
 }
 
 export function isRelease(): boolean {
-  return import.meta.env.PROD;
+  return FE_MODE !== "dev" && import.meta.env.PROD;
 }
 
 export function humanizeTs(ts: number): string {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare const FE_MODE: "release" | "dev";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,8 @@ import Components from "unplugin-vue-components/vite";
 const SERVER_PORT = parseInt(process.env.PORT ?? "", 10) ?? 3000;
 const HTTPS_PORT = 443;
 
+const FE_MODE = process.env.FE_MODE === "dev" ? "dev" : "release"; // default to 'release'
+
 export default defineConfig(() => {
   // NOTE: the following lines is to solve https://github.com/gitpod-io/gitpod/issues/6719
   // tl;dr : the HMR(hot module replacement) will behave differently when VPN is on, and by manually set its port to 443 should prevent this issue.
@@ -33,6 +35,9 @@ export default defineConfig(() => {
       }),
       Icons(),
     ],
+    define: {
+      FE_MODE: JSON.stringify(FE_MODE),
+    },
     server: {
       port: SERVER_PORT,
       proxy: {


### PR DESCRIPTION
Close BYT-828

### Feature
Now we are allowed to build Bytebase with an environment variable `FE_MODE=dev` to enable canary dev features in the binary.

e.g., `FE_MODE=dev sh ./scripts/build.sh`

This is preparing for BYT-720

### Known issues

- Some frontend/backend combined dev features will not work if we are using a release version of backend with a development version of frontend. E.g., the plan switch and role switch button at the top right corner of the page.