### PR TITLE
fix(mysql): using lower case for database name if the lower case table name is 1

### DIFF
--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -1088,7 +1088,6 @@ func (s *Server) createDatabaseCreateTaskList(ctx context.Context, c api.CreateD
 	if adminDataSource == nil {
 		return nil, common.Errorf(common.Internal, "admin data source not found for instance %q", instance.Title)
 	}
-	// Snowflake needs to use upper case of DatabaseName.
 	databaseName := c.DatabaseName
 	switch instance.Engine {
 	case db.Snowflake:


### PR DESCRIPTION
For MySQL, how table and database names are stored on disk and used in MySQL is affected by the [lower_case_table_names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) system variable.
We should use the lowercase if we find that the value of `lower_case_table_names` is `1`. Otherwise, we cannot find the database we create because we depend on the database name in the create database task.