### PR TITLE
feat: support HEAD request for VCS

### DIFF
--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -206,7 +206,7 @@ type WebhookPushEvent struct {
 // should be either "user" or "users/{username}".
 func (p *Provider) fetchUserInfoImpl(ctx context.Context, oauthCtx common.OauthContext, instanceURL, resourceURI string) (*vcs.UserInfo, error) {
 	url := fmt.Sprintf("%s/%s", p.APIURL(instanceURL), resourceURI)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -272,7 +272,7 @@ type FileCommit struct {
 // FetchCommitByID fetches the commit data by its ID from the repository.
 func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, commitID string) (*vcs.Commit, error) {
 	url := fmt.Sprintf("%s/repos/%s/git/commits/%s", p.APIURL(instanceURL), repositoryID, commitID)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -389,7 +389,7 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 // indicating whether the next page exists.
 func (p *Provider) fetchPaginatedRepositoryCollaborators(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, page int) (collaborators []RepositoryCollaborator, hasNextPage bool, err error) {
 	url := fmt.Sprintf("%s/repos/%s/collaborators?page=%d&per_page=%d", p.APIURL(instanceURL), repositoryID, page, apiPageSize)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -535,7 +535,7 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 // with a boolean indicating whether the next page exists.
 func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, page int) (repos []Repository, hasNextPage bool, err error) {
 	url := fmt.Sprintf("%s/user/repos?page=%d&per_page=%d", p.APIURL(instanceURL), page, apiPageSize)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -586,7 +586,7 @@ func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx co
 // maximum limit and requires making non-recursive request to each sub-tree.
 func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*vcs.RepositoryTreeNode, error) {
 	url := fmt.Sprintf("%s/repos/%s/git/trees/%s?recursive=true", p.APIURL(instanceURL), repositoryID, ref)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -658,7 +658,7 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/contents/%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath))
-	code, _, err := oauth.Put(
+	code, _, _, err := oauth.Put(
 		ctx,
 		p.client,
 		url,
@@ -728,7 +728,7 @@ func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthCon
 // readFile reads the given file in the repository.
 func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*File, error) {
 	url := fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), ref)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -784,7 +784,7 @@ func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, i
 // Docs: https://docs.github.com/en/rest/webhooks/repos#create-a-repository-webhook
 func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error) {
 	url := fmt.Sprintf("%s/repos/%s/hooks", p.APIURL(instanceURL), repositoryID)
-	code, body, err := oauth.Post(
+	code, _, body, err := oauth.Post(
 		ctx,
 		p.client,
 		url,
@@ -830,7 +830,7 @@ func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthConte
 // Docs: https://docs.github.com/en/rest/webhooks/repos#update-a-repository-webhook
 func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error {
 	url := fmt.Sprintf("%s/repos/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
-	code, body, err := oauth.Patch(
+	code, _, body, err := oauth.Patch(
 		ctx,
 		p.client,
 		url,
@@ -867,7 +867,7 @@ func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContex
 // Docs: https://docs.github.com/en/rest/webhooks/repos#delete-a-repository-webhook
 func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string) error {
 	url := fmt.Sprintf("%s/repos/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
-	code, body, err := oauth.Delete(
+	code, _, body, err := oauth.Delete(
 		ctx,
 		p.client,
 		url,

--- a/plugin/vcs/github/github_test.go
+++ b/plugin/vcs/github/github_test.go
@@ -1126,7 +1126,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 		return nil
 	}
 
-	_, _, err := oauth.Get(
+	_, _, _, err := oauth.Get(
 		ctx,
 		client,
 		"https://api.github.com/users/octocat",

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -292,7 +292,7 @@ func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx co
 	// We will use user's token to create webhook in the project, which requires the
 	// token owner to be at least the project maintainer(40).
 	url := fmt.Sprintf("%s/projects?membership=true&simple=true&min_access_level=40&page=%d&per_page=%d", p.APIURL(instanceURL), page, apiPageSize)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -337,7 +337,7 @@ func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx co
 // should be either "user" or "users/{userID}".
 func (p *Provider) fetchUserInfoImpl(ctx context.Context, oauthCtx common.OauthContext, instanceURL, resourceURI string) (*vcs.UserInfo, error) {
 	url := fmt.Sprintf("%s/%s", p.APIURL(instanceURL), resourceURI)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -381,7 +381,7 @@ func (p *Provider) TryLogin(ctx context.Context, oauthCtx common.OauthContext, i
 // FetchCommitByID fetches the commit data by its ID from the repository.
 func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, commitID string) (*vcs.Commit, error) {
 	url := fmt.Sprintf("%s/projects/%s/repository/commits/%s", p.APIURL(instanceURL), repositoryID, commitID)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -521,7 +521,7 @@ func (p *Provider) fetchPaginatedRepositoryActiveMemberList(ctx context.Context,
 	// The "state" filter only available in GitLab Premium self-managed, GitLab
 	// Premium SaaS, and higher tiers, but worth a try for less abandoned results.
 	url := fmt.Sprintf("%s/projects/%s/members/all?state=active&page=%d&per_page=%d", p.APIURL(instanceURL), repositoryID, page, apiPageSize)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -601,7 +601,7 @@ func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.
 // boolean indicating whether the next page exists.
 func (p *Provider) fetchPaginatedRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string, page int) (treeNodes []RepositoryTreeNode, hasNextPage bool, err error) {
 	url := fmt.Sprintf("%s/projects/%s/repository/tree?recursive=true&ref=%s&path=%s&page=%d&per_page=%d", p.APIURL(instanceURL), repositoryID, ref, filePath, page, apiPageSize)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -658,7 +658,7 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/repository/files/%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath))
-	code, _, err := oauth.Post(
+	code, _, _, err := oauth.Post(
 		ctx,
 		p.client,
 		url,
@@ -707,7 +707,7 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/repository/files/%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath))
-	code, _, err := oauth.Put(
+	code, _, _, err := oauth.Put(
 		ctx,
 		p.client,
 		url,
@@ -772,7 +772,7 @@ func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthCon
 // Docs: https://docs.gitlab.com/ee/api/projects.html#add-project-hook
 func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error) {
 	url := fmt.Sprintf("%s/projects/%s/hooks", p.APIURL(instanceURL), repositoryID)
-	code, body, err := oauth.Post(
+	code, _, body, err := oauth.Post(
 		ctx,
 		p.client,
 		url,
@@ -823,7 +823,7 @@ func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthConte
 // Docs: https://docs.gitlab.com/ee/api/projects.html#edit-project-hook
 func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error {
 	url := fmt.Sprintf("%s/projects/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
-	code, body, err := oauth.Put(
+	code, _, body, err := oauth.Put(
 		ctx,
 		p.client,
 		url,
@@ -860,7 +860,7 @@ func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContex
 // Docs: https://docs.gitlab.com/ee/api/projects.html#delete-project-hook
 func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string) error {
 	url := fmt.Sprintf("%s/projects/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
-	code, body, err := oauth.Delete(
+	code, _, body, err := oauth.Delete(
 		ctx,
 		p.client,
 		url,
@@ -897,7 +897,7 @@ func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthConte
 // get the file metadata.
 func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*File, error) {
 	url := fmt.Sprintf("%s/projects/%s/repository/files/%s?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), url.QueryEscape(ref))
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,

--- a/plugin/vcs/gitlab/gitlab_test.go
+++ b/plugin/vcs/gitlab/gitlab_test.go
@@ -793,7 +793,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 		return nil
 	}
 
-	_, _, err := oauth.Get(
+	_, _, _, err := oauth.Get(
 		ctx,
 		client,
 		"https://gitlab.example.com/api/v4/users/octocat",

--- a/plugin/vcs/internal/oauth/oauth.go
+++ b/plugin/vcs/internal/oauth/oauth.go
@@ -35,69 +35,75 @@ func requester(ctx context.Context, client *http.Client, method, url string, tok
 
 // Post makes a HTTP POST request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Post(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Post(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, head http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodPost, url, token, body))
 }
 
 // Get makes a HTTP GET request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Get(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Get(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, head http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodGet, url, token, nil))
 }
 
 // Put makes a HTTP PUT request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Put(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Put(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, head http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodPut, url, token, body))
 }
 
 // Patch makes a HTTP PATCH request to the given URL using the token. It
 // refreshes token and retries the request in the case of the token has expired.
-func Patch(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Patch(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, head http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodPatch, url, token, body))
 }
 
 // Delete makes a HTTP DELETE request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Delete(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Delete(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, head http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodDelete, url, token, nil))
+}
+
+// Head makes a HTTP HEAD request to the given URL using the token. It refreshes
+// token and retries the request in the case of the token has expired.
+func Head(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, head http.Header, respBody string, err error) {
+	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodHead, url, token, nil))
 }
 
 const maxRetries = 3
 
-func retry(ctx context.Context, client *http.Client, token *string, tokenRefresher TokenRefresher, f func() (*http.Response, error)) (code int, respBody string, err error) {
+func retry(ctx context.Context, client *http.Client, token *string, tokenRefresher TokenRefresher, f func() (*http.Response, error)) (code int, head http.Header, respBody string, err error) {
 	var resp *http.Response
 	var body []byte
 	for retries := 0; retries < maxRetries; retries++ {
 		select {
 		case <-ctx.Done():
-			return 0, "", ctx.Err()
+			return 0, nil, "", ctx.Err()
 		default:
 		}
 
 		resp, err = f()
 		if err != nil {
-			return 0, "", err
+			return 0, nil, "", err
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return 0, "", errors.Wrapf(err, "read response body with status code %d", resp.StatusCode)
+			return 0, nil, "", errors.Wrapf(err, "read response body with status code %d", resp.StatusCode)
 		}
 
 		if err = getOAuthErrorDetails(resp.StatusCode, body); err != nil {
 			if _, ok := err.(*oauthError); ok {
 				// Refresh the token
 				if err := tokenRefresher(ctx, client, token); err != nil {
-					return 0, "", err
+					return 0, nil, "", err
 				}
 				continue
 			}
-			return 0, "", errors.Errorf("got unexpected OAuth error %T", err)
+			return 0, nil, "", errors.Errorf("got unexpected OAuth error %T", err)
 		}
-		return resp.StatusCode, string(body), nil
+		return resp.StatusCode, resp.Header, string(body), nil
 	}
-	return 0, "", errors.Errorf("retries exceeded for OAuth refresher with status code %d and body %q", resp.StatusCode, string(body))
+	return 0, nil, "", errors.Errorf("retries exceeded for OAuth refresher with status code %d and body %q", resp.StatusCode, string(body))
 }
 
 type oauthError struct {

--- a/plugin/vcs/internal/oauth/oauth_test.go
+++ b/plugin/vcs/internal/oauth/oauth_test.go
@@ -31,7 +31,7 @@ func TestPost(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Post(ctx, client, "", &token, strings.NewReader("POST body"), nil)
+	_, _, _, err := Post(ctx, client, "", &token, strings.NewReader("POST body"), nil)
 	require.NoError(t, err)
 }
 
@@ -48,7 +48,7 @@ func TestGet(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Get(ctx, client, "", &token, nil)
+	_, _, _, err := Get(ctx, client, "", &token, nil)
 	require.NoError(t, err)
 }
 
@@ -69,7 +69,7 @@ func TestPut(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Put(ctx, client, "", &token, strings.NewReader("PUT body"), nil)
+	_, _, _, err := Put(ctx, client, "", &token, strings.NewReader("PUT body"), nil)
 	require.NoError(t, err)
 }
 
@@ -90,7 +90,7 @@ func TestPatch(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Patch(ctx, client, "", &token, strings.NewReader("PATCH body"), nil)
+	_, _, _, err := Patch(ctx, client, "", &token, strings.NewReader("PATCH body"), nil)
 	require.NoError(t, err)
 }
 
@@ -107,7 +107,7 @@ func TestDelete(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Delete(ctx, client, "", &token, nil)
+	_, _, _, err := Delete(ctx, client, "", &token, nil)
 	require.NoError(t, err)
 }
 
@@ -115,7 +115,7 @@ func TestRetry_Exceeded(t *testing.T) {
 	ctx := context.Background()
 	token := "expired"
 
-	_, _, err := retry(ctx, nil, &token,
+	_, _, _, err := retry(ctx, nil, &token,
 		func(_ context.Context, _ *http.Client, _ *string) error {
 			return nil
 		},


### PR DESCRIPTION
[Older versions of GitLab did not handle reading large file requests perfectly](https://gitlab.com/gitlab-org/gitlab-pages/-/issues/315). We move to use [another API](https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository) to get raw file content.
We need to use the HEAD method to get the file metadata.