### PR TITLE
chore: update the helm readme

### DIFF
--- a/helm-charts/bytebase/README.md
+++ b/helm-charts/bytebase/README.md
@@ -4,7 +4,7 @@ Install the web-based schema change and version control tool [Bytebase](https://
 
 ## Installing
 
-`helm -n <YOUR_NAMESPACE> --set bytebase.option.port={PORT} --set bytebase.option.host={HOST} --set bytebase.option.pg={PGDSN} --set bytebase.version={VERSION} install <RELEASE_NAME> helm-charts/bytebase`
+`helm -n <YOUR_NAMESPACE> --set bytebase.option.port={PORT} --set bytebase.option.external_url={EXTERNAL_URL} --set bytebase.option.pg={PGDSN} --set bytebase.version={VERSION} install <RELEASE_NAME> helm-charts/bytebase`
 
 ## Uninstalling
 

--- a/helm-charts/bytebase/templates/statefulset.yaml
+++ b/helm-charts/bytebase/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- $host := .Values.bytebase.option.host -}}
+{{- $external_url := .Values.bytebase.option.external_url -}}
 {{- $port := .Values.bytebase.option.port -}}
 {{- $pg := .Values.bytebase.option.pg -}}
 {{- $data := .Values.bytebase.option.data -}}


### PR DESCRIPTION
After #2608, we remove the `host` argument and introduce the `external_url` argument. We need to update the helm README to notify the users on how to set up `external_url`.