### PR TITLE
chore: allow Mongo and Redis to query in SQL Editor

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -1349,6 +1349,8 @@ func (*SQLService) validateQueryRequest(instance *store.InstanceMessage, databas
 		if err := parser.PLSQLValidateForEditor(tree); err != nil {
 			return status.Errorf(codes.InvalidArgument, err.Error())
 		}
+	case db.MongoDB, db.Redis:
+		// Do nothing.
 	default:
 		// TODO(rebelice): support multiple statements here.
 		if !parser.ValidateSQLForEditor(convertToParserEngine(instance.Engine), statement) {

--- a/frontend/src/utils/v1/instance.ts
+++ b/frontend/src/utils/v1/instance.ts
@@ -128,9 +128,7 @@ export const instanceV1HasBackupRestore = (
 export const instanceV1HasReadonlyMode = (
   instanceOrEngine: Instance | Engine
 ): boolean => {
-  const engine = engineOfInstanceV1(instanceOrEngine);
-  if (engine === Engine.MONGODB) return false;
-  if (engine === Engine.REDIS) return false;
+  // For MongoDB and Redis, we rely on users setting up read-only data source for queries.
   return true;
 };
 


### PR DESCRIPTION
Users have to setup read-only data source to make sure queries to be immutable.