### PR TITLE
feat(sql-editor): some minor improvements and fixes

### DIFF
--- a/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
@@ -15,7 +15,11 @@
           </Pane>
         </Splitpanes>
       </n-tab-pane>
-      <n-tab-pane name="instances" :tab="$t('common.instances')">
+      <n-tab-pane
+        v-if="hasInstanceView"
+        name="instances"
+        :tab="$t('common.instances')"
+      >
         <Splitpanes
           horizontal
           class="default-theme"
@@ -40,17 +44,27 @@
 import { computed, ref, watchEffect } from "vue";
 import { isUndefined } from "lodash-es";
 
-import { useConnectionTreeStore } from "@/store";
+import { useConnectionTreeStore, useCurrentUser } from "@/store";
 import DatabaseTree from "./DatabaseTree.vue";
 import QueryHistoryContainer from "./QueryHistoryContainer.vue";
 import TableSchema from "./TableSchema.vue";
 import { Splitpanes, Pane } from "splitpanes";
 import { ConnectionTreeMode } from "@/types";
+import { hasWorkspacePermission } from "@/utils";
 
 const FULL_HEIGHT = 100;
 const DATABASE_PANE_SIZE = 60;
 
+const currentUser = useCurrentUser();
+
 const tab = ref<"projects" | "instances" | "history">("projects");
+
+const hasInstanceView = computed((): boolean => {
+  return hasWorkspacePermission(
+    "bb.permission.workspace.manage-database",
+    currentUser.value.role
+  );
+});
 
 const connectionTreeStore = useConnectionTreeStore();
 

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -14,7 +14,7 @@
         </template>
       </n-input>
     </div>
-    <div class="databases-tree--tree flex-1 overflow-y-auto">
+    <div class="databases-tree--tree flex-1 overflow-y-auto select-none">
       <NTree
         block-line
         :data="treeData"

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -2,6 +2,7 @@
   <div
     v-if="connectionTreeStore.tree.state === ConnectionTreeState.LOADED"
     class="databases-tree p-2 space-y-2 h-full flex flex-col"
+    :class="connectionTreeStore.tree.mode"
   >
     <div class="databases-tree--input">
       <n-input
@@ -399,8 +400,14 @@ watch(
 </script>
 
 <style postcss>
+.databases-tree .n-tree-node-content {
+  @apply !pl-0;
+}
 .databases-tree .n-tree-node-content__prefix {
   @apply shrink-0 !mr-1;
+}
+.databases-tree.project .n-tree-node-content__prefix {
+  @apply hidden;
 }
 .databases-tree .n-tree-node-content__text {
   @apply truncate mr-1;

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -190,6 +190,14 @@ const setConnection = (
       }
       tabStore.selectOrAddSimilarTab(target);
       tabStore.updateCurrentTab(target);
+
+      if (connectionTreeStore.selectedTableAtom) {
+        const tableAtom = connectionTreeStore.selectedTableAtom;
+        if (tableAtom.parentId !== target.connection.databaseId) {
+          // Switching database should hide the selected table schema panel
+          connectionTreeStore.selectedTableAtom = undefined;
+        }
+      }
     };
 
     // If selected item is instance node

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -348,6 +348,7 @@ const nodeProps = ({ option }: { option: TreeOption }) => {
         dropdownPosition.value.y = e.clientY;
       });
     },
+    "data-node-type": atom.type,
   };
 };
 
