### PR TITLE
chore:(frontend) loosen workspace approval setting resolving

### DIFF
--- a/frontend/src/utils/workspaceApprovalSetting.ts
+++ b/frontend/src/utils/workspaceApprovalSetting.ts
@@ -162,7 +162,12 @@ const resolveApprovalConfigRules = (rules: LocalApprovalRule[]) => {
     if (!args || args.length === 0) return fail(expr, rule);
 
     for (let i = 0; i < args.length; i++) {
-      resolveLogicAndExpr(args[i], rule);
+      if (args[i].operator === "_&&_") {
+        resolveLogicAndExpr(args[i], rule);
+      }
+      if (args[i].operator === "_||_") {
+        resolveLogicOrExpr(args[i], rule);
+      }
     }
   };
 


### PR DESCRIPTION
Since we've migrated the expressions from binary expression trees to string source codes. It is not guarded that the a "and and and and ..." or "or or or or or ..." tree is strictly aligned to the left or to the right sub-tree.
It's hard and even impossible to convert a complex tree to a perfect, clear "and and and ..." or "or or or ..." array (aka. Condition Group in Bytebase). So we loosen the workspace approval setting resolving procedure. 