### PR TITLE
fix(pg_dump): split large sslca to mutli smaller sslcas

### DIFF
--- a/backend/plugin/db/pg/dump.go
+++ b/backend/plugin/db/pg/dump.go
@@ -273,7 +273,7 @@ func (driver *Driver) Restore(ctx context.Context, sc io.Reader) error {
 	return txn.Commit()
 }
 
-// split large sslCA to multi smaller sslCA.
+// split large sslCA to multiple smaller sslCAs.
 func splitSslCA(sslca string) []string {
 	if len(sslca) < sslCAThreshold {
 		return []string{sslca}

--- a/backend/plugin/db/pg/dump.go
+++ b/backend/plugin/db/pg/dump.go
@@ -20,6 +20,8 @@ import (
 )
 
 // threshold of one sslCA size.
+// we use 120kb as the threshold to avoid argument list too long error.
+// https://stackoverflow.com/questions/46897008/why-am-i-getting-e2big-from-exec-when-im-accounting-for-the-arguments-and-the
 const sslCAThreshold = 120 * 1024
 
 // Dump dumps the database.

--- a/backend/plugin/db/pg/dump.go
+++ b/backend/plugin/db/pg/dump.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"bufio"
 	"context"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,9 +14,13 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/plugin/db/util"
 	parser "github.com/bytebase/bytebase/backend/plugin/parser/sql"
 )
+
+// threshold of one sslCA size.
+const sslCAThreshold = 120 * 1024
 
 // Dump dumps the database.
 func (driver *Driver) Dump(ctx context.Context, out io.Writer, schemaOnly bool) (string, error) {
@@ -93,6 +98,24 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 	args = append(args, "--no-privileges")
 	args = append(args, database)
 
+	sslCAs := splitSslCA(driver.config.TLSConfig.SslCA)
+	dumpSuccess := false
+	for _, sslCA := range sslCAs {
+		if err := driver.execPgDump(ctx, args, out, sslCA); err != nil {
+			slog.Warn("Failed to exec pg_dump", log.BBError(err))
+		} else {
+			dumpSuccess = true
+			slog.Info("pg dump successfully")
+			break
+		}
+	}
+	if !dumpSuccess {
+		return errors.New("Failed to exec pg_dump")
+	}
+	return nil
+}
+
+func (driver *Driver) execPgDump(ctx context.Context, args []string, out io.Writer, sslCA string) error {
 	pgDumpPath := filepath.Join(driver.dbBinDir, "pg_dump")
 	cmd := exec.CommandContext(ctx, pgDumpPath, args...)
 	// Unlike MySQL, PostgreSQL does not support specifying commands in commands, we can do this by means of environment variables.
@@ -102,8 +125,8 @@ func (driver *Driver) dumpOneDatabaseWithPgDump(ctx context.Context, database st
 	if driver.config.TLSConfig.SslCert != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("PGSSLCERT=%s", driver.config.TLSConfig.SslCert))
 	}
-	if driver.config.TLSConfig.SslCA != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("PGSSLROOTCERT=%s", driver.config.TLSConfig.SslCA))
+	if sslCA != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PGSSLROOTCERT=%s", sslCA))
 	}
 	if driver.config.TLSConfig.SslKey != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("PGSSLKEY=%s", driver.config.TLSConfig.SslKey))
@@ -246,4 +269,33 @@ func (driver *Driver) Restore(ctx context.Context, sc io.Reader) error {
 	}
 
 	return txn.Commit()
+}
+
+// split large sslCA to multi smaller sslCA.
+func splitSslCA(sslca string) []string {
+	if len(sslca) < sslCAThreshold {
+		return []string{sslca}
+	}
+
+	var certs []string
+	var cert string
+	for block, rest := pem.Decode([]byte(sslca)); block != nil; block, rest = pem.Decode(rest) {
+		switch block.Type {
+		case "CERTIFICATE":
+			curCert := string(pem.EncodeToMemory(block))
+			if len(cert)+len(curCert) > sslCAThreshold {
+				certs = append(certs, cert)
+				cert = curCert
+			} else {
+				cert += curCert
+			}
+		default:
+			slog.Warn("unknown block type when spliting sslca")
+		}
+	}
+
+	if len(cert) > 0 {
+		certs = append(certs, cert)
+	}
+	return certs
 }

--- a/backend/plugin/db/pg/dump.go
+++ b/backend/plugin/db/pg/dump.go
@@ -19,7 +19,7 @@ import (
 	parser "github.com/bytebase/bytebase/backend/plugin/parser/sql"
 )
 
-// threshold of one sslCA size.
+// sslCAThreshold is the block size for splitting sslCA.
 // we use 120kb as the threshold to avoid argument list too long error.
 // https://stackoverflow.com/questions/46897008/why-am-i-getting-e2big-from-exec-when-im-accounting-for-the-arguments-and-the
 const sslCAThreshold = 120 * 1024


### PR DESCRIPTION
fix: https://github.com/bytebase/bytebase/issues/7738