### PR TITLE
fix: disallow EXPLAIN ANAYZE and CTE for DML in SQL editor

### DIFF
--- a/backend/plugin/parser/parser.go
+++ b/backend/plugin/parser/parser.go
@@ -14,6 +14,7 @@ import (
 type EngineType string
 
 const (
+	Standard EngineType = "STANDARD"
 	// MySQL is the engine type for MYSQL.
 	MySQL EngineType = "MYSQL"
 	// TiDB is the engine type for TiDB.

--- a/backend/plugin/parser/parser.go
+++ b/backend/plugin/parser/parser.go
@@ -14,6 +14,7 @@ import (
 type EngineType string
 
 const (
+	// Standard is the engine type for standard SQL.
 	Standard EngineType = "STANDARD"
 	// MySQL is the engine type for MYSQL.
 	MySQL EngineType = "MYSQL"

--- a/backend/plugin/parser/validate_sql_for_editor.go
+++ b/backend/plugin/parser/validate_sql_for_editor.go
@@ -94,13 +94,13 @@ func postgresValidateSQLForEditor(statement string) bool {
 
 		dmlKeyList := []string{"InsertStmt", "UpdateStmt", "DeleteStmt"}
 
-		return !keyExistsInJsonData(jsonData, dmlKeyList)
+		return !keyExistsInJSONData(jsonData, dmlKeyList)
 	}
 
 	return false
 }
 
-func keyExistsInJsonData(jsonData map[string]interface{}, keyList []string) bool {
+func keyExistsInJSONData(jsonData map[string]interface{}, keyList []string) bool {
 	for _, key := range keyList {
 		if _, ok := jsonData[key]; ok {
 			return true
@@ -110,13 +110,13 @@ func keyExistsInJsonData(jsonData map[string]interface{}, keyList []string) bool
 	for _, value := range jsonData {
 		switch v := value.(type) {
 		case map[string]interface{}:
-			if keyExistsInJsonData(v, keyList) {
+			if keyExistsInJSONData(v, keyList) {
 				return true
 			}
 		case []interface{}:
 			for _, item := range v {
 				if m, ok := item.(map[string]interface{}); ok {
-					if keyExistsInJsonData(m, keyList) {
+					if keyExistsInJSONData(m, keyList) {
 						return true
 					}
 				}

--- a/backend/plugin/parser/validate_sql_for_editor.go
+++ b/backend/plugin/parser/validate_sql_for_editor.go
@@ -1,0 +1,381 @@
+package parser
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	pgquery "github.com/pganalyze/pg_query_go/v2"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/backend/common/log"
+)
+
+// ValidateSQLForEditor validates the SQL statement for editor.
+// We support the following SQLs:
+// 1. EXPLAIN statement, except EXPLAIN ANALYZE
+// 2. SELECT statement
+//
+// We also support CTE with SELECT statements, but not with DML statements.
+func ValidateSQLForEditor(engine EngineType, statement string) bool {
+	switch engine {
+	case Postgres:
+		return postgresValidateSQLForEditor(statement)
+	case MySQL, TiDB, MariaDB:
+		return mysqlValidateSQLForEditor(statement)
+	default:
+		return standardValidateSQLForEditor(statement)
+	}
+}
+
+func standardValidateSQLForEditor(statement string) bool {
+	textWithoutQuotedAndComment, err := removeQuotedTextAndComment(Standard, statement)
+	if err != nil {
+		log.Debug("Failed to remove quoted text and comment", zap.String("statement", statement), zap.Error(err))
+		return false
+	}
+
+	return checkStatementWithoutQuotedTextAndComment(textWithoutQuotedAndComment)
+}
+
+func mysqlValidateSQLForEditor(statement string) bool {
+	textWithoutQuotedAndComment, err := removeQuotedTextAndComment(MySQL, statement)
+	if err != nil {
+		log.Debug("Failed to remove quoted text and comment", zap.String("statement", statement), zap.Error(err))
+		return false
+	}
+
+	return checkStatementWithoutQuotedTextAndComment(textWithoutQuotedAndComment)
+}
+
+func postgresValidateSQLForEditor(statement string) bool {
+	jsonText, err := pgquery.ParseToJSON(statement)
+	if err != nil {
+		log.Debug("Failed to parse statement to JSON", zap.String("statement", statement), zap.Error(err))
+		return false
+	}
+
+	formattedStr := strings.ToUpper(strings.TrimSpace(statement))
+	if isSelect, _ := regexp.MatchString(`^SELECT\s+?`, formattedStr); isSelect {
+		return true
+	}
+
+	if isExplain, _ := regexp.MatchString(`^EXPLAIN\s+?`, formattedStr); isExplain {
+		if isExplainAnalyze, _ := regexp.MatchString(`^EXPLAIN\s+ANALYZE\s+?`, formattedStr); isExplainAnalyze {
+			return false
+		}
+		return true
+	}
+
+	cteRegex := regexp.MustCompile(`^WITH\s+?`)
+	if matchResult := cteRegex.MatchString(formattedStr); matchResult {
+		var jsonData map[string]interface{}
+
+		if err := json.Unmarshal([]byte(jsonText), &jsonData); err != nil {
+			log.Debug("Failed to unmarshal JSON", zap.String("jsonText", jsonText), zap.Error(err))
+			return false
+		}
+
+		dmlKeyList := []string{"InsertStmt", "UpdateStmt", "DeleteStmt"}
+
+		return !keyExistsInJsonData(jsonData, dmlKeyList)
+	}
+
+	return false
+}
+
+func keyExistsInJsonData(jsonData map[string]interface{}, keyList []string) bool {
+	for _, key := range keyList {
+		if _, ok := jsonData[key]; ok {
+			return true
+		}
+	}
+
+	for _, value := range jsonData {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			if keyExistsInJsonData(v, keyList) {
+				return true
+			}
+		case []interface{}:
+			for _, item := range v {
+				if m, ok := item.(map[string]interface{}); ok {
+					if keyExistsInJsonData(m, keyList) {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func checkStatementWithoutQuotedTextAndComment(statement string) bool {
+	formattedStr := strings.ToUpper(strings.TrimSpace(statement))
+	if isSelect, _ := regexp.MatchString(`^SELECT\s+?`, formattedStr); isSelect {
+		return true
+	}
+
+	if isExplain, _ := regexp.MatchString(`^EXPLAIN\s+?`, formattedStr); isExplain {
+		if isExplainAnalyze, _ := regexp.MatchString(`^EXPLAIN\s+ANALYZE\s+?`, formattedStr); isExplainAnalyze {
+			return false
+		}
+		return true
+	}
+
+	cteRegex := regexp.MustCompile(`^WITH\s+?`)
+	if matchResult := cteRegex.MatchString(formattedStr); matchResult {
+		dmlRegs := []string{`\bINSERT\b`, `\bUPDATE\b`, `\bDELETE\b`}
+		for _, reg := range dmlRegs {
+			if matchResult, _ := regexp.MatchString(reg, formattedStr); matchResult {
+				return false
+			}
+		}
+		return true
+	}
+
+	return false
+}
+
+func removeQuotedTextAndComment(engine EngineType, statement string) (string, error) {
+	switch engine {
+	case Postgres:
+		return postgresRemoveQuotedTextAndComment(statement)
+	case MySQL, TiDB, MariaDB:
+		return mysqlRemoveQuotedTextAndComment(statement)
+	case Standard, Oracle, MSSQL:
+		return standardRemoveQuotedTextAndComment(statement)
+	}
+	return "", errors.Errorf("unsupported engine type: %s", engine)
+}
+
+func standardRemoveQuotedTextAndComment(statement string) (string, error) {
+	var buf bytes.Buffer
+	t := newTokenizer(statement)
+
+	t.skipBlank()
+	startPos := t.pos()
+	for {
+		switch {
+		case t.char(0) == '/' && t.char(1) == '*':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanComment(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '-' && t.char(1) == '-':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanComment(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '\'':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanString('\''); err != nil {
+				return "'", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '"':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanIdentifier('"'); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == eofRune:
+			text := t.getString(startPos, t.pos()-startPos)
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		default:
+			t.skip(1)
+		}
+	}
+}
+
+func mysqlRemoveQuotedTextAndComment(statement string) (string, error) {
+	var buf bytes.Buffer
+	t := newTokenizer(statement)
+
+	t.skipBlank()
+	startPos := t.pos()
+	for {
+		switch {
+		case t.char(0) == eofRune:
+			text := t.getString(startPos, t.pos()-startPos)
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		case t.char(0) == '/' && t.char(1) == '*':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanComment(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '-' && t.char(1) == '-':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanComment(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '#':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanComment(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '\'' || t.char(0) == '"':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanString(t.char(0)); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '`':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanIdentifier('`'); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		default:
+			t.skip(1)
+		}
+	}
+}
+
+func postgresRemoveQuotedTextAndComment(statement string) (string, error) {
+	var buf bytes.Buffer
+	t := newTokenizer(statement)
+
+	t.skipBlank()
+	startPos := t.pos()
+	for {
+		switch {
+		case t.char(0) == '/' && t.char(1) == '*':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanComment(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '-' && t.char(1) == '-':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanComment(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '\'':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanString('\''); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '$':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanDoubleDollarQuotedString(); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == '"':
+			text := t.getString(startPos, t.pos()-startPos)
+			if err := t.scanIdentifier('"'); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			if err := buf.WriteByte(' '); err != nil {
+				return "", err
+			}
+			startPos = t.pos()
+		case t.char(0) == eofRune:
+			text := t.getString(startPos, t.pos()-startPos)
+			if _, err := buf.WriteString(text); err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		default:
+			t.skip(1)
+		}
+	}
+}

--- a/backend/plugin/parser/validate_sql_for_editor_test.go
+++ b/backend/plugin/parser/validate_sql_for_editor_test.go
@@ -1,0 +1,213 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser"
+)
+
+type testData struct {
+	sql string
+	ans bool
+}
+
+func TestValidateSQLForPG(t *testing.T) {
+	tests := []testData{
+		{
+			sql: `explain select * from t;`,
+			ans: true,
+		},
+		{
+			sql: `explain    analyze select * from t`,
+			ans: false,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1
+				), tx as (
+					delete from t2
+				)
+				select * from t;
+				`,
+			ans: false,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1
+				), tx as (
+					select * from t1
+				)
+				update t set a = 1;
+				`,
+			ans: false,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1
+				), tx as (
+					select * from t1
+				)
+				insert into t values (1, 2, 3);
+				`,
+			ans: false,
+		},
+		{
+			sql: "select * from t where a = 'klasjdfkljsa$tag$; -- lkjdlkfajslkdfj'",
+			ans: true,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1 where a = 'insert'
+				), tx as (
+					select * from "delete"
+				) /* UPDATE */
+				select "update" from t;
+				`,
+			ans: true,
+		},
+		{
+			sql: `create table t (a int);`,
+			ans: false,
+		},
+	}
+
+	for _, test := range tests {
+		ans := parser.ValidateSQLForEditor(parser.Postgres, test.sql)
+		require.Equal(t, test.ans, ans, test.sql)
+	}
+}
+
+func TestValidateSQLForMySQL(t *testing.T) {
+	tests := []testData{
+		{
+			sql: `explain select * from t;`,
+			ans: true,
+		},
+		{
+			sql: `explain    analyze select * from t`,
+			ans: false,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1
+				), tx as (
+					select * from t1
+				)
+				update t set a = 1;
+				`,
+			ans: false,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1
+				), tx as (
+					select * from t1
+				)
+				insert into t values (1, 2, 3);
+				`,
+			ans: false,
+		},
+		{
+			sql: "select * from t where a = 'klasjdfkljsa$tag$; -- lkjdlkfajslkdfj'",
+			ans: true,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1 where a = 'insert'
+				), tx as (` +
+				"   select * from `delete`" +
+				`) /* UPDATE */` +
+				"select `update` from t;",
+			ans: true,
+		},
+		{
+			sql: `create table t (a int);`,
+			ans: false,
+		},
+	}
+
+	for _, test := range tests {
+		ans := parser.ValidateSQLForEditor(parser.MySQL, test.sql)
+		require.Equal(t, test.ans, ans, test.sql)
+
+		ans = parser.ValidateSQLForEditor(parser.TiDB, test.sql)
+		require.Equal(t, test.ans, ans, test.sql)
+
+		ans = parser.ValidateSQLForEditor(parser.MariaDB, test.sql)
+		require.Equal(t, test.ans, ans, test.sql)
+	}
+}
+
+func TestValidateSQLForStandard(t *testing.T) {
+	tests := []testData{
+		{
+			sql: `explain select * from t;`,
+			ans: true,
+		},
+		{
+			sql: `explain    analyze select * from t`,
+			ans: false,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1
+				), tx as (
+					select * from t1
+				)
+				update t set a = 1;
+				`,
+			ans: false,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1
+				), tx as (
+					select * from t1
+				)
+				insert into t values (1, 2, 3);
+				`,
+			ans: false,
+		},
+		{
+			sql: "select * from t where a = 'klasjdfkljsa$tag$; -- lkjdlkfajslkdfj'",
+			ans: true,
+		},
+		{
+			sql: `
+				With t as (
+					select * from t1 where a = 'insert'
+				), tx as (
+					select * from "delete"
+				) /* UPDATE */
+				select "update" from t;
+				`,
+			ans: true,
+		},
+		{
+			sql: `create table t (a int);`,
+			ans: false,
+		},
+	}
+
+	for _, test := range tests {
+		ans := parser.ValidateSQLForEditor(parser.Standard, test.sql)
+		require.Equal(t, test.ans, ans, test.sql)
+
+		ans = parser.ValidateSQLForEditor(parser.Oracle, test.sql)
+		require.Equal(t, test.ans, ans, test.sql)
+
+		ans = parser.ValidateSQLForEditor(parser.MSSQL, test.sql)
+		require.Equal(t, test.ans, ans, test.sql)
+	}
+}

--- a/backend/server/sql_test.go
+++ b/backend/server/sql_test.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"testing"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser"
 )
 
 func TestValidateSQLSelectStatement(t *testing.T) {
+	engines := []parser.EngineType{parser.MySQL, parser.Postgres, parser.MariaDB, parser.MSSQL, parser.Oracle, parser.TiDB, parser.Standard}
 	tests := []struct {
 		sqlStatement string
 		want         bool
@@ -88,9 +91,11 @@ func TestValidateSQLSelectStatement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := validateSQLSelectStatement(test.sqlStatement)
-		if result != test.want {
-			t.Errorf("Validate SQLStatement %q: got result %v, want %v.", test.sqlStatement, result, test.want)
+		for _, engine := range engines {
+			result := parser.ValidateSQLForEditor(engine, test.sqlStatement)
+			if result != test.want {
+				t.Errorf("Validate SQLStatement %q: got result %v, want %v, for engine %s.", test.sqlStatement, result, test.want, engine)
+			}
 		}
 	}
 }


### PR DESCRIPTION
close BYT-2820

ValidateSQLForEditor validates the SQL statement for SQL editor.
We support the following SQLs:
1. EXPLAIN statement, except EXPLAIN ANALYZE
2. SELECT statement

We also support CTE with SELECT statements, but not with DML statements

## For PostgreSQL

Consider that the tokenizer cannot handle the dollar-sign($), so we use pg_query_go to parse the statement.
For EXPLAIN and normal SELECT statements, we can directly use regexp to check.
For CTE, we need to parse the statement to JSON and check the JSON keys.

## For other databases

We validate the statement by following steps:
1. Remove all quoted text(quoted identifier, string literal) and comments from the statement.
2. Use regexp to check if the statement is a normal SELECT statement and EXPLAIN statement.
3. For CTE, use regexp to check if the statement has UPDATE, DELETE and INSERT statements.