### PR TITLE
chore(mongodb): using admin as placeholder in authSource

### DIFF
--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -210,7 +210,7 @@
             type="text"
             class="textfield mt-1 w-full"
             autocomplete="off"
-            placeholder="Auth Source"
+            placeholder="admin"
             :value="state.instance.authSource"
             @input="handleInstanceAuthSourceInput"
           />


### PR DESCRIPTION
If defaultauthdb is unspecified, then [authSource](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource) defaults to admin.