### PR TITLE
feat(advanced-masking-policy): crud for semantic category setting

### DIFF
--- a/backend/api/v1/common.go
+++ b/backend/api/v1/common.go
@@ -33,8 +33,10 @@ const (
 
 var (
 	resourceIDMatcher = regexp.MustCompile("^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$")
-	deletePatch       = true
-	undeletePatch     = false
+	// https://datatracker.ietf.org/doc/html/rfc4122#section-4.1
+	uuidMatcher   = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+	deletePatch   = true
+	undeletePatch = false
 )
 
 func isNumber(v string) (int, bool) {
@@ -401,4 +403,10 @@ func unmarshalPageToken(s string, pageToken *storepb.PageToken) error {
 		return errors.Wrapf(err, "failed to unmarshal page token")
 	}
 	return nil
+}
+
+// isValidUUID validates that the id is the valid UUID format.
+// https://datatracker.ietf.org/doc/html/rfc4122#section-4.1
+func isValidUUID(id string) bool {
+	return uuidMatcher.MatchString(id)
 }

--- a/backend/api/v1/setting_service.go
+++ b/backend/api/v1/setting_service.go
@@ -496,7 +496,7 @@ func (s *SettingService) SetSetting(ctx context.Context, request *v1pb.SetSettin
 			if _, ok := idMap[category.Id]; ok {
 				return nil, status.Errorf(codes.InvalidArgument, "duplicate category id: %s", category.Id)
 			}
-			idMap[category.Id] = interface{}(nil)
+			idMap[category.Id] = any(nil)
 		}
 		bytes, err := protojson.Marshal(storeCategorySetting)
 		if err != nil {

--- a/backend/api/v1/setting_service.go
+++ b/backend/api/v1/setting_service.go
@@ -72,6 +72,7 @@ var whitelistSettings = []api.SettingName{
 	api.SettingEnterpriseTrial,
 	api.SettingSchemaTemplate,
 	api.SettingDataClassification,
+	api.SettingSemanticCategory,
 }
 
 //go:embed mail_templates/testmail/template.html
@@ -479,6 +480,29 @@ func (s *SettingService) SetSetting(ctx context.Context, request *v1pb.SetSettin
 			return nil, status.Errorf(codes.Internal, "failed to marshal setting for %s with error: %v", apiSettingName, err)
 		}
 		storeSettingValue = string(bytes)
+	case api.SettingSemanticCategory:
+		storeCategorySetting := new(storepb.SemanticCategorySetting)
+		if err := convertV1PbToStorePb(request.Setting.Value.GetSemanticCategorySettingValue(), storeCategorySetting); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to unmarshal setting value for %s with error: %v", apiSettingName, err)
+		}
+		idMap := make(map[string]any)
+		for _, category := range storeCategorySetting.Categories {
+			if !isValidUUID(category.Id) {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid category id format: %s", category.Id)
+			}
+			if category.Title == "" {
+				return nil, status.Errorf(codes.InvalidArgument, "category title cannot be empty: %s", category.Id)
+			}
+			if _, ok := idMap[category.Id]; ok {
+				return nil, status.Errorf(codes.InvalidArgument, "duplicate category id: %s", category.Id)
+			}
+			idMap[category.Id] = interface{}(nil)
+		}
+		bytes, err := protojson.Marshal(storeCategorySetting)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to marshal setting for %s with error: %v", apiSettingName, err)
+		}
+		storeSettingValue = string(bytes)
 	default:
 		storeSettingValue = request.Setting.Value.GetStringValue()
 	}
@@ -672,6 +696,19 @@ func (s *SettingService) convertToSettingMessage(ctx context.Context, setting *s
 			Value: &v1pb.Value{
 				Value: &v1pb.Value_DataClassificationSettingValue{
 					DataClassificationSettingValue: v1Value,
+				},
+			},
+		}, nil
+	case api.SettingSemanticCategory:
+		v1Value := new(v1pb.SemanticCategorySetting)
+		if err := protojson.Unmarshal([]byte(setting.Value), v1Value); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to unmarshal setting value for %s with error: %v", setting.Name, err)
+		}
+		return &v1pb.Setting{
+			Name: settingName,
+			Value: &v1pb.Value{
+				Value: &v1pb.Value_SemanticCategorySettingValue{
+					SemanticCategorySettingValue: v1Value,
 				},
 			},
 		}, nil

