### PR TITLE
fix(vcs): use string to represent external repository ID

### DIFF
--- a/backend/legacyapi/vcs.go
+++ b/backend/legacyapi/vcs.go
@@ -75,7 +75,7 @@ type VCSDelete struct {
 
 // ExternalRepository is the API message for external repository.
 type ExternalRepository struct {
-	ID       int64  `jsonapi:"primary,id"`
+	ID       string `jsonapi:"primary,id"`
 	Name     string `jsonapi:"attr,name"`
 	FullPath string `jsonapi:"attr,fullPath"`
 	WebURL   string `jsonapi:"attr,webUrl"`

--- a/backend/plugin/vcs/github/github.go
+++ b/backend/plugin/vcs/github/github.go
@@ -449,7 +449,7 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 		}
 		allRepos = append(allRepos,
 			&vcs.Repository{
-				ID:       r.ID,
+				ID:       strconv.FormatInt(r.ID, 10),
 				Name:     r.Name,
 				FullPath: r.FullName,
 				WebURL:   r.HTMLURL,

--- a/backend/plugin/vcs/github/github_test.go
+++ b/backend/plugin/vcs/github/github_test.go
@@ -267,7 +267,7 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 	// Repositories without admin permissions should be excluded
 	want := []*vcs.Repository{
 		{
-			ID:       1296269,
+			ID:       "1296269",
 			Name:     "Hello-World",
 			FullPath: "octocat/Hello-World",
 			WebURL:   "https://github.com/octocat/Hello-World",

--- a/backend/plugin/vcs/gitlab/gitlab.go
+++ b/backend/plugin/vcs/gitlab/gitlab.go
@@ -253,7 +253,7 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 	for _, r := range gitlabRepos {
 		allRepos = append(allRepos,
 			&vcs.Repository{
-				ID:       r.ID,
+				ID:       strconv.FormatInt(r.ID, 10),
 				Name:     r.Name,
 				FullPath: r.PathWithNamespace,
 				WebURL:   r.WebURL,

--- a/backend/plugin/vcs/gitlab/gitlab_test.go
+++ b/backend/plugin/vcs/gitlab/gitlab_test.go
@@ -156,7 +156,7 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 
 	want := []*vcs.Repository{
 		{
-			ID:       4,
+			ID:       "4",
 			Name:     "Diaspora Client",
 			FullPath: "diaspora/diaspora-client",
 			WebURL:   "http://example.com/diaspora/diaspora-client",

--- a/backend/plugin/vcs/vcs.go
+++ b/backend/plugin/vcs/vcs.go
@@ -146,7 +146,7 @@ type UserInfo struct {
 
 // Repository is the API message for repository info.
 type Repository struct {
-	ID       int64  `json:"id"`
+	ID       string `json:"id"`
 	Name     string `json:"name"`
 	FullPath string `json:"fullPath"`
 	WebURL   string `json:"webUrl"`

--- a/frontend/src/store/modules/repository.ts
+++ b/frontend/src/store/modules/repository.ts
@@ -45,7 +45,7 @@ function convert(
 
   return {
     ...(repository.attributes as Omit<Repository, "id" | "vcs" | "project">),
-    id: parseInt(repository.id),
+    id: repository.id,
     vcs,
     project,
   };


### PR DESCRIPTION
Not all code hosts use numberic ID for repositories (i.e. Bitbucket Cloud uses UUID), so we need to use the string representation to be most compatible. Turns out our store layer is already using string type for persisting external repository ID: 

https://github.com/bytebase/bytebase/blob/8ed1b98b600e08052f01c6371a1f353b48074559/backend/store/repository.go#L34