### PR TITLE
fix: show correct instance type

### DIFF
--- a/frontend/src/components/CreateDataSourceExample.vue
+++ b/frontend/src/components/CreateDataSourceExample.vue
@@ -116,7 +116,7 @@
 import { reactive, PropType } from "vue";
 import { toClipboard } from "@soerenmartius/vue3-clipboard";
 import { useI18n } from "vue-i18n";
-import { DataSourceType, EngineType } from "../types";
+import { DataSourceType, EngineType, engineName } from "../types";
 import { pushNotification } from "@/store";
 
 interface LocalState {
@@ -195,7 +195,9 @@ const copyGrantStatement = () => {
       pushNotification({
         module: "bytebase",
         style: "INFO",
-        title: t("instance.copy-grant-statement"),
+        title: t("instance.copy-grant-statement", {
+          engine: engineName(props.engineType),
+        }),
       });
     }
   );

--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -293,6 +293,7 @@ import {
   ConnectionInfo,
   SQLResultSet,
   EngineType,
+  engineName,
 } from "../types";
 import isEmpty from "lodash-es/isEmpty";
 import { useI18n } from "vue-i18n";
@@ -428,23 +429,6 @@ watch(showSSL, (ssl) => {
     state.instance.sslCert = "";
   }
 });
-
-const engineName = (type: EngineType): string => {
-  switch (type) {
-    case "CLICKHOUSE":
-      return "ClickHouse";
-    case "MYSQL":
-      return "MySQL";
-    case "POSTGRES":
-      return "PostgreSQL";
-    case "SNOWFLAKE":
-      return "Snowflake";
-    case "TIDB":
-      return "TiDB";
-    case "MONGODB":
-      return "MongoDB";
-  }
-};
 
 // The default host name is 127.0.0.1 or host.docker.internal which is not applicable to Snowflake, so we change
 // the host name between 127.0.0.1/host.docker.internal and "" if user hasn't changed default yet.

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -720,7 +720,7 @@
     "unable-to-connect": "Bytebase is unable to connect the instance. We recommend you to review the connection info again. But it's OK to ignore this warning for now. You can still fix the connection info from the instance detail page after creation.\n\nError detail: {0}",
     "successfully-created-instance-createdinstance-name": "Successfully created instance '{0}'.",
     "successfully-updated-instance-instance-name": "Successfully updated instance '{0}'.",
-    "copy-grant-statement": "CREATE USER and GRANT statements copied to clipboard. Paste to your mysql client to apply.",
+    "copy-grant-statement": "CREATE USER and GRANT statements copied to clipboard. Paste to your {engine} client to apply.",
     "successfully-connected-instance": "Successfully connected instance.",
     "failed-to-connect-instance": "Failed to connect instance.",
     "failed-to-connect-instance-localhost": "Failed to connect instance.\nIf you run Bytebase with Docker, please try \"host.docker.internal\" for the host address.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -720,7 +720,7 @@
     "unable-to-connect": "Bytebase 无法连接到实例。我们推荐您再检查一遍连接信息。但也可以暂时忽略此警告。您在创建后仍能在实例详细页里修复连接信息。\n\n错误详情:{0}",
     "successfully-created-instance-createdinstance-name": "成功创建实例'{0}'。",
     "successfully-updated-instance-instance-name": "成功更新实例'{0}'。",
-    "copy-grant-statement": "CREATE USER and GRANT 语句已复制到剪贴板。 粘贴到您的 mysql 客户端。",
+    "copy-grant-statement": "CREATE USER and GRANT 语句已复制到剪贴板。 粘贴到您的 {engine} 客户端。",
     "successfully-connected-instance": "成功连接到实例。",
     "failed-to-connect-instance": "连接到实例失败。",
     "failed-to-connect-instance-localhost": "连接到实例失败。\n如果您使用的 Docker 部署，请尝试使用 \"host.docker.internal\" 作为 Host 地址。",

--- a/frontend/src/types/instance.ts
+++ b/frontend/src/types/instance.ts
@@ -28,6 +28,23 @@ export function defaultCharset(type: EngineType): string {
   }
 }
 
+export function engineName(type: EngineType): string {
+  switch (type) {
+    case "CLICKHOUSE":
+      return "ClickHouse";
+    case "MYSQL":
+      return "MySQL";
+    case "POSTGRES":
+      return "PostgreSQL";
+    case "SNOWFLAKE":
+      return "Snowflake";
+    case "TIDB":
+      return "TiDB";
+    case "MONGODB":
+      return "MongoDB";
+  }
+}
+
 export function defaultCollation(type: EngineType): string {
   switch (type) {
     case "CLICKHOUSE":


### PR DESCRIPTION
We should show the correct instance type in the hint message when user click the copy button of the connection info block.
![CleanShot 2022-12-11 at 23 56 13@2x](https://user-images.githubusercontent.com/87714218/206914069-1edf4bb6-f684-45f0-b599-04d24ee05968.png)
