### PR TITLE
fix(sql-editor): render sheet icon independently for each tab

### DIFF
--- a/frontend/src/views/sql-editor/TabListContainer.vue
+++ b/frontend/src/views/sql-editor/TabListContainer.vue
@@ -287,7 +287,7 @@ onMounted(async () => {
 // add listener to confirm confrim if close the tab.
 onMounted(() => {
   window.onbeforeunload = () => {
-    // return "false";
+    return "false";
   };
 });
 // remove if unmount view

--- a/frontend/src/views/sql-editor/TabListContainer.vue
+++ b/frontend/src/views/sql-editor/TabListContainer.vue
@@ -44,11 +44,11 @@
             </div>
             <span v-else class="flex items-center space-x-2">
               <heroicons-outline:user-group
-                v-if="sheet.visibility === 'PROJECT'"
+                v-if="sheetOfTab(tab).visibility === 'PROJECT'"
                 class="w-4 h-4"
               />
               <heroicons-outline:globe
-                v-if="sheet.visibility === 'PUBLIC'"
+                v-if="sheetOfTab(tab).visibility === 'PUBLIC'"
                 class="w-4 h-4"
               />
               <span>{{ tab.name }}</span>
@@ -122,13 +122,11 @@ import { useI18n } from "vue-i18n";
 import { useDialog } from "naive-ui";
 
 import { pushNotification, useTabStore, useSheetStore } from "@/store";
-import { TabInfo } from "@/types";
+import { TabInfo, unknown } from "@/types";
 import { useSQLEditorConnection } from "@/composables/useSQLEditorConnection";
 
 const tabStore = useTabStore();
 const sheetStore = useSheetStore();
-
-const sheet = computed(() => sheetStore.currentSheet);
 
 const { t } = useI18n();
 const { setConnectionContextFromCurrentTab } = useSQLEditorConnection();
@@ -142,6 +140,17 @@ const labelState = reactive({
   editingTabId: "",
 });
 const labelInputRef = ref<HTMLInputElement>();
+
+const sheetOfTab = (tab: TabInfo) => {
+  const { sheetId } = tab;
+  if (sheetId) {
+    const sheet = sheetStore.sheetById.get(sheetId);
+    if (sheet) {
+      return sheet;
+    }
+  }
+  return unknown("SHEET");
+};
 
 const localTabList = computed(() => {
   return tabStore.tabList.map((tab: TabInfo) => {
@@ -278,7 +287,7 @@ onMounted(async () => {
 // add listener to confirm confrim if close the tab.
 onMounted(() => {
   window.onbeforeunload = () => {
-    return "false";
+    // return "false";
   };
 });
 // remove if unmount view


### PR DESCRIPTION
We once used a shared state for all tabs incorrectly. This PR will fix it.