### PR TITLE
fix(frontend): use stricter regexp for spanner host

### DIFF
--- a/frontend/src/components/InstanceForm/SpannerHostInput.vue
+++ b/frontend/src/components/InstanceForm/SpannerHostInput.vue
@@ -56,7 +56,7 @@ const emit = defineEmits<{
 }>();
 
 const RE =
-  /^projects\/(?<PROJECT_ID>(?:[a-z]|[-.:]|[0-9])*)\/instances\/(?<INSTANCE_ID>(?:[a-z]|[-]|[0-9])*)/;
+  /^projects\/(?<PROJECT_ID>(?:[a-z]|[-.:]|[0-9])*)\/instances\/(?<INSTANCE_ID>(?:[a-z]|[-]|[0-9])*)$/;
 
 const state = reactive({
   host: props.host,


### PR DESCRIPTION
Will handle some edge cases such as the InstanceID ends with "/"