### PR TITLE
feat(frontend): display support information on console

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -208,7 +208,8 @@
     "no": "No",
     "yes": "Yes",
     "advanced": "Advanced",
-    "restart": "Restart"
+    "restart": "Restart",
+    "want-help": "Want help"
   },
   "error-page": {
     "go-back-home": "Go back home"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -208,7 +208,8 @@
     "no": "否",
     "yes": "是",
     "advanced": "高级",
-    "restart": "重启"
+    "restart": "重启",
+    "want-help": "加入用户群"
   },
   "error-page": {
     "go-back-home": "回到主页"

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -116,6 +116,14 @@
             </svg>
           </div>
         </div>
+        <div
+          v-if="currentPlan === PlanType.FREE"
+          class="flex justify-between items-center min-w-fit px-4 py-2 bg-indigo-600 text-sm font-medium text-white rounded-md cursor-pointer"
+          @click="handleWantHelp"
+        >
+          <span class="hidden lg:block mr-2">{{ $t("common.want-help") }}</span>
+          <heroicons-outline:chat-bubble-left-right class="w-5 h-5" />
+        </div>
         <router-link to="/inbox" exact-active-class>
           <span
             v-if="inboxSummary.hasUnread"
@@ -193,6 +201,17 @@
       >{{ $t("common.settings") }}</router-link
     >
   </div>
+  <BBModal
+    v-if="state.showQRCodeModal"
+    :title="$t('common.want-help')"
+    @close="state.showQRCodeModal = false"
+  >
+    <img
+      class="w-48 h-48"
+      src="@/assets/bb-helper-wechat-qrcode.webp"
+      alt="bb_helper"
+    />
+  </BBModal>
 </template>
 
 <script lang="ts">
@@ -218,6 +237,7 @@ import { PlanType } from "@/types";
 
 interface LocalState {
   showMobileMenu: boolean;
+  showQRCodeModal: boolean;
 }
 
 export default defineComponent({
@@ -231,10 +251,11 @@ export default defineComponent({
     const subscriptionStore = useSubscriptionStore();
     const router = useRouter();
     const route = useRoute();
-    const { setLocale, toggleLocales } = useLanguage();
+    const { setLocale, toggleLocales, locale } = useLanguage();
 
     const state = reactive<LocalState>({
       showMobileMenu: false,
+      showQRCodeModal: false,
     });
 
     const currentUser = useCurrentUser();
@@ -396,6 +417,17 @@ export default defineComponent({
     ]);
     useRegisterActions(i18nActions);
 
+    const handleWantHelp = () => {
+      if (locale.value === "zh-CN") {
+        state.showQRCodeModal = true;
+      } else {
+        window.open(
+          "https://www.bytebase.com/docs/faq#how-to-reach-us",
+          "_blank"
+        );
+      }
+    };
+
     return {
       state,
       getRouteLinkClass,
@@ -413,6 +445,7 @@ export default defineComponent({
       isDebug,
       toggleDebug,
       toggleLocales,
+      handleWantHelp,
     };
   },
 });

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -68,21 +68,33 @@
         >
           <div
             class="cursor-pointer hover:bg-link-hover focus:outline-none"
-            :class="currentPlan == 0 ? 'underline text-accent' : 'text-main'"
+            :class="
+              currentPlan == PlanType.FREE
+                ? 'underline text-accent'
+                : 'text-main'
+            "
             @click.prevent="switchToFree"
           >
             {{ $t("subscription.plan.free.title") }}
           </div>
           <div
             class="cursor-pointer hover:bg-link-hover focus:outline-none"
-            :class="currentPlan == 1 ? 'underline text-accent' : 'text-main'"
+            :class="
+              currentPlan == PlanType.TEAM
+                ? 'underline text-accent'
+                : 'text-main'
+            "
             @click.prevent="switchToTeam"
           >
             {{ $t("subscription.plan.team.title") }}
           </div>
           <div
             class="cursor-pointer hover:bg-link-hover focus:outline-none"
-            :class="currentPlan == 2 ? 'underline text-accent' : 'text-main'"
+            :class="
+              currentPlan == PlanType.ENTERPRISE
+                ? 'underline text-accent'
+                : 'text-main'
+            "
             @click.prevent="switchToEnterprise"
           >
             {{ $t("subscription.plan.enterprise.title") }}
@@ -202,6 +214,7 @@ import {
   useInboxStore,
 } from "@/store";
 import { storeToRefs } from "pinia";
+import { PlanType } from "@/types";
 
 interface LocalState {
   showMobileMenu: boolean;
@@ -391,6 +404,7 @@ export default defineComponent({
       logoUrl,
       currentUser,
       currentPlan,
+      PlanType,
       isDevFeatures,
       inboxSummary,
       switchToFree,


### PR DESCRIPTION
When users have trouble in Bytebase console use (FREE Plan only), click the button to open the page "https://www.bytebase.com/docs/faq#how-to-reach-us" to get contact information. For Chinese users, show the qrcode to let them join our wechat group.

https://user-images.githubusercontent.com/56376387/199670495-e9e5c083-2e66-4cb1-a8a7-e95e35902bf1.mp4