### PR TITLE
fix(sso): improve description of the OAuth 2 scopes

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -423,7 +423,7 @@
         "endpoints": "Endpoints",
         "endpoints-description": "The related urls provided by your OAuth provider.",
         "auth-url-description": "The link to OAuth login page",
-        "scopes-description": "The scope parameter carried when accessing the Auth URL",
+        "scopes-description": "A space-separated list of scopes to be carried when accessing the Auth URL",
         "token-url-description": "The API address for obtaining accessToken",
         "user-info-url-description": "The API address for obtaining user information by accessToken",
         "user-information-mapping": "User information mapping",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -423,7 +423,7 @@
         "endpoints": "链接信息",
         "endpoints-description": "链接信息是由你的 OAuth 提供商提供。",
         "auth-url-description": "登录页面的链接",
-        "scopes-description": "访问 Auth URL 时携带的范围参数",
+        "scopes-description": "访问 Auth URL 时携带的范围参数，使用空格分隔多个值",
         "token-url-description": "用于获取 accessToken 的 API 地址",
         "user-info-url-description": "用于通过 accessToken 获取用户信息的 API 地址",
         "user-information-mapping": "用户信息映射",


### PR DESCRIPTION
It is quite unclear what to do when there is more than one scope needed for the OAuth 2 "Scopes" field.

Updated the field description to inform the user to use space as the separator.

## Test plan

<img width="536" alt="CleanShot 2023-02-10 at 14 15 45@2x" src="https://user-images.githubusercontent.com/2946214/218017104-056994f9-de1c-4e31-926e-5793f893b747.png">
