### PR TITLE
feat: put demo data under separate pgdata-demo/<<demo-name>> directory

### DIFF
--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/component/config"
 	api "github.com/bytebase/bytebase/backend/legacyapi"
 	"github.com/bytebase/bytebase/backend/plugin/app/feishu"
 )
 
-func getBaseProfile() config.Profile {
+func getBaseProfile(dataDir string) config.Profile {
 	backupStorageBackend := api.BackupStorageBackendLocal
 	if flags.backupBucket != "" {
 		backupStorageBackend = api.BackupStorageBackendS3
@@ -17,6 +18,8 @@ func getBaseProfile() config.Profile {
 		GrpcPort:             flags.port + 1, // Using flags.port + 1 as our gRPC server port.
 		DatastorePort:        flags.port + 2, // Using flags.port + 2 as our datastore port.
 		Readonly:             flags.readonly,
+		DataDir:              dataDir,
+		ResourceDir:          common.GetResourceDir(dataDir),
 		Debug:                flags.debug,
 		DemoName:             flags.demoName,
 		Version:              version,

--- a/backend/bin/server/cmd/profile_dev.go
+++ b/backend/bin/server/cmd/profile_dev.go
@@ -11,10 +11,9 @@ import (
 )
 
 func activeProfile(dataDir string) config.Profile {
-	p := getBaseProfile()
+	p := getBaseProfile(dataDir)
 	p.Mode = common.ReleaseModeDev
 	p.PgUser = "bbdev"
-	p.DataDir = dataDir
 	p.BackupRunnerInterval = 10 * time.Second
 	p.AppRunnerInterval = 30 * time.Second
 	p.MetricConnectionKey = "3zcZLeX3ahvlueEJqNyJysGfVAErsjjT"

--- a/backend/bin/server/cmd/profile_release.go
+++ b/backend/bin/server/cmd/profile_release.go
@@ -11,10 +11,9 @@ import (
 )
 
 func activeProfile(dataDir string) config.Profile {
-	p := getBaseProfile()
+	p := getBaseProfile(dataDir)
 	p.Mode = common.ReleaseModeProd
 	p.PgUser = "bb"
-	p.DataDir = dataDir
 	p.BackupRunnerInterval = 10 * time.Minute
 	p.AppRunnerInterval = 30 * time.Second
 	p.MetricConnectionKey = "so9lLwj5zLjH09sxNabsyVNYSsAHn68F"

--- a/backend/common/util.go
+++ b/backend/common/util.go
@@ -59,7 +59,13 @@ func HasPrefixes(src string, prefixes ...string) bool {
 }
 
 // GetPostgresDataDir returns the postgres data directory of Bytebase.
-func GetPostgresDataDir(dataDir string) string {
+func GetPostgresDataDir(dataDir string, demoName string) string {
+	// If demo is specified, we will use demo specific directory to store the demo data. Because
+	// we reset the demo data when starting Bytebase and this can prevent accidentally removing the
+	// production data.
+	if demoName != "" {
+		return path.Join(dataDir, fmt.Sprintf("pgdata-demo/%s", demoName))
+	}
 	return path.Join(dataDir, "pgdata")
 }
 

--- a/backend/component/config/profile.go
+++ b/backend/component/config/profile.go
@@ -29,8 +29,8 @@ type Profile struct {
 	Readonly bool
 	// DataDir is the directory stores the data including Bytebase's own database, backups, etc.
 	DataDir string
-	// ResourceDirOverride is the directory stores the resources including embedded postgres and mysqlutil.
-	ResourceDirOverride string
+	// ResourceDir is the directory stores the resources including embedded postgres, mysqlutil, mongoutil and etc.
+	ResourceDir string
 	// Debug decides the log level
 	Debug bool
 	// DemoName specifies the demo name. Empty string means no demo.

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -196,16 +196,11 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 		errorRecordRing: api.NewErrorRecordRing(),
 	}
 
-	resourceDir := common.GetResourceDir(profile.DataDir)
-	if profile.ResourceDirOverride != "" {
-		resourceDir = profile.ResourceDirOverride
-	}
-
 	// Display config
 	log.Info("-----Config BEGIN-----")
 	log.Info(fmt.Sprintf("mode=%s", profile.Mode))
 	log.Info(fmt.Sprintf("dataDir=%s", profile.DataDir))
-	log.Info(fmt.Sprintf("resourceDir=%s", resourceDir))
+	log.Info(fmt.Sprintf("resourceDir=%s", profile.ResourceDir))
 	log.Info(fmt.Sprintf("externalURL=%s", profile.ExternalURL))
 	log.Info(fmt.Sprintf("readonly=%t", profile.Readonly))
 	log.Info(fmt.Sprintf("debug=%t", profile.Debug))
@@ -225,26 +220,26 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 
 	var err error
 	// Install mysqlutil
-	s.mysqlBinDir, err = mysqlutil.Install(resourceDir)
+	s.mysqlBinDir, err = mysqlutil.Install(profile.ResourceDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot install mysql utility binaries")
 	}
 
-	s.mongoBinDir, err = mongoutil.Install(resourceDir)
+	s.mongoBinDir, err = mongoutil.Install(profile.ResourceDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot install mongo utility binaries")
 	}
 
 	// Installs the Postgres and utility binaries and creates the 'activeProfile.pgUser' user/database
 	// to store Bytebase's own metadata.
-	s.pgBinDir, err = postgres.Install(resourceDir)
+	s.pgBinDir, err = postgres.Install(profile.ResourceDir)
 	if err != nil {
 		return nil, err
 	}
 
 	// New MetadataDB instance.
 	if profile.UseEmbedDB() {
-		pgDataDir := common.GetPostgresDataDir(profile.DataDir)
+		pgDataDir := common.GetPostgresDataDir(profile.DataDir, profile.DemoName)
 		log.Info("-----Embedded Postgres Config BEGIN-----")
 		log.Info(fmt.Sprintf("datastorePort=%d", profile.DatastorePort))
 		log.Info(fmt.Sprintf("pgDataDir=%s", pgDataDir))

--- a/backend/tests/schema_update_test.go
+++ b/backend/tests/schema_update_test.go
@@ -724,7 +724,7 @@ func TestVCS_SDL(t *testing.T) {
 
 			// Create a PostgreSQL instance.
 			pgPort := getTestPort()
-			stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDirOverride)
+			stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDir)
 			defer stopInstance()
 
 			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
@@ -1429,7 +1429,7 @@ func TestVCS_SQL_Review(t *testing.T) {
 
 			// Create a PostgreSQL instance.
 			pgPort := getTestPort()
-			stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDirOverride)
+			stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDir)
 			defer stopInstance()
 
 			pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))
@@ -1879,7 +1879,7 @@ CREATE TABLE public.book (
 			dbPort := getTestPort()
 			switch test.dbType {
 			case db.Postgres:
-				stopInstance := postgres.SetupTestInstance(t, dbPort, resourceDirOverride)
+				stopInstance := postgres.SetupTestInstance(t, dbPort, resourceDir)
 				defer stopInstance()
 			default:
 				a.FailNow("unsupported db type")

--- a/backend/tests/sql_editor_test.go
+++ b/backend/tests/sql_editor_test.go
@@ -73,7 +73,7 @@ func TestAdminQueryAffectedRows(t *testing.T) {
 
 	// Create a PostgreSQL instance.
 	pgPort := getTestPort()
-	pgStopInstance := postgres.SetupTestInstance(t, pgPort, resourceDirOverride)
+	pgStopInstance := postgres.SetupTestInstance(t, pgPort, resourceDir)
 	defer pgStopInstance()
 
 	// Create a project.

--- a/backend/tests/sql_review_test.go
+++ b/backend/tests/sql_review_test.go
@@ -87,7 +87,7 @@ func TestSQLReviewForPostgreSQL(t *testing.T) {
 
 	// Create a PostgreSQL instance.
 	pgPort := getTestPort()
-	stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDirOverride)
+	stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDir)
 	defer stopInstance()
 
 	pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))

--- a/backend/tests/start_test.go
+++ b/backend/tests/start_test.go
@@ -67,19 +67,19 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	resourceDirOverride = os.TempDir()
-	dir, err := postgres.Install(resourceDirOverride)
+	resourceDir = os.TempDir()
+	dir, err := postgres.Install(resourceDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 	externalPgBinDir = dir
-	if _, err := mysqlutil.Install(resourceDirOverride); err != nil {
+	if _, err := mysqlutil.Install(resourceDir); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := mongoutil.Install(resourceDirOverride); err != nil {
+	if _, err := mongoutil.Install(resourceDir); err != nil {
 		log.Fatal(err)
 	}
-	dir, err = resourcemysql.Install(resourceDirOverride)
+	dir, err = resourcemysql.Install(resourceDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/backend/tests/sync_schema_test.go
+++ b/backend/tests/sync_schema_test.go
@@ -57,7 +57,7 @@ DROP SCHEMA "schema_a";
 
 	// Create a PostgreSQL instance.
 	pgPort := getTestPort()
-	stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDirOverride)
+	stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDir)
 	defer stopInstance()
 
 	pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))

--- a/backend/tests/syncer_test.go
+++ b/backend/tests/syncer_test.go
@@ -140,7 +140,7 @@ func TestSyncerForPostgreSQL(t *testing.T) {
 
 	// Create a PostgreSQL instance.
 	pgPort := getTestPort()
-	stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDirOverride)
+	stopInstance := postgres.SetupTestInstance(t, pgPort, resourceDir)
 	defer stopInstance()
 
 	pgDB, err := sql.Open("pgx", fmt.Sprintf("host=/tmp port=%d user=root database=postgres", pgPort))

--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -162,8 +162,8 @@ var (
 	externalPgDataDir  string
 	nextDatabaseNumber = 20210113
 
-	// resourceDirOverride is the shared resource directory.
-	resourceDirOverride string
+	// resourceDir is the shared resource directory.
+	resourceDir string
 )
 
 // getTestPort reserves and returns a port.
@@ -213,7 +213,7 @@ func (ctl *controller) StartServerWithExternalPg(ctx context.Context, config *co
 
 	pgURL := fmt.Sprintf("postgresql://%s@:%d/%s?host=%s", externalPgUser, externalPgPort, databaseName, common.GetPostgresSocketDir())
 	serverPort := getTestPort()
-	profile := getTestProfileWithExternalPg(config.dataDir, resourceDirOverride, serverPort, externalPgUser, pgURL, ctl.feishuProvider.APIURL(ctl.feishuURL))
+	profile := getTestProfileWithExternalPg(config.dataDir, resourceDir, serverPort, externalPgUser, pgURL, ctl.feishuProvider.APIURL(ctl.feishuURL))
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {
 		return err
@@ -237,7 +237,7 @@ func (ctl *controller) StartServer(ctx context.Context, config *config) error {
 		return err
 	}
 	serverPort := getTestPortForEmbeddedPg()
-	profile := getTestProfile(config.dataDir, resourceDirOverride, serverPort, config.readOnly, ctl.feishuProvider.APIURL(ctl.feishuURL))
+	profile := getTestProfile(config.dataDir, resourceDir, serverPort, config.readOnly, ctl.feishuProvider.APIURL(ctl.feishuURL))
 	server, err := server.NewServer(ctx, profile)
 	if err != nil {
 		return err
@@ -250,7 +250,7 @@ func (ctl *controller) StartServer(ctx context.Context, config *config) error {
 
 // GetTestProfile will return a profile for testing.
 // We require port as an argument of GetTestProfile so that test can run in parallel in different ports.
-func getTestProfile(dataDir, resourceDirOverride string, port int, readOnly bool, feishuAPIURL string) componentConfig.Profile {
+func getTestProfile(dataDir, resourceDir string, port int, readOnly bool, feishuAPIURL string) componentConfig.Profile {
 	return componentConfig.Profile{
 		Mode:                 testReleaseMode,
 		ExternalURL:          fmt.Sprintf("http://localhost:%d", port),
@@ -259,7 +259,7 @@ func getTestProfile(dataDir, resourceDirOverride string, port int, readOnly bool
 		PgUser:               "bbtest",
 		Readonly:             readOnly,
 		DataDir:              dataDir,
-		ResourceDirOverride:  resourceDirOverride,
+		ResourceDir:          resourceDir,
 		AppRunnerInterval:    1 * time.Second,
 		BackupRunnerInterval: 10 * time.Second,
 		BackupStorageBackend: api.BackupStorageBackendLocal,
@@ -270,14 +270,14 @@ func getTestProfile(dataDir, resourceDirOverride string, port int, readOnly bool
 // GetTestProfileWithExternalPg will return a profile for testing with external Postgres.
 // We require port as an argument of GetTestProfile so that test can run in parallel in different ports,
 // pgURL for connect to Postgres.
-func getTestProfileWithExternalPg(dataDir, resourceDirOverride string, port int, pgUser string, pgURL string, feishuAPIURL string) componentConfig.Profile {
+func getTestProfileWithExternalPg(dataDir, resourceDir string, port int, pgUser string, pgURL string, feishuAPIURL string) componentConfig.Profile {
 	return componentConfig.Profile{
 		Mode:                 testReleaseMode,
 		ExternalURL:          fmt.Sprintf("http://localhost:%d", port),
 		GrpcPort:             port + 1,
 		PgUser:               pgUser,
 		DataDir:              dataDir,
-		ResourceDirOverride:  resourceDirOverride,
+		ResourceDir:          resourceDir,
 		AppRunnerInterval:    1 * time.Second,
 		BackupRunnerInterval: 10 * time.Second,
 		BackupStorageBackend: api.BackupStorageBackendLocal,


### PR DESCRIPTION
#### Layout
![CleanShot 2023-01-27 at 20 36 52](https://user-images.githubusercontent.com/230323/215088754-24bd00c2-6ed8-48bb-8f94-051c4ac360ea.png)


Because we reset data when running demo and this prevents we accidentally removing production data (if user first starts in normal mode and then starts in demo mode).

Fix BYT-1815
