### PR TITLE
fix: make `common.Errorf` support formatting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,3 +83,8 @@ linters-settings:
   gocritic:
     disabled-checks:
       - ifElseChain
+  govet:
+    settings:
+      printf: # The name of the analyzer, run `go tool vet help` to see the list of all analyzers
+        funcs: # Run `go tool vet help printf` to see the full configuration of `printf`
+          - common.Errorf

--- a/api/deploy.go
+++ b/api/deploy.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/bytebase/bytebase/common"
 )
@@ -110,31 +109,31 @@ func ValidateAndGetDeploymentSchedule(payload string) (*DeploymentSchedule, erro
 
 	for _, d := range schedule.Deployments {
 		if d.Name == "" {
-			return nil, common.Errorf(common.Invalid, fmt.Errorf("Deployment name must not be empty"))
+			return nil, common.Errorf(common.Invalid, "Deployment name must not be empty")
 		}
 		hasEnv := false
 		for _, e := range d.Spec.Selector.MatchExpressions {
 			switch e.Operator {
 			case InOperatorType:
 				if len(e.Values) == 0 {
-					return nil, common.Errorf(common.Invalid, fmt.Errorf("expression key %q with %q operator should have at least one value", e.Key, e.Operator))
+					return nil, common.Errorf(common.Invalid, "expression key %q with %q operator should have at least one value", e.Key, e.Operator)
 				}
 			case ExistsOperatorType:
 				if len(e.Values) > 0 {
-					return nil, common.Errorf(common.Invalid, fmt.Errorf("expression key %q with %q operator shouldn't have values", e.Key, e.Operator))
+					return nil, common.Errorf(common.Invalid, "expression key %q with %q operator shouldn't have values", e.Key, e.Operator)
 				}
 			default:
-				return nil, common.Errorf(common.Invalid, fmt.Errorf("expression key %q has invalid operator %q", e.Key, e.Operator))
+				return nil, common.Errorf(common.Invalid, "expression key %q has invalid operator %q", e.Key, e.Operator)
 			}
 			if e.Key == EnvironmentKeyName {
 				hasEnv = true
 				if e.Operator != InOperatorType || len(e.Values) != 1 {
-					return nil, common.Errorf(common.Invalid, fmt.Errorf("label %q should must use operator %q with exactly one value", EnvironmentKeyName, InOperatorType))
+					return nil, common.Errorf(common.Invalid, "label %q should must use operator %q with exactly one value", EnvironmentKeyName, InOperatorType)
 				}
 			}
 		}
 		if !hasEnv {
-			return nil, common.Errorf(common.Invalid, fmt.Errorf("deployment should contain %q label", EnvironmentKeyName))
+			return nil, common.Errorf(common.Invalid, "deployment should contain %q label", EnvironmentKeyName)
 		}
 	}
 	return schedule, nil

--- a/common/error.go
+++ b/common/error.go
@@ -85,8 +85,17 @@ func ErrorMessage(err error) string {
 	return "Internal error."
 }
 
-// Errorf is a helper function to return an Error with a given code and error.
-func Errorf(code Code, err error) *Error {
+// Errorf is a helper function to return an Error with given code, format and
+// arguments.
+func Errorf(code Code, format string, args ...interface{}) *Error {
+	return &Error{
+		Code: code,
+		Err:  fmt.Errorf(format, args...),
+	}
+}
+
+// WithError is a helper function to return an Error with given code and error.
+func WithError(code Code, err error) *Error {
 	return &Error{
 		Code: code,
 		Err:  err,
@@ -95,5 +104,5 @@ func Errorf(code Code, err error) *Error {
 
 // FormatDBErrorEmptyRowWithQuery formats database error that query returns empty row.
 func FormatDBErrorEmptyRowWithQuery(query string) error {
-	return Errorf(DbExecutionError, fmt.Errorf("query %q returned empty row", query))
+	return Errorf(DbExecutionError, "query %q returned empty row", query)
 }

--- a/plugin/db/clickhouse/dump.go
+++ b/plugin/db/clickhouse/dump.go
@@ -90,7 +90,7 @@ func dumpTxn(ctx context.Context, txn *sql.Tx, database string, out io.Writer) e
 			}
 		}
 		if !exist {
-			return common.Errorf(common.NotFound, fmt.Errorf("database %s not found", database))
+			return common.Errorf(common.NotFound, "database %s not found", database)
 		}
 		dumpableDbNames = []string{database}
 	} else {

--- a/plugin/db/clickhouse/sync.go
+++ b/plugin/db/clickhouse/sync.go
@@ -196,7 +196,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		&schema.Name,
 	); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, common.Errorf(common.NotFound, fmt.Errorf("database %q not found", databaseName))
+			return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 		}
 		return nil, err
 	}

