### PR TITLE
fix(github): return an error when member is missing public email

### DIFF
--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -209,11 +209,17 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 		page++
 	}
 
+	var emptyEmailUserIDList []string
 	var allMembers []*vcs.RepositoryMember
 	for _, c := range allCollaborators {
 		userInfo, err := p.FetchUserInfo(ctx, oauthCtx, "", c.Login)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetch user info, login: %s", c.Login)
+		}
+
+		if userInfo.PublicEmail == "" {
+			emptyEmailUserIDList = append(emptyEmailUserIDList, userInfo.Name)
+			continue
 		}
 
 		githubRole, bytebaseRole := getRoleAndMappedRole(c.RoleName)
@@ -228,6 +234,11 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 			},
 		)
 	}
+
+	if len(emptyEmailUserIDList) != 0 {
+		return nil, fmt.Errorf("[ %v ] did not configure their public email in GitHub, please make sure every members' public email is configured before syncing, see https://docs.github.com/en/account-and-profile", strings.Join(emptyEmailUserIDList, ", "))
+	}
+
 	return allMembers, nil
 }
 

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -209,7 +209,7 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 		page++
 	}
 
-	var emptyEmailUserIDList []string
+	var emptyEmailUserList []string
 	var allMembers []*vcs.RepositoryMember
 	for _, c := range allCollaborators {
 		userInfo, err := p.FetchUserInfo(ctx, oauthCtx, "", c.Login)
@@ -218,7 +218,7 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 		}
 
 		if userInfo.PublicEmail == "" {
-			emptyEmailUserIDList = append(emptyEmailUserIDList, userInfo.Name)
+			emptyEmailUserList = append(emptyEmailUserList, userInfo.Name)
 			continue
 		}
 
@@ -235,8 +235,8 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 		)
 	}
 
-	if len(emptyEmailUserIDList) != 0 {
-		return nil, fmt.Errorf("[ %v ] did not configure their public email in GitHub, please make sure every members' public email is configured before syncing, see https://docs.github.com/en/account-and-profile", strings.Join(emptyEmailUserIDList, ", "))
+	if len(emptyEmailUserList) != 0 {
+		return nil, fmt.Errorf("[ %v ] did not configure their public email in GitHub, please make sure every members' public email is configured before syncing, see https://docs.github.com/en/account-and-profile", strings.Join(emptyEmailUserList, ", "))
 	}
 
 	return allMembers, nil

--- a/plugin/vcs/github/github_test.go
+++ b/plugin/vcs/github/github_test.go
@@ -93,6 +93,117 @@ func TestProvider_FetchUserInfo(t *testing.T) {
 }
 
 func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
+	t.Run("missing public email", func(t *testing.T) {
+		p := newProvider(
+			vcs.ProviderConfig{
+				Client: &http.Client{
+					Transport: &common.MockRoundTripper{
+						MockRoundTrip: func(r *http.Request) (*http.Response, error) {
+							switch r.URL.Path {
+							case "/repos/octocat/Hello-World/collaborators":
+								return &http.Response{
+									StatusCode: http.StatusOK,
+									// Example response taken from https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators
+									Body: io.NopCloser(strings.NewReader(`
+[
+  {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false,
+    "permissions": {
+      "pull": true,
+      "triage": true,
+      "push": true,
+      "maintain": false,
+      "admin": false
+    },
+    "role_name": "write"
+  }
+]
+`)),
+								}, nil
+							case "/users/octocat":
+								return &http.Response{
+									StatusCode: http.StatusOK,
+									// Example response derived from https://docs.github.com/en/rest/reference/users#get-a-user
+									Body: io.NopCloser(strings.NewReader(`
+{
+  "login": "octocat",
+  "id": 1,
+  "node_id": "MDQ6VXNlcjE=",
+  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+  "gravatar_id": "",
+  "url": "https://api.github.com/users/octocat",
+  "html_url": "https://github.com/octocat",
+  "followers_url": "https://api.github.com/users/octocat/followers",
+  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+  "organizations_url": "https://api.github.com/users/octocat/orgs",
+  "repos_url": "https://api.github.com/users/octocat/repos",
+  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+  "received_events_url": "https://api.github.com/users/octocat/received_events",
+  "type": "User",
+  "site_admin": false,
+  "name": "monalisa octocat",
+  "company": "GitHub",
+  "blog": "https://github.com/blog",
+  "location": "San Francisco",
+  "email": "",
+  "hireable": false,
+  "bio": "There once was...",
+  "twitter_username": "monatheoctocat",
+  "public_repos": 2,
+  "public_gists": 1,
+  "followers": 20,
+  "following": 0,
+  "created_at": "2008-01-14T04:33:35Z",
+  "updated_at": "2008-01-14T04:33:35Z",
+  "private_gists": 81,
+  "total_private_repos": 100,
+  "owned_private_repos": 100,
+  "disk_usage": 10000,
+  "collaborators": 8,
+  "two_factor_authentication": true,
+  "plan": {
+    "name": "Medium",
+    "space": 400,
+    "private_repos": 20,
+    "collaborators": 0
+  }
+}
+`)),
+								}, nil
+							}
+							return nil, errors.Errorf("unexpected request path: %s", r.URL.Path)
+						},
+					},
+				},
+			},
+		)
+
+		ctx := context.Background()
+		_, got := p.FetchRepositoryActiveMemberList(ctx, common.OauthContext{}, "", "octocat/Hello-World")
+		want := "[ monalisa octocat ] did not configure their public email in GitHub, please make sure every members' public email is configured before syncing, see https://docs.github.com/en/account-and-profile"
+		assert.EqualError(t, got, want)
+	})
+
 	p := newProvider(
 		vcs.ProviderConfig{
 			Client: &http.Client{

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -466,7 +466,7 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 		page++
 	}
 
-	var emptyEmailUserIDList []string
+	var emptyEmailUserList []string
 	var activeMembers []*vcs.RepositoryMember
 	for _, m := range allMembers {
 		// We only want active member (both state and membership_state is active)
@@ -488,7 +488,7 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 		}
 
 		if m.Email == "" {
-			emptyEmailUserIDList = append(emptyEmailUserIDList, m.Name)
+			emptyEmailUserList = append(emptyEmailUserList, m.Name)
 			continue
 		}
 
@@ -506,8 +506,8 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 		)
 	}
 
-	if len(emptyEmailUserIDList) != 0 {
-		return nil, fmt.Errorf("[ %v ] did not configure their public email in GitLab, please make sure every members' public email is configured before syncing, see https://docs.gitlab.com/ee/user/profile", strings.Join(emptyEmailUserIDList, ", "))
+	if len(emptyEmailUserList) != 0 {
+		return nil, fmt.Errorf("[ %v ] did not configure their public email in GitLab, please make sure every members' public email is configured before syncing, see https://docs.gitlab.com/ee/user/profile", strings.Join(emptyEmailUserList, ", "))
 	}
 
 	return activeMembers, nil


### PR DESCRIPTION
It is possible that members of a GitHub repository has configured to not expose email publicly. This PR makes sure it returns an error to _behave consistently_ with the GitLab implementation (doesn't mean this is the optimal UX).

Also added unit tests for both providers.