### PR TITLE
fix(mongodb): using id directly

### DIFF
--- a/plugin/db/mongodb/migrate.go
+++ b/plugin/db/mongodb/migrate.go
@@ -3,7 +3,6 @@ package mongodb
 import (
 	"context"
 	"database/sql"
-	"strconv"
 	"time"
 
 	// embed will embeds the migration schema.
@@ -125,11 +124,7 @@ func (driver *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Mig
 	collection := database.Collection(migrationHistoryDefaultCollection)
 	filter := bson.M{}
 	if v := find.ID; v != nil {
-		id, err := primitive.ObjectIDFromHex(strconv.Itoa(*v))
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to convert id %q to object id", strconv.Itoa(*v))
-		}
-		filter["id"] = id
+		filter["id"] = *v
 	}
 	if v := find.Database; v != nil {
 		filter["namespace"] = *v


### PR DESCRIPTION
We use `id` instead of `_id`, so we don't need to generate ObjectID object anymore.
![CleanShot 2022-12-23 at 17 56 25](https://user-images.githubusercontent.com/87714218/209315674-5f956608-56b1-4e64-b3ba-872cbb2a7d85.gif)
