### PR TITLE
refactor: use errors.Wrapf

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/bytebase/bytebase/plugin/advisor"
+	"github.com/pkg/errors"
 )
 
 // PolicyType is the type or name of a policy.
@@ -141,7 +142,7 @@ func (pa PipelineApprovalPolicy) String() (string, error) {
 func UnmarshalPipelineApprovalPolicy(payload string) (*PipelineApprovalPolicy, error) {
 	var pa PipelineApprovalPolicy
 	if err := json.Unmarshal([]byte(payload), &pa); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal pipeline approval policy %q, error: %w", payload, err)
+		return nil, errors.Wrapf(err, "failed to unmarshal pipeline approval policy %q", payload)
 	}
 	return &pa, nil
 }

--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/resources/mysqlutil"
 	"github.com/bytebase/bytebase/resources/postgres"
+	"github.com/pkg/errors"
 
 	// install mysql driver.
 	_ "github.com/bytebase/bytebase/plugin/db/mysql"
@@ -33,13 +34,13 @@ func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 		// dburl.Parse() parses 'pg', 'postgresql' and 'pgsql' to 'postgres'.
 		// https://pkg.go.dev/github.com/xo/dburl@v0.9.1#hdr-Protocol_Schemes_and_Aliases
 		if err := mysqlutil.Install(resourceDir); err != nil {
-			return nil, fmt.Errorf("cannot install mysqlutil in directory %q, error: %w", resourceDir, err)
+			return nil, errors.Wrapf(err, "cannot install mysqlutil in directory %q", resourceDir)
 		}
 	case "postgres":
 		dbType = db.Postgres
 		pgInstance, err := postgres.Install(resourceDir, "" /* pgDataDir */, "" /* pgUser */)
 		if err != nil {
-			return nil, fmt.Errorf("cannot install postgres in directory %q, error: %w", resourceDir, err)
+			return nil, errors.Wrapf(err, "cannot install postgres in directory %q", resourceDir)
 		}
 		pgInstanceDir = pgInstance.BaseDir
 	default:

--- a/plugin/db/mysql/dump.go
+++ b/plugin/db/mysql/dump.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db/util"
 	"github.com/bytebase/bytebase/resources/mysqlutil"
+	"github.com/pkg/errors"
 )
 
 // Dump and restore.
