### PR TITLE
fix(oauth): correctly handle access token refresh

### DIFF
--- a/backend/plugin/vcs/bitbucket/bitbucket.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket.go
@@ -987,10 +987,10 @@ func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthConte
 
 // oauthContext is the request context for refreshing OAuth token.
 type oauthContext struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	RefreshToken string `json:"refresh_token"`
-	GrantType    string `json:"grant_type"`
+	ClientID     string
+	ClientSecret string
+	RefreshToken string
+	GrantType    string
 }
 
 type refreshOAuthResponse struct {
@@ -1002,11 +1002,12 @@ type refreshOAuthResponse struct {
 
 func tokenRefresher(instanceURL string, oauthCtx oauthContext, refresher common.TokenRefresher) oauth.TokenRefresher {
 	return func(ctx context.Context, client *http.Client, oldToken *string) error {
-		form := &url.Values{}
-		form.Set("grant_type", "refresh_token")
-		form.Set("refresh_token", oauthCtx.RefreshToken)
+		params := &url.Values{}
+		params.Set("grant_type", "refresh_token")
+		params.Set("refresh_token", oauthCtx.RefreshToken)
+
 		url := fmt.Sprintf("%s/site/oauth2/access_token", instanceURL)
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(form.Encode()))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(params.Encode()))
 		if err != nil {
 			return errors.Wrapf(err, "construct POST %s", url)
 		}

--- a/backend/plugin/vcs/bitbucket/bitbucket_test.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket_test.go
@@ -877,7 +877,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusUnauthorized,
 						Body: io.NopCloser(strings.NewReader(`
-					{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
+					{"error":"invalid_grant","error_description":"The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."}
 					`)),
 					}, nil
 				}

--- a/backend/plugin/vcs/bitbucket/bitbucket_test.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket_test.go
@@ -877,7 +877,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusUnauthorized,
 						Body: io.NopCloser(strings.NewReader(`
-					{"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}
+					{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
 					`)),
 					}, nil
 				}

--- a/backend/plugin/vcs/github/github.go
+++ b/backend/plugin/vcs/github/github.go
@@ -1333,10 +1333,10 @@ func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthConte
 
 // oauthContext is the request context for refreshing oauth token.
 type oauthContext struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	RefreshToken string `json:"refresh_token"`
-	GrantType    string `json:"grant_type"`
+	ClientID     string
+	ClientSecret string
+	RefreshToken string
+	GrantType    string
 }
 
 type refreshOAuthResponse struct {
@@ -1349,25 +1349,25 @@ type refreshOAuthResponse struct {
 
 func tokenRefresher(instanceURL string, oauthCtx oauthContext, refresher common.TokenRefresher) oauth.TokenRefresher {
 	return func(ctx context.Context, client *http.Client, oldToken *string) error {
-		url := fmt.Sprintf("%s/login/oauth/access_token", instanceURL)
-		oauthCtx.GrantType = "refresh_token"
-		body, err := json.Marshal(oauthCtx)
-		if err != nil {
-			return err
-		}
+		params := &url.Values{}
+		params.Set("client_id", oauthCtx.ClientID)
+		params.Set("client_secret", oauthCtx.ClientSecret)
+		params.Set("refresh_token", oauthCtx.RefreshToken)
+		params.Set("grant_type", "refresh_token")
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		url := fmt.Sprintf("%s/login/oauth/access_token", instanceURL)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(params.Encode()))
 		if err != nil {
 			return errors.Wrapf(err, "construct POST %s", url)
 		}
 
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		resp, err := client.Do(req)
 		if err != nil {
 			return errors.Wrapf(err, "POST %s", url)
 		}
 
-		body, err = io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrapf(err, "read body of POST %s", url)
 		}

--- a/backend/plugin/vcs/github/github_test.go
+++ b/backend/plugin/vcs/github/github_test.go
@@ -732,7 +732,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusBadRequest,
 						Body: io.NopCloser(strings.NewReader(`
-					{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
+					{"error":"invalid_grant","error_description":"The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."}
 					`)),
 					}, nil
 				}

--- a/backend/plugin/vcs/github/github_test.go
+++ b/backend/plugin/vcs/github/github_test.go
@@ -732,7 +732,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusBadRequest,
 						Body: io.NopCloser(strings.NewReader(`
-					{"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}
+					{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
 					`)),
 					}, nil
 				}

--- a/backend/plugin/vcs/gitlab/gitlab_test.go
+++ b/backend/plugin/vcs/gitlab/gitlab_test.go
@@ -428,7 +428,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusBadRequest,
 						Body: io.NopCloser(strings.NewReader(`
-					{"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}
+					{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
 					`)),
 					}, nil
 				}

