### PR TITLE
fix(sql-editor): result table fixes

### DIFF
--- a/frontend/src/views/sql-editor/TablePanel/DataTable.vue
+++ b/frontend/src/views/sql-editor/TablePanel/DataTable.vue
@@ -4,14 +4,14 @@
   >
     <div class="w-full flex-1 overflow-hidden">
       <div
+        class="header-track absolute z-0 left-0 top-0 right-0 h-[34px] border border-block-border bg-gray-50"
+      />
+
+      <div
         ref="scrollerRef"
         class="inner-wrapper max-h-full w-full overflow-auto border-y border-r border-block-border fix-scrollbar-z-index"
         :class="data.length === 0 && 'border-b-0 border-r-0'"
       >
-        <div
-          class="header-track absolute z-0 left-0 top-0 right-0 h-[34px] border border-block-border bg-gray-50"
-        />
-
         <table
           ref="tableRef"
           class="relative border-collapse table-fixed z-[1]"

--- a/frontend/src/views/sql-editor/TablePanel/useTableResize.ts
+++ b/frontend/src/views/sql-editor/TablePanel/useTableResize.ts
@@ -104,7 +104,12 @@ const useTableResize = (options: TableResizeOptions) => {
           const stretchedWidth = getElementWidth(th);
           const finalWidth = normalizeWidth(stretchedWidth);
 
-          state.columns[index].width = finalWidth;
+          const column = state.columns[index];
+          if (column) {
+            // sometimes the `columns` is out-of-sync with the `indexList`
+            // so we need to detect and suppress errors here.
+            column.width = finalWidth;
+          }
 
           return finalWidth;
         });

--- a/frontend/src/views/sql-editor/TablePanel/useTableResize.ts
+++ b/frontend/src/views/sql-editor/TablePanel/useTableResize.ts
@@ -106,8 +106,9 @@ const useTableResize = (options: TableResizeOptions) => {
 
           const column = state.columns[index];
           if (column) {
-            // sometimes the `columns` is out-of-sync with the `indexList`
+            // Sometimes the `columns` is out-of-sync with the `indexList`
             // so we need to detect and suppress errors here.
+            // Only occurs in dev hot reload mode.
             column.width = finalWidth;
           }
 


### PR DESCRIPTION
### Fix

1. The table header track scrolls with the content.
![image](https://user-images.githubusercontent.com/2749742/195224676-0052ed06-84fc-4821-a78f-04976a7662bd.png)

2. Sometimes we see assigning to an undefined value's property in the console (only occurs in dev hot reload mode).