### PR TITLE
fix(frontend): fill the value correctly when switching from "skip" to "require"

### DIFF
--- a/frontend/src/components/EnvironmentForm/AssigneeGroupEditor.vue
+++ b/frontend/src/components/EnvironmentForm/AssigneeGroupEditor.vue
@@ -114,7 +114,8 @@ watch(
       // Empty the array since it's meaningless when MANUAL_APPROVAL_NEVER
       emit("update", []);
     } else if (value === "MANUAL_APPROVAL_ALWAYS") {
-      // Sync the local state to the payload
+      // Sync the local state (DBA_OR_OWNER / PROJECT_OWNER) to the payload
+      // when switching from "skip manual approval" -> "require manual approval"
       emit("update", getAssigneeGroupListByValue(state.assigneeGroup));
     }
   },

--- a/frontend/src/components/EnvironmentForm/AssigneeGroupEditor.vue
+++ b/frontend/src/components/EnvironmentForm/AssigneeGroupEditor.vue
@@ -113,6 +113,9 @@ watch(
     if (value === "MANUAL_APPROVAL_NEVER") {
       // Empty the array since it's meaningless when MANUAL_APPROVAL_NEVER
       emit("update", []);
+    } else if (value === "MANUAL_APPROVAL_ALWAYS") {
+      // Sync the local state to the payload
+      emit("update", getAssigneeGroupListByValue(state.assigneeGroup));
     }
   },
   { immediate: true }


### PR DESCRIPTION
As mentioned in #2982 
![image](https://user-images.githubusercontent.com/2749742/195273479-607e8722-4cf4-4ea3-8848-6ad05da93f36.png)

When switching from "skip manual approval" -> "require manual approval", the policy payload becomes 
```
{"value":"MANUAL_APPROVAL_ALWAYS","assigneeGroupList":[]}
```

But when switching from "require project owner" -> "dba or workspace owner", the policy payload becomes
```
{"value":"MANUAL_APPROVAL_ALWAYS","assigneeGroupList":[{"issueType":"bb.issue.database.schema.update","value":"WORKSPACE_OWNER_OR_DBA"},{"issueType":"bb.issue.database.data.update","value":"WORKSPACE_OWNER_OR_DBA"},{"issueType":"bb.issue.database.schema.update.ghost","value":"WORKSPACE_OWNER_OR_DBA"}]}
```

They are equivalent since our logic fallbacks to the second one ("MANUAL_APPROVAL_ALWAYS" + "WORKSPACE_OWNER_OR_DBA") when seeing the first one. But it's confusing that different values have the same behaviors.

We are getting rid of the first type in this PR.