### PR TITLE
feat: add a switch to control whether to build the rollback sql

### DIFF
--- a/backend/legacyapi/issue.go
+++ b/backend/legacyapi/issue.go
@@ -153,6 +153,8 @@ type MigrationDetail struct {
 	// SchemaVersion is parsed from VCS file name.
 	// It is automatically generated in the UI workflow.
 	SchemaVersion string `json:"schemaVersion"`
+	// If RollbackEnabled, build the rollbackStatement of the task.
+	RollbackEnabled bool `json:"rollbackEnabled"`
 }
 
 // MigrationContext is the issue create context for database migration such as Migrate, Data.

--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -177,6 +177,8 @@ type TaskDatabaseDataUpdatePayload struct {
 
 	// MySQL rollback SQL related.
 
+	// Build the RollbackStatement if RollbackEnabled.
+	RollbackEnabled bool `json:"rollbackEnabled,omitempty"`
 	// ThreadID is the ID of the connection executing the migration.
 	// We use it to filter the binlog events of the migration transaction.
 	ThreadID string `json:"threadId,omitempty"`

--- a/backend/runner/rollbackrun/runner.go
+++ b/backend/runner/rollbackrun/runner.go
@@ -64,7 +64,7 @@ func (r *Runner) retryGenerateRollbackSQL(ctx context.Context) {
 	find := &api.TaskFind{
 		StatusList: &[]api.TaskStatus{api.TaskDone},
 		TypeList:   &[]api.TaskType{api.TaskDatabaseDataUpdate},
-		Payload:    "task.payload->>'threadID'!='' AND task.payload->>'rollbackError' IS NULL AND task.payload->>'rollbackStatement' IS NULL",
+		Payload:    "(task.payload->>'rollbackEnabled')::BOOLEAN IS TRUE AND task.payload->>'threadID'!='' AND task.payload->>'rollbackError' IS NULL AND task.payload->>'rollbackStatement' IS NULL",
 	}
 	taskList, err := r.store.ListTasks(ctx, find)
 	if err != nil {

--- a/backend/tests/rollback_test.go
+++ b/backend/tests/rollback_test.go
@@ -171,6 +171,7 @@ func TestCreateRollbackIssueMySQL(t *testing.T) {
 					DELETE FROM t WHERE id = 1;
 					UPDATE t SET name = 'unknown\nunknown';
 				`,
+				RollbackEnabled: true,
 			},
 		},
 	})


### PR DESCRIPTION
Add `RollbackEnabled` boolean to control whether to build the rollback SQL.

We don't want to build the rollback SQL for every DML task which consumes CPU, memory, network bandwidth, etc.

Completing BYT-2496

FYI @LiuJi-Jim 

Patching RollbackEnabled will be in the following PR.