### PR TITLE
fix(snowflake): using SCHEMA_NAME instead of TABLE_SCHEMA in *.INFORMATION_SCHEMA.SCHEMATA to sync schema

### DIFF
--- a/backend/plugin/db/snowflake/sync.go
+++ b/backend/plugin/db/snowflake/sync.go
@@ -134,7 +134,7 @@ func (driver *Driver) getSchemaList(ctx context.Context, database string) ([]str
 	for k := range systemSchemas {
 		excludedSchemaList = append(excludedSchemaList, fmt.Sprintf("'%s'", k))
 	}
-	excludeWhere := fmt.Sprintf("LOWER(TABLE_SCHEMA) NOT IN (%s)", strings.Join(excludedSchemaList, ", "))
+	excludeWhere := fmt.Sprintf("LOWER(SCHEMA_NAME) NOT IN (%s)", strings.Join(excludedSchemaList, ", "))
 
 	query := fmt.Sprintf(`
 		SELECT


### PR DESCRIPTION
> <html>
SCHEMA_NAME | TEXT | Name of the schema
-- | -- | --
</html>


For the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/info-schema/schemata#columns), we need to use the `SCHEMA_NAME` field to filter out the excluded schemata instead of `TABLE_SCHEMA`.
