### PR TITLE
feat(frontend): introducing <BBGrid> - a responsive, flexible <BBTable> alternative

### DIFF
--- a/frontend/src/assets/css/tailwind.css
+++ b/frontend/src/assets/css/tailwind.css
@@ -80,6 +80,26 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .bb-grid {
+    @apply grid border-block-border;
+  }
+  .bb-grid-row {
+    @apply contents;
+  }
+  .bb-grid-header-cell {
+    @apply flex items-center bg-gray-50 p-2 text-left text-xs font-medium text-gray-500 tracking-wider;
+    @apply first:pl-4 last:pr-4;
+  }
+  .bb-grid-cell {
+    @apply border-t border-block-border flex items-center text-sm leading-5 p-2 whitespace-pre-wrap break-all;
+    @apply first:pl-4 last:pr-4;
+  }
+  .bb-grid-row.clickable:hover > .bb-grid-cell {
+    @apply cursor-pointer bg-gray-100;
+  }
+}
+
 .btn-primary {
   @apply select-none inline-flex border border-transparent rounded-md text-accent-text bg-accent hover:bg-accent-hover disabled:bg-accent disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 text-sm leading-5 font-medium focus:ring-control focus:outline-none focus-visible:ring-2 focus:ring-offset-2;
 }

--- a/frontend/src/bbkit/BBGrid/BBGrid.vue
+++ b/frontend/src/bbkit/BBGrid/BBGrid.vue
@@ -1,0 +1,88 @@
+<template>
+  <div role="table" class="bb-grid border-block-border" :class="gridClass">
+    <template v-if="customHeader">
+      <slot name="header" />
+    </template>
+    <div v-else role="table-row" class="bb-grid-row bb-grid-header-row group">
+      <div
+        v-for="(column, row) in columnList"
+        :key="row"
+        role="table-cell"
+        class="bb-grid-header-cell"
+        :class="[headerClass, column.class]"
+      >
+        {{ column.title }}
+      </div>
+    </div>
+
+    <div
+      v-for="(item, row) in dataSource"
+      :key="row"
+      row="table-row"
+      class="bb-grid-row group"
+      :class="{
+        clickable: rowClickable,
+      }"
+      @click="handleClick(item, 0, row, $event)"
+    >
+      <slot name="item" :item="item" :row="row" />
+    </div>
+
+    <slot name="footer" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { VueClass } from "@/utils";
+import { BBGridColumn } from "../types";
+import { useResponsiveGridColumns } from "./useResponsiveGridColumns";
+
+type DataType = any; // vue does not support generic typed components yet
+
+const emit = defineEmits<{
+  (
+    event: "click-row",
+    item: DataType,
+    section: number,
+    row: number,
+    e: MouseEvent
+  ): void;
+}>();
+
+const props = withDefaults(
+  defineProps<{
+    columnList?: BBGridColumn[];
+    dataSource?: DataType[];
+    showHeader?: boolean;
+    customHeader?: boolean;
+    headerClass?: VueClass;
+    rowClickable?: boolean;
+    showPlaceholder?: boolean;
+  }>(),
+  {
+    columnList: () => [],
+    dataSource: () => [],
+    showHeader: true,
+    customHeader: false,
+    headerClass: undefined,
+    rowClickable: true,
+    showPlaceholder: true,
+  }
+);
+
+const gridClass = useResponsiveGridColumns(
+  computed(() => props.columnList.map((col) => col.width))
+);
+
+const handleClick = (
+  item: DataType,
+  section: number,
+  row: number,
+  e: MouseEvent
+) => {
+  if (props.rowClickable) {
+    emit("click-row", item, section, row, e);
+  }
+};
+</script>

--- a/frontend/src/bbkit/BBGrid/index.ts
+++ b/frontend/src/bbkit/BBGrid/index.ts
@@ -1,0 +1,4 @@
+import BBGrid from "./BBGrid.vue";
+export * from "./useResponsiveGridColumns";
+
+export { BBGrid };

