### PR TITLE
feat: add external context column to store the external context

### DIFF
--- a/backend/store/migration/dev/20230312000000##issue_external_context.sql
+++ b/backend/store/migration/dev/20230312000000##issue_external_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE issue ADD COLUMN external_context TEXT NOT NULL DEFAULT '';

--- a/backend/store/migration/dev/LATEST.sql
+++ b/backend/store/migration/dev/LATEST.sql
@@ -670,7 +670,8 @@ CREATE TABLE issue (
     -- While changing assignee_id, one should only change it to a non-robot DBA/owner.
     assignee_id INTEGER NOT NULL REFERENCES principal (id),
     assignee_need_attention BOOLEAN NOT NULL DEFAULT FALSE, 
-    payload JSONB NOT NULL DEFAULT '{}'
+    payload JSONB NOT NULL DEFAULT '{}',
+    external_context TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX idx_issue_project_id ON issue(project_id);


### PR DESCRIPTION
The external context field is used to capture context information provided by an external system. When a webhook is triggered due to a change in system state, the content of this field will be included in the webhook payload and sent back to the external system. This allows the external system to receive the same context information it provided, facilitating two-way communication and enabling more advanced integrations.

