### PR TITLE
chore: move SQL Editor link to the top right

### DIFF
--- a/frontend/src/locales/subscription/en-US.json
+++ b/frontend/src/locales/subscription/en-US.json
@@ -33,17 +33,17 @@
     "title": "Community",
     "try": "Start free trial",
     "free": {
-      "title": "Community Plan",
+      "title": "Community",
       "label": "",
       "desc": "Team essentials to manage database development lifecycle."
     },
     "team": {
-      "title": "Pro Plan",
+      "title": "Pro",
       "label": "",
       "desc": "More policies to standardize and facilitate collaboration across teams."
     },
     "enterprise": {
-      "title": "Enterprise Plan",
+      "title": "Enterprise",
       "label": "",
       "desc": "Extra security, compliance, and permission features. Dedicated support with SLA."
     }

--- a/frontend/src/locales/subscription/es-ES.json
+++ b/frontend/src/locales/subscription/es-ES.json
@@ -33,17 +33,17 @@
     "title": "Plan",
     "try": "Empezar la prueba gratuita",
     "free": {
-      "title": "Plan comunitario",
+      "title": "Comunitario",
       "label": "",
       "desc": "Elementos esenciales del equipo para centralizar la gestión del ciclo de vida de la base de datos."
     },
     "team": {
-      "title": "Plan Pro",
+      "title": "Pro",
       "label": "",
       "desc": "Más políticas para estandarizar y facilitar la colaboración entre equipos."
     },
     "enterprise": {
-      "title": "Plan Empresarial",
+      "title": "Empresarial",
       "label": "",
       "desc": "Funciones adicionales de seguridad, cumplimiento y permisos. Soporte dedicado con SLA."
     }

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -116,6 +116,13 @@
           <span class="hidden lg:block mr-2">{{ $t("common.want-help") }}</span>
           <heroicons-outline:chat-bubble-left-right class="w-4 h-4" />
         </div>
+        <a
+          href="/sql-editor"
+          target="_blank"
+          class="w-6 h-6"
+        >
+          <heroicons-solid:terminal class="w-6 h-6" />
+        </a>
         <router-link to="/inbox" exact-active-class="">
           <span
             v-if="inboxSummary.unread > 0"

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -116,11 +116,7 @@
           <span class="hidden lg:block mr-2">{{ $t("common.want-help") }}</span>
           <heroicons-outline:chat-bubble-left-right class="w-4 h-4" />
         </div>
-        <a
-          href="/sql-editor"
-          target="_blank"
-          class="w-6 h-6"
-        >
+        <a href="/sql-editor" target="_blank" class="w-6 h-6">
           <heroicons-solid:terminal class="w-6 h-6" />
         </a>
         <router-link to="/inbox" exact-active-class="">

--- a/frontend/src/views/DashboardSidebar.vue
+++ b/frontend/src/views/DashboardSidebar.vue
@@ -47,14 +47,6 @@
           <heroicons-outline:search class="h-4 w-4 text-control" />
         </button>
       </router-link>
-      <a
-        href="/sql-editor"
-        target="_blank"
-        class="outline-item group flex items-center px-2 py-1.5 capitalize"
-      >
-        <heroicons-solid:terminal class="w-5 h-5 mr-2" />
-        {{ $t("sql-editor.self") }}
-      </a>
       <router-link
         v-if="shouldShowSyncSchemaEntry"
         to="/sync-schema"


### PR DESCRIPTION
* SQL Editor is the only item that requires opening a new tab.
* Still need to make it available on all pages.
* Logically to make SQL Editor a more standalone component. The other items on the left sidebar and the incoming `Change Center` are more coherent.


![CleanShot 2023-09-17 at 12-22-56 png](https://github.com/bytebase/bytebase/assets/230323/18ad9da0-f054-435d-9ef9-3a7e340d7238)
