### PR TITLE
fix: sheet_id doesn't exist in change history table

### DIFF
--- a/backend/migrator/migrator.go
+++ b/backend/migrator/migrator.go
@@ -139,7 +139,7 @@ func initializeSchema(ctx context.Context, storeInstance *store.Store, metadataD
 	if _, err := metadataDriver.GetDB().ExecContext(ctx, stmt); err != nil {
 		return err
 	}
-	if _, err := storeInstance.CreateInstanceChangeHistory(ctx, &store.InstanceChangeHistoryMessage{
+	if err := storeInstance.CreateInstanceChangeHistory(ctx, &store.InstanceChangeHistoryMessage{
 		CreatorID:      api.SystemBotID,
 		InstanceUID:    nil,
 		DatabaseUID:    nil,

--- a/backend/store/instance_change_history.go
+++ b/backend/store/instance_change_history.go
@@ -78,33 +78,27 @@ type UpdateInstanceChangeHistoryMessage struct {
 }
 
 // CreateInstanceChangeHistory creates instance change history in batch.
-func (s *Store) CreateInstanceChangeHistory(ctx context.Context, creates ...*InstanceChangeHistoryMessage) ([]*InstanceChangeHistoryMessage, error) {
+func (s *Store) CreateInstanceChangeHistory(ctx context.Context, create *InstanceChangeHistoryMessage) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer tx.Rollback()
 
-	list, err := s.createInstanceChangeHistoryImpl(ctx, tx, creates...)
-	if err != nil {
-		return nil, err
+	if create.SheetID == nil {
+		if _, err := s.createInstanceChangeHistoryImplWithoutSheet(ctx, tx, create); err != nil {
+			return err
+		}
+	} else {
+		if _, err := s.createInstanceChangeHistoryImpl(ctx, tx, create); err != nil {
+			return err
+		}
 	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	return list, nil
+	return tx.Commit()
 }
 
-func (*Store) createInstanceChangeHistoryImpl(ctx context.Context, tx *Tx, creates ...*InstanceChangeHistoryMessage) ([]*InstanceChangeHistoryMessage, error) {
-	if len(creates) == 0 {
-		return nil, nil
-	}
-	var query strings.Builder
-	var values []any
-	var queryValues []string
-
-	_, _ = query.WriteString(`
+func (*Store) createInstanceChangeHistoryImpl(ctx context.Context, tx *Tx, create *InstanceChangeHistoryMessage) (string, error) {
+	query := `
 		INSERT INTO instance_change_history (
 			creator_id,
 			updater_id,
@@ -123,111 +117,94 @@ func (*Store) createInstanceChangeHistoryImpl(ctx context.Context, tx *Tx, creat
 			sheet_id,
 			schema_prev,
 			execution_duration_ns,
-			payload,
-			created_ts,
-			updated_ts
-		) VALUES `)
+			payload
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+		RETURNING id`
 
-	count := 1
-	for _, create := range creates {
-		payload, err := protojson.Marshal(create.Payload)
-		if err != nil {
-			return nil, err
-		}
-		values = append(values,
-			create.CreatorID,
-			create.CreatorID,
-			create.InstanceUID,
-			create.DatabaseUID,
-			create.IssueUID,
-			create.ReleaseVersion,
-			create.Sequence,
-			create.Source,
-			create.Type,
-			create.Status,
-			create.Version,
-			create.Description,
-			create.Statement,
-			create.Schema,
-			create.SheetID,
-			create.SchemaPrev,
-			create.ExecutionDurationNs,
-			payload,
-		)
-		const countToPayload = 18
-		var valueStr []string
-		for i := 0; i < countToPayload; i++ {
-			valueStr = append(valueStr, fmt.Sprintf("$%d", count))
-			count++
-		}
-		if create.CreatedTs == 0 {
-			valueStr = append(valueStr, "DEFAULT")
-		} else {
-			valueStr = append(valueStr, fmt.Sprintf("$%d", count))
-			values = append(values, create.CreatedTs)
-			count++
-		}
-		if create.UpdatedTs == 0 {
-			valueStr = append(valueStr, "DEFAULT")
-		} else {
-			valueStr = append(valueStr, fmt.Sprintf("$%d", count))
-			values = append(values, create.UpdatedTs)
-			count++
-		}
-		queryValues = append(queryValues, fmt.Sprintf("(%s)", strings.Join(valueStr, " , ")))
-	}
-
-	_, _ = query.WriteString(strings.Join(queryValues, ", "))
-	_, _ = query.WriteString(` RETURNING id, created_ts`)
-
-	rows, err := tx.QueryContext(ctx, query.String(), values...)
+	payload, err := protojson.Marshal(create.Payload)
 	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var list []*InstanceChangeHistoryMessage
-
-	i := 0
-	for rows.Next() {
-		var id string
-		var createdTs int64
-		if err := rows.Scan(&id, &createdTs); err != nil {
-			return nil, err
-		}
-
-		create := creates[i]
-		list = append(list, &InstanceChangeHistoryMessage{
-			CreatorID:           create.CreatorID,
-			UpdaterID:           create.CreatorID,
-			InstanceUID:         create.InstanceUID,
-			DatabaseUID:         create.DatabaseUID,
-			IssueUID:            create.IssueUID,
-			ReleaseVersion:      create.ReleaseVersion,
-			Sequence:            create.Sequence,
-			Source:              create.Source,
-			Type:                create.Type,
-			Status:              create.Status,
-			Version:             create.Version,
-			Description:         create.Description,
-			Statement:           create.Statement,
-			Schema:              create.Schema,
-			SheetID:             create.SheetID,
-			SchemaPrev:          create.SchemaPrev,
-			ExecutionDurationNs: create.ExecutionDurationNs,
-			Payload:             create.Payload,
-
-			UID:       id,
-			CreatedTs: createdTs,
-			UpdatedTs: createdTs,
-		})
-		i++
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return list, nil
+	var uid string
+	if err := tx.QueryRowContext(ctx, query,
+		create.CreatorID,
+		create.CreatorID,
+		create.InstanceUID,
+		create.DatabaseUID,
+		create.IssueUID,
+		create.ReleaseVersion,
+		create.Sequence,
+		create.Source,
+		create.Type,
+		create.Status,
+		create.Version,
+		create.Description,
+		create.Statement,
+		create.Schema,
+		create.SheetID,
+		create.SchemaPrev,
+		create.ExecutionDurationNs,
+		payload,
+	).Scan(&uid); err != nil {
+		return "", err
+	}
+
+	return uid, nil
+}
+
+func (*Store) createInstanceChangeHistoryImplWithoutSheet(ctx context.Context, tx *Tx, create *InstanceChangeHistoryMessage) (string, error) {
+	query := `
+		INSERT INTO instance_change_history (
+			creator_id,
+			updater_id,
+			instance_id,
+			database_id,
+			issue_id,
+			release_version,
+			sequence,
+			source,
+			type,
+			status,
+			version,
+			description,
+			statement,
+			"schema",
+			schema_prev,
+			execution_duration_ns,
+			payload
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		RETURNING id`
+
+	payload, err := protojson.Marshal(create.Payload)
+	if err != nil {
+		return "", err
+	}
+
+	var uid string
+	if err := tx.QueryRowContext(ctx, query,
+		create.CreatorID,
+		create.CreatorID,
+		create.InstanceUID,
+		create.DatabaseUID,
+		create.IssueUID,
+		create.ReleaseVersion,
+		create.Sequence,
+		create.Source,
+		create.Type,
+		create.Status,
+		create.Version,
+		create.Description,
+		create.Statement,
+		create.Schema,
+		create.SchemaPrev,
+		create.ExecutionDurationNs,
+		payload,
+	).Scan(&uid); err != nil {
+		return "", err
+	}
+
+	return uid, nil
 }
 
 func convertInstanceChangeHistoryToMigrationHistory(change *InstanceChangeHistoryMessage) (*db.MigrationHistory, error) {
@@ -563,7 +540,7 @@ func (s *Store) CreatePendingInstanceChangeHistory(ctx context.Context, prevSche
 	if err != nil {
 		return "", err
 	}
-	list, err := s.createInstanceChangeHistoryImpl(ctx, tx, &InstanceChangeHistoryMessage{
+	instanceChange := &InstanceChangeHistoryMessage{
 		CreatorID:           m.CreatorID,
 		InstanceUID:         m.InstanceID,
 		DatabaseUID:         m.DatabaseID,
@@ -581,16 +558,27 @@ func (s *Store) CreatePendingInstanceChangeHistory(ctx context.Context, prevSche
 		SchemaPrev:          prevSchema,
 		ExecutionDurationNs: 0,
 		Payload:             m.Payload,
-	})
-	if err != nil {
-		return "", err
+	}
+	var uid string
+	if instanceChange.SheetID == nil {
+		id, err := s.createInstanceChangeHistoryImplWithoutSheet(ctx, tx, instanceChange)
+		if err != nil {
+			return "", err
+		}
+		uid = id
+	} else {
+		id, err := s.createInstanceChangeHistoryImpl(ctx, tx, instanceChange)
+		if err != nil {
+			return "", err
+		}
+		uid = id
 	}
 
 	if err := tx.Commit(); err != nil {
 		return "", err
 	}
 
-	return list[0].UID, nil
+	return uid, nil
 }
 
 // ListInstanceChangeHistoryForMigrator finds the instance change history for the migrator,

--- a/backend/store/instance_change_history.go
+++ b/backend/store/instance_change_history.go
@@ -306,10 +306,12 @@ func (s *Store) ListInstanceChangeHistory(ctx context.Context, find *FindInstanc
 	if v := find.ID; v != nil {
 		where, args = append(where, fmt.Sprintf("instance_change_history.id = $%d", len(args)+1)), append(args, *v)
 	}
+	sheetField := "instance_change_history.sheet_id"
 	if v := find.InstanceID; v != nil {
 		where, args = append(where, fmt.Sprintf("instance_change_history.instance_id = $%d", len(args)+1)), append(args, *v)
 	} else {
 		where = append(where, "instance_change_history.instance_id is NULL AND instance_change_history.database_id is NULL")
+		sheetField = "NULL"
 	}
 	if v := find.DatabaseID; v != nil {
 		where, args = append(where, fmt.Sprintf("instance_change_history.database_id = $%d", len(args)+1)), append(args, *v)
@@ -355,7 +357,7 @@ func (s *Store) ListInstanceChangeHistory(ctx context.Context, find *FindInstanc
 			%s,
 			%s,
 			%s,
-			instance_change_history.sheet_id,
+			%s,
 			instance_change_history.execution_duration_ns,
 			instance_change_history.payload,
 			COALESCE(instance.resource_id, ''),
@@ -363,7 +365,7 @@ func (s *Store) ListInstanceChangeHistory(ctx context.Context, find *FindInstanc
 		FROM instance_change_history
 		LEFT JOIN instance on instance.id = instance_change_history.instance_id
 		LEFT JOIN db on db.id = instance_change_history.database_id
-		WHERE `+strings.Join(where, " AND ")+` ORDER BY instance_change_history.instance_id, instance_change_history.database_id, instance_change_history.sequence DESC`, statementField, schemaField, schemaPrevField)
+		WHERE `+strings.Join(where, " AND ")+` ORDER BY instance_change_history.instance_id, instance_change_history.database_id, instance_change_history.sequence DESC`, statementField, schemaField, schemaPrevField, sheetField)
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}

--- a/backend/store/instance_change_history.go
+++ b/backend/store/instance_change_history.go
@@ -85,8 +85,8 @@ func (s *Store) CreateInstanceChangeHistory(ctx context.Context, create *Instanc
 	}
 	defer tx.Rollback()
 
-	if create.SheetID == nil {
-		if _, err := s.createInstanceChangeHistoryImplWithoutSheet(ctx, tx, create); err != nil {
+	if create.InstanceUID == nil {
+		if _, err := s.createInstanceChangeHistoryImplForMigrator(ctx, tx, create); err != nil {
 			return err
 		}
 	} else {
@@ -153,7 +153,7 @@ func (*Store) createInstanceChangeHistoryImpl(ctx context.Context, tx *Tx, creat
 	return uid, nil
 }
 
-func (*Store) createInstanceChangeHistoryImplWithoutSheet(ctx context.Context, tx *Tx, create *InstanceChangeHistoryMessage) (string, error) {
+func (*Store) createInstanceChangeHistoryImplForMigrator(ctx context.Context, tx *Tx, create *InstanceChangeHistoryMessage) (string, error) {
 	query := `
 		INSERT INTO instance_change_history (
 			creator_id,
@@ -562,8 +562,8 @@ func (s *Store) CreatePendingInstanceChangeHistory(ctx context.Context, prevSche
 		Payload:             m.Payload,
 	}
 	var uid string
-	if instanceChange.SheetID == nil {
-		id, err := s.createInstanceChangeHistoryImplWithoutSheet(ctx, tx, instanceChange)
+	if instanceChange.InstanceUID == nil {
+		id, err := s.createInstanceChangeHistoryImplForMigrator(ctx, tx, instanceChange)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
The new version of migrator should not rely on the sheet_id if it hasn't yet exist in the old version of schema yet.