### PR TITLE
chore: ui update

### DIFF
--- a/frontend/src/bbkit/BBOutline.vue
+++ b/frontend/src/bbkit/BBOutline.vue
@@ -39,12 +39,13 @@
         :item-list="item.childList"
         :allow-collapse="item.childCollapse"
         :level="level + 1"
+        :outline-item-class="outlineItemClass"
       />
       <router-link
         v-else-if="item.link"
         :to="item.link"
         class="outline-item group flex justify-between pr-1 py-1"
-        :class="'pl-' + (4 + level * 3)"
+        :class="['pl-' + (4 + level * 3), outlineItemClass]"
       >
         <div class="flex flex-row justify-start items-center truncate">
           <component :is="item.prefix" class="mr-1" />
@@ -86,12 +87,14 @@ const props = withDefaults(
     allowDelete?: boolean;
     allowCollapse?: boolean;
     level?: number;
+    outlineItemClass?: string;
   }>(),
   {
     id: "",
     allowDelete: false,
     allowCollapse: false,
     level: 0,
+    outlineItemClass: "",
   }
 );
 

--- a/frontend/src/components/DatabaseDetail/Settings/DatabaseSettingsPanel.vue
+++ b/frontend/src/components/DatabaseDetail/Settings/DatabaseSettingsPanel.vue
@@ -33,7 +33,10 @@ const databaseStore = useDatabaseV1Store();
 const envStore = useEnvironmentV1Store();
 
 const environment = computed(() => {
-  return envStore.getEnvironmentByName(props.database.environment);
+  return envStore.getEnvironmentByName(
+    props.database.environment ||
+      props.database.instanceEntity.environmentEntity.name
+  );
 });
 
 const handleSelectEnvironmentUID = async (uid: number | string) => {

--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -4,6 +4,7 @@
     :title="$t('common.databases')"
     :item-list="mixedDatabaseList"
     :allow-collapse="false"
+    :outline-item-class="'pt-0.5 pb-0.5'"
   />
 </template>
 
@@ -88,7 +89,7 @@ const databaseList = computed(() => {
 const databaseListByEnvironment = computed(() => {
   const envToDbMap: Map<string, BBOutlineItem[]> = new Map();
   for (const environment of environmentList.value) {
-    envToDbMap.set(environment.uid, []);
+    envToDbMap.set(environment.name, []);
   }
   const list = [...databaseList.value].filter(
     (db) =>
@@ -100,7 +101,9 @@ const databaseListByEnvironment = computed(() => {
   });
   for (const database of list) {
     const dbList = envToDbMap.get(
-      String(database.instanceEntity.environmentEntity.uid)
+      String(
+        database.environment || database.instanceEntity.environmentEntity.name
+      )
     )!;
     // dbList may be undefined if the environment is archived
     if (dbList) {
@@ -114,14 +117,14 @@ const databaseListByEnvironment = computed(() => {
 
   return environmentList.value
     .filter((environment) => {
-      const items = envToDbMap.get(environment.uid) ?? [];
+      const items = envToDbMap.get(environment.name) ?? [];
       return items.length > 0;
     })
     .map((environment): BBOutlineItem => {
       return {
         id: `bb.env.${environment.uid}`,
         name: environmentV1Name(environment),
-        childList: envToDbMap.get(environment.uid),
+        childList: envToDbMap.get(environment.name),
         childCollapse: true,
       };
     });

--- a/frontend/src/store/modules/tab.ts
+++ b/frontend/src/store/modules/tab.ts
@@ -48,6 +48,7 @@ export const useTabStore = defineStore("tab", () => {
   const tabs = ref(new Map<string, TabInfo>());
   const tabIdList = ref<string[]>([]);
   const currentTabId = ref<string>();
+  const asidePanelTab = ref<"databases" | "sheets">("databases");
 
   // getters
   const getTabById = (id: string) => {
@@ -87,6 +88,8 @@ export const useTabStore = defineStore("tab", () => {
     }
     currentTabId.value = id;
     tabs.value.set(id, newTab);
+
+    asidePanelTab.value = "databases";
 
     watchTab(newTab, false);
   };
@@ -255,6 +258,7 @@ export const useTabStore = defineStore("tab", () => {
     selectOrAddTempTab,
     selectOrAddSimilarTab,
     reset,
+    asidePanelTab,
   };
 });
 

--- a/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="aside-panel h-full">
-    <NTabs v-model:value="mainTab" class="h-full" :tabs-padding="8">
+    <NTabs
+      v-model:value="tabStore.asidePanelTab"
+      class="h-full"
+      :tabs-padding="8"
+    >
       <NTabPane name="databases" :tab="$t('common.databases')">
         <NTabs v-model:value="databaseTab" type="segment" class="h-full">
           <NTabPane name="projects" :tab="$t('common.projects')">
@@ -96,7 +100,6 @@ const tabStore = useTabStore();
 const connectionTreeStore = useConnectionTreeStore();
 const searchPattern = ref("");
 
-const mainTab = ref<"databases" | "sheets">("databases");
 const databaseTab = ref<"projects" | "instances" | "history">(
   connectionTreeStore.tree.mode === ConnectionTreeMode.INSTANCE
     ? "instances"

--- a/frontend/src/views/sql-editor/AsidePanel/SheetList/SheetList.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SheetList/SheetList.vue
@@ -18,7 +18,7 @@
       </NButton>
     </div>
     <div
-      class="flex-1 flex flex-col gap-y-2 h-full overflow-y-auto"
+      class="flex-1 flex flex-col h-full overflow-y-auto"
       @scroll="dropdown = undefined"
     >
       <div


### PR DESCRIPTION
- Condense SQL Editor sheet list spacing

<img width="375" alt="图片" src="https://github.com/bytebase/bytebase/assets/10706318/2f70b663-a412-4220-86a2-10ca980b7773">

- Condense database list spacing in the dashboard sidebar

<img width="220" alt="图片" src="https://github.com/bytebase/bytebase/assets/10706318/9419acc4-5dbc-4386-8671-30fff3521a9a">

- Switch the tab to "database" after adding a new sheet (because users need to select a database to continue editing)
![CleanShot 2023-08-05 at 09 32 11](https://github.com/bytebase/bytebase/assets/10706318/94288dfe-127c-4eea-8179-d8eb9d480866)

- Fix database list grouping in the database sidebar

Close BYT-3705