### PR TITLE
fix: make text of announcement optional

### DIFF
--- a/frontend/src/components/GeneralSetting/AnnouncementSetting.vue
+++ b/frontend/src/components/GeneralSetting/AnnouncementSetting.vue
@@ -46,7 +46,6 @@
         >
           <span class="font-medium"
             >{{ $t("settings.general.workspace.announcement-text.self") }}
-            <span class="text-red-600">*</span>
           </span>
 
           <FeatureBadge feature="bb.feature.announcement" />
@@ -177,10 +176,6 @@ const allowEdit = computed((): boolean => {
 
 const allowSave = computed((): boolean => {
   if (!allowEdit.value) {
-    return false;
-  }
-
-  if (state.announcement.text.length === 0) {
     return false;
   }
 

--- a/frontend/src/views/BannerAnnouncement.vue
+++ b/frontend/src/views/BannerAnnouncement.vue
@@ -1,24 +1,17 @@
 <template>
-  <div v-if="showBanner" :class="[`${bgColor}`]">
-    <div
-      class="mx-auto py-1 px-3 w-full flex flex-row items-center justify-center flex-wrap"
+  <div
+    v-if="showBanner"
+    class="max-auto py-1 px-3 w-full flex flex-row justify-center flex-wrap"
+    :class="[`${bgColor}`]"
+  >
+    <a
+      :href="announcementLink"
+      target="_blank"
+      class="font-medium text-center text-white hover:underline flex flex-row items-center"
     >
-      <div class="px-1 font-medium text-white flex flex-row items-center">
-        <p>{{ announcementText }}</p>
-      </div>
-      <div
-        v-if="announcementLink.length > 0"
-        class="item-center px-1 font-medium text-white truncate"
-      >
-        <a
-          :href="announcementLink"
-          target="_blank"
-          class="text-center underline"
-        >
-          <heroicons-solid:arrow-long-right class="mr-3 w-5 h-5" />
-        </a>
-      </div>
-    </div>
+      <p class="px-1">{{ announcementText }}</p>
+      <heroicons-solid:arrow-long-right class="mr-3 w-5 h-5" />
+    </a>
   </div>
 </template>
 


### PR DESCRIPTION
hover:
![image](https://github.com/bytebase/bytebase/assets/71714656/a377b564-08c8-4e92-aec7-801c260ddb19)

text fileld is optional:
![image](https://github.com/bytebase/bytebase/assets/71714656/6125488f-0828-4920-94b4-2816913c4a2a)

