### PR TITLE
refactor: change migrationHistoryID to string from int64

### DIFF
--- a/api/instance.go
+++ b/api/instance.go
@@ -141,7 +141,7 @@ type InstanceMigration struct {
 // MigrationHistory is stored in the instance instead of our own data file, so the field
 // format is a bit different from the standard format.
 type MigrationHistory struct {
-	ID int `jsonapi:"primary,migrationHistory"`
+	ID string `jsonapi:"primary,migrationHistory"`
 
 	// Standard fields
 	Creator   string `jsonapi:"attr,creator"`

--- a/api/task.go
+++ b/api/task.go
@@ -179,10 +179,10 @@ type TaskDatabaseDataUpdatePayload struct {
 
 	// ThreadID is the ID of the connection executing the migration.
 	// We use it to filter the binlog events of the migration transaction.
-	ThreadID string `json:"threadID,omitempty"`
+	ThreadID string `json:"threadId,omitempty"`
 	// MigrationID is the ID of the migration history record.
 	// We use it to get the schema when the transaction ran.
-	MigrationID string `json:"migrationID,omitempty"`
+	MigrationID string `json:"migrationId,omitempty"`
 	// BinlogXxx are obtained before and after executing the migration.
 	// We use them to locate the range of binlog for the migration transaction.
 	BinlogFileStart string `json:"binlogFileStart,omitempty"`

--- a/api/task.go
+++ b/api/task.go
@@ -182,7 +182,7 @@ type TaskDatabaseDataUpdatePayload struct {
 	ThreadID string `json:"threadID,omitempty"`
 	// MigrationID is the ID of the migration history record.
 	// We use it to get the schema when the transaction ran.
-	MigrationID int `json:"migrationID,omitempty"`
+	MigrationID string `json:"migrationID,omitempty"`
 	// BinlogXxx are obtained before and after executing the migration.
 	// We use them to locate the range of binlog for the migration transaction.
 	BinlogFileStart string `json:"binlogFileStart,omitempty"`

--- a/api/task_run.go
+++ b/api/task_run.go
@@ -25,7 +25,7 @@ const (
 // TaskRunResultPayload is the result payload for a task run.
 type TaskRunResultPayload struct {
 	Detail      string `json:"detail,omitempty"`
-	MigrationID int64  `json:"migrationId,omitempty"`
+	MigrationID string `json:"migrationId,omitempty"`
 	Version     string `json:"version,omitempty"`
 }
 

--- a/plugin/advisor/utils_for_tests.go
+++ b/plugin/advisor/utils_for_tests.go
@@ -303,8 +303,8 @@ func (*MockDriver) SetupMigrationIfNeeded(_ context.Context) error {
 }
 
 // ExecuteMigration implements the Driver interface.
-func (*MockDriver) ExecuteMigration(_ context.Context, _ *database.MigrationInfo, _ string) (int64, string, error) {
-	return 0, "", nil
+func (*MockDriver) ExecuteMigration(_ context.Context, _ *database.MigrationInfo, _ string) (string, string, error) {
+	return "", "", nil
 }
 
 // FindMigrationHistoryList implements the Driver interface.

--- a/plugin/db/driver.go
+++ b/plugin/db/driver.go
@@ -311,7 +311,7 @@ func ParseSchemaFileInfo(baseDirectory, schemaPathTemplate, file string) (*Migra
 
 // MigrationHistory is the API message for migration history.
 type MigrationHistory struct {
-	ID int
+	ID string
 
 	Creator   string
 	CreatedTs int64
@@ -338,7 +338,7 @@ type MigrationHistory struct {
 
 // MigrationHistoryFind is the API message for finding migration histories.
 type MigrationHistoryFind struct {
-	ID *int
+	ID *string
 
 	Database *string
 	Source   *MigrationSource
@@ -471,7 +471,7 @@ type Driver interface {
 	// Execute migration will apply the statement and record the migration history, the schema after migration on success.
 	// The migration type is determined by m.Type. Note, it can also perform data migration (DML) in addition to schema migration (DDL).
 	// It returns the migration history id and the schema after migration on success.
-	ExecuteMigration(ctx context.Context, m *MigrationInfo, statement string) (int64, string, error)
+	ExecuteMigration(ctx context.Context, m *MigrationInfo, statement string) (string, string, error)
 	// Find the migration history list and return most recent item first.
 	FindMigrationHistoryList(ctx context.Context, find *MigrationHistoryFind) ([]*MigrationHistory, error)
 

--- a/plugin/db/mongodb/migrate.go
+++ b/plugin/db/mongodb/migrate.go
@@ -365,7 +365,7 @@ func (driver *Driver) UpdateHistoryAsDone(ctx context.Context, _ *sql.Tx, migrat
 		return errors.Wrapf(err, "failed to update a migration history as done")
 	}
 	if updateResult.MatchedCount == 0 {
-		return errors.Errorf("failed to find a migration history record to mark as done with ID %d ", insertedID)
+		return errors.Errorf("failed to find a migration history record to mark as done with ID %s", insertedID)
 	}
 	return nil
 }
@@ -387,7 +387,7 @@ func (driver *Driver) UpdateHistoryAsFailed(ctx context.Context, _ *sql.Tx, migr
 		return errors.Wrapf(err, "failed to update a migration history as failed")
 	}
 	if updateResult.MatchedCount == 0 {
-		return errors.Errorf("failed to find a migration history record to mark as failed with ID %d ", insertedID)
+		return errors.Errorf("failed to find a migration history record to mark as failed with ID %s", insertedID)
 	}
 	return nil
 }

--- a/plugin/db/mongodb/migrate.go
+++ b/plugin/db/mongodb/migrate.go
@@ -3,7 +3,7 @@ package mongodb
 import (
 	"context"
 	"database/sql"
-	"strconv"
+	"fmt"
 	"time"
 
 	// embed will embeds the migration schema.
@@ -176,7 +176,7 @@ func convertMigrationHistory(history MigrationHistory) (db.MigrationHistory, err
 		return db.MigrationHistory{}, err
 	}
 	return db.MigrationHistory{
-		ID:                    strconv.FormatInt(history.ID, 10),
+		ID:                    fmt.Sprintf("%d", history.ID),
 		Creator:               history.CreatedBy,
 		CreatedTs:             int64(history.CreatedTs.T),
 		Updater:               history.UpdatedBy,
@@ -342,7 +342,7 @@ func (driver *Driver) InsertPendingHistory(ctx context.Context, _ *sql.Tx, seque
 			}
 			return "", errors.Wrapf(err, "failed to insert a pending migration history record")
 		}
-		return strconv.FormatInt(nextID, 10), nil
+		return fmt.Sprintf("%d", nextID), nil
 	}
 	return "", errors.Errorf("failed to insert a pending migration history record because of the duplidate id after %d retries", retryTimes)
 }

--- a/plugin/db/mysql/migrate.go
+++ b/plugin/db/mysql/migrate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strconv"
 
 	// embed will embeds the migration schema.
 	_ "embed"
@@ -166,7 +165,7 @@ func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int
 	if err != nil {
 		return "", util.FormatErrorWithQuery(err, insertHistoryQuery)
 	}
-	return strconv.FormatInt(insertedID, 10), nil
+	return fmt.Sprintf("%d", insertedID), nil
 }
 
 // UpdateHistoryAsDone will update the migration record as done.
@@ -180,11 +179,7 @@ func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDura
 		` + "`schema` = ?" + `
 		WHERE id = ?
 		`
-	id, err := strconv.ParseInt(insertedID, 10, 64)
-	if err != nil {
-		return err
-	}
-	_, err = tx.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, id)
+	_, err := tx.ExecContext(ctx, updateHistoryAsDoneQuery, db.Done, migrationDurationNs, updatedSchema, insertedID)
 	return err
 }
 
@@ -198,11 +193,7 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 			execution_duration_ns = ?
 		WHERE id = ?
 		`
-	id, err := strconv.ParseInt(insertedID, 10, 64)
-	if err != nil {
-		return err
-	}
-	_, err = tx.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, id)
+	_, err := tx.ExecContext(ctx, updateHistoryAsFailedQuery, db.Failed, migrationDurationNs, insertedID)
 	return err
 }
 

--- a/plugin/db/pg/migrate.go
+++ b/plugin/db/pg/migrate.go
@@ -164,7 +164,7 @@ func (*Driver) FindLargestSequence(ctx context.Context, tx *sql.Tx, namespace st
 }
 
 // InsertPendingHistory will insert the migration record with pending status and return the inserted ID.
-func (*Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (int64, error) {
+func (*Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (string, error) {
 	const insertHistoryQuery = `
 	INSERT INTO migration_history (
 		created_by,
@@ -189,7 +189,7 @@ func (*Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence in
 	VALUES ($1, EXTRACT(epoch from NOW()), $2, EXTRACT(epoch from NOW()), $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 0, $14, $15)
 	RETURNING id
 	`
-	var insertedID int64
+	var insertedID string
 	if err := tx.QueryRowContext(ctx, insertHistoryQuery,
 		m.Creator,
 		m.Creator,
@@ -207,13 +207,13 @@ func (*Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence in
 		m.IssueID,
 		m.Payload,
 	).Scan(&insertedID); err != nil {
-		return 0, err
+		return "", err
 	}
 	return insertedID, nil
 }
 
 // UpdateHistoryAsDone will update the migration record as done.
-func (*Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
+func (*Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, updatedSchema string, insertedID string) error {
 	const updateHistoryAsDoneQuery = `
 	UPDATE
 		migration_history
@@ -228,7 +228,7 @@ func (*Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDur
 }
 
 // UpdateHistoryAsFailed will update the migration record as failed.
-func (*Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, insertedID int64) error {
+func (*Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, insertedID string) error {
 	const updateHistoryAsFailedQuery = `
 	UPDATE
 		migration_history
@@ -242,7 +242,7 @@ func (*Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationD
 }
 
 // ExecuteMigration will execute the migration.
-func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
+func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (string, string, error) {
 	if driver.strictUseDb() {
 		return util.ExecuteMigration(ctx, driver, m, statement, driver.strictDatabase)
 	}

--- a/plugin/db/spanner/migrate.go
+++ b/plugin/db/spanner/migrate.go
@@ -68,7 +68,7 @@ func (d *Driver) SetupMigrationIfNeeded(ctx context.Context) error {
 }
 
 // ExecuteMigration executes a migration.
-func (*Driver) ExecuteMigration(_ context.Context, _ *db.MigrationInfo, _ string) (int64, string, error) {
+func (*Driver) ExecuteMigration(_ context.Context, _ *db.MigrationInfo, _ string) (string, string, error) {
 	panic("not implemented")
 }
 
@@ -151,9 +151,9 @@ func (d *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Migratio
 		}
 		var history db.MigrationHistory
 		var storedVersion string
-		var id, sequence int64
+		var sequence int64
 		if err := row.Columns(
-			&id,
+			&history.ID,
 			&history.Creator,
 			&history.CreatedTs,
 			&history.Updater,
@@ -175,7 +175,6 @@ func (d *Driver) FindMigrationHistoryList(ctx context.Context, find *db.Migratio
 		); err != nil {
 			return nil, err
 		}
-		history.ID = int(id)
 		history.Sequence = int(sequence)
 		useSemanticVersion, version, semanticVersionSuffix, err := util.FromStoredVersion(storedVersion)
 		if err != nil {

--- a/plugin/db/sqlite/migrate.go
+++ b/plugin/db/sqlite/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 
 	// embed will embeds the migration schema.
 	_ "embed"
@@ -136,7 +137,7 @@ func (Driver) FindLargestSequence(ctx context.Context, tx *sql.Tx, namespace str
 }
 
 // InsertPendingHistory will insert the migration record with pending status and return the inserted ID.
-func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (int64, error) {
+func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int, prevSchema string, m *db.MigrationInfo, storedVersion, statement string) (string, error) {
 	const insertHistoryQuery = `
 	INSERT INTO bytebase_migration_history (
 		created_by,
@@ -178,18 +179,18 @@ func (Driver) InsertPendingHistory(ctx context.Context, tx *sql.Tx, sequence int
 		m.Payload,
 	)
 	if err != nil {
-		return int64(0), util.FormatErrorWithQuery(err, insertHistoryQuery)
+		return "", util.FormatErrorWithQuery(err, insertHistoryQuery)
 	}
 
 	insertedID, err := res.LastInsertId()
 	if err != nil {
-		return int64(0), util.FormatErrorWithQuery(err, insertHistoryQuery)
+		return "", util.FormatErrorWithQuery(err, insertHistoryQuery)
 	}
-	return insertedID, nil
+	return strconv.FormatInt(insertedID, 10), nil
 }
 
 // UpdateHistoryAsDone will update the migration record as done.
-func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, updatedSchema string, insertedID int64) error {
+func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, updatedSchema string, insertedID string) error {
 	const updateHistoryAsDoneQuery = `
 	UPDATE
 		bytebase_migration_history
@@ -204,7 +205,7 @@ func (Driver) UpdateHistoryAsDone(ctx context.Context, tx *sql.Tx, migrationDura
 }
 
 // UpdateHistoryAsFailed will update the migration record as failed.
-func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, insertedID int64) error {
+func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDurationNs int64, insertedID string) error {
 	const updateHistoryAsFailedQuery = `
 	UPDATE
 		bytebase_migration_history
@@ -218,7 +219,7 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 }
 
 // ExecuteMigration will execute the migration.
-func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (int64, string, error) {
+func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (string, string, error) {
 	return util.ExecuteMigration(ctx, driver, m, statement, bytebaseDatabase)
 }
 

--- a/server/instance.go
+++ b/server/instance.go
@@ -278,10 +278,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Instance ID is not a number: %s", c.Param("instanceID"))).SetInternal(err)
 		}
 
-		historyID, err := strconv.Atoi(c.Param("historyID"))
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("History ID is not a number: %s", c.Param("historyID"))).SetInternal(err)
-		}
+		historyID := c.Param("historyID")
 
 		instance, err := s.store.GetInstanceByID(ctx, id)
 		if err != nil {
@@ -302,7 +299,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch migration history list").SetInternal(err)
 		}
 		if len(list) == 0 {
-			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Migration history ID %d not found for instance %q", historyID, instance.Name))
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Migration history ID %q not found for instance %q", historyID, instance.Name))
 		}
 		entry := list[0]
 

--- a/server/runner/rollbackrun/runner.go
+++ b/server/runner/rollbackrun/runner.go
@@ -141,10 +141,10 @@ func (r *Runner) generateRollbackSQLImpl(ctx context.Context, task *api.Task, pa
 	defer driver.Close(ctx)
 	list, err := driver.FindMigrationHistoryList(ctx, &db.MigrationHistoryFind{ID: &payload.MigrationID})
 	if err != nil {
-		return "", errors.WithMessagef(err, "failed to find migration history with ID %d", payload.MigrationID)
+		return "", errors.WithMessagef(err, "failed to find migration history with ID %s", payload.MigrationID)
 	}
 	if len(list) == 0 {
-		return "", errors.Errorf("migration history with ID %d not found", payload.MigrationID)
+		return "", errors.Errorf("migration history with ID %s not found", payload.MigrationID)
 	}
 	if len(list) > 1 {
 		return "", errors.Errorf("found %d migration history record, expecting one", len(list))

--- a/server/runner/taskrun/executor.go
+++ b/server/runner/taskrun/executor.go
@@ -127,13 +127,13 @@ func preMigration(ctx context.Context, store *store.Store, profile config.Profil
 	return mi, nil
 }
 
-func executeMigration(ctx context.Context, store *store.Store, dbFactory *dbfactory.DBFactory, stateCfg *state.State, task *api.Task, statement string, mi *db.MigrationInfo) (migrationID int64, schema string, err error) {
+func executeMigration(ctx context.Context, store *store.Store, dbFactory *dbfactory.DBFactory, stateCfg *state.State, task *api.Task, statement string, mi *db.MigrationInfo) (migrationID string, schema string, err error) {
 	statement = strings.TrimSpace(statement)
 	databaseName := task.Database.Name
 
 	driver, err := dbFactory.GetAdminDatabaseDriver(ctx, task.Instance, databaseName)
 	if err != nil {
-		return 0, "", err
+		return "", "", err
 	}
 	defer driver.Close(ctx)
 
@@ -148,29 +148,29 @@ func executeMigration(ctx context.Context, store *store.Store, dbFactory *dbfact
 
 	setup, err := driver.NeedsSetupMigration(ctx)
 	if err != nil {
-		return 0, "", errors.Wrapf(err, "failed to check migration setup for instance %q", task.Instance.Name)
+		return "", "", errors.Wrapf(err, "failed to check migration setup for instance %q", task.Instance.Name)
 	}
 	if setup {
-		return 0, "", common.Errorf(common.MigrationSchemaMissing, "missing migration schema for instance %q", task.Instance.Name)
+		return "", "", common.Errorf(common.MigrationSchemaMissing, "missing migration schema for instance %q", task.Instance.Name)
 	}
 
 	if task.Type == api.TaskDatabaseDataUpdate && task.Instance.Engine == db.MySQL {
 		updatedTask, err := setThreadIDAndStartBinlogCoordinate(ctx, driver, task, store)
 		if err != nil {
-			return 0, "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
+			return "", "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
 		}
 		task = updatedTask
 	}
 
 	migrationID, schema, err = driver.ExecuteMigration(ctx, mi, statement)
 	if err != nil {
-		return 0, "", err
+		return "", "", err
 	}
 
 	if task.Type == api.TaskDatabaseDataUpdate && task.Instance.Engine == db.MySQL {
 		updatedTask, err := setMigrationIDAndEndBinlogCoordinate(ctx, driver, task, store, migrationID)
 		if err != nil {
-			return 0, "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
+			return "", "", errors.Wrap(err, "failed to update the task payload for MySQL rollback SQL")
 		}
 		// The runner will periodically scan the map to generate rollback SQL asynchronously.
 		stateCfg.RollbackGenerateMap.Store(updatedTask.ID, updatedTask)
@@ -226,13 +226,13 @@ func setThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver, 
 	return updatedTask, nil
 }
 
-func setMigrationIDAndEndBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store, migrationID int64) (*api.Task, error) {
+func setMigrationIDAndEndBinlogCoordinate(ctx context.Context, driver db.Driver, task *api.Task, store *store.Store, migrationID string) (*api.Task, error) {
 	payload := &api.TaskDatabaseDataUpdatePayload{}
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
 		return nil, errors.Wrap(err, "invalid database data update payload")
 	}
 
-	payload.MigrationID = int(migrationID)
+	payload.MigrationID = migrationID
 	db, err := driver.GetDBConnection(ctx, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get the DB connection")
@@ -265,7 +265,7 @@ func setMigrationIDAndEndBinlogCoordinate(ctx context.Context, driver db.Driver,
 	return updatedTask, nil
 }
 
-func postMigration(ctx context.Context, stores *store.Store, activityManager *activity.Manager, profile config.Profile, task *api.Task, vcsPushEvent *vcsPlugin.PushEvent, mi *db.MigrationInfo, migrationID int64, schema string) (bool, *api.TaskRunResultPayload, error) {
+func postMigration(ctx context.Context, stores *store.Store, activityManager *activity.Manager, profile config.Profile, task *api.Task, vcsPushEvent *vcsPlugin.PushEvent, mi *db.MigrationInfo, migrationID string, schema string) (bool, *api.TaskRunResultPayload, error) {
 	databaseName := task.Database.Name
 	issue, err := findIssueByTask(ctx, stores, task)
 	if err != nil {

--- a/server/runner/taskrun/pitr_restore_executor.go
+++ b/server/runner/taskrun/pitr_restore_executor.go
@@ -490,16 +490,16 @@ func downloadBackupFileFromCloud(ctx context.Context, s3Client *bbs3.Client, bac
 // all migration history from source database because that might be expensive (e.g. we may use restore to
 // create many ephemeral databases from backup for testing purpose)
 // Returns migration history id and the version on success.
-func createBranchMigrationHistory(ctx context.Context, store *store.Store, dbFactory *dbfactory.DBFactory, profile config.Profile, sourceDatabase, targetDatabase *api.Database, backup *api.Backup, task *api.Task) (int64, string, error) {
+func createBranchMigrationHistory(ctx context.Context, store *store.Store, dbFactory *dbfactory.DBFactory, profile config.Profile, sourceDatabase, targetDatabase *api.Database, backup *api.Backup, task *api.Task) (string, string, error) {
 	targetDriver, err := dbFactory.GetAdminDatabaseDriver(ctx, targetDatabase.Instance, targetDatabase.Name)
 	if err != nil {
-		return -1, "", err
+		return "", "", err
 	}
 	defer targetDriver.Close(ctx)
 
 	issue, err := store.GetIssueByPipelineID(ctx, task.PipelineID)
 	if err != nil {
-		return -1, "", errors.Wrapf(err, "failed to fetch containing issue when creating the migration history: %v", task.Name)
+		return "", "", errors.Wrapf(err, "failed to fetch containing issue when creating the migration history: %v", task.Name)
 	}
 
 	// Add a branch migration history record.
@@ -526,7 +526,7 @@ func createBranchMigrationHistory(ctx context.Context, store *store.Store, dbFac
 	}
 	migrationID, _, err := targetDriver.ExecuteMigration(ctx, m, "")
 	if err != nil {
-		return -1, "", errors.Wrap(err, "failed to create migration history")
+		return "", "", errors.Wrap(err, "failed to create migration history")
 	}
 	return migrationID, m.Version, nil
 }

--- a/store/migration/dev/20230106000000##change_migration_history_id_type_to_string.sql
+++ b/store/migration/dev/20230106000000##change_migration_history_id_type_to_string.sql
@@ -1,0 +1,8 @@
+UPDATE task
+SET payload = payload || jsonb_build_object('migrationID', payload->>'migrationID'::TEXT)
+WHERE type = 'bb.task.database.data.update' AND payload ? 'migrationID';
+
+UPDATE task_run
+SET result = result || jsonb_build_object('migrationId', result->>'migrationId'::TEXT)
+WHERE result ? 'migrationId';
+

--- a/store/migration/dev/20230106000000##change_migration_history_id_type_to_string.sql
+++ b/store/migration/dev/20230106000000##change_migration_history_id_type_to_string.sql
@@ -1,7 +1,3 @@
-UPDATE task
-SET payload = payload || jsonb_build_object('migrationID', payload->>'migrationID'::TEXT)
-WHERE type = 'bb.task.database.data.update' AND payload ? 'migrationID';
-
 UPDATE task_run
 SET result = result || jsonb_build_object('migrationId', result->>'migrationId'::TEXT)
 WHERE result ? 'migrationId';

--- a/tests/instance.go
+++ b/tests/instance.go
@@ -44,7 +44,7 @@ func (ctl *controller) getInstanceByID(instanceID int) (*api.Instance, error) {
 	return instance, nil
 }
 
-func (ctl *controller) getInstanceMigrationHistory(find db.MigrationHistoryFind) ([]*api.MigrationHistory, error) {
+func (ctl *controller) getInstanceMigrationHistory(instanceID int, find db.MigrationHistoryFind) ([]*api.MigrationHistory, error) {
 	params := make(map[string]string)
 	if find.Database != nil {
 		params["database"] = *find.Database
@@ -55,7 +55,7 @@ func (ctl *controller) getInstanceMigrationHistory(find db.MigrationHistoryFind)
 	if find.Limit != nil {
 		params["limit"] = fmt.Sprintf("%d", *find.Limit)
 	}
-	body, err := ctl.get(fmt.Sprintf("/instance/%v/migration/history", *find.ID), params)
+	body, err := ctl.get(fmt.Sprintf("/instance/%d/migration/history", instanceID), params)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -155,7 +155,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	a.Equal(api.TaskDone, status)
 
 	// Get migration history.
-	histories, err := ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID})
+	histories, err := ctl.getInstanceMigrationHistory(instance.ID, db.MigrationHistoryFind{})
 	a.NoError(err)
 	wantHistories := []api.MigrationHistory{
 		{
@@ -224,7 +224,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	a.NoError(err)
 	a.Equal(bookDataSQLResult, result)
 	// Query clone migration history.
-	histories, err = ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID, Database: &cloneDatabaseName})
+	histories, err = ctl.getInstanceMigrationHistory(instance.ID, db.MigrationHistoryFind{Database: &cloneDatabaseName})
 	a.NoError(err)
 	wantCloneHistories := []api.MigrationHistory{
 		{
@@ -580,7 +580,7 @@ func TestVCS(t *testing.T) {
 			a.NoError(err)
 
 			// Get migration history.
-			histories, err := ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID})
+			histories, err := ctl.getInstanceMigrationHistory(instance.ID, db.MigrationHistoryFind{})
 			a.NoError(err)
 
 			var historiesDeref []api.MigrationHistory
@@ -1002,7 +1002,7 @@ ALTER TABLE ONLY public.users
 
 `
 
-			histories, err := ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID})
+			histories, err := ctl.getInstanceMigrationHistory(instance.ID, db.MigrationHistoryFind{})
 			a.NoError(err)
 			wantHistories := []api.MigrationHistory{
 				{

--- a/tests/sync_schema_test.go
+++ b/tests/sync_schema_test.go
@@ -137,8 +137,7 @@ DROP SCHEMA "schema_a";
 	a.NoError(err)
 	a.Equal(api.TaskDone, status)
 
-	history, err := ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{
-		ID:       &instance.ID,
+	history, err := ctl.getInstanceMigrationHistory(instance.ID, db.MigrationHistoryFind{
 		Database: &database.Name,
 	})
 	a.NoError(err)

--- a/tests/tenant_test.go
+++ b/tests/tenant_test.go
@@ -185,7 +185,7 @@ func TestTenant(t *testing.T) {
 	hm1 := map[string]bool{}
 	hm2 := map[string]bool{}
 	for _, instance := range instances {
-		histories, err := ctl.getInstanceMigrationHistory(db.MigrationHistoryFind{ID: &instance.ID, Database: &databaseName})
+		histories, err := ctl.getInstanceMigrationHistory(instance.ID, db.MigrationHistoryFind{Database: &databaseName})
 		a.NoError(err)
 		a.Equal(2, len(histories))
 		a.NotEqual(histories[0].Version, "")
@@ -482,8 +482,8 @@ func TestTenantVCS(t *testing.T) {
 			hm2 := map[string]bool{}
 			for _, instance := range instances {
 				histories, err := ctl.getInstanceMigrationHistory(
+					instance.ID,
 					db.MigrationHistoryFind{
-						ID:       &instance.ID,
 						Database: &databaseName,
 					},
 				)
@@ -936,8 +936,8 @@ func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
 				tenant := fmt.Sprintf("tenant%d", i)
 				databaseName := baseDatabaseName + "_" + tenant
 				histories, err := ctl.getInstanceMigrationHistory(
+					instance.ID,
 					db.MigrationHistoryFind{
-						ID:       &instance.ID,
 						Database: &databaseName,
 					},
 				)
@@ -951,8 +951,8 @@ func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
 				tenant := fmt.Sprintf("tenant%d", i)
 				databaseName := baseDatabaseName + "_" + tenant
 				histories, err := ctl.getInstanceMigrationHistory(
+					instance.ID,
 					db.MigrationHistoryFind{
-						ID:       &instance.ID,
 						Database: &databaseName,
 					},
 				)
@@ -1244,8 +1244,8 @@ func TestTenantVCSDatabaseNameTemplate_Empty(t *testing.T) {
 				tenant := fmt.Sprintf("tenant%d", i)
 				databaseName := baseDatabaseName + "_" + tenant
 				histories, err := ctl.getInstanceMigrationHistory(
+					instance.ID,
 					db.MigrationHistoryFind{
-						ID:       &instance.ID,
 						Database: &databaseName,
 					},
 				)
@@ -1552,8 +1552,8 @@ statement: |
 
 			// Query migration history, only the database of the first tenant should be touched
 			histories, err := ctl.getInstanceMigrationHistory(
+				testInstances[0].ID,
 				db.MigrationHistoryFind{
-					ID:       &testInstances[0].ID,
 					Database: &databases[0].Name,
 				},
 			)
@@ -1562,8 +1562,8 @@ statement: |
 			require.Equal(t, histories[0].Version, "ver2")
 
 			histories, err = ctl.getInstanceMigrationHistory(
+				testInstances[1].ID,
 				db.MigrationHistoryFind{
-					ID:       &testInstances[1].ID,
 					Database: &databases[1].Name,
 				},
 			)


### PR DESCRIPTION
Change MigrationHistory.ID type to string because the ID of the migration_history table of Spanner is of string type.