### PR TITLE
chore: remove instance engine check

### DIFF
--- a/backend/store/migration/dev/20230317000000##sqlserver.sql
+++ b/backend/store/migration/dev/20230317000000##sqlserver.sql
@@ -1,3 +1,0 @@
-ALTER TABLE instance DROP CONSTRAINT instance_engine_check;
-
-ALTER TABLE instance ADD CONSTRAINT instance_engine_check CHECK (engine IN ('MYSQL', 'POSTGRES', 'TIDB', 'CLICKHOUSE', 'SNOWFLAKE', 'SQLITE', 'MONGODB', 'SPANNER', 'REDIS', 'ORACLE', 'MSSQL'));

--- a/backend/store/migration/dev/LATEST.sql
+++ b/backend/store/migration/dev/LATEST.sql
@@ -302,7 +302,7 @@ CREATE TABLE instance (
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     environment_id INTEGER NOT NULL REFERENCES environment (id),
     name TEXT NOT NULL,
-    engine TEXT NOT NULL CONSTRAINT instance_engine_check CHECK (engine IN ('MYSQL', 'POSTGRES', 'TIDB', 'CLICKHOUSE', 'SNOWFLAKE', 'SQLITE', 'MONGODB', 'SPANNER', 'REDIS', 'ORACLE', 'MSSQL')),
+    engine TEXT NOT NULL,
     engine_version TEXT NOT NULL DEFAULT '',
     external_link TEXT NOT NULL DEFAULT '',
     resource_id TEXT NOT NULL

--- a/backend/store/migration/prod/1.15/0001##drop_engine_check.sql
+++ b/backend/store/migration/prod/1.15/0001##drop_engine_check.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instance DROP CONSTRAINT instance_engine_check;

--- a/backend/store/migration/prod/LATEST.sql
+++ b/backend/store/migration/prod/LATEST.sql
@@ -301,7 +301,7 @@ CREATE TABLE instance (
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     environment_id INTEGER NOT NULL REFERENCES environment (id),
     name TEXT NOT NULL,
-    engine TEXT NOT NULL CONSTRAINT instance_engine_check CHECK (engine IN ('MYSQL', 'POSTGRES', 'TIDB', 'CLICKHOUSE', 'SNOWFLAKE', 'SQLITE', 'MONGODB', 'SPANNER', 'REDIS', 'ORACLE')),
+    engine TEXT NOT NULL,
     engine_version TEXT NOT NULL DEFAULT '',
     external_link TEXT NOT NULL DEFAULT '',
     resource_id TEXT NOT NULL

--- a/backend/store/pg_engine_test.go
+++ b/backend/store/pg_engine_test.go
@@ -222,5 +222,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("1.15.0"), releaseVersion)
+	require.Equal(t, semver.MustParse("1.15.1"), releaseVersion)
 }


### PR DESCRIPTION
We don't want to check the schema version for introducing new database types. 