### PR TITLE
chore(frontend): prevent double scrollbars on small screens

### DIFF
--- a/frontend/src/components/AccessControl/AddRuleForm.vue
+++ b/frontend/src/components/AccessControl/AddRuleForm.vue
@@ -10,7 +10,8 @@
 
     <DatabaseTable
       mode="ALL_TINY"
-      class="max-h-[55vh] overflow-y-auto"
+      class="overflow-y-auto"
+      style="max-height: calc(100vh - 320px)"
       table-class="border"
       :custom-click="true"
       :database-list="databaseList"

--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -8,7 +8,8 @@
             <NTabs v-model:value="state.alterType">
               <NTabPane :tab="$t('alter-schema.alter-db-group')" name="TENANT">
                 <ProjectTenantView
-                  class="max-h-[55vh] overflow-y-auto"
+                  class="overflow-y-auto"
+                  style="max-height: calc(100vh - 320px)"
                   :state="state"
                   :database-list="databaseList"
                   :environment-list="environmentList"
@@ -22,7 +23,8 @@
               >
                 <DatabaseTable
                   mode="PROJECT_SHORT"
-                  class="max-h-[55vh] overflow-y-auto"
+                  class="overflow-y-auto"
+                  style="max-height: calc(100vh - 360px)"
                   table-class="border"
                   :custom-click="true"
                   :database-list="databaseList"

--- a/frontend/src/components/AlterSchemaPrepForm/ProjectStandardView.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/ProjectStandardView.vue
@@ -10,7 +10,8 @@
     <slot name="header"></slot>
 
     <NCollapse
-      class="max-h-[55vh] overflow-y-auto"
+      class="overflow-y-auto"
+      style="max-height: calc(100vh - 380px)"
       arrow-placement="left"
       :default-expanded-names="
         databaseListGroupByEnvironment.map((group) => group.environment.id)

--- a/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
@@ -3,7 +3,8 @@
     <slot name="transfer-source-selector" />
 
     <DatabaseTable
-      class="max-h-[55vh] overflow-y-auto"
+      class="overflow-y-auto"
+      style="max-height: calc(100vh - 400px)"
       table-class="border"
       :mode="transferSource === 'DEFAULT' ? 'PROJECT_SHORT' : 'ALL_SHORT'"
       :custom-click="true"

--- a/frontend/src/views/SettingWorkspaceAccessControl.vue
+++ b/frontend/src/views/SettingWorkspaceAccessControl.vue
@@ -15,7 +15,7 @@
 
       <div>
         <button
-          class="btn-primary"
+          class="btn-primary whitespace-nowrap"
           :disabled="!allowAdmin"
           @click="state.showAddRuleModal = true"
         >


### PR DESCRIPTION
We did some kind of style tunings on small screens to prevent double scrollbars for the popup database list windows.

Close BYT-2229

FYI @Candybase 