### PR TITLE
feat(schema-diagram): (experimental) copy exported png to clipboard

### DIFF
--- a/frontend/src/components/SchemaDiagram/Canvas/DummyCanvas.vue
+++ b/frontend/src/components/SchemaDiagram/Canvas/DummyCanvas.vue
@@ -37,6 +37,7 @@
 </template>
 
 <script lang="ts" setup>
+import { pushNotification } from "@/store";
 import { computed, defineComponent, nextTick, PropType, ref, VNode } from "vue";
 
 import {
@@ -122,17 +123,29 @@ const capture = async (filename: string) => {
     return;
   }
 
-  const [{ toPng }, { default: download }] = await Promise.all([
-    import("html-to-image"),
-    import("downloadjs"),
-  ]);
-  const dataUrl = await toPng(node, {
-    pixelRatio: 1,
-    quality: 0.9,
-  });
-  download(dataUrl, filename, `image/png`);
+  try {
+    const [{ toBlob }, { default: download }] = await Promise.all([
+      import("html-to-image"),
+      import("downloadjs"),
+    ]);
+    const blob = await toBlob(node, {
+      pixelRatio: 1,
+      quality: 0.9,
+    });
+    if (blob) {
+      download(blob, filename, blob.type);
 
-  isCapturing.value = false;
+      const data = [new window.ClipboardItem({ [blob.type]: blob })];
+      await navigator.clipboard.write(data);
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: "Screenshot generated successfully and copied to clipboard!",
+      });
+    }
+  } finally {
+    isCapturing.value = false;
+  }
 };
 
 provideSchemaDiagramContext({

--- a/frontend/src/components/SchemaDiagram/Canvas/DummyCanvas.vue
+++ b/frontend/src/components/SchemaDiagram/Canvas/DummyCanvas.vue
@@ -140,7 +140,7 @@ const capture = async (filename: string) => {
       pushNotification({
         module: "bytebase",
         style: "SUCCESS",
-        title: "Screenshot generated successfully and copied to clipboard!",
+        title: "Screenshot generated successfully and copied to the clipboard!",
       });
     }
   } finally {


### PR DESCRIPTION
### Features

- When exporting the schema diagram to PNG, we also try to copy the binary image data to the clipboard.

### Screenshots

<img width="460" alt="image" src="https://user-images.githubusercontent.com/2749742/213123367-66deadcf-f04f-4616-9467-09d4a406821a.png">

### Known issues

- Due to some security limitations of browsers, users might be asked when the exported image is large (> 1MB, I guess).
<img width="350" alt="image" src="https://user-images.githubusercontent.com/2749742/213122920-ece9f492-c817-459e-a34e-3ab49fb0eb24.png">

FYI @tianzhou 