### PR TITLE
fix: use noop token refresher to delete the project webhook

### DIFF
--- a/server/project.go
+++ b/server/project.go
@@ -484,7 +484,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 					ClientSecret: vcs.Secret,
 					AccessToken:  repo.AccessToken,
 					RefreshToken: repo.RefreshToken,
-					Refresher:    s.refreshToken(ctx, repo.WebURL),
+					Refresher:    refreshTokenNoop(),
 				},
 				vcs.InstanceURL,
 				repo.ExternalID,


### PR DESCRIPTION
We cannot patch the repository table to store the new acess-token if we encounter 'token expired' in delete webhook procedure because we always delete the repository record first and then delete the corresponding webhook.