### PR TITLE
chore(idp): debug log for user claims

### DIFF
--- a/backend/plugin/idp/oauth2/oauth2.go
+++ b/backend/plugin/idp/oauth2/oauth2.go
@@ -95,6 +95,7 @@ func (p *IdentityProvider) UserInfo(token string) (*storepb.IdentityProviderUser
 		log.Error("Failed to unmarshal response body", zap.String("token", token), zap.String("body", string(body)), zap.Error(err))
 		return nil, errors.Wrap(err, "failed to unmarshal response body")
 	}
+	log.Debug("User info", zap.Any("claims", claims))
 
 	userInfo := &storepb.IdentityProviderUserInfo{}
 	if v, ok := claims[p.config.FieldMapping.Identifier].(string); ok {


### PR DESCRIPTION
Adds debug-level logging after we unmarshaled user claims from the IdP response for easier troubleshooting.

## Test plan

```
2023-02-13T11:54:50.981+0800	DEBUG	oidc/oidc.go:109	User info	{"claims": {"email_verified":false,"family_name":"REDACTED","given_name":"REDACTED","name":"REDACTED","preferred_username":"admin","sub":"3c2f21e3-0abd-4f58-bf15-c9551a7bf713"}}
```