### PR TITLE
feat(frontend): disable transfer db, establish baseline and backup/restore features for archived database

### DIFF
--- a/frontend/src/components/DatabaseBackupPanel.vue
+++ b/frontend/src/components/DatabaseBackupPanel.vue
@@ -21,6 +21,7 @@
               <span>{{ $t("database.backup-policy-violation") }}</span>
             </router-link>
             <button
+              v-if="allowAdmin"
               type="button"
               class="ml-4 btn-normal"
               @click.prevent="state.showBackupSettingModal = true"

--- a/frontend/src/components/DatabaseBackupPanel.vue
+++ b/frontend/src/components/DatabaseBackupPanel.vue
@@ -71,6 +71,7 @@
             :disabled="!allowEdit"
           />
           <button
+            v-if="allowEdit"
             class="btn-primary mt-2"
             :disabled="!allowEdit || !urlChanged"
             @click.prevent="updateBackupHookUrl()"

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -91,3 +91,13 @@ export function isPITRDatabase(db: Database): boolean {
   // A pitr database's name is xxx_pitr_1234567890 or xxx_pitr_1234567890_del
   return !!name.match(/^(.+?)_pitr_(\d+)(_del)?$/);
 }
+
+export function isArchivedDatabase(db: Database): boolean {
+  if (db.instance.rowStatus === "ARCHIVED") {
+    return true;
+  }
+  if (db.instance.environment.rowStatus === "ARCHIVED") {
+    return true;
+  }
+  return false;
+}

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -322,6 +322,7 @@ import {
   isPITRDatabase,
   isDatabaseAccessible,
   allowUsingUIEditor,
+  isArchivedDatabase,
 } from "@/utils";
 import {
   ProjectId,
@@ -416,6 +417,10 @@ const allowQuery = computed(() => {
 // - Workspace role can manage instance
 // - Project role can transfer database
 const allowTransferProject = computed(() => {
+  if (isArchivedDatabase(database.value)) {
+    return false;
+  }
+
   if (database.value.project.id == DEFAULT_PROJECT_ID) {
     return true;
   }
@@ -452,6 +457,10 @@ const allowTransferProject = computed(() => {
 // - Edit database label
 // - Enable/disable backup
 const allowAdmin = computed(() => {
+  if (isArchivedDatabase(database.value)) {
+    return false;
+  }
+
   if (
     hasWorkspacePermission(
       "bb.permission.workspace.manage-instance",
@@ -479,6 +488,10 @@ const allowAdmin = computed(() => {
 // The edit operation includes
 // - Take manual backup
 const allowEdit = computed(() => {
+  if (isArchivedDatabase(database.value)) {
+    return false;
+  }
+
   if (
     hasWorkspacePermission(
       "bb.permission.workspace.manage-instance",


### PR DESCRIPTION
On the database detail page, the buttons below will be hidden
- Transfer Database
- Establish baseline
- Enable auto backup
- Edit auto backup (when enabled)
- Restore to point in time
- Backup Now
- Restore (in the backup list)

Close BYT-1970