### PR TITLE
feat(schema): risk

### DIFF
--- a/backend/store/migration/prod/1.15/0000##risk.sql
+++ b/backend/store/migration/prod/1.15/0000##risk.sql
@@ -1,0 +1,23 @@
+-- risk stores the definition of a risk.
+CREATE TABLE risk (
+    id BIGSERIAL PRIMARY KEY,
+    row_status row_status NOT NULL DEFAULT 'NORMAL',
+    creator_id INTEGER NOT NULL REFERENCES principal (id),
+    created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    updater_id INTEGER NOT NULL REFERENCES principal (id),
+    updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    source TEXT NOT NULL CHECK (source LIKE 'bb.risk.%'),
+    -- how risky is the risk, the higher the riskier
+    level BIGINT NOT NULL,
+    name TEXT NOT NULL,
+    active BOOLEAN NOT NULL,
+    expression JSONB NOT NULL
+);
+
+ALTER SEQUENCE risk_id_seq RESTART WITH 101;
+
+CREATE TRIGGER update_risk_updated_ts
+BEFORE
+UPDATE
+    ON risk FOR EACH ROW
+EXECUTE FUNCTION trigger_update_updated_ts();

--- a/backend/store/migration/prod/LATEST.sql
+++ b/backend/store/migration/prod/LATEST.sql
@@ -1102,3 +1102,28 @@ BEFORE
 UPDATE
     ON external_approval FOR EACH ROW
 EXECUTE FUNCTION trigger_update_updated_ts();
+
+
+-- risk stores the definition of a risk.
+CREATE TABLE risk (
+    id BIGSERIAL PRIMARY KEY,
+    row_status row_status NOT NULL DEFAULT 'NORMAL',
+    creator_id INTEGER NOT NULL REFERENCES principal (id),
+    created_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    updater_id INTEGER NOT NULL REFERENCES principal (id),
+    updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
+    source TEXT NOT NULL CHECK (source LIKE 'bb.risk.%'),
+    -- how risky is the risk, the higher the riskier
+    level BIGINT NOT NULL,
+    name TEXT NOT NULL,
+    active BOOLEAN NOT NULL,
+    expression JSONB NOT NULL
+);
+
+ALTER SEQUENCE risk_id_seq RESTART WITH 101;
+
+CREATE TRIGGER update_risk_updated_ts
+BEFORE
+UPDATE
+    ON risk FOR EACH ROW
+EXECUTE FUNCTION trigger_update_updated_ts();

--- a/backend/store/pg_engine_test.go
+++ b/backend/store/pg_engine_test.go
@@ -222,5 +222,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("1.14.3"), releaseVersion)
+	require.Equal(t, semver.MustParse("1.15.0"), releaseVersion)
 }


### PR DESCRIPTION
The most important part of a risk is the `expression`.

On the frontend, risks having the same level will be grouped and displayed as e.g. High risk with many expressions.

We hard code low, mid, high as 1e9, 2e9, 3e9 at the moment.
