### PR TITLE
fix: disallow SchemaRuleIndexKeyNumberLimit for PostgreSQL

### DIFF
--- a/frontend/src/types/sql-review-schema.yaml
+++ b/frontend/src/types/sql-review-schema.yaml
@@ -361,7 +361,6 @@ ruleList:
     engineList:
       - MYSQL
       - TIDB
-      - POSTGRES
     componentList:
       - key: number
         payload:

--- a/plugin/advisor/sql_review.go
+++ b/plugin/advisor/sql_review.go
@@ -822,7 +822,7 @@ func getAdvisorTypeByRule(ruleType SQLReviewRuleType, engine db.Type) (Type, err
 		}
 	case SchemaRuleIndexKeyNumberLimit:
 		switch engine {
-		case db.MySQL, db.TiDB, db.Postgres:
+		case db.MySQL, db.TiDB:
 			return MySQLIndexKeyNumberLimit, nil
 		}
 	case SchemaRuleIndexTotalNumberLimit:


### PR DESCRIPTION
We will publish the PostgreSQL SQL review rule in the future.