### PR TITLE
chore(frontend): normalize engines' languages and sql dialects

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
@@ -215,6 +215,8 @@ const allowSyncSQLFromSchemaEditor = computed(() => {
 const databaseList = props.databaseIdList.map((databaseId) => {
   return databaseStore.getDatabaseById(databaseId);
 });
+// Returns the type if it's uniq.
+// Returns "unknown" if there are more than ONE types.
 const databaseEngineType = computed((): EngineType | "unknown" => {
   const engineTypes = uniq(databaseList.map((db) => db.instance.engine));
   if (engineTypes.length !== 1) return "unknown";

--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -157,7 +157,14 @@ import {
   useUIStateStore,
 } from "@/store";
 import { useIssueLogic, TaskTypeWithSheetId, sheetIdOfTask } from "./logic";
-import type { Database, SQLDialect, Task, TaskCreate, TaskId } from "@/types";
+import {
+  Database,
+  dialectOfEngine,
+  SQLDialect,
+  Task,
+  TaskCreate,
+  TaskId,
+} from "@/types";
 import { UNKNOWN_ID } from "@/types";
 import { TableMetadata } from "@/types/proto/store/database";
 import MonacoEditor from "../MonacoEditor/MonacoEditor.vue";
@@ -316,11 +323,7 @@ const language = useInstanceEditorLanguage(
 
 const dialect = computed((): SQLDialect => {
   const db = selectedDatabase.value;
-  if (db?.instance.engine === "POSTGRES") {
-    return "postgresql";
-  }
-  // fallback to mysql dialect anyway
-  return "mysql";
+  return dialectOfEngine(db?.instance.engine);
 });
 
 const formatOnSave = computed({

--- a/frontend/src/components/Issue/logic/common.ts
+++ b/frontend/src/components/Issue/logic/common.ts
@@ -15,7 +15,6 @@ import {
   IssueCreate,
   IssuePatch,
   IssueType,
-  SQLDialect,
   Task,
   TaskCreate,
   TaskDatabaseCreatePayload,
@@ -33,6 +32,7 @@ import {
   TaskDatabaseSchemaUpdateGhostSyncPayload,
   SheetId,
   MigrationContext,
+  dialectOfEngine,
 } from "@/types";
 import { useIssueLogic } from "./index";
 import { isDev, isTaskTriggeredByVCS, taskCheckRunSummary } from "@/utils";
@@ -292,11 +292,7 @@ export const maybeFormatStatementOnSave = (
     return statement;
   }
 
-  // Default to use mysql dialect but use postgresql dialect if needed
-  let dialect: SQLDialect = "mysql";
-  if (database && database.instance.engine === "POSTGRES") {
-    dialect = "postgresql";
-  }
+  const dialect = dialectOfEngine(database?.instance.engine);
 
   const result = formatSQL(statement, dialect);
   if (!result.error) {

--- a/frontend/src/components/MonacoEditor/MonacoEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoEditor.vue
@@ -38,7 +38,7 @@ const props = defineProps({
   },
   dialect: {
     type: String as PropType<SQLDialect>,
-    default: "mysql",
+    default: "MYSQL",
   },
   readonly: {
     type: Boolean,

--- a/frontend/src/components/MonacoEditor/sqlFormatter.ts
+++ b/frontend/src/components/MonacoEditor/sqlFormatter.ts
@@ -1,4 +1,4 @@
-import { format, FormatOptions } from "sql-formatter";
+import { format, FormatOptions, supportedDialects } from "sql-formatter";
 
 import { SQLDialect } from "../../types";
 
@@ -8,12 +8,12 @@ type FormatResult = {
 };
 
 const formatSQL = (sql: string, dialect: SQLDialect): FormatResult => {
-  const options: FormatOptions = {
-    language: dialect,
-  };
-  if (dialect !== "mysql" && dialect !== "postgresql") {
-    options.language = "mysql";
+  if (!supportedDialects.includes(dialect)) {
+    dialect = "mysql";
   }
+  const options: Partial<FormatOptions> = {
+    language: dialect as FormatOptions["language"],
+  };
 
   try {
     const formatted = format(sql, options);

--- a/frontend/src/components/MonacoEditor/sqlFormatter.ts
+++ b/frontend/src/components/MonacoEditor/sqlFormatter.ts
@@ -1,4 +1,4 @@
-import { format, FormatOptions, supportedDialects } from "sql-formatter";
+import { format, FormatOptions } from "sql-formatter";
 
 import { SQLDialect } from "../../types";
 
@@ -7,12 +7,20 @@ type FormatResult = {
   error: Error | null;
 };
 
+type FormatterLanguage = FormatOptions["language"];
+
+const convertDialectToFormatterLanguage = (
+  dialect: SQLDialect
+): FormatterLanguage => {
+  if (dialect === "MYSQL" || dialect === "TIDB") return "mysql";
+  if (dialect === "POSTGRES") return "postgresql";
+  if (dialect === "SNOWFLAKE") return "snowflake";
+  return "sql";
+};
+
 const formatSQL = (sql: string, dialect: SQLDialect): FormatResult => {
-  if (!supportedDialects.includes(dialect)) {
-    dialect = "mysql";
-  }
   const options: Partial<FormatOptions> = {
-    language: dialect as FormatOptions["language"],
+    language: convertDialectToFormatterLanguage(dialect),
   };
 
   try {

--- a/frontend/src/components/SyncDatabaseSchemaPrepForm.vue
+++ b/frontend/src/components/SyncDatabaseSchemaPrepForm.vue
@@ -219,7 +219,7 @@
           data-label="bb-issue-sql-editor"
           :value="state.editStatement"
           :auto-focus="false"
-          :dialect="(state.engineType as SQLDialect)"
+          :dialect="dialectOfEngine(state.engineType)"
           @change="onStatementChange"
           @ready="updateEditorHeight"
         />
@@ -273,7 +273,7 @@ import {
   MigrationHistory,
   MigrationType,
   ProjectId,
-  SQLDialect,
+  dialectOfEngine,
   UNKNOWN_ID,
 } from "@/types";
 import {

--- a/frontend/src/plugins/sql-lsp/server/complete/index.ts
+++ b/frontend/src/plugins/sql-lsp/server/complete/index.ts
@@ -11,7 +11,7 @@ import {
   createSubQueryCandidates,
   createTableCandidates,
 } from "./candidates";
-import { getFromClauses } from "./utils";
+import { getFromClauses, isDialectWithSchema } from "./utils";
 import { simpleTokenize } from "./tokenizer";
 import { AliasMapping } from "./alias";
 import { SubQueryMapping } from "./sub-query";
@@ -35,6 +35,7 @@ export const complete = (
   const { fromTables, subQueries } = getFromClauses(sql);
   const subQueryMapping = new SubQueryMapping(tableList, subQueries, dialect);
   const aliasMapping = new AliasMapping(tableList, fromTables, dialect);
+  const withSchema = isDialectWithSchema(dialect);
 
   let suggestions: CompletionItem[] = [];
 
@@ -92,20 +93,20 @@ export const complete = (
       provideColumnAutoCompletionByAlias(maybeAlias);
 
       // - "{database_name}." (mysql)
-      if (dialect === "mysql") {
+      if (!withSchema) {
         const maybeDatabaseName = tokenListBeforeDot[0];
         provideTableAutoCompletion(maybeDatabaseName, tableList);
       }
       // - "{table_name}." (mysql)
       const maybeTableName = tokenListBeforeDot[0];
-      if (dialect === "mysql") {
+      if (!withSchema) {
         provideColumnAutoCompletion(maybeTableName, tableList);
         provideColumnAutoCompletion(
           maybeTableName,
           subQueryMapping.virtualTableList
         );
       }
-      if (dialect === "postgresql") {
+      if (withSchema) {
         // for postgresql, we also try "public.{table_name}."
         // since "public" schema can be omitted by default
         provideColumnAutoCompletion(`public.${maybeTableName}`, tableList);
@@ -118,21 +119,21 @@ export const complete = (
       // - "{database_name}.{table_name}." (mysql)
       // - "{schema_name}.{table_name}." (postgresql)
       const [maybeDatabaseName, maybeTableName] = tokenListBeforeDot;
-      if (dialect === "mysql") {
+      if (!withSchema) {
         provideColumnAutoCompletion(
           maybeTableName,
           tableList,
           maybeDatabaseName
         );
       }
-      if (dialect === "postgresql") {
+      if (withSchema) {
         const maybeTableNameWithSchema = tokenListBeforeDot.join(".");
         provideColumnAutoCompletion(maybeTableNameWithSchema, tableList);
       }
       // TODO: "{database_name}.{schema_name}." (postgresql)
     }
 
-    if (dialect === "postgresql" && tokenListBeforeDot.length === 3) {
+    if (withSchema && tokenListBeforeDot.length === 3) {
       // if the input is "x.y.z." it might be
       // - "{database_name}.{schema_name}.{table_name}." (postgresql only)
       //   and bytebase save {schema_name}.{table_name} as the table name
@@ -153,11 +154,12 @@ export const complete = (
     const suggestionsForAliases = aliasMapping.createAllAliasCandidates();
 
     // MySQL allows to query different databases, so we provide the database name suggestion for MySQL.
-    const suggestionsForDatabase =
-      dialect === "mysql" ? createDatabaseCandidates(schema.databases) : [];
+    const suggestionsForDatabase = !withSchema
+      ? createDatabaseCandidates(schema.databases)
+      : [];
     const suggestionsForTable = createTableCandidates(
       tableList,
-      dialect === "mysql" // Add database prefix to table candidates only for MySQL.
+      !withSchema // Add database prefix to table candidates only for MySQL.
     );
     const suggestionsForSubQueryVirtualTable = createSubQueryCandidates(
       subQueryMapping.virtualTableList

--- a/frontend/src/plugins/sql-lsp/server/complete/utils/common.ts
+++ b/frontend/src/plugins/sql-lsp/server/complete/utils/common.ts
@@ -10,7 +10,7 @@ export enum SortText {
 }
 
 export const isDialectWithSchema = (dialect: SQLDialect) => {
-  const DIALECTS_WITHOUT_SCHEMA: SQLDialect[] = ["mysql", "tidb"];
+  const DIALECTS_WITHOUT_SCHEMA: SQLDialect[] = ["MYSQL", "TIDB"];
   if (DIALECTS_WITHOUT_SCHEMA.includes(dialect)) {
     return false;
   }

--- a/frontend/src/plugins/sql-lsp/server/complete/utils/common.ts
+++ b/frontend/src/plugins/sql-lsp/server/complete/utils/common.ts
@@ -1,3 +1,5 @@
+import { SQLDialect } from "@/plugins/sql-lsp/types";
+
 export enum SortText {
   DATABASE = "0",
   TABLE = "1",
@@ -6,3 +8,11 @@ export enum SortText {
   ALIAS = "2", // Same as COLUMN
   KEYWORD = "3",
 }
+
+export const isDialectWithSchema = (dialect: SQLDialect) => {
+  const DIALECTS_WITHOUT_SCHEMA: SQLDialect[] = ["mysql", "tidb"];
+  if (DIALECTS_WITHOUT_SCHEMA.includes(dialect)) {
+    return false;
+  }
+  return true;
+};

--- a/frontend/src/plugins/sql-lsp/server/complete/utils/parser-helper.ts
+++ b/frontend/src/plugins/sql-lsp/server/complete/utils/parser-helper.ts
@@ -7,6 +7,7 @@ import type {
 } from "@joe-re/sql-parser";
 import { parseFromClause } from "@joe-re/sql-parser";
 import type { Column, SQLDialect, Table } from "@/plugins/sql-lsp/types";
+import { isDialectWithSchema } from "./common";
 
 export const getFromClauses = (sql: string) => {
   const fromTables: TableNode[] = [];
@@ -36,13 +37,14 @@ export const getFromClauses = (sql: string) => {
 
 export const getTableNameFromTableNode = (
   clause: TableNode,
-  dialect: SQLDialect = "mysql"
+  dialect: SQLDialect = "MYSQL"
 ): Pick<Table, "database" | "name"> => {
   const { table, db, catalog } = clause;
+  const withSchema = isDialectWithSchema(dialect);
   if (db && catalog) {
     // format: "x.y.z"
     // The parser recognizes x and store it to the `catalog` field.
-    if (dialect === "mysql") {
+    if (!withSchema) {
       // should be "{catalog}.{database}.{table}"
       // but we don't support mysql catalog by now, so just ignore it.
       return { name: table, database: db };
@@ -55,7 +57,7 @@ export const getTableNameFromTableNode = (
     }
   } else if (db) {
     // format: "x.y"
-    if (dialect === "mysql") {
+    if (!withSchema) {
       // should be "{database}.{table}"
       return { name: table, database: db };
     } else {

--- a/frontend/src/plugins/sql-lsp/server/server.ts
+++ b/frontend/src/plugins/sql-lsp/server/server.ts
@@ -5,7 +5,7 @@ import {
   CompletionItem,
 } from "vscode-languageserver/browser";
 import { initializeConnection } from "./initializeConnection";
-import type { Schema, SQLDialect } from "@sql-lsp/types";
+import { EngineTypesUsingSQL, Schema, SQLDialect } from "@sql-lsp/types";
 import { complete } from "./complete";
 
 declare const self: DedicatedWorkerGlobalScope;
@@ -87,13 +87,11 @@ connection.onExecuteCommand((request) => {
     state.schema = schema;
   } else if (request.command === "changeDialect") {
     const dialect = args[0];
-    if (!["mysql", "postgresql"].includes(dialect)) {
-      connection.sendNotification("error", {
-        message: `unknown dialect "${dialect}"`,
-      });
-      return;
+    if (EngineTypesUsingSQL.includes(dialect)) {
+      state.dialect = dialect;
+    } else {
+      state.dialect = "MYSQL";
     }
-    state.dialect = dialect;
   } else {
     connection.sendNotification("error", {
       message: "unknown command requested",

--- a/frontend/src/plugins/sql-lsp/server/server.ts
+++ b/frontend/src/plugins/sql-lsp/server/server.ts
@@ -21,7 +21,7 @@ type LocalState = {
 
 const state: LocalState = {
   schema: { databases: [] } as Schema,
-  dialect: "mysql",
+  dialect: "MYSQL",
 };
 
 connection.onInitialize((params): InitializeResult => {

--- a/frontend/src/plugins/sql-lsp/types/sql.ts
+++ b/frontend/src/plugins/sql-lsp/types/sql.ts
@@ -1,7 +1,7 @@
 export type SQLDialect =
-  | "mysql"
-  | "postgresql"
-  | "snowflake"
-  | "clickhouse"
-  | "tidb"
-  | "spanner";
+  | "MYSQL"
+  | "CLICKHOUSE"
+  | "POSTGRES"
+  | "SNOWFLAKE"
+  | "TIDB"
+  | "SPANNER";

--- a/frontend/src/plugins/sql-lsp/types/sql.ts
+++ b/frontend/src/plugins/sql-lsp/types/sql.ts
@@ -1,1 +1,7 @@
-export type SQLDialect = "mysql" | "postgresql";
+export type SQLDialect =
+  | "mysql"
+  | "postgresql"
+  | "snowflake"
+  | "clickhouse"
+  | "tidb"
+  | "spanner";

--- a/frontend/src/plugins/sql-lsp/types/sql.ts
+++ b/frontend/src/plugins/sql-lsp/types/sql.ts
@@ -1,7 +1,10 @@
-export type SQLDialect =
-  | "MYSQL"
-  | "CLICKHOUSE"
-  | "POSTGRES"
-  | "SNOWFLAKE"
-  | "TIDB"
-  | "SPANNER";
+export const EngineTypesUsingSQL = [
+  "MYSQL",
+  "CLICKHOUSE",
+  "POSTGRES",
+  "SNOWFLAKE",
+  "TIDB",
+  "SPANNER",
+] as const;
+
+export type SQLDialect = typeof EngineTypesUsingSQL[number];

--- a/frontend/src/types/sqlEditor.ts
+++ b/frontend/src/types/sqlEditor.ts
@@ -1,5 +1,5 @@
 import type * as monaco from "monaco-editor";
-import { InstanceId, DatabaseId, ActivityId } from "../types";
+import { InstanceId, DatabaseId, ActivityId, EngineType } from "../types";
 import { Principal } from "./principal";
 
 export type EditorModel = monaco.editor.ITextModel;
@@ -7,7 +7,34 @@ export type EditorPosition = monaco.Position;
 export type CompletionItems = monaco.languages.CompletionItem[];
 
 export type Language = "sql" | "javascript";
-export type SQLDialect = "mysql" | "postgresql";
+export type SQLDialect =
+  | "mysql"
+  | "postgresql"
+  | "snowflake"
+  | "clickhouse"
+  | "tidb"
+  | "spanner";
+
+export const languageOfEngine = (engine?: EngineType | "unknown"): Language => {
+  if (engine === "MONGODB") {
+    return "javascript";
+  }
+
+  return "sql";
+};
+
+export const dialectOfEngine = (
+  engine?: EngineType | "unknown"
+): SQLDialect => {
+  if (engine === "POSTGRES") {
+    return "postgresql";
+  }
+  if (engine === "SNOWFLAKE") {
+    return "snowflake";
+  }
+  // fallback to mysql dialect anyway
+  return "mysql";
+};
 
 export enum SortText {
   DATABASE = "0",

--- a/frontend/src/types/sqlEditor.ts
+++ b/frontend/src/types/sqlEditor.ts
@@ -7,13 +7,16 @@ export type EditorPosition = monaco.Position;
 export type CompletionItems = monaco.languages.CompletionItem[];
 
 export type Language = "sql" | "javascript";
-export type SQLDialect =
-  | "mysql"
-  | "postgresql"
-  | "snowflake"
-  | "clickhouse"
-  | "tidb"
-  | "spanner";
+
+export const EngineTypesUsingSQL = [
+  "MYSQL",
+  "CLICKHOUSE",
+  "POSTGRES",
+  "SNOWFLAKE",
+  "TIDB",
+  "SPANNER",
+] as const;
+export type SQLDialect = typeof EngineTypesUsingSQL[number];
 
 export const languageOfEngine = (engine?: EngineType | "unknown"): Language => {
   if (engine === "MONGODB") {
@@ -23,17 +26,12 @@ export const languageOfEngine = (engine?: EngineType | "unknown"): Language => {
   return "sql";
 };
 
-export const dialectOfEngine = (
-  engine?: EngineType | "unknown"
-): SQLDialect => {
-  if (engine === "POSTGRES") {
-    return "postgresql";
+export const dialectOfEngine = (engine = "unknown"): SQLDialect => {
+  if (EngineTypesUsingSQL.includes(engine as any)) {
+    return engine as SQLDialect;
   }
-  if (engine === "SNOWFLAKE") {
-    return "snowflake";
-  }
-  // fallback to mysql dialect anyway
-  return "mysql";
+  // Fallback to MYSQL otherwise
+  return "MYSQL";
 };
 
 export enum SortText {

--- a/frontend/src/utils/instance.ts
+++ b/frontend/src/utils/instance.ts
@@ -1,5 +1,11 @@
 import { computed, unref } from "vue";
-import { Environment, Instance, Language, MaybeRef } from "../types";
+import {
+  Environment,
+  Instance,
+  Language,
+  languageOfEngine,
+  MaybeRef,
+} from "../types";
 
 export function instanceName(instance: Instance) {
   let name = instance.name;
@@ -38,10 +44,7 @@ export const useInstanceEditorLanguage = (
   instance: MaybeRef<Instance | undefined>
 ) => {
   return computed((): Language => {
-    if (unref(instance)?.engine === "MONGODB") {
-      return "javascript";
-    }
-    return "sql";
+    return languageOfEngine(unref(instance)?.engine);
   });
 };
 

--- a/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
@@ -30,8 +30,9 @@ import {
   useDBSchemaStore,
 } from "@/store";
 import MonacoEditor from "@/components/MonacoEditor/MonacoEditor.vue";
-import type {
+import {
   Database,
+  dialectOfEngine,
   ExecuteConfig,
   ExecuteOption,
   SQLDialect,
@@ -67,11 +68,8 @@ const selectedInstanceEngine = computed(() => {
 });
 const selectedLanguage = useInstanceEditorLanguage(selectedInstance);
 const selectedDialect = computed((): SQLDialect => {
-  const engine = selectedInstanceEngine.value;
-  if (engine === "PostgreSQL") {
-    return "postgresql";
-  }
-  return "mysql";
+  const engine = selectedInstance.value.engine;
+  return dialectOfEngine(engine);
 });
 const readonly = computed(() => sheetStore.isReadOnly);
 const currentTabId = computed(() => tabStore.currentTabId);

--- a/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
@@ -29,7 +29,13 @@ import {
   useInstanceById,
 } from "@/store";
 import MonacoEditor from "@/components/MonacoEditor/MonacoEditor.vue";
-import { Database, ExecuteConfig, ExecuteOption, SQLDialect } from "@/types";
+import {
+  Database,
+  dialectOfEngine,
+  ExecuteConfig,
+  ExecuteOption,
+  SQLDialect,
+} from "@/types";
 import { TableMetadata } from "@/types/proto/store/database";
 import { useInstanceEditorLanguage } from "@/utils";
 
@@ -75,11 +81,8 @@ const selectedInstanceEngine = computed(() => {
 });
 const selectedLanguage = useInstanceEditorLanguage(selectedInstance);
 const selectedDialect = computed((): SQLDialect => {
-  const engine = selectedInstanceEngine.value;
-  if (engine === "PostgreSQL") {
-    return "postgresql";
-  }
-  return "mysql";
+  const engine = selectedInstance.value.engine;
+  return dialectOfEngine(engine);
 });
 const currentTabId = computed(() => tabStore.currentTabId);
 const isSwitchingTab = ref(false);


### PR DESCRIPTION
### Changes
- Before: MYSQL -> "mysql", POSTGRES -> "postgresql", others -> "mysql"
- After: Each EngineType is mapped to a dedicated dialect type.

