### PR TITLE
feat(frontend): UI support for gh-ost sync task progress

### DIFF
--- a/frontend/src/components/Issue/PipelineGhostFlow.vue
+++ b/frontend/src/components/Issue/PipelineGhostFlow.vue
@@ -35,17 +35,15 @@
               {{ taskNameOfTask(task) }}
             </div>
           </div>
-          <div v-if="getTaskProgress(task) > 0">
-            <BBProgressPie
-              class="w-9 h-9 text-info"
-              :thickness="2"
-              :percent="getTaskProgress(task)"
-            >
-              <template #default="{ percent }">
-                <span class="text-xs scale-90">{{ percent }}%</span>
-              </template>
-            </BBProgressPie>
-          </div>
+
+          <TaskProgressPie
+            v-if="
+              !create &&
+              task.type === 'bb.task.database.schema.update.ghost.sync'
+            "
+            :task="(task as Task)"
+            unit-key="row"
+          />
         </div>
 
         <div
@@ -76,6 +74,7 @@ import TaskStatusIcon from "./TaskStatusIcon.vue";
 import { useDatabaseStore } from "@/store";
 import { BBProgressPie } from "@/bbkit";
 import PipelineStageList from "./PipelineStageList.vue";
+import TaskProgressPie from "./TaskProgressPie.vue";
 import { useIssueLogic } from "./logic";
 
 const { t } = useI18n();
@@ -147,23 +146,6 @@ const selectedStageIdOrIndex = computed(() => {
     selectedStage.value as StageCreate
   );
 });
