### PR TITLE
chore: use a single connection to execute migration in the lifetime of a MySQL driver

### DIFF
--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -55,7 +55,7 @@ func newDriver(dc db.DriverConfig) db.Driver {
 }
 
 // Open opens a MySQL driver.
-func (driver *Driver) Open(_ context.Context, dbType db.Type, connCfg db.ConnectionConfig, connCtx db.ConnectionContext) (db.Driver, error) {
+func (driver *Driver) Open(ctx context.Context, dbType db.Type, connCfg db.ConnectionConfig, connCtx db.ConnectionContext) (db.Driver, error) {
 	protocol := "tcp"
 	if strings.HasPrefix(connCfg.Host, "/") {
 		protocol = "unix"
@@ -94,7 +94,7 @@ func (driver *Driver) Open(_ context.Context, dbType db.Type, connCfg db.Connect
 	if err != nil {
 		return nil, err
 	}
-	conn, err := db.Conn(context.Background())
+	conn, err := db.Conn(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -90,6 +90,9 @@ func (driver *Driver) Open(_ context.Context, dbType db.Type, connCfg db.Connect
 	if err != nil {
 		return nil, err
 	}
+	// Use a single connection in the lifetime of the driver.
+	// This makes things easier, such as the thread ID will not change.
+	db.SetMaxOpenConns(1)
 	driver.dbType = dbType
 	driver.db = db
 	driver.connectionCtx = connCtx


### PR DESCRIPTION
This keeps the thread ID executing the migration unchanged. Thus it's easy to get the thread ID when we need to generate the rollback SQL.