### PR TITLE
chore: drop idx_repository_unique_webhook_endpoint_id index

### DIFF
--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -945,8 +945,6 @@ CREATE TABLE repository (
 
 CREATE UNIQUE INDEX idx_repository_unique_project_id ON repository(project_id);
 
-CREATE UNIQUE INDEX idx_repository_unique_webhook_endpoint_id ON repository(webhook_endpoint_id);
-
 ALTER SEQUENCE repository_id_seq RESTART WITH 101;
 
 CREATE TRIGGER update_repository_updated_ts

--- a/store/migration/prod/1.4/0001__drop_repository_webhook_index.sql
+++ b/store/migration/prod/1.4/0001__drop_repository_webhook_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_repository_unique_webhook_endpoint_id;

--- a/store/migration/prod/LATEST.sql
+++ b/store/migration/prod/LATEST.sql
@@ -944,8 +944,6 @@ CREATE TABLE repository (
 
 CREATE UNIQUE INDEX idx_repository_unique_project_id ON repository(project_id);
 
-CREATE UNIQUE INDEX idx_repository_unique_webhook_endpoint_id ON repository(webhook_endpoint_id);
-
 ALTER SEQUENCE repository_id_seq RESTART WITH 101;
 
 CREATE TRIGGER update_repository_updated_ts

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -707,8 +707,6 @@ func FormatError(err error) error {
 			return common.Errorf(common.Conflict, "bookmark already exists")
 		case strings.Contains(err.Error(), "idx_repository_unique_project_id"):
 			return common.Errorf(common.Conflict, "project has already linked repository")
-		case strings.Contains(err.Error(), "idx_repository_unique_webhook_endpoint_id"):
-			return common.Errorf(common.Conflict, "webhook endpoint already exists")
 		case strings.Contains(err.Error(), "idx_label_key_unique_key"):
 			return common.Errorf(common.Conflict, "label key already exists")
 		case strings.Contains(err.Error(), "idx_label_value_unique_key_value"):


### PR DESCRIPTION
We'd like to reuse the same webhook ID for the different repositories/projects.