### PR TITLE
feat(frontend): put database list into an independent tab in project detail page

### DIFF
--- a/frontend/src/components/ProjectDatabasesPanel.vue
+++ b/frontend/src/components/ProjectDatabasesPanel.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="space-y-2">
+    <div
+      class="text-lg font-medium leading-7 text-main flex items-center justify-between"
+    >
+      {{ $t("common.database") }}
+    </div>
+
+    <template v-if="filteredDatabaseList.length > 0">
+      <DatabaseTable mode="PROJECT" :database-list="filteredDatabaseList" />
+    </template>
+    <div v-else class="text-center textinfolabel">
+      <i18n-t keypath="project.overview.no-db-prompt" tag="p">
+        <template #newDb>
+          <span class="text-main">{{ $t("quick-action.new-db") }}</span>
+        </template>
+        <template #transferInDb>
+          <span class="text-main">{{ $t("quick-action.transfer-in-db") }}</span>
+        </template>
+      </i18n-t>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { reactive, PropType, computed } from "vue";
+
+import type { Database, Project } from "../types";
+import { filterDatabaseByKeyword } from "@/utils";
+import DatabaseTable from "../components/DatabaseTable.vue";
+
+interface LocalState {
+  keyword: string;
+}
+
+const props = defineProps({
+  project: {
+    required: true,
+    type: Object as PropType<Project>,
+  },
+  databaseList: {
+    required: true,
+    type: Object as PropType<Database[]>,
+  },
+});
+
+const state = reactive<LocalState>({
+  keyword: "",
+});
+
+const filteredDatabaseList = computed(() => {
+  return props.databaseList.filter((db) => {
+    return filterDatabaseByKeyword(db, state.keyword, [
+      "name",
+      "environment",
+      "instance",
+    ]);
+  });
+});
+</script>

--- a/frontend/src/components/ProjectDeploymentConfigPanel.vue
+++ b/frontend/src/components/ProjectDeploymentConfigPanel.vue
@@ -1,5 +1,18 @@
 <template>
   <div class="max-w-[60rem] mx-auto">
+    <div v-if="state.deployment" class="mb-6">
+      <div class="text-lg font-medium leading-7 text-main">
+        {{ $t("deployment-config.preview-deployment-pipeline") }}
+      </div>
+      <DeploymentMatrix
+        class="w-full mt-4 !px-0 overflow-x-auto"
+        :project="project"
+        :deployment="state.deployment"
+        :database-list="databaseList"
+        :environment-list="environmentList"
+      />
+    </div>
+
     <div class="text-lg font-medium leading-7 text-main">
       {{ $t("project.db-name-template") }}
     </div>
@@ -107,19 +120,6 @@
             </span>
           </NPopover>
         </div>
-      </div>
-
-      <div class="mt-6">
-        <div class="text-lg font-medium leading-7 text-main border-t pt-4">
-          {{ $t("deployment-config.preview-deployment-pipeline") }}
-        </div>
-        <DeploymentMatrix
-          class="w-full mt-4 !px-0 overflow-x-auto"
-          :project="project"
-          :deployment="state.deployment"
-          :database-list="databaseList"
-          :environment-list="environmentList"
-        />
       </div>
     </div>
 

--- a/frontend/src/components/ProjectOverviewPanel.vue
+++ b/frontend/src/components/ProjectOverviewPanel.vue
@@ -25,70 +25,6 @@
     </div>
 
     <div class="space-y-2">
