### PR TITLE
feat(frontend): Generate rollback issue for a DML task

### DIFF
--- a/frontend/src/components/Issue/IssueHighlightPanel.vue
+++ b/frontend/src/components/Issue/IssueHighlightPanel.vue
@@ -70,6 +70,7 @@
               }}</template>
             </i18n-t>
           </p>
+          <IssueRollbackFromTips />
         </div>
       </div>
     </div>
@@ -82,6 +83,7 @@
 <script lang="ts" setup>
 import { reactive, watch, computed, Ref } from "vue";
 import IssueStatusIcon from "./IssueStatusIcon.vue";
+import IssueRollbackFromTips from "./IssueRollbackFromTips.vue";
 import { activeTask } from "@/utils";
 import {
   TaskDatabaseSchemaUpdatePayload,

--- a/frontend/src/components/Issue/IssueRollbackButton.vue
+++ b/frontend/src/components/Issue/IssueRollbackButton.vue
@@ -1,0 +1,183 @@
+<template>
+  <button
+    v-if="showRollbackButton"
+    :disabled="!allowRollback || state.buttonState === ButtonState.LOADING"
+    type="button"
+    class="mt-0.5 px-3 inline-flex items-center gap-x-2 border border-control-border rounded-sm text-control bg-control-bg hover:bg-control-bg-hover text-sm leading-5 font-normal focus:ring-control focus:outline-none focus-visible:ring-2 focus:ring-offset-2 relative disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:bg-control-bg"
+    @click="tryRollbackTask"
+  >
+    {{ $t("common.rollback") }}
+    <template v-if="state.buttonState === ButtonState.LOADING">
+      <BBSpin class="w-4 h-4 -mr-1.5" />
+    </template>
+  </button>
+</template>
+
+<script lang="ts" setup>
+import { computed, reactive } from "vue";
+import { useRouter } from "vue-router";
+import dayjs from "dayjs";
+
+import type {
+  Issue,
+  IssueCreate,
+  RollbackContext,
+  Task,
+  TaskDatabaseDataUpdatePayload,
+} from "@/types";
+import { useIssueLogic } from "./logic";
+import { useCurrentUser, useIssueStore } from "@/store";
+import {
+  absolutifyLink,
+  buildIssueLinkWithTask,
+  hasProjectPermission,
+  hasWorkspacePermission,
+} from "@/utils";
+
+enum ButtonState {
+  DEFAULT,
+  LOADING,
+  GENERATED,
+}
+
+type LocalState = {
+  buttonState: ButtonState;
+  rollbackIssue: Issue | undefined;
+};
+
+const state = reactive<LocalState>({
+  buttonState: ButtonState.DEFAULT,
+  rollbackIssue: undefined,
+});
+
+const router = useRouter();
+const issueStore = useIssueStore();
+const currentUser = useCurrentUser();
+
+const { issue, project, create, selectedTask } = useIssueLogic();
+
+const showRollbackButton = computed(() => {
+  if (create.value) return false;
+
+  const issueEntity = issue.value as Issue;
+  const task = selectedTask.value as Task;
+
+  return (
+    issueEntity.type === "bb.issue.database.data.update" &&
+    task.type === "bb.task.database.data.update" &&
+    task.status === "DONE" &&
+    project.value.workflowType === "UI" &&
+    task.database?.instance.engine === "MYSQL"
+  );
+});
+
+const allowRollback = computed(() => {
+  if (!showRollbackButton.value) return false;
+
+  const issueEntity = issue.value as Issue;
+  const user = currentUser.value;
+
+  if (user.id === issueEntity.creator.id) {
+    // Allowed to the issue creator
+    return true;
+  }
+
+  if (user.id === issueEntity.assignee.id) {
+    // Allowed to the issue assignee
+    return true;
+  }
+
+  const memberInProject = issueEntity.project.memberList.find(
+    (member) => member.principal.id === user.id
+  );
+  if (
+    memberInProject?.role &&
+    hasProjectPermission(
+      "bb.permission.project.admin-database",
+      memberInProject.role
+    )
+  ) {
+    // Allowed to the project owner
+    return true;
+  }
+
+  if (
+    hasWorkspacePermission("bb.permission.workspace.manage-issue", user.role)
+  ) {
+    // Allowed to DBAs and workspace owners
+    return true;
+  }
+  return false;
+});
+
+const tryRollbackTask = async () => {
+  if (!showRollbackButton.value) return;
+
+  const navigateToRollbackIssue = () => {
+    if (!state.rollbackIssue) return;
+    router.push(`/issue/${state.rollbackIssue.id}`);
+  };
+
+  if (state.buttonState === ButtonState.GENERATED && state.rollbackIssue) {
+    return navigateToRollbackIssue();
+  }
+
+  try {
+    state.buttonState = ButtonState.LOADING;
+
+    const issueEntity = issue.value as Issue;
+    const task = selectedTask.value as Task;
+
+    const rollbackContext: RollbackContext = {
+      issueId: issueEntity.id,
+      taskIdList: [task.id],
+    };
+
+    const datetime = `${dayjs(issueEntity.createdTs * 1000).format(
+      "MM-DD HH:mm:ss"
+    )}`;
+    const tz = `UTC${dayjs().format("ZZ")}`;
+
+    const issueName = [
+      `[${task.database!.name}]`,
+      `Rollback ${task.name}`,
+      `in #${issueEntity.id}`,
+      `@${datetime} ${tz}`,
+    ].join(" ");
+
+    const originalIssueTaskLink = buildIssueLinkWithTask(
+      issueEntity,
+      task,
+      true /* Keep the URL short and clean */
+    );
+    const description = [
+      `The original task: ${absolutifyLink(originalIssueTaskLink)}`,
+      `The original SQL statement: ${
+        (task.payload as TaskDatabaseDataUpdatePayload).statement
+      }`,
+    ].join("\n");
+
+    const issueCreate: IssueCreate = {
+      type: "bb.issue.database.rollback",
+      projectId: issueEntity.project.id,
+      name: issueName,
+      description,
+      payload: {},
+      // Use the same assignee as the original issue
+      assigneeId: issueEntity.assignee.id,
+      createContext: rollbackContext,
+    };
+
+    const createdIssue = await issueStore.createIssue(issueCreate);
+    state.rollbackIssue = createdIssue;
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    state.buttonState = ButtonState.GENERATED;
+
+    navigateToRollbackIssue();
+  } catch {
+    state.buttonState = ButtonState.DEFAULT;
+  }
+};
+</script>

--- a/frontend/src/components/Issue/IssueRollbackFromTips.vue
+++ b/frontend/src/components/Issue/IssueRollbackFromTips.vue
@@ -1,0 +1,84 @@
+<template>
+  <div
+    v-if="shouldShowTips"
+    class="mt-1 text-sm text-control-light flex flex-row items-center space-x-1"
+  >
+    <heroicons-outline:arrow-uturn-left class="w-4 h-4" />
+    <i18n-t keypath="issue.rollback-from" tag="span">
+      <template #link>
+        <router-link :to="rollbackIssueLink" class="normal-link">
+          <i18n-t keypath="issue.issue-link-with-task">
+            <template #issue>#{{ rollbackFromIssue.id }}</template>
+            <template #task>[{{ rollbackFromTask.name }}]</template>
+          </i18n-t>
+        </router-link>
+      </template>
+    </i18n-t>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+
+import type { Task, TaskDatabaseDataUpdatePayload } from "@/types";
+import { unknown, UNKNOWN_ID } from "@/types";
+import { flattenTaskList, useIssueLogic } from "./logic";
+import { useIssueById } from "@/store";
+import { buildIssueLinkWithTask } from "@/utils";
+
+const { create, selectedTask } = useIssueLogic();
+
+const payload = computed(() => {
+  if (create.value) return undefined;
+
+  const task = selectedTask.value as Task;
+  if (task.type === "bb.task.database.data.update") {
+    return task.payload as TaskDatabaseDataUpdatePayload | undefined;
+  }
+  return undefined;
+});
+
+const rollbackFromIssueId = computed(() => {
+  return payload.value?.rollbackFromIssueId || UNKNOWN_ID;
+});
+
+const rollbackFromTaskId = computed(() => {
+  return payload.value?.rollbackFromTaskId || UNKNOWN_ID;
+});
+
+const rollbackFromIssue = useIssueById(
+  rollbackFromIssueId,
+  true /* Lazy fetch */
+);
+
+const rollbackFromTask = computed((): Task => {
+  const issue = rollbackFromIssue.value;
+  if (issue.id === UNKNOWN_ID) return unknown("TASK");
+
+  const taskId = rollbackFromTaskId.value;
+  if (taskId === UNKNOWN_ID) return unknown("TASK");
+
+  const task = flattenTaskList<Task>(issue).find((t) => t.id === taskId);
+  if (task) {
+    return task;
+  }
+
+  return unknown("TASK");
+});
+
+const shouldShowTips = computed(() => {
+  // Show the tips when rollbackFromIssue and rollbackFromTask are both ready.
+  return (
+    rollbackFromIssue.value.id !== UNKNOWN_ID &&
+    rollbackFromTask.value.id !== UNKNOWN_ID
+  );
+});
+
+const rollbackIssueLink = computed(() => {
+  if (!shouldShowTips.value) return "";
+  return buildIssueLinkWithTask(
+    rollbackFromIssue.value,
+    rollbackFromTask.value
+  );
+});
+</script>

--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -119,6 +119,8 @@
           </button>
         </template>
       </template>
+
+      <IssueRollbackButton />
     </div>
   </div>
   <label class="sr-only">{{ $t("common.sql-statement") }}</label>
@@ -177,6 +179,8 @@ import {
   Ref,
 } from "vue";
 import { useDialog } from "naive-ui";
+import { useI18n } from "vue-i18n";
+
 import {
   pushNotification,
   useRepositoryStore,
@@ -187,7 +191,7 @@ import { useIssueLogic } from "./logic";
 import MonacoEditor from "../MonacoEditor/MonacoEditor.vue";
 import type { Issue, Repository, SQLDialect, Task, TaskId } from "@/types";
 import { baseDirectoryWebUrl, UNKNOWN_ID } from "@/types";
-import { useI18n } from "vue-i18n";
+import IssueRollbackButton from "./IssueRollbackButton.vue";
 
 interface LocalState {
   editing: boolean;
@@ -206,6 +210,7 @@ export default defineComponent({
   name: "IssueTaskStatementPanel",
   components: {
     MonacoEditor,
+    IssueRollbackButton,
   },
   props: {
     sqlHint: {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -210,7 +210,8 @@
     "advanced": "Advanced",
     "restart": "Restart",
     "want-help": "Want help",
-    "operation": "Operation"
+    "operation": "Operation",
+    "rollback": "Rollback"
   },
   "error-page": {
     "go-back-home": "Go back home"
@@ -546,7 +547,9 @@
       "change-will-apply-to-all-tasks-in-tenant-mode": "The change will be applied to all tasks",
       "dont-apply-to-database-in-baseline-migration": "This is a baseline migration and Bytebase won't apply the SQL to the database, it will only record a baseline history",
       "snowflake": "Use <<schema>>.<<table>> to specify a Snowflake table"
-    }
+    },
+    "rollback-from": "This task rollbacks from {link}.",
+    "issue-link-with-task": "Issue {issue} - task {task}"
   },
   "alter-schema": {
     "vcs-enabled": "This project has enabled VCS based version control and selecting database below will navigate you to the corresponding Git repository to initiate the change process.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -210,7 +210,8 @@
     "advanced": "高级",
     "restart": "重启",
     "want-help": "加入用户群",
-    "operation": "操作"
+    "operation": "操作",
+    "rollback": "回滚"
   },
   "error-page": {
     "go-back-home": "回到主页"
@@ -546,7 +547,9 @@
       "change-will-apply-to-all-tasks-in-tenant-mode": "改动将会应用到其他所有任务",
       "dont-apply-to-database-in-baseline-migration": "对于建立基线的迁移，Bytebase 不会应用到数据库，只会记录一个基线历史",
       "snowflake": "使用 <<schema>>.<<table>> 来标注一个 SnowFlake 的表"
-    }
+    },
+    "rollback-from": "当前任务回滚自 {link}。",
+    "issue-link-with-task": "工单 {issue} - 任务 {task}"
   },
   "alter-schema": {
     "vcs-enabled": "该项目开启了基于 VCS 的版本管理，选择下面的数据库会将您导航到相应的 Git 仓库以发起变更流程。",

--- a/frontend/src/types/issue.ts
+++ b/frontend/src/types/issue.ts
@@ -5,6 +5,7 @@ import {
   IssueId,
   PrincipalId,
   ProjectId,
+  TaskId,
 } from "./id";
 import { Pipeline, PipelineCreate } from "./pipeline";
 import { Principal } from "./principal";
@@ -18,6 +19,7 @@ type IssueTypeDatabase =
   | "bb.issue.database.grant"
   | "bb.issue.database.schema.update"
   | "bb.issue.database.data.update"
+  | "bb.issue.database.rollback"
   | "bb.issue.database.schema.update.ghost"
   | "bb.issue.database.restore.pitr";
 
@@ -71,6 +73,13 @@ export type PITRContext = {
   createDatabaseContext?: CreateDatabaseContext;
 };
 
+export type RollbackContext = {
+  // IssueID is the id of the issue to rollback.
+  issueId: IssueId;
+  // TaskIDList is the list of task ids to rollback.
+  taskIdList: TaskId[];
+};
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type EmptyContext = {};
 
@@ -79,6 +88,7 @@ export type IssueCreateContext =
   | MigrationContext
   | UpdateSchemaGhostContext
   | PITRContext
+  | RollbackContext
   | EmptyContext;
 
 export type IssuePayload = { [key: string]: any };

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -4,6 +4,7 @@ import {
   BackupId,
   DatabaseId,
   InstanceId,
+  IssueId,
   ProjectId,
   TaskId,
   TaskRunId,
@@ -97,6 +98,9 @@ export type TaskDatabasePITRDeletePayload = {
 export type TaskDatabaseDataUpdatePayload = {
   statement: string;
   pushEvent?: VCSPushEvent;
+  rollbackStatement: string;
+  rollbackFromIssueId: IssueId;
+  rollbackFromTaskId: TaskId;
 };
 
 export type TaskDatabaseRestorePayload = {

--- a/frontend/src/utils/link.ts
+++ b/frontend/src/utils/link.ts
@@ -5,3 +5,9 @@ const resourceToPrefix = new Map([["DATABASE", "/db"]]);
 export function linkfy(type: ResourceType, id: string): string {
   return [resourceToPrefix.get(type), id].join("/");
 }
+
+export function absolutifyLink(rel: string): string {
+  const anchor = document.createElement("a");
+  anchor.setAttribute("href", rel);
+  return anchor.href;
+}

--- a/frontend/src/utils/task.ts
+++ b/frontend/src/utils/task.ts
@@ -1,11 +1,13 @@
 import { useDatabaseStore } from "@/store";
 import {
+  Issue,
   Task,
   TaskCreate,
   TaskDatabaseCreatePayload,
   TaskDatabasePITRRestorePayload,
   unknown,
 } from "@/types";
+import { issueSlug, stageSlug, taskSlug } from "./slug";
 
 export const extractDatabaseNameFromTask = (
   task: Task | TaskCreate
@@ -52,4 +54,25 @@ export const extractDatabaseNameFromTask = (
 
   // Fallback to <<Unknown database>>. Won't be happy to see it.
   return unknown("DATABASE").name;
+};
+
+export const buildIssueLinkWithTask = (
+  issue: Issue,
+  task: Task,
+  simple = false
+) => {
+  const stage = task.stage;
+  const stageIndex = issue.pipeline.stageList.findIndex(
+    (s) => s.id === stage.id
+  );
+
+  const issuePart = simple ? String(issue.id) : issueSlug(issue.name, issue.id);
+  const stagePart = simple
+    ? String(stageIndex + 1)
+    : stageSlug(stage.name, stageIndex + 1);
+  const taskPart = simple ? String(task.id) : taskSlug(task.name, task.id);
+
+  const url = `/issue/${issuePart}?stage=${stagePart}&task=${taskPart}`;
+
+  return url;
 };


### PR DESCRIPTION
### Features and specs

**Condition**
- Issue type and task type are DML
- [and] Task status is "DONE"
- [and] Project workflow type is "UI"
- [and] Database engine type is "MYSQL"

**Who can click the [Rollback] button?**
- The issue creator
- [or] The issue assignee
- [or] Project owners
- [or] DBAs and workspace owners

### Screenshots

**The [Rollback] button**
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/2749742/203516403-12db920d-a4cc-4b7e-8243-1626d927f1a8.png">

**The generated rollback issue**
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/2749742/203516277-082d41dd-1daf-4188-845e-007c5cc5b2f4.png">

**Screen recording**

https://user-images.githubusercontent.com/2749742/203516799-02a9350f-c501-4521-bf76-7ab302abb825.mp4



