### PR TITLE
fix(tests): waitIssuePipeline ignore invalid transition error

### DIFF
--- a/backend/tests/issue.go
+++ b/backend/tests/issue.go
@@ -302,6 +302,9 @@ func (ctl *controller) waitIssuePipelineTaskImpl(id int, approveFunc func(issue 
 				if strings.Contains(err.Error(), "The task has not passed all the checks yet") {
 					continue
 				}
+				if strings.Contains(err.Error(), "invalid task status transition") {
+					continue
+				}
 				return api.TaskFailed, err
 			}
 			approved = true

--- a/backend/tests/issue.go
+++ b/backend/tests/issue.go
@@ -302,6 +302,8 @@ func (ctl *controller) waitIssuePipelineTaskImpl(id int, approveFunc func(issue 
 				if strings.Contains(err.Error(), "The task has not passed all the checks yet") {
 					continue
 				}
+				// "invalid task status transition" error means this task has been approved.
+				// we continue and get its status in the next round.
 				if strings.Contains(err.Error(), "invalid task status transition") {
 					continue
 				}


### PR DESCRIPTION
If we see "invalid task status transition" error, we silently ignore and wait for another round.

Close BYT-2498