### PR TITLE
feat: convert drop sequence and deparse PostgreSQL drop sequence statement

### DIFF
--- a/plugin/parser/ast/drop_sequence_stmt.go
+++ b/plugin/parser/ast/drop_sequence_stmt.go
@@ -1,0 +1,10 @@
+package ast
+
+// DropSequenceStmt is the struct for drop sequence statement.
+type DropSequenceStmt struct {
+	ddl
+
+	IfExists         bool
+	SequenceNameList []SequenceNameDef
+	Behavior         DropBehavior
+}

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -314,6 +314,23 @@ func convert(node *pgquery.Node, statement parser.SingleSQL) (res ast.Node, err 
 				dropSchema.SchemaList = append(dropSchema.SchemaList, strNode.String_.Str)
 			}
 			return dropSchema, nil
+		case pgquery.ObjectType_OBJECT_SEQUENCE:
+			dropSequence := &ast.DropSequenceStmt{
+				IfExists: in.DropStmt.MissingOk,
+				Behavior: convertDropBehavior(in.DropStmt.Behavior),
+			}
+			for _, sequence := range in.DropStmt.Objects {
+				list, ok := sequence.Node.(*pgquery.Node_List)
+				if !ok {
+					return nil, parser.NewConvertErrorf("expected List but found %t", sequence.Node)
+				}
+				sequenceDef, err := convertListToSequenceNameDef(list)
+				if err != nil {
+					return nil, err
+				}
+				dropSequence.SequenceNameList = append(dropSequence.SequenceNameList, sequenceDef)
+			}
+			return dropSequence, nil
 		}
 	case *pgquery.Node_DropdbStmt:
 		return &ast.DropDatabaseStmt{
@@ -410,7 +427,6 @@ func convert(node *pgquery.Node, statement parser.SingleSQL) (res ast.Node, err 
 				return nil, parser.NewConvertErrorf("unsupported option %s", defElemNode.DefElem.Defname)
 			}
 		}
-
 		return createSeqStmt, nil
 	case *pgquery.Node_AlterObjectSchemaStmt:
 		switch in.AlterObjectSchemaStmt.ObjectType {
@@ -826,6 +842,26 @@ func convertSetOperation(t pgquery.SetOperation) (ast.SetOperationType, error) {
 		return ast.SetOperationTypeExcept, nil
 	default:
 		return 0, errors.Errorf("failed to parse set operation: unknown type %s", t)
+	}
+}
+
+func convertListToSequenceNameDef(in *pgquery.Node_List) (ast.SequenceNameDef, error) {
+	stringList, err := convertListToStringList(in)
+	if err != nil {
+		return ast.SequenceNameDef{}, err
+	}
+	switch len(in.List.Items) {
+	case 2:
+		return ast.SequenceNameDef{
+			Schema: stringList[0],
+			Name:   stringList[1],
+		}, nil
+	case 1:
+		return ast.SequenceNameDef{
+			Name: stringList[0],
+		}, nil
+	default:
+		return ast.SequenceNameDef{}, parser.NewConvertErrorf("expected length is 1 or 2, but found %d", len(in.List.Items))
 	}
 }
 

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -2475,3 +2475,54 @@ func TestCreateSequence(t *testing.T) {
 	}
 	runTests(t, tests)
 }
+
+func TestDropSequence(t *testing.T) {
+	tests := []testData{
+		{
+			stmt: `DROP SEQUENCE public.tbl_seq_id_seq;`,
+			want: []ast.Node{
+				&ast.DropSequenceStmt{
+					IfExists: false,
+					Behavior: ast.DropBehaviorRestrict,
+					SequenceNameList: []ast.SequenceNameDef{
+						{
+							Schema: "public",
+							Name:   "tbl_seq_id_seq",
+						},
+					},
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+					Text:     `DROP SEQUENCE public.tbl_seq_id_seq;`,
+					LastLine: 1,
+				},
+			},
+		},
+		{
+			stmt: `DROP SEQUENCE IF EXISTS tbl_seq1, public.tbl_seq2 CASCADE;`,
+			want: []ast.Node{
+				&ast.DropSequenceStmt{
+					IfExists: true,
+					Behavior: ast.DropBehaviorCascade,
+					SequenceNameList: []ast.SequenceNameDef{
+						{
+							Name: "tbl_seq1",
+						},
+						{
+							Schema: "public",
+							Name:   "tbl_seq2",
+						},
+					},
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+					Text:     `DROP SEQUENCE IF EXISTS tbl_seq1, public.tbl_seq2 CASCADE;`,
+					LastLine: 1,
+				},
+			},
+		},
+	}
+	runTests(t, tests)
+}


### PR DESCRIPTION
We should drop the redundant sequence in PostgreSQL sync schema. This PR is the preparation work to allow us to restore our bb drop sequence AST.