### PR TITLE
feat: dismiss stale reviews for Pending tasks & failed tasks retry as PendingApproval

### DIFF
--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -198,7 +198,7 @@ export const TASK_STATUS_TRANSITION_LIST: Map<
     "RETRY",
     {
       type: "RETRY",
-      to: "RUNNING",
+      to: "PENDING_APPROVAL",
       buttonName: "common.retry",
       buttonType: "PRIMARY",
     },

--- a/server/task.go
+++ b/server/task.go
@@ -20,10 +20,10 @@ import (
 var (
 	applicableTaskStatusTransition = map[api.TaskStatus][]api.TaskStatus{
 		api.TaskPendingApproval: {api.TaskPending},
-		api.TaskPending:         {api.TaskCanceled, api.TaskRunning},
+		api.TaskPending:         {api.TaskCanceled, api.TaskRunning, api.TaskPendingApproval},
 		api.TaskRunning:         {api.TaskDone, api.TaskFailed, api.TaskCanceled},
 		api.TaskDone:            {},
-		api.TaskFailed:          {api.TaskRunning},
+		api.TaskFailed:          {api.TaskRunning, api.TaskPendingApproval},
 		api.TaskCanceled:        {api.TaskPendingApproval},
 	}
 	taskCancellationImplemented = map[api.TaskType]bool{
@@ -398,6 +398,19 @@ func (s *Server) patchTask(ctx context.Context, task *api.Task, taskPatch *api.T
 				return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to create activity after updating task statement: %v", taskPatched.Name)).SetInternal(err)
 			}
 
+			// updated statement, dismiss stale approvals and transfer the status to PendingApproval.
+			if taskPatched.Status != api.TaskPendingApproval {
+				t, err := s.patchTaskStatus(ctx, taskPatched, &api.TaskStatusPatch{
+					IDList:    []int{taskPatch.ID},
+					UpdaterID: taskPatch.UpdaterID,
+					Status:    api.TaskPendingApproval,
+				})
+				if err != nil {
+					return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to change task status to PendingApproval after updating task: %v", taskPatched.Name)).SetInternal(err)
+				}
+				taskPatched = t
+			}
+
 			if taskPatched.Type == api.TaskDatabaseSchemaUpdateGhostSync {
 				_, err = s.store.CreateTaskCheckRunIfNeeded(ctx, &api.TaskCheckRunCreate{
 					CreatorID: taskPatched.CreatorID,
@@ -475,6 +488,7 @@ func (s *Server) patchTask(ctx context.Context, task *api.Task, taskPatch *api.T
 
 	// earliest allowed time update.
 	// - create an activity.
+	// - dismiss stale approval.
 	if taskPatched.EarliestAllowedTs != task.EarliestAllowedTs {
 		// create an activity
 		if issue == nil {
@@ -504,6 +518,19 @@ func (s *Server) patchTask(ctx context.Context, task *api.Task, taskPatch *api.T
 		})
 		if err != nil {
 			return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to create activity after updating task earliest allowed time: %v", taskPatched.Name)).SetInternal(err)
+		}
+
+		// updated earliest allowed time, dismiss stale approvals and transfer the status to PendingApproval.
+		if taskPatched.Status != api.TaskPendingApproval {
+			t, err := s.patchTaskStatus(ctx, taskPatched, &api.TaskStatusPatch{
+				IDList:    []int{taskPatch.ID},
+				UpdaterID: taskPatch.UpdaterID,
+				Status:    api.TaskPendingApproval,
+			})
+			if err != nil {
+				return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to change task status to PendingApproval after updating task: %v", taskPatched.Name)).SetInternal(err)
+			}
+			taskPatched = t
 		}
 	}
 	return taskPatched, nil

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -527,11 +527,12 @@ func TestVCS(t *testing.T) {
 			a.Len(stage.TaskList, 1)
 			task := stage.TaskList[0]
 			// simulate retrying the failed task.
-			ctl.patchTaskStatus(api.TaskStatusPatch{
+			_, err = ctl.patchTaskStatus(api.TaskStatusPatch{
 				IDList:    []int{task.ID},
 				UpdaterID: api.SystemBotID,
 				Status:    api.TaskPendingApproval,
 			}, issue.PipelineID, task.ID)
+			a.NoError(err)
 
 			status, err = ctl.waitIssuePipeline(issue.ID)
 			a.NoError(err)

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -521,6 +521,18 @@ func TestVCS(t *testing.T) {
 			a.NoError(err)
 			a.Len(issues, 1)
 			issue = issues[0]
+
+			a.Len(issue.Pipeline.StageList, 1)
+			stage := issue.Pipeline.StageList[0]
+			a.Len(stage.TaskList, 1)
+			task := stage.TaskList[0]
+			// simulate retrying the failed task.
+			ctl.patchTaskStatus(api.TaskStatusPatch{
+				IDList:    []int{task.ID},
+				UpdaterID: api.SystemBotID,
+				Status:    api.TaskPendingApproval,
+			}, issue.PipelineID, task.ID)
+
 			status, err = ctl.waitIssuePipeline(issue.ID)
 			a.NoError(err)
 			a.Equal(api.TaskDone, status)


### PR DESCRIPTION
- Transit task status to `PendingApproval` on EarliestAllowedTime & SQL statement modifications if the task status is `Pending`.
- Retry failed tasks will set the task status to `PendingApproval`.

Close BYT-1605

@LiuJi-Jim FYI