### PR TITLE
fix: passCheck should only accept finished checks

### DIFF
--- a/server/runner/taskrun/scheduler.go
+++ b/server/runner/taskrun/scheduler.go
@@ -797,7 +797,7 @@ func passCheck(taskCheckRunList []*api.TaskCheckRun, checkType api.TaskCheckType
 		}
 	}
 
-	if lastRun == nil || lastRun.Status == api.TaskCheckRunFailed {
+	if lastRun == nil || lastRun.Status != api.TaskCheckRunDone {
 		return false, nil
 	}
 	checkResult := &api.TaskCheckRunResultPayload{}


### PR DESCRIPTION
passCheck should only check the results of a "DONE" task check.