### PR TITLE
feat(oracle): support Oracle rollback DML

### DIFF
--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -193,6 +193,9 @@ type TaskDatabaseDataUpdatePayload struct {
 	RollbackEnabled bool `json:"rollbackEnabled,omitempty"`
 	// RollbackSQLStatus is the status of the rollback generation.
 	RollbackSQLStatus RollbackSQLStatus `json:"rollbackSqlStatus,omitempty"`
+	// TransactionID is the ID of the transaction executing the migration.
+	// It is only use for Oracle to find Rollback SQL statement now.
+	TransactionID string `json:"transactionId,omitempty"`
 	// ThreadID is the ID of the connection executing the migration.
 	// We use it to filter the binlog events of the migration transaction.
 	ThreadID string `json:"threadId,omitempty"`

--- a/backend/plugin/db/oracle/migrate.go
+++ b/backend/plugin/db/oracle/migrate.go
@@ -28,9 +28,11 @@ func (d *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, stat
 	return d.ExecuteMigrationWithBeforeCommitTxFunc(ctx, m, statement, nil)
 }
 
-// ExecuteMigration executes a migration.
-// ExecuteMigration will execute the database migration.
-// Returns the created migration history id and the updated schema on success.
+// ExecuteMigrationWithBeforeCommitTxFunc executes the migration, `beforeCommitTxFunc` will be called before transaction commit and after executing `statement`.
+//
+// Callers can use `beforeCommitTx` to do some extra work before transaction commit, like get the transaction id.
+//
+// Any error returned by `beforeCommitTx` will rollback the transaction, so it is the callers' responsibility to return nil if the error occurs in `beforeCommitTx` is not fatal.
 func (d *Driver) ExecuteMigrationWithBeforeCommitTxFunc(ctx context.Context, m *db.MigrationInfo, statement string, beforeCommitTxFunc func(tx *sql.Tx) error) (migrationHistoryID string, updatedSchema string, resErr error) {
 	if m.CreateDatabase {
 		return "", "", errors.New("creating databases is not supported")

--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -29,6 +29,8 @@ func init() {
 // Driver is the Oracle driver.
 type Driver struct {
 	db *sql.DB
+	// If executeBeforeCommitTxFunc is not nil, it will be called before transaction commit in Execute().
+	executeBeforeCommitTxFunc func(tx *sql.Tx) error
 }
 
 func newDriver(db.DriverConfig) db.Driver {
@@ -75,15 +77,31 @@ func (driver *Driver) GetDBConnection(_ context.Context, _ string) (*sql.DB, err
 }
 
 // Execute executes a SQL statement and returns the affected rows.
-func (driver *Driver) Execute(ctx context.Context, statement string, _ bool) (int64, error) {
-	totalRowsAffected := int64(0)
-	tx, err := driver.db.BeginTx(ctx, nil)
+func (driver *Driver) Execute(ctx context.Context, statement string, createDatabase bool) (int64, error) {
+	return driver.executeWithBeforeCommitTxFunc(ctx, statement, createDatabase, nil)
+}
+
+// ExecuteWithBeforeCommitTxFunc executes the SQL statements and returns the effected rows, `beforeCommitTx` will be called before transaction commit and after executing `statement`.
+//
+// Callers can use `beforeCommitTx` to do some extra work before transaction commit, like get the transaction id.
+//
+// Any error returned by `beforeCommitTx` will rollback the transaction, so it is the callers' responsibility to return nil if the error occurs in `beforeCommitTx` is not fatal.
+func (driver *Driver) executeWithBeforeCommitTxFunc(ctx context.Context, statement string, _ bool, beforeCommitTx func(tx *sql.Tx) error) (int64, error) {
+	conn, err := driver.db.Conn(ctx)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrapf(err, "failed to get connection")
+	}
+	defer conn.Close()
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to begin transaction")
 	}
 	defer tx.Rollback()
 
+	totalRowsAffected := int64(0)
 	f := func(stmt string) error {
+		// The underlying oracle golang driver go-ora does not support semicolon, so we should trim the suffix semicolon.
+		stmt = strings.TrimSuffix(stmt, ";")
 		sqlResult, err := tx.ExecContext(ctx, stmt)
 		if err != nil {
 			return err
@@ -102,8 +120,14 @@ func (driver *Driver) Execute(ctx context.Context, statement string, _ bool) (in
 		return 0, err
 	}
 
+	if beforeCommitTx != nil {
+		if err := beforeCommitTx(tx); err != nil {
+			return 0, errors.Wrapf(err, "failed to execute beforeCommitTx")
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
-		return 0, err
+		return 0, errors.Wrapf(err, "failed to commit transaction")
 	}
 	return totalRowsAffected, nil
 }

--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -29,8 +29,6 @@ func init() {
 // Driver is the Oracle driver.
 type Driver struct {
 	db *sql.DB
-	// If executeBeforeCommitTxFunc is not nil, it will be called before transaction commit in Execute().
-	executeBeforeCommitTxFunc func(tx *sql.Tx) error
 }
 
 func newDriver(db.DriverConfig) db.Driver {

--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -79,7 +79,7 @@ func (driver *Driver) Execute(ctx context.Context, statement string, createDatab
 	return driver.executeWithBeforeCommitTxFunc(ctx, statement, createDatabase, nil)
 }
 
-// ExecuteWithBeforeCommitTxFunc executes the SQL statements and returns the effected rows, `beforeCommitTx` will be called before transaction commit and after executing `statement`.
+// executeWithBeforeCommitTxFunc executes the SQL statements and returns the effected rows, `beforeCommitTx` will be called before transaction commit and after executing `statement`.
 //
 // Callers can use `beforeCommitTx` to do some extra work before transaction commit, like get the transaction id.
 //

--- a/backend/runner/rollbackrun/runner.go
+++ b/backend/runner/rollbackrun/runner.go
@@ -2,7 +2,9 @@
 package rollbackrun
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -68,7 +70,7 @@ func (r *Runner) retryGenerateRollbackSQL(ctx context.Context) {
 	find := &api.TaskFind{
 		StatusList: &[]api.TaskStatus{api.TaskDone},
 		TypeList:   &[]api.TaskType{api.TaskDatabaseDataUpdate},
-		Payload:    "(task.payload->>'rollbackEnabled')::BOOLEAN IS TRUE AND task.payload->>'threadID'!='' AND task.payload->>'rollbackSqlStatus'='PENDING'",
+		Payload:    "(task.payload->>'rollbackEnabled')::BOOLEAN IS TRUE AND (task.payload->>'threadId'!='' OR task.payload->>'transactionId' != '') AND task.payload->>'rollbackSqlStatus'='PENDING'",
 	}
 	taskList, err := r.store.ListTasks(ctx, find)
 	if err != nil {
@@ -97,12 +99,94 @@ func (r *Runner) generateRollbackSQL(ctx context.Context, task *store.TaskMessag
 		log.Error("Invalid database data update payload", zap.Error(err))
 		return
 	}
+	instance, err := r.store.GetInstanceV2(ctx, &store.FindInstanceMessage{UID: &task.InstanceID})
+	if err != nil {
+		log.Error("Failed to find instance", zap.Error(err))
+		return
+	}
+	switch instance.Engine {
+	case db.MySQL:
+		r.generateMySQLRollbackSQL(ctx, task, payload, instance)
+	case db.Oracle:
+		r.generateOracleRollbackSQL(ctx, task, payload, instance)
+	}
 
+}
+
+func (r *Runner) generateOracleRollbackSQL(ctx context.Context, task *store.TaskMessage, payload *api.TaskDatabaseDataUpdatePayload, instance *store.InstanceMessage) {
+	var rollbackSQLStatus api.RollbackSQLStatus
+	var rollbackStatement, rollbackError string
+
+	statementsBuffer, err := r.generateOracleRollbackSQLImpl(ctx, payload, instance)
+	if err != nil {
+		log.Error("Failed to generate rollback SQL statement", zap.Error(err))
+		rollbackSQLStatus = api.RollbackSQLStatusFailed
+		rollbackError = err.Error()
+	} else {
+		rollbackSQLStatus = api.RollbackSQLStatusDone
+		rollbackStatement = statementsBuffer.String()
+	}
+
+	patch := &api.TaskPatch{
+		ID:                task.ID,
+		UpdaterID:         api.SystemBotID,
+		RollbackSQLStatus: &rollbackSQLStatus,
+		RollbackStatement: &rollbackStatement,
+		RollbackError:     &rollbackError,
+	}
+	if _, err := r.store.UpdateTaskV2(ctx, patch); err != nil {
+		log.Error("Failed to patch task with the Oracle payload", zap.Int("taskID", task.ID))
+		return
+	}
+	log.Debug("Rollback SQL generation success", zap.Int("taskID", task.ID))
+}
+
+func (r *Runner) generateOracleRollbackSQLImpl(ctx context.Context, payload *api.TaskDatabaseDataUpdatePayload, instance *store.InstanceMessage) (*bytes.Buffer, error) {
+	if payload.TransactionID == "" {
+		return nil, errors.New("missing transaction ID, may be there is no data change in the transaction")
+	}
+	driver, err := r.dbFactory.GetAdminDatabaseDriver(ctx, instance, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get admin database driver")
+	}
+	defer driver.Close(ctx)
+
+	db, err := driver.GetDBConnection(ctx, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get database connection")
+	}
+
+	// Get the undo SQL from the undo log.
+	var statements bytes.Buffer
+	undoSQLs, err := db.QueryContext(ctx, "SELECT undo_sql FROM flashback_transaction_query WHERE xid=HEXTORAW(:1)", payload.TransactionID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query undo SQL")
+	}
+	var undoSQL sql.NullString
+	for undoSQLs.Next() {
+		err := undoSQLs.Scan(&undoSQL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to scan undo SQL")
+		}
+		if !undoSQL.Valid {
+			continue
+		}
+		if _, err := statements.WriteString(undoSQL.String); err != nil {
+			return nil, errors.Wrapf(err, "failed to write undo SQL to buffer")
+		}
+	}
+	if err := undoSQLs.Err(); err != nil {
+		return nil, errors.Wrapf(err, "failed to iterate undo SQL")
+	}
+	return &statements, nil
+}
+
+func (r *Runner) generateMySQLRollbackSQL(ctx context.Context, task *store.TaskMessage, payload *api.TaskDatabaseDataUpdatePayload, instance *store.InstanceMessage) {
 	var rollbackSQLStatus api.RollbackSQLStatus
 	var rollbackStatement, rollbackError string
 
 	const binlogSizeLimit = 8 * 1024 * 1024
-	rollbackSQL, err := r.generateRollbackSQLImpl(ctx, task, payload, binlogSizeLimit)
+	rollbackSQL, err := r.generateMySQLRollbackSQLImpl(ctx, payload, binlogSizeLimit, instance)
 	if err != nil {
 		log.Error("Failed to generate rollback SQL statement", zap.Error(err))
 		rollbackSQLStatus = api.RollbackSQLStatusFailed
@@ -132,13 +216,9 @@ func (r *Runner) generateRollbackSQL(ctx context.Context, task *store.TaskMessag
 	log.Debug("Rollback SQL generation success", zap.Int("taskID", task.ID))
 }
 
-func (r *Runner) generateRollbackSQLImpl(ctx context.Context, task *store.TaskMessage, payload *api.TaskDatabaseDataUpdatePayload, binlogSizeLimit int) (string, error) {
+func (r *Runner) generateMySQLRollbackSQLImpl(ctx context.Context, payload *api.TaskDatabaseDataUpdatePayload, binlogSizeLimit int, instance *store.InstanceMessage) (string, error) {
 	if ctx.Err() != nil {
 		return "", ctx.Err()
-	}
-	instance, err := r.store.GetInstanceV2(ctx, &store.FindInstanceMessage{UID: &task.InstanceID})
-	if err != nil {
-		return "", err
 	}
 	// We cannot support rollback SQL generation for sheets because it can take lots of resources.
 	if payload.SheetID > 0 {

--- a/backend/runner/taskrun/database_create_executor.go
+++ b/backend/runner/taskrun/database_create_executor.go
@@ -202,7 +202,7 @@ func (exec *DatabaseCreateExecutor) RunOnce(ctx context.Context, task *store.Tas
 
 	mi.DatabaseID = &database.UID
 
-	migrationID, _, err := utils.ExecuteMigration(ctx, exec.store, driver, mi, statement)
+	migrationID, _, err := utils.ExecuteMigration(ctx, exec.store, driver, mi, statement, nil /* executeBeforeCommitTx */)
 	if err != nil {
 		return true, nil, err
 	}

--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -194,6 +194,7 @@ func executeMigration(ctx context.Context, stores *store.Store, dbFactory *dbfac
 			// The runner will periodically scan the map to generate rollback SQL asynchronously.
 			stateCfg.RollbackGenerate.Store(task.ID, updatedTask)
 		}
+		return migrationID, schema, nil
 	}
 
 	migrationID, schema, err = utils.ExecuteMigration(ctx, stores, driver, mi, statement, nil /* executeBeforeCommitTx */)

--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -2,6 +2,7 @@ package taskrun
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -177,8 +178,25 @@ func executeMigration(ctx context.Context, stores *store.Store, dbFactory *dbfac
 		}
 		task = updatedTask
 	}
+	// If the migration is a data migration, enable the rollback SQL generation and the type of the driver is Oracle, we need to get the rollback SQL before the transaction is committed.
+	if task.Type == api.TaskDatabaseDataUpdate && instance.Engine == db.Oracle {
+		migrationID, schema, err = utils.ExecuteMigration(ctx, stores, driver, mi, statement, getSetOracleTransactionIDFunc(ctx, task, stores))
+		// getSetOracleTransactionIdFunc will update the task payload to set the Oracle transaction id, we need to re-retrieve the task to store to the RollbackGenerate.
+		updatedTask, err := stores.GetTaskV2ByID(ctx, task.ID)
+		if err != nil {
+			return "", "", errors.Wrapf(err, "cannot get task by id %d", task.ID)
+		}
+		payload := &api.TaskDatabaseDataUpdatePayload{}
+		if err := json.Unmarshal([]byte(updatedTask.Payload), payload); err != nil {
+			return "", "", errors.Wrap(err, "invalid database data update payload")
+		}
+		if payload.RollbackEnabled {
+			// The runner will periodically scan the map to generate rollback SQL asynchronously.
+			stateCfg.RollbackGenerate.Store(task.ID, updatedTask)
+		}
+	}
 
-	migrationID, schema, err = utils.ExecuteMigration(ctx, stores, driver, mi, statement)
+	migrationID, schema, err = utils.ExecuteMigration(ctx, stores, driver, mi, statement, nil /* executeBeforeCommitTx */)
 	if err != nil {
 		return "", "", err
 	}
@@ -200,6 +218,48 @@ func executeMigration(ctx context.Context, stores *store.Store, dbFactory *dbfac
 	}
 
 	return migrationID, schema, nil
+}
+
+func getSetOracleTransactionIDFunc(ctx context.Context, task *store.TaskMessage, store *store.Store) func(tx *sql.Tx) error {
+	return func(tx *sql.Tx) error {
+		payload := &api.TaskDatabaseDataUpdatePayload{}
+		if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
+			log.Error("failed to unmarshal task payload", zap.Int("TaskId", task.ID), zap.Error(err))
+			return nil
+		}
+		// Get oracle current transaction id;
+		transactionID, err := tx.QueryContext(ctx, "SELECT RAWTOHEX(tx.xid) FROM v$transaction tx JOIN v$session s ON tx.ses_addr = s.saddr")
+		if err != nil {
+			log.Error("failed to transaction id in task", zap.Int("TaskId", task.ID), zap.Error(err))
+			return nil
+		}
+		defer transactionID.Close()
+		var txID string
+		for transactionID.Next() {
+			err := transactionID.Scan(&txID)
+			if err != nil {
+				log.Error("failed to the Oracle transaction id in task", zap.Int("TaskId", task.ID), zap.Error(err))
+				return nil
+			}
+		}
+		payload.TransactionID = txID
+		updatedPayload, err := json.Marshal(payload)
+		if err != nil {
+			log.Error("failed to unmarshal task payload", zap.Int("TaskId", task.ID), zap.Error(err), zap.Any("payload", updatedPayload))
+			return nil
+		}
+		updatedPayloadString := string(updatedPayload)
+		patch := &api.TaskPatch{
+			ID:        task.ID,
+			UpdaterID: api.SystemBotID,
+			Payload:   &updatedPayloadString,
+		}
+		if _, err = store.UpdateTaskV2(ctx, patch); err != nil {
+			log.Error("failed to update task with new payload", zap.Any("TaskPatch", patch), zap.Error(err))
+			return nil
+		}
+		return nil
+	}
 }
 
 func setThreadIDAndStartBinlogCoordinate(ctx context.Context, driver db.Driver, task *store.TaskMessage, store *store.Store) (*store.TaskMessage, error) {

--- a/backend/runner/taskrun/pitr_cutover_executor.go
+++ b/backend/runner/taskrun/pitr_cutover_executor.go
@@ -155,7 +155,7 @@ func (exec *PITRCutoverExecutor) pitrCutover(ctx context.Context, dbFactory *dbf
 		IssueID:        strconv.Itoa(issue.UID),
 	}
 
-	if _, _, err := utils.ExecuteMigration(ctx, exec.store, driver, m, "/* pitr cutover */"); err != nil {
+	if _, _, err := utils.ExecuteMigration(ctx, exec.store, driver, m, "/* pitr cutover */", nil /* executeBeforeCommitTx */); err != nil {
 		log.Error("Failed to add migration history record", zap.Error(err))
 		return true, nil, errors.Wrap(err, "failed to add migration history record")
 	}

--- a/backend/runner/taskrun/pitr_restore_executor.go
+++ b/backend/runner/taskrun/pitr_restore_executor.go
@@ -552,7 +552,7 @@ func createBranchMigrationHistory(ctx context.Context, stores *store.Store, dbFa
 		return "", "", err
 	}
 	defer targetDriver.Close(ctx)
-	migrationID, _, err := utils.ExecuteMigration(ctx, stores, targetDriver, m, "")
+	migrationID, _, err := utils.ExecuteMigration(ctx, stores, targetDriver, m, "", nil /* executeBeforeCommitTx */)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to create migration history")
 	}

--- a/frontend/src/components/Issue/rollback/common.ts
+++ b/frontend/src/components/Issue/rollback/common.ts
@@ -58,12 +58,20 @@ export const useRollbackLogic = () => {
     }
     const database = databaseOfTask(task.value);
     const { engine, engineVersion } = database.instance;
-    if (engine !== "MYSQL") {
-      return "NONE";
+    switch (engine) {
+      case "MYSQL":
+        if (
+          !semverCompare(engineVersion, MIN_ROLLBACK_SQL_MYSQL_VERSION, "gte")
+        ) {
+          return "NONE";
+        }
+        break;
+      case "ORACLE":
+        break;
+      default:
+        return "NONE";
     }
-    if (!semverCompare(engineVersion, MIN_ROLLBACK_SQL_MYSQL_VERSION, "gte")) {
-      return "NONE";
-    }
+
     if (create.value) {
       return "SWITCH";
     }

--- a/frontend/src/components/Issue/rollback/common.ts
+++ b/frontend/src/components/Issue/rollback/common.ts
@@ -67,6 +67,7 @@ export const useRollbackLogic = () => {
         }
         break;
       case "ORACLE":
+        // We don't have a check for oracle similar to the MySQL version check.
         break;
       default:
         return "NONE";


### PR DESCRIPTION
## Overview
This PR implements the feature that allows user rollback DML on Oracle instance. We get the transaction id in the Oracle data update task and store it in the rollback runner if the user turns on the `ROLLBACK` switch. And we get the undo SQL by using transaction id.

## Pre-requirements:
1. Our Oracle rollback DML feature depends on [Oracle Flashback Transaction Query](https://docs.oracle.com/cd/B14117_01/appdev.101/b10795/adfns_fl.htm) features. Users should **turn on the [supplemental logging](https://docs.oracle.com/database/121/SUTIL/GUID-D2DDD67C-E1CC-45A6-A2A7-198E4C142FA3.htm#SUTIL1583)**.

> **Warning**
> We use `SELECT RAWTOHEX(tx.xid) FROM v$transaction tx JOIN v$session s ON tx.ses_addr = s.saddr;` to get the transaction id, but the underlying Golang oracle driver `go-ora` may reuse the session/connection(aka connection pool), so we may get multiple transaction ids which contain the transaction executed in this connection previously.
But I tried a few times and got the correct undo SQL. I will follow up on this issue.


## Demo
The following video shows that insert a record, rollback, and rollback-rollback...

https://user-images.githubusercontent.com/87714218/226791977-fec10dd6-151b-4fc0-9998-ebaefe0c9e17.mp4

