### PR TITLE
feat(frontend): GitHub style button with context menu

### DIFF
--- a/frontend/src/bbkit/BBContextMenuButton.vue
+++ b/frontend/src/bbkit/BBContextMenuButton.vue
@@ -160,6 +160,7 @@ const handleClickActionList = (action: ButtonAction) => {
 
   const storage = getStorage();
   if (storage) {
+    // Save the selected action as the default action
     storage.value = action.key;
   }
 

--- a/frontend/src/bbkit/BBContextMenuButton.vue
+++ b/frontend/src/bbkit/BBContextMenuButton.vue
@@ -1,0 +1,217 @@
+<template>
+  <button
+    class="select-none inline-flex items-center border rounded-md disabled:opacity-50 disabled:cursor-not-allowed text-sm leading-5 font-medium overflow-hidden focus:ring-control focus:outline-none focus-visible:ring-2 focus:ring-offset-2"
+    :data-button-type="state.currentAction.type"
+    :class="actionButtonClass.wrapper"
+    :disabled="disabled"
+  >
+    <div
+      class="flex items-center px-4 py-2"
+      :class="[actionButtonClass.btn, disabled && 'pointer-events-none']"
+      @click.stop="handleClickButton"
+    >
+      <slot name="default" :action="state.currentAction">
+        {{ state.currentAction.text }}
+      </slot>
+    </div>
+
+    <div
+      v-if="actionList.length > 1"
+      class="flex h-full w-0 border-l"
+      :class="actionButtonClass.divider"
+    />
+
+    <NPopover
+      v-if="actionList.length > 1"
+      ref="popover"
+      :disabled="disabled"
+      placement="bottom-end"
+      trigger="click"
+      raw
+      style="box-shadow: none"
+      :show-arrow="false"
+    >
+      <template #trigger>
+        <div
+          class="flex items-center px-2 h-full"
+          :class="[actionButtonClass.btn, disabled && 'pointer-events-none']"
+        >
+          <heroicons-outline:chevron-down />
+        </div>
+      </template>
+
+      <div
+        class="flex flex-col divide-y divide-gray-200 border border-gray-200 rounded-md shadow-md overflow-hidden"
+      >
+        <slot
+          v-for="(action, index) in actionList"
+          :key="action.key"
+          name="action-item"
+          :action="action"
+          :index="index"
+          :selected="isCurrentAction(action)"
+          :click-handler="() => handleClickActionList(action)"
+        >
+          <div
+            class="flex items-center justify-between gap-x-4 py-2 pl-4 pr-2 bg-white cursor-pointer text-sm font-medium text-control hover:bg-main-hover hover:text-white"
+            @click.stop="handleClickActionList(action)"
+          >
+            <span>{{ action.text }}</span>
+            <span :class="!isCurrentAction(action) && 'invisible'">
+              <heroicons-outline:check />
+            </span>
+          </div>
+        </slot>
+      </div>
+    </NPopover>
+  </button>
+</template>
+
+<script lang="ts" setup>
+import { computed, PropType, reactive, shallowRef, watch } from "vue";
+import { useLocalStorage } from "@vueuse/core";
+import { NPopover } from "naive-ui";
+import { BBButtonType } from "./types";
+
+export type ButtonAction<T = unknown> = {
+  key: string;
+  text: string;
+  type: BBButtonType;
+  params: T;
+};
+
+type LocalState = {
+  currentAction: ButtonAction;
+};
+
+const STORE_PREFIX = "bb.button-with-context-menu";
+
+const props = defineProps({
+  preferenceKey: {
+    type: String,
+    default: "",
+  },
+  actionList: {
+    type: Array as PropType<ButtonAction[]>,
+    required: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits<{
+  (event: "click", action: ButtonAction): void;
+}>();
+
+const popover = shallowRef<InstanceType<typeof NPopover>>();
+
+const getStorage = () => {
+  const { preferenceKey } = props;
+  if (!preferenceKey) return undefined;
+  // e.g key = "bb.button-with-context-menu.task-status-transition"
+  const key = `${STORE_PREFIX}.${preferenceKey}`;
+  return useLocalStorage(key, "", {
+    listenToStorageChanges: false,
+  });
+};
+
+// Load user stored default action from localStorage if possible.
+// The stored default action may not be in the actionList this time.
+// Fallback to the first action if not found.
+// But we won't mutate the stored value.
+const getDefaultAction = (): ButtonAction => {
+  const storage = getStorage();
+  if (storage && storage.value) {
+    const storedDefaultAction = props.actionList.find(
+      (action) => action.key === storage.value
+    );
+    if (storedDefaultAction) {
+      return storedDefaultAction;
+    }
+  }
+
+  return props.actionList[0];
+};
+
+const state = reactive<LocalState>({
+  currentAction: getDefaultAction(),
+});
+
+const actionButtonClass = computed(() => {
+  const { type } = state.currentAction;
+  if (type in BUTTON_CLASS_MAP) {
+    return BUTTON_CLASS_MAP[type];
+  }
+  return BUTTON_CLASS_MAP.NORMAL;
+});
+
+const isCurrentAction = (action: ButtonAction) => {
+  return action.key === state.currentAction.key;
+};
+
+const handleClickActionList = (action: ButtonAction) => {
+  const reset = () => {
+    popover.value?.setShow(false);
+  };
+
+  if (isCurrentAction(action)) return reset();
+
+  const storage = getStorage();
+  if (storage) {
+    storage.value = action.key;
+  }
+
+  state.currentAction = action;
+
+  reset();
+};
+
+const handleClickButton = () => {
+  if (props.disabled) return;
+  emit("click", state.currentAction);
+};
+
+watch(
+  () => props.actionList,
+  () => {
+    state.currentAction = getDefaultAction();
+  }
+);
+
+const BUTTON_CLASS_MAP: Record<
+  BBButtonType,
+  {
+    wrapper: string;
+    btn: string;
+    divider: string;
+  }
+> = {
+  NORMAL: {
+    wrapper: "border-control-border text-control disabled:bg-control-bg",
+    btn: "bg-white hover:bg-control-bg-hover",
+    divider: "border-control-border",
+  },
+  PRIMARY: {
+    wrapper: "border-transparent text-accent-text disabled:bg-accent",
+    btn: "bg-accent hover:bg-accent-hover",
+    divider: "border-indigo-500",
+  },
+  SECONDARY: {
+    wrapper: "border-control-border text-main  disabled:bg-control-bg",
+    btn: "bg-white hover:bg-control-bg-hover hover:text-control-hover",
+    divider: "border-control-border",
+  },
+  SUCCESS: {
+    wrapper: "border-transparent text-accent-text disabled:bg-success",
+    btn: "bg-success hover:bg-success-hover",
+    divider: "border-green-500",
+  },
+  DANGER: {
+    wrapper: "border-transparent text-accent-text disabled:bg-error",
+    btn: "bg-error hover:bg-error-hover",
+    divider: "border-red-500",
+  },
+};
+</script>

--- a/frontend/src/bbkit/BBTooltipButton.vue
+++ b/frontend/src/bbkit/BBTooltipButton.vue
@@ -2,14 +2,18 @@
   <NTooltip trigger="manual" :show="state.tooltipVisible">
     <template #trigger>
       <!--
-        <button disabled> will swallow all mouse related events such as mouseover/mouseout...
-        so we need to handle it manually with lower level DOM pointer events
+        Allowing to overwrite the entire button
+        with manual tooltip control functions
       -->
       <slot
         name="button"
         :show-tooltip="showTooltip"
         :hide-tooltip="hideTooltip"
       >
+        <!--
+          <button disabled> will swallow all mouse related events such as mouseover/mouseout...
+          so we need to handle it manually with lower level DOM pointer events
+        -->
         <button
           type="button"
           v-bind="$attrs"

--- a/frontend/src/bbkit/BBTooltipButton.vue
+++ b/frontend/src/bbkit/BBTooltipButton.vue
@@ -5,17 +5,23 @@
         <button disabled> will swallow all mouse related events such as mouseover/mouseout...
         so we need to handle it manually with lower level DOM pointer events
       -->
-      <button
-        type="button"
-        v-bind="$attrs"
-        :disabled="disabled"
-        :class="[`btn-${props.type}`, $attrs.class]"
-        @click.prevent="$emit('click')"
-        @pointerenter="showTooltip"
-        @pointerleave="hideTooltip"
+      <slot
+        name="button"
+        :show-tooltip="showTooltip"
+        :hide-tooltip="hideTooltip"
       >
-        <slot name="default"></slot>
-      </button>
+        <button
+          type="button"
+          v-bind="$attrs"
+          :disabled="disabled"
+          :class="[`btn-${props.type}`, $attrs.class]"
+          @click.prevent="$emit('click')"
+          @pointerenter="showTooltip"
+          @pointerleave="hideTooltip"
+        >
+          <slot name="default"></slot>
+        </button>
+      </slot>
     </template>
     <slot name="tooltip"></slot>
   </NTooltip>

--- a/frontend/src/bbkit/index.ts
+++ b/frontend/src/bbkit/index.ts
@@ -6,6 +6,7 @@ import BBButtonAdd from "./BBButtonAdd.vue";
 import BBButtonConfirm from "./BBButtonConfirm.vue";
 import BBCheckbox from "./BBCheckbox.vue";
 import BBContextMenu from "./BBContextMenu.vue";
+import BBContextMenuButton from "./BBContextMenuButton.vue";
 import BBModal from "./BBModal.vue";
 import BBDialog from "./BBDialog.vue";
 import BBNotification from "./BBNotification.vue";
@@ -37,6 +38,7 @@ export {
   BBButtonConfirm,
   BBCheckbox,
   BBContextMenu,
+  BBContextMenuButton,
   BBModal,
   BBDialog,
   BBNotification,

--- a/frontend/src/bbkit/types.ts
+++ b/frontend/src/bbkit/types.ts
@@ -1,3 +1,10 @@
+export type BBButtonType =
+  | "NORMAL"
+  | "PRIMARY"
+  | "SECONDARY"
+  | "DANGER"
+  | "SUCCESS";
+
 export type BBButtonConfirmStyle =
   | "DELETE"
   | "ARCHIVE"

--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -13,7 +13,7 @@
           :disabled="pitrButtonDisabled"
           @pointerenter="showTooltip"
           @pointerleave="hideTooltip"
-          @click="(action) => onClickPITRButton(action as any)"
+          @click="(action) => onClickPITRButton(action as PITRButtonAction)"
         >
           <template #default="{ action }">
             <span>{{ action.text }}</span>
@@ -198,6 +198,7 @@ type PITRTarget = "IN-PLACE" | "NEW";
 
 type Mode = "LAST_MIGRATION" | "CUSTOM";
 type Step = "LAST_MIGRATION_INFO" | "PITR_FORM";
+type PITRButtonAction = ButtonAction<{ step: Step; mode: Mode }>;
 
 interface LocalState {
   showDatabasePITRModal: boolean;
@@ -248,34 +249,24 @@ const pitrButtonDisabled = computed((): boolean => {
   return !props.allowAdmin || !pitrAvailable.value.result;
 });
 
-const buttonActionList = computed(
-  (): ButtonAction<{
-    step: Step;
-    mode: Mode;
-  }>[] => {
-    return [
-      {
-        key: "CUSTOM",
-        text: t("database.pitr.restore-to-point-in-time"),
-        type: "NORMAL",
-        params: { step: "PITR_FORM", mode: "CUSTOM" },
-      },
-      {
-        key: "LAST_MIGRATION",
-        text: t("database.pitr.restore-before-last-migration"),
-        type: "NORMAL",
-        params: { step: "LAST_MIGRATION_INFO", mode: "LAST_MIGRATION" },
-      },
-    ];
-  }
-);
+const buttonActionList = computed((): PITRButtonAction[] => {
+  return [
+    {
+      key: "CUSTOM",
+      text: t("database.pitr.restore-to-point-in-time"),
+      type: "NORMAL",
+      params: { step: "PITR_FORM", mode: "CUSTOM" },
+    },
+    {
+      key: "LAST_MIGRATION",
+      text: t("database.pitr.restore-before-last-migration"),
+      type: "NORMAL",
+      params: { step: "LAST_MIGRATION_INFO", mode: "LAST_MIGRATION" },
+    },
+  ];
+});
 
-const onClickPITRButton = (
-  action: ButtonAction<{
-    step: Step;
-    mode: Mode;
-  }>
-) => {
+const onClickPITRButton = (action: PITRButtonAction) => {
   const { step, mode } = action.params;
   openDialog(step, mode);
 };

--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -1,43 +1,30 @@
 <template>
-  <div class="relative mr-6">
+  <div class="flex relative mr-6">
     <BBTooltipButton
       type="normal"
       tooltip-mode="DISABLED-ONLY"
-      class="group"
       :disabled="pitrButtonDisabled"
       @click="openDialog"
     >
-      <div class="flex items-center gap-x-2">
-        <span>{{ $t("database.pitr.restore-to-point-in-time") }}</span>
-        <FeatureBadge
-          feature="bb.feature.disaster-recovery-pitr"
-          class="text-accent"
-        />
+      <template #button="{ showTooltip, hideTooltip }">
+        <BBContextMenuButton
+          preference-key="pitr"
+          :action-list="buttonActionList"
+          :disabled="pitrButtonDisabled"
+          @pointerenter="showTooltip"
+          @pointerleave="hideTooltip"
+          @click="(action) => onClickPITRButton(action as any)"
+        >
+          <template #default="{ action }">
+            <span>{{ action.text }}</span>
+            <FeatureBadge
+              feature="bb.feature.disaster-recovery-pitr"
+              class="text-accent ml-2 -mr-1"
+            />
+          </template>
+        </BBContextMenuButton>
+      </template>
 
-        <template v-if="lastMigrationHistory && !pitrButtonDisabled">
-          <span class="border-l border-control-light pl-2 -mr-1">
-            <heroicons-outline:chevron-down />
-          </span>
-
-          <div
-            class="hidden group-hover:flex whitespace-nowrap absolute right-0 -bottom-[1px] transform translate-y-[100%] z-50 rounded-md bg-white shadow-lg"
-            @click.prevent.stop="
-              openDialog('LAST_MIGRATION_INFO', 'LAST_MIGRATION')
-            "
-          >
-            <div
-              class="flex flex-col items-end py-1"
-              role="menu"
-              aria-orientation="vertical"
-              aria-labelledby="user-menu"
-            >
-              <div class="menu-item">
-                {{ $t("database.pitr.restore-before-last-migration") }}
-              </div>
-            </div>
-          </div>
-        </template>
-      </div>
       <template v-if="allowAdmin && !pitrAvailable.result" #tooltip>
         {{ pitrAvailable.message }}
       </template>
@@ -205,6 +192,7 @@ import { issueSlug } from "@/utils";
 import { featureToRef } from "@/store";
 import CreatePITRDatabaseForm from "./CreatePITRDatabaseForm.vue";
 import { CreatePITRDatabaseContext } from "./utils";
+import type { ButtonAction } from "@/bbkit/BBContextMenuButton.vue";
 
 type PITRTarget = "IN-PLACE" | "NEW";
 
@@ -259,6 +247,38 @@ const { pitrAvailable, doneBackupList, lastMigrationHistory, createPITRIssue } =
 const pitrButtonDisabled = computed((): boolean => {
   return !props.allowAdmin || !pitrAvailable.value.result;
 });
+
+const buttonActionList = computed(
+  (): ButtonAction<{
+    step: Step;
+    mode: Mode;
+  }>[] => {
+    return [
+      {
+        key: "CUSTOM",
+        text: t("database.pitr.restore-to-point-in-time"),
+        type: "NORMAL",
+        params: { step: "PITR_FORM", mode: "CUSTOM" },
+      },
+      {
+        key: "LAST_MIGRATION",
+        text: t("database.pitr.restore-before-last-migration"),
+        type: "NORMAL",
+        params: { step: "LAST_MIGRATION_INFO", mode: "LAST_MIGRATION" },
+      },
+    ];
+  }
+);
+
+const onClickPITRButton = (
+  action: ButtonAction<{
+    step: Step;
+    mode: Mode;
+  }>
+) => {
+  const { step, mode } = action.params;
+  openDialog(step, mode);
+};
 
 const earliest = computed((): number => {
   if (!pitrAvailable.value) {

--- a/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
+++ b/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
@@ -19,40 +19,11 @@
         v-for="(transition, index) in applicableTaskStatusTransitionList"
         :key="index"
       >
-        <button
-          type="button"
-          class="flex items-center gap-x-3 group relative overflow-visible"
-          :class="transition.buttonClass"
-          @click.prevent="tryStartTaskStatusTransition(transition)"
-        >
-          <span>
-            {{ $t(transition.buttonName) }}
-          </span>
-          <template v-if="allowApplyTaskTransitionToStage(transition)">
-            <span class="border-l pl-2 -mr-2">
-              <heroicons-outline:chevron-down />
-            </span>
-            <div
-              class="hidden group-hover:flex whitespace-nowrap absolute right-0 -bottom-[2px] transform translate-y-[100%] z-50 rounded-md bg-white shadow-lg"
-              @click.prevent.stop="tryStartStageStatusTransition(transition)"
-            >
-              <div
-                class="flex flex-col items-end py-1"
-                role="menu"
-                aria-orientation="vertical"
-                aria-labelledby="user-menu"
-              >
-                <div class="menu-item">
-                  {{
-                    $t("issue.action-to-current-stage", {
-                      action: $t(transition.buttonName),
-                    })
-                  }}
-                </div>
-              </div>
-            </div>
-          </template>
-        </button>
+        <BBContextMenuButton
+          preference-key="task-status-transition"
+          :action-list="getButtonActionList(transition)"
+          @click="(action) => onClickTaskStatusTransitionActionButton(action as ButtonAction<TaskStatusTransitionButtonActionParams>)"
+        />
       </template>
       <template v-if="applicableIssueStatusTransitionList.length > 0">
         <button
@@ -159,6 +130,7 @@ import {
   useExtraIssueLogic,
   useIssueLogic,
 } from "./logic";
+import type { ButtonAction } from "@/bbkit/BBContextMenuButton.vue";
 
 export type IssueContext = {
   currentUser: Principal;
@@ -180,6 +152,11 @@ interface UpdateStatusModalState {
   isTransiting: boolean;
 }
 
+type TaskStatusTransitionButtonActionParams = {
+  transition: TaskStatusTransition;
+  target: "TASK" | "STAGE";
+};
+
 const { t } = useI18n();
 const menu = ref<InstanceType<typeof BBContextMenu>>();
 
@@ -189,7 +166,6 @@ const {
   template: issueTemplate,
   activeTaskOfPipeline,
   doCreate,
-  isTenantMode,
 } = useIssueLogic();
 const { changeIssueStatus, changeStageAllTaskStatus, changeTaskStatus } =
   useExtraIssueLogic();
@@ -258,14 +234,6 @@ const tryStartStageOrTaskStatusTransition = (
   updateStatusModalState.show = true;
 };
 
-const tryStartTaskStatusTransition = (transition: TaskStatusTransition) => {
-  tryStartStageOrTaskStatusTransition(transition, "TASK");
-};
-
-const tryStartStageStatusTransition = (transition: StageStatusTransition) => {
-  tryStartStageOrTaskStatusTransition(transition, "STAGE");
-};
-
 const doTaskStatusTransition = (
   transition: TaskStatusTransition,
   task: Task,
@@ -285,6 +253,37 @@ const doStageStatusTransition = (
 const currentTask = computed(() => {
   return activeTaskOfPipeline((issue.value as Issue).pipeline);
 });
+
+const getButtonActionList = (transition: TaskStatusTransition) => {
+  const actionList: ButtonAction<TaskStatusTransitionButtonActionParams>[] = [];
+  const { type, buttonName, buttonType } = transition;
+  actionList.push({
+    key: `${type}-TASK`,
+    text: t(buttonName),
+    type: buttonType,
+    params: { transition, target: "TASK" },
+  });
+
+  if (allowApplyTaskTransitionToStage(transition)) {
+    actionList.push({
+      key: `${type}-STAGE`,
+      text: t("issue.action-to-current-stage", {
+        action: t(buttonName),
+      }),
+      type: buttonType,
+      params: { transition, target: "STAGE" },
+    });
+  }
+
+  return actionList;
+};
+
+const onClickTaskStatusTransitionActionButton = (
+  action: ButtonAction<TaskStatusTransitionButtonActionParams>
+) => {
+  const { transition, target } = action.params;
+  tryStartStageOrTaskStatusTransition(transition, target);
+};
 
 const allowIssueStatusTransition = (
   transition: IssueStatusTransition

--- a/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
+++ b/frontend/src/components/Issue/IssueStatusTransitionButtonGroup.vue
@@ -22,7 +22,7 @@
         <BBContextMenuButton
           preference-key="task-status-transition"
           :action-list="getButtonActionList(transition)"
-          @click="(action) => onClickTaskStatusTransitionActionButton(action as ButtonAction<TaskStatusTransitionButtonActionParams>)"
+          @click="(action) => onClickTaskStatusTransitionActionButton(action as TaskStatusTransitionButtonAction)"
         />
       </template>
       <template v-if="applicableIssueStatusTransitionList.length > 0">
@@ -152,10 +152,10 @@ interface UpdateStatusModalState {
   isTransiting: boolean;
 }
 
-type TaskStatusTransitionButtonActionParams = {
+type TaskStatusTransitionButtonAction = ButtonAction<{
   transition: TaskStatusTransition;
   target: "TASK" | "STAGE";
-};
+}>;
 
 const { t } = useI18n();
 const menu = ref<InstanceType<typeof BBContextMenu>>();
@@ -255,7 +255,7 @@ const currentTask = computed(() => {
 });
 
 const getButtonActionList = (transition: TaskStatusTransition) => {
-  const actionList: ButtonAction<TaskStatusTransitionButtonActionParams>[] = [];
+  const actionList: TaskStatusTransitionButtonAction[] = [];
   const { type, buttonName, buttonType } = transition;
   actionList.push({
     key: `${type}-TASK`,
@@ -279,7 +279,7 @@ const getButtonActionList = (transition: TaskStatusTransition) => {
 };
 
 const onClickTaskStatusTransitionActionButton = (
-  action: ButtonAction<TaskStatusTransitionButtonActionParams>
+  action: TaskStatusTransitionButtonAction
 ) => {
   const { transition, target } = action.params;
   tryStartStageOrTaskStatusTransition(transition, target);

--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -1,3 +1,4 @@
+import { BBButtonType } from "@/bbkit/types";
 import { uniq } from "lodash-es";
 import {
   Database,
@@ -165,7 +166,7 @@ export interface TaskStatusTransition {
   type: TaskStatusTransitionType;
   to: TaskStatus;
   buttonName: string;
-  buttonClass: string;
+  buttonType: BBButtonType;
 }
 
 const TASK_STATUS_TRANSITION_LIST: Map<
@@ -178,7 +179,7 @@ const TASK_STATUS_TRANSITION_LIST: Map<
       type: "RUN",
       to: "RUNNING",
       buttonName: "common.run",
-      buttonClass: "btn-primary",
+      buttonType: "PRIMARY",
     },
   ],
   [
@@ -187,7 +188,7 @@ const TASK_STATUS_TRANSITION_LIST: Map<
       type: "APPROVE",
       to: "PENDING",
       buttonName: "common.approve",
-      buttonClass: "btn-primary",
+      buttonType: "PRIMARY",
     },
   ],
   [
@@ -196,7 +197,7 @@ const TASK_STATUS_TRANSITION_LIST: Map<
       type: "RETRY",
       to: "RUNNING",
       buttonName: "common.retry",
-      buttonClass: "btn-primary",
+      buttonType: "PRIMARY",
     },
   ],
   [
@@ -205,7 +206,7 @@ const TASK_STATUS_TRANSITION_LIST: Map<
       type: "CANCEL",
       to: "PENDING",
       buttonName: "common.cancel",
-      buttonClass: "btn-primary",
+      buttonType: "NORMAL",
     },
   ],
 ]);


### PR DESCRIPTION
### Feature

Re-implement the task approval button and pitr restore button. Who's style and logic are very similar to GitHub's create pull request button. 

![image](https://user-images.githubusercontent.com/2749742/186831748-acebd905-af40-4e37-ac6c-9796b3cbd1cb.png)

The selected action will be stored in the user's browser localStorage, and set as the default selection next time if possible.

FYI @dragonly 

### Screenshot

<img width="296" alt="image" src="https://user-images.githubusercontent.com/2749742/186832757-c94fefd6-59ed-42e9-bab0-ed14ba7d9978.png">

----

![button-with-context-menu-approve](https://user-images.githubusercontent.com/2749742/186832251-40beba3c-2766-4e6b-bc60-1a788af2394c.gif)

----

![button-with-context-menu-pitr](https://user-images.githubusercontent.com/2749742/186832373-45fccd08-4898-49d2-b995-a3cb281450f9.gif)
