### PR TITLE
fix: cannot running CREATE TRIGGER/FUNCTION/PROCEDURE/EVENT in DDL issue

### DIFF
--- a/plugin/parser/utils.go
+++ b/plugin/parser/utils.go
@@ -1,7 +1,9 @@
 package parser
 
 import (
+	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	tidbast "github.com/pingcap/tidb/parser/ast"
@@ -66,4 +68,61 @@ func SetLineForMySQLCreateTableStmt(node *tidbast.CreateTableStmt) error {
 	}
 	firstLine := node.OriginTextPosition() - strings.Count(node.Text(), "\n")
 	return newTokenizer(node.Text()).setLineForMySQLCreateTableStmt(node, firstLine)
+}
+
+// ExtractTiDBUnsupportStmts returns a list of unsupported statements in TiDB extracted from the `stmts`,
+// and returns the remaining statements supported by TiDB from `stmts`.
+func ExtractTiDBUnsupportStmts(stmts string) ([]string, string, error) {
+	var (
+		unsupportStmts []string
+		supportedStmts string
+	)
+	// We use our bb tokenizer to help us split the multi-statements into statement list.
+	singleSQLs, err := SplitMultiSQL(MySQL, stmts)
+	if err != nil {
+		return nil, "", errors.Wrapf(err, "cannot split multi sql %q via bytebase parser", stmts)
+	}
+	for _, sql := range singleSQLs {
+		content := sql.Text
+		if isTiDBUnsupportStmt(content) {
+			unsupportStmts = append(unsupportStmts, content)
+			continue
+		}
+		supportedStmts += content + "\n"
+	}
+	return unsupportStmts, supportedStmts, nil
+}
+
+// isTiDBUnsupportStmt returns true if this statement is unsupported in TiDB.
+func isTiDBUnsupportStmt(stmt string) bool {
+	if isTiDBUnsupportDDLStmt(stmt) {
+		return true
+	}
+	// Match DELIMITER statement
+	// Now, we assume that all input comes from our mysqldump, and the tokenizer can split the mysqldump DELIMITER statement
+	// in one singleSQL correctly, so we can handle it easily here by checking the prefix.
+	return strings.HasPrefix(stmt, "DELIMITER ")
+}
+
+// isTiDBUnsupportStmt checks whether the `stmt` is unsupported DDL statement in TiDB, the following statements are unsupported:
+// 1. `CREATE TRIGGER`
+// 2. `CREATE EVENT`
+// 3. `CREATE FUNCTION`
+// 4. `CREATE PROCEDURE`.
+func isTiDBUnsupportDDLStmt(stmt string) bool {
+	objects := []string{
+		"TRIGGER",
+		"EVENT",
+		"FUNCTION",
+		"PROCEDURE",
+	}
+	regexFmt := "(?i)^CREATE DEFINER=`.+`@`.+` %s\\s+"
+	for _, obj := range objects {
+		regex := fmt.Sprintf(regexFmt, obj)
+		re := regexp.MustCompile(regex)
+		if re.MatchString(stmt) {
+			return true
+		}
+	}
+	return false
 }

--- a/plugin/parser/utils.go
+++ b/plugin/parser/utils.go
@@ -99,7 +99,9 @@ func isTiDBUnsupportStmt(stmt string) bool {
 	// Match DELIMITER statement
 	// Now, we assume that all input comes from our mysqldump, and the tokenizer can split the mysqldump DELIMITER statement
 	// in one singleSQL correctly, so we can handle it easily here by checking the prefix.
-	return strings.HasPrefix(stmt, "DELIMITER ")
+	delimiterRegex := `(?i)^DELIMITER\s+`
+	re := regexp.MustCompile(delimiterRegex)
+	return re.MatchString(stmt)
 }
 
 // isTiDBUnsupportStmt checks whether the `stmt` is unsupported DDL statement in TiDB, the following statements are unsupported:

