### PR TITLE
feat: patch task rollbackEnabled

### DIFF
--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -324,12 +324,15 @@ type TaskPatch struct {
 	UpdaterID int
 
 	// Domain specific fields
-	DatabaseID *int
-	// Statement/SchemaVersion and Payload cannot be set at the same time.
-	Statement         *string `jsonapi:"attr,statement"`
-	SchemaVersion     *string
-	Payload           *string
+	DatabaseID        *int
 	EarliestAllowedTs *int64 `jsonapi:"attr,earliestAllowedTs"`
+
+	// Payload and others cannot be set at the same time.
+	Payload *string
+
+	Statement       *string `jsonapi:"attr,statement"`
+	SchemaVersion   *string
+	RollbackEnabled *bool `jsonapi:"attr,rollbackEnabled"`
 }
 
 // TaskStatusPatch is the API message for patching a task status.

--- a/backend/server/task.go
+++ b/backend/server/task.go
@@ -53,7 +53,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			taskPatch := *taskPatch
 			taskPatch.ID = task.ID
 			// TODO(d): patch tasks in batch.
-			if err := s.TaskScheduler.PatchTaskStatement(ctx, task, &taskPatch, issue); err != nil {
+			if err := s.TaskScheduler.PatchTask(ctx, task, &taskPatch, issue); err != nil {
 				return err
 			}
 		}
@@ -103,7 +103,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			}
 		}
 
