### PR TITLE
feat: enforce sheet ACL on the backend

### DIFF
--- a/api/project_member.go
+++ b/api/project_member.go
@@ -129,8 +129,12 @@ const (
 	ProjectPermissionManageGeneral ProjectPermissionType = "bb.permission.project.manage-general"
 	// ProjectPermissionManageMember allows user to manage project memberships.
 	ProjectPermissionManageMember ProjectPermissionType = "bb.permission.project.manage-member"
-	// ProjectPermissionManageSheet allows user to manage sheets in the project.
-	ProjectPermissionManageSheet ProjectPermissionType = "bb.permission.project.manage-sheet"
+	// ProjectPermissionCreateSheet allows user to create sheets in the project.
+	ProjectPermissionCreateSheet ProjectPermissionType = "bb.permission.project.create-sheet"
+	// ProjectPermissionAdminSheet allows user to manage sheet settings in the project.
+	ProjectPermissionAdminSheet ProjectPermissionType = "bb.permission.project.admin-sheet"
+	// ProjectPermissionOrganizeSheet allows user to organize sheet (star, pin) in the project.
+	ProjectPermissionOrganizeSheet ProjectPermissionType = "bb.permission.project.organize-sheet"
 	// ProjectPermissionChangeDatabase allows user to make DML/DDL database change in the project.
 	ProjectPermissionChangeDatabase ProjectPermissionType = "bb.permission.project.change-database"
 	// ProjectPermissionAdminDatabase allows user to manage database settings in the project.
@@ -149,7 +153,9 @@ func ProjectPermission(permission ProjectPermissionType, plan PlanType, role com
 	projectPermissionMatrix := map[ProjectPermissionType][2]bool{
 		ProjectPermissionManageGeneral:  {false, true},
 		ProjectPermissionManageMember:   {false, true},
-		ProjectPermissionManageSheet:    {false, true},
+		ProjectPermissionCreateSheet:    {true, true},
+		ProjectPermissionAdminSheet:     {false, true},
+		ProjectPermissionOrganizeSheet:  {true, true},
 		ProjectPermissionChangeDatabase: {true, true},
 		ProjectPermissionAdminDatabase:  {false, true},
 		// If dba-workflow is disabled, then project developer can also create database.

--- a/server/acl_project_test.go
+++ b/server/acl_project_test.go
@@ -5,30 +5,7 @@ import (
 	"testing"
 
 	"github.com/bytebase/bytebase/api"
-	"github.com/bytebase/bytebase/common"
 )
-
-var roleFinder = func(projectID int, principalID int) (common.ProjectRole, error) {
-	switch projectID {
-	case 100:
-		switch principalID {
-		case 200:
-			return common.ProjectOwner, nil
-		case 201:
-			return common.ProjectDeveloper, nil
-		}
-	case 101:
-		switch principalID {
-		case 200:
-			return "", nil
-		case 201:
-			return "", nil
-		case 202:
-			return common.ProjectOwner, nil
-		}
-	}
-	return "", nil
-}
 
 func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 	type test struct {
@@ -115,7 +92,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100",
 			method:      "PATCH",
 			principalID: 201,
-			errMsg:      "rejected by the project ACL policy; PATCH /project/100 u201/DEVELOPER",
+			errMsg:      "not have permission to manage the project general setting",
 		},
 		{
 			desc:        "Patch a single project as a non-member",
@@ -123,7 +100,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100",
 			method:      "PATCH",
 			principalID: 202,
-			errMsg:      "rejected by the project ACL policy; PATCH /project/100 u202/non-member",
+			errMsg:      "is not a member of the project",
 		},
 		{
 			desc:        "Fetch subroute from a single project as a project owner",
@@ -163,7 +140,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/repository",
 			method:      "POST",
 			principalID: 201,
-			errMsg:      "rejected by the project ACL policy; POST /project/100/repository u201/DEVELOPER",
+			errMsg:      "not have permission to manage the project general setting",
 		},
 		{
 			desc:        "Create subroute from a single project as a non member",
@@ -171,7 +148,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/repository",
 			method:      "POST",
 			principalID: 202,
-			errMsg:      "rejected by the project ACL policy; POST /project/100/repository u202/non-member",
+			errMsg:      "is not a member of the project",
 		},
 		{
 			desc:        "Patch subroute from a single project as a project owner",
@@ -187,7 +164,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/repository",
 			method:      "PATCH",
 			principalID: 201,
-			errMsg:      "rejected by the project ACL policy; PATCH /project/100/repository u201/DEVELOPER",
+			errMsg:      "not have permission to manage the project general setting",
 		},
 		{
 			desc:        "Patch subroute from a single project as a non member",
@@ -195,7 +172,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/repository",
 			method:      "PATCH",
 			principalID: 202,
-			errMsg:      "rejected by the project ACL policy; PATCH /project/100/repository u202/non-member",
+			errMsg:      "is not a member of the project",
 		},
 		{
 			desc:        "Delete subroute from a single project as a project owner",
@@ -211,7 +188,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/repository",
 			method:      "DELETE",
 			principalID: 201,
-			errMsg:      "rejected by the project ACL policy; DELETE /project/100/repository u201/DEVELOPER",
+			errMsg:      "not have permission to manage the project general setting",
 		},
 		{
 			desc:        "Delete subroute from a single project as a non member",
@@ -219,7 +196,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/repository",
 			method:      "DELETE",
 			principalID: 202,
-			errMsg:      "rejected by the project ACL policy; DELETE /project/100/repository u202/non-member",
+			errMsg:      "is not a member of the project",
 		},
 		{
 			desc:        "Create member from a single project as a project owner",
@@ -235,7 +212,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/member",
 			method:      "POST",
 			principalID: 201,
-			errMsg:      "rejected by the project ACL policy; POST /project/100/member u201/DEVELOPER",
+			errMsg:      "not have permission to manage the project member",
 		},
 		{
 			desc:        "Create member from a single project as a non-member",
@@ -243,7 +220,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/member",
 			method:      "POST",
 			principalID: 202,
-			errMsg:      "rejected by the project ACL policy; POST /project/100/member u202/non-member",
+			errMsg:      "is not a member of the project",
 		},
 		{
 			desc:        "PATCH member from a single project as a project owner",
@@ -259,7 +236,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/member/567",
 			method:      "PATCH",
 			principalID: 201,
-			errMsg:      "rejected by the project ACL policy; PATCH /project/100/member/567 u201/DEVELOPER",
+			errMsg:      "not have permission to manage the project member",
 		},
 		{
 			desc:        "PATCH member from a single project as a non-member",
@@ -267,7 +244,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/member/567",
 			method:      "PATCH",
 			principalID: 202,
-			errMsg:      "rejected by the project ACL policy; PATCH /project/100/member/567 u202/non-member",
+			errMsg:      "is not a member of the project",
 		},
 		{
 			desc:        "DELETE member from a single project as a project owner",
@@ -283,7 +260,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/member/567",
 			method:      "DELETE",
 			principalID: 201,
-			errMsg:      "rejected by the project ACL policy; DELETE /project/100/member/567 u201/DEVELOPER",
+			errMsg:      "not have permission to manage the project member",
 		},
 		{
 			desc:        "DELETE member from a single project as a non-member",
@@ -291,7 +268,7 @@ func TestEnforceWorkspaceDeveloperProjectRouteACL(t *testing.T) {
 			path:        "/project/100/member/567",
 			method:      "DELETE",
 			principalID: 202,
-			errMsg:      "rejected by the project ACL policy; DELETE /project/100/member/567 u202/non-member",
+			errMsg:      "is not a member of the project",
 		},
 	}
 

--- a/server/acl_sheet_test.go
+++ b/server/acl_sheet_test.go
@@ -1,0 +1,313 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/bytebase/bytebase/api"
+)
+
+func TestEnforceWorkspaceDeveloperSheetRouteACL(t *testing.T) {
+	type test struct {
+		desc        string
+		plan        api.PlanType
+		path        string
+		method      string
+		principalID int
+		errMsg      string
+	}
+
+	tests := []test{
+		{
+			desc:        "Fetch own sheet",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/my",
+			method:      "GET",
+			principalID: 200,
+			errMsg:      "",
+		},
+		{
+			desc:        "Fetch shared sheet",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/shared",
+			method:      "GET",
+			principalID: 200,
+			errMsg:      "",
+		},
+		{
+			desc:        "Fetch starred sheet",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/starred",
+			method:      "GET",
+			principalID: 200,
+			errMsg:      "",
+		},
+	}
+
+	privateSheetTests := []test{
+		{
+			desc:        "Access private sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "GET",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Access private sheet as a project owner",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "GET",
+			principalID: 200,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Access private sheet as a project developer",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "GET",
+			principalID: 201,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Access private sheet as a non-member",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "GET",
+			principalID: 204,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Change private sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Change private sheet as a project owner",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "PATCH",
+			principalID: 200,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Change private sheet as a project developer",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "PATCH",
+			principalID: 201,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Change private sheet as a non-member",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "PATCH",
+			principalID: 204,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Change private sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000",
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Organize private sheet as a project owner",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000/organize",
+			method:      "PATCH",
+			principalID: 200,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Organize private sheet as a project developer",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000/organize",
+			method:      "PATCH",
+			principalID: 201,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+		{
+			desc:        "Organize private sheet as a non-member",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1000/organize",
+			method:      "PATCH",
+			principalID: 204,
+			errMsg:      "not allowed to access private sheet created by other user",
+		},
+	}
+
+	projectSheetTests := []test{
+		{
+			desc:        "Access project sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "GET",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Access project sheet as a project owner",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "GET",
+			principalID: 200,
+			errMsg:      "",
+		},
+		{
+			desc:        "Access project sheet as a project developer",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "GET",
+			principalID: 201,
+			errMsg:      "",
+		},
+		{
+			desc:        "Access project sheet as a non-member",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "GET",
+			principalID: 204,
+			errMsg:      "is not a member of the project containing the sheet",
+		},
+		{
+			desc:        "Change project sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Change project sheet as a project owner",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "PATCH",
+			principalID: 200,
+			errMsg:      "",
+		},
+		{
+			desc:        "Change project sheet as a project developer",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "PATCH",
+			principalID: 201,
+			errMsg:      "not have permission to change the project sheet",
+		},
+		{
+			desc:        "Change project sheet as a non-member",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001",
+			method:      "PATCH",
+			principalID: 204,
+			errMsg:      "is not a member of the project containing the sheet",
+		},
+		{
+			desc:        "Organize project sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001/organize",
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Organize project sheet as a project owner",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001/organize",
+			method:      "PATCH",
+			principalID: 200,
+			errMsg:      "",
+		},
+		{
+			desc:        "Organize project sheet as a project developer",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001/organize",
+			method:      "PATCH",
+			principalID: 201,
+			errMsg:      "",
+		},
+		{
+			desc:        "Organize project sheet as a non-member",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1001/organize",
+			method:      "PATCH",
+			principalID: 204,
+			errMsg:      "is not a member of the project containing the sheet",
+		},
+	}
+
+	publicSheetTests := []test{
+		{
+			desc:        "Access public sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1002",
+			method:      "GET",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Access public sheet as a non-creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1002",
+			method:      "GET",
+			principalID: 204,
+			errMsg:      "",
+		},
+		{
+			desc:        "Change public sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1002",
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Change public sheet as a non-creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1002",
+			method:      "PATCH",
+			principalID: 204,
+			errMsg:      "not allowed to change public sheet created by other user",
+		},
+		{
+			desc:        "Organize public sheet as a creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1002/organize",
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Organize public sheet as a non-creator",
+			plan:        api.ENTERPRISE,
+			path:        "/sheet/1002/organize",
+			method:      "PATCH",
+			principalID: 204,
+			errMsg:      "",
+		},
+	}
+
+	tests = append(tests, privateSheetTests...)
+	tests = append(tests, projectSheetTests...)
+	tests = append(tests, publicSheetTests...)
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := enforceWorkspaceDeveloperSheetRouteACL(tc.plan, tc.path, tc.method, tc.principalID, roleFinder, sheetFinder)
+			if err != nil {
+				if tc.errMsg == "" {
+					t.Errorf("expect no error, got %s", err.Internal.Error())
+				} else if tc.errMsg != err.Internal.Error() {
+					t.Errorf("expect error %s, got %s", tc.errMsg, err.Internal.Error())
+				}
+			} else if tc.errMsg != "" {
+				t.Errorf("expect error %s, got no error", tc.errMsg)
+			}
+		})
+	}
+}

