### PR TITLE
chore: do not release linux-arm64

### DIFF
--- a/.github/workflows/build-artifacts-and-draft-release.yml
+++ b/.github/workflows/build-artifacts-and-draft-release.yml
@@ -27,8 +27,6 @@ jobs:
           go-version: 1.16
           check-latest: true
           cache: true
-      - name: Install cross-compiler for linux/arm64
-        run: sudo apt-get -y install gcc-aarch64-linux-gnu
       - name: Build
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,6 @@ jobs:
           go-version: 1.16
           check-latest: true
           cache: true
-      - name: Install cross-compiler for linux/arm64
-        run: sudo apt-get -y install gcc-aarch64-linux-gnu
       - name: Release dry-run
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser-for-linux.yaml
+++ b/.goreleaser-for-linux.yaml
@@ -24,14 +24,10 @@ builds:
       - BUILD_USER="unknown"
     goos:
       - linux
+    # We currently cannot run mysqlbinlog on arm64.
     goarch:
       - amd64
-      - arm64
     overrides:
-      - goos: linux
-        goarch: arm64
-        env:
-          - CC=aarch64-linux-gnu-gcc
       - goos: linux
         goarch: amd64
         env:
@@ -57,14 +53,10 @@ builds:
       - BUILD_USER="unknown"
     goos:
       - linux
+    # We currently cannot run mysqlbinlog on arm64.
     goarch:
       - amd64
-      - arm64
     overrides:
-      - goos: linux
-        goarch: arm64
-        env:
-          - CC=aarch64-linux-gnu-gcc
       - goos: linux
         goarch: amd64
         env:


### PR DESCRIPTION
We do not have a mysqlbinlog binary for linux arm64 combination.