### PR TITLE
fix: should not break when iterating the project list to find a user's projects

### DIFF
--- a/server/project.go
+++ b/server/project.go
@@ -107,7 +107,6 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			for _, project := range projectList {
 				if api.HasActiveProjectMembership(principalID, project) {
 					activeProjectList = append(activeProjectList, project)
-					break
 				}
 			}
 		} else {


### PR DESCRIPTION
This was introduced in https://github.com/bytebase/bytebase/commit/6a51ebb8eb6da7b28aecea31f22f9e511f42b635#diff-0c812e31ab390c0fee9f18e8423f33c1f9fa59e3a54742a9470275604723fcf8L107-L112