### PR TITLE
feat(sql-editor): return effected rows if sql editor submit a single SQL and the type is UPDATE/DELETE/INSERT

### DIFF
--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -213,7 +213,7 @@ func (driver *Driver) Query(ctx context.Context, statement string, queryContext 
 	}
 	// https://dev.mysql.com/doc/c-api/8.0/en/mysql-affected-rows.html
 	// If the statement is an INSERT, UPDATE, or DELETE statement, we will call execute instead of query and return the number of rows affected.
-	if len(singleSQLs) == 1 && isAffectedRowsStatement(singleSQLs[0].Text) {
+	if len(singleSQLs) == 1 && util.IsAffectedRowsStatement(singleSQLs[0].Text) {
 		affectedRows, err := driver.Execute(ctx, singleSQLs[0].Text, false)
 		if err != nil {
 			return nil, err
@@ -251,15 +251,4 @@ func transformDelimiter(out io.Writer, statement string) error {
 		}
 	}
 	return nil
-}
-
-func isAffectedRowsStatement(stmt string) bool {
-	affectedRowsStatementPrefix := []string{"INSERT ", "UPDATE ", "DELETE "}
-	upperStatement := strings.ToUpper(stmt)
-	for _, prefix := range affectedRowsStatementPrefix {
-		if strings.HasPrefix(upperStatement, prefix) {
-			return true
-		}
-	}
-	return false
 }

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -218,7 +218,10 @@ func (driver *Driver) Query(ctx context.Context, statement string, queryContext 
 		if err != nil {
 			return nil, err
 		}
-		return []interface{}{affectedRows}, nil
+		field := []string{"Affected Rows"}
+		types := []string{"INT"}
+		rows := [][]interface{}{{affectedRows}}
+		return []interface{}{field, types, rows}, nil
 	}
 	return util.Query(ctx, driver.dbType, driver.db, statement, queryContext)
 }

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -204,6 +204,22 @@ func (driver *Driver) GetMigrationConnID(ctx context.Context) (string, error) {
 
 // Query queries a SQL statement.
 func (driver *Driver) Query(ctx context.Context, statement string, queryContext *db.QueryContext) ([]interface{}, error) {
+	singleSQLs, err := bbparser.SplitMultiSQL(bbparser.MySQL, statement)
+	if err != nil {
+		return nil, err
+	}
+	if len(singleSQLs) == 0 {
+		return nil, nil
+	}
+	// https://dev.mysql.com/doc/c-api/8.0/en/mysql-affected-rows.html
+	// If the statement is an INSERT, UPDATE, or DELETE statement, we will call execute instead of query and return the number of rows affected.
+	if len(singleSQLs) == 1 && isAffectedRowsStatement(singleSQLs[0].Text) {
+		affectedRows, err := driver.Execute(ctx, singleSQLs[0].Text, false)
+		if err != nil {
+			return nil, err
+		}
+		return []interface{}{affectedRows}, nil
+	}
 	return util.Query(ctx, driver.dbType, driver.db, statement, queryContext)
 }
 
@@ -232,4 +248,15 @@ func transformDelimiter(out io.Writer, statement string) error {
 		}
 	}
 	return nil
