### PR TITLE
feat(schema-diagram): call Schema Editor UI via Schema Diagram

### DIFF
--- a/frontend/src/components/SchemaDiagram/Canvas/Canvas.vue
+++ b/frontend/src/components/SchemaDiagram/Canvas/Canvas.vue
@@ -54,7 +54,7 @@ import { fitView } from "./libs/fitView";
 const canvas = ref<Element>();
 const desktop = ref<Element>();
 
-const { tableList, rectOfTable, zoom, position, events } =
+const { tableList, rectOfTable, zoom, position, panning, events } =
   useSchemaDiagramContext();
 
 const zoomCenter = ref<Position>({ x: 0.5, y: 0.5 });
@@ -100,11 +100,16 @@ const handleZoom = (delta: number, center: Position = { x: 0.5, y: 0.5 }) => {
 const handlePan = (x: number, y: number) => {
   position.value.x += x;
   position.value.y += y;
+  panning.value = true;
+};
+const handlePanEnd = () => {
+  panning.value = false;
 };
 
 useDraggable(canvas, {
   exact: false,
   onPan: handlePan,
+  onEnd: handlePanEnd,
 });
 
 useEventListener(

--- a/frontend/src/components/SchemaDiagram/common/useDraggable.ts
+++ b/frontend/src/components/SchemaDiagram/common/useDraggable.ts
@@ -5,7 +5,9 @@ import { Position } from "../types";
 
 export type DraggableOptions = {
   exact?: boolean;
+  onStart?: () => void;
   onPan?: (dx: number, dy: number) => void;
+  onEnd?: () => void;
   capture?: boolean;
 };
 
@@ -28,6 +30,7 @@ export const useDraggable = (
     };
     e.stopPropagation();
     e.preventDefault();
+    options.onStart?.();
   };
   const move = (e: PointerEvent) => {
     if (!startPointerPosition.value) return;
@@ -45,6 +48,7 @@ export const useDraggable = (
     startPointerPosition.value = undefined;
     e.stopPropagation();
     e.preventDefault();
+    options.onEnd?.();
   };
 
   const capture = options.capture ?? false;

--- a/frontend/src/components/SchemaDiagram/types/context.ts
+++ b/frontend/src/components/SchemaDiagram/types/context.ts
@@ -11,10 +11,12 @@ import { EditStatus } from "./edit";
 export type SchemaDiagramContext = {
   // Props
   tableList: Ref<TableMetadata[]>;
+  editable: Ref<boolean>;
 
   // States
   zoom: Ref<number>;
   position: Ref<Position>;
+  panning: Ref<boolean>;
 
   // Methods
   idOfTable: (table: TableMetadata) => string;
@@ -31,5 +33,11 @@ export type SchemaDiagramContext = {
     render: undefined;
     layout: undefined;
     "fit-view": undefined;
+    "edit-table": TableMetadata;
+    "edit-column": {
+      table: TableMetadata;
+      column: ColumnMetadata;
+      target: "name" | "type";
+    };
   }>;
 };

--- a/frontend/src/components/SchemaEditor/Panels/DatabaseEditor.vue
+++ b/frontend/src/components/SchemaEditor/Panels/DatabaseEditor.vue
@@ -161,6 +161,9 @@
         :table-list="tableMetadataList"
         :table-status="tableStatus"
         :column-status="columnStatus"
+        :editable="true"
+        @edit-table="tryEditTable"
+        @edit-column="tryEditColumn"
       />
     </template>
   </div>
@@ -177,7 +180,7 @@
 <script lang="ts" setup>
 import { head } from "lodash-es";
 import { NEllipsis } from "naive-ui";
-import { computed, reactive, watch } from "vue";
+import { computed, nextTick, reactive, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   generateUniqueTabId,
@@ -198,6 +201,7 @@ import HighlightCodeBlock from "@/components/HighlightCodeBlock";
 import TableNameModal from "../Modals/TableNameModal.vue";
 import SchemaDiagram from "@/components/SchemaDiagram";
 import { useMetadataForDiagram } from "../utils/useMetadataForDiagram";
+import { ColumnMetadata, TableMetadata } from "@/types/proto/store/database";
 
 type TabType = "table-list" | "schema-diagram" | "raw-sql";
 
@@ -391,8 +395,40 @@ const handleRestoreTable = (table: Table) => {
   editorStore.restoreTable(table);
 };
 
-const { tableMetadataList, tableStatus, columnStatus } =
-  useMetadataForDiagram(databaseSchema);
+const {
+  tableMetadataList,
+  tableStatus,
+  columnStatus,
+  editableTable,
+  editableColumn,
+} = useMetadataForDiagram(databaseSchema);
+
+const tryEditTable = (tableMeta: TableMetadata) => {
+  const table = editableTable(tableMeta);
+  if (table) {
+    handleTableItemClick(table);
+  }
+};
+
+const tryEditColumn = (
+  tableMeta: TableMetadata,
+  columnMeta: ColumnMetadata,
+  target: "name" | "type"
+) => {
+  const table = editableTable(tableMeta);
+  const column = editableColumn(columnMeta);
+  if (table && column) {
+    handleTableItemClick(table);
+    nextTick(() => {
+      const container = document.querySelector("#table-editor-container");
+      const input = container?.querySelector(
+        `.column-${column.id} .column-${target}-input`
+      ) as HTMLInputElement | undefined;
+
+      input?.focus();
+    });
+  }
+};
 </script>
 
 <style scoped>

--- a/frontend/src/components/SchemaEditor/Panels/TableEditor.vue
+++ b/frontend/src/components/SchemaEditor/Panels/TableEditor.vue
@@ -52,6 +52,7 @@
 
       <!-- column table -->
       <div
+        id="table-editor-container"
         ref="tableEditorContainerRef"
         class="w-full h-auto grid auto-rows-auto border-y relative overflow-y-auto"
       >
@@ -96,7 +97,7 @@
                 v-model="column.type"
                 :disabled="disableAlterColumn(column)"
                 placeholder="column type"
-                class="column-field-input !pr-8"
+                class="column-field-input column-type-input !pr-8"
                 type="text"
               />
               <NDropdown


### PR DESCRIPTION
Close BYT-2167

FYI @tianzhou @Candybase 

### Plans

- Keep the zoom and position when switching back from editor to diagram.
- Click on a foreign key line to edit it.

### Screenshots

https://user-images.githubusercontent.com/2749742/210506763-79c9ef60-254c-4e0c-adb0-1564c8976685.mp4

