### PR TITLE
chore: modify the deparse format as pg_dump

### DIFF
--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -48,7 +48,7 @@ func deparseCreateTable(context parser.DeparseContext, in *ast.CreateTableStmt, 
 		}
 	}
 	columnContext := parser.DeparseContext{
-		Indent: fmt.Sprintf("%s    ", context.Indent),
+		IndentLevel: context.IndentLevel + 1,
 	}
 	for i, column := range in.ColumnList {
 		if i != 0 {
@@ -76,8 +76,10 @@ func deparseCreateTable(context parser.DeparseContext, in *ast.CreateTableStmt, 
 }
 
 func deparseColumnDef(context parser.DeparseContext, in *ast.ColumnDef, buf *strings.Builder) error {
-	if _, err := buf.WriteString(context.Indent); err != nil {
-		return err
+	for i := 0; i < context.IndentLevel; i++ {
+		if _, err := buf.WriteString(parser.DeparseIndentString); err != nil {
+			return err
+		}
 	}
 	if err := writeSurrounding(buf, in.ColumnName, "\""); err != nil {
 		return err

--- a/plugin/parser/engine/pg/deparse_test.go
+++ b/plugin/parser/engine/pg/deparse_test.go
@@ -50,31 +50,34 @@ func TestCreateTable(t *testing.T) {
 				r serial2,
 				s serial4,
 				t decimal)`,
-			want: `CREATE TABLE "tech_book"(` +
-				`"a" INT2, ` +
-				`"b" INT4, ` +
-				`"c" INT8, ` +
-				`"d" DECIMAL(10, 2), ` +
-				`"e" DECIMAL(4), ` +
-				`"f" FLOAT4, ` +
-				`"g" FLOAT8, ` +
-				`"h" SERIAL2, ` +
-				`"i" SERIAL4, ` +
-				`"j" SERIAL8, ` +
-				`"k" INT8, ` +
-				`"l" SERIAL8, ` +
-				`"m" FLOAT8, ` +
-				`"n" INT4, ` +
-				`"o" INT4, ` +
-				`"p" FLOAT4, ` +
-				`"q" INT2, ` +
-				`"r" SERIAL2, ` +
-				`"s" SERIAL4, ` +
-				`"t" DECIMAL)`,
+			want: `CREATE TABLE "tech_book" (
+    "a" smallint,
+    "b" integer,
+    "c" bigint,
+    "d" numeric(10, 2),
+    "e" numeric(4),
+    "f" real,
+    "g" double precision,
+    "h" smallserial,
+    "i" serial,
+    "j" bigserial,
+    "k" bigint,
+    "l" bigserial,
+    "m" double precision,
+    "n" integer,
+    "o" integer,
+    "p" real,
+    "q" smallint,
+    "r" smallserial,
+    "s" serial,
+    "t" numeric
+)`,
 		},
 		{
 			stmt: `create table "TechBook"(a "user defined data type")`,
-			want: `CREATE TABLE "TechBook"("a" "user defined data type")`,
+			want: `CREATE TABLE "TechBook" (
+    "a" "user defined data type"
+)`,
 		},
 	}
 

--- a/plugin/parser/parser.go
+++ b/plugin/parser/parser.go
@@ -27,6 +27,7 @@ type ParseContext struct {
 
 // DeparseContext is the contxt for restoring.
 type DeparseContext struct {
+	Indent string
 }
 
 // Parser is the interface for parser.

--- a/plugin/parser/parser.go
+++ b/plugin/parser/parser.go
@@ -19,6 +19,9 @@ const (
 	Postgres EngineType = "POSTGRES"
 	// TiDB is the engine type for TiDB.
 	TiDB EngineType = "TIDB"
+
+	// DeparseIndentString is the string for each indent level.
+	DeparseIndentString = "    "
 )
 
 // ParseContext is the context for parsing.
@@ -27,9 +30,9 @@ type ParseContext struct {
 
 // DeparseContext is the contxt for restoring.
 type DeparseContext struct {
-	// Indent is indent at the beginning of the line.
-	// The parser deparses statements with the indent for pretty format.
-	Indent string
+	// IndentLevel is indent level for current line.
+	// The parser deparses statements with the indent level for pretty format.
+	IndentLevel int
 }
 
 // Parser is the interface for parser.

--- a/plugin/parser/parser.go
+++ b/plugin/parser/parser.go
@@ -27,6 +27,8 @@ type ParseContext struct {
 
 // DeparseContext is the contxt for restoring.
 type DeparseContext struct {
+	// Indent is indent at the beginning of the line.
+	// The parser deparses statements with the indent for pretty format.
 	Indent string
 }
 


### PR DESCRIPTION
This PR changes the deparse format:
1. use lower case for data type, because data type is the identifier
2. for CREATE TABLE, we deparse it as
``` SQL
CREATE TABLE table_name (
    column_one ...,
    column_two ...
);
```