### PR TITLE
feat: support to get foreign keys for MySQL

### DIFF
--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -284,8 +284,8 @@ func (*MockDriver) SyncInstance(_ context.Context) (*database.InstanceMeta, erro
 }
 
 // SyncDBSchema implements the Driver interface.
-func (*MockDriver) SyncDBSchema(_ context.Context, _ string) (*database.Schema, error) {
-	return nil, nil
+func (*MockDriver) SyncDBSchema(_ context.Context, _ string) (*database.Schema, []*storepb.ForeignKeyMetadata, error) {
+	return nil, nil, nil
 }
 
 // NeedsSetupMigration implements the Driver interface.

--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -284,7 +284,7 @@ func (*MockDriver) SyncInstance(_ context.Context) (*database.InstanceMeta, erro
 }
 
 // SyncDBSchema implements the Driver interface.
-func (*MockDriver) SyncDBSchema(_ context.Context, _ string) (*database.Schema, []*storepb.ForeignKeyMetadata, error) {
+func (*MockDriver) SyncDBSchema(_ context.Context, _ string) (*database.Schema, map[string][]*storepb.ForeignKeyMetadata, error) {
 	return nil, nil, nil
 }
 

--- a/plugin/db/clickhouse/sync.go
+++ b/plugin/db/clickhouse/sync.go
@@ -69,7 +69,7 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, map[string][]*storepb.ForeignKeyMetadata, error) {
 	// Query column info
 	columnWhere := fmt.Sprintf("LOWER(database) = '%s'", strings.ToLower(databaseName))
 	columnQuery := `

--- a/plugin/db/clickhouse/sync.go
+++ b/plugin/db/clickhouse/sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
 // SyncInstance syncs the instance.
@@ -68,7 +69,7 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
 	// Query column info
 	columnWhere := fmt.Sprintf("LOWER(database) = '%s'", strings.ToLower(databaseName))
 	columnQuery := `
@@ -84,7 +85,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 			WHERE ` + columnWhere
 	columnRows, err := driver.db.QueryContext(ctx, columnQuery)
 	if err != nil {
-		return nil, util.FormatErrorWithQuery(err, columnQuery)
+		return nil, nil, util.FormatErrorWithQuery(err, columnQuery)
 	}
 	defer columnRows.Close()
 
@@ -103,7 +104,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 			&column.Type,
 			&column.Comment,
 		); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		key := fmt.Sprintf("%s/%s", dbName, tableName)
@@ -114,7 +115,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if err := columnRows.Err(); err != nil {
-		return nil, util.FormatErrorWithQuery(err, columnQuery)
+		return nil, nil, util.FormatErrorWithQuery(err, columnQuery)
 	}
 
 	// Query table info
@@ -133,7 +134,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 			WHERE ` + tableWhere
 	tableRows, err := driver.db.QueryContext(ctx, tableQuery)
 	if err != nil {
-		return nil, util.FormatErrorWithQuery(err, tableQuery)
+		return nil, nil, util.FormatErrorWithQuery(err, tableQuery)
 	}
 	defer tableRows.Close()
 
@@ -156,7 +157,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 			&definition,
 			&comment,
 		); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if engine == "View" {
@@ -182,7 +183,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if err := tableRows.Err(); err != nil {
-		return nil, util.FormatErrorWithQuery(err, tableQuery)
+		return nil, nil, util.FormatErrorWithQuery(err, tableQuery)
 	}
 
 	// Query db info
@@ -197,14 +198,14 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		&schema.Name,
 	); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
+			return nil, nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	schema.TableList = tableMap[schema.Name]
 	schema.ViewList = viewMap[schema.Name]
 
-	return &schema, nil
+	return &schema, nil, nil
 }
 
 func (driver *Driver) getUserList(ctx context.Context) ([]db.User, error) {

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/plugin/vcs"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
 )
 
