### PR TITLE
chore: tigger GHA workflow based on path

### DIFF
--- a/.github/workflows/tests-backend.yml
+++ b/.github/workflows/tests-backend.yml
@@ -5,26 +5,10 @@ on:
     branches:
       - main
       - "release/*.*.*"
+    paths-ignore:
+      - "frontend/**"
 
 jobs:
-  eslint-checks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 6.10.0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-          cache: pnpm
-          cache-dependency-path: "frontend/pnpm-lock.yaml"
-      - run: pnpm install --frozen-lockfile
-        working-directory: frontend
-      - name: Run pnpm lint
-        run: pnpm lint
-        working-directory: frontend
-
   golangci-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests-backend.yml
+++ b/.github/workflows/tests-backend.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
       - "release/*.*.*"
-    paths-ignore:
-      - "frontend/**"
+    paths:
+      - "!frontend/**"
 
 jobs:
   golangci-lint:

--- a/.github/workflows/tests-frontend.yml
+++ b/.github/workflows/tests-frontend.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/*.*.*"
+    paths:
+      - "**.js"
+      - "frontend/**"
+      - ".github/**"
+
+jobs:
+  eslint-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 6.10.0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: pnpm
+          cache-dependency-path: "frontend/pnpm-lock.yaml"
+      - run: pnpm install --frozen-lockfile
+        working-directory: frontend
+      - name: Run pnpm lint
+        run: pnpm lint
+        working-directory: frontend


### PR DESCRIPTION
Hopefully, this can make frontend PR tests run much quicker by skipping the golang tests.