### PR TITLE
chore: set issue mode to normal for tenant mode project in sync schema

### DIFF
--- a/frontend/src/components/Issue/logic/base.ts
+++ b/frontend/src/components/Issue/logic/base.ts
@@ -172,6 +172,7 @@ export const useBaseIssueLogic = (params: {
   });
 
   const isTenantMode = computed((): boolean => {
+    if (route.query.mode !== "tenant") return false;
     if (project.value.tenantMode !== "TENANT") return false;
 
     // We support single database migration in tenant mode projects.

--- a/frontend/src/views/SyncDatabaseSchema/index.vue
+++ b/frontend/src/views/SyncDatabaseSchema/index.vue
@@ -337,22 +337,15 @@ const tryFinishSetup = async () => {
 
   const project = await projectStore.getOrFetchProjectById(state.projectId!);
 
-  const isTenantProject = project.tenantMode === "TENANT";
   const query: Record<string, any> = {
     template: "bb.issue.database.schema.update",
     project: project.id,
     mode: "normal",
     ghost: undefined,
   };
-  if (isTenantProject) {
-    query.mode = "tenant";
-    query.sql = statementList.join("\n");
-    query.name = generateIssueName(targetDatabaseList.map((db) => db.name));
-  } else {
-    query.databaseList = databaseIdList.join(",");
-    query.sqlList = JSON.stringify(statementList);
-    query.name = generateIssueName(targetDatabaseList.map((db) => db.name));
-  }
+  query.databaseList = databaseIdList.join(",");
+  query.sqlList = JSON.stringify(statementList);
+  query.name = generateIssueName(targetDatabaseList.map((db) => db.name));
 
   const routeInfo = {
     name: "workspace.issue.detail",


### PR DESCRIPTION
In sync schema, we should allow different statements in tenant mode tasks. The easiest way is treat it as normal project.
