### PR TITLE
feat: support mysql/tidb ssl

### DIFF
--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -404,7 +404,11 @@ const defaultPort = computed(() => {
 });
 
 const showSSL = computed((): boolean => {
-  return state.instance.engine === "CLICKHOUSE";
+  return (
+    state.instance.engine === "CLICKHOUSE" ||
+    state.instance.engine === "MYSQL" ||
+    state.instance.engine === "TIDB"
+  );
 });
 
 const showDatabase = computed((): boolean => {

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -79,10 +79,6 @@ func (driver *Driver) Open(ctx context.Context, dbType db.Type, connCfg db.Conne
 		return nil, errors.Wrap(err, "sql: tls config error")
 	}
 
-	dsn := fmt.Sprintf("%s@%s(%s:%s)/%s?%s", connCfg.Username, protocol, connCfg.Host, port, connCfg.Database, strings.Join(params, "&"))
-	if connCfg.Password != "" {
-		dsn = fmt.Sprintf("%s:%s@%s(%s:%s)/%s?%s", connCfg.Username, connCfg.Password, protocol, connCfg.Host, port, connCfg.Database, strings.Join(params, "&"))
-	}
 	tlsKey := "db.mysql.tls"
 	if tlsConfig != nil {
 		if err := mysql.RegisterTLSConfig(tlsKey, tlsConfig); err != nil {
@@ -90,7 +86,11 @@ func (driver *Driver) Open(ctx context.Context, dbType db.Type, connCfg db.Conne
 		}
 		// TLS config is only used during sql.Open, so should be safe to deregister afterwards.
 		defer mysql.DeregisterTLSConfig(tlsKey)
-		dsn += fmt.Sprintf("&tls=%s", tlsKey)
+		params = append(params, fmt.Sprintf("tls=%s", tlsKey))
+	}
+	dsn := fmt.Sprintf("%s@%s(%s:%s)/%s?%s", connCfg.Username, protocol, connCfg.Host, port, connCfg.Database, strings.Join(params, "&"))
+	if connCfg.Password != "" {
+		dsn = fmt.Sprintf("%s:%s@%s(%s:%s)/%s?%s", connCfg.Username, connCfg.Password, protocol, connCfg.Host, port, connCfg.Database, strings.Join(params, "&"))
 	}
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -90,7 +90,7 @@ func (driver *Driver) Open(ctx context.Context, dbType db.Type, connCfg db.Conne
 		}
 		// TLS config is only used during sql.Open, so should be safe to deregister afterwards.
 		defer mysql.DeregisterTLSConfig(tlsKey)
-		dsn += fmt.Sprintf("?tls=%s", tlsKey)
+		dsn += fmt.Sprintf("&tls=%s", tlsKey)
 	}
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/server/sql.go
+++ b/server/sql.go
@@ -53,7 +53,8 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		}
 
 		var tlsConfig db.TLSConfig
-		if connectionInfo.Engine == db.ClickHouse {
+		supportTls := (connectionInfo.Engine == db.ClickHouse || connectionInfo.Engine == db.MySQL || connectionInfo.Engine == db.TiDB)
+		if supportTls {
 			if connectionInfo.SslCa == nil && connectionInfo.SslCert == nil && connectionInfo.SslKey == nil && connectionInfo.InstanceID != nil {
 				// Frontend will not pass ssl related field if user don't modify ssl suite, we need get ssl suite from database for this case.
 				tc, err := s.store.GetInstanceSslSuiteByID(ctx, *connectionInfo.InstanceID)

--- a/server/sql.go
+++ b/server/sql.go
@@ -53,8 +53,8 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 		}
 
 		var tlsConfig db.TLSConfig
-		supportTls := (connectionInfo.Engine == db.ClickHouse || connectionInfo.Engine == db.MySQL || connectionInfo.Engine == db.TiDB)
-		if supportTls {
+		supportTLS := (connectionInfo.Engine == db.ClickHouse || connectionInfo.Engine == db.MySQL || connectionInfo.Engine == db.TiDB)
+		if supportTLS {
 			if connectionInfo.SslCa == nil && connectionInfo.SslCert == nil && connectionInfo.SslKey == nil && connectionInfo.InstanceID != nil {
 				// Frontend will not pass ssl related field if user don't modify ssl suite, we need get ssl suite from database for this case.
 				tc, err := s.store.GetInstanceSslSuiteByID(ctx, *connectionInfo.InstanceID)


### PR DESCRIPTION
close BYT-2177

Maybe there's still some front-end work left unfinished. cc @LiuJi-Jim @boojack 

I do the local test with MySQL and TiDB.
1. open the ssl feature in the database engine
2. create the user REQUIRE SSL
3. connect in Bytebase

MySQL without SSL
![6Bf0TG3d0y](https://user-images.githubusercontent.com/20775801/209314112-ebeb3bc9-a234-4bed-8c9b-63e277b7b096.jpg)
MySQL with SSL
![F9UpJM14Xu](https://user-images.githubusercontent.com/20775801/209314133-388faa69-71b9-4cb6-a7a7-6e2a316648e0.jpg)

TiDB without SSL
![Plqo8UBjWY](https://user-images.githubusercontent.com/20775801/209314186-d47a9625-f387-40b0-8168-516aa0c9531c.jpg)
TiDB with SSL
![ZBwh5GCYaK](https://user-images.githubusercontent.com/20775801/209314247-b5cb1e0c-0e9d-4942-9088-b2b598934c9e.jpg)
