### PR TITLE
fix(SDL): replace use of nil `migrationInfo`

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -584,7 +584,7 @@ func (s *Server) createIssueFromPushEvent(ctx context.Context, pushEvent vcs.Pus
 		if repo.Project.TenantMode == api.TenantModeTenant {
 			updateSchemaDetails = append(updateSchemaDetails,
 				&api.UpdateSchemaDetail{
-					DatabaseName: migrationInfo.Database,
+					DatabaseName: dbName,
 					Statement:    content,
 				},
 			)


### PR DESCRIPTION
The `migrationInfo` is nil at where it is currently being used, we should use the `dbName` directly.

Also created https://linear.app/bbteam/issue/BYT-1359/sbm-add-integration-tests-for-tenant-mode to cover SDL for tenant mode through integration tests.