@@ -225,7 +226,7 @@ func dumpTxn(ctx context.Context, txn *sql.Tx, database string, out io.Writer, s
 		// Table and view statement.
 		tables, err := getTablesTx(txn, dbName)
 		if err != nil {
-			return fmt.Errorf("failed to get tables of database %q, error: %w", dbName, err)
+			return errors.Wrapf(err, "failed to get tables of database %q", dbName)
 		}
 		for _, tbl := range tables {
 			if schemaOnly && tbl.TableType == baseTableType {

--- a/resources/mysql/mysql.go
+++ b/resources/mysql/mysql.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/bytebase/bytebase/resources/utils"
+	"github.com/pkg/errors"
 
 	// install mysql driver.
 	_ "github.com/go-sql-driver/mysql"
@@ -68,7 +69,7 @@ func (i *Instance) Start(port int, stdout, stderr io.Writer) (err error) {
 		if time.Now().After(endTime) {
 			err := i.proc.Kill()
 			if err != nil {
-				return fmt.Errorf("mysql instance has started as process %d, but failed to kill it, error: %w", i.proc.Pid, err)
+				return errors.Wrapf(err, "mysql instance has started as process %d, but failed to kill it", i.proc.Pid)
 			}
 			return fmt.Errorf("failed to connect to mysql")
 		}
@@ -102,12 +103,12 @@ func Install(basedir, datadir, user string) (*Instance, error) {
 
 	tarF, err := resources.Open(tarName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open mysql dist %q, error: %w", tarName, err)
+		return nil, errors.Wrapf(err, "failed to open mysql dist %q", tarName)
 	}
 	defer tarF.Close()
 
 	if err := extractFn(tarF, basedir); err != nil {
-		return nil, fmt.Errorf("failed to extract mysql distribution %q, error: %w", tarName, err)
+		return nil, errors.Wrapf(err, "failed to extract mysql distribution %q", tarName)
 	}
 
 	basedir = filepath.Join(basedir, version)

--- a/resources/mysqlutil/mysqlutil.go
+++ b/resources/mysqlutil/mysqlutil.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/bytebase/bytebase/resources/utils"
+	"github.com/pkg/errors"
 )
 
 type binaryName string
@@ -91,7 +92,7 @@ func Install(resourceDir string) error {
 
 	if _, err := os.Stat(mysqlutilDir); err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to check binary directory path %q, error: %w", mysqlutilDir, err)
+			return errors.Wrapf(err, "failed to check binary directory path %q", mysqlutilDir)
 		}
 		// Install if not exist yet
 		if err := installImpl(resourceDir, mysqlutilDir, tarName, version); err != nil {
@@ -114,11 +115,11 @@ func Install(resourceDir string) error {
 	for _, fp := range checks {
 		if _, err := os.Stat(fp); err != nil {
 			if !os.IsNotExist(err) {
-				return fmt.Errorf("failed to check libncurses library path %q, error: %w", fp, err)
+				return errors.Wrapf(err, "failed to check libncurses library path %q", fp)
 			}
 			// Remove mysqlutil of old version and reinstall it
 			if err := os.RemoveAll(mysqlutilDir); err != nil {
-				return fmt.Errorf("failed to remove the old version mysqlutil binary directory %q, error: %w", mysqlutilDir, err)
+				return errors.Wrapf(err, "failed to remove the old version mysqlutil binary directory %q", mysqlutilDir)
 			}
 			// Install the current version
 			if err := installImpl(resourceDir, mysqlutilDir, tarName, version); err != nil {
@@ -135,7 +136,7 @@ func Install(resourceDir string) error {
 func installImpl(resourceDir, mysqlutilDir, tarName, version string) error {
 	tmpDir := path.Join(resourceDir, fmt.Sprintf("tmp-%s", version))
 	if err := os.RemoveAll(tmpDir); err != nil {
-		return fmt.Errorf("failed to remove mysqlutil binaries temp directory %q, error: %w", tmpDir, err)
+		return errors.Wrapf(err, "failed to remove mysqlutil binaries temp directory %q", tmpDir)
 	}
 
 	f, err := resources.Open(tarName)
@@ -149,7 +150,7 @@ func installImpl(resourceDir, mysqlutilDir, tarName, version string) error {
 	}
 
 	if err := os.Rename(tmpDir, mysqlutilDir); err != nil {
-		return fmt.Errorf("failed to rename mysqlutil binaries directory from %q to %q, error: %w", tmpDir, mysqlutilDir, err)
+		return errors.Wrapf(err, "failed to rename mysqlutil binaries directory from %q to %q", tmpDir, mysqlutilDir)
 	}
 
 	return nil

--- a/resources/utils/extract.go
+++ b/resources/utils/extract.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/xi2/xz"
 )
 
@@ -45,7 +46,7 @@ func extractTar(r io.Reader, targetDir string) error {
 
 		targetPath, err := filepath.Abs(filepath.Join(targetDir, header.Name))
 		if err != nil {
-			return fmt.Errorf("failed to get absolute path for %q, error: %w", header.Name, err)
+			return errors.Wrapf(err, "failed to get absolute path for %q", header.Name)
 		}
 
 		// Ensure that output paths constructed from zip archive entries
@@ -55,7 +56,7 @@ func extractTar(r io.Reader, targetDir string) error {
 		}
 
 		if err := os.MkdirAll(path.Dir(targetPath), os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create directory %q, error: %w", header.Name, err)
+			return errors.Wrapf(err, "failed to create directory %q", header.Name)
 		}
 
 		switch header.Typeflag {

--- a/server/activity_manager.go
+++ b/server/activity_manager.go
@@ -61,7 +61,7 @@ func (m *ActivityManager) CreateActivity(ctx context.Context, create *api.Activi
 	}
 	webhookList, err := m.s.store.FindProjectWebhook(ctx, hookFind)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find project webhook after changing the issue status: %v, error: %w", meta.issue.Name, err)
+		return nil, errors.Wrapf(err, "failed to find project webhook after changing the issue status: %v", meta.issue.Name)
 	}
 	if len(webhookList) == 0 {
 		return activity, nil
@@ -69,7 +69,7 @@ func (m *ActivityManager) CreateActivity(ctx context.Context, create *api.Activi
 
 	updater, err := m.s.store.GetPrincipalByID(ctx, create.CreatorID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find updater for posting webhook event after changing the issue status: %v, error: %w", meta.issue.Name, err)
+		return nil, errors.Wrapf(err, "failed to find updater for posting webhook event after changing the issue status: %v", meta.issue.Name)
 	}
 	if updater == nil {
 		return nil, fmt.Errorf("updater principal not found for ID %v", create.CreatorID)

--- a/server/cache.go
+++ b/server/cache.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/gob"
-	"fmt"
 
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/bytebase/bytebase/api"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -37,7 +37,7 @@ func (s *CacheService) FindCache(namespace api.CacheNamespace, id int, entry int
 	if has {
 		dec := gob.NewDecoder(bytes.NewReader(buf2))
 		if err := dec.Decode(entry); err != nil {
-			return false, fmt.Errorf("failed to decode entry for cache namespace: %s, error: %w", namespace, err)
+			return false, errors.Wrapf(err, "failed to decode entry for cache namespace: %s", namespace)
 		}
 		return true, nil
 	}
@@ -53,7 +53,7 @@ func (s *CacheService) UpsertCache(namespace api.CacheNamespace, id int, entry i
 	var buf2 bytes.Buffer
 	enc := gob.NewEncoder(&buf2)
 	if err := enc.Encode(entry); err != nil {
-		return fmt.Errorf("failed to encode entry for cache namespace: %s, error: %w", namespace, err)
+		return errors.Wrapf(err, "failed to encode entry for cache namespace: %s", namespace)
 	}
 	s.cache.Set(append([]byte(namespace), buf1...), buf2.Bytes())
 

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/pkg/errors"
 )
 
 // ScheduleNextTaskIfNeeded tries to schedule the next task if needed.
@@ -26,7 +26,7 @@ func (s *Server) ScheduleNextTaskIfNeeded(ctx context.Context, pipeline *api.Pip
 
 				policy, err := s.store.GetPipelineApprovalPolicy(ctx, task.Instance.EnvironmentID)
 				if err != nil {
-					return nil, fmt.Errorf("failed to get approval policy for environment ID %d, error: %w", task.Instance.EnvironmentID, err)
+					return nil, errors.Wrapf(err, "failed to get approval policy for environment ID %d", task.Instance.EnvironmentID)
 				}
 				if policy.Value == api.PipelineApprovalValueManualNever {
 					// transit into Pending for ManualNever (auto-approval) tasks if all required task checks passed.

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
+	"github.com/pkg/errors"
 )
 
 // TaskExecutor is the task executor.
@@ -316,10 +317,10 @@ func findIssueByTask(ctx context.Context, server *Server, task *api.Task) (*api.
 	issue, err := server.store.GetIssueByPipelineID(ctx, task.PipelineID)
 	if err != nil {
 		// If somehow we cannot find the issue, emit the error since it's not fatal.
-		return nil, fmt.Errorf("failed to fetch containing issue for composing the migration info, task_id: %v, error: %w", task.ID, err)
+		return nil, errors.Wrapf(err, "failed to fetch containing issue for composing the migration info, task_id: %v", task.ID)
 	}
 	if issue == nil {
-		return nil, fmt.Errorf("failed to fetch containing issue for composing the migration info, issue not found, pipeline ID: %v, task_id: %v, error: %w", task.PipelineID, task.ID, err)
+		return nil, errors.Wrapf(err, "failed to fetch containing issue for composing the migration info, issue not found, pipeline ID: %v, task_id: %v", task.PipelineID, task.ID)
 	}
 	return issue, nil
 }

--- a/server/task_executor_database_backup.go
+++ b/server/task_executor_database_backup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common/log"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -43,7 +44,7 @@ func (exec *DatabaseBackupTaskExecutor) RunOnce(ctx context.Context, server *Ser
 
 	backup, err := server.store.GetBackupByID(ctx, payload.BackupID)
 	if err != nil {
-		return true, nil, fmt.Errorf("failed to find backup with ID %d, error: %w", payload.BackupID, err)
+		return true, nil, errors.Wrapf(err, "failed to find backup with ID %d", payload.BackupID)
 	}
 	if backup == nil {
 		return true, nil, fmt.Errorf("backup %v not found", payload.BackupID)

--- a/server/task_executor_database_restore.go
+++ b/server/task_executor_database_restore.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/pkg/errors"
 
 	"go.uber.org/zap"
 )
@@ -47,7 +48,7 @@ func (exec *DatabaseRestoreTaskExecutor) RunOnce(ctx context.Context, server *Se
 
 	backup, err := server.store.GetBackupByID(ctx, payload.BackupID)
 	if err != nil {
-		return true, nil, fmt.Errorf("failed to find backup with ID %d, error: %w", payload.BackupID, err)
+		return true, nil, errors.Wrapf(err, "failed to find backup with ID %d", payload.BackupID)
 	}
 	if backup == nil {
 		return true, nil, fmt.Errorf("backup with ID %d not found", payload.BackupID)
@@ -103,7 +104,7 @@ func (exec *DatabaseRestoreTaskExecutor) RunOnce(ctx context.Context, server *Se
 		SourceBackupID: &backup.ID,
 	}
 	if _, err = server.store.PatchDatabase(ctx, databasePatch); err != nil {
-		return true, nil, fmt.Errorf("failed to patch database source with ID %d and backup ID %d after restore, error: %w", targetDatabase.ID, backup.ID, err)
+		return true, nil, errors.Wrapf(err, "failed to patch database source with ID %d and backup ID %d after restore", targetDatabase.ID, backup.ID)
 	}
 
 	// Sync database schema after restore is completed.

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bytebase/bytebase/plugin/db/mysql"
 	"github.com/bytebase/bytebase/plugin/db/util"
 	"github.com/bytebase/bytebase/store"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -37,7 +38,7 @@ func (exec *PITRRestoreTaskExecutor) RunOnce(ctx context.Context, server *Server
 
 	payload := api.TaskDatabasePITRRestorePayload{}
 	if err := json.Unmarshal([]byte(task.Payload), &payload); err != nil {
-		return true, nil, fmt.Errorf("invalid PITR restore payload: %s, error: %w", task.Payload, err)
+		return true, nil, errors.Wrapf(err, "invalid PITR restore payload: %s", task.Payload)
 	}
 
 	if (payload.BackupID == nil) == (payload.PointInTimeTs == nil) {
@@ -79,7 +80,7 @@ func (exec *PITRRestoreTaskExecutor) doRestoreToNewDatabase(ctx context.Context,
 	// Restore full backup only
 	backup, err := server.store.GetBackupByID(ctx, *payload.BackupID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find backup with ID %d, error: %w", *payload.BackupID, err)
+		return nil, errors.Wrapf(err, "failed to find backup with ID %d", *payload.BackupID)
 	}
 	if backup == nil {
 		return nil, fmt.Errorf("backup with ID %d not found", *payload.BackupID)
@@ -140,7 +141,7 @@ func (exec *PITRRestoreTaskExecutor) doRestoreToNewDatabase(ctx context.Context,
 		SourceBackupID: &backup.ID,
 	}
 	if _, err = server.store.PatchDatabase(ctx, databasePatch); err != nil {
-		return nil, fmt.Errorf("failed to patch database source with ID %d and backup ID %d after restore, error: %w", targetDatabase.ID, backup.ID, err)
+		return nil, errors.Wrapf(err, "failed to patch database source with ID %d and backup ID %d after restore", targetDatabase.ID, backup.ID)
 	}
 
 	// Sync database schema after restore is completed.
@@ -200,13 +201,13 @@ func (exec *PITRRestoreTaskExecutor) doRestoreInPlace(ctx context.Context, serve
 			zap.Int64("targetTs", targetTs),
 			zap.String("targetTsHuman", targetTsHuman),
 			zap.Error(err))
-		return nil, fmt.Errorf("failed to get latest backup before or equal to %s, error: %w", targetTsHuman, err)
+		return nil, errors.Wrapf(err, "failed to get latest backup before or equal to %s", targetTsHuman)
 	}
 	log.Debug("Got latest backup before or equal to targetTs", zap.String("backup", backup.Name))
 	backupFileName := getBackupAbsFilePath(server.profile.DataDir, backup.DatabaseID, backup.Name)
 	backupFile, err := os.Open(backupFileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open backup file %q, error: %w", backupFileName, err)
+		return nil, errors.Wrapf(err, "failed to open backup file %q", backupFileName)
 	}
 	defer backupFile.Close()
 	log.Debug("Successfully opened backup file", zap.String("filename", backupFileName))
@@ -257,7 +258,7 @@ func (*PITRRestoreTaskExecutor) doRestoreInPlacePostgres(ctx context.Context, se
 
 	backup, err := server.store.GetBackupByID(ctx, *payload.BackupID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find backup with ID %d, error: %w", *payload.BackupID, err)
+		return nil, errors.Wrapf(err, "failed to find backup with ID %d", *payload.BackupID)
 	}
 	if backup == nil {
 		return nil, fmt.Errorf("backup with ID %d not found", *payload.BackupID)
@@ -265,7 +266,7 @@ func (*PITRRestoreTaskExecutor) doRestoreInPlacePostgres(ctx context.Context, se
 	backupFileName := getBackupAbsFilePath(server.profile.DataDir, backup.DatabaseID, backup.Name)
 	backupFile, err := os.Open(backupFileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open backup file %q, error: %w", backupFileName, err)
+		return nil, errors.Wrapf(err, "failed to open backup file %q", backupFileName)
 	}
 	defer backupFile.Close()
 	db, err := driver.GetDBConnection(ctx, db.BytebaseDatabase)
@@ -274,15 +275,15 @@ func (*PITRRestoreTaskExecutor) doRestoreInPlacePostgres(ctx context.Context, se
 	}
 	pitrDatabaseName := util.GetPITRDatabaseName(task.Database.Name, issue.CreatedTs)
 	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s;", pitrDatabaseName)); err != nil {
-		return nil, fmt.Errorf("failed to create PITR database %q, error: %w", pitrDatabaseName, err)
+		return nil, errors.Wrapf(err, "failed to create PITR database %q", pitrDatabaseName)
 	}
 	// Switch to the PITR database.
 	// TODO(dragonly): This is a trick, needs refactor.
 	if _, err := driver.GetDBConnection(ctx, pitrDatabaseName); err != nil {
-		return nil, fmt.Errorf("failed to get connection for database %q, error: %w", pitrDatabaseName, err)
+		return nil, errors.Wrapf(err, "failed to get connection for database %q", pitrDatabaseName)
 	}
 	if err := driver.Restore(ctx, backupFile); err != nil {
-		return nil, fmt.Errorf("failed to restore backup to the PITR database %q, error: %w", pitrDatabaseName, err)
+		return nil, errors.Wrapf(err, "failed to restore backup to the PITR database %q", pitrDatabaseName)
 	}
 	return &api.TaskRunResultPayload{
 		Detail: fmt.Sprintf("Restored database %q in place from backup %q", task.Database.Name, backup.Name),
@@ -292,12 +293,12 @@ func (*PITRRestoreTaskExecutor) doRestoreInPlacePostgres(ctx context.Context, se
 func (exec *PITRRestoreTaskExecutor) updateProgress(ctx context.Context, driver *mysql.Driver, backupFile *os.File, startBinlogInfo api.BinlogInfo, binlogDir string) error {
 	backupFileInfo, err := backupFile.Stat()
 	if err != nil {
-		return fmt.Errorf("failed to get stat of backup file %q, error: %w", backupFile.Name(), err)
+		return errors.Wrapf(err, "failed to get stat of backup file %q", backupFile.Name())
 	}
 	backupFileBytes := backupFileInfo.Size()
 	replayBinlogPaths, err := mysql.GetBinlogReplayList(startBinlogInfo, binlogDir)
 	if err != nil {
-		return fmt.Errorf("failed to get binlog replay list with startBinlogInfo %+v in binlog directory %q, error: %w", startBinlogInfo, binlogDir, err)
+		return errors.Wrapf(err, "failed to get binlog replay list with startBinlogInfo %+v in binlog directory %q", startBinlogInfo, binlogDir)
 	}
 	totalBinlogBytes, err := common.GetFileSizeSum(replayBinlogPaths)
 	if err != nil {
@@ -340,7 +341,7 @@ func getIssueByPipelineID(ctx context.Context, store *store.Store, pid int) (*ap
 	issue, err := store.GetIssueByPipelineID(ctx, pid)
 	if err != nil {
 		log.Error("failed to get issue by PipelineID", zap.Int("PipelineID", pid), zap.Error(err))
-		return nil, fmt.Errorf("failed to get issue by PipelineID: %d, error: %w", pid, err)
+		return nil, errors.Wrapf(err, "failed to get issue by PipelineID: %d", pid)
 	}
 	if issue == nil {
 		log.Error("issue not found with PipelineID", zap.Int("PipelineID", pid))

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/github/gh-ost/go/base"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/api"
@@ -37,7 +38,7 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 
 	taskDAG, err := server.store.GetTaskDAGByToTaskID(ctx, task.ID)
 	if err != nil {
-		return true, nil, fmt.Errorf("failed to get a single taskDAG for schema update gh-ost cutover task, id: %v, error: %w", task.ID, err)
+		return true, nil, errors.Wrapf(err, "failed to get a single taskDAG for schema update gh-ost cutover task, id: %v", task.ID)
 	}
 
 	syncTaskID := taskDAG.FromTaskID

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/pkg/errors"
 
 	"go.uber.org/zap"
 )
@@ -358,11 +359,11 @@ func (s *TaskScheduler) isTaskBlocked(ctx context.Context, task *api.Task) (bool
 	for _, blockingTaskIDString := range task.BlockedBy {
 		blockingTaskID, err := strconv.Atoi(blockingTaskIDString)
 		if err != nil {
-			return true, fmt.Errorf("failed to convert id string to int, id string: %v, error: %w", blockingTaskIDString, err)
+			return true, errors.Wrapf(err, "failed to convert id string to int, id string: %v", blockingTaskIDString)
 		}
 		blockingTask, err := s.server.store.GetTaskByID(ctx, blockingTaskID)
 		if err != nil {
-			return true, fmt.Errorf("failed to fetch the blocking task, id: %v, error: %w", blockingTaskID, err)
+			return true, errors.Wrapf(err, "failed to fetch the blocking task, id: %v", blockingTaskID)
 		}
 		if blockingTask.Status != api.TaskDone {
 			return true, nil

--- a/store/activity.go
+++ b/store/activity.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // activityRaw is the store model for an Activity.
@@ -57,11 +58,11 @@ func (raw *activityRaw) toActivity() *api.Activity {
 func (s *Store) CreateActivity(ctx context.Context, create *api.ActivityCreate) (*api.Activity, error) {
 	activityRaw, err := s.createActivityRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Activity with ActivityCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Activity with ActivityCreate[%+v]", create)
 	}
 	activity, err := s.composeActivity(ctx, activityRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Activity with activityRaw[%+v], error: %w", activityRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Activity with activityRaw[%+v]", activityRaw)
 	}
 	return activity, nil
 }
@@ -70,14 +71,14 @@ func (s *Store) CreateActivity(ctx context.Context, create *api.ActivityCreate) 
 func (s *Store) GetActivityByID(ctx context.Context, id int) (*api.Activity, error) {
 	activityRaw, err := s.getActivityRawByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Activity with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Activity with ID %d", id)
 	}
 	if activityRaw == nil {
 		return nil, nil
 	}
 	activity, err := s.composeActivity(ctx, activityRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Activity with activityRaw[%+v], error: %w", activityRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Activity with activityRaw[%+v]", activityRaw)
 	}
 	return activity, nil
 }
@@ -86,13 +87,13 @@ func (s *Store) GetActivityByID(ctx context.Context, id int) (*api.Activity, err
 func (s *Store) FindActivity(ctx context.Context, find *api.ActivityFind) ([]*api.Activity, error) {
 	activityRawList, err := s.findActivityRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Activity list with ActivityFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Activity list with ActivityFind[%+v]", find)
 	}
 	var activityList []*api.Activity
 	for _, raw := range activityRawList {
 		activity, err := s.composeActivity(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Activity with activityRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Activity with activityRaw[%+v]", raw)
 		}
 		activityList = append(activityList, activity)
 	}
@@ -103,11 +104,11 @@ func (s *Store) FindActivity(ctx context.Context, find *api.ActivityFind) ([]*ap
 func (s *Store) PatchActivity(ctx context.Context, patch *api.ActivityPatch) (*api.Activity, error) {
 	activityRaw, err := s.patchActivityRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Activity with ActivityPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Activity with ActivityPatch[%+v]", patch)
 	}
 	activity, err := s.composeActivity(ctx, activityRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Activity with activityRaw[%+v], error: %w", activityRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Activity with activityRaw[%+v]", activityRaw)
 	}
 	return activity, nil
 }

--- a/store/anomaly.go
+++ b/store/anomaly.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // anomalyRaw is the store model for an Anomaly.
@@ -60,11 +61,11 @@ func (raw *anomalyRaw) toAnomaly() *api.Anomaly {
 func (s *Store) UpsertActiveAnomaly(ctx context.Context, upsert *api.AnomalyUpsert) (*api.Anomaly, error) {
 	anomalyRaw, err := s.upsertActiveAnomalyRaw(ctx, upsert)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upsert active anomaly with AnomalyUpsert[%+v], error: %w", upsert, err)
+		return nil, errors.Wrapf(err, "failed to upsert active anomaly with AnomalyUpsert[%+v]", upsert)
 	}
 	anomaly, err := s.composeAnomaly(ctx, anomalyRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose anomaly with AnomalyRaw[%+v], error: %w", anomalyRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose anomaly with AnomalyRaw[%+v]", anomalyRaw)
 	}
 	return anomaly, nil
 }
@@ -73,13 +74,13 @@ func (s *Store) UpsertActiveAnomaly(ctx context.Context, upsert *api.AnomalyUpse
 func (s *Store) FindAnomaly(ctx context.Context, find *api.AnomalyFind) ([]*api.Anomaly, error) {
 	anomalyRawList, err := s.findAnomalyRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find anomaly with AnomalyFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find anomaly with AnomalyFind[%+v]", find)
 	}
 	var anomalyList []*api.Anomaly
 	for _, anomalyRaw := range anomalyRawList {
 		anomaly, err := s.composeAnomaly(ctx, anomalyRaw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose anomaly with AnomalyRaw[%+v], error: %w", anomalyRaw, err)
+			return nil, errors.Wrapf(err, "failed to compose anomaly with AnomalyRaw[%+v]", anomalyRaw)
 		}
 		anomalyList = append(anomalyList, anomaly)
 	}

--- a/store/backup.go
+++ b/store/backup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // backupRaw is the store model for an Backup.
@@ -117,11 +118,11 @@ func (raw *backupSettingRaw) toBackupSetting() *api.BackupSetting {
 func (s *Store) CreateBackup(ctx context.Context, create *api.BackupCreate) (*api.Backup, error) {
 	backupRaw, err := s.createBackupRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Backup with BackupCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Backup with BackupCreate[%+v]", create)
 	}
 	backup, err := s.composeBackup(ctx, backupRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Backup with backupRaw[%+v], error: %w", backupRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", backupRaw)
 	}
 	return backup, nil
 }
@@ -130,14 +131,14 @@ func (s *Store) CreateBackup(ctx context.Context, create *api.BackupCreate) (*ap
 func (s *Store) GetBackupByID(ctx context.Context, id int) (*api.Backup, error) {
 	backupRaw, err := s.getBackupRawByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get backup setting by ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get backup setting by ID %d", id)
 	}
 	if backupRaw == nil {
 		return nil, nil
 	}
 	backupSetting, err := s.composeBackup(ctx, backupRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Backup with backupRaw[%+v], error: %w", backupRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", backupRaw)
 	}
 	return backupSetting, nil
 }
@@ -146,13 +147,13 @@ func (s *Store) GetBackupByID(ctx context.Context, id int) (*api.Backup, error) 
 func (s *Store) FindBackup(ctx context.Context, find *api.BackupFind) ([]*api.Backup, error) {
 	backupRawList, err := s.findBackupRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Backup list with BackupFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Backup list with BackupFind[%+v]", find)
 	}
 	var backupList []*api.Backup
 	for _, raw := range backupRawList {
 		backup, err := s.composeBackup(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Backup with backupRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", raw)
 		}
 		backupList = append(backupList, backup)
 	}
@@ -163,11 +164,11 @@ func (s *Store) FindBackup(ctx context.Context, find *api.BackupFind) ([]*api.Ba
 func (s *Store) PatchBackup(ctx context.Context, patch *api.BackupPatch) (*api.Backup, error) {
 	backupRaw, err := s.patchBackupRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Backup with BackupPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Backup with BackupPatch[%+v]", patch)
 	}
 	backup, err := s.composeBackup(ctx, backupRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Backup with backupRaw[%+v], error: %w", backupRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", backupRaw)
 	}
 	return backup, nil
 }
@@ -176,13 +177,13 @@ func (s *Store) PatchBackup(ctx context.Context, patch *api.BackupPatch) (*api.B
 func (s *Store) FindBackupSetting(ctx context.Context, find api.BackupSettingFind) ([]*api.BackupSetting, error) {
 	backupSettingRawList, err := s.findBackupSettingRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find backup setting list with BackupSettingFind %+v, error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find backup setting list with BackupSettingFind %+v", find)
 	}
 	var backupSettingList []*api.BackupSetting
 	for _, raw := range backupSettingRawList {
 		backupSetting, err := s.composeBackupSetting(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose BackupSetting with backupSettingRaw %+v, error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose BackupSetting with backupSettingRaw %+v", raw)
 		}
 		backupSettingList = append(backupSettingList, backupSetting)
 	}
@@ -193,14 +194,14 @@ func (s *Store) FindBackupSetting(ctx context.Context, find api.BackupSettingFin
 func (s *Store) GetBackupSettingByDatabaseID(ctx context.Context, id int) (*api.BackupSetting, error) {
 	backupSettingRaw, err := s.getBackupSettingRaw(ctx, &api.BackupSettingFind{DatabaseID: &id})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get backup setting by ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get backup setting by ID %d", id)
 	}
 	if backupSettingRaw == nil {
 		return nil, nil
 	}
 	backupSetting, err := s.composeBackupSetting(ctx, backupSettingRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose BackupSetting with backupSettingRaw[%+v], error: %w", backupSettingRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose BackupSetting with backupSettingRaw[%+v]", backupSettingRaw)
 	}
 	return backupSetting, nil
 }
@@ -209,11 +210,11 @@ func (s *Store) GetBackupSettingByDatabaseID(ctx context.Context, id int) (*api.
 func (s *Store) UpsertBackupSetting(ctx context.Context, upsert *api.BackupSettingUpsert) (*api.BackupSetting, error) {
 	backupSettingRaw, err := s.upsertBackupSettingRaw(ctx, upsert)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upsert backup setting with BackupSettingUpsert[%+v], error: %w", upsert, err)
+		return nil, errors.Wrapf(err, "failed to upsert backup setting with BackupSettingUpsert[%+v]", upsert)
 	}
 	backup, err := s.composeBackupSetting(ctx, backupSettingRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Backup with backupRaw[%+v], error: %w", backupSettingRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", backupSettingRaw)
 	}
 	return backup, nil
 }
@@ -222,13 +223,13 @@ func (s *Store) UpsertBackupSetting(ctx context.Context, upsert *api.BackupSetti
 func (s *Store) FindBackupSettingsMatch(ctx context.Context, match *api.BackupSettingsMatch) ([]*api.BackupSetting, error) {
 	backupSettingRawList, err := s.findBackupSettingsMatchImpl(ctx, match)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find matching backup setting list with BackupSettingsMatch[%+v], error: %w", match, err)
+		return nil, errors.Wrapf(err, "failed to find matching backup setting list with BackupSettingsMatch[%+v]", match)
 	}
 	var backupSettingList []*api.BackupSetting
 	for _, raw := range backupSettingRawList {
 		backupSetting, err := s.composeBackupSetting(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Backup with backupRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", raw)
 		}
 		backupSettingList = append(backupSettingList, backupSetting)
 	}

--- a/store/bookmark.go
+++ b/store/bookmark.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // bookmarkRaw is the store model for an Bookmark.
@@ -48,11 +49,11 @@ func (raw *bookmarkRaw) toBookmark() *api.Bookmark {
 func (s *Store) CreateBookmark(ctx context.Context, create *api.BookmarkCreate) (*api.Bookmark, error) {
 	bookmarkRaw, err := s.createBookmarkRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Bookmark with BookmarkCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Bookmark with BookmarkCreate[%+v]", create)
 	}
 	bookmark, err := s.composeBookmark(ctx, bookmarkRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Bookmark with bookmarkRaw[%+v], error: %w", bookmarkRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Bookmark with bookmarkRaw[%+v]", bookmarkRaw)
 	}
 	return bookmark, nil
 }
@@ -62,14 +63,14 @@ func (s *Store) GetBookmarkByID(ctx context.Context, id int) (*api.Bookmark, err
 	find := &api.BookmarkFind{ID: &id}
 	bookmarkRaw, err := s.getBookmarkRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Bookmark with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Bookmark with ID %d", id)
 	}
 	if bookmarkRaw == nil {
 		return nil, nil
 	}
 	bookmark, err := s.composeBookmark(ctx, bookmarkRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Bookmark with bookmarkRaw[%+v], error: %w", bookmarkRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Bookmark with bookmarkRaw[%+v]", bookmarkRaw)
 	}
 	return bookmark, nil
 }
@@ -78,13 +79,13 @@ func (s *Store) GetBookmarkByID(ctx context.Context, id int) (*api.Bookmark, err
 func (s *Store) FindBookmark(ctx context.Context, find *api.BookmarkFind) ([]*api.Bookmark, error) {
 	bookmarkRawList, err := s.findBookmarkRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Bookmark list with BookmarkFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Bookmark list with BookmarkFind[%+v]", find)
 	}
 	var bookmarkList []*api.Bookmark
 	for _, raw := range bookmarkRawList {
 		bookmark, err := s.composeBookmark(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Bookmark with bookmarkRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Bookmark with bookmarkRaw[%+v]", raw)
 		}
 		bookmarkList = append(bookmarkList, bookmark)
 	}

--- a/store/data_source.go
+++ b/store/data_source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // dataSourceRaw is the store model for an DataSource.
@@ -66,11 +67,11 @@ func (raw *dataSourceRaw) toDataSource() *api.DataSource {
 func (s *Store) CreateDataSource(ctx context.Context, create *api.DataSourceCreate) (*api.DataSource, error) {
 	dataSourceRaw, err := s.createDataSourceRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create data source with DataSourceCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create data source with DataSourceCreate[%+v]", create)
 	}
 	dataSource, err := s.composeDataSource(ctx, dataSourceRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose data source with dataSourceRaw[%+v], error: %w", dataSourceRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose data source with dataSourceRaw[%+v]", dataSourceRaw)
 	}
 	return dataSource, nil
 }
@@ -79,14 +80,14 @@ func (s *Store) CreateDataSource(ctx context.Context, create *api.DataSourceCrea
 func (s *Store) GetDataSource(ctx context.Context, find *api.DataSourceFind) (*api.DataSource, error) {
 	dataSourceRaw, err := s.getDataSourceRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get data source with DataSourceFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to get data source with DataSourceFind[%+v]", find)
 	}
 	if dataSourceRaw == nil {
 		return nil, nil
 	}
 	dataSource, err := s.composeDataSource(ctx, dataSourceRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose data source with dataSourceRaw[%+v], error: %w", dataSourceRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose data source with dataSourceRaw[%+v]", dataSourceRaw)
 	}
 	return dataSource, nil
 }
@@ -95,13 +96,13 @@ func (s *Store) GetDataSource(ctx context.Context, find *api.DataSourceFind) (*a
 func (s *Store) FindDataSource(ctx context.Context, find *api.DataSourceFind) ([]*api.DataSource, error) {
 	dataSourceRawList, err := s.findDataSourceRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find DataSource list with DataSourceFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find DataSource list with DataSourceFind[%+v]", find)
 	}
 	var dataSourceList []*api.DataSource
 	for _, raw := range dataSourceRawList {
 		dataSource, err := s.composeDataSource(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose DataSource role with dataSourceRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose DataSource role with dataSourceRaw[%+v]", raw)
 		}
 		dataSourceList = append(dataSourceList, dataSource)
 	}
@@ -112,11 +113,11 @@ func (s *Store) FindDataSource(ctx context.Context, find *api.DataSourceFind) ([
 func (s *Store) PatchDataSource(ctx context.Context, patch *api.DataSourcePatch) (*api.DataSource, error) {
 	dataSourceRaw, err := s.patchDataSourceRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch DataSource with DataSourcePatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch DataSource with DataSourcePatch[%+v]", patch)
 	}
 	dataSource, err := s.composeDataSource(ctx, dataSourceRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose DataSource role with dataSourceRaw[%+v], error: %w", dataSourceRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose DataSource role with dataSourceRaw[%+v]", dataSourceRaw)
 	}
 	return dataSource, nil
 }
@@ -130,7 +131,7 @@ func (s *Store) PatchDataSource(ctx context.Context, patch *api.DataSourcePatch)
 func (s *Store) createDataSourceRawTx(ctx context.Context, tx *sql.Tx, create *api.DataSourceCreate) error {
 	_, err := s.createDataSourceImpl(ctx, tx, create)
 	if err != nil {
-		return fmt.Errorf("failed to create data source with DataSourceCreate[%+v], error: %w", create, err)
+		return errors.Wrapf(err, "failed to create data source with DataSourceCreate[%+v]", create)
 	}
 	return nil
 }

--- a/store/database.go
+++ b/store/database.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/metric"
+	"github.com/pkg/errors"
 )
 
 // databaseRaw is the store model for an Database.
@@ -69,11 +70,11 @@ func (raw *databaseRaw) toDatabase() *api.Database {
 func (s *Store) CreateDatabase(ctx context.Context, create *api.DatabaseCreate) (*api.Database, error) {
 	databaseRaw, err := s.createDatabaseRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Database with DatabaseCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Database with DatabaseCreate[%+v]", create)
 	}
 	database, err := s.composeDatabase(ctx, databaseRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Database with databaseRaw[%+v], error: %w", databaseRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Database with databaseRaw[%+v]", databaseRaw)
 	}
 	return database, nil
 }
@@ -82,13 +83,13 @@ func (s *Store) CreateDatabase(ctx context.Context, create *api.DatabaseCreate) 
 func (s *Store) FindDatabase(ctx context.Context, find *api.DatabaseFind) ([]*api.Database, error) {
 	databaseRawList, err := s.findDatabaseRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Database list with DatabaseFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Database list with DatabaseFind[%+v]", find)
 	}
 	var databaseList []*api.Database
 	for _, raw := range databaseRawList {
 		database, err := s.composeDatabase(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Database with databaseRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Database with databaseRaw[%+v]", raw)
 		}
 		databaseList = append(databaseList, database)
 	}
@@ -112,14 +113,14 @@ func (s *Store) FindDatabase(ctx context.Context, find *api.DatabaseFind) ([]*ap
 func (s *Store) GetDatabase(ctx context.Context, find *api.DatabaseFind) (*api.Database, error) {
 	databaseRaw, err := s.getDatabaseRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Database with DatabaseFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to get Database with DatabaseFind[%+v]", find)
 	}
 	if databaseRaw == nil {
 		return nil, nil
 	}
 	database, err := s.composeDatabase(ctx, databaseRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Database with databaseRaw[%+v], error: %w", databaseRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Database with databaseRaw[%+v]", databaseRaw)
 	}
 	return database, nil
 }
@@ -128,11 +129,11 @@ func (s *Store) GetDatabase(ctx context.Context, find *api.DatabaseFind) (*api.D
 func (s *Store) PatchDatabase(ctx context.Context, patch *api.DatabasePatch) (*api.Database, error) {
 	databaseRaw, err := s.patchDatabaseRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Database with DatabasePatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Database with DatabasePatch[%+v]", patch)
 	}
 	database, err := s.composeDatabase(ctx, databaseRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Database with databaseRaw[%+v], error: %w", databaseRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Database with databaseRaw[%+v]", databaseRaw)
 	}
 	return database, nil
 }

--- a/store/deploy.go
+++ b/store/deploy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // deploymentConfigRaw is the store model for an DeploymentConfig.
@@ -54,14 +55,14 @@ func (raw *deploymentConfigRaw) toDeploymentConfig() *api.DeploymentConfig {
 func (s *Store) GetDeploymentConfigByProjectID(ctx context.Context, projectID int) (*api.DeploymentConfig, error) {
 	deploymentConfigRaw, err := s.getDeploymentConfigImpl(ctx, &api.DeploymentConfigFind{ProjectID: &projectID})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get DeploymentConfig with projectID %d, error: %w", projectID, err)
+		return nil, errors.Wrapf(err, "failed to get DeploymentConfig with projectID %d", projectID)
 	}
 	if deploymentConfigRaw == nil {
 		return nil, nil
 	}
 	deploymentConfig, err := s.composeDeploymentConfig(ctx, deploymentConfigRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose DeploymentConfig with deploymentConfigRaw[%+v], error: %w", deploymentConfigRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose DeploymentConfig with deploymentConfigRaw[%+v]", deploymentConfigRaw)
 	}
 	return deploymentConfig, nil
 }
@@ -70,11 +71,11 @@ func (s *Store) GetDeploymentConfigByProjectID(ctx context.Context, projectID in
 func (s *Store) UpsertDeploymentConfig(ctx context.Context, upsert *api.DeploymentConfigUpsert) (*api.DeploymentConfig, error) {
 	deploymentConfigRaw, err := s.upsertDeploymentConfigRaw(ctx, upsert)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upsert deployment config with DeploymentConfigUpsert[%+v], error: %w", upsert, err)
+		return nil, errors.Wrapf(err, "failed to upsert deployment config with DeploymentConfigUpsert[%+v]", upsert)
 	}
 	deploymentConfig, err := s.composeDeploymentConfig(ctx, deploymentConfigRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose DeploymentConfig with deploymentConfigRaw[%+v], error: %w", deploymentConfigRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose DeploymentConfig with deploymentConfigRaw[%+v]", deploymentConfigRaw)
 	}
 	return deploymentConfig, nil
 }

--- a/store/environment.go
+++ b/store/environment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // environmentRaw is the store model for an Environment.
@@ -48,11 +49,11 @@ func (raw *environmentRaw) toEnvironment() *api.Environment {
 func (s *Store) CreateEnvironment(ctx context.Context, create *api.EnvironmentCreate) (*api.Environment, error) {
 	environmentRaw, err := s.createEnvironmentRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Environment with EnvironmentCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Environment with EnvironmentCreate[%+v]", create)
 	}
 	environment, err := s.composeEnvironment(ctx, environmentRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Environment with environmentRaw[%+v], error: %w", environmentRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Environment with environmentRaw[%+v]", environmentRaw)
 	}
 	return environment, nil
 }
@@ -61,13 +62,13 @@ func (s *Store) CreateEnvironment(ctx context.Context, create *api.EnvironmentCr
 func (s *Store) FindEnvironment(ctx context.Context, find *api.EnvironmentFind) ([]*api.Environment, error) {
 	environmentRawList, err := s.findEnvironmentRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Environment list with EnvironmentFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Environment list with EnvironmentFind[%+v]", find)
 	}
 	var environmentList []*api.Environment
 	for _, raw := range environmentRawList {
 		environment, err := s.composeEnvironment(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Environment role with environmentRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Environment role with environmentRaw[%+v]", raw)
 		}
 		environmentList = append(environmentList, environment)
 	}
@@ -78,11 +79,11 @@ func (s *Store) FindEnvironment(ctx context.Context, find *api.EnvironmentFind) 
 func (s *Store) PatchEnvironment(ctx context.Context, patch *api.EnvironmentPatch) (*api.Environment, error) {
 	environmentRaw, err := s.patchEnvironmentRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Environment with EnvironmentPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Environment with EnvironmentPatch[%+v]", patch)
 	}
 	environment, err := s.composeEnvironment(ctx, environmentRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Environment role with environmentRaw[%+v], error: %w", environmentRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Environment role with environmentRaw[%+v]", environmentRaw)
 	}
 	return environment, nil
 }
@@ -91,7 +92,7 @@ func (s *Store) PatchEnvironment(ctx context.Context, patch *api.EnvironmentPatc
 func (s *Store) GetEnvironmentByID(ctx context.Context, id int) (*api.Environment, error) {
 	envRaw, err := s.getEnvironmentByIDRaw(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get environment with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get environment with ID %d", id)
 	}
 	if envRaw == nil {
 		return nil, nil
@@ -99,7 +100,7 @@ func (s *Store) GetEnvironmentByID(ctx context.Context, id int) (*api.Environmen
 
 	env, err := s.composeEnvironment(ctx, envRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose environment with environmentRaw[%+v], error: %w", envRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose environment with environmentRaw[%+v]", envRaw)
 	}
 
 	return env, nil

--- a/store/extension.go
+++ b/store/extension.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/pkg/errors"
 )
 
 // dbExtensionRaw is the store model for an DBExtension.
@@ -59,13 +60,13 @@ func (raw *dbExtensionRaw) toDBExtension() *api.DBExtension {
 func (s *Store) FindDBExtension(ctx context.Context, find *api.DBExtensionFind) ([]*api.DBExtension, error) {
 	dbExtensionRawList, err := s.findDBExtensionRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find dbExtension list with dbExtensionFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find dbExtension list with dbExtensionFind[%+v]", find)
 	}
 	var dbExtensionList []*api.DBExtension
 	for _, raw := range dbExtensionRawList {
 		dbExtension, err := s.composeDBExtension(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose dbExtension with dbExtensionRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose dbExtension with dbExtensionRaw[%+v]", raw)
 		}
 		dbExtensionList = append(dbExtensionList, dbExtension)
 	}

--- a/store/inbox.go
+++ b/store/inbox.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // inboxRaw is the store model for an Inbox.
@@ -36,11 +37,11 @@ func (raw *inboxRaw) toInbox() *api.Inbox {
 func (s *Store) CreateInbox(ctx context.Context, create *api.InboxCreate) (*api.Inbox, error) {
 	inboxRaw, err := s.createInboxRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Inbox with InboxCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Inbox with InboxCreate[%+v]", create)
 	}
 	inbox, err := s.composeInbox(ctx, inboxRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Inbox with inboxRaw[%+v], error: %w", inboxRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Inbox with inboxRaw[%+v]", inboxRaw)
 	}
 	return inbox, nil
 }
@@ -50,14 +51,14 @@ func (s *Store) GetInboxByID(ctx context.Context, id int) (*api.Inbox, error) {
 	find := &api.InboxFind{ID: &id}
 	inboxRaw, err := s.getInboxRawByID(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Inbox with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Inbox with ID %d", id)
 	}
 	if inboxRaw == nil {
 		return nil, nil
 	}
 	inbox, err := s.composeInbox(ctx, inboxRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Inbox with inboxRaw[%+v], error: %w", inboxRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Inbox with inboxRaw[%+v]", inboxRaw)
 	}
 	return inbox, nil
 }
@@ -66,13 +67,13 @@ func (s *Store) GetInboxByID(ctx context.Context, id int) (*api.Inbox, error) {
 func (s *Store) FindInbox(ctx context.Context, find *api.InboxFind) ([]*api.Inbox, error) {
 	inboxRawList, err := s.findInboxRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Inbox list with InboxFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Inbox list with InboxFind[%+v]", find)
 	}
 	var inboxList []*api.Inbox
 	for _, raw := range inboxRawList {
 		inbox, err := s.composeInbox(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Inbox with inboxRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Inbox with inboxRaw[%+v]", raw)
 		}
 		inboxList = append(inboxList, inbox)
 	}
@@ -83,11 +84,11 @@ func (s *Store) FindInbox(ctx context.Context, find *api.InboxFind) ([]*api.Inbo
 func (s *Store) PatchInbox(ctx context.Context, patch *api.InboxPatch) (*api.Inbox, error) {
 	inboxRaw, err := s.patchInboxRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Inbox with InboxPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Inbox with InboxPatch[%+v]", patch)
 	}
 	inbox, err := s.composeInbox(ctx, inboxRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Inbox with inboxRaw[%+v], error: %w", inboxRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Inbox with inboxRaw[%+v]", inboxRaw)
 	}
 	return inbox, nil
 }

--- a/store/instance.go
+++ b/store/instance.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/metric"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/pkg/errors"
 )
 
 // instanceRaw is the store model for an Instance.
@@ -66,11 +67,11 @@ func (raw *instanceRaw) toInstance() *api.Instance {
 func (s *Store) CreateInstance(ctx context.Context, create *api.InstanceCreate) (*api.Instance, error) {
 	instanceRaw, err := s.createInstanceRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Instance with InstanceCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Instance with InstanceCreate[%+v]", create)
 	}
 	instance, err := s.composeInstance(ctx, instanceRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Instance with instanceRaw[%+v], error: %w", instanceRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Instance with instanceRaw[%+v]", instanceRaw)
 	}
 	return instance, nil
 }
@@ -80,14 +81,14 @@ func (s *Store) GetInstanceByID(ctx context.Context, id int) (*api.Instance, err
 	find := &api.InstanceFind{ID: &id}
 	instanceRaw, err := s.getInstanceRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Instance with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Instance with ID %d", id)
 	}
 	if instanceRaw == nil {
 		return nil, nil
 	}
 	instance, err := s.composeInstance(ctx, instanceRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Instance with instanceRaw[%+v], error: %w", instanceRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Instance with instanceRaw[%+v]", instanceRaw)
 	}
 	return instance, nil
 }
@@ -96,13 +97,13 @@ func (s *Store) GetInstanceByID(ctx context.Context, id int) (*api.Instance, err
 func (s *Store) FindInstance(ctx context.Context, find *api.InstanceFind) ([]*api.Instance, error) {
 	instanceRawList, err := s.findInstanceRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Instance list with InstanceFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Instance list with InstanceFind[%+v]", find)
 	}
 	var instanceList []*api.Instance
 	for _, raw := range instanceRawList {
 		instance, err := s.composeInstance(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Instance with instanceRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Instance with instanceRaw[%+v]", raw)
 		}
 		instanceList = append(instanceList, instance)
 	}
@@ -113,11 +114,11 @@ func (s *Store) FindInstance(ctx context.Context, find *api.InstanceFind) ([]*ap
 func (s *Store) PatchInstance(ctx context.Context, patch *api.InstancePatch) (*api.Instance, error) {
 	instanceRaw, err := s.patchInstanceRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Instance with InstancePatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Instance with InstancePatch[%+v]", patch)
 	}
 	instance, err := s.composeInstance(ctx, instanceRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Instance with instanceRaw[%+v], error: %w", instanceRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Instance with instanceRaw[%+v]", instanceRaw)
 	}
 	return instance, nil
 }
@@ -238,7 +239,7 @@ func (s *Store) FindInstanceWithDatabaseBackupEnabled(ctx context.Context, engin
 	for _, raw := range instanceRawList {
 		instance, err := s.composeInstance(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Instance with instanceRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Instance with instanceRaw[%+v]", raw)
 		}
 		instanceList = append(instanceList, instance)
 	}

--- a/store/issue.go
+++ b/store/issue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/metric"
+	"github.com/pkg/errors"
 )
 
 // issueRaw is the store model for an Issue.
@@ -68,11 +69,11 @@ func (raw *issueRaw) toIssue() *api.Issue {
 func (s *Store) CreateIssue(ctx context.Context, create *api.IssueCreate) (*api.Issue, error) {
 	issueRaw, err := s.createIssueRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Issue with IssueCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Issue with IssueCreate[%+v]", create)
 	}
 	issue, err := s.composeIssue(ctx, issueRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Issue with issueRaw[%+v], error: %w", issueRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Issue with issueRaw[%+v]", issueRaw)
 	}
 	return issue, nil
 }
@@ -82,14 +83,14 @@ func (s *Store) GetIssueByID(ctx context.Context, id int) (*api.Issue, error) {
 	find := &api.IssueFind{ID: &id}
 	issueRaw, err := s.getIssueRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Issue with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Issue with ID %d", id)
 	}
 	if issueRaw == nil {
 		return nil, nil
 	}
 	issue, err := s.composeIssue(ctx, issueRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Issue with issueRaw[%+v], error: %w", issueRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Issue with issueRaw[%+v]", issueRaw)
 	}
 	return issue, nil
 }
@@ -99,14 +100,14 @@ func (s *Store) GetIssueByPipelineID(ctx context.Context, id int) (*api.Issue, e
 	find := &api.IssueFind{PipelineID: &id}
 	issueRaw, err := s.getIssueRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Issue with PipelineID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Issue with PipelineID %d", id)
 	}
 	if issueRaw == nil {
 		return nil, nil
 	}
 	issue, err := s.composeIssue(ctx, issueRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Issue with issueRaw[%+v], error: %w", issueRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Issue with issueRaw[%+v]", issueRaw)
 	}
 	return issue, nil
 }
@@ -115,13 +116,13 @@ func (s *Store) GetIssueByPipelineID(ctx context.Context, id int) (*api.Issue, e
 func (s *Store) FindIssue(ctx context.Context, find *api.IssueFind) ([]*api.Issue, error) {
 	issueRawList, err := s.findIssueRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Issue list with IssueFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Issue list with IssueFind[%+v]", find)
 	}
 	var issueList []*api.Issue
 	for _, raw := range issueRawList {
 		issue, err := s.composeIssue(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Issue with issueRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Issue with issueRaw[%+v]", raw)
 		}
 		issueList = append(issueList, issue)
 	}
@@ -132,11 +133,11 @@ func (s *Store) FindIssue(ctx context.Context, find *api.IssueFind) ([]*api.Issu
 func (s *Store) PatchIssue(ctx context.Context, patch *api.IssuePatch) (*api.Issue, error) {
 	issueRaw, err := s.patchIssueRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Issue with IssuePatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Issue with IssuePatch[%+v]", patch)
 	}
 	issue, err := s.composeIssue(ctx, issueRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Issue with issueRaw[%+v], error: %w", issueRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Issue with issueRaw[%+v]", issueRaw)
 	}
 	return issue, nil
 }

--- a/store/issue_subscriber.go
+++ b/store/issue_subscriber.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // issueSubscriberRaw is the store model for an IssueSubscriber.
@@ -30,11 +31,11 @@ func (raw *issueSubscriberRaw) toIssueSubscriber() *api.IssueSubscriber {
 func (s *Store) CreateIssueSubscriber(ctx context.Context, create *api.IssueSubscriberCreate) (*api.IssueSubscriber, error) {
 	issueSubRaw, err := s.createIssueSubscriberRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create IssueSubscriber with IssueSubscriberCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create IssueSubscriber with IssueSubscriberCreate[%+v]", create)
 	}
 	issueSub, err := s.composeIssueSubscriber(ctx, issueSubRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose IssueSubscriber with issueSubRaw[%+v], error: %w", issueSubRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose IssueSubscriber with issueSubRaw[%+v]", issueSubRaw)
 	}
 	return issueSub, nil
 }
@@ -43,13 +44,13 @@ func (s *Store) CreateIssueSubscriber(ctx context.Context, create *api.IssueSubs
 func (s *Store) FindIssueSubscriber(ctx context.Context, find *api.IssueSubscriberFind) ([]*api.IssueSubscriber, error) {
 	issueSubRawList, err := s.findIssueSubscriberRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find IssueSubscriber list with IssueSubscriberFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find IssueSubscriber list with IssueSubscriberFind[%+v]", find)
 	}
 	var issueSubList []*api.IssueSubscriber
 	for _, raw := range issueSubRawList {
 		issueSub, err := s.composeIssueSubscriber(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose IssueSubscriber with issueSubRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose IssueSubscriber with issueSubRaw[%+v]", raw)
 		}
 		issueSubList = append(issueSubList, issueSub)
 	}

--- a/store/label.go
+++ b/store/label.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // labelKeyRaw is the store model for an LabelKey.
@@ -144,7 +145,7 @@ func (s *Store) SetDatabaseLabelList(ctx context.Context, labelList []*api.Datab
 
 		label, err := s.composeDatabaseLabel(ctx, labelRaw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose DatabaseLabel with databaseLabelRaw[%+v], error: %w", labelRaw, err)
+			return nil, errors.Wrapf(err, "failed to compose DatabaseLabel with databaseLabelRaw[%+v]", labelRaw)
 		}
 		ret = append(ret, label)
 	}
@@ -160,13 +161,13 @@ func (s *Store) SetDatabaseLabelList(ctx context.Context, labelList []*api.Datab
 func (s *Store) FindLabelKey(ctx context.Context, find *api.LabelKeyFind) ([]*api.LabelKey, error) {
 	labelKeyRawList, err := s.findLabelKeyRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find LabelKey list with LabelKeyFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find LabelKey list with LabelKeyFind[%+v]", find)
 	}
 	var labelKeyList []*api.LabelKey
 	for _, raw := range labelKeyRawList {
 		labelKey, err := s.composeLabelKey(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose LabelKey with labelKeyRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose LabelKey with labelKeyRaw[%+v]", raw)
 		}
 		labelKeyList = append(labelKeyList, labelKey)
 	}
@@ -177,11 +178,11 @@ func (s *Store) FindLabelKey(ctx context.Context, find *api.LabelKeyFind) ([]*ap
 func (s *Store) PatchLabelKey(ctx context.Context, patch *api.LabelKeyPatch) (*api.LabelKey, error) {
 	labelKeyRaw, err := s.patchLabelKeyRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch LabelKey with LabelKeyPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch LabelKey with LabelKeyPatch[%+v]", patch)
 	}
 	labelKey, err := s.composeLabelKey(ctx, labelKeyRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose LabelKey with labelKeyRaw[%+v], error: %w", labelKeyRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose LabelKey with labelKeyRaw[%+v]", labelKeyRaw)
 	}
 	return labelKey, nil
 }
@@ -190,13 +191,13 @@ func (s *Store) PatchLabelKey(ctx context.Context, patch *api.LabelKeyPatch) (*a
 func (s *Store) FindDatabaseLabel(ctx context.Context, find *api.DatabaseLabelFind) ([]*api.DatabaseLabel, error) {
 	labelKeyRawList, err := s.findDatabaseLabelRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find DatabaseLabel list with DatabaseLabelFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find DatabaseLabel list with DatabaseLabelFind[%+v]", find)
 	}
 	var labelKeyList []*api.DatabaseLabel
 	for _, raw := range labelKeyRawList {
 		labelKey, err := s.composeDatabaseLabel(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose DatabaseLabel with labelKeyRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose DatabaseLabel with labelKeyRaw[%+v]", raw)
 		}
 		labelKeyList = append(labelKeyList, labelKey)
 	}

--- a/store/member.go
+++ b/store/member.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/metric"
+	"github.com/pkg/errors"
 )
 
 // memberRaw is the store model for an Member.
@@ -53,11 +54,11 @@ func (raw *memberRaw) toMember() *api.Member {
 func (s *Store) CreateMember(ctx context.Context, create *api.MemberCreate) (*api.Member, error) {
 	memberRaw, err := s.createMemberRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Member with MemberCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Member with MemberCreate[%+v]", create)
 	}
 	member, err := s.composeMember(ctx, memberRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Member with memberRaw[%+v], error: %w", memberRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Member with memberRaw[%+v]", memberRaw)
 	}
 	return member, nil
 }
@@ -66,13 +67,13 @@ func (s *Store) CreateMember(ctx context.Context, create *api.MemberCreate) (*ap
 func (s *Store) FindMember(ctx context.Context, find *api.MemberFind) ([]*api.Member, error) {
 	memberRawList, err := s.findMemberRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Member list with MemberFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Member list with MemberFind[%+v]", find)
 	}
 	var memberList []*api.Member
 	for _, raw := range memberRawList {
 		member, err := s.composeMember(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Member with memberRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Member with memberRaw[%+v]", raw)
 		}
 		memberList = append(memberList, member)
 	}
@@ -84,14 +85,14 @@ func (s *Store) GetMemberByPrincipalID(ctx context.Context, id int) (*api.Member
 	find := &api.MemberFind{PrincipalID: &id}
 	memberRaw, err := s.getMemberRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Member with PrincipalID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Member with PrincipalID %d", id)
 	}
 	if memberRaw == nil {
 		return nil, nil
 	}
 	member, err := s.composeMember(ctx, memberRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Member with memberRaw[%+v], error: %w", memberRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Member with memberRaw[%+v]", memberRaw)
 	}
 	return member, nil
 }
@@ -101,14 +102,14 @@ func (s *Store) GetMemberByID(ctx context.Context, id int) (*api.Member, error) 
 	find := &api.MemberFind{ID: &id}
 	memberRaw, err := s.getMemberRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Member with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Member with ID %d", id)
 	}
 	if memberRaw == nil {
 		return nil, nil
 	}
 	member, err := s.composeMember(ctx, memberRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Member with memberRaw[%+v], error: %w", memberRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Member with memberRaw[%+v]", memberRaw)
 	}
 	return member, nil
 }
