### PR TITLE
fix: bb modal max width

### DIFF
--- a/frontend/src/bbkit/BBModal.vue
+++ b/frontend/src/bbkit/BBModal.vue
@@ -203,9 +203,10 @@ export const useOverrideSubtitle = (
 
 <style scoped lang="postcss">
 .bb-modal {
-  @apply max-w-max bg-white shadow-lg rounded-lg pt-4 pb-4 flex pointer-events-auto;
+  @apply bg-white shadow-lg rounded-lg pt-4 pb-4 flex pointer-events-auto;
   @apply flex-col;
 
+  max-width: calc(100vw - 80px);
   max-height: calc(100vh - 80px);
 }
 


### PR DESCRIPTION
### Before

<img width="1628" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/30dd7256-d686-40ee-bbcd-62693bbe9093">

### After

<img width="1629" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/0fbb2db9-c76d-4aa4-a4b5-82457034322a">
