### PR TITLE
fix: prevent updated_ts will be updated by trigger

### DIFF
--- a/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
+++ b/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
@@ -56,7 +56,7 @@ FOR row_data IN (
 )
 LOOP
   SELECT * INTO first_user FROM principal WHERE email = row_data.email ORDER BY id LIMIT 1;
-  UPDATE setting SET creator_id = first_user.id, updated_ts = updated_ts WHERE creator_id = row_data.id;
+  UPDATE setting SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE setting SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE environment SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE environment SET updater_id = first_user.id WHERE updater_id = row_data.id;

--- a/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
+++ b/backend/migrator/migration/prod/1.16/0002##delete_email_duplicated_principal.sql
@@ -1,4 +1,39 @@
-BEGIN;
+ALTER TABLE principal DISABLE TRIGGER update_principal_updated_ts;
+ALTER TABLE setting DISABLE TRIGGER update_setting_updated_ts;
+ALTER TABLE member DISABLE TRIGGER update_member_updated_ts;
+ALTER TABLE environment DISABLE TRIGGER update_environment_updated_ts;
+ALTER TABLE policy DISABLE TRIGGER update_policy_updated_ts;
+ALTER TABLE project DISABLE TRIGGER update_project_updated_ts;
+ALTER TABLE project_member DISABLE TRIGGER update_project_member_updated_ts;
+ALTER TABLE project_webhook DISABLE TRIGGER update_project_webhook_updated_ts;
+ALTER TABLE instance DISABLE TRIGGER update_instance_updated_ts;
+ALTER TABLE instance_user DISABLE TRIGGER update_instance_user_updated_ts;
+ALTER TABLE db DISABLE TRIGGER update_db_updated_ts;
+ALTER TABLE db_schema DISABLE TRIGGER update_db_schema_updated_ts;
+ALTER TABLE data_source DISABLE TRIGGER update_data_source_updated_ts;
+ALTER TABLE backup DISABLE TRIGGER update_backup_updated_ts;
+ALTER TABLE backup_setting DISABLE TRIGGER update_backup_setting_updated_ts;
+ALTER TABLE pipeline DISABLE TRIGGER update_pipeline_updated_ts;
+ALTER TABLE stage DISABLE TRIGGER update_stage_updated_ts;
+ALTER TABLE task DISABLE TRIGGER update_task_updated_ts;
+ALTER TABLE task_run DISABLE TRIGGER update_task_run_updated_ts;
+ALTER TABLE task_check_run DISABLE TRIGGER update_task_check_run_updated_ts;
+ALTER TABLE issue DISABLE TRIGGER update_issue_updated_ts;
+ALTER TABLE instance_change_history DISABLE TRIGGER update_instance_change_history_updated_ts;
+ALTER TABLE activity DISABLE TRIGGER update_activity_updated_ts;
+ALTER TABLE bookmark DISABLE TRIGGER update_bookmark_updated_ts;
+ALTER TABLE vcs DISABLE TRIGGER update_vcs_updated_ts;
+ALTER TABLE repository DISABLE TRIGGER update_repository_updated_ts;
+ALTER TABLE anomaly DISABLE TRIGGER update_anomaly_updated_ts;
+ALTER TABLE label_key DISABLE TRIGGER update_label_key_updated_ts;
+ALTER TABLE label_value DISABLE TRIGGER update_label_value_updated_ts;
+ALTER TABLE db_label DISABLE TRIGGER update_db_label_updated_ts;
+ALTER TABLE deployment_config DISABLE TRIGGER update_deployment_config_updated_ts;
+ALTER TABLE sheet DISABLE TRIGGER update_sheet_updated_ts;
+ALTER TABLE external_approval DISABLE TRIGGER update_external_approval_updated_ts;
+ALTER TABLE risk DISABLE TRIGGER update_risk_updated_ts;
+ALTER TABLE slow_query DISABLE TRIGGER update_slow_query_updated_ts;
+
 DO $$
 DECLARE
   row_data RECORD;
