### PR TITLE
feat: add fallback email field

### DIFF
--- a/api/setting.go
+++ b/api/setting.go
@@ -85,7 +85,7 @@ type SettingAppIMValue struct {
 	ExternalApproval struct {
 		Enabled              bool   `json:"enabled"`
 		ApprovalDefinitionID string `json:"approvalDefinitionID"`
-		// FallbackEmail is optional. It's used as a substitution of bytebase bot. If the issue creator is bytebase bot, we use this email to find the user on the IM.
+		// FallbackEmail is optional. It's used as a substitution for bytebase bot. If the issue creator is bytebase bot, we use this email to find the user on the IM.
 		FallbackEmail string `json:"fallbackEmail"`
 	} `json:"externalApproval"`
 }

--- a/api/setting.go
+++ b/api/setting.go
@@ -85,5 +85,7 @@ type SettingAppIMValue struct {
 	ExternalApproval struct {
 		Enabled              bool   `json:"enabled"`
 		ApprovalDefinitionID string `json:"approvalDefinitionID"`
+		// FallbackEmail is optional. It's used as a substitution of bytebase bot. If the issue creator is bytebase bot, we use this email to find the user on the IM.
+		FallbackEmail string `json:"fallbackEmail"`
 	} `json:"externalApproval"`
 }


### PR DESCRIPTION
FallbackEmail is optional. It's used as a substitution for bytebase bot. If the issue creator is bytebase bot, we use this email to find the user on the IM.

This PR 
- adds this field
- implements validating patching
- uses fallback email if conditions are met

Completing BYT-1871