### PR TITLE
feat(backend): support add redshift in backend

### DIFF
--- a/backend/plugin/db/redshift/dump.go
+++ b/backend/plugin/db/redshift/dump.go
@@ -1,19 +1,19 @@
+// Package redshift is the plugin for RedShift driver.
 package redshift
 
 import (
 	"context"
 	"io"
+
+	"github.com/pkg/errors"
 )
 
-// Dump and restore
-// Dump the database, if dbName is empty, then dump all databases.
-// The returned string is the JSON encoded metadata for the logical dump.
-// For MySQL, the payload contains the binlog filename and position when the dump is generated.
-func (_ *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
+// Dump dumps the database to the writer. But not implemented yet.
+func (*Driver) Dump(context.Context, string, io.Writer, bool) (string, error) {
 	return "", nil
 }
 
 // Restore the database from src, which is a full backup.
-func (_ *Driver) Restore(ctx context.Context, src io.Reader) error {
-	return nil
+func (*Driver) Restore(context.Context, io.Reader) error {
+	return errors.Errorf("not implemented")
 }

--- a/backend/plugin/db/redshift/dump.go
+++ b/backend/plugin/db/redshift/dump.go
@@ -1,0 +1,19 @@
+package redshift
+
+import (
+	"context"
+	"io"
+)
+
+// Dump and restore
+// Dump the database, if dbName is empty, then dump all databases.
+// The returned string is the JSON encoded metadata for the logical dump.
+// For MySQL, the payload contains the binlog filename and position when the dump is generated.
+func (_ *Driver) Dump(ctx context.Context, database string, out io.Writer, schemaOnly bool) (string, error) {
+	return "", nil
+}
+
+// Restore the database from src, which is a full backup.
+func (_ *Driver) Restore(ctx context.Context, src io.Reader) error {
+	return nil
+}

--- a/backend/plugin/db/redshift/migrate.go
+++ b/backend/plugin/db/redshift/migrate.go
@@ -1,0 +1,36 @@
+package redshift
+
+import (
+	"context"
+	"errors"
+
+	"github.com/bytebase/bytebase/backend/plugin/db"
+	"github.com/bytebase/bytebase/backend/plugin/db/util"
+)
+
+// Migration related.
+
+// NeedsSetupMigration checks whether we need to setup migration (e.g. creating/upgrading the migration related tables).
+func (*Driver) NeedsSetupMigration(context.Context) (bool, error) {
+	return false, nil
+}
+
+// SetupMigrationIfNeeded create or upgrade migration related tables.
+func (*Driver) SetupMigrationIfNeeded(context.Context) error {
+	return nil
+}
+
+// ExecuteMigration executes a migration.
+// ExecuteMigration will execute the database migration.
+// Returns the created migration history id and the updated schema on success.
+func (d *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (migrationHistoryID string, updatedSchema string, resErr error) {
+	if _, err := d.Execute(ctx, statement, m.CreateDatabase); err != nil {
+		return "", "", util.FormatError(err)
+	}
+	return "", "", nil
+}
+
+// FindMigrationHistoryList finds the migration history list and return most recent item first.
+func (*Driver) FindMigrationHistoryList(context.Context, *db.MigrationHistoryFind) ([]*db.MigrationHistory, error) {
+	return nil, errors.New("unsupported")
+}

--- a/backend/plugin/db/redshift/redshift.go
+++ b/backend/plugin/db/redshift/redshift.go
@@ -1,9 +1,11 @@
+// Package redshift is the plugin for RedShift driver.
 package redshift
 
 import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -13,10 +15,19 @@ import (
 
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/plugin/db"
+	"github.com/bytebase/bytebase/backend/plugin/db/util"
+	"github.com/bytebase/bytebase/backend/plugin/parser"
 )
 
 var (
-	excludedDatabaseList = map[string]bool{}
+	excludedDatabaseList = map[string]bool{
+		// Skip internal databases from cloud service providers
+		// aws
+		"padb_harvest": true,
+		// system templates.
+		"template0": true,
+		"template1": true,
+	}
 
 	// driverName is the driver name that our driver dependence register, now is "pgx".
 	driverName = "pgx"
@@ -41,14 +52,12 @@ type Driver struct {
 	databaseName     string
 }
 
-func newDriver(config db.DriverConfig) db.Driver {
+func newDriver(db.DriverConfig) db.Driver {
 	return &Driver{}
 }
 
-// General execution
-// A driver might support multiple engines (e.g. MySQL driver can support both MySQL and TiDB),
-// So we pass the dbType to tell the exact engine.
-func (driver *Driver) Open(ctx context.Context, dbType db.Type, config db.ConnectionConfig, connCtx db.ConnectionContext) (db.Driver, error) {
+// Open opens a redshift database, it may just check the connection string is valid depends on the pgx driver.
+func (driver *Driver) Open(_ context.Context, _ db.Type, config db.ConnectionConfig, connCtx db.ConnectionContext) (db.Driver, error) {
 	// Require username for Postgres, as the guessDSN 1st guess is to use the username as the connecting database
 	// if database name is not explicitly specified.
 	if config.Username == "" {
@@ -147,10 +156,11 @@ func guessDSN(username, password, hostname, port, database, sslCA, sslCert, sslK
 		return database, dsn, nil
 	}
 
-	// The dafault database name is "dev" for Redshift.
-	guesses := []string{"dev"}
+	// Redshift disallows us connect to template0 and template1, so only guess the username and dev database which is the default database.
+	//
+	guessDatabases := []string{username, "dev"}
 	//  dsn+" dbname=bytebase"
-	for _, guessDatabase := range guesses {
+	for _, guessDatabase := range guessDatabases {
 		guessDSN := fmt.Sprintf("%s dbname=%s", dsn, guessDatabase)
 		if err := func() error {
 			connectionString, err := registerConnectionConfig(guessDSN, tlsConfig)
@@ -165,7 +175,7 @@ func guessDSN(username, password, hostname, port, database, sslCA, sslCert, sslK
 			defer db.Close()
 			return db.Ping()
 		}(); err != nil {
-			log.Debug("guessDSN attemp	t failed", zap.Error(err))
+			log.Debug("guessDSN attempt failed", zap.Error(err))
 			continue
 		}
 		return guessDatabase, guessDSN, nil
@@ -175,32 +185,279 @@ func guessDSN(username, password, hostname, port, database, sslCA, sslCert, sslK
 
 // Close closes the database and prevents new queries from starting.
 // Close then waits for all queries that have started processing on the server to finish.
-func (d *Driver) Close(_ context.Context) error {
-	return d.db.Close()
+func (driver *Driver) Close(_ context.Context) error {
+	return driver.db.Close()
 }
 
 // Ping verifies a connection to the database is still alive, establishing a connection if necessary.
-func (d *Driver) Ping(ctx context.Context) error {
-	return d.db.PingContext(ctx)
+func (driver *Driver) Ping(ctx context.Context) error {
+	return driver.db.PingContext(ctx)
 }
 
 // GetType returns the database type.
-func (d *Driver) GetType() db.Type {
+func (*Driver) GetType() db.Type {
 	return db.Redshift
 }
 
 // GetDBConnection returns the database connection.
-func (d *Driver) GetDBConnection(ctx context.Context, database string) (*sql.DB, error) {
-	return nil, errors.Errorf("get db connection for Redshift is not implemented yet")
+func (driver *Driver) GetDBConnection(_ context.Context, database string) (*sql.DB, error) {
+	if err := driver.switchDatabase(database); err != nil {
+		return nil, err
+	}
+	return driver.db, nil
+}
+
+func (driver *Driver) switchDatabase(dbName string) error {
+	if driver.db != nil {
+		unregisterConnectionConfig(driver.connectionString)
+		if err := driver.db.Close(); err != nil {
+			return err
+		}
+	}
+
+	dsn := driver.baseDSN + " dbname=" + dbName
+
+	connectionString, err := registerConnectionConfig(dsn, driver.config.TLSConfig)
+	if err != nil {
+		return err
+	}
+	driver.connectionString = connectionString
+
+	db, err := sql.Open(driverName, driver.connectionString)
+	if err != nil {
+		return err
+	}
+	driver.db = db
+	driver.databaseName = dbName
+	return nil
 }
 
 // Execute will execute the statement. For CREATE DATABASE statement, some types of databases such as Postgres
 // will not use transactions to execute the statement but will still use transactions to execute the rest of statements.
-func (d *Driver) Execute(ctx context.Context, statement string, createDatabase bool) (int64, error) {
-	return 0, errors.Errorf("execute for Redshift is not implemented yet")
+func (driver *Driver) Execute(ctx context.Context, statement string, createDatabase bool) (int64, error) {
+	owner, err := driver.GetCurrentDatabaseOwner()
+	if err != nil {
+		return 0, err
+	}
+
+	connected := false
+	var remainingStmts []string
+	var nonTransactionStmts []string
+	totalRowsAffected := int64(0)
+	f := func(stmt string) error {
+		// We don't use transaction for creating / altering databases in Postgres.
+		// We will execute the statement directly before "\\connect" statement.
+		// https://github.com/bytebase/bytebase/issues/202
+		if createDatabase && !connected {
+			if strings.HasPrefix(stmt, "CREATE DATABASE ") {
+				databases, err := driver.getDatabases(ctx)
+				if err != nil {
+					return err
+				}
+				databaseName, err := getDatabaseInCreateDatabaseStatement(stmt)
+				if err != nil {
+					return err
+				}
+				exist := false
+				for _, database := range databases {
+					if database.Name == databaseName {
+						exist = true
+						break
+					}
+				}
+				if !exist {
+					if _, err := driver.db.ExecContext(ctx, stmt); err != nil {
+						return err
+					}
+				}
+			} else if strings.HasPrefix(stmt, "ALTER DATABASE") && strings.Contains(stmt, " OWNER TO ") {
+				if _, err := driver.db.ExecContext(ctx, stmt); err != nil {
+					return err
+				}
+			} else if strings.HasPrefix(stmt, "\\connect ") {
+				// For the case of `\connect "dbname";`, we need to use GetDBConnection() instead of executing the statement.
+				parts := strings.Split(stmt, `"`)
+				if len(parts) != 3 {
+					return errors.Errorf("invalid statement %q", stmt)
+				}
+				if _, err = driver.GetDBConnection(ctx, parts[1]); err != nil {
+					return err
+				}
+				// Update current owner
+				if owner, err = driver.GetCurrentDatabaseOwner(); err != nil {
+					return err
+				}
+				connected = true
+			} else {
+				sqlResult, err := driver.db.ExecContext(ctx, stmt)
+				if err != nil {
+					return err
+				}
+				rowsAffected, err := sqlResult.RowsAffected()
+				if err != nil {
+					// Since we cannot differentiate DDL and DML yet, we have to ignore the error.
+					log.Debug("rowsAffected returns error", zap.Error(err))
+				} else {
+					totalRowsAffected += rowsAffected
+				}
+			}
+		} else {
+			if isSuperuserStatement(stmt) {
+				// CREATE EVENT TRIGGER statement only supports EXECUTE PROCEDURE in version 10 and before, while newer version supports both EXECUTE { FUNCTION | PROCEDURE }.
+				// Since we use pg_dump version 14, the dump uses a new style even for an old version of PostgreSQL.
+				// We should convert EXECUTE FUNCTION to EXECUTE PROCEDURE to make the restoration work on old versions.
+				// https://www.postgresql.org/docs/14/sql-createeventtrigger.html
+				if strings.Contains(strings.ToUpper(stmt), "CREATE EVENT TRIGGER") {
+					stmt = strings.ReplaceAll(stmt, "EXECUTE FUNCTION", "EXECUTE PROCEDURE")
+				}
+				// Use superuser privilege to run privileged statements.
+				stmt = fmt.Sprintf("SET LOCAL ROLE NONE;%sSET LOCAL ROLE '%s';", stmt, owner)
+				remainingStmts = append(remainingStmts, stmt)
+			} else if isNonTransactionStatement(stmt) {
+				nonTransactionStmts = append(nonTransactionStmts, stmt)
+			} else if !isIgnoredStatement(stmt) {
+				remainingStmts = append(remainingStmts, stmt)
+			}
+		}
+		return nil
+	}
+
+	if _, err := parser.SplitMultiSQLStream(parser.Redshift, strings.NewReader(statement), f); err != nil {
+		return 0, err
+	}
+
+	if len(remainingStmts) != 0 {
+		tx, err := driver.db.BeginTx(ctx, nil)
+		if err != nil {
+			return 0, err
+		}
+		defer tx.Rollback()
+
+		// Set the current transaction role to the database owner so that the owner of created database will be the same as the database owner.
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL ROLE '%s'", owner)); err != nil {
+			return 0, err
+		}
+
+		sqlResult, err := tx.ExecContext(ctx, strings.Join(remainingStmts, "\n"))
+		if err != nil {
+			return 0, err
+		}
+		if err := tx.Commit(); err != nil {
+			return 0, err
+		}
+		rowsAffected, err := sqlResult.RowsAffected()
+		if err != nil {
+			// Since we cannot differentiate DDL and DML yet, we have to ignore the error.
+			log.Debug("rowsAffected returns error", zap.Error(err))
+		} else {
+			totalRowsAffected += rowsAffected
+		}
+	}
+
+	// Run non-transaction statements at the end.
+	for _, stmt := range nonTransactionStmts {
+		if _, err := driver.db.Exec(stmt); err != nil {
+			return 0, err
+		}
+	}
+	return totalRowsAffected, nil
 }
 
-// Used for execute readonly SELECT statement
-func (d *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string, queryContext *db.QueryContext) ([]interface{}, error) {
-	return nil, errors.Errorf("query conn for Redshift is not implemented yet")
+func isSuperuserStatement(stmt string) bool {
+	upperCaseStmt := strings.ToUpper(stmt)
+	if strings.HasPrefix(upperCaseStmt, "GRANT") || strings.HasPrefix(upperCaseStmt, "CREATE EXTENSION") || strings.HasPrefix(upperCaseStmt, "CREATE EVENT TRIGGER") || strings.HasPrefix(upperCaseStmt, "COMMENT ON EVENT TRIGGER") {
+		return true
+	}
+	return false
+}
+
+func isIgnoredStatement(stmt string) bool {
+	// Extensions created in AWS Aurora PostgreSQL are owned by rdsadmin.
+	// We don't have privileges to comment on the extension and have to ignore it.
+	upperCaseStmt := strings.ToUpper(stmt)
+	return strings.HasPrefix(upperCaseStmt, "COMMENT ON EXTENSION")
+}
+
+func isNonTransactionStatement(stmt string) bool {
+	// CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+	// CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ [ IF NOT EXISTS ] name ] ON [ ONLY ] table_name [ USING method ] ...
+	createIndexReg := regexp.MustCompile(`(?i)CREATE(\s+(UNIQUE\s+)?)INDEX(\s+)CONCURRENTLY`)
+	if len(createIndexReg.FindString(stmt)) > 0 {
+		return true
+	}
+
+	// DROP INDEX CONCURRENTLY cannot run inside a transaction block.
+	// DROP INDEX [ CONCURRENTLY ] [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
+	dropIndexReg := regexp.MustCompile(`(?i)DROP(\s+)INDEX(\s+)CONCURRENTLY`)
+	return len(dropIndexReg.FindString(stmt)) > 0
+}
+
+func getDatabaseInCreateDatabaseStatement(createDatabaseStatement string) (string, error) {
+	raw := strings.TrimRight(createDatabaseStatement, ";")
+	raw = strings.TrimPrefix(raw, "CREATE DATABASE")
+	tokens := strings.Fields(raw)
+	if len(tokens) == 0 {
+		return "", errors.Errorf("database name not found")
+	}
+	databaseName := strings.TrimLeft(tokens[0], `"`)
+	databaseName = strings.TrimRight(databaseName, `"`)
+	return databaseName, nil
+}
+
+// QueryConn will query the database using the provided connection, it is useful for keeping the context of the connection.
+func (*Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string, queryContext *db.QueryContext) ([]interface{}, error) {
+	singleSQLs, err := parser.SplitMultiSQL(parser.Postgres, statement)
+	if err != nil {
+		return nil, err
+	}
+	if len(singleSQLs) == 0 {
+		return nil, nil
+	}
+
+	// If the statement is an INSERT, UPDATE, or DELETE statement, we will call execute instead of query and return the number of rows affected.
+	// https://github.com/postgres/postgres/blob/master/src/bin/psql/common.c#L969
+	if len(singleSQLs) == 1 && util.IsAffectedRowsStatement(singleSQLs[0].Text) {
+		sqlResult, err := conn.ExecContext(ctx, singleSQLs[0].Text)
+		if err != nil {
+			return nil, err
+		}
+		affectedRows, err := sqlResult.RowsAffected()
+		if err != nil {
+			return nil, err
+		}
+		field := []string{"Affected Rows"}
+		types := []string{"INT"}
+		rows := [][]interface{}{{affectedRows}}
+		return []interface{}{field, types, rows}, nil
+	}
+	return util.Query(ctx, db.Postgres, conn, statement, queryContext)
+}
+
+// GetCurrentDatabaseOwner returns the current database owner name.
+func (driver *Driver) GetCurrentDatabaseOwner() (string, error) {
+	const query = `
+		SELECT
+			u.usename
+		FROM
+			pg_database as d JOIN pg_user as u ON (d.datdba = u.usesysid)
+		WHERE d.datname = current_database();
+	`
+	var owner string
+	rows, err := driver.db.Query(query)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := rows.Scan(&owner); err != nil {
+			return "", err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if owner == "" {
+		return "", errors.Errorf("cannot find the current database owner because the query result is empty")
+	}
+	return owner, nil
 }

--- a/backend/plugin/db/redshift/redshift.go
+++ b/backend/plugin/db/redshift/redshift.go
@@ -1,0 +1,206 @@
+package redshift
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/bytebase/bytebase/backend/common/log"
+	"github.com/bytebase/bytebase/backend/plugin/db"
+)
+
+var (
+	excludedDatabaseList = map[string]bool{}
+
+	// driverName is the driver name that our driver dependence register, now is "pgx".
+	driverName = "pgx"
+
+	_ db.Driver = (*Driver)(nil)
+)
+
+func init() {
+	db.Register(db.Redshift, newDriver)
+}
+
+// Driver is the Postgres driver.
+type Driver struct {
+	connectionCtx db.ConnectionContext
+	config        db.ConnectionConfig
+
+	db *sql.DB
+	// connectionString is the connection string registered by pgx.
+	// Unregister connectionString if we don't need it.
+	connectionString string
+	baseDSN          string
+	databaseName     string
+}
+
+func newDriver(config db.DriverConfig) db.Driver {
+	return &Driver{}
+}
+
+// General execution
+// A driver might support multiple engines (e.g. MySQL driver can support both MySQL and TiDB),
+// So we pass the dbType to tell the exact engine.
+func (driver *Driver) Open(ctx context.Context, dbType db.Type, config db.ConnectionConfig, connCtx db.ConnectionContext) (db.Driver, error) {
+	// Require username for Postgres, as the guessDSN 1st guess is to use the username as the connecting database
+	// if database name is not explicitly specified.
+	if config.Username == "" {
+		return nil, errors.Errorf("user must be set")
+	}
+
+	if (config.TLSConfig.SslCert == "" && config.TLSConfig.SslKey != "") ||
+		(config.TLSConfig.SslCert != "" && config.TLSConfig.SslKey == "") {
+		return nil, errors.Errorf("ssl-cert and ssl-key must be both set or unset")
+	}
+
+	databaseName, dsn, err := guessDSN(
+		config.Username,
+		config.Password,
+		config.Host,
+		config.Port,
+		config.Database,
+		config.TLSConfig.SslCA,
+		config.TLSConfig.SslCert,
+		config.TLSConfig.SslKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if config.ReadOnly {
+		dsn = fmt.Sprintf("%s default_transaction_read_only=true", dsn)
+	}
+	driver.databaseName = databaseName
+	driver.baseDSN = dsn
+	driver.connectionCtx = connCtx
+	driver.config = config
+
+	connectionString, err := registerConnectionConfig(dsn, driver.config.TLSConfig)
+	if err != nil {
+		return nil, err
+	}
+	driver.connectionString = connectionString
+
+	db, err := sql.Open(driverName, driver.connectionString)
+	if err != nil {
+		return nil, err
+	}
+	driver.db = db
+	return driver, nil
+}
+
+func registerConnectionConfig(dsn string, tlsConfig db.TLSConfig) (string, error) {
+	connConfig, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return "", err
+	}
+
+	if tlsConfig.SslCA != "" {
+		sslConfig, err := tlsConfig.GetSslConfig()
+		if err != nil {
+			return "", err
+		}
+		connConfig.TLSConfig = sslConfig
+	}
+
+	return stdlib.RegisterConnConfig(connConfig), nil
+}
+
+func unregisterConnectionConfig(connectionString string) {
+	stdlib.UnregisterConnConfig(connectionString)
+}
+
+// guessDSN will guess a valid DB connection and its database name.
+func guessDSN(username, password, hostname, port, database, sslCA, sslCert, sslKey string) (string, string, error) {
+	// dbname is guessed if not specified.
+	m := map[string]string{
+		"host":     hostname,
+		"port":     port,
+		"user":     username,
+		"password": password,
+	}
+	if database != "" {
+		m["dbname"] = database
+	}
+
+	tlsConfig := db.TLSConfig{
+		SslCA:   sslCA,
+		SslCert: sslCert,
+		SslKey:  sslKey,
+	}
+
+	var tokens []string
+	for k, v := range m {
+		if v != "" {
+			tokens = append(tokens, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+	dsn := strings.Join(tokens, " ")
+
+	if database != "" {
+		return database, dsn, nil
+	}
+
+	// The dafault database name is "dev" for Redshift.
+	guesses := []string{"dev"}
+	//  dsn+" dbname=bytebase"
+	for _, guessDatabase := range guesses {
+		guessDSN := fmt.Sprintf("%s dbname=%s", dsn, guessDatabase)
+		if err := func() error {
+			connectionString, err := registerConnectionConfig(guessDSN, tlsConfig)
+			if err != nil {
+				return err
+			}
+			defer unregisterConnectionConfig(connectionString)
+			db, err := sql.Open(driverName, connectionString)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			return db.Ping()
+		}(); err != nil {
+			log.Debug("guessDSN attemp	t failed", zap.Error(err))
+			continue
+		}
+		return guessDatabase, guessDSN, nil
+	}
+	return "", "", errors.Errorf("cannot connect to the instance, make sure the connection info is correct")
+}
+
+// Close closes the database and prevents new queries from starting.
+// Close then waits for all queries that have started processing on the server to finish.
+func (d *Driver) Close(_ context.Context) error {
+	return d.db.Close()
+}
+
+// Ping verifies a connection to the database is still alive, establishing a connection if necessary.
+func (d *Driver) Ping(ctx context.Context) error {
+	return d.db.PingContext(ctx)
+}
+
+// GetType returns the database type.
+func (d *Driver) GetType() db.Type {
+	return db.Redshift
+}
+
+// GetDBConnection returns the database connection.
+func (d *Driver) GetDBConnection(ctx context.Context, database string) (*sql.DB, error) {
+	return nil, errors.Errorf("get db connection for Redshift is not implemented yet")
+}
+
+// Execute will execute the statement. For CREATE DATABASE statement, some types of databases such as Postgres
+// will not use transactions to execute the statement but will still use transactions to execute the rest of statements.
+func (d *Driver) Execute(ctx context.Context, statement string, createDatabase bool) (int64, error) {
+	return 0, errors.Errorf("execute for Redshift is not implemented yet")
+}
+
+// Used for execute readonly SELECT statement
+func (d *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string, queryContext *db.QueryContext) ([]interface{}, error) {
+	return nil, errors.Errorf("query conn for Redshift is not implemented yet")
+}

--- a/backend/plugin/db/redshift/role.go
+++ b/backend/plugin/db/redshift/role.go
@@ -1,0 +1,34 @@
+package redshift
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/backend/plugin/db"
+)
+
+// CreateRole creates the role.
+func (*Driver) CreateRole(_ context.Context, _ *db.DatabaseRoleUpsertMessage) (*db.DatabaseRoleMessage, error) {
+	return nil, errors.Errorf("create role for MSSQL is not implemented yet")
+}
+
+// UpdateRole updates the role.
+func (*Driver) UpdateRole(_ context.Context, _ string, _ *db.DatabaseRoleUpsertMessage) (*db.DatabaseRoleMessage, error) {
+	return nil, errors.Errorf("update role for MSSQL is not implemented yet")
+}
+
+// FindRole finds the role by name.
+func (*Driver) FindRole(_ context.Context, _ string) (*db.DatabaseRoleMessage, error) {
+	return nil, errors.Errorf("find role for MSSQL is not implemented yet")
+}
+
+// ListRole lists the role.
+func (*Driver) ListRole(_ context.Context) ([]*db.DatabaseRoleMessage, error) {
+	return nil, errors.Errorf("list role for MSSQL is not implemented yet")
+}
+
+// DeleteRole deletes the role by name.
+func (*Driver) DeleteRole(_ context.Context, _ string) error {
+	return errors.Errorf("delete role for MSSQL is not implemented yet")
+}

--- a/backend/plugin/db/redshift/sync.go
+++ b/backend/plugin/db/redshift/sync.go
@@ -1,20 +1,219 @@
+// Package redshift is the plugin for RedShift driver.
 package redshift
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
+	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
 // SyncInstance syncs the instance.
 func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error) {
-	return nil, errors.Errorf("sync instance for Redshift is not implemented yet")
+	version, err := driver.getVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	instanceRoles, err := driver.getInstanceRoles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	databases, err := driver.getDatabases(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get databases")
+	}
+
+	var filteredDatabases []*storepb.DatabaseMetadata
+	for _, database := range databases {
+		// Skip all system databases
+		if _, ok := excludedDatabaseList[database.Name]; ok {
+			continue
+		}
+		filteredDatabases = append(filteredDatabases, database)
+	}
+
+	return &db.InstanceMetadata{
+		Version:       version,
+		InstanceRoles: instanceRoles,
+		Databases:     filteredDatabases,
+	}, nil
+}
+
+func (driver *Driver) getInstanceRoles(ctx context.Context) ([]*storepb.InstanceRoleMetadata, error) {
+	// Reference: https://sourcegraph.com/github.com/postgres/postgres@REL_14_0/-/blob/src/bin/psql/describe.c?L3792
+	query := `
+	SELECT
+		u.usename AS rolename,
+		u.usesuper AS rolsuper,
+		true AS rolinherit,
+		false AS rolcreaterole,
+		u.usecreatedb AS rolcreatedb,
+		true AS rolcanlogin,
+		-1 AS rolconnlimit,
+		u.valuntil as rolvaliduntil
+	FROM pg_catalog.pg_user u
+	ORDER BY 1;
+	`
+	var instanceRoles []*storepb.InstanceRoleMetadata
+	rows, err := driver.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var role string
+		var super, inherit, createrole, createdb, canLogin bool
+		var connectionLimit int32
+		var validUntil sql.NullString
+		if err := rows.Scan(
+			&role,
+			&super,
+			&inherit,
+			&createrole,
+			&createdb,
+			&canLogin,
+			&connectionLimit,
+			&validUntil,
+		); err != nil {
+			return nil, err
+		}
+
+		var attributes []string
+		if super {
+			attributes = append(attributes, "Superuser")
+		}
+		if !inherit {
+			attributes = append(attributes, "No inheritance")
+		}
+		if createrole {
+			attributes = append(attributes, "Create role")
+		}
+		if createdb {
+			attributes = append(attributes, "Create DB")
+		}
+		if !canLogin {
+			attributes = append(attributes, "Cannot login")
+		}
+		if connectionLimit >= 0 {
+			if connectionLimit == 0 {
+				attributes = append(attributes, "No connections")
+			} else if connectionLimit == 1 {
+				attributes = append(attributes, "1 connection")
+			} else {
+				attributes = append(attributes, fmt.Sprintf("%d connections", connectionLimit))
+			}
+		}
+		if validUntil.Valid {
+			attributes = append(attributes, fmt.Sprintf("Password valid until %s", validUntil.String))
+		}
+		instanceRoles = append(instanceRoles, &storepb.InstanceRoleMetadata{
+			Name:  role,
+			Grant: strings.Join(attributes, ", "),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return instanceRoles, nil
 }
 
 // SyncDBSchema syncs a single database schema.
-func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*storepb.DatabaseMetadata, error) {
-	return nil, errors.Errorf("sync instance for Redshift is not implemented yet")
+func (*Driver) SyncDBSchema(_ context.Context, _ string) (*storepb.DatabaseMetadata, error) {
+	// TODO(zp): implement it.
+	return &storepb.DatabaseMetadata{}, nil
+}
+
+func (driver *Driver) getVersion(ctx context.Context) (string, error) {
+	// Redshift doesn't support SHOW server_version to retrieve the clean version number.
+	// We can parse the output of `SELECT version()` to get the PostgreSQL version and the
+	// Redshift version because Redshift is based on PostgreSQL.
+	// For example, the output of `SELECT version()` is:
+	// PostgreSQL 8.0.2 on i686-pc-linux-gnu, compiled by GCC gcc (GCC) 3.4.2 20041017 (Red Hat 3.4.2-6.fc3), Redshift 1.0.48042
+	// We will return the 'Redshift 1.0.48042 based on PostgreSQL 8.0.2'.
+	rows, err := driver.db.QueryContext(ctx, "SELECT version()")
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	var version string
+	for rows.Next() {
+		if err := rows.Scan(&version); err != nil {
+			return "", err
+		}
+	}
+	// We try to parse the version string to get the PostgreSQL version and the Redshift version, but it's not a big deal if we fail.
+	// We will just return the version string as is.
+	pgVersion, redshiftVersion, err := getPgVersionAndRedshiftVersion(version)
+	if err != nil {
+		log.Debug("Failed to parse version string", zap.String("version", version))
+		// nolint
+		return version, nil
+	}
+	return buildRedshiftVersionString(redshiftVersion, pgVersion), nil
+}
+
+// parseVersionRegex is a regex to parse the output from Redshift's `SELECT version()`, captures the PostgreSQL version and the Redshift version.
+var parseVersionRegex = regexp.MustCompile(`(?i)^PostgreSQL (?P<pgVersion>\d+\.\d+\.\d+) on .*, Redshift (?P<redshiftVersion>\d+\.\d+\.\d+)`)
+
+// getPgVersionAndRedshiftVersion parses the output from Redshift's `SELECT version()` to get the PostgreSQL version and the Redshift version.
+func getPgVersionAndRedshiftVersion(version string) (string, string, error) {
+	matches := parseVersionRegex.FindStringSubmatch(version)
+	if len(matches) == 0 {
+		return "", "", errors.Errorf("unable to parse version string: %s", version)
+	}
+
+	pgVersion := ""
+	redshiftVersion := ""
+	for i, name := range parseVersionRegex.SubexpNames() {
+		if i != 0 && name != "" {
+			switch name {
+			case "pgVersion":
+				pgVersion = matches[i]
+			case "redshiftVersion":
+				redshiftVersion = matches[i]
+			}
+		}
+	}
+
+	return pgVersion, redshiftVersion, nil
+}
+
+// buildRedshiftVersionString builds the Redshift version string, format is "Redshift <redshiftVersion> based on PostgreSQL <postgresVersion>".
+func buildRedshiftVersionString(redshiftVersion, postgresVersion string) string {
+	return "Redshift " + redshiftVersion + " based on PostgreSQL " + postgresVersion
+}
+
+// getDatabases gets all databases of an instance.
+func (driver *Driver) getDatabases(ctx context.Context) ([]*storepb.DatabaseMetadata, error) {
+	var databases []*storepb.DatabaseMetadata
+	rows, err := driver.db.QueryContext(ctx, `
+		SELECT datname,
+		pg_encoding_to_char(encoding)
+		FROM pg_database;
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		database := storepb.DatabaseMetadata{}
+		if err := rows.Scan(&database.Name, &database.CharacterSet); err != nil {
+			return nil, err
+		}
+		databases = append(databases, &database)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return databases, nil
 }

--- a/backend/plugin/db/redshift/sync.go
+++ b/backend/plugin/db/redshift/sync.go
@@ -1,0 +1,20 @@
+package redshift
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/backend/plugin/db"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+)
+
+// SyncInstance syncs the instance.
+func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error) {
+	return nil, errors.Errorf("sync instance for Redshift is not implemented yet")
+}
+
+// SyncDBSchema syncs a single database schema.
+func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*storepb.DatabaseMetadata, error) {
+	return nil, errors.Errorf("sync instance for Redshift is not implemented yet")
+}

--- a/backend/plugin/db/redshift/sync_test.go
+++ b/backend/plugin/db/redshift/sync_test.go
@@ -1,0 +1,34 @@
+package redshift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPgVersionAndRedshiftVersion(t *testing.T) {
+	testCases := []struct {
+		version      string
+		wantPg       string
+		wantRedshift string
+		wantErr      bool
+	}{
+		{
+			version:      "PostgreSQL 8.0.2 on i686-pc-linux-gnu, compiled by GCC gcc (GCC) 3.4.2 20041017 (Red Hat 3.4.2-6.fc3), Redshift 1.0.48042",
+			wantPg:       "8.0.2",
+			wantRedshift: "1.0.48042",
+			wantErr:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		pg, redshift, err := getPgVersionAndRedshiftVersion(tc.version)
+		if tc.wantErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tc.wantPg, pg)
+			require.Equal(t, tc.wantRedshift, redshift)
+		}
+	}
+}

--- a/backend/plugin/parser/parser.go
+++ b/backend/plugin/parser/parser.go
@@ -28,6 +28,8 @@ const (
 	Oracle EngineType = "ORACLE"
 	// MSSQL is the engine type for MSSQL.
 	MSSQL EngineType = "MSSQL"
+	// Redshift is the engine type for redshift.
+	Redshift EngineType = "REDSHIFT"
 
 	// DeparseIndentString is the string for each indent level.
 	DeparseIndentString = "    "

--- a/backend/plugin/parser/utils.go
+++ b/backend/plugin/parser/utils.go
@@ -33,7 +33,7 @@ func SplitMultiSQL(engineType EngineType, statement string) ([]SingleSQL, error)
 	case Oracle, MSSQL:
 		t := newTokenizer(statement)
 		list, err = t.splitStandardMultiSQL()
-	case Postgres:
+	case Postgres, Redshift:
 		t := newTokenizer(statement)
 		list, err = t.splitPostgreSQLMultiSQL()
 	case MySQL, TiDB, MariaDB:
@@ -68,7 +68,7 @@ func SplitMultiSQLStream(engineType EngineType, src io.Reader, f func(string) er
 	case Oracle, MSSQL:
 		t := newStreamTokenizer(src, f)
 		list, err = t.splitStandardMultiSQL()
-	case Postgres:
+	case Postgres, Redshift:
 		t := newStreamTokenizer(src, f)
 		list, err = t.splitPostgreSQLMultiSQL()
 	case MySQL, TiDB, MariaDB:

--- a/backend/runner/taskrun/database_create_executor.go
+++ b/backend/runner/taskrun/database_create_executor.go
@@ -266,6 +266,8 @@ func getConnectionStatement(dbType db.Type, databaseName string) (string, error)
 		// We embed mongosh to execute the mongodb statement, and `use` statement is not effective in mongosh.
 		// We will connect to the specified database by specifying the database name in the connection string.
 		return "", nil
+	case db.Redshift:
+		return fmt.Sprintf("\\connect \"%s\";\n", databaseName), nil
 	}
 
 	return "", errors.Errorf("unsupported database type %s", dbType)

--- a/backend/server/database.go
+++ b/backend/server/database.go
@@ -630,6 +630,7 @@ func (s *Server) registerDatabaseRoutes(g *echo.Group) {
 			Username:      dataSourcePatch.Username,
 			Host:          dataSourcePatch.Host,
 			Port:          dataSourcePatch.Port,
+			Database:      dataSourcePatch.Database,
 		}
 		if dataSourcePatch.Password != nil {
 			obfuscated := common.Obfuscate(*dataSourcePatch.Password, s.secret)

--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -1301,6 +1301,25 @@ func getCreateDatabaseStatement(dbType db.Type, createDatabaseContext api.Create
 		return fmt.Sprintf("CREATE DATABASE %s", databaseName), nil
 	case db.Oracle:
 		return fmt.Sprintf("CREATE DATABASE %s", databaseName), nil
+	case db.Redshift:
+		if adminDatasourceUser != "" && createDatabaseContext.Owner != adminDatasourceUser {
+			stmt = fmt.Sprintf("GRANT \"%s\" TO \"%s\";\n", createDatabaseContext.Owner, adminDatasourceUser)
+		}
+		if createDatabaseContext.Collation == "" {
+			stmt = fmt.Sprintf("%sCREATE DATABASE \"%s\" ENCODING '%s';", stmt, databaseName, createDatabaseContext.CharacterSet)
+		} else {
+			stmt = fmt.Sprintf("%sCREATE DATABASE \"%s\" ENCODING '%s' LC_COLLATE '%s';", stmt, databaseName, createDatabaseContext.CharacterSet, createDatabaseContext.Collation)
+		}
+		// Set the database owner.
+		// We didn't use CREATE DATABASE WITH OWNER because RDS requires the current role to be a member of the database owner.
+		// However, people can still use ALTER DATABASE to change the owner afterwards.
+		// Error string below:
+		// query: CREATE DATABASE h1 WITH OWNER hello;
+		// ERROR:  must be member of role "hello"
+		//
+		// For tenant project, the schema for the newly created database will belong to the same owner.
+		// TODO(d): alter schema "public" owner to the database owner.
+		return fmt.Sprintf("%s\nALTER DATABASE \"%s\" OWNER TO \"%s\";", stmt, databaseName, createDatabaseContext.Owner), nil
 	}
 	return "", errors.Errorf("unsupported database type %s", dbType)
 }
@@ -1382,6 +1401,10 @@ func checkCharacterSetCollationOwner(dbType db.Type, characterSet, collation, ow
 	case db.Postgres:
 		if owner == "" {
 			return errors.Errorf("database owner is required for PostgreSQL")
+		}
+	case db.Redshift:
+		if owner == "" {
+			return errors.Errorf("database owner is required for Redshift")
 		}
 	case db.SQLite, db.MongoDB, db.MSSQL:
 		// no-op.

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -97,7 +97,8 @@ import (
 	_ "github.com/bytebase/bytebase/backend/plugin/db/oracle"
 	// Register mssql driver.
 	_ "github.com/bytebase/bytebase/backend/plugin/db/mssql"
-
+	// Register redshift driver.
+	_ "github.com/bytebase/bytebase/backend/plugin/db/redshift"
 	// Register pingcap parser driver.
 	_ "github.com/pingcap/tidb/types/parser_driver"
 	// Register fake advisor.

--- a/backend/server/sql.go
+++ b/backend/server/sql.go
@@ -648,7 +648,7 @@ func (s *Server) registerSQLRoutes(g *echo.Group) {
 
 			var singleSQLResults []api.SingleSQLResult
 			// We split the query into multiple statements and execute them one by one for MySQL and PostgreSQL.
-			if instance.Engine == db.MySQL || instance.Engine == db.TiDB || instance.Engine == db.MariaDB || instance.Engine == db.Postgres || instance.Engine == db.Oracle {
+			if instance.Engine == db.MySQL || instance.Engine == db.TiDB || instance.Engine == db.MariaDB || instance.Engine == db.Postgres || instance.Engine == db.Oracle || instance.Engine == db.Redshift {
 				singleSQLs, err := parser.SplitMultiSQL(parser.EngineType(instance.Engine), exec.Statement)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to split statements")

--- a/backend/store/data_source.go
+++ b/backend/store/data_source.go
@@ -50,6 +50,7 @@ type UpdateDataSourceMessage struct {
 	ObfuscatedSslKey   *string
 	Host               *string
 	Port               *string
+	Database           *string
 	// Flatten data source options.
 	SRV                    *bool
 	AuthenticationDatabase *string
@@ -206,6 +207,9 @@ func (s *Store) UpdateDataSourceV2(ctx context.Context, patch *UpdateDataSourceM
 	}
 	if v := patch.Port; v != nil {
 		set, args = append(set, fmt.Sprintf("port = $%d", len(args)+1)), append(args, *v)
+	}
+	if v := patch.Database; v != nil {
+		set, args = append(set, fmt.Sprintf("database = $%d", len(args)+1)), append(args, *v)
 	}
 
 	// Use jsonb_build_object to build the jsonb object to update some fields in jsonb instead of whole column.

--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -149,7 +149,8 @@
         <div class="w-full">
           <label for="charset" class="textlabel">
             {{
-              selectedInstance.engine == "POSTGRES"
+              selectedInstance.engine == "POSTGRES" ||
+              selectedInstance.engine == "REDSHIFT"
                 ? $t("db.encoding")
                 : $t("db.character-set")
             }}</label
@@ -460,7 +461,7 @@ export default defineComponent({
       if (instance.id === UNKNOWN_ID) {
         return false;
       }
-      return instance.engine === "POSTGRES";
+      return instance.engine === "POSTGRES" || instance.engine === "REDSHIFT";
     });
 
     const validDatabaseOwnerName = computed((): boolean => {

--- a/frontend/src/components/DatabaseBackupPanel.vue
+++ b/frontend/src/components/DatabaseBackupPanel.vue
@@ -112,10 +112,9 @@
           />
 
           <button
-            v-if="allowEdit"
+            v-if="allowEdit && disableBackupButton"
             type="button"
             class="btn-normal whitespace-nowrap items-center"
-            :disabled="database.instance.engine === 'MONGODB'"
             @click.prevent="state.showCreateBackupModal = true"
           >
             {{ $t("database.backup-now") }}
@@ -196,6 +195,8 @@ import {
   localFromUTC,
   parseScheduleFromBackupSetting,
 } from "@/components/DatabaseBackup/";
+
+import { instanceHasBackupRestore } from "@/utils";
 
 interface LocalState {
   showCreateBackupModal: boolean;
@@ -279,6 +280,10 @@ export default defineComponent({
 
       state.backupSetting = backupSetting;
     };
+
+    const disableBackupButton = computed(() => {
+      return !instanceHasBackupRestore(props.database.instance);
+    });
 
     // List PENDING_CREATE backups first, followed by backups in createdTs descending order.
     const backupList = computed(() => {
@@ -459,6 +464,7 @@ export default defineComponent({
       updateBackupSetting,
       urlChanged,
       updateBackupHookUrl,
+      disableBackupButton,
     };
   },
 });

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -895,7 +895,8 @@ const hasReadonlyReplicaPort = computed((): boolean => {
 
 const showDatabase = computed((): boolean => {
   return (
-    basicInformation.value.engine === "POSTGRES" &&
+    (basicInformation.value.engine === "POSTGRES" ||
+      basicInformation.value.engine === "REDSHIFT") &&
     state.currentDataSourceType === "ADMIN"
   );
 });

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -1247,7 +1247,8 @@ const doCreate = async () => {
 
   if (
     instanceCreate.engine !== "POSTGRES" &&
-    instanceCreate.engine !== "MONGODB"
+    instanceCreate.engine !== "MONGODB" &&
+    instanceCreate.engine !== "REDSHIFT"
   ) {
     // Clear the `database` field if not needed.
     instanceCreate.database = "";

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -260,11 +260,14 @@ const makeUnknown = (type: ResourceType) => {
     host: "",
     port: "",
     database: "",
-    options: { srv: false, authenticationDatabase: "" },
+    options: {
+      srv: false,
+      authenticationDatabase: "",
+      sid: "",
+      serviceName: "",
+    },
     // UI-only fields
     updateSsl: false,
-    sid: "",
-    serviceName: "",
   };
 
   const UNKNOWN_BACKUP_SETTING: BackupSetting = {

--- a/frontend/src/types/instance.ts
+++ b/frontend/src/types/instance.ts
@@ -79,7 +79,7 @@ export function defaultCharset(type: EngineType): string {
     case "MSSQL":
       return "";
     case "REDSHIFT":
-      return "";
+      return "UNICODE";
   }
 }
 

--- a/frontend/src/utils/instance.ts
+++ b/frontend/src/utils/instance.ts
@@ -67,6 +67,7 @@ export const instanceHasBackupRestore = (instance: Instance): boolean => {
   if (engine === "MONGODB") return false;
   if (engine === "REDIS") return false;
   if (engine === "SPANNER") return false;
+  if (engine === "REDSHIFT") return false;
   return true;
 };
 


### PR DESCRIPTION
This PR supports user add Redshift in Bytebase, and supports the following features:
- Create database
- DML/DDL issues
- SQL Editor Readonly/Admin mode

Unfortunately, I do not support `dump schema` in this PR because I found that we use [pg_dump 15 which doesn't support PostgreSQL 8.0 anymore](https://sourcegraph.com/github.com/postgres/postgres@REL_15_0/-/blob/src/bin/pg_dump/pg_dumpall.c?L1643)(which pg_dump 14 supports). But when users need it, we can easily embed pg_dump 14.