### PR TITLE
feat: diff null vs empty for rollback statement error

### DIFF
--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -187,13 +187,13 @@ type TaskDatabaseDataUpdatePayload struct {
 	MigrationID string `json:"migrationId,omitempty"`
 	// BinlogXxx are obtained before and after executing the migration.
 	// We use them to locate the range of binlog for the migration transaction.
-	BinlogFileStart string `json:"binlogFileStart,omitempty"`
-	BinlogFileEnd   string `json:"binlogFileEnd,omitempty"`
-	BinlogPosStart  int64  `json:"binlogPosStart,omitempty"`
-	BinlogPosEnd    int64  `json:"binlogPosEnd,omitempty"`
-	RollbackError   string `json:"rollbackError,omitempty"`
+	BinlogFileStart string  `json:"binlogFileStart,omitempty"`
+	BinlogFileEnd   string  `json:"binlogFileEnd,omitempty"`
+	BinlogPosStart  int64   `json:"binlogPosStart,omitempty"`
+	BinlogPosEnd    int64   `json:"binlogPosEnd,omitempty"`
+	RollbackError   *string `json:"rollbackError,omitempty"`
 	// RollbackStatement is the generated rollback SQL statement for the DML task.
-	RollbackStatement string `json:"rollbackStatement,omitempty"`
+	RollbackStatement *string `json:"rollbackStatement,omitempty"`
 	// RollbackFromIssueID is the issue ID containing the original task from which the rollback SQL statement is generated for this task.
 	RollbackFromIssueID int `json:"rollbackFromIssueId,omitempty"`
 	// RollbackFromTaskID is the task ID from which the rollback SQL statement is generated for this task.
@@ -333,8 +333,8 @@ type TaskPatch struct {
 	Statement         *string `jsonapi:"attr,statement"`
 	SchemaVersion     *string
 	RollbackEnabled   *bool `jsonapi:"attr,rollbackEnabled"`
-	RollbackStatement *string
-	RollbackError     *string
+	RollbackStatement **string
+	RollbackError     **string
 }
 
 // TaskStatusPatch is the API message for patching a task status.

--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"encoding/json"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -333,8 +334,8 @@ type TaskPatch struct {
 	Statement         *string `jsonapi:"attr,statement"`
 	SchemaVersion     *string
 	RollbackEnabled   *bool `jsonapi:"attr,rollbackEnabled"`
-	RollbackStatement **string
-	RollbackError     **string
+	RollbackStatement *sql.NullString
+	RollbackError     *sql.NullString
 }
 
 // TaskStatusPatch is the API message for patching a task status.

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -355,7 +355,7 @@ func (s *Scheduler) PatchTask(ctx context.Context, task *store.TaskMessage, task
 	// Reset rollbackStatement and rollbackError because we are trying to build
 	// the rollbackStatement again and there could be previous runs.
 	if taskPatch.RollbackEnabled != nil && *taskPatch.RollbackEnabled {
-		var ptrStr *string = nil
+		var ptrStr *string
 		taskPatch.RollbackStatement = &ptrStr
 		taskPatch.RollbackError = &ptrStr
 	}

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -355,9 +355,9 @@ func (s *Scheduler) PatchTask(ctx context.Context, task *store.TaskMessage, task
 	// Reset rollbackStatement and rollbackError because we are trying to build
 	// the rollbackStatement again and there could be previous runs.
 	if taskPatch.RollbackEnabled != nil && *taskPatch.RollbackEnabled {
-		empty := ""
-		taskPatch.RollbackStatement = &empty
-		taskPatch.RollbackError = &empty
+		var ptrStr *string = nil
+		taskPatch.RollbackStatement = &ptrStr
+		taskPatch.RollbackError = &ptrStr
 	}
 
 	taskPatched, err := s.store.UpdateTaskV2(ctx, taskPatch)

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -3,6 +3,7 @@ package taskrun
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -355,9 +356,8 @@ func (s *Scheduler) PatchTask(ctx context.Context, task *store.TaskMessage, task
 	// Reset rollbackStatement and rollbackError because we are trying to build
 	// the rollbackStatement again and there could be previous runs.
 	if taskPatch.RollbackEnabled != nil && *taskPatch.RollbackEnabled {
-		var ptrStr *string
-		taskPatch.RollbackStatement = &ptrStr
-		taskPatch.RollbackError = &ptrStr
+		taskPatch.RollbackStatement = &sql.NullString{}
+		taskPatch.RollbackError = &sql.NullString{}
 	}
 
 	taskPatched, err := s.store.UpdateTaskV2(ctx, taskPatch)

--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -597,12 +597,12 @@ func (s *Server) getPipelineCreateForDatabaseRollback(ctx context.Context, issue
 	switch {
 	case !taskPayload.RollbackEnabled:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Rollback SQL is not requested to build.")
-	case taskPayload.RollbackStatement == "" && taskPayload.RollbackError == "":
+	case taskPayload.RollbackStatement == nil && taskPayload.RollbackError == nil:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d is still in progress", taskID))
-	case taskPayload.RollbackStatement == "" && taskPayload.RollbackError != "":
-		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d has already failed: %s", taskID, taskPayload.RollbackError))
-	case taskPayload.RollbackStatement != "" && taskPayload.RollbackError != "":
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Invalid task payload: RollbackStatement=%q, RollbackError=%q", taskPayload.RollbackStatement, taskPayload.RollbackError))
+	case taskPayload.RollbackStatement == nil && taskPayload.RollbackError != nil:
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d has already failed: %s", taskID, *taskPayload.RollbackError))
+	case taskPayload.RollbackStatement != nil && taskPayload.RollbackError != nil:
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Invalid task payload: RollbackStatement=%q, RollbackError=%q", *taskPayload.RollbackStatement, *taskPayload.RollbackError))
 	}
 
 	issueCreateContext := &api.MigrationContext{
@@ -610,7 +610,7 @@ func (s *Server) getPipelineCreateForDatabaseRollback(ctx context.Context, issue
 			{
 				MigrationType: db.Data,
 				DatabaseID:    *task.DatabaseID,
-				Statement:     taskPayload.RollbackStatement,
+				Statement:     *taskPayload.RollbackStatement,
 			},
 		},
 	}

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -434,10 +434,18 @@ func (s *Store) UpdateTaskV2(ctx context.Context, patch *api.TaskPatch) (*TaskMe
 		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackEnabled', to_jsonb($%d::BOOLEAN))`, len(args)+1)), append(args, *v)
 	}
 	if v := patch.RollbackStatement; v != nil {
-		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, *v)
+		if *v == nil {
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, nil)
+		} else {
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, **v)
+		}
 	}
 	if v := patch.RollbackError; v != nil {
-		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackError', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, *v)
+		if *v == nil {
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackError', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, nil)
+		} else {
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackError', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, **v)
+		}
 	}
 	if len(payloadSet) != 0 {
 		set = append(set, fmt.Sprintf(`payload = payload || %s`, strings.Join(payloadSet, "||")))

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -434,17 +434,17 @@ func (s *Store) UpdateTaskV2(ctx context.Context, patch *api.TaskPatch) (*TaskMe
 		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackEnabled', to_jsonb($%d::BOOLEAN))`, len(args)+1)), append(args, *v)
 	}
 	if v := patch.RollbackStatement; v != nil {
-		if *v == nil {
-			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, nil)
+		if v.Valid {
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, v.String)
 		} else {
-			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, **v)
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, nil)
 		}
 	}
 	if v := patch.RollbackError; v != nil {
-		if *v == nil {
-			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackError', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, nil)
+		if v.Valid {
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackError', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, v.String)
 		} else {
-			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackError', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, **v)
+			payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackError', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, nil)
 		}
 	}
 	if len(payloadSet) != 0 {


### PR DESCRIPTION
Differentiate between null and empty rollbackStatement and rollbackError.

We calculate the rollback generation status by rollbackStatement and rollbackError. We consider it running if rollbackStatement == "" and rollbackError == "".
However, a DML task can affect 0 rows, thus the rollback statement is empty. And we wrongly consider a finished as running.
So we need to differentiate between null and empty rollbackStatement.

@LiuJi-Jim FYI