### PR TITLE
feat(frontend): narrow the condition to judge if a task is editable

### DIFF
--- a/frontend/src/components/Issue/logic/common.ts
+++ b/frontend/src/components/Issue/logic/common.ts
@@ -27,6 +27,7 @@ import {
   UpdateSchemaDetail,
 } from "@/types";
 import { useIssueLogic } from "./index";
+import { taskCheckRunSummary } from "./utils";
 import { isDev } from "@/utils";
 
 export const useCommonLogic = () => {
@@ -113,15 +114,7 @@ export const useCommonLogic = () => {
       return false;
     }
 
-    // check `selectedTask`, expected to be PENDING or PENDING_APPROVAL or FAILED
-    const checkTask = (task: Task) => {
-      return (
-        task.status == "PENDING" ||
-        task.status == "PENDING_APPROVAL" ||
-        task.status == "FAILED"
-      );
-    };
-    return checkTask(selectedTask.value as Task);
+    return isTaskEditable(selectedTask.value as Task);
   });
 
   const selectedStatement = computed((): string => {
@@ -299,4 +292,24 @@ const statementOfTask = (task: Task) => {
     case "bb.task.database.schema.update.ghost.drop-original-table":
       return ""; // should never reach here
   }
+};
+
+export const isTaskEditable = (task: Task): boolean => {
+  if (task.status === "PENDING_APPROVAL" || task.status === "FAILED") {
+    return true;
+  }
+  if (task.status === "PENDING") {
+    // If a task's status is "PENDING", its statement is editable if there
+    // are at least ONE ERROR task checks.
+    // Since once all its task checks are fulfilled, it might be queued by
+    // the scheduler.
+    // Editing a queued task's SQL statement is dangerous with kinds of race
+    // condition risks.
+    const summary = taskCheckRunSummary(task);
+    if (summary.errorCount > 0) {
+      return true;
+    }
+  }
+
+  return false;
 };

--- a/frontend/src/components/Issue/logic/index.ts
+++ b/frontend/src/components/Issue/logic/index.ts
@@ -8,6 +8,7 @@ export * from "./base";
 export * from "./common";
 export * from "./extra";
 export * from "./transition";
+export * from "./utils";
 
 export {
   IssueLogic,

--- a/frontend/src/components/Issue/logic/utils.ts
+++ b/frontend/src/components/Issue/logic/utils.ts
@@ -1,0 +1,60 @@
+import { groupBy, maxBy } from "lodash-es";
+import { Task } from "@/types";
+
+export type TaskCheckRunSummary = {
+  runningCount: number;
+  successCount: number;
+  warnCount: number;
+  errorCount: number;
+};
+
+export function taskCheckRunSummary(task: Task): TaskCheckRunSummary {
+  const summary: TaskCheckRunSummary = {
+    runningCount: 0,
+    successCount: 0,
+    warnCount: 0,
+    errorCount: 0,
+  };
+
+  const taskCheckRunList = task.taskCheckRunList ?? [];
+
+  const listGroupByType = groupBy(
+    taskCheckRunList,
+    (checkRun) => checkRun.type
+  );
+
+  const latestCheckRunOfEachType = Object.keys(listGroupByType).map((type) => {
+    const listOfType = listGroupByType[type];
+    const latest = maxBy(listOfType, (checkRun) => checkRun.updatedTs)!;
+    return latest;
+  });
+
+  for (const checkRun of latestCheckRunOfEachType) {
+    switch (checkRun.status) {
+      case "CANCELED":
+        // nothing todo
+        break;
+      case "FAILED":
+        summary.errorCount++;
+        break;
+      case "RUNNING":
+        summary.runningCount++;
+        break;
+      case "DONE":
+        for (const result of checkRun.result.resultList) {
+          switch (result.status) {
+            case "SUCCESS":
+              summary.successCount++;
+              break;
+            case "WARN":
+              summary.warnCount++;
+              break;
+            case "ERROR":
+              summary.errorCount++;
+          }
+        }
+    }
+  }
+
+  return summary;
+}


### PR DESCRIPTION
Per discussion, a task is defined to be editable when 

- Its status is "PENDING_APPROVAL" or "FAILED"
- Or, its status is "PENDING" but it will NOT be scheduled, which means
  - At least one of its task checks' results is "error", which means it's blocked to be scheduled due to its pre-flight checks are not all fulfilled.