### PR TITLE
chore: remove learn more link in batch query

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/BatchQueryDatabasesSelector.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/BatchQueryDatabasesSelector.vue
@@ -27,16 +27,12 @@
     </template>
     <div class="w-128 max-h-128 overflow-y-auto p-1 pb-2">
       <p class="text-gray-500 mb-1 w-full leading-4">
-        <span class="mr-1">{{
+        {{
           $t("sql-editor.batch-query.description", {
             count: selectedDatabaseNames.length,
             project: project.title,
           })
-        }}</span>
-        <LearnMoreLink
-          url="https://www.bytebase.com/docs/sql-editor/batch-query?source=console"
-          class="text-sm"
-        />
+        }}
       </p>
       <div class="w-full flex flex-col justify-start items-start">
         <template v-if="databases.length > 0">


### PR DESCRIPTION
It’s now quite straightforward and no need to hint user to check further