### PR TITLE
fix: application runner, continue on failing to approve stage

### DIFF
--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -138,6 +138,7 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 									return nil
 								}(); err != nil {
 									log.Error("failed to approve stage", zap.Error(err))
+									continue
 								}
 
 								if _, err := r.store.PatchExternalApproval(ctx, &api.ExternalApprovalPatch{
@@ -146,6 +147,7 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 									RowStatus: api.Archived,
 								}); err != nil {
 									log.Error("failed to archive external apporval", zap.Error(err))
+									continue
 								}
 							}
 						}


### PR DESCRIPTION
We should continue if we fail to approve the stage; otherwise, we will send another approval because we archived the old external approval.

Completing BYT-1890