### PR TITLE
fix: skip not found db in task generation

### DIFF
--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -278,6 +278,10 @@ func GetDatabaseMatrixFromDeploymentSchedule(schedule *api.DeploymentSchedule, d
 			if _, ok := idsSeen[database.UID]; ok {
 				continue
 			}
+			// Skip if the database is not found.
+			if database.SyncState == api.NotFound {
+				continue
+			}
 
 			if isMatchExpressions(idToLabels[database.UID], deployment.Spec.Selector.MatchExpressions) {
 				matchedDatabaseList = append(matchedDatabaseList, database.UID)


### PR DESCRIPTION
Don't create tasks for a not found database.

Close BYT-2670