### PR TITLE
chore: use latest schema when database has no migration history

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1150,7 +1150,7 @@
     "selected-n-databases": "{n} database selected | {n} databases selected",
     "sync-schema": {
       "title": "Sync Schema",
-      "description": "Bytebase supports synchronizing a specified schema version of one database to another.",
+      "description": "Bytebase supports synchronizing a specified schema version of one database to others.",
       "select-source-schema": "Select source schema",
       "select-target-databases": "Select target databases",
       "select-project": "Select project",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1148,7 +1148,7 @@
     "selected-n-databases": "已选择 {n} 个数据库",
     "sync-schema": {
       "title": "库表同步",
-      "description": "Bytebase supports synchronizing a specified schema version of one database to another.",
+      "description": "Bytebase 支持将一个数据库的指定 Schema 版本同步到其他数据库。",
       "select-source-schema": "选择源数据库",
       "select-target-databases": "选择目标数据库",
       "select-project": "选择项目",

--- a/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
+++ b/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
@@ -29,7 +29,7 @@
             >{{ sourceDatabase.name }}</a
           >
         </div>
-        <div>
+        <div v-if="!isEqual(sourceSchema.migrationHistory.id, UNKNOWN_ID)">
           <span>{{ $t("database.sync-schema.schema-version.self") }} - </span>
           <a
             class="normal-link inline-flex items-center"
@@ -46,7 +46,7 @@
     </div>
 
     <Splitpanes
-      class="default-theme border rounded-lg w-full h-144 flex flex-row overflow-hidden mt-4"
+      class="default-theme relative border rounded-lg w-full h-144 flex flex-row overflow-hidden mt-4"
     >
       <Pane min-size="20" size="25">
         <div
@@ -213,6 +213,13 @@
             }}
           </div>
         </main>
+        <div
+          v-show="state.isLoading"
+          class="absolute inset-0 z-10 bg-white bg-opacity-40 backdrop-blur-sm w-full h-full flex flex-col justify-center items-center"
+        >
+          <BBSpin />
+          <span class="mt-1">{{ $t("common.loading") }}</span>
+        </div>
       </Pane>
     </Splitpanes>
   </div>
@@ -231,6 +238,7 @@
 <script lang="ts" setup>
 import { toClipboard } from "@soerenmartius/vue3-clipboard";
 import axios from "axios";
+import { isEqual } from "lodash-es";
 import { NEllipsis } from "naive-ui";
 import { PropType, computed, onMounted, reactive, ref, watch } from "vue";
 import { CodeDiff } from "v-code-diff";
@@ -249,6 +257,7 @@ import {
   EnvironmentId,
   MigrationHistory,
   ProjectId,
+  UNKNOWN_ID,
   dialectOfEngine,
 } from "@/types";
 import { migrationHistorySlug } from "@/utils";

--- a/frontend/src/views/SyncDatabaseSchema/index.vue
+++ b/frontend/src/views/SyncDatabaseSchema/index.vue
@@ -80,7 +80,7 @@
                 databaseMigrationHistoryList(state.sourceSchema.databaseId as DatabaseId)
               "
               :placeholder="$t('change-history.select')"
-              :show-prefix-item="true"
+              :show-prefix-item="databaseMigrationHistoryList(state.sourceSchema.databaseId as DatabaseId).length > 0"
               @select-item="(migrationHistory: MigrationHistory) => handleSchemaVersionSelect(migrationHistory)"
             >
               <template #menuItem="{ item: migrationHistory }">
@@ -384,8 +384,23 @@ watch(
       ).filter((migrationHistory) =>
         allowedMigrationTypeList.includes(migrationHistory.type)
       );
-      // Default select the first migration history.
-      state.sourceSchema.migrationHistory = head(migrationHistoryList);
+
+      if (migrationHistoryList.length > 0) {
+        // Default select the first migration history.
+        state.sourceSchema.migrationHistory = head(migrationHistoryList);
+      } else {
+        // If database has no migration history, we will use its latest schema.
+        const schema = await databaseStore.fetchDatabaseSchemaById(
+          databaseId as DatabaseId
+        );
+        state.sourceSchema.migrationHistory = {
+          id: UNKNOWN_ID,
+          updatedTs: Date.now() / 1000,
+          schema: schema,
+          version: "Latest version",
+          description: "the latest schema of database",
+        } as any as MigrationHistory;
+      }
     } else {
       state.sourceSchema.migrationHistory = undefined;
     }


### PR DESCRIPTION
* use latest schema when database has no migration history;
* add a loading overlay;