### PR TITLE
chore: backfill instance and database ID for SQL editor query activities

### DIFF
--- a/api/activity.go
+++ b/api/activity.go
@@ -195,12 +195,15 @@ type ActivityProjectDatabaseTransferPayload struct {
 // ActivitySQLEditorQueryPayload is the API message payloads for the executed query info.
 type ActivitySQLEditorQueryPayload struct {
 	// Used by activity table to display info without paying the join cost
-	Statement    string           `json:"statement"`
-	DurationNs   int64            `json:"durationNs"`
-	InstanceName string           `json:"instanceName"`
-	DatabaseName string           `json:"databaseName"`
-	Error        string           `json:"error"`
-	AdviceList   []advisor.Advice `json:"adviceList"`
+	Statement  string `json:"statement"`
+	DurationNs int64  `json:"durationNs"`
+	InstanceID int    `json:"instanceID"`
+	// DeprecatedInstanceName is deprecated and should be removed from future version.
+	DeprecatedInstanceName string           `json:"instanceName"`
+	DatabaseID             int              `json:"databaseID"`
+	DatabaseName           string           `json:"databaseName"`
+	Error                  string           `json:"error"`
+	AdviceList             []advisor.Advice `json:"adviceList"`
 }
 
 // Activity is the API message for an activity.
@@ -275,4 +278,7 @@ type ActivityPatch struct {
 
 	// Domain specific fields
 	Comment *string `jsonapi:"attr,comment"`
+
+	// TODO(d): remove the payload after the backfill.
+	Payload *string
 }

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -126,7 +126,9 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
           updatedTs: history.updatedTs,
           statement: payload.statement,
           durationNs: payload.durationNs,
+          instanceId: payload.instanceId,
           instanceName: payload.instanceName,
+          databaseId: payload.databaseId,
           databaseName: payload.databaseName,
           error: payload.error,
           createdAt: dayjs(history.createdTs * 1000).format(

--- a/frontend/src/types/activity.ts
+++ b/frontend/src/types/activity.ts
@@ -1,5 +1,12 @@
 import { FieldId } from "../plugins";
-import { ActivityId, ContainerId, PrincipalId, TaskId } from "./id";
+import {
+  ActivityId,
+  ContainerId,
+  DatabaseId,
+  InstanceId,
+  PrincipalId,
+  TaskId,
+} from "./id";
 import { IssueStatus } from "./issue";
 import { MemberStatus, RoleType } from "./member";
 import { TaskStatus } from "./pipeline";
@@ -178,7 +185,9 @@ export type ActivityProjectDatabaseTransferPayload = {
 export type ActivitySQLEditorQueryPayload = {
   statement: string;
   durationNs: number;
+  instanceId: InstanceId;
   instanceName: string;
+  databaseId: DatabaseId;
   databaseName: string;
   error: string;
   adviceList: Advice[];

--- a/server/server.go
+++ b/server/server.go
@@ -188,6 +188,11 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 	storeInstance := store.New(storeDB, cacheService)
 	s.store = storeInstance
 
+	// Backfill activity.
+	if err := storeInstance.BackfillSQLEditorActivity(ctx); err != nil {
+		return nil, err
+	}
+
 	config, err := getInitSetting(ctx, storeInstance)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init config")

--- a/server/server.go
+++ b/server/server.go
@@ -190,7 +190,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 
 	// Backfill activity.
 	if err := storeInstance.BackfillSQLEditorActivity(ctx); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "cannot backfill SQL editor activities")
 	}
 
 	config, err := getInitSetting(ctx, storeInstance)

--- a/server/sql.go
+++ b/server/sql.go
@@ -782,7 +782,7 @@ func (s *Server) createSQLEditorQueryActivity(ctx context.Context, c echo.Contex
 		Type:        api.ActivitySQLEditorQuery,
 		ContainerID: containerID,
 		Level:       level,
-		Comment: fmt.Sprintf("Executed `%q` in database %q of instance %q.",
+		Comment: fmt.Sprintf("Executed `%q` in database %q of instance %d.",
 			payload.Statement, payload.DatabaseName, payload.InstanceID),
 		Payload: string(activityBytes),
 	}

--- a/server/sql.go
+++ b/server/sql.go
@@ -319,7 +319,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			errMessage = queryErr.Error()
 		}
 		var databaseID int
-		if exec.DatabaseName != "" {
+		if database != nil {
 			databaseID = database.ID
 		}
 		if err := s.createSQLEditorQueryActivity(ctx, c, level, exec.InstanceID, api.ActivitySQLEditorQueryPayload{
@@ -431,7 +431,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			errMessage = queryErr.Error()
 		}
 		var databaseID int
-		if exec.DatabaseName != "" {
+		if database != nil {
 			databaseID = database.ID
 		}
 		if err := s.createSQLEditorQueryActivity(ctx, c, level, exec.InstanceID, api.ActivitySQLEditorQueryPayload{

--- a/server/sql.go
+++ b/server/sql.go
@@ -180,16 +180,8 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		if instance == nil {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Instance ID not found: %d", exec.InstanceID))
 		}
-
-		adviceLevel := advisor.Success
-		adviceList := []advisor.Advice{}
-
-		if api.IsSQLReviewSupported(instance.Engine, s.profile.Mode) && exec.DatabaseName != "" {
-			dbType, err := advisorDB.ConvertToAdvisorDBType(string(instance.Engine))
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to convert db type %v into advisor db type", instance.Engine))
-			}
-
+		var database *api.Database
+		if exec.DatabaseName != "" {
 			databaseFind := &api.DatabaseFind{
 				InstanceID: &instance.ID,
 				Name:       &exec.DatabaseName,
@@ -204,9 +196,19 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			if len(dbList) > 1 {
 				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("There are multiple database `%s` for instance ID: %d", exec.DatabaseName, instance.ID))
 			}
-			db := dbList[0]
+			database = dbList[0]
+		}
 
-			catalog, err := s.store.NewCatalog(ctx, db.ID, instance.Engine)
+		adviceLevel := advisor.Success
+		adviceList := []advisor.Advice{}
+
+		if api.IsSQLReviewSupported(instance.Engine, s.profile.Mode) && exec.DatabaseName != "" {
+			dbType, err := advisorDB.ConvertToAdvisorDBType(string(instance.Engine))
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to convert db type %v into advisor db type", instance.Engine))
+			}
+
+			catalog, err := s.store.NewCatalog(ctx, database.ID, instance.Engine)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create a catalog")
 			}
@@ -224,8 +226,8 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			adviceLevel, adviceList, err = s.sqlCheck(
 				ctx,
 				dbType,
-				db.CharacterSet,
-				db.Collation,
+				database.CharacterSet,
+				database.Collation,
 				instance.EnvironmentID,
 				exec.Statement,
 				catalog,
@@ -237,12 +239,14 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 
 			if adviceLevel == advisor.Error {
 				if err := s.createSQLEditorQueryActivity(ctx, c, api.ActivityError, exec.InstanceID, api.ActivitySQLEditorQueryPayload{
-					Statement:    exec.Statement,
-					DurationNs:   0,
-					InstanceName: instance.Name,
-					DatabaseName: exec.DatabaseName,
-					Error:        "",
-					AdviceList:   adviceList,
+					Statement:              exec.Statement,
+					DurationNs:             0,
+					InstanceID:             instance.ID,
+					DeprecatedInstanceName: instance.Name,
+					DatabaseID:             database.ID,
+					DatabaseName:           exec.DatabaseName,
+					Error:                  "",
+					AdviceList:             adviceList,
 				}); err != nil {
 					return err
 				}
@@ -314,13 +318,19 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			level = api.ActivityError
 			errMessage = queryErr.Error()
 		}
+		var databaseID int
+		if exec.DatabaseName != "" {
+			databaseID = database.ID
+		}
 		if err := s.createSQLEditorQueryActivity(ctx, c, level, exec.InstanceID, api.ActivitySQLEditorQueryPayload{
-			Statement:    exec.Statement,
-			DurationNs:   time.Now().UnixNano() - start,
-			InstanceName: instance.Name,
-			DatabaseName: exec.DatabaseName,
-			Error:        errMessage,
-			AdviceList:   adviceList,
+			Statement:              exec.Statement,
+			DurationNs:             time.Now().UnixNano() - start,
+			InstanceID:             instance.ID,
+			DeprecatedInstanceName: instance.Name,
+			DatabaseID:             databaseID,
+			DatabaseName:           exec.DatabaseName,
+			Error:                  errMessage,
+			AdviceList:             adviceList,
 		}); err != nil {
 			return err
 		}
@@ -376,6 +386,24 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		if instance == nil {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Instance ID not found: %d", exec.InstanceID))
 		}
+		var database *api.Database
+		if exec.DatabaseName != "" {
+			databaseFind := &api.DatabaseFind{
+				InstanceID: &instance.ID,
+				Name:       &exec.DatabaseName,
+			}
+			dbList, err := s.store.FindDatabase(ctx, databaseFind)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch database `%s` for instance ID: %d", exec.DatabaseName, instance.ID)).SetInternal(err)
+			}
+			if len(dbList) == 0 {
+				return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database `%s` for instance ID: %d not found", exec.DatabaseName, instance.ID))
+			}
+			if len(dbList) > 1 {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("There are multiple database `%s` for instance ID: %d", exec.DatabaseName, instance.ID))
+			}
+			database = dbList[0]
+		}
 
 		// Admin API always executes with read-only off.
 		exec.Readonly = true
@@ -402,12 +430,18 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			level = api.ActivityError
 			errMessage = queryErr.Error()
 		}
+		var databaseID int
+		if exec.DatabaseName != "" {
+			databaseID = database.ID
+		}
 		if err := s.createSQLEditorQueryActivity(ctx, c, level, exec.InstanceID, api.ActivitySQLEditorQueryPayload{
-			Statement:    exec.Statement,
-			DurationNs:   time.Now().UnixNano() - start,
-			InstanceName: instance.Name,
-			DatabaseName: exec.DatabaseName,
-			Error:        errMessage,
+			Statement:              exec.Statement,
+			DurationNs:             time.Now().UnixNano() - start,
+			InstanceID:             instance.ID,
+			DeprecatedInstanceName: instance.Name,
+			DatabaseID:             databaseID,
+			DatabaseName:           exec.DatabaseName,
+			Error:                  errMessage,
 		}); err != nil {
 			return err
 		}
@@ -737,7 +771,7 @@ func (s *Server) createSQLEditorQueryActivity(ctx context.Context, c echo.Contex
 	if err != nil {
 		log.Warn("Failed to marshal activity after executing sql statement",
 			zap.String("database_name", payload.DatabaseName),
-			zap.String("instance_name", payload.InstanceName),
+			zap.Int("instance_id", payload.InstanceID),
 			zap.String("statement", payload.Statement),
 			zap.Error(err))
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to construct activity payload").SetInternal(err)
@@ -749,14 +783,14 @@ func (s *Server) createSQLEditorQueryActivity(ctx context.Context, c echo.Contex
 		ContainerID: containerID,
 		Level:       level,
 		Comment: fmt.Sprintf("Executed `%q` in database %q of instance %q.",
-			payload.Statement, payload.DatabaseName, payload.InstanceName),
+			payload.Statement, payload.DatabaseName, payload.InstanceID),
 		Payload: string(activityBytes),
 	}
 
 	if _, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{}); err != nil {
 		log.Warn("Failed to create activity after executing sql statement",
 			zap.String("database_name", payload.DatabaseName),
-			zap.String("instance_name", payload.InstanceName),
+			zap.Int("instance_id", payload.InstanceID),
 			zap.String("statement", payload.Statement),
 			zap.Error(err))
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create activity").SetInternal(err)


### PR DESCRIPTION
InstanceID is unique than instance name. We will keep both database ID and name for getting the database object and readable name.