### PR TITLE
refactor(frontend): migrate issue list batch status ops to v1 api

### DIFF
--- a/frontend/src/components/IssueV1/components/BatchIssueActionsV1.vue
+++ b/frontend/src/components/IssueV1/components/BatchIssueActionsV1.vue
@@ -1,9 +1,9 @@
 <template>
   <BBTooltipButton
     type="primary"
-    :disabled="!isTransitionApplicableForAllIssues('RESOLVE')"
+    :disabled="!isActionApplicableForAllIssues('RESOLVE')"
     tooltip-mode="DISABLED-ONLY"
-    @click="startBatchIssueTransition('RESOLVE')"
+    @click="startBatchIssueStatusAction('RESOLVE')"
   >
     {{ $t("issue.batch-transition.resolve") }}
     <template #tooltip>
@@ -19,9 +19,9 @@
 
   <BBTooltipButton
     type="normal"
-    :disabled="!isTransitionApplicableForAllIssues('CANCEL')"
+    :disabled="!isActionApplicableForAllIssues('CANCEL')"
     tooltip-mode="DISABLED-ONLY"
-    @click="startBatchIssueTransition('CANCEL')"
+    @click="startBatchIssueStatusAction('CANCEL')"
   >
     {{ $t("issue.batch-transition.cancel") }}
     <template #tooltip>
@@ -37,9 +37,9 @@
 
   <BBTooltipButton
     type="normal"
-    :disabled="!isTransitionApplicableForAllIssues('REOPEN')"
+    :disabled="!isActionApplicableForAllIssues('REOPEN')"
     tooltip-mode="DISABLED-ONLY"
-    @click="startBatchIssueTransition('REOPEN')"
+    @click="startBatchIssueStatusAction('REOPEN')"
   >
     {{ $t("issue.batch-transition.reopen") }}
     <template #tooltip>
@@ -53,106 +53,29 @@
     </template>
   </BBTooltipButton>
 
-  <BBModal
-    v-if="state.modal.show"
-    :title="state.modal.title"
-    class="relative overflow-hidden"
-    @close="state.modal.show = false"
-  >
-    <div
-      v-if="state.isRequesting"
-      class="absolute inset-0 flex flex-col items-center justify-center bg-white/70"
-    >
-      <BBSpin />
-      <div class="flex items-center textlabel">
-        <span>{{ $t("common.updating") }}</span>
-        <span v-if="state.stats"
-          >({{ state.stats.success }} / {{ state.stats.total }})</span
-        >
-      </div>
-    </div>
-
-    <div>
-      <div class="sm:col-span-4 w-112 min-w-full">
-        <label for="about" class="textlabel">
-          {{ $t("issue.status-transition.form.note") }}
-        </label>
-        <div class="mt-1">
-          <textarea
-            ref="commentTextArea"
-            v-model="state.modal.comment"
-            rows="3"
-            class="textarea block w-full resize-none mt-1 text-sm text-control rounded-md whitespace-pre-wrap"
-            :placeholder="$t('issue.status-transition.form.placeholder')"
-            @input="
-              (e) => {
-                sizeToFit(e.target as HTMLTextAreaElement);
-              }
-            "
-            @focus="
-              (e) => {
-                sizeToFit(e.target as HTMLTextAreaElement);
-              }
-            "
-          ></textarea>
-        </div>
-      </div>
-    </div>
-
-    <!-- Update button group -->
-    <div class="flex justify-end items-center pt-5">
-      <button
-        type="button"
-        class="btn-normal mt-3 px-4 py-2 sm:mt-0 sm:w-auto"
-        @click.prevent="state.modal.show = false"
-      >
-        {{ $t("common.cancel") }}
-      </button>
-      <button
-        type="button"
-        class="ml-3 px-4 py-2"
-        :class="state.modal.okButtonClass"
-        @click="doBatchIssueTransition(state.modal.transition!)"
-      >
-        {{ state.modal.okButtonText }}
-      </button>
-    </div>
-  </BBModal>
+  <BatchIssueStatusActionPanel
+    :issue-list="issueList"
+    :action="ongoingIssueStatusAction?.action"
+    @updating="state.isRequesting = true"
+    @updated="handleUpdated"
+    @close="ongoingIssueStatusAction = undefined"
+  />
 </template>
 
 <script lang="ts" setup>
