### PR TITLE
feat: support modifying user email (backend)

### DIFF
--- a/api/principal.go
+++ b/api/principal.go
@@ -117,6 +117,7 @@ type PrincipalPatch struct {
 
 	// Domain specific fields
 	Name         *string `jsonapi:"attr,name"`
+	Email        *string `jsonapi:"attr,email"`
 	Password     *string `jsonapi:"attr,password"`
 	PasswordHash *string
 }

--- a/store/principal.go
+++ b/store/principal.go
@@ -374,6 +374,9 @@ func patchPrincipalImpl(ctx context.Context, tx *Tx, patch *api.PrincipalPatch) 
 	if v := patch.Name; v != nil {
 		set, args = append(set, fmt.Sprintf("name = $%d", len(args)+1)), append(args, *v)
 	}
+	if v := patch.Email; v != nil {
+		set, args = append(set, fmt.Sprintf("email = $%d", len(args)+1)), append(args, *v)
+	}
 	if v := patch.PasswordHash; v != nil {
 		set, args = append(set, fmt.Sprintf("password_hash = $%d", len(args)+1)), append(args, *v)
 	}


### PR DESCRIPTION
Support modifying principal email.

Because when using feishu approval integration, we require users to have the same email both on Bytebase and feishu side. Users may want to change their emails in Bytebase.

Completing BYT-1870