### PR TITLE
feat: support address column order

### DIFF
--- a/plugin/parser/differ/mysql/column_test.go
+++ b/plugin/parser/differ/mysql/column_test.go
@@ -255,11 +255,11 @@ func TestColumnOrder(t *testing.T) {
 		// Complicated case.
 		{
 			old: `CREATE TABLE book(c1 INT, c2 INT, c3 INT, c4 INT, c5 INT);`,
-			new: `CREATE TABLE book(c6 INT, c2 INT, c3 INT, c7 INT, c8 INT);`,
+			new: `CREATE TABLE book(c6 INT, c2 INT, c3 INT, c7 INT, c8 INT, c4 INT, c5 INT);`,
 			want: "ALTER TABLE `book` ADD COLUMN `c6` INT FIRST, " + // c6, c1, c2, c3, c4, c5
 				"ADD COLUMN `c7` INT AFTER `c3`, " + // c6, c1, c2, c3, c7, c4, c5
 				"ADD COLUMN `c8` INT AFTER `c7`;\n" + // c6, c1, c2, c3, c7, c8, c4, c5
-				"ALTER TABLE `book` DROP COLUMN `c4`, DROP COLUMN `c5`, DROP COLUMN `c1`;\n", // c6, c2, c3, c7, c8
+				"ALTER TABLE `book` DROP COLUMN `c1`;\n", // c6, c2, c3, c7, c8, c4, c5
 		},
 	}
 	testDiffWithoutDisableForeignKeyCheck(t, tests)

