### PR TITLE
fix: apply task's sheet id to others

### DIFF
--- a/frontend/src/components/Issue/IssueDetailLayout.vue
+++ b/frontend/src/components/Issue/IssueDetailLayout.vue
@@ -191,8 +191,8 @@ const {
   allowApplyIssueStatusTransition,
   allowApplyTaskStatusTransition,
   selectedStatement,
-  allowApplyStatementToOtherTasks,
-  applyStatementToOtherTasks,
+  allowApplyTaskStateToOthers,
+  applyTaskStateToOthers,
 } = useBaseIssueLogic({ issue, create });
 
 const issueLogic = ref<IssueLogic>();
@@ -388,8 +388,8 @@ provideIssueLogic(
     allowApplyIssueStatusTransition,
     allowApplyTaskStatusTransition,
     selectedStatement,
-    allowApplyStatementToOtherTasks,
-    applyStatementToOtherTasks,
+    allowApplyTaskStateToOthers,
+    applyTaskStateToOthers,
   },
   true
   // This is the root logic, could be overwritten by other (standard, gh-ost, tenant...) logic providers.

--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -12,11 +12,11 @@
         <span v-if="sqlHint" class="text-accent">{{ `(${sqlHint})` }}</span>
       </div>
       <button
-        v-if="allowApplyStatementToOtherTasks"
+        v-if="allowApplyTaskStateToOthers"
         :disabled="isEmpty(state.editStatement)"
         type="button"
         class="btn-small"
-        @click.prevent="applyStatementToOtherTasks(state.editStatement)"
+        @click.prevent="applyTaskStateToOthers(selectedTask as Task)"
       >
         {{ $t("issue.apply-to-other-tasks") }}
       </button>
@@ -233,8 +233,8 @@ const {
   selectedTask,
   updateStatement,
   updateSheetId,
-  allowApplyStatementToOtherTasks,
-  applyStatementToOtherTasks,
+  allowApplyTaskStateToOthers,
+  applyTaskStateToOthers,
 } = useIssueLogic();
 
 const { t } = useI18n();

