### PR TITLE
refactor(test): reduce boilerplate

### DIFF
--- a/plugin/vcs/github/github_test.go
+++ b/plugin/vcs/github/github_test.go
@@ -17,16 +17,12 @@ import (
 )
 
 func TestProvider_FetchUserInfo(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/users/octocat", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/reference/users#get-a-user
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/users/octocat", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/reference/users#get-a-user
+			Body: io.NopCloser(strings.NewReader(`
 {
   "login": "octocat",
   "id": 1,
@@ -74,11 +70,8 @@ func TestProvider_FetchUserInfo(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -205,17 +198,13 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
 		assert.EqualError(t, got, want)
 	})
 
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						switch r.URL.Path {
-						case "/repos/octocat/Hello-World/collaborators":
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								// Example response taken from https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators
-								Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/repos/octocat/Hello-World/collaborators":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				// Example response taken from https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators
+				Body: io.NopCloser(strings.NewReader(`
 [
   {
     "login": "octocat",
@@ -247,12 +236,12 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
   }
 ]
 `)),
-							}, nil
-						case "/users/octocat":
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								// Example response taken from https://docs.github.com/en/rest/reference/users#get-a-user
-								Body: io.NopCloser(strings.NewReader(`
+			}, nil
+		case "/users/octocat":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				// Example response taken from https://docs.github.com/en/rest/reference/users#get-a-user
+				Body: io.NopCloser(strings.NewReader(`
 {
   "login": "octocat",
   "id": 1,
@@ -300,13 +289,10 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
   }
 }
 `)),
-							}, nil
-						}
-						return nil, errors.Errorf("unexpected request path: %s", r.URL.Path)
-					},
-				},
-			},
-		},
+			}, nil
+		}
+		return nil, errors.Errorf("unexpected request path: %s", r.URL.Path)
+	},
 	)
 
 	ctx := context.Background()
