### PR TITLE
fix(BAC): avoid workspace developer operating the issue in some cases

### DIFF
--- a/backend/server/acl.go
+++ b/backend/server/acl.go
@@ -217,7 +217,7 @@ func enforceWorkspaceDeveloperIssueRouteACL(path string, method string, queryPar
 			if err != nil {
 				return echo.NewHTTPError(http.StatusBadRequest, "Invalid issue ID").SetInternal(err)
 			}
-			if err := isWorkspaceDeveloperMemberOfIssue(issueID, principalID); err != nil {
+			if err := canWorkspaceDeveloperUpdateIssue(issueID, principalID); err != nil {
 				return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("user %d is not a member of issue %d", principalID, issueID)).SetInternal(err)
 			}
 		}

--- a/backend/server/acl.go
+++ b/backend/server/acl.go
@@ -190,7 +190,7 @@ func enforceWorkspaceDeveloperSheetRouteACL(plan api.PlanType, path string, meth
 
 var issueStatusRegex = regexp.MustCompile(`^/issue/(?P<issueID>\d+)/status`)
 
-func enforceWorkspaceDeveloperIssueRouteACL(path string, method string, queryParams url.Values, principalID int, role api.Role, canWorkspaceDeveloperUpdateIssue func(issueID int, principalID int) error) *echo.HTTPError {
+func enforceWorkspaceDeveloperIssueRouteACL(path string, method string, queryParams url.Values, principalID int, canWorkspaceDeveloperUpdateIssue func(issueID int, principalID int) error) *echo.HTTPError {
 	if !strings.HasPrefix(path, "/issue") {
 		return nil
 	}
@@ -372,7 +372,7 @@ func aclMiddleware(s *Server, pathPrefix string, ce *casbin.Enforcer, next echo.
 				}
 				aclErr = enforceWorkspaceDeveloperDatabaseRouteACL(path, method, principalID, isMemberOfAnyProjectOwnsDatabase)
 			} else if strings.HasPrefix(path, "/issue") {
-				aclErr = enforceWorkspaceDeveloperIssueRouteACL(path, method, c.QueryParams(), principalID, role, getCanWorkspaceDeveloperUpdateIssue(ctx, s.store))
+				aclErr = enforceWorkspaceDeveloperIssueRouteACL(path, method, c.QueryParams(), principalID, getCanWorkspaceDeveloperUpdateIssue(ctx, s.store))
 			}
 			if aclErr != nil {
 				return aclErr

--- a/backend/server/acl.go
+++ b/backend/server/acl.go
@@ -190,8 +190,7 @@ func enforceWorkspaceDeveloperSheetRouteACL(plan api.PlanType, path string, meth
 
 var issueStatusRegex = regexp.MustCompile(`^/issue/(?P<issueID>\d+)/status`)
 
-// enforceIssueRouteACL enforces the ACL for /issue route, return true if the request is allowed, error is not nil indicates encounter error during the process.
-func enforceIssueRouteACL(path string, method string, queryParams url.Values, principalID int, role api.Role, isWorkspaceDeveloperMemberOfIssue func(issueID int, principalID int) error) *echo.HTTPError {
+func enforceWorkspaceDeveloperIssueRouteACL(path string, method string, queryParams url.Values, principalID int, role api.Role, canWorkspaceDeveloperUpdateIssue func(issueID int, principalID int) error) *echo.HTTPError {
 	if !strings.HasPrefix(path, "/issue") {
 		return nil
 	}
@@ -211,11 +210,8 @@ func enforceIssueRouteACL(path string, method string, queryParams url.Values, pr
 			}
 		}
 	} else if method == "PATCH" {
-		// Workspace developer can only operating the issues in the project they are a member of or the issues they created.
+		// Workspace developer can only operating the issues if canWorkspaceDeveloperUpdateIssue returns no error.
 		if matches := issueStatusRegex.FindStringSubmatch(path); len(matches) > 0 {
-			if role == api.DBA || role == api.Owner {
-				return nil
-			}
 			issueIDStr := matches[1]
 			issueID, err := strconv.Atoi(issueIDStr)
 			if err != nil {
@@ -225,7 +221,6 @@ func enforceIssueRouteACL(path string, method string, queryParams url.Values, pr
 				return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("user %d is not a member of issue %d", principalID, issueID)).SetInternal(err)
 			}
 		}
-
 	}
 	return nil
 }
@@ -376,14 +371,12 @@ func aclMiddleware(s *Server, pathPrefix string, ce *casbin.Enforcer, next echo.
 					return false, nil
 				}
 				aclErr = enforceWorkspaceDeveloperDatabaseRouteACL(path, method, principalID, isMemberOfAnyProjectOwnsDatabase)
+			} else if strings.HasPrefix(path, "/issue") {
+				aclErr = enforceWorkspaceDeveloperIssueRouteACL(path, method, c.QueryParams(), principalID, role, getCanWorkspaceDeveloperUpdateIssue(ctx, s.store))
 			}
 			if aclErr != nil {
 				return aclErr
 			}
-		}
-
-		if err := enforceIssueRouteACL(path, method, c.QueryParams(), principalID, role, getIsWorkspaceDeveloperMemberOfIssue(ctx, s.store)); err != nil {
-			return err
 		}
 
 		// Stores role into context.
@@ -393,11 +386,10 @@ func aclMiddleware(s *Server, pathPrefix string, ce *casbin.Enforcer, next echo.
 	}
 }
 
