### PR TITLE
fix(frontend): 🔥 wrong issue entity cache

### DIFF
--- a/frontend/src/store/modules/issue.ts
+++ b/frontend/src/store/modules/issue.ts
@@ -150,9 +150,9 @@ export const useIssueStore = defineStore("issue", {
         getIssueFromIncludedList
       );
 
-      issueList.forEach((issue) =>
-        this.setIssueById({ issueId: issue.id, issue })
-      );
+      // The issue list API returns incomplete issue entities (without
+      // task.instance and task.database compositions)
+      // So we shouldn't store the incomplete cache items in issueById set here.
 
       const nextToken = isPagedResponse(responseData, "issues")
         ? responseData.data.attributes.nextToken


### PR DESCRIPTION
Thanks for the reporting from @Megrax 

Due to performance considerations, the `[GET] /api/issue` issue list API endpoint is a compact one, returning incomplete issue entities without composed `database` and `instance` relationships. So we shouldn't store them as a cache item.