### PR TITLE
feat(flashback): generate rollback SQL for executed DML task

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -164,8 +164,7 @@ type TaskDatabaseDataUpdatePayload struct {
 	// 0. The initial state is "".
 	// 1. When the rollback generation starts, we set it to "RUNNING".
 	// 2. When the rollback generation succeeds, we set it to "SUCCESS".
-	// 3. When the rollback generation meets recoverable failure, we set it to "" and retry later.
-	// 4. When the rollback generation meets unrecoverable failure, we set it to "FAIL", and set the err to RollbackError.
+	// 4. When the rollback generation fails, we set it to "FAIL", and set the err to RollbackError.
 	RollbackTaskState string `json:"rollbackTaskState,omitempty"`
 	RollbackError     string `json:"rollbackError,omitempty"`
 	// RollbackStatement is the generated rollback SQL statement for the DML task.

--- a/api/task.go
+++ b/api/task.go
@@ -132,6 +132,14 @@ type TaskDatabaseSchemaUpdateGhostSyncPayload struct {
 // TaskDatabaseSchemaUpdateGhostCutoverPayload is the task payload for gh-ost switching the original table and the ghost table.
 type TaskDatabaseSchemaUpdateGhostCutoverPayload struct{}
 
+type RollbackTaskState string
+
+const (
+	RollbackTaskRunning RollbackTaskState = "RUNNING"
+	RollbackTaskSuccess RollbackTaskState = "SUCCESS"
+	RollbackTaskFail    RollbackTaskState = "FAIL"
+)
+
 // TaskDatabaseDataUpdatePayload is the task payload for database data update (DML).
 type TaskDatabaseDataUpdatePayload struct {
 	Statement     string         `json:"statement,omitempty"`
@@ -143,12 +151,25 @@ type TaskDatabaseDataUpdatePayload struct {
 	// ThreadID is the ID of the connection executing the migration.
 	// We use it to filter the binlog events of the migration transaction.
 	ThreadID string `json:"threadID,omitempty"`
+	// MigrationID is the ID of the migration history record.
+	// We use it to get the schema when the transaction ran.
+	MigrationID int `json:"migrationID,omitempty"`
 	// BinlogXxx are obtained before and after executing the migration.
 	// We use them to locate the range of binlog for the migration transaction.
 	BinlogFileStart string `json:"binlogFileStart,omitempty"`
 	BinlogFileEnd   string `json:"binlogFileEnd,omitempty"`
 	BinlogPosStart  int64  `json:"binlogPosStart,omitempty"`
 	BinlogPosEnd    int64  `json:"binlogPosEnd,omitempty"`
+	// RollbackTaskState is a state machine
+	// 0. The initial state is "".
+	// 1. When the rollback generation starts, we set it to "RUNNING".
+	// 2. When the rollback generation succeeds, we set it to "SUCCESS".
+	// 3. When the rollback generation meets recoverable failure, we set it to "" and retry later.
+	// 4. When the rollback generation meets unrecoverable failure, we set it to "FAIL", and set the err to RollbackError.
+	RollbackTaskState string `json:"rollbackTaskState,omitempty"`
+	RollbackError     string `json:"rollbackError,omitempty"`
+	// RollbackStatement is the generated rollback SQL statement for the DML task.
+	RollbackStatement string `json:"rollbackStatement,omitempty"`
 }
 
 // TaskDatabaseBackupPayload is the task payload for database backup.

--- a/api/task.go
+++ b/api/task.go
@@ -165,8 +165,8 @@ type TaskDatabaseDataUpdatePayload struct {
 	// 1. When the rollback generation starts, we set it to "RUNNING".
 	// 2. When the rollback generation succeeds, we set it to "SUCCESS".
 	// 4. When the rollback generation fails, we set it to "FAIL", and set the err to RollbackError.
-	RollbackTaskState string `json:"rollbackTaskState,omitempty"`
-	RollbackError     string `json:"rollbackError,omitempty"`
+	RollbackTaskState RollbackTaskState `json:"rollbackTaskState,omitempty"`
+	RollbackError     string            `json:"rollbackError,omitempty"`
 	// RollbackStatement is the generated rollback SQL statement for the DML task.
 	RollbackStatement string `json:"rollbackStatement,omitempty"`
 }

--- a/server/rollback_runner.go
+++ b/server/rollback_runner.go
@@ -104,10 +104,10 @@ func (r *RollbackRunner) getRollbackSQL(ctx context.Context, task *api.Task) {
 	rollbackSQL, err := r.getRollbackSQLImpl(ctx, task, payload)
 	if err != nil {
 		log.Error("Failed to generate rollback SQL statement", zap.Error(err))
-		payload.RollbackTaskState = string(api.RollbackTaskFail)
+		payload.RollbackTaskState = api.RollbackTaskFail
 		payload.RollbackError = err.Error()
 	}
-	payload.RollbackTaskState = string(api.RollbackTaskSuccess)
+	payload.RollbackTaskState = api.RollbackTaskSuccess
 	payload.RollbackStatement = rollbackSQL
 
 	payloadBytes, err := json.Marshal(payload)

--- a/server/rollback_runner.go
+++ b/server/rollback_runner.go
@@ -1,0 +1,252 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/pingcap/tidb/parser"
+	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+	"github.com/bytebase/bytebase/common/log"
+	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/bytebase/bytebase/plugin/db/mysql"
+	bbparser "github.com/bytebase/bytebase/plugin/parser"
+	"github.com/bytebase/bytebase/resources/mysqlutil"
+)
+
+var (
+	generateRollbackSQLChan = make(chan *api.Task, 100)
+)
+
+// NewRollbackRunner creates a new backup runner.
+func NewRollbackRunner(server *Server) *RollbackRunner {
+	return &RollbackRunner{
+		server: server,
+	}
+}
+
+// RollbackRunner is the backup runner scheduling automatic backups.
+type RollbackRunner struct {
+	server *Server
+}
+
+// Run is the runner for backup runner.
+func (r *RollbackRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case task := <-generateRollbackSQLChan:
+			if task.Instance.Engine == db.MySQL && task.Type == api.TaskDatabaseDataUpdate {
+				r.getRollbackSQL(ctx, task)
+			}
+		case <-ctx.Done(): // if cancel() execute
+			return
+		}
+	}
+}
+
+func (r *RollbackRunner) getRollbackSQL(ctx context.Context, task *api.Task) {
+	defer func() {
+		if r := recover(); r != nil {
+			err, ok := r.(error)
+			if !ok {
+				err = errors.Errorf("%v", r)
+			}
+			log.Error("Rollback runner PANIC RECOVER", zap.Error(err), zap.Stack("panic-stack"))
+		}
+	}()
+
+	payload := &api.TaskDatabaseDataUpdatePayload{}
+	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
+		log.Error("Invalid database data update payload", zap.Error(err))
+		return
+	}
+	if payload.ThreadID == "" ||
+		payload.BinlogFileStart == "" ||
+		payload.BinlogPosStart == 0 ||
+		payload.BinlogFileEnd == "" ||
+		payload.BinlogPosEnd == 0 {
+		log.Error("Cannot generate rollback SQL statement for the data update task with invalid payload", zap.Any("payload", *payload))
+		return
+	}
+
+	rollbackSQL, err := r.getRollbackSQLImpl(ctx, task, payload)
+	if err != nil {
+		log.Error("Failed to generate rollback SQL statement", zap.Error(err))
+		payload.RollbackTaskState = string(api.RollbackTaskFail)
+		payload.RollbackError = err.Error()
+	}
+	payload.RollbackTaskState = string(api.RollbackTaskSuccess)
+	payload.RollbackStatement = rollbackSQL
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		log.Error("Failed to marshal task payload", zap.Error(err))
+		return
+	}
+	payloadString := string(payloadBytes)
+	patch := &api.TaskPatch{
+		ID:        task.ID,
+		UpdaterID: api.SystemBotID,
+		Payload:   &payloadString,
+	}
+	if _, err := r.server.store.PatchTask(ctx, patch); err != nil {
+		log.Error("Failed to patch task with the MySQL thread ID", zap.Int("taskID", task.ID))
+		return
+	}
+	log.Debug("Rollback SQL generation success", zap.Int("taskID", task.ID))
+}
+
+func (r *RollbackRunner) getRollbackSQLImpl(ctx context.Context, task *api.Task, payload *api.TaskDatabaseDataUpdatePayload) (string, error) {
+	basename, seqStart, err := mysql.ParseBinlogName(payload.BinlogFileStart)
+	if err != nil {
+		return "", errors.WithMessagef(err, "invalid start binlog file name %s", payload.BinlogFileStart)
+	}
+	_, seqEnd, err := mysql.ParseBinlogName(payload.BinlogFileEnd)
+	if err != nil {
+		return "", errors.WithMessagef(err, "Invalid end binlog file name %s", payload.BinlogFileEnd)
+	}
+	binlogFileNameList := mysql.GenBinlogFileNames(basename, seqStart, seqEnd)
+
+	driver, err := r.server.getAdminDatabaseDriver(ctx, task.Instance, "")
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to get admin database driver")
+	}
+
+	list, err := driver.FindMigrationHistoryList(ctx, &db.MigrationHistoryFind{ID: &payload.MigrationID})
+	if err != nil {
+		return "", errors.WithMessagef(err, "failed to find migration history with ID %d", payload.MigrationID)
+	}
+	if len(list) == 0 {
+		return "", errors.WithMessagef(err, "migration history with ID %d not found", payload.MigrationID)
+	}
+	history := list[0]
+	tableMap, err := parseTableColumns(history.Schema)
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to parse the schema")
+	}
+
+	rollbackSQL, err := r.generateRollbackSQL(ctx, task, payload, binlogFileNameList, tableMap)
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to generate rollback SQL statement")
+	}
+
+	return rollbackSQL, nil
+}
+
+func parseTableColumns(schema string) (map[string][]string, error) {
+	_, supportStmts, err := bbparser.ExtractTiDBUnsupportStmts(schema)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to extract TiDB unsupported statements from old statements %q", schema)
+	}
+	nodes, _, err := parser.New().Parse(supportStmts, "", "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse old statement %q", schema)
+	}
+	tableMap := make(map[string][]string)
+	for _, node := range nodes {
+		if stmt, ok := node.(*ast.CreateTableStmt); ok {
+			var columnNames []string
+			for _, col := range stmt.Cols {
+				columnNames = append(columnNames, col.Name.Name.O)
+			}
+			tableMap[stmt.Table.Name.O] = columnNames
+		}
+	}
+	return tableMap, nil
+}
+
+func (r *RollbackRunner) generateRollbackSQL(ctx context.Context, task *api.Task, payload *api.TaskDatabaseDataUpdatePayload, binlogFileNameList []string, tableMap map[string][]string) (string, error) {
+	adminDataSource := api.DataSourceFromInstanceWithType(task.Instance, api.Admin)
+	args := binlogFileNameList
+	args = append(args,
+		"--read-from-remote-server",
+		// Verify checksum binlog events.
+		"--verify-binlog-checksum",
+		// Tell mysqlbinlog to suppress the BINLOG statements for row events, which reduces the unneeded output.
+		"--base64-output=DECODE-ROWS",
+		// Reconstruct pseudo-SQL statements out of row events. This is where we parse the data changes.
+		"--verbose",
+		"--host", task.Instance.Host,
+		"--user", adminDataSource.Username,
+		// Start decoding the binary log at the log position, this option applies to the first log file named on the command line.
+		"--start-position", fmt.Sprintf("%d", payload.BinlogPosStart),
+		// Stop decoding the binary log at the log position, this option applies to the last log file named on the command line.
+		"--stop-position", fmt.Sprintf("%d", payload.BinlogPosEnd),
+	)
+	if task.Instance.Port != "" {
+		args = append(args, "--port", task.Instance.Port)
+	}
+	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, common.GetResourceDir(r.server.profile.DataDir)), args...)
+	log.Debug("mysqlbinlog", zap.String("command", cmd.String()))
+	if adminDataSource.Password != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("MYSQL_PWD=%s", adminDataSource.Password))
+	}
+	pr, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create stdout pipe")
+	}
+
+	errPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create stderr pipe")
+	}
+	defer errPipe.Close()
+	errScanner := bufio.NewScanner(errPipe)
+
+	if err := cmd.Start(); err != nil {
+		return "", errors.Wrap(err, "failed to run mysqlbinlog")
+	}
+
+	txnList, err := mysql.ParseBinlogStream(pr)
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to parse binlog stream")
+	}
+
+	txnList, err = mysql.FilterBinlogTransactionsByThreadID(txnList, payload.ThreadID)
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to filter binlog transactions by thread ID")
+	}
+
+	var rollbackSQLList []string
+	for i := len(txnList) - 1; i >= 0; i-- {
+		sql, err := txnList[i].GetRollbackSQL(tableMap)
+		if err != nil {
+			return "", errors.WithMessage(err, "failed to generate rollback SQL statement for transaction")
+		}
+		rollbackSQLList = append(rollbackSQLList, sql)
+	}
+
+	var errBuilder strings.Builder
+	for errScanner.Scan() {
+		line := errScanner.Text()
+		// Log the error, but return the first 1024 characters in the error to users.
+		log.Warn(line)
+		if errBuilder.Len() < 1024 {
+			if _, err := errBuilder.WriteString(line); err != nil {
+				return "", errors.Wrap(err, "failed to write mysqlbinlog error string")
+			}
+			if _, err := errBuilder.WriteString("\n"); err != nil {
+				return "", errors.Wrap(err, "failed to write mysqlbinlog error string")
+			}
+		}
+	}
+	if errScanner.Err() != nil {
+		return "", errors.Wrap(errScanner.Err(), "error scanner failed")
+	}
+
+	if err = cmd.Wait(); err != nil {
+		return "", errors.Wrapf(err, "mysqlbinlog error: %s", errBuilder.String())
+	}
+
+	return strings.Join(rollbackSQLList, "\n\n"), nil
+}

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -236,7 +236,7 @@ func setMigrationIDAndEndBinlogCoordinate(ctx context.Context, driver db.Driver,
 	}
 	payload.BinlogFileEnd = binlogInfo.FileName
 	payload.BinlogPosEnd = binlogInfo.Position
