### PR TITLE
feat: introduce db_schema table for storing database schema metadata and dump

### DIFF
--- a/store/migration/dev/20221206000000##db_schema.sql
+++ b/store/migration/dev/20221206000000##db_schema.sql
@@ -1,0 +1,21 @@
+CREATE TABLE db_schema (
+    id SERIAL PRIMARY KEY,
+    row_status row_status NOT NULL DEFAULT 'NORMAL',
+    creator_id INTEGER NOT NULL REFERENCES principal (id),
+    created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    updater_id INTEGER NOT NULL REFERENCES principal (id),
+    updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    database_id INTEGER NOT NULL REFERENCES db (id) ON DELETE CASCADE,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    raw_dump TEXT NOT NULL DEFAULT ''
+);
+
+CREATE UNIQUE INDEX idx_db_schema_unique_database_id ON tbl(database_id);
+
+ALTER SEQUENCE db_schema_id_seq RESTART WITH 101;
+
+CREATE TRIGGER update_db_schema_updated_ts
+BEFORE
+UPDATE
+    ON db_schema FOR EACH ROW
+EXECUTE FUNCTION trigger_update_updated_ts();

--- a/store/migration/dev/20221206000000##db_schema.sql
+++ b/store/migration/dev/20221206000000##db_schema.sql
@@ -10,7 +10,7 @@ CREATE TABLE db_schema (
     raw_dump TEXT NOT NULL DEFAULT ''
 );
 
-CREATE UNIQUE INDEX idx_db_schema_unique_database_id ON tbl(database_id);
+CREATE UNIQUE INDEX idx_db_schema_unique_database_id ON db_schema(database_id);
 
 ALTER SEQUENCE db_schema_id_seq RESTART WITH 101;
 

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -346,6 +346,29 @@ UPDATE
     ON db FOR EACH ROW
 EXECUTE FUNCTION trigger_update_updated_ts();
 
+-- db_schema stores the database schema metadata for a particular database.
+CREATE TABLE db_schema (
+    id SERIAL PRIMARY KEY,
+    row_status row_status NOT NULL DEFAULT 'NORMAL',
+    creator_id INTEGER NOT NULL REFERENCES principal (id),
+    created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    updater_id INTEGER NOT NULL REFERENCES principal (id),
+    updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    database_id INTEGER NOT NULL REFERENCES db (id) ON DELETE CASCADE,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    raw_dump TEXT NOT NULL DEFAULT ''
+);
+
+CREATE UNIQUE INDEX idx_db_schema_unique_database_id ON tbl(database_id);
+
+ALTER SEQUENCE db_schema_id_seq RESTART WITH 101;
+
+CREATE TRIGGER update_db_schema_updated_ts
+BEFORE
+UPDATE
+    ON db_schema FOR EACH ROW
+EXECUTE FUNCTION trigger_update_updated_ts();
+
 -- tbl stores the table for a particular database
 -- data is synced periodically from the instance
 CREATE TABLE tbl (

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -359,7 +359,7 @@ CREATE TABLE db_schema (
     raw_dump TEXT NOT NULL DEFAULT ''
 );
 
-CREATE UNIQUE INDEX idx_db_schema_unique_database_id ON tbl(database_id);
+CREATE UNIQUE INDEX idx_db_schema_unique_database_id ON db_schema(database_id);
 
 ALTER SEQUENCE db_schema_id_seq RESTART WITH 101;
 


### PR DESCRIPTION
This is the first step of denormalizing other database metadata tables.