### PR TITLE
refactor(rollback): filter transaction by thread id in stream

### DIFF
--- a/plugin/db/mysql/binlog_stream_parser_test.go
+++ b/plugin/db/mysql/binlog_stream_parser_test.go
@@ -366,80 +366,6 @@ BEGIN
 `,
 					},
 				},
-				{
-					{
-						Type:   QueryEventType,
-						Header: "#221018 16:21:19 server id 1  end_log_pos 1886 CRC32 0xd95a1592 	Query	thread_id=58599	exec_time=0	error_code=0\n",
-						Body: `SET TIMESTAMP=1666081279/*!*/;
-BEGIN
-/*!*/;
-`,
-					},
-					{
-						Type:   UpdateRowsEventType,
-						Header: "#221018 16:21:19 server id 1  end_log_pos 2044 CRC32 0x9dbbb766 	Update_rows: table id 259 flags: STMT_END_F\n",
-						Body: `### UPDATE ` + "`binlog_test`.`user`" + `
-### WHERE
-###   @1=1
-###   @2='alice'
-###   @3=90
-### SET
-###   @1=1
-###   @2='alice'
-###   @3=0
-### UPDATE ` + "`binlog_test`.`user`" + `
-### WHERE
-###   @1=2
-###   @2='bob'
-###   @3=110
-### SET
-###   @1=2
-###   @2='bob'
-###   @3=0
-`,
-					},
-					{
-						Type:   XidEventType,
-						Header: "#221018 16:21:19 server id 1  end_log_pos 2075 CRC32 0x64944ac3 	Xid = 349592\n",
-						Body: `COMMIT/*!*/;
-`,
-					},
-				},
-				{
-					{
-						Type:   QueryEventType,
-						Header: "#221018 16:21:45 server id 1  end_log_pos 2236 CRC32 0x965db1d1 	Query	thread_id=58599	exec_time=0	error_code=0\n",
-						Body: `SET TIMESTAMP=1666081305/*!*/;
-BEGIN
-/*!*/;
-`,
-					},
-					{
-						Type:   DeleteRowsEventType,
-						Header: "#221018 16:21:45 server id 1  end_log_pos 2365 CRC32 0xf759c90c 	Delete_rows: table id 259 flags: STMT_END_F\n",
-						Body: `### DELETE FROM ` + "`binlog_test`.`user`" + `
-### WHERE
-###   @1=1
-###   @2='alice'
-###   @3=0
-### DELETE FROM ` + "`binlog_test`.`user`" + `
-### WHERE
-###   @1=2
-###   @2='bob'
-###   @3=0
-`,
-					},
-					{
-						Type:   XidEventType,
-						Header: "#221018 16:21:45 server id 1  end_log_pos 2396 CRC32 0x816695ae 	Xid = 349604\n",
-						Body: `COMMIT/*!*/;
-SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
-DELIMITER ;
-# End of log file
-/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
-/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
-					},
-				},
 			},
 			err: false,
 		},
