### PR TITLE
refactor: PITR tests

### DIFF
--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -112,59 +112,6 @@ const (
 	numRowsTime2 = 30
 )
 
-func setUpForPITRTest(t *testing.T, ctl *controller, port, envID int, project *api.Project) (*sql.DB, *api.Database, func()) {
-	a := require.New(t)
-
-	baseName := strings.ReplaceAll(t.Name(), " ", "")
-	baseName = strings.ReplaceAll(baseName, "/", "")
-	databaseName := baseName + "Database"
-
-	_, stopInstance := resourcemysql.SetupTestInstance(t, port)
-	connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
-	instance, err := ctl.addInstance(api.InstanceCreate{
-		EnvironmentID: envID,
-		Name:          baseName + "Instance",
-		Engine:        db.MySQL,
-		Host:          connCfg.Host,
-		Port:          connCfg.Port,
-		Username:      connCfg.Username,
-	})
-	a.NoError(err)
-
-	err = ctl.createDatabase(project, instance, databaseName, nil)
-	a.NoError(err)
-
-	databases, err := ctl.getDatabases(api.DatabaseFind{
-		InstanceID: &instance.ID,
-	})
-	a.NoError(err)
-	a.Equal(1, len(databases))
-	database := databases[0]
-
-	err = ctl.disableAutomaticBackup(database.ID)
-	a.NoError(err)
-
-	mysqlDB, _ := initPITRDB(t, databaseName, port)
-
-	insertRangeData(t, mysqlDB, 0, numRowsTime0)
-
-	log.Debug("Create a full backup")
-	backup, err := ctl.createBackup(api.BackupCreate{
-		DatabaseID:     database.ID,
-		Name:           "first-backup",
-		Type:           api.BackupTypeManual,
-		StorageBackend: api.BackupStorageBackendLocal,
-	})
-	a.NoError(err)
-	err = ctl.waitBackup(database.ID, backup.ID)
-	a.NoError(err)
-
-	return mysqlDB, database, func() {
-		stopInstance()
-		mysqlDB.Close()
-	}
-}
-
 func TestPITR(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
@@ -206,6 +153,7 @@ func TestPITR(t *testing.T) {
 	a.NoError(err)
 
 	t.Run("Buggy Application", func(t *testing.T) {
+		a := require.New(t)
 		port := getTestPort(t.Name())
 		mysqlDB, database, cleanFn := setUpForPITRTest(t, ctl, port, prodEnvironment.ID, project)
 		defer cleanFn()
@@ -214,18 +162,7 @@ func TestPITR(t *testing.T) {
 
 		ctxUpdateRow, cancelUpdateRow := context.WithCancel(ctx)
 		targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
-		createCtx, err := json.Marshal(&api.PITRContext{
-			DatabaseID:    database.ID,
-			PointInTimeTs: targetTs,
-		})
-		a.NoError(err)
-		issue, err := ctl.createIssue(api.IssueCreate{
-			ProjectID:     project.ID,
-			Name:          fmt.Sprintf("Restore database %s to the time %d", database.Name, targetTs),
-			Type:          api.IssueDatabasePITR,
-			AssigneeID:    project.Creator.ID,
-			CreateContext: string(createCtx),
-		})
+		issue, err := createPITRIssue(ctl, project, database, targetTs)
 		a.NoError(err)
 
 		// Restore stage.
@@ -248,75 +185,22 @@ func TestPITR(t *testing.T) {
 	})
 
 	t.Run("Schema Migration Failure", func(t *testing.T) {
-		log.Debug(t.Name())
-		databaseName := "schema_migration_failure"
-
+		a := require.New(t)
 		port := getTestPort(t.Name())
-		_, stopFn := resourcemysql.SetupTestInstance(t, port)
-		defer stopFn()
-
-		connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
-		instance, err := ctl.addInstance(api.InstanceCreate{
-			EnvironmentID: prodEnvironment.ID,
-			Name:          "SchemaMigrationFailureInstance",
-			Engine:        db.MySQL,
-			Host:          connCfg.Host,
-			Port:          connCfg.Port,
-			Username:      connCfg.Username,
-		})
-		a.NoError(err)
-
-		err = ctl.createDatabase(project, instance, databaseName, nil)
-		a.NoError(err)
-
-		databases, err := ctl.getDatabases(api.DatabaseFind{
-			InstanceID: &instance.ID,
-		})
-		a.NoError(err)
-		a.Equal(1, len(databases))
-		database := databases[0]
-
-		err = ctl.disableAutomaticBackup(database.ID)
-		a.NoError(err)
-
-		mysqlDB, _ := initPITRDB(t, databaseName, port)
-		defer mysqlDB.Close()
-
-		insertRangeData(t, mysqlDB, 0, numRowsTime0)
-
-		log.Debug("Create a full backup")
-		backup, err := ctl.createBackup(api.BackupCreate{
-			DatabaseID:     database.ID,
-			Name:           "first-backup",
-			Type:           api.BackupTypeManual,
-			StorageBackend: api.BackupStorageBackendLocal,
-		})
-		a.NoError(err)
-		err = ctl.waitBackup(database.ID, backup.ID)
-		a.NoError(err)
+		mysqlDB, database, cleanFn := setUpForPITRTest(t, ctl, port, prodEnvironment.ID, project)
+		defer cleanFn()
 
 		insertRangeData(t, mysqlDB, numRowsTime0, numRowsTime1)
 
 		ctxUpdateRow, cancelUpdateRow := context.WithCancel(ctx)
-		targetTs := startUpdateRow(ctxUpdateRow, t, databaseName, port) + 1
+		targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
 
 		dropColumnStmt := `ALTER TABLE tbl1 DROP COLUMN id;`
 		log.Debug("mimics schema migration", zap.String("statement", dropColumnStmt))
 		_, err = mysqlDB.ExecContext(ctx, dropColumnStmt)
 		a.NoError(err)
 
-		createCtx, err := json.Marshal(&api.PITRContext{
-			DatabaseID:    database.ID,
-			PointInTimeTs: targetTs,
-		})
-		a.NoError(err)
-		issue, err := ctl.createIssue(api.IssueCreate{
-			ProjectID:     project.ID,
-			Name:          fmt.Sprintf("Restore database %s to the time %d", databaseName, targetTs),
-			Type:          api.IssueDatabasePITR,
-			AssigneeID:    project.Creator.ID,
-			CreateContext: string(createCtx),
-		})
+		issue, err := createPITRIssue(ctl, project, database, targetTs)
 		a.NoError(err)
 
 		// Restore stage.
@@ -333,69 +217,27 @@ func TestPITR(t *testing.T) {
 		a.NoError(err)
 		a.Equal(api.TaskDone, status)
 
-		validateTbl0(t, mysqlDB, databaseName, numRowsTime1)
-		validateTbl1(t, mysqlDB, databaseName, numRowsTime1)
-		validateTableUpdateRow(t, mysqlDB, databaseName)
+		validateTbl0(t, mysqlDB, database.Name, numRowsTime1)
+		validateTbl1(t, mysqlDB, database.Name, numRowsTime1)
+		validateTableUpdateRow(t, mysqlDB, database.Name)
 	})
 
 	t.Run("Drop Database", func(t *testing.T) {
-		log.Debug(t.Name())
-		databaseName := "drop_database"
-
+		a := require.New(t)
 		port := getTestPort(t.Name())
-		_, stopFn := resourcemysql.SetupTestInstance(t, port)
-		defer stopFn()
-
-		connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
-		instance, err := ctl.addInstance(api.InstanceCreate{
-			EnvironmentID: prodEnvironment.ID,
-			Name:          "DropDatabaseInstance",
-			Engine:        db.MySQL,
-			Host:          connCfg.Host,
-			Port:          connCfg.Port,
-			Username:      connCfg.Username,
-		})
-		a.NoError(err)
-
-		err = ctl.createDatabase(project, instance, databaseName, nil)
-		a.NoError(err)
-
-		databases, err := ctl.getDatabases(api.DatabaseFind{
-			InstanceID: &instance.ID,
-		})
-		a.NoError(err)
-		a.Equal(1, len(databases))
-		database := databases[0]
-
-		err = ctl.disableAutomaticBackup(database.ID)
-		a.NoError(err)
-
-		mysqlDB, _ := initPITRDB(t, databaseName, port)
-		defer mysqlDB.Close()
-
-		insertRangeData(t, mysqlDB, 0, numRowsTime0)
-
-		log.Debug("Create a full backup")
-		backup, err := ctl.createBackup(api.BackupCreate{
-			DatabaseID:     database.ID,
-			Name:           "first-backup",
-			Type:           api.BackupTypeManual,
-			StorageBackend: api.BackupStorageBackendLocal,
-		})
-		a.NoError(err)
-		err = ctl.waitBackup(database.ID, backup.ID)
-		a.NoError(err)
+		mysqlDB, database, cleanFn := setUpForPITRTest(t, ctl, port, prodEnvironment.ID, project)
+		defer cleanFn()
 
 		insertRangeData(t, mysqlDB, numRowsTime0, numRowsTime1)
 
 		time.Sleep(1 * time.Second)
 		targetTs := time.Now().Unix()
 
-		dropStmt := fmt.Sprintf(`DROP DATABASE %s;`, databaseName)
+		dropStmt := fmt.Sprintf(`DROP DATABASE %s;`, database.Name)
 		_, err = mysqlDB.ExecContext(ctx, dropStmt)
 		a.NoError(err)
 
-		dbRows, err := mysqlDB.Query(fmt.Sprintf(`SHOW DATABASES LIKE '%s';`, databaseName))
+		dbRows, err := mysqlDB.Query(fmt.Sprintf(`SHOW DATABASES LIKE '%s';`, database.Name))
 		a.NoError(err)
 		defer dbRows.Close()
 		for dbRows.Next() {
@@ -406,18 +248,7 @@ func TestPITR(t *testing.T) {
 		}
 		a.NoError(dbRows.Err())
 
-		createCtx, err := json.Marshal(&api.PITRContext{
-			DatabaseID:    database.ID,
-			PointInTimeTs: targetTs,
-		})
-		a.NoError(err)
-		issue, err := ctl.createIssue(api.IssueCreate{
-			ProjectID:     project.ID,
-			Name:          fmt.Sprintf("Restore database %s to the time %d", databaseName, targetTs),
-			Type:          api.IssueDatabasePITR,
-			AssigneeID:    project.Creator.ID,
-			CreateContext: string(createCtx),
-		})
+		issue, err := createPITRIssue(ctl, project, database, targetTs)
 		a.NoError(err)
 
 		// Restore stage.
@@ -433,69 +264,27 @@ func TestPITR(t *testing.T) {
 		a.NoError(err)
 		a.Equal(api.TaskDone, status)
 
-		validateTbl0(t, mysqlDB, databaseName, numRowsTime1)
-		validateTbl1(t, mysqlDB, databaseName, numRowsTime1)
-		validateTableUpdateRow(t, mysqlDB, databaseName)
+		validateTbl0(t, mysqlDB, database.Name, numRowsTime1)
+		validateTbl1(t, mysqlDB, database.Name, numRowsTime1)
+		validateTableUpdateRow(t, mysqlDB, database.Name)
 	})
 
 	t.Run("Case Sensitive", func(t *testing.T) {
-		log.Debug(t.Name())
-		databaseName := "CASE_sensitive"
-
+		a := require.New(t)
 		port := getTestPort(t.Name())
-		_, stopFn := resourcemysql.SetupTestInstance(t, port)
-		defer stopFn()
-
-		connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
-		instance, err := ctl.addInstance(api.InstanceCreate{
-			EnvironmentID: prodEnvironment.ID,
-			Name:          "DropSensitiveInstance",
-			Engine:        db.MySQL,
-			Host:          connCfg.Host,
-			Port:          connCfg.Port,
-			Username:      connCfg.Username,
-		})
-		a.NoError(err)
-
-		err = ctl.createDatabase(project, instance, databaseName, nil)
-		a.NoError(err)
-
-		databases, err := ctl.getDatabases(api.DatabaseFind{
-			InstanceID: &instance.ID,
-		})
-		a.NoError(err)
-		a.Equal(1, len(databases))
-		database := databases[0]
-
-		err = ctl.disableAutomaticBackup(database.ID)
-		a.NoError(err)
-
-		mysqlDB, _ := initPITRDB(t, databaseName, port)
-		defer mysqlDB.Close()
-
-		insertRangeData(t, mysqlDB, 0, numRowsTime0)
-
-		log.Debug("Create a full backup")
-		backup, err := ctl.createBackup(api.BackupCreate{
-			DatabaseID:     database.ID,
-			Name:           "first-backup",
-			Type:           api.BackupTypeManual,
-			StorageBackend: api.BackupStorageBackendLocal,
-		})
-		a.NoError(err)
-		err = ctl.waitBackup(database.ID, backup.ID)
-		a.NoError(err)
+		mysqlDB, database, cleanFn := setUpForPITRTest(t, ctl, port, prodEnvironment.ID, project)
+		defer cleanFn()
 
 		insertRangeData(t, mysqlDB, numRowsTime0, numRowsTime1)
 
 		time.Sleep(1 * time.Second)
 		targetTs := time.Now().Unix()
 
-		dropStmt := fmt.Sprintf(`DROP DATABASE %s;`, databaseName)
+		dropStmt := fmt.Sprintf(`DROP DATABASE %s;`, database.Name)
 		_, err = mysqlDB.ExecContext(ctx, dropStmt)
 		a.NoError(err)
 
-		dbRows, err := mysqlDB.Query(fmt.Sprintf(`SHOW DATABASES LIKE '%s';`, databaseName))
+		dbRows, err := mysqlDB.Query(fmt.Sprintf(`SHOW DATABASES LIKE '%s';`, database.Name))
 		a.NoError(err)
 		defer dbRows.Close()
 		for dbRows.Next() {
@@ -506,18 +295,7 @@ func TestPITR(t *testing.T) {
 		}
 		a.NoError(dbRows.Err())
 
-		createCtx, err := json.Marshal(&api.PITRContext{
-			DatabaseID:    database.ID,
-			PointInTimeTs: targetTs,
-		})
-		a.NoError(err)
-		issue, err := ctl.createIssue(api.IssueCreate{
-			ProjectID:     project.ID,
-			Name:          fmt.Sprintf("Restore database %s to the time %d", databaseName, targetTs),
-			Type:          api.IssueDatabasePITR,
-			AssigneeID:    project.Creator.ID,
-			CreateContext: string(createCtx),
-		})
+		issue, err := createPITRIssue(ctl, project, database, targetTs)
 		a.NoError(err)
 
 		// Restore stage.
@@ -533,75 +311,22 @@ func TestPITR(t *testing.T) {
 		a.NoError(err)
 		a.Equal(api.TaskDone, status)
 
-		validateTbl0(t, mysqlDB, databaseName, numRowsTime1)
-		validateTbl1(t, mysqlDB, databaseName, numRowsTime1)
-		validateTableUpdateRow(t, mysqlDB, databaseName)
+		validateTbl0(t, mysqlDB, database.Name, numRowsTime1)
+		validateTbl1(t, mysqlDB, database.Name, numRowsTime1)
+		validateTableUpdateRow(t, mysqlDB, database.Name)
 	})
 
 	t.Run("PITR Twice", func(t *testing.T) {
-		log.Debug(t.Name())
-		databaseName := "pitr_twice"
-
+		a := require.New(t)
 		port := getTestPort(t.Name())
-		_, stopFn := resourcemysql.SetupTestInstance(t, port)
-		defer stopFn()
-
-		connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
-		instance, err := ctl.addInstance(api.InstanceCreate{
-			EnvironmentID: prodEnvironment.ID,
-			Name:          "PITRTwiceInstance",
-			Engine:        db.MySQL,
-			Host:          connCfg.Host,
-			Port:          connCfg.Port,
-			Username:      connCfg.Username,
-		})
-		a.NoError(err)
-
-		err = ctl.createDatabase(project, instance, databaseName, nil)
-		a.NoError(err)
-
-		databases, err := ctl.getDatabases(api.DatabaseFind{
-			InstanceID: &instance.ID,
-		})
-		a.NoError(err)
-		a.Equal(1, len(databases))
-		database := databases[0]
-
-		err = ctl.disableAutomaticBackup(database.ID)
-		a.NoError(err)
-
-		mysqlDB, _ := initPITRDB(t, databaseName, port)
-		defer mysqlDB.Close()
-
-		insertRangeData(t, mysqlDB, 0, numRowsTime0)
-
-		log.Debug("Create a full backup")
-		backup, err := ctl.createBackup(api.BackupCreate{
-			DatabaseID:     database.ID,
-			Name:           "first-backup",
-			Type:           api.BackupTypeManual,
-			StorageBackend: api.BackupStorageBackendLocal,
-		})
-		a.NoError(err)
-		err = ctl.waitBackup(database.ID, backup.ID)
-		a.NoError(err)
+		mysqlDB, database, cleanFn := setUpForPITRTest(t, ctl, port, prodEnvironment.ID, project)
+		defer cleanFn()
 
 		log.Debug("Creating issue for the first PITR.")
 		insertRangeData(t, mysqlDB, numRowsTime0, numRowsTime1)
 		ctxUpdateRow, cancelUpdateRow := context.WithCancel(ctx)
-		targetTs := startUpdateRow(ctxUpdateRow, t, databaseName, port) + 1
-		pitrIssueCtx, err := json.Marshal(&api.PITRContext{
-			DatabaseID:    database.ID,
-			PointInTimeTs: targetTs,
-		})
-		a.NoError(err)
-		issue, err := ctl.createIssue(api.IssueCreate{
-			ProjectID:     project.ID,
-			Name:          fmt.Sprintf("Restore database %s to the time %d", databaseName, targetTs),
-			Type:          api.IssueDatabasePITR,
-			AssigneeID:    project.Creator.ID,
-			CreateContext: string(pitrIssueCtx),
-		})
+		targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
+		issue, err := createPITRIssue(ctl, project, database, targetTs)
 		a.NoError(err)
 
 		// Restore stage.
@@ -618,9 +343,9 @@ func TestPITR(t *testing.T) {
 		a.NoError(err)
 		a.Equal(api.TaskDone, status)
 
-		validateTbl0(t, mysqlDB, databaseName, numRowsTime1)
-		validateTbl1(t, mysqlDB, databaseName, numRowsTime1)
-		validateTableUpdateRow(t, mysqlDB, databaseName)
+		validateTbl0(t, mysqlDB, database.Name, numRowsTime1)
+		validateTbl1(t, mysqlDB, database.Name, numRowsTime1)
+		validateTableUpdateRow(t, mysqlDB, database.Name)
 		log.Debug("First PITR done.")
 
 		log.Debug("Wait for the first PITR auto backup to finish.")
@@ -633,26 +358,15 @@ func TestPITR(t *testing.T) {
 		err = ctl.waitBackup(database.ID, backups[0].ID)
 		a.NoError(err)
 
-		log.Debug("Creating issue for the first PITR.")
+		log.Debug("Creating issue for the second PITR.")
 		ctxUpdateRow, cancelUpdateRow = context.WithCancel(ctx)
-		targetTs = startUpdateRow(ctxUpdateRow, t, databaseName, port) + 1
+		targetTs = startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
 		insertRangeData(t, mysqlDB, numRowsTime1, numRowsTime2)
-		pitrIssueCtx, err = json.Marshal(&api.PITRContext{
-			DatabaseID:    database.ID,
-			PointInTimeTs: targetTs,
-		})
-		a.NoError(err)
-		issue, err = ctl.createIssue(api.IssueCreate{
-			ProjectID:     project.ID,
-			Name:          fmt.Sprintf("Restore database %s to the time %d", databaseName, targetTs),
-			Type:          api.IssueDatabasePITR,
-			AssigneeID:    project.Creator.ID,
-			CreateContext: string(pitrIssueCtx),
-		})
+		issue2, err := createPITRIssue(ctl, project, database, targetTs)
 		a.NoError(err)
 
 		// Restore stage.
-		status, err = ctl.waitIssueNextTaskWithTaskApproval(issue.ID)
+		status, err = ctl.waitIssueNextTaskWithTaskApproval(issue2.ID)
 		a.NoError(err)
 		a.Equal(api.TaskDone, status)
 
@@ -661,78 +375,25 @@ func TestPITR(t *testing.T) {
 		time.Sleep(time.Second)
 
 		// Cutover stage.
-		status, err = ctl.waitIssueNextTaskWithTaskApproval(issue.ID)
+		status, err = ctl.waitIssueNextTaskWithTaskApproval(issue2.ID)
 		a.NoError(err)
 		a.Equal(api.TaskDone, status)
 
 		// Second PITR
-		validateTbl0(t, mysqlDB, databaseName, numRowsTime1)
-		validateTbl1(t, mysqlDB, databaseName, numRowsTime1)
-		validateTableUpdateRow(t, mysqlDB, databaseName)
+		validateTbl0(t, mysqlDB, database.Name, numRowsTime1)
+		validateTbl1(t, mysqlDB, database.Name, numRowsTime1)
+		validateTableUpdateRow(t, mysqlDB, database.Name)
+		log.Debug("Second PITR done.")
 	})
 
 	t.Run("Invalid Time Point", func(t *testing.T) {
-		log.Debug(t.Name())
-		databaseName := "invalid_time_point"
-
+		a := require.New(t)
 		port := getTestPort(t.Name())
-		_, stopFn := resourcemysql.SetupTestInstance(t, port)
-		defer stopFn()
+		targetTs := time.Now().Unix()
+		_, database, cleanFn := setUpForPITRTest(t, ctl, port, prodEnvironment.ID, project)
+		defer cleanFn()
 
-		connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
-		instance, err := ctl.addInstance(api.InstanceCreate{
-			EnvironmentID: prodEnvironment.ID,
-			Name:          "InvalidTimePointInstance",
-			Engine:        db.MySQL,
-			Host:          connCfg.Host,
-			Port:          connCfg.Port,
-			Username:      connCfg.Username,
-		})
-		a.NoError(err)
-
-		err = ctl.createDatabase(project, instance, databaseName, nil)
-		a.NoError(err)
-
-		databases, err := ctl.getDatabases(api.DatabaseFind{
-			InstanceID: &instance.ID,
-		})
-		a.NoError(err)
-		a.Equal(1, len(databases))
-		database := databases[0]
-
-		err = ctl.disableAutomaticBackup(database.ID)
-		a.NoError(err)
-
-		mysqlDB, _ := initPITRDB(t, databaseName, port)
-		defer mysqlDB.Close()
-
-		insertRangeData(t, mysqlDB, 0, numRowsTime0)
-
-		log.Debug("Create a full backup")
-		backup, err := ctl.createBackup(api.BackupCreate{
-			DatabaseID:     database.ID,
-			Name:           "first-backup",
-			Type:           api.BackupTypeManual,
-			StorageBackend: api.BackupStorageBackendLocal,
-		})
-		a.NoError(err)
-		err = ctl.waitBackup(database.ID, backup.ID)
-		a.NoError(err)
-
-		targetTs := backup.CreatedTs - 1
-
-		createCtx, err := json.Marshal(&api.PITRContext{
-			DatabaseID:    database.ID,
-			PointInTimeTs: targetTs,
-		})
-		a.NoError(err)
-		issue, err := ctl.createIssue(api.IssueCreate{
-			ProjectID:     project.ID,
-			Name:          fmt.Sprintf("Restore database %s to the time %d", databaseName, targetTs),
-			Type:          api.IssueDatabasePITR,
-			AssigneeID:    project.Creator.ID,
-			CreateContext: string(createCtx),
-		})
+		issue, err := createPITRIssue(ctl, project, database, targetTs)
 		a.NoError(err)
 
 		status, err := ctl.waitIssueNextTaskWithTaskApproval(issue.ID)
@@ -741,10 +402,78 @@ func TestPITR(t *testing.T) {
 	})
 }
 
-func initPITRDB(t *testing.T, database string, port int) (*sql.DB, func()) {
+func createPITRIssue(ctl *controller, project *api.Project, database *api.Database, targetTs int64) (*api.Issue, error) {
+	pitrIssueCtx, err := json.Marshal(&api.PITRContext{
+		DatabaseID:    database.ID,
+		PointInTimeTs: targetTs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ctl.createIssue(api.IssueCreate{
+		ProjectID:     project.ID,
+		Name:          fmt.Sprintf("Restore database %s to the time %d", database.Name, targetTs),
+		Type:          api.IssueDatabasePITR,
+		AssigneeID:    project.Creator.ID,
+		CreateContext: string(pitrIssueCtx),
+	})
+}
+
+func setUpForPITRTest(t *testing.T, ctl *controller, port, envID int, project *api.Project) (*sql.DB, *api.Database, func()) {
 	a := require.New(t)
 
-	var stopFn func()
+	baseName := strings.ReplaceAll(t.Name(), "/", "_")
+	databaseName := baseName + "Database"
+
+	_, stopInstance := resourcemysql.SetupTestInstance(t, port)
+	connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
+	instance, err := ctl.addInstance(api.InstanceCreate{
+		EnvironmentID: envID,
+		Name:          baseName + "Instance",
+		Engine:        db.MySQL,
+		Host:          connCfg.Host,
+		Port:          connCfg.Port,
+		Username:      connCfg.Username,
+	})
+	a.NoError(err)
+
+	err = ctl.createDatabase(project, instance, databaseName, nil)
+	a.NoError(err)
+
+	databases, err := ctl.getDatabases(api.DatabaseFind{
+		InstanceID: &instance.ID,
+	})
+	a.NoError(err)
+	a.Equal(1, len(databases))
+	database := databases[0]
+
+	err = ctl.disableAutomaticBackup(database.ID)
+	a.NoError(err)
+
+	mysqlDB := initPITRDB(t, databaseName, port)
+
+	insertRangeData(t, mysqlDB, 0, numRowsTime0)
+
+	log.Debug("Create a full backup")
+	backup, err := ctl.createBackup(api.BackupCreate{
+		DatabaseID:     database.ID,
+		Name:           "first-backup",
+		Type:           api.BackupTypeManual,
+		StorageBackend: api.BackupStorageBackendLocal,
+	})
+	a.NoError(err)
+	err = ctl.waitBackup(database.ID, backup.ID)
+	a.NoError(err)
+
+	return mysqlDB, database, func() {
+		stopInstance()
+		mysqlDB.Close()
+	}
+}
+
+func initPITRDB(t *testing.T, database string, port int) *sql.DB {
+	a := require.New(t)
+
 	var db *sql.DB
 	db, err := connectTestMySQL(port, "")
 	a.NoError(err)
@@ -769,7 +498,7 @@ func initPITRDB(t *testing.T, database string, port int) (*sql.DB, func()) {
 	_, err = db.Exec(stmt)
 	a.NoError(err)
 
-	return db, stopFn
+	return db
 }
 
 func insertRangeData(t *testing.T, db *sql.DB, begin, end int) {


### PR DESCRIPTION
Extract common routines:
1. `setUpForPITRTest` for setting up common PITR testing.
2. `createPITRIssue` for creating PITR issue.

Close BYT-901.