### PR TITLE
chore(parser): not expand the serial type

### DIFF
--- a/plugin/parser/ast/serial.go
+++ b/plugin/parser/ast/serial.go
@@ -1,0 +1,25 @@
+package ast
+
+import "strings"
+
+// Serial is the struct for serial.
+type Serial struct {
+	numericType
+
+	// the storage size(bytes)
+	Size int
+}
+
+// EquivalentType implements the DataType interface.
+func (s *Serial) EquivalentType(tp string) bool {
+	tp = strings.ToLower(tp)
+	switch s.Size {
+	case 2:
+		return tp == "smallserial" || tp == "serial2"
+	case 4:
+		return tp == "serial" || tp == "serial4"
+	case 8:
+		return tp == "bigserial" || tp == "serial8"
+	}
+	return false
+}

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -781,9 +781,8 @@ func convertColumnDef(in *pgquery.Node_ColumnDef) (*ast.ColumnDef, error) {
 	column := &ast.ColumnDef{
 		ColumnName: in.ColumnDef.Colname,
 	}
-	columnType, constraintList := convertDataType(in.ColumnDef.TypeName)
+	columnType := convertDataType(in.ColumnDef.TypeName)
 	column.Type = columnType
-	column.ConstraintList = append(column.ConstraintList, constraintList...)
 
 	for _, cons := range in.ColumnDef.Constraints {
 		constraint, ok := cons.Node.(*pgquery.Node_Constraint)
@@ -822,44 +821,44 @@ func stripPgCatalogPrefix(tp *pgquery.TypeName) *pgquery.TypeName {
 	return tp
 }
 
-func convertDataType(tp *pgquery.TypeName) (ast.DataType, []*ast.ConstraintDef) {
+func convertDataType(tp *pgquery.TypeName) ast.DataType {
 	tp = stripPgCatalogPrefix(tp)
 	if len(tp.Names) == 1 {
 		name, ok := tp.Names[0].Node.(*pgquery.Node_String_)
 		if !ok {
-			return &ast.UnconvertedDataType{}, nil
+			return &ast.UnconvertedDataType{}
 		}
 		s := name.String_.Str
 		switch {
 		case strings.HasPrefix(s, "int"):
 			size, err := strconv.Atoi(s[3:])
 			if err != nil {
-				return convertToUnconvertedDataType(tp), nil
+				return convertToUnconvertedDataType(tp)
 			}
-			return &ast.Integer{Size: size}, nil
+			return &ast.Integer{Size: size}
 		case strings.HasPrefix(s, "float"):
 			size, err := strconv.Atoi(s[5:])
 			if err != nil {
-				return convertToUnconvertedDataType(tp), nil
+				return convertToUnconvertedDataType(tp)
 			}
-			return &ast.Float{Size: size}, nil
+			return &ast.Float{Size: size}
 		case s == "serial":
-			return &ast.Integer{Size: 4}, []*ast.ConstraintDef{{Type: ast.ConstraintTypeNotNull}}
+			return &ast.Serial{Size: 4}
 		case s == "smallserial":
-			return &ast.Integer{Size: 2}, []*ast.ConstraintDef{{Type: ast.ConstraintTypeNotNull}}
+			return &ast.Serial{Size: 2}
 		case s == "bigserial":
-			return &ast.Integer{Size: 8}, []*ast.ConstraintDef{{Type: ast.ConstraintTypeNotNull}}
+			return &ast.Serial{Size: 8}
 		case strings.HasPrefix(s, "serial"):
 			size, err := strconv.Atoi(s[6:])
 			if err != nil {
-				return convertToUnconvertedDataType(tp), nil
+				return convertToUnconvertedDataType(tp)
 			}
-			return &ast.Integer{Size: size}, []*ast.ConstraintDef{{Type: ast.ConstraintTypeNotNull}}
+			return &ast.Serial{Size: size}
 		case s == "numeric":
-			return convertToDecimal(tp.Typmods), nil
+			return convertToDecimal(tp.Typmods)
 		}
 	}
-	return convertToUnconvertedDataType(tp), nil
+	return convertToUnconvertedDataType(tp)
 }
 
 func convertToUnconvertedDataType(tp *pgquery.TypeName) ast.DataType {

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -111,30 +111,15 @@ func TestPGConvertCreateTableStmt(t *testing.T) {
 						},
 						{
 							ColumnName: "h",
-							Type:       &ast.Integer{Size: 2},
-							ConstraintList: []*ast.ConstraintDef{
-								{
-									Type: ast.ConstraintTypeNotNull,
-								},
-							},
+							Type:       &ast.Serial{Size: 2},
 						},
 						{
 							ColumnName: "i",
-							Type:       &ast.Integer{Size: 4},
-							ConstraintList: []*ast.ConstraintDef{
-								{
-									Type: ast.ConstraintTypeNotNull,
-								},
-							},
+							Type:       &ast.Serial{Size: 4},
 						},
 						{
 							ColumnName: "j",
-							Type:       &ast.Integer{Size: 8},
-							ConstraintList: []*ast.ConstraintDef{
-								{
-									Type: ast.ConstraintTypeNotNull,
-								},
-							},
+							Type:       &ast.Serial{Size: 8},
 						},
 						{
 							ColumnName: "k",
@@ -142,12 +127,7 @@ func TestPGConvertCreateTableStmt(t *testing.T) {
 						},
 						{
 							ColumnName: "l",
-							Type:       &ast.Integer{Size: 8},
-							ConstraintList: []*ast.ConstraintDef{
-								{
-									Type: ast.ConstraintTypeNotNull,
-								},
-							},
+							Type:       &ast.Serial{Size: 8},
 						},
 						{
 							ColumnName: "m",
@@ -171,21 +151,11 @@ func TestPGConvertCreateTableStmt(t *testing.T) {
 						},
 						{
 							ColumnName: "r",
-							Type:       &ast.Integer{Size: 2},
-							ConstraintList: []*ast.ConstraintDef{
-								{
-									Type: ast.ConstraintTypeNotNull,
-								},
-							},
+							Type:       &ast.Serial{Size: 2},
 						},
 						{
 							ColumnName: "s",
-							Type:       &ast.Integer{Size: 4},
-							ConstraintList: []*ast.ConstraintDef{
-								{
-									Type: ast.ConstraintTypeNotNull,
-								},
-							},
+							Type:       &ast.Serial{Size: 4},
 						},
 						{
 							ColumnName: "t",

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -171,6 +171,13 @@ func deparseDataType(_ parser.DeparseContext, in ast.DataType, buf *strings.Buil
 		if _, err := buf.WriteString(strconv.Itoa(node.Size)); err != nil {
 			return err
 		}
+	case *ast.Serial:
+		if _, err := buf.WriteString("SERIAL"); err != nil {
+			return err
+		}
+		if _, err := buf.WriteString(strconv.Itoa(node.Size)); err != nil {
+			return err
+		}
 	case *ast.UnconvertedDataType:
 		var nameList []string
 		for _, name := range node.Name {

--- a/plugin/parser/engine/pg/deparse_test.go
+++ b/plugin/parser/engine/pg/deparse_test.go
@@ -58,18 +58,18 @@ func TestCreateTable(t *testing.T) {
 				`"e" DECIMAL(4), ` +
 				`"f" FLOAT4, ` +
 				`"g" FLOAT8, ` +
-				`"h" INT2 NOT NULL, ` +
-				`"i" INT4 NOT NULL, ` +
-				`"j" INT8 NOT NULL, ` +
+				`"h" SERIAL2, ` +
+				`"i" SERIAL4, ` +
+				`"j" SERIAL8, ` +
 				`"k" INT8, ` +
-				`"l" INT8 NOT NULL, ` +
+				`"l" SERIAL8, ` +
 				`"m" FLOAT8, ` +
 				`"n" INT4, ` +
 				`"o" INT4, ` +
 				`"p" FLOAT4, ` +
 				`"q" INT2, ` +
-				`"r" INT2 NOT NULL, ` +
-				`"s" INT4 NOT NULL, ` +
+				`"r" SERIAL2, ` +
+				`"s" SERIAL4, ` +
 				`"t" DECIMAL)`,
 		},
 		{


### PR DESCRIPTION
Before this, we expanded the serial type in the parser. Now we realize that we shouldn't expand it. Because the parser should only parse the statement.