### PR TITLE
refactor: move server.Profile to common.Profile

### DIFF
--- a/bin/server/cmd/profile.go
+++ b/bin/server/cmd/profile.go
@@ -5,15 +5,14 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/server"
 )
 
 // GetTestProfile will return a profile for testing.
 // We require port as an argument of GetTestProfile so that test can run in parallel in different ports.
-func GetTestProfile(dataDir string, port int) server.Profile {
+func GetTestProfile(dataDir string, port int) common.Profile {
 	// Using flags.port + 1 as our datastore port
 	datastorePort := port + 1
-	return server.Profile{
+	return common.Profile{
 		Mode:                 common.ReleaseModeDev,
 		BackendHost:          flags.host,
 		BackendPort:          port,
@@ -28,8 +27,8 @@ func GetTestProfile(dataDir string, port int) server.Profile {
 // GetTestProfileWithExternalPg will return a profile for testing with external Postgres.
 // We require port as an argument of GetTestProfile so that test can run in parallel in different ports,
 // pgURL for connect to Postgres.
-func GetTestProfileWithExternalPg(dataDir string, port int, pgUser string, pgURL string) server.Profile {
-	return server.Profile{
+func GetTestProfileWithExternalPg(dataDir string, port int, pgUser string, pgURL string) common.Profile {
+	return common.Profile{
 		Mode:                 common.ReleaseModeDev,
 		BackendHost:          flags.host,
 		BackendPort:          port,

--- a/bin/server/cmd/profile_dev.go
+++ b/bin/server/cmd/profile_dev.go
@@ -8,10 +8,9 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/server"
 )
 
-func activeProfile(dataDir string) server.Profile {
+func activeProfile(dataDir string) common.Profile {
 	// `flags.demo` always be true in dev mode
 	demoName := string(common.ReleaseModeDev)
 	if flags.demoName != "" {
@@ -21,7 +20,7 @@ func activeProfile(dataDir string) server.Profile {
 	// Using flags.port + 1 as our datastore port
 	datastorePort := flags.port + 1
 
-	return server.Profile{
+	return common.Profile{
 		Mode:                 common.ReleaseModeDev,
 		BackendHost:          flags.host,
 		BackendPort:          flags.port,

--- a/common/config.go
+++ b/common/config.go
@@ -1,5 +1,7 @@
 package common
 
+import "time"
+
 // ReleaseMode is the mode for release, such as dev or release.
 type ReleaseMode string
 
@@ -9,3 +11,50 @@ const (
 	// ReleaseModeDev is the dev mode.
 	ReleaseModeDev ReleaseMode = "dev"
 )
+
+// Profile is the configuration to start main server.
+type Profile struct {
+	// Mode can be "prod" or "dev"
+	Mode ReleaseMode
+	// BackendHost is the listening backend host for server
+	BackendHost string
+	// BackendPort is the binding backend port for server.
+	BackendPort int
+	// FrontendHost is the listening frontend host for server.
+	FrontendHost string
+	// FrontendPort is the listening frontend host for server.
+	FrontendPort int
+	// DatastorePort is the binding port for database instance for storing Bytebase data.
+	DatastorePort int
+	// PgUser is the user we use to connect to bytebase's Postgres database.
+	// The name of the database storing metadata is the same as pgUser.
+	PgUser string
+	// When we are running in readonly mode:
+	// - The data file will be opened in readonly mode, no applicable migration or seeding will be applied.
+	// - Requests other than GET will be rejected
+	// - Any operations involving mutation will not start (e.g. Background schema syncer, task scheduler)
+	Readonly bool
+	// DataDir is the directory stores the data including Bytebase's own database, backups, etc.
+	DataDir string
+	// Debug decides the log level
+	Debug bool
+	// Demo decides that whether load demo data.
+	Demo bool
+	// DemoDataDir points to where to populate the initial data.
+	DemoDataDir string
+	// BackupRunnerInterval is the interval for backup runner.
+	BackupRunnerInterval time.Duration
+	// Version is the bytebase's version
+	Version string
+	// Git commit hash of the build
+	GitCommit string
+	// PgURL is the optional external PostgreSQL instance connection url
+	PgURL string
+	// MetricConnectionKey is the connection key for metric.
+	MetricConnectionKey string
+}
+
+// UseEmbedDB returns whether to use the embedded PostgreSQL.
+func (prof *Profile) UseEmbedDB() bool {
+	return len(prof.PgURL) == 0
+}

--- a/server/config.go
+++ b/server/config.go
@@ -1,11 +1,5 @@
 package server
 
-import (
-	"time"
-
-	"github.com/bytebase/bytebase/common"
-)
-
 const (
 	// secretLength is the length for the secret used to sign the JWT auto token
 	secretLength = 32
@@ -17,50 +11,4 @@ type config struct {
 	secret string
 	// workspaceID used to initial the identify for a new workspace.
 	workspaceID string
-}
-
-// Profile is the configuration to start main server.
-type Profile struct {
-	// Mode can be "prod" or "dev"
-	Mode common.ReleaseMode
-	// BackendHost is the listening backend host for server
-	BackendHost string
-	// BackendPort is the binding backend port for server.
-	BackendPort int
-	// FrontendHost is the listening frontend host for server.
-	FrontendHost string
-	// FrontendPort is the listening frontend host for server.
-	FrontendPort int
-	// DatastorePort is the binding port for database instance for storing Bytebase data.
-	DatastorePort int
-	// PgUser is the user we use to connect to bytebase's Postgres database.
-	// The name of the database storing metadata is the same as pgUser.
-	PgUser string
-	// When we are running in readonly mode:
-	// - The data file will be opened in readonly mode, no applicable migration or seeding will be applied.
-	// - Requests other than GET will be rejected
-	// - Any operations involving mutation will not start (e.g. Background schema syncer, task scheduler)
-	Readonly bool
-	// DataDir is the directory stores the data including Bytebase's own database, backups, etc.
-	DataDir string
-	// Debug decides the log level
-	Debug bool
-	// Demo decides that whether load demo data.
-	Demo bool
-	// DemoDataDir points to where to populate the initial data.
-	DemoDataDir string
-	// BackupRunnerInterval is the interval for backup runner.
-	BackupRunnerInterval time.Duration
-	// Version is the bytebase's version
-	Version string
-	// Git commit hash of the build
-	GitCommit string
-	// PgURL is the optional external PostgreSQL instance connection url
-	PgURL string
-	// MetricConnectionKey is the connection key for metric.
-	MetricConnectionKey string
-}
-
-func (prof *Profile) useEmbedDB() bool {
-	return len(prof.PgURL) == 0
 }

--- a/store/store.go
+++ b/store/store.go
@@ -2,19 +2,22 @@ package store
 
 import (
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 )
 
 // Store provides database access to all raw objects
 type Store struct {
-	db    *DB
-	cache api.CacheService
+	db      *DB
+	cache   api.CacheService
+	profile common.Profile
 }
 
 // New creates a new instance of Store
-func New(db *DB, cache api.CacheService) *Store {
+func New(db *DB, cache api.CacheService, profile common.Profile) *Store {
 	return &Store{
-		db:    db,
-		cache: cache,
+		db:      db,
+		cache:   cache,
+		profile: profile,
 	}
 }
 


### PR DESCRIPTION
Now we can embed the profile into both `Server` and `Store`, and make it easier to add a release guard for dev without passing `mode` all the way down.