### PR TITLE
fix(github): provide example value for "Homepage URL"

### DIFF
--- a/frontend/src/components/VCSProviderOAuthPanel.vue
+++ b/frontend/src/components/VCSProviderOAuthPanel.vue
@@ -142,6 +142,21 @@
                 </dt>
                 <dd class="text-sm text-main">Bytebase</dd>
               </div>
+              <div class="grid grid-cols-2 gap-4 px-4 py-2">
+                <dt class="text-sm font-medium text-control-light text-right">
+                  Homepage URL
+                </dt>
+                <dd class="text-sm text-main items-center flex">
+                  https://bytebase.com
+                  <button
+                    tabindex="-1"
+                    class="ml-1 text-sm font-medium text-control-light hover:bg-gray-100"
+                    @click.prevent="copyHomepageURL"
+                  >
+                    <heroicons-outline:clipboard class="w-6 h-6" />
+                  </button>
+                </dd>
+              </div>
               <div class="grid grid-cols-2 gap-4 px-4 py-2 items-center">
                 <dt class="text-sm font-medium text-control-light text-right">
                   Authorization callback URL
@@ -268,12 +283,26 @@ export default defineComponent({
       return "";
     });
 
+    const copyHomepageURL = () => {
+      toClipboard("https://bytebase.com").then(() => {
+        pushNotification({
+          module: "bytebase",
+          style: "INFO",
+          title: t(
+            "version-control.setting.add-git-provider.oauth-info.copy-homepage-url"
+          ),
+        });
+      });
+    };
+
     const copyRedirectURI = () => {
       toClipboard(redirectUrl()).then(() => {
         pushNotification({
           module: "bytebase",
           style: "INFO",
-          title: `Redirect URI copied to clipboard. Paste to the corresponding field on the OAuth application form.`,
+          title: t(
+            "version-control.setting.add-git-provider.oauth-info.copy-redirect-uri"
+          ),
         });
       });
     };
@@ -382,6 +411,7 @@ export default defineComponent({
       redirectUrl,
       state,
       createAdminApplicationUrl,
+      copyHomepageURL,
       copyRedirectURI,
       changeApplicationId,
       changeSecret,

--- a/frontend/src/components/VCSProviderOAuthPanel.vue
+++ b/frontend/src/components/VCSProviderOAuthPanel.vue
@@ -142,7 +142,7 @@
                 </dt>
                 <dd class="text-sm text-main">Bytebase</dd>
               </div>
-              <div class="grid grid-cols-2 gap-4 px-4 py-2">
+              <div class="grid grid-cols-2 gap-4 px-4 py-2 items-center">
                 <dt class="text-sm font-medium text-control-light text-right">
                   Homepage URL
                 </dt>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1076,6 +1076,8 @@
           "github-login-as-admin": "Login as an organization admin user to the GitHub.com. The account must be an organization admin of the GitHub organization (able to access the organization Settings page).",
           "github-visit-admin-page": "Go to the Settings page, then navigate to \"Developer settings > OAuth Apps\" section and click \"Register an application\" button.",
           "github-paste-oauth-info": "Paste the Client ID and Client secret from that just created application into fields below.",
+          "copy-homepage-url": "Homepage URL copied to clipboard. Paste to the corresponding field on the OAuth application form.",
+          "copy-redirect-uri": "Redirect URI copied to clipboard. Paste to the corresponding field on the OAuth application form.",
           "direct-link": "Direct link",
           "create-oauth-app": "Create your Bytebase OAuth application with the following info.",
           "gitlab-application-id-error": "Application ID must be a 64-character alphanumeric string",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1077,6 +1077,8 @@
           "github-login-as-admin": "以组织管理员身份登录 GitHub.com。这个账号必须是 GitHub 组织的管理员 (能够进入组织 Settings 页面)。",
           "github-visit-admin-page": "进入组织 Settings 页面，然后导航到「Developer settings > OAuth Apps」分区，再点击「Register an application」。",
           "github-paste-oauth-info": "从刚创建好的应用上粘贴它的 Client ID 和 Client secret 到下面的字段。",
+          "copy-homepage-url": "Homepage URL 已复制到剪切板，请粘贴至 OAuth 应用的对应字段内。",
+          "copy-redirect-uri": "Redirect URI 已复制到剪切板，请粘贴至 OAuth 应用的对应字段内。",
           "direct-link": "直达链接",
           "create-oauth-app": "使用如下信息来创建您的 Bytebase OAuth 应用。",
           "gitlab-application-id-error": "应用 ID 必须是 64 个字母长度",


### PR DESCRIPTION
"Homepage URL" is a required field for creating an OAuth application on GitHub, providing an example value helps the user think less.

This PR also fixes the missing i18n strings for copy notifications on this page.

<img width="660" alt="CleanShot 2022-08-07 at 21 06 44@2x" src="https://user-images.githubusercontent.com/2946214/183292107-438348c1-e79a-45c2-a0ee-b2d810935055.png">

