### PR TITLE
fix: indent

### DIFF
--- a/bin/bb/cmd/migrate.go
+++ b/bin/bb/cmd/migrate.go
@@ -40,7 +40,7 @@ func newMigrateCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				// nolint:revive
+				//nolint:revive
 				// f.Close() is intended to be deferred to the end of the function.
 				defer f.Close()
 				sqlReaders = append(sqlReaders, f)

--- a/plugin/advisor/advisor.go
+++ b/plugin/advisor/advisor.go
@@ -39,7 +39,7 @@ func NewStatusBySQLReviewRuleLevel(level SQLReviewRuleLevel) (Status, error) {
 }
 
 // Type is the type of advisor.
-// nolint
+//nolint
 type Type string
 
 const (

--- a/plugin/advisor/db/db.go
+++ b/plugin/advisor/db/db.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Type is the type of a database.
-// nolint
+//nolint
 type Type string
 
 const (

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Type is the type of a database.
-// nolint
+//nolint
 type Type string
 
 const (

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Type is the type of a VCS.
-// nolint
+//nolint
 type Type string
 
 const (


### PR DESCRIPTION
Change `// nolint` to `//nolint`.
`nolint` is a directive, so it should be `//nolint`, like `//go:build`
refer https://go.dev/doc/comment#:~:text=Arabic%2C%0A%20%20%20%20%22Armenian%22%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Armenian%2C%0A%20%20%20%20...%0A%7D-,Syntax,-Go%20doc%20comments