### PR TITLE
chore(frontend): use RollbackSQLStatus

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -304,7 +304,8 @@
       "log": "Log",
       "failed": "Failed",
       "preview-rollback": "Preview rollback",
-      "logging": "Logging"
+      "logging": "Logging",
+      "empty-rollback-statement": "The rollback statement is empty"
     }
   },
   "banner": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -301,7 +301,8 @@
       "sql-rollback": "SQL 回滚",
       "log": "记录",
       "failed": "失败",
-      "logging": "记录中"
+      "logging": "记录中",
+      "empty-rollback-statement": "回滚语句为空"
     }
   },
   "banner": {

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -112,6 +112,8 @@ export type TaskDatabasePITRDeletePayload = {
   // more input and output parameters in the future
 };
 
+export type RollbackSQLStatus = "PENDING" | "DONE" | "FAILED";
+
 export type TaskDatabaseDataUpdatePayload = {
   skipped: boolean;
   skippedReason: string;
@@ -119,6 +121,7 @@ export type TaskDatabaseDataUpdatePayload = {
   sheetId: SheetId;
   pushEvent?: VCSPushEvent;
   rollbackEnabled: boolean;
+  rollbackSqlStatus?: RollbackSQLStatus;
   rollbackStatement?: string;
   rollbackError?: string;
   rollbackFromIssueId?: IssueId;


### PR DESCRIPTION
Use the new field introduced by #4716 to make the logic more stable.

We can now detect the scene that the rollback statement was generated successfully as an empty string (usually 0 rows affected by the original SQL).
![localhost_3000_issue_ggg-change-data-02-13-1342-utc0800-350_stage=beta-stage-1 task=dmldata-for-database-ggg-876(1600_900)](https://user-images.githubusercontent.com/2749742/218381500-9fc183af-d8b6-491d-ba0c-85487424d44b.png)
