### PR TITLE
feat: compose environmentTier into environment

### DIFF
--- a/api/environment.go
+++ b/api/environment.go
@@ -18,8 +18,9 @@ type Environment struct {
 	UpdatedTs int64      `jsonapi:"attr,updatedTs"`
 
 	// Domain specific fields
-	Name  string `jsonapi:"attr,name"`
-	Order int    `jsonapi:"attr,order"`
+	Name  string               `jsonapi:"attr,name"`
+	Order int                  `jsonapi:"attr,order"`
+	Tier  EnvironmentTierValue `jsonapi:"attr,tier"`
 }
 
 // EnvironmentCreate is the API message for creating an environment.

--- a/store/environment.go
+++ b/store/environment.go
@@ -125,6 +125,12 @@ func (s *Store) composeEnvironment(ctx context.Context, raw *environmentRaw) (*a
 	}
 	env.Updater = updater
 
+	tier, err := s.GetEnvironmentTierPolicyByEnvID(ctx, env.ID)
+	if err != nil {
+		return nil, err
+	}
+	env.Tier = tier.EnvironmentTier
+
 	return env, nil
 }
 

--- a/store/policy.go
+++ b/store/policy.go
@@ -212,6 +212,19 @@ func (s *Store) GetSQLReviewPolicyIDByEnvID(ctx context.Context, environmentID i
 	return policy.ID, nil
 }
 
+// GetEnvironmentTierPolicyByEnvID will get the environment tier policy for an environment.
+func (s *Store) GetEnvironmentTierPolicyByEnvID(ctx context.Context, environmentID int) (*api.EnvironmentTierPolicy, error) {
+	pType := api.PolicyTypeEnvironmentTier
+	policy, err := s.getPolicyRaw(ctx, &api.PolicyFind{
+		EnvironmentID: &environmentID,
+		Type:          &pType,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return api.UnmarshalEnvironmentTierPolicy(policy.Payload)
+}
+
 //
 // private functions
 //


### PR DESCRIPTION
Compose `environmentTier` into `environment` so that the frontend doesn’t have to fetch the policy for every environment, which is a hassle.