### PR TITLE
chore(oidc): reduce `GetOidcConfig` calls

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -709,15 +709,16 @@ func (s *AuthService) getOrCreateUserWithIDP(ctx context.Context, request *v1pb.
 			return nil, status.Errorf(codes.InvalidArgument, "missing OAuth2 context")
 		}
 
+		idpConfig := idp.Config.GetOidcConfig()
 		oidcIDP, err := oidc.NewIdentityProvider(
 			ctx,
 			oidc.IdentityProviderConfig{
-				Issuer:        idp.Config.GetOidcConfig().Issuer,
-				ClientID:      idp.Config.GetOidcConfig().ClientId,
-				ClientSecret:  idp.Config.GetOidcConfig().ClientSecret,
-				FieldMapping:  idp.Config.GetOidcConfig().FieldMapping,
-				SkipTLSVerify: idp.Config.GetOidcConfig().SkipTlsVerify,
-				AuthStyle:     idp.Config.GetOidcConfig().GetAuthStyle(),
+				Issuer:        idpConfig.Issuer,
+				ClientID:      idpConfig.ClientId,
+				ClientSecret:  idpConfig.ClientSecret,
+				FieldMapping:  idpConfig.FieldMapping,
+				SkipTLSVerify: idpConfig.SkipTlsVerify,
+				AuthStyle:     idpConfig.GetAuthStyle(),
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
Minor fix, no need to call the same method 6 times when we can just call it once.