### PR TITLE
fix(github): list all repositories the user has admin permissions

### DIFF
--- a/frontend/src/components/RepositorySelectionPanel.vue
+++ b/frontend/src/components/RepositorySelectionPanel.vue
@@ -115,6 +115,8 @@ const repositoryList = computed(() => {
 const attentionText = computed((): string => {
   if (props.config.vcs.type == "GITLAB_SELF_HOST") {
     return "repository.select-repository-attention-gitlab";
+  } else if (props.config.vcs.type == "GITHUB_COM") {
+    return "repository.select-repository-attention-github";
   }
   return "";
 });

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -890,6 +890,7 @@
     "choose-git-provider-visit-workspace": "Visit {workspace} setting to add more Git providers.",
     "choose-git-provider-contact-workspace-owner": "Contact your Bytebase owner if you want other Git providers to appear here. Bytebase currently supports self-host GitLab EE/CE, and plan to add GitLab.com, and GitHub Enterprise later.",
     "select-repository-attention-gitlab": "Bytebase only lists GitLab projects granting you at least the 'Maintainer' role, which allows to configure the project webhook to observe the code push event.",
+    "select-repository-attention-github": "Bytebase only lists GitHub repositories you have admin permissions, which allows to configure the repository webhook to observe the code push event.",
     "select-repository-search": "Search repository",
     "linked": "Linked repositories",
     "role-provider": "Project role provider",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -891,6 +891,7 @@
     "choose-git-provider-visit-workspace": "访问 {workspace} 设置以添加更多 Git 提供方.",
     "choose-git-provider-contact-workspace-owner": "如果您希望其他 Git 提供方出现在列表中，请联系 Bytebase 实例的所有者。当前 Bytebase 支持自己托管的 GitLab EE/CE，我们之后也会支持 GitLab.com 和 GitHub Enterprise",
     "select-repository-attention-gitlab": "Bytebase 仅列出您至少拥有 'Maintainer' 权限的 GitLab 项目。因为只有至少拥有该权限，才能够配置项目的 webhook 用来监听代码推送事件。",
+    "select-repository-attention-github": "Bytebase 仅列出您拥有管理员权限的 GitHub 仓库。因为只有拥有该权限，才能够配置仓库的 webhook 用来监听代码推送事件。",
     "select-repository-search": "搜索仓库",
     "linked": "关联的仓库",
     "role-provider": "项目角色权限提供方",

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -486,6 +486,10 @@ func (p *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL string, o
 // FetchAllRepositoryList fetches all repositories where the authenticated user
 // has admin permissions, which is required to create webhook in the repository.
 //
+// NOTE: GitHub API does not provide a native filter for admin permissions, thus
+// we need to first fetch all repositories and then filter down the list using
+// the `permissions.admin` field.
+//
 // Docs: https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user
 func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]*vcs.Repository, error) {
 	var githubRepos []Repository

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -521,7 +521,7 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 }
 
 // fetchPaginatedRepositoryList fetches repositories where the authenticated
-// user has access to in given page. It return the paginated results along
+// user has access to in given page. It returns the paginated results along
 // with a boolean indicating whether the next page exists.
 func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, page int) (repos []Repository, hasNextPage bool, err error) {
 	url := fmt.Sprintf("%s/user/repos?page=%d&per_page=%d", p.APIURL(instanceURL), page, apiPageSize)

--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -85,10 +85,13 @@ type User struct {
 
 // Repository represents a GitHub API response for a repository.
 type Repository struct {
-	ID       int64  `json:"id"`
-	Name     string `json:"name"`
-	FullName string `json:"full_name"`
-	HTMLURL  string `json:"html_url"`
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	FullName    string `json:"full_name"`
+	HTMLURL     string `json:"html_url"`
+	Permissions struct {
+		Admin bool `json:"admin"`
+	} `json:"permissions"`
 }
 
 // RepositoryTree represents a GitHub API response for a repository tree.
@@ -481,7 +484,7 @@ func (p *Provider) ExchangeOAuthToken(ctx context.Context, instanceURL string, o
 }
 
 // FetchAllRepositoryList fetches all repositories where the authenticated user
-// has a owner role, which is required to create webhook in the repository.
+// has admin permissions, which is required to create webhook in the repository.
 //
 // Docs: https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user
 func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]*vcs.Repository, error) {
@@ -502,6 +505,9 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 
 	var allRepos []*vcs.Repository
 	for _, r := range githubRepos {
+		if !r.Permissions.Admin {
+			continue
+		}
 		allRepos = append(allRepos,
 			&vcs.Repository{
 				ID:       r.ID,
@@ -515,12 +521,10 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 }
 
 // fetchPaginatedRepositoryList fetches repositories where the authenticated
-// user has a owner role in given page. It return the paginated results along
+// user has access to in given page. It return the paginated results along
 // with a boolean indicating whether the next page exists.
 func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, page int) (repos []Repository, hasNextPage bool, err error) {
-	// We will use user's token to create webhook in the project, which requires the
-	// token owner to be at least the project maintainer(40).
-	url := fmt.Sprintf("%s/user/repos?affiliation=owner&page=%d&per_page=%d", p.APIURL(instanceURL), page, apiPageSize)
+	url := fmt.Sprintf("%s/user/repos?page=%d&per_page=%d", p.APIURL(instanceURL), page, apiPageSize)
 	code, body, err := oauth.Get(
 		ctx,
 		p.client,

--- a/plugin/vcs/github/github_test.go
+++ b/plugin/vcs/github/github_test.go
@@ -445,7 +445,7 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 						assert.Equal(t, "/user/repos", r.URL.Path)
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user
+							// Example response derived from https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user
 							Body: io.NopCloser(strings.NewReader(`
 [
   {
@@ -546,8 +546,8 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
     "created_at": "2011-01-26T19:01:12Z",
     "updated_at": "2011-01-26T19:14:43Z",
     "permissions": {
-      "admin": false,
-      "push": false,
+      "admin": true,
+      "push": true,
       "pull": true
     },
     "allow_rebase_merge": true,
@@ -570,6 +570,17 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
     "forks": 1,
     "open_issues": 1,
     "watchers": 1
+  },
+  {
+    "id": 1296270,
+    "name": "Hello-World2",
+    "full_name": "octocat/Hello-World2",
+    "html_url": "https://github.com/octocat/Hello-World2",
+    "permissions": {
+      "admin": false,
+      "push": false,
+      "pull": true
+    }
   }
 ]
 `)),
@@ -584,6 +595,7 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 	got, err := p.FetchAllRepositoryList(ctx, common.OauthContext{}, githubComURL)
 	require.NoError(t, err)
 
+	// Repositories without admin permissions should be excluded
 	want := []*vcs.Repository{
 		{
 			ID:       1296269,
@@ -680,7 +692,7 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 		got, err := p.FetchRepositoryFileList(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "main", "subdir")
 		require.NoError(t, err)
 
-		// Non-blob type should excluded
+		// Non-blob type should be excluded
 		want := []*vcs.RepositoryTreeNode{
 			{
 				Path: "subdir/exec_file",


### PR DESCRIPTION
We are using the `affiliation=owner` filter for fetching the repositories list of the authenticated user, but this resulted in only personal repositories being listed.

Unfortunately, GitHub API does not provide a native filter for admin permissions, thus we need to first fetch all repositories and then filter down the list using the `permissions.admin` field.

This PR also fixes the missing "Attention needed" text:

<img width="1180" alt="CleanShot 2022-08-03 at 21 24 37@2x" src="https://user-images.githubusercontent.com/2946214/182620765-782a25cf-ec7e-4dea-a932-a22f63f7db40.png">

