### PR TITLE
feat: support to deparse alter table add primary key constraint

### DIFF
--- a/plugin/parser/engine/pg/test-data/test_alter_table_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_alter_table_data.yaml
@@ -84,3 +84,15 @@
   want: |-
     ALTER TABLE "t"
         ADD CONSTRAINT "check_a" CHECK ((a + b) > c);
+- stmt: |-
+    alter table t
+        add constraint email_pkey primary key(email, id);
+  want: |-
+    ALTER TABLE "t"
+        ADD CONSTRAINT "email_pkey" PRIMARY KEY ("email", "id");
+- stmt: |-
+    alter table t
+        add constraint email_pkey primary key(email) include (email) using index tablespace demo_tablespace;
+  want: |-
+    ALTER TABLE "t"
+        ADD CONSTRAINT "email_pkey" PRIMARY KEY ("email") INCLUDE ("email") USING INDEX TABLESPACE "demo_tablespace";


### PR DESCRIPTION
This PR supports to deparse `ALTER TABLE ADD CONSTRAINT constraint_name PRIMARY KEY` statement.
Completing BYT-1762.