### PR TITLE
feat: migrate instance schema to make mongodb valid

### DIFF
--- a/store/migration/dev/20221209000000##mongo_instance_type.sql
+++ b/store/migration/dev/20221209000000##mongo_instance_type.sql
@@ -1,0 +1,4 @@
+-- NOTE: we did not declare a name for this constraint first, so this may not work.
+ALTER TABLE instance DROP CONSTRAINT instance_engine_check;
+
+ALTER TABLE instance ADD CONSTRAINT instance_engine_check CHECK (engine IN ('MYSQL', 'POSTGRES', 'TIDB', 'CLICKHOUSE', 'SNOWFLAKE', 'SQLITE', 'MONGODB'));

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -274,7 +274,7 @@ CREATE TABLE instance (
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     environment_id INTEGER NOT NULL REFERENCES environment (id),
     name TEXT NOT NULL,
-    engine TEXT NOT NULL CHECK (engine IN ('MYSQL', 'POSTGRES', 'TIDB', 'CLICKHOUSE', 'SNOWFLAKE', 'SQLITE')),
+    engine TEXT NOT NULL CONSTRAINT instance_engine_check CHECK (engine IN ('MYSQL', 'POSTGRES', 'TIDB', 'CLICKHOUSE', 'SNOWFLAKE', 'SQLITE', 'MONGODB')),
     engine_version TEXT NOT NULL DEFAULT '',
     host TEXT NOT NULL,
     port TEXT NOT NULL,


### PR DESCRIPTION
This PR makes MONGODB a valid engine type in Bytebase's instance table.

We did not declare a name for the check constraint at first, so the drop constraint statement may not work.