### PR TITLE
feat: support wait one task with approval in integration test

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -813,7 +813,6 @@ func (ctl *controller) approveIssueTasksWithStageApproval(issue *api.Issue) erro
 
 // getNextTaskStatus gets the next task status that needs to be handle.
 func getNextTaskStatus(issue *api.Issue) (api.TaskStatus, error) {
-	running := false
 	for _, stage := range issue.Pipeline.StageList {
 		for _, task := range stage.TaskList {
 			switch task.Status {
@@ -833,9 +832,6 @@ func getNextTaskStatus(issue *api.Issue) (api.TaskStatus, error) {
 				return api.TaskPending, nil
 			}
 		}
-	}
-	if running {
-		return api.TaskRunning, nil
 	}
 	return api.TaskDone, nil
 }

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -815,22 +815,17 @@ func (ctl *controller) approveIssueTasksWithStageApproval(issue *api.Issue) erro
 func getNextTaskStatus(issue *api.Issue) (api.TaskStatus, error) {
 	for _, stage := range issue.Pipeline.StageList {
 		for _, task := range stage.TaskList {
-			switch task.Status {
-			case api.TaskPendingApproval:
-				return api.TaskPendingApproval, nil
-			case api.TaskFailed:
+			if task.Status == api.TaskDone {
+				continue
+			}
+			if task.Status == api.TaskFailed {
 				var runs []string
 				for _, run := range task.TaskRunList {
 					runs = append(runs, fmt.Sprintf("%+v", run))
 				}
 				return api.TaskFailed, fmt.Errorf("pipeline task %v failed runs: %v", task.ID, strings.Join(runs, ", "))
-			case api.TaskCanceled:
-				return api.TaskCanceled, nil
-			case api.TaskRunning:
-				return api.TaskRunning, nil
-			case api.TaskPending:
-				return api.TaskPending, nil
 			}
+			return task.Status, nil
 		}
 	}
 	return api.TaskDone, nil

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -910,7 +910,6 @@ func (ctl *controller) waitIssueNextTaskWithTaskApproval(id int) (api.TaskStatus
 		}
 	}
 	return api.TaskDone, nil
-
 }
 
 // waitIssuePipeline waits for pipeline to finish and approves tasks when necessary.


### PR DESCRIPTION
In the PITR integration test, we need to approve only one task instead of approving a stage or a pipeline.
Completing BYT-881.