-      <div
-        class="text-lg font-medium leading-7 text-main flex items-center justify-between"
-      >
-        {{ $t("common.database") }}
-        <div v-if="isTenantProject">
-          <label for="search" class="sr-only">Search</label>
-          <div class="relative rounded-md shadow-sm">
-            <div
-              class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
-              aria-hidden="true"
-            >
-              <heroicons-solid:search class="mr-3 h-4 w-4 text-control" />
-            </div>
-            <input
-              v-model="state.databaseNameFilter"
-              type="text"
-              autocomplete="off"
-              name="search"
-              class="focus:ring-main focus:border-main block w-full pl-9 sm:text-sm border-control-border rounded-md"
-              :placeholder="$t('database.search-database-name')"
-            />
-          </div>
-        </div>
-      </div>
-
-      <YAxisRadioGroup
-        v-if="isTenantProject && state.yAxisLabel"
-        v-model:label="state.yAxisLabel"
-        :excluded-key-list="excludedKeyList"
-        class="text-sm font-normal py-1"
-      />
-
-      <template v-if="databaseList.length > 0">
-        <template v-if="isTenantProject">
-          <TenantDatabaseTable
-            v-if="state.yAxisLabel"
-            :database-list="filteredDatabaseList"
-            :project="project"
-            :x-axis-label="state.xAxisLabel"
-            :y-axis-label="state.yAxisLabel"
-          />
-          <div v-else class="w-full h-40 flex justify-center items-center">
-            <NSpin />
-          </div>
-        </template>
-        <DatabaseTable v-else :mode="'PROJECT'" :database-list="databaseList" />
-      </template>
-      <div v-else class="text-center textinfolabel">
-        <i18n-t keypath="project.overview.no-db-prompt" tag="p">
-          <template #newDb>
-            <span class="text-main">{{
-              $t("quick-action.new-db")
-            }}</span></template
-          >
-          <template #transferInDb>
-            <span class="text-main">{{
-              $t("quick-action.transfer-in-db")
-            }}</span></template
-          >
-        </i18n-t>
-      </div>
-    </div>
-
-    <div class="space-y-2">
       <p class="text-lg font-medium leading-7 text-main">
         {{ $t("common.issue") }}
       </p>
@@ -157,17 +93,11 @@ import {
   defineComponent,
   watch,
 } from "vue";
-import { NSpin } from "naive-ui";
 import ActivityTable from "../components/ActivityTable.vue";
-import DatabaseTable from "../components/DatabaseTable.vue";
-import TenantDatabaseTable, { YAxisRadioGroup } from "./TenantDatabaseTable";
 import { IssueTable } from "../components/Issue";
 import { Activity, Database, Issue, Project, LabelKeyType } from "../types";
 import { findDefaultGroupByLabel } from "../utils";
-import {
-  useActivityStore,
-  usePolicyListByResourceTypeAndPolicyType,
-} from "@/store";
+import { useActivityStore } from "@/store";
 import PagedIssueTable from "@/components/Issue/PagedIssueTable.vue";
 
 // Show at most 5 activity
