### PR TITLE
chore: remove idp fields for principal table

### DIFF
--- a/backend/store/migration/dev/20230303000001##remove_idp_fields_in_principal.sql
+++ b/backend/store/migration/dev/20230303000001##remove_idp_fields_in_principal.sql
@@ -1,0 +1,3 @@
+ALTER TABLE principal DROP COLUMN idp_id;
+
+ALTER TABLE principal DROP COLUMN idp_user_info;

--- a/backend/store/migration/dev/LATEST.sql
+++ b/backend/store/migration/dev/LATEST.sql
@@ -46,8 +46,6 @@ CREATE TABLE principal (
     name TEXT NOT NULL,
     email TEXT NOT NULL,
     password_hash TEXT NOT NULL,
-    idp_id INTEGER REFERENCES idp (id),
-    idp_user_info JSONB NOT NULL DEFAULT '{}',
     mfa_config JSONB NOT NULL DEFAULT '{}'
 );
 


### PR DESCRIPTION
Since `idp_id` and `idp_user_info` are not used, we should remove them from the schema to avoid confusing users.

Close BYT-2708