### PR TITLE
fix: only block DDL/SELECT/EXPLAIN statement in CHANGE DATA

### DIFF
--- a/plugin/parser/ast/alter_table_stmt.go
+++ b/plugin/parser/ast/alter_table_stmt.go
@@ -2,7 +2,7 @@ package ast
 
 // AlterTableStmt is the struct for alter table or view statement.
 type AlterTableStmt struct {
-	node
+	ddl
 
 	Table         *TableDef
 	AlterItemList []Node

--- a/plugin/parser/ast/create_index_stmt.go
+++ b/plugin/parser/ast/create_index_stmt.go
@@ -2,7 +2,7 @@ package ast
 
 // CreateIndexStmt is the struct for create index statement.
 type CreateIndexStmt struct {
-	node
+	ddl
 
 	Index *IndexDef
 }

--- a/plugin/parser/ast/create_table_stmt.go
+++ b/plugin/parser/ast/create_table_stmt.go
@@ -2,7 +2,7 @@ package ast
 
 // CreateTableStmt is the strcut for create table stmt.
 type CreateTableStmt struct {
-	node
+	ddl
 
 	IfNotExists    bool
 	Name           *TableDef

--- a/plugin/parser/ast/ddl_node.go
+++ b/plugin/parser/ast/ddl_node.go
@@ -1,0 +1,18 @@
+package ast
+
+var (
+	_ DDLNode = (*ddl)(nil)
+)
+
+// DDLNode is the interface for DDL.
+type DDLNode interface {
+	Node
+
+	ddlNode()
+}
+
+type ddl struct {
+	node
+}
+
+func (*ddl) ddlNode() {}

--- a/plugin/parser/ast/drop_database_stmt.go
+++ b/plugin/parser/ast/drop_database_stmt.go
@@ -2,7 +2,7 @@ package ast
 
 // DropDatabaseStmt is the struct for drop database statement.
 type DropDatabaseStmt struct {
-	node
+	ddl
 
 	DatabaseName string
 	IfExists     bool

--- a/plugin/parser/ast/drop_index_stmt.go
+++ b/plugin/parser/ast/drop_index_stmt.go
@@ -2,7 +2,7 @@ package ast
 
 // DropIndexStmt is the struct for drop index statement.
 type DropIndexStmt struct {
-	node
+	ddl
 
 	// Here use IndexDef because the drop index statement needs the schema name for PostgreSQL.
 	// If the drop index statement doesn't contain schema name, the Table of this index is nil.

--- a/plugin/parser/ast/drop_table_stmt.go
+++ b/plugin/parser/ast/drop_table_stmt.go
@@ -2,7 +2,7 @@ package ast
 
 // DropTableStmt is the struct for drop table or view statement.
 type DropTableStmt struct {
-	node
+	ddl
 
 	TableList []*TableDef
 }

--- a/plugin/parser/ast/rename_index_stmt.go
+++ b/plugin/parser/ast/rename_index_stmt.go
@@ -2,7 +2,7 @@ package ast
 
 // RenameIndexStmt is the struct for the rename index statement.
 type RenameIndexStmt struct {
-	node
+	ddl
 
 	// For PostgreSQL, we only use TableDef.Schema.
 	// If this rename index statement doesn't contain schema name, Table will be not nil and the Schema name is empty string.

--- a/server/task_check_executor_statement_type.go
+++ b/server/task_check_executor_statement_type.go
@@ -103,6 +103,8 @@ func mysqlStatementTypeCheck(statement string, charset string, collation string,
 			_, isDDL := node.(tidbast.DDLNode)
 			_, isQuery := node.(*tidbast.SelectStmt)
 			_, isExplain := node.(*tidbast.ExplainStmt)
+			// We only want to disallow DDL, QUERY and EXPLAIN statements in CHANGE DATA.
+			// We need to run some common statements, e.g. COMMIT.
 			if isDDL || isQuery || isExplain {
 				result = append(result, api.TaskCheckResult{
 					Status:    api.TaskCheckStatusError,
@@ -155,6 +157,8 @@ func postgresqlStatementTypeCheck(statement string, taskType api.TaskType) (resu
 			_, isDDL := node.(ast.DDLNode)
 			_, isSelect := node.(*ast.SelectStmt)
 			_, isExplain := node.(*ast.ExplainStmt)
+			// We only want to disallow DDL, QUERY and EXPLAIN statements in CHANGE DATA.
+			// We need to run some common statements, e.g. COMMIT.
 			if isDDL || isSelect || isExplain {
 				result = append(result, api.TaskCheckResult{
 					Status:    api.TaskCheckStatusError,

--- a/server/task_check_executor_statement_type.go
+++ b/server/task_check_executor_statement_type.go
@@ -100,9 +100,10 @@ func mysqlStatementTypeCheck(statement string, charset string, collation string,
 	switch taskType {
 	case api.TaskDatabaseDataUpdate:
 		for _, node := range stmts {
-			_, isDML := node.(tidbast.DMLNode)
+			_, isDDL := node.(tidbast.DDLNode)
 			_, isQuery := node.(*tidbast.SelectStmt)
-			if !isDML || isQuery {
+			_, isExplain := node.(*tidbast.ExplainStmt)
+			if isDDL || isQuery || isExplain {
 				result = append(result, api.TaskCheckResult{
 					Status:    api.TaskCheckStatusError,
 					Namespace: api.BBNamespace,
@@ -151,7 +152,10 @@ func postgresqlStatementTypeCheck(statement string, taskType api.TaskType) (resu
 	switch taskType {
 	case api.TaskDatabaseDataUpdate:
 		for _, node := range stmts {
-			if _, ok := node.(ast.DMLNode); !ok {
+			_, isDDL := node.(ast.DDLNode)
+			_, isSelect := node.(*ast.SelectStmt)
+			_, isExplain := node.(*ast.ExplainStmt)
+			if isDDL || isSelect || isExplain {
 				result = append(result, api.TaskCheckResult{
 					Status:    api.TaskCheckStatusError,
 					Namespace: api.BBNamespace,

--- a/server/task_check_executor_statement_type_test.go
+++ b/server/task_check_executor_statement_type_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+
+	// Register pingcap parser driver.
+	_ "github.com/pingcap/tidb/types/parser_driver"
+	// Register postgres parser driver.
+	_ "github.com/bytebase/bytebase/plugin/parser/engine/pg"
+)
+
+type testData struct {
+	stmt     string
+	taskType api.TaskType
+	want     []api.TaskCheckResult
+}
+
+func TestStatementTypeCheck(t *testing.T) {
+	tests := []testData{
+		{
+			stmt:     "CREATE TABLE t(a int, b int)",
+			taskType: api.TaskDatabaseDataUpdate,
+			want: []api.TaskCheckResult{
+				{
+					Status:    api.TaskCheckStatusError,
+					Namespace: api.BBNamespace,
+					Code:      common.TaskTypeNotDML.Int(),
+					Title:     "Data change can only run DML",
+					Content:   "\"CREATE TABLE t(a int, b int)\" is not DML",
+				},
+			},
+		},
+		{
+			stmt:     "ALTER TABLE t ADD COLUMN a int",
+			taskType: api.TaskDatabaseDataUpdate,
+			want: []api.TaskCheckResult{
+				{
+					Status:    api.TaskCheckStatusError,
+					Namespace: api.BBNamespace,
+					Code:      common.TaskTypeNotDML.Int(),
+					Title:     "Data change can only run DML",
+					Content:   "\"ALTER TABLE t ADD COLUMN a int\" is not DML",
+				},
+			},
+		},
+		{
+			stmt:     "INSERT INTO t values(1, 2, 3)",
+			taskType: api.TaskDatabaseDataUpdate,
+			want:     []api.TaskCheckResult(nil),
+		},
+		{
+			stmt:     "COMMIT;",
+			taskType: api.TaskDatabaseDataUpdate,
+			want:     []api.TaskCheckResult(nil),
+		},
+		{
+			stmt:     "CREATE TABLE t(a int, b int)",
+			taskType: api.TaskDatabaseSchemaUpdate,
+			want:     []api.TaskCheckResult(nil),
+		},
+		{
+			stmt:     "ALTER TABLE t ADD COLUMN a int",
+			taskType: api.TaskDatabaseSchemaUpdate,
+			want:     []api.TaskCheckResult(nil),
+		},
+		{
+			stmt:     "INSERT INTO t values(1, 2, 3)",
+			taskType: api.TaskDatabaseSchemaUpdate,
+			want: []api.TaskCheckResult{
+				{
+					Status:    api.TaskCheckStatusError,
+					Namespace: api.BBNamespace,
+					Code:      common.TaskTypeNotDDL.Int(),
+					Title:     "Alter schema can only run DDL",
+					Content:   "\"INSERT INTO t values(1, 2, 3)\" is not DDL",
+				},
+			},
+		},
+		{
+			stmt:     "COMMIT;",
+			taskType: api.TaskDatabaseSchemaUpdate,
+			want:     []api.TaskCheckResult(nil),
+		},
+	}
+
+	for _, test := range tests {
+		res, err := mysqlStatementTypeCheck(test.stmt, "", "", test.taskType)
+		require.NoError(t, err)
+		require.Equal(t, test.want, res)
+		res, err = postgresqlStatementTypeCheck(test.stmt, test.taskType)
+		require.NoError(t, err)
+		require.Equal(t, test.want, res)
+	}
+}


### PR DESCRIPTION
Tips:
- PostgreSQL parser cannot parse all DDL statements now. I'll enhance it in the future.