### PR TITLE
refactor: remove databaseId/projectId query parameter when fetching my/shared/starred sheets

### DIFF
--- a/api/sheet.go
+++ b/api/sheet.go
@@ -137,9 +137,9 @@ type SheetFind struct {
 	Payload    *string
 	// Used to find starred/pinned sheet list, could be PRIVATE/PROJECT/PUBLIC sheet.
 	// For now, we only need the starred sheets.
-	OrganizerID *int
-	// Used to find a constraint sheet list with related projects containing PrincipalID as an active member.
-	// When finding a shared PROJECT/PROJECT sheet, the value should have value.
+	OrganizerPrincipalID *int
+	// Used to find a sheet list from projects containing PrincipalID as an active member.
+	// When finding a shared PROJECT/PUBLIC sheets, this value should be present.
 	PrincipalID *int
 }
 

--- a/frontend/src/store/modules/sheet.ts
+++ b/frontend/src/store/modules/sheet.ts
@@ -12,7 +12,6 @@ import {
   Project,
   unknown,
   UNKNOWN_ID,
-  SheetFind,
   SheetCreate,
   SheetOrganizerUpsert,
   ProjectId,
@@ -196,16 +195,8 @@ export const useSheetStore = defineStore("sheet", {
 
       return sheet;
     },
-    async fetchMySheetList(sheetFind?: SheetFind) {
-      const queryList = [];
-      if (sheetFind?.projectId) {
-        queryList.push(`projectId=${sheetFind.projectId}`);
-      }
-      if (sheetFind?.databaseId) {
-        queryList.push(`databaseId=${sheetFind.databaseId}`);
-      }
-      const resData = (await axios.get(`/api/sheet/my?${queryList.join("&")}`))
-        .data;
+    async fetchMySheetList() {
+      const resData = (await axios.get(`/api/sheet/my`)).data;
       const sheetList: Sheet[] = resData.data.map((rawData: ResourceObject) => {
         const sheet = convertSheet(rawData, resData.included);
         this.setSheetById({
@@ -220,17 +211,8 @@ export const useSheetStore = defineStore("sheet", {
 
       return sheetList;
     },
-    async fetchSharedSheetList(sheetFind?: SheetFind) {
-      const queryList = [];
-      if (sheetFind?.projectId) {
-        queryList.push(`projectId=${sheetFind.projectId}`);
-      }
-      if (sheetFind?.databaseId) {
-        queryList.push(`databaseId=${sheetFind.databaseId}`);
-      }
-      const resData = (
-        await axios.get(`/api/sheet/shared?${queryList.join("&")}`)
-      ).data;
+    async fetchSharedSheetList() {
+      const resData = (await axios.get(`/api/sheet/shared`)).data;
       const sheetList: Sheet[] = resData.data.map((rawData: ResourceObject) => {
         const sheet = convertSheet(rawData, resData.included);
         this.setSheetById({
@@ -245,17 +227,8 @@ export const useSheetStore = defineStore("sheet", {
 
       return sheetList;
     },
-    async fetchStarredSheetList(sheetFind?: SheetFind) {
-      const queryList = [];
-      if (sheetFind?.projectId) {
-        queryList.push(`projectId=${sheetFind.projectId}`);
-      }
-      if (sheetFind?.databaseId) {
-        queryList.push(`databaseId=${sheetFind.databaseId}`);
-      }
-      const resData = (
-        await axios.get(`/api/sheet/starred?${queryList.join("&")}`)
-      ).data;
+    async fetchStarredSheetList() {
+      const resData = (await axios.get(`/api/sheet/starred`)).data;
       const sheetList: Sheet[] = resData.data.map((rawData: ResourceObject) => {
         const sheet = convertSheet(rawData, resData.included);
         this.setSheetById({

--- a/frontend/src/types/sheet.ts
+++ b/frontend/src/types/sheet.ts
@@ -76,15 +76,6 @@ export interface SheetPatch {
   payload?: SheetPayload;
 }
 
-export interface SheetFind {
-  creatorId?: PrincipalId;
-  rowStatus?: RowStatus;
-  projectId?: ProjectId;
-  databaseId?: DatabaseId;
-  visibility?: SheetVisibility;
-  organizerId?: PrincipalId;
-}
-
 export type AccessOption = {
   label: string;
   description: string;

--- a/store/sheet.go
+++ b/store/sheet.go
@@ -469,7 +469,7 @@ func findSheetImpl(ctx context.Context, tx *Tx, find *api.SheetFind) ([]*sheetRa
 	if v := find.PrincipalID; v != nil {
 		where, args = append(where, fmt.Sprintf("project_id IN (SELECT project_id FROM project_member WHERE principal_id = $%d)", len(args)+1)), append(args, *v)
 	}
-	if v := find.OrganizerID; v != nil {
+	if v := find.OrganizerPrincipalID; v != nil {
 		// For now, we only need the starred sheets.
 		where, args = append(where, fmt.Sprintf("id IN (SELECT sheet_id FROM sheet_organizer WHERE principal_id = $%d AND starred = true)", len(args)+1)), append(args, *v)
 	}

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -266,9 +266,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	})
 	a.NoError(err)
 
-	_, err = ctl.listSheets(api.SheetFind{
-		DatabaseID: &database.ID,
-	})
+	_, err = ctl.listMySheets()
 	a.NoError(err)
 }
 

--- a/tests/sheet_vcs_test.go
+++ b/tests/sheet_vcs_test.go
@@ -106,14 +106,17 @@ func TestSheetVCS(t *testing.T) {
 			err = ctl.vcsProvider.AddFiles(test.externalID, files)
 			a.NoError(err)
 
+			sheetsBefore, err := ctl.listMySheets()
+			a.NoError(err)
+
 			err = ctl.syncSheet(project.ID)
 			a.NoError(err)
 
-			sheets, err := ctl.listSheets(api.SheetFind{ProjectID: &project.ID})
+			sheetsAfter, err := ctl.listMySheets()
 			a.NoError(err)
-			a.Len(sheets, 1)
+			a.Len(sheetsAfter, len(sheetsBefore)+1)
 
-			sheetFromVCS := sheets[0]
+			sheetFromVCS := sheetsAfter[len(sheetsAfter)-1]
 			a.Equal("all_employee", sheetFromVCS.Name)
 			a.Equal(fileContent, sheetFromVCS.Statement)
 		})

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1475,16 +1474,9 @@ func (ctl *controller) createSheet(sheetCreate api.SheetCreate) (*api.Sheet, err
 	return sheet, nil
 }
 
-// listSheets lists sheets for a database.
-func (ctl *controller) listSheets(sheetFind api.SheetFind) ([]*api.Sheet, error) {
+// listMySheets lists caller's sheets.
+func (ctl *controller) listMySheets() ([]*api.Sheet, error) {
 	params := map[string]string{}
-	if sheetFind.ProjectID != nil {
-		params["projectId"] = strconv.Itoa(*sheetFind.ProjectID)
-	}
-	if sheetFind.DatabaseID != nil {
-		params["databaseId"] = strconv.Itoa(*sheetFind.DatabaseID)
-	}
-
 	body, err := ctl.get("/sheet/my", params)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We currently don't use them at all. These query parameters will complicate permission processing in our acl middleware. This is because we need to check whether the caller can access the sheets related to a particular databaseId/projectId for those endpoints.