### PR TITLE
feat: add task dependencies based on schema version

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -677,7 +677,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 				sameEnvStageFound := false
 				for index, stage := range create.StageList {
 					if stage.EnvironmentID == database.Instance.Environment.ID {
-						stage.TaskList = append(stage.TaskList, *taskCreate)
+						stage.TaskList = append(stage.TaskList, *taskCreate.task)
 						create.StageList[index] = stage
 						sameEnvStageFound = true
 						break
@@ -688,7 +688,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 					create.StageList = append(create.StageList, api.StageCreate{
 						Name:          fmt.Sprintf("%s Stage", database.Instance.Environment.Name),
 						EnvironmentID: database.Instance.Environment.ID,
-						TaskList:      []api.TaskCreate{*taskCreate},
+						TaskList:      []api.TaskCreate{*taskCreate.task},
 					})
 				}
 			}
@@ -719,7 +719,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 					if err != nil {
 						return nil, err
 					}
-					taskCreateList = append(taskCreateList, *taskCreate)
+					taskCreateList = append(taskCreateList, *taskCreate.task)
 				}
 				if len(environmentSet) != 1 {
 					var environments []string
@@ -748,7 +748,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 			id    int
 			order int
 		}
-		envToDatabaseMap := make(map[envKey][]api.TaskCreate)
+		envToDatabaseMap := make(map[envKey][]*versionTask)
 		for _, d := range c.DetailList {
 			if d.MigrationType == db.Migrate && d.Statement == "" {
 				return nil, echo.NewHTTPError(http.StatusBadRequest, "Failed to create issue, sql statement missing")
@@ -761,13 +761,13 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 				return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database ID not found: %d", d.DatabaseID))
 			}
 
-			taskCreate, err := getUpdateTask(database, c.VCSPushEvent, d, getOrDefaultSchemaVersion(d))
+			vt, err := getUpdateTask(database, c.VCSPushEvent, d, getOrDefaultSchemaVersion(d))
 			if err != nil {
 				return nil, err
 			}
 
 			key := envKey{name: database.Instance.Environment.Name, id: database.Instance.Environment.ID, order: database.Instance.Environment.Order}
-			envToDatabaseMap[key] = append(envToDatabaseMap[key], *taskCreate)
+			envToDatabaseMap[key] = append(envToDatabaseMap[key], vt)
 		}
 		// Sort and group by environments.
 		var envKeys []envKey
@@ -778,14 +778,45 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 			return envKeys[i].order < envKeys[j].order
 		})
 		for _, env := range envKeys {
+			taskList, taskIndexDagList := getTaskAndDagListByVersion(envToDatabaseMap[env])
 			create.StageList = append(create.StageList, api.StageCreate{
-				Name:          env.name,
-				EnvironmentID: env.id,
-				TaskList:      envToDatabaseMap[env],
+				Name:             env.name,
+				EnvironmentID:    env.id,
+				TaskList:         taskList,
+				TaskIndexDAGList: taskIndexDagList,
 			})
 		}
 	}
 	return create, nil
