### PR TITLE
feat(frontend): BYT-1053 make SQL change activity more readable

### DIFF
--- a/frontend/src/components/DatabaseTable.vue
+++ b/frontend/src/components/DatabaseTable.vue
@@ -17,7 +17,7 @@
         <slot name="selection" :database="database" />
       </BBTableCell>
       <BBTableCell :left-padding="showSelectionColumn ? 2 : 4" class="w-[25%]">
-        <div class="flex items-center space-x-2 tooltip-wrapper">
+        <div class="flex items-center space-x-2">
           <span>{{ database.name }}</span>
           <BBBadge
             v-if="isPITRDatabase(database)"

--- a/frontend/src/components/Issue/activity/ActionSentence.vue
+++ b/frontend/src/components/Issue/activity/ActionSentence.vue
@@ -1,12 +1,9 @@
 <template>
-  <template v-if="typeof actionSentence === 'string'">
-    {{ actionSentence }}
-  </template>
-  <component :is="() => actionSentence" v-else />
+  <renderer />
 </template>
 
 <script lang="ts" setup>
-import { h, PropType, computed } from "vue";
+import { h, PropType } from "vue";
 import {
   Activity,
   ActivityTaskEarliestAllowedTimeUpdatePayload,
@@ -34,7 +31,7 @@ const props = defineProps({
 
 const { t } = useI18n();
 
-const actionSentence = computed(() => {
+const renderActionSentence = () => {
   const { activity, issue } = props;
   if (activity.type.startsWith("bb.issue.")) {
     const [tid, params] = issueActivityActionSentence(activity);
@@ -123,7 +120,11 @@ const actionSentence = computed(() => {
     }
   }
   return "";
-});
+};
+
+const renderer = {
+  render: renderActionSentence,
+};
 
 const renderStatement = (statement: string) => {
   return h(SQLPreviewPopover, {

--- a/frontend/src/components/Issue/activity/ActionSentence.vue
+++ b/frontend/src/components/Issue/activity/ActionSentence.vue
@@ -1,0 +1,136 @@
+<template>
+  <template v-if="typeof actionSentence === 'string'">
+    {{ actionSentence }}
+  </template>
+  <component :is="() => actionSentence" v-else />
+</template>
+
+<script lang="ts" setup>
+import { h, PropType, computed } from "vue";
+import {
+  Activity,
+  ActivityTaskEarliestAllowedTimeUpdatePayload,
+  ActivityTaskFileCommitPayload,
+  ActivityTaskStatementUpdatePayload,
+  ActivityTaskStatusUpdatePayload,
+  Issue,
+  SYSTEM_BOT_ID,
+} from "@/types";
+import { findTaskById, issueActivityActionSentence } from "@/utils";
+import { Translation, useI18n } from "vue-i18n";
+import dayjs from "dayjs";
+import SQLPreviewPopover from "@/components/misc/SQLPreviewPopover.vue";
+
+const props = defineProps({
+  activity: {
+    type: Object as PropType<Activity>,
+    required: true,
+  },
+  issue: {
+    type: Object as PropType<Issue>,
+    required: true,
+  },
+});
+
+const { t } = useI18n();
+
+const actionSentence = computed(() => {
+  const { activity, issue } = props;
+  if (activity.type.startsWith("bb.issue.")) {
+    const [tid, params] = issueActivityActionSentence(activity);
+    return t(tid, params);
+  }
+  switch (activity.type) {
+    case "bb.pipeline.task.status.update": {
+      const payload = activity.payload as ActivityTaskStatusUpdatePayload;
+      if (payload.newStatus === "PENDING_APPROVAL") {
+        // stale approval dismissed.
+
+        const task = findTaskById(issue.pipeline, payload.taskId);
+        const taskName = t("activity.sentence.task-name", {
+          name: task.name,
+        });
+        return t("activity.sentence.dismissed-stale-approval", {
+          task: taskName,
+        });
+      }
+
+      let str = t("activity.sentence.changed");
+      switch (payload.newStatus) {
+        case "PENDING": {
+          if (payload.oldStatus == "RUNNING") {
+            str = t("activity.sentence.canceled");
+          } else if (payload.oldStatus == "PENDING_APPROVAL") {
+            str = t("activity.sentence.approved");
+          }
+          break;
+        }
+        case "RUNNING": {
+          str = t("activity.sentence.started");
+          break;
+        }
+        case "DONE": {
+          str = t("activity.sentence.completed");
+          break;
+        }
+        case "FAILED": {
+          str = t("activity.sentence.failed");
+          break;
+        }
+      }
+      if (activity.creator.id != SYSTEM_BOT_ID) {
+        // If creator is not the robot (which means we do NOT use task name in the subject),
+        // then we append the task name here.
+        const task = findTaskById(issue.pipeline, payload.taskId);
+        str += t("activity.sentence.task-name", { name: task.name });
+      }
+      return str;
+    }
+    case "bb.pipeline.task.file.commit": {
+      const payload = activity.payload as ActivityTaskFileCommitPayload;
+      // return `committed ${payload.filePath} to ${payload.branch}@${payload.repositoryFullPath}`;
+      return t("activity.sentence.committed-to-at", {
+        file: payload.filePath,
+        branch: payload.branch,
+        repo: payload.repositoryFullPath,
+      });
+    }
+    case "bb.pipeline.task.statement.update": {
+      const payload = activity.payload as ActivityTaskStatementUpdatePayload;
+
+      return h(
+        Translation,
+        {
+          keypath: "activity.sentence.changed-from-to",
+        },
+        {
+          name: () => "SQL",
+          oldValue: () => renderStatement(payload.oldStatement),
+          newValue: () => renderStatement(payload.newStatement),
+        }
+      );
+    }
+    case "bb.pipeline.task.general.earliest-allowed-time.update": {
+      const payload =
+        activity.payload as ActivityTaskEarliestAllowedTimeUpdatePayload;
+      const newVal = payload.newEarliestAllowedTs;
+      const oldVal = payload.oldEarliestAllowedTs;
+      return t("activity.sentence.changed-from-to", {
+        name: "earliest allowed time",
+        oldValue: oldVal ? dayjs(oldVal * 1000) : "Unset",
+        newValue: newVal ? dayjs(newVal * 1000) : "Unset",
+      });
+    }
+  }
+  return "";
+});
+
+const renderStatement = (statement: string) => {
+  return h(SQLPreviewPopover, {
+    statement,
+    maxLength: 50,
+    width: 400,
+    statementClass: "text-main",
+  });
+};
+</script>

--- a/frontend/src/components/MigrationHistoryTable.vue
+++ b/frontend/src/components/MigrationHistoryTable.vue
@@ -65,26 +65,11 @@
         </template>
       </BBTableCell>
       <BBTableCell>
-        <NPopover
-          :disabled="history.statement.length < 100"
-          style="max-height: 300px"
+        <SQLPreviewPopover
+          :statement="history.statement"
+          :max-length="100"
           placement="bottom"
-          width="trigger"
-          scrollable
-        >
-          <highlight-code-block
-            :code="history.statement"
-            class="whitespace-pre-wrap"
-          />
-
-          <template #trigger>
-            {{
-              history.statement.length > 100
-                ? history.statement.substring(0, 100) + "..."
-                : history.statement
-            }}
-          </template>
-        </NPopover>
+        />
       </BBTableCell>
       <BBTableCell>
         {{ nanosecondsToString(history.executionDurationNs) }}
@@ -100,7 +85,6 @@
 </template>
 
 <script lang="ts">
-import { NPopover } from "naive-ui";
 import { computed, defineComponent, PropType } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
@@ -112,13 +96,14 @@ import {
   nanosecondsToString,
 } from "@/utils";
 import MigrationHistoryStatusIcon from "./MigrationHistoryStatusIcon.vue";
+import SQLPreviewPopover from "./misc/SQLPreviewPopover.vue";
 
 type Mode = "DATABASE" | "PROJECT";
 
 export default defineComponent({
   name: "MigrationHistoryTable",
   components: {
-    NPopover,
+    SQLPreviewPopover,
     MigrationHistoryStatusIcon,
   },
   props: {

--- a/frontend/src/components/misc/SQLPreviewPopover.vue
+++ b/frontend/src/components/misc/SQLPreviewPopover.vue
@@ -1,0 +1,50 @@
+<template>
+  <NPopover
+    :disabled="statement.length <= maxLength"
+    :placement="placement"
+    style="max-height: 300px"
+    width="trigger"
+    scrollable
+  >
+    <highlight-code-block :code="statement" class="whitespace-pre-wrap" />
+
+    <template #trigger>
+      <span :class="statementClass">
+        {{
+          statement.length <= maxLength
+            ? statement
+            : statement.substring(0, maxLength) + "..."
+        }}
+      </span>
+    </template>
+  </NPopover>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import { NPopover, PopoverPlacement } from "naive-ui";
+import { VueClass } from "@/utils";
+
+export default defineComponent({
+  name: "SQLPreviewPopover",
+  components: { NPopover },
+  props: {
+    statement: {
+      type: String,
+      required: true,
+    },
+    maxLength: {
+      type: Number,
+      default: 100,
+    },
+    placement: {
+      type: String as PropType<PopoverPlacement>,
+      default: "top",
+    },
+    statementClass: {
+      type: [String, Object, Array] as PropType<VueClass>,
+      default: undefined,
+    },
+  },
+});
+</script>


### PR DESCRIPTION
Close BYT-1053
Proposed by @candy2255 

### Feature
- Cut the displayed SQL statement if it's too long.
- Color the SQL statement a little bit darker to make it easier to be distinguished as "from ... to ..." pattern.
- We also extracted the "action sentence" from plain text to a component. Enabling us to render richer activity action sentences in the future.

The `actionSentence` is complex, that's why we didn't refactor it to template logic this time.

### Screenshot
See "CREATE TABLE ......"
![IssueActivityActionSentence](https://user-images.githubusercontent.com/2749742/183820316-6bc7ae94-d585-442a-b89a-acc9ec349f42.png)
