### PR TITLE
feat: allow wildcard (`*`) as database template name for tenant projects

### DIFF
--- a/api/project.go
+++ b/api/project.go
@@ -230,7 +230,7 @@ func ValidateRepositorySchemaPathTemplate(schemaPathTemplate string, tenantMode 
 
 // ValidateProjectDBNameTemplate validates the project database name template.
 func ValidateProjectDBNameTemplate(template string) error {
-	if template == "" {
+	if template == "" || template == "*" {
 		return nil
 	}
 	tokens, _ := common.ParseTemplateTokens(template)
@@ -285,7 +285,8 @@ func formatTemplateRegexp(template string, tokens map[string]string) (string, er
 
 // GetBaseDatabaseName will return the base database name given the database name, dbNameTemplate, labelsJSON.
 func GetBaseDatabaseName(databaseName, dbNameTemplate, labelsJSON string) (string, error) {
-	if dbNameTemplate == "" {
+	// There is no need to check database name if the template is empty or a wildcard.
+	if dbNameTemplate == "" || dbNameTemplate == "*" {
 		return databaseName, nil
 	}
 	var labels []*DatabaseLabel

--- a/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
+++ b/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
@@ -130,7 +130,7 @@ const requiredLabelList = computed((): Label[] => {
 
 const dbNameMatchesTemplate = computed((): boolean => {
   const project = targetProject.value;
-  if (!project.dbNameTemplate) {
+  if (!project.dbNameTemplate || project.dbNameTemplate == "*") {
     // no restrictions, because no template
     return true;
   }

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -244,8 +244,8 @@ type MigrationInfo struct {
 }
 
 // placeholderRegexp is the regexp for placeholder.
-// Refer to https://stackoverflow.com/a/6222235/19075342, but we support '.' for now.
-const placeholderRegexp = `[^\\/?%*:|"<>]+`
+// Refer to https://stackoverflow.com/a/6222235/19075342, but we support "." and "*" for now.
+const placeholderRegexp = `[^\\/?%:|"<>]+`
 
 // ParseMigrationInfo matches filePath against filePathTemplate
 // If filePath matches, then it will derive MigrationInfo from the filePath.

--- a/server/database.go
+++ b/server/database.go
@@ -809,8 +809,9 @@ func (s *Server) setDatabaseLabels(ctx context.Context, labelsJSON string, datab
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to validate database labels").SetInternal(err)
 	}
 
-	// Validate labels can match database name template on the project.
-	if project.DBNameTemplate != "" {
+	// Validate labels can match database name template on the project if the
+	// template is not a wildcard.
+	if project.DBNameTemplate != "" && project.DBNameTemplate != "*" {
 		tokens := make(map[string]string)
 		for _, label := range labels {
 			tokens[label.Key] = tokens[label.Value]

--- a/server/deploy.go
+++ b/server/deploy.go
@@ -77,14 +77,18 @@ func getDatabaseMatrixFromDeploymentSchedule(schedule *api.DeploymentSchedule, b
 		// Loop over databaseList instead of idToLabels to get determinant results.
 		for _, database := range databaseList {
 			labels := idToLabels[database.ID]
-			// The tenant database should match the database name.
-			name, err := formatDatabaseName(baseDatabaseName, dbNameTemplate, labels)
-			if err != nil {
-				continue
+
+			if dbNameTemplate != "*" {
+				// The tenant database should match the database name if the template is not a wildcard.
+				name, err := formatDatabaseName(baseDatabaseName, dbNameTemplate, labels)
+				if err != nil {
+					continue
+				}
+				if database.Name != name {
+					continue
+				}
 			}
-			if database.Name != name {
-				continue
-			}
+
 			// Skip if the database is already in a stage.
 			if _, ok := idsSeen[database.ID]; ok {
 				continue

--- a/server/issue.go
+++ b/server/issue.go
@@ -1339,6 +1339,11 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 	// If there are existing databases with the same name, we will disallow the database creation.
 	// Otherwise, we will create a blank new database.
 	if similarDB == nil {
+		// Ignore the database name conflict if the template is a wildcard.
+		if project.DBNameTemplate == "*" {
+			return "", "", nil
+		}
+
 		found := false
 		for _, db := range dbList {
 			var labelList []*api.DatabaseLabel


### PR DESCRIPTION
Currently, we only allow two possible values `{{DB_NAME}}` and `{{DB_NAME}}_{{TENANT}}` to be used as the database name template for tenant projects with GitOps workflow. Both of them imply a single file change will only apply to a single database.

This PR adds the support to allow a third possible value wildcard (`*`) to be used as the database name template, which implies a single file change will be applied to _all_ databases within the project.

### Demo

One file commit changes all (two) databases in the project:

![CleanShot 2022-09-30 at 17 49 27@2x](https://user-images.githubusercontent.com/2946214/193244143-0ff00d37-ea7a-46d3-a0af-07280c0d1f97.png)


### TODO

- I will add integration tests once the approach looks good.