@@ -327,16 +313,12 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
 }
 
 func TestProvider_FetchCommitByID(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/git/commits#get-a-commit
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/git/commits#get-a-commit
+			Body: io.NopCloser(strings.NewReader(`
 {
   "sha": "7638417db6d59f3c431d3e1f261cc637155684cd",
   "node_id": "MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==",
@@ -372,11 +354,8 @@ func TestProvider_FetchCommitByID(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -392,29 +371,22 @@ func TestProvider_FetchCommitByID(t *testing.T) {
 }
 
 func TestProvider_ExchangeOAuthToken(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/login/oauth/access_token", r.URL.Path)
-						assert.Equal(t, "client_id=test_client_id&client_secret=test_client_secret&code=test_code&redirect_uri=http%3A%2F%2Flocalhost%3A3000", r.URL.RawQuery)
-						assert.Equal(t, "application/json", r.Header.Get("Accept"))
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/login/oauth/access_token", r.URL.Path)
+		assert.Equal(t, "client_id=test_client_id&client_secret=test_client_secret&code=test_code&redirect_uri=http%3A%2F%2Flocalhost%3A3000", r.URL.RawQuery)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response
+			Body: io.NopCloser(strings.NewReader(`
 {
   "access_token":"gho_16C7e42F292c6912E7710c838347Ae178B4a",
   "scope":"repo,gist",
   "token_type":"bearer"
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -437,16 +409,12 @@ func TestProvider_ExchangeOAuthToken(t *testing.T) {
 }
 
 func TestProvider_FetchAllRepositoryList(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/user/repos", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response derived from https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/user/repos", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response derived from https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user
+			Body: io.NopCloser(strings.NewReader(`
 [
   {
     "id": 1296269,
@@ -584,11 +552,8 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
   }
 ]
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -608,16 +573,12 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 }
 
 func TestProvider_FetchRepositoryFileList(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/octocat/Hello-World/git/trees/main", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/git/trees#get-a-tree
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/octocat/Hello-World/git/trees/main", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/git/trees#get-a-tree
+			Body: io.NopCloser(strings.NewReader(`
 {
   "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
   "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
@@ -657,11 +618,8 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
   "truncated": false
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	t.Run("no path prefix", func(t *testing.T) {
@@ -704,21 +662,17 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 }
 
 func TestProvider_CreateFile(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/octocat/Hello-World/contents/notes%2Fhello.txt", r.URL.RawPath)
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/octocat/Hello-World/contents/notes%2Fhello.txt", r.URL.RawPath)
 
-						body, err := io.ReadAll(r.Body)
-						require.NoError(t, err)
-						wantBody := `{"message":"my commit message","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","branch":"master"}`
-						assert.Equal(t, wantBody, string(body))
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
-							Body: io.NopCloser(strings.NewReader(`
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		wantBody := `{"message":"my commit message","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","branch":"master"}`
+		assert.Equal(t, wantBody, string(body))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
+			Body: io.NopCloser(strings.NewReader(`
 {
   "content": {
     "name": "hello.txt",
@@ -772,11 +726,8 @@ func TestProvider_CreateFile(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -796,21 +747,17 @@ func TestProvider_CreateFile(t *testing.T) {
 }
 
 func TestProvider_OverwriteFile(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/octocat/Hello-World/contents/notes%2Fhello.txt", r.URL.RawPath)
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/octocat/Hello-World/contents/notes%2Fhello.txt", r.URL.RawPath)
 
-						body, err := io.ReadAll(r.Body)
-						require.NoError(t, err)
-						wantBody := `{"message":"update file","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","sha":"7638417db6d59f3c431d3e1f261cc637155684cd","branch":"master"}`
-						assert.Equal(t, wantBody, string(body))
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
-							Body: io.NopCloser(strings.NewReader(`
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		wantBody := `{"message":"update file","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","sha":"7638417db6d59f3c431d3e1f261cc637155684cd","branch":"master"}`
+		assert.Equal(t, wantBody, string(body))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
+			Body: io.NopCloser(strings.NewReader(`
 {
   "content": {
     "name": "hello.txt",
@@ -864,11 +811,8 @@ func TestProvider_OverwriteFile(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -889,16 +833,12 @@ func TestProvider_OverwriteFile(t *testing.T) {
 }
 
 func TestProvider_ReadFileMeta(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/octocat/Hello-World/contents/README.md", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response derived from https://docs.github.com/en/rest/repos/contents#get-repository-content
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/octocat/Hello-World/contents/README.md", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response derived from https://docs.github.com/en/rest/repos/contents#get-repository-content
+			Body: io.NopCloser(strings.NewReader(`
 {
   "type": "file",
   "encoding": "base64",
@@ -918,11 +858,8 @@ func TestProvider_ReadFileMeta(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -939,16 +876,12 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 }
 
 func TestProvider_ReadFileContent(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/octocat/Hello-World/contents/README.md", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response derived from https://docs.github.com/en/rest/repos/contents#get-repository-content
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/octocat/Hello-World/contents/README.md", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response derived from https://docs.github.com/en/rest/repos/contents#get-repository-content
+			Body: io.NopCloser(strings.NewReader(`
 {
   "type": "file",
   "encoding": "base64",
@@ -968,11 +901,8 @@ func TestProvider_ReadFileContent(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -992,16 +922,12 @@ You can look around to get an idea how to structure your project and, when done,
 }
 
 func TestProvider_CreateWebhook(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/1/hooks", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusCreated,
-							// Example response taken from https://docs.github.com/en/rest/webhooks/repos#create-a-repository-webhook
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/1/hooks", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			// Example response taken from https://docs.github.com/en/rest/webhooks/repos#create-a-repository-webhook
+			Body: io.NopCloser(strings.NewReader(`
 {
   "type": "Repository",
   "id": 12345678,
@@ -1029,11 +955,8 @@ func TestProvider_CreateWebhook(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -1043,20 +966,13 @@ func TestProvider_CreateWebhook(t *testing.T) {
 }
 
 func TestProvider_PatchWebhook(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/1/hooks/1", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							Body:       io.NopCloser(strings.NewReader("")),
-						}, nil
-					},
-				},
-			},
-		},
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/1/hooks/1", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -1065,20 +981,13 @@ func TestProvider_PatchWebhook(t *testing.T) {
 }
 
 func TestProvider_DeleteWebhook(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/1/hooks/1", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							Body:       io.NopCloser(strings.NewReader("")),
-						}, nil
-					},
-				},
-			},
-		},
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/1/hooks/1", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -1143,17 +1052,13 @@ func TestOAuth_RefreshToken(t *testing.T) {
 }
 
 func TestProvider_GetBranch(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "GET", r.Method)
-						assert.Equal(t, "/repos/octocat/Hello-World/git/ref/heads/featureA", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/git/refs#get-a-reference
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/repos/octocat/Hello-World/git/ref/heads/featureA", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/git/refs#get-a-reference
+			Body: io.NopCloser(strings.NewReader(`
 {
   "ref": "refs/heads/featureA",
   "node_id": "MDM6UmVmcmVmcy9oZWFkcy9mZWF0dXJlQQ==",
@@ -1165,11 +1070,8 @@ func TestProvider_GetBranch(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -1184,17 +1086,13 @@ func TestProvider_GetBranch(t *testing.T) {
 }
 
 func TestProvider_CreateBranch(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "POST", r.Method)
-						assert.Equal(t, "/repos/octocat/Hello-World/git/refs", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/git/refs#create-a-reference
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/repos/octocat/Hello-World/git/refs", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/git/refs#create-a-reference
+			Body: io.NopCloser(strings.NewReader(`
 {
   "ref": "refs/heads/featureA",
   "node_id": "MDM6UmVmcmVmcy9oZWFkcy9mZWF0dXJlQQ==",
@@ -1206,11 +1104,8 @@ func TestProvider_CreateBranch(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -1222,17 +1117,13 @@ func TestProvider_CreateBranch(t *testing.T) {
 }
 
 func TestProvider_CreatePullRequest(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "POST", r.Method)
-						assert.Equal(t, "/repos/octocat/Hello-World/pulls", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/repos/octocat/Hello-World/pulls", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request
+			Body: io.NopCloser(strings.NewReader(`
 {
   "url": "https://api.github.com/repos/octocat/Hello-World/pulls/1347",
   "id": 1,
@@ -1323,11 +1214,8 @@ func TestProvider_CreatePullRequest(t *testing.T) {
   "changed_files": 5
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -1343,38 +1231,31 @@ func TestProvider_CreatePullRequest(t *testing.T) {
 }
 
 func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						switch r.URL.Path {
-						case "/repos/octocat/Hello-World/actions/secrets/public-key":
-							assert.Equal(t, "GET", r.Method)
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								// Example response taken from https://docs.github.com/en/rest/actions/secrets#get-a-repository-public-key
-								Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/repos/octocat/Hello-World/actions/secrets/public-key":
+			assert.Equal(t, "GET", r.Method)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				// Example response taken from https://docs.github.com/en/rest/actions/secrets#get-a-repository-public-key
+				Body: io.NopCloser(strings.NewReader(`
 {
   "key_id": "568250167242549743",
   "key": "YJf3Ojcv8TSEBCtR0wtTR/F2bD3nBl1lxiwkfV/TYQk="
 }
 `)),
-							}, nil
-						case "/repos/octocat/Hello-World/actions/secrets/1":
-							assert.Equal(t, "PUT", r.Method)
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								// Example response taken from https://docs.github.com/en/rest/actions/secrets#create-or-update-a-repository-secret
-								Body: io.NopCloser(strings.NewReader("")),
-							}, nil
-						}
+			}, nil
+		case "/repos/octocat/Hello-World/actions/secrets/1":
+			assert.Equal(t, "PUT", r.Method)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				// Example response taken from https://docs.github.com/en/rest/actions/secrets#create-or-update-a-repository-secret
+				Body: io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
 
-						return nil, errors.Errorf("Invalid request. %s: %s", r.Method, r.URL.Path)
-					},
-				},
-			},
-		},
+		return nil, errors.Errorf("Invalid request. %s: %s", r.Method, r.URL.Path)
+	},
 	)
 
 	ctx := context.Background()
@@ -1383,22 +1264,18 @@ func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
 }
 
 func TestProvider_ListPullRequestFile(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/repos/octocat/Hello-World/pulls/1/files", r.URL.Path)
-						if r.URL.Query().Get("page") == "2" {
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								Body:       io.NopCloser(strings.NewReader(`[]`)),
-							}, nil
-						}
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/repos/octocat/Hello-World/pulls/1/files", r.URL.Path)
+		if r.URL.Query().Get("page") == "2" {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`[]`)),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+			Body: io.NopCloser(strings.NewReader(`
 [
   {
     "sha": "bbcd538c8e72b8c175046e27cc8f907076331401",
@@ -1414,11 +1291,8 @@ func TestProvider_ListPullRequestFile(t *testing.T) {
   }
 ]
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 	ctx := context.Background()
 	got, err := p.ListPullRequestFile(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "1")
@@ -1432,4 +1306,16 @@ func TestProvider_ListPullRequestFile(t *testing.T) {
 		},
 	}
 	assert.Equal(t, want, got)
+}
+
+func newMockProvider(mockRoundTrip func(r *http.Request) (*http.Response, error)) vcs.Provider {
+	return newProvider(
+		vcs.ProviderConfig{
+			Client: &http.Client{
+				Transport: &common.MockRoundTripper{
+					MockRoundTrip: mockRoundTrip,
+				},
+			},
+		},
+	)
 }

--- a/plugin/vcs/gitlab/gitlab_test.go
+++ b/plugin/vcs/gitlab/gitlab_test.go
@@ -17,16 +17,12 @@ import (
 )
 
 func TestProvider_FetchUserInfo(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/users/1", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/users.html#single-user
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/users/1", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/users.html#single-user
+			Body: io.NopCloser(strings.NewReader(`
 {
   "id": 1,
   "username": "john_smith",
@@ -49,11 +45,8 @@ func TestProvider_FetchUserInfo(t *testing.T) {
   "following": 1
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -148,17 +141,13 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
 		assert.EqualError(t, got, want)
 	})
 
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						switch r.URL.Path {
-						case "/api/v4/projects/1/members/all":
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								// Example response derived from https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members
-								Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/api/v4/projects/1/members/all":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				// Example response derived from https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members
+				Body: io.NopCloser(strings.NewReader(`
 [
   {
     "id": 1,
@@ -209,12 +198,12 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
   }
 ]
 `)),
-							}, nil
-						case "/api/v4/users/1":
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								// Example response taken from https://docs.gitlab.com/ee/api/users.html#single-user
-								Body: io.NopCloser(strings.NewReader(`
+			}, nil
+		case "/api/v4/users/1":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				// Example response taken from https://docs.gitlab.com/ee/api/users.html#single-user
+				Body: io.NopCloser(strings.NewReader(`
 {
   "id": 1,
   "username": "john_smith",
@@ -237,13 +226,10 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
   "following": 1
 }
 `)),
-							}, nil
-						}
-						return nil, errors.Errorf("unexpected request path: %s", r.URL.Path)
-					},
-				},
-			},
-		},
+			}, nil
+		}
+		return nil, errors.Errorf("unexpected request path: %s", r.URL.Path)
+	},
 	)
 
 	ctx := context.Background()
@@ -265,16 +251,12 @@ func TestProvider_FetchRepositoryActiveMemberList(t *testing.T) {
 }
 
 func TestProvider_FetchCommitByID(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/5/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/5/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit
+			Body: io.NopCloser(strings.NewReader(`
 {
   "id": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
   "short_id": "6104942438c",
@@ -305,11 +287,8 @@ func TestProvider_FetchCommitByID(t *testing.T) {
   "web_url": "https://gitlab.example.com/thedude/gitlab-foss/-/commit/6104942438c14ec7bd21c6cd5bd995272b3faff6"
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -325,17 +304,13 @@ func TestProvider_FetchCommitByID(t *testing.T) {
 }
 
 func TestProvider_ExchangeOAuthToken(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/oauth/token", r.URL.Path)
-						assert.Equal(t, "client_id=test_client_id&client_secret=test_client_secret&code=test_code&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A3000", r.URL.RawQuery)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/oauth2.html#authorization-code-flow
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/oauth/token", r.URL.Path)
+		assert.Equal(t, "client_id=test_client_id&client_secret=test_client_secret&code=test_code&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A3000", r.URL.RawQuery)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/oauth2.html#authorization-code-flow
+			Body: io.NopCloser(strings.NewReader(`
 {
  "access_token": "de6780bc506a0446309bd9362820ba8aed28aa506c71eedbe1c5c4f9dd350e54",
  "token_type": "bearer",
@@ -344,11 +319,8 @@ func TestProvider_ExchangeOAuthToken(t *testing.T) {
  "created_at": 1607635748
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -373,16 +345,12 @@ func TestProvider_ExchangeOAuthToken(t *testing.T) {
 }
 
 func TestProvider_FetchAllRepositoryList(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/projects.html#list-all-projects
+			Body: io.NopCloser(strings.NewReader(`
 [
   {
     "id": 4,
@@ -412,11 +380,8 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
   }
 ]
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -435,16 +400,12 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 }
 
 func TestProvider_FetchRepositoryFileList(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/repository/tree", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/repository/tree", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree
+			Body: io.NopCloser(strings.NewReader(`
 [
   {
     "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
@@ -462,11 +423,8 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
   }
 ]
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -484,31 +442,24 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 }
 
 func TestProvider_CreateFile(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
 
-						body, err := io.ReadAll(r.Body)
-						require.NoError(t, err)
-						wantBody := `{"branch":"master","content":"some content","commit_message":"create a new file"}`
-						assert.Equal(t, wantBody, string(body))
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/repository_files.html#create-new-file-in-repository
-							Body: io.NopCloser(strings.NewReader(`
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		wantBody := `{"branch":"master","content":"some content","commit_message":"create a new file"}`
+		assert.Equal(t, wantBody, string(body))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/repository_files.html#create-new-file-in-repository
+			Body: io.NopCloser(strings.NewReader(`
 {
   "file_path": "app/project.rb",
   "branch": "master"
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -528,31 +479,24 @@ func TestProvider_CreateFile(t *testing.T) {
 }
 
 func TestProvider_OverwriteFile(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/repository/files/lib%2Fclass.rb", r.URL.RawPath)
 
-						body, err := io.ReadAll(r.Body)
-						require.NoError(t, err)
-						wantBody := `{"branch":"master","content":"some content","commit_message":"update file","last_commit_id":"7638417db6d59f3c431d3e1f261cc637155684cd"}`
-						assert.Equal(t, wantBody, string(body))
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/repository_files.html#update-existing-file-in-repository
-							Body: io.NopCloser(strings.NewReader(`
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		wantBody := `{"branch":"master","content":"some content","commit_message":"update file","last_commit_id":"7638417db6d59f3c431d3e1f261cc637155684cd"}`
+		assert.Equal(t, wantBody, string(body))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/repository_files.html#update-existing-file-in-repository
+			Body: io.NopCloser(strings.NewReader(`
 {
   "file_path": "app/project.rb",
   "branch": "master"
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -573,27 +517,20 @@ func TestProvider_OverwriteFile(t *testing.T) {
 }
 
 func TestProvider_ReadFileMeta(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/repository/files/app%2Fmodels%2Fkey.rb/raw", r.URL.RawPath)
-						header := http.Header{}
-						header.Set("x-gitlab-file-name", "key.rb")
-						header.Set("x-gitlab-file-path", "app/models/key.rb")
-						header.Set("x-gitlab-size", "3")
-						header.Set("x-gitlab-last-commit-id", "27329d3afac51fbf2762428e12f2635d1137c549")
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
-							Body:   io.NopCloser(strings.NewReader(`key`)),
-							Header: header,
-						}, nil
-					},
-				},
-			},
-		},
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/repository/files/app%2Fmodels%2Fkey.rb/raw", r.URL.RawPath)
+		header := http.Header{}
+		header.Set("x-gitlab-file-name", "key.rb")
+		header.Set("x-gitlab-file-path", "app/models/key.rb")
+		header.Set("x-gitlab-size", "3")
+		header.Set("x-gitlab-last-commit-id", "27329d3afac51fbf2762428e12f2635d1137c549")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
+			Body:   io.NopCloser(strings.NewReader(`key`)),
+			Header: header,
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -607,21 +544,17 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 }
 
 func TestProvider_ReadFileContent(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/repository/files/app%2Fmodels%2Fkey.rb/raw", r.URL.RawPath)
-						header := http.Header{}
-						header.Set("x-gitlab-file-name", "key.rb")
-						header.Set("x-gitlab-file-path", "app/models/key.rb")
-						header.Set("x-gitlab-size", "3")
-						header.Set("x-gitlab-last-commit-id", "27329d3afac51fbf2762428e12f2635d1137c549")
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
-							Body: io.NopCloser(strings.NewReader(`# Sample GitLab Project
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/repository/files/app%2Fmodels%2Fkey.rb/raw", r.URL.RawPath)
+		header := http.Header{}
+		header.Set("x-gitlab-file-name", "key.rb")
+		header.Set("x-gitlab-file-path", "app/models/key.rb")
+		header.Set("x-gitlab-size", "3")
+		header.Set("x-gitlab-last-commit-id", "27329d3afac51fbf2762428e12f2635d1137c549")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response derived from https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
+			Body: io.NopCloser(strings.NewReader(`# Sample GitLab Project
 
 This sample project shows how a project in GitLab looks for demonstration purposes. It contains issues, merge requests and Markdown files in many branches,
 named and filled with lorem ipsum.
@@ -630,12 +563,9 @@ You can look around to get an idea how to structure your project and, when done,
 
 [Learn more about creating GitLab projects.](https://docs.gitlab.com/ee/gitlab-basics/create-project.html)
 `)),
-							Header: header,
-						}, nil
-					},
-				},
-			},
-		},
+			Header: header,
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -655,16 +585,12 @@ You can look around to get an idea how to structure your project and, when done,
 }
 
 func TestProvider_CreateWebhook(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/hooks", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusCreated,
-							// Example response taken from https://docs.gitlab.com/ee/api/projects.html#get-project-hook
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/hooks", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			// Example response taken from https://docs.gitlab.com/ee/api/projects.html#get-project-hook
+			Body: io.NopCloser(strings.NewReader(`
 {
   "id": 1,
   "url": "http://example.com/hook",
@@ -686,11 +612,8 @@ func TestProvider_CreateWebhook(t *testing.T) {
   "created_at": "2012-10-12T17:04:47Z"
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -700,20 +623,13 @@ func TestProvider_CreateWebhook(t *testing.T) {
 }
 
 func TestProvider_PatchWebhook(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/hooks/1", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							Body:       io.NopCloser(strings.NewReader("")),
-						}, nil
-					},
-				},
-			},
-		},
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/hooks/1", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -722,20 +638,13 @@ func TestProvider_PatchWebhook(t *testing.T) {
 }
 
 func TestProvider_DeleteWebhook(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/hooks/1", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							Body:       io.NopCloser(strings.NewReader("")),
-						}, nil
-					},
-				},
-			},
-		},
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/hooks/1", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -799,17 +708,13 @@ func TestOAuth_RefreshToken(t *testing.T) {
 }
 
 func TestProvider_GetBranch(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "GET", r.Method)
-						assert.Equal(t, "/api/v4/projects/1/repository/branches/main", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v4/projects/1/repository/branches/main", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch
+			Body: io.NopCloser(strings.NewReader(`
 {
   "name": "main",
   "merged": false,
@@ -836,11 +741,8 @@ func TestProvider_GetBranch(t *testing.T) {
   }
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -855,17 +757,13 @@ func TestProvider_GetBranch(t *testing.T) {
 }
 
 func TestProvider_CreateBranch(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "POST", r.Method)
-						assert.Equal(t, "/api/v4/projects/1/repository/branches", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/branches.html#create-repository-branch
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v4/projects/1/repository/branches", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/branches.html#create-repository-branch
+			Body: io.NopCloser(strings.NewReader(`
 {
   "commit": {
     "author_email": "john@example.com",
@@ -892,11 +790,8 @@ func TestProvider_CreateBranch(t *testing.T) {
   "web_url": "https://gitlab.example.com/my-group/my-project/-/tree/newbranch"
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -908,16 +803,12 @@ func TestProvider_CreateBranch(t *testing.T) {
 }
 
 func TestProvider_CreatePullRequest(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/merge_requests", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/merge_requests", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
+			Body: io.NopCloser(strings.NewReader(`
 {
   "id": 1,
   "iid": 1,
@@ -1002,11 +893,8 @@ func TestProvider_CreatePullRequest(t *testing.T) {
   "diverged_commits_count": 2
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 
 	ctx := context.Background()
@@ -1022,18 +910,14 @@ func TestProvider_CreatePullRequest(t *testing.T) {
 }
 
 func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						switch r.URL.Path {
-						case "/api/v4/projects/1/variables/1":
-							if r.Method == "GET" {
-								return &http.Response{
-									StatusCode: http.StatusOK,
-									// Example response taken from https://docs.gitlab.com/ee/api/project_level_variables.html#get-a-single-variable
-									Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/api/v4/projects/1/variables/1":
+			if r.Method == "GET" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					// Example response taken from https://docs.gitlab.com/ee/api/project_level_variables.html#get-a-single-variable
+					Body: io.NopCloser(strings.NewReader(`
 {
     "variable_type": "env_var",
     "key": "1",
@@ -1043,12 +927,12 @@ func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
     "environment_scope": "*"
 }
 `)),
-								}, nil
-							} else if r.Method == "PUT" {
-								return &http.Response{
-									StatusCode: http.StatusOK,
-									// Example response taken from https://docs.gitlab.com/ee/api/project_level_variables.html#update-a-variable
-									Body: io.NopCloser(strings.NewReader(`
+				}, nil
+			} else if r.Method == "PUT" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					// Example response taken from https://docs.gitlab.com/ee/api/project_level_variables.html#update-a-variable
+					Body: io.NopCloser(strings.NewReader(`
 {
     "variable_type": "env_var",
     "key": "1",
@@ -1058,14 +942,14 @@ func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
     "environment_scope": "*"
 }
 `)),
-								}, nil
-							}
-						case "/api/v4/projects/1/variables":
-							assert.Equal(t, "POST", r.Method)
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								// Example response taken from https://docs.gitlab.com/ee/api/project_level_variables.html#create-a-variable
-								Body: io.NopCloser(strings.NewReader(`
+				}, nil
+			}
+		case "/api/v4/projects/1/variables":
+			assert.Equal(t, "POST", r.Method)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				// Example response taken from https://docs.gitlab.com/ee/api/project_level_variables.html#create-a-variable
+				Body: io.NopCloser(strings.NewReader(`
 {
     "variable_type": "env_var",
     "key": "1",
@@ -1075,14 +959,11 @@ func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
     "environment_scope": "*"
 }
 `)),
-							}, nil
-						}
+			}, nil
+		}
 
-						return nil, errors.Errorf("Invalid request. %s: %s", r.Method, r.URL.Path)
-					},
-				},
-			},
-		},
+		return nil, errors.Errorf("Invalid request. %s: %s", r.Method, r.URL.Path)
+	},
 	)
 
 	ctx := context.Background()
@@ -1091,16 +972,12 @@ func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
 }
 
 func TestProvider_ListPullRequestFile(t *testing.T) {
-	p := newProvider(
-		vcs.ProviderConfig{
-			Client: &http.Client{
-				Transport: &common.MockRoundTripper{
-					MockRoundTrip: func(r *http.Request) (*http.Response, error) {
-						assert.Equal(t, "/api/v4/projects/1/merge_requests/1/changes", r.URL.Path)
-						return &http.Response{
-							StatusCode: http.StatusOK,
-							// Example response taken from https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes
-							Body: io.NopCloser(strings.NewReader(`
+	p := newMockProvider(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v4/projects/1/merge_requests/1/changes", r.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Example response taken from https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes
+			Body: io.NopCloser(strings.NewReader(`
 {
   "id": 21,
   "iid": 1,
@@ -1137,11 +1014,8 @@ func TestProvider_ListPullRequestFile(t *testing.T) {
   "overflow": false
 }
 `)),
-						}, nil
-					},
-				},
-			},
-		},
+		}, nil
+	},
 	)
 	ctx := context.Background()
 	got, err := p.ListPullRequestFile(ctx, common.OauthContext{}, "", "1", "1")
@@ -1155,4 +1029,16 @@ func TestProvider_ListPullRequestFile(t *testing.T) {
 		},
 	}
 	assert.Equal(t, want, got)
+}
+
+func newMockProvider(mockRoundTrip func(r *http.Request) (*http.Response, error)) vcs.Provider {
+	return newProvider(
+		vcs.ProviderConfig{
+			Client: &http.Client{
+				Transport: &common.MockRoundTripper{
+					MockRoundTrip: mockRoundTrip,
+				},
+			},
+		},
+	)
 }


### PR DESCRIPTION
Reduce boilerplate and indentations by extracting a `newMockProvider` helper function.