### PR TITLE
chore(differ): fix bugs for dropping statements in differ

### DIFF
--- a/plugin/parser/differ/pg/differ.go
+++ b/plugin/parser/differ/pg/differ.go
@@ -34,9 +34,9 @@ type diffNode struct {
 	dropIndexList              []ast.Node
 	dropDefaultList            []ast.Node
 	dropSequenceOwnedByList    []ast.Node
-	dropSequenceList           []ast.Node
 	dropColumnList             []ast.Node
 	dropTableList              []ast.Node
+	dropSequenceList           []ast.Node
 	dropSchemaList             []ast.Node
 
 	// Create nodes
@@ -973,13 +973,13 @@ func (diff *diffNode) deparse() (string, error) {
 	if err := printStmtSlice(&buf, diff.dropSequenceOwnedByList); err != nil {
 		return "", err
 	}
-	if err := printStmtSlice(&buf, diff.dropSequenceList); err != nil {
-		return "", err
-	}
 	if err := printStmtSlice(&buf, diff.dropColumnList); err != nil {
 		return "", err
 	}
 	if err := printStmtSlice(&buf, diff.dropTableList); err != nil {
+		return "", err
+	}
+	if err := printStmtSlice(&buf, diff.dropSequenceList); err != nil {
 		return "", err
 	}
 	if err := printStmtSlice(&buf, diff.dropSchemaList); err != nil {
@@ -1049,10 +1049,6 @@ func (diff *diffNode) dropConstraint(m schemaMap) {
 func dropTable(m schemaMap) *ast.DropTableStmt {
 	var tableList []*tableInfo
 	for _, schema := range m {
-		if !schema.existsInNew {
-			// dropped by DROP SCHEMA ... CASCADE statements
-			continue
-		}
 		for _, table := range schema.tableMap {
 			if table.existsInNew {
 				// no need to drop
@@ -1104,10 +1100,6 @@ func dropSchema(m schemaMap) *ast.DropSchemaStmt {
 func dropIndex(m schemaMap) *ast.DropIndexStmt {
 	var indexList []*indexInfo
 	for _, schema := range m {
-		if !schema.existsInNew {
-			// dropped by DROP SCHEMA ... CASCADE statements
-			continue
-		}
 		for _, index := range schema.indexMap {
 			if index.existsInNew {
 				// no need to drop

--- a/plugin/parser/differ/pg/differ_test.go
+++ b/plugin/parser/differ/pg/differ_test.go
@@ -64,6 +64,8 @@ func TestComputeDiff(t *testing.T) {
 		"test_differ_merge.yaml",
 		// Sequence
 		"test_differ_sequence.yaml",
+		// Drop
+		"test_drop_statement.yaml",
 	}
 	for _, test := range testFileList {
 		runDifferTest(t, test, false /* record */)

--- a/plugin/parser/differ/pg/differ_test.go
+++ b/plugin/parser/differ/pg/differ_test.go
@@ -64,8 +64,6 @@ func TestComputeDiff(t *testing.T) {
 		"test_differ_merge.yaml",
 		// Sequence
 		"test_differ_sequence.yaml",
-		// Drop
-		"test_drop_statement.yaml",
 	}
 	for _, test := range testFileList {
 		runDifferTest(t, test, false /* record */)

--- a/plugin/parser/differ/pg/test-data/test_differ_data.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_data.yaml
@@ -150,3 +150,21 @@
         ALTER COLUMN "e" SET DATA TYPE jsonb;
     ALTER TABLE "public"."t"
         ALTER COLUMN "f" SET DATA TYPE pg_catalog.bit(4);
+- oldSchema: |
+    create schema schema1;
+    create table schema1.t1(a int, b int, c int);
+    create index idx_t1_a on schema1.t1(a);
+    create sequence schema1.sequence1
+      NO MINVALUE
+      NO MAXVALUE
+      START WITH 1;
+    alter sequence schema1.sequence1 owned by schema1.t1.a;
+    alter table schema1.t1 alter column a set default nextval('schema1.sequence1'::regclass);
+  newSchema: ""
+  diff: |
+    DROP INDEX "schema1"."idx_t1_a";
+    ALTER SEQUENCE "schema1"."sequence1"
+        OWNED BY NONE;
+    DROP TABLE "schema1"."t1";
+    DROP SEQUENCE "schema1"."sequence1";
+    DROP SCHEMA "schema1";

--- a/plugin/parser/differ/pg/test-data/test_differ_sequence.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_sequence.yaml
@@ -37,8 +37,8 @@
   diff: |
     ALTER SEQUENCE "public"."s1"
         OWNED BY NONE;
-    DROP SEQUENCE "public"."s1";
     DROP TABLE "public"."t1";
+    DROP SEQUENCE "public"."s1";
 - oldSchema: |
     create table public.t1 (a int);
     create sequence public.s1


### PR DESCRIPTION
This PR fix two bugs:
1. The PostgreSQL differ needs to drop objects as the safe order, so that we cannot skip dropping index `schema_a.index_a` if `schema_a` need to be dropped. We should drop the `index_a` firstly and then drop the `schema_a`;
2. The correct order to drop sequences is that:
        drop sequence owned by -> drop table/column -> drop sequence
    The reason is that some columns may depend on sequences by DEFAULT clause. And after `dropping sequence owned by`, dropping a table/column does not drop dependent sequences. This is as expected.

related issues #3542 