### PR TITLE
feat(flashback): get rollback SQL for a binlog transaction

### DIFF
--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -8,10 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	regexpDatabaseTable = regexp.MustCompile("`(.+)`\\.`(.+)`")
-)
-
 // GetRollbackSQL generates the rollback SQL for the list of binlog events in the reversed order.
 func (txn BinlogTransaction) GetRollbackSQL(columnNames []string) (string, error) {
 	if len(txn) == 0 {
@@ -34,222 +30,98 @@ func (txn BinlogTransaction) GetRollbackSQL(columnNames []string) (string, error
 	return strings.Join(sqlList, "\n"), nil
 }
 
+var (
+	reDMLBlockPrefix = regexp.MustCompile("(?m)^### ")
+	reInsertInto     = regexp.MustCompile("(?m)^INSERT INTO")
+	reDeleteFrom     = regexp.MustCompile("(?m)^DELETE FROM")
+)
+
 func (e *BinlogEvent) getRollbackSQL(columnNames []string) (string, error) {
-	body, err := e.parseDMLBody()
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse the body %q of %s event", e.Body, e.Type.String())
-	}
+	// 1. Remove the "### " prefix of each line.
+	body := reDMLBlockPrefix.ReplaceAllLiteralString(e.Body, "")
 
-	if len(body.oldDataList) > 0 && len(body.oldDataList[0]) != len(columnNames) {
-		return "", errors.Errorf("provided %d columns, but got %d values in the old data list of the %s event", len(columnNames), len(body.oldDataList), e.Type.String())
-	}
-	if len(body.newDataList) > 0 && len(body.newDataList[0]) != len(columnNames) {
-		return "", errors.Errorf("provided %d columns, but got %d values in the new data list of the %s event", len(columnNames), len(body.newDataList), e.Type.String())
-	}
-
-	var sqlList []string
+	// 2. Switch "DELETE FROM" and "INSERT INTO".
+	// 3. Replace "WHERE" and "SET" with each other.
+	// 4. Replace "@i" with the column names.
+	// 5. Add a ";" at the end of each row.
+	var err error
 	switch e.Type {
 	case WriteRowsEventType:
-		for _, row := range body.newDataList {
-			var where []string
-			for i := range columnNames {
-				where = append(where, fmt.Sprintf("%s=%s", columnNames[i], row[i]))
-			}
-			sqlList = append(sqlList, fmt.Sprintf("DELETE FROM `%s`.`%s` WHERE %s;", body.database, body.table, strings.Join(where, " AND ")))
+		body = reInsertInto.ReplaceAllLiteralString(body, "DELETE FROM")
+		body = strings.ReplaceAll(body, "\nSET", "\nWHERE")
+		body, err = replaceColumns(columnNames, body, "\nWHERE", " AND")
+		if err != nil {
+			return "", err
 		}
+		return addSemicolon(body, "\nDELETE FROM"), nil
 	case DeleteRowsEventType:
-		cols := strings.Join(columnNames, ", ")
-		for _, row := range body.oldDataList {
-			vals := strings.Join(row, ", ")
-			sqlList = append(sqlList, fmt.Sprintf("INSERT INTO `%s`.`%s` (%s) VALUES (%s);", body.database, body.table, cols, vals))
+		body = reDeleteFrom.ReplaceAllLiteralString(body, "INSERT INTO")
+		body = strings.ReplaceAll(body, "\nWHERE", "\nSET")
+		body, err = replaceColumns(columnNames, body, "\nSET", ",")
+		if err != nil {
+			return "", err
 		}
+		return addSemicolon(body, "\nINSERT INTO"), nil
 	case UpdateRowsEventType:
-		for i := range body.oldDataList {
-			var where []string
-			var set []string
-			for j, colName := range columnNames {
-				where = append(where, fmt.Sprintf("%s=%s", colName, body.newDataList[i][j]))
-				set = append(set, fmt.Sprintf("%s=%s", colName, body.oldDataList[i][j]))
+		body = strings.ReplaceAll(body, "\nWHERE", "\nOLDWHERE")
+		body = strings.ReplaceAll(body, "\nSET", "\nWHERE")
+		body = strings.ReplaceAll(body, "\nOLDWHERE", "\nSET")
+		body, err = replaceColumns(columnNames, body, "\nWHERE", " AND")
+		if err != nil {
+			return "", err
+		}
+		body, err = replaceColumns(columnNames, body, "\nSET", ",")
+		if err != nil {
+			return "", err
+		}
+		return addSemicolon(body, "\nUPDATE"), nil
+	}
+
+	return "", errors.Errorf("invalid binlog event type %s", e.Type.String())
+}
+
+func addSemicolon(sql, delimiter string) string {
+	rows := strings.Split(sql, delimiter)
+	// rows = rows[1:]
+	// rows[0] = delimiter + rows[0]
+	for i := range rows {
+		rows[i] = strings.TrimSuffix(rows[i], "\n")
+	}
+	return strings.Join(rows, ";"+delimiter) + ";"
+}
+
+func replaceColumns(columnNames []string, body, delimBlock, delimCol string) (string, error) {
+	var rows []string
+	// Split the block with "\nWHERE" or "\nSET".
+	blocks := strings.Split(body, delimBlock)
+	rows = append(rows, blocks[0])
+	for _, block := range blocks[1:] {
+		// prefixLocs is the index of all column placeholders "@i", which uses the same format as strings.FindAllStringIndex.
+		var prefixLocs [][]int
+		for i := range columnNames {
+			prefix := fmt.Sprintf("\n  @%d=", i+1)
+			colIndex := strings.Index(block, prefix)
+			if colIndex == -1 {
+				return "", errors.Errorf("the block has fewer values than columns, which means the schema has changed after executing the original task")
 			}
-			sqlList = append(sqlList, fmt.Sprintf("UPDATE `%s`.`%s` SET %s WHERE %s;", body.database, body.table, strings.Join(set, ", "), strings.Join(where, " AND ")))
+			prefixLocs = append(prefixLocs, []int{colIndex, colIndex + len(prefix)})
 		}
-	}
-
-	return strings.Join(sqlList, "\n"), nil
-}
-
-type dmlBody struct {
-	database    string
-	table       string
-	oldDataList [][]string
-	newDataList [][]string
-}
-
-func (e *BinlogEvent) parseDMLBody() (*dmlBody, error) {
-	body := strings.Split(e.Body, "\n")
-	if len(body) < e.minBlockLen() {
-		return nil, errors.Errorf("invalid %s event body, must be at least %d lines, but got %#v", e.Type.String(), e.minBlockLen(), body)
-	}
-	groups, err := e.splitDMLBody(body)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to split %s event body %#v", e.Type.String(), body)
-	}
-
-	var parsedBody dmlBody
-	for _, block := range groups {
-		if len(block) < e.minBlockLen() {
-			return nil, errors.Errorf("binlog event block must be at least %d lines, but got %#v", e.minBlockLen(), block)
-		}
-		matches := regexpDatabaseTable.FindStringSubmatch(block[0])
-		if len(matches) != 3 {
-			return nil, errors.Errorf("failed to parse database and table from the %s event body block %q", e.Type.String(), strings.Join(block, "\n"))
-		}
-		parsedBody.database = matches[1]
-		parsedBody.table = matches[2]
-		dataOld, dataNew, err := e.parseDMLBlock(block)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse the %s event block", e.Type.String())
-		}
-		if dataOld != nil {
-			parsedBody.oldDataList = append(parsedBody.oldDataList, dataOld)
-		}
-		if dataNew != nil {
-			parsedBody.newDataList = append(parsedBody.newDataList, dataNew)
-		}
-	}
-
-	if err := validateRows(parsedBody.oldDataList, e.Type.String(), e.Body); err != nil {
-		return nil, err
-	}
-	if err := validateRows(parsedBody.newDataList, e.Type.String(), e.Body); err != nil {
-		return nil, err
-	}
-	if len(parsedBody.oldDataList) > 0 &&
-		len(parsedBody.newDataList) > 0 &&
-		len(parsedBody.oldDataList) != len(parsedBody.newDataList) {
-		return nil, errors.Errorf("invalid %s event block, the old data list has %d items, but the new data list has %d items", e.Type.String(), len(parsedBody.oldDataList), len(parsedBody.newDataList))
-	}
-
-	return &parsedBody, nil
-}
-
-// validateRows checks that all the rows have the same number of columns.
-func validateRows(rows [][]string, eventType, body string) error {
-	if len(rows) > 0 {
-		cols := len(rows[0])
-		for _, row := range rows[1:] {
-			if len(row) != cols {
-				return errors.Errorf("inconsistent value length found in the %s event body %q", eventType, body)
+		var row []string
+		for i, name := range columnNames {
+			left := prefixLocs[i][1]
+			var right int
+			if i < len(columnNames)-1 {
+				// For columns except the last one.
+				right = prefixLocs[i+1][0]
+			} else {
+				// Write to the end of the block.
+				right = len(block)
 			}
+			row = append(row, fmt.Sprintf("\n  `%s`=%s", name, block[left:right]))
 		}
+		rows = append(rows, strings.Join(row, delimCol))
 	}
-	return nil
-}
-
-func (e *BinlogEvent) parseDMLBlock(block []string) (dataOld []string, dataNew []string, err error) {
-	block = block[1:]
-	switch e.Type {
-	case DeleteRowsEventType:
-		// Example block:
-		// ### DELETE FROM `database`.`table`
-		// ### WHERE
-		// ###   @1=x
-		//       ...
-		where, err := parseDMLBlockSection(block, "WHERE")
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to parse the WHERE section of the DELETE event")
-		}
-		return where, nil, nil
-	case UpdateRowsEventType:
-		// Example block:
-		// ### UPDATE `database`.`table`
-		// ### WHERE
-		// ###   @1=x
-		//       ...
-		// ### SET
-		// ###   @1=y
-		// 	     ...
-		if len(block)%2 != 0 {
-			return nil, nil, errors.Errorf("invalid UPDATE event block, WHERE clause length != SET clause length: %#v", block)
-		}
-		where, err := parseDMLBlockSection(block[:len(block)/2], "WHERE")
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to parse the WHERE section of the UPDATE event")
-		}
-		block = block[len(block)/2:]
-		set, err := parseDMLBlockSection(block, "SET")
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to parse the SET section of the UPDATE event")
-		}
-		return where, set, nil
-	case WriteRowsEventType:
-		// Example block:
-		// ### INSERT INTO `database`.`table`
-		// ### SET
-		// ###   @1=x
-		//       ...
-		set, err := parseDMLBlockSection(block, "SET")
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to parse the SET section of the INSERT event")
-		}
-		return nil, set, nil
-	default:
-		// This is to make the compiler happy.
-		return nil, nil, errors.Errorf("invalid DML binlog event type %s", e.Type.String())
-	}
-}
-
-func (e *BinlogEvent) splitDMLBody(lines []string) ([][]string, error) {
-	var groups [][]string
-	var group []string
-	for _, line := range lines {
-		if len(line) == 0 {
-			// Skip empty lines.
-			continue
-		}
-		if !strings.HasPrefix(line, "### ") {
-			return nil, errors.Errorf("invalid event body line %q, must start with \"### \"", line)
-		}
-		// Starts of a new group.
-		if strings.HasPrefix(line, fmt.Sprintf("### %s", e.Type.String())) {
-			if len(group) > 0 {
-				groups = append(groups, group)
-				group = nil
-			}
-		}
-		group = append(group, line)
-	}
-	// The last group.
-	groups = append(groups, group)
-	return groups, nil
-}
-
-func parseDMLBlockSection(lines []string, header string) ([]string, error) {
-	if lines[0] != fmt.Sprintf("### %s", header) {
-		return nil, errors.Errorf("failed to parse event body's first line, expecting \"### %s\", but got %q", header, lines[0])
-	}
-	var values []string
-	for i, line := range lines[1:] {
-		prefix := fmt.Sprintf("###   @%d=", i+1)
-		if !strings.HasPrefix(line, prefix) {
-			return nil, errors.Errorf("invalid binlog event body line %q, expecting prefix %q", line, prefix)
-		}
-		values = append(values, strings.TrimPrefix(line, prefix))
-	}
-	return values, nil
-}
-
-func (e *BinlogEvent) minBlockLen() int {
-	switch e.Type {
-	case DeleteRowsEventType:
-		return 3
-	case UpdateRowsEventType:
-		return 5
-	case WriteRowsEventType:
-		return 3
-	default:
-		return 0
-	}
+	return strings.Join(rows, delimBlock), nil
 }
 
 func (t BinlogEventType) String() string {

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -82,8 +82,6 @@ func (e *BinlogEvent) getRollbackSQL(columnNames []string) (string, error) {
 
 func addSemicolon(sql, delimiter string) string {
 	rows := strings.Split(sql, delimiter)
-	// rows = rows[1:]
-	// rows[0] = delimiter + rows[0]
 	for i := range rows {
 		rows[i] = strings.TrimSuffix(rows[i], "\n")
 	}

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -45,18 +45,10 @@ func (e *BinlogEvent) getRollbackSQL(columnNames []string) (string, error) {
 		body = replaceAllPrefix(body, "INSERT INTO", "DELETE FROM")
 		body = replaceAllPrefix(body, "SET", "WHERE")
 		body, err = replaceColumns(columnNames, body, "WHERE", " AND", ";")
-		if err != nil {
-			return "", err
-		}
-		return strings.Join(body, "\n"), nil
 	case DeleteRowsEventType:
 		body = replaceAllPrefix(body, "DELETE FROM", "INSERT INTO")
 		body = replaceAllPrefix(body, "WHERE", "SET")
 		body, err = replaceColumns(columnNames, body, "SET", ",", ";")
-		if err != nil {
-			return "", err
-		}
-		return strings.Join(body, "\n"), nil
 	case UpdateRowsEventType:
 		body = replaceAllPrefix(body, "WHERE", "OLDWHERE")
 		body = replaceAllPrefix(body, "SET", "WHERE")
@@ -66,12 +58,11 @@ func (e *BinlogEvent) getRollbackSQL(columnNames []string) (string, error) {
 			return "", err
 		}
 		body, err = replaceColumns(columnNames, body, "WHERE", " AND", ";")
-		if err != nil {
-			return "", err
-		}
-		return strings.Join(body, "\n"), nil
+	default:
+		return "", errors.Errorf("invalid binlog event type %s", e.Type.String())
 	}
-	return "", errors.Errorf("invalid binlog event type %s", e.Type.String())
+
+	return strings.Join(body, "\n"), err
 }
 
 func replaceAllPrefix(body []string, old, new string) []string {

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -17,8 +17,7 @@ func (txn BinlogTransaction) GetRollbackSQL(columnNames []string) (string, error
 	if len(txn) == 0 {
 		return "", nil
 	}
-	var sb strings.Builder
-	_, _ = sb.WriteString("BEGIN;\n")
+	var sqlList []string
 	// Generate rollback SQL for each statement of the transaction in reversed order.
 	// Each statement may have multiple affected rows in a single binlog event. The order between them is irrelevant.
 	for i := len(txn) - 1; i >= 0; i-- {
@@ -30,11 +29,9 @@ func (txn BinlogTransaction) GetRollbackSQL(columnNames []string) (string, error
 		if err != nil {
 			return "", err
 		}
-		_, _ = sb.WriteString(sql)
-		_, _ = sb.WriteString("\n")
+		sqlList = append(sqlList, sql)
 	}
-	_, _ = sb.WriteString("COMMIT;")
-	return sb.String(), nil
+	return strings.Join(sqlList, "\n"), nil
 }
 
 func (e *BinlogEvent) getRollbackSQL(columnNames []string) (string, error) {

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -1,0 +1,268 @@
+package mysql
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	regexpDatabaseTable = regexp.MustCompile("`(.+)`\\.`(.+)`")
+)
+
+// GetRollbackSQL generates the rollback SQL for the list of binlog events in the reversed order.
+func (txn BinlogTransaction) GetRollbackSQL(columnNames []string) (string, error) {
+	if len(txn) == 0 {
+		return "", nil
+	}
+	var sb strings.Builder
+	_, _ = sb.WriteString("BEGIN;\n")
+	// Generate rollback SQL for each statement of the transaction in reversed order.
+	// Each statement may have multiple affected rows in a single binlog event. The order between them is irrelevant.
+	for i := len(txn) - 1; i >= 0; i-- {
+		e := txn[i]
+		if e.Type != WriteRowsEventType && e.Type != DeleteRowsEventType && e.Type != UpdateRowsEventType {
+			continue
+		}
+		sql, err := e.getRollbackSQL(columnNames)
+		if err != nil {
+			return "", err
+		}
+		_, _ = sb.WriteString(sql)
+		_, _ = sb.WriteString("\n")
+	}
+	_, _ = sb.WriteString("COMMIT;")
+	return sb.String(), nil
+}
+
+func (e *BinlogEvent) getRollbackSQL(columnNames []string) (string, error) {
+	body, err := e.parseDMLBody()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse the body %q of %s event", e.Body, e.Type.String())
+	}
+
+	if len(body.oldDataList) > 0 && len(body.oldDataList[0]) != len(columnNames) {
+		return "", errors.Errorf("provided %d columns, but got %d values in the old data list of the %s event", len(columnNames), len(body.oldDataList), e.Type.String())
+	}
+	if len(body.newDataList) > 0 && len(body.newDataList[0]) != len(columnNames) {
+		return "", errors.Errorf("provided %d columns, but got %d values in the new data list of the %s event", len(columnNames), len(body.newDataList), e.Type.String())
+	}
+
+	var sqlList []string
+	switch e.Type {
+	case WriteRowsEventType:
+		for _, row := range body.newDataList {
+			var where []string
+			for i := range columnNames {
+				where = append(where, fmt.Sprintf("%s=%s", columnNames[i], row[i]))
+			}
+			sqlList = append(sqlList, fmt.Sprintf("DELETE FROM `%s`.`%s` WHERE %s;", body.database, body.table, strings.Join(where, " AND ")))
+		}
+	case DeleteRowsEventType:
+		cols := strings.Join(columnNames, ", ")
+		for _, row := range body.oldDataList {
+			vals := strings.Join(row, ", ")
+			sqlList = append(sqlList, fmt.Sprintf("INSERT INTO `%s`.`%s` (%s) VALUES (%s);", body.database, body.table, cols, vals))
+		}
+	case UpdateRowsEventType:
+		for i := range body.oldDataList {
+			var where []string
+			var set []string
+			for j, colName := range columnNames {
+				where = append(where, fmt.Sprintf("%s=%s", colName, body.newDataList[i][j]))
+				set = append(set, fmt.Sprintf("%s=%s", colName, body.oldDataList[i][j]))
+			}
+			sqlList = append(sqlList, fmt.Sprintf("UPDATE `%s`.`%s` SET %s WHERE %s;", body.database, body.table, strings.Join(set, ", "), strings.Join(where, " AND ")))
+		}
+	}
+
+	return strings.Join(sqlList, "\n"), nil
+}
+
+type dmlBody struct {
+	database    string
+	table       string
+	oldDataList [][]string
+	newDataList [][]string
+}
+
+func (e *BinlogEvent) parseDMLBody() (*dmlBody, error) {
+	body := strings.Split(e.Body, "\n")
+	if len(body) < e.minBlockLen() {
+		return nil, errors.Errorf("invalid %s event body, must be at least %d lines, but got %#v", e.Type.String(), e.minBlockLen(), body)
+	}
+	groups, err := e.splitDMLBody(body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to split %s event body %#v", e.Type.String(), body)
+	}
+
+	var parsedBody dmlBody
+	for _, block := range groups {
+		if len(block) < e.minBlockLen() {
+			return nil, errors.Errorf("binlog event block must be at least %d lines, but got %#v", e.minBlockLen(), block)
+		}
+		matches := regexpDatabaseTable.FindStringSubmatch(block[0])
+		if len(matches) != 3 {
+			return nil, errors.Errorf("failed to parse database and table from the %s event body block %q", e.Type.String(), strings.Join(block, "\n"))
+		}
+		parsedBody.database = matches[1]
+		parsedBody.table = matches[2]
+		dataOld, dataNew, err := e.parseDMLBlock(block)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse the %s event block", e.Type.String())
+		}
+		if dataOld != nil {
+			parsedBody.oldDataList = append(parsedBody.oldDataList, dataOld)
+		}
+		if dataNew != nil {
+			parsedBody.newDataList = append(parsedBody.newDataList, dataNew)
+		}
+	}
+
+	if err := validateRows(parsedBody.oldDataList, e.Type.String(), e.Body); err != nil {
+		return nil, err
+	}
+	if err := validateRows(parsedBody.newDataList, e.Type.String(), e.Body); err != nil {
+		return nil, err
+	}
+	if len(parsedBody.oldDataList) > 0 &&
+		len(parsedBody.newDataList) > 0 &&
+		len(parsedBody.oldDataList) != len(parsedBody.newDataList) {
+		return nil, errors.Errorf("invalid %s event block, the old data list has %d items, but the new data list has %d items", e.Type.String(), len(parsedBody.oldDataList), len(parsedBody.newDataList))
+	}
+
+	return &parsedBody, nil
+}
+
+// validateRows checks that all the rows have the same number of columns.
+func validateRows(rows [][]string, eventType, body string) error {
+	if len(rows) > 0 {
+		cols := len(rows[0])
+		for _, row := range rows[1:] {
+			if len(row) != cols {
+				return errors.Errorf("inconsistent value length found in the %s event body %q", eventType, body)
+			}
+		}
+	}
+	return nil
+}
+
+func (e *BinlogEvent) parseDMLBlock(block []string) (dataOld []string, dataNew []string, err error) {
+	block = block[1:]
+	switch e.Type {
+	case DeleteRowsEventType:
+		// Example block:
+		// ### DELETE FROM `database`.`table`
+		// ### WHERE
+		// ###   @1=x
+		//       ...
+		where, err := parseDMLBlockSection(block, "WHERE")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the WHERE section of the DELETE event")
+		}
+		return where, nil, nil
+	case UpdateRowsEventType:
+		// Example block:
+		// ### UPDATE `database`.`table`
+		// ### WHERE
+		// ###   @1=x
+		//       ...
+		// ### SET
+		// ###   @1=y
+		// 	     ...
+		if len(block)%2 != 0 {
+			return nil, nil, errors.Errorf("invalid UPDATE event block, WHERE clause length != SET clause length: %#v", block)
+		}
+		where, err := parseDMLBlockSection(block[:len(block)/2], "WHERE")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the WHERE section of the UPDATE event")
+		}
+		block = block[len(block)/2:]
+		set, err := parseDMLBlockSection(block, "SET")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the SET section of the UPDATE event")
+		}
+		return where, set, nil
+	case WriteRowsEventType:
+		// Example block:
+		// ## INSERT INTO `database`.`table`
+		// ### SET
+		// ###   @1=x
+		//       ...
+		set, err := parseDMLBlockSection(block, "SET")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to parse the SET section of the INSERT event")
+		}
+		return nil, set, nil
+	default:
+		return nil, nil, errors.Errorf("invalid DML binlog event type %s", e.Type.String())
+	}
+}
+
+func (e *BinlogEvent) splitDMLBody(lines []string) ([][]string, error) {
+	var groups [][]string
+	var group []string
+	for _, line := range lines {
+		if len(line) == 0 {
+			// Skip empty lines.
+			continue
+		}
+		if !strings.HasPrefix(line, "### ") {
+			return nil, errors.Errorf("invalid event body line %q, must start with \"### \"", line)
+		}
+		// Starts of a new group.
+		if strings.HasPrefix(line, fmt.Sprintf("### %s", e.Type.String())) {
+			if len(group) > 0 {
+				groups = append(groups, group)
+				group = nil
+			}
+		}
+		group = append(group, line)
+	}
+	// The last group.
+	groups = append(groups, group)
+	return groups, nil
+}
+
+func parseDMLBlockSection(lines []string, header string) ([]string, error) {
+	if lines[0] != fmt.Sprintf("### %s", header) {
+		return nil, errors.Errorf("failed to parse event body's first line, expecting \"### %s\", but got %q", header, lines[0])
+	}
+	var values []string
+	for i, line := range lines[1:] {
+		prefix := fmt.Sprintf("###   @%d=", i+1)
+		if !strings.HasPrefix(line, prefix) {
+			return nil, errors.Errorf("invalid binlog event body line %q, expecting prefix %q", line, prefix)
+		}
+		values = append(values, strings.TrimPrefix(line, prefix))
+	}
+	return values, nil
+}
+
+func (e *BinlogEvent) minBlockLen() int {
+	switch e.Type {
+	case DeleteRowsEventType:
+		return 3
+	case UpdateRowsEventType:
+		return 5
+	case WriteRowsEventType:
+		return 3
+	default:
+		return -1
+	}
+}
+
+func (t BinlogEventType) String() string {
+	switch t {
+	case DeleteRowsEventType:
+		return "DELETE"
+	case UpdateRowsEventType:
+		return "UPDATE"
+	case WriteRowsEventType:
+		return "INSERT"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -187,7 +187,7 @@ func (e *BinlogEvent) parseDMLBlock(block []string) (dataOld []string, dataNew [
 		return where, set, nil
 	case WriteRowsEventType:
 		// Example block:
-		// ## INSERT INTO `database`.`table`
+		// ### INSERT INTO `database`.`table`
 		// ### SET
 		// ###   @1=x
 		//       ...

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -197,6 +197,7 @@ func (e *BinlogEvent) parseDMLBlock(block []string) (dataOld []string, dataNew [
 		}
 		return nil, set, nil
 	default:
+		// This is to make the compiler happy.
 		return nil, nil, errors.Errorf("invalid DML binlog event type %s", e.Type.String())
 	}
 }
@@ -250,7 +251,7 @@ func (e *BinlogEvent) minBlockLen() int {
 	case WriteRowsEventType:
 		return 3
 	default:
-		return -1
+		return 0
 	}
 }
 
@@ -262,6 +263,10 @@ func (t BinlogEventType) String() string {
 		return "UPDATE"
 	case WriteRowsEventType:
 		return "INSERT"
+	case QueryEventType:
+		return "QUERY"
+	case XidEventType:
+		return "XID"
 	default:
 		return "UNKNOWN"
 	}

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -60,11 +60,9 @@ BEGIN
 				},
 			},
 			columnNames: []string{"id", "name", "balance"},
