### PR TITLE
chore(frontend): don't load too much issues

### DIFF
--- a/frontend/src/components/Issue/table/WaitingForMyApprovalIssueTable.vue
+++ b/frontend/src/components/Issue/table/WaitingForMyApprovalIssueTable.vue
@@ -1,47 +1,25 @@
 <template>
-  <slot
-    name="table"
-    :issue-list="filteredList.map((item) => item.issue)"
-    :loading="state.loading"
-  />
-  <div
-    v-if="state.loading"
-    class="flex items-center justify-center py-2 text-gray-400 text-sm"
-  >
-    <BBSpin />
-  </div>
+  <PagedIssueTable :page-size="20">
+    <template #table="{ issueList, loading }">
+      <slot name="table" :issue-list="filter(issueList)" :loading="loading" />
+    </template>
+  </PagedIssueTable>
 </template>
 
 <script lang="ts" setup>
-import { reactive, computed, watchEffect } from "vue";
-import type { Issue, IssueFind } from "@/types";
-import { useAuthStore, useIsLoggedIn, useIssueStore } from "@/store";
+import { computed } from "vue";
+import type { Issue } from "@/types";
+import { useAuthStore } from "@/store";
 import {
   extractIssueReviewContext,
   useWrappedReviewSteps,
 } from "@/plugins/issue/logic";
 import { Review } from "@/types/proto/v1/review_service";
 
-type LocalState = {
-  loading: boolean;
-  issueList: Issue[];
-};
-
-const props = defineProps<{
-  issueFind?: IssueFind;
-}>();
-
-const state = reactive<LocalState>({
-  loading: true,
-  issueList: [],
-});
-
-const issueStore = useIssueStore();
-const isLoggedIn = useIsLoggedIn();
 const currentUserName = computed(() => useAuthStore().currentUser.name);
 
-const issueListWithReview = computed(() => {
-  return state.issueList.map((issue) => {
+const filter = (issueList: Issue[]) => {
+  const issueListWithReview = issueList.map((issue) => {
     const review = computed(() => {
       try {
         return Review.fromJSON(issue.payload.approval);
@@ -57,10 +35,8 @@ const issueListWithReview = computed(() => {
       steps,
     };
   });
-});
 
-const filteredList = computed(() => {
-  return issueListWithReview.value.filter(({ issue, steps }) => {
+  const filteredList = issueListWithReview.filter(({ steps }) => {
     const currentStep = steps.value?.find((step) => step.status === "CURRENT");
 
     const me = currentStep?.candidates.find(
@@ -69,26 +45,6 @@ const filteredList = computed(() => {
 
     return me;
   });
-});
-
-const fetchData = () => {
-  if (!isLoggedIn.value) {
-    return;
-  }
-
-  state.loading = true;
-  issueStore
-    .fetchIssueList({
-      ...props.issueFind,
-      limit: 20,
-    })
-    .then((issueList) => {
-      state.issueList = issueList;
-    })
-    .finally(() => {
-      state.loading = false;
-    });
+  return filteredList.map(({ issue }) => issue);
 };
-
-watchEffect(fetchData);
 </script>

--- a/frontend/src/components/Issue/table/WaitingForMyApprovalIssueTable.vue
+++ b/frontend/src/components/Issue/table/WaitingForMyApprovalIssueTable.vue
@@ -19,7 +19,7 @@ import { Review } from "@/types/proto/v1/review_service";
 const currentUserName = computed(() => useAuthStore().currentUser.name);
 
 const filter = (issueList: Issue[]) => {
-  const issueListWithReview = issueList.map((issue) => {
+  return issueList.filter((issue) => {
     const review = computed(() => {
       try {
         return Review.fromJSON(issue.payload.approval);
@@ -29,22 +29,13 @@ const filter = (issueList: Issue[]) => {
     });
     const context = extractIssueReviewContext(review);
     const steps = useWrappedReviewSteps(issue, context);
-    return {
-      issue,
-      context,
-      steps,
-    };
-  });
-
-  const filteredList = issueListWithReview.filter(({ steps }) => {
     const currentStep = steps.value?.find((step) => step.status === "CURRENT");
-
-    const me = currentStep?.candidates.find(
-      (user) => user.name === currentUserName.value
+    if (!currentStep) return false;
+    return (
+      currentStep.candidates.findIndex(
+        (user) => user.name === currentUserName.value
+      ) >= 0
     );
-
-    return me;
   });
-  return filteredList.map(({ issue }) => issue);
 };
 </script>

--- a/frontend/src/components/Issue/table/WaitingForMyApprovalIssueTable.vue
+++ b/frontend/src/components/Issue/table/WaitingForMyApprovalIssueTable.vue
@@ -80,7 +80,7 @@ const fetchData = () => {
   issueStore
     .fetchIssueList({
       ...props.issueFind,
-      limit: 1000000,
+      limit: 20,
     })
     .then((issueList) => {
       state.issueList = issueList;

--- a/frontend/src/components/ProjectOverviewPanel.vue
+++ b/frontend/src/components/ProjectOverviewPanel.vue
@@ -47,6 +47,7 @@
       <div>
         <WaitingForMyApprovalIssueTable
           v-if="hasCustomApprovalFeature"
+          session-key="project-waiting-approval"
           :issue-find="{
             statusList: ['OPEN'],
             projectId: project.id,

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -16,6 +16,7 @@
 
     <WaitingForMyApprovalIssueTable
       v-if="hasCustomApprovalFeature"
+      session-key="home-waiting-approval"
       :issue-find="{
         statusList: ['OPEN'],
       }"
@@ -24,7 +25,6 @@
         <IssueTable
           :left-bordered="false"
           :right-bordered="false"
-          :bottom-bordered="loading"
           :show-placeholder="!loading"
           :title="$t('issue.waiting-for-my-approval')"
           :issue-list="issueList.filter(keywordAndEnvironmentFilter)"
@@ -43,6 +43,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTable
+          class="-mt-px"
           :left-bordered="false"
           :right-bordered="false"
           :show-placeholder="!loading"


### PR DESCRIPTION
To save the loading cost and save the performance.

### Changes
- Use `<PagedIssueTable>` for "Waiting approval" section
- The page size is set to 20. Sometimes none of the 20 issues matches the condition. So when we click "Load more" we may see nothing new. 