### PR TITLE
feat: support sync unique constraint

### DIFF
--- a/plugin/parser/ast/drop_constraint_stmt.go
+++ b/plugin/parser/ast/drop_constraint_stmt.go
@@ -6,4 +6,5 @@ type DropConstraintStmt struct {
 
 	Table          *TableDef
 	ConstraintName string
+	IfExists       bool
 }

--- a/plugin/parser/differ/pg/differ_test.go
+++ b/plugin/parser/differ/pg/differ_test.go
@@ -55,9 +55,9 @@ func runDifferTest(t *testing.T, file string, record bool) {
 
 func TestComputeDiff(t *testing.T) {
 	testFileList := []string{
-		// "test_differ_data.yaml",
+		"test_differ_data.yaml",
 		// // Schema
-		// "test_differ_schema.yaml",
+		"test_differ_schema.yaml",
 		// Constraint
 		"test_differ_constraint.yaml",
 	}

--- a/plugin/parser/differ/pg/differ_test.go
+++ b/plugin/parser/differ/pg/differ_test.go
@@ -62,6 +62,6 @@ func TestComputeDiff(t *testing.T) {
 		"test_differ_constraint.yaml",
 	}
 	for _, test := range testFileList {
-		runDifferTest(t, test, true /* record */)
+		runDifferTest(t, test, false /* record */)
 	}
 }

--- a/plugin/parser/differ/pg/differ_test.go
+++ b/plugin/parser/differ/pg/differ_test.go
@@ -55,11 +55,13 @@ func runDifferTest(t *testing.T, file string, record bool) {
 
 func TestComputeDiff(t *testing.T) {
 	testFileList := []string{
-		"test_differ_data.yaml",
-		// Schema
-		"test_differ_schema.yaml",
+		// "test_differ_data.yaml",
+		// // Schema
+		// "test_differ_schema.yaml",
+		// Constraint
+		"test_differ_constraint.yaml",
 	}
 	for _, test := range testFileList {
-		runDifferTest(t, test, false /* record */)
+		runDifferTest(t, test, true /* record */)
 	}
 }

--- a/plugin/parser/differ/pg/test-data/test_differ_constraint.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_constraint.yaml
@@ -1,0 +1,48 @@
+- oldSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+  newSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (order_id);
+  diff: |
+    ALTER TABLE "public"."order_details"
+        ADD CONSTRAINT "order_details_un_order_id" UNIQUE ("order_id");
+- oldSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (order_id);
+  newSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+  diff: |
+    ALTER TABLE "public"."order_details"
+        DROP CONSTRAINT IF EXISTS "order_details_un_order_id";
+- oldSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (id, order_id);
+  newSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (order_id);
+  diff: |
+    ALTER TABLE "public"."order_details"
+        DROP CONSTRAINT IF EXISTS "order_details_un_order_id",
+        ADD CONSTRAINT "order_details_un_order_id" UNIQUE ("order_id");
+- oldSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (order_id);
+  newSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (id, order_id);
+  diff: |
+    ALTER TABLE "public"."order_details"
+        DROP CONSTRAINT IF EXISTS "order_details_un_order_id",
+        ADD CONSTRAINT "order_details_un_order_id" UNIQUE ("id", "order_id");
+- oldSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT, email_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (id, order_id, email_id);
+  newSchema: |
+    CREATE TABLE public.order_details(id INT, order_id INT);
+    ALTER TABLE public.order_details ADD CONSTRAINT order_details_un_order_id UNIQUE (id, order_id);
+  diff: |
+    ALTER TABLE "public"."order_details"
+        DROP COLUMN "email_id";
+    ALTER TABLE "public"."order_details"
+        DROP CONSTRAINT IF EXISTS "order_details_un_order_id",
+        ADD CONSTRAINT "order_details_un_order_id" UNIQUE ("id", "order_id");

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -82,6 +82,7 @@ func convert(node *pgquery.Node, statement parser.SingleSQL) (res ast.Node, err 
 					dropConstraint := &ast.DropConstraintStmt{
 						Table:          alterTable.Table,
 						ConstraintName: alterCmd.Name,
+						IfExists:       alterCmd.MissingOk,
 					}
 
 					alterTable.AlterItemList = append(alterTable.AlterItemList, dropConstraint)

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -848,6 +848,7 @@ func TestPGDropConstraintStmt(t *testing.T) {
 								Name: "tech_book",
 							},
 							ConstraintName: "uk_tech_a",
+							IfExists:       false,
 						},
 					},
 				},
@@ -855,6 +856,33 @@ func TestPGDropConstraintStmt(t *testing.T) {
 			statementList: []parser.SingleSQL{
 				{
 					Text:     "ALTER TABLE tech_book DROP CONSTRAINT uk_tech_a",
+					LastLine: 1,
+				},
+			},
+		},
+		{
+			stmt: "ALTER TABLE tech_book DROP CONSTRAINT IF EXISTS uk_tech_a",
+			want: []ast.Node{
+				&ast.AlterTableStmt{
+					Table: &ast.TableDef{
+						Type: ast.TableTypeBaseTable,
+						Name: "tech_book",
+					},
+					AlterItemList: []ast.Node{
+						&ast.DropConstraintStmt{
+							Table: &ast.TableDef{
+								Type: ast.TableTypeBaseTable,
+								Name: "tech_book",
+							},
+							ConstraintName: "uk_tech_a",
+							IfExists:       true,
+						},
+					},
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+					Text:     "ALTER TABLE tech_book DROP CONSTRAINT IF EXISTS uk_tech_a",
 					LastLine: 1,
 				},
 			},

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -44,6 +44,11 @@ func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) e
 			return err
 		}
 		return buf.WriteByte(';')
+	case *ast.AddConstraintStmt:
+		if err := deparseAddConstraint(context, node, buf); err != nil {
+			return err
+		}
+		return buf.WriteByte(';')
 	}
 	return errors.Errorf("failed to deparse %T", in)
 }

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -262,6 +262,11 @@ func deparseDropConstraint(context parser.DeparseContext, in *ast.DropConstraint
 	if _, err := buf.WriteString("DROP CONSTRAINT "); err != nil {
 		return err
 	}
+	if in.IfExists {
+		if _, err := buf.WriteString("IF EXISTS "); err != nil {
+			return err
+		}
+	}
 
 	return writeSurrounding(buf, in.ConstraintName, `"`)
 }

--- a/plugin/parser/engine/pg/test-data/test_alter_table_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_alter_table_data.yaml
@@ -56,6 +56,12 @@
         DROP CONSTRAINT "unique_tbl_email_key";
 - stmt: |-
     alter table t
+        drop constraint if exists unique_tbl_email_key;
+  want: |-
+    ALTER TABLE "t"
+        DROP CONSTRAINT IF EXISTS "unique_tbl_email_key";
+- stmt: |-
+    alter table t
         add constraint email_unique_key unique(email);
   want: |-
     ALTER TABLE "t"


### PR DESCRIPTION
This PR support diff unique constraint in PostgreSQL, and the input must come from pg_dump.
We use the `CASCADE` keyword to drop some objects, such as tables and columns. And this leads to hard decisions about generating a `DROP CONSTRAINT` statement, so we always generate a `DROP CONSTRAINT` statement and set the `IF EXISTS` field.