### PR TITLE
chore: move create tenant database schema generation from task creation to task execution

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -87,13 +87,12 @@ type TaskDatabasePITRCutoverPayload struct{}
 // TaskDatabaseCreatePayload is the task payload for creating databases.
 type TaskDatabaseCreatePayload struct {
 	// The project owning the database.
-	ProjectID     int    `json:"projectId,omitempty"`
-	DatabaseName  string `json:"databaseName,omitempty"`
-	Statement     string `json:"statement,omitempty"`
-	CharacterSet  string `json:"character,omitempty"`
-	Collation     string `json:"collation,omitempty"`
-	Labels        string `json:"labels,omitempty"`
-	SchemaVersion string `json:"schemaVersion,omitempty"`
+	ProjectID    int    `json:"projectId,omitempty"`
+	DatabaseName string `json:"databaseName,omitempty"`
+	Statement    string `json:"statement,omitempty"`
+	CharacterSet string `json:"character,omitempty"`
+	Collation    string `json:"collation,omitempty"`
+	Labels       string `json:"labels,omitempty"`
 }
 
 // TaskDatabaseSchemaBaselinePayload is the task payload for database schema baseline.

--- a/server/database.go
+++ b/server/database.go
@@ -834,6 +834,9 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 }
 
 func (s *Server) setDatabaseLabels(ctx context.Context, labelsJSON string, database *api.Database, project *api.Project, updaterID int, validateOnly bool) error {
+	if labelsJSON == "" {
+		return nil
+	}
 	// NOTE: this is a partially filled DatabaseLabel
 	var labels []*api.DatabaseLabel
 	if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {

--- a/server/issue.go
+++ b/server/issue.go
@@ -1100,7 +1100,7 @@ func (s *Server) createDatabaseCreateTaskList(ctx context.Context, c api.CreateD
 	if instance.Engine == db.Snowflake {
 		databaseName = strings.ToUpper(databaseName)
 	}
-	stmt, err := getCreateDatabaseStatement(instance.Engine, c, databaseName, adminDataSource.Username)
+	statement, err := getCreateDatabaseStatement(instance.Engine, c, databaseName, adminDataSource.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -1110,7 +1110,7 @@ func (s *Server) createDatabaseCreateTaskList(ctx context.Context, c api.CreateD
 		Collation:    c.Collation,
 		Labels:       c.Labels,
 		DatabaseName: databaseName,
-		Statement:    stmt,
+		Statement:    statement,
 	}
 	bytes, err := json.Marshal(payload)
 	if err != nil {

--- a/server/task.go
+++ b/server/task.go
@@ -333,9 +333,6 @@ func (s *Server) patchTask(ctx context.Context, task *api.Task, taskPatch *api.T
 			}
 			oldStatement = payload.Statement
 			payload.Statement = *taskPatch.Statement
-			// We should update the schema version if we've updated the SQL, otherwise we will
-			// get migration history version conflict if the previous task has been attempted.
-			payload.SchemaVersion = common.DefaultMigrationVersion()
 			bytes, err := json.Marshal(payload)
 			if err != nil {
 				return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to construct updated task payload").SetInternal(err)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1297,6 +1297,8 @@ func (ctl *controller) createDatabase(project *api.Project, instance *api.Instan
 	if err != nil {
 		return errors.Wrapf(err, "failed to patch issue status %v to done", issue.ID)
 	}
+	// Add a second sleep to avoid schema version conflict.
+	time.Sleep(time.Second)
 	return nil
 }
 


### PR DESCRIPTION
Previously, we allow users to edit the schema in create database issue if there is any error. However, the schema in the create database issue may be stale while creating the database.