### PR TITLE
feat(frontend): show exact time in issue activity

### DIFF
--- a/frontend/src/components/Issue/IssueActivityPanel.vue
+++ b/frontend/src/components/Issue/IssueActivityPanel.vue
@@ -141,8 +141,11 @@
                           :activity="item.activity"
                         />
 
-                        {{ humanizeTs(item.activity.createdTs) }}
-                        <template
+                        <HumanizeTs
+                          :ts="item.activity.createdTs"
+                          class="ml-1"
+                        />
+                        <span
                           v-if="
                             item.activity.createdTs !=
                               item.activity.updatedTs &&
@@ -150,8 +153,11 @@
                           "
                         >
                           ({{ $t("common.edited") }}
-                          {{ humanizeTs(item.activity.updatedTs) }})
-                        </template>
+                          <HumanizeTs
+                            :ts="item.activity.updatedTs"
+                            class="ml-1"
+                          />)
+                        </span>
                       </a>
                       <span
                         v-if="item.similar.length > 0"
@@ -330,6 +336,7 @@ import {
 } from "vue";
 import { useRoute } from "vue-router";
 import PrincipalAvatar from "../PrincipalAvatar.vue";
+import HumanizeTs from "../misc/HumanizeTs.vue";
 import type {
   Issue,
   Activity,

--- a/frontend/src/components/misc/HumanizeTs.vue
+++ b/frontend/src/components/misc/HumanizeTs.vue
@@ -1,0 +1,32 @@
+<template>
+  <NTooltip trigger="hover">
+    <template #trigger>
+      <span v-bind="$attrs">{{ humanized }}</span>
+    </template>
+
+    <span class="whitespace-nowrap">{{ detail }}</span>
+  </NTooltip>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import dayjs from "dayjs";
+import { NTooltip } from "naive-ui";
+
+import { humanizeTs } from "@/utils";
+
+const props = defineProps({
+  ts: {
+    type: Number,
+    required: true,
+  },
+  format: {
+    type: String,
+    default: "YYYY-MM-DD HH:mm:ss UTCZZ",
+  },
+});
+
+const humanized = computed(() => humanizeTs(props.ts));
+
+const detail = computed(() => dayjs(props.ts * 1000).format(props.format));
+</script>


### PR DESCRIPTION
### Feature

We still use the `humanizeTs` as the default display to keep it clear and consistent, but add a tooltip to show the exact time while hovering.

The `<HumanizeTs>` is also useful everywhere in the future.

### Screenshot

<img width="390" alt="image" src="https://user-images.githubusercontent.com/2749742/205476359-1c849124-62ad-4e42-9a2d-a54f429665b4.png">