@@ -117,11 +118,11 @@ func (s *Store) GetMemberByID(ctx context.Context, id int) (*api.Member, error) 
 func (s *Store) PatchMember(ctx context.Context, patch *api.MemberPatch) (*api.Member, error) {
 	memberRaw, err := s.patchMemberRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Member with MemberPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Member with MemberPatch[%+v]", patch)
 	}
 	member, err := s.composeMember(ctx, memberRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Member with memberRaw[%+v], error: %w", memberRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Member with memberRaw[%+v]", memberRaw)
 	}
 	return member, nil
 }

--- a/store/pipeline.go
+++ b/store/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -50,11 +51,11 @@ func (raw *pipelineRaw) toPipeline() *api.Pipeline {
 func (s *Store) CreatePipeline(ctx context.Context, create *api.PipelineCreate) (*api.Pipeline, error) {
 	pipelineRaw, err := s.createPipelineRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Pipeline with PipelineCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Pipeline with PipelineCreate[%+v]", create)
 	}
 	pipeline, err := s.composePipeline(ctx, pipelineRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Pipeline with pipelineRaw[%+v], error: %w", pipelineRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Pipeline with pipelineRaw[%+v]", pipelineRaw)
 	}
 	return pipeline, nil
 }
@@ -64,14 +65,14 @@ func (s *Store) GetPipelineByID(ctx context.Context, id int) (*api.Pipeline, err
 	find := &api.PipelineFind{ID: &id}
 	pipelineRaw, err := s.getPipelineRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Pipeline with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Pipeline with ID %d", id)
 	}
 	if pipelineRaw == nil {
 		return nil, nil
 	}
 	pipeline, err := s.composePipeline(ctx, pipelineRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Pipeline with pipelineRaw[%+v], error: %w", pipelineRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Pipeline with pipelineRaw[%+v]", pipelineRaw)
 	}
 	return pipeline, nil
 }
