### PR TITLE
feat(frontend): use legacy task patch API to update statement for legacy issues in new UI

### DIFF
--- a/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
@@ -173,6 +173,7 @@ import {
   specForTask,
   createEmptyLocalSheet,
   notifyNotEditableLegacyIssue,
+  patchLegacyIssueTasksStatement,
 } from "@/components/IssueV1/logic";
 import DownloadSheetButton from "@/components/Sheet/DownloadSheetButton.vue";
 import UploadProgressButton from "@/components/misc/UploadProgressButton.vue";
@@ -545,7 +546,18 @@ const updateStatement = async (statement: string) => {
 
   const planPatch = cloneDeep(issue.value.planEntity);
   if (!planPatch) {
-    notifyNotEditableLegacyIssue();
+    // notifyNotEditableLegacyIssue();
+    try {
+      await patchLegacyIssueTasksStatement(issue.value, tasks, statement);
+      events.emit("status-changed", { eager: true });
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("common.updated"),
+      });
+    } finally {
+      // nothing
+    }
     return;
   }
 

--- a/frontend/src/components/IssueV1/logic/index.ts
+++ b/frontend/src/components/IssueV1/logic/index.ts
@@ -13,3 +13,4 @@ export * from "./plan-check";
 export * from "./task-run";
 export * from "./poll";
 export * from "./subscriber";
+export * from "./legacy-issue-compatibility";

--- a/frontend/src/components/IssueV1/logic/legacy-issue-compatibility.ts
+++ b/frontend/src/components/IssueV1/logic/legacy-issue-compatibility.ts
@@ -1,0 +1,37 @@
+import { useIssueStore, useSheetV1Store, useTaskStore } from "@/store";
+import { ComposedIssue, TaskPatch } from "@/types";
+import { Task } from "@/types/proto/v1/rollout_service";
+import { extractSheetUID, setSheetStatement } from "@/utils";
+import { createEmptyLocalSheet } from "./sheet";
+
+export const patchLegacyIssueTasksStatement = async (
+  issue: ComposedIssue,
+  tasks: Task[],
+  statement: string
+) => {
+  const sheetCreate = {
+    ...createEmptyLocalSheet(),
+    title: issue.title,
+  };
+  setSheetStatement(sheetCreate, statement);
+  const createdSheet = await useSheetV1Store().createSheet(
+    issue.project,
+    sheetCreate
+  );
+
+  const legacyIssue = await useIssueStore().getOrFetchIssueById(
+    Number(issue.uid)
+  );
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    const taskPatch: TaskPatch = {
+      sheetId: Number(extractSheetUID(createdSheet.name)),
+    };
+    await useTaskStore().patchTask({
+      issueId: legacyIssue.id,
+      pipelineId: legacyIssue.pipeline!.id,
+      taskId: Number(task.uid),
+      taskPatch,
+    });
+  }
+};


### PR DESCRIPTION
If an issue has no plan, which means it's a legacy issue, we will fallback to use legacy task patch API to update statements.

FYI @RainbowDashy 