### PR TITLE
feat: expr editor for database group

### DIFF
--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/Condition.vue
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/Condition.vue
@@ -1,0 +1,51 @@
+<!-- eslint-disable vue/no-mutating-props -->
+<template>
+  <NInputGroup
+    class="bb-risk-expr-editor-condition w-full flex items-center overflow-x-hidden"
+  >
+    <FactorSelect :expr="expr" />
+
+    <OperatorSelect :expr="expr" />
+
+    <ValueInput :expr="expr" />
+
+    <NButton
+      v-if="allowAdmin"
+      size="small"
+      type="default"
+      :style="'flex-shrink: 0;padding-left: 0;padding-right: 0;--n-width: 28px;--n-color: white;'"
+      @click="$emit('remove')"
+    >
+      <heroicons:trash class="w-3.5 h-3.5" />
+    </NButton>
+  </NInputGroup>
+</template>
+
+<script lang="ts" setup>
+import { watch } from "vue";
+import { NButton, NInputGroup } from "naive-ui";
+
+import { type ConditionExpr } from "@/plugins/cel";
+import { FactorSelect, OperatorSelect, ValueInput } from "./components";
+import { useExprEditorContext } from "./context";
+
+const props = defineProps<{
+  expr: ConditionExpr;
+}>();
+
+const emit = defineEmits<{
+  (event: "remove"): void;
+  (event: "update"): void;
+}>();
+
+const context = useExprEditorContext();
+const { allowAdmin } = context;
+
+watch(
+  () => props.expr,
+  () => {
+    emit("update");
+  },
+  { deep: true }
+);
+</script>

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/ConditionGroup.vue
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/ConditionGroup.vue
@@ -1,0 +1,204 @@
+<template>
+  <div
+    class="bb-risk-expr-editor-group w-full overflow-hidden space-y-2 py-0.5"
+    :class="[root ? '' : 'border rounded-[3px] bg-gray-50']"
+  >
+    <div v-if="!root" class="pl-2.5 pr-1 text-gray-500 flex items-center">
+      <div class="flex-1">
+        <template v-if="args.length > 0">
+          <template v-if="operator === '_||_'">
+            {{
+              $t("custom-approval.security-rule.condition.group.or.description")
+            }}
+          </template>
+          <template v-if="operator === '_&&_'">
+            {{
+              $t(
+                "custom-approval.security-rule.condition.group.and.description"
+              )
+            }}
+          </template>
+        </template>
+        <template v-else>
+          <i18n-t
+            keypath="custom-approval.security-rule.condition.add-condition-in-group-placeholder"
+            tag="div"
+            class="inline-flex items-center"
+          >
+            <template #plus>
+              <heroicons:plus class="w-3 h-3 mx-1" />
+            </template>
+          </i18n-t>
+        </template>
+      </div>
+      <div v-if="allowAdmin" class="flex items-center justify-end">
+        <NButton
+          size="tiny"
+          quaternary
+          type="default"
+          :style="`flex-shrink: 0; padding-left: 0; padding-right: 0; --n-width: 22px`"
+          @click="addCondition"
+        >
+          <heroicons:plus class="w-4 h-4" />
+        </NButton>
+        <NButton
+          size="tiny"
+          quaternary
+          type="default"
+          :style="`flex-shrink: 0; padding-left: 0; padding-right: 0; --n-width: 22px;`"
+          @click="emit('remove')"
+        >
+          <heroicons:trash class="w-3.5 h-3.5" />
+        </NButton>
+      </div>
+    </div>
+
+    <div v-if="root && args.length === 0" class="px-1.5 text-gray-500">
+      {{
+        $t(
+          "custom-approval.security-rule.condition.add-root-condition-placeholder"
+        )
+      }}
+    </div>
+    <div
+      v-for="(operand, i) in args"
+      :key="i"
+      class="flex items-start gap-x-1 w-full"
+      :class="[root ? '' : 'px-1']"
+    >
+      <div class="w-14 shrink-0">
+        <div v-if="i === 0" class="pl-1.5 pt-1 text-control">Where</div>
+        <NSelect
+          v-else-if="i === 1 && allowAdmin"
+          v-model:value="operator"
+          :options="OPERATORS"
+          :consistent-menu-width="false"
+          size="small"
+          @update:value="$emit('update')"
+        />
+        <div v-else class="pl-2 pt-1 text-control lowercase">
+          {{ operatorLabel(operator) }}
+        </div>
+      </div>
+      <div class="flex-1 space-y-1 overflow-x-hidden">
+        <ConditionGroup
+          v-if="isConditionGroupExpr(operand)"
+          :expr="operand"
+          @remove="removeConditionGroup(operand)"
+          @update="$emit('update')"
+        />
+        <Condition
+          v-if="isConditionExpr(operand)"
+          :expr="operand"
+          @remove="removeCondition(operand)"
+          @update="$emit('update')"
+        />
+      </div>
+    </div>
+    <div v-if="root && allowAdmin" class="space-x-1">
+      <NButton size="small" quaternary @click="addCondition">
+        <template #icon><heroicons:plus class="w-4 h-4" /></template>
+        <span>{{ $t("custom-approval.security-rule.condition.add") }}</span>
+      </NButton>
+      <NButton size="small" quaternary @click="addConditionGroup">
+        <template #icon><heroicons:plus class="w-4 h-4" /></template>
+        <span>{{
+          $t("custom-approval.security-rule.condition.add-group")
+        }}</span>
+        <NTooltip>
+          <template #trigger>
+            <heroicons:question-mark-circle class="ml-1 w-3 h-3" />
+          </template>
+          <div class="max-w-[18rem]">
+            {{ $t("custom-approval.security-rule.condition.group.tooltip") }}
+          </div>
+        </NTooltip>
+      </NButton>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+/* eslint-disable vue/no-mutating-props */
+import { computed } from "vue";
+import { NButton, NSelect, NTooltip, type SelectOption } from "naive-ui";
+
+import {
+  type ConditionExpr,
+  type ConditionGroupExpr,
+  type LogicalOperator,
+  StringOperatorList,
+  LogicalOperatorList,
+  isConditionGroupExpr,
+  isConditionExpr,
+} from "@/plugins/cel";
+import { useExprEditorContext } from "./context";
+import { StringFactorList } from "./factor";
+import Condition from "./Condition.vue";
+
+const props = defineProps<{
+  expr: ConditionGroupExpr;
+  root?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: "remove"): void;
+  (event: "update"): void;
+}>();
+
+const context = useExprEditorContext();
+const { allowAdmin } = context;
+
+const operator = computed({
+  get() {
+    return props.expr.operator;
+  },
+  set(op) {
+    props.expr.operator = op;
+  },
+});
+const args = computed(() => props.expr.args);
+
+const operatorLabel = (op: LogicalOperator) => {
+  if (op === "_&&_") return "and";
+  if (op === "_||_") return "or";
+  throw new Error(`unknown logical operator "${op}"`);
+};
+
+const OPERATORS: SelectOption[] = [
+  { label: operatorLabel("_&&_"), value: "_&&_" },
+  { label: operatorLabel("_||_"), value: "_||_" },
+];
+
+const addCondition = () => {
+  args.value.push({
+    operator: StringOperatorList[0],
+    args: [StringFactorList[0], ""],
+  });
+  emit("update");
+};
+
+const addConditionGroup = () => {
+  args.value.push({
+    operator: LogicalOperatorList[0],
+    args: [],
+  });
+  emit("update");
+};
+
+const removeCondition = (condition: ConditionExpr) => {
+  const index = args.value.indexOf(condition);
+  if (index >= 0) {
+    args.value.splice(index, 1);
+    emit("update");
+  }
+};
+
+const removeConditionGroup = (group: ConditionGroupExpr) => {
+  const index = args.value.indexOf(group);
+  if (index >= 0) {
+    args.value.splice(index, 1);
+    emit("update");
+  }
+};
+</script>

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/ExprEditor.vue
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/ExprEditor.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="bb-expr-editor text-sm w-full">
+    <ConditionGroup :expr="expr" :root="true" @update="$emit('update')" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { toRef } from "vue";
+import type { ConditionGroupExpr } from "@/plugins/cel";
+import { ResourceType, provideExprEditorContext } from "./context";
+import ConditionGroup from "./ConditionGroup.vue";
+
+const props = withDefaults(
+  defineProps<{
+    expr: ConditionGroupExpr;
+    resourceType: ResourceType;
+    allowAdmin?: boolean;
+  }>(),
+  {
+    resourceType: "DATABASE_GROUP",
+    allowAdmin: false,
+  }
+);
+
+defineEmits<{
+  (event: "update"): void;
+}>();
+
+provideExprEditorContext({
+  allowAdmin: toRef(props, "allowAdmin"),
+  resourceType: toRef(props, "resourceType"),
+});
+</script>
+
+<style>
+.bb-expr-editor .n-base-selection {
+  --n-padding-single: 0 22px 0 8px !important;
+  --n-padding-multiple: 3px 24px 0 5px !important;
+}
+.bb-expr-editor .n-base-selection .n-base-suffix {
+  right: 5px !important;
+}
+
+.bb-expr-editor .n-base-selection-tag-wrapper {
+  padding-right: 2px;
+}
+
+.bb-expr-editor .n-button {
+  --n-padding: 0 6px 0 2px !important;
+}
+.bb-expr-editor .n-button .n-button__icon {
+  margin-right: 0px !important;
+}
+</style>

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/components/FactorSelect.vue
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/components/FactorSelect.vue
@@ -1,0 +1,58 @@
+<template>
+  <NSelect
+    v-model:value="factor"
+    :options="options"
+    :consistent-menu-width="false"
+    :disabled="!allowAdmin"
+    size="small"
+    style="width: auto; max-width: 9rem; flex-shrink: 0"
+  />
+</template>
+
+<script lang="ts" setup>
+/* eslint-disable vue/no-mutating-props */
+import { computed, watch } from "vue";
+import { SelectOption } from "naive-ui";
+
+import { type ConditionExpr, type Factor } from "@/plugins/cel";
+import { useExprEditorContext } from "../context";
+import { factorText } from "../../utils";
+import { FactorList } from "../factor";
+
+const props = defineProps<{
+  expr: ConditionExpr;
+}>();
+
+const { allowAdmin, resourceType } = useExprEditorContext();
+
+const factor = computed({
+  get() {
+    return props.expr.args[0];
+  },
+  set(factor) {
+    props.expr.args[0] = factor;
+  },
+});
+
+const factorList = computed((): Factor[] => {
+  return FactorList[resourceType.value];
+});
+
+const options = computed(() => {
+  return factorList.value.map<SelectOption>((v) => ({
+    label: factorText(v),
+    value: v,
+  }));
+});
+
+watch(
+  [factor, factorList],
+  () => {
+    if (factorList.value.length === 0) return;
+    if (!factorList.value.includes(factor.value)) {
+      factor.value = factorList.value[0];
+    }
+  },
+  { immediate: true }
+);
+</script>

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/components/OperatorSelect.vue
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/components/OperatorSelect.vue
@@ -1,0 +1,79 @@
+<!-- eslint-disable vue/no-mutating-props -->
+<template>
+  <NSelect
+    v-model:value="operator"
+    :options="options"
+    :consistent-menu-width="false"
+    :disabled="!allowAdmin"
+    size="small"
+    style="width: auto; max-width: 7rem; min-width: 2.5rem; flex-shrink: 0"
+  />
+</template>
+
+<script lang="ts" setup>
+/* eslint-disable vue/no-mutating-props */
+
+import { SelectOption } from "naive-ui";
+import { computed, watch } from "vue";
+import {
+  type Operator,
+  type ConditionOperator,
+  type ConditionExpr,
+  getOperatorListByFactor,
+} from "@/plugins/cel";
+import { useExprEditorContext } from "../context";
+
+const props = defineProps<{
+  expr: ConditionExpr;
+}>();
+
+const context = useExprEditorContext();
+const { allowAdmin } = context;
+
+const operator = computed({
+  get() {
+    return props.expr.operator;
+  },
+  set(op) {
+    props.expr.operator = op;
+  },
+});
+
+const factor = computed(() => {
+  return props.expr.args[0];
+});
+
+const OPERATOR_DICT = new Map([
+  ["_==_", "=="],
+  ["_!=_", "!="],
+  ["_<_", "<"],
+  ["_<=_", "≤"],
+  ["_>=_", "≥"],
+  ["_>_", ">"],
+]);
+
+const options = computed(() => {
+  const operators = getOperatorListByFactor(factor.value);
+
+  const mapOption = (op: Operator): SelectOption => {
+    const label = OPERATOR_DICT.get(op) ?? op.replace(/^@/g, "");
+    return {
+      label,
+      value: op,
+    };
+  };
+  return operators.map(mapOption);
+});
+
+// normalize operator when factor changed
+watch(
+  [options, () => props.expr.operator],
+  () => {
+    if (options.value.length === 0) return;
+    if (!options.value.find((opt) => opt.value === props.expr.operator)) {
+      props.expr.operator = options.value[0].value as ConditionOperator;
+    }
+  },
+  { immediate: true }
+);
+</script>

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/components/StringInput.vue
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/components/StringInput.vue
@@ -1,0 +1,26 @@
+<template>
+  <NInput
+    :value="value"
+    :placeholder="$t('custom-approval.security-rule.condition.input-value')"
+    :disabled="!allowAdmin"
+    size="small"
+    style="min-width: 7rem; width: auto; overflow-x: hidden"
+    @update:value="$emit('update:value', $event)"
+  />
+</template>
+
+<script lang="ts" setup>
+import { NInput } from "naive-ui";
+import { useExprEditorContext } from "../context";
+
+defineProps<{
+  value: string;
+}>();
+
+defineEmits<{
+  (event: "update:value", value: string): void;
+}>();
+
+const context = useExprEditorContext();
+const { allowAdmin } = context;
+</script>

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/components/ValueInput.vue
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/components/ValueInput.vue
@@ -1,0 +1,72 @@
+<template>
+  <template v-if="inputType === 'INPUT'">
+    <StringInput
+      v-if="isStringValue"
+      :value="getStringValue()"
+      @update:value="setStringValue($event)"
+    />
+  </template>
+</template>
+
+<script lang="ts" setup>
+/* eslint-disable vue/no-mutating-props */
+import { computed, watch } from "vue";
+
+import {
+  type ConditionExpr,
+  isEqualityOperator,
+  isStringOperator,
+  isStringFactor,
+} from "@/plugins/cel";
+import StringInput from "./StringInput.vue";
+
+type InputType = "INPUT";
+
+const props = defineProps<{
+  expr: ConditionExpr;
+}>();
+
+const operator = computed(() => {
+  return props.expr.operator;
+});
+
+const factor = computed(() => {
+  return props.expr.args[0];
+});
+
+const isStringValue = computed(() => {
+  if (isStringOperator(operator.value)) return true;
+  if (isEqualityOperator(operator.value) && isStringFactor(factor.value)) {
+    return true;
+  }
+  return false;
+});
+const inputType = computed((): InputType => {
+  return "INPUT";
+});
+
+const getStringValue = () => {
+  const value = props.expr.args[1];
+  if (typeof value !== "string") return "";
+  return value;
+};
+const setStringValue = (value: string) => {
+  props.expr.args[1] = value;
+};
+
+// clean up value type when factor and operator changed
+watch(
+  [factor, operator, () => props.expr.args[1]],
+  ([factor, operator, value]) => {
+    if (isEqualityOperator(operator)) {
+      if (isStringFactor(factor) && typeof value !== "string") {
+        setStringValue("");
+      }
+    }
+    if (isStringOperator(operator) && typeof value !== "string") {
+      setStringValue("");
+    }
+  },
+  { immediate: true }
+);
+</script>

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/components/index.ts
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/components/index.ts
@@ -1,0 +1,5 @@
+import FactorSelect from "./FactorSelect.vue";
+import OperatorSelect from "./OperatorSelect.vue";
+import ValueInput from "./ValueInput.vue";
+
+export { FactorSelect, OperatorSelect, ValueInput };

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/context.ts
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/context.ts
@@ -1,0 +1,20 @@
+import { inject, provide, type InjectionKey, type Ref } from "vue";
+
+export type ResourceType = "DATABASE_GROUP" | "SCHEMA_GROUP";
+
+export type ExprEditorContext = {
+  allowAdmin: Ref<boolean>;
+  resourceType: Ref<ResourceType>;
+};
+
+export const KEY = Symbol(
+  "bb.database-group.expr-editor"
+) as InjectionKey<ExprEditorContext>;
+
+export const useExprEditorContext = () => {
+  return inject(KEY)!;
+};
+
+export const provideExprEditorContext = (context: ExprEditorContext) => {
+  provide(KEY, context);
+};

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/factor.ts
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/factor.ts
@@ -1,0 +1,10 @@
+export const StringFactorList = [
+  "resource.database_name",
+  "resource.schema_name",
+  "resource.table_name",
+] as const;
+
+export const FactorList = {
+  DATABASE_GROUP: ["resource.database_name"],
+  SCHEMA_GROUP: ["resource.table_name"],
+};

