### PR TITLE
feat(catalog): walk-through support some MySQL statements

### DIFF
--- a/plugin/advisor/catalog/state.go
+++ b/plugin/advisor/catalog/state.go
@@ -35,7 +35,7 @@ func newSchemaState(s *Schema, context *FinderContext) *schemaState {
 	}
 
 	for _, table := range s.TableList {
-		schema.tableSet[table.Name] = newTableState(table, context)
+		schema.tableSet[table.Name] = newTableState(table)
 	}
 
 	for _, view := range s.ViewList {
@@ -65,7 +65,7 @@ func newExtensionState(e *Extension) *extensionState {
 	}
 }
 
-func newTableState(t *Table, context *FinderContext) *tableState {
+func newTableState(t *Table) *tableState {
 	table := &tableState{
 		name:          t.Name,
 		tableType:     t.Type,
@@ -79,7 +79,6 @@ func newTableState(t *Table, context *FinderContext) *tableState {
 		comment:       t.Comment,
 		columnSet:     make(columnStateMap),
 		indexSet:      make(indexStateMap),
-		context:       context.Copy(),
 	}
 
 	for _, column := range t.ColumnList {
@@ -159,8 +158,6 @@ type tableState struct {
 	columnSet columnStateMap
 	// indexSet isn't supported for ClickHouse, Snowflake.
 	indexSet indexStateMap
-
-	context *FinderContext
 }
 type tableStateMap map[string]*tableState
 
@@ -179,6 +176,10 @@ func (table *tableState) convertToCatalog() *Table {
 		ColumnList:    table.columnSet.convertToCatalog(),
 		IndexList:     table.indexSet.convertToCatalog(),
 	}
+}
+
+func (table *tableState) copy() *tableState {
+	return newTableState(table.convertToCatalog())
 }
 
 type indexState struct {

--- a/plugin/advisor/catalog/state.go
+++ b/plugin/advisor/catalog/state.go
@@ -124,6 +124,7 @@ type databaseState struct {
 	collation    string
 	dbType       db.Type
 	schemaSet    schemaStateMap
+	deleted      bool
 
 	context *FinderContext
 }

--- a/plugin/advisor/catalog/walk_through.go
+++ b/plugin/advisor/catalog/walk_through.go
@@ -186,6 +186,8 @@ func (d *databaseState) changeState(in tidbast.StmtNode) error {
 		return d.alterDatabase(node)
 	case *tidbast.DropDatabaseStmt:
 		return d.dropDatabase(node)
+	case *tidbast.CreateDatabaseStmt:
+		return NewAccessOtherDatabaseError(d.name, node.Name)
 	default:
 		return nil
 	}

--- a/plugin/advisor/catalog/walk_through_test.go
+++ b/plugin/advisor/catalog/walk_through_test.go
@@ -449,6 +449,56 @@ func TestWalkThrough(t *testing.T) {
 				DbType: db.MySQL,
 			},
 			statement: `
+				CREATE TABLE t(a int);
+				RENAME TABLE t to other_db.t1
+			`,
+			want: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+				SchemaList: []*Schema{
+					{},
+				},
+			},
+		},
+		{
+			origin: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+			},
+			statement: `
+				CREATE TABLE t(a int);
+				RENAME TABLE t to test.t1
+			`,
+			want: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+				SchemaList: []*Schema{
+					{
+						Name: "",
+						TableList: []*Table{
+							{
+								Name: "t1",
+								ColumnList: []*Column{
+									{
+										Name:     "a",
+										Position: 1,
+										Default:  nil,
+										Nullable: true,
+										Type:     "int(11)",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			origin: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+			},
+			statement: `
 				DROP DATABASE test;
 				CREATE TABLE t(a int);
 			`,

--- a/plugin/advisor/catalog/walk_through_test.go
+++ b/plugin/advisor/catalog/walk_through_test.go
@@ -38,6 +38,208 @@ func TestWalkThrough(t *testing.T) {
 					INDEX (b, a),
 					UNIQUE (b, c, d),
 					FULLTEXT (b, d) WITH PARSER ngram INVISIBLE
+				);
+				CREATE TABLE t_copy like t;
+			`,
+			want: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+				SchemaList: []*Schema{
+					{
+						Name: "",
+						TableList: []*Table{
+							{
+								Name: "t_copy",
+								ColumnList: []*Column{
+									{
+										Name:     "a",
+										Position: 1,
+										Default:  &one,
+										Nullable: false,
+										Type:     "int(11)",
+									},
+									{
+										Name:         "b",
+										Position:     2,
+										Default:      nil,
+										Nullable:     false,
+										Type:         "varchar(200)",
+										CharacterSet: "utf8mb4",
+									},
+									{
+										Name:     "c",
+										Position: 3,
+										Default:  nil,
+										Nullable: true,
+										Type:     "int(11)",
+										Comment:  "This is a comment",
+									},
+									{
+										Name:      "d",
+										Position:  4,
+										Default:   nil,
+										Nullable:  true,
+										Type:      "varchar(10)",
+										Collation: "utf8mb4_polish_ci",
+									},
+								},
+								IndexList: []*Index{
+									{
+										Name:           "PRIMARY",
+										ExpressionList: []string{"a"},
+										Type:           "BTREE",
+										Unique:         true,
+										Primary:        true,
+										Visible:        true,
+									},
+									{
+										Name:           "b",
+										ExpressionList: []string{"b"},
+										Type:           "BTREE",
+										Unique:         true,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "idx_a",
+										ExpressionList: []string{"a"},
+										Type:           "BTREE",
+										Unique:         false,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "b_2",
+										ExpressionList: []string{"b", "a"},
+										Type:           "BTREE",
+										Unique:         false,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "b_3",
+										ExpressionList: []string{"b", "c", "d"},
+										Type:           "BTREE",
+										Unique:         true,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "b_4",
+										ExpressionList: []string{"b", "d"},
+										Type:           "FULLTEXT",
+										Unique:         false,
+										Primary:        false,
+										Visible:        false,
+									},
+								},
+							},
+							{
+								Name: "t",
+								ColumnList: []*Column{
+									{
+										Name:     "a",
+										Position: 1,
+										Default:  &one,
+										Nullable: false,
+										Type:     "int(11)",
+									},
+									{
+										Name:         "b",
+										Position:     2,
+										Default:      nil,
+										Nullable:     false,
+										Type:         "varchar(200)",
+										CharacterSet: "utf8mb4",
+									},
+									{
+										Name:     "c",
+										Position: 3,
+										Default:  nil,
+										Nullable: true,
+										Type:     "int(11)",
+										Comment:  "This is a comment",
+									},
+									{
+										Name:      "d",
+										Position:  4,
+										Default:   nil,
+										Nullable:  true,
+										Type:      "varchar(10)",
+										Collation: "utf8mb4_polish_ci",
+									},
+								},
+								IndexList: []*Index{
+									{
+										Name:           "PRIMARY",
+										ExpressionList: []string{"a"},
+										Type:           "BTREE",
+										Unique:         true,
+										Primary:        true,
+										Visible:        true,
+									},
+									{
+										Name:           "b",
+										ExpressionList: []string{"b"},
+										Type:           "BTREE",
+										Unique:         true,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "idx_a",
+										ExpressionList: []string{"a"},
+										Type:           "BTREE",
+										Unique:         false,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "b_2",
+										ExpressionList: []string{"b", "a"},
+										Type:           "BTREE",
+										Unique:         false,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "b_3",
+										ExpressionList: []string{"b", "c", "d"},
+										Type:           "BTREE",
+										Unique:         true,
+										Primary:        false,
+										Visible:        true,
+									},
+									{
+										Name:           "b_4",
+										ExpressionList: []string{"b", "d"},
+										Type:           "FULLTEXT",
+										Unique:         false,
+										Primary:        false,
+										Visible:        false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			origin: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+			},
+			statement: `
+				CREATE TABLE t(
+					a int PRIMARY KEY DEFAULT 1,
+					b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE,
+					c int auto_increment NULL COMMENT 'This is a comment',
+					d varchar(10) COLLATE utf8mb4_polish_ci,
+					KEY idx_a (a),
+					INDEX (b, a),
+					UNIQUE (b, c, d),
+					FULLTEXT (b, d) WITH PARSER ngram INVISIBLE
 				)
 			`,
 			want: &Database{

--- a/plugin/advisor/catalog/walk_through_test.go
+++ b/plugin/advisor/catalog/walk_through_test.go
@@ -449,6 +449,20 @@ func TestWalkThrough(t *testing.T) {
 				DbType: db.MySQL,
 			},
 			statement: `
+				DROP DATABASE test;
+				CREATE TABLE t(a int);
+			`,
+			err: &WalkThroughError{
+				Type:    ErrorTypeDatabaseIsDeleted,
+				Content: "Database `test` is deleted",
+			},
+		},
+		{
+			origin: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+			},
+			statement: `
 				CREATE TABLE t(
 					a int PRIMARY KEY DEFAULT 1,
 					b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE,

--- a/plugin/advisor/catalog/walk_through_test.go
+++ b/plugin/advisor/catalog/walk_through_test.go
@@ -29,6 +29,23 @@ func TestWalkThrough(t *testing.T) {
 				DbType: db.MySQL,
 			},
 			statement: `
+				ALTER DATABASE CHARACTER SET = utf8mb4;
+				ALTER DATABASE test COLLATE utf8mb4_polish_ci;
+			`,
+			want: &Database{
+				Name:         "test",
+				DbType:       db.MySQL,
+				CharacterSet: "utf8mb4",
+				Collation:    "utf8mb4_polish_ci",
+				SchemaList:   []*Schema{{}},
+			},
+		},
+		{
+			origin: &Database{
+				Name:   "test",
+				DbType: db.MySQL,
+			},
+			statement: `
 				CREATE TABLE t(
 					a int PRIMARY KEY DEFAULT 1,
 					b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE,


### PR DESCRIPTION
support:
1. CREATE TABLE ... LIKE ...
2. ALTER DATABASE
3. DROP DATABASE
4. RENAME TABLE
5. return error for CREATE DATABASE

close BYT-1339