### PR TITLE
chore(1.5.0): cherrypick pr #2846

### DIFF
--- a/frontend/src/components/Issue/IssueActivityPanel.vue
+++ b/frontend/src/components/Issue/IssueActivityPanel.vue
@@ -341,6 +341,7 @@ import type {
   ActivityCreate,
   IssueSubscriber,
   ActivityTaskFileCommitPayload,
+  Task,
 } from "@/types";
 import { UNKNOWN_ID, EMPTY_ID, SYSTEM_BOT_ID } from "@/types";
 import { findTaskById, issueSlug, sizeToFit, taskSlug } from "@/utils";
@@ -378,6 +379,10 @@ type ActionIconType =
   | "fail"
   | "complete"
   | "commit";
+
+const emit = defineEmits<{
+  (event: "run-checks", task: Task): void;
+}>();
 
 const { t } = useI18n();
 const activityStore = useActivityStore();
@@ -478,6 +483,10 @@ const doCreateComment = (comment: string, clear = true) => {
     }
     if (!isSubscribed) {
       addSubscriberId(currentUser.value.id);
+    }
+
+    if (comment === "LGTM") {
+      emit("run-checks", logic.selectedTask.value as Task);
     }
   });
 };

--- a/frontend/src/components/Issue/IssueDetailLayout.vue
+++ b/frontend/src/components/Issue/IssueDetailLayout.vue
@@ -90,7 +90,7 @@
                 aria-labelledby="activity-title"
                 class="mt-4"
               >
-                <IssueActivityPanel />
+                <IssueActivityPanel @run-checks="runTaskChecks" />
               </section>
             </div>
           </div>


### PR DESCRIPTION
### Features

- Automatically re-run task checks after an "LTGM" comment (either the LGTM button or manually comment "LGTM").

### Known issues

- The run task checks API endpoint will run all check types if possible. I consider it will be better to support running specified type(s) of task checks. wdyt @RainbowDashy 