### PR TITLE
fix: use length instead of octet_length

### DIFF
--- a/backend/store/sheet.go
+++ b/backend/store/sheet.go
@@ -319,7 +319,7 @@ func createSheetImpl(ctx context.Context, tx *Tx, create *api.SheetCreate) (*she
 			payload
 		)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-		RETURNING id, row_status, creator_id, created_ts, updater_id, updated_ts, project_id, database_id, name, LEFT(statement, %d), visibility, source, type, payload, octet_length(statement)
+		RETURNING id, row_status, creator_id, created_ts, updater_id, updated_ts, project_id, database_id, name, LEFT(statement, %d), visibility, source, type, payload, LENGTH(statement)
 	`, common.MaxSheetSize)
 	var sheetRaw sheetRaw
 	databaseID := sql.NullInt32{}
@@ -396,7 +396,7 @@ func patchSheetImpl(ctx context.Context, tx *Tx, patch *api.SheetPatch) (*sheetR
 		UPDATE sheet
 		SET `+strings.Join(set, ", ")+`
 		WHERE id = $%d
-		RETURNING id, row_status, creator_id, created_ts, updater_id, updated_ts, project_id, database_id, name, LEFT(statement, %d), visibility, source, type, payload, octet_length(statement)
+		RETURNING id, row_status, creator_id, created_ts, updater_id, updated_ts, project_id, database_id, name, LEFT(statement, %d), visibility, source, type, payload, LENGTH(statement)
 	`, len(args), common.MaxSheetSize),
 		args...,
 	).Scan(
@@ -489,7 +489,7 @@ func findSheetImpl(ctx context.Context, tx *Tx, find *api.SheetFind) ([]*sheetRa
 			source,
 			type,
 			payload,
-			octet_length(statement)
+			LENGTH(statement)
 		FROM sheet
 		WHERE %s`, statementField, strings.Join(where, " AND ")),
 		args...,
@@ -772,7 +772,7 @@ func (s *Store) ListSheetsV2(ctx context.Context, find *api.SheetFind, currentPr
 			sheet.source,
 			sheet.type,
 			sheet.payload,
-			octet_length(sheet.statement),
+			LENGTH(sheet.statement),
 			COALESCE(sheet_organizer.starred, FALSE),
 			COALESCE(sheet_organizer.pinned, FALSE)
 		FROM sheet


### PR DESCRIPTION
`octet_length(string)` is using to get the number of bytes in binary string.

reference: https://www.postgresql.org/docs/9.0/functions-binarystring.html