--- a/frontend/src/components/DatabaseGroup/common/ExprEditor/index.ts
+++ b/frontend/src/components/DatabaseGroup/common/ExprEditor/index.ts
@@ -1,0 +1,3 @@
+import ExprEditor from "./ExprEditor.vue";
+
+export default ExprEditor;

--- a/frontend/src/components/DatabaseGroup/common/utils.ts
+++ b/frontend/src/components/DatabaseGroup/common/utils.ts
@@ -1,0 +1,14 @@
+import type { Factor } from "@/plugins/cel";
+import { t, te } from "@/plugins/i18n";
+
+const stringifyFactor = (factor: Factor) => {
+  return factor.replace(/\./g, "_");
+};
+
+export const factorText = (factor: Factor) => {
+  const keypath = `database-group.factor.${stringifyFactor(factor)}`;
+  if (te(keypath)) {
+    return t(keypath);
+  }
+  return factor;
+};

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2507,5 +2507,11 @@
       "description": "System defined project querier role"
     },
     "select-role": "Select role"
+  },
+  "database-group": {
+    "factor": {
+      "resource_database_name": "Database name",
+      "resource_table_name": "Table name"
+    }
   }
 }

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2488,5 +2488,11 @@
       "description": "Rol de querier del proyecto definido por el sistema"
     },
     "select-role": "Seleccionar rol"
