### PR TITLE
fix(spanner): create database in tenant mode

### DIFF
--- a/backend/runner/taskrun/database_create_executor.go
+++ b/backend/runner/taskrun/database_create_executor.go
@@ -94,12 +94,16 @@ func (exec *DatabaseCreateExecutor) RunOnce(ctx context.Context, task *store.Tas
 			return true, nil, err
 		}
 		schemaVersion = sv
-		connectionStmt, err := getConnectionStatement(instance.Engine, payload.DatabaseName)
-		if err != nil {
-			return true, nil, err
-		}
-		if !strings.Contains(payload.Statement, connectionStmt) {
-			statement = fmt.Sprintf("%s\n%s\n%s", statement, connectionStmt, schema)
+		if instance.Engine == db.Spanner {
+			statement = fmt.Sprintf("%s;%s", statement, schema)
+		} else {
+			connectionStmt, err := getConnectionStatement(instance.Engine, payload.DatabaseName)
+			if err != nil {
+				return true, nil, err
+			}
+			if !strings.Contains(payload.Statement, connectionStmt) {
+				statement = fmt.Sprintf("%s\n%s\n%s", statement, connectionStmt, schema)
+			}
 		}
 	}
 	if schemaVersion == "" {


### PR DESCRIPTION
We can pass extra statements (DDLs) when creating a new spanner database. So we don't need to (and cannot) switch database using "USE db1" statement.

First, we concat 'CREATE DATABASE Xxx' and the schema from the peer. Then we split them by ';', and the first is the "CREATE DATABASE" statement, others go to the extra statements.

Close BYT-2439