--- a/frontend/src/bbkit/BBGrid/useResponsiveGridColumns.ts
+++ b/frontend/src/bbkit/BBGrid/useResponsiveGridColumns.ts
@@ -1,0 +1,93 @@
+import { MaybeRef } from "@/types";
+import { useStyleTag } from "@vueuse/core";
+import { uniqueId } from "lodash-es";
+import { computed, onUnmounted, unref } from "vue";
+
+const breakpoints = {
+  default: "0",
+  sm: "640px",
+  md: "768px",
+  lg: "1024px",
+  xl: "1280px",
+  "2xl": "1536px",
+  "3xl": "1920px",
+  "4xl": "2160px",
+} as const;
+
+export type ScreenSize = keyof typeof breakpoints;
+export type ColumnWidth = string | Partial<{ [S in ScreenSize]: string }>;
+
+const screenSizes = Object.keys(breakpoints) as ScreenSize[];
+
+export const useResponsiveGridColumns = (widths: MaybeRef<ColumnWidth[]>) => {
+  const className = `${uniqueId("bb-responsive-grid-columns-")}`;
+  const css = computed(() => {
+    const _widths = unref(widths);
+    const rules = screenSizes
+      .map((screen) => {
+        if (_widths.some((width) => isDefinedScreen(width, screen))) {
+          return generateCSS(className, _widths, screen);
+        }
+        return "";
+      })
+      .join("");
+
+    return rules;
+  });
+  const tag = useStyleTag(css);
+  onUnmounted(() => tag.unload());
+  return className;
+};
+
+const isDefinedScreen = (width: ColumnWidth, screen: ScreenSize) => {
+  if (typeof width === "string") {
+    return screen === "default";
+  }
+
+  return typeof width[screen] === "string";
+};
+
+const generateGridTemplateColumns = (
+  widths: ColumnWidth[],
+  screen: ScreenSize
+) => {
+  return widths
+    .map((width) => getColumnWidthByScreen(width, screen))
+    .filter((value) => value !== "")
+    .join(" ");
+};
+
+const generateCSS = (
+  className: string,
+  widths: ColumnWidth[],
+  screen: ScreenSize
+) => {
+  const styleValue = generateGridTemplateColumns(widths, screen);
+  const rule = `.${className}{grid-template-columns:${styleValue};}`;
+  if (screen === "default") {
+    return rule;
+  } else {
+    const size = breakpoints[screen];
+    return `@media (min-width: ${size}) { ${rule} }`;
+  }
+};
+
+const getColumnWidthByScreen = (target: ColumnWidth, screen: ScreenSize) => {
+  if (typeof target === "string") {
+    return target;
+  }
+  const index = screenSizes.indexOf(screen);
+  if (index < 0) {
+    throw new Error(`unexpected screen size "${screen}"`);
+  }
+
+  for (let i = index; i >= 0; i--) {
+    const s = screenSizes[i];
+    const value = target[s];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return "";
+};

--- a/frontend/src/bbkit/index.ts
+++ b/frontend/src/bbkit/index.ts
@@ -26,9 +26,12 @@ import {
   BBTableHeaderCell,
   BBTableSearch,
 } from "./BBTable";
+import { BBGrid } from "./BBGrid";
 import BBTabPanel from "./BBTabPanel.vue";
 import BBTextField from "./BBTextField.vue";
 import BBBetaBadge from "./BBBetaBadge.vue";
+
+export * from "./types";
 
 export {
   BBAlert,
@@ -58,6 +61,7 @@ export {
   BBTableCell,
   BBTableHeaderCell,
   BBTableSearch,
+  BBGrid,
   BBTextField,
   BBBetaBadge,
 };

--- a/frontend/src/bbkit/types.ts
+++ b/frontend/src/bbkit/types.ts
@@ -1,3 +1,6 @@
+import { VueClass } from "@/utils";
+import { ColumnWidth } from "./BBGrid";
+
 export type BBButtonType =
   | "NORMAL"
   | "PRIMARY"
@@ -17,6 +20,12 @@ export type BBTableColumn = {
   title: string;
   center?: boolean;
   nowrap?: boolean;
+};
+
+export type BBGridColumn = {
+  title: string;
+  width: ColumnWidth;
+  class?: VueClass;
 };
 
 export type BBTableSectionDataSource<T> = {

--- a/frontend/src/components/InstanceTable.vue
+++ b/frontend/src/components/InstanceTable.vue
@@ -1,31 +1,29 @@
 <template>
-  <BBTable
+  <BBGrid
     :column-list="columnList"
     :data-source="instanceList"
-    :show-header="true"
-    :left-bordered="false"
-    :right-bordered="false"
+    class="mt-2 border-y"
     @click-row="clickInstance"
   >
-    <template #body="{ rowData: instance }">
-      <BBTableCell :left-padding="4" class="w-4">
+    <template #item="{ item: instance }">
+      <div class="bb-grid-cell justify-center !px-2">
         <InstanceEngineIcon :instance="instance" />
-      </BBTableCell>
-      <BBTableCell class="w-32">
+      </div>
+      <div class="bb-grid-cell">
         {{ instanceName(instance) }}
-      </BBTableCell>
-      <BBTableCell class="w-16">
+      </div>
+      <div class="bb-grid-cell">
         <div class="flex items-center gap-x-1">
           {{ environmentNameFromId(instance.environment.id) }}
           <ProtectedEnvironmentIcon :environment="instance.environment" />
         </div>
-      </BBTableCell>
-      <BBTableCell class="w-48">
+      </div>
+      <div class="bb-grid-cell">
         <template v-if="instance.port"
           >{{ instance.host }}:{{ instance.port }}</template
         ><template v-else>{{ instance.host }}</template>
-      </BBTableCell>
-      <BBTableCell class="w-4">
+      </div>
+      <div class="bb-grid-cell hidden sm:flex">
         <button
           v-if="instance.externalLink?.trim().length != 0"
           class="btn-icon"
@@ -33,12 +31,12 @@
         >
           <heroicons-outline:external-link class="w-4 h-4" />
         </button>
-      </BBTableCell>
-      <BBTableCell class="w-16">
+      </div>
+      <div class="bb-grid-cell">
         {{ humanizeTs(instance.createdTs) }}
-      </BBTableCell>
+      </div>
     </template>
-  </BBTable>
+  </BBGrid>
 </template>
 
 <script lang="ts">
@@ -50,6 +48,7 @@ import { EnvironmentId, Instance } from "@/types";
 import { useEnvironmentStore } from "@/store";
 import InstanceEngineIcon from "./InstanceEngineIcon.vue";
 import ProtectedEnvironmentIcon from "./Environment/ProtectedEnvironmentIcon.vue";
+import { BBGridColumn } from "@/bbkit";
 
 export default defineComponent({
   name: "InstanceTable",
@@ -65,31 +64,42 @@ export default defineComponent({
 
     const router = useRouter();
 
-    const columnList = computed(() => {
+    const columnList = computed((): BBGridColumn[] => {
       return [
         {
           title: "",
+          width: "minmax(auto, 4rem)",
         },
         {
           title: t("common.name"),
+          width: "minmax(auto, 3fr)",
         },
         {
           title: t("common.environment"),
+          width: "minmax(auto, 1fr)",
         },
         {
           title: t("common.Address"),
+          width: "minmax(auto, 2fr)",
         },
         {
           title: t("instance.external-link"),
+          width: { sm: "1fr" },
+          class: "hidden sm:flex",
         },
         {
           title: t("common.created-at"),
+          width: "minmax(auto, 8rem)",
         },
       ];
     });
 
-    const clickInstance = (section: number, row: number, e: MouseEvent) => {
-      const instance = props.instanceList[row];
+    const clickInstance = (
+      instance: Instance,
+      section: number,
+      row: number,
+      e: MouseEvent
+    ) => {
       const url = `/instance/${instanceSlug(instance)}`;
       if (e.ctrlKey || e.metaKey) {
         window.open(url, "_blank");


### PR DESCRIPTION
Benefiting from using `display: grid`, we may control the columns' widths more precisely, responsively, and flexibly. Especially when the columns are mixed with fixed width, auto width and flex width.

We may replace some `<BBTable>`s with `<BBGrid>`. Starting from the `<InstanceTable>`, which is not too complex.

### Screenshots


https://user-images.githubusercontent.com/2749742/207763023-c3577eca-d7a9-42ad-9c3b-4dae1f68c53d.mp4

