### PR TITLE
fix(sql-editor): responsive height when debug banner is on

### DIFF
--- a/frontend/src/views/sql-editor/SQLEditorPage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sqleditor--wrapper">
     <TabListContainer />
-    <Splitpanes class="default-theme splitpanes-wrap">
+    <Splitpanes class="default-theme flex flex-col flex-1 overflow-hidden">
       <Pane size="20">
         <AsidePanel />
       </Pane>
@@ -73,15 +73,10 @@ const isFetchingSheet = computed(() => sqlEditorStore.isFetchingSheet);
 .sqleditor--wrapper {
   color: var(--base);
   --base: #444;
-  --nav-height: 64px;
-  --tab-height: 36px;
   --font-code: "Source Code Pro", monospace;
   --color-branding: #4f46e5;
   --border-color: rgba(200, 200, 200, 0.2);
-  height: calc(100vh - var(--nav-height));
-}
 
-.splitpanes.default-theme.splitpanes-wrap {
-  height: calc(100% - var(--tab-height));
+  @apply flex-1 overflow-hidden flex flex-col;
 }
 </style>

--- a/frontend/src/views/sql-editor/TabListContainer.vue
+++ b/frontend/src/views/sql-editor/TabListContainer.vue
@@ -291,7 +291,6 @@ onUnmounted(() => {
 
 <style scoped>
 .tab-list-container {
-  height: var(--tab-height);
   @apply flex box-border;
   @apply text-gray-500 text-sm;
   @apply border-b;


### PR DESCRIPTION
We once used a static calculation for the containers' heights. Now we use flex that will be responsive whenever the debug banner is on or off.

### Screenshot
Before
<img width="1800" alt="bug-height-with-debug-banner" src="https://user-images.githubusercontent.com/2749742/192674037-3d07b06a-39f3-4d00-bc43-6c2d24a50298.png">

After
<img width="1800" alt="bugfix-height-with-debug-banner" src="https://user-images.githubusercontent.com/2749742/192674043-c29466e1-3750-4ccd-ae7e-5f4f7cad0fd9.png">
