### PR TITLE
feat(spanner): backend sync db schema

### DIFF
--- a/plugin/db/spanner/dump.go
+++ b/plugin/db/spanner/dump.go
@@ -2,12 +2,55 @@ package spanner
 
 import (
 	"context"
+	"fmt"
 	"io"
+
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"github.com/pkg/errors"
 )
 
 // Dump dumps the database.
-func (*Driver) Dump(_ context.Context, _ string, _ io.Writer, _ bool) (string, error) {
-	panic("not implemented")
+func (d *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
+	if !schemaOnly {
+		return "", errors.New("Dump can only dump schemas")
+	}
+	instance, err := d.SyncInstance(ctx)
+	if err != nil {
+		return "", err
+	}
+	var dumpableDbNames []string
+	if database != "" {
+		exist := false
+		for _, db := range instance.DatabaseList {
+			if db.Name == database {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			return "", errors.Errorf("database %q not found", database)
+		}
+		dumpableDbNames = []string{database}
+	} else {
+		for _, db := range instance.DatabaseList {
+			dumpableDbNames = append(dumpableDbNames, db.Name)
+		}
+	}
+	for _, db := range dumpableDbNames {
+		resp, err := d.dbClient.GetDatabaseDdl(ctx, &databasepb.GetDatabaseDdlRequest{
+			Database: getDSN(d.config.Host, db),
+		})
+		if err != nil {
+			return "", err
+		}
+		for _, stmt := range resp.Statements {
+			if _, err := io.WriteString(out, fmt.Sprintf("%s;\n", stmt)); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return "", nil
 }
 
 // Restore restores a database.

--- a/plugin/db/spanner/migrate.go
+++ b/plugin/db/spanner/migrate.go
@@ -2,19 +2,23 @@ package spanner
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"go.uber.org/zap"
 
 	"github.com/bytebase/bytebase/common/log"
 	"github.com/bytebase/bytebase/plugin/db"
+	"github.com/bytebase/bytebase/plugin/db/util"
 
+	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// NeedsSetupMigration checks if it needs to set up migration.
-func (d *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
+func (d *Driver) notFoundDatabase(ctx context.Context, databaseName string) (bool, error) {
 	dsn := getDSN(d.config.Host, db.BytebaseDatabase)
 	_, err := d.dbClient.GetDatabase(ctx, &databasepb.GetDatabaseRequest{Name: dsn})
 	if status.Code(err) == codes.NotFound {
@@ -24,6 +28,15 @@ func (d *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return false, nil
+}
+
+// NeedsSetupMigration checks if it needs to set up migration.
+func (d *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
+	notFound, err := d.notFoundDatabase(ctx, db.BytebaseDatabase)
+	if err != nil {
+		return false, err
+	}
+	return notFound, nil
 }
 
 // SetupMigrationIfNeeded sets up migration if needed.
@@ -60,6 +73,112 @@ func (*Driver) ExecuteMigration(_ context.Context, _ *db.MigrationInfo, _ string
 }
 
 // FindMigrationHistoryList finds the migration history list.
-func (*Driver) FindMigrationHistoryList(_ context.Context, _ *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {
-	panic("not implemented")
+func (d *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {
+	if err := d.switchDatabase(ctx, db.BytebaseDatabase); err != nil {
+		return nil, err
+	}
+	query := `
+	SELECT
+		id,
+		created_by,
+		created_ts,
+		updated_by,
+		updated_ts,
+		release_version,
+		namespace,
+		sequence,
+		source,
+		type,
+		status,
+		version,
+		description,
+		statement,
+		schema,
+		schema_prev,
+		execution_duration_ns,
+		issue_id,
+		payload
+		FROM migration_history
+  `
+	params := make(map[string]interface{})
+	var where []string
+
+	if v := find.ID; v != nil {
+		where = append(where, `id = @id`)
+		params["id"] = *v
+	}
+	if v := find.Database; v != nil {
+		where = append(where, `namespace = @namespace`)
+		params["namespace"] = *v
+	}
+	if v := find.Source; v != nil {
+		where = append(where, `source = @source`)
+		params["source"] = *v
+	}
+	if v := find.Version; v != nil {
+		// TODO(d): support semantic versioning.
+		storedVersion, err := util.ToStoredVersion(false, *v, "")
+		if err != nil {
+			return nil, err
+		}
+		where = append(where, "version = @version")
+		params["version"] = storedVersion
+	}
+	query = fmt.Sprintf("%s WHERE %s ORDER BY namespace, sequence DESC", query, strings.Join(where, " AND "))
+	if v := find.Limit; v != nil {
+		query += fmt.Sprintf(" LIMIT %d", *v)
+	}
+
+	stmt := spanner.Statement{
+		SQL:    query,
+		Params: params,
+	}
+
+	var migrationHistoryList []*db.MigrationHistory
+	iter := d.client.Single().Query(ctx, stmt)
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var history db.MigrationHistory
+		var storedVersion string
+		var id, sequence int64
+		if err := row.Columns(
+			&id,
+			&history.Creator,
+			&history.CreatedTs,
+			&history.Updater,
+			&history.UpdatedTs,
+			&history.ReleaseVersion,
+			&history.Namespace,
+			&sequence,
+			&history.Source,
+			&history.Type,
+			&history.Status,
+			&storedVersion,
+			&history.Description,
+			&history.Statement,
+			&history.Schema,
+			&history.SchemaPrev,
+			&history.ExecutionDurationNs,
+			&history.IssueID,
+			&history.Payload,
+		); err != nil {
+			return nil, err
+		}
+		history.ID = int(id)
+		history.Sequence = int(sequence)
+		useSemanticVersion, version, semanticVersionSuffix, err := util.FromStoredVersion(storedVersion)
+		if err != nil {
+			return nil, err
+		}
+		history.UseSemanticVersion, history.Version, history.SemanticVersionSuffix = useSemanticVersion, version, semanticVersionSuffix
+		migrationHistoryList = append(migrationHistoryList, &history)
+	}
+
+	return migrationHistoryList, nil
 }

--- a/plugin/db/spanner/migrate.go
+++ b/plugin/db/spanner/migrate.go
@@ -74,6 +74,11 @@ func (*Driver) ExecuteMigration(_ context.Context, _ *db.MigrationInfo, _ string
 
 // FindMigrationHistoryList finds the migration history list.
 func (d *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {
+	defer func(db string) {
+		if err := d.switchDatabase(ctx, db); err != nil {
+			log.Error("failed to switch back database for spanner driver", zap.String("database", db), zap.Error(err))
+		}
+	}(d.dbName)
 	if err := d.switchDatabase(ctx, db.BytebaseDatabase); err != nil {
 		return nil, err
 	}

--- a/plugin/db/spanner/migrate.go
+++ b/plugin/db/spanner/migrate.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (d *Driver) notFoundDatabase(ctx context.Context, databaseName string) (bool, error) {
-	dsn := getDSN(d.config.Host, db.BytebaseDatabase)
+	dsn := getDSN(d.config.Host, databaseName)
 	_, err := d.dbClient.GetDatabase(ctx, &databasepb.GetDatabaseRequest{Name: dsn})
 	if status.Code(err) == codes.NotFound {
 		return true, nil

--- a/plugin/db/spanner/spanner.go
+++ b/plugin/db/spanner/spanner.go
@@ -50,6 +50,7 @@ type Driver struct {
 	client   *spanner.Client
 	dbClient *spannerdb.DatabaseAdminClient
 
+	// dbName is the currently connected database name.
 	dbName string
 }
 

--- a/plugin/db/spanner/spanner.go
+++ b/plugin/db/spanner/spanner.go
@@ -49,6 +49,8 @@ type Driver struct {
 	connCtx  db.ConnectionContext
 	client   *spanner.Client
 	dbClient *spannerdb.DatabaseAdminClient
+
+	dbName string
 }
 
 func newDriver(_ db.DriverConfig) db.Driver {
@@ -66,6 +68,7 @@ func (d *Driver) Open(ctx context.Context, _ db.Type, config db.ConnectionConfig
 	d.connCtx = connCtx
 	if config.Database == "" {
 		// try to connect to bytebase
+		d.dbName = db.BytebaseDatabase
 		dsn := getDSN(d.config.Host, db.BytebaseDatabase)
 		client, err := spanner.NewClient(ctx, dsn, option.WithCredentialsJSON([]byte(config.Password)))
 		if status.Code(err) == codes.NotFound {
@@ -76,6 +79,7 @@ func (d *Driver) Open(ctx context.Context, _ db.Type, config db.ConnectionConfig
 			d.client = client
 		}
 	} else {
+		d.dbName = d.config.Database
 		dsn := getDSN(d.config.Host, d.config.Database)
 		client, err := spanner.NewClient(ctx, dsn, option.WithCredentialsJSON([]byte(config.Password)))
 		if err != nil {
@@ -91,6 +95,23 @@ func (d *Driver) Open(ctx context.Context, _ db.Type, config db.ConnectionConfig
 
 	d.dbClient = dbClient
 	return d, nil
+}
+
+func (d *Driver) switchDatabase(ctx context.Context, dbName string) error {
+	if d.dbName == dbName {
+		return nil
+	}
+	if d.client != nil {
+		d.client.Close()
+	}
+	dsn := getDSN(d.config.Host, dbName)
+	client, err := spanner.NewClient(ctx, dsn, option.WithCredentialsJSON([]byte(d.config.Password)))
+	if err != nil {
+		return err
+	}
+	d.client = client
+	d.dbName = dbName
+	return nil
 }
 
 // Close closes the driver.

--- a/plugin/db/spanner/sync.go
+++ b/plugin/db/spanner/sync.go
@@ -31,6 +31,12 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error) {
 			return nil, err
 		}
 
+		// filter out databases using postgresql dialect which are not supported currently
+		// TODO(p0ny): remove this after supporting postgresql dialect
+		if database.DatabaseDialect == databasepb.DatabaseDialect_POSTGRESQL {
+			continue
+		}
+
 		// database.Name is of the form `projects/<project>/instances/<instance>/databases/<database>`
 		// We use regular expression to extract <database> from it.
 		databaseName, err := getDatabaseFromDSN(database.Name)
@@ -153,7 +159,7 @@ func getColumn(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[db.Tab
       ORDINAL_POSITION,
       COLUMN_DEFAULT,
       IS_NULLABLE = 'YES',
-      SPANNER_TYPE,
+      SPANNER_TYPE
     FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'SPANNER_SYS')
     ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION

--- a/plugin/db/spanner/sync.go
+++ b/plugin/db/spanner/sync.go
@@ -2,12 +2,16 @@ package spanner
 
 import (
 	"context"
+	"sort"
 
+	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/pkg/errors"
 
+	"github.com/bytebase/bytebase/common"
 	"github.com/bytebase/bytebase/plugin/db"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
@@ -46,6 +50,302 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMeta, error) {
 }
 
 // SyncDBSchema syncs a single database schema.
-func (*Driver) SyncDBSchema(_ context.Context, _ string) (*storepb.DatabaseMetadata, error) {
-	return nil, errors.New("not implemented")
+func (d *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*storepb.DatabaseMetadata, error) {
+	notFound, err := d.notFoundDatabase(ctx, databaseName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if database exists")
+	}
+	if notFound {
+		return nil, common.Errorf(common.NotFound, "database %q not found", databaseName)
+	}
+
+	tx := d.client.ReadOnlyTransaction()
+	defer tx.Close()
+
+	databaseMetadata := &storepb.DatabaseMetadata{
+		Name: databaseName,
+	}
+	tableMap, err := getTable(ctx, tx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get tables from database %q", databaseName)
+	}
+	viewMap, err := getView(ctx, tx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get views from database %q", databaseName)
+	}
+
+	schemaNameMap := make(map[string]bool)
+	for schemaName := range tableMap {
+		schemaNameMap[schemaName] = true
+	}
+	for schemaName := range viewMap {
+		schemaNameMap[schemaName] = true
+	}
+	var schemaNames []string
+	for schemaName := range schemaNameMap {
+		schemaNames = append(schemaNames, schemaName)
+	}
+	sort.Strings(schemaNames)
+	for _, schemaName := range schemaNames {
+		databaseMetadata.Schemas = append(databaseMetadata.Schemas, &storepb.SchemaMetadata{
+			Name:   schemaName,
+			Tables: tableMap[schemaName],
+			Views:  viewMap[schemaName],
+		})
+	}
+
+	return databaseMetadata, err
+}
+
+func getTable(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[string][]*storepb.TableMetadata, error) {
+	columnMap, err := getColumn(ctx, tx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get table columns")
+	}
+	indexMap, err := getIndex(ctx, tx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get indices")
+	}
+	foreignKeyMap, err := getForeignKey(ctx, tx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get foreign keys")
+	}
+	tableMap := make(map[string][]*storepb.TableMetadata)
+	query := `
+    SELECT
+      TABLE_SCHEMA,
+      TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'SPANNER_SYS') AND TABLE_TYPE = 'BASE TABLE'
+    ORDER BY TABLE_SCHEMA, TABLE_NAME
+  `
+	iter := tx.Query(ctx, spanner.NewStatement(query))
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var table storepb.TableMetadata
+		var schema string
+		if err := row.Columns(&schema, &table.Name); err != nil {
+			return nil, err
+		}
+		key := db.TableKey{Schema: schema, Table: table.Name}
+		table.Columns = columnMap[key]
+		table.Indexes = indexMap[key]
+		table.ForeignKeys = foreignKeyMap[key]
+
+		tableMap[schema] = append(tableMap[schema], &table)
+	}
+	return tableMap, nil
+}
+
+func getColumn(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[db.TableKey][]*storepb.ColumnMetadata, error) {
+	columnsMap := make(map[db.TableKey][]*storepb.ColumnMetadata)
+	query := `
+    SELECT 
+      TABLE_SCHEMA,
+      TABLE_NAME,
+      COLUMN_NAME,
+      ORDINAL_POSITION,
+      COLUMN_DEFAULT,
+      IS_NULLABLE = 'YES',
+      SPANNER_TYPE,
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'SPANNER_SYS')
+    ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION
+  `
+	iter := tx.Query(ctx, spanner.NewStatement(query))
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		column := &storepb.ColumnMetadata{}
+		var (
+			schemaName string
+			tableName  string
+			position   int64
+			defaultStr spanner.NullString
+		)
+		if err := row.Columns(&schemaName, &tableName, &column.Name, &position, &defaultStr, &column.Nullable, &column.Type); err != nil {
+			return nil, err
+		}
+		column.Position = int32(position)
+		if defaultStr.Valid {
+			column.Default = &wrapperspb.StringValue{Value: defaultStr.StringVal}
+		}
+		key := db.TableKey{Schema: schemaName, Table: tableName}
+		columnsMap[key] = append(columnsMap[key], column)
+	}
+	return columnsMap, nil
+
+}
+
+func getIndex(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[db.TableKey][]*storepb.IndexMetadata, error) {
+	query := `
+    SELECT
+      TABLE_SCHEMA,
+      TABLE_NAME,
+      INDEX_NAME,
+      IS_UNIQUE,
+      INDEX_TYPE = 'PRIMARY_KEY' AS IS_PRIMARY,
+      ARRAY (
+        SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.INDEX_COLUMNS AS ic
+        WHERE ic.TABLE_SCHEMA = i.TABLE_SCHEMA AND ic.TABLE_NAME = i.TABLE_NAME AND ic.INDEX_NAME = i.INDEX_NAME
+        ORDER BY ic.ORDINAL_POSITION
+      )
+    FROM INFORMATION_SCHEMA.INDEXES as i
+    WHERE TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'SPANNER_SYS') AND SPANNER_IS_MANAGED = FALSE
+    ORDER BY TABLE_SCHEMA, TABLE_NAME, INDEX_NAME
+  `
+
+	keyIndexMap := make(map[db.TableKey][]*storepb.IndexMetadata)
+
+	iter := tx.Query(ctx, spanner.NewStatement(query))
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var idx storepb.IndexMetadata
+		var schema, table string
+		if err := row.Columns(
+			&schema,
+			&table,
+			&idx.Name,
+			&idx.Unique,
+			&idx.Primary,
+			&idx.Expressions,
+		); err != nil {
+			return nil, err
+		}
+		key := db.TableKey{Schema: schema, Table: table}
+		keyIndexMap[key] = append(keyIndexMap[key], &idx)
+	}
+
+	return keyIndexMap, nil
+}
+
+func getForeignKey(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[db.TableKey][]*storepb.ForeignKeyMetadata, error) {
+	foreignKeyMap := make(map[db.TableKey][]*storepb.ForeignKeyMetadata)
+	query := `
+    WITH t AS (
+      SELECT DISTINCT
+        tc.CONSTRAINT_SCHEMA,
+        tc.CONSTRAINT_NAME,
+        tc.TABLE_NAME,
+        rc.UNIQUE_CONSTRAINT_SCHEMA,
+        rc.UNIQUE_CONSTRAINT_NAME,
+        ccu.TABLE_SCHEMA AS REFERENCED_TABLE_SCHEMA,
+        ccu.TABLE_NAME AS REFERENCED_TABLE_NAME,
+        rc.DELETE_RULE,
+        rc.UPDATE_RULE,
+        rc.MATCH_OPTION
+      FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
+      JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc
+      ON tc.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA AND tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME 
+      JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE as ccu
+      ON tc.CONSTRAINT_SCHEMA = ccu.CONSTRAINT_SCHEMA AND tc.CONSTRAINT_NAME = ccu.CONSTRAINT_NAME 
+      WHERE tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
+    )
+    SELECT
+      t.CONSTRAINT_SCHEMA,
+      t.CONSTRAINT_NAME,
+      t.TABLE_NAME,
+      t.REFERENCED_TABLE_SCHEMA,
+      t.REFERENCED_TABLE_NAME,
+      ARRAY (
+        SELECT
+          COLUMN_NAME
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu
+        WHERE t.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA AND t.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+        ORDER BY kcu.ORDINAL_POSITION
+      ) AS TABLE_COLUMNS,
+      ARRAY (
+        SELECT
+          COLUMN_NAME
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu
+        WHERE t.UNIQUE_CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA AND t.UNIQUE_CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+        ORDER BY kcu.ORDINAL_POSITION
+      ) AS REFERENCED_TABLE_COLUMNS,
+      t.DELETE_RULE,
+      t.UPDATE_RULE,
+      t.MATCH_OPTION
+    FROM t
+  `
+	iter := tx.Query(ctx, spanner.NewStatement(query))
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var fk storepb.ForeignKeyMetadata
+		var schema, table string
+		var columns, referencedColumns []string
+		if err := row.Columns(
+			&schema,
+			&fk.Name,
+			&table,
+			&fk.ReferencedSchema,
+			&fk.ReferencedTable,
+			&columns,
+			&referencedColumns,
+			&fk.OnDelete,
+			&fk.OnUpdate,
+			&fk.MatchType,
+		); err != nil {
+			return nil, err
+		}
+		key := db.TableKey{Schema: schema, Table: table}
+		foreignKeyMap[key] = append(foreignKeyMap[key], &fk)
+	}
+	return foreignKeyMap, nil
+}
+
+func getView(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[string][]*storepb.ViewMetadata, error) {
+	viewMap := make(map[string][]*storepb.ViewMetadata)
+	query := `
+  SELECT
+    TABLE_SCHEMA,
+    TABLE_NAME,
+    VIEW_DEFINITION
+  FROM INFORMATION_SCHEMA.VIEWS
+  WHERE TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'SPANNER_SYS')
+  `
+	iter := tx.Query(ctx, spanner.NewStatement(query))
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var (
+			schema     string
+			name       string
+			definition string
+		)
+		if err := row.Columns(&schema, &name, &definition); err != nil {
+			return nil, err
+		}
+		viewMap[schema] = append(viewMap[schema], &storepb.ViewMetadata{
+			Name:       name,
+			Definition: definition,
+		})
+	}
+	return viewMap, nil
 }

--- a/plugin/db/spanner/sync.go
+++ b/plugin/db/spanner/sync.go
@@ -191,7 +191,6 @@ func getColumn(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[db.Tab
 		columnsMap[key] = append(columnsMap[key], column)
 	}
 	return columnsMap, nil
-
 }
 
 func getIndex(ctx context.Context, tx *spanner.ReadOnlyTransaction) (map[db.TableKey][]*storepb.IndexMetadata, error) {


### PR DESCRIPTION
This PR implements syncing database schema for the spanner driver.

Note that only databases using google standard SQL are supported currently.

Also need to fix the instance/database detail page for spanner, as some fields are unavailable.

Completing BYT-2241

