### PR TITLE
chore(parser): set text deparsed by pg_query_go to unconverted data type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -170,4 +170,4 @@ replace github.com/pingcap/tidb => github.com/bytebase/tidb v0.0.0-2022102803595
 
 replace github.com/pingcap/tidb/parser => github.com/bytebase/tidb/parser v0.0.0-20221028035959-5d3b71eadf24
 
-replace github.com/pganalyze/pg_query_go/v2 => github.com/bytebase/pg_query_go/v2 v2.0.0-20221115090145-10eaaf3c22b6
+replace github.com/pganalyze/pg_query_go/v2 => github.com/bytebase/pg_query_go/v2 v2.0.0-20221123093650-17425d1d18b7

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651 h1:NpoTuRY6Ckj37zTlEax/UTfvHCOdanI5/5dVCarOD18=
 github.com/bytebase/gh-ost v1.1.3-0.20220728080340-11d9c9027651/go.mod h1:/HsnX0+34LXVz3MxtZoW15GiwEOXz/PrEhutjb3icfE=
-github.com/bytebase/pg_query_go/v2 v2.0.0-20221115090145-10eaaf3c22b6 h1:cdcvc3OYUFLylc9EKFnexiRixHryry5MG7d4jqsxBIA=
-github.com/bytebase/pg_query_go/v2 v2.0.0-20221115090145-10eaaf3c22b6/go.mod h1:XAxmVqz1tEGqizcQ3YSdN90vCOHBWjJi8URL1er5+cA=
+github.com/bytebase/pg_query_go/v2 v2.0.0-20221123093650-17425d1d18b7 h1:RDN6UnjTq4HR4LKrN8Yav4XfwUoGRjTocvWmzGr6Usc=
+github.com/bytebase/pg_query_go/v2 v2.0.0-20221123093650-17425d1d18b7/go.mod h1:XAxmVqz1tEGqizcQ3YSdN90vCOHBWjJi8URL1er5+cA=
 github.com/bytebase/tidb v0.0.0-20221028035959-5d3b71eadf24 h1:XR25hLtR8TtpW/4mgP7EcOlzi8ewNY5EVan97WzDQxc=
 github.com/bytebase/tidb v0.0.0-20221028035959-5d3b71eadf24/go.mod h1:xrVXE+0V54QRGgrD9o+tuZmBDDx8vJpQgrPtRQvodWo=
 github.com/bytebase/tidb/parser v0.0.0-20221028035959-5d3b71eadf24 h1:DZPxIt2aZJ6L/gh8tH9jspTTIufBt7Wvgae1T7TmXAg=

--- a/plugin/parser/ast/unconverted_data_type.go
+++ b/plugin/parser/ast/unconverted_data_type.go
@@ -1,7 +1,5 @@
 package ast
 
-import "strings"
-
 // UnconvertedDataType is the struct for unconverted data type.
 // TODO(rebelice): remove it.
 // We define this because we cannot convert all data types now.
@@ -13,6 +11,5 @@ type UnconvertedDataType struct {
 
 // EquivalentType implements the DataType interface.
 func (u *UnconvertedDataType) EquivalentType(tp string) bool {
-	tp = strings.ToLower(tp)
-	return strings.ToLower(strings.Join(u.Name, ".")) == tp
+	return u.Text() == tp
 }

--- a/plugin/parser/differ/pg/test-data/test_differ_data.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_data.yaml
@@ -128,3 +128,25 @@
     DROP INDEX IF EXISTS "public"."idx1" CASCADE;
     CREATE INDEX "idx2" ON "public"."t1" USING btree (a);
     CREATE INDEX "idx3" ON "public"."t1" USING btree (a, b);
+- oldSchema: |
+    CREATE TABLE public.t (a int, b varchar(20), c boolean, d bit(2), e jsonb);
+  newSchema: |
+    CREATE TABLE public.t (a integer, b varchar(20), c boolean, d bit(2), e jsonb);
+  diff: ""
+- oldSchema: |
+    CREATE TABLE public.t (a int8, b varchar(220), c date, d varbit(2), e json, f bit(2));
+  newSchema: |
+    CREATE TABLE public.t (a integer, b varchar(20), c boolean, d bit(2), e jsonb, f bit(4));
+  diff: |
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "a" SET DATA TYPE integer;
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "b" SET DATA TYPE character varying(20);
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "c" SET DATA TYPE boolean;
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "d" SET DATA TYPE pg_catalog.bit(2);
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "e" SET DATA TYPE jsonb;
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "f" SET DATA TYPE pg_catalog.bit(4);

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -48,6 +48,12 @@ func runTests(t *testing.T, tests []testData) {
 	}
 }
 
+func newUnconvertedDataType(name []string, text string) *ast.UnconvertedDataType {
+	tp := &ast.UnconvertedDataType{Name: name}
+	tp.SetText(text)
+	return tp
+}
+
 func TestPGConvertCreateTableStmt(t *testing.T) {
 	tests := []testData{
 		{
@@ -220,7 +226,7 @@ func TestPGConvertCreateTableStmt(t *testing.T) {
 						},
 						{
 							ColumnName: "u",
-							Type:       &ast.UnconvertedDataType{Name: []string{"user defined data type"}},
+							Type:       newUnconvertedDataType([]string{"user defined data type"}, `"user defined data type"`),
 						},
 					},
 				},

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -908,11 +908,7 @@ func deparseDataType(_ parser.DeparseContext, in ast.DataType, buf *strings.Buil
 			return err
 		}
 	case *ast.UnconvertedDataType:
-		var nameList []string
-		for _, name := range node.Name {
-			nameList = append(nameList, fmt.Sprintf(`"%s"`, name))
-		}
-		if _, err := buf.WriteString(strings.Join(nameList, ".")); err != nil {
+		if _, err := buf.WriteString(node.Text()); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
related PR https://github.com/bytebase/pg_query_go/pull/3

We do not convert all data type.
Here we use the result from the `pg_query_go deparser` instead of converting all data type for differ.