### PR TITLE
fix: diable foreign key checks after diff SQL

### DIFF
--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -43,6 +43,7 @@ const (
 )
 const (
 	disableFKCheckStmt string = "SET FOREIGN_KEY_CHECKS=0;\n"
+	enableFKCheckStmt  string = "SET FOREIGN_KEY_CHECKS=1;\n"
 )
 
 // SchemaDiffer it the parser for MySQL dialect.
@@ -404,7 +405,7 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 		return "", errors.Wrapf(err, "deparse failed")
 	}
 	if buf.Len() > 0 {
-		return fmt.Sprintf("%s%s", disableFKCheckStmt, buf.String()), nil
+		return fmt.Sprintf("%s%s%s", disableFKCheckStmt, buf.String(), enableFKCheckStmt), nil
 	}
 	return "", nil
 }

--- a/plugin/parser/differ/mysql/differ_test.go
+++ b/plugin/parser/differ/mysql/differ_test.go
@@ -94,6 +94,8 @@ func testDiffWithoutDisableForeignKeyCheck(t *testing.T, testCases []testCase) {
 		if len(out) > 0 {
 			a.Equal(disableFKCheckStmt, out[:len(disableFKCheckStmt)])
 			out = out[len(disableFKCheckStmt):]
+			a.Equal(enableFKCheckStmt, out[len(out)-len(enableFKCheckStmt):])
+			out = out[:len(out)-len(enableFKCheckStmt)]
 		}
 		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
 	}


### PR DESCRIPTION
We introduce disabled foreign key check statement in #3091. We use `go-sql-driver` as our MySQL driver, and [it uses `go/sql`'s connection pool](https://github.com/go-sql-driver/mysql#connection-pool-and-timeouts). We should enable foreign key check after running diff SQLs. 