-// getIsWorkspaceDeveloperMemberOfIssue returns a function that checks if a principal is a member of an issue.
-// If the principal is one of the following, it is considered as a member of the issue:
+// getCanWorkspaceDeveloperUpdateIssue returns a function that checks if a workspace developer can update an issue.
 // 1. The creator of the issue.
 // 2. The member of the project that the issue belongs to.
-func getIsWorkspaceDeveloperMemberOfIssue(ctx context.Context, s *store.Store) func(issueID int, principalID int) error {
+func getCanWorkspaceDeveloperUpdateIssue(ctx context.Context, s *store.Store) func(issueID int, principalID int) error {
 	return func(issueID, principalID int) error {
 		issue, err := s.GetIssueV2(ctx, &store.FindIssueMessage{
 			UID: &issueID,
@@ -408,7 +400,7 @@ func getIsWorkspaceDeveloperMemberOfIssue(ctx context.Context, s *store.Store) f
 		if issue == nil {
 			return errors.Errorf("cannot find issue %d", issueID)
 		}
-		if issue.Assignee.ID == principalID || issue.Creator.ID == principalID {
+		if issue.Creator.ID == principalID {
 			return nil
 		}
 
@@ -428,7 +420,7 @@ func getIsWorkspaceDeveloperMemberOfIssue(ctx context.Context, s *store.Store) f
 				}
 			}
 		}
-		return errors.Errorf("principal %d is not a member of issue %d", principalID, issueID)
+		return errors.Errorf("principal %d cannot update the issue %d", principalID, issueID)
 	}
 }
 

--- a/backend/server/acl_issue_test.go
+++ b/backend/server/acl_issue_test.go
@@ -7,7 +7,7 @@ import (
 	api "github.com/bytebase/bytebase/backend/legacyapi"
 )
 
-func TestEnforceEnforceIssueRouteACL_RetrieveIssue(t *testing.T) {
+func TestWorkspaceDeveloperIssueRouteACL_RetrieveIssue(t *testing.T) {
 	type test struct {
 		desc        string
 		path        string
@@ -38,7 +38,7 @@ func TestEnforceEnforceIssueRouteACL_RetrieveIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)
@@ -52,7 +52,7 @@ func TestEnforceEnforceIssueRouteACL_RetrieveIssue(t *testing.T) {
 	}
 }
 
-func TestEnforceEnforceIssueRouteACL_OperateIssue(t *testing.T) {
+func TestWorkspaceDeveloperIssueRouteACL_OperateIssue(t *testing.T) {
 	type test struct {
 		desc        string
 		path        string
@@ -91,7 +91,7 @@ func TestEnforceEnforceIssueRouteACL_OperateIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)

--- a/backend/server/acl_issue_test.go
+++ b/backend/server/acl_issue_test.go
@@ -3,8 +3,6 @@ package server
 import (
 	"net/url"
 	"testing"
-
-	api "github.com/bytebase/bytebase/backend/legacyapi"
 )
 
 func TestWorkspaceDeveloperIssueRouteACL_RetrieveIssue(t *testing.T) {
@@ -38,7 +36,7 @@ func TestWorkspaceDeveloperIssueRouteACL_RetrieveIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, canWorkspaceDeveloperUpdateIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, canWorkspaceDeveloperUpdateIssue)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)
@@ -91,7 +89,7 @@ func TestWorkspaceDeveloperIssueRouteACL_OperateIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, canWorkspaceDeveloperUpdateIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, canWorkspaceDeveloperUpdateIssue)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)

--- a/backend/server/acl_issue_test.go
+++ b/backend/server/acl_issue_test.go
@@ -36,7 +36,7 @@ func TestWorkspaceDeveloperIssueRouteACL_RetrieveIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, canWorkspaceDeveloperUpdateIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, mockGetIssueCreatorIDAndProjectID, mockGetProjectIDMemberIDs)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)
@@ -67,7 +67,7 @@ func TestWorkspaceDeveloperIssueRouteACL_OperateIssue(t *testing.T) {
 			queryParams: url.Values{},
 			method:      "PATCH",
 			principalID: 202,
-			errMsg:      "user 202 is not a member of issue 403",
+			errMsg:      "not allowed to operate the issue",
 		},
 		{
 			desc:        "Operating the issue I created",
@@ -89,7 +89,7 @@ func TestWorkspaceDeveloperIssueRouteACL_OperateIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, canWorkspaceDeveloperUpdateIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, mockGetIssueCreatorIDAndProjectID, mockGetProjectIDMemberIDs)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)

