### PR TITLE
fix: add rollbackEnabledList to RollbackCreateContext

### DIFF
--- a/backend/legacyapi/issue.go
+++ b/backend/legacyapi/issue.go
@@ -202,6 +202,8 @@ type RollbackContext struct {
 	IssueID int `json:"issueId"`
 	// TaskIDList is the list of task ids to rollback.
 	TaskIDList []int `json:"taskIdList"`
+	// RollbackEnabledList enables rollback generation of the corresponding task in taskIDList.
+	RollbackEnabledList []bool `json:"rollbackEnabledList"`
 }
 
 // IssuePatch is the API message for patching an issue.

--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -596,7 +596,7 @@ func (s *Server) getPipelineCreateForDatabaseRollback(ctx context.Context, issue
 	}
 	switch {
 	case !taskPayload.RollbackEnabled:
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "Rollback SQL is not requested to build.")
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Rollback SQL is not enabled.")
 	case taskPayload.RollbackStatement == "" && taskPayload.RollbackError == "":
 		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d is still in progress", taskID))
 	case taskPayload.RollbackStatement == "" && taskPayload.RollbackError != "":


### PR DESCRIPTION
Add rollbackEnabledList to RollbackCreateContext.

A rollback task is a DML task, so we need this to control if rollback is enabled for the rollback task.

@LiuJi-Jim FYI

Completing BYT-2496
