### PR TITLE
chore: skip schema version sync except for force sync

### DIFF
--- a/server/deploy.go
+++ b/server/deploy.go
@@ -1,0 +1,1 @@
+package server

--- a/server/runner/taskrun/executor.go
+++ b/server/runner/taskrun/executor.go
@@ -283,12 +283,14 @@ func postMigration(ctx context.Context, store *store.Store, activityManager *act
 		return true, nil, errors.Errorf("failed to find linked repository for database %q", task.Database.Name)
 	}
 
-	if _, err := store.PatchDatabase(ctx, &api.DatabasePatch{
-		ID:            *task.DatabaseID,
-		UpdaterID:     api.SystemBotID,
-		SchemaVersion: &mi.Version,
-	}); err != nil {
-		return true, nil, err
+	if mi.Type == db.Migrate || mi.Type == db.MigrateSDL {
+		if _, err := store.PatchDatabase(ctx, &api.DatabasePatch{
+			ID:            *task.DatabaseID,
+			UpdaterID:     api.SystemBotID,
+			SchemaVersion: &mi.Version,
+		}); err != nil {
+			return true, nil, err
+		}
 	}
 	// On the presence of schema path template and non-wildcard branch filter, We write back the latest schema after migration for VCS-based projects for
 	// 1) baseline migration for SDL,

--- a/server/runner/taskrun/executor.go
+++ b/server/runner/taskrun/executor.go
@@ -283,6 +283,13 @@ func postMigration(ctx context.Context, store *store.Store, activityManager *act
 		return true, nil, errors.Errorf("failed to find linked repository for database %q", task.Database.Name)
 	}
 
+	if _, err := store.PatchDatabase(ctx, &api.DatabasePatch{
+		ID:            *task.DatabaseID,
+		UpdaterID:     api.SystemBotID,
+		SchemaVersion: &mi.Version,
+	}); err != nil {
+		return true, nil, err
+	}
 	// On the presence of schema path template and non-wildcard branch filter, We write back the latest schema after migration for VCS-based projects for
 	// 1) baseline migration for SDL,
 	// 2) all DDL/Ghost migrations.


### PR DESCRIPTION
This can reduce the amount of time and customer instance resources on automatic schema syncs. We will update the database schema version on database changes.