### PR TITLE
feat(frontend): generate a comment when rollbacking a task

### DIFF
--- a/frontend/src/components/Issue/IssueActivityPanel.vue
+++ b/frontend/src/components/Issue/IssueActivityPanel.vue
@@ -231,7 +231,7 @@
                       ></textarea>
                     </template>
                     <template v-else>
-                      {{ item.activity.comment }}
+                      <ActivityComment :activity="item.activity" />
                     </template>
                     <template
                       v-if="
@@ -353,6 +353,7 @@ import {
 import { useEventListener } from "@vueuse/core";
 import { useExtraIssueLogic, useIssueLogic } from "./logic";
 import ActivityActionSentence from "./activity/ActionSentence.vue";
+import ActivityComment from "./activity/Comment";
 import { isSimilarActivity } from "./activity/utils";
 
 interface LocalState {

--- a/frontend/src/components/Issue/activity/Comment.ts
+++ b/frontend/src/components/Issue/activity/Comment.ts
@@ -1,0 +1,41 @@
+import { h, defineComponent, PropType } from "vue";
+import { Activity } from "@/types";
+
+export default defineComponent({
+  name: "ActivityComment",
+  props: {
+    activity: {
+      type: Object as PropType<Activity>,
+      required: true,
+    },
+  },
+  render() {
+    const { comment } = this.$props.activity;
+    if (!comment) return null;
+
+    const pattern = /(#\d+)\b/;
+    const parts = comment.split(pattern);
+
+    return parts.map((part) => {
+      if (part === "") return null;
+
+      if (part.match(part)) {
+        const id = parseInt(part.slice(1), 10);
+        if (!Number.isNaN(id) && id > 0) {
+          // we met a valid #{issue_id} in which issue_id is an integer and >= 0
+          // render a link to the issue
+          return h(
+            "a",
+            {
+              href: `/issue/${id}`,
+              class: "font-medium text-main whitespace-nowrap hover:underline",
+            },
+            part
+          );
+        }
+      }
+
+      return h("span", {}, part);
+    });
+  },
+});


### PR DESCRIPTION
### Features

- Automatically comment on the issue with the newly created rollback issue id.
- Recognize "#{issue_id}" patterns in comment activities and render them as a link to the issue.

### Screenshot

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/2749742/203898791-ef502b56-49b0-4833-ba54-20558d235a19.png">