### PR TITLE
chore: clear push event

### DIFF
--- a/backend/migrator/migration/prod/2.7/0006##clean_pushevent.sql
+++ b/backend/migrator/migration/prod/2.7/0006##clean_pushevent.sql
@@ -1,0 +1,11 @@
+ALTER TABLE sheet DISABLE TRIGGER update_sheet_updated_ts;
+ALTER TABLE task DISABLE TRIGGER update_task_updated_ts;
+
+UPDATE task SET payload = payload - 'pushEvent';
+
+UPDATE sheet
+SET payload = payload || jsonb_build_object('vcsPayload', jsonb_build_object('pushEvent', (sheet.payload->'vcsPayload'->'pushEvent')::JSONB - 'fileCommit'))
+WHERE payload->'vcsPayload' IS NOT NULL;
+
+ALTER TABLE task ENABLE TRIGGER update_task_updated_ts;
+ALTER TABLE sheet ENABLE TRIGGER update_sheet_updated_ts;

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -241,5 +241,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("2.7.5"), releaseVersion)
+	require.Equal(t, semver.MustParse("2.7.6"), releaseVersion)
 }


### PR DESCRIPTION
We've migrated pushEvent from task to sheet.
We've also deprecated fileCommit.