### PR TITLE
feat: rollback generation status

### DIFF
--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -164,6 +164,18 @@ type TaskDatabaseSchemaUpdateGhostCutoverPayload struct {
 	SkippedReason string `json:"skippedReason,omitempty"`
 }
 
+// RollbackStatus is the status of a rollback SQL generation task.
+type RollbackStatus string
+
+const (
+	// RollbackStatusPending means the rollback SQL generation task is pending.
+	RollbackStatusPending RollbackStatus = "PENDING"
+	// RollbackStatusDone means the rollback SQL generation task finished and has no error.
+	RollbackStatusDone RollbackStatus = "DONE"
+	// RollbackStatusFailed means the rollback SQL generation task failed.
+	RollbackStatusFailed RollbackStatus = "FAILED"
+)
+
 // TaskDatabaseDataUpdatePayload is the task payload for database data update (DML).
 type TaskDatabaseDataUpdatePayload struct {
 	// Common fields
@@ -179,6 +191,8 @@ type TaskDatabaseDataUpdatePayload struct {
 
 	// Build the RollbackStatement if RollbackEnabled.
 	RollbackEnabled bool `json:"rollbackEnabled,omitempty"`
+	// RollbackStatus is the status of the rollback generation.
+	RollbackStatus RollbackStatus `json:"rollbackStatus,omitempty"`
 	// ThreadID is the ID of the connection executing the migration.
 	// We use it to filter the binlog events of the migration transaction.
 	ThreadID string `json:"threadId,omitempty"`
@@ -333,6 +347,7 @@ type TaskPatch struct {
 	Statement         *string `jsonapi:"attr,statement"`
 	SchemaVersion     *string
 	RollbackEnabled   *bool `jsonapi:"attr,rollbackEnabled"`
+	RollbackStatus    *RollbackStatus
 	RollbackStatement *string
 	RollbackError     *string
 }

--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -164,16 +164,16 @@ type TaskDatabaseSchemaUpdateGhostCutoverPayload struct {
 	SkippedReason string `json:"skippedReason,omitempty"`
 }
 
-// RollbackStatus is the status of a rollback SQL generation task.
-type RollbackStatus string
+// RollbackSQLStatus is the status of a rollback SQL generation task.
+type RollbackSQLStatus string
 
 const (
-	// RollbackStatusPending means the rollback SQL generation task is pending.
-	RollbackStatusPending RollbackStatus = "PENDING"
-	// RollbackStatusDone means the rollback SQL generation task finished and has no error.
-	RollbackStatusDone RollbackStatus = "DONE"
-	// RollbackStatusFailed means the rollback SQL generation task failed.
-	RollbackStatusFailed RollbackStatus = "FAILED"
+	// RollbackSQLStatusPending means the rollback SQL generation task is pending.
+	RollbackSQLStatusPending RollbackSQLStatus = "PENDING"
+	// RollbackSQLStatusDone means the rollback SQL generation task finished and has no error.
+	RollbackSQLStatusDone RollbackSQLStatus = "DONE"
+	// RollbackSQLStatusFailed means the rollback SQL generation task failed.
+	RollbackSQLStatusFailed RollbackSQLStatus = "FAILED"
 )
 
 // TaskDatabaseDataUpdatePayload is the task payload for database data update (DML).
@@ -191,8 +191,8 @@ type TaskDatabaseDataUpdatePayload struct {
 
 	// Build the RollbackStatement if RollbackEnabled.
 	RollbackEnabled bool `json:"rollbackEnabled,omitempty"`
-	// RollbackStatus is the status of the rollback generation.
-	RollbackStatus RollbackStatus `json:"rollbackStatus,omitempty"`
+	// RollbackSQLStatus is the status of the rollback generation.
+	RollbackSQLStatus RollbackSQLStatus `json:"rollbackSqlStatus,omitempty"`
 	// ThreadID is the ID of the connection executing the migration.
 	// We use it to filter the binlog events of the migration transaction.
 	ThreadID string `json:"threadId,omitempty"`
@@ -347,7 +347,7 @@ type TaskPatch struct {
 	Statement         *string `jsonapi:"attr,statement"`
 	SchemaVersion     *string
 	RollbackEnabled   *bool `jsonapi:"attr,rollbackEnabled"`
-	RollbackStatus    *RollbackStatus
+	RollbackSQLStatus *RollbackSQLStatus
 	RollbackStatement *string
 	RollbackError     *string
 }

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -356,8 +356,8 @@ func (s *Scheduler) PatchTask(ctx context.Context, task *store.TaskMessage, task
 	// the rollbackStatement again and there could be previous runs.
 	if taskPatch.RollbackEnabled != nil && *taskPatch.RollbackEnabled {
 		empty := ""
-		pending := api.RollbackStatusPending
-		taskPatch.RollbackStatus = &pending
+		pending := api.RollbackSQLStatusPending
+		taskPatch.RollbackSQLStatus = &pending
 		taskPatch.RollbackStatement = &empty
 		taskPatch.RollbackError = &empty
 	}

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -352,13 +352,19 @@ func (s *Scheduler) PatchTask(ctx context.Context, task *store.TaskMessage, task
 		}
 	}
 
-	// Reset rollbackStatement and rollbackError because we are trying to build
+	// Reset because we are trying to build
 	// the rollbackStatement again and there could be previous runs.
 	if taskPatch.RollbackEnabled != nil && *taskPatch.RollbackEnabled {
 		empty := ""
+		pending := api.RollbackStatusPending
+		taskPatch.RollbackStatus = &pending
 		taskPatch.RollbackStatement = &empty
 		taskPatch.RollbackError = &empty
 	}
+	// if *taskPatch.RollbackEnabled == false, we don't reset
+	// 1. they are meaningless anyway if rollback is disabled
+	// 2. they will be reset when enabling
+	// 3. we cancel the generation after writing to db. The rollback sql generation may finish and write to db, too.
 
 	taskPatched, err := s.store.UpdateTaskV2(ctx, taskPatch)
 	if err != nil {
@@ -371,8 +377,9 @@ func (s *Scheduler) PatchTask(ctx context.Context, task *store.TaskMessage, task
 		}
 	}
 
+	// enqueue or cancel after it's written to the database.
 	if taskPatch.RollbackEnabled != nil {
-		// Enqueue the task if it's done.
+		// Enqueue the rollback sql generation if the task done.
 		if *taskPatch.RollbackEnabled && taskPatched.Status == api.TaskDone {
 			s.stateCfg.RollbackGenerate.Store(taskPatched.ID, taskPatched)
 		} else {

--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -596,13 +596,11 @@ func (s *Server) getPipelineCreateForDatabaseRollback(ctx context.Context, issue
 	}
 	switch {
 	case !taskPayload.RollbackEnabled:
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "Rollback SQL is not requested to build.")
-	case taskPayload.RollbackStatement == "" && taskPayload.RollbackError == "":
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Rollback SQL generation is not enabled.")
+	case taskPayload.RollbackStatus == api.RollbackStatusPending:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d is still in progress", taskID))
-	case taskPayload.RollbackStatement == "" && taskPayload.RollbackError != "":
+	case taskPayload.RollbackStatus == api.RollbackStatusFailed:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d has already failed: %s", taskID, taskPayload.RollbackError))
-	case taskPayload.RollbackStatement != "" && taskPayload.RollbackError != "":
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Invalid task payload: RollbackStatement=%q, RollbackError=%q", taskPayload.RollbackStatement, taskPayload.RollbackError))
 	}
 
 	issueCreateContext := &api.MigrationContext{
@@ -1105,6 +1103,7 @@ func getUpdateTask(database *store.DatabaseMessage, instance *store.InstanceMess
 			SchemaVersion:   schemaVersion,
 			VCSPushEvent:    vcsPushEvent,
 			RollbackEnabled: d.RollbackEnabled,
+			RollbackStatus:  api.RollbackStatusPending,
 		}
 		bytes, err := json.Marshal(payload)
 		if err != nil {

--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -597,9 +597,9 @@ func (s *Server) getPipelineCreateForDatabaseRollback(ctx context.Context, issue
 	switch {
 	case !taskPayload.RollbackEnabled:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Rollback SQL generation is not enabled.")
-	case taskPayload.RollbackStatus == api.RollbackStatusPending:
+	case taskPayload.RollbackSQLStatus == api.RollbackSQLStatusPending:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d is still in progress", taskID))
-	case taskPayload.RollbackStatus == api.RollbackStatusFailed:
+	case taskPayload.RollbackSQLStatus == api.RollbackSQLStatusFailed:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rollback SQL generation for task %d has already failed: %s", taskID, taskPayload.RollbackError))
 	}
 
@@ -1098,12 +1098,12 @@ func getUpdateTask(database *store.DatabaseMessage, instance *store.InstanceMess
 		taskName = fmt.Sprintf("DML(data) for database %q", database.DatabaseName)
 		taskType = api.TaskDatabaseDataUpdate
 		payload := api.TaskDatabaseDataUpdatePayload{
-			Statement:       d.Statement,
-			SheetID:         d.SheetID,
-			SchemaVersion:   schemaVersion,
-			VCSPushEvent:    vcsPushEvent,
-			RollbackEnabled: d.RollbackEnabled,
-			RollbackStatus:  api.RollbackStatusPending,
+			Statement:         d.Statement,
+			SheetID:           d.SheetID,
+			SchemaVersion:     schemaVersion,
+			VCSPushEvent:      vcsPushEvent,
+			RollbackEnabled:   d.RollbackEnabled,
+			RollbackSQLStatus: api.RollbackSQLStatusPending,
 		}
 		bytes, err := json.Marshal(payload)
 		if err != nil {

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -420,8 +420,8 @@ func (s *Store) UpdateTaskV2(ctx context.Context, patch *api.TaskPatch) (*TaskMe
 	if (patch.Statement != nil || patch.SchemaVersion != nil) && patch.Payload != nil {
 		return nil, errors.Errorf("cannot set both statement/schemaVersion and payload for TaskPatch")
 	}
-	if (patch.RollbackEnabled != nil || patch.RollbackStatus != nil || patch.RollbackStatement != nil || patch.RollbackError != nil) && patch.Payload != nil {
-		return nil, errors.Errorf("cannot set both rollbackEnabled/rollbackStatus/rollbackStatement/rollbackError payload for TaskPatch")
+	if (patch.RollbackEnabled != nil || patch.RollbackSQLStatus != nil || patch.RollbackStatement != nil || patch.RollbackError != nil) && patch.Payload != nil {
+		return nil, errors.Errorf("cannot set both rollbackEnabled/rollbackSQLStatus/rollbackStatement/rollbackError payload for TaskPatch")
 	}
 	var payloadSet []string
 	if v := patch.Statement; v != nil {
@@ -433,8 +433,8 @@ func (s *Store) UpdateTaskV2(ctx context.Context, patch *api.TaskPatch) (*TaskMe
 	if v := patch.RollbackEnabled; v != nil {
 		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackEnabled', to_jsonb($%d::BOOLEAN))`, len(args)+1)), append(args, *v)
 	}
-	if v := patch.RollbackStatus; v != nil {
-		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatus', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, *v)
+	if v := patch.RollbackSQLStatus; v != nil {
+		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackSqlStatus', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, *v)
 	}
 	if v := patch.RollbackStatement; v != nil {
 		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, *v)

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -420,8 +420,8 @@ func (s *Store) UpdateTaskV2(ctx context.Context, patch *api.TaskPatch) (*TaskMe
 	if (patch.Statement != nil || patch.SchemaVersion != nil) && patch.Payload != nil {
 		return nil, errors.Errorf("cannot set both statement/schemaVersion and payload for TaskPatch")
 	}
-	if (patch.RollbackEnabled != nil || patch.RollbackStatement != nil || patch.RollbackError != nil) && patch.Payload != nil {
-		return nil, errors.Errorf("cannot set both rollbackEnabled/rollbackStatement/rollbackError payload for TaskPatch")
+	if (patch.RollbackEnabled != nil || patch.RollbackStatus != nil || patch.RollbackStatement != nil || patch.RollbackError != nil) && patch.Payload != nil {
+		return nil, errors.Errorf("cannot set both rollbackEnabled/rollbackStatus/rollbackStatement/rollbackError payload for TaskPatch")
 	}
 	var payloadSet []string
 	if v := patch.Statement; v != nil {
@@ -432,6 +432,9 @@ func (s *Store) UpdateTaskV2(ctx context.Context, patch *api.TaskPatch) (*TaskMe
 	}
 	if v := patch.RollbackEnabled; v != nil {
 		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackEnabled', to_jsonb($%d::BOOLEAN))`, len(args)+1)), append(args, *v)
+	}
+	if v := patch.RollbackStatus; v != nil {
+		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatus', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, *v)
 	}
 	if v := patch.RollbackStatement; v != nil {
 		payloadSet, args = append(payloadSet, fmt.Sprintf(`jsonb_build_object('rollbackStatement', to_jsonb($%d::TEXT))`, len(args)+1)), append(args, *v)


### PR DESCRIPTION
retry #4690 

Add a status field because we thought we could calculate the status by rollbackStatement and rollbackError by assuming that rollbackStatement is not "" for a completed generation but it turns out not.