### PR TITLE
feat: create activity on external approval rejected

### DIFF
--- a/api/activity.go
+++ b/api/activity.go
@@ -114,9 +114,8 @@ type ActivityIssueStatusUpdatePayload struct {
 
 // ActivityIssueExternalApprovalRejectPayload is the API message payloads for rejected external approvals.
 type ActivityIssueExternalApprovalRejectPayload struct {
-	AssigneeID int    `json:"assigneeId"`
-	StageName  string `json:"stageName"`
-	IMType     IMType `json:"imType"`
+	StageName            string               `json:"stageName"`
+	ExternalApprovalType ExternalApprovalType `json:"externalApprovalType"`
 }
 
 // ActivityPipelineTaskStatusUpdatePayload is the API message payloads for updating pipeline task status.

--- a/api/activity.go
+++ b/api/activity.go
@@ -29,6 +29,8 @@ const (
 	ActivityPipelineTaskStatementUpdate ActivityType = "bb.pipeline.task.statement.update"
 	// ActivityPipelineTaskEarliestAllowedTimeUpdate is the type for updating pipeline task the earliest allowed time.
 	ActivityPipelineTaskEarliestAllowedTimeUpdate ActivityType = "bb.pipeline.task.general.earliest-allowed-time.update"
+	// ActivityIssueExternalApprovalReject is the type for external approvals rejected on the IM side.
+	ActivityIssueExternalApprovalReject ActivityType = "bb.issue.external-approval.reject"
 
 	// Member related.
 
@@ -108,6 +110,13 @@ type ActivityIssueStatusUpdatePayload struct {
 	NewStatus IssueStatus `json:"newStatus,omitempty"`
 	// Used by inbox to display info without paying the join cost
 	IssueName string `json:"issueName"`
+}
+
+// ActivityIssueExternalApprovalRejectPayload is the API message payloads for rejected external approvals.
+type ActivityIssueExternalApprovalRejectPayload struct {
+	AssigneeID int    `json:"assigneeId"`
+	StageName  string `json:"stageName"`
+	IMType     IMType `json:"imType"`
 }
 
 // ActivityPipelineTaskStatusUpdatePayload is the API message payloads for updating pipeline task status.

--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -33,9 +33,11 @@ type ExternalApprovalPayloadFeishu struct {
 	StageID    int
 	AssigneeID int
 
-	// feishu
+	// Feishu
 	InstanceCode string
 	RequesterID  string
+	// Rejected tells if the approval has been rejected on Feishu.
+	Rejected bool
 }
 
 // ExternalApprovalCreate is the API message for creating an ExternalApproval.
@@ -59,4 +61,6 @@ type ExternalApprovalFind struct {
 type ExternalApprovalPatch struct {
 	ID        int
 	RowStatus RowStatus
+
+	Payload *string
 }

--- a/frontend/src/components/Issue/activity/ActionSentence.vue
+++ b/frontend/src/components/Issue/activity/ActionSentence.vue
@@ -10,6 +10,7 @@ import {
   ActivityTaskFileCommitPayload,
   ActivityTaskStatementUpdatePayload,
   ActivityTaskStatusUpdatePayload,
+  ActivityIssueExternalApprovalRejectPayload,
   Issue,
   SYSTEM_BOT_ID,
 } from "@/types";
@@ -34,6 +35,23 @@ const { t } = useI18n();
 const renderActionSentence = () => {
   const { activity, issue } = props;
   if (activity.type.startsWith("bb.issue.")) {
+    if (activity.type === "bb.issue.external-approval.reject") {
+      const payload =
+        activity.payload as ActivityIssueExternalApprovalRejectPayload;
+
+      switch (payload.externalApprovalType) {
+        case "bb.plugin.im.feishu":
+          return t("activity.sentence.external-approval-rejected", {
+            stageName: payload.stageName,
+            imName: t("common.feishu"),
+          });
+        default:
+          return t("activity.sentence.external-approval-rejected", {
+            stageName: payload.stageName,
+            imName: "",
+          });
+      }
+    }
     const [tid, params] = issueActivityActionSentence(activity);
     return t(tid, params);
   }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -429,7 +429,8 @@
       "project-member-delete": "delete project member",
       "project-member-role-update": "change project member role",
       "pipeline-task-earliest-allowed-time-update": "update earliest allowed time",
-      "database-recovery-pitr-done": "restore database to point in time"
+      "database-recovery-pitr-done": "restore database to point in time",
+      "external-approval-rejected": "external approval rejected"
     },
     "sentence": {
       "created-issue": "created issue",
@@ -456,7 +457,8 @@
       "failed": "failed",
       "task-name": " task {name}",
       "committed-to-at": "committed {file} to{branch}{'@'}{repo}",
-      "dismissed-stale-approval": "dismissed stale approvals of {task}"
+      "dismissed-stale-approval": "dismissed stale approvals of {task}",
+      "external-approval-rejected": "rejected external approval from {imName} of stage \"{stageName}\""
     },
     "subject-prefix": {
       "task": "Task"

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -456,7 +456,7 @@
       "completed": "completed",
       "failed": "failed",
       "task-name": " task {name}",
-      "committed-to-at": "committed {file} to{branch}{'@'}{repo}",
+      "committed-to-at": "committed {file} to {branch}{'@'}{repo}",
       "dismissed-stale-approval": "dismissed stale approvals of {task}",
       "external-approval-rejected": "rejected external approval from {imName} of stage \"{stageName}\""
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -429,7 +429,8 @@
       "project-member-delete": "删除项目成员",
       "project-member-role-update": "变更项目成员角色",
       "pipeline-task-earliest-allowed-time-update": "更新最早允许执行时间",
-      "database-recovery-pitr-done": "将数据库恢复到指定时间点"
+      "database-recovery-pitr-done": "将数据库恢复到指定时间点",
+      "external-approval-rejected": "拒绝外部审批"
     },
     "sentence": {
       "created-issue": "创建工单",
@@ -456,7 +457,8 @@
       "failed": "失败",
       "task-name": "任务 {name}",
       "committed-to-at": "提交 {file} 到 {branch}{'@'}{repo}",
-      "dismissed-stale-approval": "更新了{task}，此前的批准已被撤销"
+      "dismissed-stale-approval": "更新了{task}，此前的批准已被撤销",
+      "external-approval-rejected": "拒绝阶段 \"{stageName}\" 的{imName}外部审批"
     },
     "subject-prefix": {
       "task": "任务"

--- a/frontend/src/types/activity.ts
+++ b/frontend/src/types/activity.ts
@@ -13,6 +13,7 @@ import { TaskStatus } from "./pipeline";
 import { Principal } from "./principal";
 import { VCSPushEvent } from "./vcs";
 import { Advice } from "./sql";
+import { ExternalApprovalType } from "./externalApproval";
 import { t } from "../plugins/i18n";
 
 export type IssueActivityType =
@@ -20,6 +21,7 @@ export type IssueActivityType =
   | "bb.issue.comment.create"
   | "bb.issue.field.update"
   | "bb.issue.status.update"
+  | "bb.issue.external-approval.reject"
   | "bb.pipeline.task.status.update"
   | "bb.pipeline.task.file.commit"
   | "bb.pipeline.task.statement.update"
@@ -57,6 +59,8 @@ export function activityName(type: ActivityType): string {
       return t("activity.type.comment-create");
     case "bb.issue.field.update":
       return t("activity.type.issue-field-update");
+    case "bb.issue.external-approval.reject":
+      return t("activity.type.external-approval-rejected");
     case "bb.issue.status.update":
       return t("activity.type.issue-status-update");
     case "bb.pipeline.task.status.update":
@@ -113,6 +117,11 @@ export type ActivityIssueStatusUpdatePayload = {
   oldStatus: IssueStatus;
   newStatus: IssueStatus;
   issueName: string;
+};
+
+export type ActivityIssueExternalApprovalRejectPayload = {
+  stageName: string;
+  externalApprovalType: ExternalApprovalType;
 };
 
 export type ActivityTaskStatusUpdatePayload = {
@@ -198,6 +207,7 @@ export type ActionPayloadType =
   | ActivityIssueCommentCreatePayload
   | ActivityIssueFieldUpdatePayload
   | ActivityIssueStatusUpdatePayload
+  | ActivityIssueExternalApprovalRejectPayload
   | ActivityTaskStatusUpdatePayload
   | ActivityTaskFileCommitPayload
   | ActivityTaskStatementUpdatePayload

--- a/frontend/src/types/externalApproval.ts
+++ b/frontend/src/types/externalApproval.ts
@@ -1,0 +1,1 @@
+export type ExternalApprovalType = "bb.plugin.im.feishu";

--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -186,8 +186,8 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 									}
 								}
 								activityPayload, err := json.Marshal(api.ActivityIssueExternalApprovalRejectPayload{
-									StageName: stageName,
-									IMType:    api.IMTypeFeishu,
+									StageName:            stageName,
+									ExternalApprovalType: api.ExternalApprovalTypeFeishu,
 								})
 								if err != nil {
 									return errors.Wrap(err, "failed to marshal ActivityIssueExternalApprovalRejectPayload")

--- a/server/issue.go
+++ b/server/issue.go
@@ -1441,10 +1441,9 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 		Payload:     string(payload),
 	}
 
-	_, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{
+	if _, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{
 		issue: updatedIssue,
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, errors.Wrapf(err, "failed to create activity after changing the issue status: %v", issue.Name)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -300,7 +300,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 		// Backup runner
 		s.BackupRunner = NewBackupRunner(s, prof.BackupRunnerInterval)
 
-		s.ApplicationRunner = NewApplicationRunner(s.store, s.ActivityManager, feishu.NewProvider(prof.FeishuAPIURL))
+		s.ApplicationRunner = NewApplicationRunner(s.store, s.ActivityManager, feishu.NewProvider(prof.FeishuAPIURL), prof.Mode)
 
 		// Anomaly scanner
 		s.AnomalyScanner = NewAnomalyScanner(s)


### PR DESCRIPTION
Introduce a new activity type `ActivityIssueExternalApprovalReject`, it's on the issue level as the external approval does, too.

We create the activity if the feishu approval is rejected.

The newly-added field `rejected` is necessary for us to tell if it's the first time we encounter this so that we would not create the activity multiple times.

Completing BYT-1831

Screenshots:

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/12679343/204429690-e4b41da5-0f29-412e-8ee4-e5554cdc42ce.png">
<img width="455" alt="image" src="https://user-images.githubusercontent.com/12679343/204429732-efb44fed-527c-4693-862e-8523c35a7070.png">
