### PR TITLE
fix(db): handle edge cases for `ParseMigrationInfo`

### DIFF
--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -250,6 +250,8 @@ func ParseMigrationInfo(filePath string, filePathTemplate string) (*MigrationInf
 		"TYPE",
 		"DESCRIPTION",
 	}
+
+	// Escape "." characters to match literals instead of using it as a wildcard.
 	filePathRegex := strings.ReplaceAll(filePathTemplate, ".", `\.`)
 	for _, placeholder := range placeholderList {
 		filePathRegex = strings.ReplaceAll(filePathRegex, fmt.Sprintf("{{%s}}", placeholder), fmt.Sprintf("(?P<%s>[a-zA-Z0-9+-=/_#?!$. ]+)", placeholder))

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -250,7 +250,7 @@ func ParseMigrationInfo(filePath string, filePathTemplate string) (*MigrationInf
 		"TYPE",
 		"DESCRIPTION",
 	}
-	filePathRegex := filePathTemplate
+	filePathRegex := strings.ReplaceAll(filePathTemplate, ".", `\.`)
 	for _, placeholder := range placeholderList {
 		filePathRegex = strings.ReplaceAll(filePathRegex, fmt.Sprintf("{{%s}}", placeholder), fmt.Sprintf("(?P<%s>[a-zA-Z0-9+-=/_#?!$. ]+)", placeholder))
 	}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -260,11 +260,11 @@ func validateGitHubWebhookSignature256(signature, key string, body []byte) (bool
 // we need to filter the commit list to prevent creating a duplicated issue. GitLab has a limitation to distinguish
 // whether the commit is a merge commit (https://gitlab.com/gitlab-org/gitlab/-/issues/30914), so we need to dedup
 // ourselves. Below is the filtering algorithm:
-// 1. If we observe the same migration file multiple times, then we should use the latest migration file. This does not matter
-//    for change-based migration since a developer would always create different migration file with incremental names, while it
-//    will be important for the state-based migration, since the file name is always the same and we need to use the latest snapshot.
-// 2. Maintain the relative commit order between different migration files. If migration file A happens before migration file B,
-//    then we should create an issue for migration file A first.
+//  1. If we observe the same migration file multiple times, then we should use the latest migration file. This does not matter
+//     for change-based migration since a developer would always create different migration file with incremental names, while it
+//     will be important for the state-based migration, since the file name is always the same and we need to use the latest snapshot.
+//  2. Maintain the relative commit order between different migration files. If migration file A happens before migration file B,
+//     then we should create an issue for migration file A first.
 type distinctFileItem struct {
 	createdTime time.Time
 	commit      gitlab.WebhookCommit
@@ -469,7 +469,7 @@ func (s *Server) createIssueFromPushEvent(ctx context.Context, repo *api.Reposit
 		}
 	}
 
-	mi, err := db.ParseMigrationInfo(fileEscaped, filepath.Join(repo.BaseDirectory, repo.FilePathTemplate))
+	mi, err := db.ParseMigrationInfo(fileEscaped, path.Join(repo.BaseDirectory, repo.FilePathTemplate))
 	if err != nil {
 		createIgnoredFileActivity(err)
 		return "", false, nil

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -469,6 +469,7 @@ func (s *Server) createIssueFromPushEvent(ctx context.Context, repo *api.Reposit
 		}
 	}
 
+	// NOTE: We do not want to use filepath.Join here because we always need "/" as the path separator.
 	mi, err := db.ParseMigrationInfo(fileEscaped, path.Join(repo.BaseDirectory, repo.FilePathTemplate))
 	if err != nil {
 		createIgnoredFileActivity(err)


### PR DESCRIPTION
This PR addresses two edge cases for `db.ParseMigrationInfo`:

1. Use `path.Join` instead of `filepath.Join` because if the Bytebase happens to run on Windows, the result would be something like `bytebase\testdb__migrate__20220811000000.sql`, and it is never going to be matched with the file path sent from the VCS because all known VCS uses Unix style OS separators (`/`).
2. Escape the `.` characters before sending to be compiled as a regex, it would match any single character instead of `.` literals. See added test case for a failure case.