### PR TITLE
chore(sql-editor): case insensitive keyword highlighting while filtering

### DIFF
--- a/frontend/src/views/sql-editor/AsidePanel/TreeNode/Label.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/TreeNode/Label.vue
@@ -9,7 +9,7 @@ import { useI18n } from "vue-i18n";
 import { escape } from "lodash-es";
 
 import { ConnectionAtom, DEFAULT_PROJECT_ID } from "@/types";
-import { getHighlightHTMLByKeyWords } from "@/utils";
+import { getHighlightHTMLByRegExp } from "@/utils";
 
 const props = defineProps<{
   atom: ConnectionAtom;
@@ -33,6 +33,10 @@ const text = computed(() => {
 });
 
 const html = computed(() => {
-  return getHighlightHTMLByKeyWords(escape(text.value), escape(props.keyword));
+  return getHighlightHTMLByRegExp(
+    escape(text.value),
+    escape(props.keyword.trim()),
+    false /* !caseSensitive */
+  );
 });
 </script>


### PR DESCRIPTION

### Screenshots

Before
<img width="359" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/22470f27-8691-4d22-9cd1-1921f9a779e8">

After
<img width="364" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/9e7eb274-9038-4d90-906e-532b83814ca0">
