### PR TITLE
chore(frontend): proxy for /hook/** api in vite for git push webhooks

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -53,6 +53,10 @@ export default defineConfig(() => {
           changeOrigin: true,
           rewrite: (path: string) => path.replace(/^\/api/, ""),
         },
+        "/hook": {
+          target: "http://localhost:8080/",
+          changeOrigin: true,
+        },
         "/v1": {
           target: "http://localhost:8080/v1",
           changeOrigin: true,


### PR DESCRIPTION
This tells vite to proxy all `/hook/**` API requests to backend.