### PR TITLE
chore: update `Upgrade trial` button in access control setting

### DIFF
--- a/frontend/src/components/UpgradeSubscriptionButton.vue
+++ b/frontend/src/components/UpgradeSubscriptionButton.vue
@@ -1,0 +1,65 @@
+<template>
+  <div
+    v-if="actionText != ''"
+    class="flex items-center justify-end mt-2 md:mt-0 md:ml-2"
+  >
+    <button
+      type="button"
+      class="btn-primary whitespace-nowrap"
+      @click.prevent="onClick"
+    >
+      {{ $t(actionText) }}
+    </button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { pushNotification, useSubscriptionV1Store } from "@/store";
+import { useI18n } from "vue-i18n";
+import { PlanType } from "@/types/proto/v1/subscription_service";
+import { planTypeToString } from "@/types";
+import { useRouter } from "vue-router";
+
+const { t } = useI18n();
+const router = useRouter();
+const subscriptionStore = useSubscriptionV1Store();
+
+const actionText = computed(() => {
+  if (!subscriptionStore.canTrial) {
+    return t("subscription.upgrade");
+  }
+  if (subscriptionStore.canUpgradeTrial) {
+    return t("subscription.upgrade-trial-button");
+  }
+  return t("subscription.start-n-days-trial", {
+    days: subscriptionStore.trialingDays,
+  });
+});
+
+const onClick = () => {
+  if (subscriptionStore.canTrial) {
+    const isUpgrade = subscriptionStore.canUpgradeTrial;
+    subscriptionStore.trialSubscription(PlanType.ENTERPRISE).then(() => {
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("common.success"),
+        description: isUpgrade
+          ? t("subscription.successfully-upgrade-trial", {
+              plan: t(
+                `subscription.plan.${planTypeToString(
+                  subscriptionStore.currentPlan
+                )}.title`
+              ),
+            })
+          : t("subscription.successfully-start-trial", {
+              days: subscriptionStore.trialingDays,
+            }),
+      });
+    });
+  } else {
+    router.push({ name: "setting.workspace.subscription" });
+  }
+};
+</script>

--- a/frontend/src/views/SettingWorkspaceAccessControl.vue
+++ b/frontend/src/views/SettingWorkspaceAccessControl.vue
@@ -65,14 +65,7 @@
         v-if="!hasDataAccessControlFeature"
         class="absolute w-full h-full inset-0 z-10 bg-gray-300/80 flex flex-col items-center justify-center"
       >
-        <button
-          type="button"
-          class="btn-primary whitespace-nowrap shadow"
-          @click.prevent="handleUpgradeSubscription"
-        >
-          <heroicons-solid:sparkles class="text-white w-5 h-auto mr-1" />
-          {{ $t("subscription.upgrade") }}
-        </button>
+        <UpgradeSubscriptionButton />
       </div>
     </div>
   </div>
@@ -103,7 +96,7 @@ import {
 import { IamPolicy } from "@/types/proto/v1/iam_policy";
 import { Expr } from "@/types/proto/google/type/expr";
 import { useDebounceFn } from "@vueuse/core";
-import { useRouter } from "vue-router";
+import UpgradeSubscriptionButton from "@/components/UpgradeSubscriptionButton.vue";
 
 interface EnvironmentPolicy {
   environment: Environment;
@@ -118,7 +111,6 @@ interface LocalState {
 }
 
 const { t } = useI18n();
-const router = useRouter();
 const environmentList = useEnvironmentV1List();
 const policyStore = usePolicyV1Store();
 const currentUserV1 = useCurrentUserV1();
@@ -198,10 +190,6 @@ onMounted(async () => {
   }
   state.isLoading = false;
 });
-
-const handleUpgradeSubscription = () => {
-  router.push({ name: "setting.workspace.subscription" });
-};
 
 const buildWorkspaceIAMPolicy = (envPolicyList: EnvironmentPolicy[]) => {
   const workspaceIamPolicy: IamPolicy = IamPolicy.fromPartial({});


### PR DESCRIPTION
Keep it has a same behavior with subscription banner.

<img width="1857" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/7e2aca80-42e6-4e34-87d0-635590364415">