### PR TITLE
fix: patch project key errors

### DIFF
--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -680,7 +680,7 @@ func FormatError(err error) error {
 		case strings.Contains(err.Error(), "idx_policy_unique_environment_id_type"):
 			return common.Errorf(common.Conflict, "policy environment and type already exists")
 		case strings.Contains(err.Error(), "idx_project_unique_key"):
-			return common.Errorf(common.Conflict, "project key already exists")
+			return common.Errorf(common.Conflict, "The project key already exists")
 		case strings.Contains(err.Error(), "idx_project_member_unique_project_id_role_provider_principal_id"):
 			return common.Errorf(common.Conflict, "project member already exists")
 		case strings.Contains(err.Error(), "idx_project_webhook_unique_project_id_url"):

--- a/store/project.go
+++ b/store/project.go
@@ -110,7 +110,7 @@ func (s *Store) CreateProject(ctx context.Context, create *api.ProjectCreate) (*
 func (s *Store) PatchProject(ctx context.Context, patch *api.ProjectPatch) (*api.Project, error) {
 	projectRaw, err := s.patchProjectRaw(ctx, patch)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to patch Project with ProjectPatch[%+v]", patch)
+		return nil, errors.Wrapf(err, "failed to patch Project with ProjectPatch %#v", patch)
 	}
 	project, err := s.composeProject(ctx, projectRaw)
 	if err != nil {


### PR DESCRIPTION
1. patch project key cannot be empty
2. return more specific errors when the project key exists

Thanks to @candy2255 for reporting the issue.