### PR TITLE
feat: allow omit `{{DB_NAME}}` in `filePathTemplate` for wildcard tenant projects

### DIFF
--- a/api/project_test.go
+++ b/api/project_test.go
@@ -42,51 +42,74 @@ func TestGetTemplateTokens(t *testing.T) {
 
 func TestValidateRepositoryFilePathTemplate(t *testing.T) {
 	tests := []struct {
-		name       string
-		template   string
-		tenantMode ProjectTenantMode
-		errPart    string
+		name           string
+		template       string
+		tenantMode     ProjectTenantMode
+		dbNameTemplate string
+		errPart        string
 	}{
 		{
 			"OK",
 			"{{DB_NAME}}_{{TYPE}}_{{VERSION}}.sql",
 			TenantModeDisabled,
 			"",
+			"",
 		}, {
 			"OK with optional tokens",
 			"{{ENV_NAME}}/{{DB_NAME}}_{{TYPE}}_{{VERSION}}_{{DESCRIPTION}}.sql",
 			TenantModeDisabled,
 			"",
+			"",
 		}, {
 			"Missing {{VERSION}}",
 			"{{DB_NAME}}_{{TYPE}}.sql",
 			TenantModeDisabled,
+			"",
 			"missing {{VERSION}}",
 		}, {
 			"UnknownToken",
 			"{{DB_NAME}}_{{TYPE}}_{{VERSION}}_{{UNKNOWN}}.sql",
 			TenantModeDisabled,
+			"",
 			"unknown token {{UNKNOWN}}",
 		}, {
 			"UnknownToken",
 			"{{DB_NAME}}_{{TYPE}}_{{VERSION}}_{{UNKNOWN}}.sql",
 			TenantModeDisabled,
+			"",
 			"unknown token {{UNKNOWN}}",
-		}, {
+		},
+
+		{
 			"Tenant mode {{ENV_NAME}}",
 			"{{ENV_NAME}}/{{DB_NAME}}_{{TYPE}}.sql",
 			TenantModeTenant,
+			"",
 			"not allowed in the template",
+		}, {
+			"Tenant mode no database name template",
+			"{{VERSION}}_{{TYPE}}.sql",
+			TenantModeTenant,
+			"",
+			"",
+		}, {
+			"Tenant mode has database name template",
+			"{{VERSION}}_{{TYPE}}.sql",
+			TenantModeTenant,
+			"{{DB_NAME}}_{{TENANT}}",
+			"missing {{DB_NAME}}",
 		},
 	}
 
 	for _, test := range tests {
-		err := ValidateRepositoryFilePathTemplate(test.template, test.tenantMode)
-		if test.errPart == "" {
-			require.NoError(t, err)
-		} else {
-			require.Contains(t, err.Error(), test.errPart)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateRepositoryFilePathTemplate(test.template, test.tenantMode, test.dbNameTemplate)
+			if test.errPart == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.errPart)
+			}
+		})
 	}
 }
 

--- a/server/project.go
+++ b/server/project.go
@@ -262,7 +262,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Project not found with ID %d", projectID))
 		}
 
-		if err := api.ValidateRepositoryFilePathTemplate(repositoryCreate.FilePathTemplate, project.TenantMode); err != nil {
+		if err := api.ValidateRepositoryFilePathTemplate(repositoryCreate.FilePathTemplate, project.TenantMode, project.DBNameTemplate); err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformed create linked repository request: %s", err.Error()))
 		}
 
@@ -387,7 +387,7 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		}
 
 		if repoPatch.FilePathTemplate != nil {
-			if err := api.ValidateRepositoryFilePathTemplate(*repoPatch.FilePathTemplate, project.TenantMode); err != nil {
+			if err := api.ValidateRepositoryFilePathTemplate(*repoPatch.FilePathTemplate, project.TenantMode, project.DBNameTemplate); err != nil {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Malformed patch linked repository request: %s", err.Error()))
 			}
 		}


### PR DESCRIPTION
Tenant projects with empty database name template imply wildcard matching for all databases, thus we also need to allow the `filePathTemplate` to be able to omit `{{DB_NAME}}` for this type of projects.