### PR TITLE
chore: deprecate database name from migration context

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -154,10 +154,8 @@ type MigrationDetail struct {
 	// MigrationType can be empty for gh-ost type of migration.
 	MigrationType db.MigrationType `json:"migrationType"`
 	// DatabaseID is the ID of a database.
+	// This should be unset when a project is in tenant mode. The ProjectID is derived from IssueCreate.
 	DatabaseID int `json:"databaseId"`
-	// DatabaseName is the name of databases, mutually exclusive to DatabaseID.
-	// This should be set when a project is in tenant mode, and ProjectID is derived from IssueCreate.
-	DatabaseName string `json:"databaseName"`
 	// Statement is the statement to update database schema.
 	Statement string `json:"statement"`
 	// EarliestAllowedTs the earliest execution time of the change at system local Unix timestamp in seconds.

--- a/server/issue.go
+++ b/server/issue.go
@@ -748,7 +748,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 	if len(c.DetailList) == 0 {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "migration detail list should not be empty")
 	}
-	databaseNameCount, databaseIDCount := 0, 0
+	emptyDatabaseIDCount, databaseIDCount := 0, 0
 	for _, detail := range c.DetailList {
 		if detail.MigrationType != db.Baseline && detail.MigrationType != db.Migrate && detail.MigrationType != db.MigrateSDL && detail.MigrationType != db.Data {
 			return nil, echo.NewHTTPError(http.StatusBadRequest, "support migrate, migrateSDL and data type migration only")
@@ -758,15 +758,14 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 		}
 		if detail.DatabaseID > 0 {
 			databaseIDCount++
-		}
-		if detail.DatabaseName != "" {
-			databaseNameCount++
+		} else {
+			emptyDatabaseIDCount++
 		}
 	}
-	if databaseNameCount > 0 && databaseIDCount > 0 {
+	if emptyDatabaseIDCount > 0 && databaseIDCount > 0 {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Migration detail should set either database name or database ID.")
 	}
-	if databaseNameCount > 1 {
+	if emptyDatabaseIDCount > 1 {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "There should be at most one migration detail with database name.")
 	}
 	if project.TenantMode == api.TenantModeTenant && !s.licenseService.IsFeatureEnabled(api.FeatureMultiTenancy) {

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -1012,7 +1012,6 @@ func (s *Server) prepareIssueFromSDLFile(ctx context.Context, repo *api.Reposito
 		migrationDetailList = append(migrationDetailList,
 			&api.MigrationDetail{
 				MigrationType: db.MigrateSDL,
-				DatabaseName:  dbName,
 				Statement:     sdl,
 			},
 		)
@@ -1060,7 +1059,6 @@ func (s *Server) prepareIssueFromFile(ctx context.Context, repo *api.Repository,
 			return []*api.MigrationDetail{
 				{
 					MigrationType: fileInfo.migrationInfo.Type,
-					DatabaseName:  fileInfo.migrationInfo.Database,
 					Statement:     content,
 					SchemaVersion: fileInfo.migrationInfo.Version,
 				},

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -158,7 +158,6 @@ func TestTenant(t *testing.T) {
 		DetailList: []*api.MigrationDetail{
 			{
 				MigrationType: db.Migrate,
-				DatabaseName:  databaseName,
 				Statement:     migrationStatement,
 			},
 		},
@@ -645,7 +644,6 @@ func TestTenantDatabaseNameTemplate(t *testing.T) {
 		DetailList: []*api.MigrationDetail{
 			{
 				MigrationType: db.Migrate,
-				DatabaseName:  baseDatabaseName,
 				Statement:     migrationStatement,
 			},
 		},


### PR DESCRIPTION
This is no longer needed as we have change to use empty database name and empty database ID for tenant mode migration regardless of the database name template value.