### PR TITLE
fix: correct postgres column list to account for sensitive column

### DIFF
--- a/frontend/src/components/ColumnTable.vue
+++ b/frontend/src/components/ColumnTable.vue
@@ -177,26 +177,36 @@ export default defineComponent({
       }
       return columnList;
     });
-    const POSTGRES_COLUMN_LIST = computed((): BBTableColumn[] => [
-      {
-        title: t("common.name"),
-      },
-      {
-        title: t("common.type"),
-      },
-      {
-        title: t("common.Default"),
-      },
-      {
-        title: t("database.nullable"),
-      },
-      {
-        title: t("db.collation"),
-      },
-      {
-        title: t("database.comment"),
-      },
-    ]);
+    const POSTGRES_COLUMN_LIST = computed(() => {
+      const columnList: BBTableColumn[] = [
+        {
+          title: t("common.name"),
+        },
+        {
+          title: t("common.type"),
+        },
+        {
+          title: t("common.Default"),
+        },
+        {
+          title: t("database.nullable"),
+        },
+        {
+          title: t("db.collation"),
+        },
+        {
+          title: t("database.comment"),
+        },
+      ];
+      if (showSensitiveColumn.value) {
+        columnList.unshift({
+          title: t("database.sensitive"),
+          center: true,
+          nowrap: true,
+        });
+      }
+      return columnList;
+    });
     const CLICKHOUSE_SNOWFLAKE_COLUMN_LIST = computed((): BBTableColumn[] => [
       {
         title: t("common.name"),

--- a/frontend/src/views/sql-editor/EditorCommon/DataTable.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/DataTable.vue
@@ -26,11 +26,11 @@
                 v-bind="tableResize.getColumnProps(header.index)"
               >
                 <div class="flex items-center overflow-hidden">
+                  <span> {{ header.column.columnDef.header }}</span>
                   <SensitiveDataIcon
                     v-if="isSensitiveColumn(header.index)"
-                    class="mr-0.5 shrink-0"
+                    class="ml-0.5 shrink-0"
                   />
-                  <span> {{ header.column.columnDef.header }}</span>
                 </div>
 
                 <!-- The drag-to-resize handler -->


### PR DESCRIPTION
Before the column is offset by 1

![CleanShot 2023-02-13 at 22-59-00 png](https://user-images.githubusercontent.com/230323/218492732-b2e7a927-b828-40c9-aab9-96cb2474c590.png)

Also move the icon to the right of the column header so the text is aligned properly

![CleanShot 2023-02-13 at 22-59-21 png](https://user-images.githubusercontent.com/230323/218492816-57a933cd-daa5-40ee-bf0a-41cadfd7d474.png)
