### PR TITLE
chore: use word rollout

### DIFF
--- a/frontend/src/components/EnvironmentForm.vue
+++ b/frontend/src/components/EnvironmentForm.vue
@@ -66,13 +66,13 @@
       </div>
       <div class="col-span-1 mt-6">
         <label class="textlabel">
-          {{ $t("policy.roll-out.name") }}
+          {{ $t("policy.rollout.name") }}
         </label>
         <span v-show="valueChanged('approvalPolicy')" class="textlabeltip">{{
-          $t("policy.roll-out.tip")
+          $t("policy.rollout.tip")
         }}</span>
         <div class="mt-1 textinfolabel">
-          {{ $t("policy.roll-out.info") }}
+          {{ $t("policy.rollout.info") }}
         </div>
         <div class="mt-4 flex flex-col space-y-4">
           <div class="flex space-x-4">
@@ -87,10 +87,10 @@
             />
             <div class="-mt-0.5">
               <div class="textlabel">
-                {{ $t("policy.roll-out.manual") }}
+                {{ $t("policy.rollout.manual") }}
               </div>
               <div class="mt-1 textinfolabel">
-                {{ $t("policy.roll-out.manual-info") }}
+                {{ $t("policy.rollout.manual-info") }}
               </div>
             </div>
           </div>
@@ -116,14 +116,14 @@
             />
             <div class="-mt-0.5">
               <div class="textlabel flex">
-                {{ $t("policy.roll-out.auto") }}
+                {{ $t("policy.rollout.auto") }}
                 <FeatureBadge
                   feature="bb.feature.approval-policy"
                   class="text-accent"
                 />
               </div>
               <div class="mt-1 textinfolabel">
-                {{ $t("policy.roll-out.auto-info") }}
+                {{ $t("policy.rollout.auto-info") }}
               </div>
             </div>
           </div>

--- a/frontend/src/components/EnvironmentForm/AssigneeGroupEditor.vue
+++ b/frontend/src/components/EnvironmentForm/AssigneeGroupEditor.vue
@@ -12,7 +12,7 @@
       />
       <div class="-mt-0.5">
         <div class="textlabel">
-          {{ $t("policy.roll-out.assignee-group.workspace-owner-or-dba") }}
+          {{ $t("policy.rollout.assignee-group.workspace-owner-or-dba") }}
         </div>
       </div>
     </div>
@@ -28,7 +28,7 @@
       />
       <div class="-mt-0.5">
         <div class="textlabel">
-          {{ $t("policy.roll-out.assignee-group.project-owner") }}
+          {{ $t("policy.rollout.assignee-group.project-owner") }}
         </div>
       </div>
     </div>

--- a/frontend/src/components/Issue/IssueBanner.vue
+++ b/frontend/src/components/Issue/IssueBanner.vue
@@ -23,7 +23,7 @@
       v-else-if="showPendingRollout"
       class="h-8 w-full text-base font-medium bg-accent text-white flex justify-center items-center"
     >
-      {{ $t("issue.waiting-to-roll-out") }}
+      {{ $t("issue.waiting-to-rollout") }}
     </div>
     <div
       v-else-if="showEarliestAllowedTimeBanner"

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -233,7 +233,7 @@
     "will-lose-unsaved-data": "Will lose any unsaved data.",
     "deleted": "Deleted",
     "will-override-current-data": "Will override current data.",
-    "rollout": "Roll out",
+    "rollout": "Rollout",
     "uploading": "Uploading",
     "active": "Active"
   },
@@ -700,12 +700,12 @@
       "full-schema": "Full schema",
       "left-schema-may-change": "The schema on the left side may change before the issue is applied."
     },
-    "assignee-tooltip": "Allow the assignee to roll out the issue once the approval flow has been passed.",
+    "assignee-tooltip": "Allow the assignee to rollout the issue once the approval flow has been passed.",
     "approval-flow": {
       "self": "Approval flow",
       "tooltip": "The approvers will review and approve the issue in the order specified in the flow. The issue can only be applied after all steps in the flow have been approved. You can configure a custom approval flow for each risk."
     },
-    "waiting-to-roll-out": "Waiting to roll out",
+    "waiting-to-rollout": "Waiting to rollout",
     "waiting-for-review": "Waiting for review",
     "issue-name": "Issue name"
   },
@@ -941,8 +941,8 @@
     }
   },
   "policy": {
-    "roll-out": {
-      "name": "Roll out policy",
+    "rollout": {
+      "name": "Rollout policy",
       "tip": "The policy is applied to issues retroactively.",
       "info": "For updating schema on the existing database, this setting controls whether the task requires manual approval.",
       "manual": "Require manual rolling out",
@@ -1731,8 +1731,8 @@
         "desc": "Intelligent database management for tenants using identical schemas."
       },
       "bb-feature-approval-policy": {
-        "title": "Roll out policy",
-        "desc": "Roll out policy controls whether the schema change task requires manual rolling out."
+        "title": "Rollout policy",
+        "desc": "Rollout policy controls whether the schema change task requires manual rolling out."
       },
       "bb-feature-backup-policy": {
         "title": "Backup policy",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -703,7 +703,7 @@
       "self": "审批流",
       "tooltip": "审批人需要按审批流指定的顺序审核和审批工单。只有审批流中所有步骤都完成审批后工单才可以执行。您可以为每个风险级别自定义审批流。"
     },
-    "waiting-to-roll-out": "等待发布",
+    "waiting-to-rollout": "等待发布",
     "waiting-for-review": "等待审核",
     "issue-name": "工单名称"
   },
@@ -939,7 +939,7 @@
     }
   },
   "policy": {
-    "roll-out": {
+    "rollout": {
       "name": "发布策略",
       "tip": "新策略对旧工单也生效",
       "info": "要更改数据库 schema，该选项控制了是否需要手动发布。",


### PR DESCRIPTION
Though "rollout" is noun and "roll out" is verb, let's still use word "rollout" consistently because it looks in a nicer form and it's commonly used in other tech products.

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/