@@ -80,14 +81,14 @@ func (s *Store) GetPipelineByID(ctx context.Context, id int) (*api.Pipeline, err
 func (s *Store) FindPipeline(ctx context.Context, find *api.PipelineFind, returnOnErr bool) ([]*api.Pipeline, error) {
 	pipelineRawList, err := s.findPipelineRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Pipeline list with PipelineFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Pipeline list with PipelineFind[%+v]", find)
 	}
 	var pipelineList []*api.Pipeline
 	for _, raw := range pipelineRawList {
 		pipeline, err := s.composePipeline(ctx, raw)
 		if err != nil {
 			if returnOnErr {
-				return nil, fmt.Errorf("failed to compose Pipeline with pipelineRaw[%+v], error: %w", raw, err)
+				return nil, errors.Wrapf(err, "failed to compose Pipeline with pipelineRaw[%+v]", raw)
 			}
 			log.Error("failed to compose pipeline",
 				zap.Any("pipelineRaw", raw),
@@ -104,11 +105,11 @@ func (s *Store) FindPipeline(ctx context.Context, find *api.PipelineFind, return
 func (s *Store) PatchPipeline(ctx context.Context, patch *api.PipelinePatch) (*api.Pipeline, error) {
 	pipelineRaw, err := s.patchPipelineRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Pipeline with PipelinePatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Pipeline with PipelinePatch[%+v]", patch)
 	}
 	pipeline, err := s.composePipeline(ctx, pipelineRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Pipeline with pipelineRaw[%+v], error: %w", pipelineRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Pipeline with pipelineRaw[%+v]", pipelineRaw)
 	}
 	return pipeline, nil
 }

--- a/store/policy.go
+++ b/store/policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/advisor"
+	"github.com/pkg/errors"
 )
 
 // policyRaw is the store model for an Policy.
@@ -57,11 +58,11 @@ func (raw *policyRaw) toPolicy() *api.Policy {
 func (s *Store) UpsertPolicy(ctx context.Context, upsert *api.PolicyUpsert) (*api.Policy, error) {
 	policyRaw, err := s.upsertPolicyRaw(ctx, upsert)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upsert policy with PolicyUpsert[%+v], error: %w", upsert, err)
+		return nil, errors.Wrapf(err, "failed to upsert policy with PolicyUpsert[%+v]", upsert)
 	}
 	policy, err := s.composePolicy(ctx, policyRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose policy with policyRaw[%+v], error: %w", policyRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose policy with policyRaw[%+v]", policyRaw)
 	}
 	return policy, nil
 }
@@ -70,11 +71,11 @@ func (s *Store) UpsertPolicy(ctx context.Context, upsert *api.PolicyUpsert) (*ap
 func (s *Store) GetPolicy(ctx context.Context, find *api.PolicyFind) (*api.Policy, error) {
 	policyRaw, err := s.getPolicyRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get policy with PolicyFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to get policy with PolicyFind[%+v]", find)
 	}
 	policy, err := s.composePolicy(ctx, policyRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose policy with policyRaw[%+v], error: %w", policyRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose policy with policyRaw[%+v]", policyRaw)
 	}
 	return policy, nil
 }
