### PR TITLE
chore: allow backend engineer dev with hot reloading easily

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "npm run copy-sql-review-file && vite --mode dev-local",
     "release": "export NODE_OPTIONS=--max_old_space_size=4096 && npm run copy-sql-review-file && vite build --mode release --outDir=../backend/server/dist --emptyOutDir",
+    "dev-embed": "export NODE OPTIONS=--max_old_space_size=4096 && npm run copy-sql-review-file && vite build --mode dev --outDir=../backend/server/dist --emptyOutDir",
     "dev-docker": "export NODE_OPTIONS=--max_old_space_size=4096 && vite build --mode dev",
     "release-docker": "export NODE_OPTIONS=--max_old_space_size=4096 && vite build --mode release",
     "lint": "eslint --cache --ext .js,.ts,.tsx,.vue src",


### PR DESCRIPTION
And then, the backend engineers can modify the `scripts/.air.toml` to develop the backend with hot reloading!
<img width="587" alt="CleanShot 2023-06-05 at 17 27 15@2x" src="https://github.com/bytebase/bytebase/assets/87714218/f44a8884-75cf-4182-9193-930818d31c9f">

**NOTE: DO NOT FORGET TO RUN `pnpm dev-embed` UNDER THE `frontend/` FIRST!**
THANKS @rebelice !!

