### PR TITLE
fix: handle GENERATED ALWAYS AS constraint for pg

### DIFF
--- a/backend/plugin/parser/sql/ast/constraint_def.go
+++ b/backend/plugin/parser/sql/ast/constraint_def.go
@@ -26,6 +26,8 @@ const (
 	ConstraintTypeExclusion
 	// ConstraintTypeDefault is the default constraint.
 	ConstraintTypeDefault
+	// ConstraintTypegenerated is the generated constraint.
+	ConstraintTypeGenerated
 )
 
 // ConstraintDef is struct for constraint definition.

--- a/backend/plugin/parser/sql/ast/constraint_def.go
+++ b/backend/plugin/parser/sql/ast/constraint_def.go
@@ -26,7 +26,7 @@ const (
 	ConstraintTypeExclusion
 	// ConstraintTypeDefault is the default constraint.
 	ConstraintTypeDefault
-	// ConstraintTypegenerated is the generated constraint.
+	// ConstraintTypeGenerated is the generated constraint.
 	ConstraintTypeGenerated
 )
 

--- a/backend/plugin/parser/sql/engine/pg/convert.go
+++ b/backend/plugin/parser/sql/engine/pg/convert.go
@@ -1504,7 +1504,7 @@ func convertConstraint(in *pgquery.Node_Constraint) (*ast.ConstraintDef, error) 
 		}
 	case ast.ConstraintTypePrimaryUsingIndex, ast.ConstraintTypeUniqueUsingIndex:
 		cons.IndexName = in.Constraint.Indexname
-	case ast.ConstraintTypeCheck, ast.ConstraintTypeDefault:
+	case ast.ConstraintTypeCheck, ast.ConstraintTypeDefault, ast.ConstraintTypeGenerated:
 		expression, _, _, err := convertExpressionNode(in.Constraint.RawExpr)
 		if err != nil {
 			return nil, err
@@ -1594,6 +1594,8 @@ func convertConstraintType(in pgquery.ConstrType, usingIndex bool) ast.Constrain
 		return ast.ConstraintTypeDefault
 	case pgquery.ConstrType_CONSTR_EXCLUSION:
 		return ast.ConstraintTypeExclusion
+	case pgquery.ConstrType_CONSTR_GENERATED:
+		return ast.ConstraintTypeGenerated
 	}
 	return ast.ConstraintTypeUndefined
 }

--- a/backend/plugin/parser/sql/engine/pg/deparse.go
+++ b/backend/plugin/parser/sql/engine/pg/deparse.go
@@ -1053,6 +1053,10 @@ func deparseColumnConstraint(_ DeparseContext, in *ast.ConstraintDef, buf *strin
 		if _, err := buf.WriteString(in.Expression.Text()); err != nil {
 			return err
 		}
+	case ast.ConstraintTypeGenerated:
+		if _, err := buf.WriteString(fmt.Sprintf("GENERATED ALWAYS AS (%s) STORED", in.Expression.Text())); err != nil {
+			return err
+		}
 	default:
 		return errors.Errorf("failed to deparse column constraint: not support %d", in.Type)
 	}

--- a/backend/plugin/parser/sql/engine/pg/test-data/test_create_table_data.yaml
+++ b/backend/plugin/parser/sql/engine/pg/test-data/test_create_table_data.yaml
@@ -81,3 +81,31 @@
         CONSTRAINT "uk1" UNIQUE ("a", "b")
     )
     PARTITION BY RANGE ("a", "b", (c + 1));
+
+- stmt: |-
+    CREATE TABLE t (
+      a numeric,
+      b numeric,
+      c numeric GENERATED ALWAYS AS (a * b) STORED
+    );
+  want: |-
+    CREATE TABLE "t" (
+        "a" numeric,
+        "b" numeric,
+        "c" numeric GENERATED ALWAYS AS (a * b) STORED
+    );
+
+- stmt: |-
+    CREATE TABLE public.t (
+      action text NOT NULL,
+      action_date timestamp NOT NULL,
+      number smallint GENERATED ALWAYS AS ((date_part('week'::text, ((action_date)::date + '1 day'::interval)))::smallint) STORED,
+      year smallint GENERATED ALWAYS AS ((date_part('year'::text, date_trunc('week'::text, action_date)))::smallint) STORED
+    );
+  want: |-
+    CREATE TABLE "public"."t" (
+        "action" text NOT NULL,
+        "action_date" timestamp NOT NULL,
+        "number" smallint GENERATED ALWAYS AS (date_part('week'::text, action_date::date + '1 day'::interval)::smallint) STORED,
+        "year" smallint GENERATED ALWAYS AS (date_part('year'::text, date_trunc('week'::text, action_date))::smallint) STORED
+    );


### PR DESCRIPTION
this pr can only handle `GENERATED ALWAYS AS ( generation_expr ) STORED` for pg. I want fix `GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( sequence_options ) ]  ` in another pr.