### PR TITLE
feat: cancel gh-ost sync task

### DIFF
--- a/server/acl_casbin_policy_dba.csv
+++ b/server/acl_casbin_policy_dba.csv
@@ -77,6 +77,7 @@ p, DBA, /pipeline/{pipelineID}/task/all, PATCH
 p, DBA, /pipeline/{pipelineID}/task/{taskID}, PATCH
 p, DBA, /pipeline/{pipelineID}/task/{taskID}/status, PATCH
 p, DBA, /pipeline/{pipelineID}/task/{taskID}/check, POST
+p, DBA, /pipeline/{pipelineID}/task/{taskID}/cancel, POST
 p, DBA, /sql/ping, POST
 p, DBA, /sql/sync-schema, POST
 p, DBA, /sql/execute, POST

--- a/server/acl_casbin_policy_developer.csv
+++ b/server/acl_casbin_policy_developer.csv
@@ -70,6 +70,7 @@ p, DEVELOPER, /pipeline/{pipelineID}/task/all, PATCH
 p, DEVELOPER, /pipeline/{pipelineID}/task/{taskID}, PATCH
 p, DEVELOPER, /pipeline/{pipelineID}/task/{taskID}/status, PATCH
 p, DEVELOPER, /pipeline/{pipelineID}/task/{taskID}/check, POST
+p, DEVELOPER, /pipeline/{pipelineID}/task/{taskID}/cancel, POST
 p, DEVELOPER, /sql/ping, POST
 p, DEVELOPER, /sql/execute, POST
 p, DEVELOPER, /vcs, GET

--- a/server/acl_casbin_policy_owner.csv
+++ b/server/acl_casbin_policy_owner.csv
@@ -82,6 +82,7 @@ p, OWNER, /pipeline/{pipelineID}/task/all, PATCH
 p, OWNER, /pipeline/{pipelineID}/task/{taskID}, PATCH
 p, OWNER, /pipeline/{pipelineID}/task/{taskID}/status, PATCH
 p, OWNER, /pipeline/{pipelineID}/task/{taskID}/check, POST
+p, OWNER, /pipeline/{pipelineID}/task/{taskID}/cancel, POST
 p, OWNER, /sql/ping, POST
 p, OWNER, /sql/sync-schema, POST
 p, OWNER, /sql/execute, POST

--- a/server/task.go
+++ b/server/task.go
@@ -261,11 +261,11 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to cancel the task").SetInternal(err)
 		}
 		if task == nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Task not found with ID %d", taskID))
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Task not found with ID %d", taskID))
 		}
 
 		if !taskCancellationImplemented[task.Type] {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Canceling task type %s is not supported", task.Type))
+			return echo.NewHTTPError(http.StatusNotImplemented, fmt.Sprintf("Canceling task type %s is not supported", task.Type))
 		}
 		// TODO(p0ny): support cancel pending task.
 		if !isTaskStatusTransitionAllowed(task.Status, api.TaskCanceled) {

--- a/server/task.go
+++ b/server/task.go
@@ -279,7 +279,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 		}
 		cancel()
 
-		return nil
+		return c.NoContent(http.StatusOK)
 	})
 }
 

--- a/server/task.go
+++ b/server/task.go
@@ -267,8 +267,9 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 		if !taskCancellationImplemented[task.Type] {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Canceling task type %s is not supported", task.Type))
 		}
-		if task.Status != api.TaskRunning {
-			return echo.NewHTTPError(http.StatusBadRequest, "Task is not running")
+		// TODO(p0ny): support cancel pending task.
+		if !isTaskStatusTransitionAllowed(task.Status, api.TaskCanceled) {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid task status transition from %v to %v.", task.Status, api.TaskCanceled))
 		}
 
 		s.TaskScheduler.runningExecutorsMutex.Lock()

--- a/server/task.go
+++ b/server/task.go
@@ -26,6 +26,9 @@ var (
 		api.TaskFailed:          {api.TaskRunning, api.TaskPendingApproval},
 		api.TaskCanceled:        {api.TaskRunning},
 	}
+	taskCancellationImplemented = map[api.TaskType]bool{
+		api.TaskDatabaseSchemaUpdateGhostSync: true,
+	}
 )
 
 func isTaskStatusTransitionAllowed(fromStatus, toStatus api.TaskStatus) bool {
@@ -244,6 +247,38 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 		if err := jsonapi.MarshalPayload(c.Response().Writer, taskUpdated); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to marshal update task \"%v\" status response", taskUpdated.Name)).SetInternal(err)
 		}
