### PR TITLE
refactor: use go struct embedding for transaction struct Tx in pg_engine.go

### DIFF
--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -26,6 +26,11 @@ func init() {
 	))
 }
 
+// Logger returns the global logger
+func Logger() *zap.Logger {
+	return gl
+}
+
 // SetLevel wraps the zap Level's SetLevel method.
 func SetLevel(level zapcore.Level) {
 	gLevel.SetLevel(level)

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -26,11 +26,6 @@ func init() {
 	))
 }
 
-// Logger returns the global logger
-func Logger() *zap.Logger {
-	return gl
-}
-
 // SetLevel wraps the zap Level's SetLevel method.
 func SetLevel(level zapcore.Level) {
 	gLevel.SetLevel(level)

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -9,13 +9,10 @@ import (
 
 	// Import pg driver.
 	// init() in pgx/v4/stdlib will register it's pgx driver.
-	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/log/zapadapter"
-	"github.com/jackc/pgx/v4/stdlib"
+	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/common"
-	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
 	"github.com/bytebase/bytebase/plugin/parser"
@@ -89,14 +86,7 @@ func (driver *Driver) Open(_ context.Context, _ db.Type, config db.ConnectionCon
 		driver.strictDatabase = config.Database
 	}
 
-	connConfig, err := pgx.ParseConfig(dsn)
-	if err != nil {
-		return nil, err
-	}
-	connConfig.Logger = zapadapter.NewLogger(log.Logger())
-	connConfig.LogLevel = pgx.LogLevelTrace
-	connStr := stdlib.RegisterConnConfig(connConfig)
-	db, err := sql.Open(driverName, connStr)
+	db, err := sql.Open(driverName, dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -9,10 +9,13 @@ import (
 
 	// Import pg driver.
 	// init() in pgx/v4/stdlib will register it's pgx driver.
-	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/log/zapadapter"
+	"github.com/jackc/pgx/v4/stdlib"
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
 	"github.com/bytebase/bytebase/plugin/parser"
@@ -86,7 +89,14 @@ func (driver *Driver) Open(_ context.Context, _ db.Type, config db.ConnectionCon
 		driver.strictDatabase = config.Database
 	}
 
-	db, err := sql.Open(driverName, dsn)
+	connConfig, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	connConfig.Logger = zapadapter.NewLogger(log.Logger())
+	connConfig.LogLevel = pgx.LogLevelTrace
+	connStr := stdlib.RegisterConnConfig(connConfig)
+	db, err := sql.Open(driverName, connStr)
 	if err != nil {
 		return nil, err
 	}

--- a/store/activity.go
+++ b/store/activity.go
@@ -124,14 +124,14 @@ func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreat
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	activity, err := createActivityImpl(ctx, tx.PTx, create)
+	activity, err := createActivityImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -144,9 +144,9 @@ func (s *Store) findActivityRaw(ctx context.Context, find *api.ActivityFind) ([]
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findActivityImpl(ctx, tx.PTx, find)
+	list, err := findActivityImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -162,9 +162,9 @@ func (s *Store) getActivityRawByID(ctx context.Context, id int) (*activityRaw, e
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findActivityImpl(ctx, tx.PTx, find)
+	list, err := findActivityImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -184,14 +184,14 @@ func (s *Store) patchActivityRaw(ctx context.Context, patch *api.ActivityPatch) 
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	activity, err := patchActivityImpl(ctx, tx.PTx, patch)
+	activity, err := patchActivityImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -217,7 +217,7 @@ func (s *Store) composeActivity(ctx context.Context, raw *activityRaw) (*api.Act
 }
 
 // createActivityImpl creates a new activity.
-func createActivityImpl(ctx context.Context, tx *sql.Tx, create *api.ActivityCreate) (*activityRaw, error) {
+func createActivityImpl(ctx context.Context, tx *Tx, create *api.ActivityCreate) (*activityRaw, error) {
 	// Insert row into activity.
 	if create.Payload == "" {
 		create.Payload = "{}"
@@ -264,7 +264,7 @@ func createActivityImpl(ctx context.Context, tx *sql.Tx, create *api.ActivityCre
 	return &activityRaw, nil
 }
 
-func findActivityImpl(ctx context.Context, tx *sql.Tx, find *api.ActivityFind) ([]*activityRaw, error) {
+func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*activityRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -339,7 +339,7 @@ func findActivityImpl(ctx context.Context, tx *sql.Tx, find *api.ActivityFind) (
 }
 
 // patchActivityImpl updates a activity by ID. Returns the new state of the activity after update.
-func patchActivityImpl(ctx context.Context, tx *sql.Tx, patch *api.ActivityPatch) (*activityRaw, error) {
+func patchActivityImpl(ctx context.Context, tx *Tx, patch *api.ActivityPatch) (*activityRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	if v := patch.Comment; v != nil {

--- a/store/bookmark.go
+++ b/store/bookmark.go
@@ -121,14 +121,14 @@ func (s *Store) createBookmarkRaw(ctx context.Context, create *api.BookmarkCreat
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	bookmark, err := createBookmarkImpl(ctx, tx.PTx, create)
+	bookmark, err := createBookmarkImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -141,9 +141,9 @@ func (s *Store) findBookmarkRaw(ctx context.Context, find *api.BookmarkFind) ([]
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findBookmarkImpl(ctx, tx.PTx, find)
+	list, err := findBookmarkImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -158,9 +158,9 @@ func (s *Store) getBookmarkRaw(ctx context.Context, find *api.BookmarkFind) (*bo
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	bookmarkRawList, err := findBookmarkImpl(ctx, tx.PTx, find)
+	bookmarkRawList, err := findBookmarkImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -180,13 +180,13 @@ func (s *Store) DeleteBookmark(ctx context.Context, delete *api.BookmarkDelete) 
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	if err := s.deleteBookmarkImpl(ctx, tx.PTx, delete); err != nil {
+	if err := s.deleteBookmarkImpl(ctx, tx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -194,7 +194,7 @@ func (s *Store) DeleteBookmark(ctx context.Context, delete *api.BookmarkDelete) 
 }
 
 // createBookmarkImpl creates a new bookmark.
-func createBookmarkImpl(ctx context.Context, tx *sql.Tx, create *api.BookmarkCreate) (*bookmarkRaw, error) {
+func createBookmarkImpl(ctx context.Context, tx *Tx, create *api.BookmarkCreate) (*bookmarkRaw, error) {
 	// Insert row into database.
 	query := `
 		INSERT INTO bookmark (
@@ -229,7 +229,7 @@ func createBookmarkImpl(ctx context.Context, tx *sql.Tx, create *api.BookmarkCre
 	return &bookmarkRaw, nil
 }
 
-func findBookmarkImpl(ctx context.Context, tx *sql.Tx, find *api.BookmarkFind) ([]*bookmarkRaw, error) {
+func findBookmarkImpl(ctx context.Context, tx *Tx, find *api.BookmarkFind) ([]*bookmarkRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -283,7 +283,7 @@ func findBookmarkImpl(ctx context.Context, tx *sql.Tx, find *api.BookmarkFind) (
 }
 
 // deleteBookmarkImpl permanently deletes a bookmark by ID.
-func (*Store) deleteBookmarkImpl(ctx context.Context, tx *sql.Tx, delete *api.BookmarkDelete) error {
+func (*Store) deleteBookmarkImpl(ctx context.Context, tx *Tx, delete *api.BookmarkDelete) error {
 	// Remove row from database.
 	result, err := tx.ExecContext(ctx, `DELETE FROM bookmark WHERE id = $1`, delete.ID)
 	if err != nil {

--- a/store/column.go
+++ b/store/column.go
@@ -17,9 +17,9 @@ func (s *Store) FindColumn(ctx context.Context, find *api.ColumnFind) ([]*api.Co
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := s.findColumnImpl(ctx, tx.PTx, find)
+	list, err := s.findColumnImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func generateColumnActions(oldColumnList []*api.Column, columnList []db.Column, 
 }
 
 // createColumnImpl creates a new column.
-func (*Store) createColumnImpl(ctx context.Context, tx *sql.Tx, create *api.ColumnCreate) (*api.Column, error) {
+func (*Store) createColumnImpl(ctx context.Context, tx *Tx, create *api.ColumnCreate) (*api.Column, error) {
 	defaultStr := sql.NullString{}
 	if create.Default != nil {
 		defaultStr = sql.NullString{
@@ -145,7 +145,7 @@ func (*Store) createColumnImpl(ctx context.Context, tx *sql.Tx, create *api.Colu
 	return &column, nil
 }
 
-func (*Store) findColumnImpl(ctx context.Context, tx *sql.Tx, find *api.ColumnFind) ([]*api.Column, error) {
+func (*Store) findColumnImpl(ctx context.Context, tx *Tx, find *api.ColumnFind) ([]*api.Column, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -227,7 +227,7 @@ func (*Store) findColumnImpl(ctx context.Context, tx *sql.Tx, find *api.ColumnFi
 }
 
 // deleteColumnImpl deletes columns.
-func (*Store) deleteColumnImpl(ctx context.Context, tx *sql.Tx, delete *api.ColumnDelete) error {
+func (*Store) deleteColumnImpl(ctx context.Context, tx *Tx, delete *api.ColumnDelete) error {
 	if _, err := tx.ExecContext(ctx, `DELETE FROM col WHERE id = $1`, delete.ID); err != nil {
 		return FormatError(err)
 	}

--- a/store/deploy.go
+++ b/store/deploy.go
@@ -120,14 +120,14 @@ func (s *Store) upsertDeploymentConfigRaw(ctx context.Context, upsert *api.Deplo
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	cfg, err := s.upsertDeploymentConfigImpl(ctx, tx.PTx, upsert)
+	cfg, err := s.upsertDeploymentConfigImpl(ctx, tx, upsert)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -140,7 +140,7 @@ func (s *Store) getDeploymentConfigImpl(ctx context.Context, find *api.Deploymen
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
@@ -151,7 +151,7 @@ func (s *Store) getDeploymentConfigImpl(ctx context.Context, find *api.Deploymen
 		where, args = append(where, fmt.Sprintf("project_id = $%d", len(args)+1)), append(args, *v)
 	}
 
-	rows, err := tx.PTx.QueryContext(ctx, `
+	rows, err := tx.QueryContext(ctx, `
 		SELECT
 			id,
 			creator_id,
@@ -203,7 +203,7 @@ func (s *Store) getDeploymentConfigImpl(ctx context.Context, find *api.Deploymen
 	}
 }
 
-func (*Store) upsertDeploymentConfigImpl(ctx context.Context, tx *sql.Tx, upsert *api.DeploymentConfigUpsert) (*deploymentConfigRaw, error) {
+func (*Store) upsertDeploymentConfigImpl(ctx context.Context, tx *Tx, upsert *api.DeploymentConfigUpsert) (*deploymentConfigRaw, error) {
 	if upsert.Payload == "" {
 		upsert.Payload = "{}"
 	}

--- a/store/environment.go
+++ b/store/environment.go
@@ -141,14 +141,14 @@ func (s *Store) createEnvironmentRaw(ctx context.Context, create *api.Environmen
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	environment, err := s.createEnvironmentImpl(ctx, tx.PTx, create)
+	environment, err := s.createEnvironmentImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -165,9 +165,9 @@ func (s *Store) findEnvironmentRaw(ctx context.Context, find *api.EnvironmentFin
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := s.findEnvironmentImpl(ctx, tx.PTx, find)
+	list, err := s.findEnvironmentImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -199,10 +199,10 @@ func (s *Store) getEnvironmentByIDRaw(ctx context.Context, id int) (*environment
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
 	find := &api.EnvironmentFind{ID: &id}
-	envRawList, err := s.findEnvironmentImpl(ctx, tx.PTx, find)
+	envRawList, err := s.findEnvironmentImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -225,14 +225,14 @@ func (s *Store) patchEnvironmentRaw(ctx context.Context, patch *api.EnvironmentP
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	envRaw, err := s.patchEnvironmentImpl(ctx, tx.PTx, patch)
+	envRaw, err := s.patchEnvironmentImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -244,7 +244,7 @@ func (s *Store) patchEnvironmentRaw(ctx context.Context, patch *api.EnvironmentP
 }
 
 // createEnvironmentImpl creates a new environment.
-func (Store) createEnvironmentImpl(ctx context.Context, tx *sql.Tx, create *api.EnvironmentCreate) (*environmentRaw, error) {
+func (Store) createEnvironmentImpl(ctx context.Context, tx *Tx, create *api.EnvironmentCreate) (*environmentRaw, error) {
 	var order int
 	// The order is the MAX(order) + 1
 	if err := tx.QueryRowContext(ctx, `
@@ -294,7 +294,7 @@ func (Store) createEnvironmentImpl(ctx context.Context, tx *sql.Tx, create *api.
 	return &envRaw, nil
 }
 
-func (*Store) findEnvironmentImpl(ctx context.Context, tx *sql.Tx, find *api.EnvironmentFind) ([]*environmentRaw, error) {
+func (*Store) findEnvironmentImpl(ctx context.Context, tx *Tx, find *api.EnvironmentFind) ([]*environmentRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -353,7 +353,7 @@ func (*Store) findEnvironmentImpl(ctx context.Context, tx *sql.Tx, find *api.Env
 }
 
 // patchEnvironmentImpl updates a environment by ID. Returns the new state of the environment after update.
-func (*Store) patchEnvironmentImpl(ctx context.Context, tx *sql.Tx, patch *api.EnvironmentPatch) (*environmentRaw, error) {
+func (*Store) patchEnvironmentImpl(ctx context.Context, tx *Tx, patch *api.EnvironmentPatch) (*environmentRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	if v := patch.RowStatus; v != nil {

--- a/store/inbox.go
+++ b/store/inbox.go
@@ -272,7 +272,7 @@ func findInboxImpl(ctx context.Context, tx *Tx, find *api.InboxFind) ([]*inboxRa
 		where, args = append(where, fmt.Sprintf("(status != 'READ' OR created_ts >= $%d)", len(args)+1)), append(args, *v)
 	}
 
-	rows, err := tx.QueryContext(ctx, ` 
+	rows, err := tx.QueryContext(ctx, `
 		SELECT
 			inbox.id,
 			receiver_id,

--- a/store/inbox.go
+++ b/store/inbox.go
@@ -100,11 +100,11 @@ func (s *Store) FindInboxSummary(ctx context.Context, principalID int) (*api.Inb
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
 	query := `SELECT EXISTS (SELECT 1 FROM inbox WHERE receiver_id = $1 AND status = 'UNREAD')`
 	var inboxSummary api.InboxSummary
-	if err := tx.PTx.QueryRowContext(ctx, query, principalID).Scan(&inboxSummary.HasUnread); err != nil {
+	if err := tx.QueryRowContext(ctx, query, principalID).Scan(&inboxSummary.HasUnread); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, common.FormatDBErrorEmptyRowWithQuery(query)
 		}
@@ -113,7 +113,7 @@ func (s *Store) FindInboxSummary(ctx context.Context, principalID int) (*api.Inb
 
 	if inboxSummary.HasUnread {
 		query2 := `SELECT EXISTS (SELECT 1 FROM inbox, activity WHERE inbox.receiver_id = $1 AND inbox.status = 'UNREAD' AND inbox.activity_id = activity.id AND activity.level = 'ERROR')`
-		if err := tx.PTx.QueryRowContext(ctx, query2, principalID).Scan(&inboxSummary.HasUnreadError); err != nil {
+		if err := tx.QueryRowContext(ctx, query2, principalID).Scan(&inboxSummary.HasUnreadError); err != nil {
 			if err == sql.ErrNoRows {
 				return nil, common.FormatDBErrorEmptyRowWithQuery(query2)
 			}
@@ -149,14 +149,14 @@ func (s *Store) createInboxRaw(ctx context.Context, create *api.InboxCreate) (*i
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	inbox, err := s.createInboxImpl(ctx, tx.PTx, create)
+	inbox, err := s.createInboxImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -169,9 +169,9 @@ func (s *Store) findInboxRaw(ctx context.Context, find *api.InboxFind) ([]*inbox
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findInboxImpl(ctx, tx.PTx, find)
+	list, err := findInboxImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -186,9 +186,9 @@ func (s *Store) getInboxRawByID(ctx context.Context, find *api.InboxFind) (*inbo
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findInboxImpl(ctx, tx.PTx, find)
+	list, err := findInboxImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -208,14 +208,14 @@ func (s *Store) patchInboxRaw(ctx context.Context, patch *api.InboxPatch) (*inbo
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	inbox, err := s.patchInboxImpl(ctx, tx.PTx, patch)
+	inbox, err := s.patchInboxImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -223,7 +223,7 @@ func (s *Store) patchInboxRaw(ctx context.Context, patch *api.InboxPatch) (*inbo
 }
 
 // createInboxImpl creates a new inbox.
-func (s *Store) createInboxImpl(ctx context.Context, tx *sql.Tx, create *api.InboxCreate) (*inboxRaw, error) {
+func (s *Store) createInboxImpl(ctx context.Context, tx *Tx, create *api.InboxCreate) (*inboxRaw, error) {
 	// Insert row into database.
 	query := `
 		INSERT INTO inbox (
@@ -258,7 +258,7 @@ func (s *Store) createInboxImpl(ctx context.Context, tx *sql.Tx, create *api.Inb
 	return &inboxRaw, nil
 }
 
-func findInboxImpl(ctx context.Context, tx *sql.Tx, find *api.InboxFind) ([]*inboxRaw, error) {
+func findInboxImpl(ctx context.Context, tx *Tx, find *api.InboxFind) ([]*inboxRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	where = append(where, "inbox.activity_id = activity.id")
@@ -272,7 +272,7 @@ func findInboxImpl(ctx context.Context, tx *sql.Tx, find *api.InboxFind) ([]*inb
 		where, args = append(where, fmt.Sprintf("(status != 'READ' OR created_ts >= $%d)", len(args)+1)), append(args, *v)
 	}
 
-	rows, err := tx.QueryContext(ctx, `
+	rows, err := tx.QueryContext(ctx, ` 
 		SELECT
 			inbox.id,
 			receiver_id,
@@ -329,7 +329,7 @@ func findInboxImpl(ctx context.Context, tx *sql.Tx, find *api.InboxFind) ([]*inb
 }
 
 // patchInboxImpl updates a inbox by ID. Returns the new state of the inbox after update.
-func (s *Store) patchInboxImpl(ctx context.Context, tx *sql.Tx, patch *api.InboxPatch) (*inboxRaw, error) {
+func (s *Store) patchInboxImpl(ctx context.Context, tx *Tx, patch *api.InboxPatch) (*inboxRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"status = $1"}, []interface{}{patch.Status}
 	args = append(args, patch.ID)

--- a/store/instance_user.go
+++ b/store/instance_user.go
@@ -18,14 +18,14 @@ func (s *Store) UpsertInstanceUser(ctx context.Context, upsert *api.InstanceUser
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	instanceUser, err := upsertInstanceUserImpl(ctx, tx.PTx, upsert)
+	instanceUser, err := upsertInstanceUserImpl(ctx, tx, upsert)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -38,9 +38,9 @@ func (s *Store) GetInstanceUser(ctx context.Context, find *api.InstanceUserFind)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findInstanceUserImpl(ctx, tx.PTx, find)
+	list, err := findInstanceUserImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -63,9 +63,9 @@ func (s *Store) FindInstanceUserByInstanceID(ctx context.Context, id int) ([]*ap
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findInstanceUserImpl(ctx, tx.PTx, find)
+	list, err := findInstanceUserImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -79,13 +79,13 @@ func (s *Store) DeleteInstanceUser(ctx context.Context, delete *api.InstanceUser
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	if err := deleteInstanceUser(ctx, tx.PTx, delete); err != nil {
+	if err := deleteInstanceUser(ctx, tx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -93,7 +93,7 @@ func (s *Store) DeleteInstanceUser(ctx context.Context, delete *api.InstanceUser
 }
 
 // upsertInstanceUserImpl upserts a new instanceUser.
-func upsertInstanceUserImpl(ctx context.Context, tx *sql.Tx, upsert *api.InstanceUserUpsert) (*api.InstanceUser, error) {
+func upsertInstanceUserImpl(ctx context.Context, tx *Tx, upsert *api.InstanceUserUpsert) (*api.InstanceUser, error) {
 	// Upsert row into database.
 	query := `
 		INSERT INTO instance_user (
@@ -130,7 +130,7 @@ func upsertInstanceUserImpl(ctx context.Context, tx *sql.Tx, upsert *api.Instanc
 	return &instanceUser, nil
 }
 
-func findInstanceUserImpl(ctx context.Context, tx *sql.Tx, find *api.InstanceUserFind) ([]*api.InstanceUser, error) {
+func findInstanceUserImpl(ctx context.Context, tx *Tx, find *api.InstanceUserFind) ([]*api.InstanceUser, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 
@@ -181,7 +181,7 @@ func findInstanceUserImpl(ctx context.Context, tx *sql.Tx, find *api.InstanceUse
 }
 
 // deleteInstanceUser permanently deletes a instance user by ID.
-func deleteInstanceUser(ctx context.Context, tx *sql.Tx, delete *api.InstanceUserDelete) error {
+func deleteInstanceUser(ctx context.Context, tx *Tx, delete *api.InstanceUserDelete) error {
 	// Remove row from database.
 	if _, err := tx.ExecContext(ctx, `DELETE FROM instance_user WHERE id = $1`, delete.ID); err != nil {
 		return FormatError(err)

--- a/store/issue.go
+++ b/store/issue.go
@@ -156,9 +156,9 @@ func (s *Store) CountIssueGroupByTypeAndStatus(ctx context.Context) ([]*metric.I
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	rows, err := tx.PTx.QueryContext(ctx, `
+	rows, err := tx.QueryContext(ctx, `
 		SELECT type, status, COUNT(*)
 		FROM issue
 		WHERE (id <= 101 AND updater_id != 1) OR id > 101
@@ -464,14 +464,14 @@ func (s *Store) createIssueRaw(ctx context.Context, create *api.IssueCreate) (*i
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	issue, err := s.createIssueImpl(ctx, tx.PTx, create)
+	issue, err := s.createIssueImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -488,9 +488,9 @@ func (s *Store) findIssueRaw(ctx context.Context, find *api.IssueFind) ([]*issue
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := s.findIssueImpl(ctx, tx.PTx, find)
+	list, err := s.findIssueImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -513,9 +513,9 @@ func (s *Store) getIssueRaw(ctx context.Context, find *api.IssueFind) (*issueRaw
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := s.findIssueImpl(ctx, tx.PTx, find)
+	list, err := s.findIssueImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -538,14 +538,14 @@ func (s *Store) patchIssueRaw(ctx context.Context, patch *api.IssuePatch) (*issu
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	issue, err := s.patchIssueImpl(ctx, tx.PTx, patch)
+	issue, err := s.patchIssueImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -557,7 +557,7 @@ func (s *Store) patchIssueRaw(ctx context.Context, patch *api.IssuePatch) (*issu
 }
 
 // createIssueImpl creates a new issue.
-func (*Store) createIssueImpl(ctx context.Context, tx *sql.Tx, create *api.IssueCreate) (*issueRaw, error) {
+func (*Store) createIssueImpl(ctx context.Context, tx *Tx, create *api.IssueCreate) (*issueRaw, error) {
 	if create.Payload == "" {
 		create.Payload = "{}"
 	}
@@ -611,7 +611,7 @@ func (*Store) createIssueImpl(ctx context.Context, tx *sql.Tx, create *api.Issue
 	return &issueRaw, nil
 }
 
-func (*Store) findIssueImpl(ctx context.Context, tx *sql.Tx, find *api.IssueFind) ([]*issueRaw, error) {
+func (*Store) findIssueImpl(ctx context.Context, tx *Tx, find *api.IssueFind) ([]*issueRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -714,7 +714,7 @@ func (*Store) findIssueImpl(ctx context.Context, tx *sql.Tx, find *api.IssueFind
 }
 
 // patchIssueImpl updates a issue by ID. Returns the new state of the issue after update.
-func (*Store) patchIssueImpl(ctx context.Context, tx *sql.Tx, patch *api.IssuePatch) (*issueRaw, error) {
+func (*Store) patchIssueImpl(ctx context.Context, tx *Tx, patch *api.IssuePatch) (*issueRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	if v := patch.Name; v != nil {

--- a/store/issue_subscriber.go
+++ b/store/issue_subscriber.go
@@ -64,13 +64,13 @@ func (s *Store) DeleteIssueSubscriber(ctx context.Context, delete *api.IssueSubs
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	if err := s.deleteIssueSubscriberImpl(ctx, tx.PTx, delete); err != nil {
+	if err := s.deleteIssueSubscriberImpl(ctx, tx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -99,14 +99,14 @@ func (s *Store) createIssueSubscriberRaw(ctx context.Context, create *api.IssueS
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	issueSubscriber, err := createIssueSubscriberImpl(ctx, tx.PTx, create)
+	issueSubscriber, err := createIssueSubscriberImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -119,9 +119,9 @@ func (s *Store) findIssueSubscriberRaw(ctx context.Context, find *api.IssueSubsc
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findIssueSubscriberImpl(ctx, tx.PTx, find)
+	list, err := findIssueSubscriberImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (s *Store) findIssueSubscriberRaw(ctx context.Context, find *api.IssueSubsc
 }
 
 // createIssueSubscriberImpl creates a new issueSubscriber.
-func createIssueSubscriberImpl(ctx context.Context, tx *sql.Tx, create *api.IssueSubscriberCreate) (*issueSubscriberRaw, error) {
+func createIssueSubscriberImpl(ctx context.Context, tx *Tx, create *api.IssueSubscriberCreate) (*issueSubscriberRaw, error) {
 	// Insert row into database.
 	query := `
 		INSERT INTO issue_subscriber (
@@ -156,7 +156,7 @@ func createIssueSubscriberImpl(ctx context.Context, tx *sql.Tx, create *api.Issu
 	return &issueSubscriberRaw, nil
 }
 
-func findIssueSubscriberImpl(ctx context.Context, tx *sql.Tx, find *api.IssueSubscriberFind) ([]*issueSubscriberRaw, error) {
+func findIssueSubscriberImpl(ctx context.Context, tx *Tx, find *api.IssueSubscriberFind) ([]*issueSubscriberRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.IssueID; v != nil {
@@ -200,7 +200,7 @@ func findIssueSubscriberImpl(ctx context.Context, tx *sql.Tx, find *api.IssueSub
 }
 
 // deleteIssueSubscriberImpl permanently deletes a issueSubscriber by ID.
-func (*Store) deleteIssueSubscriberImpl(ctx context.Context, tx *sql.Tx, delete *api.IssueSubscriberDelete) error {
+func (*Store) deleteIssueSubscriberImpl(ctx context.Context, tx *Tx, delete *api.IssueSubscriberDelete) error {
 	// Remove row from database.
 	if _, err := tx.ExecContext(ctx, `DELETE FROM issue_subscriber WHERE issue_id = $1 AND subscriber_id = $2`, delete.IssueID, delete.SubscriberID); err != nil {
 		return FormatError(err)

--- a/store/label.go
+++ b/store/label.go
@@ -104,7 +104,7 @@ func (s *Store) SetDatabaseLabelList(ctx context.Context, labelList []*api.Datab
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
 	var ret []*api.DatabaseLabel
 
@@ -121,7 +121,7 @@ func (s *Store) SetDatabaseLabelList(ctx context.Context, labelList []*api.Datab
 			Key:        oldLabelRaw.Key,
 			Value:      oldLabelRaw.Value,
 		}
-		if _, err := s.upsertDatabaseLabelImpl(ctx, tx.PTx, upsert); err != nil {
+		if _, err := s.upsertDatabaseLabelImpl(ctx, tx, upsert); err != nil {
 			return nil, err
 		}
 	}
@@ -139,7 +139,7 @@ func (s *Store) SetDatabaseLabelList(ctx context.Context, labelList []*api.Datab
 			Key:        label.Key,
 			Value:      label.Value,
 		}
-		labelRaw, err := s.upsertDatabaseLabelImpl(ctx, tx.PTx, upsert)
+		labelRaw, err := s.upsertDatabaseLabelImpl(ctx, tx, upsert)
 		if err != nil {
 			return nil, err
 		}
@@ -151,7 +151,7 @@ func (s *Store) SetDatabaseLabelList(ctx context.Context, labelList []*api.Datab
 		ret = append(ret, label)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -253,21 +253,21 @@ func (s *Store) findLabelKeyRaw(ctx context.Context, find *api.LabelKeyFind) ([]
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	ret, err := s.findLabelKeyImpl(ctx, tx.PTx, find)
+	ret, err := s.findLabelKeyImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
 	return ret, nil
 }
 
-func (*Store) findLabelKeyImpl(ctx context.Context, tx *sql.Tx, find *api.LabelKeyFind) ([]*labelKeyRaw, error) {
+func (*Store) findLabelKeyImpl(ctx context.Context, tx *Tx, find *api.LabelKeyFind) ([]*labelKeyRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.RowStatus; v != nil {
@@ -360,9 +360,9 @@ func (s *Store) patchLabelKeyRaw(ctx context.Context, patch *api.LabelKeyPatch) 
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	labelKeyRawList, err := s.findLabelKeyImpl(ctx, tx.PTx, &api.LabelKeyFind{})
+	labelKeyRawList, err := s.findLabelKeyImpl(ctx, tx, &api.LabelKeyFind{})
 	if err != nil {
 		return nil, err
 	}
@@ -404,12 +404,12 @@ func (s *Store) patchLabelKeyRaw(ctx context.Context, patch *api.LabelKeyPatch) 
 	}
 
 	for _, upsert := range upserts {
-		if err := s.upsertLabelValueImpl(ctx, tx.PTx, upsert); err != nil {
+		if err := s.upsertLabelValueImpl(ctx, tx, upsert); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -417,7 +417,7 @@ func (s *Store) patchLabelKeyRaw(ctx context.Context, patch *api.LabelKeyPatch) 
 	return labelKeyRaw, nil
 }
 
-func (*Store) upsertLabelValueImpl(ctx context.Context, tx *sql.Tx, upsert labelValueUpsert) error {
+func (*Store) upsertLabelValueImpl(ctx context.Context, tx *Tx, upsert labelValueUpsert) error {
 	// Upsert row into label_value
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO label_value (
@@ -450,21 +450,21 @@ func (s *Store) findDatabaseLabelRaw(ctx context.Context, find *api.DatabaseLabe
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	databaseLabelList, err := s.findDatabaseLabelsImpl(ctx, tx.PTx, find)
+	databaseLabelList, err := s.findDatabaseLabelsImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
 	return databaseLabelList, nil
 }
 
-func (*Store) findDatabaseLabelsImpl(ctx context.Context, tx *sql.Tx, find *api.DatabaseLabelFind) ([]*databaseLabelRaw, error) {
+func (*Store) findDatabaseLabelsImpl(ctx context.Context, tx *Tx, find *api.DatabaseLabelFind) ([]*databaseLabelRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -523,7 +523,7 @@ func (*Store) findDatabaseLabelsImpl(ctx context.Context, tx *sql.Tx, find *api.
 	return ret, nil
 }
 
-func (*Store) upsertDatabaseLabelImpl(ctx context.Context, tx *sql.Tx, upsert *api.DatabaseLabelUpsert) (*databaseLabelRaw, error) {
+func (*Store) upsertDatabaseLabelImpl(ctx context.Context, tx *Tx, upsert *api.DatabaseLabelUpsert) (*databaseLabelRaw, error) {
 	// Upsert row into db_label
 	query := `
 		INSERT INTO db_label (

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -660,6 +660,11 @@ type Tx struct {
 	now time.Time
 }
 
+func (tx *Tx) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	panic("sdfsfd")
+	// return tx.PTx.QueryRowContext(ctx, query, args...)
+}
+
 // FormatError returns err as a Bytebase error, if possible.
 // Otherwise returns the original error.
 func FormatError(err error) error {

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -647,7 +647,7 @@ func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 
 	// Return wrapper Tx that includes the transaction start time.
 	return &Tx{
-		PTx: ptx,
+		Tx:  ptx,
 		db:  db,
 		now: db.Now().UTC().Truncate(time.Second),
 	}, nil
@@ -655,14 +655,9 @@ func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 
 // Tx wraps the SQL Tx object to provide a timestamp at the start of the transaction.
 type Tx struct {
-	PTx *sql.Tx
+	*sql.Tx
 	db  *DB
 	now time.Time
-}
-
-func (tx *Tx) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	panic("sdfsfd")
-	// return tx.PTx.QueryRowContext(ctx, query, args...)
 }
 
 // FormatError returns err as a Bytebase error, if possible.

--- a/store/pipeline.go
+++ b/store/pipeline.go
@@ -172,14 +172,14 @@ func (s *Store) createPipelineRaw(ctx context.Context, create *api.PipelineCreat
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	pipeline, err := s.createPipelineImpl(ctx, tx.PTx, create)
+	pipeline, err := s.createPipelineImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -196,9 +196,9 @@ func (s *Store) findPipelineRaw(ctx context.Context, find *api.PipelineFind) ([]
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := s.findPipelineImpl(ctx, tx.PTx, find)
+	list, err := s.findPipelineImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -232,9 +232,9 @@ func (s *Store) getPipelineRaw(ctx context.Context, find *api.PipelineFind) (*pi
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	pipelineRawList, err := s.findPipelineImpl(ctx, tx.PTx, find)
+	pipelineRawList, err := s.findPipelineImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -257,14 +257,14 @@ func (s *Store) patchPipelineRaw(ctx context.Context, patch *api.PipelinePatch) 
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	pipelineRaw, err := s.patchPipelineImpl(ctx, tx.PTx, patch)
+	pipelineRaw, err := s.patchPipelineImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -276,7 +276,7 @@ func (s *Store) patchPipelineRaw(ctx context.Context, patch *api.PipelinePatch) 
 }
 
 // createPipelineImpl creates a new pipeline.
-func (*Store) createPipelineImpl(ctx context.Context, tx *sql.Tx, create *api.PipelineCreate) (*pipelineRaw, error) {
+func (*Store) createPipelineImpl(ctx context.Context, tx *Tx, create *api.PipelineCreate) (*pipelineRaw, error) {
 	query := `
 		INSERT INTO pipeline (
 			creator_id,
@@ -309,7 +309,7 @@ func (*Store) createPipelineImpl(ctx context.Context, tx *sql.Tx, create *api.Pi
 	return &pipelineRaw, nil
 }
 
-func (*Store) findPipelineImpl(ctx context.Context, tx *sql.Tx, find *api.PipelineFind) ([]*pipelineRaw, error) {
+func (*Store) findPipelineImpl(ctx context.Context, tx *Tx, find *api.PipelineFind) ([]*pipelineRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -363,7 +363,7 @@ func (*Store) findPipelineImpl(ctx context.Context, tx *sql.Tx, find *api.Pipeli
 }
 
 // patchPipelineImpl updates a pipeline by ID. Returns the new state of the pipeline after update.
-func (*Store) patchPipelineImpl(ctx context.Context, tx *sql.Tx, patch *api.PipelinePatch) (*pipelineRaw, error) {
+func (*Store) patchPipelineImpl(ctx context.Context, tx *Tx, patch *api.PipelinePatch) (*pipelineRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	if v := patch.Status; v != nil {

--- a/store/principal.go
+++ b/store/principal.go
@@ -142,14 +142,14 @@ func (s *Store) createPrincipalRaw(ctx context.Context, create *api.PrincipalCre
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	principal, err := createPrincipalImpl(ctx, tx.PTx, create)
+	principal, err := createPrincipalImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -166,9 +166,9 @@ func (s *Store) findPrincipalRawList(ctx context.Context) ([]*principalRaw, erro
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findPrincipalRawListImpl(ctx, tx.PTx, &api.PrincipalFind{})
+	list, err := findPrincipalRawListImpl(ctx, tx, &api.PrincipalFind{})
 	if err != nil {
 		return nil, err
 	}
@@ -200,9 +200,9 @@ func (s *Store) getPrincipalRaw(ctx context.Context, find *api.PrincipalFind) (*
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findPrincipalRawListImpl(ctx, tx.PTx, find)
+	list, err := findPrincipalRawListImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -226,14 +226,14 @@ func (s *Store) patchPrincipalRaw(ctx context.Context, patch *api.PrincipalPatch
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	principal, err := patchPrincipalImpl(ctx, tx.PTx, patch)
+	principal, err := patchPrincipalImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -270,7 +270,7 @@ func (s *Store) composePrincipal(ctx context.Context, raw *principalRaw) (*api.P
 }
 
 // createPrincipalImpl creates a new principal.
-func createPrincipalImpl(ctx context.Context, tx *sql.Tx, create *api.PrincipalCreate) (*principalRaw, error) {
+func createPrincipalImpl(ctx context.Context, tx *Tx, create *api.PrincipalCreate) (*principalRaw, error) {
 	// Insert row into database.
 	query := `
 		INSERT INTO principal (
@@ -311,7 +311,7 @@ func createPrincipalImpl(ctx context.Context, tx *sql.Tx, create *api.PrincipalC
 	return &principalRaw, nil
 }
 
-func findPrincipalRawListImpl(ctx context.Context, tx *sql.Tx, find *api.PrincipalFind) ([]*principalRaw, error) {
+func findPrincipalRawListImpl(ctx context.Context, tx *Tx, find *api.PrincipalFind) ([]*principalRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -369,7 +369,7 @@ func findPrincipalRawListImpl(ctx context.Context, tx *sql.Tx, find *api.Princip
 }
 
 // patchPrincipalImpl updates a principal by ID. Returns the new state of the principal after update.
-func patchPrincipalImpl(ctx context.Context, tx *sql.Tx, patch *api.PrincipalPatch) (*principalRaw, error) {
+func patchPrincipalImpl(ctx context.Context, tx *Tx, patch *api.PrincipalPatch) (*principalRaw, error) {
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	if v := patch.Name; v != nil {
 		set, args = append(set, fmt.Sprintf("name = $%d", len(args)+1)), append(args, *v)

--- a/store/project_webhook.go
+++ b/store/project_webhook.go
@@ -124,13 +124,13 @@ func (s *Store) DeleteProjectWebhook(ctx context.Context, delete *api.ProjectWeb
 	if err != nil {
 		return FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	if err := s.deleteProjectWebhookImpl(ctx, tx.PTx, delete); err != nil {
+	if err := s.deleteProjectWebhookImpl(ctx, tx, delete); err != nil {
 		return FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return FormatError(err)
 	}
 
@@ -165,14 +165,14 @@ func (s *Store) createProjectWebhookRaw(ctx context.Context, create *api.Project
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	projectWebhook, err := createProjectWebhookImpl(ctx, tx.PTx, create)
+	projectWebhook, err := createProjectWebhookImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -185,9 +185,9 @@ func (s *Store) findProjectWebhookRaw(ctx context.Context, find *api.ProjectWebh
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findProjectWebhookImpl(ctx, tx.PTx, find)
+	list, err := findProjectWebhookImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -202,9 +202,9 @@ func (s *Store) getProjectWebhookRaw(ctx context.Context, find *api.ProjectWebho
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findProjectWebhookImpl(ctx, tx.PTx, find)
+	list, err := findProjectWebhookImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -224,14 +224,14 @@ func (s *Store) patchProjectWebhookRaw(ctx context.Context, patch *api.ProjectWe
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	projectWebhook, err := patchProjectWebhookImpl(ctx, tx.PTx, patch)
+	projectWebhook, err := patchProjectWebhookImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -239,7 +239,7 @@ func (s *Store) patchProjectWebhookRaw(ctx context.Context, patch *api.ProjectWe
 }
 
 // createProjectWebhookImpl creates a new projectWebhook.
-func createProjectWebhookImpl(ctx context.Context, tx *sql.Tx, create *api.ProjectWebhookCreate) (*projectWebhookRaw, error) {
+func createProjectWebhookImpl(ctx context.Context, tx *Tx, create *api.ProjectWebhookCreate) (*projectWebhookRaw, error) {
 	// Insert row into database.
 	query := `
 		INSERT INTO project_webhook (
@@ -287,7 +287,7 @@ func createProjectWebhookImpl(ctx context.Context, tx *sql.Tx, create *api.Proje
 	return &projectWebhookRaw, nil
 }
 
-func findProjectWebhookImpl(ctx context.Context, tx *sql.Tx, find *api.ProjectWebhookFind) ([]*projectWebhookRaw, error) {
+func findProjectWebhookImpl(ctx context.Context, tx *Tx, find *api.ProjectWebhookFind) ([]*projectWebhookRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -362,7 +362,7 @@ func findProjectWebhookImpl(ctx context.Context, tx *sql.Tx, find *api.ProjectWe
 }
 
 // patchProjectWebhookImpl updates a projectWebhook by ID. Returns the new state of the projectWebhook after update.
-func patchProjectWebhookImpl(ctx context.Context, tx *sql.Tx, patch *api.ProjectWebhookPatch) (*projectWebhookRaw, error) {
+func patchProjectWebhookImpl(ctx context.Context, tx *Tx, patch *api.ProjectWebhookPatch) (*projectWebhookRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	if v := patch.Name; v != nil {
@@ -412,7 +412,7 @@ func patchProjectWebhookImpl(ctx context.Context, tx *sql.Tx, patch *api.Project
 }
 
 // deleteProjectWebhookImpl permanently deletes a projectWebhook by ID.
-func (*Store) deleteProjectWebhookImpl(ctx context.Context, tx *sql.Tx, delete *api.ProjectWebhookDelete) error {
+func (*Store) deleteProjectWebhookImpl(ctx context.Context, tx *Tx, delete *api.ProjectWebhookDelete) error {
 	// Remove row from database.
 	if _, err := tx.ExecContext(ctx, `DELETE FROM project_webhook WHERE id = $1`, delete.ID); err != nil {
 		return FormatError(err)

--- a/store/setting.go
+++ b/store/setting.go
@@ -128,14 +128,14 @@ func (s *Store) createSettingRawIfNotExist(ctx context.Context, create *api.Sett
 		if err != nil {
 			return nil, FormatError(err)
 		}
-		defer tx.PTx.Rollback()
+		defer tx.Rollback()
 
-		setting, err := createSettingImpl(ctx, tx.PTx, create)
+		setting, err := createSettingImpl(ctx, tx, create)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := tx.PTx.Commit(); err != nil {
+		if err := tx.Commit(); err != nil {
 			return nil, FormatError(err)
 		}
 
@@ -151,9 +151,9 @@ func (s *Store) findSettingRaw(ctx context.Context, find *api.SettingFind) ([]*s
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findSettingImpl(ctx, tx.PTx, find)
+	list, err := findSettingImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -167,9 +167,9 @@ func (s *Store) getSettingRaw(ctx context.Context, find *api.SettingFind) (*sett
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findSettingImpl(ctx, tx.PTx, find)
+	list, err := findSettingImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -189,14 +189,14 @@ func (s *Store) patchSettingRaw(ctx context.Context, patch *api.SettingPatch) (*
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	setting, err := patchSettingImpl(ctx, tx.PTx, patch)
+	setting, err := patchSettingImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -204,7 +204,7 @@ func (s *Store) patchSettingRaw(ctx context.Context, patch *api.SettingPatch) (*
 }
 
 // createSettingImpl creates a new setting.
-func createSettingImpl(ctx context.Context, tx *sql.Tx, create *api.SettingCreate) (*settingRaw, error) {
+func createSettingImpl(ctx context.Context, tx *Tx, create *api.SettingCreate) (*settingRaw, error) {
 	// Insert row into database.
 	query := `
 		INSERT INTO setting (
@@ -238,7 +238,7 @@ func createSettingImpl(ctx context.Context, tx *sql.Tx, create *api.SettingCreat
 	return &settingRaw, nil
 }
 
-func findSettingImpl(ctx context.Context, tx *sql.Tx, find *api.SettingFind) ([]*settingRaw, error) {
+func findSettingImpl(ctx context.Context, tx *Tx, find *api.SettingFind) ([]*settingRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.Name; v != nil {
@@ -289,7 +289,7 @@ func findSettingImpl(ctx context.Context, tx *sql.Tx, find *api.SettingFind) ([]
 }
 
 // patchSettingImpl updates a setting by name. Returns the new state of the setting after update.
-func patchSettingImpl(ctx context.Context, tx *sql.Tx, patch *api.SettingPatch) (*settingRaw, error) {
+func patchSettingImpl(ctx context.Context, tx *Tx, patch *api.SettingPatch) (*settingRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	set, args = append(set, "value = $2"), append(args, patch.Value)

--- a/store/sheet_organizer.go
+++ b/store/sheet_organizer.go
@@ -40,14 +40,14 @@ func (s *Store) UpsertSheetOrganizer(ctx context.Context, upsert *api.SheetOrgan
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	sheetOrganizerRaw, err := upsertSheetOrganizerImpl(ctx, tx.PTx, upsert)
+	sheetOrganizerRaw, err := upsertSheetOrganizerImpl(ctx, tx, upsert)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -62,9 +62,9 @@ func (s *Store) FindSheetOrganizer(ctx context.Context, find *api.SheetOrganizer
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	sheetOrganizerRawlist, err := findSheetOrganizerListImpl(ctx, tx.PTx, find)
+	sheetOrganizerRawlist, err := findSheetOrganizerListImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (s *Store) FindSheetOrganizer(ctx context.Context, find *api.SheetOrganizer
 	return sheetOrganizer, nil
 }
 
-func upsertSheetOrganizerImpl(ctx context.Context, tx *sql.Tx, upsert *api.SheetOrganizerUpsert) (*sheetOrganizerRaw, error) {
+func upsertSheetOrganizerImpl(ctx context.Context, tx *Tx, upsert *api.SheetOrganizerUpsert) (*sheetOrganizerRaw, error) {
 	query := `
 	  INSERT INTO sheet_organizer (
 			sheet_id,
@@ -115,7 +115,7 @@ func upsertSheetOrganizerImpl(ctx context.Context, tx *sql.Tx, upsert *api.Sheet
 	return &sheetOrganizerRaw, nil
 }
 
-func findSheetOrganizerListImpl(ctx context.Context, tx *sql.Tx, find *api.SheetOrganizerFind) ([]*sheetOrganizerRaw, error) {
+func findSheetOrganizerListImpl(ctx context.Context, tx *Tx, find *api.SheetOrganizerFind) ([]*sheetOrganizerRaw, error) {
 	where, args := []string{"1 = 1"}, []interface{}{}
 	where, args = append(where, fmt.Sprintf("sheet_id = $%d", len(args)+1)), append(args, find.SheetID)
 	where, args = append(where, fmt.Sprintf("principal_id = $%d", len(args)+1)), append(args, find.PrincipalID)

--- a/store/stage.go
+++ b/store/stage.go
@@ -151,14 +151,14 @@ func (s *Store) createStageRaw(ctx context.Context, create *api.StageCreate) (*s
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	stage, err := s.createStageImpl(ctx, tx.PTx, create)
+	stage, err := s.createStageImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -171,9 +171,9 @@ func (s *Store) findStageRaw(ctx context.Context, find *api.StageFind) ([]*stage
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	stageRawList, err := s.findStageImpl(ctx, tx.PTx, find)
+	stageRawList, err := s.findStageImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (s *Store) findStageRaw(ctx context.Context, find *api.StageFind) ([]*stage
 }
 
 // createStageImpl creates a new stage.
-func (*Store) createStageImpl(ctx context.Context, tx *sql.Tx, create *api.StageCreate) (*stageRaw, error) {
+func (*Store) createStageImpl(ctx context.Context, tx *Tx, create *api.StageCreate) (*stageRaw, error) {
 	query := `
 		INSERT INTO stage (
 			creator_id,
@@ -219,7 +219,7 @@ func (*Store) createStageImpl(ctx context.Context, tx *sql.Tx, create *api.Stage
 	return &stageRaw, nil
 }
 
-func (*Store) findStageImpl(ctx context.Context, tx *sql.Tx, find *api.StageFind) ([]*stageRaw, error) {
+func (*Store) findStageImpl(ctx context.Context, tx *Tx, find *api.StageFind) ([]*stageRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {

--- a/store/table_index.go
+++ b/store/table_index.go
@@ -18,9 +18,9 @@ func (s *Store) FindIndex(ctx context.Context, find *api.IndexFind) ([]*api.Inde
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := s.findIndexImpl(ctx, tx.PTx, find)
+	list, err := s.findIndexImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func generateIndexActions(oldIndexList []*api.Index, indexList []db.Index, datab
 }
 
 // createIndexImpl creates a new index.
-func (*Store) createIndexImpl(ctx context.Context, tx *sql.Tx, create *api.IndexCreate) (*api.Index, error) {
+func (*Store) createIndexImpl(ctx context.Context, tx *Tx, create *api.IndexCreate) (*api.Index, error) {
 	// Insert row into index.
 	query := `
 		INSERT INTO idx (
@@ -150,7 +150,7 @@ func (*Store) createIndexImpl(ctx context.Context, tx *sql.Tx, create *api.Index
 	return &index, nil
 }
 
-func (*Store) findIndexImpl(ctx context.Context, tx *sql.Tx, find *api.IndexFind) ([]*api.Index, error) {
+func (*Store) findIndexImpl(ctx context.Context, tx *Tx, find *api.IndexFind) ([]*api.Index, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {
@@ -230,7 +230,7 @@ func (*Store) findIndexImpl(ctx context.Context, tx *sql.Tx, find *api.IndexFind
 }
 
 // deleteIndexImpl deletes an index.
-func (*Store) deleteIndexImpl(ctx context.Context, tx *sql.Tx, delete *api.IndexDelete) error {
+func (*Store) deleteIndexImpl(ctx context.Context, tx *Tx, delete *api.IndexDelete) error {
 	if _, err := tx.ExecContext(ctx, `DELETE FROM idx WHERE id = $1`, delete.ID); err != nil {
 		return FormatError(err)
 	}

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -134,7 +134,7 @@ func (s *Store) createTaskCheckRunRawIfNeeded(ctx context.Context, create *api.T
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
 	statusList := []api.TaskCheckRunStatus{api.TaskCheckRunRunning}
 	if create.SkipIfAlreadyTerminated {
@@ -148,7 +148,7 @@ func (s *Store) createTaskCheckRunRawIfNeeded(ctx context.Context, create *api.T
 		StatusList: &statusList,
 	}
 
-	taskCheckRunList, err := s.findTaskCheckRunRawTx(ctx, tx.PTx, taskCheckRunFind)
+	taskCheckRunList, err := s.findTaskCheckRunRawTx(ctx, tx, taskCheckRunFind)
 	if err != nil {
 		return nil, err
 	}
@@ -178,12 +178,12 @@ func (s *Store) createTaskCheckRunRawIfNeeded(ctx context.Context, create *api.T
 		return taskCheckRunList[0], nil
 	}
 
-	taskCheckRun, err := s.createTaskCheckRunImpl(ctx, tx.PTx, create)
+	taskCheckRun, err := s.createTaskCheckRunImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -191,7 +191,7 @@ func (s *Store) createTaskCheckRunRawIfNeeded(ctx context.Context, create *api.T
 }
 
 // createTaskCheckRunImpl creates a new taskCheckRun.
-func (*Store) createTaskCheckRunImpl(ctx context.Context, tx *sql.Tx, create *api.TaskCheckRunCreate) (*taskCheckRunRaw, error) {
+func (*Store) createTaskCheckRunImpl(ctx context.Context, tx *Tx, create *api.TaskCheckRunCreate) (*taskCheckRunRaw, error) {
 	if create.Payload == "" {
 		create.Payload = "{}"
 	}
@@ -244,9 +244,9 @@ func (s *Store) findTaskCheckRunRaw(ctx context.Context, find *api.TaskCheckRunF
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := s.findTaskCheckRunImpl(ctx, tx.PTx, find)
+	list, err := s.findTaskCheckRunImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func (s *Store) findTaskCheckRunRaw(ctx context.Context, find *api.TaskCheckRunF
 }
 
 // findTaskCheckRunRawTx retrieves a list of taskCheckRuns based on find.
-func (s *Store) findTaskCheckRunRawTx(ctx context.Context, tx *sql.Tx, find *api.TaskCheckRunFind) ([]*taskCheckRunRaw, error) {
+func (s *Store) findTaskCheckRunRawTx(ctx context.Context, tx *Tx, find *api.TaskCheckRunFind) ([]*taskCheckRunRaw, error) {
 	list, err := s.findTaskCheckRunImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
@@ -270,14 +270,14 @@ func (s *Store) patchTaskCheckRunRawStatus(ctx context.Context, patch *api.TaskC
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	taskCheckRun, err := s.patchTaskCheckRunStatusImpl(ctx, tx.PTx, patch)
+	taskCheckRun, err := s.patchTaskCheckRunStatusImpl(ctx, tx, patch)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 
@@ -285,7 +285,7 @@ func (s *Store) patchTaskCheckRunRawStatus(ctx context.Context, patch *api.TaskC
 }
 
 // patchTaskCheckRunStatusImpl updates a taskCheckRun status. Returns the new state of the taskCheckRun after update.
-func (*Store) patchTaskCheckRunStatusImpl(ctx context.Context, tx *sql.Tx, patch *api.TaskCheckRunStatusPatch) (*taskCheckRunRaw, error) {
+func (*Store) patchTaskCheckRunStatusImpl(ctx context.Context, tx *Tx, patch *api.TaskCheckRunStatusPatch) (*taskCheckRunRaw, error) {
 	// Build UPDATE clause.
 	if patch.Result == "" {
 		patch.Result = "{}"
@@ -331,7 +331,7 @@ func (*Store) patchTaskCheckRunStatusImpl(ctx context.Context, tx *sql.Tx, patch
 	return &taskCheckRunRaw, nil
 }
 
-func (*Store) findTaskCheckRunImpl(ctx context.Context, tx *sql.Tx, find *api.TaskCheckRunFind) ([]*taskCheckRunRaw, error) {
+func (*Store) findTaskCheckRunImpl(ctx context.Context, tx *Tx, find *api.TaskCheckRunFind) ([]*taskCheckRunRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {

--- a/store/task_dag.go
+++ b/store/task_dag.go
@@ -74,13 +74,13 @@ func (s *Store) createTaskDAGRaw(ctx context.Context, create *api.TaskDAGCreate)
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	taskDAG, err := createTaskDAGImpl(ctx, tx.PTx, create)
+	taskDAG, err := createTaskDAGImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.PTx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, FormatError(err)
 	}
 	return taskDAG, nil
@@ -91,16 +91,16 @@ func (s *Store) findTaskDAGRawList(ctx context.Context, find *api.TaskDAGFind) (
 	if err != nil {
 		return nil, FormatError(err)
 	}
-	defer tx.PTx.Rollback()
+	defer tx.Rollback()
 
-	list, err := findTaskDAGRawListImpl(ctx, tx.PTx, find)
+	list, err := findTaskDAGRawListImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
 	}
 	return list, nil
 }
 
-func createTaskDAGImpl(ctx context.Context, tx *sql.Tx, create *api.TaskDAGCreate) (*taskDAGRaw, error) {
+func createTaskDAGImpl(ctx context.Context, tx *Tx, create *api.TaskDAGCreate) (*taskDAGRaw, error) {
 	query := `
 		INSERT INTO task_dag (
 			from_task_id,
@@ -131,7 +131,7 @@ func createTaskDAGImpl(ctx context.Context, tx *sql.Tx, create *api.TaskDAGCreat
 	return &taskDAGRaw, nil
 }
 
-func findTaskDAGRawListImpl(ctx context.Context, tx *sql.Tx, find *api.TaskDAGFind) ([]*taskDAGRaw, error) {
+func findTaskDAGRawListImpl(ctx context.Context, tx *Tx, find *api.TaskDAGFind) ([]*taskDAGRaw, error) {
 	rows, err := tx.QueryContext(ctx, `
 		SELECT
 			id,

--- a/store/task_run.go
+++ b/store/task_run.go
@@ -63,7 +63,7 @@ func (raw *taskRunRaw) toTaskRun() *api.TaskRun {
 }
 
 // createTaskRunImpl creates a new taskRun.
-func (*Store) createTaskRunImpl(ctx context.Context, tx *sql.Tx, create *api.TaskRunCreate) (*taskRunRaw, error) {
+func (*Store) createTaskRunImpl(ctx context.Context, tx *Tx, create *api.TaskRunCreate) (*taskRunRaw, error) {
 	if create.Payload == "" {
 		create.Payload = "{}"
 	}
@@ -113,7 +113,7 @@ func (*Store) createTaskRunImpl(ctx context.Context, tx *sql.Tx, create *api.Tas
 
 // getTaskRunRawTx retrieves a single taskRun based on find.
 // Returns ECONFLICT if finding more than 1 matching records.
-func (s *Store) getTaskRunRawTx(ctx context.Context, tx *sql.Tx, find *api.TaskRunFind) (*taskRunRaw, error) {
+func (s *Store) getTaskRunRawTx(ctx context.Context, tx *Tx, find *api.TaskRunFind) (*taskRunRaw, error) {
 	taskRunRawList, err := s.findTaskRunImpl(ctx, tx, find)
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func (s *Store) getTaskRunRawTx(ctx context.Context, tx *sql.Tx, find *api.TaskR
 }
 
 // patchTaskRunStatusImpl updates a taskRun status. Returns the new state of the taskRun after update.
-func (*Store) patchTaskRunStatusImpl(ctx context.Context, tx *sql.Tx, patch *api.TaskRunStatusPatch) (*taskRunRaw, error) {
+func (*Store) patchTaskRunStatusImpl(ctx context.Context, tx *Tx, patch *api.TaskRunStatusPatch) (*taskRunRaw, error) {
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	set, args = append(set, "status = $2"), append(args, patch.Status)
@@ -185,7 +185,7 @@ func (*Store) patchTaskRunStatusImpl(ctx context.Context, tx *sql.Tx, patch *api
 	return &taskRunRaw, nil
 }
 
-func (*Store) findTaskRunImpl(ctx context.Context, tx *sql.Tx, find *api.TaskRunFind) ([]*taskRunRaw, error) {
+func (*Store) findTaskRunImpl(ctx context.Context, tx *Tx, find *api.TaskRunFind) ([]*taskRunRaw, error) {
 	// Build WHERE clause.
 	where, args := []string{"1 = 1"}, []interface{}{}
 	if v := find.ID; v != nil {


### PR DESCRIPTION
This PR has no functional difference, this prepares a follow-up PR to hook in the SQL logging.