### PR TITLE
refactor: simplify the interface of database schema sync

### DIFF
--- a/api/database.go
+++ b/api/database.go
@@ -7,12 +7,6 @@ import (
 const (
 	// AllDatabaseName is the wild expression for all databases.
 	AllDatabaseName = "*"
-	// DefaultCharacterSetName is the default character set.
-	DefaultCharacterSetName = "utf8mb4"
-	// DefaultCollationName is the default collation name.
-	// Use utf8mb4_general_ci instead of the new MySQL 8.0.1 default utf8mb4_0900_ai_ci
-	// because the former is compatible with more other MySQL flavors (e.g. MariaDB).
-	DefaultCollationName = "utf8mb4_general_ci"
 )
 
 // SyncStatus is the database sync status.

--- a/server/database.go
+++ b/server/database.go
@@ -219,7 +219,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 		}
 		if dbSchema == nil {
 			// TODO(d): make SyncDatabaseSchema return the updated database schema.
-			if err := s.SchemaSyncer.SyncDatabaseSchema(ctx, database.Instance, database.Name, true /* force */); err != nil {
+			if err := s.SchemaSyncer.SyncDatabaseSchema(ctx, database, true /* force */); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to sync database schema for database ID %v", id)).SetInternal(err)
 			}
 			newDBSchema, err := s.store.GetDBSchema(ctx, id)

--- a/server/runner/schemasync/syncer.go
+++ b/server/runner/schemasync/syncer.go
@@ -328,6 +328,7 @@ func (s *Syncer) SyncDatabaseSchema(ctx context.Context, database *api.Database,
 		SyncStatus:           &syncStatus,
 		LastSuccessfulSyncTs: &ts,
 		SchemaVersion:        patchSchemaVersion,
+		// TODO(d): update CharacterSet and Collation.
 	}
 	database, err = s.store.PatchDatabase(ctx, databasePatch)
 	if err != nil {

--- a/server/runner/schemasync/syncer.go
+++ b/server/runner/schemasync/syncer.go
@@ -245,14 +245,13 @@ func (s *Syncer) SyncInstance(ctx context.Context, instance *api.Instance) ([]st
 		}
 		if !exist {
 			databaseCreate := &api.DatabaseCreate{
-				CreatorID:            api.SystemBotID,
-				ProjectID:            api.DefaultProjectID,
-				InstanceID:           instance.ID,
-				EnvironmentID:        instance.EnvironmentID,
-				Name:                 databaseMetadata.Name,
-				CharacterSet:         databaseMetadata.CharacterSet,
-				Collation:            databaseMetadata.Collation,
-				LastSuccessfulSyncTs: 0,
+				CreatorID:     api.SystemBotID,
+				ProjectID:     api.DefaultProjectID,
+				InstanceID:    instance.ID,
+				EnvironmentID: instance.EnvironmentID,
+				Name:          databaseMetadata.Name,
+				CharacterSet:  databaseMetadata.CharacterSet,
+				Collation:     databaseMetadata.Collation,
 			}
 			if _, err := s.store.CreateDatabase(ctx, databaseCreate); err != nil {
 				if common.ErrorCode(err) == common.Conflict {

--- a/server/runner/schemasync/syncer.go
+++ b/server/runner/schemasync/syncer.go
@@ -175,12 +175,6 @@ func (s *Syncer) SyncInstance(ctx context.Context, instance *api.Instance) ([]st
 	}
 	defer driver.Close(ctx)
 
-	return s.syncInstanceSchema(ctx, instance, driver)
-}
-
-// syncInstanceSchema syncs the instance and all database metadata first without diving into the deep structure of each database.
-func (s *Syncer) syncInstanceSchema(ctx context.Context, instance *api.Instance, driver db.Driver) ([]string, error) {
-	// Sync instance metadata.
 	instanceMeta, err := driver.SyncInstance(ctx)
 	if err != nil {
 		return nil, err
@@ -237,72 +231,54 @@ func (s *Syncer) syncInstanceSchema(ctx context.Context, instance *api.Instance,
 		}
 	}
 
-	// Compare the stored db info with the just synced db schema.
-	// Case 1: If item appears in both stored db info and the synced db metadata, then it's a no-op. We rely on syncDatabaseSchema() later to sync its details.
-	// Case 2: If item only appears in the synced schema and not in the stored db, then we CREATE the database record in the stored db.
-	// Case 3: Conversely, if item only appears in the stored db, but not in the synced schema, then we MARK the record as NOT_FOUND.
-	//   	   We don't delete the entry because:
-	//   	   1. This entry has already been associated with other entities, we can't simply delete it.
-	//   	   2. The deletion in the schema might be a mistake, so it's better to surface as NOT_FOUND to let user review it.
-	databaseFind := &api.DatabaseFind{
-		InstanceID: &instance.ID,
-	}
-	dbList, err := s.store.FindDatabase(ctx, databaseFind)
+	databases, err := s.store.ListDatabases(ctx, &store.FindDatabaseMessage{InstanceID: &instance.ResourceID})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to sync database for instance: %s. Failed to find database list", instance.Name)
 	}
 	for _, databaseMetadata := range instanceMeta.DatabaseList {
-		databaseName := databaseMetadata.Name
-
-		var matchedDb *api.Database
-		for _, db := range dbList {
-			if db.Name == databaseName {
-				matchedDb = db
+		exist := false
+		for _, database := range databases {
+			if database.DatabaseName == databaseMetadata.Name {
+				exist = true
 				break
 			}
 		}
-		if matchedDb != nil {
-			// Case 1, appear in both the Bytebase metadata and the synced database metadata.
-			// We rely on syncDatabaseSchema() to sync the database details.
-			continue
-		}
-		// Case 2, only appear in the synced db schema.
-		databaseCreate := &api.DatabaseCreate{
-			CreatorID:            api.SystemBotID,
-			ProjectID:            api.DefaultProjectID,
-			InstanceID:           instance.ID,
-			EnvironmentID:        instance.EnvironmentID,
-			Name:                 databaseName,
-			CharacterSet:         databaseMetadata.CharacterSet,
-			Collation:            databaseMetadata.Collation,
-			LastSuccessfulSyncTs: 0,
-		}
-		if _, err := s.store.CreateDatabase(ctx, databaseCreate); err != nil {
-			if common.ErrorCode(err) == common.Conflict {
-				return nil, errors.Errorf("failed to sync database for instance: %s. Database name already exists: %s", instance.Name, databaseCreate.Name)
+		if !exist {
+			databaseCreate := &api.DatabaseCreate{
+				CreatorID:            api.SystemBotID,
+				ProjectID:            api.DefaultProjectID,
+				InstanceID:           instance.ID,
+				EnvironmentID:        instance.EnvironmentID,
+				Name:                 databaseMetadata.Name,
+				CharacterSet:         databaseMetadata.CharacterSet,
+				Collation:            databaseMetadata.Collation,
+				LastSuccessfulSyncTs: 0,
 			}
-			return nil, errors.Wrapf(err, "failed to sync database for instance: %s. Failed to import new database: %s", instance.Name, databaseCreate.Name)
+			if _, err := s.store.CreateDatabase(ctx, databaseCreate); err != nil {
+				if common.ErrorCode(err) == common.Conflict {
+					return nil, errors.Errorf("failed to sync database for instance: %s. Database name already exists: %s", instance.Name, databaseCreate.Name)
+				}
+				return nil, errors.Wrapf(err, "failed to sync database for instance: %s. Failed to import new database: %s", instance.Name, databaseCreate.Name)
+			}
 		}
 	}
 
-	// Case 3, only appear in the Bytebase metadata
-	for _, db := range dbList {
-		found := false
+	for _, database := range databases {
+		exist := false
 		for _, databaseMetadata := range instanceMeta.DatabaseList {
-			if db.Name == databaseMetadata.Name {
-				found = true
+			if database.DatabaseName == databaseMetadata.Name {
+				exist = true
 				break
 			}
 		}
-		if !found {
+		if !exist {
 			syncStatus := api.NotFound
 			ts := time.Now().Unix()
 			databasePatch := &api.DatabasePatch{
-				ID:                   db.ID,
+				ID:                   database.UID,
 				UpdaterID:            api.SystemBotID,
 				SyncStatus:           &syncStatus,
 				LastSuccessfulSyncTs: &ts,
-				// SchemaVersion will not be over-written.
 			}
 			database, err := s.store.PatchDatabase(ctx, databasePatch)
 			if err != nil {
@@ -318,7 +294,6 @@ func (s *Syncer) syncInstanceSchema(ctx context.Context, instance *api.Instance,
 	for _, database := range instanceMeta.DatabaseList {
 		databaseList = append(databaseList, database.Name)
 	}
-
 	return databaseList, nil
 }
 

--- a/server/runner/taskrun/database_create_executor.go
+++ b/server/runner/taskrun/database_create_executor.go
@@ -213,7 +213,7 @@ func (exec *DatabaseCreateExecutor) RunOnce(ctx context.Context, task *api.Task)
 		return true, nil, err
 	}
 
-	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, instance, database.Name, true /* force */); err != nil {
+	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, database, true /* force */); err != nil {
 		log.Error("failed to sync database schema",
 			zap.String("instanceName", instance.Name),
 			zap.String("databaseName", database.Name),

--- a/server/runner/taskrun/pitr_cutover_executor.go
+++ b/server/runner/taskrun/pitr_cutover_executor.go
@@ -135,7 +135,7 @@ func (exec *PITRCutoverExecutor) pitrCutover(ctx context.Context, dbFactory *dbf
 	}
 
 	// Sync database schema after restore is completed.
-	if err := schemaSyncer.SyncDatabaseSchema(ctx, task.Database.Instance, task.Database.Name, true /* force */); err != nil {
+	if err := schemaSyncer.SyncDatabaseSchema(ctx, task.Database, true /* force */); err != nil {
 		log.Error("failed to sync database schema",
 			zap.String("instanceName", task.Database.Instance.Name),
 			zap.String("databaseName", task.Database.Name),

--- a/server/runner/taskrun/pitr_restore_executor.go
+++ b/server/runner/taskrun/pitr_restore_executor.go
@@ -156,7 +156,7 @@ func (exec *PITRRestoreExecutor) doBackupRestore(ctx context.Context, store *sto
 	}
 
 	// Sync database schema after restore is completed.
-	if err := schemaSyncer.SyncDatabaseSchema(ctx, targetDatabase.Instance, targetDatabase.Name, true /* force */); err != nil {
+	if err := schemaSyncer.SyncDatabaseSchema(ctx, targetDatabase, true /* force */); err != nil {
 		log.Error("failed to sync database schema",
 			zap.String("instanceName", targetDatabase.Instance.Name),
 			zap.String("databaseName", targetDatabase.Name),

--- a/server/runner/taskrun/schema_baseline_executor.go
+++ b/server/runner/taskrun/schema_baseline_executor.go
@@ -49,7 +49,7 @@ func (exec *SchemaBaselineExecutor) RunOnce(ctx context.Context, task *api.Task)
 
 	terminated, result, err := runMigration(ctx, exec.store, exec.dbFactory, exec.activityManager, exec.stateCfg, exec.profile, task, db.Baseline, "" /* statement */, payload.SchemaVersion, nil /* vcsPushEvent */)
 
-	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Instance, task.Database.Name, true /* force */); err != nil {
+	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Database, true /* force */); err != nil {
 		log.Error("failed to sync database schema",
 			zap.String("instanceName", task.Instance.Name),
 			zap.String("databaseName", task.Database.Name),

--- a/server/runner/taskrun/schema_update_executor.go
+++ b/server/runner/taskrun/schema_update_executor.go
@@ -59,7 +59,7 @@ func (exec *SchemaUpdateExecutor) RunOnce(ctx context.Context, task *api.Task) (
 		statement = sheet.Statement
 	}
 	terminated, result, err := runMigration(ctx, exec.store, exec.dbFactory, exec.activityManager, exec.stateCfg, exec.profile, task, db.Migrate, statement, payload.SchemaVersion, payload.VCSPushEvent)
-	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Instance, task.Database.Name, true /* force */); err != nil {
+	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Database, true /* force */); err != nil {
 		log.Error("failed to sync database schema",
 			zap.String("instanceName", task.Instance.Name),
 			zap.String("databaseName", task.Database.Name),

--- a/server/runner/taskrun/schema_update_ghost_cutover_executor.go
+++ b/server/runner/taskrun/schema_update_ghost_cutover_executor.go
@@ -84,7 +84,7 @@ func (exec *SchemaUpdateGhostCutoverExecutor) RunOnce(ctx context.Context, task 
 
 	terminated, result, err := cutover(ctx, exec.store, exec.dbFactory, exec.activityManager, exec.profile, task, payload.Statement, payload.SchemaVersion, payload.VCSPushEvent, postponeFilename, sharedGhost.migrationContext, sharedGhost.errCh)
 
-	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Instance, task.Database.Name, true /* force */); err != nil {
+	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Database, true /* force */); err != nil {
 		log.Error("failed to sync database schema",
 			zap.String("instanceName", task.Instance.Name),
 			zap.String("databaseName", task.Database.Name),

--- a/server/runner/taskrun/schema_update_sdl_executor.go
+++ b/server/runner/taskrun/schema_update_sdl_executor.go
@@ -56,7 +56,7 @@ func (exec *SchemaUpdateSDLExecutor) RunOnce(ctx context.Context, task *api.Task
 	}
 	terminated, result, err := runMigration(ctx, exec.store, exec.dbFactory, exec.activityManager, exec.stateCfg, exec.profile, task, db.MigrateSDL, ddl, payload.SchemaVersion, payload.VCSPushEvent)
 
-	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Instance, task.Database.Name, true /* force */); err != nil {
+	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, task.Database, true /* force */); err != nil {
 		log.Error("failed to sync database schema",
 			zap.String("instanceName", task.Instance.Name),
 			zap.String("databaseName", task.Database.Name),

--- a/server/sql.go
+++ b/server/sql.go
@@ -147,7 +147,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 			if database == nil {
 				return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Database ID not found: %d", *sync.DatabaseID))
 			}
-			if err := s.SchemaSyncer.SyncDatabaseSchema(ctx, database.Instance, database.Name, true /* force */); err != nil {
+			if err := s.SchemaSyncer.SyncDatabaseSchema(ctx, database, true /* force */); err != nil {
 				resultSet.Error = err.Error()
 			}
 		}

--- a/store/instance.go
+++ b/store/instance.go
@@ -378,8 +378,6 @@ func (s *Store) createInstanceRaw(ctx context.Context, create *InstanceCreate) (
 		InstanceID:    instance.ID,
 		EnvironmentID: instance.EnvironmentID,
 		Name:          api.AllDatabaseName,
-		CharacterSet:  api.DefaultCharacterSetName,
-		Collation:     api.DefaultCollationName,
 	}
 	allDatabase, err := s.createDatabaseRawTx(ctx, tx, databaseCreate)
 	if err != nil {
@@ -896,8 +894,6 @@ func (s *Store) CreateInstanceV2(ctx context.Context, environmentID string, inst
 		InstanceID:    instanceID,
 		EnvironmentID: environment.UID,
 		Name:          api.AllDatabaseName,
-		CharacterSet:  api.DefaultCharacterSetName,
-		Collation:     api.DefaultCollationName,
 	}
 	allDatabase, err := s.createDatabaseRawTx(ctx, tx, databaseCreate)
 	if err != nil {


### PR DESCRIPTION
In addition, removed the default charset and collation for wildcard dummy database because they should always be empty string.