### PR TITLE
feat: different change history truncate size for Get/List

### DIFF
--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -853,10 +853,11 @@ func (s *DatabaseService) ListChangeHistories(ctx context.Context, request *v1pb
 	limitPlusOne := limit + 1
 
 	find := &store.FindInstanceChangeHistoryMessage{
-		InstanceID: &instance.UID,
-		DatabaseID: &database.UID,
-		Limit:      &limitPlusOne,
-		Offset:     &offset,
+		InstanceID:   &instance.UID,
+		DatabaseID:   &database.UID,
+		Limit:        &limitPlusOne,
+		Offset:       &offset,
+		TruncateSize: 512,
 	}
 	if request.View == v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL {
 		find.ShowFull = true
@@ -926,9 +927,10 @@ func (s *DatabaseService) GetChangeHistory(ctx context.Context, request *v1pb.Ge
 	}
 
 	find := &store.FindInstanceChangeHistoryMessage{
-		InstanceID: &instance.UID,
-		DatabaseID: &database.UID,
-		ID:         &changeHistoryIDStr,
+		InstanceID:   &instance.UID,
+		DatabaseID:   &database.UID,
+		ID:           &changeHistoryIDStr,
+		TruncateSize: 1024 * 1024,
 	}
 	if request.View == v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL {
 		find.ShowFull = true

--- a/backend/runner/rollbackrun/runner.go
+++ b/backend/runner/rollbackrun/runner.go
@@ -285,7 +285,11 @@ func (r *Runner) generateMySQLRollbackSQLImpl(ctx context.Context, payload *api.
 		return "", errors.WithMessage(err, "failed to get admin database driver")
 	}
 	defer driver.Close(ctx)
-	list, err := r.store.ListInstanceChangeHistory(ctx, &store.FindInstanceChangeHistoryMessage{InstanceID: &instance.UID, ID: &payload.MigrationID})
+	list, err := r.store.ListInstanceChangeHistory(ctx, &store.FindInstanceChangeHistoryMessage{
+		InstanceID: &instance.UID,
+		ID:         &payload.MigrationID,
+		ShowFull:   true,
+	})
 	if err != nil {
 		return "", errors.WithMessagef(err, "failed to find migration history with ID %s", payload.MigrationID)
 	}

--- a/backend/store/instance_change_history.go
+++ b/backend/store/instance_change_history.go
@@ -55,9 +55,6 @@ type InstanceChangeHistoryMessage struct {
 	IssueProjectID string
 }
 
-// instanceChangeHistoryTruncateLength is the maximum characters of a sheet for displaying.
-const instanceChangeHistoryTruncateLength = 2048
-
 // FindInstanceChangeHistoryMessage is for listing a list of instance change history.
 type FindInstanceChangeHistoryMessage struct {
 	ID              *string
@@ -71,7 +68,8 @@ type FindInstanceChangeHistoryMessage struct {
 	Offset          *int
 
 	// Truncate Statement, Schema, SchemaPrev unless ShowFull.
-	ShowFull bool
+	ShowFull     bool
+	TruncateSize int
 }
 
 // UpdateInstanceChangeHistoryMessage is for updating an instance change history.
@@ -483,15 +481,15 @@ func (s *Store) ListInstanceChangeHistory(ctx context.Context, find *FindInstanc
 
 	statementField := "COALESCE(sheet.statement, instance_change_history.statement)"
 	if !find.ShowFull {
-		statementField = fmt.Sprintf("LEFT(%s, %d)", statementField, instanceChangeHistoryTruncateLength)
+		statementField = fmt.Sprintf("LEFT(%s, %d)", statementField, find.TruncateSize)
 	}
-	schemaField := fmt.Sprintf("LEFT(instance_change_history.schema, %d)", instanceChangeHistoryTruncateLength)
-	if find.ShowFull {
-		schemaField = "instance_change_history.schema"
+	schemaField := "instance_change_history.schema"
+	if !find.ShowFull {
+		schemaField = fmt.Sprintf("LEFT(%s, %d)", schemaField, find.TruncateSize)
 	}
-	schemaPrevField := fmt.Sprintf("LEFT(instance_change_history.schema_prev, %d)", instanceChangeHistoryTruncateLength)
-	if find.ShowFull {
-		schemaPrevField = "instance_change_history.schema_prev"
+	schemaPrevField := "instance_change_history.schema_prev"
+	if !find.ShowFull {
+		schemaPrevField = fmt.Sprintf("LEFT(%s, %d)", schemaPrevField, find.TruncateSize)
 	}
 
 	query := fmt.Sprintf(`
@@ -790,17 +788,17 @@ func (s *Store) ListInstanceChangeHistoryForMigrator(ctx context.Context, find *
 		where, args = append(where, fmt.Sprintf("instance_change_history.version = $%d", len(args)+1)), append(args, storedVersion)
 	}
 
-	statementField := fmt.Sprintf("LEFT(instance_change_history.statement, %d)", instanceChangeHistoryTruncateLength)
-	if find.ShowFull {
-		statementField = "instance_change_history.statement"
+	statementField := "instance_change_history.statement"
+	if !find.ShowFull {
+		statementField = fmt.Sprintf("LEFT(%s, %d)", statementField, find.TruncateSize)
 	}
-	schemaField := fmt.Sprintf("LEFT(instance_change_history.schema, %d)", instanceChangeHistoryTruncateLength)
-	if find.ShowFull {
-		schemaField = "instance_change_history.schema"
+	schemaField := "instance_change_history.schema"
+	if !find.ShowFull {
+		schemaField = fmt.Sprintf("LEFT(%s, %d)", schemaField, find.TruncateSize)
 	}
-	schemaPrevField := fmt.Sprintf("LEFT(instance_change_history.schema_prev, %d)", instanceChangeHistoryTruncateLength)
-	if find.ShowFull {
-		schemaPrevField = "instance_change_history.schema_prev"
+	schemaPrevField := "instance_change_history.schema_prev"
+	if !find.ShowFull {
+		schemaPrevField = fmt.Sprintf("LEFT(%s, %d)", schemaPrevField, find.TruncateSize)
 	}
 
 	query := fmt.Sprintf(`

--- a/backend/tests/change_history_test.go
+++ b/backend/tests/change_history_test.go
@@ -132,6 +132,7 @@ func TestFilterChangeHistoryByResources(t *testing.T) {
 	for _, tt := range tests {
 		resp, err := ctl.databaseServiceClient.ListChangeHistories(ctx, &v1pb.ListChangeHistoriesRequest{
 			Parent: database.Name,
+			View:   v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 			Filter: tt.filter,
 		})
 		a.NoError(err)

--- a/backend/tests/schema_update_test.go
+++ b/backend/tests/schema_update_test.go
@@ -141,6 +141,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	// Get migration history.
 	resp, err := ctl.databaseServiceClient.ListChangeHistories(ctx, &v1pb.ListChangeHistoriesRequest{
 		Parent: database.Name,
+		View:   v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 	})
 	a.NoError(err)
 	histories := resp.ChangeHistories
@@ -205,6 +206,7 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 	// Query clone migration history.
 	resp, err = ctl.databaseServiceClient.ListChangeHistories(ctx, &v1pb.ListChangeHistoriesRequest{
 		Parent: cloneDatabase.Name,
+		View:   v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 	})
 	a.NoError(err)
 	histories = resp.ChangeHistories
@@ -580,6 +582,7 @@ func TestVCS(t *testing.T) {
 			// Get migration history.
 			resp, err := ctl.databaseServiceClient.ListChangeHistories(ctx, &v1pb.ListChangeHistoriesRequest{
 				Parent: database.Name,
+				View:   v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 			})
 			a.NoError(err)
 			histories := resp.ChangeHistories
@@ -939,6 +942,7 @@ ALTER TABLE ONLY public.users
 
 			resp, err := ctl.databaseServiceClient.ListChangeHistories(ctx, &v1pb.ListChangeHistoriesRequest{
 				Parent: database.Name,
+				View:   v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 			})
 			a.NoError(err)
 			histories := resp.ChangeHistories
@@ -2390,6 +2394,7 @@ func TestVCS_SDL_MySQL(t *testing.T) {
 
 			resp, err := ctl.databaseServiceClient.ListChangeHistories(ctx, &v1pb.ListChangeHistoriesRequest{
 				Parent: database.Name,
+				View:   v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 			})
 			a.NoError(err)
 			histories := resp.ChangeHistories
@@ -2424,6 +2429,7 @@ func TestVCS_SDL_MySQL(t *testing.T) {
 			sdlHistory, err := ctl.databaseServiceClient.GetChangeHistory(ctx, &v1pb.GetChangeHistoryRequest{
 				Name:      histories[1].Name,
 				SdlFormat: true,
+				View:      v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 			})
 			a.NoError(err)
 			a.Equal(updatedSDL, sdlHistory.Schema)

--- a/backend/tests/sync_schema_test.go
+++ b/backend/tests/sync_schema_test.go
@@ -110,6 +110,7 @@ DROP SCHEMA "schema_a";
 
 	resp, err := ctl.databaseServiceClient.ListChangeHistories(ctx, &v1pb.ListChangeHistoriesRequest{
 		Parent: database.Name,
+		View:   v1pb.ChangeHistoryView_CHANGE_HISTORY_VIEW_FULL,
 	})
 	a.NoError(err)
 	histories := resp.ChangeHistories


### PR DESCRIPTION
Known issues: frontend uses List rather than Get in ChangeHistoryDetail page, so the truncate size will be 512.