@@ -187,11 +117,7 @@ export default defineComponent({
   name: "ProjectOverviewPanel",
   components: {
     ActivityTable,
-    DatabaseTable,
-    TenantDatabaseTable,
     IssueTable,
-    YAxisRadioGroup,
-    NSpin,
     PagedIssueTable,
   },
   props: {
@@ -215,10 +141,6 @@ export default defineComponent({
       yAxisLabel: undefined,
     });
     const activityStore = useActivityStore();
-    const accessControlPolicyList = usePolicyListByResourceTypeAndPolicyType({
-      resourceType: "database",
-      policyType: "bb.policy.access-control",
-    });
 
     const prepareActivityList = () => {
       state.isFetchingActivityList = true;
@@ -276,7 +198,6 @@ export default defineComponent({
       isTenantProject,
       filteredDatabaseList,
       excludedKeyList,
-      accessControlPolicyList,
     };
   },
 });

--- a/frontend/src/layouts/ProjectLayout.vue
+++ b/frontend/src/layouts/ProjectLayout.vue
@@ -99,6 +99,7 @@ export default defineComponent({
     const projectTabItemList = computed((): ProjectTabItem[] => {
       const list: (ProjectTabItem | null)[] = [
         { name: t("common.overview"), hash: "overview" },
+        { name: t("common.databases"), hash: "databases" },
 
         isTenantProject.value
           ? null // Hide "Migration History" tab for tenant projects
@@ -107,14 +108,6 @@ export default defineComponent({
         { name: t("common.activities"), hash: "activity" },
         { name: t("common.version-control"), hash: "version-control" },
         { name: t("common.webhooks"), hash: "webhook" },
-
-        isTenantProject.value
-          ? {
-              name: t("common.deployment-config"),
-              hash: "deployment-config",
-            }
-          : null, // Show "Deployment Config" only for tenant projects
-
         { name: t("common.settings"), hash: "setting" },
       ];
       const filteredList = list.filter(

--- a/frontend/src/views/ProjectDetail.vue
+++ b/frontend/src/views/ProjectDetail.vue
@@ -6,6 +6,19 @@
       :database-list="databaseList"
     />
   </template>
+  <template v-else-if="hash === 'databases'">
+    <ProjectDeploymentConfigPanel
+      v-if="isTenantProject"
+      id="deployment-config"
+      :project="project"
+      :allow-edit="allowEdit"
+    />
+    <ProjectDatabasesPanel
+      v-else
+      :project="project"
+      :database-list="databaseList"
+    />
+  </template>
   <template v-if="hash === 'migration-history'">
     <ProjectMigrationHistoryPanel
       id="migration-history"
@@ -37,13 +50,6 @@
       :allow-edit="allowEdit"
     />
   </template>
-  <template v-else-if="hash === 'deployment-config'">
-    <ProjectDeploymentConfigPanel
-      id="deployment-config"
-      :project="project"
-      :allow-edit="allowEdit"
-    />
-  </template>
 </template>
 
 <script lang="ts">
@@ -52,6 +58,7 @@ import { idFromSlug, sortDatabaseList } from "../utils";
 import ProjectActivityPanel from "../components/ProjectActivityPanel.vue";
 import ProjectMigrationHistoryPanel from "../components/ProjectMigrationHistoryPanel.vue";
 import ProjectOverviewPanel from "../components/ProjectOverviewPanel.vue";
+import ProjectDatabasesPanel from "../components/ProjectDatabasesPanel.vue";
 import ProjectVersionControlPanel from "../components/ProjectVersionControlPanel.vue";
 import ProjectWebhookPanel from "../components/ProjectWebhookPanel.vue";
 import ProjectSettingPanel from "../components/ProjectSettingPanel.vue";
@@ -70,6 +77,7 @@ export default defineComponent({
     ProjectWebhookPanel,
     ProjectSettingPanel,
     ProjectDeploymentConfigPanel,
+    ProjectDatabasesPanel,
   },
   props: {
     projectWebhookSlug: {
@@ -111,10 +119,15 @@ export default defineComponent({
       return sortDatabaseList(list, environmentList.value);
     });
 
+    const isTenantProject = computed(() => {
+      return project.value.tenantMode === "TENANT";
+    });
+
     return {
       hash,
       project,
       databaseList,
+      isTenantProject,
     };
   },
 });


### PR DESCRIPTION
Close BYT-1892

### Features
- Remove databases on the tab "Overview"
- Add a new tab "Databases" after "Overview"
  - Standard projects: list all databases on the tab "Databases", and support searching by database name, env name
  - Tenant projects: rename the tab "Deployment config" as "Databases", and move the database info from the bottom to the top

### Screenshots
- 
![localhost_3000_404(1600_900) (5)](https://user-images.githubusercontent.com/2749742/206945127-5fbb4ad8-7b61-449f-a744-e305dca1e189.png)

-
![localhost_3000_project_trash-103(1600_900)](https://user-images.githubusercontent.com/2749742/206945142-4e4c37d4-5806-4324-9fa6-e822ea3a1300.png)

-
![localhost_3000_404(1600_900) (6)](https://user-images.githubusercontent.com/2749742/206945151-13e03f81-8c30-44f1-97c2-45c65299ee61.png)


