### PR TITLE
fix: reset payload rollback statement and error

### DIFF
--- a/backend/runner/rollbackrun/runner.go
+++ b/backend/runner/rollbackrun/runner.go
@@ -93,6 +93,8 @@ func (r *Runner) generateRollbackSQL(ctx context.Context, task *store.TaskMessag
 		log.Error("Invalid database data update payload", zap.Error(err))
 		return
 	}
+	payload.RollbackStatement = ""
+	payload.RollbackError = ""
 
 	rollbackSQL, err := r.generateRollbackSQLImpl(ctx, task, payload)
 	if err != nil {


### PR DESCRIPTION
Should reset payload.RollbackStatement and payload.RollbackError as we can retry generating rollback SQL now.