+}
+
+// getTaskAndDagListByVersion adds the task dependencies for tasks belonging to the same database.
+func getTaskAndDagListByVersion(versionTaskList []*versionTask) ([]api.TaskCreate, []api.TaskIndexDAG) {
+	var taskCreateList []api.TaskCreate
+	var taskIndexDAGList []api.TaskIndexDAG
+	databaseMap := make(map[int][]*versionTask)
+	for _, vt := range versionTaskList {
+		databaseMap[*vt.task.DatabaseID] = append(databaseMap[*vt.task.DatabaseID], vt)
+	}
+	var databaseList []int
+	for k := range databaseMap {
+		databaseList = append(databaseList, k)
+	}
+	sort.Ints(databaseList)
+
+	for _, databaseID := range databaseList {
+		list := databaseMap[databaseID]
+		sort.Slice(list, func(i, j int) bool {
+			return list[i].version < list[j].version
+		})
+		for i := 0; i < len(list)-1; i++ {
+			taskIndexDAGList = append(taskIndexDAGList, api.TaskIndexDAG{FromIndex: len(taskCreateList) + i, ToIndex: len(taskCreateList) + i + 1})
+		}
+		for _, vt := range list {
+			taskCreateList = append(taskCreateList, *vt.task)
+		}
+	}
+	return taskCreateList, taskIndexDAGList
 }
 
 func (s *Server) getPipelineCreateForDatabaseSchemaUpdateGhost(ctx context.Context, issueCreate *api.IssueCreate) (*api.PipelineCreate, error) {
@@ -850,7 +881,12 @@ func getOrDefaultSchemaVersion(detail *api.MigrationDetail) string {
 	return common.DefaultMigrationVersion()
 }
 
-func getUpdateTask(database *api.Database, vcsPushEvent *vcs.PushEvent, d *api.MigrationDetail, schemaVersion string) (*api.TaskCreate, error) {
+type versionTask struct {
+	task    *api.TaskCreate
+	version string
+}
+
+func getUpdateTask(database *api.Database, vcsPushEvent *vcs.PushEvent, d *api.MigrationDetail, schemaVersion string) (*versionTask, error) {
 	var taskName string
 	var taskType api.TaskType
 
@@ -912,15 +948,18 @@ func getUpdateTask(database *api.Database, vcsPushEvent *vcs.PushEvent, d *api.M
 		return nil, errors.Errorf("unsupported migration type %q", d.MigrationType)
 	}
 
-	return &api.TaskCreate{
-		Name:              taskName,
-		InstanceID:        database.Instance.ID,
-		DatabaseID:        &database.ID,
-		Status:            api.TaskPendingApproval,
-		Type:              taskType,
-		Statement:         d.Statement,
-		EarliestAllowedTs: d.EarliestAllowedTs,
-		Payload:           payloadString,
+	return &versionTask{
+		task: &api.TaskCreate{
+			Name:              taskName,
+			InstanceID:        database.Instance.ID,
+			DatabaseID:        &database.ID,
+			Status:            api.TaskPendingApproval,
+			Type:              taskType,
+			Statement:         d.Statement,
+			EarliestAllowedTs: d.EarliestAllowedTs,
+			Payload:           payloadString,
+		},
+		version: schemaVersion,
 	}, nil
 }
 

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -183,6 +183,47 @@ func TestGetTaskAndDagListByVersion(t *testing.T) {
 		{
 			versionTaskList: []*versionTask{
 				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task1"},
+					version: "v1",
+				},
+			},
+			wantTaskList: []api.TaskCreate{
+				{DatabaseID: &databaseID1, Name: "task1"},
+			},
+			wantDAGList: nil,
+		},
+		{
+			versionTaskList: []*versionTask{
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task2"},
+					version: "v2",
+				},
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task3"},
+					version: "v3",
+				},
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task1"},
+					version: "v1",
+				},
+			},
+			wantTaskList: []api.TaskCreate{
+				{DatabaseID: &databaseID1, Name: "task1"},
+				{DatabaseID: &databaseID1, Name: "task2"},
+				{DatabaseID: &databaseID1, Name: "task3"},
+			},
+			wantDAGList: []api.TaskIndexDAG{
+				{FromIndex: 0, ToIndex: 1},
+				{FromIndex: 1, ToIndex: 2},
+			},
+		},
+		{
+			versionTaskList: []*versionTask{
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID2, Name: "task1"},
+					version: "v1",
+				},
+				{
 					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task2"},
 					version: "v2",
 				},
