### PR TITLE
fix: add different suffixes to the schema version of different tasks of a database

### DIFF
--- a/backend/server/issue.go
+++ b/backend/server/issue.go
@@ -1136,7 +1136,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 					for i := 0; i < len(schemaGroups)-1; i++ {
 						taskIndexDAGList = append(taskIndexDAGList, api.TaskIndexDAG{FromIndex: len(taskCreateList) + migrationDetailIdx*len(schemaGroups) + i, ToIndex: len(taskCreateList) + migrationDetailIdx*len(schemaGroups) + i + 1})
 					}
-					for _, schemaGroup := range schemaGroups {
+					for schemaGroupIdx, schemaGroup := range schemaGroups {
 						matches, _, err := getMatchesAndUnmatchedTables(ctx, dbSchema, schemaGroup)
 						if err != nil {
 							return nil, err
@@ -1144,7 +1144,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 						if len(matches) == 0 {
 							continue
 						}
-						for _, match := range matches {
+						for matchIdx, match := range matches {
 							newStatement := strings.ReplaceAll(originalSheet.Statement, schemaGroup.Placeholder, match)
 							newSheet, err := s.store.CreateSheetV2(ctx, &store.SheetMessage{
 								ProjectUID: originalSheet.ProjectUID,
@@ -1163,7 +1163,7 @@ func (s *Server) getPipelineCreateForDatabaseSchemaAndDataUpdate(ctx context.Con
 							// Replace the origin sheet id
 							newMigrationDetail := *migrationDetail
 							newMigrationDetail.SheetID = newSheet.UID
-							taskCreate, err := getUpdateTask(database, instance, c.VCSPushEvent, &newMigrationDetail, getOrDefaultSchemaVersion(&newMigrationDetail))
+							taskCreate, err := getUpdateTask(database, instance, c.VCSPushEvent, &newMigrationDetail, getOrDefaultSchemaVersionWithSuffix(&newMigrationDetail, fmt.Sprintf("-%03d-%03d-%03d", migrationDetailIdx, schemaGroupIdx, matchIdx)))
 							if err != nil {
 								return nil, err
 							}
@@ -1204,6 +1204,13 @@ func getOrDefaultSchemaVersion(detail *api.MigrationDetail) string {
 		return detail.SchemaVersion
 	}
 	return common.DefaultMigrationVersion()
+}
+
+func getOrDefaultSchemaVersionWithSuffix(detail *api.MigrationDetail, suffix string) string {
+	if detail.SchemaVersion != "" {
+		return detail.SchemaVersion + suffix
+	}
+	return common.DefaultMigrationVersion() + suffix
 }
 
 func getUpdateTask(database *store.DatabaseMessage, instance *store.InstanceMessage, vcsPushEvent *vcs.PushEvent, d *api.MigrationDetail, schemaVersion string) (api.TaskCreate, error) {


### PR DESCRIPTION
```go
fmt.Sprintf("-%03d-%03d-%03d", migrationDetailIdx, schemaGroupIdx, matchIdx)
```
However, according to the current design, migrationDetailIdx, schemaGroupIdx should always be 0.

<img width="2543" alt="CleanShot 2023-06-07 at 11 59 59@2x" src="https://github.com/bytebase/bytebase/assets/87714218/6f1c5234-17f3-454f-abbb-ed574694e2ed">

<img width="1149" alt="CleanShot 2023-06-07 at 12 00 26@2x" src="https://github.com/bytebase/bytebase/assets/87714218/23e7aceb-3d62-4f46-881d-df0ffa0d2ad8">

