### PR TITLE
feat(schema-diagram): preview schema changes in schema diagram from schema editor

### DIFF
--- a/frontend/src/components/SchemaDiagram/ER/TableNode.vue
+++ b/frontend/src/components/SchemaDiagram/ER/TableNode.vue
@@ -27,8 +27,8 @@
         :bb-column-name="column.name"
         :bb-status="columnStatus(column)"
         :class="[
-          isDroppedColumn(column) && 'text-red-700 bg-red-50 line-through',
-          isCreatedColumn(column) && 'text-green-700 bg-green-50',
+          isColumnDropped(column) && 'text-red-700 bg-red-50 line-through',
+          isColumnCreated(column) && 'text-green-700 bg-green-50',
         ]"
       >
         <td class="w-5 py-1.5">
@@ -108,11 +108,11 @@ const isTableChanged = computed(() => {
   return tableStatus(props.table) === "changed";
 });
 
-const isDroppedColumn = (column: ColumnMetadata) => {
+const isColumnDropped = (column: ColumnMetadata) => {
   return columnStatus(column) === "dropped";
 };
 
-const isCreatedColumn = (column: ColumnMetadata) => {
+const isColumnCreated = (column: ColumnMetadata) => {
   return columnStatus(column) === "created";
 };
 

--- a/frontend/src/components/SchemaDiagram/ER/TableNode.vue
+++ b/frontend/src/components/SchemaDiagram/ER/TableNode.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute rounded-md shadow-lg border-b border-gray-200 bg-white w-[16rem] divide-y z-[10]"
+    class="absolute overflow-hidden rounded-md shadow-lg border-b border-gray-200 bg-white w-[16rem] divide-y z-[10]"
     bb-node-type="table"
     :bb-node-id="idOfTable(table)"
     :bb-status="tableStatus(table)"

--- a/frontend/src/components/SchemaDiagram/ER/TableNode.vue
+++ b/frontend/src/components/SchemaDiagram/ER/TableNode.vue
@@ -3,24 +3,33 @@
     class="absolute rounded-md shadow-lg border-b border-gray-200 bg-white w-[16rem] divide-y z-[10]"
     bb-node-type="table"
     :bb-node-id="idOfTable(table)"
+    :bb-status="tableStatus(table)"
     :style="{
       left: `${position.x}px`,
       top: `${position.y}px`,
     }"
   >
     <h3
-      class="font-medium leading-6 text-white text-center truncate px-2 py-2 rounded-t-md"
+      class="font-medium leading-6 text-white truncate px-2 py-2 rounded-t-md flex items-center justify-center gap-x-1"
       :style="{
         'background-color': tableColor,
       }"
     >
-      {{ table.name }}
+      <span :class="[isTableDropped && 'line-through']">{{ table.name }}</span>
+      <span v-if="isTableCreated" class="text-xs">(Created)</span>
+      <span v-if="isTableDropped" class="text-xs">(Dropped)</span>
+      <span v-if="isTableChanged" class="text-xs">(Changed)</span>
     </h3>
     <table class="w-full text-sm table-fixed">
       <tr
         v-for="(column, i) in table.columns"
         :key="i"
         :bb-column-name="column.name"
+        :bb-status="columnStatus(column)"
+        :class="[
+          isDroppedColumn(column) && 'text-red-700 bg-red-50 line-through',
+          isCreatedColumn(column) && 'text-green-700 bg-green-50',
+        ]"
       >
         <td class="w-5 py-1.5">
           <heroicons-outline:key
@@ -51,7 +60,7 @@
 import { computed } from "vue";
 
 import { hashCode } from "@/bbkit/BBUtil";
-import { TableMetadata } from "@/types/proto/store/database";
+import { ColumnMetadata, TableMetadata } from "@/types/proto/store/database";
 import { useSchemaDiagramContext, isPrimaryKey, isIndex } from "../common";
 
 const props = withDefaults(
@@ -60,7 +69,8 @@ const props = withDefaults(
   }>(),
   {}
 );
