### PR TITLE
Add support for PGPASSWORD env var for external metadata DB connection config

### DIFF
--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -162,7 +162,7 @@ func guessDSN(username, password, hostname, port, database, sslCA, sslCert, sslK
 		}
 		return guessDatabase, guessDSN, nil
 	}
-	return "", "", errors.Errorf("cannot connecting instance, make sure the connection info is correct")
+	return "", "", errors.Errorf("cannot connect to the instance, make sure the connection info is correct")
 }
 
 // Close closes the driver.

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -105,7 +105,12 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 
 	if u.User != nil {
 		connCfg.Username = u.User.Username()
-		connCfg.Password, _ = u.User.Password()
+		if password, isSet := u.User.Password(); isSet {
+			connCfg.Password = password
+		} else {
+			connCfg.Password = os.Getenv("PGPASSWORD")
+		}
+
 	}
 
 	if connCfg.Username == "" {

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -108,9 +108,11 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 		if password, isSet := u.User.Password(); isSet {
 			connCfg.Password = password
 		} else {
+			// Try to lookup the password using Postgres' default
+			// env var.
+			// https://www.postgresql.org/docs/current/libpq-envars.html
 			connCfg.Password = os.Getenv("PGPASSWORD")
 		}
-
 	}
 
 	if connCfg.Username == "" {

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -108,8 +108,10 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 		if password, isSet := u.User.Password(); isSet {
 			connCfg.Password = password
 		} else {
-			// Try to lookup the password using env var.
-			connCfg.Password = os.Getenv("BB_META_DB_PASSWORD")
+			// Try to lookup the password using Postgres' default
+			// env var.
+			// https://www.postgresql.org/docs/current/libpq-envars.html
+			connCfg.Password = os.Getenv("PGPASSWORD")
 		}
 	}
 

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -108,10 +108,8 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 		if password, isSet := u.User.Password(); isSet {
 			connCfg.Password = password
 		} else {
-			// Try to lookup the password using Postgres' default
-			// env var.
-			// https://www.postgresql.org/docs/current/libpq-envars.html
-			connCfg.Password = os.Getenv("PGPASSWORD")
+			// Try to lookup the password using env var.
+			connCfg.Password = os.Getenv("BB_META_DB_PASSWORD")
 		}
 	}
 

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -109,7 +109,7 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 			connCfg.Password = password
 		} else {
 			// Try to lookup the password using Postgres' default
-			// env var.
+			// env var since the metadata DB can only be a Postgres DB.
 			// https://www.postgresql.org/docs/current/libpq-envars.html
 			connCfg.Password = os.Getenv("PGPASSWORD")
 		}


### PR DESCRIPTION
Hello 👋 I noticed that there was no way to pass the password for an external metadata DB via an environment variable. It seems that while the underlying `pgx` driver itself (which is what would get used due to the metadata db being a Postgres DB always) supports the default env vars. However, since Bytebase is parsing the connection config manually before calling the driver, the password is not looked up using the env var. Let me know if I misunderstood this or if there is already a way to specify the password for the metadata DB via an env var.