### PR TITLE
feat: introduce sensitive data policy

### DIFF
--- a/api/plan.go
+++ b/api/plan.go
@@ -140,6 +140,8 @@ const (
 	//
 	// e.g. set the tier to "PROTECTED" for the production environment.
 	FeatureEnvironmentTierPolicy FeatureType = "bb.feature.environment-tier-policy"
+	// FeatureSensitiveData allows user to annotate and protect sensitive data.
+	FeatureSensitiveData FeatureType = "bb.feature.sensitive-data"
 )
 
 // Name returns a readable name of the feature.
@@ -188,6 +190,8 @@ func (e FeatureType) Name() string {
 		return "Backup policy"
 	case FeatureEnvironmentTierPolicy:
 		return "Environment tier"
+	case FeatureSensitiveData:
+		return "Sensitive data"
 	}
 	return ""
 }
@@ -297,6 +301,10 @@ var featureMatrix = map[FeatureType]featureConfig{
 		planToggle: [3]bool{false, true, true},
 	},
 	FeatureEnvironmentTierPolicy: {
+		enabled:    true,
+		planToggle: [3]bool{false, false, true},
+	},
+	FeatureSensitiveData: {
 		enabled:    true,
 		planToggle: [3]bool{false, false, true},
 	},

--- a/api/policy.go
+++ b/api/policy.go
@@ -38,6 +38,8 @@ const (
 	PolicyTypeSQLReview PolicyType = "bb.policy.sql-review"
 	// PolicyTypeEnvironmentTier is the tier of an environment.
 	PolicyTypeEnvironmentTier PolicyType = "bb.policy.environment-tier"
+	// PolicyTypeSensitiveData is the sensitive data policy type.
+	PolicyTypeSensitiveData PolicyType = "bb.policy.sensitive-data"
 
 	// PipelineApprovalValueManualNever means the pipeline will automatically be approved without user intervention.
 	PipelineApprovalValueManualNever PipelineApprovalValue = "MANUAL_APPROVAL_NEVER"
@@ -76,12 +78,13 @@ const (
 )
 
 var (
-	// PolicyTypes is a set of all policy types.
-	PolicyTypes = map[PolicyType]bool{
+	// policyTypes is a set of all policy types.
+	policyTypes = map[PolicyType]bool{
 		PolicyTypePipelineApproval: true,
 		PolicyTypeBackupPlan:       true,
 		PolicyTypeSQLReview:        true,
 		PolicyTypeEnvironmentTier:  true,
+		PolicyTypeSensitiveData:    true,
 	}
 )
 
@@ -240,6 +243,44 @@ func (p *EnvironmentTierPolicy) String() (string, error) {
 	return string(s), nil
 }
 
+// SensitiveDataPolicy is the policy configuration for sensitive data.
+// It is only applicable to database resource type.
+type SensitiveDataPolicy struct {
+	SensitiveDataList []SensitiveData `json:"sensitiveDataList"`
+}
+
+// SensitiveData is the value for sensitive data.
+type SensitiveData struct {
+	Table  string            `json:"table"`
+	Column string            `json:"column"`
+	Type   SensitiveDataType `json:"type"`
+}
+
+// SensitiveDataType is the type for sensitive data.
+type SensitiveDataType string
+
+const (
+	// SensitiveDataTypeWildcard is the sensitive data type for using wildcard to hide data.
+	SensitiveDataTypeWildcard SensitiveDataType = "WILDCARD"
+)
+
+// UnmarshalSensitiveDataPolicy will unmarshal payload to sensitive data policy.
+func UnmarshalSensitiveDataPolicy(payload string) (*SensitiveDataPolicy, error) {
+	var p SensitiveDataPolicy
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal sensitive data policy %q", payload)
+	}
+	return &p, nil
+}
+
+func (p *SensitiveDataPolicy) String() (string, error) {
+	s, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	return string(s), nil
+}
+
 // UnmarshalEnvironmentTierPolicy will unmarshal payload to environment tier policy.
 func UnmarshalEnvironmentTierPolicy(payload string) (*EnvironmentTierPolicy, error) {
 	var p EnvironmentTierPolicy
@@ -249,62 +290,89 @@ func UnmarshalEnvironmentTierPolicy(payload string) (*EnvironmentTierPolicy, err
 	return &p, nil
 }
 
-// ValidatePolicy will validate the policy type and payload values.
-func ValidatePolicy(pType PolicyType, payload string) error {
-	if !PolicyTypes[pType] {
+// ValidatePolicType will validate the policy type.
+func ValidatePolicType(pType PolicyType) error {
+	if !policyTypes[pType] {
 		return errors.Errorf("invalid policy type: %s", pType)
 	}
-	if payload == "" {
-		return nil
-	}
-
-	switch pType {
-	case PolicyTypePipelineApproval:
-		pa, err := UnmarshalPipelineApprovalPolicy(payload)
-		if err != nil {
-			return err
-		}
-		if pa.Value != PipelineApprovalValueManualNever && pa.Value != PipelineApprovalValueManualAlways {
-			return errors.Errorf("invalid approval policy value: %q", payload)
-		}
-		issueTypeSeen := make(map[IssueType]bool)
-		for _, group := range pa.AssigneeGroupList {
-			if group.IssueType != IssueDatabaseSchemaUpdate &&
-				group.IssueType != IssueDatabaseSchemaUpdateGhost &&
-				group.IssueType != IssueDatabaseDataUpdate {
-				return errors.Errorf("invalid assignee group issue type %q", group.IssueType)
-			}
-			if issueTypeSeen[group.IssueType] {
-				return errors.Errorf("duplicate assignee group issue type %q", group.IssueType)
-			}
-			issueTypeSeen[group.IssueType] = true
-		}
-	case PolicyTypeBackupPlan:
-		bp, err := UnmarshalBackupPlanPolicy(payload)
-		if err != nil {
-			return err
-		}
-		if bp.Schedule != BackupPlanPolicyScheduleUnset && bp.Schedule != BackupPlanPolicyScheduleDaily && bp.Schedule != BackupPlanPolicyScheduleWeekly {
-			return errors.Errorf("invalid backup plan policy schedule: %q", bp.Schedule)
-		}
-	case PolicyTypeSQLReview:
-		sr, err := UnmarshalSQLReviewPolicy(payload)
-		if err != nil {
-			return err
-		}
-		if err := sr.Validate(); err != nil {
-			return errors.Wrap(err, "invalid SQL review policy")
-		}
-	case PolicyTypeEnvironmentTier:
-		p, err := UnmarshalEnvironmentTierPolicy(payload)
-		if err != nil {
-			return err
-		}
-		if p.EnvironmentTier != EnvironmentTierValueProtected && p.EnvironmentTier != EnvironmentTierValueUnprotected {
-			return errors.Errorf("invalid environment tier value %q", p.EnvironmentTier)
-		}
-	}
 	return nil
+}
+
+// ValidatePolicy will validate the policy resource type, type and payload values.
+func ValidatePolicy(resourceType PolicyResourceType, pType PolicyType, payload *string) error {
+	if payload == nil {
+		return errors.Errorf("empty payload")
+	}
+	switch resourceType {
+	case PolicyResourceTypeEnvironment:
+		switch pType {
+		case PolicyTypePipelineApproval:
+			pa, err := UnmarshalPipelineApprovalPolicy(*payload)
+			if err != nil {
+				return err
+			}
+			if pa.Value != PipelineApprovalValueManualNever && pa.Value != PipelineApprovalValueManualAlways {
+				return errors.Errorf("invalid approval policy value: %q", *payload)
+			}
+			issueTypeSeen := make(map[IssueType]bool)
+			for _, group := range pa.AssigneeGroupList {
+				if group.IssueType != IssueDatabaseSchemaUpdate &&
+					group.IssueType != IssueDatabaseSchemaUpdateGhost &&
+					group.IssueType != IssueDatabaseDataUpdate {
+					return errors.Errorf("invalid assignee group issue type %q", group.IssueType)
+				}
+				if issueTypeSeen[group.IssueType] {
+					return errors.Errorf("duplicate assignee group issue type %q", group.IssueType)
+				}
+				issueTypeSeen[group.IssueType] = true
+			}
+			return nil
+		case PolicyTypeBackupPlan:
+			bp, err := UnmarshalBackupPlanPolicy(*payload)
+			if err != nil {
+				return err
+			}
+			if bp.Schedule != BackupPlanPolicyScheduleUnset && bp.Schedule != BackupPlanPolicyScheduleDaily && bp.Schedule != BackupPlanPolicyScheduleWeekly {
+				return errors.Errorf("invalid backup plan policy schedule: %q", bp.Schedule)
+			}
+			return nil
+		case PolicyTypeSQLReview:
+			sr, err := UnmarshalSQLReviewPolicy(*payload)
+			if err != nil {
+				return err
+			}
+			if err := sr.Validate(); err != nil {
+				return errors.Wrap(err, "invalid SQL review policy")
+			}
+			return nil
+		case PolicyTypeEnvironmentTier:
+			p, err := UnmarshalEnvironmentTierPolicy(*payload)
+			if err != nil {
+				return err
+			}
+			if p.EnvironmentTier != EnvironmentTierValueProtected && p.EnvironmentTier != EnvironmentTierValueUnprotected {
+				return errors.Errorf("invalid environment tier value %q", p.EnvironmentTier)
+			}
+			return nil
+		}
+	case PolicyResourceTypeDatabase:
+		if pType == PolicyTypeSensitiveData {
+			p, err := UnmarshalSensitiveDataPolicy(*payload)
+			if err != nil {
+				return err
+			}
+			for _, v := range p.SensitiveDataList {
+				if v.Table == "" || v.Column == "" {
+					return errors.Errorf("sensitive data policy rule cannot have empty table or column name")
+				}
+				if v.Type != SensitiveDataTypeWildcard {
+					return errors.Errorf("sensitive data policy rule must have type %q", SensitiveDataTypeWildcard)
+				}
+			}
+			return nil
+		}
+	}
+	return errors.Errorf("invalid resource type %s and policy type %s", resourceType, pType)
 }
 
 // GetDefaultPolicy will return the default value for the given policy type.
@@ -328,6 +396,9 @@ func GetDefaultPolicy(pType PolicyType) (string, error) {
 		policy := EnvironmentTierPolicy{
 			EnvironmentTier: EnvironmentTierValueUnprotected,
 		}
+		return policy.String()
+	case PolicyTypeSensitiveData:
+		policy := SensitiveDataPolicy{}
 		return policy.String()
 	}
 	return "", nil

--- a/api/policy.go
+++ b/api/policy.go
@@ -120,7 +120,7 @@ type PolicyFind struct {
 	ResourceID   *int
 
 	// Domain specific fields
-	Type *PolicyType `jsonapi:"attr,type"`
+	Type PolicyType `jsonapi:"attr,type"`
 }
 
 // PolicyUpsert is the message to upsert a policy.

--- a/server/policy.go
+++ b/server/policy.go
@@ -150,7 +150,7 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 		policyFind := &api.PolicyFind{
 			ResourceType: &resourceType,
 			ResourceID:   &resourceID,
-			Type:         &pType,
+			Type:         pType,
 		}
 		policy, err := s.store.GetPolicy(ctx, policyFind)
 		if err != nil {
@@ -189,7 +189,7 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 		policyFind := &api.PolicyFind{
 			ResourceType: resourceType,
 			ResourceID:   resourceID,
-			Type:         &pType,
+			Type:         pType,
 		}
 
 		ctx := c.Request().Context()

--- a/server/policy.go
+++ b/server/policy.go
@@ -44,6 +44,10 @@ func (s *Server) hasAccessToUpsertPolicy(policyUpsert *api.PolicyUpsert) error {
 		if !s.feature(api.FeatureEnvironmentTierPolicy) {
 			return errors.Errorf(api.FeatureEnvironmentTierPolicy.AccessErrorMessage())
 		}
+	case api.PolicyTypeSensitiveData:
+		if !s.feature(api.FeatureSensitiveData) {
+			return errors.Errorf(api.FeatureSensitiveData.AccessErrorMessage())
+		}
 	}
 	return nil
 }
@@ -59,10 +63,9 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 		}
-
 		pType := api.PolicyType(c.QueryParam("type"))
-		if err := api.ValidatePolicy(pType, ""); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid policy type: %q", pType)).SetInternal(err)
+		if err := api.ValidatePolicType(pType); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 		}
 		policyUpsert := &api.PolicyUpsert{
 			ResourceType: resourceType,
@@ -76,6 +79,11 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 
 		if err := s.hasAccessToUpsertPolicy(policyUpsert); err != nil {
 			return echo.NewHTTPError(http.StatusForbidden, err.Error()).SetInternal(err)
+		}
+
+		// Validate policy.
+		if err := api.ValidatePolicy(policyUpsert.ResourceType, policyUpsert.Type, policyUpsert.Payload); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid policy payload %s", err.Error())).SetInternal(err)
 		}
 
 		policy, err := s.store.UpsertPolicy(ctx, policyUpsert)
@@ -103,10 +111,14 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 		}
+		pType := api.PolicyType(c.QueryParam("type"))
+		if err := api.ValidatePolicType(pType); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+		}
 		policyDelete := &api.PolicyDelete{
 			ResourceType: resourceType,
 			ResourceID:   resourceID,
-			Type:         api.PolicyType(c.QueryParam("type")),
+			Type:         pType,
 			DeleterID:    c.Get(getPrincipalIDContextKey()).(int),
 		}
 		if err := s.store.DeletePolicy(ctx, policyDelete); err != nil {
@@ -132,8 +144,8 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 		}
 		pType := api.PolicyType(c.QueryParam("type"))
-		if err := api.ValidatePolicy(pType, ""); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid policy type: %q", pType)).SetInternal(err)
+		if err := api.ValidatePolicType(pType); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 		}
 		policyFind := &api.PolicyFind{
 			ResourceType: &resourceType,
@@ -153,10 +165,6 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 	})
 
 	g.GET("/policy", func(c echo.Context) error {
-		pType := api.PolicyType(c.QueryParam("type"))
-		if err := api.ValidatePolicy(pType, ""); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid policy type: %q", pType)).SetInternal(err)
-		}
 		var resourceType *api.PolicyResourceType
 		var resourceID *int
 		if c.QueryParam("resourceType") != "" {
@@ -173,6 +181,11 @@ func (s *Server) registerPolicyRoutes(g *echo.Group) {
 			}
 			resourceID = &id
 		}
+		pType := api.PolicyType(c.QueryParam("type"))
+		if err := api.ValidatePolicType(pType); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+		}
+
 		policyFind := &api.PolicyFind{
 			ResourceType: resourceType,
 			ResourceID:   resourceID,

--- a/store/policy.go
+++ b/store/policy.go
@@ -136,12 +136,6 @@ func (s *Store) DeletePolicy(ctx context.Context, policyDelete *api.PolicyDelete
 
 // ListPolicy gets a list of policy by PolicyFind.
 func (s *Store) ListPolicy(ctx context.Context, find *api.PolicyFind) ([]*api.Policy, error) {
-	// Validate policy type existence.
-	if find.Type != nil && *find.Type != "" {
-		if err := api.ValidatePolicy(*find.Type, ""); err != nil {
-			return nil, &common.Error{Code: common.Invalid, Err: err}
-		}
-	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
@@ -291,12 +285,6 @@ func (s *Store) composePolicy(ctx context.Context, raw *policyRaw) (*api.Policy,
 // getPolicyRaw finds the policy for an environment.
 // Returns ECONFLICT if finding more than 1 matching records.
 func (s *Store) getPolicyRaw(ctx context.Context, find *api.PolicyFind) (*policyRaw, error) {
-	// Validate policy type existence.
-	if find.Type != nil && *find.Type != "" {
-		if err := api.ValidatePolicy(*find.Type, ""); err != nil {
-			return nil, &common.Error{Code: common.Invalid, Err: err}
-		}
-	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)
@@ -465,12 +453,6 @@ func findPolicyImpl(ctx context.Context, tx *Tx, find *api.PolicyFind, mode comm
 
 // upsertPolicyRaw sets a policy for an environment.
 func (s *Store) upsertPolicyRaw(ctx context.Context, upsert *api.PolicyUpsert) (*policyRaw, error) {
-	// Validate policy.
-	if upsert.Type != "" && upsert.Payload != nil {
-		if err := api.ValidatePolicy(upsert.Type, *upsert.Payload); err != nil {
-			return nil, &common.Error{Code: common.Invalid, Err: err}
-		}
-	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, FormatError(err)

--- a/store/policy.go
+++ b/store/policy.go
@@ -106,7 +106,7 @@ func (s *Store) DeletePolicy(ctx context.Context, policyDelete *api.PolicyDelete
 	find := &api.PolicyFind{
 		ResourceType: &policyDelete.ResourceType,
 		ResourceID:   &policyDelete.ResourceID,
-		Type:         &policyDelete.Type,
+		Type:         policyDelete.Type,
 	}
 	policyRawList, err := findPolicyImpl(ctx, tx, find, s.db.mode)
 	if err != nil {
@@ -162,11 +162,10 @@ func (s *Store) ListPolicy(ctx context.Context, find *api.PolicyFind) ([]*api.Po
 // GetBackupPlanPolicyByEnvID will get the backup plan policy for an environment.
 func (s *Store) GetBackupPlanPolicyByEnvID(ctx context.Context, environmentID int) (*api.BackupPlanPolicy, error) {
 	environmentResourceType := api.PolicyResourceTypeEnvironment
-	pType := api.PolicyTypeBackupPlan
 	policy, err := s.getPolicyRaw(ctx, &api.PolicyFind{
 		ResourceType: &environmentResourceType,
 		ResourceID:   &environmentID,
-		Type:         &pType,
+		Type:         api.PolicyTypeBackupPlan,
 	})
 	if err != nil {
 		return nil, err
@@ -176,12 +175,11 @@ func (s *Store) GetBackupPlanPolicyByEnvID(ctx context.Context, environmentID in
 
 // GetPipelineApprovalPolicy will get the pipeline approval policy for an environment.
 func (s *Store) GetPipelineApprovalPolicy(ctx context.Context, environmentID int) (*api.PipelineApprovalPolicy, error) {
-	pType := api.PolicyTypePipelineApproval
 	environmentResourceType := api.PolicyResourceTypeEnvironment
 	policy, err := s.getPolicyRaw(ctx, &api.PolicyFind{
 		ResourceType: &environmentResourceType,
 		ResourceID:   &environmentID,
-		Type:         &pType,
+		Type:         api.PolicyTypePipelineApproval,
 	})
 	if err != nil {
 		return nil, err
@@ -196,9 +194,8 @@ func (s *Store) GetNormalSQLReviewPolicy(ctx context.Context, find *api.PolicyFi
 	}
 
 	environmentResourceType := api.PolicyResourceTypeEnvironment
-	pType := api.PolicyTypeSQLReview
 	find.ResourceType = &environmentResourceType
-	find.Type = &pType
+	find.Type = api.PolicyTypeSQLReview
 	policy, err := s.getPolicyRaw(ctx, find)
 	if err != nil {
 		return nil, err
@@ -215,11 +212,10 @@ func (s *Store) GetNormalSQLReviewPolicy(ctx context.Context, find *api.PolicyFi
 // GetSQLReviewPolicyIDByEnvID will get the SQL review policy ID for an environment.
 func (s *Store) GetSQLReviewPolicyIDByEnvID(ctx context.Context, environmentID int) (int, error) {
 	environmentResourceType := api.PolicyResourceTypeEnvironment
-	pType := api.PolicyTypeSQLReview
 	policy, err := s.getPolicyRaw(ctx, &api.PolicyFind{
 		ResourceType: &environmentResourceType,
 		ResourceID:   &environmentID,
-		Type:         &pType,
+		Type:         api.PolicyTypeSQLReview,
 	})
 	if err != nil {
 		return 0, err
@@ -236,11 +232,10 @@ func (s *Store) GetEnvironmentTierPolicyByEnvID(ctx context.Context, environment
 	}
 	if !ok {
 		environmentResourceType := api.PolicyResourceTypeEnvironment
-		pType := api.PolicyTypeEnvironmentTier
 		p, err := s.getPolicyRaw(ctx, &api.PolicyFind{
 			ResourceType: &environmentResourceType,
 			ResourceID:   &environmentID,
-			Type:         &pType,
+			Type:         api.PolicyTypeEnvironmentTier,
 		})
 		if err != nil {
 			return nil, err
@@ -301,7 +296,7 @@ func (s *Store) getPolicyRaw(ctx context.Context, find *api.PolicyFind) (*policy
 		ret = &policyRaw{
 			CreatorID: api.SystemBotID,
 			UpdaterID: api.SystemBotID,
-			Type:      *find.Type,
+			Type:      find.Type,
 		}
 		if find.ResourceType != nil {
 			ret.ResourceType = *find.ResourceType
@@ -317,7 +312,7 @@ func (s *Store) getPolicyRaw(ctx context.Context, find *api.PolicyFind) (*policy
 
 	if ret.Payload == "" {
 		// Return the default policy when there is no stored policy.
-		payload, err := api.GetDefaultPolicy(*find.Type)
+		payload, err := api.GetDefaultPolicy(find.Type)
 		if err != nil {
 			return nil, &common.Error{Code: common.Internal, Err: err}
 		}
@@ -341,9 +336,7 @@ func findPolicyImpl(ctx context.Context, tx *Tx, find *api.PolicyFind, mode comm
 		if v := find.ResourceID; v != nil {
 			where, args = append(where, fmt.Sprintf("resource_id = $%d", len(args)+1)), append(args, *v)
 		}
-		if v := find.Type; v != nil {
-			where, args = append(where, fmt.Sprintf("type = $%d", len(args)+1)), append(args, *v)
-		}
+		where, args = append(where, fmt.Sprintf("type = $%d", len(args)+1)), append(args, find.Type)
 
 		rows, err := tx.QueryContext(ctx, `
 		SELECT
@@ -400,9 +393,7 @@ func findPolicyImpl(ctx context.Context, tx *Tx, find *api.PolicyFind, mode comm
 	if v := find.ResourceID; v != nil {
 		where, args = append(where, fmt.Sprintf("environment_id = $%d", len(args)+1)), append(args, *v)
 	}
-	if v := find.Type; v != nil {
-		where, args = append(where, fmt.Sprintf("type = $%d", len(args)+1)), append(args, *v)
-	}
+	where, args = append(where, fmt.Sprintf("type = $%d", len(args)+1)), append(args, find.Type)
 
 	rows, err := tx.QueryContext(ctx, `
 		SELECT


### PR DESCRIPTION
Sensitive data policy is only supported at database level.

curl 'http://localhost:3000/api/policy/database/103?type=bb.policy.sensitive-data' \
  -X 'PATCH' \
  --data-raw '{"data":{"type":"policyUpsert","attributes":{"payload":"{\"sensitiveDataList\":[{\"table\":\"hello\",\"column\":\"world\",\"type\":\"WILDCARD\"}]}"}}}' \
  --compressed