### PR TITLE
chore(frontend): introduce grpc-web error notification middleware

### DIFF
--- a/frontend/src/grpcweb/index.ts
+++ b/frontend/src/grpcweb/index.ts
@@ -3,7 +3,10 @@ import {
   createClientFactory,
   FetchTransport,
 } from "nice-grpc-web";
-import { authInterceptorMiddleware } from "./middlewares";
+import {
+  authInterceptorMiddleware,
+  errorNotificationMiddleware,
+} from "./middlewares";
 import { AuthServiceDefinition } from "@/types/proto/v1/auth_service";
 import { RoleServiceDefinition } from "@/types/proto/v1/role_service";
 import { IdentityProviderServiceDefinition } from "@/types/proto/v1/idp_service";
@@ -37,7 +40,10 @@ const channel = createChannel(
   })
 );
 
-const clientFactory = createClientFactory().use(authInterceptorMiddleware);
+const clientFactory = createClientFactory()
+  // A middleware that is attached first, will be invoked last.
+  .use(authInterceptorMiddleware)
+  .use(errorNotificationMiddleware);
 
 export const authServiceClient = clientFactory.create(
   AuthServiceDefinition,

--- a/frontend/src/grpcweb/index.ts
+++ b/frontend/src/grpcweb/index.ts
@@ -46,7 +46,7 @@ const clientFactory = createClientFactory()
   .use(errorNotificationMiddleware);
 /**
  * Example to use error notification middleware.
- * Errors occurs during the request will cause UI notifications automatically.
+ * Errors occurs during all requests will cause UI notifications automatically.
  * abcServiceClient.foo(requestParams, {
  *   // true if you want to suppress error notifications for this call
  *   silent: true,

--- a/frontend/src/grpcweb/index.ts
+++ b/frontend/src/grpcweb/index.ts
@@ -44,6 +44,14 @@ const clientFactory = createClientFactory()
   // A middleware that is attached first, will be invoked last.
   .use(authInterceptorMiddleware)
   .use(errorNotificationMiddleware);
+/**
+ * Example to use error notification middleware.
+ * Errors occurs during the request will cause UI notifications automatically.
+ * abcServiceClient.foo(requestParams, {
+ *   // true if you want to suppress error notifications for this call
+ *   silent: true,
+ * })
+ */
 
 export const authServiceClient = clientFactory.create(
   AuthServiceDefinition,

--- a/frontend/src/grpcweb/middlewares/errorNotificationMiddleware.ts
+++ b/frontend/src/grpcweb/middlewares/errorNotificationMiddleware.ts
@@ -1,0 +1,71 @@
+import { ClientError, ServerError } from "nice-grpc-common";
+
+import { pushNotification } from "@/store";
+import { t } from "@/plugins/i18n";
+import { ClientMiddleware } from "nice-grpc-web";
+
+export type SilentRequestOptions = {
+  /**
+   * if set to true, will NOT show push notifications when request error occurs.
+   */
+  silent?: boolean;
+};
+
+/**
+ * Way to define a grpc-web middleware
+ * ClientMiddleware<CallOptionsExt = {}, RequiredCallOptionsExt = {}>
+ * See
+ *   - https://github.com/deeplay-io/nice-grpc/blob/master/packages/nice-grpc-client-middleware-deadline/src/index.ts
+ *   - https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-web#middleware
+ *   as an example.
+ */
+export const errorNotificationMiddleware: ClientMiddleware<SilentRequestOptions> =
+  async function* (call, options) {
+    const maybePushNotification = (title: string, description?: string) => {
+      if (options.silent) return;
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title,
+        description,
+      });
+    };
+
+    const handleError = async (error: unknown) => {
+      if (error instanceof ClientError || error instanceof ServerError) {
+        maybePushNotification(
+          `Code ${error.code}: ${error.message}`,
+          error.details
+        );
+      } else {
+        // Other non-grpc errors.
+        // E.g,. failed to encode protobuf for request data.
+        // or other frontend exception.
+        // Expect not to be here.
+        maybePushNotification(
+          `${t("common.error")}: ${call.method.path}`,
+          String(error)
+        );
+      }
+      throw error;
+    };
+
+    if (!call.responseStream) {
+      try {
+        const response = yield* call.next(call.request, options);
+        return response;
+      } catch (error) {
+        await handleError(error);
+      }
+    } else {
+      try {
+        for await (const response of call.next(call.request, options)) {
+          yield response;
+        }
+      } catch (error) {
+        await handleError(error);
+      }
+
+      return;
+    }
+  };

--- a/frontend/src/grpcweb/middlewares/index.ts
+++ b/frontend/src/grpcweb/middlewares/index.ts
@@ -1,1 +1,2 @@
 export * from "./authInterceptorMiddleware";
+export * from "./errorNotificationMiddleware";

--- a/frontend/src/store/modules/v1/policy.ts
+++ b/frontend/src/store/modules/v1/policy.ts
@@ -109,9 +109,14 @@ export const usePolicyV1Store = defineStore("policy_v1", {
         return cachedData;
       }
       try {
-        const policy = await policyServiceClient.getPolicy({
-          name: name.toLowerCase(),
-        });
+        const policy = await policyServiceClient.getPolicy(
+          {
+            name: name.toLowerCase(),
+          },
+          {
+            silent: true,
+          }
+        );
         this.policyMapByName.set(policy.name, policy);
         return policy;
       } catch {


### PR DESCRIPTION
- Like legacy restful requests, now all grpc-web requests will be intercepted to push notification when error occurs
  - [CAUTION] might be sometimes too noisy at this point in time.
  - Error notifications can be muted by passing { silent: true } to the second argument of grpc calls. This option need to be set per-call one-by-one. See 'modules/v1/policy.ts:L117' as an example.

Close BYT-3364