### PR TITLE
fix: disallow change PENDING task statement

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -82,6 +82,9 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 			}
 
+			// Allow frontend to change the SQL statement of
+			// a PendingApproval task, which hasn't started yet
+			// a Failed task, which can be retried
 			if task.Status != api.TaskPendingApproval && task.Status != api.TaskFailed {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Can not update task in %v state", task.Status))
 			}

--- a/server/task.go
+++ b/server/task.go
@@ -82,7 +82,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 			}
 
-			if task.Status != api.TaskPending && task.Status != api.TaskPendingApproval && task.Status != api.TaskFailed {
+			if task.Status != api.TaskPendingApproval && task.Status != api.TaskFailed {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Can not update task in %v state", task.Status))
 			}
 			newStatement = *taskPatch.Statement


### PR DESCRIPTION
PENDING task could be scheduled by task_scheduler at any time and turns RUNNING. We should disallow change the statement of a PENDING task.