### PR TITLE
chore(ci): show more issues of golangci-lint

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
-          args: --verbose --timeout 10m
+          args: --verbose --timeout 10m --max-same-issues=30
           skip-cache: true
 
   go-tests:


### PR DESCRIPTION
Run `golangci-lint` locally often takes up too many resources, especially trigger golangci-lint while saving in VSCode. : \\
And the default value of  [`golangci-lint --max-same-issues` is `3`](https://golangci-lint.run/usage/configuration/#issues-configuration), it is too little and will result in the need for repeated commits to pass the check.