--- a/plugin/parser/utils.go
+++ b/plugin/parser/utils.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"regexp"
@@ -74,7 +75,7 @@ func SetLineForMySQLCreateTableStmt(node *tidbast.CreateTableStmt) error {
 // and returns the remaining statements supported by TiDB from `stmts`.
 func ExtractTiDBUnsupportStmts(stmts string) ([]string, string, error) {
 	var unsupportStmts []string
-	var supportedStmts string
+	var supportedStmts bytes.Buffer
 	// We use our bb tokenizer to help us split the multi-statements into statement list.
 	singleSQLs, err := SplitMultiSQL(MySQL, stmts)
 	if err != nil {
@@ -86,9 +87,10 @@ func ExtractTiDBUnsupportStmts(stmts string) ([]string, string, error) {
 			unsupportStmts = append(unsupportStmts, content)
 			continue
 		}
-		supportedStmts += content + "\n"
+		_, _ = supportedStmts.Write([]byte(content))
+		_, _ = supportedStmts.Write([]byte("\n"))
 	}
-	return unsupportStmts, supportedStmts, nil
+	return unsupportStmts, supportedStmts.String(), nil
 }
 
 // isTiDBUnsupportStmt returns true if this statement is unsupported in TiDB.

--- a/plugin/parser/utils.go
+++ b/plugin/parser/utils.go
@@ -73,10 +73,8 @@ func SetLineForMySQLCreateTableStmt(node *tidbast.CreateTableStmt) error {
 // ExtractTiDBUnsupportStmts returns a list of unsupported statements in TiDB extracted from the `stmts`,
 // and returns the remaining statements supported by TiDB from `stmts`.
 func ExtractTiDBUnsupportStmts(stmts string) ([]string, string, error) {
-	var (
-		unsupportStmts []string
-		supportedStmts string
-	)
+	var unsupportStmts []string
+	var supportedStmts string
 	// We use our bb tokenizer to help us split the multi-statements into statement list.
 	singleSQLs, err := SplitMultiSQL(MySQL, stmts)
 	if err != nil {

--- a/plugin/parser/utils.go
+++ b/plugin/parser/utils.go
@@ -116,7 +116,7 @@ func isTiDBUnsupportDDLStmt(stmt string) bool {
 		"FUNCTION",
 		"PROCEDURE",
 	}
-	regexFmt := "(?i)^CREATE DEFINER=`.+`@`.+` %s\\s+"
+	regexFmt := "(?i)^CREATE\\s+(DEFINER=`(.)+`@`(.)+`(\\s)+)?%s\\s+"
 	for _, obj := range objects {
 		regex := fmt.Sprintf(regexFmt, obj)
 		re := regexp.MustCompile(regex)

--- a/plugin/parser/utils_test.go
+++ b/plugin/parser/utils_test.go
@@ -1,0 +1,89 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTiDBUnsupportStmts(t *testing.T) {
+	tests := []struct {
+		stmts         string
+		wantUnsupport []string
+		wantSupport   string
+		wantErr       bool
+	}{
+		{
+			stmts: "CREATE TABLE t1(id INT, name VARCHAR(50), price DECIMAL(10,2), CONSTRAINT PRIMARY KEY(50), INDEX idx_name(name);\n" +
+				"DELIMITER ;;\n" +
+				"CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON `account` FOR EACH SET @sum=@sum + NEW.price;;\n" +
+				"DELIMITER ;\n",
+			wantUnsupport: []string{
+				"DELIMITER ;;",
+				"CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON `account` FOR EACH SET @sum=@sum + NEW.price;;",
+				"DELIMITER ;",
+			},
+			wantSupport: "CREATE TABLE t1(id INT, name VARCHAR(50), price DECIMAL(10,2), CONSTRAINT PRIMARY KEY(50), INDEX idx_name(name);\n",
+			wantErr:     false,
+		},
+	}
+	a := require.New(t)
+	for _, test := range tests {
+		gotUnsupport, gotSupport, err := ExtractTiDBUnsupportStmts(test.stmts)
+		if test.wantErr {
+			a.Error(err)
+		} else {
+			a.Equal(test.wantUnsupport, gotUnsupport)
+			a.Equal(test.wantSupport, gotSupport)
+		}
+	}
+}
+
+func TestIsTiDBUnsupportStmt(t *testing.T) {
+	tests := []struct {
+		stmt string
+		want bool
+	}{
+		{
+			stmt: "DELIMITER ;;",
+			want: true,
+		},
+		{
+			stmt: "CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON `account` FOR EACH SET @sum=@sum + NEW.price;;",
+			want: true,
+		},
+		{
+			stmt: "DELIMITER ;",
+			want: true,
+		},
+		{
+			stmt: "CREATE TABLE t1(id INT, name VARCHAR(50), price DECIMAL(10,2), CONSTRAINT PRIMARY KEY(50), INDEX idx_name(name);",
+			want: false,
+		},
+		{
+			stmt: "CREATE DEFINER=`root`@`%` PROCEDURE `citycount` (IN `country` CHAR(3), OUT `cities` INT)\n" +
+				"BEGIN\n" +
+				"	SELECT COUNT(*) INTO cities FROM world.city\n" +
+				"WHERE CountryCode = country;\n" +
+				"END//",
+			want: true,
+		},
+		{
+			stmt: "CREATE DEFINER=`root`@`%` FUNCTION `hello` (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC\n" +
+				"RETURN CONCAT('Hello, ',s,'!');",
+			want: true,
+		},
+		{
+			stmt: "CREATE DEFINER=`root`@`%` EVENT `test_event_01` ON SCHEDULE AT CURRENT_TIMESTAMP \n" +
+				"DO\n" +
+				"	INSERT INTO message(message, created_at)\n" +
+				"	VALUES('test event', NOW());",
+			want: true,
+		},
+	}
+	a := require.New(t)
+	for _, test := range tests {
+		got := isTiDBUnsupportStmt(test.stmt)
+		a.Equal(test.want, got)
+	}
+}

--- a/plugin/parser/utils_test.go
+++ b/plugin/parser/utils_test.go
@@ -49,11 +49,15 @@ func TestIsTiDBUnsupportStmt(t *testing.T) {
 			want: true,
 		},
 		{
+			stmt: "delimiter ;;",
+			want: true,
+		},
+		{
 			stmt: "CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON `account` FOR EACH SET @sum=@sum + NEW.price;;",
 			want: true,
 		},
 		{
-			stmt: "DELIMITER ;",
+			stmt: "create trigger `ins_sum` BEFORE INSERT ON `account` FOR EACH SET @sum=@sum + NEW.price;;",
 			want: true,
 		},
 		{
@@ -69,7 +73,20 @@ func TestIsTiDBUnsupportStmt(t *testing.T) {
 			want: true,
 		},
 		{
+			stmt: "create procedure `citycount` (IN `country` CHAR(3), OUT `cities` INT)\n" +
+				"BEGIN\n" +
+				"	SELECT COUNT(*) INTO cities FROM world.city\n" +
+				"WHERE CountryCode = country;\n" +
+				"END//",
+			want: true,
+		},
+		{
 			stmt: "CREATE DEFINER=`root`@`%` FUNCTION `hello` (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC\n" +
+				"RETURN CONCAT('Hello, ',s,'!');",
+			want: true,
+		},
+		{
+			stmt: "create function `hello` (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC\n" +
 				"RETURN CONCAT('Hello, ',s,'!');",
 			want: true,
 		},
@@ -79,11 +96,17 @@ func TestIsTiDBUnsupportStmt(t *testing.T) {
 				"	INSERT INTO message(message, created_at)\n" +
 				"	VALUES('test event', NOW());",
 			want: true,
+		}, {
+			stmt: "create event `test_event_01` ON SCHEDULE AT CURRENT_TIMESTAMP \n" +
+				"DO\n" +
+				"	INSERT INTO message(message, created_at)\n" +
+				"	VALUES('test event', NOW());",
+			want: true,
 		},
 	}
 	a := require.New(t)
 	for _, test := range tests {
 		got := isTiDBUnsupportStmt(test.stmt)
-		a.Equal(test.want, got)
+		a.Equalf(test.want, got, "statement: %s\n", test.stmt)
 	}
 }


### PR DESCRIPTION
We now rely on TiDB's parser for parsing MySQL statements, but TiDB parser doesn't support **at least** the following statements:
1. `DELIMITER`
2. `CREATE FUNCTION`
3. `CREATE PROCEDURE`
4. `CREATE EVENT`
5. `CREATE TRIGGER`

So we need to extract these statements before sending input to TiDB parser. We match them by using regexp.
To simplify the regexp, we only match our MySQL dump format for the above SQLs like **CREATE DEFINER=\`root\`@\`%\` TRIGGER \`tri\` xxxxxx**.

Complete BYT-1663.

A part of #3080.