### PR TITLE
chore: plan and version should align left/right respectively

### DIFF
--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -105,7 +105,7 @@
             {{ $t("common.archive") }}
           </router-link>
           <div
-            class="flex-shrink-0 flex border-t border-block-border px-3 py-2"
+            class="flex-shrink-0 flex justify-between border-t border-block-border px-3 py-2"
           >
             <div
               v-if="isDemo"


### PR DESCRIPTION
They use different font size and co-locating them together looks bad

Before
![CleanShot 2023-07-02 at 22-10-28 png](https://github.com/bytebase/bytebase/assets/230323/487f7f21-1856-4130-88c1-8313f5cf938d)

After
![CleanShot 2023-07-02 at 22-12-09 png](https://github.com/bytebase/bytebase/assets/230323/ee82d8da-0a20-48f5-8bed-24ce54591bbb)

