### PR TITLE
fix: clear token cache on patch

### DIFF
--- a/plugin/app/feishu/feishu.go
+++ b/plugin/app/feishu/feishu.go
@@ -42,7 +42,7 @@ func NewProvider() *Provider {
 	return &p
 }
 
-// Clear token cache removes cached token.
+// ClearTokenCache clears cached token.
 func (p *Provider) ClearTokenCache() {
 	p.Token.Store("")
 }

--- a/plugin/app/feishu/feishu.go
+++ b/plugin/app/feishu/feishu.go
@@ -42,6 +42,11 @@ func NewProvider() *Provider {
 	return &p
 }
 
+// Clear token cache removes cached token.
+func (p *Provider) ClearTokenCache() {
+	p.Token.Store("")
+}
+
 // TokenCtx is the token context to access feishu APIs.
 type TokenCtx struct {
 	AppID     string

--- a/server/setting.go
+++ b/server/setting.go
@@ -72,6 +72,7 @@ func (s *Server) registerSettingRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusBadRequest, api.FeatureIMApproval.AccessErrorMessage())
 			}
 			p := s.ApplicationRunner.p
+			// clear token cache so that we won't use the previous token.
 			p.ClearTokenCache()
 			approvalCode, err := p.CreateApprovalDefinition(ctx, feishu.TokenCtx{
 				AppID:     value.AppID,

--- a/server/setting.go
+++ b/server/setting.go
@@ -72,6 +72,7 @@ func (s *Server) registerSettingRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusBadRequest, api.FeatureIMApproval.AccessErrorMessage())
 			}
 			p := s.ApplicationRunner.p
+			p.ClearTokenCache()
 			approvalCode, err := p.CreateApprovalDefinition(ctx, feishu.TokenCtx{
 				AppID:     value.AppID,
 				AppSecret: value.AppSecret,


### PR DESCRIPTION
Clear cache on update so that we won't use the previous token when we try to create new approval definition.