### PR TITLE
chore: minor markdown editor style tweak

### DIFF
--- a/frontend/src/components/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor.vue
@@ -1,19 +1,19 @@
 <template>
   <div>
-    <div v-if="mode === 'editor'" class="flex gap-x-3 mb-2 text-sm">
+    <div v-if="mode === 'editor'" class="flex gap-x-2 mb-2 text-sm">
       <div
         :class="[
           'p-2 rounded cursor-pointer',
-          state.showPreview ? '' : 'bg-gray-100 font-bold',
+          state.showPreview ? '' : 'bg-gray-100 text-gray-800',
         ]"
         @click="state.showPreview = false"
       >
-        {{ $t("issue.comment-editor.editor") }}
+        {{ $t("issue.comment-editor.write") }}
       </div>
       <div
         :class="[
           'p-2 rounded cursor-pointer',
-          state.showPreview ? 'bg-gray-100 font-bold' : '',
+          state.showPreview ? 'bg-gray-100 text-gray-800' : '',
         ]"
         @click="state.showPreview = true"
       >
@@ -361,7 +361,7 @@ const toolbarItems: Toolbar[] = [
     icon: "code",
     tooltip: t("issue.comment-editor.toolbar.code"),
     action: () => {
-      insertWithCursorPosition("\n```sql\n\n```\n", 8);
+      insertWithCursorPosition("```sql\n\n```", 7);
     },
   },
   {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -696,7 +696,7 @@
     "edit-comment": "Edit comment",
     "leave-a-comment": "Leave a comment...",
     "comment-editor": {
-      "editor": "Editor",
+      "write": "Write",
       "preview": "Preview",
       "nothing-to-preview": "Nothing to preview",
       "toolbar": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -696,7 +696,7 @@
     "edit-comment": "Editar comentario",
     "leave-a-comment": "Dejar un comentario...",
     "comment-editor": {
-      "editor": "Editor",
+      "write": "Escribir",
       "preview": "Vista previa",
       "nothing-to-preview": "Nada para previsualizar",
       "toolbar": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -693,7 +693,7 @@
     "edit-comment": "编辑评论",
     "leave-a-comment": "发表一条评论…",
     "comment-editor": {
-      "editor": "编辑",
+      "write": "编辑",
       "preview": "预览",
       "nothing-to-preview": "暂无预览",
       "toolbar": {


### PR DESCRIPTION
* Use `Write` instead of `Editor` (follow GitHub)
* Insert SQL snippet should not introduce new line (follow GitHub)
* Shorten the space between Write and Preview button
* Use text color instead of bold font to highlight selection.