### PR TITLE
feat(sql-editor): cancel query

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2062,7 +2062,8 @@
       "database-labels": "{database} labels",
       "database-has-no-label": "{database} has no label",
       "description": "Batch query {count} additional databases with the same label values."
-    }
+    },
+    "executing-query": "Executing query"
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2058,7 +2058,8 @@
       "database-labels": "Etiquetas de {database}",
       "database-has-no-label": "{database} no tiene etiquetas",
       "description": "Consulta por lotes bases de datos adicionales con los mismos valores de etiqueta."
-    }
+    },
+    "executing-query": "Ejecutando consulta"
   },
   "schema-editor": {
     "self": "Editor de esquema",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2057,7 +2057,8 @@
       "database-labels": "{database} 标签",
       "database-has-no-label": "{database} 没有标签",
       "description": "批量查询具有相同标签值的其他数据库。"
-    }
+    },
+    "executing-query": "执行查询"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/store/modules/sqlEditor.ts
+++ b/frontend/src/store/modules/sqlEditor.ts
@@ -35,20 +35,26 @@ export const useSQLEditorStore = defineStore("sqlEditor", {
     setIsFetchingQueryHistory(payload: boolean) {
       this.isFetchingQueryHistory = payload;
     },
-    async executeQuery({
-      instanceId,
-      databaseName,
-      statement,
-    }: Pick<QueryInfo, "instanceId" | "databaseName" | "statement">) {
+    async executeQuery(
+      {
+        instanceId,
+        databaseName,
+        statement,
+      }: Pick<QueryInfo, "instanceId" | "databaseName" | "statement">,
+      signal: AbortSignal
+    ) {
       const instance = useInstanceV1Store().getInstanceByUID(
         String(instanceId)
       );
-      const response = await useSQLStore().queryReadonly({
-        name: instance.name,
-        connectionDatabase: databaseName || "",
-        statement,
-        limit: RESULT_ROWS_LIMIT,
-      });
+      const response = await useSQLStore().queryReadonly(
+        {
+          name: instance.name,
+          connectionDatabase: databaseName || "",
+          statement,
+          limit: RESULT_ROWS_LIMIT,
+        },
+        signal
+      );
 
       return response;
     },

--- a/frontend/src/store/modules/v1/sql.ts
+++ b/frontend/src/store/modules/v1/sql.ts
@@ -41,7 +41,8 @@ const getSqlReviewReports = (err: unknown): Advice[] => {
 
 export const useSQLStore = defineStore("sql", () => {
   const queryReadonly = async (
-    params: QueryRequest
+    params: QueryRequest,
+    signal: AbortSignal
   ): Promise<SQLResultSetV1> => {
     try {
       const response = await sqlServiceClient.query(params, {
@@ -49,6 +50,7 @@ export const useSQLStore = defineStore("sql", () => {
         // errors manually.
         ignoredCodes: [Status.PERMISSION_DENIED],
         silent: true,
+        signal,
       });
 
       return {

--- a/frontend/src/types/tab.ts
+++ b/frontend/src/types/tab.ts
@@ -29,6 +29,11 @@ export interface BatchQueryContext {
   selectedLabels: string[];
 }
 
+export type QueryContext = {
+  beginTimestampMS: number;
+  abortController: AbortController;
+};
+
 export interface TabInfo {
   id: string;
   name: string;
@@ -49,6 +54,8 @@ export interface TabInfo {
   isFreshNew?: boolean;
   // batchQueryContext saves the context of batch query, including the selected labels.
   batchQueryContext?: BatchQueryContext;
+  // queryContext saves the context of a query, including beginTimestampMS and abortController
+  queryContext?: QueryContext;
   // databaseQueryResultMap is used to store the query result of each database.
   // It's used for the case that the user selects multiple databases to query.
   // The key is the databaseName. Format: instances/{instance}/databases/{database}

--- a/frontend/src/views/sql-editor/ResultPanel/ResultPanel.vue
+++ b/frontend/src/views/sql-editor/ResultPanel/ResultPanel.vue
@@ -4,13 +4,27 @@
     :class="loading && 'bg-white/80 dark:bg-black/80'"
   >
     <template v-if="loading">
-      <div class="w-full h-full flex flex-col justify-center items-center">
-        <BBSpin />
-        {{ $t("sql-editor.loading-data") }}
+      <div
+        class="w-full h-full flex flex-col justify-center items-center text-sm gap-y-1"
+      >
+        <div class="flex flex-row gap-x-1">
+          <BBSpin />
+          <span>{{ $t("sql-editor.executing-query") }}</span>
+          <span>-</span>
+          <!-- use mono font to prevent the UI jitters frequently -->
+          <span class="font-mono">{{ queryElapsedTime }}</span>
+        </div>
+        <div>
+          <NButton size="small" @click="cancelQuery">
+            {{ $t("common.cancel") }}
+          </NButton>
+        </div>
       </div>
     </template>
     <template v-else-if="!selectedResultSet">
-      <div class="w-full h-full flex flex-col justify-center items-center">
+      <div
+        class="w-full h-full flex flex-col justify-center items-center text-sm"
+      >
         <span>{{ $t("sql-editor.table-empty-placeholder") }}</span>
       </div>
     </template>
@@ -59,6 +73,7 @@
 </template>
 
 <script lang="ts" setup>
+import { useTimestamp } from "@vueuse/core";
 import { head } from "lodash-es";
 import { Info } from "lucide-vue-next";
 import { NButton, NTooltip } from "naive-ui";
@@ -86,10 +101,28 @@ const selectedResultSet = computed(() => {
 });
 const executeParams = computed(() => tabStore.currentTab.executeParams);
 const loading = computed(() => tabStore.currentTab.isExecutingSQL);
+const currentTimestampMS = useTimestamp();
+const queryElapsedTime = computed(() => {
+  if (!loading.value) return "";
+  const tab = tabStore.currentTab;
+  const { isExecutingSQL, queryContext } = tab;
+  if (!isExecutingSQL) return "";
+  if (!queryContext) return;
+  const beginMS = queryContext.beginTimestampMS;
+  const elapsedMS = currentTimestampMS.value - beginMS;
+  return `${(elapsedMS / 1000).toFixed(1)}s`;
+});
 
 const isDatabaseQueryFailed = (database: ComposedDatabase) => {
   return tabStore.currentTab.databaseQueryResultMap?.get(database.name || "")
     ?.error;
+};
+
+const cancelQuery = () => {
+  const { queryContext } = tabStore.currentTab;
+  if (!queryContext) return;
+  const { abortController } = queryContext;
+  abortController?.abort();
 };
 
 // Auto select the first database when the databases are ready.

--- a/frontend/src/views/sql-editor/SecondarySidebar/InfoTabPane/SchemaPanel/DatabaseSchema.vue
+++ b/frontend/src/views/sql-editor/SecondarySidebar/InfoTabPane/SchemaPanel/DatabaseSchema.vue
@@ -7,7 +7,7 @@
         @click="handleClickHeader"
       >
         <heroicons-outline:database class="h-4 w-4 mr-1 flex-shrink-0" />
-        <span class="text-sm">{{ databaseMetadata.name }}</span>
+        <span class="text-sm">{{ database.databaseName }}</span>
       </div>
       <div class="flex justify-end gap-x-0.5">
         <SchemaDiagramButton


### PR DESCRIPTION
- Show an execution timer
- Allow to cancel a query
- Once any one of a batch queries is aborted, the rest of the queries won't execute and will mock an "Aborted blah blah" result for them as if they have been really aborted. But the queries that are already finished will still be displayed.

![localhost_3000_sql-editor_example-mysql-8-113_employee-353(1600_900) (3)](https://github.com/bytebase/bytebase/assets/2749742/ec963d39-97c8-41bc-93bc-fb62d70389c3)

<img width="379" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/d1307af1-3548-4746-a21a-eca83c63bd1d">

Close BYT-4149
