### PR TITLE
feat(frontend): access control settings improvements

### DIFF
--- a/frontend/src/components/AccessControl/AddRuleForm.vue
+++ b/frontend/src/components/AccessControl/AddRuleForm.vue
@@ -50,7 +50,7 @@
       <i18n-t
         keypath="settings.access-control.no-database-in-protected-environment"
         tag="div"
-        class="text-sm leading-6 text-gray-500 max-w-[14rem] whitespace-pre-wrap text-center"
+        class="text-sm leading-6 text-gray-500 max-w-[15rem] whitespace-pre-wrap text-center"
       >
         <template #protected_environment>
           <a
@@ -59,6 +59,9 @@
             target="__BLANK"
           >
             {{ $t("environment.protected-environment") }}
+            <heroicons-outline:external-link
+              class="inline-block w-4 h-4 -mt-0.5 mr-0.5"
+            />
           </a>
         </template>
       </i18n-t>

--- a/frontend/src/components/AccessControl/AddRuleForm.vue
+++ b/frontend/src/components/AccessControl/AddRuleForm.vue
@@ -47,10 +47,21 @@
       v-if="!state.isLoading && databaseList.length === 0"
       class="w-full flex flex-col py-6 justify-start items-center"
     >
-      <heroicons-outline:inbox class="w-12 h-auto text-gray-500" />
-      <span class="text-sm leading-6 text-gray-500">{{
-        $t("common.no-data")
-      }}</span>
+      <i18n-t
+        keypath="settings.access-control.no-database-in-protected-environment"
+        tag="div"
+        class="text-sm leading-6 text-gray-500 max-w-[14rem] whitespace-pre-wrap text-center"
+      >
+        <template #protected_environment>
+          <a
+            href="https://www.bytebase.com/docs/administration/database-access-control"
+            class="normal-link lowercase"
+            target="__BLANK"
+          >
+            {{ $t("environment.protected-environment") }}
+          </a>
+        </template>
+      </i18n-t>
     </div>
 
     <div class="flex items-center justify-between">
@@ -86,20 +97,21 @@
 import { computed, PropType, reactive } from "vue";
 
 import type { Database, DatabaseId, Policy } from "@/types";
-import { DEFAULT_PROJECT_ID } from "@/types";
-import { useDatabaseStore } from "@/store";
 import { filterDatabaseByKeyword } from "@/utils";
 
 type LocalState = {
   isLoading: boolean;
   searchText: string;
-  databaseList: Database[];
   selectedDatabaseIdList: Set<DatabaseId>;
 };
 
 const props = defineProps({
   policyList: {
     type: Array as PropType<Policy[]>,
+    default: () => [],
+  },
+  databaseList: {
+    type: Array as PropType<Database[]>,
     default: () => [],
   },
 });
@@ -112,21 +124,8 @@ const emit = defineEmits<{
 const state = reactive<LocalState>({
   isLoading: false,
   searchText: "",
-  databaseList: [],
   selectedDatabaseIdList: new Set(),
 });
-
-const databaseStore = useDatabaseStore();
-
-const prepareList = async () => {
-  state.isLoading = true;
-
-  const allDatabaseList = await databaseStore.fetchDatabaseList();
-  state.databaseList = allDatabaseList
-    .filter((db) => db.instance.environment.tier === "PROTECTED")
-    .filter((db) => db.project.id !== DEFAULT_PROJECT_ID);
-  state.isLoading = false;
-};
 
 const presetDatabaseIdList = computed(() => {
   const databaseIdList = props.policyList.map(
@@ -137,7 +136,7 @@ const presetDatabaseIdList = computed(() => {
 
 const databaseList = computed(() => {
   // Don't show the databases already have access control policy.
-  let list = state.databaseList.filter(
+  let list = props.databaseList.filter(
     (db) => !presetDatabaseIdList.value.has(db.id)
   );
 
@@ -204,6 +203,4 @@ const toggleAllDatabasesSelection = (
     });
   }
 };
-
-prepareList();
 </script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -423,9 +423,12 @@
       "remove-sensitive-column-tips": "Expose this column?"
     },
     "access-control": {
-      "description": "Allow developers to execute queries for the following databases in the protected environments from SQL Editor.",
+      "description": "Allow developers to execute queries for the following databases in the protected environments from SQL Editor. {link}",
       "add-rule": "Add rule",
-      "remove-policy-tips": "Remove this rule?"
+      "remove-policy-tips": "Remove this rule?",
+      "inactive-rules": "Inactive rules",
+      "inactive-rules-description": "These rules are inactive because environment is not protected.",
+      "no-database-in-protected-environment": "Make sure there are databases in the {protected_environment}."
     },
     "release": {
       "new-version-available": "New version is available",
@@ -755,7 +758,8 @@
     "disable-auto-backup": {
       "self": "Disable database automatic backup",
       "content": "Disabling automatic backup policy is not applied retroactively.\nAre you sure about applying to all databases in this environment?"
-    }
+    },
+    "protected-environment": "Protected environment"
   },
   "quick-start": {
     "bookmark-an-issue": "Bookmark an issue",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -423,9 +423,12 @@
       "remove-sensitive-column-tips": "不再对此列数据脱敏？"
     },
     "access-control": {
-      "description": "允许开发者通过 SQL 编辑器对下列受保护环境中的数据库执行查询。",
+      "description": "允许开发者通过 SQL 编辑器对下列受保护环境中的数据库执行查询。{link}",
       "add-rule": "添加规则",
-      "remove-policy-tips": "删除这条规则？"
+      "remove-policy-tips": "删除这条规则？",
+      "inactive-rules": "无效的规则",
+      "inactive-rules-description": "这些规则不再生效，因为所属环境不是受保护的。",
+      "no-database-in-protected-environment": "请确保{protected_environment}中有数据库。"
     },
     "release": {
       "new-version-available": "有新版本可更新",
@@ -755,7 +758,8 @@
     "disable-auto-backup": {
       "self": "禁用数据库自动备份",
       "content": "禁用自动备份策略仅对新添加的数据库生效。\n是否要将该设置应用到当前环境下的所有数据库？"
-    }
+    },
+    "protected-environment": "受保护的环境"
   },
   "quick-start": {
     "bookmark-an-issue": "收藏工单",

--- a/frontend/src/views/SettingWorkspaceAccessControl.vue
+++ b/frontend/src/views/SettingWorkspaceAccessControl.vue
@@ -4,7 +4,7 @@
       <i18n-t
         tag="div"
         keypath="settings.access-control.description"
-        class="textinfolabel max-w-xl"
+        class="textinfolabel"
       >
         <template #link>
           <LearnMoreLink


### PR DESCRIPTION
### Changes

- Add a "Learn more" link. (Close BYT-2197)
- Add wordings for empty "Add rule" dialog. (Close BYT-2197)
- Show "Inactive rules" if some of the rules are in unprotected environments. (Close BYT-2075)

FYI @Candybase 

### Screenshots

![localhost_3000_setting_access-control(1600_900) (3)](https://user-images.githubusercontent.com/2749742/210737897-5d74ed0c-4603-41cb-ab83-eb845a83465b.png)

![localhost_3000_setting_access-control(1600_900) (5)](https://user-images.githubusercontent.com/2749742/210737914-d28f0056-a9fa-419b-82aa-f87354bdad03.png)

![localhost_3000_setting_access-control(1600_900) (6)](https://user-images.githubusercontent.com/2749742/210737945-6078e368-d5fc-403d-845a-b4a915217c5a.png)
