### PR TITLE
fix: remove key words in SQL

### DIFF
--- a/store/database.go
+++ b/store/database.go
@@ -519,7 +519,7 @@ func (*Store) listDatabaseImplV2(ctx context.Context, tx *Tx, find *FindDatabase
 			) keys,
 			ARRAY_AGG (
 				db_label.value
-			) values
+			) label_values
 		FROM db
 		LEFT JOIN project ON db.project_id = project.id
 		LEFT JOIN instance ON db.instance_id = instance.id


### PR DESCRIPTION
Only PostgreSQL 14+ can use the key word `values` as the alias without `AS`.
Remove the key word `values` in queries to ensure higher robustness.