### PR TITLE
fix: webhook should post the updated issue

### DIFF
--- a/server/activity_manager.go
+++ b/server/activity_manager.go
@@ -119,7 +119,7 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 			title = "Issue canceled - " + meta.issue.Name
 		}
 	case api.ActivityIssueCommentCreate:
-		title = "Comment created"
+		title = "Comment created - " + meta.issue.Name
 		link += fmt.Sprintf("#activity%d", activity.ID)
 	case api.ActivityIssueFieldUpdate:
 		update := new(api.ActivityIssueFieldUpdatePayload)
@@ -187,20 +187,20 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 					}
 
 					if oldAssignee != nil && newAssignee != nil {
-						title = fmt.Sprintf("Reassigned issue from %s to %s", oldAssignee.Name, newAssignee.Name)
+						title = fmt.Sprintf("Reassigned issue from %s to %s - ", oldAssignee.Name, newAssignee.Name) + meta.issue.Name
 					} else if newAssignee != nil {
-						title = fmt.Sprintf("Assigned issue to %s", newAssignee.Name)
+						title = fmt.Sprintf("Assigned issue to %s - ", newAssignee.Name) + meta.issue.Name
 					} else if oldAssignee != nil {
-						title = fmt.Sprintf("Unassigned issue from %s", newAssignee.Name)
+						title = fmt.Sprintf("Unassigned issue from %s - ", newAssignee.Name) + meta.issue.Name
 					}
 				}
 			}
 		case api.IssueFieldDescription:
-			title = "Changed issue description"
+			title = "Changed issue description - " + meta.issue.Name
 		case api.IssueFieldName:
-			title = "Changed issue name"
+			title = "Changed issue name - " + meta.issue.Name
 		default:
-			title = "Updated issue"
+			title = "Updated issue - " + meta.issue.Name
 		}
 	case api.ActivityPipelineTaskStatusUpdate:
 		update := &api.ActivityPipelineTaskStatusUpdatePayload{}

--- a/server/activity_manager.go
+++ b/server/activity_manager.go
@@ -107,19 +107,19 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 	link := fmt.Sprintf("%s/issue/%s", m.s.profile.ExternalURL, api.IssueSlug(meta.issue))
 	switch activity.Type {
 	case api.ActivityIssueCreate:
-		title = "Issue created - " + meta.issue.Name
+		title = fmt.Sprintf("Issue created - %s", meta.issue.Name)
 	case api.ActivityIssueStatusUpdate:
 		switch meta.issue.Status {
 		case "OPEN":
-			title = "Issue reopened - " + meta.issue.Name
+			title = fmt.Sprintf("Issue reopened - %s", meta.issue.Name)
 		case "DONE":
 			level = webhook.WebhookSuccess
-			title = "Issue resolved - " + meta.issue.Name
+			title = fmt.Sprintf("Issue resolved - %s", meta.issue.Name)
 		case "CANCELED":
-			title = "Issue canceled - " + meta.issue.Name
+			title = fmt.Sprintf("Issue canceled - %s", meta.issue.Name)
 		}
 	case api.ActivityIssueCommentCreate:
-		title = "Comment created - " + meta.issue.Name
+		title = fmt.Sprintf("Comment created - %s", meta.issue.Name)
 		link += fmt.Sprintf("#activity%d", activity.ID)
 	case api.ActivityIssueFieldUpdate:
 		update := new(api.ActivityIssueFieldUpdatePayload)
@@ -187,20 +187,20 @@ func (m *ActivityManager) getWebhookContext(ctx context.Context, activity *api.A
 					}
 
 					if oldAssignee != nil && newAssignee != nil {
-						title = fmt.Sprintf("Reassigned issue from %s to %s - ", oldAssignee.Name, newAssignee.Name) + meta.issue.Name
+						title = fmt.Sprintf("Reassigned issue from %s to %s - %s", oldAssignee.Name, newAssignee.Name, meta.issue.Name)
 					} else if newAssignee != nil {
-						title = fmt.Sprintf("Assigned issue to %s - ", newAssignee.Name) + meta.issue.Name
+						title = fmt.Sprintf("Assigned issue to %s - %s", newAssignee.Name, meta.issue.Name)
 					} else if oldAssignee != nil {
-						title = fmt.Sprintf("Unassigned issue from %s - ", newAssignee.Name) + meta.issue.Name
+						title = fmt.Sprintf("Unassigned issue from %s - %s", newAssignee.Name, meta.issue.Name)
 					}
 				}
 			}
 		case api.IssueFieldDescription:
-			title = "Changed issue description - " + meta.issue.Name
+			title = fmt.Sprintf("Changed issue description - %s", meta.issue.Name)
 		case api.IssueFieldName:
-			title = "Changed issue name - " + meta.issue.Name
+			title = fmt.Sprintf("Changed issue name - %s", meta.issue.Name)
 		default:
-			title = "Updated issue - " + meta.issue.Name
+			title = fmt.Sprintf("Updated issue - %s", meta.issue.Name)
 		}
 	case api.ActivityPipelineTaskStatusUpdate:
 		update := &api.ActivityPipelineTaskStatusUpdatePayload{}

--- a/server/issue.go
+++ b/server/issue.go
@@ -252,7 +252,7 @@ func (s *Server) registerIssueRoutes(g *echo.Group) {
 				Payload:     string(payload),
 			}
 			_, err := s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{
-				issue: issue,
+				issue: updatedIssue,
 			})
 			if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to create activity after updating issue: %v", updatedIssue.Name)).SetInternal(err)


### PR DESCRIPTION
The current issue status change webhook will post the old issue in the event.
This PR changes to post the updated issue.
Also changed event message names to be consistent with the create issue event.