### PR TITLE
feat(sql-editor): split history items and query items

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1466,7 +1466,7 @@
     },
     "read-only-mode-not-allowed": "Instance {instance} is not accessible in read-only mode.",
     "run-selected": "Run selected",
-    "clear-history": "Clear history"
+    "clear-screen": "Clear screen"
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1466,7 +1466,7 @@
     },
     "read-only-mode-not-allowed": "实例{instance}无法通过只读模式访问。",
     "run-selected": "运行选中的语句",
-    "clear-history": "清除历史"
+    "clear-screen": "清屏"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
@@ -23,11 +23,11 @@
         {{ $t("sql-editor.format") }} (⇧+⌥+F)
       </NButton>
       <NButton
-        v-if="showClearHistory"
+        v-if="showClearScreen"
         :disabled="queryList.length <= 1 || isExecutingSQL"
-        @click="handleClearHistory"
+        @click="handleClearScreen"
       >
-        {{ $t("sql-editor.clear-history") }} (⇧+⌥+C)
+        {{ $t("sql-editor.clear-screen") }} (⇧+⌥+C)
       </NButton>
     </div>
     <div class="action-right space-x-2 flex justify-end items-center">
@@ -86,7 +86,7 @@ const emit = defineEmits<{
     config: ExecuteConfig,
     option?: ExecuteOption
   ): void;
-  (e: "clear-history"): void;
+  (e: "clear-screen"): void;
 }>();
 
 const instanceStore = useInstanceStore();
@@ -137,7 +137,7 @@ const allowSave = computed(() => {
   return true;
 });
 
