### PR TITLE
refactor: simplify ACL logic to make XXX as a superset of XXX_SELF in casbin config

### DIFF
--- a/server/acl_casbin_policy_dba.csv
+++ b/server/acl_casbin_policy_dba.csv
@@ -103,7 +103,6 @@ p, DBA, /sheet/shared, GET
 p, DBA, /sheet/starred, GET
 p, DBA, /sheet/{id}, GET
 p, DBA, /sheet/{id}, PATCH
-p, DBA, /sheet/{id}, PATCH_SELF
 p, DBA, /sheet/{id}, DELETE_SELF
 p, DBA, /sheet/{id}/organizer, PATCH
 p, DBA, /sheet/project/{projectID}/sync, POST

--- a/server/acl_casbin_policy_developer.csv
+++ b/server/acl_casbin_policy_developer.csv
@@ -88,7 +88,6 @@ p, DEVELOPER, /sheet/shared, GET
 p, DEVELOPER, /sheet/starred, GET
 p, DEVELOPER, /sheet/{id}, GET
 p, DEVELOPER, /sheet/{id}, PATCH
-p, DEVELOPER, /sheet/{id}, PATCH_SELF
 p, DEVELOPER, /sheet/{id}, DELETE_SELF
 p, DEVELOPER, /sheet/{id}/organizer, PATCH
 p, DEVELOPER, /sheet/project/{projectID}/sync, POST

--- a/server/acl_casbin_policy_owner.csv
+++ b/server/acl_casbin_policy_owner.csv
@@ -2,7 +2,6 @@ p, OWNER, /principal, POST
 p, OWNER, /principal, GET
 p, OWNER, /principal/{id}, GET
 p, OWNER, /principal/{id}, PATCH
-p, OWNER, /principal/{id}, PATCH_SELF
 p, OWNER, /member, POST
 p, OWNER, /member, GET
 p, OWNER, /member/{id}, PATCH
@@ -109,7 +108,6 @@ p, OWNER, /sheet/shared, GET
 p, OWNER, /sheet/starred, GET
 p, OWNER, /sheet/{id}, GET
 p, OWNER, /sheet/{id}, PATCH
-p, OWNER, /sheet/{id}, PATCH_SELF
 p, OWNER, /sheet/{id}, DELETE_SELF
 p, OWNER, /sheet/{id}/organizer, PATCH
 p, OWNER, /sheet/project/{projectID}/sync, POST


### PR DESCRIPTION
e.g. If the role allows PATCH, then there is no need to specify a separate PATCH_SELF in the casbin config