### PR TITLE
feat(sql-editor): Execute query in admin mode

### DIFF
--- a/frontend/src/components/InstanceEngineIcon.vue
+++ b/frontend/src/components/InstanceEngineIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <NTooltip>
     <template #trigger>
-      <div class="relative" v-bind="$attrs">
+      <div class="relative w-4" v-bind="$attrs">
         <img class="h-4 w-auto" :src="SelectedEngineIconPath" />
         <div
           v-if="showStatus"

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -134,6 +134,7 @@ const prepareSheet = async () => {
         instanceId: sheet.database?.instanceId || UNKNOWN_ID,
         databaseId: sheet.databaseId || UNKNOWN_ID,
       },
+      mode: sheet.payload.tabMode,
     });
   }
 

--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -4,7 +4,6 @@ import { useI18n } from "vue-i18n";
 
 import {
   parseSQL,
-  transformSQL,
   isSelectStatement,
   isMultipleStatements,
   isDDLStatement,
@@ -12,7 +11,7 @@ import {
 } from "../components/MonacoEditor/sqlParser";
 import { pushNotification, useTabStore, useSQLEditorStore } from "@/store";
 import { BBNotificationStyle } from "@/bbkit/types";
-import { ExecuteConfig, ExecuteOption } from "@/types";
+import { ExecuteConfig, ExecuteOption, TabMode } from "@/types";
 
 const useExecuteSQL = () => {
   const { t } = useI18n();
@@ -32,29 +31,12 @@ const useExecuteSQL = () => {
     });
   };
 
-  const execute = async (
+  const executeReadonly = async (
     query: string,
     config: ExecuteConfig,
     option?: Partial<ExecuteOption>
   ) => {
     const tab = tabStore.currentTab;
-
-    if (tab.isExecutingSQL) {
-      notify("INFO", t("common.tips"), t("sql-editor.can-not-execute-query"));
-      return;
-    }
-
-    const isDisconnected = tabStore.isDisconnected;
-    if (isDisconnected) {
-      notify("CRITICAL", t("sql-editor.select-connection"));
-      return;
-    }
-
-    if (isEmpty(query)) {
-      notify("CRITICAL", t("sql-editor.notify-empty-statement"));
-      return;
-    }
-
     const { data } = parseSQL(query);
 
     if (data === undefined) {
@@ -88,14 +70,12 @@ const useExecuteSQL = () => {
       );
     }
 
-    let selectStatement =
-      data !== null ? transformSQL(data, config.databaseType) : query;
+    let selectStatement = query;
     if (option?.explain) {
       selectStatement = `EXPLAIN ${selectStatement}`;
     }
 
     try {
-      tab.isExecutingSQL = true;
       const sqlResultSet = await sqlEditorStore.executeQuery({
         statement: selectStatement,
       });
@@ -152,9 +132,92 @@ const useExecuteSQL = () => {
         },
       });
       notify("CRITICAL", error as string);
-    } finally {
-      tab.isExecutingSQL = false;
     }
+  };
+
+  const executeAdmin = async (
+    query: string,
+    config: ExecuteConfig,
+    option?: Partial<ExecuteOption>
+  ) => {
+    const tab = tabStore.currentTab;
+
+    let statement = query;
+    if (option?.explain) {
+      statement = `EXPLAIN ${statement}`;
+    }
+
+    try {
+      const sqlResultSet = await sqlEditorStore.executeAdminQuery({
+        statement,
+      });
+
+      // we ignore SQL review advices here
+
+      // use `markRaw` to prevent vue from monitoring the object change deeply
+      const queryResult = sqlResultSet.data
+        ? markRaw(sqlResultSet.data)
+        : undefined;
+      Object.assign(tab, {
+        queryResult,
+        adviceList: sqlResultSet.adviceList,
+        executeParams: {
+          query,
+          config,
+          option,
+        },
+      });
+      if (queryResult) {
+        // Refresh the query history list when the query executed successfully
+        // (with or without warnings).
+        sqlEditorStore.fetchQueryHistoryList();
+      }
+    } catch (error) {
+      Object.assign(tab, {
+        queryResult: undefined,
+        adviceList: undefined,
+        executeParams: {
+          query,
+          config,
+          option,
+        },
+      });
+      notify("CRITICAL", error as string);
+    }
+  };
+
+  const execute = async (
+    query: string,
+    config: ExecuteConfig,
+    option?: Partial<ExecuteOption>
+  ) => {
+    const tab = tabStore.currentTab;
+
+    if (tab.isExecutingSQL) {
+      notify("INFO", t("common.tips"), t("sql-editor.can-not-execute-query"));
+      return;
+    }
+
+    const isDisconnected = tabStore.isDisconnected;
+    if (isDisconnected) {
+      notify("CRITICAL", t("sql-editor.select-connection"));
+      return;
+    }
+
+    if (isEmpty(query)) {
+      notify("CRITICAL", t("sql-editor.notify-empty-statement"));
+      return;
+    }
+
+    tab.isExecutingSQL = true;
+
+    if (tab.mode === TabMode.ReadOnly) {
+      await executeReadonly(query, config, option);
+    } else if (tab.mode === TabMode.Admin) {
+      await executeAdmin(query, config, option);
+    }
+
+    tab.isExecutingSQL = false;
   };
 
   return {

--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -152,8 +152,6 @@ const useExecuteSQL = () => {
         statement,
       });
 
