### PR TITLE
feat: support new version reminder

### DIFF
--- a/frontend/src/components/ReleaseRemindModal.vue
+++ b/frontend/src/components/ReleaseRemindModal.vue
@@ -34,8 +34,8 @@
           type="button"
           class="btn-primary"
           target="_blank"
-          @click="$emit('cancel')"
           :href="actuatorStore.releaseInfo.latest?.html_url"
+          @click="$emit('cancel')"
         >
           {{ $t("common.learn-more") }}
         </a>

--- a/frontend/src/components/ReleaseRemindModal.vue
+++ b/frontend/src/components/ReleaseRemindModal.vue
@@ -8,7 +8,13 @@
         <p class="whitespace-pre-wrap">
           <i18n-t keypath="settings.release.new-version-content">
             <template #tag>
-              <strong>{{ actuatorStore.releaseInfo.latest?.tag_name }}</strong>
+              <a
+                class="font-bold underline"
+                target="_blank"
+                :href="actuatorStore.releaseInfo.latest?.html_url"
+              >
+                {{ actuatorStore.releaseInfo.latest?.tag_name }}
+              </a>
             </template>
           </i18n-t>
         </p>
@@ -34,7 +40,7 @@
           type="button"
           class="btn-primary"
           target="_blank"
-          :href="actuatorStore.releaseInfo.latest?.html_url"
+          href="https://www.bytebase.com/docs/get-started/install/overview"
           @click="$emit('cancel')"
         >
           {{ $t("common.learn-more") }}

--- a/frontend/src/components/ReleaseRemindModal.vue
+++ b/frontend/src/components/ReleaseRemindModal.vue
@@ -1,0 +1,53 @@
+<template>
+  <BBModal
+    :title="$t('settings.release.new-version-available')"
+    @close="$emit('cancel')"
+  >
+    <div class="min-w-0 md:min-w-400">
+      <div>
+        <p class="whitespace-pre-wrap">
+          <i18n-t keypath="settings.release.new-version-content">
+            <template #tag>
+              <strong>{{ actuatorStore.releaseInfo.lastest?.tag_name }}</strong>
+            </template>
+          </i18n-t>
+        </p>
+        <BBCheckbox
+          class="mt-3 ml-1"
+          :title="$t('settings.release.not-show-till-next-release')"
+          :value="actuatorStore.releaseInfo.ignoreRemindModalTillNextRelease"
+          @toggle="
+            (on) =>
+              (actuatorStore.releaseInfo.ignoreRemindModalTillNextRelease = on)
+          "
+        />
+      </div>
+      <div class="mt-7 flex justify-end space-x-2">
+        <button
+          type="button"
+          class="btn-normal"
+          @click.prevent="$emit('cancel')"
+        >
+          {{ $t("common.dismiss") }}
+        </button>
+        <a
+          type="button"
+          class="btn-primary"
+          target="_blank"
+          @click="$emit('cancel')"
+          :href="actuatorStore.releaseInfo.lastest?.html_url"
+        >
+          {{ $t("common.learn-more") }}
+        </a>
+      </div>
+    </div>
+  </BBModal>
+</template>
+
+<script lang="ts" setup>
+import { useActuatorStore } from "@/store";
+
+defineEmits(["cancel"]);
+
+const actuatorStore = useActuatorStore();
+</script>

--- a/frontend/src/components/ReleaseRemindModal.vue
+++ b/frontend/src/components/ReleaseRemindModal.vue
@@ -8,7 +8,7 @@
         <p class="whitespace-pre-wrap">
           <i18n-t keypath="settings.release.new-version-content">
             <template #tag>
-              <strong>{{ actuatorStore.releaseInfo.lastest?.tag_name }}</strong>
+              <strong>{{ actuatorStore.releaseInfo.latest?.tag_name }}</strong>
             </template>
           </i18n-t>
         </p>
@@ -35,7 +35,7 @@
           class="btn-primary"
           target="_blank"
           @click="$emit('cancel')"
-          :href="actuatorStore.releaseInfo.lastest?.html_url"
+          :href="actuatorStore.releaseInfo.latest?.html_url"
         >
           {{ $t("common.learn-more") }}
         </a>

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -61,8 +61,8 @@
               @click="state.showReleaseModal = canUpgrade"
             >
               <heroicons-outline:lightning-bolt
