### PR TITLE
chore: add plan limit for maximum tasks that can be created for DDL/DML

### DIFF
--- a/api/plan.go
+++ b/api/plan.go
@@ -1,6 +1,9 @@
 package api
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+)
 
 // PlanType is the type for a plan.
 type PlanType int
@@ -183,4 +186,17 @@ type Plan struct {
 // PlanPatch is the API message for patching a plan.
 type PlanPatch struct {
 	Type PlanType `jsonapi:"attr,type"`
+}
+
+// PlanLimit is the type for plan limits.
+type PlanLimit int
+
+const (
+	// PlanLimitMaxmimumTask is the key name for maximum number of tasks for a plan.
+	PlanLimitMaxmimumTask PlanLimit = iota
+)
+
+// PlanLimitValues is the plan limit value mapping.
+var PlanLimitValues = map[PlanLimit][3]int64{
+	PlanLimitMaxmimumTask: {4, math.MaxInt64, math.MaxInt64},
 }

--- a/server/issue.go
+++ b/server/issue.go
@@ -715,6 +715,11 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 			}
 		}
 	} else {
+		maximumTaskLimit := s.getPlanLimitValue(api.PlanLimitMaxmimumTask)
+		if int64(len(c.DetailList)) > maximumTaskLimit {
+			return nil, echo.NewHTTPError(http.StatusForbidden, fmt.Sprintf("Effective plan %s can update up to %d databases, got %d.", s.getEffectivePlan(), maximumTaskLimit, len(c.DetailList)))
+		}
+
 		type envKey struct {
 			name  string
 			id    int

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -94,8 +94,20 @@ func (s *Server) loadLicense() (*enterpriseAPI.License, error) {
 }
 
 func (s *Server) feature(feature api.FeatureType) bool {
-	if expireTime := time.Unix(s.subscription.ExpiresTs, 0); expireTime.Before(time.Now()) {
-		return api.FeatureMatrix[feature][api.FREE]
+	return api.FeatureMatrix[feature][s.getEffectivePlan()]
+}
+
+func (s *Server) getPlanLimitValue(name api.PlanLimit) int64 {
+	v, ok := api.PlanLimitValues[name]
+	if !ok {
+		return 0
 	}
-	return api.FeatureMatrix[feature][s.subscription.Plan]
+	return v[s.getEffectivePlan()]
+}
+
+func (s *Server) getEffectivePlan() api.PlanType {
+	if expireTime := time.Unix(s.subscription.ExpiresTs, 0); expireTime.Before(time.Now()) {
+		return api.FREE
+	}
+	return s.subscription.Plan
 }


### PR DESCRIPTION
There could be scaling issues if there are too many tasks created.