### PR TITLE
feat: write semicolon in PostgreSQL deparse procedure

### DIFF
--- a/plugin/parser/differ/pg/test-data/test_differ_data.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_data.yaml
@@ -18,24 +18,21 @@
     );
 - oldSchema: CREATE TABLE t1(a int, b char(20), c int);
   newSchema: CREATE TABLE t1(a int);
-  diff: |+
+  diff: |
     ALTER TABLE "t1"
         DROP COLUMN "b",
         DROP COLUMN "c";
-
 - oldSchema: CREATE TABLE t1(a int);
   newSchema: CREATE TABLE t1(a int, b char(20), c int)
-  diff: |+
+  diff: |
     ALTER TABLE "t1"
         ADD COLUMN "b" character(20),
         ADD COLUMN "c" integer;
-
 - oldSchema: create table t1(a int, b bigint, c serial);
   newSchema: create table t1(a varchar(20), b serial, c bigint, d char(30))
-  diff: |+
+  diff: |
     ALTER TABLE "t1"
         ALTER COLUMN "a" SET DATA TYPE character varying(20),
         ALTER COLUMN "b" SET DATA TYPE serial,
         ALTER COLUMN "c" SET DATA TYPE bigint,
         ADD COLUMN "d" character(30);
-

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -11,7 +11,12 @@ import (
 	"github.com/bytebase/bytebase/plugin/parser/ast"
 )
 
-func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) error {
+func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) (err error) {
+	defer func() {
+		if err == nil {
+			err = buf.WriteByte(';')
+		}
+	}()
 	switch node := in.(type) {
 	case ast.DataType:
 		return deparseDataType(context, node, buf)
@@ -61,9 +66,6 @@ func deparseAlterTable(context parser.DeparseContext, in *ast.AlterTableStmt, bu
 				return err
 			}
 		}
-	}
-	if _, err := buf.WriteString(";\n"); err != nil {
-		return err
 	}
 	return nil
 }

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -12,29 +12,37 @@ import (
 )
 
 func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) (err error) {
-	defer func() {
-		if err == nil {
-			err = buf.WriteByte(';')
-		}
-	}()
 	switch node := in.(type) {
 	case ast.DataType:
-		return deparseDataType(context, node, buf)
+		if err := deparseDataType(context, node, buf); err != nil {
+			return err
+		}
 	case *ast.CreateTableStmt:
-		return deparseCreateTable(context, node, buf)
+		if err := deparseCreateTable(context, node, buf); err != nil {
+			return err
+		}
 	case *ast.AlterTableStmt:
-		return deparseAlterTable(context, node, buf)
+		if err := deparseAlterTable(context, node, buf); err != nil {
+			return err
+		}
 	case *ast.TableDef:
-		return deparseTableDef(context, node, buf)
+		if err := deparseTableDef(context, node, buf); err != nil {
+			return err
+		}
 	case *ast.ColumnDef:
-		return deparseColumnDef(context, node, buf)
+		if err := deparseColumnDef(context, node, buf); err != nil {
+			return err
+		}
 	case *ast.CreateSchemaStmt:
-		return deparseCreateSchema(context, node, buf)
+		if err := deparseCreateSchema(context, node, buf); err != nil {
+			return err
+		}
 	case *ast.DropSchemaStmt:
-		return deparseDropSchema(context, node, buf)
+		if err := deparseDropSchema(context, node, buf); err != nil {
+			return err
+		}
 	}
-
-	return errors.Errorf("failed to deparse %T", in)
+	return buf.WriteByte(';')
 }
 
 func deparseAlterTable(context parser.DeparseContext, in *ast.AlterTableStmt, buf *strings.Builder) error {

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bytebase/bytebase/plugin/parser/ast"
 )
 
