### PR TITLE
fix(frontend): roll forward pr 5248

### DIFF
--- a/frontend/src/store/modules/subscription.ts
+++ b/frontend/src/store/modules/subscription.ts
@@ -114,7 +114,7 @@ export const useSubscriptionStore = defineStore("subscription", {
         return false;
       }
 
-      return !this.isExpired && matrix[this.currentPlan];
+      return !this.isExpired && matrix[this.currentPlan - 1];
     },
     getMinimumRequiredPlan(type: FeatureType): PlanType {
       const matrix = this.featureMatrix.get(type);


### PR DESCRIPTION
- #5238 was incorrectly cherry-picked into release/1.15.0
- #5248 reverts #5238, and cherry-picked into release/1.15.0 via #5249 

Now we will roll forward this change again and we SHOULD NOT cherry-pick this into release/1.15.0