### PR TITLE
chore: cache static assets

### DIFF
--- a/server/server_frontend_embed.go
+++ b/server/server_frontend_embed.go
@@ -15,8 +15,8 @@ import (
 //go:embed dist
 var embeddedFiles embed.FS
 
-func getFileSystem() http.FileSystem {
-	fs, err := fs.Sub(embeddedFiles, "dist")
+func getFileSystem(path string) http.FileSystem {
+	fs, err := fs.Sub(embeddedFiles, path)
 	if err != nil {
 		panic(err)
 	}
@@ -29,6 +29,18 @@ func embedFrontend(e *echo.Echo) {
 	// refer: https://github.com/labstack/echo/blob/master/middleware/static.go
 	e.Use(middleware.StaticWithConfig(middleware.StaticConfig{
 		HTML5:      true,
-		Filesystem: getFileSystem(),
+		Filesystem: getFileSystem("dist"),
+	}))
+
+	g := e.Group("assets")
+	g.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderCacheControl, "max-age=31536000, immutable")
+			return next(c)
+		}
+	})
+	g.Use(middleware.StaticWithConfig(middleware.StaticConfig{
+		HTML5:      true,
+		Filesystem: getFileSystem("dist/assets"),
 	}))
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12679343/187378254-0461d674-f5d3-4682-8cfa-1c9d91b6e1bc.png)

This can save some MBs of data transfering.


Close BYT-1274