### PR TITLE
refactor(oauth/oidc): use state param instead of session storage

### DIFF
--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -229,7 +229,7 @@ const trySigninWithIdentityProvider = async (
 ) => {
   await openWindowForSSO(
     identityProvider,
-    false,
+    false /* !popup */,
     route.query.redirect as string
   );
 };


### PR DESCRIPTION
- Why we don't use `redirect_uri`?
- 
Some OAuth/OIDC providers (like Google) strict the `redirect_uri` to exactly equals what the administrator has configured in Google API Console. So we cannot push parameters dynamically to `redirect_uri`. 

That's why we use `state`