### PR TITLE
chore: remove stack in error logging

### DIFF
--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -52,9 +52,6 @@ func Warn(msg string, fields ...zap.Field) {
 
 // Error wraps the zap Logger's Error method.
 func Error(msg string, fields ...zap.Field) {
-	// Append the stack info in Error logging for better debugging experience.
-	// Note that we should skip one stack frames so that the top frame start at the caller of log.Error.
-	fields = append(fields, zap.StackSkip("stack", 1))
 	gl.Error(msg, fields...)
 }
 


### PR DESCRIPTION
We now use `github.com/pkg/errors` to create errors, which already have stack info.