### PR TITLE
fix(frontend): use correct field to display database group selector

### DIFF
--- a/frontend/src/components/DatabaseGroup/DatabaseGroupSelect.vue
+++ b/frontend/src/components/DatabaseGroup/DatabaseGroupSelect.vue
@@ -8,7 +8,7 @@
     @select-item="(item: DatabaseGroup) => $emit('select-database-group-id', item.name)"
   >
     <template #menuItem="{ item }">
-      {{ getDatabaseGroupTitle(item.name) }}
+      {{ item.databasePlaceholder }}
     </template>
   </BBSelect>
 </template>
@@ -49,10 +49,6 @@ const dbGroupList = computed(() => {
         : true
     );
 });
-
-const getDatabaseGroupTitle = (databaseGroupName: string): string => {
-  return databaseGroupName.split("/").pop() || "";
-};
 
 const invalidateSelectionIfNeeded = () => {
   if (


### PR DESCRIPTION
Before 
![794df51e-0c59-4887-978a-5bfa5d9e6fb6](https://github.com/bytebase/bytebase/assets/2749742/fcf2262e-df1f-40da-95c5-a8684c7f52a0)

After 
![746c6192-8975-45d9-8566-762561191e74](https://github.com/bytebase/bytebase/assets/2749742/60745df2-10f4-475e-a711-31425d27bb0d)

@d-bytebase up to u to decide whether to backport this to 2.3.0 . It's harmless but quite confusing and annoying