### PR TITLE
chore(frontend): tenant deployment matrix layout improvement

### DIFF
--- a/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
+++ b/frontend/src/components/TenantDatabaseTable/DeployDatabaseTable.vue
@@ -73,7 +73,7 @@
         <BBTableCell v-for="(dbList, i) in matrix.stages" :key="i">
           <div
             v-if="databaseList.length > 0"
-            class="flex flex-col items-start space-y-1"
+            class="flex flex-col items-start w-max mx-auto space-y-1"
           >
             <DatabaseMatrixItem
               v-for="db in dbList"
@@ -87,7 +87,7 @@
         <BBTableCell v-if="hasRest">
           <div
             v-if="databaseList.length > 0"
-            class="flex flex-col items-start space-y-1"
+            class="flex flex-col items-start w-max mx-auto space-y-1"
           >
             <DatabaseMatrixItem
               v-for="db in matrix.rest"


### PR DESCRIPTION
![image](https://github.com/bytebase/bytebase/assets/2749742/0021d4d3-04a4-49ec-9cfd-a1778f5c8725)
Center in the big box. Left to the small box.

Close BYT-3537