### PR TITLE
fix: PostgreSQL double quotes in name

### DIFF
--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -707,7 +707,7 @@ func quoteIdentifier(s string) string {
 		quote = true
 	}
 	if quote {
-		return strings.ReplaceAll(s, "\"", "\"\"")
+		return fmt.Sprintf("\"%s\"", s)
 	}
 	return s
 }

--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -707,8 +707,7 @@ func quoteIdentifier(s string) string {
 		quote = true
 	}
 	if quote {
-		return fmt.Sprintf("\"%s\"", strings.ReplaceAll(s, "\"", "\"\""))
+		return strings.ReplaceAll(s, "\"", "\"\"")
 	}
 	return s
-
 }


### PR DESCRIPTION
It is a tiny fix, we need to add an integration test in the next cycle.