### PR TITLE
feat(vcs): don't filter diff if the before field is zero

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -510,7 +510,7 @@ func (s *Server) processPushEvent(ctx context.Context, repositoryList []*api.Rep
 
 	repo := repositoryList[0]
 	filteredDistinctFileList := distinctFileList
-	// The before commit ID is all zeros when the branch is created, and we will encounter an error when we try to get the diff.
+	// The before commit ID is all zeros when the branch is just created and contains no commits yet, and we will encounter an error when we try to get the diff.
 	if baseVCSPushEvent.Before != strings.Repeat("0", 40) {
 		var err error
 		filteredDistinctFileList, err = s.filterFilesByCommitsDiff(ctx, repo, distinctFileList, baseVCSPushEvent.Before, baseVCSPushEvent.After)

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -509,9 +509,14 @@ func (s *Server) processPushEvent(ctx context.Context, repositoryList []*api.Rep
 	}
 
 	repo := repositoryList[0]
-	filteredDistinctFileList, err := s.filterFilesByCommitsDiff(ctx, repo, distinctFileList, baseVCSPushEvent.Before, baseVCSPushEvent.After)
-	if err != nil {
-		return nil, err
+	filteredDistinctFileList := distinctFileList
+	// The before commit ID is all zeros when the branch is created, and we will encounter an error when we try to get the diff.
+	if baseVCSPushEvent.Before != strings.Repeat("0", 40) {
+		var err error
+		filteredDistinctFileList, err = s.filterFilesByCommitsDiff(ctx, repo, distinctFileList, baseVCSPushEvent.Before, baseVCSPushEvent.After)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var createdMessageList []string


### PR DESCRIPTION
## Related Issue
- #4372
## Background
We introduce `commit filter` in #3411, which extract the `before` and `after` field in the `push event` payload, and then request GitLab/GitHub for more information with them to get the "correct" commit list to filter the original `commits` field.
But for the new branch, the `before` field always be zero, and the VCS returns `404` status code, and then we return `500` status code to VCS.

For example:
```bash
git checkout -b foo
[do some change]
git add .
git commit -m "msg"
```
The `before` field in the push event is zero, and the `commits` field contains the file Bytebase wants:
![CleanShot 2023-01-20 at 23 19 30](https://user-images.githubusercontent.com/87714218/213734248-eaa07951-80f3-44d5-953e-16b413d06240.png)

## Solution
Skip the filter if the before field is zero.
**This is a temporary fix to unblock customers. we need to evaluate the GitOps workflow later carefully and come up with a cleaner fix.**

The screenshots after the fix:
![CleanShot 2023-01-20 at 23 22 26](https://user-images.githubusercontent.com/87714218/213734916-1a7215f8-7386-429c-a5d3-70a938978c8d.png)

![CleanShot 2023-01-20 at 23 22 42](https://user-images.githubusercontent.com/87714218/213734888-e1e90275-c428-4b33-bc20-e37bbcc5c244.png)

Thanks @NickStepanov
