### PR TITLE
feat(frontend): PITR to the point before last migration

### DIFF
--- a/frontend/src/components/DatabaseDetail/MigrationHistoryBrief.vue
+++ b/frontend/src/components/DatabaseDetail/MigrationHistoryBrief.vue
@@ -11,7 +11,6 @@
           class="normal-link flex items-center gap-x-1"
         >
           {{ migrationHistory.version }}
-          <heroicons-outline:external-link class="w-4 h-4" />
         </a>
       </div>
     </div>
@@ -27,7 +26,6 @@
           class="normal-link flex items-center gap-x-1"
         >
           {{ migrationHistory.issueId }}
-          <heroicons-outline:external-link class="w-4 h-4" />
         </a>
       </div>
     </div>

--- a/frontend/src/components/DatabaseDetail/MigrationHistoryBrief.vue
+++ b/frontend/src/components/DatabaseDetail/MigrationHistoryBrief.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="w-full space-y-4 text-sm">
+    <div class="flex items-center gap-x-4">
+      <label class="w-1/4 flex justify-end textlabel">
+        {{ $t("common.version") }}
+      </label>
+      <div class="flex-1">
+        <a
+          :href="migrationHistoryLink"
+          target="__BLANK"
+          class="normal-link flex items-center gap-x-1"
+        >
+          {{ migrationHistory.version }}
+          <heroicons-outline:external-link class="w-4 h-4" />
+        </a>
+      </div>
+    </div>
+
+    <div v-if="migrationHistory.issueId" class="flex items-center gap-x-4">
+      <label class="w-1/4 flex justify-end textlabel">
+        {{ $t("common.issue") }}
+      </label>
+      <div class="flex-1">
+        <a
+          :href="`/issue/${migrationHistory.issueId}`"
+          target="__BLANK"
+          class="normal-link flex items-center gap-x-1"
+        >
+          {{ migrationHistory.issueId }}
+          <heroicons-outline:external-link class="w-4 h-4" />
+        </a>
+      </div>
+    </div>
+
+    <div class="flex items-start gap-x-4">
+      <label class="w-1/4 flex justify-end textlabel">
+        {{ $t("common.sql") }}
+      </label>
+      <div class="flex-1">
+        <NPopover
+          :disabled="migrationHistory.statement.length < MAX_SQL_LENGTH"
+          style="max-height: 300px"
+          placement="bottom"
+          overlap
+          width="trigger"
+          scrollable
+        >
+          <highlight-code-block
+            :code="migrationHistory.statement"
+            class="whitespace-pre-wrap"
+          />
+
+          <template #trigger>
+            <div class="w-full">
+              {{ displayStatement }}
+            </div>
+          </template>
+        </NPopover>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-x-4">
+      <label class="w-1/4 flex justify-end textlabel">
+        {{ $t("common.created-at") }}
+      </label>
+      <div class="flex-1">
+        <span>{{ createdAt }}</span>
+        <span class="textinfolabel ml-1">({{ timezone }})</span>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-x-4">
+      <label class="w-1/4 flex justify-end textlabel">
+        {{ $t("common.creator") }}
+      </label>
+      <div class="flex-1">{{ migrationHistory.creator }}</div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, PropType } from "vue";
+import dayjs from "dayjs";
+import { Database, MigrationHistory } from "@/types";
+import { databaseSlug, migrationHistorySlug } from "@/utils";
+
+const props = defineProps({
+  database: {
+    type: Object as PropType<Database>,
+    required: true,
+  },
+  migrationHistory: {
+    type: Object as PropType<MigrationHistory>,
+    required: true,
+  },
+});
+
+const MAX_SQL_LENGTH = 100;
+
+const migrationHistoryLink = computed(() => {
+  const { database, migrationHistory } = props;
+  return `/db/${databaseSlug(database)}/history/${migrationHistorySlug(
+    migrationHistory.id,
+    migrationHistory.version
+  )}`;
+});
+
+const createdAt = computed(() => {
+  return dayjs(props.migrationHistory.createdTs * 1000).format(
+    "YYYY-MM-DD HH:mm:ss"
+  );
+});
+const timezone = computed(() => "UTC" + dayjs().format("ZZ"));
+
+const displayStatement = computed((): string => {
+  const { migrationHistory } = props;
+  return migrationHistory.statement.length > MAX_SQL_LENGTH
+    ? migrationHistory.statement.substring(0, MAX_SQL_LENGTH) + "..."
+    : migrationHistory.statement;
+});
+</script>

--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -3,15 +3,40 @@
     <BBTooltipButton
       type="normal"
       tooltip-mode="DISABLED-ONLY"