@@ -203,11 +244,13 @@ func TestGetTaskAndDagListByVersion(t *testing.T) {
 				{DatabaseID: &databaseID1, Name: "task1"},
 				{DatabaseID: &databaseID1, Name: "task2"},
 				{DatabaseID: &databaseID1, Name: "task3"},
+				{DatabaseID: &databaseID2, Name: "task1"},
 				{DatabaseID: &databaseID2, Name: "task2"},
 			},
 			wantDAGList: []api.TaskIndexDAG{
 				{FromIndex: 0, ToIndex: 1},
 				{FromIndex: 1, ToIndex: 2},
+				{FromIndex: 3, ToIndex: 4},
 			},
 		},
 	}

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -166,3 +166,55 @@ func TestCheckCharacterSetCollationOwner(t *testing.T) {
 		}
 	}
 }
+
+func TestGetTaskAndDagListByVersion(t *testing.T) {
+	databaseID1 := 1
+	databaseID2 := 2
+	tests := []struct {
+		versionTaskList []*versionTask
+		wantTaskList    []api.TaskCreate
+		wantDAGList     []api.TaskIndexDAG
+	}{
+		{
+			versionTaskList: []*versionTask{},
+			wantTaskList:    nil,
+			wantDAGList:     nil,
+		},
+		{
+			versionTaskList: []*versionTask{
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task2"},
+					version: "v2",
+				},
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID2, Name: "task2"},
+					version: "v2",
+				},
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task3"},
+					version: "v3",
+				},
+				{
+					task:    &api.TaskCreate{DatabaseID: &databaseID1, Name: "task1"},
+					version: "v1",
+				},
+			},
+			wantTaskList: []api.TaskCreate{
+				{DatabaseID: &databaseID1, Name: "task1"},
+				{DatabaseID: &databaseID1, Name: "task2"},
+				{DatabaseID: &databaseID1, Name: "task3"},
+				{DatabaseID: &databaseID2, Name: "task2"},
+			},
+			wantDAGList: []api.TaskIndexDAG{
+				{FromIndex: 0, ToIndex: 1},
+				{FromIndex: 1, ToIndex: 2},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		gotTaskList, gotDAGList := getTaskAndDagListByVersion(test.versionTaskList)
+		assert.Equal(t, test.wantTaskList, gotTaskList)
+		assert.Equal(t, test.wantDAGList, gotDAGList)
+	}
+}

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -438,7 +438,7 @@ func TestVCS(t *testing.T) {
 			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile3: migrationStatement})
 			a.NoError(err)
 
-			payload, err := json.Marshal(test.newWebhookPushEvent([][]string{{gitFile}, {gitFile2}, {gitFile3}}, [][]string{nil, nil, nil}))
+			payload, err := json.Marshal(test.newWebhookPushEvent([][]string{{gitFile3}, {gitFile2}, {gitFile}}, [][]string{nil, nil, nil}))
 			a.NoError(err)
 			err = ctl.vcsProvider.SendWebhookPush(test.externalID, payload)
 			a.NoError(err)
@@ -459,6 +459,7 @@ func TestVCS(t *testing.T) {
 			a.Equal(api.TaskDone, status)
 			issue, err = ctl.getIssue(issue.ID)
 			a.NoError(err)
+			// TODO(xz): expose task DAG list and check the dependency.
 			a.Equal(api.TaskDatabaseSchemaUpdate, issue.Pipeline.StageList[0].TaskList[0].Type)
 			a.Equal("[testVCSSchemaUpdate] Alter schema", issue.Name)
 			a.Equal("By VCS files Prod/testVCSSchemaUpdate##ver1##migrate##create_table_book.sql, Prod/testVCSSchemaUpdate##ver2##migrate##create_table_book2.sql, Prod/testVCSSchemaUpdate##ver3##migrate##create_table_book3.sql", issue.Description)

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -459,7 +459,7 @@ func TestVCS(t *testing.T) {
 			a.Equal(api.TaskDone, status)
 			issue, err = ctl.getIssue(issue.ID)
 			a.NoError(err)
-			// TODO(xz): expose task DAG list and check the dependency.
+			// TODO(p0ny): expose task DAG list and check the dependency.
 			a.Equal(api.TaskDatabaseSchemaUpdate, issue.Pipeline.StageList[0].TaskList[0].Type)
 			a.Equal("[testVCSSchemaUpdate] Alter schema", issue.Name)
 			a.Equal("By VCS files Prod/testVCSSchemaUpdate##ver1##migrate##create_table_book.sql, Prod/testVCSSchemaUpdate##ver2##migrate##create_table_book2.sql, Prod/testVCSSchemaUpdate##ver3##migrate##create_table_book3.sql", issue.Description)

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -428,17 +428,17 @@ func TestVCS(t *testing.T) {
 
 			// Simulate Git commits for schema update.
 			// We create multiple commits in one push event to test for the behavior of creating one issue per database.
-			gitFile := "bbtest/Prod/testVCSSchemaUpdate##ver3##migrate##create_table_book3.sql"
-			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile: migrationStatement3})
+			gitFile3 := "bbtest/Prod/testVCSSchemaUpdate##ver3##migrate##create_table_book3.sql"
+			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile3: migrationStatement3})
 			a.NoError(err)
 			gitFile2 := "bbtest/Prod/testVCSSchemaUpdate##ver2##migrate##create_table_book2.sql"
 			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile2: migrationStatement2})
 			a.NoError(err)
