### PR TITLE
fix: retry finding if task status is patched to pending approval

### DIFF
--- a/backend/server/task.go
+++ b/backend/server/task.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/google/jsonapi"
 	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/log"
 	api "github.com/bytebase/bytebase/backend/legacyapi"
 	"github.com/bytebase/bytebase/backend/store"
 	"github.com/bytebase/bytebase/backend/utils"
@@ -135,7 +138,7 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 		}
 
 		// dismiss stale review, re-find the approval template
-		if taskPatch.Statement != nil {
+		if taskPatch.Statement != nil && task.Status == api.TaskPendingApproval {
 			payloadBytes, err := protojson.Marshal(&storepb.IssuePayload{
 				Approval: &storepb.IssuePayloadApproval{
 					ApprovalFindingDone: false,
@@ -258,6 +261,37 @@ func (s *Server) registerTaskRoutes(g *echo.Group) {
 			}
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to update task \"%v\" status", task.Name)).SetInternal(err)
 		}
+
+		// re-find the approval template
+		// it's ok if we failed
+		if taskStatusPatch.Status == api.TaskPendingApproval {
+			if err := func() error {
+				issue, err := s.store.GetIssueV2(ctx, &store.FindIssueMessage{PipelineID: &task.PipelineID})
+				if err != nil {
+					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch issue with pipeline ID %d", task.PipelineID)).SetInternal(err)
+				}
+				payloadBytes, err := protojson.Marshal(&storepb.IssuePayload{
+					Approval: &storepb.IssuePayloadApproval{
+						ApprovalFindingDone: false,
+					},
+				})
+				if err != nil {
+					return errors.Wrap(err, "failed to marshal issue payload")
+				}
+				payloadStr := string(payloadBytes)
+				issue, err = s.store.UpdateIssueV2(ctx, issue.UID, &store.UpdateIssueMessage{
+					Payload: &payloadStr,
+				}, api.SystemBotID)
+				if err != nil {
+					return errors.Wrap(err, "failed to update issue payload")
+				}
+				s.stateCfg.ApprovalFinding.Store(issue.UID, issue)
+				return nil
+			}(); err != nil {
+				log.Error("Failed to trigger re-finding the approval template", zap.Error(err))
+			}
+		}
+
 		composedTask, err := s.store.GetTaskByID(ctx, task.ID)
 		if err != nil {
 			return err

--- a/backend/server/webhook.go
+++ b/backend/server/webhook.go
@@ -1399,6 +1399,9 @@ func (s *Server) tryUpdateTasksFromModifiedFile(ctx context.Context, databases [
 		// dismiss stale review, re-find the approval template
 		// it's ok if we failed
 		if err := func() error {
+			if task.Status != api.TaskPendingApproval {
+				return nil
+			}
 			payloadBytes, err := protojson.Marshal(&storepb.IssuePayload{
 				Approval: &storepb.IssuePayloadApproval{
 					ApprovalFindingDone: false,
@@ -1417,7 +1420,7 @@ func (s *Server) tryUpdateTasksFromModifiedFile(ctx context.Context, databases [
 			s.stateCfg.ApprovalFinding.Store(issue.UID, issue)
 			return nil
 		}(); err != nil {
-			log.Warn("Failed to dismiss stale review", zap.Error(err))
+			log.Error("Failed to dismiss stale review", zap.Error(err))
 		}
 	}
 	return nil


### PR DESCRIPTION
- retry finding if task status is patched to pending approval
- retry finding if task statement is patched and the task status is pending approval