### PR TITLE
refactor(sbm): rename SchemaMigrationType to SchemaChangeType

### DIFF
--- a/api/project.go
+++ b/api/project.go
@@ -43,16 +43,16 @@ const (
 	TenantModeTenant ProjectTenantMode = "TENANT"
 )
 
-// ProjectSchemaMigrationType is the schema migration type for projects.
-type ProjectSchemaMigrationType string
+// ProjectSchemaChangeType is the schema change type for projects.
+type ProjectSchemaChangeType string
 
 const (
-	// ProjectSchemaMigrationTypeDDL is the Data Definition Language (DDL) schema
+	// ProjectSchemaChangeTypeDDL is the Data Definition Language (DDL) schema
 	// migration.
-	ProjectSchemaMigrationTypeDDL ProjectSchemaMigrationType = "DDL"
-	// ProjectSchemaMigrationTypeSDL is the Schema Definition Language (SDL) schema
+	ProjectSchemaChangeTypeDDL ProjectSchemaChangeType = "DDL"
+	// ProjectSchemaChangeTypeSDL is the Schema Definition Language (SDL) schema
 	// migration.
-	ProjectSchemaMigrationTypeSDL ProjectSchemaMigrationType = "SDL"
+	ProjectSchemaChangeTypeSDL ProjectSchemaChangeType = "SDL"
 )
 
 // Project is the API message for a project.
@@ -81,8 +81,8 @@ type Project struct {
 	// Empty value means {{DB_NAME}}.
 	DBNameTemplate string              `jsonapi:"attr,dbNameTemplate"`
 	RoleProvider   ProjectRoleProvider `jsonapi:"attr,roleProvider"`
-	// SchemaMigrationType is the type of the schema migration script.
-	SchemaMigrationType ProjectSchemaMigrationType `jsonapi:"attr,schemaMigrationType"`
+	// SchemaChangeType is the type of the schema migration script.
+	SchemaChangeType ProjectSchemaChangeType `jsonapi:"attr,schemaChangeType"`
 }
 
 // ProjectCreate is the API message for creating a project.
@@ -92,12 +92,12 @@ type ProjectCreate struct {
 	CreatorID int
 
 	// Domain specific fields
-	Name                string                     `jsonapi:"attr,name"`
-	Key                 string                     `jsonapi:"attr,key"`
-	TenantMode          ProjectTenantMode          `jsonapi:"attr,tenantMode"`
-	DBNameTemplate      string                     `jsonapi:"attr,dbNameTemplate"`
-	RoleProvider        ProjectRoleProvider        `jsonapi:"attr,roleProvider"`
-	SchemaMigrationType ProjectSchemaMigrationType `jsonapi:"attr,schemaMigrationType"`
+	Name             string                  `jsonapi:"attr,name"`
+	Key              string                  `jsonapi:"attr,key"`
+	TenantMode       ProjectTenantMode       `jsonapi:"attr,tenantMode"`
+	DBNameTemplate   string                  `jsonapi:"attr,dbNameTemplate"`
+	RoleProvider     ProjectRoleProvider     `jsonapi:"attr,roleProvider"`
+	SchemaChangeType ProjectSchemaChangeType `jsonapi:"attr,schemaChangeType"`
 }
 
 // ProjectFind is the API message for finding projects.
