### PR TITLE
feat(backend): differentiate skipped (mark as done) tasks

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -342,4 +342,8 @@ type TaskStatusPatch struct {
 	Code    *common.Code
 	Comment *string `jsonapi:"attr,comment"`
 	Result  *string
+	// Skipped is set to true if frontend sets the Status to DONE.
+	// And SkippedReason is Comment.
+	Skipped       *bool
+	SkippedReason *string
 }

--- a/api/task.go
+++ b/api/task.go
@@ -59,6 +59,10 @@ const (
 
 // TaskDatabasePITRRestorePayload is the task payload for database PITR restore.
 type TaskDatabasePITRRestorePayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	// The project owning the database.
 	ProjectID int `json:"projectId,omitempty"`
 
@@ -82,10 +86,18 @@ type TaskDatabasePITRRestorePayload struct {
 
 // TaskDatabasePITRCutoverPayload is the task payload for PITR cutover.
 // It is currently only a placeholder.
-type TaskDatabasePITRCutoverPayload struct{}
+type TaskDatabasePITRCutoverPayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+}
 
 // TaskDatabaseCreatePayload is the task payload for creating databases.
 type TaskDatabaseCreatePayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	// The project owning the database.
 	ProjectID    int    `json:"projectId,omitempty"`
 	DatabaseName string `json:"databaseName,omitempty"`
@@ -97,11 +109,19 @@ type TaskDatabaseCreatePayload struct {
 
 // TaskDatabaseSchemaBaselinePayload is the task payload for database schema baseline.
 type TaskDatabaseSchemaBaselinePayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	SchemaVersion string `json:"schemaVersion,omitempty"`
 }
 
 // TaskDatabaseSchemaUpdatePayload is the task payload for database schema update (DDL).
 type TaskDatabaseSchemaUpdatePayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	Statement     string         `json:"statement,omitempty"`
 	SheetID       int            `json:"sheetId,omitempty"`
 	SchemaVersion string         `json:"schemaVersion,omitempty"`
@@ -110,6 +130,10 @@ type TaskDatabaseSchemaUpdatePayload struct {
 
 // TaskDatabaseSchemaUpdateSDLPayload is the task payload for database schema update (SDL).
 type TaskDatabaseSchemaUpdateSDLPayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	Statement     string         `json:"statement,omitempty"`
 	SheetID       int            `json:"sheetId,omitempty"`
 	SchemaVersion string         `json:"schemaVersion,omitempty"`
@@ -118,6 +142,10 @@ type TaskDatabaseSchemaUpdateSDLPayload struct {
 
 // TaskDatabaseSchemaUpdateGhostSyncPayload is the task payload for gh-ost syncing ghost table.
 type TaskDatabaseSchemaUpdateGhostSyncPayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	Statement     string         `json:"statement,omitempty"`
 	SheetID       int            `json:"sheetId,omitempty"`
 	SchemaVersion string         `json:"schemaVersion,omitempty"`
@@ -129,10 +157,18 @@ type TaskDatabaseSchemaUpdateGhostSyncPayload struct {
 }
 
 // TaskDatabaseSchemaUpdateGhostCutoverPayload is the task payload for gh-ost switching the original table and the ghost table.
-type TaskDatabaseSchemaUpdateGhostCutoverPayload struct{}
+type TaskDatabaseSchemaUpdateGhostCutoverPayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+}
 
 // TaskDatabaseDataUpdatePayload is the task payload for database data update (DML).
 type TaskDatabaseDataUpdatePayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	Statement     string         `json:"statement,omitempty"`
 	SheetID       int            `json:"sheetId,omitempty"`
 	SchemaVersion string         `json:"schemaVersion,omitempty"`
@@ -163,6 +199,10 @@ type TaskDatabaseDataUpdatePayload struct {
 
 // TaskDatabaseBackupPayload is the task payload for database backup.
 type TaskDatabaseBackupPayload struct {
+	// Common fields
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+
 	BackupID int `json:"backupId,omitempty"`
 }
 

--- a/server/task.go
+++ b/server/task.go
@@ -148,6 +148,13 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusUnauthorized, "Not allowed to change task status")
 		}
 
+		if taskStatusPatch.Status == api.TaskDone {
+			// the user marks the task as DONE, set Skipped to true and SkippedReason to Comment.
+			skipped := true
+			taskStatusPatch.Skipped = &skipped
+			taskStatusPatch.SkippedReason = taskStatusPatch.Comment
+		}
+
 		taskPatched, err := s.TaskScheduler.PatchTaskStatus(ctx, task, taskStatusPatch)
 		if err != nil {
 			if common.ErrorCode(err) == common.Invalid {

--- a/store/task.go
+++ b/store/task.go
@@ -776,6 +776,12 @@ func (s *Store) patchTaskStatusImpl(ctx context.Context, tx *Tx, patch *api.Task
 	// Build UPDATE clause.
 	set, args := []string{"updater_id = $1"}, []interface{}{patch.UpdaterID}
 	set, args = append(set, "status = $2"), append(args, patch.Status)
+	if v := patch.Skipped; v != nil {
+		set, args = append(set, fmt.Sprintf(`payload['skipped'] = to_json($%d::BOOLEAN)`, len(args)+1)), append(args, *v)
+	}
+	if v := patch.SkippedReason; v != nil {
+		set, args = append(set, fmt.Sprintf(`payload['skippedReason'] = to_json($%d::TEXT)`, len(args)+1)), append(args, *v)
+	}
 	var ids []string
 	for _, id := range patch.IDList {
 		ids = append(ids, strconv.Itoa(id))

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -2082,6 +2082,7 @@ func TestMarkTaskAsDone(t *testing.T) {
 	})
 	a.NoError(err)
 
+	// Skip the task.
 	a.Equal(1, len(issue.Pipeline.StageList))
 	a.Equal(1, len(issue.Pipeline.StageList[0].TaskList))
 	task := issue.Pipeline.StageList[0].TaskList[0]
@@ -2092,11 +2093,13 @@ func TestMarkTaskAsDone(t *testing.T) {
 	}, issue.PipelineID, task.ID)
 	a.NoError(err)
 	a.Equal(api.TaskDone, task.Status)
+
 	var payload api.TaskDatabaseSchemaUpdatePayload
 	err = json.Unmarshal([]byte(task.Payload), &payload)
 	a.NoError(err)
 	a.Equal(true, payload.Skipped)
 	a.Equal(skippedReason, payload.SkippedReason)
+
 	status, err := ctl.waitIssuePipelineWithNoApproval(issue.ID)
 	a.NoError(err)
 	a.Equal(api.TaskDone, status)


### PR DESCRIPTION
We want to differentiate skipped tasks from completed tasks. They all have the status "DONE" currently, and we have no way to tell them apart.

We add the following fields to `Task.Payload` and use `Skipped` to mark skipped tasks.
```go
	Skipped       bool   `json:"skipped,omitempty"`
	SkippedReason string `json:"skippedReason,omitempty"`
```

Next, we will differentiate them on the frontend and in our webhooks.

@LiuJi-Jim FYI

Completing BYT-2171
