### PR TITLE
feat: pagination support for activity list

### DIFF
--- a/api/activity.go
+++ b/api/activity.go
@@ -262,7 +262,7 @@ type ActivityFind struct {
 	LevelList      []ActivityLevel
 	ContainerID    *int
 	Limit          *int
-	// If specified, only find activities whose ID is smaller that SinceID.
+	// If specified, only find activities whose ID is smaller than SinceID.
 	SinceID *int
 	// If specified, sorts the returned list by created_ts in <<ORDER>>
 	// Different use cases want different orders.

--- a/api/activity.go
+++ b/api/activity.go
@@ -232,6 +232,12 @@ type Activity struct {
 	Payload string        `jsonapi:"attr,payload"`
 }
 
+// ActivityResponse is the API message for an activity response.
+type ActivityResponse struct {
+	ActivityList []*Activity `jsonapi:"relation,activityList"`
+	NextToken    string      `jsonapi:"attr,nextToken"`
+}
+
 // ActivityCreate is the API message for creating an activity.
 type ActivityCreate struct {
 	// Standard fields
@@ -256,6 +262,8 @@ type ActivityFind struct {
 	LevelList      []ActivityLevel
 	ContainerID    *int
 	Limit          *int
+	// If specified, only find activities whose ID is smaller that SinceID.
+	SinceID *int
 	// If specified, sorts the returned list by created_ts in <<ORDER>>
 	// Different use cases want different orders.
 	// e.g. Issue activity list wants ASC, while view recent activity list wants DESC.

--- a/frontend/src/store/modules/auditLog.ts
+++ b/frontend/src/store/modules/auditLog.ts
@@ -1,35 +1,49 @@
 import { watchEffect } from "vue";
 import { defineStore, storeToRefs } from "pinia";
 import axios from "axios";
-import type { AuditLogState, ResponseWithData, ResourceObjects } from "@/types";
-import { AuditActivityType } from "@/types";
+import type {
+  AuditLogState,
+  ResourceObject,
+  ResourceIdentifier,
+} from "@/types";
+import { AuditActivityType, empty, isPagedResponse } from "@/types";
 import type { AuditLog } from "@/types/auditLog";
+import { getPrincipalFromIncludedList } from "./principal";
+import { convertEntityList } from "./utils";
 
-const convertAuditLogList = (res: ResponseWithData): AuditLog[] => {
-  const activityList = res.data as ResourceObjects;
-  const auditLogList: AuditLog[] = activityList.map(
-    (activity) =>
-      ({
-        createdTs: activity.attributes.createdTs as number,
-        creator: res.included!.find(
-          (item) =>
-            item.id ===
-            (
-              activity.relationships!.creator.data as {
-                id: string;
-                type: string;
-              }
-            ).id
-        )?.attributes.email as string,
-        type: activity.attributes.type as string,
-        level: activity.attributes.level as string,
-        comment: activity.attributes.comment as string,
-        payload: activity.attributes.payload as string,
-      } as AuditLog)
-  );
-
-  return auditLogList;
+const convert = (
+  auditLog: ResourceObject,
+  includedList: ResourceObject[]
+): AuditLog => {
+  return {
+    ...(auditLog.attributes as Omit<AuditLog, "creator">),
+    creator: getPrincipalFromIncludedList(
+      auditLog.relationships!.creator.data,
+      includedList
+    )?.email as string,
+  };
 };
+
+function getAuditLogFromIncludedList(
+  data:
+    | ResourceIdentifier<ResourceObject>
+    | ResourceIdentifier<ResourceObject>[]
+    | undefined,
+  includedList: ResourceObject[]
+): AuditLog {
+  if (data == null) {
+    return empty("AUDIT_LOG");
+  }
+  for (const item of includedList || []) {
+    if (item.type !== "activity") {
+      continue;
+    }
+    if (item.id == (data as ResourceIdentifier).id) {
+      return convert(item, includedList);
+    }
+  }
+  return empty("AUDIT_LOG");
+}
 
 const typePrefixQuery = `${(
   Object.keys(AuditActivityType) as Array<keyof typeof AuditActivityType>
@@ -45,11 +59,27 @@ export const useAuditLogStore = defineStore("auditLog", {
     setAuditLogList(auditLogList: AuditLog[]) {
       this.auditLogList = auditLogList;
     },
+    async fetchPagedAuditLogList() {
+      const url = `/api/activity?${typePrefixQuery}`;
+      const responseData = (await axios.get(url)).data;
+      const auditLogList = convertEntityList(
+        responseData,
+        "activityList",
+        convert,
+        getAuditLogFromIncludedList
+      );
+      const nextToken = isPagedResponse(responseData, "activityList")
+        ? responseData.data.attributes.nextToken
+        : "";
+      return {
+        nextToken,
+        auditLogList,
+      };
+    },
     async fetchAuditLogList() {
-      const res = (await axios.get(`/api/activity?${typePrefixQuery}`)).data;
-      const list = convertAuditLogList(res);
-      this.setAuditLogList(list);
-      return list;
+      const res = await this.fetchPagedAuditLogList();
+      this.setAuditLogList(res.auditLogList);
+      return res.auditLogList;
     },
   },
 });

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -26,6 +26,7 @@ import { DeploymentConfig } from "./deployment";
 import { Policy, DefaultApprovalPolicy } from "./policy";
 import { Sheet } from "./sheet";
 import { SQLReviewPolicy } from "./sqlReview";
+import { AuditLog, AuditActivityType, AuditActivityLevel } from "./auditLog";
 
 // System bot id
 export const SYSTEM_BOT_ID = 1;
@@ -129,7 +130,8 @@ export type ResourceType =
   | "ANOMALY"
   | "DEPLOYMENT_CONFIG"
   | "SHEET"
-  | "SQL_REVIEW";
+  | "SQL_REVIEW"
+  | "AUDIT_LOG";
 
 interface ResourceMaker {
   (type: "PRINCIPAL"): Principal;
@@ -157,6 +159,7 @@ interface ResourceMaker {
   (type: "DEPLOYMENT_CONFIG"): DeploymentConfig;
   (type: "SHEET"): Sheet;
   (type: "SQL_REVIEW"): SQLReviewPolicy;
+  (type: "AUDIT_LOG"): AuditLog;
 }
 
 const makeUnknown = (type: ResourceType) => {
@@ -926,6 +929,15 @@ const makeEmpty = (type: ResourceType) => {
     ruleList: [],
   };
 
+  const EMPTY_AUDIT_LOG: AuditLog = {
+    createdTs: 0,
+    creator: EMPTY_PRINCIPAL.email,
+    type: AuditActivityType.MemberCreate,
+    level: AuditActivityLevel.INFO,
+    comment: "",
+    payload: "",
+  };
+
   switch (type) {
     case "PRINCIPAL":
       return EMPTY_PRINCIPAL;
@@ -977,6 +989,8 @@ const makeEmpty = (type: ResourceType) => {
       return EMPTY_SHEET;
     case "SQL_REVIEW":
       return EMPTY_SQL_REVIEW_POLICY;
+    case "AUDIT_LOG":
+      return EMPTY_AUDIT_LOG;
   }
 };
 export const empty = makeEmpty as ResourceMaker;

--- a/store/activity.go
+++ b/store/activity.go
@@ -359,6 +359,9 @@ func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*a
 		}
 		where = append(where, fmt.Sprintf("(%s)", strings.Join(queryValues, " OR ")))
 	}
+	if v := find.SinceID; v != nil {
+		where, args = append(where, fmt.Sprintf("id <= $%d", len(args)+1)), append(args, *v)
+	}
 
 	var query = `
 		SELECT
@@ -375,7 +378,7 @@ func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*a
 		FROM activity
 		WHERE ` + strings.Join(where, " AND ")
 	if v := find.Order; v != nil {
-		query += fmt.Sprintf(" ORDER BY created_ts %s", *v)
+		query += fmt.Sprintf(" ORDER BY id %s", *v)
 	}
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)


### PR DESCRIPTION
Modified the response structure of getting the activity list.

-> GET `/api/activity?limit=10`
```json5
"data": {
  "type": "",
  "attributes": {
    "nextToken": "MTA5"
  },
  "relationships": {
    "activityList": {
      "data": [...10 items]
    }
  }
},
"included": {...}
```

Reference: 
- Server-side: https://github.com/bytebase/bytebase/pull/2381
- Client-side: https://github.com/bytebase/bytebase/pull/2404