### PR TITLE
fix(sql-editor): Miss database logo before instance label in the SQL editor left navigation

### DIFF
--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -21,6 +21,7 @@
         :selected-keys="selectedKeys"
         :expanded-keys="sqlEditorStore.expandedTreeNodeKeys"
         :render-label="renderLabel"
+        :render-prefix="renderPrefix"
         :render-suffix="renderSuffix"
         :node-props="nodeProps"
         :on-load="loadSubTree"
@@ -55,6 +56,7 @@ import type { ConnectionAtom, DatabaseId, InstanceId } from "@/types";
 import { ConnectionTreeState, UNKNOWN_ID } from "@/types";
 import {
   useDatabaseStore,
+  useInstanceStore,
   useIsLoggedIn,
   useSQLEditorStore,
   useTableStore,
@@ -69,6 +71,9 @@ import {
 } from "@/utils";
 import { generateTableItem } from "./utils";
 import { scrollIntoViewIfNeeded } from "@/bbkit/BBUtil";
+import InstanceEngineIcon from "@/components/InstanceEngineIcon.vue";
+import HeroiconsOutlineDatabase from "~icons/heroicons-outline/database";
+import HeroiconsOutlineTable from "~icons/heroicons-outline/table";
 
 type Position = {
   x: number;
@@ -81,6 +86,7 @@ type DropdownOptionWithConnectionAtom = DropdownOption & {
 
 const { t } = useI18n();
 
+const instanceStore = useInstanceStore();
 const databaseStore = useDatabaseStore();
 const sqlEditorStore = useSQLEditorStore();
 const tableStore = useTableStore();
@@ -199,6 +205,26 @@ const renderLabel = ({ option }: { option: ConnectionAtom }) => {
     ),
     class: classes,
   });
+};
+
+// Render icons before nodes.
+const renderPrefix = ({ option }: { option: ConnectionAtom }) => {
+  if (option.type === "instance") {
+    const instanceId = option.id;
+    const instance = instanceStore.getInstanceById(instanceId);
+    return h(InstanceEngineIcon, {
+      instance,
+    });
+  } else if (option.type === "database") {
+    return h(HeroiconsOutlineDatabase, {
+      class: "w-4 h-4",
+    });
+  } else if (option.type === "table") {
+    return h(HeroiconsOutlineTable, {
+      class: "w-4 h-4",
+    });
+  }
+  return null;
 };
 
 // Render a 'connected' icon in the right of the node

--- a/frontend/src/views/sql-editor/AsidePanel/utils.ts
+++ b/frontend/src/views/sql-editor/AsidePanel/utils.ts
@@ -1,21 +1,12 @@
-import { h } from "vue";
 import { ConnectionAtom } from "@/types";
 import type { useInstanceStore } from "@/store";
-import InstanceEngineIconVue from "@/components/InstanceEngineIcon.vue";
-import HeroiconsOutlineDatabase from "~icons/heroicons-outline/database";
-import HeroiconsOutlineTable from "~icons/heroicons-outline/table";
 
 export const generateInstanceNode = (
   item: ConnectionAtom,
   instanceStore: ReturnType<typeof useInstanceStore>
 ) => {
-  const instance = instanceStore.getInstanceById(item.id);
   return {
     ...item,
-    prefix: () =>
-      h(InstanceEngineIconVue, {
-        instance,
-      }),
     children: item.children?.map(generateDatabaseItem),
   };
 };
@@ -23,10 +14,6 @@ export const generateInstanceNode = (
 export const generateDatabaseItem = (item: ConnectionAtom) => {
   return {
     ...item,
-    prefix: () =>
-      h(HeroiconsOutlineDatabase, {
-        class: "h-4 w-4",
-      }),
     children: item.children?.map(generateTableItem),
   };
 };
@@ -35,9 +22,5 @@ export const generateTableItem = (item: ConnectionAtom) => {
   return {
     ...item,
     isLeaf: true,
-    prefix: () =>
-      h(HeroiconsOutlineTable, {
-        class: "h-4 w-4",
-      }),
   };
 };


### PR DESCRIPTION
Close BYT-1623
![image](https://user-images.githubusercontent.com/2749742/195515872-fe826da4-1846-4e0f-b504-990daa66795f.png)
