### PR TITLE
feat(db): support PostgreSQL SSL connection

### DIFF
--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -470,7 +470,8 @@ const showSSL = computed((): boolean => {
   return (
     state.instance.engine === "CLICKHOUSE" ||
     state.instance.engine === "MYSQL" ||
-    state.instance.engine === "TIDB"
+    state.instance.engine === "TIDB" ||
+    state.instance.engine === "POSTGRES"
   );
 });
 

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -626,7 +626,8 @@ const showSSL = computed((): boolean => {
   return (
     state.instance.engine === "CLICKHOUSE" ||
     state.instance.engine === "MYSQL" ||
-    state.instance.engine === "TIDB"
+    state.instance.engine === "TIDB" ||
+    state.instance.engine === "POSTGRES"
   );
 });
 

--- a/plugin/db/pg/pg.go
+++ b/plugin/db/pg/pg.go
@@ -184,6 +184,9 @@ func guessDSN(username, password, hostname, port, database, sslCA, sslCert, sslK
 		guessDSN := fmt.Sprintf("%s dbname=%s", dsn, guessDatabase)
 		if err := func() error {
 			connectionString, err := registerConnectionConfig(guessDSN, tlsConfig)
+			if err != nil {
+				return err
+			}
 			defer unregisterConnectionConfig(connectionString)
 			db, err := sql.Open(driverName, connectionString)
 			if err != nil {


### PR DESCRIPTION
close BYT-2178

Add SSL config in DSN for PostgreSQL only supports the file path, so we use the Package stdlib which is the compatibility layer from pgx to database/sql.

To connection PG:
1. generate the DSN without SSL config
2. parse the DSN to pgx.ConnConfig
3. add the SSL config into pgx.ConnConfig
4. register the new pgx.ConnConfig and get the connection string
5. use the connection string to connection PG with SSL

Also, we need to unregister the connection string if we don't need the pgx.ConnConfig.

![image](https://user-images.githubusercontent.com/20775801/211712055-1e1b1e59-1910-42da-9ff7-4b64231f0831.png)
![image](https://user-images.githubusercontent.com/20775801/211712169-b40af857-0fe1-46c2-a80e-936dfb6e5b5f.png)

