### PR TITLE
feat(parser): support CREATE INDEX statements

### DIFF
--- a/plugin/parser/ast/create_index_stmt.go
+++ b/plugin/parser/ast/create_index_stmt.go
@@ -4,5 +4,6 @@ package ast
 type CreateIndexStmt struct {
 	ddl
 
-	Index *IndexDef
+	Index       *IndexDef
+	IfNotExists bool
 }

--- a/plugin/parser/ast/index_def.go
+++ b/plugin/parser/ast/index_def.go
@@ -1,5 +1,23 @@
 package ast
 
+// IndexMethodType is the index method type.
+type IndexMethodType int
+
+const (
+	// IndexMethodTypeBTree is the index method type for B-Tree. It's the default type.
+	IndexMethodTypeBTree = iota
+	// IndexMethodTypeHash is the index method type for hash.
+	IndexMethodTypeHash
+	// IndexMethodTypeGiST is the index method type for GiST.
+	IndexMethodTypeGiST
+	// IndexMethodTypeSpGiST is the index method type for SP-GiST.
+	IndexMethodTypeSpGiST
+	// IndexMethodTypeGin is the index method type for GIN.
+	IndexMethodTypeGin
+	// IndexMethodTypeBrin is the index method type for BRIN.
+	IndexMethodTypeBrin
+)
+
 // IndexDef is the struct for index definition.
 type IndexDef struct {
 	node
@@ -8,6 +26,7 @@ type IndexDef struct {
 	Table   *TableDef
 	Unique  bool
 	KeyList []*IndexKeyDef
+	Method  IndexMethodType
 }
 
 // GetKeyNameList to get the name from KeyList.

--- a/plugin/parser/ast/index_key_def.go
+++ b/plugin/parser/ast/index_key_def.go
@@ -1,5 +1,31 @@
 package ast
 
+// SortOrderType is the sort order type for the index.
+type SortOrderType int
+
+const (
+	// SortOrderTypeDefault is the sort order type for default value.
+	SortOrderTypeDefault = iota
+	// SortOrderTypeAscending is the sort order type for ASC.
+	SortOrderTypeAscending
+	// SortOrderTypeDescending is the sort order type for DESC.
+	SortOrderTypeDescending
+)
+
+// NullOrderType is the null sort order type for the index.
+type NullOrderType int
+
+const (
+	// NullOrderTypeDefault is the default null sort order type.
+	NullOrderTypeDefault = iota
+	// NullOrderTypeFirst is the null sort order type that nulls sort before non-nulls.
+	// This is the default when DESC is specified.
+	NullOrderTypeFirst
+	// NullOrderTypeLast is the null sort order type that nulls sort after non-nulls.
+	// This is the default when DESC is not specified.
+	NullOrderTypeLast
+)
+
 // IndexKeyType is the type for index key.
 type IndexKeyType int
 
@@ -11,11 +37,11 @@ const (
 )
 
 // IndexKeyDef is the struct for index key definition.
-// Only support conversion IndexKeyTypeColumn now.
-// TODO(rebelice): support conversion IndexKeyTypeExpression.
 type IndexKeyDef struct {
 	node
 
-	Type IndexKeyType
-	Key  string
+	Type      IndexKeyType
+	Key       string
+	SortOrder SortOrderType
+	NullOrder NullOrderType
 }

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -208,26 +208,46 @@ func convert(node *pgquery.Node, statement parser.SingleSQL) (res ast.Node, err 
 			Unique: in.IndexStmt.Unique,
 		}
 
+		method, err := convertMethodType(in.IndexStmt.AccessMethod)
+		if err != nil {
+			return nil, err
+		}
+		indexDef.Method = method
+
 		for _, key := range in.IndexStmt.IndexParams {
 			index, ok := key.Node.(*pgquery.Node_IndexElem)
 			if !ok {
 				return nil, parser.NewConvertErrorf("expected IndexElem but found %t", key.Node)
 			}
-			// We only support index on columns now.
-			// TODO(rebelice): support index on expressions.
+			indexKey := &ast.IndexKeyDef{}
 			if index.IndexElem.Name != "" {
-				indexDef.KeyList = append(indexDef.KeyList, &ast.IndexKeyDef{
-					Type: ast.IndexKeyTypeColumn,
-					Key:  index.IndexElem.Name,
-				})
+				indexKey.Type = ast.IndexKeyTypeColumn
+				indexKey.Key = index.IndexElem.Name
 			} else {
-				indexDef.KeyList = append(indexDef.KeyList, &ast.IndexKeyDef{
-					Type: ast.IndexKeyTypeExpression,
-				})
+				expression, err := pgquery.DeparseNode(pgquery.DeparseTypeExpr, index.IndexElem.Expr)
+				if err != nil {
+					return nil, err
+				}
+				indexKey.Type = ast.IndexKeyTypeExpression
+				indexKey.Key = expression
 			}
+
+			order, err := convertSortOrder(index.IndexElem.Ordering)
+			if err != nil {
+				return nil, err
+			}
+			indexKey.SortOrder = order
+
+			nullOrder, err := convertNullOrder(index.IndexElem.NullsOrdering)
+			if err != nil {
+				return nil, err
+			}
+			indexKey.NullOrder = nullOrder
+
+			indexDef.KeyList = append(indexDef.KeyList, indexKey)
 		}
 
-		return &ast.CreateIndexStmt{Index: indexDef}, nil
+		return &ast.CreateIndexStmt{Index: indexDef, IfNotExists: in.IndexStmt.IfNotExists}, nil
 	case *pgquery.Node_DropStmt:
 		switch in.DropStmt.RemoveType {
 		case pgquery.ObjectType_OBJECT_INDEX:
@@ -494,6 +514,51 @@ func convertRoleSpec(in *pgquery.RoleSpec) (*ast.RoleSpec, error) {
 		}, nil
 	}
 	return nil, parser.NewConvertErrorf("unexpected role spec type: %q", in.Roletype.String())
+}
+
+func convertNullOrder(order pgquery.SortByNulls) (ast.NullOrderType, error) {
+	switch order {
+	case pgquery.SortByNulls_SORTBY_NULLS_DEFAULT:
+		return ast.NullOrderTypeDefault, nil
+	case pgquery.SortByNulls_SORTBY_NULLS_FIRST:
+		return ast.NullOrderTypeFirst, nil
+	case pgquery.SortByNulls_SORTBY_NULLS_LAST:
+		return ast.NullOrderTypeLast, nil
+	default:
+		return ast.NullOrderTypeDefault, parser.NewConvertErrorf("unsupported null sort order: %d", order)
+	}
+}
+
+func convertSortOrder(order pgquery.SortByDir) (ast.SortOrderType, error) {
+	switch order {
+	case pgquery.SortByDir_SORTBY_DEFAULT:
+		return ast.SortOrderTypeDefault, nil
+	case pgquery.SortByDir_SORTBY_ASC:
+		return ast.SortOrderTypeAscending, nil
+	case pgquery.SortByDir_SORTBY_DESC:
+		return ast.SortOrderTypeDescending, nil
+	default:
+		return ast.NullOrderTypeDefault, parser.NewConvertErrorf("unsupported sort order: %d", order)
+	}
+}
+
+func convertMethodType(method string) (ast.IndexMethodType, error) {
+	switch method {
+	case "btree":
+		return ast.IndexMethodTypeBTree, nil
+	case "hash":
+		return ast.IndexMethodTypeHash, nil
+	case "gist":
+		return ast.IndexMethodTypeGiST, nil
+	case "spgist":
+		return ast.IndexMethodTypeSpGiST, nil
+	case "gin":
+		return ast.IndexMethodTypeGin, nil
+	case "brin":
+		return ast.IndexMethodTypeBrin, nil
+	default:
+		return ast.IndexMethodTypeBTree, parser.NewConvertErrorf("unsupported index method type: %s", method)
+	}
 }
 
 func convertExpressionNode(node *pgquery.Node) (ast.ExpressionNode, []*ast.PatternLikeDef, []*ast.SubqueryDef, error) {

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -94,23 +94,7 @@ func deparseCreateIndex(context parser.DeparseContext, in *ast.CreateIndexStmt, 
 		return err
 	}
 
-	method := ""
-	switch in.Index.Method {
-	case ast.IndexMethodTypeBTree:
-		method = "btree"
-	case ast.IndexMethodTypeHash:
-		method = "hash"
-	case ast.IndexMethodTypeGiST:
-		method = "gist"
-	case ast.IndexMethodTypeSpGiST:
-		method = "spgist"
-	case ast.IndexMethodTypeGin:
-		method = "gin"
-	case ast.IndexMethodTypeBrin:
-		method = "brin"
-	}
-
-	if _, err := buf.WriteString(method); err != nil {
+	if err := deparseIndexMethod(in.Index.Method, buf); err != nil {
 		return err
 	}
 
@@ -134,6 +118,24 @@ func deparseCreateIndex(context parser.DeparseContext, in *ast.CreateIndexStmt, 
 	}
 
 	return nil
+}
+
+func deparseIndexMethod(method ast.IndexMethodType, buf *strings.Builder) (err error) {
+	switch method {
+	case ast.IndexMethodTypeBTree:
+		_, err = buf.WriteString("btree")
+	case ast.IndexMethodTypeHash:
+		_, err = buf.WriteString("hash")
+	case ast.IndexMethodTypeGiST:
+		_, err = buf.WriteString("gist")
+	case ast.IndexMethodTypeSpGiST:
+		_, err = buf.WriteString("spgist")
+	case ast.IndexMethodTypeGin:
+		_, err = buf.WriteString("gin")
+	case ast.IndexMethodTypeBrin:
+		_, err = buf.WriteString("brin")
+	}
+	return err
 }
 
 func deparseIndexKey(context parser.DeparseContext, in *ast.IndexKeyDef, buf *strings.Builder) error {

--- a/plugin/parser/engine/pg/deparse_test.go
+++ b/plugin/parser/engine/pg/deparse_test.go
@@ -64,6 +64,8 @@ func TestDeparse(t *testing.T) {
 		// Schema
 		"test_create_schema_data.yaml",
 		"test_drop_schema_data.yaml",
+		// Index
+		"test_create_index_data.yaml",
 	}
 	for _, test := range testFileList {
 		runDeparseTest(t, test, false /* record */)

--- a/plugin/parser/engine/pg/test-data/test_create_index_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_create_index_data.yaml
@@ -4,3 +4,5 @@
   want: CREATE UNIQUE INDEX IF NOT EXISTS "idx_1" ON "public"."t" USING btree (a NULLS FIRST, b DESC NULLS LAST, c);
 - stmt: create index if not exists idx_1 on public.t using hash (a, b, c)
   want: CREATE INDEX IF NOT EXISTS "idx_1" ON "public"."t" USING hash (a, b, c);
+- stmt: create index if not exists idx_1 on public.t using btree((a+b) desc, c)
+  want: CREATE INDEX IF NOT EXISTS "idx_1" ON "public"."t" USING btree ((a + b) DESC, c);

--- a/plugin/parser/engine/pg/test-data/test_create_index_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_create_index_data.yaml
@@ -1,0 +1,6 @@
+- stmt: create index idx_1 on public.t using btree (a, b, c)
+  want: CREATE INDEX "idx_1" ON "public"."t" USING btree (a, b, c);
+- stmt: create unique index if not exists idx_1 on public.t(a nulls first, b desc nulls last, c asc)
+  want: CREATE UNIQUE INDEX IF NOT EXISTS "idx_1" ON "public"."t" USING btree (a NULLS FIRST, b DESC NULLS LAST, c);
+- stmt: create index if not exists idx_1 on public.t using hash (a, b, c)
+  want: CREATE INDEX IF NOT EXISTS "idx_1" ON "public"."t" USING hash (a, b, c);


### PR DESCRIPTION
This PR supports
```
CREATE [ UNIQUE ] INDEX [ [ IF NOT EXISTS ] name ] ON table_name [ USING method ]
    ( { column_name | ( expression ) } [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] )
```

And for `method`, this PR only supports and tests for `btree` .