@@ -99,7 +100,7 @@ func (s *Store) DeletePolicy(ctx context.Context, delete *api.PolicyDelete) erro
 	}
 	policyRawList, err := findPolicyImpl(ctx, tx.PTx, find)
 	if err != nil {
-		return fmt.Errorf("failed to list policy with PolicyFind[%+v], error: %w", find, err)
+		return errors.Wrapf(err, "failed to list policy with PolicyFind[%+v]", find)
 	}
 	if len(policyRawList) != 1 {
 		return &common.Error{Code: common.NotFound, Err: fmt.Errorf("failed to found policy with filter %+v, expect 1. ", find)}
@@ -136,14 +137,14 @@ func (s *Store) ListPolicy(ctx context.Context, find *api.PolicyFind) ([]*api.Po
 
 	policyRawList, err := findPolicyImpl(ctx, tx.PTx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list policy with PolicyFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to list policy with PolicyFind[%+v]", find)
 	}
 
 	policyList := []*api.Policy{}
 	for _, raw := range policyRawList {
 		policy, err := s.composePolicy(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose policy with policyRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose policy with policyRaw[%+v]", raw)
 		}
 		policyList = append(policyList, policy)
 	}

--- a/store/principal.go
+++ b/store/principal.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -56,7 +57,7 @@ func (raw *principalRaw) toPrincipal() *api.Principal {
 func (s *Store) CreatePrincipal(ctx context.Context, create *api.PrincipalCreate) (*api.Principal, error) {
 	principalRaw, err := s.createPrincipalRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Principal with PrincipalCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Principal with PrincipalCreate[%+v]", create)
 	}
 	// NOTE: Currently the corresponding Member object is not created yet.
 	// YES, we are returning a Principal with empty Role field. OMG.
@@ -74,7 +75,7 @@ func (s *Store) GetPrincipalList(ctx context.Context) ([]*api.Principal, error) 
 	for _, raw := range principalRawList {
 		principal, err := s.composePrincipal(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Principal role with principalRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Principal role with principalRaw[%+v]", raw)
 		}
 		principalList = append(principalList, principal)
 	}
@@ -86,14 +87,14 @@ func (s *Store) GetPrincipalByEmail(ctx context.Context, email string) (*api.Pri
 	find := &api.PrincipalFind{Email: &email}
 	principalRaw, err := s.getPrincipalRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Principal with PrincipalFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Principal with PrincipalFind[%+v]", find)
 	}
 	if principalRaw == nil {
 		return nil, nil
 	}
 	principal, err := s.composePrincipal(ctx, principalRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Principal role with principalRaw[%+v], error: %w", principalRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Principal role with principalRaw[%+v]", principalRaw)
 	}
 	return principal, nil
 }
@@ -102,11 +103,11 @@ func (s *Store) GetPrincipalByEmail(ctx context.Context, email string) (*api.Pri
 func (s *Store) PatchPrincipal(ctx context.Context, patch *api.PrincipalPatch) (*api.Principal, error) {
 	principalRaw, err := s.patchPrincipalRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Principal with PrincipalPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Principal with PrincipalPatch[%+v]", patch)
 	}
 	principal, err := s.composePrincipal(ctx, principalRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Principal role with principalRaw[%+v], error: %w", principalRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Principal role with principalRaw[%+v]", principalRaw)
 	}
 	return principal, nil
 }
