### PR TITLE
chore: Revert "docs: use air 1.29.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ working on the code:
 
 - [Go](https://golang.org/doc/install) (1.19 or later)
 - [pnpm](https://pnpm.io/installation)
-- [Air](https://github.com/cosmtrek/air#installation) (**must use 1.29.0**). This is for backend live reload.
+- [Air](https://github.com/cosmtrek/air#installation) (**must use 1.30.0**). This is for backend live reload.
 
 ### Steps
 
-1. Install Air v1.29.0. Use 1.29.0 because the newer version changes the behavior and won't shutdown the previous service properly.
+1. Install Air v1.30.0. Use 1.30.0 because the newer version changes the behavior and won't shutdown the previous service properly.
 
    ```bash
-   go install github.com/cosmtrek/air@v1.29.0
+   go install github.com/cosmtrek/air@v1.30.0
    ```
 
 1. Pull source.


### PR DESCRIPTION
Reverts bytebase/bytebase#2872

Updated kill delay instead.