-	payload.RollbackTaskState = string(api.RollbackTaskRunning)
+	payload.RollbackTaskState = api.RollbackTaskRunning
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -153,9 +153,11 @@ func executeMigration(ctx context.Context, server *Server, task *api.Task, state
 	}
 
 	if task.Type == api.TaskDatabaseDataUpdate && task.Instance.Engine == db.MySQL {
-		if err := setThreadIDAndStartBinlogCoordinate(ctx, driver, task, server.store); err != nil {
+		updatedTask, err := setThreadIDAndStartBinlogCoordinate(ctx, driver, task, server.store)
+		if err != nil {
 			return 0, "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
 		}
+		task = updatedTask
 	}
 
 	migrationID, schema, err = driver.ExecuteMigration(ctx, mi, statement)
@@ -164,43 +166,45 @@ func executeMigration(ctx context.Context, server *Server, task *api.Task, state
 	}
 
 	if task.Type == api.TaskDatabaseDataUpdate && task.Instance.Engine == db.MySQL {
-		if err := setEndBinlogCoordinate(ctx, driver, task, server.store); err != nil {
+		updatedTask, err := setMigrationIDAndEndBinlogCoordinate(ctx, driver, task, server.store, migrationID)
+		if err != nil {
 			return 0, "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
 		}
+		generateRollbackSQLChan <- updatedTask
 	}
 
 	return migrationID, schema, nil
 }
 
-func setThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store) error {
+func setThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store) (*api.Task, error) {
 	mysqlDriver, ok := driver.(*mysql.Driver)
 	if !ok {
-		return errors.Errorf("failed to cast driver to mysql.Driver")
+		return nil, errors.Errorf("failed to cast driver to mysql.Driver")
 	}
 	payload := &api.TaskDatabaseDataUpdatePayload{}
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
-		return errors.Wrap(err, "invalid database data update payload")
+		return nil, errors.Wrap(err, "invalid database data update payload")
 	}
 	connID, err := mysqlDriver.GetMigrationConnID(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	payload.ThreadID = connID
 
 	db, err := driver.GetDBConnection(ctx, "")
 	if err != nil {
-		return errors.Wrap(err, "failed to get the DB connection")
+		return nil, errors.Wrap(err, "failed to get the DB connection")
 	}
 	binlogInfo, err := mysql.GetBinlogInfo(ctx, db)
 	if err != nil {
-		return errors.Wrap(err, "failed to get the binlog info before executing the migration transaction")
+		return nil, errors.Wrap(err, "failed to get the binlog info before executing the migration transaction")
 	}
 	payload.BinlogFileStart = binlogInfo.FileName
 	payload.BinlogPosStart = binlogInfo.Position
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal task payload")
+		return nil, errors.Wrap(err, "failed to marshal task payload")
 	}
 	payloadString := string(payloadBytes)
 	patch := &api.TaskPatch{
@@ -208,32 +212,35 @@ func setThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver, 
 		UpdaterID: api.SystemBotID,
 		Payload:   &payloadString,
 	}
