### PR TITLE
chore(deps): update dependency @bytebase/tidb to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,6 @@ replace github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.
 
 replace github.com/github/gh-ost => github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651
 
-replace github.com/pingcap/tidb => github.com/bytebase/tidb v0.0.0-20221028032950-1eefadef45ba
+replace github.com/pingcap/tidb => github.com/bytebase/tidb v0.0.0-20221028035959-5d3b71eadf24
 
-replace github.com/pingcap/tidb/parser => github.com/bytebase/tidb/parser v0.0.0-20221028032950-1eefadef45ba
+replace github.com/pingcap/tidb/parser => github.com/bytebase/tidb/parser v0.0.0-20221028035959-5d3b71eadf24

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,6 @@ replace github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.
 
 replace github.com/github/gh-ost => github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651
 
-replace github.com/pingcap/tidb => github.com/bytebase/tidb v0.0.0-20221026055853-b84d87cb3775
+replace github.com/pingcap/tidb => github.com/bytebase/tidb v0.0.0-20221028032950-1eefadef45ba
 
-replace github.com/pingcap/tidb/parser => github.com/bytebase/tidb/parser v0.0.0-20221026055853-b84d87cb3775
+replace github.com/pingcap/tidb/parser => github.com/bytebase/tidb/parser v0.0.0-20221028032950-1eefadef45ba

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,10 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651 h1:NpoTuRY6Ckj37zTlEax/UTfvHCOdanI5/5dVCarOD18=
 github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651/go.mod h1:/HsnX0+34LXVz3MxtZoW15GiwEOXz/PrEhutjb3icfE=
-github.com/bytebase/tidb v0.0.0-20221028032950-1eefadef45ba h1:w+w2Q+8Yk18zcvEnYsgml5VDws7kTofVJNGbfdc7xso=
-github.com/bytebase/tidb v0.0.0-20221028032950-1eefadef45ba/go.mod h1:xrVXE+0V54QRGgrD9o+tuZmBDDx8vJpQgrPtRQvodWo=
-github.com/bytebase/tidb/parser v0.0.0-20221028032950-1eefadef45ba h1:gCYQHNRq9V0FMC1pIMQ5trLHkFZP+68txj+IVhToibs=
-github.com/bytebase/tidb/parser v0.0.0-20221028032950-1eefadef45ba/go.mod h1:wjvp+T3/T9XYt0nKqGX3Kc1AKuyUcfno6LTc6b2A6ew=
+github.com/bytebase/tidb v0.0.0-20221028035959-5d3b71eadf24 h1:XR25hLtR8TtpW/4mgP7EcOlzi8ewNY5EVan97WzDQxc=
+github.com/bytebase/tidb v0.0.0-20221028035959-5d3b71eadf24/go.mod h1:xrVXE+0V54QRGgrD9o+tuZmBDDx8vJpQgrPtRQvodWo=
+github.com/bytebase/tidb/parser v0.0.0-20221028035959-5d3b71eadf24 h1:DZPxIt2aZJ6L/gh8tH9jspTTIufBt7Wvgae1T7TmXAg=
+github.com/bytebase/tidb/parser v0.0.0-20221028035959-5d3b71eadf24/go.mod h1:wjvp+T3/T9XYt0nKqGX3Kc1AKuyUcfno6LTc6b2A6ew=
 github.com/casbin/casbin/v2 v2.1.0/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/casbin/casbin/v2 v2.55.1 h1:vaTAHSLkQfielg9UiHdIdvIVK/NAmMjBkDkrOM9iDqI=
 github.com/casbin/casbin/v2 v2.55.1/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,10 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651 h1:NpoTuRY6Ckj37zTlEax/UTfvHCOdanI5/5dVCarOD18=
 github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651/go.mod h1:/HsnX0+34LXVz3MxtZoW15GiwEOXz/PrEhutjb3icfE=
-github.com/bytebase/tidb v0.0.0-20221026055853-b84d87cb3775 h1:pcgMqsX9R6tDMOvSVEkKXypkEKO8fxRHURc2pNB6VAA=
-github.com/bytebase/tidb v0.0.0-20221026055853-b84d87cb3775/go.mod h1:xrVXE+0V54QRGgrD9o+tuZmBDDx8vJpQgrPtRQvodWo=
-github.com/bytebase/tidb/parser v0.0.0-20221026055853-b84d87cb3775 h1:hobw6n/MFkNCdyIXVmX84ORZxLWGXYE/rvCQff3TTzM=
-github.com/bytebase/tidb/parser v0.0.0-20221026055853-b84d87cb3775/go.mod h1:wjvp+T3/T9XYt0nKqGX3Kc1AKuyUcfno6LTc6b2A6ew=
+github.com/bytebase/tidb v0.0.0-20221028032950-1eefadef45ba h1:w+w2Q+8Yk18zcvEnYsgml5VDws7kTofVJNGbfdc7xso=
+github.com/bytebase/tidb v0.0.0-20221028032950-1eefadef45ba/go.mod h1:xrVXE+0V54QRGgrD9o+tuZmBDDx8vJpQgrPtRQvodWo=
+github.com/bytebase/tidb/parser v0.0.0-20221028032950-1eefadef45ba h1:gCYQHNRq9V0FMC1pIMQ5trLHkFZP+68txj+IVhToibs=
+github.com/bytebase/tidb/parser v0.0.0-20221028032950-1eefadef45ba/go.mod h1:wjvp+T3/T9XYt0nKqGX3Kc1AKuyUcfno6LTc6b2A6ew=
 github.com/casbin/casbin/v2 v2.1.0/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/casbin/casbin/v2 v2.55.1 h1:vaTAHSLkQfielg9UiHdIdvIVK/NAmMjBkDkrOM9iDqI=
 github.com/casbin/casbin/v2 v2.55.1/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=

--- a/plugin/parser/edit/mysql/schema_test.go
+++ b/plugin/parser/edit/mysql/schema_test.go
@@ -64,7 +64,7 @@ func TestDeparseDatabaseEdit(t *testing.T) {
 					},
 				},
 			},
-			want: "CREATE TABLE `t1` (\n  `id` INT NOT NULL\n) ENGINE = InnoDB;\nCREATE TABLE `t2` (\n  `id` INT NOT NULL\n) ENGINE = InnoDB;",
+			want: "CREATE TABLE `t1` (\n  `id` INT NOT NULL\n) ENGINE=InnoDB;\nCREATE TABLE `t2` (\n  `id` INT NOT NULL\n) ENGINE=InnoDB;",
 		},
 		{
 			name: "create table t1 with name",
@@ -92,7 +92,7 @@ func TestDeparseDatabaseEdit(t *testing.T) {
 					},
 				},
 			},
-			want: "CREATE TABLE `t1` (\n  `id` INT COMMENT 'ID' DEFAULT '0',\n  `name` VARCHAR CHARACTER SET UTF8MB4 COLLATE utf8mb4_bin COMMENT 'Name' NOT NULL\n) ENGINE = InnoDB;",
+			want: "CREATE TABLE `t1` (\n  `id` INT COMMENT 'ID' DEFAULT '0',\n  `name` VARCHAR CHARACTER SET UTF8MB4 COLLATE utf8mb4_bin COMMENT 'Name' NOT NULL\n) ENGINE=InnoDB;",
 		},
 	}
 


### PR DESCRIPTION
I am a bot from renovate. 🤖️

Make [TiDB parser restore more pretty](https://github.com/bytebase/tidb/pull/2?notification_referrer_id=NT_kwDOBTppqrM0NzAzMDkyODEzOjg3NzE0MjE4#pullrequestreview-1159318269) to fix the double space case in #3154 