### PR TITLE
refactor: remove pgInstance to split the code path between embed and external pg mode

### DIFF
--- a/bin/bb/cmd/utils.go
+++ b/bin/bb/cmd/utils.go
@@ -39,11 +39,11 @@ func open(ctx context.Context, u *dburl.URL) (db.Driver, error) {
 		dbBinDir = dir
 	case "postgres":
 		dbType = db.Postgres
-		pgInstance, err := postgres.Install(resourceDir, "" /* pgDataDir */, "" /* pgUser */)
+		dir, err := postgres.Install(resourceDir)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot install postgres in directory %q", resourceDir)
 		}
-		dbBinDir = pgInstance.BinDir
+		dbBinDir = dir
 	default:
 		return nil, errors.Errorf("database type %q not supported; supported types: mysql, pg", u.Driver)
 	}

--- a/resources/mysql/mysql.go
+++ b/resources/mysql/mysql.go
@@ -157,8 +157,8 @@ user=%s
 }
 
 // SetupTestInstance installs and starts a mysql instance for testing,
-// returns the instance and the stop function.
-func SetupTestInstance(t *testing.T, port int) (*Instance, func()) {
+// returns the stop function.
+func SetupTestInstance(t *testing.T, port int) func() {
 	basedir, datadir := t.TempDir(), t.TempDir()
 	t.Log("Installing Mysql...")
 	i, err := Install(basedir, datadir, "root")
@@ -177,7 +177,7 @@ func SetupTestInstance(t *testing.T, port int) (*Instance, func()) {
 		}
 	}
 
-	return i, stopFn
+	return stopFn
 }
 
 // Import executes sql script in the given path on the instance.

