### PR TITLE
fix: update the baseline instruction

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -25,12 +25,13 @@ const (
 
 	// 201 db migration error
 	// Db migration is a core feature, so we separate it from the db error.
-	MigrationSchemaMissing   Code = 201
-	MigrationAlreadyApplied  Code = 202
-	MigrationOutOfOrder      Code = 203
-	MigrationBaselineMissing Code = 204
-	MigrationPending         Code = 205
-	MigrationFailed          Code = 206
+	MigrationSchemaMissing  Code = 201
+	MigrationAlreadyApplied Code = 202
+	MigrationOutOfOrder     Code = 203
+	// MigrationBaselineMissing is no longer used
+	// MigrationBaselineMissing Code = 204
+	MigrationPending Code = 205
+	MigrationFailed  Code = 206
 
 	// 301 task error.
 	TaskTimingNotAllowed Code = 301

--- a/common/error.go
+++ b/common/error.go
@@ -28,8 +28,8 @@ const (
 	MigrationSchemaMissing  Code = 201
 	MigrationAlreadyApplied Code = 202
 	MigrationOutOfOrder     Code = 203
-	// MigrationBaselineMissing is no longer used
-	// MigrationBaselineMissing Code = 204
+	// MigrationBaselineMissing is no longer used.
+	// MigrationBaselineMissing Code = 204.
 	MigrationPending Code = 205
 	MigrationFailed  Code = 206
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -753,7 +753,7 @@
     "establish-baseline": "Establish new baseline",
     "refreshing-history": "Refreshing history ...",
     "config-instance": "Config instance",
-    "establish-baseline-description": "Bytebase will use the current schema as the new baseline. You should check that the current schema does reflect the desired state. For VCS workflow, there must exist a baseline before any incremental migration change can be applied to the database.",
+    "establish-baseline-description": "Bytebase will use the current schema as the new baseline. You should check that the current schema does reflect the desired state.",
     "establish-database-baseline": "Establish \"{name}\" baseline",
     "instance-missing-migration-schema": "Missing migration history schema on instance \"{name}\".",
     "instance-bad-connection": "Unable to connect instance \"{name}\" to retrieve migration history.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -754,7 +754,7 @@
     "establish-baseline": "建立新的基线",
     "refreshing-history": "刷新历史中 ...",
     "config-instance": "配置实例",
-    "establish-baseline-description": "Bytebase 将用当前的 schema 作为新的基线。您应该检查当前的基线确实反映了期望的状态。 对于 VCS 工作流来说，也只有在建立起基线的前提下，才能进行数据库变更。",
+    "establish-baseline-description": "Bytebase 将用当前的 schema 作为新的基线。您应该检查当前的基线确实反映了期望的状态。",
     "establish-database-baseline": "建立「{name}」基线",
     "instance-missing-migration-schema": "实例「{name}」缺失用于记录变更历史的 schema。",
     "instance-bad-connection": "无法连接实例「{name}」以获取变更历史。",


### PR DESCRIPTION
Baseline is NOT a pre-requisite for applying migration for VCS-based project. Applying the schema migration will record the latest schema snapshot, which essentially is a baselining.

The code has already relaxed this, we forgot to update the instruction.