### PR TITLE
feat(vcs): filter commits in push event webhook by commits diff

### DIFF
--- a/plugin/vcs/github/github.go
+++ b/plugin/vcs/github/github.go
@@ -203,6 +203,8 @@ type WebhookCommit struct {
 // WebhookPushEvent is the API message for webhook push event.
 type WebhookPushEvent struct {
 	Ref        string            `json:"ref"`
+	Before     string            `json:"before"`
+	After      string            `json:"after"`
 	Repository WebhookRepository `json:"repository"`
 	Sender     WebhookSender     `json:"sender"`
 	Commits    []WebhookCommit   `json:"commits"`
@@ -313,6 +315,11 @@ func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthCon
 		AuthorName: commit.Author.Name,
 		CreatedTs:  commit.Author.Date.Unix(),
 	}, nil
+}
+
+// GetDiffFileList gets the diff files list between two commits.
+func (*Provider) GetDiffFileList(_ context.Context, _ common.OauthContext, _, _, _, _ string) ([]vcs.FileDiff, error) {
+	return nil, nil
 }
 
 // FetchUserInfo fetches user info of given user ID.
@@ -1429,7 +1436,10 @@ func (p WebhookPushEvent) ToVCS() vcs.PushEvent {
 		})
 	}
 	return vcs.PushEvent{
+		VCSType:            vcs.GitHubCom,
 		Ref:                p.Ref,
+		Before:             p.Before,
+		After:              p.After,
 		RepositoryID:       p.Repository.FullName,
 		RepositoryURL:      p.Repository.HTMLURL,
 		RepositoryFullPath: p.Repository.FullName,

--- a/plugin/vcs/vcs.go
+++ b/plugin/vcs/vcs.go
@@ -83,6 +83,25 @@ type FileMeta struct {
 	LastCommitID string
 }
 
+// FileDiffType is the type of file diff.
+type FileDiffType int
+
+const (
+	// FileDiffTypeAdded means the file is newly added.
+	FileDiffTypeAdded FileDiffType = iota
+	// FileDiffTypeModified means the file is modified.
+	FileDiffTypeModified
+	// FileDiffTypeRemoved means the file is removed.
+	FileDiffTypeRemoved
+)
+
+// FileDiff contains file diffs between two commits.
+// It's obtained by comparing the base and head commits of a PR/MR so that we know the real changes.
+type FileDiff struct {
+	Path string
+	Type FileDiffType
+}
+
 // RepositoryTreeNode records the node(file/folder) of a repository tree from `git ls-tree`.
 type RepositoryTreeNode struct {
 	Path string
@@ -94,6 +113,8 @@ type PushEvent struct {
 	VCSType            Type     `json:"vcsType"`
 	BaseDirectory      string   `json:"baseDir"`
 	Ref                string   `json:"ref"`
+	Before             string   `json:"before"`
+	After              string   `json:"after"`
 	RepositoryID       string   `json:"repositoryId"`
 	RepositoryURL      string   `json:"repositoryUrl"`
 	RepositoryFullPath string   `json:"repositoryFullPath"`
@@ -191,6 +212,14 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// commitID: the commit ID
 	FetchCommitByID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, commitID string) (*Commit, error)
+	// Get the diff files list between two commits
+	//
+	// oauthCtx: OAuth context to fetch commit
+	// instanceURL: VCS instance URL
+	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
+	// beforeCommit: the previous commit
+	// afterCommit: the current commit
+	GetDiffFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, beforeCommit, afterCommit string) ([]FileDiff, error)
 	// Fetch the user info of the given userID
 	//
 	// oauthCtx: OAuth context to write the file content

--- a/tests/fake/github.go
+++ b/tests/fake/github.go
@@ -440,6 +440,11 @@ func (gh *GitHub) CreateRepository(id string) {
 	}
 }
 
+// AddCommitsDiff adds a commits diff.
+func (*GitHub) AddCommitsDiff(_, _, _ string, _ []vcs.FileDiff) error {
+	return nil
+}
+
 // SendWebhookPush sends out a webhook for a push event for the GitHub
 // repository using given payload.
 func (gh *GitHub) SendWebhookPush(repositoryID string, payload []byte) error {

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -49,6 +49,9 @@ type projectData struct {
 		*gitlab.MergeRequestChange
 		*gitlab.MergeRequest
 	}
+	// commitsDiff is the map for commits compare.
+	// The map key has the format "from...to" which is SHA or branch name.
+	commitsDiff map[string]*gitlab.CommitsDiff
 }
 
 // NewGitLab creates a new fake implementation of GitLab VCS provider.
