### PR TITLE
chore: backfill bytebase user to SSO

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -526,7 +526,7 @@ func (s *AuthService) getUserWithLoginRequestOfIdentityProvider(ctx context.Cont
 	if user == nil {
 		// Backfill the existing user with same email for special case.
 		// TODO(steven): remove this after vcs->idp backfill done.
-		existBytebaseUser, err := s.store.GetUser(ctx, &store.FindUserMessage{
+		existBytebaseUsers, err := s.store.ListUsers(ctx, &store.FindUserMessage{
 			Email:                      &userInfo.Email,
 			IdentityProviderResourceID: &emptyIdentityProvider,
 		})
@@ -534,7 +534,8 @@ func (s *AuthService) getUserWithLoginRequestOfIdentityProvider(ctx context.Cont
 			return nil, status.Errorf(codes.Internal, "failed to get user")
 		}
 
-		if existBytebaseUser != nil {
+		if len(existBytebaseUsers) == 1 {
+			existBytebaseUser := existBytebaseUsers[0]
 			user, err = s.store.UpdateUser(ctx, existBytebaseUser.ID, &store.UpdateUserMessage{
 				IdentityProviderID:       &identityProvider.UID,
 				IdentityProviderUserInfo: userInfo,

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -524,7 +524,8 @@ func (s *AuthService) getUserWithLoginRequestOfIdentityProvider(ctx context.Cont
 		return nil, status.Errorf(codes.Internal, "failed to get principal")
 	}
 	if user == nil {
-		// Backfill the existing user with same email for special case.
+		// Find the existing user who has the same email, and update her
+		// with identity provider id and userinfo.
 		// TODO(steven): remove this after vcs->idp backfill done.
 		existBytebaseUsers, err := s.store.ListUsers(ctx, &store.FindUserMessage{
 			Email:                      &userInfo.Email,

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -531,7 +531,7 @@ func (s *AuthService) getUserWithLoginRequestOfIdentityProvider(ctx context.Cont
 			IdentityProviderResourceID: &emptyIdentityProvider,
 		})
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to get user")
+			return nil, status.Errorf(codes.Internal, "failed to list users")
 		}
 
 		if len(existBytebaseUsers) == 1 {

--- a/backend/store/principal.go
+++ b/backend/store/principal.go
@@ -92,6 +92,7 @@ type UpdateUserMessage struct {
 	Name                     *string
 	PasswordHash             *string
 	Role                     *api.Role
+	IdentityProviderID       *int
 	IdentityProviderUserInfo *storepb.IdentityProviderUserInfo
 	Delete                   *bool
 }
@@ -395,6 +396,9 @@ func (s *Store) UpdateUser(ctx context.Context, userID int, patch *UpdateUserMes
 	}
 	if v := patch.PasswordHash; v != nil {
 		principalSet, principalArgs = append(principalSet, fmt.Sprintf("password_hash = $%d", len(principalArgs)+1)), append(principalArgs, *v)
+	}
+	if v := patch.IdentityProviderID; v != nil {
+		principalSet, principalArgs = append(principalSet, fmt.Sprintf("idp_id = $%d", len(principalArgs)+1)), append(principalArgs, *v)
 	}
 	if v := patch.IdentityProviderUserInfo; v != nil {
 		userInfoBytes, err := protojson.Marshal(v)


### PR DESCRIPTION
This PR add the backfill code for principal table. 

We will update `idp_id` and `idp_user_info` fields for those Bytebase user has the same email with userinfo from SSO provider.