### PR TITLE
feat(frontend): minor style tuning for slow query log table

### DIFF
--- a/frontend/src/components/SlowQuery/Panel/DetailPanel.vue
+++ b/frontend/src/components/SlowQuery/Panel/DetailPanel.vue
@@ -88,10 +88,10 @@
                 </div>
               </div>
               <div class="bb-grid-cell">
-                {{ detail.queryTime?.seconds.toFixed(6) }}
+                {{ detail.queryTime?.seconds.toFixed(2) }}s
               </div>
               <div class="bb-grid-cell">
-                {{ detail.lockTime?.seconds.toFixed(6) }}
+                {{ detail.lockTime?.seconds.toFixed(2) }}s
               </div>
               <div class="bb-grid-cell">
                 {{ detail.rowsExamined }}

--- a/frontend/src/components/SlowQuery/Panel/LogTable.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogTable.vue
@@ -7,7 +7,7 @@
       (row) => instanceHasSlowQueryDetail(row.database.instance)
     "
     :is-row-expanded="isSelectedRow"
-    class="border compact w-auto overflow-x-auto"
+    class="border w-auto overflow-x-auto"
     header-class="capitalize"
     @click-row="(log: ComposedSlowQueryLog) => $emit('select', log)"
   >
@@ -146,43 +146,43 @@ const columns = computed(() => {
     },
     {
       title: t("slow-query.sql-statement"),
-      width: "minmax(20rem, 1fr)",
+      width: "minmax(10rem, 1fr)",
     },
     {
       title: t("slow-query.total-query-count"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.query-count-percent"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.max-query-time"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.avg-query-time"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.query-time-percent"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.max-rows-examined"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.avg-rows-examined"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.max-rows-sent"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     {
       title: t("slow-query.avg-rows-sent"),
-      width: "minmax(6rem, auto)",
+      width: "6rem",
     },
     props.showProjectColumn && {
       title: t("common.project"),
@@ -190,15 +190,15 @@ const columns = computed(() => {
     },
     props.showEnvironmentColumn && {
       title: t("common.environment"),
-      width: "minmax(6rem, auto)",
+      width: "8rem",
     },
     props.showInstanceColumn && {
       title: t("common.instance"),
-      width: "minmax(12rem, 18rem)",
+      width: "12rem",
     },
     props.showDatabaseColumn && {
       title: t("common.database"),
-      width: "minmax(12rem, 18rem)",
+      width: "8rem",
     },
     {
       title: t("slow-query.last-query-time"),

--- a/frontend/src/components/SlowQuery/Panel/LogTable.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogTable.vue
@@ -224,7 +224,7 @@ const durationText = (duration: Duration | undefined) => {
   if (!duration) return "-";
   const { seconds, nanos } = duration;
   const total = seconds + nanos / 1e9;
-  return total.toFixed(6);
+  return total.toFixed(2) + "s";
 };
 
 watch(

--- a/frontend/src/store/modules/slowQuery.ts
+++ b/frontend/src/store/modules/slowQuery.ts
@@ -76,7 +76,7 @@ const composeSlowQueryLogDatabase = async (
     return map;
   }, new Map<string, Database>());
 
-  return slowQueryLogList.slice(0, 5).map<ComposedSlowQueryLog>((log) => ({
+  return slowQueryLogList.map<ComposedSlowQueryLog>((log) => ({
     log,
     database: databaseMap.get(log.resource) ?? unknown("DATABASE"), // databaseMap.get(log.resource)!,
   }));

--- a/frontend/src/store/modules/slowQuery.ts
+++ b/frontend/src/store/modules/slowQuery.ts
@@ -76,7 +76,7 @@ const composeSlowQueryLogDatabase = async (
     return map;
   }, new Map<string, Database>());
 
-  return slowQueryLogList.map<ComposedSlowQueryLog>((log) => ({
+  return slowQueryLogList.slice(0, 5).map<ComposedSlowQueryLog>((log) => ({
     log,
     database: databaseMap.get(log.resource) ?? unknown("DATABASE"), // databaseMap.get(log.resource)!,
   }));


### PR DESCRIPTION
### Changes
- Adjust column widths and column gaps
- Set decimal precision to 2 digits (Close BYT-3072)

### Screenshots

<img width="2231" alt="image" src="https://user-images.githubusercontent.com/2749742/234235485-029d0c54-47a1-4c00-a0ce-927131bdb979.png">
<img width="2231" alt="image" src="https://user-images.githubusercontent.com/2749742/234235782-30ed0759-941f-4a0e-a969-93d5cc22295c.png">

