### PR TITLE
chore: append a suffix to the schema version string

### DIFF
--- a/backend/plugin/db/driver.go
+++ b/backend/plugin/db/driver.go
@@ -141,6 +141,21 @@ const (
 	Data MigrationType = "DATA"
 )
 
+// GetVersionTypeSuffix returns the suffix used for schema version string from GitOps.
+func (t MigrationType) GetVersionTypeSuffix() string {
+	switch t {
+	case Migrate:
+		return "ddl"
+	case Data:
+		return "dml"
+	case MigrateSDL:
+		return "sdl"
+	case Baseline:
+		return "baseline"
+	}
+	return ""
+}
+
 // MigrationStatus is the status of migration.
 type MigrationStatus string
 

--- a/backend/server/webhook.go
+++ b/backend/server/webhook.go
@@ -1002,7 +1002,16 @@ func sortFilesBySchemaVersion(fileInfoList []fileInfo) []fileInfo {
 	sort.Slice(ret, func(i, j int) bool {
 		mi := ret[i].migrationInfo
 		mj := ret[j].migrationInfo
-		return mi.Database < mj.Database || (mi.Database == mj.Database && mi.Version < mj.Version)
+		if mi.Database < mj.Database {
+			return true
+		}
+		if mi.Database == mj.Database && mi.Version < mj.Version {
+			return true
+		}
+		if mi.Database == mj.Database && mi.Version == mj.Version && mi.Type.GetVersionTypeSuffix() < mj.Type.GetVersionTypeSuffix() {
+			return true
+		}
+		return false
 	})
 	return ret
 }
@@ -1304,7 +1313,7 @@ func (s *Server) prepareIssueFromFile(ctx context.Context, repo *api.Repository,
 				{
 					MigrationType: fileInfo.migrationInfo.Type,
 					SheetID:       sheet.ID,
-					SchemaVersion: fileInfo.migrationInfo.Version,
+					SchemaVersion: fmt.Sprintf("%s-%s", fileInfo.migrationInfo.Version, fileInfo.migrationInfo.Type.GetVersionTypeSuffix()),
 				},
 			}, nil
 		}
@@ -1356,7 +1365,7 @@ func (s *Server) prepareIssueFromFile(ctx context.Context, repo *api.Repository,
 						MigrationType: fileInfo.migrationInfo.Type,
 						DatabaseID:    db.UID,
 						SheetID:       sheet.ID,
-						SchemaVersion: fileInfo.migrationInfo.Version,
+						SchemaVersion: fmt.Sprintf("%s-%s", fileInfo.migrationInfo.Version, fileInfo.migrationInfo.Type.GetVersionTypeSuffix()),
 					},
 				)
 			}
@@ -1393,14 +1402,15 @@ func (s *Server) prepareIssueFromFile(ctx context.Context, repo *api.Repository,
 					MigrationType: fileInfo.migrationInfo.Type,
 					DatabaseID:    database.UID,
 					SheetID:       sheet.ID,
-					SchemaVersion: fileInfo.migrationInfo.Version,
+					SchemaVersion: fmt.Sprintf("%s-%s", fileInfo.migrationInfo.Version, fileInfo.migrationInfo.Type.GetVersionTypeSuffix()),
 				},
 			)
 		}
 		return migrationDetailList, nil
 	}
 
-	if err := s.tryUpdateTasksFromModifiedFile(ctx, databases, fileInfo.item.FileName, fileInfo.migrationInfo.Version, content); err != nil {
+	migrationVersion := fmt.Sprintf("%s-%s", fileInfo.migrationInfo.Version, fileInfo.migrationInfo.Type.GetVersionTypeSuffix())
+	if err := s.tryUpdateTasksFromModifiedFile(ctx, databases, fileInfo.item.FileName, migrationVersion, content); err != nil {
 		return nil, []*api.ActivityCreate{
 			getIgnoredFileActivityCreate(
 				repo.ProjectID,

--- a/backend/store/project_member.go
+++ b/backend/store/project_member.go
@@ -197,7 +197,10 @@ func (s *Store) getProjectPolicyImpl(ctx context.Context, tx *Tx, find *GetProje
 		if string(keys[i].role) < string(keys[j].role) {
 			return true
 		}
-		return keys[i].rawCondition < keys[j].rawCondition
+		if string(keys[i].role) == string(keys[j].role) && keys[i].rawCondition < keys[j].rawCondition {
+			return true
+		}
+		return false
 	})
 	projectPolicy := &IAMPolicyMessage{}
 	for _, key := range keys {

--- a/backend/tests/schema_update_test.go
+++ b/backend/tests/schema_update_test.go
@@ -751,10 +751,10 @@ func TestVCS(t *testing.T) {
 				a.Equalf(wantHistories[i], got, "got histories %+v", historiesDeref)
 				a.NotEmpty(history.Version)
 			}
-			a.Equal("ver4", histories[1].Version)
-			a.Equal("ver3", histories[2].Version)
-			a.Equal("ver2", histories[3].Version)
-			a.Equal("ver1", histories[4].Version)
+			a.Equal("ver4-dml", histories[1].Version)
+			a.Equal("ver3-ddl", histories[2].Version)
+			a.Equal("ver2-ddl", histories[3].Version)
+			a.Equal("ver1-ddl", histories[4].Version)
 		})
 	}
 }

--- a/backend/tests/tenant_test.go
+++ b/backend/tests/tenant_test.go
@@ -497,7 +497,7 @@ func TestTenantVCS(t *testing.T) {
 				)
 				a.NoError(err)
 				a.Len(histories, 1)
-				a.Equal(histories[0].Version, "ver1")
+				a.Equal("ver1-ddl", histories[0].Version)
 				hm1[histories[0].Version] = true
 			}
 			a.Len(hm1, 1)
@@ -961,7 +961,7 @@ func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
 				)
 				a.NoError(err)
 				a.Len(histories, 1)
-				a.Equal(histories[0].Version, "ver1")
+				a.Equal("ver1-ddl", histories[0].Version)
 				hm1[histories[0].Version] = true
 			}
 			for i, instance := range prodInstances {
@@ -975,7 +975,7 @@ func TestTenantVCSDatabaseNameTemplate(t *testing.T) {
 				)
 				a.NoError(err)
 				a.Len(histories, 1)
-				a.Equal("ver1", histories[0].Version)
+				a.Equal("ver1-ddl", histories[0].Version)
 				hm2[histories[0].Version] = true
 			}
 
@@ -1267,7 +1267,7 @@ func TestTenantVCSDatabaseNameTemplate_Empty(t *testing.T) {
 				)
 				a.NoError(err)
 				a.Len(histories, 1)
-				a.Equal(histories[0].Version, "ver1")
+				a.Equal("ver1-ddl", histories[0].Version)
 				hm[histories[0].Version] = true
 			}
 
@@ -1573,7 +1573,7 @@ statement: |
 			)
 			require.NoError(t, err)
 			require.Len(t, histories, 2)
-			require.Equal(t, histories[0].Version, "ver2")
+			require.Equal(t, "ver2-dml", histories[0].Version)
 
 			histories, err = ctl.getInstanceMigrationHistory(
 				testInstances[1].ID,
@@ -1583,7 +1583,7 @@ statement: |
 			)
 			require.NoError(t, err)
 			require.Len(t, histories, 1)
-			require.Equal(t, histories[0].Version, "ver1")
+			require.Equal(t, "ver1-ddl", histories[0].Version)
 		})
 	}
 }


### PR DESCRIPTION
Append a type suffix to the schema version. This will create two different tasks with different version for two files from GitOps.