### PR TITLE
feat(mongodb): sync mongodb index schema (part2)

### DIFF
--- a/frontend/src/components/IndexTable.vue
+++ b/frontend/src/components/IndexTable.vue
@@ -11,20 +11,28 @@
         class="w-16"
         :title="columnList[0].title"
       />
-      <BBTableHeaderCell class="w-4" :title="columnList[1].title" />
+      <BBTableHeaderCell
+        v-if="showPositionColumn"
+        class="w-4"
+        :title="columnList[1].title"
+      />
       <BBTableHeaderCell class="w-4" :title="columnList[2].title" />
       <BBTableHeaderCell
         v-if="showVisibleColumn"
         class="w-4"
         :title="columnList[3].title"
       />
-      <BBTableHeaderCell class="w-16" :title="columnList[4].title" />
+      <BBTableHeaderCell
+        v-if="showCommentColumn"
+        class="w-16"
+        :title="columnList[4].title"
+      />
     </template>
     <template #body="{ rowData: index }">
       <BBTableCell :left-padding="4">
         {{ index.expressions.join(",") }}
       </BBTableCell>
-      <BBTableCell>
+      <BBTableCell v-if="showPositionColumn">
         {{ index.position }}
       </BBTableCell>
       <BBTableCell>
@@ -63,7 +71,16 @@ export default defineComponent({
   setup(props) {
     const { t } = useI18n();
     const showVisibleColumn = computed(() => {
-      return props.database.instance.engine !== "POSTGRES";
+      return (
+        props.database.instance.engine !== "POSTGRES" &&
+        props.database.instance.engine !== "MONGODB"
+      );
+    });
+    const showPositionColumn = computed(() => {
+      return props.database.instance.engine !== "MONGODB";
+    });
+    const showCommentColumn = computed(() => {
+      return props.database.instance.engine !== "MONGODB";
     });
     const columnList = computed(() => [
       {
@@ -104,6 +121,8 @@ export default defineComponent({
       columnList,
       sectionList,
       showVisibleColumn,
+      showPositionColumn,
+      showCommentColumn,
     };
   },
 });

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -73,14 +73,16 @@ type Index struct {
 	Name string
 	// This could refer to a column or an expression.
 	Expression string
-	Position   int
-	// Type isn't supported for SQLite.
-	Type    string
-	Unique  bool
+	// Position isn't supported for MongoDB.
+	Position int
+	// Type isn't supported for SQLite, MongoDB.
+	Type   string
+	Unique bool
+	// Primary isn't supported for MongoDB.
 	Primary bool
-	// Visible isn't supported for Postgres, SQLite.
+	// Visible isn't supported for Postgres, SQLite, MongoDB.
 	Visible bool
-	// Comment isn't supported for SQLite.
+	// Comment isn't supported for SQLite, MongoDB.
 	Comment string
 }
 
@@ -127,7 +129,8 @@ type Table struct {
 	// CreateOptions isn't supported for Postgres, ClickHouse, Snowflake, SQLite, MongoDB.
 	CreateOptions string
 	// Comment isn't supported for SQLite, MongoDB.
-	Comment    string
+	Comment string
+	// Columnlist isn't supported for MongoDB.
 	ColumnList []Column
 	// IndexList isn't supported for ClickHouse, Snowflake.
 	IndexList []Index

--- a/plugin/db/mongodb/sync.go
+++ b/plugin/db/mongodb/sync.go
@@ -149,7 +149,7 @@ func (driver *Driver) syncAllIndexSchema(ctx context.Context, databaseName, coll
 		if err := indexCursor.Decode(&indexInfo); err != nil {
 			return nil, errors.Wrap(err, "failed to decode index info")
 		}
-		index, err := getIndexSchema(ctx, indexInfo)
+		index, err := getIndexSchema(indexInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/plugin/db/mongodb/sync.go
+++ b/plugin/db/mongodb/sync.go
@@ -161,7 +161,7 @@ func (driver *Driver) syncAllIndexSchema(ctx context.Context, databaseName, coll
 
 // getIndexSchema returns the index schema.
 // https://www.mongodb.com/docs/manual/reference/command/listIndexes/#output
-func getIndexSchema(ctx context.Context, indexInfo bson.M) (db.Index, error) {
+func getIndexSchema(indexInfo bson.M) (db.Index, error) {
 	var index db.Index
 	indexName, ok := indexInfo["name"]
 	if !ok {


### PR DESCRIPTION
After #3912, implement the sync index schema.

<img width="1354" alt="CleanShot 2022-12-16 at 23 53 48@2x" src="https://user-images.githubusercontent.com/87714218/208137551-82d2e1d6-845f-4ad1-ac8f-b14928f69d5c.png">

