### PR TITLE
fix: return error if SetupMigrationIfNeeded encounter some errors

### DIFF
--- a/plugin/db/clickhouse/migrate.go
+++ b/plugin/db/clickhouse/migrate.go
@@ -39,7 +39,7 @@ func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	setup, err := driver.NeedsSetupMigration(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if setup {

--- a/plugin/db/mysql/migrate.go
+++ b/plugin/db/mysql/migrate.go
@@ -38,7 +38,7 @@ func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	setup, err := driver.NeedsSetupMigration(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if setup {

--- a/plugin/db/pg/migrate.go
+++ b/plugin/db/pg/migrate.go
@@ -52,7 +52,7 @@ func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	setup, err := driver.NeedsSetupMigration(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if setup {

--- a/plugin/db/snowflake/migrate.go
+++ b/plugin/db/snowflake/migrate.go
@@ -46,7 +46,7 @@ func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	setup, err := driver.NeedsSetupMigration(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if setup {

--- a/plugin/db/sqlite/migrate.go
+++ b/plugin/db/sqlite/migrate.go
@@ -48,7 +48,7 @@ func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	setup, err := driver.NeedsSetupMigration(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if setup {


### PR DESCRIPTION
IMO, it is a copy-paste error.
We should return an error instead of nil if `SetupMigrationIfNeeded()` encounter some errors. Otherwise, the user may boot Bytebase web server successfully although our migration is failed.