### PR TITLE
fix: assigneeGroupValue

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -41,6 +41,8 @@ const (
 	// PipelineApprovalValueManualAlways means the pipeline should be manually approved by user to proceed.
 	PipelineApprovalValueManualAlways PipelineApprovalValue = "MANUAL_APPROVAL_ALWAYS"
 
+	// AssigneeGroupValueWorkspaceOwnerOrDBA means the assignee can be selected from the workspace owners and DBAs.
+	AssigneeGroupValueWorkspaceOwnerOrDBA AssigneeGroupValue = "WORKSPACE_OWNER_OR_DBA"
 	// AssigneeGroupValueProjectOwner means the assignee can be selected from the project owners.
 	AssigneeGroupValueProjectOwner AssigneeGroupValue = "PROJECT_OWNER"
 

--- a/server/task.go
+++ b/server/task.go
@@ -529,7 +529,7 @@ func (s *Server) canPrincipalBeAssignee(ctx context.Context, principalID int, en
 			break
 		}
 	}
-	if groupValue == nil {
+	if groupValue == nil || *groupValue == api.AssigneeGroupValueWorkspaceOwnerOrDBA {
 		// no value is set, fallback to default.
 		// the assignee group is the workspace owner and DBA.
 		principal, err := s.store.GetPrincipalByID(ctx, principalID)
@@ -835,7 +835,7 @@ func (s *Server) getDefaultAssigneeID(ctx context.Context, environmentID int, pr
 			break
 		}
 	}
-	if groupValue == nil {
+	if groupValue == nil || *groupValue == api.AssigneeGroupValueWorkspaceOwnerOrDBA {
 		member, err := s.getAnyWorkspaceOwnerOrDBA(ctx)
 		if err != nil {
 			return api.UnknownID, errors.Wrap(err, "failed to get a workspace owner or DBA")

--- a/server/task.go
+++ b/server/task.go
@@ -531,7 +531,7 @@ func (s *Server) canPrincipalBeAssignee(ctx context.Context, principalID int, en
 	}
 	if groupValue == nil || *groupValue == api.AssigneeGroupValueWorkspaceOwnerOrDBA {
 		// no value is set, fallback to default.
-		// the assignee group is the workspace owner and DBA.
+		// the assignee group is the workspace owner or DBA.
 		principal, err := s.store.GetPrincipalByID(ctx, principalID)
 		if err != nil {
 			return false, common.Wrapf(err, common.Internal, "failed to get principal by ID %d", principalID)


### PR DESCRIPTION
Close BYT-1612
![JR1eTM66xq](https://user-images.githubusercontent.com/12679343/195269726-e712c226-656c-47f4-a051-67d99ec1601d.jpg)


skip manual approval -> require dba or workspace owner
payload is
```
{"value":"MANUAL_APPROVAL_ALWAYS","assigneeGroupList":[]}
```


require project owner -> dba or workspace owner
payload is
```
{"value":"MANUAL_APPROVAL_ALWAYS","assigneeGroupList":[{"issueType":"bb.issue.database.schema.update","value":"WORKSPACE_OWNER_OR_DBA"},{"issueType":"bb.issue.database.data.update","value":"WORKSPACE_OWNER_OR_DBA"},{"issueType":"bb.issue.database.schema.update.ghost","value":"WORKSPACE_OWNER_OR_DBA"}]}
```


The assignee group value "WORKSPACE_OWNER_OR_DBA" is not handled on the backend, which leads to "invalid AssingeeGroupValue" error.

Because some users may already have "WORKSPACE_OWNER_OR_DBA" value stored, we fix the problem by adding it on the backend instead of removing it from the frontend.