### PR TITLE
feat: use rollout policy in scheduler

### DIFF
--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -1208,83 +1209,54 @@ func (s *RolloutService) createPipeline(ctx context.Context, project *store.Proj
 }
 
 // canUserRunStageTasks returns if a user can run the tasks in a stage.
+// TODO(p0ny): support roles/LAST_APPROVER.
 func canUserRunStageTasks(ctx context.Context, s *store.Store, user *store.UserMessage, issue *store.IssueMessage, stageEnvironmentID int) (bool, error) {
 	// the workspace owner and DBA roles can always run tasks.
 	if user.Role == api.Owner || user.Role == api.DBA {
 		return true, nil
 	}
-	groupValue, err := getGroupValueForIssueTypeEnvironment(ctx, s, issue.Type, stageEnvironmentID)
+
+	p, err := s.GetRolloutPolicy(ctx, stageEnvironmentID)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get assignee group value for issueID %d", issue.UID)
+		return false, errors.Wrapf(err, "failed to get rollout policy for stageEnvironmentID %d", stageEnvironmentID)
 	}
-	// as the policy says, the project owner has the privilege to run.
-	if groupValue == api.AssigneeGroupValueProjectOwner {
-		policy, err := s.GetProjectPolicy(ctx, &store.GetProjectPolicyMessage{UID: &issue.Project.UID})
-		if err != nil {
-			return false, common.Wrapf(err, common.Internal, "failed to get project %d policy", issue.Project.UID)
+
+	policy, err := s.GetProjectPolicy(ctx, &store.GetProjectPolicyMessage{UID: &issue.Project.UID})
+	if err != nil {
+		return false, common.Wrapf(err, common.Internal, "failed to get project %d policy", issue.Project.UID)
+	}
+
+	allowedProjectRoles := map[api.Role]bool{}
+	for _, role := range p.ProjectRoles {
+		allowedProjectRoles[api.Role(strings.TrimPrefix(role, "roles/"))] = true
+	}
+	for _, binding := range policy.Bindings {
+		if !allowedProjectRoles[binding.Role] {
+			continue
 		}
-		for _, binding := range policy.Bindings {
-			if binding.Role != api.Owner {
-				continue
-			}
-			for _, member := range binding.Members {
-				if member.ID == user.ID {
-					return true, nil
-				}
+		for _, member := range binding.Members {
+			if member.ID == user.ID {
+				return true, nil
 			}
 		}
 	}
+
+	if user.ID == issue.Creator.ID {
+		for _, issueRole := range p.IssueRoles {
+			if issueRole == "roles/CREATOR" {
+				return true, nil
+			}
+		}
+	}
+
 	return false, nil
 }
 
 // canUserCancelStageTaskRun returns if a user can cancel the task runs in a stage.
 func canUserCancelStageTaskRun(ctx context.Context, s *store.Store, user *store.UserMessage, issue *store.IssueMessage, stageEnvironmentID int) (bool, error) {
-	// the workspace owner and DBA roles can always cancel task runs.
-	if user.Role == api.Owner || user.Role == api.DBA {
-		return true, nil
-	}
 	// The creator can cancel task runs.
 	if user.ID == issue.Creator.ID {
 		return true, nil
 	}
-	groupValue, err := getGroupValueForIssueTypeEnvironment(ctx, s, issue.Type, stageEnvironmentID)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to get assignee group value for issueID %d", issue.UID)
-	}
-	// as the policy says, the project owner has the privilege to cancel.
-	if groupValue == api.AssigneeGroupValueProjectOwner {
-		policy, err := s.GetProjectPolicy(ctx, &store.GetProjectPolicyMessage{UID: &issue.Project.UID})
-		if err != nil {
-			return false, common.Wrapf(err, common.Internal, "failed to get project %d policy", issue.Project.UID)
-		}
-		for _, binding := range policy.Bindings {
-			if binding.Role != api.Owner {
-				continue
-			}
-			for _, member := range binding.Members {
-				if member.ID == user.ID {
-					return true, nil
-				}
-			}
-		}
-	}
-	return false, nil
-}
-
-func getGroupValueForIssueTypeEnvironment(ctx context.Context, s *store.Store, issueType api.IssueType, environmentID int) (api.AssigneeGroupValue, error) {
-	defaultGroupValue := api.AssigneeGroupValueWorkspaceOwnerOrDBA
-	policy, err := s.GetPipelineApprovalPolicy(ctx, environmentID)
-	if err != nil {
-		return defaultGroupValue, errors.Wrapf(err, "failed to get pipeline approval policy by environmentID %d", environmentID)
-	}
-	if policy == nil {
-		return defaultGroupValue, nil
-	}
-
-	for _, assigneeGroup := range policy.AssigneeGroupList {
-		if assigneeGroup.IssueType == issueType {
-			return assigneeGroup.Value, nil
-		}
-	}
-	return defaultGroupValue, nil
+	return canUserRunStageTasks(ctx, s, user, issue, stageEnvironmentID)
 }

--- a/backend/migrator/migration/dev/LATEST_DATA.sql
+++ b/backend/migrator/migration/dev/LATEST_DATA.sql
@@ -58,8 +58,8 @@ VALUES
         'ENVIRONMENT',
         101,
         TRUE,
-        'bb.policy.pipeline-approval',
-        '{"value":"MANUAL_APPROVAL_NEVER"}'
+        'bb.policy.rollout',
+        '{"automatic": true}'
     );
 
 INSERT INTO
@@ -81,8 +81,8 @@ VALUES
         'ENVIRONMENT',
         102,
         TRUE,
-        'bb.policy.pipeline-approval',
-        '{"value":"MANUAL_APPROVAL_ALWAYS"}'
+        'bb.policy.rollout',
+        '{"automatic": false, "workspaceRoles": ["roles/OWNER","roles/DBA"]}'
     );
 
 INSERT INTO

