### PR TITLE
fix: inactive accounts cannot be assigned to projects and issues

### DIFF
--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -208,6 +208,7 @@
           :allowed-role-list="['OWNER', 'DBA']"
           :selectedId="state.assigneeId"
           :placeholder="'Select assignee'"
+          :custom-filter="filterPrincipal"
           @select-principal-id="selectAssignee"
         />
       </div>
@@ -280,11 +281,14 @@ import {
   Instance,
   InstanceUserId,
   PITRContext,
+  Principal,
 } from "../types";
 import {
   buildDatabaseNameByTemplateAndLabelList,
   hasWorkspacePermission,
   issueSlug,
+  isDBA,
+  isOwner,
 } from "../utils";
 import { useEventListener } from "@vueuse/core";
 import {
@@ -294,6 +298,7 @@ import {
   useInstanceStore,
   useIssueStore,
   useProjectStore,
+  useMemberStore,
 } from "@/store";
 
 interface LocalState {
@@ -597,6 +602,17 @@ export default defineComponent({
         );
     };
 
+    const filterPrincipal = (principal: Principal): boolean => {
+      if (
+        useMemberStore().memberByPrincipalId(principal.id).rowStatus ===
+        "ARCHIVED"
+      ) {
+        return false;
+      }
+
+      return isOwner(principal.role) || isDBA(principal.role);
+    };
+
     // update `state.labelList` when selected Environment changed
     watchEffect(() => {
       const envId = state.environmentId;
@@ -636,6 +652,7 @@ export default defineComponent({
       selectAssignee,
       cancel,
       create,
+      filterPrincipal,
     };
   },
 });

--- a/frontend/src/components/Issue/IssueSidebar.vue
+++ b/frontend/src/components/Issue/IssueSidebar.vue
@@ -318,6 +318,7 @@ import {
   useEnvironmentStore,
   useLabelList,
   useProjectStore,
+  useMemberStore,
 } from "@/store";
 import {
   useExtraIssueLogic,
@@ -577,6 +578,12 @@ const selectTaskId = (taskId: TaskId) => {
 
 const allowProjectOwnerToApprove = useAllowProjectOwnerToApprove();
 const filterPrincipal = (principal: Principal): boolean => {
+  // Always hide inactive principals.
+  if (
+    useMemberStore().memberByPrincipalId(principal.id).rowStatus === "ARCHIVED"
+  ) {
+    return false;
+  }
   if (allowProjectOwnerToApprove.value) {
     return isOwnerOfProject(principal, project.value);
   }

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -90,6 +90,7 @@
                 :required="false"
                 :placeholder="$t('project.settings.member-placeholder')"
                 :selected-id="state.principalId"
+                :custom-filter="filterPrincipal"
                 @select-principal-id="
                   (principalId) => {
                     state.principalId = principalId;
@@ -161,6 +162,7 @@ import MemberSelect from "../components/MemberSelect.vue";
 import ProjectMemberTable from "../components/ProjectMemberTable.vue";
 import {
   DEFAULT_PROJECT_ID,
+  Principal,
   PrincipalId,
   Project,
   ProjectMember,
@@ -407,6 +409,10 @@ export default defineComponent({
       }
     };
 
+    const filterPrincipal = (principal: Principal): boolean =>
+      useMemberStore().memberByPrincipalId(principal.id).rowStatus !==
+      "ARCHIVED";
+
     return {
       state,
       hasRBACFeature,
@@ -423,6 +429,7 @@ export default defineComponent({
       onRefreshSync,
       onToggleRoleProvider,
       onConfirmToggleRoleProvider,
+      filterPrincipal,
     };
   },
 });

--- a/server/task.go
+++ b/server/task.go
@@ -536,7 +536,7 @@ func (s *Server) patchTask(ctx context.Context, task *api.Task, taskPatch *api.T
 	return taskPatched, nil
 }
 
-// canPrincipalBeAssignee checks if a principal could be the assignee of an issue, judging by the principal role and the environment policy.
+// canPrincipalBeAssignee checks if a principal could be the assignee of an issue, judging by the principal role, the member rowStatus and the environment policy.
 func (s *Server) canPrincipalBeAssignee(ctx context.Context, principalID int, environmentID int, projectID int, issueType api.IssueType) (bool, error) {
 	policy, err := s.store.GetPipelineApprovalPolicy(ctx, environmentID)
 	if err != nil {


### PR DESCRIPTION
- On the server side, there'll be an error indicating "Deactivated member cannot be an assignee" when users try to set an inactive account to projects or issues.
- On the client side, we will hide inactive accounts from the assignee selection drop menus.

Close BYT-1715