### PR TITLE
fix: missing override for data source

### DIFF
--- a/store/instance.go
+++ b/store/instance.go
@@ -403,16 +403,18 @@ func (s *Store) createInstanceRaw(ctx context.Context, create *InstanceCreate) (
 
 	for _, dataSource := range create.DataSourceList {
 		dataSourceCreate := &api.DataSourceCreate{
-			CreatorID:  create.CreatorID,
-			InstanceID: instance.ID,
-			DatabaseID: allDatabase.ID,
-			Name:       dataSource.Name,
-			Type:       dataSource.Type,
-			Username:   dataSource.Username,
-			Password:   dataSource.Password,
-			SslKey:     dataSource.SslKey,
-			SslCert:    dataSource.SslCert,
-			SslCa:      dataSource.SslCa,
+			CreatorID:    create.CreatorID,
+			InstanceID:   instance.ID,
+			DatabaseID:   allDatabase.ID,
+			Name:         dataSource.Name,
+			Type:         dataSource.Type,
+			Username:     dataSource.Username,
+			Password:     dataSource.Password,
+			SslKey:       dataSource.SslKey,
+			SslCert:      dataSource.SslCert,
+			SslCa:        dataSource.SslCa,
+			HostOverride: dataSource.HostOverride,
+			PortOverride: dataSource.PortOverride,
 		}
 		if err := s.createDataSourceRawTx(ctx, tx, dataSourceCreate); err != nil {
 			return nil, err
@@ -524,16 +526,18 @@ func (s *Store) patchInstanceRaw(ctx context.Context, patch *InstancePatch) (*in
 
 		for _, dataSource := range patch.DataSourceList {
 			dataSourceCreate := &api.DataSourceCreate{
-				CreatorID:  patch.UpdaterID,
-				InstanceID: instance.ID,
-				DatabaseID: database.ID,
-				Name:       dataSource.Name,
-				Type:       dataSource.Type,
-				Username:   dataSource.Username,
-				Password:   dataSource.Password,
-				SslKey:     dataSource.SslKey,
-				SslCert:    dataSource.SslCert,
-				SslCa:      dataSource.SslCa,
+				CreatorID:    patch.UpdaterID,
+				InstanceID:   instance.ID,
+				DatabaseID:   database.ID,
+				Name:         dataSource.Name,
+				Type:         dataSource.Type,
+				Username:     dataSource.Username,
+				Password:     dataSource.Password,
+				SslKey:       dataSource.SslKey,
+				SslCert:      dataSource.SslCert,
+				SslCa:        dataSource.SslCa,
+				HostOverride: dataSource.HostOverride,
+				PortOverride: dataSource.PortOverride,
 			}
 			if err := s.createDataSourceRawTx(ctx, tx, dataSourceCreate); err != nil {
 				return nil, err


### PR DESCRIPTION
- fix missing override for data source
- rename the instance for archive (to avoid the duplicate name)