--- a/plugin/parser/differ/mysql/column_test.go
+++ b/plugin/parser/differ/mysql/column_test.go
@@ -12,12 +12,12 @@ func TestColumnExist(t *testing.T) {
 		{
 			old:  `CREATE TABLE book(id INT, PRIMARY KEY(id));`,
 			new:  `CREATE TABLE book(id INT, price INT, PRIMARY KEY(id));`,
-			want: "ALTER TABLE `book` ADD COLUMN (`price` INT);\n",
+			want: "ALTER TABLE `book` ADD COLUMN `price` INT AFTER `id`;\n",
 		},
 		{
 			old:  `CREATE TABLE book(id INT, PRIMARY KEY(id))`,
 			new:  `CREATE TABLE book(id INT, price INT, code VARCHAR(50), PRIMARY KEY(id));`,
-			want: "ALTER TABLE `book` ADD COLUMN (`price` INT), ADD COLUMN (`code` VARCHAR(50));\n",
+			want: "ALTER TABLE `book` ADD COLUMN `price` INT AFTER `id`, ADD COLUMN `code` VARCHAR(50) AFTER `price`;\n",
 		},
 		{
 			old:  ``,
@@ -221,6 +221,45 @@ func TestColumnCollate(t *testing.T) {
 			old:  `CREATE TABLE book(name VARCHAR(50) COLLATE utf8mb4_bin DEFAULT 'Holmes' NOT NULL);`,
 			new:  `CREATE TABLE book(name VARCHAR(50) COLLATE utf8mb4_bin DEFAULT 'Holmes' NOT NULL);`,
 			want: "",
+		},
+	}
+	testDiffWithoutDisableForeignKeyCheck(t, tests)
+}
+
+func TestColumnOrder(t *testing.T) {
+	tests := []testCase{
+		// Append the column to the end of the table.
+		{
+			old:  `CREATE TABLE book(id INT PRIMARY KEY);`,
+			new:  `CREATE TABLE book(id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, author VARCHAR(50) NOT NULL);`,
+			want: "ALTER TABLE `book` ADD COLUMN `name` VARCHAR(50) NOT NULL AFTER `id`, ADD COLUMN `author` VARCHAR(50) NOT NULL AFTER `name`;\n",
+		},
+		// Add the column at the beginning of the table.
+		{
+			old:  `CREATE TABLE book(author VARCHAR(50) NOT NULL);`,
+			new:  `CREATE TABLE book(id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, author VARCHAR(50) NOT NULL);`,
+			want: "ALTER TABLE `book` ADD COLUMN `id` INT PRIMARY KEY FIRST, ADD COLUMN `name` VARCHAR(50) NOT NULL AFTER `id`;\n",
+		},
+		// Add the column in the middle of the table.
+		{
+			old:  `CREATE TABLE book(id INT PRIMARY KEY, author VARCHAR(50) NOT NULL);`,
+			new:  `CREATE TABLE book(id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, author VARCHAR(50) NOT NULL);`,
+			want: "ALTER TABLE `book` ADD COLUMN `name` VARCHAR(50) NOT NULL AFTER `id`;\n",
+		},
+		// Modify the existing column order.
+		{
+			old:  `CREATE TABLE book(author VARCHAR(50) NOT NULL, id INT PRIMARY KEY, name VARCHAR(50) NOT NULL);`,
+			new:  `CREATE TABLE book(id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, author VARCHAR(50) NOT NULL);`,
+			want: "ALTER TABLE `book` MODIFY COLUMN `id` INT PRIMARY KEY FIRST, MODIFY COLUMN `name` VARCHAR(50) NOT NULL AFTER `id`;\n",
+		},
+		// Complicated case.
+		{
+			old: `CREATE TABLE book(c1 INT, c2 INT, c3 INT, c4 INT, c5 INT);`,
+			new: `CREATE TABLE book(c6 INT, c2 INT, c3 INT, c7 INT, c8 INT);`,
+			want: "ALTER TABLE `book` ADD COLUMN `c6` INT FIRST, " + // c6, c1, c2, c3, c4, c5
+				"ADD COLUMN `c7` INT AFTER `c3`, " + // c6, c1, c2, c3, c7, c4, c5
+				"ADD COLUMN `c8` INT AFTER `c7`;\n" + // c6, c1, c2, c3, c7, c8, c4, c5
+				"ALTER TABLE `book` DROP COLUMN `c4`, DROP COLUMN `c5`, DROP COLUMN `c1`;\n", // c6, c2, c3, c7, c8
 		},
 	}
 	testDiffWithoutDisableForeignKeyCheck(t, tests)

--- a/plugin/parser/differ/mysql/constraint_test.go
+++ b/plugin/parser/differ/mysql/constraint_test.go
@@ -460,7 +460,7 @@ func TestForeignKeyDefination(t *testing.T) {
 				"	CONSTRAINT `employee_ibfk_1` FOREIGN KEY (`manager_id`) REFERENCES `employeee` (`id`)" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 
-			want: "ALTER TABLE `employeee` ADD COLUMN (`manager_id` INT DEFAULT NULL);\n" +
+			want: "ALTER TABLE `employeee` ADD COLUMN `manager_id` INT DEFAULT NULL AFTER `leader_id`;\n" +
 				"ALTER TABLE `employeee` DROP FOREIGN KEY `employee_ibfk_1`;\n" +
 				"ALTER TABLE `employeee` ADD CONSTRAINT `employee_ibfk_1` FOREIGN KEY (`manager_id`) REFERENCES `employeee`(`id`);\n",
 		},
@@ -500,7 +500,7 @@ func TestConstraint(t *testing.T) {
 		{
 			old: `CREATE TABLE book(id INT, name VARCHAR(50), CONSTRAINT PRIMARY KEY(id, name));`,
 			new: `CREATE TABLE book(id INT, name VARCHAR(50), address VARCHAR(50) NOT NULL, CONSTRAINT PRIMARY KEY(id, address));`,
-			want: "ALTER TABLE `book` ADD COLUMN (`address` VARCHAR(50) NOT NULL);\n" +
+			want: "ALTER TABLE `book` ADD COLUMN `address` VARCHAR(50) NOT NULL AFTER `name`;\n" +
 				"ALTER TABLE `book` DROP PRIMARY KEY;\n" +
 				"ALTER TABLE `book` ADD PRIMARY KEY(`id`, `address`);\n",
 		},
@@ -508,7 +508,7 @@ func TestConstraint(t *testing.T) {
 		{
 			old: `CREATE TABLE book(id INT, name VARCHAR(50), INDEX id_name_idx (id, name));`,
 			new: `CREATE TABLE book(id INT, name VARCHAR(50), address VARCHAR(50) NOT NULL, INDEX id_address_idx (id, address));`,
-			want: "ALTER TABLE `book` ADD COLUMN (`address` VARCHAR(50) NOT NULL);\n" +
+			want: "ALTER TABLE `book` ADD COLUMN `address` VARCHAR(50) NOT NULL AFTER `name`;\n" +
 				"ALTER TABLE `book` ADD INDEX `id_address_idx`(`id`, `address`);\n" +
 				"ALTER TABLE `book` DROP INDEX `id_name_idx`;\n",
 		},
@@ -516,7 +516,7 @@ func TestConstraint(t *testing.T) {
 		{
 			old: `CREATE TABLE book(id INT, name VARCHAR(50), INDEX idx (id, name));`,
 			new: `CREATE TABLE book(id INT, name VARCHAR(50), address VARCHAR(50) NOT NULL, INDEX idx (id, address));`,
-			want: "ALTER TABLE `book` ADD COLUMN (`address` VARCHAR(50) NOT NULL);\n" +
+			want: "ALTER TABLE `book` ADD COLUMN `address` VARCHAR(50) NOT NULL AFTER `name`;\n" +
 				"ALTER TABLE `book` DROP INDEX `idx`;\n" +
 				"ALTER TABLE `book` ADD INDEX `idx`(`id`, `address`);\n",
 		},

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -1271,9 +1271,9 @@ func buildTableOptionMap(options []*ast.TableOption) map[ast.TableOptionType]*as
 
 // hasColumnsIntersection returns true if two column slices have column name intersaction.
 func hasColumnsIntersection(a, b []*ast.ColumnDef) bool {
-	bMap := make(map[string]struct{})
+	bMap := make(map[string]bool)
 	for _, col := range b {
-		bMap[col.Name.Name.O] = struct{}{}
+		bMap[col.Name.Name.O] = true
 	}
 	for _, col := range a {
 		if _, ok := bMap[col.Name.Name.O]; ok {

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -122,22 +122,41 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 			var alterTableInplaceDropConstraintSpecs []*ast.AlterTableSpec
 
 			oldColumnMap := buildColumnMap(oldNodes, newStmt.Table.Name)
-			for _, columnDef := range newStmt.Cols {
+			oldColumnPositionMap := buildColumnPositionMap(oldStmt)
+			for idx, columnDef := range newStmt.Cols {
 				newColumnName := columnDef.Name.Name.O
 				oldColumnDef, ok := oldColumnMap[newColumnName]
 				if !ok {
+					columnPosition := &ast.ColumnPosition{Tp: ast.ColumnPositionFirst}
+					if idx >= 1 {
+						columnPosition.Tp = ast.ColumnPositionAfter
+						columnPosition.RelativeColumn = &ast.ColumnName{Name: model.NewCIStr(newStmt.Cols[idx-1].Name.Name.O)}
+					}
 					alterTableAddColumnSpecs = append(alterTableAddColumnSpecs, &ast.AlterTableSpec{
 						Tp:         ast.AlterTableAddColumns,
 						NewColumns: []*ast.ColumnDef{columnDef},
+						Position:   columnPosition,
 					})
 					continue
 				}
-				// Compare the two column definitions.
-				if !isColumnEqual(oldColumnDef, columnDef) {
+
+				// Compare the column possitions.
+				columnPosition := &ast.ColumnPosition{Tp: ast.ColumnPositionNone}
+				columnPosInOld := oldColumnPositionMap[newColumnName]
+				if hasColumnsIntersection(oldStmt.Cols[:columnPosInOld], newStmt.Cols[idx+1:]) {
+					if idx == 0 {
+						columnPosition.Tp = ast.ColumnPositionFirst
+					} else {
+						columnPosition.Tp = ast.ColumnPositionAfter
+						columnPosition.RelativeColumn = &ast.ColumnName{Name: model.NewCIStr(newStmt.Cols[idx-1].Name.Name.O)}
+					}
+				}
+				// Compare the column definitions.
+				if !isColumnEqual(oldColumnDef, columnDef) || columnPosition.Tp != ast.ColumnPositionNone {
 					alterTableModifyColumnSpecs = append(alterTableModifyColumnSpecs, &ast.AlterTableSpec{
 						Tp:         ast.AlterTableModifyColumn,
 						NewColumns: []*ast.ColumnDef{columnDef},
-						Position:   &ast.ColumnPosition{Tp: ast.ColumnPositionNone},
+						Position:   columnPosition,
 					})
 				}
 				delete(oldColumnMap, newColumnName)
@@ -654,6 +673,15 @@ func buildColumnMap(nodes []ast.StmtNode, tableName model.CIStr) map[string]*ast
 		}
 	}
 	return oldColumnMap
+}
+
+// buildColumnPositionMap returns a map of column name to column position.
+func buildColumnPositionMap(stmt *ast.CreateTableStmt) map[string]int {
+	m := make(map[string]int)
+	for i, col := range stmt.Cols {
+		m[col.Name.Name.O] = i
+	}
+	return m
 }
 
 // buildIndexMap build a map of index name to constraint on given table name.
@@ -1239,4 +1267,18 @@ func buildTableOptionMap(options []*ast.TableOption) map[ast.TableOptionType]*as
 		m[option.Tp] = option
 	}
 	return m
+}
+
+// hasColumnsIntersection returns true if two column slices have column name intersaction.
+func hasColumnsIntersection(a, b []*ast.ColumnDef) bool {
+	bMap := make(map[string]struct{})
+	for _, col := range b {
+		bMap[col.Name.Name.O] = struct{}{}
+	}
+	for _, col := range a {
+		if _, ok := bMap[col.Name.Name.O]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/plugin/parser/differ/mysql/differ.go
+++ b/plugin/parser/differ/mysql/differ.go
@@ -140,7 +140,7 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 					continue
 				}
 
-				// Compare the column possitions.
+				// Compare the column positions.
 				columnPosition := &ast.ColumnPosition{Tp: ast.ColumnPositionNone}
 				columnPosInOld := oldColumnPositionMap[newColumnName]
 				if hasColumnsIntersection(oldStmt.Cols[:columnPosInOld], newStmt.Cols[idx+1:]) {

--- a/plugin/parser/differ/mysql/utils_test.go
+++ b/plugin/parser/differ/mysql/utils_test.go
@@ -11,7 +11,7 @@ func TestTrigger(t *testing.T) {
 				"CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = @sum + NEW.amount;",
 			new: `CREATE TABLE account(acct_num INT, amount DECIMAL(10,2), price INT);` +
 				"CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = sum + NEW.amount * NEW.price;",
-			want: "ALTER TABLE `account` ADD COLUMN (`price` INT);\n" +
+			want: "ALTER TABLE `account` ADD COLUMN `price` INT AFTER `amount`;\n" +
 				"DROP TRIGGER IF EXISTS `ins_sum`;\n" +
 				"CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = sum + NEW.amount * NEW.price;\n",
 		},


### PR DESCRIPTION
The steps of the algorithm are simple, we iterate the new column slice, and each column will be one of the following cases:
1. New column, we always specify the column position in ALTER TABLE ADD COLUMN statement.
2. Exist column, leaving the column definition behind, we consider the column position. Let's say the column position in the old column slice and the new column slice are x and y. We should address the column order if there is a not null intersection in the oldColumns[:x] and the newColumns[y+1:] because the relative order of this column in the old column slice has changed.

This algorithm works well in most cases. But our differ follow the sequence of operations below:
1. Add new nodes.
2. Inplace update.
3. Inplace drop.
4. Inplace add.
5. Drop.

This leads to the problem that our relative column in column position in ALTER TABLE ADD COLUMN statement may be changed later in ALTER TABLE MODIFY COLUMN statements.

For example:
Now:
```sql
CREATE TABLE `book` (
  `c1` int DEFAULT NULL,
  `c2` int DEFAULT NULL,
  `c3` int DEFAULT NULL,
  `c4` int DEFAULT NULL,
  `c5` int DEFAULT NULL
)
```

Want:
```sql
CREATE TABLE `book`(
  `c6` int DEFAULT NULL,
  `c3` int DEFAULT NULL,
  `c8` int DEFAULT NULL,
  `c2` int DEFAULT NULL,
  `c7` int DEFAULT NULL
)
```
We will add column c7 after c2 first, but the position of c2 will be modified later.

Navicat cannot work well too in this case, lol.