### PR TITLE
chore: create activity in batch

### DIFF
--- a/server/activity_manager.go
+++ b/server/activity_manager.go
@@ -60,14 +60,9 @@ func (m *ActivityManager) BatchCreateTaskStatusUpdateApprovalActivity(ctx contex
 		createList = append(createList, activityCreate)
 	}
 
-	// TODO(d): change to batch create.
-	var activityList []*api.Activity
-	for _, create := range createList {
-		activity, err := m.store.CreateActivity(ctx, create)
-		if err != nil {
-			return err
-		}
-		activityList = append(activityList, activity)
+	activityList, err := m.store.BatchCreateActivity(ctx, createList)
+	if err != nil {
+		return err
 	}
 	if len(activityList) == 0 {
 		return errors.Errorf("failed to create any activity")

--- a/store/activity.go
+++ b/store/activity.go
@@ -165,7 +165,7 @@ func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreat
 	}
 	defer tx.Rollback()
 
-	activityRaw, err := createActivityImpl(ctx, tx, create)
+	activity, err := createActivityImpl(ctx, tx, create)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreat
 		return nil, FormatError(err)
 	}
 
-	return activityRaw, nil
+	return activity, nil
 }
 
 // findActivityRaw retrieves a list of activities based on the find condition.

--- a/store/activity.go
+++ b/store/activity.go
@@ -68,6 +68,26 @@ func (s *Store) CreateActivity(ctx context.Context, create *api.ActivityCreate) 
 	return activity, nil
 }
 
+// BatchCreateActivity creates activities in batch.
+func (s *Store) BatchCreateActivity(ctx context.Context, creates []*api.ActivityCreate) ([]*api.Activity, error) {
+	if len(creates) == 0 {
+		return nil, nil
+	}
+	activityRawList, err := s.batchCreateActivityRaw(ctx, creates)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create TaskCheckRun with TaskCheckRunCreates[%+v]", creates)
+	}
+	var activityList []*api.Activity
+	for _, activityRaw := range activityRawList {
+		activity, err := s.composeActivity(ctx, activityRaw)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to compose activity with activityRaw %+v", activityRaw)
+		}
+		activityList = append(activityList, activity)
+	}
+	return activityList, nil
+}
+
 // GetActivityByID gets an instance of Activity.
 func (s *Store) GetActivityByID(ctx context.Context, id int) (*api.Activity, error) {
 	activityRaw, err := s.getActivityRawByID(ctx, id)
@@ -118,15 +138,14 @@ func (s *Store) PatchActivity(ctx context.Context, patch *api.ActivityPatch) (*a
 // private function
 //
 
-// createActivityRaw creates a new activity.
-func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreate) (*activityRaw, error) {
+func (s *Store) batchCreateActivityRaw(ctx context.Context, creates []*api.ActivityCreate) ([]*activityRaw, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
 	}
 	defer tx.Rollback()
 
-	activity, err := createActivityImpl(ctx, tx, create)
+	activityRawList, err := batchCreateActivityImpl(ctx, tx, creates...)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +154,31 @@ func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreat
 		return nil, FormatError(err)
 	}
 
-	return activity, nil
+	return activityRawList, nil
+}
+
+// createActivityRaw creates a new activity.
+func (s *Store) createActivityRaw(ctx context.Context, create *api.ActivityCreate) (*activityRaw, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, FormatError(err)
+	}
+	defer tx.Rollback()
+
+	activityRawList, err := batchCreateActivityImpl(ctx, tx, create)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, FormatError(err)
+	}
+
+	if len(activityRawList) != 1 {
+		return nil, errors.Errorf("invalid number of activity raw returned %v but expecting one", len(activityRawList))
+	}
+
+	return activityRawList[0], nil
 }
 
 // findActivityRaw retrieves a list of activities based on the find condition.
@@ -216,14 +259,14 @@ func (s *Store) composeActivity(ctx context.Context, raw *activityRaw) (*api.Act
 	return activity, nil
 }
 
