### PR TITLE
feat: define access control policy

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -290,13 +290,13 @@ func (p *SensitiveDataPolicy) String() (string, error) {
 // AccessControlPolicy is the policy configuration for database access control.
 // It is only applicable to database and environment resource type.
 type AccessControlPolicy struct {
-	DisallowRuleList []AccessControlDisallowRule `json:"disallowRuleList"`
+	DisallowRuleList []AccessControlRule `json:"disallowRuleList"`
 }
 
-// AccessControlDisallowRule is the disallow rule for access control policy.
-type AccessControlDisallowRule struct {
-	// DisallowDatabase will disallow the full database access.
-	DisallowDatabase bool `json:"disallowDatabase"`
+// AccessControlRule is the disallow rule for access control policy.
+type AccessControlRule struct {
+	// FullDatabase will apply to the full database.
+	FullDatabase bool `json:"fullDatabase"`
 }
 
 // UnmarshalAccessControlPolicy will unmarshal payload to access control policy.

--- a/api/policy.go
+++ b/api/policy.go
@@ -290,7 +290,13 @@ func (p *SensitiveDataPolicy) String() (string, error) {
 // AccessControlPolicy is the policy configuration for database access control.
 // It is only applicable to database and environment resource type.
 type AccessControlPolicy struct {
-	// TODO(d): define access control policy.
+	DisallowRuleList []AccessControlDisallowRule `json:"disallowRuleList"`
+}
+
+// AccessControlDisallowRule is the disallow rule for access control policy.
+type AccessControlDisallowRule struct {
+	// DisallowDatabase will disallow the full database access.
+	DisallowDatabase bool `json:"disallowDatabase"`
 }
 
 // UnmarshalAccessControlPolicy will unmarshal payload to access control policy.
@@ -406,8 +412,7 @@ func ValidatePolicy(resourceType PolicyResourceType, pType PolicyType, payload *
 		}
 		return nil
 	case PolicyTypeAccessControl:
-		_, err := UnmarshalAccessControlPolicy(*payload)
-		if err != nil {
+		if _, err := UnmarshalAccessControlPolicy(*payload); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
Access control policy includes a list of disallow rules. We only support the disallow rule that turns off access for the full database. In the future, we can add table, column, expiration time to the rule.

To disable the access for the whole environment, we should add policy with
```
inheritFromParent: true (default)


disallowRuleList: {
  {
    FullDatabase: true,
  },
}
```

To allow access for certain databases under an environment, we should add policy at database level with
```
inheritFromParent: false

disallowRuleList: {
}
```