### PR TITLE
feat: parse binlog events from mysqlbinlog output

### DIFF
--- a/plugin/db/mysql/binlog.go
+++ b/plugin/db/mysql/binlog.go
@@ -1,0 +1,265 @@
+package mysql
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type binlogEventType int
+
+const (
+	// DeleteRowsEvent is the binlog event for DELETE.
+	DeleteRowsEvent binlogEventType = iota
+	// UpdateRowsEvent is the binlog event for UPDATE.
+	UpdateRowsEvent
+	// WriteRowsEvent is the binlog event for INSERT.
+	WriteRowsEvent
+	// QueryEvent is the binlog event for QUERY.
+	// The thread ID is parsed from QUERY events.
+	QueryEvent
+)
+
+var (
+	regexpDeleteRow = regexp.MustCompile("DELETE FROM `(.+)`\\.`(.+)`")
+	regexpUpdateRow = regexp.MustCompile("UPDATE `(.+)`\\.`(.+)`")
+	regexpWriteRow  = regexp.MustCompile("INSERT INTO `(.+)`\\.`(.+)`")
+	regexpThreadID  = regexp.MustCompile(`thread_id=(\d+)`)
+)
+
+func (t binlogEventType) String() string {
+	switch t {
+	case DeleteRowsEvent:
+		return "DELETE"
+	case UpdateRowsEvent:
+		return "UPDATE"
+	case WriteRowsEvent:
+		return "INSERT"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func (t binlogEventType) Regexp() *regexp.Regexp {
+	switch t {
+	case DeleteRowsEvent:
+		return regexpDeleteRow
+	case UpdateRowsEvent:
+		return regexpUpdateRow
+	case WriteRowsEvent:
+		return regexpWriteRow
+	default:
+		return nil
+	}
+}
+
+func (t binlogEventType) MinBlockLen() int {
+	switch t {
+	case DeleteRowsEvent:
+		return 3
+	case UpdateRowsEvent:
+		return 5
+	case WriteRowsEvent:
+		return 3
+	default:
+		return -1
+	}
+}
+
+func (t binlogEventType) ParseDMLPayload(block []string) (beforeValue []string, afterValue []string, err error) {
+	block = block[1:]
+	switch t {
+	case DeleteRowsEvent:
+		// Example block:
+		// ### DELETE FROM `database`.`table`
+		// ### WHERE
+		// ###   @1=x
+		//       ...
+		where, err := parseBinlogEventPayloadBlock(block, "WHERE")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the WHERE payload section of the DELETE event")
+		}
+		return where, nil, nil
+	case UpdateRowsEvent:
+		// Example block:
+		// ### UPDATE `database`.`table`
+		// ### WHERE
+		// ###   @1=x
+		//       ...
+		// ### SET
+		// ###   @1=y
+		// 	     ...
+		if len(block)%2 != 0 {
+			return nil, nil, errors.Errorf("invalid UPDATE event block, WHERE clause length != SET clause length: %q", strings.Join(block, "\n"))
+		}
+		where, err := parseBinlogEventPayloadBlock(block[:len(block)/2], "WHERE")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the WHERE payload section of the UPDATE event")
+		}
+		block = block[len(block)/2:]
+		set, err := parseBinlogEventPayloadBlock(block, "SET")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the SET payload section of the UPDATE event")
+		}
+		return where, set, nil
+	case WriteRowsEvent:
+		// Example block:
+		// ## INSERT INTO `database`.`table`
+		// ### SET
+		// ###   @1=x
+		//       ...
+		set, err := parseBinlogEventPayloadBlock(block, "SET")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the SET payload section of the INSERT event")
+		}
+		return nil, set, nil
+	default:
+		return nil, nil, errors.Errorf("invalid DML binlog event type %s", t.String())
+	}
+}
+
+type binlogEvent struct {
+	Type       binlogEventType
+	Database   string
+	Table      string
+	DataBefore [][]string
+	DataAfter  [][]string
+	ThreadID   string
+}
+
+func parseBinlogEvent(binlogText string) (*binlogEvent, error) {
+	lines := strings.Split(binlogText, "\n")
+	if len(lines) < 2 {
+		return nil, errors.Errorf("invalid mysqlbinlog dump string: must be at least 2 lines")
+	}
+	if !strings.HasPrefix(lines[0], "# at") {
+		return nil, errors.Errorf("invalid mysqlbinlog dump string: must starts with \"# at\"")
+	}
+
+	// The second line must contain the event header information.
+	// E.g., "#221017 14:25:24 server id 1  end_log_pos 916 CRC32 0x896854fc 	Write_rows: table id 259 flags: STMT_END_F"
+	header := lines[1]
+
+	var rowEvent *binlogEvent
+	var err error
+	body := lines[2:]
+	if strings.Contains(header, "Delete_rows") {
+		rowEvent, err = parseBinlogEventDML(DeleteRowsEvent, body)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse DELETE event")
+		}
+	} else if strings.Contains(header, "Update_rows") {
+		rowEvent, err = parseBinlogEventDML(UpdateRowsEvent, body)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse UPDATE event")
+		}
+	} else if strings.Contains(header, "Write_rows") {
+		rowEvent, err = parseBinlogEventDML(WriteRowsEvent, body)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse INSERT event")
+		}
+	} else if strings.Contains(header, "Query") {
+		rowEvent, err = parseBinlogEventQuery(header)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse QUERY event")
+		}
+	} else {
+		// The binlog event type is none of DELETE/UPDATE/INSERT. Skip for now.
+		rowEvent = nil
+	}
+
+	return rowEvent, nil
+}
+
+func parseBinlogEventQuery(header string) (*binlogEvent, error) {
+	matches := regexpThreadID.FindStringSubmatch(header)
+	if len(matches) != 2 {
+		return nil, errors.Errorf("failed to parse thread ID from the QUERY event header: %q", header)
+	}
+	return &binlogEvent{
+		Type:     QueryEvent,
+		ThreadID: matches[1],
+	}, nil
+}
+
+func parseBinlogEventDML(eventType binlogEventType, body []string) (*binlogEvent, error) {
+	if len(body) < eventType.MinBlockLen() {
+		return nil, errors.Errorf("invalid %s event body, must be at least %d lines", eventType.String(), eventType.MinBlockLen())
+	}
+	groups, err := splitBinlogEventBody(body, eventType.String())
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to split %s event body", eventType.String())
+	}
+
+	rowEvent := &binlogEvent{
+		Type: eventType,
+	}
+	re := eventType.Regexp()
+	if re == nil {
+		// Should not reach here.
+		return nil, errors.Errorf("invalid DML binlog event type %s", eventType.String())
+	}
+	for i, block := range groups {
+		if len(block) < eventType.MinBlockLen() {
+			return nil, errors.Errorf("binlog event payload must be at least %d lines, bot got %q", eventType.MinBlockLen(), strings.Join(block, "\n"))
+		}
+		if i == 0 {
+			matches := re.FindStringSubmatch(block[0])
+			if len(matches) != 3 {
+				return nil, errors.Wrapf(err, "failed to parse database and table names from the binlog event %q with regexp %s", block[0], re.String())
+			}
+			rowEvent.Database = matches[1]
+			rowEvent.Table = matches[2]
+		}
+		beforeValue, afterValue, err := eventType.ParseDMLPayload(block)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse the DML binlog event payload")
+		}
+		if beforeValue != nil {
+			rowEvent.DataBefore = append(rowEvent.DataBefore, beforeValue)
+		}
+		if afterValue != nil {
+			rowEvent.DataAfter = append(rowEvent.DataAfter, afterValue)
+		}
+	}
+
+	return rowEvent, nil
+}
+
+func parseBinlogEventPayloadBlock(lines []string, header string) ([]string, error) {
+	if lines[0] != fmt.Sprintf("### %s", header) {
+		return nil, errors.Errorf("failed to parse event payload head line, expecting \"### %s\", but got %q", header, lines[0])
+	}
+	var values []string
+	for i, line := range lines[1:] {
+		prefix := fmt.Sprintf("###   @%d=", i+1)
+		if !strings.HasPrefix(line, prefix) {
+			return nil, errors.Errorf("invalid binlog event payload line %q, expecting prefix %q", line, prefix)
+		}
+		values = append(values, strings.TrimPrefix(line, prefix))
+	}
+	return values, nil
+}
+
+func splitBinlogEventBody(lines []string, prefix string) ([][]string, error) {
+	var groups [][]string
+	var group []string
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "### ") {
+			return nil, errors.Errorf("invalid event payload line %q, must starts with \"### \"", line)
+		}
+		// Starts of a new group.
+		if strings.HasPrefix(line, fmt.Sprintf("### %s", prefix)) {
+			if len(group) > 0 {
+				groups = append(groups, group)
+				group = nil
+			}
+		}
+		group = append(group, line)
+	}
+	// The last group.
+	groups = append(groups, group)
+	return groups, nil
+}

