### PR TITLE
fix: convert EXECUTE FUNCTION to PROCEDURE for CREATE EVENT TRIGGER statements

### DIFF
--- a/plugin/db/pg/dump.go
+++ b/plugin/db/pg/dump.go
@@ -145,6 +145,16 @@ func (driver *Driver) Restore(ctx context.Context, sc io.Reader) error {
 	}
 
 	f := func(stmt string) error {
+		// CREATE EVENT TRIGGER statement only supports EXECUTE PROCEDURE in version 10 and before, while newer version supports both EXECUTE { FUNCTION | PROCEDURE }.
+		// Since we use pg_dump version 14, the dump uses new style even for old version of PostgreSQL.
+		// We should convert EXECUTE FUNCTION to EXECUTE PROCEDURE to make the restore to work on old versions.
+		// https://www.postgresql.org/docs/14/sql-createeventtrigger.html
+		if strings.Contains(strings.ToUpper(stmt), "CREATE EVENT TRIGGER") {
+			stmt = strings.ReplaceAll(stmt, "EXECUTE FUNCTION", "EXECUTE PROCEDURE")
+		}
+		if isSuperuserStatement(stmt) {
+			stmt = fmt.Sprintf("SET LOCAL ROLE NONE;%sSET LOCAL ROLE %s;", stmt, owner)
+		}
 		if _, err := txn.Exec(stmt); err != nil {
 			return err
 		}

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -265,8 +265,8 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 			}
 		} else if isSuperuserStatement(stmt) {
 			// CREATE EVENT TRIGGER statement only supports EXECUTE PROCEDURE in version 10 and before, while newer version supports both EXECUTE { FUNCTION | PROCEDURE }.
-			// Since we use pg_dump version 14, the dump uses new style even for old version of PostgreSQL.
-			// We should convert EXECUTE FUNCTION to EXECUTE PROCEDURE to make the restore to work on old versions.
+			// Since we use pg_dump version 14, the dump uses a new style even for an old version of PostgreSQL.
+			// We should convert EXECUTE FUNCTION to EXECUTE PROCEDURE to make the restoration work on old versions.
 			// https://www.postgresql.org/docs/14/sql-createeventtrigger.html
 			if strings.Contains(strings.ToUpper(stmt), "CREATE EVENT TRIGGER") {
 				stmt = strings.ReplaceAll(stmt, "EXECUTE FUNCTION", "EXECUTE PROCEDURE")

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -264,10 +264,16 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 				return err
 			}
 		} else if isSuperuserStatement(stmt) {
+			// CREATE EVENT TRIGGER statement only supports EXECUTE PROCEDURE in version 10 and before, while newer version supports both EXECUTE { FUNCTION | PROCEDURE }.
+			// Since we use pg_dump version 14, the dump uses new style even for old version of PostgreSQL.
+			// We should convert EXECUTE FUNCTION to EXECUTE PROCEDURE to make the restore to work on old versions.
+			// https://www.postgresql.org/docs/14/sql-createeventtrigger.html
+			if strings.Contains(strings.ToUpper(stmt), "CREATE EVENT TRIGGER") {
+				stmt = strings.ReplaceAll(stmt, "EXECUTE FUNCTION", "EXECUTE PROCEDURE")
+			}
 			// Use superuser privilege to run privileged statements.
-			remainingStmts = append(remainingStmts, "SET LOCAL ROLE NONE;")
+			stmt = fmt.Sprintf("SET LOCAL ROLE NONE;%sSET LOCAL ROLE %s;", stmt, owner)
 			remainingStmts = append(remainingStmts, stmt)
-			remainingStmts = append(remainingStmts, fmt.Sprintf("SET LOCAL ROLE %s;", owner))
 		} else {
 			remainingStmts = append(remainingStmts, stmt)
 		}


### PR DESCRIPTION
CREATE EVENT TRIGGER statement only supports EXECUTE PROCEDURE in version 10 and before, while newer version supports both EXECUTE { FUNCTION | PROCEDURE }.
Since we use pg_dump version 14, the dump uses a new style even for an old version of PostgreSQL. We should convert EXECUTE FUNCTION to EXECUTE PROCEDURE to make the restoration work on old versions.
https://www.postgresql.org/docs/14/sql-createeventtrigger.html