### PR TITLE
refactor(frontend): split the connectionTree in sqlEditorStore into an independent module

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -37,7 +37,6 @@ import {
   useSQLReviewStore,
   useProjectStore,
   useTableStore,
-  useSQLEditorStore,
   useSheetStore,
   useAuthStore,
   useDatabaseStore,
@@ -47,6 +46,7 @@ import {
   usePrincipalStore,
   useRouterStore,
   useDBSchemaStore,
+  useConnectionTreeStore,
 } from "@/store";
 
 const HOME_MODULE = "workspace.home";
@@ -1426,13 +1426,13 @@ router.beforeEach((to, from, next) => {
     const databaseId = idFromSlug(databaseSlug);
     if (Number.isNaN(databaseId)) {
       // Connected to instance
-      useSQLEditorStore()
+      useConnectionTreeStore()
         .fetchConnectionByInstanceId(instanceId)
         .then(() => next())
         .catch(() => next());
     } else {
       // Connected to db
-      useSQLEditorStore()
+      useConnectionTreeStore()
         .fetchConnectionByInstanceIdAndDatabaseId(instanceId, databaseId)
         .then(() => next())
         .catch(() => next());

--- a/frontend/src/store/modules/connectionTree.ts
+++ b/frontend/src/store/modules/connectionTree.ts
@@ -1,0 +1,133 @@
+import { defineStore } from "pinia";
+import {
+  DatabaseId,
+  InstanceId,
+  Connection,
+  Policy,
+  ConnectionAtom,
+} from "@/types";
+import { ConnectionTreeState, UNKNOWN_ID, unknown } from "@/types";
+import { useDatabaseStore } from "./database";
+import { useInstanceStore } from "./instance";
+import { useTableStore } from "./table";
+import { emptyConnection } from "@/utils";
+import { reactive, ref } from "vue";
+
+export const useConnectionTreeStore = defineStore("connectionTree", () => {
+  // states
+  const accessControlPolicyList = ref<Policy[]>([]);
+  const tree = reactive({
+    data: [] as ConnectionAtom[],
+    state: ConnectionTreeState.UNSET,
+  });
+  const expandedTreeNodeKeys = ref<string[]>([]);
+  const selectedTable = unknown("TABLE");
+
+  // actions
+  const fetchConnectionByInstanceIdAndDatabaseId = async (
+    instanceId: InstanceId,
+    databaseId: DatabaseId
+  ): Promise<Connection> => {
+    try {
+      await Promise.all([
+        useDatabaseStore().getOrFetchDatabaseById(databaseId),
+        useInstanceStore().getOrFetchInstanceById(instanceId),
+        useTableStore().getOrFetchTableListByDatabaseId(databaseId),
+      ]);
+
+      return {
+        instanceId,
+        databaseId,
+      };
+    } catch {
+      // Fallback to disconnected if error occurs such as 404.
+      return { instanceId: UNKNOWN_ID, databaseId: UNKNOWN_ID };
+    }
+  };
+  const fetchConnectionByInstanceId = async (
+    instanceId: InstanceId
+  ): Promise<Connection> => {
+    try {
+      const [databaseList] = await Promise.all([
+        useDatabaseStore().getDatabaseListByInstanceId(instanceId),
+        useInstanceStore().getOrFetchInstanceById(instanceId),
+      ]);
+      const tableStore = useTableStore();
+      await Promise.all(
+        databaseList.map((db) =>
+          tableStore.getOrFetchTableListByDatabaseId(db.id)
+        )
+      );
+
+      return {
+        instanceId,
+        databaseId: UNKNOWN_ID,
+      };
+    } catch {
+      // Fallback to disconnected if error occurs such as 404.
+      return { instanceId: UNKNOWN_ID, databaseId: UNKNOWN_ID };
+    }
+  };
+
+  return {
+    accessControlPolicyList,
+    tree,
+    expandedTreeNodeKeys,
+    selectedTable,
+    fetchConnectionByInstanceIdAndDatabaseId,
+    fetchConnectionByInstanceId,
+  };
+});
+
+export const searchConnectionByName = (
+  instanceId: InstanceId,
+  databaseId: DatabaseId,
+  instanceName: string,
+  databaseName: string
+): Connection => {
+  const connection = emptyConnection();
+  const store = useConnectionTreeStore();
+
+  if (instanceId !== UNKNOWN_ID) {
+    // If we found instanceId and/or databaseId, use the IDs first.
+    connection.instanceId = instanceId;
+    if (databaseId !== UNKNOWN_ID) {
+      connection.databaseId = databaseId;
+    }
+
+    return connection;
+  }
+
+  // Search the instance and database by name otherwise.
+  // Remain this part for legacy sheet support.
+  const rootNodes = store.tree.data;
+  for (let i = 0; i < rootNodes.length; i++) {
+    const maybeInstanceNode = rootNodes[i];
+    if (maybeInstanceNode.type !== "instance") {
+      // Skip if we met dirty data.
+      continue;
+    }
+    if (maybeInstanceNode.label === instanceName) {
+      connection.instanceId = maybeInstanceNode.id;
+      if (databaseName) {
+        const { children = [] } = maybeInstanceNode;
+        for (let j = 0; j < children.length; j++) {
+          const maybeDatabaseNode = children[j];
+          if (maybeDatabaseNode.type !== "database") {
+            // Skip if we met dirty data.
+            continue;
+          }
+          if (maybeDatabaseNode.label === databaseName) {
+            connection.databaseId = maybeDatabaseNode.id;
+            // Don't go further since we've found the databaseId
+            break;
+          }
+        }
+      }
+      // Don't go further since we've found the instanceId
+      break;
+    }
+  }
+
+  return connection;
+};

--- a/frontend/src/store/modules/index.ts
+++ b/frontend/src/store/modules/index.ts
@@ -33,6 +33,7 @@ export * from "./stage";
 export * from "./sql";
 export * from "./sqlEditor";
 export * from "./webTerminal";
+export * from "./connectionTree";
 export * from "./subscription";
 export * from "./tab";
 export * from "./table";

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -1,35 +1,22 @@
 import { defineStore } from "pinia";
 import dayjs from "dayjs";
-import type {
+import {
   SQLEditorState,
   QueryInfo,
-  DatabaseId,
   QueryHistory,
-  InstanceId,
-  Connection,
   ActivitySQLEditorQueryPayload,
 } from "@/types";
-import { ConnectionTreeState, UNKNOWN_ID, unknown } from "@/types";
+import { UNKNOWN_ID } from "@/types";
 import { useActivityStore } from "./activity";
 import { useDatabaseStore } from "./database";
-import { useInstanceStore } from "./instance";
-import { useTableStore } from "./table";
 import { useSQLStore } from "./sql";
 import { useTabStore } from "./tab";
-import { emptyConnection } from "@/utils";
 
 // set the limit to 10000 temporarily to avoid the query timeout and page crash
 export const RESULT_ROWS_LIMIT = 10000;
 
 export const useSQLEditorStore = defineStore("sqlEditor", {
   state: (): SQLEditorState => ({
-    accessControlPolicyList: [],
-    connectionTree: {
-      data: [],
-      state: ConnectionTreeState.UNSET,
-    },
-    expandedTreeNodeKeys: [],
-    selectedTable: unknown("TABLE"),
     isShowExecutingHint: false,
     shouldFormatContent: false,
     // Related data and status
@@ -77,50 +64,6 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
 
       return queryResult;
     },
-    async fetchConnectionByInstanceIdAndDatabaseId(
-      instanceId: InstanceId,
-      databaseId: DatabaseId
-    ): Promise<Connection> {
-      try {
-        await Promise.all([
-          useDatabaseStore().getOrFetchDatabaseById(databaseId),
-          useInstanceStore().getOrFetchInstanceById(instanceId),
-          useTableStore().getOrFetchTableListByDatabaseId(databaseId),
-        ]);
-
-        return {
-          instanceId,
-          databaseId,
-        };
-      } catch {
-        // Fallback to disconnected if error occurs such as 404.
-        return { instanceId: UNKNOWN_ID, databaseId: UNKNOWN_ID };
-      }
-    },
-    async fetchConnectionByInstanceId(
-      instanceId: InstanceId
-    ): Promise<Connection> {
-      try {
-        const [databaseList] = await Promise.all([
-          useDatabaseStore().getDatabaseListByInstanceId(instanceId),
-          useInstanceStore().getOrFetchInstanceById(instanceId),
-        ]);
-        const tableStore = useTableStore();
-        await Promise.all(
-          databaseList.map((db) =>
-            tableStore.getOrFetchTableListByDatabaseId(db.id)
-          )
-        );
-
-        return {
-          instanceId,
-          databaseId: UNKNOWN_ID,
-        };
-      } catch {
-        // Fallback to disconnected if error occurs such as 404.
-        return { instanceId: UNKNOWN_ID, databaseId: UNKNOWN_ID };
-      }
-    },
     async fetchQueryHistoryList() {
       this.setIsFetchingQueryHistory(true);
       const activityList =
@@ -153,56 +96,3 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
     },
   },
 });
-
-export const searchConnectionByName = (
-  instanceId: InstanceId,
-  databaseId: DatabaseId,
-  instanceName: string,
-  databaseName: string
-): Connection => {
-  const connection = emptyConnection();
-  const store = useSQLEditorStore();
-
-  if (instanceId !== UNKNOWN_ID) {
-    // If we found instanceId and/or databaseId, use the IDs first.
-    connection.instanceId = instanceId;
-    if (databaseId !== UNKNOWN_ID) {
-      connection.databaseId = databaseId;
-    }
-
-    return connection;
-  }
-
-  // Search the instance and database by name otherwise.
-  // Remain this part for legacy sheet support.
-  const rootNodes = store.connectionTree.data;
-  for (let i = 0; i < rootNodes.length; i++) {
-    const maybeInstanceNode = rootNodes[i];
-    if (maybeInstanceNode.type !== "instance") {
-      // Skip if we met dirty data.
-      continue;
-    }
-    if (maybeInstanceNode.label === instanceName) {
-      connection.instanceId = maybeInstanceNode.id;
-      if (databaseName) {
-        const { children = [] } = maybeInstanceNode;
-        for (let j = 0; j < children.length; j++) {
-          const maybeDatabaseNode = children[j];
-          if (maybeDatabaseNode.type !== "database") {
-            // Skip if we met dirty data.
-            continue;
-          }
-          if (maybeDatabaseNode.label === databaseName) {
-            connection.databaseId = maybeDatabaseNode.id;
-            // Don't go further since we've found the databaseId
-            break;
-          }
-        }
-      }
-      // Don't go further since we've found the instanceId
-      break;
-    }
-  }
-
-  return connection;
-};

--- a/frontend/src/types/connectionTree.ts
+++ b/frontend/src/types/connectionTree.ts
@@ -1,0 +1,13 @@
+import { InstanceId, DatabaseId, TableId, ViewId } from "../types";
+
+export type ConnectionAtomType = "instance" | "database" | "table" | "view";
+export interface ConnectionAtom {
+  parentId: InstanceId | DatabaseId | TableId | ViewId;
+  id: InstanceId | DatabaseId | TableId | ViewId;
+  key: string;
+  label: string;
+  type?: ConnectionAtomType;
+  children?: ConnectionAtom[];
+  disabled?: boolean;
+  isLeaf?: boolean;
+}

--- a/frontend/src/types/connectionTree.ts
+++ b/frontend/src/types/connectionTree.ts
@@ -1,6 +1,13 @@
 import { InstanceId, DatabaseId, TableId, ViewId } from "../types";
 
 export type ConnectionAtomType = "instance" | "database" | "table" | "view";
+
+export enum ConnectionTreeState {
+  UNSET,
+  LOADING,
+  LOADED,
+}
+
 export interface ConnectionAtom {
   parentId: InstanceId | DatabaseId | TableId | ViewId;
   id: InstanceId | DatabaseId | TableId | ViewId;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -42,6 +42,7 @@ export * from "./db_extension";
 export * from "./label";
 export * from "./deployment";
 export * from "./sqlEditor";
+export * from "./connectionTree";
 export * from "./webTerminal";
 export * from "./tab";
 export * from "./subscription";

--- a/frontend/src/types/sqlEditor.ts
+++ b/frontend/src/types/sqlEditor.ts
@@ -1,24 +1,12 @@
 import type * as monaco from "monaco-editor";
-import { InstanceId, DatabaseId, TableId, ViewId, ActivityId } from "../types";
+import { InstanceId, DatabaseId, ActivityId } from "../types";
 import { Principal } from "./principal";
 
 export type EditorModel = monaco.editor.ITextModel;
 export type EditorPosition = monaco.Position;
 export type CompletionItems = monaco.languages.CompletionItem[];
 
-export type ConnectionAtomType = "instance" | "database" | "table" | "view";
 export type SQLDialect = "mysql" | "postgresql";
-
-export interface ConnectionAtom {
-  parentId: InstanceId | DatabaseId | TableId | ViewId;
-  id: InstanceId | DatabaseId | TableId | ViewId;
-  key: string;
-  label: string;
-  type?: ConnectionAtomType;
-  children?: ConnectionAtom[];
-  disabled?: boolean;
-  isLeaf?: boolean;
-}
 
 export enum SortText {
   DATABASE = "0",

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -48,7 +48,6 @@ import { Setting, SettingName } from "./setting";
 import { Table } from "./table";
 import { VCS } from "./vcs";
 import { Label } from "./label";
-import { ConnectionAtom } from "./sqlEditor";
 import { ReleaseInfo } from "./actuator";
 import type { DebugLog } from "@/types/debug";
 import type { AuditLog } from "@/types/auditLog";
@@ -214,13 +213,6 @@ export enum ConnectionTreeState {
 }
 
 export interface SQLEditorState {
-  accessControlPolicyList: Policy[];
-  connectionTree: {
-    data: ConnectionAtom[];
-    state: ConnectionTreeState;
-  };
-  expandedTreeNodeKeys: string[];
-  selectedTable: Table;
   shouldFormatContent: boolean;
   queryHistoryList: QueryHistory[];
   isFetchingQueryHistory: boolean;

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -206,12 +206,6 @@ export interface LabelState {
   labelList: Label[];
 }
 
-export enum ConnectionTreeState {
-  UNSET,
-  LOADING,
-  LOADED,
-}
-
 export interface SQLEditorState {
   shouldFormatContent: boolean;
   queryHistoryList: QueryHistory[];

--- a/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts" setup>
 import { computed } from "vue";
-import { useSQLEditorStore } from "@/store";
+import { useConnectionTreeStore } from "@/store";
 import DatabaseTree from "./DatabaseTree.vue";
 import QueryHistoryContainer from "./QueryHistoryContainer.vue";
 import TableSchema from "./TableSchema.vue";
@@ -32,16 +32,16 @@ import { unknown, UNKNOWN_ID } from "@/types";
 const FULL_HEIGHT = 100;
 const DATABASE_PANE_SIZE = 60;
 
-const sqlEditorStore = useSQLEditorStore();
+const connectionTreeStore = useConnectionTreeStore();
 const databasePaneSize = computed(() => {
-  if (sqlEditorStore.selectedTable.id !== UNKNOWN_ID) {
+  if (connectionTreeStore.selectedTable.id !== UNKNOWN_ID) {
     return DATABASE_PANE_SIZE;
   }
   return FULL_HEIGHT;
 });
 
 const handleCloseTableSchemaPane = () => {
-  sqlEditorStore.selectedTable = unknown("TABLE");
+  connectionTreeStore.selectedTable = unknown("TABLE");
 };
 </script>
 

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="sqlEditorStore.connectionTree.state === ConnectionTreeState.LOADED"
+    v-if="connectionTreeStore.tree.state === ConnectionTreeState.LOADED"
     class="databases-tree p-2 space-y-2 h-full"
   >
     <div class="databases-tree--input">
@@ -19,7 +19,7 @@
         :data="treeData"
         :pattern="searchPattern"
         :selected-keys="selectedKeys"
-        :expanded-keys="sqlEditorStore.expandedTreeNodeKeys"
+        :expanded-keys="connectionTreeStore.expandedTreeNodeKeys"
         :render-label="renderLabel"
         :render-prefix="renderPrefix"
         :render-suffix="renderSuffix"
@@ -61,11 +61,11 @@ import type {
 } from "@/types";
 import { ConnectionTreeState, TabMode, UNKNOWN_ID } from "@/types";
 import {
+  useConnectionTreeStore,
   useCurrentUser,
   useDatabaseStore,
   useInstanceStore,
   useIsLoggedIn,
-  useSQLEditorStore,
   useTableStore,
   useTabStore,
 } from "@/store";
@@ -97,7 +97,7 @@ const { t } = useI18n();
 
 const instanceStore = useInstanceStore();
 const databaseStore = useDatabaseStore();
-const sqlEditorStore = useSQLEditorStore();
+const connectionTreeStore = useConnectionTreeStore();
 const tableStore = useTableStore();
 const tabStore = useTabStore();
 const isLoggedIn = useIsLoggedIn();
@@ -164,7 +164,7 @@ const allowAdmin = computed(() =>
   )
 );
 
-const treeData = computed(() => sqlEditorStore.connectionTree.data);
+const treeData = computed(() => connectionTreeStore.tree.data);
 
 const setConnection = (
   option: ConnectionAtom,
@@ -208,7 +208,7 @@ const setConnection = (
       tableStore
         .getOrFetchTableByDatabaseIdAndTableId(databaseId, tableId)
         .then((table) => {
-          sqlEditorStore.selectedTable = table;
+          connectionTreeStore.selectedTable = table;
         });
     }
 
@@ -225,7 +225,7 @@ const renderLabel = ({ option }: { option: ConnectionAtom }) => {
   };
 
   if (option.type === "table") {
-    if (option.id === sqlEditorStore.selectedTable.id) {
+    if (option.id === connectionTreeStore.selectedTable.id) {
       emphasize();
     }
   }
@@ -380,7 +380,7 @@ const nodeProps = ({ option }: { option: ConnectionAtom }) => {
 };
 
 const updateExpandedKeys = (keys: string[]) => {
-  sqlEditorStore.expandedTreeNodeKeys = keys;
+  connectionTreeStore.expandedTreeNodeKeys = keys;
 };
 
 // When switching tabs, scroll the matched node into view if needed.
@@ -415,12 +415,12 @@ watch(
   ([isLoggedIn, instanceId, databaseId]) => {
     if (!isLoggedIn) {
       // Don't go further and cleanup the state if we signed out.
-      sqlEditorStore.expandedTreeNodeKeys = [];
+      connectionTreeStore.expandedTreeNodeKeys = [];
       return;
     }
 
     const maybeExpandKey = (key: string) => {
-      const keys = sqlEditorStore.expandedTreeNodeKeys;
+      const keys = connectionTreeStore.expandedTreeNodeKeys;
       if (!keys.includes(key)) {
         keys.push(key);
       }

--- a/frontend/src/views/sql-editor/AsidePanel/TableSchema.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/TableSchema.vue
@@ -69,14 +69,14 @@ import { stringify } from "qs";
 
 import type { Repository } from "@/types";
 import { baseDirectoryWebUrl, UNKNOWN_ID } from "@/types";
-import { useRepositoryStore, useSQLEditorStore } from "@/store";
+import { useConnectionTreeStore, useRepositoryStore } from "@/store";
 
 const emit = defineEmits<{
   (e: "close-pane"): void;
 }>();
 
-const sqlEditorStore = useSQLEditorStore();
-const table = computed(() => sqlEditorStore.selectedTable);
+const connectionTreeStore = useConnectionTreeStore();
+const table = computed(() => connectionTreeStore.selectedTable);
 
 const gotoAlterSchema = () => {
   if (table.value.id === UNKNOWN_ID) {


### PR DESCRIPTION
Both connectionTree and sqlEditor are getting more complex, so we split them into two.