### PR TITLE
refactor(sql-editor): decouple selected table from tab connection info

### DIFF
--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -4,7 +4,6 @@ import {
   SQLEditorState,
   ConnectionAtom,
   QueryInfo,
-  ConnectionContext,
   Database,
   DatabaseId,
   ProjectId,
@@ -12,6 +11,7 @@ import {
   UNKNOWN_ID,
   InstanceId,
   Connection,
+  unknown,
 } from "@/types";
 import { useActivityStore } from "./activity";
 import { useDatabaseStore } from "./database";
@@ -22,14 +22,10 @@ import { useProjectStore } from "./project";
 import { useTabStore } from "./tab";
 import { emptyConnection } from "@/utils";
 
-export const getDefaultConnectionContext = () => ({
-  option: {} as any,
-});
-
 export const useSQLEditorStore = defineStore("sqlEditor", {
   state: (): SQLEditorState => ({
     connectionTree: [],
-    connectionContext: getDefaultConnectionContext(),
+    selectedTable: unknown("TABLE"),
     isLoadingTree: false,
     isShowExecutingHint: false,
     shouldFormatContent: false,
@@ -80,9 +76,6 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
     },
     setConnectionTree(payload: ConnectionAtom[]) {
       this.connectionTree = payload;
-    },
-    setConnectionContext(payload: Partial<ConnectionContext>) {
-      Object.assign(this.connectionContext, payload);
     },
     setShouldFormatContent(payload: boolean) {
       this.shouldFormatContent = payload;

--- a/frontend/src/store/modules/table.ts
+++ b/frontend/src/store/modules/table.ts
@@ -81,6 +81,15 @@ export const useTableStore = defineStore("table", {
       return table || unknown("TABLE");
     },
 
+    async getOrFetchTableByDatabaseIdAndTableId(
+      databaseId: DatabaseId,
+      tableId: TableId
+    ) {
+      const tableList = await this.getOrFetchTableListByDatabaseId(databaseId);
+      const table = tableList.find((t) => t.id === tableId);
+      return table || unknown("TABLE");
+    },
+
     setTableByDatabaseIdAndTableName({
       databaseId,
       tableName,

--- a/frontend/src/types/sqlEditor.ts
+++ b/frontend/src/types/sqlEditor.ts
@@ -26,11 +26,6 @@ export enum SortText {
   KEYWORD = "3",
 }
 
-// TODO(Jim): refactor <TableSchema> to get rid of this structure totally.
-export type ConnectionContext = {
-  option: ConnectionAtom;
-};
-
 export interface QueryHistory {
   id: ActivityId;
 

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -46,7 +46,7 @@ import { Setting, SettingName } from "./setting";
 import { Table } from "./table";
 import { VCS } from "./vcs";
 import { Label } from "./label";
-import { ConnectionAtom, ConnectionContext } from "./sqlEditor";
+import { ConnectionAtom } from "./sqlEditor";
 import { TabInfo } from "./tab";
 import type { DebugLog } from "@/types/debug";
 
@@ -193,7 +193,7 @@ export interface LabelState {
 
 export interface SQLEditorState {
   connectionTree: ConnectionAtom[];
-  connectionContext: ConnectionContext;
+  selectedTable: Table;
   shouldFormatContent: boolean;
   queryHistoryList: QueryHistory[];
   isFetchingQueryHistory: boolean;

--- a/frontend/src/types/tab.ts
+++ b/frontend/src/types/tab.ts
@@ -1,11 +1,4 @@
-import {
-  Advice,
-  DatabaseId,
-  InstanceId,
-  ProjectId,
-  SheetId,
-  TableId,
-} from "../types";
+import { Advice, DatabaseId, InstanceId, ProjectId, SheetId } from "../types";
 
 export type ExecuteConfig = {
   databaseType: string;
@@ -19,7 +12,6 @@ export type Connection = {
   projectId: ProjectId;
   instanceId: InstanceId;
   databaseId: DatabaseId;
-  tableId: TableId;
 };
 
 export interface TabInfo {

--- a/frontend/src/utils/tab.ts
+++ b/frontend/src/utils/tab.ts
@@ -11,7 +11,6 @@ export const emptyConnection = (): Connection => {
     projectId: DEFAULT_PROJECT_ID,
     instanceId: UNKNOWN_ID,
     databaseId: UNKNOWN_ID,
-    tableId: UNKNOWN_ID,
   };
 };
 
@@ -35,4 +34,8 @@ export const isTempTab = (tab: TabInfo): boolean => {
   if (!tab.isSaved) return false;
   if (tab.statement) return false;
   return true;
+};
+
+export const isSameConnection = (a: Connection, b: Connection): boolean => {
+  return a.instanceId === b.instanceId && a.databaseId === b.databaseId;
 };

--- a/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
@@ -6,7 +6,6 @@
           horizontal
           class="default-theme"
           :dbl-click-splitter="false"
-          @resized="handleResized"
         >
           <Pane :size="databasePaneSize"><DatabaseTree /></Pane>
           <Pane :size="FULL_HEIGHT - databasePaneSize">
@@ -22,38 +21,28 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from "vue";
+import { computed } from "vue";
 import { useSQLEditorStore } from "@/store";
 import DatabaseTree from "./DatabaseTree.vue";
 import QueryHistoryContainer from "./QueryHistoryContainer.vue";
 import TableSchema from "./TableSchema.vue";
 import { Splitpanes, Pane } from "splitpanes";
+import { unknown, UNKNOWN_ID } from "@/types";
 
 const FULL_HEIGHT = 100;
 const DATABASE_PANE_SIZE = 60;
 
 const sqlEditorStore = useSQLEditorStore();
-const databasePaneSize = ref(FULL_HEIGHT);
-
-const handleResized = (data: any) => {
-  const [top] = data;
-  databasePaneSize.value = top.size;
-};
+const databasePaneSize = computed(() => {
+  if (sqlEditorStore.selectedTable.id !== UNKNOWN_ID) {
+    return DATABASE_PANE_SIZE;
+  }
+  return FULL_HEIGHT;
+});
 
 const handleCloseTableSchemaPane = () => {
-  databasePaneSize.value = FULL_HEIGHT;
+  sqlEditorStore.selectedTable = unknown("TABLE");
 };
-
-watch(
-  () => sqlEditorStore.connectionContext.option,
-  (option) => {
-    if (option && option.type === "table") {
-      databasePaneSize.value = DATABASE_PANE_SIZE;
-    } else {
-      databasePaneSize.value = FULL_HEIGHT;
-    }
-  }
-);
 </script>
 
 <style scoped>

--- a/frontend/src/views/sql-editor/EditorPanel/EditorAction.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/EditorAction.vue
@@ -60,14 +60,6 @@
               <heroicons-outline:database />
               <span class="ml-2">{{ selectedDatabase.name }}</span>
             </div>
-            <div
-              v-if="selectedTable.id !== UNKNOWN_ID"
-              class="flex items-center"
-            >
-              &nbsp; / &nbsp;
-              <heroicons-outline:table />
-              <span class="ml-2">{{ selectedTable.name }}</span>
-            </div>
           </label>
         </template>
         <section>
@@ -85,10 +77,6 @@
             >
               <h1 class="text-gray-400">{{ $t("common.database") }}:</h1>
               <span>{{ selectedDatabase.name }}</span>
-            </div>
-            <div v-if="selectedTable.id !== UNKNOWN_ID" class="flex flex-col">
-              <h1 class="text-gray-400">{{ $t("common.table") }}:</h1>
-              <span>{{ selectedTable.name }}</span>
             </div>
           </div>
         </section>
@@ -132,7 +120,6 @@ import {
   useSQLEditorStore,
   useInstanceById,
   useDatabaseById,
-  useTableStore,
 } from "@/store";
 import { UNKNOWN_ID } from "@/types";
 import { instanceSlug } from "@/utils/slug";
@@ -146,7 +133,6 @@ const router = useRouter();
 const instanceStore = useInstanceStore();
 const tabStore = useTabStore();
 const sqlEditorStore = useSQLEditorStore();
-const tableStore = useTableStore();
 
 const connection = computed(() => tabStore.currentTab.connection);
 
@@ -163,10 +149,6 @@ const selectedInstanceEngine = computed(() => {
 const selectedDatabase = useDatabaseById(
   computed(() => connection.value.databaseId)
 );
-const selectedTable = computed(() => {
-  const { databaseId, tableId } = connection.value;
-  return tableStore.getTableByDatabaseIdAndTableId(databaseId, tableId);
-});
 
 const hasReadonlyDataSource = computed(() => {
   for (const ds of selectedInstance.value.dataSourceList) {


### PR DESCRIPTION
Close BYT-1533

We once store the `tableId` as a field of `TabInfo`. That's weird since `tableId` is actually not a part of the connection params.

Now we split it to `sqlEditorStore.selectedTable`, which is just a UI state for the <TableSchema> panel.