--- a/backend/server/acl_issue_test.go
+++ b/backend/server/acl_issue_test.go
@@ -38,7 +38,7 @@ func TestWorkspaceDeveloperIssueRouteACL_RetrieveIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, canWorkspaceDeveloperUpdateIssue)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)
@@ -91,7 +91,7 @@ func TestWorkspaceDeveloperIssueRouteACL_OperateIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
+			err := enforceWorkspaceDeveloperIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, canWorkspaceDeveloperUpdateIssue)
 			if err != nil {
 				if tc.errMsg == "" {
 					t.Errorf("expect no error, got %s", err.Message)

--- a/backend/server/acl_issue_test.go
+++ b/backend/server/acl_issue_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"net/url"
+	"testing"
+
+	api "github.com/bytebase/bytebase/backend/legacyapi"
+)
+
+func TestEnforceEnforceIssueRouteACL_RetrieveIssue(t *testing.T) {
+	type test struct {
+		desc        string
+		path        string
+		method      string
+		queryParams url.Values
+		principalID int
+		errMsg      string
+	}
+
+	tests := []test{
+		{
+			desc:        "Retrieve other users' issue",
+			path:        "/issue?user=201",
+			queryParams: url.Values{"user": []string{"201"}},
+			method:      "GET",
+			principalID: 202,
+			errMsg:      "not allowed to list other users' issues",
+		},
+		{
+			desc:        "Retrieve my issue",
+			path:        "/issue?user=202",
+			queryParams: url.Values{"user": []string{"202"}},
+			method:      "GET",
+			principalID: 202,
+			errMsg:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := enforceIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
+			if err != nil {
+				if tc.errMsg == "" {
+					t.Errorf("expect no error, got %s", err.Message)
+				} else if tc.errMsg != err.Message {
+					t.Errorf("expect error %s, got %s", tc.errMsg, err.Message)
+				}
+			} else if tc.errMsg != "" {
+				t.Errorf("expect error %s, got no error", tc.errMsg)
+			}
+		})
+	}
+}
+
+func TestEnforceEnforceIssueRouteACL_OperateIssue(t *testing.T) {
+	type test struct {
+		desc        string
+		path        string
+		method      string
+		queryParams url.Values
+		principalID int
+		errMsg      string
+	}
+
+	tests := []test{
+		{
+			desc:        "Operating the issue created by other user in other projects",
+			path:        "/issue/403/status",
+			queryParams: url.Values{},
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "user 202 is not a member of issue 403",
+		},
+		{
+			desc:        "Operating the issue I created",
+			path:        "/issue/401/status",
+			queryParams: url.Values{},
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+		{
+			desc:        "Operating the issue created by other user in projects I am a member of",
+			path:        "/issue/402/status",
+			queryParams: url.Values{},
+			method:      "PATCH",
+			principalID: 202,
+			errMsg:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := enforceIssueRouteACL(tc.path, tc.method, tc.queryParams, tc.principalID, api.Developer, isWorkspaceDeveloperMemberOfIssue)
+			if err != nil {
+				if tc.errMsg == "" {
+					t.Errorf("expect no error, got %s", err.Message)
+				} else if tc.errMsg != err.Message {
+					t.Errorf("expect error %s, got %s", tc.errMsg, err.Message)
+				}
+			} else if tc.errMsg != "" {
+				t.Errorf("expect error %s, got no error", tc.errMsg)
+			}
+		})
+	}
+}

