### PR TITLE
feat(schemadiff): support compute schema diff and generate DDLs

### DIFF
--- a/plugin/parser/schemadiff.go
+++ b/plugin/parser/schemadiff.go
@@ -1,0 +1,72 @@
+package parser
+
+import (
+	"bytes"
+
+	"github.com/bytebase/bytebase/plugin/parser/ast"
+)
+
+// SchemaDiff represents the schema diff between old and new schema.
+type SchemaDiff struct {
+	// Diffs is an ordered list of diffs for schema changes.
+	Diffs []Diff
+}
+
+// Diff represents a schema change of tables, columns and constraints.
+type Diff interface {
+	// String returns the DDL to create the schema change.
+	String() string
+}
+
+// CreateTableDiff represents a schema change of a new table.
+type CreateTableDiff struct {
+	// Name is the name of the new table.
+	Name string
+	// Text is the original DDL of the new table.
+	Text string
+}
+
+// String returns the DDL to create the new table.
+func (d *CreateTableDiff) String() string {
+	return d.Text
+}
+
+// String returns the migration scripts for the schema diff.
+func (d *SchemaDiff) String() string {
+	var buf bytes.Buffer
+	for _, diff := range d.Diffs {
+		_, _ = buf.WriteString(diff.String())
+		_, _ = buf.WriteString("\n")
+	}
+	return buf.String()
+}
+
+// ComputeDiff computes the schema differences between old and new schema.
+func ComputeDiff(old, new []ast.Node) (*SchemaDiff, error) {
+	oldTables := make(map[string]*ast.CreateTableStmt)
+	for _, node := range old {
+		if n, ok := node.(*ast.CreateTableStmt); ok {
+			oldTables[n.Name.Name] = n
+		}
+	}
+
+	var diffs []Diff
+	for _, node := range new {
+		if newTable, ok := node.(*ast.CreateTableStmt); ok {
+			_, hasTable := oldTables[newTable.Name.Name]
+			if !hasTable {
+				diffs = append(diffs,
+					&CreateTableDiff{
+						Name: newTable.Name.Name,
+						Text: newTable.Text(),
+					},
+				)
+				continue
+			}
+		}
+	}
+
+	return &SchemaDiff{
+		Diffs: diffs,
+	}, nil
+}

--- a/plugin/parser/schemadiff_test.go
+++ b/plugin/parser/schemadiff_test.go
@@ -1,0 +1,45 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/plugin/parser"
+	// Register PostgreSQL parser engine.
+	_ "github.com/bytebase/bytebase/plugin/parser/engine/pg"
+)
+
+func TestComputeDiff(t *testing.T) {
+	oldSchema, err := parser.Parse(parser.Postgres, parser.ParseContext{}, `
+CREATE TABLE projects ();
+`)
+	require.NoError(t, err)
+	newSchema, err := parser.Parse(parser.Postgres, parser.ParseContext{}, `
+CREATE TABLE users (
+	id serial PRIMARY KEY,
+	username TEXT NOT NULL
+);
+CREATE TABLE projects ();
+CREATE TABLE repositories (
+	id serial PRIMARY KEY
+);
+`)
+	require.NoError(t, err)
+
+	diff, err := parser.ComputeDiff(oldSchema, newSchema)
+	require.NoError(t, err)
+	got := diff.String()
+
+	// The DDLs for the diff should be in the exact same order as the DDLs in the new schema.
+	want := `CREATE TABLE users (
+	id serial PRIMARY KEY,
+	username TEXT NOT NULL
+);
+CREATE TABLE repositories (
+	id serial PRIMARY KEY
+);
+`
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
This PR adds a basic schema diff functionality that supports detecting new tables in the new schema and generating DDLs later to be used as migration scripts.

---

Part of https://linear.app/bbteam/issue/BYT-1262/sbm-handle-webhook-event-for-schema-file-change