### PR TITLE
feat(flashback): store binlog coordinates for MySQL DML task

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -138,9 +138,17 @@ type TaskDatabaseDataUpdatePayload struct {
 	SchemaVersion string         `json:"schemaVersion,omitempty"`
 	VCSPushEvent  *vcs.PushEvent `json:"pushEvent,omitempty"`
 
-	// ThreadID is the ID of the connection executing the migration.
 	// MySQL rollback SQL related.
+
+	// ThreadID is the ID of the connection executing the migration.
+	// We use it to filter the binlog events of the migration transaction.
 	ThreadID string `json:"threadID,omitempty"`
+	// BinlogXxx are obtained before and after executing the migration.
+	// We use them to locate the range of binlog for the migration transaction.
+	BinlogFileStart string `json:"binlogFileStart,omitempty"`
+	BinlogFileEnd   string `json:"binlogFileEnd,omitempty"`
+	BinlogPosStart  int64  `json:"binlogPosStart,omitempty"`
+	BinlogPosEnd    int64  `json:"binlogPosEnd,omitempty"`
 }
 
 // TaskDatabaseBackupPayload is the task payload for database backup.

--- a/plugin/db/mysql/dump.go
+++ b/plugin/db/mysql/dump.go
@@ -106,7 +106,7 @@ func (driver *Driver) Dump(ctx context.Context, database string, out io.Writer, 
 			return "", err
 		}
 
-		binlog, err := GetBinlogInfo(ctx, conn)
+		binlog, err := GetBinlogInfo(ctx, driver.db)
 		if err != nil {
 			return "", err
 		}
@@ -357,11 +357,11 @@ func excludeSchemaAutoIncrementValue(s string) string {
 }
 
 // GetBinlogInfo queries current binlog info from MySQL server.
-func GetBinlogInfo(ctx context.Context, conn *sql.Conn) (api.BinlogInfo, error) {
+func GetBinlogInfo(ctx context.Context, db *sql.DB) (api.BinlogInfo, error) {
 	query := "SHOW MASTER STATUS"
 	binlogInfo := api.BinlogInfo{}
 	var unused interface{}
-	if err := conn.QueryRowContext(ctx, query).Scan(
+	if err := db.QueryRowContext(ctx, query).Scan(
 		&binlogInfo.FileName,
 		&binlogInfo.Position,
 		&unused,

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -153,7 +153,7 @@ func executeMigration(ctx context.Context, server *Server, task *api.Task, state
 	}
 
 	if task.Type == api.TaskDatabaseDataUpdate && task.Instance.Engine == db.MySQL {
-		if err := saveThreadIDAndStartBinlogCoordinate(ctx, driver, task, server.store); err != nil {
+		if err := setThreadIDAndStartBinlogCoordinate(ctx, driver, task, server.store); err != nil {
 			return 0, "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
 		}
 	}
@@ -164,7 +164,7 @@ func executeMigration(ctx context.Context, server *Server, task *api.Task, state
 	}
 
 	if task.Type == api.TaskDatabaseDataUpdate && task.Instance.Engine == db.MySQL {
-		if err := saveEndBinlogCoordinate(ctx, driver, task, server.store); err != nil {
+		if err := setEndBinlogCoordinate(ctx, driver, task, server.store); err != nil {
 			return 0, "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
 		}
 	}
@@ -172,7 +172,7 @@ func executeMigration(ctx context.Context, server *Server, task *api.Task, state
 	return migrationID, schema, nil
 }
 
-func saveThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store) error {
+func setThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store) error {
 	mysqlDriver, ok := driver.(*mysql.Driver)
 	if !ok {
 		return errors.Errorf("failed to cast driver to mysql.Driver")
@@ -214,7 +214,7 @@ func saveThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver,
 	return nil
 }
 
-func saveEndBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store) error {
+func setEndBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store) error {
 	payload := &api.TaskDatabaseDataUpdatePayload{}
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
 		return errors.Wrap(err, "invalid database data update payload")


### PR DESCRIPTION
This is part of the MySQL DML task rollback feature.

Close BYT-1717.