### PR TITLE
feat: improve local development for VCS integration

### DIFF
--- a/server/oauth.go
+++ b/server/oauth.go
@@ -67,7 +67,7 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 			}
 		}
 
-		oauthExchange.RedirectURL = fmt.Sprintf("%s/oauth/callback", s.profile.ExternalURL)
+		oauthExchange.RedirectURL = fmt.Sprintf("%s/oauth/callback", oauthRedirectURL(s.profile.ExternalURL))
 		oauthToken, err := vcsPlugin.Get(vcsType, vcsPlugin.ProviderConfig{}).
 			ExchangeOAuthToken(
 				c.Request().Context(),
@@ -75,7 +75,7 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 				oauthExchange,
 			)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to exchange OAuth token. Make sure --external-url: %s matches your browser host.", s.profile.ExternalURL)).SetInternal(err)
+			return echo.NewHTTPError(http.StatusInternalServerError, oauthErrorMessage(oauthExchange.RedirectURL)).SetInternal(err)
 		}
 
 		resp := &api.OAuthToken{

--- a/server/server_frontend_embed.go
+++ b/server/server_frontend_embed.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"net/http"
 
@@ -44,4 +45,12 @@ func embedFrontend(e *echo.Echo) {
 		HTML5:      true,
 		Filesystem: getFileSystem("dist/assets"),
 	}))
+}
+
+func oauthRedirectURL(externalURL string) string {
+	return externalURL
+}
+
+func oauthErrorMessage(redirectURL string) string {
+	return fmt.Sprintf("Failed to exchange OAuth token. Make sure --external-url: %s matches your browser host.", redirectURL)
 }

--- a/server/server_frontend_not_embed.go
+++ b/server/server_frontend_not_embed.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -17,4 +18,14 @@ func embedFrontend(e *echo.Echo) {
 	e.GET("/*", func(c echo.Context) error {
 		return c.HTML(http.StatusOK, "This Bytebase build does not bundle frontend and backend together.")
 	})
+}
+
+// In non embedded mode, the redirect URL is the frontend URL which is different
+// from the external URL. By default, this frontend URL is http://localhost:3000
+func oauthRedirectURL(_ string) string {
+	return "http://localhost:3000"
+}
+
+func oauthErrorMessage(redirectURL string) string {
+	return fmt.Sprintf("Failed to exchange OAuth token. Make sure oauthRedirectURL: %s matches your browser host.", redirectURL)
 }


### PR DESCRIPTION
After https://github.com/bytebase/bytebase/pull/2608

We consolidate the backend and frontend addresses into a single `--external-url`. We can do this because our release build bundles backend and frontend together.

On the other hand, this brings complexity to our development environment. Our dev environment runs backend and frontend on separate ports. This is for getting frontend hot reloading. The major obstacle is the OAuth redirect URL which points to the frontend address. 

To overcome this, This PR overrides the redirect URL when frontend is not embedded in the backend and returns our default frontend address http://localhost:3000 used in our dev environment.