-const { idOfTable, rectOfTable } = useSchemaDiagramContext();
+const { idOfTable, rectOfTable, tableStatus, columnStatus } =
+  useSchemaDiagramContext();
 
 const COLOR_LIST = [
   "#64748B",
@@ -85,6 +95,26 @@ const tableColor = computed(() => {
   const index = (hashCode(props.table.name) & 0xfffffff) % COLOR_LIST.length;
   return COLOR_LIST[index];
 });
+
+const isTableDropped = computed(() => {
+  return tableStatus(props.table) === "dropped";
+});
+
+const isTableCreated = computed(() => {
+  return tableStatus(props.table) === "created";
+});
+
+const isTableChanged = computed(() => {
+  return tableStatus(props.table) === "changed";
+});
+
+const isDroppedColumn = (column: ColumnMetadata) => {
+  return columnStatus(column) === "dropped";
+};
+
+const isCreatedColumn = (column: ColumnMetadata) => {
+  return columnStatus(column) === "created";
+};
 
 const position = computed(() => rectOfTable(props.table));
 </script>

--- a/frontend/src/components/SchemaDiagram/index.ts
+++ b/frontend/src/components/SchemaDiagram/index.ts
@@ -1,3 +1,4 @@
+export * from "./types";
 import SchemaDiagram from "./SchemaDiagram.vue";
 import SchemaDiagramIcon from "./SchemaDiagramIcon.vue";
 

--- a/frontend/src/components/SchemaDiagram/types/context.ts
+++ b/frontend/src/components/SchemaDiagram/types/context.ts
@@ -1,8 +1,9 @@
 import { Ref } from "vue";
 import type Emittery from "emittery";
-import { TableMetadata } from "@/types/proto/store/database";
 
+import { ColumnMetadata, TableMetadata } from "@/types/proto/store/database";
 import { Position, Rect } from "./geometry";
+import { EditStatus } from "./edit";
 
 // This is an abstract Schema Diagram context including states, methods and
 // events. This should be implemented in the root component of SchemaDiagram
@@ -22,6 +23,8 @@ export type SchemaDiagramContext = {
   render: () => void;
   // auto-layout all components
   layout: () => void;
+  tableStatus: (table: TableMetadata) => EditStatus;
+  columnStatus: (column: ColumnMetadata) => EditStatus;
 
   // Events
   events: Emittery<{

--- a/frontend/src/components/SchemaDiagram/types/edit.ts
+++ b/frontend/src/components/SchemaDiagram/types/edit.ts
@@ -1,0 +1,1 @@
+export type EditStatus = "normal" | "changed" | "created" | "dropped";

--- a/frontend/src/components/SchemaDiagram/types/index.ts
+++ b/frontend/src/components/SchemaDiagram/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./context";
 export * from "./geometry";
 export * from "./schema";
+export * from "./edit";

--- a/frontend/src/components/SchemaEditor/Panels/DatabaseEditor.vue
+++ b/frontend/src/components/SchemaEditor/Panels/DatabaseEditor.vue
@@ -157,7 +157,9 @@
       <SchemaDiagram
         :key="currentTab.databaseId"
         :database="database"
-        :table-list="dbSchemaStore.getTableListByDatabaseId(database.id)"
+        :table-list="tableMetadataList"
+        :table-status="tableStatus"
+        :column-status="columnStatus"
       />
     </template>
   </div>
@@ -178,7 +180,6 @@ import { computed, onMounted, reactive, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   generateUniqueTabId,
-  useDBSchemaStore,
   useNotificationStore,
   useSchemaEditorStore,
 } from "@/store";
@@ -195,6 +196,7 @@ import { diffSchema } from "@/utils/schemaEditor/diffSchema";
 import HighlightCodeBlock from "@/components/HighlightCodeBlock";
 import TableNameModal from "../Modals/TableNameModal.vue";
 import SchemaDiagram from "@/components/SchemaDiagram";
+import { useMetadataForDiagram } from "../utils/useMetadataForDiagram";
 
 type TabType = "table-list" | "schema-diagram" | "raw-sql";
 
@@ -212,7 +214,6 @@ interface LocalState {
 
 const { t } = useI18n();
 const editorStore = useSchemaEditorStore();
-const dbSchemaStore = useDBSchemaStore();
 const notificationStore = useNotificationStore();
 const state = reactive<LocalState>({
   selectedTab: "table-list",
@@ -371,6 +372,9 @@ const handleDropTable = (table: Table) => {
 const handleRestoreTable = (table: Table) => {
   editorStore.restoreTable(table);
 };
+
+const { tableMetadataList, tableStatus, columnStatus } =
+  useMetadataForDiagram(databaseSchema);
 </script>
 
 <style scoped>

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -69,6 +69,10 @@ export const useMetadataForDiagram = (
           return columnMeta;
         });
 
+        // We don't have indexes other than primary key, so something will lost
+        // here when converting Table back to TableMetadata.
+        // But they will be back soon when editing indexes supported in Schema
+        // Editor.
         tableMeta.indexes = [
           {
             primary: true,

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -88,7 +88,9 @@ export const useMetadataForDiagram = (
         );
 
         tableMeta.foreignKeys = foreignKeyList.map((fk) => {
-          const refSchema = unref(schemaList).find(
+          // In PostgreSQL, foreign keys can cross different schemas.
+          // So we need to search the schemaList here.
+          const refSchema = schemaList.find(
             (schema) => schema.name === fk.referencedSchema
           )!;
           const refTable = refSchema.tableList.find(

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -70,10 +70,11 @@ export const useMetadataForDiagram = (
           return columnMeta;
         });
 
-        // We don't have indexes other than primary key, so something will lost
-        // here when converting Table back to TableMetadata.
-        // But they will be back soon when editing indexes supported in Schema
-        // Editor.
+        // We don't have indexes other than primary key in Schema Editor,
+        // so something will lost here when converting Table back to
+        // TableMetadata.
+        // But they will be back soon when editing indexes is supported in
+        // Schema Editor.
         const pk = IndexMetadata.fromPartial({});
         Object.assign(pk, {
           primary: true,

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -6,6 +6,7 @@ import { EditStatus } from "@/components/SchemaDiagram";
 import {
   ColumnMetadata,
   ForeignKeyMetadata,
+  IndexMetadata,
   TableMetadata,
 } from "@/types/proto/store/database";
 import { isTableChanged } from "./table";
@@ -73,19 +74,15 @@ export const useMetadataForDiagram = (
         // here when converting Table back to TableMetadata.
         // But they will be back soon when editing indexes supported in Schema
         // Editor.
-        tableMeta.indexes = [
-          {
-            primary: true,
-            type: "",
-            unique: true,
-            comment: "",
-            visible: true,
-            name: table.primaryKey.name,
-            expressions: table.primaryKey.columnIdList.map(
-              (id) => table.columnList.find((col) => col.id === id)!.name
-            ),
-          },
-        ];
+        const pk = IndexMetadata.fromPartial({});
+        Object.assign(pk, {
+          primary: true,
+          name: table.primaryKey.name,
+          expressions: table.primaryKey.columnIdList.map(
+            (id) => table.columnList.find((col) => col.id === id)!.name
+          ),
+        });
+        tableMeta.indexes = [pk];
         const foreignKeyList = schema.foreignKeyList.filter(
           (fk) => fk.tableId === table.id
         );

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -83,10 +83,10 @@ export const useMetadataForDiagram = (
           ),
         });
         tableMeta.indexes = [pk];
+
         const foreignKeyList = schema.foreignKeyList.filter(
           (fk) => fk.tableId === table.id
         );
-
         tableMeta.foreignKeys = foreignKeyList.map((fk) => {
           // In PostgreSQL, foreign keys can cross different schemas.
           // So we need to search the schemaList here.

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -11,7 +11,7 @@ import {
 import { isTableChanged } from "./table";
 
 type MetadataWithEditStatus<T> = T & {
-  $$status: EditStatus;
+  $$status?: EditStatus;
 };
 
 const statusOfTable = (

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -1,0 +1,131 @@
+import { computed, unref } from "vue";
+
+import { Database, DatabaseSchema, MaybeRef } from "@/types";
+import { Column, Schema, Table } from "@/types/schemaEditor/atomType";
+import { EditStatus } from "@/components/SchemaDiagram";
+import {
+  ColumnMetadata,
+  ForeignKeyMetadata,
+  TableMetadata,
+} from "@/types/proto/store/database";
+import { isTableChanged } from "./table";
+
+const statusOfTable = (
+  database: Database,
+  schema: Schema,
+  table: Table
+): EditStatus => {
+  const { status } = table;
+  if (status === "created" || status === "dropped") {
+    return status;
+  }
+  if (isTableChanged(database.id, schema.name, table.id)) {
+    return "changed";
+  }
+
+  return "normal";
+};
+
+export const useMetadataForDiagram = (
+  databaseSchema: MaybeRef<DatabaseSchema>
+) => {
+  const tableMetadataList = computed(() => {
+    const { database, schemaList } = unref(databaseSchema);
+
+    return unref(schemaList).flatMap((schema) => {
+      const { tableList } = schema;
+
+      return tableList.map((table) => {
+        const tableMeta = TableMetadata.fromPartial({});
+        Object.defineProperty(tableMeta, "$$status", {
+          enumerable: false,
+          value: statusOfTable(database, schema, table),
+        });
+
+        tableMeta.name = table.name;
+        tableMeta.engine = table.engine;
+        tableMeta.collation = table.collation;
+        tableMeta.rowCount = table.rowCount;
+        tableMeta.dataSize = table.dataSize;
+        tableMeta.comment = table.comment;
+
+        tableMeta.columns = table.columnList.map((column) => {
+          const columnMeta = ColumnMetadata.fromPartial({});
+          Object.defineProperty(columnMeta, "$$column", {
+            enumerable: false,
+            value: column,
+          });
+
+          columnMeta.name = column.name;
+          columnMeta.type = column.type;
+          columnMeta.nullable = column.nullable;
+          columnMeta.comment = column.comment;
+          columnMeta.default = column.default;
+
+          return columnMeta;
+        });
+
+        tableMeta.indexes = [
+          {
+            primary: true,
+            type: "",
+            unique: true,
+            comment: "",
+            visible: true,
+            name: table.primaryKey.name,
+            expressions: table.primaryKey.columnIdList.map(
+              (id) => table.columnList.find((col) => col.id === id)!.name
+            ),
+          },
+        ];
+        const foreignKeyList = schema.foreignKeyList.filter(
+          (fk) => fk.tableId === table.id
+        );
+
+        tableMeta.foreignKeys = foreignKeyList.map((fk) => {
+          const refSchema = unref(schemaList).find(
+            (schema) => schema.name === fk.referencedSchema
+          )!;
+          const refTable = refSchema.tableList.find(
+            (table) => table.id === fk.referencedTableId
+          )!;
+          const fkMeta = ForeignKeyMetadata.fromPartial({});
+          Object.assign(fkMeta, {
+            columns: fk.columnIdList.map(
+              (id) => table.columnList.find((col) => col.id === id)!.name
+            ),
+            name: fk.name,
+            referencedSchema: refSchema.name,
+            referencedTable: refTable.name,
+            referencedColumns: fk.referencedColumnIdList.map(
+              (id) => refTable.columnList.find((col) => col.id === id)!.name
+            ),
+          });
+          return fkMeta;
+        });
+        return tableMeta;
+      });
+    });
+  });
+
+  const tableStatus = (tableMeta: TableMetadata): EditStatus => {
+    const status = (tableMeta as any).$$status as EditStatus;
+    if (typeof status !== "undefined") {
+      return status;
+    }
+    return "normal";
+  };
+  const columnStatus = (columnMeta: ColumnMetadata): EditStatus => {
+    const column = (columnMeta as any).$$column as Column;
+    if (column) {
+      return column.status;
+    }
+    return "normal";
+  };
+
+  return {
+    tableMetadataList,
+    tableStatus,
+    columnStatus,
+  };
+};


### PR DESCRIPTION
Close BYT-2166

FYI @tianzhou @Candybase 

We now support colorizing these kinds of schema changes (basically the same as Schema Editor)

- Table
  - Created / Dropped / Changed
- Column
  - Created / Dropped

### Screenshots

https://user-images.githubusercontent.com/2749742/210339533-7cbf9f64-8a27-4c6f-b25f-7c52ee4db818.mp4

