### PR TITLE
chore: always allow Codenotify to post comments

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -9,7 +9,6 @@ jobs:
       actions: read
       checks: write
       contents: read
-      id-token: read
       pull-requests: write
       statuses: write
     runs-on: ubuntu-latest

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -10,7 +10,6 @@ jobs:
       checks: write
       contents: read
       id-token: read
-      issues: write
       pull-requests: write
       statuses: write
     runs-on: ubuntu-latest

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   codenotify:
-    permissions: write-all
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      id-token: read
+      issues: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     name: Codenotify
     steps:

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   codenotify:
+    permissions: write-all
     runs-on: ubuntu-latest
     name: Codenotify
     steps:


### PR DESCRIPTION
By default, Codenotify can't post comments to a PR from forked repositories, thus we give the action minimum explicit permissions to be able to read repository files and post comments to pull requests.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions