### PR TITLE
feat: use solid terminal icon for SQL Editor

### DIFF
--- a/frontend/src/components/DatabaseTable.vue
+++ b/frontend/src/components/DatabaseTable.vue
@@ -39,6 +39,16 @@
       </BBTableCell>
       <BBTableCell :left-padding="showSelectionColumn ? 2 : 4" class="w-[25%]">
         <div class="flex items-center space-x-2">
+          <button
+            v-if="showSQLEditorLink"
+            class="btn-icon tooltip-wrapper"
+            @click.stop="gotoSQLEditor(database)"
+          >
+            <heroicons-solid:terminal class="w-5 h-5" />
+            <div class="tooltip whitespace-nowrap">
+              {{ $t("sql-editor.self") }}
+            </div>
+          </button>
           <span>{{ database.name }}</span>
           <BBBadge
             v-if="isPITRDatabase(database)"
@@ -65,17 +75,6 @@
               }}
             </div>
           </NTooltip>
-
-          <button
-            v-if="showSQLEditorLink"
-            class="btn-icon tooltip-wrapper"
-            @click.stop="gotoSQLEditor(database)"
-          >
-            <heroicons-outline:terminal class="w-4 h-4" />
-            <div class="tooltip whitespace-nowrap">
-              {{ $t("sql-editor.self") }}
-            </div>
-          </button>
         </div>
       </BBTableCell>
       <BBTableCell class="w-[10%]">

--- a/frontend/src/views/DashboardSidebar.vue
+++ b/frontend/src/views/DashboardSidebar.vue
@@ -31,7 +31,7 @@
       target="_blank"
       class="outline-item group flex items-center px-2 py-2"
     >
-      <heroicons-outline:terminal class="w-5 h-5 mr-2" />
+      <heroicons-solid:terminal class="w-5 h-5 mr-2" />
       {{ $t("sql-editor.self") }}
     </a>
     <router-link

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -100,7 +100,7 @@
               @click.prevent="gotoSQLEditor"
             >
               <span class="mr-1">{{ $t("sql-editor.self") }}</span>
-              <heroicons-outline:terminal class="w-4 h-4" />
+              <heroicons-solid:terminal class="w-5 h-5" />
             </dd>
             <DatabaseLabelProps
               :label-list="database.labels"

--- a/frontend/src/views/TableDetail.vue
+++ b/frontend/src/views/TableDetail.vue
@@ -79,7 +79,7 @@
                 {{ $t("sql-editor.self") }}
               </span>
               <button class="ml-1 btn-icon" @click.prevent="gotoSQLEditor">
-                <heroicons-outline:terminal class="w-4 h-4" />
+                <heroicons-solid:terminal class="w-5 h-5" />
               </button>
             </dd>
           </dl>


### PR DESCRIPTION
![CleanShot 2022-11-18 at 18 15 00](https://user-images.githubusercontent.com/230323/202678129-95c4a9ae-3ace-45c5-b193-ff85ca2f05ea.png)

To promote usage as SQL Editor has become more mature. Solid icon is more obvious.

Also reposition the terminal icon before the database name to align properly.

Fix BYT-1839