### PR TITLE
fix(frontend): auto-complete does not work in the standard project with multi-tasks

### DIFF
--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -266,6 +266,13 @@ export default defineComponent({
       updateEditorHeight();
     };
 
+    watch([databaseList, tableList], () => {
+      editorRef.value?.setEditorAutoCompletionContext(
+        databaseList.value,
+        tableList.value
+      );
+    });
+
     const updateEditorHeight = () => {
       const contentHeight =
         editorRef.value?.editorInstance?.getContentHeight() as number;


### PR DESCRIPTION
Close BYT-1257

call `setEditorAutoCompletionContext` automatically when `databaseList` and `tableList` changed.