### PR TITLE
feat(sql-editor): query history improvement

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1456,7 +1456,8 @@
       "self": "Admin mode"
     },
     "read-only-mode-not-allowed": "Instance {instance} is not accessible in read-only mode.",
-    "run-selected": "Run selected"
+    "run-selected": "Run selected",
+    "clear-history": "Clear history"
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1456,7 +1456,8 @@
       "self": "管理员模式"
     },
     "read-only-mode-not-allowed": "实例{instance}无法通过只读模式访问。",
-    "run-selected": "运行选中的语句"
+    "run-selected": "运行选中的语句",
+    "clear-history": "清除历史"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/store/modules/webTerminal.ts
+++ b/frontend/src/store/modules/webTerminal.ts
@@ -1,27 +1,36 @@
-import { reactive } from "vue";
+import { reactive, ref } from "vue";
 import { defineStore } from "pinia";
+import { uniqueId } from "lodash-es";
+
 import type { TabInfo, WebTerminalQueryItem } from "@/types";
 
-const createInitialQueryItemByTab = (tab: TabInfo): WebTerminalQueryItem => ({
-  sql: tab.statement,
-  status: "IDLE",
+const createInitialQueryItemByTab = (tab: TabInfo): WebTerminalQueryItem => {
+  return createQueryItem(tab.statement);
+};
+
+export const createQueryItem = (
+  sql = "",
+  status: WebTerminalQueryItem["status"] = "IDLE"
+): WebTerminalQueryItem => ({
+  id: uniqueId(),
+  sql,
+  status,
 });
 
 export const useWebTerminalStore = defineStore("webTerminal", () => {
-  const map = new Map<string, WebTerminalQueryItem[]>();
+  const map = ref(new Map<string, WebTerminalQueryItem[]>());
 
   const getQueryListByTab = (tab: TabInfo) => {
-    const existed = map.get(tab.id);
+    const existed = map.value.get(tab.id);
     if (existed) return existed;
 
     const init = reactive([createInitialQueryItemByTab(tab)]);
-    // TODO(Jim): watch the length of the list, shift the oldest one if len>20 (maybe)
-    map.set(tab.id, init);
+    map.value.set(tab.id, init);
     return init;
   };
 
   const clearQueryListByTab = (tab: TabInfo) => {
-    map.delete(tab.id);
+    map.value.delete(tab.id);
   };
 
   return { getQueryListByTab, clearQueryListByTab };

--- a/frontend/src/types/webTerminal.ts
+++ b/frontend/src/types/webTerminal.ts
@@ -2,6 +2,7 @@ import { SQLResultSet } from "./sqlAdvice";
 import { ExecuteConfig, ExecuteOption } from "./tab";
 
 export type WebTerminalQueryItem = {
+  id: string;
   sql: string;
   executeParams?: {
     query: string;

--- a/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
@@ -22,6 +22,13 @@
       >
         {{ $t("sql-editor.format") }} (⇧+⌥+F)
       </NButton>
+      <NButton
+        v-if="showClearHistory"
+        :disabled="queryList.length <= 1 || isExecutingSQL"
+        @click="handleClearHistory"
+      >
+        {{ $t("sql-editor.clear-history") }} (⇧+⌥+C)
+      </NButton>
     </div>
     <div class="action-right space-x-2 flex justify-end items-center">
       <AdminModeButton />
@@ -64,6 +71,7 @@ import {
   useTabStore,
   useSQLEditorStore,
   useInstanceById,
+  useWebTerminalStore,
 } from "@/store";
 import type { ExecuteConfig, ExecuteOption } from "@/types";
 import { TabMode, UNKNOWN_ID } from "@/types";
@@ -78,11 +86,13 @@ const emit = defineEmits<{
     config: ExecuteConfig,
     option?: ExecuteOption
   ): void;
+  (e: "clear-history"): void;
 }>();
 
 const instanceStore = useInstanceStore();
 const tabStore = useTabStore();
 const sqlEditorStore = useSQLEditorStore();
+const webTerminalStore = useWebTerminalStore();
 
 const connection = computed(() => tabStore.currentTab.connection);
 
@@ -127,6 +137,14 @@ const allowSave = computed(() => {
   return true;
 });
 
+const showClearHistory = computed(() => {
+  return tabStore.currentTab.mode === TabMode.Admin;
+});
+
+const queryList = computed(() => {
+  return webTerminalStore.getQueryListByTab(tabStore.currentTab);
+});
+
 const handleRunQuery = async () => {
   const currentTab = tabStore.currentTab;
   const statement = currentTab.statement;
@@ -150,5 +168,9 @@ const handleExplainQuery = () => {
 
 const handleFormatSQL = () => {
   sqlEditorStore.setShouldFormatContent(true);
+};
+
+const handleClearHistory = () => {
+  emit("clear-history");
 };
 </script>

--- a/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
@@ -54,6 +54,7 @@ const emit = defineEmits<{
     option?: ExecuteOption
   ): void;
   (e: "history", direction: "up" | "down"): void;
+  (e: "clear-history"): void;
 }>();
 
 const MIN_EDITOR_HEIGHT = 40; // ~= 1 line
@@ -171,9 +172,23 @@ const handleEditorReady = async () => {
   editor?.addAction({
     id: "ExplainQuery",
     label: "Explain Query",
+    keybindings: [
+      monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyC,
+    ],
+    contextMenuGroupId: "operation",
+    contextMenuOrder: 2,
+    precondition: "!readonly",
+    run: () => {
+      emit("clear-history");
+    },
+  });
+
+  editor?.addAction({
+    id: "ClearHistory",
+    label: "Clear History",
     keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyE],
     contextMenuGroupId: "operation",
-    contextMenuOrder: 0,
+    contextMenuOrder: 3,
     precondition: "!readonly",
     run: async () => {
       emit(


### PR DESCRIPTION
### Changes

- Limit maximum query history count to 20 to prevent memory inflation.
- Add a button and keyboard shortcut to clear query history. (Close BYT-1919)