### PR TITLE
fix: check nil database in scheduler

### DIFF
--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -803,7 +803,9 @@ func (s *Scheduler) scheduleAutoApprovedTasks(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			environmentID = database.EffectiveEnvironmentID
+			if database != nil {
+				environmentID = database.EffectiveEnvironmentID
+			}
 		}
 		environment, err := s.store.GetEnvironmentV2(ctx, &store.FindEnvironmentMessage{ResourceID: &environmentID})
 		if err != nil {

--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -120,7 +120,9 @@ func (s *SchedulerV2) scheduleAutoRolloutTask(ctx context.Context, taskUID int) 
 		if err != nil {
 			return err
 		}
-		environmentID = database.EffectiveEnvironmentID
+		if database != nil {
+			environmentID = database.EffectiveEnvironmentID
+		}
 	}
 	environment, err := s.store.GetEnvironmentV2(ctx, &store.FindEnvironmentMessage{ResourceID: &environmentID})
 	if err != nil {


### PR DESCRIPTION
database can be nil if e.g. database.SyncStatus = NOT_FOUND.