### PR TITLE
refactor: use DbBinDir to unify MySQL/PG driver utility paths

### DIFF
--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -27,23 +27,23 @@ func getDatabase(u *dburl.URL) string {
 
 func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 	var dbType db.Type
-	var pgInstanceDir string
+	var dbBinDir string
 	resourceDir := os.TempDir()
 	switch u.Driver {
 	case "mysql":
 		dbType = db.MySQL
-		// dburl.Parse() parses 'pg', 'postgresql' and 'pgsql' to 'postgres'.
-		// https://pkg.go.dev/github.com/xo/dburl@v0.9.1#hdr-Protocol_Schemes_and_Aliases
-		if err := mysqlutil.Install(resourceDir); err != nil {
+		dir, err := mysqlutil.Install(resourceDir)
+		if err != nil {
 			return nil, errors.Wrapf(err, "cannot install mysqlutil in directory %q", resourceDir)
 		}
+		dbBinDir = dir
 	case "postgres":
 		dbType = db.Postgres
 		pgInstance, err := postgres.Install(resourceDir, "" /* pgDataDir */, "" /* pgUser */)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot install postgres in directory %q", resourceDir)
 		}
-		pgInstanceDir = pgInstance.BaseDir
+		dbBinDir = pgInstance.BinDir
 	default:
 		return nil, errors.Errorf("database type %q not supported; supported types: mysql, pg", u.Driver)
 	}
@@ -52,8 +52,7 @@ func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 		ctx,
 		dbType,
 		db.DriverConfig{
-			PgInstanceDir: pgInstanceDir,
-			ResourceDir:   resourceDir,
+			DbBinDir: dbBinDir,
 		},
 		db.ConnectionConfig{
 			Host:     u.Hostname(),

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -157,10 +157,12 @@ var (
 
 // DriverConfig is the driver configuration.
 type DriverConfig struct {
-	PgInstanceDir string
-	// We use resource directory to splice the path of embedded binary, likes binaries in mysqlutil package.
-	ResourceDir string
-	BinlogDir   string
+	// The directiory contains db specific utilites (e.g. mysqldump for MySQL, pg_dump for PostgreSQL).
+	DbBinDir string
+
+	// NOTE, introducing db specific fields is the last resort.
+	// MySQL specific
+	BinlogDir string
 }
 
 type driverFunc func(DriverConfig) Driver

--- a/plugin/db/mysql/dump.go
+++ b/plugin/db/mysql/dump.go
@@ -779,7 +779,7 @@ func (driver *Driver) restoreImpl(ctx context.Context, backup io.Reader, databas
 	if driver.connCfg.Password != "" {
 		mysqlArgs = append(mysqlArgs, fmt.Sprintf("--password=%s", driver.connCfg.Password))
 	}
-	mysqlCmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQL, driver.resourceDir), mysqlArgs...)
+	mysqlCmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQL, driver.dbBinDir), mysqlArgs...)
 
 	var stderr bytes.Buffer
 	countingReader := common.NewCountingReader(backup)

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -36,7 +36,7 @@ type Driver struct {
 	connectionCtx db.ConnectionContext
 	connCfg       db.ConnectionConfig
 	dbType        db.Type
-	resourceDir   string
+	dbBinDir      string
 	binlogDir     string
 	db            *sql.DB
 	// migrationConn is used to execute migrations.
@@ -50,8 +50,8 @@ type Driver struct {
 
 func newDriver(dc db.DriverConfig) db.Driver {
 	return &Driver{
-		resourceDir: dc.ResourceDir,
-		binlogDir:   dc.BinlogDir,
+		dbBinDir:  dc.DbBinDir,
+		binlogDir: dc.BinlogDir,
 	}
 }
 

--- a/plugin/db/mysql/restore.go
+++ b/plugin/db/mysql/restore.go
@@ -174,8 +174,8 @@ func (driver *Driver) replayBinlogFromDir(ctx context.Context, originalDatabase,
 		mysqlArgs = append(mysqlArgs, fmt.Sprintf("--password=%s", driver.connCfg.Password))
 	}
 
-	mysqlbinlogCmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.resourceDir), mysqlbinlogArgs...)
-	mysqlCmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQL, driver.resourceDir), mysqlArgs...)
+	mysqlbinlogCmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.dbBinDir), mysqlbinlogArgs...)
+	mysqlCmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQL, driver.dbBinDir), mysqlArgs...)
 	log.Debug("Start replay binlog commands.",
 		zap.String("mysqlbinlog", mysqlbinlogCmd.String()),
 		zap.String("mysql", mysqlCmd.String()))
