### PR TITLE
chore(frontend): avatar component improvements

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "highlight.js": "11.6.0",
     "html-to-image": "^1.11.4",
     "inter-ui": "3.19.3",
+    "is-chinese": "^2.0.0",
     "js-base64": "^3.7.5",
     "js-yaml": "4.1.0",
     "jszip": "^3.10.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -77,6 +77,9 @@ dependencies:
   inter-ui:
     specifier: 3.19.3
     version: 3.19.3
+  is-chinese:
+    specifier: ^2.0.0
+    version: 2.0.0
   js-base64:
     specifier: ^3.7.5
     version: 3.7.5
@@ -3562,6 +3565,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
+
+  /is-chinese@2.0.0:
+    resolution: {integrity: sha512-1BTwHrs0wHnNZTyMWM8MPpVEs8u4uvLnUA2QZGt6cFjqY82DZV3lKH6hBGHqu8eJxkAIYcelm1kBR8v8URS4yA==}
+    dev: false
 
   /is-core-module@2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}

--- a/frontend/src/components/ActivityTable/ActivityTable.vue
+++ b/frontend/src/components/ActivityTable/ActivityTable.vue
@@ -38,7 +38,11 @@
       </BBTableCell>
       <BBTableCell class="w-[12%]">
         <div class="flex flex-row items-center">
-          <BBAvatar :size="'SMALL'" :username="getUser(activity)?.title" />
+          <BBAvatar
+            :size="'SMALL'"
+            :username="getUser(activity)?.title"
+            :email="getUser(activity)?.email"
+          />
           <span class="ml-2">{{ getUser(activity)?.title }}</span>
         </div>
       </BBTableCell>

--- a/frontend/src/components/Issue/review/CurrentApprover.vue
+++ b/frontend/src/components/Issue/review/CurrentApprover.vue
@@ -7,7 +7,11 @@
       <BBSpin />
     </template>
     <template v-else-if="currentApprover">
-      <BBAvatar :size="'SMALL'" :username="currentApprover.title" />
+      <BBAvatar
+        :size="'SMALL'"
+        :username="currentApprover.title"
+        :email="currentApprover.email"
+      />
       <span class="ml-2">
         {{ currentApprover.title }}
       </span>

--- a/frontend/src/components/Issue/table/IssueTable.vue
+++ b/frontend/src/components/Issue/table/IssueTable.vue
@@ -119,6 +119,7 @@
             :username="
               issue.assignee ? issue.assignee.name : $t('common.unassigned')
             "
+            :email="issue.assignee?.email"
           />
           <span class="ml-2">
             {{ issue.assignee ? issue.assignee.name : $t("common.unassigned") }}
@@ -127,7 +128,11 @@
       </BBTableCell>
       <BBTableCell class="hidden sm:table-cell w-36">
         <div class="flex flex-row items-center">
-          <BBAvatar :size="'SMALL'" :username="issue.creator.name" />
+          <BBAvatar
+            :size="'SMALL'"
+            :username="issue.creator.name"
+            :email="issue.creator.email"
+          />
           <span class="ml-2">
             {{ issue.creator.name }}
           </span>

--- a/frontend/src/components/PrincipalAvatar.vue
+++ b/frontend/src/components/PrincipalAvatar.vue
@@ -1,6 +1,7 @@
 <template>
   <BBAvatar
     :username="name"
+    :email="email"
     :size="size"
     :override-class="overrideClass"
     :override-text-size="overrideTextSize"
@@ -46,7 +47,13 @@ export default defineComponent({
       }
       return props.principal.name;
     });
-    return { name };
+    const email = computed((): string => {
+      if (props.principal.id === UNKNOWN_ID) {
+        return "";
+      }
+      return props.principal.email;
+    });
+    return { name, email };
   },
 });
 </script>

--- a/frontend/src/components/User/UserAvatar.vue
+++ b/frontend/src/components/User/UserAvatar.vue
@@ -1,6 +1,7 @@
 <template>
   <BBAvatar
     :username="username"
+    :email="email"
     :size="size"
     :override-class="overrideClass"
     :override-text-size="overrideTextSize"
@@ -39,5 +40,11 @@ const username = computed((): string => {
     return "?";
   }
   return props.user.title;
+});
+const email = computed(() => {
+  if (props.user.name === `users/${UNKNOWN_ID}`) {
+    return undefined;
+  }
+  return props.user.email;
 });
 </script>


### PR DESCRIPTION
- Display name improvements, with priority as

1. First Chinese character
2. At most the first 2 letters in email
Fallback if email is invalid (won't happen if works as expected)
1. The first and the last initial letter in title
2. The first initial letter in title

- Bytebase (systembot) will always show "BB"
- Bytebase (systembot) will always use the branding color

<img width="247" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/a18e05a9-aed5-4ce1-8900-c64a01b4176c">

<img width="246" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/a99f3182-d5e0-482e-9d6c-26a010536d7a">

Close BYT-3574
