### PR TITLE
feat: add cancel task result msg

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -663,11 +663,17 @@ func (s *Server) patchTaskStatus(ctx context.Context, task *api.Task, taskStatus
 		cancel, ok := s.TaskScheduler.runningExecutorsCancel[task.ID]
 		s.TaskScheduler.runningExecutorsMutex.Unlock()
 		if !ok {
-			return nil, errors.New("Failed to cancel task")
+			return nil, errors.New("failed to cancel task")
 		}
 		cancel()
-		result := "Task cancellation requested."
-		taskStatusPatch.Result = &result
+		result, err := json.Marshal(api.TaskRunResultPayload{
+			Detail: "Task cancellation requested.",
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed")
+		}
+		resultStr := string(result)
+		taskStatusPatch.Result = &resultStr
 	}
 
 	taskPatched, err := s.store.PatchTaskStatus(ctx, taskStatusPatch)

--- a/server/task.go
+++ b/server/task.go
@@ -666,6 +666,8 @@ func (s *Server) patchTaskStatus(ctx context.Context, task *api.Task, taskStatus
 			return nil, errors.New("Failed to cancel task")
 		}
 		cancel()
+		result := "Task cancellation requested."
+		taskStatusPatch.Result = &result
 	}
 
 	taskPatched, err := s.store.PatchTaskStatus(ctx, taskStatusPatch)

--- a/server/task.go
+++ b/server/task.go
@@ -670,7 +670,7 @@ func (s *Server) patchTaskStatus(ctx context.Context, task *api.Task, taskStatus
 			Detail: "Task cancellation requested.",
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed")
+			return nil, errors.Wrapf(err, "failed to marshal TaskRunResultPayload")
 		}
 		resultStr := string(result)
 		taskStatusPatch.Result = &resultStr


### PR DESCRIPTION
Set the `result` field which will eventually show on the task run table on the frontend.