### PR TITLE
test(gitlab): abstract `fake.VCSProvider` for VCS integration testing

### DIFF
--- a/tests/fake/provider.go
+++ b/tests/fake/provider.go
@@ -1,0 +1,25 @@
+package fake
+
+import (
+	"net"
+)
+
+// VCSProvider is a fake implementation of a VCS provider.
+type VCSProvider interface {
+	// Run starts the server of the VCS provider.
+	Run() error
+	// Close shuts down the server of the VCS provider.
+	Close() error
+	// ListenerAddr returns listener address of the server.
+	ListenerAddr() net.Addr
+
+	// CreateRepository creates a new repository with given ID.
+	CreateRepository(id string)
+	// SendWebhookPush sends out a webhook for a push event for the repository using
+	// given payload.
+	SendWebhookPush(repositoryID string, payload []byte) error
+	// AddFiles adds given files to the repository.
+	AddFiles(repositoryID string, files map[string]string) error
+	// GetFiles returns files with given paths from the repository.
+	GetFiles(repositoryID string, filePaths ...string) (map[string]string, error)
+}

--- a/tests/sheet_vcs_test.go
+++ b/tests/sheet_vcs_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/plugin/vcs"
-	"github.com/stretchr/testify/require"
 )
 
-func TestSheetVCS(t *testing.T) {
+func TestSheetVCS_GitLab(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
@@ -50,8 +51,8 @@ func TestSheetVCS(t *testing.T) {
 	refreshToken := "refreshToken"
 	gitlabProjectID := 121
 	gitlabProjectIDStr := fmt.Sprintf("%d", gitlabProjectID)
-	// create a gitlab project.
-	ctl.gitlab.CreateProject(gitlabProjectIDStr)
+	// create a vcsProvider project.
+	ctl.vcsProvider.CreateRepository(gitlabProjectIDStr)
 	_, err = ctl.createRepository(api.RepositoryCreate{
 		VCSID:              vcs.ID,
 		ProjectID:          project.ID,
@@ -75,7 +76,7 @@ func TestSheetVCS(t *testing.T) {
 	gitFile := "sheet/all_employee.sql"
 	fileContent := "SELECT * FROM employee"
 	files[gitFile] = fileContent
-	err = ctl.gitlab.AddFiles(gitlabProjectIDStr, files)
+	err = ctl.vcsProvider.AddFiles(gitlabProjectIDStr, files)
 	a.NoError(err)
 
 	err = ctl.syncSheet(project.ID)


### PR DESCRIPTION
This PR abstracts a `fake.VCSProvider` interface out of the existing fake GitLab VCS provider implementation, it is necessary to make it possible to swap in the fake GitHub VCS provider later for the VCS integration testing.

There is no change to how existing tests are done or what is being tested.

---

Part of https://linear.app/bbteam/issue/BYT-856/add-integration-tests