### PR TITLE
fix: remove log.BBError(err) if nil

### DIFF
--- a/backend/plugin/idp/oauth2/oauth2.go
+++ b/backend/plugin/idp/oauth2/oauth2.go
@@ -118,7 +118,7 @@ func (p *IdentityProvider) UserInfo(token string) (*storepb.IdentityProviderUser
 		userInfo.Identifier = v
 	}
 	if userInfo.Identifier == "" {
-		slog.Error("Missing identifier in response body", slog.String("token", token), slog.Any("claims", claims), log.BBError(err))
+		slog.Error("Missing identifier in response body", slog.String("token", token), slog.Any("claims", claims))
 		return nil, errors.Errorf("the field %q is not found in claims or has empty value", p.config.FieldMapping.Identifier)
 	}
 

--- a/backend/server/webhook.go
+++ b/backend/server/webhook.go
@@ -2094,7 +2094,7 @@ func (s *Server) tryUpdateTasksFromModifiedFile(ctx context.Context, databases [
 			return nil
 		}
 		if issue == nil {
-			slog.Error("issue not found by pipeline ID", slog.Int("pipeline ID", task.PipelineID), log.BBError(err))
+			slog.Error("issue not found by pipeline ID", slog.Int("pipeline ID", task.PipelineID))
 			return nil
 		}
 


### PR DESCRIPTION
Passing nil to `log.BBError` causes panic.