### PR TITLE
refactor: move the MySQL to use schemaList instead of tableList in databaseSchema

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -1466,7 +1466,7 @@ func (s *SQLService) getSensitiveSchemaInfo(ctx context.Context, instance *store
 						Sensitive: sensitive,
 					})
 				}
-				if instance.Engine == db.Snowflake || instance.Engine == db.MSSQL {
+				if instance.Engine == db.Snowflake || instance.Engine == db.MSSQL || instance.Engine == db.MySQL {
 					schemaSchema.TableList = append(schemaSchema.TableList, tableSchema)
 				} else {
 					databaseSchema.TableList = append(databaseSchema.TableList, tableSchema)
@@ -1477,9 +1477,13 @@ func (s *SQLService) getSensitiveSchemaInfo(ctx context.Context, instance *store
 					Name:       view.Name,
 					Definition: view.Definition,
 				}
-				databaseSchema.ViewList = append(databaseSchema.ViewList, viewSchema)
+				if instance.Engine == db.Snowflake || instance.Engine == db.MSSQL || instance.Engine == db.MySQL {
+					databaseSchema.ViewList = append(schemaSchema.ViewList, viewSchema)
+				} else {
+					databaseSchema.ViewList = append(databaseSchema.ViewList, viewSchema)
+				}
 			}
-			if instance.Engine == db.Snowflake || instance.Engine == db.MSSQL {
+			if instance.Engine == db.Snowflake || instance.Engine == db.MSSQL || instance.Engine == db.MySQL {
 				databaseSchema.SchemaList = append(databaseSchema.SchemaList, schemaSchema)
 			}
 		}

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -1478,7 +1478,7 @@ func (s *SQLService) getSensitiveSchemaInfo(ctx context.Context, instance *store
 					Definition: view.Definition,
 				}
 				if instance.Engine == db.Snowflake || instance.Engine == db.MSSQL || instance.Engine == db.MySQL {
-					databaseSchema.ViewList = append(schemaSchema.ViewList, viewSchema)
+					schemaSchema.ViewList = append(schemaSchema.ViewList, viewSchema)
 				} else {
 					databaseSchema.ViewList = append(databaseSchema.ViewList, viewSchema)
 				}

--- a/backend/plugin/db/driver.go
+++ b/backend/plugin/db/driver.go
@@ -630,7 +630,7 @@ type DatabaseSchema struct {
 	SchemaList []SchemaSchema
 
 	// !!DEPRECATED!!, should use SchemaList instead.
-	// TODO(rebelice/zp): Migrate MySQL/PostgreSQL/Oracle to SchemaList.
+	// TODO(rebelice/zp): Migrate PostgreSQL/Oracle to SchemaList.
 	TableList []TableSchema
 	ViewList  []ViewSchema
 }
@@ -639,6 +639,7 @@ type DatabaseSchema struct {
 type SchemaSchema struct {
 	Name      string
 	TableList []TableSchema
+	ViewList  []ViewSchema
 }
 
 // ViewSchema is the view schema using to extract sensitive fields.

--- a/backend/plugin/db/util/driverutil_test.go
+++ b/backend/plugin/db/util/driverutil_test.go
@@ -178,7 +178,7 @@ func generateOneMBInsert() string {
 	return fmt.Sprintf("INSERT INTO t values('%s')", string(b))
 }
 
-func TestExtractSensitiveField(t *testing.T) {
+func TestMySQLExtractSensitiveField(t *testing.T) {
 	const (
 		defaultDatabase = "db"
 	)
@@ -187,25 +187,30 @@ func TestExtractSensitiveField(t *testing.T) {
 			DatabaseList: []db.DatabaseSchema{
 				{
 					Name: defaultDatabase,
-					TableList: []db.TableSchema{
+					SchemaList: []db.SchemaSchema{
 						{
-							Name: "t",
-							ColumnList: []db.ColumnInfo{
+							Name: "",
+							TableList: []db.TableSchema{
 								{
-									Name:      "a",
-									Sensitive: true,
-								},
-								{
-									Name:      "b",
-									Sensitive: false,
-								},
-								{
-									Name:      "c",
-									Sensitive: false,
-								},
-								{
-									Name:      "d",
-									Sensitive: true,
+									Name: "t",
+									ColumnList: []db.ColumnInfo{
+										{
+											Name:      "a",
+											Sensitive: true,
+										},
+										{
+											Name:      "b",
+											Sensitive: false,
+										},
+										{
+											Name:      "c",
+											Sensitive: false,
+										},
+										{
+											Name:      "d",
+											Sensitive: true,
+										},
+									},
 								},
 							},
 						},

--- a/backend/plugin/db/util/mask_sensitive_data_mysql.go
+++ b/backend/plugin/db/util/mask_sensitive_data_mysql.go
@@ -546,11 +546,16 @@ func (extractor *sensitiveFieldExtractor) findTableSchema(databaseName string, t
 	}
 
 	for _, database := range extractor.schemaInfo.DatabaseList {
+		if len(database.SchemaList) == 0 {
+			continue
+		}
+		tableList := database.SchemaList[0].TableList
+
 		if extractor.schemaInfo.IgnoreCaseSensitive {
 			lowerDatabase := strings.ToLower(database.Name)
 			lowerTable := strings.ToLower(tableName)
 			if lowerDatabase == strings.ToLower(databaseName) || (databaseName == "" && lowerDatabase == strings.ToLower(extractor.currentDatabase)) {
-				for _, table := range database.TableList {
+				for _, table := range tableList {
 					if lowerTable == strings.ToLower(table.Name) {
 						explicitDatabase := databaseName
 						if explicitDatabase == "" {
@@ -561,7 +566,7 @@ func (extractor *sensitiveFieldExtractor) findTableSchema(databaseName string, t
 				}
 			}
 		} else if databaseName == database.Name || (databaseName == "" && extractor.currentDatabase == database.Name) {
-			for _, table := range database.TableList {
+			for _, table := range tableList {
 				if tableName == table.Name {
 					explicitDatabase := databaseName
 					if explicitDatabase == "" {
@@ -606,11 +611,16 @@ func (extractor *sensitiveFieldExtractor) buildTableSchemaForView(viewName strin
 
 func (extractor *sensitiveFieldExtractor) findViewSchema(databaseName string, viewName string) (string, db.TableSchema, error) {
 	for _, database := range extractor.schemaInfo.DatabaseList {
+		if len(database.SchemaList) == 0 {
+			continue
+		}
+		viewList := database.SchemaList[0].ViewList
+
 		if extractor.schemaInfo.IgnoreCaseSensitive {
 			lowerDatabase := strings.ToLower(database.Name)
 			lowerView := strings.ToLower(viewName)
 			if lowerDatabase == strings.ToLower(databaseName) || (databaseName == "" && lowerDatabase == strings.ToLower(extractor.currentDatabase)) {
-				for _, view := range database.ViewList {
+				for _, view := range viewList {
 					if lowerView == strings.ToLower(view.Name) {
 						explicitDatabase := databaseName
 						if explicitDatabase == "" {
@@ -623,7 +633,7 @@ func (extractor *sensitiveFieldExtractor) findViewSchema(databaseName string, vi
 				}
 			}
 		} else if databaseName == database.Name || (databaseName == "" && extractor.currentDatabase == database.Name) {
-			for _, view := range database.ViewList {
+			for _, view := range viewList {
 				if viewName == view.Name {
 					explicitDatabase := databaseName
 					if explicitDatabase == "" {


### PR DESCRIPTION
We need to add the `maskingLevel` and `maskingAlgorithm` in database schema, I do not want to add that two field duplicately in `Database.SchemaList.TableList` and `Database.TableList`.

<img width="760" alt="CleanShot 2023-08-28 at 17 42 46@2x" src="https://github.com/bytebase/bytebase/assets/87714218/5f9cf298-9616-4a41-8b87-851264242dca">
