### PR TITLE
fix(frontend): avoid calling ListProjects too many times

### DIFF
--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -11,6 +11,7 @@ import {
   useLegacyProjectStore,
   useDebugStore,
   useUserStore,
+  useProjectV1Store,
 } from "@/store";
 import { DEFAULT_PROJECT_ID } from "../types";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
@@ -23,6 +24,7 @@ export default defineComponent({
       useRoleStore().fetchRoleList(),
       useUserStore().fetchUserList(),
       useEnvironmentV1Store().fetchEnvironments(),
+      useProjectV1Store().fetchProjectList(true),
       // The default project hosts databases not explicitly assigned to other users project.
       useLegacyProjectStore().fetchProjectById(DEFAULT_PROJECT_ID),
       useLegacyProjectStore().fetchAllProjectList(), // TODO(Jim): For legacy API support only. Remove this after refactored

--- a/frontend/src/store/modules/v1/project.ts
+++ b/frontend/src/store/modules/v1/project.ts
@@ -160,7 +160,10 @@ export const useProjectV1List = (
   const store = useProjectV1Store();
   const ready = ref(false);
   watchEffect(() => {
-    if (!unref(forceUpdate)) return;
+    if (!unref(forceUpdate)) {
+      ready.value = true;
+      return;
+    }
     ready.value = false;
     store.fetchProjectList(unref(showDeleted)).then(() => {
       ready.value = true;

--- a/frontend/src/store/modules/v1/project.ts
+++ b/frontend/src/store/modules/v1/project.ts
@@ -153,10 +153,14 @@ export const useProjectV1Store = defineStore("project_v1", () => {
   };
 });
 
-export const useProjectV1List = (showDeleted: MaybeRef<boolean> = false) => {
+export const useProjectV1List = (
+  showDeleted: MaybeRef<boolean> = false,
+  forceUpdate = false
+) => {
   const store = useProjectV1Store();
   const ready = ref(false);
   watchEffect(() => {
+    if (!unref(forceUpdate)) return;
     ready.value = false;
     store.fetchProjectList(unref(showDeleted)).then(() => {
       ready.value = true;


### PR DESCRIPTION
- call `fetchProjectList` one time when the page is initialized.
- `useProjectV1List()` will now default to be lazy.
