### PR TITLE
feat: create activity on external approval rejected

### DIFF
--- a/api/activity.go
+++ b/api/activity.go
@@ -114,9 +114,8 @@ type ActivityIssueStatusUpdatePayload struct {
 
 // ActivityIssueExternalApprovalRejectPayload is the API message payloads for rejected external approvals.
 type ActivityIssueExternalApprovalRejectPayload struct {
-	AssigneeID int    `json:"assigneeId"`
-	StageName  string `json:"stageName"`
-	IMType     IMType `json:"imType"`
+	StageName            string               `json:"stageName"`
+	ExternalApprovalType ExternalApprovalType `json:"externalApprovalType"`
 }
 
 // ActivityPipelineTaskStatusUpdatePayload is the API message payloads for updating pipeline task status.

--- a/api/activity.go
+++ b/api/activity.go
@@ -29,8 +29,6 @@ const (
 	ActivityPipelineTaskStatementUpdate ActivityType = "bb.pipeline.task.statement.update"
 	// ActivityPipelineTaskEarliestAllowedTimeUpdate is the type for updating pipeline task the earliest allowed time.
 	ActivityPipelineTaskEarliestAllowedTimeUpdate ActivityType = "bb.pipeline.task.general.earliest-allowed-time.update"
-	// ActivityIssueExternalApprovalReject is the type for external approvals rejected on the IM side.
-	ActivityIssueExternalApprovalReject ActivityType = "bb.issue.external-approval.reject"
 
 	// Member related.
 
@@ -91,6 +89,8 @@ type ActivityIssueCreatePayload struct {
 
 // ActivityIssueCommentCreatePayload is the API message payloads for creating issue comments.
 type ActivityIssueCommentCreatePayload struct {
+	ExternalApprovalEvent *ExternalApprovalEvent `json:"externalApprovalEvent"`
+
 	// Used by inbox to display info without paying the join cost
 	IssueName string `json:"issueName"`
 }
@@ -110,12 +110,6 @@ type ActivityIssueStatusUpdatePayload struct {
 	NewStatus IssueStatus `json:"newStatus,omitempty"`
 	// Used by inbox to display info without paying the join cost
 	IssueName string `json:"issueName"`
-}
-
-// ActivityIssueExternalApprovalRejectPayload is the API message payloads for rejected external approvals.
-type ActivityIssueExternalApprovalRejectPayload struct {
-	StageName            string               `json:"stageName"`
-	ExternalApprovalType ExternalApprovalType `json:"externalApprovalType"`
 }
 
 // ActivityPipelineTaskStatusUpdatePayload is the API message payloads for updating pipeline task status.

--- a/api/activity.go
+++ b/api/activity.go
@@ -29,6 +29,8 @@ const (
 	ActivityPipelineTaskStatementUpdate ActivityType = "bb.pipeline.task.statement.update"
 	// ActivityPipelineTaskEarliestAllowedTimeUpdate is the type for updating pipeline task the earliest allowed time.
 	ActivityPipelineTaskEarliestAllowedTimeUpdate ActivityType = "bb.pipeline.task.general.earliest-allowed-time.update"
+	// ActivityIssueExternalApprovalReject is the type for external approvals rejected on the IM side.
+	ActivityIssueExternalApprovalReject ActivityType = "bb.issue.external-approval.reject"
 
 	// Member related.
 
@@ -108,6 +110,13 @@ type ActivityIssueStatusUpdatePayload struct {
 	NewStatus IssueStatus `json:"newStatus,omitempty"`
 	// Used by inbox to display info without paying the join cost
 	IssueName string `json:"issueName"`
+}
+
+// ActivityIssueExternalApprovalRejectPayload is the API message payloads for rejected external approvals.
+type ActivityIssueExternalApprovalRejectPayload struct {
+	AssigneeID int    `json:"assigneeId"`
+	StageName  string `json:"stageName"`
+	IMType     IMType `json:"imType"`
 }
 
 // ActivityPipelineTaskStatusUpdatePayload is the API message payloads for updating pipeline task status.

--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -33,9 +33,11 @@ type ExternalApprovalPayloadFeishu struct {
 	StageID    int
 	AssigneeID int
 
-	// feishu
+	// Feishu
 	InstanceCode string
 	RequesterID  string
+	// Rejected tells if the approval has been rejected on Feishu.
+	Rejected bool
 }
 
 // ExternalApprovalCreate is the API message for creating an ExternalApproval.
@@ -59,4 +61,6 @@ type ExternalApprovalFind struct {
 type ExternalApprovalPatch struct {
 	ID        int
 	RowStatus RowStatus
+
+	Payload *string
 }

--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -77,7 +77,7 @@ const (
 
 // ExternalApprovalEvent is the API message for describing an ExternalApproval.
 type ExternalApprovalEvent struct {
-	Type      ExternalApprovalType
-	Action    ExternalApprovalEventActionType
-	StageName string
+	Type      ExternalApprovalType            `json:"type"`
+	Action    ExternalApprovalEventActionType `json:"action"`
+	StageName string                          `json:"stageName"`
 }

--- a/api/external_approval.go
+++ b/api/external_approval.go
@@ -64,3 +64,20 @@ type ExternalApprovalPatch struct {
 
 	Payload *string
 }
+
+// ExternalApprovalEventActionType is the type of the action which the user took.
+type ExternalApprovalEventActionType string
+
+const (
+	// ExternalApprovalEventActionApprove means that the user approves via the external approval.
+	ExternalApprovalEventActionApprove ExternalApprovalEventActionType = "APPROVE"
+	// ExternalApprovalEventActionReject means that the user rejects via the external approval.
+	ExternalApprovalEventActionReject ExternalApprovalEventActionType = "REJECT"
+)
+
+// ExternalApprovalEvent is the API message for describing an ExternalApproval.
+type ExternalApprovalEvent struct {
+	Type      ExternalApprovalType
+	Action    ExternalApprovalEventActionType
+	StageName string
+}

--- a/frontend/src/components/Issue/activity/ActionSentence.vue
+++ b/frontend/src/components/Issue/activity/ActionSentence.vue
@@ -39,19 +39,16 @@ const renderActionSentence = () => {
       const payload = activity.payload as ActivityIssueCommentCreatePayload;
       if (payload.externalApprovalEvent) {
         if (payload.externalApprovalEvent.action == "REJECT") {
-          console.log(payload.externalApprovalEvent);
+          let imName = "";
           switch (payload.externalApprovalEvent.type) {
             case "bb.plugin.app.feishu":
-              return t("activity.sentence.external-approval-rejected", {
-                stageName: payload.externalApprovalEvent.stageName,
-                imName: t("common.feishu"),
-              });
-            default:
-              return t("activity.sentence.external-approval-rejected", {
-                stageName: payload.externalApprovalEvent.stageName,
-                imName: "",
-              });
+              imName = t("common.feishu");
+              break;
           }
+          return t("activity.sentence.external-approval-rejected", {
+            stageName: payload.externalApprovalEvent.stageName,
+            imName: imName,
+          });
         }
       }
     }

--- a/frontend/src/components/Issue/activity/ActionSentence.vue
+++ b/frontend/src/components/Issue/activity/ActionSentence.vue
@@ -10,6 +10,7 @@ import {
   ActivityTaskFileCommitPayload,
   ActivityTaskStatementUpdatePayload,
   ActivityTaskStatusUpdatePayload,
+  ActivityIssueExternalApprovalRejectPayload,
   Issue,
   SYSTEM_BOT_ID,
 } from "@/types";
@@ -34,6 +35,23 @@ const { t } = useI18n();
 const renderActionSentence = () => {
   const { activity, issue } = props;
   if (activity.type.startsWith("bb.issue.")) {
+    if (activity.type === "bb.issue.external-approval.reject") {
+      const payload =
+        activity.payload as ActivityIssueExternalApprovalRejectPayload;
+
+      switch (payload.externalApprovalType) {
+        case "bb.plugin.im.feishu":
+          return t("activity.sentence.external-approval-rejected", {
+            stageName: payload.stageName,
+            imName: t("common.feishu"),
+          });
+        default:
+          return t("activity.sentence.external-approval-rejected", {
+            stageName: payload.stageName,
+            imName: "",
+          });
+      }
+    }
     const [tid, params] = issueActivityActionSentence(activity);
     return t(tid, params);
   }

--- a/frontend/src/components/Issue/activity/ActionSentence.vue
+++ b/frontend/src/components/Issue/activity/ActionSentence.vue
@@ -6,11 +6,11 @@
 import { h, PropType } from "vue";
 import {
   Activity,
+  ActivityIssueCommentCreatePayload,
   ActivityTaskEarliestAllowedTimeUpdatePayload,
   ActivityTaskFileCommitPayload,
   ActivityTaskStatementUpdatePayload,
   ActivityTaskStatusUpdatePayload,
-  ActivityIssueExternalApprovalRejectPayload,
   Issue,
   SYSTEM_BOT_ID,
 } from "@/types";
@@ -35,21 +35,24 @@ const { t } = useI18n();
 const renderActionSentence = () => {
   const { activity, issue } = props;
   if (activity.type.startsWith("bb.issue.")) {
-    if (activity.type === "bb.issue.external-approval.reject") {
-      const payload =
-        activity.payload as ActivityIssueExternalApprovalRejectPayload;
-
-      switch (payload.externalApprovalType) {
-        case "bb.plugin.im.feishu":
-          return t("activity.sentence.external-approval-rejected", {
-            stageName: payload.stageName,
-            imName: t("common.feishu"),
-          });
-        default:
-          return t("activity.sentence.external-approval-rejected", {
-            stageName: payload.stageName,
-            imName: "",
-          });
+    if (activity.type === "bb.issue.comment.create") {
+      const payload = activity.payload as ActivityIssueCommentCreatePayload;
+      if (payload.externalApprovalEvent) {
+        if (payload.externalApprovalEvent.action == "REJECT") {
+          console.log(payload.externalApprovalEvent);
+          switch (payload.externalApprovalEvent.type) {
+            case "bb.plugin.app.feishu":
+              return t("activity.sentence.external-approval-rejected", {
+                stageName: payload.externalApprovalEvent.stageName,
+                imName: t("common.feishu"),
+              });
+            default:
+              return t("activity.sentence.external-approval-rejected", {
+                stageName: payload.externalApprovalEvent.stageName,
+                imName: "",
+              });
+          }
+        }
       }
     }
     const [tid, params] = issueActivityActionSentence(activity);

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -438,7 +438,8 @@
       "project-member-delete": "delete project member",
       "project-member-role-update": "change project member role",
       "pipeline-task-earliest-allowed-time-update": "update earliest allowed time",
-      "database-recovery-pitr-done": "restore database to point in time"
+      "database-recovery-pitr-done": "restore database to point in time",
+      "external-approval-rejected": "external approval rejected"
     },
     "sentence": {
       "created-issue": "created issue",
@@ -465,7 +466,8 @@
       "failed": "failed",
       "task-name": " task {name}",
       "committed-to-at": "committed {file} to{branch}{'@'}{repo}",
-      "dismissed-stale-approval": "dismissed stale approvals of {task}"
+      "dismissed-stale-approval": "dismissed stale approvals of {task}",
+      "external-approval-rejected": "rejected external approval from {imName} of stage \"{stageName}\""
     },
     "subject-prefix": {
       "task": "Task"

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -465,7 +465,7 @@
       "completed": "completed",
       "failed": "failed",
       "task-name": " task {name}",
-      "committed-to-at": "committed {file} to{branch}{'@'}{repo}",
+      "committed-to-at": "committed {file} to {branch}{'@'}{repo}",
       "dismissed-stale-approval": "dismissed stale approvals of {task}",
       "external-approval-rejected": "rejected external approval from {imName} of stage \"{stageName}\""
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -438,7 +438,8 @@
       "project-member-delete": "删除项目成员",
       "project-member-role-update": "变更项目成员角色",
       "pipeline-task-earliest-allowed-time-update": "更新最早允许执行时间",
-      "database-recovery-pitr-done": "将数据库恢复到指定时间点"
+      "database-recovery-pitr-done": "将数据库恢复到指定时间点",
+      "external-approval-rejected": "拒绝外部审批"
     },
     "sentence": {
       "created-issue": "创建工单",
@@ -465,7 +466,8 @@
       "failed": "失败",
       "task-name": "任务 {name}",
       "committed-to-at": "提交 {file} 到 {branch}{'@'}{repo}",
-      "dismissed-stale-approval": "更新了{task}，此前的批准已被撤销"
+      "dismissed-stale-approval": "更新了{task}，此前的批准已被撤销",
+      "external-approval-rejected": "拒绝阶段 \"{stageName}\" 的{imName}外部审批"
     },
     "subject-prefix": {
       "task": "任务"

--- a/frontend/src/types/activity.ts
+++ b/frontend/src/types/activity.ts
@@ -13,6 +13,7 @@ import { TaskStatus } from "./pipeline";
 import { Principal } from "./principal";
 import { VCSPushEvent } from "./vcs";
 import { Advice } from "./sql";
+import { ExternalApprovalType } from "./externalApproval";
 import { t } from "../plugins/i18n";
 
 export type IssueActivityType =
@@ -20,6 +21,7 @@ export type IssueActivityType =
   | "bb.issue.comment.create"
   | "bb.issue.field.update"
   | "bb.issue.status.update"
+  | "bb.issue.external-approval.reject"
   | "bb.pipeline.task.status.update"
   | "bb.pipeline.task.file.commit"
   | "bb.pipeline.task.statement.update"
@@ -57,6 +59,8 @@ export function activityName(type: ActivityType): string {
       return t("activity.type.comment-create");
     case "bb.issue.field.update":
       return t("activity.type.issue-field-update");
+    case "bb.issue.external-approval.reject":
+      return t("activity.type.external-approval-rejected");
     case "bb.issue.status.update":
       return t("activity.type.issue-status-update");
     case "bb.pipeline.task.status.update":
@@ -113,6 +117,11 @@ export type ActivityIssueStatusUpdatePayload = {
   oldStatus: IssueStatus;
   newStatus: IssueStatus;
   issueName: string;
+};
+
+export type ActivityIssueExternalApprovalRejectPayload = {
+  stageName: string;
+  externalApprovalType: ExternalApprovalType;
 };
 
 export type ActivityTaskStatusUpdatePayload = {
@@ -198,6 +207,7 @@ export type ActionPayloadType =
   | ActivityIssueCommentCreatePayload
   | ActivityIssueFieldUpdatePayload
   | ActivityIssueStatusUpdatePayload
+  | ActivityIssueExternalApprovalRejectPayload
   | ActivityTaskStatusUpdatePayload
   | ActivityTaskFileCommitPayload
   | ActivityTaskStatementUpdatePayload

--- a/frontend/src/types/activity.ts
+++ b/frontend/src/types/activity.ts
@@ -1,3 +1,4 @@
+import { ExternalApprovalEvent } from "./externalApproval";
 import { FieldId } from "../plugins";
 import {
   ActivityId,
@@ -13,7 +14,6 @@ import { TaskStatus } from "./pipeline";
 import { Principal } from "./principal";
 import { VCSPushEvent } from "./vcs";
 import { Advice } from "./sql";
-import { ExternalApprovalType } from "./externalApproval";
 import { t } from "../plugins/i18n";
 
 export type IssueActivityType =
@@ -21,7 +21,6 @@ export type IssueActivityType =
   | "bb.issue.comment.create"
   | "bb.issue.field.update"
   | "bb.issue.status.update"
-  | "bb.issue.external-approval.reject"
   | "bb.pipeline.task.status.update"
   | "bb.pipeline.task.file.commit"
   | "bb.pipeline.task.statement.update"
@@ -59,8 +58,6 @@ export function activityName(type: ActivityType): string {
       return t("activity.type.comment-create");
     case "bb.issue.field.update":
       return t("activity.type.issue-field-update");
-    case "bb.issue.external-approval.reject":
-      return t("activity.type.external-approval-rejected");
     case "bb.issue.status.update":
       return t("activity.type.issue-status-update");
     case "bb.pipeline.task.status.update":
@@ -103,6 +100,7 @@ export type ActivityIssueCreatePayload = {
 };
 
 export type ActivityIssueCommentCreatePayload = {
+  externalApprovalEvent: ExternalApprovalEvent;
   issueName: string;
 };
 
@@ -117,11 +115,6 @@ export type ActivityIssueStatusUpdatePayload = {
   oldStatus: IssueStatus;
   newStatus: IssueStatus;
   issueName: string;
-};
-
-export type ActivityIssueExternalApprovalRejectPayload = {
-  stageName: string;
-  externalApprovalType: ExternalApprovalType;
 };
 
 export type ActivityTaskStatusUpdatePayload = {
@@ -207,7 +200,6 @@ export type ActionPayloadType =
   | ActivityIssueCommentCreatePayload
   | ActivityIssueFieldUpdatePayload
   | ActivityIssueStatusUpdatePayload
-  | ActivityIssueExternalApprovalRejectPayload
   | ActivityTaskStatusUpdatePayload
   | ActivityTaskFileCommitPayload
   | ActivityTaskStatementUpdatePayload

--- a/frontend/src/types/externalApproval.ts
+++ b/frontend/src/types/externalApproval.ts
@@ -1,1 +1,9 @@
-export type ExternalApprovalType = "bb.plugin.im.feishu";
+export type ExternalApprovalType = "bb.plugin.app.feishu";
+
+export type ExternalApprovalEvent = {
+  type: ExternalApprovalType;
+  action: ExternalApprovalEventActionType;
+  stageName: string;
+};
+
+export type ExternalApprovalEventActionType = "APPROVE" | "REJECT";

--- a/frontend/src/types/externalApproval.ts
+++ b/frontend/src/types/externalApproval.ts
@@ -1,0 +1,1 @@
+export type ExternalApprovalType = "bb.plugin.im.feishu";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -50,3 +50,4 @@ export * from "./sqlReview";
 export * from "./utils";
 export * from "./onboardingGuide";
 export * from "./UIEditor";
+export * from "./externalApproval";

--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -199,8 +199,8 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 									}
 								}
 								activityPayload, err := json.Marshal(api.ActivityIssueExternalApprovalRejectPayload{
-									StageName: stageName,
-									IMType:    api.IMTypeFeishu,
+									StageName:            stageName,
+									ExternalApprovalType: api.ExternalApprovalTypeFeishu,
 								})
 								if err != nil {
 									return errors.Wrap(err, "failed to marshal ActivityIssueExternalApprovalRejectPayload")

--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/app/feishu"
 	"github.com/bytebase/bytebase/store"
@@ -30,11 +31,12 @@ const (
 )
 
 // NewApplicationRunner returns a ApplicationRunner.
-func NewApplicationRunner(store *store.Store, activityManager *ActivityManager, feishuProvider *feishu.Provider) *ApplicationRunner {
+func NewApplicationRunner(store *store.Store, activityManager *ActivityManager, feishuProvider *feishu.Provider, releaseMode common.ReleaseMode) *ApplicationRunner {
 	return &ApplicationRunner{
 		store:           store,
 		activityManager: activityManager,
 		p:               feishuProvider,
+		mode:            releaseMode,
 	}
 }
 
@@ -43,6 +45,7 @@ type ApplicationRunner struct {
 	store           *store.Store
 	activityManager *ActivityManager
 	p               *feishu.Provider
+	mode            common.ReleaseMode
 }
 
 // Run runs the ApplicationRunner.
@@ -94,6 +97,10 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 							continue
 						}
 
+						if payload.Rejected {
+							continue
+						}
+
 						issue, err := r.store.GetIssueByID(ctx, externalApproval.IssueID)
 						if err != nil {
 							log.Error("failed to get issue by issue id", zap.Int("issueID", externalApproval.IssueID), zap.Error(err))
@@ -122,7 +129,8 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 							continue
 						}
 
-						if status == feishu.ApprovalStatusApproved {
+						switch status {
+						case feishu.ApprovalStatusApproved:
 							// double check
 							if stage.ID == payload.StageID && payload.AssigneeID == issue.AssigneeID {
 								// approve stage
@@ -161,8 +169,60 @@ func (r *ApplicationRunner) Run(ctx context.Context, wg *sync.WaitGroup) {
 									continue
 								}
 							}
+						case feishu.ApprovalStatusRejected:
+							if err := func() error {
+								// TODO(p0ny): remove release guard.
+								if r.mode == common.ReleaseModeProd {
+									return nil
+								}
+								payload := payload
+								payload.Rejected = true
+								bytes, err := json.Marshal(payload)
+								if err != nil {
+									return errors.Wrapf(err, "failed to marshal payload %+v", payload)
+								}
+								payloadString := string(bytes)
+
+								if _, err := r.store.PatchExternalApproval(ctx, &api.ExternalApprovalPatch{
+									ID:        externalApproval.ID,
+									RowStatus: api.Normal,
+									Payload:   &payloadString,
+								}); err != nil {
+									return errors.Wrap(err, "failed to patch external approval")
+								}
+
+								stageName := "UNKNOWN"
+								for _, stage := range issue.Pipeline.StageList {
+									if stage.ID == payload.StageID {
+										stageName = stage.Name
+										break
+									}
+								}
+								activityPayload, err := json.Marshal(api.ActivityIssueExternalApprovalRejectPayload{
+									StageName: stageName,
+									IMType:    api.IMTypeFeishu,
+								})
+								if err != nil {
+									return errors.Wrap(err, "failed to marshal ActivityIssueExternalApprovalRejectPayload")
+								}
+
+								activityCreate := &api.ActivityCreate{
+									CreatorID:   payload.AssigneeID,
+									ContainerID: issue.ID,
+									Type:        api.ActivityIssueExternalApprovalReject,
+									Level:       api.ActivityInfo,
+									Comment:     "",
+									Payload:     string(activityPayload),
+								}
+
+								if _, err = r.activityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{}); err != nil {
+									return errors.Wrap(err, "failed to create activity after external approval rejected")
+								}
+								return nil
+							}(); err != nil {
+								log.Error("failed to handle rejected feishu approval", zap.Error(err))
+							}
 						}
-						// Do nothing for ApprovalStatusRejected
 					default:
 						log.Error("Unknown ExternalApproval.Type", zap.Any("ExternalApproval", externalApproval))
 					}
@@ -410,6 +470,7 @@ func (r *ApplicationRunner) createExternalApproval(ctx context.Context, issue *a
 		AssigneeID:   issue.AssigneeID,
 		InstanceCode: instanceCode,
 		RequesterID:  users[issue.Creator.Email],
+		Rejected:     false,
 	}
 	b, err := json.Marshal(payload)
 	if err != nil {

--- a/server/issue.go
+++ b/server/issue.go
@@ -1303,10 +1303,9 @@ func (s *Server) changeIssueStatus(ctx context.Context, issue *api.Issue, newSta
 		Payload:     string(payload),
 	}
 
-	_, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{
+	if _, err = s.ActivityManager.CreateActivity(ctx, activityCreate, &ActivityMeta{
 		issue: updatedIssue,
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, errors.Wrapf(err, "failed to create activity after changing the issue status: %v", issue.Name)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -302,7 +302,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 		// Backup runner
 		s.BackupRunner = NewBackupRunner(s, prof.BackupRunnerInterval)
 
-		s.ApplicationRunner = NewApplicationRunner(s.store, s.ActivityManager, feishu.NewProvider(prof.FeishuAPIURL), prof.Mode)
+		s.ApplicationRunner = NewApplicationRunner(s.store, s.ActivityManager, feishu.NewProvider(prof.FeishuAPIURL))
 
 		// Anomaly scanner
 		s.AnomalyScanner = NewAnomalyScanner(s)

--- a/server/server.go
+++ b/server/server.go
@@ -302,7 +302,7 @@ func NewServer(ctx context.Context, prof Profile) (*Server, error) {
 		// Backup runner
 		s.BackupRunner = NewBackupRunner(s, prof.BackupRunnerInterval)
 
-		s.ApplicationRunner = NewApplicationRunner(s.store, s.ActivityManager, feishu.NewProvider(prof.FeishuAPIURL))
+		s.ApplicationRunner = NewApplicationRunner(s.store, s.ActivityManager, feishu.NewProvider(prof.FeishuAPIURL), prof.Mode)
 
 		// Anomaly scanner
 		s.AnomalyScanner = NewAnomalyScanner(s)


### PR DESCRIPTION
retry #3531 

Reusing exsiting activity type "bb.issue.comment.create".

We create the activity if the feishu approval is rejected.

The newly-added field `rejected` is necessary for us to tell if it's the first time we encounter this so that we would not create the activity multiple times.

Completing BYT-1831

## screenshots

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/12679343/204481274-a50fb05f-f9e4-4b63-ad98-3e70405151ea.png">

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/12679343/204481332-811dd7b4-1b05-4c02-9621-fd76d8371c29.png">

## a little question

The comment can be modified since we are using "bb.issue.comment".

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/12679343/204481441-04daf567-45dd-4560-bae2-82565670d502.png">

