### PR TITLE
feat(sql-editor): support table column resizing

### DIFF
--- a/frontend/src/views/sql-editor/TablePanel/useTableResize.ts
+++ b/frontend/src/views/sql-editor/TablePanel/useTableResize.ts
@@ -1,0 +1,228 @@
+import { computed, onBeforeUnmount, reactive, Ref, watch } from "vue";
+import { useEventListener, usePointer } from "@vueuse/core";
+import { sumBy } from "lodash-es";
+
+export type TableResizeOptions = {
+  tableRef: Ref<HTMLTableElement | undefined>;
+  scrollerRef: Ref<HTMLElement | undefined>;
+  minWidth: number;
+  maxWidth: number;
+};
+
+type ColumnProps = {
+  width: number;
+};
+
+type DragState = {
+  start: number;
+  index: number;
+  initialWidth: number;
+};
+
+type LocalState = {
+  columns: ColumnProps[];
+  drag?: DragState;
+  isAutoAdjusting: boolean;
+};
+
+const useTableResize = (options: TableResizeOptions) => {
+  const state = reactive<LocalState>({
+    columns: [],
+    drag: undefined,
+    isAutoAdjusting: false,
+  });
+  const pointer = usePointer();
+
+  const table = computed(() => options.tableRef.value!);
+
+  const normalizeWidth = (width: number) => {
+    const { maxWidth, minWidth } = options;
+    if (width > maxWidth) return maxWidth;
+    if (width < minWidth) return minWidth;
+    return width;
+  };
+
+  const reset = () => {
+    if (!table.value) return;
+
+    state.drag = undefined;
+    state.isAutoAdjusting = false;
+
+    const thList = Array.from(table.value.querySelectorAll("th"));
+    const columnCount = thList.length;
+    state.columns = new Array(columnCount);
+
+    const indexList: number[] = [];
+    for (let i = 0; i < columnCount; i++) {
+      indexList.push(i);
+      state.columns[i] = {
+        width: 0, // For auto adjust below
+      };
+    }
+
+    // Calculate a friendly width for every column when the first render happened.
+    requestAnimationFrame(() => {
+      autoAdjustColumnWidth(indexList);
+    });
+  };
+
+  // Automatically estimate the width of a column.
+  // Like double-clicking a cell border of Excel.
+  // Able to estimate multiple columns in a time.
+  const autoAdjustColumnWidth = (indexList: number[]): Promise<number[]> => {
+    return new Promise((resolve) => {
+      const cellListOfEachColumn = indexList.map((index, i) => {
+        const pseudo = `:nth-child(${index + 1})`;
+        // Find all cells in this column
+        const cellList = Array.from(
+          table.value.querySelectorAll(`th${pseudo}, td${pseudo}`)
+        ) as HTMLElement[];
+        return cellList;
+      });
+
+      // Update the cells' and table's style to estimate the width.
+      state.isAutoAdjusting = true;
+      cellListOfEachColumn.forEach((cellList) => {
+        cellList.forEach((cell) => {
+          cell.style.whiteSpace = "nowrap";
+          cell.style.overflow = "visible";
+          cell.style.width = "auto";
+          cell.style.maxWidth = `${options.maxWidth}px`;
+          cell.style.minWidth = `${options.minWidth}px`;
+        });
+      });
+      const tableWidthBackup = table.value.style.width;
+      table.value.style.width = "auto";
+
+      // Wait for the next render frame.
+      requestAnimationFrame(() => {
+        // Read the rendered widths.
+
+        const widthList = indexList.map((index, i) => {
+          const cellList = cellListOfEachColumn[i];
+          const th = cellList[0];
+          const stretchedWidth = getElementWidth(th);
+          const finalWidth = normalizeWidth(stretchedWidth);
+
+          state.columns[index].width = finalWidth;
+
+          return finalWidth;
+        });
+
+        // Reset the cells' and table's style.
+        cellListOfEachColumn.forEach((cellList) => {
+          cellList.forEach((cell) => {
+            cell.style.whiteSpace = "";
+            cell.style.overflow = "";
+            cell.style.width = "";
+            cell.style.maxWidth = "";
+            cell.style.minWidth = "";
+          });
+        });
+        table.value.style.width = tableWidthBackup;
+        state.isAutoAdjusting = false;
+
+        resolve(widthList);
+        // Style bindings will be automatically updated next frame.
+      });
+    });
+  };
+
+  // Record the initial state of dragging.
+  const startResizing = (index: number) => {
+    state.drag = {
+      start: pointer.x.value,
+      index,
+      initialWidth: state.columns[index].width,
+    };
+    toggleDragStyle(table, true);
+  };
+
+  // Watch the drag moving.
+  watch(pointer.x, () => {
+    const { drag } = state;
+    if (!drag) return;
+    const { start, index, initialWidth } = drag;
+
+    // Calculate the expectedWidth according to the pointer's position.
+    const offset = pointer.x.value - start;
+    const expectedWidth = initialWidth + offset;
+    state.columns[index].width = normalizeWidth(expectedWidth);
+    if (index === state.columns.length - 1) {
+      // When resizing the last column, Keep the horizontal scroll at the end of the container.
+      scrollMaxX(options.scrollerRef.value);
+    }
+  });
+
+  // Reset dragging state when mouse button released.
+  useEventListener("pointerup", () => {
+    if (state.drag) {
+      state.drag = undefined;
+      toggleDragStyle(table, false);
+    }
+  });
+
+  const getColumnProps = (index: number) => {
+    const column = state.columns[index];
+    if (!column) return {};
+    return {
+      style: {
+        width: `${column.width}px`,
+      },
+      class: "truncate",
+      "data-index": index,
+    };
+  };
+
+  const getTableProps = () => {
+    if (state.isAutoAdjusting) {
+      return {};
+    }
+    const totalWidth = sumBy(state.columns, (col) => col.width);
+    return {
+      style: {
+        width: `${totalWidth}px`,
+      },
+    };
+  };
+
+  onBeforeUnmount(() => {
+    toggleDragStyle(table, false);
+  });
+
+  return {
+    reset,
+    getColumnProps,
+    getTableProps,
+    autoAdjustColumnWidth,
+    startResizing,
+  };
+};
+
+export default useTableResize;
+
+const getElementWidth = (elem: HTMLElement) => {
+  const rect = elem.getBoundingClientRect();
+  return rect.width;
+};
+
+const scrollMaxX = (elem: HTMLElement | undefined) => {
+  if (!elem) return;
+  const max = elem.scrollWidth;
+  elem.scrollTo(max, elem.scrollTop);
+};
+
+const toggleDragStyle = (
+  table: Ref<HTMLTableElement | undefined>,
+  on: boolean
+) => {
+  if (on) {
+    // Prevent text selection while dragging.
+    table.value?.classList.add("select-none");
+    // Set the cursor style.
+    document.body.classList.add("cursor-col-resize");
+  } else {
+    table.value?.classList.remove("select-none");
+    document.body.classList.remove("cursor-col-resize");
+  }
+};


### PR DESCRIPTION
### Features

- Automatically calculate columns' widths according to the table header and content (with min/max width limitation).
- Drag to resize a column.
- Double-click to auto-fit column width.

### Screenshots

![auto-width-1](https://user-images.githubusercontent.com/2749742/188341178-6da50457-5c73-4272-95d2-53aec175d104.gif)
![auto-width-2](https://user-images.githubusercontent.com/2749742/188341185-54b27db1-2881-443c-8d74-716e97d50712.gif)
![double-click](https://user-images.githubusercontent.com/2749742/188341188-e42db21d-a921-42d2-b835-fb02b27e8b0a.gif)
