### PR TITLE
chore: set classification to project during creation

### DIFF
--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -90,6 +90,14 @@ func (s *ProjectService) CreateProject(ctx context.Context, request *v1pb.Create
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
+	setting, err := s.store.GetDataClassificationSetting(ctx)
+	if err != nil {
+		log.Error("failed to find classification setting", zap.Error(err))
+	}
+	if setting != nil && len(setting.Configs) != 0 {
+		projectMessage.DataClassificationConfigID = setting.Configs[0].Id
+	}
+
 	principalID := ctx.Value(common.PrincipalIDContextKey).(int)
 	project, err := s.store.CreateProjectV2(ctx,
 		projectMessage,

--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -177,14 +177,15 @@ func (s *Store) CreateProjectV2(ctx context.Context, create *ProjectMessage, cre
 	defer tx.Rollback()
 
 	project := &ProjectMessage{
-		ResourceID:       create.ResourceID,
-		Title:            create.Title,
-		Key:              create.Key,
-		Workflow:         create.Workflow,
-		Visibility:       create.Visibility,
-		TenantMode:       create.TenantMode,
-		DBNameTemplate:   create.DBNameTemplate,
-		SchemaChangeType: create.SchemaChangeType,
+		ResourceID:                 create.ResourceID,
+		Title:                      create.Title,
+		Key:                        create.Key,
+		Workflow:                   create.Workflow,
+		Visibility:                 create.Visibility,
+		TenantMode:                 create.TenantMode,
+		DBNameTemplate:             create.DBNameTemplate,
+		SchemaChangeType:           create.SchemaChangeType,
+		DataClassificationConfigID: create.DataClassificationConfigID,
 	}
 	if err := tx.QueryRowContext(ctx, `
 			INSERT INTO project (
@@ -197,9 +198,10 @@ func (s *Store) CreateProjectV2(ctx context.Context, create *ProjectMessage, cre
 				visibility,
 				tenant_mode,
 				db_name_template,
-				schema_change_type
+				schema_change_type,
+				data_classification_config_id
 			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 			RETURNING id
 		`,
 		creatorID,
@@ -212,6 +214,7 @@ func (s *Store) CreateProjectV2(ctx context.Context, create *ProjectMessage, cre
 		create.TenantMode,
 		create.DBNameTemplate,
 		create.SchemaChangeType,
+		create.DataClassificationConfigID,
 	).Scan(
 		&project.UID,
 	); err != nil {


### PR DESCRIPTION
Add we will set the classification to all projects when we update the classification setting BTW: https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/backend/api/v1/setting_service.go?L523