### PR TITLE
fix(PITR): support case sensitive database name in replaying binlog process

### DIFF
--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -109,7 +109,7 @@ func (driver *Driver) replayBinlog(ctx context.Context, originalDatabase, pitrDa
 		// Table names are stored in lowercase on disk and name comparisons are not case-sensitive.
 		originalDBName = strings.ToLower(originalDatabase)
 	case "2":
-		// 	Table and database names are stored on disk using the lettercase specified in the CREATE TABLE or CREATE DATABASE statement, but MySQL converts them to lowercase on lookup.
+		// Table and database names are stored on disk using the lettercase specified in the CREATE TABLE or CREATE DATABASE statement, but MySQL converts them to lowercase on lookup.
 		// Name comparisons are not case-sensitive.
 		originalDBName = strings.ToLower(originalDatabase)
 	default:

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -10,7 +10,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -417,11 +416,6 @@ func TestPITR(t *testing.T) {
 	})
 
 	t.Run("Case Sensitive", func(t *testing.T) {
-		// TODO(zp): This test currently only passes correctly on the linux platform, and fails on non-case-sensitive platforms such as MacOS.
-		// This if block will be removed after the fix is complete.
-		if runtime.GOOS != "linux" {
-			return
-		}
 		t.Log(t.Name())
 		databaseName := "CASE_sensitive"
 


### PR DESCRIPTION
ref: https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html
![CleanShot 2022-07-11 at 10 57 05@2x](https://user-images.githubusercontent.com/87714218/178249348-d7d0e48e-1d32-4fa6-9165-4431c46fa7aa.png)

