### PR TITLE
chore: golangci-lint skip cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           version: v1.45.2
           args: -v
+          skip-cache: true
 
   # Copied from build-artifacts-and-draft-release.yml, should be consistent if updating build-artifacts-and-draft-release.yml.
   release-dry-run:


### PR DESCRIPTION
Currently, the output contains 30k+ garbage like this: https://github.com/bytebase/bytebase/runs/7573944337?check_suite_focus=true
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/8433465/181697514-fd60c576-735f-45b1-89eb-01dadfd28f20.png">

After this PR: https://github.com/bytebase/bytebase/runs/7573980270?check_suite_focus=true
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/8433465/181697642-43401ac5-c582-4ea7-90bd-0cbf87374a8c.png">

Guess the root cause is that we have already enabled cache in `actions/setup-go`.