@@ -81,6 +84,7 @@ func NewGitLab(port int) VCSProvider {
 	projectGroup.POST("/projects/:id/variables", gl.createProjectEnvironmentVariable)
 	projectGroup.PUT("/projects/:id/variables/:variableKey", gl.updateProjectEnvironmentVariable)
 	projectGroup.GET("/projects/:id/merge_requests/:mrID/changes", gl.getMergeRequestChanges)
+	projectGroup.GET("/projects/:id/repository/compare", gl.compareCommits)
 
 	return gl
 }
@@ -115,6 +119,7 @@ func (gl *GitLab) CreateRepository(id string) {
 			*gitlab.MergeRequestChange
 			*gitlab.MergeRequest
 		}{},
+		commitsDiff: map[string]*gitlab.CommitsDiff{},
 	}
 }
 
@@ -437,7 +442,7 @@ func (gl *GitLab) getMergeRequestChanges(c echo.Context) error {
 
 	mergeRequest, ok := pd.mergeRequests[mrNumber]
 	if !ok {
-		return c.String(http.StatusNotFound, fmt.Sprintf("Cannot found the merge request: %v", c.Param("mrID")))
+		return c.String(http.StatusNotFound, fmt.Sprintf("Cannot find the merge request: %v", c.Param("mrID")))
 	}
 
 	buf, err := json.Marshal(mergeRequest.MergeRequestChange)
@@ -445,6 +450,49 @@ func (gl *GitLab) getMergeRequestChanges(c echo.Context) error {
 		return c.String(http.StatusInternalServerError, fmt.Sprintf("failed to marshal response body: %v", err))
 	}
 	return c.String(http.StatusOK, string(buf))
+}
+
+func (gl *GitLab) compareCommits(c echo.Context) error {
+	pd, err := gl.validProject(c)
+	if err != nil {
+		return err
+	}
+	key := fmt.Sprintf("%s...%s", c.QueryParam("from"), c.QueryParam("to"))
+	diff, ok := pd.commitsDiff[key]
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Cannot find the diff key %s", key))
+	}
+	buf, err := json.Marshal(diff)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal response body").SetInternal(err)
+	}
+	return c.String(http.StatusOK, string(buf))
+}
+
+// AddCommitsDiff adds a commits diff.
+func (gl *GitLab) AddCommitsDiff(projectID, fromCommit, toCommit string, fileDiffList []vcs.FileDiff) error {
+	pd, ok := gl.projects[projectID]
+	if !ok {
+		return errors.Errorf("gitlab project %q doesn't exist", projectID)
+	}
+	key := fmt.Sprintf("%s...%s", fromCommit, toCommit)
+	commitsDiff := &gitlab.CommitsDiff{
+		FileDiffList: []gitlab.MergeRequestFile{},
+	}
+	for _, fileDiff := range fileDiffList {
+		mrFile := gitlab.MergeRequestFile{
+			NewPath: fileDiff.Path,
+		}
+		switch fileDiff.Type {
+		case vcs.FileDiffTypeAdded:
+			mrFile.NewFile = true
+		case vcs.FileDiffTypeRemoved:
+			mrFile.DeletedFile = true
+		}
+		commitsDiff.FileDiffList = append(commitsDiff.FileDiffList, mrFile)
+	}
+	pd.commitsDiff[key] = commitsDiff
+	return nil
 }
 
 // SendWebhookPush sends out a webhook for a push event for the GitLab project

--- a/tests/fake/provider.go
+++ b/tests/fake/provider.go
@@ -28,6 +28,8 @@ type VCSProvider interface {
 	GetFiles(repositoryID string, filePaths ...string) (map[string]string, error)
 	// AddPullRequest creates a new pull request and add changed files to it.
 	AddPullRequest(repositoryID string, prID int, files []*vcs.PullRequestFile) error
+	// AddCommitsDiff adds a commits diff.
+	AddCommitsDiff(repositoryID, fromCommit, toCommit string, fileDiffList []vcs.FileDiff) error
 }
 
 // VCSProviderCreator a function to create a new VCSProvider.

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -1094,6 +1094,23 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 	externalID := "121"
 	repoFullPath := "test/wildcard"
 
+	defaultNewWebhookPushEvent := func(added []string, beforeSHA, afterSHA string) interface{} {
+		return gitlab.WebhookPushEvent{
+			ObjectKind: gitlab.WebhookPush,
+			Ref:        fmt.Sprintf("refs/heads/%s", branchFilter),
+			Before:     beforeSHA,
+			After:      afterSHA,
+			Project: gitlab.WebhookProject{
+				ID: 121,
+			},
+			CommitList: []gitlab.WebhookCommit{
+				{
+					Timestamp: "2021-01-13T13:14:00Z",
+					AddedList: added,
+				},
+			},
+		}
+	}
 	tests := []struct {
 		name                  string
 		vcsProviderCreator    fake.VCSProviderCreator
@@ -1131,23 +1148,7 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 				false,
 				false,
 			},
