### PR TITLE
feat(schema-diagram): primary keys and indexes

### DIFF
--- a/frontend/src/components/SchemaDiagram/ER/TableNode.vue
+++ b/frontend/src/components/SchemaDiagram/ER/TableNode.vue
@@ -23,10 +23,13 @@
         :bb-column-name="column.name"
       >
         <td class="w-5 py-1.5">
-          <!-- TODO: remove this -->
           <heroicons-outline:key
-            v-if="column.name === 'emp_no' || column.name === 'dept_no'"
+            v-if="isPrimaryKey(table, column)"
             class="w-3 h-3 mx-auto text-amber-500"
+          />
+          <tabler:diamonds
+            v-else-if="isIndex(table, column)"
+            class="w-3 h-3 mx-auto text-gray-500"
           />
         </td>
         <td class="w-auto text-xs py-1.5">
@@ -51,7 +54,7 @@ import { computed } from "vue";
 
 import { hashCode } from "@/bbkit/BBUtil";
 import { TableMetadata } from "@/types/proto/database";
-import { useSchemaDiagramContext } from "../common";
+import { useSchemaDiagramContext, isPrimaryKey, isIndex } from "../common";
 
 const props = withDefaults(
   defineProps<{

--- a/frontend/src/components/SchemaDiagram/common/index.ts
+++ b/frontend/src/components/SchemaDiagram/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./context";
 export * from "./useDraggable";
 export * from "./utils";
+export * from "./schema";

--- a/frontend/src/components/SchemaDiagram/common/schema.ts
+++ b/frontend/src/components/SchemaDiagram/common/schema.ts
@@ -1,0 +1,21 @@
+import { ColumnMetadata, TableMetadata } from "@/types/proto/database";
+
+export const findPrimaryKey = (table: TableMetadata) => {
+  return table.indexes.find((idx) => idx.primary);
+};
+
+export const isPrimaryKey = (table: TableMetadata, column: ColumnMetadata) => {
+  const pk = findPrimaryKey(table);
+  if (!pk) return false;
+  return pk.expressions.includes(column.name);
+};
+
+export const findIndexes = (table: TableMetadata, column: ColumnMetadata) => {
+  return table.indexes.filter(
+    (idx) => !idx.primary && idx.expressions.includes(column.name)
+  );
+};
+
+export const isIndex = (table: TableMetadata, column: ColumnMetadata) => {
+  return findIndexes(table, column).length > 0;
+};


### PR DESCRIPTION
Close BYT-2155

### Features

- Use yellow `key` icons to indicate primary keys.
- Use gray `diamond` icons to indicate indexes (similar to Navicat).

### Screenshot

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/2749742/208800453-ac05cb2d-2ee3-4287-8292-9a6788217af2.png">
