### PR TITLE
chore: use mask in the name

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -256,7 +256,7 @@ type SensitiveData struct {
 	Type   SensitiveDataMaskType `json:"type"`
 }
 
-// SensitiveDataMaskType is the type for sensitive data.
+// SensitiveDataMaskType is the mask type for sensitive data.
 type SensitiveDataMaskType string
 
 const (

--- a/api/policy.go
+++ b/api/policy.go
@@ -253,7 +253,7 @@ type SensitiveDataPolicy struct {
 type SensitiveData struct {
 	Table  string                `json:"table"`
 	Column string                `json:"column"`
-	Type   SensitiveDataMaskType `json:"type"`
+	Type   SensitiveDataMaskType `json:"maskType"`
 }
 
 // SensitiveDataMaskType is the mask type for sensitive data.

--- a/api/policy.go
+++ b/api/policy.go
@@ -251,17 +251,17 @@ type SensitiveDataPolicy struct {
 
 // SensitiveData is the value for sensitive data.
 type SensitiveData struct {
-	Table  string            `json:"table"`
-	Column string            `json:"column"`
-	Type   SensitiveDataType `json:"type"`
+	Table  string                `json:"table"`
+	Column string                `json:"column"`
+	Type   SensitiveDataMaskType `json:"type"`
 }
 
-// SensitiveDataType is the type for sensitive data.
-type SensitiveDataType string
+// SensitiveDataMaskType is the type for sensitive data.
+type SensitiveDataMaskType string
 
 const (
-	// SensitiveDataTypeWildcard is the sensitive data type for using wildcard to hide data.
-	SensitiveDataTypeWildcard SensitiveDataType = "WILDCARD"
+	// SensitiveDataMaskTypeWildcard is the sensitive data type for using wildcard to hide data.
+	SensitiveDataMaskTypeWildcard SensitiveDataMaskType = "WILDCARD"
 )
 
 // UnmarshalSensitiveDataPolicy will unmarshal payload to sensitive data policy.
@@ -365,14 +365,14 @@ func ValidatePolicy(resourceType PolicyResourceType, pType PolicyType, payload *
 				if v.Table == "" || v.Column == "" {
 					return errors.Errorf("sensitive data policy rule cannot have empty table or column name")
 				}
-				if v.Type != SensitiveDataTypeWildcard {
-					return errors.Errorf("sensitive data policy rule must have type %q", SensitiveDataTypeWildcard)
+				if v.Type != SensitiveDataMaskTypeWildcard {
+					return errors.Errorf("sensitive data policy rule must have type %q", SensitiveDataMaskTypeWildcard)
 				}
 			}
 			return nil
 		}
 	}
-	return errors.Errorf("invalid resource type %s and policy type %s", resourceType, pType)
+	return errors.Errorf("invalid resource type %s and policy type %s pair", resourceType, pType)
 }
 
 // GetDefaultPolicy will return the default value for the given policy type.

--- a/api/policy.go
+++ b/api/policy.go
@@ -260,8 +260,8 @@ type SensitiveData struct {
 type SensitiveDataMaskType string
 
 const (
-	// SensitiveDataMaskTypeWildcard is the sensitive data type for using wildcard to hide data.
-	SensitiveDataMaskTypeWildcard SensitiveDataMaskType = "WILDCARD"
+	// SensitiveDataMaskTypeDefault is the sensitive data type to hide data with a default method.
+	SensitiveDataMaskTypeDefault SensitiveDataMaskType = "DEFAULT"
 )
 
 // UnmarshalSensitiveDataPolicy will unmarshal payload to sensitive data policy.
@@ -365,8 +365,8 @@ func ValidatePolicy(resourceType PolicyResourceType, pType PolicyType, payload *
 				if v.Table == "" || v.Column == "" {
 					return errors.Errorf("sensitive data policy rule cannot have empty table or column name")
 				}
-				if v.Type != SensitiveDataMaskTypeWildcard {
-					return errors.Errorf("sensitive data policy rule must have type %q", SensitiveDataMaskTypeWildcard)
+				if v.Type != SensitiveDataMaskTypeDefault {
+					return errors.Errorf("sensitive data policy rule must have type %q", SensitiveDataMaskTypeDefault)
 				}
 			}
 			return nil

--- a/api/policy.go
+++ b/api/policy.go
@@ -261,6 +261,7 @@ type SensitiveDataMaskType string
 
 const (
 	// SensitiveDataMaskTypeDefault is the sensitive data type to hide data with a default method.
+	// The default method is subject to change.
 	SensitiveDataMaskTypeDefault SensitiveDataMaskType = "DEFAULT"
 )
 

--- a/api/policy.go
+++ b/api/policy.go
@@ -367,7 +367,7 @@ func ValidatePolicy(resourceType PolicyResourceType, pType PolicyType, payload *
 					return errors.Errorf("sensitive data policy rule cannot have empty table or column name")
 				}
 				if v.Type != SensitiveDataMaskTypeDefault {
-					return errors.Errorf("sensitive data policy rule must have type %q", SensitiveDataMaskTypeDefault)
+					return errors.Errorf("sensitive data policy rule must have mask type %q", SensitiveDataMaskTypeDefault)
 				}
 			}
 			return nil


### PR DESCRIPTION
Still keep WILDCARD for the enum name instead of default. I'd like to avoid having default value, and the mask type is required.