### PR TITLE
fix: task statement update prerequisite

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -38,9 +38,9 @@ func isTaskStatusTransitionAllowed(fromStatus, toStatus api.TaskStatus) bool {
 
 func (s *Server) canUpdateTaskStatement(ctx context.Context, task *api.Task) *echo.HTTPError {
 	// Allow frontend to change the SQL statement of
-	// a PendingApproval task which hasn't started yet
-	// a Failed task which can be retried
-	// a Pending task which can't be scheduled because of failed task checks
+	// 1. a PendingApproval task which hasn't started yet
+	// 2. a Failed task which can be retried
+	// 3. a Pending task which can't be scheduled because of failed task checks
 	if task.Status != api.TaskPendingApproval && task.Status != api.TaskFailed && task.Status != api.TaskPending {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("can not update task in %q state", task.Status))
 	}

--- a/server/task.go
+++ b/server/task.go
@@ -42,14 +42,14 @@ func (s *Server) canUpdateTaskStatement(ctx context.Context, task *api.Task) *ec
 	// a Failed task which can be retried
 	// a Pending task which can't be scheduled because of failed task checks
 	if task.Status != api.TaskPendingApproval && task.Status != api.TaskFailed && task.Status != api.TaskPending {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("can not update task in %v state", task.Status))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("can not update task in %q state", task.Status))
 	}
 	if task.Status == api.TaskPending {
-		schedule, err := s.TaskScheduler.canScheduleTask(ctx, task)
+		canSchedule, err := s.TaskScheduler.canScheduleTask(ctx, task)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to check whether the task can be scheduled").SetInternal(err)
 		}
-		if !schedule {
+		if canSchedule {
 			return echo.NewHTTPError(http.StatusBadRequest, "can not update the PENDING task because it can be running at any time")
 		}
 	}


### PR DESCRIPTION
Allow changing the statement of a Pending Task if it can't be scheduled.