### PR TITLE
feat: add sheet id to task statement update acitivity payload

### DIFF
--- a/backend/legacyapi/activity.go
+++ b/backend/legacyapi/activity.go
@@ -167,6 +167,8 @@ type ActivityPipelineTaskStatementUpdatePayload struct {
 	TaskID       int    `json:"taskId"`
 	OldStatement string `json:"oldStatement,omitempty"`
 	NewStatement string `json:"newStatement,omitempty"`
+	OldSheetID   int    `json:"oldSheetId,omitempty"`
+	NewSheetID   int    `json:"newSheetId,omitempty"`
 	// Used by inbox to display info without paying the join cost
 	IssueName string `json:"issueName"`
 	TaskName  string `json:"taskName"`

--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -345,6 +345,17 @@ func GetTaskStatement(taskPayload string) (string, error) {
 	return taskStatement.Statement, nil
 }
 
+// GetTaskSheetID gets the sheetID of a task.
+func GetTaskSheetID(taskPayload string) (int, error) {
+	var taskSheetID struct {
+		SheetID int `json:"sheetId"`
+	}
+	if err := json.Unmarshal([]byte(taskPayload), &taskSheetID); err != nil {
+		return 0, err
+	}
+	return taskSheetID.SheetID, nil
+}
+
 // GetTaskSkippedAndReason gets skipped and skippedReason from a task.
 func GetTaskSkippedAndReason(task *api.Task) (bool, string, error) {
 	var payload struct {


### PR DESCRIPTION
Reuse `ActivityPipelineTaskStatementUpdatePayload` to record task.SheetID updated activities.