### PR TITLE
feat(db): add `schema_migration_type` column to `project` table

### DIFF
--- a/store/migration/dev/20220807000000__add_project_schema_migration_type.sql
+++ b/store/migration/dev/20220807000000__add_project_schema_migration_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE project ADD COLUMN schema_migration_type TEXT NOT NULL CHECK (schema_migration_type IN ('DDL', 'SDL')) DEFAULT 'DDL';

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -170,7 +170,7 @@ CREATE TABLE project (
     db_name_template TEXT NOT NULL,
     role_provider TEXT NOT NULL CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_COM')) DEFAULT 'BYTEBASE',
     schema_version_type TEXT NOT NULL CHECK (schema_version_type IN ('TIMESTAMP', 'SEMANTIC')) DEFAULT 'TIMESTAMP',
-    schema_migration_type TEXT NOT NULL DEFAULT 'DDL' CHECK (schema_migration_type IN ('DDL', 'SDL'))
+    schema_migration_type TEXT NOT NULL CHECK (schema_migration_type IN ('DDL', 'SDL')) DEFAULT 'DDL'
 );
 
 CREATE UNIQUE INDEX idx_project_unique_key ON project(key);

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -169,7 +169,8 @@ CREATE TABLE project (
     -- Empty value means {{DB_NAME}}.
     db_name_template TEXT NOT NULL,
     role_provider TEXT NOT NULL CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_COM')) DEFAULT 'BYTEBASE',
-    schema_version_type TEXT NOT NULL CHECK (schema_version_type IN ('TIMESTAMP', 'SEMANTIC')) DEFAULT 'TIMESTAMP'
+    schema_version_type TEXT NOT NULL CHECK (schema_version_type IN ('TIMESTAMP', 'SEMANTIC')) DEFAULT 'TIMESTAMP',
+    schema_migration_type TEXT NOT NULL DEFAULT 'DDL' CHECK (schema_migration_type IN ('DDL', 'SDL'))
 );
 
 CREATE UNIQUE INDEX idx_project_unique_key ON project(key);


### PR DESCRIPTION
This PR adds a DB migration to add the `project.schema_migration_type` column, which will be used to store what type of schema migration the project uses.

DDL stands for Data Definition Language and SDL stands for Schema Definition Language.

---

Changes are extracted from https://github.com/bytebase/bytebase/pull/2333, part of https://linear.app/bbteam/issue/BYT-1065/implement-sbm-mvp-version