### PR TITLE
fix(vcs): nil environment for schema file write back

### DIFF
--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -68,6 +68,7 @@ func preMigration(ctx context.Context, server *Server, task *api.Task, migration
 		// TODO(d): support semantic versioning.
 		Version:     schemaVersion,
 		Description: task.Name,
+		Environment: task.Instance.Environment.Name,
 	}
 	if vcsPushEvent == nil {
 		mi.Source = db.UI


### PR DESCRIPTION
Currently, migrationInfo.Environment is nil in the VCS code path, which will results in invalid schema file for write back.

Issue example:

failed to create file after applying migration 5 to "db-1": failed to create file through URL https://gitlab.bytebase.com/api/v4/projects/63/repository/files/bytebase%2F%2F.db-1__LATEST.sql, status code: 400, body: {"branch":"main","content":"SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;\nSET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;\n--\n-- Table structure for `t1`\n--\nCREATE TABLE `t1` (\n  `id` int DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n\n--\n-- Table structure for `t4`\n--\nCREATE TABLE `t4` (\n  `id` int NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n\nSET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;\nSET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;\n","commit_message":"[Bytebase] Create latest schema for \"db-1\" after migration 5\n\nTHIS COMMIT IS AUTO-GENERATED BY BYTEBASE\n\nhttp://localhost:3000/issue/create-table-t5-by-prod-db-1__5__migrate__create_table_t5-sql-113?stage=125\n\n--------Original migration change--------\n\nhttp://gitlab.bytebase.com/yilong/bbdev/-/commit/31fc5aed2cee62c5fa463a2bd1f014e0e458a663\n\nver5\n"} 

