### PR TITLE
chore: set stats_temp_directory to tmp

### DIFF
--- a/resources/postgres/postgres.go
+++ b/resources/postgres/postgres.go
@@ -109,7 +109,7 @@ func Start(port int, baseDir string, dataDir string, stdout, stderr io.Writer) (
 	// https://www.postgresql.org/docs/current/app-postgres.html
 	p := exec.Command(pgbin, "start", "-w",
 		"-D", dataDir,
-		"-o", fmt.Sprintf(`-p %d -k %s -h ""`, port, common.GetPostgresSocketDir()))
+		"-o", fmt.Sprintf(`-p %d -k %s -h "" -c stats_temp_directory=/tmp`, port, common.GetPostgresSocketDir()))
 
 	p.Stdout = stdout
 	p.Stderr = stderr


### PR DESCRIPTION
This fixes the warning for

could not open statistics file "pg_stat_tmp/global.stat": Operation not permitted