### PR TITLE
refactor: remove mysqlutil instance

### DIFF
--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
-	"github.com/bytebase/bytebase/resources/mysqlutil"
 	"github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
 )
@@ -32,7 +31,6 @@ type Driver struct {
 	connectionCtx db.ConnectionContext
 	connCfg       db.ConnectionConfig
 	dbType        db.Type
-	mysqlutil     mysqlutil.Instance
 	resourceDir   string
 	binlogDir     string
 	db            *sql.DB

--- a/resources/mysqlutil/mysqlutil.go
+++ b/resources/mysqlutil/mysqlutil.go
@@ -24,37 +24,35 @@ const (
 	MySQLDump binaryName = "mysqldump"
 )
 
-// Instance involve the path of all binaries binary.
-type Instance struct {
-	mysqlBinPath       string
-	mysqlbinlogBinPath string
-	mysqldumpBinPath   string
-}
-
-// GetPath returns the binary path specified by `binName`.
-func (ins *Instance) GetPath(binName binaryName) string {
+// GetPath returns the binary path specified by `binName`, `resourceDir` is the path that installed the mysqlutil.
+func GetPath(binName binaryName, resourceDir string) string {
+	_, version, err := getTarNameAndVersion()
+	if err != nil {
+		return "UNEXPECTED_ERROR"
+	}
+	baseDir := filepath.Join(resourceDir, version)
 	switch binName {
 	case MySQL:
-		return ins.mysqlBinPath
+		return filepath.Join(baseDir, "bin", "mysql")
 	case MySQLBinlog:
-		return ins.mysqlbinlogBinPath
+		return filepath.Join(baseDir, "bin", "mysqlbinlog")
 	case MySQLDump:
-		return ins.mysqldumpBinPath
+		return filepath.Join(baseDir, "bin", "mysqldump")
 	}
-	return "UNKNOWN"
+	return "UNKNOWN_BINARY"
 }
 
-// Version returns the raw output of ``binName` -V`.
-func (ins *Instance) Version(binName binaryName) (string, error) {
+// version returns the raw output of ``binName` -V`.
+func version(binName binaryName, resourceDir string) (string, error) {
 	var cmd *exec.Cmd
 	var version bytes.Buffer
 	switch binName {
 	case MySQL:
-		cmd = exec.Command(ins.GetPath(MySQL), "-V")
+		cmd = exec.Command(GetPath(MySQL, resourceDir), "-V")
 	case MySQLBinlog:
-		cmd = exec.Command(ins.GetPath(MySQLBinlog), "-V")
+		cmd = exec.Command(GetPath(MySQLBinlog, resourceDir), "-V")
 	case MySQLDump:
-		cmd = exec.Command(ins.GetPath(MySQLDump), "-V")
+		cmd = exec.Command(GetPath(MySQLDump, resourceDir), "-V")
 	default:
 		return "", fmt.Errorf("unknown binary name: %s", binName)
 	}
@@ -67,8 +65,7 @@ func (ins *Instance) Version(binName binaryName) (string, error) {
 	return version.String(), nil
 }
 
-// Install will extract the mysqlutil tar in resourceDir.
-func Install(resourceDir string) (*Instance, error) {
+func getTarNameAndVersion() (tarname string, version string, err error) {
 	var tarName string
 	switch {
 	case runtime.GOOS == "darwin" && runtime.GOARCH == "arm64":
@@ -78,18 +75,27 @@ func Install(resourceDir string) (*Instance, error) {
 	case runtime.GOOS == "linux" && runtime.GOARCH == "amd64":
 		tarName = "mysqlutil-8.0.28-linux-glibc2.17-x86_64.tar.gz"
 	default:
-		return nil, fmt.Errorf("unsupported combination of OS %q and ARCH %q", runtime.GOOS, runtime.GOARCH)
+		return "", "", fmt.Errorf("unsupported combination of OS %q and ARCH %q", runtime.GOOS, runtime.GOARCH)
+	}
+	return tarName, strings.TrimRight(tarName, "tar.gz"), nil
+}
+
+// Install will extract the mysqlutil tar in resourceDir.
+func Install(resourceDir string) error {
+	tarName, version, err := getTarNameAndVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get tarball name and version, error: %w", err)
 	}
 
-	version := strings.TrimRight(tarName, "tar.gz")
 	mysqlutilDir := path.Join(resourceDir, version)
+
 	if _, err := os.Stat(mysqlutilDir); err != nil {
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to check binary directory path %q, error: %w", mysqlutilDir, err)
+			return fmt.Errorf("failed to check binary directory path %q, error: %w", mysqlutilDir, err)
 		}
 		// Install if not exist yet
 		if err := install(resourceDir, mysqlutilDir, tarName, version); err != nil {
-			return nil, fmt.Errorf("cannot install mysqlutil, error: %w", err)
+			return fmt.Errorf("cannot install mysqlutil, error: %w", err)
 		}
 	}
 
@@ -108,25 +114,21 @@ func Install(resourceDir string) (*Instance, error) {
 	for _, fp := range checks {
 		if _, err := os.Stat(fp); err != nil {
 			if !os.IsNotExist(err) {
-				return nil, fmt.Errorf("failed to check libncurses library path %q, error: %w", fp, err)
+				return fmt.Errorf("failed to check libncurses library path %q, error: %w", fp, err)
 			}
 			// Remove mysqlutil of old version and reinstall it
 			if err := os.RemoveAll(mysqlutilDir); err != nil {
-				return nil, fmt.Errorf("failed to remove the old version mysqlutil binary directory %q, error: %w", mysqlutilDir, err)
+				return fmt.Errorf("failed to remove the old version mysqlutil binary directory %q, error: %w", mysqlutilDir, err)
 			}
 			// Install the current version
 			if err := install(resourceDir, mysqlutilDir, tarName, version); err != nil {
-				return nil, fmt.Errorf("cannot install mysqlutil, error: %w", err)
+				return fmt.Errorf("cannot install mysqlutil, error: %w", err)
 			}
 			break
 		}
 	}
 
-	return &Instance{
-		mysqlBinPath:       filepath.Join(mysqlutilDir, "bin", "mysql"),
-		mysqlbinlogBinPath: filepath.Join(mysqlutilDir, "bin", "mysqlbinlog"),
-		mysqldumpBinPath:   filepath.Join(mysqlutilDir, "bin", "mysqldump"),
-	}, nil
+	return nil
 }
 
 // install installs mysqlutil in resourceDir.

--- a/resources/mysqlutil/mysqlutil.go
+++ b/resources/mysqlutil/mysqlutil.go
@@ -42,8 +42,8 @@ func GetPath(binName binaryName, resourceDir string) string {
 	return "UNKNOWN_BINARY"
 }
 
-// version returns the raw output of ``binName` -V`.
-func version(binName binaryName, resourceDir string) (string, error) {
+// getExecutableVersion returns the raw output of ``binName` -V`.
+func getExecutableVersion(binName binaryName, resourceDir string) (string, error) {
 	var cmd *exec.Cmd
 	var version bytes.Buffer
 	switch binName {

--- a/resources/mysqlutil/mysqlutil_test.go
+++ b/resources/mysqlutil/mysqlutil_test.go
@@ -20,17 +20,17 @@ func TestRunBinary(t *testing.T) {
 	a.NoError(err)
 
 	t.Run("run mysql client", func(t *testing.T) {
-		_, err := version(MySQL, tmpDir)
+		_, err := getExecutableVersion(MySQL, tmpDir)
 		a.NoError(err)
 	})
 
 	t.Run("run mysqlbinlog", func(t *testing.T) {
-		_, err := version(MySQLBinlog, tmpDir)
+		_, err := getExecutableVersion(MySQLBinlog, tmpDir)
 		a.NoError(err)
 	})
 
 	t.Run("run mysqldump", func(t *testing.T) {
-		_, err := version(MySQLDump, tmpDir)
+		_, err := getExecutableVersion(MySQLDump, tmpDir)
 		a.NoError(err)
 	})
 }

--- a/resources/mysqlutil/mysqlutil_test.go
+++ b/resources/mysqlutil/mysqlutil_test.go
@@ -16,21 +16,21 @@ func TestRunBinary(t *testing.T) {
 
 	a := require.New(t)
 	tmpDir := t.TempDir()
-	ins, err := Install(tmpDir)
+	err := Install(tmpDir)
 	a.NoError(err)
 
 	t.Run("run mysql client", func(t *testing.T) {
-		_, err := ins.Version(MySQL)
+		_, err := version(MySQL, tmpDir)
 		a.NoError(err)
 	})
 
 	t.Run("run mysqlbinlog", func(t *testing.T) {
-		_, err := ins.Version(MySQLBinlog)
+		_, err := version(MySQLBinlog, tmpDir)
 		a.NoError(err)
 	})
 
 	t.Run("run mysqldump", func(t *testing.T) {
-		_, err := ins.Version(MySQLDump)
+		_, err := version(MySQLDump, tmpDir)
 		a.NoError(err)
 	})
 }
@@ -46,7 +46,7 @@ func TestReinstallOnLinuxAmd64(t *testing.T) {
 
 	a := require.New(t)
 	tmpDir := t.TempDir()
-	instance, err := Install(tmpDir)
+	err := Install(tmpDir)
 	a.NoError(err)
 
 	baseDir := filepath.Join(tmpDir, "mysqlutil-8.0.28-linux-glibc2.17-x86_64" /*Hard code, don't care about this*/)
@@ -59,7 +59,7 @@ func TestReinstallOnLinuxAmd64(t *testing.T) {
 		filepath.Join(binDir, "mysqldump"),
 	}
 
-	mysqlPath := instance.GetPath(MySQL)
+	mysqlPath := GetPath(MySQL, tmpDir)
 
 	for _, fp := range checks {
 		a.FileExists(fp)
@@ -68,7 +68,7 @@ func TestReinstallOnLinuxAmd64(t *testing.T) {
 		a.NoError(err)
 		a.NoFileExists(fp)
 
-		_, err = Install(tmpDir)
+		err = Install(tmpDir)
 		a.NoError(err)
 		a.FileExists(fp)
 		a.FileExists(mysqlPath)

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,6 @@ type Server struct {
 
 	profile       Profile
 	e             *echo.Echo
-	mysqlutil     mysqlutil.Instance
 	pgInstanceDir string
 	metaDB        *store.MetadataDB
 	store         *store.Store
@@ -129,11 +128,10 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 
 	resourceDir := common.GetResourceDir(prof.DataDir)
 	// Install mysqlutil
-	mysqlutilIns, err := mysqlutil.Install(resourceDir)
+	err = mysqlutil.Install(resourceDir)
 	if err != nil {
 		return nil, fmt.Errorf("cannot install mysqlbinlog binary, error: %w", err)
 	}
-	s.mysqlutil = *mysqlutilIns
 
 	// Install Postgres.
 	pgDataDir := common.GetPostgresDataDir(prof.DataDir)
@@ -216,9 +214,9 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 
 		taskScheduler.Register(api.TaskDatabaseSchemaUpdateGhostCutover, NewSchemaUpdateGhostCutoverTaskExecutor)
 
-		taskScheduler.Register(api.TaskDatabasePITRRestore, func() TaskExecutor { return NewPITRRestoreTaskExecutor(s.mysqlutil) })
+		taskScheduler.Register(api.TaskDatabasePITRRestore, NewPITRRestoreTaskExecutor)
 
-		taskScheduler.Register(api.TaskDatabasePITRCutover, func() TaskExecutor { return NewPITRCutoverTaskExecutor(s.mysqlutil) })
+		taskScheduler.Register(api.TaskDatabasePITRCutover, NewPITRCutoverTaskExecutor)
 
 		s.TaskScheduler = taskScheduler
 

--- a/server/server.go
+++ b/server/server.go
@@ -128,8 +128,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 
 	resourceDir := common.GetResourceDir(prof.DataDir)
 	// Install mysqlutil
-	err = mysqlutil.Install(resourceDir)
-	if err != nil {
+	if err := mysqlutil.Install(resourceDir); err != nil {
 		return nil, fmt.Errorf("cannot install mysqlbinlog binary, error: %w", err)
 	}
 

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -12,21 +12,17 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/mysql"
-	"github.com/bytebase/bytebase/resources/mysqlutil"
 	"go.uber.org/zap"
 )
 
 // NewPITRCutoverTaskExecutor creates a PITR cutover task executor.
-func NewPITRCutoverTaskExecutor(instance mysqlutil.Instance) TaskExecutor {
-	return &PITRCutoverTaskExecutor{
-		mysqlutil: instance,
-	}
+func NewPITRCutoverTaskExecutor() TaskExecutor {
+	return &PITRCutoverTaskExecutor{}
 }
 
 // PITRCutoverTaskExecutor is the PITR cutover task executor.
 type PITRCutoverTaskExecutor struct {
 	completed int32
-	mysqlutil mysqlutil.Instance
 }
 
 // RunOnce will run the PITR cutover task executor once.

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -14,22 +14,18 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/mysql"
-	"github.com/bytebase/bytebase/resources/mysqlutil"
 	"github.com/bytebase/bytebase/store"
 	"go.uber.org/zap"
 )
 
 // NewPITRRestoreTaskExecutor creates a PITR restore task executor.
-func NewPITRRestoreTaskExecutor(instance mysqlutil.Instance) TaskExecutor {
-	return &PITRRestoreTaskExecutor{
-		mysqlutil: instance,
-	}
+func NewPITRRestoreTaskExecutor() TaskExecutor {
+	return &PITRRestoreTaskExecutor{}
 }
 
 // PITRRestoreTaskExecutor is the PITR restore task executor.
 type PITRRestoreTaskExecutor struct {
 	completed int32
-	mysqlutil mysqlutil.Instance
 }
 
 // RunOnce will run the PITR restore task executor once.
@@ -96,7 +92,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 		log.Error("Failed to cast driver to mysql.Driver")
 		return fmt.Errorf("[internal] cast driver to mysql.Driver failed")
 	}
-	mysqlDriver.SetUpForPITR(exec.mysqlutil, binlogDir)
+	mysqlDriver.SetUpForPITR(binlogDir)
 
 	log.Debug("Downloading all binlog files")
 	if err := mysqlDriver.FetchAllBinlogFiles(ctx, true /* downloadLatestBinlogFile */); err != nil {

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -66,7 +66,7 @@ func (*PITRRestoreTaskExecutor) GetProgress() api.Progress {
 	return api.Progress{}
 }
 
-func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *api.Task, store *store.Store, driver db.Driver, dataDir string, targetTs int64, mode common.ReleaseMode) error {
+func (*PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *api.Task, store *store.Store, driver db.Driver, dataDir string, targetTs int64, mode common.ReleaseMode) error {
 	instance := task.Instance
 	database := task.Database
 

--- a/tests/mysql.go
+++ b/tests/mysql.go
@@ -31,11 +31,17 @@ func connectTestMySQL(port int, database string) (*sql.DB, error) {
 }
 
 func getTestMySQLDriver(ctx context.Context, port, database string) (db.Driver, error) {
+	return getTestMySQLDriverWithResourceDir(ctx, port, database, "" /*resourceDir*/)
+}
+
+func getTestMySQLDriverWithResourceDir(ctx context.Context, port, database, resourceDir string) (db.Driver, error) {
 	connCfg := getMySQLConnectionConfig(port, database)
 	return db.Open(
 		ctx,
 		db.MySQL,
-		db.DriverConfig{},
+		db.DriverConfig{
+			ResourceDir: resourceDir,
+		},
 		connCfg,
 		db.ConnectionContext{},
 	)

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -141,10 +141,10 @@ func TestFetchBinlogFiles(t *testing.T) {
 	mysqlDriver, ok := driver.(*pluginmysql.Driver)
 	a.Equal(true, ok)
 	utilDir := t.TempDir()
-	utilInstance, err := mysqlutil.Install(utilDir)
-	binlogDir := t.TempDir()
-	mysqlDriver.SetUpForPITR(*utilInstance, binlogDir)
+	err = mysqlutil.Install(utilDir)
 	a.NoError(err)
+	binlogDir := t.TempDir()
+	mysqlDriver.SetUpForPITR(binlogDir)
 
 	// init schema
 	_, err = db.ExecContext(ctx, `

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -134,15 +134,16 @@ func TestFetchBinlogFiles(t *testing.T) {
 	a.NoError(err)
 	defer db.Close()
 
-	driver, err := getTestMySQLDriver(ctx, strconv.Itoa(port), "")
+	utilDir := t.TempDir()
+	err = mysqlutil.Install(utilDir)
+	a.NoError(err)
+
+	driver, err := getTestMySQLDriverWithResourceDir(ctx, strconv.Itoa(port), "", utilDir)
 	a.NoError(err)
 	defer driver.Close(ctx)
 
 	mysqlDriver, ok := driver.(*pluginmysql.Driver)
 	a.Equal(true, ok)
-	utilDir := t.TempDir()
-	err = mysqlutil.Install(utilDir)
-	a.NoError(err)
 	binlogDir := t.TempDir()
 	mysqlDriver.SetUpForPITR(binlogDir)
 


### PR DESCRIPTION
The 3rd step of using mysqldump to speed up the backup and restore. After merging the #2144 , we don't need mysqlutilinstance anymore.
Completing BYT-975