-import { computed, PropType, reactive } from "vue";
+import { computed, PropType, reactive, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { pushNotification, refreshIssueList, useIssueStore } from "@/store";
-import type {
-  ComposedIssue,
-  IssueStatusPatch,
-  IssueStatusTransition,
-  IssueStatusTransitionType,
-} from "@/types";
-import { ISSUE_STATUS_TRANSITION_LIST } from "@/types";
-import { extractIssueUID } from "@/utils";
-import { calcApplicableIssueStatusTransitionList } from "../logic/transition";
-
-type RequestStats = {
-  total: number;
-  success: number;
-  failed: number;
-};
-
-type ModalProps = {
-  show: boolean;
-  title: string;
-  comment: string;
-  transition?: IssueStatusTransition;
-  okButtonText: string;
-  okButtonClass?: string;
-};
+import { refreshIssueList } from "@/store";
+import type { ComposedIssue } from "@/types";
+import {
+  getApplicableIssueStatusActionList,
+  IssueStatusAction,
+  issueStatusActionDisplayName,
+} from "../logic";
+import { BatchIssueStatusActionPanel } from "./Panel";
 
 type LocalState = {
   isRequesting: boolean;
-  modal: ModalProps;
-  stats?: RequestStats;
 };
 
 const props = defineProps({
@@ -164,91 +87,41 @@ const props = defineProps({
 
 const state = reactive<LocalState>({
   isRequesting: false,
-  modal: {
-    show: false,
-    title: "",
-    comment: "",
-    okButtonText: "",
-  },
 });
 
-const issueStore = useIssueStore();
 const { t } = useI18n();
 
-const issueTransitionList = computed(() => {
+const ongoingIssueStatusAction = ref<{
+  action: IssueStatusAction;
+  title: string;
+}>();
+
+const issueStatusActionList = computed(() => {
   return props.issueList.map((issue) => {
-    const transitions = calcApplicableIssueStatusTransitionList(issue);
-    return { issue, transitions };
+    const actions = getApplicableIssueStatusActionList(issue);
+    return { issue, actions };
   });
 });
 
-const isTransitionApplicableForAllIssues = (
-  type: IssueStatusTransitionType
-): boolean => {
-  return issueTransitionList.value.every((item) => {
-    return (
-      item.transitions.findIndex((transition) => transition.type === type) >= 0
-    );
+const isActionApplicableForAllIssues = (action: IssueStatusAction): boolean => {
+  return issueStatusActionList.value.every(({ actions }) => {
+    return actions.includes(action);
   });
 };
 
-const startBatchIssueTransition = (type: IssueStatusTransitionType) => {
-  const { modal } = state;
-  modal.show = true;
-  const transition = ISSUE_STATUS_TRANSITION_LIST.get(type)!;
-  modal.transition = transition;
-  modal.comment = "";
-  modal.okButtonClass = transition.buttonClass;
-  modal.okButtonText = t(transition.buttonName);
-  modal.title = t("issue.batch-transition.action-n-issues", {
-    action: t(`issue.batch-transition.${type.toLowerCase()}`),
-    n: props.issueList.length,
-  });
+const handleUpdated = () => {
+  state.isRequesting = false;
+  ongoingIssueStatusAction.value = undefined;
+  refreshIssueList();
 };
 
-const doBatchIssueTransition = async (transition: IssueStatusTransition) => {
-  const issueStatusPatch: IssueStatusPatch = {
-    status: transition.to,
-    comment: state.modal.comment,
+const startBatchIssueStatusAction = (action: IssueStatusAction) => {
+  ongoingIssueStatusAction.value = {
+    action,
+    title: t("issue.batch-transition.action-n-issues", {
+      action: issueStatusActionDisplayName(action),
+      n: props.issueList.length,
+    }),
   };
-
-  const stats = reactive<RequestStats>({
-    total: props.issueList.length,
-    success: 0,
-    failed: 0,
-  });
-
-  const doSingleIssueTransition = async (
-    issue: ComposedIssue,
-    index: number
-  ) => {
-    const request = issueStore.updateIssueStatus({
-      issueId: extractIssueUID(issue.name),
-      issueStatusPatch,
-    });
-    request.then(
-      () => stats.success++,
-      () => stats.failed++
-    );
-
-    return request;
-  };
-
-  state.isRequesting = true;
-  state.stats = stats;
-  try {
-    const requestList = props.issueList.map(doSingleIssueTransition);
-    await Promise.allSettled(requestList);
-    pushNotification({
-      module: "bytebase",
-      style: "SUCCESS",
-      title: t("issue.batch-transition.successfully-updated-n-issues", {
-        n: stats.success,
-      }),
-    });
-  } finally {
-    state.isRequesting = false;
-    refreshIssueList();
-  }
 };
 </script>

--- a/frontend/src/components/IssueV1/components/Panel/BatchIssueStatusActionPanel.vue
+++ b/frontend/src/components/IssueV1/components/Panel/BatchIssueStatusActionPanel.vue
@@ -1,0 +1,132 @@
+<template>
+  <CommonDrawer
+    :show="action !== undefined"
+    :title="title"
+    :loading="state.loading"
+    @show="comment = ''"
+    @close="$emit('close')"
+  >
+    <template #default>
+      <div v-if="action" class="flex flex-col gap-y-4 px-1">
+        <div class="flex flex-col gap-y-1">
+          <div class="font-medium text-control">
+            {{
+              issueList.length === 1 ? $t("common.issue") : $t("common.issues")
+            }}
+          </div>
+          <div class="textinfolabel">
+            <ul
+              class="flex flex-col"
+              :class="[issueList.length > 1 && 'list-disc pl-4']"
+            >
+              <li v-for="issue in issueList" :key="issue.uid">
+                {{ issue.title }}
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-y-1">
+          <p class="font-medium text-control">
+            {{ $t("common.comment") }}
+          </p>
+          <NInput
+            v-model:value="comment"
+            type="textarea"
+            :placeholder="$t('issue.leave-a-comment')"
+            :autosize="{
+              minRows: 3,
+              maxRows: 10,
+            }"
+          />
+        </div>
+      </div>
+    </template>
+    <template #footer>
+      <div v-if="action" class="flex justify-end gap-x-3">
+        <NButton @click="$emit('close')">
+          {{ $t("common.cancel") }}
+        </NButton>
+        <NButton
+          v-bind="issueStatusActionButtonProps(action)"
+          @click="handleConfirm(action, comment)"
+        >
+          {{ issueStatusActionDisplayName(action) }}
+        </NButton>
+      </div>
+    </template>
+  </CommonDrawer>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+  IssueStatusAction,
+  issueStatusActionButtonProps,
+  issueStatusActionDisplayName,
+  IssueStatusActionToIssueStatusMap,
+} from "@/components/IssueV1/logic";
+import { issueServiceClient } from "@/grpcweb";
+import { pushNotification } from "@/store";
+import { ComposedIssue } from "@/types";
+import CommonDrawer from "./CommonDrawer.vue";
+
+type LocalState = {
+  loading: boolean;
+};
+
+const props = defineProps<{
+  issueList: ComposedIssue[];
+  action?: IssueStatusAction;
+}>();
+
+const emit = defineEmits<{
+  (event: "updating"): void;
+  (event: "updated"): void;
+  (event: "close"): void;
+}>();
+
+const { t } = useI18n();
+const state = reactive<LocalState>({
+  loading: false,
+});
+const comment = ref("");
+
+const title = computed(() => {
+  const { action } = props;
+  if (!action) return "";
+
+  return t("issue.batch-transition.action-n-issues", {
+    action: issueStatusActionDisplayName(action),
+    n: props.issueList.length,
+  });
+});
+
+const handleConfirm = async (
+  action: IssueStatusAction,
+  comment: string | undefined
+) => {
+  state.loading = true;
+
+  try {
+    emit("updating");
+    await issueServiceClient.batchUpdateIssuesStatus({
+      parent: "projects/-",
+      issues: props.issueList.map((issue) => issue.name),
+      status: IssueStatusActionToIssueStatusMap[action],
+      reason: comment ?? "",
+    });
+
+    // notify the parent component that issues updated
+    pushNotification({
+      module: "bytebase",
+      style: "SUCCESS",
+      title: t("common.updated"),
+    });
+    emit("updated");
+  } finally {
+    state.loading = false;
+  }
+};
+</script>

--- a/frontend/src/components/IssueV1/components/Panel/index.ts
+++ b/frontend/src/components/IssueV1/components/Panel/index.ts
@@ -1,3 +1,4 @@
+import BatchIssueStatusActionPanel from "./BatchIssueStatusActionPanel.vue";
 import IssueReviewActionPanel from "./IssueReviewActionPanel.vue";
 import IssueStatusActionPanel from "./IssueStatusActionPanel.vue";
 import TaskRolloutActionPanel from "./TaskRolloutActionPanel.vue";
@@ -6,4 +7,5 @@ export {
   IssueStatusActionPanel,
   IssueReviewActionPanel,
   TaskRolloutActionPanel,
+  BatchIssueStatusActionPanel,
 };

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -16,6 +16,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTableV1
+          class="border-x-0"
           :show-placeholder="!loading"
           :title="$t('issue.waiting-approval')"
           :issue-list="issueList.filter(keywordFilter)"
@@ -37,7 +38,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTableV1
-          class="-mt-px"
+          class="-mt-px border-x-0"
           :show-placeholder="!loading"
           :title="$t('issue.waiting-rollout')"
           :issue-list="issueList.filter(keywordFilter)"
@@ -59,7 +60,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTableV1
-          class="-mt-px"
+          class="-mt-px border-x-0"
           :show-placeholder="!loading"
           :title="$t('common.created')"
           :issue-list="issueList.filter(keywordFilter)"
@@ -81,7 +82,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTableV1
-          class="-mt-px"
+          class="-mt-px border-x-0"
           :show-placeholder="!loading"
           :title="$t('common.subscribed')"
           :issue-list="issueList.filter(keywordFilter)"
@@ -105,7 +106,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTableV1
-          class="-mt-px"
+          class="-mt-px border-x-0"
           :show-placeholder="!loading"
           :title="$t('project.overview.recently-closed')"
           :issue-list="issueList.filter(keywordFilter)"

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -51,8 +51,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTableV1
-          :top-bordered="true"
-          :bottom-bordered="true"
+          class="border-x-0"
           :show-placeholder="!loading"
           :title="$t('issue.table.open')"
           :issue-list="issueList.filter(filter)"
@@ -74,9 +73,7 @@
     >
       <template #table="{ issueList, loading }">
         <IssueTableV1
-          class="-mt-px"
-          :top-bordered="true"
-          :bottom-bordered="true"
+          class="-mt-px border-x-0"
           :show-placeholder="!loading"
           :title="$t('issue.table.closed')"
           :issue-list="issueList.filter(filter)"


### PR DESCRIPTION
- `[PATCH] /api/issue/${issue_id}/status` now could be retired. FYI @d-bytebase @RainbowDashy 
- Batch issue status ops in the issue list is back! Plus the new drawer UI! FYI @ecmadao 

![localhost_3000_(1600_900)](https://github.com/bytebase/bytebase/assets/2749742/77ce2387-5dea-4637-8476-609c22cfaf87)
