### PR TITLE
feat: generate alter table stmt modify column specs if the comments of two columns not match

### DIFF
--- a/plugin/parser/differ/mysql/column_test.go
+++ b/plugin/parser/differ/mysql/column_test.go
@@ -138,6 +138,54 @@ func TestColumnOption(t *testing.T) {
 	}
 }
 
+func TestColumnComment(t *testing.T) {
+	tests := []struct {
+		old  string
+		new  string
+		want string
+	}{
+		// NULL option not match.
+		{
+			old:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Author Name' NOT NULL);`,
+			new:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Book Name' NOT NULL);`,
+			want: "ALTER TABLE `book` MODIFY COLUMN `name` VARCHAR(50) COMMENT 'Book Name' NOT NULL;\n",
+		},
+		{
+			old:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Author Name' NOT NULL);`,
+			new:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'AUTHOR NAME' NOT NULL);`,
+			want: "ALTER TABLE `book` MODIFY COLUMN `name` VARCHAR(50) COMMENT 'AUTHOR NAME' NOT NULL;\n",
+		},
+		{
+			old:  `CREATE TABLE book(name VARCHAR(50) NOT NULL);`,
+			new:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Book Name' NOT NULL);`,
+			want: "ALTER TABLE `book` MODIFY COLUMN `name` VARCHAR(50) COMMENT 'Book Name' NOT NULL;\n",
+		},
+		{
+			old:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Book Name' NOT NULL);`,
+			new:  `CREATE TABLE book(name VARCHAR(50) NOT NULL);`,
+			want: "ALTER TABLE `book` MODIFY COLUMN `name` VARCHAR(50) NOT NULL;\n",
+		},
+		{
+			old:  `CREATE TABLE book(name VARCHAR(50) NOT NULL);`,
+			new:  `CREATE TABLE book(name VARCHAR(50) NOT NULL);`,
+			want: "",
+		},
+		{
+			old:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Book Name' NOT NULL);`,
+			new:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Book Name' NOT NULL);`,
+			want: "",
+		},
+	}
+	a := require.New(t)
+	for _, test := range tests {
+		oldNodes := getStmtNodes(t, test.old)
+		newNodes := getStmtNodes(t, test.new)
+		out, err := SchemaDiff(oldNodes, newNodes)
+		a.NoError(err)
+		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
+	}
+}
+
 func getStmtNodes(t *testing.T, sql string) []ast.StmtNode {
 	nodes, _, err := parser.New().Parse(sql, "", "")
 	require.NoError(t, err)

--- a/plugin/parser/differ/mysql/column_test.go
+++ b/plugin/parser/differ/mysql/column_test.go
@@ -144,7 +144,6 @@ func TestColumnComment(t *testing.T) {
 		new  string
 		want string
 	}{
-		// NULL option not match.
 		{
 			old:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Author Name' NOT NULL);`,
 			new:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Book Name' NOT NULL);`,

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -130,7 +130,14 @@ func isColumnOptionsEqaul(old, new []*ast.ColumnOption) bool {
 		if oldOption.Tp != newOption.Tp {
 			return false
 		}
-		// TODO(zp): it's not enough to compare the type for some option.
+		// TODO(zp): it's not enough to compare the type for some options.
+		switch oldOption.Tp {
+		case ast.ColumnOptionComment:
+			if oldOption.Expr.(ast.ValueExpr).GetString() != newOption.Expr.(ast.ValueExpr).GetString() {
+				return false
+			}
+		default:
+		}
 	}
 	return true
 }


### PR DESCRIPTION
NOTE: MySQL will help us to drop the column comment if the comment option does not exists in the alter table modify column spec.