### PR TITLE
feat(frontend): redis shouldn't have "Create database"

### DIFF
--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -107,15 +107,15 @@
           </label>
         </div>
         <div class="flex flex-row space-x-2 items-center">
-          <!-- eslint-disable vue/attribute-hyphenation -->
           <InstanceSelect
             id="instance"
             class="mt-1"
             name="instance"
             required
             :disabled="!allowEditInstance"
-            :selectedId="state.instanceId"
-            :environmentId="state.environmentId"
+            :selected-id="state.instanceId"
+            :environment-id="state.environmentId"
+            :filter="instanceHasCreateDatabase"
             @select-instance-id="selectInstance"
           />
         </div>
@@ -130,8 +130,8 @@
           id="instance-user"
           class="mt-1"
           name="instance-user"
-          :instanceId="state.instanceId"
-          :selectedId="state.instanceUserId"
+          :instance-id="state.instanceId"
+          :selected-id="state.instanceUserId"
           @select="selectInstanceUser"
         />
       </div>
@@ -271,7 +271,11 @@ import {
   InstanceUserId,
   PITRContext,
 } from "../types";
-import { hasWorkspacePermission, issueSlug } from "../utils";
+import {
+  hasWorkspacePermission,
+  instanceHasCreateDatabase,
+  issueSlug,
+} from "../utils";
 import { useEventListener } from "@vueuse/core";
 import {
   hasFeature,
@@ -622,6 +626,7 @@ export default defineComponent({
       showCollationAndCharacterSet,
       requireDatabaseOwnerName,
       showAssigneeSelect,
+      instanceHasCreateDatabase,
       selectProject,
       selectEnvironment,
       selectInstance,

--- a/frontend/src/components/InstanceSelect.vue
+++ b/frontend/src/components/InstanceSelect.vue
@@ -17,7 +17,7 @@
 <script lang="ts">
 import { useInstanceStore } from "@/store";
 import { computed, defineComponent, PropType, reactive, watch } from "vue";
-import { Instance, UNKNOWN_ID } from "../types";
+import { IdType, Instance, UNKNOWN_ID } from "../types";
 
 interface LocalState {
   selectedInstance?: Instance;
@@ -28,11 +28,11 @@ export default defineComponent({
   components: {},
   props: {
     selectedId: {
-      type: Number,
+      type: [String, Number] as PropType<IdType>,
       default: undefined,
     },
     environmentId: {
-      type: Number,
+      type: [String, Number] as PropType<IdType>,
       default: undefined,
     },
     filter: {

--- a/frontend/src/utils/instance.ts
+++ b/frontend/src/utils/instance.ts
@@ -75,3 +75,9 @@ export const instanceHasReadonlyMode = (instance: Instance): boolean => {
   if (engine === "REDIS") return false;
   return true;
 };
+
+export const instanceHasCreateDatabase = (instance: Instance): boolean => {
+  const { engine } = instance;
+  if (engine === "REDIS") return false;
+  return true;
+};

--- a/frontend/src/views/InstanceDetail.vue
+++ b/frontend/src/views/InstanceDetail.vue
@@ -45,7 +45,10 @@
               {{ $t("common.sync-now") }}
             </button>
             <button
-              v-if="instance.rowStatus == 'NORMAL'"
+              v-if="
+                instance.rowStatus == 'NORMAL' &&
+                instanceHasCreateDatabase(instance)
+              "
               type="button"
               class="btn-primary"
               @click.prevent="createDatabase"
@@ -150,7 +153,11 @@
 
 <script lang="ts" setup>
 import { computed, reactive, watchEffect } from "vue";
-import { idFromSlug, hasWorkspacePermission } from "../utils";
+import {
+  idFromSlug,
+  hasWorkspacePermission,
+  instanceHasCreateDatabase,
+} from "../utils";
 import ArchiveBanner from "../components/ArchiveBanner.vue";
 import DatabaseTable from "../components/DatabaseTable.vue";
 import DataSourceTable from "../components/DataSourceTable.vue";


### PR DESCRIPTION
### Changes

- Don't list redis instances in the "Instance" selector of the "Create dialog" dialog.
- Don't show "New database" button for redis on the instance detail page.