--- a/backend/migrator/migration/prod/LATEST_DATA.sql
+++ b/backend/migrator/migration/prod/LATEST_DATA.sql
@@ -58,8 +58,8 @@ VALUES
         'ENVIRONMENT',
         101,
         TRUE,
-        'bb.policy.pipeline-approval',
-        '{"value":"MANUAL_APPROVAL_NEVER"}'
+        'bb.policy.rollout',
+        '{"automatic": true}'
     );
 
 INSERT INTO
@@ -81,8 +81,8 @@ VALUES
         'ENVIRONMENT',
         102,
         TRUE,
-        'bb.policy.pipeline-approval',
-        '{"value":"MANUAL_APPROVAL_NEVER"}'
+        'bb.policy.rollout',
+        '{"automatic": true}'
     );
 
 ALTER SEQUENCE policy_id_seq RESTART WITH 103;

--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -106,11 +106,11 @@ func (s *SchedulerV2) scheduleAutoRolloutTasks(ctx context.Context) error {
 
 	var autoRolloutEnvironmentIDs []int
 	for _, environment := range environments {
-		policy, err := s.store.GetPipelineApprovalPolicy(ctx, environment.UID)
+		policy, err := s.store.GetRolloutPolicy(ctx, environment.UID)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get approval policy for environment ID %d", environment.UID)
+			return errors.Wrapf(err, "failed to get rollout policy for environment ID %d", environment.UID)
 		}
-		if policy.Value != api.PipelineApprovalValueManualNever {
+		if !policy.Automatic {
 			continue
 		}
 		autoRolloutEnvironmentIDs = append(autoRolloutEnvironmentIDs, environment.UID)

--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -273,10 +273,10 @@ func (ctl *controller) StartServerWithExternalPg(ctx context.Context, config *co
 		if _, err := ctl.orgPolicyServiceClient.CreatePolicy(metaCtx, &v1pb.CreatePolicyRequest{
 			Parent: fmt.Sprintf("environments/%s", environment),
 			Policy: &v1pb.Policy{
-				Type: v1pb.PolicyType_DEPLOYMENT_APPROVAL,
-				Policy: &v1pb.Policy_DeploymentApprovalPolicy{
-					DeploymentApprovalPolicy: &v1pb.DeploymentApprovalPolicy{
-						DefaultStrategy: v1pb.ApprovalStrategy_MANUAL,
+				Type: v1pb.PolicyType_ROLLOUT_POLICY,
+				Policy: &v1pb.Policy_RolloutPolicy{
+					RolloutPolicy: &v1pb.RolloutPolicy{
+						Automatic: false,
 					},
 				},
 			},


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 215d329</samp>

### Summary
🔄🧹🚀

<!--
1.  🔄 - This emoji represents the change of using the new rollout policy instead of the pipeline approval policy for automatic rollouts. It suggests a switch or a rotation of policies.
2.  🧹 - This emoji represents the cleanup of unused or redundant code and the simplification of the default policy. It suggests a sweep or a removal of clutter.
3.  🚀 - This emoji represents the enablement of automatic execution of migrations for some prod environments. It suggests a launch or a boost of speed.
-->
This pull request introduces a new rollout policy for managing task execution and cancellation across different environments. It updates the `rollout_service`, `migrator`, `store`, and `taskrun` packages to use the new policy and removes some obsolete code. It also adjusts the `LATEST_DATA.sql` files for the dev and prod environments to apply the new policy settings.

> _Roll out the new policy, unleash the taskrun_
> _No more pipeline approvals, we are the chosen ones_
> _Refactor and simplify, optimize the store_
> _Migrate the prod environments, let the data roar_

### Walkthrough
*  Rename and modify `GetPipelineApprovalPolicy` function to `GetRolloutPolicy` and use `storepb.RolloutPolicy` struct instead of `api.PipelineApprovalPolicy` struct ([link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-6003ad56fd733eb612e7947fe886cb584432600de895b8e968355a51f7dbfa38L37-R39), [link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-6003ad56fd733eb612e7947fe886cb584432600de895b8e968355a51f7dbfa38L47-R59))
*  Update `scheduleAutoRolloutTasks` function to use the new rollout policy and check the `automatic` field instead of the `value` field ([link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-494c545cce27ea854883fbf80b3618919936c967dc35656d9b9690216455a759L109-R113))
*  Simplify and refactor `canUserRunStageTasks` and `canUserCancelStageTaskRun` functions to use the new rollout policy and a map and loop logic ([link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-1cb02603d98bcabce561505e95fc1612e1cc49fcca3816cabf96d3266edc3ec2L1216-R1251), [link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-1cb02603d98bcabce561505e95fc1612e1cc49fcca3816cabf96d3266edc3ec2L1242-R1262))
*  Add a TODO comment to support the `roles/LAST_APPROVER` role in the rollout policy ([link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-1cb02603d98bcabce561505e95fc1612e1cc49fcca3816cabf96d3266edc3ec2R1212))
*  Update `LATEST_DATA.sql` files for dev and prod environments to use the new rollout policy and set the `automatic` and `workspaceRoles` fields accordingly ([link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-da80833be01f15f19a616f42f9d7d5ed1412f6b4ee3a52cd9e416fa6c5f3d6dbL61-R62), [link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-da80833be01f15f19a616f42f9d7d5ed1412f6b4ee3a52cd9e416fa6c5f3d6dbL84-R85), [link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-d612e8e39d02d12f409c4b4ed4e5ff3fe024d5d27779171082237c526070d31dL61-R62), [link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-d612e8e39d02d12f409c4b4ed4e5ff3fe024d5d27779171082237c526070d31dL84-R85))
*  Import `strings` package in `v1` package to use `strings.TrimPrefix` function ([link](https://github.com/bytebase/bytebase/pull/8766/files?diff=unified&w=0#diff-1cb02603d98bcabce561505e95fc1612e1cc49fcca3816cabf96d3266edc3ec2R9))