@@ -124,7 +125,7 @@ func (s *Store) GetPrincipalByID(ctx context.Context, id int) (*api.Principal, e
 
 	principal, err := s.composePrincipal(ctx, principalRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Principal role with principalRaw[%+v], error: %w", principalRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Principal role with principalRaw[%+v]", principalRaw)
 	}
 
 	return principal, nil
@@ -260,7 +261,7 @@ func (s *Store) composePrincipal(ctx context.Context, raw *principalRaw) (*api.P
 				zap.Int("id", principal.ID),
 				zap.String("name", principal.Name),
 			)
-			return nil, fmt.Errorf("member with PrincipalID %d not exist, error: %w", principal.ID, err)
+			return nil, errors.Wrapf(err, "member with PrincipalID %d not exist", principal.ID)
 		}
 		principal.Role = memberRaw.Role
 	}

--- a/store/project.go
+++ b/store/project.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/metric"
+	"github.com/pkg/errors"
 )
 
 // projectRaw is the store model for a Project.
@@ -60,14 +61,14 @@ func (s *Store) GetProjectByID(ctx context.Context, id int) (*api.Project, error
 	find := &api.ProjectFind{ID: &id}
 	projectRaw, err := s.getProjectRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Project with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Project with ID %d", id)
 	}
 	if projectRaw == nil {
 		return nil, nil
 	}
 	project, err := s.composeProject(ctx, projectRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Project with projectRaw[%+v], error: %w", projectRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Project with projectRaw[%+v]", projectRaw)
 	}
 	return project, nil
 }
@@ -76,13 +77,13 @@ func (s *Store) GetProjectByID(ctx context.Context, id int) (*api.Project, error
 func (s *Store) FindProject(ctx context.Context, find *api.ProjectFind) ([]*api.Project, error) {
 	projectRawList, err := s.findProjectRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Project list with ProjectFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Project list with ProjectFind[%+v]", find)
 	}
 	var projectList []*api.Project
 	for _, raw := range projectRawList {
 		project, err := s.composeProject(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Project with projectRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Project with projectRaw[%+v]", raw)
 		}
 		projectList = append(projectList, project)
 	}
@@ -93,11 +94,11 @@ func (s *Store) FindProject(ctx context.Context, find *api.ProjectFind) ([]*api.
 func (s *Store) CreateProject(ctx context.Context, create *api.ProjectCreate) (*api.Project, error) {
 	projectRaw, err := s.createProjectRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Project with ProjectCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Project with ProjectCreate[%+v]", create)
 	}
 	project, err := s.composeProject(ctx, projectRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Project with projectRaw[%+v], error: %w", projectRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Project with projectRaw[%+v]", projectRaw)
 	}
 	return project, nil
 }
@@ -106,11 +107,11 @@ func (s *Store) CreateProject(ctx context.Context, create *api.ProjectCreate) (*
 func (s *Store) PatchProject(ctx context.Context, patch *api.ProjectPatch) (*api.Project, error) {
 	projectRaw, err := s.patchProjectRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Project with ProjectPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Project with ProjectPatch[%+v]", patch)
 	}
 	project, err := s.composeProject(ctx, projectRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Project with projectRaw[%+v], error: %w", projectRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Project with projectRaw[%+v]", projectRaw)
 	}
 	return project, nil
 }

--- a/store/project_member.go
+++ b/store/project_member.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // projectMemberRaw is the store model for an ProjectMember.
@@ -58,11 +59,11 @@ func (raw *projectMemberRaw) toProjectMember() *api.ProjectMember {
 func (s *Store) CreateProjectMember(ctx context.Context, create *api.ProjectMemberCreate) (*api.ProjectMember, error) {
 	projectMemberRaw, err := s.createProjectMemberRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create ProjectMember with ProjectMemberCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create ProjectMember with ProjectMemberCreate[%+v]", create)
 	}
 	projectMember, err := s.composeProjectMember(ctx, projectMemberRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose ProjectMember with projectMemberRaw[%+v], error: %w", projectMemberRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose ProjectMember with projectMemberRaw[%+v]", projectMemberRaw)
 	}
 	return projectMember, nil
 }
@@ -71,13 +72,13 @@ func (s *Store) CreateProjectMember(ctx context.Context, create *api.ProjectMemb
 func (s *Store) FindProjectMember(ctx context.Context, find *api.ProjectMemberFind) ([]*api.ProjectMember, error) {
 	projectMemberRawList, err := s.findProjectMemberRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find ProjectMember list with ProjectMemberFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find ProjectMember list with ProjectMemberFind[%+v]", find)
 	}
 	var projectMemberList []*api.ProjectMember
 	for _, raw := range projectMemberRawList {
 		projectMember, err := s.composeProjectMember(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose ProjectMember with projectMemberRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose ProjectMember with projectMemberRaw[%+v]", raw)
 		}
 		projectMemberList = append(projectMemberList, projectMember)
 	}
@@ -88,14 +89,14 @@ func (s *Store) FindProjectMember(ctx context.Context, find *api.ProjectMemberFi
 func (s *Store) GetProjectMember(ctx context.Context, find *api.ProjectMemberFind) (*api.ProjectMember, error) {
 	projectMemberRaw, err := s.getProjectMemberRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ProjectMember with projectMemberFind %+v, error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to get ProjectMember with projectMemberFind %+v", find)
 	}
 	if projectMemberRaw == nil {
 		return nil, nil
 	}
 	projectMember, err := s.composeProjectMember(ctx, projectMemberRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose ProjectMember with projectMemberRaw %+v, error: %w", projectMemberRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose ProjectMember with projectMemberRaw %+v", projectMemberRaw)
 	}
 	return projectMember, nil
 }
@@ -105,7 +106,7 @@ func (s *Store) GetProjectMemberByID(ctx context.Context, id int) (*api.ProjectM
 	find := &api.ProjectMemberFind{ID: &id}
 	projectMember, err := s.GetProjectMember(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ProjectMember with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get ProjectMember with ID %d", id)
 	}
 	return projectMember, nil
 }
@@ -114,11 +115,11 @@ func (s *Store) GetProjectMemberByID(ctx context.Context, id int) (*api.ProjectM
 func (s *Store) PatchProjectMember(ctx context.Context, patch *api.ProjectMemberPatch) (*api.ProjectMember, error) {
 	projectMemberRaw, err := s.patchProjectMemberRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch ProjectMember with ProjectMemberPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch ProjectMember with ProjectMemberPatch[%+v]", patch)
 	}
 	projectMember, err := s.composeProjectMember(ctx, projectMemberRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose ProjectMember with projectMemberRaw[%+v], error: %w", projectMemberRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose ProjectMember with projectMemberRaw[%+v]", projectMemberRaw)
 	}
 	return projectMember, nil
 }
@@ -146,20 +147,20 @@ func (s *Store) DeleteProjectMember(ctx context.Context, delete *api.ProjectMemb
 func (s *Store) BatchUpdateProjectMember(ctx context.Context, batchUpdate *api.ProjectMemberBatchUpdate) ([]*api.ProjectMember, []*api.ProjectMember, error) {
 	createdMemberRawList, deletedMemberRawList, err := s.batchUpdateProjectMemberRaw(ctx, batchUpdate)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to batch update projectMemberRaw with ProjectMemberBatchUpdate[%+v], error: %w", batchUpdate, err)
+		return nil, nil, errors.Wrapf(err, "failed to batch update projectMemberRaw with ProjectMemberBatchUpdate[%+v]", batchUpdate)
 	}
 	var createdMemberList, deletedMemberList []*api.ProjectMember
 	for _, raw := range createdMemberRawList {
 		createdMember, err := s.composeProjectMember(ctx, raw)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to compose created ProjectMember with projectMemberRaw[%+v], error: %w", raw, err)
+			return nil, nil, errors.Wrapf(err, "failed to compose created ProjectMember with projectMemberRaw[%+v]", raw)
 		}
 		createdMemberList = append(createdMemberList, createdMember)
 	}
 	for _, raw := range deletedMemberRawList {
 		deletedMember, err := s.composeProjectMember(ctx, raw)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to compose deleted ProjectMember with projectMemberRaw[%+v], error: %w", raw, err)
+			return nil, nil, errors.Wrapf(err, "failed to compose deleted ProjectMember with projectMemberRaw[%+v]", raw)
 		}
 		deletedMemberList = append(deletedMemberList, deletedMember)
 	}

--- a/store/project_webhook.go
+++ b/store/project_webhook.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgtype"
+	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
@@ -61,11 +62,11 @@ func (raw *projectWebhookRaw) toProjectWebhook() *api.ProjectWebhook {
 func (s *Store) CreateProjectWebhook(ctx context.Context, create *api.ProjectWebhookCreate) (*api.ProjectWebhook, error) {
 	projectWebhookRaw, err := s.createProjectWebhookRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create ProjectWebhook with ProjectWebhookCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create ProjectWebhook with ProjectWebhookCreate[%+v]", create)
 	}
 	projectWebhook, err := s.composeProjectWebhook(ctx, projectWebhookRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose ProjectWebhook with projectWebhookRaw[%+v], error: %w", projectWebhookRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose ProjectWebhook with projectWebhookRaw[%+v]", projectWebhookRaw)
 	}
 	return projectWebhook, nil
 }
@@ -75,14 +76,14 @@ func (s *Store) GetProjectWebhookByID(ctx context.Context, id int) (*api.Project
 	find := &api.ProjectWebhookFind{ID: &id}
 	projectWebhookRaw, err := s.getProjectWebhookRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ProjectWebhook with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get ProjectWebhook with ID %d", id)
 	}
 	if projectWebhookRaw == nil {
 		return nil, nil
 	}
 	projectWebhook, err := s.composeProjectWebhook(ctx, projectWebhookRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose ProjectWebhook with projectWebhookRaw[%+v], error: %w", projectWebhookRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose ProjectWebhook with projectWebhookRaw[%+v]", projectWebhookRaw)
 	}
 	return projectWebhook, nil
 }
