### PR TITLE
feat(schema-diagram): render changed columns in yellow

### DIFF
--- a/frontend/src/components/SchemaDiagram/ER/TableNode.vue
+++ b/frontend/src/components/SchemaDiagram/ER/TableNode.vue
@@ -41,13 +41,9 @@
         :key="i"
         :bb-column-name="column.name"
         :bb-status="columnStatus(column)"
-        :class="[
-          editable && 'cursor-pointer',
-          isColumnDropped(column) && 'text-red-700 bg-red-50 line-through',
-          isColumnCreated(column) && 'text-green-700 bg-green-50',
-        ]"
+        :class="columnClasses(column)"
       >
-        <td class="w-5 py-1.5">
+        <td class="w-5 py-1.5 relative">
           <heroicons-outline:key
             v-if="isPrimaryKey(table, column)"
             class="w-3 h-3 mx-auto text-amber-500"
@@ -90,6 +86,7 @@ import {
   TableMetadata,
 } from "@/types/proto/store/database";
 import { useSchemaDiagramContext, isPrimaryKey, isIndex } from "../common";
+import { VueClass } from "@/utils";
 
 const props = withDefaults(
   defineProps<{
@@ -151,12 +148,22 @@ const isTableChanged = computed(() => {
   return tableStatus(props.table) === "changed";
 });
 
-const isColumnDropped = (column: ColumnMetadata) => {
-  return columnStatus(column) === "dropped";
-};
+const columnClasses = (column: ColumnMetadata): VueClass => {
+  const classes: string[] = [];
+  if (editable.value) {
+    classes.push("cursor-pointer");
+  }
 
-const isColumnCreated = (column: ColumnMetadata) => {
-  return columnStatus(column) === "created";
+  const status = columnStatus(column);
+  if (status === "changed") {
+    classes.push("text-yellow-700", "bg-yellow-50");
+  } else if (status === "created") {
+    classes.push("text-green-700", "bg-green-50");
+  } else if (status === "dropped") {
+    classes.push("text-red-700", "bg-red-50", "line-through");
+  }
+
+  return classes;
 };
 
 const handleClickColumn = (column: ColumnMetadata, target: "name" | "type") => {

--- a/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
+++ b/frontend/src/components/SchemaEditor/utils/useMetadataForDiagram.ts
@@ -13,6 +13,7 @@ import {
 } from "@/types/proto/store/database";
 import { isTableChanged } from "./table";
 import { isSchemaChanged } from "./schema";
+import { isColumnChanged } from "./column";
 
 type MetadataWithEditStatus<T, E> = T & {
   $$status?: EditStatus;
@@ -40,6 +41,23 @@ const statusOfTable = (
     return status;
   }
   if (isTableChanged(database.id, schema.id, table.id)) {
+    return "changed";
+  }
+
+  return "normal";
+};
+
+const statusOfColumn = (
+  database: Database,
+  schema: Schema,
+  table: Table,
+  column: Column
+): EditStatus => {
+  const { status } = column;
+  if (status === "created" || status === "dropped") {
+    return status;
+  }
+  if (isColumnChanged(database.id, schema.id, table.id, column.id)) {
     return "changed";
   }
 
@@ -89,7 +107,7 @@ export const useMetadataForDiagram = (
           const columnMeta = ColumnMetadata.fromPartial({});
           Object.defineProperty(columnMeta, "$$status", {
             enumerable: false,
-            value: column.status,
+            value: statusOfColumn(database, schema, table, column),
           });
           Object.defineProperty(columnMeta, "$$edit", {
             enumerable: false,


### PR DESCRIPTION
Benefiting from #4234, we can now also highlight changed columns in Schema Diagram.

Close BYT-2260

We've tried but still can't find a perfect position to place a "DOT" indicator (like VSCode tabs). Maybe consider more about this and bring it next time.

FYI @Candybase @tianzhou 

### Screenshots
<img width="275" alt="image" src="https://user-images.githubusercontent.com/2749742/211491451-5c5ce233-436a-4dda-a893-a1715ffc395d.png">
