### PR TITLE
refactor: gh-ost new migration context

### DIFF
--- a/server/task_check_executor_ghost_sync.go
+++ b/server/task_check_executor_ghost_sync.go
@@ -48,15 +48,15 @@ func (*TaskCheckGhostSyncExecutor) Run(ctx context.Context, server *Server, task
 		return nil, common.Wrap(err, common.Internal)
 	}
 	if task == nil {
-		return nil, common.Errorf(common.Internal, "failed to find task %v", taskCheckRun.TaskID)
+		return nil, common.Errorf(common.Internal, "failed to find task %d", taskCheckRun.TaskID)
 	}
 
 	if task.Instance == nil {
-		return nil, common.Errorf(common.Internal, "instance ID not found %v", task.InstanceID)
+		return nil, common.Errorf(common.Internal, "failed to find instance %d", task.InstanceID)
 	}
 
 	if task.Database == nil {
-		return nil, common.Errorf(common.Internal, "database ID not found %v", task.DatabaseID)
+		return nil, common.Errorf(common.Internal, "failed to find database %d", task.DatabaseID)
 	}
 
 	adminDataSource := api.DataSourceFromInstanceWithType(task.Instance, api.Admin)

--- a/server/task_check_executor_ghost_sync.go
+++ b/server/task_check_executor_ghost_sync.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/github/gh-ost/go/logic"
 	"github.com/pkg/errors"
@@ -46,64 +45,40 @@ func (*TaskCheckGhostSyncExecutor) Run(ctx context.Context, server *Server, task
 	}()
 	task, err := server.store.GetTaskByID(ctx, taskCheckRun.TaskID)
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Wrap(err, common.Internal)
+		return nil, common.Wrap(err, common.Internal)
 	}
 	if task == nil {
-		return []api.TaskCheckResult{
-			{
-				Status:    api.TaskCheckStatusError,
-				Namespace: api.BBNamespace,
-				Code:      common.Internal.Int(),
-				Title:     fmt.Sprintf("Failed to find task %v", taskCheckRun.TaskID),
-				Content:   err.Error(),
-			},
-		}, nil
+		return nil, common.Errorf(common.Internal, "failed to find task %v", taskCheckRun.TaskID)
 	}
 
-	instance := task.Instance
-	if instance == nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Internal, "instance ID not found %v", task.InstanceID)
+	if task.Instance == nil {
+		return nil, common.Errorf(common.Internal, "instance ID not found %v", task.InstanceID)
 	}
 
-	database := task.Database
-	if database == nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Internal, "database ID not found %v", task.DatabaseID)
+	if task.Database == nil {
+		return nil, common.Errorf(common.Internal, "database ID not found %v", task.DatabaseID)
 	}
 
-	adminDataSource := api.DataSourceFromInstanceWithType(instance, api.Admin)
+	adminDataSource := api.DataSourceFromInstanceWithType(task.Instance, api.Admin)
 	if adminDataSource == nil {
-		return []api.TaskCheckResult{}, common.Errorf(common.Internal, "admin data source not found for instance %d", instance.ID)
+		return nil, common.Errorf(common.Internal, "admin data source not found for instance %d", task.InstanceID)
 	}
 
 	payload := &api.TaskDatabaseSchemaUpdateGhostSyncPayload{}
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
-		return []api.TaskCheckResult{}, common.Wrapf(err, common.Internal, "invalid database schema update gh-ost sync payload")
+		return nil, common.Wrapf(err, common.Internal, "invalid database schema update gh-ost sync payload")
 	}
 
-	databaseName := database.Name
 	tableName, err := getTableNameFromStatement(payload.Statement)
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Wrapf(err, common.Internal, "failed to parse table name from statement, statement: %v", payload.Statement)
+		return nil, common.Wrapf(err, common.Internal, "failed to parse table name from statement, statement: %v", payload.Statement)
 	}
 
-	migrationContext, err := newMigrationContext(ghostConfig{
-		host:                 instance.Host,
-		port:                 instance.Port,
-		user:                 adminDataSource.Username,
-		password:             adminDataSource.Password,
-		database:             databaseName,
-		table:                tableName,
-		alterStatement:       payload.Statement,
-		socketFilename:       getSocketFilename(taskCheckRun.ID, task.Database.ID, databaseName, tableName),
-		postponeFlagFilename: "",
-		noop:                 true,
-		// On the source and each replica, you must set the server_id system variable to establish a unique replication ID. For each server, you should pick a unique positive integer in the range from 1 to 2^32 − 1, and each ID must be different from every other ID in use by any other source or replica in the replication topology. Example: server-id=3.
-		// https://dev.mysql.com/doc/refman/5.7/en/replication-options-source.html
-		// Here we use serverID = offset + task.ID to avoid potential conflicts.
-		serverID: 20000000 + uint(taskCheckRun.ID),
-	})
+	config := getGhostConfig(task, adminDataSource, tableName, payload.Statement, true, 20000000)
+
+	migrationContext, err := newMigrationContext(config)
 	if err != nil {
-		return []api.TaskCheckResult{}, common.Wrapf(err, common.Internal, "failed to create migration context")
+		return nil, common.Wrapf(err, common.Internal, "failed to create migration context")
 	}
 
 	migrator := logic.NewMigrator(migrationContext, "bb")


### PR DESCRIPTION
- Abstract a new func `getGhostConfig`.
- Remove some local vars.