### PR TITLE
feat: start sample pg instance and generate onboarding data after first signup

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/mail"
+	"strconv"
 
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
@@ -13,14 +14,20 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/pkg/errors"
+
 	"github.com/bytebase/bytebase/backend/api/auth"
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/component/config"
+	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	api "github.com/bytebase/bytebase/backend/legacyapi"
 	metricAPI "github.com/bytebase/bytebase/backend/metric"
+	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/idp/oauth2"
 	"github.com/bytebase/bytebase/backend/plugin/metric"
+	"github.com/bytebase/bytebase/backend/resources/postgres"
 	"github.com/bytebase/bytebase/backend/runner/metricreport"
+	"github.com/bytebase/bytebase/backend/runner/schemasync"
 	"github.com/bytebase/bytebase/backend/store"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
@@ -30,17 +37,21 @@ import (
 type AuthService struct {
 	v1pb.UnimplementedAuthServiceServer
 	store          *store.Store
+	dbFactory      *dbfactory.DBFactory
 	secret         string
 	metricReporter *metricreport.Reporter
+	schemaSyncer   *schemasync.Syncer
 	profile        *config.Profile
 }
 
 // NewAuthService creates a new AuthService.
-func NewAuthService(store *store.Store, secret string, metricReporter *metricreport.Reporter, profile *config.Profile) *AuthService {
+func NewAuthService(store *store.Store, dbFactory *dbfactory.DBFactory, secret string, metricReporter *metricreport.Reporter, schemaSyncer *schemasync.Syncer, profile *config.Profile) *AuthService {
 	return &AuthService{
 		store:          store,
+		dbFactory:      dbFactory,
 		secret:         secret,
 		metricReporter: metricReporter,
+		schemaSyncer:   schemaSyncer,
 		profile:        profile,
 	}
 }
@@ -96,6 +107,21 @@ func (s *AuthService) CreateUser(ctx context.Context, request *v1pb.CreateUserRe
 		return nil, status.Errorf(codes.Internal, "failed to generate password hash, error: %v", err)
 	}
 
+	existingUsers, err := s.store.ListUsers(ctx, &store.FindUserMessage{
+		ShowDeleted: true,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to find existing users, error: %v", err)
+	}
+
+	noExistingEndUser := true
+	for _, user := range existingUsers {
+		if user.Type == api.EndUser {
+			noExistingEndUser = false
+			break
+		}
+	}
+
 	user, err := s.store.CreateUser(ctx, &store.UserMessage{
 		Email:        request.User.Email,
 		Name:         request.User.Title,
@@ -104,6 +130,13 @@ func (s *AuthService) CreateUser(ctx context.Context, request *v1pb.CreateUserRe
 	}, api.SystemBotID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create user, error: %v", err)
+	}
+
+	// Only generates onbaording data after the first enduser signup.
+	if noExistingEndUser {
+		if err := s.generateOnboardingData(ctx, user.ID); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to prepare onboarding data, error: %v", err)
+		}
 	}
 
 	if user.ID == api.PrincipalIDForFirstUser && s.metricReporter != nil {
@@ -471,4 +504,69 @@ func (s *AuthService) getUserWithLoginRequestOfIdentityProvider(ctx context.Cont
 		return nil, status.Errorf(codes.Unauthenticated, "user has been deactivated by administrators")
 	}
 	return user, nil
+}
+
+// generateOnboardingData generates onboarding data after the first signup.
+func (s *AuthService) generateOnboardingData(ctx context.Context, userID int) error {
+	project, err := s.store.CreateProjectV2(ctx, &store.ProjectMessage{
+		ResourceID: "project-sample",
+		Title:      "Sample Project",
+		Key:        "SAM",
+		Workflow:   api.UIWorkflow,
+		Visibility: api.Public,
+		TenantMode: api.TenantModeDisabled,
+	}, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create onboarding project")
+	}
+
+	instance, err := s.store.CreateInstanceV2(ctx, api.DefaultTestEnvironmentID, &store.InstanceMessage{
+		ResourceID:   "postgres-sample",
+		Title:        "Postgres Sample Instance",
+		Engine:       db.Postgres,
+		ExternalLink: "",
+		DataSources: []*store.DataSourceMessage{
+			{
+				Title:              api.AdminDataSourceName,
+				Type:               api.Admin,
+				Username:           postgres.SampleUser,
+				ObfuscatedPassword: common.Obfuscate("", s.secret),
+				Host:               common.GetPostgresSocketDir(),
+				Port:               strconv.Itoa(s.profile.SampleDatabasePort),
+				Database:           postgres.SampleDatabase,
+			},
+		},
+	}, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create onboarding instance")
+	}
+
+	// Try creating the migration history database.
+	driver, err := s.dbFactory.GetAdminDatabaseDriver(ctx, instance, postgres.SampleDatabase)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect onboarding instance")
+	}
+	defer driver.Close(ctx)
+	if err := driver.SetupMigrationIfNeeded(ctx); err != nil {
+		return errors.Wrapf(err, "failed to set up migration schema on onboarding instance")
+	}
+
+	// Sync the instance schema so we can transfer the sample database later.
+	if _, err := s.schemaSyncer.SyncInstance(ctx, instance); err != nil {
+		return errors.Wrapf(err, "failed to sync onboarding instance")
+	}
+
+	// Transfer sample database to the just created project.
+	transferDatabaseMessage := &store.UpdateDatabaseMessage{
+		EnvironmentID: api.DefaultTestEnvironmentID,
+		InstanceID:    instance.ResourceID,
+		DatabaseName:  postgres.SampleDatabase,
+		ProjectID:     &project.ResourceID,
+	}
+	_, err = s.store.UpdateDatabase(ctx, transferDatabaseMessage, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to transfer sample database")
+	}
+
+	return nil
 }

--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -17,6 +17,7 @@ func getBaseProfile(dataDir string) config.Profile {
 		ExternalURL:          flags.externalURL,
 		GrpcPort:             flags.port + 1, // Using flags.port + 1 as our gRPC server port.
 		DatastorePort:        flags.port + 2, // Using flags.port + 2 as our datastore port.
+		SampleDatabasePort:   flags.port + 3, // Using flags.port + 3 as our sample database port.
 		Readonly:             flags.readonly,
 		DataDir:              dataDir,
 		ResourceDir:          common.GetResourceDir(dataDir),

--- a/backend/common/util.go
+++ b/backend/common/util.go
@@ -69,6 +69,11 @@ func GetPostgresDataDir(dataDir string, demoName string) string {
 	return path.Join(dataDir, "pgdata")
 }
 
+// GetPostgresSampleDataDir returns the data directory of postgres sample instance.
+func GetPostgresSampleDataDir(dataDir string) string {
+	return path.Join(dataDir, "pgdata-sample")
+}
+
 // GetPostgresSocketDir returns the postgres socket directory of Bytebase.
 func GetPostgresSocketDir() string {
 	return "/tmp"

--- a/backend/component/config/profile.go
+++ b/backend/component/config/profile.go
@@ -17,6 +17,8 @@ type Profile struct {
 	// DatastorePort is the binding port for database instance for storing Bytebase metadata.
 	// Only applicable when using embedded PG (PgURL is empty).
 	DatastorePort int
+	// SampleDatabasePort is the binding port for sample database instance.
+	SampleDatabasePort int
 	// GrpcPort is the binding port for gRPC server.
 	GrpcPort int
 	// PgUser is the user we use to connect to bytebase's Postgres database.

--- a/backend/legacyapi/project.go
+++ b/backend/legacyapi/project.go
@@ -15,6 +15,13 @@ const (
 	DefaultProjectUID = 1
 	// DefaultProjectID is the resource ID for the default project.
 	DefaultProjectID = "default"
+
+	// Below are defined in LATEST_DATA.sql.
+
+	// DefaultTestEnvironmentID is the initial resource ID for the default project.
+	// This can be mutated by the user. But for now this is only used by onboarding flow to create
+	// a test instance after first signup, so it's safe to refer it.
+	DefaultTestEnvironmentID = "test"
 )
 
 // ProjectWorkflowType is the workflow type for projects.

--- a/backend/resources/postgres/employee.sql
+++ b/backend/resources/postgres/employee.sql
@@ -1,0 +1,8 @@
+CREATE TABLE employee (
+    emp_no      SERIAL,
+    name TEXT NOT NULL,
+    PRIMARY KEY (emp_no)
+);
+
+INSERT INTO employee (name) VALUES ('Alice');
+INSERT INTO employee (name) VALUES ('Bob');

--- a/backend/tests/start_test.go
+++ b/backend/tests/start_test.go
@@ -27,9 +27,10 @@ func startStopServer(ctx context.Context, a *require.Assertions, ctl *controller
 	projects, err := ctl.getProjects()
 	a.NoError(err)
 
-	// Default project.
-	a.Equal(1, len(projects))
+	// Default + Sample project.
+	a.Equal(2, len(projects))
 	a.Equal("Default", projects[0].Name)
+	a.Equal("Sample Project", projects[1].Name)
 
 	err = ctl.Close(ctx)
 	a.NoError(err)

--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -256,6 +256,7 @@ func getTestProfile(dataDir, resourceDir string, port int, readOnly bool, feishu
 		ExternalURL:          fmt.Sprintf("http://localhost:%d", port),
 		GrpcPort:             port + 1,
 		DatastorePort:        port + 2,
+		SampleDatabasePort:   port + 3,
 		PgUser:               "bbtest",
 		Readonly:             readOnly,
 		DataDir:              dataDir,
@@ -272,9 +273,12 @@ func getTestProfile(dataDir, resourceDir string, port int, readOnly bool, feishu
 // pgURL for connect to Postgres.
 func getTestProfileWithExternalPg(dataDir, resourceDir string, port int, pgUser string, pgURL string, feishuAPIURL string) componentConfig.Profile {
 	return componentConfig.Profile{
-		Mode:                 testReleaseMode,
-		ExternalURL:          fmt.Sprintf("http://localhost:%d", port),
-		GrpcPort:             port + 1,
+		Mode:        testReleaseMode,
+		ExternalURL: fmt.Sprintf("http://localhost:%d", port),
+		GrpcPort:    port + 1,
+		// Not applicable for external Postgres.
+		// DatastorePort:        port + 2,
+		SampleDatabasePort:   port + 3,
 		PgUser:               pgUser,
 		DataDir:              dataDir,
 		ResourceDir:          resourceDir,


### PR DESCRIPTION
With this, the first signup user will have a ready-to-be used instance to play with

![CleanShot 2023-01-29 at 14 27 20](https://user-images.githubusercontent.com/230323/215309170-b3b15b4c-00ea-48fd-b87b-4f9e4c8e8f14.png)

![CleanShot 2023-01-29 at 14 28 13](https://user-images.githubusercontent.com/230323/215309188-00b89f18-5a75-4098-bd00-48f2abfc84b6.png)

### Implementation

* Always start a sample pg instance on startup, it will consume another port (--port + 3).
* Set up that sample database data, this PR contains the example data for an employee table. The sample data stays in a separate `pgdata-sample` dir
![CleanShot 2023-01-29 at 14 34 27](https://user-images.githubusercontent.com/230323/215309438-2db2a7d6-7163-4dba-b623-eb024d768022.png)

* Generate onboarding data after the first user signup, create a sample project, transfer the sample database to that project and etc.

### Remaining work

* Generate more fruitful sample data.
* Clean up the existing sample database creation using hard-coded 23333.
* Implement the onboarding flow based on this sample instance.

Fix BYT-1815