### PR TITLE
feat(sql-editor): optimize result display

### DIFF
--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -104,9 +104,7 @@ const useExecuteSQL = () => {
       }
 
       // use `markRaw` to prevent vue from monitoring the object change deeply
-      const queryResult = sqlResultSet.data
-        ? markRaw(sqlResultSet.data)
-        : undefined;
+      const queryResult = sqlResultSet ? markRaw(sqlResultSet) : undefined;
       Object.assign(tab, {
         queryResult,
         adviceList: sqlResultSet.adviceList,
@@ -155,9 +153,7 @@ const useExecuteSQL = () => {
       });
 
       // use `markRaw` to prevent vue from monitoring the object change deeply
-      const queryResult = sqlResultSet.data
-        ? markRaw(sqlResultSet.data)
-        : undefined;
+      const queryResult = sqlResultSet ? markRaw(sqlResultSet) : undefined;
       Object.assign(tab, {
         queryResult,
         adviceList: sqlResultSet.adviceList,
@@ -184,7 +180,7 @@ const useExecuteSQL = () => {
           option,
         },
       });
-      notify("CRITICAL", error as string);
+      // notify("CRITICAL", error as string);
     }
   };
 

--- a/frontend/src/store/modules/sql.ts
+++ b/frontend/src/store/modules/sql.ts
@@ -147,9 +147,6 @@ export const useSQLStore = defineStore("sql", {
       ).data;
 
       const resultSet = convert(res.data);
-      if (resultSet.error) {
-        throw new Error(resultSet.error);
-      }
 
       return resultSet;
     },
@@ -173,9 +170,6 @@ export const useSQLStore = defineStore("sql", {
       ).data;
 
       const resultSet = convert(res.data);
-      if (resultSet.error) {
-        throw new Error(resultSet.error);
-      }
 
       return resultSet;
     },

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -5,6 +5,7 @@ import {
   QueryInfo,
   QueryHistory,
   ActivitySQLEditorQueryPayload,
+  SingleSQLResult,
 } from "@/types";
 import { UNKNOWN_ID } from "@/types";
 import { useActivityStore } from "./activity";
@@ -96,3 +97,10 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
     },
   },
 });
+
+export const mockAffectedRows0 = (): SingleSQLResult => {
+  return {
+    data: [["Affected Rows"], ["BIGINT"], [[0]], [false]],
+    error: "",
+  };
+};

--- a/frontend/src/types/tab.ts
+++ b/frontend/src/types/tab.ts
@@ -39,7 +39,7 @@ export interface TabInfo {
     option?: Partial<ExecuteOption>;
   };
   isExecutingSQL: boolean;
-  queryResult?: SingleSQLResult["data"];
+  queryResult?: SingleSQLResult;
   sheetId?: SheetId;
   adviceList?: Advice[];
 }

