### PR TITLE
chore: update email principal cleaning script

### DIFF
--- a/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
+++ b/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
@@ -22,6 +22,8 @@ LOOP
   SELECT * INTO first_user FROM principal WHERE email = row_data.email ORDER BY id LIMIT 1;
   UPDATE setting SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE setting SET updater_id = first_user.id WHERE updater_id = row_data.id;
+  UPDATE role SET creator_id = first_user.id WHERE creator_id = row_data.id;
+  UPDATE role SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE environment SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE environment SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE policy SET creator_id = first_user.id WHERE creator_id = row_data.id;
@@ -52,9 +54,12 @@ LOOP
   UPDATE task SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE task_run SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE task_run SET updater_id = first_user.id WHERE updater_id = row_data.id;
+  UPDATE task_check_run SET creator_id = first_user.id WHERE creator_id = row_data.id;
+  UPDATE task_check_run SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE issue SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE issue SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE issue SET assignee_id = first_user.id WHERE assignee_id = row_data.id;
+  UPDATE issue_subscriber SET subscriber_id = first_user.id WHERE subscriber_id = row_data.id;
   UPDATE instance_change_history SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE instance_change_history SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE activity SET creator_id = first_user.id WHERE creator_id = row_data.id;
@@ -62,6 +67,8 @@ LOOP
   UPDATE inbox SET receiver_id = first_user.id WHERE receiver_id = row_data.id;
   UPDATE bookmark SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE bookmark SET updater_id = first_user.id WHERE updater_id = row_data.id;
+  UPDATE vcs SET creator_id = first_user.id WHERE creator_id = row_data.id;
+  UPDATE vcs SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE repository SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE repository SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE anomaly SET creator_id = first_user.id WHERE creator_id = row_data.id;

--- a/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
+++ b/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
@@ -22,8 +22,6 @@ LOOP
   SELECT * INTO first_user FROM principal WHERE email = row_data.email ORDER BY id LIMIT 1;
   UPDATE setting SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE setting SET updater_id = first_user.id WHERE updater_id = row_data.id;
-  UPDATE role SET creator_id = first_user.id WHERE creator_id = row_data.id;
-  UPDATE role SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE environment SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE environment SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE policy SET creator_id = first_user.id WHERE creator_id = row_data.id;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6b1f565</samp>

### Summary
🐛🔧🗑️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request.
2.  🔧 - This emoji represents a tool or configuration change, which is what the SQL script is doing by updating the user id references.
3.  🗑️ - This emoji represents a deletion or removal, which is what the SQL script is doing by deleting the duplicate users.
-->
Fix a data migration bug that could cause duplicate users and foreign key errors. Update the user id references in `task_check_run`, `issue_subscriber`, and `vcs` tables in `./backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql`.

> _There once was a script that would fail_
> _When deleting some users by email_
> _It would mess up the `vcs`_
> _And the `task_check_run`s_
> _But this pull request fixed the detail_

### Walkthrough
*  Update the user id references in the task_check_run, issue_subscriber, and vcs tables to match the first user with the same email ([link](https://github.com/bytebase/bytebase/pull/5615/files?diff=unified&w=0#diff-dc03c02a63f2a3a8bc5f509d8b761e58edf8ed2e14e1df8928811447e1187bb1L55-R60), [link](https://github.com/bytebase/bytebase/pull/5615/files?diff=unified&w=0#diff-dc03c02a63f2a3a8bc5f509d8b761e58edf8ed2e14e1df8928811447e1187bb1R68-R69)). These changes are part of the `backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql` script, which removes the email-duplicated users from the principal table and merges their data with the first user.

