### PR TITLE
fix(sbm): disable foreign key check

### DIFF
--- a/plugin/parser/differ/mysql/column_test.go
+++ b/plugin/parser/differ/mysql/column_test.go
@@ -4,15 +4,10 @@ import (
 	"testing"
 
 	_ "github.com/pingcap/tidb/types/parser_driver"
-	"github.com/stretchr/testify/require"
 )
 
 func TestColumnExist(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		// Missing columns
 		{
 			old:  `CREATE TABLE book(id INT, PRIMARY KEY(id));`,
@@ -35,21 +30,11 @@ func TestColumnExist(t *testing.T) {
 			want: "",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestColumnType(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		// Different types.
 		{
 			old:  `CREATE TABLE book(id INT);`,
@@ -68,21 +53,11 @@ func TestColumnType(t *testing.T) {
 			want: "",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestColumnOption(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		// NULL option not match.
 		{
 			old:  `CREATE TABLE book(name VARCHAR(50) NOT NULL);`,
@@ -125,21 +100,11 @@ func TestColumnOption(t *testing.T) {
 			want: "",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestColumnComment(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Author Name' NOT NULL);`,
 			new:  `CREATE TABLE book(name VARCHAR(50) COMMENT 'Book Name' NOT NULL);`,
@@ -171,21 +136,11 @@ func TestColumnComment(t *testing.T) {
 			want: "",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestColumnDefaultValue(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old:  `CREATE TABLE book(name VARCHAR(50) DEFAULT 'Harry Potter' NOT NULL);`,
 			new:  `CREATE TABLE book(name VARCHAR(50) NOT NULL);`,
@@ -227,21 +182,11 @@ func TestColumnDefaultValue(t *testing.T) {
 			want: "",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestColumnCollate(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old:  `CREATE TABLE book(name VARCHAR(50) COLLATE utf8mb4_bin DEFAULT 'Harry Potter' NOT NULL);`,
 			new:  `CREATE TABLE book(name VARCHAR(50) COLLATE utf8mb4_polish_ci DEFAULT 'Harry Potter' NOT NULL);`,
@@ -263,11 +208,5 @@ func TestColumnCollate(t *testing.T) {
 			want: "",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }

--- a/plugin/parser/differ/mysql/constraint_test.go
+++ b/plugin/parser/differ/mysql/constraint_test.go
@@ -234,11 +234,7 @@ func TestIsIndexOptionEqual(t *testing.T) {
 }
 
 func TestIndexType(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: `CREATE TABLE book(name VARCHAR(50) NOT NULL, INDEX book_idx USING BTREE(name));`,
 			new: `CREATE TABLE book(name VARCHAR(50) NOT NULL, INDEX book_idx USING HASH(name));`,
@@ -257,21 +253,11 @@ func TestIndexType(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestIndexOption(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		// KEY_BLOCK_SIZE not match.
 		{
 			old: `CREATE TABLE book(name VARCHAR(50) NOT NULL, INDEX book_idx(name) KEY_BLOCK_SIZE=30);`,
@@ -338,21 +324,11 @@ func TestIndexOption(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestKeyPart(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: `CREATE TABLE book(id INT, name VARCHAR(50) NOT NULL, INDEX book_idx USING BTREE (id, name) COMMENT 'comment_a');`,
 			new: `CREATE TABLE book(id INT, name VARCHAR(50) NOT NULL, INDEX book_idx USING BTREE (id) COMMENT 'comment_a');`,
@@ -411,21 +387,11 @@ func TestKeyPart(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestForeignKeyDefination(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: `CREATE TABLE department(id INT, name VARCHAR(50) NOT NULL, PRIMARY KEY(department));
 			CREATE TABLE employee(id INT, name VARCHAR(50) NOT NULL, department_id INT, PRIMARY KEY(id), FOREIGN KEY employee_ibfk_1(department_id) REFERENCES department(id));`,
@@ -500,21 +466,11 @@ func TestForeignKeyDefination(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestCheckConstraint(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: "CREATE TABLE book(id INT, price INT, PRIMARY KEY(id), CONSTRAINT `check_price` CHECK (price > 0));",
 			new: "CREATE TABLE book(id INT, price INT, PRIMARY KEY(id), CONSTRAINT `check_price` CHECK (price > 1));",
@@ -535,21 +491,11 @@ func TestCheckConstraint(t *testing.T) {
 				"ALTER TABLE `book` DROP CHECK `check_price2`;\n",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestConstraint(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		// ADD COLUMN -> DROP PRIMARY KEY -> ADD PRIMARY KEY
 		{
 			old: `CREATE TABLE book(id INT, name VARCHAR(50), CONSTRAINT PRIMARY KEY(id, name));`,
@@ -575,11 +521,5 @@ func TestConstraint(t *testing.T) {
 				"ALTER TABLE `book` ADD INDEX `idx`(`id`, `address`);\n",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -83,6 +83,7 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 		return "", errors.Wrapf(err, "failed to parse new statement %q", newStmt)
 	}
 
+	var newTableList []ast.Node
 	var newNodeList []ast.Node
 	var inplaceUpdate []ast.Node
 	// inplaceDropNodeList and inplaceAddNodeList are used to handle destructive node updates.
@@ -105,7 +106,7 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 			if !ok {
 				stmt := *newStmt
 				stmt.IfNotExists = true
-				newNodeList = append(newNodeList, &stmt)
+				newTableList = append(newTableList, &stmt)
 				continue
 			}
 			if alterTableOptionStmt := diffTableOptions(newStmt.Table, oldStmt.Options, newStmt.Options); alterTableOptionStmt != nil {
@@ -391,6 +392,10 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 	if len(dropViewStmt.Tables) > 0 {
 		dropNodeList = append(dropNodeList, dropViewStmt)
 	}
+
+	// We should create table first and then add the constraint such as add foreign key on an other table,
+	// becase mysqldump have not topology sort.
+	newNodeList = append(newTableList, newNodeList...)
 
 	return deparse(newNodeList, newNodeStmt, inplaceUpdate,
 		inplaceAddNodeList, inplaceAddStmt, inplaceDropNodeList,

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -4,6 +4,7 @@ package mysql
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strings"
@@ -397,109 +398,115 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 	// becase mysqldump have not topology sort.
 	newNodeList = append(newTableList, newNodeList...)
 
-	return deparse(newNodeList, newNodeStmt, inplaceUpdate,
+	var buf bytes.Buffer
+	_, _ = buf.Write([]byte("SET FOREIGN_KEY_CHECKS=0;\n"))
+
+	if err := deparse(&buf, newNodeList, newNodeStmt, inplaceUpdate,
 		inplaceAddNodeList, inplaceAddStmt, inplaceDropNodeList,
 		inplaceDropStmt, dropNodeList, dropStmt, viewStmts,
-		format.DefaultRestoreFlags|format.RestoreStringWithoutCharset)
+		format.DefaultRestoreFlags|format.RestoreStringWithoutCharset); err != nil {
+		return "", errors.Wrapf(err, "deparse failed")
+	}
+	return buf.String(), nil
 }
 
-func deparse(newNodeList []ast.Node, newNodeStmt []string, inplaceUpdate []ast.Node,
+func deparse(out io.Writer, newNodeList []ast.Node, newNodeStmt []string, inplaceUpdate []ast.Node,
 	inplaceAdd []ast.Node, inplaceAddStmt []string, inplaceDrop []ast.Node,
 	inplaceDropStmt []string, dropNodeList []ast.Node, dropStmt []string,
-	viewStmts []*ast.CreateViewStmt, flag format.RestoreFlags) (string, error) {
-	var buf bytes.Buffer
+	viewStmts []*ast.CreateViewStmt, flag format.RestoreFlags) error {
 	// We should following the right order to avoid break the dependency:
 	// Additions for new nodes.
 	// Updates for in-place node updates.
 	// Deletions for destructive (none in-place) node updates (in reverse order).
 	// Additions for destructive node updates.
 	// Deletions for deleted nodes (in reverse order).
+	restoreCtx := format.NewRestoreCtx(flag, out)
 	for _, node := range newNodeList {
-		if err := node.Restore(format.NewRestoreCtx(flag, &buf)); err != nil {
-			return "", err
+		if err := node.Restore(restoreCtx); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte(";\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(";\n")); err != nil {
+			return err
 		}
 	}
 	for _, stmt := range newNodeStmt {
-		if _, err := buf.Write([]byte(stmt)); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(stmt)); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte("\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte("\n")); err != nil {
+			return err
 		}
 	}
 
 	for _, node := range inplaceUpdate {
-		if err := node.Restore(format.NewRestoreCtx(flag, &buf)); err != nil {
-			return "", err
+		if err := node.Restore(restoreCtx); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte(";\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(";\n")); err != nil {
+			return err
 		}
 	}
 
 	for i := len(inplaceDrop) - 1; i >= 0; i-- {
-		if err := inplaceDrop[i].Restore(format.NewRestoreCtx(flag, &buf)); err != nil {
-			return "", err
+		if err := inplaceDrop[i].Restore(restoreCtx); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte(";\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(";\n")); err != nil {
+			return err
 		}
 	}
 	for i := len(inplaceDropStmt) - 1; i >= 0; i-- {
-		if _, err := buf.Write([]byte(inplaceDropStmt[i])); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(inplaceDropStmt[i])); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte("\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte("\n")); err != nil {
+			return err
 		}
 	}
 
 	for i := len(inplaceAdd) - 1; i >= 0; i-- {
-		if err := inplaceAdd[i].Restore(format.NewRestoreCtx(flag, &buf)); err != nil {
-			return "", err
+		if err := inplaceAdd[i].Restore(restoreCtx); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte(";\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(";\n")); err != nil {
+			return err
 		}
 	}
 	for _, stmt := range inplaceAddStmt {
-		if _, err := buf.Write([]byte(stmt)); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(stmt)); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte("\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte("\n")); err != nil {
+			return err
 		}
 	}
 
 	for i := len(dropNodeList) - 1; i >= 0; i-- {
-		if err := dropNodeList[i].Restore(format.NewRestoreCtx(flag, &buf)); err != nil {
-			return "", err
+		if err := dropNodeList[i].Restore(restoreCtx); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte(";\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(";\n")); err != nil {
+			return err
 		}
 	}
 	for i := len(dropStmt) - 1; i >= 0; i-- {
-		if _, err := buf.Write([]byte(dropStmt[i])); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(dropStmt[i])); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte("\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte("\n")); err != nil {
+			return err
 		}
 	}
 
 	for _, node := range viewStmts {
-		if err := node.Restore(format.NewRestoreCtx(flag, &buf)); err != nil {
-			return "", err
+		if err := node.Restore(restoreCtx); err != nil {
+			return err
 		}
-		if _, err := buf.Write([]byte(";\n")); err != nil {
-			return "", err
+		if _, err := out.Write([]byte(";\n")); err != nil {
+			return err
 		}
 	}
-	return buf.String(), nil
+	return nil
 }
 
 // buildTableMap returns a map of table name to create table statements.

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -84,7 +84,6 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 		return "", errors.Wrapf(err, "failed to parse new statement %q", newStmt)
 	}
 
-	var newTableList []ast.Node
 	var newNodeList []ast.Node
 	var inplaceUpdate []ast.Node
 	// inplaceDropNodeList and inplaceAddNodeList are used to handle destructive node updates.
@@ -107,7 +106,7 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 			if !ok {
 				stmt := *newStmt
 				stmt.IfNotExists = true
-				newTableList = append(newTableList, &stmt)
+				newNodeList = append(newNodeList, &stmt)
 				continue
 			}
 			if alterTableOptionStmt := diffTableOptions(newStmt.Table, oldStmt.Options, newStmt.Options); alterTableOptionStmt != nil {
@@ -393,10 +392,6 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 	if len(dropViewStmt.Tables) > 0 {
 		dropNodeList = append(dropNodeList, dropViewStmt)
 	}
-
-	// We should create table first and then add the constraint such as add foreign key on an other table,
-	// becase mysqldump have not topology sort.
-	newNodeList = append(newTableList, newNodeList...)
 
 	var buf bytes.Buffer
 	_, _ = buf.Write([]byte("SET FOREIGN_KEY_CHECKS=0;\n"))

--- a/plugin/parser/differ/mysql/differ_test.go
+++ b/plugin/parser/differ/mysql/differ_test.go
@@ -78,3 +78,22 @@ func TestExtractUnsupportObjNameAndType(t *testing.T) {
 		a.Equal(test.wantName, gotName)
 	}
 }
+
+type testCase struct {
+	old  string
+	new  string
+	want string
+}
+
+func testDiffWithoutDisableForeignKeyCheck(t *testing.T, testCases []testCase) {
+	a := require.New(t)
+	mysqlDiffer := &SchemaDiffer{}
+	disableFK := "SET FOREIGN_KEY_CHECKS=0;\n"
+	for _, test := range testCases {
+		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
+		a.NoError(err)
+		a.Equal(disableFK, out[:len(disableFK)])
+		trimPrefix := out[len(disableFK):]
+		a.Equalf(test.want, trimPrefix, "old: %s\nnew: %s\n", test.old, test.new)
+	}
+}

--- a/plugin/parser/differ/mysql/table_test.go
+++ b/plugin/parser/differ/mysql/table_test.go
@@ -35,6 +35,14 @@ func TestTable(t *testing.T) {
 			`,
 			want: "",
 		},
+		{
+			old: `CREATE TABLE book(id INT);`,
+			new: `CREATE TABLE book(id INT, price_id DECIMAL(10,2), CONSTRAINT FOREIGN KEY fk_price (price_id) REFERENCES price(amount));
+			CREATE TABLE price(id INT PRIMARY KEY, amount DECIMAL(10,2));`,
+			want: "CREATE TABLE IF NOT EXISTS `price` (`id` INT PRIMARY KEY,`amount` DECIMAL(10,2));\n" +
+				"ALTER TABLE `book` ADD COLUMN (`price_id` DECIMAL(10,2));\n" +
+				"ALTER TABLE `book` ADD CONSTRAINT `fk_price` FOREIGN KEY (`price_id`) REFERENCES `price`(`amount`);\n",
+		},
 	}
 	a := require.New(t)
 	mysqlDiffer := &SchemaDiffer{}

--- a/plugin/parser/differ/mysql/table_test.go
+++ b/plugin/parser/differ/mysql/table_test.go
@@ -4,15 +4,10 @@ import (
 	"testing"
 
 	_ "github.com/pingcap/tidb/types/parser_driver"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTable(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: ``,
 			new: `CREATE TABLE book(id INT, price INT, PRIMARY KEY(id));
@@ -35,30 +30,12 @@ func TestTable(t *testing.T) {
 			`,
 			want: "",
 		},
-		{
-			old: `CREATE TABLE book(id INT);`,
-			new: `CREATE TABLE book(id INT, price_id DECIMAL(10,2), CONSTRAINT FOREIGN KEY fk_price (price_id) REFERENCES price(amount));
-			CREATE TABLE price(id INT PRIMARY KEY, amount DECIMAL(10,2));`,
-			want: "CREATE TABLE IF NOT EXISTS `price` (`id` INT PRIMARY KEY,`amount` DECIMAL(10,2));\n" +
-				"ALTER TABLE `book` ADD COLUMN (`price_id` DECIMAL(10,2));\n" +
-				"ALTER TABLE `book` ADD CONSTRAINT `fk_price` FOREIGN KEY (`price_id`) REFERENCES `price`(`amount`);\n",
-		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equal(test.want, out)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestTableOption(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		// AUTO_INCREMENT
 		{
 			old:  `CREATE TABLE book(id INT AUTO_INCREMENT, CONSTRAINT PRIMARY KEY(id)) AUTO_INCREMENT = 4;`,
@@ -269,22 +246,11 @@ func TestTableOption(t *testing.T) {
 			want: "ALTER TABLE `book` UNION = (`book2`,`book3`);\n",
 		},
 	}
-	t.Parallel()
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestView(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old:  `CREATE VIEW book AS SELECT * FROM book;`,
 			new:  `CREATE VIEW book AS SELECT * FROM book2;`,
@@ -349,12 +315,5 @@ func TestView(t *testing.T) {
 				"CREATE OR REPLACE ALGORITHM = UNDEFINED DEFINER = CURRENT_USER SQL SECURITY DEFINER VIEW `b` AS SELECT `a_id` AS `b_id` FROM `a`;\n",
 		},
 	}
-	t.Parallel()
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }

--- a/plugin/parser/differ/mysql/unsupport_object_test.go
+++ b/plugin/parser/differ/mysql/unsupport_object_test.go
@@ -2,16 +2,10 @@ package mysql
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestTrigger(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: `CREATE TABLE account(acct_num INT, amount DECIMAL(10,2));` +
 				"CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = @sum + NEW.amount;",
@@ -22,21 +16,11 @@ func TestTrigger(t *testing.T) {
 				"CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = sum + NEW.amount * NEW.price;\n",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestFunction(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: "DELIMITER ;;\n" +
 				"CREATE DEFINER=`root`@`%` FUNCTION `AddOne`(v INT) RETURNS int\n" +
@@ -51,21 +35,11 @@ func TestFunction(t *testing.T) {
 				"BEGIN   DECLARE a INT;   SET a = v;   SET a = a * 1 + 1;   RETURN a; END ;;\n",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestProcedure(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: "DELIMITER ;;\n" +
 				"CREATE DEFINER=`admin`@`localhost` PROCEDURE `account_count`()\n" +
@@ -89,21 +63,11 @@ func TestProcedure(t *testing.T) {
 				"END ;;\n",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }
 
 func TestEvent(t *testing.T) {
-	tests := []struct {
-		old  string
-		new  string
-		want string
-	}{
+	tests := []testCase{
 		{
 			old: "DELIMITER ;;\n" +
 				"CREATE DEFINER=`root`@`%` EVENT `e_daily` ON SCHEDULE EVERY 1 DAY STARTS '2022-10-19 10:10:42' ON COMPLETION NOT PRESERVE ENABLE COMMENT 'Saves total number of sessions then clears the table each day' DO BEGIN\n" +
@@ -126,11 +90,5 @@ func TestEvent(t *testing.T) {
 				"END ;;\n",
 		},
 	}
-	a := require.New(t)
-	mysqlDiffer := &SchemaDiffer{}
-	for _, test := range tests {
-		out, err := mysqlDiffer.SchemaDiff(test.old, test.new)
-		a.NoError(err)
-		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
-	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }


### PR DESCRIPTION
mysqldump does not guarantee topological sorting.
Let's say we want to migrate from:
```sql
CREATE TABLE t1(id INT PRIMARY KEY);
```
to:
```sql
CREATE TABLE t1(id INT PRIMARY KEY, t2_id INT, CONSTRAINT FOREIGN KEY(t2_id) REFERENCES t2(id));
CREATE TABLE t2(id INT PRIMARY KEY);
```
Now we generate
```sql
ALTER TABLE t1 ADD COLUMN(t2_id INT);
ALTER TABLE t1 ADD CONSTRAINT FOREIGN KEY (t2_id) REFERENCES t2(id);
CREATE TABLE t2(id INT PRIMARY KEY);
```
We will encounter an error because there is no table t2.

We can use `SET FOREIGN_KEY_CHECKS=0;` to handle this problem like mysqldump does.