### PR TITLE
chore: suppress PG stdout message

### DIFF
--- a/server/instance.go
+++ b/server/instance.go
@@ -392,7 +392,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to init embedded postgres database").SetInternal(err)
 			}
 
-			if err := postgres.Start(port, s.pgBinDir, dataDir, os.Stderr, os.Stderr); err != nil {
+			if err := postgres.Start(port, s.pgBinDir, dataDir); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to start embedded postgres instance").SetInternal(err)
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -553,8 +553,8 @@ func (s *Server) Run(ctx context.Context, port int) error {
 
 // Shutdown will shut down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	log.Info("Trying to stop Bytebase...")
-	log.Info("Trying to gracefully shutdown server...")
+	log.Info("Stopping Bytebase...")
+	log.Info("Stopping web server...")
 
 	// Close the metric reporter
 	if s.MetricReporter != nil {

--- a/store/metadb.go
+++ b/store/metadb.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -65,7 +64,7 @@ func (m *MetadataDB) Connect(datastorePort int, readonly bool, version string) (
 
 // connectEmbed starts the embed postgres server and returns an instance of store.DB.
 func (m *MetadataDB) connectEmbed(datastorePort int, pgUser string, readonly bool, demoDataDir, version string, mode common.ReleaseMode) (*DB, error) {
-	if err := postgres.Start(datastorePort, m.binDir, m.pgDataDir, os.Stderr, os.Stderr); err != nil {
+	if err := postgres.Start(datastorePort, m.binDir, m.pgDataDir); err != nil {
 		return nil, err
 	}
 	// mark pgStarted if start successfully, used in Close()
@@ -158,8 +157,8 @@ func (m *MetadataDB) Close() error {
 		return nil
 	}
 
-	log.Info("Trying to shutdown postgresql server...")
-	if err := postgres.Stop(m.binDir, m.pgDataDir, os.Stdout, os.Stderr); err != nil {
+	log.Info("Stopping PostgreSQL...")
+	if err := postgres.Stop(m.binDir, m.pgDataDir); err != nil {
 		return err
 	}
 	m.pgStarted = false

--- a/store/pg_engine_test.go
+++ b/store/pg_engine_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -151,7 +150,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	require.NoError(t, err)
 	err = postgres.InitDB(pgBinDir, pgDataDir, pgUser)
 	require.NoError(t, err)
-	err = postgres.Start(pgPort, pgBinDir, pgDataDir, os.Stderr, os.Stderr)
+	err = postgres.Start(pgPort, pgBinDir, pgDataDir)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -214,7 +213,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	// The extra one is for the initial schema setup.
 	require.Len(t, histories, len(devMigrations)+1)
 
-	err = postgres.Stop(pgBinDir, pgDataDir, os.Stdout, os.Stderr)
+	err = postgres.Stop(pgBinDir, pgDataDir)
 	require.NoError(t, err)
 }
 

--- a/tests/external_pg_test.go
+++ b/tests/external_pg_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -38,7 +37,7 @@ func newFakeExternalPg(tmpDir string, port int) (*fakeExternalPg, error) {
 		return nil, errors.Wrap(err, "cannot initdb")
 	}
 
-	err = postgres.Start(port, pgBinDir, dataDir, os.Stderr, os.Stderr)
+	err = postgres.Start(port, pgBinDir, dataDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot start postgres server")
 	}
@@ -52,7 +51,7 @@ func newFakeExternalPg(tmpDir string, port int) (*fakeExternalPg, error) {
 }
 
 func (f *fakeExternalPg) Destroy() error {
-	return postgres.Stop(f.pgBinDir, f.pgDataDir, os.Stderr, os.Stderr)
+	return postgres.Stop(f.pgBinDir, f.pgDataDir)
 }
 
 func TestBootWithExternalPg(t *testing.T) {


### PR DESCRIPTION
Keep stderr and suppress stdout.

The underlying PG message is not useful.