### PR TITLE
fix: show new rules with disabled level in the frontend

### DIFF
--- a/frontend/src/types/sqlReview.ts
+++ b/frontend/src/types/sqlReview.ts
@@ -91,6 +91,7 @@ export type RuleType =
   | "statement.select.no-select-all"
   | "statement.where.require"
   | "statement.where.no-leading-wildcard-like"
+  | "statement.disallow-commit"
   | "schema.backward-compatibility"
   | "database.drop-empty-database";
 

--- a/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
@@ -204,7 +204,8 @@ import {
   SQLReviewPolicy,
   SchemaRuleEngineType,
   convertToCategoryList,
-  ruleTemplateMap,
+  RuleType,
+  TEMPLATE_LIST,
   convertPolicyRuleToRuleTemplate,
 } from "@/types";
 import {
@@ -264,6 +265,16 @@ const reviewPolicy = computed((): SQLReviewPolicy => {
   );
 });
 
+const ruleTemplateMap: Map<RuleType, RuleTemplate> = TEMPLATE_LIST.reduce(
+  (map, template) => {
+    for (const rule of template.ruleList) {
+      map.set(rule.type, rule);
+    }
+    return map;
+  },
+  new Map<RuleType, RuleTemplate>()
+);
+
 const selectedRuleList = computed((): RuleTemplate[] => {
   if (!reviewPolicy.value) {
     return [];
@@ -281,6 +292,14 @@ const selectedRuleList = computed((): RuleTemplate[] => {
     if (data) {
       ruleTemplateList.push(data);
     }
+    ruleTemplateMap.delete(policyRule.type);
+  }
+
+  for (const rule of ruleTemplateMap.values()) {
+    ruleTemplateList.push({
+      ...rule,
+      level: RuleLevel.DISABLED,
+    });
   }
 
   return ruleTemplateList;


### PR DESCRIPTION
After we add a new rule in the SQL review, we won’t migrate existing policies in the user’s database. So we need to show these new rules in the frontend with disabled level status.

<img width="707" alt="图片" src="https://user-images.githubusercontent.com/10706318/191157508-eb899ac5-4b6f-46c7-a1b1-9062cd59e9f7.png">
