### PR TITLE
feat(PITR): add databaseName field for PITRContext

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -186,7 +186,9 @@ type UpdateSchemaGhostContext struct {
 
 // PITRContext is the issue create context for performing a PITR in a database.
 type PITRContext struct {
-	DatabaseID int `json:"databaseId"`
+	DatabaseID     int    `json:"databaseId"`
+	TargetDatabase string `json:"targetDatabase`
+
 	// After the PITR operations, the database will be recovered to the state at this time.
 	// Represented in UNIX timestamp in seconds.
 	PointInTimeTs int64 `json:"pointInTimeTs"`

--- a/api/issue.go
+++ b/api/issue.go
@@ -186,8 +186,8 @@ type UpdateSchemaGhostContext struct {
 
 // PITRContext is the issue create context for performing a PITR in a database.
 type PITRContext struct {
-	DatabaseID         int    `json:"databaseId"`
-	TargetDatabaseName string `json:"targetDatabaseName"`
+	DatabaseID        int                    `json:"databaseId"`
+	CreateDatabaseCtx *CreateDatabaseContext `json:"createDatabaseContext"`
 
 	// After the PITR operations, the database will be recovered to the state at this time.
 	// Represented in UNIX timestamp in seconds.

--- a/api/issue.go
+++ b/api/issue.go
@@ -186,8 +186,8 @@ type UpdateSchemaGhostContext struct {
 
 // PITRContext is the issue create context for performing a PITR in a database.
 type PITRContext struct {
-	DatabaseID     int    `json:"databaseId"`
-	TargetDatabase string `json:"targetDatabase`
+	DatabaseID         int    `json:"databaseId"`
+	TargetDatabaseName string `json:"targetDatabaseName"`
 
 	// After the PITR operations, the database will be recovered to the state at this time.
 	// Represented in UNIX timestamp in seconds.


### PR DESCRIPTION
This is the first step of [BYT-813](https://linear.app/bbteam/issue/BYT-813/pitr-to-a-new-database). Frontend can pass the value of `CreateDatabaseCtx` and then the backend can restore the target database to a new database by creating a two tasks pipeline. 