### PR TITLE
fix(bbc): hide SQL Review section in repo settings

### DIFF
--- a/frontend/src/components/RepositoryForm.vue
+++ b/frontend/src/components/RepositoryForm.vue
@@ -260,7 +260,7 @@
         </template>
       </div>
     </div>
-    <div>
+    <div v-if="canEnableSQLReview">
       <div class="textlabel flex gap-x-1">
         {{ $t("repository.sql-review-ci") }}
         <FeatureBadge feature="bb.feature.vcs-sql-review" class="text-accent" />
@@ -378,6 +378,11 @@ export default defineComponent({
     });
     const isProjectSchemaChangeTypeSDL = computed(() => {
       return (props.schemaChangeType || "DDL") === "SDL";
+    });
+    const canEnableSQLReview = computed(() => {
+      return (
+        props.vcsType.startsWith("GITLAB") || props.vcsType.startsWith("GITHUB")
+      );
     });
     const enableSQLReviewTitle = computed(() => {
       return props.vcsType.startsWith("GITLAB")
@@ -518,6 +523,7 @@ export default defineComponent({
       getRquiredPlanString: subscriptionStore.getRquiredPlanString,
       isProjectSchemaChangeTypeDDL,
       isProjectSchemaChangeTypeSDL,
+      canEnableSQLReview,
       enableSQLReviewTitle,
       sampleFilePath,
       sampleSchemaPath,


### PR DESCRIPTION
Fixes BYT-2875

## Test plan

No "SQL Review" section for Bitbucket Cloud:

<img width="704" alt="CleanShot 2023-04-03 at 16 13 51@2x" src="https://user-images.githubusercontent.com/2946214/229451030-63da6094-3512-4267-a39f-e2494ba187c7.png">
