### PR TITLE
feat(frontend): speed-up issue detail page

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -40,7 +40,6 @@ import {
   useDatabaseStore,
   useEnvironmentStore,
   useInstanceStore,
-  useIssueStore,
   usePrincipalStore,
   useRouterStore,
   useDBSchemaStore,
@@ -842,14 +841,6 @@ const routes: Array<RouteRecordRaw> = [
             path: "issue/:issueSlug",
             name: "workspace.issue.detail",
             meta: {
-              title: (route: RouteLocationNormalized) => {
-                const slug = route.params.issueSlug as string;
-                if (slug.toLowerCase() == "new") {
-                  return t("issue.new-issue");
-                }
-                const issue = useIssueStore().getIssueById(idFromSlug(slug));
-                return issue.name;
-              },
               allowBookmark: true,
             },
             components: {
@@ -952,7 +943,6 @@ router.beforeEach((to, from, next) => {
   const dbSchemaStore = useDBSchemaStore();
   const environmentStore = useEnvironmentStore();
   const instanceStore = useInstanceStore();
-  const issueStore = useIssueStore();
   const routerStore = useRouterStore();
   const projectWebhookStore = useProjectWebhookStore();
   const projectStore = useProjectStore();
@@ -1234,62 +1224,9 @@ router.beforeEach((to, from, next) => {
   }
 
   if (issueSlug) {
-    if (issueSlug.toLowerCase() == "new") {
-      // For preparing the database if user visits creating issue url directly.
-      // It's horrible to fetchDatabaseById one-by-one when query.databaseList
-      // is big (100+ sometimes)
-      // So we are fetching databaseList by project since that's better cached.
-      const prepare = async () => {
-        if (to.query.project) {
-          // If we found query.project, we can directly fetchDatabaseListByProjectId
-          const projectId = to.query.project as string;
-          await databaseStore.fetchDatabaseListByProjectId(
-            parseInt(projectId, 10)
-          );
-        } else {
-          // Otherwise, we don't have the projectId (very rare to see, theoretically)
-          // so we need to fetch the first database in databaseList by id,
-          // and see what project it belongs.
-          const databaseIdList = (to.query.databaseList as string)
-            .split(",")
-            .map((str) => parseInt(str, 10));
-          if (databaseIdList.length > 0) {
-            const firstDB = await databaseStore.getOrFetchDatabaseById(
-              databaseIdList[0]
-            );
-            if (databaseIdList.length > 1) {
-              // If we have more than one databases in the list
-              // fetch the rest of databases by projectId
-              await databaseStore.fetchDatabaseListByProjectId(
-                firstDB.project.id
-              );
-            }
-          }
-        }
-      };
-      prepare()
-        .then(() => next())
-        .catch((error) => {
-          next({
-            name: "error.404",
-            replace: false,
-          });
-          throw error;
-        });
-      return;
-    }
-    issueStore
-      .fetchIssueById(idFromSlug(issueSlug))
-      .then(() => {
-        next();
-      })
-      .catch((error) => {
-        next({
-          name: "error.404",
-          replace: false,
-        });
-        throw error;
-      });
+    // We've moved the preparation data fetch jobs into IssueDetail page
+    // so just next() here.
+    next();
     return;
   }
 

--- a/frontend/src/views/IssueDetail.vue
+++ b/frontend/src/views/IssueDetail.vue
@@ -32,9 +32,12 @@ import {
   Project,
   unknown,
   UNKNOWN_ID,
+  Issue,
 } from "@/types";
 import { hasFeature, useIssueStore, useProjectStore } from "@/store";
 import { useInitializeIssue, usePollIssue } from "@/plugins/issue/logic";
+import { useTitle } from "@vueuse/core";
+import { useI18n } from "vue-i18n";
 
 interface LocalState {
   showFeatureModal: boolean;
@@ -48,6 +51,7 @@ const props = defineProps({
 });
 
 const route = useRoute();
+const { t } = useI18n();
 
 const state = reactive<LocalState>({
   showFeatureModal: false,
@@ -100,4 +104,18 @@ const findProject = async (): Promise<Project> => {
 
   return project;
 };
+
+const documentTitle = computed(() => {
+  if (create.value) {
+    return t("issue.new-issue");
+  } else {
+    const issueEntity = issue.value as Issue | undefined;
+
+    if (issueEntity) {
+      return issueEntity.name;
+    }
+    return t("common.loading");
+  }
+});
+useTitle(documentTitle);
 </script>


### PR DESCRIPTION
### Changes

By now, we have a problem that is when clicking on an issue link, the page might stall for several seconds and then redirect to the issue detail page.

That's because we are doing some data fetching jobs in the router before routing. When the issue is very big (e.g., tens of tasks within), the stalling time will be as long as 30 seconds. Users won't know whether the page is still alive, and they might do some monkey clicks.

We don't really speed the loading procedure up. We just put it into the issue detail page (rather than the router). So when clicking on an issue link, the page will redirect ASAP and show a loading indicator. 