+  },
+  "database-group": {
+    "factor": {
+      "resource_database_name": "nombre de la base de datos",
+      "resource_table_name": "nombre de la tabla"
+    }
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2501,5 +2501,11 @@
       "description": "系统定义的项目数据查询者角色"
     },
     "select-role": "选择角色"
+  },
+  "database-group": {
+    "factor": {
+      "resource_database_name": "数据库名",
+      "resource_table_name": "表名"
+    }
   }
 }

--- a/frontend/src/plugins/cel/types/factor.ts
+++ b/frontend/src/plugins/cel/types/factor.ts
@@ -23,6 +23,10 @@ export const StringFactorList = [
   "resource.table",
   "request.statement",
   "request.export_format",
+
+  // Database/table group related factors
+  "resource.database_name",
+  "resource.table_name",
 ] as const;
 export type StringFactor = typeof StringFactorList[number];
 

--- a/frontend/src/plugins/cel/types/operator.ts
+++ b/frontend/src/plugins/cel/types/operator.ts
@@ -75,13 +75,9 @@ export const OperatorList: Record<Factor, Operator[]> = {
     ...StringOperatorList,
   ]),
 
-  "resource.database": uniq([
-    ...EqualityOperatorList,
-    ...CollectionOperatorList,
-  ]),
-  "resource.schema": uniq([...EqualityOperatorList, ...CollectionOperatorList]),
-  "resource.table": uniq([...EqualityOperatorList, ...CollectionOperatorList]),
-  "request.time": uniq([...CompareOperatorList]),
+  // Database group related fields.
+  "resource.database_name": uniq(["_==_", "startsWith"]),
+  "resource.table_name": uniq(["_==_", "startsWith"]),
 };
 
 export const getOperatorListByFactor = (factor: Factor) => {


### PR DESCRIPTION
A simple expr editor was copied from the risk center, containing factors `database-name`/`table-name` and operators `==`/`startWith`.

https://github.com/bytebase/bytebase/assets/24653555/2630b569-7ebf-4904-a914-334d58a51b36

