### PR TITLE
fix: do not flush tables when dumping an empty database

### DIFF
--- a/plugin/db/mysql/dump.go
+++ b/plugin/db/mysql/dump.go
@@ -164,10 +164,12 @@ func FlushTablesWithReadLock(ctx context.Context, conn *sql.Conn, database strin
 		}
 		tableNames = append(tableNames, fmt.Sprintf("`%s`", table.Name))
 	}
-	flushTableStmt := fmt.Sprintf("FLUSH TABLES %s WITH READ LOCK;", strings.Join(tableNames, ", "))
 
-	if _, err := txn.ExecContext(ctxWithTimeout, flushTableStmt); err != nil {
-		return err
+	if len(tableNames) != 0 {
+		flushTableStmt := fmt.Sprintf("FLUSH TABLES %s WITH READ LOCK;", strings.Join(tableNames, ", "))
+		if _, err := txn.ExecContext(ctxWithTimeout, flushTableStmt); err != nil {
+			return err
+		}
 	}
 
 	return txn.Commit()


### PR DESCRIPTION
With an empty database, the SQL would be `FLUSH TABLES  WITH READ LOCK;` which requires a global lock and cannot be unlocked.

Thanks to @candy2255 for reporting this issue.