### PR TITLE
feat(sql-editor): database tree improvement

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -16,13 +16,8 @@ import {
   useInstanceStore,
   pushNotification,
 } from "@/store";
-import {
-  Instance,
-  Database,
-  ConnectionAtom,
-  UNKNOWN_ID,
-  DEFAULT_PROJECT_ID,
-} from "@/types";
+import type { Instance, Database, ConnectionAtom } from "@/types";
+import { UNKNOWN_ID, DEFAULT_PROJECT_ID } from "@/types";
 import {
   emptyConnection,
   idFromSlug,
@@ -90,7 +85,7 @@ const prepareSQLEditorContext = async () => {
       .filter((db) => db.instance.id === instance.id)
       .map(mapConnectionAtom("database", instance.id));
 
-    sqlEditorStore.setConnectionTree(connectionTree);
+    sqlEditorStore.connectionTree.data = connectionTree;
   }
 
   // Won't fetch tableList for every database here.
@@ -135,7 +130,6 @@ const prepareSheet = async () => {
     isSaved: true,
     connection: {
       ...emptyConnection(),
-      projectId: sheet.database?.projectId || DEFAULT_PROJECT_ID,
       instanceId: sheet.database?.instanceId || UNKNOWN_ID,
       databaseId: sheet.databaseId || UNKNOWN_ID,
     },
@@ -238,10 +232,19 @@ const syncURLWithConnection = () => {
 };
 
 onMounted(async () => {
-  sqlEditorStore.isLoadingTree = true;
-  await prepareAccessibleConnectionByProject();
-  await prepareSQLEditorContext();
-  sqlEditorStore.isLoadingTree = false;
+  if (sqlEditorStore.connectionTree.state === "unset") {
+    sqlEditorStore.connectionTree.state = "loading";
+    await prepareAccessibleConnectionByProject();
+    await prepareSQLEditorContext();
+    sqlEditorStore.connectionTree.state = "loaded";
+  }
+
+  watch(currentUser, (user) => {
+    if (user.id === UNKNOWN_ID) {
+      sqlEditorStore.connectionTree.data = [];
+      sqlEditorStore.connectionTree.state = "unset";
+    }
+  });
 
   await setConnectionFromQuery();
   await sqlEditorStore.fetchQueryHistoryList();

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -17,7 +17,7 @@ import {
   pushNotification,
 } from "@/store";
 import type { Instance, Database, ConnectionAtom } from "@/types";
-import { UNKNOWN_ID, DEFAULT_PROJECT_ID } from "@/types";
+import { ConnectionTreeState, UNKNOWN_ID, DEFAULT_PROJECT_ID } from "@/types";
 import {
   emptyConnection,
   idFromSlug,
@@ -232,17 +232,17 @@ const syncURLWithConnection = () => {
 };
 
 onMounted(async () => {
-  if (sqlEditorStore.connectionTree.state === "unset") {
-    sqlEditorStore.connectionTree.state = "loading";
+  if (sqlEditorStore.connectionTree.state === ConnectionTreeState.UNSET) {
+    sqlEditorStore.connectionTree.state = ConnectionTreeState.LOADING;
     await prepareAccessibleConnectionByProject();
     await prepareSQLEditorContext();
-    sqlEditorStore.connectionTree.state = "loaded";
+    sqlEditorStore.connectionTree.state = ConnectionTreeState.LOADED;
   }
 
   watch(currentUser, (user) => {
     if (user.id === UNKNOWN_ID) {
       sqlEditorStore.connectionTree.data = [];
-      sqlEditorStore.connectionTree.state = "unset";
+      sqlEditorStore.connectionTree.state = ConnectionTreeState.UNSET;
     }
   });
 

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -9,6 +9,7 @@ import type {
   Connection,
   ActivitySQLEditorQueryPayload,
 } from "@/types";
+import { ConnectionTreeState } from "@/types";
 import { UNKNOWN_ID, unknown } from "@/types";
 import { useActivityStore } from "./activity";
 import { useDatabaseStore } from "./database";
@@ -21,7 +22,7 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
   state: (): SQLEditorState => ({
     connectionTree: {
       data: [],
-      state: "unset",
+      state: ConnectionTreeState.UNSET,
     },
     expandedTreeNodeKeys: [],
     selectedTable: unknown("TABLE"),

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -2,7 +2,6 @@ import { defineStore } from "pinia";
 import dayjs from "dayjs";
 import type {
   SQLEditorState,
-  ConnectionAtom,
   QueryInfo,
   DatabaseId,
   QueryHistory,
@@ -20,9 +19,12 @@ import { useTabStore } from "./tab";
 
 export const useSQLEditorStore = defineStore("sqlEditor", {
   state: (): SQLEditorState => ({
-    connectionTree: [],
+    connectionTree: {
+      data: [],
+      state: "unset",
+    },
+    expandedTreeNodeKeys: [],
     selectedTable: unknown("TABLE"),
-    isLoadingTree: false,
     isShowExecutingHint: false,
     shouldFormatContent: false,
     // Related data and status
@@ -34,9 +36,6 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
   actions: {
     setSQLEditorState(payload: Partial<SQLEditorState>) {
       Object.assign(this, payload);
-    },
-    setConnectionTree(payload: ConnectionAtom[]) {
-      this.connectionTree = payload;
     },
     setShouldFormatContent(payload: boolean) {
       this.shouldFormatContent = payload;

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -191,12 +191,15 @@ export interface LabelState {
 }
 
 export interface SQLEditorState {
-  connectionTree: ConnectionAtom[];
+  connectionTree: {
+    data: ConnectionAtom[];
+    state: "unset" | "loading" | "loaded";
+  };
+  expandedTreeNodeKeys: string[];
   selectedTable: Table;
   shouldFormatContent: boolean;
   queryHistoryList: QueryHistory[];
   isFetchingQueryHistory: boolean;
-  isLoadingTree: boolean;
   isFetchingSheet: boolean;
   isShowExecutingHint: boolean;
 }

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -190,10 +190,16 @@ export interface LabelState {
   labelList: Label[];
 }
 
+export enum ConnectionTreeState {
+  UNSET,
+  LOADING,
+  LOADED,
+}
+
 export interface SQLEditorState {
   connectionTree: {
     data: ConnectionAtom[];
-    state: "unset" | "loading" | "loaded";
+    state: ConnectionTreeState;
   };
   expandedTreeNodeKeys: string[];
   selectedTable: Table;

--- a/frontend/src/utils/dom.ts
+++ b/frontend/src/utils/dom.ts
@@ -1,0 +1,12 @@
+export const isDescendantOf = (
+  node: Element | null | undefined,
+  selector: string
+) => {
+  while (node) {
+    if (node.matches(selector)) {
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+};

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -19,3 +19,4 @@ export * from "./principal";
 export * from "./sql-editor";
 export * from "./sheet";
 export * from "./pev2";
+export * from "./dom";

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -156,6 +156,7 @@ export function getStringCookie(name: string): string {
 }
 
 export function getHighlightHTMLByKeyWords(s: string, k: string) {
+  if (!k) return s;
   return s.replaceAll(k, `<b class="text-accent">${k}</b>`);
 }
 

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="sqlEditorStore.connectionTree.state === 'loaded'"
+    v-if="sqlEditorStore.connectionTree.state === ConnectionTreeState.LOADED"
     class="databases-tree p-2 space-y-2 h-full"
   >
     <div class="databases-tree--input">
@@ -52,7 +52,7 @@ import { stringify } from "qs";
 import ConnectedIcon from "~icons/heroicons-outline/lightning-bolt";
 
 import type { ConnectionAtom, DatabaseId, InstanceId } from "@/types";
-import { UNKNOWN_ID } from "@/types";
+import { ConnectionTreeState, UNKNOWN_ID } from "@/types";
 import {
   useDatabaseStore,
   useIsLoggedIn,

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -360,11 +360,14 @@ watch(
 </script>
 
 <style>
-.n-tree-node-content__prefix {
+.databases-tree .n-tree-node-content__prefix {
   @apply shrink-0;
 }
-.n-tree-node-content__text {
+.databases-tree .n-tree-node-content__text {
   @apply truncate mr-1;
+}
+.databases-tree .n-tree-node--pending {
+  background-color: transparent !important;
 }
 </style>
 

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -369,6 +369,9 @@ watch(
 .databases-tree .n-tree-node--pending {
   background-color: transparent !important;
 }
+.databases-tree .n-tree-node--pending:hover {
+  background-color: var(--n-node-color-hover) !important;
+}
 </style>
 
 <style scoped>

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -55,7 +55,6 @@ import type { ConnectionAtom, DatabaseId, InstanceId } from "@/types";
 import { UNKNOWN_ID } from "@/types";
 import {
   useDatabaseStore,
-  useInstanceStore,
   useIsLoggedIn,
   useSQLEditorStore,
   useTableStore,
@@ -68,7 +67,7 @@ import {
   isSameConnection,
   mapConnectionAtom,
 } from "@/utils";
-import { generateInstanceNode, generateTableItem } from "./utils";
+import { generateTableItem } from "./utils";
 import { scrollIntoViewIfNeeded } from "@/bbkit/BBUtil";
 
 type Position = {
@@ -82,7 +81,6 @@ type DropdownOptionWithConnectionAtom = DropdownOption & {
 
 const { t } = useI18n();
 
-const instanceStore = useInstanceStore();
 const databaseStore = useDatabaseStore();
 const sqlEditorStore = useSQLEditorStore();
 const tableStore = useTableStore();
@@ -130,21 +128,7 @@ const selectedKeys = computed(() => {
   return [];
 });
 
-const generateTreeData = () => {
-  return sqlEditorStore.connectionTree.data.map((item) =>
-    generateInstanceNode(item, instanceStore)
-  );
-};
-
-const treeData = ref<ConnectionAtom[]>([]);
-
-watch(
-  () => sqlEditorStore.connectionTree.data,
-  () => {
-    treeData.value = generateTreeData();
-  },
-  { immediate: true }
-);
+const treeData = computed(() => sqlEditorStore.connectionTree.data);
 
 const setConnection = (option: ConnectionAtom) => {
   if (option) {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -51,7 +51,7 @@
       "unplugin-icons/types/vue",
       "vite/client"
     ] /* Type declaration files to be included in compilation. */,
-    "lib": ["WebWorker"],
+    "lib": ["WebWorker", "ES2022"],
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
### Features

- Won't re-build the tree when redirecting from the "Sheets" page.
- Expand, highlight and locate the corresponding tree node when switching tabs or the current tab's connection params changed.

### Screenshots
Highlighting
![image](https://user-images.githubusercontent.com/2749742/192996871-88cbc16b-ae0f-4047-a600-291d1d55a0f1.png)

Scroll the node into view if needed
![scroll-node-into-view](https://user-images.githubusercontent.com/2749742/193009322-3cdeace1-f76a-4761-93dc-e01631796d57.gif)

Also: close BYT-1517


