### PR TITLE
chore(frontend): display failed or canceled plan check runs in CI/CD UI

### DIFF
--- a/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckDetail.vue
+++ b/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckDetail.vue
@@ -177,6 +177,7 @@ const checkResultList = computed((): PlanCheckRun_Result[] => {
       PlanCheckRun_Result.fromPartial({
         status: PlanCheckRun_Result_Status.ERROR,
         title: t("common.error"),
+        content: props.planCheckRun.error,
       }),
     ];
   } else if (props.planCheckRun.status === PlanCheckRun_Status.CANCELED) {
@@ -184,6 +185,7 @@ const checkResultList = computed((): PlanCheckRun_Result[] => {
       PlanCheckRun_Result.fromPartial({
         status: PlanCheckRun_Result_Status.WARNING,
         title: t("common.canceled"),
+        content: props.planCheckRun.error,
       }),
     ];
   }


### PR DESCRIPTION
<img width="509" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/5d9000a9-a3fc-46b7-aaed-c8f960d30c37">

![e33e7cca-6d9e-4891-a4ab-5f8d60ee7c78](https://github.com/bytebase/bytebase/assets/2749742/e69746f5-8a5d-4b2e-835c-d804bf37b121)

Will display `error` field as the content when the status is `FAILED(3)` or `CANCELED(4)`

FYI @RainbowDashy 