### PR TITLE
chore(frontend): improve database info display in CICD UI

### DIFF
--- a/frontend/src/components/EnvironmentSelect.vue
+++ b/frontend/src/components/EnvironmentSelect.vue
@@ -11,7 +11,7 @@
       <EnvironmentV1Name
         :environment="environment"
         :link="false"
-        :suffiux="
+        :suffix="
           defaultEnvironment == environment.name
             ? `(${$t('common.default')})`
             : ''

--- a/frontend/src/components/IssueV1/components/StageSection/StageInfo/DatabaseInfo.vue
+++ b/frontend/src/components/IssueV1/components/StageSection/StageInfo/DatabaseInfo.vue
@@ -1,31 +1,45 @@
 <template>
   <div class="flex items-center flex-wrap gap-1">
-    <EnvironmentV1Name
-      :environment="environment"
-      :plain="true"
-      :tooltip="true"
-      class="hover:underline"
-    />
-
-    <heroicons-outline:chevron-right class="text-control-light" />
-
     <InstanceV1Name
       :instance="coreDatabaseInfo.instanceEntity"
       :plain="true"
-      class="hover:underline"
-    />
+      text-class="hover:underline"
+    >
+      <template
+        v-if="
+          database &&
+          database.instanceEntity.environment !== database.effectiveEnvironment
+        "
+        #prefix
+      >
+        <EnvironmentV1Name
+          :environment="database.instanceEntity.environmentEntity"
+          :plain="true"
+          :show-icon="false"
+          text-class="hover:underline text-control-light"
+        />
+      </template>
+    </InstanceV1Name>
 
     <heroicons-outline:chevron-right class="text-control-light" />
 
     <div class="flex items-center gap-x-1">
       <heroicons-outline:database />
 
-      <DatabaseV1Name
-        v-if="database"
-        :database="database"
-        :plain="true"
-        class="hover:underline"
-      />
+      <template v-if="database">
+        <EnvironmentV1Name
+          :environment="database.effectiveEnvironmentEntity"
+          :plain="true"
+          :show-icon="false"
+          text-class="hover:underline text-control-light"
+        />
+
+        <DatabaseV1Name
+          :database="database"
+          :plain="true"
+          class="hover:underline"
+        />
+      </template>
       <span v-else>
         {{ coreDatabaseInfo.databaseName }}
       </span>
@@ -104,10 +118,6 @@ const databaseCreationStatus = computed((): DatabaseCreationStatus => {
     return "PENDING_CREATE";
   }
   return "EXISTED";
-});
-
-const environment = computed(() => {
-  return coreDatabaseInfo.value.effectiveEnvironmentEntity;
 });
 
 const database = computed(() => {

--- a/frontend/src/components/v2/Model/EnvironmentV1Name.vue
+++ b/frontend/src/components/v2/Model/EnvironmentV1Name.vue
@@ -5,11 +5,12 @@
     class="inline-flex items-center gap-x-1"
     :class="link && !plain && 'normal-link'"
   >
-    <span class="line-clamp-1">
+    <span class="line-clamp-1" :class="textClass">
       {{ environmentV1Name(environment) }}
-      {{ suffiux }}
+      {{ suffix }}
     </span>
     <ProductionEnvironmentV1Icon
+      v-if="showIcon"
       :environment="environment"
       :class="iconClass ?? '!text-current'"
       :tooltip="tooltip"
@@ -31,7 +32,9 @@ const props = withDefaults(
     plain?: boolean;
     iconClass?: VueClass;
     tooltip?: boolean;
-    suffiux?: string;
+    suffix?: string;
+    showIcon?: boolean;
+    textClass?: string;
   }>(),
   {
     tag: "span",
@@ -39,7 +42,9 @@ const props = withDefaults(
     plain: false,
     iconClass: undefined,
     tooltip: false,
-    suffiux: "",
+    suffix: "",
+    showIcon: true,
+    textClass: "",
   }
 );
 

--- a/frontend/src/components/v2/Model/Instance/InstanceV1Name.vue
+++ b/frontend/src/components/v2/Model/Instance/InstanceV1Name.vue
@@ -10,7 +10,11 @@
       :instance="instance"
     />
 
-    <span class="line-clamp-1">{{ instanceV1Name(instance) }}</span>
+    <slot name="prefix" />
+
+    <span class="line-clamp-1" :class="textClass">{{
+      instanceV1Name(instance)
+    }}</span>
 
     <InstanceV1EngineIcon
       v-if="icon && iconPosition === 'suffix'"
@@ -33,6 +37,7 @@ const props = withDefaults(
     icon?: boolean;
     plain?: boolean;
     iconPosition?: "prefix" | "suffix";
+    textClass?: string;
   }>(),
   {
     tag: "span",
@@ -40,6 +45,7 @@ const props = withDefaults(
     icon: true,
     plain: false,
     iconPosition: "prefix",
+    textClass: "",
   }
 );
 


### PR DESCRIPTION
database environment same to instance environment
<img width="224" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/0399fec8-0fa1-4964-8dea-4fca1163d9fc">

database environment differ from instance environment
<img width="223" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/2ef9ec06-bf7d-4882-aa07-df4c9cb0222a">
