### PR TITLE
chore(sql-editor): default name of admin tab

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/AdminModeButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/AdminModeButton.vue
@@ -15,7 +15,10 @@ import { computed } from "vue";
 
 import { TabMode } from "@/types";
 import { useCurrentUser, useTabStore, useWebTerminalStore } from "@/store";
-import { hasWorkspacePermission } from "@/utils";
+import {
+  getDefaultTabNameFromConnection,
+  hasWorkspacePermission,
+} from "@/utils";
 import { last } from "lodash-es";
 
 const emit = defineEmits<{
@@ -44,6 +47,7 @@ const enterAdminMode = () => {
   const target = {
     connection: current.connection,
     mode: TabMode.Admin,
+    name: getDefaultTabNameFromConnection(current.connection),
   };
   tabStore.selectOrAddSimilarTab(target, /* beside */ true);
   tabStore.updateCurrentTab({


### PR DESCRIPTION
This won't be displayed but will be used as part of the filename while exporting query results.

Close BYT-2480