### PR TITLE
fix: parallel test must not use the loop var in the closure

### DIFF
--- a/api/project_test.go
+++ b/api/project_test.go
@@ -102,6 +102,8 @@ func TestValidateRepositoryFilePathTemplate(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		// Fix the problem that closure in a for loop will always use the last element.
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			err := ValidateRepositoryFilePathTemplate(test.template, test.tenantMode, test.dbNameTemplate)
 			if test.errPart == "" {

--- a/plugin/db/driver_test.go
+++ b/plugin/db/driver_test.go
@@ -309,6 +309,8 @@ func TestParseSchemaFileInfo(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		// Fix the problem that closure in a for loop will always use the last element.
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			got, err := ParseSchemaFileInfo(test.baseDirectory, test.schemaPathTemplate, test.file)
 			require.NoError(t, err)

--- a/plugin/db/mysql/binlog_stream_parser_test.go
+++ b/plugin/db/mysql/binlog_stream_parser_test.go
@@ -446,6 +446,8 @@ DELIMITER ;
 	}
 
 	for _, test := range tests {
+		// Fix the problem that closure in a for loop will always use the last element.
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			a := require.New(t)
 			txns, err := ParseBinlogStream(strings.NewReader(test.stream))
@@ -608,6 +610,8 @@ func TestFilterBinlogTransactionsByThreadID(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		// Fix the problem that closure in a for loop will always use the last element.
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			a := require.New(t)
 			_, err := FilterBinlogTransactionsByThreadID(test.txnList, test.threadID)

--- a/plugin/db/mysql/rollback_test.go
+++ b/plugin/db/mysql/rollback_test.go
@@ -218,6 +218,8 @@ SET
 	}
 
 	for _, test := range tests {
+		// Fix the problem that closure in a for loop will always use the last element.
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			a := require.New(t)
 			sql, err := test.txn.GetRollbackSQL(test.tableCatalog)
@@ -258,6 +260,8 @@ CREATE TABLE balance (
 		},
 	}
 	for _, test := range tests {
+		// Fix the problem that closure in a for loop will always use the last element.
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			a := require.New(t)
 			tableMap, err := GetTableColumns(test.schema)

--- a/tests/sheet_vcs_test.go
+++ b/tests/sheet_vcs_test.go
@@ -36,6 +36,8 @@ func TestSheetVCS(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		// Fix the problem that closure in a for loop will always use the last element.
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
It should have been detected by https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure. I have no idea why.

The current implementation only runs the last test case in paralleled subtests.