### PR TITLE
feat: hide license column for FREE plan

### DIFF
--- a/frontend/src/components/v2/Model/Instance/InstanceV1Table/InstanceV1Table.vue
+++ b/frontend/src/components/v2/Model/Instance/InstanceV1Table/InstanceV1Table.vue
@@ -31,7 +31,7 @@
         </button>
       </div>
       <div v-if="canAssignLicense" class="bb-grid-cell hover:underline">
-        {{ instance.activation ? "Assigned" : "N/A" }}
+        {{ instance.activation ? "Y" : "" }}
       </div>
     </template>
   </BBGrid>

--- a/frontend/src/views/InstanceDashboard.vue
+++ b/frontend/src/views/InstanceDashboard.vue
@@ -20,7 +20,7 @@
     </div>
     <InstanceV1Table
       :instance-list="filteredInstanceV1List"
-      :can-assign-license="true"
+      :can-assign-license="subscriptionStore.currentPlan !== PlanType.FREE"
     />
   </div>
 </template>


### PR DESCRIPTION
Also use "Y" instead of literal "Assigned" to avoid i18n translation

### Before
![CleanShot 2023-07-02 at 21-53-48 png](https://github.com/bytebase/bytebase/assets/230323/32617b41-bbce-47d6-b769-520ffa2c4be0)

### After
![CleanShot 2023-07-02 at 21-56-55 png](https://github.com/bytebase/bytebase/assets/230323/76bdb806-7a77-4226-ba34-67f113d0034e)
