### PR TITLE
fix: sync schema show more button

### DIFF
--- a/frontend/src/views/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/views/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -89,15 +89,6 @@
               </span>
             </div>
           </template>
-          <template v-if="shouldShowMoreVersionButton" #suffixItem>
-            <div
-              class="w-full flex flex-row justify-start items-center pl-3 leading-8 text-accent cursor-pointer hover:opacity-80"
-              @click.prevent.capture="() => (state.showFeatureModal = true)"
-            >
-              <heroicons-solid:sparkles class="w-4 h-auto mr-1" />
-              {{ $t("database.sync-schema.more-version") }}
-            </div>
-          </template>
         </BBSelect>
       </div>
     </div>
@@ -167,13 +158,6 @@ const hasSyncSchemaFeature = computed(() => {
   return useSubscriptionV1Store().hasInstanceFeature(
     "bb.feature.sync-schema-all-versions",
     database.value?.instanceEntity
-  );
-});
-
-const shouldShowMoreVersionButton = computed(() => {
-  return (
-    hasSyncSchemaFeature.value &&
-    databaseChangeHistoryList(state.databaseId as string).length > 0
   );
 });
 
@@ -286,6 +270,13 @@ const databaseChangeHistoryList = (databaseId: string) => {
 };
 
 const handleSchemaVersionSelect = (changeHistory: ChangeHistory) => {
+  const index = databaseChangeHistoryList(state.databaseId as string).findIndex(
+    (history) => history.uid === changeHistory.uid
+  );
+  if (index > 0 && !hasSyncSchemaFeature.value) {
+    state.showFeatureModal = true;
+    return;
+  }
   state.changeHistory = changeHistory;
 };
 

--- a/frontend/src/views/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/views/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -172,7 +172,7 @@ const hasSyncSchemaFeature = computed(() => {
 
 const shouldShowMoreVersionButton = computed(() => {
   return (
-    !hasSyncSchemaFeature.value &&
+    hasSyncSchemaFeature.value &&
     databaseChangeHistoryList(state.databaseId as string).length > 0
   );
 });


### PR DESCRIPTION
Close BYT-3710

Fix https://github.com/bytebase/bytebase/commit/66f92960915540392601403190c5bb86868cd76f
We should show this button only if users have the sync schema feature.
Related background https://linear.app/bytebase/issue/BYT-3541/the-dialog-box-should-not-be-displayed-when-choosing-a-database
FYI @boojack 