### PR TITLE
feat: use bb stacktrace to replace debug.Stack()

### DIFF
--- a/backend/common/log/slog_utils.go
+++ b/backend/common/log/slog_utils.go
@@ -48,7 +48,7 @@ func BBError(err error) slog.Attr {
 }
 
 func BBStack(key string) slog.Attr {
-	stack := stacktrace.TakeStacktrace(20, 3)
+	stack := stacktrace.TakeStacktrace(20 /* n */, 3 /* skip */)
 	return slog.Any(key, stack)
 }
 

--- a/backend/common/log/slog_utils.go
+++ b/backend/common/log/slog_utils.go
@@ -3,8 +3,9 @@ package log
 import (
 	"log/slog"
 	"os"
-	"runtime/debug"
 	"strings"
+
+	"github.com/bytebase/bytebase/backend/common/stacktrace"
 )
 
 var GLogLevel *slog.LevelVar
@@ -47,7 +48,8 @@ func BBError(err error) slog.Attr {
 }
 
 func BBStack(key string) slog.Attr {
-	return slog.Any(key, debug.Stack())
+	stack := stacktrace.TakeStacktrace(20, 3)
+	return slog.Any(key, stack)
 }
 
 func BBStrings(key string, ss []string) slog.Attr {


### PR DESCRIPTION
since https://github.com/bytebase/bytebase/pull/8540, we can use our stacktrace function to replace `debug.Stack()`