### PR TITLE
refactor: extract logic of creating issue

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -395,7 +395,7 @@ func (s *Server) processFile(ctx context.Context, pushEvent vcs.PushEvent, repo 
 		return "", false, activityCreateList, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create issue").SetInternal(err)
 	}
 
-	return fmt.Sprintf("Created issue %q on adding %s", issueName, file), true, activityCreateList, nil
+	return fmt.Sprintf("Created issue %q from file %q", issueName, file), true, activityCreateList, nil
 }
 
 func (s *Server) createIssueFromPushEvent(ctx context.Context, issueName string, pushEvent vcs.PushEvent, repo *api.Repository, migrationType db.MigrationType, migrationDetailList []*api.MigrationDetail) error {


### PR DESCRIPTION
Reduce the complexity of the function `processFile()`.

This PR also makes it easier to implement the logic of creating one issue per push event for DDL migration while preserving the behavior of creating one issue per schema file for state-based migration.