### PR TITLE
feat: introduce schema metadata API

### DIFF
--- a/tests/sync_schema_test.go
+++ b/tests/sync_schema_test.go
@@ -167,7 +167,7 @@ DROP SCHEMA "schema_a";
 	newDatabase := databases[0]
 	a.Equal(instance.ID, database.Instance.ID)
 
-	newDatabaseSchema, err := ctl.getLatestSchemaOfDatabaseID(newDatabase.ID)
+	newDatabaseSchema, err := ctl.getLatestSchemaDump(newDatabase.ID)
 	a.NoError(err)
 
 	diff, err := ctl.getSchemaDiff(schemaDiffRequest{

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1385,8 +1385,20 @@ func (ctl *controller) createSQLReviewCI(projectID, repositoryID int) (*api.SQLR
 	return sqlReviewCISetup, nil
 }
 
-func (ctl *controller) getLatestSchemaOfDatabaseID(databaseID int) (string, error) {
+func (ctl *controller) getLatestSchemaDump(databaseID int) (string, error) {
 	body, err := ctl.get(fmt.Sprintf("/database/%d/schema", databaseID), nil)
+	if err != nil {
+		return "", err
+	}
+	bs, err := io.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}
+
+func (ctl *controller) getLatestSchemaMetadata(databaseID int) (string, error) {
+	body, err := ctl.get(fmt.Sprintf("/database/%d/schema", databaseID), map[string]string{"metadata": "true"})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We will use the "metadata=true" query parameter for "database/:id/schema" API for getting the database schema metadata in json format. The frontend will convert it to proto then. Without the query parameter, we will return the raw dump as before.