### PR TITLE
feat: read error message until EOF

### DIFF
--- a/backend/plugin/db/pg/dump.go
+++ b/backend/plugin/db/pg/dump.go
@@ -160,6 +160,10 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 			}
 			return err
 		}
+		// We may store the error message in meta store, due to the performance concern, we only store the first 1024 bytes.
+		if len(allMsg) >= 1024 {
+			break
+		}
 	}
 	err = cmd.Wait()
 	if err != nil {

--- a/backend/plugin/db/pg/dump.go
+++ b/backend/plugin/db/pg/dump.go
@@ -146,11 +146,13 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 		}
 	}
 
-	errorMsg := make([]byte, 1024)
+	allMsg := make([]byte, 1024)
 	for {
+		errorMsg := make([]byte, 1024)
 		readSize, readErr := errReader.Read(errorMsg)
 		if readSize > 0 {
 			log.Warn(string(errorMsg))
+			allMsg = append(allMsg, errorMsg...)
 		}
 		if readErr != nil {
 			if readErr == io.EOF {
@@ -161,7 +163,7 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 	}
 	err = cmd.Wait()
 	if err != nil {
-		return errors.Wrapf(err, "error message: %s", errorMsg)
+		return errors.Wrapf(err, "error message: %s", allMsg)
 	}
 	return nil
 }

--- a/backend/plugin/db/pg/dump.go
+++ b/backend/plugin/db/pg/dump.go
@@ -147,12 +147,17 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 	}
 
 	errorMsg := make([]byte, 1024)
-	readSize, readErr := errReader.Read(errorMsg)
-	if readErr != nil && readErr != io.EOF {
-		return err
-	}
-	if readSize > 0 {
-		log.Warn(string(errorMsg))
+	for {
+		readSize, readErr := errReader.Read(errorMsg)
+		if readSize > 0 {
+			log.Warn(string(errorMsg))
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return err
+		}
 	}
 	err = cmd.Wait()
 	if err != nil {


### PR DESCRIPTION
We collect the pg_dump error by using pipeline, we should collect the error message until the following cases:
1. meet `io.EOF`
2. had collected 1024 bytes

@rebelice How to reproduce the problem in [BYT-2463]? I cannot reproduce this by using:
```SQL
CREATE TABLE tbl(id INT UNIQUE, id2 INT UNIQUE);
CREATE TABLE tbl2(id INT UNIQUE, id2 INT UNIQUE, CONSTRAINT fk_id_tbl_id2 FOREIGN KEY (id) REFERENCES tbl(id2));
ALTER TABLE tbl ADD CONSTRAINT fk_id_tbl2_id2 FOREIGN KEY (id) REFERENCES tbl2(id2);
```