### PR TITLE
feat(sql-editor): open history item in new tab with connection info if possible

### DIFF
--- a/frontend/src/views/sql-editor/AsidePanel/QueryHistoryContainer.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/QueryHistoryContainer.vue
@@ -60,7 +60,12 @@ import { computed, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import { useClipboard } from "@vueuse/core";
 
-import { pushNotification, useTabStore, useSQLEditorStore } from "@/store";
+import {
+  pushNotification,
+  useTabStore,
+  useSQLEditorStore,
+  searchConnectionByName,
+} from "@/store";
 import { QueryHistory } from "@/types";
 import { getHighlightHTMLByKeyWords } from "@/utils";
 
@@ -134,10 +139,18 @@ const handleCopy = (history: QueryHistory) => {
 };
 
 const handleQueryHistoryClick = async (queryHistory: QueryHistory) => {
-  // Changing SQL statement is quite harmless, so we just update the current tab.
+  // It's awkward that we stored instanceName and databaseName rather than IDs
+  // in the history activity entity.
+  // We may try our best to find the correct database and instance by searching
+  // their names.
+  const { instanceName, databaseName, statement } = queryHistory;
+  const connection = searchConnectionByName(instanceName, databaseName);
+
+  // Open a new tab with the connection and statement.
+  tabStore.selectOrAddTempTab();
   tabStore.updateCurrentTab({
-    statement: queryHistory.statement,
-    selectedStatement: "",
+    connection,
+    statement,
   });
 };
 </script>


### PR DESCRIPTION
Close BYT-1540

### Features

- Clicking a query history item will open a new tab (instead of replacing the current one) with statement and connection info recovery, if possible

### Details
It's awkward that we stored instanceName and databaseName rather than IDs in the history activity entity.

We may try our best to find the correct database and instance by searching the name.