-
-const getTaskProgress = (task: Task | TaskCreate) => {
-  if (create.value) {
-    return 0;
-  }
-  if (task.type !== "bb.task.database.schema.update.ghost.sync") return 0;
-  const taskRun = (task as Task).taskRunList.find((run) => {
-    // TODO(Jim): find the correct taskRun which indicates the sync progress.
-    return false;
-  });
-  if (taskRun) {
-    // TODO(Jim): get progress from taskRun.result.detail
-  }
-
-  // nothing found
-  return 0;
-};
 
 const taskClass = (task: Task | TaskCreate): string[] => {
   const classes: string[] = [];

--- a/frontend/src/components/Issue/PipelineGhostFlow.vue
+++ b/frontend/src/components/Issue/PipelineGhostFlow.vue
@@ -72,7 +72,6 @@ import type {
 import { activeTask, activeTaskInStage, taskSlug } from "@/utils";
 import TaskStatusIcon from "./TaskStatusIcon.vue";
 import { useDatabaseStore } from "@/store";
-import { BBProgressPie } from "@/bbkit";
 import PipelineStageList from "./PipelineStageList.vue";
 import TaskProgressPie from "./TaskProgressPie.vue";
 import { useIssueLogic } from "./logic";

--- a/frontend/src/components/Issue/TaskProgressPie.vue
+++ b/frontend/src/components/Issue/TaskProgressPie.vue
@@ -65,6 +65,7 @@ import { computed, PropType } from "vue";
 import { NPopover } from "naive-ui";
 import type { Task, TaskProgress } from "@/types";
 import { empty } from "@/types";
+import { BBProgressPie } from "@/bbkit";
 
 type ProgressSummary = TaskProgress & {
   percent: number;

--- a/frontend/src/components/Issue/TaskProgressPie.vue
+++ b/frontend/src/components/Issue/TaskProgressPie.vue
@@ -1,0 +1,136 @@
+<template>
+  <NPopover v-if="showProgress" placement="bottom" :disabled="!showPopover">
+    <template #trigger>
+      <BBProgressPie
+        class="w-10 h-10"
+        :class="task.status === 'DONE' ? 'text-success' : 'text-info'"
+        :thickness="3"
+        :percent="progress.percent"
+      >
+        <template #default="{ percent }">
+          <span v-if="task.status !== 'DONE'" class="text-xs">
+            {{ percent }}%
+          </span>
+          <span v-else>
+            <heroicons-outline:check class="w-8 h-8" />
+          </span>
+        </template>
+      </BBProgressPie>
+    </template>
+
+    <div class="flex flex-col gap-y-2">
+      <div class="flex flex-col items-start">
+        <label class="textlabel">
+          {{
+            $t("task.progress.completed-units", {
+              units: $t(`task.progress.units.${unitKey}`),
+            })
+          }}
+        </label>
+        <span>{{ progress.completedUnit }}</span>
+      </div>
+      <div class="flex flex-col items-start">
+        <label class="textlabel">
+          {{
+            $t("task.progress.total-units", {
+              units: $t(`task.progress.units.${unitKey}`),
+            })
+          }}
+        </label>
+        <span v-if="progress.totalUnit > 0">{{ progress.totalUnit }}</span>
+        <span v-else class="text-gray-400">
+          {{ $t("task.progress.counting") }}
+        </span>
+      </div>
+      <div
+        v-if="task.status === 'RUNNING' && progress.eta > 0"
+        class="flex flex-col items-start whitespace-nowrap"
+      >
+        <label class="textlabel whitespace-nowrap">
+          <span>{{ $t("task.progress.eta") }}</span>
+          <span class="text-gray-400 text-xs">
+            UTC{{ dayjs().format("ZZ") }}
+          </span>
+        </label>
+        <span class="whitespace-nowrap">
+          {{ dayjs(progress.eta * 1000).format("YYYY-MM-DD HH:mm:ss") }}
+        </span>
+      </div>
+    </div>
+  </NPopover>
+</template>
+
+<script lang="ts" setup>
+import { computed, PropType } from "vue";
+import { NPopover } from "naive-ui";
+import type { Task, TaskProgress } from "@/types";
+import { empty } from "@/types";
+
+type ProgressSummary = TaskProgress & {
+  percent: number;
+  eta: number;
+};
+
+const props = defineProps({
+  task: {
+    type: Object as PropType<Task>,
+    required: true,
+  },
+  unitKey: {
+    type: String,
+    default: "unit",
+  },
+});
+
+const showProgress = computed((): boolean => {
+  const { status } = props.task;
+
+  return status === "PENDING" || status === "RUNNING" || status === "DONE";
+});
+
+const progress = computed((): ProgressSummary => {
+  const ZERO: ProgressSummary = {
+    ...empty("TASK_PROGRESS"),
+    percent: 0,
+    eta: 0,
+  };
+
+  const { task } = props;
+
+  if (task.status === "DONE") {
+    return { ...task.progress, percent: 100, eta: task.updatedTs };
+  }
+
+  const { progress } = task;
+  if (progress.totalUnit > 0) {
+    const completedUnit = progress.completedUnit;
+    const totalUnit = Math.max(progress.completedUnit, progress.totalUnit);
+
+    const p = completedUnit / totalUnit;
+    const percent = Math.floor(p * 100);
+
+    const result: ProgressSummary = {
+      ...task.progress,
+      totalUnit,
+      percent,
+      eta: 0,
+    };
+
+    const { updatedTs, createdTs } = progress;
+    if (updatedTs > 0 && createdTs > 0 && p > 0) {
+      const elapsedSeconds = progress.updatedTs - progress.createdTs;
+      const estimatedTotalSeconds = Math.floor(elapsedSeconds / p);
+      const eta = progress.createdTs + estimatedTotalSeconds;
+      result.eta = eta;
+    }
+
+    return result;
+  }
+
+  return ZERO;
+});
+
+const showPopover = computed((): boolean => {
+  return props.task.status !== "DONE";
+});
+</script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -264,6 +264,16 @@
       "bb-task-database-schema-update-ghost-sync": "Sync data",
       "bb-task-database-schema-update-ghost-cutover": "Switch tables",
       "bb-task-database-schema-update-ghost-drop-original-table": "Drop original table"
+    },
+    "progress": {
+      "completed-units": "Completed {units}",
+      "total-units": "Total {units}",
+      "eta": "ETA",
+      "units": {
+        "unit": "units",
+        "row": "rows"
+      },
+      "counting": "Counting"
     }
   },
   "banner": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -264,6 +264,16 @@
       "bb-task-database-schema-update-ghost-sync": "同步数据",
       "bb-task-database-schema-update-ghost-cutover": "切换表",
       "bb-task-database-schema-update-ghost-drop-original-table": "删除原始表"
+    },
+    "progress": {
+      "completed-units": "已完成{units}",
+      "total-units": "总共{units}",
+      "eta": "预计完成时间",
+      "units": {
+        "unit": "单元数",
+        "row": "行数"
+      },
+      "counting": "统计中"
     }
   },
   "banner": {

--- a/frontend/src/store/modules/task.ts
+++ b/frontend/src/store/modules/task.ts
@@ -16,6 +16,7 @@ import {
   TaskCheckRun,
   TaskId,
   TaskPatch,
+  TaskProgress,
   TaskRun,
   TaskState,
   TaskStatusPatch,
@@ -87,6 +88,23 @@ function convertTaskCheckRun(
   };
 }
 
+function convertTaskProgress(attributes: any): TaskProgress {
+  if (!attributes) return unknown("TASK_PROGRESS");
+
+  const progress: TaskProgress = { ...attributes };
+  if (typeof attributes.comment === "string") {
+    try {
+      progress.payload = JSON.parse(attributes.comment);
+    } catch {
+      progress.payload = undefined;
+    }
+  } else {
+    progress.payload = undefined;
+  }
+
+  return progress;
+}
+
 function convertPartial(
   task: ResourceObject,
   includedList: ResourceObject[]
@@ -153,6 +171,7 @@ function convertPartial(
       database = databaseStore.convert(item, includedList);
     }
   }
+  const progress = convertTaskProgress(task.attributes.progress);
 
   return {
     ...(task.attributes as Omit<
@@ -167,6 +186,7 @@ function convertPartial(
       | "taskCheckRunList"
       | "pipeline"
       | "stage"
+      | "progress"
     >),
     id: parseInt(task.id),
     creator: getPrincipalFromIncludedList(
@@ -180,6 +200,7 @@ function convertPartial(
     payload,
     instance,
     database,
+    progress,
     taskRunList,
     taskCheckRunList,
   };

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -11,7 +11,7 @@ import { Inbox } from "./inbox";
 import { Instance } from "./instance";
 import { Issue } from "./issue";
 import { Member } from "./member";
-import { Pipeline, Stage, Task } from "./pipeline";
+import { Pipeline, Stage, Task, TaskProgress } from "./pipeline";
 import { Principal } from "./principal";
 import {
   Project,
@@ -128,6 +128,7 @@ export type ResourceType =
   | "PIPELINE"
   | "POLICY"
   | "STAGE"
+  | "TASK_PROGRESS"
   | "TASK"
   | "ACTIVITY"
   | "INBOX"
@@ -154,6 +155,7 @@ interface ResourceMaker {
   (type: "PIPELINE"): Pipeline;
   (type: "POLICY"): Policy;
   (type: "STAGE"): Stage;
+  (type: "TASK_PROGRESS"): TaskProgress;
   (type: "TASK"): Task;
   (type: "ACTIVITY"): Activity;
   (type: "INBOX"): Inbox;
@@ -306,6 +308,7 @@ const makeUnknown = (type: ResourceType) => {
     hour: 0,
     dayOfWeek: 0,
     hookUrl: "",
+    retentionPeriodTs: 0,
   };
 
   const UNKNOWN_PIPELINE: Pipeline = {
@@ -362,6 +365,13 @@ const makeUnknown = (type: ResourceType) => {
     taskList: [],
   };
 
+  const UNKNOWN_TASK_PROGRESS: TaskProgress = {
+    totalUnit: 0,
+    completedUnit: 0,
+    createdTs: 0,
+    updatedTs: 0,
+  };
+
   const UNKNOWN_TASK: Task = {
     id: UNKNOWN_ID,
     pipeline: UNKNOWN_PIPELINE,
@@ -379,6 +389,7 @@ const makeUnknown = (type: ResourceType) => {
     taskRunList: [],
     taskCheckRunList: [],
     blockedBy: [],
+    progress: { ...UNKNOWN_TASK_PROGRESS },
   };
 
   const UNKNOWN_ACTIVITY: Activity = {
@@ -536,6 +547,8 @@ const makeUnknown = (type: ResourceType) => {
       return UNKNOWN_POLICY;
     case "STAGE":
       return UNKNOWN_STAGE;
+    case "TASK_PROGRESS":
+      return UNKNOWN_TASK_PROGRESS;
     case "TASK":
       return UNKNOWN_TASK;
     case "ACTIVITY":
@@ -698,6 +711,7 @@ const makeEmpty = (type: ResourceType) => {
     hour: 0,
     dayOfWeek: 0,
     hookUrl: "",
+    retentionPeriodTs: 0,
   };
 
   const EMPTY_PIPELINE: Pipeline = {
@@ -754,6 +768,13 @@ const makeEmpty = (type: ResourceType) => {
     taskList: [],
   };
 
+  const EMPTY_TASK_PROGRESS: TaskProgress = {
+    totalUnit: 0,
+    completedUnit: 0,
+    createdTs: 0,
+    updatedTs: 0,
+  };
+
   const EMPTY_TASK: Task = {
     id: EMPTY_ID,
     pipeline: EMPTY_PIPELINE,
@@ -771,6 +792,7 @@ const makeEmpty = (type: ResourceType) => {
     taskCheckRunList: [],
     earliestAllowedTs: 0,
     blockedBy: [],
+    progress: { ...EMPTY_TASK_PROGRESS },
   };
 
   const EMPTY_ACTIVITY: Activity = {
@@ -928,6 +950,8 @@ const makeEmpty = (type: ResourceType) => {
       return EMPTY_POLICY;
     case "STAGE":
       return EMPTY_STAGE;
+    case "TASK_PROGRESS":
+      return EMPTY_TASK_PROGRESS;
     case "TASK":
       return EMPTY_TASK;
     case "ACTIVITY":

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -104,6 +104,18 @@ export type TaskPayload =
   | TaskDatabasePITRCutoverPayload
   | TaskDatabasePITRDeletePayload;
 
+export type TaskProgressPayload = {
+  comment: string;
+};
+
+export type TaskProgress = {
+  totalUnit: number;
+  completedUnit: number;
+  createdTs: number;
+  updatedTs: number;
+  payload?: TaskProgressPayload; // JSON encoded
+};
+
 export type Task = {
   id: TaskId;
 
@@ -131,6 +143,9 @@ export type Task = {
 
   // Task DAG
   blockedBy: Task[];
+
+  // Task progress
+  progress: TaskProgress;
 };
 
 export type TaskCreate = {


### PR DESCRIPTION
Close BYT-1025

Backend supported by @RainbowDashy 

### Features

- [x] For gh-ost sync tasks, display a progress pie.
- [ ] The UI update depends on polling the issue. Polling an issue is quite expensive, so it will be executed every **several seconds**. In the future, we may introduce a new lightweight API endpoint to fetch a single task entity and turn the polling interval to hundreds of milliseconds. Then the progress will be more reactive.

### Screenshots

https://user-images.githubusercontent.com/2749742/181420287-04741ad8-a075-4995-8521-2ec5e1e8f425.mov