@@ -705,7 +705,7 @@ func (driver *Driver) downloadBinlogFile(ctx context.Context, binlogFileToDownlo
 		args = append(args, "--port", driver.connCfg.Port)
 	}
 
-	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.resourceDir), args...)
+	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.dbBinDir), args...)
 	// We cannot set password as a flag. Otherwise, there is warning message
 	// "mysqlbinlog: [Warning] Using a password on the command line interface can be insecure."
 	if driver.connCfg.Password != "" {
@@ -948,7 +948,7 @@ func (driver *Driver) parseLocalBinlogFirstEventTs(ctx context.Context, fileName
 		// Tell mysqlbinlog to suppress the BINLOG statements for row events, which reduces the unneeded output.
 		"--base64-output=DECODE-ROWS",
 	}
-	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.resourceDir), args...)
+	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.dbBinDir), args...)
 	cmd.Stderr = os.Stderr
 	pr, err := cmd.StdoutPipe()
 	if err != nil {
@@ -993,7 +993,7 @@ func (driver *Driver) getBinlogEventPositionAtOrAfterTs(ctx context.Context, bin
 		// Instruct mysqlbinlog to start output only after encountering the first binlog event with timestamp equal or after targetTs.
 		"--start-datetime", formatDateTime(targetTs),
 	}
-	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.resourceDir), args...)
+	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.dbBinDir), args...)
 	cmd.Stderr = os.Stderr
 	pr, err := cmd.StdoutPipe()
 	if err != nil {

--- a/plugin/db/mysql/rollback.go
+++ b/plugin/db/mysql/rollback.go
@@ -76,7 +76,7 @@ func (driver *Driver) GenerateRollbackSQL(ctx context.Context, binlogFileNameLis
 	if driver.connCfg.Port != "" {
 		args = append(args, "--port", driver.connCfg.Port)
 	}
-	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.resourceDir), args...)
+	cmd := exec.CommandContext(ctx, mysqlutil.GetPath(mysqlutil.MySQLBinlog, driver.dbBinDir), args...)
 	log.Debug("mysqlbinlog", zap.String("command", cmd.String()))
 	if driver.connCfg.Password != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("MYSQL_PWD=%s", driver.connCfg.Password))

--- a/plugin/db/pg/dump.go
+++ b/plugin/db/pg/dump.go
@@ -74,7 +74,8 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 	// Avoid pg_dump v15 generate REVOKE/GRANT statement.
 	args = append(args, "--no-privileges")
 	args = append(args, database)
