### PR TITLE
feat(CD): trigger render staging listening new release branch when creating release branch

### DIFF
--- a/.github/workflows/update-render-staging-service.yml
+++ b/.github/workflows/update-render-staging-service.yml
@@ -1,0 +1,34 @@
+name: Update render staging service
+
+on:
+  create:
+    branches:
+      - "release/*.*.*"
+
+jobs:
+  update-render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract version
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF_NAME#release/}" >> $GITHUB_ENV
+      - name: Update render web service
+        run: |
+          export RENDER_API_STATUS_CODE=$(curl --request PATCH \
+                -w %{http_code} \
+                -o /dev/null \
+                --url https://api.render.com/v1/services/srv-c760lk4objdcv67lc6ug \
+                --header 'Accept: application/json' \
+                --header 'Authorization: Bearer ${{ secrets.RENDER_API_KEY }}' \
+                --header 'Content-Type: application/json' \
+                --data '
+                {
+                  "autoDeploy": "yes",
+                  "branch": "release/${{ env.RELEASE_VERSION }}"
+                }
+                '
+              )
+          if [ "${RENDER_API_STATUS_CODE-}" != "200" ]; then
+            exit 1
+          fi

--- a/.github/workflows/update-render-staging-service.yml
+++ b/.github/workflows/update-render-staging-service.yml
@@ -1,9 +1,6 @@
 name: Update render staging service
 
 on:
-  create:
-    branches:
-      - "release/*.*.*"
   push:
     branches:
       - "release/*.*.*"

--- a/.github/workflows/update-render-staging-service.yml
+++ b/.github/workflows/update-render-staging-service.yml
@@ -29,6 +29,6 @@ jobs:
                 '
               )
           echo ${RENDER_RESPONSE}
-          if [ "$(echo ${RENDER_RESPONSE} | tail -n 1)" != "200" ]; then
+          if [[ "$(echo ${RENDER_RESPONSE} | tail -n 1)" != "200" ]]; then
             exit 1
           fi

--- a/.github/workflows/update-render-staging-service.yml
+++ b/.github/workflows/update-render-staging-service.yml
@@ -29,6 +29,6 @@ jobs:
                 '
               )
           echo ${RENDER_RESPONSE}
-          if [ "echo ${RENDER_RESPONSE} | tail -n 1" != "200" ]; then
+          if [ "$(echo ${RENDER_RESPONSE} | tail -n 1)" != "200" ]; then
             exit 1
           fi

--- a/.github/workflows/update-render-staging-service.yml
+++ b/.github/workflows/update-render-staging-service.yml
@@ -4,6 +4,11 @@ on:
   create:
     branches:
       - "release/*.*.*"
+  push:
+    branches:
+      - "release/*.*.*"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   update-render:

--- a/.github/workflows/update-render-staging-service.yml
+++ b/.github/workflows/update-render-staging-service.yml
@@ -15,9 +15,8 @@ jobs:
           echo "RELEASE_VERSION=${GITHUB_REF_NAME#release/}" >> $GITHUB_ENV
       - name: Update render web service
         run: |
-          export RENDER_API_STATUS_CODE=$(curl --request PATCH \
+          RENDER_RESPONSE=$(curl --request PATCH \
                 -w %{http_code} \
-                -o /dev/null \
                 --url https://api.render.com/v1/services/srv-c760lk4objdcv67lc6ug \
                 --header 'Accept: application/json' \
                 --header 'Authorization: Bearer ${{ secrets.RENDER_API_KEY }}' \
@@ -29,6 +28,7 @@ jobs:
                 }
                 '
               )
-          if [ "${RENDER_API_STATUS_CODE-}" != "200" ]; then
+          echo ${RENDER_RESPONSE}
+          if [ "echo ${RENDER_RESPONSE} | tail -n 1" != "200" ]; then
             exit 1
           fi


### PR DESCRIPTION
Using [render's API](https://api-docs.render.com/reference/update-service) with GitHub Action allows us to switch the monitor branch of Bytebase staging web service in render to the new release branch when we create the `release/x.y.z` branch.
Here is a [demo](https://github.com/h3n4l/render-cd-test).
Completing BYT-726.