### PR TITLE
chore: move default deployment configuration generation to backend

### DIFF
--- a/frontend/src/components/ProjectCreate.vue
+++ b/frontend/src/components/ProjectCreate.vue
@@ -147,15 +147,13 @@ import { useRouter } from "vue-router";
 import { isEmpty } from "lodash-es";
 import { useI18n } from "vue-i18n";
 import { useEventListener } from "@vueuse/core";
-import { generateDefaultSchedule, projectSlug, randomString } from "@/utils";
+import { projectSlug, randomString } from "@/utils";
 import { Project, ProjectCreate } from "@/types";
 import {
   hasFeature,
   pushNotification,
   useUIStateStore,
   useProjectStore,
-  useEnvironmentList,
-  useDeploymentStore,
 } from "@/store";
 
 interface LocalState {
@@ -252,19 +250,6 @@ export default defineComponent({
           path: `/project/${projectSlug(createdProject)}`,
           hash: "",
         };
-        if (state.project.tenantMode === "TENANT") {
-          // Generate and save default deployment configuration if it's a tenant mode project
-          const environmentList = useEnvironmentList(["NORMAL"]);
-          const schedule = generateDefaultSchedule(environmentList.value);
-          await useDeploymentStore().patchDeploymentConfigByProjectId({
-            projectId: createdProject.id,
-            deploymentConfigPatch: {
-              payload: JSON.stringify(schedule),
-            },
-          });
-
-          url.hash = "deployment-config";
-        }
         router.push(url);
         emit("dismiss");
       } finally {

--- a/frontend/src/components/ProjectDeploymentConfigPanel.vue
+++ b/frontend/src/components/ProjectDeploymentConfigPanel.vue
@@ -122,14 +122,12 @@ import {
   Project,
   AvailableLabel,
   DeploymentConfig,
-  UNKNOWN_ID,
   EMPTY_ID,
-  empty,
   DeploymentConfigPatch,
   LabelSelectorRequirement,
 } from "../types";
 import DeploymentConfigTool, { DeploymentMatrix } from "./DeploymentConfigTool";
-import { generateDefaultSchedule, validateDeploymentConfig } from "../utils";
+import { validateDeploymentConfig } from "../utils";
 import {
   pushNotification,
   useDatabaseStore,
@@ -210,24 +208,10 @@ export default defineComponent({
       const dep = await deploymentStore.fetchDeploymentConfigByProjectId(
         props.project.id
       );
-
-      if (dep.id === UNKNOWN_ID) {
-        // if the project has no related deployment-config
-        // just generate a "staged-by-env" example to users
-        // this is not saved immediately, it's a draft
-        // users need to edit and save it before creating a deployment issue
-        if (environmentList.value.length > 0) {
-          state.deployment = empty("DEPLOYMENT_CONFIG") as DeploymentConfig;
-          state.deployment.schedule = generateDefaultSchedule(
-            environmentList.value
-          );
-        }
-      } else {
-        // otherwise we clone the saved deployment-config
-        // <DeploymentConfigTool /> will mutate `state.deployment` directly
-        // when update button clicked, we save the draft to backend
-        state.deployment = cloneDeep(dep);
-      }
+      // We clone the saved deployment-config
+      // <DeploymentConfigTool /> will mutate `state.deployment` directly
+      // when update button clicked, we save the draft to backend.
+      state.deployment = cloneDeep(dep);
       // clone the object to the backup
       state.originalDeployment = cloneDeep(state.deployment);
       // clean up error and dirty status

--- a/frontend/src/store/modules/deployment.ts
+++ b/frontend/src/store/modules/deployment.ts
@@ -5,7 +5,6 @@ import {
   ProjectId,
   DeploymentState,
   DeploymentConfig,
-  EMPTY_ID,
   empty,
   unknown,
   UNKNOWN_ID,
@@ -17,7 +16,7 @@ function convert(
   deployment: ResourceObject,
   includedList: ResourceObject[]
 ): DeploymentConfig {
-  if (parseInt(deployment.id, 10) === EMPTY_ID) {
+  if (parseInt(deployment.id, 10) === UNKNOWN_ID) {
     return empty("DEPLOYMENT_CONFIG") as DeploymentConfig;
   }
 
@@ -61,10 +60,6 @@ export const useDeploymentStore = defineStore("deployment", {
   }),
   actions: {
     getDeploymentConfigByProjectId(projectId: ProjectId): DeploymentConfig {
-      if (projectId == EMPTY_ID) {
-        return empty("DEPLOYMENT_CONFIG") as DeploymentConfig;
-      }
-
       return (
         this.deploymentConfigByProjectId.get(projectId) ||
         (unknown("DEPLOYMENT_CONFIG") as DeploymentConfig)
@@ -85,7 +80,7 @@ export const useDeploymentStore = defineStore("deployment", {
 
       const deploymentConfig = convert(data.data, data.included);
       const { id } = deploymentConfig;
-      if (id !== EMPTY_ID && id !== UNKNOWN_ID) {
+      if (id !== UNKNOWN_ID) {
         this.setDeploymentConfigByProjectId({
           projectId,
           deploymentConfig,

--- a/frontend/src/utils/deployment.ts
+++ b/frontend/src/utils/deployment.ts
@@ -1,35 +1,6 @@
-import {
-  DeploymentConfig,
-  DeploymentSchedule,
-  DeploymentSpec,
-  Environment,
-  Label,
-} from "../types";
+import { DeploymentConfig, DeploymentSpec, Label } from "../types";
 import escapeStringRegexp from "escape-string-regexp";
 import { hidePrefix } from "./label";
-
-export const generateDefaultSchedule = (environmentList: Environment[]) => {
-  const schedule: DeploymentSchedule = {
-    deployments: [],
-  };
-  environmentList.forEach((env) => {
-    schedule.deployments.push({
-      name: `${env.name} Stage`,
-      spec: {
-        selector: {
-          matchExpressions: [
-            {
-              key: "bb.environment",
-              operator: "In",
-              values: [env.name],
-            },
-          ],
-        },
-      },
-    });
-  });
-  return schedule;
-};
 
 export const validateDeploymentConfig = (
   config: DeploymentConfig

--- a/server/project.go
+++ b/server/project.go
@@ -636,14 +636,10 @@ func (s *Server) registerProjectRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Project not found with ID %d", id))
 		}
 
+		// DeploymentConfig is never nil.
 		deploymentConfig, err := s.store.GetDeploymentConfigByProjectID(ctx, id)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to get deployment configuration for project id: %d", id)).SetInternal(err)
-		}
-
-		// We should return empty deployment config when it doesn't exist.
-		if deploymentConfig == nil {
-			deploymentConfig = &api.DeploymentConfig{}
 		}
 
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)

--- a/store/deploy.go
+++ b/store/deploy.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -59,13 +60,44 @@ func (s *Store) GetDeploymentConfigByProjectID(ctx context.Context, projectID in
 		return nil, errors.Wrapf(err, "failed to get DeploymentConfig with projectID %d", projectID)
 	}
 	if deploymentConfigRaw == nil {
-		return nil, nil
+		config, err := s.getDefaultDeploymentConfig(ctx, projectID)
+		if err != nil {
+			return nil, err
+		}
+		deploymentConfigRaw = config
 	}
 	deploymentConfig, err := s.composeDeploymentConfig(ctx, deploymentConfigRaw)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compose DeploymentConfig with deploymentConfigRaw[%+v]", deploymentConfigRaw)
 	}
 	return deploymentConfig, nil
+}
+
+func (s *Store) getDefaultDeploymentConfig(ctx context.Context, projectID int) (*deploymentConfigRaw, error) {
+	normalRowStatus := api.Normal
+	environmentList, err := s.FindEnvironment(ctx, &api.EnvironmentFind{RowStatus: &normalRowStatus})
+	if err != nil {
+		return nil, err
+	}
+	scheduleList := api.DeploymentSchedule{}
+	for _, environment := range environmentList {
+		scheduleList.Deployments = append(scheduleList.Deployments, &api.Deployment{
+			Name: fmt.Sprintf("%s Stage", environment.Name),
+			Spec: &api.DeploymentSpec{
+				Selector: &api.LabelSelector{
+					MatchExpressions: []*api.LabelSelectorRequirement{
+						{Key: "bb.environment", Operator: api.InOperatorType, Values: []string{environment.Name}},
+					},
+				},
+			},
+		})
+	}
+	bytes, err := json.Marshal(scheduleList)
+	if err != nil {
+		return nil, err
+	}
+	config := &deploymentConfigRaw{ID: 0, CreatorID: api.SystemBotID, UpdaterID: api.SystemBotID, ProjectID: projectID, Payload: string(bytes)}
+	return config, nil
 }
 
 // UpsertDeploymentConfig upserts an instance of DeploymentConfig.

--- a/store/environment.go
+++ b/store/environment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -65,6 +66,9 @@ func (s *Store) FindEnvironment(ctx context.Context, find *api.EnvironmentFind) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Environment list with EnvironmentFind[%+v]", find)
 	}
+	sort.Slice(environmentRawList, func(i, j int) bool {
+		return environmentRawList[i].Order < environmentRawList[j].Order
+	})
 	var environmentList []*api.Environment
 	for _, raw := range environmentRawList {
 		environment, err := s.composeEnvironment(ctx, raw)


### PR DESCRIPTION
This is the first attempt to unify the issue creation for tenant and non-tenant mode projects. Both should rely on deployment configuration to produce the pipeline/stage/tasks.