### PR TITLE
fix: remove user email cache

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -78,11 +78,6 @@ linters-settings:
         disabled: true
       - name: early-return
         disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
-      - name: var-naming
-        arguments:
-          - ["IdP"] # AllowList
-          - [] # DenyList
   gocritic:
     disabled-checks:
       - ifElseChain

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -78,6 +78,11 @@ linters-settings:
         disabled: true
       - name: early-return
         disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
+      - name: var-naming
+        arguments:
+          - ["IdP"] # AllowList
+          - [] # DenyList
   gocritic:
     disabled-checks:
       - ifElseChain

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -416,11 +416,11 @@ func (*AuthService) Logout(ctx context.Context, _ *v1pb.LogoutRequest) (*emptypb
 }
 
 func (s *AuthService) getUserWithLoginRequestOfBytebase(ctx context.Context, request *v1pb.LoginRequest) (*store.UserMessage, error) {
-	emptyIdp := ""
+	emptyIdP := ""
 	user, err := s.store.GetUser(ctx, &store.FindUserMessage{
 		Email:                      &request.Email,
 		ShowDeleted:                true,
-		IdentityProviderResourceID: &emptyIdp,
+		IdentityProviderResourceID: &emptyIdP,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get principal by email %q", request.Email)

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -416,7 +416,12 @@ func (*AuthService) Logout(ctx context.Context, _ *v1pb.LogoutRequest) (*emptypb
 }
 
 func (s *AuthService) getUserWithLoginRequestOfBytebase(ctx context.Context, request *v1pb.LoginRequest) (*store.UserMessage, error) {
-	user, err := s.store.GetUserByEmail(ctx, request.Email)
+	emptyIdp := ""
+	user, err := s.store.GetUser(ctx, &store.FindUserMessage{
+		Email:                      &request.Email,
+		ShowDeleted:                true,
+		IdentityProviderResourceID: &emptyIdp,
+	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get principal by email %q", request.Email)
 	}

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -416,11 +416,11 @@ func (*AuthService) Logout(ctx context.Context, _ *v1pb.LogoutRequest) (*emptypb
 }
 
 func (s *AuthService) getUserWithLoginRequestOfBytebase(ctx context.Context, request *v1pb.LoginRequest) (*store.UserMessage, error) {
-	emptyIdP := ""
+	emptyIDP := ""
 	user, err := s.store.GetUser(ctx, &store.FindUserMessage{
 		Email:                      &request.Email,
 		ShowDeleted:                true,
-		IdentityProviderResourceID: &emptyIdP,
+		IdentityProviderResourceID: &emptyIDP,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get principal by email %q", request.Email)

--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -424,7 +424,10 @@ func (s *ProjectService) convertToIAMPolicyMessage(ctx context.Context, iamPolic
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 		for _, member := range binding.Members {
-			user, err := s.store.GetUserByEmail(ctx, getUserEmailFromIdentifier(member))
+			email := getUserEmailFromIdentifier(member)
+			user, err := s.store.GetUser(ctx, &store.FindUserMessage{
+				Email: &email,
+			})
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, err.Error())
 			}

--- a/backend/server/auth.go
+++ b/backend/server/auth.go
@@ -59,8 +59,12 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusBadRequest, "Malformed login request").SetInternal(err)
 				}
 
-				var err error
-				user, err = s.store.GetUserByEmail(ctx, login.Email)
+				emptyIdp := ""
+				user, err := s.store.GetUser(ctx, &store.FindUserMessage{
+					Email:                      &login.Email,
+					ShowDeleted:                true,
+					IdentityProviderResourceID: &emptyIdp,
+				})
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to authenticate user").SetInternal(err)
 				}
@@ -122,7 +126,10 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusUnauthorized, "Fail to login via VCS, user is Archived")
 				}
 
-				user, err = s.store.GetUserByEmail(ctx, userInfo.PublicEmail)
+				user, err := s.store.GetUser(ctx, &store.FindUserMessage{
+					Email:       &userInfo.PublicEmail,
+					ShowDeleted: true,
+				})
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to authenticate user").SetInternal(err)
 				}

--- a/backend/server/auth.go
+++ b/backend/server/auth.go
@@ -59,8 +59,9 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusBadRequest, "Malformed login request").SetInternal(err)
 				}
 
+				var err error
 				emptyIdp := ""
-				user, err := s.store.GetUser(ctx, &store.FindUserMessage{
+				user, err = s.store.GetUser(ctx, &store.FindUserMessage{
 					Email:                      &login.Email,
 					ShowDeleted:                true,
 					IdentityProviderResourceID: &emptyIdp,
@@ -126,7 +127,7 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusUnauthorized, "Fail to login via VCS, user is Archived")
 				}
 
-				user, err := s.store.GetUser(ctx, &store.FindUserMessage{
+				user, err = s.store.GetUser(ctx, &store.FindUserMessage{
 					Email:       &userInfo.PublicEmail,
 					ShowDeleted: true,
 				})

--- a/backend/server/auth.go
+++ b/backend/server/auth.go
@@ -60,11 +60,11 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 				}
 
 				var err error
-				emptyIdp := ""
+				emptyIdP := ""
 				user, err = s.store.GetUser(ctx, &store.FindUserMessage{
 					Email:                      &login.Email,
 					ShowDeleted:                true,
-					IdentityProviderResourceID: &emptyIdp,
+					IdentityProviderResourceID: &emptyIdP,
 				})
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to authenticate user").SetInternal(err)

--- a/backend/server/auth.go
+++ b/backend/server/auth.go
@@ -60,11 +60,11 @@ func (s *Server) registerAuthRoutes(g *echo.Group) {
 				}
 
 				var err error
-				emptyIdP := ""
+				emptyIDP := ""
 				user, err = s.store.GetUser(ctx, &store.FindUserMessage{
 					Email:                      &login.Email,
 					ShowDeleted:                true,
-					IdentityProviderResourceID: &emptyIdP,
+					IdentityProviderResourceID: &emptyIDP,
 				})
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to authenticate user").SetInternal(err)

--- a/backend/server/webhook.go
+++ b/backend/server/webhook.go
@@ -885,7 +885,9 @@ func (s *Server) createIssueFromMigrationDetailList(ctx context.Context, issueNa
 func (s *Server) getIssueCreatorID(ctx context.Context, email string) int {
 	creatorID := api.SystemBotID
 	if email != "" {
-		committerPrincipal, err := s.store.GetUserByEmail(ctx, email)
+		committerPrincipal, err := s.store.GetUser(ctx, &store.FindUserMessage{
+			Email: &email,
+		})
 		if err != nil {
 			log.Warn("Failed to find the principal with committer email, use system bot instead", zap.String("email", email), zap.Error(err))
 		} else if committerPrincipal == nil {

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -13,7 +13,6 @@ type Store struct {
 	db *DB
 
 	userIDCache          sync.Map // map[int]*UserMessage
-	userEmailCache       sync.Map // map[string]*UserMessage
 	environmentCache     sync.Map // map[string]*EnvironmentMessage
 	environmentIDCache   sync.Map // map[int]*EnvironmentMessage
 	instanceCache        sync.Map // map[string]*InstanceMessage


### PR DESCRIPTION
Since `email` isn't an identifier of `principal` table, the `userEmailCache` will cause bytebase user cannot login if there is an idp user with same email.