### PR TITLE
refactor(tests): make `controller` accept a constructor for creating VCS provider

### DIFF
--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	resourcemysql "github.com/bytebase/bytebase/resources/mysql"
+	"github.com/bytebase/bytebase/tests/fake"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -117,7 +119,7 @@ func TestPITR(t *testing.T) {
 	port := getTestPort(t.Name())
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, port)
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, port)
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()

--- a/tests/external_pg_test.go
+++ b/tests/external_pg_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/resources/postgres"
+	"github.com/bytebase/bytebase/tests/fake"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,7 +66,7 @@ func TestBootWithExternalPg(t *testing.T) {
 
 	ctl := &controller{}
 	dataTmpDir := t.TempDir()
-	err = ctl.StartServerWithExternalPg(ctx, dataTmpDir, serverPort, externalPg.pgUser, externalPg.pgURL)
+	err = ctl.StartServerWithExternalPg(ctx, dataTmpDir, fake.NewGitLab, serverPort, externalPg.pgUser, externalPg.pgURL)
 	a.NoError(err)
 	defer ctl.Close(ctx)
 }

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -82,7 +82,7 @@ func (gl *GitLab) ListenerAddr() net.Addr {
 
 // APIURL returns the GitLab VCS provider API URL.
 func (*GitLab) APIURL(instanceURL string) string {
-	return instanceURL + "/api/v4"
+	return fmt.Sprintf("%s/api/v4", instanceURL)
 }
 
 // CreateRepository creates a GitLab project with given ID.

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -81,7 +81,7 @@ func (gl *GitLab) ListenerAddr() net.Addr {
 }
 
 // APIURL returns the GitLab VCS provider API URL.
-func (gl *GitLab) APIURL(instanceURL string) string {
+func (*GitLab) APIURL(instanceURL string) string {
 	return instanceURL + "/api/v4"
 }
 

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -80,6 +80,11 @@ func (gl *GitLab) ListenerAddr() net.Addr {
 	return gl.echo.ListenerAddr()
 }
 
+// APIURL returns the GitLab VCS provider API URL.
+func (gl *GitLab) APIURL(instanceURL string) string {
+	return instanceURL + "/api/v4"
+}
+
 // CreateRepository creates a GitLab project with given ID.
 func (gl *GitLab) CreateRepository(id string) {
 	gl.projects[id] = &projectData{

--- a/tests/fake/provider.go
+++ b/tests/fake/provider.go
@@ -12,6 +12,8 @@ type VCSProvider interface {
 	Close() error
 	// ListenerAddr returns listener address of the server.
 	ListenerAddr() net.Addr
+	// APIURL returns the API URL of the VCS provider.
+	APIURL(instanceURL string) string
 
 	// CreateRepository creates a new repository with given ID.
 	CreateRepository(id string)
@@ -23,3 +25,6 @@ type VCSProvider interface {
 	// GetFiles returns files with given paths from the repository.
 	GetFiles(repositoryID string, filePaths ...string) (map[string]string, error)
 }
+
+// VCSProviderCreator a function to create a new VCSProvider.
+type VCSProviderCreator func(port int) VCSProvider

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/resources/mysql"
+	"github.com/bytebase/bytebase/tests/fake"
+
 	ghostsql "github.com/github/gh-ost/go/sql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
@@ -69,7 +71,7 @@ func TestGhostSchemaUpdate(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()

--- a/tests/sql_review_test.go
+++ b/tests/sql_review_test.go
@@ -12,12 +12,14 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/advisor"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/resources/mysql"
-	"github.com/stretchr/testify/require"
+	"github.com/bytebase/bytebase/tests/fake"
 )
 
 func TestSQLReview(t *testing.T) {
@@ -256,7 +258,7 @@ func TestSQLReview(t *testing.T) {
 	ctl := &controller{}
 	dataDir := t.TempDir()
 	port := getTestPort(t.Name()) + 3
-	err := ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()

--- a/tests/start_test.go
+++ b/tests/start_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/tests/fake"
 )
 
 func TestServiceRestart(t *testing.T) {
@@ -13,7 +15,7 @@ func TestServiceRestart(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 
 	err = ctl.Login()
@@ -29,7 +31,7 @@ func TestServiceRestart(t *testing.T) {
 	err = ctl.Close(ctx)
 	a.NoError(err)
 
-	err = ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err = ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 	defer ctl.Close(ctx)
 

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/vcs"
 	"github.com/bytebase/bytebase/plugin/vcs/gitlab"
+	"github.com/bytebase/bytebase/tests/fake"
 )
 
 var (
@@ -29,7 +30,7 @@ func TestTenant(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -209,7 +210,7 @@ func TestTenantVCS_GitLab(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -223,8 +224,8 @@ func TestTenantVCS_GitLab(t *testing.T) {
 	vcs, err := ctl.createVCS(api.VCSCreate{
 		Name:          "TestVCS",
 		Type:          vcs.GitLabSelfHost,
-		InstanceURL:   ctl.gitURL,
-		APIURL:        ctl.gitAPIURL,
+		InstanceURL:   ctl.vcsURL,
+		APIURL:        ctl.vcsProvider.APIURL(ctl.vcsURL),
 		ApplicationID: applicationID,
 		Secret:        applicationSecret,
 	})
@@ -244,14 +245,14 @@ func TestTenantVCS_GitLab(t *testing.T) {
 	refreshToken := "refreshToken1"
 	gitlabProjectID := 121
 	gitlabProjectIDStr := fmt.Sprintf("%d", gitlabProjectID)
-	// create a vcsProvider project.
+	// Create a GitLab project.
 	ctl.vcsProvider.CreateRepository(gitlabProjectIDStr)
 	_, err = ctl.createRepository(api.RepositoryCreate{
 		VCSID:              vcs.ID,
 		ProjectID:          project.ID,
 		Name:               "Test Repository",
 		FullPath:           repositoryPath,
-		WebURL:             fmt.Sprintf("%s/%s", ctl.gitURL, repositoryPath),
+		WebURL:             fmt.Sprintf("%s/%s", ctl.vcsURL, repositoryPath),
 		BranchFilter:       "feature/foo",
 		BaseDirectory:      baseDirectory,
 		FilePathTemplate:   "{{DB_NAME}}__{{VERSION}}__{{TYPE}}__{{DESCRIPTION}}.sql",
@@ -437,7 +438,7 @@ func TestTenantDatabaseNameTemplate(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -590,7 +591,7 @@ func TestTenantVCSDatabaseNameTemplate_GitLab(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -604,8 +605,8 @@ func TestTenantVCSDatabaseNameTemplate_GitLab(t *testing.T) {
 	vcs, err := ctl.createVCS(api.VCSCreate{
 		Name:          "TestVCS",
 		Type:          vcs.GitLabSelfHost,
-		InstanceURL:   ctl.gitURL,
-		APIURL:        ctl.gitAPIURL,
+		InstanceURL:   ctl.vcsURL,
+		APIURL:        ctl.vcsProvider.APIURL(ctl.vcsURL),
 		ApplicationID: applicationID,
 		Secret:        applicationSecret,
 	})
@@ -626,14 +627,14 @@ func TestTenantVCSDatabaseNameTemplate_GitLab(t *testing.T) {
 	refreshToken := "refreshToken1"
 	gitlabProjectID := 121
 	gitlabProjectIDStr := fmt.Sprintf("%d", gitlabProjectID)
-	// create a vcsProvider project.
+	// Create a GitLab project.
 	ctl.vcsProvider.CreateRepository(gitlabProjectIDStr)
 	_, err = ctl.createRepository(api.RepositoryCreate{
 		VCSID:              vcs.ID,
 		ProjectID:          project.ID,
 		Name:               "Test Repository",
 		FullPath:           repositoryPath,
-		WebURL:             fmt.Sprintf("%s/%s", ctl.gitURL, repositoryPath),
+		WebURL:             fmt.Sprintf("%s/%s", ctl.vcsURL, repositoryPath),
 		BranchFilter:       "feature/foo",
 		BaseDirectory:      "bbtest",
 		FilePathTemplate:   "{{DB_NAME}}__{{VERSION}}__{{TYPE}}__{{DESCRIPTION}}.sql",


### PR DESCRIPTION
This PR makes the test `controller` assume no internal knowledge about a `fake.VCSProvider` implementation.