### PR TITLE
fix(frontend): don't switch to active task if url params exists

### DIFF
--- a/frontend/src/components/Issue/IssueDetailLayout.vue
+++ b/frontend/src/components/Issue/IssueDetailLayout.vue
@@ -317,7 +317,7 @@ watch(
 
 // When activeTask is changed, we automatically select it.
 // This enables users to know the pipeline status has changed and we may move forward.
-const autoSelectWhenStatusChanged = () => {
+const autoSelectWhenStatusChanged = (immediate: boolean) => {
   const activeTask = computed((): Task | undefined => {
     if (create.value) return undefined;
     const { pipeline } = issue.value as Issue;
@@ -336,13 +336,19 @@ const autoSelectWhenStatusChanged = () => {
       selectTask(task);
     },
     // Also triggered when the first time the page is loaded.
-    { immediate: true }
+    { immediate }
   );
 };
 
 const onStatusChanged = (eager: boolean) => emit("status-changed", eager);
 
-autoSelectWhenStatusChanged();
+if (route.query.stage || route.query.task) {
+  // If we have selected stage/task in URL, don't switch to activeTask immediately.
+  autoSelectWhenStatusChanged(false);
+} else {
+  // Otherwise, automatically switch to the active task immediately.
+  autoSelectWhenStatusChanged(true);
+}
 
 provideIssueLogic(
   {


### PR DESCRIPTION
By default, we switch to active task while opening the issue detail page. But we shouldn't do this if the stage and/or task is specified in URL params, which is designed to directly switch to the specified stage/task.

FYI @RainbowDashy 