### PR TITLE
refactor(frontend): make use of multiple typePrefixes to reduce request count

### DIFF
--- a/frontend/src/components/ProjectActivityPanel.vue
+++ b/frontend/src/components/ProjectActivityPanel.vue
@@ -35,20 +35,13 @@ export default defineComponent({
     const activityStore = useActivityStore();
 
     const prepareActivityList = () => {
-      const requests = [
-        activityStore.fetchActivityListForDatabaseByProjectId({
+      activityStore
+        .fetchActivityListForProject({
           projectId: props.project.id,
-        }),
-        activityStore.fetchActivityListForProject({
-          projectId: props.project.id,
-        }),
-      ];
-
-      Promise.all(requests).then((lists) => {
-        const flattenList = lists.flatMap((list) => list);
-        flattenList.sort((a, b) => -(a.createdTs - b.createdTs)); // by createdTs DESC
-        state.activityList = flattenList;
-      });
+        })
+        .then((list) => {
+          state.activityList = list;
+        });
     };
 
     onBeforeMount(prepareActivityList);

--- a/frontend/src/components/ProjectOverviewPanel.vue
+++ b/frontend/src/components/ProjectOverviewPanel.vue
@@ -145,24 +145,15 @@ export default defineComponent({
     const prepareActivityList = () => {
       state.isFetchingActivityList = true;
       state.activityList = [];
-      const requests = [
-        activityStore.fetchActivityListForDatabaseByProjectId({
+      activityStore
+        .fetchActivityListForProject({
           projectId: props.project.id,
           limit: ACTIVITY_LIMIT,
-        }),
-        activityStore.fetchActivityListForProject({
-          projectId: props.project.id,
-          limit: ACTIVITY_LIMIT,
-        }),
-      ];
-
-      Promise.all(requests).then((lists) => {
-        const flattenList = lists.flatMap((list) => list);
-        flattenList.sort((a, b) => -(a.createdTs - b.createdTs)); // by createdTs DESC
-        state.activityList = flattenList.slice(0, ACTIVITY_LIMIT);
-
-        state.isFetchingActivityList = false;
-      });
+        })
+        .then((list) => {
+          state.activityList = list.slice(0, ACTIVITY_LIMIT);
+          state.isFetchingActivityList = false;
+        });
     };
 
     const isTenantProject = computed((): boolean => {


### PR DESCRIPTION
With the help of https://github.com/bytebase/bytebase/pull/3823, we can reduce the requests made to fetch activities (by specifying all typePrefixes we need in one try).

This PR is also to pave the road of pagination for activities.