### PR TITLE
chore: reduce log of repo internal structure

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -229,7 +229,11 @@ func (s *Server) createIssuesFromCommits(ctx context.Context, webhookEndpointID 
 		createdMessages = append(createdMessages, createdMessageList...)
 	}
 	if len(createdMessages) == 0 {
-		log.Warn("Ignored push event because no applicable file found in the commit list", zap.Any("repos", filteredRepos))
+		var repoURLs []string
+		for _, repo := range filteredRepos {
+			repoURLs = append(repoURLs, repo.WebURL)
+		}
+		log.Warn("Ignored push event because no applicable file found in the commit list", zap.Any("repos", repoURLs))
 	}
 	return createdMessages, nil
 }


### PR DESCRIPTION
Repository log contains repeated creator info, which spams the log.