### PR TITLE
feat(sql-editor): shortcut to request access when ACCESS_DENIED

### DIFF
--- a/frontend/src/components/Issue/panel/RequestQueryPanel/index.vue
+++ b/frontend/src/components/Issue/panel/RequestQueryPanel/index.vue
@@ -203,11 +203,6 @@ const extractDatabaseResourceFromProps = (): Pick<
   };
 };
 
-console.log(
-  "extractDatabaseResourceFromProps",
-  extractDatabaseResourceFromProps()
-);
-
 const { t } = useI18n();
 const router = useRouter();
 const databaseStore = useDatabaseV1Store();

--- a/frontend/src/components/Issue/panel/RequestQueryPanel/index.vue
+++ b/frontend/src/components/Issue/panel/RequestQueryPanel/index.vue
@@ -56,6 +56,7 @@
             class="w-full flex flex-row justify-start items-center"
           >
             <SelectDatabaseResourceForm
+              v-if="state.projectId"
               :project-id="state.projectId"
               :selected-database-resource-list="
                 state.selectedDatabaseResourceList
@@ -142,10 +143,12 @@ import {
 import { computed, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import {
+  ComposedDatabase,
   DatabaseResource,
   IssueCreate,
   PresetRoleType,
   SYSTEM_BOT_ID,
+  UNKNOWN_ID,
 } from "@/types";
 import { extractUserUID, issueSlug, memberListInProjectV1 } from "@/utils";
 import {
@@ -170,17 +173,48 @@ interface LocalState {
   description: string;
 }
 
+const props = defineProps<{
+  projectId?: string;
+  database?: ComposedDatabase;
+}>();
+
 defineEmits<{
   (event: "close"): void;
 }>();
+
+const extractDatabaseResourceFromProps = (): Pick<
+  LocalState,
+  "allDatabases" | "selectedDatabaseResourceList"
+> => {
+  const { database } = props;
+  if (!database || database.uid === String(UNKNOWN_ID)) {
+    return {
+      allDatabases: true,
+      selectedDatabaseResourceList: [],
+    };
+  }
+  return {
+    allDatabases: false,
+    selectedDatabaseResourceList: [
+      {
+        databaseName: database.name,
+      },
+    ],
+  };
+};
+
+console.log(
+  "extractDatabaseResourceFromProps",
+  extractDatabaseResourceFromProps()
+);
 
 const { t } = useI18n();
 const router = useRouter();
 const databaseStore = useDatabaseV1Store();
 const currentUser = useCurrentUserV1();
 const state = reactive<LocalState>({
-  allDatabases: true,
-  selectedDatabaseResourceList: [],
+  projectId: props.projectId,
+  ...extractDatabaseResourceFromProps(),
   expireDays: 7,
   customDays: 365,
   description: "",

--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -16,6 +16,7 @@ import {
   Advice_Status,
   advice_StatusToJSON,
 } from "@/types/proto/v1/sql_service";
+import { Status } from "nice-grpc-common";
 
 const useExecuteSQL = () => {
   const { t } = useI18n();
@@ -94,12 +95,13 @@ const useExecuteSQL = () => {
       selectStatement = `EXPLAIN ${selectStatement}`;
     }
 
-    const fail = (error: string) => {
+    const fail = (error: string, status: Status | undefined = undefined) => {
       Object.assign(tab, {
         sqlResultSet: {
           error,
           results: [],
           advices: [],
+          status,
         },
         // Legacy compatibility
         queryResult: {
@@ -151,7 +153,7 @@ const useExecuteSQL = () => {
       }
 
       if (sqlResultSet.error) {
-        return fail(sqlResultSet.error);
+        return fail(sqlResultSet.error, sqlResultSet.status);
       }
 
       Object.assign(tab, {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1755,7 +1755,8 @@
     "allow-admin-mode-only": "Instance {instance} is accessible in admin mode only.",
     "run-selected": "Run selected",
     "clear-screen": "Clear screen",
-    "query-time": "Query time"
+    "query-time": "Query time",
+    "request-access": "Request Access"
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1756,7 +1756,7 @@
     "run-selected": "Run selected",
     "clear-screen": "Clear screen",
     "query-time": "Query time",
-    "request-access": "Request Access"
+    "request-query": "Request Query"
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1742,7 +1742,7 @@
     "run-selected": "Ejecutar selección",
     "clear-screen": "Limpiar pantalla",
     "query-time": "Tiempo de consulta",
-    "request-access": "Solicitar acceso"
+    "request-query": "Solicitar consulta"
   },
   "schema-editor": {
     "self": "Editor de esquema",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1741,7 +1741,8 @@
     "allow-admin-mode-only": "La instancia {instance} solo es accesible en modo administrador.",
     "run-selected": "Ejecutar selección",
     "clear-screen": "Limpiar pantalla",
-    "query-time": "Tiempo de consulta"
+    "query-time": "Tiempo de consulta",
+    "request-access": "Solicitar acceso"
   },
   "schema-editor": {
     "self": "Editor de esquema",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1751,7 +1751,7 @@
     "run-selected": "运行选中的语句",
     "clear-screen": "清屏",
     "query-time": "查询时间",
-    "request-access": "申请查询权限"
+    "request-query": "申请查询权限"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1750,7 +1750,8 @@
     "allow-admin-mode-only": "实例{instance}只能通过管理员模式访问。",
     "run-selected": "运行选中的语句",
     "clear-screen": "清屏",
-    "query-time": "查询时间"
+    "query-time": "查询时间",
+    "request-access": "申请查询权限"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/store/modules/v1/sql.ts
+++ b/frontend/src/store/modules/v1/sql.ts
@@ -6,7 +6,7 @@ import {
   QueryRequest,
 } from "@/types/proto/v1/sql_service";
 import { extractGrpcErrorMessage } from "@/utils/grpcweb";
-import { Status } from "nice-grpc-common";
+import { ClientError, Status } from "nice-grpc-common";
 import { defineStore } from "pinia";
 
 export const useSQLStore = defineStore("sql", () => {
@@ -27,10 +27,12 @@ export const useSQLStore = defineStore("sql", () => {
       };
     } catch (err) {
       const error = extractGrpcErrorMessage(err);
+      const status = err instanceof ClientError ? err.code : Status.UNKNOWN;
       return {
         error,
         results: [],
         advices: [],
+        status,
       };
     }
   };

--- a/frontend/src/types/v1/sql.ts
+++ b/frontend/src/types/v1/sql.ts
@@ -1,7 +1,9 @@
+import { Status } from "nice-grpc-common";
 import { Advice, QueryResult } from "../proto/v1/sql_service";
 
 export type SQLResultSetV1 = {
   error: string; // empty if no error occurred
   results: QueryResult[];
   advices: Advice[];
+  status?: Status;
 };

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
@@ -1,0 +1,37 @@
+<template>
+  <div v-if="available">
+    <NButton text type="primary" @click="showPanel = true">
+      {{ $t("sql-editor.request-access") }}
+    </NButton>
+
+    <RequestQueryPanel
+      :show="showPanel"
+      :project-id="database?.projectEntity.uid"
+      :database="database"
+      @close="showPanel = false"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import RequestQueryPanel from "@/components/Issue/panel/RequestQueryPanel/index.vue";
+import { useDatabaseV1Store, useTabStore } from "@/store";
+import { UNKNOWN_ID, unknownDatabase } from "@/types";
+
+const tabStore = useTabStore();
+const connection = computed(() => tabStore.currentTab.connection);
+const showPanel = ref(false);
+
+const database = computed(() => {
+  const { databaseId } = connection.value;
+  if (databaseId !== String(UNKNOWN_ID)) {
+    return useDatabaseV1Store().getDatabaseByUID(databaseId);
+  }
+  return unknownDatabase();
+});
+
+const available = computed(() => {
+  return database.value.uid !== String(UNKNOWN_ID);
+});
+</script>

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="available">
     <NButton text type="primary" @click="showPanel = true">
-      {{ $t("sql-editor.request-access") }}
+      {{ $t("sql-editor.request-query") }}
     </NButton>
 
     <RequestQueryPanel

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
@@ -32,6 +32,9 @@
       </template>
       <template v-else-if="viewMode === 'ERROR'">
         <ErrorView :error="resultSet.error" />
+        <RequestQueryButton
+          v-if="resultSet.status === Status.PERMISSION_DENIED"
+        />
       </template>
     </template>
 
@@ -55,6 +58,7 @@
 import { computed, PropType, toRef } from "vue";
 import { useI18n } from "vue-i18n";
 import { darkTheme, NConfigProvider, NTabs, NTabPane } from "naive-ui";
+import { Status } from "nice-grpc-common";
 
 import { darkThemeOverrides } from "@/../naive-ui.config";
 import SingleResultViewV1 from "./SingleResultViewV1.vue";
@@ -62,6 +66,7 @@ import EmptyView from "./EmptyView.vue";
 import { ExecuteConfig, ExecuteOption, SQLResultSetV1 } from "@/types";
 import { provideSQLResultViewContext } from "./context";
 import ErrorView from "./ErrorView.vue";
+import RequestQueryButton from "./RequestQueryButton.vue";
 import { QueryResult } from "@/types/proto/v1/sql_service";
 
 type ViewMode = "SINGLE-RESULT" | "MULTI-RESULT" | "EMPTY" | "ERROR";


### PR DESCRIPTION
https://github.com/bytebase/bytebase/assets/2749742/e456e00a-d695-4dd1-b6ce-fe04f9675035

We don't actually know which schema/table is denied to access from the frontend. So we can just pre-set the database when opening the panel.

Close BYT-3449