### PR TITLE
fix(frontend): remove the color reverse for <EnvironmentSelect> when hovered

### DIFF
--- a/frontend/src/components/EnvironmentSelect.vue
+++ b/frontend/src/components/EnvironmentSelect.vue
@@ -10,10 +10,7 @@
     <template #menuItem="{ item: environment }">
       <div class="flex items-center">
         {{ environmentName(environment) }}
-        <ProtectedEnvironmentIcon
-          class="ml-1 group-hover:text-main-text"
-          :environment="environment"
-        />
+        <ProtectedEnvironmentIcon class="ml-1" :environment="environment" />
       </div>
     </template>
   </BBSelect>


### PR DESCRIPTION
### Screenshot
Before
![image](https://user-images.githubusercontent.com/2749742/191638774-03abc8cd-4ee5-4c27-8c4a-e130505699d1.png)

After
![image](https://user-images.githubusercontent.com/2749742/191638781-ba33fbb8-bdf8-40f1-a55c-6f36cae21069.png)
