### PR TITLE
chore: use bin instead of full_bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ working on the code:
 
 - [Go](https://golang.org/doc/install) (1.19 or later)
 - [pnpm](https://pnpm.io/installation)
-- [Air](https://github.com/cosmtrek/air#installation) (**must use folked repo 87187cc**). This is for backend live reload.
+- [Air](https://github.com/cosmtrek/air#installation) (**must use forked repo 87187cc**). This is for backend live reload.
 
 ### Steps
 
-1. Install folked Air 87187cc. Use 87187cc because it has the cherrypicked fix.
+1. Install forked Air 87187cc. Use 87187cc because it has the cherrypicked fix.
 
    ```bash
    go install github.com/bytebase/air@87187cc

--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ working on the code:
 
 - [Go](https://golang.org/doc/install) (1.19 or later)
 - [pnpm](https://pnpm.io/installation)
-- [Air](https://github.com/cosmtrek/air#installation) (**must use 1.30.0**). This is for backend live reload.
+- [Air](https://github.com/cosmtrek/air#installation) (**must use folked repo 87187cc**). This is for backend live reload.
 
 ### Steps
 
-1. Install Air v1.30.0. Use 1.30.0 because the newer version changes the behavior and won't shutdown the previous service properly.
+1. Install folked Air 87187cc. Use 87187cc because it has the cherrypicked fix.
 
    ```bash
-   go install github.com/cosmtrek/air@v1.30.0
+   go install github.com/bytebase/air@87187cc
    ```
 
 1. Pull source.

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = ".air"
 
 [build]
-  full_bin = 'BB_REDIRECT_URL=http:\/\/localhost:3000 ./.air/bytebase --port 8080 --external-url http:\/\/1e29-115-194-90-33.jp.ngrok.io --data . --debug'
+  bin = './.air/bytebase --port 8080 --data . --debug'
   ## Use --tags "store.db" to enable SQL query logging against our metadata db.
   cmd = """
   go build \


### PR DESCRIPTION
The "additional runtime parameters such as --backup-bucket" in https://github.com/bytebase/bytebase#steps never work.

1. We need to use bin instead of full_bin for taking additional runtime parameters.
2. air 1.30.0 hasn’t yet supported additional runtime parameters yet.
3. The latest air will not shutdown PostgreSQL server gracefully. So we have to use a forked repo with the patch.