### PR TITLE
chore: use ColumnName instead of ColumnDef in RenameColumnStmt

### DIFF
--- a/plugin/parser/ast/rename_column_stmt.go
+++ b/plugin/parser/ast/rename_column_stmt.go
@@ -5,7 +5,7 @@ package ast
 type RenameColumnStmt struct {
 	node
 
-	Table   *TableDef
-	Column  *ColumnDef
-	NewName string
+	Table      *TableDef
+	ColumnName string
+	NewName    string
 }

--- a/plugin/parser/ast/utils.go
+++ b/plugin/parser/ast/utils.go
@@ -30,9 +30,6 @@ func Walk(v Visitor, node Node) {
 		if n.Table != nil {
 			Walk(v, n.Table)
 		}
-		if n.Column != nil {
-			Walk(v, n.Column)
-		}
 	case *AlterTableStmt:
 		if n.Table != nil {
 			Walk(v, n.Table)

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -82,9 +82,9 @@ func convert(node *pgquery.Node) (ast.Node, error) {
 		switch in.RenameStmt.RenameType {
 		case pgquery.ObjectType_OBJECT_COLUMN:
 			return &ast.RenameColumnStmt{
-				Table:   convertRangeVarToTableName(in.RenameStmt.Relation),
-				Column:  &ast.ColumnDef{ColumnName: in.RenameStmt.Subname},
-				NewName: in.RenameStmt.Newname,
+				Table:      convertRangeVarToTableName(in.RenameStmt.Relation),
+				ColumnName: in.RenameStmt.Subname,
+				NewName:    in.RenameStmt.Newname,
 			}, nil
 		case pgquery.ObjectType_OBJECT_TABLE:
 			return &ast.RenameTableStmt{

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -214,10 +214,8 @@ func TestPGRenameColumnStmt(t *testing.T) {
 					Table: &ast.TableDef{
 						Name: "techbook",
 					},
-					Column: &ast.ColumnDef{
-						ColumnName: "abc",
-					},
-					NewName: "ABC",
+					ColumnName: "abc",
+					NewName:    "ABC",
 				},
 			},
 		},


### PR DESCRIPTION
In `RenameColumnStmt`, we only need `ColumnName` rather than `ColumnDef`.