### PR TITLE
chore: bump the version of pnpm/action-setup to 2.2.3

### DIFF
--- a/.github/workflows/build-artifacts-and-draft-release.yml
+++ b/.github/workflows/build-artifacts-and-draft-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 6.10.0
       - uses: actions/setup-node@v3
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 6.10.0
       - uses: actions/setup-node@v3
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 6.10.0
       - uses: actions/setup-node@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 6.10.0
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### Problem
![image](https://user-images.githubusercontent.com/2749742/195543611-08805099-b648-43f4-90e6-9c21c52b3b30.png)

### References

- [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- [pnpm/action-setup/#56](https://github.com/pnpm/action-setup/pull/56/files)
- [pnpm/action-setup/release/v2.2.3](https://github.com/pnpm/action-setup/releases/tag/v2.2.3)