### PR TITLE
feat(sso): support login through LDAP

### DIFF
--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -124,8 +124,8 @@
           >
             <n-tab-pane
               v-if="identityProvider.type === IdentityProviderType.LDAP"
-              name="ldap"
-              tab="LDAP"
+              :name="identityProvider.name"
+              :tab="identityProvider.title"
             >
               <form
                 class="space-y-6"

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -7,107 +7,207 @@
     />
 
     <div class="mt-8">
-      <form class="space-y-6" @submit.prevent="trySignin">
-        <div>
-          <label
-            for="email"
-            class="block text-sm font-medium leading-5 text-control"
-          >
-            {{ $t("common.email") }}
-            <span class="text-red-600">*</span>
-          </label>
-          <div class="mt-1 rounded-md shadow-sm">
-            <input
-              id="email"
-              v-model="state.email"
-              type="email"
-              required
-              placeholder="jim@example.com"
-              class="appearance-none block w-full px-3 py-2 border border-control-border rounded-md placeholder-control-placeholder focus:outline-none focus:shadow-outline-blue focus:border-control-border sm:text-sm sm:leading-5"
-            />
-          </div>
-        </div>
+      <n-card>
+        <n-tabs
+          class="card-tabs"
+          default-value="standard"
+          size="small"
+          animated
+          pane-style="padding: 12px 2px 0 2px"
+        >
+          <n-tab-pane name="standard" tab="Standard">
+            <form class="space-y-6" @submit.prevent="trySignin()">
+              <div>
+                <label
+                  for="email"
+                  class="block text-sm font-medium leading-5 text-control"
+                >
+                  {{ $t("common.email") }}
+                  <span class="text-red-600">*</span>
+                </label>
+                <div class="mt-1 rounded-md shadow-sm">
+                  <input
+                    id="email"
+                    v-model="state.email"
+                    type="email"
+                    required
+                    placeholder="jim@example.com"
+                    class="appearance-none block w-full px-3 py-2 border border-control-border rounded-md placeholder-control-placeholder focus:outline-none focus:shadow-outline-blue focus:border-control-border sm:text-sm sm:leading-5"
+                  />
+                </div>
+              </div>
 
-        <div>
-          <label
-            for="password"
-            class="flex justify-between text-sm font-medium leading-5 text-control"
-          >
-            <div>
-              {{ $t("common.password") }}
-              <span class="text-red-600">*</span>
-            </div>
-            <router-link
-              to="/auth/password-forgot"
-              class="text-sm font-normal text-control-light hover:underline focus:outline-none"
-              tabindex="-1"
-              >{{ $t("auth.sign-in.forget-password") }}</router-link
-            >
-          </label>
-          <div
-            class="relative flex flex-row items-center mt-1 rounded-md shadow-sm"
-          >
-            <input
-              id="password"
-              v-model="state.password"
-              :type="state.showPassword ? 'text' : 'password'"
-              autocomplete="on"
-              required
-              class="appearance-none block w-full px-3 py-2 border border-control-border rounded-md placeholder-control-placeholder focus:outline-none focus:shadow-outline-blue focus:border-control-border sm:text-sm sm:leading-5"
-            />
-            <div
-              class="hover:cursor-pointer absolute right-3"
-              @click="
-                () => {
-                  state.showPassword = !state.showPassword;
-                }
-              "
-            >
-              <heroicons-outline:eye
-                v-if="state.showPassword"
-                class="w-4 h-4"
-              />
-              <heroicons-outline:eye-slash v-else class="w-4 h-4" />
-            </div>
-          </div>
-        </div>
+              <div>
+                <label
+                  for="password"
+                  class="flex justify-between text-sm font-medium leading-5 text-control"
+                >
+                  <div>
+                    {{ $t("common.password") }}
+                    <span class="text-red-600">*</span>
+                  </div>
+                  <router-link
+                    to="/auth/password-forgot"
+                    class="text-sm font-normal text-control-light hover:underline focus:outline-none"
+                    tabindex="-1"
+                    >{{ $t("auth.sign-in.forget-password") }}</router-link
+                  >
+                </label>
+                <div
+                  class="relative flex flex-row items-center mt-1 rounded-md shadow-sm"
+                >
+                  <input
+                    id="password"
+                    v-model="state.password"
+                    :type="state.showPassword ? 'text' : 'password'"
+                    autocomplete="on"
+                    required
+                    class="appearance-none block w-full px-3 py-2 border border-control-border rounded-md placeholder-control-placeholder focus:outline-none focus:shadow-outline-blue focus:border-control-border sm:text-sm sm:leading-5"
+                  />
+                  <div
+                    class="hover:cursor-pointer absolute right-3"
+                    @click="
+                      () => {
+                        state.showPassword = !state.showPassword;
+                      }
+                    "
+                  >
+                    <heroicons-outline:eye
+                      v-if="state.showPassword"
+                      class="w-4 h-4"
+                    />
+                    <heroicons-outline:eye-slash v-else class="w-4 h-4" />
+                  </div>
+                </div>
+              </div>
 