-	if _, err := store.PatchTask(ctx, patch); err != nil {
-		return errors.Wrapf(err, "failed to patch task %d with the MySQL thread ID", task.ID)
+	updatedTask, err := store.PatchTask(ctx, patch)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to patch task %d with the MySQL thread ID", task.ID)
 	}
-	return nil
+	return updatedTask, nil
 }
 
-func setEndBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store) error {
+func setMigrationIDAndEndBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store, migrationID int64) (*api.Task, error) {
 	payload := &api.TaskDatabaseDataUpdatePayload{}
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
-		return errors.Wrap(err, "invalid database data update payload")
+		return nil, errors.Wrap(err, "invalid database data update payload")
 	}
 
+	payload.MigrationID = int(migrationID)
 	db, err := driver.GetDBConnection(ctx, "")
 	if err != nil {
-		return errors.Wrap(err, "failed to get the DB connection")
+		return nil, errors.Wrap(err, "failed to get the DB connection")
 	}
 	binlogInfo, err := mysql.GetBinlogInfo(ctx, db)
 	if err != nil {
-		return errors.Wrap(err, "failed to get the binlog info before executing the migration transaction")
+		return nil, errors.Wrap(err, "failed to get the binlog info before executing the migration transaction")
 	}
 	payload.BinlogFileEnd = binlogInfo.FileName
 	payload.BinlogPosEnd = binlogInfo.Position
