### PR TITLE
feat(sql-editor): improve connection info indicator

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ConnectionPathBar.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ConnectionPathBar.vue
@@ -4,13 +4,7 @@
     class="w-full py-1 px-4 flex justify-between items-center border-b"
     :class="[isProtectedEnvironment && 'bg-yellow-50']"
   >
-    <div :class="[isProtectedEnvironment ? 'text-yellow-700' : 'text-main']">
-      <template v-if="isProtectedEnvironment">
-        {{ $t("sql-editor.sql-execute-in-protected-environment") }}
-      </template>
-    </div>
-
-    <div class="action-right flex justify-end items-center">
+    <div class="flex justify-start items-center">
       <NPopover
         v-if="selectedInstance.id !== UNKNOWN_ID && !hasReadonlyDataSource"
         trigger="hover"
@@ -52,7 +46,11 @@
               v-if="selectedInstance.id !== UNKNOWN_ID"
               class="flex items-center"
             >
-              <span class="mx-2">/</span>
+              <span class="mx-2">
+                <heroicons-solid:chevron-right
+                  class="flex-shrink-0 h-4 w-4 text-control-light"
+                />
+              </span>
               <InstanceEngineIcon :instance="selectedInstance" show-status />
               <span class="ml-2">{{ selectedInstance.name }}</span>
             </div>
@@ -60,7 +58,11 @@
               v-if="selectedDatabase.id !== UNKNOWN_ID"
               class="flex items-center"
             >
-              <span class="mx-2">/</span>
+              <span class="mx-2">
+                <heroicons-solid:chevron-right
+                  class="flex-shrink-0 h-4 w-4 text-control-light"
+                />
+              </span>
               <heroicons-outline:database />
               <span class="ml-2">{{ selectedDatabase.name }}</span>
             </div>
@@ -98,6 +100,12 @@
           </div>
         </section>
       </NPopover>
+    </div>
+
+    <div :class="[isProtectedEnvironment ? 'text-yellow-700' : 'text-main']">
+      <template v-if="isProtectedEnvironment">
+        {{ $t("sql-editor.sql-execute-in-protected-environment") }}
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
BYT-1898

### Features
- Put the connection info closer to the database tree. This also makes it looks more like VSCode.
- Update the delimiter's style.

### Screenshot
**Before**
![localhost_3000_sql-editor(1600_900) (1)](https://user-images.githubusercontent.com/2749742/203929860-e8320b69-fe08-4cc4-838e-71c24ef492dc.png)

**After**
![localhost_3000_sql-editor(1600_900)](https://user-images.githubusercontent.com/2749742/203929868-daec15e2-e02a-4f7e-bb0e-440fe8e322c6.png)