--- a/plugin/db/mysql/binlog_test.go
+++ b/plugin/db/mysql/binlog_test.go
@@ -45,10 +45,8 @@ func TestParseBinlogEventDelete(t *testing.T) {
 ### WHERE
 ###   @1=1`, "\n"),
 			want: &binlogEvent{
-				Type:       DeleteRowsEvent,
-				Database:   "binlog_test",
-				Table:      "user",
-				DataBefore: [][]string{{"1"}},
+				Type:    DeleteRowsEvent,
+				DataOld: [][]string{{"1"}},
 			},
 			err: false,
 		},
@@ -65,10 +63,8 @@ func TestParseBinlogEventDelete(t *testing.T) {
 ###   @2='bob'
 ###   @3=0`, "\n"),
 			want: &binlogEvent{
-				Type:     DeleteRowsEvent,
-				Database: "binlog_test",
-				Table:    "user",
-				DataBefore: [][]string{
+				Type: DeleteRowsEvent,
+				DataOld: [][]string{
 					{"1", "'alice'", "0"},
 					{"2", "'bob'", "0"},
 				},
@@ -166,14 +162,12 @@ func TestParseBinlogEventUpdate(t *testing.T) {
 ###   @2='bob'
 ###   @3=0`, "\n"),
 			want: &binlogEvent{
-				Type:     UpdateRowsEvent,
-				Database: "binlog_test",
-				Table:    "user",
-				DataBefore: [][]string{
+				Type: UpdateRowsEvent,
+				DataOld: [][]string{
 					{"1", "'alice'", "90"},
 					{"2", "'bob'", "110"},
 				},
-				DataAfter: [][]string{
+				DataNew: [][]string{
 					{"1", "'alice'", "0"},
 					{"2", "'bob'", "0"},
 				},
@@ -234,10 +228,8 @@ func TestParseBinlogEventInsert(t *testing.T) {
 ### SET
 ###   @1=1`, "\n"),
 			want: &binlogEvent{
-				Type:      WriteRowsEvent,
-				Database:  "binlog_test",
-				Table:     "user",
-				DataAfter: [][]string{{"1"}},
+				Type:    WriteRowsEvent,
+				DataNew: [][]string{{"1"}},
 			},
 			err: false,
 		},
@@ -259,10 +251,8 @@ func TestParseBinlogEventInsert(t *testing.T) {
 ###   @2='cindy'
 ###   @3=100`, "\n"),
 			want: &binlogEvent{
-				Type:     WriteRowsEvent,
-				Database: "binlog_test",
-				Table:    "user",
-				DataAfter: [][]string{
+				Type: WriteRowsEvent,
+				DataNew: [][]string{
 					{"1", "'alice'", "100"},
 					{"2", "'bob'", "100"},
 					{"3", "'cindy'", "100"},
@@ -373,10 +363,8 @@ func TestParseBinlogEvent(t *testing.T) {
 ###   @2='alice'
 ###   @3=100`,
 			want: &binlogEvent{
-				Type:      WriteRowsEvent,
-				Database:  "binlog_test",
-				Table:     "user",
-				DataAfter: [][]string{{"1", "'alice'", "100"}},
+				Type:    WriteRowsEvent,
+				DataNew: [][]string{{"1", "'alice'", "100"}},
 			},
 		},
 		{
@@ -393,11 +381,9 @@ func TestParseBinlogEvent(t *testing.T) {
 ###   @2='alice'
 ###   @3=90`,
 			want: &binlogEvent{
-				Type:       UpdateRowsEvent,
-				Database:   "binlog_test",
-				Table:      "user",
-				DataBefore: [][]string{{"1", "'alice'", "100"}},
-				DataAfter:  [][]string{{"1", "'alice'", "90"}},
+				Type:    UpdateRowsEvent,
+				DataOld: [][]string{{"1", "'alice'", "100"}},
+				DataNew: [][]string{{"1", "'alice'", "90"}},
 			},
 		},
 		{
@@ -410,10 +396,8 @@ func TestParseBinlogEvent(t *testing.T) {
 ###   @2='cindy'
 ###   @3=100`,
 			want: &binlogEvent{
-				Type:       DeleteRowsEvent,
-				Database:   "binlog_test",
-				Table:      "user",
-				DataBefore: [][]string{{"3", "'cindy'", "100"}},
+				Type:    DeleteRowsEvent,
+				DataOld: [][]string{{"3", "'cindy'", "100"}},
 			},
 		},
 		{

--- a/plugin/db/mysql/binlog_test.go
+++ b/plugin/db/mysql/binlog_test.go
@@ -1,0 +1,442 @@
+package mysql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBinlogEventDelete(t *testing.T) {
+	tests := []struct {
+		name            string
+		binlogTextLines []string
+		want            *binlogEvent
+		err             bool
+	}{
+		{
+			name:            "empty",
+			binlogTextLines: nil,
+			want:            nil,
+			err:             true,
+		},
+		{
+			name:            "partial 1 line 1",
+			binlogTextLines: []string{"### DELETE FROM"},
+			want:            nil,
+			err:             true,
+		},
+		{
+			name:            "partial 1 line 2",
+			binlogTextLines: []string{"### DELETE FROM `binlog_test`.`user`"},
+			want:            nil,
+			err:             true,
+		},
+		{
+			name: "partial 2 lines",
+			binlogTextLines: strings.Split(`### DELETE FROM `+"`binlog_test`.`user`"+`
+### WHERE`, "\n"),
+			want: nil,
+			err:  true,
+		},
+		{
+			name: "min block length",
+			binlogTextLines: strings.Split(`### DELETE FROM `+"`binlog_test`.`user`"+`
+### WHERE
+###   @1=1`, "\n"),
+			want: &binlogEvent{
+				Type:       DeleteRowsEvent,
+				Database:   "binlog_test",
+				Table:      "user",
+				DataBefore: [][]string{{"1"}},
+			},
+			err: false,
+		},
+		{
+			name: "multiple rows",
+			binlogTextLines: strings.Split(`### DELETE FROM `+"`binlog_test`.`user`"+`
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=0
+### DELETE FROM `+"`binlog_test`.`user`"+`
+### WHERE
+###   @1=2
+###   @2='bob'
+###   @3=0`, "\n"),
+			want: &binlogEvent{
+				Type:     DeleteRowsEvent,
+				Database: "binlog_test",
+				Table:    "user",
+				DataBefore: [][]string{
+					{"1", "'alice'", "0"},
+					{"2", "'bob'", "0"},
+				},
+			},
+			err: false,
+		},
+	}
+
+	a := require.New(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, err := parseBinlogEventDML(DeleteRowsEvent, test.binlogTextLines)
+			if test.err {
+				a.Error(err)
+			} else {
+				a.NoError(err)
+				a.Equal(test.want, event)
+			}
+		})
+	}
+}
+
+func TestParseBinlogEventUpdate(t *testing.T) {
+	tests := []struct {
+		name            string
+		binlogTextLines []string
+		want            *binlogEvent
+		err             bool
+	}{
+		{
+			name:            "empty",
+			binlogTextLines: nil,
+			want:            nil,
+			err:             true,
+		},
+		{
+			name:            "partial 1 line 1",
+			binlogTextLines: []string{"### UPDATE"},
+			want:            nil,
+			err:             true,
+		},
+		{
+			name:            "partial 1 line 2",
+			binlogTextLines: []string{"### UPDATE `binlog_test`.`user`"},
+			want:            nil,
+			err:             true,
+		},
+		{
+			name: "partial 2 lines",
+			binlogTextLines: strings.Split(`### UPDATE `+"`binlog_test`.`user`"+`
+### WHERE`, "\n"),
+			want: nil,
+			err:  true,
+		},
+		{
+			name: "no SET clause",
+			binlogTextLines: strings.Split(`### UPDATE `+"`binlog_test`.`user`"+`
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=90`, "\n"),
+			want: nil,
+			err:  true,
+		},
+		{
+			name: "WHERE and SET clause not match",
+			binlogTextLines: strings.Split(`### UPDATE `+"`binlog_test`.`user`"+`
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=90
+### SET
+###   @1=1`, "\n"),
+			want: nil,
+			err:  true,
+		},
+		{
+			name: "multiple rows",
+			binlogTextLines: strings.Split(`### UPDATE `+"`binlog_test`.`user`"+`
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=90
+### SET
+###   @1=1
+###   @2='alice'
+###   @3=0
+### UPDATE `+"`binlog_test`.`user`"+`
+### WHERE
+###   @1=2
+###   @2='bob'
+###   @3=110
+### SET
+###   @1=2
+###   @2='bob'
+###   @3=0`, "\n"),
+			want: &binlogEvent{
+				Type:     UpdateRowsEvent,
+				Database: "binlog_test",
+				Table:    "user",
+				DataBefore: [][]string{
+					{"1", "'alice'", "90"},
+					{"2", "'bob'", "110"},
+				},
+				DataAfter: [][]string{
+					{"1", "'alice'", "0"},
+					{"2", "'bob'", "0"},
+				},
+			},
+			err: false,
+		},
+	}
+
+	a := require.New(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, err := parseBinlogEventDML(UpdateRowsEvent, test.binlogTextLines)
+			if test.err {
+				a.Error(err)
+			} else {
+				a.NoError(err)
+				a.Equal(test.want, event)
+			}
+		})
+	}
+}
+
+func TestParseBinlogEventInsert(t *testing.T) {
+	tests := []struct {
+		name            string
+		binlogTextLines []string
+		want            *binlogEvent
+		err             bool
+	}{
+		{
+			name:            "empty",
+			binlogTextLines: nil,
+			want:            nil,
+			err:             true,
+		},
+		{
+			name:            "partial 1 line 1",
+			binlogTextLines: []string{"### INSERT INTO"},
+			want:            nil,
+			err:             true,
+		},
+		{
+			name:            "partial 1 line 2",
+			binlogTextLines: []string{"### INSERT INTO `binlog_test`.`user`"},
+			want:            nil,
+			err:             true,
+		},
+		{
+			name: "partial 2 lines",
+			binlogTextLines: strings.Split(`### INSERT INTO `+"`binlog_test`.`user`"+`
+### SET`, "\n"),
+			want: nil,
+			err:  true,
+		},
+		{
+			name: "min block length",
+			binlogTextLines: strings.Split(`### INSERT INTO `+"`binlog_test`.`user`"+`
+### SET
+###   @1=1`, "\n"),
+			want: &binlogEvent{
+				Type:      WriteRowsEvent,
+				Database:  "binlog_test",
+				Table:     "user",
+				DataAfter: [][]string{{"1"}},
+			},
+			err: false,
+		},
+		{
+			name: "multiple rows",
+			binlogTextLines: strings.Split(`### INSERT INTO `+"`binlog_test`.`user`"+`
+### SET
+###   @1=1
+###   @2='alice'
+###   @3=100
+### INSERT INTO `+"`binlog_test`.`user`"+`
+### SET
+###   @1=2
+###   @2='bob'
+###   @3=100
+### INSERT INTO `+"`binlog_test`.`user`"+`
+### SET
+###   @1=3
+###   @2='cindy'
+###   @3=100`, "\n"),
+			want: &binlogEvent{
+				Type:     WriteRowsEvent,
+				Database: "binlog_test",
+				Table:    "user",
+				DataAfter: [][]string{
+					{"1", "'alice'", "100"},
+					{"2", "'bob'", "100"},
+					{"3", "'cindy'", "100"},
+				},
+			},
+			err: false,
+		},
+	}
+
+	a := require.New(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, err := parseBinlogEventDML(WriteRowsEvent, test.binlogTextLines)
+			if test.err {
+				a.Error(err)
+			} else {
+				a.NoError(err)
+				a.Equal(test.want, event)
+			}
+		})
+	}
+}
+
+func TestParseBinlogEventQuery(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   *binlogEvent
+		err    bool
+	}{
+		{
+			name:   "empty",
+			header: "",
+			want:   nil,
+			err:    true,
+		},
+		{
+			name:   "invalid",
+			header: "#221017 11:59:35 server id 1  end_log_pos 363 CRC32 0x88a0af23 	Query	thread_id=",
+			want:   nil,
+			err:    true,
+		},
+		{
+			name:   "valid",
+			header: "#221017 11:59:35 server id 1  end_log_pos 363 CRC32 0x88a0af23 	Query	thread_id=53771	exec_time=0	error_code=0	Xid = 327575",
+			want: &binlogEvent{
+				Type:     QueryEvent,
+				ThreadID: "53771",
+			},
+		},
+	}
+
+	a := require.New(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, err := parseBinlogEventQuery(test.header)
+			if test.err {
+				a.Error(err)
+			} else {
+				a.NoError(err)
+				a.Equal(test.want, event)
+			}
+		})
+	}
+}
+
+// The body parsing are tested in the above cases for INSERT/UPDATE/DELETE/QUERY.
+// So we only test for the whole process and the header parsing errors here.
+func TestParseBinlogEvent(t *testing.T) {
+	tests := []struct {
+		name       string
+		binlogText string
+		want       *binlogEvent
+		err        bool
+	}{
+		{
+			name:       "empty",
+			binlogText: "",
+			want:       nil,
+			err:        true,
+		},
+		{
+			name:       "partial line",
+			binlogText: "# at",
+			want:       nil,
+			err:        true,
+		},
+		{
+			name:       "one line",
+			binlogText: "# at 123",
+			want:       nil,
+			err:        true,
+		},
+		{
+			name: "ignore other events",
+			binlogText: `# at 1886
+#221018 16:21:19 server id 1  end_log_pos 1952 CRC32 0x4abaf53a 	Table_map: ` + "`binlog_test`.`user`" + ` mapped to number 259`,
+			want: nil,
+			err:  false,
+		},
+		{
+			name: "INSERT event",
+			binlogText: `# at 838
+#221017 14:25:24 server id 1  end_log_pos 916 CRC32 0x896854fc 	Write_rows: table id 259 flags: STMT_END_F
+### INSERT INTO ` + "`binlog_test`.`user`" + `
+### SET
+###   @1=1
+###   @2='alice'
+###   @3=100`,
+			want: &binlogEvent{
+				Type:      WriteRowsEvent,
+				Database:  "binlog_test",
+				Table:     "user",
+				DataAfter: [][]string{{"1", "'alice'", "100"}},
+			},
+		},
+		{
+			name: "UPDATE event",
+			binlogText: `# at 1183
+#221017 14:25:53 server id 1  end_log_pos 1249 CRC32 0x3d8fa43e 	Update_rows: table id 259 flags: STMT_END_F
+### UPDATE ` + "`binlog_test`.`user`" + `
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=100
+### SET
+###   @1=1
+###   @2='alice'
+###   @3=90`,
+			want: &binlogEvent{
+				Type:       UpdateRowsEvent,
+				Database:   "binlog_test",
+				Table:      "user",
+				DataBefore: [][]string{{"1", "'alice'", "100"}},
+				DataAfter:  [][]string{{"1", "'alice'", "90"}},
+			},
+		},
+		{
+			name: "DELETE event",
+			binlogText: `# at 1635
+#221017 14:31:53 server id 1  end_log_pos 1685 CRC32 0x5ea4b2c4 	Delete_rows: table id 259 flags: STMT_END_F
+### DELETE FROM ` + "`binlog_test`.`user`" + `
+### WHERE
+###   @1=3
+###   @2='cindy'
+###   @3=100`,
+			want: &binlogEvent{
+				Type:       DeleteRowsEvent,
+				Database:   "binlog_test",
+				Table:      "user",
+				DataBefore: [][]string{{"3", "'cindy'", "100"}},
+			},
+		},
+		{
+			name: "QUERY event",
+			binlogText: `# at 234
+#221017 11:59:35 server id 1  end_log_pos 363 CRC32 0x88a0af23 	Query	thread_id=53771	exec_time=0	error_code=0	Xid = 327575`,
+			want: &binlogEvent{
+				Type:     QueryEvent,
+				ThreadID: "53771",
+			},
+		},
+	}
+
+	a := require.New(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, err := parseBinlogEvent(test.binlogText)
+			if test.err {
+				a.Error(err)
+			} else {
+				a.NoError(err)
+				a.Equal(test.want, event)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Parse the text output of `mysqlbinlog` for INSERT/UPDATE/DELETE/QUERY events, which is needed for the flashback SQL generation of a DML task.

Close BYT-1705.