### PR TITLE
fix: redis json marshal cannot handle map[any]any

### DIFF
--- a/backend/plugin/db/redis/redis.go
+++ b/backend/plugin/db/redis/redis.go
@@ -155,9 +155,8 @@ func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, _
 		}
 
 		val := cmd.Val()
-		switch val.(type) {
-		// json.Marshal cannot handle map[interface{}]interface{}
-		case map[interface{}]interface{}:
+		if _, ok := val.(map[interface{}]interface{}); ok {
+			// json.Marshal cannot handle map[interface{}]interface{}
 			val = cmd.String()
 		}
 

--- a/backend/plugin/db/redis/redis.go
+++ b/backend/plugin/db/redis/redis.go
@@ -151,9 +151,17 @@ func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, _
 	for _, cmd := range cmds {
 		if cmd.Err() == redis.Nil {
 			data = append(data, []interface{}{"redis: nil"})
-		} else {
-			data = append(data, []interface{}{cmd.Val()})
+			continue
 		}
+
+		val := cmd.Val()
+		switch val.(type) {
+		// json.Marshal cannot handle map[interface{}]interface{}
+		case map[interface{}]interface{}:
+			val = cmd.String()
+		}
+
+		data = append(data, []interface{}{val})
 	}
 
 	return []interface{}{[]string{"result"}, []string{"TEXT"}, data}, nil


### PR DESCRIPTION
type information is lost because we use the universal `Cmd` to handle user inputs.
The returned values could be a map[interface{}]interface{} value which cannot be parsed by `encoding/json`. And we fall back to cmd.String() in that case.