-			rollbackSQL: `BEGIN;
-DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=1 AND name='alice' AND balance=100;
+			rollbackSQL: `DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=1 AND name='alice' AND balance=100;
 DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=2 AND name='bob' AND balance=100;
-DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=3 AND name='cindy' AND balance=100;
-COMMIT;`,
+DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=3 AND name='cindy' AND balance=100;`,
 			err: false,
 		},
 		{
@@ -114,10 +112,8 @@ BEGIN
 				},
 			},
 			columnNames: []string{"id", "name", "balance"},
-			rollbackSQL: `BEGIN;
-UPDATE ` + "`binlog_test`.`user`" + ` SET id=2, name='bob', balance=100 WHERE id=2 AND name='bob' AND balance=110;
-UPDATE ` + "`binlog_test`.`user`" + ` SET id=1, name='alice', balance=100 WHERE id=1 AND name='alice' AND balance=90;
-COMMIT;`,
+			rollbackSQL: `UPDATE ` + "`binlog_test`.`user`" + ` SET id=2, name='bob', balance=100 WHERE id=2 AND name='bob' AND balance=110;
+UPDATE ` + "`binlog_test`.`user`" + ` SET id=1, name='alice', balance=100 WHERE id=1 AND name='alice' AND balance=90;`,
 			err: false,
 		},
 		{
@@ -158,10 +154,8 @@ DELIMITER ;
 				},
 			},
 			columnNames: []string{"id", "name", "balance"},
