### PR TITLE
feat(frontend): better MongoDB support while using MonacoEditor

### DIFF
--- a/frontend/src/components/InstanceEngineIcon.vue
+++ b/frontend/src/components/InstanceEngineIcon.vue
@@ -2,7 +2,7 @@
   <NTooltip>
     <template #trigger>
       <div class="relative w-4" v-bind="$attrs">
-        <img class="h-4 w-auto" :src="SelectedEngineIconPath" />
+        <img class="h-4 w-auto mx-auto" :src="SelectedEngineIconPath" />
         <div
           v-if="showStatus"
           class="bg-green-400 border-surface-high rounded-full absolute border-2"

--- a/frontend/src/components/MonacoEditor/useMonaco.ts
+++ b/frontend/src/components/MonacoEditor/useMonaco.ts
@@ -6,10 +6,12 @@ import { getBBTheme } from "./themes/bb";
 import { getBBDarkTheme } from "./themes/bb-dark";
 
 export const useMonaco = async () => {
-  const [monaco, { default: EditorWorker }] = await Promise.all([
-    import("monaco-editor"),
-    import("monaco-editor/esm/vs/editor/editor.worker?worker"),
-  ]);
+  const [monaco, { default: EditorWorker }, { default: TSWorker }] =
+    await Promise.all([
+      import("monaco-editor"),
+      import("monaco-editor/esm/vs/editor/editor.worker?worker"),
+      import("monaco-editor/esm/vs/language/typescript/ts.worker?worker"),
+    ]);
 
   const bbTheme = getBBTheme();
   const bbDarkTheme = getBBDarkTheme();
@@ -19,6 +21,9 @@ export const useMonaco = async () => {
   self.MonacoEnvironment = {
     getWorker: (workerId, label) => {
       console.debug("MonacoEnvironment.getWorker", workerId, label);
+      if (label === "javascript") {
+        return new TSWorker();
+      }
       return new EditorWorker();
     },
   };

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1419,7 +1419,8 @@
     "connect-in-admin-mode": "Connect in admin mode",
     "admin-mode": {
       "self": "Admin mode"
-    }
+    },
+    "read-only-mode-not-allowed": "Instance {instance} is not accessible in read-only mode."
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1419,7 +1419,8 @@
     "connect-in-admin-mode": "以管理员模式连接",
     "admin-mode": {
       "self": "管理员模式"
-    }
+    },
+    "read-only-mode-not-allowed": "实例{instance}无法通过只读模式访问。"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/types/sqlEditor.ts
+++ b/frontend/src/types/sqlEditor.ts
@@ -6,6 +6,7 @@ export type EditorModel = monaco.editor.ITextModel;
 export type EditorPosition = monaco.Position;
 export type CompletionItems = monaco.languages.CompletionItem[];
 
+export type Language = "sql" | "javascript";
 export type SQLDialect = "mysql" | "postgresql";
 
 export enum SortText {

--- a/frontend/src/utils/instance.ts
+++ b/frontend/src/utils/instance.ts
@@ -1,4 +1,5 @@
-import { Environment, Instance } from "../types";
+import { computed, unref } from "vue";
+import { Environment, Instance, Language, MaybeRef } from "../types";
 
 export function instanceName(instance: Instance) {
   let name = instance.name;
@@ -32,3 +33,14 @@ export function sortInstanceList(
     return bEnvIndex - aEnvIndex;
   });
 }
+
+export const useInstanceEditorLanguage = (
+  instance: MaybeRef<Instance | undefined>
+) => {
+  return computed((): Language => {
+    if (unref(instance)?.engine === "MONGODB") {
+      return "javascript";
+    }
+    return "sql";
+  });
+};

--- a/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
@@ -6,6 +6,7 @@
       ref="editorRef"
       v-model:value="sqlCode"
       class="w-full h-full"
+      :language="selectedLanguage"
       :dialect="selectedDialect"
       :readonly="readonly"
       @change="handleChange"
@@ -36,6 +37,7 @@ import type {
   SQLDialect,
 } from "@/types";
 import { TableMetadata } from "@/types/proto/store/database";
