### PR TITLE
feat(frontend): database list improvement

### DIFF
--- a/frontend/src/bbkit/BBGrid/BBGrid.vue
+++ b/frontend/src/bbkit/BBGrid/BBGrid.vue
@@ -1,5 +1,10 @@
 <template>
-  <div role="table" class="bb-grid border-block-border" :class="gridClass">
+  <div
+    role="table"
+    class="bb-grid border-block-border"
+    :class="gridClass"
+    v-bind="$attrs"
+  >
     <template v-if="customHeader">
       <slot name="header" />
     </template>
@@ -27,9 +32,9 @@
     >
       <slot name="item" :item="item" :row="row" />
     </div>
-
-    <slot name="footer" />
   </div>
+
+  <slot name="footer" />
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/components/AccessControl/AddRuleForm.vue
+++ b/frontend/src/components/AccessControl/AddRuleForm.vue
@@ -10,7 +10,8 @@
 
     <DatabaseTable
       mode="ALL_TINY"
-      :bordered="true"
+      class="max-h-[55vh] overflow-y-auto"
+      table-class="border"
       :custom-click="true"
       :database-list="databaseList"
       :show-selection-column="true"

--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -8,6 +8,7 @@
             <NTabs v-model:value="state.alterType">
               <NTabPane :tab="$t('alter-schema.alter-db-group')" name="TENANT">
                 <ProjectTenantView
+                  class="max-h-[55vh] overflow-y-auto"
                   :state="state"
                   :database-list="databaseList"
                   :environment-list="environmentList"
@@ -21,7 +22,8 @@
               >
                 <DatabaseTable
                   mode="PROJECT_SHORT"
-                  :bordered="true"
+                  class="max-h-[55vh] overflow-y-auto"
+                  table-class="border"
                   :custom-click="true"
                   :database-list="databaseList"
                   :show-selection-column="true"
@@ -81,7 +83,7 @@
           <!-- a simple table -->
           <DatabaseTable
             mode="ALL_SHORT"
-            :bordered="true"
+            table-class="border"
             :custom-click="true"
             :database-list="databaseList"
             @select-database="selectDatabase"

--- a/frontend/src/components/AlterSchemaPrepForm/ProjectStandardView.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/ProjectStandardView.vue
@@ -8,7 +8,7 @@
       {{ $t("alter-schema.alter-multiple-db-info") }}
     </div>
     <slot name="header"></slot>
-    <div class="space-y-4">
+    <div class="space-y-4 max-h-[55vh] overflow-y-auto">
       <div
         v-for="{
           environment,
@@ -53,7 +53,7 @@
                   : 'cursor-not-allowed'
               "
             >
-              <div class="radio text-sm">
+              <div class="radio text-sm flex justify-start">
                 <input
                   type="checkbox"
                   class="h-4 w-4 text-accent rounded disabled:cursor-not-allowed border-control-border focus:ring-accent"
@@ -66,12 +66,8 @@
                   @input="(e: any) => toggleDatabaseIdForEnvironment(database.id, environment.id, e.target.checked)"
                 />
                 <span
-                  class="font-medium"
-                  :class="
-                    database.syncStatus == 'OK'
-                      ? 'ml-2 text-main'
-                      : 'ml-6 text-control-light'
-                  "
+                  class="font-medium ml-2 text-main"
+                  :class="database.syncStatus !== 'OK' && 'opacity-40'"
                   >{{ database.name }}</span
                 >
               </div>
@@ -99,7 +95,7 @@
     <slot name="header"></slot>
     <DatabaseTable
       mode="PROJECT_SHORT"
-      :bordered="true"
+      table-class="border"
       :custom-click="true"
       :database-list="databaseList"
       @select-database="selectDatabase"

--- a/frontend/src/components/ProjectDatabasesPanel.vue
+++ b/frontend/src/components/ProjectDatabasesPanel.vue
@@ -14,7 +14,11 @@
     </div>
 
     <template v-if="databaseList.length > 0">
-      <DatabaseTable mode="PROJECT" :database-list="filteredDatabaseList" />
+      <DatabaseTable
+        mode="PROJECT"
+        table-class="border"
+        :database-list="filteredDatabaseList"
+      />
     </template>
     <div v-else class="text-center textinfolabel">
       <i18n-t keypath="project.overview.no-db-prompt" tag="p">

--- a/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
@@ -1,10 +1,11 @@
 <template>
-  <div class="px-4 space-y-6 w-208">
+  <div class="px-4 space-y-6 w-[60rem]">
     <slot name="transfer-source-selector" />
 
     <DatabaseTable
+      class="max-h-[55vh] overflow-y-auto"
+      table-class="border"
       :mode="transferSource === 'DEFAULT' ? 'PROJECT_SHORT' : 'ALL_SHORT'"
-      :bordered="true"
       :custom-click="true"
       :database-list="databaseList"
       :show-selection-column="true"
@@ -35,6 +36,7 @@
         />
       </template>
     </DatabaseTable>
+
     <!-- Update button group -->
     <div class="pt-4 border-t border-block-border flex justify-between">
       <div>

--- a/frontend/src/store/modules/database.ts
+++ b/frontend/src/store/modules/database.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import axios from "axios";
-import { computed, unref, watch } from "vue";
+import { computed, unref, watch, markRaw } from "vue";
 import {
   Backup,
   Database,
@@ -140,10 +140,10 @@ function convert(
     }
   }
 
-  return {
+  return markRaw({
     ...(databaseWPartial as Omit<Database, "dataSourceList">),
     dataSourceList,
-  };
+  });
 }
 
 const databaseSorter = (a: Database, b: Database): number => {

--- a/frontend/src/views/DatabaseDashboard.vue
+++ b/frontend/src/views/DatabaseDashboard.vue
@@ -35,7 +35,7 @@
       </div>
     </div>
 
-    <DatabaseTable :bordered="false" :database-list="filteredList" />
+    <DatabaseTable pagination-class="mb-4" :database-list="filteredList" />
 
     <div
       v-if="state.loading"


### PR DESCRIPTION
### Changes

- Pagination - we've tried a couple of ways to optimize the performance when first rendering, but finally, we have to do pagination.
- Use BBGrid - better responsive column widths.
- Partial scrolling for modal dialogs with `<DatabaseTable>`, such as alter schema dialog, and transfer DB dialog. We could always see the [Cancel][Next] button groups without scrolling to the bottom.

Now we can finish the first rendering of 100 databases in an average of 1~2 seconds and scroll at 60FPS after that.