### PR TITLE
feat: generate more onboarding data

### DIFF
--- a/backend/legacyapi/project.go
+++ b/backend/legacyapi/project.go
@@ -18,10 +18,10 @@ const (
 
 	// Below are defined in LATEST_DATA.sql.
 
-	// DefaultTestEnvironmentID is the initial resource ID for the default project.
+	// DefaultProdEnvironmentID is the initial resource ID for the prod environment.
 	// This can be mutated by the user. But for now this is only used by onboarding flow to create
-	// a test instance after first signup, so it's safe to refer it.
-	DefaultTestEnvironmentID = "test"
+	// a prod instance after first signup, so it's safe to refer it.
+	DefaultProdEnvironmentID = "prod"
 )
 
 // ProjectWorkflowType is the workflow type for projects.

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -3,9 +3,11 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/google/uuid"
+	"github.com/gosimple/slug"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/labstack/echo-contrib/pprof"
@@ -28,8 +31,10 @@ import (
 	echoSwagger "github.com/swaggo/echo-swagger"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
 
@@ -47,6 +52,7 @@ import (
 	"github.com/bytebase/bytebase/backend/metric"
 	metricCollector "github.com/bytebase/bytebase/backend/metric/collector"
 	"github.com/bytebase/bytebase/backend/plugin/app/feishu"
+	"github.com/bytebase/bytebase/backend/plugin/db"
 	bbs3 "github.com/bytebase/bytebase/backend/plugin/storage/s3"
 	"github.com/bytebase/bytebase/backend/resources/mongoutil"
 	"github.com/bytebase/bytebase/backend/resources/mysqlutil"
@@ -449,7 +455,16 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 	s.grpcServer = grpc.NewServer(
 		grpc.ChainUnaryInterceptor(authProvider.AuthenticationInterceptor, aclProvider.ACLInterceptor),
 	)
-	v1pb.RegisterAuthServiceServer(s.grpcServer, v1.NewAuthService(s.store, s.dbFactory, s.secret, s.MetricReporter, s.SchemaSyncer, &profile))
+	v1pb.RegisterAuthServiceServer(s.grpcServer, v1.NewAuthService(s.store, s.secret, s.MetricReporter, &profile,
+		func(ctx context.Context, user *store.UserMessage, firstEndUser bool) error {
+			// Only generate onboarding data after the first enduser signup.
+			if firstEndUser {
+				if err := s.generateOnboardingData(ctx, user.ID); err != nil {
+					return status.Errorf(codes.Internal, "failed to prepare onboarding data, error: %v", err)
+				}
+			}
+			return nil
+		}))
 	v1pb.RegisterEnvironmentServiceServer(s.grpcServer, v1.NewEnvironmentService(s.store, s.licenseService))
 	v1pb.RegisterInstanceServiceServer(s.grpcServer, v1.NewInstanceService(s.store, s.licenseService, s.secret))
 	v1pb.RegisterProjectServiceServer(s.grpcServer, v1.NewProjectService(s.store))
@@ -730,4 +745,139 @@ func (s *Server) GetEcho() *echo.Echo {
 // GetWorkspaceID returns the workspace id.
 func (s *Server) GetWorkspaceID() string {
 	return s.workspaceID
+}
+
+// generateOnboardingData generates onboarding data after the first signup.
+func (s *Server) generateOnboardingData(ctx context.Context, userID int) error {
+	project, err := s.store.CreateProjectV2(ctx, &store.ProjectMessage{
+		ResourceID: "project-sample",
+		Title:      "Sample Project",
+		Key:        "SAM",
+		Workflow:   api.UIWorkflow,
+		Visibility: api.Public,
+		TenantMode: api.TenantModeDisabled,
+	}, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create onboarding project")
+	}
+
+	instance, err := s.store.CreateInstanceV2(ctx, api.DefaultProdEnvironmentID, &store.InstanceMessage{
+		ResourceID:   "postgres-sample",
+		Title:        "Postgres Sample Instance",
+		Engine:       db.Postgres,
+		ExternalLink: "",
+		DataSources: []*store.DataSourceMessage{
+			{
+				Title:              api.AdminDataSourceName,
+				Type:               api.Admin,
+				Username:           postgres.SampleUser,
+				ObfuscatedPassword: common.Obfuscate("", s.secret),
+				Host:               common.GetPostgresSocketDir(),
+				Port:               strconv.Itoa(s.profile.SampleDatabasePort),
+				Database:           postgres.SampleDatabase,
+			},
+		},
+	}, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create onboarding instance")
+	}
+
+	// Try creating the migration history database.
+	driver, err := s.dbFactory.GetAdminDatabaseDriver(ctx, instance, postgres.SampleDatabase)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect onboarding instance")
+	}
+	defer driver.Close(ctx)
+	if err := driver.SetupMigrationIfNeeded(ctx); err != nil {
+		return errors.Wrapf(err, "failed to set up migration schema on onboarding instance")
+	}
+
+	// Sync the instance schema so we can transfer the sample database later.
+	if _, err := s.SchemaSyncer.SyncInstance(ctx, instance); err != nil {
+		return errors.Wrapf(err, "failed to sync onboarding instance")
+	}
+
+	// Transfer sample database to the just created project.
+	transferDatabaseMessage := &store.UpdateDatabaseMessage{
+		EnvironmentID: api.DefaultProdEnvironmentID,
+		InstanceID:    instance.ResourceID,
+		DatabaseName:  postgres.SampleDatabase,
+		ProjectID:     &project.ResourceID,
+	}
+	_, err = s.store.UpdateDatabase(ctx, transferDatabaseMessage, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to transfer sample database")
+	}
+
+	dbName := postgres.SampleDatabase
+	database, err := s.store.GetDatabaseV2(ctx, &store.FindDatabaseMessage{
+		InstanceID:   &instance.ResourceID,
+		DatabaseName: &dbName,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find onboarding instance")
+	}
+
+	// Need to sync database schema so we can create the schema update issue later.
+	if err := s.SchemaSyncer.SyncDatabaseSchema(ctx, database, true /* force */); err != nil {
+		return errors.Wrapf(err, "failed to sync sample database schema")
+	}
+
+	// Create a schema update issue.
+	createContext, err := json.Marshal(
+		&api.MigrationContext{
+			DetailList: []*api.MigrationDetail{
+				{
+					MigrationType: db.Migrate,
+					DatabaseID:    database.UID,
+					Statement:     "ALTER TABLE Salary ADD COLUMN IF NOT EXISTS email TEXT;",
+				},
+			},
+		})
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal sample schema update issue context")
+	}
+
+	issueCreate := &api.IssueCreate{
+		ProjectID: project.UID,
+		Name:      "[Sample] Add email column to Salary table",
+		Type:      api.IssueDatabaseSchemaUpdate,
+		Description: `A sample issue to showcase how to review database schema change.
+		
+Click "Approve" button to apply the schema update.`,
+		AssigneeID:    userID,
+		CreateContext: string(createContext),
+	}
+
+	issue, err := s.createIssue(ctx, issueCreate, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create sample issue")
+	}
+
+	// Bookmark the issue.
+	if _, err := s.store.CreateBookmark(ctx, &api.BookmarkCreate{
+		CreatorID: userID,
+		Name:      issue.Name,
+		Link:      fmt.Sprintf("/issue/%s-%d", slug.Make(issue.Name), issue.ID),
+	}); err != nil {
+		return errors.Wrapf(err, "failed to bookmark sample issue")
+	}
+
+	// Create a SQL sheet with sample queries.
+	sheetCreate := &api.SheetCreate{
+		CreatorID:  userID,
+		ProjectID:  project.UID,
+		DatabaseID: &database.UID,
+		Name:       "Sample Sheet",
+		Statement:  "SELECT * FROM Salary;",
+		Visibility: api.ProjectSheet,
+		Source:     api.SheetFromBytebase,
+		Type:       api.SheetForSQL,
+	}
+	_, err = s.store.CreateSheet(ctx, sheetCreate)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create sample sheet")
+	}
+
+	return nil
 }

--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -71,7 +71,6 @@ import { idFromSlug } from "../utils";
 import {
   useCurrentUser,
   useRouterStore,
-  useUIStateStore,
   useBookmarkStore,
   useDatabaseStore,
   useProjectStore,
@@ -221,12 +220,7 @@ export default defineComponent({
           name: breadcrumbList.value[breadcrumbList.value.length - 1].name,
           link: currentRoute.value.path,
         };
-        bookmarkStore.createBookmark(newBookmark).then(() => {
-          useUIStateStore().saveIntroStateByKey({
-            key: "bookmark.create",
-            newState: true,
-          });
-        });
+        bookmarkStore.createBookmark(newBookmark);
       }
     };
 

--- a/frontend/src/components/Issue/IssueActivityPanel.vue
+++ b/frontend/src/components/Issue/IssueActivityPanel.vue
@@ -365,7 +365,6 @@ import { IssueBuiltinFieldId } from "@/plugins";
 import { useI18n } from "vue-i18n";
 import {
   useCurrentUser,
-  useUIStateStore,
   useIssueSubscriberStore,
   useActivityStore,
 } from "@/store";
@@ -503,11 +502,6 @@ const doCreateComment = (comment: string, clear = true) => {
     comment,
   };
   activityStore.createActivity(createActivity).then(() => {
-    useUIStateStore().saveIntroStateByKey({
-      key: "comment.create",
-      newState: true,
-    });
-
     if (clear) {
       newComment.value = "";
       nextTick(() => sizeToFit(newCommentTextArea.value));

--- a/frontend/src/components/ProfileDropdown.vue
+++ b/frontend/src/components/ProfileDropdown.vue
@@ -157,8 +157,7 @@ export default defineComponent({
 
     const resetQuickstart = () => {
       const keys = [
-        "bookmark.create",
-        "comment.create",
+        "issue.visit",
         "project.visit",
         "environment.visit",
         "instance.visit",

--- a/frontend/src/components/Quickstart.vue
+++ b/frontend/src/components/Quickstart.vue
@@ -82,16 +82,9 @@ export default defineComponent({
 
     const introList: IntroItem[] = [
       {
-        name: computed(() => t("quick-start.bookmark-an-issue")),
-        link: "/issue/hello-world-101",
-        done: computed(() =>
-          uiStateStore.getIntroStateByKey("bookmark.create")
-        ),
-      },
-      {
-        name: computed(() => t("quick-start.add-a-comment")),
-        link: "/issue/hello-world-101#activity14001",
-        done: computed(() => uiStateStore.getIntroStateByKey("comment.create")),
+        name: computed(() => t("quick-start.view-an-issue")),
+        link: "/issue/101",
+        done: computed(() => uiStateStore.getIntroStateByKey("issue.visit")),
       },
       {
         name: computed(() => t("quick-start.visit-project")),

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -776,8 +776,7 @@
     "protected-environment": "Protected environment"
   },
   "quick-start": {
-    "bookmark-an-issue": "Bookmark an issue",
-    "add-a-comment": "Add a comment",
+    "view-an-issue": "View an issue",
     "visit-project": "@:common.visit @:common.projects",
     "visit-instance": "@:common.visit @:common.instances",
     "visit-database": "@:common.visit @:common.databases",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -776,8 +776,7 @@
     "protected-environment": "受保护的环境"
   },
   "quick-start": {
-    "bookmark-an-issue": "收藏工单",
-    "add-a-comment": "添加评论",
+    "view-an-issue": "查看工单",
     "visit-project": "@:common.visit@:common.projects",
     "visit-instance": "@:common.visit@:common.instances",
     "visit-database": "@:common.visit@:common.databases",

--- a/frontend/src/views/IssueDetail.vue
+++ b/frontend/src/views/IssueDetail.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, reactive, watch } from "vue";
+import { onMounted, computed, reactive, watch } from "vue";
 import { useRoute, _RouteLocationBase } from "vue-router";
 import { NSpin } from "naive-ui";
 import { IssueDetailLayout } from "@/components/Issue";
@@ -34,7 +34,12 @@ import {
   UNKNOWN_ID,
   Issue,
 } from "@/types";
-import { hasFeature, useIssueStore, useProjectStore } from "@/store";
+import {
+  hasFeature,
+  useIssueStore,
+  useProjectStore,
+  useUIStateStore,
+} from "@/store";
 import { useInitializeIssue, usePollIssue } from "@/plugins/issue/logic";
 import { useTitle } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
@@ -50,6 +55,7 @@ const props = defineProps({
   },
 });
 
+const uiStateStore = useUIStateStore();
 const route = useRoute();
 const { t } = useI18n();
 
@@ -68,6 +74,15 @@ const showLoading = computed(() => {
 });
 
 const pollIssue = usePollIssue(issueSlug, issue);
+
+onMounted(() => {
+  if (!uiStateStore.getIntroStateByKey("issue.visit")) {
+    uiStateStore.saveIntroStateByKey({
+      key: "issue.visit",
+      newState: true,
+    });
+  }
+});
 
 watch(issueSlug, async () => {
   if (!create.value) return;


### PR DESCRIPTION
* Create a schema update issue
* Bookmark the issue
* Create a sheet

Accordingly, the PR also changes:

* Move the onboarding logic to a postCreateUser callback, otherwise, it would be hard to call the server.CreateIssue
* Create the sample instance under prod environment, so that user can click `approve` to review the schema change
* Simplify Quickstart panel, remove `bookmark an issue` and `add a comment`. And add "Visit an issue".

Fix BYT-1815