### PR TITLE
feat(frontend): migrate batch mode deployment to CI/CD v2 in backend

### DIFF
--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/create/CreateButton.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/create/CreateButton.vue
@@ -45,7 +45,12 @@ import { ComposedIssue, dialectOfEngineV1, languageOfEngineV1 } from "@/types";
 import { Issue } from "@/types/proto/v1/issue_service";
 import { Plan_ChangeDatabaseConfig } from "@/types/proto/v1/rollout_service";
 import { Sheet } from "@/types/proto/v1/sheet_service";
-import { extractSheetUID, getSheetStatement, setSheetStatement } from "@/utils";
+import {
+  extractDeploymentConfigName,
+  extractSheetUID,
+  getSheetStatement,
+  setSheetStatement,
+} from "@/utils";
 
 const MAX_FORMATTABLE_STATEMENT_SIZE = 10000; // 10K characters
 
@@ -140,6 +145,11 @@ const createSheets = async () => {
   const sheetNameMap = new Map<string, string>();
   for (let i = 0; i < pendingCreateSheetList.length; i++) {
     const sheet = pendingCreateSheetList[i];
+    if (extractDeploymentConfigName(sheet.database)) {
+      // If a sheet's target is a deploymentConfig, it should be unset
+      // since it actually doesn't belongs to any exact database.
+      sheet.database = "";
+    }
     sheet.title = issue.value.title;
     const createdSheet = await useSheetV1Store().createSheet(
       issue.value.project,

--- a/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
@@ -404,27 +404,27 @@ const chooseUpdateStatementTarget = () => {
   };
 
   if (isDeploymentConfigChangeTaskV1(issue.value, selectedTask.value)) {
-    // dialog.info({
-    //   title: t("issue.update-statement.self", { type: statementTitle.value }),
-    //   content: t(
-    //     "issue.update-statement.current-change-will-apply-to-all-tasks-in-batch-mode"
-    //   ),
-    //   type: "info",
-    //   autoFocus: false,
-    //   closable: false,
-    //   maskClosable: false,
-    //   closeOnEsc: false,
-    //   showIcon: false,
-    //   positiveText: t("common.confirm"),
-    //   negativeText: t("common.cancel"),
-    //   onPositiveClick: () => {
-    //     d.resolve({ target: "ALL", tasks: targets.ALL });
-    //   },
-    //   onNegativeClick: () => {
-    //     d.resolve({ target: "CANCELED", tasks: [] });
-    //   },
-    // });
-    // return d.promise;
+    dialog.info({
+      title: t("issue.update-statement.self", { type: statementTitle.value }),
+      content: t(
+        "issue.update-statement.current-change-will-apply-to-all-tasks-in-batch-mode"
+      ),
+      type: "info",
+      autoFocus: false,
+      closable: false,
+      maskClosable: false,
+      closeOnEsc: false,
+      showIcon: false,
+      positiveText: t("common.confirm"),
+      negativeText: t("common.cancel"),
+      onPositiveClick: () => {
+        d.resolve({ target: "ALL", tasks: targets.ALL });
+      },
+      onNegativeClick: () => {
+        d.resolve({ target: "CANCELED", tasks: [] });
+      },
+    });
+    return d.promise;
   }
 
   if (targets.STAGE.length === 1 && targets.ALL.length === 1) {

--- a/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
@@ -174,6 +174,7 @@ import {
   createEmptyLocalSheet,
   notifyNotEditableLegacyIssue,
   patchLegacyIssueTasksStatement,
+  isDeploymentConfigChangeTaskV1,
 } from "@/components/IssueV1/logic";
 import MonacoEditor from "@/components/MonacoEditor";
 import DownloadSheetButton from "@/components/Sheet/DownloadSheetButton.vue";
@@ -367,10 +368,8 @@ const beginEdit = () => {
 
 const saveEdit = async () => {
   try {
-    // TODO
     await updateStatement(state.statement);
     resetTempEditState();
-    await new Promise((r) => setTimeout(r, 500));
   } finally {
     state.isEditing = false;
   }
@@ -382,10 +381,11 @@ const cancelEdit = () => {
 };
 
 const chooseUpdateStatementTarget = () => {
-  type Target = "TASK" | "STAGE" | "ALL";
+  type Target = "CANCELED" | "TASK" | "STAGE" | "ALL";
   const d = defer<{ target: Target; tasks: Task[] }>();
 
   const targets: Record<Target, Task[]> = {
+    CANCELED: [],
     TASK: [selectedTask.value],
     STAGE: (stageForTask(issue.value, selectedTask.value)?.tasks ?? []).filter(
       (task) => {
@@ -402,6 +402,30 @@ const chooseUpdateStatementTarget = () => {
       );
     }),
   };
+
+  if (isDeploymentConfigChangeTaskV1(issue.value, selectedTask.value)) {
+    // dialog.info({
+    //   title: t("issue.update-statement.self", { type: statementTitle.value }),
+    //   content: t(
+    //     "issue.update-statement.current-change-will-apply-to-all-tasks-in-batch-mode"
+    //   ),
+    //   type: "info",
+    //   autoFocus: false,
+    //   closable: false,
+    //   maskClosable: false,
+    //   closeOnEsc: false,
+    //   showIcon: false,
+    //   positiveText: t("common.confirm"),
+    //   negativeText: t("common.cancel"),
+    //   onPositiveClick: () => {
+    //     d.resolve({ target: "ALL", tasks: targets.ALL });
+    //   },
+    //   onNegativeClick: () => {
+    //     d.resolve({ target: "CANCELED", tasks: [] });
+    //   },
+    // });
+    // return d.promise;
+  }
 
   if (targets.STAGE.length === 1 && targets.ALL.length === 1) {
     d.resolve({ target: "TASK", tasks: targets.TASK });
@@ -423,6 +447,13 @@ const chooseUpdateStatementTarget = () => {
         $d.destroy();
       };
 
+      const CANCEL = h(
+        NButton,
+        { size: "small", onClick: () => finish("CANCELED") },
+        {
+          default: () => t("common.cancel"),
+        }
+      );
       const TASK = h(
         NButton,
         { size: "small", onClick: () => finish("TASK") },
@@ -430,7 +461,7 @@ const chooseUpdateStatementTarget = () => {
           default: () => t("issue.update-statement.target.selected-task"),
         }
       );
-      const buttons = [TASK];
+      const buttons = [CANCEL, TASK];
       if (targets.STAGE.length > 1) {
         // More than one editable tasks in stage
         // Add "Selected stage" option
@@ -461,6 +492,9 @@ const chooseUpdateStatementTarget = () => {
         { class: "flex items-center justify-end gap-x-2" },
         buttons
       );
+    },
+    onClose() {
+      d.resolve({ target: "CANCELED", tasks: [] });
     },
   });
 
@@ -547,7 +581,12 @@ const updateStatement = async (statement: string) => {
   // Find the target editing task(s)
   // default to selectedTask
   // also ask whether to apply the change to all tasks in the stage.
-  const { tasks } = await chooseUpdateStatementTarget();
+  const { target, tasks } = await chooseUpdateStatementTarget();
+
+  if (target === "CANCELED" || tasks.length === 0) {
+    cancelEdit();
+    return;
+  }
 
   const planPatch = cloneDeep(issue.value.planEntity);
   if (!planPatch) {

--- a/frontend/src/components/IssueV1/components/TaskStatusIcon.vue
+++ b/frontend/src/components/IssueV1/components/TaskStatusIcon.vue
@@ -11,7 +11,12 @@
     >
       <heroicons:exclamation-triangle class="w-7 h-7 text-warning" />
     </template>
-    <template v-else-if="status === Task_Status.NOT_STARTED">
+    <template
+      v-else-if="
+        status === Task_Status.NOT_STARTED ||
+        status === Task_Status.STATUS_UNSPECIFIED
+      "
+    >
       <heroicons-outline:user class="w-4 h-4" />
     </template>
     <template v-else-if="status === Task_Status.PENDING">
@@ -97,6 +102,7 @@ const classes = computed((): string => {
 
   switch (props.status) {
     case Task_Status.NOT_STARTED:
+    case Task_Status.STATUS_UNSPECIFIED:
       if (!isCreating.value && props.active) {
         return "bg-white border-2 border-info text-info";
       }

--- a/frontend/src/components/IssueV1/logic/rollout.ts
+++ b/frontend/src/components/IssueV1/logic/rollout.ts
@@ -10,6 +10,7 @@ import {
 } from "@/types/proto/v1/rollout_service";
 import {
   extractDatabaseGroupName,
+  extractDeploymentConfigName,
   extractUserResourceName,
   flattenTaskV1List,
   hasWorkspacePermissionV1,
@@ -25,6 +26,20 @@ export const isGroupingChangeTaskV1 = (issue: ComposedIssue, task: Task) => {
     spec.changeDatabaseConfig?.target ?? ""
   );
   return databaseGroup !== "";
+};
+
+export const isDeploymentConfigChangeTaskV1 = (
+  issue: ComposedIssue,
+  task: Task
+) => {
+  const spec = specForTask(issue.planEntity, task);
+  if (!spec) {
+    return false;
+  }
+  const deploymentConfig = extractDeploymentConfigName(
+    spec.changeDatabaseConfig?.target ?? ""
+  );
+  return deploymentConfig !== "";
 };
 
 export const allowUserToEditStatementForTask = (

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -915,7 +915,8 @@
         "selected-task": "Selected task",
         "selected-stage": "Selected stage",
         "all-tasks": "All tasks"
-      }
+      },
+      "current-change-will-apply-to-all-tasks-in-batch-mode": "In batch mode, current change will be applied to all tasks."
     },
     "not-editable-legacy-issue": "This issue is not editable because it was created in an old version of Bytebase",
     "action-anyway": "{action} anyway"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -914,7 +914,8 @@
         "selected-task": "Tarea seleccionada",
         "selected-stage": "Etapa seleccionada",
         "all-tasks": "Todas las tareas"
-      }
+      },
+      "current-change-will-apply-to-all-tasks-in-batch-mode": "En el modo por lotes, el cambio actual se aplicará a todas las tareas."
     },
     "not-editable-legacy-issue": "Este problema no es editable porque se creó en una versión anterior de Bytebase",
     "action-anyway": "{action} de todos modos"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -912,7 +912,8 @@
         "selected-task": "选中的任务",
         "selected-stage": "选中的阶段",
         "all-tasks": "所有任务"
-      }
+      },
+      "current-change-will-apply-to-all-tasks-in-batch-mode": "在批量模式下，当前更改将应用​​于所有任务。"
     },
     "not-editable-legacy-issue": "这个工单不可编辑，因为它是在旧版本的 Bytebase 中创建的。",
     "action-anyway": "仍要{action}"

--- a/frontend/src/utils/v1/deploymentConfig.ts
+++ b/frontend/src/utils/v1/deploymentConfig.ts
@@ -4,6 +4,12 @@ import {
   OperatorType,
 } from "@/types/proto/v1/project_service";
 
+export const extractDeploymentConfigName = (name: string) => {
+  const pattern = /(?:^|\/)deploymentConfigs\/([^/]+)(?:$|\/)/;
+  const matches = name.match(pattern);
+  return matches?.[1] ?? "";
+};
+
 export const validateDeploymentConfigV1 = (
   config: DeploymentConfig
 ): string | undefined => {


### PR DESCRIPTION
- In batch mode
  - Expand the pipeline using deploymentConfig as `spec.changeDatabaseConfig.target` on server-side
  - All tasks in a batch mode rollout targeting a deploymentConfig will share ONE plan/spec. This means they share ONE sheet, rollbackEnabled and earliestAllowedTime and cannot be changed independently.
  - Once any one of the tasks is done, the sheet cannot be changed. Means that the SQL statement of any other tasks cannot be changed. 

<img width="479" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/edc6f06f-6abb-4efa-8c02-842cd5cbdeab">

FYI @d-bytebase @RainbowDashy 

Close BYT-3939 