### PR TITLE
chore: separate test steps & increase timeout minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           mkdir -p server/dist
           touch server/dist/index.html
-      - name: Install dependencies and run all tests
-        run: |
-          go generate -tags ${{ matrix.release-tags }}mysql ./...
-          go test -v ./... -tags=${{ matrix.release-tags }}mysql
+      - name: Install dependencies
+        run: go generate -tags ${{ matrix.release-tags }}mysql ./...
+      - name: Run all tests
+        run: go test -v ./... -tags=${{ matrix.release-tags }}mysql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,4 +66,5 @@ jobs:
       - name: Install dependencies
         run: go generate -tags ${{ matrix.release-tags }}mysql ./...
       - name: Run all tests
+        timeout-minutes: 15
         run: go test -v ./... -tags=${{ matrix.release-tags }}mysql


### PR DESCRIPTION
- Separate test steps to better view how long it takes to run tests.
- Increase timeout minutes because 10 minutes seems to be too strict for "test release".