### PR TITLE
chore: remove “bytebase” as one of the PG guess dbs

### DIFF
--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -171,7 +171,7 @@ func guessDSN(username, password, hostname, port, database, sslCA, sslCert, sslK
 
 	// Some postgres server default behavior is to use username as the database name if not specified,
 	// while some postgres server explicitly requires the database name to be present (e.g. render.com).
-	guesses := []string{"postgres", "bytebase", username, "template1"}
+	guesses := []string{"postgres", username, "template1"}
 	//  dsn+" dbname=bytebase"
 	for _, guessDatabase := range guesses {
 		guessDSN := fmt.Sprintf("%s dbname=%s", dsn, guessDatabase)


### PR DESCRIPTION
We no longer create a separate "bytebase" database to store migration history.