### PR TITLE
feat: allow to clear the last grouping label in SQL Editor

### DIFF
--- a/frontend/src/views/sql-editor/AsidePanel/GroupingBar/FactorTag.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/GroupingBar/FactorTag.vue
@@ -8,8 +8,11 @@
     @click.stop="handleClick"
   >
     <span
-      class="leading-6 hover:line-through"
-      :class="factor.disabled && 'line-through'"
+      class="leading-6"
+      :class="[
+        factor.disabled && 'line-through',
+        allowDisable && 'hover:line-through',
+      ]"
     >
       {{ readableSQLEditorTreeFactor(factor.factor) }}
     </span>
@@ -48,18 +51,15 @@ const allowDisable = computed(() => {
 });
 
 const allowRemove = computed(() => {
-  if (factorList.value.length <= 1) {
-    // Disallow to remove the only one factor
-    return false;
-  }
   const { factor } = props;
-  if (!factor.disabled) {
-    if (filteredFactorList.value.length <= 1) {
-      // Disallow to remove the only one enabled factor
-      return false;
-    }
+  // Always allow to remove the disabled factor
+  if (factor.disabled) {
+    return true;
   }
-  return true;
+
+  // Otherwise, we only allow to remove the enabled factor if this is the only factor
+  // or there exists other enabled factors
+  return factorList.value.length === 1 || filteredFactorList.value.length >= 2;
 });
 
 const clickable = computed(() => {

--- a/frontend/src/views/sql-editor/AsidePanel/GroupingBar/GroupingBar.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/GroupingBar/GroupingBar.vue
@@ -89,6 +89,12 @@ const toggleDisabled = (factor: StatefulFactor, index: number) => {
 
 const remove = (factor: StatefulFactor, index: number) => {
   factorList.value.splice(index, 1);
+  if (factorList.value.length === 0) {
+    factorList.value.push({
+      factor: "project",
+      disabled: false,
+    });
+  }
   treeStore.buildTree();
 };
 


### PR DESCRIPTION
![CleanShot 2023-10-16 at 23-40-51 png](https://github.com/bytebase/bytebase/assets/230323/87f1282c-88f2-4a6a-b434-16416c326c5b)

removing it will reset to the project group

![CleanShot 2023-10-16 at 23-43-27 png](https://github.com/bytebase/bytebase/assets/230323/168168a1-6d2c-4497-bcce-c90719009f14)


---

![CleanShot 2023-10-16 at 23-41-38 png](https://github.com/bytebase/bytebase/assets/230323/a3705d2c-1e3e-4a2a-b91a-b99fc391ce58)

On the other end, disallow removing the label if all other factors are disabled. 