+		return nil
+	})
+
+	g.POST("/pipeline/:pipelineID/task/:taskID/cancel", func(c echo.Context) error {
+		ctx := c.Request().Context()
+		taskID, err := strconv.Atoi(c.Param("taskID"))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Task ID is not a number: %s", c.Param("taskID"))).SetInternal(err)
+		}
+		task, err := s.store.GetTaskByID(ctx, taskID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to cancel the task").SetInternal(err)
+		}
+		if task == nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("Task not found with ID %d", taskID))
+		}
+
+		if !taskCancellationImplemented[task.Type] {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Canceling task type %s is not supported", task.Type))
+		}
+		if task.Status != api.TaskRunning {
+			return echo.NewHTTPError(http.StatusBadRequest, "Task is not running")
+		}
+
+		s.TaskScheduler.runningExecutorsMutex.Lock()
+		defer s.TaskScheduler.runningExecutorsMutex.Unlock()
+		cancel, ok := s.TaskScheduler.runningExecutorsCancel[taskID]
+		if !ok {
+			return echo.NewHTTPError(http.StatusBadRequest, "Failed to cancel task")
+		}
+		cancel()
+
 		return nil
 	})
 }
@@ -663,7 +698,8 @@ func (s *Server) patchTaskStatus(ctx context.Context, task *api.Task, taskStatus
 	if !isTaskStatusTransitionAllowed(task.Status, taskStatusPatch.Status) {
 		return nil, &common.Error{
 			Code: common.Invalid,
-			Err:  errors.Errorf("invalid task status transition from %v to %v. Applicable transition(s) %v", task.Status, taskStatusPatch.Status, applicableTaskStatusTransition[task.Status])}
+			Err:  errors.Errorf("invalid task status transition from %v to %v. Applicable transition(s) %v", task.Status, taskStatusPatch.Status, applicableTaskStatusTransition[task.Status]),
+		}
 	}
 
 	taskPatched, err := s.store.PatchTaskStatus(ctx, taskStatusPatch)
