### PR TITLE
chore: pass migration info from vcs webhook

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -157,7 +157,7 @@ type UpdateSchemaDetail struct {
 	EarliestAllowedTs int64 `jsonapi:"attr,earliestAllowedTs"`
 }
 
-// UpdateSchemaContext is the issue create context for updating database schema.
+// UpdateSchemaContext is the shared issue create context for updating database schema and data.
 type UpdateSchemaContext struct {
 	// MigrationType is the type of a migration.
 	MigrationType db.MigrationType `json:"migrationType"`
@@ -166,6 +166,9 @@ type UpdateSchemaContext struct {
 	DetailList []*UpdateSchemaDetail `json:"updateSchemaDetailList"`
 	// VCSPushEvent is the event information for VCS push.
 	VCSPushEvent *vcs.PushEvent `json:"vcsPushEvent"`
+	// MigrationInfo is only available when VCSPushEvent != nil.
+	// It's parsed from VCSPushEvent.
+	MigrationInfo *db.MigrationInfo `json:"migrationInfo,omitempty"`
 }
 
 // UpdateSchemaGhostDetail is the detail of updating database schema using gh-ost.

--- a/api/task.go
+++ b/api/task.go
@@ -95,10 +95,12 @@ type TaskDatabaseCreatePayload struct {
 
 // TaskDatabaseSchemaUpdatePayload is the task payload for database schema update (DDL).
 type TaskDatabaseSchemaUpdatePayload struct {
-	MigrationType db.MigrationType `json:"migrationType,omitempty"`
-	Statement     string           `json:"statement,omitempty"`
-	SchemaVersion string           `json:"schemaVersion,omitempty"`
-	VCSPushEvent  *vcs.PushEvent   `json:"pushEvent,omitempty"`
+	Statement     string         `json:"statement,omitempty"`
+	SchemaVersion string         `json:"schemaVersion,omitempty"`
+	VCSPushEvent  *vcs.PushEvent `json:"pushEvent,omitempty"`
+	// MigrationInfo is only available when VCSPushEvent != nil.
+	// It's parsed from VCSPushEvent.
+	MigrationInfo *db.MigrationInfo `json:"migrationInfo,omitempty"`
 }
 
 // TaskDatabaseSchemaUpdateGhostSyncPayload is the task payload for gh-ost syncing ghost table.
@@ -121,6 +123,9 @@ type TaskDatabaseDataUpdatePayload struct {
 	Statement     string         `json:"statement,omitempty"`
 	SchemaVersion string         `json:"schemaVersion,omitempty"`
 	VCSPushEvent  *vcs.PushEvent `json:"pushEvent,omitempty"`
+	// MigrationInfo is only available when VCSPushEvent != nil.
+	// It's parsed from VCSPushEvent.
+	MigrationInfo *db.MigrationInfo `json:"migrationInfo,omitempty"`
 }
 
 // TaskDatabaseBackupPayload is the task payload for database backup.
@@ -207,7 +212,6 @@ type TaskCreate struct {
 	Labels            string `jsonapi:"attr,labels"`
 	BackupID          *int   `jsonapi:"attr,backupId"`
 	VCSPushEvent      *vcs.PushEvent
-	MigrationType     db.MigrationType `jsonapi:"attr,migrationType"`
 }
 
 // TaskFind is the API message for finding tasks.

--- a/server/issue.go
+++ b/server/issue.go
@@ -639,6 +639,10 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 	}
 
 	schemaVersion := common.DefaultMigrationVersion()
+	// VCS push event contains the migration version in the file path.
+	if c.MigrationInfo != nil {
+		schemaVersion = c.MigrationInfo.Version
+	}
 	// Tenant mode project pipeline has its own generation.
 	if project.TenantMode == api.TenantModeTenant {
 		if !s.feature(api.FeatureMultiTenancy) {
@@ -664,7 +668,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 				return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database ID not found: %d", d.DatabaseID))
 			}
 
-			taskCreate, err := getUpdateTask(database, c.MigrationType, c.VCSPushEvent, d, schemaVersion)
+			taskCreate, err := getUpdateTask(database, c, d, schemaVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -697,7 +701,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 					environmentSet[database.Instance.Environment.Name] = true
 					environmentID = database.Instance.EnvironmentID
 
-					taskCreate, err := getUpdateTask(database, c.MigrationType, c.VCSPushEvent, d, schemaVersion)
+					taskCreate, err := getUpdateTask(database, c, d, schemaVersion)
 					if err != nil {
 						return nil, err
 					}
@@ -743,7 +747,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 				return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database ID not found: %d", d.DatabaseID))
 			}
 
-			taskCreate, err := getUpdateTask(database, c.MigrationType, c.VCSPushEvent, d, schemaVersion)
+			taskCreate, err := getUpdateTask(database, c, d, schemaVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -825,32 +829,32 @@ func (s *Server) getPipelineCreateForDatabaseSchemaUpdateGhost(ctx context.Conte
 	return create, nil
 }
 
-func getUpdateTask(database *api.Database, migrationType db.MigrationType, vcsPushEvent *vcs.PushEvent, d *api.UpdateSchemaDetail, schemaVersion string) (*api.TaskCreate, error) {
+func getUpdateTask(database *api.Database, c api.UpdateSchemaContext, d *api.UpdateSchemaDetail, schemaVersion string) (*api.TaskCreate, error) {
 	taskName := fmt.Sprintf("Establish %q baseline", database.Name)
-	switch migrationType {
+	switch c.MigrationType {
 	case db.Migrate:
 		taskName = fmt.Sprintf("Update %q schema", database.Name)
 	case db.Data:
 		taskName = fmt.Sprintf("Update %q data", database.Name)
 	}
 	payload := api.TaskDatabaseSchemaUpdatePayload{}
-	payload.MigrationType = migrationType
 	payload.Statement = d.Statement
 	payload.SchemaVersion = schemaVersion
-	if vcsPushEvent != nil {
-		payload.VCSPushEvent = vcsPushEvent
+	if c.VCSPushEvent != nil {
+		payload.VCSPushEvent = c.VCSPushEvent
+		payload.MigrationInfo = c.MigrationInfo
 	}
 	bytes, err := json.Marshal(payload)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to marshal database schema update payload: %v", err)
-		if migrationType == db.Data {
+		if c.MigrationType == db.Data {
 			errMsg = fmt.Sprintf("Failed to marshal database data update payload: %v", err)
 		}
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, errMsg)
 	}
 
 	taskType := api.TaskDatabaseSchemaUpdate
-	if migrationType == db.Data {
+	if c.MigrationType == db.Data {
 		taskType = api.TaskDatabaseDataUpdate
 	}
 	return &api.TaskCreate{
@@ -861,7 +865,6 @@ func getUpdateTask(database *api.Database, migrationType db.MigrationType, vcsPu
 		Type:              taskType,
 		Statement:         d.Statement,
 		EarliestAllowedTs: d.EarliestAllowedTs,
-		MigrationType:     migrationType,
 		Payload:           string(bytes),
 	}, nil
 }
@@ -1038,7 +1041,6 @@ func createGhostTaskList(database *api.Database, vcsPushEvent *vcs.PushEvent, de
 		Type:              api.TaskDatabaseSchemaUpdateGhostSync,
 		Statement:         detail.Statement,
 		EarliestAllowedTs: detail.EarliestAllowedTs,
-		MigrationType:     db.Migrate,
 		Payload:           string(bytesSync),
 	})
 

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -52,7 +52,7 @@ func RunTaskExecutorOnce(ctx context.Context, exec TaskExecutor, server *Server,
 	return exec.RunOnce(ctx, server, task)
 }
 
-func preMigration(ctx context.Context, server *Server, task *api.Task, migrationType db.MigrationType, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent) (*db.MigrationInfo, error) {
+func preMigration(ctx context.Context, server *Server, task *api.Task, migrationType db.MigrationType, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, mi *db.MigrationInfo) (*db.MigrationInfo, error) {
 	if task.Database == nil {
 		msg := "missing database when updating schema"
 		if migrationType == db.Data {
@@ -62,11 +62,11 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 	}
 	databaseName := task.Database.Name
 
-	mi := &db.MigrationInfo{
-		ReleaseVersion: server.profile.Version,
-		Type:           migrationType,
-	}
 	if vcsPushEvent == nil {
+		mi = &db.MigrationInfo{
+			ReleaseVersion: server.profile.Version,
+			Type:           migrationType,
+		}
 		mi.Source = db.UI
 		creator, err := server.store.GetPrincipalByID(ctx, task.CreatorID)
 		if err != nil {
@@ -82,29 +82,6 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 		// TODO(d): support semantic versioning.
 		mi.Version = schemaVersion
 		mi.Description = task.Name
-	} else {
-		repo, err := findRepositoryByTask(ctx, server, task)
-		if err != nil {
-			return nil, err
-		}
-		mi, err = db.ParseMigrationInfo(
-			vcsPushEvent.FileCommit.Added,
-			filepath.Join(vcsPushEvent.BaseDirectory, repo.FilePathTemplate),
-		)
-		// This should not happen normally as we already check this when creating the issue. Just in case.
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to prepare for database migration")
-		}
-		mi.Creator = vcsPushEvent.FileCommit.AuthorName
-
-		miPayload := &db.MigrationInfoPayload{
-			VCSPushEvent: vcsPushEvent,
-		}
-		bytes, err := json.Marshal(miPayload)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to prepare for database migration, unable to marshal vcs push event payload")
-		}
-		mi.Payload = string(bytes)
 	}
 
 	mi.Database = databaseName
@@ -300,8 +277,8 @@ func postMigration(ctx context.Context, server *Server, task *api.Task, vcsPushE
 	}, nil
 }
 
-func runMigration(ctx context.Context, server *Server, task *api.Task, migrationType db.MigrationType, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	mi, err := preMigration(ctx, server, task, migrationType, statement, schemaVersion, vcsPushEvent)
+func runMigration(ctx context.Context, server *Server, task *api.Task, migrationType db.MigrationType, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, mi *db.MigrationInfo) (bool, *api.TaskRunResultPayload, error) {
+	mi, err := preMigration(ctx, server, task, migrationType, statement, schemaVersion, vcsPushEvent, mi)
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_data_update.go
+++ b/server/task_executor_data_update.go
@@ -28,7 +28,7 @@ func (*DataUpdateTaskExecutor) RunOnce(ctx context.Context, server *Server, task
 		return true, nil, errors.Wrap(err, "invalid database data update payload")
 	}
 
-	return runMigration(ctx, server, task, db.Data, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
+	return runMigration(ctx, server, task, db.Data, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, payload.MigrationInfo)
 }
 
 // IsCompleted tells the scheduler if the task execution has completed.

--- a/server/task_executor_schema_update.go
+++ b/server/task_executor_schema_update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/plugin/db"
 )
 
 // NewSchemaUpdateTaskExecutor creates a schema update (DDL) task executor.
@@ -28,7 +29,7 @@ func (exec *SchemaUpdateTaskExecutor) RunOnce(ctx context.Context, server *Serve
 		return true, nil, errors.Wrap(err, "invalid database schema update payload")
 	}
 
-	return runMigration(ctx, server, task, payload.MigrationType, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent)
+	return runMigration(ctx, server, task, db.Migrate, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, payload.MigrationInfo)
 }
 
 // IsCompleted tells the scheduler if the task execution has completed.

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
-	vcsPlugin "github.com/bytebase/bytebase/plugin/vcs"
 )
 
 // NewSchemaUpdateGhostCutoverTaskExecutor creates a schema update (gh-ost) cutover task executor.
@@ -65,13 +64,13 @@ func (exec *SchemaUpdateGhostCutoverTaskExecutor) RunOnce(ctx context.Context, s
 	}
 	sharedGhost := value.(sharedGhostState)
 
-	return cutover(ctx, server, task, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, postponeFilename, sharedGhost.migrationContext, sharedGhost.errCh)
+	return cutover(ctx, server, task, payload, postponeFilename, sharedGhost.migrationContext, sharedGhost.errCh)
 }
 
-func cutover(ctx context.Context, server *Server, task *api.Task, statement, schemaVersion string, vcsPushEvent *vcsPlugin.PushEvent, postponeFilename string, migrationContext *base.MigrationContext, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	statement = strings.TrimSpace(statement)
+func cutover(ctx context.Context, server *Server, task *api.Task, payload *api.TaskDatabaseSchemaUpdateGhostSyncPayload, postponeFilename string, migrationContext *base.MigrationContext, errCh <-chan error) (terminated bool, result *api.TaskRunResultPayload, err error) {
+	statement := strings.TrimSpace(payload.Statement)
 
-	mi, err := preMigration(ctx, server, task, db.Migrate, statement, schemaVersion, vcsPushEvent)
+	mi, err := preMigration(ctx, server, task, db.Migrate, statement, payload.SchemaVersion, payload.VCSPushEvent, nil)
 	if err != nil {
 		return true, nil, err
 	}
@@ -140,7 +139,7 @@ func cutover(ctx context.Context, server *Server, task *api.Task, statement, sch
 		return true, nil, err
 	}
 
-	return postMigration(ctx, server, task, vcsPushEvent, mi, migrationID, schema)
+	return postMigration(ctx, server, task, payload.VCSPushEvent, mi, migrationID, schema)
 }
 
 func waitForCutover(ctx context.Context, migrationContext *base.MigrationContext) bool {


### PR DESCRIPTION
This way, we can process the VCS-created issue even if the path template is changed before the issue is running.

This also passes the schema version of the migration info into the task payload. This enables us to find tasks with a specific schema version. Then we can utilize the modified files in VCS push events to change pending/failed task's SQL statement.