### PR TITLE
fix: fix failure in readonly mode

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -148,6 +148,7 @@ type config struct {
 	dataDir                 string
 	vcsProviderCreator      fake.VCSProviderCreator
 	feishuProverdierCreator fake.FeishuProviderCreator
+	readOnly                bool
 }
 
 var (
@@ -236,7 +237,7 @@ func (ctl *controller) StartServer(ctx context.Context, config *config) error {
 		return err
 	}
 	serverPort := getTestPortForEmbeddedPg()
-	profile := getTestProfile(config.dataDir, resourceDirOverride, serverPort, ctl.feishuProvider.APIURL(ctl.feishuURL))
+	profile := getTestProfile(config.dataDir, resourceDirOverride, serverPort, config.readOnly, ctl.feishuProvider.APIURL(ctl.feishuURL))
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {
 		return err
@@ -249,13 +250,14 @@ func (ctl *controller) StartServer(ctx context.Context, config *config) error {
 
 // GetTestProfile will return a profile for testing.
 // We require port as an argument of GetTestProfile so that test can run in parallel in different ports.
-func getTestProfile(dataDir, resourceDirOverride string, port int, feishuAPIURL string) componentConfig.Profile {
+func getTestProfile(dataDir, resourceDirOverride string, port int, readOnly bool, feishuAPIURL string) componentConfig.Profile {
 	return componentConfig.Profile{
 		Mode:                 testReleaseMode,
 		ExternalURL:          fmt.Sprintf("http://localhost:%d", port),
 		GrpcPort:             port + 1,
 		DatastorePort:        port + 2,
 		PgUser:               "bbtest",
+		Readonly:             readOnly,
 		DataDir:              dataDir,
 		ResourceDirOverride:  resourceDirOverride,
 		AppRunnerInterval:    1 * time.Second,


### PR DESCRIPTION
Bug is introduced in https://github.com/bytebase/bytebase/pull/4186 where we added getLatestVersion to fetch the schema version. However, there is a hidden order dependency, and calling getLatestVersion after d.GetDBConnection would invalidate the connection, thus causing `sql: connection is closed` error in readonly mode 