### PR TITLE
fix: allow workspace DBA and Owner to manage any project from UI

### DIFF
--- a/frontend/src/components/ProjectSettingPanel.vue
+++ b/frontend/src/components/ProjectSettingPanel.vue
@@ -44,7 +44,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, PropType } from "vue";
-import { hasProjectPermission } from "../utils";
+import { hasProjectPermission, hasWorkspacePermission } from "../utils";
 import ProjectGeneralSettingPanel from "../components/ProjectGeneralSettingPanel.vue";
 import { ProjectAdvancedSettingPanel } from "../components/Project/ProjectSetting";
 import ProjectMemberPanel from "../components/ProjectMemberPanel.vue";
@@ -72,15 +72,21 @@ export default defineComponent({
     const currentUser = useCurrentUser();
     const projectStore = useProjectStore();
 
-    // Only the project with manage permission can archive/restore the project info.
-    // This means even the workspace owner won't be able to edit it.
-    // There seems to be no good reason that workspace owner needs to archive/restore the project.
     const allowArchiveOrRestore = computed(() => {
+      if (
+        hasWorkspacePermission(
+          "bb.permission.workspace.manage-project",
+          currentUser.value.role
+        )
+      ) {
+        return true;
+      }
+
       for (const member of props.project.memberList) {
         if (member.principal.id == currentUser.value.id) {
           if (
             hasProjectPermission(
-              "bb.permission.project.manage-general",
+              "bb.permission.project.archive-restore",
               member.role
             )
           ) {

--- a/frontend/src/layouts/ProjectLayout.vue
+++ b/frontend/src/layouts/ProjectLayout.vue
@@ -46,7 +46,11 @@
 <script lang="ts">
 import { computed, defineComponent, reactive, watch } from "vue";
 import { useRouter } from "vue-router";
-import { idFromSlug, hasProjectPermission } from "../utils";
+import {
+  idFromSlug,
+  hasProjectPermission,
+  hasWorkspacePermission,
+} from "../utils";
 import ArchiveBanner from "../components/ArchiveBanner.vue";
 import { BBTabFilterItem } from "../bbkit/types";
 import { useI18n } from "vue-i18n";
@@ -139,6 +143,15 @@ export default defineComponent({
     const allowEdit = computed(() => {
       if (project.value.rowStatus == "ARCHIVED") {
         return false;
+      }
+
+      if (
+        hasWorkspacePermission(
+          "bb.permission.workspace.manage-project",
+          currentUser.value.role
+        )
+      ) {
+        return true;
       }
 
       for (const member of project.value.memberList) {

--- a/frontend/src/utils/role.ts
+++ b/frontend/src/utils/role.ts
@@ -56,6 +56,7 @@ export function hasWorkspacePermission(
 export type ProjectPermissionType =
   | "bb.permission.project.manage-general"
   | "bb.permission.project.manage-member"
+  | "bb.permission.project.archive-restore"
   | "bb.permission.project.change-database"
   | "bb.permission.project.create-or-transfer-database";
 
@@ -74,6 +75,7 @@ export function hasProjectPermission(
     new Map([
       ["bb.permission.project.manage-general", [false, true]],
       ["bb.permission.project.manage-member", [false, true]],
+      ["bb.permission.project.archive-restore", [false, true]],
       ["bb.permission.project.change-database", [true, true]],
       // If dba-workflow is disabled, then project developer can also create or transfer database.
       [


### PR DESCRIPTION
Our backend always allows DBA and Owner to manage any project (we do have customers using the owner's access token to call our API to manage projects). But previously, we don't allow this from UI. So this PR makes the behavior consistent.

We didn't allow DBA and Owner to manage any project to prevent them changing the application developers' projects by accident. We can alternatively add a lock UI later to prevent this if this does cause a problem. 