### PR TITLE
chore: add sdl parameters for GET /database/:databaseID/schema

### DIFF
--- a/backend/server/database.go
+++ b/backend/server/database.go
@@ -233,7 +233,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 		isMetadata := c.QueryParam("metadata") == "true"
 		isSDL := c.QueryParam("sdl") == "true"
 		if isMetadata && isSDL {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Cannot choose metadata and sdl format together"))
+			return echo.NewHTTPError(http.StatusBadRequest, "Cannot choose metadata and sdl format together")
 		}
 		if isMetadata {
 			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)

--- a/backend/server/database.go
+++ b/backend/server/database.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/parser"
 	"github.com/bytebase/bytebase/backend/plugin/parser/edit"
+	"github.com/bytebase/bytebase/backend/plugin/parser/transform"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -229,19 +230,46 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 			dbSchema = newDBSchema
 		}
 
-		isQuerySchema := c.QueryParam("metadata") == ""
-		if isQuerySchema {
-			c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)
-			if _, err := c.Response().Write([]byte(dbSchema.Schema)); err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to write schema response for database %q", database.DatabaseName)).SetInternal(err)
-			}
-		} else {
+		isMetadata := c.QueryParam("metadata") == "true"
+		isSDL := c.QueryParam("sdl") == "true"
+		if isMetadata && isSDL {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Cannot choose metadata and sdl format together"))
+		}
+		if isMetadata {
 			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
 			metadataBytes, err := protojson.Marshal(dbSchema.Metadata)
 			if err != nil {
 				return err
 			}
 			if _, err := c.Response().Write(metadataBytes); err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to write schema response for database %q", database.DatabaseName)).SetInternal(err)
+			}
+		} else if isSDL {
+			instance, err := s.store.GetInstanceV2(ctx, &store.FindInstanceMessage{EnvironmentID: &database.EnvironmentID, ResourceID: &database.InstanceID})
+			if err != nil {
+				return err
+			}
+			// We only support MySQL now.
+			var engineType parser.EngineType
+			switch instance.Engine {
+			case db.MySQL:
+				engineType = parser.MySQL
+			default:
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Not support SDL format for %s instance", instance.Engine))
+			}
+
+			sdlSchema, err := transform.SchemaTransform(engineType, string(dbSchema.Schema))
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to transform SDL format for database %q", database.DatabaseName)).SetInternal(err)
+			}
+
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)
+			if _, err := c.Response().Write([]byte(sdlSchema)); err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to write schema response for database %q", database.DatabaseName)).SetInternal(err)
+			}
+		} else {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)
+			if _, err := c.Response().Write([]byte(dbSchema.Schema)); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to write schema response for database %q", database.DatabaseName)).SetInternal(err)
 			}
 		}

--- a/backend/tests/database.go
+++ b/backend/tests/database.go
@@ -176,6 +176,18 @@ func (ctl *controller) postDatabaseEdit(databaseEdit api.DatabaseEdit) (*Databas
 	return databaseEditResult, nil
 }
 
+func (ctl *controller) getLatestSchemaSDL(databaseID int) (string, error) {
+	body, err := ctl.get(fmt.Sprintf("/database/%d/schema", databaseID), map[string]string{"sdl": "true"})
+	if err != nil {
+		return "", err
+	}
+	bs, err := io.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}
+
 func (ctl *controller) getLatestSchemaDump(databaseID int) (string, error) {
 	body, err := ctl.get(fmt.Sprintf("/database/%d/schema", databaseID), nil)
 	if err != nil {


### PR DESCRIPTION
The frontend can use `sdl` parameters to get the SDL format schema.