### PR TITLE
refactor: add `normal` to `TableOrColumnStatus`

### DIFF
--- a/frontend/src/components/UIEditor/Panels/TableEditor.vue
+++ b/frontend/src/components/UIEditor/Panels/TableEditor.vue
@@ -326,6 +326,7 @@ watch(
 
 watch([table.value], () => {
   state.tableCache.newName = table.value.newName;
+  state.tableCache.status = table.value.status;
 });
 
 watch(
@@ -414,7 +415,7 @@ const handleRestoreColumn = (column: Column) => {
     return;
   }
 
-  delete column.status;
+  column.status = "normal";
 };
 
 const handleDiscardChanges = () => {
@@ -424,12 +425,12 @@ const handleDiscardChanges = () => {
 
   state.tableCache.newName = state.tableCache.oldName;
   state.tableCache.columnList = cloneDeep(state.tableCache.originColumnList);
-  delete state.tableCache.status;
+  state.tableCache.status = "normal";
 
   const table = editorStore.getTableWithTableTab(currentTab) as Table;
   table.newName = table.oldName;
   table.columnList = cloneDeep(table.columnList);
-  delete table.status;
+  table.status = "normal";
 };
 </script>
 

--- a/frontend/src/store/modules/UIEditor.ts
+++ b/frontend/src/store/modules/UIEditor.ts
@@ -87,14 +87,6 @@ export const useUIEditorStore = defineStore("UIEditor", {
         this.setCurrentTab(tab.id);
       }
     },
-    saveTab(tab: TabContext) {
-      if (tab.type === UIEditorTabType.TabForDatabase) {
-        // Edit database metadata is not allowed.
-      } else if (tab.type === UIEditorTabType.TabForTable) {
-        // tab.table.name = tab.tableCache.name;
-        // tab.table.columnList = cloneDeep(tab.tableCache.columnList);
-      }
-    },
     setCurrentTab(tabId: string) {
       if (isUndefined(this.tabState.tabMap.get(tabId))) {
         this.tabState.currentTabId = undefined;
@@ -187,10 +179,10 @@ export const useUIEditorStore = defineStore("UIEditor", {
       );
     },
     dropTable(table: Table) {
-      const index = this.tableList.findIndex((item) => item === table);
+      // Remove table record and close tab for created table.
       if (table.status === "created") {
+        const index = this.tableList.findIndex((item) => item === table);
         this.tableList.splice(index, 1);
-        // Close tab for new table.
         const tab = this.findTab(table.databaseId, table.newName);
         if (tab) {
           this.closeTab(tab.id);
@@ -200,7 +192,7 @@ export const useUIEditorStore = defineStore("UIEditor", {
       }
     },
     restoreTable(table: Table) {
-      delete table.status;
+      table.status = "normal";
     },
     async postDatabaseEdit(databaseEdit: DatabaseEdit) {
       const resData = (

--- a/frontend/src/types/UIEditor.ts
+++ b/frontend/src/types/UIEditor.ts
@@ -1,6 +1,6 @@
 import { Database, DatabaseId, TableEngineType, TableType } from ".";
 
-type TableOrColumnStatus = "created" | "dropped";
+type TableOrColumnStatus = "normal" | "created" | "dropped";
 
 export interface Column {
   // Related fields
@@ -14,7 +14,7 @@ export interface Column {
   comment: string;
   default: string | null;
 
-  status?: TableOrColumnStatus;
+  status: TableOrColumnStatus;
 }
 
 export interface Table {
@@ -33,7 +33,7 @@ export interface Table {
   columnList: Column[];
   originColumnList: Column[];
 
-  status?: TableOrColumnStatus;
+  status: TableOrColumnStatus;
 }
 
 export enum UIEditorTabType {

--- a/frontend/src/utils/UIEditor/diffColumn.test.ts
+++ b/frontend/src/utils/UIEditor/diffColumn.test.ts
@@ -73,6 +73,7 @@ it("diff modify column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
+          status: "normal",
         } as any as Column,
       ],
       columnList: [
@@ -83,6 +84,7 @@ it("diff modify column list", () => {
           comment: "",
           nullable: false,
           default: undefined,
+          status: "normal",
         } as any as Column,
       ],
       wanted: {
@@ -179,6 +181,7 @@ it("diff column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
+          status: "normal",
         } as any as Column,
         {
           oldName: "name",
@@ -187,6 +190,7 @@ it("diff column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
+          status: "normal",
         } as any as Column,
         {
           oldName: "city",
@@ -195,6 +199,7 @@ it("diff column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
+          status: "normal",
         } as any as Column,
       ],
       columnList: [
@@ -205,6 +210,7 @@ it("diff column list", () => {
           comment: "this is id",
           nullable: true,
           default: undefined,
+          status: "normal",
         } as any as Column,
         {
           oldName: "name",
@@ -213,6 +219,7 @@ it("diff column list", () => {
           comment: "",
           nullable: false,
           default: "",
+          status: "normal",
         } as Column,
         {
           oldName: "city",

--- a/frontend/src/utils/UIEditor/diffColumn.test.ts
+++ b/frontend/src/utils/UIEditor/diffColumn.test.ts
@@ -28,7 +28,7 @@ it("diff add column list", () => {
           nullable: false,
           default: undefined,
           status: "created",
-        } as Column,
+        } as any as Column,
       ],
       wanted: {
         addColumnList: [
@@ -73,7 +73,7 @@ it("diff modify column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
-        } as Column,
+        } as any as Column,
       ],
       columnList: [
         {
@@ -83,7 +83,7 @@ it("diff modify column list", () => {
           comment: "",
           nullable: false,
           default: undefined,
-        } as Column,
+        } as any as Column,
       ],
       wanted: {
         addColumnList: [],
@@ -129,7 +129,7 @@ it("diff drop column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
-        } as Column,
+        } as any as Column,
       ],
       columnList: [
         {
@@ -140,7 +140,7 @@ it("diff drop column list", () => {
           nullable: true,
           default: undefined,
           status: "dropped",
-        } as Column,
+        } as any as Column,
       ],
       wanted: {
         addColumnList: [],
@@ -179,7 +179,7 @@ it("diff column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
-        } as Column,
+        } as any as Column,
         {
           oldName: "name",
           newName: "name",
@@ -187,7 +187,7 @@ it("diff column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
-        } as Column,
+        } as any as Column,
         {
           oldName: "city",
           newName: "city",
@@ -195,7 +195,7 @@ it("diff column list", () => {
           comment: "",
           nullable: true,
           default: undefined,
-        } as Column,
+        } as any as Column,
       ],
       columnList: [
         {
@@ -205,7 +205,7 @@ it("diff column list", () => {
           comment: "this is id",
           nullable: true,
           default: undefined,
-        } as Column,
+        } as any as Column,
         {
           oldName: "name",
           newName: "name",
@@ -222,7 +222,7 @@ it("diff column list", () => {
           nullable: true,
           default: undefined,
           status: "dropped",
-        } as Column,
+        } as any as Column,
         {
           oldName: "birthday",
           newName: "birthday",

--- a/frontend/src/utils/UIEditor/diffColumn.ts
+++ b/frontend/src/utils/UIEditor/diffColumn.ts
@@ -1,4 +1,4 @@
-import { isEqual, isUndefined, omit } from "lodash-es";
+import { isEqual, isUndefined } from "lodash-es";
 import type {
   AddColumnContext,
   DropColumnContext,
@@ -26,7 +26,7 @@ export const diffColumnList = (
 
   const changeColumnContextList: ChangeColumnContext[] = [];
   const changedColumnList = columnList.filter(
-    (column) => column.status === undefined
+    (column) => column.status === "normal"
   );
   for (const column of changedColumnList) {
     const originColumn = originColumnList.find(
@@ -35,7 +35,7 @@ export const diffColumnList = (
     if (isUndefined(originColumn)) {
       continue;
     }
-    if (!isEqual(omit(originColumn, "status"), omit(column, "status"))) {
+    if (!isEqual(originColumn, column)) {
       changeColumnContextList.push(
         transformColumnToChangeColumnContext(originColumn, column)
       );

--- a/frontend/src/utils/UIEditor/diffTable.test.ts
+++ b/frontend/src/utils/UIEditor/diffTable.test.ts
@@ -111,8 +111,10 @@ it("diff alter table list", () => {
               comment: "",
               nullable: false,
               default: undefined,
+              status: "normal",
             },
           ],
+          status: "normal",
         } as any as Table,
       ],
       targetTableList: [
@@ -133,6 +135,7 @@ it("diff alter table list", () => {
               comment: "",
               nullable: false,
               default: undefined,
+              status: "normal",
             },
             {
               oldName: "email",
@@ -146,6 +149,7 @@ it("diff alter table list", () => {
               status: "created",
             },
           ],
+          status: "normal",
         } as any as Table,
       ],
       wanted: {

--- a/frontend/src/utils/UIEditor/diffTable.test.ts
+++ b/frontend/src/utils/UIEditor/diffTable.test.ts
@@ -216,6 +216,7 @@ it("diff drop table list", () => {
               default: undefined,
             },
           ],
+          status: "normal",
         } as any as Table,
       ],
       targetTableList: [

--- a/frontend/src/utils/UIEditor/diffTable.ts
+++ b/frontend/src/utils/UIEditor/diffTable.ts
@@ -1,4 +1,4 @@
-import { isEqual, isUndefined, omit } from "lodash-es";
+import { isEqual, isUndefined } from "lodash-es";
 import type {
   AlterTableContext,
   CreateTableContext,
@@ -29,7 +29,7 @@ export const diffTableList = (originTableList: Table[], tableList: Table[]) => {
   const alterTableContextList: AlterTableContext[] = [];
   const renameTableContextList: RenameTableContext[] = [];
   const changedTableList = tableList.filter(
-    (table) => table.status === undefined
+    (table) => table.status === "normal"
   );
   for (const table of changedTableList) {
     const originTable = originTableList.find(
@@ -41,7 +41,7 @@ export const diffTableList = (originTableList: Table[], tableList: Table[]) => {
       continue;
     }
 
-    if (!isEqual(omit(originTable, "status"), omit(table, "status"))) {
+    if (!isEqual(originTable, table)) {
       if (table.newName !== table.oldName) {
         renameTableContextList.push({
           oldName: table.oldName,

--- a/frontend/src/utils/UIEditor/transform.ts
+++ b/frontend/src/utils/UIEditor/transform.ts
@@ -25,6 +25,7 @@ export const transformTableDataToTable = (tableData: TableData): Table => {
     comment: tableData.comment,
     originColumnList: columnList,
     columnList: cloneDeep(columnList),
+    status: "normal",
   };
 };
 
@@ -37,6 +38,7 @@ export const transformColumnDataToColumn = (columnData: ColumnData): Column => {
     nullable: columnData.nullable,
     comment: columnData.comment,
     default: columnData.default || null,
+    status: "normal",
   };
 };
 


### PR DESCRIPTION
`TableOrColumnStatus` is a status field for table/column in UI Editor. It now has three values.
* `normal` means that the object(table/column) is in a non-special status;
* `created` means that the object is newly created;
* `dropped` means that the object was deleted;
