### PR TITLE
refactor(frontend): use v1 API in project settings

### DIFF
--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -73,7 +73,7 @@ import {
   useRouterStore,
   useBookmarkStore,
   useDatabaseStore,
-  useProjectStore,
+  useProjectV1Store,
 } from "@/store";
 import HelpTriggerIcon from "@/components/HelpTriggerIcon.vue";
 
@@ -95,7 +95,7 @@ export default defineComponent({
     const bookmarkStore = useBookmarkStore();
 
     const currentUser = useCurrentUser();
-    const projectStore = useProjectStore();
+    const projectV1Store = useProjectV1Store();
 
     const documentTitle = useTitle(null, { observe: true });
 
@@ -153,9 +153,11 @@ export default defineComponent({
         });
 
         if (projectWebhookSlug) {
-          const project = projectStore.getProjectById(idFromSlug(projectSlug));
+          const project = projectV1Store.getProjectByUID(
+            idFromSlug(projectSlug)
+          );
           list.push({
-            name: `${project.name}`,
+            name: `${project.title}`,
             path: `/project/${projectSlug}`,
           });
         }

--- a/frontend/src/components/Project/ProjectSetting/ProjectGeneralSettingPanel.vue
+++ b/frontend/src/components/Project/ProjectSetting/ProjectGeneralSettingPanel.vue
@@ -11,7 +11,7 @@
         <dd class="mt-1 text-sm text-main">
           <input
             id="projectName"
-            v-model="state.name"
+            v-model="state.title"
             :disabled="!allowEdit"
             required
             autocomplete="off"
@@ -21,7 +21,7 @@
         </dd>
         <ResourceIdField
           resource-type="project"
-          :value="project.resourceId"
+          :value="extractProjectResourceName(project.name)"
           :readonly="true"
         />
       </dl>
@@ -57,7 +57,7 @@
               tabindex="-1"
               type="radio"
               class="btn"
-              value="DISABLED"
+              :value="TenantMode.TENANT_MODE_DISABLED"
             />
             <span class="label">{{ $t("project.mode.standard") }}</span>
           </label>
@@ -67,7 +67,7 @@
               tabindex="-1"
               type="radio"
               class="btn"
-              value="TENANT"
+              :value="TenantMode.TENANT_MODE_ENABLED"
             />
             <span class="label">{{ $t("project.mode.tenant") }}</span>
             <FeatureBadge
@@ -98,107 +98,87 @@
   </form>
 </template>
 
-<script lang="ts">
-import isEmpty from "lodash-es/isEmpty";
-import { computed, defineComponent, PropType, reactive } from "vue";
+<script lang="ts" setup>
+import { computed, PropType, reactive } from "vue";
+import { cloneDeep, isEmpty } from "lodash-es";
 import { useI18n } from "vue-i18n";
-import {
-  DEFAULT_PROJECT_ID,
-  Project,
-  ProjectPatch,
-  ProjectTenantMode,
-  FeatureType,
-} from "../../../types";
-import { hasFeature, pushNotification, useProjectStore } from "@/store";
+
+import { DEFAULT_PROJECT_ID, FeatureType } from "../../../types";
+import { hasFeature, pushNotification, useProjectV1Store } from "@/store";
 import FeatureModal from "@/components/FeatureModal.vue";
 import ResourceIdField from "@/components/v2/Form/ResourceIdField.vue";
+import { Project, TenantMode } from "@/types/proto/v1/project_service";
+import { extractProjectResourceName } from "@/utils";
 
 interface LocalState {
-  name: string;
+  title: string;
   key: string;
-  tenantMode: ProjectTenantMode;
+  tenantMode: TenantMode;
   requiredFeature: FeatureType | undefined;
 }
 
-export default defineComponent({
-  name: "ProjectGeneralSettingPanel",
-  components: {
-    FeatureModal,
-    ResourceIdField,
+const props = defineProps({
+  project: {
+    required: true,
+    type: Object as PropType<Project>,
   },
-  props: {
-    project: {
-      required: true,
-      type: Object as PropType<Project>,
-    },
-    allowEdit: {
-      default: true,
-      type: Boolean,
-    },
-  },
-  setup(props) {
-    const { t } = useI18n();
-    const projectStore = useProjectStore();
-
-    const state = reactive<LocalState>({
-      name: props.project.name,
-      key: props.project.key,
-      tenantMode: props.project.tenantMode,
-      requiredFeature: undefined,
-    });
-
-    const allowSave = computed((): boolean => {
-      return (
-        props.project.id != DEFAULT_PROJECT_ID &&
-        !isEmpty(state.name) &&
-        (state.name !== props.project.name ||
-          state.key !== props.project.key ||
-          state.tenantMode !== props.project.tenantMode)
-      );
-    });
-
-    const save = () => {
-      const projectPatch: ProjectPatch = {};
-
-      if (state.name !== props.project.name) {
-        projectPatch.name = state.name;
-      }
-      if (state.key !== props.project.key) {
-        projectPatch.key = state.key;
-      }
-      if (state.tenantMode !== props.project.tenantMode) {
-        if (state.tenantMode === "TENANT") {
-          if (!hasFeature("bb.feature.multi-tenancy")) {
-            state.tenantMode = "DISABLED";
-            state.requiredFeature = "bb.feature.multi-tenancy";
-            return;
-          }
-        }
-        projectPatch.tenantMode = state.tenantMode;
-      }
-
-      projectStore
-        .patchProject({
-          projectId: props.project.id,
-          projectPatch,
-        })
-        .then((updatedProject: Project) => {
-          pushNotification({
-            module: "bytebase",
-            style: "SUCCESS",
-            title: t("project.settings.success-updated"),
-          });
-          state.name = updatedProject.name;
-          state.key = updatedProject.key;
-          state.tenantMode = updatedProject.tenantMode;
-        });
-    };
-
-    return {
-      state,
-      allowSave,
-      save,
-    };
+  allowEdit: {
+    default: true,
+    type: Boolean,
   },
 });
+
+const { t } = useI18n();
+const projectV1Store = useProjectV1Store();
+
+const state = reactive<LocalState>({
+  title: props.project.title,
+  key: props.project.key,
+  tenantMode: props.project.tenantMode,
+  requiredFeature: undefined,
+});
+
+const allowSave = computed((): boolean => {
+  return (
+    parseInt(props.project.uid, 10) !== DEFAULT_PROJECT_ID &&
+    !isEmpty(state.title) &&
+    (state.title !== props.project.title ||
+      state.key !== props.project.key ||
+      state.tenantMode !== props.project.tenantMode)
+  );
+});
+
+const save = () => {
+  const projectPatch = cloneDeep(props.project);
+  const updateMask: Array<keyof Project> = [];
+  if (state.title !== props.project.title) {
+    projectPatch.title = state.title;
+    updateMask.push("title");
+  }
+  if (state.key !== props.project.key) {
+    projectPatch.key = state.key;
+    updateMask.push("key");
+  }
+  if (state.tenantMode !== props.project.tenantMode) {
+    if (state.tenantMode === TenantMode.TENANT_MODE_ENABLED) {
+      if (!hasFeature("bb.feature.multi-tenancy")) {
+        state.tenantMode = TenantMode.TENANT_MODE_DISABLED;
+        state.requiredFeature = "bb.feature.multi-tenancy";
+        return;
+      }
+    }
+    projectPatch.tenantMode = state.tenantMode;
+    updateMask.push("tenantMode");
+  }
+  projectV1Store.updateProject(projectPatch, updateMask).then((updated) => {
+    pushNotification({
+      module: "bytebase",
+      style: "SUCCESS",
+      title: t("project.settings.success-updated"),
+    });
+    state.title = updated.title;
+    state.key = updated.key;
+    state.tenantMode = updated.tenantMode;
+  });
+};
 </script>

--- a/frontend/src/components/Project/ProjectSetting/ProjectMemberTable/ProjectMemberTable.vue
+++ b/frontend/src/components/Project/ProjectSetting/ProjectMemberTable/ProjectMemberTable.vue
@@ -9,8 +9,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { Project } from "@/types";
-import type { IamPolicy } from "@/types/proto/v1/project_service";
+import type { IamPolicy, Project } from "@/types/proto/v1/project_service";
 import PrincipalTable from "./PrincipalTable.vue";
 import { ComposedPrincipal } from "../common";
 

--- a/frontend/src/components/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMemberPanel.vue
@@ -91,14 +91,13 @@ import {
   DEFAULT_PROJECT_ID,
   Principal,
   PrincipalId,
-  Project,
   ProjectRoleType,
   UNKNOWN_ID,
 } from "../types";
 import { PrincipalSelect, ProjectRolesSelect } from "./v2";
 import {
   addRoleToProjectIamPolicy,
-  hasPermissionInProject,
+  hasPermissionInProjectV1,
   hasWorkspacePermission,
 } from "../utils";
 import {
@@ -106,6 +105,7 @@ import {
   featureToRef,
   pushNotification,
   useCurrentUser,
+  useCurrentUserV1,
   useMemberStore,
   usePrincipalStore,
   useProjectIamPolicy,
@@ -113,6 +113,8 @@ import {
   useUserStore,
 } from "@/store";
 import { ComposedPrincipal } from "./Project/ProjectSetting/common";
+import { Project } from "@/types/proto/v1/project_service";
+import { State } from "@/types/proto/v1/common";
 
 interface LocalState {
   principalId: PrincipalId | undefined;
@@ -131,9 +133,8 @@ const props = defineProps({
 const ROLE_OWNER = "roles/OWNER";
 const { t } = useI18n();
 const currentUser = useCurrentUser();
-const projectResourceName = computed(
-  () => `projects/${props.project.resourceId}`
-);
+const currentUserV1 = useCurrentUserV1();
+const projectResourceName = computed(() => props.project.name);
 const { policy: iamPolicy, ready } = useProjectIamPolicy(projectResourceName);
 
 const state = reactive<LocalState>({
@@ -148,11 +149,11 @@ const userStore = useUserStore();
 const memberStore = useMemberStore();
 
 const allowAdmin = computed(() => {
-  if (props.project.id === DEFAULT_PROJECT_ID) {
+  if (parseInt(props.project.uid, 10) === DEFAULT_PROJECT_ID) {
     return false;
   }
 
-  if (props.project.rowStatus === "ARCHIVED") {
+  if (props.project.state === State.DELETED) {
     return false;
   }
 
@@ -167,9 +168,9 @@ const allowAdmin = computed(() => {
   }
 
   if (
-    hasPermissionInProject(
-      props.project,
-      currentUser.value,
+    hasPermissionInProjectV1(
+      iamPolicy.value,
+      currentUserV1.value,
       "bb.permission.project.manage-member"
     )
   ) {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -57,6 +57,7 @@ import {
   useCurrentUser,
   useSubscriptionStore,
   useUserStore,
+  useProjectV1Store,
 } from "@/store";
 import { useConversationStore } from "@/plugins/ai/store";
 import { PlanType } from "@/types/proto/v1/subscription_service";
@@ -1107,6 +1108,7 @@ router.beforeEach((to, from, next) => {
   const routerStore = useRouterStore();
   const projectWebhookStore = useProjectWebhookStore();
   const projectStore = useProjectStore();
+  const projectV1Store = useProjectV1Store();
 
   const isLoggedIn = authStore.isLoggedIn();
 
@@ -1426,6 +1428,7 @@ router.beforeEach((to, from, next) => {
   if (projectSlug) {
     projectStore
       .fetchProjectById(idFromSlug(projectSlug))
+      .then(() => projectV1Store.fetchProjectByUID(idFromSlug(projectSlug)))
       .then(() => {
         if (!projectWebhookSlug) {
           next();

--- a/frontend/src/utils/v1/project.ts
+++ b/frontend/src/utils/v1/project.ts
@@ -8,6 +8,12 @@ import {
   ProjectPermissionType,
 } from "../role";
 
+export const extractProjectResourceName = (name: string) => {
+  const pattern = /(?:^|\/)project\/([^/]+)(?:$|\/)/;
+  const matches = name.match(pattern);
+  return matches?.[1] ?? "";
+};
+
 export const hasPermissionInProjectV1 = (
   policy: IamPolicy,
   user: User,

--- a/frontend/src/views/ProjectDetail.vue
+++ b/frontend/src/views/ProjectDetail.vue
@@ -50,7 +50,7 @@
   <template v-if="project.id !== DEFAULT_PROJECT_ID && hash === 'setting'">
     <ProjectSettingPanel
       id="setting"
-      :project="project"
+      :project="projectV1"
       :allow-edit="allowEdit"
     />
   </template>
@@ -72,7 +72,12 @@ import ProjectVersionControlPanel from "../components/ProjectVersionControlPanel
 import ProjectWebhookPanel from "../components/ProjectWebhookPanel.vue";
 import ProjectSettingPanel from "../components/ProjectSettingPanel.vue";
 import ProjectDeploymentConfigPanel from "../components/ProjectDeploymentConfigPanel.vue";
-import { useDatabaseStore, useEnvironmentList, useProjectStore } from "@/store";
+import {
+  useDatabaseStore,
+  useEnvironmentList,
+  useProjectStore,
+  useProjectV1Store,
+} from "@/store";
 
 export default defineComponent({
   name: "ProjectDetail",
@@ -105,11 +110,15 @@ export default defineComponent({
     const route = useRoute();
     const databaseStore = useDatabaseStore();
     const projectStore = useProjectStore();
+    const projectV1Store = useProjectV1Store();
 
     const hash = computed(() => route.hash.replace(/^#?/, ""));
 
     const project = computed(() => {
       return projectStore.getProjectById(idFromSlug(props.projectSlug));
+    });
+    const projectV1 = computed(() => {
+      return projectV1Store.getProjectByUID(idFromSlug(props.projectSlug));
     });
 
     const environmentList = useEnvironmentList(["NORMAL"]);
@@ -137,6 +146,7 @@ export default defineComponent({
       DEFAULT_PROJECT_ID,
       hash,
       project,
+      projectV1,
       databaseList,
       isTenantProject,
     };


### PR DESCRIPTION
### Changes
- Fetch v1 project in routers
- Use v1 project in project settings
- Use v1 project in breadcrumb