### PR TITLE
chore: update demo banner link

### DIFF
--- a/frontend/src/views/BannerDemo.vue
+++ b/frontend/src/views/BannerDemo.vue
@@ -13,7 +13,7 @@
           class="order-3 mt-2 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto"
         >
           <a
-            href="https://www.bytebase.com/docs/install/install-with-docker?source=console"
+            href="https://www.bytebase.com/docs/get-started/deploy-to-production/deploy-with-docker?source=console"
             target="_blank"
             class="flex items-center justify-center pl-4 pr-2 py-2 border border-transparent rounded-md shadow-sm text-base font-medium text-accent bg-white hover:bg-indigo-50"
           >


### PR DESCRIPTION
The previous one returns 404.

<img width="1440" alt="CleanShot 2022-07-08 at 15 05 05@2x" src="https://user-images.githubusercontent.com/56376387/177936308-b2b797d8-9987-4404-b79b-a11974b26fb4.png">
