### PR TITLE
fix: improve feishu approval card info

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -131,7 +131,8 @@ func truncateString(str string, limit int) (string, bool) {
 }
 
 // TruncateStringWithDescription tries to truncate the string and append "... (view details in Bytebase)" if truncated.
-func TruncateStringWithDescription(str string, limit int) string {
+func TruncateStringWithDescription(str string) string {
+	const limit = 450
 	if truncatedStr, truncated := truncateString(str, limit); truncated {
 		return fmt.Sprintf("%s... (view details in Bytebase)", truncatedStr)
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -117,8 +117,8 @@ func GetBinlogRelativeDir(binlogDir string) string {
 	return filepath.Join("backup", "instance", instanceID)
 }
 
-// TruncateString truncates the string to have a maximum length of `limit` characters.
-func TruncateString(str string, limit int) (string, bool) {
+// truncateString truncates the string to have a maximum length of `limit` characters.
+func truncateString(str string, limit int) (string, bool) {
 	chars := 0
 	// The string may contain unicode characters, so we iterate here.
 	for i := range str {
@@ -132,7 +132,7 @@ func TruncateString(str string, limit int) (string, bool) {
 
 // TruncateStringWithDescription tries to truncate the string and append "... (view details in Bytebase)" if truncated.
 func TruncateStringWithDescription(str string, limit int) string {
-	if truncatedStr, truncated := TruncateString(str, limit); truncated {
+	if truncatedStr, truncated := truncateString(str, limit); truncated {
 		return fmt.Sprintf("%s... (view details in Bytebase)", truncatedStr)
 	}
 	return str

--- a/common/util.go
+++ b/common/util.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"os"
 	"path"
@@ -114,4 +115,25 @@ func GetFileSizeSum(fileNameList []string) (int64, error) {
 func GetBinlogRelativeDir(binlogDir string) string {
 	instanceID := filepath.Base(binlogDir)
 	return filepath.Join("backup", "instance", instanceID)
+}
+
+// TruncateString truncates the string to have a maximum length of `limit` characters.
+func TruncateString(str string, limit int) (string, bool) {
+	chars := 0
+	// The string may contain unicode characters, so we iterate here.
+	for i := range str {
+		if chars >= limit {
+			return str[:i], true
+		}
+		chars++
+	}
+	return str, false
+}
+
+// TruncateStringWithDescription tries to truncate the string and append "... (view details in Bytebase)" if truncated.
+func TruncateStringWithDescription(str string, limit int) string {
+	if truncatedStr, truncated := TruncateString(str, limit); truncated {
+		return fmt.Sprintf("%s... (view details in Bytebase)", truncatedStr)
+	}
+	return str
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -33,10 +33,87 @@ func TestHasPrefixes(t *testing.T) {
 			want: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got := HasPrefixes(tt.args.src, tt.args.prefixes...)
 			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		limit     int
+		want      string
+		truncated bool
+	}{
+		{
+			name:      "simple truncate 0",
+			str:       "0123",
+			limit:     0,
+			want:      "",
+			truncated: true,
+		},
+		{
+			name:      "simple truncate 2",
+			str:       "0123",
+			limit:     2,
+			want:      "01",
+			truncated: true,
+		},
+		{
+			name:      "simple truncate 3",
+			str:       "0123",
+			limit:     3,
+			want:      "012",
+			truncated: true,
+		},
+		{
+			name:      "simple truncate 4",
+			str:       "0123",
+			limit:     4,
+			want:      "0123",
+			truncated: false,
+		},
+		{
+			name:      "simple truncate 20",
+			str:       "0123",
+			limit:     20,
+			want:      "0123",
+			truncated: false,
+		},
+		{
+			name:      "unicode truncate 5",
+			str:       "H㐀〾▓朗퐭텟şüöžåйкл¤",
+			limit:     5,
+			want:      "H㐀〾▓朗",
+			truncated: true,
+		},
+		{
+			name:      "unicode truncate 10",
+			str:       "H㐀〾▓朗퐭텟şüöžåйкл¤",
+			limit:     10,
+			want:      "H㐀〾▓朗퐭텟şüö",
+			truncated: true,
+		},
+		{
+			name:      "unicode fit",
+			str:       "H㐀〾▓朗퐭텟şüöžåйкл¤",
+			limit:     16,
+			want:      "H㐀〾▓朗퐭텟şüöžåйкл¤",
+			truncated: false,
+		},
+	}
+	a := assert.New(t)
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			got, truncated := TruncateString(test.str, test.limit)
+			a.Equal(test.want, got)
+			a.Equal(test.truncated, truncated)
 		})
 	}
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -111,7 +111,7 @@ func TestTruncateString(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			got, truncated := TruncateString(test.str, test.limit)
+			got, truncated := truncateString(test.str, test.limit)
 			a.Equal(test.want, got)
 			a.Equal(test.truncated, truncated)
 		})

--- a/plugin/app/feishu/feishu.go
+++ b/plugin/app/feishu/feishu.go
@@ -694,7 +694,7 @@ func formatForm(content Content) (string, error) {
 
 func formatFormSQL(contentTaskList []Task) (string, error) {
 	const taskSQLDisplayLimit = 5
-	delimiter := fmt.Sprintf("%s", strings.Repeat("=", 25))
+	delimiter := strings.Repeat("=", 25)
 	var sql strings.Builder
 
 	sqlHashToTaskGroup := make(map[string]int)

--- a/plugin/app/feishu/feishu.go
+++ b/plugin/app/feishu/feishu.go
@@ -722,7 +722,7 @@ func formatFormSQL(contentTaskList []Task) (string, error) {
 		if _, err := sql.WriteString(fmt.Sprintf("%s\nThe SQL statement of every task\n%s\n", delimiter, delimiter)); err != nil {
 			return "", err
 		}
-		truncated := common.TruncateStringWithDescription(contentTaskList[taskGroup[0][0]].Statement, 450)
+		truncated := common.TruncateStringWithDescription(contentTaskList[taskGroup[0][0]].Statement)
 		if _, err := sql.WriteString(fmt.Sprintf("%s\n\n", truncated)); err != nil {
 			return "", err
 		}
@@ -749,7 +749,7 @@ func formatFormSQL(contentTaskList []Task) (string, error) {
 		if _, err := sql.WriteString(fmt.Sprintf("%s\nThe SQL statement of task %s\n%s\n", delimiter, strings.Join(tasks, ","), delimiter)); err != nil {
 			return "", err
 		}
-		truncated := common.TruncateStringWithDescription(contentTaskList[taskList[0]].Statement, 450)
+		truncated := common.TruncateStringWithDescription(contentTaskList[taskList[0]].Statement)
 		if _, err := sql.WriteString(fmt.Sprintf("%s\n\n", truncated)); err != nil {
 			return "", err
 		}

--- a/plugin/app/feishu/feishu_test.go
+++ b/plugin/app/feishu/feishu_test.go
@@ -286,3 +286,167 @@ func TestProvider_GetBotID(t *testing.T) {
 	want := "ou_e6e14f667cfe239d7b129b521dce0569"
 	a.Equal(want, botID)
 }
+
+func TestFormatSQL(t *testing.T) {
+	a := require.New(t)
+	tests := []struct {
+		name            string
+		contentTaskList []Task
+		want            string
+	}{
+		{
+			name: "one group",
+			contentTaskList: []Task{
+				{
+					Statement: "-- 1",
+				},
+				{
+					Statement: "-- 1",
+				},
+				{
+					Statement: "-- 1",
+				},
+			},
+			want: `=========================
+The SQL statement of every task
+=========================
+-- 1
+
+`,
+		},
+		{
+			name: "two groups",
+			contentTaskList: []Task{
+				{
+					Statement: "-- 1",
+				},
+				{
+					Statement: "-- 1",
+				},
+				{
+					Statement: "-- 2",
+				},
+			},
+			want: `=========================
+The SQL statement of task 1,2
+=========================
+-- 1
+
+=========================
+The SQL statement of task 3
+=========================
+-- 2
+
+`,
+		},
+		{
+			name: "five groups",
+			contentTaskList: []Task{
+				{
+					Statement: "-- 1",
+				},
+				{
+					Statement: "-- 2",
+				},
+				{
+					Statement: "-- 3",
+				},
+				{
+					Statement: "-- 3",
+				},
+				{
+					Statement: "-- 4",
+				},
+				{
+					Statement: "-- 5",
+				},
+			},
+			want: `=========================
+The SQL statement of task 1
+=========================
+-- 1
+
+=========================
+The SQL statement of task 2
+=========================
+-- 2
+
+=========================
+The SQL statement of task 3,4
+=========================
+-- 3
+
+=========================
+The SQL statement of task 5
+=========================
+-- 4
+
+=========================
+The SQL statement of task 6
+=========================
+-- 5
+
+`,
+		},
+		{
+			name: "six groups",
+			contentTaskList: []Task{
+				{
+					Statement: "-- 1",
+				},
+				{
+					Statement: "-- 2",
+				},
+				{
+					Statement: "-- 3",
+				},
+				{
+					Statement: "-- 7",
+				},
+				{
+					Statement: "-- 4",
+				},
+				{
+					Statement: "-- 5",
+				},
+			},
+			want: `=========================
+The SQL statement of task 1
+=========================
+-- 1
+
+=========================
+The SQL statement of task 2
+=========================
+-- 2
+
+=========================
+The SQL statement of task 3
+=========================
+-- 3
+
+=========================
+The SQL statement of task 4
+=========================
+-- 7
+
+=========================
+The SQL statement of task 5
+=========================
+-- 4
+
+=========================
+Displaying 5 SQL statements, view more in Bytebase
+`,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			sql, err := formatFormSQL(test.contentTaskList)
+			a.NoError(err)
+			a.Equal(test.want, sql)
+		})
+	}
+}

--- a/plugin/webhook/webhook.go
+++ b/plugin/webhook/webhook.go
@@ -103,7 +103,7 @@ func (c *Context) getMetaList() []meta {
 		// view it easily in the corresponding webhook client.
 		m = append(m, meta{
 			Name:  "Issue Description",
-			Value: common.TruncateStringWithDescription(c.Issue.Description, 200),
+			Value: common.TruncateStringWithDescription(c.Issue.Description),
 		})
 	}
 
@@ -119,7 +119,7 @@ func (c *Context) getMetaList() []meta {
 		if c.TaskResult.Detail != "" {
 			m = append(m, meta{
 				Name:  "Result Detail",
-				Value: common.TruncateStringWithDescription(c.TaskResult.Detail, 200),
+				Value: common.TruncateStringWithDescription(c.TaskResult.Detail),
 			})
 		}
 	}

--- a/plugin/webhook/webhook.go
+++ b/plugin/webhook/webhook.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bytebase/bytebase/common"
 	"github.com/pkg/errors"
 )
 
@@ -99,15 +100,9 @@ func (c *Context) getMetaList() []meta {
 		// So the description could be long, which is hard to display if merged into the issue name.
 		// We also trim it to 200 bytes to limit the message size in the webhook body, so that users can
 		// view it easily in the corresponding webhook client.
-		// The issue description may contain unicode characters, so we use rune here.
-		descriptionRune := []rune(c.Issue.Description)
-		if len(descriptionRune) > 200 {
-			descriptionRune = descriptionRune[:200]
-			descriptionRune = append(descriptionRune, []rune("... (view details in Bytebase)")...)
-		}
 		m = append(m, meta{
 			Name:  "Issue Description",
-			Value: string(descriptionRune),
+			Value: common.TruncateStringWithDescription(c.Issue.Description, 200),
 		})
 	}
 
@@ -121,14 +116,9 @@ func (c *Context) getMetaList() []meta {
 			Value: c.TaskResult.Status,
 		})
 		if c.TaskResult.Detail != "" {
-			resultDetailRune := []rune(c.TaskResult.Detail)
-			if len(resultDetailRune) > 200 {
-				resultDetailRune = resultDetailRune[:200]
-				resultDetailRune = append(resultDetailRune, []rune("... (view details in Bytebase)")...)
-			}
 			m = append(m, meta{
 				Name:  "Result Detail",
-				Value: string(resultDetailRune),
+				Value: common.TruncateStringWithDescription(c.TaskResult.Detail, 200),
 			})
 		}
 	}

--- a/plugin/webhook/webhook.go
+++ b/plugin/webhook/webhook.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bytebase/bytebase/common"
 	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/common"
 )
 
 var (

--- a/plugin/webhook/webhook_test.go
+++ b/plugin/webhook/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"testing"
 
+	"github.com/bytebase/bytebase/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,12 +64,6 @@ func TestContext_getMetaList(t *testing.T) {
 		detail := string(b)
 		a.Equal(300, len(detail))
 
-		resultDetailRune := []rune(detail)
-		if len(resultDetailRune) > 200 {
-			resultDetailRune = resultDetailRune[:200]
-			resultDetailRune = append(resultDetailRune, []rune("... (view details in Bytebase)")...)
-		}
-
 		context := Context{
 			TaskResult: &TaskResult{
 				Name:   "task name",
@@ -87,7 +82,7 @@ func TestContext_getMetaList(t *testing.T) {
 			},
 			{
 				Name:  "Result Detail",
-				Value: string(resultDetailRune),
+				Value: common.TruncateStringWithDescription(detail, 200),
 			},
 		}
 		a.Equal(want, context.getMetaList())

--- a/plugin/webhook/webhook_test.go
+++ b/plugin/webhook/webhook_test.go
@@ -83,7 +83,40 @@ func TestContext_getMetaList(t *testing.T) {
 			},
 			{
 				Name:  "Result Detail",
-				Value: common.TruncateStringWithDescription(detail, 200),
+				Value: common.TruncateStringWithDescription(detail),
+			},
+		}
+		a.Equal(want, context.getMetaList())
+	})
+	t.Run("task4", func(t *testing.T) {
+		a := require.New(t)
+
+		// generate random string
+		b := make([]byte, 600)
+		_, err := rand.Read(b)
+		a.NoError(err)
+		detail := string(b)
+		a.Equal(600, len(detail))
+
+		context := Context{
+			TaskResult: &TaskResult{
+				Name:   "task name",
+				Status: "FAILED",
+				Detail: detail,
+			},
+		}
+		want := []meta{
+			{
+				Name:  "Task",
+				Value: "task name",
+			},
+			{
+				Name:  "Status",
+				Value: "FAILED",
+			},
+			{
+				Name:  "Result Detail",
+				Value: common.TruncateStringWithDescription(detail),
 			},
 		}
 		a.Equal(want, context.getMetaList())

--- a/plugin/webhook/webhook_test.go
+++ b/plugin/webhook/webhook_test.go
@@ -4,8 +4,9 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"github.com/bytebase/bytebase/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/common"
 )
 
 func TestContext_getMetaList(t *testing.T) {

--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -448,6 +448,17 @@ func (r *ApplicationRunner) createExternalApproval(ctx context.Context, issue *a
 		})
 	}
 
+	for i, task := range stage.TaskList {
+		statement, err := getTaskStatement(task)
+		if err != nil {
+			return err
+		}
+		if statement == "" {
+			continue
+		}
+		taskList[i].Statement = statement
+	}
+
 	instanceCode, err := r.p.CreateExternalApproval(ctx,
 		feishu.TokenCtx{
 			AppID:     settingValue.AppID,

--- a/server/task.go
+++ b/server/task.go
@@ -939,3 +939,13 @@ func (s *Server) cancelDependingTasks(ctx context.Context, task *api.Task) error
 	}
 	return nil
 }
+
+func getTaskStatement(task *api.Task) (string, error) {
+	var taskStatement struct {
+		Statement string `json:"statement"`
+	}
+	if err := json.Unmarshal([]byte(task.Payload), &taskStatement); err != nil {
+		return "", err
+	}
+	return taskStatement.Statement, nil
+}


### PR DESCRIPTION
Close BYT-1864

Improve feishu approval card information by sending the SQLs of tasks.
We can't send the SQLs as is because if SQLs get too long, it's impossible to view them on Feishu.

Our strategies are
- For tasks having identical statements, merge them into one task group.
-  Send the SQL of at most five task groups.
- For each task group, truncate the SQL to fit within the limit of 450 characters.

## Known question

The SQL in the feishu approval card might get stale because we won't recall & resend on modifying SQL on Bytebase for now. This problem is to be solved together with https://github.com/bytebase/bytebase/issues/3558 in the follow-ups of #3640.

## screenshots

<img width="344" alt="image" src="https://user-images.githubusercontent.com/12679343/204996064-3d53c672-383e-4a19-97bf-9823abac07eb.png">

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/12679343/204996162-ef7a53c9-6515-4a5d-8d4f-b2809f60c99a.png">


## examples of generated SQL

```
=========================
The SQL statement of every task
=========================
-- 用来测试 SQL Editor 的 SQL
-- 3309 / ggg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_1e7
s... (view details in Bytebase)

```
```
=========================
The SQL statement of task 1
=========================
-- 用来测试 SQL Editor 的 SQL
-- 3309 / gggghgg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_1... (view details in Bytebase)

=========================
The SQL statement of task 2,3,4,5,6
=========================
-- 用来测试 SQL Editor 的 SQL
-- 3309 / ggg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_1e7
s... (view details in Bytebase)
```

```

Stage "Prod Stage" has 6 task(s).
1. [PENDING_APPROVAL] DDL(schema) for database "db".
2. [PENDING_APPROVAL] DDL(schema) for database "dc".
3. [PENDING_APPROVAL] DDL(schema) for database "dd".
4. [PENDING_APPROVAL] DDL(schema) for database "dfherh".
5. [PENDING_APPROVAL] DDL(schema) for database "tenant_db2".
6. [PENDING_APPROVAL] DDL(schema) for database "tet".
SQL
=========================
The SQL statement of task 1
=========================
-- 用来测试 SQL Editor 的 SQL1
-- 3309 / gggghgg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_... (view details in Bytebase)

=========================
The SQL statement of task 2
=========================
-- 用来测试 SQL Editor 的 SQL2
-- 3309 / ggg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_1e7
... (view details in Bytebase)

=========================
The SQL statement of task 3
=========================
-- 用来测试 SQL Editor 的 SQL3
-- 3309 / ggg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_1e7
... (view details in Bytebase)

=========================
The SQL statement of task 4
=========================
-- 用来测试 SQL Editor 的 SQL4
-- 3309 / ggg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_1e7
... (view details in Bytebase)

=========================
The SQL statement of task 5
=========================
-- 用来测试 SQL Editor 的 SQL5
-- 3309 / ggg
select
id,
cq_begq_iffpue_oypdiqpu_dnhvxqywpl,
kg_wrpa_dqfnjd_nrtlwgku_enoeqbjoxs,
tl_scgj_fideag_ifxjizpp_izbgtutaqf,
cf_uqkj_xrkiur_bqeacicz_rsdyryfaov,
wd_tifd_kdawmo_grvyyigl_yjnswhqvgd,
ph_knba_niweli_qemakvrx_hyaqgtxpyn,
cr_kxsg_cbupuh_gjswijzr_lxaierhrth,
creator_id,
updater_id,
created_ts,
updated_ts,
'🚀' as `中文 & emoji`
from
so_many_cols
where
1 = 1;

-- 3310 / db_1e7
... (view details in Bytebase)

=========================
Displaying 5 SQL statements, view more in Bytebase
```