@@ -91,13 +92,13 @@ func (s *Store) GetProjectWebhookByID(ctx context.Context, id int) (*api.Project
 func (s *Store) FindProjectWebhook(ctx context.Context, find *api.ProjectWebhookFind) ([]*api.ProjectWebhook, error) {
 	projectWebhookRawList, err := s.findProjectWebhookRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find ProjectWebhook list with ProjectWebhookFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find ProjectWebhook list with ProjectWebhookFind[%+v]", find)
 	}
 	var projectWebhookList []*api.ProjectWebhook
 	for _, raw := range projectWebhookRawList {
 		projectWebhook, err := s.composeProjectWebhook(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose ProjectWebhook with projectWebhookRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose ProjectWebhook with projectWebhookRaw[%+v]", raw)
 		}
 		projectWebhookList = append(projectWebhookList, projectWebhook)
 	}
@@ -108,11 +109,11 @@ func (s *Store) FindProjectWebhook(ctx context.Context, find *api.ProjectWebhook
 func (s *Store) PatchProjectWebhook(ctx context.Context, patch *api.ProjectWebhookPatch) (*api.ProjectWebhook, error) {
 	projectWebhookRaw, err := s.patchProjectWebhookRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch ProjectWebhook with ProjectWebhookPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch ProjectWebhook with ProjectWebhookPatch[%+v]", patch)
 	}
 	projectWebhook, err := s.composeProjectWebhook(ctx, projectWebhookRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose ProjectWebhook with projectWebhookRaw[%+v], error: %w", projectWebhookRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose ProjectWebhook with projectWebhookRaw[%+v]", projectWebhookRaw)
 	}
 	return projectWebhook, nil
 }

--- a/store/repository.go
+++ b/store/repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // repositoryRaw is the store model for a Repository.
@@ -81,11 +82,11 @@ func (raw *repositoryRaw) toRepository() *api.Repository {
 func (s *Store) CreateRepository(ctx context.Context, create *api.RepositoryCreate) (*api.Repository, error) {
 	repositoryRaw, err := s.createRepositoryRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Repository with RepositoryCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Repository with RepositoryCreate[%+v]", create)
 	}
 	repository, err := s.composeRepository(ctx, repositoryRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Repository with repositoryRaw[%+v], error: %w", repositoryRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Repository with repositoryRaw[%+v]", repositoryRaw)
 	}
 	return repository, nil
 }
@@ -94,14 +95,14 @@ func (s *Store) CreateRepository(ctx context.Context, create *api.RepositoryCrea
 func (s *Store) GetRepository(ctx context.Context, find *api.RepositoryFind) (*api.Repository, error) {
 	repositoryRaw, err := s.getRepositoryRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Repository with RepositoryFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to get Repository with RepositoryFind[%+v]", find)
 	}
 	if repositoryRaw == nil {
 		return nil, nil
 	}
 	repository, err := s.composeRepository(ctx, repositoryRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Repository with repositoryRaw[%+v], error: %w", repositoryRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Repository with repositoryRaw[%+v]", repositoryRaw)
 	}
 	return repository, nil
 }
@@ -110,13 +111,13 @@ func (s *Store) GetRepository(ctx context.Context, find *api.RepositoryFind) (*a
 func (s *Store) FindRepository(ctx context.Context, find *api.RepositoryFind) ([]*api.Repository, error) {
 	repositoryRawList, err := s.findRepositoryRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Repository list with RepositoryFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Repository list with RepositoryFind[%+v]", find)
 	}
 	var repositoryList []*api.Repository
 	for _, raw := range repositoryRawList {
 		repository, err := s.composeRepository(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Repository with repositoryRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Repository with repositoryRaw[%+v]", raw)
 		}
 		repositoryList = append(repositoryList, repository)
 	}
@@ -127,11 +128,11 @@ func (s *Store) FindRepository(ctx context.Context, find *api.RepositoryFind) ([
 func (s *Store) PatchRepository(ctx context.Context, patch *api.RepositoryPatch) (*api.Repository, error) {
 	repositoryRaw, err := s.patchRepositoryRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Repository with RepositoryPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Repository with RepositoryPatch[%+v]", patch)
 	}
 	repository, err := s.composeRepository(ctx, repositoryRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Repository with repositoryRaw[%+v], error: %w", repositoryRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Repository with repositoryRaw[%+v]", repositoryRaw)
 	}
 	return repository, nil
 }

--- a/store/setting.go
+++ b/store/setting.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // settingRaw is the store model for an Setting.
@@ -50,11 +51,11 @@ func (raw *settingRaw) toSetting() *api.Setting {
 func (s *Store) CreateSettingIfNotExist(ctx context.Context, create *api.SettingCreate) (*api.Setting, error) {
 	settingRaw, err := s.createSettingRawIfNotExist(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Setting with SettingCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Setting with SettingCreate[%+v]", create)
 	}
 	setting, err := s.composeSetting(ctx, settingRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Setting with settingRaw[%+v], error: %w", settingRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Setting with settingRaw[%+v]", settingRaw)
 	}
 	return setting, nil
 }
@@ -63,13 +64,13 @@ func (s *Store) CreateSettingIfNotExist(ctx context.Context, create *api.Setting
 func (s *Store) FindSetting(ctx context.Context, find *api.SettingFind) ([]*api.Setting, error) {
 	settingRawList, err := s.findSettingRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Setting list with SettingFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Setting list with SettingFind[%+v]", find)
 	}
 	var settingList []*api.Setting
 	for _, raw := range settingRawList {
 		setting, err := s.composeSetting(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Setting with settingRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Setting with settingRaw[%+v]", raw)
 		}
 		settingList = append(settingList, setting)
 	}
@@ -80,11 +81,11 @@ func (s *Store) FindSetting(ctx context.Context, find *api.SettingFind) ([]*api.
 func (s *Store) PatchSetting(ctx context.Context, patch *api.SettingPatch) (*api.Setting, error) {
 	settingRaw, err := s.patchSettingRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Setting with SettingPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Setting with SettingPatch[%+v]", patch)
 	}
 	setting, err := s.composeSetting(ctx, settingRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Setting with settingRaw[%+v], error: %w", settingRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Setting with settingRaw[%+v]", settingRaw)
 	}
 	return setting, nil
 }

--- a/store/sheet.go
+++ b/store/sheet.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/metric"
+	"github.com/pkg/errors"
 )
 
 // sheetRaw is the store model for an Sheet.
@@ -74,11 +75,11 @@ func (raw *sheetRaw) toSheet() *api.Sheet {
 func (s *Store) CreateSheet(ctx context.Context, create *api.SheetCreate) (*api.Sheet, error) {
 	sheetRaw, err := s.createSheetRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Sheet with SheetCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Sheet with SheetCreate[%+v]", create)
 	}
 	sheet, err := s.composeSheet(ctx, sheetRaw, create.CreatorID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Sheet with sheetRaw[%+v], error: %w", sheetRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Sheet with sheetRaw[%+v]", sheetRaw)
 	}
 	return sheet, nil
 }
@@ -87,14 +88,14 @@ func (s *Store) CreateSheet(ctx context.Context, create *api.SheetCreate) (*api.
 func (s *Store) GetSheet(ctx context.Context, find *api.SheetFind, currentPrincipalID int) (*api.Sheet, error) {
 	sheetRaw, err := s.getSheetRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Sheet with SheetFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to get Sheet with SheetFind[%+v]", find)
 	}
 	if sheetRaw == nil {
 		return nil, nil
 	}
 	sheet, err := s.composeSheet(ctx, sheetRaw, currentPrincipalID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Sheet with sheetRaw[%+v], error: %w", sheetRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Sheet with sheetRaw[%+v]", sheetRaw)
 	}
 	return sheet, nil
 }
@@ -109,7 +110,7 @@ func (s *Store) FindSheet(ctx context.Context, find *api.SheetFind, currentPrinc
 	for _, raw := range sheetRawList {
 		sheet, err := s.composeSheet(ctx, raw, currentPrincipalID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Sheet with sheetRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Sheet with sheetRaw[%+v]", raw)
 		}
 		sheetList = append(sheetList, sheet)
 	}
@@ -120,11 +121,11 @@ func (s *Store) FindSheet(ctx context.Context, find *api.SheetFind, currentPrinc
 func (s *Store) PatchSheet(ctx context.Context, patch *api.SheetPatch) (*api.Sheet, error) {
 	sheetRaw, err := s.patchSheetRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Sheet with SheetPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Sheet with SheetPatch[%+v]", patch)
 	}
 	sheet, err := s.composeSheet(ctx, sheetRaw, patch.UpdaterID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Sheet with sheetRaw[%+v], error: %w", sheetRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Sheet with sheetRaw[%+v]", sheetRaw)
 	}
 	return sheet, nil
 }

--- a/store/stage.go
+++ b/store/stage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 // stageRaw is the store model for an Stage.
@@ -54,11 +55,11 @@ func (raw *stageRaw) toStage() *api.Stage {
 func (s *Store) CreateStage(ctx context.Context, create *api.StageCreate) (*api.Stage, error) {
 	stageRaw, err := s.createStageRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Stage with StageCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Stage with StageCreate[%+v]", create)
 	}
 	stage, err := s.composeStage(ctx, stageRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Stage with stageRaw[%+v], error: %w", stageRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Stage with stageRaw[%+v]", stageRaw)
 	}
 	return stage, nil
 }
@@ -67,13 +68,13 @@ func (s *Store) CreateStage(ctx context.Context, create *api.StageCreate) (*api.
 func (s *Store) FindStage(ctx context.Context, find *api.StageFind) ([]*api.Stage, error) {
 	stageRawList, err := s.findStageRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Stage list with StageFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Stage list with StageFind[%+v]", find)
 	}
 	var stageList []*api.Stage
 	for _, raw := range stageRawList {
 		stage, err := s.composeStage(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Stage with stageRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Stage with stageRaw[%+v]", raw)
 		}
 		stageList = append(stageList, stage)
 	}

--- a/store/table.go
+++ b/store/table.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/pkg/errors"
 )
 
 // tableRaw is the store model for an Table.
@@ -72,14 +73,14 @@ func (raw *tableRaw) toTable() *api.Table {
 func (s *Store) GetTable(ctx context.Context, find *api.TableFind) (*api.Table, error) {
 	tableRaw, err := s.getTableRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Table with TableFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to get Table with TableFind[%+v]", find)
 	}
 	if tableRaw == nil {
 		return nil, nil
 	}
 	table, err := s.composeTable(ctx, tableRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Table with tableRaw[%+v], error: %w", tableRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Table with tableRaw[%+v]", tableRaw)
 	}
 	return table, nil
 }
@@ -94,7 +95,7 @@ func (s *Store) FindTable(ctx context.Context, find *api.TableFind) ([]*api.Tabl
 	for _, raw := range tableRawList {
 		table, err := s.composeTable(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose Table with tableRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose Table with tableRaw[%+v]", raw)
 		}
 		tableList = append(tableList, table)
 	}

--- a/store/task.go
+++ b/store/task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/metric"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -84,11 +85,11 @@ func (raw *taskRaw) toTask() *api.Task {
 func (s *Store) CreateTask(ctx context.Context, create *api.TaskCreate) (*api.Task, error) {
 	taskRaw, err := s.createTaskRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Task with TaskCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create Task with TaskCreate[%+v]", create)
 	}
 	task, err := s.composeTask(ctx, taskRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Task with taskRaw[%+v], error: %w", taskRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Task with taskRaw[%+v]", taskRaw)
 	}
 	return task, nil
 }
@@ -98,14 +99,14 @@ func (s *Store) GetTaskByID(ctx context.Context, id int) (*api.Task, error) {
 	find := &api.TaskFind{ID: &id}
 	taskRaw, err := s.getTaskRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Task with ID %d, error: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to get Task with ID %d", id)
 	}
 	if taskRaw == nil {
 		return nil, nil
 	}
 	task, err := s.composeTask(ctx, taskRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Task with taskRaw[%+v], error: %w", taskRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Task with taskRaw[%+v]", taskRaw)
 	}
 	return task, nil
 }
