### PR TITLE
fix: skip scheduling in task creation

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -388,18 +388,13 @@ func (s *Server) createIssue(ctx context.Context, issueCreate *api.IssueCreate) 
 			IssueID:      issue.ID,
 			SubscriberID: subscriberID,
 		}
-		_, err := s.store.CreateIssueSubscriber(ctx, subscriberCreate)
-		if err != nil {
+		if _, err := s.store.CreateIssueSubscriber(ctx, subscriberCreate); err != nil {
 			return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to add subscriber %d after creating issue %d", subscriberID, issue.ID)).SetInternal(err)
 		}
 	}
 
 	if err := s.TaskCheckScheduler.SchedulePipelineTaskCheck(ctx, issue.Pipeline); err != nil {
 		return nil, errors.Wrapf(err, "failed to schedule task check after creating the issue: %v", issue.Name)
-	}
-
-	if err := s.TaskScheduler.ScheduleActiveStage(ctx, issue.Pipeline); err != nil {
-		return nil, errors.Wrapf(err, "failed to schedule task after creating the issue: %v", issue.Name)
 	}
 
 	createActivityPayload := api.ActivityIssueCreatePayload{


### PR DESCRIPTION
Since almost all tasks have task checks, the canAutoApprove() should never be true. Right now, there is a bug that we call schedule before we create the task check events so that we are approving the tasks before task checks are passed.

[1]
https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/server/runner/taskrun/scheduler.go?L900&subtree=true