### PR TITLE
feat: remove task run useless columns

### DIFF
--- a/backend/migrator/migration/dev/LATEST.sql
+++ b/backend/migrator/migration/dev/LATEST.sql
@@ -639,13 +639,10 @@ CREATE TABLE task_run (
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     task_id INTEGER NOT NULL REFERENCES task (id),
     name TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('RUNNING', 'DONE', 'FAILED', 'CANCELED')),
-    type TEXT NOT NULL CHECK (type LIKE 'bb.task.%'),
+    status TEXT NOT NULL CHECK (status IN ('PENDING', 'RUNNING', 'DONE', 'FAILED', 'CANCELED')),
     code INTEGER NOT NULL DEFAULT 0,
-    comment TEXT NOT NULL DEFAULT '',
     -- result saves the task run result in json format
-    result  JSONB NOT NULL DEFAULT '{}',
-    payload JSONB NOT NULL DEFAULT '{}'
+    result  JSONB NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX idx_task_run_task_id ON task_run(task_id);

--- a/backend/migrator/migration/prod/2.6/0000##task_run_remove_useless_update_status.sql
+++ b/backend/migrator/migration/prod/2.6/0000##task_run_remove_useless_update_status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE task_run DROP IF EXISTS type, DROP IF EXISTS comment, DROP IF EXISTS payload;
+
+ALTER TABLE task_run DROP CONSTRAINT task_run_status_check;
+
+ALTER TABLE task_run ADD CONSTRAINT task_run_status_check CHECK (status IN ('PENDING', 'RUNNING', 'DONE', 'FAILED', 'CANCELED'));

--- a/backend/migrator/migration/prod/LATEST.sql
+++ b/backend/migrator/migration/prod/LATEST.sql
@@ -638,13 +638,10 @@ CREATE TABLE task_run (
     updated_ts BIGINT NOT NULL DEFAULT extract(epoch from now()),
     task_id INTEGER NOT NULL REFERENCES task (id),
     name TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('RUNNING', 'DONE', 'FAILED', 'CANCELED')),
-    type TEXT NOT NULL CHECK (type LIKE 'bb.task.%'),
+    status TEXT NOT NULL CHECK (status IN ('PENDING', 'RUNNING', 'DONE', 'FAILED', 'CANCELED')),
     code INTEGER NOT NULL DEFAULT 0,
-    comment TEXT NOT NULL DEFAULT '',
     -- result saves the task run result in json format
-    result  JSONB NOT NULL DEFAULT '{}',
-    payload JSONB NOT NULL DEFAULT '{}'
+    result  JSONB NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX idx_task_run_task_id ON task_run(task_id);

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -241,5 +241,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("2.5.5"), releaseVersion)
+	require.Equal(t, semver.MustParse("2.6.0"), releaseVersion)
 }

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -562,7 +562,6 @@ func (s *Store) UpdateTaskStatusV2(ctx context.Context, patch *api.TaskStatusPat
 			UpdaterID: patch.UpdaterID,
 			Code:      patch.Code,
 			Result:    patch.Result,
-			Comment:   patch.Comment,
 		}
 		switch patch.Status {
 		case api.TaskDone:

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -549,7 +549,6 @@ func (s *Store) UpdateTaskStatusV2(ctx context.Context, patch *api.TaskStatusPat
 			if err := s.createTaskRunImpl(ctx, tx, &TaskRunMessage{
 				TaskUID: task.ID,
 				Name:    fmt.Sprintf("%s %d", task.Name, time.Now().Unix()),
-				Type:    task.Type,
 			}, patch.UpdaterID); err != nil {
 				return nil, err
 			}

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -65,9 +65,7 @@ type TaskRunStatusPatch struct {
 	// Domain specific fields
 	Status api.TaskRunStatus
 	Code   *common.Code
-	// Records the status detail (e.g. error message on failure)
-	Comment *string
-	Result  *string
+	Result *string
 }
 
 func (taskRun *TaskRunMessage) toTaskRun() *api.TaskRun {
@@ -223,9 +221,6 @@ func (*Store) patchTaskRunStatusImpl(ctx context.Context, tx *Tx, patch *TaskRun
 	set, args = append(set, "status = $2"), append(args, patch.Status)
 	if v := patch.Code; v != nil {
 		set, args = append(set, fmt.Sprintf("code = $%d", len(args)+1)), append(args, *v)
-	}
-	if v := patch.Comment; v != nil {
-		set, args = append(set, fmt.Sprintf("comment = $%d", len(args)+1)), append(args, *v)
 	}
 	if v := patch.Result; v != nil {
 		result := "{}"

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -44,15 +44,6 @@ type FindTaskRunMessage struct {
 	PipelineUID *int
 }
 
-// TaskRunCreate is the API message for creating a task run.
-type TaskRunCreate struct {
-	CreatorID int
-	TaskID    int
-	Name      string
-	Type      api.TaskType
-	Payload   string
-}
-
 // TaskRunFind is the API message for finding task runs.
 type TaskRunFind struct {
 	// Related fields

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -188,7 +188,7 @@ func (*Store) createTaskRunImpl(ctx context.Context, tx *Tx, create *TaskRunMess
 			task_id,
 			name,
 			status
-		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+		) VALUES ($1, $2, $3, $4, $5)
 	`
 	if _, err := tx.ExecContext(ctx, query,
 		creatorID,


### PR DESCRIPTION
Remove `type`,`comment`,`payload` from `task_run` table.
Update `task_run.status` constraint.