### PR TITLE
chore: support PG ADD CHECK and DROP DATABASE

### DIFF
--- a/plugin/parser/ast/constraint_def.go
+++ b/plugin/parser/ast/constraint_def.go
@@ -20,6 +20,8 @@ const (
 	ConstraintTypeUniqueUsingIndex
 	// ConstraintTypeNotNull is the not null constraint.
 	ConstraintTypeNotNull
+	// ConstraintTypeCheck is the check constraint.
+	ConstraintTypeCheck
 )
 
 // ConstraintDef is struct for constraint definition.
@@ -49,4 +51,9 @@ type ConstraintDef struct {
 	// IndexName is a ConstraintTypePrimaryUsingIndex or ConstraintTypeUniqueUsingIndex type specific field.
 	// See https://www.postgresql.org/docs/current/sql-altertable.html.
 	IndexName string
+	// For PG, the option SkipValidation is currently only allowed for foreign key and CHECK constraints.
+	// If SkipValidation is true, the constraint will only be enforced against subsequent inserts or updates.
+	SkipValidation bool
+	// CheckExpression is the expression for the check constraint.
+	CheckExpression ExpressionNode
 }

--- a/plugin/parser/ast/drop_database_stmt.go
+++ b/plugin/parser/ast/drop_database_stmt.go
@@ -1,0 +1,9 @@
+package ast
+
+// DropDatabaseStmt is the struct for drop database statement.
+type DropDatabaseStmt struct {
+	node
+
+	DatabaseName string
+	IfExists     bool
+}

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -445,6 +445,28 @@ func TestPGDropConstraintStmt(t *testing.T) {
 func TestPGAddConstraintStmt(t *testing.T) {
 	tests := []testData{
 		{
+			stmt: "ALTER TABLE tech_book ADD CONSTRAINT check_a_bigger_than_b CHECK (a > b) NOT VALID",
+			want: []ast.Node{
+				&ast.AlterTableStmt{
+					Table: &ast.TableDef{Name: "tech_book"},
+					AlterItemList: []ast.Node{
+						&ast.AddConstraintStmt{
+							Table: &ast.TableDef{Name: "tech_book"},
+							Constraint: &ast.ConstraintDef{
+								Type:            ast.ConstraintTypeCheck,
+								Name:            "check_a_bigger_than_b",
+								SkipValidation:  true,
+								CheckExpression: &ast.UnconvertedExpressionDef{},
+							},
+						},
+					},
+				},
+			},
+			textList: []string{
+				"ALTER TABLE tech_book ADD CONSTRAINT check_a_bigger_than_b CHECK (a > b) NOT VALID",
+			},
+		},
+		{
 			stmt: "ALTER TABLE tech_book ADD CONSTRAINT uk_tech_book_id UNIQUE (id)",
 			want: []ast.Node{
 				&ast.AlterTableStmt{
@@ -791,6 +813,36 @@ func TestPGSelectStmt(t *testing.T) {
 						(SELECT * FROM t1 WHERE x LIKE b)
 				UNION
 				SELECT * FROM t`,
+			},
+		},
+	}
+
+	runTests(t, tests)
+}
+
+func TestPGDropDatabaseStmt(t *testing.T) {
+	tests := []testData{
+		{
+			stmt: "DROP DATABASE test",
+			want: []ast.Node{
+				&ast.DropDatabaseStmt{
+					DatabaseName: "test",
+				},
+			},
+			textList: []string{
+				"DROP DATABASE test",
+			},
+		},
+		{
+			stmt: "DROP DATABASE IF EXISTS test",
+			want: []ast.Node{
+				&ast.DropDatabaseStmt{
+					DatabaseName: "test",
+					IfExists:     true,
+				},
+			},
+			textList: []string{
+				"DROP DATABASE IF EXISTS test",
 			},
 		},
 	}


### PR DESCRIPTION
It's for the SCHEMA COMPATIBILITY rule.