### PR TITLE
feat: disable database creation for Oracle

### DIFF
--- a/backend/runner/taskrun/database_create_executor.go
+++ b/backend/runner/taskrun/database_create_executor.go
@@ -63,7 +63,9 @@ func (exec *DatabaseCreateExecutor) RunOnce(ctx context.Context, task *store.Tas
 	}
 
 	var driver db.Driver
-	if instance.Engine == db.MongoDB {
+	if instance.Engine == db.Oracle {
+		return true, nil, errors.Errorf("Creating Oracle database is not supported")
+	} else if instance.Engine == db.MongoDB {
 		// For MongoDB, it allows us to connect to the non-existing database. So we pass the database name to driver to let us connect to the specific database.
 		// And run the create collection statement later.
 		driver, err = exec.dbFactory.GetAdminDatabaseDriver(ctx, instance, payload.DatabaseName)

--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -575,6 +575,9 @@ func (s *Server) getPipelineCreateForDatabaseCreate(ctx context.Context, issueCr
 	if instance == nil {
 		return nil, errors.Errorf("instance ID not found %v", c.InstanceID)
 	}
+	if instance.Engine == db.Oracle {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Creating Oracle database is not supported")
+	}
 	environment, err := s.store.GetEnvironmentV2(ctx, &store.FindEnvironmentMessage{ResourceID: &instance.EnvironmentID})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Creating an Oracle database is an elaborative/physical process, and users will usually do it themselves. We don't support it for now.