### PR TITLE
chore: add account name to MFA secret generator

### DIFF
--- a/backend/plugin/mfa/otp/otp.go
+++ b/backend/plugin/mfa/otp/otp.go
@@ -21,13 +21,13 @@ type TimeBasedReader struct {
 	reader *strings.Reader
 }
 
-// NewTimeBasedReader creates a new TimeBasedReader for the given timestamp.
-func NewTimeBasedReader(timestamp time.Time) *TimeBasedReader {
+// NewTimeBasedReader creates a new TimeBasedReader with the given account name and timestamp.
+func NewTimeBasedReader(accountName string, timestamp time.Time) *TimeBasedReader {
 	// Convert the timestamp to Unix time and divide by the secretMaxExpiredDuration.
 	// We generate a new secret every 5 minutes. e.g. 15:00, 15:05
 	formatedTimestampUnix := timestamp.Unix() / int64(generateSecretPeriod/time.Second)
 	return &TimeBasedReader{
-		reader: strings.NewReader(strconv.FormatInt(formatedTimestampUnix, 10)),
+		reader: strings.NewReader(accountName + strconv.FormatInt(formatedTimestampUnix, 10)),
 	}
 }
 
@@ -40,7 +40,7 @@ func GenerateSecret(accountName string, timestamp time.Time) (string, error) {
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      issuerName,
 		AccountName: accountName,
-		Rand:        NewTimeBasedReader(timestamp),
+		Rand:        NewTimeBasedReader(accountName, timestamp),
 	})
 	if err != nil {
 		return "", err
@@ -58,7 +58,7 @@ func GetValidSecrets(accountName string, timestamp time.Time) ([]string, error) 
 		key, err := totp.Generate(totp.GenerateOpts{
 			Issuer:      issuerName,
 			AccountName: accountName,
-			Rand:        NewTimeBasedReader(t),
+			Rand:        NewTimeBasedReader(accountName, t),
 		})
 		if err != nil {
 			return nil, err

--- a/backend/plugin/mfa/otp/otp_test.go
+++ b/backend/plugin/mfa/otp/otp_test.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func TestGenerateTimeBasedSecret(t *testing.T) {
+func TestValidateTimeBasedSecretDuration(t *testing.T) {
 	currentTime := time.Now()
 	accountName := "test-user"
 
@@ -75,6 +75,30 @@ func TestGenerateTimeBasedSecret(t *testing.T) {
 			validSecrets, err := GetValidSecrets(accountName, test.validateTime)
 			assert.NoError(t, err)
 			assert.Equal(t, test.isSecretExpired, !slices.Contains(validSecrets, secret))
+		})
+	}
+}
+
+func TestGenerateTimeBasedSecret(t *testing.T) {
+	accountName := "test-user"
+
+	tests := []struct {
+		accountName  string
+		timestamp    time.Time
+		wantedSecret string
+	}{
+		{
+			accountName:  "test-user",
+			timestamp:    time.Unix(1678115520, 0),
+			wantedSecret: "ORSXG5BNOVZWK4RVGU4TGNZRHAAAAAAA",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.accountName, func(t *testing.T) {
+			secret, err := GenerateSecret(accountName, test.timestamp)
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantedSecret, secret)
 		})
 	}
 }


### PR DESCRIPTION
Add account name(unique user name) to MFA secret generator to prevent the same key from being generated by different users.