### PR TITLE
fix(frontend): migration history cannot filter by ID as spanner's ID is UUID, use sequence

### DIFF
--- a/frontend/src/views/MigrationHistoryDetail.vue
+++ b/frontend/src/views/MigrationHistoryDetail.vue
@@ -300,7 +300,15 @@ export default defineComponent({
         instanceStore.fetchInstanceList();
       }
 
-      return migrationHistoryList.filter((mh) => mh.id <= migrationHistoryId);
+      // The returned migration history list has been ordered by `sequence` DESC.
+      // We can obtain prevMigrationHistoryList by cutting up the array by the `migrationHistoryId`.
+      let met = false;
+      return migrationHistoryList.filter((mh) => {
+        if (mh.id === migrationHistoryId) {
+          met = true;
+        }
+        return met;
+      });
     });
 
     // migrationHistory is the latest migration NOW.

--- a/frontend/src/views/MigrationHistoryDetail.vue
+++ b/frontend/src/views/MigrationHistoryDetail.vue
@@ -302,13 +302,13 @@ export default defineComponent({
 
       // The returned migration history list has been ordered by `id` DESC or (`namespace` ASC, `sequence` DESC) .
       // We can obtain prevMigrationHistoryList by cutting up the array by the `migrationHistoryId`.
-      let met = false;
-      return migrationHistoryList.filter((mh) => {
-        if (mh.id === migrationHistoryId) {
-          met = true;
-        }
-        return met;
-      });
+      const idx = migrationHistoryList.findIndex(
+        (mh) => mh.id === migrationHistoryId
+      );
+      if (idx === -1) {
+        return [];
+      }
+      return migrationHistoryList.slice(idx);
     });
 
     // migrationHistory is the latest migration NOW.

--- a/frontend/src/views/MigrationHistoryDetail.vue
+++ b/frontend/src/views/MigrationHistoryDetail.vue
@@ -300,7 +300,7 @@ export default defineComponent({
         instanceStore.fetchInstanceList();
       }
 
-      // The returned migration history list has been ordered by `sequence` DESC.
+      // The returned migration history list has been ordered by `id` DESC or (`namespace` ASC, `sequence` DESC) .
       // We can obtain prevMigrationHistoryList by cutting up the array by the `migrationHistoryId`.
       let met = false;
       return migrationHistoryList.filter((mh) => {


### PR DESCRIPTION
The ID field is UUID for spanner, so we can't use ID to get the previous migration history list. Fortunately, the returned migrationHistoryList is ordered descending either by ID (others) or (namespace, sequence) pair (spanner). We can get the previous migration history list by obtaining the one that has the migrationHistoryId and every one after.

Close BYT-2485