### PR TITLE
refactor: read backup storage backend from server profile

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -127,9 +127,9 @@ type BackupCreate struct {
 	DatabaseID int `jsonapi:"attr,databaseId"`
 
 	// Domain specific fields
-	Name                    string               `jsonapi:"attr,name"`
-	Type                    BackupType           `jsonapi:"attr,type"`
-	StorageBackend          BackupStorageBackend `jsonapi:"attr,storageBackend"`
+	Name                    string     `jsonapi:"attr,name"`
+	Type                    BackupType `jsonapi:"attr,type"`
+	StorageBackend          BackupStorageBackend
 	MigrationHistoryVersion string
 	Path                    string
 }

--- a/bin/server/cmd/profile.go
+++ b/bin/server/cmd/profile.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/server"
 )
@@ -22,6 +23,7 @@ func GetTestProfile(dataDir string, port int) server.Profile {
 		DataDir:              dataDir,
 		DemoDataDir:          fmt.Sprintf("demo/%s", common.ReleaseModeDev),
 		BackupRunnerInterval: 10 * time.Second,
+		BackupStorageBackend: api.BackupStorageBackendLocal,
 	}
 }
 
@@ -37,6 +39,7 @@ func GetTestProfileWithExternalPg(dataDir string, port int, pgUser string, pgURL
 		DataDir:              dataDir,
 		DemoDataDir:          fmt.Sprintf("demo/%s", common.ReleaseModeDev),
 		BackupRunnerInterval: 10 * time.Second,
+		BackupStorageBackend: api.BackupStorageBackendLocal,
 		PgURL:                pgURL,
 	}
 }

--- a/bin/server/cmd/profile_dev.go
+++ b/bin/server/cmd/profile_dev.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/server"
 )
 
