### PR TITLE
feat: lgtm task checker

### DIFF
--- a/api/task_check_run.go
+++ b/api/task_check_run.go
@@ -77,6 +77,8 @@ const (
 	TaskCheckGhostSync TaskCheckType = "bb.task-check.database.ghost.sync"
 	// TaskCheckGeneralEarliestAllowedTime is the task check type for earliest allowed time.
 	TaskCheckGeneralEarliestAllowedTime TaskCheckType = "bb.task-check.general.earliest-allowed-time"
+	// TaskCheckIssueLGTM is the task check type for LGTM comments.
+	TaskCheckIssueLGTM TaskCheckType = "bb.task-check.issue.lgtm"
 )
 
 // TaskCheckEarliestAllowedTimePayload is the task check payload for earliest allowed time.

--- a/server/server.go
+++ b/server/server.go
@@ -269,6 +269,9 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 		timingExecutor := NewTaskCheckTimingExecutor()
 		taskCheckScheduler.Register(api.TaskCheckGeneralEarliestAllowedTime, timingExecutor)
 
+		checkLGTMExecutor := NewTaskCheckLGTMExecutor()
+		taskCheckScheduler.Register(api.TaskCheckIssueLGTM, checkLGTMExecutor)
+
 		s.TaskCheckScheduler = taskCheckScheduler
 
 		// Schema syncer

--- a/server/task_check_executor_lgtm.go
+++ b/server/task_check_executor_lgtm.go
@@ -117,10 +117,6 @@ func isCommentLGTM(ctx context.Context, store *store.Store, activity *api.Activi
 	if activity.Comment != "LGTM" {
 		return false, nil
 	}
-	// LGTM by oneself doesn't count.
-	if activity.CreatorID == issue.CreatorID {
-		return false, nil
-	}
 	member, err := store.GetProjectMember(ctx, &api.ProjectMemberFind{
 		PrincipalID: &activity.CreatorID,
 		ProjectID:   &issue.ProjectID,

--- a/server/task_check_executor_lgtm.go
+++ b/server/task_check_executor_lgtm.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/store"
+)
+
+// NewTaskCheckLGTMExecutor creates a task check LGTM executor.
+func NewTaskCheckLGTMExecutor() TaskCheckExecutor {
+	return &TaskCheckLGTMExecutor{}
+}
+
+// TaskCheckLGTMExecutor is the task check LGTM executor. It checks if "LGTM" comments are present.
+type TaskCheckLGTMExecutor struct {
+}
+
+// Run will run the task check LGTM executor once.
+func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheckRun *api.TaskCheckRun) (result []api.TaskCheckResult, err error) {
+	task, err := server.store.GetTaskByID(ctx, taskCheckRun.TaskID)
+	if err != nil {
+		return []api.TaskCheckResult{}, common.Wrap(err, common.Internal)
+	}
+	if task == nil {
+		return []api.TaskCheckResult{
+			{
+				Status:    api.TaskCheckStatusError,
+				Namespace: api.BBNamespace,
+				Code:      common.Internal.Int(),
+				Title:     fmt.Sprintf("Failed to find task %v", taskCheckRun.TaskID),
+				Content:   err.Error(),
+			},
+		}, nil
+	}
+
+	issue, err := server.store.GetIssueByPipelineID(ctx, task.PipelineID)
+	if err != nil {
+		return []api.TaskCheckResult{}, common.Wrap(err, common.Internal)
+	}
+	if issue == nil {
+		return []api.TaskCheckResult{
+			{
+				Status:    api.TaskCheckStatusError,
+				Namespace: api.BBNamespace,
+				Code:      common.Internal.Int(),
+				Title:     fmt.Sprintf("Failed to find issue by pipelineID %v", task.PipelineID),
+				Content:   err.Error(),
+			},
+		}, nil
+	}
+
+	if issue.Project.LGTMCheckSetting.Value == api.LGTMValueDisabled {
+		return []api.TaskCheckResult{
+			{
+				Status:    api.TaskCheckStatusSuccess,
+				Namespace: api.BBNamespace,
+				Code:      common.Ok.Int(),
+				Title:     "Skip check",
+				Content:   "This check is disabled.",
+			},
+		}, nil
+	}
+
+	activityType := string(api.ActivityIssueCommentCreate)
+	activityList, err := server.store.FindActivity(ctx, &api.ActivityFind{
+		TypePrefix:  &activityType,
+		ContainerID: &issue.ID,
+	})
+	if err != nil {
+		return []api.TaskCheckResult{}, common.Wrap(err, common.Internal)
+	}
+
+	ok, err := checkLGTMcomments(ctx, server.store, activityList, issue)
+	if err != nil {
+		return []api.TaskCheckResult{}, errors.Wrap(err, "failed to check LGTM comments")
+	}
+	if ok {
+		return []api.TaskCheckResult{
+			{
+				Status:    api.TaskCheckStatusSuccess,
+				Namespace: api.BBNamespace,
+				Code:      common.Ok.Int(),
+				Title:     "OK",
+				Content:   "Valid LGTM found!",
+			},
+		}, nil
+	}
+
+	return []api.TaskCheckResult{
+		{
+			Status:    api.TaskCheckStatusError,
+			Namespace: api.BBNamespace,
+			Code:      common.NotFound.Int(),
+			Title:     "Not Found",
+			Content:   "Valid LGTM NOT found!",
+		},
+	}, nil
+}
+
+func checkLGTMcomments(ctx context.Context, store *store.Store, activityList []*api.Activity, issue *api.Issue) (bool, error) {
+	for _, activity := range activityList {
+		ok, err := isCommentLGTM(ctx, store, activity, issue)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isCommentLGTM(ctx context.Context, store *store.Store, activity *api.Activity, issue *api.Issue) (bool, error) {
+	if activity.Comment != "LGTM" {
+		return false, nil
+	}
+	member, err := store.GetProjectMember(ctx, &api.ProjectMemberFind{
+		PrincipalID: &activity.CreatorID,
+		ProjectID:   &issue.ProjectID,
+	})
+	if err != nil {
+		return false, err
+	}
+	if member == nil {
+		return false, nil
+	}
+	switch issue.Project.LGTMCheckSetting.Value {
+	case api.LGTMValueProjectMember:
+		return true, nil
+	case api.LGTMValueProjectOwner:
+		return member.Role == string(api.Owner), nil
+	}
+	return false, errors.Errorf("unexpected LGTM setting value: %v", issue.Project.LGTMCheckSetting.Value)
+}

--- a/server/task_check_executor_lgtm.go
+++ b/server/task_check_executor_lgtm.go
@@ -86,7 +86,7 @@ func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheck
 				Namespace: api.BBNamespace,
 				Code:      common.Ok.Int(),
 				Title:     "OK",
-				Content:   "Valid LGTM found!",
+				Content:   "Valid LGTM found",
 			},
 		}, nil
 	}