@@ -414,7 +415,9 @@ watch(
 .databases-tree .n-tree-node-content__prefix {
   @apply shrink-0 !mr-1;
 }
-.databases-tree.project .n-tree-node-content__prefix {
+.databases-tree.project
+  .n-tree-node[data-node-type="project"]
+  .n-tree-node-content__prefix {
   @apply hidden;
 }
 .databases-tree .n-tree-node-content__text {

--- a/frontend/src/views/sql-editor/AsidePanel/TreeNode/InstancePrefix.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/TreeNode/InstancePrefix.vue
@@ -1,0 +1,30 @@
+<template>
+  <InstanceEngineIcon :instance="instance" />
+  <span class="text-sm -mr-0.5" :class="[!disabled && 'text-gray-500']">
+    (
+  </span>
+  <ProtectedEnvironmentIcon
+    :environment="instance.environment"
+    class="w-4 h-4 text-inherit"
+  />
+  <span class="text-sm" :class="[!disabled && 'text-gray-500']">
+    {{ instance.environment.name }}
+  </span>
+  <span class="text-sm -ml-0.5" :class="[!disabled && 'text-gray-500']">
+    )
+  </span>
+</template>
+
+<script setup lang="ts">
+import type { Instance } from "@/types";
+
+withDefaults(
+  defineProps<{
+    instance: Instance;
+    disabled?: boolean;
+  }>(),
+  {
+    disabled: false,
+  }
+);
+</script>

--- a/frontend/src/views/sql-editor/AsidePanel/TreeNode/Prefix.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/TreeNode/Prefix.vue
@@ -4,53 +4,16 @@
   </template>
   <template v-else-if="atom.type === 'instance'">
     <span class="flex items-center gap-x-1">
-      <span
-        class="text-sm -mr-0.5"
-        :class="[!atom.disabled && 'text-gray-500']"
-      >
-        (
-      </span>
-      <InstanceEngineIcon :instance="instance" />
-      <ProtectedEnvironmentIcon
-        :environment="instance.environment"
-        class="w-4 h-4 text-inherit"
-      />
-      <span class="text-sm" :class="[!atom.disabled && 'text-gray-500']">
-        {{ instance.environment.name }}
-      </span>
-      <span
-        class="text-sm -ml-0.5"
-        :class="[!atom.disabled && 'text-gray-500']"
-      >
-        )
-      </span>
+      <InstancePrefix :instance="instance" :disabled="atom.disabled" />
     </span>
   </template>
   <template v-else-if="atom.type === 'database'">
     <span class="flex items-center gap-x-1">
-      <template
+      <InstancePrefix
         v-if="connectionTreeStore.tree.mode === ConnectionTreeMode.PROJECT"
-      >
-        <span
-          class="text-sm -mr-0.5"
-          :class="[!atom.disabled && 'text-gray-500']"
-        >
-          (
-        </span>
-        <ProtectedEnvironmentIcon
-          :environment="database.instance.environment"
-          class="w-4 h-4 text-inherit"
-        />
-        <span class="text-sm" :class="[!atom.disabled && 'text-gray-500']">
-          {{ database.instance.environment.name }}
-        </span>
-        <span
-          class="text-sm -ml-0.5"
-          :class="[!atom.disabled && 'text-gray-500']"
-        >
-          )
-        </span>
-      </template>
+        :instance="database.instance"
+        :disabled="atom.disabled"
+      />
 
       <heroicons-outline:database class="w-4 h-4" />
     </span>
@@ -63,14 +26,13 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 
-import InstanceEngineIcon from "@/components/InstanceEngineIcon.vue";
-import ProtectedEnvironmentIcon from "@/components/Environment/ProtectedEnvironmentIcon.vue";
 import { ConnectionAtom, unknown, ConnectionTreeMode } from "@/types";
 import {
   useConnectionTreeStore,
   useDatabaseStore,
   useInstanceStore,
 } from "@/store";
+import InstancePrefix from "./InstancePrefix.vue";
 
 const props = defineProps<{
   atom: ConnectionAtom;

--- a/frontend/src/views/sql-editor/AsidePanel/TreeNode/Prefix.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/TreeNode/Prefix.vue
@@ -4,6 +4,12 @@
   </template>
   <template v-else-if="atom.type === 'instance'">
     <span class="flex items-center gap-x-1">
+      <span
+        class="text-sm -mr-0.5"
+        :class="[!atom.disabled && 'text-gray-500']"
+      >
+        (
+      </span>
       <InstanceEngineIcon :instance="instance" />
       <ProtectedEnvironmentIcon
         :environment="instance.environment"
@@ -12,6 +18,12 @@
       <span class="text-sm" :class="[!atom.disabled && 'text-gray-500']">
         {{ instance.environment.name }}
       </span>
+      <span
+        class="text-sm -ml-0.5"
+        :class="[!atom.disabled && 'text-gray-500']"
+      >
+        )
+      </span>
     </span>
   </template>
   <template v-else-if="atom.type === 'database'">
@@ -19,12 +31,24 @@
       <template
         v-if="connectionTreeStore.tree.mode === ConnectionTreeMode.PROJECT"
       >
+        <span
+          class="text-sm -mr-0.5"
+          :class="[!atom.disabled && 'text-gray-500']"
+        >
+          (
+        </span>
         <ProtectedEnvironmentIcon
           :environment="database.instance.environment"
           class="w-4 h-4 text-inherit"
         />
         <span class="text-sm" :class="[!atom.disabled && 'text-gray-500']">
           {{ database.instance.environment.name }}
+        </span>
+        <span
+          class="text-sm -ml-0.5"
+          :class="[!atom.disabled && 'text-gray-500']"
+        >
+          )
         </span>
       </template>
 

--- a/frontend/src/views/sql-editor/AsidePanel/TreeNode/Suffix.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/TreeNode/Suffix.vue
@@ -1,5 +1,5 @@
 <template>
-  <heroicons-outline:lightning-bolt v-if="connected" class="w-4 h-4" />
+  <heroicons-outline:link v-if="connected" class="w-4 h-4" />
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/views/sql-editor/TabList/TabItem/AdminLabel.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/AdminLabel.vue
@@ -1,5 +1,5 @@
 <template>
-  <label class="flex items-center text-sm h-6 ml-0.5">
+  <label class="flex items-center text-sm h-6 ml-0.5 whitespace-nowrap">
     <template v-if="instance.id !== UNKNOWN_ID">
       <span>{{ instance.environment.name }}</span>
       <ProtectedEnvironmentIcon

--- a/frontend/src/views/sql-editor/TabList/TabList.vue
+++ b/frontend/src/views/sql-editor/TabList/TabList.vue
@@ -184,21 +184,4 @@ onMounted(() => recalculateScrollState());
 .tab-list {
   @apply flex flex-nowrap overflow-x-auto w-full hide-scrollbar;
 }
-
-.tab-list::before {
-  @apply absolute top-0 left-0 w-4 h-full z-50 pointer-events-none transition-shadow;
-  content: "";
-  box-shadow: none;
-}
-.tab-list::after {
-  @apply absolute top-0 right-0 w-4 h-full z-50 pointer-events-none transition-shadow;
-  content: "";
-  box-shadow: none;
-}
-.tab-list.more-left::before {
-  box-shadow: inset 1rem 0 0.5rem -0.5rem rgb(0 0 0 / 25%);
-}
-.tab-list.more-right::after {
-  box-shadow: inset -1rem 0 0.5rem -0.5rem rgb(0 0 0 / 25%);
-}
 </style>


### PR DESCRIPTION
### Changes

- Show parentheses and instance icons for project-database view nodes. (Close BYT-2275, BYT-2286)
- Make instance-database view only available for high-privileged users. (Close BYT-2281)
- Tuning spacings for tree nodes without prefix icons. (Close BYT-2289)
- Make the tree not text-selectable. (Close BYT-2280)
- Fix Admin mode tabs' text wrapping issue. (Close BYT-2279)
- Hide table schema panel when switching databases/instances. (Close BYT-2291)
- Hide the overflow indicator gradient. (Close BYT-2282)

FYI @Candybase @tianzhou 

### Screenshots

<img width="342" alt="image" src="https://user-images.githubusercontent.com/2749742/211456799-a5389126-bfaf-4241-a89b-92437d7573c5.png">

<img width="332" alt="image" src="https://user-images.githubusercontent.com/2749742/211474158-b7d91e8f-001e-48f5-bdac-5c761e1f1453.png">


