### PR TITLE
feat: improving purchase flow

### DIFF
--- a/frontend/src/components/PricingTable/PricingTable.vue
+++ b/frontend/src/components/PricingTable/PricingTable.vue
@@ -350,7 +350,7 @@ const onButtonClick = (plan: Plan) => {
       return;
     }
     window.open(
-      "https://bytebase.com/pricing?source=console.subscription",
+      "https://hub.bytebase.com/subscription?source=console.subscription",
       "__blank"
     );
   } else if (plan.type === PlanType.ENTERPRISE) {

--- a/frontend/src/locales/subscription/en-US.json
+++ b/frontend/src/locales/subscription/en-US.json
@@ -5,7 +5,7 @@
   "instance-count": "Instance count",
   "expires-at": "Expires at",
   "free-trial": "You can start a free trial for 14 days - no credit card required",
-  "purchase-license": "Purchase a license",
+  "purchase-license": "Purchase a License",
   "sensitive-placeholder": "Paste your license here - write only",
   "plan-compare": "Compare features between different plans",
   "disabled-feature": "This is a premium feature in subscription plan",

--- a/frontend/src/views/BannerSubscription.vue
+++ b/frontend/src/views/BannerSubscription.vue
@@ -1,45 +1,40 @@
 <template>
-  <div class="bg-warning">
-    <div class="mx-auto py-3 px-3">
-      <div class="flex items-center justify-between flex-wrap">
-        <div class="w-0 flex-1 flex items-center">
-          <p class="ml-3 font-medium text-white truncate">
-            <span v-if="isExpired">
-              {{
-                $t("banner.license-expires", {
-                  plan: currentPlan,
-                  expireAt: expireAt,
-                })
-              }}
-            </span>
-            <span v-else-if="isTrialing">
-              {{
-                $t("banner.trial-expires", {
-                  plan: currentPlan,
-                  days: daysBeforeExpire,
-                  expireAt: expireAt,
-                })
-              }}
-            </span>
-          </p>
-        </div>
-        <div
-          class="order-3 mt-2 mr-3 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto"
-        >
-          <a
-            target="_self"
-            href="https://hub.bytebase.com/subscription?source=console.banner"
-            class="flex items-center justify-center p-2 border border-transparent rounded-md shadow-sm text-base font-medium text-accent bg-white hover:bg-indigo-50"
-          >
+  <div class="bg-info">
+    <div class="mx-auto py-1 px-3">
+      <div class="flex items-center justify-center flex-wrap space-x-2">
+        <p class="ml-3 text-base font-medium text-white truncate">
+          <span v-if="isExpired">
             {{
-              $t(
-                isTrialing
-                  ? "subscription.purchase-license"
-                  : "banner.update-license"
-              )
+              $t("banner.license-expires", {
+                plan: currentPlan,
+                expireAt: expireAt,
+              })
             }}
-          </a>
-        </div>
+          </span>
+          <span v-else-if="isTrialing">
+            {{
+              $t("banner.trial-expires", {
+                plan: currentPlan,
+                days: daysBeforeExpire,
+                expireAt: expireAt,
+              })
+            }}
+          </span>
+        </p>
+        <router-link
+          to="/setting/subscription"
+          class="flex items-center justify-center py-1 text-base font-medium cursor-pointer text-white underline hover:opacity-80"
+          exact-active-class=""
+        >
+          {{
+            $t(
+              isTrialing
+                ? "subscription.purchase-license"
+                : "banner.update-license"
+            )
+          }}
+          <heroicons-outline:shopping-cart class="ml-1 h-6 w-6 text-white" />
+        </router-link>
       </div>
     </div>
   </div>

--- a/frontend/src/views/SettingWorkspaceSubscription.vue
+++ b/frontend/src/views/SettingWorkspaceSubscription.vue
@@ -4,7 +4,7 @@
       {{ $t("subscription.description") }}
       <a
         class="text-accent"
-        href="https://bytebase.com/pricing?source=console.subscription"
+        href="https://hub.bytebase.com/subscription?source=console.subscription"
         target="__blank"
       >
         {{ $t("subscription.purchase-license") }}
@@ -69,10 +69,8 @@
       />
       <button
         type="button"
-        :class="[
-          disabled ? 'cursor-not-allowed' : '',
-          'btn-primary inline-flex justify-center ml-auto mt-3',
-        ]"
+        class="btn-primary inline-flex justify-center ml-auto mt-3"
+        :disabled="disabled"
         target="_blank"
         @click="uploadLicense"
       >


### PR DESCRIPTION
* Decrease banner height to save space, align center and use icon to signal.
* The purchase links to the console pricing page instead of the website pricing page.
* Console pricing page links to the hub instead of the website pricing page, which is kind of duplicate info.
* Fix upload license style.

![CleanShot 2023-02-12 at 13-19-33 png](https://user-images.githubusercontent.com/230323/218294351-57bb5bc1-4136-430c-8aa2-36c5f988a74c.png)
