### PR TITLE
feat(github): implement `ReadFileMeta` and `ReadFileContent`

### DIFF
--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -651,6 +651,8 @@ func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, r
 			)
 	}
 
+	// This API endpoint returns a JSON array if the path is a directory, and we do
+	// not want that.
 	if body != "" && body[0] == '[' {
 		return nil, errors.Errorf("%q is a directory not a file", filePath)
 	}

--- a/plugin/vcs/github/github_test.go
+++ b/plugin/vcs/github/github_test.go
@@ -873,6 +873,109 @@ func TestProvider_OverwriteFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestProvider_ReadFileMeta(t *testing.T) {
+	p := newProvider(
+		vcs.ProviderConfig{
+			Client: &http.Client{
+				Transport: &common.MockRoundTripper{
+					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
+						assert.Equal(t, "/repos/octocat/Hello-World/contents/README.md", r.URL.Path)
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							// Example response derived from https://docs.github.com/en/rest/repos/contents#get-repository-content
+							Body: io.NopCloser(strings.NewReader(`
+{
+  "type": "file",
+  "encoding": "base64",
+  "size": 442,
+  "name": "README.md",
+  "path": "README.md",
+  "content": "IyBTYW1wbGUgR2l0TGFiIFByb2plY3QKClRoaXMgc2FtcGxlIHByb2plY3Qgc2hvd3MgaG93IGEgcHJvamVjdCBpbiBHaXRMYWIgbG9va3MgZm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMuIEl0IGNvbnRhaW5zIGlzc3VlcywgbWVyZ2UgcmVxdWVzdHMgYW5kIE1hcmtkb3duIGZpbGVzIGluIG1hbnkgYnJhbmNoZXMsCm5hbWVkIGFuZCBmaWxsZWQgd2l0aCBsb3JlbSBpcHN1bS4KCllvdSBjYW4gbG9vayBhcm91bmQgdG8gZ2V0IGFuIGlkZWEgaG93IHRvIHN0cnVjdHVyZSB5b3VyIHByb2plY3QgYW5kLCB3aGVuIGRvbmUsIHlvdSBjYW4gc2FmZWx5IGRlbGV0ZSB0aGlzIHByb2plY3QuCgpbTGVhcm4gbW9yZSBhYm91dCBjcmVhdGluZyBHaXRMYWIgcHJvamVjdHMuXShodHRwczovL2RvY3MuZ2l0bGFiLmNvbS9lZS9naXRsYWItYmFzaWNzL2NyZWF0ZS1wcm9qZWN0Lmh0bWwpCg==",
+  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+  "url": "https://api.github.com/repos/octocat/Hello-World/contents/README.md",
+  "git_url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+  "html_url": "https://github.com/octocat/Hello-World/blob/master/README.md",
+  "download_url": "https://raw.githubusercontent.com/octocat/Hello-World/master/README.md",
+  "_links": {
+    "git": "https://api.github.com/repos/octocat/Hello-World/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "self": "https://api.github.com/repos/octocat/Hello-World/contents/README.md",
+    "html": "https://github.com/octocat/Hello-World/blob/master/README.md"
+  }
+}
+`)),
+						}, nil
+					},
+				},
+			},
+		},
+	)
+
+	ctx := context.Background()
+	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, "", "octocat/Hello-World", "README.md", "master")
+	require.NoError(t, err)
+
+	want := &vcs.FileMeta{
+		Name:         "README.md",
+		Path:         "README.md",
+		Size:         442,
+		LastCommitID: "3d21ec53a331a6f037a91c368710b99387d012c1",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestProvider_ReadFileContent(t *testing.T) {
+	p := newProvider(
+		vcs.ProviderConfig{
+			Client: &http.Client{
+				Transport: &common.MockRoundTripper{
+					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
+						assert.Equal(t, "/repos/octocat/Hello-World/contents/README.md", r.URL.Path)
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							// Example response derived from https://docs.github.com/en/rest/repos/contents#get-repository-content
+							Body: io.NopCloser(strings.NewReader(`
+{
+  "type": "file",
+  "encoding": "base64",
+  "size": 442,
+  "name": "README.md",
+  "path": "README.md",
+  "content": "IyBTYW1wbGUgR2l0TGFiIFByb2plY3QKClRoaXMgc2FtcGxlIHByb2plY3Qgc2hvd3MgaG93IGEgcHJvamVjdCBpbiBHaXRMYWIgbG9va3MgZm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMuIEl0IGNvbnRhaW5zIGlzc3VlcywgbWVyZ2UgcmVxdWVzdHMgYW5kIE1hcmtkb3duIGZpbGVzIGluIG1hbnkgYnJhbmNoZXMsCm5hbWVkIGFuZCBmaWxsZWQgd2l0aCBsb3JlbSBpcHN1bS4KCllvdSBjYW4gbG9vayBhcm91bmQgdG8gZ2V0IGFuIGlkZWEgaG93IHRvIHN0cnVjdHVyZSB5b3VyIHByb2plY3QgYW5kLCB3aGVuIGRvbmUsIHlvdSBjYW4gc2FmZWx5IGRlbGV0ZSB0aGlzIHByb2plY3QuCgpbTGVhcm4gbW9yZSBhYm91dCBjcmVhdGluZyBHaXRMYWIgcHJvamVjdHMuXShodHRwczovL2RvY3MuZ2l0bGFiLmNvbS9lZS9naXRsYWItYmFzaWNzL2NyZWF0ZS1wcm9qZWN0Lmh0bWwpCg==",
+  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+  "url": "https://api.github.com/repos/octocat/Hello-World/contents/README.md",
+  "git_url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+  "html_url": "https://github.com/octocat/Hello-World/blob/master/README.md",
+  "download_url": "https://raw.githubusercontent.com/octocat/Hello-World/master/README.md",
+  "_links": {
+    "git": "https://api.github.com/repos/octocat/Hello-World/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "self": "https://api.github.com/repos/octocat/Hello-World/contents/README.md",
+    "html": "https://github.com/octocat/Hello-World/blob/master/README.md"
+  }
+}
+`)),
+						}, nil
+					},
+				},
+			},
+		},
+	)
+
+	ctx := context.Background()
+	got, err := p.ReadFileContent(ctx, common.OauthContext{}, "", "octocat/Hello-World", "README.md", "master")
+	require.NoError(t, err)
+
+	want := `# Sample GitLab Project
+
+This sample project shows how a project in GitLab looks for demonstration purposes. It contains issues, merge requests and Markdown files in many branches,
+named and filled with lorem ipsum.
+
+You can look around to get an idea how to structure your project and, when done, you can safely delete this project.
+
+[Learn more about creating GitLab projects.](https://docs.gitlab.com/ee/gitlab-basics/create-project.html)
+`
+	assert.Equal(t, want, got)
+}
+
 func TestOAuth_RefreshToken(t *testing.T) {
 	ctx := context.Background()
 	client := &http.Client{

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -124,7 +124,7 @@ type RepositoryTreeNode struct {
 	Type string `json:"type"`
 }
 
-// File is the API message for file metadata.
+// File represents a GitLab API response for a repository file.
 type File struct {
 	FileName     string `json:"file_name"`
 	FilePath     string `json:"file_path"`
@@ -748,11 +748,13 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 	return nil
 }
 
-// ReadFileMeta reads the file metadata.
-func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, filePath string, ref string) (*vcs.FileMeta, error) {
+// ReadFileMeta reads the metadata of the given file in the repository.
+//
+// Docs: https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*vcs.FileMeta, error) {
 	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file metadata %s from GitLab instance %s: %w", filePath, instanceURL, err)
+		return nil, errors.Wrap(err, "read file")
 	}
 
 	return &vcs.FileMeta{
@@ -763,13 +765,14 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 	}, nil
 }
 