-        <div>
-          <span class="flex w-full rounded-md items-center">
-            <button
-              type="submit"
-              :disabled="!allowSignin"
-              class="btn-primary justify-center flex-grow py-2 px-4"
+              <div>
+                <span class="flex w-full rounded-md items-center">
+                  <button
+                    type="submit"
+                    :disabled="!allowSignin()"
+                    class="btn-primary justify-center flex-grow py-2 px-4"
+                  >
+                    {{ $t("common.sign-in") }}
+                  </button>
+                </span>
+              </div>
+            </form>
+
+            <div class="mt-6 relative">
+              <div class="relative flex justify-center text-sm">
+                <template v-if="isDemo">
+                  <span class="pl-2 bg-white text-accent">{{
+                    $t("auth.sign-in.demo-note", {
+                      username: "demo@example.com",
+                      password: "1024",
+                    })
+                  }}</span>
+                </template>
+                <template v-else-if="!disallowSignup">
+                  <span class="pl-2 bg-white text-control">{{
+                    $t("auth.sign-in.new-user")
+                  }}</span>
+                  <router-link
+                    to="/auth/signup"
+                    class="accent-link bg-white px-2"
+                    >{{ $t("common.sign-up") }}</router-link
+                  >
+                </template>
+              </div>
+            </div>
+          </n-tab-pane>
+
+          <template
+            v-for="identityProvider in groupedIdentityProviderList"
+            :key="identityProvider.name"
+          >
+            <n-tab-pane
+              v-if="identityProvider.type === IdentityProviderType.LDAP"
+              name="ldap"
+              tab="LDAP"
             >
-              {{ $t("common.sign-in") }}
-            </button>
-          </span>
-        </div>
-      </form>
+              <form
+                class="space-y-6"
+                @submit.prevent="trySignin(identityProvider.name)"
+              >
+                <div>
+                  <label
+                    for="email"
+                    class="block text-sm font-medium leading-5 text-control"
+                  >
+                    {{ $t("common.username") }}
+                    <span class="text-red-600">*</span>
+                  </label>
+                  <div class="mt-1 rounded-md shadow-sm">
+                    <input
+                      id="username"
+                      v-model="state.email"
+                      type="text"
+                      required
+                      placeholder="jim"
+                      class="appearance-none block w-full px-3 py-2 border border-control-border rounded-md placeholder-control-placeholder focus:outline-none focus:shadow-outline-blue focus:border-control-border sm:text-sm sm:leading-5"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label
+                    for="password"
+                    class="flex justify-between text-sm font-medium leading-5 text-control"
+                  >
+                    <div>
+                      {{ $t("common.password") }}
+                      <span class="text-red-600">*</span>
+                    </div>
+                  </label>
+                  <div
+                    class="relative flex flex-row items-center mt-1 rounded-md shadow-sm"
+                  >
+                    <input
+                      id="password"
+                      v-model="state.password"
+                      :type="state.showPassword ? 'text' : 'password'"
+                      autocomplete="on"
+                      required
+                      class="appearance-none block w-full px-3 py-2 border border-control-border rounded-md placeholder-control-placeholder focus:outline-none focus:shadow-outline-blue focus:border-control-border sm:text-sm sm:leading-5"
+                    />
+                    <div
+                      class="hover:cursor-pointer absolute right-3"
+                      @click="
+                        () => {
+                          state.showPassword = !state.showPassword;
+                        }
+                      "
+                    >
+                      <heroicons-outline:eye
+                        v-if="state.showPassword"
+                        class="w-4 h-4"
+                      />
+                      <heroicons-outline:eye-slash v-else class="w-4 h-4" />
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <span class="flex w-full rounded-md items-center">
+                    <button
+                      type="submit"
+                      :disabled="!allowSignin(identityProvider.name)"
+                      class="btn-primary justify-center flex-grow py-2 px-4"
+                    >
+                      {{ $t("common.sign-in") }}
+                    </button>
+                  </span>
+                </div>
+              </form>
+            </n-tab-pane>
+          </template>
+        </n-tabs>
+      </n-card>
     </div>
 
