### PR TITLE
chore: include SqlReviewReport as query/export error detail

### DIFF
--- a/backend/plugin/parser/pg/query.go
+++ b/backend/plugin/parser/pg/query.go
@@ -32,6 +32,11 @@ func init() {
 func ValidateSQLForEditor(statement string) (bool, error) {
 	stmtList, err := pgrawparser.Parse(pgrawparser.ParseContext{}, statement)
 	if err != nil {
+		// Parse error again for getting a better error message.
+		_, syntaxError := ParsePostgreSQL(statement)
+		if syntaxError != nil {
+			return false, syntaxError
+		}
 		return false, err
 	}
 	for _, stmt := range stmtList {

--- a/backend/plugin/parser/tidb/tidb.go
+++ b/backend/plugin/parser/tidb/tidb.go
@@ -1,6 +1,8 @@
 package tidb
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 
 	tidbparser "github.com/pingcap/tidb/parser"
@@ -10,6 +12,7 @@ import (
 	// The packege parser_driver has to be imported.
 	_ "github.com/pingcap/tidb/types/parser_driver"
 
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/backend/plugin/parser/tokenizer"
 )
 
@@ -22,7 +25,35 @@ func ParseTiDB(sql string, charset string, collation string) ([]ast.StmtNode, er
 	p.EnableWindowFunc(true)
 
 	nodes, _, err := p.Parse(sql, charset, collation)
-	return nodes, err
+	return nodes, convertParserError(err)
+}
+
+var (
+	lineColumnRegex = regexp.MustCompile(`line (\d+) column (\d+)`)
+)
+
+func convertParserError(parserErr error) error {
+	// line 1 column 15 near "TO world;"
+	res := lineColumnRegex.FindAllStringSubmatch(parserErr.Error(), -1)
+	if len(res) != 1 {
+		return parserErr
+	}
+	if len(res[0]) != 3 {
+		return parserErr
+	}
+	line, err := strconv.Atoi(res[0][1])
+	if err != nil {
+		return parserErr
+	}
+	column, err := strconv.Atoi(res[0][2])
+	if err != nil {
+		return parserErr
+	}
+	return &base.SyntaxError{
+		Line:    line,
+		Column:  column,
+		Message: parserErr.Error(),
+	}
 }
 
 // SetLineForMySQLCreateTableStmt sets the line for columns and table constraints in MySQL CREATE TABLE statments.

--- a/backend/plugin/parser/tidb/tidb.go
+++ b/backend/plugin/parser/tidb/tidb.go
@@ -25,7 +25,10 @@ func ParseTiDB(sql string, charset string, collation string) ([]ast.StmtNode, er
 	p.EnableWindowFunc(true)
 
 	nodes, _, err := p.Parse(sql, charset, collation)
-	return nodes, convertParserError(err)
+	if err != nil {
+		return nil, convertParserError(err)
+	}
+	return nodes, nil
 }
 
 var (

--- a/backend/plugin/parser/tidb/tidb_test.go
+++ b/backend/plugin/parser/tidb/tidb_test.go
@@ -7,6 +7,8 @@ import (
 	tidbparser "github.com/pingcap/tidb/parser"
 	tidbast "github.com/pingcap/tidb/parser/ast"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
 type setLineTestData struct {
@@ -110,4 +112,14 @@ func TestMySQLCreateTableSetLine(t *testing.T) {
 			require.Equal(t, cons.OriginTextPosition(), test.constraintLineList[i], i)
 		}
 	}
+}
+
+func TestTiDBParserError(t *testing.T) {
+	_, err := ParseTiDB("SELECT hello TO world;", "", "")
+	require.Error(t, err)
+	syntaxErr, ok := err.(*base.SyntaxError)
+	require.True(t, ok)
+	require.Equal(t, 1, syntaxErr.Line)
+	require.Equal(t, 15, syntaxErr.Column)
+	require.Equal(t, `line 1 column 15 near "TO world;" `, syntaxErr.Message)
 }


### PR DESCRIPTION
Also converted tidb and postgres parser error to base.SyntaxError so that we know which line and column hits the error.