### PR TITLE
fix: skip checking backup anomalies for unsupported databases

### DIFF
--- a/backend/runner/anomaly/scanner.go
+++ b/backend/runner/anomaly/scanner.go
@@ -364,6 +364,11 @@ func (s *Scanner) checkDatabaseAnomaly(ctx context.Context, instance *store.Inst
 }
 
 func (s *Scanner) checkBackupAnomaly(ctx context.Context, environment *store.EnvironmentMessage, instance *store.InstanceMessage, database *store.DatabaseMessage, policyMap map[int]*api.BackupPlanPolicy) {
+	if instance.Engine == db.MongoDB || instance.Engine == db.Spanner {
+		// skip checking backup anomalies for MongoDB and Spanner because they don't support Backup.
+		return
+	}
+
 	schedule := api.BackupPlanPolicyScheduleUnset
 	backupSetting, err := s.store.GetBackupSettingV2(ctx, database.UID)
 	if err != nil {


### PR DESCRIPTION
e.g. 

![CleanShot 2023-02-14 at 11 05 16@2x](https://user-images.githubusercontent.com/12679343/218628657-7be40d4a-f80b-47e9-93cb-8147cdfdc35d.png)

This change will leave the anomaly forever if there was one already. Because we now skip in the first place, there is no chance to archive it. However, this should be fine as MongoDB and Spanner are both in beta.

close BYT-2552