### PR TITLE
chore(frontend): add a required star to "Schema path template" for SDL projects

### DIFF
--- a/frontend/src/components/RepositoryForm.vue
+++ b/frontend/src/components/RepositoryForm.vue
@@ -158,13 +158,14 @@
     <div>
       <div class="textlabel flex gap-x-1">
         {{ $t("repository.schema-path-template") }}
+        <span v-if="isProjectSchemaChangeTypeSDL" class="text-red-600">*</span>
         <FeatureBadge
           feature="bb.feature.vcs-schema-write-back"
           class="text-accent"
         />
       </div>
       <div class="mt-1 textinfolabel">
-        <template v-if="!isProjectSchemaChangeTypeDDL">
+        <template v-if="isProjectSchemaChangeTypeSDL">
           {{ $t("project.settings.schema-path-template-sdl-description") }}
         </template>
         <template v-else>
@@ -366,6 +367,9 @@ export default defineComponent({
     const isProjectSchemaChangeTypeDDL = computed(() => {
       return (props.schemaChangeType || "DDL") === "DDL";
     });
+    const isProjectSchemaChangeTypeSDL = computed(() => {
+      return (props.schemaChangeType || "DDL") === "SDL";
+    });
     const enableSQLReviewTitle = computed(() => {
       return props.vcsType.startsWith("GITLAB")
         ? t("repository.sql-review-ci-enable-gitlab")
@@ -492,6 +496,7 @@ export default defineComponent({
       hasFeature,
       getRquiredPlanString: subscriptionStore.getRquiredPlanString,
       isProjectSchemaChangeTypeDDL,
+      isProjectSchemaChangeTypeSDL,
       enableSQLReviewTitle,
       sampleFilePath,
       sampleSchemaPath,


### PR DESCRIPTION
For DDL, it's optional. But required for SDL.
FYI @Candybase @rebelice 

### Screenshots
<img width="369" alt="image" src="https://user-images.githubusercontent.com/2749742/223892498-cd949451-f42c-42b8-88b6-4594dde5d7ea.png">
