### PR TITLE
chore: update vcs url

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -405,8 +405,8 @@ export default defineComponent({
                 DB_NAME: state.selectedDatabaseName!,
                 TYPE:
                   props.type === "bb.issue.database.schema.update"
-                    ? "migrate"
-                    : "data",
+                    ? "ddl"
+                    : "dml",
               }),
               "_blank"
             );
@@ -448,8 +448,8 @@ export default defineComponent({
                 ENV_NAME: database.instance.environment.name,
                 TYPE:
                   props.type === "bb.issue.database.schema.update"
-                    ? "migrate"
-                    : "data",
+                    ? "ddl"
+                    : "dml",
               }),
               "_blank"
             );

--- a/frontend/src/types/repository.ts
+++ b/frontend/src/types/repository.ts
@@ -90,7 +90,7 @@ export type ExternalRepositoryInfo = {
 type WebUrlReplaceParams = {
   DB_NAME?: string;
   VERSION?: string;
-  TYPE?: "migrate" | "data";
+  TYPE?: "ddl" | "dml";
   ENV_NAME?: string;
 };
 

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -580,8 +580,7 @@ const createMigration = async (
           baseDirectoryWebUrl(repository, {
             DB_NAME: database.value.name,
             ENV_NAME: database.value.instance.environment.name,
-            TYPE:
-              type === "bb.issue.database.schema.update" ? "migrate" : "data",
+            TYPE: type === "bb.issue.database.schema.update" ? "ddl" : "dml",
           }),
           "_blank"
         );


### PR DESCRIPTION
Update the placeholder replacements when opening VCS URL.

- {{TYPE}}
  - `migrate` -> `ddl`
  - `data` -> `dml`