-// createActivityImpl creates a new activity.
-func createActivityImpl(ctx context.Context, tx *Tx, create *api.ActivityCreate) (*activityRaw, error) {
-	// Insert row into activity.
-	if create.Payload == "" {
-		create.Payload = "{}"
-	}
-	query := `
-		INSERT INTO activity (
+// batchCreateActivityImpl creates new activities in batch.
+func batchCreateActivityImpl(ctx context.Context, tx *Tx, creates ...*api.ActivityCreate) ([]*activityRaw, error) {
+	var query strings.Builder
+	var values []interface{}
+	var queryValues []string
+
+	if _, err := query.WriteString(
+		`INSERT INTO activity (
 			creator_id,
 			updater_id,
 			container_id,
@@ -231,37 +274,61 @@ func createActivityImpl(ctx context.Context, tx *Tx, create *api.ActivityCreate)
 			level,
 			comment,
 			payload
-		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
-		RETURNING id, creator_id, created_ts, updater_id, updated_ts, container_id, type, level, comment, payload
-	`
-	var activityRaw activityRaw
-	if err := tx.QueryRowContext(ctx, query,
-		create.CreatorID,
-		create.CreatorID,
-		create.ContainerID,
-		create.Type,
-		create.Level,
-		create.Comment,
-		create.Payload,
-	).Scan(
-		&activityRaw.ID,
-		&activityRaw.CreatorID,
-		&activityRaw.CreatedTs,
-		&activityRaw.UpdaterID,
-		&activityRaw.UpdatedTs,
-		&activityRaw.ContainerID,
-		&activityRaw.Type,
-		&activityRaw.Level,
-		&activityRaw.Comment,
-		&activityRaw.Payload,
-	); err != nil {
-		if err == sql.ErrNoRows {
-			return nil, common.FormatDBErrorEmptyRowWithQuery(query)
+		) VALUES
+    `); err != nil {
+		return nil, err
+	}
+	for i, create := range creates {
+		if create.Payload == "" {
+			create.Payload = "{}"
 		}
+		values = append(values,
+			create.CreatorID,
+			create.CreatorID,
+			create.ContainerID,
+			create.Type,
+			create.Level,
+			create.Comment,
+			create.Payload,
+		)
+		const count = 7
+		queryValues = append(queryValues, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d)", i*count+1, i*count+2, i*count+3, i*count+4, i*count+5, i*count+6, i*count+7))
+	}
+	if _, err := query.WriteString(strings.Join(queryValues, ",")); err != nil {
+		return nil, err
+	}
+	if _, err := query.WriteString(` RETURNING id, creator_id, created_ts, updater_id, updated_ts, container_id, type, level, comment, payload`); err != nil {
+		return nil, err
+	}
+
+	var activityRawList []*activityRaw
+	rows, err := tx.QueryContext(ctx, query.String(), values...)
+	if err != nil {
 		return nil, FormatError(err)
 	}
-	return &activityRaw, nil
+	defer rows.Close()
+	for rows.Next() {
+		var activityRaw activityRaw
+		if err := rows.Scan(
+			&activityRaw.ID,
+			&activityRaw.CreatorID,
+			&activityRaw.CreatedTs,
+			&activityRaw.UpdaterID,
+			&activityRaw.UpdatedTs,
+			&activityRaw.ContainerID,
+			&activityRaw.Type,
+			&activityRaw.Level,
+			&activityRaw.Comment,
+			&activityRaw.Payload,
+		); err != nil {
+			return nil, FormatError(err)
+		}
+		activityRawList = append(activityRawList, &activityRaw)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, FormatError(err)
+	}
+	return activityRawList, nil
 }
 
 func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*activityRaw, error) {

--- a/store/task.go
+++ b/store/task.go
@@ -692,7 +692,6 @@ func (s *Store) patchTaskStatusImpl(ctx context.Context, tx *Tx, patch *api.Task
 			taskRunStatusPatch := &api.TaskRunStatusPatch{
 				ID:        &taskRunRaw.ID,
 				UpdaterID: patch.UpdaterID,
-				TaskID:    &id,
 				Code:      patch.Code,
 				Result:    patch.Result,
 				Comment:   patch.Comment,


### PR DESCRIPTION
1. Introduced a batch activity creation function.
2. Removed the where clause for task_id, otherwise we may get transaction conflict.

2022-10-23 00:57:22.721 CST [53872] ERROR:  could not serialize access due to read/write dependencies among transactions
2022-10-23 00:57:22.721 CST [53872] DETAIL:  Reason code: Canceled on identification as a pivot, during write.
2022-10-23 00:57:22.721 CST [53872] HINT:  The transaction might succeed if retried.
2022-10-23 00:57:22.721 CST [53872] STATEMENT:  
			UPDATE task
			SET updater_id = $1, status = $2
			WHERE id in (125) 
			RETURNING id, creator_id, created_ts, updater_id, updated_ts, pipeline_id, stage_id, instance_id, database_id, name, status, type, payload, earliest_allowed_ts
		
2022-10-23T00:57:22.721+0800	ERROR	Failed to change task status.	{"id": 125, "name": "DDL(schema) for \"d5\"", "old_status": "RUNNING", "new_status": "DONE", "error": "failed to change task 125(DDL(schema) for \"d5\") status: failed to patch TaskStatus with TaskStatusPatch[&{IDList:[125] UpdaterID:1 Status:DONE Code:0x14001d42d30 Comment:<nil> Result:0x14001887530}]: ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)", "errorVerbose": "ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)\nfailed to patch TaskStatus with TaskStatusPatch[&{IDList:[125] UpdaterID:1 Status:DONE Code:0x14001d42d30 Comment:<nil> Result:0x14001887530}]\ngithub.com/bytebase/bytebase/store.(*Store).PatchTaskStatus\n\t/Users/danny/src/bytebase/store/task.go:155\ngithub.com/bytebase/bytebase/server.(*Server).patchTaskStatus\n\t/Users/danny/src/bytebase/server/task.go:704\ngithub.com/bytebase/bytebase/server.(*TaskScheduler).Run.func1.3\n\t/Users/danny/src/bytebase/server/task_scheduler.go:253\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.19.2/libexec/src/runtime/asm_arm64.s:1172\nfailed to change task 125(DDL(schema) for \"d5\") status\ngithub.com/bytebase/bytebase/server.(*Server).patchTaskStatus\n\t/Users/danny/src/bytebase/server/task.go:706\ngithub.com/bytebase/bytebase/server.(*TaskScheduler).Run.func1.3\n\t/Users/danny/src/bytebase/server/task_scheduler.go:253\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.19.2/libexec/src/runtime/asm_arm64.s:1172"}
