### PR TITLE
feat(frontend): display task run status change activity in CI/CD UI

### DIFF
--- a/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActionIcon.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActionIcon.vue
@@ -109,6 +109,7 @@ import PrincipalAvatar from "@/components/PrincipalAvatar.vue";
 import { useUserStore } from "@/store";
 import {
   ActivityIssueCommentCreatePayload,
+  ActivityPipelineTaskRunStatusUpdatePayload,
   ActivityStageStatusUpdatePayload,
   ActivityTaskStatusUpdatePayload,
   SYSTEM_BOT_EMAIL,
@@ -180,6 +181,36 @@ const icon = computed((): ActionIconType => {
       }
       case "PENDING_APPROVAL": {
         return "avatar"; // stale approval dismissed.
+      }
+    }
+  } else if (
+    activity.action === LogEntity_Action.ACTION_PIPELINE_TASK_RUN_STATUS_UPDATE
+  ) {
+    const payload = JSON.parse(
+      activity.payload
+    ) as ActivityPipelineTaskRunStatusUpdatePayload;
+
+    switch (payload.newStatus) {
+      case "PENDING": {
+        return "rollout";
+      }
+      case "CANCELED": {
+        return "cancel";
+      }
+      case "RUNNING": {
+        return "run";
+      }
+      case "DONE": {
+        return "complete";
+        // TODO check if skipped
+        // if (payload.oldStatus === "RUNNING") {
+        //   return "complete";
+        // } else {
+        //   return "skip";
+        // }
+      }
+      case "FAILED": {
+        return "fail";
       }
     }
   } else if (

--- a/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActionSentence.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActionSentence.vue
@@ -10,6 +10,7 @@ import TextOverflowPopover from "@/components/misc/TextOverflowPopover.vue";
 import { useSheetV1Store, useSheetStatementByUID } from "@/store";
 import {
   ActivityIssueCommentCreatePayload,
+  ActivityPipelineTaskRunStatusUpdatePayload,
   ActivityStageStatusUpdatePayload,
   ActivityTaskEarliestAllowedTimeUpdatePayload,
   ActivityTaskFileCommitPayload,
@@ -129,6 +130,68 @@ const renderActionSentence = () => {
           } else {
             params.verb = t("activity.sentence.skipped");
           }
+          break;
+        }
+        case "FAILED": {
+          params.verb = t("activity.sentence.failed");
+          break;
+        }
+        case "CANCELED": {
+          params.verb = t("activity.sentence.canceled");
+          break;
+        }
+        default:
+          params.verb = t("activity.sentence.changed");
+      }
+      const task = findTaskByUID(issue.rolloutEntity, String(payload.taskId));
+      if (task) {
+        params.target = h(TaskName, { issue, task });
+      }
+      return renderVerbTypeTarget(params, {
+        tag: "span",
+      });
+    }
+    case LogEntity_Action.ACTION_PIPELINE_TASK_RUN_STATUS_UPDATE: {
+      const payload = JSON.parse(
+        activity.payload
+      ) as ActivityPipelineTaskRunStatusUpdatePayload;
+      // if (payload.newStatus === "PENDING_APPROVAL") {
+      //   // stale approval dismissed.
+
+      //   const task = findTaskByUID(issue.rolloutEntity, String(payload.taskId));
+      //   const taskName = t("activity.sentence.task-name", {
+      //     name: task.title,
+      //   });
+      //   return t("activity.sentence.dismissed-stale-approval", {
+      //     task: taskName,
+      //   });
+      // }
+      const params: VerbTypeTarget = {
+        activity,
+        verb: "",
+        type: t("common.task"),
+        target: "",
+      };
+      switch (payload.newStatus) {
+        case "PENDING": {
+          params.verb = maybeAutomaticallyVerb(
+            activity,
+            t("activity.sentence.rolled-out")
+          );
+          break;
+        }
+        case "RUNNING": {
+          params.verb = t("activity.sentence.started");
+          break;
+        }
+        case "DONE": {
+          params.verb = t("activity.sentence.completed");
+          // TODO: check if skipped
+          // if (payload.oldStatus === "RUNNING") {
+          //   params.verb = t("activity.sentence.completed");
+          // } else {
+          //   params.verb = t("activity.sentence.skipped");
+          // }
           break;
         }
         case "FAILED": {

--- a/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActivityItem.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActivityItem.vue
@@ -1,4 +1,7 @@
 <template>
+  <li class="issue-debug">
+    {{ LogEntity.toJSON(activity) }}
+  </li>
   <li>
     <div :id="`#${activity.name}`" class="relative pb-4">
       <span

--- a/frontend/src/types/activity.ts
+++ b/frontend/src/types/activity.ts
@@ -16,7 +16,7 @@ import {
 } from "./id";
 import { IssueStatus } from "./issue";
 import { MemberStatus, RoleType } from "./member";
-import { StageStatusUpdateType, TaskStatus } from "./pipeline";
+import { StageStatusUpdateType, TaskRunStatus, TaskStatus } from "./pipeline";
 import { ApprovalEvent } from "./review";
 import { Advice } from "./sqlAdvice";
 import { VCSPushEvent } from "./vcs";
@@ -100,6 +100,7 @@ export type ActivityIssueStatusUpdatePayload = {
   newStatus: IssueStatus;
   issueName: string;
 };
+
 export type ActivityStageStatusUpdatePayload = {
   stageId: StageId;
   stageStatusUpdateType: StageStatusUpdateType;
@@ -111,6 +112,13 @@ export type ActivityTaskStatusUpdatePayload = {
   taskId: TaskId;
   oldStatus: TaskStatus;
   newStatus: TaskStatus;
+  issueName: string;
+  taskName: string;
+};
+
+export type ActivityPipelineTaskRunStatusUpdatePayload = {
+  taskId: TaskId;
+  newStatus: TaskRunStatus;
   issueName: string;
   taskName: string;
 };

--- a/frontend/src/types/pipeline/task.ts
+++ b/frontend/src/types/pipeline/task.ts
@@ -230,7 +230,12 @@ export type TaskStatusPatch = {
 };
 
 // TaskRun is one run of a particular task
-export type TaskRunStatus = "RUNNING" | "DONE" | "FAILED" | "CANCELED";
+export type TaskRunStatus =
+  | "PENDING"
+  | "RUNNING"
+  | "DONE"
+  | "FAILED"
+  | "CANCELED";
 
 export type TaskRunResultPayload = {
   detail: string;


### PR DESCRIPTION
<img width="576" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/4d99ba7a-f22b-401f-bf9d-a1d50110d2e3">

"SKIP" is a task status change rather than a task-run status change, so it's still not implemented.

FYI @RainbowDashy 