### PR TITLE
fix(parser): handle the case where there are no backquotes on both sides of the object name

### DIFF
--- a/backend/plugin/parser/differ/mysql/differ_test.go
+++ b/backend/plugin/parser/differ/mysql/differ_test.go
@@ -13,6 +13,11 @@ func TestExtractUnsupportObjNameAndType(t *testing.T) {
 		wantName string
 	}{
 		{
+			stmt:     "CREATE DEFINER=`root`@`%` TRIGGER xcytestT \t\nBEFORE \n INSERT ON xcytest FOR EACH ROW\n BEGIN\n\tSET new.code=REPLACE(UUID(), '-', ''); \nEND ;;",
+			wantTp:   trigger,
+			wantName: "xcytestT",
+		},
+		{
 			stmt:     "CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON `account` FOR EACH SET @sum=@sum + NEW.price;;",
 			wantTp:   trigger,
 			wantName: "ins_sum",

--- a/backend/plugin/parser/differ/mysql/utils.go
+++ b/backend/plugin/parser/differ/mysql/utils.go
@@ -27,8 +27,9 @@ func extractUnsupportObjNameAndType(stmt string) (string, objectType, error) {
 		function,
 		procedure,
 	}
-	regexFmt := "(?i)^CREATE\\s+(DEFINER=`(.)+`@`(.)+`(\\s)+)?%s\\s+(?P<OBJECT_NAME>%s)(\\s)*\\("
-	namingRegex := "`[^\\\\/?%*:|\\\"`<>]+`"
+	regexFmt := "(?mUi)^CREATE\\s+(DEFINER=(`(.)+`|(.)+)@(`(.)+`|(.)+)(\\s)+)?%s\\s+(?P<OBJECT_NAME>%s)(\\s)*\\("
+	// We should support the naming likes "`abc`" or "abc".
+	namingRegex := fmt.Sprintf("(`%s`)|(%s)", "[^\\\\/?%*:|\\\"`<>]+", "[^\\\\/?%*:|\\\"`<>]+")
 	for _, obj := range fs {
 		regex := fmt.Sprintf(regexFmt, string(obj), namingRegex)
 		re := regexp.MustCompile(regex)
@@ -43,7 +44,7 @@ func extractUnsupportObjNameAndType(stmt string) (string, objectType, error) {
 		trigger,
 		event,
 	}
-	regexFmt = "(?i)^CREATE\\s+(DEFINER=`(.)+`@`(.)+`(\\s)+)?%s\\s+(?P<OBJECT_NAME>%s)(\\s)+"
+	regexFmt = "(?mUi)^CREATE\\s+(DEFINER=(`(.)+`|(.)+)@(`(.)+`|(.)+)(\\s)+)?%s\\s+(?P<OBJECT_NAME>%s)(\\s)+"
 	for _, obj := range objects {
 		regex := fmt.Sprintf(regexFmt, string(obj), namingRegex)
 		re := regexp.MustCompile(regex)

--- a/backend/plugin/parser/utils.go
+++ b/backend/plugin/parser/utils.go
@@ -164,7 +164,7 @@ func IsTiDBUnsupportDDLStmt(stmt string) bool {
 		"FUNCTION",
 		"PROCEDURE",
 	}
-	createRegexFmt := "(?i)^\\s*CREATE\\s+(DEFINER=`(.)+`@`(.)+`(\\s)+)?%s\\s+"
+	createRegexFmt := "(?i)^\\s*CREATE\\s+(DEFINER=(`(.)+`|(.)+)@(`(.)+`|(.)+)(\\s)+)?%s\\s+"
 	dropRegexFmt := "(?i)^\\s*DROP\\s+%s\\s+"
 	for _, obj := range objects {
 		createRegexp := fmt.Sprintf(createRegexFmt, obj)

--- a/backend/plugin/parser/utils_test.go
+++ b/backend/plugin/parser/utils_test.go
@@ -94,6 +94,11 @@ func TestIsTiDBUnsupportStmt(t *testing.T) {
 			want: true,
 		},
 		{
+			stmt: "CREATE DEFINER=root@%% FUNCTION `hello`(s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC\n" +
+				"RETURN CONCAT('Hello, ',s,'!');",
+			want: true,
+		},
+		{
 			stmt: "create function `hello` (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC\n" +
 				"RETURN CONCAT('Hello, ',s,'!');",
 			want: true,
@@ -104,7 +109,8 @@ func TestIsTiDBUnsupportStmt(t *testing.T) {
 				"	INSERT INTO message(message, created_at)\n" +
 				"	VALUES('test event', NOW());",
 			want: true,
-		}, {
+		},
+		{
 			stmt: "create event `test_event_01` ON SCHEDULE AT CURRENT_TIMESTAMP \n" +
 				"DO\n" +
 				"	INSERT INTO message(message, created_at)\n" +


### PR DESCRIPTION
Previously, we assume that `mysqldump` gives us the trigger statement likes
``` SQL 
CREATE DEFINER=`root`@`%` TRIGGER `tri` ...
```
But recently, we found that the mysqldump may trim the backquotes on both sides of the object name, a MySQL Server  version known to be affected is `5.7.20-log`. I haven't tried reproducing it yet, but I think this PR can handle the situation properly.