-func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) (err error) {
+func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) error {
 	switch node := in.(type) {
 	case ast.DataType:
 		if err := deparseDataType(context, node, buf); err != nil {

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -21,10 +21,12 @@ func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) e
 		if err := deparseCreateTable(context, node, buf); err != nil {
 			return err
 		}
+		return buf.WriteByte(';')
 	case *ast.AlterTableStmt:
 		if err := deparseAlterTable(context, node, buf); err != nil {
 			return err
 		}
+		return buf.WriteByte(';')
 	case *ast.TableDef:
 		if err := deparseTableDef(context, node, buf); err != nil {
 			return err
@@ -37,12 +39,14 @@ func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) e
 		if err := deparseCreateSchema(context, node, buf); err != nil {
 			return err
 		}
+		return buf.WriteByte(';')
 	case *ast.DropSchemaStmt:
 		if err := deparseDropSchema(context, node, buf); err != nil {
 			return err
 		}
+		return buf.WriteByte(';')
 	}
-	return buf.WriteByte(';')
+	return errors.Errorf("failed to deparse %T", in)
 }
 
 func deparseAlterTable(context parser.DeparseContext, in *ast.AlterTableStmt, buf *strings.Builder) error {

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -14,9 +14,7 @@ import (
 func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) error {
 	switch node := in.(type) {
 	case ast.DataType:
-		if err := deparseDataType(context, node, buf); err != nil {
-			return err
-		}
+		return deparseDataType(context, node, buf)
 	case *ast.CreateTableStmt:
 		if err := deparseCreateTable(context, node, buf); err != nil {
 			return err
@@ -28,13 +26,9 @@ func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) e
 		}
 		return buf.WriteByte(';')
 	case *ast.TableDef:
-		if err := deparseTableDef(context, node, buf); err != nil {
-			return err
-		}
+		return deparseTableDef(context, node, buf)
 	case *ast.ColumnDef:
-		if err := deparseColumnDef(context, node, buf); err != nil {
-			return err
-		}
+		return deparseColumnDef(context, node, buf)
 	case *ast.CreateSchemaStmt:
 		if err := deparseCreateSchema(context, node, buf); err != nil {
 			return err

--- a/plugin/parser/engine/pg/test-data/test_alter_table_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_alter_table_data.yaml
@@ -1,16 +1,16 @@
 - stmt: alter table t add column a int
-  want: |
+  want: |-
     ALTER TABLE "t"
         ADD COLUMN "a" integer;
 - stmt: alter table t alter column a type varchar(20)
-  want: |
+  want: |-
     ALTER TABLE "t"
         ALTER COLUMN "t" SET DATA TYPE character varying(20);
 - stmt: |-
     alter table t
         add column a integer,
         add column b char(20)
-  want: |
+  want: |-
     ALTER TABLE "t"
         ADD COLUMN "a" integer,
         ADD COLUMN "b" character(20);

--- a/plugin/parser/engine/pg/test-data/test_create_schema_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_create_schema_data.yaml
@@ -2,12 +2,12 @@
   want: |-
     CREATE SCHEMA "myschema" AUTHORIZATION "bytebase" CREATE TABLE "tbl" (
         "id" integer
-    )
+    );
 - stmt: create schema if not exists myschema authorization bytebase;
-  want: CREATE SCHEMA IF NOT EXISTS "myschema" AUTHORIZATION "bytebase"
+  want: CREATE SCHEMA IF NOT EXISTS "myschema" AUTHORIZATION "bytebase";
 - stmt: create schema if not exists myschema
-  want: CREATE SCHEMA IF NOT EXISTS "myschema"
+  want: CREATE SCHEMA IF NOT EXISTS "myschema";
 - stmt: create schema if not exists "myschema" authorization bytebase
-  want: CREATE SCHEMA IF NOT EXISTS "myschema" AUTHORIZATION "bytebase"
+  want: CREATE SCHEMA IF NOT EXISTS "myschema" AUTHORIZATION "bytebase";
 - stmt: create schema if not exists authorization bytebase
-  want: CREATE SCHEMA IF NOT EXISTS AUTHORIZATION "bytebase"
+  want: CREATE SCHEMA IF NOT EXISTS AUTHORIZATION "bytebase";

--- a/plugin/parser/engine/pg/test-data/test_create_table_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_create_table_data.yaml
@@ -2,7 +2,7 @@
   want: |-
     CREATE TABLE "TechBook" (
         "a" "user defined data type"
-    )
+    );
 - stmt: |-
     CREATE TABLE tech_book(
       a char(20),
@@ -10,7 +10,7 @@
       c varchar(330),
       d character varying(400),
       e text
-    )
+    );
   want: |-
     CREATE TABLE "tech_book" (
         "a" character(20),
@@ -18,7 +18,7 @@
         "c" character varying(330),
         "d" character varying(400),
         "e" text
-    )
+    );
 - stmt: |-
     CREATE TABLE tech_book(
       a smallint,
@@ -63,4 +63,4 @@
         "r" smallserial,
         "s" serial,
         "t" numeric
-    )
+    );

--- a/plugin/parser/engine/pg/test-data/test_drop_schema_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_drop_schema_data.yaml
@@ -1,5 +1,4 @@
 - stmt: drop schema myschema
-  want: DROP SCHEMA "myschema" RESTRICT
-
+  want: DROP SCHEMA "myschema" RESTRICT;
 - stmt: drop schema if exists s1, s2 cascade
-  want: DROP SCHEMA IF EXISTS "s1", "s2" CASCADE
+  want: DROP SCHEMA IF EXISTS "s1", "s2" CASCADE;


### PR DESCRIPTION
As discussion in #3209 , we need to write the `;` at the end of the deparse statement.