### PR TITLE
feat: install mysqlutil in bb cmd

### DIFF
--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -30,7 +30,7 @@ func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 	switch u.Driver {
 	case "mysql":
 		dbType = db.MySQL
-		// dburl.Parse() do the job of parsing 'pg', 'postgresql' and 'pgsql' to 'postgres'.
+		// dburl.Parse() parses 'pg', 'postgresql' and 'pgsql' to 'postgres'.
 		// https://pkg.go.dev/github.com/xo/dburl@v0.9.1#hdr-Protocol_Schemes_and_Aliases
 		if err := mysqlutil.Install(resourceDir); err != nil {
 			return nil, fmt.Errorf("cannot install mysqlutil in directory %s, error: %w", resourceDir, err)

--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -39,7 +39,7 @@ func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 		dbType = db.Postgres
 		pgInstance, err := postgres.Install(resourceDir, "" /* pgDataDir */, "" /* pgUser */)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot install postgres in directory %q, error: %w", resourceDir, err)
 		}
 		pgInstanceDir = pgInstance.BaseDir
 	default:

--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -26,19 +26,18 @@ func getDatabase(u *dburl.URL) string {
 func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 	var dbType db.Type
 	var pgInstanceDir string
-	var resourceDir string
+	resourceDir := os.TempDir()
 	switch u.Driver {
 	case "mysql":
 		dbType = db.MySQL
 		// dburl.Parse() do the job of parsing 'pg', 'postgresql' and 'pgsql' to 'postgres'.
 		// https://pkg.go.dev/github.com/xo/dburl@v0.9.1#hdr-Protocol_Schemes_and_Aliases
-		resourceDir = os.TempDir()
 		if err := mysqlutil.Install(resourceDir); err != nil {
 			return nil, fmt.Errorf("cannot install mysqlutil in directory %s, error: %w", resourceDir, err)
 		}
 	case "postgres":
 		dbType = db.Postgres
-		pgInstance, err := postgres.Install(os.TempDir(), "" /* pgDataDir */, "" /* pgUser */)
+		pgInstance, err := postgres.Install(resourceDir, "" /* pgDataDir */, "" /* pgUser */)
 		if err != nil {
 			return nil, err
 		}

--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -33,7 +33,6 @@ func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 		// dburl.Parse() do the job of parsing 'pg', 'postgresql' and 'pgsql' to 'postgres'.
 		// https://pkg.go.dev/github.com/xo/dburl@v0.9.1#hdr-Protocol_Schemes_and_Aliases
 		resourceDir = os.TempDir()
-		fmt.Println(resourceDir)
 		if err := mysqlutil.Install(resourceDir); err != nil {
 			return nil, fmt.Errorf("cannot install mysqlutil in directory %s, error: %w", resourceDir, err)
 		}

--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -33,7 +33,7 @@ func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 		// dburl.Parse() parses 'pg', 'postgresql' and 'pgsql' to 'postgres'.
 		// https://pkg.go.dev/github.com/xo/dburl@v0.9.1#hdr-Protocol_Schemes_and_Aliases
 		if err := mysqlutil.Install(resourceDir); err != nil {
-			return nil, fmt.Errorf("cannot install mysqlutil in directory %s, error: %w", resourceDir, err)
+			return nil, fmt.Errorf("cannot install mysqlutil in directory %q, error: %w", resourceDir, err)
 		}
 	case "postgres":
 		dbType = db.Postgres


### PR DESCRIPTION
Implement a part of bb support in #2159 .
To keep bb stateless, mysqlutil will be installed every time bb starts some operations about MySQL instead of support `--data` option.