### PR TITLE
chore: compose instance and database into anomaly

### DIFF
--- a/api/anomaly.go
+++ b/api/anomaly.go
@@ -99,9 +99,11 @@ type Anomaly struct {
 	UpdatedTs int64      `jsonapi:"attr,updatedTs"`
 
 	// Related fields
-	InstanceID int `jsonapi:"attr,instanceId"`
+	InstanceID int       `jsonapi:"attr,instanceId"`
+	Instance   *Instance `jsonapi:"relation,instance"`
 	// Instance anomaly doesn't have databaseID
-	DatabaseID *int `jsonapi:"attr,databaseId"`
+	DatabaseID *int      `jsonapi:"attr,databaseId"`
+	Database   *Database `jsonapi:"relation,database"`
 
 	// Domain specific fields
 	Type AnomalyType `jsonapi:"attr,type"`

--- a/store/anomaly.go
+++ b/store/anomaly.go
@@ -107,6 +107,22 @@ func (s *Store) composeAnomaly(ctx context.Context, raw *anomalyRaw) (*api.Anoma
 	}
 	anomaly.Updater = updater
 
+	instance, err := s.GetInstanceByID(ctx, anomaly.InstanceID)
+	if err != nil {
+		return nil, err
+	}
+	anomaly.Instance = instance
+
+	if anomaly.DatabaseID != nil {
+		database, err := s.GetDatabase(ctx, &api.DatabaseFind{
+			ID: anomaly.DatabaseID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		anomaly.Database = database
+	}
+
 	return anomaly, nil
 }
 


### PR DESCRIPTION
We need `anomaly.database` to display the schema drift diff dialog. And I'd like to compose it in backend instead of fetching it in frontend.