### PR TITLE
feat: impl approval runner factors

### DIFF
--- a/backend/legacyapi/task_check_run.go
+++ b/backend/legacyapi/task_check_run.go
@@ -214,8 +214,8 @@ func IsStatementTypeCheckSupported(dbType db.Type) bool {
 	}
 }
 
-// IsStatementTypeReportCheckSupported checks if statement type report supports the engine type.
-func IsStatementTypeReportCheckSupported(dbType db.Type) bool {
+// IsTaskCheckReportSupported checks if the task report supports the engine type.
+func IsTaskCheckReportSupported(dbType db.Type) bool {
 	switch dbType {
 	case db.Postgres, db.TiDB, db.MySQL:
 		return true
@@ -224,10 +224,10 @@ func IsStatementTypeReportCheckSupported(dbType db.Type) bool {
 	}
 }
 
-// IsStatementAffectedRowsReportCheckSupported checks if statement affected rows report supports the engine type.
-func IsStatementAffectedRowsReportCheckSupported(dbType db.Type) bool {
-	switch dbType {
-	case db.Postgres, db.TiDB, db.MySQL:
+// IsTaskCheckReportNeededForTaskType checks if the task report is needed for the task type.
+func IsTaskCheckReportNeededForTaskType(taskType TaskType) bool {
+	switch taskType {
+	case TaskDatabaseSchemaUpdate, TaskDatabaseSchemaUpdateSDL, TaskDatabaseSchemaUpdateGhostSync, TaskDatabaseDataUpdate:
 		return true
 	default:
 		return false

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -242,21 +242,25 @@ func getTaskRiskLevel(ctx context.Context, s *store.Store, issue *store.IssueMes
 		return 0, false, err
 	}
 
-	// TODO(p0ny): not all tasks have these reports
-	affectedRowsReportResult, done, err := getReportResult(ctx, s, task, api.TaskCheckDatabaseStatementAffectedRowsReport)
-	if err != nil {
-		return 0, false, err
-	}
-	if !done {
-		return 0, false, nil
-	}
+	var affectedRowsReportResult, statementTypeReportResult []api.TaskCheckResult
+	if api.IsTaskCheckReportSupported(instance.Engine) && api.IsTaskCheckReportNeededForTaskType(task.Type) {
+		affectedRowsReportResultInner, done, err := getReportResult(ctx, s, task, api.TaskCheckDatabaseStatementAffectedRowsReport)
+		if err != nil {
+			return 0, false, err
+		}
+		if !done {
+			return 0, false, nil
+		}
+		affectedRowsReportResult = affectedRowsReportResultInner
 
-	statementTypeReportResult, done, err := getReportResult(ctx, s, task, api.TaskCheckDatabaseStatementTypeReport)
-	if err != nil {
-		return 0, false, err
-	}
-	if !done {
-		return 0, false, nil
+		statementTypeReportResultInner, done, err := getReportResult(ctx, s, task, api.TaskCheckDatabaseStatementTypeReport)
+		if err != nil {
+			return 0, false, err
+		}
+		if !done {
+			return 0, false, nil
+		}
+		statementTypeReportResult = statementTypeReportResultInner
 	}
 
 	if len(affectedRowsReportResult) != len(statementTypeReportResult) {

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	api "github.com/bytebase/bytebase/backend/legacyapi"
 	"github.com/bytebase/bytebase/backend/store"
-	"github.com/bytebase/bytebase/backend/utils"
 
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
@@ -187,23 +186,6 @@ func getIssueRiskLevel(ctx context.Context, s *store.Store, issue *store.IssueMe
 	})
 	if err != nil {
 		return 0, err
-	}
-
-	// all tasks must have passed task checks.
-	for _, task := range tasks {
-		instance, err := s.GetInstanceV2(ctx, &store.FindInstanceMessage{
-			UID: &task.InstanceID,
-		})
-		if err != nil {
-			return 0, err
-		}
-		pass, err := utils.PassAllCheck(task, api.TaskCheckStatusWarn, task.TaskCheckRunRawList, instance.Engine)
-		if err != nil {
-			return 0, err
-		}
-		if !pass {
-			return 0, nil
-		}
 	}
 
 	var maxRiskLevel int64

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -26,7 +26,7 @@ import (
 
 const approvalRunnerInterval = 30 * time.Second
 
-var predefinedVariables = []cel.EnvOption{
+var riskFactors = []cel.EnvOption{
 	// string factors
 	// use environment.resource_id
 	cel.Variable("environment_id", cel.StringType),
@@ -289,7 +289,7 @@ func getTaskRiskLevel(ctx context.Context, s *store.Store, issue *store.IssueMes
 		databaseName = database.DatabaseName
 	}
 
-	e, err := cel.NewEnv(predefinedVariables...)
+	e, err := cel.NewEnv(riskFactors...)
 	if err != nil {
 		return 0, false, err
 	}

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -3,6 +3,7 @@ package approval
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"sort"
 	"sync"
@@ -227,16 +228,14 @@ func getTaskRiskLevel(ctx context.Context, s *store.Store, issue *store.IssueMes
 		return 0, err
 	}
 
-	pass, err := utils.PassAllCheck(task, api.TaskCheckStatusWarn, task.TaskCheckRunRawList, instance.Engine)
-	if err != nil {
-		return 0, err
-	}
-	if !pass {
-		return 0, nil
-	}
-
 	var databaseName string
-	if task.Type != api.TaskDatabaseCreate {
+	if task.Type == api.TaskDatabaseCreate {
+		payload := &api.TaskDatabaseCreatePayload{}
+		if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
+			return 0, err
+		}
+		databaseName = payload.DatabaseName
+	} else {
 		database, err := s.GetDatabaseV2(ctx, &store.FindDatabaseMessage{
 			UID: task.DatabaseID,
 		})

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -319,7 +319,7 @@ func getTaskRiskLevel(ctx context.Context, s *store.Store, issue *store.IssueMes
 				args := args
 				affectedRows, err := strconv.ParseInt(affectedRowsReportResult[i].Content, 10, 64)
 				if err != nil {
-					log.Warn("", zap.Error(err))
+					log.Warn("failed to convert affectedRows to int64, will use 0 as the value of affected_rows", zap.Error(err))
 				} else {
 					args["affected_rows"] = affectedRows
 				}

--- a/backend/runner/taskcheck/scheduler.go
+++ b/backend/runner/taskcheck/scheduler.go
@@ -445,11 +445,10 @@ func (*Scheduler) getPITRTaskCheck(task *store.TaskMessage, creatorID int) ([]*s
 }
 
 func getStatementTypeReportTaskCheck(task *store.TaskMessage, instance *store.InstanceMessage, dbSchema *store.DBSchema, statement string, creatorID int) ([]*store.TaskCheckRunMessage, error) {
-	if !api.IsStatementTypeReportCheckSupported(instance.Engine) {
+	if !api.IsTaskCheckReportSupported(instance.Engine) {
 		return nil, nil
 	}
-	// TBD(p0ny): approval, maybe change to issue type
-	if task.Type != api.TaskDatabaseSchemaUpdate && task.Type != api.TaskDatabaseDataUpdate && task.Type != api.TaskDatabaseSchemaUpdateGhostSync {
+	if !api.IsTaskCheckReportNeededForTaskType(task.Type) {
 		return nil, nil
 	}
 	payload, err := json.Marshal(&api.TaskCheckDatabaseStatementTypeReportPayload{
@@ -474,15 +473,10 @@ func getStatementTypeReportTaskCheck(task *store.TaskMessage, instance *store.In
 }
 
 func getStatementAffectedRowsReportTaskCheck(task *store.TaskMessage, instance *store.InstanceMessage, dbSchema *store.DBSchema, statement string, creatorID int) ([]*store.TaskCheckRunMessage, error) {
-	if !api.IsStatementAffectedRowsReportCheckSupported(instance.Engine) {
+	if !api.IsTaskCheckReportSupported(instance.Engine) {
 		return nil, nil
 	}
-	switch task.Type {
-	case api.TaskDatabaseSchemaUpdate:
-	case api.TaskDatabaseSchemaUpdateSDL:
-	case api.TaskDatabaseSchemaUpdateGhostSync:
-	case api.TaskDatabaseDataUpdate:
-	default:
+	if !api.IsTaskCheckReportNeededForTaskType(task.Type) {
 		return nil, nil
 	}
 	payload, err := json.Marshal(&api.TaskCheckDatabaseStatementAffectedRowsReportPayload{

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -63,6 +63,7 @@ import (
 	"github.com/bytebase/bytebase/backend/resources/mysqlutil"
 	"github.com/bytebase/bytebase/backend/resources/postgres"
 	"github.com/bytebase/bytebase/backend/runner/anomaly"
+	"github.com/bytebase/bytebase/backend/runner/approval"
 	"github.com/bytebase/bytebase/backend/runner/apprun"
 	"github.com/bytebase/bytebase/backend/runner/backuprun"
 	"github.com/bytebase/bytebase/backend/runner/metricreport"
@@ -140,6 +141,7 @@ type Server struct {
 	AnomalyScanner     *anomaly.Scanner
 	ApplicationRunner  *apprun.Runner
 	RollbackRunner     *rollbackrun.Runner
+	ApprovalRunner     *approval.Runner
 	runnerWG           sync.WaitGroup
 
 	ActivityManager *activity.Manager
@@ -396,6 +398,7 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 		s.ApplicationRunner = apprun.NewRunner(storeInstance, s.ActivityManager, s.feishuProvider, profile)
 		s.BackupRunner = backuprun.NewRunner(storeInstance, s.dbFactory, s.s3Client, s.stateCfg, &profile)
 		s.RollbackRunner = rollbackrun.NewRunner(storeInstance, s.dbFactory, s.stateCfg)
+		s.ApprovalRunner = approval.NewRunner(storeInstance, s.dbFactory)
 
 		s.TaskScheduler = taskrun.NewScheduler(storeInstance, s.ApplicationRunner, s.SchemaSyncer, s.ActivityManager, s.licenseService, s.stateCfg, profile, s.MetricReporter)
 		s.TaskScheduler.Register(api.TaskGeneral, taskrun.NewDefaultExecutor())
@@ -823,6 +826,8 @@ func (s *Server) Run(ctx context.Context, port int) error {
 		go s.ApplicationRunner.Run(ctx, &s.runnerWG)
 		s.runnerWG.Add(1)
 		go s.RollbackRunner.Run(ctx, &s.runnerWG)
+		s.runnerWG.Add(1)
+		go s.ApprovalRunner.Run(ctx, &s.runnerWG)
 
 		s.runnerWG.Add(1)
 		go s.MetricReporter.Run(ctx, &s.runnerWG)


### PR DESCRIPTION
- activate the approval runner
- impl factors: `affected_rows`, `sql_type`
- No more requiring passAllChecks before finding the template because loading the task check runs of the whole issue may consume lots of memory. Instead only check statementTypeReportTaskCheck & statementAffectedRowsReportTaskCheck.