+import { useInstanceEditorLanguage } from "@/utils";
 
 const emit = defineEmits<{
   (e: "save-sheet", content?: string): void;
@@ -63,6 +65,7 @@ const selectedInstance = useInstanceById(
 const selectedInstanceEngine = computed(() => {
   return instanceStore.formatEngine(selectedInstance.value);
 });
+const selectedLanguage = useInstanceEditorLanguage(selectedInstance);
 const selectedDialect = computed((): SQLDialect => {
   const engine = selectedInstanceEngine.value;
   if (engine === "PostgreSQL") {

--- a/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
@@ -4,24 +4,10 @@
       ref="editorRef"
       class="w-full h-auto max-h-[360px]"
       :value="sql"
+      :language="selectedLanguage"
       :dialect="selectedDialect"
       :readonly="readonly"
-      :options="{
-        theme: 'bb-dark',
-        minimap: {
-          enabled: false,
-        },
-        scrollbar: {
-          vertical: 'hidden',
-          horizontal: 'hidden',
-          alwaysConsumeMouseWheel: false,
-        },
-        overviewRulerLanes: 0,
-        lineNumbers: getLineNumber,
-        lineNumbersMinChars: 5,
-        glyphMargin: false,
-        cursorStyle: 'block',
-      }"
+      :options="EDITOR_OPTIONS"
       @change="handleChange"
       @change-selection="handleChangeSelection"
       @save="handleSaveSheet"
@@ -32,6 +18,7 @@
 
 <script lang="ts" setup>
 import { computed, nextTick, ref, watch, watchEffect } from "vue";
+import { editor as Editor } from "monaco-editor";
 
 import {
   useInstanceStore,
@@ -44,6 +31,7 @@ import {
 import MonacoEditor from "@/components/MonacoEditor/MonacoEditor.vue";
 import { Database, ExecuteConfig, ExecuteOption, SQLDialect } from "@/types";
 import { TableMetadata } from "@/types/proto/store/database";
+import { useInstanceEditorLanguage } from "@/utils";
 
 const props = defineProps({
   sql: {
@@ -83,6 +71,7 @@ const selectedInstance = useInstanceById(
 const selectedInstanceEngine = computed(() => {
   return instanceStore.formatEngine(selectedInstance.value);
 });
+const selectedLanguage = useInstanceEditorLanguage(selectedInstance);
 const selectedDialect = computed((): SQLDialect => {
   const engine = selectedInstanceEngine.value;
   if (engine === "PostgreSQL") {
@@ -110,6 +99,10 @@ watch(
   }
 );
 
+const firstLinePrompt = computed(() => {
+  return selectedLanguage.value === "sql" ? "SQL>" : "MONGO>";
+});
+
 const getLineNumber = (lineNumber: number) => {
   /*
     Show a SQL CLI like command prompt.
@@ -117,7 +110,9 @@ const getLineNumber = (lineNumber: number) => {
       -> second_line
       -> more_lines
   */
-  if (lineNumber === 1) return "SQL>";
+  if (lineNumber === 1) {
+    return firstLinePrompt.value;
+  }
   return "->";
 };
 
@@ -257,4 +252,25 @@ const updateEditorHeight = () => {
   }
   editorRef.value?.setEditorContentHeight(actualHeight);
 };
+
+const EDITOR_OPTIONS = ref<Editor.IStandaloneEditorConstructionOptions>({
+  theme: "bb-dark",
+  minimap: {
+    enabled: false,
+  },
+  scrollbar: {
+    vertical: "hidden",
+    horizontal: "hidden",
+    alwaysConsumeMouseWheel: false,
+  },
+  overviewRulerLanes: 0,
+  lineNumbers: getLineNumber,
+  lineNumbersMinChars: firstLinePrompt.value.length + 1,
+  glyphMargin: false,
+  cursorStyle: "block",
+});
+watch(
+  firstLinePrompt,
+  (prompt) => (EDITOR_OPTIONS.value.lineNumbersMinChars = prompt.length + 1)
+);
 </script>


### PR DESCRIPTION
### Changes

- Only enable SQL Editor for MongoDB database in admin mode (BYT-2207).
- Use javascript language support in MonacoEditor for MongoDB.
- Show "Statement" instead of "SQL" on the issue detail page for MongoDB tasks.
- Horizontal center aligned MongoDB engine icon.

### Screenshots

![localhost_3000_issue_db1-change-data-12-27-1550-utc0800-186_stage=prod-stage-1 task=dmldata-for-database-db1-597(1600_900)](https://user-images.githubusercontent.com/2749742/209633284-f635366e-c1d6-4cc6-a65b-4cb7a6adeca2.png)

![localhost_3000_sql-editor_prod-mongodb6-115_db1-362(1600_900) (1)](https://user-images.githubusercontent.com/2749742/209633298-20403109-cf40-480c-aba5-580569383c63.png)

![localhost_3000_sql-editor_prod-mongodb6-115_db1-362(1600_900)](https://user-images.githubusercontent.com/2749742/209633303-8e1d4fe0-b061-4193-a39a-21d69d7a7221.png)
