### PR TITLE
refactor(flashback): parse table name

### DIFF
--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -58,7 +58,9 @@ BEGIN
 `,
 				},
 			},
-			tableMap: map[string][]string{"user": {"id", "name", "balance"}},
+			tableMap: map[string][]string{
+				"user": {"id", "name", "balance"},
+			},
 			rollbackSQL: `DELETE FROM ` + "`binlog_test`.`user`" + `
 WHERE
   ` + "`id`" + `=1 AND
@@ -120,7 +122,9 @@ BEGIN
 `,
 				},
 			},
-			tableMap: map[string][]string{"user": {"id", "name", "balance"}},
+			tableMap: map[string][]string{
+				"user": {"id", "name", "balance"},
+			},
 			rollbackSQL: `UPDATE ` + "`binlog_test`.`user`" + `
 SET
   ` + "`id`" + `=2,
@@ -177,7 +181,9 @@ DELIMITER ;
 /*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
 				},
 			},
-			tableMap: map[string][]string{"user": {"id", "name", "balance"}},
+			tableMap: map[string][]string{
+				"user": {"id", "name", "balance"},
+			},
 			rollbackSQL: `INSERT INTO ` + "`binlog_test`.`user`" + `
 SET
   ` + "`id`" + `=1,
@@ -203,7 +209,9 @@ SET
 ###   @3=0`,
 				},
 			},
-			tableMap:    map[string][]string{"user": {"id", "name", "balance", "new_column"}},
+			tableMap: map[string][]string{
+				"user": {"id", "name", "balance", "new_column"},
+			},
 			rollbackSQL: "",
 			err:         true,
 		},

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -7,10 +7,6 @@ import (
 )
 
 func TestGetRollbackSQL(t *testing.T) {
-	tableMap := make(map[string][]string)
-	tableMap["user"] = []string{"id", "name", "balance"}
-	tableMapNew := make(map[string][]string)
-	tableMapNew["user"] = []string{"id", "name", "balance", "new_column"}
 	tests := []struct {
 		name        string
 		txn         BinlogTransaction
@@ -21,7 +17,7 @@ func TestGetRollbackSQL(t *testing.T) {
 		{
 			name:        "empty",
 			txn:         BinlogTransaction{},
-			tableMap:    make(map[string][]string),
+			tableMap:    map[string][]string{},
 			rollbackSQL: "",
 			err:         false,
 		},
@@ -62,7 +58,7 @@ BEGIN
 `,
 				},
 			},
-			tableMap: tableMap,
+			tableMap: map[string][]string{"user": {"id", "name", "balance"}},
 			rollbackSQL: `DELETE FROM ` + "`binlog_test`.`user`" + `
 WHERE
   ` + "`id`" + `=1 AND
@@ -124,7 +120,7 @@ BEGIN
 `,
 				},
 			},
-			tableMap: tableMap,
+			tableMap: map[string][]string{"user": {"id", "name", "balance"}},
 			rollbackSQL: `UPDATE ` + "`binlog_test`.`user`" + `
 SET
   ` + "`id`" + `=2,
@@ -181,7 +177,7 @@ DELIMITER ;
 /*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
 				},
 			},
-			tableMap: tableMap,
+			tableMap: map[string][]string{"user": {"id", "name", "balance"}},
 			rollbackSQL: `INSERT INTO ` + "`binlog_test`.`user`" + `
 SET
   ` + "`id`" + `=1,
@@ -207,7 +203,7 @@ SET
 ###   @3=0`,
 				},
 			},
-			tableMap:    tableMapNew,
+			tableMap:    map[string][]string{"user": {"id", "name", "balance", "new_column"}},
 			rollbackSQL: "",
 			err:         true,
 		},

--- a/tests/rollback_test.go
+++ b/tests/rollback_test.go
@@ -83,8 +83,7 @@ func TestRollback(t *testing.T) {
 	a.NoError(err)
 	a.Equal(2, len(txList))
 	var rollbackSQLList []string
-	tableMap := make(map[string][]string)
-	tableMap["user"] = []string{"id", "name", "balance"}
+	tableMap := map[string][]string{"user": {"id", "name", "balance"}}
 	for _, tx := range txList {
 		sql, err := tx.GetRollbackSQL(tableMap)
 		a.NoError(err)

--- a/tests/rollback_test.go
+++ b/tests/rollback_test.go
@@ -83,7 +83,9 @@ func TestRollback(t *testing.T) {
 	a.NoError(err)
 	a.Equal(2, len(txList))
 	var rollbackSQLList []string
-	tableMap := map[string][]string{"user": {"id", "name", "balance"}}
+	tableMap := map[string][]string{
+		"user": {"id", "name", "balance"},
+	}
 	for _, tx := range txList {
 		sql, err := tx.GetRollbackSQL(tableMap)
 		a.NoError(err)

--- a/tests/rollback_test.go
+++ b/tests/rollback_test.go
@@ -83,8 +83,10 @@ func TestRollback(t *testing.T) {
 	a.NoError(err)
 	a.Equal(2, len(txList))
 	var rollbackSQLList []string
+	tableMap := make(map[string][]string)
+	tableMap["user"] = []string{"id", "name", "balance"}
 	for _, tx := range txList {
-		sql, err := tx.GetRollbackSQL([]string{"id", "name", "balance"})
+		sql, err := tx.GetRollbackSQL(tableMap)
 		a.NoError(err)
 		rollbackSQLList = append(rollbackSQLList, sql)
 	}


### PR DESCRIPTION
There may be multiple tables in a transaction. We should parse the table name to match against the provided table map to get the column names.