### PR TITLE
chore: restore function in driver interface accepts a reader parameter to be more general

### DIFF
--- a/bin/bb/cmd/restore.go
+++ b/bin/bb/cmd/restore.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -38,12 +37,11 @@ func newRestoreCmd() *cobra.Command {
 
 // restoreDatabase restores the schema of a database instance.
 func restoreDatabase(ctx context.Context, u *dburl.URL, file string) error {
-	f, err := os.OpenFile(file, os.O_RDONLY, os.ModePerm)
+	f, err := os.Open(file)
 	if err != nil {
 		return fmt.Errorf("os.OpenFile(%q) error: %v", file, err)
 	}
 	defer f.Close()
-	sc := bufio.NewScanner(f)
 
 	db, err := open(ctx, u)
 	if err != nil {
@@ -51,7 +49,7 @@ func restoreDatabase(ctx context.Context, u *dburl.URL, file string) error {
 	}
 	defer db.Close(ctx)
 
-	if err := db.Restore(ctx, sc); err != nil {
+	if err := db.Restore(ctx, f); err != nil {
 		return fmt.Errorf("failed to restore from database dump %s got error: %w", file, err)
 	}
 	return nil

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -1,7 +1,6 @@
 package clickhouse
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -126,8 +125,8 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 		}
 		return nil
 	}
-	sc := bufio.NewScanner(strings.NewReader(statement))
-	if err := util.ApplyMultiStatements(sc, f); err != nil {
+
+	if err := util.ApplyMultiStatements(strings.NewReader(statement), f); err != nil {
 		return err
 	}
 

--- a/plugin/db/clickhouse/dump.go
+++ b/plugin/db/clickhouse/dump.go
@@ -1,7 +1,6 @@
 package clickhouse
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -193,7 +192,7 @@ func getTables(ctx context.Context, txn *sql.Tx, dbName string) ([]*tableSchema,
 }
 
 // Restore restores a database.
-func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error) {
+func (driver *Driver) Restore(ctx context.Context, sc io.Reader) (err error) {
 	txn, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -215,6 +214,6 @@ func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error
 }
 
 // RestoreTx restores the database in the given transaction.
-func (*Driver) RestoreTx(context.Context, *sql.Tx, *bufio.Scanner) error {
+func (*Driver) RestoreTx(context.Context, *sql.Tx, io.Reader) error {
 	return fmt.Errorf("Unimplemented")
 }

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -421,10 +420,10 @@ type Driver interface {
 	// The returned string is the JSON encoded metadata for the logical dump.
 	// For MySQL, the payload contains the binlog filename and position when the dump is generated.
 	Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error)
-	// Restore the database from sc, which is a full backup.
-	Restore(ctx context.Context, sc *bufio.Scanner) error
-	// RestoreTx restores the database from sc in the given transaction.
-	RestoreTx(ctx context.Context, tx *sql.Tx, sc *bufio.Scanner) error
+	// Restore the database from src, which is a full backup.
+	Restore(ctx context.Context, src io.Reader) error
+	// RestoreTx restores the database from src in the given transaction.
+	RestoreTx(ctx context.Context, tx *sql.Tx, src io.Reader) error
 }
 
 // Register makes a database driver available by the provided type.

--- a/plugin/db/mysql/dump.go
+++ b/plugin/db/mysql/dump.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -662,7 +661,7 @@ func getTriggerStmt(txn *sql.Tx, dbName, triggerName string) (string, error) {
 }
 
 // Restore restores a database.
-func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error) {
+func (driver *Driver) Restore(ctx context.Context, sc io.Reader) (err error) {
 	txn, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -681,11 +680,11 @@ func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error
 }
 
 // RestoreTx restores a database in the given transaction.
-func (*Driver) RestoreTx(ctx context.Context, tx *sql.Tx, sc *bufio.Scanner) error {
+func (*Driver) RestoreTx(ctx context.Context, tx *sql.Tx, sc io.Reader) error {
 	return restoreTx(ctx, tx, sc)
 }
 
-func restoreTx(ctx context.Context, tx *sql.Tx, sc *bufio.Scanner) error {
+func restoreTx(ctx context.Context, tx *sql.Tx, sc io.Reader) error {
 	fnExecuteStmt := func(stmt string) error {
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
 			return err

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math"
 	"os"
@@ -204,7 +205,7 @@ func (driver *Driver) GetReplayedBinlogBytes() int64 {
 // RestorePITR is a wrapper to perform PITR. It restores a full backup followed by replaying the binlog.
 // It performs the step 1 of the restore process.
 // TODO(dragonly): Refactor so that the first part is in driver.Restore, and remove this wrapper.
-func (driver *Driver) RestorePITR(ctx context.Context, fullBackup *bufio.Scanner, startBinlogInfo api.BinlogInfo, database string, suffixTs, targetTs int64) error {
+func (driver *Driver) RestorePITR(ctx context.Context, fullBackup io.Reader, startBinlogInfo api.BinlogInfo, database string, suffixTs, targetTs int64) error {
 	pitrDatabaseName := getPITRDatabaseName(database, suffixTs)
 	query := fmt.Sprintf(""+
 		// Create the pitr database.

--- a/plugin/db/pg/dump.go
+++ b/plugin/db/pg/dump.go
@@ -131,7 +131,7 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 }
 
 // Restore restores a database.
-func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error) {
+func (driver *Driver) Restore(ctx context.Context, sc io.Reader) (err error) {
 	txn, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -157,6 +157,6 @@ func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error
 }
 
 // RestoreTx restores the database in the given transaction.
-func (*Driver) RestoreTx(context.Context, *sql.Tx, *bufio.Scanner) error {
+func (*Driver) RestoreTx(context.Context, *sql.Tx, io.Reader) error {
 	return fmt.Errorf("Unimplemented")
 }

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -1,7 +1,6 @@
 package pg
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -272,8 +271,8 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 		}
 		return nil
 	}
-	sc := bufio.NewScanner(strings.NewReader(statement))
-	if err := util.ApplyMultiStatements(sc, f); err != nil {
+
+	if err := util.ApplyMultiStatements(strings.NewReader(statement), f); err != nil {
 		return err
 	}
 

--- a/plugin/db/snowflake/dump.go
+++ b/plugin/db/snowflake/dump.go
@@ -1,7 +1,6 @@
 package snowflake
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -135,7 +134,7 @@ func dumpOneDatabase(ctx context.Context, txn *sql.Tx, database string, out io.W
 }
 
 // Restore restores a database.
-func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error) {
+func (driver *Driver) Restore(ctx context.Context, sc io.Reader) (err error) {
 	if err := driver.useRole(ctx, sysAdminRole); err != nil {
 		return nil
 	}
@@ -164,6 +163,6 @@ func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error
 }
 
 // RestoreTx restores the database in the given transaction.
-func (*Driver) RestoreTx(context.Context, *sql.Tx, *bufio.Scanner) error {
+func (*Driver) RestoreTx(context.Context, *sql.Tx, io.Reader) error {
 	return fmt.Errorf("Unimplemented")
 }

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -1,7 +1,6 @@
 package snowflake
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -221,8 +220,8 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 		count++
 		return nil
 	}
-	sc := bufio.NewScanner(strings.NewReader(statement))
-	if err := util.ApplyMultiStatements(sc, f); err != nil {
+
+	if err := util.ApplyMultiStatements(strings.NewReader(statement), f); err != nil {
 		return err
 	}
 

--- a/plugin/db/sqlite/dump.go
+++ b/plugin/db/sqlite/dump.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -150,7 +149,7 @@ func exportTableData(txn *sql.Tx, tblName string, out io.Writer) error {
 }
 
 // Restore restores a database.
-func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error) {
+func (driver *Driver) Restore(ctx context.Context, sc io.Reader) (err error) {
 	txn, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -176,6 +175,6 @@ func (driver *Driver) Restore(ctx context.Context, sc *bufio.Scanner) (err error
 }
 
 // RestoreTx restores the database in the given transaction.
-func (*Driver) RestoreTx(context.Context, *sql.Tx, *bufio.Scanner) error {
+func (*Driver) RestoreTx(context.Context, *sql.Tx, io.Reader) error {
 	return fmt.Errorf("Unimplemented")
 }

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -147,8 +146,8 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 		}
 		return nil
 	}
-	sc := bufio.NewScanner(strings.NewReader(statement))
-	if err := util.ApplyMultiStatements(sc, f); err != nil {
+
+	if err := util.ApplyMultiStatements(strings.NewReader(statement), f); err != nil {
 		return err
 	}
 

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -24,12 +25,13 @@ func FormatErrorWithQuery(err error, query string) error {
 }
 
 // ApplyMultiStatements will apply the split statements from scanner.
-func ApplyMultiStatements(sc *bufio.Scanner, f func(string) error) error {
+func ApplyMultiStatements(sc io.Reader, f func(string) error) error {
+	scanner := bufio.NewScanner(sc)
 	s := ""
 	delimiter := false
 	comment := false
-	for sc.Scan() {
-		line := sc.Text()
+	for scanner.Scan() {
+		line := scanner.Text()
 
 		execute := false
 		switch {
@@ -88,7 +90,7 @@ func ApplyMultiStatements(sc *bufio.Scanner, f func(string) error) error {
 		}
 	}
 
-	if err := sc.Err(); err != nil {
+	if err := scanner.Err(); err != nil {
 		return err
 	}
 	return nil

--- a/server/sql.go
+++ b/server/sql.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -592,8 +591,7 @@ func getLatestSchemaVersion(ctx context.Context, driver db.Driver, databaseName 
 func validateSQLSelectStatement(sqlStatement string) bool {
 	// Check if the query has only one statement.
 	count := 0
-	sc := bufio.NewScanner(strings.NewReader(sqlStatement))
-	if err := util.ApplyMultiStatements(sc, func(_ string) error {
+	if err := util.ApplyMultiStatements(strings.NewReader(sqlStatement), func(_ string) error {
 		count++
 		return nil
 	}); err != nil {

--- a/server/task_executor_database_restore.go
+++ b/server/task_executor_database_restore.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -135,14 +134,13 @@ func (*DatabaseRestoreTaskExecutor) restoreDatabase(ctx context.Context, instanc
 		backupPath = filepath.Join(dataDir, backupPath)
 	}
 
-	f, err := os.OpenFile(backupPath, os.O_RDONLY, os.ModePerm)
+	f, err := os.Open(backupPath)
 	if err != nil {
 		return fmt.Errorf("failed to open backup file at %s: %w", backupPath, err)
 	}
 	defer f.Close()
-	sc := bufio.NewScanner(f)
 
-	if err := driver.Restore(ctx, sc); err != nil {
+	if err := driver.Restore(ctx, f); err != nil {
 		return fmt.Errorf("failed to restore backup: %w", err)
 	}
 	return nil

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -116,7 +115,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 	}
 	log.Debug("Got latest backup before or equal to targetTs", zap.String("backup", backup.Name))
 	backupFileName := getBackupAbsFilePath(dataDir, backup.DatabaseID, backup.Name)
-	backupFile, err := os.OpenFile(backupFileName, os.O_RDONLY, os.ModePerm)
+	backupFile, err := os.Open(backupFileName)
 	if err != nil {
 		return fmt.Errorf("failed to open backup file %q, error: %w", backupFileName, err)
 	}
@@ -136,7 +135,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, task *ap
 		return fmt.Errorf("failed to setup progress update process, error: %w", err)
 	}
 
-	if err := mysqlDriver.RestorePITR(ctx, bufio.NewScanner(backupFile), startBinlogInfo, database.Name, issue.CreatedTs, targetTs); err != nil {
+	if err := mysqlDriver.RestorePITR(ctx, backupFile, startBinlogInfo, database.Name, issue.CreatedTs, targetTs); err != nil {
 		log.Error("failed to perform a PITR restore in the PITR database",
 			zap.Int("issueID", issue.ID),
 			zap.String("database", database.Name),

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -88,7 +88,7 @@ func TestBackupRestoreBasic(t *testing.T) {
 	a.NoError(err)
 
 	// restore
-	err = driver.Restore(ctx, bufio.NewScanner(buf))
+	err = driver.Restore(ctx, bufio.NewReader(buf))
 	a.NoError(err)
 
 	// validate data


### PR DESCRIPTION
The first step of we use the MySQL client to speed up the restore.
Complete BYT-975.