### PR TITLE
fix: create personal draft baseline schema

### DIFF
--- a/backend/api/v1/schema_design_service.go
+++ b/backend/api/v1/schema_design_service.go
@@ -176,18 +176,11 @@ func (s *SchemaDesignService) CreateSchemaDesign(ctx context.Context, request *v
 	if schemaDesignType == storepb.SheetPayload_SchemaDesign_MAIN_BRANCH {
 		schemaDesignSheetPayload.SchemaDesign.BaselineSheetId = fmt.Sprintf("%d", baselineSheetUID)
 	} else if schemaDesignType == storepb.SheetPayload_SchemaDesign_PERSONAL_DRAFT {
-		// Create a new sheet to save the baseline full schema of the personal draft schema design.
-		baselineSheet, err := s.getSheet(ctx, &store.FindSheetMessage{
-			UID: &baselineSheetUID,
-		})
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, fmt.Sprintf("failed to get sheet: %v", err))
-		}
 		baselineSheetCreate := &store.SheetMessage{
 			Name:        schemaDesign.Title,
 			ProjectUID:  project.UID,
 			DatabaseUID: &database.UID,
-			Statement:   baselineSheet.Statement,
+			Statement:   schemaDesign.BaselineSchema,
 			Visibility:  store.ProjectSheet,
 			Source:      store.SheetFromBytebaseArtifact,
 			Type:        store.SheetForSQL,

--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -105,9 +105,9 @@
   </div>
 
   <MergeBranchPanel
-    v-if="state.showDiffEditor"
-    :source-branch-name="state.schemaDesignName"
-    :target-branch-name="schemaDesign.baselineSheetName"
+    v-if="state.showDiffEditor && mergeBranchPanelContext"
+    :source-branch-name="mergeBranchPanelContext.sourceBranchName"
+    :target-branch-name="mergeBranchPanelContext.targetBranchName"
     @dismiss="state.showDiffEditor = false"
     @merged="handleMergeAfterConflictResolved"
   />
@@ -175,6 +175,10 @@ const state = reactive<LocalState>({
   isEditingTitle: false,
   showDiffEditor: false,
 });
+const mergeBranchPanelContext = ref<{
+  sourceBranchName: string;
+  targetBranchName: string;
+}>();
 const schemaEditorKey = ref<string>(uniqueId());
 
 const schemaDesign = computed(() => {
@@ -381,9 +385,12 @@ const handleSaveBranch = async () => {
             closable: true,
             maskClosable: true,
             closeOnEsc: true,
-            onNegativeClick: () => {},
             onPositiveClick: () => {
               state.showDiffEditor = true;
+              mergeBranchPanelContext.value = {
+                sourceBranchName: newBranch.name,
+                targetBranchName: schemaDesign.value.name,
+              };
             },
           });
         } else {

--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -365,6 +365,7 @@ const handleSaveBranch = async () => {
       const branchName = generateForkedBranchName(schemaDesign.value);
       const newBranch = await schemaDesignStore.createSchemaDesignDraft({
         ...schemaDesign.value,
+        baselineSchema: schemaDesign.value.schema,
         schemaMetadata: mergedMetadata,
         title: branchName,
       });
@@ -406,6 +407,8 @@ const handleSaveBranch = async () => {
 
       // Delete the draft after merged.
       await schemaDesignStore.deleteSchemaDesign(newBranch.name);
+      // Fetch the latest schema design after merged.
+      await schemaDesignStore.fetchSchemaDesignByName(schemaDesign.value.name);
     } else {
       await schemaDesignStore.updateSchemaDesign(
         SchemaDesign.fromPartial({


### PR DESCRIPTION
As we'll create draft branches when saving edits, we should use the baseline schema from api not the latest schema of parent branch.

Frontend changes: https://github.com/bytebase/bytebase/pull/8445

FYI @tianzhou 