-    <div class="mt-6 relative">
-      <div class="relative flex justify-center text-sm">
-        <template v-if="isDemo">
-          <span class="pl-2 bg-white text-accent">{{
-            $t("auth.sign-in.demo-note", {
-              username: "demo@example.com",
-              password: "1024",
-            })
-          }}</span>
-        </template>
-        <template v-else-if="!disallowSignup">
-          <span class="pl-2 bg-white text-control">{{
-            $t("auth.sign-in.new-user")
-          }}</span>
-          <router-link to="/auth/signup" class="accent-link bg-white px-2">{{
-            $t("common.sign-up")
-          }}</router-link>
-        </template>
-      </div>
-    </div>
-
-    <div v-if="identityProviderList.length > 0" class="mb-3">
+    <div v-if="separatedIdentityProviderList.length > 0" class="mb-3">
       <div class="relative my-4">
         <div class="absolute inset-0 flex items-center" aria-hidden="true">
           <div class="w-full border-t border-control-border"></div>
@@ -117,7 +217,7 @@
         </div>
       </div>
       <template
-        v-for="identityProvider in identityProviderList"
+        v-for="identityProvider in separatedIdentityProviderList"
         :key="identityProvider.name"
       >
         <button
@@ -149,7 +249,10 @@ import {
   useAuthStore,
   useIdentityProviderStore,
 } from "@/store";
-import { IdentityProvider } from "@/types/proto/v1/idp_service";
+import {
+  IdentityProvider,
+  IdentityProviderType,
+} from "@/types/proto/v1/idp_service";
 import AuthFooter from "./AuthFooter.vue";
 
 interface LocalState {
@@ -171,8 +274,15 @@ const state = reactive<LocalState>({
 });
 const { isDemo, disallowSignup } = storeToRefs(actuatorStore);
 
-const identityProviderList = computed(
-  () => identityProviderStore.identityProviderList
+const separatedIdentityProviderList = computed(() =>
+  identityProviderStore.identityProviderList.filter(
+    (idp) => idp.type !== IdentityProviderType.LDAP
+  )
+);
+const groupedIdentityProviderList = computed(() =>
+  identityProviderStore.identityProviderList.filter(
+    (idp) => idp.type === IdentityProviderType.LDAP
+  )
 );
 
 onMounted(async () => {
@@ -201,15 +311,19 @@ onMounted(async () => {
   }
 });
 
-const allowSignin = computed(() => {
-  return isValidEmail(state.email) && state.password;
-});
+const allowSignin = (idpName?: string) => {
+  if (!idpName) {
+    return isValidEmail(state.email) && state.password;
+  }
+  return state.email && state.password;
+};
 
-const trySignin = async () => {
+const trySignin = async (idpName?: string) => {
   const mfaTempToken = await authStore.login({
     email: state.email,
     password: state.password,
     web: true,
+    idpName: idpName,
   });
   if (mfaTempToken) {
     router.push({


### PR DESCRIPTION
This PR updates the sign-in UI to provide LDAP as a sign-in option when configured.

Because the LDAP authentication flow does not involve redirecting users to the IdP's site, we need to provide the input boxes for username and password similar to standard sign-in.

## Test plan

**What UI looks like when no IdP is configured:**

<img width="559" alt="CleanShot 2023-08-08 at 13 26 19@2x" src="https://github.com/bytebase/bytebase/assets/2946214/342eecfa-aa51-49d7-91fd-e88a964c8f23">

(I made some attempts to hide the "Standard" text but did not succeed)

**Demo of both a failure and success sign-in with LDAP:**


https://github.com/bytebase/bytebase/assets/2946214/071d619c-9901-4a25-920b-562b5d173142

Used JumpCloud as the LDAP server.

---

Part of https://linear.app/bytebase/issue/BYT-3128/support-ldap-in-sso