### PR TITLE
chore: move pg differ under parser/differ/pg in parallel to mysql differ

### DIFF
--- a/plugin/parser/differ/pg/differ.go
+++ b/plugin/parser/differ/pg/differ.go
@@ -1,4 +1,5 @@
-package parser
+// Package pg provides the PostgreSQL differ plugin.
+package pg
 
 import (
 	"bytes"

--- a/plugin/parser/differ/pg/differ_test.go
+++ b/plugin/parser/differ/pg/differ_test.go
@@ -1,4 +1,4 @@
-package parser_test
+package pg
 
 import (
 	"testing"
@@ -50,7 +50,7 @@ CREATE TABLE repositories (
 		newSchemaNodes, err := parser.Parse(test.engineType, parser.ParseContext{}, test.newSchema)
 		require.NoError(t, err)
 
-		diff, err := parser.SchemaDiff(oldSchemaNodes, newSchemaNodes)
+		diff, err := SchemaDiff(oldSchemaNodes, newSchemaNodes)
 		if test.errPart == "" {
 			require.NoError(t, err)
 		} else {

--- a/server/openapi.go
+++ b/server/openapi.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/metric"
 	"github.com/bytebase/bytebase/plugin/parser"
+	"github.com/bytebase/bytebase/plugin/parser/differ/pg"
 )
 
 var (
@@ -234,7 +235,7 @@ func (s *Server) schemaDiff(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to parse target schema into AST nodes").SetInternal(err)
 	}
 
-	diff, err := parser.SchemaDiff(sourceSchemaNodes, targetSchemaNodes)
+	diff, err := pg.SchemaDiff(sourceSchemaNodes, targetSchemaNodes)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to compute diff between source and target schemas").SetInternal(err)
 	}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/parser"
+	"github.com/bytebase/bytebase/plugin/parser/differ/pg"
 	"github.com/bytebase/bytebase/plugin/vcs"
 	"github.com/bytebase/bytebase/plugin/vcs/github"
 	"github.com/bytebase/bytebase/plugin/vcs/gitlab"
@@ -932,7 +933,7 @@ func (s *Server) computeDatabaseSchemaDiff(ctx context.Context, database *api.Da
 		return "", errors.Wrap(err, "parse new schema")
 	}
 
-	diff, err := parser.SchemaDiff(oldSchema, newSchema)
+	diff, err := pg.SchemaDiff(oldSchema, newSchema)
 	if err != nil {
 		return "", errors.New("compute schema diff")
 	}


### PR DESCRIPTION
Trying to unify the external interface of MySQL and PG differ.