### PR TITLE
feat: add task check for OceanBase

### DIFF
--- a/backend/legacyapi/task_check_run.go
+++ b/backend/legacyapi/task_check_run.go
@@ -171,7 +171,7 @@ func IsStatementTypeCheckSupported(dbType db.Type) bool {
 // IsTaskCheckReportSupported checks if the task report supports the engine type.
 func IsTaskCheckReportSupported(dbType db.Type) bool {
 	switch dbType {
-	case db.Postgres, db.TiDB, db.MySQL:
+	case db.Postgres, db.TiDB, db.MySQL, db.MariaDB, db.OceanBase:
 		return true
 	default:
 		return false

--- a/backend/legacyapi/task_check_run.go
+++ b/backend/legacyapi/task_check_run.go
@@ -161,7 +161,7 @@ func IsSQLReviewSupported(dbType db.Type) bool {
 // IsStatementTypeCheckSupported checks the engine type if statement type check supports it.
 func IsStatementTypeCheckSupported(dbType db.Type) bool {
 	switch dbType {
-	case db.Postgres, db.TiDB, db.MySQL, db.MariaDB:
+	case db.Postgres, db.TiDB, db.MySQL, db.MariaDB, db.OceanBase:
 		return true
 	default:
 		return false

--- a/backend/legacyapi/task_check_run.go
+++ b/backend/legacyapi/task_check_run.go
@@ -171,7 +171,7 @@ func IsStatementTypeCheckSupported(dbType db.Type) bool {
 // IsTaskCheckReportSupported checks if the task report supports the engine type.
 func IsTaskCheckReportSupported(dbType db.Type) bool {
 	switch dbType {
-	case db.Postgres, db.TiDB, db.MySQL, db.MariaDB, db.OceanBase:
+	case db.Postgres, db.MySQL, db.MariaDB, db.OceanBase:
 		return true
 	default:
 		return false

--- a/backend/runner/taskcheck/statement_type_report_executor.go
+++ b/backend/runner/taskcheck/statement_type_report_executor.go
@@ -90,7 +90,7 @@ func (s *StatementTypeReportExecutor) Run(ctx context.Context, _ *store.TaskChec
 	switch instance.Engine {
 	case db.Postgres:
 		return reportStatementTypeForPostgres(renderedStatement)
-	case db.MySQL:
+	case db.MySQL, db.MariaDB, db.OceanBase, db.TiDB:
 		return reportStatementTypeForMySQL(renderedStatement, charset, collation)
 	default:
 		return nil, errors.New("unsupported db type")


### PR DESCRIPTION
There are some common processes in `backend/runner/taskcheck/statement_affected_rows_report_executor.go` so I refactored this file when adding support for OceanBase explain response.