### PR TITLE
feat: distinguish between request export permission and export data

### DIFF
--- a/frontend/src/components/Issue/panel/RequestExportPanel/index.vue
+++ b/frontend/src/components/Issue/panel/RequestExportPanel/index.vue
@@ -6,7 +6,7 @@
     @update:show="(show: boolean) => !show && $emit('close')"
   >
     <NDrawerContent
-      :title="$t('quick-action.request-export')"
+      :title="$t('quick-action.request-export-permission')"
       :closable="true"
       class="w-[50rem] max-w-[100vw] relative"
     >

--- a/frontend/src/components/Issue/panel/RequestQueryPanel/index.vue
+++ b/frontend/src/components/Issue/panel/RequestQueryPanel/index.vue
@@ -6,7 +6,7 @@
     @update:show="(show: boolean) => !show && $emit('close')"
   >
     <NDrawerContent
-      :title="$t('quick-action.request-query')"
+      :title="$t('quick-action.request-query-permission')"
       :closable="true"
       class="w-[50rem] max-w-[100vw] relative"
     >

--- a/frontend/src/components/QuickActionPanel.vue
+++ b/frontend/src/components/QuickActionPanel.vue
@@ -158,7 +158,7 @@
           <h3
             class="flex-1 mt-1.5 text-center text-sm font-normal text-main tracking-tight"
           >
-            {{ $t("quick-action.request-query") }}
+            {{ $t("quick-action.request-query-permission") }}
           </h3>
         </div>
 
@@ -175,7 +175,7 @@
           <h3
             class="flex-1 mt-1.5 text-center text-sm font-normal text-main tracking-tight"
           >
-            {{ $t("quick-action.request-export") }}
+            {{ $t("quick-action.request-export-permission") }}
           </h3>
         </div>
       </template>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1018,8 +1018,9 @@
     "unassigned-db-hint": "Bytebase periodically syncs the instance schema. Newly synced databases are unassigned at first, and they need to be transferred to a project before they can be used.",
     "transfer-out-db": "Transfer out DB",
     "transfer-out-db-title": "Transfer out database",
-    "request-query": "Request Query",
-    "request-export": "Request Export"
+    "request-query-permission": "Request Query",
+    "request-export-permission": "Request Export",
+    "request-export-data": "Request Export"
   },
   "create-db": {
     "new-database-name": "New database name",
@@ -2038,7 +2039,7 @@
     "run-selected": "Run selected",
     "clear-screen": "Clear screen",
     "query-time": "Query time",
-    "request-query": "Request Query",
+    "request-query-permission": "Request Query",
     "connection-lost": "Connection lost. Will try to reconnect when executing next query.",
     "sheet": {
       "choose-sheet": "Choose Sheet",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1017,8 +1017,9 @@
     "unassigned-db-hint": "Bytebase sincroniza periódicamente el esquema de la instancia. Las bases de datos recién sincronizadas no están asignadas al principio y deben transferirse a un proyecto antes de que puedan usarse.",
     "transfer-out-db": "Transferir base de datos",
     "transfer-out-db-title": "Transferir la base de datos",
-    "request-export": "Solicitar exportación",
-    "request-query": "Solicitar consulta"
+    "request-export-permission": "Solicitar exportación",
+    "request-query-permission": "Solicitar consulta",
+    "request-query-data": "Solicitar consulta"
   },
   "create-db": {
     "new-database-name": "Nuevo nombre de la base de datos",
@@ -2034,7 +2035,7 @@
     "run-selected": "Ejecutar selección",
     "clear-screen": "Limpiar pantalla",
     "query-time": "Tiempo de consulta",
-    "request-query": "Solicitar consulta",
+    "request-query-permission": "Solicitar consulta",
     "connection-lost": "Conexión perdida. \nIntentará volver a conectarse al ejecutar la siguiente consulta.",
     "sheet": {
       "choose-sheet": "Elegir hoja",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1015,8 +1015,9 @@
     "unassigned-db-hint": "Bytebase 会定期同步实例的 Schema。新同步的数据库起先是未分配的状态。需要把数据库转移到项目后，才能使用。",
     "transfer-out-db": "转出数据库",
     "transfer-out-db-title": "转出数据库",
-    "request-query": "申请查询权限",
-    "request-export": "申请导出数据"
+    "request-query-permission": "申请查询权限",
+    "request-export-permission": "申请导出权限",
+    "request-export-data": "申请导出数据"
   },
   "create-db": {
     "new-database-name": "新数据库名称",
@@ -2033,7 +2034,7 @@
     "run-selected": "运行选中的语句",
     "clear-screen": "清屏",
     "query-time": "查询时间",
-    "request-query": "申请查询权限",
+    "request-query-permission": "申请查询权限",
     "connection-lost": "连接丢失。下一次执行查询时将尝试重新连接。",
     "sheet": {
       "choose-sheet": "选择工作表",

--- a/frontend/src/views/ExportCenter/index.vue
+++ b/frontend/src/views/ExportCenter/index.vue
@@ -36,7 +36,7 @@
             feature="bb.feature.access-control"
             custom-class="mr-2"
           />
-          {{ $t("quick-action.request-export") }}
+          {{ $t("quick-action.request-export-data") }}
         </NButton>
       </div>
     </div>

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="available">
     <NButton text type="primary" @click="showPanel = true">
-      {{ $t("sql-editor.request-query") }}
+      {{ $t("sql-editor.request-query-permission") }}
     </NButton>
 
     <RequestQueryPanel

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
@@ -74,7 +74,7 @@
           @export="handleExportBtnClick"
         />
         <NButton v-else @click="state.showRequestExportPanel = true">
-          {{ $t("quick-action.request-export") }}
+          {{ $t("quick-action.request-export-data") }}
         </NButton>
       </div>
     </div>


### PR DESCRIPTION
Though underlying they both use the IAM model, from the user’s perception, they behave differently. Export data is requested via SQL Editor and Export Center, which require supplying the SQL query.

Only change for Chinese. For English/Spanish, just use `Request Export` since we don't have enough space

![CleanShot 2023-10-12 at 11 33 19](https://github.com/bytebase/bytebase/assets/230323/ae367bdf-a976-46ed-aa3a-f4c18ca5e1e8)

![CleanShot 2023-10-12 at 11 32 49](https://github.com/bytebase/bytebase/assets/230323/c1606587-30f5-401d-a328-3a65ee9f0c14)

![CleanShot 2023-10-12 at 11 33 10](https://github.com/bytebase/bytebase/assets/230323/5b2e4766-0aed-4656-a0d4-34be0b70a31f)