-                class="h-6 w-6"
                 v-if="canUpgrade"
+                class="h-6 w-6"
               />
               {{ version }}
               <span v-if="gitCommit" class="tooltip"
@@ -127,8 +127,8 @@
             @click="state.showReleaseModal = canUpgrade"
           >
             <heroicons-outline:lightning-bolt
-              class="h-6 w-6"
               v-if="canUpgrade"
+              class="h-6 w-6"
             />
             {{ version }}
             <span v-if="gitCommit" class="tooltip"

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -51,7 +51,19 @@
               <heroicons-solid:sparkles class="w-5 h-5" />
               {{ $t(currentPlan) }}
             </div>
-            <div class="text-sm ml-auto text-control-light tooltip-wrapper">
+            <div
+              class="text-sm flex ml-auto tooltip-wrapper"
+              :class="
+                canUpgrade
+                  ? 'text-success cursor-pointer'
+                  : 'text-control-light cursor-default'
+              "
+              @click="state.showReleaseModal = canUpgrade"
+            >
+              <heroicons-outline:lightning-bolt
+                class="h-6 w-6"
+                v-if="canUpgrade"
+              />
               {{ version }}
               <span v-if="gitCommit" class="tooltip"
                 >Git hash {{ gitCommit }}</span
@@ -106,8 +118,18 @@
             {{ $t(currentPlan) }}
           </div>
           <div
-            class="text-sm ml-auto text-control-light tooltip-wrapper whitespace-nowrap truncate"
+            class="text-sm flex ml-auto tooltip-wrapper whitespace-nowrap truncate"
+            :class="
+              canUpgrade
+                ? 'text-success cursor-pointer'
+                : 'text-control-light cursor-default'
+            "
+            @click="state.showReleaseModal = canUpgrade"
           >
+            <heroicons-outline:lightning-bolt
+              class="h-6 w-6"
+              v-if="canUpgrade"
+            />
             {{ version }}
             <span v-if="gitCommit" class="tooltip"
               >Git hash {{ gitCommit }}</span
@@ -166,6 +188,10 @@
     v-if="state.showTrialModal"
     @cancel="state.showTrialModal = false"
   />
+  <ReleaseRemindModal
+    v-if="state.showReleaseModal"
+    @cancel="state.showReleaseModal = false"
+  />
 </template>
 
 <script lang="ts">
