### PR TITLE
chore: precheck server port availability

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -67,6 +67,7 @@ type Profile struct {
 	DisableMetric bool
 }
 
-func (prof *Profile) useEmbedDB() bool {
+// UseEmbedDB returns whether to use embedDB
+func (prof *Profile) UseEmbedDB() bool {
 	return len(prof.PgURL) == 0
 }

--- a/server/config.go
+++ b/server/config.go
@@ -67,7 +67,7 @@ type Profile struct {
 	DisableMetric bool
 }
 
-// UseEmbedDB returns whether to use embedDB
+// UseEmbedDB returns whether to use embedDB.
 func (prof *Profile) UseEmbedDB() bool {
 	return len(prof.PgURL) == 0
 }

--- a/server/server.go
+++ b/server/server.go
@@ -152,7 +152,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 
 	// Install Postgres.
 	var pgDataDir string
-	if prof.useEmbedDB() {
+	if prof.UseEmbedDB() {
 		pgDataDir = common.GetPostgresDataDir(prof.DataDir)
 	}
 	log.Info("-----Embedded Postgres Config BEGIN-----")
@@ -171,7 +171,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 	s.pgInstance = pgInstance
 
 	// New MetadataDB instance.
-	if prof.useEmbedDB() {
+	if prof.UseEmbedDB() {
 		s.metaDB = store.NewMetadataDBWithEmbedPg(pgInstance, prof.PgUser, prof.DemoDataDir, prof.Mode)
 	} else {
 		s.metaDB = store.NewMetadataDBWithExternalPg(pgInstance, prof.PgURL, prof.DemoDataDir, prof.Mode)

--- a/server/server.go
+++ b/server/server.go
@@ -521,7 +521,7 @@ func (s *Server) Run(ctx context.Context, port int) error {
 	s.cancel = cancel
 	if !s.profile.Readonly {
 		if err := s.TaskScheduler.ClearRunningTasks(ctx); err != nil {
-			return errors.Wrap(err, "failed to clear existing RUNNING tasks before start the task scheduler")
+			return errors.Wrap(err, "failed to clear existing RUNNING tasks before starting the task scheduler")
 		}
 		// runnerWG waits for all goroutines to complete.
 		s.runnerWG.Add(1)
@@ -550,8 +550,8 @@ func (s *Server) Run(ctx context.Context, port int) error {
 
 // Shutdown will shut down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	log.Info("Trying to stop Bytebase ....")
-	log.Info("Trying to gracefully shutdown server")
+	log.Info("Trying to stop Bytebase...")
+	log.Info("Trying to gracefully shutdown server...")
 
 	// Close the metric reporter
 	if s.MetricReporter != nil {


### PR DESCRIPTION
![CleanShot 2022-11-21 at 15 08 29](https://user-images.githubusercontent.com/230323/202989862-d99fd4dd-d31d-4161-87b1-bd5593370f8c.png)

Benefits:

1. Give the user a clean failure log. Previously, a bunch of runners have already started and emitted logs
2. Reduce side effects. We want to avoid that we start Bytebase, does the possible schema migration, and then find we are unable to start server.
