### PR TITLE
feat: MySQL driver will take the resrouceDirectory

### DIFF
--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -155,6 +155,8 @@ var (
 // DriverConfig is the driver configuration.
 type DriverConfig struct {
 	PgInstanceDir string
+	// We use resrouce directory to splice the path of embedded binary, likes binaries in mysqlutil package.
+	ResourceDir string
 }
 
 type driverFunc func(DriverConfig) Driver

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -33,12 +33,15 @@ type Driver struct {
 	connCfg       db.ConnectionConfig
 	dbType        db.Type
 	mysqlutil     mysqlutil.Instance
+	resourceDir   string
 	binlogDir     string
 	db            *sql.DB
 }
 
-func newDriver(db.DriverConfig) db.Driver {
-	return &Driver{}
+func newDriver(dc db.DriverConfig) db.Driver {
+	return &Driver{
+		resourceDir: dc.ResourceDir,
+	}
 }
 
 // Open opens a MySQL driver.

--- a/server/anomaly_scanner.go
+++ b/server/anomaly_scanner.go
@@ -148,7 +148,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api.Instance) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.server.pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.server.pgInstanceDir, common.GetResourceDir(s.server.profile.DataDir))
 
 	// Check connection
 	if err != nil {
@@ -226,7 +226,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 }
 
 func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api.Instance, database *api.Database) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, database.Name, s.server.pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, database.Name, s.server.pgInstanceDir, common.GetResourceDir(s.server.profile.DataDir))
 
 	// Check connection
 	if err != nil {

--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -221,7 +221,7 @@ func (r *BackupRunner) downloadBinlogFilesForInstance(ctx context.Context, insta
 		r.downloadBinlogMu.Unlock()
 		r.downloadBinlogWg.Done()
 	}()
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", "" /* pgInstanceDir */)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "", "" /* pgInstanceDir */, common.GetResourceDir(r.server.profile.DataDir))
 	if err != nil {
 		if common.ErrorCode(err) == common.DbConnectionFailure {
 			log.Warn("Cannot connect to instance", zap.String("instance", instance.Name), zap.Error(err))
@@ -311,7 +311,7 @@ func (r *BackupRunner) startAutoBackups(ctx context.Context, runningTasks map[in
 
 func (s *Server) scheduleBackupTask(ctx context.Context, database *api.Database, backupName string, backupType api.BackupType, storageBackend api.BackupStorageBackend, creatorID int) (*api.Backup, error) {
 	// Store the migration history version if exists.
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get admin database driver, error: %w", err)
 	}

--- a/server/database.go
+++ b/server/database.go
@@ -230,7 +230,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 
 				// Tenant database exists when peerSchemaVersion or peerSchema are not empty.
 				if peerSchemaVersion != "" || peerSchema != "" {
-					driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstanceDir)
+					driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 					if err != nil {
 						return err
 					}
@@ -826,7 +826,7 @@ func (s *Server) setDatabaseLabels(ctx context.Context, labelsJSON string, datab
 
 // Try to get database driver using the instance's admin data source.
 // Upon successful return, caller MUST call driver.Close, otherwise, it will leak the database connection.
-func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName, pgInstanceDir string) (db.Driver, error) {
+func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName, pgInstanceDir, resourceDir string) (db.Driver, error) {
 	connCfg, err := getConnectionConfig(instance, databaseName)
 	if err != nil {
 		return nil, err
@@ -835,7 +835,10 @@ func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databas
 	driver, err := getDatabaseDriver(
 		ctx,
 		instance.Engine,
-		db.DriverConfig{PgInstanceDir: pgInstanceDir},
+		db.DriverConfig{
+			PgInstanceDir: pgInstanceDir,
+			ResourceDir:   resourceDir,
+		},
 		connCfg,
 		db.ConnectionContext{
 			EnvironmentName: instance.Environment.Name,

--- a/server/instance.go
+++ b/server/instance.go
@@ -45,7 +45,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		// Try creating the "bytebase" db in the added instance if needed.
 		// Since we allow user to add new instance upfront even providing the incorrect username/password,
 		// thus it's OK if it fails. Frontend will surface relevant info suggesting the "bytebase" db hasn't created yet.
-		db, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir)
+		db, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 		if err == nil {
 			defer db.Close(ctx)
 			if err := db.SetupMigrationIfNeeded(ctx); err != nil {
@@ -183,7 +183,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 
 		// Try immediately setup the migration schema, sync the engine version and schema after updating any connection related info.
 		if instancePatch.Host != nil || instancePatch.Port != nil {
-			db, err := getAdminDatabaseDriver(ctx, instancePatched, "", s.pgInstanceDir)
+			db, err := getAdminDatabaseDriver(ctx, instancePatched, "", s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 			if err == nil {
 				defer db.Close(ctx)
 				if err := db.SetupMigrationIfNeeded(ctx); err != nil {
@@ -244,7 +244,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		resultSet := &api.SQLResultSet{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir)
+		db, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 		if err != nil {
 			resultSet.Error = err.Error()
 		} else {
@@ -277,7 +277,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		instanceMigration := &api.InstanceMigration{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir)
+		db, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 		if err != nil {
 			instanceMigration.Status = api.InstanceMigrationSchemaUnknown
 			instanceMigration.Error = err.Error()
@@ -322,7 +322,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		find := &db.MigrationHistoryFind{ID: &historyID}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir)
+		driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history ID %d for instance %q", id, instance.Name)).SetInternal(err)
 		}
@@ -397,7 +397,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		historyList := []*api.MigrationHistory{}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir)
+		driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history for instance %q", instance.Name)).SetInternal(err)
 		}

--- a/server/issue.go
+++ b/server/issue.go
@@ -1238,7 +1238,7 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 		return "", "", nil
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name, s.pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name, s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 	if err != nil {
 		return "", "", err
 	}

--- a/server/task_check_executor_database_connect.go
+++ b/server/task_check_executor_database_connect.go
@@ -43,7 +43,7 @@ func (*TaskCheckDatabaseConnectExecutor) Run(ctx context.Context, server *Server
 		return []api.TaskCheckResult{}, common.Errorf(common.Internal, "database ID not found %v", task.DatabaseID)
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, server.pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, server.pgInstanceDir, common.GetResourceDir(server.profile.DataDir))
 	if err != nil {
 		return []api.TaskCheckResult{
 			{

--- a/server/task_check_executor_migration_schema.go
+++ b/server/task_check_executor_migration_schema.go
@@ -40,7 +40,7 @@ func (*TaskCheckMigrationSchemaExecutor) Run(ctx context.Context, server *Server
 		return []api.TaskCheckResult{}, err
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", server.pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "", server.pgInstanceDir, common.GetResourceDir(server.profile.DataDir))
 	if err != nil {
 		return []api.TaskCheckResult{}, err
 	}

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -131,11 +131,11 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 	return mi, nil
 }
 
-func executeMigration(ctx context.Context, pgInstanceDir string, task *api.Task, statement string, mi *db.MigrationInfo) (migrationID int64, schema string, err error) {
+func executeMigration(ctx context.Context, pgInstanceDir, resourceDir string, task *api.Task, statement string, mi *db.MigrationInfo) (migrationID int64, schema string, err error) {
 	statement = strings.TrimSpace(statement)
 	databaseName := task.Database.Name
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, databaseName, pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, databaseName, pgInstanceDir, resourceDir)
 	if err != nil {
 		return 0, "", err
 	}
@@ -305,7 +305,7 @@ func runMigration(ctx context.Context, server *Server, task *api.Task, migration
 	if err != nil {
 		return true, nil, err
 	}
-	migrationID, schema, err := executeMigration(ctx, server.pgInstanceDir, task, statement, mi)
+	migrationID, schema, err := executeMigration(ctx, server.pgInstanceDir, server.profile.DataDir, task, statement, mi)
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_database_backup.go
+++ b/server/task_executor_database_backup.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"go.uber.org/zap"
 )
@@ -54,7 +55,7 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 		zap.String("backup", backup.Name),
 	)
 
-	backupPayload, backupErr := exec.backupDatabase(ctx, task.Instance, task.Database.Name, backup, server.profile.DataDir, server.pgInstanceDir)
+	backupPayload, backupErr := exec.backupDatabase(ctx, task.Instance, task.Database.Name, backup, server.profile.DataDir, server.pgInstanceDir, common.GetResourceDir(server.profile.DataDir))
 	backupPatch := api.BackupPatch{
 		ID:        backup.ID,
 		Status:    string(api.BackupStatusDone),
@@ -80,8 +81,8 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 }
 
 // backupDatabase will take a backup of a database.
-func (*DatabaseBackupTaskExecutor) backupDatabase(ctx context.Context, instance *api.Instance, databaseName string, backup *api.Backup, dataDir, pgInstanceDir string) (string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, pgInstanceDir)
+func (*DatabaseBackupTaskExecutor) backupDatabase(ctx context.Context, instance *api.Instance, databaseName string, backup *api.Backup, dataDir, pgInstanceDir, resourceDir string) (string, error) {
+	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, pgInstanceDir, resourceDir)
 	if err != nil {
 		return "", err
 	}

--- a/server/task_executor_database_create.go
+++ b/server/task_executor_database_create.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"go.uber.org/zap"
@@ -48,7 +49,7 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	}
 
 	instance := task.Instance
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", server.pgInstanceDir)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", server.pgInstanceDir, common.GetResourceDir(server.profile.DataDir))
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_database_restore.go
+++ b/server/task_executor_database_restore.go
@@ -83,7 +83,7 @@ func (exec *DatabaseRestoreTaskExecutor) RunOnce(ctx context.Context, server *Se
 	)
 
 	// Restore the database to the target database.
-	if err := exec.restoreDatabase(ctx, targetDatabase.Instance, targetDatabase.Name, backup, server.profile.DataDir, server.pgInstanceDir); err != nil {
+	if err := exec.restoreDatabase(ctx, targetDatabase.Instance, targetDatabase.Name, backup, server.profile.DataDir, server.pgInstanceDir, server.profile.DataDir); err != nil {
 		return true, nil, err
 	}
 
@@ -123,8 +123,8 @@ func (exec *DatabaseRestoreTaskExecutor) RunOnce(ctx context.Context, server *Se
 }
 
 // restoreDatabase will restore the database from a backup.
-func (*DatabaseRestoreTaskExecutor) restoreDatabase(ctx context.Context, instance *api.Instance, databaseName string, backup *api.Backup, dataDir, pgInstanceDir string) error {
-	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, pgInstanceDir)
+func (*DatabaseRestoreTaskExecutor) restoreDatabase(ctx context.Context, instance *api.Instance, databaseName string, backup *api.Backup, dataDir, pgInstanceDir, resourceDir string) error {
+	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, pgInstanceDir, resourceDir)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (*DatabaseRestoreTaskExecutor) restoreDatabase(ctx context.Context, instanc
 // create many ephemeral databases from backup for testing purpose)
 // Returns migration history id and the version on success.
 func createBranchMigrationHistory(ctx context.Context, server *Server, sourceDatabase, targetDatabase *api.Database, backup *api.Backup, task *api.Task) (int64, string, error) {
-	targetDriver, err := getAdminDatabaseDriver(ctx, targetDatabase.Instance, targetDatabase.Name, server.pgInstanceDir)
+	targetDriver, err := getAdminDatabaseDriver(ctx, targetDatabase.Instance, targetDatabase.Name, server.pgInstanceDir, common.GetResourceDir(server.profile.DataDir))
 	if err != nil {
 		return -1, "", err
 	}

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -91,7 +91,7 @@ func (*PITRCutoverTaskExecutor) GetProgress() api.Progress {
 // 2. Create a backup with type PITR. The backup is scheduled asynchronously.
 // We must check the possible failed/ongoing PITR type backup in the recovery process.
 func (*PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.Task, server *Server, issue *api.Issue) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", "" /* pgInstanceDir */)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", "" /* pgInstanceDir */, common.GetResourceDir(server.profile.DataDir))
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -42,7 +42,7 @@ func (exec *PITRRestoreTaskExecutor) RunOnce(ctx context.Context, server *Server
 		return true, nil, fmt.Errorf("invalid PITR restore payload: %s, error: %w", task.Payload, err)
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", "" /* pgInstanceDir */)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", "" /* pgInstanceDir */, common.GetResourceDir(server.profile.DataDir))
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -76,7 +76,7 @@ func cutover(ctx context.Context, server *Server, task *api.Task, statement, sch
 		return true, nil, err
 	}
 	migrationID, schema, err := func() (migrationHistoryID int64, updatedSchema string, resErr error) {
-		driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, "" /* pgInstanceDir */)
+		driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, "" /* pgInstanceDir */, common.GetResourceDir(server.profile.DataDir))
 		if err != nil {
 			return -1, "", err
 		}


### PR DESCRIPTION
The second step of using mysqldump to speed up the dump and restore. Dump() in MySQL driver need it to build the path of some embed binaries.