### PR TITLE
fix: generate correct commit link for GitHub.com

### DIFF
--- a/backend/plugin/vcs/github/github.go
+++ b/backend/plugin/vcs/github/github.go
@@ -94,6 +94,18 @@ type RepositoryTreeNode struct {
 	Type string `json:"type"`
 }
 
+// Reference represents a GitHub API response for a reference.
+type Reference struct {
+	Ref    string `json:"ref"`
+	NodeID string `json:"node_id"`
+	URL    string `json:"url"`
+	Object struct {
+		Type string `json:"type"`
+		SHA  string `json:"sha"`
+		URL  string `json:"url"`
+	} `json:"object"`
+}
+
 // File represents a GitHub API response for a repository file.
 type File struct {
 	Encoding string `json:"encoding"`
@@ -580,7 +592,7 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 		Message: fileCommitCreate.CommitMessage,
 		Content: base64.StdEncoding.EncodeToString([]byte(fileCommitCreate.Content)),
 		Branch:  fileCommitCreate.Branch,
-		SHA:     fileCommitCreate.LastCommitID,
+		SHA:     fileCommitCreate.SHA,
 	}
 	if fileCommitCreate.AuthorName != "" && fileCommitCreate.AuthorEmail != "" {
 		fileCommit.Author = CommitAuthor{
@@ -637,7 +649,11 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 //
 // Docs: https://docs.github.com/en/rest/repos/contents#get-repository-content
 func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*vcs.FileMeta, error) {
-	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, ref)
+	lastCommitID, err := p.getLastCommitID(ctx, oauthCtx, instanceURL, repositoryID, ref)
+	if err != nil {
+		return nil, errors.Wrap(err, "get last commit ID")
+	}
+	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, lastCommitID)
 	if err != nil {
 		return nil, errors.Wrap(err, "read file")
 	}
@@ -646,8 +662,54 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 		Name:         file.Name,
 		Path:         file.Path,
 		Size:         file.Size,
-		LastCommitID: file.SHA,
+		SHA:          file.SHA,
+		LastCommitID: lastCommitID,
 	}, nil
+}
+
+// getLastCommitID gets the last commit ID of given reference in the repository.
+//
+// Docs: https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
+func (p *Provider) getLastCommitID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref string) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/git/refs/heads/%s", p.APIURL(instanceURL), repositoryID, ref)
+	fmt.Println("get commit ID URL ", url)
+
+	code, _, body, err := oauth.Get(
+		ctx,
+		p.client,
+		url,
+		&oauthCtx.AccessToken,
+		tokenRefresher(
+			instanceURL,
+			oauthContext{
+				ClientID:     oauthCtx.ClientID,
+				ClientSecret: oauthCtx.ClientSecret,
+				RefreshToken: oauthCtx.RefreshToken,
+			},
+			oauthCtx.Refresher,
+		),
+	)
+	if err != nil {
+		return "", errors.Wrapf(err, "GET %s", url)
+	}
+
+	if code == http.StatusNotFound {
+		return "", common.Errorf(common.NotFound, "failed to get last commit ID from URL %s", url)
+	} else if code >= 300 {
+		return "",
+			errors.Errorf("failed to get last commit ID from URL %s, status code: %d, body: %s",
+				url,
+				code,
+				body,
+			)
+	}
+
+	var reference Reference
+	if err = json.Unmarshal([]byte(body), &reference); err != nil {
+		return "", errors.Wrap(err, "unmarshal body")
+	}
+
+	return reference.Object.SHA, nil
 }
 
 // ReadFileContent reads the content of the given file in the repository.

