### PR TITLE
feat: support merge PostgreSQL ALTER TABLE SET DEFAULT statement

### DIFF
--- a/plugin/parser/differ/pg/differ.go
+++ b/plugin/parser/differ/pg/differ.go
@@ -32,6 +32,7 @@ type diffNode struct {
 	dropForeignKeyList         []ast.Node
 	dropConstraintExceptFkList []ast.Node
 	dropIndexList              []ast.Node
+	dropDefaultList            []ast.Node
 	dropColumnList             []ast.Node
 	dropTableList              []ast.Node
 	dropSchemaList             []ast.Node
@@ -41,6 +42,7 @@ type diffNode struct {
 	createTableList              []ast.Node
 	createColumnList             []ast.Node
 	alterColumnList              []ast.Node
+	setDefaultList               []ast.Node
 	createIndexList              []ast.Node
 	createConstraintExceptFkList []ast.Node
 	createForeignKeyList         []ast.Node
@@ -176,19 +178,23 @@ func (m schemaMap) getIndex(schemaName string, indexName string) *indexInfo {
 	return schema.indexMap[indexName]
 }
 
-// mergeStatements merges some statements into one statement, for example, merge
+func parseAndPreprocessStatment(statement string) ([]ast.Node, error) {
+	nodeList, err := parser.Parse(parser.Postgres, parser.ParseContext{}, statement)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse statement %q", statement)
+	}
+	return mergeDefaultIntoColumn(nodeList)
+}
+
+// mergeDefaultIntoColumn merges some statements into one statement, for example, merge
 // `CREATE TABLE tbl(id INT DEFAULT '3');`,
 // `ALTER TABLE ONLY tbl ALTER COLUMN id nextval('tbl_id_seq'::regclass);`
 // to `CREATE TABLE tbl(id INT DEFAULT nextval('tbl_id_seq'::regclass));`.
-func mergeStatements(statements string) ([]ast.Node, error) {
-	nodes, err := parser.Parse(parser.Postgres, parser.ParseContext{}, statements)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse statements %q", statements)
-	}
+func mergeDefaultIntoColumn(nodeList []ast.Node) ([]ast.Node, error) {
 	var retNodes []ast.Node
 
 	schemaTableNameToRetNodesIdx := make(map[string]int)
-	for _, node := range nodes {
+	for _, node := range nodeList {
 		switch node := node.(type) {
 		case *ast.CreateTableStmt:
 			schemaTableName := node.Name.Schema + "." + node.Name.Name
@@ -198,39 +204,28 @@ func mergeStatements(statements string) ([]ast.Node, error) {
 			schemaTableName := node.Table.Schema + "." + node.Table.Name
 			retNodesIdx, ok := schemaTableNameToRetNodesIdx[schemaTableName]
 			if !ok {
-				return nil, errors.Errorf("cannot find table %s when merging statements %q", schemaTableName, statements)
+				// For pg_dump, this will never happen.
+				return nil, errors.Errorf("cannot find table %s", schemaTableName)
 			}
 			for _, alterItem := range node.AlterItemList {
 				switch item := alterItem.(type) {
 				case *ast.SetDefaultStmt:
-					columnFind := false
 					for _, columnDef := range retNodes[retNodesIdx].(*ast.CreateTableStmt).ColumnList {
 						if columnDef.ColumnName == item.ColumnName {
-							columnFind = true
 							constraintDef := &ast.ConstraintDef{
 								Type:       ast.ConstraintTypeDefault,
 								Expression: item.Expression,
 							}
-							defaultConstraintFind := false
-							for idx, constraint := range columnDef.ConstraintList {
-								if constraint.Type == ast.ConstraintTypeDefault {
-									columnDef.ConstraintList[idx] = constraintDef
-									defaultConstraintFind = true
-									break
-								}
-							}
-							if !defaultConstraintFind {
-								columnDef.ConstraintList = append(columnDef.ConstraintList, constraintDef)
-							}
+							// pg_dump will ensure that there is only one default constraint, in ColumnDef or AlterTableStmt.
+							columnDef.ConstraintList = append(columnDef.ConstraintList, constraintDef)
 							break
 						}
-					}
-					if !columnFind {
-						return nil, errors.Errorf("cannot find column %s when merging statements %q", item.ColumnName, statements)
 					}
 				default:
 					retNodes = append(retNodes, node)
 				}
+				// For pg_dump, Set Default statements will be alone in one alter tabel statement.
+				// So here sikp append is safe.
 			}
 		default:
 			retNodes = append(retNodes, node)
@@ -241,13 +236,13 @@ func mergeStatements(statements string) ([]ast.Node, error) {
 
 // SchemaDiff computes the schema differences between old and new schema.
 func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
-	oldNodes, err := mergeStatements(oldStmt)
+	oldNodes, err := parseAndPreprocessStatment(oldStmt)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to merge old statements %q", oldStmt)
+		return "", errors.Wrapf(err, "failed to parse and preprocess old statements %q", oldStmt)
 	}
-	newNodes, err := mergeStatements(newStmt)
+	newNodes, err := parseAndPreprocessStatment(newStmt)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to merge new statements %q", newStmt)
+		return "", errors.Wrapf(err, "failed to and preprocess new statements %q", newStmt)
 	}
 	oldSchemaMap := make(schemaMap)
 	oldSchemaMap["public"] = newSchemaInfo(-1, &ast.CreateSchemaStmt{Name: "public"})
@@ -608,15 +603,25 @@ func (diff *diffNode) modifyColumn(tableName *ast.TableDef, oldColumn *ast.Colum
 	if needSetDefault {
 		expression := &ast.UnconvertedExpressionDef{}
 		expression.SetText(newDefault)
-		alterTableStmt.AlterItemList = append(alterTableStmt.AlterItemList, &ast.SetDefaultStmt{
-			Table:      alterTableStmt.Table,
-			ColumnName: columnName,
-			Expression: expression,
+		diff.setDefaultList = append(diff.setDefaultList, &ast.AlterTableStmt{
+			Table: tableName,
+			AlterItemList: []ast.Node{
+				&ast.SetDefaultStmt{
+					Table:      alterTableStmt.Table,
+					ColumnName: columnName,
+					Expression: expression,
+				},
+			},
 		})
 	} else if needDropDefault {
-		alterTableStmt.AlterItemList = append(alterTableStmt.AlterItemList, &ast.DropDefaultStmt{
-			Table:      alterTableStmt.Table,
-			ColumnName: columnName,
+		diff.dropDefaultList = append(diff.dropDefaultList, &ast.AlterTableStmt{
+			Table: tableName,
+			AlterItemList: []ast.Node{
+				&ast.DropDefaultStmt{
+					Table:      alterTableStmt.Table,
+					ColumnName: columnName,
+				},
+			},
 		})
 	}
 
@@ -700,6 +705,9 @@ func (diff *diffNode) deparse() (string, error) {
 	if err := printStmtSlice(&buf, diff.dropIndexList); err != nil {
 		return "", err
 	}
+	if err := printStmtSlice(&buf, diff.dropDefaultList); err != nil {
+		return "", err
+	}
 	if err := printStmtSlice(&buf, diff.dropColumnList); err != nil {
 		return "", err
 	}
@@ -721,6 +729,9 @@ func (diff *diffNode) deparse() (string, error) {
 		return "", err
 	}
 	if err := printStmtSlice(&buf, diff.alterColumnList); err != nil {
+		return "", err
+	}
+	if err := printStmtSlice(&buf, diff.setDefaultList); err != nil {
 		return "", err
 	}
 	if err := printStmtSlice(&buf, diff.createIndexList); err != nil {

--- a/plugin/parser/differ/pg/differ_test.go
+++ b/plugin/parser/differ/pg/differ_test.go
@@ -60,6 +60,8 @@ func TestComputeDiff(t *testing.T) {
 		"test_differ_schema.yaml",
 		// Constraint
 		"test_differ_constraint.yaml",
+		// Merge
+		"test_differ_merge.yaml",
 	}
 	for _, test := range testFileList {
 		runDifferTest(t, test, false /* record */)

--- a/plugin/parser/differ/pg/test-data/test_differ_data.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_data.yaml
@@ -51,9 +51,9 @@
   newSchema: create table public.t1(a int DEFAULT 1, b int, c int DEFAULT 1+2+3+4)
   diff: |
     ALTER TABLE "public"."t1"
-        ALTER COLUMN "a" SET DEFAULT 1;
-    ALTER TABLE "public"."t1"
         ALTER COLUMN "b" DROP DEFAULT;
+    ALTER TABLE "public"."t1"
+        ALTER COLUMN "a" SET DEFAULT 1;
     ALTER TABLE "public"."t1"
         ALTER COLUMN "c" SET DEFAULT ((1 + 2) + 3) + 4;
 - oldSchema: |

--- a/plugin/parser/differ/pg/test-data/test_differ_merge.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_merge.yaml
@@ -1,0 +1,18 @@
+- oldSchema: |
+    CREATE TABLE public.t (a INTEGER);
+  newSchema: |
+    CREATE TABLE public.t (a INTEGER);
+    ALTER TABLE ONLY public.t ALTER COLUMN a SET DEFAULT nextval('public.t_a_seq'::regclass);
+  diff: |
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "a" SET DEFAULT nextval('public.t_a_seq'::regclass);
+
+- oldSchema: |
+    CREATE TABLE public.t (a INTEGER);
+    ALTER TABLE ONLY public.t ALTER COLUMN a SET DEFAULT nextval('public.t_a_seq'::regclass);
+  newSchema: |
+    CREATE TABLE public.t (a INTEGER);
+    ALTER TABLE ONLY public.t ALTER COLUMN a SET DEFAULT nextval('public.t_a_seq_2'::regclass);
+  diff: |
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "a" SET DEFAULT nextval('public.t_a_seq_2'::regclass);

--- a/plugin/parser/differ/pg/test-data/test_differ_merge.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_merge.yaml
@@ -6,7 +6,6 @@
   diff: |
     ALTER TABLE "public"."t"
         ALTER COLUMN "a" SET DEFAULT nextval('public.t_a_seq'::regclass);
-
 - oldSchema: |
     CREATE TABLE public.t (a INTEGER);
     ALTER TABLE ONLY public.t ALTER COLUMN a SET DEFAULT nextval('public.t_a_seq'::regclass);
@@ -16,3 +15,11 @@
   diff: |
     ALTER TABLE "public"."t"
         ALTER COLUMN "a" SET DEFAULT nextval('public.t_a_seq_2'::regclass);
+- oldSchema: |
+    CREATE TABLE public.t (a INTEGER);
+    ALTER TABLE ONLY public.t ALTER COLUMN a SET DEFAULT nextval('public.t_a_seq'::regclass);
+  newSchema: |
+    CREATE TABLE public.t (a INTEGER);
+  diff: |
+    ALTER TABLE "public"."t"
+        ALTER COLUMN "a" DROP DEFAULT;


### PR DESCRIPTION
We execute the following statement in PostgreSQL:
```sql
CRAETE TABLE tbl(id serial);
```
and pg_dump give us:
```SQL
CREATE TABLE public.tbl(
	id integer NOT NULL
);
CREATE SEQUENCE public.tbl_id_seq
	AS integer
    START WITH 1
    INCREMENT BY 1
    NO MINVALUE
    NO MAXVALUE
    CACHE 1;
ALTER SEQUENCE public.tbl_id_seq OWNED BY public.tbl.id;
ALTER TABLE ONLY public.tbl ALTER COLUMN id SET DEFAULT nextval('public.tbl_id_seq'::regclass);
```
And now we generate diff table result when we found a `CRAETE TABLE` statement in new statements.
So we need to merge the `ALTER TABLE ONLY public.tbl ALTER COLUMN id SET DEFAULT nextval('public.tbl_id_seq'::regclass);` into `CREATE TABLE` statement. 
This also lays the groundwork for SBM, if SBM supports such syntax.