### PR TITLE
feat: workspace-level audit log for owners and DBAs

### DIFF
--- a/frontend/src/bbkit/BBDialog.vue
+++ b/frontend/src/bbkit/BBDialog.vue
@@ -11,6 +11,7 @@
 
     <div class="pt-4 border-t border-block-border flex justify-end space-x-3">
       <button
+        v-if="needNegativeBtn"
         type="button"
         class="btn-normal py-2 px-4"
         @click.prevent="onNegativeClick"
@@ -45,6 +46,10 @@ const props = defineProps({
   closable: {
     type: Boolean,
     default: false,
+  },
+  needNegativeBtn: {
+    type: Boolean,
+    default: true,
   },
   negativeText: {
     type: String,

--- a/frontend/src/bbkit/BBDialog.vue
+++ b/frontend/src/bbkit/BBDialog.vue
@@ -11,7 +11,7 @@
 
     <div class="pt-4 border-t border-block-border flex justify-end space-x-3">
       <button
-        v-if="needNegativeBtn"
+        v-if="showNegativeBtn"
         type="button"
         class="btn-normal py-2 px-4"
         @click.prevent="onNegativeClick"
@@ -47,7 +47,7 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  needNegativeBtn: {
+  showNegativeBtn: {
     type: Boolean,
     default: true,
   },

--- a/frontend/src/components/AuditLog/AuditLogEmptyView.vue
+++ b/frontend/src/components/AuditLog/AuditLogEmptyView.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="bg-white rounded-lg py-6">
+    <div
+      class="border-4 border-dashed border-gray-200 rounded-lg h-96 flex justify-center items-center"
+    >
+      <div class="text-center flex flex-col justify-center items-center">
+        <img src="../../assets/illustration/no-data.webp" class="w-52" />
+        <h3 class="mt-2 font-medium text-gray-900">
+          {{ $t("audit-log.no-logs") }}
+        </h3>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/AuditLog/AuditLogTable.vue
+++ b/frontend/src/components/AuditLog/AuditLogTable.vue
@@ -1,0 +1,104 @@
+<template>
+  <BBTable
+    class="mt-2"
+    :column-list="columnList"
+    :data-source="auditLogList"
+    :show-header="true"
+    :row-clickable="false"
+  >
+    <template #body="{ rowData: auditLog }">
+      <BBTableCell :left-padding="4" class="table-cell w-56">
+        <div>
+          {{ dayjs.unix(auditLog.createdTs).format("YYYY-MM-DD HH:mm:ss Z") }}
+        </div>
+      </BBTableCell>
+      <BBTableCell class="table-cell w-20">
+        {{ auditLog.creator }}
+      </BBTableCell>
+      <BBTableCell class="table-cell w-28">
+        <span
+          class="inline-flex items-center px-2 py-1 rounded-lg text-xs font-semibold bg-green-100 text-green-800"
+        >
+          {{
+            t(AuditActivityTypeI18nNameMap[auditLog.type as AuditActivityType])
+          }}
+        </span>
+      </BBTableCell>
+      <BBTableCell class="table-cell w-24">
+        <div>{{ auditLog.level }}</div>
+      </BBTableCell>
+      <BBTableCell class="table-cell w-36">
+        <div v-if="auditLog.comment">
+          {{ auditLog.comment }}
+        </div>
+        <span v-else class="italic text-gray-500">{{
+          $t("audit-log.table.empty")
+        }}</span>
+      </BBTableCell>
+      <BBTableCell class="table-cell w-28">
+        <div>
+          <div class="tooltip-wrapper">
+            <div class="tooltip whitespace-nowrap">
+              {{ $t("audit-log.table.view-details") }}
+            </div>
+            <button
+              type="button"
+              class="group btn-normal items-center !px-3 !text-accent hover:!bg-gray-50"
+              @click.stop="
+                () => {
+                  $emit('view-detail', auditLog);
+                }
+              "
+            >
+              <heroicons-outline:document-magnifying-glass class="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      </BBTableCell>
+    </template>
+  </BBTable>
+</template>
+
+<script lang="ts" setup>
+import { computed, PropType } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+  AuditLog,
+  AuditActivityTypeI18nNameMap,
+  AuditActivityType,
+} from "@/types";
+
+defineProps({
+  auditLogList: {
+    type: Array as PropType<AuditLog[]>,
+    required: true,
+  },
+});
+
+defineEmits<{
+  (event: "view-detail", list: AuditLog, e: MouseEvent): void;
+}>();
+
+const { t } = useI18n();
+
+const columnList = computed(() => [
+  {
+    title: t("audit-log.table.created-ts"),
+  },
+  {
+    title: t("audit-log.table.creator"),
+  },
+  {
+    title: t("audit-log.table.type"),
+  },
+  {
+    title: t("audit-log.table.level"),
+  },
+  {
+    title: t("audit-log.table.comment"),
+  },
+  {
+    title: t("audit-log.table.payload"),
+  },
+]);
+</script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -337,7 +337,8 @@
       "labels": "Labels",
       "debug-log": "Debug Log",
       "sensitive-data": "Sensitive Data",
-      "access-control": "Access Control"
+      "access-control": "Access Control",
+      "audit-log": "Audit Log"
     },
     "profile": {
       "email": "Email",
@@ -1680,6 +1681,29 @@
         "copied": "Copied!",
         "export": "Export"
       }
+    }
+  },
+  "audit-log": {
+    "no-logs": "No audit logs",
+    "audit-log-detail": "Audit Log Details",
+    "table": {
+      "created-ts": "Time",
+      "created-time": "Created Time",
+      "updated-time": "Updated Time",
+      "creator": "Creator",
+      "type": "Audit Type",
+      "level": "Audit Level",
+      "comment": "Comment",
+      "payload": "Payload",
+      "empty": "<Empty>",
+      "view-details": "View Details"
+    },
+    "type": {
+      "member-create": "Create Member",
+      "member-role-update": "Update Member Role",
+      "member-activate": "Activate Member",
+      "member-deactivate": "Deactivate Member",
+      "database-transfer": "Transfer Database"
     }
   },
   "onboarding-guide": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -337,7 +337,8 @@
       "labels": "标签",
       "debug-log": "Debug 日志",
       "sensitive-data": "敏感数据",
