### PR TITLE
feat: remove the foreign key constraint for db_label to tabel label_value

### DIFF
--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -1043,8 +1043,7 @@ CREATE TABLE db_label (
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     database_id INTEGER NOT NULL REFERENCES db (id),
     key TEXT NOT NULL,
-    value TEXT NOT NULL,
-    FOREIGN KEY(key, value) REFERENCES label_value(key, value)
+    value TEXT NOT NULL
 );
 
 -- database_id/key's are unique within the db_label table.

--- a/store/migration/prod/1.8/0001##drop_db_label_key_value_fkey.sql
+++ b/store/migration/prod/1.8/0001##drop_db_label_key_value_fkey.sql
@@ -1,0 +1,1 @@
+ALTER TABLE db_label DROP CONSTRAINT db_label_key_value_fkey;

--- a/store/migration/prod/LATEST.sql
+++ b/store/migration/prod/LATEST.sql
@@ -1042,8 +1042,7 @@ CREATE TABLE db_label (
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     database_id INTEGER NOT NULL REFERENCES db (id),
     key TEXT NOT NULL,
-    value TEXT NOT NULL,
-    FOREIGN KEY(key, value) REFERENCES label_value(key, value)
+    value TEXT NOT NULL
 );
 
 -- database_id/key's are unique within the db_label table.

--- a/store/pg_engine_test.go
+++ b/store/pg_engine_test.go
@@ -219,5 +219,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("1.8.0"), releaseVersion)
+	require.Equal(t, semver.MustParse("1.8.1"), releaseVersion)
 }


### PR DESCRIPTION
We'd like to allow project owners to label databases without depending on labels defined at workspace level.