-			rollbackSQL: `BEGIN;
-INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (1, 'alice', 0);
-INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (2, 'bob', 0);
-COMMIT;`,
+			rollbackSQL: `INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (1, 'alice', 0);
+INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (2, 'bob', 0);`,
 			err: false,
 		},
 		{

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -60,9 +60,21 @@ BEGIN
 				},
 			},
 			columnNames: []string{"id", "name", "balance"},
-			rollbackSQL: `DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=1 AND name='alice' AND balance=100;
-DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=2 AND name='bob' AND balance=100;
-DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=3 AND name='cindy' AND balance=100;`,
+			rollbackSQL: `DELETE FROM ` + "`binlog_test`.`user`" + `
+WHERE
+  ` + "`id`" + `=1 AND
+  ` + "`name`" + `='alice' AND
+  ` + "`balance`" + `=100;
+DELETE FROM ` + "`binlog_test`.`user`" + `
+WHERE
+  ` + "`id`" + `=2 AND
+  ` + "`name`" + `='bob' AND
+  ` + "`balance`" + `=100;
+DELETE FROM ` + "`binlog_test`.`user`" + `
+WHERE
+  ` + "`id`" + `=3 AND
+  ` + "`name`" + `='cindy' AND
+  ` + "`balance`" + `=100;`,
 			err: false,
 		},
 		{
@@ -112,8 +124,24 @@ BEGIN
 				},
 			},
 			columnNames: []string{"id", "name", "balance"},
