### PR TITLE
refactor: improve test port allocation

### DIFF
--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -37,9 +37,8 @@ func TestRestoreToNewDatabase(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	ctl := &controller{}
-	project, mysqlDB, database, backup, cleanFn := setUpForPITRTest(ctx, t, ctl, port)
+	project, mysqlDB, database, backup, _, cleanFn := setUpForPITRTest(ctx, t, ctl)
 	defer cleanFn()
 
 	issue, err := createPITRIssue(ctl, project, api.PITRContext{
@@ -74,12 +73,14 @@ func TestRetentionPolicy(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	ctl := &controller{}
-	_, _, database, backup, cleanFn := setUpForPITRTest(ctx, t, ctl, port)
+	_, _, database, backup, _, cleanFn := setUpForPITRTest(ctx, t, ctl)
 	defer cleanFn()
 
-	metaDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=bbtest database=bbtest", port+2))
+	serverPort, err := strconv.Atoi(strings.TrimPrefix(ctl.server.GetEcho().Server.Addr, ":"))
+	a.NoError(err)
+	pgMetaPort := serverPort + 1
+	metaDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=bbtest database=bbtest", pgMetaPort))
 	a.NoError(err)
 	a.NoError(metaDB.Ping())
 
@@ -89,6 +90,7 @@ func TestRetentionPolicy(t *testing.T) {
 	a.NoError(err)
 
 	// Change retention period to 1s, and the backup should be quickly removed.
+	// TODO(d): clean-up the hack.
 	_, err = metaDB.ExecContext(ctx, fmt.Sprintf("UPDATE backup_setting SET enabled=true, retention_period_ts=1 WHERE database_id=%d;", database.ID))
 	a.NoError(err)
 	err = ctl.waitBackupArchived(database.ID, backup.ID)
@@ -106,15 +108,14 @@ func TestPITRGeneral(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	ctl := &controller{}
-	project, mysqlDB, database, _, cleanFn := setUpForPITRTest(ctx, t, ctl, port)
+	project, mysqlDB, database, _, mysqlPort, cleanFn := setUpForPITRTest(ctx, t, ctl)
 	defer cleanFn()
 
 	insertRangeData(t, mysqlDB, numRowsTime0, numRowsTime1)
 
 	ctxUpdateRow, cancelUpdateRow := context.WithCancel(ctx)
-	targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
+	targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, mysqlPort) + 1
 
 	dropColumnStmt := `ALTER TABLE tbl1 DROP COLUMN id;`
 	log.Debug("mimics schema migration", zap.String("statement", dropColumnStmt))
@@ -150,9 +151,8 @@ func TestPITRDropDatabase(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	ctl := &controller{}
-	project, mysqlDB, database, _, cleanFn := setUpForPITRTest(ctx, t, ctl, port)
+	project, mysqlDB, database, _, _, cleanFn := setUpForPITRTest(ctx, t, ctl)
 	defer cleanFn()
 
 	insertRangeData(t, mysqlDB, numRowsTime0, numRowsTime1)
@@ -203,15 +203,14 @@ func TestPITRTwice(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	ctl := &controller{}
-	project, mysqlDB, database, _, cleanFn := setUpForPITRTest(ctx, t, ctl, port)
+	project, mysqlDB, database, _, mysqlPort, cleanFn := setUpForPITRTest(ctx, t, ctl)
 	defer cleanFn()
 
 	log.Debug("Creating issue for the first PITR.")
 	insertRangeData(t, mysqlDB, numRowsTime0, numRowsTime1)
 	ctxUpdateRow, cancelUpdateRow := context.WithCancel(ctx)
-	targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
+	targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, mysqlPort) + 1
 
 	issue, err := createPITRIssue(ctl, project, api.PITRContext{
 		DatabaseID:    database.ID,
@@ -250,7 +249,7 @@ func TestPITRTwice(t *testing.T) {
 
 	log.Debug("Creating issue for the second PITR.")
 	ctxUpdateRow, cancelUpdateRow = context.WithCancel(ctx)
-	targetTs = startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
+	targetTs = startUpdateRow(ctxUpdateRow, t, database.Name, mysqlPort) + 1
 	insertRangeData(t, mysqlDB, numRowsTime1, numRowsTime2)
 
 	issue2, err := createPITRIssue(ctl, project, api.PITRContext{
@@ -284,12 +283,11 @@ func TestPITRToNewDatabaseInAnotherInstance(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	ctl := &controller{}
-	project, sourceMySQLDB, database, _, cleanFn := setUpForPITRTest(ctx, t, ctl, port)
+	project, sourceMySQLDB, database, _, mysqlPort, cleanFn := setUpForPITRTest(ctx, t, ctl)
 	defer cleanFn()
 
-	dstPort := port + 2
+	dstPort := getTestPort()
 	_, dstStopFn := resourcemysql.SetupTestInstance(t, dstPort)
 	defer dstStopFn()
 	dstConnCfg := getMySQLConnectionConfig(strconv.Itoa(dstPort), "")
@@ -314,7 +312,7 @@ func TestPITRToNewDatabaseInAnotherInstance(t *testing.T) {
 	ctxUpdateRow, cancelUpdateRow := context.WithCancel(ctx)
 	cancelUpdateRow()
 
-	targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, port) + 1
+	targetTs := startUpdateRow(ctxUpdateRow, t, database.Name, mysqlPort) + 1
 
 	dropColumnStmt := `ALTER TABLE tbl1 DROP COLUMN id;`
 	log.Debug("mimics schema migration", zap.String("statement", dropColumnStmt))
@@ -371,10 +369,9 @@ func TestPITRInvalidTimePoint(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	ctl := &controller{}
 	targetTs := time.Now().Unix()
-	project, _, database, _, cleanFn := setUpForPITRTest(ctx, t, ctl, port)
+	project, _, database, _, _, cleanFn := setUpForPITRTest(ctx, t, ctl)
 	defer cleanFn()
 
 	issue, err := createPITRIssue(ctl, project, api.PITRContext{
@@ -402,13 +399,12 @@ func createPITRIssue(ctl *controller, project *api.Project, pitrContext api.PITR
 	})
 }
 
-func setUpForPITRTest(ctx context.Context, t *testing.T, ctl *controller, port int) (*api.Project, *sql.DB, *api.Database, *api.Backup, func()) {
+func setUpForPITRTest(ctx context.Context, t *testing.T, ctl *controller) (*api.Project, *sql.DB, *api.Database, *api.Backup, int, func()) {
 	a := require.New(t)
 
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               port + 1,
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)
@@ -443,8 +439,9 @@ func setUpForPITRTest(ctx context.Context, t *testing.T, ctl *controller, port i
 	baseName := strings.ReplaceAll(t.Name(), "/", "_")
 	databaseName := baseName + "_Database"
 
-	_, stopInstance := resourcemysql.SetupTestInstance(t, port)
-	connCfg := getMySQLConnectionConfig(strconv.Itoa(port), "")
+	mysqlPort := getTestPort()
+	_, stopInstance := resourcemysql.SetupTestInstance(t, mysqlPort)
+	connCfg := getMySQLConnectionConfig(strconv.Itoa(mysqlPort), "")
 	instance, err := ctl.addInstance(api.InstanceCreate{
 		EnvironmentID: prodEnvironment.ID,
 		Name:          baseName + "_Instance",
@@ -468,7 +465,7 @@ func setUpForPITRTest(ctx context.Context, t *testing.T, ctl *controller, port i
 	err = ctl.disableAutomaticBackup(database.ID)
 	a.NoError(err)
 
-	mysqlDB := initPITRDB(t, databaseName, port)
+	mysqlDB := initPITRDB(t, databaseName, mysqlPort)
 
 	insertRangeData(t, mysqlDB, 0, numRowsTime0)
 
@@ -483,7 +480,7 @@ func setUpForPITRTest(ctx context.Context, t *testing.T, ctl *controller, port i
 	err = ctl.waitBackup(database.ID, backup.ID)
 	a.NoError(err)
 
-	return project, mysqlDB, database, backup, func() {
+	return project, mysqlDB, database, backup, mysqlPort, func() {
 		a.NoError(ctl.Close(ctx))
 		stopInstance()
 		a.NoError(mysqlDB.Close())

--- a/tests/data_source_test.go
+++ b/tests/data_source_test.go
@@ -17,12 +17,10 @@ func TestDataSource(t *testing.T) {
 	a := require.New(t)
 	log.SetLevel(zapcore.DebugLevel)
 	ctx := context.Background()
-	serverPort := getTestPort(t.Name())
 	ctl := &controller{}
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               serverPort,
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)

--- a/tests/external_pg_test.go
+++ b/tests/external_pg_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/resources/postgres"
 	"github.com/bytebase/bytebase/tests/fake"
-
-	"github.com/stretchr/testify/require"
 )
 
 type fakeExternalPg struct {
@@ -58,10 +57,8 @@ func TestBootWithExternalPg(t *testing.T) {
 
 	pgTmpDir := t.TempDir()
 
-	port := getTestPort(t.Name())
-	serverPort := port + 1
-
-	externalPg, err := newFakeExternalPg(pgTmpDir, port)
+	pgPort := getTestPort()
+	externalPg, err := newFakeExternalPg(pgTmpDir, pgPort)
 	a.NoError(err)
 	defer func() {
 		if err = externalPg.Destroy(); err != nil {
@@ -74,7 +71,6 @@ func TestBootWithExternalPg(t *testing.T) {
 	dataTmpDir := t.TempDir()
 	err = ctl.StartServerWithExternalPg(ctx, &config{
 		dataDir:            dataTmpDir,
-		port:               serverPort,
 		vcsProviderCreator: fake.NewGitLab,
 		pgUser:             externalPg.pgUser,
 		pgURL:              externalPg.pgURL,

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -30,13 +30,13 @@ func TestGhostParser(t *testing.T) {
 	ADD
 		COLUMN ghost_play_2 int;
 	`
-	t.Run("fail to parse", func(st *testing.T) {
-		st.Parallel()
+	t.Run("fail to parse", func(t *testing.T) {
+		t.Parallel()
 		parser := ghostsql.NewParserFromAlterStatement(statement)
 		a.Equal(false, parser.HasExplicitTable())
 	})
-	t.Run("succeed to parse", func(st *testing.T) {
-		st.Parallel()
+	t.Run("succeed to parse", func(t *testing.T) {
+		t.Parallel()
 		s := strings.Join(strings.Fields(statement), " ")
 		parser := ghostsql.NewParserFromAlterStatement(s)
 		a.Equal(true, parser.HasExplicitTable())

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -30,13 +30,13 @@ func TestGhostParser(t *testing.T) {
 	ADD
 		COLUMN ghost_play_2 int;
 	`
-	t.Run("fail to parse", func(t *testing.T) {
-		t.Parallel()
+	t.Run("fail to parse", func(st *testing.T) {
+		st.Parallel()
 		parser := ghostsql.NewParserFromAlterStatement(statement)
 		a.Equal(false, parser.HasExplicitTable())
 	})
-	t.Run("succeed to parse", func(t *testing.T) {
-		t.Parallel()
+	t.Run("succeed to parse", func(st *testing.T) {
+		st.Parallel()
 		s := strings.Join(strings.Fields(statement), " ")
 		parser := ghostsql.NewParserFromAlterStatement(s)
 		a.Equal(true, parser.HasExplicitTable())
@@ -65,7 +65,6 @@ func TestGhostSchemaUpdate(t *testing.T) {
 		mysqlBookSchema2 = `[["TABLE_CATALOG","TABLE_SCHEMA","TABLE_NAME","COLUMN_NAME","ORDINAL_POSITION","COLUMN_DEFAULT","IS_NULLABLE","DATA_TYPE","CHARACTER_MAXIMUM_LENGTH","CHARACTER_OCTET_LENGTH","NUMERIC_PRECISION","NUMERIC_SCALE","DATETIME_PRECISION","CHARACTER_SET_NAME","COLLATION_NAME","COLUMN_TYPE","COLUMN_KEY","EXTRA","PRIVILEGES","COLUMN_COMMENT","GENERATION_EXPRESSION","SRS_ID"],["VARCHAR","VARCHAR","VARCHAR","VARCHAR","INT","TEXT","VARCHAR","TEXT","BIGINT","BIGINT","BIGINT","BIGINT","INT","VARCHAR","VARCHAR","TEXT","CHAR","VARCHAR","VARCHAR","TEXT","TEXT","INT"],[["def","testGhostSchemaUpdate","book","id",1,null,"NO","int",null,null,"10","0",null,null,null,"int","PRI","auto_increment","select,insert,update,references","","",null],["def","testGhostSchemaUpdate","book","name",2,null,"YES","text","65535","65535",null,null,null,"utf8mb4","utf8mb4_general_ci","text","","","select,insert,update,references","","",null],["def","testGhostSchemaUpdate","book","author",3,null,"YES","varchar","54","216",null,null,null,"utf8mb4","utf8mb4_general_ci","varchar(54)","","","select,insert,update,references","","",null]]]`
 	)
 
-	port := getTestPort(t.Name()) + 3
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
@@ -73,7 +72,6 @@ func TestGhostSchemaUpdate(t *testing.T) {
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)
@@ -83,10 +81,11 @@ func TestGhostSchemaUpdate(t *testing.T) {
 	err = ctl.setLicense()
 	a.NoError(err)
 
-	_, stopInstance := mysql.SetupTestInstance(t, port)
+	mysqlPort := getTestPort()
+	_, stopInstance := mysql.SetupTestInstance(t, mysqlPort)
 	defer stopInstance()
 
-	mysqlDB, err := connectTestMySQL(port, "")
+	mysqlDB, err := connectTestMySQL(mysqlPort, "")
 	a.NoError(err)
 	defer mysqlDB.Close()
 
@@ -117,7 +116,7 @@ func TestGhostSchemaUpdate(t *testing.T) {
 		Name:          "mysqlInstance",
 		Engine:        db.MySQL,
 		Host:          "127.0.0.1",
-		Port:          strconv.Itoa(port),
+		Port:          strconv.Itoa(mysqlPort),
 		Username:      "bytebase",
 		Password:      "bytebase",
 	})

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -24,16 +24,14 @@ func TestCheckEngineInnoDB(t *testing.T) {
 	a := require.New(t)
 	ctx := context.Background()
 
-	port := getTestPort(t.Name())
-
 	t.Run("success", func(t *testing.T) {
-		port := port
 		t.Parallel()
-		_, stopFn := resourcemysql.SetupTestInstance(t, port)
+		mysqlPort := getTestPort()
+		_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 		defer stopFn()
 		t.Log("create test database")
 		database := "test_success"
-		db, err := connectTestMySQL(port, "")
+		db, err := connectTestMySQL(mysqlPort, "")
 		a.NoError(err)
 		defer db.Close()
 		_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`; USE `%s`;", database, database))
@@ -44,7 +42,7 @@ func TestCheckEngineInnoDB(t *testing.T) {
 		a.NoError(err)
 
 		t.Log("check InnoDB engine")
-		driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(port), database, "")
+		driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), database, "")
 		a.NoError(err)
 		defer driver.Close(ctx)
 
@@ -55,13 +53,13 @@ func TestCheckEngineInnoDB(t *testing.T) {
 	})
 
 	t.Run("fail", func(t *testing.T) {
-		port := port + 1
 		t.Parallel()
-		_, stopFn := resourcemysql.SetupTestInstance(t, port)
+		mysqlPort := getTestPort()
+		_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 		defer stopFn()
 		t.Log("create test database")
 		database := "test_fail"
-		db, err := connectTestMySQL(port, "")
+		db, err := connectTestMySQL(mysqlPort, "")
 		a.NoError(err)
 		defer db.Close()
 		_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`; USE `%s`;", database, database))
@@ -75,7 +73,7 @@ func TestCheckEngineInnoDB(t *testing.T) {
 		a.NoError(err)
 
 		t.Log("check InnoDB engine")
-		driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(port), database, "")
+		driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), database, "")
 		a.NoError(err)
 		defer driver.Close(ctx)
 
@@ -92,15 +90,15 @@ func TestCheckServerVersionAndBinlogForPITR(t *testing.T) {
 	a := require.New(t)
 	ctx := context.Background()
 
-	port := getTestPort(t.Name())
-	_, stopFn := resourcemysql.SetupTestInstance(t, port)
+	mysqlPort := getTestPort()
+	_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 	defer stopFn()
 
-	db, err := connectTestMySQL(port, "")
+	db, err := connectTestMySQL(mysqlPort, "")
 	a.NoError(err)
 	defer db.Close()
 
-	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(port), "", "")
+	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), "", "")
 	a.NoError(err)
 	defer driver.Close(ctx)
 
@@ -126,11 +124,11 @@ func TestFetchBinlogFiles(t *testing.T) {
 	ctx := context.Background()
 	log.SetLevel(zapcore.DebugLevel)
 
-	port := getTestPort(t.Name())
-	_, stopFn := resourcemysql.SetupTestInstance(t, port)
+	mysqlPort := getTestPort()
+	_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 	defer stopFn()
 
-	db, err := connectTestMySQL(port, "")
+	db, err := connectTestMySQL(mysqlPort, "")
 	a.NoError(err)
 	defer db.Close()
 
@@ -138,7 +136,7 @@ func TestFetchBinlogFiles(t *testing.T) {
 	err = mysqlutil.Install(resourceDir)
 	a.NoError(err)
 
-	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(port), "", resourceDir)
+	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), "", resourceDir)
 	a.NoError(err)
 	defer driver.Close(ctx)
 

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -19,12 +19,10 @@ func TestArchiveProject(t *testing.T) {
 	a := require.New(t)
 	log.SetLevel(zapcore.DebugLevel)
 	ctx := context.Background()
-	serverPort := getTestPort(t.Name())
 	ctl := &controller{}
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               serverPort,
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)

--- a/tests/rollback_test.go
+++ b/tests/rollback_test.go
@@ -18,13 +18,13 @@ func TestRollback(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
-	port := getTestPort(t.Name())
 	database := "funny\ndatabase"
 
-	_, stopFn := resourcemysql.SetupTestInstance(t, port)
+	mysqlPort := getTestPort()
+	_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 	defer stopFn()
 
-	db, err := connectTestMySQL(port, "")
+	db, err := connectTestMySQL(mysqlPort, "")
 	a.NoError(err)
 	defer db.Close()
 	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`; USE `%s`; CREATE TABLE user (id INT PRIMARY KEY, name VARCHAR(64), balance INT);", database, database))
@@ -37,7 +37,7 @@ func TestRollback(t *testing.T) {
 	resourceDir := t.TempDir()
 	err = mysqlutil.Install(resourceDir)
 	a.NoError(err)
-	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(port), database, resourceDir)
+	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), database, resourceDir)
 	a.NoError(err)
 	defer driver.Close(ctx)
 

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -36,7 +36,6 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)
@@ -361,7 +360,6 @@ func TestVCS(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)
@@ -738,7 +736,6 @@ func TestVCS_SDL(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)
@@ -752,11 +749,11 @@ func TestVCS_SDL(t *testing.T) {
 			a.NoError(err)
 
 			// Create a PostgreSQL instance.
-			port := getTestPort(t.Name()) + 3
-			_, stopInstance := postgres.SetupTestInstance(t, port)
+			pgPort := getTestPort()
+			_, stopInstance := postgres.SetupTestInstance(t, pgPort)
 			defer stopInstance()
 
-			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", port))
+			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
 			a.NoError(err)
 			defer func() {
 				_ = pgDB.Close()
@@ -833,7 +830,7 @@ func TestVCS_SDL(t *testing.T) {
 					Name:          "pgInstance",
 					Engine:        db.Postgres,
 					Host:          "/tmp",
-					Port:          strconv.Itoa(port),
+					Port:          strconv.Itoa(pgPort),
 					Username:      "bytebase",
 					Password:      "bytebase",
 				},
@@ -1232,13 +1229,11 @@ func TestWildcardInVCSFilePathTemplate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			port := getTestPort(t.Name())
 			a := require.New(t)
 			ctx := context.Background()
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               port,
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)
@@ -1462,7 +1457,6 @@ func TestVCS_SQL_Review(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)
@@ -1476,11 +1470,11 @@ func TestVCS_SQL_Review(t *testing.T) {
 			a.NoError(err)
 
 			// Create a PostgreSQL instance.
-			port := getTestPort(t.Name()) + 3
-			_, stopInstance := postgres.SetupTestInstance(t, port)
+			pgPort := getTestPort()
+			_, stopInstance := postgres.SetupTestInstance(t, pgPort)
 			defer stopInstance()
 
-			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", port))
+			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
 			a.NoError(err)
 			defer func() {
 				_ = pgDB.Close()
@@ -1530,7 +1524,7 @@ func TestVCS_SQL_Review(t *testing.T) {
 				Name:          "pgInstance",
 				Engine:        db.Postgres,
 				Host:          "/tmp",
-				Port:          strconv.Itoa(port),
+				Port:          strconv.Itoa(pgPort),
 				Username:      "bytebase",
 				Password:      "bytebase",
 			})

--- a/tests/sheet_vcs_test.go
+++ b/tests/sheet_vcs_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestSheetVCS(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		vcsProviderCreator fake.VCSProviderCreator
@@ -46,7 +47,6 @@ func TestSheetVCS(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)

--- a/tests/sql_review_test.go
+++ b/tests/sql_review_test.go
@@ -254,10 +254,8 @@ func TestSQLReviewForPostgreSQL(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	port := getTestPort(t.Name()) + 3
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)
@@ -266,10 +264,11 @@ func TestSQLReviewForPostgreSQL(t *testing.T) {
 	a.NoError(err)
 
 	// Create a PostgreSQL instance.
-	_, stopInstance := postgres.SetupTestInstance(t, port)
+	pgPort := getTestPort()
+	_, stopInstance := postgres.SetupTestInstance(t, pgPort)
 	defer stopInstance()
 
-	pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", port))
+	pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
 	a.NoError(err)
 	defer pgDB.Close()
 
@@ -322,7 +321,7 @@ func TestSQLReviewForPostgreSQL(t *testing.T) {
 		Name:          "pgInstance",
 		Engine:        db.Postgres,
 		Host:          "/tmp",
-		Port:          strconv.Itoa(port),
+		Port:          strconv.Itoa(pgPort),
 		Username:      "bytebase",
 		Password:      "bytebase",
 	})
@@ -985,10 +984,8 @@ func TestSQLReviewForMySQL(t *testing.T) {
 	ctx := context.Background()
 	ctl := &controller{}
 	dataDir := t.TempDir()
-	port := getTestPort(t.Name()) + 3
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)
@@ -997,10 +994,11 @@ func TestSQLReviewForMySQL(t *testing.T) {
 	a.NoError(err)
 
 	// Create a MySQL instance.
-	_, stopInstance := mysql.SetupTestInstance(t, port)
+	mysqlPort := getTestPort()
+	_, stopInstance := mysql.SetupTestInstance(t, mysqlPort)
 	defer stopInstance()
 
-	mysqlDB, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/mysql", port))
+	mysqlDB, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/mysql", mysqlPort))
 	a.NoError(err)
 	defer mysqlDB.Close()
 
@@ -1052,7 +1050,7 @@ func TestSQLReviewForMySQL(t *testing.T) {
 		Name:          "mysqlInstance",
 		Engine:        db.MySQL,
 		Host:          "127.0.0.1",
-		Port:          strconv.Itoa(port),
+		Port:          strconv.Itoa(mysqlPort),
 		Username:      "bytebase",
 		Password:      "bytebase",
 	})

--- a/tests/start_test.go
+++ b/tests/start_test.go
@@ -17,7 +17,6 @@ func TestServiceRestart(t *testing.T) {
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)
@@ -37,7 +36,6 @@ func TestServiceRestart(t *testing.T) {
 
 	err = ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -34,7 +34,6 @@ func TestTenant(t *testing.T) {
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 	a.NoError(err)
@@ -211,6 +210,7 @@ func TestTenant(t *testing.T) {
 }
 
 func TestTenantVCS(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		vcsProviderCreator  fake.VCSProviderCreator
@@ -291,7 +291,6 @@ func TestTenantVCS(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)
@@ -527,7 +526,6 @@ func TestTenantDatabaseNameTemplate(t *testing.T) {
 	dataDir := t.TempDir()
 	err := ctl.StartServer(ctx, &config{
 		dataDir:            dataDir,
-		port:               getTestPort(t.Name()),
 		vcsProviderCreator: fake.NewGitLab,
 	})
 
@@ -758,7 +756,6 @@ func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)
@@ -1098,7 +1095,6 @@ func TestTenantVCSDatabaseNameTemplate_Empty(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			a.NoError(err)
@@ -1372,7 +1368,7 @@ func TestTenantVCS_YAML(t *testing.T) {
 	}
 	for _, test := range tests {
 		// Fix the problem that closure in a for loop will always use the last element.
-		// test := test
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1380,7 +1376,6 @@ func TestTenantVCS_YAML(t *testing.T) {
 			ctl := &controller{}
 			err := ctl.StartServer(ctx, &config{
 				dataDir:            t.TempDir(),
-				port:               getTestPort(t.Name()),
 				vcsProviderCreator: test.vcsProviderCreator,
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
Even with t.Parallel(), the tests are running inside the same process so that we can use a shared integer to allocate the port.