### PR TITLE
feat(frontend): prevent repeat clicking while creating instances

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -138,6 +138,7 @@
     "Default": "Default",
     "definition": "Definition",
     "empty": "Empty",
+    "connecting": "Connecting...",
     "creating": "Creating...",
     "updating": "Updating...",
     "Address": "Address",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -138,6 +138,7 @@
     "Default": "默认",
     "definition": "定义",
     "empty": "空",
+    "connecting": "连接中...",
     "creating": "创建中...",
     "updating": "更新中...",
     "Address": "地址",


### PR DESCRIPTION
Closing BYT-1889

### Features

- Show a "connecting..." indicator while we test the connection.
- Disable related buttons while testing the connection.

### Screenshots

![localhost_3000_instance(1600_900)](https://user-images.githubusercontent.com/2749742/203985370-81ff7bc7-6098-4ebd-bb79-f7ebe4c75f7f.png)
