### PR TITLE
chore(sdl): display `sheetPathTemplate` setting

### DIFF
--- a/frontend/src/components/RepositoryForm.vue
+++ b/frontend/src/components/RepositoryForm.vue
@@ -205,7 +205,7 @@
         }}
       </div>
     </div>
-    <div v-if="schemaMigrationType === 'DDL'">
+    <div>
       <div class="textlabel">{{ $t("repository.sheet-path-template") }}</div>
       <div class="mt-1 textinfolabel">
         {{ $t("repository.sheet-path-template-description") }}


### PR DESCRIPTION
The use of `sheetPathTemplate` is independent of DDL or SDL.