### PR TITLE
fix: io.Reader can only be read once

### DIFF
--- a/plugin/vcs/internal/oauth/oauth.go
+++ b/plugin/vcs/internal/oauth/oauth.go
@@ -2,6 +2,7 @@
 package oauth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,8 +18,16 @@ import (
 type TokenRefresher func(ctx context.Context, client *http.Client, oldToken *string) error
 
 func requester(ctx context.Context, client *http.Client, method, url string, token *string, body io.Reader) func() (*http.Response, error) {
+	// body may be read multiple times but io.Reader is meant to be read once.
+	// so we read body first and build the reader every time.
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return func() (*http.Response, error) {
+			return nil, errors.Wrap(err, "failed to read from body")
+		}
+	}
 	return func() (*http.Response, error) {
-		req, err := http.NewRequestWithContext(ctx, method, url, body)
+		req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(b))
 		if err != nil {
 			return nil, errors.Wrapf(err, "construct %s %s", method, url)
 		}

--- a/plugin/vcs/internal/oauth/oauth.go
+++ b/plugin/vcs/internal/oauth/oauth.go
@@ -18,8 +18,8 @@ import (
 type TokenRefresher func(ctx context.Context, client *http.Client, oldToken *string) error
 
 func requester(ctx context.Context, client *http.Client, method, url string, token *string, body io.Reader) func() (*http.Response, error) {
-	// body may be read multiple times but io.Reader is meant to be read once.
-	// so we read body first and build the reader every time.
+	// The body may be read multiple times but io.Reader is meant to be read once,
+	// so we read the body first and build the reader every time.
 	var bodyBytes []byte
 	if body != nil {
 		b, err := io.ReadAll(body)


### PR DESCRIPTION
The function returned by `requester` could be called multiple times, which means that `body` would be read multiple times. However, `io.Reader` can only be read once. This would cause every subsequent read returns empty content.
So we first read everything from `io.Reader` and build the reader from the bytes to solve this problem.

Minimal reproduction:
- before https://go.dev/play/p/kzivKFuXVU2
- after https://go.dev/play/p/eoPN3LQZFKb