### PR TITLE
feat(sql-editor): visualize sql advice errors and warnings

### DIFF
--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -132,10 +132,11 @@
       class="w-full h-auto max-h-[360px]"
       data-label="bb-issue-sql-editor"
       :value="state.editStatement"
-      :readonly="!state.editing || !allowEditStatement || isTaskHasSheetId"
+      :readonly="readonly"
       :auto-focus="false"
       :language="language"
       :dialect="dialect"
+      :advices="readonly ? markers : []"
       @change="onStatementChange"
       @ready="handleMonacoEditorReady"
     />
@@ -195,6 +196,7 @@ import MonacoEditor from "../MonacoEditor/MonacoEditor.vue";
 import IssueRollbackButton from "./IssueRollbackButton.vue";
 import { isUndefined } from "lodash-es";
 import { useInstanceEditorLanguage } from "@/utils";
+import { useSQLAdviceMarkers } from "./logic/useSQLAdviceMarkers";
 
 interface LocalState {
   editing: boolean;
@@ -334,6 +336,12 @@ const useTempEditState = (state: LocalState) => {
 };
 
 useTempEditState(state);
+
+const readonly = computed(() => {
+  return !state.editing || !allowEditStatement.value || isTaskHasSheetId.value;
+});
+
+const { markers } = useSQLAdviceMarkers();
 
 const language = useInstanceEditorLanguage(
   computed(() => selectedDatabase.value?.instance)

--- a/frontend/src/components/Issue/logic/useSQLAdviceMarkers.ts
+++ b/frontend/src/components/Issue/logic/useSQLAdviceMarkers.ts
@@ -1,0 +1,41 @@
+import { computed } from "vue";
+import { maxBy } from "lodash-es";
+
+import type { Task } from "@/types";
+import type { AdviceOption } from "@/components/MonacoEditor";
+import { useIssueLogic } from ".";
+
+export const useSQLAdviceMarkers = () => {
+  const { create, selectedTask } = useIssueLogic();
+  const markers = computed(() => {
+    if (create.value) return [];
+    const task = selectedTask.value as Task;
+
+    const advices = task.taskCheckRunList.filter(
+      (check) => check.type === "bb.task-check.database.statement.advise"
+    );
+    const latest = maxBy(advices, (advice) => advice.id);
+    if (!latest) {
+      return [];
+    }
+
+    const { resultList = [] } = latest.result;
+    return resultList
+      .filter((result) => result.status === "ERROR" || result.status === "WARN")
+      .filter((result) => result.line !== undefined)
+      .map<AdviceOption>((result) => {
+        return {
+          severity: result.status === "ERROR" ? "ERROR" : "WARNING",
+          message: result.content,
+          source: `${result.title} (${result.code})`,
+          startLineNumber: result.line! + 1,
+          // We don't know the actual column yet, so we show the marker at then end of the line
+          startColumn: Number.MAX_SAFE_INTEGER,
+          endLineNumber: result.line! + 1,
+          // We don't know the actual column yet, so we show the marker at then end of the line
+          endColumn: Number.MAX_SAFE_INTEGER,
+        };
+      });
+  });
+  return { markers };
+};

--- a/frontend/src/components/MonacoEditor/MonacoEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoEditor.vue
@@ -24,6 +24,8 @@ import { TableMetadata } from "@/types/proto/store/database";
 import { MonacoHelper, useMonaco } from "./useMonaco";
 import { useLineDecorations } from "./lineDecorations";
 import type { useLanguageClient } from "@sql-lsp/client";
+import type { AdviceOption } from "./types";
+import { useAdvices } from "./plugins/useAdvices";
 
 const props = defineProps({
   value: {
@@ -45,6 +47,10 @@ const props = defineProps({
   autoFocus: {
     type: Boolean,
     default: true,
+  },
+  advices: {
+    type: Array as PropType<AdviceOption[]>,
+    default: () => [],
   },
   options: {
     type: Object as PropType<Editor.IStandaloneEditorConstructionOptions>,
@@ -77,6 +83,8 @@ const initEditorInstance = () => {
   const model = monaco.editor.createModel(sqlCode.value);
   const editorInstance = monaco.editor.create(editorContainerRef.value!, {
     model,
+    // Learn more: https://github.com/microsoft/monaco-editor/issues/311
+    renderValidationDecorations: "on",
     theme: "bb",
     tabSize: 2,
     insertSpaces: true,
@@ -247,6 +255,8 @@ onMounted(async () => {
     editorInstance.focus();
     nextTick(() => setPositionAtEndOfLine(editorInstance));
   }
+
+  useAdvices(editorInstance, toRef(props, "advices"));
 
   isEditorLoaded.value = true;
 

--- a/frontend/src/components/MonacoEditor/index.ts
+++ b/frontend/src/components/MonacoEditor/index.ts
@@ -1,0 +1,7 @@
+import MonacoEditor from "./MonacoEditor.vue";
+
+export * from "./types";
+
+export { MonacoEditor };
+
+export default MonacoEditor;

--- a/frontend/src/components/MonacoEditor/plugins/useAdvices.ts
+++ b/frontend/src/components/MonacoEditor/plugins/useAdvices.ts
@@ -1,0 +1,85 @@
+import { unref, watchEffect } from "vue";
+import { maxBy } from "lodash-es";
+import type { editor as Editor } from "monaco-editor";
+
+import type { MaybeRef } from "@/types";
+import type { AdviceOption } from "../types";
+import { escapeMarkdown } from "@/utils";
+import { callVar } from "../themes/utils";
+
+export const useAdvices = async (
+  editor: Editor.IStandaloneCodeEditor,
+  advices: MaybeRef<AdviceOption[]>
+) => {
+  const monaco = await import("monaco-editor");
+
+  watchEffect((onCleanup) => {
+    const _advices = unref(advices);
+    const maxSeverity =
+      maxBy(
+        _advices.map((m) => m.severity),
+        (s) => levelOfSeverity(s)
+      ) ?? "WARNING";
+    const decorators = editor.createDecorationsCollection(
+      _advices.map((advice) => {
+        return {
+          range: new monaco.Range(
+            advice.startLineNumber,
+            advice.startColumn,
+            advice.endLineNumber,
+            advice.endColumn
+          ),
+          options: {
+            className:
+              maxSeverity === "ERROR" ? "squiggly-error" : "squiggly-warning",
+            minimap: {
+              color: { id: "minimap.errorHighlight" },
+              position: monaco.editor.MinimapPosition.Inline,
+            },
+            overviewRuler: {
+              color: { id: "editorOverviewRuler.errorForeground" },
+              position: monaco.editor.OverviewRulerLane.Right,
+            },
+            showIfCollapsed: true,
+            stickiness:
+              monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+            zIndex: 30,
+            hoverMessage: {
+              value: buildHoverMessage(advice),
+              isTrusted: true,
+            },
+          },
+        };
+      })
+    );
+    onCleanup(() => {
+      decorators.clear();
+    });
+  });
+};
+
+const buildHoverMessage = (advice: AdviceOption) => {
+  const COLORS = {
+    WARNING: callVar("--color-warning"),
+    ERROR: callVar("--color-error"),
+  };
+
+  const { severity, message, source } = advice;
+  const parts: string[] = [];
+  parts.push(`<span style="color:${COLORS[severity]};">[${severity}]</span>`);
+  if (source) {
+    parts.push(` ${escapeMarkdown(source)}`);
+  }
+  parts.push(`\n${escapeMarkdown(message)}`);
+  return parts.join("");
+};
+
+const levelOfSeverity = (severity: AdviceOption["severity"]) => {
+  switch (severity) {
+    case "WARNING":
+      return 0;
+    case "ERROR":
+      return 1;
+  }
+  throw new Error(`unsupported value "${severity}"`);
+};

--- a/frontend/src/components/MonacoEditor/types.ts
+++ b/frontend/src/components/MonacoEditor/types.ts
@@ -1,0 +1,9 @@
+export type AdviceOption = {
+  severity: "ERROR" | "WARNING";
+  message: string;
+  source?: string;
+  startLineNumber: number; // starts from 1
+  startColumn: number; // starts from 1
+  endLineNumber: number; // starts from 1
+  endColumn: number; // starts from 1
+};

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -289,6 +289,7 @@ export type TaskCheckResult = {
   code: ErrorCode;
   title: string;
   content: string;
+  line: number | undefined;
   namespace: TaskCheckNamespace;
 };
 

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -13,6 +13,7 @@ export * from "./types";
 export * from "./util";
 export * from "./label";
 export * from "./deployment";
+export * from "./string";
 export * from "./tab";
 export * from "./task";
 export * from "./principal";

--- a/frontend/src/utils/string.ts
+++ b/frontend/src/utils/string.ts
@@ -1,0 +1,3 @@
+export const escapeMarkdown = (md: string): string => {
+  return md.replaceAll(/[*_~\-#`[\]()\\]/g, (ch) => `\\${ch}`);
+};


### PR DESCRIPTION
### Features and know issues

- The wavy lines are only visible when we are NOT editing SQL statements.
- Only SQL advices are ready to visualize since we are starting from #4350 
- We don't know the column numbers, so we put the wavy lines at the end of the line, once we get the line numbers, they could be soon optimized.
- I tried to add a hyper link to the error code but failed since monaco-editor doesn't support this.

### Screenshots
<img width="999" alt="image" src="https://user-images.githubusercontent.com/2749742/213650163-fb7cf82e-45a0-4369-98b6-05a7324adc61.png">

Close BYT-2382
FYI @rebelice @Candybase 