--- a/plugin/db/mysql/dump.go
+++ b/plugin/db/mysql/dump.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db/util"
-	"go.uber.org/zap"
 )
 
 // Dump and restore
@@ -189,7 +190,7 @@ func dumpTxn(ctx context.Context, txn *sql.Tx, database string, out io.Writer, s
 			}
 		}
 		if !exist {
-			return common.Errorf(common.NotFound, fmt.Errorf("database %s not found", database))
+			return common.Errorf(common.NotFound, "database %s not found", database)
 		}
 		dumpableDbNames = []string{database}
 	} else {

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db/util"
 	"github.com/bytebase/bytebase/resources/mysqlutil"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/blang/semver/v4"
 )
@@ -861,7 +862,7 @@ func (driver *Driver) getBinlogEventPositionAtOrAfterTs(ctx context.Context, bin
 	}
 
 	if pos == 0 {
-		return 0, common.Errorf(common.NotFound, fmt.Errorf("failed to find event position at or after targetTs %d", targetTs))
+		return 0, common.Errorf(common.NotFound, "failed to find event position at or after targetTs %d", targetTs)
 	}
 
 	return pos, nil

--- a/plugin/db/mysql/sync.go
+++ b/plugin/db/mysql/sync.go
@@ -375,7 +375,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		&schema.CharacterSet,
 		&schema.Collation); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, common.Errorf(common.NotFound, fmt.Errorf("database %q not found", databaseName))
+			return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 		}
 		return nil, err
 	}

--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -156,7 +156,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if !found {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("database %q not found", databaseName))
+		return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 	}
 
 	sqldb, err := driver.GetDBConnection(ctx, databaseName)

--- a/plugin/db/snowflake/sync.go
+++ b/plugin/db/snowflake/sync.go
@@ -85,7 +85,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if !found {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("database %q not found", databaseName))
+		return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 	}
 
 	tableList, viewList, err := driver.syncTableSchema(ctx, databaseName)

--- a/plugin/db/sqlite/sync.go
+++ b/plugin/db/sqlite/sync.go
@@ -77,7 +77,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if !found {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("database %q not found", databaseName))
+		return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 	}
 
 	sqldb, err := driver.GetDBConnection(ctx, databaseName)

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -167,7 +167,7 @@ func (p *Provider) fetchUserInfo(ctx context.Context, oauthCtx common.OauthConte
 	}
 
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to read user info from URL %s", url))
+		return nil, common.Errorf(common.NotFound, "failed to read user info from URL %s", url)
 	} else if code >= 300 {
 		return nil, fmt.Errorf("failed to read user info from URL %s, status code: %d, body: %s", url, code, body)
 	}
@@ -228,7 +228,7 @@ func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthCon
 	}
 
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch commit data from URL %s", url))
+		return nil, common.Errorf(common.NotFound, "failed to fetch commit data from URL %s", url)
 	} else if code >= 300 {
 		return nil, fmt.Errorf("failed to fetch commit data from URL %s, status code: %d, body: %s", url, code, body)
 	}
