### PR TITLE
feat(frontend): allow to approve current stage when some of the tasks were approved already

### DIFF
--- a/frontend/src/components/Issue/logic/transition.ts
+++ b/frontend/src/components/Issue/logic/transition.ts
@@ -13,7 +13,6 @@ import {
   activeStage,
   allTaskList,
   applicableTaskTransition,
-  isApplicableTaskTransition,
   isDBAOrOwner,
   isOwnerOfProject,
   StageStatusTransition,
@@ -127,7 +126,7 @@ export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
           const pendingApprovalTaskList = currentStage.taskList.filter(
             (task) => {
               return (
-                isApplicableTaskTransition(task, APPROVE.type) &&
+                task.status === "PENDING_APPROVAL" &&
                 allowApplyTaskStatusTransition(task, APPROVE.to)
               );
             }

--- a/frontend/src/components/Issue/logic/transition.ts
+++ b/frontend/src/components/Issue/logic/transition.ts
@@ -10,13 +10,15 @@ import {
   IssueStatusTransition,
 } from "@/types";
 import {
+  activeStage,
   allTaskList,
-  applicableStageTransition,
   applicableTaskTransition,
+  isApplicableTaskTransition,
   isDBAOrOwner,
   isOwnerOfProject,
   StageStatusTransition,
   TaskStatusTransition,
+  TASK_STATUS_TRANSITION_LIST,
 } from "@/utils";
 import { useAllowProjectOwnerToApprove, useIssueLogic } from ".";
 
@@ -118,11 +120,24 @@ export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
         return [];
       case "OPEN": {
         if (isAllowedToApplyTaskTransition.value) {
-          const currentTask = activeTaskOfPipeline(issue.pipeline);
-          return applicableStageTransition(issue.pipeline).filter(
-            (transition) =>
-              allowApplyTaskStatusTransition(currentTask, transition.to)
+          // Only "Approve" can be applied to current stage by now.
+          const APPROVE = TASK_STATUS_TRANSITION_LIST.get("APPROVE")!;
+          const currentStage = activeStage(issue.pipeline);
+
+          const pendingApprovalTaskList = currentStage.taskList.filter(
+            (task) => {
+              return (
+                isApplicableTaskTransition(task, APPROVE.type) &&
+                allowApplyTaskStatusTransition(task, APPROVE.to)
+              );
+            }
           );
+
+          // Allowing "Approve" a stage when it has TWO OR MORE tasks applicable
+          // by this type of transition (including the "activeTask" itself)
+          if (pendingApprovalTaskList.length >= 2) {
+            return [APPROVE];
+          }
         }
 
         return [];

--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -1,5 +1,4 @@
 import { BBButtonType } from "@/bbkit/types";
-import { uniq } from "lodash-es";
 import {
   Database,
   empty,
@@ -173,7 +172,7 @@ export interface TaskStatusTransition {
   buttonType: BBButtonType;
 }
 
-const TASK_STATUS_TRANSITION_LIST: Map<
+export const TASK_STATUS_TRANSITION_LIST: Map<
   TaskStatusTransitionType,
   TaskStatusTransition
 > = new Map([
@@ -225,7 +224,7 @@ const TASK_STATUS_TRANSITION_LIST: Map<
 ]);
 
 // The transition button are displayed from left to right on the UI, and the right-most one is the primary button
-const APPLICABLE_TASK_TRANSITION_LIST: Map<
+export const APPLICABLE_TASK_TRANSITION_LIST: Map<
   TaskStatus,
   TaskStatusTransitionType[]
 > = new Map([
@@ -236,6 +235,20 @@ const APPLICABLE_TASK_TRANSITION_LIST: Map<
   ["FAILED", ["RETRY"]],
   ["CANCELED", ["RESTART"]],
 ]);
+
+export function isApplicableTaskTransition(
+  task: Task,
+  transitionType: TaskStatusTransitionType
+): boolean {
+  if (task.id == EMPTY_ID || task.id == UNKNOWN_ID) {
+    return false;
+  }
+
+  const list = APPLICABLE_TASK_TRANSITION_LIST.get(task.status);
+
+  if (!list) return false;
+  return list.includes(transitionType);
+}
 
 export function applicableTaskTransition(
   pipeline: Pipeline
@@ -258,24 +271,3 @@ export function applicableTaskTransition(
 // The status transition applying to a stage is applying to all tasks in the
 // stage simultaneously.
 export type StageStatusTransition = TaskStatusTransition;
-
-export function applicableStageTransition(
-  pipeline: Pipeline
-): StageStatusTransition[] {
-  const task = activeTask(pipeline);
-  if (task.id === EMPTY_ID || task.id === UNKNOWN_ID) {
-    return [];
-  }
-  const stage = task.stage;
-  const statusList = uniq(stage.taskList.map((t) => t.status));
-
-  // Only allowed to apply status patch to a stage when all it's tasks' status
-  // are the same.
-  if (statusList.length > 1) {
-    return [];
-  }
-
-  const transitionTypes = APPLICABLE_TASK_TRANSITION_LIST.get(statusList[0])!;
-
-  return transitionTypes.map((type) => TASK_STATUS_TRANSITION_LIST.get(type)!);
-}

--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -236,20 +236,6 @@ export const APPLICABLE_TASK_TRANSITION_LIST: Map<
   ["CANCELED", ["RESTART"]],
 ]);
 
-export function isApplicableTaskTransition(
-  task: Task,
-  transitionType: TaskStatusTransitionType
-): boolean {
-  if (task.id == EMPTY_ID || task.id == UNKNOWN_ID) {
-    return false;
-  }
-
-  const list = APPLICABLE_TASK_TRANSITION_LIST.get(task.status);
-
-  if (!list) return false;
-  return list.includes(transitionType);
-}
-
 export function applicableTaskTransition(
   pipeline: Pipeline
 ): TaskStatusTransition[] {


### PR DESCRIPTION
Following #3013 
Close SPT-3

### Features
- Before: Allow to "Approve current stage" only when ALL tasks in the stage are "PENDING_APPROVAL"
- After: Allow to "Approve current stage" when TWO OR MORE tasks in the stage are "PENDING_APPROVAL"