### PR TITLE
feat(flashback): get table columns from schema

### DIFF
--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -42,9 +42,9 @@ func (txn BinlogTransaction) GetRollbackSQL(tables map[string][]string) (string,
 	return strings.Join(sqlList, "\n"), nil
 }
 
-// ParseTableColumns parses the schema to get the table columns map.
+// GetTableColumns parses the schema to get the table columns map.
 // This is used to generate rollback SQL from the binlog events.
-func ParseTableColumns(schema string) (map[string][]string, error) {
+func GetTableColumns(schema string) (map[string][]string, error) {
 	_, supportStmts, err := bbparser.ExtractTiDBUnsupportStmts(schema)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to extract TiDB unsupported statements from old statements %q", schema)

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -231,7 +231,7 @@ SET
 	}
 }
 
-func TestParseTableColumns(t *testing.T) {
+func TestGetTableColumns(t *testing.T) {
 	tests := []struct {
 		name     string
 		schema   string
@@ -260,7 +260,7 @@ CREATE TABLE balance (
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			a := require.New(t)
-			tableMap, err := ParseTableColumns(test.schema)
+			tableMap, err := GetTableColumns(test.schema)
 			if test.err {
 				a.Error(err)
 			} else {

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -230,3 +230,43 @@ SET
 		})
 	}
 }
+
+func TestParseTableColumns(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   string
+		tableMap map[string][]string
+		err      bool
+	}{
+		{
+			name: "multiple tables",
+			schema: `
+CREATE TABLE user (
+	id INT PRIMARY KEY,
+	name VARCHAR(20)
+);
+CREATE TABLE balance (
+	id INT PRIMARY KEY,
+	user_id INT REFERENCES user(id),
+	balance INT
+);`,
+			tableMap: map[string][]string{
+				"user":    {"id", "name"},
+				"balance": {"id", "user_id", "balance"},
+			},
+			err: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := require.New(t)
+			tableMap, err := ParseTableColumns(test.schema)
+			if test.err {
+				a.Error(err)
+			} else {
+				a.NoError(err)
+				a.Equal(test.tableMap, tableMap)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before generating the rollback SQL for a DML task, we must parse the migration schema and get the table columns.