### PR TITLE
feat(frontend): update task and issue status transition limitations for assignee

### DIFF
--- a/frontend/src/components/Issue/IssueSidebar.vue
+++ b/frontend/src/components/Issue/IssueSidebar.vue
@@ -42,7 +42,7 @@
         <MemberSelect
           class="w-full"
           :disabled="!allowEditAssignee"
-          :selectedId="create ? (issue as IssueCreate).assigneeId : (issue as Issue).assignee?.id"
+          :selected-id="assigneeId as number"
           :custom-filter="filterPrincipal"
           data-label="bb-assignee-select"
           @select-principal-id="
@@ -93,7 +93,7 @@
         <div class="col-span-2">
           <StageSelect
             :pipeline="(issue as Issue).pipeline"
-            :selected-id="(selectedStage as Stage).id"
+            :selected-id="(selectedStage as Stage).id as number"
             @select-stage-id="(stageId) => selectStageOrTask(stageId)"
           />
         </div>
@@ -332,7 +332,6 @@ import {
   hasWorkspacePermission,
   hidePrefix,
   taskSlug,
-  isOwnerOfProject,
   extractDatabaseNameFromTask,
   PRESET_LABEL_KEYS,
 } from "@/utils";
@@ -344,9 +343,11 @@ import {
   useProjectStore,
 } from "@/store";
 import {
+  allowUserToBeAssignee,
+  allowUserToChangeAssignee,
+  useCurrentRollOutPolicyForActiveEnvironment,
   useExtraIssueLogic,
   useIssueLogic,
-  useAllowProjectOwnerToApprove,
 } from "./logic";
 import ProductionEnvironmentIcon from "@/components/Environment/ProductionEnvironmentIcon.vue";
 import { SQLEditorButton } from "@/components/DatabaseDetail";
@@ -443,6 +444,13 @@ const project = computed((): Project => {
   return (issue.value as Issue).project;
 });
 
