### PR TITLE
chore(frontend): introduce grpc-web error notification middleware

### DIFF
--- a/frontend/src/grpcweb/index.ts
+++ b/frontend/src/grpcweb/index.ts
@@ -3,6 +3,7 @@ import {
   createClientFactory,
   FetchTransport,
 } from "nice-grpc-web";
+import { errorNotificationMiddleware } from "./middlewares";
 import { AuthServiceDefinition } from "@/types/proto/v1/auth_service";
 import { RoleServiceDefinition } from "@/types/proto/v1/role_service";
 import { IdentityProviderServiceDefinition } from "@/types/proto/v1/idp_service";
@@ -36,7 +37,7 @@ const channel = createChannel(
   })
 );
 
-const clientFactory = createClientFactory();
+const clientFactory = createClientFactory().use(errorNotificationMiddleware);
 
 export const authServiceClient = clientFactory.create(
   AuthServiceDefinition,

--- a/frontend/src/grpcweb/middlewares.ts
+++ b/frontend/src/grpcweb/middlewares.ts
@@ -1,0 +1,76 @@
+import { ClientError, ServerError, Status } from "nice-grpc-common";
+
+import { pushNotification, useAuthStore } from "@/store";
+import { router } from "@/router";
+import { t } from "@/plugins/i18n";
+import { ClientMiddleware } from "nice-grpc-web";
+
+export type SilentRequestOptions = {
+  /**
+   * if set to true, will NOT show push notifications when request error occurs.
+   */
+  silent?: boolean;
+};
+
+export const errorNotificationMiddleware: ClientMiddleware<SilentRequestOptions> =
+  async function* (call, options) {
+    const maybePushNotification = (title: string, description?: string) => {
+      if (options.silent) return;
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title,
+        description,
+      });
+    };
+
+    const handleError = async (error: unknown) => {
+      if (error instanceof ClientError || error instanceof ServerError) {
+        if (error.code === Status.UNAUTHENTICATED) {
+          // "Kick out" sign in status if access token expires.
+          try {
+            await useAuthStore().logout();
+          } finally {
+            router.push({ name: "auth.signin" });
+          }
+        } else if (error.code === Status.PERMISSION_DENIED) {
+          // Jump to 403 page
+          router.push({ name: "error.403" });
+        }
+
+        maybePushNotification(
+          `Code ${error.code}: ${error.message}`,
+          error.details
+        );
+      } else {
+        // Other non-grpc errors.
+        // E.g,. failed to encode protobuf for request data.
+        // or other frontend exception.
+        // Expect not to be here.
+        maybePushNotification(
+          `${t("common.error")}: ${call.method.path}`,
+          String(error)
+        );
+      }
+      throw error;
+    };
+
+    if (!call.responseStream) {
+      try {
+        const response = yield* call.next(call.request, options);
+        return response;
+      } catch (error) {
+        await handleError(error);
+      }
+    } else {
+      try {
+        for await (const response of call.next(call.request, options)) {
+          yield response;
+        }
+      } catch (error) {
+        await handleError(error);
+      }
+
+      return;
+    }
+  };

--- a/frontend/src/grpcweb/middlewares.ts
+++ b/frontend/src/grpcweb/middlewares.ts
@@ -12,6 +12,12 @@ export type SilentRequestOptions = {
   silent?: boolean;
 };
 
+/**
+ * Way to define a grpc-web middleware
+ * ClientMiddleware<ExtendedOptions>
+ * See https://github.com/deeplay-io/nice-grpc/blob/master/packages/nice-grpc-client-middleware-deadline/src/index.ts
+ *   as an example.
+ */
 export const errorNotificationMiddleware: ClientMiddleware<SilentRequestOptions> =
   async function* (call, options) {
     const maybePushNotification = (title: string, description?: string) => {

--- a/frontend/src/store/modules/v1/policy.ts
+++ b/frontend/src/store/modules/v1/policy.ts
@@ -109,9 +109,14 @@ export const usePolicyV1Store = defineStore("policy_v1", {
         return cachedData;
       }
       try {
-        const policy = await policyServiceClient.getPolicy({
-          name: name.toLowerCase(),
-        });
+        const policy = await policyServiceClient.getPolicy(
+          {
+            name: name.toLowerCase(),
+          },
+          {
+            silent: true,
+          }
+        );
         this.policyMapByName.set(policy.name, policy);
         return policy;
       } catch {


### PR DESCRIPTION
- Like legacy restful requests, now all grpc-web requests will be intercepted to push notification when error occurs
  - [CAUTION] might be sometimes too noisy at this point in time.
  - Error notifications can be muted by passing `{ silent: true }` to the second argument of grpc calls. This option need to be set per-call one-by-one. See 'modules/v1/policy.ts:L117' as an example.
- Response code `UNAUTHENTICATED` will lead to a "kick out" of login status and redirection to the login page.
- Response code `PERMISSION_DENIED` will lead to redirection to 403 page.

Close BYT-3364, BYT-3310