### PR TITLE
feat: support finding activities with multiple typePrefixes

### DIFF
--- a/api/activity.go
+++ b/api/activity.go
@@ -251,11 +251,11 @@ type ActivityFind struct {
 	ID *int
 
 	// Domain specific fields
-	CreatorID   *int
-	TypePrefix  *string
-	Level       *ActivityLevel
-	ContainerID *int
-	Limit       *int
+	CreatorID      *int
+	TypePrefixList []string
+	Level          *ActivityLevel
+	ContainerID    *int
+	Limit          *int
 	// If specified, sorts the returned list by created_ts in <<ORDER>>
 	// Different use cases want different orders.
 	// e.g. Issue activity list wants ASC, while view recent activity list wants DESC.

--- a/server/activity.go
+++ b/server/activity.go
@@ -65,8 +65,8 @@ func (s *Server) registerActivityRoutes(g *echo.Group) {
 			}
 			activityFind.CreatorID = &creatorID
 		}
-		if typePrefixStr := c.QueryParams().Get("typePrefix"); typePrefixStr != "" {
-			activityFind.TypePrefix = &typePrefixStr
+		if typePrefixList := c.QueryParams()["typePrefix"]; typePrefixList != nil {
+			activityFind.TypePrefixList = typePrefixList
 		}
 		if levelStr := c.QueryParams().Get("level"); levelStr != "" {
 			activityLevel := api.ActivityLevel(levelStr)

--- a/server/runner/taskcheck/lgtm_executor.go
+++ b/server/runner/taskcheck/lgtm_executor.go
@@ -54,8 +54,8 @@ func (e *LGTMExecutor) Run(ctx context.Context, _ *api.TaskCheckRun, task *api.T
 
 	activityType := string(api.ActivityIssueCommentCreate)
 	activityList, err := e.store.FindActivity(ctx, &api.ActivityFind{
-		TypePrefix:  &activityType,
-		ContainerID: &issue.ID,
+		TypePrefixList: []string{activityType},
+		ContainerID:    &issue.ID,
 	})
 	if err != nil {
 		return nil, common.Wrap(err, common.Internal)

--- a/store/activity.go
+++ b/store/activity.go
@@ -344,8 +344,13 @@ func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*a
 	if v := find.CreatorID; v != nil {
 		where, args = append(where, fmt.Sprintf("creator_id = $%d", len(args)+1)), append(args, *v)
 	}
-	if v := find.TypePrefix; v != nil {
-		where, args = append(where, fmt.Sprintf("type LIKE $%d", len(args)+1)), append(args, fmt.Sprintf("%s%%", *v))
+	if v := find.TypePrefixList; v != nil {
+		var queryValues []string
+		// Iterate over the typePrefix list and join each one with an OR condition.
+		for _, str := range v {
+			queryValues, args = append(queryValues, fmt.Sprintf("type LIKE $%d", len(args)+1)), append(args, fmt.Sprintf("%s%%", str))
+		}
+		where = append(where, fmt.Sprintf("(%s)", strings.Join(queryValues, " OR ")))
 	}
 	if v := find.Level; v != nil {
 		where, args = append(where, fmt.Sprintf("level = $%d", len(args)+1)), append(args, *v)
@@ -452,7 +457,7 @@ func patchActivityImpl(ctx context.Context, tx *Tx, patch *api.ActivityPatch) (*
 // TODO(d): remove this after the backfill.
 func (s *Store) BackfillSQLEditorActivity(ctx context.Context) error {
 	typePrefix := string(api.ActivitySQLEditorQuery)
-	activityList, err := s.FindActivity(ctx, &api.ActivityFind{TypePrefix: &typePrefix})
+	activityList, err := s.FindActivity(ctx, &api.ActivityFind{TypePrefixList: []string{typePrefix}})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Make it possible to get activities with a range of typePrefixes. 

Now with a request to `/api/activity?typePrefix=bb.member&typePrefix=bb.project`, we'll get activities that are either of the `bb.member` type or of the `bb.project` type. 
While it is still compatible with cases like `/api/activity?typePrefix=bb.member` for activities only of the single `bb.member` type.

This change is to pave the road for audit logs so that we can request multiple determined types of activities at one time.