### PR TITLE
chore: use the correct testify package for advisor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.0.7
 	github.com/VictoriaMetrics/fastcache v1.6.0
 	github.com/blang/semver/v4 v4.0.0
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/casbin/casbin/v2 v2.40.6
 	github.com/github/gh-ost v1.1.4
 	github.com/go-sql-driver/mysql v1.6.0

--- a/plugin/advisor/pg/advisor_syntax_test.go
+++ b/plugin/advisor/pg/advisor_syntax_test.go
@@ -3,8 +3,8 @@ package pg
 import (
 	"testing"
 
-	"github.com/bmizerany/assert"
 	"github.com/bytebase/bytebase/plugin/advisor"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/bytebase/bytebase/plugin/parser/engine/pg"

--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/bmizerany/assert"
 	"github.com/bytebase/bytebase/plugin/advisor/catalog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,6 +74,6 @@ func RunSchemaReviewRuleTests(
 	for _, tc := range tests {
 		adviceList, err := adv.Check(ctx, tc.Statement)
 		require.NoError(t, err)
-		assert.Equal(t, tc.Want, adviceList)
+		assert.Equal(t, tc.Want, adviceList, tc.Statement)
 	}
 }


### PR DESCRIPTION
* github.com/bmizerany/assert is a very old package. We have to keep it because it's a dependency for the segment golang library. On the other hand, we should not use it directly in our code.  github.com/stretchr/testify/assert is the right one as it gives detailed test error and won't abort on first test failure

* Output the statement when the advisor test case fails.

<img width="1194" alt="CleanShot 2022-07-04 at 23 15 48@2x" src="https://user-images.githubusercontent.com/230323/177184325-7f66add5-348e-46b5-b0b2-fc55046df578.png">

