### PR TITLE
chore: clear project policy cache

### DIFF
--- a/backend/store/principal.go
+++ b/backend/store/principal.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -446,5 +447,9 @@ func (s *Store) UpdateUser(ctx context.Context, userID int, patch *UpdateUserMes
 		return nil, err
 	}
 	s.userIDCache.Store(user.ID, user)
+	if patch.Email != nil {
+		s.projectIDPolicyCache = sync.Map{}
+		s.projectPolicyCache = sync.Map{}
+	}
 	return user, nil
 }


### PR DESCRIPTION
When email is updated, we need to invalid the project policy cache because the policy kept the email.