### PR TITLE
feat: allow postgres:// scheme for --pg

### DIFF
--- a/bin/bb/cmd/var.go
+++ b/bin/bb/cmd/var.go
@@ -8,11 +8,12 @@ DSN format:
 
 Drivers:
   mysql
-  postgresql
+  postgres or postgresql
 
 Examples:
   mysql://root@localhost:3306/
   mysql://user:pass@localhost:3306/dbname
+  postgres://$(whoami)@localhost:5432/postgres
   postgresql://$(whoami)@localhost:5432/postgres
   postgresql://user:pass@localhost:5432/dbname?ssl-key=a&ssl-ca=b&ssl-cert=c
 `

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -92,7 +92,10 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 
 	log.Info("Establishing external PostgreSQL connection...", zap.String("pgURL", u.Redacted()))
 
-	if u.Scheme != "postgresql" {
+	// Though the official libpq adopts postgresql:// (https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+	// Several popular services such as render.com, supabase use postgres://.
+	// So we allow both schemes. The underlying pgx driver also supports both format.
+	if u.Scheme != "postgresql" && u.Scheme != "postgres" {
 		return nil, errors.Errorf("invalid connection protocol: %s", u.Scheme)
 	}
 


### PR DESCRIPTION
Several popular services such as render.com, supabase use postgres://.