### PR TITLE
chore: only log embedded pg info if embedded is used.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -155,13 +155,16 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 	var pgDataDir string
 	if prof.UseEmbedDB() {
 		pgDataDir = common.GetPostgresDataDir(prof.DataDir)
+		log.Info("-----Embedded Postgres Config BEGIN-----")
+		log.Info(fmt.Sprintf("datastorePort=%d", prof.DatastorePort))
+		log.Info(fmt.Sprintf("resourceDir=%s", resourceDir))
+		log.Info(fmt.Sprintf("pgdataDir=%s", pgDataDir))
+		log.Info("-----Embedded Postgres Config END-----")
+		log.Info("Preparing embedded PostgreSQL instance for metadb and pg_dump...")
+	} else {
+		log.Info("Preparing embedded PostgreSQL instance for pg_dump...")
 	}
-	log.Info("-----Embedded Postgres Config BEGIN-----")
-	log.Info(fmt.Sprintf("datastorePort=%d", prof.DatastorePort))
-	log.Info(fmt.Sprintf("resourceDir=%s", resourceDir))
-	log.Info(fmt.Sprintf("pgdataDir=%s", pgDataDir))
-	log.Info("-----Embedded Postgres Config END-----")
-	log.Info("Preparing embedded PostgreSQL instance...")
+
 	// Installs the Postgres binary and creates the 'activeProfile.pgUser' user/database
 	// to store Bytebase's own metadata.
 	log.Info(fmt.Sprintf("Installing Postgres OS %q Arch %q", runtime.GOOS, runtime.GOARCH))


### PR DESCRIPTION
This is the start of the series of refactoring I am going to do.

I noticed we introduced some engine-specific fields to the driver interface. This is something we really need to avoid. I will try to refactor this piece this time, but in the future, we shouldn't allow this to happen in the first place.

**THIS IS NOT THE CODE QUALITY WE LIVE UP TO**

https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/plugin/db/driver.go?L160&subtree=true

![CleanShot 2022-11-27 at 13 01 41@2x](https://user-images.githubusercontent.com/230323/204120010-ecbfd751-c0ad-49d7-85de-b11dec69b882.png)

![CleanShot 2022-11-27 at 13 02 26](https://user-images.githubusercontent.com/230323/204120034-25404d46-f8bb-4872-8f3d-3cb2cfe543ee.png)

![CleanShot 2022-11-27 at 13 02 46](https://user-images.githubusercontent.com/230323/204120046-cd747c94-caa9-4704-b8d2-f7878e205bc8.png)

Looking at the above image, we already have a bad smell to pass "" to pgInstanceDir.

