### PR TITLE
chore: deprecate legacy issue type with DML

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -347,17 +347,9 @@ func (s *IssueService) SearchIssues(ctx context.Context, request *v1pb.SearchIss
 			if spec.operator != comparatorTypeEqual {
 				return nil, status.Errorf(codes.InvalidArgument, `only support "=" operation for "level" filter`)
 			}
-			if spec.value == "DDL" {
-				issueFind.TypeList = append(
-					issueFind.TypeList,
-					api.IssueDatabaseCreate,
-					api.IssueDatabaseSchemaUpdate,
-					api.IssueDatabaseSchemaUpdateGhost,
-					api.IssueDatabaseRestorePITR,
-					api.IssueDatabaseGeneral,
-				)
-			} else if spec.value == "DML" {
-				issueFind.TypeList = append(issueFind.TypeList, api.IssueDatabaseDataUpdate)
+			// TODO(p0ny): fix it with the right type.
+			if spec.value == "DDL" || spec.value == "DML" {
+				issueFind.TypeList = append(issueFind.TypeList, api.IssueDatabaseGeneral)
 			} else {
 				return nil, status.Errorf(codes.InvalidArgument, `unknown value "%s"`, spec.value)
 			}
@@ -1533,12 +1525,10 @@ func convertToIssue(ctx context.Context, s *store.Store, issue *store.IssueMessa
 
 func convertToIssueType(t api.IssueType) v1pb.Issue_Type {
 	switch t {
-	case api.IssueDatabaseCreate, api.IssueDatabaseSchemaUpdate, api.IssueDatabaseSchemaUpdateGhost, api.IssueDatabaseDataUpdate, api.IssueDatabaseRestorePITR, api.IssueDatabaseGeneral:
+	case api.IssueDatabaseGeneral:
 		return v1pb.Issue_DATABASE_CHANGE
 	case api.IssueGrantRequest:
 		return v1pb.Issue_GRANT_REQUEST
-	case api.IssueGeneral:
-		return v1pb.Issue_TYPE_UNSPECIFIED
 	default:
 		return v1pb.Issue_TYPE_UNSPECIFIED
 	}

--- a/backend/legacyapi/issue.go
+++ b/backend/legacyapi/issue.go
@@ -21,18 +21,6 @@ const (
 type IssueType string
 
 const (
-	// IssueGeneral is the issue type for general issues.
-	IssueGeneral IssueType = "bb.issue.general"
-	// IssueDatabaseCreate is the issue type for creating databases.
-	IssueDatabaseCreate IssueType = "bb.issue.database.create"
-	// IssueDatabaseSchemaUpdate is the issue type for updating database schemas (DDL).
-	IssueDatabaseSchemaUpdate IssueType = "bb.issue.database.schema.update"
-	// IssueDatabaseSchemaUpdateGhost is the issue type for updating database schemas using gh-ost.
-	IssueDatabaseSchemaUpdateGhost IssueType = "bb.issue.database.schema.update.ghost"
-	// IssueDatabaseDataUpdate is the issue type for updating database data (DML).
-	IssueDatabaseDataUpdate IssueType = "bb.issue.database.data.update"
-	// IssueDatabaseRestorePITR is the issue type for performing a Point-in-time Recovery.
-	IssueDatabaseRestorePITR IssueType = "bb.issue.database.restore.pitr"
 	// IssueGrantRequest is the issue type for requesting grant.
 	IssueGrantRequest IssueType = "bb.issue.grant.request"
 

--- a/backend/migrator/migration/prod/2.8/0004##issue_type.sql
+++ b/backend/migrator/migration/prod/2.8/0004##issue_type.sql
@@ -1,0 +1,7 @@
+ALTER TABLE issue DISABLE TRIGGER update_issue_updated_ts;
+
+UPDATE issue
+SET type = 'bb.issue.database.general'
+WHERE type IN ('bb.issue.database.create', 'bb.issue.database.schema.update', 'bb.issue.database.schema.update.ghost', 'bb.issue.database.data.update', 'bb.issue.database.restore.pitr');
+
+ALTER TABLE issue ENABLE TRIGGER update_issue_updated_ts;

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -241,5 +241,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("2.8.3"), releaseVersion)
+	require.Equal(t, semver.MustParse("2.8.4"), releaseVersion)
 }

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -334,8 +334,6 @@ func getIssueRisk(ctx context.Context, s *store.Store, licenseService enterprise
 	switch issue.Type {
 	case api.IssueGrantRequest:
 		return getGrantRequestIssueRisk(ctx, s, issue, risks)
-	case api.IssueGeneral, api.IssueDatabaseCreate, api.IssueDatabaseSchemaUpdate, api.IssueDatabaseSchemaUpdateGhost, api.IssueDatabaseDataUpdate, api.IssueDatabaseRestorePITR:
-		return 0, store.RiskSourceDatabaseSchemaUpdate, true, nil
 	case api.IssueDatabaseGeneral:
 		return getDatabaseGeneralIssueRisk(ctx, s, licenseService, dbFactory, issue, risks)
 	default:


### PR DESCRIPTION
Note: we will still keep the legacy issue type in deployment policy. We will fix CD policy in the future.