### PR TITLE
chore: support wildcard branch still

### DIFF
--- a/frontend/src/components/RepositoryForm.vue
+++ b/frontend/src/components/RepositoryForm.vue
@@ -43,7 +43,7 @@
     </div>
     <div>
       <div class="textlabel">
-        {{ $t("common.branch") }}
+        {{ $t("common.branch") }} <span class="text-red-600">*</span>
       </div>
       <div class="mt-1 textinfolabel">
         {{ $t("repository.branch-observe-file-change") }}

--- a/frontend/src/components/RepositoryPanel.vue
+++ b/frontend/src/components/RepositoryPanel.vue
@@ -328,6 +328,7 @@ export default defineComponent({
 
     const allowUpdate = computed(() => {
       return (
+        !isEmpty(state.repositoryConfig.branchFilter) &&
         !isEmpty(state.repositoryConfig.filePathTemplate) &&
         (props.repository.branchFilter !==
           state.repositoryConfig.branchFilter ||

--- a/frontend/src/components/RepositorySetupWizard.vue
+++ b/frontend/src/components/RepositorySetupWizard.vue
@@ -254,7 +254,10 @@ export default defineComponent({
 
     const allowNext = computed((): boolean => {
       if (state.currentStep == CONFIGURE_DEPLOY_STEP) {
-        return !isEmpty(state.config.repositoryConfig.filePathTemplate.trim());
+        return (
+          !isEmpty(state.config.repositoryConfig.branchFilter.trim()) &&
+          !isEmpty(state.config.repositoryConfig.filePathTemplate.trim())
+        );
       }
       return true;
     });

--- a/frontend/src/types/repository.ts
+++ b/frontend/src/types/repository.ts
@@ -98,8 +98,8 @@ export function baseDirectoryWebUrl(
   repository: Repository,
   params: WebUrlReplaceParams = {}
 ): string {
-  // If branchFilter is empty, we can't locate to the exact branch name, thus we will just return the repository web url
-  if (isEmpty(repository.branchFilter)) {
+  // If branchFilter has wildcard, we can't locate to the exact branch name, thus we will just return the repository web url
+  if (repository.branchFilter.includes("*")) {
     return repository.webUrl;
   }
   let url = "";

--- a/server/project.go
+++ b/server/project.go
@@ -244,8 +244,11 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		if err := jsonapi.UnmarshalPayload(c.Request().Body, repositoryCreate); err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, "Malformed create linked repository request").SetInternal(err)
 		}
-		if repositoryCreate.BranchFilter == "" && repositoryCreate.SchemaPathTemplate != "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "Schema path template is supported only if branch is specified")
+		if repositoryCreate.BranchFilter == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "Branch must be specified.")
+		}
+		if strings.Contains(repositoryCreate.BranchFilter, "*") && repositoryCreate.SchemaPathTemplate != "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "Schema path template is supported only if branch doesn't have wildcard.")
 		}
 
 		// We need to check the FilePathTemplate in create repository request.
@@ -482,8 +485,11 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 		if repoPatch.BranchFilter != nil {
 			newBranchFilter = *repoPatch.BranchFilter
 		}
-		if newBranchFilter == "" && newSchemaPathTemplate != "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "Schema path template is supported only if branch is specified")
+		if newBranchFilter == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "Branch must be specified.")
+		}
+		if strings.Contains(newBranchFilter, "*") && newSchemaPathTemplate != "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "Schema path template is supported only if branch doesn't have wildcard.")
 		}
 
 		// We need to check the FilePathTemplate in create repository request.

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -175,11 +175,11 @@ func postMigration(ctx context.Context, server *Server, task *api.Task, vcsPushE
 		return true, nil, errors.Errorf("failed to find linked repository for database %q", task.Database.Name)
 	}
 
-	// We write back the latest schema after migration for VCS-based projects when schema path template and branch filter is specified and
+	// On the presence of schema path template and non-wildcard branch filter, We write back the latest schema after migration for VCS-based projects for
 	// 1) baseline migration for SDL,
 	// 2) all DDL/Ghost migrations.
 	writeBack := false
-	if repo != nil && repo.SchemaPathTemplate != "" && repo.BranchFilter != "" {
+	if repo != nil && repo.SchemaPathTemplate != "" && !strings.Contains(repo.BranchFilter, "*") {
 		if repo.Project.SchemaChangeType == api.ProjectSchemaChangeTypeSDL {
 			if task.Type == api.TaskDatabaseSchemaBaseline {
 				writeBack = true

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -429,19 +430,18 @@ func (s *Server) filterRepository(ctx context.Context, webhookEndpointID string,
 }
 
 func (*Server) isWebhookEventBranch(pushEventRef, branchFilter string) (bool, error) {
-	// Empty branch filter will accept pushed from any branch.
-	if branchFilter == "" {
-		return true, nil
-	}
 	branch, err := parseBranchNameFromRefs(pushEventRef)
 	if err != nil {
 		return false, echo.NewHTTPError(http.StatusBadRequest, "Invalid ref: %s", pushEventRef).SetInternal(err)
 	}
-	if branch != branchFilter {
+	ok, err := filepath.Match(branchFilter, branch)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to match branch filter")
+	}
+	if !ok {
 		log.Debug("Skipping repo due to branch filter mismatch", zap.String("branch", branch), zap.String("filter", branchFilter))
 		return false, nil
 	}
-
 	return true, nil
 }
 


### PR DESCRIPTION
Have to continue the support for wildcard matching. The user could use two Bytebase projects (Prod and Dev) pointing into the same GitLab project. Dev needs to match branch "*/*" while Prod needs to match the exact branch "main". We need a wildcard to provide isolation between Dev and Prod projects.