### PR TITLE
feat(frontend): hide NOT_FOUND databases if not needed

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -275,6 +275,8 @@ const databaseList = computed(() => {
     list = databaseStore.getDatabaseListByPrincipalId(currentUser.value.id);
   }
 
+  list = list.filter((db) => db.syncStatus === "OK");
+
   const keyword = state.searchText.trim();
   list = list.filter((db) =>
     filterDatabaseByKeyword(db, keyword, [

--- a/frontend/src/components/ProjectDeploymentConfigPanel.vue
+++ b/frontend/src/components/ProjectDeploymentConfigPanel.vue
@@ -149,15 +149,14 @@ import {
   EMPTY_ID,
   DeploymentConfigPatch,
   LabelSelectorRequirement,
+  Database,
 } from "../types";
 import DeploymentConfigTool, { DeploymentMatrix } from "./DeploymentConfigTool";
 import { validateDeploymentConfig } from "../utils";
 import {
   pushNotification,
-  useDatabaseStore,
   useDeploymentStore,
   useEnvironmentList,
-  useEnvironmentStore,
   useProjectStore,
 } from "@/store";
 
@@ -177,13 +176,16 @@ export default defineComponent({
       required: true,
       type: Object as PropType<Project>,
     },
+    databaseList: {
+      type: Array as PropType<Database[]>,
+      default: () => [],
+    },
     allowEdit: {
       default: true,
       type: Boolean,
     },
   },
   setup(props) {
-    const databaseStore = useDatabaseStore();
     const deploymentStore = useDeploymentStore();
     const { t } = useI18n();
     const dialog = useDialog();
@@ -206,18 +208,7 @@ export default defineComponent({
       return true;
     });
 
-    const prepareList = () => {
-      useEnvironmentStore().fetchEnvironmentList();
-      databaseStore.fetchDatabaseListByProjectId(props.project.id);
-    };
-
     const environmentList = useEnvironmentList();
-
-    const databaseList = computed(() =>
-      databaseStore.getDatabaseListByProjectId(props.project.id)
-    );
-
-    watchEffect(prepareList);
 
     const resetStates = async () => {
       await nextTick(); // Waiting for all watchers done
@@ -359,7 +350,6 @@ export default defineComponent({
       isDeploymentConfigDirty,
       allowUpdateDeploymentConfig,
       environmentList,
-      databaseList,
       addStage,
       revertDeploymentConfig,
       updateDeploymentConfig,

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1740,5 +1740,8 @@
   "schema-diagram": {
     "self": "Schema Diagram",
     "fit-content-with-view": "Fit content within view"
+  },
+  "databases": {
+    "hide-not-found-databases": "Hide not found databases"
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1741,5 +1741,8 @@
   "schema-diagram": {
     "self": "Schema 展示图",
     "fit-content-with-view": "自动适应视图"
+  },
+  "databases": {
+    "hide-not-found-databases": "隐藏未找到的数据库"
   }
 }

--- a/frontend/src/views/InstanceDetail.vue
+++ b/frontend/src/views/InstanceDetail.vue
@@ -23,7 +23,7 @@
             :tab-item-list="tabItemList"
             :selected-index="state.selectedIndex"
             @select-index="
-              (index) => {
+              (index: number) => {
                 state.selectedIndex = index;
               }
             "
@@ -54,11 +54,21 @@
             </button>
           </div>
         </div>
-        <DatabaseTable
-          v-if="state.selectedIndex == DATABASE_TAB"
-          :mode="'INSTANCE'"
-          :database-list="databaseList"
-        />
+        <div v-if="state.selectedIndex == DATABASE_TAB">
+          <div class="mb-2 pl-4">
+            <BBCheckbox
+              :title="$t('databases.hide-not-found-databases')"
+              :value="state.hideNotFoundDatabases"
+              @toggle="state.hideNotFoundDatabases = $event"
+            />
+          </div>
+          <DatabaseTable
+            mode="INSTANCE"
+            :scroll-on-page-change="false"
+            :hide-not-found-databases="state.hideNotFoundDatabases"
+            :database-list="databaseList"
+          />
+        </div>
         <InstanceUserTable
           v-else-if="state.selectedIndex == USER_TAB"
           :instance-user-list="instanceUserList"
@@ -177,6 +187,7 @@ interface LocalState {
   showCreateDatabaseModal: boolean;
   syncingSchema: boolean;
   showFeatureModal: boolean;
+  hideNotFoundDatabases: boolean;
 }
 
 const props = defineProps({
@@ -201,6 +212,7 @@ const state = reactive<LocalState>({
   showCreateDatabaseModal: false,
   syncingSchema: false,
   showFeatureModal: false,
+  hideNotFoundDatabases: true,
 });
 
 const instance = computed((): Instance => {

--- a/frontend/src/views/ProjectDetail.vue
+++ b/frontend/src/views/ProjectDetail.vue
@@ -11,6 +11,7 @@
       v-if="isTenantProject"
       id="deployment-config"
       :project="project"
+      :database-list="databaseList"
       :allow-edit="allowEdit"
     />
     <ProjectDatabasesPanel
@@ -114,7 +115,9 @@ export default defineComponent({
 
     const databaseList = computed(() => {
       const list = cloneDeep(
-        databaseStore.getDatabaseListByProjectId(project.value.id)
+        databaseStore
+          .getDatabaseListByProjectId(project.value.id)
+          .filter((db) => db.syncStatus === "OK")
       );
       return sortDatabaseList(list, environmentList.value);
     });


### PR DESCRIPTION
A workaround of BYT-1941

### Changes

- Hide NOT_FOUND databases by default.
  - Databases dashboard
  - Project's databases list
  - Instance's databases list
  - Alter schema / Change data dialog
- Show a checkbox like "Hide not found databases" on the instance detail page, default checked.

### Screenshots

![localhost_3000_project_tpl-110(1600_900) (1)](https://user-images.githubusercontent.com/2749742/209088956-da99d25b-32d2-4421-8ce3-84d2ba460299.png)
