### PR TITLE
fix(sql-editor): restrict instance/database connection scope to provide different suggestion items

### DIFF
--- a/frontend/src/components/MonacoEditor/MonacoEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoEditor.vue
@@ -360,7 +360,8 @@ const formatEditorContent = () => {
 };
 
 const setEditorAutoCompletionContext = (
-  databaseMap: Map<Database, TableMetadata[]>
+  databaseMap: Map<Database, TableMetadata[]>,
+  connectionScope: "instance" | "database" = "database"
 ) => {
   const databases = [];
   for (const [database, tableList] of databaseMap) {
@@ -378,6 +379,7 @@ const setEditorAutoCompletionContext = (
   languageClientRef.value?.changeSchema({
     databases: databases,
   });
+  languageClientRef.value?.changeConnectionScope(connectionScope);
 };
 
 defineExpose({

--- a/frontend/src/plugins/sql-lsp/client/useLanguageClient.ts
+++ b/frontend/src/plugins/sql-lsp/client/useLanguageClient.ts
@@ -3,7 +3,7 @@ import { MonacoLanguageClient, MonacoServices } from "monaco-languageclient";
 import { StandaloneServices } from "@codingame/monaco-vscode-api/services";
 import getMessageServiceOverride from "@codingame/monaco-vscode-api/service-override/messages";
 import { createLanguageServerWorker } from "@sql-lsp/server";
-import { Schema, SQLDialect } from "@sql-lsp/types";
+import { ConnectionScope, Schema, SQLDialect } from "@sql-lsp/types";
 import { createLanguageClient } from "./createLanguageClient";
 
 type LocalStage = {
@@ -87,6 +87,13 @@ const changeDialect = (dialect: SQLDialect) => {
   });
 };
 
+const changeConnectionScope = (scope: ConnectionScope) => {
+  executeCommand({
+    command: "changeConnectionScope",
+    arguments: [scope],
+  });
+};
+
 const resolvePendingCommands = (client: MonacoLanguageClient) => {
   if (state.stopped) {
     return;
@@ -136,5 +143,5 @@ export const useLanguageClient = () => {
   // Initialize if needed
   getLanguageClient();
 
-  return { start, stop, changeSchema, changeDialect };
+  return { start, stop, changeSchema, changeDialect, changeConnectionScope };
 };

--- a/frontend/src/plugins/sql-lsp/server/complete/index.ts
+++ b/frontend/src/plugins/sql-lsp/server/complete/index.ts
@@ -3,7 +3,7 @@ import type {
   CompletionItem,
   CompletionParams,
 } from "vscode-languageserver/browser";
-import type { SQLDialect, Schema, Table, LanguageState } from "@sql-lsp/types";
+import type { Table, LanguageState } from "@sql-lsp/types";
 import {
   createColumnCandidates,
   createDatabaseCandidates,

--- a/frontend/src/plugins/sql-lsp/server/complete/index.ts
+++ b/frontend/src/plugins/sql-lsp/server/complete/index.ts
@@ -156,7 +156,7 @@ export const complete = async (
     const suggestionsForTable = createTableCandidates(
       tableList,
       // Add database prefix to table candidates when connection scope is 'instance'
-      state.connectionScope === "instance"
+      connectionScope === "instance"
     );
     const suggestionsForSubQueryVirtualTable = createSubQueryCandidates(
       subQueryMapping.virtualTableList
@@ -169,7 +169,7 @@ export const complete = async (
       ...suggestionsForTable,
       ...suggestionsForSubQueryVirtualTable,
     ];
-    if (state.connectionScope === "instance") {
+    if (connectionScope === "instance") {
       // Provide database suggestions only when we are connection to instance scope
       // MySQL allows to query different databases, so we provide the database name suggestion for MySQL.
       const suggestionsForDatabase = createDatabaseCandidates(schema.databases);

--- a/frontend/src/plugins/sql-lsp/types/index.ts
+++ b/frontend/src/plugins/sql-lsp/types/index.ts
@@ -1,2 +1,13 @@
+import { Schema } from "./schema";
+import { SQLDialect } from "./sql";
+
 export * from "./schema";
 export * from "./sql";
+
+export type ConnectionScope = "instance" | "database";
+
+export type LanguageState = {
+  schema: Schema;
+  dialect: SQLDialect;
+  connectionScope: ConnectionScope;
+};


### PR DESCRIPTION
- Show database suggestions only when connected to instance scope.
- Add database name prefix to table suggestions only when connected to instance scope.

Close BYT-2782