### PR TITLE
fix: skip SQL check if nothing changed in the local state

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/SchemaEditorSQLCheckButton/useSchemaEditorSQLCheck.ts
+++ b/frontend/src/components/AlterSchemaPrepForm/SchemaEditorSQLCheckButton/useSchemaEditorSQLCheck.ts
@@ -51,6 +51,12 @@ export const useSchemaEditorSQLCheck = (params: {
     if (!databaseSchema) {
       return { errors: [], statement: "" };
     }
+    if (isEqual(databaseSchema.schemaList, databaseSchema.originSchemaList)) {
+      return {
+        errors: [t("schema-editor.nothing-changed")],
+        statement: "",
+      };
+    }
     const metadata = await dbSchemaV1Store.getOrFetchDatabaseMetadata(
       db.name,
       false /* !skipCache */,


### PR DESCRIPTION
We will show the SQL review error even if nothing changes while altering the schema.
<img width="1569" alt="CleanShot 2023-10-19 at 11 34 07@2x" src="https://github.com/bytebase/bytebase/assets/10706318/7441d553-e89a-4f41-a061-a2086cd2a146">

This is because we won't fetch the schema list until users expand the database tree:
- https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/frontend/src/components/SchemaEditorV1/index.vue?L86
- https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/frontend/src/components/SchemaEditorV1/Aside/DatabaseTree.vue?L600

So that the schema list in the local state is empty, this will be treated as dropping the schema during the diff.