### PR TITLE
feat(frontend): slow query improvements 2

### DIFF
--- a/frontend/src/bbkit/BBGrid/BBGrid.vue
+++ b/frontend/src/bbkit/BBGrid/BBGrid.vue
@@ -24,18 +24,33 @@
       </div>
     </div>
 
-    <div
+    <template
       v-for="(item, row) in dataSource"
       :key="rowKey ? item[rowKey] : row"
-      row="table-row"
-      class="bb-grid-row group"
-      :class="{
-        clickable: rowClickable,
-      }"
-      @click="handleClick(item, 0, row, $event)"
     >
-      <slot name="item" :item="item" :row="row" />
-    </div>
+      <div
+        row="table-row"
+        class="bb-grid-row group"
+        :class="{
+          clickable: rowClickable,
+        }"
+        @click="handleClick(item, 0, row, $event)"
+      >
+        <slot name="item" :item="item" :row="row" />
+      </div>
+      <div v-if="isRowExpanded(item, row)" row="table-row" class="bb-grid-row">
+        <div
+          class="bb-grid-cell"
+          :style="{
+            gridColumnStart: 1,
+            gridColumnEnd: columnList.length + 1,
+          }"
+        >
+          <slot name="expanded-item" :item="item" :row="row" />
+        </div>
+      </div>
+    </template>
+
     <slot name="placeholder">
       <div
         v-if="dataSource.length === 0 && showPlaceholder"
@@ -54,6 +69,7 @@
 
 <script lang="ts" setup>
 import { computed } from "vue";
+
 import { VueClass } from "@/utils";
 import { BBGridColumn } from "../types";
 import { useResponsiveGridColumns } from "./useResponsiveGridColumns";
@@ -80,6 +96,7 @@ const props = withDefaults(
     headerClass?: VueClass;
     rowClickable?: boolean;
     showPlaceholder?: boolean;
+    isRowExpanded?: (item: DataType, row: number) => boolean;
   }>(),
   {
     columnList: () => [],
@@ -90,6 +107,7 @@ const props = withDefaults(
     headerClass: undefined,
     rowClickable: true,
     showPlaceholder: false,
+    isRowExpanded: () => false,
   }
 );
 

--- a/frontend/src/components/DatabaseSlowQueryPanel.vue
+++ b/frontend/src/components/DatabaseSlowQueryPanel.vue
@@ -7,6 +7,7 @@
       :show-project-column="false"
       :show-environment-column="false"
       :show-instance-column="false"
+      :show-database-column="false"
     />
   </div>
 </template>

--- a/frontend/src/components/DatabaseSlowQueryPanel.vue
+++ b/frontend/src/components/DatabaseSlowQueryPanel.vue
@@ -4,6 +4,7 @@
       v-if="database"
       v-model:filter="filter"
       :filter-types="['time-range']"
+      :show-project-column="false"
       :show-environment-column="false"
       :show-instance-column="false"
     />

--- a/frontend/src/components/ProjectSlowQueryPanel.vue
+++ b/frontend/src/components/ProjectSlowQueryPanel.vue
@@ -2,7 +2,8 @@
   <div>
     <SlowQueryPanel
       v-model:filter="filter"
-      :filter-types="['environment', 'database', 'time-range']"
+      :filter-types="['environment', 'instance', 'database', 'time-range']"
+      :show-project-column="false"
     />
   </div>
 </template>

--- a/frontend/src/components/SlowQuery/Panel/DetailPanel.vue
+++ b/frontend/src/components/SlowQuery/Panel/DetailPanel.vue
@@ -6,22 +6,20 @@
     @update:show="(show) => !show && $emit('close')"
   >
     <NDrawerContent
-      :title="$t('common.detail')"
+      :title="$t('slow-query.detail')"
       :closable="true"
       class="w-[calc(100vw-2rem)] lg:max-w-[64rem] xl:max-w-[72rem]"
     >
       <div v-if="slowQueryLog" class="max-h-full flex flex-col gap-y-4 text-sm">
         <div
-          class="grid grid-cols-[auto_1fr] md:grid-cols-[minmax(auto,7rem)_1fr_minmax(auto,7rem)_1fr_minmax(auto,7rem)_1fr] gap-x-2 gap-y-4"
+          class="grid grid-cols-[auto_1fr] md:grid-cols-[minmax(auto,7rem)_1fr_minmax(auto,7rem)_1fr] gap-x-2 gap-y-4"
         >
           <div class="contents">
             <label class="font-medium capitalize">
               {{ $t("common.project") }}
             </label>
 
