### PR TITLE
feat(advanced-masking): evaluate the masking level of column

### DIFF
--- a/backend/api/v1/common.go
+++ b/backend/api/v1/common.go
@@ -410,19 +410,3 @@ func unmarshalPageToken(s string, pageToken *storepb.PageToken) error {
 func isValidUUID(id string) bool {
 	return uuidMatcher.MatchString(id)
 }
-
-// getTheStrictestMaskingLevel returns the strictest masking level from the given levels.
-func getTheStrictestMaskingLevel(a, b storepb.MaskingLevel) storepb.MaskingLevel {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// getTheKindestMaskingRule returns the kindest masking level from the given levels.
-func getTheKindestMaskingRule(a, b storepb.MaskingLevel) storepb.MaskingLevel {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/backend/api/v1/common.go
+++ b/backend/api/v1/common.go
@@ -411,15 +411,16 @@ func isValidUUID(id string) bool {
 	return uuidMatcher.MatchString(id)
 }
 
-// theStrictestMaskingLevel returns the strictest masking level from the given levels.
-func theStrictestMaskingLevel(a, b storepb.MaskingLevel) storepb.MaskingLevel {
+// getTheStrictestMaskingLevel returns the strictest masking level from the given levels.
+func getTheStrictestMaskingLevel(a, b storepb.MaskingLevel) storepb.MaskingLevel {
 	if a > b {
 		return a
 	}
 	return b
 }
 
-func theKindestMaskingRule(a, b storepb.MaskingLevel) storepb.MaskingLevel {
+// getTheKindestMaskingRule returns the kindest masking level from the given levels.
+func getTheKindestMaskingRule(a, b storepb.MaskingLevel) storepb.MaskingLevel {
 	if a < b {
 		return a
 	}

--- a/backend/api/v1/common.go
+++ b/backend/api/v1/common.go
@@ -410,3 +410,18 @@ func unmarshalPageToken(s string, pageToken *storepb.PageToken) error {
 func isValidUUID(id string) bool {
 	return uuidMatcher.MatchString(id)
 }
+
+// theStrictestMaskingLevel returns the strictest masking level from the given levels.
+func theStrictestMaskingLevel(a, b storepb.MaskingLevel) storepb.MaskingLevel {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func theKindestMaskingRule(a, b storepb.MaskingLevel) storepb.MaskingLevel {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -1592,7 +1592,7 @@ func evalMaskingLevelOfDatabaseColumn(databaseMessage *store.DatabaseMessage, da
 								return storepb.MaskingLevel_MASKING_LEVEL_UNSPECIFIED, errors.Wrap(err, "expect bool result for masking rule")
 							}
 							if boolVar {
-								finalLevel = theStrictestMaskingLevel(finalLevel, maskingRule.MaskingLevel)
+								finalLevel = getTheStrictestMaskingLevel(finalLevel, maskingRule.MaskingLevel)
 								break
 							}
 						}
@@ -1646,7 +1646,7 @@ func evalMaskingLevelOfDatabaseColumn(databaseMessage *store.DatabaseMessage, da
 
 						// TODO(zp): Expectedly, a column should hit only one exception,
 						// but we can take the strictest level here to make the whole program more robust.
-						finalLevel = theKindestMaskingRule(finalLevel, filteredMaskingException.MaskingLevel)
+						finalLevel = getTheKindestMaskingRule(finalLevel, filteredMaskingException.MaskingLevel)
 					}
 					return finalLevel, nil
 				}

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/base64"
@@ -1592,7 +1593,7 @@ func evalMaskingLevelOfDatabaseColumn(databaseMessage *store.DatabaseMessage, da
 								return storepb.MaskingLevel_MASKING_LEVEL_UNSPECIFIED, errors.Wrap(err, "expect bool result for masking rule")
 							}
 							if boolVar {
-								finalLevel = getTheStrictestMaskingLevel(finalLevel, maskingRule.MaskingLevel)
+								finalLevel = maskingRule.MaskingLevel
 								break
 							}
 						}
@@ -1646,7 +1647,9 @@ func evalMaskingLevelOfDatabaseColumn(databaseMessage *store.DatabaseMessage, da
 
 						// TODO(zp): Expectedly, a column should hit only one exception,
 						// but we can take the strictest level here to make the whole program more robust.
-						finalLevel = getTheKindestMaskingRule(finalLevel, filteredMaskingException.MaskingLevel)
+						if cmp.Less[storepb.MaskingLevel](filteredMaskingException.MaskingLevel, finalLevel) {
+							finalLevel = filteredMaskingException.MaskingLevel
+						}
 					}
 					return finalLevel, nil
 				}

--- a/backend/api/v1/sql_service_test.go
+++ b/backend/api/v1/sql_service_test.go
@@ -780,14 +780,6 @@ func TestEvalMaskingLevelOfDatabaseColumn(t *testing.T) {
 						Members:      []string{defaultEmail},
 						MaskingLevel: storepb.MaskingLevel_NONE,
 					},
-					{
-						Action: storepb.MaskingExceptionPolicy_MaskingException_QUERY,
-						Condition: &expr.Expr{
-							Expression: `(resource.instance_id == "neon-host") && (resource.database_name == "bb") && (resource.schema_name == "compnay") && (resource.table_name == "office") && (resource.column_name == "city")`,
-						},
-						Members:      []string{defaultEmail},
-						MaskingLevel: storepb.MaskingLevel_FULL,
-					},
 				},
 			},
 			want: db.DatabaseSchema{

--- a/backend/api/v1/sql_service_test.go
+++ b/backend/api/v1/sql_service_test.go
@@ -2,11 +2,16 @@ package v1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/expr"
 
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	parser "github.com/bytebase/bytebase/backend/plugin/parser/sql"
+	"github.com/bytebase/bytebase/backend/store"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
 )
 
@@ -257,5 +262,611 @@ func TestGetExcelColumnName(t *testing.T) {
 		got, err := getExcelColumnName(test.index)
 		a.NoError(err)
 		a.Equal(test.want, got)
+	}
+}
+
+func TestEvalMaskingLevelOfDatabaseColumn(t *testing.T) {
+	defaultDBSchemaMetadata := &storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "hiring",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "employees",
+						Columns: []*storepb.ColumnMetadata{
+							{
+								Name: "id",
+							},
+							{
+								Name: "name",
+							},
+							{
+								Name: "remote",
+							},
+						},
+					},
+					{
+						Name: "salary",
+						Columns: []*storepb.ColumnMetadata{
+							{
+								Name: "employee_id",
+							},
+							{
+								Name: "salary",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "company",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "office",
+						Columns: []*storepb.ColumnMetadata{
+							{
+								Name: "office_id",
+							},
+							{
+								Name: "city",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	defaultDatabaseMessage := &store.DatabaseMessage{
+		EnvironmentID: "prod",
+		ProjectID:     "bytebase",
+		InstanceID:    "neon-host",
+		DatabaseName:  "bb",
+	}
+
+	defaultEmail := "zp@bytebase.com"
+	defaultCurrentPrincipal := &store.UserMessage{
+		Email: defaultEmail,
+	}
+
+	testCases := []struct {
+		name                   string
+		database               *store.DatabaseMessage
+		databaseSchemaMetadata *storepb.DatabaseSchemaMetadata
+		maskingPolicy          *storepb.MaskingPolicy
+		maskingRulePolicy      *storepb.MaskingRulePolicy
+		maskingExceptionPolicy *storepb.MaskingExceptionPolicy
+		currentPrincipal       *store.UserMessage
+		requestTime            time.Time
+		want                   db.DatabaseSchema
+	}{
+		{
+			name:                   "Respect Masking Policy",
+			database:               defaultDatabaseMessage,
+			databaseSchemaMetadata: defaultDBSchemaMetadata,
+			currentPrincipal:       defaultCurrentPrincipal,
+			maskingPolicy: &storepb.MaskingPolicy{
+				MaskData: []*storepb.MaskData{
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "name",
+						MaskingLevel: storepb.MaskingLevel_PARTIAL,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "remote",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "salary",
+						Column:       "employee_id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "salary",
+						Column:       "salary",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Schema:       "company",
+						Table:        "office",
+						Column:       "office_id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "company",
+						Table:        "office",
+						Column:       "city",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+				},
+			},
+			maskingRulePolicy: &storepb.MaskingRulePolicy{
+				Rules: []*storepb.MaskingRulePolicy_MaskingRule{
+					{
+						Condition: &expr.Expr{
+							Expression: `(environment_id == "prod") && (table_name == "employees")`,
+						},
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+				},
+			},
+			maskingExceptionPolicy: &storepb.MaskingExceptionPolicy{},
+			want: db.DatabaseSchema{
+				Name: "bb",
+				SchemaList: []db.SchemaSchema{
+					{
+						Name: "hiring",
+						TableList: []db.TableSchema{
+							{
+								Name: "employees",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "name",
+										MaskingLevel: storepb.MaskingLevel_PARTIAL,
+										Sensitive:    true,
+									},
+									{
+										Name:         "remote",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+								},
+							},
+							{
+								Name: "salary",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "employee_id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "salary",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "company",
+						TableList: []db.TableSchema{
+							{
+								Name: "office",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "office_id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "city",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requestTime: time.Now(),
+		},
+		{
+			name:                   "Fallback To Masking Rule",
+			database:               defaultDatabaseMessage,
+			databaseSchemaMetadata: defaultDBSchemaMetadata,
+			currentPrincipal:       defaultCurrentPrincipal,
+			maskingPolicy: &storepb.MaskingPolicy{
+				MaskData: []*storepb.MaskData{
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "salary",
+						Column:       "employee_id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "company",
+						Table:        "office",
+						Column:       "office_id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+				},
+			},
+			maskingRulePolicy: &storepb.MaskingRulePolicy{
+				Rules: []*storepb.MaskingRulePolicy_MaskingRule{
+					{
+						Condition: &expr.Expr{
+							Expression: `(environment_id == "prod") && (schema_name == "hiring") && ((table_name == "employees") || (table_name == "salary"))`,
+						},
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Condition: &expr.Expr{
+							Expression: `(environment_id == "prod") && (schema_name == "company") && (table_name == "office")`,
+						},
+						MaskingLevel: storepb.MaskingLevel_PARTIAL,
+					},
+				},
+			},
+			maskingExceptionPolicy: &storepb.MaskingExceptionPolicy{},
+			want: db.DatabaseSchema{
+				Name: "bb",
+				SchemaList: []db.SchemaSchema{
+					{
+						Name: "hiring",
+						TableList: []db.TableSchema{
+							{
+								Name: "employees",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "name",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+									{
+										Name:         "remote",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+								},
+							},
+							{
+								Name: "salary",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "employee_id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "salary",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "company",
+						TableList: []db.TableSchema{
+							{
+								Name: "office",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "office_id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "city",
+										MaskingLevel: storepb.MaskingLevel_PARTIAL,
+										Sensitive:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requestTime: time.Now(),
+		},
+		{
+			name:                   "Find Lower Level In Masking Exception Policy",
+			database:               defaultDatabaseMessage,
+			databaseSchemaMetadata: defaultDBSchemaMetadata,
+			currentPrincipal:       defaultCurrentPrincipal,
+			maskingPolicy: &storepb.MaskingPolicy{
+				MaskData: []*storepb.MaskData{
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "name",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "remote",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "salary",
+						Column:       "employee_id",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "salary",
+						Column:       "salary",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Schema:       "company",
+						Table:        "office",
+						Column:       "office_id",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Schema:       "company",
+						Table:        "office",
+						Column:       "city",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+				},
+			},
+			maskingRulePolicy: &storepb.MaskingRulePolicy{
+				Rules: []*storepb.MaskingRulePolicy_MaskingRule{},
+			},
+			maskingExceptionPolicy: &storepb.MaskingExceptionPolicy{
+				MaskingExceptions: []*storepb.MaskingExceptionPolicy_MaskingException{
+					{
+						Action: storepb.MaskingExceptionPolicy_MaskingException_QUERY,
+						Condition: &expr.Expr{
+							Expression: `(resource.instance_id == "neon-host") && (resource.database_name == "bb") && (resource.schema_name == "hiring") && (resource.table_name == "employees") && (resource.column_name == "id")`,
+						},
+						Members:      []string{defaultEmail},
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Action: storepb.MaskingExceptionPolicy_MaskingException_QUERY,
+						Condition: &expr.Expr{
+							Expression: `(resource.instance_id == "neon-host") && (resource.database_name == "bb") && (resource.schema_name == "hiring") && (resource.table_name == "salary") && (resource.column_name == "salary")`,
+						},
+						Members:      []string{defaultEmail},
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+				},
+			},
+			want: db.DatabaseSchema{
+				Name: "bb",
+				SchemaList: []db.SchemaSchema{
+					{
+						Name: "hiring",
+						TableList: []db.TableSchema{
+							{
+								Name: "employees",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "name",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+									{
+										Name:         "remote",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+								},
+							},
+							{
+								Name: "salary",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "employee_id",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+									{
+										Name:         "salary",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "company",
+						TableList: []db.TableSchema{
+							{
+								Name: "office",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "office_id",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+									{
+										Name:         "city",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requestTime: time.Now(),
+		},
+		{
+			name:                   "Mixed",
+			database:               defaultDatabaseMessage,
+			databaseSchemaMetadata: defaultDBSchemaMetadata,
+			currentPrincipal:       defaultCurrentPrincipal,
+			maskingPolicy: &storepb.MaskingPolicy{
+				MaskData: []*storepb.MaskData{
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "employees",
+						Column:       "name",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "salary",
+						Column:       "employee_id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Schema:       "hiring",
+						Table:        "salary",
+						Column:       "salary",
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+					{
+						Schema:       "company",
+						Table:        "office",
+						Column:       "office_id",
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+				},
+			},
+			maskingRulePolicy: &storepb.MaskingRulePolicy{
+				Rules: []*storepb.MaskingRulePolicy_MaskingRule{
+					{
+						Condition: &expr.Expr{
+							Expression: `(table_name == "employees")`,
+						},
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+				},
+			},
+			maskingExceptionPolicy: &storepb.MaskingExceptionPolicy{
+				MaskingExceptions: []*storepb.MaskingExceptionPolicy_MaskingException{
+					{
+						Action: storepb.MaskingExceptionPolicy_MaskingException_QUERY,
+						Condition: &expr.Expr{
+							Expression: `(resource.instance_id == "neon-host") && (resource.database_name == "bb") && (resource.schema_name == "hiring") && (resource.table_name == "salary") && (resource.column_name == "salary")`,
+						},
+						Members:      []string{defaultEmail},
+						MaskingLevel: storepb.MaskingLevel_NONE,
+					},
+					{
+						Action: storepb.MaskingExceptionPolicy_MaskingException_QUERY,
+						Condition: &expr.Expr{
+							Expression: `(resource.instance_id == "neon-host") && (resource.database_name == "bb") && (resource.schema_name == "compnay") && (resource.table_name == "office") && (resource.column_name == "city")`,
+						},
+						Members:      []string{defaultEmail},
+						MaskingLevel: storepb.MaskingLevel_FULL,
+					},
+				},
+			},
+			want: db.DatabaseSchema{
+				Name: "bb",
+				SchemaList: []db.SchemaSchema{
+					{
+						Name: "hiring",
+						TableList: []db.TableSchema{
+							{
+								Name: "employees",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									{
+										Name:         "name",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									// Inherited from masking rule.
+									{
+										Name:         "remote",
+										MaskingLevel: storepb.MaskingLevel_FULL,
+										Sensitive:    true,
+									},
+								},
+							},
+							{
+								Name: "salary",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "employee_id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									// Hit Exception.
+									{
+										Name:         "salary",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "company",
+						TableList: []db.TableSchema{
+							{
+								Name: "office",
+								ColumnList: []db.ColumnInfo{
+									{
+										Name:         "office_id",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+									// Do not included in masking policy and masking rule, ignore the exception.
+									{
+										Name:         "city",
+										MaskingLevel: storepb.MaskingLevel_NONE,
+										Sensitive:    false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requestTime: time.Now(),
+		},
+	}
+
+	a := require.New(t)
+
+	for _, tc := range testCases {
+		result, err := evalMaskingLevelOfDatabaseColumn(tc.database, tc.databaseSchemaMetadata, tc.maskingPolicy, tc.maskingRulePolicy, tc.maskingExceptionPolicy, tc.currentPrincipal, tc.requestTime)
+		a.NoError(err, tc.name)
+		a.Equal(tc.want, result, tc.name)
 	}
 }

--- a/backend/common/convert.go
+++ b/backend/common/convert.go
@@ -49,6 +49,7 @@ var MaskingRulePolicyCELAttributes = []cel.EnvOption{
 	cel.Variable("project_id", cel.StringType),
 	cel.Variable("instance_id", cel.StringType),
 	cel.Variable("database_name", cel.StringType),
+	cel.Variable("schema_name", cel.StringType),
 	cel.Variable("table_name", cel.StringType),
 	cel.Variable("column_classification", cel.StringType),
 }
@@ -58,6 +59,7 @@ var MaskingExceptionPolicyCELAttributes = []cel.EnvOption{
 	cel.Variable("resource.instance_id", cel.StringType),
 	cel.Variable("resource.database_name", cel.StringType),
 	cel.Variable("resource.table_name", cel.StringType),
+	cel.Variable("resource.schema_name", cel.StringType),
 	cel.Variable("resource.column_name", cel.StringType),
 	cel.Variable("request.time", cel.TimestampType),
 }

--- a/backend/plugin/db/driver.go
+++ b/backend/plugin/db/driver.go
@@ -651,8 +651,10 @@ type TableSchema struct {
 
 // ColumnInfo is the column info using to extract sensitive fields.
 type ColumnInfo struct {
-	Name      string
-	Sensitive bool
+	Name string
+	// TODO(zp): retire Sensitive boolean flag.
+	Sensitive    bool
+	MaskingLevel storepb.MaskingLevel
 }
 
 // SensitiveField is the struct about SELECT fields.


### PR DESCRIPTION
`evalMaskingLevelOfDatabaseColumn` is not use for now.

![image](https://github.com/bytebase/bytebase/assets/87714218/4aa087b3-f7d7-457a-b3d9-86672f4e8942)

Return if cannot go to the next status.
