### PR TITLE
feat: external approval api & store

### DIFF
--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -41,11 +41,14 @@ type ExternalApprovalPayloadFeishu struct {
 
 // ExternalApprovalCreate is the API message for creating an ExternalApproval.
 type ExternalApprovalCreate struct {
+	// Related fields
 	IssueID     int
 	RequesterID int
 	ApproverID  int
-	Type        ExternalApprovalType
-	Payload     string
+
+	// Domain specific fields
+	Type    ExternalApprovalType
+	Payload string
 }
 
 // ExternalApprovalFind is the API message for finding ExternalApprovals.

--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -1,9 +1,13 @@
 package api
 
+// ExternalApprovalType is the type of the ExternalApproval.
 type ExternalApprovalType string
 
+// ExternalApprovalTypeFeishu is the ExternalApproval from feishu.
 const ExternalApprovalTypeFeishu = "bb.plugin.app.feishu"
 
+// ExternalApproval is the API message of ExternalApproval.
+// It only lives in the backend.
 type ExternalApproval struct {
 	ID int
 
@@ -24,6 +28,7 @@ type ExternalApproval struct {
 	Payload string
 }
 
+// ExternalApprovalPayloadFeishu is the payload for feishu type ExternalApproval.
 type ExternalApprovalPayloadFeishu struct {
 	// feishu
 	InstanceCode string
@@ -34,6 +39,7 @@ type ExternalApprovalPayloadFeishu struct {
 	AssigneeID int
 }
 
+// ExternalApprovalCreate is the API message for creating an ExternalApproval.
 type ExternalApprovalCreate struct {
 	IssueID     int
 	RequesterID int
@@ -42,8 +48,10 @@ type ExternalApprovalCreate struct {
 	Payload     string
 }
 
+// ExternalApprovalFind is the API message for finding ExternalApprovals.
 type ExternalApprovalFind struct{}
 
+// ExternalApprovalPatch is the API message for patching an ExternalApproval.
 type ExternalApprovalPatch struct {
 	ID        int
 	RowStatus RowStatus

--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -30,13 +30,12 @@ type ExternalApproval struct {
 
 // ExternalApprovalPayloadFeishu is the payload for feishu type ExternalApproval.
 type ExternalApprovalPayloadFeishu struct {
+	StageID    int
+	AssigneeID int
+
 	// feishu
 	InstanceCode string
 	RequesterID  string
-
-	// bytebase
-	StageID    int
-	AssigneeID int
 }
 
 // ExternalApprovalCreate is the API message for creating an ExternalApproval.

--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -1,0 +1,50 @@
+package api
+
+type ExternalApprovalType string
+
+const ExternalApprovalTypeFeishu = "bb.plugin.app.feishu"
+
+type ExternalApproval struct {
+	ID int
+
+	// Standard fields
+	RowStatus RowStatus
+	CreatedTs int64
+	UpdatedTs int64
+
+	// Related fields
+	IssueID     int
+	RequesterID int
+	Requester   *Principal
+	ApproverID  int
+	Approver    *Principal
+
+	// Domain specific fields
+	Type    ExternalApprovalType
+	Payload string
+}
+
+type ExternalApprovalPayloadFeishu struct {
+	// feishu
+	InstanceCode string
+	RequesterID  string
+
+	// bytebase
+	StageID    int
+	AssigneeID int
+}
+
+type ExternalApprovalCreate struct {
+	IssueID     int
+	RequesterID int
+	ApproverID  int
+	Type        ExternalApprovalType
+	Payload     string
+}
+
+type ExternalApprovalFind struct{}
+
+type ExternalApprovalPatch struct {
+	ID        int
+	RowStatus RowStatus
+}

--- a/store/external_approval.go
+++ b/store/external_approval.go
@@ -1,0 +1,266 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/pkg/errors"
+)
+
+type externalApprovalRaw struct {
+	ID int
+
+	// Standard fields
+	RowStatus api.RowStatus
+	CreatedTs int64
+	UpdatedTs int64
+
+	// Related fields
+	IssueID     int
+	RequesterID int
+	ApproverID  int
+
+	// Domain specific fields
+	Type    api.ExternalApprovalType
+	Payload string
+}
+
+func (raw *externalApprovalRaw) toExternalApproval() *api.ExternalApproval {
+	return &api.ExternalApproval{
+		ID: raw.ID,
+
+		// Standard fields
+		RowStatus: raw.RowStatus,
+		CreatedTs: raw.CreatedTs,
+		UpdatedTs: raw.UpdatedTs,
+
+		// Related fields
+		IssueID:     raw.IssueID,
+		RequesterID: raw.RequesterID,
+		ApproverID:  raw.ApproverID,
+		Type:        raw.Type,
+		Payload:     raw.Payload,
+	}
+}
+
+func (s *Store) CreateExternalApproval(ctx context.Context, create *api.ExternalApprovalCreate) (*api.ExternalApproval, error) {
+	externalApprovalRaw, err := s.createExternalApprovalRaw(ctx, create)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create ExternalApproval with ExternalApprovalCreate[%+v]", create)
+	}
+	externalApproval, err := s.composeExternalApproval(ctx, externalApprovalRaw)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to compose ExternalApproval with externalApprovalRaw[%+v]", externalApprovalRaw)
+	}
+	return externalApproval, nil
+}
+
+func (s *Store) FindExternalApproval(ctx context.Context, find *api.ExternalApprovalFind) ([]*api.ExternalApproval, error) {
+	rawList, err := s.findExternalApprovalRaw(ctx, find)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to find ExternalApproval with ExternalApprovalFind[%+v]", find)
+	}
+	var externalApprovalList []*api.ExternalApproval
+	for _, raw := range rawList {
+		externalApproval, err := s.composeExternalApproval(ctx, raw)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to compose ExternalApproval with externalApprovalRaw[%+v]", raw)
+		}
+		externalApprovalList = append(externalApprovalList, externalApproval)
+	}
+	return externalApprovalList, nil
+}
+
+func (s *Store) PatchExternalApproval(ctx context.Context, patch *api.ExternalApprovalPatch) (*api.ExternalApproval, error) {
+	externalApprovalRaw, err := s.patchExternalApprovalRaw(ctx, patch)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to patch ExternalApproval with ExternalApprovalPatch[%+v]", patch)
+	}
+	externalApproval, err := s.composeExternalApproval(ctx, externalApprovalRaw)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to compose ExternalApproval with externalApprovalRaw[%+v]", externalApprovalRaw)
+	}
+	return externalApproval, nil
+}
+
+//
+// private functions
+//
+
+func (s *Store) composeExternalApproval(ctx context.Context, raw *externalApprovalRaw) (*api.ExternalApproval, error) {
+	externalApproval := raw.toExternalApproval()
+
+	requester, err := s.GetPrincipalByID(ctx, externalApproval.RequesterID)
+	if err != nil {
+		return nil, err
+	}
+	externalApproval.Requester = requester
+
+	approver, err := s.GetPrincipalByID(ctx, externalApproval.ApproverID)
+	if err != nil {
+		return nil, err
+	}
+	externalApproval.Approver = approver
+
+	return externalApproval, nil
+}
+
+func (s *Store) createExternalApprovalRaw(ctx context.Context, create *api.ExternalApprovalCreate) (*externalApprovalRaw, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	externalApprovalRaw, err := s.createExternalApprovalImpl(ctx, tx, create)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return externalApprovalRaw, nil
+}
+
+func (s *Store) findExternalApprovalRaw(ctx context.Context, find *api.ExternalApprovalFind) ([]*externalApprovalRaw, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	rawList, err := s.findExternalApprovalImpl(ctx, tx, find)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return rawList, nil
+}
+
+func (s *Store) patchExternalApprovalRaw(ctx context.Context, patch *api.ExternalApprovalPatch) (*externalApprovalRaw, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, FormatError(err)
+	}
+	defer tx.Rollback()
+	raw, err := s.patchExternalApprovalImpl(ctx, tx, patch)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func (s *Store) createExternalApprovalImpl(ctx context.Context, tx *Tx, create *api.ExternalApprovalCreate) (*externalApprovalRaw, error) {
+	query := `
+    INSERT INTO external_approval (
+      issue_id,
+      requester_id,
+      approver_id,
+      type,
+      payload
+    )
+    VALUES ($1, $2, $3, $4, $5)
+    RETURNING id, row_status, created_ts, updated_ts, issue_id, requester_id, approver_id, type, payload
+  `
+	var externalApprovalRaw externalApprovalRaw
+	if err := tx.QueryRowContext(ctx, query,
+		create.IssueID,
+		create.RequesterID,
+		create.ApproverID,
+		create.Type,
+		create.Payload,
+	).Scan(
+		&externalApprovalRaw.ID,
+		&externalApprovalRaw.RowStatus,
+		&externalApprovalRaw.CreatedTs,
+		&externalApprovalRaw.UpdatedTs,
+		&externalApprovalRaw.IssueID,
+		&externalApprovalRaw.RequesterID,
+		&externalApprovalRaw.ApproverID,
+		&externalApprovalRaw.Type,
+		&externalApprovalRaw.Payload,
+	); err != nil {
+		return nil, FormatError(err)
+	}
+	return &externalApprovalRaw, nil
+}
+
+func (s *Store) findExternalApprovalImpl(ctx context.Context, tx *Tx, find *api.ExternalApprovalFind) ([]*externalApprovalRaw, error) {
+	where, args := []string{"1 = 1"}, []interface{}{}
+	where, args = append(where, fmt.Sprintf("row_status = $%d", len(args)+1)), append(args, api.Normal)
+	rows, err := tx.QueryContext(ctx, `
+    SELECT
+      id,
+      row_status,
+      created_ts,
+      updated_ts,
+      issue_id,
+      requester_id,
+      approver_id,
+      type,
+      payload
+    FROM external_approval
+    WHERE `+strings.Join(where, " AND "),
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var rawList []*externalApprovalRaw
+	for rows.Next() {
+		var raw externalApprovalRaw
+		if err := rows.Scan(
+			&raw.ID,
+			&raw.RowStatus,
+			&raw.CreatedTs,
+			&raw.UpdatedTs,
+			&raw.IssueID,
+			&raw.RequesterID,
+			&raw.ApproverID,
+			&raw.Type,
+			&raw.Payload,
+		); err != nil {
+			return nil, err
+		}
+		rawList = append(rawList, &raw)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, FormatError(err)
+	}
+
+	return rawList, nil
+}
+
+func (s *Store) patchExternalApprovalImpl(ctx context.Context, tx *Tx, patch *api.ExternalApprovalPatch) (*externalApprovalRaw, error) {
+	var raw externalApprovalRaw
+	query := `
+    UPDATE external_approval
+    SET row_status = $1
+    WHERE id = $2
+    RETURNING id, row_status, created_ts, updated_ts, issue_id, requester_id, approver_id, type, payload
+  `
+	if err := tx.QueryRowContext(ctx, query, patch.RowStatus, patch.ID).Scan(
+		&raw.ID,
+		&raw.RowStatus,
+		&raw.CreatedTs,
+		&raw.UpdatedTs,
+		&raw.IssueID,
+		&raw.RequesterID,
+		&raw.ApproverID,
+		&raw.Type,
+		&raw.Payload,
+	); err != nil {
+		return nil, FormatError(err)
+	}
+	return &raw, nil
+}

--- a/store/external_approval.go
+++ b/store/external_approval.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bytebase/bytebase/api"
 	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/api"
 )
 
 type externalApprovalRaw struct {
@@ -45,6 +46,7 @@ func (raw *externalApprovalRaw) toExternalApproval() *api.ExternalApproval {
 	}
 }
 
