### PR TITLE
fix(idp): display `*` next to field mapping identifier

### DIFF
--- a/frontend/src/components/IdentityProviderCreateForm.vue
+++ b/frontend/src/components/IdentityProviderCreateForm.vue
@@ -305,6 +305,7 @@
           />
           <p class="flex flex-row justify-start items-center">
             {{ $t("settings.sso.form.identifier") }}
+            <span class="text-red-600">*</span>
             <NTooltip>
               <template #trigger>
                 <heroicons-outline:information-circle
@@ -504,6 +505,7 @@
           />
           <p class="flex flex-row justify-start items-center">
             {{ $t("settings.sso.form.identifier") }}
+            <span class="text-red-600">*</span>
             <NTooltip>
               <template #trigger>
                 <heroicons-outline:information-circle


### PR DESCRIPTION
This mapping field is required but not visually informed like other required fields.

## Test plan

<img width="601" alt="CleanShot 2023-08-07 at 12 21 25@2x" src="https://github.com/bytebase/bytebase/assets/2946214/de915dde-728a-44c6-8825-d5fd3fc8c76b">
