### PR TITLE
fix(frontend): hide NOT_FOUND databases in sidebar

### DIFF
--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -43,7 +43,9 @@ export default defineComponent({
 
     // Use this to make the list reactive when project is transferred.
     const databaseList = computed((): Database[] => {
-      return databaseStore.getDatabaseListByPrincipalId(currentUser.value.id);
+      return databaseStore
+        .getDatabaseListByPrincipalId(currentUser.value.id)
+        .filter((db) => db.syncStatus === "OK");
     });
 
     const databaseListByEnvironment = computed(() => {


### PR DESCRIPTION
We've hidden NOT_FOUND databases by default since #3973, but this place is missed.