### PR TITLE
fix: cancel external approval on cancellation timing

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -1300,7 +1300,6 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 			}
 		}
 		pipelineStatus = api.PipelineCanceled
-
 	}
 
 	pipelinePatch := &api.PipelinePatch{

--- a/server/issue.go
+++ b/server/issue.go
@@ -1301,10 +1301,6 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 		}
 		pipelineStatus = api.PipelineCanceled
 
-		// Cancel external approval, it's ok if we failed.
-		if err := s.ApplicationRunner.CancelExternalApproval(ctx, issue); err != nil {
-			log.Error("failed to cancel external appoval if needed on issue cancellation", zap.Error(err))
-		}
 	}
 
 	pipelinePatch := &api.PipelinePatch{
@@ -1324,6 +1320,13 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 	updatedIssue, err := s.store.PatchIssue(ctx, issuePatch)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update issue %q's status with patch %v", issue.Name, issuePatch)
+	}
+
+	// Cancel external approval, it's ok if we failed.
+	if newStatus != api.IssueOpen {
+		if err := s.ApplicationRunner.CancelExternalApproval(ctx, issue); err != nil {
+			log.Error("failed to cancel external appoval if needed on issue cancellation", zap.Error(err))
+		}
 	}
 
 	payload, err := json.Marshal(api.ActivityIssueStatusUpdatePayload{

--- a/server/issue.go
+++ b/server/issue.go
@@ -1324,7 +1324,7 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 	// Cancel external approval, it's ok if we failed.
 	if newStatus != api.IssueOpen {
 		if err := s.ApplicationRunner.CancelExternalApproval(ctx, issue); err != nil {
-			log.Error("failed to cancel external approval on issue cancellation", zap.Error(err))
+			log.Error("failed to cancel external approval on issue cancellation or completion", zap.Error(err))
 		}
 	}
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -1324,7 +1324,7 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 	// Cancel external approval, it's ok if we failed.
 	if newStatus != api.IssueOpen {
 		if err := s.ApplicationRunner.CancelExternalApproval(ctx, issue); err != nil {
-			log.Error("failed to cancel external appoval if needed on issue cancellation", zap.Error(err))
+			log.Error("failed to cancel external approval on issue cancellation", zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
Cancel external approval after patching the issue, otherwise, we will have a short period of time when the external approval is canceled, but the issue status is still open, which leads to `ScheduleApproval` sending a new external approval.