@@ -187,6 +213,7 @@ import {
 interface LocalState {
   showMobileOverlay: boolean;
   showTrialModal: boolean;
+  showReleaseModal: boolean;
 }
 
 export default defineComponent({
@@ -205,6 +232,15 @@ export default defineComponent({
     const state = reactive<LocalState>({
       showMobileOverlay: false,
       showTrialModal: false,
+      showReleaseModal: false,
+    });
+
+    actuatorStore.tryToRemindRelease().then((openRemindModal) => {
+      state.showReleaseModal = openRemindModal;
+    });
+
+    const canUpgrade = computed(() => {
+      return actuatorStore.hasNewRelease;
     });
 
     const currentUser = useCurrentUser();
@@ -302,6 +338,7 @@ export default defineComponent({
       gitCommit,
       currentPlan,
       isFreePlan,
+      canUpgrade,
     };
   },
 });

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -52,7 +52,7 @@
               {{ $t(currentPlan) }}
             </div>
             <div
-              class="text-sm flex ml-auto tooltip-wrapper"
+              class="text-sm flex items-center gap-x-1 ml-auto tooltip-wrapper"
               :class="
                 canUpgrade
                   ? 'text-success cursor-pointer'
@@ -60,10 +60,7 @@
               "
               @click="state.showReleaseModal = canUpgrade"
             >
-              <heroicons-outline:lightning-bolt
-                v-if="canUpgrade"
-                class="h-6 w-6"
-              />
+              <heroicons-outline:volume-up v-if="canUpgrade" class="h-4 w-4" />
               {{ version }}
               <span v-if="gitCommit" class="tooltip"
                 >Git hash {{ gitCommit }}</span
@@ -118,7 +115,7 @@
             {{ $t(currentPlan) }}
           </div>
           <div
-            class="text-sm flex ml-auto tooltip-wrapper whitespace-nowrap truncate"
+            class="text-xs flex items-center gap-x-1 ml-auto tooltip-wrapper whitespace-nowrap"
             :class="
               canUpgrade
                 ? 'text-success cursor-pointer'
@@ -126,14 +123,14 @@
             "
             @click="state.showReleaseModal = canUpgrade"
           >
-            <heroicons-outline:lightning-bolt
-              v-if="canUpgrade"
-              class="h-6 w-6"
-            />
+            <heroicons-outline:volume-up v-if="canUpgrade" class="h-4 w-4" />
             {{ version }}
-            <span v-if="gitCommit" class="tooltip"
-              >Git hash {{ gitCommit }}</span
-            >
+            <span v-if="canUpgrade" class="tooltip whitespace-nowrap">
+              {{ $t("settings.release.new-version-available") }}
+            </span>
+            <span v-else-if="gitCommit" class="tooltip">
+              Git hash {{ gitCommit }}
+            </span>
           </div>
         </div>
       </div>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -427,7 +427,7 @@
     },
     "release": {
       "new-version-available": "New version available!",
-      "new-version-content": "The new version {tag} is available now! Please go to the GitHub to check the lastest release.",
+      "new-version-content": "The new version {tag} is available now! Please go to the GitHub to check the latest release.",
       "not-show-till-next-release": "Don't show this till next version"
     }
   },

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -426,7 +426,7 @@
       "remove-policy-tips": "Remove this rule?"
     },
     "release": {
-      "new-version-available": "New version available!",
+      "new-version-available": "New version is available",
       "new-version-content": "The new version {tag} is available now! Please check our docs for installation.",
       "not-show-till-next-release": "Don't show this till next version"
     }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -427,7 +427,7 @@
     },
     "release": {
       "new-version-available": "New version available!",
-      "new-version-content": "The new version {tag} is available now! Please go to the GitHub to check the latest release.",
+      "new-version-content": "The new version {tag} is available now! Please check our docs for installation.",
       "not-show-till-next-release": "Don't show this till next version"
     }
   },

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -424,6 +424,11 @@
       "description": "Allow developers to execute queries for the following databases in the protected environments from SQL Editor.",
       "add-rule": "Add rule",
       "remove-policy-tips": "Remove this rule?"
+    },
+    "release": {
+      "new-version-available": "New version available!",
+      "new-version-content": "The new version {tag} is available now! Please go to the GitHub to check the lastest release.",
+      "not-show-till-next-release": "Don't show this till next version"
     }
   },
   "activity": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -427,7 +427,7 @@
     },
     "release": {
       "new-version-available": "更新提醒",
-      "new-version-content": "新版本 {tag} 正式发布！请到 GitHub 查看最新的 release 信息。",
+      "new-version-content": "新版本 {tag} 正式发布！请根据我们的文档来获取新版本。",
       "not-show-till-next-release": "在下次更新前不要提醒我"
     }
   },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -424,6 +424,11 @@
       "description": "允许开发者通过 SQL 编辑器对下列受保护环境中的数据库执行查询。",
       "add-rule": "添加规则",
       "remove-policy-tips": "删除这条规则？"
+    },
+    "release": {
+      "new-version-available": "更新提醒",
+      "new-version-content": "新版本 {tag} 正式发布！请到 GitHub 查看最新的 release 信息。",
+      "not-show-till-next-release": "在下次更新前不要提醒我"
     }
   },
   "activity": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -426,7 +426,7 @@
       "remove-policy-tips": "删除这条规则？"
     },
     "release": {
-      "new-version-available": "更新提醒",
+      "new-version-available": "有新版本可更新",
       "new-version-content": "新版本 {tag} 正式发布！请根据我们的文档来获取新版本。",
       "not-show-till-next-release": "在下次更新前不要提醒我"
     }

--- a/frontend/src/store/modules/actuator.ts
+++ b/frontend/src/store/modules/actuator.ts
@@ -1,13 +1,21 @@
 import axios from "axios";
 import { defineStore } from "pinia";
