### PR TITLE
chore: using 0 as container id if the type of activity is 'bb.member.*'

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -187,8 +187,9 @@ func (s *AuthService) CreateUser(ctx context.Context, request *v1pb.CreateUserRe
 		return nil, status.Errorf(codes.Internal, "failed to construct activity payload, error: %v", err)
 	}
 	activityCreate := &api.ActivityCreate{
-		CreatorID:   user.ID,
-		ContainerID: user.ID,
+		CreatorID: user.ID,
+		// The container id is 0 because the activity is related to workspace.
+		ContainerID: 0,
 		Type:        api.ActivityMemberCreate,
 		Level:       api.ActivityInfo,
 		Payload:     string(bytes),

--- a/backend/server/member.go
+++ b/backend/server/member.go
@@ -41,8 +41,9 @@ func (s *Server) registerMemberRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to construct activity payload").SetInternal(err)
 			}
 			activityCreate := &api.ActivityCreate{
-				CreatorID:   c.Get(getPrincipalIDContextKey()).(int),
-				ContainerID: user.ID,
+				CreatorID: c.Get(getPrincipalIDContextKey()).(int),
+				// The container id is 0 because the activity is related to workspace.
+				ContainerID: 0,
 				Type:        api.ActivityMemberCreate,
 				Level:       api.ActivityInfo,
 				Payload:     string(bytes),
@@ -172,8 +173,9 @@ func (s *Server) registerMemberRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to construct activity payload").SetInternal(err)
 				}
 				activityCreate := &api.ActivityCreate{
-					CreatorID:   c.Get(getPrincipalIDContextKey()).(int),
-					ContainerID: user.ID,
+					CreatorID: c.Get(getPrincipalIDContextKey()).(int),
+					// The container id is 0 because the activity is related to workspace.
+					ContainerID: 0,
 					Type:        api.ActivityMemberRoleUpdate,
 					Level:       api.ActivityInfo,
 					Payload:     string(bytes),
@@ -197,8 +199,9 @@ func (s *Server) registerMemberRoutes(g *echo.Group) {
 					theType = api.ActivityMemberDeactivate
 				}
 				activityCreate := &api.ActivityCreate{
-					CreatorID:   c.Get(getPrincipalIDContextKey()).(int),
-					ContainerID: user.ID,
+					CreatorID: c.Get(getPrincipalIDContextKey()).(int),
+					// The container id is 0 because the activity is related to workspace.
+					ContainerID: 0,
 					Type:        theType,
 					Level:       api.ActivityInfo,
 					Payload:     string(bytes),

--- a/backend/store/demo/schema-migration-history/10001##data.sql
+++ b/backend/store/demo/schema-migration-history/10001##data.sql
@@ -158,7 +158,7 @@ Let''s try some simple tasks:
 INSERT INTO "public"."activity" ("id", "row_status", "creator_id", "created_ts", "updater_id", "updated_ts", "container_id", "type", "level", "comment", "payload") VALUES
 (101, 'NORMAL', 1, 1657272778, 1, 1657272778, 101, 'bb.issue.create', 'INFO', '', '{}'),
 (102, 'NORMAL', 1, 1657272778, 1, 1657272778, 101, 'bb.issue.comment.create', 'INFO', 'Go fish!', '{}'),
-(103, 'NORMAL', 101, 1657272815, 101, 1657272815, 101, 'bb.member.create', 'INFO', '', '{"role": "OWNER", "principalId": 101, "memberStatus": "ACTIVE", "principalName": "Demo", "principalEmail": "demo@example.com"}'),
+(103, 'NORMAL', 101, 1657272815, 101, 1657272815, 0, 'bb.member.create', 'INFO', '', '{"role": "OWNER", "principalId": 101, "memberStatus": "ACTIVE", "principalName": "Demo", "principalEmail": "demo@example.com"}'),
 (104, 'NORMAL', 101, 1657272880, 101, 1657272880, 1, 'bb.project.database.transfer', 'INFO', 'Transferred out database "employee" to project "DEMO".', '{"databaseId": 103, "databaseName": "employee"}'),
 (105, 'NORMAL', 101, 1657272880, 101, 1657272880, 101, 'bb.project.database.transfer', 'INFO', 'Transferred in database "employee" from project "Default".', '{"databaseId": 103, "databaseName": "employee"}'),
 (106, 'NORMAL', 101, 1657272890, 101, 1657272890, 102, 'bb.issue.create', 'INFO', '', '{"issueName": "Establish \"employee\" baseline"}'),

--- a/backend/store/migration/dev/20230312000000##checks_activity_container_id_ge_zero.sql
+++ b/backend/store/migration/dev/20230312000000##checks_activity_container_id_ge_zero.sql
@@ -1,0 +1,5 @@
+ALTER TABLE activity DROP CONSTRAINT IF EXISTS activity_container_id_check;
+
+ALTER TABLE activity ADD CONSTRAINT activity_container_id_check CHECK (container_id >= 0);
+
+UPDATE activity SET container_id = 0 WHERE "type" LIKE 'bb.member.%';

--- a/backend/store/migration/dev/LATEST.sql
+++ b/backend/store/migration/dev/LATEST.sql
@@ -764,7 +764,7 @@ CREATE TABLE activity (
     created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
-    container_id INTEGER NOT NULL CHECK (container_id > 0),
+    container_id INTEGER NOT NULL CONSTRAINT activity_container_id_check CHECK (container_id >= 0),
     type TEXT NOT NULL CHECK (type LIKE 'bb.%'),
     level TEXT NOT NULL CHECK (level IN ('INFO', 'WARN', 'ERROR')),
     comment TEXT NOT NULL DEFAULT '',

--- a/backend/store/migration/prod/1.14/0003##checks_activity_container_id_ge_zero.sql
+++ b/backend/store/migration/prod/1.14/0003##checks_activity_container_id_ge_zero.sql
@@ -1,0 +1,5 @@
+ALTER TABLE activity DROP CONSTRAINT IF EXISTS activity_container_id_check;
+
+ALTER TABLE activity ADD CONSTRAINT activity_container_id_check CHECK (container_id >= 0);
+
+UPDATE activity SET container_id = 0 WHERE "type" LIKE 'bb.member.%';

--- a/backend/store/migration/prod/LATEST.sql
+++ b/backend/store/migration/prod/LATEST.sql
@@ -763,7 +763,7 @@ CREATE TABLE activity (
     created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     updater_id INTEGER NOT NULL REFERENCES principal (id),
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
-    container_id INTEGER NOT NULL CHECK (container_id > 0),
+    container_id INTEGER NOT NULL CONSTRAINT activity_container_id_check CHECK (container_id >= 0),
     type TEXT NOT NULL CHECK (type LIKE 'bb.%'),
     level TEXT NOT NULL CHECK (level IN ('INFO', 'WARN', 'ERROR')),
     comment TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
Originally, we wanted to set the `container_id` of activities with the prefix `'bb.member.create'` to the `workspace-id`. However, the problem is that the `workspace-id` was introduced in a certain version (let's assume it's version `x`), which means that if a user **upgrades Bytebase from a version earlier than `x`**, we won't be able to handle the old data because we don't know what the `workspace-id` is at that time. Therefore, we treat activities with `container_id = 0` as belonging to the workspace. Another benefit of doing this is that we don't need to expose/use the `workspace_id` until the concept of multi-workspace is mature enough.