### PR TITLE
chore: use raw api to get GitLab file content

### DIFF
--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -206,7 +206,7 @@ type WebhookPushEvent struct {
 // should be either "user" or "users/{username}".
 func (p *Provider) fetchUserInfoImpl(ctx context.Context, oauthCtx common.OauthContext, instanceURL, resourceURI string) (*vcs.UserInfo, error) {
 	url := fmt.Sprintf("%s/%s", p.APIURL(instanceURL), resourceURI)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -272,7 +272,7 @@ type FileCommit struct {
 // FetchCommitByID fetches the commit data by its ID from the repository.
 func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, commitID string) (*vcs.Commit, error) {
 	url := fmt.Sprintf("%s/repos/%s/git/commits/%s", p.APIURL(instanceURL), repositoryID, commitID)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -389,7 +389,7 @@ func (p *Provider) FetchRepositoryActiveMemberList(ctx context.Context, oauthCtx
 // indicating whether the next page exists.
 func (p *Provider) fetchPaginatedRepositoryCollaborators(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, page int) (collaborators []RepositoryCollaborator, hasNextPage bool, err error) {
 	url := fmt.Sprintf("%s/repos/%s/collaborators?page=%d&per_page=%d", p.APIURL(instanceURL), repositoryID, page, apiPageSize)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -535,7 +535,7 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 // with a boolean indicating whether the next page exists.
 func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, page int) (repos []Repository, hasNextPage bool, err error) {
 	url := fmt.Sprintf("%s/user/repos?page=%d&per_page=%d", p.APIURL(instanceURL), page, apiPageSize)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -586,7 +586,7 @@ func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx co
 // maximum limit and requires making non-recursive request to each sub-tree.
 func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*vcs.RepositoryTreeNode, error) {
 	url := fmt.Sprintf("%s/repos/%s/git/trees/%s?recursive=true", p.APIURL(instanceURL), repositoryID, ref)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -658,7 +658,7 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/contents/%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath))
-	code, _, err := oauth.Put(
+	code, _, _, err := oauth.Put(
 		ctx,
 		p.client,
 		url,
@@ -728,7 +728,7 @@ func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthCon
 // readFile reads the given file in the repository.
 func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*File, error) {
 	url := fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), ref)
-	code, body, err := oauth.Get(
+	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
 		url,
@@ -784,7 +784,7 @@ func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, i
 // Docs: https://docs.github.com/en/rest/webhooks/repos#create-a-repository-webhook
 func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error) {
 	url := fmt.Sprintf("%s/repos/%s/hooks", p.APIURL(instanceURL), repositoryID)
-	code, body, err := oauth.Post(
+	code, _, body, err := oauth.Post(
 		ctx,
 		p.client,
 		url,
@@ -830,7 +830,7 @@ func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthConte
 // Docs: https://docs.github.com/en/rest/webhooks/repos#update-a-repository-webhook
 func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error {
 	url := fmt.Sprintf("%s/repos/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
-	code, body, err := oauth.Patch(
+	code, _, body, err := oauth.Patch(
 		ctx,
 		p.client,
 		url,
@@ -867,7 +867,7 @@ func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContex
 // Docs: https://docs.github.com/en/rest/webhooks/repos#delete-a-repository-webhook
 func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string) error {
 	url := fmt.Sprintf("%s/repos/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
-	code, body, err := oauth.Delete(
+	code, _, body, err := oauth.Delete(
 		ctx,
 		p.client,
 		url,

--- a/plugin/vcs/github/github_test.go
+++ b/plugin/vcs/github/github_test.go
@@ -1126,7 +1126,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 		return nil
 	}
 
-	_, _, err := oauth.Get(
+	_, _, _, err := oauth.Get(
 		ctx,
 		client,
 		"https://api.github.com/users/octocat",

--- a/plugin/vcs/gitlab/gitlab.go
+++ b/plugin/vcs/gitlab/gitlab.go
@@ -120,10 +120,7 @@ type RepositoryTreeNode struct {
 
 // File represents a GitLab API response for a repository file.
 type File struct {
-	FileName     string
-	FilePath     string
 	Content      string
-	Size         int64
 	LastCommitID string
 }
 
@@ -747,9 +744,6 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 	}
 
 	return &vcs.FileMeta{
-		Name:         file.FileName,
-		Path:         file.FilePath,
-		Size:         file.Size,
 		LastCommitID: file.LastCommitID,
 	}, nil
 }
@@ -927,16 +921,8 @@ func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, i
 			)
 	}
 
-	fileSize, err := strconv.ParseInt(header.Get("x-gitlab-size"), 0, 32)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot parse file size from header x-gitlab-size %q", header.Get("x-gitlab-size"))
-	}
-
 	return &File{
-		FileName:     header.Get("x-gitlab-file-name"),
-		FilePath:     header.Get("x-gitlab-file-path"),
 		Content:      body,
-		Size:         fileSize,
 		LastCommitID: header.Get("x-gitlab-last-commit-id"),
 	}, nil
 }

--- a/plugin/vcs/gitlab/gitlab_test.go
+++ b/plugin/vcs/gitlab/gitlab_test.go
@@ -601,9 +601,6 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	require.NoError(t, err)
 
 	want := &vcs.FileMeta{
-		Name:         "key.rb",
-		Path:         "app/models/key.rb",
-		Size:         3,
 		LastCommitID: "27329d3afac51fbf2762428e12f2635d1137c549",
 	}
 	assert.Equal(t, want, got)

--- a/plugin/vcs/gitlab/gitlab_test.go
+++ b/plugin/vcs/gitlab/gitlab_test.go
@@ -578,25 +578,17 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 			Client: &http.Client{
 				Transport: &common.MockRoundTripper{
 					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
+						assert.Equal(t, "/api/v4/projects/1/repository/files/app%2Fmodels%2Fkey.rb/raw", r.URL.RawPath)
+						header := http.Header{}
+						header.Set("x-gitlab-file-name", "key.rb")
+						header.Set("x-gitlab-file-path", "app/models/key.rb")
+						header.Set("x-gitlab-size", "3")
+						header.Set("x-gitlab-last-commit-id", "27329d3afac51fbf2762428e12f2635d1137c549")
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
-							Body: io.NopCloser(strings.NewReader(`
-{
-  "file_name": "key.rb",
-  "file_path": "app/models/key.rb",
-  "size": 442,
-  "encoding": "base64",
-  "content": "IyBTYW1wbGUgR2l0TGFiIFByb2plY3QKClRoaXMgc2FtcGxlIHByb2plY3Qgc2hvd3MgaG93IGEgcHJvamVjdCBpbiBHaXRMYWIgbG9va3MgZm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMuIEl0IGNvbnRhaW5zIGlzc3VlcywgbWVyZ2UgcmVxdWVzdHMgYW5kIE1hcmtkb3duIGZpbGVzIGluIG1hbnkgYnJhbmNoZXMsCm5hbWVkIGFuZCBmaWxsZWQgd2l0aCBsb3JlbSBpcHN1bS4KCllvdSBjYW4gbG9vayBhcm91bmQgdG8gZ2V0IGFuIGlkZWEgaG93IHRvIHN0cnVjdHVyZSB5b3VyIHByb2plY3QgYW5kLCB3aGVuIGRvbmUsIHlvdSBjYW4gc2FmZWx5IGRlbGV0ZSB0aGlzIHByb2plY3QuCgpbTGVhcm4gbW9yZSBhYm91dCBjcmVhdGluZyBHaXRMYWIgcHJvamVjdHMuXShodHRwczovL2RvY3MuZ2l0bGFiLmNvbS9lZS9naXRsYWItYmFzaWNzL2NyZWF0ZS1wcm9qZWN0Lmh0bWwpCg==",
-  "content_sha256": "71dd06da8f5915544335e547e4447de6377ef369d67b6a5214c8a780d336b2e2",
-  "ref": "master",
-  "blob_id": "79f7bbd25901e8334750839545a9bd021f0e4c83",
-  "commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
-  "last_commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
-  "execute_filemode": false
-}
-`)),
+							Body:   io.NopCloser(strings.NewReader(`key`)),
+							Header: header,
 						}, nil
 					},
 				},
@@ -605,13 +597,13 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, "", "1", "lib/class.rb", "master")
+	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", "master")
 	require.NoError(t, err)
 
 	want := &vcs.FileMeta{
 		Name:         "key.rb",
 		Path:         "app/models/key.rb",
-		Size:         442,
+		Size:         3,
 		LastCommitID: "27329d3afac51fbf2762428e12f2635d1137c549",
 	}
 	assert.Equal(t, want, got)
@@ -623,25 +615,25 @@ func TestProvider_ReadFileContent(t *testing.T) {
 			Client: &http.Client{
 				Transport: &common.MockRoundTripper{
 					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
+						assert.Equal(t, "/api/v4/projects/1/repository/files/app%2Fmodels%2Fkey.rb/raw", r.URL.RawPath)
+						header := http.Header{}
+						header.Set("x-gitlab-file-name", "key.rb")
+						header.Set("x-gitlab-file-path", "app/models/key.rb")
+						header.Set("x-gitlab-size", "3")
+						header.Set("x-gitlab-last-commit-id", "27329d3afac51fbf2762428e12f2635d1137c549")
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
-							Body: io.NopCloser(strings.NewReader(`
-{
-  "file_name": "key.rb",
-  "file_path": "app/models/key.rb",
-  "size": 442,
-  "encoding": "base64",
-  "content": "IyBTYW1wbGUgR2l0TGFiIFByb2plY3QKClRoaXMgc2FtcGxlIHByb2plY3Qgc2hvd3MgaG93IGEgcHJvamVjdCBpbiBHaXRMYWIgbG9va3MgZm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMuIEl0IGNvbnRhaW5zIGlzc3VlcywgbWVyZ2UgcmVxdWVzdHMgYW5kIE1hcmtkb3duIGZpbGVzIGluIG1hbnkgYnJhbmNoZXMsCm5hbWVkIGFuZCBmaWxsZWQgd2l0aCBsb3JlbSBpcHN1bS4KCllvdSBjYW4gbG9vayBhcm91bmQgdG8gZ2V0IGFuIGlkZWEgaG93IHRvIHN0cnVjdHVyZSB5b3VyIHByb2plY3QgYW5kLCB3aGVuIGRvbmUsIHlvdSBjYW4gc2FmZWx5IGRlbGV0ZSB0aGlzIHByb2plY3QuCgpbTGVhcm4gbW9yZSBhYm91dCBjcmVhdGluZyBHaXRMYWIgcHJvamVjdHMuXShodHRwczovL2RvY3MuZ2l0bGFiLmNvbS9lZS9naXRsYWItYmFzaWNzL2NyZWF0ZS1wcm9qZWN0Lmh0bWwpCg==",
-  "content_sha256": "71dd06da8f5915544335e547e4447de6377ef369d67b6a5214c8a780d336b2e2",
-  "ref": "master",
-  "blob_id": "79f7bbd25901e8334750839545a9bd021f0e4c83",
-  "commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
-  "last_commit_id": "27329d3afac51fbf2762428e12f2635d1137c549",
-  "execute_filemode": false
-}
+							Body: io.NopCloser(strings.NewReader(`# Sample GitLab Project
+
+This sample project shows how a project in GitLab looks for demonstration purposes. It contains issues, merge requests and Markdown files in many branches,
+named and filled with lorem ipsum.
+
+You can look around to get an idea how to structure your project and, when done, you can safely delete this project.
+
+[Learn more about creating GitLab projects.](https://docs.gitlab.com/ee/gitlab-basics/create-project.html)
 `)),
+							Header: header,
 						}, nil
 					},
 				},
@@ -650,7 +642,7 @@ func TestProvider_ReadFileContent(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileContent(ctx, common.OauthContext{}, "", "1", "lib/class.rb", "master")
+	got, err := p.ReadFileContent(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", "master")
 	require.NoError(t, err)
 
 	want := `# Sample GitLab Project

--- a/plugin/vcs/gitlab/gitlab_test.go
+++ b/plugin/vcs/gitlab/gitlab_test.go
@@ -793,7 +793,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 		return nil
 	}
 
-	_, _, err := oauth.Get(
+	_, _, _, err := oauth.Get(
 		ctx,
 		client,
 		"https://gitlab.example.com/api/v4/users/octocat",

--- a/plugin/vcs/internal/oauth/oauth.go
+++ b/plugin/vcs/internal/oauth/oauth.go
@@ -35,69 +35,69 @@ func requester(ctx context.Context, client *http.Client, method, url string, tok
 
 // Post makes a HTTP POST request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Post(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Post(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, header http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodPost, url, token, body))
 }
 
 // Get makes a HTTP GET request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Get(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Get(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, header http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodGet, url, token, nil))
 }
 
 // Put makes a HTTP PUT request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Put(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Put(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, header http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodPut, url, token, body))
 }
 
 // Patch makes a HTTP PATCH request to the given URL using the token. It
 // refreshes token and retries the request in the case of the token has expired.
-func Patch(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Patch(ctx context.Context, client *http.Client, url string, token *string, body io.Reader, tokenRefresher TokenRefresher) (code int, header http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodPatch, url, token, body))
 }
 
 // Delete makes a HTTP DELETE request to the given URL using the token. It refreshes
 // token and retries the request in the case of the token has expired.
-func Delete(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, respBody string, err error) {
+func Delete(ctx context.Context, client *http.Client, url string, token *string, tokenRefresher TokenRefresher) (code int, header http.Header, respBody string, err error) {
 	return retry(ctx, client, token, tokenRefresher, requester(ctx, client, http.MethodDelete, url, token, nil))
 }
 
 const maxRetries = 3
 
-func retry(ctx context.Context, client *http.Client, token *string, tokenRefresher TokenRefresher, f func() (*http.Response, error)) (code int, respBody string, err error) {
+func retry(ctx context.Context, client *http.Client, token *string, tokenRefresher TokenRefresher, f func() (*http.Response, error)) (code int, header http.Header, respBody string, err error) {
 	var resp *http.Response
 	var body []byte
 	for retries := 0; retries < maxRetries; retries++ {
 		select {
 		case <-ctx.Done():
-			return 0, "", ctx.Err()
+			return 0, nil, "", ctx.Err()
 		default:
 		}
 
 		resp, err = f()
 		if err != nil {
-			return 0, "", err
+			return 0, nil, "", err
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return 0, "", errors.Wrapf(err, "read response body with status code %d", resp.StatusCode)
+			return 0, nil, "", errors.Wrapf(err, "read response body with status code %d", resp.StatusCode)
 		}
 
 		if err = getOAuthErrorDetails(resp.StatusCode, body); err != nil {
 			if _, ok := err.(*oauthError); ok {
 				// Refresh the token
 				if err := tokenRefresher(ctx, client, token); err != nil {
-					return 0, "", err
+					return 0, nil, "", err
 				}
 				continue
 			}
-			return 0, "", errors.Errorf("got unexpected OAuth error %T", err)
+			return 0, nil, "", errors.Errorf("got unexpected OAuth error %T", err)
 		}
-		return resp.StatusCode, string(body), nil
+		return resp.StatusCode, resp.Header, string(body), nil
 	}
-	return 0, "", errors.Errorf("retries exceeded for OAuth refresher with status code %d and body %q", resp.StatusCode, string(body))
+	return 0, nil, "", errors.Errorf("retries exceeded for OAuth refresher with status code %d and body %q", resp.StatusCode, string(body))
 }
 
 type oauthError struct {

--- a/plugin/vcs/internal/oauth/oauth_test.go
+++ b/plugin/vcs/internal/oauth/oauth_test.go
@@ -31,7 +31,7 @@ func TestPost(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Post(ctx, client, "", &token, strings.NewReader("POST body"), nil)
+	_, _, _, err := Post(ctx, client, "", &token, strings.NewReader("POST body"), nil)
 	require.NoError(t, err)
 }
 
@@ -48,7 +48,7 @@ func TestGet(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Get(ctx, client, "", &token, nil)
+	_, _, _, err := Get(ctx, client, "", &token, nil)
 	require.NoError(t, err)
 }
 
@@ -69,7 +69,7 @@ func TestPut(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Put(ctx, client, "", &token, strings.NewReader("PUT body"), nil)
+	_, _, _, err := Put(ctx, client, "", &token, strings.NewReader("PUT body"), nil)
 	require.NoError(t, err)
 }
 
@@ -90,7 +90,7 @@ func TestPatch(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Patch(ctx, client, "", &token, strings.NewReader("PATCH body"), nil)
+	_, _, _, err := Patch(ctx, client, "", &token, strings.NewReader("PATCH body"), nil)
 	require.NoError(t, err)
 }
 
@@ -107,7 +107,7 @@ func TestDelete(t *testing.T) {
 		},
 	}
 	token := "token"
-	_, _, err := Delete(ctx, client, "", &token, nil)
+	_, _, _, err := Delete(ctx, client, "", &token, nil)
 	require.NoError(t, err)
 }
 
@@ -115,7 +115,7 @@ func TestRetry_Exceeded(t *testing.T) {
 	ctx := context.Background()
 	token := "expired"
 
-	_, _, err := retry(ctx, nil, &token,
+	_, _, _, err := retry(ctx, nil, &token,
 		func(_ context.Context, _ *http.Client, _ *string) error {
 			return nil
 		},

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = ".air"
 
 [build]
-  full_bin = 'BB_REDIRECT_URL=http:\/\/localhost:3000 ./.air/bytebase --port 8080 --external-url http:\/\/localhost:3000 --data . --debug'
+  full_bin = 'BB_REDIRECT_URL=http:\/\/localhost:3000 ./.air/bytebase --port 8080 --external-url https:\/\/f779-58-152-48-226.ap.ngrok.io --data . --debug'
   ## Use --tags "store.db" to enable SQL query logging against our metadata db.
   cmd = """
   go build \

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = ".air"
 
 [build]
-  full_bin = 'BB_REDIRECT_URL=http:\/\/localhost:3000 ./.air/bytebase --port 8080 --external-url https:\/\/f779-58-152-48-226.ap.ngrok.io --data . --debug'
+  full_bin = 'BB_REDIRECT_URL=http:\/\/localhost:3000 ./.air/bytebase --port 8080 --external-url https:\/\/change-me.ngrok.io --data . --debug'
   ## Use --tags "store.db" to enable SQL query logging against our metadata db.
   cmd = """
   go build \

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = ".air"
 
 [build]
-  full_bin = 'BB_REDIRECT_URL=http:\/\/localhost:3000 ./.air/bytebase --port 8080 --external-url https:\/\/change-me.ngrok.io --data . --debug'
+  full_bin = 'BB_REDIRECT_URL=http:\/\/localhost:3000 ./.air/bytebase --port 8080 --external-url http:\/\/localhost:3000 --data . --debug'
   ## Use --tags "store.db" to enable SQL query logging against our metadata db.
   cmd = """
   go build \


### PR DESCRIPTION
[Older versions of GitLab did not handle reading large file requests perfectly](https://gitlab.com/gitlab-org/gitlab-pages/-/issues/315). We move to use [another API](https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository) to get raw file content.