### PR TITLE
fix(webhook): handle edge case for `isSkipGeneratedSchemaFile`

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -624,11 +624,13 @@ func isSkipGeneratedSchemaFile(repository *api.Repository, added string) bool {
 			"ENV_NAME",
 			"DB_NAME",
 		}
-		schemafilePathRegex := repository.SchemaPathTemplate
+
+		// Escape "." characters to match literals instead of using it as a wildcard.
+		schemaFilePathRegex := strings.ReplaceAll(repository.SchemaPathTemplate, ".", `\.`)
 		for _, placeholder := range placeholderList {
-			schemafilePathRegex = strings.ReplaceAll(schemafilePathRegex, fmt.Sprintf("{{%s}}", placeholder), fmt.Sprintf("(?P<%s>[a-zA-Z0-9+-=/_#?!$. ]+)", placeholder))
+			schemaFilePathRegex = strings.ReplaceAll(schemaFilePathRegex, fmt.Sprintf("{{%s}}", placeholder), fmt.Sprintf("(?P<%s>[a-zA-Z0-9+-=/_#?!$. ]+)", placeholder))
 		}
-		myRegex, err := regexp.Compile(schemafilePathRegex)
+		myRegex, err := regexp.Compile(schemaFilePathRegex)
 		if err != nil {
 			log.Warn("Invalid schema path template.", zap.String("schema_path_template",
 				repository.SchemaPathTemplate),

--- a/server/webhook_test.go
+++ b/server/webhook_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/bytebase/bytebase/api"
 	"github.com/bytebase/bytebase/plugin/vcs/gitlab"
 )
 
@@ -355,5 +356,33 @@ func TestParseBranchNameFromGitHubRefs(t *testing.T) {
 		} else {
 			assert.Equal(t, test.expect, branch)
 		}
+	}
+}
+
+func TestIsSkipGeneratedSchemaFile(t *testing.T) {
+	tests := []struct {
+		repository *api.Repository
+		added      string
+		want       bool
+	}{
+		{
+			repository: &api.Repository{
+				SchemaPathTemplate: "{{ENV_NAME}}/.{{DB_NAME}}__LATEST.sql",
+			},
+			added: "Prod/.db__LATEST.sql",
+			want:  true,
+		},
+		{
+			repository: &api.Repository{
+				SchemaPathTemplate: "{{ENV_NAME}}/.{{DB_NAME}}__LATEST.sql",
+			},
+			added: "Prod/Adb__LATEST.sql",
+			want:  false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.added, func(t *testing.T) {
+			assert.Equal(t, test.want, isSkipGeneratedSchemaFile(test.repository, test.added))
+		})
 	}
 }


### PR DESCRIPTION
This PR addresses the edge case by escaping the `.` characters before sending to be compiled as a regex, it would match any single character instead of `.` literals. See added test case for a failure case.

Related PR: https://github.com/bytebase/bytebase/pull/2229