### PR TITLE
fix: feishu cancel approval user id

### DIFF
--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -285,7 +285,7 @@ func (r *ApplicationRunner) cancelOldExternalApprovalIfNeeded(ctx context.Contex
 			},
 			settingValue.ExternalApproval.ApprovalDefinitionID,
 			payload.InstanceCode,
-			botID,
+			payload.RequesterID,
 		); err != nil {
 			return nil, err
 		}
@@ -353,7 +353,7 @@ func (r *ApplicationRunner) CancelExternalApproval(ctx context.Context, issueID 
 		},
 		value.ExternalApproval.ApprovalDefinitionID,
 		payload.InstanceCode,
-		botID,
+		payload.RequesterID,
 	); err != nil {
 		return err
 	}

--- a/tests/fake/feishu.go
+++ b/tests/fake/feishu.go
@@ -37,6 +37,8 @@ type FeishuProviderCreator func(int) *Feishu
 type approval struct {
 	approvalCode string
 	instanceCode string
+	requesterID  string
+	approverID   string
 	status       feishu.ApprovalStatus
 }
 
@@ -163,12 +165,16 @@ func (f *Feishu) createApprovalInstance(c echo.Context) error {
 	if !f.userIDs[create.OpenID] {
 		return errors.Errorf("not found user id %s", create.OpenID)
 	}
-	for _, idList := range create.NodeApproverOpenIDList {
-		for _, id := range idList.Value {
-			if !f.userIDs[id] {
-				return errors.Errorf("not found user id %s", id)
-			}
-		}
+	if len(create.NodeApproverOpenIDList) != 1 {
+		return errors.New("expect the length of NodeApproverOpenIDList to be 1")
+	}
+	if len(create.NodeApproverOpenIDList[0].Value) != 1 {
+		return errors.New("expect the length of NodeApproverOpenIDList[0].Value to be 1")
+	}
+
+	approverID := create.NodeApproverOpenIDList[0].Value[0]
+	if !f.userIDs[approverID] {
+		return errors.Errorf("not found user id %s", approverID)
 	}
 
 	id := uuid.NewString()
@@ -176,6 +182,8 @@ func (f *Feishu) createApprovalInstance(c echo.Context) error {
 		approvalCode: create.ApprovalCode,
 		instanceCode: id,
 		status:       feishu.ApprovalStatusPending,
+		approverID:   approverID,
+		requesterID:  create.OpenID,
 	}
 
 	return c.JSON(http.StatusOK, &feishu.ExternalApprovalResponse{
@@ -252,6 +260,9 @@ func (f *Feishu) cancelApprovalInstance(c echo.Context) error {
 	}
 	if !f.userIDs[req.UserID] {
 		return errors.Errorf("not found user id %s", req.UserID)
+	}
+	if req.UserID != approval.requesterID {
+		return errors.New("the request user id should match the requester id")
 	}
 	if approval.status != feishu.ApprovalStatusPending {
 		return errors.Errorf(`expect to cancel a "pending" approval, but get status %q`, approval.status)


### PR DESCRIPTION
Feishu API requires the `user_id` in [cancelExternalApproval](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/instance/cancel) request equals the `open_id` in [createExternalApproval](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/instance/create). (which is not explicitly expressed in their docs tho)

Bug introduced in #3512 