### PR TITLE
fix(frontend): set migrationDetail.rollbackEnabled respectively

### DIFF
--- a/frontend/src/components/Issue/rollback/common.ts
+++ b/frontend/src/components/Issue/rollback/common.ts
@@ -146,10 +146,9 @@ export const useRollbackLogic = () => {
         // In tenant mode, all tasks share a common MigrationDetail
         const issueCreate = issue.value as IssueCreate;
         const createContext = issueCreate.createContext as MigrationContext;
-        const migrationDetail = head(createContext.detailList);
-        if (migrationDetail) {
-          migrationDetail.rollbackEnabled = on;
-        }
+        createContext.detailList.forEach((detail) => {
+          detail.rollbackEnabled = on;
+        });
       } else {
         // In standard mode, every task has a independent TaskCreate with its
         // own rollbackEnabled field.


### PR DESCRIPTION
fix: when the project is in tenant mode and we use "manual selection", we use multiple migrationDetail in the issue creation context.