### PR TITLE
fix: force cancel external approval

### DIFF
--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -91,10 +91,10 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 							stage = issue.Pipeline.StageList[len(issue.Pipeline.StageList)-1]
 						}
 						if issue.Status != api.IssueOpen {
-							if _, err := r.cancelOldExternalApprovalIfNeeded(ctx, issue, stage, &value); err != nil {
+							if err := r.CancelExternalApproval(ctx, issue.ID); err != nil {
 								log.Error("failed to cancel external approval", zap.Error(err))
-								continue
 							}
+							continue
 						}
 
 						status, err := r.p.GetExternalApprovalStatus(ctx, feishu.TokenCtx{
@@ -205,7 +205,7 @@ func (r *ApplicationRunner) cancelOldExternalApprovalIfNeeded(ctx context.Contex
 }
 
 // CancelExternalApproval cancels the active external approval of an issue.
-func (r *ApplicationRunner) CancelExternalApproval(ctx context.Context, issue *api.Issue) error {
+func (r *ApplicationRunner) CancelExternalApproval(ctx context.Context, issueID int) error {
 	settingName := api.SettingAppIM
 	setting, err := r.store.GetSetting(ctx, &api.SettingFind{Name: &settingName})
 	if err != nil {
@@ -224,7 +224,7 @@ func (r *ApplicationRunner) CancelExternalApproval(ctx context.Context, issue *a
 	if !value.ExternalApproval.Enabled {
 		return nil
 	}
-	approval, err := r.store.GetExternalApprovalByIssueID(ctx, issue.ID)
+	approval, err := r.store.GetExternalApprovalByIssueID(ctx, issueID)
 	if err != nil {
 		return err
 	}

--- a/server/issue.go
+++ b/server/issue.go
@@ -1418,7 +1418,7 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 
 	// Cancel external approval, it's ok if we failed.
 	if newStatus != api.IssueOpen {
-		if err := s.ApplicationRunner.CancelExternalApproval(ctx, issue); err != nil {
+		if err := s.ApplicationRunner.CancelExternalApproval(ctx, issue.ID); err != nil {
 			log.Error("failed to cancel external approval on issue cancellation or completion", zap.Error(err))
 		}
 	}


### PR DESCRIPTION
Force cancel external approval for non-open issues.

Though we have force-closed external approvals when closing/resolving an issue, we still double-check here.