### PR TITLE
chore: consolidate sheet wording

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -197,9 +197,6 @@
     },
     "no-data": "No data",
     "visibility": "Visibility",
-    "star": "Star",
-    "unstar": "Unstar",
-    "starred": "Starred",
     "duplicate": "Duplicate",
     "clear-search": "Clear search",
     "enable": "Enable",
@@ -2190,8 +2187,11 @@
   "sheet": {
     "self": "Sheets",
     "my-sheets": "My Sheets",
-    "shared-with-me": "Shared with me",
+    "mine": "Mine",
+    "star": "Star",
+    "unstar": "Unstar",
     "starred": "Starred",
+    "shared-with-me": "Shared with me",
     "actions": {
       "sync-from-vcs": "Sync SQL scripts from VCS"
     },
@@ -2207,8 +2207,6 @@
     "from-issue-warning": "The sheet comes from issue {issue} in read-only mode. {oversize}",
     "content-oversize-warning": "SQL is oversized and inline-editing is disallowed. ",
     "sheets": "Sheets",
-    "mine": "Mine",
-    "shared": "Shared",
     "search-sheets": "Search Sheets"
   },
   "engine": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -196,9 +196,6 @@
     },
     "no-data": "Sin datos",
     "visibility": "Visibilidad",
-    "star": "Marcar Favorito",
-    "unstar": "Quitar Favorito",
-    "starred": "Favorito",
     "duplicate": "Duplicar",
     "clear-search": "Borrar búsqueda",
     "enable": "Habilitar",
@@ -2187,8 +2184,11 @@
   "sheet": {
     "self": "Hojas",
     "my-sheets": "Mis Hojas",
+    "mine": "Mío",
+    "star": "Marcar Favorito",
+    "unstar": "Quitar Favorito",
+    "starred": "Favorito",
     "shared-with-me": "Compartido conmigo",
-    "starred": "Marcado como favorito",
     "actions": {
       "sync-from-vcs": "Sincronizar scripts SQL desde VCS"
     },
@@ -2204,8 +2204,6 @@
       "duplicate-success": "Duplicado con éxito en \"Mis hojas\""
     },
     "sheets": "Hojas",
-    "mine": "Mío",
-    "shared": "Compartido",
     "search-sheets": "Hojas de búsqueda"
   },
   "engine": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -196,9 +196,6 @@
     },
     "no-data": "无数据",
     "visibility": "可见性",
-    "star": "添加收藏",
-    "unstar": "取消收藏",
-    "starred": "已收藏",
     "duplicate": "拷贝",
     "clear-search": "清空搜索",
     "enable": "开启",
@@ -2185,8 +2182,11 @@
   "sheet": {
     "self": "工作表",
     "my-sheets": "我的工作表",
-    "shared-with-me": "与我共享",
-    "starred": "已加星标",
+    "mine": "我的",
+    "starred": "收藏的",
+    "star": "添加收藏",
+    "unstar": "取消收藏",
+    "shared-with-me": "共享给我的",
     "actions": {
       "sync-from-vcs": "从 VCS 同步 SQL 脚本"
     },
@@ -2202,8 +2202,6 @@
     "from-issue-warning": "这个工作表来自工单 {issue}，处于只读模式。{oversize}",
     "content-oversize-warning": "SQL 过大所以无法直接编辑。",
     "sheets": "工作表",
-    "mine": "我的",
-    "shared": "分享的",
     "search-sheets": "搜索工作表"
   },
   "engine": {

--- a/frontend/src/views/SheetDashboard.vue
+++ b/frontend/src/views/SheetDashboard.vue
@@ -134,7 +134,7 @@ const navigationList = computed(() => {
     },
     {
       path: "/sheets/starred",
-      label: t("common.starred"),
+      label: t("sheet.starred"),
     },
   ];
 

--- a/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
@@ -70,11 +70,11 @@
           <NTabPane name="my" :tab="$t('sheet.mine')">
             <SheetList view="my" />
           </NTabPane>
-          <NTabPane name="shared" :tab="$t('sheet.shared')">
-            <SheetList view="shared" @add-tab="sheetTab = 'my'" />
-          </NTabPane>
           <NTabPane name="starred" :tab="$t('sheet.starred')">
             <SheetList view="starred" @add-tab="sheetTab = 'my'" />
+          </NTabPane>
+          <NTabPane name="shared" :tab="$t('sheet.shared-with-me')">
+            <SheetList view="shared" @add-tab="sheetTab = 'my'" />
           </NTabPane>
         </NTabs>
       </NTabPane>

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/DataTable.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/DataTable.vue
@@ -17,7 +17,7 @@
           class="relative border-collapse table-fixed z-[1]"
           v-bind="tableResize.getTableProps()"
         >
-          <thead class="sticky top-0 z-[1] shadow">
+          <thead class="sticky top-0 z-[1] drop-shadow-sm">
             <tr>
               <th
                 v-for="header of table.getFlatHeaders()"

--- a/frontend/src/views/sql-editor/Sheet/SheetTable/Dropdown.vue
+++ b/frontend/src/views/sql-editor/Sheet/SheetTable/Dropdown.vue
@@ -45,12 +45,12 @@ const options = computed(() => {
   if (sheet.starred) {
     options.push({
       key: "unstar",
-      label: t("common.unstar"),
+      label: t("sheet.unstar"),
     });
   } else {
     options.push({
       key: "star",
-      label: t("common.star"),
+      label: t("sheet.star"),
     });
   }
 

--- a/frontend/src/views/sql-editor/Sheet/common/Dropdown.vue
+++ b/frontend/src/views/sql-editor/Sheet/common/Dropdown.vue
@@ -53,12 +53,12 @@ const options = computed(() => {
   if (sheet.starred) {
     options.push({
       key: "unstar",
-      label: t("common.unstar"),
+      label: t("sheet.unstar"),
     });
   } else {
     options.push({
       key: "star",
-      label: t("common.star"),
+      label: t("sheet.star"),
     });
   }
 

--- a/frontend/src/views/sql-editor/SheetPanel/SheetPanel.vue
+++ b/frontend/src/views/sql-editor/SheetPanel/SheetPanel.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="w-[75vw] max-w-[calc(100vw-2rem)]">
     <NTabs v-model:value="view">
-      <NTabPane name="my" :tab="$t('sheet.my-sheets')">
+      <NTabPane name="my" :tab="$t('sheet.mine')">
         <SheetTable view="my" @select-sheet="handleSelectSheet" />
+      </NTabPane>
+      <NTabPane name="starred" :tab="$t('sheet.starred')">
+        <SheetTable view="starred" @select-sheet="handleSelectSheet" />
       </NTabPane>
       <NTabPane name="shared" :tab="$t('sheet.shared-with-me')">
         <SheetTable view="shared" @select-sheet="handleSelectSheet" />
-      </NTabPane>
-      <NTabPane name="starred" :tab="$t('common.starred')">
-        <SheetTable view="starred" @select-sheet="handleSelectSheet" />
       </NTabPane>
     </NTabs>
   </div>


### PR DESCRIPTION
* Also swap the order of `shared` and `starred`.
* Use a small drop shadow for result table header, a little bit subtle shadow is enough to distinguish the boarder while scrolling.

Before

![CleanShot 2023-08-19 at 00-08-30 png](https://github.com/bytebase/bytebase/assets/230323/e8c6f732-673a-4736-a133-719f8af1dfae)


After

![CleanShot 2023-08-19 at 00-07-05 png](https://github.com/bytebase/bytebase/assets/230323/3639fc76-9603-4d53-b126-022a889fd9dd)
