### PR TITLE
test(vcs): add a standalone method to create branches in repos

### DIFF
--- a/tests/fake/github.go
+++ b/tests/fake/github.go
@@ -233,14 +233,11 @@ func (gh *GitHub) getRepositoryBranch(c echo.Context) error {
 	}
 
 	branchName := c.Param("branchName")
-	r.refs[branchName] = &github.Branch{
-		Ref: fmt.Sprintf("refs/heads/%s", branchName),
-		Object: github.ReferenceObject{
-			SHA: "fake_github_commit_sha",
-		},
+	if _, ok := r.refs[fmt.Sprintf("refs/heads/%s", branchName)]; !ok {
+		return c.String(http.StatusNotFound, fmt.Sprintf("branch not found: %v", branchName))
 	}
 
-	buf, err := json.Marshal(r.refs[branchName])
+	buf, err := json.Marshal(r.refs[fmt.Sprintf("refs/heads/%s", branchName)])
 	if err != nil {
 		return c.String(http.StatusInternalServerError, fmt.Sprintf("failed to marshal response body for getting repository branch: %v", err))
 	}

--- a/tests/fake/github.go
+++ b/tests/fake/github.go
@@ -462,6 +462,27 @@ func (gh *GitHub) CreateRepository(id string) {
 	}
 }
 
+// CreateBranch creates a new branch with the given name.
+func (gh *GitHub) CreateBranch(id, branchName string) error {
+	pd, ok := gh.repositories[id]
+	if !ok {
+		return errors.Errorf("github project %q doesn't exist", id)
+	}
+
+	if _, ok := pd.refs[fmt.Sprintf("refs/heads/%s", branchName)]; ok {
+		return errors.Errorf("branch %q already exists", branchName)
+	}
+
+	pd.refs[fmt.Sprintf("refs/heads/%s", branchName)] = &github.Branch{
+		Ref: fmt.Sprintf("refs/heads/%s", branchName),
+		Object: github.ReferenceObject{
+			SHA: "fake_github_commit_sha",
+		},
+	}
+
+	return nil
+}
+
 // AddCommitsDiff adds a commits diff.
 func (gh *GitHub) AddCommitsDiff(repositoryID, fromCommit, toCommit string, fileDiffList []vcs.FileDiff) error {
 	r, ok := gh.repositories[repositoryID]

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -269,16 +269,11 @@ func (gl *GitLab) getProjectBranch(c echo.Context) error {
 	}
 
 	branchName := c.Param("branchName")
-	pd.branches[branchName] = &gitlab.Branch{
-		Name: branchName,
-		Commit: gitlab.Commit{
-			ID:         "fake_gitlab_commit_id",
-			AuthorName: "fake_gitlab_bot",
-			CreatedAt:  time.Now(),
-		},
+	if _, ok := pd.branches[fmt.Sprintf("refs/heads/%s", branchName)]; !ok {
+		return c.String(http.StatusNotFound, fmt.Sprintf("branch not found: %v", branchName))
 	}
 
-	buf, err := json.Marshal(pd.branches[branchName])
+	buf, err := json.Marshal(pd.branches[fmt.Sprintf("refs/heads/%s", branchName)])
 	if err != nil {
 		return c.String(http.StatusInternalServerError, fmt.Sprintf("failed to marshal response body for getting project branch: %v", err))
 	}

--- a/tests/fake/gitlab.go
+++ b/tests/fake/gitlab.go
@@ -123,6 +123,28 @@ func (gl *GitLab) CreateRepository(id string) {
 	}
 }
 
+// CreateBranch creates a new branch with the given name.
+func (gl *GitLab) CreateBranch(id, branchName string) error {
+	pd, ok := gl.projects[id]
+	if !ok {
+		return errors.Errorf("gitlab project %q doesn't exist", id)
+	}
+
+	if _, ok := pd.branches[fmt.Sprintf("refs/heads/%s", branchName)]; ok {
+		return errors.Errorf("branch %q already exists", branchName)
+	}
+
+	pd.branches[fmt.Sprintf("refs/heads/%s", branchName)] = &gitlab.Branch{
+		Name: branchName,
+		Commit: gitlab.Commit{
+			ID:         "fake_gitlab_commit_id",
+			AuthorName: "fake_gitlab_bot",
+			CreatedAt:  time.Now(),
+		},
+	}
+	return nil
+}
+
 // createProjectHook creates a project webhook.
 func (gl *GitLab) createProjectHook(c echo.Context) error {
 	pd, err := gl.validProject(c)

--- a/tests/fake/provider.go
+++ b/tests/fake/provider.go
@@ -19,6 +19,8 @@ type VCSProvider interface {
 
 	// CreateRepository creates a new repository with given ID.
 	CreateRepository(id string)
+	// CreateBranch creates a new branch in the repository with given ID.
+	CreateBranch(id, branchName string) error
 	// SendWebhookPush sends out a webhook for a push event for the repository using
 	// given payload.
 	SendWebhookPush(repositoryID string, payload []byte) error

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -800,6 +800,11 @@ func TestVCS_SDL(t *testing.T) {
 
 			// Create a repository
 			ctl.vcsProvider.CreateRepository(test.externalID)
+
+			// Create the branch
+			err = ctl.vcsProvider.CreateBranch(test.externalID, "feature/foo")
+			a.NoError(err)
+
 			_, err = ctl.createRepository(
 				api.RepositoryCreate{
 					VCSID:              apiVCS.ID,
@@ -1270,6 +1275,11 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 
 			// Create a repository.
 			ctl.vcsProvider.CreateRepository(externalID)
+
+			// Create the branch.
+			err = ctl.vcsProvider.CreateBranch(externalID, branchFilter)
+			a.NoError(err)
+
 			_, err = ctl.createRepository(
 				api.RepositoryCreate{
 					VCSID:              apiVCS.ID,
@@ -1536,6 +1546,11 @@ func TestVCS_SQL_Review(t *testing.T) {
 
 			// Create a repository.
 			ctl.vcsProvider.CreateRepository(test.externalID)
+
+			// Create the branch.
+			err = ctl.vcsProvider.CreateBranch(test.externalID, "feature/foo")
+			a.NoError(err)
+
 			repository, err := ctl.createRepository(
 				api.RepositoryCreate{
 					VCSID:              vcsData.ID,


### PR DESCRIPTION
Previously, we create branches inside `getRepositoryBranch` method of fake VCS providers. This means that when we want to get a branch, we first create it. But we shouldn't allow users to bind vcs settings on a branch that doesn't exist. And the previous test methodology will never reveal this bug.

So in this PR, I created a standalone `CreateBranch` method. When writing tests, we should explicitly create a branch after creating a fake repo. Otherwise, if we try to bind vcs settings on a branch that doesn't exist, the test should detect that.