### PR TITLE
feat: implement feishu bot api callers

### DIFF
--- a/plugin/app/feishu/feishu.go
+++ b/plugin/app/feishu/feishu.go
@@ -133,6 +133,15 @@ type CancelExternalApprovalResponse struct {
 	Msg  string `json:"msg"`
 }
 
+// GetBotIDResponse is the response of GetBotID.
+type GetBotIDResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Bot  struct {
+		OpenID string `json:"open_id"`
+	} `json:"bot"`
+}
+
 // CreateApprovalInstanceRequest is the request of CreateApprovalInstance.
 type CreateApprovalInstanceRequest struct {
 	ApprovalCode           string `json:"approval_code"`
@@ -550,6 +559,29 @@ func (p *Provider) GetIDByEmail(ctx context.Context, tokenCtx TokenCtx, emails [
 	}
 
 	return userID, nil
+}
+
+// GetBotID gets the id of the bot.
+// https://open.feishu.cn/document/ukTMukTMukTM/uAjMxEjLwITMx4CMyETM
+func (p *Provider) GetBotID(ctx context.Context, tokenCtx TokenCtx) (string, error) {
+	url := fmt.Sprintf("%s/bot/v3/info", p.APIPath)
+	code, _, b, err := p.do(ctx, p.client, http.MethodGet, url, nil, p.tokenRefresher(tokenCtx))
+	if err != nil {
+		return "", errors.Wrapf(err, "POST %s", url)
+	}
+	if code != http.StatusOK {
+		return "", errors.Errorf("non-200 POST status code %d with body %q", code, b)
+	}
+
+	var response GetBotIDResponse
+	if err := json.Unmarshal([]byte(b), &response); err != nil {
+		return "", err
+	}
+	if response.Code != 0 {
+		return "", errors.Errorf("failed to create external approval, code %d, msg %s", response.Code, response.Msg)
+	}
+
+	return response.Bot.OpenID, nil
 }
 
 func formatForm(content Content) (string, error) {

--- a/plugin/app/feishu/feishu_test.go
+++ b/plugin/app/feishu/feishu_test.go
@@ -227,3 +227,36 @@ func TestProvider_GetIDByEmail(t *testing.T) {
 		a.Equal("ou_919112245678741d29069abcdef096af", user["lisi@a.com"])
 	})
 }
+
+func TestProvider_GetBotID(t *testing.T) {
+	a := require.New(t)
+	p := NewProvider(APIPath)
+	p.client = &http.Client{
+		Transport: &common.MockRoundTripper{
+			MockRoundTrip: func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+{
+    "code":0,
+    "msg":"ok",
+    "bot":{
+        "activate_status":2,
+        "app_name":"name",
+        "avatar_url":"https://s1-imfile.feishucdn.com/static-resource/v1/da5xxxx14b16113",
+        "ip_white_list":[
+
+        ],
+        "open_id":"ou_e6e14f667cfe239d7b129b521dce0569"
+    }
+}`)),
+				}, nil
+			},
+		},
+	}
+	ctx := context.Background()
+	botID, err := p.GetBotID(ctx, TokenCtx{})
+	a.NoError(err)
+	want := "ou_e6e14f667cfe239d7b129b521dce0569"
+	a.Equal(want, botID)
+}

--- a/server/setting.go
+++ b/server/setting.go
@@ -78,6 +78,16 @@ func (s *Server) registerSettingRoutes(g *echo.Group) {
 				p := s.ApplicationRunner.p
 				// clear token cache so that we won't use the previous token.
 				p.ClearTokenCache()
+
+				// check bot info
+				if _, err := p.GetBotID(ctx, feishu.TokenCtx{
+					AppID:     value.AppID,
+					AppSecret: value.AppSecret,
+				}); err != nil {
+					return echo.NewHTTPError(http.StatusBadRequest, "Failed to get bot id. Hint: check if bot is enabled.").SetInternal(err)
+				}
+
+				// create approval definition
 				approvalDefinitionID, err := p.CreateApprovalDefinition(ctx, feishu.TokenCtx{
 					AppID:     value.AppID,
 					AppSecret: value.AppSecret,
@@ -85,6 +95,7 @@ func (s *Server) registerSettingRoutes(g *echo.Group) {
 				if err != nil {
 					return echo.NewHTTPError(http.StatusBadRequest, "Failed to create approval definition").SetInternal(err)
 				}
+
 				value.ExternalApproval.ApprovalDefinitionID = approvalDefinitionID
 				b, err := json.Marshal(value)
 				if err != nil {


### PR DESCRIPTION
We require to enable bot on the feishu, which represents bytebase system bot.

We can get rid of "default email" this way #3509 

Close BYT-1887