--- a/backend/plugin/vcs/gitlab/gitlab_test.go
+++ b/backend/plugin/vcs/gitlab/gitlab_test.go
@@ -428,7 +428,7 @@ func TestOAuth_RefreshToken(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusBadRequest,
 						Body: io.NopCloser(strings.NewReader(`
-					{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
+					{"error":"invalid_grant","error_description":"The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."}
 					`)),
 					}, nil
 				}

--- a/backend/server/oauth.go
+++ b/backend/server/oauth.go
@@ -81,7 +81,10 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 				oauthExchange,
 			)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, oauthErrorMessage(setting.ExternalUrl)).SetInternal(err)
+			return echo.NewHTTPError(
+				http.StatusInternalServerError,
+				fmt.Sprintf("Failed to exchange OAuth token. Make sure %q matches your browser host. Note that if you are not using port 80 or 443, you should also specify the port such as --external-url=http://host:port", setting.ExternalUrl),
+			).SetInternal(err)
 		}
 
 		resp := &api.OAuthToken{

--- a/backend/server/oauth.go
+++ b/backend/server/oauth.go
@@ -73,7 +73,7 @@ func (s *Server) registerOAuthRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find workspace setting").SetInternal(err)
 		}
 
-		oauthExchange.RedirectURL = fmt.Sprintf("%s/oauth/callback", oauthRedirectURL(setting.ExternalUrl))
+		oauthExchange.RedirectURL = fmt.Sprintf("%s/oauth/callback", setting.ExternalUrl)
 		oauthToken, err := vcsPlugin.Get(vcsType, vcsPlugin.ProviderConfig{}).
 			ExchangeOAuthToken(
 				c.Request().Context(),

--- a/backend/server/server_frontend_embed.go
+++ b/backend/server/server_frontend_embed.go
@@ -5,14 +5,11 @@ package server
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-
-	"github.com/bytebase/bytebase/backend/common"
 )
 
 //go:embed dist/assets/*
@@ -49,15 +46,4 @@ func embedFrontend(e *echo.Echo) {
 		HTML5:      true,
 		Filesystem: getFileSystem("dist/assets"),
 	}))
-}
-
-func oauthRedirectURL(externalURL string) string {
-	return externalURL
-}
-
-func oauthErrorMessage(externalURL string) string {
-	if externalURL == "" {
-		return fmt.Sprintf("Failed to exchange OAuth token. You have not configured --external-url, please follow %s", common.ExternalURLPlaceholder)
-	}
-	return fmt.Sprintf("Failed to exchange OAuth token. Make sure --external-url %s matches your browser host. Note that if you are not using port 80 or 443, you should also specify the port such as --external-url=http://host:port", externalURL)
 }

--- a/backend/server/server_frontend_not_embed.go
+++ b/backend/server/server_frontend_not_embed.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -18,8 +17,4 @@ func embedFrontend(e *echo.Echo) {
 	e.GET("/*", func(c echo.Context) error {
 		return c.HTML(http.StatusOK, "This Bytebase build does not bundle frontend and backend together.")
 	})
-}
-
-func oauthErrorMessage(externalURL string) string {
-	return fmt.Sprintf("Failed to exchange OAuth token. Make sure %q matches your browser host. Note that if you are not using port 80 or 443, you should also specify the port such as --external-url=http://host:port", externalURL)
 }

--- a/backend/server/server_frontend_not_embed.go
+++ b/backend/server/server_frontend_not_embed.go
@@ -6,7 +6,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/labstack/echo/v4"
 
@@ -21,16 +20,6 @@ func embedFrontend(e *echo.Echo) {
 	})
 }
 
-// In non embedded mode, the redirect URL is the frontend URL which is different
-// from the external URL. By default, this frontend URL is http://localhost:3000
-func oauthRedirectURL(_ string) string {
-	url := os.Getenv("BB_REDIRECT_URL")
-	if url != "" {
-		return url
-	}
-	return "http://localhost:3000"
-}
-
 func oauthErrorMessage(externalURL string) string {
-	return fmt.Sprintf("Failed to exchange OAuth token. Make sure BB_REDIRECT_URL: %s matches your browser host. Note that if you are not using port 80 or 443, you should also specify the port such as --external-url=http://host:port", externalURL)
+	return fmt.Sprintf("Failed to exchange OAuth token. Make sure %q matches your browser host. Note that if you are not using port 80 or 443, you should also specify the port such as --external-url=http://host:port", externalURL)
 }


### PR DESCRIPTION
This PR fixes various problems related to OAuth:

1. Fixed a place where we pass `nil` as the token refresher, it panics when the access token is expired.
2. Use the correct format (POST form) for token refresh requests instead of JSON.
3. Remove `BB_REDIRECT_URL`, it is no longer relevant with the use of [pgrok](https://github.com/pgrok/pgrok).

---

Close https://linear.app/bytebase/issue/BYT-2809/gitops-oauth-does-not-refresh-on-token-expire