### PR TITLE
feat(sql-editor): auto-re-focus to active SQL Editor when needed

### DIFF
--- a/frontend/src/views/sql-editor/TerminalPanel/TerminalPanel.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/TerminalPanel.vue
@@ -20,6 +20,9 @@
           <CompactSQLEditor
             v-model:sql="query.sql"
             class="min-h-[2rem]"
+            :class="[
+              isEditableQueryItem(query) ? 'active-editor' : 'read-only-editor',
+            ]"
             :readonly="!isEditableQueryItem(query)"
             @execute="handleExecute"
             @history="handleHistory"
@@ -80,6 +83,7 @@ import {
 import { useExecuteSQL } from "@/composables/useExecuteSQL";
 import { useCancelableTimeout } from "@/composables/useCancelableTimeout";
 import { useHistory } from "./useHistory";
+import { useAttractFocus } from "./useAttractFocus";
 
 const QUERY_TIMEOUT_MS = 5000;
 const MAX_QUERY_ITEM_COUNT = 20;
@@ -192,4 +196,6 @@ watch(queryListHeight, () => {
     }
   });
 });
+
+useAttractFocus();
 </script>

--- a/frontend/src/views/sql-editor/TerminalPanel/TerminalPanel.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/TerminalPanel.vue
@@ -197,5 +197,8 @@ watch(queryListHeight, () => {
   });
 });
 
-useAttractFocus();
+useAttractFocus({
+  excluded: [{ tag: "textarea", selector: ".active-editor" }],
+  targetSelector: ".active-editor textarea",
+});
 </script>

--- a/frontend/src/views/sql-editor/TerminalPanel/useAttractFocus.ts
+++ b/frontend/src/views/sql-editor/TerminalPanel/useAttractFocus.ts
@@ -1,0 +1,54 @@
+import { isDescendantOf } from "@/utils";
+import { useEventListener } from "@vueuse/core";
+
+const FOCUS_ATTRACTIVE_KEYS: (RegExp | string)[] = [
+  /^[A-Za-z0-9\s.`~!@#$%^&*()-=[\]\\;',./_+{}|:"<>?]$/,
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Backspace",
+  "Delete",
+  "Home",
+  "End",
+];
+
+const shouldAttractFocus = (e: KeyboardEvent) => {
+  if (e.metaKey || e.ctrlKey) {
+    // A downgrade for safety since key strokes with cmd or ctrl might
+    // probably be a system-wide keyboard shortcut.
+    return false;
+  }
+  return FOCUS_ATTRACTIVE_KEYS.some((rule) => {
+    if (typeof rule === "string") {
+      return e.key === rule;
+    }
+    return e.key.match(rule);
+  });
+};
+
+export const useAttractFocus = () => {
+  useEventListener("keydown", (e: KeyboardEvent) => {
+    const sourceElement = e.target as Element;
+    const tag = sourceElement.tagName.toLowerCase();
+    if (tag === "input") {
+      // Don't rob the focus in other text boxes
+      return;
+    }
+    if (tag === "textarea") {
+      if (isDescendantOf(sourceElement, ".active-editor")) {
+        // The active editor is already focused
+        return;
+      }
+    }
+    if (!shouldAttractFocus(e)) {
+      return;
+    }
+
+    const target = document.querySelector(
+      ".active-editor textarea"
+    ) as HTMLTextAreaElement | null;
+    // monaco-editor will consume the focus event with key stroke
+    target?.focus();
+  });
+};


### PR DESCRIPTION
As discussed in BYT-2475, clicking on the page will cause the active SQL Editor to lose its focus. This PR tries to re-focus the active SQL Editor while appropriate keystroke events are emitted.

FYI @tianzhou 

### Screenshot

https://user-images.githubusercontent.com/2749742/217706587-d40e9d67-efa0-4ea3-9baa-337d0d4d4b39.mp4

