### PR TITLE
fix(schema): rename BITBUCKET to BITBUCKET_CLOUD

### DIFF
--- a/backend/store/migration/dev/LATEST.sql
+++ b/backend/store/migration/dev/LATEST.sql
@@ -779,7 +779,7 @@ CREATE TABLE vcs (
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     name TEXT NOT NULL,
-    type TEXT NOT NULL CHECK (type IN ('GITLAB', 'GITHUB', 'BITBUCKET')),
+    type TEXT NOT NULL CHECK (type IN ('GITLAB', 'GITHUB', 'BITBUCKET_CLOUD')),
     instance_url TEXT NOT NULL CHECK ((instance_url LIKE 'http://%' OR instance_url LIKE 'https://%') AND instance_url = rtrim(instance_url, '/')),
     api_url TEXT NOT NULL CHECK ((api_url LIKE 'http://%' OR api_url LIKE 'https://%') AND api_url = rtrim(api_url, '/')),
     application_id TEXT NOT NULL,

--- a/backend/store/migration/prod/1.13/0000##gitlab_github_bitbucket.sql
+++ b/backend/store/migration/prod/1.13/0000##gitlab_github_bitbucket.sql
@@ -6,5 +6,5 @@ UPDATE vcs SET type = 'GITHUB' WHERE type = 'GITHUB_COM';
 UPDATE sheet SET source = 'GITLAB' WHERE source = 'GITLAB_SELF_HOST';
 UPDATE sheet SET source = 'GITHUB' WHERE source = 'GITHUB_COM';
 
-ALTER TABLE vcs ADD CONSTRAINT vcs_type_check CHECK (type IN ('GITLAB', 'GITHUB', 'BITBUCKET'));
-ALTER TABLE sheet ADD CONSTRAINT sheet_source_check CHECK (source IN ('BYTEBASE', 'GITLAB', 'GITHUB', 'BITBUCKET'));
+ALTER TABLE vcs ADD CONSTRAINT vcs_type_check CHECK (type IN ('GITLAB', 'GITHUB', 'BITBUCKET_CLOUD'));
+ALTER TABLE sheet ADD CONSTRAINT sheet_source_check CHECK (source IN ('BYTEBASE', 'GITLAB', 'GITHUB', 'BITBUCKET_CLOUD'));

--- a/backend/store/migration/prod/LATEST.sql
+++ b/backend/store/migration/prod/LATEST.sql
@@ -778,7 +778,7 @@ CREATE TABLE vcs (
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     name TEXT NOT NULL,
-    type TEXT NOT NULL CHECK (type IN ('GITLAB', 'GITHUB', 'BITBUCKET')),
+    type TEXT NOT NULL CHECK (type IN ('GITLAB', 'GITHUB', 'BITBUCKET_CLOUD')),
     instance_url TEXT NOT NULL CHECK ((instance_url LIKE 'http://%' OR instance_url LIKE 'https://%') AND instance_url = rtrim(instance_url, '/')),
     api_url TEXT NOT NULL CHECK ((api_url LIKE 'http://%' OR api_url LIKE 'https://%') AND api_url = rtrim(api_url, '/')),
     application_id TEXT NOT NULL,
@@ -991,7 +991,7 @@ CREATE TABLE sheet (
     name TEXT NOT NULL,
     statement TEXT NOT NULL,
     visibility TEXT NOT NULL CHECK (visibility IN ('PRIVATE', 'PROJECT', 'PUBLIC')) DEFAULT 'PRIVATE',
-    source TEXT NOT NULL CHECK (source IN ('BYTEBASE', 'GITLAB', 'GITHUB', 'BITBUCKET')) DEFAULT 'BYTEBASE',
+    source TEXT NOT NULL CHECK (source IN ('BYTEBASE', 'GITLAB', 'GITHUB', 'BITBUCKET_CLOUD')) DEFAULT 'BYTEBASE',
     type TEXT NOT NULL CHECK (type IN ('SQL')) DEFAULT 'SQL',
     payload JSONB NOT NULL DEFAULT '{}'
 );


### PR DESCRIPTION
Atlassian EOL for Bitbucket Server (self-hosted) but rebranded it to Bitbucket Data Center (single-tenant managed Cloud), as well as the other Bitbucket Cloud (bitbucket.org, multi-tenant Cloud). They do not share same API references so we need to treat them differently.