### PR TITLE
feat(sql-editor): open VCS path in new window if needed

### DIFF
--- a/frontend/src/views/sql-editor/AsidePanel/TableSchema.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/TableSchema.vue
@@ -67,8 +67,9 @@
 import { computed } from "vue";
 import { stringify } from "qs";
 
-import { UNKNOWN_ID } from "@/types";
-import { useSQLEditorStore } from "@/store";
+import type { Repository } from "@/types";
+import { baseDirectoryWebUrl, UNKNOWN_ID } from "@/types";
+import { useRepositoryStore, useSQLEditorStore } from "@/store";
 
 const emit = defineEmits<{
   (e: "close-pane"): void;
@@ -83,6 +84,23 @@ const gotoAlterSchema = () => {
   }
 
   const { database } = table.value;
+  const { project } = database;
+  if (project.workflowType === "VCS") {
+    useRepositoryStore()
+      .fetchRepositoryByProjectId(database.project.id)
+      .then((repository: Repository) => {
+        window.open(
+          baseDirectoryWebUrl(repository, {
+            DB_NAME: database.name,
+            ENV_NAME: database.instance.environment.name,
+            TYPE: "ddl",
+          }),
+          "_blank"
+        );
+      });
+    return;
+  }
+
   const query = {
     template: "bb.issue.database.schema.update",
     name: `[${database.name}] Alter schema`,


### PR DESCRIPTION
### Features

- When clicking the [Alter Schema] button on the table schema panel, open the VCS path in a new browser window if the project is VCS workflow.

### Screenshots

![image](https://user-images.githubusercontent.com/2749742/199865709-bdb97e16-3155-4637-84e9-f5ba55c9adc2.png)

