### PR TITLE
feat: add a database schema API

### DIFF
--- a/server/acl_casbin_policy_dba.csv
+++ b/server/acl_casbin_policy_dba.csv
@@ -48,6 +48,7 @@ p, DBA, /database/{id}/table, GET
 p, DBA, /database/{id}/table/{tableName}, GET
 p, DBA, /database/{id}/view, GET
 p, DBA, /database/{id}/extension, GET
+p, DBA, /database/{id}/schema, GET
 p, DBA, /database/{id}/backup, GET
 p, DBA, /database/{id}/backup, POST
 p, DBA, /database/{id}/backup-setting, GET

--- a/server/acl_casbin_policy_developer.csv
+++ b/server/acl_casbin_policy_developer.csv
@@ -41,6 +41,7 @@ p, DEVELOPER, /database/{id}/table, GET
 p, DEVELOPER, /database/{id}/table/{tableName}, GET
 p, DEVELOPER, /database/{id}/view, GET
 p, DEVELOPER, /database/{id}/extension, GET
+p, DEVELOPER, /database/{id}/schema, GET
 p, DEVELOPER, /database/{id}/backup, GET
 p, DEVELOPER, /database/{id}/backup, POST
 p, DEVELOPER, /database/{id}/backup-setting, GET

--- a/server/acl_casbin_policy_owner.csv
+++ b/server/acl_casbin_policy_owner.csv
@@ -53,6 +53,7 @@ p, OWNER, /database/{id}/table, GET
 p, OWNER, /database/{id}/table/{tableName}, GET
 p, OWNER, /database/{id}/view, GET
 p, OWNER, /database/{id}/extension, GET
+p, OWNER, /database/{id}/schema, GET
 p, OWNER, /database/{id}/backup, GET
 p, OWNER, /database/{id}/backup, POST
 p, OWNER, /database/{id}/backup-setting, GET


### PR DESCRIPTION
This will return the database schema in text format. This API is used for syncing database schema.