### PR TITLE
chore(snowflake): update the privileges we need for Snowflake (#5356)

### DIFF
--- a/backend/plugin/db/snowflake/dump.go
+++ b/backend/plugin/db/snowflake/dump.go
@@ -53,11 +53,6 @@ func dumpTxn(ctx context.Context, txn *sql.Tx, database string, out io.Writer) e
 		}
 	}
 
-	// Use ACCOUNTADMIN role to dump database;
-	if _, err := txn.ExecContext(ctx, fmt.Sprintf("USE ROLE %s", accountAdminRole)); err != nil {
-		return err
-	}
-
 	for _, dbName := range dumpableDbNames {
 		// includeCreateDatabaseStmt should be false if dumping a single database.
 		dumpSingleDatabase := len(dumpableDbNames) == 1
@@ -137,9 +132,6 @@ func dumpOneDatabase(ctx context.Context, txn *sql.Tx, database string, out io.W
 
 // Restore restores a database.
 func (driver *Driver) Restore(ctx context.Context, sc io.Reader) (err error) {
-	if err := driver.useRole(ctx, sysAdminRole); err != nil {
-		return nil
-	}
 	txn, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err

--- a/backend/plugin/db/snowflake/migrate.go
+++ b/backend/plugin/db/snowflake/migrate.go
@@ -224,9 +224,6 @@ func (Driver) UpdateHistoryAsFailed(ctx context.Context, tx *sql.Tx, migrationDu
 
 // ExecuteMigration will execute the migration.
 func (driver *Driver) ExecuteMigration(ctx context.Context, m *db.MigrationInfo, statement string) (string, string, error) {
-	if err := driver.useRole(ctx, sysAdminRole); err != nil {
-		return "", "", err
-	}
 	_, err := driver.Execute(ctx, statement, m.CreateDatabase)
 	return "", "", err
 }

--- a/backend/plugin/db/snowflake/sync.go
+++ b/backend/plugin/db/snowflake/sync.go
@@ -23,10 +23,6 @@ var (
 
 // SyncInstance syncs the instance.
 func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error) {
-	if err := driver.useRole(ctx, accountAdminRole); err != nil {
-		return nil, err
-	}
-
 	version, err := driver.getVersion(ctx)
 	if err != nil {
 		return nil, err
@@ -60,10 +56,6 @@ func (driver *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, e
 
 // SyncDBSchema syncs a single database schema.
 func (driver *Driver) SyncDBSchema(ctx context.Context, databaseName string) (*storepb.DatabaseMetadata, error) {
-	if err := driver.useRole(ctx, accountAdminRole); err != nil {
-		return nil, err
-	}
-
 	// Query db info
 	databases, err := driver.getDatabases(ctx)
 	if err != nil {

--- a/frontend/src/components/CreateDataSourceExample.vue
+++ b/frontend/src/components/CreateDataSourceExample.vue
@@ -200,21 +200,39 @@ const grantStatement = (
       case "CLICKHOUSE":
         return "CREATE USER bytebase IDENTIFIED BY 'YOUR_DB_PWD';\n\nGRANT ALL ON *.* TO bytebase WITH GRANT OPTION;";
       case "SNOWFLAKE":
-        return `-- The following privilege is the lowest privileges bytebase needed, you still need to assign the role owns the database which need managed by Bytebase to BYTEBASE role by yourself.
+        return `-- Option 1: grant ACCOUNTADMIN role
+
+CREATE OR REPLACE USER bytebase PASSWORD = 'YOUR_DB_PWD'
+DEFAULT_ROLE = "ACCOUNTADMIN"
+DEFAULT_WAREHOUSE = 'YOUR_COMPUTE_WAREHOUSE';
+        
+GRANT ROLE "ACCOUNTADMIN" TO USER bytebase;
+
+-- Option 2: grant more granular privileges
+
 CREATE OR REPLACE ROLE BYTEBASE;
--- If using non-enterprise edition, the following command may encounter error likes 'Unsupported feature GRANT/REVOKE APPLY TAG ON ACCOUNT',
--- you can remove the related privileges and make it works.
+
+-- If using non-enterprise edition, the following commands may encounter error likes 'Unsupported feature GRANT/REVOKE APPLY TAG ON ACCOUNT', you can skip those unsupported GRANTs.
+-- Grant the least privileges required by Bytebase 
+
 GRANT CREATE DATABASE, IMPORT SHARE, APPLY MASKING POLICY, APPLY ROW ACCESS POLICY, APPLY TAG ON ACCOUNT TO ROLE BYTEBASE;
+
 GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE TO ROLE BYTEBASE;
+
 GRANT USAGE ON WAREHOUSE "YOUR_COMPUTE_WAREHOUSE" TO ROLE BYTEBASE;
+
 CREATE OR REPLACE USER BYTEBASE
   PASSWORD = 'YOUR_PWD'
   DEFAULT_ROLE = "BYTEBASE"
   DEFAULT_WAREHOUSE = "YOUR_COMPUTE_WAREHOUSE";
+
 GRANT ROLE "BYTEBASE" TO USER BYTEBASE;
+
 GRANT ROLE "BYTEBASE" TO ROLE SYSADMIN;
--- The database privileges, for example:
--- GRANT ALL PRIVILEGES ON DATABASE EMPLOYEE TO ROLE BYTEBASE;
+
+-- For each database to be managed by Bytebase, you need to grant the following privileges
+
+GRANT ALL PRIVILEGES ON DATABASE {{YOUR_DB_NAME}} TO ROLE BYTEBASE;
 `;
       case "POSTGRES":
         return "CREATE USER bytebase WITH ENCRYPTED PASSWORD 'YOUR_DB_PWD';\n\nALTER USER bytebase WITH SUPERUSER;";
@@ -233,19 +251,39 @@ GRANT ROLE "BYTEBASE" TO ROLE SYSADMIN;
       case "CLICKHOUSE":
         return "CREATE USER bytebase IDENTIFIED BY 'YOUR_DB_PWD';\n\nGRANT SHOW TABLES, SELECT ON database.* TO bytebase;";
       case "SNOWFLAKE":
-        return `-- The following privilege is the lowest privileges bytebase needed, you still need to assign the role owns the database which need managed by Bytebase to BYTEBASE role by yourself.
+        return `-- Option 1: grant ACCOUNTADMIN role
+
+CREATE OR REPLACE USER bytebase PASSWORD = 'YOUR_DB_PWD'
+DEFAULT_ROLE = "ACCOUNTADMIN"
+DEFAULT_WAREHOUSE = 'YOUR_COMPUTE_WAREHOUSE';
+        
+GRANT ROLE "ACCOUNTADMIN" TO USER bytebase;
+
+-- Option 2: grant more granular privileges
+
 CREATE OR REPLACE ROLE BYTEBASE_READER;
+
+-- If using non-enterprise edition, the following commands may encounter error likes 'Unsupported feature GRANT/REVOKE APPLY TAG ON ACCOUNT', you can skip those unsupported GRANTs.
+-- Grant the least privileges required by Bytebase 
+
 GRANT IMPORT SHARE, APPLY MASKING POLICY, APPLY ROW ACCESS POLICY, APPLY TAG ON ACCOUNT TO ROLE BYTEBASE_READER;
+
 GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE TO ROLE BYTEBASE_READER;
+
 GRANT USAGE ON WAREHOUSE "YOUR_COMPUTE_WAREHOUSE" TO ROLE BYTEBASE_READER;
+
 CREATE OR REPLACE USER BYTEBASE_READER
   PASSWORD = 'YOUR_PWD'
   DEFAULT_ROLE = "BYTEBASE_READER"
   DEFAULT_WAREHOUSE = "YOUR_COMPUTE_WAREHOUSE";
-  GRANT ROLE "BYTEBASE_READER" TO USER BYTEBASE_READER;
-  GRANT ROLE "BYTEBASE_READER" TO ROLE SYSADMIN;
--- The database privileges, for example:
--- GRANT ALL PRIVILEGES ON DATABASE EMPLOYEE TO ROLE BYTEBASE_READER;
+
+GRANT ROLE "BYTEBASE_READER" TO USER BYTEBASE_READER;
+
+GRANT ROLE "BYTEBASE_READER" TO ROLE SYSADMIN;
+
+-- For each database to be managed by Bytebase, you need to grant the following privileges
+
+GRANT ALL PRIVILEGES ON DATABASE {{YOUR_DB_NAME}} TO ROLE BYTEBASE_READER;
 `;
       case "POSTGRES":
         return "CREATE USER bytebase WITH ENCRYPTED PASSWORD 'YOUR_DB_PWD';\n\nALTER USER bytebase WITH SUPERUSER;";


### PR DESCRIPTION
* chore: remove the use ACCOUNTADMIN role before dump database

* chore: update the SQL statement to get the shared databases

* chore: remove the use ACCOUNTADMIN role before get database

* chore: remove use ACCOUNTADMIN before sync instance and database

* chore: update the privileges we use for snowflake

* chore: update

* chore: update the css for connection info hint

* chore: update the connection info hint for non-enterprise edition user

* chore: update the connection info hint for non-enterprise edition user