### PR TITLE
refactor: seprate transfer and create database permission

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -541,7 +541,8 @@ const routes: Array<RouteRecordRaw> = [
 
                   const currentUser = useAuthStore().currentUser;
                   let allowAlterSchemaOrChangeData = false;
-                  let allowCreateOrTransferDB = false;
+                  let allowCreateDB = false;
+                  let allowTransferDB = false;
                   if (
                     hasWorkspacePermission(
                       "bb.permission.workspace.manage-instance",
@@ -549,7 +550,8 @@ const routes: Array<RouteRecordRaw> = [
                     )
                   ) {
                     allowAlterSchemaOrChangeData = true;
-                    allowCreateOrTransferDB = true;
+                    allowCreateDB = true;
+                    allowTransferDB = true;
                   } else {
                     const memberOfProject = project.memberList.find(
                       (m) => m.principal.id === currentUser.id
@@ -559,8 +561,12 @@ const routes: Array<RouteRecordRaw> = [
                         "bb.permission.project.change-database",
                         memberOfProject.role
                       );
-                      allowCreateOrTransferDB = hasProjectPermission(
-                        "bb.permission.project.create-or-transfer-database",
+                      allowCreateDB = hasProjectPermission(
+                        "bb.permission.project.create-database",
+                        memberOfProject.role
+                      );
+                      allowTransferDB = hasProjectPermission(
+                        "bb.permission.project.transfer-database",
                         memberOfProject.role
                       );
                     }
@@ -576,11 +582,11 @@ const routes: Array<RouteRecordRaw> = [
                     );
                   }
 
-                  if (allowCreateOrTransferDB) {
-                    actionList.push(
-                      "quickaction.bb.database.create",
-                      "quickaction.bb.project.database.transfer"
-                    );
+                  if (allowCreateDB) {
+                    actionList.push("quickaction.bb.database.create");
+                  }
+                  if (allowTransferDB) {
+                    actionList.push("quickaction.bb.project.database.transfer");
                   }
 
                   return new Map([

--- a/frontend/src/utils/role.ts
+++ b/frontend/src/utils/role.ts
@@ -59,7 +59,8 @@ export type ProjectPermissionType =
   | "bb.permission.project.manage-sheet"
   | "bb.permission.project.change-database"
   | "bb.permission.project.admin-database"
-  | "bb.permission.project.create-or-transfer-database";
+  | "bb.permission.project.create-database"
+  | "bb.permission.project.transfer-database";
 
 // Returns true if RBAC is not enabled or the particular project role has the particular project permission.
 export function hasProjectPermission(
@@ -79,9 +80,14 @@ export function hasProjectPermission(
       ["bb.permission.project.manage-sheet", [false, true]],
       ["bb.permission.project.change-database", [true, true]],
       ["bb.permission.project.admin-database", [false, true]],
-      // If dba-workflow is disabled, then project developer can also create or transfer database.
+      // If dba-workflow is disabled, then project developer can also create database.
       [
-        "bb.permission.project.create-or-transfer-database",
+        "bb.permission.project.create-database",
+        [!hasFeature("bb.feature.dba-workflow"), true],
+      ],
+      // If dba-workflow is disabled, then project developer can also transfer database.
+      [
+        "bb.permission.project.transfer-database",
         [!hasFeature("bb.feature.dba-workflow"), true],
       ],
     ]);

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -405,7 +405,7 @@ const allowTransferProject = computed(() => {
     if (
       member.principal.id == currentUser.value.id &&
       hasProjectPermission(
-        "bb.permission.project.create-or-transfer-database",
+        "bb.permission.project.transfer-database",
         member.role
       )
     ) {


### PR DESCRIPTION
"Create database" and "Transfer database" has different complexity. In particular, transfer database has more complex rules depending on the from/to project.

Thus separate them