### PR TITLE
feat: do not return error if we don’t find DONE migration history

### DIFF
--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -189,7 +189,7 @@ func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (
 		return &v, nil
 	}
 
-	return nil, errors.Errorf("failed to find a successful migration history")
+	return nil, nil
 }
 
 // setupDemoData loads the setupDemoData data for testing.


### PR DESCRIPTION
I think there are 2 ways to deal with migration history

* Option 1, if the latest migration is DONE, we immediately fail the migration and require human inspection.
* Option 2, find the most recent DONE migration.

Our existing logic adopts option 2. Then if there is no DONE migration in the migration history, we should treat it the same as no migration happened instead of returning an error.

---

I encountered this when deploying render probably because there is multiple Bytebase render services accessing the same database.

