### PR TITLE
chore: remove tailwind line-clamp

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,7 +85,6 @@
     "@popperjs/core": "2.11.8",
     "@rollup/plugin-yaml": "4.1.1",
     "@tailwindcss/forms": "0.5.6",
-    "@tailwindcss/line-clamp": "0.4.4",
     "@tailwindcss/typography": "0.5.10",
     "@trivago/prettier-plugin-sort-imports": "^4.2.0",
     "@types/canvas-confetti": "1.6.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -214,9 +214,6 @@ devDependencies:
   '@tailwindcss/forms':
     specifier: 0.5.6
     version: 0.5.6(tailwindcss@3.3.3)
-  '@tailwindcss/line-clamp':
-    specifier: 0.4.4
-    version: 0.4.4(tailwindcss@3.3.3)
   '@tailwindcss/typography':
     specifier: 0.5.10
     version: 0.5.10(tailwindcss@3.3.3)
@@ -1154,14 +1151,6 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.3.3
-    dev: true
-
-  /@tailwindcss/line-clamp@0.4.4(tailwindcss@3.3.3):
-    resolution: {integrity: sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==}
-    peerDependencies:
-      tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
-    dependencies:
       tailwindcss: 3.3.3
     dev: true
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -114,9 +114,5 @@ module.exports = {
       textColor: ["disabled"],
     },
   },
-  plugins: [
-    require("@tailwindcss/forms"),
-    require("@tailwindcss/line-clamp"),
-    require("@tailwindcss/typography"),
-  ],
+  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
Remove the unused plugin `@tailwindcss/line-clamp` as it's included in the framework by default after tailwindcss v3.

Reference: https://github.com/tailwindlabs/tailwindcss-line-clamp#tailwindcssline-clamp