### PR TITLE
feat(frontend): improve SDL issue display

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -661,7 +661,8 @@
     "sdl": {
       "schema-change": "Schema change",
       "generated-ddl-statements": "Generated DDL statements",
-      "full-schema": "Full schema"
+      "full-schema": "Full schema",
+      "left-schema-may-change": "The schema on the left side may change before the issue is applied."
     }
   },
   "alter-schema": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -659,7 +659,8 @@
     "sdl": {
       "schema-change": "Schema 变化",
       "generated-ddl-statements": "生成的 DDL 语句",
-      "full-schema": "完整 schema"
+      "full-schema": "完整 schema",
+      "left-schema-may-change": "左边的 schema 在工单执行前可能会发生变化。"
     }
   },
   "alter-schema": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,6 +7,7 @@ import NaiveUI from "./plugins/naive-ui";
 import dayjs from "./plugins/dayjs";
 import highlight from "./plugins/highlight";
 import mountDemoApp from "./plugins/demo";
+import { isSilent } from "./plugins/silent-request";
 import { router } from "./router";
 import {
   pinia,
@@ -89,7 +90,7 @@ axios.interceptors.response.use(
         }
       }
 
-      if (error.response.data.message) {
+      if (error.response.data.message && !isSilent()) {
         pushNotification({
           module: "bytebase",
           style: "CRITICAL",
@@ -100,7 +101,7 @@ axios.interceptors.response.use(
             : undefined,
         });
       }
-    } else if (error.code == "ECONNABORTED") {
+    } else if (error.code == "ECONNABORTED" && !isSilent()) {
       pushNotification({
         module: "bytebase",
         style: "CRITICAL",

--- a/frontend/src/plugins/silent-request.ts
+++ b/frontend/src/plugins/silent-request.ts
@@ -1,0 +1,16 @@
+const state = {
+  silent: false,
+};
+
+export const isSilent = () => {
+  return state.silent;
+};
+
+// Requests wrapped in useSilentRequest won't be intercepted by our global
+// error handling (pushNotifications)
+export const useSilentRequest = async <T>(fn: () => Promise<T>): Promise<T> => {
+  state.silent = true;
+  const result = await fn();
+  state.silent = false;
+  return result;
+};


### PR DESCRIPTION
### Changes

- Adjust the layout (Close BYT-2700)
  - Remove the "SQL" label
  - Add a tooltip to the "Schema change" tab (The Learn More link's URL might be updated while our new user docs about this are done FYI @Candybase @rebelice )
- Error handling while the SDL has syntax errors.
  - Won't push notifications. But display user-readable error messages on the panel.
  - Also, the "Schema change" and "Generated DML statement" tabs are disabled since they are unavailable.

### Screenshots

- Tooltip
<img width="643" alt="image" src="https://user-images.githubusercontent.com/2749742/223612360-79ae916d-e6d7-4b92-8d27-204510595a4a.png">

- Error displaying
<img width="818" alt="image" src="https://user-images.githubusercontent.com/2749742/223611656-02c3a4cb-9ec2-4fb0-bb9f-ba71da637e44.png">
