### PR TITLE
feat(github): update call sites of `vcs.Provider` methods to reach parity with GitLab

### DIFF
--- a/api/project_member.go
+++ b/api/project_member.go
@@ -10,10 +10,13 @@ import (
 type ProjectRoleProvider string
 
 const (
-	// ProjectRoleProviderBytebase is the role provider of a project.
+	// ProjectRoleProviderBytebase indicates the role provider is the Bytebase.
 	ProjectRoleProviderBytebase ProjectRoleProvider = "BYTEBASE"
-	// ProjectRoleProviderGitLabSelfHost is the role provider of a project.
+	// ProjectRoleProviderGitLabSelfHost indicates the role provider is the GitLab
+	// self-hosted.
 	ProjectRoleProviderGitLabSelfHost ProjectRoleProvider = "GITLAB_SELF_HOST"
+	// ProjectRoleProviderGitHubCom indicates the role provider is the GitHub.com.
+	ProjectRoleProviderGitHubCom ProjectRoleProvider = "GITHUB_COM"
 )
 
 // ProjectRoleProviderPayload is the payload for role provider

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -112,6 +112,34 @@ type WebhookInfo struct {
 	ID int `json:"id"`
 }
 
+// WebhookConfig represents the GitHub API message for webhook configuration.
+type WebhookConfig struct {
+	// URL is the URL to which the payloads will be delivered.
+	URL string `json:"url"`
+	// ContentType is the media type used to serialize the payloads. Supported
+	// values include "json" and "form". The default is "form".
+	ContentType string `json:"content_type"`
+	// Secret is the secret will be used as the key to generate the HMAC hex digest
+	// value for delivery signature headers.
+	Secret string `json:"secret"`
+	// InsecureSSL determines whether the SSL certificate of the host for url will
+	// be verified when delivering payloads. Supported values include 0
+	// (verification is performed) and 1 (verification is not performed). The
+	// default is 0.
+	InsecureSSL int `json:"insecure_ssl"`
+}
+
+// WebhookCreateOrUpdate represents a GitHub API request for creating or
+// updating a webhook.
+type WebhookCreateOrUpdate struct {
+	// Config contains settings for the webhook.
+	Config WebhookConfig `json:"config"`
+	// Events determines what events the hook is triggered for. The default is
+	// ["push"]. The full list of events can be viewed at
+	// https://docs.github.com/webhooks/event-payloads.
+	Events []string `json:"events"`
+}
+
 // fetchUserInfo fetches user information from the given resourceURI, which
 // should be either "user" or "users/{username}".
 func (p *Provider) fetchUserInfo(ctx context.Context, oauthCtx common.OauthContext, resourceURI string) (*vcs.UserInfo, error) {

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -45,8 +45,8 @@ type WebhookInfo struct {
 	ID int `json:"id"`
 }
 
-// WebhookPost is the API message for webhook POST.
-type WebhookPost struct {
+// WebhookCreate represents a GitLab API request for creating a new webhook.
+type WebhookCreate struct {
 	URL         string `json:"url"`
 	SecretToken string `json:"token"`
 	// This is set to true
@@ -58,12 +58,11 @@ type WebhookPost struct {
 	// Saying that, delivering a souding dry run solution would be great and hopefully we can achieve that one day.
 	// MergeRequestsEvents  bool   `json:"merge_requests_events"`
 	PushEventsBranchFilter string `json:"push_events_branch_filter"`
-	// TODO(tianzhou): This is set to false, be lax to not enable_ssl_verification
-	EnableSSLVerification bool `json:"enable_ssl_verification"`
+	EnableSSLVerification  bool   `json:"enable_ssl_verification"`
 }
 
-// WebhookPut is the API message for webhook PUT.
-type WebhookPut struct {
+// WebhookUpdate represents a GitLab API request for updating a new webhook.
+type WebhookUpdate struct {
 	URL                    string `json:"url"`
 	PushEventsBranchFilter string `json:"push_events_branch_filter"`
 }

--- a/server/project_member.go
+++ b/server/project_member.go
@@ -108,16 +108,24 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 				CreatorID:    c.Get(getPrincipalIDContextKey()).(int),
 				PrincipalID:  principal.ID,
 				Role:         projectMember.Role,
-				RoleProvider: api.ProjectRoleProvider(projectMember.RoleProvider),
+				RoleProvider: projectMember.RoleProvider,
 				Payload:      string(providerPayloadBytes),
 			}
 			createList = append(createList, createProjectMember)
 		}
 
+		var roleProvider api.ProjectRoleProvider
+		switch vcs.Type {
+		case vcsPlugin.GitLabSelfHost:
+			roleProvider = api.ProjectRoleProviderGitLabSelfHost
+		case vcsPlugin.GitHubCom:
+			roleProvider = api.ProjectRoleProviderGitHubCom
+		}
+
 		batchUpdateProjectMember := &api.ProjectMemberBatchUpdate{
 			ID:           projectID,
 			UpdaterID:    c.Get(getPrincipalIDContextKey()).(int),
-			RoleProvider: api.ProjectRoleProviderGitLabSelfHost, /* we only support gitlab for now */
+			RoleProvider: roleProvider,
 			List:         createList,
 		}
 		createdMemberList, deletedMemberList, err := s.store.BatchUpdateProjectMember(ctx, batchUpdateProjectMember)

--- a/server/project_member.go
+++ b/server/project_member.go
@@ -108,7 +108,7 @@ func (s *Server) registerProjectMemberRoutes(g *echo.Group) {
 				CreatorID:    c.Get(getPrincipalIDContextKey()).(int),
 				PrincipalID:  principal.ID,
 				Role:         projectMember.Role,
-				RoleProvider: projectMember.RoleProvider,
+				RoleProvider: api.ProjectRoleProvider(projectMember.RoleProvider),
 				Payload:      string(providerPayloadBytes),
 			}
 			createList = append(createList, createProjectMember)

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -8,12 +8,13 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
-	"go.uber.org/zap"
 )
 
 // TaskExecutor is the task executor.
@@ -336,7 +337,7 @@ func findRepositoryByTask(ctx context.Context, server *Server, task *api.Task) (
 // Writes back the latest schema to the repository after migration
 // Returns the commit id on success.
 func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.Repository, pushEvent *vcsPlugin.PushEvent, mi *db.MigrationInfo, branch string, latestSchemaFile string, schema string, bytebaseURL string) (string, error) {
-	schemaFileMeta, err := vcsPlugin.Get(vcsPlugin.GitLabSelfHost, vcsPlugin.ProviderConfig{}).ReadFileMeta(
+	schemaFileMeta, err := vcsPlugin.Get(repository.VCS.Type, vcsPlugin.ProviderConfig{}).ReadFileMeta(
 		ctx,
 		common.OauthContext{
 			ClientID:     repository.VCS.ApplicationID,
@@ -383,7 +384,7 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 			zap.String("schema_file", latestSchemaFile),
 		)
 
-		err := vcsPlugin.Get(vcsPlugin.GitLabSelfHost, vcsPlugin.ProviderConfig{}).CreateFile(
+		err := vcsPlugin.Get(repository.VCS.Type, vcsPlugin.ProviderConfig{}).CreateFile(
 			ctx,
 			common.OauthContext{
 				ClientID:     repository.VCS.ApplicationID,
@@ -407,7 +408,7 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 		)
 
 		schemaFileCommit.LastCommitID = schemaFileMeta.LastCommitID
-		err := vcsPlugin.Get(vcsPlugin.GitLabSelfHost, vcsPlugin.ProviderConfig{}).OverwriteFile(
+		err := vcsPlugin.Get(repository.VCS.Type, vcsPlugin.ProviderConfig{}).OverwriteFile(
 			ctx,
 			common.OauthContext{
 				ClientID:     repository.VCS.ApplicationID,
@@ -427,7 +428,7 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 	}
 
 	// VCS such as GitLab API doesn't return the commit on write, so we have to call ReadFileMeta again
-	schemaFileMeta, err = vcsPlugin.Get(vcsPlugin.GitLabSelfHost, vcsPlugin.ProviderConfig{}).ReadFileMeta(
+	schemaFileMeta, err = vcsPlugin.Get(repository.VCS.Type, vcsPlugin.ProviderConfig{}).ReadFileMeta(
 		ctx,
 		common.OauthContext{
 			ClientID:     repository.VCS.ApplicationID,

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	gitLabWebhookPath = "hook/gitlab"
+	gitlabWebhookPath = "hook/gitlab"
 )
 
 func (s *Server) registerWebhookRoutes(g *echo.Group) {
@@ -157,7 +157,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Webhook endpoint not found: %v", webhookEndpointID))
 			}
 
-			content, err := vcs.Get(vcs.GitLabSelfHost, vcs.ProviderConfig{}).ReadFileContent(
+			content, err := vcs.Get(repo2.VCS.Type, vcs.ProviderConfig{}).ReadFileContent(
 				ctx,
 				common.OauthContext{
 					ClientID:     repo2.VCS.ApplicationID,

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	gitlabWebhookPath = "hook/gitlab"
+	githubWebhookPath = "hook/github"
 )
 
 func (s *Server) registerWebhookRoutes(g *echo.Group) {

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -29,7 +29,7 @@ type GitLab struct {
 }
 
 type projectData struct {
-	webhooks []*gitlab.WebhookPost
+	webhooks []*gitlab.WebhookCreate
 	// files is a map that the full file path is the key and the file content is the value.
 	files map[string]string
 }
@@ -87,15 +87,15 @@ func (gl *GitLab) createProjectHook(c echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to read create project hook request body, error %w", err)
 	}
-	webhookPost := &gitlab.WebhookPost{}
-	if err := json.Unmarshal(b, webhookPost); err != nil {
+	webhookCreate := &gitlab.WebhookCreate{}
+	if err := json.Unmarshal(b, webhookCreate); err != nil {
 		return fmt.Errorf("failed to unmarshal create project hook request body, error %w", err)
 	}
 	pd, ok := gl.projects[gitlabProjectID]
 	if !ok {
 		return fmt.Errorf("gitlab project %q doesn't exist", gitlabProjectID)
 	}
-	pd.webhooks = append(pd.webhooks, webhookPost)
+	pd.webhooks = append(pd.webhooks, webhookCreate)
 
 	if err := json.NewEncoder(c.Response().Writer).Encode(&gitlab.WebhookInfo{
 		ID: gl.nextWebhookID,


### PR DESCRIPTION
This PR updates code logics that are hard-coded for `GitLabSelfHost` to have logical branches or be compatible to handle `GitHubCom`.

Fix BYT-933, https://linear.app/bbteam/issue/BYT-933/update-call-sites-to-the-implemented-methods-of-vcsprovider