### PR TITLE
feat(frontend): Allow to mark an environment as protected

### DIFF
--- a/frontend/src/bbkit/BBSelect.vue
+++ b/frontend/src/bbkit/BBSelect.vue
@@ -63,7 +63,7 @@
               v-for="(item, index) in itemList"
               :key="index"
               role="option"
-              class="text-main hover:text-main-text hover:bg-main-hover cursor-default select-none relative py-2 pl-3 pr-9"
+              class="group text-main hover:text-main-text hover:bg-main-hover cursor-default select-none relative py-2 pl-3 pr-9"
               @click="
                 if (item !== state.selectedItem) {
                   $emit('select-item', item, () => {

--- a/frontend/src/bbkit/BBTab.vue
+++ b/frontend/src/bbkit/BBTab.vue
@@ -30,7 +30,9 @@
           <heroicons-solid:arrow-circle-left class="w-6 h-6" />
         </button>
         <div v-else class="pl-6"></div>
-        {{ item.title }}
+        <slot name="item" :item="item" :index="index">
+          {{ item.title }}
+        </slot>
         <button
           v-if="
             index != tabItemList.length - 1 &&

--- a/frontend/src/bbkit/types.ts
+++ b/frontend/src/bbkit/types.ts
@@ -17,10 +17,11 @@ export type BBTableSectionDataSource<T> = {
   list: T[];
 };
 
-export type BBTabItem = {
+export type BBTabItem<T = any> = {
   title: string;
   // Used as the anchor
   id: string;
+  data?: T;
 };
 
 export type BBTabFilterItem = {

--- a/frontend/src/components/AlterSchemaPrepForm/ProjectStandardView.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/ProjectStandardView.vue
@@ -28,6 +28,10 @@
             @input="toggleAllDatabasesSelectionForEnvironment(environment, databaseListInEnvironment, ($event.target as HTMLInputElement).checked)"
           />
           <div>{{ environment.name }}</div>
+          <ProtectedEnvironmentIcon
+            class="w-4 h-4 -ml-1"
+            :environment="environment"
+          />
         </label>
         <div class="relative bg-white rounded-md -space-y-px">
           <template

--- a/frontend/src/components/DatabaseTable.vue
+++ b/frontend/src/components/DatabaseTable.vue
@@ -118,7 +118,13 @@
         </div>
       </BBTableCell>
       <BBTableCell v-if="showEnvironmentColumn" class="w-[10%]">
-        {{ environmentName(database.instance.environment) }}
+        <div class="flex items-center">
+          {{ environmentName(database.instance.environment) }}
+          <ProtectedEnvironmentIcon
+            class="ml-1"
+            :environment="database.instance.environment"
+          />
+        </div>
       </BBTableCell>
       <BBTableCell v-if="showInstanceColumn" class="w-[25%]">
         <div class="flex flex-row items-center space-x-1">

--- a/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
+++ b/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <NTooltip
-    v-if="environment.tier === 'PROTECTED'"
+    v-if="enabled"
     :disabled="!tooltip"
     :delay="0"
     :show-arrow="false"
@@ -19,8 +19,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "vue";
+import { computed, defineComponent, PropType } from "vue";
 import { Environment } from "@/types";
+import { featureToRef } from "@/store";
 
 export default defineComponent({
   name: "ProtectedEnvironmentIcon",
@@ -34,6 +35,20 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+  },
+  setup(props) {
+    const hasEnvironmentTierPolicyFeature = featureToRef(
+      "bb.feature.environment-tier-policy"
+    );
+
+    const enabled = computed((): boolean => {
+      if (!hasEnvironmentTierPolicyFeature.value) {
+        return false;
+      }
+      return props.environment.tier === "PROTECTED";
+    });
+
+    return { enabled };
   },
 });
 </script>

--- a/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
+++ b/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
@@ -1,0 +1,3 @@
+<template>
+  <heroicons-solid:shield-exclamation />
+</template>

--- a/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
+++ b/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
@@ -1,3 +1,29 @@
 <template>
-  <heroicons-solid:shield-exclamation />
+  <NTooltip v-if="environment.tier === 'PROTECTED'" :disabled="!tooltip">
+    <template #trigger>
+      <heroicons-solid:shield-exclamation v-bind="$attrs" />
+    </template>
+
+    <span>{{ $t("environment.protected") }}</span>
+  </NTooltip>
 </template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import { Environment } from "@/types";
+
+export default defineComponent({
+  name: "ProtectedEnvironmentIcon",
+  inheritAttrs: false,
+  props: {
+    environment: {
+      type: Object as PropType<Environment>,
+      required: true,
+    },
+    tooltip: {
+      type: Boolean,
+      default: false,
+    },
+  },
+});
+</script>

--- a/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
+++ b/frontend/src/components/Environment/ProtectedEnvironmentIcon.vue
@@ -1,7 +1,17 @@
 <template>
-  <NTooltip v-if="environment.tier === 'PROTECTED'" :disabled="!tooltip">
+  <NTooltip
+    v-if="environment.tier === 'PROTECTED'"
+    :disabled="!tooltip"
+    :delay="0"
+    :show-arrow="false"
+    :animated="false"
+    placement="top-start"
+  >
     <template #trigger>
-      <heroicons-solid:shield-exclamation v-bind="$attrs" />
+      <heroicons-solid:shield-exclamation
+        class="text-control inline-block"
+        v-bind="$attrs"
+      />
     </template>
 
     <span>{{ $t("environment.protected") }}</span>

--- a/frontend/src/components/EnvironmentSelect.vue
+++ b/frontend/src/components/EnvironmentSelect.vue
@@ -8,7 +8,13 @@
     @select-item="(env) => $emit('select-environment-id', env.id)"
   >
     <template #menuItem="{ item: environment }">
-      {{ environmentName(environment) }}
+      <div class="flex items-center">
+        {{ environmentName(environment) }}
+        <ProtectedEnvironmentIcon
+          class="ml-1 group-hover:text-main-text"
+          :environment="environment"
+        />
+      </div>
     </template>
   </BBSelect>
 </template>

--- a/frontend/src/components/Issue/IssueSidebar.vue
+++ b/frontend/src/components/Issue/IssueSidebar.vue
@@ -190,9 +190,10 @@
       </h2>
       <router-link
         :to="`/environment/${environmentSlug(environment)}`"
-        class="col-span-2 text-sm font-medium text-main hover:underline"
+        class="col-span-2 text-sm font-medium text-main hover:underline flex items-center"
       >
         {{ environmentName(environment) }}
+        <ProtectedEnvironmentIcon class="ml-1" :environment="environment" />
       </router-link>
 
       <template v-for="label in visibleLabelList" :key="label.key">
@@ -323,6 +324,7 @@ import {
   useIssueLogic,
   useAllowProjectOwnerToApprove,
 } from "./logic";
+import ProtectedEnvironmentIcon from "@/components/Environment/ProtectedEnvironmentIcon.vue";
 
 dayjs.extend(isSameOrAfter);
 

--- a/frontend/src/components/Issue/IssueTable.vue
+++ b/frontend/src/components/Issue/IssueTable.vue
@@ -87,7 +87,13 @@
         <span>{{ issue.name }}</span>
       </BBTableCell>
       <BBTableCell class="table-cell">
-        {{ activeEnvironmentName(issue) }}
+        <div class="flex items-center">
+          {{ activeEnvironmentName(issue) }}
+          <ProtectedEnvironmentIcon
+            class="ml-1"
+            :environment="activeEnvironment(issue.pipeline)"
+          />
+        </div>
       </BBTableCell>
       <BBTableCell class="table-cell">
         {{ activeDatabaseName(issue) }}
@@ -141,6 +147,7 @@ import {
   activeTaskInStage,
 } from "../../utils";
 import { Issue, Task } from "../../types";
+import ProtectedEnvironmentIcon from "../Environment/ProtectedEnvironmentIcon.vue";
 
 type Mode = "ALL" | "PROJECT";
 
@@ -208,7 +215,7 @@ interface LocalState {
 
 export default defineComponent({
   name: "IssueTable",
-  components: { IssueStatusIcon },
+  components: { IssueStatusIcon, ProtectedEnvironmentIcon },
   props: {
     issueSectionList: {
       required: true,
@@ -297,6 +304,7 @@ export default defineComponent({
     return {
       state,
       columnList: columnListMap.get(props.mode)!,
+      activeEnvironment,
       activeEnvironmentName,
       activeDatabaseName,
       taskStepList,

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -658,7 +658,8 @@
     "archive-info": "Archived environment will not be shown on the normal interface. You can still restore later from the Archive page.",
     "create": "Create Environment",
     "restore": "Restore this environment",
-    "successfully-updated-environment": "Successfully updated environment '{name}'."
+    "successfully-updated-environment": "Successfully updated environment '{name}'.",
+    "protected": "Protected"
   },
   "quick-start": {
     "bookmark-an-issue": "Bookmark an issue",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -736,6 +736,10 @@
       "daily-info": "Enforce every database to backup daily.",
       "weekly": "Weekly backup",
       "weekly-info": "Enforce every database to backup weekly."
+    },
+    "environment-tier": {
+      "name": "Environment tier",
+      "mark-env-as-protected": "Mark as protected environment"
     }
   },
   "migration-history": {
@@ -1347,6 +1351,10 @@
       "bb-feature-backup-policy": {
         "title": "Backup policy",
         "desc": "Backup policy will auto-backup your database based on the schedule."
+      },
+      "bb-feature-environment-tier-policy": {
+        "title": "Environment tier",
+        "desc": "Mark environment as protected."
       },
       "bb-feature-sql-review": {
         "title": "SQL review policy",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -737,6 +737,10 @@
       "daily-info": "每日备份数据库。",
       "weekly": "每周",
       "weekly-info": "每周备份数据库。"
+    },
+    "environment-tier": {
+      "name": "环境级别",
+      "mark-env-as-protected": "标记为受保护的环境"
     }
   },
   "migration-history": {
@@ -1348,6 +1352,10 @@
       "bb-feature-backup-policy": {
         "title": "备份策略",
         "desc": "「备份策略」可以根据指定的周期自动备份数据库"
+      },
+      "bb-feature-environment-tier-policy": {
+        "title": "环境级别",
+        "desc": "「环境级别」可以将环境标记为受保护的"
       },
       "bb-feature-sql-review": {
         "title": "Schema 审核策略",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -659,7 +659,8 @@
     "archive-info": "已归档环境不会显示。您可以从归档界面恢复。",
     "create": "创建环境",
     "restore": "恢复此环境",
-    "successfully-updated-environment": "环境'{0}'更新成功"
+    "successfully-updated-environment": "环境'{0}'更新成功",
+    "protected": "受保护的"
   },
   "quick-start": {
     "bookmark-an-issue": "收藏工单",

--- a/frontend/src/types/environment.ts
+++ b/frontend/src/types/environment.ts
@@ -1,5 +1,6 @@
 import { RowStatus } from "./common";
 import { EnvironmentId } from "./id";
+import { EnvironmentTier } from "./policy";
 import { Principal } from "./principal";
 
 export type Environment = {
@@ -15,6 +16,7 @@ export type Environment = {
   // Domain specific fields
   name: string;
   order: number;
+  tier: EnvironmentTier;
 };
 
 export type EnvironmentCreate = {

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -13,6 +13,7 @@ export type FeatureType =
   // Policy Control
   | "bb.feature.approval-policy"
   | "bb.feature.backup-policy"
+  | "bb.feature.environment-tier-policy"
   // Admin & Security
   | "bb.feature.rbac"
   | "bb.feature.3rd-party-auth"
@@ -61,6 +62,7 @@ export const FEATURE_MATRIX: Map<FeatureType, boolean[]> = new Map([
   // Policy Control
   ["bb.feature.approval-policy", [false, true, true]],
   ["bb.feature.backup-policy", [false, true, true]],
+  ["bb.feature.environment-tier-policy", [false, true, true]],
   // Admin & Security
   ["bb.feature.rbac", [false, true, true]],
   ["bb.feature.3rd-party-auth", [false, true, true]],

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -62,7 +62,7 @@ export const FEATURE_MATRIX: Map<FeatureType, boolean[]> = new Map([
   // Policy Control
   ["bb.feature.approval-policy", [false, true, true]],
   ["bb.feature.backup-policy", [false, true, true]],
-  ["bb.feature.environment-tier-policy", [false, true, true]],
+  ["bb.feature.environment-tier-policy", [false, false, true]],
   // Admin & Security
   ["bb.feature.rbac", [false, true, true]],
   ["bb.feature.3rd-party-auth", [false, true, true]],

--- a/frontend/src/types/policy.ts
+++ b/frontend/src/types/policy.ts
@@ -12,7 +12,8 @@ import {
 export type PolicyType =
   | "bb.policy.pipeline-approval"
   | "bb.policy.backup-plan"
-  | "bb.policy.sql-review";
+  | "bb.policy.sql-review"
+  | "bb.policy.environment-tier";
 
 export type PipelineApprovalPolicyValue =
   | "MANUAL_APPROVAL_NEVER"
@@ -25,6 +26,14 @@ export type PipelineApprovalPolicyPayload = {
 
 export const DefaultApprovalPolicy: PipelineApprovalPolicyValue =
   "MANUAL_APPROVAL_ALWAYS";
+
+export type EnvironmentTier = "PROTECTED" | "UNPROTECTED";
+
+export type EnvironmentTierPolicyPayload = {
+  environmentTier: EnvironmentTier;
+};
+
+export const DefaultEnvironmentTier: EnvironmentTier = "UNPROTECTED";
 
 export type BackupPlanPolicySchedule = "UNSET" | "DAILY" | "WEEKLY";
 
@@ -62,7 +71,8 @@ export type AssigneeGroup = {
 export type PolicyPayload =
   | PipelineApprovalPolicyPayload
   | BackupPlanPolicyPayload
-  | SQLReviewPolicyPayload;
+  | SQLReviewPolicyPayload
+  | EnvironmentTierPolicyPayload;
 
 export type Policy = {
   id: PolicyId;

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -15,6 +15,12 @@
                 >
                   {{ database.name }}
 
+                  <ProtectedEnvironmentIcon
+                    :environment="database.instance.environment"
+                    tooltip
+                    class="w-5 h-5"
+                  />
+
                   <BBBadge
                     v-if="isPITRDatabase(database)"
                     text="PITR"

--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -12,10 +12,7 @@
       >
         <div class="flex items-center">
           {{ item.title }}
-          <ProtectedEnvironmentIcon
-            v-if="isProtectedEnvironment(item.data!)"
-            class="ml-1"
-          />
+          <ProtectedEnvironmentIcon :environment="item.data!" class="ml-1" />
         </div>
       </template>
 
@@ -319,11 +316,5 @@ const selectEnvironment = (index: number) => {
     name: "workspace.environment",
     hash: "#" + environmentList.value[index].id,
   });
-};
-
-const isProtectedEnvironment = (environment: Environment) => {
-  // TODO: need the backend to compose the environment-tier policy as an env's
-  // attribute
-  return false;
 };
 </script>

--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -7,6 +7,15 @@
       @reorder-index="reorderEnvironment"
       @select-index="selectEnvironment"
     >
+      <template
+        #item="{ item }: { item: BBTabItem<Environment>, index: number }"
+      >
+        <div class="flex items-center">
+          {{ item.title }}
+          <ProtectedEnvironmentIcon v-if="isProtectedEnvironment(item.data!)" />
+        </div>
+      </template>
+
       <BBTabPanel
         v-for="(item, index) in environmentList"
         :key="item.id"
@@ -45,8 +54,9 @@
     <EnvironmentForm
       :create="true"
       :environment="DEFAULT_NEW_ENVIRONMENT"
-      :approval-policy="DEFAULT_NEW_APPROVAL_POLICY"
-      :backup-policy="DEFAULT_NEW_BACKUP_PLAN_POLICY"
+      :approval-policy="(DEFAULT_NEW_APPROVAL_POLICY as any)"
+      :backup-policy="(DEFAULT_NEW_BACKUP_PLAN_POLICY as any)"
+      :environment-tier-policy="(DEFAULT_NEW_ENVIRONMENT_TIER_POLICY as any)"
       @create="doCreate"
       @cancel="state.showCreateModal = false"
     />
@@ -59,23 +69,25 @@
   />
 </template>
 
-<script lang="ts">
-import { onMounted, computed, reactive, watch, defineComponent } from "vue";
+<script lang="ts" setup>
+import { onMounted, computed, reactive, watch } from "vue";
 import { useRouter } from "vue-router";
 import { array_swap } from "../utils";
 import EnvironmentDetail from "../views/EnvironmentDetail.vue";
 import EnvironmentForm from "../components/EnvironmentForm.vue";
-import {
+import type {
   Environment,
   EnvironmentCreate,
   Policy,
   PolicyUpsert,
-  DefaultApprovalPolicy,
-  DefaultSchedulePolicy,
-  PipelineApprovalPolicyPayload,
   BackupPlanPolicyPayload,
 } from "../types";
-import { BBTabItem } from "../bbkit/types";
+import {
+  DefaultApprovalPolicy,
+  DefaultSchedulePolicy,
+  DefaultEnvironmentTier,
+} from "../types";
+import type { BBTabItem } from "../bbkit/types";
 import {
   useRegisterCommand,
   useUIStateStore,
@@ -84,6 +96,7 @@ import {
   useEnvironmentStore,
   useEnvironmentList,
 } from "@/store";
+import { isEqual } from "lodash-es";
 
 const DEFAULT_NEW_ENVIRONMENT: EnvironmentCreate = {
   name: "New Env",
@@ -104,6 +117,12 @@ const DEFAULT_NEW_BACKUP_PLAN_POLICY: PolicyUpsert = {
   },
 };
 
+const DEFAULT_NEW_ENVIRONMENT_TIER_POLICY: PolicyUpsert = {
+  payload: {
+    environmentTier: DefaultEnvironmentTier,
+  },
+};
+
 interface LocalState {
   reorderedEnvironmentList: Environment[];
   selectedIndex: number;
@@ -114,214 +133,193 @@ interface LocalState {
     | "bb.feature.backup-policy";
 }
 
-export default defineComponent({
-  name: "EnvironmentDashboard",
-  components: {
-    EnvironmentDetail,
-    EnvironmentForm,
-  },
-  props: {},
-  setup() {
-    const environmentStore = useEnvironmentStore();
-    const uiStateStore = useUIStateStore();
-    const policyStore = usePolicyStore();
-    const router = useRouter();
+const environmentStore = useEnvironmentStore();
+const uiStateStore = useUIStateStore();
+const policyStore = usePolicyStore();
+const router = useRouter();
 
-    const state = reactive<LocalState>({
-      reorderedEnvironmentList: [],
-      selectedIndex: -1,
-      showCreateModal: false,
-      reorder: false,
-    });
+const state = reactive<LocalState>({
+  reorderedEnvironmentList: [],
+  selectedIndex: -1,
+  showCreateModal: false,
+  reorder: false,
+});
 
-    const selectEnvironmentOnHash = () => {
-      if (environmentList.value.length > 0) {
-        if (router.currentRoute.value.hash) {
-          for (let i = 0; i < environmentList.value.length; i++) {
-            if (
-              environmentList.value[i].id ===
-              parseInt(router.currentRoute.value.hash.slice(1), 10)
-            ) {
-              selectEnvironment(i);
-              break;
-            }
-          }
-        } else {
-          selectEnvironment(0);
-        }
-      }
-    };
-
-    onMounted(() => {
-      selectEnvironmentOnHash();
-
-      if (!uiStateStore.getIntroStateByKey("environment.visit")) {
-        uiStateStore.saveIntroStateByKey({
-          key: "environment.visit",
-          newState: true,
-        });
-      }
-    });
-
-    useRegisterCommand({
-      id: "bb.environment.create",
-      registerId: "environment.dashboard",
-      run: () => {
-        createEnvironment();
-      },
-    });
-    useRegisterCommand({
-      id: "bb.environment.reorder",
-      registerId: "environment.dashboard",
-      run: () => {
-        startReorder();
-      },
-    });
-
-    watch(
-      () => router.currentRoute.value.hash,
-      () => {
-        if (router.currentRoute.value.name == "workspace.environment") {
-          selectEnvironmentOnHash();
-        }
-      }
-    );
-
-    const environmentList = useEnvironmentList();
-
-    const tabItemList = computed((): BBTabItem[] => {
-      if (environmentList.value) {
-        const list = state.reorder
-          ? state.reorderedEnvironmentList
-          : environmentList.value;
-        return list.map((item: Environment, index: number): BBTabItem => {
-          const title = `${index + 1}. ${item.name}`;
-          const id = item.id.toString();
-          return { title, id };
-        });
-      }
-      return [];
-    });
-
-    const createEnvironment = () => {
-      stopReorder();
-      state.showCreateModal = true;
-    };
-
-    const doCreate = (
-      newEnvironment: EnvironmentCreate,
-      approvalPolicy: Policy,
-      backupPolicy: Policy
-    ) => {
-      if (
-        (approvalPolicy.payload as PipelineApprovalPolicyPayload).value !==
-          DefaultApprovalPolicy &&
-        !hasFeature("bb.feature.approval-policy")
-      ) {
-        state.missingRequiredFeature = "bb.feature.approval-policy";
-        return;
-      }
-      if (
-        (backupPolicy.payload as BackupPlanPolicyPayload).schedule !==
-          DefaultSchedulePolicy &&
-        !hasFeature("bb.feature.backup-policy")
-      ) {
-        state.missingRequiredFeature = "bb.feature.backup-policy";
-        return;
-      }
-
-      environmentStore
-        .createEnvironment(newEnvironment)
-        .then((environment: Environment) => {
-          Promise.all([
-            policyStore.upsertPolicyByEnvironmentAndType({
-              environmentId: environment.id,
-              type: "bb.policy.pipeline-approval",
-              policyUpsert: { payload: approvalPolicy.payload },
-            }),
-            policyStore.upsertPolicyByEnvironmentAndType({
-              environmentId: environment.id,
-              type: "bb.policy.backup-plan",
-              policyUpsert: { payload: backupPolicy.payload },
-            }),
-          ]).then(() => {
-            state.showCreateModal = false;
-            selectEnvironment(environmentList.value.length - 1);
-          });
-        });
-    };
-
-    const startReorder = () => {
-      state.reorderedEnvironmentList = [...environmentList.value];
-      state.reorder = true;
-    };
-
-    const stopReorder = () => {
-      state.reorder = false;
-      state.reorderedEnvironmentList = [];
-    };
-
-    const reorderEnvironment = (sourceIndex: number, targetIndex: number) => {
-      array_swap(state.reorderedEnvironmentList, sourceIndex, targetIndex);
-      selectEnvironment(targetIndex);
-    };
-
-    const orderChanged = computed(() => {
-      for (let i = 0; i < state.reorderedEnvironmentList.length; i++) {
+const selectEnvironmentOnHash = () => {
+  if (environmentList.value.length > 0) {
+    if (router.currentRoute.value.hash) {
+      for (let i = 0; i < environmentList.value.length; i++) {
         if (
-          state.reorderedEnvironmentList[i].id != environmentList.value[i].id
+          environmentList.value[i].id ===
+          parseInt(router.currentRoute.value.hash.slice(1), 10)
         ) {
-          return true;
+          selectEnvironment(i);
+          break;
         }
       }
-      return false;
+    } else {
+      selectEnvironment(0);
+    }
+  }
+};
+
+onMounted(() => {
+  selectEnvironmentOnHash();
+
+  if (!uiStateStore.getIntroStateByKey("environment.visit")) {
+    uiStateStore.saveIntroStateByKey({
+      key: "environment.visit",
+      newState: true,
     });
+  }
+});
 
-    const discardReorder = () => {
-      stopReorder();
-    };
-
-    const doReorder = () => {
-      environmentStore
-        .reorderEnvironmentList(state.reorderedEnvironmentList)
-        .then(() => {
-          stopReorder();
-        });
-    };
-
-    const doArchive = (/* environment: Environment */) => {
-      if (environmentList.value.length > 0) {
-        selectEnvironment(0);
-      }
-    };
-
-    const selectEnvironment = (index: number) => {
-      state.selectedIndex = index;
-      router.replace({
-        name: "workspace.environment",
-        hash: "#" + environmentList.value[index].id,
-      });
-    };
-
-    const tabClass = computed(() => "w-1/" + environmentList.value.length);
-
-    return {
-      DEFAULT_NEW_ENVIRONMENT,
-      DEFAULT_NEW_APPROVAL_POLICY,
-      DEFAULT_NEW_BACKUP_PLAN_POLICY,
-      state,
-      environmentList,
-      tabItemList,
-      createEnvironment,
-      doCreate,
-      doArchive,
-      reorderEnvironment,
-      orderChanged,
-      discardReorder,
-      doReorder,
-      selectEnvironment,
-      tabClass,
-    };
+useRegisterCommand({
+  id: "bb.environment.create",
+  registerId: "environment.dashboard",
+  run: () => {
+    createEnvironment();
   },
 });
+useRegisterCommand({
+  id: "bb.environment.reorder",
+  registerId: "environment.dashboard",
+  run: () => {
+    startReorder();
+  },
+});
+
+watch(
+  () => router.currentRoute.value.hash,
+  () => {
+    if (router.currentRoute.value.name == "workspace.environment") {
+      selectEnvironmentOnHash();
+    }
+  }
+);
+
+const environmentList = useEnvironmentList();
+
+const tabItemList = computed((): BBTabItem[] => {
+  if (environmentList.value) {
+    const list = state.reorder
+      ? state.reorderedEnvironmentList
+      : environmentList.value;
+    return list.map((item: Environment, index: number): BBTabItem => {
+      const title = `${index + 1}. ${item.name}`;
+      const id = item.id.toString();
+      return { title, id, data: item };
+    });
+  }
+  return [];
+});
+
+const createEnvironment = () => {
+  stopReorder();
+  state.showCreateModal = true;
+};
+
+const doCreate = (
+  newEnvironment: EnvironmentCreate,
+  approvalPolicy: Policy,
+  backupPolicy: Policy,
+  environmentTierPolicy: Policy
+) => {
+  if (
+    !isEqual(approvalPolicy, DEFAULT_NEW_APPROVAL_POLICY) &&
+    !hasFeature("bb.feature.approval-policy")
+  ) {
+    state.missingRequiredFeature = "bb.feature.approval-policy";
+    return;
+  }
+  if (
+    (backupPolicy.payload as BackupPlanPolicyPayload).schedule !==
+      DefaultSchedulePolicy &&
+    !hasFeature("bb.feature.backup-policy")
+  ) {
+    state.missingRequiredFeature = "bb.feature.backup-policy";
+    return;
+  }
+
+  environmentStore
+    .createEnvironment(newEnvironment)
+    .then((environment: Environment) => {
+      Promise.all([
+        policyStore.upsertPolicyByEnvironmentAndType({
+          environmentId: environment.id,
+          type: "bb.policy.pipeline-approval",
+          policyUpsert: { payload: approvalPolicy.payload },
+        }),
+        policyStore.upsertPolicyByEnvironmentAndType({
+          environmentId: environment.id,
+          type: "bb.policy.backup-plan",
+          policyUpsert: { payload: backupPolicy.payload },
+        }),
+        policyStore.upsertPolicyByEnvironmentAndType({
+          environmentId: environment.id,
+          type: "bb.policy.environment-tier",
+          policyUpsert: { payload: environmentTierPolicy.payload },
+        }),
+      ]).then(() => {
+        state.showCreateModal = false;
+        selectEnvironment(environmentList.value.length - 1);
+      });
+    });
+};
+
+const startReorder = () => {
+  state.reorderedEnvironmentList = [...environmentList.value];
+  state.reorder = true;
+};
+
+const stopReorder = () => {
+  state.reorder = false;
+  state.reorderedEnvironmentList = [];
+};
+
+const reorderEnvironment = (sourceIndex: number, targetIndex: number) => {
+  array_swap(state.reorderedEnvironmentList, sourceIndex, targetIndex);
+  selectEnvironment(targetIndex);
+};
+
+const orderChanged = computed(() => {
+  for (let i = 0; i < state.reorderedEnvironmentList.length; i++) {
+    if (state.reorderedEnvironmentList[i].id != environmentList.value[i].id) {
+      return true;
+    }
+  }
+  return false;
+});
+
+const discardReorder = () => {
+  stopReorder();
+};
+
+const doReorder = () => {
+  environmentStore
+    .reorderEnvironmentList(state.reorderedEnvironmentList)
+    .then(() => {
+      stopReorder();
+    });
+};
+
+const doArchive = (/* environment: Environment */) => {
+  if (environmentList.value.length > 0) {
+    selectEnvironment(0);
+  }
+};
+
+const selectEnvironment = (index: number) => {
+  state.selectedIndex = index;
+  router.replace({
+    name: "workspace.environment",
+    hash: "#" + environmentList.value[index].id,
+  });
+};
+
+const isProtectedEnvironment = (environment: Environment) => {
+  // TODO: need the backend to compose the environment-tier policy as an env's
+  // attribute
+  return false;
+};
 </script>

--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -12,7 +12,10 @@
       >
         <div class="flex items-center">
           {{ item.title }}
-          <ProtectedEnvironmentIcon v-if="isProtectedEnvironment(item.data!)" />
+          <ProtectedEnvironmentIcon
+            v-if="isProtectedEnvironment(item.data!)"
+            class="ml-1"
+          />
         </div>
       </template>
 
@@ -72,6 +75,7 @@
 <script lang="ts" setup>
 import { onMounted, computed, reactive, watch } from "vue";
 import { useRouter } from "vue-router";
+import { isEqual } from "lodash-es";
 import { array_swap } from "../utils";
 import EnvironmentDetail from "../views/EnvironmentDetail.vue";
 import EnvironmentForm from "../components/EnvironmentForm.vue";
@@ -96,7 +100,7 @@ import {
   useEnvironmentStore,
   useEnvironmentList,
 } from "@/store";
-import { isEqual } from "lodash-es";
+import ProtectedEnvironmentIcon from "../components/Environment/ProtectedEnvironmentIcon.vue";
 
 const DEFAULT_NEW_ENVIRONMENT: EnvironmentCreate = {
   name: "New Env",

--- a/frontend/src/views/EnvironmentDetail.vue
+++ b/frontend/src/views/EnvironmentDetail.vue
@@ -215,6 +215,11 @@ export default defineComponent({
             state.backupPolicy = policy;
           } else if (type === "bb.policy.environment-tier") {
             state.environmentTierPolicy = policy;
+            // Write the value to state.environment entity. So that we don't
+            // need to re-fetch it front the server.
+            state.environment.tier = (
+              policy.payload as EnvironmentTierPolicyPayload
+            ).environmentTier;
           }
 
           pushNotification({

--- a/frontend/src/views/EnvironmentDetail.vue
+++ b/frontend/src/views/EnvironmentDetail.vue
@@ -3,10 +3,13 @@
     <ArchiveBanner v-if="state.environment.rowStatus == 'ARCHIVED'" />
   </div>
   <EnvironmentForm
-    v-if="state.approvalPolicy && state.backupPolicy"
+    v-if="
+      state.approvalPolicy && state.backupPolicy && state.environmentTierPolicy
+    "
     :environment="state.environment"
     :approval-policy="state.approvalPolicy"
     :backup-policy="state.backupPolicy"
+    :environment-tier-policy="state.environmentTierPolicy"
     @update="doUpdate"
     @archive="doArchive"
     @restore="doRestore"
@@ -33,6 +36,8 @@ import {
   DefaultSchedulePolicy,
   PipelineApprovalPolicyPayload,
   BackupPlanPolicyPayload,
+  EnvironmentTierPolicyPayload,
+  DefaultEnvironmentTier,
 } from "../types";
 import { idFromSlug } from "../utils";
 import {
@@ -48,9 +53,11 @@ interface LocalState {
   showArchiveModal: boolean;
   approvalPolicy?: Policy;
   backupPolicy?: Policy;
+  environmentTierPolicy?: Policy;
   missingRequiredFeature?:
     | "bb.feature.approval-policy"
-    | "bb.feature.backup-policy";
+    | "bb.feature.backup-policy"
+    | "bb.feature.environment-tier-policy";
 }
 
 export default defineComponent({
@@ -79,22 +86,33 @@ export default defineComponent({
     });
 
     const preparePolicy = () => {
+      const environmentId = (state.environment as Environment).id;
+
       policyStore
         .fetchPolicyByEnvironmentAndType({
-          environmentId: (state.environment as Environment).id,
+          environmentId,
           type: "bb.policy.pipeline-approval",
         })
-        .then((policy: Policy) => {
+        .then((policy) => {
           state.approvalPolicy = policy;
         });
 
       policyStore
         .fetchPolicyByEnvironmentAndType({
-          environmentId: (state.environment as Environment).id,
+          environmentId,
           type: "bb.policy.backup-plan",
         })
-        .then((policy: Policy) => {
+        .then((policy) => {
           state.backupPolicy = policy;
+        });
+
+      policyStore
+        .fetchPolicyByEnvironmentAndType({
+          environmentId,
+          type: "bb.policy.environment-tier",
+        })
+        .then((policy) => {
+          state.environmentTierPolicy = policy;
         });
     };
 
@@ -173,6 +191,15 @@ export default defineComponent({
         state.missingRequiredFeature = "bb.feature.backup-policy";
         return;
       }
+      if (
+        type === "bb.policy.environment-tier" &&
+        (policy.payload as EnvironmentTierPolicyPayload).environmentTier !==
+          DefaultEnvironmentTier &&
+        !hasFeature("bb.feature.environment-tier-policy")
+      ) {
+        state.missingRequiredFeature = "bb.feature.environment-tier-policy";
+        return;
+      }
       policyStore
         .upsertPolicyByEnvironmentAndType({
           environmentId,
@@ -186,6 +213,8 @@ export default defineComponent({
             state.approvalPolicy = policy;
           } else if (type === "bb.policy.backup-plan") {
             state.backupPolicy = policy;
+          } else if (type === "bb.policy.environment-tier") {
+            state.environmentTierPolicy = policy;
           }
 
           pushNotification({


### PR DESCRIPTION
BYT-386

### Screenshot
Configuration
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/2749742/186090370-be50b656-69f8-4dbb-9035-dc343a33330a.png">

Database list and issue list
![image](https://user-images.githubusercontent.com/2749742/186141636-8e63dbae-f8e9-42bd-ac2c-b04d10e37ebc.png)

Database detail
![image](https://user-images.githubusercontent.com/2749742/186141727-ff28ea7f-b394-4607-bd5b-ebd7cbbe3f72.png)

Environment selector dropdown
![image](https://user-images.githubusercontent.com/2749742/186141801-8a82c777-45a3-425a-b28c-77ad2e469666.png)

Issue sidebar
![image](https://user-images.githubusercontent.com/2749742/186141864-489e97ff-0d9a-42ae-bece-c8bd51931679.png)

I consider we need to compose the environment-tier policy value as an environment's attribute to make the shield icon's display logic much more simple. wdyt @RainbowDashy 