### PR TITLE
fix: running DROP TRIGGER/EVENT/PROCEDURE/FUNCTION in DDL issue

### DIFF
--- a/plugin/parser/utils.go
+++ b/plugin/parser/utils.go
@@ -116,10 +116,16 @@ func isTiDBUnsupportDDLStmt(stmt string) bool {
 		"FUNCTION",
 		"PROCEDURE",
 	}
-	regexFmt := "(?i)^CREATE\\s+(DEFINER=`(.)+`@`(.)+`(\\s)+)?%s\\s+"
+	createRegexFmt := "(?i)^\\s*CREATE\\s+(DEFINER=`(.)+`@`(.)+`(\\s)+)?%s\\s+"
+	dropRegexFmt := "(?i)^\\s*DROP\\s+%s\\s+"
 	for _, obj := range objects {
-		regex := fmt.Sprintf(regexFmt, obj)
-		re := regexp.MustCompile(regex)
+		createRegexp := fmt.Sprintf(createRegexFmt, obj)
+		re := regexp.MustCompile(createRegexp)
+		if re.MatchString(stmt) {
+			return true
+		}
+		dropRegexp := fmt.Sprintf(dropRegexFmt, obj)
+		re = regexp.MustCompile(dropRegexp)
 		if re.MatchString(stmt) {
 			return true
 		}
@@ -129,7 +135,7 @@ func isTiDBUnsupportDDLStmt(stmt string) bool {
 
 // IsDelimiter returns true if the statement is a delimiter statement.
 func IsDelimiter(stmt string) bool {
-	delimiterRegex := `(?i)^DELIMITER\s+`
+	delimiterRegex := `(?i)^\s*DELIMITER\s+`
 	re := regexp.MustCompile(delimiterRegex)
 	return re.MatchString(stmt)
 }

--- a/plugin/parser/utils_test.go
+++ b/plugin/parser/utils_test.go
@@ -61,6 +61,14 @@ func TestIsTiDBUnsupportStmt(t *testing.T) {
 			want: true,
 		},
 		{
+			stmt: "DROP TRIGGER `ins_sum`;",
+			want: true,
+		},
+		{
+			stmt: "DROP TRIGGER IF EXISTS `ins_sum`;",
+			want: true,
+		},
+		{
 			stmt: "CREATE TABLE t1(id INT, name VARCHAR(50), price DECIMAL(10,2), CONSTRAINT PRIMARY KEY(50), INDEX idx_name(name);",
 			want: false,
 		},


### PR DESCRIPTION
After #3084, we allow users to run `CREATE TRIGGER/EVENT/PROCEDURE/FUNCTION` statement in Bytebase DDL issues. Also, we should allow users to run the corresponding `DROP` statement.