@@ -97,7 +97,7 @@ func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheck
 			Namespace: api.BBNamespace,
 			Code:      common.NotFound.Int(),
 			Title:     "Not Found",
-			Content:   "Valid LGTM NOT found!",
+			Content:   "Valid LGTM NOT found",
 		},
 	}, nil
 }
@@ -117,6 +117,10 @@ func checkLGTMcomments(ctx context.Context, store *store.Store, activityList []*
 
 func isCommentLGTM(ctx context.Context, store *store.Store, activity *api.Activity, issue *api.Issue) (bool, error) {
 	if activity.Comment != "LGTM" {
+		return false, nil
+	}
+	// LGTM by oneself doesn't count.
+	if activity.CreatorID == issue.CreatorID {
 		return false, nil
 	}
 	member, err := store.GetProjectMember(ctx, &api.ProjectMemberFind{

--- a/server/task_check_executor_lgtm.go
+++ b/server/task_check_executor_lgtm.go
@@ -33,14 +33,13 @@ func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheck
 				Namespace: api.BBNamespace,
 				Code:      common.Internal.Int(),
 				Title:     fmt.Sprintf("Failed to find task %d", taskCheckRun.TaskID),
-				Content:   err.Error(),
 			},
 		}, nil
 	}
 
 	issue, err := server.store.GetIssueByPipelineID(ctx, task.PipelineID)
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Wrap(err, common.Internal)
+		return nil, common.Wrap(err, common.Internal)
 	}
 	if issue == nil {
 		return []api.TaskCheckResult{
@@ -49,7 +48,6 @@ func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheck
 				Namespace: api.BBNamespace,
 				Code:      common.Internal.Int(),
 				Title:     fmt.Sprintf("Failed to find issue by pipelineID %d", task.PipelineID),
-				Content:   err.Error(),
 			},
 		}, nil
 	}
