### PR TITLE
chore: don't require database field for spanner instance

### DIFF
--- a/frontend/src/components/CreateInstanceForm.vue
+++ b/frontend/src/components/CreateInstanceForm.vue
@@ -248,12 +248,6 @@
           <div class="flex flex-row items-center space-x-2">
             <label for="database" class="textlabel block">
               {{ $t("common.database") }}
-              <template v-if="state.instance.engine === 'SPANNER'">
-                <span style="color: red">*</span>
-                <p class="text-sm text-gray-500 mt-1">
-                  {{ $t("instance.used-for-testing-connection") }}
-                </p>
-              </template>
             </label>
           </div>
           <input
@@ -459,10 +453,7 @@ const embeddedPostgresInstance = ref<Partial<InstanceCreate>>();
 const allowCreate = computed(() => {
   if (state.instance.engine === "SPANNER") {
     return (
-      state.instance.name &&
-      state.instance.host &&
-      state.instance.password &&
-      state.instance.database
+      state.instance.name && state.instance.host && state.instance.password
     );
   }
   return state.instance.name && state.instance.host;
@@ -497,9 +488,7 @@ const showSSL = computed((): boolean => {
 });
 
 const showDatabase = computed((): boolean => {
-  return (
-    state.instance.engine === "POSTGRES" || state.instance.engine === "SPANNER"
-  );
+  return state.instance.engine === "POSTGRES";
 });
 
 const showAuthenticationDatabase = computed((): boolean => {
@@ -690,11 +679,6 @@ const tryCreate = () => {
   // MongoDB can use auth database.
   // https://www.mongodb.com/docs/manual/tutorial/authenticate-a-user/#std-label-authentication-auth-as-user
   if (instance.engine === "MONGODB") {
-    connectionInfo.database = instance.database;
-  }
-  // Spanner must connect to a specific database.
-  // To test connection, we must set database.
-  if (instance.engine === "SPANNER") {
     connectionInfo.database = instance.database;
   }
 

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -51,10 +51,16 @@
             <template v-else-if="state.instance.engine === 'SPANNER'">
               {{ $t("instance.project-id-and-instance-id") }}
               <span style="color: red">*</span>
-              <p class="text-sm text-gray-500 mt-1 mb-2">
-                Don't know where to find project ID and instance ID? Check this
-                link!
-                <!-- TODO(p0ny): fix the link -->
+              <p class="text-sm text-gray-500 mt-1">
+                {{ $t("instance.find-gcp-project-id-and-instance-id") }}
+                <a
+                  href="https://www.bytebase.com/docs/how-to/spanner/how-to-find-project-id-and-instance-id"
+                  target="_blank"
+                  class="normal-link inline-flex items-center"
+                >
+                  {{ $t("common.detailed-guide")
+                  }}<heroicons-outline:external-link class="w-4 h-4 ml-1"
+                /></a>
               </p>
             </template>
             <template v-else>
@@ -239,11 +245,22 @@
             <label for="password" class="textlabel block">
               <template v-if="state.instance.engine === 'SPANNER'">
                 {{ $t("common.credentials") }}
+                <span class="text-red-600">*</span>
+                <p class="text-sm text-gray-500 mt-1">
+                  {{ $t("instance.create-gcp-credentials") }}
+                  <a
+                    href="https://www.bytebase.com/docs/how-to/spanner/how-to-create-a-service-account-for-bytebase"
+                    target="_blank"
+                    class="normal-link inline-flex items-center"
+                    >{{ $t("common.detailed-guide") }}
+                    <heroicons-outline:external-link class="w-4 h-4 ml-1"
+                  /></a>
+                </p>
               </template>
               <template v-else>
                 {{ $t("common.password") }}
+                <span class="text-red-600">*</span>
               </template>
-              <span class="text-red-600">*</span>
             </label>
             <BBCheckbox
               :title="$t('common.empty')"


### PR DESCRIPTION
Don't require `database` field for spanner instance anymore.

We needed it before because we want to connect to a database when Ping, now we just use ListDatabases for Ping.

also update spanner instance description in InstanceForm.vue. Forgot about that in #4309 ...


Close BYT-2349