-      "access-control": "访问控制"
+      "access-control": "访问控制",
+      "audit-log": "审计日志"
     },
     "profile": {
       "email": "邮箱",
@@ -1681,6 +1682,29 @@
         "copied": "已拷贝",
         "export": "导出"
       }
+    }
+  },
+  "audit-log": {
+    "no-logs": "暂无审计日志",
+    "audit-log-detail": "审计详情",
+    "table": {
+      "created-ts": "时间",
+      "created-time": "创建时间",
+      "updated-time": "更新时间",
+      "creator": "操作者",
+      "type": "事件类型",
+      "level": "事件等级",
+      "comment": "评论",
+      "payload": "Payload",
+      "empty": "<空>",
+      "view-details": "查看详情"
+    },
+    "type": {
+      "member-create": "增加成员",
+      "member-role-update": "更新角色",
+      "member-activate": "激活成员",
+      "member-deactivate": "禁用成员",
+      "database-transfer": "转移数据库"
     }
   },
   "onboarding-guide": {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -443,6 +443,16 @@ const routes: Array<RouteRecordRaw> = [
                 props: true,
               },
               {
+                path: "audit-log",
+                name: "setting.workspace.audit-log",
+                meta: {
+                  title: () => t("settings.sidebar.audit-log"),
+                },
+                component: () =>
+                  import("../views/SettingWorkspaceAuditLog.vue"),
+                props: true,
+              },
+              {
                 path: "debug-log",
                 name: "setting.workspace.debug-log",
                 meta: {
@@ -1048,9 +1058,27 @@ router.beforeEach((to, from, next) => {
     }
   }
 
+  if (to.name?.toString().startsWith("setting.workspace.audit-log")) {
+    if (
+      !hasWorkspacePermission(
+        "bb.permission.workspace.audit-log",
+        currentUser.role
+      )
+    ) {
+      next({
+        name: "error.403",
+        replace: false,
+      });
+      return;
+    }
+  }
+
   if (to.name?.toString().startsWith("setting.workspace.debug-log")) {
     if (
-      !hasWorkspacePermission("bb.permission.workspace.debug", currentUser.role)
+      !hasWorkspacePermission(
+        "bb.permission.workspace.debug-log",
+        currentUser.role
+      )
     ) {
       next({
         name: "error.403",

--- a/frontend/src/store/modules/auditLog.ts
+++ b/frontend/src/store/modules/auditLog.ts
@@ -1,0 +1,62 @@
+import { watchEffect } from "vue";
+import { defineStore, storeToRefs } from "pinia";
+import axios from "axios";
+import type { AuditLogState, ResponseWithData, ResourceObjects } from "@/types";
+import { AuditActivityType } from "@/types";
+import type { AuditLog } from "@/types/auditLog";
+
+const convertAuditLogList = (res: ResponseWithData): AuditLog[] => {
+  const activityList = res.data as ResourceObjects;
+  const auditLogList: AuditLog[] = activityList.map(
+    (activity) =>
+      ({
+        createdTs: activity.attributes.createdTs as number,
+        creator: res.included!.find(
+          (item) =>
+            item.id ===
+            (
+              activity.relationships!.creator.data as {
+                id: string;
+                type: string;
+              }
+            ).id
+        )?.attributes.email as string,
+        type: activity.attributes.type as string,
+        level: activity.attributes.level as string,
+        comment: activity.attributes.comment as string,
+        payload: activity.attributes.payload as string,
+      } as AuditLog)
+  );
+
+  return auditLogList;
+};
+
+const typePrefixQuery = `${(
+  Object.keys(AuditActivityType) as Array<keyof typeof AuditActivityType>
+)
+  .map((key) => `typePrefix=${AuditActivityType[key]}`)
+  .join("&")}`;
+
+export const useAuditLogStore = defineStore("auditLog", {
+  state: (): AuditLogState => ({
+    auditLogList: [],
+  }),
+  actions: {
+    setAuditLogList(auditLogList: AuditLog[]) {
+      this.auditLogList = auditLogList;
+    },
+    async fetchAuditLogList() {
+      const res = (await axios.get(`/api/activity?${typePrefixQuery}`)).data;
+      const list = convertAuditLogList(res);
+      this.setAuditLogList(list);
+      return list;
+    },
+  },
+});
+
+export const useAuditLogList = () => {
+  const store = useAuditLogStore();
+  watchEffect(async () => await store.fetchAuditLogList());
+
+  return storeToRefs(store).auditLogList;
+};

--- a/frontend/src/store/modules/index.ts
+++ b/frontend/src/store/modules/index.ts
@@ -1,6 +1,7 @@
 export * from "./activity";
 export * from "./actuator";
 export * from "./anomaly";
+export * from "./auditLog";
 export * from "./auth";
 export * from "./backup";
 export * from "./bookmark";

--- a/frontend/src/types/auditLog.ts
+++ b/frontend/src/types/auditLog.ts
@@ -1,0 +1,34 @@
+export enum AuditActivityType {
+  // Member related
+  MemberCreate = "bb.member.create",
+  MemberRoleUpdate = "bb.member.role.update",
+  MemberActivate = "bb.member.activate",
+  MemberDeactivate = "bb.member.deactivate",
+
+  // Project related
+  DatabaseTransfer = "bb.project.database.transfer",
+}
+
+export enum AuditActivityLevel {
+  INFO = "INFO",
+  WARN = "WARN",
+  ERROR = "ERROR",
+}
+
+// Mapping from an activity type to a human readable string.
+export const AuditActivityTypeI18nNameMap: Record<AuditActivityType, string> = {
+  [AuditActivityType.MemberCreate]: "audit-log.type.member-create",
+  [AuditActivityType.MemberRoleUpdate]: "audit-log.type.member-role-update",
+  [AuditActivityType.MemberActivate]: "audit-log.type.member-activate",
+  [AuditActivityType.MemberDeactivate]: "audit-log.type.member-deactivate",
+  [AuditActivityType.DatabaseTransfer]: "audit-log.type.database-transfer",
+};
+
+export type AuditLog = {
+  createdTs: number;
+  creator: string;
+  type: AuditActivityType;
+  level: AuditActivityLevel;
+  comment: string;
+  payload: unknown;
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from "./activity";
 export * from "./actuator";
 export * from "./anomaly";
+export * from "./auditLog";
 export * from "./auth";
 export * from "./backup";
 export * from "./bookmark";

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -49,6 +49,7 @@ import { VCS } from "./vcs";
 import { Label } from "./label";
 import { ConnectionAtom } from "./sqlEditor";
 import type { DebugLog } from "@/types/debug";
+import type { AuditLog } from "@/types/auditLog";
 
 export interface ActuatorState {
   serverInfo?: ServerInfo;
@@ -57,6 +58,10 @@ export interface ActuatorState {
 export interface AuthState {
   authProviderList: AuthProvider[];
   currentUser: Principal;
+}
+
+export interface AuditLogState {
+  auditLogList: AuditLog[];
 }
 
 export interface SettingState {

--- a/frontend/src/utils/role.ts
+++ b/frontend/src/utils/role.ts
@@ -18,7 +18,10 @@ export type WorkspacePermissionType =
   | "bb.permission.workspace.manage-access-control"
   | "bb.permission.workspace.manage-subscription"
   // Can execute admininstrive queries such as "SHOW PROCESSLIST"
-  | "bb.permission.workspace.admin-sql-editor";
+  | "bb.permission.workspace.admin-sql-editor"
+  // Can view sensitive information such as audit logs and debug logs
+  | "bb.permission.workspace.audit-log"
+  | "bb.permission.workspace.debug-log";
 
 // A map from a particular workspace permission to the respective enablement of a particular workspace role.
 // The key is the workspace permission type and the value is the workspace [DEVELOPER, DBA, OWNER] triplet.
@@ -41,6 +44,8 @@ export const WORKSPACE_PERMISSION_MATRIX: Map<
   ["bb.permission.workspace.manage-access-control", [false, true, true]],
   ["bb.permission.workspace.manage-subscription", [false, false, true]],
   ["bb.permission.workspace.admin-sql-editor", [false, true, true]],
+  ["bb.permission.workspace.audit-log", [false, true, true]],
+  ["bb.permission.workspace.debug-log", [false, true, true]],
 ]);
 
 // Returns true if RBAC is not enabled or the particular role has the particular permission.

--- a/frontend/src/views/SettingSidebar.vue
+++ b/frontend/src/views/SettingSidebar.vue
@@ -97,7 +97,13 @@
             >{{ $t("settings.sidebar.subscription") }}</router-link
           >
           <router-link
-            v-if="showDebugItem"
+            v-if="showAuditLogItem"
+            to="/setting/audit-log"
+            class="outline-item group w-full flex items-center pl-11 pr-2 py-2"
+            >{{ $t("settings.sidebar.audit-log") }}</router-link
+          >
+          <router-link
+            v-if="showDebugLogItem"
             to="/setting/debug-log"
             class="outline-item group w-full flex items-center pl-11 pr-2 py-2"
             >{{ $t("settings.sidebar.debug-log") }}</router-link
@@ -125,15 +131,7 @@ import { useCurrentUser, useRouterStore } from "@/store";
 
 const routerStore = useRouterStore();
 const router = useRouter();
-
 const currentUser = useCurrentUser();
-
-const showDebugItem = computed((): boolean => {
-  return hasWorkspacePermission(
-    "bb.permission.workspace.debug",
-    currentUser.value.role
-  );
-});
 
 const showProjectItem = computed((): boolean => {
   return hasWorkspacePermission(
@@ -166,6 +164,20 @@ const showIMIntegrationItem = computed((): boolean => {
 const showVCSItem = computed((): boolean => {
   return hasWorkspacePermission(
     "bb.permission.workspace.manage-vcs-provider",
+    currentUser.value.role
+  );
+});
+
+const showDebugLogItem = computed((): boolean => {
+  return hasWorkspacePermission(
+    "bb.permission.workspace.debug-log",
+    currentUser.value.role
+  );
+});
+
+const showAuditLogItem = computed((): boolean => {
+  return hasWorkspacePermission(
+    "bb.permission.workspace.audit-log",
     currentUser.value.role
   );
 });

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -3,21 +3,14 @@
     <div v-if="auditLogList.length > 0">
       <AuditLogTable
         :audit-log-list="auditLogList.sort((a, b) => b.createdTs - a.createdTs)"
-        @view-detail="
-          (log: any) => {
-            console.log(log)
-            state.modalContent = log
-            state.showModal = true;
-            dialog!.open();
-          }
-        "
+        @view-detail="handleViewDetail"
       />
       <BBDialog
         ref="dialog"
         :title="$t('audit-log.audit-log-detail')"
         data-label="bb-audit-log-detail-dialog"
         :closable="true"
-        :need-negative-btn="false"
+        :show-negative-btn="false"
       >
         <div class="w-192 font-mono">
           <dl>
@@ -81,5 +74,11 @@ const logKeyMap = {
   level: t("audit-log.table.level"),
   comment: t("audit-log.table.comment"),
   payload: t("audit-log.table.payload"),
+};
+
+const handleViewDetail = (log: any) => {
+  state.modalContent = log;
+  state.showModal = true;
+  dialog.value!.open();
 };
 </script>

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="space-y-4">
+    <div v-if="auditLogList.length > 0">
+      <AuditLogTable
+        :audit-log-list="auditLogList.sort((a, b) => b.createdTs - a.createdTs)"
+        @view-detail="
+          (log: any) => {
+            console.log(log)
+            state.modalContent = log
+            state.showModal = true;
+            dialog!.open();
+          }
+        "
+      />
+      <BBDialog
+        ref="dialog"
+        :title="$t('audit-log.audit-log-detail')"
+        data-label="bb-audit-log-detail-dialog"
+        :closable="true"
+        :need-negative-btn="false"
+      >
+        <div class="w-192 font-mono">
+          <dl>
+            <dd
+              v-for="(value, key) in state.modalContent"
+              :key="key"
+              class="flex items-start text-sm md:mr-4 mb-1"
+            >
+              <NGrid x-gap="20" :cols="20">
+                <NGi span="3">
+                  <span class="textlabel whitespace-nowrap">{{
+                    logKeyMap[key]
+                  }}</span
+                  ><span class="mr-1">:</span>
+                </NGi>
+                <NGi span="17">
+                  <span v-if="value !== ''">
+                    {{
+                      (key as string).includes("Ts")
+                        ? dayjs
+                            .unix(value as number)
+                            .format("YYYY-MM-DD HH:mm:ss Z")
+                        : value
+                    }}
+                  </span>
+                  <span v-else class="italic text-gray-500">
+                    {{ $t("audit-log.table.empty") }}
+                  </span>
+                </NGi>
+              </NGrid>
+            </dd>
+          </dl>
+        </div>
+      </BBDialog>
+    </div>
+    <AuditLogEmptyView v-else />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { reactive, ref } from "vue";
+import { NGrid, NGi } from "naive-ui";
+import { useI18n } from "vue-i18n";
+import { BBDialog } from "@/bbkit";
+import { useAuditLogList } from "@/store";
+
+const dialog = ref<InstanceType<typeof BBDialog> | null>(null);
+const state = reactive({
+  showModal: false,
+  modalContent: {},
+});
+
+const { t } = useI18n();
+const auditLogList = useAuditLogList();
+
+const logKeyMap = {
+  createdTs: t("audit-log.table.created-time"),
+  updatedTs: t("audit-log.table.updated-time"),
+  creator: t("audit-log.table.creator"),
+  type: t("audit-log.table.type"),
+  level: t("audit-log.table.level"),
+  comment: t("audit-log.table.comment"),
+  payload: t("audit-log.table.payload"),
+};
+</script>


### PR DESCRIPTION
I'll introduce pagination for activities (and also audit logs) in the next PR.

For now, audit logs record the following activity types:
- bb.member.create
- bb.member.role.update
- bb.member.activate
- bb.member.deactivate
- bb.project.database.transfer

![localhost_3000_setting_audit-log (2)](https://user-images.githubusercontent.com/56376387/207559844-1a375916-b939-4226-ad26-a6710d1b2129.png)

![localhost_3000_setting_audit-log (1)](https://user-images.githubusercontent.com/56376387/207559552-c029604c-d147-4a22-bfb1-cf9e2c55359b.png)

<img width="886" alt="2022-12-14-Microsoft Edge-SOAFArMX" src="https://user-images.githubusercontent.com/56376387/207559614-9a54e9ea-78e1-41ef-8f87-46045b38cba8.png">

<img width="866" alt="2022-12-14-Microsoft Edge-agiFNybK" src="https://user-images.githubusercontent.com/56376387/207561915-b4888f4c-ca62-4164-b160-a9f791547733.png">