### PR TITLE
fix: rename in the same directory

### DIFF
--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -721,26 +721,26 @@ func (driver *Driver) downloadBinlogFile(ctx context.Context, binlogFileToDownlo
 	}
 
 	log.Debug("Checking downloaded binlog file stat", zap.String("path", binlogFilePathTemp))
-	binlogFileInfo, err := os.Stat(binlogFilePathTemp)
+	binlogFileTempInfo, err := os.Stat(binlogFilePathTemp)
 	if err != nil {
 		log.Error("Failed to get stat of the binlog file.", zap.String("path", binlogFilePathTemp), zap.Error(err))
 		return errors.Wrapf(err, "failed to get stat of the binlog file %q", binlogFilePathTemp)
 	}
-	if !isLast && binlogFileInfo.Size() != binlogFileToDownload.Size {
+	if !isLast && binlogFileTempInfo.Size() != binlogFileToDownload.Size {
 		log.Error("Downloaded archived binlog file size is not equal to size queried on the MySQL server earlier.",
 			zap.String("binlog", binlogFileToDownload.Name),
 			zap.Int64("sizeInfo", binlogFileToDownload.Size),
-			zap.Int64("downloadedSize", binlogFileInfo.Size()),
+			zap.Int64("downloadedSize", binlogFileTempInfo.Size()),
 		)
-		return errors.Errorf("downloaded archived binlog file %q size %d is not equal to size %d queried on MySQL server earlier", binlogFilePathTemp, binlogFileInfo.Size(), binlogFileToDownload.Size)
+		return errors.Errorf("downloaded archived binlog file %q size %d is not equal to size %d queried on MySQL server earlier", binlogFilePathTemp, binlogFileTempInfo.Size(), binlogFileToDownload.Size)
 	}
 
-	binlogFilePath := filepath.Join(driver.binlogDir, binlogFileInfo.Name())
+	binlogFilePath := filepath.Join(driver.binlogDir, binlogFileToDownload.Name)
 	if err := os.Rename(binlogFilePathTemp, binlogFilePath); err != nil {
 		return errors.Wrapf(err, "failed to rename %q to %q", binlogFilePathTemp, binlogFilePath)
 	}
 
-	if err := driver.writeBinlogMetadataFile(ctx, binlogFileInfo.Name()); err != nil {
+	if err := driver.writeBinlogMetadataFile(ctx, binlogFileToDownload.Name); err != nil {
 		return errors.Wrapf(err, "failed to write binlog metadata file for binlog file %q", binlogFilePathTemp)
 	}
 	return nil

--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -104,9 +103,7 @@ func (c *Client) GetBucket() string {
 // In case of network errors which will get partially downloaded files, we first download to a temporary file.
 // After that, we then rename it to the target file path.
 func (c *Client) DownloadFileFromCloud(ctx context.Context, filePathLocal, filePathOnCloud string) error {
-	tempDir := os.TempDir()
-	baseName := filepath.Base(filePathLocal)
-	filePathTemp := filepath.Join(tempDir, baseName)
+	filePathTemp := filePathLocal + ".tmp"
 	fileTemp, err := os.Create(filePathTemp)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create the local temporary file %s", filePathTemp)


### PR DESCRIPTION
This avoids the situation that the source and target files are in different volumns, which triggers the error "invalid cross-device link" for `os.Rename`.

Fix BYT-1419.