### PR TITLE
fix(sql-editor): disallow to set connection to protected instances

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -29,6 +29,7 @@ import {
   isSameConnection,
   isTempTab,
   isDatabaseAccessible,
+  isInstanceAccessible,
 } from "@/utils";
 import { useI18n } from "vue-i18n";
 
@@ -85,7 +86,14 @@ const prepareSQLEditorContext = async () => {
   let connectionTree: ConnectionAtom[] = [];
 
   const { instanceList, databaseList } = state;
-  connectionTree = instanceList.map(mapConnectionAtom("instance", 0));
+  const instanceMapper = mapConnectionAtom("instance", 0);
+  connectionTree = instanceList.map((instance) => {
+    const node = instanceMapper(instance);
+    if (!isInstanceAccessible(instance, currentUser.value)) {
+      node.disabled = true;
+    }
+    return node;
+  });
 
   for (const instance of instanceList) {
     const instanceItem = connectionTree.find(

--- a/frontend/src/utils/policy.ts
+++ b/frontend/src/utils/policy.ts
@@ -20,7 +20,7 @@ export const isInstanceAccessible = (instance: Instance, user: Principal) => {
     return true;
   }
 
-  // See if the instance is in an protected environment
+  // See if the instance is in a protected environment
   const { environment } = instance;
   if (environment.tier === "UNPROTECTED") {
     return true;

--- a/frontend/src/utils/policy.ts
+++ b/frontend/src/utils/policy.ts
@@ -1,6 +1,33 @@
 import { hasFeature } from "@/store";
-import type { Database, Policy, Principal } from "@/types";
+import type { Database, Instance, Policy, Principal } from "@/types";
 import { hasWorkspacePermission } from "./role";
+
+export const isInstanceAccessible = (instance: Instance, user: Principal) => {
+  if (!hasFeature("bb.feature.access-control")) {
+    // The current plan doesn't have access control feature.
+    // Fallback to true.
+    return true;
+  }
+
+  if (
+    hasWorkspacePermission(
+      "bb.permission.workspace.manage-access-control",
+      user.role
+    )
+  ) {
+    // The current user has the super privilege to access all databases.
+    // AKA. Owners and DBAs
+    return true;
+  }
+
+  // See if the instance is in an protected environment
+  const { environment } = instance;
+  if (environment.tier === "UNPROTECTED") {
+    return true;
+  }
+
+  return false;
+};
 
 export const isDatabaseAccessible = (
   database: Database,

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -113,6 +113,11 @@ const dropdownOptions = computed((): DropdownOptionWithConnectionAtom[] => {
       },
     ];
   } else {
+    // Don't show any context menu actions for disabled
+    // instances/databases
+    if (dropdownContext.value.disabled) {
+      return [];
+    }
     return [
       {
         key: "open-connection",
@@ -219,12 +224,12 @@ const renderPrefix = ({ option }: { option: ConnectionAtom }) => {
       }),
       h(ProtectedEnvironmentIcon, {
         environment: instance.environment,
-        class: "w-4 h-4",
+        class: "w-4 h-4 text-inherit",
       }),
       h(
         "span",
         {
-          class: "text-gray-500 text-sm",
+          class: ["text-sm", !option.disabled && "text-gray-500"],
         },
         `(${instance.environment.name})`
       ),
@@ -319,6 +324,8 @@ const handleClickoutside = () => {
 const nodeProps = ({ option }: { option: ConnectionAtom }) => {
   return {
     onClick(e: MouseEvent) {
+      if (option.disabled) return;
+
       if (isDescendantOf(e.target as Element, ".n-tree-node-content")) {
         // Check if clicked on the content part.
         // And ignore the fold/unfold arrow.
@@ -417,10 +424,6 @@ watch(
 .databases-tree .n-tree-node--selected,
 .databases-tree .n-tree-node--selected:hover {
   background-color: var(--n-node-color-active) !important;
-}
-.databases-tree .n-tree-node--disabled > * {
-  pointer-events: none;
-  cursor: not-allowed !important;
 }
 </style>
 

--- a/frontend/src/views/sql-editor/SQLEditorPage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorPage.vue
@@ -51,6 +51,7 @@ import { TabMode, UNKNOWN_ID } from "@/types";
 import {
   useCurrentUser,
   useDatabaseStore,
+  useInstanceStore,
   useSQLEditorStore,
   useTabStore,
 } from "@/store";
@@ -59,10 +60,11 @@ import EditorPanel from "./EditorPanel/EditorPanel.vue";
 import TerminalPanel from "./TerminalPanel/TerminalPanel.vue";
 import TabList from "./TabList";
 import TablePanel from "./TablePanel/TablePanel.vue";
-import { isDatabaseAccessible } from "@/utils";
+import { isDatabaseAccessible, isInstanceAccessible } from "@/utils";
 
 const tabStore = useTabStore();
 const databaseStore = useDatabaseStore();
+const instanceStore = useInstanceStore();
 const sqlEditorStore = useSQLEditorStore();
 const currentUser = useCurrentUser();
 
@@ -70,10 +72,11 @@ const isDisconnected = computed(() => tabStore.isDisconnected);
 const isFetchingSheet = computed(() => sqlEditorStore.isFetchingSheet);
 
 const allowQuery = computed(() => {
-  const { databaseId } = tabStore.currentTab.connection;
+  const { databaseId, instanceId } = tabStore.currentTab.connection;
   const database = databaseStore.getDatabaseById(databaseId);
   if (database.id === UNKNOWN_ID) {
-    return true; // fallback
+    const instance = instanceStore.getInstanceById(instanceId);
+    return isInstanceAccessible(instance, currentUser.value);
   }
   const { accessControlPolicyList } = sqlEditorStore;
   return isDatabaseAccessible(


### PR DESCRIPTION
Close BYT-2042

### Features
- Disallow to set a connection to protected instances
- The node is still expandable since some children might be accessible.

### Screenshot

![localhost_3000_sql-editor_prod-3333-101(1600_900)](https://user-images.githubusercontent.com/2749742/206392295-bf4fdb19-7365-43aa-9b25-182d4422bc95.png)
