### PR TITLE
feat: bulk insert task check run

### DIFF
--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -50,7 +50,7 @@ func (s *Server) ScheduleActiveStage(ctx context.Context, pipeline *api.Pipeline
 func (s *Server) schedulePipelineTaskCheck(ctx context.Context, pipeline *api.Pipeline) error {
 	for _, stage := range pipeline.StageList {
 		for _, task := range stage.TaskList {
-			if _, err := s.TaskCheckScheduler.ScheduleCheckIfNeeded(ctx, task, api.SystemBotID); err != nil {
+			if _, err := s.TaskCheckScheduler.ScheduleCheck(ctx, task, api.SystemBotID); err != nil {
 				return errors.Wrapf(err, "failed to schedule task check for task %d", task.ID)
 			}
 		}

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -48,12 +48,18 @@ func (s *Server) ScheduleActiveStage(ctx context.Context, pipeline *api.Pipeline
 }
 
 func (s *Server) schedulePipelineTaskCheck(ctx context.Context, pipeline *api.Pipeline) error {
+	var createList []*api.TaskCheckRunCreate
 	for _, stage := range pipeline.StageList {
 		for _, task := range stage.TaskList {
-			if _, err := s.TaskCheckScheduler.ScheduleCheck(ctx, task, api.SystemBotID); err != nil {
-				return errors.Wrapf(err, "failed to schedule task check for task %d", task.ID)
+			create, err := s.TaskCheckScheduler.getTaskCheck(ctx, task, api.SystemBotID)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get task check for task %d", task.ID)
 			}
+			createList = append(createList, create...)
 		}
+	}
+	if _, err := s.store.BulkCreateTaskCheckRun(ctx, createList); err != nil {
+		return errors.Wrap(err, "failed to bulk insert TaskCheckRunCreate")
 	}
 	return nil
 }

--- a/server/task.go
+++ b/server/task.go
@@ -240,7 +240,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("Task not found with ID %d", taskID))
 		}
 
-		taskUpdated, err := s.TaskCheckScheduler.ScheduleCheckIfNeeded(ctx, task, c.Get(getPrincipalIDContextKey()).(int))
+		taskUpdated, err := s.TaskCheckScheduler.ScheduleCheck(ctx, task, c.Get(getPrincipalIDContextKey()).(int))
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to run task check \"%v\"", task.Name)).SetInternal(err)
 		}

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -178,26 +178,35 @@ func (s *TaskCheckScheduler) Register(taskType api.TaskCheckType, executor TaskC
 	s.executors[taskType] = executor
 }
 
