### PR TITLE
feat(driver): parse Location and Tenant as migration info

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -556,9 +556,9 @@ func getFileInfo(fileItem vcs.DistinctFileItem, repositoryList []*api.Repository
 			continue
 		}
 
-		allowOmitDatabaseName := repository.Project.TenantMode == api.TenantModeTenant && repository.Project.DBNameTemplate == ""
+		isTenantWildcard := repository.Project.TenantMode == api.TenantModeTenant && repository.Project.DBNameTemplate == ""
 		// NOTE: We do not want to use filepath.Join here because we always need "/" as the path separator.
-		mi, err := db.ParseMigrationInfo(fileItem.FileName, path.Join(repository.BaseDirectory, repository.FilePathTemplate), allowOmitDatabaseName)
+		mi, err := db.ParseMigrationInfo(fileItem.FileName, path.Join(repository.BaseDirectory, repository.FilePathTemplate), isTenantWildcard)
 		if err != nil {
 			log.Error("Failed to parse migration file info",
 				zap.Int("project", repository.ProjectID),


### PR DESCRIPTION
This PR adds parse logic for `{{LOCATION}}` and `{{TENANT}}` to the `db.ParseMigrationInfo` to be used later to target a set of databases that match these criteria. 