### PR TITLE
fix(SBM): update same name index

### DIFF
--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -273,7 +273,6 @@ func deparse(newNodeList []ast.Node, inplaceUpdate []ast.Node, inplaceAdd []ast.
 		if _, err := buf.Write([]byte(";\n")); err != nil {
 			return "", err
 		}
-
 	}
 
 	for i := len(inplaceAdd) - 1; i >= 0; i-- {


### PR DESCRIPTION
When we try to update the index with the same name, we cannot update it in place but drop it first and then create the new one.
We introduce `inplaceDropNodeList` and `inplaceAddNodeList` to handle this, and `inplaceDropNodeList` will restore after the newNodeList, and the `inplaceAddNodeList` will restore after `inplaceDropNodeList`.