### PR TITLE
chore: update gha setup-go and checkout

### DIFF
--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -10,7 +10,7 @@ jobs:
   build-release-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Extract build args
         # Extract version from branch name
         # Example: branch name `release/1.0.0` sets up env.RELEASE_VERSION=1.0.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.16
+          check-latest: true
+          cache: true
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,7 +9,7 @@ jobs:
   release-binary:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.1.0
         with:
           version: 6.10.0
@@ -22,7 +22,7 @@ jobs:
         working-directory: frontend
       - run: pnpm release
         working-directory: frontend
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.16
       - name: Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
+          check-latest: true
+          cache: true
       - name: go generate -tags mysql ./...
         run: go generate -tags mysql ./...
       - name: golangci-lint
@@ -30,6 +32,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
+          check-latest: true
+          cache: true
       - name: Verify go.mod is tidy
         run: |
           go mod tidy
@@ -55,6 +59,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.16
+          check-latest: true
+          cache: true
       - name: Release dry-run
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
   go-tidy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.17
       - name: Verify go.mod is tidy
@@ -39,7 +39,7 @@ jobs:
   release-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.1.0
         with:
           version: 6.10.0
@@ -52,7 +52,7 @@ jobs:
         working-directory: frontend
       - run: pnpm release
         working-directory: frontend
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.16
       - name: Release dry-run
@@ -72,10 +72,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.17
       - name: Cache MySQL

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,8 +78,10 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
+          check-latest: true
+          cache: true
       - name: Cache MySQL
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./resources/mysql/*.tar.gz

--- a/.github/workflows/update-render-staging-service.yml
+++ b/.github/workflows/update-render-staging-service.yml
@@ -11,7 +11,7 @@ jobs:
   update-render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Extract version
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF_NAME#release/}" >> $GITHUB_ENV


### PR DESCRIPTION
`setup-go@v3` supports caching go dependencies.