### PR TITLE
feat: support running DELIMITER commands in DDL issue

### DIFF
--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -162,7 +162,7 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 	}
 	defer tx.Rollback()
 
-	_, err = tx.ExecContext(ctx, handledStatement)
+	_, err = tx.ExecContext(ctx, transformedStatement)
 
 	if err == nil {
 		if err := tx.Commit(); err != nil {

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -155,7 +155,7 @@ func (driver *Driver) Execute(ctx context.Context, statement string) error {
 	if err := transformDelimiter(&buf, statement); err != nil {
 		return err
 	}
-	handledStatement := buf.String()
+	transformedStatement := buf.String()
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err

--- a/plugin/db/mysql/mysql_test.go
+++ b/plugin/db/mysql/mysql_test.go
@@ -1,0 +1,87 @@
+package mysql
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformDelimiter(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      string
+	}{
+		{
+			statement: "CREATE TABLE t1(id INT PRIMAR KEY);",
+			want:      "CREATE TABLE t1(id INT PRIMAR KEY);",
+		},
+		{
+			statement: `
+			DELIMITER ;;
+			CREATE DEFINER=root@% TRIGGER upd_film AFTER UPDATE ON film FOR EACH ROW BEGIN
+				IF (old.title != new.title) OR (old.description != new.description) OR (old.film_id != new.film_id)
+				THEN
+					UPDATE film_text
+						SET title=new.title,
+							description=new.description,
+							film_id=new.film_id
+					WHERE film_id=old.film_id;
+				END IF;
+			  END ;;
+			DELIMITER ;
+			`,
+			want: `CREATE DEFINER=root@% TRIGGER upd_film AFTER UPDATE ON film FOR EACH ROW BEGIN
+				IF (old.title != new.title) OR (old.description != new.description) OR (old.film_id != new.film_id)
+				THEN
+					UPDATE film_text
+						SET title=new.title,
+							description=new.description,
+							film_id=new.film_id
+					WHERE film_id=old.film_id;
+				END IF;
+			  END ;`,
+		},
+		{
+			statement: `
+			DELIMITER ;;
+			CREATE DEFINER=root@% TRIGGER upd_film AFTER UPDATE ON film FOR EACH ROW BEGIN
+				IF (old.title != new.title) OR (old.description != new.description) OR (old.film_id != new.film_id)
+				THEN
+					UPDATE film_text
+						SET title=new.title,
+							description=new.description,
+							film_id=new.film_id
+					WHERE film_id=old.film_id;
+				END IF;
+			  END ;;
+			DELIMITER ;
+			CREATE TABLE t1(id INT PRIMAR KEY);
+			DELIMITER ;;
+			CREATE DEFINER=root@% TRIGGER del_film AFTER DELETE ON film FOR EACH ROW BEGIN
+				DELETE FROM film_text WHERE film_id = old.film_id;
+			  END ;;
+			DELIMITER ;
+			`,
+			want: `CREATE DEFINER=root@% TRIGGER upd_film AFTER UPDATE ON film FOR EACH ROW BEGIN
+				IF (old.title != new.title) OR (old.description != new.description) OR (old.film_id != new.film_id)
+				THEN
+					UPDATE film_text
+						SET title=new.title,
+							description=new.description,
+							film_id=new.film_id
+					WHERE film_id=old.film_id;
+				END IF;
+			  END ;CREATE TABLE t1(id INT PRIMAR KEY);CREATE DEFINER=root@% TRIGGER del_film AFTER DELETE ON film FOR EACH ROW BEGIN
+				DELETE FROM film_text WHERE film_id = old.film_id;
+			  END ;`,
+		},
+	}
+	a := require.New(t)
+	for _, test := range tests {
+		var buf bytes.Buffer
+		err := transformDelimiter(&buf, test.statement)
+		a.NoError(err)
+		a.Equal(test.want, buf.String())
+	}
+}

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -359,7 +359,10 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 				delete(oldUnsupportMap[tp], newName)
 				continue
 			}
-			newNodeStmt = append(newNodeStmt, newStmt)
+			// Now, the input of differ comes from the our mysqldump, mysqldump use ;; to separate the CREATE TRIGGER/FUNCTION/PROCEDURE/EVENT statements;
+			// So we should append DELIMITER statement to the newStmt.
+			delimiterNewStmt := fmt.Sprintf("DELIMITER ;;\n%s\nDELIMITER ;\n", newStmt)
+			newNodeStmt = append(newNodeStmt, delimiterNewStmt)
 		}
 	}
 	// drop remaining TiDB unsupported objects

--- a/plugin/parser/utils.go
+++ b/plugin/parser/utils.go
@@ -139,3 +139,15 @@ func IsDelimiter(stmt string) bool {
 	re := regexp.MustCompile(delimiterRegex)
 	return re.MatchString(stmt)
 }
+
+// ExtractDelimiter extracts the delimiter from the delimiter statement.
+func ExtractDelimiter(stmt string) (string, error) {
+	delimiterRegex := `(?i)^\s*DELIMITER\s+(?P<DELIMITER>[^\s\\]+)\s*`
+	re := regexp.MustCompile(delimiterRegex)
+	matchList := re.FindStringSubmatch(stmt)
+	index := re.SubexpIndex("DELIMITER")
+	if index >= 0 && index < len(matchList) {
+		return matchList[index], nil
+	}
+	return "", errors.Errorf("cannot extract delimiter from %q", stmt)
+}

--- a/plugin/parser/utils_test.go
+++ b/plugin/parser/utils_test.go
@@ -118,3 +118,57 @@ func TestIsTiDBUnsupportStmt(t *testing.T) {
 		a.Equalf(test.want, got, "statement: %s\n", test.stmt)
 	}
 }
+
+func TestExtractDelimiter(t *testing.T) {
+	tests := []struct {
+		stmt    string
+		want    string
+		wantErr bool
+	}{
+		{
+			stmt:    "DELIMITER ;;",
+			want:    ";;",
+			wantErr: false,
+		},
+		{
+			stmt:    "DELIMITER //",
+			want:    "//",
+			wantErr: false,
+		},
+		{
+			stmt:    "DELIMITER $$",
+			want:    "$$",
+			wantErr: false,
+		},
+		{
+			stmt:    "DELIMITER    @@   ",
+			want:    "@@",
+			wantErr: false,
+		},
+		{
+			stmt:    "DELIMITER    @@//",
+			want:    "@@//",
+			wantErr: false,
+		},
+		{
+			stmt:    "DELIMITER    @@//",
+			want:    "@@//",
+			wantErr: false,
+		},
+		// DELIMITER cannot contain a backslash character
+		{
+			stmt:    "DELIMITER    \\",
+			wantErr: true,
+		},
+	}
+	a := require.New(t)
+	for _, test := range tests {
+		got, err := ExtractDelimiter(test.stmt)
+		if test.wantErr {
+			a.Error(err)
+		} else {
+			a.NoError(err)
+			a.Equal(test.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Now, the users cannot run DELIMITER commands in the DDL issue, which may cause some problems. For example, the users always use the below format to create the function via MySQL client:
```sql
DELIMITER ;;
CREATE FUNCTION xxx
END ;;
DELIMITER ;
```
But MySQL server side does not support `DELIMITER` command. We can easily replace the delimiter with the default delimiter ';', and then send to the go-sql-driver.

Completing BYT-1679:
<img width="1357" alt="CleanShot 2022-10-25 at 16 36 49@2x" src="https://user-images.githubusercontent.com/87714218/197727106-69bc7d73-084f-4bef-a772-845c0195a60c.png">
