### PR TITLE
refactor(frontend): use V1 api to patch project's schema change type and workflow type

### DIFF
--- a/frontend/src/components/ProjectVersionControlPanel.vue
+++ b/frontend/src/components/ProjectVersionControlPanel.vue
@@ -8,6 +8,7 @@
       <RepositorySetupWizard
         :create="state.showWizardForCreate"
         :project="project"
+        :project-v1="projectV1"
         @cancel="cancelWizard"
         @finish="finishWizard"
       />
@@ -76,6 +77,7 @@
       <template v-else-if="project.workflowType == 'VCS'">
         <RepositoryPanel
           :project="project"
+          :project-v1="projectV1"
           :repository="repository"
           :allow-edit="allowEdit"
           @change-repository="enterWizard(false)"
@@ -93,6 +95,7 @@ import RepositoryPanel from "./RepositoryPanel.vue";
 import { Project, ProjectWorkflowType, UNKNOWN_ID } from "../types";
 import { useI18n } from "vue-i18n";
 import { pushNotification, useRepositoryStore } from "@/store";
+import { Project as ProjectV1 } from "@/types/proto/v1/project_service";
 
 interface LocalState {
   workflowType: ProjectWorkflowType;
@@ -114,6 +117,10 @@ export default defineComponent({
     allowEdit: {
       default: true,
       type: Boolean,
+    },
+    projectV1: {
+      required: true,
+      type: Object as PropType<ProjectV1>,
     },
   },
   async setup(props) {

--- a/frontend/src/store/modules/project.ts
+++ b/frontend/src/store/modules/project.ts
@@ -7,7 +7,6 @@ import {
   Project,
   ProjectId,
   ProjectMember,
-  ProjectPatch,
   ProjectState,
   ResourceIdentifier,
   ResourceObject,
@@ -165,31 +164,6 @@ export const useLegacyProjectStore = defineStore("project_legacy", {
         project,
       });
       return project;
-    },
-
-    async patchProject({
-      projectId,
-      projectPatch,
-    }: {
-      projectId: ProjectId;
-      projectPatch: ProjectPatch;
-    }) {
-      const data = (
-        await axios.patch(`/api/project/${projectId}`, {
-          data: {
-            type: "projectPatch",
-            attributes: projectPatch,
-          },
-        })
-      ).data;
-      const updatedProject = convert(data.data, data.included);
-
-      this.setProjectById({
-        projectId,
-        project: updatedProject,
-      });
-
-      return updatedProject;
     },
 
     // sync member role from vcs

--- a/frontend/src/views/ProjectDetail.vue
+++ b/frontend/src/views/ProjectDetail.vue
@@ -34,6 +34,7 @@
     <ProjectVersionControlPanel
       id="gitops"
       :project="project"
+      :project-v1="projectV1"
       :allow-edit="allowEdit"
     />
   </template>


### PR DESCRIPTION
It's awful to use mixed new and legacy APIs but it just works by now.
FYI @h3n4l 
close BYT-3209