### PR TITLE
fix(test): wait for PITR auto backup done, and update data

### DIFF
--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -160,7 +160,7 @@ func (driver *Driver) replayBinlog(ctx context.Context, originalDatabase, pitrDa
 
 	mysqlbinlogCmd := exec.CommandContext(ctx, driver.mysqlutil.GetPath(mysqlutil.MySQLBinlog), mysqlbinlogArgs...)
 	mysqlCmd := exec.CommandContext(ctx, driver.mysqlutil.GetPath(mysqlutil.MySQL), mysqlArgs...)
-	log.Debug("Start replay binlog commands",
+	log.Debug("Start replay binlog commands.",
 		zap.String("mysqlbinlog", mysqlbinlogCmd.String()),
 		zap.String("mysql", mysqlCmd.String()))
 
@@ -185,6 +185,8 @@ func (driver *Driver) replayBinlog(ctx context.Context, originalDatabase, pitrDa
 	if err := mysqlbinlogCmd.Wait(); err != nil {
 		return fmt.Errorf("error occurred while waiting for mysqlbinlog to exit: %w", err)
 	}
+
+	log.Debug("Replayed binlog successfully.")
 	return nil
 }
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1239,6 +1239,7 @@ func (ctl *controller) waitBackup(databaseID, backupID int) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
+	log.Debug("Waiting for backup.", zap.Int("id", backupID))
 	for range ticker.C {
 		backups, err := ctl.listBackups(databaseID)
 		if err != nil {


### PR DESCRIPTION
Try to fix this error: https://github.com/bytebase/bytebase/runs/7553600250?check_suite_focus=true#step:7:4658
The speculated execution is:
1. the first PITR done, backup is scheduled
2. data update
3. backup is taken

Clue: according to the log, the PITR backup's binlog coordinate is 763950, and the targetTs's binlog coordinate is 768283 (just a bit before the PITR backup), so the chosen backup is the first, which is wrong.

This test run also revealed the fact that there's a small **unrecoverable** range after each PITR (before the backup is taken).