### PR TITLE
chore: remove sync status from database list

### DIFF
--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseTableRow.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseTableRow.vue
@@ -17,23 +17,6 @@
         :can-remove="false"
         class="text-xs"
       />
-      <NTooltip
-        v-if="!showMiscColumn && database.syncState !== State.ACTIVE"
-        placement="right"
-      >
-        <template #trigger>
-          <heroicons-outline:exclamation-circle class="w-5 h-5 text-error" />
-        </template>
-
-        <div class="whitespace-nowrap">
-          {{
-            $t("database.last-sync-status-long", [
-              "NOT_FOUND",
-              humanizeDate(database.successfulSyncTime),
-            ])
-          }}
-        </div>
-      </NTooltip>
     </div>
   </div>
   <div v-if="showEnvironmentColumn" class="bb-grid-cell">
@@ -60,48 +43,6 @@
       tag="div"
     />
   </div>
-  <div v-if="showMiscColumn" class="bb-grid-cell">
-    <div class="w-full flex justify-center">
-      <NTooltip placement="left">
-        <template #trigger>
-          <div
-            class="flex items-center justify-center rounded-full select-none w-5 h-5 overflow-hidden text-white font-medium text-base"
-            :class="
-              database.syncState === State.ACTIVE ? 'bg-success' : 'bg-error'
-            "
-          >
-            <template v-if="database.syncState === State.ACTIVE">
-              <heroicons-solid:check class="w-4 h-4" />
-            </template>
-            <template v-else>
-              <span
-                class="h-2 w-2 flex items-center justify-center"
-                aria-hidden="true"
-                >!</span
-              >
-            </template>
-          </div>
-        </template>
-
-        <span>
-          <template v-if="database.syncState === State.ACTIVE">
-            {{
-              $t("database.synced-at", {
-                time: humanizeDate(database.successfulSyncTime),
-              })
-            }}
-          </template>
-          <template v-else>
-            {{
-              $t("database.not-found-last-successful-sync-was", {
-                time: humanizeDate(database.successfulSyncTime),
-              })
-            }}
-          </template>
-        </span>
-      </NTooltip>
-    </div>
-  </div>
 </template>
 
 <script lang="ts" setup>
@@ -109,7 +50,6 @@ import { computed } from "vue";
 import { InstanceV1Name, EnvironmentV1Name } from "@/components/v2";
 import { useEnvironmentV1Store } from "@/store";
 import { ComposedDatabase } from "@/types";
-import { State } from "@/types/proto/v1/common";
 import { isPITRDatabaseV1 } from "@/utils";
 import ProjectCol from "./ProjectCol.vue";
 

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
@@ -326,20 +326,12 @@ const columnListMap = computed(() => {
     title: t("common.instance"),
     width: "minmax(auto, 1fr)",
   };
-  const SYNC_STATUS = {
-    title: t("database.sync-status"),
-    width: "auto",
-    class: "items-center",
-  };
   return new Map<Mode, (BBGridColumn | undefined)[]>([
-    [
-      "ALL",
-      [NAME, ENVIRONMENT, SCHEMA_VERSION, PROJECT, INSTANCE, SYNC_STATUS],
-    ],
+    ["ALL", [NAME, ENVIRONMENT, SCHEMA_VERSION, PROJECT, INSTANCE]],
     ["ALL_SHORT", [NAME, ENVIRONMENT, SCHEMA_VERSION, PROJECT, INSTANCE]],
     ["ALL_TINY", [NAME, ENVIRONMENT, PROJECT, INSTANCE]],
-    ["INSTANCE", [NAME, ENVIRONMENT, SCHEMA_VERSION, PROJECT, SYNC_STATUS]],
-    ["PROJECT", [NAME, ENVIRONMENT, SCHEMA_VERSION, INSTANCE, SYNC_STATUS]],
+    ["INSTANCE", [NAME, ENVIRONMENT, SCHEMA_VERSION, PROJECT]],
+    ["PROJECT", [NAME, ENVIRONMENT, SCHEMA_VERSION, INSTANCE]],
     ["PROJECT_SHORT", [NAME, ENVIRONMENT, SCHEMA_VERSION, INSTANCE]],
   ]);
 });


### PR DESCRIPTION
We always show active databases so the column was unnecessary.