### PR TITLE
fix(demo): test filename

### DIFF
--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -35,7 +35,7 @@ seedDemoData() {
 
     bytebase --port ${ONLINE_DEMO_PORT} --external-url ${ONLINE_DEMO_EXTERNAL_URL} --demo ${DEMO_NAME} --data /var/opt/bytebase &
 
-    until [ -f /var/opt/bytebase/pgdata/PG_VERSION ]; do
+    until [ -f /var/opt/bytebase/pgdata-demo/default/PG_VERSION ]; do
         echo "waiting..."
         sleep 1
     done


### PR DESCRIPTION
Seems that we were relying on testing the file to check if postgres has started. But the file changed unfortunately.

It would be more reliable if bytebase creates the file indicating that postgres has finished setup though...