-const showClearHistory = computed(() => {
+const showClearScreen = computed(() => {
   return tabStore.currentTab.mode === TabMode.Admin;
 });
 
@@ -170,7 +170,7 @@ const handleFormatSQL = () => {
   sqlEditorStore.setShouldFormatContent(true);
 };
 
-const handleClearHistory = () => {
-  emit("clear-history");
+const handleClearScreen = () => {
+  emit("clear-screen");
 };
 </script>

--- a/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
@@ -54,7 +54,7 @@ const emit = defineEmits<{
     option?: ExecuteOption
   ): void;
   (e: "history", direction: "up" | "down"): void;
-  (e: "clear-history"): void;
+  (e: "clear-screen"): void;
 }>();
 
 const MIN_EDITOR_HEIGHT = 40; // ~= 1 line
@@ -172,31 +172,33 @@ const handleEditorReady = async () => {
   editor?.addAction({
     id: "ExplainQuery",
     label: "Explain Query",
-    keybindings: [
-      monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyC,
-    ],
-    contextMenuGroupId: "operation",
-    contextMenuOrder: 2,
-    precondition: "!readonly",
-    run: () => {
-      emit("clear-history");
-    },
-  });
-
-  editor?.addAction({
-    id: "ClearHistory",
-    label: "Clear History",
     keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyE],
     contextMenuGroupId: "operation",
-    contextMenuOrder: 3,
+    contextMenuOrder: 1,
     precondition: "!readonly",
     run: async () => {
       emit(
         "execute",
         props.sql,
-        { databaseType: selectedInstanceEngine.value },
+        {
+          databaseType: selectedInstanceEngine.value,
+        },
         { explain: true }
       );
+    },
+  });
+
+  editor?.addAction({
+    id: "ClearScreen",
+    label: "Clear Screen",
+    keybindings: [
+      monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyC,
+    ],
+    contextMenuGroupId: "operation",
+    contextMenuOrder: 3,
+    precondition: "!readonly",
+    run: () => {
+      emit("clear-screen");
     },
   });
 

--- a/frontend/src/views/sql-editor/TerminalPanel/useHistory.ts
+++ b/frontend/src/views/sql-editor/TerminalPanel/useHistory.ts
@@ -4,6 +4,8 @@ import { TabMode } from "@/types";
 import { useTabStore, useWebTerminalStore } from "@/store";
 import { minmax } from "@/utils";
 
+const MAX_HISTORY_ITEM_COUNT = 1000;
+
 type HistoryItem = {
   statement: string;
 };
@@ -42,8 +44,12 @@ export const useHistory = () => {
   const push = (item: HistoryItem) => {
     const stack = currentStack();
     if (!stack) return;
-    stack.list.push(item);
-    stack.index = stack.list.length - 1;
+    const { list } = stack;
+    list.push(item);
+    if (list.length > MAX_HISTORY_ITEM_COUNT) {
+      list.shift();
+    }
+    stack.index = list.length - 1;
   };
 
   const move = (direction: "up" | "down") => {

--- a/frontend/src/views/sql-editor/TerminalPanel/useHistory.ts
+++ b/frontend/src/views/sql-editor/TerminalPanel/useHistory.ts
@@ -1,18 +1,14 @@
 import { computed, watch } from "vue";
 
-import { TabMode } from "@/types";
+import { TabMode, WebTerminalQueryItem } from "@/types";
 import { useTabStore, useWebTerminalStore } from "@/store";
 import { minmax } from "@/utils";
 
 const MAX_HISTORY_ITEM_COUNT = 1000;
 
-type HistoryItem = {
-  statement: string;
-};
-
 type HistoryState = {
   index: number;
-  list: HistoryItem[];
+  list: WebTerminalQueryItem[];
 };
 
 export const useHistory = () => {
@@ -41,11 +37,11 @@ export const useHistory = () => {
     return initial;
   };
 
-  const push = (item: HistoryItem) => {
+  const push = (query: WebTerminalQueryItem) => {
     const stack = currentStack();
     if (!stack) return;
     const { list } = stack;
-    list.push(item);
+    list.push(query);
     if (list.length > MAX_HISTORY_ITEM_COUNT) {
       list.shift();
     }
@@ -64,9 +60,9 @@ export const useHistory = () => {
     if (nextIndex === list.length - 1) {
       currentQuery.value.sql = "";
     } else {
-      const history = list[nextIndex];
-      if (history) {
-        currentQuery.value.sql = history.statement;
+      const historyQuery = list[nextIndex];
+      if (historyQuery) {
+        currentQuery.value.sql = historyQuery.sql;
       }
     }
 
@@ -76,7 +72,7 @@ export const useHistory = () => {
   watch(
     () => currentQuery.value,
     (query) => {
-      push({ statement: query.sql });
+      push(query);
     },
     {
       immediate: true,

--- a/frontend/src/views/sql-editor/TerminalPanel/useHistory.ts
+++ b/frontend/src/views/sql-editor/TerminalPanel/useHistory.ts
@@ -1,0 +1,81 @@
+import { computed, watch } from "vue";
+
+import { TabMode } from "@/types";
+import { useTabStore, useWebTerminalStore } from "@/store";
+import { minmax } from "@/utils";
+
+type HistoryItem = {
+  statement: string;
+};
+
+type HistoryState = {
+  index: number;
+  list: HistoryItem[];
+};
+
+export const useHistory = () => {
+  const tabStore = useTabStore();
+  const webTerminalStore = useWebTerminalStore();
+  const historyByTabId = new Map<string, HistoryState>();
+
+  const currentQuery = computed(() => {
+    const queryList = webTerminalStore.getQueryListByTab(tabStore.currentTab);
+    return queryList[queryList.length - 1];
+  });
+
+  const currentStack = () => {
+    const tab = tabStore.currentTab;
+    if (tab.mode === TabMode.ReadOnly) return undefined;
+
+    const existed = historyByTabId.get(tab.id);
+    if (existed) {
+      return existed;
+    }
+    const initial: HistoryState = {
+      index: -1,
+      list: [],
+    };
+    historyByTabId.set(tab.id, initial);
+    return initial;
+  };
+
+  const push = (item: HistoryItem) => {
+    const stack = currentStack();
+    if (!stack) return;
+    stack.list.push(item);
+    stack.index = stack.list.length - 1;
+  };
+
+  const move = (direction: "up" | "down") => {
+    const stack = currentStack();
+    if (!stack) return;
+    const { index, list } = stack;
+    const delta = direction === "up" ? -1 : 1;
+    const nextIndex = minmax(index + delta, 0, list.length - 1);
+    if (nextIndex === index) {
+      return;
+    }
+    if (nextIndex === list.length - 1) {
+      currentQuery.value.sql = "";
+    } else {
+      const history = list[nextIndex];
+      if (history) {
+        currentQuery.value.sql = history.statement;
+      }
+    }
+
+    stack.index = nextIndex;
+  };
+
+  watch(
+    () => currentQuery.value,
+    (query) => {
+      push({ statement: query.sql });
+    },
+    {
+      immediate: true,
+    }
+  );
+
+  return { push, move };
+};


### PR DESCRIPTION
Close BYT-2448
FYI @tianzhou 

### Changes

- Split history items and query items.
- Display up to 20 query items (per tab) on the screen to prevent consuming hundreds of megabytes of system memory.
- Remember up to 1000 history items (per tab) for cmd+up/down searching. (not persistent, will lose after refreshing the page).
- Rename "Clear history" to "Clear screen". It will only clear the query items on the screen but keep statements searchable via cmd+up/down. (like `clear` or `cls` in an actual terminal).