### PR TITLE
refactor(flashback): improve DML task payload

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -132,14 +132,6 @@ type TaskDatabaseSchemaUpdateGhostSyncPayload struct {
 // TaskDatabaseSchemaUpdateGhostCutoverPayload is the task payload for gh-ost switching the original table and the ghost table.
 type TaskDatabaseSchemaUpdateGhostCutoverPayload struct{}
 
-type RollbackTaskState string
-
-const (
-	RollbackTaskRunning RollbackTaskState = "RUNNING"
-	RollbackTaskSuccess RollbackTaskState = "SUCCESS"
-	RollbackTaskFail    RollbackTaskState = "FAIL"
-)
-
 // TaskDatabaseDataUpdatePayload is the task payload for database data update (DML).
 type TaskDatabaseDataUpdatePayload struct {
 	Statement     string         `json:"statement,omitempty"`
@@ -160,15 +152,6 @@ type TaskDatabaseDataUpdatePayload struct {
 	BinlogFileEnd   string `json:"binlogFileEnd,omitempty"`
 	BinlogPosStart  int64  `json:"binlogPosStart,omitempty"`
 	BinlogPosEnd    int64  `json:"binlogPosEnd,omitempty"`
-	// RollbackTaskState is a state machine
-	// 0. The initial state is "".
-	// 1. When the rollback generation starts, we set it to "RUNNING".
-	// 2. When the rollback generation succeeds, we set it to "SUCCESS".
-	// 4. When the rollback generation fails, we set it to "FAIL", and set the err to RollbackError.
-	RollbackTaskState RollbackTaskState `json:"rollbackTaskState,omitempty"`
-	RollbackError     string            `json:"rollbackError,omitempty"`
-	// RollbackStatement is the generated rollback SQL statement for the DML task.
-	RollbackStatement string `json:"rollbackStatement,omitempty"`
 }
 
 // TaskDatabaseBackupPayload is the task payload for database backup.

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -235,7 +235,6 @@ func setMigrationIDAndEndBinlogCoordinate(ctx context.Context, driver db.Driver,
 	}
 	payload.BinlogFileEnd = binlogInfo.FileName
 	payload.BinlogPosEnd = binlogInfo.Position
-	payload.RollbackTaskState = api.RollbackTaskRunning
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
1. Refactor task_executor to get the updated task. The latest task struct is needed for the later implementation of the rollback runner.
2. Add migration ID to the DML task payload. This is needed to parse the migration schema when generating the rollback SQL.