### PR TITLE
feat: frontend support for empty database name template

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -355,7 +355,7 @@ export default defineComponent({
     });
 
     const allowGenerateTenant = computed(() => {
-      // All databases will be the same group of dbNameTemplate is empty.
+      // All databases will be in the same group if dbNameTemplate is empty.
       if (isTenantProject.value && state.project?.dbNameTemplate === "")
         return true;
       if (!state.selectedDatabaseName) return false;

--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -355,6 +355,9 @@ export default defineComponent({
     });
 
     const allowGenerateTenant = computed(() => {
+      // All databases will be the same group of dbNameTemplate is empty.
+      if (isTenantProject.value && state.project?.dbNameTemplate === "")
+        return true;
       if (!state.selectedDatabaseName) return false;
 
       // not allowed when database list filtered by deployment config is empty

--- a/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
@@ -180,7 +180,7 @@ const deployment = computed(() => {
 const databaseListGroupByName = computed(
   (): { name: string; list: Database[] }[] => {
     if (!props.project) return [];
-    // All databases will be the same group of dbNameTemplate is empty.
+    // All databases will be in the same group if dbNameTemplate is empty.
     if (props.project.dbNameTemplate === "") {
       return [{ name: "", list: props.databaseList }];
     }

--- a/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/ProjectTenantView.vue
@@ -180,6 +180,10 @@ const deployment = computed(() => {
 const databaseListGroupByName = computed(
   (): { name: string; list: Database[] }[] => {
     if (!props.project) return [];
+    // All databases will be the same group of dbNameTemplate is empty.
+    if (props.project.dbNameTemplate === "") {
+      return [{ name: "", list: props.databaseList }];
+    }
     if (props.project.dbNameTemplate && labelList.value.length === 0) return [];
 
     const dict = groupBy(props.databaseList, (db) => {
@@ -189,8 +193,6 @@ const databaseListGroupByName = computed(
           props.project!.dbNameTemplate,
           labelList.value
         );
-      } else {
-        return db.name;
       }
     });
     return Object.keys(dict).map((name) => ({

--- a/frontend/src/components/ProjectCreate.vue
+++ b/frontend/src/components/ProjectCreate.vue
@@ -203,7 +203,9 @@ export default defineComponent({
     watch(
       () => state.enableDbNameTemplate,
       (on) => {
-        if (!on) {
+        if (on) {
+          state.project.dbNameTemplate = "{{DB_NAME}}_{{TENANT}}";
+        } else {
           state.project.dbNameTemplate = "";
         }
       }

--- a/frontend/src/components/TenantDatabaseTable/TenantDatabaseTable.vue
+++ b/frontend/src/components/TenantDatabaseTable/TenantDatabaseTable.vue
@@ -70,6 +70,9 @@ export default defineComponent({
     const environmentList = useEnvironmentList();
 
     const databaseListGroupByName = computed((): DatabaseGroupByName[] => {
+      if (props.project.dbNameTemplate === "") {
+        return [{ name: "", databaseList: props.databaseList }];
+      }
       if (props.project.dbNameTemplate) {
         if (props.labelList.length === 0) return [];
       }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1326,7 +1326,7 @@
     "setting": {
       "description": "A label is a key-value pair that helps you identify the tenant for a database. {link}."
     },
-    "db-name-template-tips": "Allow you to group databases with the same {placeholder} from different tenants. {link}.",
+    "db-name-template-tips": "The name of all tenant databases should follow a naming template. The databases with the same {placeholder} will be the same group. {link}.",
     "confirm-change": "Are you sure to change '{label}' ?",
     "parsed-from-template": "Parsed from {name} by template {template}.",
     "cannot-transfer-template-not-match": "Database '{name}' cannot be transferred to this project. Since its name doesn't match the template {template}."

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1326,7 +1326,7 @@
     "setting": {
       "description": "标签是一组可用于标识数据库租户的键值对。{link}。"
     },
-    "db-name-template-tips": "让您能够把属于不同租户但是有相同 {placeholder} 的数据库分成一组。{link}。",
+    "db-name-template-tips": "所有租户数据库名字遵循命名模版。有着相同 {placeholder} 的数据库会被分成一组。{link}。",
     "confirm-change": "您确定要修改 '{label}' 吗？",
     "parsed-from-template": "从 {name} 中依据模板 {template} 解析得出",
     "cannot-transfer-template-not-match": "数据库 '{name}' 无法转移到这个项目，因为它的名称不符合模板 {template}。"


### PR DESCRIPTION
The database name template is rebranded to restrict the format of database naming. 

1. The "Create Project" form allows users to decide whether all tenant databases should follow a naming template.
<img width="450" alt="Screen Shot 2022-10-01 at 22 54 07" src="https://user-images.githubusercontent.com/98006139/193415533-1d53b77b-e872-4a93-94bb-cb04b11ce0c4.png">

2. All tenant databases for empty dbNameTemplate project will be the same group.
<img width="1303" alt="Screen Shot 2022-10-01 at 22 54 29" src="https://user-images.githubusercontent.com/98006139/193415567-37056cb5-0cba-4f23-a17a-633a79537a0e.png">
<img width="1303" alt="Screen Shot 2022-10-01 at 22 54 40" src="https://user-images.githubusercontent.com/98006139/193415580-8b58cb6c-c2e0-4752-9cb2-9abfb89bd85e.png">
<img width="1303" alt="Screen Shot 2022-10-01 at 22 54 57" src="https://user-images.githubusercontent.com/98006139/193415584-69655885-f0d7-4342-b78a-79491526a4ae.png">

TODO1: we need to tune the tenant database matrix to better display tenant databases. Right now, it looks quite strange even for both empty and non-empty dbNameTemplate cases.
TODO2: allow users to update dbNameTemplate after the project is created.