### PR TITLE
feat(frontend): memorize pagination state

### DIFF
--- a/frontend/src/components/Issue/PagedIssueTable.vue
+++ b/frontend/src/components/Issue/PagedIssueTable.vue
@@ -134,7 +134,7 @@ const fetchData = (refresh = false) => {
       if (issueList.length === 0) {
         state.hasMore = false;
       } else if (!isFirstFetch) {
-        // If we didn't reach the end, memoize we've clicked the "load more" button.
+        // If we didn't reach the end, memorize we've clicked the "load more" button.
         sessionState.value.page++;
       }
 

--- a/frontend/src/components/Issue/PagedIssueTable.vue
+++ b/frontend/src/components/Issue/PagedIssueTable.vue
@@ -25,8 +25,13 @@
 </template>
 
 <script lang="ts" setup>
-import { buildQueryListByIssueFind, useIssueStore } from "@/store";
+import {
+  buildQueryListByIssueFind,
+  useIsLoggedIn,
+  useIssueStore,
+} from "@/store";
 import { Issue, IssueFind } from "@/types";
+import { useSessionStorage } from "@vueuse/core";
 import { computed, PropType, reactive, watch } from "vue";
 
 type LocalState = {
@@ -36,9 +41,29 @@ type LocalState = {
   hasMore: boolean;
 };
 
+/**
+ * It's complex and dangerous to cache the issue list.
+ * So we just memoize how many times the user clicks the "load more" button.
+ * And load the first N pages in the first fetch.
+ * E.g., the user clicked "load more" 4 times, then the first time will set limit
+ *   to `pageSize * 5`.
+ */
+type SessionState = {
+  // How many times the user clicks the "load more" button.
+  page: number;
+  // Help us to check if the session is outdated.
+  updatedTs: number;
+};
+
 const MAX_PAGE_SIZE = 1000;
+const SESSION_LIFE = 1 * 60 * 1000; // 1 minute
 
 const props = defineProps({
+  // A unique key to identify the session state.
+  sessionKey: {
+    type: String,
+    required: true,
+  },
   issueFind: {
     type: Object as PropType<IssueFind>,
     default: undefined,
@@ -60,7 +85,16 @@ const state = reactive<LocalState>({
   hasMore: true,
 });
 
+const sessionState = useSessionStorage<SessionState>(
+  `bb.page-issue-table.${props.sessionKey}`,
+  {
+    page: 1,
+    updatedTs: 0,
+  }
+);
+
 const issueStore = useIssueStore();
+const isLoggedIn = useIsLoggedIn();
 
 const limit = computed(() => {
   if (props.pageSize <= 0) return MAX_PAGE_SIZE;
@@ -77,10 +111,17 @@ const condition = computed(() => {
 
 const fetchData = (refresh = false) => {
   state.loading = true;
+
+  const isFirstFetch = state.paginationToken === "";
+
   issueStore
     .fetchPagedIssueList({
       ...props.issueFind,
-      limit: limit.value,
+      limit: isFirstFetch
+        ? // Load one or more page for the first fetch to restore the session
+          limit.value * sessionState.value.page
+        : // Always load one page if NOT the first fetch
+          limit.value,
       token: state.paginationToken,
     })
     .then(({ nextToken, issueList }) => {
@@ -92,8 +133,12 @@ const fetchData = (refresh = false) => {
 
       if (issueList.length === 0) {
         state.hasMore = false;
+      } else if (!isFirstFetch) {
+        // If we didn't reach the end, memoize we've clicked the "load more" button.
+        sessionState.value.page++;
       }
 
+      sessionState.value.updatedTs = Date.now();
       state.paginationToken = nextToken;
     })
     .finally(() => {
@@ -101,9 +146,17 @@ const fetchData = (refresh = false) => {
     });
 };
 
+const resetSession = () => {
+  sessionState.value = {
+    page: 1,
+    updatedTs: 0,
+  };
+};
+
 const refresh = () => {
   state.paginationToken = "";
   state.hasMore = true;
+  resetSession();
   fetchData(true);
 };
 
@@ -111,6 +164,16 @@ const fetchNextPage = () => {
   fetchData(false);
 };
 
+if (Date.now() - sessionState.value.updatedTs > SESSION_LIFE) {
+  // Reset session if it's outdated.
+  resetSession();
+}
 fetchData(true);
 watch(condition, refresh);
+watch(isLoggedIn, () => {
+  // Reset session when logged out.
+  if (!isLoggedIn.value) {
+    resetSession();
+  }
+});
 </script>

--- a/frontend/src/components/Issue/PagedIssueTable.vue
+++ b/frontend/src/components/Issue/PagedIssueTable.vue
@@ -43,7 +43,7 @@ type LocalState = {
 
 /**
  * It's complex and dangerous to cache the issue list.
- * So we just memoize how many times the user clicks the "load more" button.
+ * So we just memorize how many times the user clicks the "load more" button.
  * And load the first N pages in the first fetch.
  * E.g., the user clicked "load more" 4 times, then the first time will set limit
  *   to `pageSize * 5`.

--- a/frontend/src/components/ProjectOverviewPanel.vue
+++ b/frontend/src/components/ProjectOverviewPanel.vue
@@ -87,6 +87,7 @@
       <!-- show OPEN issues with pageSize=10 -->
       <div>
         <PagedIssueTable
+          session-key="project-open"
           :issue-find="{
             statusList: ['OPEN'],
             projectId: project.id,
@@ -107,6 +108,7 @@
         <!-- show the first 5 DONE or CANCELED issues -->
         <!-- But won't show "Load more", since we have a "View all closed" link below -->
         <PagedIssueTable
+          session-key="project-closed"
           :issue-find="{
             statusList: ['DONE', 'CANCELED'],
             projectId: project.id,

--- a/frontend/src/store/modules/auth.ts
+++ b/frontend/src/store/modules/auth.ts
@@ -1,7 +1,7 @@
 import { defineStore, storeToRefs } from "pinia";
 import axios from "axios";
 import { isEqual } from "lodash-es";
-import { Ref } from "vue";
+import { computed, Ref } from "vue";
 import {
   Principal,
   AuthState,
@@ -130,4 +130,9 @@ export const useAuthStore = defineStore("auth", {
 
 export const useCurrentUser = (): Ref<Principal> => {
   return storeToRefs(useAuthStore()).currentUser;
+};
+
+export const useIsLoggedIn = (): Ref<boolean> => {
+  const store = useAuthStore();
+  return computed(() => store.isLoggedIn());
 };

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -9,12 +9,13 @@
       <BBTableSearch
         ref="searchField"
         :placeholder="$t('issue.search-issue-name')"
-        @change-text="(text) => changeSearchText(text)"
+        @change-text="(text: string) => changeSearchText(text)"
       />
     </div>
 
     <!-- show OPEN Assigned issues with pageSize=10 -->
     <PagedIssueTable
+      session-key="home-assigned"
       :issue-find="{
         statusList: ['OPEN'],
         assigneeId: currentUser.id,
@@ -38,6 +39,7 @@
 
     <!-- show OPEN Created issues with pageSize=10 -->
     <PagedIssueTable
+      session-key="home-created"
       :issue-find="{
         statusList: ['OPEN'],
         creatorId: currentUser.id,
@@ -62,6 +64,7 @@
 
     <!-- show OPEN Subscribed issues with pageSize=10 -->
     <PagedIssueTable
+      session-key="home-subscribed"
       :issue-find="{
         statusList: ['OPEN'],
         subscriberId: currentUser.id,
@@ -87,6 +90,7 @@
     <!-- show the first 5 DONE or CANCELED issues -->
     <!-- But won't show "Load more", since we have a "View all closed" link below -->
     <PagedIssueTable
+      session-key="home-closed"
       :issue-find="{
         statusList: ['DONE', 'CANCELED'],
         principalId: currentUser.id,

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -34,6 +34,7 @@
     <!-- show all OPEN issues with pageSize=10  -->
     <PagedIssueTable
       v-if="showOpen"
+      session-key="dashboard-open"
       :issue-find="{
         statusList: ['OPEN'],
         principalId: selectedPrincipalId > 0 ? selectedPrincipalId : undefined,
@@ -58,6 +59,7 @@
     <!-- show all DONE and CANCELED issues with pageSize=10 -->
     <PagedIssueTable
       v-if="showClosed"
+      session-key="dashboard-closed"
       :issue-find="{
         statusList: ['DONE', 'CANCELED'],
         principalId: selectedPrincipalId > 0 ? selectedPrincipalId : undefined,


### PR DESCRIPTION
Close BYT-1324

It's complex and dangerous to cache the issue list.
So we just memorize how many times the user clicks the "load more" button, and load the first N pages in the first fetch.
E.g., if the user clicked "load more" 4 times, then the first time will set the `limit` to `pageSize * 5`.

The session will be reset in 1 minute after the last visit to the issue list.

Though the first fetch might be a little bit slower if the `limit` gets larger. It's more stable than fetching the pages one-by-one since an async request chain if quite complex to control.