### PR TITLE
fix: populate correct binDir according to the instance engine type

### DIFF
--- a/server/anomaly_scanner.go
+++ b/server/anomaly_scanner.go
@@ -150,7 +150,7 @@ func (s *AnomalyScanner) Run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api.Instance) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.server.pgInstance.BinDir, s.server.profile.DataDir)
+	driver, err := s.server.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 
 	// Check connection
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *AnomalyScanner) checkInstanceAnomaly(ctx context.Context, instance *api
 }
 
 func (s *AnomalyScanner) checkDatabaseAnomaly(ctx context.Context, instance *api.Instance, database *api.Database) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, database.Name, s.server.pgInstance.BinDir, s.server.profile.DataDir)
+	driver, err := s.server.getAdminDatabaseDriver(ctx, instance, database.Name)
 
 	// Check connection
 	if err != nil {

--- a/server/backup_runner.go
+++ b/server/backup_runner.go
@@ -264,7 +264,7 @@ func (r *BackupRunner) downloadBinlogFilesForInstance(ctx context.Context, insta
 		r.downloadBinlogMu.Unlock()
 		r.downloadBinlogWg.Done()
 	}()
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, r.server.mysqlBinDir, r.server.profile.DataDir)
+	driver, err := r.server.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 	if err != nil {
 		if common.ErrorCode(err) == common.DbConnectionFailure {
 			log.Debug("Cannot connect to instance", zap.String("instance", instance.Name), zap.Error(err))
@@ -360,7 +360,7 @@ func (r *BackupRunner) startAutoBackups(ctx context.Context, runningTasks map[in
 
 func (s *Server) scheduleBackupTask(ctx context.Context, database *api.Database, backupName string, backupType api.BackupType, creatorID int) (*api.Backup, error) {
 	// Store the migration history version if exists.
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BinDir, s.profile.DataDir)
+	driver, err := s.getAdminDatabaseDriver(ctx, database.Instance, database.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get admin database driver")
 	}

--- a/server/instance.go
+++ b/server/instance.go
@@ -184,7 +184,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		resultSet := &api.SQLResultSet{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
+		db, err := s.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 		if err != nil {
 			resultSet.Error = err.Error()
 		} else {
@@ -217,7 +217,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		instanceMigration := &api.InstanceMigration{}
-		db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
+		db, err := s.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 		if err != nil {
 			instanceMigration.Status = api.InstanceMigrationSchemaUnknown
 			instanceMigration.Error = err.Error()
@@ -262,7 +262,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		find := &db.MigrationHistoryFind{ID: &historyID}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
+		driver, err := s.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history ID %d for instance %q", id, instance.Name)).SetInternal(err)
 		}
@@ -337,7 +337,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		historyList := []*api.MigrationHistory{}
-		driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
+		driver, err := s.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch migration history for instance %q", instance.Name)).SetInternal(err)
 		}
@@ -454,7 +454,7 @@ func (s *Server) createInstance(ctx context.Context, create *api.InstanceCreate)
 	// Try creating the "bytebase" db in the added instance if needed.
 	// Since we allow user to add new instance upfront even providing the incorrect username/password,
 	// thus it's OK if it fails. Frontend will surface relevant info suggesting the "bytebase" db hasn't created yet.
-	db, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
+	db, err := s.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 	if err == nil {
 		defer db.Close(ctx)
 		if err := db.SetupMigrationIfNeeded(ctx); err != nil {
@@ -533,7 +533,7 @@ func (s *Server) updateInstance(ctx context.Context, patch *api.InstancePatch) (
 
 	// Try immediately setup the migration schema, sync the engine version and schema after updating any connection related info.
 	if patch.Host != nil || patch.Port != nil {
-		db, err := getAdminDatabaseDriver(ctx, instancePatched, "" /* databaseName */, s.pgInstance.BinDir, s.profile.DataDir)
+		db, err := s.getAdminDatabaseDriver(ctx, instancePatched, "" /* databaseName */)
 		if err == nil {
 			defer db.Close(ctx)
 			if err := db.SetupMigrationIfNeeded(ctx); err != nil {

--- a/server/issue.go
+++ b/server/issue.go
@@ -1499,7 +1499,7 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 		return "", "", nil
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name, s.pgInstance.BinDir, s.profile.DataDir)
+	driver, err := s.getAdminDatabaseDriver(ctx, similarDB.Instance, similarDB.Name)
 	if err != nil {
 		return "", "", err
 	}

--- a/server/openapi_sql.go
+++ b/server/openapi_sql.go
@@ -105,7 +105,7 @@ func (s *Server) sqlCheckController(c echo.Context) error {
 		if err != nil {
 			return err
 		}
-		driver, err = tryGetReadOnlyDatabaseDriver(ctx, database.Instance, database.Name)
+		driver, err = s.tryGetReadOnlyDatabaseDriver(ctx, database.Instance, database.Name)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get database driver").SetInternal(err)
 		}

--- a/server/rollback_runner.go
+++ b/server/rollback_runner.go
@@ -14,21 +14,18 @@ import (
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/mysql"
-	"github.com/bytebase/bytebase/store"
 )
 
 // NewRollbackRunner creates a new rollback runner.
-func NewRollbackRunner(store *store.Store, dataDir string) *RollbackRunner {
+func NewRollbackRunner(server *Server) *RollbackRunner {
 	return &RollbackRunner{
-		store:   store,
-		dataDir: dataDir,
+		server: server,
 	}
 }
 
 // RollbackRunner is the rollback runner generating rollback SQL statements.
 type RollbackRunner struct {
-	store       *store.Store
-	dataDir     string
+	server      *Server
 	generateMap sync.Map
 }
 
@@ -62,7 +59,7 @@ func (r *RollbackRunner) retryGenerateRollbackSQL(ctx context.Context) {
 		TypeList:   &[]api.TaskType{api.TaskDatabaseDataUpdate},
 		Payload:    "payload->>'threadID'!='' AND payload->>'rollbackError' IS NULL AND payload->>'rollbackStatement' IS NULL",
 	}
-	taskList, err := r.store.FindTask(ctx, find, true)
+	taskList, err := r.server.store.FindTask(ctx, find, true)
 	if err != nil {
 		log.Error("Failed to get running DML tasks", zap.Error(err))
 		return
@@ -108,7 +105,7 @@ func (r *RollbackRunner) generateRollbackSQL(ctx context.Context, task *api.Task
 		UpdaterID: api.SystemBotID,
 		Payload:   &payloadString,
 	}
-	if _, err := r.store.PatchTask(ctx, patch); err != nil {
+	if _, err := r.server.store.PatchTask(ctx, patch); err != nil {
 		log.Error("Failed to patch task with the MySQL thread ID", zap.Int("taskID", task.ID))
 		return
 	}
@@ -126,7 +123,7 @@ func (r *RollbackRunner) generateRollbackSQLImpl(ctx context.Context, task *api.
 	}
 	binlogFileNameList := mysql.GenBinlogFileNames(basename, seqStart, seqEnd)
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "", "", r.dataDir)
+	driver, err := r.server.getAdminDatabaseDriver(ctx, task.Instance, "")
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to get admin database driver")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -313,7 +313,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 		s.AnomalyScanner = NewAnomalyScanner(s)
 
 		// Rollback SQL generator
-		s.RollbackRunner = NewRollbackRunner(s.store, s.profile.DataDir)
+		s.RollbackRunner = NewRollbackRunner(s)
 
 		// Metric reporter
 		s.initMetricReporter(config.workspaceID)

--- a/server/sql.go
+++ b/server/sql.go
@@ -202,7 +202,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create a catalog")
 			}
 
-			driver, err := tryGetReadOnlyDatabaseDriver(ctx, instance, exec.DatabaseName)
+			driver, err := s.tryGetReadOnlyDatabaseDriver(ctx, instance, exec.DatabaseName)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get database driver").SetInternal(err)
 			}
@@ -268,7 +268,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		start := time.Now().UnixNano()
 
 		bytes, queryErr := func() ([]byte, error) {
-			driver, err := tryGetReadOnlyDatabaseDriver(ctx, instance, exec.DatabaseName)
+			driver, err := s.tryGetReadOnlyDatabaseDriver(ctx, instance, exec.DatabaseName)
 			if err != nil {
 				return nil, err
 			}
@@ -417,7 +417,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		start := time.Now().UnixNano()
 
 		bytes, queryErr := func() ([]byte, error) {
-			driver, err := getAdminDatabaseDriver(ctx, instance, exec.DatabaseName, s.pgInstance.BinDir, s.profile.DataDir)
+			driver, err := s.getAdminDatabaseDriver(ctx, instance, exec.DatabaseName)
 			if err != nil {
 				return nil, err
 			}
@@ -490,7 +490,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 }
 
 func (s *Server) syncInstance(ctx context.Context, instance *api.Instance) ([]string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstance.BinDir, s.profile.DataDir)
+	driver, err := s.getAdminDatabaseDriver(ctx, instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +647,7 @@ func (s *Server) syncInstanceSchema(ctx context.Context, instance *api.Instance,
 }
 
 func (s *Server) syncDatabaseSchema(ctx context.Context, instance *api.Instance, databaseName string) error {
-	driver, err := getAdminDatabaseDriver(ctx, instance, "", s.pgInstance.BinDir, s.profile.DataDir)
+	driver, err := s.getAdminDatabaseDriver(ctx, instance, "")
 	if err != nil {
 		return err
 	}

--- a/server/task_check_executor_database_connect.go
+++ b/server/task_check_executor_database_connect.go
@@ -43,7 +43,7 @@ func (*TaskCheckDatabaseConnectExecutor) Run(ctx context.Context, server *Server
 		return []api.TaskCheckResult{}, common.Errorf(common.Internal, "database ID not found %v", task.DatabaseID)
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, database.Instance, database.Name)
 	if err != nil {
 		return []api.TaskCheckResult{
 			{

--- a/server/task_check_executor_migration_schema.go
+++ b/server/task_check_executor_migration_schema.go
@@ -40,7 +40,7 @@ func (*TaskCheckMigrationSchemaExecutor) Run(ctx context.Context, server *Server
 		return []api.TaskCheckResult{}, err
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 	if err != nil {
 		return []api.TaskCheckResult{}, err
 	}

--- a/server/task_check_executor_pitr_mysql.go
+++ b/server/task_check_executor_pitr_mysql.go
@@ -59,7 +59,7 @@ func (*TaskCheckPITRMySQLExecutor) Run(ctx context.Context, server *Server, task
 		return nil, errors.Wrapf(err, "failed to get instance by ID %d", instanceID)
 	}
 
-	driver, err := getAdminDatabaseDriver(ctx, instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, instance, "" /* databaseName */)
 	if err != nil {
 		return nil, err
 	}

--- a/server/task_check_executor_statement_advisor_composite.go
+++ b/server/task_check_executor_statement_advisor_composite.go
@@ -67,7 +67,7 @@ func (*TaskCheckStatementAdvisorCompositeExecutor) Run(ctx context.Context, serv
 		return nil, err
 	}
 
-	driver, err := tryGetReadOnlyDatabaseDriver(ctx, task.Instance, task.Database.Name)
+	driver, err := server.tryGetReadOnlyDatabaseDriver(ctx, task.Instance, task.Database.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/server/task_executor.go
+++ b/server/task_executor.go
@@ -130,7 +130,7 @@ func executeMigration(ctx context.Context, server *Server, task *api.Task, state
 	statement = strings.TrimSpace(statement)
 	databaseName := task.Database.Name
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, databaseName, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, task.Instance, databaseName)
 	if err != nil {
 		return 0, "", err
 	}

--- a/server/task_executor_database_backup.go
+++ b/server/task_executor_database_backup.go
@@ -142,7 +142,7 @@ func dumpBackupFile(ctx context.Context, driver db.Driver, databaseName, backupF
 
 // backupDatabase will take a backup of a database.
 func (*DatabaseBackupTaskExecutor) backupDatabase(ctx context.Context, server *Server, instance *api.Instance, databaseName string, backup *api.Backup) (string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, instance, databaseName)
 	if err != nil {
 		return "", err
 	}

--- a/server/task_executor_database_create.go
+++ b/server/task_executor_database_create.go
@@ -52,7 +52,7 @@ func (exec *DatabaseCreateTaskExecutor) RunOnce(ctx context.Context, server *Ser
 	}
 
 	instance := task.Instance
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */)
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_pitr_cutover.go
+++ b/server/task_executor_pitr_cutover.go
@@ -92,7 +92,7 @@ func (*PITRCutoverTaskExecutor) GetProgress() api.Progress {
 // 2. Create a backup with type PITR. The backup is scheduled asynchronously.
 // We must check the possible failed/ongoing PITR type backup in the recovery process.
 func (exec *PITRCutoverTaskExecutor) pitrCutover(ctx context.Context, task *api.Task, server *Server, issue *api.Issue) (terminated bool, result *api.TaskRunResultPayload, err error) {
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, task.Instance, "" /* databaseName */)
 	if err != nil {
 		return true, nil, err
 	}

--- a/server/task_executor_pitr_restore.go
+++ b/server/task_executor_pitr_restore.go
@@ -173,7 +173,7 @@ func (exec *PITRRestoreTaskExecutor) doBackupRestore(ctx context.Context, server
 }
 
 func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *Server, task *api.Task, payload api.TaskDatabasePITRRestorePayload) (*api.TaskRunResultPayload, error) {
-	sourceDriver, err := getAdminDatabaseDriver(ctx, task.Instance, "", server.mysqlBinDir, server.profile.DataDir)
+	sourceDriver, err := server.getAdminDatabaseDriver(ctx, task.Instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (exec *PITRRestoreTaskExecutor) doPITRRestore(ctx context.Context, server *
 		if err != nil {
 			return nil, err
 		}
-		if targetDriver, err = getAdminDatabaseDriver(ctx, targetInstance, "", server.mysqlBinDir, server.profile.DataDir); err != nil {
+		if targetDriver, err = server.getAdminDatabaseDriver(ctx, targetInstance, ""); err != nil {
 			return nil, err
 		}
 	}
@@ -344,7 +344,7 @@ func (*PITRRestoreTaskExecutor) doRestoreInPlacePostgres(ctx context.Context, se
 	}
 	defer backupFile.Close()
 
-	driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, server.pgInstance.BinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func getIssueByPipelineID(ctx context.Context, store *store.Store, pid int) (*ap
 
 // restoreDatabase will restore the database to the instance from the backup.
 func (*PITRRestoreTaskExecutor) restoreDatabase(ctx context.Context, server *Server, instance *api.Instance, databaseName string, backup *api.Backup) error {
-	driver, err := getAdminDatabaseDriver(ctx, instance, databaseName, server.mysqlBinDir, server.profile.DataDir)
+	driver, err := server.getAdminDatabaseDriver(ctx, instance, databaseName)
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func downloadBackupFileFromCloud(ctx context.Context, server *Server, backupPath
 // create many ephemeral databases from backup for testing purpose)
 // Returns migration history id and the version on success.
 func createBranchMigrationHistory(ctx context.Context, server *Server, sourceDatabase, targetDatabase *api.Database, backup *api.Backup, task *api.Task) (int64, string, error) {
-	targetDriver, err := getAdminDatabaseDriver(ctx, targetDatabase.Instance, targetDatabase.Name, server.pgInstance.BinDir, server.profile.DataDir)
+	targetDriver, err := server.getAdminDatabaseDriver(ctx, targetDatabase.Instance, targetDatabase.Name)
 	if err != nil {
 		return -1, "", err
 	}

--- a/server/task_executor_schema_update_ghost_cutover.go
+++ b/server/task_executor_schema_update_ghost_cutover.go
@@ -76,7 +76,7 @@ func cutover(ctx context.Context, server *Server, task *api.Task, statement, sch
 		return true, nil, err
 	}
 	migrationID, schema, err := func() (migrationHistoryID int64, updatedSchema string, resErr error) {
-		driver, err := getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name, server.pgInstance.BinDir, server.profile.DataDir)
+		driver, err := server.getAdminDatabaseDriver(ctx, task.Instance, task.Database.Name)
 		if err != nil {
 			return -1, "", err
 		}

--- a/server/task_executor_schema_update_sdl.go
+++ b/server/task_executor_schema_update_sdl.go
@@ -53,7 +53,7 @@ func (*SchemaUpdateSDLTaskExecutor) GetProgress() api.Progress {
 // and the given schema. It returns an empty string if there is no applicable
 // diff.
 func (s *Server) computeDatabaseSchemaDiff(ctx context.Context, database *api.Database, newSchemaStr string) (string, error) {
-	driver, err := getAdminDatabaseDriver(ctx, database.Instance, database.Name, s.pgInstance.BinDir, s.profile.DataDir)
+	driver, err := s.getAdminDatabaseDriver(ctx, database.Instance, database.Name)
 	if err != nil {
 		return "", errors.Wrap(err, "get admin driver")
 	}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -359,7 +359,7 @@ func (s *Server) sqlAdviceForFile(
 			return nil, errors.Errorf("Failed to get catalog for database %v with error: %v", database.ID, err)
 		}
 
-		driver, err := tryGetReadOnlyDatabaseDriver(ctx, database.Instance, database.Name)
+		driver, err := s.tryGetReadOnlyDatabaseDriver(ctx, database.Instance, database.Name)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Fix getAdminDatabaseDriver
* Add the driver config for tryGetReadOnlyDatabaseDriver

Followup https://github.com/bytebase/bytebase/pull/3541