### PR TITLE
chore: increase golangci-lint timeout to 10m

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
-          args: -v
+          args: --verbose --timeout 10m
           skip-cache: true
 
   go-tests:


### PR DESCRIPTION
Our golangci-lint jobs are timing out recently.

Increase goangci-lint job to 10m according to https://github.com/golangci/golangci-lint-action/issues/297