### PR TITLE
chore: rename UpdateSchema to Migration in issue creation

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -144,7 +144,7 @@ type CreateDatabaseContext struct {
 	Labels string `jsonapi:"attr,labels,omitempty"`
 }
 
-// MigrationDetail is the detail of updating database schema.
+// MigrationDetail is the detail for database migration such as Migrate, Data.
 type MigrationDetail struct {
 	// DatabaseID is the ID of a database.
 	DatabaseID int `json:"databaseId"`

--- a/api/issue.go
+++ b/api/issue.go
@@ -144,8 +144,8 @@ type CreateDatabaseContext struct {
 	Labels string `jsonapi:"attr,labels,omitempty"`
 }
 
-// UpdateSchemaDetail is the detail of updating database schema.
-type UpdateSchemaDetail struct {
+// MigrationDetail is the detail of updating database schema.
+type MigrationDetail struct {
 	// DatabaseID is the ID of a database.
 	DatabaseID int `json:"databaseId"`
 	// DatabaseName is the name of databases, mutually exclusive to DatabaseID.
@@ -160,13 +160,13 @@ type UpdateSchemaDetail struct {
 	SchemaVersion string `json:"schemaVersion"`
 }
 
-// UpdateSchemaContext is the issue create context for updating database schema.
-type UpdateSchemaContext struct {
+// MigrationContext is the issue create context for database migration such as Migrate, Data.
+type MigrationContext struct {
 	// MigrationType is the type of a migration.
 	MigrationType db.MigrationType `json:"migrationType"`
 	// DetailList is the details of schema update.
 	// When a project is in tenant mode, there should be one item in the list.
-	DetailList []*UpdateSchemaDetail `json:"updateSchemaDetailList"`
+	DetailList []*MigrationDetail `json:"detailList"`
 	// VCSPushEvent is the event information for VCS push.
 	VCSPushEvent *vcs.PushEvent `json:"vcsPushEvent"`
 }
@@ -186,9 +186,9 @@ type UpdateSchemaGhostDetail struct {
 
 // UpdateSchemaGhostContext is the issue create context for updating database schema using gh-ost.
 type UpdateSchemaGhostContext struct {
-	// UpdateSchemaGhostDetail is the details of schema update.
+	// DetailList is the details of schema update.
 	// When a project is in tenant mode, there should be one item in the list.
-	DetailList []*UpdateSchemaGhostDetail `json:"updateSchemaGhostDetailList"`
+	DetailList []*UpdateSchemaGhostDetail `json:"detailList"`
 	// VCSPushEvent is the event information for VCS push.
 	VCSPushEvent *vcs.PushEvent
 }

--- a/docs/design/gh-ost-integration.md
+++ b/docs/design/gh-ost-integration.md
@@ -378,7 +378,7 @@ type UpdateSchemaGhostDetail struct {
 }
 
 type UpdateSchemaGhostContext struct {
-    UpdateSchemaDetailList []*UpdateSchemaGhostDetail `json:"updateSchemaDetailList`
+    DetailList []*UpdateSchemaGhostDetail `json:"detailList`
     VCSPushEvent *vcs.PushEvent
 }
 

--- a/frontend/src/components/Issue/logic/GhostModeProvider.ts
+++ b/frontend/src/components/Issue/logic/GhostModeProvider.ts
@@ -49,7 +49,7 @@ export default defineComponent({
       const stageList = issueCreate.pipeline!.stageList;
       const createContext =
         issueCreate.createContext as UpdateSchemaGhostContext;
-      const detailList = createContext.updateSchemaGhostDetailList;
+      const detailList = createContext.detailList;
       stageList.forEach((stage, i) => {
         const detail = detailList[i];
         const syncTask = stage.taskList.find(

--- a/frontend/src/components/Issue/logic/TenantModeProvider.ts
+++ b/frontend/src/components/Issue/logic/TenantModeProvider.ts
@@ -7,7 +7,7 @@ import {
   Task,
   TaskCreate,
   TaskDatabaseSchemaUpdatePayload,
-  UpdateSchemaContext,
+  MigrationContext,
 } from "@/types";
 import {
   errorAssertion,
@@ -37,8 +37,8 @@ export default defineComponent({
     const selectedStatement = computed(() => {
       if (create.value) {
         const issueCreate = issue.value as IssueCreate;
-        const context = issueCreate.createContext as UpdateSchemaContext;
-        return context.updateSchemaDetailList[0].statement;
+        const context = issueCreate.createContext as MigrationContext;
+        return context.detailList[0].statement;
       } else {
         const issueEntity = issue.value as Issue;
         const task = issueEntity.pipeline.stageList[0].taskList[0];
@@ -59,9 +59,9 @@ export default defineComponent({
         });
 
         const issueCreate = issue.value as IssueCreate;
-        const context = issueCreate.createContext as UpdateSchemaContext;
+        const context = issueCreate.createContext as MigrationContext;
         // We also apply it back to the CreateContext
-        context.updateSchemaDetailList.forEach(
+        context.detailList.forEach(
           (detail) => (detail.statement = newStatement)
         );
       } else {
@@ -92,8 +92,8 @@ export default defineComponent({
       // for multi-tenancy issue pipeline (M * N)
       // createContext is up-to-date already
       // so we just format the statement if needed
-      const context = issueCreate.createContext as UpdateSchemaContext;
-      context.updateSchemaDetailList.forEach((detail) => {
+      const context = issueCreate.createContext as MigrationContext;
+      context.detailList.forEach((detail) => {
         const db = databaseStore.getDatabaseById(detail.databaseId!);
         detail.statement = maybeFormatStatementOnSave(detail.statement, db);
       });

--- a/frontend/src/components/Issue/logic/common.ts
+++ b/frontend/src/components/Issue/logic/common.ts
@@ -25,8 +25,8 @@ import {
   TaskId,
   TaskPatch,
   TaskType,
-  UpdateSchemaContext,
-  UpdateSchemaDetail,
+  MigrationContext,
+  MigrationDetail,
 } from "@/types";
 import { useIssueLogic } from "./index";
 import { taskCheckRunSummary } from "./utils";
@@ -182,7 +182,7 @@ export const useCommonLogic = () => {
     // for standard issue pipeline (1 * 1 or M * 1)
     // copy user edited tasks back to issue.createContext
     const taskList = flattenTaskList<TaskCreate>(issueCreate);
-    const detailList: UpdateSchemaDetail[] = taskList.map((task) => {
+    const detailList: MigrationDetail[] = taskList.map((task) => {
       const db = databaseStore.getDatabaseById(task.databaseId!);
       return {
         databaseId: task.databaseId!,
@@ -195,7 +195,7 @@ export const useCommonLogic = () => {
 
     issueCreate.createContext = {
       migrationType,
-      updateSchemaDetailList: detailList,
+      detailList: detailList,
     };
 
     // If the database is within VCS project, try to find its latest and done migration history from VCS.
@@ -210,7 +210,7 @@ export const useCommonLogic = () => {
             database.name
           );
         if (migrationHistory) {
-          (issueCreate.createContext as UpdateSchemaContext).vcsPushEvent =
+          (issueCreate.createContext as MigrationContext).vcsPushEvent =
             migrationHistory.payload?.pushEvent;
         }
       }

--- a/frontend/src/plugins/issue/logic/initialize/ghost.ts
+++ b/frontend/src/plugins/issue/logic/initialize/ghost.ts
@@ -32,7 +32,7 @@ const buildNewGhostIssue = async (
 
   const databaseList = findDatabaseListByQuery(context);
   const createContext: UpdateSchemaGhostContext = {
-    updateSchemaGhostDetailList: databaseList.map((db) => {
+    detailList: databaseList.map((db) => {
       return {
         databaseId: db.id,
         databaseName: db.name,

--- a/frontend/src/plugins/issue/logic/initialize/standard.ts
+++ b/frontend/src/plugins/issue/logic/initialize/standard.ts
@@ -4,7 +4,7 @@ import {
   IssueCreate,
   IssueCreateContext,
   MigrationType,
-  UpdateSchemaContext,
+  MigrationContext,
 } from "@/types";
 import {
   findDatabaseListByQuery,
@@ -37,7 +37,7 @@ export const buildNewStandardIssue = async (
 
   const createContext: IssueCreateContext = {
     migrationType,
-    updateSchemaDetailList: databaseList.map((db) => {
+    detailList: databaseList.map((db) => {
       return {
         databaseId: db.id,
         databaseName: "", // Only `databaseId` is needed in standard pipeline.
@@ -58,7 +58,7 @@ export const buildNewStandardIssue = async (
           database.name
         );
       if (migrationHistory) {
-        (createContext as UpdateSchemaContext).vcsPushEvent =
+        (createContext as MigrationContext).vcsPushEvent =
           migrationHistory.payload?.pushEvent;
       }
     }

--- a/frontend/src/plugins/issue/logic/initialize/tenant.ts
+++ b/frontend/src/plugins/issue/logic/initialize/tenant.ts
@@ -62,8 +62,7 @@ const buildNewTenantSchemaUpdateIssue = async (
   // is not that friendly to users
   // setting it to empty can provide a placeholder to user, along with an
   // exclamation mark indicating "No SQL statement"
-  const createContext = helper.issueCreate!
-    .createContext as MigrationContext;
+  const createContext = helper.issueCreate!.createContext as MigrationContext;
   createContext.detailList[0].statement = "";
 
   return helper.generate();

--- a/frontend/src/plugins/issue/logic/initialize/tenant.ts
+++ b/frontend/src/plugins/issue/logic/initialize/tenant.ts
@@ -3,7 +3,7 @@ import {
   IssueCreate,
   IssueType,
   MigrationType,
-  UpdateSchemaContext,
+  MigrationContext,
 } from "@/types";
 import {
   findProject,
@@ -49,7 +49,7 @@ const buildNewTenantSchemaUpdateIssue = async (
   }
   helper.issueCreate!.createContext = {
     migrationType,
-    updateSchemaDetailList: [
+    detailList: [
       {
         databaseName: route.query.databaseName,
         statement: VALIDATE_ONLY_SQL,
@@ -63,8 +63,8 @@ const buildNewTenantSchemaUpdateIssue = async (
   // setting it to empty can provide a placeholder to user, along with an
   // exclamation mark indicating "No SQL statement"
   const createContext = helper.issueCreate!
-    .createContext as UpdateSchemaContext;
-  createContext.updateSchemaDetailList[0].statement = "";
+    .createContext as MigrationContext;
+  createContext.detailList[0].statement = "";
 
   return helper.generate();
 };

--- a/frontend/src/types/issue.ts
+++ b/frontend/src/types/issue.ts
@@ -44,26 +44,26 @@ export type CreateDatabaseContext = {
   labels?: string; // JSON encoded
 };
 
-export type UpdateSchemaDetail = {
+export type MigrationDetail = {
   databaseId: DatabaseId;
   databaseName: string;
   statement: string;
   earliestAllowedTs: number;
 };
 
-export type UpdateSchemaGhostDetail = UpdateSchemaDetail & {
+export type UpdateSchemaGhostDetail = MigrationDetail & {
   // empty by now
   // more input parameters in the future
 };
 
-export type UpdateSchemaContext = {
+export type MigrationContext = {
   migrationType: MigrationType;
-  updateSchemaDetailList: UpdateSchemaDetail[];
+  detailList: MigrationDetail[];
   vcsPushEvent?: VCSPushEvent;
 };
 
 export type UpdateSchemaGhostContext = {
-  updateSchemaGhostDetailList: UpdateSchemaGhostDetail[];
+  detailList: UpdateSchemaGhostDetail[];
 };
 
 export type PITRContext = {
@@ -78,7 +78,7 @@ export type EmptyContext = {};
 
 export type IssueCreateContext =
   | CreateDatabaseContext
-  | UpdateSchemaContext
+  | MigrationContext
   | UpdateSchemaGhostContext
   | PITRContext
   | EmptyContext;

--- a/server/issue.go
+++ b/server/issue.go
@@ -602,7 +602,7 @@ func (s *Server) getPipelineCreateForDatabasePITR(ctx context.Context, issueCrea
 }
 
 func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Context, issueCreate *api.IssueCreate) (*api.PipelineCreate, error) {
-	c := api.UpdateSchemaContext{}
+	c := api.MigrationContext{}
 	if err := json.Unmarshal([]byte(issueCreate.CreateContext), &c); err != nil {
 		return nil, err
 	}
@@ -833,7 +833,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaUpdateGhost(ctx context.Conte
 	return create, nil
 }
 
-func getUpdateTask(database *api.Database, migrationType db.MigrationType, vcsPushEvent *vcs.PushEvent, d *api.UpdateSchemaDetail, schemaVersion string) (*api.TaskCreate, error) {
+func getUpdateTask(database *api.Database, migrationType db.MigrationType, vcsPushEvent *vcs.PushEvent, d *api.MigrationDetail, schemaVersion string) (*api.TaskCreate, error) {
 	taskName := fmt.Sprintf("Establish %q baseline", database.Name)
 	switch migrationType {
 	case db.Migrate:

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -143,9 +143,9 @@ func TestGhostSchemaUpdate(t *testing.T) {
 	database := databases[0]
 	a.Equal(instance.ID, database.Instance.ID)
 
-	createContext, err := json.Marshal(&api.UpdateSchemaContext{
+	createContext, err := json.Marshal(&api.MigrationContext{
 		MigrationType: db.Migrate,
-		DetailList: []*api.UpdateSchemaDetail{
+		DetailList: []*api.MigrationDetail{
 			{
 				DatabaseID: database.ID,
 				Statement:  mysqlMigrationStatement,

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -93,9 +93,9 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	a.Equal(instance.ID, database.Instance.ID)
 
 	// Create an issue that updates database schema.
-	createContext, err := json.Marshal(&api.UpdateSchemaContext{
+	createContext, err := json.Marshal(&api.MigrationContext{
 		MigrationType: db.Migrate,
-		DetailList: []*api.UpdateSchemaDetail{
+		DetailList: []*api.MigrationDetail{
 			{
 				DatabaseID: database.ID,
 				Statement:  migrationStatement,
@@ -123,9 +123,9 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	a.Equal(bookSchemaSQLResult, result)
 
 	// Create an issue that updates database data.
-	createContext, err = json.Marshal(&api.UpdateSchemaContext{
+	createContext, err = json.Marshal(&api.MigrationContext{
 		MigrationType: db.Data,
-		DetailList: []*api.UpdateSchemaDetail{
+		DetailList: []*api.MigrationDetail{
 			{
 				DatabaseID: database.ID,
 				Statement:  dataUpdateStatement,

--- a/tests/sql_review_test.go
+++ b/tests/sql_review_test.go
@@ -734,9 +734,9 @@ func TestSQLReviewForMySQL(t *testing.T) {
 }
 
 func createIssueAndReturnSQLReviewResult(a *require.Assertions, ctl *controller, databaseID int, projectID int, assigneeID int, statement string, wait bool) []api.TaskCheckResult {
-	createContext, err := json.Marshal(&api.UpdateSchemaContext{
+	createContext, err := json.Marshal(&api.MigrationContext{
 		MigrationType: db.Migrate,
-		DetailList: []*api.UpdateSchemaDetail{
+		DetailList: []*api.MigrationDetail{
 			{
 				DatabaseID: databaseID,
 				Statement:  statement,

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -151,9 +151,9 @@ func TestTenant(t *testing.T) {
 	a.Equal(prodTenantNumber, len(prodDatabases))
 
 	// Create an issue that updates database schema.
-	createContext, err := json.Marshal(&api.UpdateSchemaContext{
+	createContext, err := json.Marshal(&api.MigrationContext{
 		MigrationType: db.Migrate,
-		DetailList: []*api.UpdateSchemaDetail{
+		DetailList: []*api.MigrationDetail{
 			{
 				DatabaseName: databaseName,
 				Statement:    migrationStatement,
@@ -616,9 +616,9 @@ func TestTenantDatabaseNameTemplate(t *testing.T) {
 	a.Equal(len(prodDatabases), prodTenantNumber)
 
 	// Create an issue that updates database schema.
-	createContext, err := json.Marshal(&api.UpdateSchemaContext{
+	createContext, err := json.Marshal(&api.MigrationContext{
 		MigrationType: db.Migrate,
-		DetailList: []*api.UpdateSchemaDetail{
+		DetailList: []*api.MigrationDetail{
 			{
 				DatabaseName: baseDatabaseName,
 				Statement:    migrationStatement,


### PR DESCRIPTION
The struct was intended for updating schema in the beginning but the name should be migration for repurposing to data change.