-      :disabled="!allowAdmin || !pitrAvailable.result"
+      class="group"
+      :disabled="pitrButtonDisabled"
       @click="openDialog"
     >
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center gap-x-2">
         <span>{{ $t("database.pitr.restore-to-point-in-time") }}</span>
         <FeatureBadge
           feature="bb.feature.disaster-recovery-pitr"
           class="text-accent"
         />
+
+        <template v-if="lastMigrationHistory && !pitrButtonDisabled">
+          <span class="border-l border-control-light pl-2 -mr-1">
+            <heroicons-outline:chevron-down />
+          </span>
+
+          <div
+            class="hidden group-hover:flex whitespace-nowrap absolute right-0 -bottom-[1px] transform translate-y-[100%] z-50 rounded-md bg-white shadow-lg"
+            @click.prevent.stop="
+              openDialog('LAST_MIGRATION_INFO', 'LAST_MIGRATION')
+            "
+          >
+            <div
+              class="flex flex-col items-end py-1"
+              role="menu"
+              aria-orientation="vertical"
+              aria-labelledby="user-menu"
+            >
+              <div class="menu-item">
+                {{ $t("database.pitr.restore-before-last-migration") }}
+              </div>
+            </div>
+          </div>
+        </template>
       </div>
       <template v-if="allowAdmin && !pitrAvailable.result" #tooltip>
         {{ pitrAvailable.message }}
@@ -27,37 +52,52 @@
   >
     <div class="w-112 flex flex-col items-center gap-4">
       <div class="w-full textinfolabel">
-        <i18n-t keypath="database.pitr.help-info" tag="p">
+        <i18n-t
+          :keypath="
+            state.mode === 'LAST_MIGRATION'
+              ? 'database.pitr.restore-before-last-migration-help-info'
+              : 'database.pitr.help-info'
+          "
+          tag="p"
+        >
           <template #link>
             <a
-              class="normal-link inline-flex items-center"
+              class="normal-link inline-flex items-center gap-x-1"
               href="https://github.com/bytebase/bytebase/blob/main/docs/design/pitr-mysql.md"
               target="__BLANK"
             >
               {{ $t("common.learn-more") }}
+              <heroicons-outline:external-link class="w-4 h-4" />
             </a>
           </template>
         </i18n-t>
       </div>
 
-      <div class="w-64 space-y-2">
-        <label class="textlabel w-full flex flex-col gap-1">
-          <span>{{ $t("database.pitr.point-in-time") }}</span>
-          <span class="text-gray-400 text-xs">{{ timezone }}</span>
-        </label>
-        <NDatePicker
-          v-model:value="state.pitrTimestampMS"
-          panel
-          type="datetime"
-          :actions="[]"
-          :time-picker-props="{
-            actions: [],
-          }"
+      <template
+        v-if="state.step === 'LAST_MIGRATION_INFO' && lastMigrationHistory"
+      >
+        <MigrationHistoryBrief
+          :database="database"
+          :migration-history="lastMigrationHistory"
         />
-      </div>
+      </template>
+
+      <template v-else>
+        <div class="w-64 space-y-2">
+          <label class="textlabel w-full flex flex-col gap-1">
+            <span>{{ $t("database.pitr.point-in-time") }}</span>
+            <span class="text-gray-400 text-xs">{{ timezone }}</span>
+          </label>
+          <NDatePicker
+            v-model:value="state.pitrTimestampMS"
+            type="datetime"
+            :disabled="state.mode === 'LAST_MIGRATION'"
+          />
+        </div>
+      </template>
 
       <div
-        class="w-full pt-6 mt-6 flex justify-end border-t border-block-border"
+        class="w-full pt-6 mt-6 flex justify-end gap-x-3 border-t border-block-border"
       >
         <button
           type="button"
@@ -67,11 +107,20 @@
           {{ $t("common.cancel") }}
         </button>
 
+        <button
+          v-if="state.step === 'LAST_MIGRATION_INFO'"
+          type="button"
+          class="btn-primary py-2 px-4"
+          @click.prevent="initLastMigrationParams"
+        >
+          {{ $t("common.next") }}
+        </button>
+
         <BBTooltipButton
+          v-if="state.step === 'PITR_FORM'"
           type="primary"
           tooltip-mode="DISABLED-ONLY"
           :disabled="!!pitrTimestampError"
-          class="ml-3"
           @click="onConfirm"
         >
           {{ $t("common.confirm") }}
@@ -110,8 +159,13 @@ import { usePITRLogic } from "@/plugins";
 import { issueSlug } from "@/utils";
 import { featureToRef } from "@/store";
 
