### PR TITLE
feat: requester fallback to bot if creator not found

### DIFF
--- a/plugin/app/feishu/feishu.go
+++ b/plugin/app/feishu/feishu.go
@@ -606,7 +606,7 @@ func (p *Provider) GetIDByEmail(ctx context.Context, tokenCtx TokenCtx, emails [
 	userID := make(map[string]string)
 	for _, user := range response.Data.UserList {
 		if user.UserID == "" {
-			return nil, errors.Errorf("id not found for email %s", user.Email)
+			continue
 		}
 		userID[user.Email] = user.UserID
 	}

--- a/plugin/app/feishu/feishu_test.go
+++ b/plugin/app/feishu/feishu_test.go
@@ -214,8 +214,11 @@ func TestProvider_GetIDByEmail(t *testing.T) {
 			},
 		}
 		ctx := context.Background()
-		_, err := p.GetIDByEmail(ctx, TokenCtx{}, []string{"zhangsan@a.com", "lisi@a.com"})
-		a.Error(err)
+		users, err := p.GetIDByEmail(ctx, TokenCtx{}, []string{"zhangsan@a.com", "lisi@a.com"})
+		a.NoError(err)
+		a.Equal("ou_979112345678741d29069abcdef089d4", users["zhangsan@a.com"])
+		_, ok := users["lisi@a.com"]
+		a.Equal(false, ok)
 	})
 	t.Run("success", func(t *testing.T) {
 		a := require.New(t)

--- a/server/application_runner.go
+++ b/server/application_runner.go
@@ -439,6 +439,21 @@ func (r *ApplicationRunner) createExternalApproval(ctx context.Context, issue *a
 	if err != nil {
 		return err
 	}
+	// assignee who approves the external approval is a must-have, so we returns error if we failed to find the user id.
+	if _, ok := users[issue.Assignee.Email]; !ok {
+		return errors.Errorf("failed to get user_id for issue assignee, email: %s", issue.Assignee.Email)
+	}
+	// if the creator is not found, the application bot will represent the creator.
+	if _, ok := users[issue.Creator.Email]; !ok {
+		botID, err := r.p.GetBotID(ctx, feishu.TokenCtx{
+			AppID:     settingValue.AppID,
+			AppSecret: settingValue.AppSecret,
+		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		users[issue.Creator.Email] = botID
+	}
 
 	var taskList []feishu.Task
 	for _, task := range stage.TaskList {

--- a/tests/external_approval_test.go
+++ b/tests/external_approval_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bytebase/bytebase/tests/fake"
 )
 
-func TestExternalApprovalFeishu(t *testing.T) {
+func TestExternalApprovalFeishu_AllUserCanBeFound(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)
 	ctx := context.Background()
@@ -67,6 +67,156 @@ func TestExternalApprovalFeishu(t *testing.T) {
 	a.NoError(err)
 
 	err = ctl.feishuProvider.RegisterEmails("demo@example.com", "dba@dba.com")
+	a.NoError(err)
+
+	// Create a project.
+	project, err := ctl.createProject(api.ProjectCreate{
+		Name: "Test Project",
+		Key:  "TestExternalApprovalFeishu",
+	})
+	a.NoError(err)
+
+	// Provision an instance.
+	instanceRootDir := t.TempDir()
+	instanceName := "testInstance1"
+	instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, instanceName)
+	a.NoError(err)
+
+	environments, err := ctl.getEnvironments()
+	a.NoError(err)
+	prodEnvironment, err := findEnvironment(environments, "Prod")
+	a.NoError(err)
+
+	// Add an instance.
+	instance, err := ctl.addInstance(api.InstanceCreate{
+		EnvironmentID: prodEnvironment.ID,
+		Name:          instanceName,
+		Engine:        db.SQLite,
+		Host:          instanceDir,
+	})
+	a.NoError(err)
+
+	// Expecting project to have no database.
+	databases, err := ctl.getDatabases(api.DatabaseFind{
+		ProjectID: &project.ID,
+	})
+	a.NoError(err)
+	a.Zero(len(databases))
+	// Expecting instance to have no database.
+	databases, err = ctl.getDatabases(api.DatabaseFind{
+		InstanceID: &instance.ID,
+	})
+	a.NoError(err)
+	a.Zero(len(databases))
+
+	// Create an issue that creates a database.
+	databaseName := "testSchemaUpdate"
+	err = ctl.createDatabase(project, instance, databaseName, "", nil /* labelMap */)
+	a.NoError(err)
+
+	// Expecting project to have 1 database.
+	databases, err = ctl.getDatabases(api.DatabaseFind{
+		ProjectID: &project.ID,
+	})
+	a.NoError(err)
+	a.Equal(1, len(databases))
+	database := databases[0]
+	a.Equal(instance.ID, database.Instance.ID)
+
+	// Create an issue that updates database schema.
+	createContext, err := json.Marshal(&api.MigrationContext{
+		DetailList: []*api.MigrationDetail{
+			{
+				MigrationType: db.Migrate,
+				DatabaseID:    database.ID,
+				Statement:     migrationStatement,
+			},
+		},
+	})
+	a.NoError(err)
+	issue, err := ctl.createIssue(api.IssueCreate{
+		ProjectID:     project.ID,
+		Name:          fmt.Sprintf("update schema for database %q", databaseName),
+		Type:          api.IssueDatabaseSchemaUpdate,
+		Description:   fmt.Sprintf("This updates the schema of database %q.", databaseName),
+		AssigneeID:    dba.ID,
+		CreateContext: string(createContext),
+	})
+	a.NoError(err)
+
+	// Sleep for 5 seconds, giving time to ApplicationRunner to create external approvals.
+	time.Sleep(5 * time.Second)
+	issue, err = ctl.getIssue(issue.ID)
+	a.NoError(err)
+	taskStatus, err := getNextTaskStatus(issue)
+	a.NoError(err)
+	// The task is still waiting for approval.
+	a.Equal(api.TaskPendingApproval, taskStatus)
+
+	// Should have 1 PENDING approval on the feishu side.
+	a.Equal(1, ctl.feishuProvider.PendingApprovalCount())
+	// Simulate users approving on the feishu side.
+	ctl.feishuProvider.ApprovePendingApprovals()
+
+	// Waiting ApplicationRunner to approves the issue.
+	status, err := ctl.waitIssuePipelineWithNoApproval(issue.ID)
+	a.NoError(err)
+	a.Equal(api.TaskDone, status)
+}
+
+func TestExternalApprovalFeishu_AssigneeCanBeFound(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	dataDir := t.TempDir()
+	err := ctl.StartServerWithExternalPg(ctx, &config{
+		dataDir:                 dataDir,
+		vcsProviderCreator:      fake.NewGitLab,
+		feishuProverdierCreator: fake.NewFeishu,
+	})
+	a.NoError(err)
+	defer ctl.Close(ctx)
+	err = ctl.Login()
+	a.NoError(err)
+
+	err = ctl.setLicense()
+	a.NoError(err)
+
+	// close existing issues
+	issues, err := ctl.getIssues(api.IssueFind{})
+	a.NoError(err)
+	for _, issue := range issues {
+		patchedIssue, err := ctl.patchIssueStatus(api.IssueStatusPatch{
+			ID:     issue.ID,
+			Status: api.IssueCanceled,
+		})
+		a.NoError(err)
+		a.Equal(api.IssueCanceled, patchedIssue.Status)
+	}
+
+	err = ctl.patchSetting(api.SettingPatch{
+		Name:  api.SettingAppIM,
+		Value: `{"imType":"im.feishu","appId":"123","appSecret":"123","externalApproval":{"enabled":true}}`,
+	})
+	a.NoError(err)
+
+	// Create a DBA account.
+	dba, err := ctl.createPrincipal(api.PrincipalCreate{
+		Type:  api.EndUser,
+		Name:  "DBA",
+		Email: "dba@dba.com",
+	})
+	a.NoError(err)
+
+	_, err = ctl.createMember(api.MemberCreate{
+		Status:      api.Active,
+		Role:        api.DBA,
+		PrincipalID: dba.ID,
+	})
+	a.NoError(err)
+
+	err = ctl.feishuProvider.RegisterEmails("dba@dba.com")
 	a.NoError(err)
 
 	// Create a project.


### PR DESCRIPTION
Close BYT-1955

Use the application as the bot if the assignee cannot be found.

Also need to modify the user doc later.

## screenshots

<img width="692" alt="image" src="https://user-images.githubusercontent.com/12679343/205227509-7f9727e5-cf34-4474-8eba-1f1918c590bc.png">
<img width="332" alt="image" src="https://user-images.githubusercontent.com/12679343/205227544-078bd845-9273-4446-894b-ac4ffbcd6499.png">
