### PR TITLE
chore: add cache for database labels

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -20,6 +20,8 @@ const (
 	PipelineCache CacheNamespace = "pl"
 	// IssueCache is the cache type of issues.
 	IssueCache CacheNamespace = "is"
+	// DatabaseLabelCache is the cache type of database labels.
+	DatabaseLabelCache CacheNamespace = "dl"
 )
 
 // CacheService is the service for caches.

--- a/api/label.go
+++ b/api/label.go
@@ -67,33 +67,17 @@ func (patch *LabelKeyPatch) Validate() error {
 
 // DatabaseLabel is the label associated with a database.
 type DatabaseLabel struct {
-	ID int `json:"-"`
-
-	// Standard fields
-	RowStatus RowStatus  `json:"-"`
-	CreatorID int        `json:"-"`
-	Creator   *Principal `json:"-"`
-	CreatedTs int64      `json:"-"`
-	UpdaterID int        `json:"-"`
-	Updater   *Principal `json:"-"`
-	UpdatedTs int64      `json:"-"`
-
-	// Related fields
-	DatabaseID int    `json:"-"`
-	Key        string `json:"key"`
-
-	// Domain specific fields
+	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
 // DatabaseLabelFind finds the labels associated with the database.
 type DatabaseLabelFind struct {
 	// Standard fields
-	ID        *int
 	RowStatus *RowStatus
 
 	// Related fields
-	DatabaseID *int
+	DatabaseID int
 }
 
 // DatabaseLabelUpsert upserts the label associated with the database.

--- a/store/database.go
+++ b/store/database.go
@@ -247,8 +247,8 @@ func (s *Store) composeDatabase(ctx context.Context, raw *databaseRaw) (*api.Dat
 	db.DataSourceList = []*api.DataSource{}
 
 	rowStatus := api.Normal
-	labelList, err := s.FindDatabaseLabel(ctx, &api.DatabaseLabelFind{
-		DatabaseID: &db.ID,
+	labelList, err := s.findDatabaseLabel(ctx, &api.DatabaseLabelFind{
+		DatabaseID: db.ID,
 		RowStatus:  &rowStatus,
 	})
 	if err != nil {


### PR DESCRIPTION
Currently, database label queries are made whenever we read the database. We should cache it by database ID.