-			rollbackSQL: `UPDATE ` + "`binlog_test`.`user`" + ` SET id=2, name='bob', balance=100 WHERE id=2 AND name='bob' AND balance=110;
-UPDATE ` + "`binlog_test`.`user`" + ` SET id=1, name='alice', balance=100 WHERE id=1 AND name='alice' AND balance=90;`,
+			rollbackSQL: `UPDATE ` + "`binlog_test`.`user`" + `
+SET
+  ` + "`id`" + `=2,
+  ` + "`name`" + `='bob',
+  ` + "`balance`" + `=100
+WHERE
+  ` + "`id`" + `=2 AND
+  ` + "`name`" + `='bob' AND
+  ` + "`balance`" + `=110;
+UPDATE ` + "`binlog_test`.`user`" + `
+SET
+  ` + "`id`" + `=1,
+  ` + "`name`" + `='alice',
+  ` + "`balance`" + `=100
+WHERE
+  ` + "`id`" + `=1 AND
+  ` + "`name`" + `='alice' AND
+  ` + "`balance`" + `=90;`,
 			err: false,
 		},
 		{
@@ -154,8 +182,16 @@ DELIMITER ;
 				},
 			},
 			columnNames: []string{"id", "name", "balance"},
-			rollbackSQL: `INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (1, 'alice', 0);
-INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (2, 'bob', 0);`,
+			rollbackSQL: `INSERT INTO ` + "`binlog_test`.`user`" + `
+SET
+  ` + "`id`" + `=1,
+  ` + "`name`" + `='alice',
+  ` + "`balance`" + `=0;
+INSERT INTO ` + "`binlog_test`.`user`" + `
+SET
+  ` + "`id`" + `=2,
+  ` + "`name`" + `='bob',
+  ` + "`balance`" + `=0;`,
 			err: false,
 		},
 		{

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -49,8 +49,7 @@ BEGIN
 ### SET
 ###   @1=3
 ###   @2='cindy'
-###   @3=100
-`,
+###   @3=100`,
 				},
 				{
 					Type:   XidEventType,
@@ -99,8 +98,7 @@ BEGIN
 ### SET
 ###   @1=1
 ###   @2='alice'
-###   @3=90
-`,
+###   @3=90`,
 				},
 				{
 					Type:   UpdateRowsEventType,
@@ -113,8 +111,7 @@ BEGIN
 ### SET
 ###   @1=2
 ###   @2='bob'
-###   @3=110
-`,
+###   @3=110`,
 				},
 				{
 					Type:   XidEventType,
@@ -167,8 +164,7 @@ BEGIN
 ### WHERE
 ###   @1=2
 ###   @2='bob'
-###   @3=0
-`,
+###   @3=0`,
 				},
 				{
 					Type:   XidEventType,
@@ -204,8 +200,7 @@ SET
 ### WHERE
 ###   @1=1
 ###   @2='alice'
-###   @3=0
-`,
+###   @3=0`,
 				},
 			},
 			columnNames: []string{"id", "name", "balance", "new_field"},

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -1,0 +1,199 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRollbackSQL(t *testing.T) {
+	tests := []struct {
+		name        string
+		txn         BinlogTransaction
+		columnNames []string
+		rollbackSQL string
+		err         bool
+	}{
+		{
+			name:        "empty",
+			txn:         BinlogTransaction{},
+			columnNames: []string{"what", "ever"},
+			rollbackSQL: "",
+			err:         false,
+		},
+		{
+			name: "INSERT",
+			txn: BinlogTransaction{
+				{
+					Type:   QueryEventType,
+					Header: "#221017 14:25:24 server id 1  end_log_pos 772 CRC32 0x37cb53f6 	Query	thread_id=53771	exec_time=0	error_code=0\n",
+					Body: `SET TIMESTAMP=1665987924/*!*/;
+BEGIN
+/*!*/;
+`,
+				},
+				{
+					Type:   WriteRowsEventType,
+					Header: "#221017 14:25:24 server id 1  end_log_pos 916 CRC32 0x896854fc 	Write_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### INSERT INTO ` + "`binlog_test`.`user`" + `
+### SET
+###   @1=1
+###   @2='alice'
+###   @3=100
+### INSERT INTO ` + "`binlog_test`.`user`" + `
+### SET
+###   @1=2
+###   @2='bob'
+###   @3=100
+### INSERT INTO ` + "`binlog_test`.`user`" + `
+### SET
+###   @1=3
+###   @2='cindy'
+###   @3=100
+`,
+				},
+				{
+					Type:   XidEventType,
+					Header: "#221017 14:25:24 server id 1  end_log_pos 947 CRC32 0xaf8e8303 	Xid = 327602\n",
+					Body: `COMMIT/*!*/;
+`,
+				},
+			},
+			columnNames: []string{"id", "name", "balance"},
+			rollbackSQL: `BEGIN;
+DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=1 AND name='alice' AND balance=100;
+DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=2 AND name='bob' AND balance=100;
+DELETE FROM ` + "`binlog_test`.`user`" + ` WHERE id=3 AND name='cindy' AND balance=100;
+COMMIT;`,
+			err: false,
+		},
+		{
+			name: "UPDATE",
+			txn: BinlogTransaction{
+				{
+					Type:   QueryEventType,
+					Header: "#221017 14:25:53 server id 1  end_log_pos 1117 CRC32 0x5842528e 	Query	thread_id=53771	exec_time=0	error_code=0\n",
+					Body: `SET TIMESTAMP=1665987953/*!*/;
+BEGIN
+/*!*/;
+`,
+				},
+				{
+					Type:   UpdateRowsEventType,
+					Header: "#221017 14:25:53 server id 1  end_log_pos 1249 CRC32 0x3d8fa43e 	Update_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### UPDATE ` + "`binlog_test`.`user`" + `
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=100
+### SET
+###   @1=1
+###   @2='alice'
+###   @3=90
+`,
+				},
+				{
+					Type:   UpdateRowsEventType,
+					Header: "#221017 14:26:08 server id 1  end_log_pos 1377 CRC32 0xd7bb3662 	Update_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### UPDATE ` + "`binlog_test`.`user`" + `
+### WHERE
+###   @1=2
+###   @2='bob'
+###   @3=100
+### SET
+###   @1=2
+###   @2='bob'
+###   @3=110
+`,
+				},
+				{
+					Type:   XidEventType,
+					Header: "#221017 14:26:12 server id 1  end_log_pos 1408 CRC32 0xf2dd63fe 	Xid = 327607\n",
+					Body: `COMMIT/*!*/;
+`,
+				},
+			},
+			columnNames: []string{"id", "name", "balance"},
+			rollbackSQL: `BEGIN;
+UPDATE ` + "`binlog_test`.`user`" + ` SET id=2, name='bob', balance=100 WHERE id=2 AND name='bob' AND balance=110;
+UPDATE ` + "`binlog_test`.`user`" + ` SET id=1, name='alice', balance=100 WHERE id=1 AND name='alice' AND balance=90;
+COMMIT;`,
+			err: false,
+		},
+		{
+			name: "DELETE",
+			txn: BinlogTransaction{
+				{
+					Type:   QueryEventType,
+					Header: "#221018 16:21:45 server id 1  end_log_pos 2236 CRC32 0x965db1d1 	Query	thread_id=58599	exec_time=0	error_code=0\n",
+					Body: `SET TIMESTAMP=1666081305/*!*/;
+BEGIN
+/*!*/;
+`,
+				},
+				{
+					Type:   DeleteRowsEventType,
+					Header: "#221018 16:21:45 server id 1  end_log_pos 2365 CRC32 0xf759c90c 	Delete_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### DELETE FROM ` + "`binlog_test`.`user`" + `
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=0
+### DELETE FROM ` + "`binlog_test`.`user`" + `
+### WHERE
+###   @1=2
+###   @2='bob'
+###   @3=0
+`,
+				},
+				{
+					Type:   XidEventType,
+					Header: "#221018 16:21:45 server id 1  end_log_pos 2396 CRC32 0x816695ae 	Xid = 349604\n",
+					Body: `COMMIT/*!*/;
+SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
+DELIMITER ;
+# End of log file
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
+				},
+			},
+			columnNames: []string{"id", "name", "balance"},
+			rollbackSQL: `BEGIN;
+INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (1, 'alice', 0);
+INSERT INTO ` + "`binlog_test`.`user`" + ` (id, name, balance) VALUES (2, 'bob', 0);
+COMMIT;`,
+			err: false,
+		},
+		{
+			name: "schema changed",
+			txn: BinlogTransaction{
+				{
+					Type:   DeleteRowsEventType,
+					Header: "#221018 16:21:45 server id 1  end_log_pos 2365 CRC32 0xf759c90c 	Delete_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### DELETE FROM ` + "`binlog_test`.`user`" + `
+### WHERE
+###   @1=1
+###   @2='alice'
+###   @3=0
+`,
+				},
+			},
+			columnNames: []string{"id", "name", "balance", "new_field"},
+			rollbackSQL: "",
+			err:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := require.New(t)
+			sql, err := test.txn.GetRollbackSQL(test.columnNames)
+			if test.err {
+				a.Error(err)
+			} else {
+				a.NoError(err)
+				a.Equal(test.rollbackSQL, sql)
+			}
+		})
+	}
+}

