### PR TITLE
refactor: move parseSchemaFileInfo() to db package

### DIFF
--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -188,6 +189,9 @@ const (
 	// Migrate is the migration type for MIGRATE.
 	// Used for DDL change including CREATE DATABASE.
 	Migrate MigrationType = "MIGRATE"
+	// SDLMigrate is the migration type for SDL_MIGRATE.
+	// Used for SDL based migration.
+	SDLMigrate MigrationType = "SDL_MIGRATE"
 	// Branch is the migration type for BRANCH.
 	// Used when restoring from a backup (the restored database branched from the original backup).
 	Branch MigrationType = "BRANCH"
@@ -250,6 +254,7 @@ const placeholderRegexp = `[^\\/?%*:|"<>]+`
 // ParseMigrationInfo matches filePath against filePathTemplate
 // If filePath matches, then it will derive MigrationInfo from the filePath.
 // Both filePath and filePathTemplate are the full file path (including the base directory) of the repository.
+// It returns (nil, nil) if it doesn't looks like a schema file path.
 func ParseMigrationInfo(filePath, filePathTemplate string) (*MigrationInfo, error) {
 	placeholderList := []string{
 		"ENV_NAME",
@@ -273,7 +278,8 @@ func ParseMigrationInfo(filePath, filePathTemplate string) (*MigrationInfo, erro
 		return nil, errors.Errorf("invalid file path template: %q", filePathTemplate)
 	}
 	if !myRegex.MatchString(filePath) {
-		return nil, errors.Errorf("file path %q does not match file path template %q", filePath, filePathTemplate)
+		// File path does not match file path template.
+		return nil, nil
 	}
 
 	mi := &MigrationInfo{
@@ -335,6 +341,51 @@ func ParseMigrationInfo(filePath, filePathTemplate string) (*MigrationInfo, erro
 	}
 
 	return mi, nil
+}
+
+// ParseSchemaFileInfo attempts to parse the given schema file path to extract
+// the schema file info.
+// It returns (nil, nil) if it doesn't looks like a schema file path.
+//
+// The possible keys for the returned map are: "ENV_NAME", "DB_NAME".
+func ParseSchemaFileInfo(baseDirectory, schemaPathTemplate, file string) (*MigrationInfo, error) {
+	if schemaPathTemplate == "" {
+		return nil, nil
+	}
+
+	// Escape "." characters to match literals instead of using it as a wildcard.
+	schemaFilePathRegex := strings.ReplaceAll(schemaPathTemplate, ".", `\.`)
+
+	placeholders := []string{
+		"ENV_NAME",
+		"DB_NAME",
+	}
+	for _, placeholder := range placeholders {
+		schemaFilePathRegex = strings.ReplaceAll(schemaFilePathRegex, fmt.Sprintf("{{%s}}", placeholder), fmt.Sprintf("(?P<%s>[a-zA-Z0-9+-=/_#?!$. ]+)", placeholder))
+	}
+
+	// NOTE: We do not want to use filepath.Join here because we always need "/" as the path separator.
+	re, err := regexp.Compile(path.Join(baseDirectory, schemaFilePathRegex))
+	if err != nil {
+		return nil, errors.Wrap(err, "compile schema file path regex")
+	}
+	match := re.FindStringSubmatch(file)
+	if len(match) == 0 {
+		return nil, nil
+	}
+
+	info := make(map[string]string)
+	// Skip the first item because it is always the empty string, see docstring of
+	// the SubexpNames() method.
+	for i, name := range re.SubexpNames()[1:] {
+		info[name] = match[i+1]
+	}
+	return &MigrationInfo{
+		Source:      VCS,
+		Type:        SDLMigrate,
+		Environment: info["ENV_NAME"],
+		Database:    info["DB_NAME"],
+	}, nil
 }
 
 // MigrationHistory is the API message for migration history.

--- a/plugin/db/driver_test.go
+++ b/plugin/db/driver_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/bmizerany/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,7 +12,7 @@ func TestParseMigrationInfo(t *testing.T) {
 	type test struct {
 		filePath         string
 		filePathTemplate string
-		want             MigrationInfo
+		want             *MigrationInfo
 		wantErr          string
 	}
 
@@ -19,7 +20,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db1__001foo",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -34,7 +35,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db foo_+-=_#!$.__1.2.3",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "1.2.3",
 				Namespace:   "db foo_+-=_#!$.",
 				Database:    "db foo_+-=_#!$.",
@@ -49,7 +50,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "bytebase/db1__001foo",
 			filePathTemplate: "bytebase/{{DB_NAME}}__{{VERSION}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -64,7 +65,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "bytebase/dev/db1__001foo",
 			filePathTemplate: "bytebase/{{ENV_NAME}}/{{DB_NAME}}__{{VERSION}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -79,7 +80,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db1__001foo__create_t1",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}__{{DESCRIPTION}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -94,7 +95,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db1__001foo__migrate",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}__{{TYPE}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -109,7 +110,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db1__001foo__ddl",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}__{{TYPE}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -124,7 +125,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db1__001foo__dml",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}__{{TYPE}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -139,7 +140,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db_shop1__001foo__data",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}__{{TYPE}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db_shop1",
 				Database:    "db_shop1",
@@ -154,7 +155,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db_shop1__001foo__data__fix_customer_info",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}__{{TYPE}}__{{DESCRIPTION}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db_shop1",
 				Database:    "db_shop1",
@@ -169,7 +170,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         ".db__20220811.sql",
 			filePathTemplate: ".{{DB_NAME}}__{{VERSION}}.sql",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "20220811",
 				Namespace:   "db",
 				Database:    "db",
@@ -184,7 +185,7 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db1__001foo__baseline",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}__{{TYPE}}",
-			want: MigrationInfo{
+			want: &MigrationInfo{
 				Version:     "001foo",
 				Namespace:   "db1",
 				Database:    "db1",
@@ -199,30 +200,14 @@ func TestParseMigrationInfo(t *testing.T) {
 		{
 			filePath:         "db",
 			filePathTemplate: "{{DB_NAME}}__{{VERSION}}",
-			want: MigrationInfo{
-				Version:     "",
-				Namespace:   "",
-				Database:    "",
-				Environment: "",
-				Type:        "",
-				Description: "",
-				Creator:     "",
-			},
-			wantErr: "does not match file path template",
+			want:             nil,
+			wantErr:          "",
 		},
 		{ // Make sure the "." is escaped and should only match literals not as a wildcard
 			filePath:         ".db__20220811.sql",
 			filePathTemplate: "A{{DB_NAME}}__{{VERSION}}Asql",
-			want: MigrationInfo{
-				Version:     "",
-				Namespace:   "",
-				Database:    "",
-				Environment: "",
-				Type:        "",
-				Description: "",
-				Creator:     "",
-			},
-			wantErr: "does not match file path template",
+			want:             nil,
+			wantErr:          "",
 		},
 	}
 	for _, tc := range tests {
@@ -234,7 +219,79 @@ func TestParseMigrationInfo(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tc.want, *mi)
+			if tc.want == nil {
+				require.Nil(t, mi)
+			} else {
+				require.Equal(t, *tc.want, *mi)
+			}
+		})
+	}
+}
+
+func TestParseSchemaFileInfo(t *testing.T) {
+	tests := []struct {
+		name               string
+		baseDirectory      string
+		schemaPathTemplate string
+		file               string
+		schemaInfo         *MigrationInfo
+	}{
+		{
+			name:               "no schemaPathTemplate",
+			baseDirectory:      "",
+			schemaPathTemplate: "",
+			file:               "Test/testdb__LATEST.sql",
+			schemaInfo:         nil,
+		},
+		{
+			name:               "only has DB_NAME",
+			baseDirectory:      "",
+			schemaPathTemplate: "{{DB_NAME}}__LATEST.sql",
+			file:               "testdb__LATEST.sql",
+			schemaInfo: &MigrationInfo{
+				Source:   VCS,
+				Type:     SDLMigrate,
+				Database: "testdb",
+			},
+		},
+		{
+			name:               "has both ENV_NAME and DB_NAME",
+			baseDirectory:      "",
+			schemaPathTemplate: "{{ENV_NAME}}/{{DB_NAME}}__LATEST.sql",
+			file:               "Test/testdb__LATEST.sql",
+			schemaInfo: &MigrationInfo{
+				Source:      VCS,
+				Type:        SDLMigrate,
+				Environment: "Test",
+				Database:    "testdb",
+			},
+		},
+
+		{
+			name:               "baseDirectory does not match",
+			baseDirectory:      "bytebase",
+			schemaPathTemplate: "{{ENV_NAME}}/{{DB_NAME}}__LATEST.sql",
+			file:               "Test/testdb__LATEST.sql",
+			schemaInfo:         nil,
+		},
+		{
+			name:               "baseDirectory with both ENV_NAME and DB_NAME",
+			baseDirectory:      "bytebase",
+			schemaPathTemplate: "{{ENV_NAME}}/{{DB_NAME}}__LATEST.sql",
+			file:               "bytebase/Test/testdb__LATEST.sql",
+			schemaInfo: &MigrationInfo{
+				Source:      VCS,
+				Type:        SDLMigrate,
+				Environment: "Test",
+				Database:    "testdb",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseSchemaFileInfo(test.baseDirectory, test.schemaPathTemplate, test.file)
+			require.NoError(t, err)
+			assert.Equal(t, test.schemaInfo, got)
 		})
 	}
 }

--- a/server/webhook_test.go
+++ b/server/webhook_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestValidateGitHubWebhookSignature256(t *testing.T) {
@@ -76,67 +75,5 @@ func TestParseBranchNameFromGitHubRefs(t *testing.T) {
 		} else {
 			assert.Equal(t, test.expect, branch)
 		}
-	}
-}
-
-func TestParseSchemaFileInfo(t *testing.T) {
-	tests := []struct {
-		name               string
-		baseDirectory      string
-		schemaPathTemplate string
-		file               string
-		schemaInfo         map[string]string
-	}{
-		{
-			name:               "no schemaPathTemplate",
-			baseDirectory:      "",
-			schemaPathTemplate: "",
-			file:               "Test/testdb__LATEST.sql",
-			schemaInfo:         nil,
-		},
-		{
-			name:               "only has DB_NAME",
-			baseDirectory:      "",
-			schemaPathTemplate: "{{DB_NAME}}__LATEST.sql",
-			file:               "testdb__LATEST.sql",
-			schemaInfo: map[string]string{
-				"DB_NAME": "testdb",
-			},
-		},
-		{
-			name:               "has both ENV_NAME and DB_NAME",
-			baseDirectory:      "",
-			schemaPathTemplate: "{{ENV_NAME}}/{{DB_NAME}}__LATEST.sql",
-			file:               "Test/testdb__LATEST.sql",
-			schemaInfo: map[string]string{
-				"ENV_NAME": "Test",
-				"DB_NAME":  "testdb",
-			},
-		},
-
-		{
-			name:               "baseDirectory does not match",
-			baseDirectory:      "bytebase",
-			schemaPathTemplate: "{{ENV_NAME}}/{{DB_NAME}}__LATEST.sql",
-			file:               "Test/testdb__LATEST.sql",
-			schemaInfo:         nil,
-		},
-		{
-			name:               "baseDirectory with both ENV_NAME and DB_NAME",
-			baseDirectory:      "bytebase",
-			schemaPathTemplate: "{{ENV_NAME}}/{{DB_NAME}}__LATEST.sql",
-			file:               "bytebase/Test/testdb__LATEST.sql",
-			schemaInfo: map[string]string{
-				"ENV_NAME": "Test",
-				"DB_NAME":  "testdb",
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := parseSchemaFileInfo(test.baseDirectory, test.schemaPathTemplate, test.file)
-			require.NoError(t, err)
-			assert.Equal(t, test.schemaInfo, got)
-		})
 	}
 }


### PR DESCRIPTION
It also introduces a new migration type SDL Migration to differentiate with standard DDL migration.