### PR TITLE
refactor: move test controller parameter to a configuration

### DIFF
--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -406,7 +406,11 @@ func setUpForPITRTest(ctx context.Context, t *testing.T, ctl *controller, port i
 	a := require.New(t)
 
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, port+1)
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               port + 1,
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	err = ctl.Login()
 	a.NoError(err)

--- a/tests/data_source_test.go
+++ b/tests/data_source_test.go
@@ -20,7 +20,11 @@ func TestDataSource(t *testing.T) {
 	serverPort := getTestPort(t.Name())
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, serverPort)
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               serverPort,
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()

--- a/tests/external_pg_test.go
+++ b/tests/external_pg_test.go
@@ -50,6 +50,7 @@ func newFakeExternalPg(tmpDir string, port int) (*fakeExternalPg, error) {
 func (f *fakeExternalPg) Destroy() error {
 	return postgres.Stop(f.pgIns.BaseDir, f.pgIns.DataDir, os.Stderr, os.Stderr)
 }
+
 func TestBootWithExternalPg(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
@@ -71,7 +72,13 @@ func TestBootWithExternalPg(t *testing.T) {
 
 	ctl := &controller{}
 	dataTmpDir := t.TempDir()
-	err = ctl.StartServerWithExternalPg(ctx, dataTmpDir, fake.NewGitLab, serverPort, externalPg.pgUser, externalPg.pgURL)
+	err = ctl.StartServerWithExternalPg(ctx, &config{
+		dataDir:            dataTmpDir,
+		port:               serverPort,
+		vcsProviderCreator: fake.NewGitLab,
+		pgUser:             externalPg.pgUser,
+		pgURL:              externalPg.pgURL,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 }

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -71,7 +71,11 @@ func TestGhostSchemaUpdate(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -22,7 +22,11 @@ func TestArchiveProject(t *testing.T) {
 	serverPort := getTestPort(t.Name())
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, serverPort)
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               serverPort,
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -34,7 +34,11 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -355,7 +359,11 @@ func TestVCS(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)
@@ -728,7 +736,11 @@ func TestVCS_SDL(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)
@@ -1224,7 +1236,11 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, port)
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               port,
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)
@@ -1444,7 +1460,11 @@ func TestVCS_SQL_Review(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)

--- a/tests/sheet_vcs_test.go
+++ b/tests/sheet_vcs_test.go
@@ -44,7 +44,11 @@ func TestSheetVCS(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)

--- a/tests/sql_review_test.go
+++ b/tests/sql_review_test.go
@@ -25,17 +25,15 @@ import (
 	"github.com/bytebase/bytebase/tests/fake"
 )
 
-var (
-	noSQLReviewPolicy = []api.TaskCheckResult{
-		{
-			Status:    api.TaskCheckStatusSuccess,
-			Namespace: api.AdvisorNamespace,
-			Code:      common.Ok.Int(),
-			Title:     "Empty SQL review policy or disabled",
-			Content:   "",
-		},
-	}
-)
+var noSQLReviewPolicy = []api.TaskCheckResult{
+	{
+		Status:    api.TaskCheckStatusSuccess,
+		Namespace: api.AdvisorNamespace,
+		Code:      common.Ok.Int(),
+		Title:     "Empty SQL review policy or disabled",
+		Content:   "",
+	},
+}
 
 type test struct {
 	statement string
@@ -257,7 +255,11 @@ func TestSQLReviewForPostgreSQL(t *testing.T) {
 	ctl := &controller{}
 	dataDir := t.TempDir()
 	port := getTestPort(t.Name()) + 3
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -984,7 +986,11 @@ func TestSQLReviewForMySQL(t *testing.T) {
 	ctl := &controller{}
 	dataDir := t.TempDir()
 	port := getTestPort(t.Name()) + 3
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()

--- a/tests/start_test.go
+++ b/tests/start_test.go
@@ -15,7 +15,11 @@ func TestServiceRestart(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 
 	err = ctl.Login()
@@ -31,7 +35,11 @@ func TestServiceRestart(t *testing.T) {
 	err = ctl.Close(ctx)
 	a.NoError(err)
 
-	err = ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err = ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -32,7 +32,11 @@ func TestTenant(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -285,7 +289,11 @@ func TestTenantVCS(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)
@@ -517,7 +525,12 @@ func TestTenantDatabaseNameTemplate(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	err := ctl.StartServer(ctx, dataDir, fake.NewGitLab, getTestPort(t.Name()))
+	err := ctl.StartServer(ctx, &config{
+		dataDir:            dataDir,
+		port:               getTestPort(t.Name()),
+		vcsProviderCreator: fake.NewGitLab,
+	})
+
 	a.NoError(err)
 	defer ctl.Close(ctx)
 	err = ctl.Login()
@@ -743,7 +756,11 @@ func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)
@@ -1079,7 +1096,11 @@ func TestTenantVCSDatabaseNameTemplate_Empty(t *testing.T) {
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			a.NoError(err)
 			defer func() {
 				_ = ctl.Close(ctx)
@@ -1357,7 +1378,11 @@ func TestTenantVCS_YAML(t *testing.T) {
 
 			ctx := context.Background()
 			ctl := &controller{}
-			err := ctl.StartServer(ctx, t.TempDir(), test.vcsProviderCreator, getTestPort(t.Name()))
+			err := ctl.StartServer(ctx, &config{
+				dataDir:            t.TempDir(),
+				port:               getTestPort(t.Name()),
+				vcsProviderCreator: test.vcsProviderCreator,
+			})
 			require.NoError(t, err)
 			defer func() {
 				_ = ctl.Close(ctx)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -148,7 +148,7 @@ type config struct {
 	dataDir string
 	port    int
 
-	vcsProviderCreator    fake.VCSProviderCreator
+	vcsProviderCreator fake.VCSProviderCreator
 
 	pgUser string
 	pgURL  string

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -144,6 +144,16 @@ type controller struct {
 	vcsURL  string
 }
 
+type config struct {
+	dataDir string
+	port    int
+
+	vcsProviderCreator    fake.VCSProviderCreator
+
+	pgUser string
+	pgURL  string
+}
+
 func getTestPort(testName string) int {
 	// We allocate 4 ports for each of the integration test, who probably would start
 	// the Bytebase server, Postgres, MySQL and code host (GitLab or GitHub).
@@ -208,23 +218,23 @@ func getTestPort(testName string) int {
 }
 
 // StartServerWithExternalPg starts the main server with external Postgres.
-func (ctl *controller) StartServerWithExternalPg(ctx context.Context, dataDir string, vcsProviderCreator fake.VCSProviderCreator, port int, pgUser, pgURL string) error {
+func (ctl *controller) StartServerWithExternalPg(ctx context.Context, config *config) error {
 	log.SetLevel(zap.DebugLevel)
-	profile := cmd.GetTestProfileWithExternalPg(dataDir, port, pgUser, pgURL)
+	profile := cmd.GetTestProfileWithExternalPg(config.dataDir, config.port, config.pgUser, config.pgURL)
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {
 		return err
 	}
 	ctl.server = server
 
-	return ctl.start(ctx, vcsProviderCreator, port)
+	return ctl.start(ctx, config.vcsProviderCreator, config.port)
 }
 
 // StartServer starts the main server with embed Postgres.
-func (ctl *controller) StartServer(ctx context.Context, dataDir string, vcsProviderCreator fake.VCSProviderCreator, port int) error {
+func (ctl *controller) StartServer(ctx context.Context, config *config) error {
 	// start main server.
 	log.SetLevel(zap.DebugLevel)
-	profile := cmd.GetTestProfile(dataDir, port)
+	profile := cmd.GetTestProfile(config.dataDir, config.port)
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {
 		return err
@@ -232,7 +242,7 @@ func (ctl *controller) StartServer(ctx context.Context, dataDir string, vcsProvi
 	ctl.server = server
 	ctl.profile = profile
 
-	return ctl.start(ctx, vcsProviderCreator, port)
+	return ctl.start(ctx, config.vcsProviderCreator, config.port)
 }
 
 // start only called by StartServer() and StartServerWithExternalPg().


### PR DESCRIPTION
We don't need to start a fake VCS server for every test.
We would do something like 
```go
if vcsProviderCreator != nil {
	ctl.vcsProvider = vcsProviderCreator(vcsPort)
	ctl.vcsURL = fmt.Sprintf("http://localhost:%d", vcsPort)
}
```

First, we compose everything into a config because we'll have more parameters in the future (more fake providers).
