### PR TITLE
chore: separate golangci-lint GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   eslint-checks:
-    name: "Check Frontend Code"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,8 +25,7 @@ jobs:
         run: pnpm lint
         working-directory: frontend
 
-  lint-golang:
-    name: "Check Golang Code"
+  golangci-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,7 +58,6 @@ jobs:
           skip-cache: true
 
   go-tests:
-    name: "Backend Unit/Integration Test"
     strategy:
       matrix:
         release-tags:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
             ./resources/mysql/*.tar.xz
           key: ${{ runner.OS }}-build-mysql-cache
       - name: Install dependencies
-        run: go generate -tags release,mysql ./...
+        run: go generate -tags mysql ./...
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   eslint-checks:
+    name: "Check Frontend Code"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +26,8 @@ jobs:
         run: pnpm lint
         working-directory: frontend
 
-  golangci-lint:
+  lint-golang:
+    name: "Check Golang Code"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,6 +60,7 @@ jobs:
           skip-cache: true
 
   go-tests:
+    name: "Backend Unit/Integration Test"
     strategy:
       matrix:
         release-tags:
@@ -75,11 +78,6 @@ jobs:
           go-version: 1.19
           check-latest: true
           cache: true
-      - name: Verify go.mod is tidy
-        if: ${{ matrix.release-tags == 'mysql' }}
-        run: |
-          go mod tidy
-          git diff --exit-code
       - name: Cache MySQL
         uses: actions/cache@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,29 @@ jobs:
         run: pnpm lint
         working-directory: frontend
 
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+          check-latest: true
+          cache: true
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          git diff --exit-code
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.49.0
+          args: -v
+          skip-cache: true
+
   go-tests:
     strategy:
       matrix:
@@ -57,13 +80,6 @@ jobs:
           key: ${{ runner.OS }}-build-mysql-cache
       - name: Install dependencies
         run: go generate -tags ${{ matrix.release-tags }} ./...
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        if: ${{ matrix.release-tags == 'mysql' }}
-        with:
-          version: v1.49.0
-          args: -v
-          skip-cache: true
       - name: Run all tests
         run: go test -v ./... -tags=${{ matrix.release-tags }} -p=10 | tee test.log; exit ${PIPESTATUS[0]}
       - name: Pretty print tests running time

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
             ./resources/mysql/*.tar.xz
           key: ${{ runner.OS }}-build-mysql-cache
       - name: Install dependencies
-        run: go generate -tags ${{ matrix.release-tags }} ./...
+        run: go generate -tags release,mysql ./...
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,15 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code
+      - name: Cache MySQL
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./resources/mysql/*.tar.gz
+            ./resources/mysql/*.tar.xz
+          key: ${{ runner.OS }}-build-mysql-cache
+      - name: Install dependencies
+        run: go generate -tags ${{ matrix.release-tags }} ./...
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
golangci-lint runs for ~3m. Parallelizing them can make the overall time reduced by ~3m.