### PR TITLE
chore: use empty database name template for naming unrestricted mode

### DIFF
--- a/api/project.go
+++ b/api/project.go
@@ -77,8 +77,12 @@ type Project struct {
 	WorkflowType ProjectWorkflowType `jsonapi:"attr,workflowType"`
 	Visibility   ProjectVisibility   `jsonapi:"attr,visibility"`
 	TenantMode   ProjectTenantMode   `jsonapi:"attr,tenantMode"`
-	// DBNameTemplate is only used when a project is in tenant mode.
-	// Empty value means {{DB_NAME}}.
+	// DBNameTemplate is only used when a project is in tenant mode and the name of tenant databases follows a format.
+	// {{DB_NAME}} is used for each tenant belonging to an individual database instance and all tenant databases have the same database name.
+	// The template can include label keys such as {{DB_NAME}}_{{TENANT}}. It allows to all tenant databases belonging to one or a few database instances.
+	// All database with the same {{DB_NAME}} (base database name) belong to one group.
+	//
+	// Empty value means all tenant databases in the project belonging to the same group.
 	DBNameTemplate string              `jsonapi:"attr,dbNameTemplate"`
 	RoleProvider   ProjectRoleProvider `jsonapi:"attr,roleProvider"`
 	// SchemaChangeType is the type of the schema migration script.
@@ -230,7 +234,7 @@ func ValidateRepositorySchemaPathTemplate(schemaPathTemplate string, tenantMode 
 
 // ValidateProjectDBNameTemplate validates the project database name template.
 func ValidateProjectDBNameTemplate(template string) error {
-	if template == "" || template == "*" {
+	if template == "" {
 		return nil
 	}
 	tokens, _ := common.ParseTemplateTokens(template)
@@ -286,7 +290,7 @@ func formatTemplateRegexp(template string, tokens map[string]string) (string, er
 // GetBaseDatabaseName will return the base database name given the database name, dbNameTemplate, labelsJSON.
 func GetBaseDatabaseName(databaseName, dbNameTemplate, labelsJSON string) (string, error) {
 	// There is no need to check database name if the template is empty or a wildcard.
-	if dbNameTemplate == "" || dbNameTemplate == "*" {
+	if dbNameTemplate == "" {
 		return databaseName, nil
 	}
 	var labels []*DatabaseLabel

--- a/api/project.go
+++ b/api/project.go
@@ -79,7 +79,7 @@ type Project struct {
 	TenantMode   ProjectTenantMode   `jsonapi:"attr,tenantMode"`
 	// DBNameTemplate is only used when a project is in tenant mode and the name of tenant databases follows a format.
 	// {{DB_NAME}} is used for each tenant belonging to an individual database instance and all tenant databases have the same database name.
-	// The template can include label keys such as {{DB_NAME}}_{{TENANT}}. It allows to all tenant databases belonging to one or a few database instances.
+	// The template can include label keys such as {{DB_NAME}}_{{TENANT}}. It allows all tenant databases to belong to one or a few database instances.
 	// All database with the same {{DB_NAME}} (base database name) belong to one group.
 	//
 	// Empty value means all tenant databases in the project belonging to the same group.

--- a/frontend/src/components/ProjectCreate.vue
+++ b/frontend/src/components/ProjectCreate.vue
@@ -174,7 +174,7 @@ export default defineComponent({
         name: "New Project",
         key: randomString(3).toUpperCase(),
         tenantMode: "DISABLED",
-        dbNameTemplate: "",
+        dbNameTemplate: "{{DB_NAME}}_{{TENANT}}",
         roleProvider: "BYTEBASE",
       } as Project,
       showFeatureModal: false,

--- a/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
+++ b/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
@@ -130,7 +130,7 @@ const requiredLabelList = computed((): Label[] => {
 
 const dbNameMatchesTemplate = computed((): boolean => {
   const project = targetProject.value;
-  if (!project.dbNameTemplate || project.dbNameTemplate == "*") {
+  if (!project.dbNameTemplate) {
     // no restrictions, because no template
     return true;
   }

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -245,7 +245,7 @@ type MigrationInfo struct {
 
 // placeholderRegexp is the regexp for placeholder.
 // Refer to https://stackoverflow.com/a/6222235/19075342, but we support "." and "*" for now.
-const placeholderRegexp = `[^\\/?%:|"<>]+`
+const placeholderRegexp = `[^\\/?%*:|"<>]+`
 
 // ParseMigrationInfo matches filePath against filePathTemplate
 // If filePath matches, then it will derive MigrationInfo from the filePath.

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -244,7 +244,7 @@ type MigrationInfo struct {
 }
 
 // placeholderRegexp is the regexp for placeholder.
-// Refer to https://stackoverflow.com/a/6222235/19075342, but we support "." and "*" for now.
+// Refer to https://stackoverflow.com/a/6222235/19075342, but we support "." for now.
 const placeholderRegexp = `[^\\/?%*:|"<>]+`
 
 // ParseMigrationInfo matches filePath against filePathTemplate

--- a/server/database.go
+++ b/server/database.go
@@ -811,7 +811,7 @@ func (s *Server) setDatabaseLabels(ctx context.Context, labelsJSON string, datab
 
 	// Validate labels can match database name template on the project if the
 	// template is not a wildcard.
-	if project.DBNameTemplate != "" && project.DBNameTemplate != "*" {
+	if project.DBNameTemplate != "" {
 		tokens := make(map[string]string)
 		for _, label := range labels {
 			tokens[label.Key] = tokens[label.Value]

--- a/server/deploy.go
+++ b/server/deploy.go
@@ -78,8 +78,8 @@ func getDatabaseMatrixFromDeploymentSchedule(schedule *api.DeploymentSchedule, b
 		for _, database := range databaseList {
 			labels := idToLabels[database.ID]
 
-			if dbNameTemplate != "*" {
-				// The tenant database should match the database name if the template is not a wildcard.
+			if dbNameTemplate != "" {
+				// The tenant database should match the database name if the template is not empty.
 				name, err := formatDatabaseName(baseDatabaseName, dbNameTemplate, labels)
 				if err != nil {
 					continue

--- a/server/deploy_test.go
+++ b/server/deploy_test.go
@@ -90,7 +90,7 @@ func TestGetDatabaseMatrixFromDeploymentSchedule(t *testing.T) {
 				},
 			},
 			"hello",
-			"",
+			"{{DB_NAME}}",
 			[]*api.Database{
 				dbs[0], dbs[1],
 			},
@@ -132,7 +132,7 @@ func TestGetDatabaseMatrixFromDeploymentSchedule(t *testing.T) {
 				},
 			},
 			"hello",
-			"",
+			"{{DB_NAME}}",
 			[]*api.Database{
 				dbs[0], dbs[1], dbs[2],
 			},
@@ -175,7 +175,7 @@ func TestGetDatabaseMatrixFromDeploymentSchedule(t *testing.T) {
 				},
 			},
 			"hello",
-			"",
+			"{{DB_NAME}}",
 			[]*api.Database{
 				dbs[0], dbs[2], dbs[3],
 			},
@@ -204,7 +204,7 @@ func TestGetDatabaseMatrixFromDeploymentSchedule(t *testing.T) {
 				},
 			},
 			"world",
-			"",
+			"{{DB_NAME}}",
 			[]*api.Database{
 				dbs[3], dbs[4],
 			},

--- a/server/issue.go
+++ b/server/issue.go
@@ -1339,8 +1339,8 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 	// If there are existing databases with the same name, we will disallow the database creation.
 	// Otherwise, we will create a blank new database.
 	if similarDB == nil {
-		// Ignore the database name conflict if the template is a wildcard.
-		if project.DBNameTemplate == "*" {
+		// Ignore the database name conflict if the template is empty.
+		if project.DBNameTemplate == "" {
 			return "", "", nil
 		}
 


### PR DESCRIPTION
1. Use database name template {{DB_NAME}} for the case that each tenant belongs to a standalone database instance and all tenant databases have the same name.
2. Use an empty database name template for the cases in that we don't restrict tenant database naming. And all tenant databases in the same project belong to the same group.
3. Change default database name template to {{DB_NAME}}_{{TENANT}} in Frontend.