--- a/server/acl_test_helper.go
+++ b/server/acl_test_helper.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
+)
+
+var roleFinder = func(projectID int, principalID int) (common.ProjectRole, error) {
+	switch projectID {
+	case 100:
+		switch principalID {
+		case 200:
+			return common.ProjectOwner, nil
+		case 201:
+			return common.ProjectDeveloper, nil
+		}
+	case 101:
+		switch principalID {
+		case 200:
+			return "", nil
+		case 201:
+			return "", nil
+		case 202:
+			return common.ProjectOwner, nil
+		}
+	}
+	return "", nil
+}
+
+var sheetFinder = func(sheetID int) (*api.Sheet, error) {
+	switch sheetID {
+	case 1000:
+		return &api.Sheet{
+			ID:         1000,
+			CreatorID:  202,
+			ProjectID:  100,
+			Visibility: api.PrivateSheet,
+		}, nil
+	case 1001:
+		return &api.Sheet{
+			ID:         1001,
+			CreatorID:  202,
+			ProjectID:  100,
+			Visibility: api.ProjectSheet,
+		}, nil
+	case 1002:
+		return &api.Sheet{
+			ID:         1002,
+			CreatorID:  202,
+			ProjectID:  100,
+			Visibility: api.PublicSheet,
+		}, nil
+	}
+	return nil, nil
+}


### PR DESCRIPTION
* Split the ACL test.
* Use more human-readable ACL error messages in the existing project ACL check as well as this new sheet ACL check.

There is one missing case to be added in the followup PR. To enforce developer can only create a sheet into the project where she has a membership. It's hard to do this in acl.go because this requires us to consume the request body stream and fetch the project id in the request, however, the request handler also needs to consume the request body. Thus we will do the check in the request handler.

It's a bit unfortunate that we can't centralize all ACL checks in one place though.