### PR TITLE
fix: rollback only when needed

### DIFF
--- a/store/activity.go
+++ b/store/activity.go
@@ -118,18 +118,27 @@ func (s *Store) PatchActivity(ctx context.Context, patch *api.ActivityPatch) (*a
 
 // createActivityRaw creates a new activity.
 func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreate) (*activityRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx       *Tx
+		err      error
+		activity *activityRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	activity, err := createActivityImpl(ctx, tx.PTx, create)
+	activity, err = createActivityImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -138,13 +147,22 @@ func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreat
 
 // findActivityRaw retrieves a list of activities based on the find condition.
 func (s *Store) findActivityRaw(ctx context.Context, find *api.ActivityFind) ([]*activityRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*activityRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findActivityImpl(ctx, tx.PTx, find)
+	list, err = findActivityImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -156,13 +174,22 @@ func (s *Store) findActivityRaw(ctx context.Context, find *api.ActivityFind) ([]
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getActivityRawByID(ctx context.Context, id int) (*activityRaw, error) {
 	find := &api.ActivityFind{ID: &id}
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*activityRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findActivityImpl(ctx, tx.PTx, find)
+	list, err = findActivityImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -178,18 +205,27 @@ func (s *Store) getActivityRawByID(ctx context.Context, id int) (*activityRaw, e
 // patchActivityRaw updates an existing activity by ID.
 // Returns ENOTFOUND if activity does not exist.
 func (s *Store) patchActivityRaw(ctx context.Context, patch *api.ActivityPatch) (*activityRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx       *Tx
+		err      error
+		activity *activityRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	activity, err := patchActivityImpl(ctx, tx.PTx, patch)
+	activity, err = patchActivityImpl(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/backup.go
+++ b/store/backup.go
@@ -265,18 +265,27 @@ func (s *Store) composeBackupSetting(ctx context.Context, raw *backupSettingRaw)
 
 // createBackupRaw creates a new backup.
 func (s *Store) createBackupRaw(ctx context.Context, create *api.BackupCreate) (*backupRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx        *Tx
+		err       error
+		backupRaw *backupRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	backupRaw, err := s.createBackupImpl(ctx, tx.PTx, create)
+	backupRaw, err = s.createBackupImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -287,13 +296,22 @@ func (s *Store) createBackupRaw(ctx context.Context, create *api.BackupCreate) (
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getBackupRawByID(ctx context.Context, id int) (*backupRaw, error) {
 	find := &api.BackupFind{ID: &id}
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx            *Tx
+		err           error
+		backupRawList []*backupRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	backupRawList, err := s.findBackupImpl(ctx, tx.PTx, find)
+	backupRawList, err = s.findBackupImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -308,13 +326,22 @@ func (s *Store) getBackupRawByID(ctx context.Context, id int) (*backupRaw, error
 
 // findBackupRaw retrieves a list of backups based on find.
 func (s *Store) findBackupRaw(ctx context.Context, find *api.BackupFind) ([]*backupRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx            *Tx
+		err           error
+		backupRawList []*backupRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	backupRawList, err := s.findBackupImpl(ctx, tx.PTx, find)
+	backupRawList, err = s.findBackupImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -325,18 +352,27 @@ func (s *Store) findBackupRaw(ctx context.Context, find *api.BackupFind) ([]*bac
 // patchBackupRaw updates an existing backup by ID.
 // Returns ENOTFOUND if backup does not exist.
 func (s *Store) patchBackupRaw(ctx context.Context, patch *api.BackupPatch) (*backupRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx        *Tx
+		err       error
+		backupRaw *backupRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	backupRaw, err := s.patchBackupImpl(ctx, tx.PTx, patch)
+	backupRaw, err = s.patchBackupImpl(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -365,19 +401,26 @@ func (s *Store) upsertBackupSettingRaw(ctx context.Context, upsert *api.BackupSe
 			}
 		}
 	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx        *Tx
+		backupRaw *backupSettingRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	backupRaw, err := s.upsertBackupSettingImpl(ctx, tx.PTx, upsert)
+	backupRaw, err = s.upsertBackupSettingImpl(ctx, tx.PTx, upsert)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -566,13 +609,22 @@ func (s *Store) patchBackupImpl(ctx context.Context, tx *sql.Tx, patch *api.Back
 // getBackupSettingRaw finds the backup setting for a database.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getBackupSettingRaw(ctx context.Context, find *api.BackupSettingFind) (*backupSettingRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*backupSettingRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findBackupSettingImpl(ctx, tx.PTx, find)
+	list, err = s.findBackupSettingImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -696,13 +748,22 @@ func (s *Store) upsertBackupSettingImpl(ctx context.Context, tx *sql.Tx, upsert 
 
 // findBackupSettingsMatchImpl retrieves a list of backup settings based on match condition.
 func (s *Store) findBackupSettingsMatchImpl(ctx context.Context, match *api.BackupSettingsMatch) ([]*backupSettingRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		rows *sql.Rows
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	rows, err := tx.PTx.QueryContext(ctx, `
+	rows, err = tx.PTx.QueryContext(ctx, `
 		SELECT
 			id,
 			creator_id,
@@ -753,7 +814,7 @@ func (s *Store) findBackupSettingsMatchImpl(ctx context.Context, match *api.Back
 
 		backupSettingRawList = append(backupSettingRawList, &backupSettingRaw)
 	}
-	if err := rows.Err(); err != nil {
+	if err = rows.Err(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/column.go
+++ b/store/column.go
@@ -12,18 +12,27 @@ import (
 
 // CreateColumn creates a new column.
 func (s *Store) CreateColumn(ctx context.Context, create *api.ColumnCreate) (*api.Column, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx     *Tx
+		err    error
+		column *api.Column
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	column, err := s.createColumnImpl(ctx, tx.PTx, create)
+	column, err = s.createColumnImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -32,13 +41,22 @@ func (s *Store) CreateColumn(ctx context.Context, create *api.ColumnCreate) (*ap
 
 // FindColumn retrieves a list of columns based on find.
 func (s *Store) FindColumn(ctx context.Context, find *api.ColumnFind) ([]*api.Column, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*api.Column
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findColumnImpl(ctx, tx.PTx, find)
+	list, err = s.findColumnImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -49,13 +67,22 @@ func (s *Store) FindColumn(ctx context.Context, find *api.ColumnFind) ([]*api.Co
 // GetColumn retrieves a single column based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) GetColumn(ctx context.Context, find *api.ColumnFind) (*api.Column, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*api.Column
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findColumnImpl(ctx, tx.PTx, find)
+	list, err = s.findColumnImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -71,18 +98,27 @@ func (s *Store) GetColumn(ctx context.Context, find *api.ColumnFind) (*api.Colum
 // PatchColumn updates an existing column by ID.
 // Returns ENOTFOUND if column does not exist.
 func (s *Store) PatchColumn(ctx context.Context, patch *api.ColumnPatch) (*api.Column, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx     *Tx
+		err    error
+		column *api.Column
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	column, err := s.patchColumn(ctx, tx.PTx, patch)
+	column, err = s.patchColumn(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/data_source.go
+++ b/store/data_source.go
@@ -155,18 +155,27 @@ func (s *Store) composeDataSource(ctx context.Context, raw *dataSourceRaw) (*api
 
 // createDataSourceRaw creates a new dataSource.
 func (s *Store) createDataSourceRaw(ctx context.Context, create *api.DataSourceCreate) (*dataSourceRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx         *Tx
+		err        error
+		dataSource *dataSourceRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	dataSource, err := s.createDataSourceImpl(ctx, tx.PTx, create)
+	dataSource, err = s.createDataSourceImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -175,13 +184,22 @@ func (s *Store) createDataSourceRaw(ctx context.Context, create *api.DataSourceC
 
 // findDataSourceRaw retrieves a list of data sources based on find.
 func (s *Store) findDataSourceRaw(ctx context.Context, find *api.DataSourceFind) ([]*dataSourceRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*dataSourceRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findDataSourceImpl(ctx, tx.PTx, find)
+	list, err = s.findDataSourceImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -192,13 +210,22 @@ func (s *Store) findDataSourceRaw(ctx context.Context, find *api.DataSourceFind)
 // getDataSourceRaw retrieves a single dataSource based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getDataSourceRaw(ctx context.Context, find *api.DataSourceFind) (*dataSourceRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*dataSourceRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findDataSourceImpl(ctx, tx.PTx, find)
+	list, err = s.findDataSourceImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -214,18 +241,27 @@ func (s *Store) getDataSourceRaw(ctx context.Context, find *api.DataSourceFind) 
 // patchDataSourceRaw updates an existing dataSource by ID.
 // Returns ENOTFOUND if dataSource does not exist.
 func (s *Store) patchDataSourceRaw(ctx context.Context, patch *api.DataSourcePatch) (*dataSourceRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx         *Tx
+		err        error
+		dataSource *dataSourceRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	dataSource, err := s.patchDataSourceImpl(ctx, tx.PTx, patch)
+	dataSource, err = s.patchDataSourceImpl(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/extension.go
+++ b/store/extension.go
@@ -86,17 +86,25 @@ func (s *Store) FindDBExtension(ctx context.Context, find *api.DBExtensionFind) 
 
 // DeleteDBExtension deletes an existing dbExtension by ID.
 func (s *Store) DeleteDBExtension(ctx context.Context, delete *api.DBExtensionDelete) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx  *Tx
+		err error
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	if err := deleteDBExtensionImpl(ctx, tx.PTx, delete); err != nil {
+	if err = deleteDBExtensionImpl(ctx, tx.PTx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -133,18 +141,27 @@ func (s *Store) composeDBExtension(ctx context.Context, raw *dbExtensionRaw) (*a
 
 // createDBExtensionRaw creates a new DBExtension.
 func (s *Store) createDBExtensionRaw(ctx context.Context, create *api.DBExtensionCreate) (*dbExtensionRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx          *Tx
+		err         error
+		dbExtension *dbExtensionRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	dbExtension, err := s.createDBExtensionImpl(ctx, tx.PTx, create)
+	dbExtension, err = s.createDBExtensionImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -153,13 +170,22 @@ func (s *Store) createDBExtensionRaw(ctx context.Context, create *api.DBExtensio
 
 // findDBExtensionRaw retrieves a list of DBExtensions based on find.
 func (s *Store) findDBExtensionRaw(ctx context.Context, find *api.DBExtensionFind) ([]*dbExtensionRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*dbExtensionRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findDBExtensionImpl(ctx, tx.PTx, find)
+	list, err = s.findDBExtensionImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}

--- a/store/issue_subscriber.go
+++ b/store/issue_subscriber.go
@@ -58,17 +58,25 @@ func (s *Store) FindIssueSubscriber(ctx context.Context, find *api.IssueSubscrib
 
 // DeleteIssueSubscriber deletes an existing issueSubscriber by ID.
 func (s *Store) DeleteIssueSubscriber(ctx context.Context, delete *api.IssueSubscriberDelete) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx  *Tx
+		err error
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	if err := deleteIssueSubscriberImpl(ctx, tx.PTx, delete); err != nil {
+	if err = deleteIssueSubscriberImpl(ctx, tx.PTx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -93,18 +101,27 @@ func (s *Store) composeIssueSubscriber(ctx context.Context, raw *issueSubscriber
 
 // createIssueSubscriberRaw creates a new issueSubscriber.
 func (s *Store) createIssueSubscriberRaw(ctx context.Context, create *api.IssueSubscriberCreate) (*issueSubscriberRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx              *Tx
+		err             error
+		issueSubscriber *issueSubscriberRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	issueSubscriber, err := createIssueSubscriberImpl(ctx, tx.PTx, create)
+	issueSubscriber, err = createIssueSubscriberImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -113,13 +130,22 @@ func (s *Store) createIssueSubscriberRaw(ctx context.Context, create *api.IssueS
 
 // findIssueSubscriberRaw retrieves a list of issueSubscribers based on find.
 func (s *Store) findIssueSubscriberRaw(ctx context.Context, find *api.IssueSubscriberFind) ([]*issueSubscriberRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*issueSubscriberRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findIssueSubscriberImpl(ctx, tx.PTx, find)
+	list, err = findIssueSubscriberImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}

--- a/store/label.go
+++ b/store/label.go
@@ -154,7 +154,7 @@ func (s *Store) SetDatabaseLabelList(ctx context.Context, labelList []*api.Datab
 		ret = append(ret, label)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/principal.go
+++ b/store/principal.go
@@ -136,22 +136,31 @@ func (s *Store) GetPrincipalByID(ctx context.Context, id int) (*api.Principal, e
 
 // createPrincipalRaw creates an instance of principalRaw.
 func (s *Store) createPrincipalRaw(ctx context.Context, create *api.PrincipalCreate) (*principalRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx        *Tx
+		err       error
+		principal *principalRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	principal, err := createPrincipalImpl(ctx, tx.PTx, create)
+	principal, err = createPrincipalImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := s.cache.UpsertCache(api.PrincipalCache, principal.ID, principal); err != nil {
+	if err = s.cache.UpsertCache(api.PrincipalCache, principal.ID, principal); err != nil {
 		return nil, err
 	}
 
@@ -160,19 +169,28 @@ func (s *Store) createPrincipalRaw(ctx context.Context, create *api.PrincipalCre
 
 // findPrincipalRawList retrieves a list of principalRaw instances.
 func (s *Store) findPrincipalRawList(ctx context.Context) ([]*principalRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*principalRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findPrincipalRawListImpl(ctx, tx.PTx, &api.PrincipalFind{})
+	list, err = findPrincipalRawListImpl(ctx, tx.PTx, &api.PrincipalFind{})
 	if err != nil {
 		return nil, err
 	}
 
 	for _, principal := range list {
-		if err := s.cache.UpsertCache(api.PrincipalCache, principal.ID, principal); err != nil {
+		if err = s.cache.UpsertCache(api.PrincipalCache, principal.ID, principal); err != nil {
 			return nil, err
 		}
 	}
@@ -194,13 +212,22 @@ func (s *Store) getPrincipalRaw(ctx context.Context, find *api.PrincipalFind) (*
 		}
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*principalRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findPrincipalRawListImpl(ctx, tx.PTx, find)
+	list, err = findPrincipalRawListImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -220,22 +247,31 @@ func (s *Store) getPrincipalRaw(ctx context.Context, find *api.PrincipalFind) (*
 // patchPrincipalRaw updates an existing instance of principalRaw by ID.
 // Returns ENOTFOUND if principal does not exist.
 func (s *Store) patchPrincipalRaw(ctx context.Context, patch *api.PrincipalPatch) (*principalRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx        *Tx
+		err       error
+		principal *principalRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	principal, err := patchPrincipalImpl(ctx, tx.PTx, patch)
+	principal, err = patchPrincipalImpl(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := s.cache.UpsertCache(api.PrincipalCache, principal.ID, principal); err != nil {
+	if err = s.cache.UpsertCache(api.PrincipalCache, principal.ID, principal); err != nil {
 		return nil, err
 	}
 

--- a/store/project_member.go
+++ b/store/project_member.go
@@ -301,7 +301,7 @@ func (s *Store) patchProjectMemberRaw(ctx context.Context, patch *api.ProjectMem
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/project_webhook.go
+++ b/store/project_webhook.go
@@ -119,17 +119,25 @@ func (s *Store) PatchProjectWebhook(ctx context.Context, patch *api.ProjectWebho
 
 // DeleteProjectWebhook deletes an existing projectWebhook by ID.
 func (s *Store) DeleteProjectWebhook(ctx context.Context, delete *api.ProjectWebhookDelete) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx  *Tx
+		err error
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	if err := deleteProjectWebhookImpl(ctx, tx.PTx, delete); err != nil {
+	if err = deleteProjectWebhookImpl(ctx, tx.PTx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -160,18 +168,27 @@ func (s *Store) composeProjectWebhook(ctx context.Context, raw *projectWebhookRa
 
 // createProjectWebhookRaw creates a new projectWebhook.
 func (s *Store) createProjectWebhookRaw(ctx context.Context, create *api.ProjectWebhookCreate) (*projectWebhookRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx             *Tx
+		err            error
+		projectWebhook *projectWebhookRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	projectWebhook, err := createProjectWebhookImpl(ctx, tx.PTx, create)
+	projectWebhook, err = createProjectWebhookImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -180,13 +197,22 @@ func (s *Store) createProjectWebhookRaw(ctx context.Context, create *api.Project
 
 // findProjectWebhookRaw retrieves a list of projectWebhooks based on find.
 func (s *Store) findProjectWebhookRaw(ctx context.Context, find *api.ProjectWebhookFind) ([]*projectWebhookRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*projectWebhookRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findProjectWebhookImpl(ctx, tx.PTx, find)
+	list, err = findProjectWebhookImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -197,13 +223,22 @@ func (s *Store) findProjectWebhookRaw(ctx context.Context, find *api.ProjectWebh
 // getProjectWebhookRaw retrieves a single projectWebhook based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getProjectWebhookRaw(ctx context.Context, find *api.ProjectWebhookFind) (*projectWebhookRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*projectWebhookRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findProjectWebhookImpl(ctx, tx.PTx, find)
+	list, err = findProjectWebhookImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -219,18 +254,27 @@ func (s *Store) getProjectWebhookRaw(ctx context.Context, find *api.ProjectWebho
 // patchProjectWebhookRaw updates an existing projectWebhook by ID.
 // Returns ENOTFOUND if projectWebhook does not exist.
 func (s *Store) patchProjectWebhookRaw(ctx context.Context, patch *api.ProjectWebhookPatch) (*projectWebhookRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx             *Tx
+		err            error
+		projectWebhook *projectWebhookRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	projectWebhook, err := patchProjectWebhookImpl(ctx, tx.PTx, patch)
+	projectWebhook, err = patchProjectWebhookImpl(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/repository.go
+++ b/store/repository.go
@@ -138,17 +138,25 @@ func (s *Store) PatchRepository(ctx context.Context, patch *api.RepositoryPatch)
 
 // DeleteRepository deletes an existing repository by ID.
 func (s *Store) DeleteRepository(ctx context.Context, delete *api.RepositoryDelete) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx  *Tx
+		err error
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	if err := s.deleteRepository(ctx, tx.PTx, delete); err != nil {
+	if err = s.deleteRepository(ctx, tx.PTx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -195,18 +203,27 @@ func (s *Store) composeRepository(ctx context.Context, raw *repositoryRaw) (*api
 
 // createRepositoryRaw creates a new repository.
 func (s *Store) createRepositoryRaw(ctx context.Context, create *api.RepositoryCreate) (*repositoryRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx         *Tx
+		err        error
+		repository *repositoryRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	repository, err := s.createRepositoryImpl(ctx, tx.PTx, create)
+	repository, err = s.createRepositoryImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -215,13 +232,22 @@ func (s *Store) createRepositoryRaw(ctx context.Context, create *api.RepositoryC
 
 // findRepositoryRaw retrieves a list of repositories based on find.
 func (s *Store) findRepositoryRaw(ctx context.Context, find *api.RepositoryFind) ([]*repositoryRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*repositoryRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findRepositoryImpl(ctx, tx.PTx, find, s.db.mode)
+	list, err = findRepositoryImpl(ctx, tx.PTx, find, s.db.mode)
 	if err != nil {
 		return nil, err
 	}
@@ -232,13 +258,22 @@ func (s *Store) findRepositoryRaw(ctx context.Context, find *api.RepositoryFind)
 // getRepositoryRaw retrieves a single repository based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getRepositoryRaw(ctx context.Context, find *api.RepositoryFind) (*repositoryRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*repositoryRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findRepositoryImpl(ctx, tx.PTx, find, s.db.mode)
+	list, err = findRepositoryImpl(ctx, tx.PTx, find, s.db.mode)
 	if err != nil {
 		return nil, err
 	}
@@ -254,18 +289,27 @@ func (s *Store) getRepositoryRaw(ctx context.Context, find *api.RepositoryFind) 
 // patchRepositoryRaw updates an existing repository by ID.
 // Returns ENOTFOUND if repository does not exist.
 func (s *Store) patchRepositoryRaw(ctx context.Context, patch *api.RepositoryPatch) (*repositoryRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx         *Tx
+		err        error
+		repository *repositoryRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	repository, err := patchRepositoryImpl(ctx, tx.PTx, patch, s.db.mode)
+	repository, err = patchRepositoryImpl(ctx, tx.PTx, patch, s.db.mode)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/setting.go
+++ b/store/setting.go
@@ -230,7 +230,7 @@ func (s *Store) patchSettingRaw(ctx context.Context, patch *api.SettingPatch) (*
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/setting.go
+++ b/store/setting.go
@@ -123,18 +123,26 @@ func (s *Store) createSettingRawIfNotExist(ctx context.Context, create *api.Sett
 		return nil, err
 	}
 	if setting == nil {
-		tx, err := s.db.BeginTx(ctx, nil)
+		var (
+			tx  *Tx
+			err error
+		)
+		tx, err = s.db.BeginTx(ctx, nil)
 		if err != nil {
 			return nil, FormatError(err)
 		}
-		defer tx.PTx.Rollback()
+		defer func() {
+			if err != nil {
+				tx.PTx.Rollback()
+			}
+		}()
 
-		setting, err := createSettingImpl(ctx, tx.PTx, create)
+		setting, err = createSettingImpl(ctx, tx.PTx, create)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := tx.PTx.Commit(); err != nil {
+		if err = tx.PTx.Commit(); err != nil {
 			return nil, FormatError(err)
 		}
 
@@ -146,13 +154,22 @@ func (s *Store) createSettingRawIfNotExist(ctx context.Context, create *api.Sett
 
 // findSettingRaw retrieves a list of settings based on find.
 func (s *Store) findSettingRaw(ctx context.Context, find *api.SettingFind) ([]*settingRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*settingRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findSettingImpl(ctx, tx.PTx, find)
+	list, err = findSettingImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -162,13 +179,22 @@ func (s *Store) findSettingRaw(ctx context.Context, find *api.SettingFind) ([]*s
 // getSettingRaw retrieves a single setting based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getSettingRaw(ctx context.Context, find *api.SettingFind) (*settingRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*settingRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findSettingImpl(ctx, tx.PTx, find)
+	list, err = findSettingImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -184,13 +210,22 @@ func (s *Store) getSettingRaw(ctx context.Context, find *api.SettingFind) (*sett
 // patchSettingRaw updates an existing setting by name.
 // Returns ENOTFOUND if setting does not exist.
 func (s *Store) patchSettingRaw(ctx context.Context, patch *api.SettingPatch) (*settingRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx      *Tx
+		err     error
+		setting *settingRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	setting, err := patchSettingImpl(ctx, tx.PTx, patch)
+	setting, err = patchSettingImpl(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}

--- a/store/sheet_organizer.go
+++ b/store/sheet_organizer.go
@@ -34,18 +34,28 @@ func (raw *sheetOrganizerRaw) toSheetOrganizer() *api.SheetOrganizer {
 
 // UpsertSheetOrganizer upserts a new SheetOrganizer.
 func (s *Store) UpsertSheetOrganizer(ctx context.Context, upsert *api.SheetOrganizerUpsert) (*api.SheetOrganizer, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+
+	var (
+		tx                *Tx
+		err               error
+		sheetOrganizerRaw *sheetOrganizerRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	sheetOrganizerRaw, err := upsertSheetOrganizerImpl(ctx, tx.PTx, upsert)
+	sheetOrganizerRaw, err = upsertSheetOrganizerImpl(ctx, tx.PTx, upsert)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -56,13 +66,22 @@ func (s *Store) UpsertSheetOrganizer(ctx context.Context, upsert *api.SheetOrgan
 
 // FindSheetOrganizer retrieves a SheetOrganizer.
 func (s *Store) FindSheetOrganizer(ctx context.Context, find *api.SheetOrganizerFind) (*api.SheetOrganizer, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx                    *Tx
+		err                   error
+		sheetOrganizerRawlist []*sheetOrganizerRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	sheetOrganizerRawlist, err := findSheetOrganizerListImpl(ctx, tx.PTx, find)
+	sheetOrganizerRawlist, err = findSheetOrganizerListImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}

--- a/store/table_index.go
+++ b/store/table_index.go
@@ -12,18 +12,27 @@ import (
 
 // CreateIndex creates a new index.
 func (s *Store) CreateIndex(ctx context.Context, create *api.IndexCreate) (*api.Index, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx    *Tx
+		err   error
+		index *api.Index
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	index, err := s.createIndexImpl(ctx, tx.PTx, create)
+	index, err = s.createIndexImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -32,13 +41,22 @@ func (s *Store) CreateIndex(ctx context.Context, create *api.IndexCreate) (*api.
 
 // FindIndex retrieves a list of indices based on find.
 func (s *Store) FindIndex(ctx context.Context, find *api.IndexFind) ([]*api.Index, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*api.Index
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findIndexImpl(ctx, tx.PTx, find)
+	list, err = s.findIndexImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -49,13 +67,22 @@ func (s *Store) FindIndex(ctx context.Context, find *api.IndexFind) ([]*api.Inde
 // GetIndex retrieves a single index based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) GetIndex(ctx context.Context, find *api.IndexFind) (*api.Index, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*api.Index
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := s.findIndexImpl(ctx, tx.PTx, find)
+	list, err = s.findIndexImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}

--- a/store/task.go
+++ b/store/task.go
@@ -391,7 +391,7 @@ func (s *Store) patchTaskRaw(ctx context.Context, patch *api.TaskPatch) (*taskRa
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/task_dag.go
+++ b/store/task_dag.go
@@ -69,30 +69,48 @@ func (s *Store) GetTaskDAGByToTaskID(ctx context.Context, id int) (*api.TaskDAG,
 }
 
 func (s *Store) createTaskDAGRaw(ctx context.Context, create *api.TaskDAGCreate) (*taskDAGRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx      *Tx
+		err     error
+		taskDAG *taskDAGRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	taskDAG, err := createTaskDAGImpl(ctx, tx.PTx, create)
+	taskDAG, err = createTaskDAGImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 	return taskDAG, nil
 }
 
 func (s *Store) findTaskDAGRawList(ctx context.Context, find *api.TaskDAGFind) ([]*taskDAGRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*taskDAGRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findTaskDAGRawListImpl(ctx, tx.PTx, find)
+	list, err = findTaskDAGRawListImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}

--- a/store/vcs.go
+++ b/store/vcs.go
@@ -143,18 +143,27 @@ func (s *Store) composeVCS(ctx context.Context, raw *vcsRaw) (*api.VCS, error) {
 
 // createVCSRaw creates a new vcs.
 func (s *Store) createVCSRaw(ctx context.Context, create *api.VCSCreate) (*vcsRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx  *Tx
+		err error
+		vcs *vcsRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	vcs, err := createVCSImpl(ctx, tx.PTx, create)
+	vcs, err = createVCSImpl(ctx, tx.PTx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -163,13 +172,22 @@ func (s *Store) createVCSRaw(ctx context.Context, create *api.VCSCreate) (*vcsRa
 
 // findVCSRaw retrieves a list of VCSs based on find conditions.
 func (s *Store) findVCSRaw(ctx context.Context, find *api.VCSFind) ([]*vcsRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*vcsRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	list, err := findVCSImpl(ctx, tx.PTx, find)
+	list, err = findVCSImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -180,16 +198,25 @@ func (s *Store) findVCSRaw(ctx context.Context, find *api.VCSFind) ([]*vcsRaw, e
 // getVCSRaw retrieves a single vcs based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getVCSRaw(ctx context.Context, id int) (*vcsRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx   *Tx
+		err  error
+		list []*vcsRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
 	find := &api.VCSFind{
 		ID: &id,
 	}
-	list, err := findVCSImpl(ctx, tx.PTx, find)
+	list, err = findVCSImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -205,18 +232,27 @@ func (s *Store) getVCSRaw(ctx context.Context, id int) (*vcsRaw, error) {
 // patchVCSRaw updates an existing vcs by ID.
 // Returns ENOTFOUND if vcs does not exist.
 func (s *Store) patchVCSRaw(ctx context.Context, patch *api.VCSPatch) (*vcsRaw, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx  *Tx
+		err error
+		vcs *vcsRaw
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	vcs, err := patchVCSImpl(ctx, tx.PTx, patch)
+	vcs, err = patchVCSImpl(ctx, tx.PTx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -225,17 +261,25 @@ func (s *Store) patchVCSRaw(ctx context.Context, patch *api.VCSPatch) (*vcsRaw, 
 
 // deleteVCSRaw deletes an existing vcs by ID.
 func (s *Store) deleteVCSRaw(ctx context.Context, delete *api.VCSDelete) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	var (
+		tx  *Tx
+		err error
+	)
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer func() {
+		if err != nil {
+			tx.PTx.Rollback()
+		}
+	}()
 
-	if err := deleteVCSImpl(ctx, tx.PTx, delete); err != nil {
+	if err = deleteVCSImpl(ctx, tx.PTx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return FormatError(err)
 	}
 

--- a/store/view.go
+++ b/store/view.go
@@ -159,7 +159,7 @@ func (s *Store) createViewRaw(ctx context.Context, create *api.ViewCreate) (*vie
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err = tx.PTx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 

--- a/store/view.go
+++ b/store/view.go
@@ -169,8 +169,9 @@ func (s *Store) createViewRaw(ctx context.Context, create *api.ViewCreate) (*vie
 // findViewRaw retrieves a list of views based on find.
 func (s *Store) findViewRaw(ctx context.Context, find *api.ViewFind) ([]*viewRaw, error) {
 	var (
-		tx  *Tx
-		err error
+		tx   *Tx
+		err  error
+		list []*viewRaw
 	)
 	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -182,7 +183,7 @@ func (s *Store) findViewRaw(ctx context.Context, find *api.ViewFind) ([]*viewRaw
 		}
 	}()
 
-	list, err := s.findViewImpl(ctx, tx.PTx, find)
+	list, err = s.findViewImpl(ctx, tx.PTx, find)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The current implementation, which always calls `Rollback`

this PR use a closure to determine if there is an err and `Rollback` conditionally.