### PR TITLE
chore(frontend): don't break word

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/RiskCenter/RiskDialog/RuleTemplateTable.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/RiskCenter/RiskDialog/RuleTemplateTable.vue
@@ -7,7 +7,7 @@
     row-key="key"
   >
     <template #item="{ item: tpl }: { item: RuleTemplate }">
-      <div class="bb-grid-cell !pl-2 !pr-1">
+      <div class="bb-grid-cell !pl-2 !pr-1 break-normal">
         {{ titleOfTemplate(tpl) }}
       </div>
       <div class="bb-grid-cell gap-x-1 !pl-1 !pr-2">


### PR DESCRIPTION
FYI @Candybase 

Before
![img_v2_d8282693-14c3-41b6-8c7a-5764388e212g](https://github.com/bytebase/bytebase/assets/2749742/1577d5b7-000d-4627-aeea-c4dd5b0ac494)
After
<img width="1068" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/26132220-9373-4e0a-b921-c499bb1f49d0">
<img width="743" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/0f8bd398-f0ca-4beb-b1c9-8385eef66724">
<img width="763" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/bf561955-a28a-4503-9fe7-b9681fe3b666">
