### PR TITLE
feat: comment Rejected by assignee on feishu approval rejected

### DIFF
--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -1,5 +1,7 @@
 package api
 
+import "github.com/bytebase/bytebase/plugin/app/feishu"
+
 // ExternalApprovalType is the type of the ExternalApproval.
 type ExternalApprovalType string
 
@@ -36,6 +38,7 @@ type ExternalApprovalPayloadFeishu struct {
 	// feishu
 	InstanceCode string
 	RequesterID  string
+	Status       feishu.ApprovalStatus
 }
 
 // ExternalApprovalCreate is the API message for creating an ExternalApproval.
@@ -57,6 +60,11 @@ type ExternalApprovalFind struct {
 
 // ExternalApprovalPatch is the API message for patching an ExternalApproval.
 type ExternalApprovalPatch struct {
-	ID        int
+	ID int
+
+	// Standard fields
 	RowStatus RowStatus
+
+	// Domain specific fields
+	Payload *string
 }


### PR DESCRIPTION
If the user clicks `Reject` on Feishu approval, Bytebase bot will comment "Rejected by assignee Xxx from Feishu" on the issue 

Add a new field to the payload because we need to know if this is the first time we see it is "Rejected".

![CleanShot 2022-11-16 at 18 10 58@2x](https://user-images.githubusercontent.com/12679343/202152477-f8f66f64-2913-4e72-a064-9b9d5c5f25d2.png)


<img width="2333" alt="image" src="https://user-images.githubusercontent.com/12679343/202152371-9233ab9c-17f8-416a-a483-e719e5592089.png">