@@ -777,7 +813,6 @@ func (s *Server) patchTaskStatus(ctx context.Context, task *api.Task, taskStatus
 
 func (s *Server) triggerDatabaseStatementAdviseTask(ctx context.Context, statement string, task *api.Task) error {
 	policyID, err := s.store.GetSQLReviewPolicyIDByEnvID(ctx, task.Instance.EnvironmentID)
-
 	if err != nil {
 		// It's OK if we failed to find the SQL review policy, just emit an error log
 		log.Error("Failed to found SQL review policy id for task",

--- a/server/task.go
+++ b/server/task.go
@@ -272,8 +272,8 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 		}
 
 		s.TaskScheduler.runningExecutorsMutex.Lock()
-		defer s.TaskScheduler.runningExecutorsMutex.Unlock()
 		cancel, ok := s.TaskScheduler.runningExecutorsCancel[taskID]
+		s.TaskScheduler.runningExecutorsMutex.Unlock()
 		if !ok {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to cancel task")
 		}

--- a/server/task.go
+++ b/server/task.go
@@ -261,7 +261,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to cancel the task").SetInternal(err)
 		}
 		if task == nil {
-			return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("Task not found with ID %d", taskID))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Task not found with ID %d", taskID))
 		}
 
 		if !taskCancellationImplemented[task.Type] {
@@ -275,7 +275,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 		defer s.TaskScheduler.runningExecutorsMutex.Unlock()
 		cancel, ok := s.TaskScheduler.runningExecutorsCancel[taskID]
 		if !ok {
-			return echo.NewHTTPError(http.StatusBadRequest, "Failed to cancel task")
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to cancel task")
 		}
 		cancel()
 

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -421,7 +421,6 @@ func writeBackLatestSchema(ctx context.Context, server *Server, repository *api.
 			latestSchemaFile,
 			schemaFileCommit,
 		)
-
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to create file after applying migration %s to %q", mi.Version, mi.Database)
 		}

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -239,9 +239,9 @@ func (exec *SchemaUpdateGhostSyncTaskExecutor) runGhostMigration(ctx context.Con
 
 	migrator := logic.NewMigrator(migrationContext, "bb")
 
-	ctx1, cancel := context.WithCancel(ctx)
+	childCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go func(ctx1 context.Context) {
+	go func(childCtx context.Context) {
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
 		createdTs := time.Now().Unix()
@@ -264,11 +264,11 @@ func (exec *SchemaUpdateGhostSyncTaskExecutor) runGhostMigration(ctx context.Con
 					close(syncDone)
 					return
 				}
-			case <-ctx1.Done():
+			case <-childCtx.Done():
 				return
 			}
 		}
-	}(ctx1)
+	}(childCtx)
 
 	go func() {
 		if err := migrator.Migrate(); err != nil {

--- a/server/task_executor_schema_update_ghost_sync.go
+++ b/server/task_executor_schema_update_ghost_sync.go
@@ -211,6 +211,8 @@ func getGhostConfig(task *api.Task, dataSource *api.DataSource, userList []*api.
 
 func (exec *SchemaUpdateGhostSyncTaskExecutor) runGhostMigration(ctx context.Context, server *Server, task *api.Task, statement string) (terminated bool, result *api.TaskRunResultPayload, err error) {
 	syncDone := make(chan struct{})
+	// set buffer size to 1 to unblock the sender because there is no listner if the task is canceled.
+	// see PR #2919.
 	migrationError := make(chan error, 1)
 
 	statement = strings.TrimSpace(statement)

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -187,8 +187,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 								UpdaterID: api.SystemBotID,
 								Status:    api.TaskCanceled,
 							}
-							_, err = s.server.patchTaskStatus(ctx, task, taskStatusPatch)
-							if err != nil {
+							if _, err := s.server.patchTaskStatus(ctx, task, taskStatusPatch); err != nil {
 								log.Error("Failed to mark task as CANCELED",
 									zap.Int("id", task.ID),
 									zap.String("name", task.Name),

--- a/server/task_scheduler.go
+++ b/server/task_scheduler.go
@@ -26,20 +26,22 @@ const (
 // NewTaskScheduler creates a new task scheduler.
 func NewTaskScheduler(server *Server) *TaskScheduler {
 	return &TaskScheduler{
-		executorGetters:  make(map[api.TaskType]func() TaskExecutor),
-		runningExecutors: make(map[int]TaskExecutor),
-		server:           server,
+		executorGetters:        make(map[api.TaskType]func() TaskExecutor),
+		runningExecutors:       make(map[int]TaskExecutor),
+		runningExecutorsCancel: make(map[int]context.CancelFunc),
+		server:                 server,
 	}
 }
 
 // TaskScheduler is the task scheduler.
 type TaskScheduler struct {
-	executorGetters       map[api.TaskType]func() TaskExecutor
-	runningExecutors      map[int]TaskExecutor
-	runningExecutorsMutex sync.Mutex
-	taskProgress          sync.Map // map[taskID]api.Progress
-	sharedTaskState       sync.Map // map[taskID]interface{}
-	server                *Server
+	executorGetters        map[api.TaskType]func() TaskExecutor
+	runningExecutors       map[int]TaskExecutor
+	runningExecutorsCancel map[int]context.CancelFunc
+	runningExecutorsMutex  sync.Mutex
+	taskProgress           sync.Map // map[taskID]api.Progress
+	sharedTaskState        sync.Map // map[taskID]interface{}
+	server                 *Server
 }
 
 // Run will run the task scheduler.
@@ -149,18 +151,54 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 						)
 						continue
 					}
+
+					executor := executorGetter()
 					s.runningExecutorsMutex.Lock()
-					s.runningExecutors[task.ID] = executorGetter()
+					s.runningExecutors[task.ID] = executor
 					s.runningExecutorsMutex.Unlock()
 
-					go func(task *api.Task, executor TaskExecutor) {
+					go func(ctx context.Context, task *api.Task, executor TaskExecutor) {
 						defer func() {
 							s.runningExecutorsMutex.Lock()
 							delete(s.runningExecutors, task.ID)
+							delete(s.runningExecutorsCancel, task.ID)
 							s.runningExecutorsMutex.Unlock()
 							s.taskProgress.Delete(task.ID)
 						}()
-						done, result, err := RunTaskExecutorOnce(ctx, executor, s.server, task)
+
+						executorCtx, cancel := context.WithCancel(ctx)
+						s.runningExecutorsMutex.Lock()
+						s.runningExecutorsCancel[task.ID] = cancel
+						s.runningExecutorsMutex.Unlock()
+
+						done, result, err := RunTaskExecutorOnce(executorCtx, executor, s.server, task)
+
+						select {
+						case <-executorCtx.Done():
+							// task cancelled
+							log.Debug("Task canceled",
+								zap.Int("id", task.ID),
+								zap.String("name", task.Name),
+								zap.String("type", string(task.Type)),
+							)
+
+							taskStatusPatch := &api.TaskStatusPatch{
+								ID:        task.ID,
+								UpdaterID: api.SystemBotID,
+								Status:    api.TaskCanceled,
+							}
+							_, err = s.server.patchTaskStatus(ctx, task, taskStatusPatch)
+							if err != nil {
+								log.Error("Failed to mark task as CANCELED",
+									zap.Int("id", task.ID),
+									zap.String("name", task.Name),
+									zap.Error(err),
+								)
+							}
+							return
+						default:
+						}
+
 						if !done && err != nil {
 							log.Debug("Encountered transient error running task, will retry",
 								zap.Int("id", task.ID),
@@ -272,7 +310,7 @@ func (s *TaskScheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 							}
 							return
 						}
-					}(task, s.runningExecutors[task.ID])
+					}(ctx, task, executor)
 				}
 			}()
 		case <-ctx.Done(): // if cancel() execute


### PR DESCRIPTION
Add a new HTTP endpoint`POST /pipeline/:pipelineID/task/:taskID/cancel` which cancels a running task executor.
This task cancellation feature leverages golang context behind the scene.

In this PR, only canceling gh-ost sync task is implemented.
We can only cancel tasks by canceling the whole issue before. Now we can have an open issue with some canceled tasks which were not possible before IIUC. We may need to revisit the UI and logic of this part afterward.

Close BYT-1386