@@ -130,10 +130,10 @@ type ProjectPatch struct {
 	UpdaterID int
 
 	// Domain specific fields
-	Name                *string `jsonapi:"attr,name"`
-	WorkflowType        *string `jsonapi:"attr,workflowType"` // NOTE: We can't use *ProjectWorkflowType because "google/jsonapi" doesn't support.
-	RoleProvider        *string `jsonapi:"attr,roleProvider"`
-	SchemaMigrationType *string `jsonapi:"attr,schemaMigrationType"` // NOTE: We can't use *ProjectSchemaMigrationType because "google/jsonapi" doesn't support.
+	Name             *string `jsonapi:"attr,name"`
+	WorkflowType     *string `jsonapi:"attr,workflowType"` // NOTE: We can't use *ProjectWorkflowType because "google/jsonapi" doesn't support.
+	RoleProvider     *string `jsonapi:"attr,roleProvider"`
+	SchemaChangeType *string `jsonapi:"attr,schemaChangeType"` // NOTE: We can't use *ProjectSchemaChangeType because "google/jsonapi" doesn't support.
 }
 
 var (

--- a/frontend/src/components/ProjectGeneralSettingPanel.vue
+++ b/frontend/src/components/ProjectGeneralSettingPanel.vue
@@ -42,24 +42,24 @@
     <div v-if="isDev">
       <dl class="">
         <div class="textlabel">
-          {{ $t("project.settings.schema-migration-type") }}
+          {{ $t("project.settings.schema-change-type") }}
           <span class="text-red-600">*</span>
         </div>
         <BBSelect
           id="schemamigrationtype"
-          :selected-item="state.schemaMigrationType"
+          :selected-item="state.schemaChangeType"
           :item-list="['DDL', 'SDL']"
           class="mt-1"
           @select-item="
-            (type: SchemaMigrationType) => {
-              state.schemaMigrationType = type;
+            (type: SchemaChangeType) => {
+              state.schemaChangeType = type;
             }
           "
         >
           <template #menuItem="{ item }">
             {{
               $t(
-                `project.settings.select-schema-migration-type-${item.toLowerCase()}`
+                `project.settings.select-schema-change-type-${item.toLowerCase()}`
               )
             }}
           </template>
@@ -88,13 +88,13 @@ import {
   DEFAULT_PROJECT_ID,
   Project,
   ProjectPatch,
-  SchemaMigrationType,
+  SchemaChangeType,
 } from "../types";
 import { pushNotification, useProjectStore } from "@/store";
 
 interface LocalState {
   name: string;
-  schemaMigrationType: SchemaMigrationType;
+  schemaChangeType: SchemaChangeType;
 }
 
 export default defineComponent({
@@ -115,7 +115,7 @@ export default defineComponent({
 
     const state = reactive<LocalState>({
       name: props.project.name,
-      schemaMigrationType: props.project.schemaMigrationType,
+      schemaChangeType: props.project.schemaChangeType,
     });
 
     const allowSave = computed((): boolean => {
@@ -123,7 +123,7 @@ export default defineComponent({
         props.project.id != DEFAULT_PROJECT_ID &&
         !isEmpty(state.name) &&
         (state.name !== props.project.name ||
-          state.schemaMigrationType != props.project.schemaMigrationType)
+          state.schemaChangeType != props.project.schemaChangeType)
       );
     });
 
@@ -133,8 +133,8 @@ export default defineComponent({
       if (state.name !== props.project.name) {
         projectPatch.name = state.name;
       }
-      if (state.schemaMigrationType !== props.project.schemaMigrationType) {
-        projectPatch.schemaMigrationType = state.schemaMigrationType;
+      if (state.schemaChangeType !== props.project.schemaChangeType) {
+        projectPatch.schemaChangeType = state.schemaChangeType;
       }
 
       projectStore
@@ -149,7 +149,7 @@ export default defineComponent({
             title: t("project.settings.success-updated"),
           });
           state.name = updatedProject.name;
-          state.schemaMigrationType = updatedProject.schemaMigrationType;
+          state.schemaChangeType = updatedProject.schemaChangeType;
         });
     };
 

--- a/frontend/src/components/RepositoryConfigPanel.vue
+++ b/frontend/src/components/RepositoryConfigPanel.vue
@@ -5,10 +5,10 @@
     :vcs-name="config.vcs.name"
     :repository-info="config.repositoryInfo"
     :repository-config="config.repositoryConfig"
-    :schema-migration-type="config.schemaMigrationType"
+    :schema-change-type="config.schemaChangeType"
     :project="project"
-    @change-schema-migration-type="
-      (type) => $emit('change-schema-migration-type', type)
+    @change-schema-change-type="
+      (type) => $emit('change-schema-change-type', type)
     "
   />
 </template>
@@ -31,6 +31,6 @@ export default defineComponent({
       type: Object as PropType<Project>,
     },
   },
-  emits: ["change-schema-migration-type"],
+  emits: ["change-schema-change-type"],
 });
 </script>

--- a/frontend/src/components/RepositoryForm.vue
+++ b/frontend/src/components/RepositoryForm.vue
@@ -72,7 +72,7 @@
         :disabled="!allowEdit"
       />
     </div>
-    <!-- Project schemaMigrationType selector -->
+    <!-- Project schemaChangeType selector -->
     <div v-if="isDev">
       <div class="textlabel">
         {{ $t("project.settings.schema-change-type") }}
@@ -80,19 +80,19 @@
       </div>
       <BBSelect
         id="schemamigrationtype"
-        :selected-item="schemaMigrationType"
+        :selected-item="schemaChangeType"
         :item-list="['DDL', 'SDL']"
         class="mt-1"
         @select-item="
           (type: string) => {
-            $emit('change-schema-migration-type', type);
+            $emit('change-schema-change-type', type);
           }
         "
       >
         <template #menuItem="{ item }">
           {{
             $t(
-              `project.settings.select-schema-migration-type-${item.toLowerCase()}`
+              `project.settings.select-schema-change-type-${item.toLowerCase()}`
             )
           }}
         </template>
@@ -165,7 +165,7 @@
         >
       </div>
       <div class="mt-1 textinfolabel">
-        <template v-if="isProjectSchemaMigrationTypeDDL">
+        <template v-if="isProjectSchemaChangeTypeDDL">
           {{ $t("repository.schema-writeback-description") }}
           <span class="font-medium text-main">{{
             $t("repository.schema-writeback-protected-branch")
@@ -236,7 +236,7 @@ import {
   ExternalRepositoryInfo,
   Project,
   RepositoryConfig,
-  SchemaMigrationType,
+  SchemaChangeType,
   VCSType,
 } from "@/types";
 
@@ -280,12 +280,12 @@ export default defineComponent({
       required: true,
       type: Object as PropType<Project>,
     },
-    schemaMigrationType: {
+    schemaChangeType: {
       required: true,
-      type: String as PropType<SchemaMigrationType>,
+      type: String as PropType<SchemaChangeType>,
     },
   },
-  emits: ["change-repository", "change-schema-migration-type"],
+  emits: ["change-repository", "change-schema-change-type"],
   setup(props) {
     const state = reactive<LocalState>({});
 
@@ -293,8 +293,8 @@ export default defineComponent({
       return props.project.tenantMode === "TENANT";
     });
 
-    const isProjectSchemaMigrationTypeDDL = computed(() => {
-      return (props.project.schemaMigrationType || "DDL") === "DDL";
+    const isProjectSchemaChangeTypeDDL = computed(() => {
+      return (props.schemaChangeType || "DDL") === "DDL";
     });
 
     const sampleFilePath = (
@@ -389,7 +389,7 @@ export default defineComponent({
       fileOptionalPlaceholder,
       schemaOptionalTagPlaceholder,
       state,
-      isProjectSchemaMigrationTypeDDL,
+      isProjectSchemaChangeTypeDDL,
       sampleFilePath,
       sampleSchemaPath,
     };

--- a/frontend/src/components/RepositoryPanel.vue
+++ b/frontend/src/components/RepositoryPanel.vue
@@ -55,8 +55,8 @@
     :repository-info="repositoryInfo"
     :repository-config="state.repositoryConfig"
     :project="project"
-    :schema-migration-type="state.schemaMigrationType"
-    @change-schema-migration-type="(type) => (state.schemaMigrationType = type)"
+    :schema-change-type="state.schemaChangeType"
+    @change-schema-change-type="(type) => (state.schemaChangeType = type)"
     @change-repository="$emit('change-repository')"
   />
   <div v-if="allowEdit" class="mt-4 pt-4 flex border-t justify-between">
@@ -93,7 +93,7 @@ import {
   RepositoryConfig,
   Project,
   ProjectPatch,
-  SchemaMigrationType,
+  SchemaChangeType,
 } from "../types";
 import { useI18n } from "vue-i18n";
 import { pushNotification, useProjectStore, useRepositoryStore } from "@/store";
@@ -101,7 +101,7 @@ import { isDev } from "@/utils";
 
 interface LocalState {
   repositoryConfig: RepositoryConfig;
-  schemaMigrationType: SchemaMigrationType;
+  schemaChangeType: SchemaChangeType;
 }
 
 export default defineComponent({
@@ -133,7 +133,7 @@ export default defineComponent({
         schemaPathTemplate: props.repository.schemaPathTemplate,
         sheetPathTemplate: props.repository.sheetPathTemplate,
       },
-      schemaMigrationType: props.project.schemaMigrationType,
+      schemaChangeType: props.project.schemaChangeType,
     });
 
     watch(
@@ -172,7 +172,7 @@ export default defineComponent({
             state.repositoryConfig.schemaPathTemplate ||
           props.repository.sheetPathTemplate !==
             state.repositoryConfig.sheetPathTemplate ||
-          props.project.schemaMigrationType !== state.schemaMigrationType)
+          props.project.schemaChangeType !== state.schemaChangeType)
       );
     });
 
@@ -220,13 +220,13 @@ export default defineComponent({
           state.repositoryConfig.sheetPathTemplate;
       }
 
-      // Update project schemaMigrationType field firstly.
+      // Update project schemaChangeType field firstly.
       if (
         isDev() &&
-        state.schemaMigrationType !== props.project.schemaMigrationType
+        state.schemaChangeType !== props.project.schemaChangeType
       ) {
         const projectPatch: ProjectPatch = {
-          schemaMigrationType: state.schemaMigrationType,
+          schemaChangeType: state.schemaChangeType,
         };
         await useProjectStore().patchProject({
           projectId: props.project.id,

--- a/frontend/src/components/RepositorySetupWizard.vue
+++ b/frontend/src/components/RepositorySetupWizard.vue
@@ -40,8 +40,8 @@
         <RepositoryConfigPanel
           :config="state.config"
           :project="project"
-          @change-schema-migration-type="
-            (type) => (state.config.schemaMigrationType = type)
+          @change-schema-change-type="
+            (type) => (state.config.schemaChangeType = type)
           "
         />
       </template>
@@ -158,7 +158,7 @@ export default defineComponent({
             ? DEFAULT_TENANT_MODE_SHEET_PATH_TEMPLATE
             : DEFAULT_SHEET_PATH_TEMPLATE,
         },
-        schemaMigrationType: props.project.schemaMigrationType,
+        schemaChangeType: props.project.schemaChangeType,
       },
       currentStep: CHOOSE_PROVIDER_STEP,
     });
@@ -189,13 +189,13 @@ export default defineComponent({
           externalId = state.config.repositoryInfo.fullPath;
         }
 
-        // Update project schemaMigrationType field firstly.
+        // Update project schemaChangeType field firstly.
         if (
           isDev() &&
-          state.config.schemaMigrationType !== props.project.schemaMigrationType
+          state.config.schemaChangeType !== props.project.schemaChangeType
         ) {
           const projectPatch: ProjectPatch = {
-            schemaMigrationType: state.config.schemaMigrationType,
+            schemaChangeType: state.config.schemaChangeType,
           };
           await useProjectStore().patchProject({
             projectId: props.project.id,

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1065,8 +1065,8 @@
       "view-vcs-member": "View members in VCS",
       "switch-role-provider-to-bytebase-success-prompt": "Successfully turning off VCS project membership sync.",
       "schema-change-type": "Schema change type",
-      "select-schema-migration-type-ddl": "Migration-based",
-      "select-schema-migration-type-sdl": "State-based",
+      "select-schema-change-type-ddl": "Migration-based",
+      "select-schema-change-type-sdl": "State-based",
       "schema-path-template-sdl-description": "The schema file that contains the desired state of the database schema. Bytebase creates new migrations for any discrepancy found between the desired state and the actual database schema."
     },
     "mode": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1065,8 +1065,8 @@
       "view-vcs-member": "在 VCS 中查看成员",
       "switch-role-provider-to-bytebase-success-prompt": "成功关闭了 VCS 项目成员同步",
       "schema-change-type": "Schema 变更类型",
-      "select-schema-migration-type-ddl": "通过指定过程 DDL 变更到期望的 Schema",
-      "select-schema-migration-type-sdl": "直接指定期望达到的 Schema",
+      "select-schema-change-type-ddl": "通过指定过程 DDL 变更到期望的 Schema",
+      "select-schema-change-type-sdl": "直接指定期望达到的 Schema",
       "schema-path-template-sdl-description": "Schema 定义文件应该包括了数据库 Schema 所在的状态。Bytebase 将会为在 Schema 状态和实际数据库之间发现的任何差异创建新的迁移。"
     },
     "mode": {

--- a/frontend/src/store/modules/project.ts
+++ b/frontend/src/store/modules/project.ts
@@ -51,7 +51,7 @@ function convert(
     tenantMode: attrs.tenantMode,
     dbNameTemplate: attrs.dbNameTemplate,
     roleProvider: attrs.roleProvider,
-    schemaMigrationType: attrs.schemaMigrationType,
+    schemaChangeType: attrs.schemaChangeType,
   };
 
   const memberList: ProjectMember[] = [];

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -18,7 +18,7 @@ export type ProjectRoleProvider =
   | "GITHUB_COM"
   | "BYTEBASE";
 
-export type SchemaMigrationType = "DDL" | "SDL";
+export type SchemaChangeType = "DDL" | "SDL";
 
 export type ProjectRoleProviderPayload = {
   vcsRole: string;
@@ -52,7 +52,7 @@ export type Project = {
   tenantMode: ProjectTenantMode;
   dbNameTemplate: string;
   roleProvider: ProjectRoleProvider;
-  schemaMigrationType: SchemaMigrationType;
+  schemaChangeType: SchemaChangeType;
 };
 
 export type ProjectCreate = {
@@ -62,7 +62,7 @@ export type ProjectCreate = {
   tenantMode: ProjectTenantMode;
   dbNameTemplate: string;
   roleProvider: ProjectRoleProvider;
-  schemaMigrationType: SchemaMigrationType;
+  schemaChangeType: SchemaChangeType;
 };
 
 export type ProjectPatch = {
@@ -72,7 +72,7 @@ export type ProjectPatch = {
   // Domain specific fields
   name?: string;
   roleProvider?: ProjectRoleProvider;
-  schemaMigrationType?: SchemaMigrationType;
+  schemaChangeType?: SchemaChangeType;
 };
 
 // Project Member
@@ -115,5 +115,5 @@ export type ProjectRepositoryConfig = {
   code: string;
   repositoryInfo: ExternalRepositoryInfo;
   repositoryConfig: RepositoryConfig;
-  schemaMigrationType: SchemaMigrationType;
+  schemaChangeType: SchemaChangeType;
 };

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -183,7 +183,7 @@ func postMigration(ctx context.Context, server *Server, task *api.Task, vcsPushE
 
 	// We write back the latest schema after migration for VCS-based projects if the
 	// schema path template is specified and the schema migration type is not SDL.
-	writeBack := (vcsPushEvent != nil) && (repo.Project.SchemaMigrationType != api.ProjectSchemaMigrationTypeSDL) && (repo.SchemaPathTemplate != "")
+	writeBack := (vcsPushEvent != nil) && (repo.Project.SchemaChangeType != api.ProjectSchemaChangeTypeSDL) && (repo.SchemaPathTemplate != "")
 	project, err := server.store.GetProjectByID(ctx, task.Database.ProjectID)
 	if err != nil {
 		return true, nil, err

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -211,7 +211,7 @@ func (s *Server) registerWebhookRoutes(g *echo.Group) {
 				)
 			}
 
-			if repo.Project.SchemaMigrationType == api.ProjectSchemaMigrationTypeSDL {
+			if repo.Project.SchemaChangeType == api.ProjectSchemaChangeTypeSDL {
 				for _, modified := range commit.Modified {
 					files = append(files,
 						fileItem{
@@ -740,7 +740,7 @@ func (s *Server) createIssueFromPushEvent(ctx context.Context, pushEvent *vcs.Pu
 
 	var migrationInfo *db.MigrationInfo
 	var updateSchemaDetails []*api.UpdateSchemaDetail
-	if repo.Project.SchemaMigrationType == api.ProjectSchemaMigrationTypeSDL {
+	if repo.Project.SchemaChangeType == api.ProjectSchemaChangeTypeSDL {
 		migrationInfo, updateSchemaDetails = s.prepareIssueFromPushEventSDL(ctx, repo, pushEvent, schemaInfo, file, fileType, webhookEndpointID)
 	} else {
 		// NOTE: We do not want to use filepath.Join here because we always need "/" as the path separator.

--- a/store/migration/dev/20220807000000__add_project_schema_change_type.sql
+++ b/store/migration/dev/20220807000000__add_project_schema_change_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE project ADD COLUMN IF NOT EXISTS schema_change_type TEXT NOT NULL CHECK (schema_change_type IN ('DDL', 'SDL')) DEFAULT 'DDL';

--- a/store/migration/dev/20220807000000__add_project_schema_migration_type.sql
+++ b/store/migration/dev/20220807000000__add_project_schema_migration_type.sql
@@ -1,1 +1,0 @@
-ALTER TABLE project ADD COLUMN schema_migration_type TEXT NOT NULL CHECK (schema_migration_type IN ('DDL', 'SDL')) DEFAULT 'DDL';

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -170,7 +170,7 @@ CREATE TABLE project (
     db_name_template TEXT NOT NULL,
     role_provider TEXT NOT NULL CHECK (role_provider IN ('BYTEBASE', 'GITLAB_SELF_HOST', 'GITHUB_COM')) DEFAULT 'BYTEBASE',
     schema_version_type TEXT NOT NULL CHECK (schema_version_type IN ('TIMESTAMP', 'SEMANTIC')) DEFAULT 'TIMESTAMP',
-    schema_migration_type TEXT NOT NULL CHECK (schema_migration_type IN ('DDL', 'SDL')) DEFAULT 'DDL'
+    schema_change_type TEXT NOT NULL CHECK (schema_change_type IN ('DDL', 'SDL')) DEFAULT 'DDL'
 );
 
 CREATE UNIQUE INDEX idx_project_unique_key ON project(key);

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -677,9 +677,9 @@ func TestVCS_SDL(t *testing.T) {
 			// Create a project
 			project, err := ctl.createProject(
 				api.ProjectCreate{
-					Name:                "Test VCS Project",
-					Key:                 "TestVCSSchemaUpdate",
-					SchemaMigrationType: api.ProjectSchemaMigrationTypeSDL,
+					Name:             "Test VCS Project",
+					Key:              "TestVCSSchemaUpdate",
+					SchemaChangeType: api.ProjectSchemaChangeTypeSDL,
 				},
 			)
 			a.NoError(err)


### PR DESCRIPTION
We have started using the term "SchemaChangeType" instead of "SchemaMigrationType" since https://github.com/bytebase/bytebase/pull/2618 as our product language, this PR updates all other places to be consistent with our product language, do it now or suffer later.

### Test plan

CI and manually tested.

---

cc @tianzhou 