### PR TITLE
fix: legacy task run table

### DIFF
--- a/frontend/src/components/Issue/TaskRunTable.vue
+++ b/frontend/src/components/Issue/TaskRunTable.vue
@@ -142,11 +142,10 @@ const comment = (taskRun: TaskRun): string => {
 
 const commentLink = (task: Task, taskRun: TaskRun): CommentLink => {
   if (taskRun.status == "DONE") {
-    switch (taskRun.type) {
+    switch (task.type) {
       case "bb.task.database.schema.baseline":
       case "bb.task.database.schema.update":
       case "bb.task.database.schema.update-sdl":
-      case "bb.task.general":
       case "bb.task.database.data.update": {
         const db = useDatabaseV1Store().getDatabaseByUID(
           String(task.database!.id)


### PR DESCRIPTION
#7352 removed taskRun.Status and the server always returns "bb.task.general". However, this will cause errors if the task type is "bb.task.database.create". Fortunately, we can presume that taskRun.Type equals task.Type and use task.Type instead.

Close BYT-3770