-// ScheduleCheck schedules variouse task checks depending on the task type.
-func (s *TaskCheckScheduler) ScheduleCheck(ctx context.Context, task *api.Task, creatorID int) (*api.Task, error) {
-	if err := s.scheduleLGTMTaskCheck(ctx, task, creatorID); err != nil {
+func (s *TaskCheckScheduler) getTaskCheck(ctx context.Context, task *api.Task, creatorID int) ([]*api.TaskCheckRunCreate, error) {
+	var createList []*api.TaskCheckRunCreate
+
+	if create, err := s.getLGTMTaskCheck(ctx, task, creatorID); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule LGTM task check")
+	} else {
+		createList = append(createList, create)
 	}
 
-	if err := s.schedulePITRTaskCheck(ctx, task, creatorID); err != nil {
+	if create, err := s.getPITRTaskCheck(ctx, task, creatorID); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule backup/PITR task check")
+	} else {
+		createList = append(createList, create)
 	}
 
 	if task.Type != api.TaskDatabaseSchemaUpdate && task.Type != api.TaskDatabaseSchemaUpdateSDL && task.Type != api.TaskDatabaseDataUpdate && task.Type != api.TaskDatabaseSchemaUpdateGhostSync {
-		return task, nil
+		return createList, nil
 	}
 
-	if err := s.scheduleGeneralTaskCheck(ctx, task, creatorID); err != nil {
+	if create, err := s.getGeneralTaskCheck(ctx, task, creatorID); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule general task check")
+	} else {
+		createList = append(createList, create...)
 	}
 
-	if err := s.scheduleGhostTaskCheck(ctx, task, creatorID); err != nil {
+	if create, err := s.getGhostTaskCheck(ctx, task, creatorID); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule gh-ost task check")
+	} else {
+		createList = append(createList, create)
 	}
 
 	statement, err := s.getStatement(task)
@@ -212,27 +221,38 @@ func (s *TaskCheckScheduler) ScheduleCheck(ctx context.Context, task *api.Task, 
 		return nil, errors.Errorf("database ID not found %v", task.DatabaseID)
 	}
 
-	if err := s.scheduleSyntaxCheckTaskCheck(ctx, task, creatorID, database, statement); err != nil {
+	if create, err := s.getSyntaxCheckTaskCheck(ctx, task, creatorID, database, statement); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule syntax check task check")
+	} else {
+		createList = append(createList, create)
 	}
 
-	if err := s.scheduleSQLReviewTaskCheck(ctx, task, creatorID, database, statement); err != nil {
+	if create, err := s.getSQLReviewTaskCheck(ctx, task, creatorID, database, statement); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule SQL review task check")
+	} else {
+		createList = append(createList, create)
 	}
 
-	if err := s.scheduleStmtTypeTaskCheck(ctx, task, creatorID, database, statement); err != nil {
+	if create, err := s.getStmtTypeTaskCheck(ctx, task, creatorID, database, statement); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule statement type task check")
+	} else {
+		createList = append(createList, create)
 	}
 
-	taskCheckRunFind := &api.TaskCheckRunFind{
-		TaskID: &task.ID,
+	return createList, nil
+}
+
+// ScheduleCheck schedules variouse task checks depending on the task type.
+func (s *TaskCheckScheduler) ScheduleCheck(ctx context.Context, task *api.Task, creatorID int) (*api.Task, error) {
+	createList, err := s.getTaskCheck(ctx, task, creatorID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to getTaskCheck")
 	}
-	taskCheckRunList, err := s.server.store.FindTaskCheckRun(ctx, taskCheckRunFind)
+	taskCheckRunList, err := s.server.store.BulkCreateTaskCheckRun(ctx, createList)
 	if err != nil {
 		return nil, err
 	}
 	task.TaskCheckRunList = taskCheckRunList
-
 	return task, err
 }
 
@@ -267,9 +287,9 @@ func (*TaskCheckScheduler) getStatement(task *api.Task) (string, error) {
 	}
 }
 
-func (s *TaskCheckScheduler) scheduleStmtTypeTaskCheck(ctx context.Context, task *api.Task, creatorID int, database *api.Database, statement string) error {
+func (s *TaskCheckScheduler) getStmtTypeTaskCheck(ctx context.Context, task *api.Task, creatorID int, database *api.Database, statement string) (*api.TaskCheckRunCreate, error) {
 	if !api.IsStatementTypeCheckSupported(database.Instance.Engine) {
-		return nil
+		return nil, nil
 	}
 	payload, err := json.Marshal(api.TaskCheckDatabaseStatementTypePayload{
 		Statement: statement,
@@ -278,26 +298,23 @@ func (s *TaskCheckScheduler) scheduleStmtTypeTaskCheck(ctx context.Context, task
 		Collation: database.Collation,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to marshal statement type payload: %v", task.Name)
+		return nil, errors.Wrapf(err, "failed to marshal statement type payload: %v", task.Name)
 	}
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+	return &api.TaskCheckRunCreate{
 		CreatorID: creatorID,
 		TaskID:    task.ID,
 		Type:      api.TaskCheckDatabaseStatementType,
 		Payload:   string(payload),
-	}); err != nil {
-		return err
-	}
-	return nil
+	}, nil
 }
 
-func (s *TaskCheckScheduler) scheduleSQLReviewTaskCheck(ctx context.Context, task *api.Task, creatorID int, database *api.Database, statement string) error {
+func (s *TaskCheckScheduler) getSQLReviewTaskCheck(ctx context.Context, task *api.Task, creatorID int, database *api.Database, statement string) (*api.TaskCheckRunCreate, error) {
 	if !api.IsSQLReviewSupported(database.Instance.Engine, s.server.profile.Mode) {
-		return nil
+		return nil, nil
 	}
 	policyID, err := s.server.store.GetSQLReviewPolicyIDByEnvID(ctx, task.Instance.EnvironmentID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get SQL review policy ID for task: %v, in environment: %v", task.Name, task.Instance.EnvironmentID)
+		return nil, errors.Wrapf(err, "failed to get SQL review policy ID for task: %v, in environment: %v", task.Name, task.Instance.EnvironmentID)
 	}
 	payload, err := json.Marshal(api.TaskCheckDatabaseStatementAdvisePayload{
 		Statement: statement,
@@ -307,22 +324,19 @@ func (s *TaskCheckScheduler) scheduleSQLReviewTaskCheck(ctx context.Context, tas
 		PolicyID:  policyID,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to marshal statement advise payload: %v", task.Name)
+		return nil, errors.Wrapf(err, "failed to marshal statement advise payload: %v", task.Name)
 	}
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+	return &api.TaskCheckRunCreate{
 		CreatorID: creatorID,
 		TaskID:    task.ID,
 		Type:      api.TaskCheckDatabaseStatementAdvise,
 		Payload:   string(payload),
-	}); err != nil {
-		return err
-	}
-	return nil
+	}, nil
 }
 
-func (s *TaskCheckScheduler) scheduleSyntaxCheckTaskCheck(ctx context.Context, task *api.Task, creatorID int, database *api.Database, statement string) error {
+func (s *TaskCheckScheduler) getSyntaxCheckTaskCheck(ctx context.Context, task *api.Task, creatorID int, database *api.Database, statement string) (*api.TaskCheckRunCreate, error) {
 	if !api.IsSyntaxCheckSupported(database.Instance.Engine, s.server.profile.Mode) {
-		return nil
+		return nil, nil
 	}
 	payload, err := json.Marshal(api.TaskCheckDatabaseStatementAdvisePayload{
 		Statement: statement,
@@ -331,91 +345,74 @@ func (s *TaskCheckScheduler) scheduleSyntaxCheckTaskCheck(ctx context.Context, t
 		Collation: database.Collation,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to marshal statement advise payload: %v", task.Name)
+		return nil, errors.Wrapf(err, "failed to marshal statement advise payload: %v", task.Name)
 	}
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+	return &api.TaskCheckRunCreate{
 		CreatorID: creatorID,
 		TaskID:    task.ID,
 		Type:      api.TaskCheckDatabaseStatementSyntax,
 		Payload:   string(payload),
-	}); err != nil {
-		return err
-	}
-	return nil
+	}, nil
 }
 
-func (s *TaskCheckScheduler) scheduleGeneralTaskCheck(ctx context.Context, task *api.Task, creatorID int) error {
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
-		CreatorID: creatorID,
-		TaskID:    task.ID,
-		Type:      api.TaskCheckDatabaseConnect,
-	}); err != nil {
-		return err
-	}
-
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
-		CreatorID: creatorID,
-		TaskID:    task.ID,
-		Type:      api.TaskCheckInstanceMigrationSchema,
-	}); err != nil {
-		return err
-	}
-
-	return nil
+func (s *TaskCheckScheduler) getGeneralTaskCheck(ctx context.Context, task *api.Task, creatorID int) ([]*api.TaskCheckRunCreate, error) {
+	return []*api.TaskCheckRunCreate{
+		{
+			CreatorID: creatorID,
+			TaskID:    task.ID,
+			Type:      api.TaskCheckDatabaseConnect,
+		},
+		{
+			CreatorID: creatorID,
+			TaskID:    task.ID,
+			Type:      api.TaskCheckInstanceMigrationSchema,
+		},
+	}, nil
 }
 
-func (s *TaskCheckScheduler) scheduleGhostTaskCheck(ctx context.Context, task *api.Task, creatorID int) error {
+func (s *TaskCheckScheduler) getGhostTaskCheck(ctx context.Context, task *api.Task, creatorID int) (*api.TaskCheckRunCreate, error) {
 	if task.Type != api.TaskDatabaseSchemaUpdateGhostSync {
-		return nil
+		return nil, nil
 	}
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+	return &api.TaskCheckRunCreate{
 		CreatorID: creatorID,
 		TaskID:    task.ID,
 		Type:      api.TaskCheckGhostSync,
-	}); err != nil {
-		return err
-	}
-	return nil
+	}, nil
 }
 