--- a/backend/plugin/vcs/github/github.go
+++ b/backend/plugin/vcs/github/github.go
@@ -672,7 +672,6 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 // Docs: https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
 func (p *Provider) getLastCommitID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref string) (string, error) {
 	url := fmt.Sprintf("%s/repos/%s/git/refs/heads/%s", p.APIURL(instanceURL), repositoryID, ref)
-	fmt.Println("get commit ID URL ", url)
 
 	code, _, body, err := oauth.Get(
 		ctx,

--- a/backend/plugin/vcs/github/github.go
+++ b/backend/plugin/vcs/github/github.go
@@ -671,7 +671,7 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 //
 // Docs: https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
 func (p *Provider) getLastCommitID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref string) (string, error) {
-	url := fmt.Sprintf("%s/repos/%s/git/refs/heads/%s", p.APIURL(instanceURL), repositoryID, ref)
+	url := fmt.Sprintf("%s/repos/%s/git/ref/heads/%s", p.APIURL(instanceURL), repositoryID, ref)
 
 	code, _, body, err := oauth.Get(
 		ctx,

--- a/backend/plugin/vcs/vcs.go
+++ b/backend/plugin/vcs/vcs.go
@@ -80,6 +80,7 @@ type FileCommitCreate struct {
 	Content       string
 	CommitMessage string
 	LastCommitID  string
+	SHA           string
 	AuthorName    string
 	AuthorEmail   string
 }
@@ -90,6 +91,7 @@ type FileMeta struct {
 	Path         string
 	Size         int64
 	LastCommitID string
+	SHA          string
 }
 
 // FileDiffType is the type of file diff.

--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -625,6 +625,7 @@ func writeBackLatestSchema(ctx context.Context, store *store.Store, repository *
 		)
 
 		schemaFileCommit.LastCommitID = schemaFileMeta.LastCommitID
+		schemaFileCommit.SHA = schemaFileMeta.SHA
 		err := vcsPlugin.Get(repo2.VCS.Type, vcsPlugin.ProviderConfig{}).OverwriteFile(
 			ctx,
 			common.OauthContext{

--- a/backend/server/project.go
+++ b/backend/server/project.go
@@ -1070,6 +1070,7 @@ func (s *Server) setupVCSSQLReviewBranch(ctx context.Context, repository *api.Re
 func (s *Server) setupVCSSQLReviewCIForGitHub(ctx context.Context, repository *api.Repository, branch *vcsPlugin.BranchInfo, sqlReviewEndpoint string) error {
 	sqlReviewConfig := github.SetupSQLReviewCI(sqlReviewEndpoint)
 	fileLastCommitID := ""
+	fileSHA := ""
 
 	fileMeta, err := vcsPlugin.Get(repository.VCS.Type, vcsPlugin.ProviderConfig{}).ReadFileMeta(
 		ctx,
@@ -1095,6 +1096,7 @@ func (s *Server) setupVCSSQLReviewCIForGitHub(ctx context.Context, repository *a
 		)
 	} else if fileMeta != nil {
 		fileLastCommitID = fileMeta.LastCommitID
+		fileSHA = fileMeta.SHA
 	}
 
 	return vcsPlugin.Get(repository.VCS.Type, vcsPlugin.ProviderConfig{}).CreateFile(
@@ -1114,6 +1116,7 @@ func (s *Server) setupVCSSQLReviewCIForGitHub(ctx context.Context, repository *a
 			CommitMessage: sqlReviewInVCSPRTitle,
 			Content:       sqlReviewConfig,
 			LastCommitID:  fileLastCommitID,
+			SHA:           fileSHA,
 		},
 	)
 }
@@ -1223,6 +1226,7 @@ func (s *Server) createOrUpdateVCSSQLReviewFileForGitLab(
 				CommitMessage: sqlReviewInVCSPRTitle,
 				Content:       newContent,
 				LastCommitID:  fileMeta.LastCommitID,
+				SHA:           fileMeta.SHA,
 			},
 		)
 	}

--- a/frontend/src/components/Issue/IssueActivityPanel.vue
+++ b/frontend/src/components/Issue/IssueActivityPanel.vue
@@ -694,6 +694,8 @@ const actionSubject = (activity: Activity): ActionSubject => {
 
 const fileCommitActivityUrl = (activity: Activity) => {
   const payload = activity.payload as ActivityTaskFileCommitPayload;
+  if (payload.vcsInstanceUrl.includes("https://github.com"))
+    return `${payload.vcsInstanceUrl}/${payload.repositoryFullPath}/commit/${payload.commitId}`;
   return `${payload.vcsInstanceUrl}/${payload.repositoryFullPath}/-/commit/${payload.commitId}`;
 };
 


### PR DESCRIPTION
close BYT-2689

For GitHub.com, it needs file SHA and commit ID for different APIs. Before this PR, we treated these two different things as one thing.

![image](https://user-images.githubusercontent.com/20775801/223685976-6e0cefbe-c729-47d9-90f4-5a727459c334.png)
