### PR TITLE
feat(frontend): do not show run button for PENDING tasks

### DIFF
--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -215,7 +215,7 @@ const APPLICABLE_TASK_TRANSITION_LIST: Map<
   TaskStatus,
   TaskStatusTransitionType[]
 > = new Map([
-  ["PENDING", ["RUN"]],
+  ["PENDING", []],
   ["PENDING_APPROVAL", ["APPROVE"]],
   ["RUNNING", []],
   ["DONE", []],


### PR DESCRIPTION
Per discussion, we will remove the "Run" button on the issue detail page.

A task is defined as "runnable" if

1. Its status is "PENDING".
2. All its task checks are success or warning, with no error.

If a task is or turns "runnable" it will definitely be scheduled to run automatically. So it's not necessary to click the run button and run it manually.

We are also planning to introduce a new UI state sth. like "Scheduling" or "Queueing" for "PENDING" tasks.