### PR TITLE
feat: validate change task status privilege by role & policy

### DIFF
--- a/server/stage.go
+++ b/server/stage.go
@@ -44,8 +44,12 @@ func (s *Server) registerStageRoutes(g *echo.Group) {
 		}
 		// pick any task in the stage to validate
 		// because all tasks in the same stage share the issue & environment.
-		if err := s.validatePrincipalChangeTaskStatus(ctx, currentPrincipalID, tasks[0]); err != nil {
-			return err
+		ok, err := s.canPrincipalChangeTaskStatus(ctx, currentPrincipalID, tasks[0])
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to validate if the principal can change task status").SetInternal(err)
+		}
+		if !ok {
+			return echo.NewHTTPError(http.StatusUnauthorized, "Not allowed to change task status")
 		}
 		var tasksPatched []*api.Task
 		for _, task := range tasks {

--- a/server/stage.go
+++ b/server/stage.go
@@ -34,13 +34,18 @@ func (s *Server) registerStageRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, "Malformed update stage tasks status request").SetInternal(err)
 		}
 
-		if err := s.validateIssueAssignee(ctx, currentPrincipalID, pipelineID); err != nil {
-			return err
-		}
-
 		tasks, err := s.store.FindTask(ctx, &api.TaskFind{PipelineID: &pipelineID, StageID: &stageID}, true /* returnOnErr */)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get tasks").SetInternal(err)
+		}
+		if len(tasks) == 0 {
+			// which is impossible, because we make sure at least there is one task in each stage.
+			return echo.NewHTTPError(http.StatusInternalServerError, "No task in the stage")
+		}
+		// pick any task in the stage to validate
+		// because all tasks in the same stage share the issue & environment.
+		if err := s.validatePrincipalChangeTaskStatus(ctx, currentPrincipalID, tasks[0]); err != nil {
+			return err
 		}
 		var tasksPatched []*api.Task
 		for _, task := range tasks {

--- a/server/task.go
+++ b/server/task.go
@@ -499,7 +499,7 @@ func (s *Server) validatePrincipalChangeTaskStatus(ctx context.Context, principa
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find issue").SetInternal(err)
 	}
 	if issue == nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Issue not found by pipeline ID: %d", task.PipelineID))
+		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Issue not found by pipeline ID: %d", task.PipelineID))
 	}
 	groupValue, err := func() (*api.AssigneeGroupValue, error) {
 		environmentID := api.UnknownID
@@ -510,7 +510,7 @@ func (s *Server) validatePrincipalChangeTaskStatus(ctx context.Context, principa
 			}
 		}
 		if environmentID == api.UnknownID {
-			return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to find environmentID by task.StageID %d", task.StageID))
+			return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Failed to find environmentID by task.StageID %d", task.StageID))
 		}
 
 		policy, err := s.store.GetPipelineApprovalPolicy(ctx, environmentID)

--- a/server/task.go
+++ b/server/task.go
@@ -530,18 +530,16 @@ func (s *Server) validatePrincipalChangeTaskStatus(ctx context.Context, principa
 	if err != nil {
 		return err
 	}
-	if groupValue != nil {
-		if *groupValue == api.AssigneeGroupValueProjectOwner {
-			member, err := s.store.GetProjectMember(ctx, &api.ProjectMemberFind{
-				ProjectID:   &issue.ProjectID,
-				PrincipalID: &principalID,
-			})
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get project member by projectID %d, principalID %d", issue.ProjectID, principalID).SetInternal(err)
-			}
-			if member != nil && member.Role == string(api.Owner) {
-				return nil
-			}
+	if groupValue != nil && *groupValue == api.AssigneeGroupValueProjectOwner {
+		member, err := s.store.GetProjectMember(ctx, &api.ProjectMemberFind{
+			ProjectID:   &issue.ProjectID,
+			PrincipalID: &principalID,
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get project member by projectID %d, principalID %d", issue.ProjectID, principalID).SetInternal(err)
+		}
+		if member != nil && member.Role == string(api.Owner) {
+			return nil
 		}
 	}
 	principal, err := s.store.GetPrincipalByID(ctx, principalID)


### PR DESCRIPTION
Previously, we only allow
-  the owners and the DBAs if the assignee is the system bot
-  the assignee if set otherwise

to patch the task status.

Now, we judge who can change task status by their roles and the environment policy.
The workspace owners and the DBAs can change the task status no matter what.
The project owners can also change the task status if the policy says so.

@h3n4l FYI
