### PR TITLE
feat(frontend): support drag-and-drop to upload SSL certification file

### DIFF
--- a/frontend/src/components/InstanceForm/SslCertificateForm.vue
+++ b/frontend/src/components/InstanceForm/SslCertificateForm.vue
@@ -18,10 +18,10 @@
       :tab="$t('data-source.ssl.ca-cert')"
       display-directive="show"
     >
-      <textarea
-        v-model="state.value.sslCa"
-        class="textarea block w-full resize-none whitespace-pre-wrap h-24"
-        placeholder="YOUR_CA_CERTIFICATE"
+      <DroppableTextarea
+        v-model:value="state.value.sslCa"
+        class="block w-full resize-none whitespace-pre-wrap h-24"
+        placeholder="Input or drag and drop YOUR_CA_CERTIFICATE"
       />
     </NTabPane>
     <NTabPane
@@ -30,10 +30,10 @@
       :tab="$t('data-source.ssl.client-key')"
       display-directive="show"
     >
-      <textarea
-        v-model="state.value.sslKey"
-        class="textarea block w-full resize-none whitespace-pre-wrap h-24"
-        placeholder="YOUR_CLIENT_KEY"
+      <DroppableTextarea
+        v-model:value="state.value.sslKey"
+        class="block w-full resize-none whitespace-pre-wrap h-24"
+        placeholder="Input or drag and drop YOUR_CLIENT_KEY"
       />
     </NTabPane>
     <NTabPane
@@ -42,10 +42,10 @@
       :tab="$t('data-source.ssl.client-cert')"
       display-directive="show"
     >
-      <textarea
-        v-model="state.value.sslCert"
-        class="textarea block w-full resize-none whitespace-pre-wrap h-24"
-        placeholder="YOUR_CLIENT_CERT"
+      <DroppableTextarea
+        v-model:value="state.value.sslCert"
+        class="block w-full resize-none whitespace-pre-wrap h-24"
+        placeholder="Input or drag and drop YOUR_CLIENT_CERT"
       />
     </NTabPane>
   </NTabs>
@@ -56,6 +56,8 @@ import { PropType, reactive, watch } from "vue";
 import { NTabs, NTabPane } from "naive-ui";
 import { useI18n } from "vue-i18n";
 import { cloneDeep } from "lodash-es";
+
+import DroppableTextarea from "../misc/DroppableTextarea.vue";
 
 const SslTypes = ["NONE", "CA", "CA+KEY+CERT"] as const;
 

--- a/frontend/src/components/misc/DroppableTextarea.vue
+++ b/frontend/src/components/misc/DroppableTextarea.vue
@@ -1,0 +1,111 @@
+<template>
+  <div
+    ref="container"
+    class="relative"
+    :class="[state.reading && 'pointer-events-none']"
+  >
+    <textarea
+      v-model="state.value"
+      class="textarea"
+      :placeholder="placeholder"
+      v-bind="$attrs"
+    />
+
+    <div
+      v-if="isOverDropZone || state.reading"
+      class="absolute inset-0 pointer-events-none flex flex-col items-center justify-center bg-white/50 border border-accent border-dashed"
+    >
+      <heroicons-outline:arrow-up-tray v-if="isOverDropZone" class="w-8 h-8" />
+      <BBSpin v-if="state.reading" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  inheritAttrs: false,
+};
+</script>
+
+<script lang="ts" setup>
+import { reactive, ref, watch } from "vue";
+import { useDropZone } from "@vueuse/core";
+import { head } from "lodash-es";
+import { useI18n } from "vue-i18n";
+
+import { pushNotification } from "@/store";
+import { BBSpin } from "@/bbkit";
+
+type LocalState = {
+  value: string | undefined;
+  reading: boolean;
+};
+
+const props = withDefaults(
+  defineProps<{
+    value: string | undefined;
+    placeholder?: string;
+    maxFileSize?: number; // in MB
+  }>(),
+  {
+    placeholder: undefined,
+    maxFileSize: 1,
+  }
+);
+
+const emit = defineEmits<{
+  (name: "update:value", value: string | undefined): void;
+}>();
+
+const { t } = useI18n();
+const state = reactive<LocalState>({
+  value: props.value,
+  reading: false,
+});
+const container = ref<HTMLDivElement>();
+
+watch(
+  () => props.value,
+  (value) => (state.value = value)
+);
+
+watch(
+  () => state.value,
+  (value) => emit("update:value", value)
+);
+
+const onDrop = (files: File[] | null) => {
+  // called when files are dropped on zone
+  const file = head(files);
+  if (file) {
+    const { maxFileSize } = props;
+    if (maxFileSize > 0 && file.size > maxFileSize * 1024 * 1024) {
+      pushNotification({
+        module: "bytebase",
+        style: "WARN",
+        title: t("common.file-selector.size-limit", { size: maxFileSize }),
+      });
+      return;
+    }
+    const fr = new FileReader();
+    fr.addEventListener("load", (e) => {
+      emit("update:value", fr.result as string);
+      state.reading = false;
+    });
+    fr.addEventListener("error", () => {
+      pushNotification({
+        module: "bytebase",
+        style: "WARN",
+        title: `Read file error`,
+        description: String(fr.error),
+      });
+      state.reading = false;
+      return;
+    });
+    state.reading = true;
+    fr.readAsText(file);
+  }
+};
+
+const { isOverDropZone } = useDropZone(container, onDrop);
+</script>


### PR DESCRIPTION
Close BYT-2253
This is a quick way to support uploading files without changing UI too much. FYI @Candybase 

Support file size up to 1MB (cert files are tens of KBs typically, so this is fairly enough).

### Screenshots

https://user-images.githubusercontent.com/2749742/216528711-95876380-862c-4403-95ab-eebd1233da1f.mp4

