### PR TITLE
fix(frontend): long name text overflow

### DIFF
--- a/frontend/src/components/EllipsisText.vue
+++ b/frontend/src/components/EllipsisText.vue
@@ -1,0 +1,17 @@
+<template>
+  <span class="tooltip-wrapper w-full">
+    <span v-if="hasTextOverflow" class="tooltip whitespace-nowrap">
+      <slot></slot>
+    </span>
+    <div ref="textRef" class="truncate w-full"><slot></slot></div>
+  </span>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed } from "vue";
+
+const textRef = ref<HTMLElement | null>(null);
+const hasTextOverflow = computed(() => {
+  return textRef.value && textRef.value.offsetWidth < textRef.value.scrollWidth;
+});
+</script>

--- a/frontend/src/components/TableTable.vue
+++ b/frontend/src/components/TableTable.vue
@@ -12,7 +12,7 @@
     <template #body="{ rowData: table }">
       <BBTableCell :left-padding="4">
         <div class="flex items-center space-x-2">
-          <span>{{ table.name }}</span>
+          <EllipsisText>{{ table.name }}</EllipsisText>
           <BBBadge
             v-if="isGhostTable(table)"
             text="gh-ost"
@@ -61,6 +61,7 @@ import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { Table } from "@/types";
 import { bytesToString, databaseSlug, isGhostTable } from "@/utils";
+import EllipsisText from "@/components/EllipsisText.vue";
 
 type LocalState = {
   showReservedTableList: boolean;
@@ -68,6 +69,7 @@ type LocalState = {
 
 export default defineComponent({
   name: "TableTable",
+  components: { EllipsisText },
   props: {
     tableList: {
       required: true,


### PR DESCRIPTION
On 1080P monitors, this may be a problem that long column names would overflow. With texts surrounded with `EllipsisText`, long texts will be truncated, and a tooltip will be used to display the full original content.

https://user-images.githubusercontent.com/56376387/184598939-fad91e72-3a63-40fc-b042-21647fe539b3.mp4


