### PR TITLE
chore: don't pre-create the connection for mysql migration

### DIFF
--- a/backend/bin/bb/cmd/migrate.go
+++ b/backend/bin/bb/cmd/migrate.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/xo/dburl"
+
+	"github.com/bytebase/bytebase/backend/plugin/db"
 )
 
 func newMigrateCmd() *cobra.Command {
@@ -70,12 +72,7 @@ func migrateDatabase(ctx context.Context, u *dburl.URL, sqlReader io.Reader) err
 	if _, err := io.Copy(&buf, sqlReader); err != nil {
 		return errors.Wrap(err, "failed to read sql file")
 	}
-	conn, err := driver.GetDB().Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	if _, err := driver.Execute(ctx, conn, buf.String(), false /* createDatabase */); err != nil {
+	if _, err := driver.Execute(ctx, buf.String(), false /* createDatabase */, db.ExecuteOptions{}); err != nil {
 		return errors.Wrap(err, "failed to migrate database")
 	}
 	return nil

--- a/backend/migrator/migrator.go
+++ b/backend/migrator/migrator.go
@@ -300,12 +300,6 @@ func migrate(ctx context.Context, storeInstance *store.Store, metadataDriver dbd
 		histories = h
 	}
 
-	conn, err := metadataDriver.GetDB().Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	// Apply migrations if needed.
 	retVersion := curVer
 	names, err := fs.Glob(migrationFS, fmt.Sprintf("migration/%s/*", common.ReleaseModeProd))
@@ -362,7 +356,7 @@ func migrate(ctx context.Context, storeInstance *store.Store, metadataDriver dbd
 				Description:           fmt.Sprintf("Migrate version %s server version %s with files %s.", pv.version, serverVersion, pv.filename),
 				Force:                 true,
 			}
-			if _, _, err := utils.ExecuteMigrationDefault(ctx, storeInstance, metadataDriver, conn, mi, string(buf), nil /* executeBeforeCommitTx */); err != nil {
+			if _, _, err := utils.ExecuteMigrationDefault(ctx, storeInstance, metadataDriver, mi, string(buf), dbdriver.ExecuteOptions{}); err != nil {
 				return err
 			}
 			retVersion = pv.version
@@ -375,7 +369,7 @@ func migrate(ctx context.Context, storeInstance *store.Store, metadataDriver dbd
 	}
 
 	if mode == common.ReleaseModeDev {
-		if err := migrateDev(ctx, storeInstance, metadataDriver, conn, serverVersion, databaseName, cutoffSchemaVersion, histories); err != nil {
+		if err := migrateDev(ctx, storeInstance, metadataDriver, serverVersion, databaseName, cutoffSchemaVersion, histories); err != nil {
 			return errors.Wrapf(err, "failed to migrate dev schema")
 		}
 	}
@@ -413,7 +407,7 @@ func getProdCutoffVersion() (semver.Version, error) {
 	return patchVersions[len(patchVersions)-1].version, nil
 }
 
-func migrateDev(ctx context.Context, storeInstance *store.Store, metadataDriver dbdriver.Driver, conn *sql.Conn, serverVersion, databaseName string, cutoffSchemaVersion semver.Version, histories []*store.InstanceChangeHistoryMessage) error {
+func migrateDev(ctx context.Context, storeInstance *store.Store, metadataDriver dbdriver.Driver, serverVersion, databaseName string, cutoffSchemaVersion semver.Version, histories []*store.InstanceChangeHistoryMessage) error {
 	devMigrations, err := getDevMigrations()
 	if err != nil {
 		return err
@@ -451,7 +445,7 @@ func migrateDev(ctx context.Context, storeInstance *store.Store, metadataDriver 
 			Description:           fmt.Sprintf("Migrate version %s server version %s with files %s.", m.version, serverVersion, m.filename),
 			Force:                 true,
 		}
-		if _, _, err := utils.ExecuteMigrationDefault(ctx, storeInstance, metadataDriver, conn, mi, m.statement, nil /* executeBeforeCommitTx */); err != nil {
+		if _, _, err := utils.ExecuteMigrationDefault(ctx, storeInstance, metadataDriver, mi, m.statement, dbdriver.ExecuteOptions{}); err != nil {
 			return err
 		}
 	}

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -174,10 +174,7 @@ func TestMigrationCompatibility(t *testing.T) {
 	defer defaultDriver.Close(ctx)
 	// Create a database with release latest schema.
 	databaseName := "hidb"
-	conn, err := defaultDriver.GetDB().Conn(ctx)
-	require.NoError(t, err)
-	defer conn.Close()
-	_, err = defaultDriver.Execute(ctx, conn, fmt.Sprintf("CREATE DATABASE %s", databaseName), true)
+	_, err = defaultDriver.Execute(ctx, fmt.Sprintf("CREATE DATABASE %s", databaseName), true, dbdriver.ExecuteOptions{})
 	require.NoError(t, err)
 
 	metadataConnConfig := connCfg

--- a/backend/plugin/advisor/utils_for_tests.go
+++ b/backend/plugin/advisor/utils_for_tests.go
@@ -240,7 +240,7 @@ func (*MockDriver) GetDB() *sql.DB {
 }
 
 // Execute implements the Driver interface.
-func (*MockDriver) Execute(_ context.Context, _ *sql.Conn, _ string, _ bool) (int64, error) {
+func (*MockDriver) Execute(_ context.Context, _ string, _ bool, _ database.ExecuteOptions) (int64, error) {
 	return 0, nil
 }
 

--- a/backend/plugin/db/clickhouse/clickhouse.go
+++ b/backend/plugin/db/clickhouse/clickhouse.go
@@ -126,8 +126,8 @@ func (driver *Driver) getVersion(ctx context.Context) (string, error) {
 }
 
 // Execute executes a SQL statement.
-func (*Driver) Execute(ctx context.Context, conn *sql.Conn, statement string, _ bool) (int64, error) {
-	tx, err := conn.BeginTx(ctx, nil)
+func (driver *Driver) Execute(ctx context.Context, statement string, _ bool, _ db.ExecuteOptions) (int64, error) {
+	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/plugin/db/driver.go
+++ b/backend/plugin/db/driver.go
@@ -493,7 +493,7 @@ type Driver interface {
 	GetType() Type
 	GetDB() *sql.DB
 	// Execute will execute the statement.
-	Execute(ctx context.Context, conn *sql.Conn, statement string, createDatabase bool) (int64, error)
+	Execute(ctx context.Context, statement string, createDatabase bool, opts ExecuteOptions) (int64, error)
 	// Used for execute readonly SELECT statement
 	QueryConn(ctx context.Context, conn *sql.Conn, statement string, queryContext *QueryContext) ([]any, error)
 	// Used for execute readonly SELECT statement
@@ -566,6 +566,12 @@ func Open(ctx context.Context, dbType Type, driverConfig DriverConfig, connectio
 	}
 
 	return driver, nil
+}
+
+// ExecuteOptions is the options for execute.
+type ExecuteOptions struct {
+	BeginFunc          func(ctx context.Context, conn *sql.Conn) error
+	EndTransactionFunc func(tx *sql.Tx) error
 }
 
 // FormatParamNameInQuestionMark formats the param name in question mark.

--- a/backend/plugin/db/mongodb/mongodb.go
+++ b/backend/plugin/db/mongodb/mongodb.go
@@ -84,7 +84,7 @@ func (*Driver) GetDB() *sql.DB {
 }
 
 // Execute executes a statement, always returns 0 as the number of rows affected because we execute the statement by mongosh, it's hard to catch the row effected number.
-func (driver *Driver) Execute(_ context.Context, _ *sql.Conn, statement string, _ bool) (int64, error) {
+func (driver *Driver) Execute(_ context.Context, statement string, _ bool, _ db.ExecuteOptions) (int64, error) {
 	connectionURI := getMongoDBConnectionURI(driver.connCfg)
 	// For MongoDB, we execute the statement in mongosh, which is a shell for MongoDB.
 	// There are some ways to execute the statement in mongosh:

--- a/backend/plugin/db/mssql/mssql.go
+++ b/backend/plugin/db/mssql/mssql.go
@@ -82,15 +82,15 @@ func (driver *Driver) GetDB() *sql.DB {
 }
 
 // Execute executes a SQL statement and returns the affected rows.
-func (*Driver) Execute(ctx context.Context, conn *sql.Conn, statement string, createDatabase bool) (int64, error) {
+func (driver *Driver) Execute(ctx context.Context, statement string, createDatabase bool, _ db.ExecuteOptions) (int64, error) {
 	if createDatabase {
-		if _, err := conn.ExecContext(ctx, statement); err != nil {
+		if _, err := driver.db.ExecContext(ctx, statement); err != nil {
 			return 0, err
 		}
 		return 0, nil
 	}
 	totalRowsAffected := int64(0)
-	tx, err := conn.BeginTx(ctx, nil)
+	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -155,7 +155,17 @@ func (driver *Driver) getVersion(ctx context.Context) (string, error) {
 }
 
 // Execute executes a SQL statement.
-func (*Driver) Execute(ctx context.Context, conn *sql.Conn, statement string, _ bool) (int64, error) {
+func (driver *Driver) Execute(ctx context.Context, statement string, _ bool, opts db.ExecuteOptions) (int64, error) {
+	conn, err := driver.db.Conn(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	if opts.BeginFunc != nil {
+		if err := opts.BeginFunc(ctx, conn); err != nil {
+			return 0, err
+		}
+	}
 	trunks, err := splitAndTransformDelimiter(statement)
 	if err != nil {
 		return 0, err

--- a/backend/plugin/db/redis/redis.go
+++ b/backend/plugin/db/redis/redis.go
@@ -141,7 +141,7 @@ func (*Driver) GetDB() *sql.DB {
 
 // Execute will execute the statement. For CREATE DATABASE statement, some types of databases such as Postgres
 // will not use transactions to execute the statement but will still use transactions to execute the rest of statements.
-func (d *Driver) Execute(ctx context.Context, _ *sql.Conn, statement string, createDatabase bool) (int64, error) {
+func (d *Driver) Execute(ctx context.Context, statement string, createDatabase bool, _ db.ExecuteOptions) (int64, error) {
 	if createDatabase {
 		return 0, errors.New("redis: cannot create database")
 	}

--- a/backend/plugin/db/redshift/redshift.go
+++ b/backend/plugin/db/redshift/redshift.go
@@ -188,7 +188,7 @@ func (driver *Driver) GetDB() *sql.DB {
 
 // Execute will execute the statement. For CREATE DATABASE statement, some types of databases such as Postgres
 // will not use transactions to execute the statement but will still use transactions to execute the rest of statements.
-func (driver *Driver) Execute(ctx context.Context, conn *sql.Conn, statement string, createDatabase bool) (int64, error) {
+func (driver *Driver) Execute(ctx context.Context, statement string, createDatabase bool, _ db.ExecuteOptions) (int64, error) {
 	if createDatabase {
 		databases, err := driver.getDatabases(ctx)
 		if err != nil {
@@ -210,7 +210,7 @@ func (driver *Driver) Execute(ctx context.Context, conn *sql.Conn, statement str
 		}
 
 		f := func(stmt string) error {
-			if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			if _, err := driver.db.ExecContext(ctx, stmt); err != nil {
 				return err
 			}
 			return nil
@@ -257,7 +257,7 @@ func (driver *Driver) Execute(ctx context.Context, conn *sql.Conn, statement str
 	}
 
 	if len(remainingStmts) != 0 {
-		tx, err := conn.BeginTx(ctx, nil)
+		tx, err := driver.db.BeginTx(ctx, nil)
 		if err != nil {
 			return 0, err
 		}
@@ -291,7 +291,7 @@ func (driver *Driver) Execute(ctx context.Context, conn *sql.Conn, statement str
 
 	// Run non-transaction statements at the end.
 	for _, stmt := range nonTransactionStmts {
-		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+		if _, err := driver.db.ExecContext(ctx, stmt); err != nil {
 			return 0, err
 		}
 	}

--- a/backend/plugin/db/snowflake/snowflake.go
+++ b/backend/plugin/db/snowflake/snowflake.go
@@ -211,7 +211,7 @@ func getDatabasesTxn(ctx context.Context, tx *sql.Tx) ([]string, error) {
 }
 
 // Execute executes a SQL statement and returns the affected rows.
-func (*Driver) Execute(ctx context.Context, conn *sql.Conn, statement string, _ bool) (int64, error) {
+func (driver *Driver) Execute(ctx context.Context, statement string, _ bool, _ db.ExecuteOptions) (int64, error) {
 	count := 0
 	f := func(stmt string) error {
 		count++
@@ -226,7 +226,7 @@ func (*Driver) Execute(ctx context.Context, conn *sql.Conn, statement string, _ 
 		return 0, nil
 	}
 
-	tx, err := conn.BeginTx(ctx, nil)
+	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/plugin/db/spanner/spanner.go
+++ b/backend/plugin/db/spanner/spanner.go
@@ -112,7 +112,7 @@ func (*Driver) GetDB() *sql.DB {
 }
 
 // Execute executes a SQL statement.
-func (d *Driver) Execute(ctx context.Context, _ *sql.Conn, statement string, createDatabase bool) (int64, error) {
+func (d *Driver) Execute(ctx context.Context, statement string, createDatabase bool, _ db.ExecuteOptions) (int64, error) {
 	if createDatabase {
 		stmts, err := sanitizeSQL(statement)
 		if err != nil {

--- a/backend/plugin/db/sqlite/sqlite.go
+++ b/backend/plugin/db/sqlite/sqlite.go
@@ -111,7 +111,7 @@ func (driver *Driver) getDatabases() ([]string, error) {
 }
 
 // Execute executes a SQL statement.
-func (driver *Driver) Execute(ctx context.Context, conn *sql.Conn, statement string, createDatabase bool) (int64, error) {
+func (driver *Driver) Execute(ctx context.Context, statement string, createDatabase bool, _ db.ExecuteOptions) (int64, error) {
 	if createDatabase {
 		parts := strings.Split(statement, `'`)
 		if len(parts) != 3 {
@@ -129,7 +129,7 @@ func (driver *Driver) Execute(ctx context.Context, conn *sql.Conn, statement str
 		return 0, nil
 	}
 
-	tx, err := conn.BeginTx(ctx, nil)
+	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/resources/postgres/postgres.go
+++ b/backend/resources/postgres/postgres.go
@@ -368,11 +368,6 @@ func prepareSampleDatabaseIfNeeded(ctx context.Context, pgUser, host, port, data
 		return errors.Wrapf(err, "failed to connect sample database")
 	}
 	defer driver.Close(ctx)
-	conn, err := driver.GetDB().Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
 
 	// Load sample data
 	names, err := fs.Glob(sampleFS, "sample/*.sql")
@@ -385,18 +380,13 @@ func prepareSampleDatabaseIfNeeded(ctx context.Context, pgUser, host, port, data
 	for _, name := range names {
 		if buf, err := fs.ReadFile(sampleFS, name); err != nil {
 			return errors.Wrapf(err, fmt.Sprintf("failed to read sample database data: %s", name))
-		} else if _, err := driver.Execute(ctx, conn, string(buf), false); err != nil {
+		} else if _, err := driver.Execute(ctx, string(buf), false, db.ExecuteOptions{}); err != nil {
 			return errors.Wrapf(err, fmt.Sprintf("failed to load sample database data: %s", name))
 		}
 	}
 
 	// Drop the default postgres database, this is to present a cleaner database list to the user.
-	_, err = driver.Execute(
-		ctx,
-		conn,
-		"DROP DATABASE postgres",
-		true)
-	if err != nil {
+	if _, err := driver.Execute(ctx, "DROP DATABASE postgres", true, db.ExecuteOptions{}); err != nil {
 		return errors.Wrapf(err, "failed to drop default postgres database")
 	}
 
@@ -422,18 +412,9 @@ func prepareDemoDatabase(ctx context.Context, pgUser, host, port, database strin
 		return errors.Wrapf(err, "failed to connect sample instance")
 	}
 	defer driver.Close(ctx)
-	conn, err := driver.GetDB().Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
 
 	// Create the sample database.
-	if _, err := driver.Execute(
-		ctx,
-		conn,
-		fmt.Sprintf("CREATE DATABASE %s", database),
-		true); err != nil {
+	if _, err := driver.Execute(ctx, fmt.Sprintf("CREATE DATABASE %s", database), true, db.ExecuteOptions{}); err != nil {
 		return errors.Wrapf(err, "failed to create sample database")
 	}
 
@@ -484,13 +465,8 @@ func createPGStatStatementsExtension(ctx context.Context, pgUser, host, port, da
 		return errors.Wrapf(err, "failed to connect sample database")
 	}
 	defer driver.Close(ctx)
-	conn, err := driver.GetDB().Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
 
-	if _, err := driver.Execute(ctx, conn, "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;", false); err != nil {
+	if _, err := driver.Execute(ctx, "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;", false, db.ExecuteOptions{}); err != nil {
 		return errors.Wrapf(err, "failed to create pg_stat_statements extension")
 	}
 	log.Info("Successfully created pg_stat_statements extension")

--- a/backend/runner/taskrun/database_create_executor.go
+++ b/backend/runner/taskrun/database_create_executor.go
@@ -141,12 +141,7 @@ func (exec *DatabaseCreateExecutor) RunOnce(ctx context.Context, task *store.Tas
 		}
 	}
 	defer defaultDBDriver.Close(ctx)
-	conn, err := defaultDBDriver.GetDB().Conn(ctx)
-	if err != nil {
-		return true, nil, err
-	}
-	defer conn.Close()
-	if _, err := defaultDBDriver.Execute(ctx, conn, statement, true /* createDatabase */); err != nil {
+	if _, err := defaultDBDriver.Execute(ctx, statement, true /* createDatabase */, db.ExecuteOptions{}); err != nil {
 		return true, nil, err
 	}
 
@@ -232,11 +227,6 @@ func (exec *DatabaseCreateExecutor) createInitialSchema(ctx context.Context, env
 		return "", "", err
 	}
 	defer driver.Close(ctx)
-	conn, err := driver.GetDB().Conn(ctx)
-	if err != nil {
-		return "", "", err
-	}
-	defer conn.Close()
 
 	// TODO(d): support semantic versioning.
 	mi := &db.MigrationInfo{
@@ -284,7 +274,7 @@ func (exec *DatabaseCreateExecutor) createInitialSchema(ctx context.Context, env
 		mi.IssueIDInt = &issue.UID
 	}
 
-	if _, _, err := utils.ExecuteMigrationDefault(ctx, exec.store, driver, conn, mi, schema, nil /* executeBeforeCommitTx */); err != nil {
+	if _, _, err := utils.ExecuteMigrationDefault(ctx, exec.store, driver, mi, schema, db.ExecuteOptions{}); err != nil {
 		return "", "", err
 	}
 	return schemaVersion, schema, nil

--- a/backend/runner/taskrun/pitr_cutover_executor.go
+++ b/backend/runner/taskrun/pitr_cutover_executor.go
@@ -154,13 +154,8 @@ func (exec *PITRCutoverExecutor) pitrCutover(ctx context.Context, dbFactory *dbf
 		return true, nil, err
 	}
 	defer driver.Close(ctx)
-	conn, err := driver.GetDB().Conn(ctx)
-	if err != nil {
-		return true, nil, err
-	}
-	defer conn.Close()
 
-	if _, _, err := utils.ExecuteMigrationDefault(ctx, exec.store, driver, conn, m, "" /* pitr cutover */, nil /* executeBeforeCommitTx */); err != nil {
+	if _, _, err := utils.ExecuteMigrationDefault(ctx, exec.store, driver, m, "" /* pitr cutover */, db.ExecuteOptions{}); err != nil {
 		log.Error("Failed to add migration history record", zap.Error(err))
 		return true, nil, errors.Wrap(err, "failed to add migration history record")
 	}

--- a/backend/runner/taskrun/pitr_restore_executor.go
+++ b/backend/runner/taskrun/pitr_restore_executor.go
@@ -554,13 +554,8 @@ func createBranchMigrationHistory(ctx context.Context, stores *store.Store, dbFa
 		return "", "", err
 	}
 	defer targetDriver.Close(ctx)
-	conn, err := targetDriver.GetDB().Conn(ctx)
-	if err != nil {
-		return "", "", err
-	}
-	defer conn.Close()
 
-	migrationID, _, err := utils.ExecuteMigrationDefault(ctx, stores, targetDriver, conn, m, "", nil /* executeBeforeCommitTx */)
+	migrationID, _, err := utils.ExecuteMigrationDefault(ctx, stores, targetDriver, m, "", db.ExecuteOptions{})
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to create migration history")
 	}

--- a/backend/runner/taskrun/schema_update_ghost_cutover_executor.go
+++ b/backend/runner/taskrun/schema_update_ghost_cutover_executor.go
@@ -127,7 +127,7 @@ func cutover(ctx context.Context, stores *store.Store, dbFactory *dbfactory.DBFa
 		return true, nil, errors.Errorf("cutover poller cancelled")
 	}
 
-	mi, err := preMigration(ctx, stores, profile, task, db.Migrate, statement, schemaVersion, vcsPushEvent)
+	mi, err := getMigrationInfo(ctx, stores, profile, task, db.Migrate, statement, schemaVersion, vcsPushEvent)
 	if err != nil {
 		return true, nil, err
 	}

--- a/backend/store/pg_engine.go
+++ b/backend/store/pg_engine.go
@@ -77,12 +77,7 @@ func (db *DB) Open(ctx context.Context) error {
 			return err
 		}
 		defer defaultDriver.Close(ctx)
-		conn, err := defaultDriver.GetDB().Conn(ctx)
-		if err != nil {
-			return err
-		}
-		defer conn.Close()
-		if _, err := defaultDriver.Execute(ctx, conn, fmt.Sprintf("CREATE DATABASE %s", databaseName), true); err != nil {
+		if _, err := defaultDriver.Execute(ctx, fmt.Sprintf("CREATE DATABASE %s", databaseName), true, dbdriver.ExecuteOptions{}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Previously, we do the following
  1) create a connection to get connection ID and binlog;
  2) dump schema using a different connection;
  3) use the connection from the 1st step to execute migration script.

If step 2) takes long time, the execution in 3rd step will fail because the connection is already closed.