-		if err := s.TaskScheduler.PatchTaskStatement(ctx, task, taskPatch, issue); err != nil {
+		if err := s.TaskScheduler.PatchTask(ctx, task, taskPatch, issue); err != nil {
 			return err
 		}
 		composedTaskPatched, err := s.store.GetTaskByID(ctx, task.ID)

--- a/backend/server/webhook.go
+++ b/backend/server/webhook.go
@@ -1203,7 +1203,7 @@ func (s *Server) tryUpdateTasksFromModifiedFile(ctx context.Context, databases [
 			Statement: &statement,
 			UpdaterID: api.SystemBotID,
 		}
-		if err := s.TaskScheduler.PatchTaskStatement(ctx, task, &taskPatch, issue); err != nil {
+		if err := s.TaskScheduler.PatchTask(ctx, task, &taskPatch, issue); err != nil {
 			log.Error("Failed to patch task with the same migration version", zap.Int("issueID", issue.UID), zap.Int("taskID", task.ID), zap.Error(err))
 			return nil
 		}

--- a/backend/tests/issue.go
+++ b/backend/tests/issue.go
@@ -129,6 +129,26 @@ func (ctl *controller) patchIssueStatus(issueStatusPatch api.IssueStatusPatch) (
 	return issue, nil
 }
 
+// patchTask patches a task.
+func (ctl *controller) patchTask(taskPatch api.TaskPatch, pipelineID int, taskID int) (*api.Task, error) {
+	buf := new(bytes.Buffer)
+	if err := jsonapi.MarshalPayload(buf, &taskPatch); err != nil {
+		return nil, errors.Wrap(err, "failed to marshal taskPatch")
+	}
+
+	body, err := ctl.patch(fmt.Sprintf("/pipeline/%d/task/%d", pipelineID, taskID), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	task := new(api.Task)
+	if err = jsonapi.UnmarshalPayload(body, task); err != nil {
+		return nil, errors.Wrap(err, "fail to unmarshal patchTask response")
+	}
+	return task, nil
+
+}
+
 // patchTaskStatus patches the status of a task in the pipeline stage.
 func (ctl *controller) patchTaskStatus(taskStatusPatch api.TaskStatusPatch, pipelineID int, taskID int) (*api.Task, error) {
 	buf := new(bytes.Buffer)

--- a/backend/tests/issue.go
+++ b/backend/tests/issue.go
@@ -146,7 +146,6 @@ func (ctl *controller) patchTask(taskPatch api.TaskPatch, pipelineID int, taskID
 		return nil, errors.Wrap(err, "fail to unmarshal patchTask response")
 	}
 	return task, nil
-
 }
 
 // patchTaskStatus patches the status of a task in the pipeline stage.

--- a/backend/tests/rollback_test.go
+++ b/backend/tests/rollback_test.go
@@ -262,3 +262,182 @@ func TestCreateRollbackIssueMySQL(t *testing.T) {
 	want2 := []record{{1, "1\n1"}, {2, "2\n2"}, {3, "3\n3"}}
 	a.Equal(want2, records2)
 }
+
+func TestCreateRollbackIssueMySQLByPatch(t *testing.T) {
+	if testReleaseMode == common.ReleaseModeProd {
+		t.Skip()
+	}
+	t.Parallel()
+
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	dataDir := t.TempDir()
+	err := ctl.StartServerWithExternalPg(ctx, &config{
+		dataDir:            dataDir,
+		vcsProviderCreator: fake.NewGitLab,
+	})
+	a.NoError(err)
+	defer func() {
+		_ = ctl.Close(ctx)
+	}()
+
+	// Create a MySQL instance.
+	mysqlPort := getTestPort()
+	stopInstance := resourcemysql.SetupTestInstance(t, mysqlPort, mysqlBinDir)
+	defer stopInstance()
+
+	// Create a project.
+	project, err := ctl.createProject(
+		api.ProjectCreate{
+			Name: fmt.Sprintf("Project %s", t.Name()),
+			Key:  "ROLLBACK",
+		},
+	)
+	a.NoError(err)
+
+	environments, err := ctl.getEnvironments()
+	a.NoError(err)
+	prodEnvironment, err := findEnvironment(environments, "Prod")
+	a.NoError(err)
+	connCfg := getMySQLConnectionConfig(strconv.Itoa(mysqlPort), "")
+	// Add MySQL instance to Bytebase.
+	instance, err := ctl.addInstance(api.InstanceCreate{
+		EnvironmentID: prodEnvironment.ID,
+		Name:          t.Name(),
+		Engine:        db.MySQL,
+		Host:          connCfg.Host,
+		Port:          connCfg.Port,
+		Username:      connCfg.Username,
+	})
+	a.NoError(err)
+	t.Log("Instance added.")
+
+	databaseName := t.Name()
+	err = ctl.createDatabase(project, instance, databaseName, "", nil)
+	a.NoError(err)
+	databases, err := ctl.getDatabases(api.DatabaseFind{
+		InstanceID: &instance.ID,
+	})
+	a.NoError(err)
+	a.Equal(1, len(databases))
+	database := databases[0]
+
+	dbMySQL, err := connectTestMySQL(mysqlPort, "")
+	a.NoError(err)
+	_, err = dbMySQL.ExecContext(ctx, fmt.Sprintf(`
+		USE %s;
+		CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20));
+		INSERT INTO t VALUES (1, '1\n1'), (2, '2\n2'), (3, '3\n3')
+	`, databaseName))
+	a.NoError(err)
+	t.Log("Schema initialized.")
+
+	// Run a DML issue with rollbackEnabled set to false.
+	createContext, err := json.Marshal(&api.MigrationContext{
+		DetailList: []*api.MigrationDetail{
+			{
+				MigrationType: db.Data,
+				DatabaseID:    database.ID,
+				Statement: `
+					DELETE FROM t WHERE id = 1;
+					UPDATE t SET name = 'unknown\nunknown';
+				`,
+				// RollbackEnabled: true,
+			},
+		},
+	})
+	a.NoError(err)
+	issue, err := ctl.createIssue(api.IssueCreate{
+		ProjectID:     project.ID,
+		Name:          "update data",
+		Type:          api.IssueDatabaseDataUpdate,
+		AssigneeID:    api.SystemBotID,
+		CreateContext: string(createContext),
+	})
+	a.NoError(err)
+	t.Logf("Issue %d created.", issue.ID)
+	status, err := ctl.waitIssuePipeline(issue.ID)
+	a.NoError(err)
+	a.Equal(api.TaskDone, status)
+	a.Len(issue.Pipeline.StageList, 1)
+	a.Len(issue.Pipeline.StageList[0].TaskList, 1)
+	task := issue.Pipeline.StageList[0].TaskList[0]
+
+	// Patch rollbackEnabled to true.
+	rollbackEnabled := true
+	_, err = ctl.patchTask(api.TaskPatch{
+		RollbackEnabled: &rollbackEnabled,
+	}, issue.PipelineID, task.ID)
+	a.NoError(err)
+
+	// Check that the data is changed.
+	type record struct {
+		id   int
+		name string
+	}
+	rows1, err := dbMySQL.QueryContext(ctx, "SELECT * FROM t;")
+	a.NoError(err)
+	defer rows1.Close()
+	var records1 []record
+	for rows1.Next() {
+		var r record
+		err = rows1.Scan(&r.id, &r.name)
+		a.NoError(err)
+		records1 = append(records1, r)
+	}
+	want1 := []record{{2, "unknown\nunknown"}, {3, "unknown\nunknown"}}
+	a.Equal(want1, records1)
+
+	// Run a rollback issue.
+	var rollbackIssue *api.Issue
+	rollbackCreateContext, err := json.Marshal(&api.RollbackContext{
+		IssueID:    issue.ID,
+		TaskIDList: []int{task.ID},
+	})
+	a.NoError(err)
+	for i := 0; i < 10; i++ {
+		// rollbackIssue, err = ctl.createRollbackIssue(issue.ID, []int{task.ID})
+		rollbackIssue, err = ctl.createIssue(api.IssueCreate{
+			ProjectID:     project.ID,
+			Name:          "rollback",
+			Type:          api.IssueDatabaseRollback,
+			AssigneeID:    api.SystemBotID,
+			CreateContext: string(rollbackCreateContext),
+		})
+		if err == nil {
+			break
+		}
+		// Wait for the rollback SQL generation and retry.
+		time.Sleep(3 * time.Second)
+	}
+	t.Logf("Rollback issue %d created.", rollbackIssue.ID)
+	status, err = ctl.waitIssuePipeline(rollbackIssue.ID)
+	a.NoError(err)
+	a.Equal(api.TaskDone, status)
+	// Re-query the issue to get the updated task, which has the RollbackFromIssueID and RollbackFromTaskID fields.
+	rollbackIssue, err = ctl.getIssue(rollbackIssue.ID)
+	a.NoError(err)
+	a.Len(rollbackIssue.Pipeline.StageList, 1)
+	a.Len(rollbackIssue.Pipeline.StageList[0].TaskList, 1)
+	rollbackTask := rollbackIssue.Pipeline.StageList[0].TaskList[0]
+	rollbackTaskPayload := &api.TaskDatabaseDataUpdatePayload{}
+	err = json.Unmarshal([]byte(rollbackTask.Payload), rollbackTaskPayload)
+	a.NoError(err)
+	a.Equal(issue.ID, rollbackTaskPayload.RollbackFromIssueID)
+	a.Equal(task.ID, rollbackTaskPayload.RollbackFromTaskID)
+
+	// Check that the data is restored.
+	rows2, err := dbMySQL.QueryContext(ctx, "SELECT * FROM t;")
+	a.NoError(err)
+	defer rows2.Close()
+	var records2 []record
+	for rows2.Next() {
+		var r record
+		err = rows2.Scan(&r.id, &r.name)
+		a.NoError(err)
+		records2 = append(records2, r)
+	}
+	want2 := []record{{1, "1\n1"}, {2, "2\n2"}, {3, "3\n3"}}
+	a.Equal(want2, records2)
+}


### PR DESCRIPTION
previous PR #4639 

support patching rollbackEnabled

Enqueue the task to the rollback generation queue if rollbackEnabled is patched to true.
Remove it from the queue if false.

Also need to cancel the ongoing generation if we were to remove it from the queue. But that's left for another PR.

@LiuJi-Jim FYI

Completing BYT-2496