--- a/resources/mysql/mysql.go
+++ b/resources/mysql/mysql.go
@@ -36,6 +36,11 @@ type Instance struct {
 	proc *os.Process
 }
 
+// DataDir returns the data dir.
+func (i Instance) DataDir() string {
+	return i.datadir
+}
+
 // Port returns the port of the mysql instance.
 func (i Instance) Port() int {
 	return i.port

--- a/tests/rollback_test.go
+++ b/tests/rollback_test.go
@@ -1,0 +1,120 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/plugin/db/mysql"
+	resourcemysql "github.com/bytebase/bytebase/resources/mysql"
+	"github.com/bytebase/bytebase/resources/mysqlutil"
+)
+
+func TestRollback(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	port := getTestPort(t.Name())
+
+	instance, stopFn := resourcemysql.SetupTestInstance(t, port)
+	binlogDir := instance.DataDir()
+	defer stopFn()
+
+	resourceDir := t.TempDir()
+	err := mysqlutil.Install(resourceDir)
+	a.NoError(err)
+
+	database := "funny\ndatabase"
+	db, err := connectTestMySQL(port, "")
+	a.NoError(err)
+	defer db.Close()
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`; USE `%s`;", database, database))
+	a.NoError(err)
+	_, err = db.ExecContext(ctx, "CREATE TABLE user (id INT PRIMARY KEY, name VARCHAR(64), balance INT);")
+	a.NoError(err)
+	_, err = db.ExecContext(ctx, "INSERT INTO user VALUES (1, 'alice\nalice', 100), (2, 'bob', 100), (3, 'cindy', 100);")
+	a.NoError(err)
+
+	txn, err := db.BeginTx(ctx, nil)
+	a.NoError(err)
+	_, err = txn.ExecContext(ctx, "UPDATE user SET balance=90 WHERE id=1;")
+	a.NoError(err)
+	_, err = txn.ExecContext(ctx, "UPDATE user SET balance=110 WHERE id=2;")
+	a.NoError(err)
+	_, err = txn.ExecContext(ctx, "DELETE FROM user WHERE id=3;")
+	a.NoError(err)
+	err = txn.Commit()
+	a.NoError(err)
+
+	// Rotate to binlog.000002 so that it's easy to rollback the following transactions and check that the state is the same as now.
+	_, err = db.ExecContext(ctx, "FLUSH BINARY LOGS;")
+	a.NoError(err)
+	_, err = db.ExecContext(ctx, "UPDATE user SET balance=0;")
+	a.NoError(err)
+	_, err = db.ExecContext(ctx, "DELETE FROM user;")
+	a.NoError(err)
+
+	t.Log("Set up mysqlbinlog")
+	args := []string{
+		path.Join(binlogDir, "binlog.000002"),
+		"--verify-binlog-checksum",
+		"-v",
+		"--base64-output=DECODE-ROWS",
+	}
+	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, resourceDir), args...)
+	cmd.Stderr = os.Stderr
+	pr, err := cmd.StdoutPipe()
+	a.NoError(err)
+	err = cmd.Start()
+	a.NoError(err)
+	defer func() {
+		err = pr.Close()
+		a.NoError(err)
+		err = cmd.Process.Kill()
+		a.NoError(err)
+	}()
+
+	txList, err := mysql.ParseBinlogStream(pr)
+	a.NoError(err)
+	a.Equal(2, len(txList))
+	var rollbackSQLList []string
+	for _, tx := range txList {
+		sql, err := tx.GetRollbackSQL([]string{"id", "name", "balance"})
+		a.NoError(err)
+		rollbackSQLList = append(rollbackSQLList, sql)
+	}
+
+	// Execute the rollback SQL in reversed order.
+	for i := len(rollbackSQLList) - 1; i >= 0; i-- {
+		sql := rollbackSQLList[i]
+		t.Log(sql)
+		_, err = db.ExecContext(ctx, sql)
+		a.NoError(err)
+	}
+
+	// Check for rollback state.
+	rows, err := db.QueryContext(ctx, "SELECT * FROM user;")
+	a.NoError(err)
+	type record struct {
+		id      int
+		name    string
+		balance int
+	}
+	var records []record
+	for rows.Next() {
+		var r record
+		err = rows.Scan(&r.id, &r.name, &r.balance)
+		a.NoError(err)
+		records = append(records, r)
+	}
+	want := []record{
+		{1, "alice\nalice", 90},
+		{2, "bob", 110},
+	}
+	a.Equal(want, records)
+}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -184,6 +184,7 @@ func getTestPort(testName string) int {
 		"TestPITRInvalidTimePoint",
 		"TestPITRTwice",
 		"TestPITRToNewDatabaseInAnotherInstance",
+		"TestRollback",
 
 		"TestCheckEngineInnoDB",
 		"TestCheckServerVersionAndBinlogForPITR",


### PR DESCRIPTION
This PR implements the function that generates the rollback SQL statements from a transaction parsed from the binlog events. This is a key part of the rollback task feature.

Close BYT-1718.