@@ -21,7 +56,7 @@ FOR row_data IN (
 )
 LOOP
   SELECT * INTO first_user FROM principal WHERE email = row_data.email ORDER BY id LIMIT 1;
-  UPDATE setting SET creator_id = first_user.id WHERE creator_id = row_data.id;
+  UPDATE setting SET creator_id = first_user.id, updated_ts = updated_ts WHERE creator_id = row_data.id;
   UPDATE setting SET updater_id = first_user.id WHERE updater_id = row_data.id;
   UPDATE environment SET creator_id = first_user.id WHERE creator_id = row_data.id;
   UPDATE environment SET updater_id = first_user.id WHERE updater_id = row_data.id;
@@ -105,4 +140,39 @@ LOOP
   DELETE FROM principal WHERE id = row_data.id;
 END LOOP;
 END $$;
-COMMIT;
+
+ALTER TABLE principal ENABLE TRIGGER update_principal_updated_ts;
+ALTER TABLE setting ENABLE TRIGGER update_setting_updated_ts;
+ALTER TABLE member ENABLE TRIGGER update_member_updated_ts;
+ALTER TABLE environment ENABLE TRIGGER update_environment_updated_ts;
+ALTER TABLE policy ENABLE TRIGGER update_policy_updated_ts;
+ALTER TABLE project ENABLE TRIGGER update_project_updated_ts;
+ALTER TABLE project_member ENABLE TRIGGER update_project_member_updated_ts;
+ALTER TABLE project_webhook ENABLE TRIGGER update_project_webhook_updated_ts;
+ALTER TABLE instance ENABLE TRIGGER update_instance_updated_ts;
+ALTER TABLE instance_user ENABLE TRIGGER update_instance_user_updated_ts;
+ALTER TABLE db ENABLE TRIGGER update_db_updated_ts;
+ALTER TABLE db_schema ENABLE TRIGGER update_db_schema_updated_ts;
+ALTER TABLE data_source ENABLE TRIGGER update_data_source_updated_ts;
+ALTER TABLE backup ENABLE TRIGGER update_backup_updated_ts;
+ALTER TABLE backup_setting ENABLE TRIGGER update_backup_setting_updated_ts;
+ALTER TABLE pipeline ENABLE TRIGGER update_pipeline_updated_ts;
+ALTER TABLE stage ENABLE TRIGGER update_stage_updated_ts;
+ALTER TABLE task ENABLE TRIGGER update_task_updated_ts;
+ALTER TABLE task_run ENABLE TRIGGER update_task_run_updated_ts;
+ALTER TABLE task_check_run ENABLE TRIGGER update_task_check_run_updated_ts;
+ALTER TABLE issue ENABLE TRIGGER update_issue_updated_ts;
+ALTER TABLE instance_change_history ENABLE TRIGGER update_instance_change_history_updated_ts;
+ALTER TABLE activity ENABLE TRIGGER update_activity_updated_ts;
+ALTER TABLE bookmark ENABLE TRIGGER update_bookmark_updated_ts;
+ALTER TABLE vcs ENABLE TRIGGER update_vcs_updated_ts;
+ALTER TABLE repository ENABLE TRIGGER update_repository_updated_ts;
+ALTER TABLE anomaly ENABLE TRIGGER update_anomaly_updated_ts;
+ALTER TABLE label_key ENABLE TRIGGER update_label_key_updated_ts;
+ALTER TABLE label_value ENABLE TRIGGER update_label_value_updated_ts;
+ALTER TABLE db_label ENABLE TRIGGER update_db_label_updated_ts;
+ALTER TABLE deployment_config ENABLE TRIGGER update_deployment_config_updated_ts;
+ALTER TABLE sheet ENABLE TRIGGER update_sheet_updated_ts;
+ALTER TABLE external_approval ENABLE TRIGGER update_external_approval_updated_ts;
+ALTER TABLE risk ENABLE TRIGGER update_risk_updated_ts;
+ALTER TABLE slow_query ENABLE TRIGGER update_slow_query_updated_ts;


### PR DESCRIPTION
This PR will disable all triggers then enable them after migration finished to prevent the `updated_ts` will be updated by trigger.