### PR TITLE
chore: do not parse VCS file name in task executor

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -166,6 +166,9 @@ type UpdateSchemaContext struct {
 	DetailList []*UpdateSchemaDetail `json:"updateSchemaDetailList"`
 	// VCSPushEvent is the event information for VCS push.
 	VCSPushEvent *vcs.PushEvent `json:"vcsPushEvent"`
+	// SchemaVersion is parsed from VCS file name.
+	// It is automatically generated in the UI workflow.
+	SchemaVersion string `json:"schemaVersion"`
 }
 
 // UpdateSchemaGhostDetail is the detail of updating database schema using gh-ost.

--- a/api/issue.go
+++ b/api/issue.go
@@ -155,6 +155,9 @@ type UpdateSchemaDetail struct {
 	Statement string `json:"statement"`
 	// EarliestAllowedTs the earliest execution time of the change at system local Unix timestamp in seconds.
 	EarliestAllowedTs int64 `jsonapi:"attr,earliestAllowedTs"`
+	// SchemaVersion is parsed from VCS file name.
+	// It is automatically generated in the UI workflow.
+	SchemaVersion string `json:"schemaVersion"`
 }
 
 // UpdateSchemaContext is the issue create context for updating database schema.
@@ -166,9 +169,6 @@ type UpdateSchemaContext struct {
 	DetailList []*UpdateSchemaDetail `json:"updateSchemaDetailList"`
 	// VCSPushEvent is the event information for VCS push.
 	VCSPushEvent *vcs.PushEvent `json:"vcsPushEvent"`
-	// SchemaVersion is parsed from VCS file name.
-	// It is automatically generated in the UI workflow.
-	SchemaVersion string `json:"schemaVersion"`
 }
 
 // UpdateSchemaGhostDetail is the detail of updating database schema using gh-ost.

--- a/server/issue.go
+++ b/server/issue.go
@@ -639,10 +639,6 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 	}
 
 	schemaVersion := common.DefaultMigrationVersion()
-	// VCS push event contains schema version in the file name, which is parsed against the file template.
-	if c.SchemaVersion != "" {
-		schemaVersion = c.SchemaVersion
-	}
 	// Tenant mode project pipeline has its own generation.
 	if project.TenantMode == api.TenantModeTenant {
 		if !s.feature(api.FeatureMultiTenancy) {
@@ -657,6 +653,10 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 		d := c.DetailList[0]
 		if d.Statement == "" {
 			return nil, echo.NewHTTPError(http.StatusBadRequest, "Failed to create issue, sql statement missing")
+		}
+		// VCS push event contains schema version in the file name, which is parsed against the file template.
+		if d.SchemaVersion != "" {
+			schemaVersion = d.SchemaVersion
 		}
 
 		if d.DatabaseName == "" && d.DatabaseID > 0 {
@@ -747,6 +747,10 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 				return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database ID not found: %d", d.DatabaseID))
 			}
 
+			// VCS push event contains schema version in the file name, which is parsed against the file template.
+			if d.SchemaVersion != "" {
+				schemaVersion = d.SchemaVersion
+			}
 			taskCreate, err := getUpdateTask(database, c.MigrationType, c.VCSPushEvent, d, schemaVersion)
 			if err != nil {
 				return nil, err

--- a/server/issue.go
+++ b/server/issue.go
@@ -639,6 +639,10 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 	}
 
 	schemaVersion := common.DefaultMigrationVersion()
+	// VCS push event contains schema version in the file name, which is parsed against the file template.
+	if c.SchemaVersion != "" {
+		schemaVersion = c.SchemaVersion
+	}
 	// Tenant mode project pipeline has its own generation.
 	if project.TenantMode == api.TenantModeTenant {
 		if !s.feature(api.FeatureMultiTenancy) {

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -775,6 +775,7 @@ func (s *Server) createIssueFromPushEvent(ctx context.Context, pushEvent *vcs.Pu
 			MigrationType: db.Migrate,
 			VCSPushEvent:  pushEvent,
 			DetailList:    updateSchemaDetails,
+			SchemaVersion: migrationInfo.Version,
 		},
 	)
 	if err != nil {

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -774,7 +774,7 @@ func (s *Server) createIssueFromPushEvent(ctx context.Context, pushEvent *vcs.Pu
 
 	createContext, err := json.Marshal(
 		&api.UpdateSchemaContext{
-			MigrationType: db.Migrate,
+			MigrationType: migrationInfo.Type,
 			VCSPushEvent:  pushEvent,
 			DetailList:    updateSchemaDetails,
 		},

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -665,8 +665,9 @@ func (s *Server) prepareIssueFromPushEventDDL(ctx context.Context, repo *api.Rep
 	if repo.Project.TenantMode == api.TenantModeTenant {
 		updateSchemaDetails = append(updateSchemaDetails,
 			&api.UpdateSchemaDetail{
-				DatabaseName: migrationInfo.Database,
-				Statement:    content,
+				DatabaseName:  migrationInfo.Database,
+				Statement:     content,
+				SchemaVersion: migrationInfo.Version,
 			},
 		)
 	} else {
@@ -685,8 +686,9 @@ func (s *Server) prepareIssueFromPushEventDDL(ctx context.Context, repo *api.Rep
 		for _, database := range databases {
 			updateSchemaDetails = append(updateSchemaDetails,
 				&api.UpdateSchemaDetail{
-					DatabaseID: database.ID,
-					Statement:  content,
+					DatabaseID:    database.ID,
+					Statement:     content,
+					SchemaVersion: migrationInfo.Version,
 				},
 			)
 		}
@@ -775,7 +777,6 @@ func (s *Server) createIssueFromPushEvent(ctx context.Context, pushEvent *vcs.Pu
 			MigrationType: db.Migrate,
 			VCSPushEvent:  pushEvent,
 			DetailList:    updateSchemaDetails,
-			SchemaVersion: migrationInfo.Version,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This PR minimizes the difference between UI and VCS migration.