### PR TITLE
feat(frontend): migrate create db and PITR issue creation to v1 API with a compatibility layer

### DIFF
--- a/frontend/src/components/DatabaseOverviewPanel.vue
+++ b/frontend/src/components/DatabaseOverviewPanel.vue
@@ -164,7 +164,8 @@
 
 <script lang="ts" setup>
 import { head } from "lodash-es";
-import { computed, reactive, watchEffect, PropType } from "vue";
+import { computed, reactive, watchEffect, PropType, onMounted } from "vue";
+import { useRoute } from "vue-router";
 import { useAnomalyV1List, useDBSchemaV1Store } from "@/store";
 import { Anomaly } from "@/types/proto/v1/anomaly_service";
 import { Engine, State } from "@/types/proto/v1/common";
@@ -188,9 +189,16 @@ const props = defineProps({
     type: Object as PropType<ComposedDatabase>,
   },
 });
-
+const route = useRoute();
 const state = reactive<LocalState>({
   selectedSchemaName: "",
+});
+
+onMounted(() => {
+  const schema = route.query.schema as string;
+  if (schema) {
+    state.selectedSchemaName = schema;
+  }
 });
 
 const dbSchemaStore = useDBSchemaV1Store();

--- a/frontend/src/components/FeatureGuard/FeatureBadge.vue
+++ b/frontend/src/components/FeatureGuard/FeatureBadge.vue
@@ -14,16 +14,31 @@
     </NTooltip>
   </div>
   <template v-else-if="!hasFeature">
-    <router-link
-      v-if="clickable"
-      to="/setting/subscription"
-      exact-active-class=""
-    >
-      <heroicons-solid:sparkles class="text-accent w-5 h-5" />
-    </router-link>
-    <span v-else>
-      <heroicons-solid:sparkles class="text-accent w-5 h-5" />
-    </span>
+    <NTooltip :show-arrow="true">
+      <template #trigger>
+        <router-link
+          v-if="clickable"
+          to="/setting/subscription"
+          exact-active-class=""
+        >
+          <heroicons-solid:sparkles class="text-accent w-5 h-5" />
+        </router-link>
+        <span v-else>
+          <heroicons-solid:sparkles class="text-accent w-5 h-5" />
+        </span>
+      </template>
+      <span class="w-56 text-sm">
+        {{
+          $t("subscription.require-subscription", {
+            requiredPlan: $t(
+              `subscription.plan.${planTypeToString(
+                subscriptionStore.getMinimumRequiredPlan(feature)
+              )}.title`
+            ),
+          })
+        }}
+      </span>
+    </NTooltip>
   </template>
   <InstanceAssignment
     v-if="instanceMissingLicense"
@@ -36,7 +51,7 @@
 import { NTooltip } from "naive-ui";
 import { reactive, PropType, computed } from "vue";
 import { useSubscriptionV1Store } from "@/store";
