### PR TITLE
feat(access-control): handle protected instance's access control policy properly

### DIFF
--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -328,7 +328,6 @@ const doReorder = () => {
 };
 
 const doArchive = (/* environment: Environment */) => {
-  debugger;
   if (environmentList.value.length > 0) {
     selectEnvironment(0);
   }

--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -82,6 +82,7 @@ import type {
   Policy,
   PolicyUpsert,
   BackupPlanPolicyPayload,
+  EnvironmentTierPolicyPayload,
 } from "../types";
 import {
   DefaultApprovalPolicy,
@@ -245,7 +246,7 @@ const doCreate = (
   environmentStore
     .createEnvironment(newEnvironment)
     .then((environment: Environment) => {
-      Promise.all([
+      const requests = [
         policyStore.upsertPolicyByEnvironmentAndType({
           environmentId: environment.id,
           type: "bb.policy.pipeline-approval",
@@ -261,10 +262,32 @@ const doCreate = (
           type: "bb.policy.environment-tier",
           policyUpsert: { payload: environmentTierPolicy.payload },
         }),
-      ]).then(() => {
-        state.showCreateModal = false;
-        selectEnvironment(environmentList.value.length - 1);
-      });
+      ];
+      // Also upsert the environment's access-control policy
+      const environmentTierPayload =
+        environmentTierPolicy.payload as EnvironmentTierPolicyPayload;
+      const disallowed = environmentTierPayload.environmentTier === "PROTECTED";
+      requests.push(
+        policyStore.upsertPolicyByEnvironmentAndType({
+          environmentId: environment.id,
+          type: "bb.policy.access-control",
+          policyUpsert: {
+            inheritFromParent: false,
+            payload: {
+              disallowRuleList: [
+                {
+                  fullDatabase: disallowed,
+                },
+              ],
+            },
+          },
+        })
+      );
+      return Promise.all(requests);
+    })
+    .then(() => {
+      state.showCreateModal = false;
+      selectEnvironment(environmentList.value.length - 1);
     });
 };
 
@@ -305,6 +328,7 @@ const doReorder = () => {
 };
 
 const doArchive = (/* environment: Environment */) => {
+  debugger;
   if (environmentList.value.length > 0) {
     selectEnvironment(0);
   }

--- a/frontend/src/views/sql-editor/SQLEditorPage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorPage.vue
@@ -51,7 +51,6 @@ import { TabMode, UNKNOWN_ID } from "@/types";
 import {
   useCurrentUser,
   useDatabaseStore,
-  useInstanceStore,
   useSQLEditorStore,
   useTabStore,
 } from "@/store";
@@ -60,11 +59,10 @@ import EditorPanel from "./EditorPanel/EditorPanel.vue";
 import TerminalPanel from "./TerminalPanel/TerminalPanel.vue";
 import TabList from "./TabList";
 import TablePanel from "./TablePanel/TablePanel.vue";
-import { isDatabaseAccessible, isInstanceAccessible } from "@/utils";
+import { isDatabaseAccessible } from "@/utils";
 
 const tabStore = useTabStore();
 const databaseStore = useDatabaseStore();
-const instanceStore = useInstanceStore();
 const sqlEditorStore = useSQLEditorStore();
 const currentUser = useCurrentUser();
 
@@ -72,11 +70,11 @@ const isDisconnected = computed(() => tabStore.isDisconnected);
 const isFetchingSheet = computed(() => sqlEditorStore.isFetchingSheet);
 
 const allowQuery = computed(() => {
-  const { databaseId, instanceId } = tabStore.currentTab.connection;
+  const { databaseId } = tabStore.currentTab.connection;
   const database = databaseStore.getDatabaseById(databaseId);
   if (database.id === UNKNOWN_ID) {
-    const instance = instanceStore.getInstanceById(instanceId);
-    return isInstanceAccessible(instance, currentUser.value);
+    // Allowed if connected to an instance
+    return true;
   }
   const { accessControlPolicyList } = sqlEditorStore;
   return isDatabaseAccessible(


### PR DESCRIPTION
Close BYT-2073

### Features

- UPSERT environment-level access-control policy when changing an environment's tier. (@rebelice PTAL)
- Hide inaccessible databases and instances in the SQL Editor's database tree.