### PR TITLE
chore(sql-editor): gracefully fallback if error occurs while opening a sheet

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -113,7 +113,7 @@ const prepareSheet = async () => {
       // If a sheet is open in a tab but it returns 404 NOT_FOUND
       // that means the sheet has been deleted somewhere else.
       // We need to turn the sheet to an unsaved tab.
-      openingSheetTab.sheetId = UNKNOWN_ID;
+      openingSheetTab.sheetId = undefined;
       openingSheetTab.isSaved = false;
     }
     return false;
@@ -242,7 +242,7 @@ const syncURLWithConnection = () => {
         } else {
           // A sheet is not found, fallback to an unsaved tab.
           tabStore.updateCurrentTab({
-            sheetId: UNKNOWN_ID,
+            sheetId: undefined,
             isSaved: false,
           });
         }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1358,16 +1358,8 @@ router.beforeEach((to, from, next) => {
     const sheetId = idFromSlug(sheetSlug);
     useSheetStore()
       .fetchSheetById(sheetId)
-      .then(() => {
-        next();
-      })
-      .catch((error) => {
-        next({
-          name: "error.404",
-          replace: false,
-        });
-        throw error;
-      });
+      .then(() => next())
+      .catch(() => next());
     return;
   }
 
@@ -1380,25 +1372,13 @@ router.beforeEach((to, from, next) => {
       useSQLEditorStore()
         .fetchConnectionByInstanceId(instanceId)
         .then(() => next())
-        .catch((error) => {
-          next({
-            name: "error.404",
-            replace: false,
-          });
-          throw error;
-        });
+        .catch(() => next());
     } else {
       // Connected to db
       useSQLEditorStore()
         .fetchConnectionByInstanceIdAndDatabaseId(instanceId, databaseId)
         .then(() => next())
-        .catch((error) => {
-          next({
-            name: "error.404",
-            replace: false,
-          });
-          throw error;
-        });
+        .catch(() => next());
     }
     return;
   }

--- a/frontend/src/store/modules/sheet.ts
+++ b/frontend/src/store/modules/sheet.ts
@@ -244,14 +244,18 @@ export const useSheetStore = defineStore("sheet", {
       return sheetList;
     },
     async fetchSheetById(sheetId: SheetId) {
-      const data = (await axios.get(`/api/sheet/${sheetId}`)).data;
-      const sheet = convertSheet(data.data, data.included);
-      this.setSheetById({
-        sheetId: sheet.id,
-        sheet: sheet,
-      });
+      try {
+        const data = (await axios.get(`/api/sheet/${sheetId}`)).data;
+        const sheet = convertSheet(data.data, data.included);
+        this.setSheetById({
+          sheetId: sheet.id,
+          sheet: sheet,
+        });
 
-      return sheet;
+        return sheet;
+      } catch {
+        return unknown("SHEET");
+      }
     },
     async getOrFetchSheetById(sheetId: SheetId) {
       const storedSheet = this.sheetById.get(sheetId);

--- a/frontend/src/store/modules/tab.ts
+++ b/frontend/src/store/modules/tab.ts
@@ -167,7 +167,7 @@ export const useTabStore = defineStore("tab", () => {
     // Fetch opening sheets if needed
     const sheetStore = useSheetStore();
     tabList.value.forEach((tab) => {
-      if (tab.sheetId) {
+      if (tab.sheetId && tab.sheetId !== UNKNOWN_ID) {
         sheetStore.getOrFetchSheetById(tab.sheetId);
       }
     });


### PR DESCRIPTION
Close BYT-1795

Now, if error occurs while opening a sheet or an unsaved tab, we will be redirected to the 404 page. Via this PR we can handle the errors more gracefully.

- If error occurs when opening a sheet (e.g., the sheet has been deleted somewhere else), fallback to an unsaved tab. The connection params and SQL statement of the sheet will be kept if possible.
- If error occurs when opening an unsaved tab (e.g., the database or instance has been transferred to an unaccessible project), fallback to disconnected state.