### PR TITLE
chore(frontend): wording and default value for Oracle schema tenant mode

### DIFF
--- a/frontend/src/components/InstanceForm/InstanceForm.vue
+++ b/frontend/src/components/InstanceForm/InstanceForm.vue
@@ -794,7 +794,8 @@ const extractBasicInfo = (instance: Instance | undefined): BasicInfo => {
     options: instance?.options
       ? cloneDeep(instance.options)
       : {
-          schemaTenantMode: true, // default to true
+          // default to false (Manage based on database, aka CDB + non-CDB)
+          schemaTenantMode: false,
         },
   };
 };

--- a/frontend/src/components/InstanceForm/OracleSyncModeInput.vue
+++ b/frontend/src/components/InstanceForm/OracleSyncModeInput.vue
@@ -1,39 +1,44 @@
 <template>
-  <div class="sm:col-span-3 sm:col-start-1 flex flex-col gap-y-2">
+  <div class="sm:col-span-4 sm:col-start-1 flex flex-col gap-y-2">
     <label class="textlabel">
       {{ $t("instance.sync-mode.self") }}
     </label>
-    <div class="flex items-center gap-x-4">
-      <label class="radio">
+    <div class="flex items-center gap-x-6">
+      <label class="flex items-center gap-1.5">
         <input
           v-model="state.mode"
           tabindex="-1"
           type="radio"
           class="text-accent disabled:text-accent-disabled focus:ring-accent"
-          value="SYNC_SELF"
+          value="DATABASE"
           :disabled="!allowEdit"
         />
-        <span class="label">
-          {{ $t("instance.sync-mode.sync-self") }}
+        <span class="text-sm font-medium text-gray-700">
+          {{ $t("instance.sync-mode.database.self") }}
         </span>
       </label>
-      <label class="radio">
+      <label class="flex items-center gap-1.5">
         <input
           v-model="state.mode"
           tabindex="-1"
           type="radio"
           class="text-accent disabled:text-accent-disabled focus:ring-accent"
-          value="SYNC_ALL"
+          value="SCHEMA"
           :disabled="!allowEdit"
         />
-        <span class="label">
-          {{ $t("instance.sync-mode.sync-all") }}
+        <span class="text-sm font-medium text-gray-700">
+          {{ $t("instance.sync-mode.schema.self") }}
         </span>
       </label>
     </div>
 
-    <label v-if="state.mode === 'SYNC_ALL'" class="textinfolabel">
-      {{ $t("instance.sync-mode.description") }}
+    <label class="text-xs text-control-light ml-[calc(16px+0.375rem)]">
+      <template v-if="state.mode === 'DATABASE'">
+        {{ $t("instance.sync-mode.database.description") }}
+      </template>
+      <template v-if="state.mode === 'SCHEMA'">
+        {{ $t("instance.sync-mode.schema.description") }}
+      </template>
     </label>
   </div>
 </template>
@@ -41,7 +46,7 @@
 <script lang="ts" setup>
 import { reactive, watch } from "vue";
 
-type SyncMode = "SYNC_SELF" | "SYNC_ALL";
+type SyncMode = "SCHEMA" | "DATABASE";
 
 type LocalState = {
   mode: SyncMode;
@@ -57,8 +62,8 @@ const emit = defineEmits<{
 }>();
 
 const guessModeFromSchemaTenantMode = (schemaTenantMode: boolean): SyncMode => {
-  if (schemaTenantMode) return "SYNC_SELF";
-  return "SYNC_ALL";
+  if (schemaTenantMode) return "SCHEMA";
+  return "DATABASE";
 };
 
 const state = reactive<LocalState>({
@@ -66,7 +71,7 @@ const state = reactive<LocalState>({
 });
 
 const update = (mode: SyncMode) => {
-  emit("update:schemaTenantMode", mode === "SYNC_SELF" ? true : false);
+  emit("update:schemaTenantMode", mode === "SCHEMA" ? true : false);
 };
 
 watch(

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -977,9 +977,14 @@
     "force-archive-description": "Force to archive. All releated issues will be resolved, and all related sheets will be deleted.",
     "sync-mode": {
       "self": "Sync Mode",
-      "sync-self": "Sync self",
-      "sync-all": "Sync self and all containing databases (CDB + PDB)",
-      "description": "Bytebase will sync the connecting database as well as its all containing databases. Only applicable to Oracle 12c+."
+      "database": {
+        "self": "Manage based on database",
+        "description": "The entire database is treated as a managed object, with CDB and PDB being regarded as distinct databases. (Supports CDB and non-CDB mode)"
+      },
+      "schema": {
+        "self": "Manage based on schema",
+        "description": "Each schema is treated as a managed object. (Only supports non-CDB mode)"
+      }
     }
   },
   "environment": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -977,9 +977,14 @@
     "force-archive-description": "Forzar a archivar. \nTodos los problemas relacionados se resolverán y todas las hojas relacionadas se eliminarán.",
     "sync-mode": {
       "self": "Modo de sincronización",
-      "sync-self": "Sincronizarse",
-      "sync-all": "Sincronización propia y de todas las bases de datos (CDB + PDB)",
-      "description": "Bytebase sincronizará la base de datos de conexión, así como todas las bases de datos que la contienen. Solo aplicable a Oracle 12c."
+      "database": {
+        "self": "Administrar basado en base de datos",
+        "description": "Toda la base de datos se trata como un objeto administrado, y CDB y PDB se consideran bases de datos distintas. (Admite modo CDB y no CDB)"
+      },
+      "schema": {
+        "self": "Administrar según el esquema",
+        "description": "Cada esquema se trata como un objeto administrado. (Solo es compatible con el modo no CDB)"
+      }
     }
   },
   "environment": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -974,9 +974,14 @@
     "force-archive-description": "强制归档。所有关联的工单都将被解决，所有关联的工作表都将被删除。",
     "sync-mode": {
       "self": "同步模式",
-      "sync-self": "同步自身",
-      "sync-all": "同步自身和所有包含的数据库（CDB + PDB）",
-      "description": "Bytebase 会同步连接数据库及其所有包含的数据库。仅适用于Oracle 12c。"
+      "database": {
+        "self": "按数据库管理",
+        "description": "将整个数据库作为单一管理对象，CDB 与 PDB 将被视作不同的数据库。（支持 CDB 与非 CDB 模式）"
+      },
+      "schema": {
+        "self": "按 Schema 管理",
+        "description": "将每个 Schema 作为管理对象。（仅支持非 CDB 模式）"
+      }
     }
   },
   "environment": {


### PR DESCRIPTION
- Wording changes
- Default value to `schemaTenantMode=false` aka "Manage based on database (supports CDB and non-CDB mode)"
<img width="700" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/9aa5d6d3-1658-4099-ad35-654b3cbd7271">
<img width="571" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/4e8b3580-b1f7-4cff-a22c-0455eccc74bc">

Close BYT-3612