### PR TITLE
feat: automatic rollout should be the default rollout policy

### DIFF
--- a/backend/migrator/migration/prod/1.0/0001##initial_data.sql
+++ b/backend/migrator/migration/prod/1.0/0001##initial_data.sql
@@ -70,29 +70,10 @@ VALUES
         1,
         102,
         'bb.policy.pipeline-approval',
-        '{"value":"MANUAL_APPROVAL_ALWAYS"}'
+        '{"value":"MANUAL_APPROVAL_NEVER"}'
     );
 
-INSERT INTO
-    policy (
-        id,
-        creator_id,
-        updater_id,
-        environment_id,
-        type,
-        payload
-    )
-VALUES
-    (
-        103,
-        1,
-        1,
-        102,
-        'bb.policy.backup-plan',
-        '{"schedule":"WEEKLY"}'
-    );
-
-ALTER SEQUENCE policy_id_seq RESTART WITH 104;
+ALTER SEQUENCE policy_id_seq RESTART WITH 103;
 
 -- Create label keys for `bb.location` and `bb.tenant`.
 INSERT INTO

--- a/backend/migrator/migration/prod/LATEST_DATA.sql
+++ b/backend/migrator/migration/prod/LATEST_DATA.sql
@@ -82,30 +82,7 @@ VALUES
         102,
         TRUE,
         'bb.policy.pipeline-approval',
-        '{"value":"MANUAL_APPROVAL_ALWAYS"}'
+        '{"value":"MANUAL_APPROVAL_NEVER"}'
     );
 
-INSERT INTO
-    policy (
-        id,
-        creator_id,
-        updater_id,
-        resource_type,
-        resource_id,
-        inherit_from_parent,
-        type,
-        payload
-    )
-VALUES
-    (
-        103,
-        1,
-        1,
-        'ENVIRONMENT',
-        102,
-        TRUE,
-        'bb.policy.backup-plan',
-        '{"schedule":"WEEKLY"}'
-    );
-
-ALTER SEQUENCE policy_id_seq RESTART WITH 104;
+ALTER SEQUENCE policy_id_seq RESTART WITH 103;

--- a/frontend/src/store/modules/v1/policy.ts
+++ b/frontend/src/store/modules/v1/policy.ts
@@ -250,7 +250,7 @@ export const getDefaultBackupPlanPolicy = (
   };
 };
 
-export const defaultApprovalStrategy = ApprovalStrategy.MANUAL;
+export const defaultApprovalStrategy = ApprovalStrategy.AUTOMATIC;
 
 export const getDefaultDeploymentApprovalPolicy = (
   parentPath: string,


### PR DESCRIPTION
* The default policy should be the one without extra control
* Also change the seed environment data to use the policy without requiring paid features. Otherwise, user will immediately see the subscription banner, which is bad for 1st time impression

![CleanShot 2023-07-02 at 21-42-13 png](https://github.com/bytebase/bytebase/assets/230323/e7df7230-67c5-4442-baad-cc7d5a24f73b)

![CleanShot 2023-07-02 at 21-42-24 png](https://github.com/bytebase/bytebase/assets/230323/78ce95f0-3bb6-44fe-bb72-bcfec25cc9bd)

Fix BYT-3506
