### PR TITLE
chore: move engine icon before the timestamp

### DIFF
--- a/frontend/src/views/sql-editor/SecondarySidebar/HistoryTabPane/HistoryTabPane.vue
+++ b/frontend/src/views/sql-editor/SecondarySidebar/HistoryTabPane/HistoryTabPane.vue
@@ -22,20 +22,20 @@
         @click="handleQueryHistoryClick(history)"
       >
         <div class="w-full flex flex-row justify-between items-center">
-          <span class="text-xs text-gray-500">
-            {{ titleOfQueryHistory(history) }}
-          </span>
           <div class="flex items-start gap-x-1">
             <HistoryConnectionIcon :query-history="history" />
-            <span
-              class="rounded text-gray-500 hover:text-gray-700 hover:bg-gray-200"
-            >
-              <heroicons-outline:clipboard-document
-                class="w-4 h-4"
-                @click.stop="handleCopy(history)"
-              />
+            <span class="text-xs text-gray-500">
+              {{ titleOfQueryHistory(history) }}
             </span>
           </div>
+          <span
+            class="rounded text-gray-500 hover:text-gray-700 hover:bg-gray-200"
+          >
+            <heroicons-outline:clipboard-document
+              class="w-4 h-4"
+              @click.stop="handleCopy(history)"
+            />
+          </span>
         </div>
         <p
           class="max-w-full text-xs break-words font-mono line-clamp-3"


### PR DESCRIPTION
The engine icon is not clickable, so do not co-locate it with the clickable paste icon.

## Before
![CleanShot 2023-09-13 at 11 53 10](https://github.com/bytebase/bytebase/assets/230323/03cf8464-c219-4359-a78e-8a6b791fb905)

## After
![CleanShot 2023-09-13 at 11 55 12](https://github.com/bytebase/bytebase/assets/230323/bb94f076-6124-445d-a0e2-2645760792c0)
