### PR TITLE
refactor(frontend): narrow environment id type

### DIFF
--- a/frontend/src/components/AnomalyTable.vue
+++ b/frontend/src/components/AnomalyTable.vue
@@ -169,7 +169,7 @@ export default defineComponent({
           const payload =
             anomaly.payload as AnomalyDatabaseBackupPolicyViolationPayload;
           const environment = useEnvironmentV1Store().getEnvironmentByUID(
-            payload.environmentId
+            String(payload.environmentId)
           );
           return `'${environment.title}' environment requires ${payload.expectedSchedule} auto-backup.`;
         }

--- a/frontend/src/components/BackupTable.vue
+++ b/frontend/src/components/BackupTable.vue
@@ -106,7 +106,7 @@
       <CreateDatabasePrepForm
         v-if="state.restoreBackupContext.target === 'NEW'"
         :project-id="database.project.id"
-        :environment-id="database.instance.environment.id"
+        :environment-id="String(database.instance.environment.id)"
         :instance-id="database.instance.id"
         :backup="state.restoreBackupContext.backup"
         @dismiss="state.restoreBackupContext = undefined"

--- a/frontend/src/components/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm.vue
@@ -257,7 +257,6 @@ import ProjectSelect from "../components/ProjectSelect.vue";
 import MemberSelect from "../components/MemberSelect.vue";
 import InstanceEngineIcon from "../components/InstanceEngineIcon.vue";
 import {
-  EnvironmentId,
   InstanceId,
   ProjectId,
   IssueCreate,
@@ -297,7 +296,7 @@ import {
 
 interface LocalState {
   projectId?: ProjectId;
-  environmentId?: EnvironmentId;
+  environmentId?: string;
   instanceId?: InstanceId;
   instanceUserId?: InstanceUserId;
   labelList: DatabaseLabel[];
@@ -328,7 +327,7 @@ export default defineComponent({
       default: undefined,
     },
     environmentId: {
-      type: Number as PropType<EnvironmentId>,
+      type: String,
       default: undefined,
     },
     instanceId: {
@@ -485,7 +484,7 @@ export default defineComponent({
       state.projectId = projectId;
     };
 
-    const selectEnvironment = (environmentId: EnvironmentId) => {
+    const selectEnvironment = (environmentId: string) => {
       state.environmentId = environmentId;
     };
 

--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -364,6 +364,7 @@ const onConfirm = async () => {
         environmentId: context.environmentId,
         instanceId: context.instanceId,
         databaseName: context.databaseName,
+        tableName: "",
         characterSet: context.characterSet,
         collation: context.collation,
         owner: "",

--- a/frontend/src/components/DatabaseDetail/utils.ts
+++ b/frontend/src/components/DatabaseDetail/utils.ts
@@ -1,9 +1,9 @@
-import { DatabaseLabel, EnvironmentId, InstanceId, ProjectId } from "@/types";
+import { DatabaseLabel, InstanceId, ProjectId } from "@/types";
 
 // MySQL only by now
 export type CreatePITRDatabaseContext = {
   projectId: ProjectId;
-  environmentId: EnvironmentId;
+  environmentId: number;
   instanceId: InstanceId;
   databaseName: string;
   characterSet: string;

--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -14,7 +14,7 @@ import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { Action, defineAction, useRegisterActions } from "@bytebase/vue-kbar";
 import type { BBOutlineItem } from "@/bbkit/types";
-import { Database, EnvironmentId, UNKNOWN_ID } from "@/types";
+import { Database, UNKNOWN_ID } from "@/types";
 import { databaseSlug, environmentV1Name, projectSlug } from "@/utils";
 import {
   useEnvironmentV1List,
@@ -55,7 +55,7 @@ export default defineComponent({
     });
 
     const databaseListByEnvironment = computed(() => {
-      const envToDbMap: Map<EnvironmentId, BBOutlineItem[]> = new Map();
+      const envToDbMap: Map<string, BBOutlineItem[]> = new Map();
       for (const environment of environmentList.value) {
         envToDbMap.set(environment.uid, []);
       }

--- a/frontend/src/components/DatabaseSelect.vue
+++ b/frontend/src/components/DatabaseSelect.vue
@@ -146,7 +146,10 @@ export default defineComponent({
         });
       }
 
-      if (props.environmentId !== String(UNKNOWN_ID) || props.projectId != UNKNOWN_ID) {
+      if (
+        props.environmentId !== String(UNKNOWN_ID) ||
+        props.projectId != UNKNOWN_ID
+      ) {
         list = list.filter((database: Database) => {
           return (
             (props.environmentId === String(UNKNOWN_ID) ||

--- a/frontend/src/components/DatabaseSelect.vue
+++ b/frontend/src/components/DatabaseSelect.vue
@@ -36,7 +36,6 @@ import {
   Database,
   ProjectId,
   InstanceId,
-  EnvironmentId,
   EngineType,
   DatabaseSyncStatus,
   DEFAULT_PROJECT_ID,
@@ -58,8 +57,8 @@ export default defineComponent({
       type: String as PropType<"ALL" | "INSTANCE" | "ENVIRONMENT" | "USER">,
     },
     environmentId: {
-      type: Number as PropType<EnvironmentId>,
-      default: UNKNOWN_ID,
+      type: String,
+      default: String(UNKNOWN_ID),
     },
     instanceId: {
       type: Number as PropType<InstanceId>,
@@ -106,7 +105,7 @@ export default defineComponent({
         databaseStore.fetchDatabaseList();
       } else if (
         props.mode == "ENVIRONMENT" &&
-        props.environmentId != UNKNOWN_ID
+        props.environmentId !== String(UNKNOWN_ID)
       ) {
         databaseStore.fetchDatabaseListByEnvironmentId(props.environmentId);
       } else if (props.mode == "INSTANCE" && props.instanceId != UNKNOWN_ID) {
@@ -124,7 +123,7 @@ export default defineComponent({
         list = databaseStore.getDatabaseList();
       } else if (
         props.mode == "ENVIRONMENT" &&
-        props.environmentId != UNKNOWN_ID
+        props.environmentId !== String(UNKNOWN_ID)
       ) {
         list = databaseStore.getDatabaseListByEnvironmentId(
           props.environmentId
@@ -147,10 +146,10 @@ export default defineComponent({
         });
       }
 
-      if (props.environmentId != UNKNOWN_ID || props.projectId != UNKNOWN_ID) {
+      if (props.environmentId !== String(UNKNOWN_ID) || props.projectId != UNKNOWN_ID) {
         list = list.filter((database: Database) => {
           return (
-            (props.environmentId == UNKNOWN_ID ||
+            (props.environmentId === String(UNKNOWN_ID) ||
               database.instance.environment.id == props.environmentId) &&
             (props.projectId == UNKNOWN_ID ||
               database.project.id == props.projectId)

--- a/frontend/src/components/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm.vue
@@ -658,7 +658,7 @@ interface BasicInformation {
   name: string;
   engine: EngineType;
   externalLink?: string;
-  environmentId: number;
+  environmentId: string;
 }
 
 interface LocalState {
@@ -695,7 +695,7 @@ const basicInformation = ref<BasicInformation>({
   rowStatus: props.instance?.rowStatus || "NORMAL",
   name: props.instance?.name || t("instance.new-instance"),
   engine: props.instance?.engine || "MYSQL",
-  environmentId: (props.instance?.environment.id || UNKNOWN_ID) as number,
+  environmentId: String(props.instance?.environment.id || UNKNOWN_ID),
 });
 
 const resourceIdField = ref<InstanceType<typeof ResourceIdField>>();
@@ -1210,7 +1210,7 @@ const updateInstanceState = async () => {
     rowStatus: instance.rowStatus,
     name: instance.name,
     engine: instance.engine,
-    environmentId: instance.environment.id as number,
+    environmentId: String(instance.environment.id),
   };
   adminDataSource.value = {
     ...cloneDeep(instance.dataSourceList.find((ds) => ds.type === "ADMIN")!),
@@ -1277,7 +1277,7 @@ const doCreate = async () => {
     name: basicInformation.value.name.trim(),
     engine: basicInformation.value.engine,
     externalLink: basicInformation.value.externalLink,
-    environmentId: basicInformation.value.environmentId,
+    environmentId: parseInt(basicInformation.value.environmentId, 10),
     host: adminDataSource.value.host,
     port: adminDataSource.value.port,
     database: adminDataSource.value.database,
@@ -1605,7 +1605,7 @@ const getInstanceStateData = () => {
       rowStatus: props.instance?.rowStatus || "NORMAL",
       name: props.instance?.name || t("instance.new-instance"),
       engine: props.instance?.engine || "MYSQL",
-      environmentId: (props.instance?.environment.id || UNKNOWN_ID) as number,
+      environmentId: String(props.instance?.environment.id || UNKNOWN_ID),
     },
     adminDataSource: {
       ...(getDataSourceWithType("ADMIN") || unknown("DATA_SOURCE")),

--- a/frontend/src/components/InstanceSelect.vue
+++ b/frontend/src/components/InstanceSelect.vue
@@ -32,7 +32,7 @@ export default defineComponent({
       default: undefined,
     },
     environmentId: {
-      type: [String, Number] as PropType<IdType>,
+      type: String,
       default: undefined,
     },
     filter: {

--- a/frontend/src/components/InstanceTable.vue
+++ b/frontend/src/components/InstanceTable.vue
@@ -45,7 +45,7 @@ import { EnvironmentName } from "@/components/v2";
 
 export default defineComponent({
   name: "InstanceTable",
-  components: { InstanceEngineIcon },
+  components: { InstanceEngineIcon, EnvironmentName },
   props: {
     instanceList: {
       required: true,

--- a/frontend/src/components/InstanceTable.vue
+++ b/frontend/src/components/InstanceTable.vue
@@ -40,12 +40,12 @@ import { useRouter } from "vue-router";
 import { urlfy, instanceSlug } from "@/utils";
 import { Instance } from "@/types";
 import InstanceEngineIcon from "./InstanceEngineIcon.vue";
-import ProductionEnvironmentIcon from "./Environment/ProductionEnvironmentIcon.vue";
 import { BBGridColumn } from "@/bbkit";
+import { EnvironmentName } from "@/components/v2";
 
 export default defineComponent({
   name: "InstanceTable",
-  components: { InstanceEngineIcon, ProductionEnvironmentIcon },
+  components: { InstanceEngineIcon },
   props: {
     instanceList: {
       required: true,

--- a/frontend/src/components/InstanceTable.vue
+++ b/frontend/src/components/InstanceTable.vue
@@ -13,10 +13,7 @@
         {{ instanceName(instance) }}
       </div>
       <div class="bb-grid-cell">
-        <div class="flex items-center gap-x-1">
-          {{ environmentNameFromId(instance.environment.id) }}
-          <ProductionEnvironmentIcon :environment="instance.environment" />
-        </div>
+        <EnvironmentName :environment="instance.environment" :link="false" />
       </div>
       <div class="bb-grid-cell">
         <template v-if="instance.port"
@@ -40,9 +37,8 @@
 import { PropType, defineComponent, computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
-import { urlfy, instanceSlug, environmentV1Name } from "@/utils";
-import { EnvironmentId, Instance } from "@/types";
-import { useEnvironmentV1Store } from "@/store";
+import { urlfy, instanceSlug } from "@/utils";
+import { Instance } from "@/types";
 import InstanceEngineIcon from "./InstanceEngineIcon.vue";
 import ProductionEnvironmentIcon from "./Environment/ProductionEnvironmentIcon.vue";
 import { BBGridColumn } from "@/bbkit";
@@ -101,16 +97,10 @@ export default defineComponent({
       }
     };
 
-    const environmentNameFromId = (id: EnvironmentId) => {
-      const env = useEnvironmentV1Store().getEnvironmentByUID(id);
-      return environmentV1Name(env);
-    };
-
     return {
       columnList,
       urlfy,
       clickInstance,
-      environmentNameFromId,
     };
   },
 });

--- a/frontend/src/components/Issue/IssueOutputPanel.vue
+++ b/frontend/src/components/Issue/IssueOutputPanel.vue
@@ -96,7 +96,7 @@ import { toClipboard } from "@soerenmartius/vue3-clipboard";
 import DatabaseSelect from "../DatabaseSelect.vue";
 import { activeEnvironment } from "@/utils";
 import { OutputField, IssueContext } from "@/plugins";
-import { DatabaseId, EnvironmentId, Issue, UNKNOWN_ID } from "@/types";
+import { DatabaseId, Issue, UNKNOWN_ID } from "@/types";
 import { pushNotification, useCurrentUser } from "@/store";
 import { useExtraIssueLogic, useIssueLogic } from "./logic";
 
@@ -108,8 +108,8 @@ const { allowEditOutput, updateCustomField } = useExtraIssueLogic();
 
 const currentUser = useCurrentUser();
 
-const environmentId = computed((): EnvironmentId => {
-  return activeEnvironment(issue.value.pipeline).id;
+const environmentId = computed((): string => {
+  return String(activeEnvironment(issue.value.pipeline).id);
 });
 
 const fieldValue = (field: OutputField): string => {

--- a/frontend/src/components/Issue/IssueSidebar.vue
+++ b/frontend/src/components/Issue/IssueSidebar.vue
@@ -426,13 +426,11 @@ const databaseName = computed((): string | undefined => {
 });
 
 const environment = computed((): Environment => {
-  if (create.value) {
-    const stage = selectedStage.value as StageCreate;
-    return useEnvironmentV1Store().getEnvironmentByUID(stage.environmentId);
-  }
-  const stage = selectedStage.value as Stage;
+  const environmentId = create.value
+    ? (selectedStage.value as StageCreate).environmentId
+    : (selectedStage.value as Stage).environment.id;
 
-  return useEnvironmentV1Store().getEnvironmentByUID(stage.environment.id);
+  return useEnvironmentV1Store().getEnvironmentByUID(String(environmentId));
 });
 
 const project = computed((): Project => {

--- a/frontend/src/components/Issue/StatusTransitionForm.vue
+++ b/frontend/src/components/Issue/StatusTransitionForm.vue
@@ -221,7 +221,7 @@ export default defineComponent({
     });
 
     const environmentId = computed(() => {
-      return activeEnvironment(props.issue.pipeline).id;
+      return String(activeEnvironment(props.issue.pipeline).id);
     });
 
     // Code block below will raise an eslint ERROR.

--- a/frontend/src/components/Issue/form/GrantRequestExporterForm.vue
+++ b/frontend/src/components/Issue/form/GrantRequestExporterForm.vue
@@ -209,7 +209,7 @@ const handleDatabaseSelect = (databaseId: DatabaseId) => {
     state.databaseId || UNKNOWN_ID
   );
   if (database) {
-    state.environmentId = String(database.instance.environment.id)
+    state.environmentId = String(database.instance.environment.id);
     handleProjectSelect(database.projectId);
   }
 };

--- a/frontend/src/components/Issue/form/GrantRequestExporterForm.vue
+++ b/frontend/src/components/Issue/form/GrantRequestExporterForm.vue
@@ -193,7 +193,7 @@ const handleProjectSelect = async (projectId: ProjectId) => {
   }
 };
 
-const handleEnvironmentSelect = (environmentId: EnvironmentId) => {
+const handleEnvironmentSelect = (environmentId: string) => {
   state.environmentId = environmentId;
   const database = databaseStore.getDatabaseById(
     state.databaseId || UNKNOWN_ID
@@ -209,7 +209,7 @@ const handleDatabaseSelect = (databaseId: DatabaseId) => {
     state.databaseId || UNKNOWN_ID
   );
   if (database) {
-    state.environmentId = database.instance.environment.id;
+    state.environmentId = String(database.instance.environment.id)
     handleProjectSelect(database.projectId);
   }
 };

--- a/frontend/src/components/Issue/form/GrantRequestExporterForm.vue
+++ b/frontend/src/components/Issue/form/GrantRequestExporterForm.vue
@@ -115,7 +115,6 @@ import { computed, onMounted, reactive, watch } from "vue";
 import { useIssueLogic } from "../logic";
 import {
   DatabaseId,
-  EnvironmentId,
   GrantRequestContext,
   GrantRequestPayload,
   Issue,
@@ -135,7 +134,7 @@ import RequiredStar from "@/components/RequiredStar.vue";
 interface LocalState {
   // For creating
   projectId?: ProjectId;
-  environmentId?: EnvironmentId;
+  environmentId?: string;
   databaseId?: DatabaseId;
   maxRowCount: number;
   exportFormat: "CSV" | "JSON";

--- a/frontend/src/components/Issue/logic/assignee.ts
+++ b/frontend/src/components/Issue/logic/assignee.ts
@@ -39,14 +39,10 @@ export const useCurrentRollOutPolicyForActiveEnvironment = () => {
   }
 
   const activeEnvironment = computed(() => {
-    if (create.value) {
-      // When creating an issue, activeEnvironmentId is the first stage's environmentId
-      const stage = (issue.value as IssueCreate).pipeline!.stageList[0];
-      return useEnvironmentV1Store().getEnvironmentByUID(stage.environmentId);
-    }
-
-    const stage = activeStageOfPipeline(issue.value.pipeline as Pipeline);
-    return useEnvironmentV1Store().getEnvironmentByUID(stage.environment.id);
+    const environmentId = create.value
+      ? (issue.value as IssueCreate).pipeline!.stageList[0].environmentId
+      : activeStageOfPipeline(issue.value.pipeline as Pipeline).id;
+    return useEnvironmentV1Store().getEnvironmentByUID(String(environmentId));
   });
 
   const activeEnvironmentApprovalPolicy = usePolicyByParentAndType(

--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -35,6 +35,7 @@ export default defineComponent({
       useEnvironmentV1Store().fetchEnvironments(),
       // The default project hosts databases not explicitly assigned to other users project.
       useProjectStore().fetchProjectById(DEFAULT_PROJECT_ID),
+      useProjectStore().fetchAllProjectList(), // TODO(Jim): For legacy API support only. Remove this after refactored
       useUIStateStore().restoreState(),
       useDebugStore().fetchDebug(),
     ]);

--- a/frontend/src/components/SlowQuery/Panel/LogFilter.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogFilter.vue
@@ -97,7 +97,6 @@ import dayjs from "dayjs";
 
 import {
   type DatabaseId,
-  type EnvironmentId,
   type InstanceId,
   type ProjectId,
   UNKNOWN_ID,
@@ -140,7 +139,7 @@ const canVisitDefaultProject = computed(() => {
   );
 });
 
-const changeEnvironmentId = (id: EnvironmentId) => {
+const changeEnvironmentId = (id: string) => {
   const environment = useEnvironmentV1Store().getEnvironmentByUID(id);
   update({ environment });
 };

--- a/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
@@ -134,14 +134,14 @@ import { computed, PropType, reactive, watch } from "vue";
 import { NCollapse, NCollapseItem } from "naive-ui";
 
 import { type BBGridColumn, BBGrid } from "@/bbkit";
-import { Database, DatabaseId, EnvironmentId } from "@/types";
+import { Database, DatabaseId } from "@/types";
 import { TransferSource } from "./utils";
 import { useDatabaseStore, useEnvironmentV1List } from "@/store";
 import { Environment } from "@/types/proto/v1/environment_service";
 import { ProductionEnvironmentV1Icon } from "../v2";
 
 type LocalState = {
-  selectedDatabaseIdListForEnvironment: Map<EnvironmentId, Set<DatabaseId>>;
+  selectedDatabaseIdListForEnvironment: Map<string, Set<DatabaseId>>;
 };
 
 const props = defineProps({
@@ -218,7 +218,7 @@ const combinedSelectedDatabaseIdList = computed(() => {
 
 const isDatabaseSelectedForEnvironment = (
   databaseId: DatabaseId,
-  environmentId: EnvironmentId
+  environmentId: string
 ) => {
   const map = state.selectedDatabaseIdListForEnvironment;
   const set = map.get(environmentId) || new Set();
@@ -227,7 +227,7 @@ const isDatabaseSelectedForEnvironment = (
 
 const toggleDatabaseIdForEnvironment = (
   databaseId: DatabaseId,
-  environmentId: EnvironmentId,
+  environmentId: string,
   selected: boolean
 ) => {
   const map = state.selectedDatabaseIdListForEnvironment;
@@ -282,8 +282,8 @@ const getSelectionStateSummaryForEnvironment = (
 const handleClickRow = (db: Database) => {
   toggleDatabaseIdForEnvironment(
     db.id,
-    db.instance.environment.id,
-    !isDatabaseSelectedForEnvironment(db.id, db.instance.environment.id)
+    String(db.instance.environment.id),
+    !isDatabaseSelectedForEnvironment(db.id, String(db.instance.environment.id))
   );
 };
 

--- a/frontend/src/components/TransferOutDatabaseForm/Label.vue
+++ b/frontend/src/components/TransferOutDatabaseForm/Label.vue
@@ -33,7 +33,7 @@ const props = defineProps<{
 }>();
 
 const id = computed(() => {
-  return parseInt(props.option.value.split("-").pop()!, 10);
+  return props.option.value.split("-").pop()!;
 });
 
 const environment = computed(() => {

--- a/frontend/src/components/v2/Select/DatabaseSelect.vue
+++ b/frontend/src/components/v2/Select/DatabaseSelect.vue
@@ -22,7 +22,6 @@ import {
   DatabaseId,
   EngineType,
   EngineTypeList,
-  EnvironmentId,
   InstanceId,
   ProjectId,
   UNKNOWN_ID,
@@ -37,7 +36,7 @@ interface DatabaseSelectOption extends SelectOption {
 const props = withDefaults(
   defineProps<{
     database: DatabaseId | undefined;
-    environment?: EnvironmentId;
+    environment?: string;
     instance?: InstanceId;
     project?: ProjectId;
     allowedEngineTypeList?: readonly EngineType[];
@@ -73,7 +72,7 @@ const rawDatabaseList = computed(() => {
   const list = databaseStore.getDatabaseListByPrincipalId(currentUser.value.id);
 
   return list.filter((db) => {
-    if (props.environment && props.environment !== UNKNOWN_ID) {
+    if (props.environment && props.environment !== String(UNKNOWN_ID)) {
       if (db.instance.environment.id !== props.environment) return false;
     }
     if (props.instance && props.instance !== UNKNOWN_ID) {

--- a/frontend/src/components/v2/Select/InstanceSelect.vue
+++ b/frontend/src/components/v2/Select/InstanceSelect.vue
@@ -22,7 +22,6 @@ import { useI18n } from "vue-i18n";
 import { useInstanceList, useInstanceStore } from "@/store";
 import {
   InstanceId,
-  EnvironmentId,
   Instance,
   EngineType,
   unknown,
@@ -39,7 +38,7 @@ interface InstanceSelectOption extends SelectOption {
 const props = withDefaults(
   defineProps<{
     instance: InstanceId | undefined;
-    environment?: EnvironmentId;
+    environment?: string;
     allowedEngineTypeList?: readonly EngineType[];
     includeAll?: boolean;
     includeArchived?: boolean;
@@ -66,7 +65,7 @@ useInstanceList();
 
 const rawInstanceList = computed(() => {
   let list: Instance[] = [];
-  if (props.environment && props.environment !== UNKNOWN_ID) {
+  if (props.environment && props.environment !== String(UNKNOWN_ID)) {
     list = instanceStore.getInstanceListByEnvironmentId(props.environment, [
       "NORMAL",
       "ARCHIVED",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -573,7 +573,7 @@ const routes: Array<RouteRecordRaw> = [
                     const slug = route.params.sqlReviewPolicySlug as string;
                     return (
                       useSQLReviewStore().getReviewPolicyByEnvironmentUID(
-                        idFromSlug(slug)
+                        String(idFromSlug(slug))
                       )?.name ?? ""
                     );
                   },
@@ -653,7 +653,7 @@ const routes: Array<RouteRecordRaw> = [
               title: (route: RouteLocationNormalized) => {
                 const slug = route.params.environmentSlug as string;
                 return useEnvironmentV1Store().getEnvironmentByUID(
-                  idFromSlug(slug)
+                  String(idFromSlug(slug))
                 ).title;
               },
               allowBookmark: true,
@@ -1441,7 +1441,7 @@ router.beforeEach((to, from, next) => {
 
   if (environmentSlug) {
     useEnvironmentV1Store()
-      .getOrFetchEnvironmentByUID(idFromSlug(environmentSlug))
+      .getOrFetchEnvironmentByUID(String(idFromSlug(environmentSlug)))
       .then((env) => {
         // getEnvironmentById returns unknown("ENVIRONMENT") when it doesn't exist
         // so we need to check the id here
@@ -1595,7 +1595,7 @@ router.beforeEach((to, from, next) => {
 
   if (sqlReviewPolicySlug) {
     useSQLReviewStore()
-      .getOrFetchReviewPolicyByEnvironmentUID(idFromSlug(sqlReviewPolicySlug))
+      .getOrFetchReviewPolicyByEnvironmentUID(String(idFromSlug(sqlReviewPolicySlug)))
       .then(() => {
         next();
       })

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1595,7 +1595,9 @@ router.beforeEach((to, from, next) => {
 
   if (sqlReviewPolicySlug) {
     useSQLReviewStore()
-      .getOrFetchReviewPolicyByEnvironmentUID(String(idFromSlug(sqlReviewPolicySlug)))
+      .getOrFetchReviewPolicyByEnvironmentUID(
+        String(idFromSlug(sqlReviewPolicySlug))
+      )
       .then(() => {
         next();
       })

--- a/frontend/src/store/modules/backup.ts
+++ b/frontend/src/store/modules/backup.ts
@@ -9,7 +9,6 @@ import {
   BackupSettingUpsert,
   BackupState,
   DatabaseId,
-  EnvironmentId,
   ResourceObject,
   unknown,
 } from "@/types";
@@ -176,7 +175,7 @@ export const useBackupStore = defineStore("backup", {
     },
 
     async upsertBackupSettingByEnvironmentId(
-      environmentId: EnvironmentId,
+      environmentId: string,
       backupSettingUpsert: Omit<BackupSettingUpsert, "databaseId">
     ) {
       const url = `/api/environment/${environmentId}/backup-setting`;

--- a/frontend/src/store/modules/database.ts
+++ b/frontend/src/store/modules/database.ts
@@ -11,7 +11,6 @@ import {
   DataSource,
   empty,
   EMPTY_ID,
-  EnvironmentId,
   Instance,
   InstanceId,
   MaybeRef,
@@ -183,11 +182,11 @@ export const useDatabaseStore = defineStore("database", {
       }
       return list;
     },
-    getDatabaseListByEnvironmentId(environmentId: EnvironmentId): Database[] {
+    getDatabaseListByEnvironmentId(environmentId: string): Database[] {
       const list: Database[] = [];
       for (const [_, databaseList] of this.databaseListByInstanceId) {
         databaseList.forEach((item: Database) => {
-          if (item.instance.environment.id == environmentId) {
+          if (String(item.instance.environment.id) === environmentId) {
             list.push(item);
           }
         });
@@ -330,7 +329,7 @@ export const useDatabaseStore = defineStore("database", {
 
       return databaseList;
     },
-    async fetchDatabaseListByEnvironmentId(environmentId: EnvironmentId) {
+    async fetchDatabaseListByEnvironmentId(environmentId: string) {
       // Don't fetch the data source info as the current user may not have access to the
       // database of this particular environment.
       const data = (

--- a/frontend/src/store/modules/instance.ts
+++ b/frontend/src/store/modules/instance.ts
@@ -6,7 +6,6 @@ import {
   empty,
   EMPTY_ID,
   Environment,
-  EnvironmentId,
   Instance,
   InstanceCreate,
   InstanceId,
@@ -143,12 +142,12 @@ export const useInstanceStore = defineStore("instance", {
       });
     },
     getInstanceListByEnvironmentId(
-      environmentId: EnvironmentId,
+      environmentId: string,
       rowStatusList?: RowStatus[]
     ): Instance[] {
       const list = this.getInstanceList(rowStatusList);
       return list.filter((item: Instance) => {
-        return item.environment.id == environmentId;
+        return String(item.environment.id) === environmentId;
       });
     },
     getInstanceById(instanceId: InstanceId): Instance {

--- a/frontend/src/store/modules/sqlReview.ts
+++ b/frontend/src/store/modules/sqlReview.ts
@@ -1,7 +1,6 @@
 import { pullAt } from "lodash-es";
 import {
   PolicyId,
-  EnvironmentId,
   RowStatus,
   SchemaPolicyRule,
   SQLReviewPolicy,
@@ -255,7 +254,7 @@ export const useSQLReviewStore = defineStore("sqlReview", {
       }
     },
     getReviewPolicyByEnvironmentUID(
-      environmentUID: EnvironmentId
+      environmentUID: string
     ): SQLReviewPolicy | undefined {
       return this.reviewPolicyList.find(
         (g) => g.environment.uid == environmentUID
@@ -281,7 +280,7 @@ export const useSQLReviewStore = defineStore("sqlReview", {
       return reviewPolicyList;
     },
     async getOrFetchReviewPolicyByEnvironmentUID(
-      environmentUID: EnvironmentId
+      environmentUID: string
     ): Promise<SQLReviewPolicy | undefined> {
       const environment = await getEnvironmentById(environmentUID);
       const policyStore = usePolicyV1Store();
@@ -312,7 +311,7 @@ export const useSQLReviewPolicyList = () => {
 };
 
 export const useReviewPolicyByEnvironmentId = (
-  environmentId: MaybeRef<EnvironmentId>
+  environmentId: MaybeRef<string>
 ) => {
   const store = useSQLReviewStore();
   watchEffect(() => {

--- a/frontend/src/store/modules/v1/environment.ts
+++ b/frontend/src/store/modules/v1/environment.ts
@@ -7,7 +7,7 @@ import {
   Environment,
   EnvironmentTier,
 } from "@/types/proto/v1/environment_service";
-import { ResourceId, EnvironmentId } from "@/types";
+import { ResourceId } from "@/types";
 import { State } from "@/types/proto/v1/common";
 import { environmentNamePrefix } from "@/store/modules/v1/common";
 
@@ -120,19 +120,16 @@ export const useEnvironmentV1Store = defineStore("environment_v1", {
       this.environmentMapByName.set(environment.name, environment);
       return environment;
     },
-    async getOrFetchEnvironmentByUID(uid: EnvironmentId) {
+    async getOrFetchEnvironmentByUID(uid: string) {
       const name = `${environmentNamePrefix}${uid}`;
       return this.getOrFetchEnvironmentByName(name);
     },
     getEnvironmentByName(name: string) {
       return this.environmentMapByName.get(name);
     },
-    getEnvironmentByUID(uid: EnvironmentId) {
-      if (typeof uid === "string") {
-        uid = parseInt(uid, 10);
-      }
+    getEnvironmentByUID(uid: string) {
       return (
-        this.environmentList.find((env) => parseInt(env.uid, 10) == uid) ??
+        this.environmentList.find((env) => env.uid == uid) ??
         Environment.fromJSON({
           uid: "-1",
         })

--- a/frontend/src/types/instance.ts
+++ b/frontend/src/types/instance.ts
@@ -1,11 +1,7 @@
 import { DataSource } from ".";
 import { RowStatus } from "./common";
 import { Environment } from "./environment";
-import {
-  InstanceId,
-  MigrationHistoryId,
-  ResourceId,
-} from "./id";
+import { InstanceId, MigrationHistoryId, ResourceId } from "./id";
 import { Engine } from "./proto/v1/common";
 import { VCSPushEvent } from "./vcs";
 

--- a/frontend/src/types/instance.ts
+++ b/frontend/src/types/instance.ts
@@ -2,7 +2,6 @@ import { DataSource } from ".";
 import { RowStatus } from "./common";
 import { Environment } from "./environment";
 import {
-  EnvironmentId,
   InstanceId,
   MigrationHistoryId,
   ResourceId,

--- a/frontend/src/types/instance.ts
+++ b/frontend/src/types/instance.ts
@@ -171,7 +171,7 @@ export type InstanceCreate = {
   resourceId: ResourceId;
 
   // Related fields
-  environmentId: EnvironmentId;
+  environmentId: number;
 
   // Domain specific fields
   name: string;

--- a/frontend/src/views/DatabaseDashboard.vue
+++ b/frontend/src/views/DatabaseDashboard.vue
@@ -71,7 +71,6 @@ import {
 import DatabaseTable from "../components/DatabaseTable.vue";
 import {
   type Database,
-  type EnvironmentId,
   UNKNOWN_ID,
   DEFAULT_PROJECT_ID,
   InstanceId,
@@ -157,8 +156,8 @@ const prepareDatabaseList = () => {
 
 watchEffect(prepareDatabaseList);
 
-const changeEnvironmentId = (environment: EnvironmentId | undefined) => {
-  if (environment && environment !== UNKNOWN_ID) {
+const changeEnvironmentId = (environment: string | undefined) => {
+  if (environment && environment !== String(UNKNOWN_ID)) {
     router.replace({
       name: "workspace.database",
       query: { environment },

--- a/frontend/src/views/EnvironmentDetail.vue
+++ b/frontend/src/views/EnvironmentDetail.vue
@@ -109,7 +109,7 @@ const { t } = useI18n();
 
 const state = reactive<LocalState>({
   environment: environmentV1Store.getEnvironmentByUID(
-    idFromSlug(props.environmentSlug)
+    String(idFromSlug(props.environmentSlug))
   ),
   showArchiveModal: false,
   showDisableAutoBackupModal: false,

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -244,9 +244,7 @@ const planImage = computed(() => {
 const selectedEnvironment = computed(() => {
   const { environment } = route.query;
   return environment
-    ? environmentV1Store.getEnvironmentByUID(
-        parseInt(environment as string, 10)
-      )
+    ? environmentV1Store.getEnvironmentByUID(environment as string)
     : undefined;
 });
 

--- a/frontend/src/views/InstanceDetail.vue
+++ b/frontend/src/views/InstanceDetail.vue
@@ -131,7 +131,7 @@
     @close="state.showCreateDatabaseModal = false"
   >
     <CreateDatabasePrepForm
-      :environment-id="instance.environment.id"
+      :environment-id="String(instance.environment.id)"
       :instance-id="instance.id"
       @dismiss="state.showCreateDatabaseModal = false"
     />

--- a/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
@@ -231,7 +231,7 @@ const hasPermission = computed(() => {
 const reviewPolicy = computed((): SQLReviewPolicy => {
   return (
     store.getReviewPolicyByEnvironmentUID(
-      idFromSlug(props.sqlReviewPolicySlug)
+      String(idFromSlug(props.sqlReviewPolicySlug))
     ) || (unknown("SQL_REVIEW") as SQLReviewPolicy)
   );
 });

--- a/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
+++ b/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
@@ -191,7 +191,7 @@
   <TargetDatabasesSelectPanel
     v-if="state.showSelectDatabasePanel"
     :project-id="projectId"
-    :environment-id="String(sourceSchema.environmentId)"
+    :environment-id="sourceSchema.environmentId"
     :database-id="sourceSchema.databaseId"
     :selected-database-id-list="state.selectedDatabaseIdList"
     @close="state.showSelectDatabasePanel = false"
@@ -216,7 +216,6 @@ import {
   Database,
   DatabaseId,
   EngineType,
-  EnvironmentId,
   MigrationHistory,
   ProjectId,
   UNKNOWN_ID,
@@ -227,7 +226,7 @@ import InstanceEngineIcon from "@/components/InstanceEngineIcon.vue";
 import DiffViewPanel from "./DiffViewPanel.vue";
 
 interface SourceSchema {
-  environmentId: EnvironmentId;
+  environmentId: string;
   databaseId: DatabaseId;
   migrationHistory: MigrationHistory;
 }

--- a/frontend/src/views/SyncDatabaseSchema/index.vue
+++ b/frontend/src/views/SyncDatabaseSchema/index.vue
@@ -142,7 +142,6 @@ import {
 import {
   DatabaseId,
   EngineType,
-  EnvironmentId,
   MigrationHistory,
   MigrationType,
   ProjectId,
@@ -156,7 +155,7 @@ const SELECT_TARGET_DATABASE_LIST = 1;
 type Step = typeof SELECT_SOURCE_DATABASE | typeof SELECT_TARGET_DATABASE_LIST;
 
 interface SourceSchema {
-  environmentId?: EnvironmentId;
+  environmentId?: string;
   databaseId?: DatabaseId;
   migrationHistory?: MigrationHistory;
 }
@@ -257,7 +256,7 @@ const handleSourceProjectSelect = async (projectId: ProjectId) => {
   state.projectId = projectId;
 };
 
-const handleSourceEnvironmentSelect = async (environmentId: EnvironmentId) => {
+const handleSourceEnvironmentSelect = async (environmentId: string) => {
   if (environmentId !== state.sourceSchema.environmentId) {
     state.sourceSchema.databaseId = UNKNOWN_ID;
   }
@@ -269,7 +268,7 @@ const handleSourceDatabaseSelect = async (databaseId: DatabaseId) => {
     const database = databaseStore.getDatabaseById(databaseId as DatabaseId);
     if (database) {
       state.projectId = database.projectId;
-      state.sourceSchema.environmentId = database.instance.environment.id;
+      state.sourceSchema.environmentId = String(database.instance.environment.id);
       state.sourceSchema.databaseId = databaseId;
     }
   }

--- a/frontend/src/views/SyncDatabaseSchema/index.vue
+++ b/frontend/src/views/SyncDatabaseSchema/index.vue
@@ -268,7 +268,9 @@ const handleSourceDatabaseSelect = async (databaseId: DatabaseId) => {
     const database = databaseStore.getDatabaseById(databaseId as DatabaseId);
     if (database) {
       state.projectId = database.projectId;
-      state.sourceSchema.environmentId = String(database.instance.environment.id);
+      state.sourceSchema.environmentId = String(
+        database.instance.environment.id
+      );
       state.sourceSchema.databaseId = databaseId;
     }
   }


### PR DESCRIPTION
Since we are using string types as `uid` in V1 entities, we will ship some ID types to pure string rather than weak mixed `number | string`.

`EnvironmentId` types are replaced by `string` in most usages. But still used in some return type definitions of legacy APIs.