### PR TITLE
feat: get the binlog replay list with an end

### DIFF
--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -279,7 +279,7 @@ func GetBinlogReplayList(startBinlogInfo, targetBinlogInfo api.BinlogInfo, binlo
 		return nil, errors.Wrapf(err, "failed to read local binlog metadata files from directory %s", binlogDir)
 	}
 
-	metaToReplay, err := getBinlogMetaSlice(metaList, startBinlogSeq, targetBinlogSeq)
+	metaToReplay, err := getMetaReplayList(metaList, startBinlogSeq, targetBinlogSeq)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get slice of binlog metadata file between seq %d and %d in directory %s", startBinlogSeq, targetBinlogSeq, binlogDir)
 	}
@@ -296,7 +296,7 @@ func GetBinlogReplayList(startBinlogInfo, targetBinlogInfo api.BinlogInfo, binlo
 	return binlogReplayList, nil
 }
 
-func getBinlogMetaSlice(metaList []binlogFileMeta, startSeq, targetSeq int64) ([]binlogFileMeta, error) {
+func getMetaReplayList(metaList []binlogFileMeta, startSeq, targetSeq int64) ([]binlogFileMeta, error) {
 	startIndex, err := findBinlogSeqIndex(metaList, startSeq)
 	if err != nil {
 		return nil, errors.Errorf("failed to find the starting local binlog metadata file with seq %d", startSeq)

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -84,8 +84,9 @@ func (files ZapBinlogFiles) MarshalLogArray(arr zapcore.ArrayEncoder) error {
 }
 
 type binlogCoordinate struct {
-	Seq int64
-	Pos int64
+	Name string
+	Seq  int64
+	Pos  int64
 }
 
 func newBinlogCoordinate(binlogFileName string, pos int64) (binlogCoordinate, error) {
@@ -93,7 +94,7 @@ func newBinlogCoordinate(binlogFileName string, pos int64) (binlogCoordinate, er
 	if err != nil {
 		return binlogCoordinate{}, err
 	}
-	return binlogCoordinate{Seq: seq, Pos: pos}, nil
+	return binlogCoordinate{Name: binlogFileName, Seq: seq, Pos: pos}, nil
 }
 
 type binlogFileMeta struct {
@@ -125,9 +126,9 @@ func readBinlogMetaFile(binlogDir, fileName string) (binlogFileMeta, error) {
 }
 
 // replayBinlogFromDir replays the binlog for `originDatabase` from `startBinlogInfo.Position` to `targetTs`, read binlog from `binlogDir`.
-func (driver *Driver) replayBinlogFromDir(ctx context.Context, originalDatabase, targetDatabase string, startBinlogInfo api.BinlogInfo, targetTs int64, binlogDir string) error {
+func (driver *Driver) replayBinlogFromDir(ctx context.Context, originalDatabase, targetDatabase string, startBinlogInfo, targetBinlogInfo api.BinlogInfo, targetTs int64, binlogDir string) error {
 	// TODO(dragonly): find the last binlog file need to replay.
-	replayBinlogPaths, err := GetBinlogReplayList(startBinlogInfo, binlogDir)
+	replayBinlogPaths, err := GetBinlogReplayList(startBinlogInfo, targetBinlogInfo, binlogDir)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get binlog replay list in directory %s", binlogDir)
 	}
@@ -229,15 +230,15 @@ func (driver *Driver) GetReplayedBinlogBytes() int64 {
 }
 
 // ReplayBinlogToDatabase replays the binlog of originDatabaseName to the targetDatabaseName.
-func (driver *Driver) ReplayBinlogToDatabase(ctx context.Context, originDatabaseName, targetDatabaseName string, startBinlogInfo api.BinlogInfo, targetTs int64, binlogDir string) error {
-	return driver.replayBinlogFromDir(ctx, originDatabaseName, targetDatabaseName, startBinlogInfo, targetTs, binlogDir)
+func (driver *Driver) ReplayBinlogToDatabase(ctx context.Context, originDatabaseName, targetDatabaseName string, startBinlogInfo, targetBinlogInfo api.BinlogInfo, targetTs int64, binlogDir string) error {
+	return driver.replayBinlogFromDir(ctx, originDatabaseName, targetDatabaseName, startBinlogInfo, targetBinlogInfo, targetTs, binlogDir)
 }
 
 // ReplayBinlogToPITRDatabase replays binlog to the PITR database.
 // It's the second step of the PITR process.
-func (driver *Driver) ReplayBinlogToPITRDatabase(ctx context.Context, databaseName string, startBinlogInfo api.BinlogInfo, suffixTs, targetTs int64) error {
+func (driver *Driver) ReplayBinlogToPITRDatabase(ctx context.Context, databaseName string, startBinlogInfo, targetBinlogInfo api.BinlogInfo, suffixTs, targetTs int64) error {
 	pitrDatabaseName := util.GetPITRDatabaseName(databaseName, suffixTs)
-	return driver.replayBinlogFromDir(ctx, databaseName, pitrDatabaseName, startBinlogInfo, targetTs, driver.binlogDir)
+	return driver.replayBinlogFromDir(ctx, databaseName, pitrDatabaseName, startBinlogInfo, targetBinlogInfo, targetTs, driver.binlogDir)
 }
 
 // RestoreBackupToDatabase create the database named `databaseName` and restores a full backup to the given database.
@@ -263,10 +264,14 @@ func (driver *Driver) RestoreBackupToPITRDatabase(ctx context.Context, backup io
 }
 
 // GetBinlogReplayList returns the path list of the binlog that need be replayed.
-func GetBinlogReplayList(startBinlogInfo api.BinlogInfo, binlogDir string) ([]string, error) {
+func GetBinlogReplayList(startBinlogInfo, targetBinlogInfo api.BinlogInfo, binlogDir string) ([]string, error) {
 	startBinlogSeq, err := GetBinlogNameSeq(startBinlogInfo.FileName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot parse the start binlog file name %q", startBinlogInfo.FileName)
+	}
+	targetBinlogSeq, err := GetBinlogNameSeq(targetBinlogInfo.FileName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot parse the target binlog file name %q", targetBinlogInfo.FileName)
 	}
 
 	metaList, err := getSortedLocalBinlogFilesMeta(binlogDir)
@@ -274,26 +279,18 @@ func GetBinlogReplayList(startBinlogInfo api.BinlogInfo, binlogDir string) ([]st
 		return nil, errors.Wrapf(err, "failed to read local binlog metadata files from directory %s", binlogDir)
 	}
 
-	startIndex := -1
-	for i, meta := range metaList {
-		if meta.seq >= startBinlogSeq {
-			startIndex = i
-			break
-		}
+	startIndex, err := findBinlogSeqIndex(metaList, startBinlogSeq)
+	if err != nil {
+		return nil, errors.Errorf("failed to find the starting local binlog metadata file %s", startBinlogInfo.FileName)
 	}
-	if startIndex == -1 {
-		log.Error("No binlog files found locally after given start binlog info", zap.Any("startBinlogInfo", startBinlogInfo))
-		return nil, errors.Errorf("no binlog files found locally after given start binlog info: %v", startBinlogInfo)
+	targetIndex, err := findBinlogSeqIndex(metaList, targetBinlogSeq)
+	if err != nil {
+		return nil, errors.Errorf("failed to find the target local binlog metadata file %s", targetBinlogInfo.FileName)
 	}
 
-	metaToReplay := metaList[startIndex:]
-	if metaToReplay[0].seq != startBinlogSeq {
-		log.Error("The starting binlog file does not exist locally", zap.String("filename", startBinlogInfo.FileName))
-		return nil, errors.Errorf("the starting binlog file %q does not exist locally", startBinlogInfo.FileName)
-	}
-
+	metaToReplay := metaList[startIndex : targetIndex+1]
 	if !binlogMetaAreContinuous(metaToReplay) {
-		return nil, errors.Errorf("discontinuous binlog file extensions detected, skip ")
+		return nil, errors.Errorf("discontinuous binlog file extensions detected between seq %d and %d in directory %s", startBinlogSeq, targetBinlogSeq, binlogDir)
 	}
 
 	var binlogReplayList []string
@@ -302,6 +299,15 @@ func GetBinlogReplayList(startBinlogInfo api.BinlogInfo, binlogDir string) ([]st
 	}
 
 	return binlogReplayList, nil
+}
+
+func findBinlogSeqIndex(metaList []binlogFileMeta, seq int64) (int, error) {
+	for i, meta := range metaList {
+		if meta.seq == seq {
+			return i, nil
+		}
+	}
+	return 0, errors.Errorf("failed to find index with seq %d in binlog metadata list", seq)
 }
 
 // sortBinlogFiles will sort binlog files in ascending order by their numeric extension.
@@ -318,15 +324,15 @@ func sortBinlogFiles(binlogFiles []BinlogFile) []BinlogFile {
 
 // GetLatestBackupBeforeOrEqualTs finds the latest logical backup and corresponding binlog info whose time is before or equal to `targetTs`.
 // The backupList should only contain DONE backups.
-func (driver *Driver) GetLatestBackupBeforeOrEqualTs(ctx context.Context, backupList []*api.Backup, targetTs int64) (*api.Backup, error) {
+func (driver *Driver) GetLatestBackupBeforeOrEqualTs(ctx context.Context, backupList []*api.Backup, targetTs int64) (*api.Backup, *api.BinlogInfo, error) {
 	if len(backupList) == 0 {
-		return nil, errors.Errorf("no valid backup")
+		return nil, nil, errors.Errorf("no valid backup")
 	}
 
 	targetBinlogCoordinate, err := driver.getBinlogCoordinateByTs(ctx, targetTs)
 	if err != nil {
 		log.Error("Failed to get binlog coordinate by targetTs", zap.Int64("targetTs", targetTs), zap.Error(err))
-		return nil, errors.Wrapf(err, "failed to get binlog coordinate by targetTs %d", targetTs)
+		return nil, nil, errors.Wrapf(err, "failed to get binlog coordinate by targetTs %d", targetTs)
 	}
 	log.Debug("Got binlog coordinate by targetTs", zap.Int64("targetTs", targetTs), zap.Any("binlogCoordinate", *targetBinlogCoordinate))
 
@@ -341,10 +347,14 @@ func (driver *Driver) GetLatestBackupBeforeOrEqualTs(ctx context.Context, backup
 
 	backup, err := getLatestBackupBeforeOrEqualBinlogCoord(validBackupList, *targetBinlogCoordinate)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get the latest backup before or equal to binlog coordinate %+v", *targetBinlogCoordinate)
+		return nil, nil, errors.Wrapf(err, "failed to get the latest backup before or equal to binlog coordinate %+v", *targetBinlogCoordinate)
+	}
+	targetBinlogInfo := &api.BinlogInfo{
+		FileName: targetBinlogCoordinate.Name,
+		Position: targetBinlogCoordinate.Pos,
 	}
 
-	return backup, nil
+	return backup, targetBinlogInfo, nil
 }
 
 func getLatestBackupBeforeOrEqualBinlogCoord(backupList []*api.Backup, targetBinlogCoordinate binlogCoordinate) (*api.Backup, error) {

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -882,11 +882,11 @@ func (driver *Driver) getBinlogCoordinateByTs(ctx context.Context, targetTs int6
 			if isLastBinlogFile {
 				return nil, errors.Errorf("the targetTs %d is after the last event ts of the latest binlog file %q", targetTs, targetMeta.binlogName)
 			}
-			return &binlogCoordinate{Seq: targetMeta.seq, Pos: math.MaxInt64}, nil
+			return &binlogCoordinate{Name: targetMeta.binlogName, Seq: targetMeta.seq, Pos: math.MaxInt64}, nil
 		}
 		return nil, errors.Wrapf(err, "failed to find the binlog event after targetTs %d", targetTs)
 	}
-	return &binlogCoordinate{Seq: targetMeta.seq, Pos: eventPos}, nil
+	return &binlogCoordinate{Name: targetMeta.binlogName, Seq: targetMeta.seq, Pos: eventPos}, nil
 }
 
 func parseBinlogEventTsInLine(line string) (eventTs int64, found bool, err error) {

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -305,6 +305,9 @@ func getMetaReplayList(metaList []binlogFileMeta, startSeq, targetSeq int64) ([]
 	if err != nil {
 		return nil, errors.Errorf("failed to find the target local binlog metadata file with seq %d", targetSeq)
 	}
+	if startIndex > targetIndex {
+		return nil, errors.Errorf("start index %d must be less than target index %d", startIndex, targetIndex)
+	}
 	return metaList[startIndex : targetIndex+1], nil
 }
 

--- a/plugin/db/mysql/restore_test.go
+++ b/plugin/db/mysql/restore_test.go
@@ -270,7 +270,7 @@ func TestGetReplayBinlogPathList(t *testing.T) {
 	}
 }
 
-func TestGetBinlogMetaSlice(t *testing.T) {
+func TestGetMetaReplayList(t *testing.T) {
 	a := require.New(t)
 	tests := []struct {
 		metaList  []binlogFileMeta

--- a/plugin/db/mysql/restore_test.go
+++ b/plugin/db/mysql/restore_test.go
@@ -270,6 +270,56 @@ func TestGetReplayBinlogPathList(t *testing.T) {
 	}
 }
 
+func TestGetBinlogMetaSlice(t *testing.T) {
+	a := require.New(t)
+	tests := []struct {
+		metaList  []binlogFileMeta
+		startSeq  int64
+		targetSeq int64
+		expect    []binlogFileMeta
+		err       bool
+	}{
+		{
+			metaList:  []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
+			startSeq:  1,
+			targetSeq: 3,
+			expect:    []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
+			err:       false,
+		},
+		{
+			metaList:  []binlogFileMeta{{seq: 1}, {seq: 3}},
+			startSeq:  1,
+			targetSeq: 3,
+			expect:    []binlogFileMeta{{seq: 1}, {seq: 3}},
+			err:       false,
+		},
+		{
+			metaList:  []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
+			startSeq:  1,
+			targetSeq: 4,
+			expect:    nil,
+			err:       true,
+		},
+		{
+			metaList:  []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
+			startSeq:  0,
+			targetSeq: 3,
+			expect:    nil,
+			err:       true,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := getBinlogMetaSlice(test.metaList, test.startSeq, test.targetSeq)
+		if test.err {
+			a.Error(err)
+		} else {
+			a.NoError(err)
+			a.Equal(test.expect, result)
+		}
+	}
+}
+
 func TestSortBinlogFiles(t *testing.T) {
 	a := require.New(t)
 	tests := []struct {

--- a/plugin/db/mysql/restore_test.go
+++ b/plugin/db/mysql/restore_test.go
@@ -296,6 +296,13 @@ func TestGetBinlogMetaSlice(t *testing.T) {
 		{
 			metaList:  []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
 			startSeq:  1,
+			targetSeq: 1,
+			expect:    []binlogFileMeta{{seq: 1}},
+			err:       false,
+		},
+		{
+			metaList:  []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
+			startSeq:  1,
 			targetSeq: 4,
 			expect:    nil,
 			err:       true,
@@ -310,7 +317,7 @@ func TestGetBinlogMetaSlice(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result, err := getBinlogMetaSlice(test.metaList, test.startSeq, test.targetSeq)
+		result, err := getMetaReplayList(test.metaList, test.startSeq, test.targetSeq)
 		if test.err {
 			a.Error(err)
 		} else {

--- a/plugin/db/mysql/restore_test.go
+++ b/plugin/db/mysql/restore_test.go
@@ -179,50 +179,67 @@ func TestGetBinlogFileNameSeqNumber(t *testing.T) {
 func TestGetReplayBinlogPathList(t *testing.T) {
 	a := require.New(t)
 	tests := []struct {
-		binlogFileNames []string
-		startBinlogInfo api.BinlogInfo
-		expect          []string
-		err             bool
+		binlogFileNames  []string
+		startBinlogInfo  api.BinlogInfo
+		targetBinlogInfo api.BinlogInfo
+		expect           []string
+		err              bool
 	}{
 		{
-			// Test skip stale binlog
-			binlogFileNames: []string{"binlog.000001", "binlog.000002", "binlog.000003"},
-			startBinlogInfo: api.BinlogInfo{
-				FileName: "binlog.000002",
-				Position: 0xdeadbeaf,
-			},
-			expect: []string{"binlog.000002", "binlog.000003"},
-			err:    false,
+			// skip stale binlog
+			binlogFileNames:  []string{"binlog.000001", "binlog.000002", "binlog.000003"},
+			startBinlogInfo:  api.BinlogInfo{FileName: "binlog.000002"},
+			targetBinlogInfo: api.BinlogInfo{FileName: "binlog.000002"},
+			expect:           []string{"binlog.000002"},
+			err:              false,
 		},
 		{
-			// Test binlog files no hole
-			binlogFileNames: []string{"binlog.000001", "binlog.000002", "binlog.000004"},
-			startBinlogInfo: api.BinlogInfo{
-				FileName: "binlog.000002",
-				Position: 0xdeadbeaf,
-			},
-			expect: []string{},
-			err:    true,
+			// binlog files not continuous
+			binlogFileNames:  []string{"binlog.000001", "binlog.000002", "binlog.000004"},
+			startBinlogInfo:  api.BinlogInfo{FileName: "binlog.000002"},
+			targetBinlogInfo: api.BinlogInfo{FileName: "binlog.000004"},
+			expect:           nil,
+			err:              true,
 		},
 		{
-			// Test mysql-bin prefix
-			binlogFileNames: []string{"mysql-bin.000001", "mysql-bin.000002", "mysql-bin.000003"},
-			startBinlogInfo: api.BinlogInfo{
-				FileName: "bin.000001",
-				Position: 0xdeadbeaf,
-			},
-			expect: []string{"mysql-bin.000001", "mysql-bin.000002", "mysql-bin.000003"},
-			err:    false,
+			// binlog files not continuous, but replayed list is continuous
+			binlogFileNames:  []string{"binlog.000001", "binlog.000002", "binlog.000004"},
+			startBinlogInfo:  api.BinlogInfo{FileName: "binlog.000001"},
+			targetBinlogInfo: api.BinlogInfo{FileName: "binlog.000002"},
+			expect:           []string{"binlog.000001", "binlog.000002"},
+			err:              false,
 		},
 		{
-			// Test out of binlog.999999
-			binlogFileNames: []string{"binlog.999999", "binlog.1000000", "binlog.1000001"},
-			startBinlogInfo: api.BinlogInfo{
-				FileName: "binlog.999999",
-				Position: 0xdeadbeaf,
-			},
-			expect: []string{"binlog.999999", "binlog.1000000", "binlog.1000001"},
-			err:    false,
+			// mysql-bin prefix
+			binlogFileNames:  []string{"mysql-bin.000001", "mysql-bin.000002", "mysql-bin.000003"},
+			startBinlogInfo:  api.BinlogInfo{FileName: "mysql-bin.000001"},
+			targetBinlogInfo: api.BinlogInfo{FileName: "mysql-bin.000002"},
+			expect:           []string{"mysql-bin.000001", "mysql-bin.000002"},
+			err:              false,
+		},
+		{
+			// out of binlog.999999
+			binlogFileNames:  []string{"binlog.999999", "binlog.1000000", "binlog.1000001"},
+			startBinlogInfo:  api.BinlogInfo{FileName: "binlog.999999"},
+			targetBinlogInfo: api.BinlogInfo{FileName: "binlog.1000001"},
+			expect:           []string{"binlog.999999", "binlog.1000000", "binlog.1000001"},
+			err:              false,
+		},
+		{
+			// start seq not exist
+			binlogFileNames:  []string{"binlog.000001", "binlog.000003", "binlog.000004"},
+			startBinlogInfo:  api.BinlogInfo{FileName: "binlog.000002"},
+			targetBinlogInfo: api.BinlogInfo{FileName: "binlog.000003"},
+			expect:           nil,
+			err:              true,
+		},
+		{
+			// target seq not exist
+			binlogFileNames:  []string{"binlog.000001", "binlog.000003", "binlog.000004"},
+			startBinlogInfo:  api.BinlogInfo{FileName: "binlog.000001"},
+			targetBinlogInfo: api.BinlogInfo{FileName: "binlog.000002"},
+			expect:           nil,
+			err:              true,
 		},
 	}
 
@@ -240,7 +257,7 @@ func TestGetReplayBinlogPathList(t *testing.T) {
 			a.NoError(err)
 		}
 
-		result, err := GetBinlogReplayList(test.startBinlogInfo, tmpDir)
+		result, err := GetBinlogReplayList(test.startBinlogInfo, test.targetBinlogInfo, tmpDir)
 		if test.err {
 			a.Error(err)
 		} else {

--- a/plugin/db/mysql/restore_test.go
+++ b/plugin/db/mysql/restore_test.go
@@ -302,6 +302,13 @@ func TestGetBinlogMetaSlice(t *testing.T) {
 		},
 		{
 			metaList:  []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
+			startSeq:  3,
+			targetSeq: 1,
+			expect:    nil,
+			err:       true,
+		},
+		{
+			metaList:  []binlogFileMeta{{seq: 1}, {seq: 2}, {seq: 3}},
 			startSeq:  1,
 			targetSeq: 4,
 			expect:    nil,
@@ -318,11 +325,11 @@ func TestGetBinlogMetaSlice(t *testing.T) {
 
 	for _, test := range tests {
 		result, err := getMetaReplayList(test.metaList, test.startSeq, test.targetSeq)
+		a.Equal(test.expect, result)
 		if test.err {
 			a.Error(err)
 		} else {
 			a.NoError(err)
-			a.Equal(test.expect, result)
 		}
 	}
 }

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -221,7 +221,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *
 
 	targetTs := *payload.PointInTimeTs
 	log.Debug("Getting latest backup before or equal to targetTs", zap.Int64("targetTs", targetTs))
-	backup, err := mysqlSourceDriver.GetLatestBackupBeforeOrEqualTs(ctx, backupList, targetTs)
+	backup, targetBinlogInfo, err := mysqlSourceDriver.GetLatestBackupBeforeOrEqualTs(ctx, backupList, targetTs)
 	if err != nil {
 		targetTsHuman := time.Unix(targetTs, 0).Format(time.RFC822)
 		log.Error("Failed to get backup before or equal to time",
@@ -249,7 +249,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *
 	startBinlogInfo := backup.Payload.BinlogInfo
 	binlogDir := getBinlogAbsDir(server.profile.DataDir, task.Instance.ID)
 
-	if err := exec.updateProgress(ctx, mysqlTargetDriver, backupFile, startBinlogInfo, binlogDir); err != nil {
+	if err := exec.updateProgress(ctx, mysqlTargetDriver, backupFile, startBinlogInfo, *targetBinlogInfo, binlogDir); err != nil {
 		return nil, errors.Wrap(err, "failed to setup progress update process")
 	}
 
@@ -261,7 +261,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *
 				zap.Error(err))
 			return nil, errors.Wrap(err, "failed to restore full backup in the new database")
 		}
-		if err := mysqlTargetDriver.ReplayBinlogToDatabase(ctx, task.Database.Name, *payload.DatabaseName, startBinlogInfo, targetTs, mysqlSourceDriver.GetBinlogDir()); err != nil {
+		if err := mysqlTargetDriver.ReplayBinlogToDatabase(ctx, task.Database.Name, *payload.DatabaseName, startBinlogInfo, *targetBinlogInfo, targetTs, mysqlSourceDriver.GetBinlogDir()); err != nil {
 			log.Error("failed to perform a PITR restore in the new database",
 				zap.Int("issueID", issue.ID),
 				zap.String("databaseName", *payload.DatabaseName),
@@ -276,7 +276,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *
 				zap.Error(err))
 			return nil, errors.Wrap(err, "failed to perform a backup restore in the PITR database")
 		}
-		if err := mysqlTargetDriver.ReplayBinlogToPITRDatabase(ctx, task.Database.Name, startBinlogInfo, issue.CreatedTs, targetTs); err != nil {
+		if err := mysqlTargetDriver.ReplayBinlogToPITRDatabase(ctx, task.Database.Name, startBinlogInfo, *targetBinlogInfo, issue.CreatedTs, targetTs); err != nil {
 			log.Error("failed to perform a PITR restore in the PITR database",
 				zap.Int("issueID", issue.ID),
 				zap.String("databaseName", task.Database.Name),
@@ -356,15 +356,15 @@ func (*PITRRestoreTaskExecutor) doRestoreInPlacePostgres(ctx context.Context, se
 	}, nil
 }
 
-func (exec *PITRRestoreTaskExecutor) updateProgress(ctx context.Context, driver *mysql.Driver, backupFile *os.File, startBinlogInfo api.BinlogInfo, binlogDir string) error {
+func (exec *PITRRestoreTaskExecutor) updateProgress(ctx context.Context, driver *mysql.Driver, backupFile *os.File, startBinlogInfo, targetBinlogInfo api.BinlogInfo, binlogDir string) error {
 	backupFileInfo, err := backupFile.Stat()
 	if err != nil {
 		return errors.Wrapf(err, "failed to get stat of backup file %q", backupFile.Name())
 	}
 	backupFileBytes := backupFileInfo.Size()
-	replayBinlogPaths, err := mysql.GetBinlogReplayList(startBinlogInfo, binlogDir)
+	replayBinlogPaths, err := mysql.GetBinlogReplayList(startBinlogInfo, targetBinlogInfo, binlogDir)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get binlog replay list with startBinlogInfo %+v in binlog directory %q", startBinlogInfo, binlogDir)
+		return errors.Wrapf(err, "failed to get binlog replay list from %s to %s in binlog directory %q", startBinlogInfo.FileName, targetBinlogInfo.FileName, binlogDir)
 	}
 	totalBinlogBytes, err := common.GetFileSizeSum(replayBinlogPaths)
 	if err != nil {


### PR DESCRIPTION
This enables us to download as fewer binlog files as possible when replaying binlog from the cloud storage.
It also makes the progress estimation more accurate.