### PR TITLE
chore(frontend): use effective environment

### DIFF
--- a/frontend/src/components/DatabaseBackup/DatabaseBackupSettingForm.vue
+++ b/frontend/src/components/DatabaseBackup/DatabaseBackupSettingForm.vue
@@ -37,7 +37,7 @@
 
             <router-link
               class="normal-link text-sm"
-              :to="`/environment/${database.instanceEntity.environmentEntity.uid}`"
+              :to="`/environment/${database.effectiveEnvironmentEntity.uid}`"
             >
               {{
                 $t(

--- a/frontend/src/components/DatabaseBackupCreateForm.vue
+++ b/frontend/src/components/DatabaseBackupCreateForm.vue
@@ -67,7 +67,7 @@ const buildBackupName = (database: ComposedDatabase) => {
   // The default format is consistent with the default automatic backup name format used in the server.
   return [
     slug(props.database.projectEntity.title),
-    slug(props.database.instanceEntity.environmentEntity.title),
+    slug(props.database.effectiveEnvironmentEntity.title),
     dayjs.utc().local().format("YYYYMMDDTHHmmss"),
   ].join("-");
 };

--- a/frontend/src/components/DatabaseBackupPanel.vue
+++ b/frontend/src/components/DatabaseBackupPanel.vue
@@ -15,7 +15,7 @@
             <router-link
               v-if="hasBackupPolicyViolation"
               class="flex items-center normal-link text-sm"
-              :to="`/environment/${database.instanceEntity.environmentEntity.uid}`"
+              :to="`/environment/${database.effectiveEnvironmentEntity.uid}`"
             >
               <heroicons-outline:exclamation-circle class="w-4 h-4 mr-1" />
               <span>{{ $t("database.backup-policy-violation") }}</span>
@@ -269,7 +269,7 @@ watchEffect(prepareBackupList);
 
 const prepareBackupPolicy = () => {
   policyV1Store.getOrFetchPolicyByParentAndType({
-    parentPath: props.database.instanceEntity.environment,
+    parentPath: props.database.effectiveEnvironment,
     policyType: PolicyType.BACKUP_PLAN,
   });
 };
@@ -362,7 +362,7 @@ const autoBackupRetentionDays = computed(() => {
 
 const backupPolicy = computed((): BackupPlanSchedule => {
   const policy = policyV1Store.getPolicyByParentAndType({
-    parentPath: props.database.instanceEntity.environment,
+    parentPath: props.database.effectiveEnvironment,
     policyType: PolicyType.BACKUP_PLAN,
   });
   return policy?.backupPlanPolicy?.schedule ?? defaultBackupSchedule;

--- a/frontend/src/components/DatabaseGroup/MatchedDatabaseView.vue
+++ b/frontend/src/components/DatabaseGroup/MatchedDatabaseView.vue
@@ -44,7 +44,7 @@
             class="ml-1 text-sm text-gray-400 max-w-[124px]"
             line-clamp="1"
           >
-            ({{ database.instanceEntity.environmentEntity.title }})
+            ({{ database.effectiveEnvironmentEntity.title }})
             {{ database.instanceEntity.title }}
           </NEllipsis>
         </div>
@@ -78,7 +78,7 @@
       >
         <NEllipsis class="text-sm" line-clamp="1">
           {{ database.databaseName }}
-          ({{ database.instanceEntity.environmentEntity.title }})
+          ({{ database.effectiveEnvironmentEntity.title }})
         </NEllipsis>
         <div class="flex flex-row justify-end items-center shrink-0">
           <NEllipsis class="ml-1 text-sm text-gray-400" line-clamp="1">

--- a/frontend/src/components/DatabaseSlowQueryPanel.vue
+++ b/frontend/src/components/DatabaseSlowQueryPanel.vue
@@ -27,7 +27,7 @@ const props = defineProps<{
 
 const filter = shallowRef<SlowQueryFilterParams>({
   ...defaultSlowQueryFilterParams(),
-  environment: props.database.instanceEntity.environmentEntity,
+  environment: props.database.effectiveEnvironmentEntity,
   instance: props.database.instanceEntity,
   database: props.database,
 });
@@ -35,7 +35,7 @@ const filter = shallowRef<SlowQueryFilterParams>({
 watch(
   () => props.database.name,
   () => {
-    filter.value.environment = props.database.instanceEntity.environmentEntity;
+    filter.value.environment = props.database.effectiveEnvironmentEntity;
     filter.value.instance = props.database.instanceEntity;
     filter.value.database = props.database;
   }

--- a/frontend/src/components/DatabasesSelectPanel.vue
+++ b/frontend/src/components/DatabasesSelectPanel.vue
@@ -178,7 +178,7 @@ const databaseListGroupByEnvironment = computed(() => {
     .filter((db) => db.databaseName.includes(state.searchText));
   const listByEnv = environmentV1Store.environmentList.map((environment) => {
     const list = databaseList.filter(
-      (db) => db.instanceEntity.environment === environment.name
+      (db) => db.effectiveEnvironment === environment.name
     );
     return {
       environment,
@@ -217,7 +217,7 @@ const toggleAllDatabasesSelectionForEnvironment = (
   on: boolean
 ) => {
   databaseList
-    .filter((db) => db.instanceEntity.environment === environment.name)
+    .filter((db) => db.effectiveEnvironment === environment.name)
     .forEach((db) => toggleDatabaseSelected(db.uid, on));
 };
 
@@ -227,7 +227,7 @@ const getAllSelectionStateForEnvironment = (
 ): { checked: boolean; indeterminate: boolean } => {
   const set = new Set(
     state.selectedDatabaseList
-      .filter((db) => db.instanceEntity.environment === environment.name)
+      .filter((db) => db.effectiveEnvironment === environment.name)
       .map((db) => db.uid)
   );
   const checked = databaseList.every((db) => set.has(db.uid));
@@ -245,7 +245,7 @@ const getSelectionStateSummaryForEnvironment = (
 ) => {
   const set = new Set(
     state.selectedDatabaseList
-      .filter((db) => db.instanceEntity.environment === environment.uid)
+      .filter((db) => db.effectiveEnvironment === environment.name)
       .map((db) => db.uid)
   );
   const selected = databaseList.filter((db) => set.has(db.uid)).length;

--- a/frontend/src/components/Issue/panel/RequestExportPanel/ExportResourceForm/Label.vue
+++ b/frontend/src/components/Issue/panel/RequestExportPanel/ExportResourceForm/Label.vue
@@ -44,7 +44,7 @@ const database = computed(() => {
 const environment = computed(() => {
   const { option } = props;
   if (option.level !== "database") return undefined;
-  return database.value?.instanceEntity.environmentEntity;
+  return database.value?.effectiveEnvironmentEntity;
 });
 
 const Prefix = () => {

--- a/frontend/src/components/Issue/panel/RequestExportPanel/index.vue
+++ b/frontend/src/components/Issue/panel/RequestExportPanel/index.vue
@@ -248,7 +248,7 @@ const handleEnvironmentSelect = (environmentId: string) => {
   if (
     database &&
     database.uid !== String(UNKNOWN_ID) &&
-    database.instanceEntity.environmentEntity.uid !== state.environmentId
+    database.effectiveEnvironmentEntity.uid !== state.environmentId
   ) {
     state.databaseId = undefined;
   }
@@ -261,7 +261,7 @@ const handleDatabaseSelect = (databaseId: string) => {
   );
   if (database && database.uid !== String(UNKNOWN_ID)) {
     handleProjectSelect(database.projectEntity.uid);
-    handleEnvironmentSelect(database.instanceEntity.environmentEntity.uid);
+    handleEnvironmentSelect(database.effectiveEnvironmentEntity.uid);
   }
 };
 

--- a/frontend/src/components/Issue/panel/RequestQueryPanel/DatabaseResourceForm/Label.vue
+++ b/frontend/src/components/Issue/panel/RequestQueryPanel/DatabaseResourceForm/Label.vue
@@ -44,7 +44,7 @@ const database = computed(() => {
 const environment = computed(() => {
   const { option } = props;
   if (option.level !== "database") return undefined;
-  return database.value?.instanceEntity.environmentEntity;
+  return database.value?.effectiveEnvironmentEntity;
 });
 
 const Prefix = () => {

--- a/frontend/src/components/Issue/table/DatabaseResourceTable.vue
+++ b/frontend/src/components/Issue/table/DatabaseResourceTable.vue
@@ -16,7 +16,7 @@
       <div class="bb-grid-cell">
         <EnvironmentV1Name
           :environment="
-            extractComposedDatabase(item).instanceEntity.environmentEntity
+            extractComposedDatabase(item).effectiveEnvironmentEntity
           "
         />
       </div>

--- a/frontend/src/components/IssueV1/components/StageSection/StageInfo/DatabaseInfo.vue
+++ b/frontend/src/components/IssueV1/components/StageSection/StageInfo/DatabaseInfo.vue
@@ -107,7 +107,7 @@ const databaseCreationStatus = computed((): DatabaseCreationStatus => {
 });
 
 const environment = computed(() => {
-  return coreDatabaseInfo.value.instanceEntity.environmentEntity;
+  return coreDatabaseInfo.value.effectiveEnvironmentEntity;
 });
 
 const database = computed(() => {

--- a/frontend/src/components/IssueV1/logic/initialize/assignee.ts
+++ b/frontend/src/components/IssueV1/logic/initialize/assignee.ts
@@ -66,7 +66,7 @@ export const trySetDefaultAssignee = async (issue: ComposedIssue) => {
   return trySetDefaultAssigneeByEnvironmentAndDeploymentType(
     issue,
     issue.projectEntity,
-    database.instanceEntity.environment,
+    database.effectiveEnvironment,
     taskTypeToDeploymentType(firstTask.type)
   );
 };

--- a/frontend/src/components/IssueV1/logic/utils.ts
+++ b/frontend/src/components/IssueV1/logic/utils.ts
@@ -60,6 +60,8 @@ const extractCoreDatabaseInfoFromDatabaseCreateTask = (
       instanceEntity,
       project: project.name,
       projectEntity: project,
+      effectiveEnvironment: instanceEntity.environment,
+      effectiveEnvironmentEntity: instanceEntity.environmentEntity,
     };
   };
 

--- a/frontend/src/components/ProjectChangeHistoryPanel.vue
+++ b/frontend/src/components/ProjectChangeHistoryPanel.vue
@@ -67,7 +67,7 @@ const fetchChangeHistory = async (databaseList: ComposedDatabase[]) => {
     if (changeHistoryList.length > 0) {
       state.databaseSectionList.push(database);
 
-      const title = `${database.databaseName} (${database.instanceEntity.environmentEntity.title})`;
+      const title = `${database.databaseName} (${database.effectiveEnvironmentEntity.title})`;
       const index = state.changeHistorySectionList.findIndex(
         (item: BBTableSectionDataSource<ChangeHistory>) => {
           return item.title == title;

--- a/frontend/src/components/ProjectDatabasesPanel.vue
+++ b/frontend/src/components/ProjectDatabasesPanel.vue
@@ -101,7 +101,7 @@ const filteredDatabaseList = computed(() => {
   );
   if (state.environment !== String(UNKNOWN_ID)) {
     list = list.filter(
-      (db) => db.instanceEntity.environmentEntity.uid === state.environment
+      (db) => db.effectiveEnvironmentEntity.uid === state.environment
     );
   }
   if (state.instance !== String(UNKNOWN_ID)) {

--- a/frontend/src/components/SchemaDesigner/BaselineSchemaSelector.vue
+++ b/frontend/src/components/SchemaDesigner/BaselineSchemaSelector.vue
@@ -168,7 +168,7 @@ onMounted(async () => {
       );
       state.projectId = props.baselineSchema.projectId;
       state.databaseId = database.uid;
-      state.environmentId = database.instanceEntity.environmentEntity.uid;
+      state.environmentId = database.effectiveEnvironmentEntity.uid;
       state.changeHistory = props.baselineSchema.changeHistory;
     } catch (error) {
       // do nothing.

--- a/frontend/src/components/SlowQuery/Panel/DetailPanel.vue
+++ b/frontend/src/components/SlowQuery/Panel/DetailPanel.vue
@@ -29,7 +29,7 @@
             </label>
 
             <EnvironmentV1Name
-              :environment="database.instanceEntity.environmentEntity"
+              :environment="database.effectiveEnvironmentEntity"
             />
           </div>
 

--- a/frontend/src/components/SlowQuery/Panel/LogTable.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogTable.vue
@@ -68,7 +68,7 @@
         </div>
         <div v-if="showEnvironmentColumn" class="bb-grid-cell">
           <EnvironmentV1Name
-            :environment="item.database.instanceEntity.environmentEntity"
+            :environment="item.database.effectiveEnvironmentEntity"
             :link="false"
           />
         </div>

--- a/frontend/src/components/TableDetailDrawer.vue
+++ b/frontend/src/components/TableDetailDrawer.vue
@@ -49,7 +49,7 @@
                     >{{ $t("common.environment") }}&nbsp;-&nbsp;</span
                   >
                   <EnvironmentV1Name
-                    :environment="database.instanceEntity.environmentEntity"
+                    :environment="database.effectiveEnvironmentEntity"
                     icon-class="textinfolabel"
                   />
                 </dd>

--- a/frontend/src/components/TransferDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm.vue
@@ -212,7 +212,7 @@ const parseLabelsIfNeeded = (database: ComposedDatabase) => {
   if (!match) return undefined;
 
   const labels: Record<string, string> = {
-    "bb.environment": database.instanceEntity.environment,
+    "bb.environment": database.effectiveEnvironment,
   };
 
   PRESET_LABEL_KEY_PLACEHOLDERS.forEach(([placeholder, key]) => {

--- a/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm/TransferMultipleDatabaseForm.vue
@@ -196,7 +196,7 @@ const gridColumnList = computed((): BBGridColumn[] => {
 const databaseListGroupByEnvironment = computed(() => {
   const listByEnv = environmentList.value.map((environment) => {
     const databaseList = props.databaseList.filter(
-      (db) => db.instanceEntity.environment === environment.name
+      (db) => db.effectiveEnvironment === environment.name
     );
     return {
       environment,
@@ -287,7 +287,7 @@ const getSelectionStateSummaryForEnvironment = (
 };
 
 const handleClickRow = (db: ComposedDatabase) => {
-  const environment = db.instanceEntity.environmentEntity;
+  const environment = db.effectiveEnvironmentEntity;
   toggleDatabaseIdForEnvironment(
     db.uid,
     environment.uid,

--- a/frontend/src/components/v2/Model/DatabaseTableRow.vue
+++ b/frontend/src/components/v2/Model/DatabaseTableRow.vue
@@ -38,7 +38,7 @@
   </div>
   <div v-if="showEnvironmentColumn" class="bb-grid-cell">
     <EnvironmentV1Name
-      :environment="environment ?? database.instanceEntity.environmentEntity"
+      :environment="environment ?? database.effectiveEnvironmentEntity"
       :link="false"
       tag="div"
     />

--- a/frontend/src/components/v2/Select/DatabaseSelect.vue
+++ b/frontend/src/components/v2/Select/DatabaseSelect.vue
@@ -67,7 +67,7 @@ const rawDatabaseList = computed(() => {
 
   return list.filter((db) => {
     if (props.environment && props.environment !== String(UNKNOWN_ID)) {
-      if (db.instanceEntity.environmentEntity.uid !== props.environment) {
+      if (db.effectiveEnvironmentEntity.uid !== props.environment) {
         return false;
       }
     }

--- a/frontend/src/store/modules/dbGroup.ts
+++ b/frontend/src/store/modules/dbGroup.ts
@@ -225,7 +225,7 @@ export const useDBGroupStore = defineStore("db-group", () => {
       const database = await databaseStore.getOrFetchDatabaseByName(item.name);
       if (
         database &&
-        database.instanceEntity.environmentEntity.uid === environmentId
+        database.effectiveEnvironmentEntity.uid === environmentId
       ) {
         unmatchedDatabaseList.push(database);
       }

--- a/frontend/src/utils/policy.ts
+++ b/frontend/src/utils/policy.ts
@@ -69,7 +69,7 @@ export const isDatabaseAccessible = (
             querierBinding.parsedExpr?.expr || Expr.fromPartial({})
           );
           const envNameList = extractEnvironmentNameListFromExpr(simpleExpr);
-          if (envNameList.includes(database.instanceEntity.environment)) {
+          if (envNameList.includes(database.effectiveEnvironment)) {
             return true;
           }
         }

--- a/frontend/src/utils/v1/database.ts
+++ b/frontend/src/utils/v1/database.ts
@@ -55,7 +55,7 @@ export const sortDatabaseV1List = (databaseList: ComposedDatabase[]) => {
   return orderBy(
     databaseList,
     [
-      (db) => db.instanceEntity.environmentEntity.order,
+      (db) => db.effectiveEnvironmentEntity.order,
       (db) => Number(db.instanceEntity.uid),
       (db) => Number(db.projectEntity.uid),
       (db) => db.databaseName,
@@ -73,7 +73,7 @@ export const isArchivedDatabaseV1 = (db: ComposedDatabase): boolean => {
   if (db.instanceEntity.state === State.DELETED) {
     return true;
   }
-  if (db.instanceEntity.environmentEntity.state === State.DELETED) {
+  if (db.effectiveEnvironmentEntity.state === State.DELETED) {
     return true;
   }
   return false;
@@ -174,7 +174,7 @@ export const isDatabaseV1Queryable = (
             querierBinding.parsedExpr?.expr || Expr.fromPartial({})
           );
           const envNameList = extractEnvironmentNameListFromExpr(simpleExpr);
-          if (envNameList.includes(database.instanceEntity.environment)) {
+          if (envNameList.includes(database.effectiveEnvironment)) {
             return true;
           }
         }
@@ -229,7 +229,7 @@ export const isTableQueryable = (
             querierBinding.parsedExpr?.expr || Expr.fromPartial({})
           );
           const envNameList = extractEnvironmentNameListFromExpr(simpleExpr);
-          if (envNameList.includes(database.instanceEntity.environment)) {
+          if (envNameList.includes(database.effectiveEnvironment)) {
             return true;
           }
         }
@@ -297,7 +297,7 @@ export function filterDatabaseV1ByKeyword(
 
   if (
     columns.includes("environment") &&
-    db.instanceEntity.environmentEntity.title.toLowerCase().includes(keyword)
+    db.effectiveEnvironmentEntity.title.toLowerCase().includes(keyword)
   ) {
     return true;
   }

--- a/frontend/src/views/AnomalyCenterDashboard.vue
+++ b/frontend/src/views/AnomalyCenterDashboard.vue
@@ -229,7 +229,7 @@ export default defineComponent({
               database.databaseName
                 .toLowerCase()
                 .includes(state.searchText.toLowerCase()) ||
-              database.instanceEntity.environmentEntity.title
+              database.effectiveEnvironmentEntity.title
                 .toLowerCase()
                 .includes(state.searchText.toLowerCase())
             ) {
@@ -247,7 +247,7 @@ export default defineComponent({
 
           if (anomalyListOfDatabase.length > 0) {
             sectionList.push({
-              title: `${database.databaseName} (${database.instanceEntity.environmentEntity.title})`,
+              title: `${database.databaseName} (${database.effectiveEnvironmentEntity.title})`,
               link: `/db/${databaseV1Slug(database)}`,
               list: anomalyListOfDatabase,
             });
@@ -318,16 +318,14 @@ export default defineComponent({
               break;
           }
         }
-        const summary = envMap.get(
-          database.instanceEntity.environmentEntity.uid
-        );
+        const summary = envMap.get(database.effectiveEnvironmentEntity.uid);
         if (summary) {
           summary.criticalCount += criticalCount;
           summary.highCount += highCount;
           summary.mediumCount += mediumCount;
         } else {
-          envMap.set(String(database.instanceEntity.environmentEntity.uid), {
-            environmentName: database.instanceEntity.environmentEntity.title,
+          envMap.set(String(database.effectiveEnvironmentEntity.uid), {
+            environmentName: database.effectiveEnvironmentEntity.title,
             criticalCount,
             highCount,
             mediumCount,

--- a/frontend/src/views/ExportCenter/ExportRecordTable.vue
+++ b/frontend/src/views/ExportCenter/ExportRecordTable.vue
@@ -28,7 +28,7 @@
       </div>
       <div class="bb-grid-cell">
         <EnvironmentV1Name
-          :environment="item.database.instanceEntity.environmentEntity"
+          :environment="item.database.effectiveEnvironmentEntity"
         />
       </div>
       <div class="bb-grid-cell">

--- a/frontend/src/views/SettingWorkspaceSensitiveData.vue
+++ b/frontend/src/views/SettingWorkspaceSensitiveData.vue
@@ -35,7 +35,7 @@
         </div>
         <div class="bb-grid-cell">
           <EnvironmentV1Name
-            :environment="item.database.instanceEntity.environmentEntity"
+            :environment="item.database.effectiveEnvironmentEntity"
             :link="false"
           />
         </div>

--- a/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
+++ b/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
@@ -163,7 +163,7 @@
               />
               <NEllipsis :tooltip="false">
                 <span class="mx-0.5 text-gray-400"
-                  >({{ database.instanceEntity.environmentEntity.title }})</span
+                  >({{ database.effectiveEnvironmentEntity.title }})</span
                 >
                 <span>{{ database.databaseName }}</span>
                 <span class="ml-0.5 text-gray-400"

--- a/frontend/src/views/SyncDatabaseSchema/TargetDatabasesSelectPanel.vue
+++ b/frontend/src/views/SyncDatabaseSchema/TargetDatabasesSelectPanel.vue
@@ -170,7 +170,7 @@ const databaseListGroupByEnvironment = computed(() => {
       .filter((db) => db.instanceEntity.engine === props.engine) || [];
   const listByEnv = environmentV1Store.environmentList.map((environment) => {
     const list = databaseList.filter(
-      (db) => db.instanceEntity.environment === environment.name
+      (db) => db.effectiveEnvironment === environment.name
     );
     return {
       environment,
@@ -209,7 +209,7 @@ const toggleAllDatabasesSelectionForEnvironment = (
   on: boolean
 ) => {
   databaseList
-    .filter((db) => db.instanceEntity.environment === environment.name)
+    .filter((db) => db.effectiveEnvironment === environment.name)
     .forEach((db) => toggleDatabaseSelected(db.uid, on));
 };
 
@@ -219,7 +219,7 @@ const getAllSelectionStateForEnvironment = (
 ): { checked: boolean; indeterminate: boolean } => {
   const set = new Set(
     state.selectedDatabaseList
-      .filter((db) => db.instanceEntity.environment === environment.name)
+      .filter((db) => db.effectiveEnvironment === environment.name)
       .map((db) => db.uid)
   );
   const checked = databaseList.every((db) => set.has(db.uid));
@@ -237,7 +237,7 @@ const getSelectionStateSummaryForEnvironment = (
 ) => {
   const set = new Set(
     state.selectedDatabaseList
-      .filter((db) => db.instanceEntity.environment === environment.name)
+      .filter((db) => db.effectiveEnvironment === environment.name)
       .map((db) => db.uid)
   );
   const selected = databaseList.filter((db) => set.has(db.uid)).length;


### PR DESCRIPTION
What's STILL NOT using `effectiveEnvironment`

- Creating DB
  In create DB panel, the `Environment` and `Instance` dropdown selectors are bound.
- Restore backup / PITR
  When restoring backups or PITR to a new database. We use the create DB panel, so the newly created DB will be under the instance environment.
  E.g., "db_A" in "instance_A(TEST)" marked as "PROD" will possibly be restored to "db_B" in "instance_A(TEST)" marked as "TEST"