### PR TITLE
chore: replace payload.Statement with sheet.Statement

### DIFF
--- a/backend/legacyapi/task.go
+++ b/backend/legacyapi/task.go
@@ -103,6 +103,7 @@ type TaskDatabaseCreatePayload struct {
 	DatabaseName string `json:"databaseName,omitempty"`
 	TableName    string `json:"tableName,omitempty"`
 	Statement    string `json:"statement,omitempty"`
+	SheetID      int    `json:"sheetId,omitempty"`
 	CharacterSet string `json:"character,omitempty"`
 	Collation    string `json:"collation,omitempty"`
 	Labels       string `json:"labels,omitempty"`

--- a/backend/runner/taskrun/schema_update_ghost_sync_executor.go
+++ b/backend/runner/taskrun/schema_update_ghost_sync_executor.go
@@ -42,7 +42,18 @@ func (exec *SchemaUpdateGhostSyncExecutor) RunOnce(ctx context.Context, task *st
 	if err := json.Unmarshal([]byte(task.Payload), payload); err != nil {
 		return true, nil, errors.Wrap(err, "invalid database schema update gh-ost sync payload")
 	}
-	return exec.runGhostMigration(ctx, exec.store, task, payload.Statement)
+	statement := payload.Statement
+	if payload.SheetID > 0 {
+		sheet, err := exec.store.GetSheet(ctx, &api.SheetFind{ID: &payload.SheetID, LoadFull: true}, api.SystemBotID)
+		if err != nil {
+			return true, nil, err
+		}
+		if sheet == nil {
+			return true, nil, errors.Errorf("sheet ID %v not found", payload.SheetID)
+		}
+		statement = sheet.Statement
+	}
+	return exec.runGhostMigration(ctx, exec.store, task, statement)
 }
 
 type sharedGhostState struct {


### PR DESCRIPTION
We want to completely rely on sheet.Statement to reduce unnecessary duplicates.

This PR adds sheet.ID to task payload and uses sheet statement.