### PR TITLE
feat(vcs): support YAML file in place of SQL for DML

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -172,6 +172,18 @@ type MigrationContext struct {
 	VCSPushEvent *vcs.PushEvent `json:"vcsPushEvent"`
 }
 
+// MigrationFileYAMLDatabase contains the information of a database in a YAML
+// format migration file.
+type MigrationFileYAMLDatabase struct {
+	Name string `yaml:"name"` // The name of the database
+}
+
+// MigrationFileYAML contains the information in a YAML format migration file.
+type MigrationFileYAML struct {
+	Databases []MigrationFileYAMLDatabase `yaml:"databases"` // The list of databases and how to identify them
+	Statement string                      `yaml:"statement"` // The SQL statement to be executed to specified list of databases
+}
+
 // UpdateSchemaGhostDetail is the detail of updating database schema using gh-ost.
 type UpdateSchemaGhostDetail struct {
 	// DatabaseID is the ID of a database.

--- a/plugin/vcs/util.go
+++ b/plugin/vcs/util.go
@@ -56,6 +56,7 @@ type DistinctFileItem struct {
 	Commit    Commit
 	FileName  string
 	ItemType  FileItemType
+	IsYAML    bool
 }
 
 // GetDistinctFileList gets the distinct files from push event commits.
@@ -74,6 +75,7 @@ func (p PushEvent) GetDistinctFileList() []DistinctFileItem {
 				Commit:    commit,
 				FileName:  fileName,
 				ItemType:  itemType,
+				IsYAML:    strings.HasSuffix(fileName, ".yml"),
 			}
 			for i, file := range distinctFileList {
 				// For the migration file with the same name, keep the one from the latest commit

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -996,17 +996,6 @@ func (s *Server) prepareIssueFromSDLFile(ctx context.Context, repo *api.Reposito
 	return migrationDetailList, nil
 }
 
-type migrationFileYAMLDatabase struct {
-	Name string `yaml:"name"` // The name of the database
-}
-
-// migrationFileYAML represents the information contained in a YAML format
-// migration file.
-type migrationFileYAML struct {
-	Databases []migrationFileYAMLDatabase `yaml:"databases"` // The list of databases and how to identify them
-	Statement string                      `yaml:"statement"` // The SQL statement to be executed to specified list of databases
-}
-
 // prepareIssueFromFile returns a list of update schema details derived
 // from the given push event for DDL.
 func (s *Server) prepareIssueFromFile(ctx context.Context, repo *api.Repository, pushEvent vcs.PushEvent, fileInfo fileInfo) ([]*api.MigrationDetail, []*api.ActivityCreate) {
@@ -1035,7 +1024,7 @@ func (s *Server) prepareIssueFromFile(ctx context.Context, repo *api.Repository,
 			}, nil
 		}
 
-		var migrationFile migrationFileYAML
+		var migrationFile api.MigrationFileYAML
 		err = yaml.Unmarshal([]byte(content), &migrationFile)
 		if err != nil {
 			return nil, []*api.ActivityCreate{

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -1605,7 +1605,7 @@ func TestVCS_SQL_Review(t *testing.T) {
 	}
 }
 
-// postVCSSQLReview will creates the VCS SQL review and get the response.
+// postVCSSQLReview will create the VCS SQL review and get the response.
 func postVCSSQLReview(ctl *controller, repo *api.Repository, request *api.VCSSQLReviewRequest) (*api.VCSSQLReviewResult, error) {
 	url := fmt.Sprintf("%s/hook/sql-review/%s", ctl.rootURL, repo.WebhookEndpointID)
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -165,6 +165,8 @@ func getTestPort(testName string) int {
 		"TestTenant",
 		"TestTenantVCS/GitLab",
 		"TestTenantVCS/GitHub",
+		"TestTenantVCS_YAML/GitLab",
+		"TestTenantVCS_YAML/GitHub",
 		"TestTenantDatabaseNameTemplate",
 		"TestGhostSchemaUpdate",
 		"TestTenantVCSDatabaseNameTemplate/GitLab",


### PR DESCRIPTION
This PR adds support for using YAML in place of DML files with a flexible database selection capability for tenant projects, as defined in the [RFC](https://docs.google.com/document/d/1toyY5tao8wsqmCJp9zB_lmRXSQHAgrtWsdTUpbQhdU0/edit#).

In other words, use the file extension `.yml` instead of `.sql` would do the switch automatically:

```diff
-{{DB_NAME}}##{{VERSION}}##{{TYPE}}.sql
+{{DB_NAME}}##{{VERSION}}##{{TYPE}}.yml
```

Based on the RFC, the database name in the file path is then ignored completely.

So far, only select databases by their names is implemented:

```yaml
databases:
  - name: mydb
statement: |
  INSERT INTO book (name) VALUES ('Star Wars')
```