--- a/frontend/src/types/webTerminal.ts
+++ b/frontend/src/types/webTerminal.ts
@@ -1,4 +1,4 @@
-import { SQLResultSet } from "./sqlAdvice";
+import { SQLResultSet } from "./sql";
 import { ExecuteConfig, ExecuteOption } from "./tab";
 
 export type WebTerminalQueryItem = {

--- a/frontend/src/views/sql-editor/EditorCommon/TableView.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/TableView.vue
@@ -4,78 +4,116 @@
     class="relative flex flex-col justify-start items-start p-2"
     :class="dark && 'dark bg-dark-bg'"
   >
-    <div
-      v-show="queryResult !== null"
-      class="w-full shrink-0 flex flex-row justify-between items-center mb-2 overflow-x-auto"
-    >
-      <div class="flex flex-row justify-start items-center mr-2 shrink-0">
-        <NInput
-          v-if="showSearchFeature"
-          v-model:value="state.search"
-          class="!max-w-[8rem] sm:!max-w-xs"
-          type="text"
-          :placeholder="t('sql-editor.search-results')"
-        >
-          <template #prefix>
-            <heroicons-outline:search class="h-5 w-5 text-gray-300" />
-          </template>
-        </NInput>
-        <span class="ml-2 whitespace-nowrap text-sm text-gray-500">{{
-          `${data.length} ${t("sql-editor.rows", data.length)}`
-        }}</span>
-        <span
-          v-if="data.length === RESULT_ROWS_LIMIT"
-          class="ml-2 whitespace-nowrap text-sm text-gray-500"
-        >
-          <span>-</span>
-          <span class="ml-2">{{ $t("sql-editor.rows-upper-limit") }}</span>
-        </span>
-      </div>
-      <div class="flex justify-between items-center gap-x-3">
-        <NPagination
-          v-if="showPagination"
-          :item-count="table.getCoreRowModel().rows.length"
-          :page="table.getState().pagination.pageIndex + 1"
-          :page-size="table.getState().pagination.pageSize"
-          :show-quick-jumper="true"
-          :show-size-picker="true"
-          :page-sizes="[20, 50, 100]"
-          @update-page="handleChangePage"
-          @update-page-size="(ps) => table.setPageSize(ps)"
-        />
-        <NButton
-          v-if="showVisualizeButton"
-          text
-          type="primary"
-          @click="visualizeExplain"
-        >
-          {{ $t("sql-editor.visualize-explain") }}
-        </NButton>
-        <NDropdown
-          trigger="hover"
-          :options="exportDropdownOptions"
-          @select="handleExportBtnClick"
-        >
-          <NButton>
-            <template #icon>
-              <heroicons-outline:download class="h-5 w-5" />
+    <template v-if="viewMode === 'result'">
+      <div
+        class="w-full shrink-0 flex flex-row justify-between items-center mb-2 overflow-x-auto"
+      >
+        <div class="flex flex-row justify-start items-center mr-2 shrink-0">
+          <NInput
+            v-if="showSearchFeature"
+            v-model:value="state.search"
+            class="!max-w-[8rem] sm:!max-w-xs"
+            type="text"
+            :placeholder="t('sql-editor.search-results')"
+          >
+            <template #prefix>
+              <heroicons-outline:search class="h-5 w-5 text-gray-300" />
             </template>
-            {{ t("common.export") }}
+          </NInput>
+          <span class="ml-2 whitespace-nowrap text-sm text-gray-500">{{
+            `${data.length} ${t("sql-editor.rows", data.length)}`
+          }}</span>
+          <span
+            v-if="data.length === RESULT_ROWS_LIMIT"
+            class="ml-2 whitespace-nowrap text-sm text-gray-500"
+          >
+            <span>-</span>
+            <span class="ml-2">{{ $t("sql-editor.rows-upper-limit") }}</span>
+          </span>
+        </div>
+        <div class="flex justify-between items-center gap-x-3">
+          <NPagination
+            v-if="showPagination"
+            :item-count="table.getCoreRowModel().rows.length"
+            :page="table.getState().pagination.pageIndex + 1"
+            :page-size="table.getState().pagination.pageSize"
+            :show-quick-jumper="true"
+            :show-size-picker="true"
+            :page-sizes="[20, 50, 100]"
+            @update-page="handleChangePage"
+            @update-page-size="(ps) => table.setPageSize(ps)"
+          />
+          <NButton
+            v-if="showVisualizeButton"
+            text
+            type="primary"
+            @click="visualizeExplain"
+          >
+            {{ $t("sql-editor.visualize-explain") }}
           </NButton>
-        </NDropdown>
+          <NDropdown
+            trigger="hover"
+            :options="exportDropdownOptions"
+            @select="handleExportBtnClick"
+          >
+            <NButton>
+              <template #icon>
+                <heroicons-outline:download class="h-5 w-5" />
+              </template>
+              {{ t("common.export") }}
+            </NButton>
+          </NDropdown>
+        </div>
       </div>
-    </div>
 
-    <div class="flex-1 w-full flex flex-col overflow-y-auto">
-      <DataTable
-        v-show="!showPlaceholder"
-        ref="dataTable"
-        :table="table"
-        :columns="columns"
-        :data="data"
-        :sensitive="sensitive"
-      />
-    </div>
+      <div class="flex-1 w-full flex flex-col overflow-y-auto">
+        <DataTable
+          v-show="!showPlaceholder"
+          ref="dataTable"
+          :table="table"
+          :columns="columns"
+          :data="data"
+          :sensitive="sensitive"
+        />
+      </div>
+    </template>
+    <template v-else-if="viewMode === 'affected-rows'">
+      <div
+        class="text-md font-normal flex items-center gap-x-1"
+        :class="[
+          dark
+            ? 'text-[var(--color-matrix-green-hover)]'
+            : 'text-control-light',
+        ]"
+      >
+        <span>{{ queryResult?.data[2][0][0] }}</span>
+        <span>rows affected</span>
+      </div>
+    </template>
+    <template v-else-if="viewMode === 'empty'">
+      <div
+        class="text-md font-normal"
+        :class="[
+          dark
+            ? 'text-[var(--color-matrix-green-hover)]'
+            : 'text-control-light',
+        ]"
+      >
+        {{ $t("sql-editor.no-rows-found") }}
+      </div>
+    </template>
+    <template v-else-if="viewMode === 'error'">
+      <div
+        class="text-md font-normal"
+        :class="[
+          dark
+            ? 'text-[var(--color-matrix-green-hover)]'
+            : 'text-control-light',
+        ]"
+      >
+        {{ queryResult?.error }}
+      </div>
+    </template>
 
     <div
       v-if="showPlaceholder"
@@ -115,15 +153,15 @@ import {
 } from "@tanstack/vue-table";
 import { SingleSQLResult } from "@/types";
 
+type ViewMode = "result" | "empty" | "affected-rows" | "error";
+
 interface State {
   search: string;
 }
 
