### PR TITLE
feat(frontend): minor optimizations for risk center and custom approval

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleSelect.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleSelect.vue
@@ -13,6 +13,7 @@
       :placeholder="$t('custom-approval.approval-flow.select')"
       :consistent-menu-width="false"
       :disabled="disabled || !allowAdmin"
+      :filterable="true"
       v-bind="selectAttrs"
     />
     <NButton

--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleSelect.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleSelect.vue
@@ -24,7 +24,7 @@
       :disabled="!selectedRule"
       @click="toApprovalFlow"
     >
-      <heroicons:arrow-top-right-on-square class="w-5 h-5" />
+      <heroicons:pencil-square class="w-5 h-5" />
     </NButton>
   </div>
 </template>

--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
@@ -83,6 +83,7 @@ const rulesMap = computed(() => {
 
 const rows = computed(() => {
   const filteredLevelList = [...filter.levels.value.values()];
+  filteredLevelList.sort((a, b) => -(a - b)); // by level DESC
   const displayLevelList =
     filteredLevelList.length === 0
       ? PresetRiskLevelList.map((item) => item.level)

--- a/frontend/src/components/CustomApproval/Settings/components/common/ExprEditor/components/common.ts
+++ b/frontend/src/components/CustomApproval/Settings/components/common/ExprEditor/components/common.ts
@@ -13,15 +13,15 @@ export const useSelectOptions = (expr: Ref<ConditionExpr>) => {
   const context = useExprEditorContext();
   const { riskSource } = context;
 
-  const getEnvironmentOptions = () => {
+  const getEnvironmentIdOptions = () => {
     const environmentList = useEnvironmentStore().getEnvironmentList();
     return environmentList.map<SelectOption>((env) => ({
-      label: env.name,
+      label: env.resourceId,
       value: env.resourceId,
     }));
   };
 
-  const getProjectOptions = () => {
+  const getProjectIdOptions = () => {
     const user = useCurrentUser().value;
     const projectList = useProjectStore().getProjectListByUser(user.id);
     return projectList.map<SelectOption>((proj) => ({
@@ -72,10 +72,10 @@ export const useSelectOptions = (expr: Ref<ConditionExpr>) => {
   const options = computed(() => {
     const factor = expr.value.args[0];
     if (factor === "environment_id") {
-      return getEnvironmentOptions();
+      return getEnvironmentIdOptions();
     }
     if (factor === "project_id") {
-      return getProjectOptions();
+      return getProjectIdOptions();
     }
     if (factor === "db_engine") {
       return getDBEndingOptions();


### PR DESCRIPTION
### Changes
- make the flow selector filterable (Close BYT-2910)
- use `environment.resource_id` as the options' display label for environment_id dropdowns (Close BYT-2920)
- use edit icon for the approval flow popup button (Close BYT-2923)
- keep the order stable (by level desc) while changing the level filters (Close BYT-2922)