### PR TITLE
feat(breaking-change): deprecate external url cli option

### DIFF
--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -16,7 +16,6 @@ func getBaseProfile(dataDir string) config.Profile {
 	}
 
 	return config.Profile{
-		ExternalURL:          flags.externalURL,
 		GrpcPort:             flags.port + 1, // Using flags.port + 1 as our gRPC server port.
 		DatastorePort:        flags.port + 2, // Using flags.port + 2 as our datastore port.
 		SampleDatabasePort:   flags.port + 3, // Using flags.port + 3 as our sample database port.

--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
-	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/server"
 )
@@ -59,9 +58,8 @@ ________________________________________________________________________________
 var (
 	flags struct {
 		// Used for Bytebase command line config
-		port        int
-		externalURL string
-		dataDir     string
+		port    int
+		dataDir string
 		// When we are running in readonly mode:
 		// - The data file will be opened in readonly mode, no applicable migration or seeding will be applied.
 		// - Requests other than GET will be rejected
@@ -109,11 +107,6 @@ func init() {
 	// Instead they would configure a gateway to forward the traffic to Bytebase. Users need to set --external-url to the address
 	// exposed on that gateway accordingly.
 	//
-	// It's important to set the correct --external-url. This is used for:
-	// 1. Constructing the correct callback URL when configuring the VCS provider. The callback URL points to the frontend.
-	// 2. Creating the correct webhook endpoint when configuring the project GitOps workflow. The webhook endpoint points to the backend.
-	// Since frontend and backend are bundled and run on the same address in the release build, thus we just need to specify a single external URL.
-	rootCmd.PersistentFlags().StringVar(&flags.externalURL, "external-url", "", "the external URL where user visits Bytebase, must start with http:// or https://")
 	rootCmd.PersistentFlags().StringVar(&flags.dataDir, "data", ".", "directory where Bytebase stores data. If relative path is supplied, then the path is relative to the directory where Bytebase is under")
 	rootCmd.PersistentFlags().BoolVar(&flags.readonly, "readonly", false, "whether to run in read-only mode")
 	rootCmd.PersistentFlags().BoolVar(&flags.saas, "saas", false, "whether to run in SaaS mode")
@@ -189,13 +182,6 @@ func start() {
 
 	var err error
 
-	if flags.externalURL != "" {
-		flags.externalURL, err = common.NormalizeExternalURL(flags.externalURL)
-		if err != nil {
-			log.Error("invalid --external-url", zap.Error(err))
-			return
-		}
-	}
 	if err := checkDataDir(); err != nil {
 		log.Error(err.Error())
 		return

--- a/backend/component/config/profile.go
+++ b/backend/component/config/profile.go
@@ -12,8 +12,6 @@ import (
 type Profile struct {
 	// Mode can be "prod" or "dev"
 	Mode common.ReleaseMode
-	// ExternalURL is the URL user visits Bytebase.
-	ExternalURL string
 	// DatastorePort is the binding port for database instance for storing Bytebase metadata.
 	// Only applicable when using embedded PG (PgURL is empty).
 	DatastorePort int

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -342,7 +342,7 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 	// Cache the license.
 	s.licenseService.LoadSubscription(ctx)
 
-	config, err := s.getInitSetting(ctx, storeInstance)
+	config, err := getInitSetting(ctx, storeInstance)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init config")
 	}
@@ -731,7 +731,7 @@ type workspaceConfig struct {
 	workspaceID string
 }
 
-func (s *Server) getInitSetting(ctx context.Context, datastore *store.Store) (*workspaceConfig, error) {
+func getInitSetting(ctx context.Context, datastore *store.Store) (*workspaceConfig, error) {
 	// secretLength is the length for the secret used to sign the JWT auto token.
 	const secretLength = 32
 
@@ -844,7 +844,7 @@ func (s *Server) getInitSetting(ctx context.Context, datastore *store.Store) (*w
 
 	// initial workspace profile setting
 	settingName := api.SettingWorkspaceProfile
-	workspaceProfileSetting, err := s.store.GetSettingV2(ctx, &store.FindSettingMessage{
+	workspaceProfileSetting, err := datastore.GetSettingV2(ctx, &store.FindSettingMessage{
 		Name:    &settingName,
 		Enforce: true,
 	})
@@ -852,16 +852,11 @@ func (s *Server) getInitSetting(ctx context.Context, datastore *store.Store) (*w
 		return nil, err
 	}
 
-	workspaceProfilePayload := &storepb.WorkspaceProfileSetting{
-		ExternalUrl: s.profile.ExternalURL,
-	}
+	workspaceProfilePayload := &storepb.WorkspaceProfileSetting{}
 	if workspaceProfileSetting != nil {
 		workspaceProfilePayload = new(storepb.WorkspaceProfileSetting)
 		if err := protojson.Unmarshal([]byte(workspaceProfileSetting.Value), workspaceProfilePayload); err != nil {
 			return nil, err
-		}
-		if s.profile.ExternalURL != "" {
-			workspaceProfilePayload.ExternalUrl = s.profile.ExternalURL
 		}
 	}
 

--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -157,6 +157,7 @@ CREATE TABLE book4 (
 )
 
 type controller struct {
+	externalURL              string
 	server                   *server.Server
 	profile                  componentConfig.Profile
 	client                   *http.Client
@@ -265,6 +266,7 @@ func (ctl *controller) StartServerWithExternalPg(ctx context.Context, config *co
 	}
 	ctl.server = server
 	ctl.profile = profile
+	ctl.externalURL = fmt.Sprintf("http://localhost:%d", serverPort)
 
 	metaCtx, err := ctl.start(ctx, serverPort)
 	if err != nil {
@@ -290,6 +292,7 @@ func (ctl *controller) StartServer(ctx context.Context, config *config) (context
 	}
 	ctl.server = server
 	ctl.profile = profile
+	ctl.externalURL = fmt.Sprintf("http://localhost:%d", serverPort)
 
 	return ctl.start(ctx, serverPort)
 }
@@ -301,7 +304,7 @@ func (ctl *controller) initWorkspaceProfile(ctx context.Context) error {
 			Value: &v1pb.Value{
 				Value: &v1pb.Value_WorkspaceProfileSettingValue{
 					WorkspaceProfileSettingValue: &v1pb.WorkspaceProfileSetting{
-						ExternalUrl:    ctl.profile.ExternalURL,
+						ExternalUrl:    ctl.externalURL,
 						DisallowSignup: false,
 					},
 				},
@@ -316,7 +319,6 @@ func (ctl *controller) initWorkspaceProfile(ctx context.Context) error {
 func getTestProfile(dataDir, resourceDir string, port int, readOnly bool, feishuAPIURL string) componentConfig.Profile {
 	return componentConfig.Profile{
 		Mode:                 testReleaseMode,
-		ExternalURL:          fmt.Sprintf("http://localhost:%d", port),
 		GrpcPort:             port + 1,
 		DatastorePort:        port + 2,
 		SampleDatabasePort:   0,
@@ -337,7 +339,6 @@ func getTestProfile(dataDir, resourceDir string, port int, readOnly bool, feishu
 func getTestProfileWithExternalPg(dataDir, resourceDir string, port int, pgUser string, pgURL string, feishuAPIURL string, skipOnboardingData bool) componentConfig.Profile {
 	return componentConfig.Profile{
 		Mode:                       testReleaseMode,
-		ExternalURL:                fmt.Sprintf("http://localhost:%d", port),
 		GrpcPort:                   port + 1,
 		SampleDatabasePort:         0,
 		PgUser:                     pgUser,


### PR DESCRIPTION
We can now set the `external-url` in the UI. We no longer need to include `external-url` in the cmd options. The pain is over.