-            <div class="col-start-2 md:col-span-5">
-              <ProjectName :project="database.project" />
-            </div>
+            <ProjectName :project="database.project" />
           </div>
 
           <div class="contents">
@@ -54,7 +52,7 @@
             </label>
 
             <div
-              class="col-start-2 md:col-span-5 max-h-[8rem] overflow-auto py-0.5 text-xs"
+              class="col-start-2 md:col-span-3 max-h-[8rem] overflow-auto py-0.5 text-xs"
             >
               <HighlightCodeBlock
                 :code="log.statistics?.sqlFingerprint ?? ''"

--- a/frontend/src/components/SlowQuery/Panel/LogTable.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogTable.vue
@@ -37,6 +37,9 @@
         <div class="bb-grid-cell">
           {{ log.statistics.averageRowsSent }}
         </div>
+        <div v-if="showProjectColumn" class="bb-grid-cell">
+          <ProjectName :project="database.project" :link="false" />
+        </div>
         <div v-if="showEnvironmentColumn" class="bb-grid-cell">
           <EnvironmentName
             :environment="database.instance.environment"
@@ -73,12 +76,14 @@ const props = withDefaults(
   defineProps<{
     slowQueryLogList?: ComposedSlowQueryLog[];
     showPlaceholder?: boolean;
+    showProjectColumn?: boolean;
     showEnvironmentColumn?: boolean;
     showInstanceColumn?: boolean;
   }>(),
   {
     slowQueryLogList: () => [],
     showPlaceholder: true,
+    showProjectColumn: true,
     showEnvironmentColumn: true,
     showInstanceColumn: true,
   }
@@ -122,6 +127,10 @@ const columns = computed(() => {
     },
     {
       title: t("slow-query.rows-sent-avg"),
+      width: "minmax(6rem, auto)",
+    },
+    props.showProjectColumn && {
+      title: t("common.project"),
       width: "minmax(6rem, auto)",
     },
     props.showEnvironmentColumn && {

--- a/frontend/src/components/SlowQuery/Panel/LogTable.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogTable.vue
@@ -49,7 +49,7 @@
         <div v-if="showInstanceColumn" class="bb-grid-cell">
           <InstanceName :instance="database.instance" :link="false" />
         </div>
-        <div class="bb-grid-cell">
+        <div v-if="showDatabaseColumn" class="bb-grid-cell">
           <DatabaseName :database="database" :link="false" />
         </div>
         <div class="bb-grid-cell whitespace-nowrap !pr-4">
@@ -79,6 +79,7 @@ const props = withDefaults(
     showProjectColumn?: boolean;
     showEnvironmentColumn?: boolean;
     showInstanceColumn?: boolean;
+    showDatabaseColumn?: boolean;
   }>(),
   {
     slowQueryLogList: () => [],
@@ -86,6 +87,7 @@ const props = withDefaults(
     showProjectColumn: true,
     showEnvironmentColumn: true,
     showInstanceColumn: true,
+    showDatabaseColumn: true,
   }
 );
 
@@ -141,7 +143,7 @@ const columns = computed(() => {
       title: t("common.instance"),
       width: "minmax(12rem, 18rem)",
     },
-    {
+    props.showDatabaseColumn && {
       title: t("common.database"),
       width: "minmax(12rem, 18rem)",
     },

--- a/frontend/src/components/SlowQuery/Panel/SlowQueryPanel.vue
+++ b/frontend/src/components/SlowQuery/Panel/SlowQueryPanel.vue
@@ -21,6 +21,7 @@
         :show-project-column="showProjectColumn"
         :show-environment-column="showEnvironmentColumn"
         :show-instance-column="showInstanceColumn"
+        :show-database-column="showDatabaseColumn"
         @select="selectedSlowQueryLog = $event"
       />
       <div
@@ -67,12 +68,14 @@ const props = withDefaults(
     showProjectColumn?: boolean;
     showEnvironmentColumn?: boolean;
     showInstanceColumn?: boolean;
+    showDatabaseColumn?: boolean;
   }>(),
   {
     filterTypes: () => FilterTypeList,
     showProjectColumn: true,
     showEnvironmentColumn: true,
     showInstanceColumn: true,
+    showDatabaseColumn: true,
   }
 );
 

--- a/frontend/src/components/SlowQuery/Panel/SlowQueryPanel.vue
+++ b/frontend/src/components/SlowQuery/Panel/SlowQueryPanel.vue
@@ -8,12 +8,7 @@
         @update:params="$emit('update:filter', $event)"
       >
         <template #suffix>
-          <NButton
-            type="primary"
-            :quaternary="true"
-            :loading="syncing"
-            @click="syncNow"
-          >
+          <NButton type="default" :loading="syncing" @click="syncNow">
             {{ $t("common.sync-now") }}
           </NButton>
         </template>
@@ -23,6 +18,7 @@
       <LogTable
         :slow-query-log-list="slowQueryLogList"
         :show-placeholder="!loading"
+        :show-project-column="showProjectColumn"
         :show-environment-column="showEnvironmentColumn"
         :show-instance-column="showInstanceColumn"
         @select="selectedSlowQueryLog = $event"
@@ -68,11 +64,13 @@ const props = withDefaults(
   defineProps<{
     filter: SlowQueryFilterParams;
     filterTypes?: readonly FilterType[];
+    showProjectColumn?: boolean;
     showEnvironmentColumn?: boolean;
     showInstanceColumn?: boolean;
   }>(),
   {
     filterTypes: () => FilterTypeList,
+    showProjectColumn: true,
     showEnvironmentColumn: true,
     showInstanceColumn: true,
   }

--- a/frontend/src/components/SlowQuery/Panel/types.ts
+++ b/frontend/src/components/SlowQuery/Panel/types.ts
@@ -11,7 +11,6 @@ export type SlowQueryFilterParams = {
 };
 
 export const FilterTypeList = [
-  "mode",
   "project",
   "environment",
   "instance",

--- a/frontend/src/components/v2/Model/ProjectName.vue
+++ b/frontend/src/components/v2/Model/ProjectName.vue
@@ -1,0 +1,42 @@
+<template>
+  <component
+    :is="link ? 'router-link' : tag"
+    v-bind="bindings"
+    class="inline-flex items-center gap-x-1"
+  >
+    <span>{{ projectName(project) }}</span>
+  </component>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+
+import type { Project } from "@/types";
+import { projectName, projectSlug } from "@/utils";
+
+const props = withDefaults(
+  defineProps<{
+    project: Project;
+    tag?: string;
+    link?: boolean;
+  }>(),
+  {
+    tag: "span",
+    link: true,
+  }
+);
+
+const bindings = computed(() => {
+  if (props.link) {
+    return {
+      to: `/project/${projectSlug(props.project)}`,
+      activeClass: "",
+      exactActiveClass: "",
+      onClick: (e: MouseEvent) => {
+        e.stopPropagation();
+      },
+    };
+  }
+  return {};
+});
+</script>

--- a/frontend/src/components/v2/Model/index.ts
+++ b/frontend/src/components/v2/Model/index.ts
@@ -1,5 +1,6 @@
 import DatabaseName from "./DatabaseName.vue";
 import InstanceName from "./InstanceName.vue";
 import EnvironmentName from "./EnvironmentName.vue";
+import ProjectName from "./ProjectName.vue";
 
-export { DatabaseName, InstanceName, EnvironmentName };
+export { DatabaseName, InstanceName, EnvironmentName, ProjectName };

--- a/frontend/src/components/v2/TabFilter/EnvironmentTabFilter.vue
+++ b/frontend/src/components/v2/TabFilter/EnvironmentTabFilter.vue
@@ -42,13 +42,13 @@ const { t } = useI18n();
 const environmentList = useEnvironmentList(["NORMAL"]);
 
 const items = computed(() => {
-  const environmentItems = environmentList.value.map<EnvironmentTabFilterItem>(
-    (env) => ({
+  const reversedEnvironmentList = [...environmentList.value].reverse();
+  const environmentItems =
+    reversedEnvironmentList.map<EnvironmentTabFilterItem>((env) => ({
       value: env.id,
       label: env.name,
       environment: env,
-    })
-  );
+    }));
   if (props.environment === UNKNOWN_ID || props.includeAll) {
     environmentItems.unshift({
       value: UNKNOWN_ID,

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2272,6 +2272,7 @@
     "lock-time": "Lock time",
     "query-time": "Query time",
     "attention-description": "Logging and analyzing slow queries for {versions}.\nBytebase will periodically sync slow query logs from instances.",
-    "sync-job-started": "Sync jobs started. Please wait for the jobs to complete."
+    "sync-job-started": "Sync jobs started. Please wait for the jobs to complete.",
+    "detail": "Slow Query Detail"
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2269,6 +2269,7 @@
     "lock-time": "持有锁时长",
     "query-time": "执行时长",
     "attention-description": "为 {versions} 记录和分析慢查询。\nBytebase 会定期从实例上同步慢查询日志。",
-    "sync-job-started": "同步作业已启动。请等待同步完成。"
+    "sync-job-started": "同步作业已启动。请等待同步完成。",
+    "detail": "慢查询详情"
   }
 }

--- a/frontend/src/store/modules/review.ts
+++ b/frontend/src/store/modules/review.ts
@@ -1,4 +1,6 @@
 import { defineStore } from "pinia";
+import { ref } from "vue";
+import { uniq, uniqBy } from "lodash-es";
 
 import { Issue } from "@/types";
 import {
@@ -7,10 +9,8 @@ import {
   ApprovalNode_Type,
   ApprovalNode_GroupValue,
 } from "@/types/proto/v1/review_service";
-import { ref } from "vue";
 import { extractUserEmail, useUserStore } from "./user";
 import { useMemberStore } from "./member";
-import { uniq, uniqBy } from "lodash-es";
 import { reviewServiceClient } from "@/grpcweb";
 import { User } from "@/types/proto/v1/auth_service";
 

--- a/frontend/src/store/modules/slowQueryPolicy.ts
+++ b/frontend/src/store/modules/slowQueryPolicy.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { computed, ref, watchEffect } from "vue";
 import axios from "axios";
-import { IdType, ResourceObject, unknown } from "@/types";
+import { IdType, ResourceObject, unknown, UNKNOWN_ID } from "@/types";
 import {
   PipelineApprovalPolicyPayload,
   Policy,
@@ -10,6 +10,7 @@ import {
   PolicyUpsert,
   SensitiveDataPolicyPayload,
 } from "@/types/policy";
+import { useCurrentUser } from "./auth";
 
 function convert(
   resourceType: PolicyResourceType,
@@ -170,3 +171,23 @@ export const useSlowQueryPolicyStore = defineStore("slow-query-policy", () => {
     deletePolicyByResourceTypeAndPolicyType,
   };
 });
+
+export const useSlowQueryPolicyList = () => {
+  const store = useSlowQueryPolicyStore();
+  const currentUser = useCurrentUser();
+  watchEffect(() => {
+    if (currentUser.value.id === UNKNOWN_ID) return;
+
+    store.fetchPolicyListByResourceTypeAndPolicyType(
+      "instance",
+      "bb.policy.slow-query"
+    );
+  });
+
+  return computed(() => {
+    return store.getPolicyListByResourceTypeAndPolicyType(
+      "instance",
+      "bb.policy.slow-query"
+    );
+  });
+};


### PR DESCRIPTION
### Changes
- Hide instances without slow query log enabled. (Close BYT-2998)
- Detail panel improvements (Close BYT-2989)
  - Add **SQL Statement** column.
  - Expandable detail rows to display full SQL detail.
- Improvements for log table and log filter.
  - Update log filters.
  - Adjust the slow query log table's column layout according to different usage
    - project slow query log table: hide **Project** column
    - database slow query log table: hide **Project**, **Environment**, **Instance** and **Database** columns
  - FYI @Candybase 
- Adjust the order of Environment filters. The higher ones to the left.

### Screenshots
![localhost_9999_db_employee-353(1600_900)](https://user-images.githubusercontent.com/2749742/231929424-9a2ac856-79a4-4c66-8ed9-96ef3f856cd9.png)

![aa8ba029-406b-4cc1-bce8-b23d8de82d09](https://user-images.githubusercontent.com/2749742/231928718-7154f38b-8454-4f41-96e1-44410ae3b87e.jpeg)

![c5e23c95-23c1-44d0-b9c2-9f44751ac29e](https://user-images.githubusercontent.com/2749742/231928684-57f8ba77-ddf7-48bb-b21e-f375759194b0.jpeg)
