### PR TITLE
chore: adjust slow query description wording

### DIFF
--- a/frontend/src/components/SlowQuery/Settings/SlowQuerySettings.vue
+++ b/frontend/src/components/SlowQuery/Settings/SlowQuerySettings.vue
@@ -35,8 +35,6 @@
 import { orderBy } from "lodash-es";
 import { computed, onMounted, reactive } from "vue";
 import { useI18n } from "vue-i18n";
-import { BBAttention } from "@/bbkit";
-import LearnMoreLink from "@/components/LearnMoreLink.vue";
 import { EnvironmentTabFilter, SearchBox } from "@/components/v2";
 import {
   pushNotification,

--- a/frontend/src/components/SlowQuery/Settings/SlowQuerySettings.vue
+++ b/frontend/src/components/SlowQuery/Settings/SlowQuerySettings.vue
@@ -1,24 +1,15 @@
 <template>
   <div class="space-y-4 pb-4 max-w-full">
-    <div>
-      <BBAttention :style="'WARN'" :title="$t('slow-query.report-slow-query')">
-        <i18n-t
-          keypath="slow-query.attention-description"
-          tag="div"
-          class="text-yellow-700 whitespace-pre-wrap mt-2 text-sm"
-        >
-          <template #slow_query>
-            <code>slow_query</code>
-          </template>
-          <template #pg_stat_statements>
-            <code>pg_stat_statements</code>
-          </template>
-        </i18n-t>
-        <div v-if="false" class="mt-2">
-          <!-- TODO: update docs link -->
-          <LearnMoreLink url="https://www.bytebase.com/404?source=console" />
-        </div>
-      </BBAttention>
+    <div class="textinfolabel">
+      {{ $t("slow-query.attention-description") }}
+      <a
+        href="https://www.bytebase.com/docs/slow-query/overview?source=console"
+        target="_blank"
+        class="normal-link inline-flex flex-row items-center"
+      >
+        {{ $t("common.learn-more") }}
+        <heroicons-outline:external-link class="w-4 h-4" />
+      </a>
     </div>
     <div class="flex items-center justify-between">
       <EnvironmentTabFilter

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2638,7 +2638,6 @@
   "slow-query": {
     "self": "Slow query",
     "slow-queries": "Slow queries",
-    "report-slow-query": "Report slow query",
     "report": "Report",
     "last-query-time": "Last query time",
     "database-name": "Database name",
@@ -2658,7 +2657,7 @@
     "rows-sent": "Rows sent",
     "lock-time": "Lock time",
     "query-time": "Query time",
-    "attention-description": "Bytebase periodically syncs slow query logs from instances.\nFor MySQL instance, {slow_query} must be enabled first.\nFor PostgreSQL instance, {pg_stat_statements} must be enabled first in each database.",
+    "attention-description": "Bytebase periodically syncs slow query logs from instances. For MySQL instance, slow_query must be enabled first. For PostgreSQL instance, only databases with pg_stat_statements enabled will collect slow queries.",
     "sync-job-started": "Sync jobs started. Please wait for the jobs to complete.",
     "detail": "Slow Query Detail",
     "filter": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2636,7 +2636,6 @@
   "slow-query": {
     "self": "Consulta lenta",
     "slow-queries": "Consultas lentas",
-    "report-slow-query": "Reportar consulta lenta",
     "report": "Reportar",
     "last-query-time": "Hora de la última consulta",
     "database-name": "Nombre de la base de datos",
@@ -2656,7 +2655,7 @@
     "rows-sent": "Filas enviadas",
     "lock-time": "Tiempo de bloqueo",
     "query-time": "Tiempo de consulta",
-    "attention-description": "Bytebase sincroniza periódicamente los registros de consultas lentas de las instancias.\nPara una instancia de MySQL, {slow_query} debe estar habilitado primero.\nPara una instancia de PostgreSQL, {pg_stat_statements} debe estar habilitado primero en cada base de datos.",
+    "attention-description": "Bytebase sincroniza periódicamente los registros de consultas lentas de las instancias. Para una instancia de MySQL, slow_query debe estar habilitado primero. Para una instancia de PostgreSQL, solo se recopilarán las consultas lentas si se habilita pg_stat_statements en la base de datos.",
     "sync-job-started": "Se iniciaron trabajos de sincronización. Espere a que los trabajos se completen.",
     "detail": "Detalles de la consulta lenta",
     "filter": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2631,7 +2631,6 @@
   "slow-query": {
     "self": "慢查询",
     "slow-queries": "慢查询",
-    "report-slow-query": "报告慢查询",
     "report": "报告",
     "last-query-time": "最近执行时间",
     "database-name": "数据库名",
@@ -2650,7 +2649,7 @@
     "rows-sent": "返回行数",
     "lock-time": "持有锁时长",
     "query-time": "执行时长",
-    "attention-description": "Bytebase 定期从实例上同步慢查询日志。\n对 MySQL 实例，需要先开启 {slow_query}。\n对 PostgreSQL 实例，需要先在各个数据库中开启 {pg_stat_statements}。",
+    "attention-description": "Bytebase 定期从实例上同步慢查询日志。对 MySQL 实例，需要先开启 slow_query。对 PostgreSQL 实例，只有开启 pg_stat_statements 的数据库才会收集慢查询。",
     "sync-job-started": "同步作业已启动。请等待同步完成。",
     "detail": "慢查询详情",
     "filter": {


### PR DESCRIPTION
For PG, we no longer require to enable pg_stat_statements on all databases

## Before

![CleanShot 2023-08-12 at 23-13-36 png](https://github.com/bytebase/bytebase/assets/230323/89c61a6c-1fad-4f50-a379-da34a8e41ae4)


## After

![CleanShot 2023-08-12 at 23-17-02 png](https://github.com/bytebase/bytebase/assets/230323/e8dd6e47-5751-4156-9908-5965918f65af)
