### PR TITLE
chore(frontend): set default visibility of uploaded SQL as sheet to "PROJECT"

### DIFF
--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -451,7 +451,7 @@ const handleUploadFile = async (event: Event, tick: (p: number) => void) => {
         projectId: projectId,
         name: filename,
         statement,
-        visibility: "PRIVATE",
+        visibility: "PROJECT",
         payload: {},
       },
       {


### PR DESCRIPTION
A workaround for BYT-2980