### PR TITLE
feat(PITR): write binlog metadata file on downloading

### DIFF
--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/bytebase/bytebase/common"
@@ -35,7 +34,6 @@ type Driver struct {
 	dbType        db.Type
 	resourceDir   string
 	binlogDir     string
-	binlogMetaDir string
 	db            *sql.DB
 
 	replayBinlogCounter *common.CountingReader
@@ -43,9 +41,8 @@ type Driver struct {
 
 func newDriver(dc db.DriverConfig) db.Driver {
 	return &Driver{
-		resourceDir:   dc.ResourceDir,
-		binlogDir:     dc.BinlogDir,
-		binlogMetaDir: filepath.Join(dc.BinlogDir, "metadata"),
+		resourceDir: dc.ResourceDir,
+		binlogDir:   dc.BinlogDir,
 	}
 }
 

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/bytebase/bytebase/common"
@@ -34,6 +35,7 @@ type Driver struct {
 	dbType        db.Type
 	resourceDir   string
 	binlogDir     string
+	binlogMetaDir string
 	db            *sql.DB
 
 	replayBinlogCounter *common.CountingReader
@@ -41,8 +43,9 @@ type Driver struct {
 
 func newDriver(dc db.DriverConfig) db.Driver {
 	return &Driver{
-		resourceDir: dc.ResourceDir,
-		binlogDir:   dc.BinlogDir,
+		resourceDir:   dc.ResourceDir,
+		binlogDir:     dc.BinlogDir,
+		binlogMetaDir: filepath.Join(dc.BinlogDir, "metadata"),
 	}
 }
 

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -98,7 +98,6 @@ func newBinlogCoordinate(binlogFileName string, pos int64) (binlogCoordinate, er
 }
 
 type binlogFileMeta struct {
-	Size         int64 `json:"size"`
 	FirstEventTs int64 `json:"first_event_ts"`
 }
 
@@ -640,7 +639,6 @@ func (driver *Driver) writeBinlogMetadataFile(ctx context.Context, binlogFileInf
 		return errors.Wrapf(err, "failed to create binlog metadata file %q", metadataFilePath)
 	}
 	metadata := binlogFileMeta{
-		Size:         binlogFileInfo.Size(),
 		FirstEventTs: eventTs,
 	}
 	metadataBytes, err := json.Marshal(metadata)

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -258,7 +258,7 @@ func GetBinlogReplayList(startBinlogInfo api.BinlogInfo, binlogDir string) ([]st
 
 	var binlogFilesToReplay []BinlogFile
 	for _, f := range binlogFiles {
-		if f.IsDir() {
+		if strings.HasSuffix(f.Name(), binlogMetaSuffix) {
 			continue
 		}
 		binlogFile, err := newBinlogFile(f.Name(), f.Size())

--- a/plugin/db/mysql/restore_test.go
+++ b/plugin/db/mysql/restore_test.go
@@ -177,23 +177,13 @@ func TestGetBinlogFileNameSeqNumber(t *testing.T) {
 func TestGetReplayBinlogPathList(t *testing.T) {
 	a := require.New(t)
 	tests := []struct {
-		subDirNames     []string
 		binlogFileNames []string
 		startBinlogInfo api.BinlogInfo
 		expect          []string
 		err             bool
 	}{
 		{
-			// Test skip directory
-			subDirNames:     []string{"subdir_a", "subdir_b"},
-			binlogFileNames: []string{},
-			startBinlogInfo: api.BinlogInfo{},
-			expect:          []string{},
-			err:             false,
-		},
-		{
 			// Test skip stale binlog
-			subDirNames:     []string{},
 			binlogFileNames: []string{"binlog.000001", "binlog.000002", "binlog.000003"},
 			startBinlogInfo: api.BinlogInfo{
 				FileName: "binlog.000002",
@@ -203,8 +193,7 @@ func TestGetReplayBinlogPathList(t *testing.T) {
 			err:    false,
 		},
 		{
-			// Test binlogs no hole
-			subDirNames:     []string{},
+			// Test binlog files no hole
 			binlogFileNames: []string{"binlog.000001", "binlog.000002", "binlog.000004"},
 			startBinlogInfo: api.BinlogInfo{
 				FileName: "binlog.000002",
@@ -215,7 +204,6 @@ func TestGetReplayBinlogPathList(t *testing.T) {
 		},
 		{
 			// Test mysql-bin prefix
-			subDirNames:     []string{},
 			binlogFileNames: []string{"mysql-bin.000001", "mysql-bin.000002", "mysql-bin.000003"},
 			startBinlogInfo: api.BinlogInfo{
 				FileName: "bin.000001",
@@ -226,7 +214,6 @@ func TestGetReplayBinlogPathList(t *testing.T) {
 		},
 		{
 			// Test out of binlog.999999
-			subDirNames:     []string{},
 			binlogFileNames: []string{"binlog.999999", "binlog.1000000", "binlog.1000001"},
 			startBinlogInfo: api.BinlogInfo{
 				FileName: "binlog.999999",
@@ -235,25 +222,10 @@ func TestGetReplayBinlogPathList(t *testing.T) {
 			expect: []string{"binlog.999999", "binlog.1000000", "binlog.1000001"},
 			err:    false,
 		},
-		{
-			subDirNames:     []string{"sub_dir"},
-			binlogFileNames: []string{"binlog.000001", "binlog.000002", "binlog.000003"},
-			startBinlogInfo: api.BinlogInfo{
-				FileName: "binlog.000002",
-				Position: 0xdeadbeaf,
-			},
-			expect: []string{"binlog.000002", "binlog.000003"},
-			err:    false,
-		},
 	}
 
 	for _, test := range tests {
 		tmpDir := t.TempDir()
-
-		for _, subDir := range test.subDirNames {
-			err := os.MkdirAll(filepath.Join(tmpDir, subDir), os.ModePerm)
-			a.NoError(err)
-		}
 
 		for _, binlogFileName := range test.binlogFileNames {
 			f, err := os.Create(filepath.Join(tmpDir, binlogFileName))

--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -156,9 +156,6 @@ func (r *BackupRunner) purgeBinlogFiles(instanceID, retentionPeriodTs int) error
 	}
 	for _, binlogFileInfo := range binlogFileInfoList {
 		if _, err := mysql.GetBinlogNameSeq(binlogFileInfo.Name()); err != nil {
-			if binlogFileInfo.Name() != "metadata" {
-				log.Warn("Found an irregular file in binlog directory.", zap.String("name", binlogFileInfo.Name()))
-			}
 			continue // next binlog file
 		}
 		// We use modification time of local binlog files which is later than the modification time of that on the MySQL server,

--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -147,6 +147,7 @@ func (r *BackupRunner) getMaxRetentionPeriodTsForMySQLInstance(ctx context.Conte
 	return maxRetentionPeriodTs, nil
 }
 
+// TODO(dragonly): Remove metadata as well.
 func (r *BackupRunner) purgeBinlogFiles(instanceID, retentionPeriodTs int) error {
 	binlogDir := getBinlogAbsDir(r.server.profile.DataDir, instanceID)
 	binlogFileInfoList, err := ioutil.ReadDir(binlogDir)
@@ -155,7 +156,9 @@ func (r *BackupRunner) purgeBinlogFiles(instanceID, retentionPeriodTs int) error
 	}
 	for _, binlogFileInfo := range binlogFileInfoList {
 		if _, err := mysql.GetBinlogNameSeq(binlogFileInfo.Name()); err != nil {
-			log.Warn("Found an irregular file in binlog directory.", zap.String("path", binlogFileInfo.Name()))
+			if binlogFileInfo.Name() != "metadata" {
+				log.Warn("Found an irregular file in binlog directory.", zap.String("name", binlogFileInfo.Name()))
+			}
 			continue // next binlog file
 		}
 		// We use modification time of local binlog files which is later than the modification time of that on the MySQL server,


### PR DESCRIPTION
Metadata for binlog files are the source of truth when we deal with binlog files.
Usage of it will be in the following PRs.
We can later add support for GTID Set.

Example metadata file content:

```
$ cat binlog.000108.meta
{"first_event_ts":1660875988}
```

Example tree structure:

```
$ tree backup/instance/6001
backup/instance/6001
├── binlog.000080
├── binlog.000080.meta
...
├── binlog.000108
└── binlog.000108.meta
```