### PR TITLE
chore: set BBCheckbox default value to false

### DIFF
--- a/frontend/src/bbkit/BBCheckbox.vue
+++ b/frontend/src/bbkit/BBCheckbox.vue
@@ -45,7 +45,7 @@ const props = withDefaults(
   {
     title: "",
     label: "",
-    value: true,
+    value: false,
     disabled: false,
   }
 );


### PR DESCRIPTION
It is pretty counter-intuitive to have the default value being `true`.