### PR TITLE
feat: share gh-ost states between sync and cutover task

### DIFF
--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -53,7 +53,6 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 		return true, nil, fmt.Errorf("failed to parse table name from statement, error: %w", err)
 	}
 
-	socketFilename := getSocketFilename(syncTaskID, task.Database.ID, task.Database.Name, tableName)
 	postponeFilename := getPostponeFlagFilename(syncTaskID, task.Database.ID, task.Database.Name, tableName)
 
 	value, ok := server.TaskScheduler.sharedTaskState.Load(syncTaskID)

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -70,7 +70,7 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 	return cutover(ctx, server, task, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, socketFilename, postponeFilename, sharedGhost.migrator, sharedGhost.errCh)
 }
 
-func cutover(ctx context.Context, server *Server, task *api.Task, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, socketFilename, postponeFilename string, migrator *logic.Migrator, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
+func cutover(ctx context.Context, server *Server, task *api.Task, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, socketFilename, postponeFilename string, _ *logic.Migrator, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
 	statement = strings.TrimSpace(statement)
 
 	mi, err := preMigration(ctx, server, task, db.Migrate, statement, schemaVersion, vcsPushEvent)

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -61,7 +61,7 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 	}
 	sharedGhost := value.(sharedGhostState)
 
-	defer server.TaskScheduler.sharedTaskState.Delete(syncTaskID)
+	server.TaskScheduler.sharedTaskState.Delete(syncTaskID)
 
 	return cutover(ctx, server, task, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, postponeFilename, sharedGhost.errCh)
 }

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -68,7 +68,7 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 	return cutover(ctx, server, task, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, socketFilename, postponeFilename, sharedGhost.migrator, sharedGhost.errCh)
 }
 