-      // we ignore SQL review advices here
-
       // use `markRaw` to prevent vue from monitoring the object change deeply
       const queryResult = sqlResultSet.data
         ? markRaw(sqlResultSet.data)

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1323,7 +1323,11 @@
     "open-connection": "Open connection",
     "visualize-explain": "Visualize Explain",
     "sql-execute-in-protected-environment": "The SQL statement below will be executed in a protected environment.",
-    "rows-upper-limit": "reached the limit of query results"
+    "rows-upper-limit": "reached the limit of query results",
+    "tab-mode": {
+      "readonly": "Readonly",
+      "admin": "Admin"
+    }
   },
   "label": {
     "empty-label-value": "<Empty Value>",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1324,7 +1324,11 @@
     "open-connection": "打开连接",
     "visualize-explain": "可视化 Explain",
     "sql-execute-in-protected-environment": "下面的 SQL 语句将会在受保护的环境中执行。",
-    "rows-upper-limit": "到达查询结果条数上限"
+    "rows-upper-limit": "到达查询结果条数上限",
+    "tab-mode": {
+      "readonly": "只读",
+      "admin": "管理员"
+    }
   },
   "label": {
     "empty-label-value": "<空值>",

--- a/frontend/src/store/modules/sql.ts
+++ b/frontend/src/store/modules/sql.ts
@@ -118,5 +118,31 @@ export const useSQLStore = defineStore("sql", {
 
       return resultSet;
     },
+    async adminQuery(queryInfo: QueryInfo): Promise<SQLResultSet> {
+      const res = (
+        await axios.post(
+          `/api/sql/execute/admin`,
+          {
+            data: {
+              type: "sqlExecute",
+              attributes: {
+                ...queryInfo,
+                readonly: true,
+              },
+            },
+          },
+          {
+            timeout: INSTANCE_OPERATION_TIMEOUT,
+          }
+        )
+      ).data;
+
+      const resultSet = convert(res.data);
+      if (resultSet.error) {
+        throw new Error(resultSet.error);
+      }
+
+      return resultSet;
+    },
   },
 });

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -63,6 +63,19 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
 
       return queryResult;
     },
