### PR TITLE
feat(frontend): allow cancelling gh-ost sync tasks

### DIFF
--- a/frontend/src/components/Issue/IssueActivityPanel.vue
+++ b/frontend/src/components/Issue/IssueActivityPanel.vue
@@ -562,6 +562,9 @@ const actionIcon = (activity: Activity): ActionIconType => {
         }
         break;
       }
+      case "CANCELED": {
+        return "cancel";
+      }
       case "RUNNING": {
         return "run";
       }

--- a/frontend/src/components/Issue/StatusTransitionForm.vue
+++ b/frontend/src/components/Issue/StatusTransitionForm.vue
@@ -104,7 +104,7 @@
         class="btn-normal mt-3 px-4 py-2 sm:mt-0 sm:w-auto"
         @click.prevent="$emit('cancel')"
       >
-        {{ $t("common.cancel") }}
+        {{ cancelText }}
       </button>
       <button
         type="button"
@@ -113,7 +113,7 @@
         :disabled="!allowSubmit"
         @click.prevent="$emit('submit', state.comment)"
       >
-        {{ okText }}
+        {{ displayingOkText }}
       </button>
     </div>
   </div>
@@ -127,6 +127,7 @@ import TaskCheckBar from "./TaskCheckBar.vue";
 import { Issue, IssueStatusTransition, Task } from "@/types";
 import { OutputField } from "@/plugins";
 import { activeEnvironment, TaskStatusTransition } from "@/utils";
+import { useI18n } from "vue-i18n";
 
 type CheckSummary = {
   successCount: number;
@@ -171,6 +172,7 @@ export default defineComponent({
   },
   emits: ["submit", "cancel"],
   setup(props) {
+    const { t } = useI18n();
     const commentTextArea = ref("");
 
     const state = reactive<LocalState>({
@@ -178,6 +180,16 @@ export default defineComponent({
       outputValueList: props.outputFieldList.map((field) =>
         cloneDeep(props.issue.payload[field.id])
       ),
+    });
+
+    const cancelText = computed(() => t("common.cancel"));
+    const displayingOkText = computed(() => {
+      if (props.okText === cancelText.value) {
+        // We don't want to see [Cancel] [Cancel]
+        // So fall back to [Cancel] [Confirm] if okText===cancelText
+        return t("common.confirm");
+      }
+      return props.okText;
     });
 
     const environmentId = computed(() => {
@@ -297,6 +309,8 @@ export default defineComponent({
 
     return {
       state,
+      cancelText,
+      displayingOkText,
       environmentId,
       showTaskCheckBar,
       commentTextArea,

--- a/frontend/src/components/Issue/TaskStatusIcon.vue
+++ b/frontend/src/components/Issue/TaskStatusIcon.vue
@@ -41,6 +41,11 @@
         >!</span
       >
     </template>
+    <template v-else-if="status === 'CANCELED'">
+      <heroicons-solid:minus-sm
+        class="w-6 h-6 rounded-full select-none bg-white border-2 border-gray-400 text-gray-400"
+      />
+    </template>
   </div>
 </template>
 

--- a/frontend/src/components/Issue/activity/ActionSentence.vue
+++ b/frontend/src/components/Issue/activity/ActionSentence.vue
@@ -74,6 +74,10 @@ const renderActionSentence = () => {
           str = t("activity.sentence.failed");
           break;
         }
+        case "CANCELED": {
+          str = t("activity.sentence.canceled");
+          break;
+        }
       }
       if (activity.creator.id != SYSTEM_BOT_ID) {
         // If creator is not the robot (which means we do NOT use task name in the subject),

--- a/frontend/src/components/Issue/logic/GhostModeProvider.ts
+++ b/frontend/src/components/Issue/logic/GhostModeProvider.ts
@@ -79,6 +79,13 @@ export default defineComponent({
           return false;
         }
       }
+      if (
+        task.type === "bb.task.database.schema.update.ghost.sync" &&
+        to === "CANCELED"
+      ) {
+        // CANCELing gh-ost sync task is allowed.
+        return true;
+      }
       return baseAllowApplyTaskStatusTransition(task, to);
     };
 

--- a/frontend/src/components/Issue/logic/base.ts
+++ b/frontend/src/components/Issue/logic/base.ts
@@ -9,6 +9,7 @@ import {
   StageId,
   Task,
   TaskCreate,
+  TaskStatus,
 } from "@/types";
 import { useRoute, useRouter } from "vue-router";
 import {
@@ -206,7 +207,13 @@ export const useBaseIssueLogic = (params: {
     return true;
   };
 
-  const allowApplyTaskStatusTransition = () => {
+  const allowApplyTaskStatusTransition = (task: Task, to: TaskStatus) => {
+    if (to === "CANCELED") {
+      // All task types are not CANCELable by default.
+      // Might be overwritten by other issue logic providers.
+      return false;
+    }
+
     // no extra logic by default
     return true;
   };

--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -204,7 +204,7 @@ const TASK_STATUS_TRANSITION_LIST: Map<
     "CANCEL",
     {
       type: "CANCEL",
-      to: "PENDING",
+      to: "CANCELED",
       buttonName: "common.cancel",
       buttonType: "NORMAL",
     },
@@ -218,9 +218,10 @@ const APPLICABLE_TASK_TRANSITION_LIST: Map<
 > = new Map([
   ["PENDING", []],
   ["PENDING_APPROVAL", ["APPROVE"]],
-  ["RUNNING", []],
+  ["RUNNING", ["CANCEL"]],
   ["DONE", []],
   ["FAILED", ["RETRY"]],
+  ["CANCELED", []],
 ]);
 
 export function applicableTaskTransition(


### PR DESCRIPTION
### Known issues
It's awkward that canceling the ghost sync task (the first task) leaves the ghost cutover task (the second task) PENDING_APPROVAL. This is weird that the second task can never be scheduled because it's blocked by the first one. Making the issue meaningless as if it's dead.

We might detect this situation and automatically close/cancel the entire issue. wdyt @RainbowDashy 

### Screenshot
![image](https://user-images.githubusercontent.com/2749742/194810599-05488309-3cea-4a97-9ce7-aad336e080c3.png)
--
![image](https://user-images.githubusercontent.com/2749742/194810531-f33d9385-2cb0-4b99-82f4-c89d5be074f1.png)
--
![image](https://user-images.githubusercontent.com/2749742/194812147-22036d9e-027f-469a-8fd3-d5e612957c4e.png)

