### PR TITLE
chore: add AuthorName and AuthorEmail for GitOps

### DIFF
--- a/backend/plugin/vcs/github/github_test.go
+++ b/backend/plugin/vcs/github/github_test.go
@@ -371,7 +371,7 @@ func TestProvider_CreateFile(t *testing.T) {
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		wantBody := `{"message":"my commit message","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","branch":"master"}`
+		wantBody := `{"message":"my commit message","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","branch":"master","author":{"date":"0001-01-01T00:00:00Z","name":"","email":""}}`
 		assert.Equal(t, wantBody, string(body))
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -456,7 +456,7 @@ func TestProvider_OverwriteFile(t *testing.T) {
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		wantBody := `{"message":"update file","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","sha":"7638417db6d59f3c431d3e1f261cc637155684cd","branch":"master"}`
+		wantBody := `{"message":"update file","content":"bXkgbmV3IGZpbGUgY29udGVudHM=","sha":"7638417db6d59f3c431d3e1f261cc637155684cd","branch":"master","author":{"date":"0001-01-01T00:00:00Z","name":"","email":""}}`
 		assert.Equal(t, wantBody, string(body))
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/backend/plugin/vcs/gitlab/gitlab.go
+++ b/backend/plugin/vcs/gitlab/gitlab.go
@@ -110,6 +110,8 @@ type FileCommit struct {
 	Content       string `json:"content"`
 	CommitMessage string `json:"commit_message"`
 	LastCommitID  string `json:"last_commit_id,omitempty"`
+	AuthorName    string `json:"author_name,omitempty"`
+	AuthorEmail   string `json:"author_email,omitempty"`
 }
 
 // RepositoryTreeNode represents a GitLab API response for a repository tree
@@ -543,6 +545,8 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 			Branch:        fileCommitCreate.Branch,
 			CommitMessage: fileCommitCreate.CommitMessage,
 			Content:       fileCommitCreate.Content,
+			AuthorName:    fileCommitCreate.AuthorName,
+			AuthorEmail:   fileCommitCreate.AuthorEmail,
 		},
 	)
 	if err != nil {
@@ -592,6 +596,8 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 			Content:       fileCommitCreate.Content,
 			CommitMessage: fileCommitCreate.CommitMessage,
 			LastCommitID:  fileCommitCreate.LastCommitID,
+			AuthorName:    fileCommitCreate.AuthorName,
+			AuthorEmail:   fileCommitCreate.AuthorEmail,
 		},
 	)
 	if err != nil {

--- a/backend/plugin/vcs/vcs.go
+++ b/backend/plugin/vcs/vcs.go
@@ -25,6 +25,11 @@ const (
 
 	// SQLReviewAPISecretName is the api secret name used in GitHub action or GitLab CI workflow.
 	SQLReviewAPISecretName = "SQL_REVIEW_API_SECRET"
+
+	// BytebaseAuthorName is the author name of bytebase.
+	BytebaseAuthorName = "Bytebase"
+	// BytebaseAuthorEmail is the author email of bytebase.
+	BytebaseAuthorEmail = "support@bytebase.com"
 )
 
 // OAuthToken is the API message for OAuthToken.
@@ -73,6 +78,8 @@ type FileCommitCreate struct {
 	Content       string
 	CommitMessage string
 	LastCommitID  string
+	AuthorName    string
+	AuthorEmail   string
 }
 
 // FileMeta records the file metadata.

--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -589,6 +589,8 @@ func writeBackLatestSchema(ctx context.Context, store *store.Store, repository *
 		Branch:        writebackBranch,
 		CommitMessage: commitMessage,
 		Content:       schema,
+		AuthorName:    vcsPlugin.BytebaseAuthorName,
+		AuthorEmail:   vcsPlugin.BytebaseAuthorEmail,
 	}
 	if createSchemaFile {
 		log.Debug("Create latest schema file",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20775801/222685465-d8754f12-2f3b-446d-a697-794adb29ca36.png)
close BYT-2695

We add this information for writing back LATEST commit to ignore redundantly GitOps issue