### PR TITLE
fix: the active tab style

### DIFF
--- a/frontend/src/bbkit/BBTab.vue
+++ b/frontend/src/bbkit/BBTab.vue
@@ -6,7 +6,7 @@
         :id="item.id"
         :key="index"
         :href="`#${item.id}`"
-        class="select-none cursor-pointer flex justify-between py-2 px-1 font-medium border-b-2 border-transparent whitespace-nowrap"
+        class="select-none cursor-pointer flex justify-between py-2 px-1 font-medium border-b-2 whitespace-nowrap"
         :class="tabClass(index == selectedIndex)"
         @click.self="selectTabIndex(index)"
         @mouseenter="state.hoverIndex = index"
@@ -102,7 +102,8 @@ const tabClass = (selected: boolean) => {
     return width + " text-control-hover border-accent";
   }
   return (
-    width + " text-control hover:text-control-hover hover:border-control-border"
+    width +
+    " border-transparent text-control hover:text-control-hover hover:border-control-border"
   );
 };
 


### PR DESCRIPTION
I guess this is caused by the package upgrade?

Before:
<img width="887" alt="CleanShot 2023-09-18 at 09 24 23@2x" src="https://github.com/bytebase/bytebase/assets/10706318/0cf4b4c6-4c0e-46cc-ac99-dd2ada6d83d8">

After:
<img width="883" alt="CleanShot 2023-09-18 at 09 24 01@2x" src="https://github.com/bytebase/bytebase/assets/10706318/ef161e69-e02a-4662-a2d6-8ea686077073">
