### PR TITLE
chore: fix document error

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,7 @@ Below diagram describes a typical mapping between an engineering org and the cor
 1. Start backend using air (with live reload).
 
    ```bash
-   PG_URL=postgresql://bbdev@localhost/bbdev
-   air -c scripts/.air.toml
+   PG_URL=postgresql://bbdev@localhost/bbdev air -c scripts/.air.toml
    ```
 
    Change the open file limit if you encounter "error: too many open files".


### PR DESCRIPTION
```bash
   PG_URL=postgresql://bbdev@localhost/bbdev
   air -c scripts/.air.toml
```
The command doesn't work in my MacOS and uses embed pg. I tried `PG_URL=postgresql://bbdev@localhost/bbdev air -c scripts/.air.toml`. It working well! So I change the document.


And I also find the database need a password. otherwise it will throw a error like :
```
time=2023-09-28T15:00:57.270+08:00 level=ERROR source=cmd/root.go:255 msg="Cannot new server" error="cannot open metadb: failed to get max_connections from metaDB: failed to connect to `host=localhost user=bbdev database=bbdev`: failed SASL auth (FATAL: password authentication failed for user \"bbdev\" (SQLSTATE 28P01))
```
But I can't sure the problem caused by my pg or a document error. If it is indeed a document error, I will submit a new PR to fix it.