+// CreateExternalApproval creates an ExternalAPproval.
 func (s *Store) CreateExternalApproval(ctx context.Context, create *api.ExternalApprovalCreate) (*api.ExternalApproval, error) {
 	externalApprovalRaw, err := s.createExternalApprovalRaw(ctx, create)
 	if err != nil {
@@ -57,6 +59,7 @@ func (s *Store) CreateExternalApproval(ctx context.Context, create *api.External
 	return externalApproval, nil
 }
 
+// FindExternalApproval finds a list of ExternalApproval by find and whose RowStatus == NORMAL.
 func (s *Store) FindExternalApproval(ctx context.Context, find *api.ExternalApprovalFind) ([]*api.ExternalApproval, error) {
 	rawList, err := s.findExternalApprovalRaw(ctx, find)
 	if err != nil {
@@ -73,6 +76,7 @@ func (s *Store) FindExternalApproval(ctx context.Context, find *api.ExternalAppr
 	return externalApprovalList, nil
 }
 
+// PatchExternalApproval patches an ExternalApproval.
 func (s *Store) PatchExternalApproval(ctx context.Context, patch *api.ExternalApprovalPatch) (*api.ExternalApproval, error) {
 	externalApprovalRaw, err := s.patchExternalApprovalRaw(ctx, patch)
 	if err != nil {
@@ -159,7 +163,7 @@ func (s *Store) patchExternalApprovalRaw(ctx context.Context, patch *api.Externa
 	return raw, nil
 }
 
-func (s *Store) createExternalApprovalImpl(ctx context.Context, tx *Tx, create *api.ExternalApprovalCreate) (*externalApprovalRaw, error) {
+func (*Store) createExternalApprovalImpl(ctx context.Context, tx *Tx, create *api.ExternalApprovalCreate) (*externalApprovalRaw, error) {
 	query := `
     INSERT INTO external_approval (
       issue_id,
@@ -194,7 +198,7 @@ func (s *Store) createExternalApprovalImpl(ctx context.Context, tx *Tx, create *
 	return &externalApprovalRaw, nil
 }
 
-func (s *Store) findExternalApprovalImpl(ctx context.Context, tx *Tx, find *api.ExternalApprovalFind) ([]*externalApprovalRaw, error) {
+func (*Store) findExternalApprovalImpl(ctx context.Context, tx *Tx, _ *api.ExternalApprovalFind) ([]*externalApprovalRaw, error) {
 	where, args := []string{"1 = 1"}, []interface{}{}
 	where, args = append(where, fmt.Sprintf("row_status = $%d", len(args)+1)), append(args, api.Normal)
 	rows, err := tx.QueryContext(ctx, `
@@ -241,7 +245,7 @@ func (s *Store) findExternalApprovalImpl(ctx context.Context, tx *Tx, find *api.
 	return rawList, nil
 }
 
-func (s *Store) patchExternalApprovalImpl(ctx context.Context, tx *Tx, patch *api.ExternalApprovalPatch) (*externalApprovalRaw, error) {
+func (*Store) patchExternalApprovalImpl(ctx context.Context, tx *Tx, patch *api.ExternalApprovalPatch) (*externalApprovalRaw, error) {
 	var raw externalApprovalRaw
 	query := `
     UPDATE external_approval

--- a/store/external_approval.go
+++ b/store/external_approval.go
@@ -46,7 +46,7 @@ func (raw *externalApprovalRaw) toExternalApproval() *api.ExternalApproval {
 	}
 }
 
-// CreateExternalApproval creates an ExternalAPproval.
+// CreateExternalApproval creates an ExternalApproval.
 func (s *Store) CreateExternalApproval(ctx context.Context, create *api.ExternalApprovalCreate) (*api.ExternalApproval, error) {
 	externalApprovalRaw, err := s.createExternalApprovalRaw(ctx, create)
 	if err != nil {


### PR DESCRIPTION
Paving the road for Feishu approval integration (2/n).

Previously, `external_approval` schema in https://github.com/bytebase/bytebase/pull/3160

This PR defines `ExternalApproval` API struct and implements storing.
Note that `ExternalApproval` only lives in the backend.
