### PR TITLE
feat(frontend): move audit log to enterprise version

### DIFF
--- a/backend/legacyapi/plan.go
+++ b/backend/legacyapi/plan.go
@@ -61,6 +61,9 @@ const (
 	// FeatureWatermark enables full-screen watermark.
 	FeatureWatermark FeatureType = "bb.feature.watermark"
 
+	// FeatureWatermark enables viewing audit logs.
+	FeatureAuditLog FeatureType = "bb.feature.audit-log"
+
 	// Branding.
 
 	// FeatureBranding enables customized branding.
@@ -160,9 +163,11 @@ func (e FeatureType) Name() string {
 		return "SSO"
 	case FeatureRBAC:
 		return "RBAC"
-	// Branding
 	case FeatureWatermark:
 		return "Watermark"
+	case FeatureAuditLog:
+		return "Audit log"
+	// Branding
 	case FeatureBranding:
 		return "Branding"
 	// Change Workflow
@@ -237,6 +242,7 @@ var FeatureMatrix = map[FeatureType][3]bool{
 	FeatureSSO:       {false, false, true},
 	FeatureRBAC:      {false, true, true},
 	FeatureWatermark: {false, false, true},
+	FeatureAuditLog:  {false, false, true},
 	// Branding
 	FeatureBranding: {false, false, true},
 	// Change Workflow

--- a/backend/legacyapi/plan.go
+++ b/backend/legacyapi/plan.go
@@ -61,7 +61,7 @@ const (
 	// FeatureWatermark enables full-screen watermark.
 	FeatureWatermark FeatureType = "bb.feature.watermark"
 
-	// FeatureWatermark enables viewing audit logs.
+	// FeatureAuditLog enables viewing audit logs.
 	FeatureAuditLog FeatureType = "bb.feature.audit-log"
 
 	// Branding.

--- a/frontend/src/bbkit/BBComboBox.vue
+++ b/frontend/src/bbkit/BBComboBox.vue
@@ -5,7 +5,7 @@
         ref="button"
         class="btn-select relative pl-3 pr-10"
         :class="[
-          disabled && 'bg-control-bg opacity-50 !cursor-not-allowed',
+          disabled && '!bg-control-bg opacity-50 !cursor-not-allowed',
           state.open && 'ring-1 ring-control border-control',
         ]"
         v-bind="$attrs"
@@ -119,7 +119,7 @@ const props = withDefaults(
     value: undefined,
     placeholder: "",
     disabled: false,
-    filter: async (options) => options,
+    filter: async (options: ItemType[]) => options,
   }
 );
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1667,6 +1667,10 @@
         "title": "Watermark",
         "desc": "Display visible watermarks on pages, including username and ID."
       },
+      "bb-feature-audit-log": {
+        "title": "Audit log",
+        "desc": "Record and query operations performed by users in workspace."
+      },
       "bb-feature-schema-drift": {
         "title": "Schema drift",
         "desc": "@:{'subscription.upgrade'} to unlock schema drift auto-detection."

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1668,6 +1668,10 @@
         "title": "水印设置",
         "desc": "在页面上显示水印，包含用户名和 ID。"
       },
+      "bb-feature-audit-log": {
+        "title": "审计日志",
+        "desc": "记录和查询工作空间中的用户执行的操作。"
+      },
       "bb-feature-schema-drift": {
         "title": "Schema 偏差",
         "desc": "@:{'subscription.upgrade'}来解锁 schema 偏差异常的自动检测。"

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -7,6 +7,7 @@ export type FeatureType =
   | "bb.feature.sso"
   | "bb.feature.rbac"
   | "bb.feature.watermark"
+  | "bb.feature.audit-log"
   // Branding
   | "bb.feature.branding"
   // Change Workflow

--- a/frontend/src/views/SettingWorkspaceAccessControl.vue
+++ b/frontend/src/views/SettingWorkspaceAccessControl.vue
@@ -21,7 +21,7 @@
       <div>
         <button
           class="btn-primary whitespace-nowrap"
-          :disabled="!allowAdmin"
+          :disabled="!allowAdmin || !hasAccessControlFeature"
           @click="state.showAddRuleModal = true"
         >
           {{ $t("settings.access-control.add-rule") }}
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <div class="relative min-h-[12rem]">
+    <div v-if="hasAccessControlFeature" class="relative min-h-[12rem]">
       <BBTable
         :column-list="COLUMN_LIST"
         :data-source="activePolicyList"
@@ -145,9 +145,6 @@
               </div>
             </BBTableCell>
             <BBTableCell>
-              {{ humanizeTs(policy.updatedTs) }}
-            </BBTableCell>
-            <BBTableCell>
               <div class="flex items-center justify-center">
                 <NPopconfirm @positive-click="handleRemove(policy)">
                   <template #trigger>
@@ -176,6 +173,20 @@
         <BBSpin />
       </div>
     </div>
+
+    <template v-else>
+      <BBTable
+        :column-list="COLUMN_LIST"
+        :data-source="[]"
+        :show-header="true"
+        :left-bordered="true"
+        :right-bordered="true"
+        :row-clickable="false"
+      />
+      <div class="w-full h-full flex flex-col items-center justify-center">
+        <img src="../assets/illustration/no-data.webp" class="max-h-[30vh]" />
+      </div>
+    </template>
   </div>
 
   <FeatureModal

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -1,8 +1,14 @@
 <template>
-  <div>
+  <div class="w-full mt-4 space-y-4">
+    <FeatureAttention
+      v-if="!hasAuditLogFeature"
+      feature="bb.feature.audit-log"
+      :description="$t('subscription.features.bb-feature-audit-log.desc')"
+    />
     <div class="flex justify-end items-center mt-1">
       <MemberSelect
         class="w-52"
+        :disabled="!hasAuditLogFeature"
         :show-all="true"
         :show-system-bot="true"
         :selected-id="selectedPrincipalId"
@@ -10,12 +16,14 @@
       />
       <div class="w-52 ml-2">
         <TypeSelect
+          :disabled="!hasAuditLogFeature"
           :selected-type-list="selectedAuditTypeList"
           @update-selected-type-list="selectAuditType"
         />
       </div>
     </div>
     <PagedAuditLogTable
+      v-if="hasAuditLogFeature"
       :activity-find="{
         typePrefix:
           selectedAuditTypeList.length > 0
@@ -31,6 +39,13 @@
         <AuditLogTable :audit-log-list="list" @view-detail="handleViewDetail" />
       </template>
     </PagedAuditLogTable>
+    <template v-else>
+      <AuditLogTable :audit-log-list="[]" />
+      <div class="w-full h-full flex flex-col items-center justify-center">
+        <img src="../assets/illustration/no-data.webp" class="max-h-[30vh]" />
+      </div>
+    </template>
+
     <BBDialog
       ref="dialog"
       :title="$t('audit-log.audit-log-detail')"
@@ -81,6 +96,7 @@ import { NGrid, NGi } from "naive-ui";
 import { useI18n } from "vue-i18n";
 import { BBDialog } from "@/bbkit";
 import { AuditActivityType, PrincipalId, EMPTY_ID } from "@/types";
+import { featureToRef } from "@/store";
 
 const dialog = ref<InstanceType<typeof BBDialog> | null>(null);
 const state = reactive({
@@ -91,6 +107,8 @@ const state = reactive({
 const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
+
+const hasAuditLogFeature = featureToRef("bb.feature.audit-log");
 
 const logKeyMap = {
   createdTs: t("audit-log.table.created-time"),

--- a/frontend/src/views/SettingWorkspaceSensitiveData.vue
+++ b/frontend/src/views/SettingWorkspaceSensitiveData.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="w-full mt-4 space-y-4">
+    <FeatureAttention
+      v-if="!hasSensitiveDataFeature"
+      feature="bb.feature.sensitive-data"
+      :description="$t('subscription.features.bb-feature-sensitive-data.desc')"
+    />
+
     <div class="textinfolabel">
       {{ $t("settings.sensitive-data.description") }}
     </div>
 
     <BBGrid
+      v-if="hasSensitiveDataFeature"
       :column-list="COLUMN_LIST"
       :data-source="state.sensitiveColumnList"
       class="border"
@@ -55,6 +62,13 @@
         </div>
       </template>
     </BBGrid>
+
+    <template v-else>
+      <BBGrid :column-list="COLUMN_LIST" :data-source="[]" class="border" />
+      <div class="w-full h-full flex flex-col items-center justify-center">
+        <img src="../assets/illustration/no-data.webp" class="max-h-[30vh]" />
+      </div>
+    </template>
   </div>
 
   <FeatureModal


### PR DESCRIPTION
WIP BYT-2520

### Changes

- Move the Audit Log feature to the Enterprise plan
- Apply the same UX to Audit Log, Sensitive Data and Access Control

### Screenshots

![localhost_3000_setting_audit-log(1600_900) (2)](https://user-images.githubusercontent.com/2749742/217981201-06d76736-fd42-4da4-8b3c-0b1bb88dfbb9.png)

![localhost_3000_setting_audit-log(1600_900) (1)](https://user-images.githubusercontent.com/2749742/217981257-f13b755e-84e3-4e16-8ed1-2acdf5a8c8d2.png)

![localhost_3000_setting_audit-log(1600_900)](https://user-images.githubusercontent.com/2749742/217981265-f3d5ac6b-db78-48dc-b407-a167bd7b5ea5.png)
