### PR TITLE
fix: schema editor column table ui

### DIFF
--- a/frontend/src/components/SchemaEditorV1/Panels/TableColumnEditor.vue
+++ b/frontend/src/components/SchemaEditorV1/Panels/TableColumnEditor.vue
@@ -169,7 +169,7 @@
             <heroicons:pencil-square class="w-4 h-auto text-gray-400" />
           </button>
         </div>
-        <div class="w-full flex justify-start items-center">
+        <div class="table-body-item-container flex justify-end items-center">
           <template v-if="!readonly">
             <n-tooltip v-if="!isDroppedColumn(column)" trigger="hover">
               <template #trigger>
@@ -288,38 +288,46 @@ const columnHeaderList = computed(() => {
     {
       key: "name",
       label: t("schema-editor.column.name"),
+      class: "6rem",
     },
     {
       key: "type",
       label: t("schema-editor.column.type"),
+      class: "minmax(0,_0.8fr)",
     },
     {
       key: "default",
       label: t("schema-editor.column.default"),
+      class: "minmax(0,_0.8fr)",
     },
     {
       key: "comment",
       label: t("schema-editor.column.comment"),
+      class: "minmax(0,_0.8fr)",
     },
     {
       key: "nullable",
       label: t("schema-editor.column.not-null"),
+      class: "80px",
     },
     {
       key: "primary",
       label: t("schema-editor.column.primary"),
+      class: "80px",
     },
   ];
   if (classificationConfig.value) {
     list.splice(1, 0, {
       key: "classification",
       label: t("schema-editor.column.classification"),
+      class: "minmax(0,_1.5fr)",
     });
   }
   if (props.showForeignKey) {
     list.push({
       key: "foreign_key",
       label: t("schema-editor.column.foreign-key"),
+      class: "minmax(0,_7rem)",
     });
   }
 
@@ -327,10 +335,9 @@ const columnHeaderList = computed(() => {
 });
 
 const gridColumnClass = computed(() => {
-  if (props.showForeignKey) {
-    return "grid-cols-[6rem_minmax(0,_1.5fr)_repeat(3,_minmax(0,_0.8fr))_repeat(2,_80px)_minmax(0,_7rem)_20px]";
-  }
-  return "grid-cols-[6rem_minmax(0,_1.5fr)_repeat(3,_minmax(0,_0.8fr))_repeat(2,_80px)_20px]";
+  return `grid-cols-[${columnHeaderList.value
+    .map((col) => col.class)
+    .join("_")}_20px]`;
 });
 
 const shownColumnList = computed(() => {


### PR DESCRIPTION
Before:
<img width="993" alt="img_v2_da2a11cd-2706-4117-9c7c-2609123fd18g" src="https://github.com/bytebase/bytebase/assets/10706318/0742e00a-67b6-4367-bc60-69a6fcd04127">

After:
<img width="901" alt="CleanShot 2023-09-28 at 21 32 04@2x" src="https://github.com/bytebase/bytebase/assets/10706318/9098c920-e1fb-4fb0-a1bf-f75027b89582">
