### PR TITLE
feat(frontend): show task check bar for more task types

### DIFF
--- a/frontend/src/components/Issue/IssueDetailLayout.vue
+++ b/frontend/src/components/Issue/IssueDetailLayout.vue
@@ -73,13 +73,13 @@
             </div>
             <div class="lg:hidden border-t border-block-border" />
             <div class="w-full lg:w-auto lg:flex-1 py-4 pr-4 overflow-x-hidden">
+              <div v-if="!create" class="mb-4">
+                <TaskCheckBar
+                  :task="(selectedTask as Task)"
+                  @run-checks="runTaskChecks"
+                />
+              </div>
               <section v-if="showIssueTaskStatementPanel" class="border-b mb-4">
-                <div v-if="!create" class="mb-4">
-                  <TaskCheckBar
-                    :task="(selectedTask as Task)"
-                    @run-checks="runTaskChecks"
-                  />
-                </div>
                 <IssueTaskStatementPanel :sql-hint="sqlHint()" />
               </section>
 

--- a/frontend/src/components/Issue/TaskCheckBadgeBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBadgeBar.vue
@@ -226,6 +226,7 @@ export default defineComponent({
 
 // Defines the order of TaskCheckType
 const TaskCheckTypeOrderList: TaskCheckType[] = [
+  "bb.task-check.pitr.mysql",
   "bb.task-check.database.ghost.sync",
   "bb.task-check.general.earliest-allowed-time",
   "bb.task-check.database.statement.compatibility",
@@ -266,5 +267,6 @@ const TaskCheckTypeNameDict = new Map<TaskCheckType, string>([
   ],
   ["bb.task-check.database.ghost.sync", "task.check-type.ghost-sync"],
   ["bb.task-check.issue.lgtm", "task.check-type.lgtm"],
+  ["bb.task-check.pitr.mysql", "task.check-type.pitr"],
 ]);
 </script>

--- a/frontend/src/components/Issue/TaskCheckBar.vue
+++ b/frontend/src/components/Issue/TaskCheckBar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="flex items-start space-x-4">
+  <div
+    v-if="task.taskCheckRunList.length > 0"
+    class="flex items-start space-x-4"
+  >
     <TaskCheckBadgeBar
       :task-check-run-list="task.taskCheckRunList"
       @select-task-check-type="viewCheckRunDetail"
@@ -141,13 +144,10 @@ export default defineComponent({
     const showRunCheckButton = computed((): boolean => {
       if (!props.allowRunTask) return false;
       return (
-        (props.task.type == "bb.task.database.schema.update" ||
-          props.task.type == "bb.task.database.data.update" ||
-          props.task.type === "bb.task.database.schema.update.ghost.sync") &&
-        (props.task.status == "PENDING" ||
-          props.task.status == "PENDING_APPROVAL" ||
-          props.task.status == "RUNNING" ||
-          props.task.status == "FAILED")
+        props.task.status == "PENDING" ||
+        props.task.status == "PENDING_APPROVAL" ||
+        props.task.status == "RUNNING" ||
+        props.task.status == "FAILED"
       );
     });
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -251,7 +251,8 @@
       "earliest-allowed-time": "Earliest allowed time",
       "ghost-sync": "gh-ost sync",
       "statement-type": "Statement type",
-      "lgtm": "LGTM"
+      "lgtm": "LGTM",
+      "pitr": "PITR"
     },
     "earliest-allowed-time-hint": "'@:{'common.when'}' specifies the expected execution timing for this task. If this field is not specified, the task will be executed once it has passed all other gating criteria.",
     "earliest-allowed-time-unset": "Unset",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -251,7 +251,8 @@
       "earliest-allowed-time": "最早执行时间",
       "ghost-sync": "gh-ost 同步",
       "statement-type": "语句类型",
-      "lgtm": "LGTM"
+      "lgtm": "LGTM",
+      "pitr": "PITR"
     },
     "earliest-allowed-time-hint": "'@:{'common.when'}' 指定了该任务最早允许执行的时间。如果该字段没有被指定，则任务会在满足其他条件后立即执行。",
     "comment": "评论",

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -219,7 +219,8 @@ export type TaskCheckType =
   | "bb.task-check.instance.migration-schema"
   | "bb.task-check.general.earliest-allowed-time"
   | "bb.task-check.database.ghost.sync"
-  | "bb.task-check.issue.lgtm";
+  | "bb.task-check.issue.lgtm"
+  | "bb.task-check.pitr.mysql";
 
 export type TaskCheckDatabaseStatementAdvisePayload = {
   statement: string;


### PR DESCRIPTION
We now show the <TaskCheckBar> for all task types. Just check if `task.taskCheckRunList.length > 0`

Close BYT-1529

![image](https://user-images.githubusercontent.com/2749742/192417156-c7d1acde-cdc5-4da8-ae4e-8e93be1fc5e8.png)
