### PR TITLE
feat(frontend): upload sheet with progress

### DIFF
--- a/frontend/src/components/misc/UploadProgressButton.vue
+++ b/frontend/src/components/misc/UploadProgressButton.vue
@@ -1,0 +1,77 @@
+<template>
+  <button
+    class="select-none inline-flex items-center space-x-1 border border-control-border rounded-md text-control bg-white hover:bg-control-bg-hover disabled:bg-white disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 text-sm leading-5 font-medium focus:ring-control focus:outline-none focus-visible:ring-2 focus:ring-offset-2"
+    :disabled="disabled"
+    @click="handleClick"
+  >
+    <slot v-if="!uploading" name="icon">
+      <heroicons-outline:arrow-up-tray class="w-4 h-auto mr-1" />
+    </slot>
+    <template v-else>
+      <BBProgressPie
+        v-if="percent > 0"
+        :percent="percent"
+        class="w-5 h-5 text-info"
+      >
+        <template #default="{ percent: displayPercent }">
+          <span class="scale-[66%]">{{ displayPercent }}</span>
+        </template>
+      </BBProgressPie>
+      <BBSpin v-else class="w-5 h-5" />
+    </template>
+
+    <span>
+      <slot v-if="!uploading" />
+      <slot v-else name="uploading">
+        {{ $t("common.uploading") }}
+      </slot>
+    </span>
+
+    <input
+      ref="inputRef"
+      type="file"
+      accept=".sql,.txt,application/sql,text/plain"
+      class="hidden"
+      @change="handleUpload"
+    />
+  </button>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import { BBProgressPie } from "@/bbkit";
+
+type Tick = (p: number) => void;
+
+const props = defineProps<{
+  upload: (e: Event, tick: Tick) => Promise<any>;
+  disabled?: boolean;
+}>();
+
+const inputRef = ref<HTMLInputElement>();
+const uploading = ref(false);
+const percent = ref(-1); // -1 to show a simple spinner instead of progress
+
+const disabled = computed(() => {
+  return props.disabled || uploading.value;
+});
+
+const updatePercent = (p: number) => {
+  percent.value = p;
+};
+
+const handleClick = () => {
+  inputRef.value?.click();
+};
+
+const handleUpload = async (e: Event) => {
+  uploading.value = true;
+  percent.value = -1;
+  try {
+    await props.upload(e, updatePercent);
+  } finally {
+    uploading.value = false;
+    percent.value = -1;
+  }
+};
+</script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -232,7 +232,8 @@
     "will-lose-unsaved-data": "Will lose any unsaved data.",
     "deleted": "Deleted",
     "will-override-current-data": "Will override current data.",
-    "rollout": "Roll out"
+    "rollout": "Roll out",
+    "uploading": "Uploading"
   },
   "error-page": {
     "go-back-home": "Go back home"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -230,7 +230,8 @@
     "will-lose-unsaved-data": "这会丢失当前所有未保存的数据。",
     "deleted": "已删除",
     "will-override-current-data": "将会覆盖当前数据。",
-    "rollout": "发布"
+    "rollout": "发布",
+    "uploading": "上传中"
   },
   "error-page": {
     "go-back-home": "回到主页"

--- a/frontend/src/store/modules/sheet.ts
+++ b/frontend/src/store/modules/sheet.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import axios from "axios";
+import axios, { type AxiosRequestConfig } from "axios";
 import { isEmpty } from "lodash-es";
 import {
   Sheet,
@@ -170,7 +170,10 @@ export const useSheetStore = defineStore("sheet", {
         visibility: "PRIVATE",
       });
     },
-    async createSheet(sheetCreate: SheetCreate): Promise<Sheet> {
+    async createSheet(
+      sheetCreate: SheetCreate,
+      config?: AxiosRequestConfig
+    ): Promise<Sheet> {
       if (sheetCreate.databaseId === UNKNOWN_ID) {
         sheetCreate.databaseId = undefined;
       }
@@ -181,12 +184,16 @@ export const useSheetStore = defineStore("sheet", {
       }
 
       const resData = (
-        await axios.post(`/api/sheet`, {
-          data: {
-            type: "createSheet",
-            attributes,
+        await axios.post(
+          `/api/sheet`,
+          {
+            data: {
+              type: "createSheet",
+              attributes,
+            },
           },
-        })
+          config
+        )
       ).data;
       const sheet = convertSheet(resData.data, resData.included);
 


### PR DESCRIPTION
### Changes
- "Upload SQL" (directly) is retired.
- "Upload SQL as Sheet" is renamed to "Upload SQL". And it's the only choice to upload SQL files larger than 1MB.

### Screenshots
**Upload progress will be displayed** (simulated to be a medium speed network)

https://user-images.githubusercontent.com/2749742/229510687-6aa7c1ec-4fb7-4d79-a014-f3cbd68a29d2.mp4

