### PR TITLE
feat(schema-diagram): multi-schema support (for pg)

### DIFF
--- a/frontend/src/components/SchemaDiagram/ER/libs/autoLayout/engines/elk.ts
+++ b/frontend/src/components/SchemaDiagram/ER/libs/autoLayout/engines/elk.ts
@@ -1,4 +1,5 @@
-import ELK, { type ElkNode } from "elkjs/lib/elk.bundled";
+import ELK, { LayoutOptions, type ElkNode } from "elkjs/lib/elk.bundled";
+import { groupBy } from "lodash-es";
 
 import type { Path, Rect } from "@/components/SchemaDiagram/types";
 import type { GraphEdgeItem, GraphNodeItem, Layout } from "../types";
@@ -8,20 +9,28 @@ export const layoutELK = async (
   edgeList: GraphEdgeItem[]
 ): Promise<Layout> => {
   const elk = new ELK({});
+  const nodeGroups = groupBy(nodeList, (node) => node.group);
+  const layoutOptions: LayoutOptions = {
+    "elk.algorithm": "layered",
+    "elk.direction": "RIGHT",
+    "spacing.nodeNode": "100",
+    "spacing.nodeNodeBetweenLayers": "200",
+    "nodePlacement.favorStraightEdges": "true",
+    "elk.edgeRouting": "POLYLINE",
+  };
   const graph: ElkNode = {
     id: "root",
-    layoutOptions: {
-      "elk.algorithm": "layered",
-      "elk.direction": "RIGHT",
-      "elk.spacing.nodeNode": "100",
-      "elk.layered.spacing.nodeNodeBetweenLayers": "200",
-      "elk.layered.nodePlacement.favorStraightEdges": "true",
-      "elk.edgeRouting": "POLYLINE",
-    },
-    children: nodeList.map(({ id, size }) => ({
-      id,
-      ...size,
-    })),
+    layoutOptions,
+    children: Object.keys(nodeGroups).map((group) => {
+      return {
+        id: `group-${group}`,
+        layoutOptions,
+        children: nodeGroups[group].map(({ id, size }) => ({
+          id,
+          ...size,
+        })),
+      };
+    }),
     edges: edgeList.map(({ id, from, to }) => ({
       id,
       sources: [from],
@@ -30,15 +39,18 @@ export const layoutELK = async (
   };
 
   const result = await elk.layout(graph, {
-    logging: true,
+    // logging: true,
   });
   const rects = new Map<string, Rect>();
-  result.children?.forEach((node) => {
-    rects.set(node.id, {
-      x: node.x!,
-      y: node.y!,
-      width: node.width!,
-      height: node.height!,
+  result.children?.forEach((cluster) => {
+    const { x = 0, y = 0 } = cluster;
+    cluster.children?.forEach((node) => {
+      rects.set(node.id, {
+        x: node.x! + x,
+        y: node.y! + y,
+        width: node.width!,
+        height: node.height!,
+      });
     });
   });
   const paths = new Map<string, Path>();

--- a/frontend/src/components/SchemaDiagram/ER/libs/autoLayout/types.ts
+++ b/frontend/src/components/SchemaDiagram/ER/libs/autoLayout/types.ts
@@ -8,6 +8,7 @@ import type {
 export type GraphChildNodeItem = { id: string; size: Size; pos: Position };
 
 export type GraphNodeItem = {
+  group: string;
   id: string;
   size: Size;
   children: GraphChildNodeItem[]; // not used yet

--- a/frontend/src/components/SchemaDiagram/types/context.ts
+++ b/frontend/src/components/SchemaDiagram/types/context.ts
@@ -1,7 +1,11 @@
 import { Ref } from "vue";
 import type Emittery from "emittery";
 
-import { ColumnMetadata, TableMetadata } from "@/types/proto/store/database";
+import {
+  ColumnMetadata,
+  SchemaMetadata,
+  TableMetadata,
+} from "@/types/proto/store/database";
 import { Position, Rect } from "./geometry";
 import { EditStatus } from "./edit";
 
@@ -25,6 +29,7 @@ export type SchemaDiagramContext = {
   render: () => void;
   // auto-layout all components
   layout: () => void;
+  schemaStatus: (schema: SchemaMetadata) => EditStatus;
   tableStatus: (table: TableMetadata) => EditStatus;
   columnStatus: (column: ColumnMetadata) => EditStatus;
 
@@ -33,8 +38,9 @@ export type SchemaDiagramContext = {
     render: undefined;
     layout: undefined;
     "fit-view": undefined;
-    "edit-table": TableMetadata;
+    "edit-table": { schema: SchemaMetadata; table: TableMetadata };
     "edit-column": {
+      schema: SchemaMetadata;
       table: TableMetadata;
       column: ColumnMetadata;
       target: "name" | "type";

--- a/frontend/src/components/SchemaDiagram/types/schema.ts
+++ b/frontend/src/components/SchemaDiagram/types/schema.ts
@@ -1,14 +1,17 @@
 import {
   ForeignKeyMetadata,
+  SchemaMetadata,
   TableMetadata,
 } from "@/types/proto/store/database";
 
 export type ForeignKey = {
   from: {
+    schema: SchemaMetadata;
     table: TableMetadata;
     column: string;
   };
   to: {
+    schema: SchemaMetadata;
     table: TableMetadata;
     column: string;
   };

--- a/frontend/src/store/modules/dbSchema.ts
+++ b/frontend/src/store/modules/dbSchema.ts
@@ -55,6 +55,12 @@ export const useDBSchemaStore = defineStore("dbSchema", {
       }
       return this.getSchemaListByDatabaseId(databaseId);
     },
+    getDatabaseMetadataByDatabaseId(databaseId: DatabaseId): DatabaseMetadata {
+      return (
+        this.databaseMetadataById.get(databaseId) ??
+        DatabaseMetadata.fromPartial({})
+      );
+    },
     getSchemaListByDatabaseId(databaseId: DatabaseId): SchemaMetadata[] {
       const databaseMetadata = this.databaseMetadataById.get(databaseId);
       if (!databaseMetadata) {

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -311,7 +311,9 @@
     <div class="w-[80vw] h-full">
       <SchemaDiagram
         :database="database"
-        :table-list="dbSchemaStore.getTableListByDatabaseId(database.id)"
+        :database-metadata="
+          dbSchemaStore.getDatabaseMetadataByDatabaseId(database.id)
+        "
       />
     </div>
   </BBModal>


### PR DESCRIPTION
### Changes

- Draw cross-schema foreign keys correctly.
- Show schema as table name prefix if schema name is not empty.
- Tables in newly created schemas or dropped schemas will also be decorated as "created" or "dropped".
- Auto-layout: try to layout tables in a schema as a cluster.

FYI @tianzhou @Candybase 

### Screenshots

- Auto-layout: schemas as clusters
![localhost_3000_db_monica-363(1600_900)](https://user-images.githubusercontent.com/2749742/210728609-1034861a-006f-48e0-adc3-50271cb9bbb2.png)

- Schema Editor integration - cross-schema foreign keys.

https://user-images.githubusercontent.com/2749742/210728477-1e53a369-0bb9-43c5-b12f-30eaeb71da43.mp4

