### PR TITLE
feat: support finding activities with multiple levels

### DIFF
--- a/api/activity.go
+++ b/api/activity.go
@@ -253,7 +253,7 @@ type ActivityFind struct {
 	// Domain specific fields
 	CreatorID      *int
 	TypePrefixList []string
-	Level          *ActivityLevel
+	LevelList      []ActivityLevel
 	ContainerID    *int
 	Limit          *int
 	// If specified, sorts the returned list by created_ts in <<ORDER>>

--- a/server/activity.go
+++ b/server/activity.go
@@ -68,9 +68,12 @@ func (s *Server) registerActivityRoutes(g *echo.Group) {
 		if typePrefixList := c.QueryParams()["typePrefix"]; typePrefixList != nil {
 			activityFind.TypePrefixList = typePrefixList
 		}
-		if levelStr := c.QueryParams().Get("level"); levelStr != "" {
-			activityLevel := api.ActivityLevel(levelStr)
-			activityFind.Level = &activityLevel
+		if levelList := c.QueryParams()["level"]; levelList != nil {
+			list := make([]api.ActivityLevel, len(levelList))
+			for i, level := range levelList {
+				list[i] = api.ActivityLevel(level)
+			}
+			activityFind.LevelList = list
 		}
 		if containerIDStr := c.QueryParams().Get("container"); containerIDStr != "" {
 			containerID, err := strconv.Atoi(containerIDStr)

--- a/store/activity.go
+++ b/store/activity.go
@@ -344,7 +344,7 @@ func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*a
 	if v := find.CreatorID; v != nil {
 		where, args = append(where, fmt.Sprintf("creator_id = $%d", len(args)+1)), append(args, *v)
 	}
-	if v := find.TypePrefixList; v != nil {
+	if v := find.TypePrefixList; len(v) > 0 {
 		var queryValues []string
 		// Iterate over the typePrefix list and join each one with an OR condition.
 		for _, str := range v {
@@ -352,7 +352,7 @@ func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*a
 		}
 		where = append(where, fmt.Sprintf("(%s)", strings.Join(queryValues, " OR ")))
 	}
-	if v := find.LevelList; v != nil {
+	if v := find.LevelList; len(v) > 0 {
 		var queryValues []string
 		for _, level := range v {
 			queryValues, args = append(queryValues, fmt.Sprintf("level = $%d", len(args)+1)), append(args, level)

--- a/store/activity.go
+++ b/store/activity.go
@@ -352,8 +352,12 @@ func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*a
 		}
 		where = append(where, fmt.Sprintf("(%s)", strings.Join(queryValues, " OR ")))
 	}
-	if v := find.Level; v != nil {
-		where, args = append(where, fmt.Sprintf("level = $%d", len(args)+1)), append(args, *v)
+	if v := find.LevelList; v != nil {
+		var queryValues []string
+		for _, level := range v {
+			queryValues, args = append(queryValues, fmt.Sprintf("level = $%d", len(args)+1)), append(args, level)
+		}
+		where = append(where, fmt.Sprintf("(%s)", strings.Join(queryValues, " OR ")))
 	}
 
 	var query = `


### PR DESCRIPTION
Similar to https://github.com/bytebase/bytebase/pull/3823, but support the `level` field this time.

Make it possible to get activities with a range of levels. Now with a request to `/api/activity?level=INFO&level=WARN`, we'll get activities that are either of the INFO level or of the WARN level.

I'm making this change because I'm adding pagination support to activities (also audit logs), and [here](https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/frontend/src/store/modules/activity.ts?L164) at the front-end we are using two separate requests to fetch activities of either INFO level or WARN level. We can support it on the server side to not only reduce client-side requests but also make it easy for pagination.