### PR TITLE
fix: default rollout policy requires manual

### DIFF
--- a/backend/store/policy.go
+++ b/backend/store/policy.go
@@ -47,7 +47,7 @@ func (s *Store) GetRolloutPolicy(ctx context.Context, environmentID int) (*store
 	}
 	if policy == nil {
 		return &storepb.RolloutPolicy{
-			Automatic: true,
+			Automatic: false,
 		}, nil
 	}
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 03261b7</samp>

### Summary
🛑🛠️🎛️

<!--
1.  🛑 - This emoji represents the change in the default behavior of the rollout policy, which could potentially stop or delay schema changes that were previously automatic. Users who rely on the default policy may need to update their configuration or approve schema changes manually after this change.
2.  🛠️ - This emoji represents the change in the `RolloutPolicy` struct, which is a technical or code-related change that affects the implementation of the feature. Users who define custom policies may need to adjust their code or settings to reflect the new field value.
3.  🎛️ - This emoji represents the change in the configurability of the feature, which gives users more control and flexibility over how they want to manage schema changes for different databases and environments. Users who want to take advantage of this feature may need to learn how to use the new settings and options.
-->
Changed the default rollout policy for schema changes to manual instead of automatic. This allows more fine-grained control over database migrations based on user-defined policies.

> _`Automatic` false_
> _Rollout policies vary_
> _Snowflakes in winter_

### Walkthrough
* Change the default rollout policy to manual ([link](https://github.com/bytebase/bytebase/pull/8770/files?diff=unified&w=0#diff-6003ad56fd733eb612e7947fe886cb584432600de895b8e968355a51f7dbfa38L50-R50)) to avoid unintended schema changes without approval

