### PR TITLE
fix: only fetch active snowflake users

### DIFF
--- a/backend/plugin/db/snowflake/role.go
+++ b/backend/plugin/db/snowflake/role.go
@@ -64,10 +64,14 @@ func (driver *Driver) getInstanceRoles(ctx context.Context) ([]*storepb.Instance
 	}
 
 	// Query user info
+	// The same user could have multiple entires in the usage if it's been deleted and recreated,
+	// so we need to use DELETED_ON IS NULL to retrieve the active user.
 	userQuery := `
 	  SELECT
 			name
 		FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
+		WHERE DELETED_ON IS NULL
+		ORDER BY name ASC
 	`
 	var instanceRoles []*storepb.InstanceRoleMetadata
 	rows, err := driver.db.QueryContext(ctx, userQuery)


### PR DESCRIPTION
ACCOUNT_USAGE can have multiple entries for the same name if there is DELETED_ON entry

![CleanShot 2023-02-28 at 18 44 09](https://user-images.githubusercontent.com/230323/221831287-fbac5732-2078-4788-a465-37fa837db3ae.png)

Fix BYT-2669