### PR TITLE
feat(frontend): Disable creating issue in the default project

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -530,10 +530,9 @@ const routes: Array<RouteRecordRaw> = [
             meta: {
               quickActionListByRole: (route: RouteLocationNormalized) => {
                 const slug = route.params.projectSlug as string;
-                const projectId = idFromSlug(slug);
-                const project = useProjectStore().getProjectById(projectId);
-
-                const isDefaultProject = projectId === DEFAULT_PROJECT_ID;
+                const project = useProjectStore().getProjectById(
+                  idFromSlug(slug)
+                );
 
                 if (project.rowStatus == "NORMAL") {
                   const actionList: string[] = [];
@@ -567,7 +566,7 @@ const routes: Array<RouteRecordRaw> = [
                             true;
                     }
                   }
-                  if (isDefaultProject) {
+                  if (project.id === DEFAULT_PROJECT_ID) {
                     allowAlterSchemaOrChangeData = false;
                   }
                   if (allowAlterSchemaOrChangeData) {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -530,9 +530,10 @@ const routes: Array<RouteRecordRaw> = [
             meta: {
               quickActionListByRole: (route: RouteLocationNormalized) => {
                 const slug = route.params.projectSlug as string;
-                const project = useProjectStore().getProjectById(
-                  idFromSlug(slug)
-                );
+                const projectId = idFromSlug(slug);
+                const project = useProjectStore().getProjectById(projectId);
+
+                const isDefaultProject = projectId === DEFAULT_PROJECT_ID;
 
                 if (project.rowStatus == "NORMAL") {
                   const actionList: string[] = [];
@@ -565,6 +566,9 @@ const routes: Array<RouteRecordRaw> = [
                           : // For TEAM plan, all members of the project are allowed
                             true;
                     }
+                  }
+                  if (isDefaultProject) {
+                    allowAlterSchemaOrChangeData = false;
                   }
                   if (allowAlterSchemaOrChangeData) {
                     actionList.push(

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -141,7 +141,7 @@
             />
           </button>
           <button
-            v-if="allowEdit"
+            v-if="allowAlterSchemaOrChangeData"
             type="button"
             class="btn-normal"
             @click="createMigration('bb.issue.database.data.update')"
@@ -153,7 +153,7 @@
             />
           </button>
           <button
-            v-if="allowEdit"
+            v-if="allowAlterSchemaOrChangeData"
             type="button"
             class="btn-normal"
             @click="createMigration('bb.issue.database.schema.update')"
@@ -445,6 +445,13 @@ const allowEdit = computed(() => {
     }
   }
   return false;
+});
+
+const allowAlterSchemaOrChangeData = computed(() => {
+  if (database.value.project.id === DEFAULT_PROJECT_ID) {
+    return false;
+  }
+  return allowEdit.value;
 });
 
 const allowEditDatabaseLabels = computed((): boolean => {


### PR DESCRIPTION
### Features
- Hide the [Alter Schema] and [Change Data] buttons in the quick action list of the default project.
- Hide the [Alter Schema] and [Change Data] buttons on the database detail page which belongs to the default project.
  - It's better to show the buttons anyway and inform the user we should transfer the database to a project before migrating. Hiding them are just a quick way to prevent errors.

Thanks for the suggestions from @dragonly 

Close BYT-1616