@@ -344,7 +344,7 @@ func (p *Provider) fetchPaginatedRepositoryCollaborators(ctx context.Context, oa
 	}
 
 	if code == http.StatusNotFound {
-		return nil, false, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch repository collaborators from URL %s", url))
+		return nil, false, common.Errorf(common.NotFound, "failed to fetch repository collaborators from URL %s", url)
 	} else if code >= 300 {
 		return nil, false,
 			fmt.Errorf("failed to read repository collaborators from URL %s, status code: %d, body: %s",
@@ -482,7 +482,7 @@ func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx co
 	}
 
 	if code == http.StatusNotFound {
-		return nil, false, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch repository list from URL %s", url))
+		return nil, false, common.Errorf(common.NotFound, "failed to fetch repository list from URL %s", url)
 	} else if code >= 300 {
 		return nil, false,
 			fmt.Errorf("failed to fetch repository list from URL %s, status code: %d, body: %s",
@@ -532,7 +532,7 @@ func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.
 	}
 
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch repository file list from URL %s", url))
+		return nil, common.Errorf(common.NotFound, "failed to fetch repository file list from URL %s", url)
 	} else if code >= 300 {
 		return nil,
 			fmt.Errorf("failed to fetch repository file list from URL %s, status code: %d, body: %s",
@@ -604,7 +604,7 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 	}
 
 	if code == http.StatusNotFound {
-		return common.Errorf(common.NotFound, fmt.Errorf("failed to create/update file through URL %s", url))
+		return common.Errorf(common.NotFound, "failed to create/update file through URL %s", url)
 	} else if code >= 300 {
 		return fmt.Errorf("failed to create/update file through URL %s, status code: %d, body: %s",
 			url,
@@ -672,7 +672,7 @@ func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, r
 	}
 
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to read file from URL %s", url))
+		return nil, common.Errorf(common.NotFound, "failed to read file from URL %s", url)
 	} else if code >= 300 {
 		return nil,
 			fmt.Errorf("failed to read file from URL %s, status code: %d, body: %s",
@@ -728,7 +728,7 @@ func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthConte
 	}
 
 	if code == http.StatusNotFound {
-		return "", common.Errorf(common.NotFound, fmt.Errorf("failed to create webhook through URL %s", url))
+		return "", common.Errorf(common.NotFound, "failed to create webhook through URL %s", url)
 	} else if code >= 300 {
 		return "",
 			fmt.Errorf("failed to create webhook through URL %s, status code: %d, body: %s",
@@ -770,7 +770,7 @@ func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContex
 	}
 
 	if code == http.StatusNotFound {
-		return common.Errorf(common.NotFound, fmt.Errorf("failed to patch webhook through URL %s", url))
+		return common.Errorf(common.NotFound, "failed to patch webhook through URL %s", url)
 	} else if code >= 300 {
 		return fmt.Errorf("failed to patch webhook through URL %s, status code: %d, body: %s",
 			url,

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -315,7 +315,7 @@ func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx co
 	}
 
 	if code == http.StatusNotFound {
-		return nil, false, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch repository list from URL %s", url))
+		return nil, false, common.Errorf(common.NotFound, "failed to fetch repository list from URL %s", url)
 	} else if code >= 300 {
 		return nil, false,
 			fmt.Errorf("failed to fetch repository list from URL %s, status code: %d, body: %s",
@@ -360,7 +360,7 @@ func (p *Provider) fetchUserInfo(ctx context.Context, oauthCtx common.OauthConte
 	}
 
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to read user info from URL %s", url))
+		return nil, common.Errorf(common.NotFound, "failed to read user info from URL %s", url)
 	} else if code >= 300 {
 		return nil, fmt.Errorf("failed to read user info from URL %s, status code: %d, body: %s",
 			url,
@@ -403,7 +403,7 @@ func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthCon
 		return nil, errors.Wrap(err, "GET")
 	}
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch commit data from URL %s", url))
+		return nil, common.Errorf(common.NotFound, "failed to fetch commit data from URL %s", url)
 	} else if code >= 300 {
 		return nil, fmt.Errorf("failed to fetch commit data from URL %s, status code: %d, body: %s",
 			url,
@@ -544,7 +544,7 @@ func (p *Provider) fetchPaginatedRepositoryActiveMemberList(ctx context.Context,
 	}
 
 	if code == http.StatusNotFound {
-		return nil, false, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch repository members from URL %s", url))
+		return nil, false, common.Errorf(common.NotFound, "failed to fetch repository members from URL %s", url)
 	} else if code >= 300 {
 		return nil, false,
 			fmt.Errorf("failed to fetch repository members from URL %s, status code: %d, body: %s",
@@ -624,7 +624,7 @@ func (p *Provider) fetchPaginatedRepositoryFileList(ctx context.Context, oauthCt
 	}
 
 	if code == http.StatusNotFound {
-		return nil, false, common.Errorf(common.NotFound, fmt.Errorf("failed to fetch repository file list from URL %s", url))
+		return nil, false, common.Errorf(common.NotFound, "failed to fetch repository file list from URL %s", url)
 	} else if code >= 300 {
 		return nil, false,
 			fmt.Errorf("failed to fetch repository file list from URL %s, status code: %d, body: %s",
@@ -682,7 +682,7 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 	}
 
 	if code == http.StatusNotFound {
-		return common.Errorf(common.NotFound, fmt.Errorf("failed to create file through URL %s", url))
+		return common.Errorf(common.NotFound, "failed to create file through URL %s", url)
 	} else if code >= 300 {
 		return fmt.Errorf("failed to create file through URL %s, status code: %d, body: %s",
 			url,
@@ -731,7 +731,7 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 	}
 
 	if code == http.StatusNotFound {
-		return common.Errorf(common.NotFound, fmt.Errorf("failed to overwrite file through URL %s", url))
+		return common.Errorf(common.NotFound, "failed to overwrite file through URL %s", url)
 	} else if code >= 300 {
 		return fmt.Errorf("failed to overwrite file through URL %s, status code: %d, body: %s",
 			url,
@@ -796,7 +796,7 @@ func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthConte
 	}
 
 	if code == http.StatusNotFound {
-		return "", common.Errorf(common.NotFound, fmt.Errorf("failed to create webhook through URL %s", url))
+		return "", common.Errorf(common.NotFound, "failed to create webhook through URL %s", url)
 	} else if code >= 300 {
 		reason := fmt.Sprintf("failed to create webhook through URL %s, status code: %d, body: %s",
 			url,
@@ -845,7 +845,7 @@ func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContex
 	}
 
 	if code == http.StatusNotFound {
-		return common.Errorf(common.NotFound, fmt.Errorf("failed to patch webhook through URL %s", url))
+		return common.Errorf(common.NotFound, "failed to patch webhook through URL %s", url)
 	} else if code >= 300 {
 		return fmt.Errorf("failed to patch webhook through URL %s, status code: %d, body: %s",
 			url,
@@ -918,7 +918,7 @@ func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, i
 	}
 
 	if code == http.StatusNotFound {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("failed to read file from URL %s", url))
+		return nil, common.Errorf(common.NotFound, "failed to read file from URL %s", url)
 	} else if code >= 300 {
 		return nil,
 			fmt.Errorf("failed to read file from URL %s, status code: %d, body: %s",

--- a/server/database.go
+++ b/server/database.go
@@ -853,7 +853,7 @@ func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databas
 func getConnectionConfig(instance *api.Instance, databaseName string) (db.ConnectionConfig, error) {
 	adminDataSource := api.DataSourceFromInstanceWithType(instance, api.Admin)
 	if adminDataSource == nil {
-		return db.ConnectionConfig{}, common.Errorf(common.Internal, fmt.Errorf("admin data source not found for instance %d", instance.ID))
+		return db.ConnectionConfig{}, common.Errorf(common.Internal, "admin data source not found for instance %d", instance.ID)
 	}
 
 	return db.ConnectionConfig{
@@ -879,7 +879,7 @@ func tryGetReadOnlyDatabaseDriver(ctx context.Context, instance *api.Instance, d
 		dataSource = api.DataSourceFromInstanceWithType(instance, api.Admin)
 	}
 	if dataSource == nil {
-		return nil, common.Errorf(common.Internal, fmt.Errorf("data source not found for instance %d", instance.ID))
+		return nil, common.Errorf(common.Internal, "data source not found for instance %d", instance.ID)
 	}
 
 	driver, err := getDatabaseDriver(
@@ -922,7 +922,7 @@ func getDatabaseDriver(ctx context.Context, engine db.Type, driverConfig db.Driv
 		connCtx,
 	)
 	if err != nil {
-		return nil, common.Errorf(common.DbConnectionFailure, fmt.Errorf("failed to connect database at %s:%s with user %q, error: %w", connectionConfig.Host, connectionConfig.Port, connectionConfig.Username, err))
+		return nil, common.Errorf(common.DbConnectionFailure, "failed to connect database at %s:%s with user %q, error: %w", connectionConfig.Host, connectionConfig.Port, connectionConfig.Username, err)
 	}
 	return driver, nil
 }
@@ -946,20 +946,20 @@ func validateDatabaseLabelList(labelList []*api.DatabaseLabel, labelKeyList []*a
 		}
 		labelKey, ok := keyValueList[label.Key]
 		if !ok {
-			return common.Errorf(common.Invalid, fmt.Errorf("invalid database label key: %v", label.Key))
+			return common.Errorf(common.Invalid, "invalid database label key: %v", label.Key)
 		}
 		_, ok = labelKey[label.Value]
 		if !ok {
-			return common.Errorf(common.Invalid, fmt.Errorf("invalid database label value %v for key %v", label.Value, label.Key))
+			return common.Errorf(common.Invalid, "invalid database label value %v for key %v", label.Value, label.Key)
 		}
 	}
 
 	// Environment label must exist and is immutable.
 	if environmentValue == nil {
-		return common.Errorf(common.NotFound, fmt.Errorf("database label key %v not found", api.EnvironmentKeyName))
+		return common.Errorf(common.NotFound, "database label key %v not found", api.EnvironmentKeyName)
 	}
 	if environmentName != *environmentValue {
-		return common.Errorf(common.Invalid, fmt.Errorf("cannot mutate database label key %v from %v to %v", api.EnvironmentKeyName, environmentName, *environmentValue))
+		return common.Errorf(common.Invalid, "cannot mutate database label key %v from %v to %v", api.EnvironmentKeyName, environmentName, *environmentValue)
 	}
 
 	return nil

--- a/server/task_check_executor_database_connect.go
+++ b/server/task_check_executor_database_connect.go
@@ -21,7 +21,7 @@ type TaskCheckDatabaseConnectExecutor struct {
 func (exec *TaskCheckDatabaseConnectExecutor) Run(ctx context.Context, server *Server, taskCheckRun *api.TaskCheckRun) (result []api.TaskCheckResult, err error) {
 	task, err := server.store.GetTaskByID(ctx, taskCheckRun.TaskID)
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Internal, err)
+		return []api.TaskCheckResult{}, common.WithError(common.Internal, err)
 	}
 	if task == nil {
 		return []api.TaskCheckResult{
@@ -37,10 +37,10 @@ func (exec *TaskCheckDatabaseConnectExecutor) Run(ctx context.Context, server *S
 
 	database, err := server.store.GetDatabase(ctx, &api.DatabaseFind{ID: task.DatabaseID})
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Internal, err)
+		return []api.TaskCheckResult{}, common.WithError(common.Internal, err)
 	}
 	if database == nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Internal, fmt.Errorf("database ID not found %v", task.DatabaseID))
+		return []api.TaskCheckResult{}, common.Errorf(common.Internal, "database ID not found %v", task.DatabaseID)
 	}
 
 	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, server.pgInstanceDir)

--- a/server/task_check_executor_migration_schema.go
+++ b/server/task_check_executor_migration_schema.go
@@ -21,7 +21,7 @@ type TaskCheckMigrationSchemaExecutor struct {
 func (exec *TaskCheckMigrationSchemaExecutor) Run(ctx context.Context, server *Server, taskCheckRun *api.TaskCheckRun) (result []api.TaskCheckResult, err error) {
 	task, err := server.store.GetTaskByID(ctx, taskCheckRun.TaskID)
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Internal, err)
+		return []api.TaskCheckResult{}, common.WithError(common.Internal, err)
 	}
 	if task == nil {
 		return []api.TaskCheckResult{

--- a/server/task_check_executor_statement_advisor_composite.go
+++ b/server/task_check_executor_statement_advisor_composite.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
@@ -29,15 +28,15 @@ type TaskCheckStatementAdvisorCompositeExecutor struct {
 // Run will run the task check statement advisor composite executor once, and run its sub-advisor one-by-one.
 func (exec *TaskCheckStatementAdvisorCompositeExecutor) Run(ctx context.Context, server *Server, taskCheckRun *api.TaskCheckRun) (result []api.TaskCheckResult, err error) {
 	if taskCheckRun.Type != api.TaskCheckDatabaseStatementAdvise {
-		return nil, common.Errorf(common.Invalid, fmt.Errorf("invalid check statement advisor composite type: %v", taskCheckRun.Type))
+		return nil, common.Errorf(common.Invalid, "invalid check statement advisor composite type: %v", taskCheckRun.Type)
 	}
 	if !server.feature(api.FeatureSQLReviewPolicy) {
-		return nil, common.Errorf(common.NotAuthorized, fmt.Errorf(api.FeatureSQLReviewPolicy.AccessErrorMessage()))
+		return nil, common.Errorf(common.NotAuthorized, api.FeatureSQLReviewPolicy.AccessErrorMessage())
 	}
 
 	payload := &api.TaskCheckDatabaseStatementAdvisePayload{}
 	if err := json.Unmarshal([]byte(taskCheckRun.Payload), payload); err != nil {
-		return nil, common.Errorf(common.Invalid, fmt.Errorf("invalid check statement advise payload: %w", err))
+		return nil, common.Errorf(common.Invalid, "invalid check statement advise payload: %w", err)
 	}
 
 	policy, err := server.store.GetNormalSchemaReviewPolicy(ctx, &api.PolicyFind{ID: &payload.PolicyID})
@@ -53,12 +52,12 @@ func (exec *TaskCheckStatementAdvisorCompositeExecutor) Run(ctx context.Context,
 				},
 			}, nil
 		}
-		return nil, common.Errorf(common.Internal, fmt.Errorf("failed to get schema review policy: %w", err))
+		return nil, common.Errorf(common.Internal, "failed to get schema review policy: %w", err)
 	}
 
 	task, err := server.store.GetTaskByID(ctx, taskCheckRun.TaskID)
 	if err != nil {
-		return nil, common.Errorf(common.Internal, fmt.Errorf("failed to get task by id: %w", err))
+		return nil, common.Errorf(common.Internal, "failed to get task by id: %w", err)
 	}
 
 	catalog := store.NewCatalog(task.DatabaseID, server.store, payload.DbType)

--- a/server/task_check_executor_statement_advisor_simple.go
+++ b/server/task_check_executor_statement_advisor_simple.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
@@ -24,7 +23,7 @@ type TaskCheckStatementAdvisorSimpleExecutor struct {
 func (exec *TaskCheckStatementAdvisorSimpleExecutor) Run(_ context.Context, _ *Server, taskCheckRun *api.TaskCheckRun) (result []api.TaskCheckResult, err error) {
 	payload := &api.TaskCheckDatabaseStatementAdvisePayload{}
 	if err := json.Unmarshal([]byte(taskCheckRun.Payload), payload); err != nil {
-		return nil, common.Errorf(common.Invalid, fmt.Errorf("invalid check statement advise payload: %w", err))
+		return nil, common.Errorf(common.Invalid, "invalid check statement advise payload: %w", err)
 	}
 
 	var advisorType advisor.Type
@@ -38,7 +37,7 @@ func (exec *TaskCheckStatementAdvisorSimpleExecutor) Run(_ context.Context, _ *S
 		case db.Postgres:
 			advisorType = advisor.PostgreSQLSyntax
 		default:
-			return nil, common.Errorf(common.Invalid, fmt.Errorf("invalid database type: %s for syntax statement advisor", payload.DbType))
+			return nil, common.Errorf(common.Invalid, "invalid database type: %s for syntax statement advisor", payload.DbType)
 		}
 	}
 
@@ -57,7 +56,7 @@ func (exec *TaskCheckStatementAdvisorSimpleExecutor) Run(_ context.Context, _ *S
 		payload.Statement,
 	)
 	if err != nil {
-		return nil, common.Errorf(common.Internal, fmt.Errorf("failed to check statement: %w", err))
+		return nil, common.Errorf(common.Internal, "failed to check statement: %w", err)
 	}
 
 	result = []api.TaskCheckResult{}

--- a/server/task_check_executor_timing.go
+++ b/server/task_check_executor_timing.go
@@ -25,7 +25,7 @@ const dataFormat = "2006-01-02 15:04:05"
 func (exec *TaskCheckTimingExecutor) Run(_ context.Context, _ *Server, taskCheckRun *api.TaskCheckRun) (result []api.TaskCheckResult, err error) {
 	payload := &api.TaskCheckEarliestAllowedTimePayload{}
 	if err := json.Unmarshal([]byte(taskCheckRun.Payload), payload); err != nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Invalid, fmt.Errorf("invalid check timing payload: %w", err))
+		return []api.TaskCheckResult{}, common.Errorf(common.Invalid, "invalid check timing payload: %w", err)
 	}
 
 	if payload.EarliestAllowedTs == 0 {

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -152,7 +152,7 @@ func executeMigration(ctx context.Context, pgInstanceDir string, task *api.Task,
 		return 0, "", fmt.Errorf("failed to check migration setup for instance %q: %w", task.Instance.Name, err)
 	}
 	if setup {
-		return 0, "", common.Errorf(common.MigrationSchemaMissing, fmt.Errorf("missing migration schema for instance %q", task.Instance.Name))
+		return 0, "", common.Errorf(common.MigrationSchemaMissing, "missing migration schema for instance %q", task.Instance.Name)
 	}
 
 	migrationID, schema, err = driver.ExecuteMigration(ctx, mi, statement)

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -10,13 +10,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
-	"go.uber.org/zap"
 )
 
 // NewSchemaUpdateGhostCutoverTaskExecutor creates a schema update (gh-ost) cutover task executor.
@@ -76,7 +77,7 @@ func cutover(ctx context.Context, server *Server, task *api.Task, statement, sch
 			return -1, "", fmt.Errorf("failed to check migration setup for instance %q: %w", task.Instance.Name, err)
 		}
 		if needsSetup {
-			return -1, "", common.Errorf(common.MigrationSchemaMissing, fmt.Errorf("missing migration schema for instance %q", task.Instance.Name))
+			return -1, "", common.Errorf(common.MigrationSchemaMissing, "missing migration schema for instance %q", task.Instance.Name)
 		}
 
 		executor := driver.(util.MigrationExecutor)

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -9,13 +9,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/common/log"
 	"github.com/github/gh-ost/go/base"
 	"github.com/github/gh-ost/go/logic"
 	ghostsql "github.com/github/gh-ost/go/sql"
 	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 )
 
 // NewSchemaUpdateGhostSyncTaskExecutor creates a schema update (gh-ost) sync task executor.
@@ -192,7 +193,7 @@ func executeGhost(task *api.Task, statement string, syncDone chan<- struct{}) er
 
 	adminDataSource := api.DataSourceFromInstanceWithType(instance, api.Admin)
 	if adminDataSource == nil {
-		return common.Errorf(common.Internal, fmt.Errorf("admin data source not found for instance %d", instance.ID))
+		return common.Errorf(common.Internal, "admin data source not found for instance %d", instance.ID)
 	}
 
 	migrationContext, err := newMigrationContext(ghostConfig{

--- a/store/label.go
+++ b/store/label.go
@@ -335,7 +335,7 @@ func (s *Store) findLabelKeyImpl(ctx context.Context, tx *sql.Tx, find *api.Labe
 		}
 		labelKey, ok := keymap[key]
 		if !ok {
-			return nil, common.Errorf(common.Internal, fmt.Errorf("label value doesn't have a label key, key %q, value %q", key, value))
+			return nil, common.Errorf(common.Internal, "label value doesn't have a label key, key %q, value %q", key, value)
 		}
 		labelKey.ValueList = append(labelKey.ValueList, value)
 	}
@@ -372,7 +372,7 @@ func (s *Store) patchLabelKeyRaw(ctx context.Context, patch *api.LabelKeyPatch) 
 		}
 	}
 	if labelKeyRaw == nil {
-		return nil, common.Errorf(common.NotFound, fmt.Errorf("label key not found with ID %v", patch.ID))
+		return nil, common.Errorf(common.NotFound, "label key not found with ID %v", patch.ID)
 	}
 
 	// Generate label value upserts.

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -694,55 +694,55 @@ func FormatError(err error) error {
 	if strings.Contains(err.Error(), "unique constraint") {
 		switch {
 		case strings.Contains(err.Error(), "idx_principal_unique_email"):
-			return common.Errorf(common.Conflict, fmt.Errorf("email already exists"))
+			return common.Errorf(common.Conflict, "email already exists")
 		case strings.Contains(err.Error(), "idx_setting_unique_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("setting name already exists"))
+			return common.Errorf(common.Conflict, "setting name already exists")
 		case strings.Contains(err.Error(), "idx_member_unique_principal_id"):
-			return common.Errorf(common.Conflict, fmt.Errorf("member already exists"))
+			return common.Errorf(common.Conflict, "member already exists")
 		case strings.Contains(err.Error(), "idx_environment_unique_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("environment name already exists"))
+			return common.Errorf(common.Conflict, "environment name already exists")
 		case strings.Contains(err.Error(), "idx_policy_unique_environment_id_type"):
-			return common.Errorf(common.Conflict, fmt.Errorf("policy environment and type already exists"))
+			return common.Errorf(common.Conflict, "policy environment and type already exists")
 		case strings.Contains(err.Error(), "idx_project_unique_key"):
-			return common.Errorf(common.Conflict, fmt.Errorf("project key already exists"))
+			return common.Errorf(common.Conflict, "project key already exists")
 		case strings.Contains(err.Error(), "idx_project_member_unique_project_id_role_provider_principal_id"):
-			return common.Errorf(common.Conflict, fmt.Errorf("project member already exists"))
+			return common.Errorf(common.Conflict, "project member already exists")
 		case strings.Contains(err.Error(), "idx_project_webhook_unique_project_id_url"):
-			return common.Errorf(common.Conflict, fmt.Errorf("webhook url already exists"))
+			return common.Errorf(common.Conflict, "webhook url already exists")
 		case strings.Contains(err.Error(), "idx_instance_user_unique_instance_id_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("instance id and name already exists"))
+			return common.Errorf(common.Conflict, "instance id and name already exists")
 		case strings.Contains(err.Error(), "idx_db_unique_instance_id_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("database name already exists"))
+			return common.Errorf(common.Conflict, "database name already exists")
 		case strings.Contains(err.Error(), "idx_tbl_unique_database_id_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("database id and name already exists"))
+			return common.Errorf(common.Conflict, "database id and name already exists")
 		case strings.Contains(err.Error(), "idx_col_unique_database_id_table_id_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("database id, table id and name already exists"))
+			return common.Errorf(common.Conflict, "database id, table id and name already exists")
 		case strings.Contains(err.Error(), "idx_idx_unique_database_id_table_id_name_expression"):
-			return common.Errorf(common.Conflict, fmt.Errorf("database id, table id, name and expression already exists"))
+			return common.Errorf(common.Conflict, "database id, table id, name and expression already exists")
 		case strings.Contains(err.Error(), "idx_vw_unique_database_id_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("database id and name already exists"))
+			return common.Errorf(common.Conflict, "database id and name already exists")
 		case strings.Contains(err.Error(), "idx_data_source_unique_database_id_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("data source name already exists"))
+			return common.Errorf(common.Conflict, "data source name already exists")
 		case strings.Contains(err.Error(), "idx_backup_unique_database_id_name"):
-			return common.Errorf(common.Conflict, fmt.Errorf("backup name already exists"))
+			return common.Errorf(common.Conflict, "backup name already exists")
 		case strings.Contains(err.Error(), "idx_backup_setting_unique_database_id"):
-			return common.Errorf(common.Conflict, fmt.Errorf("database id already exists"))
+			return common.Errorf(common.Conflict, "database id already exists")
 		case strings.Contains(err.Error(), "idx_bookmark_unique_creator_id_link"):
-			return common.Errorf(common.Conflict, fmt.Errorf("bookmark already exists"))
+			return common.Errorf(common.Conflict, "bookmark already exists")
 		case strings.Contains(err.Error(), "idx_repository_unique_project_id"):
-			return common.Errorf(common.Conflict, fmt.Errorf("project has already linked repository"))
+			return common.Errorf(common.Conflict, "project has already linked repository")
 		case strings.Contains(err.Error(), "idx_repository_unique_webhook_endpoint_id"):
-			return common.Errorf(common.Conflict, fmt.Errorf("webhook endpoint already exists"))
+			return common.Errorf(common.Conflict, "webhook endpoint already exists")
 		case strings.Contains(err.Error(), "idx_label_key_unique_key"):
-			return common.Errorf(common.Conflict, fmt.Errorf("label key already exists"))
+			return common.Errorf(common.Conflict, "label key already exists")
 		case strings.Contains(err.Error(), "idx_label_value_unique_key_value"):
-			return common.Errorf(common.Conflict, fmt.Errorf("label key value already exists"))
+			return common.Errorf(common.Conflict, "label key value already exists")
 		case strings.Contains(err.Error(), "idx_db_label_unique_database_id_key"):
-			return common.Errorf(common.Conflict, fmt.Errorf("database id and key already exists"))
+			return common.Errorf(common.Conflict, "database id and key already exists")
 		case strings.Contains(err.Error(), "idx_deployment_config_unique_project_id"):
-			return common.Errorf(common.Conflict, fmt.Errorf("project deployment configuration already exists"))
+			return common.Errorf(common.Conflict, "project deployment configuration already exists")
 		case strings.Contains(err.Error(), "issue_subscriber_pkey"):
-			return common.Errorf(common.Conflict, fmt.Errorf("issue subscriber already exists"))
+			return common.Errorf(common.Conflict, "issue subscriber already exists")
 		}
 	}
 	return err


### PR DESCRIPTION
This PR makes the `common.Errorf` function to support formatting (i.e. embedding `fmt.Errorf`), and adds `common.WithError` for the cases where we already have the error object.

This is for two reasons:

1. Almost all of our [call sites for `common.Errorf` are in combination with `fmt.Errorf`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/bytebase/bytebase%24+common.Errorf%28&patternType=literal).
2. The way it's been used currently isn't Go idiomatic, i.e. a function ending with `f` often implies formatting.

Since we're no longer directly using the `fmt.Errorf`, `go vet` would stop checking the type mismatch between formatting verbs and variables we provide, thus adds a new rule in `.golangci.yaml` for checking type mismatch for `common.Errorf`, it works as follows:


```
deploy.go:131:18: printf: github.com/bytebase/bytebase/common.Errorf format %d has arg InOperatorType of wrong type github.com/bytebase/bytebase/api.OperatorType (govet)
					return nil, common.Errorf(common.Invalid, "label %q should must use operator %d with exactly one value", EnvironmentKeyName, InOperatorType)
					            ^
```