### PR TITLE
feat(frontend): allow to upload and override oversized sheets

### DIFF
--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -53,13 +53,24 @@
         </UploadProgressButton>
       </template>
 
-      <NButton
-        v-if="shouldShowStatementEditButtonForUI"
-        size="tiny"
-        @click.prevent="beginEdit"
-      >
-        {{ $t("common.edit") }}
-      </NButton>
+      <template v-if="shouldShowStatementEditButtonForUI">
+        <!-- for small size sheets, show full featured UI editing button group -->
+        <NButton
+          v-if="!isTaskSheetOversize"
+          size="tiny"
+          @click.prevent="beginEdit"
+        >
+          {{ $t("common.edit") }}
+        </NButton>
+        <!-- for oversized sheets, only allow to upload and override the sheet -->
+        <UploadProgressButton
+          v-else
+          :upload="handleUploadAndOverride"
+          size="tiny"
+        >
+          {{ $t("issue.upload-sql") }}
+        </UploadProgressButton>
+      </template>
 
       <template v-else-if="!create">
         <NButton
@@ -371,10 +382,6 @@ const shouldShowStatementEditButtonForUI = computed(() => {
   if (create.value) {
     return false;
   }
-  // For those task sheet oversized, it's readonly.
-  if (isTaskSheetOversize.value) {
-    return false;
-  }
   // Will show another button group as [Upload][Cancel][Save]
   // while editing
   if (state.editing) {
@@ -479,6 +486,51 @@ const saveEdit = async () => {
   state.editing = false;
 };
 
+const handleUploadAndOverride = async (event: Event) => {
+  if (!selectedDatabase.value) {
+    return;
+  }
+  if (state.isUploadingFile) {
+    return;
+  }
+  try {
+    state.isUploadingFile = true;
+    await showOverrideConfirmDialog();
+    const { filename, content: statement } = await handleUploadFileEvent(
+      event,
+      100
+    );
+    const projectName = selectedDatabase.value.project;
+    let payload = {};
+    if (!create.value) {
+      payload = getBacktracePayloadWithIssue(issue.value as Issue);
+    }
+    // TODO: upload process
+    const sheet = await sheetV1Store.createSheet(projectName, {
+      title: filename,
+      content: new TextEncoder().encode(statement),
+      visibility: Sheet_Visibility.VISIBILITY_PROJECT,
+      source: Sheet_Source.SOURCE_BYTEBASE_ARTIFACT,
+      type: Sheet_Type.TYPE_SQL,
+      payload: JSON.stringify(payload),
+    });
+
+    resetTempEditState();
+    await updateSheetId(sheetV1Store.getSheetUid(sheet.name));
+    if (selectedTask.value) {
+      updateEditorHeight();
+    }
+
+    pushNotification({
+      module: "bytebase",
+      style: "INFO",
+      title: "File upload success",
+    });
+  } finally {
+    state.isUploadingFile = false;
+  }
+};
+
 const cancelEdit = async () => {
   state.editStatement = await getOrFetchSheetStatementByName(
     state.taskSheetName
@@ -499,6 +551,27 @@ const allowSaveSQL = computed((): boolean => {
   // Allowed to save otherwise
   return true;
 });
+
+const showOverrideConfirmDialog = () => {
+  return new Promise((resolve, reject) => {
+    // Show a confirm dialog before replacing if the editing statement is not empty.
+    overrideSQLDialog.create({
+      positiveText: t("common.confirm"),
+      negativeText: t("common.cancel"),
+      title: t("issue.override-current-statement"),
+      autoFocus: false,
+      closable: false,
+      maskClosable: false,
+      closeOnEsc: false,
+      onNegativeClick: () => {
+        reject();
+      },
+      onPositiveClick: () => {
+        resolve(undefined);
+      },
+    });
+  });
+};
 
 const handleUploadFile = async (event: Event, tick: (p: number) => void) => {
   if (!selectedDatabase.value) {
@@ -550,29 +623,12 @@ const handleUploadFile = async (event: Event, tick: (p: number) => void) => {
     }
   };
 
-  return new Promise((resolve, reject) => {
-    if (state.editStatement) {
-      // Show a confirm dialog before replacing if the editing statement is not empty.
-      overrideSQLDialog.create({
-        positiveText: t("common.confirm"),
-        negativeText: t("common.cancel"),
-        title: t("issue.override-current-statement"),
-        autoFocus: false,
-        closable: false,
-        maskClosable: false,
-        closeOnEsc: false,
-        onNegativeClick: () => {
-          state.isUploadingFile = false;
-          reject();
-        },
-        onPositiveClick: () => {
-          resolve(uploadStatementAsSheet());
-        },
-      });
-    } else {
-      resolve(uploadStatementAsSheet());
-    }
-  });
+  if (state.editStatement) {
+    await showOverrideConfirmDialog();
+    return uploadStatementAsSheet();
+  }
+
+  return uploadStatementAsSheet();
 };
 
 const handleUploadFileEvent = (

--- a/frontend/src/components/Issue/IssueTaskStatementPanel.vue
+++ b/frontend/src/components/Issue/IssueTaskStatementPanel.vue
@@ -62,10 +62,10 @@
         >
           {{ $t("common.edit") }}
         </NButton>
-        <!-- for oversized sheets, only allow to upload and override the sheet -->
+        <!-- for oversized sheets, only allow to upload and overwrite the sheet -->
         <UploadProgressButton
           v-else
-          :upload="handleUploadAndOverride"
+          :upload="handleUploadAndOverwrite"
           size="tiny"
         >
           {{ $t("issue.upload-sql") }}
@@ -197,7 +197,7 @@ const {
 } = useIssueLogic();
 
 const { t } = useI18n();
-const overrideSQLDialog = useDialog();
+const overwriteSQLDialog = useDialog();
 const uiStateStore = useUIStateStore();
 const dbSchemaStore = useDBSchemaV1Store();
 const sheetV1Store = useSheetV1Store();
@@ -486,7 +486,7 @@ const saveEdit = async () => {
   state.editing = false;
 };
 
-const handleUploadAndOverride = async (event: Event) => {
+const handleUploadAndOverwrite = async (event: Event) => {
   if (!selectedDatabase.value) {
     return;
   }
@@ -495,7 +495,7 @@ const handleUploadAndOverride = async (event: Event) => {
   }
   try {
     state.isUploadingFile = true;
-    await showOverrideConfirmDialog();
+    await showOverwriteConfirmDialog();
     const { filename, content: statement } = await handleUploadFileEvent(
       event,
       100
@@ -552,13 +552,13 @@ const allowSaveSQL = computed((): boolean => {
   return true;
 });
 
-const showOverrideConfirmDialog = () => {
+const showOverwriteConfirmDialog = () => {
   return new Promise((resolve, reject) => {
     // Show a confirm dialog before replacing if the editing statement is not empty.
-    overrideSQLDialog.create({
+    overwriteSQLDialog.create({
       positiveText: t("common.confirm"),
       negativeText: t("common.cancel"),
-      title: t("issue.override-current-statement"),
+      title: t("issue.overwrite-current-statement"),
       autoFocus: false,
       closable: false,
       maskClosable: false,
@@ -624,7 +624,7 @@ const handleUploadFile = async (event: Event, tick: (p: number) => void) => {
   };
 
   if (state.editStatement) {
-    await showOverrideConfirmDialog();
+    await showOverwriteConfirmDialog();
     return uploadStatementAsSheet();
   }
 

--- a/frontend/src/components/misc/UploadProgressButton.vue
+++ b/frontend/src/components/misc/UploadProgressButton.vue
@@ -78,6 +78,12 @@ const handleUpload = async (e: Event) => {
   } finally {
     uploading.value = false;
     percent.value = -1;
+    if (inputRef.value) {
+      // Clear the selected file.
+      // Otherwise selecting the same file again will not trigger
+      // change event
+      inputRef.value.value = "";
+    }
   }
 };
 </script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -729,8 +729,8 @@
     "edit-sql-statement": "Edit SQL statement",
     "upload-sql": "Upload SQL",
     "upload-sql-as-sheet": "Upload SQL as Sheet",
-    "statement-from-sheet-warning": "The current SQL statement comes from a sheet. It is read-only and only part of it is displayed.",
-    "override-current-statement": "Override current SQL statement",
+    "statement-from-sheet-warning": "SQL is oversized and inline-editing is disallowed. You can upload a new SQL file to overwrite it.",
+    "overwrite-current-statement": "Overwrite current SQL statement",
     "upload-sql-file-max-size-exceeded": "Max file size ({size}) exceeded.",
     "waiting-earliest-allowed-time": "Will run after {time}",
     "batch-transition": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -722,8 +722,8 @@
     "edit-sql-statement": "Editar declaración SQL",
     "upload-sql": "Cargar SQL",
     "upload-sql-as-sheet": "Cargar SQL como Hoja",
-    "statement-from-sheet-warning": "La declaración SQL actual proviene de una hoja. Es de solo lectura y solo se muestra parte de ella.",
-    "override-current-statement": "Anular la declaración SQL actual",
+    "statement-from-sheet-warning": "SQL está sobredimensionado y no se permite la edición en línea. \nPuede cargar un nuevo archivo SQL para sobrescribirlo.",
+    "overwrite-current-statement": "Sobrescribir la declaración SQL actual",
     "upload-sql-file-max-size-exceeded": "Se ha excedido el tamaño máximo del archivo ({size}).",
     "waiting-earliest-allowed-time": "Se ejecutará después de {time}",
     "batch-transition": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -726,8 +726,8 @@
     "edit-sql-statement": "编辑 SQL 语句",
     "upload-sql": "上传 SQL",
     "upload-sql-as-sheet": "上传 SQL 至工作表",
-    "statement-from-sheet-warning": "当前的 SQL 语句来自一个工作表。它是只读的且只显示了部分内容。",
-    "override-current-statement": "覆盖当前的 SQL 语句",
+    "statement-from-sheet-warning": "SQL 过大所以无法直接编辑。你可以上传新的 SQL 文件以将其覆盖。",
+    "overwrite-current-statement": "覆盖当前的 SQL 语句",
     "upload-sql-file-max-size-exceeded": "上传文件大小不能超过 {size}。",
     "waiting-earliest-allowed-time": "将于 {time} 之后执行",
     "batch-transition": {


### PR DESCRIPTION
- An oversized sheet can be overridden by "upload" another SQL file.
- If the newly updated SQL file is NOT oversized, the sheet will be UI-editable again.

![localhost_3000_issue_employee-change-data-06-27-1414-utc0800-997_stage=prod-stage-1 task=dmldata-for-database-employee-1746(1080P)](https://github.com/bytebase/bytebase/assets/2749742/3dd60667-fd1c-495c-9086-e9028c78e57f)

![localhost_3000_issue_employee-change-data-06-27-1414-utc0800-997_stage=prod-stage-1 task=dmldata-for-database-employee-1746(1080P) (1)](https://github.com/bytebase/bytebase/assets/2749742/bdaf23cf-a5f0-47dd-a42c-881f78c40613)


Close BYT-3457
