### PR TITLE
chore(frontend): legacy project API compatibility

### DIFF
--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -13,6 +13,7 @@ import {
   useProjectStore,
   useDebugStore,
   useUserStore,
+  useCurrentUser,
 } from "@/store";
 import { defineComponent } from "vue";
 import { DEFAULT_PROJECT_ID } from "../types";
@@ -20,6 +21,8 @@ import { DEFAULT_PROJECT_ID } from "../types";
 export default defineComponent({
   name: "ProvideDashboardContext",
   async setup() {
+    const currentUser = useCurrentUser();
+
     await Promise.all([
       useSettingStore().fetchSetting(),
       // Fetch so MemberSelect can have the data.
@@ -35,6 +38,10 @@ export default defineComponent({
       useEnvironmentStore().fetchEnvironmentList(),
       // The default project hosts databases not explicitly assigned to other users project.
       useProjectStore().fetchProjectById(DEFAULT_PROJECT_ID),
+      // For legacy project API support. Remove this after shipping to project v1.
+      useProjectStore().fetchProjectListByUser({
+        userId: currentUser.value.id,
+      }),
       useUIStateStore().restoreState(),
       useDebugStore().fetchDebug(),
     ]);


### PR DESCRIPTION
We are using implicit data dependencies somewhere that imagine a project entity is pre-fetched. But we are not after shipping to v1 partly.
So we pre-fetch the project list globally for legacy compatibility. After shipping to project v1 totally, we should remove this.