### PR TITLE
chore: skip instance change backfill for schemaless or new types of databases

### DIFF
--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -187,7 +187,7 @@ func executeMigration(ctx context.Context, stores *store.Store, dbFactory *dbfac
 		task = updatedTask
 	}
 
-	if instance.Engine == db.Redis {
+	if instance.Engine == db.Redis || instance.Engine == db.Oracle {
 		migrationID, schema, err = utils.ExecuteMigration(ctx, stores, driver, mi, statement)
 		if err != nil {
 			return "", "", err

--- a/backend/server/instance.go
+++ b/backend/server/instance.go
@@ -380,7 +380,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 
 		var entry *db.MigrationHistory
 		find := &db.MigrationHistoryFind{ID: &historyID, InstanceID: instanceID}
-		if instance.Engine == db.Redis {
+		if instance.Engine == db.Redis || instance.Engine == db.Oracle {
 			list, err := s.store.FindInstanceChangeHistoryList(ctx, find)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch migration history list").SetInternal(err)
@@ -470,7 +470,7 @@ func (s *Server) registerInstanceRoutes(g *echo.Group) {
 		find := &db.MigrationHistoryFind{
 			InstanceID: instance.UID,
 		}
-		if instance.Engine == db.Redis {
+		if instance.Engine == db.Redis || instance.Engine == db.Oracle {
 			if databaseStr := c.QueryParams().Get("database"); databaseStr != "" {
 				database, err := s.store.GetDatabaseV2(ctx, &store.FindDatabaseMessage{
 					InstanceID:   &instance.ResourceID,

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -1085,7 +1085,7 @@ func (s *Server) backfillInstanceChangeHistory(ctx context.Context) {
 		var errList error
 		for _, instance := range instanceList {
 			err := func() error {
-				if instance.Engine == db.Redis {
+				if instance.Engine == db.Redis || instance.Engine == db.Oracle || instance.Engine == db.Spanner || instance.Engine == db.MongoDB {
 					return nil
 				}
 				if instanceMigrated[instance.UID] {

--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -35,7 +35,7 @@ func GetLatestSchemaVersion(ctx context.Context, store *store.Store, driver db.D
 		Limit:      &limit,
 	}
 
-	if driver.GetType() == db.Redis {
+	if driver.GetType() == db.Redis || driver.GetType() == db.Oracle {
 		history, err := store.FindInstanceChangeHistoryList(ctx, find)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to get migration history for database %q", databaseName)


### PR DESCRIPTION
And handle migration history well for Oracle.