--- a/server/database.go
+++ b/server/database.go
@@ -897,7 +897,7 @@ func (s *Server) getAdminDatabaseDriver(ctx context.Context, instance *api.Insta
 	case db.MySQL, db.TiDB:
 		dbBinDir = s.mysqlBinDir
 	case db.Postgres:
-		dbBinDir = s.pgInstance.BinDir
+		dbBinDir = s.pgBinDir
 	}
 
 	driver, err := getDatabaseDriver(
@@ -953,7 +953,7 @@ func (s *Server) tryGetReadOnlyDatabaseDriver(ctx context.Context, instance *api
 	case db.MySQL, db.TiDB:
 		dbBinDir = s.mysqlBinDir
 	case db.Postgres:
-		dbBinDir = s.pgInstance.BinDir
+		dbBinDir = s.pgBinDir
 	}
 
 	driver, err := getDatabaseDriver(

--- a/server/instance.go
+++ b/server/instance.go
@@ -388,11 +388,11 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 
 		// If the data dir does not exist, then we will start a PostgreSQL instance with a fixed port temporarily.
 		if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-			if err := postgres.InitDB(s.pgInstance.BinDir, dataDir, pgUser); err != nil {
+			if err := postgres.InitDB(s.pgBinDir, dataDir, pgUser); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to init embedded postgres database").SetInternal(err)
 			}
 
-			if err := postgres.Start(port, s.pgInstance.BinDir, dataDir, os.Stderr, os.Stderr); err != nil {
+			if err := postgres.Start(port, s.pgBinDir, dataDir, os.Stderr, os.Stderr); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to start embedded postgres instance").SetInternal(err)
 			}
 		}

--- a/store/pg_engine_test.go
+++ b/store/pg_engine_test.go
@@ -146,11 +146,13 @@ var (
 func TestMigrationCompatibility(t *testing.T) {
 	log.SetLevel(zap.DebugLevel)
 	pgDir := t.TempDir()
-	pgInstance, err := postgres.Install(path.Join(pgDir, "resource"), path.Join(pgDir, "data"), pgUser)
+	pgBinDir, err := postgres.Install(path.Join(pgDir, "resource"))
+	pgDataDir := path.Join(pgDir, "data")
 	require.NoError(t, err)
-	err = postgres.Start(pgPort, pgInstance.BinDir, pgInstance.DataDir, os.Stderr, os.Stderr)
+	err = postgres.InitDB(pgBinDir, pgDataDir, pgUser)
 	require.NoError(t, err)
-	pgInstance.Port = pgPort
+	err = postgres.Start(pgPort, pgBinDir, pgDataDir, os.Stderr, os.Stderr)
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	connCfg := dbdriver.ConnectionConfig{
@@ -162,7 +164,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	d, err := dbdriver.Open(
 		ctx,
 		dbdriver.Postgres,
-		dbdriver.DriverConfig{DbBinDir: pgInstance.BinDir},
+		dbdriver.DriverConfig{DbBinDir: pgBinDir},
 		connCfg,
 		dbdriver.ConnectionContext{},
 	)
@@ -212,7 +214,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	// The extra one is for the initial schema setup.
 	require.Len(t, histories, len(devMigrations)+1)
 
-	err = postgres.Stop(pgInstance.BinDir, pgInstance.DataDir, os.Stdout, os.Stderr)
+	err = postgres.Stop(pgBinDir, pgDataDir, os.Stdout, os.Stderr)
 	require.NoError(t, err)
 }
 

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -288,7 +288,7 @@ func TestPITRToNewDatabaseInAnotherInstance(t *testing.T) {
 	defer cleanFn()
 
 	dstPort := getTestPort()
-	_, dstStopFn := resourcemysql.SetupTestInstance(t, dstPort)
+	dstStopFn := resourcemysql.SetupTestInstance(t, dstPort)
 	defer dstStopFn()
 	dstConnCfg := getMySQLConnectionConfig(strconv.Itoa(dstPort), "")
 
@@ -441,7 +441,7 @@ func setUpForPITRTest(ctx context.Context, t *testing.T, ctl *controller) (*api.
 	databaseName := baseName + "_Database"
 
 	mysqlPort := getTestPort()
-	_, stopInstance := resourcemysql.SetupTestInstance(t, mysqlPort)
+	stopInstance := resourcemysql.SetupTestInstance(t, mysqlPort)
 	connCfg := getMySQLConnectionConfig(strconv.Itoa(mysqlPort), "")
 	instance, err := ctl.addInstance(api.InstanceCreate{
 		EnvironmentID: prodEnvironment.ID,

--- a/tests/ghost_test.go
+++ b/tests/ghost_test.go
@@ -82,7 +82,7 @@ func TestGhostSchemaUpdate(t *testing.T) {
 	a.NoError(err)
 
 	mysqlPort := getTestPort()
-	_, stopInstance := mysql.SetupTestInstance(t, mysqlPort)
+	stopInstance := mysql.SetupTestInstance(t, mysqlPort)
 	defer stopInstance()
 
 	mysqlDB, err := connectTestMySQL(mysqlPort, "")

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -27,7 +27,7 @@ func TestCheckEngineInnoDB(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		mysqlPort := getTestPort()
-		_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
+		stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 		defer stopFn()
 		t.Log("create test database")
 		database := "test_success"
@@ -55,7 +55,7 @@ func TestCheckEngineInnoDB(t *testing.T) {
 	t.Run("fail", func(t *testing.T) {
 		t.Parallel()
 		mysqlPort := getTestPort()
-		_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
+		stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 		defer stopFn()
 		t.Log("create test database")
 		database := "test_fail"
@@ -91,7 +91,7 @@ func TestCheckServerVersionAndBinlogForPITR(t *testing.T) {
 	ctx := context.Background()
 
 	mysqlPort := getTestPort()
-	_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
+	stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 	defer stopFn()
 
 	db, err := connectTestMySQL(mysqlPort, "")
@@ -125,7 +125,7 @@ func TestFetchBinlogFiles(t *testing.T) {
 	log.SetLevel(zapcore.DebugLevel)
 
 	mysqlPort := getTestPort()
-	_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
+	stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 	defer stopFn()
 
 	db, err := connectTestMySQL(mysqlPort, "")

--- a/tests/rollback_test.go
+++ b/tests/rollback_test.go
@@ -26,7 +26,7 @@ func TestRollback(t *testing.T) {
 	database := "funny\ndatabase"
 
 	mysqlPort := getTestPort()
-	_, stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
+	stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 	defer stopFn()
 
 	db, err := connectTestMySQL(mysqlPort, "")
@@ -113,7 +113,7 @@ func TestCreateRollbackIssueMySQL(t *testing.T) {
 
 	// Create a MySQL instance.
 	mysqlPort := getTestPort()
-	_, stopInstance := resourcemysql.SetupTestInstance(t, mysqlPort)
+	stopInstance := resourcemysql.SetupTestInstance(t, mysqlPort)
 	defer stopInstance()
 
 	// Create a project.

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -755,7 +755,7 @@ func TestVCS_SDL(t *testing.T) {
 
 			// Create a PostgreSQL instance.
 			pgPort := getTestPort()
-			_, stopInstance := postgres.SetupTestInstance(t, pgPort)
+			stopInstance := postgres.SetupTestInstance(t, pgPort)
 			defer stopInstance()
 
 			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
@@ -1486,7 +1486,7 @@ func TestVCS_SQL_Review(t *testing.T) {
 
 			// Create a PostgreSQL instance.
 			pgPort := getTestPort()
-			_, stopInstance := postgres.SetupTestInstance(t, pgPort)
+			stopInstance := postgres.SetupTestInstance(t, pgPort)
 			defer stopInstance()
 
 			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
@@ -1924,7 +1924,7 @@ CREATE TABLE public.book (
 			dbPort := getTestPort()
 			switch test.dbType {
 			case db.Postgres:
-				_, stopInstance := postgres.SetupTestInstance(t, dbPort)
+				stopInstance := postgres.SetupTestInstance(t, dbPort)
 				defer stopInstance()
 			default:
 				a.FailNow("unsupported db type")

--- a/tests/sensitive_data_test.go
+++ b/tests/sensitive_data_test.go
@@ -53,7 +53,7 @@ func TestSensitiveData(t *testing.T) {
 
 	// Create a MySQL instance.
 	mysqlPort := getTestPort()
-	_, stopInstance := mysql.SetupTestInstance(t, mysqlPort)
+	stopInstance := mysql.SetupTestInstance(t, mysqlPort)
 	defer stopInstance()
 
 	mysqlDB, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/mysql", mysqlPort))

--- a/tests/sql_review_test.go
+++ b/tests/sql_review_test.go
@@ -265,7 +265,7 @@ func TestSQLReviewForPostgreSQL(t *testing.T) {
 
 	// Create a PostgreSQL instance.
 	pgPort := getTestPort()
-	_, stopInstance := postgres.SetupTestInstance(t, pgPort)
+	stopInstance := postgres.SetupTestInstance(t, pgPort)
 	defer stopInstance()
 
 	pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
@@ -999,7 +999,7 @@ func TestSQLReviewForMySQL(t *testing.T) {
 
 	// Create a MySQL instance.
 	mysqlPort := getTestPort()
-	_, stopInstance := mysql.SetupTestInstance(t, mysqlPort)
+	stopInstance := mysql.SetupTestInstance(t, mysqlPort)
 	defer stopInstance()
 
 	mysqlDB, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/mysql", mysqlPort))


### PR DESCRIPTION
To decouple the pg utility binaries usage from the postgres server used in embed mode. In both embed and external mode, the pg utility binaries are always needed, so we always install them (because we bundle postgres and utility binaries together , thus in such case, we would still install the unneeded postgres binary, this is a minor issue that we can stay with for now).

While pgDataDir and initdb are only needed in embed mode.

----

This completes the refactor around how we pass around db specific binaries

https://github.com/bytebase/bytebase/pull/3539
https://github.com/bytebase/bytebase/pull/3541
https://github.com/bytebase/bytebase/pull/3543
https://github.com/bytebase/bytebase/pull/3544