### PR TITLE
fix: 🔥retire legacy SensitiveDataPolicy

### DIFF
--- a/backend/legacyapi/policy.go
+++ b/backend/legacyapi/policy.go
@@ -189,12 +189,6 @@ func (p *EnvironmentTierPolicy) String() (string, error) {
 	return string(s), nil
 }
 
-// SensitiveDataPolicy is the policy configuration for sensitive data.
-// It is only applicable to database resource type.
-type SensitiveDataPolicy struct {
-	SensitiveDataList []SensitiveData `json:"sensitiveDataList"`
-}
-
 // SensitiveData is the value for sensitive data.
 type SensitiveData struct {
 	Schema string                `json:"schema"`
@@ -211,23 +205,6 @@ const (
 	// The default method is subject to change.
 	SensitiveDataMaskTypeDefault SensitiveDataMaskType = "DEFAULT"
 )
-
-// UnmarshalSensitiveDataPolicy will unmarshal payload to sensitive data policy.
-func UnmarshalSensitiveDataPolicy(payload string) (*SensitiveDataPolicy, error) {
-	var p SensitiveDataPolicy
-	if err := json.Unmarshal([]byte(payload), &p); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal sensitive data policy %q", payload)
-	}
-	return &p, nil
-}
-
-func (p *SensitiveDataPolicy) String() (string, error) {
-	s, err := json.Marshal(p)
-	if err != nil {
-		return "", err
-	}
-	return string(s), nil
-}
 
 // SlowQueryPolicy is the policy configuration for slow query.
 type SlowQueryPolicy struct {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -1481,17 +1481,17 @@ func (s *Server) generateOnboardingData(ctx context.Context, user *store.UserMes
 
 	// Add a sensitive data policy to pair it with the sample query below. So that user can
 	// experience the sensitive data masking feature from SQL Editor.
-	sensitiveDataPolicy := api.SensitiveDataPolicy{
-		SensitiveDataList: []api.SensitiveData{
+	maskingPolicy := &storepb.MaskingPolicy{
+		MaskData: []*storepb.MaskData{
 			{
-				Schema: "public",
-				Table:  "salary",
-				Column: "amount",
-				Type:   api.SensitiveDataMaskTypeDefault,
+				Schema:       "public",
+				Table:        "salary",
+				Column:       "amount",
+				MaskingLevel: storepb.MaskingLevel_FULL,
 			},
 		},
 	}
-	policyPayload, err = json.Marshal(sensitiveDataPolicy)
+	policyPayload, err = json.Marshal(maskingPolicy)
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal onboarding sensitive data policy")
 	}


### PR DESCRIPTION
Need to cherry-pick to 2.7.0 otherwise new users will get exceptions for sensitive data policy