### PR TITLE
fix: use id to sort migration history

### DIFF
--- a/plugin/db/clickhouse/migrate.go
+++ b/plugin/db/clickhouse/migrate.go
@@ -264,7 +264,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 	}
 	var query = baseQuery +
 		db.FormatParamNameInNumberedPosition(paramNames) +
-		`ORDER BY created_ts DESC`
+		`ORDER BY id DESC`
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}

--- a/plugin/db/mysql/migrate.go
+++ b/plugin/db/mysql/migrate.go
@@ -246,7 +246,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 	}
 	var query = baseQuery +
 		db.FormatParamNameInQuestionMark(paramNames) +
-		`ORDER BY created_ts DESC`
+		`ORDER BY id DESC`
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}

--- a/plugin/db/pg/migrate.go
+++ b/plugin/db/pg/migrate.go
@@ -293,7 +293,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 	}
 	var query = baseQuery +
 		db.FormatParamNameInNumberedPosition(paramNames) +
-		`ORDER BY created_ts DESC`
+		`ORDER BY id DESC`
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}

--- a/plugin/db/snowflake/migrate.go
+++ b/plugin/db/snowflake/migrate.go
@@ -274,7 +274,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 	}
 	var query = baseQuery +
 		db.FormatParamNameInQuestionMark(paramNames) +
-		`ORDER BY created_ts DESC`
+		`ORDER BY id DESC`
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}

--- a/plugin/db/sqlite/migrate.go
+++ b/plugin/db/sqlite/migrate.go
@@ -266,7 +266,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 	}
 	var query = baseQuery +
 		db.FormatParamNameInQuestionMark(paramNames) +
-		`ORDER BY created_ts DESC`
+		`ORDER BY id DESC`
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}


### PR DESCRIPTION
The currently failing test cases (such as https://github.com/bytebase/bytebase/actions/runs/3367174445/jobs/5584411970#step:8:1700) are triggered when some of the migration histories have the same `created_ts`.

This PR uses the autoincremental ids to sort them, which is unique and has the same order as the created_ts.

Thanks to @RainbowDashy for reporting this issue.