### PR TITLE
refactor(sql-editor): tab store with setup api

### DIFF
--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -47,7 +47,6 @@ import { Table } from "./table";
 import { VCS } from "./vcs";
 import { Label } from "./label";
 import { ConnectionAtom } from "./sqlEditor";
-import { TabInfo } from "./tab";
 import type { DebugLog } from "@/types/debug";
 
 export interface ActuatorState {
@@ -200,11 +199,6 @@ export interface SQLEditorState {
   isLoadingTree: boolean;
   isFetchingSheet: boolean;
   isShowExecutingHint: boolean;
-}
-
-export interface TabState {
-  tabList: TabInfo[];
-  currentTabId: string;
 }
 
 export interface DeploymentState {


### PR DESCRIPTION
Refactor the tab store with [pinia setup api](https://pinia.vuejs.org/core-concepts/#setup-stores). No code logic changes.

This refactor is a preparation for the upcoming tab list local store (BYT-1538).