### PR TITLE
fix(mongodb): convert string to long and then pass to migration_history id

### DIFF
--- a/plugin/db/mongodb/migrate.go
+++ b/plugin/db/mongodb/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"time"
 
 	// embed will embeds the migration schema.
@@ -350,8 +351,13 @@ func (driver *Driver) InsertPendingHistory(ctx context.Context, _ *sql.Tx, seque
 // UpdateHistoryAsDone will update the migration record as done.
 func (driver *Driver) UpdateHistoryAsDone(ctx context.Context, _ *sql.Tx, migrationDurationNs int64, _ string, insertedID string) error {
 	collection := driver.client.Database(migrationHistoryDefaultDatabase).Collection(migrationHistoryDefaultCollection)
+	longMigrationHistoryID, err := strconv.ParseInt(insertedID, 10, 64)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse inserted ID %s to uint64", insertedID)
+	}
+
 	filter := bson.M{
-		"id": insertedID,
+		"id": longMigrationHistoryID,
 	}
 	update := bson.M{
 		"$set": bson.M{
@@ -373,8 +379,12 @@ func (driver *Driver) UpdateHistoryAsDone(ctx context.Context, _ *sql.Tx, migrat
 // UpdateHistoryAsFailed will update the migration record as failed.
 func (driver *Driver) UpdateHistoryAsFailed(ctx context.Context, _ *sql.Tx, migrationDurationNs int64, insertedID string) error {
 	collection := driver.client.Database(migrationHistoryDefaultDatabase).Collection(migrationHistoryDefaultCollection)
+	longMigrationHistoryID, err := strconv.ParseInt(insertedID, 10, 64)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse inserted ID %s to uint64", insertedID)
+	}
 	filter := bson.M{
-		"id": insertedID,
+		"id": longMigrationHistoryID,
 	}
 	update := bson.M{
 		"$set": bson.M{


### PR DESCRIPTION
This bug was introduced by https://github.com/bytebase/bytebase/pull/4197.

And then, we set the migration history id as string.https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/plugin/db/mongodb/migrate.go?L354

But we store the migration history id as long int

https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/plugin/db/mongodb/collmod_migrationHistory_collection_command.json?L31.