### PR TITLE
feat(PITR): download the latest binlog file in backup runner

### DIFF
--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -243,7 +243,7 @@ func (r *BackupRunner) downloadBinlogFilesForInstance(ctx context.Context, insta
 		return
 	}
 	mysqlDriver.SetUpForPITR(mysqlutil, binlogDir)
-	if err := mysqlDriver.FetchAllBinlogFiles(ctx, false /* downloadLatestBinlogFile */); err != nil {
+	if err := mysqlDriver.FetchAllBinlogFiles(ctx, true /* downloadLatestBinlogFile */); err != nil {
 		log.Error("Failed to download all binlog files for instance", zap.String("instance", instance.Name), zap.Error(err))
 		return
 	}


### PR DESCRIPTION
Currently, we only download the latest backup if the user creates a PITR issue (which is a very rare situation). This behavior introduces the risk that the MySQL server is down and we lost the latest backup forever.

This PR downloads the latest (partial) binlog file in the backup runner periodically. The partial file is fine because a later download will always re-download the incomplete part.