+}
+
+func isAffectedRowsStatement(stmt string) bool {
+	affectedRowsStatementPrefix := []string{"INSERT ", "UPDATE ", "DELETE "}
+	upperStatement := strings.ToUpper(stmt)
+	for _, prefix := range affectedRowsStatementPrefix {
+		if strings.HasPrefix(upperStatement, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -417,7 +417,7 @@ func (driver *Driver) Query(ctx context.Context, statement string, queryContext 
 
 	// If the statement is an INSERT, UPDATE, or DELETE statement, we will call execute instead of query and return the number of rows affected.
 	// https://github.com/postgres/postgres/blob/master/src/bin/psql/common.c#L969
-	if len(singleSQLs) == 1 && isAffectedRowsStatement(singleSQLs[0].Text) {
+	if len(singleSQLs) == 1 && util.IsAffectedRowsStatement(singleSQLs[0].Text) {
 		affectedRows, err := driver.Execute(ctx, singleSQLs[0].Text, false)
 		if err != nil {
 			return nil, err
@@ -445,15 +445,4 @@ func (driver *Driver) switchDatabase(dbName string) error {
 	driver.db = db
 	driver.databaseName = dbName
 	return nil
-}
-
-func isAffectedRowsStatement(stmt string) bool {
-	affectedRowsStatementPrefix := []string{"INSERT ", "UPDATE ", "DELETE "}
-	upperStatement := strings.ToUpper(stmt)
-	for _, prefix := range affectedRowsStatementPrefix {
-		if strings.HasPrefix(upperStatement, prefix) {
-			return true
-		}
-	}
-	return false
 }

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -422,7 +422,10 @@ func (driver *Driver) Query(ctx context.Context, statement string, queryContext 
 		if err != nil {
 			return nil, err
 		}
-		return []interface{}{affectedRows}, nil
+		field := []string{"Affected Rows"}
+		types := []string{"INT"}
+		rows := [][]interface{}{{affectedRows}}
+		return []interface{}{field, types, rows}, nil
 	}
 	return util.Query(ctx, db.Postgres, driver.db, statement, queryContext)
 }

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -818,3 +818,14 @@ func extractMySQLSingleTable(fromClause *tidbast.TableRefsClause) (string, strin
 	}
 	return tableName.Schema.O, tableName.Name.O, true
 }
+
+func IsAffectedRowsStatement(stmt string) bool {
+	affectedRowsStatementPrefix := []string{"INSERT ", "UPDATE ", "DELETE "}
+	upperStatement := strings.ToUpper(stmt)
+	for _, prefix := range affectedRowsStatementPrefix {
+		if strings.HasPrefix(upperStatement, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -819,6 +819,7 @@ func extractMySQLSingleTable(fromClause *tidbast.TableRefsClause) (string, strin
 	return tableName.Schema.O, tableName.Name.O, true
 }
 
+// IsAffectedRowsStatement returns true if the statement will return the number of affected rows.
 func IsAffectedRowsStatement(stmt string) bool {
 	affectedRowsStatementPrefix := []string{"INSERT ", "UPDATE ", "DELETE "}
 	upperStatement := strings.ToUpper(stmt)

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -328,7 +328,7 @@ func Query(ctx context.Context, dbType db.Type, sqldb *sql.DB, statement string,
 	readOnly := queryContext.ReadOnly
 	limit := queryContext.Limit
 	if !readOnly {
-		return queryAdmin(ctx, sqldb, dbType, statement, limit)
+		return queryAdmin(ctx, sqldb, statement, limit)
 	}
 	// Limit SQL query result size.
 	if dbType == db.MySQL {
@@ -443,7 +443,7 @@ func Query(ctx context.Context, dbType db.Type, sqldb *sql.DB, statement string,
 }
 
 // query will execute a query.
-func queryAdmin(ctx context.Context, sqldb *sql.DB, dbType db.Type, statement string, _ int) ([]interface{}, error) {
+func queryAdmin(ctx context.Context, sqldb *sql.DB, statement string, _ int) ([]interface{}, error) {
 	rows, err := sqldb.QueryContext(ctx, statement)
 	if err != nil {
 		return nil, FormatErrorWithQuery(err, statement)

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -328,7 +328,7 @@ func Query(ctx context.Context, dbType db.Type, sqldb *sql.DB, statement string,
 	readOnly := queryContext.ReadOnly
 	limit := queryContext.Limit
 	if !readOnly {
-		return queryAdmin(ctx, sqldb, statement, limit)
+		return queryAdmin(ctx, sqldb, dbType, statement, limit)
 	}
 	// Limit SQL query result size.
 	if dbType == db.MySQL {
@@ -443,7 +443,7 @@ func Query(ctx context.Context, dbType db.Type, sqldb *sql.DB, statement string,
 }
 
 // query will execute a query.
-func queryAdmin(ctx context.Context, sqldb *sql.DB, statement string, _ int) ([]interface{}, error) {
+func queryAdmin(ctx context.Context, sqldb *sql.DB, dbType db.Type, statement string, _ int) ([]interface{}, error) {
 	rows, err := sqldb.QueryContext(ctx, statement)
 	if err != nil {
 		return nil, FormatErrorWithQuery(err, statement)

--- a/tests/sql_editor_test.go
+++ b/tests/sql_editor_test.go
@@ -31,30 +31,28 @@ func TestAdminQueryAffectedRows(t *testing.T) {
 			dbType:            db.MySQL,
 			prepareStatements: "CREATE TABLE tbl(id INT PRIMARY KEY);",
 			query:             "INSERT INTO tbl VALUES(1);",
-			want:              true,
-			affectedRows:      "[1]",
+			affectedRows:      `[["Affected Rows"],["INT"],[[1]]]`,
 		},
 		{
 			databaseName:      "Test2",
 			dbType:            db.MySQL,
 			prepareStatements: "CREATE TABLE tbl(id INT PRIMARY KEY);",
 			query:             "INSERT INTO tbl VALUES(1); DELETE FROM tbl WHERE id = 1;",
-			want:              false,
+			affectedRows:      `[[],null,[]]`,
 		},
 		{
 			databaseName:      "Test3",
 			dbType:            db.Postgres,
 			prepareStatements: "CREATE TABLE public.tbl(id INT PRIMARY KEY);",
 			query:             "INSERT INTO tbl VALUES(1),(2);",
-			want:              true,
-			affectedRows:      "[2]",
+			affectedRows:      `[["Affected Rows"],["INT"],[[2]]]`,
 		},
 		{
 			databaseName:      "Test4",
 			dbType:            db.Postgres,
 			prepareStatements: "CREATE TABLE tbl(id INT PRIMARY KEY);",
 			query:             "ALTER TABLE tbl ADD COLUMN name VARCHAR(255);",
-			want:              false,
+			affectedRows:      `[[],null,[]]`,
 		},
 	}
 
@@ -170,10 +168,6 @@ func TestAdminQueryAffectedRows(t *testing.T) {
 
 		affectedRows, err := ctl.adminQuery(instance, tt.databaseName, tt.query)
 		a.NoError(err)
-		if tt.want {
-			a.Equal(tt.affectedRows, affectedRows)
-		} else {
-			a.Equal(tt.affectedRows, "")
-		}
+		a.Equal(tt.affectedRows, affectedRows)
 	}
 }

--- a/tests/sql_editor_test.go
+++ b/tests/sql_editor_test.go
@@ -1,0 +1,179 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/plugin/db"
+	resourcemysql "github.com/bytebase/bytebase/resources/mysql"
+	"github.com/bytebase/bytebase/resources/postgres"
+	"github.com/bytebase/bytebase/tests/fake"
+)
+
+func TestAdminQueryAffectedRows(t *testing.T) {
+	tests := []struct {
+		databaseName      string
+		dbType            db.Type
+		prepareStatements string
+		query             string
+		want              bool
+		affectedRows      string
+	}{
+		{
+			databaseName:      "Test1",
+			dbType:            db.MySQL,
+			prepareStatements: "CREATE TABLE tbl(id INT PRIMARY KEY);",
+			query:             "INSERT INTO tbl VALUES(1);",
+			want:              true,
+			affectedRows:      "[1]",
+		},
+		{
+			databaseName:      "Test2",
+			dbType:            db.MySQL,
+			prepareStatements: "CREATE TABLE tbl(id INT PRIMARY KEY);",
+			query:             "INSERT INTO tbl VALUES(1); DELETE FROM tbl WHERE id = 1;",
+			want:              false,
+		},
+		{
+			databaseName:      "Test3",
+			dbType:            db.Postgres,
+			prepareStatements: "CREATE TABLE public.tbl(id INT PRIMARY KEY);",
+			query:             "INSERT INTO tbl VALUES(1),(2);",
+			want:              true,
+			affectedRows:      "[2]",
+		},
+		{
+			databaseName:      "Test4",
+			dbType:            db.Postgres,
+			prepareStatements: "CREATE TABLE tbl(id INT PRIMARY KEY);",
+			query:             "ALTER TABLE tbl ADD COLUMN name VARCHAR(255);",
+			want:              false,
+		},
+	}
+
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	dataDir := t.TempDir()
+	err := ctl.StartServerWithExternalPg(ctx, &config{
+		dataDir:            dataDir,
+		vcsProviderCreator: fake.NewGitLab,
+	})
+	a.NoError(err)
+	defer ctl.Close(ctx)
+	err = ctl.Login()
+	a.NoError(err)
+	err = ctl.setLicense()
+	a.NoError(err)
+
+	mysqlPort := getTestPort()
+	mysqlStopInstance := resourcemysql.SetupTestInstance(t, mysqlPort, mysqlBinDir)
+	defer mysqlStopInstance()
+
+	// Create a PostgreSQL instance.
+	pgPort := getTestPort()
+	pgStopInstance := postgres.SetupTestInstance(t, pgPort, resourceDirOverride)
+	defer pgStopInstance()
+
+	// Create a project.
+	project, err := ctl.createProject(api.ProjectCreate{
+		Name: "Test Project",
+		Key:  t.Name(),
+	})
+	a.NoError(err)
+	environments, err := ctl.getEnvironments()
+	a.NoError(err)
+	prodEnvironment, err := findEnvironment(environments, "Prod")
+	a.NoError(err)
+
+	mysqlInstance, err := ctl.addInstance(api.InstanceCreate{
+		EnvironmentID: prodEnvironment.ID,
+		Name:          "mysqlInstance",
+		Engine:        db.MySQL,
+		Host:          "127.0.0.1",
+		Port:          strconv.Itoa(mysqlPort),
+		Username:      "root",
+		Password:      "",
+	})
+	a.NoError(err)
+
+	pgInstance, err := ctl.addInstance(api.InstanceCreate{
+		EnvironmentID: prodEnvironment.ID,
+		Name:          "pgInstance",
+		Engine:        db.Postgres,
+		Host:          "/tmp",
+		Port:          strconv.Itoa(pgPort),
+		Username:      "root",
+	})
+	a.NoError(err)
+
+	for idx, tt := range tests {
+		var instance *api.Instance
+		databaseOwner := ""
+		switch tt.dbType {
+		case db.MySQL:
+			instance = mysqlInstance
+		case db.Postgres:
+			instance = pgInstance
+			databaseOwner = "root"
+		default:
+			a.FailNow("unsupported db type")
+		}
+		err = ctl.createDatabase(project, instance, tt.databaseName, databaseOwner, nil)
+		a.NoError(err)
+
+		databases, err := ctl.getDatabases(api.DatabaseFind{
+			ProjectID: &project.ID,
+		})
+		a.NoError(err)
+		a.Equal(idx+1, len(databases))
+
+		sort.Slice(databases, func(i, j int) bool {
+			return databases[i].CreatedTs > databases[j].CreatedTs
+		})
+		database := databases[0]
+
+		a.Equal(instance.ID, database.Instance.ID)
+
+		// Create an issue that updates database schema.
+		createContext, err := json.Marshal(&api.MigrationContext{
+			DetailList: []*api.MigrationDetail{
+				{
+					MigrationType: db.Migrate,
+					DatabaseID:    database.ID,
+					Statement:     tt.prepareStatements,
+				},
+			},
+		})
+		a.NoError(err)
+		issue, err := ctl.createIssue(api.IssueCreate{
+			ProjectID:   project.ID,
+			Name:        fmt.Sprintf("Prepare statements of database %q", tt.databaseName),
+			Type:        api.IssueDatabaseSchemaUpdate,
+			Description: fmt.Sprintf("Prepare statements of database %q.", tt.databaseName),
+			// Assign to self.
+			AssigneeID:    project.Creator.ID,
+			CreateContext: string(createContext),
+		})
+		a.NoError(err)
+		status, err := ctl.waitIssuePipeline(issue.ID)
+		a.NoError(err)
+		a.Equal(api.TaskDone, status)
+
+		affectedRows, err := ctl.adminQuery(instance, tt.databaseName, tt.query)
+		a.NoError(err)
+		if tt.want {
+			a.Equal(tt.affectedRows, affectedRows)
+		} else {
+			a.Equal(tt.affectedRows, "")
+		}
+	}
+}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	// Import pg driver.
-	// init() in pgx/v4/stdlib will register it's pgx driver.
+	// init() in pgx/v5/stdlib will register it's pgx driver.
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/bytebase/bytebase/api"


### PR DESCRIPTION
This feature is only suitable for MySQL/PostgreSQL family.
If the user submits only one SQL via SQL Editor, and the statement type is UPDATE/DELETE/INSERT, the backend will return the affected rows. 
~~In that case, the `data` field in `SQLResultSet` will only contain one number.~~
<img width="2183" alt="CleanShot 2022-12-02 at 16 08 58@2x" src="https://user-images.githubusercontent.com/87714218/205246183-684532fd-3233-48d7-ac2a-a378c000e7d9.png">

FYI @LiuJi-Jim 
