### PR TITLE
fix: revert "fix(clickhouse): using empty tls config instead of nil"

### DIFF
--- a/plugin/db/clickhouse/clickhouse.go
+++ b/plugin/db/clickhouse/clickhouse.go
@@ -3,7 +3,6 @@ package clickhouse
 
 import (
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -57,10 +56,6 @@ func (driver *Driver) Open(_ context.Context, dbType db.Type, config db.Connecti
 	if err != nil {
 		return nil, errors.Wrap(err, "sql: tls config error")
 	}
-	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
-	}
-
 	// Default user name is "default".
 	conn := clickhouse.OpenDB(&clickhouse.Options{
 		Addr: []string{addr},


### PR DESCRIPTION
Reverts bytebase/bytebase#4113

`tlsConfig = &fls.Config{}` means that we use the CA in local operation system, such as `/etc/ssl/cert.pem` in MacOS.

`tlsConfig = nil` means that we don't use the SSL connection.

The #4113 will cause that bytebase always connects clickhouse with SSL

Close BYT-2305