### PR TITLE
chore: update gh-ost seed data

### DIFF
--- a/store/demo/dev/10110__task.sql
+++ b/store/demo/dev/10110__task.sql
@@ -577,35 +577,6 @@ VALUES
         '{}'
     );
 
-INSERT INTO
-    task (
-        id,
-        creator_id,
-        updater_id,
-        pipeline_id,
-        stage_id,
-        instance_id,
-        database_id,
-        name,
-        type,
-        status,
-        payload
-    )
-VALUES
-    (
-        11019,
-        1,
-        1,
-        9010,
-        10017,
-        6001,
-        7002,
-        'Update testdb_dev gh-ost drop original table',
-        'bb.task.database.schema.update.ghost.drop-original-table',
-        'PENDING_APPROVAL',
-        '{"databaseName":"testdb_prod","tableName":"_tbl1_del"}'
-    );
-
 -- Tasks for PITR pipeline
 INSERT INTO
     task (
@@ -623,7 +594,7 @@ INSERT INTO
     )
 VALUES
     (
-        11020,
+        11019,
         1,
         1,
         9011,
@@ -652,7 +623,7 @@ INSERT INTO
     )
 VALUES
     (
-        11021,
+        11020,
         1,
         1,
         9011,
@@ -681,7 +652,7 @@ INSERT INTO
     )
 VALUES
     (
-        11022,
+        11021,
         1,
         1,
         9011,
@@ -694,4 +665,4 @@ VALUES
         '{}'
     );
 
-ALTER SEQUENCE task_id_seq RESTART WITH 11023;
+ALTER SEQUENCE task_id_seq RESTART WITH 11022;

--- a/store/demo/dev/10111__task_dag.sql
+++ b/store/demo/dev/10111__task_dag.sql
@@ -1,4 +1,4 @@
--- task_dag for task dependency
+-- task_dag for gh-ost
 INSERT INTO
     task_dag (
         id,
@@ -12,6 +12,7 @@ VALUES
         11018
     );
 
+-- task_dag for PITR tasks
 INSERT INTO
     task_dag (
         id,
@@ -21,11 +22,10 @@ INSERT INTO
 VALUES
     (
         11102,
-        11018,
-        11019
+        11019,
+        11020
     );
 
--- task_dag for PITR tasks
 INSERT INTO
     task_dag (
         id,
@@ -39,17 +39,4 @@ VALUES
         11021
     );
 
-INSERT INTO
-    task_dag (
-        id,
-        from_task_id,
-        to_task_id
-    )
-VALUES
-    (
-        11104,
-        11021,
-        11022
-    );
-
-ALTER SEQUENCE task_dag_id_seq RESTART WITH 11105;
+ALTER SEQUENCE task_dag_id_seq RESTART WITH 11104;

--- a/store/demo/dev/10130__issue.sql
+++ b/store/demo/dev/10130__issue.sql
@@ -295,10 +295,10 @@ VALUES
         1,
         3001,
         9010,
-        'Hello task dependency!',
+        'Hello gh-ost!',
         'OPEN',
         'bb.issue.database.schema.update.ghost',
-        'This issue is to demonstrate task dependency.',
+        'This issue is to demonstrate gh-ost integration.',
         101
     );
 


### PR DESCRIPTION
Removed the "drop original table" task.