+	payload.RollbackTaskState = string(api.RollbackTaskRunning)
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal task payload")
+		return nil, errors.Wrap(err, "failed to marshal task payload")
 	}
 	payloadString := string(payloadBytes)
 	patch := &api.TaskPatch{
@@ -241,10 +248,11 @@ func setEndBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Tas
 		UpdaterID: api.SystemBotID,
 		Payload:   &payloadString,
 	}
-	if _, err := store.PatchTask(ctx, patch); err != nil {
-		return errors.Wrapf(err, "failed to patch task %d with the MySQL thread ID", task.ID)
+	updatedTask, err := store.PatchTask(ctx, patch)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to patch task %d with the MySQL thread ID", task.ID)
 	}
-	return nil
+	return updatedTask, nil
 }
 
 func postMigration(ctx context.Context, server *Server, task *api.Task, vcsPushEvent *vcsPlugin.PushEvent, mi *db.MigrationInfo, migrationID int64, schema string) (bool, *api.TaskRunResultPayload, error) {


### PR DESCRIPTION
This PR implements the rollback SQL generation process for a successful DML task.

The generation process is asynchronous with the execution of the DML task, which means there might be a few seconds gap between the execution of the DML task and when the rollback SQL is available.

The schema in the generated rollback SQL is parsed from the schema history corresponding to the DML task's migration.