### PR TITLE
feat: return validation message list for `DatabaseEdit`

### DIFF
--- a/api/database.go
+++ b/api/database.go
@@ -197,3 +197,31 @@ type ChangeColumnContext struct {
 type DropColumnContext struct {
 	Name string `json:"name"`
 }
+
+// ValidateResultType is the type of a validate result.
+type ValidateResultType string
+
+const (
+	// ValidateErrorResult is the validate result type for ERROR validation.
+	ValidateErrorResult ValidateResultType = "ERROR"
+)
+
+// ValidateResult is a validation result type, including validation type and message.
+type ValidateResult struct {
+	Type    ValidateResultType `json:"type"`
+	Message string             `json:"message"`
+}
+
+func (result *ValidateResult) String() string {
+	str, err := json.Marshal(*result)
+	if err != nil {
+		return err.Error()
+	}
+	return string(str)
+}
+
+// DatabaseEditResult is the response api message for editing database.
+type DatabaseEditResult struct {
+	Statement          string            `jsonapi:"attr,statement"`
+	ValidateResultList []*ValidateResult `jsonapi:"attr,validateResultList"`
+}

--- a/frontend/src/components/UIEditor/Panels/DatabaseEditor.vue
+++ b/frontend/src/components/UIEditor/Panels/DatabaseEditor.vue
@@ -159,6 +159,7 @@ import { useI18n } from "vue-i18n";
 import {
   generateUniqueTabId,
   useDatabaseStore,
+  useNotificationStore,
   useUIEditorStore,
 } from "@/store";
 import { DatabaseId, DatabaseTabContext, UIEditorTabType } from "@/types";
@@ -183,6 +184,7 @@ interface LocalState {
 const { t } = useI18n();
 const editorStore = useUIEditorStore();
 const databaseStore = useDatabaseStore();
+const notificationStore = useNotificationStore();
 const state = reactive<LocalState>({
   selectedTab: "table-list",
   isFetchingDDL: false,
@@ -247,12 +249,20 @@ watch(
           databaseId: database.id,
           ...diffTableListResult,
         };
-        try {
-          const statement = await editorStore.postDatabaseEdit(databaseEdit);
-          state.statement = statement;
-        } catch (error) {
+        const databaseEditResult = await editorStore.postDatabaseEdit(
+          databaseEdit
+        );
+        if (databaseEditResult.validateResultList.length > 0) {
+          notificationStore.pushNotification({
+            module: "bytebase",
+            style: "CRITICAL",
+            title: "Invalid request",
+            description: JSON.stringify(databaseEditResult.validateResultList),
+          });
           state.statement = "";
+          return;
         }
+        state.statement = databaseEditResult.statement;
       }
       state.isFetchingDDL = false;
     }

--- a/frontend/src/store/modules/UIEditor.ts
+++ b/frontend/src/store/modules/UIEditor.ts
@@ -9,8 +9,9 @@ import {
   UIEditorTabType,
   TableTabContext,
   DatabaseEdit,
+  ResourceObject,
 } from "@/types";
-import { Table } from "@/types/UIEditor";
+import { DatabaseEditResult, Table } from "@/types/UIEditor";
 import { useDatabaseStore, useTableStore } from "./";
 import { transformTableDataToTable } from "@/utils/UIEditor/transform";
 
@@ -29,6 +30,14 @@ const getDefaultUIEditorState = (): UIEditorState => {
     tableList: [],
   };
 };
+
+function convertDatabaseEditResult(
+  databaseEditResult: ResourceObject
+): DatabaseEditResult {
+  return {
+    ...databaseEditResult.attributes,
+  } as any as DatabaseEditResult;
+}
 
 export const useUIEditorStore = defineStore("UIEditor", {
   state: (): UIEditorState => {
@@ -194,13 +203,14 @@ export const useUIEditorStore = defineStore("UIEditor", {
       delete table.status;
     },
     async postDatabaseEdit(databaseEdit: DatabaseEdit) {
-      const stmt = (
-        await axios.post<string>(
+      const resData = (
+        await axios.post(
           `/api/database/${databaseEdit.databaseId}/edit`,
           databaseEdit
         )
       ).data;
-      return stmt;
+      const databaseEditResult = convertDatabaseEditResult(resData.data);
+      return databaseEditResult;
     },
   },
 });

--- a/frontend/src/types/UIEditor.ts
+++ b/frontend/src/types/UIEditor.ts
@@ -134,3 +134,16 @@ export interface ChangeColumnContext {
 export interface DropColumnContext {
   name: string;
 }
+
+/**
+ * Type definition for DatabaseEdit validation API message.
+ */
+export interface ValidateResult {
+  type: string;
+  message: string;
+}
+
+export interface DatabaseEditResult {
+  statement: string;
+  validateResultList: ValidateResult[];
+}

--- a/frontend/src/utils/UIEditor/validate.ts
+++ b/frontend/src/utils/UIEditor/validate.ts
@@ -1,30 +1,18 @@
-import { DatabaseEdit } from "@/types";
-
-interface ValidateResult {
-  isValid: boolean;
-  messageList: {
-    message: string;
-    level: "warning" | "error";
-  }[];
-}
+import { DatabaseEdit, ValidateResult } from "@/types";
 
 export const validateDatabaseEdit = (
   databaseEdit: DatabaseEdit
-): ValidateResult => {
-  const validateResult: ValidateResult = {
-    isValid: true,
-    messageList: [],
-  };
+): ValidateResult[] => {
+  const validateResultList: ValidateResult[] = [];
 
   for (const createTableContext of databaseEdit.createTableList) {
     if (createTableContext.addColumnList.length === 0) {
-      validateResult.isValid = false;
-      validateResult.messageList.push({
+      validateResultList.push({
+        type: "ERROR",
         message: `Table ${createTableContext.name} should has at least one column.`,
-        level: "error",
       });
     }
   }
 
-  return validateResult;
+  return validateResultList;
 };

--- a/plugin/parser/edit/edit.go
+++ b/plugin/parser/edit/edit.go
@@ -13,7 +13,7 @@ import (
 // SchemaEditor is the interface for schema editor.
 type SchemaEditor interface {
 	DeparseDatabaseEdit(databaseEdit *api.DatabaseEdit) (string, error)
-	ValidateDatabaseEdit(databaseEdit *api.DatabaseEdit) error
+	ValidateDatabaseEdit(databaseEdit *api.DatabaseEdit) ([]*api.ValidateResult, error)
 }
 
 var (
@@ -48,12 +48,12 @@ func DeparseDatabaseEdit(engineType parser.EngineType, databaseEdit *api.Databas
 }
 
 // ValidateDatabaseEdit validates the api message DatabaseEdit, including related column type.
-func ValidateDatabaseEdit(engineType parser.EngineType, databaseEdit *api.DatabaseEdit) error {
+func ValidateDatabaseEdit(engineType parser.EngineType, databaseEdit *api.DatabaseEdit) ([]*api.ValidateResult, error) {
 	editorMu.RLock()
 	se, ok := editors[engineType]
 	editorMu.RUnlock()
 	if !ok {
-		return errors.Errorf("engine: unknown engine type %v", engineType)
+		return nil, errors.Errorf("engine: unknown engine type %v", engineType)
 	}
 	return se.ValidateDatabaseEdit(databaseEdit)
 }

--- a/plugin/parser/edit/mysql/validate.go
+++ b/plugin/parser/edit/mysql/validate.go
@@ -2,20 +2,17 @@ package mysql
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/api"
 )
 
 // ValidateDatabaseEdit validates the api message DatabaseEdit, including related column type.
-// TODO(steven): return a validation result struct list instead of string.
-func (*SchemaEditor) ValidateDatabaseEdit(databaseEdit *api.DatabaseEdit) error {
-	var invalidMessageList []string
-	var addColumnContextList []*api.AddColumnContext
-	var changeColumnContextList []*api.ChangeColumnContext
+func (*SchemaEditor) ValidateDatabaseEdit(databaseEdit *api.DatabaseEdit) ([]*api.ValidateResult, error) {
+	validateResultList := []*api.ValidateResult{}
+	addColumnContextList := []*api.AddColumnContext{}
+	changeColumnContextList := []*api.ChangeColumnContext{}
 
 	for _, createTableContext := range databaseEdit.CreateTableList {
 		addColumnContextList = append(addColumnContextList, createTableContext.AddColumnList...)
@@ -28,12 +25,18 @@ func (*SchemaEditor) ValidateDatabaseEdit(databaseEdit *api.DatabaseEdit) error 
 	for _, addColumnContext := range addColumnContextList {
 		columnType, err := transformColumnType(addColumnContext.Type)
 		if err != nil {
-			invalidMessageList = append(invalidMessageList, fmt.Sprintf("invalid column type `%s`", addColumnContext.Type))
+			validateResultList = append(validateResultList, &api.ValidateResult{
+				Type:    api.ValidateErrorResult,
+				Message: fmt.Sprintf("invalid column type `%s`", addColumnContext.Type),
+			})
 		}
 		if addColumnContext.Default != nil {
 			// TEXT will be regarded as mysql.TypeBlob in the TiDB parser.
 			if columnType.GetType() == mysql.TypeBlob || columnType.GetType() == mysql.TypeGeometry || columnType.GetType() == mysql.TypeJSON {
-				invalidMessageList = append(invalidMessageList, fmt.Sprintf("column type `%s` cannot have a default value", addColumnContext.Type))
+				validateResultList = append(validateResultList, &api.ValidateResult{
+					Type:    api.ValidateErrorResult,
+					Message: fmt.Sprintf("column type `%s` cannot have a default value", addColumnContext.Type),
+				})
 			}
 		}
 	}
@@ -41,17 +44,20 @@ func (*SchemaEditor) ValidateDatabaseEdit(databaseEdit *api.DatabaseEdit) error 
 	for _, changeColumnContext := range changeColumnContextList {
 		columnType, err := transformColumnType(changeColumnContext.Type)
 		if err != nil {
-			invalidMessageList = append(invalidMessageList, fmt.Sprintf("invalid column type `%s`", changeColumnContext.Type))
+			validateResultList = append(validateResultList, &api.ValidateResult{
+				Type:    api.ValidateErrorResult,
+				Message: fmt.Sprintf("invalid column type `%s`", changeColumnContext.Type),
+			})
 		}
 		if changeColumnContext.Default != nil {
 			if columnType.GetType() == mysql.TypeBlob || columnType.GetType() == mysql.TypeGeometry || columnType.GetType() == mysql.TypeJSON {
-				invalidMessageList = append(invalidMessageList, fmt.Sprintf("column type `%s` cannot have a default value", changeColumnContext.Type))
+				validateResultList = append(validateResultList, &api.ValidateResult{
+					Type:    api.ValidateErrorResult,
+					Message: fmt.Sprintf("column type `%s` cannot have a default value", changeColumnContext.Type),
+				})
 			}
 		}
 	}
 
-	if len(invalidMessageList) != 0 {
-		return errors.New(strings.Join(invalidMessageList, "\n"))
-	}
-	return nil
+	return validateResultList, nil
 }

--- a/plugin/parser/edit/mysql/validate_test.go
+++ b/plugin/parser/edit/mysql/validate_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestValidateDatabaseEditColumnType(t *testing.T) {
 	tests := []struct {
-		databaseEdit *api.DatabaseEdit
-		errorMessage string
+		databaseEdit       *api.DatabaseEdit
+		validateResultList []*api.ValidateResult
 	}{
 		{
 			databaseEdit: &api.DatabaseEdit{
@@ -29,7 +29,7 @@ func TestValidateDatabaseEditColumnType(t *testing.T) {
 					},
 				},
 			},
-			errorMessage: "",
+			validateResultList: []*api.ValidateResult{},
 		},
 		{
 			databaseEdit: &api.DatabaseEdit{
@@ -47,45 +47,29 @@ func TestValidateDatabaseEditColumnType(t *testing.T) {
 					},
 				},
 			},
-			errorMessage: "invalid column type `int123`",
+			validateResultList: []*api.ValidateResult{
+				{
+					Type:    api.ValidateErrorResult,
+					Message: "invalid column type `int123`",
+				},
+			},
 		},
 	}
 
 	mysqlEditor := &SchemaEditor{}
 	for _, test := range tests {
-		err := mysqlEditor.ValidateDatabaseEdit(test.databaseEdit)
-		if err != nil {
-			assert.Equal(t, test.errorMessage, err.Error())
-		} else {
-			assert.Equal(t, test.errorMessage, "")
-		}
+		validateResultList, err := mysqlEditor.ValidateDatabaseEdit(test.databaseEdit)
+		assert.NoError(t, err)
+		assert.Equal(t, test.validateResultList, validateResultList)
 	}
 }
 
 func TestValidateDatabaseEditColumnTypeAndDefault(t *testing.T) {
-	defaultValue := "123"
+	defaultValue := "default_value"
 	tests := []struct {
-		databaseEdit *api.DatabaseEdit
-		errorMessage string
+		databaseEdit       *api.DatabaseEdit
+		validateResultList []*api.ValidateResult
 	}{
-		{
-			databaseEdit: &api.DatabaseEdit{
-				DatabaseID: api.UnknownID,
-				CreateTableList: []*api.CreateTableContext{
-					{
-						Name: "t1",
-						Type: "BASE TABLE",
-						AddColumnList: []*api.AddColumnContext{
-							{
-								Name: "id",
-								Type: "TEXT",
-							},
-						},
-					},
-				},
-			},
-			errorMessage: "",
-		},
 		{
 			databaseEdit: &api.DatabaseEdit{
 				DatabaseID: api.UnknownID,
@@ -103,7 +87,7 @@ func TestValidateDatabaseEditColumnTypeAndDefault(t *testing.T) {
 					},
 				},
 			},
-			errorMessage: "",
+			validateResultList: []*api.ValidateResult{},
 		},
 		{
 			databaseEdit: &api.DatabaseEdit{
@@ -122,17 +106,19 @@ func TestValidateDatabaseEditColumnTypeAndDefault(t *testing.T) {
 					},
 				},
 			},
-			errorMessage: "column type `TEXT` cannot have a default value",
+			validateResultList: []*api.ValidateResult{
+				{
+					Type:    api.ValidateErrorResult,
+					Message: "column type `TEXT` cannot have a default value",
+				},
+			},
 		},
 	}
 
 	mysqlEditor := &SchemaEditor{}
 	for _, test := range tests {
-		err := mysqlEditor.ValidateDatabaseEdit(test.databaseEdit)
-		if err != nil {
-			assert.Equal(t, test.errorMessage, err.Error())
-		} else {
-			assert.Equal(t, test.errorMessage, "")
-		}
+		validateResultList, err := mysqlEditor.ValidateDatabaseEdit(test.databaseEdit)
+		assert.NoError(t, err)
+		assert.Equal(t, test.validateResultList, validateResultList)
 	}
 }


### PR DESCRIPTION
Return a list of validation results instead of string for `DatabaseEdit`.

Prev PR: https://github.com/bytebase/bytebase/pull/3778