### PR TITLE
feat(webhook): support optionally including modified files from payload

### DIFF
--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -82,13 +82,14 @@ type WebhookCommitAuthor struct {
 
 // WebhookCommit is the API message for webhook commit.
 type WebhookCommit struct {
-	ID        string              `json:"id"`
-	Title     string              `json:"title"`
-	Message   string              `json:"message"`
-	Timestamp string              `json:"timestamp"`
-	URL       string              `json:"url"`
-	Author    WebhookCommitAuthor `json:"author"`
-	AddedList []string            `json:"added"`
+	ID           string              `json:"id"`
+	Title        string              `json:"title"`
+	Message      string              `json:"message"`
+	Timestamp    string              `json:"timestamp"`
+	URL          string              `json:"url"`
+	Author       WebhookCommitAuthor `json:"author"`
+	AddedList    []string            `json:"added"`
+	ModifiedList []string            `json:"modified"`
 }
 
 // WebhookPushEvent is the API message for webhook push event.

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -78,7 +78,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			zap.String("project", repo.Project.Name),
 		)
 
-		distinctFileList := dedupMigrationFilesFromCommitList(pushEvent.CommitList, false)
+		distinctFileList := dedupMigrationFilesFromCommitList(pushEvent.CommitList, false /* includeModified */)
 		var createdMessageList []string
 		for _, item := range distinctFileList {
 			createdMessage, created, httpErr := s.createIssueFromPushEvent(

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -78,7 +78,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 			zap.String("project", repo.Project.Name),
 		)
 
-		distinctFileList := dedupMigrationFilesFromCommitList(pushEvent.CommitList)
+		distinctFileList := dedupMigrationFilesFromCommitList(pushEvent.CommitList, false)
 		var createdMessageList []string
 		for _, item := range distinctFileList {
 			createdMessage, created, httpErr := s.createIssueFromPushEvent(
@@ -298,7 +298,7 @@ type distinctFileItem struct {
 	fileName    string
 }
 
-func dedupMigrationFilesFromCommitList(commitList []gitlab.WebhookCommit) []distinctFileItem {
+func dedupMigrationFilesFromCommitList(commitList []gitlab.WebhookCommit, includeModified bool) []distinctFileItem {
 	// Use list instead of map because we need to maintain the relative commit order in the source branch.
 	var distinctFileList []distinctFileItem
 	for _, commit := range commitList {
@@ -312,26 +312,31 @@ func dedupMigrationFilesFromCommitList(commitList []gitlab.WebhookCommit) []dist
 			log.Warn("Ignored commit, failed to parse commit timestamp.", zap.String("commit", common.EscapeForLogging(commit.ID)), zap.String("timestamp", common.EscapeForLogging(commit.Timestamp)), zap.Error(err))
 		}
 
-		for _, added := range commit.AddedList {
-			isNew := true
+		addDistinctFile := func(fileName string) {
 			item := distinctFileItem{
 				createdTime: createdTime,
 				commit:      commit,
-				fileName:    added,
+				fileName:    fileName,
 			}
 			for i, file := range distinctFileList {
 				// For the migration file with the same name, keep the one from the latest commit
-				if added == file.fileName {
-					isNew = false
+				if item.fileName == file.fileName {
 					if file.createdTime.Before(createdTime) {
 						distinctFileList[i] = item
 					}
-					break
+					return
 				}
 			}
+			distinctFileList = append(distinctFileList, item)
+		}
 
-			if isNew {
-				distinctFileList = append(distinctFileList, item)
+		for _, added := range commit.AddedList {
+			addDistinctFile(added)
+		}
+
+		if includeModified {
+			for _, modified := range commit.ModifiedList {
+				addDistinctFile(modified)
 			}
 		}
 	}

--- a/server/webhook_test.go
+++ b/server/webhook_test.go
@@ -19,9 +19,10 @@ func TestDedupMigrationFiles(t *testing.T) {
 	time3, _ := time.Parse(time.RFC3339, timestamp3)
 
 	tests := []struct {
-		name       string
-		commitList []gitlab.WebhookCommit
-		want       []distinctFileItem
+		name            string
+		commitList      []gitlab.WebhookCommit
+		includeModified bool
+		want            []distinctFileItem
 	}{
 		{
 			name:       "Empty",
@@ -216,6 +217,7 @@ func TestDedupMigrationFiles(t *testing.T) {
 						"v2.sql",
 						"v3.sql",
 					},
+					ModifiedList: []string{"v4.sql"},
 				},
 			},
 			want: []distinctFileItem{
@@ -235,6 +237,7 @@ func TestDedupMigrationFiles(t *testing.T) {
 							"v2.sql",
 							"v3.sql",
 						},
+						ModifiedList: []string{"v4.sql"},
 					},
 					fileName: "v1.sql",
 				},
@@ -254,6 +257,7 @@ func TestDedupMigrationFiles(t *testing.T) {
 							"v2.sql",
 							"v3.sql",
 						},
+						ModifiedList: []string{"v4.sql"},
 					},
 					fileName: "v2.sql",
 				},
@@ -273,16 +277,148 @@ func TestDedupMigrationFiles(t *testing.T) {
 							"v2.sql",
 							"v3.sql",
 						},
+						ModifiedList: []string{"v4.sql"},
 					},
 					fileName: "v3.sql",
+				},
+			},
+		},
+		{
+			name: "Multi commits, multi files, include modified",
+			commitList: []gitlab.WebhookCommit{
+				{
+					ID:        "1",
+					Title:     "Commit 1",
+					Message:   "Update 1",
+					Timestamp: timestamp1,
+					URL:       "example.com",
+					Author: gitlab.WebhookCommitAuthor{
+						Name: "bob",
+					},
+					AddedList: []string{
+						"v1.sql",
+						"v2.sql",
+					},
+				},
+				{
+					ID:        "2",
+					Title:     "Commit 2",
+					Message:   "Update 2",
+					Timestamp: timestamp1,
+					URL:       "example.com",
+					Author: gitlab.WebhookCommitAuthor{
+						Name: "bob",
+					},
+					AddedList: []string{
+						"v3.sql",
+					},
+				},
+				{
+					ID:        "3",
+					Title:     "Merge branch",
+					Message:   "Merge update",
+					Timestamp: timestamp3,
+					URL:       "example.com",
+					Author: gitlab.WebhookCommitAuthor{
+						Name: "bob",
+					},
+					AddedList: []string{
+						"v1.sql",
+						"v2.sql",
+						"v3.sql",
+					},
+					ModifiedList: []string{"v4.sql"},
+				},
+			},
+			includeModified: true,
+			want: []distinctFileItem{
+				{
+					createdTime: time3,
+					commit: gitlab.WebhookCommit{
+						ID:        "3",
+						Title:     "Merge branch",
+						Message:   "Merge update",
+						Timestamp: timestamp3,
+						URL:       "example.com",
+						Author: gitlab.WebhookCommitAuthor{
+							Name: "bob",
+						},
+						AddedList: []string{
+							"v1.sql",
+							"v2.sql",
+							"v3.sql",
+						},
+						ModifiedList: []string{"v4.sql"},
+					},
+					fileName: "v1.sql",
+				},
+				{
+					createdTime: time3,
+					commit: gitlab.WebhookCommit{
+						ID:        "3",
+						Title:     "Merge branch",
+						Message:   "Merge update",
+						Timestamp: timestamp3,
+						URL:       "example.com",
+						Author: gitlab.WebhookCommitAuthor{
+							Name: "bob",
+						},
+						AddedList: []string{
+							"v1.sql",
+							"v2.sql",
+							"v3.sql",
+						},
+						ModifiedList: []string{"v4.sql"},
+					},
+					fileName: "v2.sql",
+				},
+				{
+					createdTime: time3,
+					commit: gitlab.WebhookCommit{
+						ID:        "3",
+						Title:     "Merge branch",
+						Message:   "Merge update",
+						Timestamp: timestamp3,
+						URL:       "example.com",
+						Author: gitlab.WebhookCommitAuthor{
+							Name: "bob",
+						},
+						AddedList: []string{
+							"v1.sql",
+							"v2.sql",
+							"v3.sql",
+						},
+						ModifiedList: []string{"v4.sql"},
+					},
+					fileName: "v3.sql",
+				},
+				{
+					createdTime: time3,
+					commit: gitlab.WebhookCommit{
+						ID:        "3",
+						Title:     "Merge branch",
+						Message:   "Merge update",
+						Timestamp: timestamp3,
+						URL:       "example.com",
+						Author: gitlab.WebhookCommitAuthor{
+							Name: "bob",
+						},
+						AddedList: []string{
+							"v1.sql",
+							"v2.sql",
+							"v3.sql",
+						},
+						ModifiedList: []string{"v4.sql"},
+					},
+					fileName: "v4.sql",
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := dedupMigrationFilesFromCommitList(tt.commitList)
-			assert.Equal(t, got, tt.want)
+			got := dedupMigrationFilesFromCommitList(tt.commitList, tt.includeModified)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
State-based migration needs to be able to read from a modified schema file, thus we need to make it possible to include the list of modified files from the webhook payload.

---

Changes are extracted from https://github.com/bytebase/bytebase/pull/2333, part of https://linear.app/bbteam/issue/BYT-1065/implement-sbm-mvp-version