@@ -450,7 +376,7 @@ DELIMITER ;
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			a := require.New(t)
-			txns, err := ParseBinlogStream(strings.NewReader(test.stream))
+			txns, err := ParseBinlogStream(strings.NewReader(test.stream), "53771")
 			if test.err {
 				a.Error(err)
 			} else {
@@ -464,9 +390,9 @@ DELIMITER ;
 func TestFilterBinlogTransactionsByThreadID(t *testing.T) {
 	tests := []struct {
 		name     string
-		txnList  []BinlogTransaction
+		txn      BinlogTransaction
 		threadID string
-		want     []BinlogTransaction
+		ok       bool
 		err      bool
 	}{
 		{
@@ -475,12 +401,11 @@ func TestFilterBinlogTransactionsByThreadID(t *testing.T) {
 		},
 		{
 			name: "invalid transaction",
-			txnList: []BinlogTransaction{
+			txn: BinlogTransaction{
 				{
-					{
-						Type:   UpdateRowsEventType,
-						Header: "#221017 14:25:53 server id 1  end_log_pos 1249 CRC32 0x3d8fa43e 	Update_rows: table id 259 flags: STMT_END_F\n",
-						Body: `### UPDATE ` + "`binlog_test`.`user`" + `
+					Type:   UpdateRowsEventType,
+					Header: "#221017 14:25:53 server id 1  end_log_pos 1249 CRC32 0x3d8fa43e 	Update_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### UPDATE ` + "`binlog_test`.`user`" + `
 	### WHERE
 	###   @1=1
 	###   @2='alice'
@@ -489,27 +414,27 @@ func TestFilterBinlogTransactionsByThreadID(t *testing.T) {
 	###   @1=1
 	###   @2='alice'
 	###   @3=90`,
-					},
 				},
 			},
+			ok:  false,
 			err: true,
 		},
 		{
-			name: "real world",
-			txnList: []BinlogTransaction{
+			name: "real world, ok",
+			txn: BinlogTransaction{
+
 				{
-					{
-						Type:   QueryEventType,
-						Header: "#221017 14:25:24 server id 1  end_log_pos 772 CRC32 0x37cb53f6 	Query	thread_id=53771	exec_time=0	error_code=0\n",
-						Body: `SET TIMESTAMP=1665987924/*!*/;
+					Type:   QueryEventType,
+					Header: "#221017 14:25:24 server id 1  end_log_pos 772 CRC32 0x37cb53f6 	Query	thread_id=53771	exec_time=0	error_code=0\n",
+					Body: `SET TIMESTAMP=1665987924/*!*/;
 	BEGIN
 	/*!*/;
 	`,
-					},
-					{
-						Type:   WriteRowsEventType,
-						Header: "#221017 14:25:24 server id 1  end_log_pos 916 CRC32 0x896854fc 	Write_rows: table id 259 flags: STMT_END_F\n",
-						Body: `### INSERT INTO ` + "`binlog_test`.`user`" + `
+				},
+				{
+					Type:   WriteRowsEventType,
+					Header: "#221017 14:25:24 server id 1  end_log_pos 916 CRC32 0x896854fc 	Write_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### INSERT INTO ` + "`binlog_test`.`user`" + `
 	### SET
 	###   @1=1
 	###   @2='alice'
@@ -524,27 +449,33 @@ func TestFilterBinlogTransactionsByThreadID(t *testing.T) {
 	###   @1=3
 	###   @2='cindy'
 	###   @3=100`,
-					},
-					{
-						Type:   XidEventType,
-						Header: "#221017 14:25:24 server id 1  end_log_pos 947 CRC32 0xaf8e8303 	Xid = 327602\n",
-						Body: `COMMIT/*!*/;
-	`,
-					},
 				},
 				{
-					{
-						Type:   QueryEventType,
-						Header: "#221018 16:21:45 server id 1  end_log_pos 2236 CRC32 0x965db1d1 	Query	thread_id=58599	exec_time=0	error_code=0\n",
-						Body: `SET TIMESTAMP=1666081305/*!*/;
+					Type:   XidEventType,
+					Header: "#221017 14:25:24 server id 1  end_log_pos 947 CRC32 0xaf8e8303 	Xid = 327602\n",
+					Body: `COMMIT/*!*/;
+	`,
+				},
+			},
+			threadID: "53771",
+			ok:       true,
+			err:      false,
+		},
+		{
+			name: "real world, thread id not match",
+			txn: BinlogTransaction{
+				{
+					Type:   QueryEventType,
+					Header: "#221018 16:21:45 server id 1  end_log_pos 2236 CRC32 0x965db1d1 	Query	thread_id=58599	exec_time=0	error_code=0\n",
+					Body: `SET TIMESTAMP=1666081305/*!*/;
 	BEGIN
 	/*!*/;
 	`,
-					},
-					{
-						Type:   DeleteRowsEventType,
-						Header: "#221018 16:21:45 server id 1  end_log_pos 2365 CRC32 0xf759c90c 	Delete_rows: table id 259 flags: STMT_END_F\n",
-						Body: `### DELETE FROM ` + "`binlog_test`.`user`" + `
+				},
+				{
+					Type:   DeleteRowsEventType,
+					Header: "#221018 16:21:45 server id 1  end_log_pos 2365 CRC32 0xf759c90c 	Delete_rows: table id 259 flags: STMT_END_F\n",
+					Body: `### DELETE FROM ` + "`binlog_test`.`user`" + `
 	### WHERE
 	###   @1=1
 	###   @2='alice'
@@ -554,58 +485,21 @@ func TestFilterBinlogTransactionsByThreadID(t *testing.T) {
 	###   @1=2
 	###   @2='bob'
 	###   @3=0`,
-					},
-					{
-						Type:   XidEventType,
-						Header: "#221018 16:21:45 server id 1  end_log_pos 2396 CRC32 0x816695ae 	Xid = 349604\n",
-						Body: `COMMIT/*!*/;
+				},
+				{
+					Type:   XidEventType,
+					Header: "#221018 16:21:45 server id 1  end_log_pos 2396 CRC32 0x816695ae 	Xid = 349604\n",
+					Body: `COMMIT/*!*/;
 	SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
 	DELIMITER ;
 	# End of log file
 	/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
 	/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;`,
-					},
 				},
 			},
 			threadID: "53771",
-			want: []BinlogTransaction{
-				{
-					{
-						Type:   QueryEventType,
-						Header: "#221017 14:25:24 server id 1  end_log_pos 772 CRC32 0x37cb53f6 	Query	thread_id=53771	exec_time=0	error_code=0\n",
-						Body: `SET TIMESTAMP=1665987924/*!*/;
-	BEGIN
-	/*!*/;
-	`,
-					},
-					{
-						Type:   WriteRowsEventType,
-						Header: "#221017 14:25:24 server id 1  end_log_pos 916 CRC32 0x896854fc 	Write_rows: table id 259 flags: STMT_END_F\n",
-						Body: `### INSERT INTO ` + "`binlog_test`.`user`" + `
-	### SET
-	###   @1=1
-	###   @2='alice'
-	###   @3=100
-	### INSERT INTO ` + "`binlog_test`.`user`" + `
-	### SET
-	###   @1=2
-	###   @2='bob'
-	###   @3=100
-	### INSERT INTO ` + "`binlog_test`.`user`" + `
-	### SET
-	###   @1=3
-	###   @2='cindy'
-	###   @3=100`,
-					},
-					{
-						Type:   XidEventType,
-						Header: "#221017 14:25:24 server id 1  end_log_pos 947 CRC32 0xaf8e8303 	Xid = 327602\n",
-						Body: `COMMIT/*!*/;
-	`,
-					},
-				},
-			},
-			err: false,
+			ok:       false,
+			err:      false,
 		},
 	}
 
@@ -614,7 +508,8 @@ func TestFilterBinlogTransactionsByThreadID(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			a := require.New(t)
-			_, err := FilterBinlogTransactionsByThreadID(test.txnList, test.threadID)
+			ok, err := filterBinlogTransactionsByThreadID(test.txn, test.threadID)
+			a.Equal(test.ok, ok)
 			if test.err {
 				a.Error(err)
 			} else {

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -97,14 +97,9 @@ func (driver *Driver) GenerateRollbackSQL(ctx context.Context, binlogFileNameLis
 		return "", errors.Wrap(err, "failed to run mysqlbinlog")
 	}
 
-	txnList, err := ParseBinlogStream(pr)
+	txnList, err := ParseBinlogStream(pr, threadID)
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to parse binlog stream")
-	}
-
-	txnList, err = FilterBinlogTransactionsByThreadID(txnList, threadID)
-	if err != nil {
-		return "", errors.WithMessage(err, "failed to filter binlog transactions by thread ID")
 	}
 
 	var rollbackSQLList []string


### PR DESCRIPTION
This PR refactors the rollback logic to filter transactions by thread ID when parsing the mysqlbinlog output stream.

The test change is mainly about fixing signatures and removing filtered transactions because now the filtering is done with parsing.