### PR TITLE
feat(schema-diagram): limit exported png size

### DIFF
--- a/frontend/src/components/SchemaDiagram/Canvas/Canvas.vue
+++ b/frontend/src/components/SchemaDiagram/Canvas/Canvas.vue
@@ -159,7 +159,7 @@ const renderDummy = () => {
 const handleScreenshot = async () => {
   busy.value = true;
   try {
-    await dummy.value?.capture(`${database.value.name}.png`, "png");
+    await dummy.value?.capture(`${database.value.name}.png`);
   } catch {
     pushNotification({
       module: "bytebase",

--- a/frontend/src/components/SchemaDiagram/Canvas/libs/fitView.ts
+++ b/frontend/src/components/SchemaDiagram/Canvas/libs/fitView.ts
@@ -1,5 +1,5 @@
-import { calcBBox, minmax } from "../../common";
-import { Geometry, Rect } from "../../types";
+import type { Geometry, Rect } from "../../types";
+import { calcBBox, fitBBox } from "../../common";
 
 export const fitView = (
   canvas: Element,
@@ -34,39 +34,9 @@ const calcFitRect = (content: Rect, view: Rect, zoomRange: number[]) => {
   const contentMarginTop = content.y;
   const contentMarginLeft = content.x;
 
-  const contentWHRatio = content.width / content.height;
-  const canvasWHRatio = view.width / view.height;
+  const { zoom, rect } = fitBBox(content, view, zoomRange);
+  rect.x -= contentMarginLeft * zoom;
+  rect.y -= contentMarginTop * zoom;
 
-  if (contentWHRatio > canvasWHRatio) {
-    // content is wider than canvas, fit horizontally
-    const targetWidth = view.width;
-    const targetZoom = targetWidth / content.width;
-    const zoom = minmax(targetZoom, zoomRange[0], zoomRange[1]);
-    const targetSize = {
-      width: content.width * zoom,
-      height: content.height * zoom,
-    };
-    const targetPos = {
-      x: (view.width - targetSize.width) / 2 - contentMarginLeft * zoom,
-      y: (view.height - targetSize.height) / 2 - contentMarginTop * zoom,
-    };
-
-    const rect = { ...targetSize, ...targetPos };
-    return { zoom, rect };
-  } else {
-    // content is taller than canvas, fit vertically
-    const targetHeight = view.height;
-    const targetZoom = targetHeight / content.height;
-    const zoom = minmax(targetZoom, zoomRange[0], zoomRange[1]);
-    const targetSize = {
-      width: content.width * zoom,
-      height: content.height * zoom,
-    };
-    const targetPos = {
-      x: (view.width - targetSize.width) / 2 - contentMarginLeft * zoom,
-      y: (view.height - targetSize.height) / 2 - contentMarginTop * zoom,
-    };
-    const rect = { ...targetSize, ...targetPos };
-    return { zoom, rect };
-  }
+  return { zoom, rect };
 };

--- a/frontend/src/components/SchemaDiagram/common/geometry.ts
+++ b/frontend/src/components/SchemaDiagram/common/geometry.ts
@@ -1,4 +1,5 @@
-import { Geometry, Path, Point, Rect } from "../types";
+import type { Geometry, Path, Point, Rect, Size } from "../types";
+import { minmax } from "./utils";
 
 export const pointsOfRect = (rect: Rect): Point[] => {
   const { x, y, width, height } = rect;
@@ -101,4 +102,38 @@ export const pointsOfGeometry = (g: Geometry): Point[] => {
   if (isRect(g)) return pointsOfRect(g);
 
   throw new Error(`'${String(g)}' is not a geometry.`);
+};
+
+export const fitBBox = (
+  content: Size,
+  boundary: Size,
+  zoomRange: number[] = [0, Infinity]
+) => {
+  const contentWHRatio = content.width / content.height;
+  const boundaryWHRatio = boundary.width / boundary.height;
+  let zoom = 1;
+
+  if (contentWHRatio > boundaryWHRatio) {
+    // content is wider than boundary, fit horizontally
+    const targetWidth = boundary.width;
+    const targetZoom = targetWidth / content.width;
+    zoom = minmax(targetZoom, zoomRange[0], zoomRange[1]);
+  } else {
+    // content is taller than boundary, fit vertically
+    const targetHeight = boundary.height;
+    const targetZoom = targetHeight / content.height;
+    zoom = minmax(targetZoom, zoomRange[0], zoomRange[1]);
+  }
+
+  const targetSize = {
+    width: content.width * zoom,
+    height: content.height * zoom,
+  };
+  const targetPos = {
+    x: (boundary.width - targetSize.width) / 2,
+    y: (boundary.height - targetSize.height) / 2,
+  };
+
+  const rect = { ...targetSize, ...targetPos };
+  return { zoom, rect };
 };


### PR DESCRIPTION
### Changes

- Limit the exported PNG in a 4096*4096 box (keeping its width:height ratio).

FYI @tianzhou 