-			newWebhookPushEvent: func(added []string, beforeSHA, afterSHA string) interface{} {
-				return gitlab.WebhookPushEvent{
-					ObjectKind: gitlab.WebhookPush,
-					Ref:        fmt.Sprintf("refs/heads/%s", branchFilter),
-					Before:     beforeSHA,
-					After:      afterSHA,
-					Project: gitlab.WebhookProject{
-						ID: 121,
-					},
-					CommitList: []gitlab.WebhookCommit{
-						{
-							Timestamp: "2021-01-13T13:14:00Z",
-							AddedList: added,
-						},
-					},
-				}
-			},
+			newWebhookPushEvent: defaultNewWebhookPushEvent,
 		},
 		{
 			name:               "doubleAsterisks",
@@ -1178,23 +1179,7 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 				true,
 				false,
 			},
-			newWebhookPushEvent: func(added []string, beforeSHA, afterSHA string) interface{} {
-				return gitlab.WebhookPushEvent{
-					ObjectKind: gitlab.WebhookPush,
-					Ref:        fmt.Sprintf("refs/heads/%s", branchFilter),
-					Before:     beforeSHA,
-					After:      afterSHA,
-					Project: gitlab.WebhookProject{
-						ID: 121,
-					},
-					CommitList: []gitlab.WebhookCommit{
-						{
-							Timestamp: "2021-01-13T13:14:00Z",
-							AddedList: added,
-						},
-					},
-				}
-			},
+			newWebhookPushEvent: defaultNewWebhookPushEvent,
 		},
 		{
 			name:               "emptyBaseAndMixAsterisks",
@@ -1221,23 +1206,7 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 				true,
 				false,
 			},
-			newWebhookPushEvent: func(added []string, beforeSHA, afterSHA string) interface{} {
-				return gitlab.WebhookPushEvent{
-					ObjectKind: gitlab.WebhookPush,
-					Ref:        fmt.Sprintf("refs/heads/%s", branchFilter),
-					Before:     beforeSHA,
-					After:      afterSHA,
-					Project: gitlab.WebhookProject{
-						ID: 121,
-					},
-					CommitList: []gitlab.WebhookCommit{
-						{
-							Timestamp: "2021-01-13T13:14:00Z",
-							AddedList: added,
-						},
-					},
-				}
-			},
+			newWebhookPushEvent: defaultNewWebhookPushEvent,
 		},
 		// We test the combination of ** and *, and the place holder is not fully represented by the ascii character set.
 		{
@@ -1265,23 +1234,7 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 				true,
 				false,
 			},
-			newWebhookPushEvent: func(added []string, beforeSHA, afterSHA string) interface{} {
-				return gitlab.WebhookPushEvent{
-					ObjectKind: gitlab.WebhookPush,
-					Ref:        fmt.Sprintf("refs/heads/%s", branchFilter),
-					Before:     beforeSHA,
-					After:      afterSHA,
-					Project: gitlab.WebhookProject{
-						ID: 121,
-					},
-					CommitList: []gitlab.WebhookCommit{
-						{
-							Timestamp: "2021-01-13T13:14:00Z",
-							AddedList: added,
-						},
-					},
-				}
-			},
+			newWebhookPushEvent: defaultNewWebhookPushEvent,
 		},
 		// No asterisk
 		{
@@ -1306,23 +1259,7 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 				false,
 				true,
 			},
-			newWebhookPushEvent: func(added []string, beforeSHA, afterSHA string) interface{} {
-				return gitlab.WebhookPushEvent{
-					ObjectKind: gitlab.WebhookPush,
-					Ref:        fmt.Sprintf("refs/heads/%s", branchFilter),
-					Before:     beforeSHA,
-					After:      afterSHA,
-					Project: gitlab.WebhookProject{
-						ID: 121,
-					},
-					CommitList: []gitlab.WebhookCommit{
-						{
-							Timestamp: "2021-01-13T13:14:00Z",
-							AddedList: added,
-						},
-					},
-				}
-			},
+			newWebhookPushEvent: defaultNewWebhookPushEvent,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
The VCS provider (GitLab/GitHub) sends a push event webhook containing commits of the PR/MR when merged. Bytebase will use the commits in the push event to generate issue(s). However, users can merge other branches in the PR/MR, which contains files that are already merged into the main branch.

In the current implementation, Bytebase will generate additional tasks for the merged-in files even if they already exist when the PR/MR is merged.

This PR introduces the commits diff as a filter. We first get the diff before and after the PR/MR is merged, and filter out files that are not in the diff. This prevents the issue described above.

Fix BYT-1785.