### PR TITLE
feat(frontend): open the VCS filePathTemplate as long as possible

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -397,7 +397,16 @@ export default defineComponent({
         repositoryStore
           .fetchRepositoryByProjectId(project.id)
           .then((repository: Repository) => {
-            window.open(baseDirectoryWebUrl(repository), "_blank");
+            window.open(
+              baseDirectoryWebUrl(repository, {
+                DB_NAME: state.selectedDatabaseName!,
+                TYPE:
+                  props.type === "bb.issue.database.schema.update"
+                    ? "migrate"
+                    : "data",
+              }),
+              "_blank"
+            );
           });
       }
     };
@@ -430,7 +439,17 @@ export default defineComponent({
         repositoryStore
           .fetchRepositoryByProjectId(database.project.id)
           .then((repository: Repository) => {
-            window.open(baseDirectoryWebUrl(repository), "_blank");
+            window.open(
+              baseDirectoryWebUrl(repository, {
+                DB_NAME: database.name,
+                ENV_NAME: database.instance.environment.name,
+                TYPE:
+                  props.type === "bb.issue.database.schema.update"
+                    ? "migrate"
+                    : "data",
+              }),
+              "_blank"
+            );
           });
         emit("dismiss");
       }

--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -388,7 +388,13 @@ export default defineComponent({
       useRepositoryStore()
         .fetchRepositoryByProjectId(issueEntity.project.id)
         .then((repository: Repository) => {
-          window.open(baseDirectoryWebUrl(repository), "_blank");
+          window.open(
+            baseDirectoryWebUrl(repository, {
+              DB_NAME: selectedDatabase.value?.name,
+              ENV_NAME: selectedDatabase.value?.instance.environment.name,
+            }),
+            "_blank"
+          );
 
           state.showVCSGuideModal = false;
         });

--- a/frontend/src/types/repository.ts
+++ b/frontend/src/types/repository.ts
@@ -110,7 +110,7 @@ export function baseDirectoryWebUrl(
     // Once we meet a "dynamic" segment which has a pattern that cannot be replaced
     // we won't push it, either the segments behind it.
     // E.g., the filePathTemplate is
-    // configue/{{ENV_NAME}}/20220707-wechat/{{TYPE}}/**/**/**/{{DB_NAME}}__{{VERSION}}__{{DESCRIPTION}}.sql
+    // configure/{{ENV_NAME}}/20220707-wechat/{{TYPE}}/**/**/**/{{DB_NAME}}__{{VERSION}}__{{DESCRIPTION}}.sql
     /**
       The segments are
         - configure
@@ -140,6 +140,8 @@ export function baseDirectoryWebUrl(
     return url;
   }
 
+  // Fallback for other types of VCS.
+  // Shouldn't reach this line.
   return repository.webUrl;
 }
 

--- a/frontend/src/types/repository.ts
+++ b/frontend/src/types/repository.ts
@@ -103,7 +103,7 @@ export function baseDirectoryWebUrl(
     }
   }
   if (url) {
-    // BYT-1344. Replace the patterns in the filePathTemplate if possible.
+    // Replace the patterns in the filePathTemplate if possible.
     const segments = repository.filePathTemplate.split("/");
     segments.pop(); // exclude the last one, it's the filename.
     // Try to replace the segments from left to right.

--- a/frontend/src/types/repository.ts
+++ b/frontend/src/types/repository.ts
@@ -79,20 +79,81 @@ export type ExternalRepositoryInfo = {
   webUrl: string;
 };
 
-export function baseDirectoryWebUrl(repository: Repository): string {
+type WebUrlReplaceParams = {
+  DB_NAME?: string;
+  VERSION?: string;
+  TYPE?: "migrate" | "data";
+  ENV_NAME?: string;
+};
+
+export function baseDirectoryWebUrl(
+  repository: Repository,
+  params: WebUrlReplaceParams = {}
+): string {
+  let url = "";
   if (repository.vcs.type == "GITLAB_SELF_HOST") {
-    let url = `${repository.webUrl}/-/tree/${repository.branchFilter}`;
+    url = `${repository.webUrl}/-/tree/${repository.branchFilter}`;
     if (!isEmpty(repository.baseDirectory)) {
       url += `/${repository.baseDirectory}`;
     }
-    return url;
   } else if (repository.vcs.type == "GITHUB_COM") {
-    let url = `${repository.webUrl}/tree/${repository.branchFilter}`;
+    url = `${repository.webUrl}/tree/${repository.branchFilter}`;
     if (!isEmpty(repository.baseDirectory)) {
       url += `/${repository.baseDirectory}`;
     }
+  }
+  if (url) {
+    // BYT-1344. Replace the patterns in the filePathTemplate if possible.
+    const segments = repository.filePathTemplate.split("/");
+    segments.pop(); // exclude the last one, it's the filename.
+    // Try to replace the segments from left to right.
+    // Once we meet a "dynamic" segment which has a pattern that cannot be replaced
+    // we won't push it, either the segments behind it.
+    // E.g., the filePathTemplate is
+    // configue/{{ENV_NAME}}/20220707-wechat/{{TYPE}}/**/**/**/{{DB_NAME}}__{{VERSION}}__{{DESCRIPTION}}.sql
+    /**
+      The segments are
+        - configure
+        - {{ENV_NAME}}
+        - 20220707-wechat
+        - {{TYPE}}
+        - **
+        - **
+        - **
+      When
+        - ENV_NAME=dev
+        - TYPE=migrate
+      we are confident enough that the path will be started with
+      "/configure/dev/20220707-wechat/migrate"
+      That's our best effort.
+     */
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i];
+      const replaced = replaceParams(segment, params);
+      if (replaced.match(/[*{}]/)) {
+        // Still remained some patterns cannot be replaced in the value.
+        break;
+      }
+      url += `/${replaced}`;
+    }
+
     return url;
   }
 
   return repository.webUrl;
 }
+
+const replaceParams = (
+  template: string,
+  params: WebUrlReplaceParams = {}
+): string => {
+  let replaced = template;
+  Object.keys(params).forEach((key) => {
+    const pattern = `{{${key}}}`;
+    const value = params[key as keyof WebUrlReplaceParams];
+    if (value) {
+      replaced = replaced.replaceAll(pattern, value);
+    }
+  });
+  return replaced;
+};

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -546,7 +546,15 @@ const createMigration = async (
     repositoryStore
       .fetchRepositoryByProjectId(database.value.project.id)
       .then((repository: Repository) => {
-        window.open(baseDirectoryWebUrl(repository), "_blank");
+        window.open(
+          baseDirectoryWebUrl(repository, {
+            DB_NAME: database.value.name,
+            ENV_NAME: database.value.instance.environment.name,
+            TYPE:
+              type === "bb.issue.database.schema.update" ? "migrate" : "data",
+          }),
+          "_blank"
+        );
       });
   }
 };


### PR DESCRIPTION
Close BYT-1344

Try to replace the segments from left to the right as long as possible.

Once we meet a "dynamic" segment that has a pattern that cannot be replaced, we won't push it, nor the segments behind it.

E.g., the `filePathTemplate` is
`configure/{{ENV_NAME}}/20220707-wechat/{{TYPE}}/**/**/**/{{DB_NAME}}__{{VERSION}}__{{DESCRIPTION}}.sql`

The segments are

- configure
- {{ENV_NAME}}
- 20220707-wechat
- {{TYPE}}
- **
- **
- **

When

- `DB_NAME=what_ever`
- `ENV_NAME=dev`
- `TYPE=migrate`

we are confident enough that the path will be started with `/configure/dev/20220707-wechat/migrate`

That's our best effort.