### PR TITLE
chore: add idx on project_id for table db

### DIFF
--- a/store/migration/dev/20221214000000##add_idx_db_project_id.sql
+++ b/store/migration/dev/20221214000000##add_idx_db_project_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_db_project_id ON db(project_id);

--- a/store/migration/dev/LATEST.sql
+++ b/store/migration/dev/LATEST.sql
@@ -338,6 +338,8 @@ CREATE INDEX idx_db_instance_id ON db(instance_id);
 
 CREATE UNIQUE INDEX idx_db_unique_instance_id_name ON db(instance_id, name);
 
+CREATE INDEX idx_db_project_id ON db(project_id);
+
 ALTER SEQUENCE db_id_seq RESTART WITH 101;
 
 CREATE TRIGGER update_db_updated_ts


### PR DESCRIPTION
Add index on db(project_id) as finding databases by project_id is frequent.