### PR TITLE
feat: HTTP endpoint to patch all tasks in an issue

### DIFF
--- a/server/acl_casbin_policy_dba.csv
+++ b/server/acl_casbin_policy_dba.csv
@@ -71,6 +71,7 @@ p, DBA, /bookmark, POST
 p, DBA, /bookmark/user/{userID}, GET_SELF
 p, DBA, /bookmark/{id}, DELETE_SELF
 p, DBA, /pipeline/{pipelineID}/stage/{stageID}/status, PATCH
+p, DBA, /pipeline/{pipelineID}/task/all, PATCH
 p, DBA, /pipeline/{pipelineID}/task/{taskID}, PATCH
 p, DBA, /pipeline/{pipelineID}/task/{taskID}/status, PATCH
 p, DBA, /pipeline/{pipelineID}/task/{taskID}/check, POST

--- a/server/acl_casbin_policy_developer.csv
+++ b/server/acl_casbin_policy_developer.csv
@@ -65,6 +65,7 @@ p, DEVELOPER, /bookmark, POST
 p, DEVELOPER, /bookmark/user/{userID}, GET_SELF
 p, DEVELOPER, /bookmark/{id}, DELETE_SELF
 p, DEVELOPER, /pipeline/{pipelineID}/stage/{stageID}/status, PATCH
+p, DEVELOPER, /pipeline/{pipelineID}/task/all, PATCH
 p, DEVELOPER, /pipeline/{pipelineID}/task/{taskID}, PATCH
 p, DEVELOPER, /pipeline/{pipelineID}/task/{taskID}/status, PATCH
 p, DEVELOPER, /pipeline/{pipelineID}/task/{taskID}/check, POST

--- a/server/acl_casbin_policy_owner.csv
+++ b/server/acl_casbin_policy_owner.csv
@@ -75,6 +75,7 @@ p, OWNER, /bookmark, POST
 p, OWNER, /bookmark/user/{userID}, GET_SELF
 p, OWNER, /bookmark/{id}, DELETE_SELF
 p, OWNER, /pipeline/{pipelineID}/stage/{stageID}/status, PATCH
+p, OWNER, /pipeline/{pipelineID}/task/all, PATCH
 p, OWNER, /pipeline/{pipelineID}/task/{taskID}, PATCH
 p, OWNER, /pipeline/{pipelineID}/task/{taskID}/status, PATCH
 p, OWNER, /pipeline/{pipelineID}/task/{taskID}/check, POST

--- a/server/task.go
+++ b/server/task.go
@@ -309,7 +309,6 @@ func (s *Server) patchTask(ctx context.Context, task *api.Task, taskPatch *api.T
 			}
 			payloadStr := string(bytes)
 			taskPatch.Payload = &payloadStr
-
 		case api.TaskDatabaseSchemaUpdateGhostSync:
 			payload := &api.TaskDatabaseSchemaUpdateGhostSyncPayload{}
 			if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
@@ -417,8 +416,8 @@ func (s *Server) patchTask(ctx context.Context, task *api.Task, taskPatch *api.T
 				}
 			}
 		}
-
 	}
+
 	// create an activity and trigger task check for earliest allowed time update
 	if taskPatched.EarliestAllowedTs != task.EarliestAllowedTs {
 		// create an activity

--- a/server/task.go
+++ b/server/task.go
@@ -77,10 +77,10 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 
 		issue, err := s.store.GetIssueByPipelineID(ctx, pipelineID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID %v", pipelineID)).SetInternal(err)
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID %d", pipelineID)).SetInternal(err)
 		}
 		if issue == nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Issue not found, pipelineID: %d", pipelineID))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Issue not found with pipelineID: %d", pipelineID))
 		}
 
 		if taskPatch.Statement != nil {
@@ -142,10 +142,10 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 
 		issue, err := s.store.GetIssueByPipelineID(ctx, task.PipelineID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID %v", task.PipelineID)).SetInternal(err)
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID %d", task.PipelineID)).SetInternal(err)
 		}
 		if issue == nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Issue not found, pipelineID: %d", task.PipelineID))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Issue not found with pipelineID: %d", task.PipelineID))
 		}
 
 		if taskPatch.Statement != nil {

--- a/server/task.go
+++ b/server/task.go
@@ -159,17 +159,6 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			}
 		}
 
-		if taskPatch.Statement != nil {
-			// Tenant mode project don't allow updating SQL statement for a single task.
-			project, err := s.store.GetProjectByID(ctx, issue.ProjectID)
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch project with ID %d", issue.ProjectID)).SetInternal(err)
-			}
-			if project.TenantMode == api.TenantModeTenant && task.Type == api.TaskDatabaseSchemaUpdate {
-				return echo.NewHTTPError(http.StatusBadRequest, "cannot update SQL statement of a single task for projects in tenant mode")
-			}
-		}
-
 		taskPatched, httpErr := s.patchTask(ctx, task, taskPatch, issue)
 		if httpErr != nil {
 			return httpErr

--- a/server/task.go
+++ b/server/task.go
@@ -77,7 +77,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 
 		issue, err := s.store.GetIssueByPipelineID(ctx, pipelineID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID %d", pipelineID)).SetInternal(err)
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID: %d", pipelineID)).SetInternal(err)
 		}
 		if issue == nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Issue not found with pipelineID: %d", pipelineID))
@@ -142,7 +142,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 
 		issue, err := s.store.GetIssueByPipelineID(ctx, task.PipelineID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID %d", task.PipelineID)).SetInternal(err)
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID: %d", task.PipelineID)).SetInternal(err)
 		}
 		if issue == nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Issue not found with pipelineID: %d", task.PipelineID))
@@ -152,7 +152,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			// Tenant mode project don't allow updating SQL statement for a single task.
 			project, err := s.store.GetProjectByID(ctx, issue.ProjectID)
 			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch project with ID %d", issue.ProjectID)).SetInternal(err)
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch project with ID: %d", issue.ProjectID)).SetInternal(err)
 			}
 			if project.TenantMode == api.TenantModeTenant && task.Type == api.TaskDatabaseSchemaUpdate {
 				return echo.NewHTTPError(http.StatusBadRequest, "cannot update SQL statement of a single task for projects in tenant mode")


### PR DESCRIPTION
This PR features a new HTTP endpoint `/pipeline/:pipelineID/task/all` which can be used to patch all tasks in the same issue.