### PR TITLE
fix: support wildcard branch filter

### DIFF
--- a/server/project.go
+++ b/server/project.go
@@ -244,10 +244,6 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create linked repository request").SetInternal(err)
 		}
 
-		if strings.Contains(repositoryCreate.BranchFilter, "*") {
-			return echo.NewHTTPError(http.StatusBadRequest, "Wildcard isn't supported for branch setting")
-		}
-
 		// We need to check the FilePathTemplate in create repository request.
 		// This avoids to a certain extent that the creation succeeds but does not work.
 		if err := vcsPlugin.IsAsterisksInTemplateValid(path.Join(repositoryCreate.BaseDirectory, repositoryCreate.FilePathTemplate)); err != nil {
@@ -430,9 +426,6 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		}
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, repoPatch); err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, "Malformed patch linked repository request").SetInternal(err)
-		}
-		if repoPatch.BranchFilter != nil && strings.Contains(*repoPatch.BranchFilter, "*") {
-			return echo.NewHTTPError(http.StatusBadRequest, "Wildcard isn't supported for branch setting")
 		}
 
 		project, err := s.store.GetProjectByID(ctx, projectID)

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -243,7 +243,17 @@ func postMigration(ctx context.Context, server *Server, task *api.Task, vcsPushE
 			bytebaseURL = fmt.Sprintf("%s/issue/%s?stage=%d", server.profile.ExternalURL, api.IssueSlug(issue), task.StageID)
 		}
 
-		commitID, err := writeBackLatestSchema(ctx, server, repo, vcsPushEvent, mi, repo.BranchFilter, latestSchemaFile, schema, bytebaseURL)
+		// TODO(d): we need to figure out the baseline write-back for users using wildcard branch filter.
+		branch := repo.BaseDirectory
+		if vcsPushEvent != nil {
+			b, err := parseBranchNameFromRefs(vcsPushEvent.Ref)
+			if err != nil {
+				return true, nil, errors.Errorf("failed to parse branch name: %s", vcsPushEvent.Ref)
+			}
+			branch = b
+		}
+		// Use the branch name from the commit as we will write back to the same branch.
+		commitID, err := writeBackLatestSchema(ctx, server, repo, vcsPushEvent, mi, branch, latestSchemaFile, schema, bytebaseURL)
 		if err != nil {
 			return true, nil, err
 		}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -429,6 +429,11 @@ func (s *Server) filterRepository(ctx context.Context, webhookEndpointID string,
 }
 
 func (*Server) isWebhookEventBranch(pushEventRef, branchFilter string) (bool, error) {
+	// TODO(d): we will accept all pushes from wildcard branch filter for now.
+	// We should implement our own branch filter later.
+	if strings.HasSuffix(branchFilter, "*") {
+		return true, nil
+	}
 	branch, err := parseBranchNameFromRefs(pushEventRef)
 	if err != nil {
 		return false, echo.NewHTTPError(http.StatusBadRequest, "Invalid ref: %s", pushEventRef).SetInternal(err)


### PR DESCRIPTION
Users are relying on branch filters in GitOps. Let’s keep the support until we find a solution to write-back the latest schema file for baseline migration. 