### PR TITLE
feat(schema-diagram): schema diagram minor improvements

### DIFF
--- a/frontend/src/components/SchemaDiagram/Canvas/DummyCanvas.vue
+++ b/frontend/src/components/SchemaDiagram/Canvas/DummyCanvas.vue
@@ -33,6 +33,19 @@
         src="../../../assets/logo-full.svg"
         alt="Bytebase"
       />
+
+      <div
+        class="absolute z-50 opacity-50 origin-bottom-right"
+        :style="{
+          lineHeight: '1em',
+          fontSize: `${logoWidth / 6}px`,
+          right: `${LOGO_PADDING * resizeParams.zoom}px`,
+          bottom: `${LOGO_PADDING * resizeParams.zoom}px`,
+          transform: `scale(${resizeParams.zoom})`,
+        }"
+      >
+        {{ now }}
+      </div>
     </div>
   </teleport>
 </template>
@@ -40,6 +53,7 @@
 <script lang="ts" setup>
 import { pushNotification } from "@/store";
 import { computed, defineComponent, nextTick, PropType, ref, VNode } from "vue";
+import dayjs from "dayjs";
 
 import { minmax } from "@/utils";
 import {
@@ -103,6 +117,10 @@ const resizeParams = computed(() => {
     },
     [0, 1]
   );
+});
+
+const now = computed((): string => {
+  return dayjs().format("YYYY-MM-DD HH:mm");
 });
 
 const DesktopRenderer = defineComponent({

--- a/frontend/src/components/SchemaDiagram/Navigator/TreeNode/Label.vue
+++ b/frontend/src/components/SchemaDiagram/Navigator/TreeNode/Label.vue
@@ -1,10 +1,15 @@
 <template>
   <!-- eslint-disable vue/no-v-html -->
-  <span
-    class="truncate"
-    :data-schema-editor-nav-tree-node-id="id"
-    v-html="html"
-  />
+  <div class="flex items-center gap-x-1 max-w-full">
+    <span
+      class="truncate"
+      :data-schema-editor-nav-tree-node-id="id"
+      v-html="html"
+    />
+    <span v-if="isTypedNode(node, 'schema')" class="shrink-0 text-gray-500">
+      ({{ node.data.tables.length }})
+    </span>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -13,6 +18,7 @@ import { escape } from "lodash-es";
 
 import type { TreeNode } from "../types";
 import { getHighlightHTMLByKeyWords } from "@/utils";
+import { isTypedNode } from "../utils";
 
 const props = defineProps<{
   node: TreeNode;


### PR DESCRIPTION
### Changes

- Include the table count beside the schema title (Close BYT-2607)
- Add a timestamp to the bottom right of the exported image file. (Close BYT-2606)

### Screenshots
![localhost_3000_db_sakila-359(1600_900)](https://user-images.githubusercontent.com/2749742/219998902-2cf38389-014a-43f6-97f5-9f7b57e88712.png)
![employee (4)](https://user-images.githubusercontent.com/2749742/219998919-b6d0fb64-897e-4742-bea4-45171fb96e01.png)