-import { FeatureType } from "@/types";
+import { FeatureType, planTypeToString } from "@/types";
 import { Instance } from "@/types/proto/v1/instance_service";
 
 interface LocalState {

--- a/frontend/src/components/IssueV1/logic/assignee.ts
+++ b/frontend/src/components/IssueV1/logic/assignee.ts
@@ -112,7 +112,7 @@ export const useCurrentRolloutPolicyForActiveEnvironment = () => {
 
 export const extractRollOutPolicyValueByDeploymentType = (
   policy: Policy | undefined,
-  type: DeploymentType
+  deploymentType: DeploymentType
 ) => {
   if (!policy || !policy.deploymentApprovalPolicy) {
     return {
@@ -130,7 +130,7 @@ export const extractRollOutPolicyValueByDeploymentType = (
 
   const assigneeGroup =
     policy.deploymentApprovalPolicy.deploymentApprovalStrategies.find(
-      (group) => group.deploymentType === type
+      (group) => group.deploymentType === deploymentType
     );
 
   if (

--- a/frontend/src/components/TableTable.vue
+++ b/frontend/src/components/TableTable.vue
@@ -67,8 +67,9 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, PropType, reactive } from "vue";
+import { computed, PropType, reactive, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
 import { BBTableColumn } from "@/bbkit";
 import EllipsisText from "@/components/EllipsisText.vue";
 import { ComposedDatabase } from "@/types";
@@ -98,9 +99,16 @@ const props = defineProps({
 });
 
 const { t } = useI18n();
-
+const route = useRoute();
 const state = reactive<LocalState>({
   showReservedTableList: false,
+});
+
+onMounted(() => {
+  const table = route.query.table as string;
+  if (table) {
+    state.selectedTableName = table;
+  }
 });
 
 const engine = computed(() => props.database.instanceEntity.engine);

--- a/frontend/src/views/IssueDetailV1.vue
+++ b/frontend/src/views/IssueDetailV1.vue
@@ -78,6 +78,6 @@ useTitle(documentTitle);
 
 <style lang="postcss">
 .issue-debug {
-  @apply bg-red-200/50 font-mono text-xs;
+  @apply hidden bg-red-200/50 font-mono text-xs;
 }
 </style>

--- a/frontend/src/views/SettingWorkspaceSensitiveData.vue
+++ b/frontend/src/views/SettingWorkspaceSensitiveData.vue
@@ -246,9 +246,9 @@ const clickRow = (
   row: number,
   e: MouseEvent
 ) => {
-  let url = `/db/${databaseV1Slug(item.database)}/table/${item.table}`;
+  let url = `/db/${databaseV1Slug(item.database)}?table=${item.table}`;
   if (item.schema != "") {
-    url += `?schema=${item.schema}`;
+    url += `&schema=${item.schema}`;
   }
   if (e.ctrlKey || e.metaKey) {
     window.open(url, "_blank");

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/DataTable.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/DataTable.vue
@@ -39,12 +39,19 @@
                     v-if="isSensitiveColumn(header.index)"
                     class="ml-0.5 shrink-0"
                   />
-                  <FeatureBadgeForInstanceLicense
-                    v-else-if="isColumnMissingSensitive(header.index)"
-                    :show="true"
-                    custom-class="ml-0.5 shrink-0"
-                    feature="bb.feature.sensitive-data"
-                  />
+                  <template v-else-if="isColumnMissingSensitive(header.index)">
+                    <FeatureBadgeForInstanceLicense
+                      v-if="hasSensitiveFeature"
+                      :show="true"
+                      custom-class="ml-0.5 shrink-0"
+                      feature="bb.feature.sensitive-data"
+                    />
+                    <FeatureBadge
+                      v-else
+                      feature="bb.feature.sensitive-data"
+                      custom-class="ml-0.5 shrink-0"
+                    />
+                  </template>
                 </div>
 
                 <!-- The drag-to-resize handler -->
@@ -94,6 +101,7 @@
 <script lang="ts" setup>
 import { ColumnDef, Table } from "@tanstack/vue-table";
 import { computed, nextTick, PropType, ref, watch } from "vue";
+import { useSubscriptionV1Store } from "@/store";
 import SensitiveDataIcon from "./SensitiveDataIcon.vue";
 import TableCell from "./TableCell.vue";
 import useTableColumnWidthLogic from "./useTableResize";
@@ -140,6 +148,7 @@ const props = defineProps({
 
 const scrollerRef = ref<HTMLDivElement>();
 const tableRef = ref<HTMLTableElement>();
+const subscriptionStore = useSubscriptionV1Store();
 
 const tableResize = useTableColumnWidthLogic({
   tableRef,
@@ -149,6 +158,10 @@ const tableResize = useTableColumnWidthLogic({
 });
 
 const data = computed(() => props.data);
+
+const hasSensitiveFeature = computed(() => {
+  return subscriptionStore.hasFeature("bb.feature.sensitive-data");
+});
 
 const isSensitiveColumn = (index: number): boolean => {
   return props.masked[index] ?? false;


### PR DESCRIPTION
Create DB and restore/PITR issues are not created via "preview" but created directly via create issue API endpoint.

Like the issue detail page, we added a compatibility layer to hide new things behind `--development-use-v2-scheduler`

- WITH `--development-use-v2-scheduler`, these issues will be created via the new V1 `IssueService.CreateIssue` API. And they can be displayed ONLY via the new issue UI.
- WITHOUT `--development-use-v2-scheduler`, these issues will be create via the legacy `[POST] /api/issue` API. They will be legacy issues in the future. And they can be displayed BOTH via the new and the old UI. But will be READONLY via new UI.