-// ReadFileContent reads the file content.
-func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, filePath string, ref string) (string, error) {
+// ReadFileContent reads the content of the given file in the repository.
+//
+// Docs: https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
+func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (string, error) {
 	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, ref)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file content %s from GitLab instance %s: %w", filePath, instanceURL, err)
+		return "", errors.Wrap(err, "read file")
 	}
-
 	return file.Content, nil
 }
 
@@ -875,7 +878,10 @@ func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthConte
 	return nil
 }
 
-// readFile reads the file data including metadata and content.
+// readFile reads the given file in the repository.
+//
+// TODO: The same GitLab API endpoint supports using the HEAD request to only
+// get the file metadata.
 func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, filePath string, ref string) (*File, error) {
 	url := fmt.Sprintf("%s/projects/%s/repository/files/%s?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), url.QueryEscape(ref))
 	code, body, err := oauth.Get(
@@ -894,39 +900,33 @@ func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, i
 		),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET")
+		return nil, errors.Wrapf(err, "GET %s", url)
 	}
+
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to read file data from GitLab instance %s", instanceURL))
+		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to read file from URL %s", url))
 	} else if code >= 300 {
-		return nil, fmt.Errorf("failed to read file data from GitLab instance %s, status code: %d",
-			instanceURL,
-			code,
-		)
+		return nil,
+			fmt.Errorf("failed to read file %s on GitLab instance %s, status code: %d",
+				filePath,
+				instanceURL,
+				code,
+			)
 	}
 
