### PR TITLE
feat(frontend): patch task with updatedTs field

### DIFF
--- a/frontend/src/components/Issue/logic/common.ts
+++ b/frontend/src/components/Issue/logic/common.ts
@@ -148,6 +148,7 @@ export const useCommonLogic = () => {
         task.id,
         {
           statement: maybeFormatStatementOnSave(newStatement, task.database),
+          updatedTs: task.updatedTs,
         },
         postUpdated
       );

--- a/frontend/src/components/Issue/logic/extra.ts
+++ b/frontend/src/components/Issue/logic/extra.ts
@@ -188,6 +188,7 @@ export const useExtraIssueLogic = () => {
       id: stage.id,
       status: newStatus,
       comment,
+      updatedTs: stage.updatedTs,
     };
     taskStore
       .updateStageAllTaskStatus({
@@ -214,6 +215,7 @@ export const useExtraIssueLogic = () => {
     const taskStatusPatch: TaskStatusPatch = {
       status: newStatus,
       comment: comment,
+      updatedTs: task.updatedTs,
     };
     taskStore
       .updateStatus({

--- a/frontend/src/components/Issue/logic/extra.ts
+++ b/frontend/src/components/Issue/logic/extra.ts
@@ -123,10 +123,12 @@ export const useExtraIssueLogic = () => {
         selectedTask.value.earliestAllowedTs = newEarliestAllowedTsMs;
       }
     } else {
+      const task = selectedTask.value as Task;
       const taskPatch: TaskPatch = {
         earliestAllowedTs: newEarliestAllowedTsMs,
+        updatedTs: task.updatedTs,
       };
-      patchTask((selectedTask.value as Task).id, taskPatch);
+      patchTask(task.id, taskPatch);
     }
   };
 

--- a/frontend/src/types/pipeline/stage.ts
+++ b/frontend/src/types/pipeline/stage.ts
@@ -39,4 +39,6 @@ export type StageAllTaskStatusPatch = {
 
   status: TaskStatus;
   comment?: string;
+
+  updatedTs: number;
 };

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -167,6 +167,8 @@ export type TaskStatusPatch = {
   // Domain specific fields
   status: TaskStatus;
   comment?: string;
+
+  updatedTs: number;
 };
 
 // TaskRun is one run of a particular task

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -159,6 +159,8 @@ export type TaskCreate = {
 export type TaskPatch = {
   statement?: string;
   earliestAllowedTs?: number;
+
+  updatedTs: number;
 };
 
 export type TaskStatusPatch = {


### PR DESCRIPTION
Per discussion, we will use (last) `updatedTs` as an optimistic lock to avoid some kind of race condition issues.

The updated POST payload looks like
![4PTcfDPAZL](https://user-images.githubusercontent.com/2749742/179456429-78f4a019-2894-43bc-9de5-8ffa6a91793c.jpg)
![image](https://user-images.githubusercontent.com/2749742/179462435-ef39ffa2-def4-4a69-a489-1424672caf2c.png)
![image](https://user-images.githubusercontent.com/2749742/179462548-35fa93e4-b97e-478d-bd47-538e50e437e7.png)

