### PR TITLE
chore(differ): remove IF EXISTS and CASCADE for drop objects

### DIFF
--- a/plugin/parser/differ/pg/differ.go
+++ b/plugin/parser/differ/pg/differ.go
@@ -218,6 +218,7 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 			if err := oldSchemaMap.addIndex(i, stmt); err != nil {
 				return "", err
 			}
+			// TODO(rebelice): add default back here
 		}
 	}
 
@@ -285,8 +286,6 @@ func (*SchemaDiffer) SchemaDiff(oldStmt, newStmt string) (string, error) {
 			if err := diff.modifyIndex(oldIndex.createIndex, stmt); err != nil {
 				return "", err
 			}
-		default:
-			return "", errors.Errorf("unsupported statement %+v", stmt)
 		}
 	}
 
@@ -723,9 +722,7 @@ func dropTable(m schemaMap) *ast.DropTableStmt {
 		tableDefList = append(tableDefList, table.createTable.Name)
 	}
 	return &ast.DropTableStmt{
-		IfExists:  true,
 		TableList: tableDefList,
-		Behavior:  ast.DropBehaviorCascade,
 	}
 }
 
@@ -749,9 +746,7 @@ func dropSchema(m schemaMap) *ast.DropSchemaStmt {
 		schemaNameList = append(schemaNameList, schema.createSchema.Name)
 	}
 	return &ast.DropSchemaStmt{
-		IfExists:   true,
 		SchemaList: schemaNameList,
-		Behavior:   ast.DropBehaviorCascade,
 	}
 }
 
@@ -785,9 +780,7 @@ func dropIndex(m schemaMap) *ast.DropIndexStmt {
 		})
 	}
 	return &ast.DropIndexStmt{
-		IfExists:  true,
 		IndexList: indexDefList,
-		Behavior:  ast.DropBehaviorCascade,
 	}
 }
 

--- a/plugin/parser/differ/pg/test-data/test_differ_data.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_data.yaml
@@ -73,7 +73,7 @@
   diff: |
     ALTER TABLE "s1"."t2"
         DROP COLUMN "b";
-    DROP TABLE IF EXISTS "s1"."t1", "s2"."t4" CASCADE;
+    DROP TABLE "s1"."t1", "s2"."t4";
     CREATE TABLE "s1"."t3" (
         "a" integer,
         "b" integer
@@ -125,7 +125,7 @@
     CREATE INDEX idx3 ON public.t1 USING btree (a, b);
   diff: |
     DROP INDEX "public"."idx2";
-    DROP INDEX IF EXISTS "public"."idx1" CASCADE;
+    DROP INDEX "public"."idx1";
     CREATE INDEX "idx2" ON "public"."t1" USING btree (a);
     CREATE INDEX "idx3" ON "public"."t1" USING btree (a, b);
 - oldSchema: |

--- a/plugin/parser/differ/pg/test-data/test_differ_schema.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_schema.yaml
@@ -1,7 +1,7 @@
 - oldSchema: CREATE SCHEMA s1; CREATE SCHEMA s2;
   newSchema: CREATE SCHEMA s1;
   diff: |
-    DROP SCHEMA IF EXISTS "s2" CASCADE;
+    DROP SCHEMA "s2";
 - oldSchema: CREATE SCHEMA s1;
   newSchema: CREATE SCHEMA s1; CREATE SCHEMA s2;
   diff: |
@@ -9,5 +9,5 @@
 - oldSchema: CREATE SCHEMA s1; CREATE SCHEMA s2;
   newSchema: CREATE SCHEMA s2; CREATE SCHEMA s3;
   diff: |
-    DROP SCHEMA IF EXISTS "s1" CASCADE;
+    DROP SCHEMA "s1";
     CREATE SCHEMA "s3";


### PR DESCRIPTION
also, I remove the default for unsupported statement here. The reason is pg_dump returns SET statement but our parser does not support it. I'll add it back later.