### PR TITLE
feat: update SSO setting pages style

### DIFF
--- a/backend/api/v1/idp_service.go
+++ b/backend/api/v1/idp_service.go
@@ -169,7 +169,7 @@ func (s *IdentityProviderService) UndeleteIdentityProvider(ctx context.Context, 
 
 	patch := &store.UpdateIdentityProviderMessage{
 		ResourceID: identityProvider.ResourceID,
-		Delete:     &deletePatch,
+		Delete:     &undeletePatch,
 	}
 	identityProvider, err = s.store.UpdateIdentityProvider(ctx, patch)
 	if err != nil {

--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -142,6 +142,7 @@ func init() {
 // -----------------------------------Command Line Config END--------------------------------------
 
 func normalizeExternalURL(url string) (string, error) {
+	return "http://localhost:3000", nil
 	r := strings.TrimSpace(url)
 	r = strings.TrimSuffix(r, "/")
 	if !common.HasPrefixes(r, "http://", "https://") {

--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -142,7 +142,6 @@ func init() {
 // -----------------------------------Command Line Config END--------------------------------------
 
 func normalizeExternalURL(url string) (string, error) {
-	return "http://localhost:3000", nil
 	r := strings.TrimSpace(url)
 	r = strings.TrimSuffix(r, "/")
 	if !common.HasPrefixes(r, "http://", "https://") {

--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -126,6 +126,7 @@ export default defineComponent({
     const allowBookmark = computed(() => currentRoute.value.meta.allowBookmark);
 
     const breadcrumbList = computed(() => {
+      const route = currentRoute.value;
       const routeSlug = routerStore.routeSlug(currentRoute.value);
       const environmentSlug = routeSlug.environmentSlug;
       const projectSlug = routeSlug.projectSlug;
@@ -137,6 +138,7 @@ export default defineComponent({
       const migrationHistory = routeSlug.migrationHistorySlug;
       const vcsSlug = routeSlug.vcsSlug;
       const sqlReviewPolicySlug = routeSlug.sqlReviewPolicySlug;
+      const ssoName = routeSlug.ssoName;
 
       const list: Array<BreadcrumbItem> = [];
       if (environmentSlug) {
@@ -193,8 +195,15 @@ export default defineComponent({
           name: t("sql-review.title"),
           path: "/setting/sql-review",
         });
+      } else if (ssoName) {
+        if (route.name !== "setting.workspace.sso.create") {
+          list.push({
+            name: t("settings.sidebar.sso"),
+            path: "/setting/sso",
+          });
+        }
       }
-      const route = currentRoute.value;
+
       const {
         title: routeTitle,
         overrideTitle,

--- a/frontend/src/components/IdentityProviderCreateForm.vue
+++ b/frontend/src/components/IdentityProviderCreateForm.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="w-full flex flex-col justify-start items-start overflow-x-hidden px-1"
-    :class="[isCreating && '!w-128']"
   >
     <div
       v-if="isCreating"
@@ -569,7 +568,6 @@ import {
   defineProps,
   ref,
   onMounted,
-  onUnmounted,
   watch,
 } from "vue";
 import {
@@ -771,32 +769,6 @@ onMounted(async () => {
   }
 });
 
-onMounted(() => {
-  if (
-    state.type === IdentityProviderType.OAUTH2 ||
-    state.type === IdentityProviderType.OIDC
-  ) {
-    window.addEventListener(
-      `bb.oauth.signin.${editedIdentityProvider.value.name}`,
-      loginWithIdentityProviderEventListener,
-      false
-    );
-  }
-});
-
-onUnmounted(() => {
-  if (
-    state.type === IdentityProviderType.OAUTH2 ||
-    state.type === IdentityProviderType.OIDC
-  ) {
-    window.removeEventListener(
-      `bb.oauth.signin.${editedIdentityProvider.value.name}`,
-      loginWithIdentityProviderEventListener,
-      false
-    );
-  }
-});
-
 const loginWithIdentityProviderEventListener = async (event: Event) => {
   const payload = (event as CustomEvent).detail as OAuthWindowEventPayload;
   if (payload.error) {
@@ -949,6 +921,30 @@ watch(
       identityProvider.value.title = "";
       identityProvider.value.name = "";
       identityProvider.value.domain = "";
+    }
+  },
+  {
+    immediate: true,
+  }
+);
+
+watch(
+  () => editedIdentityProvider.value.name,
+  (newName, oldName) => {
+    if (
+      state.type === IdentityProviderType.OAUTH2 ||
+      state.type === IdentityProviderType.OIDC
+    ) {
+      window.removeEventListener(
+        `bb.oauth.signin.${oldName}`,
+        loginWithIdentityProviderEventListener,
+        false
+      );
+      window.addEventListener(
+        `bb.oauth.signin.${newName}`,
+        loginWithIdentityProviderEventListener,
+        false
+      );
     }
   },
   {

--- a/frontend/src/components/IdentityProviderCreateForm.vue
+++ b/frontend/src/components/IdentityProviderCreateForm.vue
@@ -65,7 +65,6 @@
           </label>
         </div>
       </template>
-      <hr class="w-full bg-gray-50" />
       <p class="text-lg font-medium !mt-4">
         {{ $t("settings.sso.form.basic-information") }}
       </p>
@@ -76,6 +75,7 @@
         </p>
         <input
           v-model="identityProvider.title"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           :placeholder="$t('settings.sso.form.name-description')"
@@ -103,6 +103,7 @@
         </p>
         <input
           v-model="identityProvider.domain"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           :placeholder="$t('settings.sso.form.domain-description')"
@@ -121,30 +122,29 @@
       </div>
       <div
         v-if="isCreating"
-        class="w-full flex flex-row justify-start items-center"
+        class="w-auto max-w-full p-4 rounded flex flex-col justify-start items-start border"
       >
-        <p class="textlabel">
-          {{ $t("settings.sso.form.redirect-url") }}
-        </p>
-        <ShowMoreIcon
-          class="ml-1 mr-2"
-          :content="$t('settings.sso.form.redirect-url-description')"
-        />
-        <div class="relative grow">
-          <input
-            type="text"
-            class="textfield w-full pr-10"
-            readonly
-            disabled
-            :value="redirectUrl"
+        <p class="textinfolabel flex flex-row justify-start items-center mb-2">
+          {{ $t("settings.sso.form.identity-provider-needed-information") }}
+          <ShowMoreIcon
+            class="ml-1 mr-2"
+            :content="$t('settings.sso.form.redirect-url-description')"
           />
-          <button
-            tabindex="-1"
-            class="absolute right-0 top-1/2 -translate-y-1/2 mr-2 p-1 text-control-light rounded hover:bg-gray-100"
-            @click.prevent="copyRedirectUrl"
-          >
-            <heroicons-outline:clipboard class="w-5 h-5" />
-          </button>
+        </p>
+        <div class="w-128 flex flex-row justify-start items-center space-x-4">
+          <p class="textlabel my-auto text-right whitespace-nowrap">
+            {{ $t("settings.sso.form.redirect-url") }}
+          </p>
+          <div class="w-full relative break-all pr-8 text-sm">
+            {{ redirectUrl }}
+            <button
+              tabindex="-1"
+              class="absolute right-0 top-1/2 -translate-y-1/2 p-1 text-control-light rounded hover:bg-gray-100"
+              @click.prevent="copyRedirectUrl"
+            >
+              <heroicons-outline:clipboard class="w-5 h-5" />
+            </button>
+          </div>
         </div>
       </div>
       <div class="w-full flex flex-col justify-start items-start">
@@ -154,6 +154,7 @@
         </p>
         <input
           v-model="configForOAuth2.clientId"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. 6655asd77895265aa110ac0d3"
@@ -166,6 +167,7 @@
         </p>
         <input
           v-model="configForOAuth2.clientSecret"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           :placeholder="
@@ -179,12 +181,13 @@
         <p class="textlabel">
           Auth URL
           <span class="text-red-600">*</span>
-          <span class="textinfolabel">
-            ({{ $t("settings.sso.form.auth-url-description") }})
-          </span>
+        </p>
+        <p class="textinfolabel">
+          {{ $t("settings.sso.form.auth-url-description") }}
         </p>
         <input
           v-model="configForOAuth2.authUrl"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. https://github.com/login/oauth/authorize"
@@ -194,12 +197,13 @@
         <p class="textlabel">
           Scopes
           <span class="text-red-600">*</span>
-          <span class="textinfolabel">
-            ({{ $t("settings.sso.form.scopes-description") }})
-          </span>
+        </p>
+        <p class="textinfolabel">
+          {{ $t("settings.sso.form.scopes-description") }}
         </p>
         <input
           v-model="scopesStringOfConfig"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. user"
@@ -209,12 +213,13 @@
         <p class="textlabel">
           Token URL
           <span class="text-red-600">*</span>
-          <span class="textinfolabel">
-            ({{ $t("settings.sso.form.token-url-description") }})
-          </span>
+        </p>
+        <p class="textinfolabel">
+          {{ $t("settings.sso.form.token-url-description") }}
         </p>
         <input
           v-model="configForOAuth2.tokenUrl"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. https://github.com/login/oauth/access_token"
@@ -224,12 +229,13 @@
         <p class="textlabel">
           User information URL
           <span class="text-red-600">*</span>
-          <span class="textinfolabel">
-            ({{ $t("settings.sso.form.user-info-url-description") }})
-          </span>
+        </p>
+        <p class="textinfolabel">
+          {{ $t("settings.sso.form.user-info-url-description") }}
         </p>
         <input
           v-model="configForOAuth2.userInfoUrl"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. https://api.github.com/user"
@@ -255,6 +261,7 @@
       <div class="w-full grid grid-cols-[256px_1fr]">
         <input
           v-model="configForOAuth2.fieldMapping!.identifier"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. login"
@@ -272,6 +279,7 @@
       <div class="w-full grid grid-cols-[256px_1fr]">
         <input
           v-model="configForOAuth2.fieldMapping!.displayName"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. name"
@@ -288,6 +296,7 @@
       <div class="w-full grid grid-cols-[256px_1fr]">
         <input
           v-model="configForOAuth2.fieldMapping!.email"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. email"
@@ -318,6 +327,7 @@
         </p>
         <input
           v-model="identityProvider.title"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           :placeholder="$t('settings.sso.form.name-description')"
@@ -345,6 +355,7 @@
         </p>
         <input
           v-model="identityProvider.domain"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           :placeholder="$t('settings.sso.form.domain-description')"
@@ -363,30 +374,29 @@
       </div>
       <div
         v-if="isCreating"
-        class="w-full flex flex-row justify-start items-center"
+        class="w-auto max-w-full p-4 rounded flex flex-col justify-start items-start border"
       >
-        <p class="textlabel">
-          {{ $t("settings.sso.form.redirect-url") }}
-        </p>
-        <ShowMoreIcon
-          class="ml-1 mr-2"
-          :content="$t('settings.sso.form.redirect-url-description')"
-        />
-        <div class="relative grow">
-          <input
-            type="text"
-            class="textfield w-full pr-10"
-            readonly
-            disabled
-            :value="redirectUrl"
+        <p class="textinfolabel flex flex-row justify-start items-center mb-2">
+          {{ $t("settings.sso.form.identity-provider-needed-information") }}
+          <ShowMoreIcon
+            class="ml-1 mr-2"
+            :content="$t('settings.sso.form.redirect-url-description')"
           />
-          <button
-            tabindex="-1"
-            class="absolute right-0 top-1/2 -translate-y-1/2 mr-2 p-1 text-control-light rounded hover:bg-gray-100"
-            @click.prevent="copyRedirectUrl"
-          >
-            <heroicons-outline:clipboard class="w-5 h-5" />
-          </button>
+        </p>
+        <div class="w-128 flex flex-row justify-start items-center space-x-4">
+          <p class="textlabel my-auto text-right whitespace-nowrap">
+            {{ $t("settings.sso.form.redirect-url") }}
+          </p>
+          <div class="w-full relative break-all pr-8 text-sm">
+            {{ redirectUrl }}
+            <button
+              tabindex="-1"
+              class="absolute right-0 top-1/2 -translate-y-1/2 p-1 text-control-light rounded hover:bg-gray-100"
+              @click.prevent="copyRedirectUrl"
+            >
+              <heroicons-outline:clipboard class="w-5 h-5" />
+            </button>
+          </div>
         </div>
       </div>
       <div class="w-full flex flex-col justify-start items-start">
@@ -396,6 +406,7 @@
         </p>
         <input
           v-model="configForOIDC.issuer"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. https://acme.okta.com"
@@ -408,6 +419,7 @@
         </p>
         <input
           v-model="configForOIDC.clientId"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. 6655asd77895265aa110ac0d3"
@@ -420,6 +432,7 @@
         </p>
         <input
           v-model="configForOIDC.clientSecret"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           :placeholder="
@@ -452,6 +465,7 @@
       <div class="w-full grid grid-cols-[256px_1fr]">
         <input
           v-model="configForOIDC.fieldMapping!.identifier"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. preferred_username"
@@ -469,6 +483,7 @@
       <div class="w-full grid grid-cols-[256px_1fr]">
         <input
           v-model="configForOIDC.fieldMapping!.displayName"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. name"
@@ -485,6 +500,7 @@
       <div class="w-full grid grid-cols-[256px_1fr]">
         <input
           v-model="configForOIDC.fieldMapping!.email"
+          :disabled="!allowEdit"
           type="text"
           class="textfield mt-1 w-full"
           placeholder="e.g. email"
@@ -506,23 +522,40 @@
     >
       <div class="space-x-4 flex flex-row justify-start items-center">
         <button
+          v-if="!isDeleted"
           :disabled="!allowTestConnection"
           class="btn-normal"
           @click="testConnection"
         >
           {{ $t("identity-provider.test-connection") }}
         </button>
-        <BBButtonConfirm
-          v-if="!isCreating"
-          :style="'DELETE'"
-          :button-text="$t('settings.sso.deletion')"
-          :ok-text="'Delete'"
-          :confirm-title="`Delete SSO '${identityProvider.name}'?`"
-          :require-confirm="true"
-          @confirm="handleDeleteButtonClick"
-        />
+        <template v-if="!isCreating">
+          <BBButtonConfirm
+            v-if="!isDeleted"
+            :style="'ARCHIVE'"
+            :button-text="$t('settings.sso.archive')"
+            :ok-text="$t('common.archive')"
+            :confirm-title="$t('settings.sso.archive')"
+            :confirm-description="''"
+            :require-confirm="true"
+            @confirm="handleDeleteButtonClick"
+          />
+          <BBButtonConfirm
+            v-else
+            :style="'RESTORE'"
+            :button-text="$t('settings.sso.restore')"
+            :ok-text="$t('common.restore')"
+            :confirm-title="$t('settings.sso.restore')"
+            :confirm-description="''"
+            :require-confirm="true"
+            @confirm="handleRestoreButtonClick"
+          />
+        </template>
       </div>
-      <div class="space-x-4 flex flex-row justify-end items-center">
+      <div
+        v-if="!isDeleted"
+        class="space-x-4 flex flex-row justify-end items-center"
+      >
         <template v-if="isCreating">
           <button class="btn-normal" @click="handleCancelButtonClick">
             {{ $t("common.cancel") }}
@@ -561,15 +594,7 @@ import { cloneDeep, head, isEqual } from "lodash-es";
 import { ClientError } from "nice-grpc-common";
 import { toClipboard } from "@soerenmartius/vue3-clipboard";
 import { useI18n } from "vue-i18n";
-import {
-  computed,
-  reactive,
-  defineEmits,
-  defineProps,
-  ref,
-  onMounted,
-  watch,
-} from "vue";
+import { computed, reactive, defineProps, ref, onMounted, watch } from "vue";
 import {
   FieldMapping,
   IdentityProvider,
@@ -588,6 +613,8 @@ import {
 } from "@/utils";
 import { OAuthWindowEventPayload } from "@/types";
 import { identityProviderClient } from "@/grpcweb";
+import { State } from "@/types/proto/v1/common";
+import { useRouter } from "vue-router";
 
 interface LocalState {
   type: IdentityProviderType;
@@ -597,13 +624,8 @@ const props = defineProps<{
   identityProviderName?: string;
 }>();
 
-const emit = defineEmits<{
-  (e: "delete", identityProvider: IdentityProvider): void;
-  (e: "cancel"): void;
-  (e: "confirm", identityProvider: IdentityProvider): void;
-}>();
-
 const { t } = useI18n();
+const router = useRouter();
 const identityProviderStore = useIdentityProviderStore();
 const state = reactive<LocalState>({
   type: IdentityProviderType.OAUTH2,
@@ -624,6 +646,12 @@ const configForOIDC = ref<OIDCIdentityProviderConfig>(
 );
 const selectedTemplate = ref<IdentityProviderTemplate>();
 
+const currentIdentityProvider = computed(() => {
+  return identityProviderStore.getIdentityProviderByName(
+    String(props.identityProviderName)
+  );
+});
+
 const identityProviderTypeList = computed(() => {
   return [IdentityProviderType.OAUTH2, IdentityProviderType.OIDC];
 });
@@ -635,7 +663,11 @@ const redirectUrl = computed(() => {
 });
 
 const isCreating = computed(() => {
-  return !props.identityProviderName || props.identityProviderName === "";
+  return currentIdentityProvider.value === undefined;
+});
+
+const isDeleted = computed(() => {
+  return currentIdentityProvider.value?.state === State.DELETED;
 });
 
 const userDocLink = computed(() => {
@@ -697,6 +729,10 @@ const isFormCompleted = computed(() => {
   }
 
   return true;
+});
+
+const allowEdit = computed(() => {
+  return !isDeleted.value;
 });
 
 const allowCreate = computed(() => {
@@ -837,11 +873,38 @@ const handleTemplateSelect = (template: IdentityProviderTemplate) => {
 };
 
 const handleDeleteButtonClick = async () => {
-  emit("delete", identityProvider.value);
+  if (currentIdentityProvider.value) {
+    await identityProviderStore.deleteIdentityProvider(
+      currentIdentityProvider.value.name
+    );
+    pushNotification({
+      module: "bytebase",
+      style: "SUCCESS",
+      title: "Archive SSO succeed",
+    });
+    router.push({
+      name: "setting.workspace.sso",
+    });
+  }
+};
+
+const handleRestoreButtonClick = async () => {
+  if (currentIdentityProvider.value) {
+    await identityProviderStore.undeleteIdentityProvider(
+      currentIdentityProvider.value.name
+    );
+    pushNotification({
+      module: "bytebase",
+      style: "SUCCESS",
+      title: "Restore SSO succeed",
+    });
+  }
 };
 
 const handleCancelButtonClick = () => {
-  emit("cancel");
+  router.push({
+    name: "setting.workspace.sso",
+  });
 };
 
 const updateEditState = (updatedIdentityProvider: IdentityProvider) => {
@@ -885,9 +948,15 @@ const handleCreateButtonClick = async () => {
     throw new Error(`identity provider type ${state.type} is invalid`);
   }
 
-  const createdIdentityProvider =
-    await identityProviderStore.createIdentityProvider(identityProviderCreate);
-  emit("confirm", createdIdentityProvider);
+  await identityProviderStore.createIdentityProvider(identityProviderCreate);
+  pushNotification({
+    module: "bytebase",
+    style: "SUCCESS",
+    title: "Create SSO succeed",
+  });
+  router.push({
+    name: "setting.workspace.sso",
+  });
 };
 
 const handleUpdateButtonClick = async () => {

--- a/frontend/src/components/IdentityProviderTable.vue
+++ b/frontend/src/components/IdentityProviderTable.vue
@@ -54,7 +54,12 @@ const columnList = computed(() => [
 ]);
 
 const clickIdentityProvider = function (section: number, row: number) {
-  const idp = props.identityProviderList[row];
-  router.push(`/setting/sso/${idp.name}`);
+  const identityProvider = props.identityProviderList[row];
+  router.push({
+    name: "setting.workspace.sso.detail",
+    params: {
+      ssoName: identityProvider.name,
+    },
+  });
 };
 </script>

--- a/frontend/src/components/IdentityProviderTable.vue
+++ b/frontend/src/components/IdentityProviderTable.vue
@@ -1,0 +1,60 @@
+<template>
+  <BBTable
+    :column-list="columnList"
+    :data-source="identityProviderList"
+    :show-header="true"
+    :left-bordered="false"
+    :right-bordered="false"
+    @click-row="clickIdentityProvider"
+  >
+    <template #body="{ rowData: identityProvider }">
+      <BBTableCell :left-padding="4" class="w-4 table-cell text-gray-500">
+        <span class="">#{{ identityProvider.uid }}</span>
+      </BBTableCell>
+      <BBTableCell class="w-48 table-cell">
+        {{ identityProvider.title }}
+      </BBTableCell>
+      <BBTableCell class="w-48 table-cell">
+        {{ identityProvider.name }}
+      </BBTableCell>
+      <BBTableCell class="w-48 table-cell">
+        {{ identityProvider.domain }}
+      </BBTableCell>
+    </template>
+  </BBTable>
+</template>
+
+<script lang="ts" setup>
+import { computed, defineProps } from "vue";
+import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { IdentityProvider } from "@/types/proto/v1/idp_service";
+
+const props = defineProps<{
+  identityProviderList: IdentityProvider[];
+}>();
+
+const router = useRouter();
+
+const { t } = useI18n();
+
+const columnList = computed(() => [
+  {
+    title: t("common.id"),
+  },
+  {
+    title: t("common.name"),
+  },
+  {
+    title: t("common.resource-id"),
+  },
+  {
+    title: t("common.domain"),
+  },
+]);
+
+const clickIdentityProvider = function (section: number, row: number) {
+  const idp = props.identityProviderList[row];
+  router.push(`/setting/sso/${idp.name}`);
+};
+</script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -405,7 +405,8 @@
     "sso": {
       "create": "Create SSO",
       "description": "Single Sign-On (SSO) is an authentication method that enables users to authenticate with multiple applications and websites via a single set of credentials.",
-      "deletion": "Delete this SSO",
+      "archive": "Archive this SSO",
+      "restore": "Restore this SSO",
       "form": {
         "type": "Type",
         "learn-more-with-user-doc": "Learn more about the configuration",
@@ -422,6 +423,7 @@
         "domain-description": "The identity provider's domain name",
         "identity-provider-information": "Identity provider information",
         "identity-provider-information-description": "The information is provided by your identity provider.",
+        "identity-provider-needed-information": "Create your SSO application with the following information.",
         "endpoints": "Endpoints",
         "endpoints-description": "The related urls provided by your OAuth provider.",
         "auth-url-description": "The link to OAuth login page",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1323,7 +1323,8 @@
     "archived": "Archived",
     "project-search-bar-placeholder": "Search @.lower:{'common.project'} name",
     "instance-search-bar-placeholder": "Search @.lower:{'common.instance'} name",
-    "environment-search-bar-placeholder": "Search @.lower:{'common.environment'} name"
+    "environment-search-bar-placeholder": "Search @.lower:{'common.environment'} name",
+    "sso-search-bar-placeholder": "Search SSO name"
   },
   "deployment-config": {
     "stage-n": "Stage {n}",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -219,7 +219,9 @@
     "rollback": "Rollback",
     "total": "Total",
     "discard-changes": "Discard changes",
-    "error-message": "Error message"
+    "error-message": "Error message",
+    "resource-id": "Resource ID",
+    "domain": "Domain"
   },
   "error-page": {
     "go-back-home": "Go back home"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -403,7 +403,8 @@
     "sso": {
       "create": "创建 SSO",
       "description": "单点登录（SSO）是一种认证方法，使用户能够通过其他应用程序和网站来进行登录。",
-      "deletion": "删除这个 SSO",
+      "archive": "归档该 SSO",
+      "restore": "恢复该 SSO",
       "form": {
         "type": "类型",
         "learn-more-with-user-doc": "了解更多如何配置",
@@ -420,6 +421,7 @@
         "domain-description": "OAuth 提供商的域名",
         "identity-provider-information": "OAuth 提供商信息",
         "identity-provider-information-description": "这些信息是由你的身份提供商提供的。",
+        "identity-provider-needed-information": "用以下信息创建你的 SSO 应用程序。",
         "endpoints": "链接信息",
         "endpoints-description": "链接信息是由你的 OAuth 提供商提供。",
         "auth-url-description": "登录页面的链接",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1320,8 +1320,9 @@
   "archive": {
     "archived": "已归档",
     "project-search-bar-placeholder": "搜索@.lower:{'common.project'}的名称",
-    "instance-bar-placeholder": "搜索@.lower:{'common.instance'}的名称",
-    "environment-bar-placeholder": "搜索@.lower:{'common.environment'}的名称"
+    "instance-search-bar-placeholder": "搜索@.lower:{'common.instance'}的名称",
+    "environment-search-bar-placeholder": "搜索@.lower:{'common.environment'}的名称",
+    "sso-search-bar-placeholder": "搜索 SSO 的名称"
   },
   "deployment-config": {
     "stage-n": "阶段 {n}",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -347,6 +347,20 @@ const routes: Array<RouteRecordRaw> = [
                 name: "setting.workspace.sso",
                 meta: { title: () => t("settings.sidebar.sso") },
                 component: () => import("../views/SettingWorkspaceSSO.vue"),
+              },
+              {
+                path: "sso/new",
+                name: "setting.workspace.sso.create",
+                meta: { title: () => t("settings.sidebar.sso") },
+                component: () =>
+                  import("../views/SettingWorkspaceSSODetail.vue"),
+              },
+              {
+                path: "sso/:name",
+                name: "setting.workspace.sso.detail",
+                meta: { title: () => t("settings.sidebar.sso") },
+                component: () =>
+                  import("../views/SettingWorkspaceSSODetail.vue"),
                 props: true,
               },
               {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -49,6 +49,7 @@ import {
   useConnectionTreeStore,
   useOnboardingStateStore,
   useTabStore,
+  useIdentityProviderStore,
 } from "@/store";
 
 const HOME_MODULE = "workspace.home";
@@ -356,9 +357,17 @@ const routes: Array<RouteRecordRaw> = [
                   import("../views/SettingWorkspaceSSODetail.vue"),
               },
               {
-                path: "sso/:name",
+                path: "sso/:ssoName",
                 name: "setting.workspace.sso.detail",
-                meta: { title: () => t("settings.sidebar.sso") },
+                meta: {
+                  title: (route: RouteLocationNormalized) => {
+                    const name = route.params.ssoName as string;
+                    return (
+                      useIdentityProviderStore().getIdentityProviderByName(name)
+                        ?.title || t("settings.sidebar.sso")
+                    );
+                  },
+                },
                 component: () =>
                   import("../views/SettingWorkspaceSSODetail.vue"),
                 props: true,

--- a/frontend/src/store/modules/idp.ts
+++ b/frontend/src/store/modules/idp.ts
@@ -2,6 +2,7 @@ import { isEqual, isUndefined } from "lodash-es";
 import { defineStore } from "pinia";
 import { IdentityProvider } from "@/types/proto/v1/idp_service";
 import { identityProviderClient } from "@/grpcweb";
+import { State } from "@/types/proto/v1/common";
 
 interface IdentityProviderState {
   identityProviderMapByName: Map<string, IdentityProvider>;
@@ -13,13 +14,22 @@ export const useIdentityProviderStore = defineStore("idp", {
   }),
   getters: {
     identityProviderList(state) {
-      return Array.from(state.identityProviderMapByName.values());
+      return Array.from(state.identityProviderMapByName.values()).filter(
+        (idp) => idp.state === State.ACTIVE
+      );
+    },
+    deletedIdentityProviderList(state) {
+      return Array.from(state.identityProviderMapByName.values()).filter(
+        (idp) => idp.state === State.DELETED
+      );
     },
   },
   actions: {
     async fetchIdentityProviderList() {
       const { identityProviders } =
-        await identityProviderClient().listIdentityProviders({});
+        await identityProviderClient().listIdentityProviders({
+          showDeleted: true,
+        });
       for (const identityProvider of identityProviders) {
         this.identityProviderMapByName.set(
           identityProvider.name,

--- a/frontend/src/store/modules/idp.ts
+++ b/frontend/src/store/modules/idp.ts
@@ -88,11 +88,27 @@ export const useIdentityProviderStore = defineStore("idp", {
       );
       return identityProvider;
     },
-    async deleteIdentityProvider(identityProvider: IdentityProvider) {
+    async deleteIdentityProvider(name: string) {
       await identityProviderClient().deleteIdentityProvider({
-        name: identityProvider.name,
+        name,
       });
-      this.identityProviderMapByName.delete(identityProvider.name);
+      const cachedData = this.getIdentityProviderByName(name);
+      if (cachedData) {
+        this.identityProviderMapByName.set(name, {
+          ...cachedData,
+          state: State.DELETED,
+        });
+      }
+    },
+    async undeleteIdentityProvider(name: string) {
+      const identityProvider =
+        await identityProviderClient().undeleteIdentityProvider({
+          name,
+        });
+      this.identityProviderMapByName.set(
+        identityProvider.name,
+        identityProvider
+      );
     },
   },
 });

--- a/frontend/src/store/modules/router.ts
+++ b/frontend/src/store/modules/router.ts
@@ -207,6 +207,20 @@ export const useRouterStore = defineStore("router", {
         }
       }
 
+      {
+        // /setting/sso/:ssoName
+        const ssoComponents = currentRoute.path.match("/setting/sso/(.+)") || [
+          "/",
+          undefined,
+        ];
+
+        if (ssoComponents[1]) {
+          return {
+            ssoName: ssoComponents[1],
+          };
+        }
+      }
+
       return {};
     },
   },

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -68,6 +68,7 @@ export type RouterSlug = {
   connectionSlug?: string;
   sheetSlug?: string;
   sqlReviewPolicySlug?: string;
+  ssoName?: string;
 };
 
 // Quick Action Type

--- a/frontend/src/views/Archive.vue
+++ b/frontend/src/views/Archive.vue
@@ -13,13 +13,7 @@
       <BBTableSearch
         ref="searchField"
         class="w-56"
-        :placeholder="
-          state.selectedIndex == PROJECT_TAB
-            ? $t('archive.project-search-bar-placeholder')
-            : state.selectedIndex == INSTANCE_TAB
-            ? $t('archive.instance-search-bar-placeholder')
-            : $t('archive.environment-search-bar-placeholder')
-        "
+        :placeholder="searchFieldPlaceholder"
         @change-text="(text: string) => changeSearchText(text)"
       />
     </div>
@@ -91,6 +85,20 @@ export default defineComponent({
     });
 
     const currentUser = useCurrentUser();
+
+    const searchFieldPlaceholder = computed(() => {
+      if (state.selectedIndex == PROJECT_TAB) {
+        return t("archive.project-search-bar-placeholder");
+      } else if (state.selectedIndex == INSTANCE_TAB) {
+        return t("archive.instance-search-bar-placeholder");
+      } else if (state.selectedIndex == ENVIRONMENT_TAB) {
+        return t("archive.environment-search-bar-placeholder");
+      } else if (state.selectedIndex == SSO_TAB) {
+        return t("archive.sso-search-bar-placeholder");
+      } else {
+        return "";
+      }
+    });
 
     const prepareList = () => {
       // It will also be called when user logout
@@ -225,6 +233,7 @@ export default defineComponent({
       environmentList,
       deletedSSOList,
       tabItemList,
+      searchFieldPlaceholder,
       filteredProjectList,
       filteredInstanceList,
       filteredEnvironmentList,

--- a/frontend/src/views/SettingWorkspaceSSO.vue
+++ b/frontend/src/views/SettingWorkspaceSSO.vue
@@ -27,48 +27,35 @@
       <img src="../assets/illustration/no-data.webp" class="mt-12 w-96" />
     </div>
     <template v-else>
-      <div class="w-full flex flex-row justify-start items-start space-x-4">
+      <div class="w-full flex flex-col justify-start items-start space-y-4">
         <div
           v-for="identityProvider in identityProviderList"
           :key="identityProvider.name"
-          class="w-28 h-28 px-2 border rounded-md flex flex-col justify-center items-center cursor-pointer"
+          class="w-full flex flex-row justify-between items-center cursor-pointer border p-4 space-x-4"
           @click="state.selectedIdentityProviderName = identityProvider.name"
         >
-          <span class="max-w-full truncate">{{ identityProvider.title }}</span>
-          <span class="text-sm text-gray-400"
-            >({{ identityProviderTypeToString(identityProvider.type) }})</span
-          >
-          <input
-            type="radio"
-            class="btn mt-2"
-            :checked="
-              state.selectedIdentityProviderName === identityProvider.name
-            "
-          />
+          <div class="flex flex-col justify-start items-start">
+            <p>
+              <span class="max-w-full truncate">{{
+                identityProvider.title
+              }}</span>
+              <span class="text-sm text-gray-400 ml-1"
+                >({{
+                  identityProviderTypeToString(identityProvider.type)
+                }})</span
+              >
+            </p>
+            <p class="textinfolabel text-xs">
+              {{ $t("common.resource-id") }}: {{ identityProvider.name }}
+            </p>
+          </div>
+          <button class="btn-normal" @click="handleViewSSO(identityProvider)">
+            {{ $t("common.view") }}
+          </button>
         </div>
       </div>
     </template>
-
-    <!-- Edit form -->
-    <div v-if="selectedIdentityProvider" class="pb-6">
-      <IdentityProviderCreateForm
-        :key="selectedIdentityProvider.name"
-        :identity-provider-name="selectedIdentityProvider.name"
-        @delete="handleDeleteIdentityProvider"
-      />
-    </div>
   </div>
-
-  <BBModal
-    v-if="state.showCreatingSSOModal"
-    :title="$t('settings.sso.create')"
-    @close="hideCreateSSOModal"
-  >
-    <IdentityProviderCreateForm
-      @cancel="hideCreateSSOModal"
-      @confirm="handleCreateIdentityProvider"
-    />
-  </BBModal>
 
   <FeatureModal
     v-if="state.showFeatureModal"
@@ -82,7 +69,6 @@ import { head } from "lodash-es";
 import { computed, reactive, watch, watchEffect } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useIdentityProviderStore } from "@/store/modules/idp";
-import IdentityProviderCreateForm from "@/components/IdentityProviderCreateForm.vue";
 import { IdentityProvider } from "@/types/proto/v1/idp_service";
 import { identityProviderTypeToString } from "@/utils";
 import { featureToRef } from "@/store";
@@ -105,12 +91,6 @@ const hasSSOFeature = featureToRef("bb.feature.sso");
 
 const identityProviderList = computed(() => {
   return identityProviderStore.identityProviderList;
-});
-
-const selectedIdentityProvider = computed(() => {
-  return identityProviderList.value.find(
-    (idp) => idp.name === state.selectedIdentityProviderName
-  );
 });
 
 watchEffect(() => {
@@ -142,27 +122,21 @@ const handleCreateSSO = () => {
     state.showFeatureModal = true;
     return;
   }
-  state.showCreatingSSOModal = true;
+  router.push({
+    name: "setting.workspace.sso.create",
+  });
 };
 
-const hideCreateSSOModal = () => {
-  state.showCreatingSSOModal = false;
-};
-
-const handleDeleteIdentityProvider = async (
-  identityProvider: IdentityProvider
-) => {
-  await identityProviderStore.deleteIdentityProvider(identityProvider);
-  if (state.selectedIdentityProviderName === identityProvider.name) {
-    state.selectedIdentityProviderName =
-      head(identityProviderList.value)?.name || "";
+const handleViewSSO = (identityProvider: IdentityProvider) => {
+  if (!hasSSOFeature.value) {
+    state.showFeatureModal = true;
+    return;
   }
-};
-
-const handleCreateIdentityProvider = async (
-  identityProvider: IdentityProvider
-) => {
-  state.selectedIdentityProviderName = identityProvider.name;
-  hideCreateSSOModal();
+  router.push({
+    name: "setting.workspace.sso.detail",
+    params: {
+      name: identityProvider.name,
+    },
+  });
 };
 </script>

--- a/frontend/src/views/SettingWorkspaceSSODetail.vue
+++ b/frontend/src/views/SettingWorkspaceSSODetail.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="w-full mt-4 space-y-4">
+    <div class="w-full flex flex-row justify-between items-center">
+      <div class="textinfolabel mr-4">
+        {{ $t("settings.sso.description") }}
+        <a
+          href="https://bytebase.com/docs/administration/sso?source=console"
+          class="normal-link inline-flex flex-row items-center"
+          target="_blank"
+        >
+          {{ $t("common.learn-more") }}
+          <heroicons-outline:external-link class="w-4 h-4" />
+        </a>
+      </div>
+    </div>
+    <hr />
+  </div>
+
+  <IdentityProviderCreateForm
+    class="py-4"
+    :identity-provider-name="selectedIdentityProvider?.name"
+    @confirm="handleCreateIdentityProvider"
+  />
+
+  <FeatureModal
+    v-if="state.showFeatureModal"
+    feature="bb.feature.sso"
+    @cancel="state.showFeatureModal = false"
+  />
+</template>
+
+<script lang="ts" setup>
+import { head } from "lodash-es";
+import { computed, onMounted, reactive, watch, watchEffect } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useIdentityProviderStore } from "@/store/modules/idp";
+import IdentityProviderCreateForm from "@/components/IdentityProviderCreateForm.vue";
+import { IdentityProvider } from "@/types/proto/v1/idp_service";
+
+interface LocalState {
+  showFeatureModal: boolean;
+  selectedIdentityProviderName: string;
+}
+
+const route = useRoute();
+const router = useRouter();
+const state = reactive<LocalState>({
+  showFeatureModal: false,
+  selectedIdentityProviderName: "",
+});
+const identityProviderStore = useIdentityProviderStore();
+
+const identityProviderList = computed(() => {
+  return identityProviderStore.identityProviderList;
+});
+
+const selectedIdentityProvider = computed(() => {
+  return identityProviderList.value.find(
+    (idp) => idp.name === route.params.name
+  );
+});
+
+onMounted(() => {
+  console.log("here");
+});
+
+watchEffect(() => {
+  const hashValue = route.hash.slice(1);
+  const identityProviderNameList = identityProviderList.value.map(
+    (idp) => idp.name
+  );
+  if (identityProviderNameList.includes(hashValue)) {
+    state.selectedIdentityProviderName = hashValue;
+  } else {
+    state.selectedIdentityProviderName = head(identityProviderNameList) || "";
+  }
+});
+
+watch(
+  () => state.selectedIdentityProviderName,
+  () => {
+    const hashValue = `#${state.selectedIdentityProviderName}`;
+    if (route.hash !== hashValue) {
+      router.push({
+        hash: hashValue,
+      });
+    }
+  }
+);
+
+const handleDeleteIdentityProvider = async (
+  identityProvider: IdentityProvider
+) => {
+  await identityProviderStore.deleteIdentityProvider(identityProvider);
+  if (state.selectedIdentityProviderName === identityProvider.name) {
+    state.selectedIdentityProviderName =
+      head(identityProviderList.value)?.name || "";
+  }
+};
+
+const handleCreateIdentityProvider = async (
+  identityProvider: IdentityProvider
+) => {
+  state.selectedIdentityProviderName = identityProvider.name;
+};
+</script>


### PR DESCRIPTION
1. Support archive/restore SSO;

    <img width="1376" alt="image" src="https://user-images.githubusercontent.com/24653555/218299412-27e02aee-cec1-4534-9fbe-d56592d77ea6.png">

2. Use list style for SSO setting page;

    <img width="1375" alt="image" src="https://user-images.githubusercontent.com/24653555/218299398-7b8fc241-80c6-45ec-84e9-20a2b5d444db.png">

3. Use page instead of dialog for creating SSO;

Close BYT-2530