### PR TITLE
chore: bring back the legacy issue list for markdown editor

### DIFF
--- a/frontend/src/components/IssueV1/components/ActivitySection/ActivityList.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/ActivityList.vue
@@ -122,17 +122,22 @@ import {
 } from "@/components/Issue/activity";
 import MarkdownEditor from "@/components/MarkdownEditor.vue";
 import { IssueBuiltinFieldId } from "@/plugins";
-import { useActivityV1Store, useCurrentUserV1, useIssueV1Store, useIssueStore } from "@/store";
+import {
+  useActivityV1Store,
+  useCurrentUserV1,
+  useIssueV1Store,
+  useIssueStore,
+} from "@/store";
 import { getLogId } from "@/store/modules/v1/common";
 import {
   ActivityIssueCommentCreatePayload,
   ActivityIssueFieldUpdatePayload,
 } from "@/types";
+import type { Issue as LegacyIssue } from "@/types";
 import { LogEntity, LogEntity_Action } from "@/types/proto/v1/logging_service";
 import { extractUserResourceName } from "@/utils";
 import { doSubscribeIssue, useIssueContext } from "../../logic";
 import { ActivityItem } from "./Activity";
-import type { Issue as LegacyIssue } from "@/types";
 
 interface LocalState {
   editCommentMode: boolean;
@@ -161,7 +166,9 @@ const prepareActivityList = async () => {
   const [_, list] = await Promise.all([
     activityV1Store.fetchActivityListForIssueV1(issue.value),
     // TODO: deprecate the legacy store.
-    issueLegacyStore.fetchIssueList({ projectId: issue.value.projectEntity.uid }),
+    issueLegacyStore.fetchIssueList({
+      projectId: issue.value.projectEntity.uid,
+    }),
   ]);
   issueList.value = list;
 };


### PR DESCRIPTION
<img width="631" alt="CleanShot 2023-08-22 at 14 40 02@2x" src="https://github.com/bytebase/bytebase/assets/10706318/8b6d7cc6-2d2e-4e4a-ad73-e85b70a52e48">

TODO: change to v1 issue and deprecate the legacy store.