### PR TITLE
chore(backend): support uid for DatabaseService.GetDatabase

### DIFF
--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -79,10 +79,17 @@ func (s *DatabaseService) GetDatabase(ctx context.Context, request *v1pb.GetData
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
-	database, err := s.store.GetDatabaseV2(ctx, &store.FindDatabaseMessage{
-		InstanceID:   &instanceID,
-		DatabaseName: &databaseName,
-	})
+	find := &store.FindDatabaseMessage{}
+	databaseUID, isNumber := isNumber(databaseName)
+	if isNumber {
+		// Expected format: "instances/{any_values}/database/{uid}"
+		find.UID = &databaseUID
+	} else {
+		// Expected format: "instances/{instance}/database/{database}"
+		find.InstanceID = &instanceID
+		find.DatabaseName = &databaseName
+	}
+	database, err := s.store.GetDatabaseV2(ctx, find)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -82,7 +82,7 @@ func (s *DatabaseService) GetDatabase(ctx context.Context, request *v1pb.GetData
 	find := &store.FindDatabaseMessage{}
 	databaseUID, isNumber := isNumber(databaseName)
 	if isNumber {
-		// Expected format: "instances/{any_values}/database/{uid}"
+		// Expected format: "instances/{ignored_value}/database/{uid}"
 		find.UID = &databaseUID
 	} else {
 		// Expected format: "instances/{instance}/database/{database}"


### PR DESCRIPTION
We consider that is safe to use the `uid` logic branch if `{database}` is pure digits, since pure digits won't be a valid resource name.