### PR TITLE
feat: support convert create sequence statement

### DIFF
--- a/plugin/parser/ast/create_sequence_stmt.go
+++ b/plugin/parser/ast/create_sequence_stmt.go
@@ -1,19 +1,5 @@
 package ast
 
-// SequenceDataType is the type of a sequence data.
-type SequenceDataType int
-
-const (
-	// SequenceDataTypeUnknown is the unknown sequence data type.
-	SequenceDataTypeUnknown SequenceDataType = iota
-	// SequenceDataTypeSmallInt is the smallint sequence data type.
-	SequenceDataTypeSmallInt
-	// SequenceDataTypeInteger is the integer sequence data type.
-	SequenceDataTypeInteger
-	// SequenceDataTypeBigInt is the bigint sequence data type.
-	SequenceDataTypeBigInt
-)
-
 // SequenceNameDef is the name of a sequence.
 type SequenceNameDef struct {
 	Schema string
@@ -27,7 +13,7 @@ type CreateSequenceStmt struct {
 
 	SequenceName     SequenceNameDef
 	IfNotExists      bool
-	SequenceDataType SequenceDataType
+	SequenceDataType *Integer
 	// No cycle is default
 	Cycle       bool
 	StartWith   *int32

--- a/plugin/parser/ast/create_sequence_stmt.go
+++ b/plugin/parser/ast/create_sequence_stmt.go
@@ -1,25 +1,9 @@
 package ast
 
-// SequenceNameDef is the name of a sequence.
-type SequenceNameDef struct {
-	Schema string
-	Name   string
-}
-
 // CreateSequenceStmt is a statement to create a sequence.
 // https://www.postgresql.org/docs/13/sql-createsequence.html
 type CreateSequenceStmt struct {
 	ddl
-
-	SequenceName     SequenceNameDef
-	IfNotExists      bool
-	SequenceDataType *Integer
-	// No cycle is default
-	Cycle       bool
-	StartWith   *int32
-	IncrementBy *int32
-	MinValue    *int32
-	MaxValue    *int32
-	Cache       *int32
-	OwnedBy     *ColumnNameDef
+	SequenceDef SequenceDef
+	IfNotExists bool
 }

--- a/plugin/parser/ast/create_sequence_stmt.go
+++ b/plugin/parser/ast/create_sequence_stmt.go
@@ -1,0 +1,33 @@
+package ast
+
+type SequenceDataType int
+
+const (
+	SequenceDataTypeUnknown SequenceDataType = iota
+	SequenceDataTypeSmallInt
+	SequenceDataTypeInteger
+	SequenceDataTypeBigInt
+)
+
+type SequenceNameDef struct {
+	Schema string
+	Name   string
+}
+
+// CreateSequenceStmt is a statement to create a sequence.
+// https://www.postgresql.org/docs/13/sql-createsequence.html
+type CreateSequenceStmt struct {
+	ddl
+
+	SequenceName     SequenceNameDef
+	IfNotExists      bool
+	SequenceDataType SequenceDataType
+	// No cycle is default
+	Cycle       bool
+	StartWith   *int32
+	IncrementBy *int32
+	MinValue    *int32
+	MaxValue    *int32
+	Cache       *int32
+	OwnedBy     *ColumnNameDef
+}

--- a/plugin/parser/ast/create_sequence_stmt.go
+++ b/plugin/parser/ast/create_sequence_stmt.go
@@ -1,14 +1,20 @@
 package ast
 
+// SequenceDataType is the type of a sequence data.
 type SequenceDataType int
 
 const (
+	// SequenceDataTypeUnknown is the unknown sequence data type.
 	SequenceDataTypeUnknown SequenceDataType = iota
+	// SequenceDataTypeSmallInt is the smallint sequence data type.
 	SequenceDataTypeSmallInt
+	// SequenceDataTypeInteger is the integer sequence data type.
 	SequenceDataTypeInteger
+	// SequenceDataTypeBigInt is the bigint sequence data type.
 	SequenceDataTypeBigInt
 )
 
+// SequenceNameDef is the name of a sequence.
 type SequenceNameDef struct {
 	Schema string
 	Name   string

--- a/plugin/parser/ast/sequence_def.go
+++ b/plugin/parser/ast/sequence_def.go
@@ -1,0 +1,23 @@
+package ast
+
+// SequenceNameDef is the name of a sequence.
+type SequenceNameDef struct {
+	Schema string
+	Name   string
+}
+
+// SequenceDef is the struct for sequence definition.
+type SequenceDef struct {
+	node
+
+	SequenceName     SequenceNameDef
+	SequenceDataType *Integer
+	// No cycle is default
+	Cycle       bool
+	StartWith   *int32
+	IncrementBy *int32
+	MinValue    *int32
+	MaxValue    *int32
+	Cache       *int32
+	OwnedBy     *ColumnNameDef
+}

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -1248,28 +1248,28 @@ func convertDefElemNodeIntegerToInt32(defElem *pgquery.DefElem) (*int32, error) 
 	return &val, nil
 }
 
-func convertDefElemToSeqType(defElem *pgquery.DefElem) (ast.SequenceDataType, error) {
+func convertDefElemToSeqType(defElem *pgquery.DefElem) (*ast.Integer, error) {
 	typeNameNode, ok := defElem.Arg.Node.(*pgquery.Node_TypeName)
 	if !ok {
-		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected TypeName but found %T", defElem.Arg.Node)
+		return nil, parser.NewConvertErrorf("expected TypeName but found %T", defElem.Arg.Node)
 	}
 	if len(typeNameNode.TypeName.Names) != 2 {
-		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected TypeName with 2 names but found %d", len(typeNameNode.TypeName.Names))
+		return nil, parser.NewConvertErrorf("expected TypeName with 2 names but found %d", len(typeNameNode.TypeName.Names))
 	}
 	// typeNameNode.TypeName.Names[0] should be 'pg_catalog'
 	nodeStr, ok := typeNameNode.TypeName.Names[1].Node.(*pgquery.Node_String_)
 	if !ok {
-		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected String but found %T", typeNameNode.TypeName.Names[1].Node)
+		return nil, parser.NewConvertErrorf("expected String but found %T", typeNameNode.TypeName.Names[1].Node)
 	}
 	switch nodeStr.String_.Str {
 	case "int2":
-		return ast.SequenceDataTypeSmallInt, nil
+		return &ast.Integer{Size: 2}, nil
 	case "int4":
-		return ast.SequenceDataTypeInteger, nil
+		return &ast.Integer{Size: 4}, nil
 	case "int8":
-		return ast.SequenceDataTypeBigInt, nil
+		return &ast.Integer{Size: 8}, nil
 	default:
-		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected int2, int4, or int8 but found %s", nodeStr.String_.Str)
+		return nil, parser.NewConvertErrorf("expected int2, int4, or int8 but found %s", nodeStr.String_.Str)
 	}
 }
 

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -359,6 +359,56 @@ func convert(node *pgquery.Node, statement parser.SingleSQL) (res ast.Node, err 
 			}
 		}
 		return deleteStmt, nil
+	case *pgquery.Node_CreateSeqStmt:
+		createSeqStmt := &ast.CreateSequenceStmt{}
+		if in.CreateSeqStmt.Sequence == nil {
+			// Unexpected case.
+			return nil, parser.NewConvertErrorf("CreateSeqStmt.Sequence is nil")
+		}
+		createSeqStmt.SequenceName = convertRangeVarToSeqName(in.CreateSeqStmt.Sequence)
+		for _, option := range in.CreateSeqStmt.Options {
+			defElemNode, ok := option.Node.(*pgquery.Node_DefElem)
+			if !ok {
+				return nil, parser.NewConvertErrorf("expected DefElem but found %t", option.Node)
+			}
+			switch defElemNode.DefElem.Defname {
+			case "as":
+				if createSeqStmt.SequenceDataType, err = convertDefElemToSeqType(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			case "increment":
+				if createSeqStmt.IncrementBy, err = convertDefElemNodeIntegerToInt32(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			case "start":
+				if createSeqStmt.StartWith, err = convertDefElemNodeIntegerToInt32(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			case "minvalue":
+				if createSeqStmt.MinValue, err = convertDefElemNodeIntegerToInt32(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			case "maxvalue":
+				if createSeqStmt.MaxValue, err = convertDefElemNodeIntegerToInt32(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			case "cache":
+				if createSeqStmt.Cache, err = convertDefElemNodeIntegerToInt32(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			case "cycle":
+				if createSeqStmt.Cycle, err = convertDefElemNodeIntegerToBool(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			case "owned_by":
+				if createSeqStmt.OwnedBy, err = convertDefElemNodeListToColumnNameDef(defElemNode.DefElem); err != nil {
+					return nil, err
+				}
+			default:
+				return nil, parser.NewConvertErrorf("unsupported option %s", defElemNode.DefElem.Defname)
+			}
+		}
+		return createSeqStmt, nil
 	case *pgquery.Node_AlterObjectSchemaStmt:
 		switch in.AlterObjectSchemaStmt.ObjectType {
 		case pgquery.ObjectType_OBJECT_TABLE:
@@ -592,51 +642,8 @@ func convertExpressionNode(node *pgquery.Node) (ast.ExpressionNode, []*ast.Patte
 		}
 		return &ast.UnconvertedExpressionDef{}, likeList, subqueryList, nil
 	case *pgquery.Node_ColumnRef:
-		columnName := &ast.ColumnNameDef{Table: &ast.TableDef{}}
-		list := in.ColumnRef.Fields
-		// There are three cases for column name:
-		//   1. schemaName.tableName.columnName
-		//   2. tableName.columnName
-		//   3. columnName
-		// The pg parser will split them by ".", and use a list to define it.
-		// So we need to consider this three cases.
-		switch len(in.ColumnRef.Fields) {
-		// schemaName.tableName.columName
-		case 3:
-			schema, ok := list[0].Node.(*pgquery.Node_String_)
-			if !ok {
-				return nil, nil, nil, parser.NewConvertErrorf("expected String but found %t", in.ColumnRef.Fields[2].Node)
-			}
-			columnName.Table.Schema = schema.String_.Str
-			// need to convert tableName.columnName
-			list = list[1:]
-			fallthrough
-		// tableName.columnName
-		case 2:
-			table, ok := list[0].Node.(*pgquery.Node_String_)
-			if !ok {
-				return nil, nil, nil, parser.NewConvertErrorf("expected String but found %t", in.ColumnRef.Fields[1].Node)
-			}
-			columnName.Table.Name = table.String_.Str
-			// need to convert columnName
-			list = list[1:]
-			fallthrough
-		// columnName
-		case 1:
-			switch column := list[0].Node.(type) {
-			// column name
-			case *pgquery.Node_String_:
-				columnName.ColumnName = column.String_.Str
-			// e.g. SELECT * FROM t;
-			case *pgquery.Node_AStar:
-				columnName.ColumnName = "*"
-			default:
-				return nil, nil, nil, parser.NewConvertErrorf("expected String or AStar but found %t", in.ColumnRef.Fields[0].Node)
-			}
-		default:
-			return nil, nil, nil, parser.NewConvertErrorf("failed to convert ColumnRef, column name contains unexpected components: %v", in)
-		}
-		return columnName, nil, nil, nil
+		columnDef, err := convertNodeListToColumnNameDef(in.ColumnRef.Fields)
+		return columnDef, nil, nil, err
 	case *pgquery.Node_FuncCall:
 		var likeList []*ast.PatternLikeDef
 		var subqueryList []*ast.SubqueryDef
@@ -880,6 +887,13 @@ func convertRangeVarToTableName(in *pgquery.RangeVar, tableType ast.TableType) *
 		Database: in.Catalogname,
 		Schema:   in.Schemaname,
 		Name:     in.Relname,
+	}
+}
+
+func convertRangeVarToSeqName(in *pgquery.RangeVar) ast.SequenceNameDef {
+	return ast.SequenceNameDef{
+		Schema: in.Schemaname,
+		Name:   in.Relname,
 	}
 }
 
@@ -1201,4 +1215,107 @@ func convertToInteger(in *pgquery.Node) (int, bool) {
 		return 0, false
 	}
 	return int(integer.Integer.Ival), true
+}
+
+func convertDefElemNodeListToColumnNameDef(defElem *pgquery.DefElem) (*ast.ColumnNameDef, error) {
+	listNode, ok := defElem.Arg.Node.(*pgquery.Node_List)
+	if !ok {
+		return nil, parser.NewConvertErrorf("expected List but found %T", defElem.Arg.Node)
+	}
+	return convertNodeListToColumnNameDef(listNode.List.Items)
+}
+
+func convertDefElemNodeIntegerToBool(defElem *pgquery.DefElem) (bool, error) {
+	if defElem.Arg == nil {
+		return false, nil
+	}
+	interger, ok := defElem.Arg.Node.(*pgquery.Node_Integer)
+	if !ok {
+		return false, parser.NewConvertErrorf("expected integer but found %T", defElem.Arg.Node)
+	}
+	return interger.Integer.Ival == 1, nil
+}
+
+func convertDefElemNodeIntegerToInt32(defElem *pgquery.DefElem) (*int32, error) {
+	if defElem.Arg == nil {
+		return nil, nil
+	}
+	interger, ok := defElem.Arg.Node.(*pgquery.Node_Integer)
+	if !ok {
+		return nil, parser.NewConvertErrorf("expected integer but found %T", defElem.Arg.Node)
+	}
+	val := interger.Integer.Ival
+	return &val, nil
+}
+
+func convertDefElemToSeqType(defElem *pgquery.DefElem) (ast.SequenceDataType, error) {
+	typeNameNode, ok := defElem.Arg.Node.(*pgquery.Node_TypeName)
+	if !ok {
+		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected TypeName but found %T", defElem.Arg.Node)
+	}
+	if len(typeNameNode.TypeName.Names) != 2 {
+		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected TypeName with 2 names but found %d", len(typeNameNode.TypeName.Names))
+	}
+	// typeNameNode.TypeName.Names[0] should be 'pg_catalog'
+	nodeStr, ok := typeNameNode.TypeName.Names[1].Node.(*pgquery.Node_String_)
+	if !ok {
+		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected String but found %T", typeNameNode.TypeName.Names[1].Node)
+	}
+	switch nodeStr.String_.Str {
+	case "int2":
+		return ast.SequenceDataTypeSmallInt, nil
+	case "int4":
+		return ast.SequenceDataTypeInteger, nil
+	case "int8":
+		return ast.SequenceDataTypeBigInt, nil
+	default:
+		return ast.SequenceDataTypeUnknown, parser.NewConvertErrorf("expected int2, int4, or int8 but found %s", nodeStr.String_.Str)
+	}
+}
+
+func convertNodeListToColumnNameDef(in []*pgquery.Node) (*ast.ColumnNameDef, error) {
+	columnName := &ast.ColumnNameDef{Table: &ast.TableDef{}}
+	// There are three cases for column name:
+	//   1. schemaName.tableName.columnName
+	//   2. tableName.columnName
+	//   3. columnName
+	// The pg parser will split them by ".", and use a list to define it.
+	// So we need to consider this three cases.
+	switch len(in) {
+	// schemaName.tableName.columName
+	case 3:
+		schema, ok := in[0].Node.(*pgquery.Node_String_)
+		if !ok {
+			return nil, parser.NewConvertErrorf("expected String but found %t", in[2].Node)
+		}
+		columnName.Table.Schema = schema.String_.Str
+		// need to convert tableName.columnName
+		in = in[1:]
+		fallthrough
+	// tableName.columnName
+	case 2:
+		table, ok := in[0].Node.(*pgquery.Node_String_)
+		if !ok {
+			return nil, parser.NewConvertErrorf("expected String but found %t", in[1].Node)
+		}
+		columnName.Table.Name = table.String_.Str
+		// need to convert columnName
+		in = in[1:]
+		fallthrough
+	// columnName
+	case 1:
+		switch column := in[0].Node.(type) {
+		// column name
+		case *pgquery.Node_String_:
+			columnName.ColumnName = column.String_.Str
+		// e.g. SELECT * FROM t;
+		case *pgquery.Node_AStar:
+			columnName.ColumnName = "*"
+		default:
+			return nil, parser.NewConvertErrorf("expected String or AStar but found %t", in[0].Node)
+		}
+	default:
+		return nil, parser.NewConvertErrorf("failed to convert ColumnRef, column name contains unexpected components: %v", in)
+	}
+	return columnName, nil
 }

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -2376,13 +2376,15 @@ func TestCreateSequence(t *testing.T) {
 						Schema: "public",
 						Name:   "tbl_seq_id_seq",
 					},
-					SequenceDataType: ast.SequenceDataTypeInteger,
-					IncrementBy:      &one,
-					StartWith:        &one,
-					MinValue:         &one,
-					MaxValue:         &one,
-					Cache:            &one,
-					Cycle:            true,
+					SequenceDataType: &ast.Integer{
+						Size: 4,
+					},
+					IncrementBy: &one,
+					StartWith:   &one,
+					MinValue:    &one,
+					MaxValue:    &one,
+					Cache:       &one,
+					Cycle:       true,
 					OwnedBy: &ast.ColumnNameDef{
 						Table: &ast.TableDef{
 							Type:   ast.TableTypeUnknown,
@@ -2410,7 +2412,7 @@ func TestCreateSequence(t *testing.T) {
 		},
 		{
 			stmt: `CREATE SEQUENCE public.tbl_seq_id_seq
-				AS integer
+				AS bigint
 				INCREMENT BY 1
 				START WITH 1
 				NO MINVALUE
@@ -2422,17 +2424,19 @@ func TestCreateSequence(t *testing.T) {
 						Schema: "public",
 						Name:   "tbl_seq_id_seq",
 					},
-					SequenceDataType: ast.SequenceDataTypeInteger,
-					IncrementBy:      &one,
-					StartWith:        &one,
-					Cache:            &one,
-					Cycle:            false,
+					SequenceDataType: &ast.Integer{
+						Size: 8,
+					},
+					IncrementBy: &one,
+					StartWith:   &one,
+					Cache:       &one,
+					Cycle:       false,
 				},
 			},
 			statementList: []parser.SingleSQL{
 				{
 					Text: `CREATE SEQUENCE public.tbl_seq_id_seq
-				AS integer
+				AS bigint
 				INCREMENT BY 1
 				START WITH 1
 				NO MINVALUE
@@ -2450,8 +2454,6 @@ func TestCreateSequence(t *testing.T) {
 						Schema: "public",
 						Name:   "tbl_seq_id_seq",
 					},
-					SequenceDataType: ast.SequenceDataTypeUnknown,
-					Cycle:            false,
 				},
 			},
 			statementList: []parser.SingleSQL{

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -2356,3 +2356,111 @@ func TestAlterColumnDefault(t *testing.T) {
 	}
 	runTests(t, tests)
 }
+
+func TestCreateSequence(t *testing.T) {
+	var one int32 = 1
+	tests := []testData{
+		{
+			stmt: `CREATE SEQUENCE public.tbl_seq_id_seq
+				AS integer
+				INCREMENT BY 1
+				START WITH 1
+				MINVALUE 1
+				MAXVALUE 1
+				CACHE 1
+				CYCLE
+				OWNED BY public.tbl.id;`,
+			want: []ast.Node{
+				&ast.CreateSequenceStmt{
+					SequenceName: ast.SequenceNameDef{
+						Schema: "public",
+						Name:   "tbl_seq_id_seq",
+					},
+					SequenceDataType: ast.SequenceDataTypeInteger,
+					IncrementBy:      &one,
+					StartWith:        &one,
+					MinValue:         &one,
+					MaxValue:         &one,
+					Cache:            &one,
+					Cycle:            true,
+					OwnedBy: &ast.ColumnNameDef{
+						Table: &ast.TableDef{
+							Type:   ast.TableTypeUnknown,
+							Name:   "tbl",
+							Schema: "public",
+						},
+						ColumnName: "id",
+					},
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+					Text: `CREATE SEQUENCE public.tbl_seq_id_seq
+				AS integer
+				INCREMENT BY 1
+				START WITH 1
+				MINVALUE 1
+				MAXVALUE 1
+				CACHE 1
+				CYCLE
+				OWNED BY public.tbl.id;`,
+					LastLine: 9,
+				},
+			},
+		},
+		{
+			stmt: `CREATE SEQUENCE public.tbl_seq_id_seq
+				AS integer
+				INCREMENT BY 1
+				START WITH 1
+				NO MINVALUE
+				NO MAXVALUE
+				CACHE 1;`,
+			want: []ast.Node{
+				&ast.CreateSequenceStmt{
+					SequenceName: ast.SequenceNameDef{
+						Schema: "public",
+						Name:   "tbl_seq_id_seq",
+					},
+					SequenceDataType: ast.SequenceDataTypeInteger,
+					IncrementBy:      &one,
+					StartWith:        &one,
+					Cache:            &one,
+					Cycle:            false,
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+					Text: `CREATE SEQUENCE public.tbl_seq_id_seq
+				AS integer
+				INCREMENT BY 1
+				START WITH 1
+				NO MINVALUE
+				NO MAXVALUE
+				CACHE 1;`,
+					LastLine: 7,
+				},
+			},
+		},
+		{
+			stmt: `CREATE SEQUENCE public.tbl_seq_id_seq;`,
+			want: []ast.Node{
+				&ast.CreateSequenceStmt{
+					SequenceName: ast.SequenceNameDef{
+						Schema: "public",
+						Name:   "tbl_seq_id_seq",
+					},
+					SequenceDataType: ast.SequenceDataTypeUnknown,
+					Cycle:            false,
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+					Text:     `CREATE SEQUENCE public.tbl_seq_id_seq;`,
+					LastLine: 1,
+				},
+			},
+		},
+	}
+	runTests(t, tests)
+}

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -2372,26 +2372,29 @@ func TestCreateSequence(t *testing.T) {
 				OWNED BY public.tbl.id;`,
 			want: []ast.Node{
 				&ast.CreateSequenceStmt{
-					SequenceName: ast.SequenceNameDef{
-						Schema: "public",
-						Name:   "tbl_seq_id_seq",
-					},
-					SequenceDataType: &ast.Integer{
-						Size: 4,
-					},
-					IncrementBy: &one,
-					StartWith:   &one,
-					MinValue:    &one,
-					MaxValue:    &one,
-					Cache:       &one,
-					Cycle:       true,
-					OwnedBy: &ast.ColumnNameDef{
-						Table: &ast.TableDef{
-							Type:   ast.TableTypeUnknown,
-							Name:   "tbl",
+					IfNotExists: false,
+					SequenceDef: ast.SequenceDef{
+						SequenceName: ast.SequenceNameDef{
 							Schema: "public",
+							Name:   "tbl_seq_id_seq",
 						},
-						ColumnName: "id",
+						SequenceDataType: &ast.Integer{
+							Size: 4,
+						},
+						IncrementBy: &one,
+						StartWith:   &one,
+						MinValue:    &one,
+						MaxValue:    &one,
+						Cache:       &one,
+						Cycle:       true,
+						OwnedBy: &ast.ColumnNameDef{
+							Table: &ast.TableDef{
+								Type:   ast.TableTypeUnknown,
+								Name:   "tbl",
+								Schema: "public",
+							},
+							ColumnName: "id",
+						},
 					},
 				},
 			},
@@ -2420,17 +2423,20 @@ func TestCreateSequence(t *testing.T) {
 				CACHE 1;`,
 			want: []ast.Node{
 				&ast.CreateSequenceStmt{
-					SequenceName: ast.SequenceNameDef{
-						Schema: "public",
-						Name:   "tbl_seq_id_seq",
+					IfNotExists: false,
+					SequenceDef: ast.SequenceDef{
+						SequenceName: ast.SequenceNameDef{
+							Schema: "public",
+							Name:   "tbl_seq_id_seq",
+						},
+						SequenceDataType: &ast.Integer{
+							Size: 8,
+						},
+						IncrementBy: &one,
+						StartWith:   &one,
+						Cache:       &one,
+						Cycle:       false,
 					},
-					SequenceDataType: &ast.Integer{
-						Size: 8,
-					},
-					IncrementBy: &one,
-					StartWith:   &one,
-					Cache:       &one,
-					Cycle:       false,
 				},
 			},
 			statementList: []parser.SingleSQL{
@@ -2447,18 +2453,21 @@ func TestCreateSequence(t *testing.T) {
 			},
 		},
 		{
-			stmt: `CREATE SEQUENCE public.tbl_seq_id_seq;`,
+			stmt: `CREATE SEQUENCE IF NOT EXISTS public.tbl_seq_id_seq;`,
 			want: []ast.Node{
 				&ast.CreateSequenceStmt{
-					SequenceName: ast.SequenceNameDef{
-						Schema: "public",
-						Name:   "tbl_seq_id_seq",
+					IfNotExists: true,
+					SequenceDef: ast.SequenceDef{
+						SequenceName: ast.SequenceNameDef{
+							Schema: "public",
+							Name:   "tbl_seq_id_seq",
+						},
 					},
 				},
 			},
 			statementList: []parser.SingleSQL{
 				{
-					Text:     `CREATE SEQUENCE public.tbl_seq_id_seq;`,
+					Text:     `CREATE SEQUENCE IF NOT EXISTS public.tbl_seq_id_seq;`,
 					LastLine: 1,
 				},
 			},


### PR DESCRIPTION
To support PostgreSQL sync schema, we should convert the `pg_query_go` create sequence statement to our create sequence statement.