### PR TITLE
refactor: verify binlog checksum events and do not remove incomplete binlog files

### DIFF
--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -131,6 +131,8 @@ func (driver *Driver) replayBinlog(ctx context.Context, originalDatabase, pitrDa
 
 	// Extract the SQL statements from the binlog and replay them to the pitrDatabase via the mysql client by pipe.
 	mysqlbinlogArgs := []string{
+		// Verify checksum binlog events.
+		"--verify-binlog-checksum",
 		// Disable binary logging.
 		"--disable-log-bin",
 		// Create rewrite rules for databases when playing back from logs written in row-based format, so that we can apply the binlog to PITR database instead of the original database.
@@ -583,6 +585,8 @@ func (driver *Driver) downloadBinlogFile(ctx context.Context, binlogFileToDownlo
 	args := []string{
 		binlogFileToDownload.Name,
 		"--read-from-remote-server",
+		// Verify checksum binlog events.
+		"--verify-binlog-checksum",
 		"--raw",
 		"--host", driver.connCfg.Host,
 		"--user", driver.connCfg.Username,
@@ -762,6 +766,8 @@ func (driver *Driver) parseLocalBinlogFirstEventTs(ctx context.Context, fileName
 	args := []string{
 		// Local binlog file path.
 		path.Join(driver.binlogDir, fileName),
+		// Verify checksum binlog events.
+		"--verify-binlog-checksum",
 		// Tell mysqlbinlog to suppress the BINLOG statements for row events, which reduces the unneeded output.
 		"--base64-output=DECODE-ROWS",
 	}
@@ -803,6 +809,8 @@ func (driver *Driver) getBinlogEventPositionAtOrAfterTs(ctx context.Context, bin
 	args := []string{
 		// Local binlog file path.
 		path.Join(driver.binlogDir, binlogFile.Name),
+		// Verify checksum binlog events.
+		"--verify-binlog-checksum",
 		// Tell mysqlbinlog to suppress the BINLOG statements for row events, which reduces the unneeded output.
 		"--base64-output=DECODE-ROWS",
 		// Instruct mysqlbinlog to start output only after encountering the first binlog event with timestamp equal or after targetTs.

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -606,7 +606,8 @@ func (driver *Driver) downloadBinlogFile(ctx context.Context, binlogFileToDownlo
 	log.Debug("Downloading binlog files using mysqlbinlog", zap.String("cmd", cmd.String()))
 	resultFilePath := filepath.Join(resultFileDir, binlogFileToDownload.Name)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("executing mysqlbinlog fails, error: %w", err)
+		log.Error("Failed to execute mysqlbinlog binary", zap.Error(err))
+		return fmt.Errorf("failed to execute mysqlbinlog binary, error: %w", err)
 	}
 
 	log.Debug("Checking downloaded binlog file stat", zap.String("path", resultFilePath))


### PR DESCRIPTION
Reasons:
1. The written bytes are checked with crc32 checksum, so it’s just **incomplete**.
2. Retry download will complete the file content by rewriting the existing bytes and appending new bytes to the end.