### PR TITLE
feat(differ): support to add enum labels if possible

### DIFF
--- a/plugin/parser/ast/add_enum_label_stmt.go
+++ b/plugin/parser/ast/add_enum_label_stmt.go
@@ -1,19 +1,19 @@
 package ast
 
-// PositionType is the type of new value position.
+// PositionType is the type of new label position.
 type PositionType int
 
 const (
-	// PositionTypeEnd is the type of new value at the end of the list values. It's default value.
+	// PositionTypeEnd is the type of new label at the end of the list labels. It's default label.
 	PositionTypeEnd PositionType = iota
-	// PositionTypeAfter is the type of after neighbor value.
+	// PositionTypeAfter is the type of after neighbor label.
 	PositionTypeAfter
-	// PositionTypeBefore is the type of before neighbor value.
+	// PositionTypeBefore is the type of before neighbor label.
 	PositionTypeBefore
 )
 
-// AddEnumValueStmt is the struct of add enum value statements.
-type AddEnumValueStmt struct {
+// AddEnumLabelStmt is the struct of add enum label statements.
+type AddEnumLabelStmt struct {
 	node
 
 	EnumType      *TypeNameDef

--- a/plugin/parser/ast/add_enum_label_stmt.go
+++ b/plugin/parser/ast/add_enum_label_stmt.go
@@ -1,0 +1,23 @@
+package ast
+
+// PositionType is the type of new value position.
+type PositionType int
+
+const (
+	// PositionTypeEnd is the type of new value at the end of the list values. It's default value.
+	PositionTypeEnd PositionType = iota
+	// PositionTypeAfter is the type of after neighbor value.
+	PositionTypeAfter
+	// PositionTypeBefore is the type of before neighbor value.
+	PositionTypeBefore
+)
+
+// AddEnumValueStmt is the struct of add enum value statements.
+type AddEnumValueStmt struct {
+	node
+
+	EnumType      *TypeNameDef
+	NewLabel      string
+	Position      PositionType
+	NeighborLabel string
+}

--- a/plugin/parser/ast/alter_type_stmt.go
+++ b/plugin/parser/ast/alter_type_stmt.go
@@ -1,0 +1,8 @@
+package ast
+
+type AlterTypeStmt struct {
+	ddl
+
+	Type          *TypeNameDef
+	AlterItemList []Node
+}

--- a/plugin/parser/ast/alter_type_stmt.go
+++ b/plugin/parser/ast/alter_type_stmt.go
@@ -1,5 +1,6 @@
 package ast
 
+// AlterTypeStmt is the struct for ALTER TYPE statements.
 type AlterTypeStmt struct {
 	ddl
 

--- a/plugin/parser/differ/pg/differ.go
+++ b/plugin/parser/differ/pg/differ.go
@@ -1031,7 +1031,7 @@ func isSubsequenceEnum(oldType ast.UserDefinedType, newType ast.UserDefinedType)
 	if !ok {
 		return false
 	}
-	newEnum, ok := oldType.(*ast.EnumTypeDef)
+	newEnum, ok := newType.(*ast.EnumTypeDef)
 	if !ok {
 		return false
 	}

--- a/plugin/parser/differ/pg/differ.go
+++ b/plugin/parser/differ/pg/differ.go
@@ -1068,7 +1068,7 @@ func (diff *diffNode) addEnumValue(oldType *ast.CreateTypeStmt, newType *ast.Cre
 		for _, label := range newEnum.LabelList {
 			diff.alterTypeList = append(diff.alterTypeList, &ast.AlterTypeStmt{
 				Type: newType.Type.TypeName(),
-				AlterItemList: []ast.Node{&ast.AddEnumValueStmt{
+				AlterItemList: []ast.Node{&ast.AddEnumLabelStmt{
 					EnumType: newType.Type.TypeName(),
 					NewLabel: label,
 					Position: ast.PositionTypeEnd,
@@ -1090,7 +1090,7 @@ func (diff *diffNode) addEnumValue(oldType *ast.CreateTypeStmt, newType *ast.Cre
 	for i := firstOldLabelPos - 1; i >= 0; i-- {
 		diff.alterTypeList = append(diff.alterTypeList, &ast.AlterTypeStmt{
 			Type: newType.Type.TypeName(),
-			AlterItemList: []ast.Node{&ast.AddEnumValueStmt{
+			AlterItemList: []ast.Node{&ast.AddEnumLabelStmt{
 				EnumType:      newType.Type.TypeName(),
 				NewLabel:      newEnum.LabelList[i],
 				Position:      ast.PositionTypeBefore,
@@ -1109,7 +1109,7 @@ func (diff *diffNode) addEnumValue(oldType *ast.CreateTypeStmt, newType *ast.Cre
 		}
 		diff.alterTypeList = append(diff.alterTypeList, &ast.AlterTypeStmt{
 			Type: newType.Type.TypeName(),
-			AlterItemList: []ast.Node{&ast.AddEnumValueStmt{
+			AlterItemList: []ast.Node{&ast.AddEnumLabelStmt{
 				EnumType:      newType.Type.TypeName(),
 				NewLabel:      newLabel,
 				Position:      ast.PositionTypeAfter,

--- a/plugin/parser/differ/pg/test-data/test_differ_data.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_data.yaml
@@ -326,11 +326,41 @@
     CREATE TYPE public.tp4 AS ENUM ('a', 'b', 'c');
     CREATE TABLE public.t1(a public.tp1, b public.tp3, c public.tp4)
   diff: |
-    DROP TYPE "public"."tp3";
     DROP TYPE "public"."tp2";
-    CREATE TYPE public.tp3 AS ENUM ('a', 'b', 'c', 'd');
     CREATE TYPE public.tp4 AS ENUM ('a', 'b', 'c');
+    ALTER TYPE "public"."tp3" ADD VALUE 'd' AFTER 'c';
     ALTER TABLE "public"."t1"
         ALTER COLUMN "b" SET DATA TYPE public.tp3;
     ALTER TABLE "public"."t1"
         ALTER COLUMN "c" SET DATA TYPE public.tp4;
+- oldSchema: |
+    create type public.enum1 as enum ('a', 'b', 'c');
+    create table public.t1 (a enum1);
+  newSchema: |
+    create type public.enum1 as enum ('1', '2', 'a', '3', '4', 'b', '5', 'c', '6', '7');
+    create table public.t1 (a enum1);
+  diff: |
+    ALTER TYPE "public"."enum1" ADD VALUE '2' BEFORE 'a';
+    ALTER TYPE "public"."enum1" ADD VALUE '1' BEFORE '2';
+    ALTER TYPE "public"."enum1" ADD VALUE '3' AFTER 'a';
+    ALTER TYPE "public"."enum1" ADD VALUE '4' AFTER '3';
+    ALTER TYPE "public"."enum1" ADD VALUE '5' AFTER 'b';
+    ALTER TYPE "public"."enum1" ADD VALUE '6' AFTER 'c';
+    ALTER TYPE "public"."enum1" ADD VALUE '7' AFTER '6';
+- oldSchema: |
+    create type public.enum1 as enum ();
+    create table public.t1 (a enum1);
+  newSchema: |
+    create type public.enum1 as enum ('1', '2', 'a', '3', '4', 'b', '5', 'c', '6', '7');
+    create table public.t1 (a enum1);
+  diff: |
+    ALTER TYPE "public"."enum1" ADD VALUE '1';
+    ALTER TYPE "public"."enum1" ADD VALUE '2';
+    ALTER TYPE "public"."enum1" ADD VALUE 'a';
+    ALTER TYPE "public"."enum1" ADD VALUE '3';
+    ALTER TYPE "public"."enum1" ADD VALUE '4';
+    ALTER TYPE "public"."enum1" ADD VALUE 'b';
+    ALTER TYPE "public"."enum1" ADD VALUE '5';
+    ALTER TYPE "public"."enum1" ADD VALUE 'c';
+    ALTER TYPE "public"."enum1" ADD VALUE '6';
+    ALTER TYPE "public"."enum1" ADD VALUE '7';

--- a/plugin/parser/differ/pg/test-data/test_differ_data.yaml
+++ b/plugin/parser/differ/pg/test-data/test_differ_data.yaml
@@ -318,7 +318,7 @@
 - oldSchema: |
     CREATE TYPE public.tp1 AS ENUM ('a', 'b', 'c');
     CREATE TYPE public.tp2 AS ENUM ('a', 'b', 'c');
-    CREATE TYPE public.tp3 AS ENUM ('a', 'b', 'c');
+    CREATE TYPE public.tp3 AS ENUM ('a', 'b', 'e');
     CREATE TABLE public.t1(a public.tp1, b public.tp2, c public.tp3)
   newSchema: |
     CREATE TYPE public.tp1 AS ENUM ('a', 'b', 'c');
@@ -326,9 +326,10 @@
     CREATE TYPE public.tp4 AS ENUM ('a', 'b', 'c');
     CREATE TABLE public.t1(a public.tp1, b public.tp3, c public.tp4)
   diff: |
+    DROP TYPE "public"."tp3";
     DROP TYPE "public"."tp2";
+    CREATE TYPE public.tp3 AS ENUM ('a', 'b', 'c', 'd');
     CREATE TYPE public.tp4 AS ENUM ('a', 'b', 'c');
-    ALTER TYPE "public"."tp3" ADD VALUE 'd' AFTER 'c';
     ALTER TABLE "public"."t1"
         ALTER COLUMN "b" SET DATA TYPE public.tp3;
     ALTER TABLE "public"."t1"

--- a/plugin/parser/engine/pg/convert.go
+++ b/plugin/parser/engine/pg/convert.go
@@ -728,7 +728,7 @@ func convert(node *pgquery.Node, statement parser.SingleSQL) (res ast.Node, err 
 				Name:   name,
 			}
 			// ADD ENUM VALUE STATEMENT
-			addEnumValueStmt := &ast.AddEnumValueStmt{
+			addEnumValueStmt := &ast.AddEnumLabelStmt{
 				EnumType:      typeName,
 				NewLabel:      in.AlterEnumStmt.NewVal,
 				NeighborLabel: in.AlterEnumStmt.NewValNeighbor,

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -2930,3 +2930,97 @@ func TestDropType(t *testing.T) {
 
 	runTests(t, tests)
 }
+
+func TestAlterType(t *testing.T) {
+	tests := []testData{
+		{
+			stmt: `ALTER TYPE public.bug_status ADD VALUE 'a' BEFORE 'b'`,
+			want: []ast.Node{
+				&ast.AlterTypeStmt{
+					Type: &ast.TypeNameDef{
+						Schema: "public",
+						Name:   "bug_status",
+					},
+					AlterItemList: []ast.Node{
+						&ast.AddEnumValueStmt{
+							EnumType: &ast.TypeNameDef{
+								Schema: "public",
+								Name:   "bug_status",
+							},
+							NewLabel:      "a",
+							Position:      ast.PositionTypeBefore,
+							NeighborLabel: "b",
+						},
+					},
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+
+					Text:     `ALTER TYPE public.bug_status ADD VALUE 'a' BEFORE 'b'`,
+					LastLine: 1,
+				},
+			},
+		},
+		{
+			stmt: `ALTER TYPE public.bug_status ADD VALUE 'a' AFTER 'b'`,
+			want: []ast.Node{
+				&ast.AlterTypeStmt{
+					Type: &ast.TypeNameDef{
+						Schema: "public",
+						Name:   "bug_status",
+					},
+					AlterItemList: []ast.Node{
+						&ast.AddEnumValueStmt{
+							EnumType: &ast.TypeNameDef{
+								Schema: "public",
+								Name:   "bug_status",
+							},
+							NewLabel:      "a",
+							Position:      ast.PositionTypeAfter,
+							NeighborLabel: "b",
+						},
+					},
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+
+					Text:     `ALTER TYPE public.bug_status ADD VALUE 'a' AFTER 'b'`,
+					LastLine: 1,
+				},
+			},
+		},
+		{
+			stmt: `ALTER TYPE public.bug_status ADD VALUE 'a'`,
+			want: []ast.Node{
+				&ast.AlterTypeStmt{
+					Type: &ast.TypeNameDef{
+						Schema: "public",
+						Name:   "bug_status",
+					},
+					AlterItemList: []ast.Node{
+						&ast.AddEnumValueStmt{
+							EnumType: &ast.TypeNameDef{
+								Schema: "public",
+								Name:   "bug_status",
+							},
+							NewLabel:      "a",
+							Position:      ast.PositionTypeEnd,
+							NeighborLabel: "",
+						},
+					},
+				},
+			},
+			statementList: []parser.SingleSQL{
+				{
+
+					Text:     `ALTER TYPE public.bug_status ADD VALUE 'a'`,
+					LastLine: 1,
+				},
+			},
+		},
+	}
+
+	runTests(t, tests)
+}

--- a/plugin/parser/engine/pg/convert_test.go
+++ b/plugin/parser/engine/pg/convert_test.go
@@ -2942,7 +2942,7 @@ func TestAlterType(t *testing.T) {
 						Name:   "bug_status",
 					},
 					AlterItemList: []ast.Node{
-						&ast.AddEnumValueStmt{
+						&ast.AddEnumLabelStmt{
 							EnumType: &ast.TypeNameDef{
 								Schema: "public",
 								Name:   "bug_status",
@@ -2971,7 +2971,7 @@ func TestAlterType(t *testing.T) {
 						Name:   "bug_status",
 					},
 					AlterItemList: []ast.Node{
-						&ast.AddEnumValueStmt{
+						&ast.AddEnumLabelStmt{
 							EnumType: &ast.TypeNameDef{
 								Schema: "public",
 								Name:   "bug_status",
@@ -3000,7 +3000,7 @@ func TestAlterType(t *testing.T) {
 						Name:   "bug_status",
 					},
 					AlterItemList: []ast.Node{
-						&ast.AddEnumValueStmt{
+						&ast.AddEnumLabelStmt{
 							EnumType: &ast.TypeNameDef{
 								Schema: "public",
 								Name:   "bug_status",

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -1206,7 +1206,7 @@ func deparseAlterType(ctx parser.DeparseContext, in *ast.AlterTypeStmt, buf *str
 
 	for _, item := range in.AlterItemList {
 		switch node := item.(type) {
-		case *ast.AddEnumValueStmt:
+		case *ast.AddEnumLabelStmt:
 			// The ADD ENUM VALUE statement use the cannot share the AlterType statement with other alter items.
 			return deparseAddEnumValue(ctx, node, buf)
 		}
@@ -1214,7 +1214,7 @@ func deparseAlterType(ctx parser.DeparseContext, in *ast.AlterTypeStmt, buf *str
 	return nil
 }
 
-func deparseAddEnumValue(ctx parser.DeparseContext, in *ast.AddEnumValueStmt, buf *strings.Builder) error {
+func deparseAddEnumValue(ctx parser.DeparseContext, in *ast.AddEnumLabelStmt, buf *strings.Builder) error {
 	if _, err := buf.WriteString("ADD VALUE "); err != nil {
 		return err
 	}

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -91,6 +91,11 @@ func deparse(context parser.DeparseContext, in ast.Node, buf *strings.Builder) e
 			return err
 		}
 		return buf.WriteByte(';')
+	case *ast.AlterTypeStmt:
+		if err := deparseAlterType(context, node, buf); err != nil {
+			return err
+		}
+		return buf.WriteByte(';')
 	}
 	return errors.Errorf("failed to deparse %T", in)
 }
@@ -1178,6 +1183,57 @@ func deparseFunctionSignature(function *ast.FunctionDef, buf *strings.Builder) e
 		}
 	}
 	return buf.WriteByte(')')
+}
+
+func deparseAlterType(ctx parser.DeparseContext, in *ast.AlterTypeStmt, buf *strings.Builder) error {
+	if _, err := buf.WriteString("ALTER TYPE "); err != nil {
+		return err
+	}
+	if in.Type.Schema != "" {
+		if err := writeSurrounding(buf, in.Type.Schema, `"`); err != nil {
+			return err
+		}
+		if err := buf.WriteByte('.'); err != nil {
+			return err
+		}
+	}
+	if err := writeSurrounding(buf, in.Type.Name, `"`); err != nil {
+		return err
+	}
+	if err := buf.WriteByte(' '); err != nil {
+		return err
+	}
+
+	for _, item := range in.AlterItemList {
+		switch node := item.(type) {
+		case *ast.AddEnumValueStmt:
+			// The ADD ENUM VALUE statement use the cannot share the AlterType statement with other alter items.
+			return deparseAddEnumValue(ctx, node, buf)
+		}
+	}
+	return nil
+}
+
+func deparseAddEnumValue(ctx parser.DeparseContext, in *ast.AddEnumValueStmt, buf *strings.Builder) error {
+	if _, err := buf.WriteString("ADD VALUE "); err != nil {
+		return err
+	}
+	if err := writeSurrounding(buf, in.NewLabel, "'"); err != nil {
+		return err
+	}
+	switch in.Position {
+	case ast.PositionTypeEnd:
+		return nil
+	case ast.PositionTypeBefore:
+		if _, err := buf.WriteString(" BEFORE "); err != nil {
+			return err
+		}
+	case ast.PositionTypeAfter:
+		if _, err := buf.WriteString(" AFTER "); err != nil {
+			return err
+		}
+	}
+	return writeSurrounding(buf, in.NeighborLabel, "'")
 }
 
 func deparseDropType(ctx parser.DeparseContext, in *ast.DropTypeStmt, buf *strings.Builder) error {

--- a/plugin/parser/engine/pg/deparse.go
+++ b/plugin/parser/engine/pg/deparse.go
@@ -1205,8 +1205,7 @@ func deparseAlterType(ctx parser.DeparseContext, in *ast.AlterTypeStmt, buf *str
 	}
 
 	for _, item := range in.AlterItemList {
-		switch node := item.(type) {
-		case *ast.AddEnumLabelStmt:
+		if node, ok := item.(*ast.AddEnumLabelStmt); ok {
 			// The ADD ENUM VALUE statement use the cannot share the AlterType statement with other alter items.
 			return deparseAddEnumValue(ctx, node, buf)
 		}
@@ -1214,7 +1213,7 @@ func deparseAlterType(ctx parser.DeparseContext, in *ast.AlterTypeStmt, buf *str
 	return nil
 }
 
-func deparseAddEnumValue(ctx parser.DeparseContext, in *ast.AddEnumLabelStmt, buf *strings.Builder) error {
+func deparseAddEnumValue(_ parser.DeparseContext, in *ast.AddEnumLabelStmt, buf *strings.Builder) error {
 	if _, err := buf.WriteString("ADD VALUE "); err != nil {
 		return err
 	}

--- a/plugin/parser/engine/pg/test-data/test_type_data.yaml
+++ b/plugin/parser/engine/pg/test-data/test_type_data.yaml
@@ -2,3 +2,9 @@
   want: DROP TYPE IF EXISTS "tp1", "public"."tp2";
 - stmt: drop type tp1 cascade;
   want: DROP TYPE "tp1" CASCADE;
+- stmt: alter type public.t1 add value 'a';
+  want: ALTER TYPE "public"."t1" ADD VALUE 'a';
+- stmt: alter type public.t1 add value 'a' after 'd';
+  want: ALTER TYPE "public"."t1" ADD VALUE 'a' AFTER 'd';
+- stmt: alter type public.t1 add value 'a' before 'x';
+  want: ALTER TYPE "public"."t1" ADD VALUE 'a' BEFORE 'x';


### PR DESCRIPTION
We cannot remove labels from enum types, but we can add enum labels.
In most changing schema scenarios, we always add enum labels, so this PR add this feature for enum labels.

close BYT-2037