### PR TITLE
fix: must find a database in composeBackupSetting

### DIFF
--- a/store/backup.go
+++ b/store/backup.go
@@ -279,6 +279,9 @@ func (s *Store) composeBackupSetting(ctx context.Context, raw *backupSettingRaw)
 	if err != nil {
 		return nil, err
 	}
+	if database == nil {
+		return nil, errors.Errorf("failed to get database with databaseID %v", backupSetting.DatabaseID)
+	}
 	backupSetting.Database = database
 
 	return backupSetting, nil


### PR DESCRIPTION
Fix the panic:
```
2022-09-17T00:03:01.670+0800	ERROR	Auto backup runner PANIC RECOVER	{"error": "runtime error: invalid memory address or nil pointer dereference", "panic-stack": "[github.com/bytebase/bytebase/server.(*BackupRunner).Run.func1.1\n\t/Users/danny/src/bytebase/server/backup_runner.go:61\nruntime.gopanic\n\t/opt/homebrew/Cellar/go/1.19.1/libexec/src/runtime/panic.go:890\nruntime.panicmem\n\t/opt/homebrew/Cellar/go/1.19.1/libexec/src/runtime/panic.go:260\nruntime.sigpanic\n\t/opt/homebrew/Cellar/go/1.19.1/libexec/src/runtime/signal_unix.go:835\ngithub.com/bytebase/bytebase/server.(*BackupRunner).startAutoBackups\n\t/Users/danny/src/bytebase/server/backup_runner.go:307\ngithub.com/bytebase/bytebase/server.(*BackupRunner).Run.func1\n\t/Users/danny/src/bytebase/server/backup_runner.go:64\ngithub.com/bytebase/bytebase/server.(*BackupRunner).Run\n\t/Users/danny/src/bytebase/server/backup_runner.go:67](http://github.com/bytebase/bytebase/server.(*BackupRunner).Run.func1.1/n/t/Users/danny/src/bytebase/server/backup_runner.go:61/nruntime.gopanic/n/t/opt/homebrew/Cellar/go/1.19.1/libexec/src/runtime/panic.go:890/nruntime.panicmem/n/t/opt/homebrew/Cellar/go/1.19.1/libexec/src/runtime/panic.go:260/nruntime.sigpanic/n/t/opt/homebrew/Cellar/go/1.19.1/libexec/src/runtime/signal_unix.go:835/ngithub.com/bytebase/bytebase/server.(*BackupRunner).startAutoBackups/n/t/Users/danny/src/bytebase/server/backup_runner.go:307/ngithub.com/bytebase/bytebase/server.(*BackupRunner).Run.func1/n/t/Users/danny/src/bytebase/server/backup_runner.go:64/ngithub.com/bytebase/bytebase/server.(*BackupRunner).Run/n/t/Users/danny/src/bytebase/server/backup_runner.go:67)"}
```

which is caused because `backupSetting.Database` is `nil`