-func cutover(ctx context.Context, server *Server, task *api.Task, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, socketFilename, postponeFilename string, _ *logic.Migrator, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
+func cutover(ctx context.Context, server *Server, task *api.Task, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, socketFilename, postponeFilename string, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
 	statement = strings.TrimSpace(statement)
 
 	mi, err := preMigration(ctx, server, task, db.Migrate, statement, schemaVersion, vcsPushEvent)

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -61,7 +61,7 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 	if !ok {
 		return true, nil, fmt.Errorf("failed to get gh-ost state from sync task")
 	}
-	sharedGhost := value.(ghostState)
+	sharedGhost := value.(sharedGhostState)
 
 	defer server.TaskScheduler.sharedTaskState.Delete(syncTaskID)
 

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/github/gh-ost/go/logic"
 	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/api"
@@ -65,10 +64,10 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 
 	defer server.TaskScheduler.sharedTaskState.Delete(syncTaskID)
 
-	return cutover(ctx, server, task, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, socketFilename, postponeFilename, sharedGhost.migrator, sharedGhost.errCh)
+	return cutover(ctx, server, task, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, postponeFilename, sharedGhost.errCh)
 }
 
-func cutover(ctx context.Context, server *Server, task *api.Task, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, socketFilename, postponeFilename string, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
+func cutover(ctx context.Context, server *Server, task *api.Task, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, postponeFilename string, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
 	statement = strings.TrimSpace(statement)
 
 	mi, err := preMigration(ctx, server, task, db.Migrate, statement, schemaVersion, vcsPushEvent)

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -122,15 +122,6 @@ func cutover(ctx context.Context, server *Server, task *api.Task, statement, sch
 			return -1, "", fmt.Errorf("failed to run gh-ost migration, err: %w", migrationErr)
 		}
 
-		ticker := time.NewTicker(time.Second * 1)
-		defer ticker.Stop()
-
-		for range ticker.C {
-			if _, err := os.Stat(socketFilename); err != nil {
-				break
-			}
-		}
-
 		var afterSchemaBuf bytes.Buffer
 		if _, err := executor.Dump(ctx, mi.Database, &afterSchemaBuf, true /*schemaOnly*/); err != nil {
 			return -1, "", util.FormatError(err)

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -73,7 +73,7 @@ func getTableNameFromStatement(statement string) (string, error) {
 	return parser.GetExplicitTable(), nil
 }
 
-type ghostState struct {
+type sharedGhostState struct {
 	migrator *logic.Migrator
 	errCh    <-chan error
 }
@@ -257,7 +257,7 @@ func (exec *SchemaUpdateGhostSyncTaskExecutor) runGhostMigration(_ context.Conte
 
 	select {
 	case <-syncDone:
-		server.TaskScheduler.sharedTaskState.Store(task.ID, ghostState{migrator: migrator, errCh: migrationError})
+		server.TaskScheduler.sharedTaskState.Store(task.ID, sharedGhostState{migrator: migrator, errCh: migrationError})
 		return true, &api.TaskRunResultPayload{Detail: "sync done"}, nil
 	case err := <-migrationError:
 		return true, nil, err

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -253,6 +253,9 @@ func (exec *SchemaUpdateGhostSyncTaskExecutor) runGhostMigration(_ context.Conte
 			return
 		}
 		migrationError <- nil
+		// we send to migrationError channel anyway because
+		// before syncDone, the gh-ost sync task will receive it.
+		// after syncDone, the gh-ost cutover task will receive it.
 	}()
 
 	select {

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -264,7 +264,7 @@ func (exec *SchemaUpdateGhostSyncTaskExecutor) runGhostMigration(_ context.Conte
 
 	select {
 	case <-syncDone:
-		server.TaskScheduler.sharedGhost.Store(task.ID, ghostState{migrator: migrator, errCh: sharedErrCh})
+		server.TaskScheduler.sharedTaskState.Store(task.ID, ghostState{migrator: migrator, errCh: sharedErrCh})
 		return true, &api.TaskRunResultPayload{Detail: "sync done"}, nil
 	case err := <-syncError:
 		return true, nil, err

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -246,16 +246,15 @@ func (exec *SchemaUpdateGhostSyncTaskExecutor) runGhostMigration(_ context.Conte
 	}(ctx)
 
 	go func() {
-		err := migrator.Migrate()
-		if err != nil {
+		if err := migrator.Migrate(); err != nil {
 			log.Error("failed to run gh-ost migration", zap.Error(err))
 			migrationError <- err
 			return
 		}
 		migrationError <- nil
-		// we send to migrationError channel anyway because
-		// before syncDone, the gh-ost sync task will receive it.
-		// after syncDone, the gh-ost cutover task will receive it.
+		// we send to migrationError channel anyway because:
+		// 1. before syncDone, the gh-ost sync task will receive it.
+		// 2. after syncDone, the gh-ost cutover task will receive it.
 	}()
 
 	select {

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -33,11 +33,8 @@ type TaskScheduler struct {
 	executorGetters  map[api.TaskType]func() TaskExecutor
 	runningExecutors map[int]TaskExecutor
 	taskProgress     sync.Map // map[taskID]api.Progress
-	// sharedGhost is to share states between gh-ost sync and cutover task.
-	// inserted by sync task.
-	// deleted by cutover task.
-	sharedGhost sync.Map // map[taskID]ghostState
-	server      *Server
+	sharedTaskState  sync.Map // map[taskID]interface{}
+	server           *Server
 }
 
 // Run will run the task scheduler.

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -32,8 +32,12 @@ func NewTaskScheduler(server *Server) *TaskScheduler {
 type TaskScheduler struct {
 	executorGetters  map[api.TaskType]func() TaskExecutor
 	runningExecutors map[int]TaskExecutor
-	taskProgress     sync.Map
-	server           *Server
+	taskProgress     sync.Map // map[taskID]api.Progress
+	// sharedGhost is to share states between gh-ost sync and cutover task.
+	// inserted by sync task.
+	// deleted by cutover task.
+	sharedGhost sync.Map // map[taskID]ghostState
+	server      *Server
 }
 
 // Run will run the task scheduler.


### PR DESCRIPTION
This PR shares some states between gh-ost sync and cutover task because after the migration_history insertion logic was moved to the cutover task, we need some mechanism to know if the migration succeeds.

Close BYT-1001

By the way, naming is hard as hell.