### PR TITLE
feat: only allow setting database connection parameter for Postgres

### DIFF
--- a/server/component/dbfactory/dbfactory.go
+++ b/server/component/dbfactory/dbfactory.go
@@ -41,6 +41,9 @@ func (d *DBFactory) GetAdminDatabaseDriver(ctx context.Context, instance *api.In
 		dbBinDir = d.pgBinDir
 	}
 
+	if databaseName == "" {
+		databaseName = instance.Database
+	}
 	driver, err := getDatabaseDriver(
 		ctx,
 		instance.Engine,


### PR DESCRIPTION
Postgres has strong isolation for databases and required database connection parameter. Right now, we are guessing the database parameter in guessDSN, but we should allow users to specify one without guessing because guesses could be incorrect.

<img width="492" alt="Screenshot 2022-12-07 at 13 03 03" src="https://user-images.githubusercontent.com/98006139/206092938-182cefeb-a9a5-43f2-9069-4421ff6e91e7.png">
