### PR TITLE
fix(frontend): feature guard array index

### DIFF
--- a/frontend/src/store/modules/subscription.ts
+++ b/frontend/src/store/modules/subscription.ts
@@ -114,7 +114,7 @@ export const useSubscriptionStore = defineStore("subscription", {
         return false;
       }
 
-      return !this.isExpired && matrix[this.currentPlan];
+      return !this.isExpired && matrix[this.currentPlan - 1];
     },
     getMinimumRequiredPlan(type: FeatureType): PlanType {
       const matrix = this.featureMatrix.get(type);


### PR DESCRIPTION
```
export enum PlanType {
  PLAN_TYPE_UNSPECIFIED = 0,
  FREE = 1,
  TEAM = 2,
  ENTERPRISE = 3,
  UNRECOGNIZED = -1,
}
```
A feature matrix item is [ boolean, boolean, boolean ] so we should use `currentPlan - 1` as the array index.
@ecmadao PTAL