### PR TITLE
fix: activity sorting order

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,5 +1,10 @@
 package api
 
+import (
+	"fmt"
+	"strings"
+)
+
 // UnknownID is the ID for unknowns.
 const UnknownID = -1
 
@@ -22,3 +27,14 @@ const (
 	// DESC is the sort order to return in descending order.
 	DESC SortOrder = "DESC"
 )
+
+// StringToSortOrder converts a valid string to SortOrder.
+func StringToSortOrder(s string) (SortOrder, error) {
+	switch strings.ToUpper(s) {
+	case string(ASC):
+		return ASC, nil
+	case string(DESC):
+		return DESC, nil
+	}
+	return SortOrder(""), fmt.Errorf("%q cannot be converted to SortOrder", s)
+}

--- a/server/activity.go
+++ b/server/activity.go
@@ -89,7 +89,10 @@ func (s *Server) registerActivityRoutes(g *echo.Group) {
 			activityFind.Limit = &limit
 		}
 		if orderStr := c.QueryParams().Get("order"); orderStr != "" {
-			order := api.SortOrder(orderStr)
+			order, err := api.StringToSortOrder(orderStr)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "Query parameter order is invalid").SetInternal(err)
+			}
 			activityFind.Order = &order
 		}
 		activityList, err := s.store.FindActivity(ctx, activityFind)

--- a/store/activity.go
+++ b/store/activity.go
@@ -325,8 +325,7 @@ func findActivityImpl(ctx context.Context, tx *sql.Tx, find *api.ActivityFind) (
 		FROM activity
 		WHERE ` + strings.Join(where, " AND ")
 	if v := find.Order; v != nil {
-		query += fmt.Sprintf(" ORDER BY created_ts $%d", len(args)+1)
-		args = append(args, *v)
+		query += fmt.Sprintf(" ORDER BY created_ts %s", *v)
 	}
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)


### PR DESCRIPTION
PR https://github.com/bytebase/bytebase/pull/1767 is a wrong fix, because the `find.Order` is constant string ASC/DESC and cannot be a prepared argument, which causes syntax error.