-	pgDumpPath := filepath.Join(driver.pgInstanceDir, "bin", "pg_dump")
+
+	pgDumpPath := filepath.Join(driver.dbBinDir, "pg_dump")
 	cmd := exec.CommandContext(ctx, pgDumpPath, args...)
 	if driver.config.Password != "" {
 		// Unlike MySQL, PostgreSQL does not support specifying commands in commands, we can do this by means of environment variables.

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -50,7 +50,7 @@ func init() {
 
 // Driver is the Postgres driver.
 type Driver struct {
-	pgInstanceDir string
+	dbBinDir      string
 	connectionCtx db.ConnectionContext
 	config        db.ConnectionConfig
 
@@ -64,7 +64,7 @@ type Driver struct {
 
 func newDriver(config db.DriverConfig) db.Driver {
 	return &Driver{
-		pgInstanceDir: config.PgInstanceDir,
+		dbBinDir: config.DbBinDir,
 	}
 }
 

--- a/resources/mysqlutil/mysqlutil_test.go
+++ b/resources/mysqlutil/mysqlutil_test.go
@@ -16,21 +16,21 @@ func TestRunBinary(t *testing.T) {
 
 	a := require.New(t)
 	tmpDir := t.TempDir()
-	err := Install(tmpDir)
+	binDir, err := Install(tmpDir)
 	a.NoError(err)
 
 	t.Run("run mysql client", func(t *testing.T) {
-		_, err := getExecutableVersion(MySQL, tmpDir)
+		_, err := getExecutableVersion(MySQL, binDir)
 		a.NoError(err)
 	})
 
 	t.Run("run mysqlbinlog", func(t *testing.T) {
-		_, err := getExecutableVersion(MySQLBinlog, tmpDir)
+		_, err := getExecutableVersion(MySQLBinlog, binDir)
 		a.NoError(err)
 	})
 
 	t.Run("run mysqldump", func(t *testing.T) {
-		_, err := getExecutableVersion(MySQLDump, tmpDir)
+		_, err := getExecutableVersion(MySQLDump, binDir)
 		a.NoError(err)
 	})
 }
@@ -46,11 +46,10 @@ func TestReinstallOnLinuxAmd64(t *testing.T) {
 
 	a := require.New(t)
 	tmpDir := t.TempDir()
-	err := Install(tmpDir)
+	binDir, err := Install(tmpDir)
 	a.NoError(err)
 
 	baseDir := filepath.Join(tmpDir, "mysqlutil-8.0.28-linux-glibc2.17-x86_64" /*Hard code, don't care about this*/)
-	binDir := filepath.Join(baseDir, "bin")
 	libDir := filepath.Join(baseDir, "lib", "private")
 
 	checks := []string{
@@ -59,8 +58,7 @@ func TestReinstallOnLinuxAmd64(t *testing.T) {
 		filepath.Join(binDir, "mysqldump"),
 	}
 
-	mysqlPath := GetPath(MySQL, tmpDir)
-
+	mysqlPath := GetPath(MySQL, binDir)
 	for _, fp := range checks {
 		a.FileExists(fp)
 
@@ -68,7 +66,7 @@ func TestReinstallOnLinuxAmd64(t *testing.T) {
 		a.NoError(err)
 		a.NoFileExists(fp)
 
-		err = Install(tmpDir)
+		_, err = Install(tmpDir)
 		a.NoError(err)
 		a.FileExists(fp)
 		a.FileExists(mysqlPath)

--- a/server/anomaly_scanner.go
+++ b/server/anomaly_scanner.go
@@ -150,7 +150,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api.Instance) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.server.pgInstance.BaseDir, s.server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.server.pgInstance.BinDir, s.server.profile.DataDir)
 
 	// Check connection
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 }
 
 func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api.Instance, database *api.Database) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, database.Name, s.server.pgInstance.BaseDir, s.server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, database.Name, s.server.pgInstance.BinDir, s.server.profile.DataDir)
 
 	// Check connection
 	if err != nil {

--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -264,7 +264,7 @@ func (r *BackupRunner) downloadBinlogFilesForInstance(ctx context.Context, insta
 		r.downloadBinlogMu.Unlock()
 		r.downloadBinlogWg.Done()
 	}()
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, r.server.pgInstance.BaseDir, r.server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, r.server.mysqlBinDir, r.server.profile.DataDir)
 	if err != nil {
 		if common.ErrorCode(err) == common.DbConnectionFailure {
 			log.Debug("Cannot connect to instance", zap.String("instance", instance.Name), zap.Error(err))
@@ -360,7 +360,7 @@ func (r *BackupRunner) startAutoBackups(ctx context.Context, runningTasks map[in
 
 func (s *Server) scheduleBackupTask(ctx context.Context, database *api.Database, backupName string, backupType api.BackupType, creatorID int) (*api.Backup, error) {
 	// Store the migration history version if exists.
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BaseDir, s.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BinDir, s.profile.DataDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get admin database driver")
 	}

--- a/server/database.go
+++ b/server/database.go
@@ -402,7 +402,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database not found with ID %d", id))
 		}
 
-		driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BaseDir, s.profile.DataDir)
+		driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BinDir, s.profile.DataDir)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get database driver").SetInternal(err)
 		}
@@ -883,7 +883,7 @@ func (s *Server) setDatabaseLabels(ctx context.Context, labelsJSON string, datab
 
 // Try to get database driver using the instance's admin data source.
 // Upon successful return, caller MUST call driver.Close, otherwise, it will leak the database connection.
-func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName, pgInstanceDir, dataDir string) (db.Driver, error) {
+func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databaseName, dbBinDir, dataDir string) (db.Driver, error) {
 	connCfg, err := getConnectionConfig(instance, databaseName)
 	if err != nil {
 		return nil, err
@@ -893,9 +893,8 @@ func getAdminDatabaseDriver(ctx context.Context, instance *api.Instance, databas
 		ctx,
 		instance.Engine,
 		db.DriverConfig{
-			PgInstanceDir: pgInstanceDir,
-			ResourceDir:   common.GetResourceDir(dataDir),
-			BinlogDir:     getBinlogAbsDir(dataDir, instance.ID),
+			DbBinDir:  dbBinDir,
+			BinlogDir: getBinlogAbsDir(dataDir, instance.ID),
 		},
 		connCfg,
 		db.ConnectionContext{

--- a/server/instance.go
+++ b/server/instance.go
@@ -184,7 +184,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		resultSet := &api.SQLResultSet{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BaseDir, s.profile.DataDir)
+		db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
 		if err != nil {
 			resultSet.Error = err.Error()
 		} else {
@@ -217,7 +217,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		instanceMigration := &api.InstanceMigration{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BaseDir, s.profile.DataDir)
+		db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
 		if err != nil {
 			instanceMigration.Status = api.InstanceMigrationSchemaUnknown
 			instanceMigration.Error = err.Error()
@@ -262,7 +262,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		find := &db.MigrationHistoryFind{ID: &historyID}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BaseDir, s.profile.DataDir)
+		driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history ID %d for instance %q", id, instance.Name)).SetInternal(err)
 		}
@@ -337,7 +337,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		historyList := []*api.MigrationHistory{}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BaseDir, s.profile.DataDir)
+		driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history for instance %q", instance.Name)).SetInternal(err)
 		}
@@ -388,11 +388,11 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 
 		// If the data dir does not exist, then we will start a PostgreSQL instance with a fixed port temporarily.
 		if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-			if err := postgres.InitDB(s.pgInstance.BaseDir, dataDir, pgUser); err != nil {
+			if err := postgres.InitDB(s.pgInstance.BinDir, dataDir, pgUser); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to init embedded postgres database").SetInternal(err)
 			}
 
-			if err := postgres.Start(port, s.pgInstance.BaseDir, dataDir, os.Stderr, os.Stderr); err != nil {
+			if err := postgres.Start(port, s.pgInstance.BinDir, dataDir, os.Stderr, os.Stderr); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to start embedded postgres instance").SetInternal(err)
 			}
 		}
@@ -454,7 +454,7 @@ func (s *Server) createInstance(ctx context.Context, create *api.InstanceCreate)
 	// Try creating the "bytebase" db in the added instance if needed.
 	// Since we allow user to add new instance upfront even providing the incorrect username/password,
 	// thus it's OK if it fails. Frontend will surface relevant info suggesting the "bytebase" db hasn't created yet.
-	db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BaseDir, s.profile.DataDir)
+	db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
 	if err == nil {
 		defer db.Close(ctx)
 		if err := db.SetupMigrationIfNeeded(ctx); err != nil {
@@ -533,7 +533,7 @@ func (s *Server) updateInstance(ctx context.Context, patch *api.InstancePatch) (
 
 	// Try immediately setup the migration schema, sync the engine version and schema after updating any connection related info.
 	if patch.Host != nil || patch.Port != nil {
-		db, err := getAdminDatabaseDriver(ctx, instancePatched, "" /* databaseName */, s.pgInstance.BaseDir, s.profile.DataDir)
+		db, err := getAdminDatabaseDriver(ctx, instancePatched, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
 		if err == nil {
 			defer db.Close(ctx)
 			if err := db.SetupMigrationIfNeeded(ctx); err != nil {

--- a/server/issue.go
+++ b/server/issue.go
@@ -1564,7 +1564,7 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 		return "", "", nil
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name, s.pgInstance.BaseDir, s.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name, s.pgInstance.BinDir, s.profile.DataDir)
 	if err != nil {
 		return "", "", err
 	}

--- a/server/sql.go
+++ b/server/sql.go
@@ -417,7 +417,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		start := time.Now().UnixNano()
 
 		bytes, queryErr := func() ([]byte, error) {
-			driver, err := getAdminDatabaseDriver(ctx, instance, exec.DatabaseName, s.pgInstance.BaseDir, s.profile.DataDir)
+			driver, err := getAdminDatabaseDriver(ctx, instance, exec.DatabaseName, s.pgInstance.BinDir, s.profile.DataDir)
 			if err != nil {
 				return nil, err
 			}
@@ -490,7 +490,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 }
 
 func (s *Server) syncInstance(ctx context.Context, instance *api.Instance) ([]string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstance.BaseDir, s.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstance.BinDir, s.profile.DataDir)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +647,7 @@ func (s *Server) syncInstanceSchema(ctx context.Context, instance *api.Instance,
 }
 
 func (s *Server) syncDatabaseSchema(ctx context.Context, instance *api.Instance, databaseName string) error {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstance.BaseDir, s.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstance.BinDir, s.profile.DataDir)
 	if err != nil {
 		return err
 	}

--- a/server/task_check_executor_database_connect.go
+++ b/server/task_check_executor_database_connect.go
@@ -43,7 +43,7 @@ func (*TaskCheckDatabaseConnectExecutor) Run(ctx context.Context, server *Server
 		return []api.TaskCheckResult{}, common.Errorf(common.Internal, "database ID not found %v", task.DatabaseID)
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return []api.TaskCheckResult{
 			{

--- a/server/task_check_executor_migration_schema.go
+++ b/server/task_check_executor_migration_schema.go
@@ -40,7 +40,7 @@ func (*TaskCheckMigrationSchemaExecutor) Run(ctx context.Context, server *Server
 		return []api.TaskCheckResult{}, err
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return []api.TaskCheckResult{}, err
 	}

--- a/server/task_check_executor_pitr_mysql.go
+++ b/server/task_check_executor_pitr_mysql.go
@@ -59,7 +59,7 @@ func (*TaskCheckPITRMySQLExecutor) Run(ctx context.Context, server *Server, task
 		return nil, errors.Wrapf(err, "failed to get instance by ID %d", instanceID)
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return nil, err
 	}

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -130,7 +130,7 @@ func executeMigration(ctx context.Context, server *Server, task *api.Task, state
 	statement = strings.TrimSpace(statement)
 	databaseName := task.Database.Name
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, databaseName, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, databaseName, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return 0, "", err
 	}

--- a/server/task_executor_database_backup.go
+++ b/server/task_executor_database_backup.go
@@ -142,7 +142,7 @@ func dumpBackupFile(ctx context.Context, driver db.Driver, databaseName, backupF
 
 // backupDatabase will take a backup of a database.
 func (*DatabaseBackupTaskExecutor) backupDatabase(ctx context.Context, server *Server, instance *api.Instance, databaseName string, backup *api.Backup) (string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return "", err
 	}

--- a/server/task_executor_database_create.go
+++ b/server/task_executor_database_create.go
@@ -51,7 +51,7 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	}
 
 	instance := task.Instance
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -92,7 +92,7 @@ func (*PITRCutoverTaskExecutor) GetProgress() api.Progress {
 // 2. Create a backup with type PITR. The backup is scheduled asynchronously.
 // We must check the possible failed/ongoing PITR type backup in the recovery process.
 func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.Task, server *Server, issue *api.Issue) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -173,7 +173,7 @@ func (exec *PITRRestoreTaskExecutor) doBackupRestore(ctx context.Context, server
 }
 
 func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *Server, task *api.Task, payload api.TaskDatabasePITRRestorePayload) (*api.TaskRunResultPayload, error) {
-	sourceDriver, err := getAdminDatabaseDriver(ctx, task.Instance, "", server.pgInstance.BaseDir, server.profile.DataDir)
+	sourceDriver, err := getAdminDatabaseDriver(ctx, task.Instance, "", server.mysqlBinDir, server.profile.DataDir)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *
 		if err != nil {
 			return nil, err
 		}
-		if targetDriver, err = getAdminDatabaseDriver(ctx, targetInstance, "", server.pgInstance.BaseDir, server.profile.DataDir); err != nil {
+		if targetDriver, err = getAdminDatabaseDriver(ctx, targetInstance, "", server.mysqlBinDir, server.profile.DataDir); err != nil {
 			return nil, err
 		}
 	}
@@ -344,7 +344,7 @@ func (*PITRRestoreTaskExecutor) doRestoreInPlacePostgres(ctx context.Context, se
 	}
 	defer backupFile.Close()
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func getIssueByPipelineID(ctx context.Context, store *store.Store, pid int) (*ap
 
 // restoreDatabase will restore the database to the instance from the backup.
 func (*PITRRestoreTaskExecutor) restoreDatabase(ctx context.Context, server *Server, instance *api.Instance, databaseName string, backup *api.Backup) error {
-	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, server.pgInstance.BaseDir, server.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, server.mysqlBinDir, server.profile.DataDir)
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func downloadBackupFileFromCloud(ctx context.Context, server *Server, backupPath
 // create many ephemeral databases from backup for testing purpose)
 // Returns migration history id and the version on success.
 func createBranchMigrationHistory(ctx context.Context, server *Server, sourceDatabase, targetDatabase *api.Database, backup *api.Backup, task *api.Task) (int64, string, error) {
-	targetDriver, err := getAdminDatabaseDriver(ctx, targetDatabase.Instance, targetDatabase.Name, server.pgInstance.BaseDir, server.profile.DataDir)
+	targetDriver, err := getAdminDatabaseDriver(ctx, targetDatabase.Instance, targetDatabase.Name, server.pgInstance.BinDir, server.profile.DataDir)
 	if err != nil {
 		return -1, "", err
 	}

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -76,7 +76,7 @@ func cutover(ctx context.Context, server *Server, task *api.Task, statement, sch
 		return true, nil, err
 	}
 	migrationID, schema, err := func() (migrationHistoryID int64, updatedSchema string, resErr error) {
-		driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, server.pgInstance.BaseDir, server.profile.DataDir)
+		driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, server.pgInstance.BinDir, server.profile.DataDir)
 		if err != nil {
 			return -1, "", err
 		}

--- a/server/task_executor_schema_update_sdl.go
+++ b/server/task_executor_schema_update_sdl.go
@@ -53,7 +53,7 @@ func (*SchemaUpdateSDLTaskExecutor) GetProgress() api.Progress {
 // and the given schema. It returns an empty string if there is no applicable
 // diff.
 func (s *Server) computeDatabaseSchemaDiff(ctx context.Context, database *api.Database, newSchemaStr string) (string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BaseDir, s.profile.DataDir)
+	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BinDir, s.profile.DataDir)
 	if err != nil {
 		return "", errors.Wrap(err, "get admin driver")
 	}

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -62,7 +62,7 @@ func (m *MetadataDB) Connect(datastorePort int, readonly bool, version string) (
 
 // connectEmbed starts the embed postgres server and returns an instance of store.DB.
 func (m *MetadataDB) connectEmbed(datastorePort int, pgUser string, readonly bool, demoDataDir, version string, mode common.ReleaseMode) (*DB, error) {
-	if err := postgres.Start(datastorePort, m.pgInstance.BaseDir, m.pgInstance.DataDir, os.Stderr, os.Stderr); err != nil {
+	if err := postgres.Start(datastorePort, m.pgInstance.BinDir, m.pgInstance.DataDir, os.Stderr, os.Stderr); err != nil {
 		return nil, err
 	}
 	m.pgInstance.Port = datastorePort
@@ -77,7 +77,7 @@ func (m *MetadataDB) connectEmbed(datastorePort int, pgUser string, readonly boo
 		Port:        fmt.Sprintf("%d", datastorePort),
 		StrictUseDb: false,
 	}
-	db := NewDB(connCfg, m.pgInstance.BaseDir, demoDataDir, readonly, version, mode)
+	db := NewDB(connCfg, m.pgInstance.BinDir, demoDataDir, readonly, version, mode)
 	return db, nil
 }
 
@@ -146,7 +146,7 @@ func (m *MetadataDB) connectExternal(readonly bool, version string) (*DB, error)
 		SslCert: q.Get("sslcert"),
 	}
 
-	db := NewDB(connCfg, m.pgInstance.BaseDir, m.demoDataDir, readonly, version, m.mode)
+	db := NewDB(connCfg, m.pgInstance.BinDir, m.demoDataDir, readonly, version, m.mode)
 	return db, nil
 }
 
@@ -157,7 +157,7 @@ func (m *MetadataDB) Close() error {
 	}
 
 	log.Info("Trying to shutdown postgresql server...")
-	if err := postgres.Stop(m.pgInstance.BaseDir, m.pgInstance.DataDir, os.Stdout, os.Stderr); err != nil {
+	if err := postgres.Stop(m.pgInstance.BinDir, m.pgInstance.DataDir, os.Stdout, os.Stderr); err != nil {
 		return err
 	}
 	m.pgStarted = false

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -64,8 +64,8 @@ type DB struct {
 	// Dir to load demo data
 	demoDataDir string
 
-	// Dir for postgres instance
-	pgBaseDir string
+	// Dir for postgres and its utility binaries
+	binDir string
 
 	// If true, database will be opened in readonly mode
 	readonly bool
@@ -82,11 +82,11 @@ type DB struct {
 }
 
 // NewDB returns a new instance of DB associated with the given datasource name.
-func NewDB(connCfg dbdriver.ConnectionConfig, pgBaseDir, demoDataDir string, readonly bool, serverVersion string, mode common.ReleaseMode) *DB {
+func NewDB(connCfg dbdriver.ConnectionConfig, binDir, demoDataDir string, readonly bool, serverVersion string, mode common.ReleaseMode) *DB {
 	db := &DB{
 		connCfg:       connCfg,
 		demoDataDir:   demoDataDir,
-		pgBaseDir:     pgBaseDir,
+		binDir:        binDir,
 		readonly:      readonly,
 		Now:           time.Now,
 		serverVersion: serverVersion,
@@ -100,7 +100,7 @@ func (db *DB) Open(ctx context.Context) (err error) {
 	d, err := dbdriver.Open(
 		ctx,
 		dbdriver.Postgres,
-		dbdriver.DriverConfig{PgInstanceDir: db.pgBaseDir},
+		dbdriver.DriverConfig{DbBinDir: db.binDir},
 		db.connCfg,
 		dbdriver.ConnectionContext{},
 	)

--- a/store/pg_engine_test.go
+++ b/store/pg_engine_test.go
@@ -148,7 +148,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	pgDir := t.TempDir()
 	pgInstance, err := postgres.Install(path.Join(pgDir, "resource"), path.Join(pgDir, "data"), pgUser)
 	require.NoError(t, err)
-	err = postgres.Start(pgPort, pgInstance.BaseDir, pgInstance.DataDir, os.Stderr, os.Stderr)
+	err = postgres.Start(pgPort, pgInstance.BinDir, pgInstance.DataDir, os.Stderr, os.Stderr)
 	require.NoError(t, err)
 	pgInstance.Port = pgPort
 
@@ -162,7 +162,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	d, err := dbdriver.Open(
 		ctx,
 		dbdriver.Postgres,
-		dbdriver.DriverConfig{PgInstanceDir: pgInstance.BaseDir},
+		dbdriver.DriverConfig{DbBinDir: pgInstance.BinDir},
 		connCfg,
 		dbdriver.ConnectionContext{},
 	)
@@ -212,7 +212,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	// The extra one is for the initial schema setup.
 	require.Len(t, histories, len(devMigrations)+1)
 
-	err = postgres.Stop(pgInstance.BaseDir, pgInstance.DataDir, os.Stdout, os.Stderr)
+	err = postgres.Stop(pgInstance.BinDir, pgInstance.DataDir, os.Stdout, os.Stderr)
 	require.NoError(t, err)
 }
 

--- a/tests/external_pg_test.go
+++ b/tests/external_pg_test.go
@@ -33,7 +33,7 @@ func newFakeExternalPg(tmpDir string, port int) (*fakeExternalPg, error) {
 		return nil, errors.Wrap(err, "cannot install postgres")
 	}
 
-	err = postgres.Start(port, pgIns.BaseDir, pgIns.DataDir, os.Stderr, os.Stderr)
+	err = postgres.Start(port, pgIns.BinDir, pgIns.DataDir, os.Stderr, os.Stderr)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot start postgres server")
 	}
@@ -47,7 +47,7 @@ func newFakeExternalPg(tmpDir string, port int) (*fakeExternalPg, error) {
 }
 
 func (f *fakeExternalPg) Destroy() error {
-	return postgres.Stop(f.pgIns.BaseDir, f.pgIns.DataDir, os.Stderr, os.Stderr)
+	return postgres.Stop(f.pgIns.BinDir, f.pgIns.DataDir, os.Stderr, os.Stderr)
 }
 
 func TestBootWithExternalPg(t *testing.T) {

--- a/tests/mysql.go
+++ b/tests/mysql.go
@@ -31,14 +31,14 @@ func connectTestMySQL(port int, database string) (*sql.DB, error) {
 	return sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?multiStatements=true", port, database))
 }
 
-func getTestMySQLDriver(ctx context.Context, t *testing.T, port, database, resourceDir string) (db.Driver, error) {
+func getTestMySQLDriver(ctx context.Context, t *testing.T, port, database, binDir string) (db.Driver, error) {
 	connCfg := getMySQLConnectionConfig(port, database)
 	return db.Open(
 		ctx,
 		db.MySQL,
 		db.DriverConfig{
-			ResourceDir: resourceDir,
-			BinlogDir:   t.TempDir(),
+			DbBinDir:  binDir,
+			BinlogDir: t.TempDir(),
 		},
 		connCfg,
 		db.ConnectionContext{},

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -133,10 +133,10 @@ func TestFetchBinlogFiles(t *testing.T) {
 	defer db.Close()
 
 	resourceDir := t.TempDir()
-	err = mysqlutil.Install(resourceDir)
+	binDir, err := mysqlutil.Install(resourceDir)
 	a.NoError(err)
 
-	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), "", resourceDir)
+	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), "", binDir)
 	a.NoError(err)
 	defer driver.Close(ctx)
 

--- a/tests/rollback_test.go
+++ b/tests/rollback_test.go
@@ -40,9 +40,9 @@ func TestRollback(t *testing.T) {
 	a.NoError(err)
 
 	resourceDir := t.TempDir()
-	err = mysqlutil.Install(resourceDir)
+	binDir, err := mysqlutil.Install(resourceDir)
 	a.NoError(err)
-	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), database, resourceDir)
+	driver, err := getTestMySQLDriver(ctx, t, strconv.Itoa(mysqlPort), database, binDir)
 	a.NoError(err)
 	defer driver.Close(ctx)
 


### PR DESCRIPTION
Unify PgInstanceDir/ResourceDir to DbBinDir. The driver only needs the dir for finding the utility binaries (pg_dump, mysql_dump, mysqlbinlog and etc.). The client is capable of passing the correct db-specific bin directory.

Overall, in the driver interface, we should avoid db-specific fields if possible (the BinlogDir is still unfortunate, but we may not have better options).