### PR TITLE
fix(frontend): scrollbar z-index

### DIFF
--- a/frontend/src/assets/css/tailwind.css
+++ b/frontend/src/assets/css/tailwind.css
@@ -238,6 +238,10 @@
   input[type="number"].hide-ticker {
     -moz-appearance: textfield;
   }
+
+  .fix-scrollbar-z-index {
+    transform: translate3d(0, 0, 0);
+  }
 }
 
 .fade-enter-active,

--- a/frontend/src/views/sql-editor/TablePanel/DataTable.vue
+++ b/frontend/src/views/sql-editor/TablePanel/DataTable.vue
@@ -5,7 +5,7 @@
     <div class="w-full flex-1 overflow-hidden">
       <div
         ref="scrollerRef"
-        class="inner-wrapper max-h-full w-full overflow-auto border-y border-r border-block-border"
+        class="inner-wrapper max-h-full w-full overflow-auto border-y border-r border-block-border fix-scrollbar-z-index"
         :class="data.length === 0 && 'border-b-0 border-r-0'"
       >
         <div


### PR DESCRIPTION
A very hacky CSS technique @_@
Close BYT-1543

### Screenshot
Before
![image](https://user-images.githubusercontent.com/2749742/194696787-8e358d9a-ad3d-4d53-95a7-ec86a7aa2b30.png)

After
![image](https://user-images.githubusercontent.com/2749742/194696777-5c8fe21a-cb47-4d9c-b446-adfe2ae0a6e7.png)

And this only reproduces when using a mouse or setting the "Show scroll bars" to "Always" in the system general settings.
