### PR TITLE
chore: adjust chunkSizeWarningLimit

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig(() => {
           "explain-visualizer": resolve(__dirname, "explain-visualizer.html"),
         },
       },
+      chunkSizeWarningLimit: 1600,
     },
     server: {
       port: SERVER_PORT,


### PR DESCRIPTION
#72 CANCELED
------
 > [linux/arm64 frontend 9/9] RUN pnpm "release-docker":
#66 91.91 dist/assets/errorMessage-f72ee830.js                                                            2,005.51 kB │ gzip:   519.16 kB
#66 91.91 dist/assets/explain-visualizer-25d54b76.js                                                      2,045.82 kB │ gzip:   719.37 kB
#66 91.91 dist/assets/main-7e06a445.js                                                                    4,729.29 kB │ gzip: 1,150.55 kB
#66 91.91 
#66 91.91 (!) Some chunks are larger than 500 kBs after minification. Consider:
#66 91.91 - Using dynamic import() to code-split the application
#66 91.91 - Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
#66 91.91 - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
#66 91.92 ✓ built in 1m 30s
#66 120.6 Aborted (core dumped)