### PR TITLE
fix: always allow to unset the OpenAI settings

### DIFF
--- a/frontend/src/components/GeneralSetting/AIAugmentationSetting.vue
+++ b/frontend/src/components/GeneralSetting/AIAugmentationSetting.vue
@@ -175,7 +175,9 @@ const handleOpenAIEndpointChange = (event: InputEvent) => {
 };
 
 const updateOpenAIKeyEndpoint = async () => {
-  if (!hasFeature("bb.feature.plugin.openai")) {
+  // Always allow to unset the key.
+  const isUnset = state.openAIKey === "" && state.openAIEndpoint === "";
+  if (!isUnset && !hasFeature("bb.feature.plugin.openai")) {
     state.showFeatureModal = true;
     return;
   }


### PR DESCRIPTION
Otherwise, there is no way to unset it in non-enterprise version and will always see the upgrade required banner