### PR TITLE
fix(frontend): BBSelect placeholder disappears

### DIFF
--- a/frontend/src/bbkit/BBSelect.vue
+++ b/frontend/src/bbkit/BBSelect.vue
@@ -112,7 +112,6 @@ import {
 } from "vue";
 import { VBinder, VTarget, VFollower } from "vueuc";
 import { onClickOutside, useElementBounding } from "@vueuse/core";
-import { isEmpty } from "lodash-es";
 
 interface LocalState {
   showMenu: boolean;
@@ -183,7 +182,11 @@ export default defineComponent({
     });
 
     const isSelected = computed(() => {
-      return !isEmpty(state.selectedItem);
+      return (
+        state.selectedItem !== null &&
+        state.selectedItem !== undefined &&
+        state.selectedItem !== ""
+      );
     });
 
     watch(


### PR DESCRIPTION
### Screenshot

![image](https://user-images.githubusercontent.com/2749742/191239035-b6d55a18-9304-46cc-adb6-b0526d30517f.png)

### Reason

`isEmpty(2)` of lodash returns `true`. We shouldn't use it here.

Thanks for the reporting from @dragonly 