### PR TITLE
feat(spanner): implement query

### DIFF
--- a/plugin/db/spanner/spanner.go
+++ b/plugin/db/spanner/spanner.go
@@ -218,6 +218,7 @@ func (d *Driver) Query(ctx context.Context, statement string, queryContext *db.Q
 	}
 	stmt := getStatementWithResultLimit(stmts[0], queryContext.Limit)
 	iter := d.client.Single().Query(ctx, spanner.NewStatement(stmt))
+	defer iter.Stop()
 
 	row, err := iter.Next()
 	if err == iterator.Done {

--- a/plugin/db/spanner/spanner.go
+++ b/plugin/db/spanner/spanner.go
@@ -7,12 +7,14 @@ import (
 	_ "embed"
 	"fmt"
 	"regexp"
+	"strings"
 
 	spanner "cloud.google.com/go/spanner"
 	spannerdb "cloud.google.com/go/spanner/admin/database/apiv1"
 	adminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"go.uber.org/zap"
 
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/common/log"
@@ -206,8 +208,248 @@ func (d *Driver) Execute(ctx context.Context, statement string, createDatabase b
 }
 
 // Query queries a SQL statement.
-func (*Driver) Query(context.Context, string, *db.QueryContext) ([]interface{}, error) {
-	panic("not implemented")
+func (d *Driver) Query(ctx context.Context, statement string, queryContext *db.QueryContext) ([]interface{}, error) {
+	stmts, err := sanitizeSQL(statement)
+	if err != nil {
+		return nil, err
+	}
+	if len(stmts) != 1 {
+		return nil, errors.Errorf("expect to get 1 statement, get %d", len(stmts))
+	}
+	stmt := getStatementWithResultLimit(stmts[0], queryContext.Limit)
+	iter := d.client.Single().Query(ctx, spanner.NewStatement(stmt))
+
+	row, err := iter.Next()
+	if err == iterator.Done {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	data := []interface{}{}
+	columnNames := getColumnNames(iter)
+	columnTypeNames, err := getColumnTypeNames(iter)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		rowData, err := readRow(row)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, rowData)
+		row, err = iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return []interface{}{columnNames, columnTypeNames, data}, nil
+}
+
+func getColumnNames(iter *spanner.RowIterator) []string {
+	var names []string
+	for _, field := range iter.Metadata.RowType.Fields {
+		names = append(names, field.Name)
+	}
+	return names
+}
+
+func getColumnTypeNames(iter *spanner.RowIterator) ([]string, error) {
+	var names []string
+	for _, field := range iter.Metadata.RowType.Fields {
+		typeName, err := getColumnTypeName(field.Type)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, typeName)
+	}
+	return names, nil
+}
+
+func getColumnTypeName(columnType *sppb.Type) (string, error) {
+	if columnType.Code == sppb.TypeCode_STRUCT {
+		return "", errors.New("spanner STRUCT type is not supported")
+	}
+	if columnType.Code == sppb.TypeCode_ARRAY {
+		if columnType.ArrayElementType.Code == sppb.TypeCode_STRUCT {
+			return "", errors.New("spanner STRUCT type is not supported")
+		}
+		return fmt.Sprintf("[]%s", columnType.ArrayElementType.Code.String()), nil
+	}
+	return columnType.Code.String(), nil
+}
+
+func readRow(row *spanner.Row) ([]interface{}, error) {
+	dest := make([]interface{}, row.Size())
+	for i := 0; i < row.Size(); i++ {
+		var col spanner.GenericColumnValue
+		if err := row.Column(i, &col); err != nil {
+			return nil, err
+		}
+		switch col.Type.Code {
+		case sppb.TypeCode_INT64:
+			var v spanner.NullInt64
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			if v.Valid {
+				dest[i] = v.Int64
+			} else {
+				dest[i] = nil
+			}
+		case sppb.TypeCode_FLOAT64:
+			var v spanner.NullFloat64
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			if v.Valid {
+				dest[i] = v.Float64
+			} else {
+				dest[i] = nil
+			}
+		case sppb.TypeCode_NUMERIC:
+			var v spanner.NullNumeric
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			if v.Valid {
+				dest[i] = v.Numeric
+			} else {
+				dest[i] = nil
+			}
+		case sppb.TypeCode_STRING:
+			var v spanner.NullString
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			if v.Valid {
+				dest[i] = v.StringVal
+			} else {
+				dest[i] = nil
+			}
+		case sppb.TypeCode_JSON:
+			var v spanner.NullJSON
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			// We always assign `v` to dest[i] here because there is no native type
+			// for JSON in the Go sql package. That means that instead of returning
+			// nil we should return a NullJSON with valid=false.
+			dest[i] = v
+		case sppb.TypeCode_BYTES:
+			// The column value is a base64 encoded string.
+			var v []byte
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			dest[i] = v
+		case sppb.TypeCode_BOOL:
+			var v spanner.NullBool
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			if v.Valid {
+				dest[i] = v.Bool
+			} else {
+				dest[i] = nil
+			}
+		case sppb.TypeCode_DATE:
+			var v spanner.NullDate
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			if v.Valid {
+				dest[i] = v.Date
+			} else {
+				dest[i] = nil
+			}
+		case sppb.TypeCode_TIMESTAMP:
+			var v spanner.NullTime
+			if err := col.Decode(&v); err != nil {
+				return nil, err
+			}
+			if v.Valid {
+				dest[i] = v.Time
+			} else {
+				dest[i] = nil
+			}
+		case sppb.TypeCode_ARRAY:
+			switch col.Type.ArrayElementType.Code {
+			case sppb.TypeCode_INT64:
+				var v []spanner.NullInt64
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_FLOAT64:
+				var v []spanner.NullFloat64
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_NUMERIC:
+				var v []spanner.NullNumeric
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_STRING:
+				var v []spanner.NullString
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_JSON:
+				var v []spanner.NullJSON
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_BYTES:
+				var v [][]byte
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_BOOL:
+				var v []spanner.NullBool
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_DATE:
+				var v []spanner.NullDate
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			case sppb.TypeCode_TIMESTAMP:
+				var v []spanner.NullTime
+				if err := col.Decode(&v); err != nil {
+					return nil, err
+				}
+				dest[i] = v
+			}
+		}
+	}
+	return dest, nil
+}
+
+func getStatementWithResultLimit(stmt string, limit int) string {
+	stmt = strings.TrimRight(stmt, " \n\t;")
+	if !strings.HasPrefix(stmt, "EXPLAIN") {
+		limitPart := ""
+		if limit > 0 {
+			limitPart = fmt.Sprintf(" LIMIT %d", limit)
+		}
+		return fmt.Sprintf("WITH result AS (%s) SELECT * FROM result%s;", stmt, limitPart)
+	}
+	return stmt
 }
 
 func getDSN(host, database string) string {

--- a/plugin/db/spanner/spanner_test.go
+++ b/plugin/db/spanner/spanner_test.go
@@ -3,6 +3,7 @@ package spanner
 import (
 	"testing"
 
+	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,5 +34,46 @@ func TestGetDatabaseFromDSN(t *testing.T) {
 		} else {
 			a.Error(err)
 		}
+	}
+}
+
+func TestGetColumnTypeName(t *testing.T) {
+	tests := []struct {
+		spannerType spannerpb.Type
+		want        string
+	}{
+		{
+			spannerType: spannerpb.Type{
+				Code: spannerpb.TypeCode_JSON,
+			},
+			want: "JSON",
+		},
+		{
+			spannerType: spannerpb.Type{
+				Code: spannerpb.TypeCode_DATE,
+			},
+			want: "DATE",
+		},
+		{
+			spannerType: spannerpb.Type{
+				Code: spannerpb.TypeCode_TIMESTAMP,
+			},
+			want: "TIMESTAMP",
+		},
+		{
+			spannerType: spannerpb.Type{
+				Code: spannerpb.TypeCode_ARRAY,
+				ArrayElementType: &spannerpb.Type{
+					Code: spannerpb.TypeCode_BYTES,
+				},
+			},
+			want: "[]BYTES",
+		},
+	}
+	a := require.New(t)
+	for i := range tests {
+		got, err := getColumnTypeName(&tests[i].spannerType)
+		a.NoError(err)
+		a.Equal(tests[i].want, got)
 	}
 }

--- a/plugin/db/spanner/statement_parser.go
+++ b/plugin/db/spanner/statement_parser.go
@@ -9,6 +9,7 @@ import (
 )
 
 var ddlStatements = map[string]bool{"CREATE": true, "DROP": true, "ALTER": true}
+var selectStatements = map[string]bool{"WITH": true, "SELECT": true}
 
 // RemoveCommentsAndTrim removes any comments in the query string and trims any
 // spaces at the beginning and end of the query. This makes checking what type
@@ -196,7 +197,16 @@ func sanitizeSQL(sql string) ([]string, error) {
 // isDDL returns true if the given sql string is a DDL statement.
 func isDDL(query string) bool {
 	for ddl := range ddlStatements {
-		if strings.EqualFold(query[:len(ddl)], ddl) {
+		if len(query) >= len(ddl) && strings.EqualFold(query[:len(ddl)], ddl) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSelect(query string) bool {
+	for keyword := range selectStatements {
+		if len(query) >= len(keyword) && strings.EqualFold(query[:len(keyword)], keyword) {
 			return true
 		}
 	}


### PR DESCRIPTION
Implement query for spanner driver.

The query func expects to take a single SQL statement and returns the result.

We don't support spanner [STURCT](https://cloud.google.com/spanner/docs/reference/standard-sql/data-types#struct_type) type for now, which should be fine as it's also not supported in the official spanner database/sql driver.
