### PR TITLE
fix(frontend): improve issue preview load latency

### DIFF
--- a/frontend/src/components/Issue/PipelineGhostFlow.vue
+++ b/frontend/src/components/Issue/PipelineGhostFlow.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watchEffect } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type {
   Pipeline,
@@ -85,22 +85,10 @@ import { useIssueLogic } from "./logic";
 const { t } = useI18n();
 const databaseStore = useDatabaseStore();
 
-const {
-  create,
-  issue,
-  project,
-  selectedStage,
-  selectedTask,
-  selectStageOrTask,
-} = useIssueLogic();
+const { create, issue, selectedStage, selectedTask, selectStageOrTask } =
+  useIssueLogic();
 
 const pipeline = computed(() => issue.value.pipeline!);
-
-watchEffect(() => {
-  if (create.value) {
-    databaseStore.fetchDatabaseListByProjectId(project.value.id);
-  }
-});
 
 const taskList = computed(() => {
   return selectedStage.value.taskList;

--- a/frontend/src/components/Issue/PipelinePITRFlow.vue
+++ b/frontend/src/components/Issue/PipelinePITRFlow.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watchEffect } from "vue";
+import { computed } from "vue";
 import { Pipeline, Stage, StageCreate, Task, TaskCreate } from "@/types";
 import {
   activeTask,
@@ -74,29 +74,14 @@ import {
   bytesToString,
 } from "@/utils";
 import TaskStatusIcon from "./TaskStatusIcon.vue";
-import { useDatabaseStore } from "@/store";
 import PipelineStageList from "./PipelineStageList.vue";
 import TaskMarkAsDoneButton from "./TaskMarkAsDoneButton.vue";
 import { useIssueLogic } from "./logic";
 
-const databaseStore = useDatabaseStore();
-
-const {
-  create,
-  issue,
-  project,
-  selectedStage,
-  selectedTask,
-  selectStageOrTask,
-} = useIssueLogic();
+const { create, issue, selectedStage, selectedTask, selectStageOrTask } =
+  useIssueLogic();
 
 const pipeline = computed(() => issue.value.pipeline!);
-
-watchEffect(() => {
-  if (create.value) {
-    databaseStore.fetchDatabaseListByProjectId(project.value.id);
-  }
-});
 
 const taskList = computed(() => {
   return selectedStage.value.taskList;

--- a/frontend/src/components/Issue/PipelineSimpleFlow.vue
+++ b/frontend/src/components/Issue/PipelineSimpleFlow.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watchEffect } from "vue";
+import { computed, ref } from "vue";
 
 import { useDatabaseStore } from "@/store";
 import {
@@ -207,12 +207,6 @@ const onClickTask = (task: Task | TaskCreate, index: number) => {
 
   selectStageOrTask(stageId, ts);
 };
-
-watchEffect(() => {
-  if (create.value) {
-    databaseStore.fetchDatabaseListByProjectId(project.value.id);
-  }
-});
 </script>
 
 <style scoped lang="postcss">

--- a/frontend/src/components/Issue/PipelineTenantFlow.vue
+++ b/frontend/src/components/Issue/PipelineTenantFlow.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watchEffect } from "vue";
+import { computed, ref } from "vue";
 import type {
   Pipeline,
   Stage,
@@ -70,14 +70,8 @@ import { useDatabaseStore } from "@/store";
 import { useIssueLogic } from "./logic";
 import { useScroll } from "@vueuse/core";
 
-const {
-  create,
-  issue,
-  project,
-  selectedStage,
-  selectedTask,
-  selectStageOrTask,
-} = useIssueLogic();
+const { create, issue, selectedStage, selectedTask, selectStageOrTask } =
+  useIssueLogic();
 
 const pipeline = computed(() => issue.value.pipeline!);
 
@@ -85,12 +79,6 @@ const databaseStore = useDatabaseStore();
 const taskBar = ref<HTMLDivElement>();
 
 const taskBarScrollState = useScroll(taskBar);
-
-watchEffect(() => {
-  if (create.value) {
-    databaseStore.fetchDatabaseListByProjectId(project.value.id);
-  }
-});
 
 const taskList = computed(() => selectedStage.value.taskList);
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1217,8 +1217,9 @@ router.beforeEach((to, from, next) => {
             parseInt(projectId, 10)
           );
         } else {
-          // Otherwise, we don't have the projectId, so we need to fetch the first
-          // database in databaseList by id, and see what project it belongs.
+          // Otherwise, we don't have the projectId (very rare to see, theoretically)
+          // so we need to fetch the first database in databaseList by id,
+          // and see what project it belongs.
           const databaseIdList = (to.query.databaseList as string)
             .split(",")
             .map((str) => parseInt(str, 10));

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1210,7 +1210,6 @@ router.beforeEach((to, from, next) => {
       // is big (100+ sometimes)
       // So we are fetching databaseList by project since that's better cached.
       const prepare = async () => {
-        console.log("prepare");
         if (to.query.project) {
           // If we found query.project, we can directly fetchDatabaseListByProjectId
           const projectId = to.query.project as string;


### PR DESCRIPTION
We optimized the API calls. We use `databases.list(project_id)` instead of `databases.get()` many times. And removed some unnecessary API calls.