### PR TITLE
fix(sql-editor): Editor history does not work

### DIFF
--- a/frontend/src/store/modules/activity.ts
+++ b/frontend/src/store/modules/activity.ts
@@ -168,23 +168,35 @@ export const useActivityStore = defineStore("activity", {
     },
     async fetchActivityListForQueryHistory({ limit }: { limit: number }) {
       const { currentUser } = useAuthStore();
-      const queryList = [
-        "typePrefix=bb.sql-editor.query",
-        `user=${currentUser.id}`,
-        `order=DESC`,
-        `limit=${limit}`,
-        // only fetch the successful query history
-        `level=INFO`,
-      ];
-      const data = (await axios.get(`/api/activity?${queryList.join("&")}`))
-        .data;
-      const activityList: Activity[] = data.data.map(
-        (activity: ResourceObject) => {
-          return convert(activity, data.included);
-        }
-      );
+      const fetchQueryList = async (level: string) => {
+        const queryList = [
+          "typePrefix=bb.sql-editor.query",
+          `user=${currentUser.id}`,
+          `order=DESC`,
+          `limit=${limit}`,
+          // only fetch the successful query history
+          `level=${level}`,
+        ];
+        const data = (await axios.get(`/api/activity?${queryList.join("&")}`))
+          .data;
+        const activityList: Activity[] = data.data.map(
+          (activity: ResourceObject) => {
+            return convert(activity, data.included);
+          }
+        );
+        return activityList;
+      };
+      const [successful, withWarning] = await Promise.all([
+        fetchQueryList("INFO"),
+        fetchQueryList("WARN"),
+      ]);
+      const mixedList = [...successful, ...withWarning];
 
-      return activityList;
+      // ORDER BY `id` DESC
+      mixedList.sort((a, b) => b.id - a.id);
+
+      // return the first `limit` rows
+      return mixedList.slice(0, limit);
     },
     async fetchActivityListForDatabaseByProjectId({
       projectId,


### PR DESCRIPTION
Close Editor history does not work

We once fetch only query history items that were executed successfully. Now we also fetch the items that were executed without error but with warnings.
The `/api/activity` API endpoint doesn't support multiple `level` filters in a request. So we request them both and then mix them at the frontend side.