### PR TITLE
chore(frontend): display timezone while filtering slow query time

### DIFF
--- a/frontend/src/components/SlowQuery/Panel/LogFilter.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogFilter.vue
@@ -60,7 +60,8 @@
           :placeholder="$t('slow-query.filter.from-date')"
           type="date"
           clearable
-          style="width: 10rem"
+          format="yyyy-MM-dd z"
+          style="width: 12rem"
           @update:value="changeFromTime($event)"
         />
         <NDatePicker
@@ -71,7 +72,8 @@
           :placeholder="$t('slow-query.filter.to-date')"
           type="date"
           clearable
-          style="width: 10rem"
+          format="yyyy-MM-dd z"
+          style="width: 12rem"
           @update:value="changeToTime($event)"
         />
       </NInputGroup>


### PR DESCRIPTION
We don't support manual timezone selection now. So it's good to display the local timezone explicitly to inform user the information.

### Screenshots
<img width="906" alt="image" src="https://user-images.githubusercontent.com/2749742/233918032-82e2b402-3cca-49ef-b33c-ca206b902222.png">