@@ -114,14 +115,14 @@ func (s *Store) GetTaskByID(ctx context.Context, id int) (*api.Task, error) {
 func (s *Store) FindTask(ctx context.Context, find *api.TaskFind, returnOnErr bool) ([]*api.Task, error) {
 	taskRawList, err := s.findTaskRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find Task list with TaskFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find Task list with TaskFind[%+v]", find)
 	}
 	var taskList []*api.Task
 	for _, raw := range taskRawList {
 		task, err := s.composeTask(ctx, raw)
 		if err != nil {
 			if returnOnErr {
-				return nil, fmt.Errorf("failed to compose Task with taskRaw[%+v], error: %w", raw, err)
+				return nil, errors.Wrapf(err, "failed to compose Task with taskRaw[%+v]", raw)
 			}
 			log.Error("failed to compose Task",
 				zap.Any("taskRaw", raw),
@@ -137,11 +138,11 @@ func (s *Store) FindTask(ctx context.Context, find *api.TaskFind, returnOnErr bo
 func (s *Store) PatchTask(ctx context.Context, patch *api.TaskPatch) (*api.Task, error) {
 	taskRaw, err := s.patchTaskRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch Task with TaskPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch Task with TaskPatch[%+v]", patch)
 	}
 	task, err := s.composeTask(ctx, taskRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose Task with taskRaw[%+v], error: %w", taskRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose Task with taskRaw[%+v]", taskRaw)
 	}
 	return task, nil
 }
@@ -150,11 +151,11 @@ func (s *Store) PatchTask(ctx context.Context, patch *api.TaskPatch) (*api.Task,
 func (s *Store) PatchTaskStatus(ctx context.Context, patch *api.TaskStatusPatch) (*api.Task, error) {
 	taskRaw, err := s.patchTaskRawStatus(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch TaskStatus with TaskStatusPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch TaskStatus with TaskStatusPatch[%+v]", patch)
 	}
 	task, err := s.composeTask(ctx, taskRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose TaskStatus with taskRaw[%+v], error: %w", taskRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose TaskStatus with taskRaw[%+v]", taskRaw)
 	}
 	return task, nil
 }

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -64,11 +65,11 @@ func (raw *taskCheckRunRaw) toTaskCheckRun() *api.TaskCheckRun {
 func (s *Store) CreateTaskCheckRunIfNeeded(ctx context.Context, create *api.TaskCheckRunCreate) (*api.TaskCheckRun, error) {
 	taskCheckRunRaw, err := s.createTaskCheckRunRawIfNeeded(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create TaskCheckRun with TaskCheckRunCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create TaskCheckRun with TaskCheckRunCreate[%+v]", create)
 	}
 	taskCheckRun, err := s.composeTaskCheckRun(ctx, taskCheckRunRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose TaskCheckRun with taskCheckRunRaw[%+v], error: %w", taskCheckRunRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose TaskCheckRun with taskCheckRunRaw[%+v]", taskCheckRunRaw)
 	}
 	return taskCheckRun, nil
 }
@@ -77,13 +78,13 @@ func (s *Store) CreateTaskCheckRunIfNeeded(ctx context.Context, create *api.Task
 func (s *Store) FindTaskCheckRun(ctx context.Context, find *api.TaskCheckRunFind) ([]*api.TaskCheckRun, error) {
 	taskCheckRunRawList, err := s.findTaskCheckRunRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find TaskCheckRun list with TaskCheckRunFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find TaskCheckRun list with TaskCheckRunFind[%+v]", find)
 	}
 	var taskCheckRunList []*api.TaskCheckRun
 	for _, raw := range taskCheckRunRawList {
 		taskCheckRun, err := s.composeTaskCheckRun(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose TaskCheckRun with taskCheckRunRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose TaskCheckRun with taskCheckRunRaw[%+v]", raw)
 		}
 		taskCheckRunList = append(taskCheckRunList, taskCheckRun)
 	}
@@ -94,11 +95,11 @@ func (s *Store) FindTaskCheckRun(ctx context.Context, find *api.TaskCheckRunFind
 func (s *Store) PatchTaskCheckRunStatus(ctx context.Context, patch *api.TaskCheckRunStatusPatch) (*api.TaskCheckRun, error) {
 	taskCheckRunRaw, err := s.patchTaskCheckRunRawStatus(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch TaskCheckRunStatus with TaskCheckRunStatusPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch TaskCheckRunStatus with TaskCheckRunStatusPatch[%+v]", patch)
 	}
 	taskCheckRun, err := s.composeTaskCheckRun(ctx, taskCheckRunRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose TaskCheckRunStatus with taskCheckRunRaw[%+v], error: %w", taskCheckRunRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose TaskCheckRunStatus with taskCheckRunRaw[%+v]", taskCheckRunRaw)
 	}
 	return taskCheckRun, nil
 }

--- a/store/task_dag.go
+++ b/store/task_dag.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
+	"github.com/pkg/errors"
 )
 
 type taskDAGRaw struct {
@@ -37,7 +38,7 @@ func (raw *taskDAGRaw) toTaskDAG() *api.TaskDAG {
 func (s *Store) CreateTaskDAG(ctx context.Context, create *api.TaskDAGCreate) (*api.TaskDAG, error) {
 	taskDAGRaw, err := s.createTaskDAGRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create TaskDAG with TaskDAGCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create TaskDAG with TaskDAGCreate[%+v]", create)
 	}
 	taskDAG := taskDAGRaw.toTaskDAG()
 	return taskDAG, nil
@@ -47,7 +48,7 @@ func (s *Store) CreateTaskDAG(ctx context.Context, create *api.TaskDAGCreate) (*
 func (s *Store) FindTaskDAGList(ctx context.Context, find *api.TaskDAGFind) ([]*api.TaskDAG, error) {
 	taskDAGRawList, err := s.findTaskDAGRawList(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find TaskDAG with TaskDAGFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find TaskDAG with TaskDAGFind[%+v]", find)
 	}
 	var taskDAGList []*api.TaskDAG
 	for _, taskDAGRaw := range taskDAGRawList {

--- a/store/vcs.go
+++ b/store/vcs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/vcs"
+	"github.com/pkg/errors"
 )
 
 // vcsRaw is the store model for a VCS (Version Control System).
@@ -55,11 +56,11 @@ func (raw *vcsRaw) toVCS() *api.VCS {
 func (s *Store) CreateVCS(ctx context.Context, create *api.VCSCreate) (*api.VCS, error) {
 	vcsRaw, err := s.createVCSRaw(ctx, create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create VCS with VCSCreate[%+v], error: %w", create, err)
+		return nil, errors.Wrapf(err, "failed to create VCS with VCSCreate[%+v]", create)
 	}
 	vcs, err := s.composeVCS(ctx, vcsRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose VCS with vcsRaw[%+v], error: %w", vcsRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose VCS with vcsRaw[%+v]", vcsRaw)
 	}
 	return vcs, nil
 }
@@ -68,13 +69,13 @@ func (s *Store) CreateVCS(ctx context.Context, create *api.VCSCreate) (*api.VCS,
 func (s *Store) FindVCS(ctx context.Context, find *api.VCSFind) ([]*api.VCS, error) {
 	vcsRawList, err := s.findVCSRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find VCS list with VCSFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find VCS list with VCSFind[%+v]", find)
 	}
 	var vcsList []*api.VCS
 	for _, raw := range vcsRawList {
 		vcs, err := s.composeVCS(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose VCS with vcsRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose VCS with vcsRaw[%+v]", raw)
 		}
 		vcsList = append(vcsList, vcs)
 	}
@@ -102,11 +103,11 @@ func (s *Store) GetVCSByID(ctx context.Context, id int) (*api.VCS, error) {
 func (s *Store) PatchVCS(ctx context.Context, patch *api.VCSPatch) (*api.VCS, error) {
 	vcsRaw, err := s.patchVCSRaw(ctx, patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch VCS with VCSPatch[%+v], error: %w", patch, err)
+		return nil, errors.Wrapf(err, "failed to patch VCS with VCSPatch[%+v]", patch)
 	}
 	vcs, err := s.composeVCS(ctx, vcsRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compose VCS with vcsRaw[%+v], error: %w", vcsRaw, err)
+		return nil, errors.Wrapf(err, "failed to compose VCS with vcsRaw[%+v]", vcsRaw)
 	}
 	return vcs, nil
 }
@@ -114,7 +115,7 @@ func (s *Store) PatchVCS(ctx context.Context, patch *api.VCSPatch) (*api.VCS, er
 // DeleteVCS deletes an instance of VCS.
 func (s *Store) DeleteVCS(ctx context.Context, delete *api.VCSDelete) error {
 	if err := s.deleteVCSRaw(ctx, delete); err != nil {
-		return fmt.Errorf("failed to delete VCS with VCSDelete[%+v], error: %w", delete, err)
+		return errors.Wrapf(err, "failed to delete VCS with VCSDelete[%+v]", delete)
 	}
 	return nil
 }

--- a/store/view.go
+++ b/store/view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/pkg/errors"
 )
 
 // viewRaw is the store model for an View.
@@ -57,13 +58,13 @@ func (raw *viewRaw) toView() *api.View {
 func (s *Store) FindView(ctx context.Context, find *api.ViewFind) ([]*api.View, error) {
 	viewRawList, err := s.findViewRaw(ctx, find)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find View list with ViewFind[%+v], error: %w", find, err)
+		return nil, errors.Wrapf(err, "failed to find View list with ViewFind[%+v]", find)
 	}
 	var viewList []*api.View
 	for _, raw := range viewRawList {
 		view, err := s.composeView(ctx, raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compose View with viewRaw[%+v], error: %w", raw, err)
+			return nil, errors.Wrapf(err, "failed to compose View with viewRaw[%+v]", raw)
 		}
 		viewList = append(viewList, view)
 	}

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/plugin/vcs"
 	"github.com/bytebase/bytebase/plugin/vcs/gitlab"
@@ -266,12 +267,12 @@ func (gl *GitLab) SendWebhookPush(projectID string, payload []byte) error {
 		// Send post request.
 		req, err := http.NewRequest("POST", webhook.URL, bytes.NewReader(payload))
 		if err != nil {
-			return fmt.Errorf("fail to create a new POST request(%q), error: %w", webhook.URL, err)
+			return errors.Wrapf(err, "fail to create a new POST request(%q)", webhook.URL)
 		}
 		req.Header.Set("X-Gitlab-Token", webhook.SecretToken)
 		resp, err := gl.client.Do(req)
 		if err != nil {
-			return fmt.Errorf("fail to send a POST request(%q), error: %w", webhook.URL, err)
+			return errors.Wrapf(err, "fail to send a POST request(%q)", webhook.URL)
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/jsonapi"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/api"
@@ -357,7 +358,7 @@ func (ctl *controller) Login() error {
 func (*controller) provisionSQLiteInstance(rootDir, name string) (string, error) {
 	p := path.Join(rootDir, name)
 	if err := os.MkdirAll(p, os.ModePerm); err != nil {
-		return "", fmt.Errorf("failed to make directory %q, error: %w", p, err)
+		return "", errors.Wrapf(err, "failed to make directory %q", p)
 	}
 
 	return p, nil
@@ -368,7 +369,7 @@ func (ctl *controller) get(shortURL string, params map[string]string) (io.ReadCl
 	gURL := fmt.Sprintf("%s%s", ctl.apiURL, shortURL)
 	req, err := http.NewRequest("GET", gURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("fail to create a new GET request(%q), error: %w", gURL, err)
+		return nil, errors.Wrapf(err, "fail to create a new GET request(%q)", gURL)
 	}
 	req.Header.Set("Cookie", ctl.cookie)
 	q := url.Values{}
@@ -378,7 +379,7 @@ func (ctl *controller) get(shortURL string, params map[string]string) (io.ReadCl
 	req.URL.RawQuery = q.Encode()
 	resp, err := ctl.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fail to send a GET request(%q), error: %w", gURL, err)
+		return nil, errors.Wrapf(err, "fail to send a GET request(%q)", gURL)
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(resp.Body)
@@ -395,12 +396,12 @@ func (ctl *controller) post(shortURL string, body io.Reader) (io.ReadCloser, err
 	url := fmt.Sprintf("%s%s", ctl.apiURL, shortURL)
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
-		return nil, fmt.Errorf("fail to create a new POST request(%q), error: %w", url, err)
+		return nil, errors.Wrapf(err, "fail to create a new POST request(%q)", url)
 	}
 	req.Header.Set("Cookie", ctl.cookie)
 	resp, err := ctl.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fail to send a POST request(%q), error: %w", url, err)
+		return nil, errors.Wrapf(err, "fail to send a POST request(%q)", url)
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(resp.Body)
@@ -417,12 +418,12 @@ func (ctl *controller) patch(shortURL string, body io.Reader) (io.ReadCloser, er
 	url := fmt.Sprintf("%s%s", ctl.apiURL, shortURL)
 	req, err := http.NewRequest("PATCH", url, body)
 	if err != nil {
-		return nil, fmt.Errorf("fail to create a new PATCH request(%q), error: %w", url, err)
+		return nil, errors.Wrapf(err, "fail to create a new PATCH request(%q)", url)
 	}
 	req.Header.Set("Cookie", ctl.cookie)
 	resp, err := ctl.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fail to send a PATCH request(%q), error: %w", url, err)
+		return nil, errors.Wrapf(err, "fail to send a PATCH request(%q)", url)
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(resp.Body)
@@ -438,12 +439,12 @@ func (ctl *controller) delete(shortURL string, body io.Reader) (io.ReadCloser, e
 	url := fmt.Sprintf("%s%s", ctl.apiURL, shortURL)
 	req, err := http.NewRequest("DELETE", url, body)
 	if err != nil {
-		return nil, fmt.Errorf("fail to create a new DELETE request(%q), error: %w", url, err)
+		return nil, errors.Wrapf(err, "fail to create a new DELETE request(%q)", url)
 	}
 	req.Header.Set("Cookie", ctl.cookie)
 	resp, err := ctl.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fail to send a DELETE request(%q), error: %w", url, err)
+		return nil, errors.Wrapf(err, "fail to send a DELETE request(%q)", url)
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(resp.Body)
@@ -777,7 +778,7 @@ func (ctl *controller) approveIssueNext(issue *api.Issue) error {
 						Status: api.TaskPending,
 					},
 					issue.Pipeline.ID); err != nil {
-					return fmt.Errorf("failed to patch task status for task %d, error: %w", task.ID, err)
+					return errors.Wrapf(err, "failed to patch task status for task %d", task.ID)
 				}
 				return nil
 			}
@@ -808,7 +809,7 @@ func (ctl *controller) approveIssueTasksWithStageApproval(issue *api.Issue) erro
 			},
 			issue.Pipeline.ID,
 		); err != nil {
-			return fmt.Errorf("failed to patch task status for stage %d, error: %w", stageID, err)
+			return errors.Wrapf(err, "failed to patch task status for stage %d", stageID)
 		}
 	}
 	return nil
@@ -1152,7 +1153,7 @@ func (ctl *controller) addLabelValues(key string, values []string) error {
 		ValueList: valueList,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to patch label key for key %q ID %d values %+v, error: %w", key, labelKey.ID, valueList, err)
+		return errors.Wrapf(err, "failed to patch label key for key %q ID %d values %+v", key, labelKey.ID, valueList)
 	}
 	return nil
 }


### PR DESCRIPTION
So that we can get the error stack automatically and do not require manual formatting ", error: %w".