### PR TITLE
fix: sql review does not require instance license binding

### DIFF
--- a/frontend/src/components/RepositoryForm.vue
+++ b/frontend/src/components/RepositoryForm.vue
@@ -326,7 +326,7 @@
         "
         class="my-4"
         :style="`WARN`"
-        :title="$t('subscription.features.bb-feature-sql-review.title')"
+        :title="$t('subscription.features.bb-feature-vcs-sql-review.title')"
         :description="
           $t('subscription.instance-assignment.missing-license-for-instances', {
             count: instanceWithoutLicense.length,

--- a/frontend/src/views/SettingWorkspaceSQLReview.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReview.vue
@@ -11,7 +11,6 @@
         <heroicons-outline:external-link class="w-4 h-4" />
       </a>
     </div>
-    <FeatureAttentionForInstanceLicense feature="bb.feature.sql-review" />
 
     <SQLReviewPolicyTable class="my-4" />
   </div>


### PR DESCRIPTION
It's available in all plans. Also fix the vcs-sql-review title