### PR TITLE
feat(schema): add rollback_by column to table task

### DIFF
--- a/store/migration/dev/20221115000000##task_rollback.sql
+++ b/store/migration/dev/20221115000000##task_rollback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task ADD rollback_by INTEGER NOT NULL DEFAULT 0;

--- a/store/migration/dev/20221115000000##task_rollback.sql
+++ b/store/migration/dev/20221115000000##task_rollback.sql
@@ -1,1 +1,1 @@
-ALTER TABLE task ADD rollback_by INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE task ADD rollback_from INTEGER NULL REFERENCES task(id);

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -660,7 +660,7 @@ CREATE TABLE task (
     type TEXT NOT NULL CHECK (type LIKE 'bb.task.%'),
     payload JSONB NOT NULL DEFAULT '{}',
     earliest_allowed_ts BIGINT NOT NULL DEFAULT 0,
-    rollback_by INTEGER NOT NULL DEFAULT 0
+    rollback_from INTEGER NULL REFERENCES task(id)
 );
 
 CREATE INDEX idx_task_pipeline_id_stage_id ON task(pipeline_id, stage_id);

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -660,6 +660,7 @@ CREATE TABLE task (
     type TEXT NOT NULL CHECK (type LIKE 'bb.task.%'),
     payload JSONB NOT NULL DEFAULT '{}',
     earliest_allowed_ts BIGINT NOT NULL DEFAULT 0,
+    -- rollback_from is the original task from which this is generated as a rollback task.
     rollback_from INTEGER NULL REFERENCES task(id)
 );
 

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -659,7 +659,8 @@ CREATE TABLE task (
     status TEXT NOT NULL CHECK (status IN ('PENDING', 'PENDING_APPROVAL', 'RUNNING', 'DONE', 'FAILED', 'CANCELED')),
     type TEXT NOT NULL CHECK (type LIKE 'bb.task.%'),
     payload JSONB NOT NULL DEFAULT '{}',
-    earliest_allowed_ts BIGINT NOT NULL DEFAULT 0
+    earliest_allowed_ts BIGINT NOT NULL DEFAULT 0,
+    rollback_by INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_task_pipeline_id_stage_id ON task(pipeline_id, stage_id);


### PR DESCRIPTION
This is a strong reference between the two tasks to indicate the rollback relationship.
For example, if task1.id=1, task2.id=2, task2.rollback_from=1, then task2 is the generated rollback task for task1.
A NULL rollback_from field means the task is not a generated rollback task of any other task.

Multiple tasks may be generated with the same rollback_from value. We should check this before executing the task. If there's one successful task with the same rollback_from value, we should fail the current one.