### PR TITLE
refactor: introduce project permission in backend and move feature gate from server module to API module

### DIFF
--- a/api/plan.go
+++ b/api/plan.go
@@ -180,7 +180,7 @@ func (e FeatureType) AccessErrorMessage() string {
 
 // minimumSupportedPlan will find the minimum plan which support the target feature.
 func (e FeatureType) minimumSupportedPlan() PlanType {
-	for i, enabled := range FeatureMatrix[e] {
+	for i, enabled := range featureMatrix[e] {
 		if enabled {
 			return PlanType(i)
 		}
@@ -189,8 +189,8 @@ func (e FeatureType) minimumSupportedPlan() PlanType {
 	return ENTERPRISE
 }
 
-// FeatureMatrix is a map from the a particular feature to the respective enablement of a particular plan.
-var FeatureMatrix = map[FeatureType][3]bool{
+// featureMatrix is a map from the a particular feature to the respective enablement of a particular plan.
+var featureMatrix = map[FeatureType][3]bool{
 	// Admin & Security
 	Feature3rdPartyAuth: {false, true, true},
 	FeatureRBAC:         {false, true, true},
@@ -248,4 +248,9 @@ const (
 // PlanLimitValues is the plan limit value mapping.
 var PlanLimitValues = map[PlanLimit][3]int64{
 	PlanLimitMaximumTask: {4, math.MaxInt64, math.MaxInt64},
+}
+
+// Feature returns the whether a particular feature is available in a particular plan.
+func Feature(feature FeatureType, plan PlanType) bool {
+	return featureMatrix[feature][plan]
 }

--- a/api/project_member.go
+++ b/api/project_member.go
@@ -120,3 +120,49 @@ type ProjectMemberBatchUpdate struct {
 	RoleProvider ProjectRoleProvider
 	List         []*ProjectMemberCreate
 }
+
+// ProjectPermissionType is the type of a project permission.
+type ProjectPermissionType string
+
+const (
+	// ProjectPermissionManageGeneral allows user to manage general project settings.
+	ProjectPermissionManageGeneral ProjectPermissionType = "bb.permission.project.manage-general"
+	// ProjectPermissionManageMember allows user to manage project memberships.
+	ProjectPermissionManageMember ProjectPermissionType = "bb.permission.project.manage-member"
+	// ProjectPermissionManageSheet allows user to manage sheets in the project.
+	ProjectPermissionManageSheet ProjectPermissionType = "bb.permission.project.manage-sheet"
+	// ProjectPermissionChangeDatabase allows user to make DML/DDL database change in the project.
+	ProjectPermissionChangeDatabase ProjectPermissionType = "bb.permission.project.change-database"
+	// ProjectPermissionAdminDatabase allows user to manage database settings in the project.
+	// - Edit database label
+	// - Backup settings
+	ProjectPermissionAdminDatabase ProjectPermissionType = "bb.permission.project.admin-database"
+	// ProjectPermissionCreateDatabase allows user to create database in the project.
+	ProjectPermissionCreateDatabase ProjectPermissionType = "bb.permission.project.create-database"
+	// ProjectPermissionTransferDatabase allows user to transfer database out of/into the project.
+	ProjectPermissionTransferDatabase ProjectPermissionType = "bb.permission.project.transfer-database"
+)
+
+// ProjectPermission returns whether a particular permission is granted to a particular project role in a particular plan.
+func ProjectPermission(permission ProjectPermissionType, plan PlanType, role common.ProjectRole) bool {
+	// a map from the a particular feature to the respective enablement of a project developer and owner.
+	projectPermissionMatrix := map[ProjectPermissionType][2]bool{
+		ProjectPermissionManageGeneral:  {false, true},
+		ProjectPermissionManageMember:   {false, true},
+		ProjectPermissionManageSheet:    {false, true},
+		ProjectPermissionChangeDatabase: {true, true},
+		ProjectPermissionAdminDatabase:  {false, true},
+		// If dba-workflow is disabled, then project developer can also create database.
+		ProjectPermissionCreateDatabase: {!Feature(FeatureDBAWorkflow, plan), true},
+		// If dba-workflow is disabled, then project developer can also transfer database.
+		ProjectPermissionTransferDatabase: {!Feature(FeatureDBAWorkflow, plan), true},
+	}
+
+	switch role {
+	case common.ProjectDeveloper:
+		return projectPermissionMatrix[permission][0]
+	case common.ProjectOwner:
+		return projectPermissionMatrix[permission][1]
+	}
+	return false
+}

--- a/api/project_member.go
+++ b/api/project_member.go
@@ -134,8 +134,8 @@ const (
 	// ProjectPermissionChangeDatabase allows user to make DML/DDL database change in the project.
 	ProjectPermissionChangeDatabase ProjectPermissionType = "bb.permission.project.change-database"
 	// ProjectPermissionAdminDatabase allows user to manage database settings in the project.
-	// - Edit database label
-	// - Backup settings
+	// - Edit database label.
+	// - Backup settings.
 	ProjectPermissionAdminDatabase ProjectPermissionType = "bb.permission.project.admin-database"
 	// ProjectPermissionCreateDatabase allows user to create database in the project.
 	ProjectPermissionCreateDatabase ProjectPermissionType = "bb.permission.project.create-database"

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -162,7 +162,7 @@ func (s *Server) loadLicense(ctx context.Context) (*enterpriseAPI.License, error
 }
 
 func (s *Server) feature(feature api.FeatureType) bool {
-	return api.FeatureMatrix[feature][s.getEffectivePlan()]
+	return api.Feature(feature, s.getEffectivePlan())
 }
 
 func (s *Server) getPlanLimitValue(name api.PlanLimit) int64 {


### PR DESCRIPTION
* The project permission will be used to gate the backend API
* Moving the feature gate to API module so that other modules can access it without bringing in the server module. This PR shows an example that ProjectPermission needs this. Also, this will help the permission unit tests later.