### PR TITLE
feat(sql-editor): auto-completion improvement

### DIFF
--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -126,6 +126,7 @@
       :value="state.editStatement"
       :readonly="!state.editing"
       :auto-focus="false"
+      :dialect="dialect"
       @change="onStatementChange"
       @ready="handleMonacoEditorReady"
     />
@@ -177,7 +178,7 @@ import {
 } from "@/store";
 import { useIssueLogic } from "./logic";
 import MonacoEditor from "../MonacoEditor/MonacoEditor.vue";
-import { baseDirectoryWebUrl, Issue, Repository } from "@/types";
+import { baseDirectoryWebUrl, Issue, Repository, SQLDialect } from "@/types";
 import { useI18n } from "vue-i18n";
 
 interface LocalState {
@@ -210,6 +211,7 @@ export default defineComponent({
       issue,
       create,
       allowEditStatement,
+      selectedDatabase,
       selectedStatement: statement,
       updateStatement,
       allowApplyStatementToOtherStages,
@@ -227,6 +229,15 @@ export default defineComponent({
 
     const editorRef = ref<InstanceType<typeof MonacoEditor>>();
     const overrideSQLDialog = useDialog();
+
+    const dialect = computed((): SQLDialect => {
+      const db = selectedDatabase.value;
+      if (db?.instance.engine === "POSTGRES") {
+        return "postgresql";
+      }
+      // fallback to mysql dialect anyway
+      return "mysql";
+    });
 
     const formatOnSave = computed({
       get: () => uiStateStore.issueFormatStatementOnSave,
@@ -389,6 +400,7 @@ export default defineComponent({
       allowEditStatement,
       statement,
       allowApplyStatementToOtherStages,
+      dialect,
       formatOnSave,
       state,
       editorRef,

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -122,6 +122,7 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
                 // since "public" schema can be omitted by default
                 await provideColumnAutoCompletion(`public.${maybeTableName}`);
               }
+              // "{schema_name}." (postgresql) - will implement next time
               // - alias (can not recognize yet)
             }
 
@@ -140,6 +141,7 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
                 const maybeTableNameWithSchema = tokenListBeforeDot.join(".");
                 await provideColumnAutoCompletion(maybeTableNameWithSchema);
               }
+              // "{database_name}.{schema_name}." (postgresql) - will implement next time
             }
 
             if (

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -107,17 +107,17 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
 
             if (tokenListBeforeDot.length === 1) {
               // if the input is "x." x might be a
-              // - database name
+              // - "{database_name}."
               const maybeDatabaseName = tokenListBeforeDot[0];
               await provideTableAutoCompletion(maybeDatabaseName);
-              // - table name
+              // - "{table_name}."
               const maybeTableName = tokenListBeforeDot[0];
               if (dialect.value === "mysql") {
                 await provideColumnAutoCompletion(maybeTableName);
               }
               if (dialect.value === "postgresql") {
-                // for postgresql, we try "public.x"
-                // since public can be omitted by default
+                // for postgresql, we also try "public.{database_name}."
+                // since "public" schema can be omitted by default
                 await provideColumnAutoCompletion(`public.${maybeTableName}`);
               }
               // - alias (can not recognize yet)
@@ -125,8 +125,8 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
 
             if (tokenListBeforeDot.length === 2) {
               // if the input is "x.y." it might be
-              // - {database_name}.{table_name}. (mysql)
-              // - {schema_name}.{table_name}. (postgresql)
+              // - "{database_name}.{table_name}." (mysql)
+              // - "{schema_name}.{table_name}." (postgresql)
               const [maybeDatabaseName, maybeTableName] = tokenListBeforeDot;
               if (dialect.value === "mysql") {
                 await provideColumnAutoCompletion(
@@ -145,7 +145,7 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
               tokenListBeforeDot.length === 3
             ) {
               // if the input is "x.y.z." it might be
-              // - {database_name}.{schema_name}.{table_name} (postgresql only)
+              // - "{database_name}.{schema_name}.{table_name}." (postgresql only)
               //   and bytebase save {schema_name}.{table_name} as the table name
               const [maybeDatabaseName, maybeSchemaName, maybeTableName] =
                 tokenListBeforeDot;
@@ -157,6 +157,8 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
             }
           } else {
             // The auto-completion trigger is SPACE
+            // We didn't walk the AST, so still we don't know which type of
+            // clause we are in. So we provide some naive suggestions.
 
             // MySQL allows to query different databases, so we provide the database name suggestion for MySQL.
             const suggestionsForDatabase =

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -116,7 +116,7 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
                 await provideColumnAutoCompletion(maybeTableName);
               }
               if (dialect.value === "postgresql") {
-                // for postgresql, we also try "public.{database_name}."
+                // for postgresql, we also try "public.{table_name}."
                 // since "public" schema can be omitted by default
                 await provideColumnAutoCompletion(`public.${maybeTableName}`);
               }

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -107,10 +107,12 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
 
             if (tokenListBeforeDot.length === 1) {
               // if the input is "x." x might be a
-              // - "{database_name}."
-              const maybeDatabaseName = tokenListBeforeDot[0];
-              await provideTableAutoCompletion(maybeDatabaseName);
-              // - "{table_name}."
+              // - "{database_name}." (mysql)
+              if (dialect.value === "mysql") {
+                const maybeDatabaseName = tokenListBeforeDot[0];
+                await provideTableAutoCompletion(maybeDatabaseName);
+              }
+              // - "{table_name}." (mysql)
               const maybeTableName = tokenListBeforeDot[0];
               if (dialect.value === "mysql") {
                 await provideColumnAutoCompletion(maybeTableName);

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -64,7 +64,10 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
           if (lastToken.endsWith(".") && lastToken !== ".") {
             // The auto-completion trigger is "."
 
-            const tokenListBeforeDot = lastToken.slice(0, -1).split(".");
+            const tokenListBeforeDot = lastToken
+              .slice(0, -1)
+              .split(".")
+              .map((word) => word.replace(/[`'"]/g, "")); // remove quotes
 
             const provideTableAutoCompletion = async (databaseName: string) => {
               const database = databaseList.value.find(
@@ -117,7 +120,7 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
                 // since public can be omitted by default
                 await provideColumnAutoCompletion(`public.${maybeTableName}`);
               }
-              // - alias (not supported)
+              // - alias (can not recognize yet)
             }
 
             if (tokenListBeforeDot.length === 2) {

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -61,9 +61,8 @@ export const useMonaco = async (defaultDialect: SQLDialect) => {
             tableList.value
           );
 
+          // The auto-completion trigger is "."
           if (lastToken.endsWith(".") && lastToken !== ".") {
-            // The auto-completion trigger is "."
-
             const tokenListBeforeDot = lastToken
               .slice(0, -1)
               .split(".")

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -6,8 +6,10 @@ import { Database, Table, CompletionItems, SQLDialect } from "@/types";
 import AutoCompletion from "./AutoCompletion";
 import sqlFormatter from "./sqlFormatter";
 
-export const useMonaco = async (lang: string) => {
+export const useMonaco = async (defaultDialect: SQLDialect) => {
   const monaco = await import("monaco-editor");
+
+  const dialect = ref(defaultDialect);
 
   monaco.editor.defineTheme("bb-sql-editor-theme", {
     base: "vs",
@@ -34,108 +36,148 @@ export const useMonaco = async (lang: string) => {
   });
 
   const completionItemProvider =
-    monaco.languages.registerCompletionItemProvider(lang, {
-      triggerCharacters: [" ", "."],
-      provideCompletionItems: async (model, position) => {
-        let suggestions: CompletionItems = [];
+    monaco.languages.registerCompletionItemProvider(
+      ["sql", "mysql", "postgresql"],
+      {
+        triggerCharacters: [" ", "."],
+        provideCompletionItems: async (model, position) => {
+          let suggestions: CompletionItems = [];
 
-        const { lineNumber, column } = position;
-        // The text before the cursor pointer
-        const textBeforePointer = model.getValueInRange({
-          startLineNumber: lineNumber,
-          startColumn: 0,
-          endLineNumber: lineNumber,
-          endColumn: column,
-        });
-        // The multi-text before the cursor pointer
-        const textBeforePointerMulti = model.getValueInRange({
-          startLineNumber: 1,
-          startColumn: 0,
-          endLineNumber: lineNumber,
-          endColumn: column,
-        });
-        // The text after the cursor pointer
-        const textAfterPointerMulti = model.getValueInRange({
-          startLineNumber: lineNumber,
-          startColumn: column,
-          endLineNumber: model.getLineCount(),
-          endColumn: model.getLineMaxColumn(model.getLineCount()),
-        });
-        const tokens = textBeforePointer.trim().split(/\s+/);
-        const lastToken = tokens[tokens.length - 1].toLowerCase();
+          const { lineNumber, column } = position;
+          // The text before the cursor pointer
+          const textBeforePointer = model.getValueInRange({
+            startLineNumber: lineNumber,
+            startColumn: 0,
+            endLineNumber: lineNumber,
+            endColumn: column,
+          });
+          const tokens = textBeforePointer.trim().split(/\s+/);
+          const lastToken = tokens[tokens.length - 1].toLowerCase();
 
-        const autoCompletion = new AutoCompletion(
-          model,
-          position,
-          databaseList.value,
-          tableList.value
-        );
-
-        // MySQL allows to query different databases, so we provide the database name suggestion for MySQL.
-        const suggestionsForDatabase =
-          lang === "mysql"
-            ? await autoCompletion.getCompletionItemsForDatabaseList()
-            : [];
-        const suggestionsForTable =
-          await autoCompletion.getCompletionItemsForTableList();
-        const suggestionsForKeyword =
-          await autoCompletion.getCompletionItemsForKeywords();
-
-        // if enter a dot
-        if (lastToken.endsWith(".")) {
-          /**
-           * tokenLevel = 1 stands for the database.table or table.column
-           * tokenLevel = 2 stands for the database.table.column
-           */
-          const tokenLevel = lastToken.split(".").length - 1;
-          const lastTokenBeforeDot = lastToken.slice(0, -1);
-          let [databaseName, tableName] = ["", ""];
-          if (tokenLevel === 1) {
-            databaseName = lastTokenBeforeDot;
-            tableName = lastTokenBeforeDot;
-          }
-          if (tokenLevel === 2) {
-            databaseName = lastTokenBeforeDot.split(".").shift() as string;
-            tableName = lastTokenBeforeDot.split(".").pop() as string;
-          }
-          const dbIdx = databaseList.value.findIndex(
-            (item: Database) => item.name === databaseName
-          );
-          const tableIdx = tableList.value.findIndex(
-            (item: Table) => item.name === tableName
+          const autoCompletion = new AutoCompletion(
+            model,
+            position,
+            databaseList.value,
+            tableList.value
           );
 
-          // if the last token is a database name
-          if (lang === "mysql" && dbIdx !== -1 && tokenLevel === 1) {
-            suggestions = await autoCompletion.getCompletionItemsForTableList(
-              databaseList.value[dbIdx],
-              true
-            );
-          }
-          // if the last token is a table name
-          if (tableIdx !== -1 || tokenLevel === 2) {
-            const table = tableList.value[tableIdx];
-            if (table.columnList && table.columnList.length > 0) {
-              suggestions =
-                await autoCompletion.getCompletionItemsForTableColumnList(
-                  tableList.value[tableIdx],
-                  false
-                );
+          if (lastToken.endsWith(".") && lastToken !== ".") {
+            // The auto-completion trigger is "."
+
+            const tokenListBeforeDot = lastToken.slice(0, -1).split(".");
+
+            const provideTableAutoCompletion = async (databaseName: string) => {
+              const database = databaseList.value.find(
+                (db) => db.name === databaseName
+              );
+              if (database) {
+                // provide auto completion items for its tables
+                const tableListOfDatabase =
+                  await autoCompletion.getCompletionItemsForTableList(
+                    database,
+                    false // without database prefix since it's already inputted
+                  );
+                suggestions.push(...tableListOfDatabase);
+              }
+            };
+
+            const provideColumnAutoCompletion = async (
+              tableName: string,
+              databaseName?: string
+            ) => {
+              const tables = tableList.value.filter((table) => {
+                if (databaseName && table.database.name !== databaseName) {
+                  return false;
+                }
+                return table.name === tableName;
+              });
+              // provide auto completion items for table columns
+              for (const table of tables) {
+                const columnListOfTable =
+                  await autoCompletion.getCompletionItemsForTableColumnList(
+                    table,
+                    false // without table prefix since it's already inputted
+                  );
+                suggestions.push(...columnListOfTable);
+              }
+            };
+
+            if (tokenListBeforeDot.length === 1) {
+              // if the input is "x." x might be a
+              // - database name
+              const maybeDatabaseName = tokenListBeforeDot[0];
+              await provideTableAutoCompletion(maybeDatabaseName);
+              // - table name
+              const maybeTableName = tokenListBeforeDot[0];
+              if (dialect.value === "mysql") {
+                await provideColumnAutoCompletion(maybeTableName);
+              }
+              if (dialect.value === "postgresql") {
+                // for postgresql, we try "public.x"
+                // since public can be omitted by default
+                await provideColumnAutoCompletion(`public.${maybeTableName}`);
+              }
+              // - alias (not supported)
             }
-          }
-        } else {
-          suggestions = [
-            ...suggestionsForKeyword,
-            ...suggestionsForTable,
-            ...suggestionsForDatabase,
-          ];
-        }
 
-        return {
-          suggestions: uniqBy(suggestions, "label"),
-        };
-      },
-    });
+            if (tokenListBeforeDot.length === 2) {
+              // if the input is "x.y." it might be
+              // - {database_name}.{table_name}. (mysql)
+              // - {schema_name}.{table_name}. (postgresql)
+              const [maybeDatabaseName, maybeTableName] = tokenListBeforeDot;
+              if (dialect.value === "mysql") {
+                await provideColumnAutoCompletion(
+                  maybeTableName,
+                  maybeDatabaseName
+                );
+              }
+              if (dialect.value === "postgresql") {
+                const maybeTableNameWithSchema = tokenListBeforeDot.join(".");
+                await provideColumnAutoCompletion(maybeTableNameWithSchema);
+              }
+            }
+
+            if (
+              dialect.value === "postgresql" &&
+              tokenListBeforeDot.length === 3
+            ) {
+              // if the input is "x.y.z." it might be
+              // - {database_name}.{schema_name}.{table_name} (postgresql only)
+              //   and bytebase save {schema_name}.{table_name} as the table name
+              const [maybeDatabaseName, maybeSchemaName, maybeTableName] =
+                tokenListBeforeDot;
+              const maybeTableNameWithSchema = `${maybeSchemaName}.${maybeTableName}`;
+              await provideColumnAutoCompletion(
+                maybeTableNameWithSchema,
+                maybeDatabaseName
+              );
+            }
+          } else {
+            // The auto-completion trigger is SPACE
+
+            // MySQL allows to query different databases, so we provide the database name suggestion for MySQL.
+            const suggestionsForDatabase =
+              dialect.value === "mysql"
+                ? await autoCompletion.getCompletionItemsForDatabaseList()
+                : [];
+            const suggestionsForTable =
+              await autoCompletion.getCompletionItemsForTableList();
+            const suggestionsForKeyword =
+              await autoCompletion.getCompletionItemsForKeywords();
+
+            suggestions = [
+              ...suggestionsForKeyword,
+              ...suggestionsForTable,
+              ...suggestionsForDatabase,
+            ];
+          }
+
+          return {
+            suggestions: uniqBy(suggestions, "label"),
+          };
+        },
+      }
+    );
 
   await Promise.all([
     // load workers
@@ -193,10 +235,10 @@ export const useMonaco = async (lang: string) => {
 
   const formatContent = (
     editorInstance: Editor.IStandaloneCodeEditor,
-    language: SQLDialect
+    dialect: SQLDialect
   ) => {
     const sql = editorInstance.getValue();
-    const { data } = sqlFormatter(sql, language);
+    const { data } = sqlFormatter(sql, dialect);
     setContent(editorInstance, data);
   };
 
@@ -217,12 +259,17 @@ export const useMonaco = async (lang: string) => {
     tableList.value = tables;
   };
 
+  const setDialect = (newDialect: SQLDialect) => {
+    dialect.value = newDialect;
+  };
+
   return {
     dispose,
     monaco,
     setContent,
     formatContent,
     setAutoCompletionContext,
+    setDialect,
     setPositionAtEndOfLine,
   };
 };

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -181,6 +181,7 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
     }: Pick<SQLEditorState["connectionContext"], "instanceId" | "databaseId">) {
       const instance = await useInstanceStore().fetchInstanceById(instanceId);
       const database = await useDatabaseStore().fetchDatabaseById(databaseId);
+      await useTableStore().fetchTableListByDatabaseId(database.id);
 
       this.setConnectionContext({
         hasSlug: true,

--- a/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
@@ -6,7 +6,7 @@
       ref="editorRef"
       v-model:value="sqlCode"
       class="w-full h-full"
-      :language="selectedLanguage"
+      :dialect="selectedDialect"
       :readonly="readonly"
       @change="handleChange"
       @change-selection="handleChangeSelection"
@@ -30,6 +30,7 @@ import {
 } from "@/store";
 import { useExecuteSQL } from "@/composables/useExecuteSQL";
 import MonacoEditor from "@/components/MonacoEditor/MonacoEditor.vue";
+import { SQLDialect } from "@/types";
 
 const emit = defineEmits<{
   (e: "save-sheet", content?: string): void;
@@ -54,15 +55,12 @@ const selectedInstance = computed(() => {
 const selectedInstanceEngine = computed(() => {
   return instanceStore.formatEngine(selectedInstance.value);
 });
-const selectedLanguage = computed(() => {
+const selectedDialect = computed((): SQLDialect => {
   const engine = selectedInstanceEngine.value;
-  if (engine === "MySQL") {
-    return "mysql";
-  }
   if (engine === "PostgreSQL") {
-    return "pgsql";
+    return "postgresql";
   }
-  return "sql";
+  return "mysql";
 });
 const readonly = computed(() => sheetStore.isReadOnly);
 


### PR DESCRIPTION
### Strategy

#### For auto-completion triggered by "."

Provide **lexical level** auto-completion suggestions.

- if the input is `"x."` x might be
  - `"{database_name}."` (mysql)
  - `"{table_name}."` (mysql)
    - also try `"public.{table_name}."` as a table name, since `"public"` schema can be omitted by default (postgresql only)      
  -  `"{schema_name}."` (postgresql) - will implement next time
  - alias (can not recognize yet)

- if the input is `"x.y."` it might be
  - `"{database_name}.{table_name}."` (mysql)
  - `"{schema_name}.{table_name}."` (postgresql)
  - `"{database_name}.{schema_name}."` (postgresql) - will implement next time

- if the input is `"x.y.z."` it might be
  - `"{database_name}.{schema_name}.{table_name}."` (postgresql only)

So we can provide different types (table names of a database, or column names of a table) of suggestions.

#### For auto-completion triggered by SPACE

- We didn't walk the AST, so still we don't know which type of SQL clause we are in. So we provide some naive suggestions.

### Refactor

- `lang` has been renamed to `dialect`. It's no longer a static argument of `useMonaco()`, but an inner state of `useMonaco` and can be overwritten by calling `setDialect`. 

Close BYT-1227