@@ -498,7 +499,7 @@ type Driver interface {
 	// SyncInstance syncs the instance metadata.
 	SyncInstance(ctx context.Context) (*InstanceMeta, error)
 	// SyncDBSchema syncs a single database schema.
-	SyncDBSchema(ctx context.Context, database string) (*Schema, error)
+	SyncDBSchema(ctx context.Context, database string) (*Schema, []*storepb.ForeignKeyMetadata, error)
 
 	// Role
 	// CreateRole creates the role.

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -499,7 +499,7 @@ type Driver interface {
 	// SyncInstance syncs the instance metadata.
 	SyncInstance(ctx context.Context) (*InstanceMeta, error)
 	// SyncDBSchema syncs a single database schema.
-	SyncDBSchema(ctx context.Context, database string) (*Schema, []*storepb.ForeignKeyMetadata, error)
+	SyncDBSchema(ctx context.Context, database string) (*Schema, map[string][]*storepb.ForeignKeyMetadata, error)
 
 	// Role
 	// CreateRole creates the role.

--- a/plugin/db/mongodb/sync.go
+++ b/plugin/db/mongodb/sync.go
@@ -60,7 +60,7 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs the database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, map[string][]*storepb.ForeignKeyMetadata, error) {
 	exist, err := driver.isDatabaseExist(ctx, databaseName)
 	if err != nil {
 		return nil, nil, err

--- a/plugin/db/mongodb/sync.go
+++ b/plugin/db/mongodb/sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/plugin/db"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
 // UsersInfo is the subset of the mongodb command result of "usersInfo".
@@ -59,25 +60,25 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs the database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
 	exist, err := driver.isDatabaseExist(ctx, databaseName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if !exist {
-		return nil, errors.Errorf("database %s does not exist", databaseName)
+		return nil, nil, errors.Errorf("database %s does not exist", databaseName)
 	}
 	schema := db.Schema{}
 	schema.Name = databaseName
 
 	tableList, err := driver.syncAllCollectionSchema(ctx, databaseName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	schema.TableList = tableList
 
 	// TODO(zp): sync View schema
-	return &schema, nil
+	return &schema, nil, nil
 }
 
 func (driver *Driver) syncAllCollectionSchema(ctx context.Context, databaseName string) ([]db.Table, error) {

--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -123,7 +123,7 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, map[string][]*storepb.ForeignKeyMetadata, error) {
 	// Query db info
 	databases, err := driver.getDatabases(ctx)
 	if err != nil {

--- a/plugin/db/pg/sync.go
+++ b/plugin/db/pg/sync.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
 // pgDatabaseSchema describes a pg database schema.
@@ -122,11 +123,11 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
 	// Query db info
 	databases, err := driver.getDatabases(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get databases")
+		return nil, nil, errors.Wrap(err, "failed to get databases")
 	}
 
 	schema := db.Schema{
@@ -142,16 +143,16 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if !found {
-		return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
+		return nil, nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 	}
 
 	sqldb, err := driver.GetDBConnection(ctx, databaseName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get database connection for %q", databaseName)
+		return nil, nil, errors.Wrapf(err, "failed to get database connection for %q", databaseName)
 	}
 	txn, err := sqldb.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer txn.Rollback()
 
@@ -159,7 +160,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 	indicesMap := make(map[string][]*indexSchema)
 	indices, err := getIndices(txn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get indices from database %q", databaseName)
+		return nil, nil, errors.Wrapf(err, "failed to get indices from database %q", databaseName)
 	}
 	for _, idx := range indices {
 		key := fmt.Sprintf("%s.%s", idx.schemaName, idx.tableName)
@@ -169,7 +170,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 	// Table statements.
 	tables, err := getPgTables(txn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get tables from database %q", databaseName)
+		return nil, nil, errors.Wrapf(err, "failed to get tables from database %q", databaseName)
 	}
 	for _, tbl := range tables {
 		var dbTable db.Table
@@ -212,7 +213,7 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 	// View statements.
 	views, err := getViews(txn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get views from database %q", databaseName)
+		return nil, nil, errors.Wrapf(err, "failed to get views from database %q", databaseName)
 	}
 	for _, view := range views {
 		var dbView db.View
@@ -229,15 +230,15 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 	// Extensions.
 	extensions, err := getExtensions(txn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get extensions from database %q", databaseName)
+		return nil, nil, errors.Wrapf(err, "failed to get extensions from database %q", databaseName)
 	}
 	schema.ExtensionList = extensions
 
 	if err := txn.Commit(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &schema, err
+	return &schema, nil, err
 }
 
 func (driver *Driver) getUserList(ctx context.Context) ([]db.User, error) {

--- a/plugin/db/snowflake/sync.go
+++ b/plugin/db/snowflake/sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
 var (
@@ -62,16 +63,16 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
 	// Query user info
 	if err := driver.useRole(ctx, accountAdminRole); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Query db info
 	databases, err := driver.getDatabases(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	schema := db.Schema{
@@ -85,16 +86,16 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if !found {
-		return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
+		return nil, nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 	}
 
 	tableList, viewList, err := driver.syncTableSchema(ctx, databaseName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	schema.TableList, schema.ViewList = tableList, viewList
 
-	return &schema, nil
+	return &schema, nil, nil
 }
 
 func (driver *Driver) getUserList(ctx context.Context) ([]db.User, error) {

--- a/plugin/db/snowflake/sync.go
+++ b/plugin/db/snowflake/sync.go
@@ -63,7 +63,7 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, map[string][]*storepb.ForeignKeyMetadata, error) {
 	// Query user info
 	if err := driver.useRole(ctx, accountAdminRole); err != nil {
 		return nil, nil, err

--- a/plugin/db/sqlite/sync.go
+++ b/plugin/db/sqlite/sync.go
@@ -63,7 +63,7 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, map[string][]*storepb.ForeignKeyMetadata, error) {
 	databases, err := driver.getDatabases()
 	if err != nil {
 		return nil, nil, err

--- a/plugin/db/sqlite/sync.go
+++ b/plugin/db/sqlite/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	"github.com/bytebase/bytebase/plugin/db/util"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
 var (
@@ -62,10 +63,10 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, error) {
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*db.Schema, []*storepb.ForeignKeyMetadata, error) {
 	databases, err := driver.getDatabases()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	schema := db.Schema{
@@ -79,23 +80,23 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 		}
 	}
 	if !found {
-		return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
+		return nil, nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
 	}
 
 	sqldb, err := driver.GetDBConnection(ctx, databaseName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get database connection for %q", databaseName)
+		return nil, nil, errors.Wrapf(err, "failed to get database connection for %q", databaseName)
 	}
 	txn, err := sqldb.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer txn.Rollback()
 	// Index statements.
 	indicesMap := make(map[string][]indexSchema)
 	indices, err := getIndices(txn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get indices from database %q", databaseName)
+		return nil, nil, errors.Wrapf(err, "failed to get indices from database %q", databaseName)
 	}
 	for _, idx := range indices {
 		indicesMap[idx.tableName] = append(indicesMap[idx.tableName], idx)
@@ -103,21 +104,21 @@ func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*d
 
 	tbls, err := getTables(txn, indicesMap)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	schema.TableList = tbls
 
 	views, err := getViews(txn)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	schema.ViewList = views
 
 	if err := txn.Commit(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &schema, nil
+	return &schema, nil, nil
 }
 
 // getTables gets all tables of a database.

--- a/server/runner/schemasync/syncer.go
+++ b/server/runner/schemasync/syncer.go
@@ -342,7 +342,7 @@ func (s *Syncer) SyncDatabaseSchema(ctx context.Context, instance *api.Instance,
 	}
 
 	// Sync database schema
-	schema, err := driver.SyncDBSchema(ctx, databaseName)
+	schema, _, err := driver.SyncDBSchema(ctx, databaseName)
 	if err != nil {
 		return err
 	}

--- a/server/runner/schemasync/syncer.go
+++ b/server/runner/schemasync/syncer.go
@@ -342,7 +342,7 @@ func (s *Syncer) SyncDatabaseSchema(ctx context.Context, instance *api.Instance,
 	}
 
 	// Sync database schema
-	schema, _, err := driver.SyncDBSchema(ctx, databaseName)
+	schema, fkMap, err := driver.SyncDBSchema(ctx, databaseName)
 	if err != nil {
 		return err
 	}
@@ -396,10 +396,10 @@ func (s *Syncer) SyncDatabaseSchema(ctx context.Context, instance *api.Instance,
 	}
 
 	// Sync database schema
-	return syncDBSchema(ctx, s.store, database, schema, driver, force)
+	return syncDBSchema(ctx, s.store, database, schema, fkMap, driver, force)
 }
 
-func syncDBSchema(ctx context.Context, stores *store.Store, database *api.Database, schema *db.Schema, driver db.Driver, force bool) error {
+func syncDBSchema(ctx context.Context, stores *store.Store, database *api.Database, schema *db.Schema, fkMap map[string][]*storepb.ForeignKeyMetadata, driver db.Driver, force bool) error {
 	dbSchema, err := stores.GetDBSchema(ctx, database.ID)
 	if err != nil {
 		return err
@@ -409,7 +409,7 @@ func syncDBSchema(ctx context.Context, stores *store.Store, database *api.Databa
 		oldDatabaseMetadata = dbSchema.Metadata
 	}
 
-	databaseMetadata := convertDBSchema(schema)
+	databaseMetadata := convertDBSchema(schema, fkMap)
 
 	if !cmp.Equal(oldDatabaseMetadata, databaseMetadata, protocmp.Transform()) {
 		rawDump := ""
@@ -438,7 +438,10 @@ func syncDBSchema(ctx context.Context, stores *store.Store, database *api.Databa
 	return nil
 }
 
-func convertDBSchema(schema *db.Schema) *storepb.DatabaseMetadata {
+func convertDBSchema(schema *db.Schema, fkMap map[string][]*storepb.ForeignKeyMetadata) *storepb.DatabaseMetadata {
+	if fkMap == nil {
+		fkMap = make(map[string][]*storepb.ForeignKeyMetadata)
+	}
 	databaseMetadata := &storepb.DatabaseMetadata{
 		Name:         schema.Name,
 		CharacterSet: schema.CharacterSet,
@@ -480,6 +483,7 @@ func convertDBSchema(schema *db.Schema) *storepb.DatabaseMetadata {
 				IndexSize:     table.IndexSize,
 				CreateOptions: table.CreateOptions,
 				Comment:       table.Comment,
+				ForeignKeys:   fkMap[table.Name],
 			}
 
 			sort.Slice(table.ColumnList, func(i, j int) bool {

--- a/server/runner/schemasync/syncer_test.go
+++ b/server/runner/schemasync/syncer_test.go
@@ -289,7 +289,7 @@ func TestConvertDBSchema(t *testing.T) {
 			},
 		},
 	}
-	got := convertDBSchema(dbSchema)
+	got := convertDBSchema(dbSchema, nil)
 	assert.Equal(t, want, got)
 }
 

--- a/tests/syncer_test.go
+++ b/tests/syncer_test.go
@@ -1,0 +1,259 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/bytebase/bytebase/api"
+	"github.com/bytebase/bytebase/plugin/db"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+	"github.com/bytebase/bytebase/resources/mysql"
+	"github.com/bytebase/bytebase/tests/fake"
+)
+
+func TestSyncerForMySQL(t *testing.T) {
+	const (
+		databaseName = "test_sync_mysql_schema_db"
+		createSchema = `
+		CREATE TABLE trd (
+			a int DEFAULT NULL,
+			b int DEFAULT NULL,
+			c int DEFAULT NULL,
+			UNIQUE KEY a (a,b,c)
+		  );
+		  CREATE TABLE tfk (
+			a int DEFAULT NULL,
+			b int DEFAULT NULL,
+			c int DEFAULT NULL,
+			KEY a (a,b,c),
+			CONSTRAINT tfk_ibfk_1 FOREIGN KEY (a, b, c) REFERENCES trd (a, b, c)
+		  );
+		`
+		expectedSchema = `{
+			"name":"test_sync_mysql_schema_db",
+			"schemas":[
+			   {
+				  "tables":[
+					 {
+						"name":"tfk",
+						"columns":[
+						   {
+							  "name":"a",
+							  "position":1,
+							  "nullable":true,
+							  "type":"int"
+						   },
+						   {
+							  "name":"b",
+							  "position":2,
+							  "nullable":true,
+							  "type":"int"
+						   },
+						   {
+							  "name":"c",
+							  "position":3,
+							  "nullable":true,
+							  "type":"int"
+						   }
+						],
+						"indexes":[
+						   {
+							  "name":"a",
+							  "expressions":[
+								 "a",
+								 "b",
+								 "c"
+							  ],
+							  "type":"BTREE",
+							  "visible":true
+						   }
+						],
+						"engine":"InnoDB",
+						"collation":"utf8mb4_general_ci",
+						"dataSize":"16384",
+						"indexSize":"16384",
+						"foreignKeys":[
+						   {
+							  "name":"tfk_ibfk_1",
+							  "columns":[
+								 "a",
+								 "b",
+								 "c"
+							  ],
+							  "referencedTable":"trd",
+							  "referencedColumns":[
+								 "a",
+								 "b",
+								 "c"
+							  ],
+							  "onDelete":"NO ACTION",
+							  "onUpdate":"NO ACTION",
+							  "matchType":"NONE"
+						   }
+						]
+					 },
+					 {
+						"name":"trd",
+						"columns":[
+						   {
+							  "name":"a",
+							  "position":1,
+							  "nullable":true,
+							  "type":"int"
+						   },
+						   {
+							  "name":"b",
+							  "position":2,
+							  "nullable":true,
+							  "type":"int"
+						   },
+						   {
+							  "name":"c",
+							  "position":3,
+							  "nullable":true,
+							  "type":"int"
+						   }
+						],
+						"indexes":[
+						   {
+							  "name":"a",
+							  "expressions":[
+								 "a",
+								 "b",
+								 "c"
+							  ],
+							  "type":"BTREE",
+							  "unique":true,
+							  "visible":true
+						   }
+						],
+						"engine":"InnoDB",
+						"collation":"utf8mb4_general_ci",
+						"dataSize":"16384",
+						"indexSize":"16384"
+					 }
+				  ]
+			   }
+			],
+			"characterSet":"utf8mb4",
+			"collation":"utf8mb4_general_ci"
+		 }`
+	)
+
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	dataDir := t.TempDir()
+	err := ctl.StartServerWithExternalPg(ctx, &config{
+		dataDir:            dataDir,
+		vcsProviderCreator: fake.NewGitLab,
+	})
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	// Create a MySQL instance.
+	mysqlPort := getTestPort()
+	stopInstance := mysql.SetupTestInstance(t, mysqlPort, mysqlBinDir)
+	defer stopInstance()
+
+	mysqlDB, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/mysql", mysqlPort))
+	a.NoError(err)
+	defer mysqlDB.Close()
+
+	_, err = mysqlDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %v", databaseName))
+	a.NoError(err)
+
+	_, err = mysqlDB.Exec("DROP USER IF EXISTS bytebase")
+	a.NoError(err)
+	_, err = mysqlDB.Exec("CREATE USER 'bytebase' IDENTIFIED WITH mysql_native_password BY 'bytebase'")
+	a.NoError(err)
+
+	_, err = mysqlDB.Exec("GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, PROCESS, REFERENCES, SELECT, SHOW DATABASES, SHOW VIEW, TRIGGER, UPDATE, USAGE, REPLICATION CLIENT, REPLICATION SLAVE, LOCK TABLES, RELOAD ON *.* to bytebase")
+	a.NoError(err)
+
+	// Create a project.
+	project, err := ctl.createProject(api.ProjectCreate{
+		Name: "Test Sync MySQL Schema",
+		Key:  "TestSyncMySQLSchema",
+	})
+	a.NoError(err)
+
+	environments, err := ctl.getEnvironments()
+	a.NoError(err)
+	prodEnvironment, err := findEnvironment(environments, "Prod")
+	a.NoError(err)
+
+	instance, err := ctl.addInstance(api.InstanceCreate{
+		EnvironmentID: prodEnvironment.ID,
+		Name:          "mysqlInstance",
+		Engine:        db.MySQL,
+		Host:          "127.0.0.1",
+		Port:          strconv.Itoa(mysqlPort),
+		Username:      "bytebase",
+		Password:      "bytebase",
+	})
+	a.NoError(err)
+
+	databases, err := ctl.getDatabases(api.DatabaseFind{
+		ProjectID: &project.ID,
+	})
+	a.NoError(err)
+	a.Nil(databases)
+
+	err = ctl.createDatabase(project, instance, databaseName, "", nil)
+	a.NoError(err)
+
+	databases, err = ctl.getDatabases(api.DatabaseFind{
+		ProjectID: &project.ID,
+	})
+	a.NoError(err)
+	a.Equal(1, len(databases))
+
+	database := databases[0]
+	a.Equal(instance.ID, database.Instance.ID)
+
+	// Create an issue that updates database schema.
+	createContext, err := json.Marshal(&api.MigrationContext{
+		DetailList: []*api.MigrationDetail{
+			{
+				MigrationType: db.Migrate,
+				DatabaseID:    database.ID,
+				Statement:     createSchema,
+			},
+		},
+	})
+	a.NoError(err)
+	issue, err := ctl.createIssue(api.IssueCreate{
+		ProjectID:   project.ID,
+		Name:        fmt.Sprintf("Create sequence for database %q", databaseName),
+		Type:        api.IssueDatabaseSchemaUpdate,
+		Description: fmt.Sprintf("Create sequence of database %q.", databaseName),
+		// Assign to self.
+		AssigneeID:    project.Creator.ID,
+		CreateContext: string(createContext),
+	})
+	a.NoError(err)
+	status, err := ctl.waitIssuePipeline(issue.ID)
+	a.NoError(err)
+	a.Equal(api.TaskDone, status)
+
+	metadata, err := ctl.getLatestSchemaMetadata(database.ID)
+	a.NoError(err)
+
+	var latestSchemaMetadata storepb.DatabaseMetadata
+	err = protojson.Unmarshal([]byte(metadata), &latestSchemaMetadata)
+	a.NoError(err)
+
+	var expectedSchemaMetadata storepb.DatabaseMetadata
+	err = protojson.Unmarshal([]byte(expectedSchema), &expectedSchemaMetadata)
+	a.NoError(err)
+	a.Equal(&expectedSchemaMetadata, &latestSchemaMetadata)
+}


### PR DESCRIPTION
This PR support to get foreign keys for MySQL.
Because we haven't used protobuf in /pulgin/db yet, I implement this feature in this ugly way. This situation will be improved when protobuf is introduced later.

I also add the integration test to check this PR.
I'll support PostgreSQL in the following PR.