### PR TITLE
fix(frontend): vertical align quick action items

### DIFF
--- a/frontend/src/components/QuickActionPanel.vue
+++ b/frontend/src/components/QuickActionPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="pt-1 overflow-hidden grid grid-cols-4 gap-x-2 gap-y-4 md:inline-flex md:gap-x-0"
+    class="pt-1 overflow-hidden grid grid-cols-4 gap-x-2 gap-y-4 md:inline-flex md:gap-x-0 items-center"
   >
     <template v-for="(quickAction, index) in quickActionList" :key="index">
       <div


### PR DESCRIPTION
### Screenshot
Before
![image](https://user-images.githubusercontent.com/2749742/191650476-89e0ac6f-2a6f-4eb0-9400-222909009ff7.png)

After
![image](https://user-images.githubusercontent.com/2749742/191650515-0eca9d2d-30f0-4b8a-9586-e367b0f4073e.png)


Thanks for the reporting from @unknwon 