### PR TITLE
fix: use reader instead of scanner to fix "bufio.Scanner: token too long"

### DIFF
--- a/plugin/db/pg/dump.go
+++ b/plugin/db/pg/dump.go
@@ -103,7 +103,7 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 	previousLineEmpty := false
 	for {
 		line, err := outReader.ReadString('\n')
-		if err != nil || err == io.EOF {
+		if err == nil || err == io.EOF {
 			// Skip "SET SESSION AUTHORIZATION" till we can support it.
 			if strings.HasPrefix(line, "SET SESSION AUTHORIZATION ") {
 				continue
@@ -143,7 +143,7 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 	var errBuilder strings.Builder
 	for {
 		line, err := errReader.ReadString('\n')
-		if err != nil || err == io.EOF {
+		if err == nil || err == io.EOF {
 			// Log the error, but return the first 1024 characters in the error to users.
 			log.Warn(line)
 			if errBuilder.Len() < 1024 {

--- a/tests/schema_update_test.go
+++ b/tests/schema_update_test.go
@@ -933,7 +933,8 @@ WHERE table_type = 'BASE TABLE'
 			a.Equal(`[["table_name"],["NAME"],[["projects"],["users"]]]`, result)
 
 			// Get migration history
-			const initialSchema = `SET statement_timeout = 0;
+			const initialSchema = `
+SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -945,7 +946,8 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 `
-			const updatedSchema = `SET statement_timeout = 0;
+			const updatedSchema = `
+SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1849,7 +1851,8 @@ func TestGetLatestSchema(t *testing.T) {
 			dbType:       db.Postgres,
 			databaseName: "latestSchema",
 			ddl:          `CREATE TABLE book(id INT, name TEXT);`,
-			wantRawSchema: `SET statement_timeout = 0;
+			wantRawSchema: `
+SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';


### PR DESCRIPTION
> Scanning stops unrecoverably at EOF, the first I/O error, or a token too large to fit in the buffer. When a scan stops, the reader may have advanced arbitrarily far past the last token. Programs that need more control over error handling or large tokens, or must run sequential scans on a reader, should use bufio.Reader instead.

Reference
- https://pkg.go.dev/bufio#Scanner

close BYT-2352