### PR TITLE
feat(frontend): tenant ui improvement

### DIFF
--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -149,13 +149,19 @@ export default defineComponent({
           return {
             id: `bb.project.${project.id}.databases`,
             name: project.name,
-            childList: databaseListGroupByNameAndCount.map(
+            childList: databaseListGroupByNameAndCount.map<BBOutlineItem>(
               ({ name, count }) => {
+                const label = [name];
+                if (count > 1) {
+                  // Add a number beside the name when there are more than 1
+                  // databases in single group.
+                  label.push(`(${count})`);
+                }
                 return {
                   id: `bb.project.${project.id}.database.${name}`,
-                  name: `${name} (${count})`,
+                  name: label.join(" "),
                   link: `/project/${projectSlug(project)}`,
-                } as BBOutlineItem;
+                };
               }
             ),
             childCollapse: true,

--- a/frontend/src/components/DeploymentConfigTool/DeploymentMatrix.vue
+++ b/frontend/src/components/DeploymentConfigTool/DeploymentMatrix.vue
@@ -18,19 +18,22 @@
 
     <template v-else>
       <div class="flex justify-between items-center py-0.5 space-x-2">
-        <select
-          v-model="state.selectedDatabaseName"
-          class="btn-select w-40 disabled:cursor-not-allowed"
-        >
-          <option disabled>{{ $t("db.select") }}</option>
-          <option
-            v-for="(group, i) in databaseListGroupByName"
-            :key="i"
-            :value="group.name"
+        <div class="flex-1">
+          <select
+            v-if="databaseListGroupByName.length > 1"
+            v-model="state.selectedDatabaseName"
+            class="btn-select w-40 disabled:cursor-not-allowed"
           >
-            {{ group.name }}
-          </option>
-        </select>
+            <option disabled>{{ $t("db.select") }}</option>
+            <option
+              v-for="(group, i) in databaseListGroupByName"
+              :key="i"
+              :value="group.name"
+            >
+              {{ group.name }}
+            </option>
+          </select>
+        </div>
 
         <YAxisRadioGroup
           v-model:label="state.label"
@@ -87,6 +90,10 @@ const state = reactive({
 const databaseListGroupByName = computed((): DatabaseGroup[] => {
   const { dbNameTemplate } = props.project;
 
+  if (!dbNameTemplate) {
+    return [{ name: "", list: props.databaseList }];
+  }
+
   if (dbNameTemplate && props.labelList.length === 0) {
     // We can't calculate dbname correctly if labelList hasn't been fetched
     // So return empty array as a fallback
@@ -124,8 +131,6 @@ watch(
 );
 
 const selectedDatabaseGroup = computed((): DatabaseGroup | undefined => {
-  if (!state.selectedDatabaseName) return undefined;
-
   return databaseListGroupByName.value.find(
     (group) => group.name === state.selectedDatabaseName
   );


### PR DESCRIPTION
### Features
- Hide "(1)" in the sidebar's database list when there's only one database in a group.
- Put all databases into one group if we are using wildcard dbNameTemplate while previewing the deployment config.

### Screenshots

#### Before

<img width="213" alt="image" src="https://user-images.githubusercontent.com/2749742/204419206-422aa0b2-6348-402a-9ce5-2d9e9b3a8ccb.png">

#### After

<img width="213" alt="image" src="https://user-images.githubusercontent.com/2749742/204419249-52aaa8d7-ca50-44d4-8984-37d2a152ca06.png">

#### Before
![image](https://user-images.githubusercontent.com/2749742/204419360-e087a41c-314f-4e7c-8042-6d7632776743.png)

#### After 
<img width="811" alt="image" src="https://user-images.githubusercontent.com/2749742/204419332-eeae0fe3-4256-44a2-8d63-2e48edc051fe.png">

