### PR TITLE
fix(timing): task executes after earliest allowed time

### DIFF
--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -29,11 +29,8 @@ func (s *Server) ScheduleNextTaskIfNeeded(ctx context.Context, pipeline *api.Pip
 					return nil, fmt.Errorf("failed to get approval policy for environment ID %d, error: %w", task.Instance.EnvironmentID, err)
 				}
 				if policy.Value == api.PipelineApprovalValueManualNever {
-					// transit into Pending for ManualNever (auto-approval) tasks.
-					// Requirements:
-					// 1. has no blocking tasks.
-					// 2. task check results are all SUCCESS.
-					ok, err := s.TaskScheduler.canTransitTaskStatus(ctx, task, api.TaskCheckStatusSuccess)
+					// transit into Pending for ManualNever (auto-approval) tasks if all required task checks passed.
+					ok, err := s.TaskScheduler.canAutoApprove(ctx, task)
 					if err != nil {
 						return nil, err
 					}

--- a/server/task.go
+++ b/server/task.go
@@ -40,12 +40,12 @@ func (s *Server) canUpdateTaskStatement(ctx context.Context, task *api.Task) *ec
 	// Allow frontend to change the SQL statement of
 	// 1. a PendingApproval task which hasn't started yet
 	// 2. a Failed task which can be retried
-	// 3. a Pending task which can't be scheduled because of failed task checks
+	// 3. a Pending task which can't be scheduled because of failed task checks, task dependency or earliest allowed time
 	if task.Status != api.TaskPendingApproval && task.Status != api.TaskFailed && task.Status != api.TaskPending {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("can not update task in %q state", task.Status))
 	}
 	if task.Status == api.TaskPending {
-		ok, err := s.TaskScheduler.canTransitTaskStatus(ctx, task, api.TaskCheckStatusWarn)
+		ok, err := s.TaskScheduler.canSchedule(ctx, task)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to check whether the task can be scheduled").SetInternal(err)
 		}

--- a/server/task_check_executor_timing.go
+++ b/server/task_check_executor_timing.go
@@ -35,7 +35,7 @@ func (*TaskCheckTimingExecutor) Run(_ context.Context, _ *Server, taskCheckRun *
 				Namespace: api.BBNamespace,
 				Code:      common.Ok.Int(),
 				Title:     "OK",
-				Content:   "Earliest allowed time unset",
+				Content:   "Earliest allowed time is not set",
 			},
 		}, nil
 	}
@@ -44,7 +44,7 @@ func (*TaskCheckTimingExecutor) Run(_ context.Context, _ *Server, taskCheckRun *
 	if time.Now().UTC().Before(time.Unix(payload.EarliestAllowedTs, 0).UTC()) {
 		return []api.TaskCheckResult{
 			{
-				Status:    api.TaskCheckStatusError,
+				Status:    api.TaskCheckStatusWarn,
 				Namespace: api.BBNamespace,
 				Code:      common.TaskTimingNotAllowed.Int(),
 				Title:     "Not ready to run",

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -178,7 +178,7 @@ func (s *TaskCheckScheduler) Register(taskType api.TaskCheckType, executor TaskC
 }
 
 // Returns true if we meet either of the following conditions:
-//   1. Task has a non-default value and no task check has run before (so we are about to kick of the check the first time)
+//   1. Task has a non-default value and no task check has run before (so we are about to kick off the check for the first time)
 //   2. The specified EarliestAllowedTs has elapsed, so we need to rerun the check to unblock the task.
 // On the other hand, we would also rerun the check if user has modified EarliestAllowedTs. This is handled separately in the task patch handler.
 func (s *TaskCheckScheduler) shouldScheduleTimingTaskCheck(ctx context.Context, task *api.Task, forceSchedule bool) (bool, error) {


### PR DESCRIPTION
Previously, the timing task check returns an error if the time condition is not met, which will stop the assignee from approving and is not what we expect.

In this PR, we make it returns a warning so that it won't prevent approval. We check the time when the task scheduler tries to run the task to implement the "timing" feature.

Close BYT-1070