--- a/backend/server/acl_test_helper.go
+++ b/backend/server/acl_test_helper.go
@@ -210,7 +210,7 @@ var testMemberIssueMap = struct {
 // If the principal is one of the following, it is considered as a member of the issue:
 // 1. The creator of the issue.
 // 2. The member of the project that the issue belongs to.
-var isWorkspaceDeveloperMemberOfIssue = func(issueID int, principalID int) error {
+var canWorkspaceDeveloperUpdateIssue = func(issueID int, principalID int) error {
 	if creatorID, ok := testMemberIssueMap.issueIDToCreatorID[issueID]; !ok {
 		return errors.Errorf("issue %d does not exist", issueID)
 	} else if creatorID == principalID {

--- a/backend/server/acl_test_helper.go
+++ b/backend/server/acl_test_helper.go
@@ -230,28 +230,3 @@ func mockGetProjectIDMemberIDs(projectID int) ([]int, error) {
 	}
 	return memberIDs, nil
 }
-
-// If the workspace developer principal is one of the following, it can update the issue:
-// 1. The creator of the issue.
-// 2. The member of the project that the issue belongs to.
-var canWorkspaceDeveloperUpdateIssue = func(issueID int, principalID int) error {
-	if creatorID, ok := testMemberIssueHelper.issueIDToCreatorID[issueID]; !ok {
-		return errors.Errorf("issue %d does not exist", issueID)
-	} else if creatorID == principalID {
-		return nil
-	}
-
-	issueProjectIDBelongTo, ok := testMemberIssueHelper.issueIDToProjectID[issueID]
-	if !ok {
-		return errors.Errorf("issue %d does not belong to any project", issueID)
-	}
-
-	principalProjectIDBelongTo, ok := testMemberIssueHelper.principalIDToProjectID[principalID]
-	if !ok {
-		return errors.Errorf("user %d is not a member of any project", principalID)
-	}
-	if issueProjectIDBelongTo != principalProjectIDBelongTo {
-		return errors.Errorf("user %d is not a member of issue %d", principalID, issueID)
-	}
-	return nil
-}

--- a/backend/server/acl_test_helper.go
+++ b/backend/server/acl_test_helper.go
@@ -178,8 +178,6 @@ var testMemberIssueHelper = struct {
 	principalIDToProjectID map[int]int
 	// issueIDToProjectID is a map from issue ID to the project ID.
 	issueIDToProjectID map[int]int
-	// issueIDToCreatorID is a map from issue ID to the creator ID.
-	issueIDToCreatorID map[int]int
 }{
 	principalIDToProjectID: map[int]int{
 		// User 202 is a member of project 102.
@@ -197,31 +195,17 @@ var testMemberIssueHelper = struct {
 		// Issue 403 belongs to project 103.
 		403: 103,
 	},
-	issueIDToCreatorID: map[int]int{
-		// Issue 401 is created by user 202.
-		401: 202,
-		// Issue 402 is created by user 203.
-		402: 203,
-		// Issue 403 is created by user 204.
-		403: 204,
-	},
 }
 
-func mockGetIssueCreatorIDAndProjectID(issueID int) (int, int, error) {
-	creatorID, ok := testMemberIssueHelper.issueIDToCreatorID[issueID]
-	if !ok {
-		return 0, 0, errors.Errorf("issue %d does not exist", issueID)
-	}
-
+func mockGetIssueProjectID(issueID int) (int, error) {
 	projectID, ok := testMemberIssueHelper.issueIDToProjectID[issueID]
 	if !ok {
-		return 0, 0, errors.Errorf("issue %d does not belong to any project", issueID)
+		return 0, errors.Errorf("issue %d does not belong to any project", issueID)
 	}
-
-	return creatorID, projectID, nil
+	return projectID, nil
 }
 
-func mockGetProjectIDMemberIDs(projectID int) ([]int, error) {
+func mockGetProjectMembers(projectID int) ([]int, error) {
 	var memberIDs []int
 	for principalID, id := range testMemberIssueHelper.principalIDToProjectID {
 		if id == projectID {

--- a/backend/server/acl_test_helper.go
+++ b/backend/server/acl_test_helper.go
@@ -207,7 +207,7 @@ var testMemberIssueMap = struct {
 	},
 }
 
-// If the principal is one of the following, it is considered as a member of the issue:
+// If the workspace developer principal is one of the following, it can update the issue:
 // 1. The creator of the issue.
 // 2. The member of the project that the issue belongs to.
 var canWorkspaceDeveloperUpdateIssue = func(issueID int, principalID int) error {


### PR DESCRIPTION
We just allow workspace developer operating the issue in the following cases:
1. The creator of the issue.
2. The member of the project that the issue belongs to.