### PR TITLE
fix(sql-review): handle the default varchar length of snowflake

### DIFF
--- a/backend/plugin/advisor/snowflake/advisor_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/snowflake/advisor_column_maximum_varchar_length.go
@@ -90,7 +90,6 @@ func (l *columnMaximumVarcharLengthChecker) EnterData_type(ctx *parser.Data_type
 	}
 
 	length := varcharDefaultLength
-
 	if v := ctx.Num(0); v != nil {
 		var err error
 		length, err = strconv.Atoi(v.GetText())

--- a/backend/plugin/advisor/snowflake/advisor_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/snowflake/advisor_column_maximum_varchar_length.go
@@ -82,11 +82,15 @@ func (l *columnMaximumVarcharLengthChecker) EnterData_type(ctx *parser.Data_type
 	if ctx.VARCHAR() == nil {
 		return
 	}
-	lengthText := ctx.Num(0).GetText()
-	length, err := strconv.Atoi(lengthText)
-	if err != nil {
-		return
+	length := 16_777_216
+	if v := ctx.Num(0); v != nil {
+		var err error
+		length, err = strconv.Atoi(v.GetText())
+		if err != nil {
+			return
+		}
 	}
+
 	if length > l.maximum {
 		l.adviceList = append(l.adviceList, advisor.Advice{
 			Status:  l.level,

--- a/backend/plugin/advisor/snowflake/advisor_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/snowflake/advisor_column_maximum_varchar_length.go
@@ -12,6 +12,12 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/advisor/db"
 )
 
+const (
+	// varcharDefaultLength is the default length of varchar in Snowflake.
+	// https://docs.snowflake.com/en/sql-reference/data-types-text
+	varcharDefaultLength = 16_777_216
+)
+
 var (
 	_ advisor.Advisor = (*ColumnMaximumVarcharLengthAdvisor)(nil)
 )
@@ -82,7 +88,9 @@ func (l *columnMaximumVarcharLengthChecker) EnterData_type(ctx *parser.Data_type
 	if ctx.VARCHAR() == nil {
 		return
 	}
-	length := 16_777_216
+
+	length := varcharDefaultLength
+
 	if v := ctx.Num(0); v != nil {
 		var err error
 		length, err = strconv.Atoi(v.GetText())

--- a/backend/plugin/advisor/snowflake/snowflake_rules_test.go
+++ b/backend/plugin/advisor/snowflake/snowflake_rules_test.go
@@ -22,6 +22,6 @@ func TestSnowflakeRules(t *testing.T) {
 	}
 
 	for _, rule := range snowflakeRules {
-		advisor.RunSQLReviewRuleTest(t, rule, db.Snowflake, false /* record */)
+		advisor.RunSQLReviewRuleTest(t, rule, db.Snowflake, true /* record */)
 	}
 }

--- a/backend/plugin/advisor/snowflake/snowflake_rules_test.go
+++ b/backend/plugin/advisor/snowflake/snowflake_rules_test.go
@@ -22,6 +22,6 @@ func TestSnowflakeRules(t *testing.T) {
 	}
 
 	for _, rule := range snowflakeRules {
-		advisor.RunSQLReviewRuleTest(t, rule, db.Snowflake, true /* record */)
+		advisor.RunSQLReviewRuleTest(t, rule, db.Snowflake, false /* record */)
 	}
 }

--- a/backend/plugin/advisor/snowflake/test/column_maximum_varchar_length.yaml
+++ b/backend/plugin/advisor/snowflake/test/column_maximum_varchar_length.yaml
@@ -14,6 +14,14 @@
       content: The maximum varchar length is 2560.
       line: 1
       details: ""
+- statement: CREATE TABLE CUSTOMER(NAME VARCHAR);
+  want:
+    - status: WARN
+      code: 422
+      title: column.maximum-varchar-length
+      content: The maximum varchar length is 2560.
+      line: 1
+      details: ""
 - statement: ALTER TABLE PUBLIC.CUSTOMER ADD NAME_2 VARCHAR(22225);
   want:
     - status: WARN


### PR DESCRIPTION
> If no length is specified, the default is the maximum allowed length (16,777,216).

https://docs.snowflake.com/en/sql-reference/data-types-text