+type Mode = "LAST_MIGRATION" | "CUSTOM";
+type Step = "LAST_MIGRATION_INFO" | "PITR_FORM";
+
 interface LocalState {
   showDatabasePITRModal: boolean;
+  mode: Mode;
+  step: Step;
   pitrTimestampMS: number;
   loading: boolean;
   showFeatureModal: boolean;
@@ -133,6 +187,8 @@ const { t } = useI18n();
 
 const state = reactive<LocalState>({
   showDatabasePITRModal: false,
+  mode: "CUSTOM",
+  step: "PITR_FORM",
   pitrTimestampMS: Date.now(),
   loading: false,
   showFeatureModal: false,
@@ -142,9 +198,12 @@ const hasPITRFeature = featureToRef("bb.feature.disaster-recovery-pitr");
 
 const timezone = computed(() => "UTC" + dayjs().format("ZZ"));
 
-const { pitrAvailable, doneBackupList, createPITRIssue } = usePITRLogic(
-  computed(() => props.database)
-);
+const { pitrAvailable, doneBackupList, lastMigrationHistory, createPITRIssue } =
+  usePITRLogic(computed(() => props.database));
+
+const pitrButtonDisabled = computed((): boolean => {
+  return !props.allowAdmin || !pitrAvailable.value.result;
+});
 
 const earliest = computed((): number => {
   if (!pitrAvailable.value) {
@@ -177,11 +236,22 @@ const resetUI = () => {
   state.loading = false;
   state.showDatabasePITRModal = false;
   state.pitrTimestampMS = Date.now();
+  state.mode = "CUSTOM";
 };
 
-const openDialog = () => {
+const openDialog = (step: Step = "PITR_FORM", mode: Mode = "CUSTOM") => {
   state.showDatabasePITRModal = true;
   state.pitrTimestampMS = Date.now();
+  state.step = step;
+  state.mode = mode;
+};
+
+const initLastMigrationParams = () => {
+  if (lastMigrationHistory.value) {
+    state.pitrTimestampMS = (lastMigrationHistory.value.createdTs - 1) * 1000;
+  }
+
+  state.step = "PITR_FORM";
 };
 
 const onConfirm = async () => {
@@ -193,12 +263,23 @@ const onConfirm = async () => {
   state.loading = true;
 
   try {
+    const issueNameParts: string[] = [
+      `Restore database [${props.database.name}]`,
+    ];
+    if (state.mode === "CUSTOM") {
+      const datetime = dayjs(state.pitrTimestampMS).format(
+        "YYYY-MM-DD HH:mm:ss"
+      );
+      issueNameParts.push(`to [${datetime} ${timezone.value}]`);
+    } else {
+      issueNameParts.push(
+        `before migration version [${lastMigrationHistory.value!.version}]`
+      );
+    }
     const issue = await createPITRIssue(
       Math.floor(state.pitrTimestampMS / 1000),
       {
-        name: `Restore database [${props.database.name}] to [${dayjs(
-          state.pitrTimestampMS
-        ).format("YYYY-MM-DD HH:mm:ss")} ${timezone.value}]`,
+        name: issueNameParts.join(" "),
       }
     );
     const slug = issueSlug(issue.name, issue.id);

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -823,7 +823,9 @@
       "minimum-supported-engine-and-version": "{engine} >= {min_version} required",
       "restore-to-point-in-time": "Restore to point in time",
       "no-earlier-than": "Restore point-in-time cannot be earlier than [{earliest}] (the earliest available backup).",
-      "no-later-than-now": "Restore point-in-time cannot be later than now."
+      "no-later-than-now": "Restore point-in-time cannot be later than now.",
+      "restore-before-last-migration": "Restore to the point before last migration",
+      "restore-before-last-migration-help-info": "@:{'database.pitr.restore-before-last-migration'}. {link}."
     },
     "show-reserved-tables": "Show Bytebase reserved tables",
     "show-reserved-databases": "Show Bytebase reserved databases",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -824,7 +824,9 @@
       "minimum-supported-engine-and-version": "需要 {engine} >= {min_version}",
       "restore-to-point-in-time": "恢复到指定时间点",
       "no-earlier-than": "恢复的时间点不能早于 [{earliest}] (最早可用的备份)。",
-      "no-later-than-now": "恢复的时间点不能晚于当前时间。"
+      "no-later-than-now": "恢复的时间点不能晚于当前时间。",
+      "restore-before-last-migration": "恢复到上次变更历史之前",
+      "restore-before-last-migration-help-info": "@:{'database.pitr.restore-before-last-migration'}。{link}。"
     },
     "show-reserved-tables": "显示 Bytebase 保留的表",
     "show-reserved-databases": "显示 Bytebase 保留的数据库",


### PR DESCRIPTION
Close BYT-965

FYI @candy2255 @changyuwong @dragonly @h3n4l @d-bytebase 

### Feature

- Support PITR to the point before the last migration. 
  - Means 1 second before the last migration history's `createdTs`.

### Screenshot

https://user-images.githubusercontent.com/2749742/181202876-27ad1df7-c81f-45cb-b65b-8a3cbd3b54a8.mov


