### PR TITLE
chore: don't warn on empty sql review policy

### DIFF
--- a/server/task_check_executor_statement_advisor_composite.go
+++ b/server/task_check_executor_statement_advisor_composite.go
@@ -45,9 +45,9 @@ func (*TaskCheckStatementAdvisorCompositeExecutor) Run(ctx context.Context, serv
 		if e, ok := err.(*common.Error); ok && e.Code == common.NotFound {
 			return []api.TaskCheckResult{
 				{
-					Status:    api.TaskCheckStatusWarn,
+					Status:    api.TaskCheckStatusSuccess,
 					Namespace: api.AdvisorNamespace,
-					Code:      advisor.NotFound.Int(),
+					Code:      common.Ok.Int(),
 					Title:     "Empty SQL review policy or disabled",
 					Content:   "",
 				},

--- a/tests/sql_review_test.go
+++ b/tests/sql_review_test.go
@@ -30,9 +30,9 @@ var (
 	sqlReviewAccessErr = fmt.Sprintf(`http response error code %d body "{\"message\":\"%s\"}\n"`, http.StatusForbidden, api.FeatureSQLReviewPolicy.AccessErrorMessage())
 	noSQLReviewPolicy  = []api.TaskCheckResult{
 		{
-			Status:    api.TaskCheckStatusWarn,
+			Status:    api.TaskCheckStatusSuccess,
 			Namespace: api.AdvisorNamespace,
-			Code:      advisor.NotFound.Int(),
+			Code:      common.Ok.Int(),
 			Title:     "Empty SQL review policy or disabled",
 			Content:   "",
 		},


### PR DESCRIPTION
We need to find other ways to guide users to new features.