### PR TITLE
chore(frontend): adjust dashboard layout

### DIFF
--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -139,6 +139,15 @@
       class="flex flex-col min-w-0 flex-1 border-l border-r border-block-border"
       data-label="bb-main-body-wrapper"
     >
+      <nav
+        class="bg-white border-b border-block-border"
+        data-label="bb-dashboard-header"
+      >
+        <div class="max-w-full mx-auto">
+          <DashboardHeader />
+        </div>
+      </nav>
+
       <!-- Static sidebar for mobile -->
       <aside class="md:hidden">
         <div
@@ -160,6 +169,7 @@
           </div>
         </div>
       </aside>
+
       <div class="w-full mx-auto md:flex">
         <div class="md:min-w-0 md:flex-1">
           <div v-if="showBreadcrumb" class="hidden md:block px-4 pt-4">
@@ -211,6 +221,7 @@
 <script lang="ts">
 import { computed, defineComponent, reactive } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import DashboardHeader from "@/views/DashboardHeader.vue";
 import Breadcrumb from "../components/Breadcrumb.vue";
 import Quickstart from "../components/Quickstart.vue";
 import QuickActionPanel from "../components/QuickActionPanel.vue";
@@ -233,6 +244,7 @@ interface LocalState {
 export default defineComponent({
   name: "BodyLayout",
   components: {
+    DashboardHeader,
     Breadcrumb,
     Quickstart,
     QuickActionPanel,

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -1,14 +1,6 @@
 <template>
   <div class="relative h-screen overflow-hidden flex flex-col">
     <BannersWrapper />
-    <nav
-      class="bg-white border-b border-block-border"
-      data-label="bb-dashboard-header"
-    >
-      <div class="max-w-full mx-auto">
-        <DashboardHeader />
-      </div>
-    </nav>
     <!-- Suspense is experimental, be aware of the potential change -->
     <Suspense>
       <template #default>
@@ -35,14 +27,12 @@
 import { defineComponent } from "vue";
 import { ServerInfo } from "@/types";
 import { pushNotification, useActuatorStore } from "@/store";
-import DashboardHeader from "@/views/DashboardHeader.vue";
 import ProvideDashboardContext from "@/components/ProvideDashboardContext.vue";
 import BannersWrapper from "@/components/BannersWrapper.vue";
 
 export default defineComponent({
   name: "DashboardLayout",
   components: {
-    DashboardHeader,
     ProvideDashboardContext,
     BannersWrapper,
   },

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="flex items-center justify-between h-16 pl-2 pr-4">
     <div class="flex items-center">
-      <div class="hidden sm:block">
+      <BytebaseLogo class="block md:hidden" />
+
+      <div class="hidden md:block">
         <div class="flex items-baseline space-x-1 whitespace-nowrap">
           <router-link
             v-if="shouldShowIssueEntry"
@@ -135,7 +137,7 @@
             <ProfileDropdown />
           </div>
         </div>
-        <div class="ml-2 -mr-2 flex sm:hidden">
+        <div class="ml-2 -mr-2 flex md:hidden">
           <!-- Mobile menu button -->
           <button
             class="icon-link inline-flex items-center justify-center rounded-md"
@@ -211,6 +213,7 @@ import { computed, reactive, watchEffect, defineComponent } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 
+import BytebaseLogo from "../components/BytebaseLogo.vue";
 import ProfileDropdown from "../components/ProfileDropdown.vue";
 import { UNKNOWN_ID } from "../types";
 import { hasWorkspacePermission, isDev } from "../utils";
@@ -232,7 +235,10 @@ interface LocalState {
 
 export default defineComponent({
   name: "DashboardHeader",
-  components: { ProfileDropdown },
+  components: {
+    BytebaseLogo,
+    ProfileDropdown,
+  },
   setup() {
     const { t, availableLocales } = useI18n();
     const debugStore = useDebugStore();


### PR DESCRIPTION
### Changes

- Changed the overall layout from `T-LR` to `L-TD`
- Still keep the logo on small screens.

### Screenshots

![image](https://user-images.githubusercontent.com/2749742/219568698-5327ab7f-3705-4a19-8c82-6a5ca74578fb.png)

![image](https://user-images.githubusercontent.com/2749742/219568717-344a5f8e-7c73-430b-bcaa-ab031793ff10.png)

![localhost_3000_issue_ggg-change-data-02-15-1454-utc0800-357_stage=beta-stage-1 task=dmldata-for-database-ggg-883(iPhone 12 Pro)](https://user-images.githubusercontent.com/2749742/219568746-c780dd7a-6660-4496-935b-dccd1e7805d7.png)