-func (s *TaskCheckScheduler) schedulePITRTaskCheck(ctx context.Context, task *api.Task, creatorID int) error {
+func (s *TaskCheckScheduler) getPITRTaskCheck(ctx context.Context, task *api.Task, creatorID int) (*api.TaskCheckRunCreate, error) {
 	if task.Type != api.TaskDatabaseRestorePITRRestore {
-		return nil
+		return nil, nil
 	}
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+	return &api.TaskCheckRunCreate{
 		CreatorID: creatorID,
 		TaskID:    task.ID,
 		Type:      api.TaskCheckPITRMySQL,
-	}); err != nil {
-		return err
-	}
-	return nil
+	}, nil
 }
 
-func (s *TaskCheckScheduler) scheduleLGTMTaskCheck(ctx context.Context, task *api.Task, creatorID int) error {
+func (s *TaskCheckScheduler) getLGTMTaskCheck(ctx context.Context, task *api.Task, creatorID int) (*api.TaskCheckRunCreate, error) {
 	if !s.server.feature(api.FeatureLGTM) {
-		return nil
+		return nil, nil
 	}
 	issue, err := s.server.store.GetIssueByPipelineID(ctx, task.PipelineID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if issue == nil {
 		// skip if no containing issue.
-		return nil
+		return nil, nil
 	}
 	if issue.Project.LGTMCheckSetting.Value == api.LGTMValueDisabled {
 		// don't schedule LGTM check if it's disabled.
-		return nil
+		return nil, nil
 	}
-	if _, err := s.server.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
+	return &api.TaskCheckRunCreate{
 		CreatorID: creatorID,
 		TaskID:    task.ID,
 		Type:      api.TaskCheckIssueLGTM,
-	}); err != nil {
-		return err
-	}
-	return nil
+	}, nil
 }
 
 // Returns true only if the task check run result is at least the minimum required level.

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -178,8 +178,8 @@ func (s *TaskCheckScheduler) Register(taskType api.TaskCheckType, executor TaskC
 	s.executors[taskType] = executor
 }
 
