### PR TITLE
chore: disable new db for oracle

### DIFF
--- a/frontend/src/utils/instance.ts
+++ b/frontend/src/utils/instance.ts
@@ -80,6 +80,7 @@ export const instanceHasReadonlyMode = (instance: Instance): boolean => {
 export const instanceHasCreateDatabase = (instance: Instance): boolean => {
   const { engine } = instance;
   if (engine === "REDIS") return false;
+  if (engine === "ORACLE") return false;
   return true;
 };
 


### PR DESCRIPTION
Oracle database creation is a heavy process. We don't support it as users will most likely do it themselves.