### PR TITLE
chore: add sdl parameters for GET /instance:instanceID/migration/history/:historyID

### DIFF
--- a/backend/server/instance.go
+++ b/backend/server/instance.go
@@ -17,6 +17,8 @@ import (
 	"github.com/bytebase/bytebase/backend/common/log"
 	api "github.com/bytebase/bytebase/backend/legacyapi"
 	"github.com/bytebase/bytebase/backend/plugin/db"
+	"github.com/bytebase/bytebase/backend/plugin/parser"
+	"github.com/bytebase/bytebase/backend/plugin/parser/transform"
 	"github.com/bytebase/bytebase/backend/resources/postgres"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -362,6 +364,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		}
 
 		historyID := c.Param("historyID")
+		isSDL := c.QueryParam("sdl") == "true"
 
 		instance, err := s.store.GetInstanceV2(ctx, &store.FindInstanceMessage{UID: &id})
 		if err != nil {
@@ -385,6 +388,24 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Migration history ID %q not found for instance %q", historyID, instance.Title))
 		}
 		entry := list[0]
+
+		if isSDL {
+			var engineType parser.EngineType
+			switch instance.Engine {
+			case db.MySQL:
+				engineType = parser.MySQL
+			default:
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Not support SDL format for %s instance", instance.Engine))
+			}
+			entry.Schema, err = transform.SchemaTransform(engineType, entry.Schema)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to transform Schema to SDL format for instance %q", instance.Title)).SetInternal(err)
+			}
+			entry.SchemaPrev, err = transform.SchemaTransform(engineType, entry.SchemaPrev)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to transform SchemaPrev to SDL format for instance %q", instance.Title)).SetInternal(err)
+			}
+		}
 
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
 		if err := jsonapi.MarshalPayload(c.Response().Writer, &api.MigrationHistory{

--- a/backend/tests/instance.go
+++ b/backend/tests/instance.go
@@ -74,3 +74,26 @@ func (ctl *controller) getInstanceMigrationHistory(instanceID int, find db.Migra
 	}
 	return histories, nil
 }
+
+func (ctl *controller) getInstanceSDLMigrationHistory(instanceID int, historyID string, find db.MigrationHistoryFind) (*api.MigrationHistory, error) {
+	params := make(map[string]string)
+	if find.Database != nil {
+		params["database"] = *find.Database
+	}
+	if find.Version != nil {
+		params["version"] = *find.Version
+	}
+	if find.Limit != nil {
+		params["limit"] = fmt.Sprintf("%d", *find.Limit)
+	}
+	params["sdl"] = "true"
+	body, err := ctl.get(fmt.Sprintf("/instance/%d/migration/history/%s", instanceID, historyID), params)
+	if err != nil {
+		return nil, err
+	}
+	result := new(api.MigrationHistory)
+	if err := jsonapi.UnmarshalPayload(body, result); err != nil {
+		return nil, errors.Wrap(err, "fail to unmarshal get migration history response")
+	}
+	return result, nil
+}

--- a/backend/tests/instance.go
+++ b/backend/tests/instance.go
@@ -75,17 +75,8 @@ func (ctl *controller) getInstanceMigrationHistory(instanceID int, find db.Migra
 	return histories, nil
 }
 
-func (ctl *controller) getInstanceSDLMigrationHistory(instanceID int, historyID string, find db.MigrationHistoryFind) (*api.MigrationHistory, error) {
+func (ctl *controller) getInstanceSDLMigrationHistory(instanceID int, historyID string) (*api.MigrationHistory, error) {
 	params := make(map[string]string)
-	if find.Database != nil {
-		params["database"] = *find.Database
-	}
-	if find.Version != nil {
-		params["version"] = *find.Version
-	}
-	if find.Limit != nil {
-		params["limit"] = fmt.Sprintf("%d", *find.Limit)
-	}
 	params["sdl"] = "true"
 	body, err := ctl.get(fmt.Sprintf("/instance/%d/migration/history/%s", instanceID, historyID), params)
 	if err != nil {

--- a/backend/tests/schema_update_test.go
+++ b/backend/tests/schema_update_test.go
@@ -2412,6 +2412,16 @@ WHERE table_schema = '%s';
 				"SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;\n" +
 				"SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;\n"
 
+			const initialSDL = ""
+			const updatedSDL = "CREATE TABLE `projects` (\n" +
+				"  `id` INT NOT NULL,\n" +
+				"  PRIMARY KEY (`id`)\n" +
+				") ENGINE=InnoDB DEFAULT CHARACTER SET=UTF8MB4 DEFAULT COLLATE=UTF8MB4_GENERAL_CI;\n" +
+				"CREATE TABLE `users` (\n" +
+				"  `id` INT NOT NULL,\n" +
+				"  PRIMARY KEY (`id`)\n" +
+				") ENGINE=InnoDB DEFAULT CHARACTER SET=UTF8MB4 DEFAULT COLLATE=UTF8MB4_GENERAL_CI;\n"
+
 			histories, err := ctl.getInstanceMigrationHistory(instance.ID, db.MigrationHistoryFind{})
 			a.NoError(err)
 			wantHistories := []api.MigrationHistory{
@@ -2454,6 +2464,12 @@ WHERE table_schema = '%s';
 				a.Equal(wantHistories[i], got, i)
 				a.NotEmpty(history.Version)
 			}
+
+			// Test SDL format.
+			sdlHistory, err := ctl.getInstanceSDLMigrationHistory(instance.ID, histories[1].ID, db.MigrationHistoryFind{})
+			a.NoError(err)
+			a.Equal(updatedSDL, sdlHistory.Schema)
+			a.Equal(initialSDL, sdlHistory.SchemaPrev)
 		})
 	}
 }

--- a/backend/tests/schema_update_test.go
+++ b/backend/tests/schema_update_test.go
@@ -2466,7 +2466,7 @@ WHERE table_schema = '%s';
 			}
 
 			// Test SDL format.
-			sdlHistory, err := ctl.getInstanceSDLMigrationHistory(instance.ID, histories[1].ID, db.MigrationHistoryFind{})
+			sdlHistory, err := ctl.getInstanceSDLMigrationHistory(instance.ID, histories[1].ID)
 			a.NoError(err)
 			a.Equal(updatedSDL, sdlHistory.Schema)
 			a.Equal(initialSDL, sdlHistory.SchemaPrev)


### PR DESCRIPTION
The frontend can use `sdl` parameters to get the SDL format schema.