### PR TITLE
feat(frontend): filter internal RDS users when creating databases in PG

### DIFF
--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -132,6 +132,7 @@
           name="instance-user"
           :instance-id="state.instanceId"
           :selected-id="state.instanceUserId"
+          :filter="filterInstanceUser"
           @select="selectInstanceUser"
         />
       </div>
@@ -243,6 +244,8 @@ import {
 } from "vue";
 import { useRouter } from "vue-router";
 import { isEmpty } from "lodash-es";
+import { useEventListener } from "@vueuse/core";
+
 import {
   DatabaseLabelForm,
   DatabaseNameTemplateTips,
@@ -273,12 +276,15 @@ import {
   PITRContext,
 } from "../types";
 import {
+  type InstanceUser,
+  INTERNAL_RDS_INSTANCE_USER_LIST,
+} from "@/types/InstanceUser";
+import {
   hasWorkspacePermission,
   instanceHasCollationAndCharacterSet,
   instanceHasCreateDatabase,
   issueSlug,
 } from "../utils";
-import { useEventListener } from "@vueuse/core";
 import {
   hasFeature,
   useCurrentUser,
@@ -491,6 +497,13 @@ export default defineComponent({
       state.assigneeId = assigneeId;
     };
 
+    const filterInstanceUser = (user: InstanceUser) => {
+      if (INTERNAL_RDS_INSTANCE_USER_LIST.includes(user.name)) {
+        return false;
+      }
+      return true;
+    };
+
     const cancel = () => {
       emit("dismiss");
     };
@@ -627,6 +640,7 @@ export default defineComponent({
       selectInstance,
       selectInstanceUser,
       selectAssignee,
+      filterInstanceUser,
       cancel,
       create,
     };

--- a/frontend/src/components/InstanceUserSelect.vue
+++ b/frontend/src/components/InstanceUserSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <BBSelect
     :selected-item="selectedInstanceUser"
-    :item-list="instanceUserList"
+    :item-list="filteredInstanceUserList"
     :placeholder="$t('instance.select-database-user')"
     :show-prefix-item="true"
     @select-item="handleSelectItem"
@@ -13,22 +13,27 @@
 </template>
 
 <script lang="ts">
+import { PropType, computed, defineComponent, ref, watch } from "vue";
+
 import { useInstanceStore } from "@/store";
 import { UNKNOWN_ID } from "@/types";
 import { InstanceUser } from "@/types/InstanceUser";
-import { defineComponent, ref, watch } from "vue";
 
 export default defineComponent({
   name: "InstanceUserSelect",
   components: {},
   props: {
     selectedId: {
-      type: Number,
-      default: UNKNOWN_ID,
+      type: String,
+      default: undefined,
     },
     instanceId: {
       type: Number,
       default: UNKNOWN_ID,
+    },
+    filter: {
+      type: Function as PropType<(user: InstanceUser) => boolean>,
+      default: undefined,
     },
   },
   emits: ["select"],
@@ -56,13 +61,18 @@ export default defineComponent({
       }
     );
 
+    const filteredInstanceUserList = computed(() => {
+      if (!props.filter) return instanceUserList.value;
+      return instanceUserList.value.filter(props.filter);
+    });
+
     const handleSelectItem = (instanceUser: InstanceUser) => {
       emit("select", instanceUser.id);
     };
 
     return {
       selectedInstanceUser,
-      instanceUserList,
+      filteredInstanceUserList,
       handleSelectItem,
     };
   },

--- a/frontend/src/types/InstanceUser.ts
+++ b/frontend/src/types/InstanceUser.ts
@@ -10,3 +10,9 @@ export type InstanceUser = {
   name: string;
   grant: string;
 };
+
+export const INTERNAL_RDS_INSTANCE_USER_LIST = [
+  "rds_ad",
+  "rdsadmin",
+  "rds_iam",
+];


### PR DESCRIPTION
Close BYT-2527
Will only hide them when creating databases

<img width="418" alt="image" src="https://user-images.githubusercontent.com/2749742/233834663-7086a43f-11c2-4e60-af08-c42282329849.png">
<img width="239" alt="image" src="https://user-images.githubusercontent.com/2749742/233834645-1987eeee-09ba-4484-8310-e677e3627adf.png">
