### PR TITLE
fix: exit with previous test exit code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install dependencies
         run: go generate -tags ${{ matrix.release-tags }} ./...
       - name: Run all tests
-        run: go test -v ./... -tags=${{ matrix.release-tags }} | tee test.log
+        run: go test -v ./... -tags=${{ matrix.release-tags }} | tee test.log; exit ${PIPESTATUS[0]}
       - name: Pretty print tests running time
         # grep: filter out lines like "--- PASS: TestVCS (15.04s)"
         # sed: remove unnecessary characters


### PR DESCRIPTION
In https://github.com/bytebase/bytebase/runs/7274535017?check_suite_focus=true#step:7:8917, we failed the test but pass the github action. We should exit with the status of `go test` not `tee`.



ref https://stackoverflow.com/questions/1221833/pipe-output-and-capture-exit-status-in-bash