### PR TITLE
chore: don't upsert backup settings for wildcard databases

### DIFF
--- a/store/backup.go
+++ b/store/backup.go
@@ -186,11 +186,7 @@ func (s *Store) FindBackupSetting(ctx context.Context, find api.BackupSettingFin
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to compose BackupSetting with backupSettingRaw %+v", raw)
 		}
-		// We may have existing backup settings for database with name "*" (api.AllDatabaseName).
-		// This will cause GetDatabase() in composeBackupSettings to return nil, and we need to filter out these stale data.
-		if backupSetting != nil {
-			backupSettingList = append(backupSettingList, backupSetting)
-		}
+		backupSettingList = append(backupSettingList, backupSetting)
 	}
 	return backupSettingList, nil
 }
@@ -236,11 +232,7 @@ func (s *Store) FindBackupSettingsMatch(ctx context.Context, match *api.BackupSe
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", raw)
 		}
-		// We may have existing backup settings for database with name "*" (api.AllDatabaseName).
-		// This will cause GetDatabase() in composeBackupSettings to return nil, and we need to filter out these stale data.
-		if backupSetting != nil {
-			backupSettingList = append(backupSettingList, backupSetting)
-		}
+		backupSettingList = append(backupSettingList, backupSetting)
 	}
 	return backupSettingList, nil
 }
@@ -288,7 +280,7 @@ func (s *Store) composeBackupSetting(ctx context.Context, raw *backupSettingRaw)
 		return nil, err
 	}
 	if database == nil {
-		return nil, nil
+		return nil, errors.Errorf("failed to get database with databaseID %v", backupSetting.DatabaseID)
 	}
 	backupSetting.Database = database
 

--- a/store/backup.go
+++ b/store/backup.go
@@ -186,7 +186,11 @@ func (s *Store) FindBackupSetting(ctx context.Context, find api.BackupSettingFin
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to compose BackupSetting with backupSettingRaw %+v", raw)
 		}
-		backupSettingList = append(backupSettingList, backupSetting)
+		// We may have existing backup settings for database with name "*" (api.AllDatabaseName).
+		// This will cause GetDatabase() in composeBackupSettings to return nil, and we need to filter out these stale data.
+		if backupSetting != nil {
+			backupSettingList = append(backupSettingList, backupSetting)
+		}
 	}
 	return backupSettingList, nil
 }
@@ -232,7 +236,11 @@ func (s *Store) FindBackupSettingsMatch(ctx context.Context, match *api.BackupSe
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to compose Backup with backupRaw[%+v]", raw)
 		}
-		backupSettingList = append(backupSettingList, backupSetting)
+		// We may have existing backup settings for database with name "*" (api.AllDatabaseName).
+		// This will cause GetDatabase() in composeBackupSettings to return nil, and we need to filter out these stale data.
+		if backupSetting != nil {
+			backupSettingList = append(backupSettingList, backupSetting)
+		}
 	}
 	return backupSettingList, nil
 }
@@ -280,7 +288,7 @@ func (s *Store) composeBackupSetting(ctx context.Context, raw *backupSettingRaw)
 		return nil, err
 	}
 	if database == nil {
-		return nil, errors.Errorf("failed to get database with databaseID %v", backupSetting.DatabaseID)
+		return nil, nil
 	}
 	backupSetting.Database = database
 

--- a/store/database.go
+++ b/store/database.go
@@ -309,7 +309,7 @@ func (s *Store) createDatabaseRawTx(ctx context.Context, tx *Tx, create *api.Dat
 	}
 
 	// Enable automatic backup setting based on backup plan policy.
-	if backupPlanPolicy.Schedule != api.BackupPlanPolicyScheduleUnset {
+	if backupPlanPolicy.Schedule != api.BackupPlanPolicyScheduleUnset && databaseRaw.Name != api.AllDatabaseName {
 		backupSettingUpsert := &api.BackupSettingUpsert{
 			UpdaterID:         api.SystemBotID,
 			DatabaseID:        databaseRaw.ID,

--- a/store/migration/prod/1.4/0002__delete_wildcard_database_backup_settings.sql
+++ b/store/migration/prod/1.4/0002__delete_wildcard_database_backup_settings.sql
@@ -1,0 +1,9 @@
+DELETE FROM backup_setting
+WHERE id IN
+(
+  SELECT
+    backup_setting.id
+  FROM backup_setting
+  INNER JOIN db ON backup_setting.database_id = db.id
+  WHERE db.name = '*'
+);

--- a/store/pg_engine_test.go
+++ b/store/pg_engine_test.go
@@ -219,5 +219,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("1.4.1"), releaseVersion)
+	require.Equal(t, semver.MustParse("1.4.2"), releaseVersion)
 }


### PR DESCRIPTION
The backup settings could point to wildcard databases previously causing in composeBackupSettings() to fail because GetDatabase() will return nil for the wildcard database.

1. We should prevent database settings upserts for wildcard databases.
2. change data to delete any previous backup settings for wildcard databases.