### PR TITLE
refactor: MigrationExecutor

### DIFF
--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -239,7 +239,9 @@ func (*MockDriver) GetType() database.Type {
 
 // SwitchDatabase switches the connected database.
 func (*MockDriver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error { return nil }
+	noop := func() error {
+		return nil 
+	}
 	return noop, nil
 }
 

--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -237,6 +237,12 @@ func (*MockDriver) GetType() database.Type {
 	return database.Type("MOCK")
 }
 
+// SwitchDatabase switches the connected database.
+func (*MockDriver) SwitchDatabase(context.Context, string) (func() error, error) {
+	noop := func() error { return nil }
+	return noop, nil
+}
+
 // GetDBConnection implements the Driver interface.
 func (*MockDriver) GetDBConnection(_ context.Context, _ string) (*sql.DB, error) {
 	return nil, nil

--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -240,7 +240,7 @@ func (*MockDriver) GetType() database.Type {
 // SwitchDatabase switches the connected database.
 func (*MockDriver) SwitchDatabase(context.Context, string) (func() error, error) {
 	noop := func() error {
-		return nil 
+		return nil
 	}
 	return noop, nil
 }

--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -227,6 +227,7 @@ func (*MockDriver) Close(_ context.Context) error {
 	return nil
 }
 
+// ForkOpen forks the driver and opens a new driver to another database.
 func (d *MockDriver) ForkOpen(context.Context, string) (database.Driver, error) {
 	return d, nil
 }

--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -227,6 +227,10 @@ func (*MockDriver) Close(_ context.Context) error {
 	return nil
 }
 
+func (d *MockDriver) ForkOpen(context.Context, string) (database.Driver, error) {
+	return d, nil
+}
+
 // Ping implements the Driver interface.
 func (*MockDriver) Ping(_ context.Context) error {
 	return nil
@@ -235,14 +239,6 @@ func (*MockDriver) Ping(_ context.Context) error {
 // GetType implements the Driver interface.
 func (*MockDriver) GetType() database.Type {
 	return database.Type("MOCK")
-}
-
-// SwitchDatabase switches the connected database.
-func (*MockDriver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error {
-		return nil
-	}
-	return noop, nil
 }
 
 // GetDBConnection implements the Driver interface.

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -106,6 +106,12 @@ func (*Driver) GetType() db.Type {
 	return db.ClickHouse
 }
 
+// SwitchDatabase switches the connected database.
+func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
+	noop := func() error { return nil }
+	return noop, nil
+}
+
 // GetDBConnection gets a database connection.
 func (driver *Driver) GetDBConnection(context.Context, string) (*sql.DB, error) {
 	return driver.db, nil

--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -108,7 +108,9 @@ func (*Driver) GetType() db.Type {
 
 // SwitchDatabase switches the connected database.
 func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error { return nil }
+	noop := func() error {
+		return nil
+	}
 	return noop, nil
 }
 

--- a/plugin/db/clickhouse/migrate.go
+++ b/plugin/db/clickhouse/migrate.go
@@ -206,7 +206,7 @@ func (driver *Driver) InsertPendingHistory(ctx context.Context, sequence int, pr
 }
 
 // UpdateHistoryAsDone will update the migration record as done.
-func (d *Driver) UpdateHistoryAsDone(ctx context.Context, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
+func (driver *Driver) UpdateHistoryAsDone(ctx context.Context, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
 	const updateHistoryAsDoneQuery = `
 		ALTER TABLE
 			bytebase.migration_history
@@ -216,12 +216,12 @@ func (d *Driver) UpdateHistoryAsDone(ctx context.Context, migrationDurationNs in
 		` + "`schema` = $3" + `
 		WHERE id = $4
 	`
-	_, err := d.db.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, insertedID)
+	_, err := driver.db.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, insertedID)
 	return err
 }
 
 // UpdateHistoryAsFailed will update the migration record as failed.
-func (d *Driver) UpdateHistoryAsFailed(ctx context.Context, migrationDurationNs int64, insertedID int64) error {
+func (driver *Driver) UpdateHistoryAsFailed(ctx context.Context, migrationDurationNs int64, insertedID int64) error {
 	const updateHistoryAsFailedQuery = `
 		ALTER TABLE
 			bytebase.migration_history
@@ -230,7 +230,7 @@ func (d *Driver) UpdateHistoryAsFailed(ctx context.Context, migrationDurationNs 
 			execution_duration_ns = $2
 		WHERE id = $3
 	`
-	_, err := d.db.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, insertedID)
+	_, err := driver.db.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, insertedID)
 	return err
 }
 

--- a/plugin/db/clickhouse/migrate.go
+++ b/plugin/db/clickhouse/migrate.go
@@ -64,6 +64,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// FindLargestVersionSinceBaselineAndLargestSequence will find the largest version since last baseline or branch and the largest sequence number.
 func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -434,13 +434,13 @@ type Driver interface {
 	// A driver might support multiple engines (e.g. MySQL driver can support both MySQL and TiDB),
 	// So we pass the dbType to tell the exact engine.
 	Open(ctx context.Context, dbType Type, config ConnectionConfig, connCtx ConnectionContext) (Driver, error)
+	// ForkOpen opens another database in the same instance.
+	// This is used to connect to the database where the migration_history table resides.
+	ForkOpen(ctx context.Context, database string) (Driver, error)
 	// Remember to call Close to avoid connection leak
 	Close(ctx context.Context) error
 	Ping(ctx context.Context) error
 	GetType() Type
-	// SwitchDatabase switches the connection to a specific database and returns a function to switch back the database.
-	// This function is a no-op if the underlying driver connection is at instance-level, e.g. MySQL.
-	SwitchDatabase(ctx context.Context, database string) (func() error, error)
 	GetDBConnection(ctx context.Context, database string) (*sql.DB, error)
 	// Execute will execute the statement. For CREATE DATABASE statement, some types of databases such as Postgres
 	// will not use transactions to execute the statement but will still use transactions to execute the rest of statements.

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -438,6 +438,9 @@ type Driver interface {
 	Close(ctx context.Context) error
 	Ping(ctx context.Context) error
 	GetType() Type
+	// SwitchDatabase switches the connection to a specific database and returns a function to switch back the database.
+	// This function is a no-op if the underlying driver connection is at instance-level, e.g. MySQL.
+	SwitchDatabase(ctx context.Context, database string) (func() error, error)
 	GetDBConnection(ctx context.Context, database string) (*sql.DB, error)
 	// Execute will execute the statement. For CREATE DATABASE statement, some types of databases such as Postgres
 	// will not use transactions to execute the statement but will still use transactions to execute the rest of statements.

--- a/plugin/db/mongodb/migrate.go
+++ b/plugin/db/mongodb/migrate.go
@@ -244,6 +244,7 @@ func (driver *Driver) FindLargestSequence(ctx context.Context, namespace string,
 	return 0, nil
 }
 
+// FindLargestVersionSinceBaselineAndLargestSequence will find the largest version since last baseline or branch and the largest sequence number.
 func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
 	version, err := driver.FindLargestVersionSinceBaseline(ctx, namespace)
 	if err != nil {

--- a/plugin/db/mongodb/mongodb.go
+++ b/plugin/db/mongodb/mongodb.go
@@ -77,7 +77,9 @@ func (*Driver) GetType() db.Type {
 
 // SwitchDatabase switches the connected database.
 func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error { return nil }
+	noop := func() error {
+		return nil
+	}
 	return noop, nil
 }
 

--- a/plugin/db/mongodb/mongodb.go
+++ b/plugin/db/mongodb/mongodb.go
@@ -54,6 +54,18 @@ func (driver *Driver) Open(ctx context.Context, _ db.Type, connCfg db.Connection
 	return driver, nil
 }
 
+// ForkOpen opens another database in the same instance.
+// This is used to connect to the database where the migration_history table resides.
+func (driver *Driver) ForkOpen(ctx context.Context, database string) (db.Driver, error) {
+	connCfg := driver.connCfg
+	connCfg.Database = database
+	fork, err := newDriver(db.DriverConfig{}).Open(ctx, "", connCfg, driver.connectionCtx)
+	if err != nil {
+		return nil, err
+	}
+	return fork, nil
+}
+
 // Close closes the MongoDB driver.
 func (driver *Driver) Close(ctx context.Context) error {
 	if err := driver.client.Disconnect(ctx); err != nil {
@@ -73,14 +85,6 @@ func (driver *Driver) Ping(ctx context.Context) error {
 // GetType returns the database type.
 func (*Driver) GetType() db.Type {
 	return db.MongoDB
-}
-
-// SwitchDatabase switches the connected database.
-func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error {
-		return nil
-	}
-	return noop, nil
 }
 
 // GetDBConnection returns a database connection.

--- a/plugin/db/mongodb/mongodb.go
+++ b/plugin/db/mongodb/mongodb.go
@@ -75,6 +75,12 @@ func (*Driver) GetType() db.Type {
 	return db.MongoDB
 }
 
+// SwitchDatabase switches the connected database.
+func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
+	noop := func() error { return nil }
+	return noop, nil
+}
+
 // GetDBConnection returns a database connection.
 // It always return nil because it has not implemented the SQL interface, and we always return error, it's caller's responsibility to
 // avoid calling this function for MongoDB.

--- a/plugin/db/mysql/migrate.go
+++ b/plugin/db/mysql/migrate.go
@@ -66,6 +66,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// FindLargestVersionSinceBaselineAndLargestSequence will find the largest version since last baseline or branch and the largest sequence number.
 func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/plugin/db/mysql/migrate.go
+++ b/plugin/db/mysql/migrate.go
@@ -66,6 +66,29 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
+	tx, err := driver.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer tx.Rollback()
+
+	largestSequece, err := driver.FindLargestSequence(ctx, tx, namespace, false)
+	if err != nil {
+		return nil, 0, err
+	}
+	version, err := driver.FindLargestVersionSinceBaseline(ctx, tx, namespace)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, 0, err
+	}
+
+	return version, largestSequece, nil
+}
+
 // FindLargestVersionSinceBaseline will find the largest version since last baseline or branch.
 func (driver Driver) FindLargestVersionSinceBaseline(ctx context.Context, tx *sql.Tx, namespace string) (*string, error) {
 	largestBaselineSequence, err := driver.FindLargestSequence(ctx, tx, namespace, true /* baseline */)
@@ -116,7 +139,7 @@ func (Driver) FindLargestSequence(ctx context.Context, tx *sql.Tx, namespace str
 }
 
 // InsertPendingHistory will insert the migration record with pending status and return the inserted ID.
-func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (int64, error) {
+func (driver *Driver) InsertPendingHistory(ctx context.Context, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (int64, error) {
 	const insertHistoryQuery = `
 		INSERT INTO bytebase.migration_history (
 			created_by,
@@ -140,7 +163,7 @@ func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int
 		)
 		VALUES (?, unix_timestamp(), ?, unix_timestamp(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
 		`
-	res, err := tx.ExecContext(ctx, insertHistoryQuery,
+	res, err := driver.db.ExecContext(ctx, insertHistoryQuery,
 		m.Creator,
 		m.Creator,
 		m.ReleaseVersion,
@@ -169,7 +192,7 @@ func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int
 }
 
 // UpdateHistoryAsDone will update the migration record as done.
-func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
+func (driver *Driver) UpdateHistoryAsDone(ctx context.Context, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
 	const updateHistoryAsDoneQuery = `
 		UPDATE
 			bytebase.migration_history
@@ -179,12 +202,12 @@ func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDura
 		` + "`schema` = ?" + `
 		WHERE id = ?
 		`
-	_, err := tx.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, insertedID)
+	_, err := driver.db.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, insertedID)
 	return err
 }
 
 // UpdateHistoryAsFailed will update the migration record as failed.
-func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, insertedID int64) error {
+func (driver *Driver) UpdateHistoryAsFailed(ctx context.Context, migrationDurationNs int64, insertedID int64) error {
 	const updateHistoryAsFailedQuery = `
 		UPDATE
 			bytebase.migration_history
@@ -193,7 +216,7 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 			execution_duration_ns = ?
 		WHERE id = ?
 		`
-	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, insertedID)
+	_, err := driver.db.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, insertedID)
 	return err
 }
 

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -130,6 +130,12 @@ func (driver *Driver) GetType() db.Type {
 	return driver.dbType
 }
 
+// SwitchDatabase switches the connected database.
+func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
+	noop := func() error { return nil }
+	return noop, nil
+}
+
 // GetDBConnection gets a database connection.
 func (driver *Driver) GetDBConnection(context.Context, string) (*sql.DB, error) {
 	return driver.db, nil

--- a/plugin/db/mysql/mysql.go
+++ b/plugin/db/mysql/mysql.go
@@ -132,7 +132,9 @@ func (driver *Driver) GetType() db.Type {
 
 // SwitchDatabase switches the connected database.
 func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error { return nil }
+	noop := func() error {
+		return nil
+	}
 	return noop, nil
 }
 

--- a/plugin/db/pg/migrate.go
+++ b/plugin/db/pg/migrate.go
@@ -34,7 +34,7 @@ func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 		if !exist {
 			return true, nil
 		}
-		if err := driver.switchDatabase(db.BytebaseDatabase); err != nil {
+		if _, err := driver.SwitchDatabase(ctx, db.BytebaseDatabase); err != nil {
 			return false, err
 		}
 	}
@@ -86,7 +86,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 				}
 			}
 
-			if err := driver.switchDatabase(db.BytebaseDatabase); err != nil {
+			if _, err := driver.SwitchDatabase(ctx, db.BytebaseDatabase); err != nil {
 				log.Error("Failed to switch to database \"bytebase\".",
 					zap.Error(err),
 					zap.String("environment", driver.connectionCtx.EnvironmentName),

--- a/plugin/db/pg/migrate.go
+++ b/plugin/db/pg/migrate.go
@@ -34,7 +34,7 @@ func (driver *Driver) NeedsSetupMigration(ctx context.Context) (bool, error) {
 		if !exist {
 			return true, nil
 		}
-		if _, err := driver.SwitchDatabase(ctx, db.BytebaseDatabase); err != nil {
+		if err := driver.switchDatabase(db.BytebaseDatabase); err != nil {
 			return false, err
 		}
 	}
@@ -86,7 +86,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 				}
 			}
 
-			if _, err := driver.SwitchDatabase(ctx, db.BytebaseDatabase); err != nil {
+			if err := driver.switchDatabase(db.BytebaseDatabase); err != nil {
 				log.Error("Failed to switch to database \"bytebase\".",
 					zap.Error(err),
 					zap.String("environment", driver.connectionCtx.EnvironmentName),

--- a/plugin/db/pg/migrate.go
+++ b/plugin/db/pg/migrate.go
@@ -114,6 +114,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// FindLargestVersionSinceBaselineAndLargestSequence will find the largest version since last baseline or branch and the largest sequence number.
 func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -440,7 +440,9 @@ func (driver *Driver) Query(ctx context.Context, statement string, queryContext 
 // SwitchDatabase switches the connected database.
 func (driver *Driver) SwitchDatabase(_ context.Context, dbName string) (func() error, error) {
 	if dbName == driver.databaseName {
-		noop := func() error { return nil }
+		noop := func() error {
+			return nil
+		}
 		return noop, nil
 	}
 

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -202,7 +202,7 @@ func (*Driver) GetType() db.Type {
 }
 
 // GetDBConnection gets a database connection.
-func (driver *Driver) GetDBConnection(ctx context.Context, database string) (*sql.DB, error) {
+func (driver *Driver) GetDBConnection(_ context.Context, database string) (*sql.DB, error) {
 	if err := driver.switchDatabase(database); err != nil {
 		return nil, err
 	}

--- a/plugin/db/snowflake/migrate.go
+++ b/plugin/db/snowflake/migrate.go
@@ -174,7 +174,7 @@ func (driver *Driver) InsertPendingHistory(ctx context.Context, sequence int, pr
 
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 	defer tx.Rollback()
 

--- a/plugin/db/snowflake/migrate.go
+++ b/plugin/db/snowflake/migrate.go
@@ -72,6 +72,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// FindLargestVersionSinceBaselineAndLargestSequence will find the largest version since last baseline or branch and the largest sequence number.
 func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/plugin/db/snowflake/migrate.go
+++ b/plugin/db/snowflake/migrate.go
@@ -72,8 +72,31 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
+	tx, err := driver.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer tx.Rollback()
+
+	largestSequece, err := driver.FindLargestSequence(ctx, tx, namespace, false)
+	if err != nil {
+		return nil, 0, err
+	}
+	version, err := driver.FindLargestVersionSinceBaseline(ctx, tx, namespace)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, 0, err
+	}
+
+	return version, largestSequece, nil
+}
+
 // FindLargestVersionSinceBaseline will find the largest version since last baseline or branch.
-func (driver Driver) FindLargestVersionSinceBaseline(ctx context.Context, tx *sql.Tx, namespace string) (*string, error) {
+func (driver *Driver) FindLargestVersionSinceBaseline(ctx context.Context, tx *sql.Tx, namespace string) (*string, error) {
 	largestBaselineSequence, err := driver.FindLargestSequence(ctx, tx, namespace, true /* baseline */)
 	if err != nil {
 		return nil, err
@@ -98,7 +121,7 @@ func (driver Driver) FindLargestVersionSinceBaseline(ctx context.Context, tx *sq
 }
 
 // FindLargestSequence will return the largest sequence number.
-func (Driver) FindLargestSequence(ctx context.Context, tx *sql.Tx, namespace string, baseline bool) (int, error) {
+func (*Driver) FindLargestSequence(ctx context.Context, tx *sql.Tx, namespace string, baseline bool) (int, error) {
 	findLargestSequenceQuery := `
 		SELECT MAX(sequence) FROM bytebase.public.migration_history
 		WHERE namespace = ?`
@@ -122,7 +145,7 @@ func (Driver) FindLargestSequence(ctx context.Context, tx *sql.Tx, namespace str
 }
 
 // InsertPendingHistory will insert the migration record with pending status and return the inserted ID.
-func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (int64, error) {
+func (driver *Driver) InsertPendingHistory(ctx context.Context, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (int64, error) {
 	const insertHistoryQuery = `
 		INSERT INTO bytebase.public.migration_history (
 			created_by,
@@ -148,6 +171,13 @@ func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int
 	`
 	var insertedID int64
 	maxIDQuery := "SELECT MAX(id)+1 FROM bytebase.public.migration_history"
+
+	tx, err := driver.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, nil
+	}
+	defer tx.Rollback()
+
 	rows, err := tx.QueryContext(ctx, maxIDQuery)
 	if err != nil {
 		return int64(0), util.FormatErrorWithQuery(err, maxIDQuery)
@@ -170,7 +200,7 @@ func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int
 		insertedID = 1
 	}
 
-	_, err = tx.ExecContext(ctx, insertHistoryQuery,
+	if _, err = tx.ExecContext(ctx, insertHistoryQuery,
 		m.Creator,
 		m.Creator,
 		m.ReleaseVersion,
@@ -186,15 +216,18 @@ func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int
 		prevSchema,
 		m.IssueID,
 		m.Payload,
-	)
-	if err != nil {
+	); err != nil {
 		return int64(0), util.FormatErrorWithQuery(err, insertHistoryQuery)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
 	}
 	return insertedID, nil
 }
 
 // UpdateHistoryAsDone will update the migration record as done.
-func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
+func (driver *Driver) UpdateHistoryAsDone(ctx context.Context, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
 	const updateHistoryAsDoneQuery = `
 		UPDATE
 			bytebase.public.migration_history
@@ -204,12 +237,12 @@ func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDura
 			schema = ?
 		WHERE id = ?
 	`
-	_, err := tx.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, insertedID)
+	_, err := driver.db.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, insertedID)
 	return err
 }
 
 // UpdateHistoryAsFailed will update the migration record as failed.
-func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, insertedID int64) error {
+func (driver *Driver) UpdateHistoryAsFailed(ctx context.Context, migrationDurationNs int64, insertedID int64) error {
 	const updateHistoryAsFailedQuery = `
 		UPDATE
 			bytebase.public.migration_history
@@ -218,7 +251,7 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 			execution_duration_ns = ?
 		WHERE id = ?
 	`
-	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, insertedID)
+	_, err := driver.db.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, insertedID)
 	return err
 }
 

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -103,6 +103,12 @@ func (driver *Driver) Ping(ctx context.Context) error {
 	return driver.db.PingContext(ctx)
 }
 
+// SwitchDatabase switches the connected database.
+func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
+	noop := func() error { return nil }
+	return noop, nil
+}
+
 // GetType returns the database type.
 func (*Driver) GetType() db.Type {
 	return db.Snowflake

--- a/plugin/db/snowflake/snowflake.go
+++ b/plugin/db/snowflake/snowflake.go
@@ -105,7 +105,9 @@ func (driver *Driver) Ping(ctx context.Context) error {
 
 // SwitchDatabase switches the connected database.
 func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error { return nil }
+	noop := func() error {
+		return nil
+	}
 	return noop, nil
 }
 

--- a/plugin/db/spanner/migrate.go
+++ b/plugin/db/spanner/migrate.go
@@ -75,11 +75,11 @@ func (*Driver) ExecuteMigration(_ context.Context, _ *db.MigrationInfo, _ string
 // FindMigrationHistoryList finds the migration history list.
 func (d *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {
 	defer func(db string) {
-		if err := d.switchDatabase(ctx, db); err != nil {
+		if _, err := d.SwitchDatabase(ctx, db); err != nil {
 			log.Error("failed to switch back database for spanner driver", zap.String("database", db), zap.Error(err))
 		}
 	}(d.dbName)
-	if err := d.switchDatabase(ctx, db.BytebaseDatabase); err != nil {
+	if _, err := d.SwitchDatabase(ctx, db.BytebaseDatabase); err != nil {
 		return nil, err
 	}
 	query := `

--- a/plugin/db/spanner/migrate.go
+++ b/plugin/db/spanner/migrate.go
@@ -74,14 +74,6 @@ func (*Driver) ExecuteMigration(_ context.Context, _ *db.MigrationInfo, _ string
 
 // FindMigrationHistoryList finds the migration history list.
 func (d *Driver) FindMigrationHistoryList(ctx context.Context, find *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {
-	defer func(db string) {
-		if _, err := d.SwitchDatabase(ctx, db); err != nil {
-			log.Error("failed to switch back database for spanner driver", zap.String("database", db), zap.Error(err))
-		}
-	}(d.dbName)
-	if _, err := d.SwitchDatabase(ctx, db.BytebaseDatabase); err != nil {
-		return nil, err
-	}
 	query := `
 	SELECT
 		id,

--- a/plugin/db/spanner/spanner.go
+++ b/plugin/db/spanner/spanner.go
@@ -100,10 +100,10 @@ func (d *Driver) Open(ctx context.Context, _ db.Type, config db.ConnectionConfig
 
 // ForkOpen opens another database in the same instance.
 // This is used to connect to the database where the migration_history table resides.
-func (driver *Driver) ForkOpen(ctx context.Context, database string) (db.Driver, error) {
-	connCfg := driver.config
+func (d *Driver) ForkOpen(ctx context.Context, database string) (db.Driver, error) {
+	connCfg := d.config
 	connCfg.Database = database
-	fork, err := newDriver(db.DriverConfig{}).Open(ctx, "", connCfg, driver.connCtx)
+	fork, err := newDriver(db.DriverConfig{}).Open(ctx, "", connCfg, d.connCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/db/spanner/spanner.go
+++ b/plugin/db/spanner/spanner.go
@@ -101,7 +101,9 @@ func (d *Driver) Open(ctx context.Context, _ db.Type, config db.ConnectionConfig
 // SwitchDatabase switches the connected database.
 func (d *Driver) SwitchDatabase(ctx context.Context, dbName string) (func() error, error) {
 	if d.dbName == dbName {
-		noop := func() error { return nil }
+		noop := func() error {
+			return nil
+		}
 		return noop, nil
 	}
 

--- a/plugin/db/sqlite/migrate.go
+++ b/plugin/db/sqlite/migrate.go
@@ -85,6 +85,7 @@ func (driver *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 	return nil
 }
 
+// FindLargestVersionSinceBaselineAndLargestSequence will find the largest version since last baseline or branch and the largest sequence number.
 func (driver *Driver) FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error) {
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -71,6 +71,12 @@ func (*Driver) GetType() db.Type {
 	return db.SQLite
 }
 
+// SwitchDatabase switches the connected database.
+func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
+	noop := func() error { return nil }
+	return noop, nil
+}
+
 // GetDBConnection gets a database connection.
 // If database is empty, we will get a connect to in-memory database.
 func (driver *Driver) GetDBConnection(_ context.Context, database string) (*sql.DB, error) {

--- a/plugin/db/sqlite/sqlite.go
+++ b/plugin/db/sqlite/sqlite.go
@@ -73,7 +73,9 @@ func (*Driver) GetType() db.Type {
 
 // SwitchDatabase switches the connected database.
 func (*Driver) SwitchDatabase(context.Context, string) (func() error, error) {
-	noop := func() error { return nil }
+	noop := func() error {
+		return nil
+	}
 	return noop, nil
 }
 

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -137,8 +137,8 @@ func NeedsSetupMigrationSchema(ctx context.Context, sqldb *sql.DB, query string)
 type MigrationExecutor interface {
 	db.Driver
 	// FindLargestVersionSinceBaselineAndLargestSequence will
-	// find the largest version since last baseline or branch.
-	// return the largest sequence number, 0 if we haven't applied any migration for this namespace.
+	// - find the largest version since last baseline or branch.
+	// - return the largest sequence number, 0 if we haven't applied any migration for this namespace.
 	FindLargestVersionSinceBaselineAndLargestSequence(ctx context.Context, namespace string) (*string, int, error)
 	// InsertPendingHistory will insert the migration record with pending status and return the inserted ID.
 	InsertPendingHistory(ctx context.Context, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (insertedID int64, err error)

--- a/plugin/db/util/driverutil.go
+++ b/plugin/db/util/driverutil.go
@@ -195,7 +195,7 @@ func ExecuteMigration(ctx context.Context, executor MigrationExecutor, m *db.Mig
 	}
 	if doMigrate {
 		// Fork open a connection to the database where migration_history table resides.
-		// Becuase the target database is not created yet and cannot be connected.
+		// Because the target database is not created yet and cannot be connected.
 		if m.CreateDatabase {
 			if err := func() (err error) {
 				fork, err := executor.ForkOpen(ctx, databaseName)


### PR DESCRIPTION
In `ExecuteMigration`, the driver needs to connect to these two databases, the databases where the actual migration happens and the database where Bytebase keeps the migration history. Unfortunately, these two databases may not always be the same database. And depending on the driver type, we may or may not be able to query on db1 while connecting db2(e.g. MySQL and Spanner, respectively). So we used to use `GetDBConnection` to fire up an additional connection (depending on the driver type, no need for e.g. MySQL) to the migration history database. However, this leaks too much detail of our Driver interface, IMO, and makes it troublesome to implement for databases of which there isn't any database/sql driver(e.g. mongo).

This PR removes unnecessary transactions and uses SwitchDatabase to switch the connected database.

minor fixes:
- use pointer receiver