### PR TITLE
fix(github): tooltip when the auth is disabled

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -689,7 +689,7 @@
       "new-user": "New to Bytebase?",
       "demo-note": "Please use demo account to sign in",
       "gitlab": "Login with GitLab",
-      "gitlab-demo": "GitLab login is disabled in Demo mode",
+      "3rd-party-auth-demo": "Third-party authentication is disabled in Demo mode",
       "gitlab-oauth": "Reach to your Admin to enable GitLab login"
     },
     "password-forget": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -690,7 +690,7 @@
       "new-user": "第一次使用 Bytebase?",
       "demo-note": "请使用 demo 账号登录",
       "gitlab": "通过 GitLab 登录",
-      "gitlab-demo": "演示模式不支持 GitLab 登录",
+      "3rd-party-auth-demo": "演示模式不支持第三方账号登录",
       "gitlab-oauth": "您可联系管理员开启 GitLab 登录"
     },
     "password-forget": {

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -36,7 +36,7 @@
             }}
           </span>
           <span v-if="isDemo" class="tooltip">{{
-            $t("auth.sign-in.gitlab-demo")
+            $t("auth.sign-in.3rd-party-auth-demo")
           }}</span>
           <span v-else-if="!has3rdPartyLoginFeature" class="tooltip">{{
             $t("subscription.features.bb-feature-3rd-party-auth.login")


### PR DESCRIPTION
Fix tooltip for GitHub.com when auth is disabled by using the neutral language.

<img width="486" alt="CleanShot 2022-08-07 at 21 19 28@2x" src="https://user-images.githubusercontent.com/2946214/183292946-28a7b094-5a01-4f7c-8a5f-f615f77e546d.png">
