### PR TITLE
feat: do not install embedded pg if using external pg

### DIFF
--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -155,7 +155,7 @@ var (
 // DriverConfig is the driver configuration.
 type DriverConfig struct {
 	PgInstanceDir string
-	// We use resrouce directory to splice the path of embedded binary, likes binaries in mysqlutil package.
+	// We use resource directory to splice the path of embedded binary, likes binaries in mysqlutil package.
 	ResourceDir string
 }
 

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -63,7 +63,7 @@ type DB struct {
 	// Dir to load demo data
 	demoDataDir string
 
-	// Dir for postgres instance
+	// Dir for embedded postgres instance
 	pgBaseDir string
 
 	// If true, database will be opened in readonly mode


### PR DESCRIPTION
# Current starting log
```
-----Config BEGIN-----
mode=prod
server=http://localhost:8080
datastore=http://localhost:8081
frontend=http://localhost:3000
demoDataDir=
readonly=false
demo=false
debug=false
dataDir=/Users/dragonly/.bytebase/data
-----Config END-------
2022-08-05T14:09:14.751+0800	INFO	Establishing external PostgreSQL connection...	{"pgURL": "postgresql://dragonly:xxxxx@localhost:5432/bytebase"}
2022-08-05T14:09:14.786+0800	INFO	Apply database migration if needed...
2022-08-05T14:09:14.786+0800	INFO	Current schema version before migration: 1.3.3
2022-08-05T14:09:14.786+0800	INFO	The prod cutoff schema version: 1.3.3
2022-08-05T14:09:14.786+0800	INFO	Skip migration 1.0.0; the current schema version 1.3.0 is higher.
2022-08-05T14:09:14.786+0800	INFO	Skip migration 1.1.0; the current schema version 1.3.0 is higher.
2022-08-05T14:09:14.786+0800	INFO	Skip migration 1.2.0; the current schema version 1.3.0 is higher.
2022-08-05T14:09:14.786+0800	INFO	Starting minor version migration cycle from 1.3.0 ...
2022-08-05T14:09:14.786+0800	INFO	Database schema is at version 1.3.3; nothing to migrate.
2022-08-05T14:09:14.790+0800	INFO	Current schema version after migration: 1.3.3
2022-08-05T14:09:14.797+0800	INFO	get project env	{"env": "prod"}
2022-08-05T14:09:14.797+0800	INFO	load public pem	{"file": "keys/prod.pub.pem"}

██████╗ ██╗   ██╗████████╗███████╗██████╗  █████╗ ███████╗███████╗
██╔══██╗╚██╗ ██╔╝╚══██╔══╝██╔════╝██╔══██╗██╔══██╗██╔════╝██╔════╝
██████╔╝ ╚████╔╝    ██║   █████╗  ██████╔╝███████║███████╗█████╗
██╔══██╗  ╚██╔╝     ██║   ██╔══╝  ██╔══██╗██╔══██║╚════██║██╔══╝
██████╔╝   ██║      ██║   ███████╗██████╔╝██║  ██║███████║███████╗
╚═════╝    ╚═╝      ╚═╝   ╚══════╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝

Version 1.3.0 has started at http://localhost:8080
___________________________________________________________________________________________
```

# Previous starting log
```
-----Config BEGIN-----
mode=prod
server=http://localhost:8080
datastore=http://localhost:8081
frontend=http://localhost:3000
demoDataDir=
readonly=false
demo=false
debug=false
dataDir=/Users/dragonly/.bytebase/data
-----Config END-------
2022-08-05T14:12:12.331+0800	INFO	-----Embedded Postgres Config BEGIN-----
2022-08-05T14:12:12.331+0800	INFO	resourceDir=/Users/dragonly/.bytebase/data/resources

2022-08-05T14:12:12.331+0800	INFO	pgdataDir=

2022-08-05T14:12:12.331+0800	INFO	-----Embedded Postgres Config END-----
2022-08-05T14:12:12.331+0800	INFO	Preparing embedded PostgreSQL instance...
2022-08-05T14:12:12.331+0800	INFO	Installing Postgres OS "darwin" Arch "arm64"

2022-08-05T14:12:15.088+0800	INFO	Establishing external PostgreSQL connection...	{"pgURL": "postgresql://dragonly:xxxxx@localhost:5432/bytebase"}
2022-08-05T14:12:15.125+0800	INFO	Apply database migration if needed...
2022-08-05T14:12:15.125+0800	INFO	Current schema version before migration: 1.3.3
2022-08-05T14:12:15.125+0800	INFO	The prod cutoff schema version: 1.3.3
2022-08-05T14:12:15.125+0800	INFO	Skip migration 1.0.0; the current schema version 1.3.0 is higher.
2022-08-05T14:12:15.125+0800	INFO	Skip migration 1.1.0; the current schema version 1.3.0 is higher.
2022-08-05T14:12:15.125+0800	INFO	Skip migration 1.2.0; the current schema version 1.3.0 is higher.
2022-08-05T14:12:15.125+0800	INFO	Starting minor version migration cycle from 1.3.0 ...
2022-08-05T14:12:15.125+0800	INFO	Database schema is at version 1.3.3; nothing to migrate.
2022-08-05T14:12:15.130+0800	INFO	Current schema version after migration: 1.3.3
2022-08-05T14:12:15.137+0800	INFO	get project env	{"env": "prod"}
2022-08-05T14:12:15.137+0800	INFO	load public pem	{"file": "keys/prod.pub.pem"}

██████╗ ██╗   ██╗████████╗███████╗██████╗  █████╗ ███████╗███████╗
██╔══██╗╚██╗ ██╔╝╚══██╔══╝██╔════╝██╔══██╗██╔══██╗██╔════╝██╔════╝
██████╔╝ ╚████╔╝    ██║   █████╗  ██████╔╝███████║███████╗█████╗
██╔══██╗  ╚██╔╝     ██║   ██╔══╝  ██╔══██╗██╔══██║╚════██║██╔══╝
██████╔╝   ██║      ██║   ███████╗██████╔╝██║  ██║███████║███████╗
╚═════╝    ╚═╝      ╚═╝   ╚══════╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝

Version 1.3.0 has started at http://localhost:8080
___________________________________________________________________________________________
```