### PR TITLE
refactor: move the GET /project ACL check to acl.go

### DIFF
--- a/server/acl.go
+++ b/server/acl.go
@@ -28,7 +28,7 @@ func getRoleContextKey() string {
 func enforceWorkspaceDeveloperProjectACL(path string, method string, quaryParams url.Values, principalID int) *echo.HTTPError {
 	if strings.HasPrefix(path, "/project") {
 		if path == "/project" {
-			// Developer can only fetch projects from herself.
+			// Developer can only fetch projects from themseleves.
 			if method == "GET" {
 				userIDStr := quaryParams.Get("user")
 				if userIDStr == "" {

--- a/server/acl_test.go
+++ b/server/acl_test.go
@@ -33,7 +33,7 @@ func TestEnforceWorkspaceDeveloperProjectACL(t *testing.T) {
 			errMsg:      "Not allowed to fetch projects from other user",
 		},
 		{
-			desc:        "Fetch projects from herself",
+			desc:        "Fetch projects from themselves",
 			path:        "/project",
 			method:      "GET",
 			queryParams: url.Values{"user": []string{"123"}},

--- a/server/acl_test.go
+++ b/server/acl_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestEnforceWorkspaceDeveloperProjectACL(t *testing.T) {
+	type test struct {
+		desc        string
+		path        string
+		method      string
+		queryParams url.Values
+		principalID int
+		errMsg      string
+	}
+
+	tests := []test{
+		{
+			desc:        "Fetch all projects",
+			path:        "/project",
+			method:      "GET",
+			queryParams: url.Values{},
+			principalID: 123,
+			errMsg:      "Not allowed to fetch all project list",
+		},
+		{
+			desc:        "Fetch projects from other user",
+			path:        "/project",
+			method:      "GET",
+			queryParams: url.Values{"user": []string{"124"}},
+			principalID: 123,
+			errMsg:      "Not allowed to fetch projects from other user",
+		},
+		{
+			desc:        "Fetch projects from herself",
+			path:        "/project",
+			method:      "GET",
+			queryParams: url.Values{"user": []string{"123"}},
+			principalID: 123,
+			errMsg:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := enforceWorkspaceDeveloperProjectACL(tc.path, tc.method, tc.queryParams, tc.principalID)
+			if err != nil {
+				if tc.errMsg == "" {
+					t.Errorf("expect no error, got %s", err.Internal.Error())
+				} else if tc.errMsg != err.Internal.Error() {
+					t.Errorf("expect error %s, got %s", tc.errMsg, err.Internal.Error())
+				}
+			} else if tc.errMsg != "" {
+				t.Errorf("expect error %s, got no error", tc.errMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR also tightens the ACL check, the existing logic does allow Developer 123 can fetch projects from Developer 124.

The plan is to centralize the project ACL logic for the workspace developer