### PR TITLE
cherrypick: fix(gitops, azure-devops): specify the ref is branch, commit, or tag …

### DIFF
--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -1163,7 +1163,10 @@ func (s *ProjectService) setupVCSSQLReviewCIForGitHub(
 		vcs.InstanceURL,
 		repository.ExternalID,
 		github.SQLReviewActionFilePath,
-		branch.Name,
+		vcsPlugin.RefInfo{
+			RefType: vcsPlugin.RefTypeBranch,
+			RefName: branch.Name,
+		},
 	)
 	if err != nil {
 		log.Debug(
@@ -1234,7 +1237,10 @@ func (s *ProjectService) setupVCSSQLReviewCIForGitLab(
 				vcs.InstanceURL,
 				repository.ExternalID,
 				gitlab.CIFilePath,
-				fileMeta.LastCommitID,
+				vcsPlugin.RefInfo{
+					RefType: vcsPlugin.RefTypeCommit,
+					RefName: fileMeta.LastCommitID,
+				},
 			)
 			if err != nil {
 				return "", err
@@ -1290,7 +1296,10 @@ func (s *ProjectService) createOrUpdateVCSSQLReviewFileForGitLab(
 		vcs.InstanceURL,
 		repository.ExternalID,
 		fileName,
-		branch.Name,
+		vcsPlugin.RefInfo{
+			RefType: vcsPlugin.RefTypeBranch,
+			RefName: branch.Name,
+		},
 	)
 	if err != nil {
 		log.Debug(

--- a/backend/api/v1/sheet_service.go
+++ b/backend/api/v1/sheet_service.go
@@ -526,7 +526,10 @@ func (s *SheetService) SyncSheets(ctx context.Context, request *v1pb.SyncSheetsR
 			vcs.InstanceURL,
 			repo.ExternalID,
 			file.Path,
-			repo.BranchFilter,
+			vcsPlugin.RefInfo{
+				RefType: vcsPlugin.RefTypeBranch,
+				RefName: repo.BranchFilter,
+			},
 		)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, fmt.Sprintf("Failed to fetch file content from VCS, instance URL: %s, repo ID: %s, file path: %s, branch: %s", vcs.InstanceURL, repo.ExternalID, file.Path, repo.BranchFilter))
@@ -544,7 +547,10 @@ func (s *SheetService) SyncSheets(ctx context.Context, request *v1pb.SyncSheetsR
 			vcs.InstanceURL,
 			repo.ExternalID,
 			file.Path,
-			repo.BranchFilter,
+			vcsPlugin.RefInfo{
+				RefType: vcsPlugin.RefTypeBranch,
+				RefName: repo.BranchFilter,
+			},
 		)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, fmt.Sprintf("Failed to fetch file meta from VCS, instance URL: %s, repo ID: %s, file path: %s, branch: %s", vcs.InstanceURL, repo.ExternalID, file.Path, repo.BranchFilter))

--- a/backend/plugin/vcs/azure/azure.go
+++ b/backend/plugin/vcs/azure/azure.go
@@ -219,7 +219,7 @@ type ChangesResponse struct {
 	Changes []ChangesResponseChange `json:"changes"`
 }
 
-// GetChangesByCommit gets the changes by commit ID.
+// GetChangesByCommit gets the changes by commit ID, and returns the list of blob files changed in the specify commit.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-changes?view=azure-devops-rest-7.0&tabs=HTTP
 // TODO(zp): We should GET the changes pagenated, otherwise it may hit the Azure DevOps API limit.
@@ -701,7 +701,7 @@ func (p *Provider) createOrUpdateFile(ctx context.Context, oauthCtx common.Oauth
 	if len(parts) != 3 {
 		return errors.Errorf("invalid repository ID %q", repositoryID)
 	}
-	organizationName, exteralRepositoryID := parts[0], parts[2]
+	organizationName, externalRepositoryID := parts[0], parts[2]
 
 	changeType := "edit"
 	if create {
@@ -710,7 +710,7 @@ func (p *Provider) createOrUpdateFile(ctx context.Context, oauthCtx common.Oauth
 
 	values := &url.Values{}
 	values.Set("api-version", "7.0")
-	url := fmt.Sprintf("https://dev.azure.com/%s/_apis/git/repositories/%s/pushes?%s", url.PathEscape(organizationName), url.PathEscape(exteralRepositoryID), values.Encode())
+	url := fmt.Sprintf("https://dev.azure.com/%s/_apis/git/repositories/%s/pushes?%s", url.PathEscape(organizationName), url.PathEscape(externalRepositoryID), values.Encode())
 
 	type createFileReqeustCommitChangesItem struct {
 		Path string `json:"path"`
@@ -822,7 +822,7 @@ func (p *Provider) createOrUpdateFile(ctx context.Context, oauthCtx common.Oauth
 // Docs:
 // - https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.0&tabs=HTTP
 // - https://learn.microsoft.com/en-us/rest/api/azure/devops/git/blobs/get-blob?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID, filePath, ref string) (*vcs.FileMeta, error) {
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
 	parts := strings.Split(repositoryID, "/")
 	if len(parts) != 3 {
 		return nil, errors.Errorf("invalid repository ID %q", repositoryID)
@@ -832,7 +832,20 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 	values.Set("api-version", "7.0")
 	values.Set("scopePath", filePath)
 	values.Set("$format", "json")
-	values.Set("versionDescriptor.version", ref)
+	var refType string
+	switch refInfo.RefType {
+	case vcs.RefTypeBranch:
+		refType = "branch"
+	case vcs.RefTypeTag:
+		refType = "tag"
+	case vcs.RefTypeCommit:
+		refType = "commit"
+	default:
+		return nil, errors.Errorf("invalid ref type %q", refInfo.RefType)
+	}
+	values.Set("versionDescriptor.versionType", refType)
+	values.Set("versionDescriptor.version", refInfo.RefName)
+
 	itemsURL := fmt.Sprintf("https://dev.azure.com/%s/_apis/git/repositories/%s/items?%s", url.PathEscape(organizationName), url.PathEscape(repositoryID), values.Encode())
 
 	type fileMetaResponseValue struct {
@@ -918,7 +931,7 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 // ReadFileContent reads the content of the given file in the repository.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, _ string, repositoryID string, filePath string, ref string) (string, error) {
+func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, _ string, repositoryID string, filePath string, refInfo vcs.RefInfo) (string, error) {
 	parts := strings.Split(repositoryID, "/")
 	if len(parts) != 3 {
 		return "", errors.Errorf("invalid repository ID %q", repositoryID)
@@ -930,7 +943,19 @@ func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthCon
 	values.Set("resolveLfs", "true")
 	values.Set("includeContent", "true")
 	values.Set("path", filePath)
-	values.Set("versionDescriptor.version", ref)
+	var refType string
+	switch refInfo.RefType {
+	case vcs.RefTypeBranch:
+		refType = "branch"
+	case vcs.RefTypeTag:
+		refType = "tag"
+	case vcs.RefTypeCommit:
+		refType = "commit"
+	default:
+		return "", errors.Errorf("invalid ref type %q", refInfo.RefType)
+	}
+	values.Set("versionDescriptor.versionType", refType)
+	values.Set("versionDescriptor.version", refInfo.RefName)
 	url := fmt.Sprintf("https://dev.azure.com/%s/_apis/git/repositories/%s/items?%s", url.PathEscape(organizationName), url.PathEscape(repositoryID), values.Encode())
 
 	code, _, body, err := oauth.Get(ctx, p.client, url, &oauthCtx.AccessToken, tokenRefresher(

--- a/backend/plugin/vcs/bitbucket/bitbucket.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket.go
@@ -527,8 +527,8 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 // ReadFileMeta reads the metadata of the given file in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#file-meta-data
-func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*vcs.FileMeta, error) {
-	url := fmt.Sprintf("%s/repositories/%s/src/%s/%s?format=meta", p.APIURL(instanceURL), repositoryID, url.PathEscape(ref), url.PathEscape(filePath))
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
+	url := fmt.Sprintf("%s/repositories/%s/src/%s/%s?format=meta", p.APIURL(instanceURL), repositoryID, url.PathEscape(refInfo.RefName), url.PathEscape(filePath))
 	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
@@ -579,8 +579,8 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 // ReadFileContent reads the content of the given file in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#raw-file-contents
-func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (string, error) {
-	url := fmt.Sprintf("%s/repositories/%s/src/%s/%s", p.APIURL(instanceURL), repositoryID, url.PathEscape(ref), url.PathEscape(filePath))
+func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (string, error) {
+	url := fmt.Sprintf("%s/repositories/%s/src/%s/%s", p.APIURL(instanceURL), repositoryID, url.PathEscape(refInfo.RefName), url.PathEscape(filePath))
 	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,

--- a/backend/plugin/vcs/bitbucket/bitbucket_test.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket_test.go
@@ -474,7 +474,10 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", "eefd5ef")
+	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", vcs.RefInfo{
+		RefType: vcs.RefTypeCommit,
+		RefName: "eefd5ef",
+	})
 	require.NoError(t, err)
 
 	want := &vcs.FileMeta{
@@ -497,7 +500,10 @@ func TestProvider_ReadFileContent(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileContent(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", "eefd5ef")
+	got, err := p.ReadFileContent(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", vcs.RefInfo{
+		RefType: vcs.RefTypeCommit,
+		RefName: "eefd5ef",
+	})
 	require.NoError(t, err)
 
 	want := "#!/bin/sh\nhalt"

--- a/backend/plugin/vcs/github/github.go
+++ b/backend/plugin/vcs/github/github.go
@@ -603,8 +603,8 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 // ReadFileMeta reads the metadata of the given file in the repository.
 //
 // Docs: https://docs.github.com/en/rest/repos/contents#get-repository-content
-func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*vcs.FileMeta, error) {
-	lastCommitID, err := p.getLastCommitID(ctx, oauthCtx, instanceURL, repositoryID, ref)
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
+	lastCommitID, err := p.getLastCommitID(ctx, oauthCtx, instanceURL, repositoryID, refInfo.RefName)
 	if err != nil {
 		return nil, errors.Wrap(err, "get last commit ID")
 	}
@@ -708,8 +708,8 @@ func (p *Provider) getLastCommitID(ctx context.Context, oauthCtx common.OauthCon
 // ReadFileContent reads the content of the given file in the repository.
 //
 // Docs: https://docs.github.com/en/rest/repos/contents#get-repository-content
-func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (string, error) {
-	url := fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), ref)
+func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), refInfo.RefName)
 	code, _, body, err := oauth.GetWithHeader(
 		ctx,
 		p.client,

--- a/backend/plugin/vcs/github/github_test.go
+++ b/backend/plugin/vcs/github/github_test.go
@@ -589,7 +589,10 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", "master")
+	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", vcs.RefInfo{
+		RefType: vcs.RefTypeBranch,
+		RefName: "master",
+	})
 	require.NoError(t, err)
 
 	want := &vcs.FileMeta{
@@ -625,7 +628,10 @@ You can look around to get an idea how to structure your project and, when done,
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileContent(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", "master")
+	got, err := p.ReadFileContent(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", vcs.RefInfo{
+		RefType: vcs.RefTypeBranch,
+		RefName: "master",
+	})
 	require.NoError(t, err)
 
 	assert.Equal(t, want, got)

--- a/backend/plugin/vcs/gitlab/gitlab.go
+++ b/backend/plugin/vcs/gitlab/gitlab.go
@@ -596,8 +596,8 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 // ReadFileMeta reads the metadata of the given file in the repository.
 //
 // Docs: https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
-func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*vcs.FileMeta, error) {
-	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, ref)
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
+	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, refInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "read file")
 	}
@@ -610,8 +610,8 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 // ReadFileContent reads the content of the given file in the repository.
 //
 // Docs: https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
-func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (string, error) {
-	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, ref)
+func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (string, error) {
+	file, err := p.readFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, refInfo)
 	if err != nil {
 		return "", errors.Wrap(err, "read file")
 	}
@@ -1140,11 +1140,11 @@ func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthConte
 //
 // TODO: The same GitLab API endpoint supports using the HEAD request to only
 // get the file metadata.
-func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*File, error) {
+func (p *Provider) readFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (*File, error) {
 	// GitLab is often deployed behind a reverse proxy, which may have compression enabled that is transparent to the GitLab instance.
 	// In such cases, the HTTP header "Content-Encoding" will, for example, be changed to "gzip" and makes the value of "Content-Length" untrustworthy.
 	// We can avoid dealing with this type of problem by using the raw API instead of the typical JSON API.
-	url := fmt.Sprintf("%s/projects/%s/repository/files/%s/raw?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), url.QueryEscape(ref))
+	url := fmt.Sprintf("%s/projects/%s/repository/files/%s/raw?ref=%s", p.APIURL(instanceURL), repositoryID, url.QueryEscape(filePath), url.QueryEscape(refInfo.RefName))
 	code, header, body, err := oauth.Get(
 		ctx,
 		p.client,

--- a/backend/plugin/vcs/gitlab/gitlab_test.go
+++ b/backend/plugin/vcs/gitlab/gitlab_test.go
@@ -300,7 +300,10 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", "master")
+	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", vcs.RefInfo{
+		RefType: vcs.RefTypeBranch,
+		RefName: "master",
+	})
 	require.NoError(t, err)
 
 	want := &vcs.FileMeta{
@@ -335,7 +338,10 @@ You can look around to get an idea how to structure your project and, when done,
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileContent(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", "master")
+	got, err := p.ReadFileContent(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", vcs.RefInfo{
+		RefType: vcs.RefTypeBranch,
+		RefName: "master",
+	})
 	require.NoError(t, err)
 
 	want := `# Sample GitLab Project

--- a/backend/plugin/vcs/vcs.go
+++ b/backend/plugin/vcs/vcs.go
@@ -36,6 +36,24 @@ const (
 	BytebaseAuthorEmail = "support@bytebase.com"
 )
 
+// RefType is the type of a ref.
+type RefType string
+
+const (
+	// RefTypeBranch is the branch ref type.
+	RefTypeBranch RefType = "branch"
+	// RefTypeTag is the tag ref type.
+	RefTypeTag RefType = "tag"
+	// RefTypeCommit is the commit ref type.
+	RefTypeCommit RefType = "commit"
+)
+
+// RefInfo is the API message for a VCS ref.
+type RefInfo struct {
+	RefType RefType
+	RefName string
+}
+
 // OAuthToken is the API message for OAuthToken.
 type OAuthToken struct {
 	AccessToken  string `json:"access_token" `
@@ -255,7 +273,7 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// filePath: file path to be read
 	// ref: the specific file version to be read, could be a name of branch, tag or commit
-	ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (*FileMeta, error)
+	ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo RefInfo) (*FileMeta, error)
 	// Reads the file content
 	//
 	// oauthCtx: OAuth context to read the file content
@@ -263,7 +281,7 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// filePath: file path to be read
 	// ref: the specific file version to be read, could be a name of branch, tag or commit
-	ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath, ref string) (string, error)
+	ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo RefInfo) (string, error)
 	// GetBranch gets the given branch in the repository.
 	//
 	// oauthCtx: OAuth context to create the webhook

--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -605,7 +605,10 @@ func writeBackLatestSchema(
 		vcs.InstanceURL,
 		repository.ExternalID,
 		latestSchemaFile,
-		writebackBranch,
+		vcsPlugin.RefInfo{
+			RefType: vcsPlugin.RefTypeBranch,
+			RefName: writebackBranch,
+		},
 	)
 
 	createSchemaFile := false
@@ -731,7 +734,10 @@ func writeBackLatestSchema(
 		vcs2.InstanceURL,
 		repo2.ExternalID,
 		latestSchemaFile,
-		writebackBranch,
+		vcsPlugin.RefInfo{
+			RefType: vcsPlugin.RefTypeBranch,
+			RefName: writebackBranch,
+		},
 	)
 
 	if err != nil {


### PR DESCRIPTION
…explicitly (#7327)

* chore: update the comment of the GetChangesByCommit

* chore: update

* fix: specify the ref is branch, commit, or tag explicitly