### PR TITLE
fix: delete the legacy data

### DIFF
--- a/backend/migrator/migration/prod/2.7/0000##migrate_sensitive_data_policy_to_proto_json.sql
+++ b/backend/migrator/migration/prod/2.7/0000##migrate_sensitive_data_policy_to_proto_json.sql
@@ -1,55 +1,71 @@
+-- Delete the legacy data likes `{"sensitiveDataList": []}`.
+DELETE FROM
+  policy
+WHERE
+  payload = '{"sensitiveDataList": []}' :: JSONB
+  AND type = 'bb.policy.sensitive-data';
+
 -- Strip the NULL values.
-UPDATE policy SET payload = jsonb_strip_nulls(payload) WHERE type = 'bb.policy.sensitive-data';
+UPDATE
+  policy
+SET
+  payload = jsonb_strip_nulls(payload)
+WHERE
+  type = 'bb.policy.sensitive-data';
 
 -- Delete the maskType field for each elements in array.
-UPDATE 
-  policy 
-SET 
+UPDATE
+  policy
+SET
   payload = jsonb_set(
-    payload, 
-    '{sensitiveDataList}', 
+    payload,
+    '{sensitiveDataList}',
     (
-      SELECT 
-        jsonb_agg(item - 'maskType') 
-      FROM 
+      SELECT
+        jsonb_agg(item - 'maskType')
+      FROM
         jsonb_array_elements(payload -> 'sensitiveDataList') AS arr(item)
     )
-  ) 
-WHERE 
-  TYPE = 'bb.policy.sensitive-data' 
+  )
+WHERE
+  TYPE = 'bb.policy.sensitive-data'
   AND payload != '{}' :: jsonb;
-
 
 -- Add "maskingLevel":"FULL" in each elements in array.
-UPDATE 
-  policy 
-SET 
+UPDATE
+  policy
+SET
   payload = jsonb_set(
-    payload, 
-    '{sensitiveDataList}', 
+    payload,
+    '{sensitiveDataList}',
     (
-      SELECT 
+      SELECT
         jsonb_agg(
           item || '{"maskingLevel": "FULL"}'
-        ) 
-      FROM 
+        )
+      FROM
         jsonb_array_elements(payload -> 'sensitiveDataList') AS arr(item)
     )
-  ) 
-WHERE 
-  TYPE = 'bb.policy.sensitive-data' 
+  )
+WHERE
+  TYPE = 'bb.policy.sensitive-data'
   AND payload != '{}' :: jsonb;
-
 
 -- Rename `sensitiveDataList` to `maskData`.
-UPDATE 
-  policy 
-SET 
+UPDATE
+  policy
+SET
   payload = jsonb_build_object(
-      'maskData', payload -> 'sensitiveDataList'
-    )
-WHERE 
-  type = 'bb.policy.sensitive-data' 
+    'maskData',
+    payload -> 'sensitiveDataList'
+  )
+WHERE
+  type = 'bb.policy.sensitive-data'
   AND payload != '{}' :: jsonb;
 
-UPDATE policy SET type = 'bb.policy.masking' WHERE type = 'bb.policy.sensitive-data';
+UPDATE
+  policy
+SET
+  type = 'bb.policy.masking'
+WHERE
+  type = 'bb.policy.sensitive-data';


### PR DESCRIPTION
The legacy data contains `{"sensitiveDataList": []}`, it would make the following query return `NULL`:
```sql
UPDATE
  policy
SET
  payload = jsonb_set(
    payload,
    '{sensitiveDataList}',
    (
      SELECT
        jsonb_agg(item - 'maskType')
      FROM
        jsonb_array_elements(payload -> 'sensitiveDataList') AS arr(item)
    )
  )
WHERE
  TYPE = 'bb.policy.sensitive-data'
  AND payload != '{}' :: jsonb;
```
