### PR TITLE
feat(idp): add BindDN-based LDAP authentication client

### DIFF
--- a/backend/plugin/idp/ldap/ldap.go
+++ b/backend/plugin/idp/ldap/ldap.go
@@ -141,8 +141,12 @@ func (p *IdentityProvider) Authenticate(username, password string) (*storepb.Ide
 		return nil, errors.Errorf("bind user: %v", err)
 	}
 
+	identifier := entry.GetAttributeValue(p.config.FieldMapping.Identifier)
+	if identifier == "" {
+		return nil, errors.Errorf("the attribute %q is not found or has empty value", p.config.FieldMapping.Identifier)
+	}
 	return &storepb.IdentityProviderUserInfo{
-		Identifier:  entry.GetAttributeValue(p.config.FieldMapping.Identifier),
+		Identifier:  identifier,
 		DisplayName: entry.GetAttributeValue(p.config.FieldMapping.DisplayName),
 		Email:       entry.GetAttributeValue(p.config.FieldMapping.Email),
 	}, nil

--- a/backend/plugin/idp/ldap/ldap.go
+++ b/backend/plugin/idp/ldap/ldap.go
@@ -1,3 +1,4 @@
+// Package ldap is the plugin for LDAP Identity Provider.
 package ldap
 
 import (
@@ -21,8 +22,10 @@ type IdentityProvider struct {
 type SecurityProtocol string
 
 const (
+	// SecurityProtocolStartTLS represents the StartTLS security protocol.
 	SecurityProtocolStartTLS SecurityProtocol = "starttls"
-	SecurityProtocolLDAPS    SecurityProtocol = "ldaps"
+	// SecurityProtocolLDAPS represents the LDAPS security protocol.
+	SecurityProtocolLDAPS SecurityProtocol = "ldaps"
 )
 
 // IdentityProviderConfig is the configuration to be consumed by the LDAP
@@ -73,12 +76,12 @@ func NewIdentityProvider(config IdentityProviderConfig) (*IdentityProvider, erro
 
 func (p *IdentityProvider) dial() (*ldap.Conn, error) {
 	addr := fmt.Sprintf("%s:%d", p.config.Host, p.config.Port)
-	tlsCfg := &tls.Config{
+	tlsConfig := &tls.Config{
 		ServerName:         p.config.Host,
 		InsecureSkipVerify: p.config.SkipTLSVerify,
 	}
 	if p.config.SecurityProtocol == SecurityProtocolLDAPS {
-		conn, err := ldap.DialTLS("tcp", addr, tlsCfg)
+		conn, err := ldap.DialTLS("tcp", addr, tlsConfig)
 		if err != nil {
 			return nil, errors.Errorf("dial TLS: %v", err)
 		}
@@ -90,7 +93,7 @@ func (p *IdentityProvider) dial() (*ldap.Conn, error) {
 		return nil, errors.Errorf("dial: %v", err)
 	}
 	if p.config.SecurityProtocol == SecurityProtocolStartTLS {
-		if err = conn.StartTLS(tlsCfg); err != nil {
+		if err = conn.StartTLS(tlsConfig); err != nil {
 			_ = conn.Close()
 			return nil, errors.Errorf("start TLS: %v", err)
 		}
@@ -98,6 +101,7 @@ func (p *IdentityProvider) dial() (*ldap.Conn, error) {
 	return conn, nil
 }
 
+// Authenticate authenticates the user with the given username and password.
 func (p *IdentityProvider) Authenticate(username, password string) (*storepb.IdentityProviderUserInfo, error) {
 	conn, err := p.dial()
 	if err != nil {

--- a/backend/plugin/idp/ldap/ldap.go
+++ b/backend/plugin/idp/ldap/ldap.go
@@ -1,0 +1,145 @@
+package ldap
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/pkg/errors"
+
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+)
+
+// IdentityProvider represents an LDAP Identity Provider.
+type IdentityProvider struct {
+	config IdentityProviderConfig
+}
+
+// SecurityProtocol represents the security protocol to be used when connecting
+// to the LDAP server.
+type SecurityProtocol string
+
+const (
+	SecurityProtocolStartTLS SecurityProtocol = "starttls"
+	SecurityProtocolLDAPS    SecurityProtocol = "ldaps"
+)
+
+// IdentityProviderConfig is the configuration to be consumed by the LDAP
+// Identity Provider.
+type IdentityProviderConfig struct {
+	Host             string                `json:"host"`
+	Port             int                   `json:"port"`
+	SkipTLSVerify    bool                  `json:"skipTlsVerify"`
+	BindDN           string                `json:"bindDn"`
+	BindPassword     string                `json:"bindPassword"`
+	BaseDN           string                `json:"baseDn"`
+	UserFilter       string                `json:"userFilter"`
+	SecurityProtocol SecurityProtocol      `json:"securityProtocol"`
+	FieldMapping     *storepb.FieldMapping `json:"fieldMapping"`
+}
+
+// NewIdentityProvider initializes a new LDAP Identity Provider with the given
+// configuration.
+func NewIdentityProvider(config IdentityProviderConfig) (*IdentityProvider, error) {
+	if config.SecurityProtocol != SecurityProtocolStartTLS && config.SecurityProtocol != SecurityProtocolLDAPS {
+		return nil, errors.Errorf("the field %q must be either %q or %q", "securityProtocol", SecurityProtocolStartTLS, SecurityProtocolLDAPS)
+	}
+	for v, field := range map[string]string{
+		config.Host:                    "host",
+		config.BindDN:                  "bindDn",
+		config.BindPassword:            "bindPassword",
+		config.BaseDN:                  "baseDn",
+		config.UserFilter:              "userFilter",
+		config.FieldMapping.Identifier: "fieldMapping.identifier",
+	} {
+		if v == "" {
+			return nil, errors.Errorf("the field %q is empty but required", field)
+		}
+	}
+
+	if config.Port <= 0 {
+		if config.SecurityProtocol == SecurityProtocolLDAPS {
+			config.Port = 636
+		} else {
+			config.Port = 389
+		}
+	}
+
+	return &IdentityProvider{
+		config: config,
+	}, nil
+}
+
+func (p *IdentityProvider) dial() (*ldap.Conn, error) {
+	addr := fmt.Sprintf("%s:%d", p.config.Host, p.config.Port)
+	tlsCfg := &tls.Config{
+		ServerName:         p.config.Host,
+		InsecureSkipVerify: p.config.SkipTLSVerify,
+	}
+	if p.config.SecurityProtocol == SecurityProtocolLDAPS {
+		conn, err := ldap.DialTLS("tcp", addr, tlsCfg)
+		if err != nil {
+			return nil, errors.Errorf("dial TLS: %v", err)
+		}
+		return conn, nil
+	}
+
+	conn, err := ldap.Dial("tcp", addr)
+	if err != nil {
+		return nil, errors.Errorf("dial: %v", err)
+	}
+	if p.config.SecurityProtocol == SecurityProtocolStartTLS {
+		if err = conn.StartTLS(tlsCfg); err != nil {
+			_ = conn.Close()
+			return nil, errors.Errorf("start TLS: %v", err)
+		}
+	}
+	return conn, nil
+}
+
+func (p *IdentityProvider) Authenticate(username, password string) (*storepb.IdentityProviderUserInfo, error) {
+	conn, err := p.dial()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Bind with a system account
+	err = conn.Bind(p.config.BindDN, p.config.BindPassword)
+	if err != nil {
+		return nil, errors.Errorf("bind: %v", err)
+	}
+
+	sr, err := conn.Search(
+		ldap.NewSearchRequest(
+			p.config.BaseDN,
+			ldap.ScopeWholeSubtree,
+			ldap.NeverDerefAliases,
+			0,
+			0,
+			false,
+			strings.ReplaceAll(p.config.UserFilter, "%s", username),
+			[]string{"dn", p.config.FieldMapping.Identifier, p.config.FieldMapping.DisplayName, p.config.FieldMapping.Email},
+			nil,
+		),
+	)
+	if err != nil {
+		return nil, errors.Errorf("search user DN: %v", err)
+	} else if len(sr.Entries) != 1 {
+		return nil, errors.Errorf("expect 1 user DN but got %d", len(sr.Entries))
+	}
+	entry := sr.Entries[0]
+
+	// Bind as the user to verify their password
+	err = conn.Bind(entry.DN, password)
+	if err != nil {
+		return nil, errors.Errorf("bind user: %v", err)
+	}
+
+	return &storepb.IdentityProviderUserInfo{
+		Identifier:  entry.GetAttributeValue(p.config.FieldMapping.Identifier),
+		DisplayName: entry.GetAttributeValue(p.config.FieldMapping.DisplayName),
+		Email:       entry.GetAttributeValue(p.config.FieldMapping.Email),
+	}, nil
+}

--- a/backend/plugin/idp/ldap/ldap_test.go
+++ b/backend/plugin/idp/ldap/ldap_test.go
@@ -1,0 +1,129 @@
+package ldap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+)
+
+func TestNewIdentityProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      IdentityProviderConfig
+		containsErr string
+	}{
+		{
+			name: "no security protocol",
+			config: IdentityProviderConfig{
+				Host:             "ldap.example.com",
+				BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				BindPassword:     "pa$$word",
+				BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
+				SecurityProtocol: "",
+				FieldMapping: &storepb.FieldMapping{
+					Identifier: "uid",
+				},
+			},
+			containsErr: `the field "securityProtocol" must be either "starttls" or "ldaps"`,
+		},
+		{
+			name: "no host",
+			config: IdentityProviderConfig{
+				Host:             "",
+				BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				BindPassword:     "pa$$word",
+				BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
+				SecurityProtocol: SecurityProtocolStartTLS,
+				FieldMapping: &storepb.FieldMapping{
+					Identifier: "uid",
+				},
+			},
+			containsErr: `the field "host" is empty but required`,
+		},
+		{
+			name: "no bindDn",
+			config: IdentityProviderConfig{
+				Host:             "ldap.example.com",
+				BindDN:           "",
+				BindPassword:     "pa$$word",
+				BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
+				SecurityProtocol: SecurityProtocolStartTLS,
+				FieldMapping: &storepb.FieldMapping{
+					Identifier: "uid",
+				},
+			},
+			containsErr: `the field "bindDn" is empty but required`,
+		},
+		{
+			name: "no bindPassword",
+			config: IdentityProviderConfig{
+				Host:             "ldap.example.com",
+				BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				BindPassword:     "",
+				BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
+				SecurityProtocol: SecurityProtocolStartTLS,
+				FieldMapping: &storepb.FieldMapping{
+					Identifier: "uid",
+				},
+			},
+			containsErr: `the field "bindPassword" is empty but required`,
+		},
+		{
+			name: "no baseDn",
+			config: IdentityProviderConfig{
+				Host:             "ldap.example.com",
+				BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				BindPassword:     "pa$$word",
+				BaseDN:           "",
+				UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
+				SecurityProtocol: SecurityProtocolStartTLS,
+				FieldMapping: &storepb.FieldMapping{
+					Identifier: "uid",
+				},
+			},
+			containsErr: `the field "baseDn" is empty but required`,
+		},
+		{
+			name: "no userFilter",
+			config: IdentityProviderConfig{
+				Host:             "ldap.example.com",
+				BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				BindPassword:     "pa$$word",
+				BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				UserFilter:       "",
+				SecurityProtocol: SecurityProtocolStartTLS,
+				FieldMapping: &storepb.FieldMapping{
+					Identifier: "uid",
+				},
+			},
+			containsErr: `the field "userFilter" is empty but required`,
+		},
+		{
+			name: "no fieldMapping.identifier",
+			config: IdentityProviderConfig{
+				Host:             "ldap.example.com",
+				BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				BindPassword:     "pa$$word",
+				BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+				UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
+				SecurityProtocol: SecurityProtocolStartTLS,
+				FieldMapping: &storepb.FieldMapping{
+					DisplayName: "displayName",
+				},
+			},
+			containsErr: `the field "fieldMapping.identifier" is empty but required`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewIdentityProvider(test.config)
+			assert.ErrorContains(t, err, test.containsErr)
+		})
+	}
+}

--- a/backend/plugin/idp/ldap/ldap_test.go
+++ b/backend/plugin/idp/ldap/ldap_test.go
@@ -1,12 +1,27 @@
 package ldap
 
 import (
+	"crypto/tls"
+	"flag"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/lor00x/goldap/message"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vjeantet/ldapserver"
 
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		ldapserver.Logger = ldapserver.DiscardingLogger
+	}
+	os.Exit(m.Run())
+}
 
 func TestNewIdentityProvider(t *testing.T) {
 	tests := []struct {
@@ -126,4 +141,134 @@ func TestNewIdentityProvider(t *testing.T) {
 			assert.ErrorContains(t, err, test.containsErr)
 		})
 	}
+}
+
+func newMockServer(t *testing.T, uid, displayName, mail string) (host string, port int) {
+	// localhostCert is a PEM-encoded TLS cert with SAN IPs
+	// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+	// generated from src/crypto/tls:
+	// go run generate_cert.go  --rsa-bits 2048 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+	var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDOTCCAiGgAwIBAgIQSRJrEpBGFc7tNb1fb5pKFzANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEA6Gba5tHV1dAKouAaXO3/ebDUU4rvwCUg/CNaJ2PT5xLD4N1Vcb8r
+bFSW2HXKq+MPfVdwIKR/1DczEoAGf/JWQTW7EgzlXrCd3rlajEX2D73faWJekD0U
+aUgz5vtrTXZ90BQL7WvRICd7FlEZ6FPOcPlumiyNmzUqtwGhO+9ad1W5BqJaRI6P
+YfouNkwR6Na4TzSj5BrqUfP0FwDizKSJ0XXmh8g8G9mtwxOSN3Ru1QFc61Xyeluk
+POGKBV/q6RBNklTNe0gI8usUMlYyoC7ytppNMW7X2vodAelSu25jgx2anj9fDVZu
+h7AXF5+4nJS4AAt0n1lNY7nGSsdZas8PbQIDAQABo4GIMIGFMA4GA1UdDwEB/wQE
+AwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1Ud
+DgQWBBStsdjh3/JCXXYlQryOrL4Sh7BW5TAuBgNVHREEJzAlggtleGFtcGxlLmNv
+bYcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAxWGI
+5NhpF3nwwy/4yB4i/CwwSpLrWUa70NyhvprUBC50PxiXav1TeDzwzLx/o5HyNwsv
+cxv3HdkLW59i/0SlJSrNnWdfZ19oTcS+6PtLoVyISgtyN6DpkKpdG1cOkW3Cy2P2
++tK/tKHRP1Y/Ra0RiDpOAmqn0gCOFGz8+lqDIor/T7MTpibL3IxqWfPrvfVRHL3B
+grw/ZQTTIVjjh4JBSW3WyWgNo/ikC1lrVxzl4iPUGptxT36Cr7Zk2Bsg0XqwbOvK
+5d+NTDREkSnUbie4GeutujmX3Dsx88UiV6UY/4lHJa6I5leHUNOHahRbpbWeOfs/
+WkBKOclmOV2xlTVuPw==
+-----END CERTIFICATE-----`)
+
+	// localhostKey is the private key for localhostCert.
+	var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDoZtrm0dXV0Aqi
+4Bpc7f95sNRTiu/AJSD8I1onY9PnEsPg3VVxvytsVJbYdcqr4w99V3AgpH/UNzMS
+gAZ/8lZBNbsSDOVesJ3euVqMRfYPvd9pYl6QPRRpSDPm+2tNdn3QFAvta9EgJ3sW
+URnoU85w+W6aLI2bNSq3AaE771p3VbkGolpEjo9h+i42TBHo1rhPNKPkGupR8/QX
+AOLMpInRdeaHyDwb2a3DE5I3dG7VAVzrVfJ6W6Q84YoFX+rpEE2SVM17SAjy6xQy
+VjKgLvK2mk0xbtfa+h0B6VK7bmODHZqeP18NVm6HsBcXn7iclLgAC3SfWU1jucZK
+x1lqzw9tAgMBAAECggEABWzxS1Y2wckblnXY57Z+sl6YdmLV+gxj2r8Qib7g4ZIk
+lIlWR1OJNfw7kU4eryib4fc6nOh6O4AWZyYqAK6tqNQSS/eVG0LQTLTTEldHyVJL
+dvBe+MsUQOj4nTndZW+QvFzbcm2D8lY5n2nBSxU5ypVoKZ1EqQzytFcLZpTN7d89
+EPj0qDyrV4NZlWAwL1AygCwnlwhMQjXEalVF1ylXwU3QzyZ/6MgvF6d3SSUlh+sq
+XefuyigXw484cQQgbzopv6niMOmGP3of+yV4JQqUSb3IDmmT68XjGd2Dkxl4iPki
+6ZwXf3CCi+c+i/zVEcufgZ3SLf8D99kUGE7v7fZ6AQKBgQD1ZX3RAla9hIhxCf+O
+3D+I1j2LMrdjAh0ZKKqwMR4JnHX3mjQI6LwqIctPWTU8wYFECSh9klEclSdCa64s
+uI/GNpcqPXejd0cAAdqHEEeG5sHMDt0oFSurL4lyud0GtZvwlzLuwEweuDtvT9cJ
+Wfvl86uyO36IW8JdvUprYDctrQKBgQDycZ697qutBieZlGkHpnYWUAeImVA878sJ
+w44NuXHvMxBPz+lbJGAg8Cn8fcxNAPqHIraK+kx3po8cZGQywKHUWsxi23ozHoxo
++bGqeQb9U661TnfdDspIXia+xilZt3mm5BPzOUuRqlh4Y9SOBpSWRmEhyw76w4ZP
+OPxjWYAgwQKBgA/FehSYxeJgRjSdo+MWnK66tjHgDJE8bYpUZsP0JC4R9DL5oiaA
+brd2fI6Y+SbyeNBallObt8LSgzdtnEAbjIH8uDJqyOmknNePRvAvR6mP4xyuR+Bv
+m+Lgp0DMWTw5J9CKpydZDItc49T/mJ5tPhdFVd+am0NAQnmr1MCZ6nHxAoGABS3Y
+LkaC9FdFUUqSU8+Chkd/YbOkuyiENdkvl6t2e52jo5DVc1T7mLiIrRQi4SI8N9bN
+/3oJWCT+uaSLX2ouCtNFunblzWHBrhxnZzTeqVq4SLc8aESAnbslKL4i8/+vYZlN
+s8xtiNcSvL+lMsOBORSXzpj/4Ot8WwTkn1qyGgECgYBKNTypzAHeLE6yVadFp3nQ
+Ckq9yzvP/ib05rvgbvrne00YeOxqJ9gtTrzgh7koqJyX1L4NwdkEza4ilDWpucn0
+xiUZS4SoaJq6ZvcBYS62Yr1t8n09iG47YL8ibgtmH3L+svaotvpVxVK+d7BLevA/
+ZboOWVe3icTy64BT3OQhmg==
+-----END RSA PRIVATE KEY-----`)
+	cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+	require.NoError(t, err)
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ServerName:   "127.0.0.1",
+	}
+
+	server := ldapserver.NewServer()
+	routes := ldapserver.NewRouteMux()
+	routes.Bind(func(w ldapserver.ResponseWriter, m *ldapserver.Message) {
+		w.Write(ldapserver.NewBindResponse(ldapserver.LDAPResultSuccess))
+	})
+	routes.Search(func(w ldapserver.ResponseWriter, m *ldapserver.Message) {
+		e := ldapserver.NewSearchResultEntry(uid)
+		e.AddAttribute("uid", message.AttributeValue(uid))
+		e.AddAttribute("displayName", message.AttributeValue(displayName))
+		e.AddAttribute("mail", message.AttributeValue(mail))
+		w.Write(e)
+		w.Write(ldapserver.NewSearchResultDoneResponse(ldapserver.LDAPResultSuccess))
+	})
+	server.Handle(routes)
+
+	go func() {
+		err := server.ListenAndServe(
+			"127.0.0.1:10389",
+			func(s *ldapserver.Server) {
+				s.Listener = tls.NewListener(s.Listener, tlsConfig)
+			},
+		)
+		require.NoError(t, err)
+	}()
+	t.Cleanup(func() { server.Stop() })
+
+	// Give a second for the server to start
+	time.Sleep(time.Second)
+	return "127.0.0.1", 10389
+}
+
+func TestIdentityProvider(t *testing.T) {
+	const (
+		testUID         = "alice"
+		testDisplayName = "Alice Smith"
+		testMail        = "alice@example.com"
+	)
+	host, port := newMockServer(t, testUID, testDisplayName, testMail)
+	ldap, err := NewIdentityProvider(
+		IdentityProviderConfig{
+			Host:             host,
+			Port:             port,
+			SkipTLSVerify:    true,
+			BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+			BindPassword:     "pa$$word",
+			BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=example,dc=com",
+			UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
+			SecurityProtocol: SecurityProtocolLDAPS,
+			FieldMapping: &storepb.FieldMapping{
+				Identifier:  "uid",
+				DisplayName: "displayName",
+				Email:       "mail",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	userInfo, err := ldap.Authenticate("alice", "pa$$word")
+	require.NoError(t, err)
+
+	wantUserInfo := &storepb.IdentityProviderUserInfo{
+		Identifier:  testUID,
+		DisplayName: testDisplayName,
+		Email:       testMail,
+	}
+	assert.Equal(t, wantUserInfo, userInfo)
 }

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/lestrrat-go/jwx/v2 v2.0.11
 	github.com/lib/pq v1.10.7
+	github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/microsoft/go-mssqldb v1.1.0
 	github.com/nyaruka/phonenumbers v1.1.7
@@ -59,6 +60,7 @@ require (
 	github.com/swaggo/echo-swagger v1.4.0
 	github.com/swaggo/swag v1.16.1
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75
+	github.com/vjeantet/ldapserver v1.0.1
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	github.com/xo/dburl v0.13.1
 	go.mongodb.org/mongo-driver v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/github/gh-ost v1.1.5
+	github.com/go-ldap/ldap/v3 v3.4.5
 	github.com/go-pkgz/expirable-cache/v2 v2.0.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
@@ -82,6 +83,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0 // indirect
+	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
@@ -89,6 +91,7 @@ require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInm
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0 h1:u/LLAOFgsMv7HmNL4Qufg58y+qElGOt5qv0z1mURkRY=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0/go.mod h1:2e8rMJtl2+2j+HXbTBwnyGpm5Nou7KhvSfxOq8JpTag=
+github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
+github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 h1:OBhqkivkhkMqLPymWEppkm7vgPQY2XsHoEkaMQ0AdZY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0/go.mod h1:kgDmCTgBzIEPFElEF+FK0SdjAor06dRq2Go927dnQ6o=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -56,6 +58,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 h1:Kk6a4nehpJ3UuJRqlA3JxYxBZEqCeOmATOvrbT4p9RA=
+github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.1581 h1:Q/yk4z/cHUVZfgTqtD09qeYBxHwshQAjVRX73qs8UH0=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
@@ -255,6 +259,8 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
+github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
+github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.6.1 h1:nNIPOBkprlKzkThvS/0YaX8Zs9KewLCOSFQS5BU06FI=
@@ -266,6 +272,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
+github.com/go-ldap/ldap/v3 v3.4.5 h1:ekEKmaDrpvR2yf5Nc/DClsGG9lAmdDixe44mLzlW5r8=
+github.com/go-ldap/ldap/v3 v3.4.5/go.mod h1:bMGIq3AGbytbaMwf8wdv5Phdxz0FWHTIYMSzyrYgnQs=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=

--- a/go.sum
+++ b/go.sum
@@ -608,6 +608,8 @@ github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
+github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3 h1:wIONC+HMNRqmWBjuMxhatuSzHaljStc4gjDeKycxy0A=
+github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3/go.mod h1:37YR9jabpiIxsb8X9VCIx8qFOjTDIIrIHHODa8C4gz0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c h1:VtwQ41oftZwlMnOEbMWQtSEUgU64U4s+GHk7hZK+jtY=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
@@ -915,6 +917,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vjeantet/ldapserver v1.0.1 h1:3z+TCXhwwDLJC3pZCNbuECPDqC2x1R7qQQbswB1Qwoc=
+github.com/vjeantet/ldapserver v1.0.1/go.mod h1:YvUqhu5vYhmbcLReMLrm/Tq3S7Yj43kSVFvvol6Lh6k=
 github.com/wangjohn/quickselect v0.0.0-20161129230411-ed8402a42d5f h1:9DDCDwOyEy/gId+IEMrFHLuQ5R/WV0KNxWLler8X2OY=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=


### PR DESCRIPTION
This PR implements the BindDN-based LDAP authentication client, which works as follows:

1. Use a bind account (aka. BindDN) to authenticate the connection, in the OAuth world, it's like using the client ID and client secret, but it acts as a service account in LDAP.
1. Search for the user (via its username) and other attributes (i.e. identifier, display name and email).
1. Verify the user's password.

For the security protocol, although the LDAP RFC allows unencrypted connections, any reasonable service would require either LDAPS (SSL) or StartTLS (TLS), so the unencrypted option is deliberately disallowed.

## Test plan

1. Set up a bind account (`system`) and a regular account (`alice`) on jumpcloud.com
2. Used the following program to test:

	```go
	package main
	
	import (
		"fmt"
		"log"
	
		"github.com/bytebase/bytebase/backend/plugin/idp/ldap"
		storepb "github.com/bytebase/bytebase/proto/generated-go/store"
	)
	
	func main() {
		idp, err := ldap.NewIdentityProvider(ldap.IdentityProviderConfig{
			Host:             "ldap.jumpcloud.com",
			BindDN:           "uid=system,ou=Users,o=6456a5e9c25dabb51ccad385,dc=jumpcloud,dc=com",
			BindPassword:     "REDACTED",
			BaseDN:           "ou=Users,o=6456a5e9c25dabb51ccad385,dc=jumpcloud,dc=com",
			UserFilter:       "(&(objectClass=posixAccount)(uid=%s))",
			SecurityProtocol: ldap.SecurityProtocolStartTLS,
			FieldMapping: &storepb.FieldMapping{
				Identifier:  "uid",
				DisplayName: "displayName",
				Email:       "mail",
			},
		})
		if err != nil {
			log.Fatal(err)
		}
	
		userInfo, err := idp.Authenticate("alice", "REDACTED")
		if err != nil {
			log.Fatal(err)
		}
		fmt.Println("userInfo:", userInfo)
	}
	// userInfo: identifier:"alice" display_name:"Alice Damn" email:"alice@bytebase.test"
	```
