### PR TITLE
fix: create database before create the data source

### DIFF
--- a/store/database.go
+++ b/store/database.go
@@ -476,6 +476,21 @@ func (s *Store) UpdateDatabase(ctx context.Context, patch *UpdateDatabaseMessage
 	return s.GetDatabaseV2(ctx, &FindDatabaseMessage{UID: &databaseUID})
 }
 
+func (s *Store) getDatabaseImplV2(ctx context.Context, tx *Tx, find *FindDatabaseMessage) (*DatabaseMessage, error) {
+	databaseList, err := s.listDatabaseImplV2(ctx, tx, find)
+	if err != nil {
+		return nil, err
+	}
+	if len(databaseList) == 0 {
+		return nil, &common.Error{Code: common.NotFound, Err: errors.Errorf("database not found with %v", find)}
+	}
+	if len(databaseList) > 1 {
+		return nil, &common.Error{Code: common.NotFound, Err: errors.Errorf("found %d data source databases with %v, but expect 1", len(databaseList), find)}
+	}
+
+	return databaseList[0], nil
+}
+
 func (*Store) listDatabaseImplV2(ctx context.Context, tx *Tx, find *FindDatabaseMessage) ([]*DatabaseMessage, error) {
 	where, args := []string{"TRUE"}, []interface{}{}
 	if !find.IncludeAllDatabase {


### PR DESCRIPTION
We’ve introduced the bug in this PR https://github.com/bytebase/bytebase/pull/4226/commits/d304a3eaa266e91213a1a522af98755b0f0e0d4d#diff-ee528d2122bdba561819021a044c90843bd46a95aa7071c144849e485d0788afL821

This will fail the data source creation for a new instance