### PR TITLE
feat(web-terminal): trigger run when pressing Enter key

### DIFF
--- a/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
@@ -177,6 +177,33 @@ const handleEditorReady = async () => {
     },
   });
 
+  editor?.addCommand(monaco.KeyCode.Enter, (...args: any[]) => {
+    // When
+    // - the SQL ends with ";"
+    // - and the cursor is at the end of the editor
+    // - then press "Enter"
+    // We trigger the "execute" event
+    if (props.sql.endsWith(";")) {
+      const model = editor.getModel();
+      if (model) {
+        const maxLine = model.getLineCount();
+        const maxColumn = model.getLineMaxColumn(maxLine);
+        const cursor = editor.getPosition();
+        const isCursorAtLast = !!cursor?.equals({
+          lineNumber: maxLine,
+          column: maxColumn,
+        });
+        if (isCursorAtLast) {
+          emit("execute", props.sql, {
+            databaseType: selectedInstanceEngine.value,
+          });
+          return false;
+        }
+      }
+    }
+    return true;
+  });
+
   watchEffect(() => {
     if (selectedInstance.value) {
       const databaseList = databaseStore.getDatabaseListByInstanceId(


### PR DESCRIPTION
When
- the SQL ends with ";"
- [and] the cursor is at the end of the editor
- then press "Enter"

We trigger the "execute" event

Close BYT-1928