### PR TITLE
fix: force close external approval

### DIFF
--- a/api/setting.go
+++ b/api/setting.go
@@ -83,7 +83,7 @@ type SettingAppIMValue struct {
 	AppID            string `json:"appId"`
 	AppSecret        string `json:"appSecret"`
 	ExternalApproval struct {
-		Enabled      bool `json:"enabled"`
-		ApprovalCode string
+		Enabled              bool   `json:"enabled"`
+		ApprovalDefinitionID string `json:"approvalDefinitionID"`
 	} `json:"externalApproval"`
 }

--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -238,7 +238,7 @@ func (r *ApplicationRunner) CancelExternalApproval(ctx context.Context, issue *a
 	if _, err := r.store.PatchExternalApproval(ctx, &api.ExternalApprovalPatch{ID: approval.ID, RowStatus: api.Archived}); err != nil {
 		return err
 	}
-	if err := r.p.CancelExternalApproval(ctx,
+	return r.p.CancelExternalApproval(ctx,
 		feishu.TokenCtx{
 			AppID:     value.AppID,
 			AppSecret: value.AppSecret,
@@ -246,10 +246,7 @@ func (r *ApplicationRunner) CancelExternalApproval(ctx context.Context, issue *a
 		value.ExternalApproval.ApprovalCode,
 		payload.InstanceCode,
 		payload.RequesterID,
-	); err != nil {
-		return err
-	}
-	return nil
+	)
 }
 
 func (r *ApplicationRunner) shouldCreateExternalApproval(ctx context.Context, issue *api.Issue, stage *api.Stage, oldApproval *api.ExternalApproval) (bool, error) {

--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -194,7 +194,7 @@ func (r *ApplicationRunner) cancelOldExternalApprovalIfNeeded(ctx context.Contex
 				AppID:     settingValue.AppID,
 				AppSecret: settingValue.AppSecret,
 			},
-			settingValue.ExternalApproval.ApprovalCode,
+			settingValue.ExternalApproval.ApprovalDefinitionID,
 			payload.InstanceCode,
 			payload.RequesterID,
 		); err != nil {
@@ -243,7 +243,7 @@ func (r *ApplicationRunner) CancelExternalApproval(ctx context.Context, issue *a
 			AppID:     value.AppID,
 			AppSecret: value.AppSecret,
 		},
-		value.ExternalApproval.ApprovalCode,
+		value.ExternalApproval.ApprovalDefinitionID,
 		payload.InstanceCode,
 		payload.RequesterID,
 	)
@@ -336,7 +336,7 @@ func (r *ApplicationRunner) createExternalApproval(ctx context.Context, issue *a
 			Link:     fmt.Sprintf("%s/issue/%s", r.activityManager.s.profile.ExternalURL, api.IssueSlug(issue)),
 			TaskList: taskList,
 		},
-		settingValue.ExternalApproval.ApprovalCode,
+		settingValue.ExternalApproval.ApprovalDefinitionID,
 		users[issue.Creator.Email],
 		users[issue.Assignee.Email])
 	if err != nil {
@@ -389,7 +389,7 @@ func (r *ApplicationRunner) ScheduleApproval(ctx context.Context, pipeline *api.
 		return
 	}
 
-	if settingValue.ExternalApproval.ApprovalCode == "" {
+	if settingValue.ExternalApproval.ApprovalDefinitionID == "" {
 		log.Error("no approval code", zap.Any("settingValue", settingValue))
 		return
 	}

--- a/server/issue.go
+++ b/server/issue.go
@@ -1301,8 +1301,8 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 		}
 		pipelineStatus = api.PipelineCanceled
 
-		// Try to cancel external approval, it's ok if we failed.
-		if err := s.ApplicationRunner.CancelExternalApprovalIfNeeded(ctx, issue); err != nil {
+		// Cancel external approval, it's ok if we failed.
+		if err := s.ApplicationRunner.CancelExternalApproval(ctx, issue); err != nil {
 			log.Error("failed to cancel external appoval if needed on issue cancellation", zap.Error(err))
 		}
 	}

--- a/server/setting.go
+++ b/server/setting.go
@@ -75,14 +75,14 @@ func (s *Server) registerSettingRoutes(g *echo.Group) {
 				p := s.ApplicationRunner.p
 				// clear token cache so that we won't use the previous token.
 				p.ClearTokenCache()
-				approvalCode, err := p.CreateApprovalDefinition(ctx, feishu.TokenCtx{
+				approvalDefinitionID, err := p.CreateApprovalDefinition(ctx, feishu.TokenCtx{
 					AppID:     value.AppID,
 					AppSecret: value.AppSecret,
 				}, "")
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create approval definition").SetInternal(err)
 				}
-				value.ExternalApproval.ApprovalCode = approvalCode
+				value.ExternalApproval.ApprovalDefinitionID = approvalDefinitionID
 				b, err := json.Marshal(value)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to marshal updated setting value").SetInternal(err)


### PR DESCRIPTION
Force close old external approval.

It didn't work because we do `cancelOldExternalApprovalIfNeeded` before updating the issue status to canceled.