### PR TITLE
fix: use MIGRATE instead of BASELINE type for CREATE DATABASE

### DIFF
--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -183,7 +183,7 @@ const (
 	// 2. Had schema drift and need to re-establish the baseline.
 	Baseline MigrationType = "BASELINE"
 	// Migrate is the migration type for MIGRATE.
-	// Used for DDL change.
+	// Used for DDL change including CREATE DATABASE.
 	Migrate MigrationType = "MIGRATE"
 	// Branch is the migration type for BRANCH.
 	// Used when restoring from a backup (the restored database branched from the original backup).

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -163,13 +163,13 @@ func ExecuteMigration(ctx context.Context, executor MigrationExecutor, m *db.Mig
 
 	// Phase 3 - Executing migration
 	// Branch migration type always has empty sql.
-	// Baseline migration type could has non-empty sql but will not execute, except for CreateDatabase.
+	// Baseline migration type could has non-empty sql but will not execute.
 	// https://github.com/bytebase/bytebase/issues/394
 	doMigrate := true
 	if statement == "" {
 		doMigrate = false
 	}
-	if m.Type == db.Baseline && !m.CreateDatabase {
+	if m.Type == db.Baseline {
 		doMigrate = false
 	}
 	if doMigrate {

--- a/server/task_executor_database_create.go
+++ b/server/task_executor_database_create.go
@@ -60,7 +60,7 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 		zap.String("statement", statement),
 	)
 
-	// Create a baseline migration history upon creating the database.
+	// Create a migrate migration history upon creating the database.
 	// TODO(d): support semantic versioning.
 	mi := &db.MigrationInfo{
 		ReleaseVersion: server.profile.Version,
@@ -69,7 +69,7 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 		Database:       payload.DatabaseName,
 		Environment:    instance.Environment.Name,
 		Source:         db.UI,
-		Type:           db.Baseline,
+		Type:           db.Migrate,
 		Description:    "Create database",
 		CreateDatabase: true,
 		Force:          true,

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -326,12 +326,15 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 		}
 
 		var stmt string
+		var createDatabase bool
 		if strictDb {
 			// User gives only database instead of instance, we cannot create database again.
 			stmt = fmt.Sprintf("%s\n%s", buf, dataBuf)
+			createDatabase = false
 		} else {
 			// We will create the database together with initial schema and data migration.
 			stmt = fmt.Sprintf("CREATE DATABASE %s;\n\\connect \"%s\";\n%s\n%s", databaseName, databaseName, buf, dataBuf)
+			createDatabase = true
 		}
 
 		if _, _, err := d.ExecuteMigration(
@@ -347,7 +350,7 @@ func migrate(ctx context.Context, d dbdriver.Driver, curVer *semver.Version, mod
 				Source:                dbdriver.LIBRARY,
 				Type:                  dbdriver.Migrate,
 				Description:           fmt.Sprintf("Initial migration version %s server version %s with file %s.", cutoffSchemaVersion, serverVersion, latestSchemaPath),
-				CreateDatabase:        !strictDb,
+				CreateDatabase:        createDatabase,
 				Force:                 true,
 			},
 			stmt,

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -166,7 +166,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 		{
 			Database:   databaseName,
 			Source:     db.UI,
-			Type:       db.Baseline,
+			Type:       db.Migrate,
 			Status:     db.Done,
 			Schema:     "",
 			SchemaPrev: "",
@@ -227,7 +227,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 		{
 			Database:   cloneDatabaseName,
 			Source:     db.UI,
-			Type:       db.Baseline,
+			Type:       db.Migrate,
 			Status:     db.Done,
 			Schema:     "",
 			SchemaPrev: "",
@@ -516,7 +516,7 @@ func TestVCS(t *testing.T) {
 				{
 					Database:   databaseName,
 					Source:     db.UI,
-					Type:       db.Baseline,
+					Type:       db.Migrate,
 					Status:     db.Done,
 					Schema:     "",
 					SchemaPrev: "",


### PR DESCRIPTION
Rationale:

1. Make code more readable. I stumbled on `if (m.Type == db.Baseline && !m.CreateDatabase) doMigrate = false` at first. Until I figured we pass Baseline for CREATE DATABASE. It's easy to just remember all Baseline does NOT perform schema change at all.

2. We already use MIGRATE for our own migration in pg_engine.go and because that could mix CREATE DATABASE and other DDL, thus we can not use BASELINE there anyway.

After change:

![CleanShot 2022-08-13 at 22 54 12](https://user-images.githubusercontent.com/230323/184499490-91b6e3c5-c6e0-4b81-8187-91478da57892.png)