-import { ActuatorState, ServerInfo } from "@/types";
+import { ActuatorState, ServerInfo, Release } from "@/types";
+import { useLocalStorage } from "@vueuse/core";
+import { semverCompare } from "@/utils";
 
 const EXTERNAL_URL_PLACEHOLDER =
   "https://www.bytebase.com/docs/get-started/install/external-url";
+const GITHUB_API_LIST_BYTEBASE_RELEASE =
+  "https://api.github.com/repos/bytebase/bytebase/releases";
 
 export const useActuatorStore = defineStore("actuator", {
   state: (): ActuatorState => ({
     serverInfo: undefined,
+    releaseInfo: useLocalStorage("bytebase_release", {
+      ignoreRemindModalTillNextRelease: false,
+      nextCheckTs: 0,
+    }),
   }),
   getters: {
     info: (state) => {
@@ -31,6 +39,16 @@ export const useActuatorStore = defineStore("actuator", {
     needConfigureExternalUrl: (state) => {
       return state.serverInfo?.externalUrl === EXTERNAL_URL_PLACEHOLDER;
     },
+    hasNewRelease: (state) => {
+      return (
+        (state.serverInfo?.version === "development" &&
+          !!state.releaseInfo.lastest?.tag_name) ||
+        semverCompare(
+          state.releaseInfo.lastest?.tag_name ?? "",
+          state.serverInfo?.version ?? ""
+        )
+      );
+    },
   },
   actions: {
     setServerInfo(serverInfo: ServerInfo) {
@@ -43,6 +61,50 @@ export const useActuatorStore = defineStore("actuator", {
       this.setServerInfo(serverInfo);
 
       return serverInfo;
+    },
+    async tryToRemindRelease(): Promise<boolean> {
+      if (!this.releaseInfo.lastest) {
+        const relase = await this.fetchLastestRelease();
+        this.releaseInfo.lastest = relase;
+      }
+      if (!this.releaseInfo.lastest) {
+        return false;
+      }
+
+      // It's time to fetch the release
+      if (new Date().getTime() >= this.releaseInfo.nextCheckTs) {
+        const relase = await this.fetchLastestRelease();
+        if (!relase) {
+          return false;
+        }
+
+        // check till 24 hours later
+        this.releaseInfo.nextCheckTs =
+          new Date().getTime() + 24 * 60 * 60 * 1000;
+
+        if (semverCompare(relase.tag_name, this.releaseInfo.lastest.tag_name)) {
+          this.releaseInfo.ignoreRemindModalTillNextRelease = false;
+        }
+
+        this.releaseInfo.lastest = relase;
+      }
+
+      if (this.releaseInfo.ignoreRemindModalTillNextRelease) {
+        return false;
+      }
+
+      return this.hasNewRelease;
+    },
+    async fetchLastestRelease(): Promise<Release | undefined> {
+      try {
+        const { data: releaseList } = await axios.get<Release[]>(
+          `${GITHUB_API_LIST_BYTEBASE_RELEASE}?per_page=1`
+        );
+        return releaseList[0];
+      } catch {
+        // It's okay to ignore the failure and just return undefined.
+        return;
+      }
     },
   },
 });

--- a/frontend/src/store/modules/actuator.ts
+++ b/frontend/src/store/modules/actuator.ts
@@ -42,9 +42,9 @@ export const useActuatorStore = defineStore("actuator", {
     hasNewRelease: (state) => {
       return (
         (state.serverInfo?.version === "development" &&
-          !!state.releaseInfo.lastest?.tag_name) ||
+          !!state.releaseInfo.latest?.tag_name) ||
         semverCompare(
-          state.releaseInfo.lastest?.tag_name ?? "",
+          state.releaseInfo.latest?.tag_name ?? "",
           state.serverInfo?.version ?? ""
         )
       );
@@ -63,17 +63,17 @@ export const useActuatorStore = defineStore("actuator", {
       return serverInfo;
     },
     async tryToRemindRelease(): Promise<boolean> {
-      if (!this.releaseInfo.lastest) {
-        const relase = await this.fetchLastestRelease();
-        this.releaseInfo.lastest = relase;
+      if (!this.releaseInfo.latest) {
+        const relase = await this.fetchLatestRelease();
+        this.releaseInfo.latest = relase;
       }
-      if (!this.releaseInfo.lastest) {
+      if (!this.releaseInfo.latest) {
         return false;
       }
 
       // It's time to fetch the release
       if (new Date().getTime() >= this.releaseInfo.nextCheckTs) {
-        const relase = await this.fetchLastestRelease();
+        const relase = await this.fetchLatestRelease();
         if (!relase) {
           return false;
         }
@@ -82,11 +82,11 @@ export const useActuatorStore = defineStore("actuator", {
         this.releaseInfo.nextCheckTs =
           new Date().getTime() + 24 * 60 * 60 * 1000;
 
-        if (semverCompare(relase.tag_name, this.releaseInfo.lastest.tag_name)) {
+        if (semverCompare(relase.tag_name, this.releaseInfo.latest.tag_name)) {
           this.releaseInfo.ignoreRemindModalTillNextRelease = false;
         }
 
-        this.releaseInfo.lastest = relase;
+        this.releaseInfo.latest = relase;
       }
 
       if (this.releaseInfo.ignoreRemindModalTillNextRelease) {
@@ -95,7 +95,7 @@ export const useActuatorStore = defineStore("actuator", {
 
       return this.hasNewRelease;
     },
-    async fetchLastestRelease(): Promise<Release | undefined> {
+    async fetchLatestRelease(): Promise<Release | undefined> {
       try {
         const { data: releaseList } = await axios.get<Release[]>(
           `${GITHUB_API_LIST_BYTEBASE_RELEASE}?per_page=1`

--- a/frontend/src/types/actuator.ts
+++ b/frontend/src/types/actuator.ts
@@ -20,7 +20,7 @@ export type Release = {
 };
 
 export type ReleaseInfo = {
-  lastest?: Release;
+  latest?: Release;
   ignoreRemindModalTillNextRelease: boolean;
   // The next check timestamp in milliseconds.
   nextCheckTs: number;

--- a/frontend/src/types/actuator.ts
+++ b/frontend/src/types/actuator.ts
@@ -8,3 +8,20 @@ export type ServerInfo = {
   needAdminSetup: boolean;
   startedTs: number;
 };
+
+export type Release = {
+  draft: boolean;
+  prerelease: boolean;
+  name: string;
+  tag_name: string;
+  html_url: string;
+  body: string;
+  published_at: string;
+};
+
+export type ReleaseInfo = {
+  lastest?: Release;
+  ignoreRemindModalTillNextRelease: boolean;
+  // The next check timestamp in milliseconds.
+  nextCheckTs: number;
+};

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -48,11 +48,14 @@ import { Table } from "./table";
 import { VCS } from "./vcs";
 import { Label } from "./label";
 import { ConnectionAtom } from "./sqlEditor";
+import { ReleaseInfo } from "./actuator";
 import type { DebugLog } from "@/types/debug";
 import type { AuditLog } from "@/types/auditLog";
+import { RemovableRef } from "@vueuse/core";
 
 export interface ActuatorState {
   serverInfo?: ServerInfo;
+  releaseInfo: RemovableRef<ReleaseInfo>;
 }
 
 export interface AuthState {


### PR DESCRIPTION
We will fetch the GitHub release API to find the latest version and show the reminder modal.
Users can choose not to show this modal till the next release.
It's okay to fail as some users may not connect to the internet.

Close BYT-745

![CleanShot 2022-12-15 at 12 36 27](https://user-images.githubusercontent.com/10706318/207776742-370e54ce-7bfa-46fc-a6f3-6be712f498f9.gif)
![CleanShot 2022-12-15 at 12 49 07](https://user-images.githubusercontent.com/10706318/207776753-82fd086f-dd85-4e42-9f90-c2780af2cbdd.gif)

BTW I don’t have other suitable icons to mean "new version available"..

<img width="248" alt="CleanShot 2022-12-15 at 13 03 09@2x" src="https://user-images.githubusercontent.com/10706318/207776833-514f441b-aef3-46f2-838d-a8ba4ae8599a.png">

<img width="562" alt="CleanShot 2022-12-15 at 13 03 17@2x" src="https://user-images.githubusercontent.com/10706318/207776835-e6fde13d-17de-45ff-9413-69d24d8c6147.png">
