### PR TITLE
fix: cannot resolve component DebugLogsEmptyView

### DIFF
--- a/frontend/src/views/SettingWorkspaceDebugLog.vue
+++ b/frontend/src/views/SettingWorkspaceDebugLog.vue
@@ -67,7 +67,7 @@
         </div>
       </BBDialog>
     </div>
-    <DebugLogsEmptyView v-else />
+    <DebugLogEmptyView v-else />
   </div>
 </template>
 


### PR DESCRIPTION
Caused by a typo.

![image](https://user-images.githubusercontent.com/56376387/196024339-6a63f2a8-248e-4a56-9b68-92b0832e8205.png)