+    async executeAdminQuery({ statement }: Pick<QueryInfo, "statement">) {
+      const { instanceId, databaseId } = useTabStore().currentTab.connection;
+      const database = useDatabaseStore().getDatabaseById(databaseId);
+      const databaseName = database.id === UNKNOWN_ID ? "" : database.name;
+      const queryResult = await useSQLStore().adminQuery({
+        instanceId,
+        databaseName,
+        statement: statement,
+        limit: RESULT_ROWS_LIMIT,
+      });
+
+      return queryResult;
+    },
     async fetchConnectionByInstanceIdAndDatabaseId(
       instanceId: InstanceId,
       databaseId: DatabaseId

--- a/frontend/src/store/modules/tab.ts
+++ b/frontend/src/store/modules/tab.ts
@@ -30,6 +30,7 @@ const PERSISTENT_TASK_FIELDS = [
   "savedAt",
   "statement",
   "sheetId",
+  "mode",
 ] as const;
 type PersistentTaskInfo = Pick<TabInfo, typeof PERSISTENT_TASK_FIELDS[number]>;
 

--- a/frontend/src/types/sheet.ts
+++ b/frontend/src/types/sheet.ts
@@ -7,6 +7,7 @@ import {
   ProjectId,
   RowStatus,
   PrincipalId,
+  TabMode,
 } from ".";
 
 export type SheetVisibility = "PRIVATE" | "PROJECT" | "PUBLIC";
@@ -14,6 +15,10 @@ export type SheetVisibility = "PRIVATE" | "PROJECT" | "PUBLIC";
 export type SheetSource = "BYTEBASE" | "GITLAB_SELF_HOST" | "GITHUB_COM";
 
 export type SheetType = "SQL";
+
+export type SheetPayload = {
+  tabMode: TabMode;
+};
 
 export interface Sheet {
   id: SheetId;
@@ -40,6 +45,7 @@ export interface Sheet {
   type: SheetType;
   starred: boolean;
   pinned: boolean;
+  payload: SheetPayload;
 }
 
 export interface SheetUpsert {
@@ -49,6 +55,7 @@ export interface SheetUpsert {
   name: string;
   statement: string;
   visibility?: SheetVisibility;
+  payload?: SheetPayload;
 }
 
 export interface SheetCreate {
@@ -57,6 +64,7 @@ export interface SheetCreate {
   name: string;
   statement: string;
   visibility: SheetVisibility;
+  payload: SheetPayload;
 }
 
 export interface SheetPatch {
@@ -65,6 +73,7 @@ export interface SheetPatch {
   statement?: string;
   visibility?: SheetVisibility;
   rowStatus?: RowStatus;
+  payload?: SheetPayload;
 }
 
 export interface SheetFind {

--- a/frontend/src/types/tab.ts
+++ b/frontend/src/types/tab.ts
@@ -13,6 +13,11 @@ export type Connection = {
   databaseId: DatabaseId;
 };
 
+export enum TabMode {
+  ReadOnly = 1,
+  Admin = 2,
+}
+
 export interface TabInfo {
   id: string;
   name: string;
@@ -21,6 +26,7 @@ export interface TabInfo {
   savedAt: string;
   statement: string;
   selectedStatement: string;
+  mode: TabMode;
   executeParams?: {
     query: string;
     config: ExecuteConfig;

--- a/frontend/src/utils/sheet.ts
+++ b/frontend/src/utils/sheet.ts
@@ -1,4 +1,4 @@
-import { Principal, Sheet } from "@/types";
+import { Principal, Sheet, SheetPayload, TabMode } from "@/types";
 
 export const isSheetReadable = (sheet: Sheet, currentUser: Principal) => {
   // readable to
@@ -53,4 +53,10 @@ export const isSheetWritable = (sheet: Sheet, currentUser: Principal) => {
   }
   // visibility === "PUBLIC"
   return false;
+};
+
+export const getDefaultSheetPayload = (): SheetPayload => {
+  return {
+    tabMode: TabMode.ReadOnly,
+  };
 };

--- a/frontend/src/utils/tab.ts
+++ b/frontend/src/utils/tab.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { computed } from "vue";
 import { v1 as uuidv1 } from "uuid";
 import { t } from "../plugins/i18n";
-import type { Connection, TabInfo } from "@/types";
+import { Connection, TabInfo, TabMode } from "@/types";
 import { UNKNOWN_ID } from "@/types";
 
 export const defaultTabName = computed(() => t("sql-editor.untitled-sheet"));
@@ -23,6 +23,7 @@ export const getDefaultTab = (): TabInfo => {
     savedAt: dayjs().format("YYYY-MM-DD HH:mm:ss"),
     statement: "",
     selectedStatement: "",
+    mode: TabMode.ReadOnly,
     isExecutingSQL: false,
   };
 };

--- a/frontend/src/utils/tab.ts
+++ b/frontend/src/utils/tab.ts
@@ -2,8 +2,8 @@ import dayjs from "dayjs";
 import { computed } from "vue";
 import { v1 as uuidv1 } from "uuid";
 import { t } from "../plugins/i18n";
-import { Connection, TabInfo, TabMode } from "@/types";
-import { UNKNOWN_ID } from "@/types";
+import type { Connection, TabInfo } from "@/types";
+import { UNKNOWN_ID, TabMode } from "@/types";
 
 export const defaultTabName = computed(() => t("sql-editor.untitled-sheet"));
 

--- a/frontend/src/views/sql-editor/EditorPanel/EditorAction.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/EditorAction.vue
@@ -105,6 +105,9 @@
           </div>
         </section>
       </NPopover>
+
+      <TabModeSelect />
+
       <NButton
         secondary
         strong
@@ -149,6 +152,7 @@ import { UNKNOWN_ID } from "@/types";
 import { instanceSlug } from "@/utils/slug";
 import SharePopover from "./SharePopover.vue";
 import ProtectedEnvironmentIcon from "@/components/Environment/ProtectedEnvironmentIcon.vue";
+import TabModeSelect from "./TabModeSelect.vue";
 
 const emit = defineEmits<{
   (e: "save-sheet", content?: string): void;

--- a/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
@@ -49,6 +49,7 @@ import SQLEditor from "./SQLEditor.vue";
 import ExecuteHint from "./ExecuteHint.vue";
 import ConnectionHolder from "./ConnectionHolder.vue";
 import SaveSheetModal from "./SaveSheetModal.vue";
+import type { SheetUpsert } from "@/types";
 import { UNKNOWN_ID } from "@/types";
 
 const tabStore = useTabStore();
@@ -98,17 +99,20 @@ const handleSaveSheet = async (sheetName?: string) => {
   }
   isShowSaveSheetModal.value = false;
 
-  const { name, statement, sheetId } = tabStore.currentTab;
+  const { name, statement, sheetId, mode } = tabStore.currentTab;
   sheetName = sheetName ? sheetName : name;
 
   const conn = tabStore.currentTab.connection;
   const database = await databaseStore.getOrFetchDatabaseById(conn.databaseId);
-  const sheetUpsert = {
+  const sheetUpsert: SheetUpsert = {
     id: sheetId,
     projectId: database.project.id,
     databaseId: conn.databaseId,
     name: sheetName,
     statement: statement,
+    payload: {
+      tabMode: mode,
+    },
   };
   const sheet = await sheetStore.upsertSheet(sheetUpsert);
 

--- a/frontend/src/views/sql-editor/EditorPanel/TabModeSelect.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/TabModeSelect.vue
@@ -1,0 +1,44 @@
+<template>
+  <NSelect
+    v-model:value="tabStore.currentTab.mode"
+    :options="tabModeOptions"
+    :consistent-menu-width="false"
+    @update:value="onUpdate"
+  />
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { SelectOption } from "naive-ui";
+import { useI18n } from "vue-i18n";
+
+import { TabMode } from "@/types";
+import { useCurrentUser, useTabStore } from "@/store";
+import { isDBAOrOwner } from "@/utils";
+
+const { t } = useI18n();
+
+const currentUser = useCurrentUser();
+
+const allowAdmin = computed(() => isDBAOrOwner(currentUser.value.role));
+
+const tabStore = useTabStore();
+
+const tabModeOptions = computed((): SelectOption[] => {
+  return [
+    {
+      value: TabMode.ReadOnly,
+      label: t("sql-editor.tab-mode.readonly"),
+    },
+    {
+      value: TabMode.Admin,
+      label: t("sql-editor.tab-mode.admin"),
+      disabled: !allowAdmin.value,
+    },
+  ];
+});
+
+const onUpdate = () => {
+  tabStore.currentTab.isSaved = false;
+};
+</script>

--- a/frontend/src/views/sql-editor/TabList/TabItem/TabItem.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/TabItem.vue
@@ -5,6 +5,7 @@
       current: isCurrentTab,
       temp: isTempTab(tab),
       hovering: state.hovering,
+      admin: tab.mode === TabMode.Admin,
     }"
     @mousedown="$emit('select', tab, index)"
     @mouseenter="state.hovering = true"
@@ -23,6 +24,7 @@ import { computed, PropType, reactive } from "vue";
 import { storeToRefs } from "pinia";
 
 import type { TabInfo } from "@/types";
+import { TabMode } from "@/types";
 import { isTempTab } from "@/utils";
 import { useTabStore } from "@/store";
 import Prefix from "./Prefix.vue";
@@ -72,5 +74,8 @@ const isCurrentTab = computed(() => props.tab.id === currentTabId.value);
 }
 .current .body {
   @apply relative bg-white text-accent border-t-accent;
+}
+.admin.current .body {
+  @apply border-t-red-600 text-red-600;
 }
 </style>

--- a/frontend/src/views/sql-editor/TabList/TabItem/TabItem.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/TabItem.vue
@@ -75,7 +75,4 @@ const isCurrentTab = computed(() => props.tab.id === currentTabId.value);
 .current .body {
   @apply relative bg-white text-accent border-t-accent;
 }
-.admin.current .body {
-  @apply border-t-red-600 text-red-600;
-}
 </style>


### PR DESCRIPTION
### Features

**Execute query in admin mode** (early 🛴 edition) BYT-1708

- Using the query admin API (introduced by #3135)
- Available for DBAs and Workspace owners.
- Non-restricted SQL statement type. (Query, DDL, DML, and database management or whatever)
- Able to run multiple SQL statements in one execution. (e.g., `use database; show tables;`)

### Screenshots

https://user-images.githubusercontent.com/2749742/197985552-a640c0c3-5068-4092-a8ce-2cca326872a3.mp4

### Future plans

- Inform users that this is an extremely dangerous zone.
- Interactive "Query-Result" loop user experience. (somehow like [Google Colaboratory](https://colab.research.google.com/) or [Jupyter Notebook](https://jupyter.org/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb))
