### PR TITLE
fix: handle PostgreSQL double quotes properly when getting tables information

### DIFF
--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -307,9 +307,10 @@ func getPgTables(txn *sql.Tx) ([]*tableSchema, error) {
 	var tables []*tableSchema
 	query := "" +
 		"SELECT tbl.schemaname, tbl.tablename, tbl.tableowner, " +
-		"pg_table_size((quote_ident(tbl.schemaname) || '.' || quote_ident(tbl.tablename))::regclass)" +
-		"pg_indexes_size((quote_ident(tbl.schemaname) || '.' || quote_ident(tbl.tablename))::regclass)" +
-		"FROM pg_catalog.pg_tables;"
+		"pg_table_size((quote_ident(tbl.schemaname) || '.' || quote_ident(tbl.tablename))::regclass), " +
+		"pg_indexes_size((quote_ident(tbl.schemaname) || '.' || quote_ident(tbl.tablename))::regclass) " +
+		"FROM pg_catalog.pg_tables tbl " +
+		"WHERE tbl.schemaname NOT IN ('pg_catalog', 'information_schema');"
 	rows, err := txn.Query(query)
 	if err != nil {
 		return nil, err

--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -399,9 +399,9 @@ func getTableColumns(txn *sql.Tx, schemaName, tableName string) ([]*columnSchema
 		cols.collation_name,
 		cols.udt_schema,
 		cols.udt_name,
-		pg_catalog.col_description(c.oid, cols.ordinal_position::int) as column_comment
-	FROM INFORMATION_SCHEMA.COLUMNS AS cols, pg_catalog.pg_class c
-	WHERE table_schema=$1 AND table_name=$2 AND cols.table_schema=c.relnamespace::regnamespace::text AND cols.table_name=c.relname;`
+		pg_catalog.col_description((quote_ident(table_schema) || '.' || quote_ident(table_name))::regclass, cols.ordinal_position::int) as column_comment
+	FROM INFORMATION_SCHEMA.COLUMNS AS cols
+	WHERE table_schema=$1 AND table_name=$2;`
 	rows, err := txn.Query(query, schemaName, tableName)
 	if err != nil {
 		return nil, err

--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -306,9 +306,10 @@ func getPgTables(txn *sql.Tx) ([]*tableSchema, error) {
 
 	var tables []*tableSchema
 	query := "" +
-		"SELECT tbl.schemaname, tbl.tablename, tbl.tableowner, pg_table_size(c.oid), pg_indexes_size(c.oid) " +
-		"FROM pg_catalog.pg_tables tbl, pg_catalog.pg_class c " +
-		"WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tbl.schemaname=c.relnamespace::regnamespace::text AND tbl.tablename = c.relname;"
+		"SELECT tbl.schemaname, tbl.tablename, tbl.tableowner, " +
+		"pg_table_size((quote_ident(tbl.schemaname) || '.' || quote_ident(tbl.tablename))::regclass)" +
+		"pg_indexes_size((quote_ident(tbl.schemaname) || '.' || quote_ident(tbl.tablename))::regclass)" +
+		"FROM pg_catalog.pg_tables;"
 	rows, err := txn.Query(query)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
More detail in linear issue. We use oid as much as possible.
Edge case:
<img width="1481" alt="0GopgX8XZw" src="https://user-images.githubusercontent.com/87714218/186220381-bd631092-0a99-4a73-81bd-0a889a22aa4d.png">
Normal case(pagila):
![CleanShot 2022-08-24 at 01 07 25@2x](https://user-images.githubusercontent.com/87714218/186220904-373d7a0c-59d3-437b-acac-cbe44e8e45b2.png)
![CleanShot 2022-08-24 at 01 08 29@2x](https://user-images.githubusercontent.com/87714218/186221193-85c218cd-dcc6-44ee-9d33-0e7f7b03f94f.png)

