### PR TITLE
feat(audit-log): support list audit logs in a specify time range

### DIFF
--- a/backend/legacyapi/activity.go
+++ b/backend/legacyapi/activity.go
@@ -280,11 +280,13 @@ type ActivityFind struct {
 	ID *int
 
 	// Domain specific fields
-	CreatorID      *int
-	TypePrefixList []string
-	LevelList      []ActivityLevel
-	ContainerID    *int
-	Limit          *int
+	CreatorID       *int
+	TypePrefixList  []string
+	LevelList       []ActivityLevel
+	ContainerID     *int
+	Limit           *int
+	CreatedTsAfter  *int64
+	CreatedTsBefore *int64
 	// If specified, only find activities whose ID is smaller than SinceID.
 	SinceID *int
 	// If specified, sorts the returned list by created_ts in <<ORDER>>

--- a/backend/server/activity.go
+++ b/backend/server/activity.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
@@ -113,6 +114,24 @@ func (s *Server) registerActivityRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusBadRequest, "Query parameter order is invalid").SetInternal(err)
 			}
 			activityFind.Order = &order
+		}
+		if createdTsAfterStr := c.QueryParam("createdTsAfter"); createdTsAfterStr != "" {
+			createdTsAfter, err := strconv.ParseInt(createdTsAfterStr, 10, 64)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "Query parameter createdTsAfter is invalid").SetInternal(err)
+			}
+			// Frontend pass it in milliseconds but we store it in seconds.
+			createdTsAfter = time.UnixMilli(createdTsAfter).Unix()
+			activityFind.CreatedTsAfter = &createdTsAfter
+		}
+		if createdTsBeforeStr := c.QueryParam("createdTsBefore"); createdTsBeforeStr != "" {
+			createdTsBefore, err := strconv.ParseInt(createdTsBeforeStr, 10, 64)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "Query parameter createdTsBefore is invalid").SetInternal(err)
+			}
+			// Frontend pass it in milliseconds but we store it in seconds.
+			createdTsBefore = time.UnixMilli(createdTsBefore).Unix()
+			activityFind.CreatedTsBefore = &createdTsBefore
 		}
 		activityList, err := s.store.FindActivity(ctx, activityFind)
 		if err != nil {

--- a/backend/store/activity.go
+++ b/backend/store/activity.go
@@ -361,6 +361,12 @@ func findActivityImpl(ctx context.Context, tx *Tx, find *api.ActivityFind) ([]*a
 	if v := find.SinceID; v != nil {
 		where, args = append(where, fmt.Sprintf("id <= $%d", len(args)+1)), append(args, *v)
 	}
+	if v := find.CreatedTsAfter; v != nil {
+		where, args = append(where, fmt.Sprintf("created_ts >= $%d", len(args)+1)), append(args, *v)
+	}
+	if v := find.CreatedTsBefore; v != nil {
+		where, args = append(where, fmt.Sprintf("created_ts <= $%d", len(args)+1)), append(args, *v)
+	}
 
 	var query = `
 		SELECT

--- a/frontend/src/types/activity.ts
+++ b/frontend/src/types/activity.ts
@@ -272,4 +272,6 @@ export type ActivityFind = {
   limit?: number;
   level?: string | string[];
   token?: string;
+  createdTsAfter?: number;
+  createdTsBefore?: number;
 };

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -27,6 +27,7 @@
           type="datetimerange"
           size="large"
           :on-confirm="confirmDatePicker"
+          :on-clear="clearDatePicker"
           clearable
         >
         </NDatePicker>
@@ -215,6 +216,17 @@ const confirmDatePicker = (value: [number, number]) => {
       ...route.query,
       createdTsAfter: value[0],
       createdTsBefore: value[1],
+    },
+  });
+};
+
+const clearDatePicker = () => {
+  router.replace({
+    name: "setting.workspace.audit-log",
+    query: {
+      ...route.query,
+      createdTsAfter: 0,
+      createdTsBefore: Date.now(),
     },
   });
 };

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -21,6 +21,16 @@
           @update-selected-type-list="selectAuditType"
         />
       </div>
+      <div class="w-112 ml-2">
+        <NDatePicker
+          v-model:value="selectedTimeRange"
+          type="datetimerange"
+          size="large"
+          :on-confirm="confirmDatePicker"
+          clearable
+        >
+        </NDatePicker>
+      </div>
     </div>
     <PagedAuditLogTable
       v-if="hasAuditLogFeature"
@@ -31,6 +41,8 @@
             : typePrefixList,
         user: selectedPrincipalId > 0 ? selectedPrincipalId : undefined,
         order: 'DESC',
+        createdTsAfter: selectedTimeRange ? selectedTimeRange[0] : undefined,
+        createdTsBefore: selectedTimeRange ? selectedTimeRange[1] : undefined,
       }"
       session-key="settings-audit-log-table"
       :page-size="10"
@@ -92,7 +104,7 @@
 <script lang="ts" setup>
 import { reactive, ref, computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { NGrid, NGi } from "naive-ui";
+import { NGrid, NGi, NDatePicker } from "naive-ui";
 import { useI18n } from "vue-i18n";
 import { BBDialog } from "@/bbkit";
 import { AuditActivityType, PrincipalId, EMPTY_ID } from "@/types";
@@ -143,6 +155,19 @@ const selectedAuditTypeList = computed((): AuditActivityType[] => {
   return [];
 });
 
+const selectedTimeRange = computed((): [number, number] => {
+  const defaultTimeRange = [0, Date.now()] as [number, number];
+  const createdTsAfter = route.query.createdTsAfter as string;
+  if (createdTsAfter) {
+    defaultTimeRange[0] = parseInt(createdTsAfter, 10);
+  }
+  const createdTsBefore = route.query.createdTsBefore as string;
+  if (createdTsBefore) {
+    defaultTimeRange[1] = parseInt(createdTsBefore, 10);
+  }
+  return defaultTimeRange;
+});
+
 const handleViewDetail = (log: any) => {
   // Display detail fields in the same order as logKeyMap.
   state.modalContent = Object.fromEntries(
@@ -181,5 +206,16 @@ const selectAuditType = (typeList: AuditActivityType[]) => {
       },
     });
   }
+};
+
+const confirmDatePicker = (value: [number, number]) => {
+  router.replace({
+    name: "setting.workspace.audit-log",
+    query: {
+      ...route.query,
+      createdTsAfter: value[0],
+      createdTsBefore: value[1],
+    },
+  });
 };
 </script>


### PR DESCRIPTION
This pull request adds a new feature to the audit logging functionality, allowing users to list audit logs within a specified time range. With this new feature, users can easily filter audit logs by specifying a start and end time, which makes it much easier to find and review relevant audit logs.

To achieve this, we have accepted a start and end time as query parameters and returned a list of audit logs that fall within the specified time range. Additionally, we have updated the UI to allow users to enter a start and end time when viewing the audit log by using [Naive UI date picker](https://www.naiveui.com/en-US/os-theme/components/date-picker#DatePicker-Slots).

Overall, this feature adds a new level of flexibility to the audit logging functionality, making it more useful for our users.

### Screenshots
#### All activities
<img width="2494" alt="CleanShot 2023-03-14 at 15 10 39@2x" src="https://user-images.githubusercontent.com/87714218/224923086-c6e92889-3943-4545-853e-1544faeb6ace.png">

#### Filtered by time range
<img width="2492" alt="CleanShot 2023-03-14 at 15 10 49@2x" src="https://user-images.githubusercontent.com/87714218/224923136-e33f092a-f181-4730-828a-5e124706105e.png">
