### PR TITLE
fix(frontend): wrong login wording with GitHub provider configured

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -756,6 +756,7 @@
       "new-user": "New to Bytebase?",
       "demo-note": "Please use demo account to sign in",
       "gitlab": "Login with GitLab",
+      "github": "Login with GitHub",
       "3rd-party-auth-demo": "Third-party authentication is disabled in Demo mode",
       "gitlab-oauth": "Reach to your Admin to enable GitLab login"
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -756,6 +756,7 @@
       "new-user": "第一次使用 Bytebase?",
       "demo-note": "请使用 demo 账号登录",
       "gitlab": "通过 GitLab 登录",
+      "github": "通过 GitHub 登录",
       "3rd-party-auth-demo": "演示模式不支持第三方账号登录",
       "gitlab-oauth": "您可联系管理员开启 GitLab 登录"
     },

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -31,7 +31,9 @@
           <span class="text-center font-semibold align-middle">
             {{
               authProviderList.length == 1
-                ? $t("auth.sign-in.gitlab")
+                ? authProvider.type.includes("GITHUB")
+                  ? $t("auth.sign-in.github")
+                  : $t("auth.sign-in.gitlab")
                 : authProvider.name
             }}
           </span>


### PR DESCRIPTION
### Before
![localhost_3001_auth](https://user-images.githubusercontent.com/56376387/204499051-3cb531a0-e470-418b-87ad-ff421c3c09be.png)


### After
![2022-11-29-Microsoft Edge-QKA9aYfM](https://user-images.githubusercontent.com/56376387/204498497-8490ff88-c504-4eb5-abfc-5459ffb00fb3.png)
