### PR TITLE
feat(frontend): hide location label

### DIFF
--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -148,6 +148,7 @@
 
       <!-- Providing other dropdowns for optional labels as if they are normal optional props of DB -->
       <DatabaseLabelForm
+        v-if="isTenantProject"
         class="w-full"
         :project="project"
         :label-list="state.labelList"

--- a/frontend/src/components/DatabaseDetail/CreatePITRDatabaseForm.vue
+++ b/frontend/src/components/DatabaseDetail/CreatePITRDatabaseForm.vue
@@ -107,6 +107,7 @@
 
   <!-- Providing other dropdowns for optional labels as if they are normal optional props of DB -->
   <DatabaseLabelForm
+    v-if="isTenantProject"
     :project="project"
     :label-list="state.context.labelList"
     filter="optional"

--- a/frontend/src/components/DeploymentConfigTool/SelectorItem.vue
+++ b/frontend/src/components/DeploymentConfigTool/SelectorItem.vue
@@ -36,7 +36,12 @@
 
 import { computed, defineComponent, PropType, watch } from "vue";
 import { Database, LabelSelectorRequirement, OperatorType } from "../../types";
-import { getLabelValuesFromDatabaseList, hidePrefix } from "../../utils";
+import {
+  getLabelValuesFromDatabaseList,
+  hidePrefix,
+  PRESET_LABEL_KEYS,
+  RESERVED_LABEL_KEYS,
+} from "../../utils";
 import LabelSelect from "./LabelSelect.vue";
 import { lowerCase, uniq } from "lodash-es";
 
@@ -62,10 +67,11 @@ export default defineComponent({
   emits: ["remove"],
   setup(props) {
     const keys = computed(() => {
+      const availableList = [...RESERVED_LABEL_KEYS, ...PRESET_LABEL_KEYS];
       const allKeys = props.databaseList.flatMap((db) =>
         db.labels.map((label) => label.key)
       );
-      return uniq(allKeys);
+      return uniq(allKeys).filter((key) => availableList.includes(key));
     });
     const values = computed(() => {
       if (!props.selector.key) return [];

--- a/frontend/src/components/Issue/IssueSidebar.vue
+++ b/frontend/src/components/Issue/IssueSidebar.vue
@@ -205,7 +205,7 @@
           {{ hidePrefix(label.key) }}
         </h2>
 
-        <div class="col-span-2 text-sm font-medium text-main capitalize">
+        <div class="col-span-2 text-sm font-medium text-main">
           {{ label.value }}
         </div>
       </template>
@@ -306,12 +306,12 @@ import type {
 import {
   allTaskList,
   databaseSlug,
-  isReservedDatabaseLabel,
   hasWorkspacePermission,
   hidePrefix,
   taskSlug,
   isOwnerOfProject,
   extractDatabaseNameFromTask,
+  PRESET_LABEL_KEYS,
 } from "@/utils";
 import {
   hasFeature,
@@ -423,8 +423,8 @@ const visibleLabelList = computed((): DatabaseLabel[] => {
   // transform non-reserved labels to db properties
   if (!props.database) return [];
 
-  return props.database.labels.filter(
-    (label) => !isReservedDatabaseLabel(label)
+  return props.database.labels.filter((label) =>
+    PRESET_LABEL_KEYS.includes(label.key)
   );
 });
 

--- a/frontend/src/components/TenantDatabaseTable/DatabaseMatrixItem.vue
+++ b/frontend/src/components/TenantDatabaseTable/DatabaseMatrixItem.vue
@@ -82,7 +82,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from "vue";
 import { Database } from "../../types";
-import { databaseSlug, isReservedDatabaseLabel, hidePrefix } from "../../utils";
+import { databaseSlug, hidePrefix, PRESET_LABEL_KEYS } from "../../utils";
 import InstanceEngineIcon from "../InstanceEngineIcon.vue";
 import { NPopover } from "naive-ui";
 
@@ -102,7 +102,7 @@ export default defineComponent({
     const displayLabelList = computed(() => {
       return props.database.labels.filter((label) => {
         if (!label.value) return false;
-        if (isReservedDatabaseLabel(label)) return false;
+        if (!PRESET_LABEL_KEYS.includes(label.key)) return false;
         return true;
       });
     });

--- a/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
+++ b/frontend/src/components/TransferDatabaseForm/SelectDatabaseLabel.vue
@@ -13,6 +13,7 @@
   </template>
   <template v-else>
     <div
+      v-if="targetProject.tenantMode === 'TENANT'"
       class="space-y-4 flex flex-col justify-center items-center"
       v-bind="$attrs"
     >

--- a/frontend/src/utils/label.ts
+++ b/frontend/src/utils/label.ts
@@ -15,18 +15,11 @@ export const MAX_LABEL_VALUE_LENGTH = 63;
 
 export const RESERVED_LABEL_KEYS = ["bb.environment"];
 
-export const PRESET_LABEL_KEYS = ["bb.location", "bb.tenant"];
+export const PRESET_LABEL_KEYS = ["bb.tenant"];
 
-export const PRESET_DB_NAME_TEMPLATE_PLACEHOLDERS = [
-  "DB_NAME",
-  "LOCATION",
-  "TENANT",
-];
+export const PRESET_DB_NAME_TEMPLATE_PLACEHOLDERS = ["DB_NAME", "TENANT"];
 
-export const PRESET_LABEL_KEY_PLACEHOLDERS = [
-  ["LOCATION", "bb.location"],
-  ["TENANT", "bb.tenant"],
-];
+export const PRESET_LABEL_KEY_PLACEHOLDERS = [["TENANT", "bb.tenant"]];
 
 export const LABEL_VALUE_EMPTY = "";
 


### PR DESCRIPTION
Close BYT-2089, BYT-2079

### Features

- Remove (hide) `location` labels.
- Won't show `Tenent` input while creating databases in non-tenant projects.

### Screenshots
-
<img width="317" alt="image" src="https://user-images.githubusercontent.com/2749742/207223565-525add07-c5f9-448f-bf92-f9f95aa8d505.png">

-
<img width="379" alt="image" src="https://user-images.githubusercontent.com/2749742/207223569-9d42dc3f-b1df-48eb-a40a-d69c7eea1519.png">

-
<img width="246" alt="image" src="https://user-images.githubusercontent.com/2749742/207223573-657a8c10-72b1-4ea0-a88c-e8529844fee1.png">

- If we meet "location" condition in legacy deployment config, it will still be displayed but not selectable any more.
<img width="463" alt="image" src="https://user-images.githubusercontent.com/2749742/207223587-a9075098-7261-4ee2-83e1-ecaf3a8effac.png">

-
<img width="782" alt="image" src="https://user-images.githubusercontent.com/2749742/207223600-f82c424a-9744-4e62-8f0c-d5fd044aa76b.png">
