### PR TITLE
feat: grant database owner to datasource role

### DIFF
--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -250,7 +250,7 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 					return err
 				}
 			}
-		} else if strings.HasPrefix(stmt, "ALTER DATABASE") && strings.Contains(stmt, " OWNER TO ") {
+		} else if strings.HasPrefix(stmt, "GRANT") || strings.HasPrefix(stmt, "ALTER DATABASE") && strings.Contains(stmt, " OWNER TO ") {
 			if _, err := driver.db.ExecContext(ctx, stmt); err != nil {
 				return err
 			}

--- a/server/issue.go
+++ b/server/issue.go
@@ -1063,7 +1063,7 @@ func getDatabaseNameAndStatement(dbType db.Type, createDatabaseContext api.Creat
 		}
 	case db.Postgres:
 		// On Cloud RDS, the data source role isn't the actual superuser with sudo privilege.
-		// We need to grant the database owner to the data source admin role so that Bytebase can have permission on the database.
+		// We need to grant the database owner role to the data source admin so that Bytebase can have permission for the database using the data source admin.
 		if adminDatasourceUser != "" && createDatabaseContext.Owner != adminDatasourceUser {
 			stmt = fmt.Sprintf("GRANT \"%s\" TO \"%s\";\n", createDatabaseContext.Owner, adminDatasourceUser)
 		}

--- a/server/issue.go
+++ b/server/issue.go
@@ -1064,7 +1064,7 @@ func getDatabaseNameAndStatement(dbType db.Type, createDatabaseContext api.Creat
 	case db.Postgres:
 		// On Cloud RDS, the data source role isn't the actual superuser with sudo privilege.
 		// We need to grant the database owner to the data source admin role so that Bytebase can have permission on the database.
-		if adminDatasourceUser != "" {
+		if adminDatasourceUser != "" && createDatabaseContext.Owner != adminDatasourceUser {
 			stmt = fmt.Sprintf("GRANT \"%s\" TO \"%s\";\n", createDatabaseContext.Owner, adminDatasourceUser)
 		}
 		if createDatabaseContext.Collation == "" {


### PR DESCRIPTION
On Cloud RDS, the data source role isn't the actual superuser with sudo privilege. We need to grant the database owner to the data source admin role so that Bytebase can have permission on the database.