### PR TITLE
fix(frontend): style of BBContextMenuButton

### DIFF
--- a/frontend/src/bbkit/BBContextMenuButton.vue
+++ b/frontend/src/bbkit/BBContextMenuButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
-    class="select-none inline-flex items-center border rounded-md disabled:opacity-50 disabled:cursor-not-allowed text-sm leading-5 font-medium overflow-hidden focus:ring-control focus:outline-none focus-visible:ring-2 focus:ring-offset-2"
-    :data-button-type="state.currentAction.type"
+    class="select-none h-[38px] inline-flex items-center border rounded-md disabled:opacity-50 disabled:cursor-not-allowed text-sm leading-5 font-medium overflow-hidden focus:ring-control focus:outline-none focus-visible:ring-2 focus:ring-offset-2"
+    :data-button-type="state.currentAction.type ?? 'NORMAL'"
     :class="actionButtonClass.wrapper"
     :disabled="disabled"
   >

--- a/frontend/src/bbkit/BBTooltipButton.vue
+++ b/frontend/src/bbkit/BBTooltipButton.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 export default {
-  name: "BBButton",
+  name: "BBTooltipButton",
   inheritAttrs: false,
 };
 </script>
@@ -53,7 +53,7 @@ export type TooltipMode = "ALWAYS" | "DISABLED-ONLY";
 
 const props = withDefaults(
   defineProps<{
-    type: ButtonType;
+    type?: ButtonType;
     disabled: boolean;
     tooltipMode: TooltipMode;
   }>(),


### PR DESCRIPTION
A weird bug. The **Approve / Approve current state** button is fine.

### Screenshots
- Before (hovering)
![image](https://user-images.githubusercontent.com/2749742/220497896-901137e5-6439-4378-abef-cd7b184b2d05.png)

- After (hovering)
![image](https://user-images.githubusercontent.com/2749742/220497910-08b77be0-9dc4-4b64-8614-ba4f2f821b29.png)
