### PR TITLE
chore(frontend): migrate issue list API and components

### DIFF
--- a/frontend/src/components/IssueV1/components/ActivitySection/ActivityList.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/ActivityList.vue
@@ -122,18 +122,13 @@ import {
 } from "@/components/Issue/activity";
 import MarkdownEditor from "@/components/MarkdownEditor.vue";
 import { IssueBuiltinFieldId } from "@/plugins";
-import {
-  useActivityV1Store,
-  useCurrentUserV1,
-  useIssueV1Store,
-  useIssueStore,
-} from "@/store";
+import { useActivityV1Store, useCurrentUserV1, useIssueV1Store } from "@/store";
 import { getLogId } from "@/store/modules/v1/common";
 import {
   ActivityIssueCommentCreatePayload,
   ActivityIssueFieldUpdatePayload,
 } from "@/types";
-import type { Issue as LegacyIssue } from "@/types";
+import type { ComposedIssue } from "@/types";
 import { LogEntity, LogEntity_Action } from "@/types/proto/v1/logging_service";
 import { extractUserResourceName } from "@/utils";
 import { doSubscribeIssue, useIssueContext } from "../../logic";
@@ -150,7 +145,7 @@ const activityV1Store = useActivityV1Store();
 const route = useRoute();
 
 const { issue } = useIssueContext();
