### PR TITLE
chore(frontend): display OpenAI API key as sk-***

### DIFF
--- a/frontend/src/components/GeneralSetting/AIAugmentationSetting.vue
+++ b/frontend/src/components/GeneralSetting/AIAugmentationSetting.vue
@@ -109,7 +109,7 @@ const state = reactive<LocalState>({
 const openAIKeySetting = useSettingByName("bb.plugin.openai.key");
 
 watchEffect(() => {
-  state.openAIKey = openAIKeySetting.value?.value ?? "";
+  state.openAIKey = openAIKeySetting.value?.value ? "sk-******" : "";
 });
 
 const allowEdit = computed((): boolean => {


### PR DESCRIPTION
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/2749742/225816815-e155bab0-6345-449f-9524-34d1ec629374.png">
Close BYT-2807

WARNING: this only hides the UI display. Developers still can analyze the API key from devtools.
FYI @Candybase 