### PR TITLE
fix: Revert "chore: go 1.20.5"

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          go-version: 1.20.1
           check-latest: true
           cache: true
       - name: Verify go.mod is tidy
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          go-version: 1.20.1
           check-latest: true
           cache: true
       - name: Cache MySQL

--- a/.github/workflows/build-artifacts-and-draft-release.yml
+++ b/.github/workflows/build-artifacts-and-draft-release.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: frontend
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          go-version: 1.20.1
           check-latest: true
           cache: true
       - name: Release

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Below diagram describes a typical mapping between an engineering org and the cor
 
 ### Prerequisites
 
-- [Go](https://golang.org/doc/install) (1.20.5 or later)
+- [Go](https://golang.org/doc/install) (1.20.1 or later)
 - [pnpm](https://pnpm.io/installation)
 - [Air](https://github.com/bytebase/air) (**our forked repo @87187cc with the proper signal handling**). This is for backend live reload.
   ```bash

--- a/scripts/.goreleaser-for-darwin.yaml
+++ b/scripts/.goreleaser-for-darwin.yaml
@@ -17,7 +17,7 @@ builds:
       - embed_frontend
     env:
       - VERSION="development"
-      - GO_VERSION="1.20.5"
+      - GO_VERSION="1.20.1"
       - CGO_ENABLED=1
       - GIT_COMMIT="unknown"
       - BUILD_TIME="unknown"
@@ -41,7 +41,7 @@ builds:
       - release
     env:
       - VERSION="development"
-      - GO_VERSION="1.20.5"
+      - GO_VERSION="1.20.1"
       - CGO_ENABLED=1
       - GIT_COMMIT="unknown"
       - BUILD_TIME="unknown"

--- a/scripts/.goreleaser-for-linux.yaml
+++ b/scripts/.goreleaser-for-linux.yaml
@@ -17,7 +17,7 @@ builds:
       - embed_frontend
     env:
       - VERSION="development"
-      - GO_VERSION="1.20.5"
+      - GO_VERSION="1.20.1"
       - CGO_ENABLED=1
       - GIT_COMMIT="unknown"
       - BUILD_TIME="unknown"
@@ -46,7 +46,7 @@ builds:
       - release
     env:
       - VERSION="development"
-      - GO_VERSION="1.20.5"
+      - GO_VERSION="1.20.1"
       - CGO_ENABLED=1
       - GIT_COMMIT="unknown"
       - BUILD_TIME="unknown"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -24,11 +24,11 @@ COPY ./backend/plugin/advisor/config/ ./src/types
 # Build frontend
 RUN pnpm "${RELEASE}-docker"
 
-FROM golang:1.20.5 as backend
+FROM golang:1.20.3 as backend
 
 ARG VERSION="development"
 ARG VERSION_SUFFIX=""
-ARG GO_VERSION="1.20.5"
+ARG GO_VERSION="1.20.1"
 ARG GIT_COMMIT="unknown"
 ARG BUILD_TIME="unknown"
 ARG BUILD_USER="unknown"

--- a/scripts/Dockerfile.bb
+++ b/scripts/Dockerfile.bb
@@ -5,10 +5,10 @@
 
 # $ docker run --init --rm --name bb bytebase/bb
 
-FROM golang:1.20.5 as bb
+FROM golang:1.20.3 as bb
 
 ARG VERSION="development"
-ARG GO_VERSION="1.20.5"
+ARG GO_VERSION="1.20.1"
 ARG GIT_COMMIT="unknown"
 ARG BUILD_TIME="unknown"
 ARG BUILD_USER="unknown"

--- a/scripts/Dockerfile.render-demo
+++ b/scripts/Dockerfile.render-demo
@@ -19,9 +19,9 @@ COPY ./backend/plugin/advisor/config/ ./src/types
 # Build frontend
 RUN pnpm "${RELEASE}-docker"
 
-FROM golang:1.20.5 as backend
+FROM golang:1.20.3 as backend
 
-ARG GO_VERSION="1.20.5"
+ARG GO_VERSION="1.20.1"
 # RENDER_GIT_COMMIT is a render.com provided env var during build.
 # https://render.com/docs/environment-variables
 ARG RENDER_GIT_COMMIT="unknown"

--- a/scripts/Dockerfile.sql-service
+++ b/scripts/Dockerfile.sql-service
@@ -5,10 +5,10 @@
 
 # $ docker run --init --rm --name sql-service --publish 8081:8081 bytebase/sql
 
-FROM golang:1.20.5 as sql
+FROM golang:1.20.3 as sql
 
 ARG VERSION="development"
-ARG GO_VERSION="1.20.5"
+ARG GO_VERSION="1.20.1"
 ARG GIT_COMMIT="unknown"
 ARG BUILD_TIME="unknown"
 ARG BUILD_USER="unknown"

--- a/scripts/build_bytebase.sh
+++ b/scripts/build_bytebase.sh
@@ -14,9 +14,9 @@ OUTPUT_DIR=$(mkdir_output "$1")
 OUTPUT_BINARY=$OUTPUT_DIR/bytebase
 
 GO_VERSION=`go version | { read _ _ v _; echo ${v#go}; }`
-if [ "$(version ${GO_VERSION})" -lt "$(version 1.20.5)" ];
+if [ "$(version ${GO_VERSION})" -lt "$(version 1.20.1)" ];
 then
-   echo "${RED}Precheck failed.${NC} Require go version >= 1.20.5. Current version ${GO_VERSION}."; exit 1;
+   echo "${RED}Precheck failed.${NC} Require go version >= 1.20.1. Current version ${GO_VERSION}."; exit 1;
 fi
 
 NODE_VERSION=`node -v | { read v; echo ${v#v}; }`
@@ -31,7 +31,7 @@ then
 fi
 
 # Step 1 - Build the frontend release version into the backend/server/dist folder
-# Step 2 - Build the monolithic app by building backend release version together with the backend/server/dist (leveraing embed introduced in Golang 1.20.5).
+# Step 2 - Build the monolithic app by building backend release version together with the backend/server/dist (leveraing embed introduced in Golang 1.20.1).
 echo "Start building Bytebase monolithic ${VERSION}..."
 
 echo ""


### PR DESCRIPTION
Reverts bytebase/bytebase#6776

This may cause:
![img_v2_75d797e0-734a-4ab6-82e8-4339dbcb9d2g](https://github.com/bytebase/bytebase/assets/87714218/48a56358-8d48-47e2-a848-8fbae47929b1)