-const issueList = ref<LegacyIssue[]>([]);
+const issueList = ref<ComposedIssue[]>([]);
 
 const state = reactive<LocalState>({
   editCommentMode: false,
@@ -160,17 +155,18 @@ const state = reactive<LocalState>({
 
 const currentUser = useCurrentUserV1();
 const issueV1Store = useIssueV1Store();
-const issueLegacyStore = useIssueStore();
 
 const prepareActivityList = async () => {
   const [_, list] = await Promise.all([
     activityV1Store.fetchActivityListForIssueV1(issue.value),
-    // TODO: deprecate the legacy store.
-    issueLegacyStore.fetchIssueList({
-      projectId: issue.value.projectEntity.uid,
+    issueV1Store.listIssues({
+      find: {
+        project: issue.value.project,
+        query: "",
+      },
     }),
   ]);
-  issueList.value = list;
+  issueList.value = list.issues;
 };
 
 watchEffect(prepareActivityList);

--- a/frontend/src/components/IssueV1/components/WaitingForMyApprovalIssueTableV1.vue
+++ b/frontend/src/components/IssueV1/components/WaitingForMyApprovalIssueTableV1.vue
@@ -1,0 +1,49 @@
+<template>
+  <PagedIssueTableV1
+    method="LIST"
+    :session-key="sessionKey"
+    :page-size="20"
+    :issue-filter="{
+      project: 'projects/-',
+      query: '',
+      statusList: [IssueStatus.OPEN],
+    }"
+  >
+    <template #table="{ issueList, loading }">
+      <slot
+        name="table"
+        :issue-list="issueList.filter(filter)"
+        :loading="loading"
+      />
+    </template>
+  </PagedIssueTableV1>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useAuthStore } from "@/store";
+import type { ComposedIssue } from "@/types";
+import { IssueStatus } from "@/types/proto/v1/issue_service";
+import { extractReviewContext, useWrappedReviewStepsV1 } from "../logic";
+import PagedIssueTableV1 from "./PagedIssueTableV1.vue";
+
+defineProps<{
+  sessionKey: string;
+}>();
+
+const currentUserName = computed(() => useAuthStore().currentUser.name);
+
+const filter = (issue: ComposedIssue) => {
+  const issueRef = computed(() => issue);
+  const reviewContext = extractReviewContext(issueRef);
+  const steps = useWrappedReviewStepsV1(issueRef, reviewContext);
+
+  const currentStep = steps.value?.find((step) => step.status === "CURRENT");
+  if (!currentStep) return false;
+  return (
+    currentStep.candidates.findIndex(
+      (user) => user.name === currentUserName.value
+    ) >= 0
+  );
+};
+</script>

--- a/frontend/src/components/IssueV1/logic/initialize/create.ts
+++ b/frontend/src/components/IssueV1/logic/initialize/create.ts
@@ -211,6 +211,7 @@ export const buildStepsViaDeploymentConfig = async (
     params,
     sheetUID
   );
+  maybeSetInitialSQLForSpec(spec, 0, params);
   const step = Plan_Step.fromPartial({
     specs: [spec],
   });

--- a/frontend/src/components/ProjectOverviewPanel.vue
+++ b/frontend/src/components/ProjectOverviewPanel.vue
@@ -63,35 +63,37 @@
       </div>
 
       <div>
-        <WaitingForMyApprovalIssueTable
+        <WaitingForMyApprovalIssueTableV1
           v-if="hasCustomApprovalFeature"
           session-key="project-waiting-approval"
-          :issue-find="{
-            statusList: ['OPEN'],
-            projectId: project.uid,
+          method="LIST"
+          :issue-filter="{
+            ...commonIssueFilter,
+            statusList: [IssueStatus.OPEN],
           }"
         >
           <template #table="{ issueList, loading }">
-            <IssueTable
+            <IssueTableV1
               :mode="'PROJECT'"
               :show-placeholder="!loading"
               :title="$t('issue.waiting-approval')"
               :issue-list="issueList"
             />
           </template>
-        </WaitingForMyApprovalIssueTable>
+        </WaitingForMyApprovalIssueTableV1>
 
         <!-- show OPEN issues with pageSize=10 -->
-        <PagedIssueTable
+        <PagedIssueTableV1
           session-key="project-open"
-          :issue-find="{
-            statusList: ['OPEN'],
-            projectId: project.uid,
+          method="LIST"
+          :issue-filter="{
+            ...commonIssueFilter,
+            statusList: [IssueStatus.OPEN],
           }"
           :page-size="10"
         >
           <template #table="{ issueList, loading }">
-            <IssueTable
+            <IssueTableV1
               class="-mt-px"
               :mode="'PROJECT'"
               :title="$t('project.overview.in-progress')"
@@ -99,21 +101,22 @@
               :show-placeholder="!loading"
             />
           </template>
-        </PagedIssueTable>
+        </PagedIssueTableV1>
 
         <!-- show the first 5 DONE or CANCELED issues -->
         <!-- But won't show "Load more", since we have a "View all closed" link below -->
-        <PagedIssueTable
+        <PagedIssueTableV1
           session-key="project-closed"
-          :issue-find="{
-            statusList: ['DONE', 'CANCELED'],
-            projectId: project.uid,
+          method="LIST"
+          :issue-filter="{
+            ...commonIssueFilter,
+            statusList: [IssueStatus.DONE, IssueStatus.CANCELED],
           }"
           :page-size="5"
           :hide-load-more="true"
         >
           <template #table="{ issueList, loading }">
-            <IssueTable
+            <IssueTableV1
               class="-mt-px"
               :mode="'PROJECT'"
               :title="$t('project.overview.recently-closed')"
@@ -121,7 +124,7 @@
               :show-placeholder="!loading"
             />
           </template>
-        </PagedIssueTable>
+        </PagedIssueTableV1>
 
         <div class="w-full flex justify-end mt-2 px-4">
           <router-link
@@ -137,21 +140,21 @@
 </template>
 
 <script lang="ts" setup>
-import { reactive, PropType } from "vue";
+import { reactive, PropType, computed } from "vue";
 import { useRouter } from "vue-router";
-import PagedIssueTable from "@/components/Issue/table/PagedIssueTable.vue";
 import { featureToRef } from "@/store";
+import { IssueStatus } from "@/types/proto/v1/issue_service";
 import { Project } from "@/types/proto/v1/project_service";
-import { IssueTable } from "../components/Issue";
-import { Issue } from "../types";
+import { IssueFilter } from "../types";
+import IssueTableV1 from "./IssueV1/components/IssueTableV1.vue";
+import PagedIssueTableV1 from "./IssueV1/components/PagedIssueTableV1.vue";
+import WaitingForMyApprovalIssueTableV1 from "./IssueV1/components/WaitingForMyApprovalIssueTableV1.vue";
 
 interface LocalState {
   isFetchingActivityList: boolean;
-  progressIssueList: Issue[];
-  closedIssueList: Issue[];
 }
 
-defineProps({
+const props = defineProps({
   project: {
     required: true,
     type: Object as PropType<Project>,
@@ -160,10 +163,15 @@ defineProps({
 
 const state = reactive<LocalState>({
   isFetchingActivityList: false,
-  progressIssueList: [],
-  closedIssueList: [],
 });
 const router = useRouter();
 
 const hasCustomApprovalFeature = featureToRef("bb.feature.custom-approval");
+
+const commonIssueFilter = computed((): IssueFilter => {
+  return {
+    project: props.project.name,
+    query: "",
+  };
+});
 </script>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,11 +1,7 @@
 <template>
   <div class="flex flex-col">
     <div class="px-4 py-2 flex justify-between items-center">
-      <EnvironmentTabFilter
-        :include-all="true"
-        :environment="selectedEnvironment?.name"
-        @update:environment="changeEnvironment"
-      />
+      <div><!-- empty --></div>
       <SearchBox
         :value="state.searchText"
         :placeholder="$t('issue.search-issue-name')"
@@ -14,109 +10,109 @@
       />
     </div>
 
-    <WaitingForMyApprovalIssueTable
+    <WaitingForMyApprovalIssueTableV1
       v-if="hasCustomApprovalFeature"
       session-key="home-waiting-approval"
-      :issue-find="{
-        statusList: ['OPEN'],
-      }"
     >
       <template #table="{ issueList, loading }">
-        <IssueTable
-          :left-bordered="false"
-          :right-bordered="false"
+        <IssueTableV1
           :show-placeholder="!loading"
           :title="$t('issue.waiting-approval')"
-          :issue-list="issueList.filter(keywordAndEnvironmentFilter)"
+          :issue-list="issueList.filter(keywordFilter)"
+          :highlight-text="state.searchText"
         />
       </template>
-    </WaitingForMyApprovalIssueTable>
+    </WaitingForMyApprovalIssueTableV1>
 
     <!-- show OPEN Assigned issues with pageSize=10 -->
-    <PagedIssueTable
+    <PagedIssueTableV1
+      method="LIST"
       session-key="home-assigned"
-      :issue-find="{
-        statusList: ['OPEN'],
-        assigneeId: Number(currentUserUID),
+      :issue-filter="{
+        ...commonIssueFilter,
+        statusList: [IssueStatus.OPEN],
+        assignee: `users/${currentUserV1.email}`,
       }"
       :page-size="OPEN_ISSUE_LIST_PAGE_SIZE"
     >
       <template #table="{ issueList, loading }">
-        <IssueTable
+        <IssueTableV1
           class="-mt-px"
-          :left-bordered="false"
-          :right-bordered="false"
           :show-placeholder="!loading"
           :title="$t('issue.waiting-rollout')"
-          :issue-list="issueList.filter(keywordAndEnvironmentFilter)"
+          :issue-list="issueList.filter(keywordFilter)"
+          :highlight-text="state.searchText"
         />
       </template>
-    </PagedIssueTable>
+    </PagedIssueTableV1>
 
     <!-- show OPEN Created issues with pageSize=10 -->
-    <PagedIssueTable
+    <PagedIssueTableV1
       session-key="home-created"
-      :issue-find="{
-        statusList: ['OPEN'],
-        creatorId: Number(currentUserUID),
+      method="LIST"
+      :issue-filter="{
+        ...commonIssueFilter,
+        statusList: [IssueStatus.OPEN],
+        creator: `users/${currentUserV1.email}`,
       }"
       :page-size="OPEN_ISSUE_LIST_PAGE_SIZE"
     >
       <template #table="{ issueList, loading }">
-        <IssueTable
+        <IssueTableV1
           class="-mt-px"
-          :left-bordered="false"
-          :right-bordered="false"
           :show-placeholder="!loading"
           :title="$t('common.created')"
-          :issue-list="issueList.filter(keywordAndEnvironmentFilter)"
+          :issue-list="issueList.filter(keywordFilter)"
+          :highlight-text="state.searchText"
         />
       </template>
-    </PagedIssueTable>
+    </PagedIssueTableV1>
 
     <!-- show OPEN Subscribed issues with pageSize=10 -->
-    <PagedIssueTable
+    <PagedIssueTableV1
       session-key="home-subscribed"
-      :issue-find="{
-        statusList: ['OPEN'],
-        subscriberId: Number(currentUserUID),
+      method="LIST"
+      :issue-filter="{
+        ...commonIssueFilter,
+        statusList: [IssueStatus.OPEN],
+        subscriber: `users/${currentUserV1.email}`,
       }"
       :page-size="OPEN_ISSUE_LIST_PAGE_SIZE"
     >
       <template #table="{ issueList, loading }">
-        <IssueTable
+        <IssueTableV1
           class="-mt-px"
-          :left-bordered="false"
-          :right-bordered="false"
           :show-placeholder="!loading"
           :title="$t('common.subscribed')"
-          :issue-list="issueList.filter(keywordAndEnvironmentFilter)"
+          :issue-list="issueList.filter(keywordFilter)"
+          :highlight-text="state.searchText"
         />
       </template>
-    </PagedIssueTable>
+    </PagedIssueTableV1>
 
     <!-- show the first 5 DONE or CANCELED issues -->
     <!-- But won't show "Load more", since we have a "View all closed" link below -->
-    <PagedIssueTable
+    <PagedIssueTableV1
       session-key="home-closed"
-      :issue-find="{
-        statusList: ['DONE', 'CANCELED'],
-        principalId: Number(currentUserUID),
+      method="LIST"
+      :issue-filter="{
+        ...commonIssueFilter,
+        statusList: [IssueStatus.DONE, IssueStatus.CANCELED],
+        principal: `users/${currentUserV1.email}`,
       }"
       :page-size="MAX_CLOSED_ISSUE"
       :hide-load-more="true"
     >
       <template #table="{ issueList, loading }">
-        <IssueTable
+        <IssueTableV1
           class="-mt-px"
-          :left-bordered="false"
-          :right-bordered="false"
           :show-placeholder="!loading"
           :title="$t('project.overview.recently-closed')"
-          :issue-list="issueList.filter(keywordAndEnvironmentFilter)"
+          :issue-list="issueList.filter(keywordFilter)"
+          :highlight-text="state.searchText"
         />
       </template>
-    </PagedIssueTable>
+    </PagedIssueTableV1>
   </div>
   <div class="w-full flex justify-end mt-2 px-4">
     <router-link
@@ -192,31 +188,19 @@
 
 <script lang="ts" setup>
 import { reactive, computed } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import IssueTableV1 from "@/components/IssueV1/components/IssueTableV1.vue";
+import PagedIssueTableV1 from "@/components/IssueV1/components/PagedIssueTableV1.vue";
+import WaitingForMyApprovalIssueTableV1 from "@/components/IssueV1/components/WaitingForMyApprovalIssueTableV1.vue";
+import { SearchBox } from "@/components/v2";
 import {
-  IssueTable,
-  PagedIssueTable,
-  WaitingForMyApprovalIssueTable,
-} from "@/components/Issue/table";
-import { EnvironmentTabFilter, SearchBox } from "@/components/v2";
-import {
-  useEnvironmentV1Store,
   useSubscriptionV1Store,
   useOnboardingStateStore,
   featureToRef,
   useCurrentUserV1,
 } from "@/store";
-import {
-  UNKNOWN_ID,
-  UNKNOWN_ENVIRONMENT_NAME,
-  Issue,
-  planTypeToString,
-} from "../types";
-import {
-  activeEnvironment,
-  extractUserUID,
-  isDatabaseRelatedIssueType,
-} from "../utils";
+import { IssueStatus } from "@/types/proto/v1/issue_service";
+import { ComposedIssue, IssueFilter, planTypeToString } from "../types";
+import { extractUserUID } from "../utils";
 
 interface LocalState {
   searchText: string;
@@ -226,11 +210,8 @@ interface LocalState {
 const OPEN_ISSUE_LIST_PAGE_SIZE = 10;
 const MAX_CLOSED_ISSUE = 5;
 
-const environmentV1Store = useEnvironmentV1Store();
 const subscriptionStore = useSubscriptionV1Store();
 const onboardingStateStore = useOnboardingStateStore();
-const router = useRouter();
-const route = useRoute();
 
 const state = reactive<LocalState>({
   searchText: "",
@@ -255,55 +236,21 @@ const planImage = computed(() => {
   ).href;
 });
 
-const selectedEnvironment = computed(() => {
-  const { environment } = route.query;
-  return environment
-    ? environmentV1Store.getEnvironmentByName(environment as string)
-    : undefined;
+const commonIssueFilter = computed((): IssueFilter => {
+  return {
+    project: "projects/-",
+    query: "",
+  };
 });
 
-const keywordAndEnvironmentFilter = (issue: Issue) => {
-  if (
-    selectedEnvironment.value &&
-    selectedEnvironment.value.uid !== String(UNKNOWN_ID)
-  ) {
-    if (!isDatabaseRelatedIssueType(issue.type)) {
-      return false;
-    }
-    if (
-      String(activeEnvironment(issue.pipeline).id) !==
-      selectedEnvironment.value.uid
-    ) {
-      return false;
-    }
-  }
+const keywordFilter = (issue: ComposedIssue) => {
   const keyword = state.searchText.trim().toLowerCase();
   if (keyword) {
-    if (!issue.name.toLowerCase().includes(keyword)) {
+    if (!issue.title.toLowerCase().includes(keyword)) {
       return false;
     }
   }
   return true;
-};
-
-const changeEnvironment = (environment: string | undefined) => {
-  if (environment && environment !== UNKNOWN_ENVIRONMENT_NAME) {
-    router.replace({
-      name: "workspace.home",
-      query: {
-        ...route.query,
-        environment,
-      },
-    });
-  } else {
-    router.replace({
-      name: "workspace.home",
-      query: {
-        ...route.query,
-        environment: undefined,
-      },
-    });
-  }
 };
 
 const changeSearchText = (searchText: string) => {


### PR DESCRIPTION
- Legacy [GET] /api/issues (issue list) endpoint has been migrated to IssueService.ListIssues and IssueService.SearchIssues
- No longer display `environment` and `progress` columns in issue list. Environment filter is also retired.
- Markdown editor's issue list has been migrated to `ComposedIssue` type.
- issueV1Store's `listIssues` and `searchIssues` now return shallow-composed issue list. By which "shallow-composed" means that their `planEntity`, `rolloutEntity`, `planCheckRunList`, `taskRunList` are empty.

FYI @RainbowDashy @ecmadao @d-bytebase 