### PR TITLE
chore: revert the production alert style

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ConnectionPathBar.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ConnectionPathBar.vue
@@ -61,7 +61,7 @@
 
     <div
       v-if="isProductionEnvironment"
-      class="flex justify-start items-center py-1 sm:py-0 sm:h-6 px-4 sm:rounded-bl text-white text-sm bg-error"
+      class="flex justify-start items-center py-1 sm:py-0 sm:h-8 px-4 text-white bg-error"
     >
       {{ $t("sql-editor.sql-execute-in-production-environment") }}
     </div>


### PR DESCRIPTION
* Revert the prod alert style change in https://github.com/bytebase/bytebase/pull/7659. As I realize the original height just aligns with the admin mode top border perfectly.
* Remove the bottom rounded corner to look sharper.

Before
![CleanShot 2023-08-20 at 00-41-32 png](https://github.com/bytebase/bytebase/assets/230323/ef0066b5-7407-486a-96d8-da63e6a7abef)

After
![CleanShot 2023-08-20 at 00-39-56 png](https://github.com/bytebase/bytebase/assets/230323/771f7cb6-3e18-4d05-917e-35aae9b4d318)