--- a/frontend/src/components/Issue/logic/GhostModeProvider.ts
+++ b/frontend/src/components/Issue/logic/GhostModeProvider.ts
@@ -32,8 +32,8 @@ export default defineComponent({
       createIssue,
       isTenantMode,
       allowApplyTaskStatusTransition: baseAllowApplyTaskStatusTransition,
-      allowApplyStatementToOtherTasks: baseAllowApplyStatementToOtherTasks,
-      applyStatementToOtherTasks: baseApplyStatementToOtherTasks,
+      allowApplyTaskStateToOthers: baseAllowApplyTaskStateToOthers,
+      applyTaskStateToOthers: baseApplyTaskStateToOthers,
       onStatusChanged,
     } = useIssueLogic();
     const databaseStore = useDatabaseStore();
@@ -248,14 +248,15 @@ export default defineComponent({
       return baseAllowApplyTaskStatusTransition(task, to);
     };
 
-    const allowApplyStatementToOtherTasks = computed(() => {
-      // We are never allowed to "apply statement to other stages" in tenant mode.
+    const allowApplyTaskStateToOthers = computed(() => {
+      // We are never allowed to "apply task state to other stages" in tenant mode.
       if (isTenantMode.value) return false;
-      return baseAllowApplyStatementToOtherTasks.value;
+      return baseAllowApplyTaskStateToOthers.value;
     });
-    const applyStatementToOtherTasks = (statement: string) => {
-      if (!allowApplyStatementToOtherTasks.value) return;
-      return baseApplyStatementToOtherTasks(statement);
+
+    const applyTaskStateToOthers = (task: Task) => {
+      if (!allowApplyTaskStateToOthers.value) return;
+      return baseApplyTaskStateToOthers(task);
     };
 
     const logic = {
@@ -263,8 +264,8 @@ export default defineComponent({
       selectedStatement,
       doCreate,
       allowApplyTaskStatusTransition,
-      allowApplyStatementToOtherTasks,
-      applyStatementToOtherTasks,
+      allowApplyTaskStateToOthers,
+      applyTaskStateToOthers,
       updateStatement,
       updateSheetId,
     };

--- a/frontend/src/components/Issue/logic/IssueLogic.ts
+++ b/frontend/src/components/Issue/logic/IssueLogic.ts
@@ -63,8 +63,8 @@ type IssueLogic = {
     postUpdated?: (updatedTask: Task) => void
   ) => any;
   updateSheetId: (sheetId: SheetId | undefined) => void;
-  allowApplyStatementToOtherTasks: Ref<boolean>;
-  applyStatementToOtherTasks: (statement: string) => any;
+  allowApplyTaskStateToOthers: Ref<boolean>;
+  applyTaskStateToOthers: (task: Task) => any;
   doCreate(): any;
 
   // events

--- a/frontend/src/components/Issue/logic/TenantModeProvider.ts
+++ b/frontend/src/components/Issue/logic/TenantModeProvider.ts
@@ -101,8 +101,8 @@ export default defineComponent({
       context.detailList.forEach((detail) => (detail.sheetId = sheetId));
     };
 
-    // We are never allowed to "apply statement to other stages" in tenant mode.
-    const allowApplyStatementToOtherTasks = computed(() => false);
+    // We are never allowed to "apply task state to other stages" in tenant mode.
+    const allowApplyTaskStateToOthers = computed(() => false);
 
     const doCreate = () => {
       const issueCreate = cloneDeep(issue.value as IssueCreate);
@@ -130,8 +130,8 @@ export default defineComponent({
       selectedStatement,
       updateStatement,
       updateSheetId,
-      allowApplyStatementToOtherTasks,
-      applyStatementToOtherTasks: errorAssertion,
+      allowApplyTaskStateToOthers,
+      applyTaskStateToOthers: errorAssertion,
       doCreate,
     };
     provideIssueLogic(logic);

--- a/frontend/src/components/Issue/logic/base.ts
+++ b/frontend/src/components/Issue/logic/base.ts
@@ -1,5 +1,5 @@
 import { computed, Ref } from "vue";
-import { isEmpty } from "lodash-es";
+import { isEmpty, isUndefined } from "lodash-es";
 import {
   Issue,
   IssueCreate,
@@ -24,7 +24,9 @@ import {
 import { useDatabaseStore, useIssueStore, useProjectStore } from "@/store";
 import {
   flattenTaskList,
+  sheetIdOfTask,
   statementOfTask,
+  TaskTypeWithSheetId,
   TaskTypeWithStatement,
 } from "./common";
 
@@ -220,14 +222,16 @@ export const useBaseIssueLogic = (params: {
     return statementOfTask(task as Task) || "";
   });
 
-  const allowApplyStatementToOtherTasks = computed(() => {
+  const allowApplyTaskStateToOthers = computed(() => {
     if (!create.value) {
       return false;
     }
     const taskList = flattenTaskList<TaskCreate>(issue.value);
-    // Allowed when more than one tasks need SQL statement.
-    const count = taskList.filter((task) =>
-      TaskTypeWithStatement.includes(task.type)
+    // Allowed when more than one tasks need SQL statement or sheet.
+    const count = taskList.filter(
+      (task) =>
+        TaskTypeWithStatement.includes(task.type) ||
+        TaskTypeWithSheetId.includes(task.type)
     ).length;
 
     return count > 1;
@@ -249,12 +253,18 @@ export const useBaseIssueLogic = (params: {
     return true;
   };
 
-  const applyStatementToOtherTasks = (statement: string) => {
+  const applyTaskStateToOthers = (task: Task) => {
     const taskList = flattenTaskList<TaskCreate>(issue.value);
+    const sheetId = sheetIdOfTask(task);
+    const statement = statementOfTask(task);
 
-    for (const task of taskList) {
-      if (TaskTypeWithStatement.includes(task.type)) {
-        task.statement = statement;
+    for (const taskItem of taskList) {
+      if (TaskTypeWithStatement.includes(taskItem.type)) {
+        if (!isUndefined(sheetId)) {
+          taskItem.sheetId = sheetId;
+        } else {
+          taskItem.statement = statement ?? "";
+        }
       }
     }
   };
@@ -273,8 +283,8 @@ export const useBaseIssueLogic = (params: {
     taskStatusOfStage,
     isValidStage,
     selectedStatement,
-    allowApplyStatementToOtherTasks,
-    applyStatementToOtherTasks,
+    allowApplyTaskStateToOthers,
+    applyTaskStateToOthers,
     allowApplyIssueStatusTransition,
     allowApplyTaskStatusTransition,
   };


### PR DESCRIPTION
refactor `applyStatementToOtherTasks` to `applyTaskStateToOthers`. 

Task's state including its statement and sheetId. And sheetId has a higher priority than statement.