### PR TITLE
chore: get view definition when view dependence error appears

### DIFF
--- a/backend/plugin/advisor/catalog/test/pg_walk_through.yaml
+++ b/backend/plugin/advisor/catalog/test/pg_walk_through.yaml
@@ -707,18 +707,24 @@
     type: 408
     content: 'Cannot drop column "id" in table "public"."test", it''s referenced by view: "public"."v1"'
     line: 1
+    payload:
+        - '"public"."v1"'
 - statement: ALTER TABLE test ALTER COLUMN id TYPE varchar(20);
   want: null
   err:
     type: 408
     content: 'Cannot alter type of column "id" in table "public"."test", it''s referenced by view: "public"."v1"'
     line: 1
+    payload:
+        - '"public"."v1"'
 - statement: DROP TABLE test;
   want: null
   err:
     type: 304
     content: 'Cannot drop table "public"."test", it''s referenced by view: "public"."v1"'
     line: 1
+    payload:
+        - '"public"."v1"'
 - statement: |-
     DROP VIEW v1;
     ALTER TABLE test DROP COLUMN id;

--- a/backend/plugin/advisor/catalog/walk_through.go
+++ b/backend/plugin/advisor/catalog/walk_through.go
@@ -129,6 +129,8 @@ type WalkThroughError struct {
 	Type    WalkThroughErrorType
 	Content string
 	Line    int
+
+	Payload interface{}
 }
 
 // NewParseError returns a new ErrorTypeParseError.

--- a/backend/plugin/advisor/catalog/walk_through_for_pg.go
+++ b/backend/plugin/advisor/catalog/walk_through_for_pg.go
@@ -198,6 +198,7 @@ func (d *DatabaseState) pgDropTable(tableDef *ast.TableDef, ifExists bool, _ ast
 		return &WalkThroughError{
 			Type:    ErrorTypeTableIsReferencedByView,
 			Content: fmt.Sprintf("Cannot drop table %q.%q, it's referenced by view: %s", schema.name, table.name, strings.Join(viewList, ", ")),
+			Payload: viewList,
 		}
 	}
 
@@ -415,6 +416,7 @@ func (d *DatabaseState) pgAlterColumnType(schema *SchemaState, t *TableState, no
 		return &WalkThroughError{
 			Type:    ErrorTypeColumnIsReferencedByView,
 			Content: fmt.Sprintf("Cannot alter type of column %q in table %q.%q, it's referenced by view: %s", column.name, schema.name, t.name, strings.Join(viewList, ", ")),
+			Payload: viewList,
 		}
 	}
 
@@ -448,6 +450,7 @@ func (d *DatabaseState) pgDropColumn(schema *SchemaState, t *TableState, node *a
 		return &WalkThroughError{
 			Type:    ErrorTypeColumnIsReferencedByView,
 			Content: fmt.Sprintf("Cannot drop column %q in table %q.%q, it's referenced by view: %s", column.name, schema.name, t.name, strings.Join(viewList, ", ")),
+			Payload: viewList,
 		}
 	}
 

--- a/backend/plugin/advisor/catalog/walk_through_test.go
+++ b/backend/plugin/advisor/catalog/walk_through_test.go
@@ -143,13 +143,17 @@ func runWalkThroughTest(t *testing.T, file string, engineType db.Type, originDat
 			} else {
 				err, yes := err.(*WalkThroughError)
 				require.True(t, yes)
-				actualPayloadText, yes := err.Payload.([]string)
-				require.True(t, yes)
-				expectedPayloadText := convertInterfaceSliceToStringSlice(test.Err.Payload.([]interface{}))
-				err.Payload = nil
-				test.Err.Payload = nil
-				require.Equal(t, test.Err, err)
-				require.Equal(t, expectedPayloadText, actualPayloadText)
+				if err.Payload != nil {
+					actualPayloadText, yes := err.Payload.([]string)
+					require.True(t, yes)
+					expectedPayloadText := convertInterfaceSliceToStringSlice(test.Err.Payload.([]interface{}))
+					err.Payload = nil
+					test.Err.Payload = nil
+					require.Equal(t, test.Err, err)
+					require.Equal(t, expectedPayloadText, actualPayloadText)
+				} else {
+					require.Equal(t, test.Err, err)
+				}
 			}
 			continue
 		}

--- a/backend/plugin/advisor/code.go
+++ b/backend/plugin/advisor/code.go
@@ -74,6 +74,7 @@ const (
 	DefaultCurrentTimeColumnCountExceedsLimit  Code = 418
 	OnUpdateCurrentTimeColumnCountExceedsLimit Code = 419
 	NoDefault                                  Code = 420
+	ColumnIsReferencedByView                   Code = 421
 
 	// 501 engine error code.
 	NotInnoDBEngine Code = 501
@@ -87,6 +88,7 @@ const (
 	TableCommentTooLong               Code = 606
 	TableExists                       Code = 607
 	CreateTablePartition              Code = 608
+	TableIsReferencedByView           Code = 609
 
 	// 701 ~ 799 database advisor error code.
 	DatabaseNotEmpty   Code = 701


### PR DESCRIPTION
close BYT-2543

![image](https://user-images.githubusercontent.com/20775801/228460761-98702eea-89a7-4080-a56f-9290bb55faaa.png)

On the other hand, we cannot display the error content in the pretty format