### PR TITLE
refactor: move my.cnf to a separate directory

### DIFF
--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -29,7 +29,6 @@ func TestCheckEngineInnoDB(t *testing.T) {
 		mysqlPort := getTestPort()
 		stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 		defer stopFn()
-		// time.Sleep(1 * time.Minute)
 		t.Log("create test database")
 		database := "test_success"
 		db, err := connectTestMySQL(mysqlPort, "")

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -29,6 +29,7 @@ func TestCheckEngineInnoDB(t *testing.T) {
 		mysqlPort := getTestPort()
 		stopFn := resourcemysql.SetupTestInstance(t, mysqlPort)
 		defer stopFn()
+		// time.Sleep(1 * time.Minute)
 		t.Log("create test database")
 		database := "test_success"
 		db, err := connectTestMySQL(mysqlPort, "")


### PR DESCRIPTION
1. It cannot be in the data directory.
2. We want to share resource/binary directory across all tests.
Thus, we need a separate directory for my.cnf.