--- a/backend/legacyapi/setting.go
+++ b/backend/legacyapi/setting.go
@@ -42,6 +42,8 @@ const (
 	SettingSchemaTemplate SettingName = "bb.workspace.schema-template"
 	// SettingDataClassification is the setting name for data classification.
 	SettingDataClassification SettingName = "bb.workspace.data-classification"
+	// SettingSemanticCategory is the setting name for semantic category.
+	SettingSemanticCategory SettingName = "bb.workspace.semantic-category"
 )
 
 // IMType is the type of IM.

--- a/frontend/src/types/proto/store/setting.ts
+++ b/frontend/src/types/proto/store/setting.ts
@@ -242,10 +242,7 @@ export interface SemanticCategorySetting {
 }
 
 export interface SemanticCategorySetting_SemanticCategory {
-  /**
-   * id is the uuid for semantic category.
-   * The id should in [0-9]+-[0-9]+-[0-9]+ format.
-   */
+  /** id is the uuid for category item. */
   id: string;
   /** the title of the category item, it should not be empty. */
   title: string;

--- a/frontend/src/types/proto/v1/setting_service.ts
+++ b/frontend/src/types/proto/v1/setting_service.ts
@@ -390,10 +390,7 @@ export interface SemanticCategorySetting {
 }
 
 export interface SemanticCategorySetting_SemanticCategory {
-  /**
-   * id is the uuid for semantic category.
-   * The id should in [0-9]+-[0-9]+-[0-9]+ format.
-   */
+  /** id is the uuid for category item. */
   id: string;
   /** the title of the category item, it should not be empty. */
   title: string;

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -2198,7 +2198,7 @@ MaskingExceptionPolicy is the allowlist of users who can access sensitive data.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | id is the uuid for semantic category. The id should in [0-9]&#43;-[0-9]&#43;-[0-9]&#43; format. |
+| id | [string](#string) |  | id is the uuid for category item. |
 | title | [string](#string) |  | the title of the category item, it should not be empty. |
 | description | [string](#string) |  | the description of the category item, it can be empty.
 

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -8739,7 +8739,7 @@ When paginating, all other parameters provided to `ListSettings` must match the 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | id is the uuid for semantic category. The id should in [0-9]&#43;-[0-9]&#43;-[0-9]&#43; format. |
+| id | [string](#string) |  | id is the uuid for category item. |
 | title | [string](#string) |  | the title of the category item, it should not be empty. |
 | description | [string](#string) |  | the description of the category item, it can be empty.
 

--- a/proto/generated-go/store/setting.pb.go
+++ b/proto/generated-go/store/setting.pb.go
@@ -1141,8 +1141,7 @@ type SemanticCategorySetting_SemanticCategory struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// id is the uuid for semantic category.
-	// The id should in [0-9]+-[0-9]+-[0-9]+ format.
+	// id is the uuid for category item.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// the title of the category item, it should not be empty.
 	Title string `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`

--- a/proto/generated-go/v1/setting_service.pb.go
+++ b/proto/generated-go/v1/setting_service.pb.go
@@ -1954,8 +1954,7 @@ type SemanticCategorySetting_SemanticCategory struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// id is the uuid for semantic category.
-	// The id should in [0-9]+-[0-9]+-[0-9]+ format.
+	// id is the uuid for category item.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// the title of the category item, it should not be empty.
 	Title string `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`

--- a/proto/store/setting.proto
+++ b/proto/store/setting.proto
@@ -162,8 +162,7 @@ message DataClassificationSetting {
 
 message SemanticCategorySetting {
   message SemanticCategory {
-    // id is the uuid for semantic category.
-    // The id should in [0-9]+-[0-9]+-[0-9]+ format.
+    // id is the uuid for category item.
     string id = 1;
     // the title of the category item, it should not be empty.
     string title = 2;

--- a/proto/v1/setting_service.proto
+++ b/proto/v1/setting_service.proto
@@ -297,8 +297,7 @@ message DataClassificationSetting {
 
 message SemanticCategorySetting {
   message SemanticCategory {
-    // id is the uuid for semantic category.
-    // The id should in [0-9]+-[0-9]+-[0-9]+ format.
+    // id is the uuid for category item.
     string id = 1;
     // the title of the category item, it should not be empty.
     string title = 2;


### PR DESCRIPTION
BTW, using uuid format for category item instead of custom id.

![image](https://github.com/bytebase/bytebase/assets/87714218/6fca2caa-1e51-44f5-aa92-51bc28f562b9)