-func activeProfile(dataDir string) server.Profile {
+func activeProfile(dataDir string, backupStorageBackend api.BackupStorageBackend) server.Profile {
 	// `flags.demo` always be true in dev mode
 	demoName := string(common.ReleaseModeDev)
 	if flags.demoName != "" {
@@ -35,6 +36,7 @@ func activeProfile(dataDir string) server.Profile {
 		DataDir:              dataDir,
 		DemoDataDir:          demoDataDir,
 		BackupRunnerInterval: 10 * time.Second,
+		BackupStorageBackend: backupStorageBackend,
 		Version:              version,
 		GitCommit:            gitcommit,
 		PgURL:                flags.pgURL,

--- a/bin/server/cmd/profile_release.go
+++ b/bin/server/cmd/profile_release.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/server"
 )
 
-func activeProfile(dataDir string) server.Profile {
+func activeProfile(dataDir string, backupStorageBackend api.BackupStorageBackend) server.Profile {
 	demoDataDir := ""
 	if flags.demo {
 		demoName := string(common.ReleaseModeProd)
@@ -37,6 +38,7 @@ func activeProfile(dataDir string) server.Profile {
 		DataDir:              dataDir,
 		DemoDataDir:          demoDataDir,
 		BackupRunnerInterval: 10 * time.Minute,
+		BackupStorageBackend: backupStorageBackend,
 		Version:              version,
 		GitCommit:            gitcommit,
 		PgURL:                flags.pgURL,

--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/server"
@@ -172,7 +173,7 @@ func start() {
 		return
 	}
 
-	activeProfile := activeProfile(flags.dataDir)
+	activeProfile := activeProfile(flags.dataDir, api.BackupStorageBackendLocal)
 
 	var s *server.Server
 	// Setup signal handlers.

--- a/frontend/src/components/DatabaseBackupPanel.vue
+++ b/frontend/src/components/DatabaseBackupPanel.vue
@@ -374,7 +374,6 @@ export default defineComponent({
         databaseId: props.database.id!,
         name: backupName,
         type: "MANUAL",
-        storageBackend: "LOCAL",
       };
       backupStore.createBackup({
         databaseId: props.database.id,

--- a/frontend/src/types/backup.ts
+++ b/frontend/src/types/backup.ts
@@ -5,7 +5,7 @@ export type BackupStatus = "PENDING_CREATE" | "DONE" | "FAILED";
 
 export type BackupType = "MANUAL" | "AUTOMATIC" | "PITR";
 
-export type BackupStorageBackend = "LOCAL";
+export type BackupStorageBackend = "LOCAL" | "S3" | "GCS";
 
 // Backup
 export type Backup = {
@@ -36,7 +36,6 @@ export type BackupCreate = {
   // Domain specific fields
   name: string;
   type: BackupType;
-  storageBackend: BackupStorageBackend;
 };
 
 // Backup setting.

--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -287,7 +287,7 @@ func (r *BackupRunner) startAutoBackups(ctx context.Context, runningTasks map[in
 				zap.String("database", database.Name),
 				zap.String("backup", backupName),
 			)
-			if _, err := r.server.scheduleBackupTask(ctx, database, backupName, api.BackupTypeAutomatic, api.BackupStorageBackendLocal, api.SystemBotID); err != nil {
+			if _, err := r.server.scheduleBackupTask(ctx, database, backupName, api.BackupTypeAutomatic, api.SystemBotID); err != nil {
 				log.Error("Failed to create automatic backup for database",
 					zap.Int("databaseID", database.ID),
 					zap.Error(err))
@@ -308,7 +308,7 @@ func (r *BackupRunner) startAutoBackups(ctx context.Context, runningTasks map[in
 	}
 }
 
-func (s *Server) scheduleBackupTask(ctx context.Context, database *api.Database, backupName string, backupType api.BackupType, storageBackend api.BackupStorageBackend, creatorID int) (*api.Backup, error) {
+func (s *Server) scheduleBackupTask(ctx context.Context, database *api.Database, backupName string, backupType api.BackupType, creatorID int) (*api.Backup, error) {
 	// Store the migration history version if exists.
 	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstanceDir, common.GetResourceDir(s.profile.DataDir))
 	if err != nil {
@@ -328,7 +328,7 @@ func (s *Server) scheduleBackupTask(ctx context.Context, database *api.Database,
 		CreatorID:               creatorID,
 		DatabaseID:              database.ID,
 		Name:                    backupName,
-		StorageBackend:          storageBackend,
+		StorageBackend:          s.profile.BackupStorageBackend,
 		Type:                    backupType,
 		Path:                    path,
 		MigrationHistoryVersion: migrationHistoryVersion,

--- a/server/config.go
+++ b/server/config.go
@@ -3,6 +3,7 @@ package server
 import (
 	"time"
 
+	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 )
 
@@ -51,6 +52,8 @@ type Profile struct {
 	DemoDataDir string
 	// BackupRunnerInterval is the interval for backup runner.
 	BackupRunnerInterval time.Duration
+	// BackupStorageBackend is the backup storage backend.
+	BackupStorageBackend api.BackupStorageBackend
 	// Version is the bytebase's version
 	Version string
 	// Git commit hash of the build

--- a/server/server.go
+++ b/server/server.go
@@ -115,6 +115,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 	log.Info(fmt.Sprintf("demo=%t", prof.Demo))
 	log.Info(fmt.Sprintf("debug=%t", prof.Debug))
 	log.Info(fmt.Sprintf("dataDir=%s", prof.DataDir))
+	log.Info(fmt.Sprintf("backupStorageBackend=%s", prof.BackupStorageBackend))
 	log.Info("-----Config END-------")
 
 	serverStarted := false

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -112,7 +112,7 @@ func (*PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.Task,
 	log.Debug("Finished swapping the original and PITR database", zap.String("originalDatabase", task.Database.Name), zap.String("pitrDatabase", pitrDatabaseName), zap.String("oldDatabase", pitrOldDatabaseName))
 
 	backupName := fmt.Sprintf("%s-%s-pitr-%d", api.ProjectShortSlug(task.Database.Project), api.EnvSlug(task.Database.Instance.Environment), issue.CreatedTs)
-	if _, err := server.scheduleBackupTask(ctx, task.Database, backupName, api.BackupTypePITR, api.BackupStorageBackendLocal, api.SystemBotID); err != nil {
+	if _, err := server.scheduleBackupTask(ctx, task.Database, backupName, api.BackupTypePITR, api.SystemBotID); err != nil {
 		return true, nil, fmt.Errorf("failed to schedule backup task for database %q after PITR, error: %w", task.Database.Name, err)
 	}
 


### PR DESCRIPTION
1. Do not pass backup storage backend from the frontend when creating a backup manually
2. Read backup storage backend from the server profile

When we later add command line flags to choose from local or s3/gcs buckets, the backup storage backend in the profile will be set accordingly.