### PR TITLE
feat: add database name field to instance table

### DIFF
--- a/store/migration/dev/20221128000000##database_in_instance.sql
+++ b/store/migration/dev/20221128000000##database_in_instance.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instance ADD COLUMN database TEXT DEFAULT '' NOT NULL;

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -278,7 +278,8 @@ CREATE TABLE instance (
     engine_version TEXT NOT NULL DEFAULT '',
     host TEXT NOT NULL,
     port TEXT NOT NULL,
-    external_link TEXT NOT NULL DEFAULT ''
+    external_link TEXT NOT NULL DEFAULT '',
+    database TEXT NOT NULL DEFAULT ''
 );
 
 ALTER SEQUENCE instance_id_seq RESTART WITH 101;


### PR DESCRIPTION
We currently guess the connecting database name following the order: username, bytebase, postgres, template1.

![CleanShot 2022-11-28 at 13 18 51](https://user-images.githubusercontent.com/230323/204199670-edd7af53-82ce-4f10-b782-529529551237.png)

The instance might not have any of those databases (e.g. Render), so we need to give the user an explicit way to specify the database name.