### PR TITLE
chore: drop pipeline status

### DIFF
--- a/backend/store/migration/dev/LATEST.sql
+++ b/backend/store/migration/dev/LATEST.sql
@@ -640,8 +640,6 @@ CREATE TABLE pipeline (
     name TEXT NOT NULL
 );
 
-CREATE INDEX idx_pipeline_status ON pipeline(status);
-
 ALTER SEQUENCE pipeline_id_seq RESTART WITH 101;
 
 CREATE TRIGGER update_pipeline_updated_ts

--- a/backend/store/migration/dev/LATEST.sql
+++ b/backend/store/migration/dev/LATEST.sql
@@ -637,8 +637,7 @@ CREATE TABLE pipeline (
     created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
-    name TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('OPEN', 'DONE', 'CANCELED'))
+    name TEXT NOT NULL
 );
 
 CREATE INDEX idx_pipeline_status ON pipeline(status);

--- a/backend/store/migration/prod/1.12/0004##drop_pipeline_status.sql
+++ b/backend/store/migration/prod/1.12/0004##drop_pipeline_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline DROP COLUMN status;

--- a/backend/store/migration/prod/1.12/0004##drop_pipeline_status.sql
+++ b/backend/store/migration/prod/1.12/0004##drop_pipeline_status.sql
@@ -1,1 +1,3 @@
 ALTER TABLE pipeline DROP COLUMN status;
+
+DROP INDEX idx_pipeline_status;

--- a/backend/store/migration/prod/LATEST.sql
+++ b/backend/store/migration/prod/LATEST.sql
@@ -639,8 +639,6 @@ CREATE TABLE pipeline (
     name TEXT NOT NULL
 );
 
-CREATE INDEX idx_pipeline_status ON pipeline(status);
-
 ALTER SEQUENCE pipeline_id_seq RESTART WITH 101;
 
 CREATE TRIGGER update_pipeline_updated_ts

--- a/backend/store/migration/prod/LATEST.sql
+++ b/backend/store/migration/prod/LATEST.sql
@@ -636,8 +636,7 @@ CREATE TABLE pipeline (
     created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
-    name TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('OPEN', 'DONE', 'CANCELED'))
+    name TEXT NOT NULL
 );
 
 CREATE INDEX idx_pipeline_status ON pipeline(status);

--- a/backend/store/pg_engine_test.go
+++ b/backend/store/pg_engine_test.go
@@ -220,5 +220,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("1.12.3"), releaseVersion)
+	require.Equal(t, semver.MustParse("1.12.4"), releaseVersion)
 }

--- a/backend/store/pipeline.go
+++ b/backend/store/pipeline.go
@@ -88,8 +88,7 @@ func (s *Store) CreatePipelineV2(ctx context.Context, create *PipelineMessage, c
 		INSERT INTO pipeline (
 			creator_id,
 			updater_id,
-			name,
-			status
+			name
 		)
 		VALUES ($1, $2, $3, $4)
 		RETURNING id, name
@@ -99,7 +98,6 @@ func (s *Store) CreatePipelineV2(ctx context.Context, create *PipelineMessage, c
 		creatorID,
 		creatorID,
 		create.Name,
-		"OPEN",
 	).Scan(
 		&pipeline.ID,
 		&pipeline.Name,

--- a/backend/store/pipeline.go
+++ b/backend/store/pipeline.go
@@ -90,7 +90,7 @@ func (s *Store) CreatePipelineV2(ctx context.Context, create *PipelineMessage, c
 			updater_id,
 			name
 		)
-		VALUES ($1, $2, $3, $4)
+		VALUES ($1, $2, $3)
 		RETURNING id, name
 	`
 	pipeline := &PipelineMessage{}


### PR DESCRIPTION
The pipeline status is no longer used. This field was used to get active pipeline in the task scheduler which is already optimized.