### PR TITLE
fix: exclude '__public' from database list of OceanBase instance

### DIFF
--- a/backend/plugin/db/mysql/sync.go
+++ b/backend/plugin/db/mysql/sync.go
@@ -37,6 +37,7 @@ var (
 		"SYS":        true,
 		"LBACSYS":    true,
 		"ORAAUDITOR": true,
+		"__public":   true,
 	}
 )
 


### PR DESCRIPTION
Found that there is still a system schema name '__public' in `information_schema.SCHEMATA` of OceanBase, which should be excluded from the database list of instance.

```mysql
mysql> SELECT
    -> SCHEMA_NAME,
    -> DEFAULT_CHARACTER_SET_NAME,
    -> DEFAULT_COLLATION_NAME
    -> FROM information_schema.SCHEMATA;
+--------------------+----------------------------+------------------------+
| SCHEMA_NAME        | DEFAULT_CHARACTER_SET_NAME | DEFAULT_COLLATION_NAME |
+--------------------+----------------------------+------------------------+
| oceanbase          | utf8mb4                    | utf8mb4_general_ci     |
| information_schema | utf8mb4                    | utf8mb4_general_ci     |
| mysql              | utf8mb4                    | utf8mb4_general_ci     |
| __public           | utf8mb4                    | utf8mb4_general_ci     |
| test               | utf8mb4                    | utf8mb4_general_ci     |
+--------------------+----------------------------+------------------------+
5 rows in set (0.18 sec)
```