-type QueryResult = SingleSQLResult["data"];
-
 const props = defineProps({
   queryResult: {
-    type: Object as PropType<QueryResult>,
+    type: Object as PropType<SingleSQLResult>,
     default: undefined,
   },
   loading: {
@@ -145,6 +183,23 @@ const instanceStore = useInstanceStore();
 
 const state = reactive<State>({
   search: "",
+});
+
+const viewMode = computed((): ViewMode => {
+  const { queryResult } = props;
+  if (!queryResult) {
+    return "empty";
+  }
+  if (queryResult.error) {
+    return "error";
+  }
+  if (
+    queryResult.data?.[0].length === 1 &&
+    queryResult.data[0][0] === "Affected Rows"
+  ) {
+    return "affected-rows";
+  }
+  return "result";
 });
 
 const dataTable = ref<InstanceType<typeof DataTable>>();
@@ -170,10 +225,10 @@ const keyword = debouncedRef(
 );
 
 const columns = computed(() => {
-  if (!props.queryResult) {
+  if (!props.queryResult?.data) {
     return [];
   }
-  const columns = props.queryResult[0];
+  const columns = props.queryResult.data[0];
   return columns.map<ColumnDef<string[]>>((col, index) => ({
     id: `${col}@${index}`,
     accessorFn: (item) => item[index],
@@ -182,11 +237,11 @@ const columns = computed(() => {
 });
 
 const data = computed(() => {
-  if (!props.queryResult) {
+  if (!props.queryResult?.data) {
     return [];
   }
 
-  const data = props.queryResult[2];
+  const data = props.queryResult.data[2];
   const search = keyword.value;
   let temp = data;
   if (search) {
@@ -198,10 +253,10 @@ const data = computed(() => {
 });
 
 const sensitive = computed(() => {
-  if (!props.queryResult) {
+  if (!props.queryResult?.data) {
     return [];
   }
-  return props.queryResult[3] ?? [];
+  return props.queryResult.data[3] ?? [];
 });
 
 const table = useVueTable<string[]>({
@@ -218,7 +273,7 @@ const table = useVueTable<string[]>({
 table.setPageSize(DEFAULT_PAGE_SIZE);
 
 const showPlaceholder = computed(() => {
-  if (!props.queryResult) return true;
+  if (!props.queryResult?.data) return true;
   if (props.loading) return true;
   return false;
 });
@@ -285,7 +340,7 @@ const visualizeExplain = () => {
     const statement = executeParams.query || "";
     if (!statement) return;
 
-    const lines: string[][] = queryResult[2];
+    const lines: string[][] = queryResult.data[2];
     const explain = lines.map((line) => line[0]).join("\n");
     if (!explain) return;
 

--- a/frontend/src/views/sql-editor/TerminalPanel/TerminalPanel.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/TerminalPanel.vue
@@ -31,7 +31,7 @@
           <div v-if="query.queryResult" class="max-h-[20rem] flex flex-col">
             <TableView
               class="flex-1 overflow-hidden"
-              :query-result="query.queryResult.data"
+              :query-result="query.queryResult"
               :loading="query.status === 'RUNNING'"
               :dark="true"
             />
@@ -72,7 +72,12 @@ import type {
   ExecuteOption,
   WebTerminalQueryItem,
 } from "@/types";
-import { createQueryItem, useTabStore, useWebTerminalStore } from "@/store";
+import {
+  createQueryItem,
+  mockAffectedRows0,
+  useTabStore,
+  useWebTerminalStore,
+} from "@/store";
 import CompactSQLEditor from "./CompactSQLEditor.vue";
 import {
   EditorAction,
@@ -147,6 +152,9 @@ const handleExecute = async (
     // If the queryItem is still the currentQuery
     // which means it hasn't been cancelled.
     if (queryItem === currentQuery.value) {
+      if (sqlResultSet?.data?.[0].length === 0) {
+        sqlResultSet.data = mockAffectedRows0().data;
+      }
       queryItem.queryResult = sqlResultSet;
       pushQueryItem();
       // Clear the tab's statement and keep it sync with the latest query


### PR DESCRIPTION
### Changes
- Display a simple line of text when the executed statement is not a query (like `alter table` or `set @var...` commands). Close BYT-2542 
- Put the error messages into the result part instead of push notifications. Close BYT-2541

These changes will make our SQL Editor behaves more like familiar native db clients such as Navicat and TablePlus.
FYI @Candybase @tianzhou 

### Screenshots

![Snipaste_2023-03-02_10-24-24](https://user-images.githubusercontent.com/2749742/222315509-347e3cd9-3097-4182-a64e-c1b95d38fa2b.jpg)


<img width="1020" alt="image" src="https://user-images.githubusercontent.com/2749742/222315418-a669c765-8b88-4df8-a77c-234d5065dcb1.png">