+const assigneeId = computed(() => {
+  if (create.value) {
+    return (issue.value as IssueCreate).assigneeId;
+  }
+  return (issue.value as Issue).assignee.id;
+});
+
 const databaseEntity = ref<Database>();
 
 const visibleLabelList = computed((): DatabaseLabel[] => {
@@ -479,30 +487,7 @@ const allowEditAssignee = computed(() => {
   if (create.value) {
     return true;
   }
-  const issueEntity = issue.value as Issue;
-  if (issueEntity.status !== "OPEN") {
-    return false;
-  }
-
-  // Who can re-assign the issue?
-  // - The issue creator
-  // - The current assignee
-  // - Workspace owners and DBAs (they always have the highest privileges)
-  if (currentUser.value.id === issueEntity.creator.id) {
-    return true;
-  }
-  if (currentUser.value.id === issueEntity.assignee.id) {
-    return true;
-  }
-  if (
-    hasWorkspacePermission(
-      "bb.permission.workspace.manage-issue",
-      currentUser.value.role
-    )
-  ) {
-    return true;
-  }
-  return false;
+  return allowUserToChangeAssignee(currentUser.value, issue.value as Issue);
 });
 
 const allowEditEarliestAllowedTime = computed(() => {
@@ -620,17 +605,15 @@ const selectTaskId = (taskId: TaskId) => {
   if (!task) return;
   const slug = taskSlug(task.name, task.id);
   const stage = selectedStage.value as Stage;
-  selectStageOrTask(stage.id, slug);
+  selectStageOrTask(stage.id as number, slug);
 };
-
-const allowProjectOwnerToApprove = useAllowProjectOwnerToApprove();
+const rollOutPolicy = useCurrentRollOutPolicyForActiveEnvironment();
 const filterPrincipal = (principal: Principal): boolean => {
-  if (allowProjectOwnerToApprove.value) {
-    return isOwnerOfProject(principal, project.value);
-  }
-  return hasWorkspacePermission(
-    "bb.permission.workspace.manage-issue",
-    principal.role
+  return allowUserToBeAssignee(
+    principal,
+    project.value,
+    rollOutPolicy.value.policy,
+    rollOutPolicy.value.assigneeGroup
   );
 };
 </script>

--- a/frontend/src/components/Issue/logic/assignee.ts
+++ b/frontend/src/components/Issue/logic/assignee.ts
@@ -86,19 +86,19 @@ export const allowUserToBeAssignee = (
   policy: PipelineApprovalPolicyValue,
   assigneeGroup: AssigneeGroupValue | undefined
 ): boolean => {
-  const isWorkspaceOwnerOrDBA = hasWorkspacePermission(
+  const hasWorkspaceIssueManagementPermission = hasWorkspacePermission(
     "bb.permission.workspace.manage-issue",
     user.role
   );
 
   if (policy === "MANUAL_APPROVAL_NEVER") {
     // DBA / workspace owner
-    return isWorkspaceOwnerOrDBA;
+    return hasWorkspaceIssueManagementPermission;
   }
 
   if (assigneeGroup === "WORKSPACE_OWNER_OR_DBA") {
     // DBA / workspace owner
-    return isWorkspaceOwnerOrDBA;
+    return hasWorkspaceIssueManagementPermission;
   }
 
   if (assigneeGroup === "PROJECT_OWNER") {

--- a/frontend/src/components/Issue/logic/assignee.ts
+++ b/frontend/src/components/Issue/logic/assignee.ts
@@ -91,8 +91,6 @@ export const allowUserToBeAssignee = (
     user.role
   );
 
-  console.log(user.name, user.role, policy, assigneeGroup);
-
   if (policy === "MANUAL_APPROVAL_NEVER") {
     // DBA / workspace owner
     return isWorkspaceOwnerOrDBA;

--- a/frontend/src/components/Issue/logic/assignee.ts
+++ b/frontend/src/components/Issue/logic/assignee.ts
@@ -44,7 +44,7 @@ export const useCurrentRollOutPolicyForActiveEnvironment = () => {
   });
 };
 
-const extractRollOutPolicyValue = (
+export const extractRollOutPolicyValue = (
   policy: Policy | undefined,
   issueType: IssueType
 ): {

--- a/frontend/src/components/Issue/logic/transition.ts
+++ b/frontend/src/components/Issue/logic/transition.ts
@@ -2,59 +2,36 @@ import { computed, Ref } from "vue";
 import { useCurrentUser } from "@/store";
 import {
   Issue,
-  SYSTEM_BOT_ID,
   IssueStatusTransitionType,
-  ASSIGNEE_APPLICABLE_ACTION_LIST,
-  CREATOR_APPLICABLE_ACTION_LIST,
   ISSUE_STATUS_TRANSITION_LIST,
   IssueStatusTransition,
+  APPLICABLE_ISSUE_ACTION_LIST,
 } from "@/types";
 import {
   activeStage,
+  activeTask,
   allTaskList,
   applicableTaskTransition,
-  hasWorkspacePermission,
-  isOwnerOfProject,
   StageStatusTransition,
   TaskStatusTransition,
   TASK_STATUS_TRANSITION_LIST,
 } from "@/utils";
-import { useAllowProjectOwnerToApprove, useIssueLogic } from ".";
+import { useIssueLogic } from ".";
 
 export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
-  const {
-    create,
-    activeTaskOfPipeline,
-    allowApplyIssueStatusTransition,
-    allowApplyTaskStatusTransition,
-  } = useIssueLogic();
+  const { create, activeTaskOfPipeline, allowApplyTaskStatusTransition } =
+    useIssueLogic();
 
   const currentUser = useCurrentUser();
-
-  const allowProjectOwnerAsAssignee = useAllowProjectOwnerToApprove();
 
   const isAllowedToApplyTaskTransition = computed(() => {
     if (create.value) {
       return false;
     }
 
-    // Applying task transition is decoupled with the issue's Assignee.
-    // But relative to the task's environment's approval policy.
-    if (
-      hasWorkspacePermission(
-        "bb.permission.workspace.manage-issue",
-        currentUser.value.role
-      )
-    ) {
-      return true;
-    }
-    if (
-      allowProjectOwnerAsAssignee.value &&
-      isOwnerOfProject(currentUser.value, (issue.value as Issue).project)
-    ) {
-      return true;
-    }
-    return false;
+    // Only the assignee can apply task status transitions
+    // including roll out, cancel, retry, etc.
+    return issue.value.assignee.id === currentUser.value.id;
   });
 
   const getApplicableIssueStatusTransitionList = (
@@ -63,58 +40,7 @@ export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
     if (create.value) {
       return [];
     }
-
-    const currentTask = activeTaskOfPipeline(issue.pipeline);
-
-    const issueEntity = issue as Issue;
-    const list: IssueStatusTransitionType[] = [];
-    // Allow assignee, or assignee is the system bot and current user can manage issue
-    if (
-      currentUser.value.id === issueEntity.assignee?.id ||
-      (issueEntity.assignee?.id == SYSTEM_BOT_ID &&
-        hasWorkspacePermission(
-          "bb.permission.workspace.manage-issue",
-          currentUser.value.role
-        ))
-    ) {
-      list.push(...ASSIGNEE_APPLICABLE_ACTION_LIST.get(issueEntity.status)!);
-    }
-    if (currentUser.value.id === issueEntity.creator.id) {
-      CREATOR_APPLICABLE_ACTION_LIST.get(issueEntity.status)!.forEach(
-        (item) => {
-          if (list.indexOf(item) == -1) {
-            list.push(item);
-          }
-        }
-      );
-    }
-
-    return list
-      .map(
-        (type: IssueStatusTransitionType) =>
-          ISSUE_STATUS_TRANSITION_LIST.get(type)!
-      )
-      .filter((transition) => {
-        const pipeline = issueEntity.pipeline;
-        // Disallow any issue status transition if the active task is in RUNNING state.
-        if (currentTask.status == "RUNNING") {
-          return false;
-        }
-
-        const taskList = allTaskList(pipeline);
-        // Don't display the Resolve action if the last task is NOT in DONE status.
-        if (
-          transition.type == "RESOLVE" &&
-          taskList.length > 0 &&
-          (currentTask.id != taskList[taskList.length - 1].id ||
-            currentTask.status != "DONE")
-        ) {
-          return false;
-        }
-
-        return allowApplyIssueStatusTransition(issue, transition.to);
-      })
-      .reverse();
+    return calcApplicableIssueStatusTransitionList(issue);
   };
 
   const getApplicableStageStatusTransitionList = (issue: Issue) => {
@@ -197,6 +123,54 @@ export const useIssueTransitionLogic = (issue: Ref<Issue>) => {
     applicableStageStatusTransitionList,
     applicableTaskStatusTransitionList,
   };
+};
+
+export const calcApplicableIssueStatusTransitionList = (
+  issue: Issue
+): IssueStatusTransition[] => {
+  const currentUser = useCurrentUser();
+  const currentTask = activeTask(issue.pipeline);
+  const flattenTaskList = allTaskList(issue.pipeline);
+
+  const issueEntity = issue as Issue;
+  const transitionTypeList: IssueStatusTransitionType[] = [];
+
+  // The creator and the assignee can apply issue status transition
+  // including resolve, cancel, reopen
+  if (
+    currentUser.value.id === issueEntity.creator?.id ||
+    currentUser.value.id === issueEntity.assignee?.id
+  ) {
+    const actions = APPLICABLE_ISSUE_ACTION_LIST.get(issueEntity.status);
+    if (actions) {
+      transitionTypeList.push(...actions);
+    }
+  }
+
+  const applicableTransitionList: IssueStatusTransition[] = [];
+  transitionTypeList.forEach((type) => {
+    const transition = ISSUE_STATUS_TRANSITION_LIST.get(type);
+    if (!transition) return;
+
+    if (flattenTaskList.some((task) => task.status === "RUNNING")) {
+      // Disallow any issue status transition if some of the tasks are in RUNNING state.
+      return;
+    }
+    if (type === "RESOLVE") {
+      // Don't display the Resolve action if the last task is NOT in DONE status.
+      if (transition.type === "RESOLVE" && flattenTaskList.length > 0) {
+        const lastTask = flattenTaskList[flattenTaskList.length - 1];
+        if (lastTask.id !== currentTask.id) {
+          return;
+        }
+        if (currentTask.status !== "DONE") {
+          return;
+        }
+      }
+    }
+    applicableTransitionList.push(transition);
+  });
+  return applicableTransitionList;
 };
 
 export function isApplicableTransition<

--- a/frontend/src/components/Issue/logic/transition.ts
+++ b/frontend/src/components/Issue/logic/transition.ts
@@ -157,12 +157,14 @@ export const calcApplicableIssueStatusTransitionList = (
       return;
     }
     if (type === "RESOLVE") {
-      // Don't display the Resolve action if the last task is NOT in DONE status.
       if (transition.type === "RESOLVE" && flattenTaskList.length > 0) {
         const lastTask = flattenTaskList[flattenTaskList.length - 1];
+        // Don't display the RESOLVE action if the pipeline doesn't reach the
+        // last task
         if (lastTask.id !== currentTask.id) {
           return;
         }
+        // Don't display the RESOLVE action if the last task is not DONE.
         if (currentTask.status !== "DONE") {
           return;
         }

--- a/frontend/src/types/issue.ts
+++ b/frontend/src/types/issue.ts
@@ -204,16 +204,7 @@ export const ISSUE_STATUS_TRANSITION_LIST: Map<
 
 // The first transition in the list is the primary action and the rests are
 // the normal action. For now there are at most 1 primary 1 normal action.
-export const CREATOR_APPLICABLE_ACTION_LIST: Map<
-  IssueStatus,
-  IssueStatusTransitionType[]
-> = new Map([
-  ["OPEN", ["CANCEL"]],
-  ["DONE", ["REOPEN"]],
-  ["CANCELED", ["REOPEN"]],
-]);
-
-export const ASSIGNEE_APPLICABLE_ACTION_LIST: Map<
+export const APPLICABLE_ISSUE_ACTION_LIST: Map<
   IssueStatus,
   IssueStatusTransitionType[]
 > = new Map([


### PR DESCRIPTION
Close BYT-2924
See also #5520 

### Changes

- Roll out (including cancel, mark as done aka skip and retry)
  - only the assignee
- Re-assign (to another capable assignee)
  - only the current assignee
  - nit: applicable to the issue creator when the current assignee is SYSTEM_BOT
- Resolve/Cancel/Reopen the issue
  - the current assignee and issue creator.