@@ -72,12 +70,12 @@ func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheck
 		ContainerID: &issue.ID,
 	})
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Wrap(err, common.Internal)
+		return nil, common.Wrap(err, common.Internal)
 	}
 
 	ok, err := checkLGTMcomments(ctx, server.store, activityList, issue)
 	if err != nil {
-		return []api.TaskCheckResult{}, errors.Wrap(err, "failed to check LGTM comments")
+		return nil, errors.Wrap(err, "failed to check LGTM comments")
 	}
 	if ok {
 		return []api.TaskCheckResult{

--- a/server/task_check_executor_lgtm.go
+++ b/server/task_check_executor_lgtm.go
@@ -24,7 +24,7 @@ type TaskCheckLGTMExecutor struct {
 func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheckRun *api.TaskCheckRun) (result []api.TaskCheckResult, err error) {
 	task, err := server.store.GetTaskByID(ctx, taskCheckRun.TaskID)
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Wrap(err, common.Internal)
+		return nil, common.Wrap(err, common.Internal)
 	}
 	if task == nil {
 		return []api.TaskCheckResult{
@@ -32,7 +32,7 @@ func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheck
 				Status:    api.TaskCheckStatusError,
 				Namespace: api.BBNamespace,
 				Code:      common.Internal.Int(),
-				Title:     fmt.Sprintf("Failed to find task %v", taskCheckRun.TaskID),
+				Title:     fmt.Sprintf("Failed to find task %d", taskCheckRun.TaskID),
 				Content:   err.Error(),
 			},
 		}, nil
@@ -48,7 +48,7 @@ func (*TaskCheckLGTMExecutor) Run(ctx context.Context, server *Server, taskCheck
 				Status:    api.TaskCheckStatusError,
 				Namespace: api.BBNamespace,
 				Code:      common.Internal.Int(),
-				Title:     fmt.Sprintf("Failed to find issue by pipelineID %v", task.PipelineID),
+				Title:     fmt.Sprintf("Failed to find issue by pipelineID %d", task.PipelineID),
 				Content:   err.Error(),
 			},
 		}, nil
@@ -139,5 +139,5 @@ func isCommentLGTM(ctx context.Context, store *store.Store, activity *api.Activi
 	case api.LGTMValueProjectOwner:
 		return member.Role == string(api.Owner), nil
 	}
-	return false, errors.Errorf("unexpected LGTM setting value: %v", issue.Project.LGTMCheckSetting.Value)
+	return false, errors.Errorf("unexpected LGTM setting value: %s", issue.Project.LGTMCheckSetting.Value)
 }

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -448,6 +448,9 @@ func (s *TaskCheckScheduler) scheduleLGTMTaskCheck(ctx context.Context, task *ap
 	if err != nil {
 		return err
 	}
+	if issue == nil {
+		return nil
+	}
 	if issue.Project.LGTMCheckSetting.Value == api.LGTMValueDisabled {
 		// don't schedule LGTM check if it's disabled.
 		return nil

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -225,6 +225,9 @@ func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *ap
 	if err := s.scheduleTimingTaskCheck(ctx, task, creatorID, skipIfAlreadyTerminated); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule timing task check")
 	}
+	if err := s.scheduleLGTMTaskCheck(ctx, task, creatorID, skipIfAlreadyTerminated); err != nil {
+		return nil, errors.Wrap(err, "failed to schedule LGTM task check")
+	}
 
 	if task.Type != api.TaskDatabaseSchemaUpdate && task.Type != api.TaskDatabaseDataUpdate && task.Type != api.TaskDatabaseSchemaUpdateGhostSync {
 		return task, nil
@@ -434,6 +437,26 @@ func (s *TaskCheckScheduler) scheduleTimingTaskCheck(ctx context.Context, task *
 		Type:                    api.TaskCheckGeneralEarliestAllowedTime,
 		Payload:                 string(taskCheckPayload),
 		SkipIfAlreadyTerminated: false,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *TaskCheckScheduler) scheduleLGTMTaskCheck(ctx context.Context, task *api.Task, creatorID int, skipIfAlreadyTerminated bool) error {
+	issue, err := s.server.store.GetIssueByPipelineID(ctx, task.PipelineID)
+	if err != nil {
+		return err
+	}
+	if issue.Project.LGTMCheckSetting.Value == api.LGTMValueDisabled {
+		// don't schedule LGTM check if it's disabled.
+		return nil
+	}
+	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+		CreatorID:               creatorID,
+		TaskID:                  task.ID,
+		Type:                    api.TaskCheckIssueLGTM,
+		SkipIfAlreadyTerminated: skipIfAlreadyTerminated,
 	}); err != nil {
 		return err
 	}

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -449,6 +449,7 @@ func (s *TaskCheckScheduler) scheduleLGTMTaskCheck(ctx context.Context, task *ap
 		return err
 	}
 	if issue == nil {
+		// skip if no containing issue.
 		return nil
 	}
 	if issue.Project.LGTMCheckSetting.Value == api.LGTMValueDisabled {


### PR DESCRIPTION
Add a new task checker which will look for "LGTM" comments from project members or project owners.
We won't schedule the LGTM task checker if it's disabled.

The LGTM checker checks by testing `comment == "LGTM"`, so only typing "LGTM" or clicking the LGTM button counts as valid LGTM. And of course, an "LGTM" by the issue creator doesn't count.