-// ScheduleCheckIfNeeded schedules a check if needed.
-func (s *TaskCheckScheduler) ScheduleCheckIfNeeded(ctx context.Context, task *api.Task, creatorID int) (*api.Task, error) {
+// ScheduleCheck schedules variouse task checks depending on the task type.
+func (s *TaskCheckScheduler) ScheduleCheck(ctx context.Context, task *api.Task, creatorID int) (*api.Task, error) {
 	if err := s.scheduleLGTMTaskCheck(ctx, task, creatorID); err != nil {
 		return nil, errors.Wrap(err, "failed to schedule LGTM task check")
 	}

--- a/server/task_check_scheduler.go
+++ b/server/task_check_scheduler.go
@@ -239,7 +239,13 @@ func (s *TaskCheckScheduler) getTaskCheck(ctx context.Context, task *api.Task, c
 		createList = append(createList, create)
 	}
 
-	return createList, nil
+	var res []*api.TaskCheckRunCreate
+	for _, create := range createList {
+		if create != nil {
+			res = append(res, create)
+		}
+	}
+	return res, nil
 }
 
 // ScheduleCheck schedules variouse task checks depending on the task type.

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -284,7 +284,8 @@ func (*Store) bulkCreateTaskCheckRunImpl(ctx context.Context, tx *Tx, creates []
 		if i == len(creates)-1 {
 			delimiter = ""
 		}
-		fmt.Fprintf(&query, "($%d, $%d, $%d, 'RUNNING', $%d, $%d, $%d)%s\n", i*6+1, i*6+2, i*6+3, i*6+4, i*6+5, i*6+6, delimiter)
+		const count = 6
+		fmt.Fprintf(&query, "($%d, $%d, $%d, 'RUNNING', $%d, $%d, $%d)%s\n", i*count+1, i*count+2, i*count+3, i*count+4, i*count+5, i*count+6, delimiter)
 	}
 	query.WriteString(`RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, status, type, code, comment, result, payload`)
 

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -266,9 +266,8 @@ func (*Store) bulkCreateTaskCheckRunImpl(ctx context.Context, tx *Tx, creates []
 			status,
 			type,
 			comment,
-			payload
-      VALUES
-		)`)
+			payload) VALUES
+      `)
 	for i, create := range creates {
 		if create.Payload == "" {
 			create.Payload = "{}"
@@ -281,7 +280,11 @@ func (*Store) bulkCreateTaskCheckRunImpl(ctx context.Context, tx *Tx, creates []
 			create.Comment,
 			create.Payload,
 		)
-		fmt.Fprintf(&query, "($%d, $%d, $%d, 'RUNNING', $%d, $%d, $%d)\n", i*6+1, i*6+2, i*6+3, i*6+4, i*6+5, i*6+6)
+		delimiter := ","
+		if i == len(creates)-1 {
+			delimiter = ""
+		}
+		fmt.Fprintf(&query, "($%d, $%d, $%d, 'RUNNING', $%d, $%d, $%d)%s\n", i*6+1, i*6+2, i*6+3, i*6+4, i*6+5, i*6+6, delimiter)
 	}
 	query.WriteString(`RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, status, type, code, comment, result, payload`)
 

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -75,6 +75,23 @@ func (s *Store) CreateTaskCheckRunIfNeeded(ctx context.Context, create *api.Task
 	return taskCheckRun, nil
 }
 
+// BulkCreateTaskCheckRun inserts many TaskCheckRun instances, which is too slow otherwise to insert one by one.
+func (s *Store) BulkCreateTaskCheckRun(ctx context.Context, creates []*api.TaskCheckRunCreate) ([]*api.TaskCheckRun, error) {
+	taskCheckRunRawList, err := s.bulkCreateTaskCheckRunRaw(ctx, creates)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create TaskCheckRun with TaskCheckRunCreates[%+v]", creates)
+	}
+	var taskCheckRunList []*api.TaskCheckRun
+	for _, taskCheckRunRaw := range taskCheckRunRawList {
+		taskCheckRun, err := s.composeTaskCheckRun(ctx, taskCheckRunRaw)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to compose TaskCheckRun with taskCheckRunRaw[%+v]", taskCheckRunRaw)
+		}
+		taskCheckRunList = append(taskCheckRunList, taskCheckRun)
+	}
+	return taskCheckRunList, nil
+}
+
 // FindTaskCheckRun finds a list of TaskCheckRun instances.
 func (s *Store) FindTaskCheckRun(ctx context.Context, find *api.TaskCheckRunFind) ([]*api.TaskCheckRun, error) {
 	taskCheckRunRawList, err := s.findTaskCheckRunRaw(ctx, find)
@@ -171,6 +188,25 @@ func (s *Store) createTaskCheckRunRawIfNeeded(ctx context.Context, create *api.T
 	return taskCheckRun, nil
 }
 
+func (s *Store) bulkCreateTaskCheckRunRaw(ctx context.Context, creates []*api.TaskCheckRunCreate) ([]*taskCheckRunRaw, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, FormatError(err)
+	}
+	defer tx.Rollback()
+
+	taskCheckRunList, err := s.bulkCreateTaskCheckRunImpl(ctx, tx, creates)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, FormatError(err)
+	}
+
+	return taskCheckRunList, nil
+}
+
 // createTaskCheckRunImpl creates a new taskCheckRun.
 func (*Store) createTaskCheckRunImpl(ctx context.Context, tx *Tx, create *api.TaskCheckRunCreate) (*taskCheckRunRaw, error) {
 	if create.Payload == "" {
@@ -217,6 +253,70 @@ func (*Store) createTaskCheckRunImpl(ctx context.Context, tx *Tx, create *api.Ta
 		return nil, FormatError(err)
 	}
 	return &taskCheckRunRaw, nil
+}
+
+func (*Store) bulkCreateTaskCheckRunImpl(ctx context.Context, tx *Tx, creates []*api.TaskCheckRunCreate) ([]*taskCheckRunRaw, error) {
+	var query strings.Builder
+	var values []interface{}
+	query.WriteString(
+		`INSERT INTO task_check_run (
+			creator_id,
+			updater_id,
+			task_id,
+			status,
+			type,
+			comment,
+			payload
+      VALUES
+		)`)
+	for i, create := range creates {
+		if create.Payload == "" {
+			create.Payload = "{}"
+		}
+		values = append(values,
+			create.CreatorID,
+			create.CreatorID,
+			create.TaskID,
+			create.Type,
+			create.Comment,
+			create.Payload,
+		)
+		fmt.Fprintf(&query, "($%d, $%d, $%d, 'RUNNING', $%d, $%d, $%d)\n", i*6+1, i*6+2, i*6+3, i*6+4, i*6+5, i*6+6)
+	}
+	query.WriteString(`RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, status, type, code, comment, result, payload`)
+
+	log.Debug("query", zap.String("query", query.String()))
+
+	var taskCheckRunRawList []*taskCheckRunRaw
+	rows, err := tx.QueryContext(ctx, query.String(), values...)
+	if err != nil {
+		return nil, FormatError(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var taskCheckRunRaw taskCheckRunRaw
+		if err := rows.Scan(
+			&taskCheckRunRaw.ID,
+			&taskCheckRunRaw.CreatorID,
+			&taskCheckRunRaw.CreatedTs,
+			&taskCheckRunRaw.UpdaterID,
+			&taskCheckRunRaw.UpdatedTs,
+			&taskCheckRunRaw.TaskID,
+			&taskCheckRunRaw.Status,
+			&taskCheckRunRaw.Type,
+			&taskCheckRunRaw.Code,
+			&taskCheckRunRaw.Comment,
+			&taskCheckRunRaw.Result,
+			&taskCheckRunRaw.Payload,
+		); err != nil {
+			return nil, FormatError(err)
+		}
+		taskCheckRunRawList = append(taskCheckRunRawList, &taskCheckRunRaw)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, FormatError(err)
+	}
+	return taskCheckRunRawList, nil
 }
 
 // findTaskCheckRunRaw retrieves a list of taskCheckRuns based on find.

--- a/store/task_check_run.go
+++ b/store/task_check_run.go
@@ -288,8 +288,6 @@ func (*Store) bulkCreateTaskCheckRunImpl(ctx context.Context, tx *Tx, creates []
 	}
 	query.WriteString(`RETURNING id, creator_id, created_ts, updater_id, updated_ts, task_id, status, type, code, comment, result, payload`)
 
-	log.Debug("query", zap.String("query", query.String()))
-
 	var taskCheckRunRawList []*taskCheckRunRaw
 	rows, err := tx.QueryContext(ctx, query.String(), values...)
 	if err != nil {


### PR DESCRIPTION
We insert task check runs for every task of every stage in an issue before. It's too slow and may leave some tasks without any task check if the frontend timeouts and cancels the insertion.

This PR collects all `TaskCheckRunCreate` and inserts them together, which can mitigate the problem.

Completing BYT-1671