### PR TITLE
feat(frontend): database transferring improvement

### DIFF
--- a/frontend/src/components/TransferDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm.vue
@@ -40,6 +40,7 @@ import {
 } from "../types";
 import {
   buildDatabaseNameRegExpByTemplate,
+  filterDatabaseByKeyword,
   PRESET_LABEL_KEY_PLACEHOLDERS,
   sortDatabaseList,
 } from "../utils";
@@ -108,9 +109,14 @@ const databaseList = computed(() => {
   }
 
   const keyword = state.searchText.trim();
-  if (keyword) {
-    list = list.filter((db) => db.name.toLowerCase().includes(keyword));
-  }
+  list = list.filter((db) =>
+    filterDatabaseByKeyword(db, keyword, [
+      "name",
+      "project",
+      "instance",
+      "environment",
+    ])
+  );
 
   return sortDatabaseList(list, environmentList.value);
 });

--- a/frontend/src/components/TransferDatabaseForm/TransferSourceSelector.vue
+++ b/frontend/src/components/TransferDatabaseForm/TransferSourceSelector.vue
@@ -1,41 +1,43 @@
 <template>
-  <div v-if="project.id != DEFAULT_PROJECT_ID" class="textlabel">
+  <div class="textlabel">
     <div v-if="state.transferSource == 'DEFAULT'" class="textinfolabel mb-2">
       {{ $t("quick-action.unassigned-db-hint") }}
     </div>
     <div class="flex items-center justify-between">
       <div class="radio-set-row">
-        <label class="radio">
-          <input
-            v-model="state.transferSource"
-            tabindex="-1"
-            type="radio"
-            class="btn"
-            value="DEFAULT"
-          />
-          <span class="label">
-            {{ $t("quick-action.from-unassigned-databases") }}
-          </span>
-        </label>
-        <label class="radio">
-          <input
-            v-model="state.transferSource"
-            tabindex="-1"
-            type="radio"
-            class="btn"
-            value="OTHER"
-          />
-          <span class="label">
-            {{ $t("quick-action.from-projects") }}
-          </span>
-        </label>
+        <template v-if="project.id != DEFAULT_PROJECT_ID">
+          <label class="radio">
+            <input
+              v-model="state.transferSource"
+              tabindex="-1"
+              type="radio"
+              class="btn"
+              value="DEFAULT"
+            />
+            <span class="label">
+              {{ $t("quick-action.from-unassigned-databases") }}
+            </span>
+          </label>
+          <label class="radio">
+            <input
+              v-model="state.transferSource"
+              tabindex="-1"
+              type="radio"
+              class="btn"
+              value="OTHER"
+            />
+            <span class="label">
+              {{ $t("quick-action.from-projects") }}
+            </span>
+          </label>
+        </template>
       </div>
       <div>
         <BBTableSearch
           class="m-px"
           :value="searchText"
-          :placeholder="$t('database.search-database-name')"
-          @change-text="(text) => $emit('search-text-change', text)"
+          :placeholder="$t('database.search-database')"
+          @change-text="(text: string) => $emit('search-text-change', text)"
         />
       </div>
     </div>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -859,6 +859,7 @@
     "sync-status": "Sync status",
     "last-successful-sync": "Last successful sync",
     "search-database-name": "Search database name",
+    "search-database": "Search database",
     "restored-from": "Restored from ",
     "database-name-is-restored-from-another-database-backup": "{0} is restored from another database backup",
     "database-backup": "database backup",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -859,6 +859,7 @@
     "no-anomalies-detected": "没有检测到异常",
     "sync-status": "同步状态",
     "search-database-name": "搜索数据库名称",
+    "search-database": "搜索数据库",
     "restored-from": "恢复于",
     "database-name-is-restored-from-another-database-backup": "{0}恢复于另一个数据库备份",
     "transfer-project": "转移项目",

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -82,6 +82,46 @@ export function allowGhostMigration(databaseList: Database[]): boolean {
   });
 }
 
+type DatabaseFilterFields = "name" | "project" | "instance" | "environment";
+export function filterDatabaseByKeyword(
+  db: Database,
+  keyword: string,
+  columns: DatabaseFilterFields[] = ["name"]
+): boolean {
+  keyword = keyword.trim().toLowerCase();
+  if (!keyword) {
+    // Skip the filter
+    return true;
+  }
+
+  if (columns.includes("name") && db.name.toLowerCase().includes(keyword)) {
+    return true;
+  }
+
+  if (
+    columns.includes("project") &&
+    db.project.name.toLowerCase().includes(keyword)
+  ) {
+    return true;
+  }
+
+  if (
+    columns.includes("instance") &&
+    db.instance.name.toLowerCase().includes(keyword)
+  ) {
+    return true;
+  }
+
+  if (
+    columns.includes("environment") &&
+    db.instance.environment.name.toLowerCase().includes(keyword)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 export function isPITRDatabase(db: Database): boolean {
   const { name } = db;
   // A pitr database's name is xxx_pitr_1234567890 or xxx_pitr_1234567890_del


### PR DESCRIPTION
Close BYT-1973, BYT-1972

### Features

- Transferring databases into the default project now supports filtering.
- Filtering databases while transferring databases now also supports project, instance, and environment names.

### Screenshots

<img width="871" alt="image" src="https://user-images.githubusercontent.com/2749742/206674887-d8bb6829-55b2-401e-9ce6-3f61857c3c91.png">
