### PR TITLE
feat: no auto approve for rollback tasks

### DIFF
--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -317,8 +317,9 @@ type TaskFind struct {
 	TypeList   *[]TaskType
 	// Payload contains JSONB expressions
 	// Ref: https://www.postgresql.org/docs/current/functions-json.html
-	Payload      string
-	StageBlocked *bool
+	Payload               string
+	FilterOutBlockedStage bool
+	FilterOutRollbackTask bool
 }
 
 func (find *TaskFind) String() string {

--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -319,7 +319,7 @@ type TaskFind struct {
 	// Ref: https://www.postgresql.org/docs/current/functions-json.html
 	Payload               string
 	FilterOutBlockedStage bool
-	FilterOutRollbackTask bool
+	NonRollbackTask       bool
 }
 
 func (find *TaskFind) String() string {

--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -317,9 +317,9 @@ type TaskFind struct {
 	TypeList   *[]TaskType
 	// Payload contains JSONB expressions
 	// Ref: https://www.postgresql.org/docs/current/functions-json.html
-	Payload               string
-	FilterOutBlockedStage bool
-	NonRollbackTask       bool
+	Payload         string
+	NoBlockingStage bool
+	NonRollbackTask bool
 }
 
 func (find *TaskFind) String() string {

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -799,10 +799,10 @@ func (s *Scheduler) isTaskBlocked(ctx context.Context, task *store.TaskMessage) 
 // scheduleAutoApprovedTasks schedules tasks that are approved automatically.
 func (s *Scheduler) scheduleAutoApprovedTasks(ctx context.Context) error {
 	taskStatusList := []api.TaskStatus{api.TaskPendingApproval}
-	blocked := false
 	taskList, err := s.store.ListTasks(ctx, &api.TaskFind{
-		StatusList:   &taskStatusList,
-		StageBlocked: &blocked,
+		StatusList:            &taskStatusList,
+		FilterOutBlockedStage: true,
+		FilterOutRollbackTask: true,
 	})
 	if err != nil {
 		return err

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -802,7 +802,7 @@ func (s *Scheduler) scheduleAutoApprovedTasks(ctx context.Context) error {
 	taskList, err := s.store.ListTasks(ctx, &api.TaskFind{
 		StatusList:            &taskStatusList,
 		FilterOutBlockedStage: true,
-		FilterOutRollbackTask: true,
+		NonRollbackTask:       true,
 	})
 	if err != nil {
 		return err

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -800,9 +800,9 @@ func (s *Scheduler) isTaskBlocked(ctx context.Context, task *store.TaskMessage) 
 func (s *Scheduler) scheduleAutoApprovedTasks(ctx context.Context) error {
 	taskStatusList := []api.TaskStatus{api.TaskPendingApproval}
 	taskList, err := s.store.ListTasks(ctx, &api.TaskFind{
-		StatusList:            &taskStatusList,
-		FilterOutBlockedStage: true,
-		NonRollbackTask:       true,
+		StatusList:      &taskStatusList,
+		NoBlockingStage: true,
+		NonRollbackTask: true,
 	})
 	if err != nil {
 		return err

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -336,7 +336,7 @@ func (s *Store) ListTasks(ctx context.Context, find *api.TaskFind) ([]*TaskMessa
 	if find.FilterOutBlockedStage {
 		where = append(where, "(SELECT NOT EXISTS (SELECT 1 FROM task as other_task WHERE other_task.pipeline_id = task.pipeline_id AND other_task.stage_id < task.stage_id AND other_task.status != 'DONE'))")
 	}
-	if find.FilterOutRollbackTask {
+	if find.NonRollbackTask {
 		where = append(where, "(NOT (task.type='bb.task.database.data.update' AND task.payload->>'rollbackFromTaskId' IS NOT NULL))")
 	}
 

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -333,7 +333,7 @@ func (s *Store) ListTasks(ctx context.Context, find *api.TaskFind) ([]*TaskMessa
 	if v := find.Payload; v != "" {
 		where = append(where, v)
 	}
-	if find.FilterOutBlockedStage {
+	if find.NoBlockingStage {
 		where = append(where, "(SELECT NOT EXISTS (SELECT 1 FROM task as other_task WHERE other_task.pipeline_id = task.pipeline_id AND other_task.stage_id < task.stage_id AND other_task.status != 'DONE'))")
 	}
 	if find.NonRollbackTask {

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -334,7 +334,7 @@ func (s *Store) ListTasks(ctx context.Context, find *api.TaskFind) ([]*TaskMessa
 		where = append(where, v)
 	}
 	if find.FilterOutBlockedStage {
-		where = append(where, "(SELECT EXISTS (SELECT 1 FROM task as other_task WHERE other_task.pipeline_id = task.pipeline_id AND other_task.stage_id < task.stage_id AND other_task.status != 'DONE'))")
+		where = append(where, "(SELECT NOT EXISTS (SELECT 1 FROM task as other_task WHERE other_task.pipeline_id = task.pipeline_id AND other_task.stage_id < task.stage_id AND other_task.status != 'DONE'))")
 	}
 	if find.FilterOutRollbackTask {
 		where = append(where, "(NOT (task.type='bb.task.database.data.update' AND task.payload->>'rollbackFromTaskId' IS NOT NULL))")


### PR DESCRIPTION
Filter out rollback tasks when fetching tasks that are to be approved automatically. Because we want to always manually approve rollback issues with which we should always be careful.

Also change `StageBlocked *bool` to `FilterOutBlockedStage` because it seems bizarre to me. It uses a bool pointer and does the filtering if the pointer is not nil. I think using a bool is more straightforward.

/cherry-pick-me

Close BYT-2569