### PR TITLE
fix: should not reset instance_change_history in demo reset

### DIFF
--- a/backend/migrator/demo/reset.sql
+++ b/backend/migrator/demo/reset.sql
@@ -11,9 +11,6 @@ WHERE
 UPDATE setting SET creator_id = 1, updater_id = 1 WHERE name = 'bb.enterprise.license';
 
 DELETE FROM
-    instance_change_history;
-
-DELETE FROM
     risk;
 
 DELETE FROM

--- a/backend/migrator/migrator.go
+++ b/backend/migrator/migrator.go
@@ -194,6 +194,7 @@ func hasInstanceChangeTable(ctx context.Context, metadataDriver dbdriver.Driver)
 	return exists, nil
 }
 
+// migrates the old Bytebase schema up to where we create the instance_change_history table.
 func migrateOld(ctx context.Context, metadataDriver dbdriver.Driver, bytebasePgDriver *pg.Driver, databaseName, serverVersion string) error {
 	has, err := hasInstanceChangeTable(ctx, metadataDriver)
 	if err != nil {
@@ -285,6 +286,7 @@ func migrateOld(ctx context.Context, metadataDriver dbdriver.Driver, bytebasePgD
 				return err
 			}
 
+			// Stops the migration after we've reached to the point where we create the instance_change_history table.
 			has, err := hasInstanceChangeTable(ctx, metadataDriver)
 			if err != nil {
 				return err


### PR DESCRIPTION
instance_change_history is the table recording the migration history. It's the metadata table instead of the data table.

We need to retain it, otherwise the backfillHIstory will attempt to find the deleted migration_history table

![CleanShot 2023-05-07 at 00-48-29 png](https://user-images.githubusercontent.com/230323/236636801-667216ab-54cf-498a-8bce-25a8c1dc95b8.png)

## Symptom
First run success
![CleanShot 2023-05-07 at 00-49-27 png](https://user-images.githubusercontent.com/230323/236636834-27a59d7e-6fba-4ebe-9c39-948073b744f9.png)

Because the instance_change_history is reset and has no record, we will attempt to query the deleted table and fail to start
![CleanShot 2023-05-07 at 00-50-36 png](https://user-images.githubusercontent.com/230323/236636888-26761ef3-e21f-417b-a973-87dbd020e32d.png)

