### PR TITLE
chore(frontend): fixed dropdown menu width for expr editor

### DIFF
--- a/frontend/src/components/ExprEditor/components/MultiSelect.vue
+++ b/frontend/src/components/ExprEditor/components/MultiSelect.vue
@@ -9,6 +9,9 @@
     max-tag-count="responsive"
     size="small"
     style="min-width: 12rem; width: auto; overflow-x: hidden"
+    :menu-props="{
+      style: 'width: 14rem',
+    }"
     @update:value="$emit('update:value', $event)"
   >
     <template #action>


### PR DESCRIPTION
Close BYT-3965

<img width="726" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/077efb73-4640-4e99-beea-1f5a2752a8c1">
