### PR TITLE
feat: add database name in restore task field

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -70,7 +70,8 @@ type TaskDatabasePITRRestorePayload struct {
 	ProjectID int `json:"projectId,omitempty"`
 
 	// DatabaseName is the target database name.
-	DatabaseName string `json:"databaseName,omitempty"`
+	// It should be non-zero and non-null if not in the case of PITR inplace
+	DatabaseName *string `json:"databaseName,omitempty"`
 
 	// TargetInstanceId must be within the same environment as the instance of the original database.
 	// Only used when doing PITR to a new database.

--- a/api/task.go
+++ b/api/task.go
@@ -70,7 +70,7 @@ type TaskDatabasePITRRestorePayload struct {
 	ProjectID int `json:"projectId,omitempty"`
 
 	// DatabaseName is the target database name.
-	// It should be non-zero and non-null if not in the case of PITR inplace
+	// It is nil for the case of in-place PITR.
 	DatabaseName *string `json:"databaseName,omitempty"`
 
 	// TargetInstanceId must be within the same environment as the instance of the original database.

--- a/api/task.go
+++ b/api/task.go
@@ -69,6 +69,9 @@ type TaskDatabasePITRRestorePayload struct {
 	// The project owning the database.
 	ProjectID int `json:"projectId,omitempty"`
 
+	// DatabaseName is the target database name.
+	DatabaseName string `json:"databaseName,omitempty"`
+
 	// TargetInstanceId must be within the same environment as the instance of the original database.
 	// Only used when doing PITR to a new database.
 	TargetInstanceID *int `json:"targetInstanceId,omitempty"`


### PR DESCRIPTION
We need the target database name to restore a full backup.