### PR TITLE
docs: use "such as" instead of "like"

### DIFF
--- a/api/repository.go
+++ b/api/repository.go
@@ -68,7 +68,7 @@ type RepositoryCreate struct {
 	ExternalID         string `jsonapi:"attr,externalId"`
 	// Token belonged by the user linking the project to the VCS repository. We store this token together
 	// with the refresh token in the new repository record so we can use it to call VCS API on
-	// behalf of that user to perform tasks like webhook CRUD later.
+	// behalf of that user to perform tasks such as webhook CRUD later.
 	AccessToken        string `jsonapi:"attr,accessToken"`
 	ExpiresTs          int64  `jsonapi:"attr,expiresTs"`
 	RefreshToken       string `jsonapi:"attr,refreshToken"`

--- a/api/sql.go
+++ b/api/sql.go
@@ -31,7 +31,7 @@ type SQLSyncSchema struct {
 // For now, we only support readonly / SELECT.
 type SQLExecute struct {
 	InstanceID int `jsonapi:"attr,instanceId"`
-	// For engines like MySQL, databaseName can be empty.
+	// For engines such as MySQL, databaseName can be empty.
 	DatabaseName string `jsonapi:"attr,databaseName"`
 	Statement    string `jsonapi:"attr,statement"`
 	// For now, Readonly must be true

--- a/api/task.go
+++ b/api/task.go
@@ -208,7 +208,7 @@ type TaskCreate struct {
 	PipelineID int
 	StageID    int
 	InstanceID int `jsonapi:"attr,instanceId"`
-	// Tasks like creating database may not have database.
+	// Tasks such as creating database may not have database.
 	DatabaseID *int `jsonapi:"attr,databaseId"`
 
 	// Domain specific fields

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -9,8 +9,8 @@ import (
 
 var (
 	// `gl` is the global logger.
-	// Other packages should use public methods like Info/Error to do the logging.
-	// If special logging is required (like log to a separate file for some special operations), we need to add other loggers.
+	// Other packages should use public methods such as Info/Error to do the logging.
+	// For other types of logging, e.g. logging to a separate file, they should use their own loggers.
 	gl     *zap.Logger
 	gLevel zap.AtomicLevel
 )

--- a/common/util.go
+++ b/common/util.go
@@ -78,7 +78,7 @@ func DefaultMigrationVersion() string {
 // For example, if the template is "{{DB_NAME}}_hello_{{LOCATION}}", then the tokens will be ["{{DB_NAME}}", "{{LOCATION}}"],
 // and the delimiters will be ["_hello_"].
 // The caller will usually replace the tokens with a normal string, or a regexp. In the latter case, it will be a problem
-// if there are special regexp characters like "$" in the delimiters. The caller should escape the delimiters in such cases.
+// if there are special regexp characters such as "$" in the delimiters. The caller should escape the delimiters in such cases.
 func ParseTemplateTokens(template string) ([]string, []string) {
 	r := regexp.MustCompile(`{{[^{}]+}}`)
 	tokens := r.FindAllString(template, -1)

--- a/docs/api-style-guide.md
+++ b/docs/api-style-guide.md
@@ -14,7 +14,7 @@ Most of the time, we only want to do partial update on the resource, and we shou
 
 ## Use resource id for addressing the specific resource
 
-Bytebase uses auto incremental ID as the primary key for all resources. To address a particular resource, we use GET `/issue/42`, if we want to support other addressing mechanism like using resource name, we should use query parameter like `.issue/42?name=foo`
+Bytebase uses auto-incremental ID as the primary key for all resources. To address a particular resource, we use GET `/issue/42`. If we want to support other addressing mechanism, we should use query parameters such as `.issue/42?name=foo`
 
 ## Use lower case, kebab-case for phrases
 

--- a/docs/design/pipeline.md
+++ b/docs/design/pipeline.md
@@ -48,8 +48,8 @@ A PIPELINE consists of multiple STAGES. A STAGE consists of multiple TASKS.
 # General design consideration
 
 - Other mainstream products either have 3 or 4 layers.
-  We choose 3 layers omitting the most granular layer - Step. For now only GitLab has 4 layer systems
-  and its step is mostly used to model a lightweight step like shell script step. This seems like
+  We choose 3 layers omitting the most granular layer - Step. For now only GitLab has 4 layer systems,
+  and its step is mostly used to model a lightweight step similar to shell script step. This seems like
   an overkill for our case. On the other hand, 3 layer design such as Octopus seems to be sufficient.
 
 - All products agree on the smallest querable execution unit (having a dedicated API resource endpoint):
@@ -75,6 +75,6 @@ To wrap up, we finally arrive the same conclusion as spinnaker.
 
 # Domain specific design consideration
 
-- We require a stage to associate with an environment. In the future, we will introduce environment tiers which define rules like whether requires manual approval.
+- We require a stage to associate with an environment. In the future, we will introduce environment tiers which define rules such as requiring manual approval.
 
-- We require a task to associate with an database instance. This limits the task usage to database operations instead of general purpose task management. Since Bytebase is dealing with database domain, this tradeoff is fine. On the other hand, a task may or may not contain a database since tasks like creating new database, syncing the entire instance schema are not database specific.
+- We require a task to associate with an database instance. This limits the task usage to database operations instead of general purpose task management. Since Bytebase is dealing with database domain, this tradeoff is fine. On the other hand, a task may or may not contain a database since tasks such as creating new database, syncing the entire instance schema are not database specific.

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -50,7 +50,7 @@ git push --set-upstream origin feat/xxx
 
 ### Branch Naming Convention
 
-The recommended branch naming convention is using `/` as a namespace separator, e.g., feat/xxx, chore/xxx, docs/xxx, which works nicely with 3rd party git tools like GitLens.
+The recommended branch naming convention is using `/` as a namespace separator, e.g., feat/xxx, chore/xxx, docs/xxx, which works nicely with 3rd party git tools such as GitLens.
 
 
 

--- a/enterprise/service/license.go
+++ b/enterprise/service/license.go
@@ -20,7 +20,7 @@ type LicenseService struct {
 }
 
 // Claims creates a struct that will be encoded to a JWT.
-// We add jwt.RegisteredClaims as an embedded type, to provide fields like name.
+// We add jwt.RegisteredClaims as an embedded type, to provide fields such as name.
 type Claims struct {
 	InstanceCount int    `json:"instanceCount"`
 	Trialing      bool   `json:"trialing"`

--- a/frontend/src/bbkit/BBTooltipButton.vue
+++ b/frontend/src/bbkit/BBTooltipButton.vue
@@ -2,7 +2,7 @@
   <NTooltip trigger="manual" :show="state.tooltipVisible">
     <template #trigger>
       <!--
-        <button disabled> will swallow all mouse related events like mouseover/mouseout...
+        <button disabled> will swallow all mouse related events such as mouseover/mouseout...
         so we need to handle it manually with lower level DOM pointer events
       -->
       <button

--- a/frontend/src/plugins/types.ts
+++ b/frontend/src/plugins/types.ts
@@ -45,7 +45,7 @@ export type InputField = {
   // is very similar to the message field id in Protocol Buffers.
   id: FieldId;
   // Used as the key to generate UI artifacts (e.g. query parameter).
-  // Though changing it won't have catastrophic consequence like changing
+  // Though changing it won't have catastrophic consequence such as changing
   // id, we strongly recommend NOT to change it as well, otherwise, previous
   // generated artifacts based on this info such as URL would become invalid.
   slug: string;

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -259,7 +259,7 @@ const routes: Array<RouteRecordRaw> = [
             // perspective, they are more familiar with the "user" concept.
             // We make an exception to use a shorthand here because it's a commonly
             // accessed endpoint, and maybe in the future, we will further provide a
-            // shortlink like u/<<uid>>
+            // shortlink such as u/<<uid>>
             path: "u/:principalId",
             name: "workspace.profile",
             meta: {

--- a/frontend/src/store/modules/task.ts
+++ b/frontend/src/store/modules/task.ts
@@ -165,7 +165,7 @@ function convertPartial(
     }
     if (
       item.type == "database" &&
-      // Tasks like creating database may not have database.
+      // Tasks such as creating database may not have database.
       (task.relationships!.database.data as ResourceIdentifier)?.id == item.id
     ) {
       database = databaseStore.convert(item, includedList);

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -136,7 +136,7 @@ export type Task = {
   type: TaskType;
   instance: Instance;
   earliestAllowedTs: number;
-  // Tasks like creating database may not have database.
+  // Tasks such as creating database may not have database.
   database?: Database;
   payload?: TaskPayload;
 

--- a/plugin/advisor/mysql/advisor_migration_compatibility.go
+++ b/plugin/advisor/mysql/advisor_migration_compatibility.go
@@ -131,7 +131,7 @@ func (v *compatibilityChecker) Enter(in ast.Node) (ast.Node, bool) {
 			// Due to the limitation that we don't know the current data type of the column before the change,
 			// so we treat all as incompatible. This generates false positive when:
 			// 1. Change to a compatible data type such as INT to BIGINT
-			// 2. Change property like comment, change it to NULL
+			// 2. Change properties such as comment, change it to NULL
 			if spec.Tp == ast.AlterTableModifyColumn || spec.Tp == ast.AlterTableChangeColumn {
 				code = advisor.CompatibilityAlterColumn
 				break

--- a/plugin/advisor/sql_review.go
+++ b/plugin/advisor/sql_review.go
@@ -227,7 +227,7 @@ func UnmarshalNamingRulePayloadAsTemplate(ruleType SQLReviewRuleType, payload st
 // For example, if the template is "{{DB_NAME}}_hello_{{LOCATION}}", then the tokens will be ["{{DB_NAME}}", "{{LOCATION}}"],
 // and the delimiters will be ["_hello_"].
 // The caller will usually replace the tokens with a normal string, or a regexp. In the latter case, it will be a problem
-// if there are special regexp characters like "$" in the delimiters. The caller should escape the delimiters in such cases.
+// if there are special regexp characters such as "$" in the delimiters. The caller should escape the delimiters in such cases.
 func parseTemplateTokens(template string) ([]string, []string) {
 	r := regexp.MustCompile(`{{[^{}]+}}`)
 	tokens := r.FindAllString(template, -1)

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -47,7 +47,7 @@ const (
 )
 
 // Claims creates a struct that will be encoded to a JWT.
-// We add jwt.RegisteredClaims as an embedded type, to provide fields like name.
+// We add jwt.RegisteredClaims as an embedded type, to provide fields such as name.
 type Claims struct {
 	Name string `json:"name"`
 	jwt.RegisteredClaims

--- a/server/metric_reporter.go
+++ b/server/metric_reporter.go
@@ -79,7 +79,7 @@ func (m *MetricReporter) Run(ctx context.Context, wg *sync.WaitGroup) {
 				}()
 
 				ctx := context.Background()
-				// identify will be triggered in every schedule loop so that we can update the latest workspace profile like subscription plan.
+				// identify will be triggered in every schedule loop so that we can update the latest workspace profile such as subscription plan.
 				m.identify(ctx)
 				for name, collector := range m.collectors {
 					log.Debug("Run metric collector", zap.String("collector", name))

--- a/store/backup.go
+++ b/store/backup.go
@@ -34,7 +34,7 @@ type backupRaw struct {
 	MigrationHistoryVersion string
 	Path                    string
 	Comment                 string
-	// Payload contains data like PITR info, which will not be created at first.
+	// Payload contains data such as PITR info, which will not be created at first.
 	// When backup runner executes the real backup job, it will fill this field.
 	Payload api.BackupPayload
 }


### PR DESCRIPTION
"such as": formal and inclusion.
"like": less formal and comparison.

https://www.grammarbank.com/such-as-vs-like.html
https://pediaa.com/difference-between-like-and-such-as/