### PR TITLE
chore: fix dataDir format error when the `--data` arguments is `/`

### DIFF
--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -196,6 +196,9 @@ func normalizeExternalURL(url string) (string, error) {
 }
 
 func checkDataDir() error {
+	// Clean data directory path.
+	flags.dataDir = filepath.Clean(flags.dataDir)
+
 	// Convert to absolute path if relative path is supplied.
 	if !filepath.IsAbs(flags.dataDir) {
 		absDir, err := filepath.Abs(filepath.Dir(os.Args[0]) + "/" + flags.dataDir)
@@ -203,11 +206,6 @@ func checkDataDir() error {
 			return err
 		}
 		flags.dataDir = absDir
-	}
-
-	// Trim trailing / in case user supplies
-	if len(flags.dataDir) > 1 {
-		flags.dataDir = strings.TrimRight(flags.dataDir, "/")
 	}
 
 	if _, err := os.Stat(flags.dataDir); err != nil {

--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -206,7 +206,9 @@ func checkDataDir() error {
 	}
 
 	// Trim trailing / in case user supplies
-	flags.dataDir = strings.TrimRight(flags.dataDir, "/")
+	if len(flags.dataDir) > 1 {
+		flags.dataDir = strings.TrimRight(flags.dataDir, "/")
+	}
 
 	if _, err := os.Stat(flags.dataDir); err != nil {
 		return errors.Wrapf(err, "unable to access --data directory %s", flags.dataDir)


### PR DESCRIPTION
Fix #3049 