-			gitFile3 := "bbtest/Prod/testVCSSchemaUpdate##ver1##migrate##create_table_book.sql"
-			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile3: migrationStatement})
+			gitFile1 := "bbtest/Prod/testVCSSchemaUpdate##ver1##migrate##create_table_book.sql"
+			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile1: migrationStatement})
 			a.NoError(err)
 
-			payload, err := json.Marshal(test.newWebhookPushEvent([][]string{{gitFile3}, {gitFile2}, {gitFile}}, [][]string{nil, nil, nil}))
+			payload, err := json.Marshal(test.newWebhookPushEvent([][]string{{gitFile3}, {gitFile2}, {gitFile1}}, [][]string{nil, nil, nil}))
 			a.NoError(err)
 			err = ctl.vcsProvider.SendWebhookPush(test.externalID, payload)
 			a.NoError(err)
@@ -477,11 +477,11 @@ func TestVCS(t *testing.T) {
 			a.Equal(bookSchemaSQLResult, result)
 
 			// Simulate Git commits for failed data update.
-			gitFile = "bbtest/Prod/testVCSSchemaUpdate##ver4##data##insert_data.sql"
-			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile: dataUpdateStatementWrong})
+			gitFile3 = "bbtest/Prod/testVCSSchemaUpdate##ver4##data##insert_data.sql"
+			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile3: dataUpdateStatementWrong})
 			a.NoError(err)
 
-			payload, err = json.Marshal(test.newWebhookPushEvent([][]string{{gitFile}}, [][]string{nil}))
+			payload, err = json.Marshal(test.newWebhookPushEvent([][]string{{gitFile3}}, [][]string{nil}))
 			a.NoError(err)
 			err = ctl.vcsProvider.SendWebhookPush(test.externalID, payload)
 			a.NoError(err)
@@ -502,9 +502,9 @@ func TestVCS(t *testing.T) {
 			a.Equal(api.TaskFailed, status)
 
 			// Simulate Git commits for a correct modified date update.
-			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile: dataUpdateStatement})
+			err = ctl.vcsProvider.AddFiles(test.externalID, map[string]string{gitFile3: dataUpdateStatement})
 			a.NoError(err)
-			payload, err = json.Marshal(test.newWebhookPushEvent([][]string{nil}, [][]string{{gitFile}}))
+			payload, err = json.Marshal(test.newWebhookPushEvent([][]string{nil}, [][]string{{gitFile3}}))
 			a.NoError(err)
 			err = ctl.vcsProvider.SendWebhookPush(test.externalID, payload)
 			a.NoError(err)


### PR DESCRIPTION
In VCS, users could push multiple migrations for the same database. We should put task dependencies based on their schema version ID so that failures from prior task will block the execution for a latter task.