### PR TITLE
chore: include schema version in the server startup log

### DIFF
--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -285,7 +285,7 @@ func start() {
 	if profile.ExternalURL == common.ExternalURLDocsLink {
 		externalAddr = fmt.Sprintf("!!! You have not set --external-url. If you want to make Bytebase\n!!! externally accessible, follow:\n\n%s", common.ExternalURLDocsLink)
 	}
-	fmt.Printf(greetingBanner, fmt.Sprintf("Version %s has started on port %d", profile.Version, flags.port), externalAddr)
+	fmt.Printf(greetingBanner, fmt.Sprintf("Version %s (schema version %s) has started on port %d", profile.Version, s.SchemaVersion, flags.port), externalAddr)
 
 	// Execute program.
 	if err := s.Run(ctx, flags.port); err != nil {

--- a/bin/server/cmd/root.go
+++ b/bin/server/cmd/root.go
@@ -285,7 +285,7 @@ func start() {
 	if profile.ExternalURL == common.ExternalURLDocsLink {
 		externalAddr = fmt.Sprintf("!!! You have not set --external-url. If you want to make Bytebase\n!!! externally accessible, follow:\n\n%s", common.ExternalURLDocsLink)
 	}
-	fmt.Printf(greetingBanner, fmt.Sprintf("Version %s (schema version %s) has started on port %d", profile.Version, s.SchemaVersion, flags.port), externalAddr)
+	fmt.Printf(greetingBanner, fmt.Sprintf("Version %s (schema version %v) has started on port %d", profile.Version, s.SchemaVersion, flags.port), externalAddr)
 
 	// Execute program.
 	if err := s.Run(ctx, flags.port); err != nil {

--- a/server/component/config/profile.go
+++ b/server/component/config/profile.go
@@ -53,7 +53,7 @@ type Profile struct {
 	// FeishuAPIURL is the URL of Feishu API server.
 	FeishuAPIURL string
 
-	// Version is the bytebase's version
+	// Version is the bytebase's server version
 	Version string
 	// Git commit hash of the build
 	GitCommit string

--- a/server/server.go
+++ b/server/server.go
@@ -125,7 +125,7 @@ type Server struct {
 	licenseService enterpriseAPI.LicenseService
 
 	// SchemaVersion is the bytebase's schema version
-	SchemaVersion semver.Version
+	SchemaVersion *semver.Version
 
 	profile         config.Profile
 	e               *echo.Echo
@@ -267,7 +267,7 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 		// return s so that caller can call s.Close() to shut down the postgres server if embedded.
 		return nil, errors.Wrap(err, "cannot open metadb")
 	}
-	s.SchemaVersion = *schemaVer
+	s.SchemaVersion = schemaVer
 
 	s.stateCfg = &state.State{
 		InstanceDatabaseSyncChan:       make(chan *api.Instance, 100),

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -184,15 +184,9 @@ func (db *DB) Open(ctx context.Context) (schemaVersion *semver.Version, err erro
 	return verAfter, nil
 }
 
-var emptyVersion = semver.Version{
-	Major: 0,
-	Minor: 0,
-	Patch: 0,
-}
-
 // getLatestVersion returns the latest schema version in semantic versioning format.
 // We expect our own migration history to use semantic versions.
-// If there's no migration history, version will be empty version.
+// If there's no migration history, version will be nil.
 func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (*semver.Version, error) {
 	limit := 1
 	history, err := d.FindMigrationHistoryList(ctx, &dbdriver.MigrationHistoryFind{
@@ -203,7 +197,7 @@ func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (
 		return nil, errors.Wrap(err, "failed to get migration history")
 	}
 	if len(history) == 0 {
-		return &emptyVersion, nil
+		return nil, nil
 	}
 
 	for _, h := range history {
@@ -231,7 +225,7 @@ func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (
 		return &v, nil
 	}
 
-	return &emptyVersion, nil
+	return nil, nil
 }
 
 // setupDemoData loads the setupDemoData data for testing.

--- a/store/pg_engine.go
+++ b/store/pg_engine.go
@@ -97,7 +97,7 @@ func NewDB(connCfg dbdriver.ConnectionConfig, binDir, demoDataDir string, readon
 }
 
 // Open opens the database connection.
-func (db *DB) Open(ctx context.Context) (err error) {
+func (db *DB) Open(ctx context.Context) (schemaVersion *semver.Version, err error) {
 	d, err := dbdriver.Open(
 		ctx,
 		dbdriver.Postgres,
@@ -106,7 +106,7 @@ func (db *DB) Open(ctx context.Context) (err error) {
 		dbdriver.ConnectionContext{},
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var databaseName string
@@ -121,46 +121,51 @@ func (db *DB) Open(ctx context.Context) (err error) {
 		// The database storing metadata is the same as user name.
 		db.db, err = d.GetDBConnection(ctx, databaseName)
 		if err != nil {
-			return errors.Wrapf(err, "failed to connect to database %q which may not be setup yet", databaseName)
+			return nil, errors.Wrapf(err, "failed to connect to database %q which may not be setup yet", databaseName)
 		}
-		return nil
+
+		ver, err := getLatestVersion(ctx, d, databaseName)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get current schema version")
+		}
+		return ver, nil
 	}
 
 	// We are also using our own migration core to manage our own schema's migration history.
 	// So here we will create a "bytebase" database to store the migration history if the target
 	// db instance does not have one yet.
 	if err := d.SetupMigrationIfNeeded(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	verBefore, err := getLatestVersion(ctx, d, databaseName)
 	if err != nil {
-		return errors.Wrap(err, "failed to get current schema version")
+		return nil, errors.Wrap(err, "failed to get current schema version")
 	}
 
 	if err := migrate(ctx, d, verBefore, db.mode, db.connCfg.StrictUseDb, db.serverVersion, databaseName); err != nil {
-		return errors.Wrap(err, "failed to migrate")
+		return nil, errors.Wrap(err, "failed to migrate")
 	}
 
 	verAfter, err := getLatestVersion(ctx, d, databaseName)
 	if err != nil {
-		return errors.Wrap(err, "failed to get current schema version")
+		return nil, errors.Wrap(err, "failed to get current schema version")
 	}
 	log.Info(fmt.Sprintf("Current schema version after migration: %s", verAfter))
 
 	db.db, err = d.GetDBConnection(ctx, databaseName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to connect to database %q", db.connCfg.Username)
+		return nil, errors.Wrapf(err, "failed to connect to database %q", db.connCfg.Username)
 	}
 
 	// Set the max open connections so that we won't exceed the connection limit of metaDB.
 	// The limit is the max connections minus connections reserved for superuser.
 	var maxConns, reservedConns int
 	if err := db.db.QueryRowContext(ctx, `SHOW max_connections`).Scan(&maxConns); err != nil {
-		return errors.Wrap(err, "failed to get max_connections from metaDB")
+		return nil, errors.Wrap(err, "failed to get max_connections from metaDB")
 	}
 	if err := db.db.QueryRowContext(ctx, `SHOW superuser_reserved_connections`).Scan(&reservedConns); err != nil {
-		return errors.Wrap(err, "failed to get superuser_reserved_connections from metaDB")
+		return nil, errors.Wrap(err, "failed to get superuser_reserved_connections from metaDB")
 	}
 	maxOpenConns := maxConns - reservedConns
 	if maxOpenConns > 50 {
@@ -170,18 +175,24 @@ func (db *DB) Open(ctx context.Context) (err error) {
 	db.db.SetMaxOpenConns(maxOpenConns)
 
 	if err := db.setupDemoData(); err != nil {
-		return errors.Wrapf(err, "failed to setup demo data."+
+		return nil, errors.Wrapf(err, "failed to setup demo data."+
 			" It could be Bytebase is running against an old Bytebase schema. If you are developing Bytebase, you can remove pgdata"+
 			" directory under the same directory where the Bytebase binary resides. and restart again to let"+
 			" Bytebase create the latest schema. If you are running in production and don't want to reset the data, you can contact support@bytebase.com for help")
 	}
 
-	return nil
+	return verAfter, nil
+}
+
+var emptyVersion = semver.Version{
+	Major: 0,
+	Minor: 0,
+	Patch: 0,
 }
 
 // getLatestVersion returns the latest schema version in semantic versioning format.
 // We expect our own migration history to use semantic versions.
-// If there's no migration history, version will be nil.
+// If there's no migration history, version will be empty version.
 func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (*semver.Version, error) {
 	limit := 1
 	history, err := d.FindMigrationHistoryList(ctx, &dbdriver.MigrationHistoryFind{
@@ -192,7 +203,7 @@ func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (
 		return nil, errors.Wrap(err, "failed to get migration history")
 	}
 	if len(history) == 0 {
-		return nil, nil
+		return &emptyVersion, nil
 	}
 
 	for _, h := range history {
@@ -220,7 +231,7 @@ func getLatestVersion(ctx context.Context, d dbdriver.Driver, database string) (
 		return &v, nil
 	}
 
-	return nil, nil
+	return &emptyVersion, nil
 }
 
 // setupDemoData loads the setupDemoData data for testing.


### PR DESCRIPTION
Reduce confusion since our schema version is not always the same as server version.

![CleanShot 2023-01-05 at 17 45 53](https://user-images.githubusercontent.com/230323/210750301-9df1906a-9eb5-42f9-8ab2-1bc7607e191b.png)