-	file := &File{}
-	if err := json.Unmarshal([]byte(body), file); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal file from GitLab instance %s: %w", instanceURL, err)
+	var file File
+	if err = json.Unmarshal([]byte(body), &file); err != nil {
+		return nil, errors.Wrap(err, "unmarshal body")
 	}
 
-	content := file.Content
 	if file.Encoding == "base64" {
 		decodedContent, err := base64.StdEncoding.DecodeString(file.Content)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode file content, err %w", err)
+			return nil, errors.Wrap(err, "decode file content")
 		}
-		content = string(decodedContent)
+		file.Content = string(decodedContent)
 	}
-
-	return &File{
-		FileName:     file.FileName,
-		FilePath:     file.FilePath,
-		Size:         file.Size,
-		Encoding:     file.Encoding,
-		Content:      content,
-		LastCommitID: file.LastCommitID,
-	}, nil
+	return &file, nil
 }
 
 // oauthContext is the request context for refreshing oauth token.

--- a/plugin/vcs/gitlab/gitlab_test.go
+++ b/plugin/vcs/gitlab/gitlab_test.go
@@ -572,6 +572,99 @@ func TestProvider_OverwriteFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestProvider_ReadFileMeta(t *testing.T) {
+	p := newProvider(
+		vcs.ProviderConfig{
+			Client: &http.Client{
+				Transport: &common.MockRoundTripper{
+					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
+						assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
+							Body: io.NopCloser(strings.NewReader(`
+{
+  "file_name": "key.rb",
+  "file_path": "app/models/key.rb",
+  "size": 442,
+  "encoding": "base64",
+  "content": "IyBTYW1wbGUgR2l0TGFiIFByb2plY3QKClRoaXMgc2FtcGxlIHByb2plY3Qgc2hvd3MgaG93IGEgcHJvamVjdCBpbiBHaXRMYWIgbG9va3MgZm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMuIEl0IGNvbnRhaW5zIGlzc3VlcywgbWVyZ2UgcmVxdWVzdHMgYW5kIE1hcmtkb3duIGZpbGVzIGluIG1hbnkgYnJhbmNoZXMsCm5hbWVkIGFuZCBmaWxsZWQgd2l0aCBsb3JlbSBpcHN1bS4KCllvdSBjYW4gbG9vayBhcm91bmQgdG8gZ2V0IGFuIGlkZWEgaG93IHRvIHN0cnVjdHVyZSB5b3VyIHByb2plY3QgYW5kLCB3aGVuIGRvbmUsIHlvdSBjYW4gc2FmZWx5IGRlbGV0ZSB0aGlzIHByb2plY3QuCgpbTGVhcm4gbW9yZSBhYm91dCBjcmVhdGluZyBHaXRMYWIgcHJvamVjdHMuXShodHRwczovL2RvY3MuZ2l0bGFiLmNvbS9lZS9naXRsYWItYmFzaWNzL2NyZWF0ZS1wcm9qZWN0Lmh0bWwpCg==",
+  "content_sha256": "71dd06da8f5915544335e547e4447de6377ef369d67b6a5214c8a780d336b2e2",
+  "ref": "master",
+  "blob_id": "79f7bbd25901e8334750839545a9bd021f0e4c83",
+  "commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
+  "last_commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
+  "execute_filemode": false
+}
+`)),
+						}, nil
+					},
+				},
+			},
+		},
+	)
+
+	ctx := context.Background()
+	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, "", "1", "lib/class.rb", "master")
+	require.NoError(t, err)
+
+	want := &vcs.FileMeta{
+		Name:         "key.rb",
+		Path:         "app/models/key.rb",
+		Size:         442,
+		LastCommitID: "27329d3afac51fbf2762428e12f2635d1137c549",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestProvider_ReadFileContent(t *testing.T) {
+	p := newProvider(
+		vcs.ProviderConfig{
+			Client: &http.Client{
+				Transport: &common.MockRoundTripper{
+					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
+						assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
+							Body: io.NopCloser(strings.NewReader(`
+{
+  "file_name": "key.rb",
+  "file_path": "app/models/key.rb",
+  "size": 442,
+  "encoding": "base64",
+  "content": "IyBTYW1wbGUgR2l0TGFiIFByb2plY3QKClRoaXMgc2FtcGxlIHByb2plY3Qgc2hvd3MgaG93IGEgcHJvamVjdCBpbiBHaXRMYWIgbG9va3MgZm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMuIEl0IGNvbnRhaW5zIGlzc3VlcywgbWVyZ2UgcmVxdWVzdHMgYW5kIE1hcmtkb3duIGZpbGVzIGluIG1hbnkgYnJhbmNoZXMsCm5hbWVkIGFuZCBmaWxsZWQgd2l0aCBsb3JlbSBpcHN1bS4KCllvdSBjYW4gbG9vayBhcm91bmQgdG8gZ2V0IGFuIGlkZWEgaG93IHRvIHN0cnVjdHVyZSB5b3VyIHByb2plY3QgYW5kLCB3aGVuIGRvbmUsIHlvdSBjYW4gc2FmZWx5IGRlbGV0ZSB0aGlzIHByb2plY3QuCgpbTGVhcm4gbW9yZSBhYm91dCBjcmVhdGluZyBHaXRMYWIgcHJvamVjdHMuXShodHRwczovL2RvY3MuZ2l0bGFiLmNvbS9lZS9naXRsYWItYmFzaWNzL2NyZWF0ZS1wcm9qZWN0Lmh0bWwpCg==",
+  "content_sha256": "71dd06da8f5915544335e547e4447de6377ef369d67b6a5214c8a780d336b2e2",
+  "ref": "master",
+  "blob_id": "79f7bbd25901e8334750839545a9bd021f0e4c83",
+  "commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
+  "last_commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
+  "execute_filemode": false
+}
+`)),
+						}, nil
+					},
+				},
+			},
+		},
+	)
+
+	ctx := context.Background()
+	got, err := p.ReadFileContent(ctx, common.OauthContext{}, "", "1", "lib/class.rb", "master")
+	require.NoError(t, err)
+
+	want := `# Sample GitLab Project
+
+This sample project shows how a project in GitLab looks for demonstration purposes. It contains issues, merge requests and Markdown files in many branches,
+named and filled with lorem ipsum.
+
+You can look around to get an idea how to structure your project and, when done, you can safely delete this project.
+
+[Learn more about creating GitLab projects.](https://docs.gitlab.com/ee/gitlab-basics/create-project.html)
+`
+	assert.Equal(t, want, got)
+}
+
 func TestOAuth_RefreshToken(t *testing.T) {
 	ctx := context.Background()
 	client := &http.Client{


### PR DESCRIPTION
This PR implements the `ReadFileMeta` and `ReadFileContent` methods of the `vcs.Provider` interface for the GitHub.com.

Piggybacks:
1. Added unit tests for `ReadFileMeta` and `ReadFileContent` methods of the GitLab provider.

---

Part of https://linear.app/bbteam/issue/BYT-855/implement-missing-methods-of-vcsprovider-interface, stacked on https://github.com/bytebase/bytebase/pull/1885