### PR TITLE
feat(sync-schema): skip sync ghost-del table in sync schema

### DIFF
--- a/plugin/parser/differ/mysql/differ_test.go
+++ b/plugin/parser/differ/mysql/differ_test.go
@@ -6,6 +6,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMatchFilterRegexp(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Match ghost del table.
+		{
+			name: "~students_1672309664_del",
+			want: true,
+		},
+	}
+
+	a := require.New(t)
+	for _, test := range tests {
+		a.Equal(test.want, matchFilterRegexp(test.name, tableNameRegexpNeedFilter))
+	}
+}
+
 func TestExtractUnsupportObjNameAndType(t *testing.T) {
 	tests := []struct {
 		stmt     string

--- a/plugin/parser/differ/mysql/table_test.go
+++ b/plugin/parser/differ/mysql/table_test.go
@@ -54,6 +54,13 @@ func TestTable(t *testing.T) {
 				"ALTER TABLE `book` DROP FOREIGN KEY `fk_price_id`;\n\n" +
 				"ALTER TABLE `book` DROP COLUMN `price_id`;\n\n",
 		},
+		// Ignore ghost del table.
+		{
+			old: "CREATE TABLE `~students_1672309664_del`(id INT, name VARCHAR(255), PRIMARY KEY(id));" +
+				"CREATE TABLE `book`(id INT, price INT, PRIMARY KEY(id));",
+			new:  "CREATE TABLE `book`(id INT, price INT, PRIMARY KEY(id));",
+			want: "",
+		},
 	}
 	testDiffWithoutDisableForeignKeyCheck(t, tests)
 }


### PR DESCRIPTION
We need to ignore ghost-del table in MySQL sync schema.
![CleanShot 2023-01-04 at 10 55 57@2x](https://user-images.githubusercontent.com/87714218/210476098-b55eaa44-e6c5-40d1-aaa2-ff3c1a789a40.png)
