### PR TITLE
refactor(PITR): use _del as old table suffix in consistent with gh-ost and review policy

### DIFF
--- a/frontend/src/components/DatabaseTable.vue
+++ b/frontend/src/components/DatabaseTable.vue
@@ -408,7 +408,7 @@ const clickDatabase = (section: number, row: number, e: MouseEvent) => {
 
 function isPITRDatabase(db: Database): boolean {
   const { name } = db;
-  // A pitr database's name is xxx_pitr_1234567890 or xxx_pitr_1234567890_old
-  return !!name.match(/^(.+?)_pitr_(\d+)(_old)?$/);
+  // A pitr database's name is xxx_pitr_1234567890 or xxx_pitr_1234567890_del
+  return !!name.match(/^(.+?)_pitr_(\d+)(_del)?$/);
 }
 </script>

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -4,8 +4,8 @@ package mysql
 // For example, the original database is `dbfoo`. The suffixTs, derived from the PITR issue's CreateTs, is 1653018005.
 // Bytebase will do the following:
 // 1. Create a database called `dbfoo_pitr_1653018005`, and do PITR restore to it.
-// 2. Create a database called `dbfoo_pitr_1653018005_old`, and move tables
-// 	  from `dbfoo` to `dbfoo_pitr_1653018005_old`, and tables from `dbfoo_pitr_1653018005` to `dbfoo`.
+// 2. Create a database called `dbfoo_pitr_1653018005_del`, and move tables
+// 	  from `dbfoo` to `dbfoo_pitr_1653018005_del`, and tables from `dbfoo_pitr_1653018005` to `dbfoo`.
 
 import (
 	"bufio"
@@ -479,9 +479,9 @@ func getPITRDatabaseName(database string, suffixTs int64) string {
 }
 
 // Composes a database name that we use as the target database for swapping out the original database.
-// For example, getPITROldDatabaseName("dbfoo", 1653018005) -> "dbfoo_pitr_1653018005_old".
+// For example, getPITROldDatabaseName("dbfoo", 1653018005) -> "dbfoo_pitr_1653018005_del".
 func getPITROldDatabaseName(database string, suffixTs int64) string {
-	suffix := fmt.Sprintf("pitr_%d_old", suffixTs)
+	suffix := fmt.Sprintf("pitr_%d_del", suffixTs)
 	return getSafeName(database, suffix)
 }
 

--- a/plugin/db/mysql/restore_test.go
+++ b/plugin/db/mysql/restore_test.go
@@ -24,8 +24,8 @@ func TestGetSafeName(t *testing.T) {
 		},
 		{
 			baseName: "normal_database_name",
-			suffix:   "old",
-			expected: "normal_database_name_old",
+			suffix:   "del",
+			expected: "normal_database_name_del",
 		},
 		{
 			baseName: "long_database_name1234567890123456789012345678901",
@@ -75,12 +75,12 @@ func TestGetPITROldDatabaseName(t *testing.T) {
 		{
 			database:  "normal_database_name",
 			timestamp: 1652237293,
-			expected:  "normal_database_name_pitr_1652237293_old",
+			expected:  "normal_database_name_pitr_1652237293_del",
 		},
 		{
 			database:  "long_database_name123456789012345678901234567890",
 			timestamp: 1652237293,
-			expected:  "long_database_name12345678901234567890123456_pitr_1652237293_old",
+			expected:  "long_database_name12345678901234567890123456_pitr_1652237293_del",
 		},
 	}
 


### PR DESCRIPTION
Close BYT-996.