### PR TITLE
feat: cancel running tasks on server start

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -465,6 +465,9 @@ func (s *Server) Run(ctx context.Context, port int) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
 	if !s.profile.Readonly {
+		if err := s.TaskScheduler.ClearRunningTasks(ctx); err != nil {
+			return errors.Wrap(err, "failed to clear existing RUNNING tasks before start the task scheduler")
+		}
 		// runnerWG waits for all goroutines to complete.
 		s.runnerWG.Add(1)
 		go s.TaskScheduler.Run(ctx, &s.runnerWG)


### PR DESCRIPTION
When Bytebase stops, there may be running tasks such as backup for a big database, which can take hours to finish. When the process exits, the task executors exit too. However, the task status in the metadata is still RUNNING.

This PR cancels the running tasks on the server start, so the state is correct.

Fix BYT-1348.
Fix BYT-1349.