### PR TITLE
refactor: deployment configuration refactoring to consolidate pipeline generation

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -798,11 +798,20 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 			}
 
 			migrationDetail := c.DetailList[0]
-			baseDBName := migrationDetail.DatabaseName
-			deployments, matrix, err := s.getTenantDatabaseMatrix(ctx, issueCreate.ProjectID, project.DBNameTemplate, dbList, baseDBName)
+			baseDatabaseName := migrationDetail.DatabaseName
+			deployConfig, err := s.store.GetDeploymentConfigByProjectID(ctx, project.ID)
 			if err != nil {
-				return nil, err
+				return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch deployment config for project ID: %v", project.ID)).SetInternal(err)
 			}
+			deploySchedule, err := api.ValidateAndGetDeploymentSchedule(deployConfig.Payload)
+			if err != nil {
+				return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to get deployment schedule").SetInternal(err)
+			}
+			deployments, matrix, err := getDatabaseMatrixFromDeploymentSchedule(deploySchedule, baseDatabaseName, project.DBNameTemplate, dbList)
+			if err != nil {
+				return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create deployment pipeline").SetInternal(err)
+			}
+
 			// Convert to pipelineCreate
 			for i, databaseList := range matrix {
 				// Since environment is required for stage, we use an internal bb system environment for tenant deployments.
@@ -1425,26 +1434,6 @@ func (s *Server) postInboxIssueActivity(ctx context.Context, issue *api.Issue, a
 	return nil
 }
 
-func (s *Server) getTenantDatabaseMatrix(ctx context.Context, projectID int, dbNameTemplate string, dbList []*api.Database, baseDatabaseName string) ([]*api.Deployment, [][]*api.Database, error) {
-	deployConfig, err := s.store.GetDeploymentConfigByProjectID(ctx, projectID)
-	if err != nil {
-		return nil, nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch deployment config for project ID: %v", projectID)).SetInternal(err)
-	}
-	if deployConfig == nil {
-		return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Deployment config missing for project ID: %v", projectID)).SetInternal(err)
-	}
-	deploySchedule, err := api.ValidateAndGetDeploymentSchedule(deployConfig.Payload)
-	if err != nil {
-		return nil, nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to get deployment schedule").SetInternal(err)
-	}
-
-	d, matrix, err := getDatabaseMatrixFromDeploymentSchedule(deploySchedule, baseDatabaseName, dbNameTemplate, dbList)
-	if err != nil {
-		return nil, nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create deployment pipeline").SetInternal(err)
-	}
-	return d, matrix, nil
-}
-
 // getSchemaFromPeerTenantDatabase gets the schema version and schema from a peer tenant database.
 // It's used for creating a database in a tenant mode project.
 // When a peer tenant database doesn't exist, we will return an error if there are databases in the project with the same name.
@@ -1458,9 +1447,17 @@ func (s *Server) getSchemaFromPeerTenantDatabase(ctx context.Context, instance *
 		return "", "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch databases in project ID: %v", projectID)).SetInternal(err)
 	}
 
-	_, matrix, err := s.getTenantDatabaseMatrix(ctx, projectID, project.DBNameTemplate, dbList, baseDatabaseName)
+	deployConfig, err := s.store.GetDeploymentConfigByProjectID(ctx, projectID)
 	if err != nil {
-		return "", "", err
+		return "", "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch deployment config for project ID: %v", projectID)).SetInternal(err)
+	}
+	deploySchedule, err := api.ValidateAndGetDeploymentSchedule(deployConfig.Payload)
+	if err != nil {
+		return "", "", echo.NewHTTPError(http.StatusInternalServerError, "Failed to get deployment schedule").SetInternal(err)
+	}
+	_, matrix, err := getDatabaseMatrixFromDeploymentSchedule(deploySchedule, baseDatabaseName, project.DBNameTemplate, dbList)
+	if err != nil {
+		return "", "", echo.NewHTTPError(http.StatusInternalServerError, "Failed to create deployment pipeline").SetInternal(err)
 	}
 	similarDB := getPeerTenantDatabase(matrix, instance.EnvironmentID)
 

--- a/store/deploy.go
+++ b/store/deploy.go
@@ -54,23 +54,23 @@ func (raw *deploymentConfigRaw) toDeploymentConfig() *api.DeploymentConfig {
 }
 
 // GetDeploymentConfigByProjectID gets an instance of DeploymentConfig.
-func (s *Store) GetDeploymentConfigByProjectID(ctx context.Context, projectID int) (*api.DeploymentConfig, error) {
+func (s *Store) GetDeploymentConfigByProjectID(ctx context.Context, projectID int) (api.DeploymentConfig, error) {
 	deploymentConfigRaw, err := s.getDeploymentConfigImpl(ctx, &api.DeploymentConfigFind{ProjectID: &projectID})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get DeploymentConfig with projectID %d", projectID)
+		return api.DeploymentConfig{}, errors.Wrapf(err, "failed to get DeploymentConfig with projectID %d", projectID)
 	}
 	if deploymentConfigRaw == nil {
 		config, err := s.getDefaultDeploymentConfig(ctx, projectID)
 		if err != nil {
-			return nil, err
+			return api.DeploymentConfig{}, err
 		}
 		deploymentConfigRaw = config
 	}
 	deploymentConfig, err := s.composeDeploymentConfig(ctx, deploymentConfigRaw)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to compose DeploymentConfig with deploymentConfigRaw[%+v]", deploymentConfigRaw)
+		return api.DeploymentConfig{}, errors.Wrapf(err, "failed to compose DeploymentConfig with deploymentConfigRaw[%+v]", deploymentConfigRaw)
 	}
-	return deploymentConfig, nil
+	return *deploymentConfig, nil
 }
 
 func (s *Store) getDefaultDeploymentConfig(ctx context.Context, projectID int) (*deploymentConfigRaw, error) {
@@ -96,8 +96,13 @@ func (s *Store) getDefaultDeploymentConfig(ctx context.Context, projectID int) (
 	if err != nil {
 		return nil, err
 	}
-	config := &deploymentConfigRaw{ID: 0, CreatorID: api.SystemBotID, UpdaterID: api.SystemBotID, ProjectID: projectID, Payload: string(bytes)}
-	return config, nil
+	return &deploymentConfigRaw{
+		ID:        0,
+		CreatorID: api.SystemBotID,
+		UpdaterID: api.SystemBotID,
+		ProjectID: projectID,
+		Payload:   string(bytes),
+	}, nil
 }
 
 // UpsertDeploymentConfig upserts an instance of DeploymentConfig.


### PR DESCRIPTION
The function getTenantDatabaseMatrix() will no longer be a shared function (right now two references) as a follow-up change. We will only rely on getDatabaseMatrixFromDeploymentSchedule().