### PR TITLE
fix(frontend): auto adjust textarea height

### DIFF
--- a/frontend/src/components/Issue/IssueDescriptionPanel.vue
+++ b/frontend/src/components/Issue/IssueDescriptionPanel.vue
@@ -137,7 +137,8 @@ watch(
     nextTick(() => {
       sizeToFit(editDescriptionTextArea.value);
     });
-  }
+  },
+  { immediate: true }
 );
 
 const beginEdit = () => {


### PR DESCRIPTION
Fix: when the page is loaded, the textarea's height should be auto-adjusted.

Thanks for the reporting from @dragonly 