### PR TITLE
chore(frontend): schema design store refactor

### DIFF
--- a/frontend/src/components/Branch/BaselineSchemaSelector.vue
+++ b/frontend/src/components/Branch/BaselineSchemaSelector.vue
@@ -149,7 +149,6 @@ const prepareChangeHistoryList = async () => {
 
   return await changeHistoryStore.fetchChangeHistoryList({
     parent: database.value.name,
-    pageSize: 1000,
   });
 };
 

--- a/frontend/src/components/Branch/BranchCreateView.vue
+++ b/frontend/src/components/Branch/BranchCreateView.vue
@@ -186,8 +186,9 @@ watch(
       return;
     }
 
-    const branch = await schemaDesignStore.getOrFetchSchemaDesignByName(
-      state.parentBranchName
+    const branch = await schemaDesignStore.fetchSchemaDesignByName(
+      state.parentBranchName,
+      false /* !useCache */
     );
     const database = await databaseStore.getOrFetchDatabaseByName(
       branch.baselineDatabase
@@ -352,8 +353,9 @@ const handleConfirm = async () => {
       })
     );
   } else {
-    const parentBranch = await schemaDesignStore.getOrFetchSchemaDesignByName(
-      state.parentBranchName
+    const parentBranch = await schemaDesignStore.fetchSchemaDesignByName(
+      state.parentBranchName,
+      false /* useCache */
     );
     createdSchemaDesign = await schemaDesignStore.createSchemaDesignDraft({
       ...parentBranch,

--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -132,7 +132,7 @@ import {
   SchemaDesign_Type,
 } from "@/types/proto/v1/schema_design_service";
 import { provideSQLCheckContext } from "../SQLCheck";
-import { getBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
+import { fetchBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
 import MergeBranchPanel from "./MergeBranchPanel.vue";
 import SchemaDesignEditor from "./SchemaDesignEditor.vue";
 import { generateForkedBranchName, validateBranchName } from "./utils";
@@ -316,7 +316,9 @@ const handleCancelEdit = async () => {
     return;
   }
 
-  const baselineMetadata = getBaselineMetadataOfBranch(branchSchema.branch);
+  const baselineMetadata = await fetchBaselineMetadataOfBranch(
+    branchSchema.branch
+  );
   const mergedMetadata = mergeSchemaEditToMetadata(
     branchSchema.schemaList,
     cloneDeep(baselineMetadata)
@@ -346,7 +348,9 @@ const handleSaveBranch = async () => {
     return;
   }
 
-  const baselineMetadata = getBaselineMetadataOfBranch(branchSchema.branch);
+  const baselineMetadata = await fetchBaselineMetadataOfBranch(
+    branchSchema.branch
+  );
   const mergedMetadata = mergeSchemaEditToMetadata(
     branchSchema.schemaList,
     cloneDeep(baselineMetadata)

--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-3 w-full overflow-x-auto px-4 pt-1">
+  <div class="space-y-3 w-full overflow-x-auto px-4 pt-1" v-bind="$attrs">
     <div class="w-full flex flex-row justify-between items-center">
       <div class="w-full flex flex-row justify-start items-center gap-x-2">
         <NInput
@@ -107,6 +107,7 @@
 </template>
 
 <script lang="ts" setup>
+import { asyncComputed } from "@vueuse/core";
 import { cloneDeep, head, isEqual, uniqueId } from "lodash-es";
 import { NButton, NDivider, NInput, NTooltip, useDialog, NTag } from "naive-ui";
 import { Status } from "nice-grpc-common";
@@ -152,7 +153,7 @@ interface LocalState {
 
 const props = defineProps<{
   // Should be a schema design name of main branch.
-  schemaDesignName: string;
+  branch: SchemaDesign;
   viewMode?: boolean;
 }>();
 
@@ -177,21 +178,22 @@ const mergeBranchPanelContext = ref<{
 const schemaEditorKey = ref<string>(uniqueId());
 
 const schemaDesign = computed(() => {
-  return schemaDesignStore.getSchemaDesignByName(props.schemaDesignName || "");
+  return props.branch;
 });
 
-const parentBranch = computed(() => {
+const parentBranch = asyncComputed(async () => {
   // Show parent branch when the current branch is a personal draft and it's not the new created one.
   if (
     schemaDesign.value.type === SchemaDesign_Type.PERSONAL_DRAFT &&
     schemaDesign.value.baselineSheetName
   ) {
-    return schemaDesignStore.getSchemaDesignByName(
-      schemaDesign.value.baselineSheetName
+    return await schemaDesignStore.fetchSchemaDesignByName(
+      schemaDesign.value.baselineSheetName,
+      true /* useCache */
     );
   }
   return undefined;
-});
+}, undefined);
 
 const changeHistory = computed(() => {
   const changeHistoryName = `${baselineDatabase.value.name}/changeHistories/${schemaDesign.value.baselineChangeHistoryId}`;
@@ -240,7 +242,7 @@ const prepareBaselineDatabase = async () => {
 };
 
 watch(
-  () => [props.schemaDesignName],
+  () => [props.branch],
   async () => {
     state.schemaDesignTitle = schemaDesign.value.title;
     await prepareBaselineDatabase();
@@ -249,8 +251,9 @@ watch(
       schemaDesign.value.type === SchemaDesign_Type.PERSONAL_DRAFT &&
       schemaDesign.value.baselineSheetName
     ) {
-      await schemaDesignStore.getOrFetchSchemaDesignByName(
-        schemaDesign.value.baselineSheetName
+      await schemaDesignStore.fetchSchemaDesignByName(
+        schemaDesign.value.baselineSheetName,
+        true /* useCache */
       );
     }
   },
@@ -455,7 +458,10 @@ const handleSaveBranch = async () => {
       // Delete the draft after merged.
       await schemaDesignStore.deleteSchemaDesign(newBranch.name);
       // Fetch the latest schema design after merged.
-      await schemaDesignStore.fetchSchemaDesignByName(schemaDesign.value.name);
+      await schemaDesignStore.fetchSchemaDesignByName(
+        schemaDesign.value.name,
+        false /* !useCache */
+      );
     } else {
       await schemaDesignStore.updateSchemaDesign(
         SchemaDesign.fromPartial({

--- a/frontend/src/components/Branch/BranchTable.vue
+++ b/frontend/src/components/Branch/BranchTable.vue
@@ -10,22 +10,22 @@
   >
     <template #item="{ item: branch }: { item: SchemaDesign }">
       <div v-if="!hideProjectColumn" class="bb-grid-cell">
-        {{ projectV1Name(getFormatedValue(branch).project) }}
+        {{ projectV1Name(getFormattedValue(branch).project) }}
       </div>
       <div class="bb-grid-cell">
         <NEllipsis :line-clamp="1">{{ branch.title }}</NEllipsis>
       </div>
       <div class="bb-grid-cell">
         <NEllipsis :line-clamp="1">{{
-          getFormatedValue(branch).parentBranch
+          getFormattedValue(branch).parentBranch
         }}</NEllipsis>
       </div>
       <div class="bb-grid-cell">
-        <DatabaseInfo :database="getFormatedValue(branch).database" />
+        <DatabaseInfo :database="getFormattedValue(branch).database" />
       </div>
       <div class="bb-grid-cell">
         <span class="text-gray-400">{{
-          getFormatedValue(branch).updatedTimeStr
+          getFormattedValue(branch).updatedTimeStr
         }}</span>
       </div>
     </template>
@@ -40,7 +40,6 @@ import { useI18n } from "vue-i18n";
 import { BBGridColumn } from "@/bbkit";
 import DatabaseInfo from "@/components/DatabaseInfo.vue";
 import { useDatabaseV1Store, useProjectV1Store, useUserStore } from "@/store";
-import { useSchemaDesignStore } from "@/store/modules/schemaDesign";
 import { getProjectAndSchemaDesignSheetId } from "@/store/modules/v1/common";
 import {
   SchemaDesign,
@@ -62,7 +61,6 @@ const { t } = useI18n();
 const userV1Store = useUserStore();
 const projectV1Store = useProjectV1Store();
 const databaseV1Store = useDatabaseV1Store();
-const schemaDesignStore = useSchemaDesignStore();
 
 const COLUMN_LIST = computed(() => {
   const columns: BBGridColumn[] = [
@@ -81,13 +79,13 @@ const COLUMN_LIST = computed(() => {
   return columns;
 });
 
-const getFormatedValue = (branch: SchemaDesign) => {
+const getFormattedValue = (branch: SchemaDesign) => {
   const [projectName] = getProjectAndSchemaDesignSheetId(branch.name);
   const project = projectV1Store.getProjectByName(`projects/${projectName}`);
   let parentBranch = "";
   if (branch.type === SchemaDesign_Type.PERSONAL_DRAFT) {
-    const parentSchemaDesign = schemaDesignStore.getSchemaDesignByName(
-      branch.baselineSheetName
+    const parentSchemaDesign = props.branches.find(
+      (br) => br.name === branch.baselineSheetName
     );
     if (parentSchemaDesign) {
       parentBranch = parentSchemaDesign.title;

--- a/frontend/src/components/Branch/SchemaDesignEditor.vue
+++ b/frontend/src/components/Branch/SchemaDesignEditor.vue
@@ -76,7 +76,7 @@ import {
   mergeSchemaEditToMetadata,
   validateDatabaseMetadata,
 } from "../SchemaEditorV1/utils";
-import { getBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
+import { fetchBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
 
 type TabType = "schema-editor" | "raw-sql-preview";
 
@@ -118,7 +118,7 @@ const fetchRawSQLPreview = async () => {
     return;
   }
 
-  const sourceMetadata = getBaselineMetadataOfBranch(props.branch);
+  const sourceMetadata = await fetchBaselineMetadataOfBranch(props.branch);
   const branchSchema = schemaEditorV1Store.resourceMap["branch"].get(
     props.branch.name
   );
@@ -126,7 +126,9 @@ const fetchRawSQLPreview = async () => {
     return undefined;
   }
 
-  const baselineMetadata = getBaselineMetadataOfBranch(branchSchema.branch);
+  const baselineMetadata = await fetchBaselineMetadataOfBranch(
+    branchSchema.branch
+  );
   const metadata = mergeSchemaEditToMetadata(
     branchSchema.schemaList,
     cloneDeep(baselineMetadata)

--- a/frontend/src/components/Branch/SchemaDesignSQLCheckButton.vue
+++ b/frontend/src/components/Branch/SchemaDesignSQLCheckButton.vue
@@ -20,6 +20,7 @@
 </template>
 
 <script lang="ts" setup>
+import { asyncComputed } from "@vueuse/core";
 import { cloneDeep, debounce } from "lodash-es";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
@@ -32,7 +33,7 @@ import { schemaDesignServiceClient } from "@/grpcweb";
 import { useDatabaseV1Store, useSchemaEditorV1Store } from "@/store";
 import { DatabaseMetadata } from "@/types/proto/v1/database_service";
 import { SchemaDesign } from "@/types/proto/v1/schema_design_service";
-import { getBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
+import { fetchBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
 
 const props = defineProps<{
   schemaDesign: SchemaDesign;
@@ -45,27 +46,29 @@ const database = computed(() => {
   return databaseStore.getDatabaseByName(props.schemaDesign.baselineDatabase);
 });
 
-const sourceMetadata = computed(() => {
+const sourceMetadata = asyncComputed(async () => {
   const branch = props.schemaDesign;
 
-  return getBaselineMetadataOfBranch(branch);
-});
+  return await fetchBaselineMetadataOfBranch(branch);
+}, undefined);
 
-const editingMetadata = computed(() => {
+const editingMetadata = asyncComputed(async () => {
   const branchSchema = schemaEditorV1Store.resourceMap["branch"].get(
     props.schemaDesign.name
   );
   if (!branchSchema) {
     return undefined;
   }
-  const baselineMetadata = getBaselineMetadataOfBranch(branchSchema.branch);
+  const baselineMetadata = await fetchBaselineMetadataOfBranch(
+    branchSchema.branch
+  );
   const metadata = mergeSchemaEditToMetadata(
     branchSchema.schemaList,
     cloneDeep(baselineMetadata)
   );
 
   return metadata;
-});
+}, undefined);
 
 const targetMetadata = ref<DatabaseMetadata>();
 const statement = ref("");

--- a/frontend/src/components/SQLCheck/SQLCheckButton.vue
+++ b/frontend/src/components/SQLCheck/SQLCheckButton.vue
@@ -61,7 +61,7 @@
 <script lang="ts" setup>
 import { debounce } from "lodash-es";
 import { ButtonProps, NButton, NPopover } from "naive-ui";
-import { CSSProperties, computed, onUnmounted, ref, watch } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 import { onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { sqlServiceClient } from "@/grpcweb";
@@ -69,18 +69,25 @@ import { usePolicyByParentAndType } from "@/store";
 import { ComposedDatabase } from "@/types";
 import { PolicyType } from "@/types/proto/v1/org_policy_service";
 import { Advice, Advice_Status } from "@/types/proto/v1/sql_service";
-import { Defer, defer, useWorkspacePermissionV1 } from "@/utils";
+import { Defer, VueStyle, defer, useWorkspacePermissionV1 } from "@/utils";
 import ErrorList from "../misc/ErrorList.vue";
 import SQLCheckPanel from "./SQLCheckPanel.vue";
 import { useSQLCheckContext } from "./context";
 
-const props = defineProps<{
-  statement: string;
-  database: ComposedDatabase;
-  buttonProps?: ButtonProps;
-  buttonStyle?: string | CSSProperties;
-  errors?: string[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    statement: string;
+    database: ComposedDatabase;
+    buttonProps?: ButtonProps;
+    buttonStyle?: VueStyle;
+    errors?: string[];
+  }>(),
+  {
+    buttonProps: undefined,
+    buttonStyle: undefined,
+    errors: undefined,
+  }
+);
 
 const { t } = useI18n();
 const SKIP_CHECK_THRESHOLD = 500000;

--- a/frontend/src/components/SchemaEditorV1/utils/branch.ts
+++ b/frontend/src/components/SchemaEditorV1/utils/branch.ts
@@ -41,7 +41,8 @@ export const fetchBaselineMetadataOfBranch = async (
     branch.baselineSheetName
   ) {
     const parentBranch = await useSchemaDesignStore().fetchSchemaDesignByName(
-      branch.baselineSheetName
+      branch.baselineSheetName,
+      false /* !useCache */
     );
     return (
       parentBranch.baselineSchemaMetadata || DatabaseMetadata.fromPartial({})

--- a/frontend/src/components/SchemaEditorV1/utils/branch.ts
+++ b/frontend/src/components/SchemaEditorV1/utils/branch.ts
@@ -10,10 +10,10 @@ import {
 } from "@/types/v1/schemaEditor";
 import { rebuildEditableSchemas } from "./metadata";
 
-export const convertBranchToBranchSchema = (
+export const convertBranchToBranchSchema = async (
   branch: SchemaDesign
-): BranchSchema => {
-  const baselineMetadata = getBaselineMetadataOfBranch(branch);
+): Promise<BranchSchema> => {
+  const baselineMetadata = await fetchBaselineMetadataOfBranch(branch);
   const originalSchemas = convertSchemaMetadataList(
     baselineMetadata.schemas || [],
     baselineMetadata.schemaConfigs || []
@@ -32,15 +32,15 @@ export const convertBranchToBranchSchema = (
   };
 };
 
-export const getBaselineMetadataOfBranch = (
+export const fetchBaselineMetadataOfBranch = async (
   branch: SchemaDesign
-): DatabaseMetadata => {
+): Promise<DatabaseMetadata> => {
   // For personal branches, we use its parent branch's schema as the original schema in editing state.
   if (
     branch.type === SchemaDesign_Type.PERSONAL_DRAFT &&
     branch.baselineSheetName
   ) {
-    const parentBranch = useSchemaDesignStore().getSchemaDesignByName(
+    const parentBranch = await useSchemaDesignStore().fetchSchemaDesignByName(
       branch.baselineSheetName
     );
     return (

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1446,7 +1446,7 @@ router.beforeEach((to, from, next) => {
     // Prepare the data for the branch detail page.
     const name = `projects/${to.params.projectName}/schemaDesigns/${to.params.branchName}`;
     useSchemaDesignStore()
-      .getOrFetchSchemaDesignByName(name)
+      .fetchSchemaDesignByName(name, false /* !useCache */)
       .then((branch) => {
         if (branch) {
           next();

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -294,7 +294,7 @@ const routes: Array<RouteRecordRaw> = [
               content: () => import("../views/branch/BranchDetail.vue"),
               leftSidebar: DashboardSidebar,
             },
-            props: { content: true },
+            props: { content: false },
           },
           {
             path: "sync-schema",

--- a/frontend/src/store/modules/schemaDesign.ts
+++ b/frontend/src/store/modules/schemaDesign.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { computed, reactive, ref, watchEffect } from "vue";
+import { reactive, ref, watchEffect } from "vue";
 import { schemaDesignServiceClient } from "@/grpcweb";
 import { Engine } from "@/types/proto/v1/common";
 import { DatabaseMetadata } from "@/types/proto/v1/database_service";
@@ -17,12 +17,10 @@ import {
 
 export const useSchemaDesignStore = defineStore("schema_design", () => {
   const schemaDesignMapByName = reactive(new Map<string, SchemaDesign>());
-
-  // Getters
-  const schemaDesignList = computed(() => {
-    const list = Array.from(schemaDesignMapByName.values());
-    return list;
-  });
+  const getSchemaDesignRequestCacheByName = new Map<
+    string,
+    Promise<SchemaDesign>
+  >();
 
   // Actions
   const fetchSchemaDesignList = async () => {
@@ -32,11 +30,6 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
         view: SchemaDesignView.SCHEMA_DESIGN_VIEW_FULL,
       }
     );
-    // Clear the cache and re-populate it.
-    schemaDesignMapByName.clear();
-    for (const schemaDesign of schemaDesigns) {
-      schemaDesignMapByName.set(schemaDesign.name, schemaDesign);
-    }
     return schemaDesigns;
   };
 
@@ -94,8 +87,24 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
     schemaDesignMapByName.set(updatedSchemaDesign.name, updatedSchemaDesign);
   };
 
-  const fetchSchemaDesignByName = async (name: string, silent = false) => {
-    const schemaDesign = await schemaDesignServiceClient.getSchemaDesign(
+  const fetchSchemaDesignByName = async (
+    name: string,
+    useCache = true,
+    silent = false
+  ) => {
+    if (useCache) {
+      const cachedEntity = schemaDesignMapByName.get(name);
+      if (cachedEntity) {
+        return cachedEntity;
+      }
+
+      // Avoid making duplicated requests concurrently
+      const cachedRequest = getSchemaDesignRequestCacheByName.get(name);
+      if (cachedRequest) {
+        return cachedRequest;
+      }
+    }
+    const request = schemaDesignServiceClient.getSchemaDesign(
       {
         name: name,
       },
@@ -103,21 +112,10 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
         silent,
       }
     );
-    schemaDesignMapByName.set(schemaDesign.name, schemaDesign);
-    return schemaDesign;
-  };
-
-  const getSchemaDesignByName = (name: string) => {
-    return schemaDesignMapByName.get(name) ?? SchemaDesign.fromPartial({});
-  };
-
-  const getOrFetchSchemaDesignByName = async (name: string, silent = false) => {
-    const cached = schemaDesignMapByName.get(name);
-    if (cached) {
-      return cached;
-    }
-    await fetchSchemaDesignByName(name, silent);
-    return getSchemaDesignByName(name);
+    request.then((schemaDesign) => {
+      schemaDesignMapByName.set(schemaDesign.name, schemaDesign);
+    });
+    return request;
   };
 
   const deleteSchemaDesign = async (name: string) => {
@@ -150,15 +148,12 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
   };
 
   return {
-    schemaDesignList,
     fetchSchemaDesignList,
     createSchemaDesign,
     createSchemaDesignDraft,
     updateSchemaDesign,
     mergeSchemaDesign,
     fetchSchemaDesignByName,
-    getOrFetchSchemaDesignByName,
-    getSchemaDesignByName,
     parseSchemaString,
     deleteSchemaDesign,
   };
@@ -167,16 +162,15 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
 export const useSchemaDesignList = () => {
   const store = useSchemaDesignStore();
   const ready = ref(false);
+  const schemaDesignList = ref<SchemaDesign[]>([]);
 
   watchEffect(() => {
     ready.value = false;
-    store.fetchSchemaDesignList().then(() => {
+    schemaDesignList.value = [];
+    store.fetchSchemaDesignList().then((response) => {
       ready.value = true;
+      schemaDesignList.value = response;
     });
-  });
-
-  const schemaDesignList = computed(() => {
-    return store.schemaDesignList;
   });
 
   return { schemaDesignList, ready };

--- a/frontend/src/store/modules/schemaDesign.ts
+++ b/frontend/src/store/modules/schemaDesign.ts
@@ -106,7 +106,7 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
     }
     const request = schemaDesignServiceClient.getSchemaDesign(
       {
-        name: name,
+        name,
       },
       {
         silent,
@@ -115,6 +115,7 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
     request.then((schemaDesign) => {
       schemaDesignMapByName.set(schemaDesign.name, schemaDesign);
     });
+    getSchemaDesignRequestCacheByName.set(name, request);
     return request;
   };
 

--- a/frontend/src/store/modules/v1/changelist.ts
+++ b/frontend/src/store/modules/v1/changelist.ts
@@ -100,7 +100,10 @@ export const useChangelistStore = defineStore("changelist", () => {
       );
     } else if (isBranchChangeSource(change)) {
       composer.collect(source, () =>
-        useSchemaDesignStore().getOrFetchSchemaDesignByName(source)
+        useSchemaDesignStore().fetchSchemaDesignByName(
+          source,
+          true /* useCache */
+        )
       );
     } else {
       // Raw SQL, no need to compose

--- a/frontend/src/views/Changelist/ChangelistDetail/AddChangePanel/AddChangePanel.vue
+++ b/frontend/src/views/Changelist/ChangelistDetail/AddChangePanel/AddChangePanel.vue
@@ -84,7 +84,7 @@ import { NRadio, NRadioGroup } from "naive-ui";
 import { zindexable as vZindexable } from "vdirs";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { getBaselineMetadataOfBranch } from "@/components/SchemaEditorV1/utils/branch";
+import { fetchBaselineMetadataOfBranch } from "@/components/SchemaEditorV1/utils/branch";
 import { Drawer, DrawerContent, ErrorTipsButton } from "@/components/v2";
 import { schemaDesignServiceClient } from "@/grpcweb";
 import {
@@ -173,7 +173,7 @@ const doAddChange = async () => {
         const branch = useSchemaDesignStore().getSchemaDesignByName(
           change.source
         );
-        const source = getBaselineMetadataOfBranch(branch);
+        const source = await fetchBaselineMetadataOfBranch(branch);
         const target = branch.schemaMetadata;
 
         const { diff } = await schemaDesignServiceClient.diffMetadata({

--- a/frontend/src/views/Changelist/ChangelistDetail/AddChangePanel/AddChangePanel.vue
+++ b/frontend/src/views/Changelist/ChangelistDetail/AddChangePanel/AddChangePanel.vue
@@ -170,8 +170,9 @@ const doAddChange = async () => {
       }
       if (sourceType === "BRANCH") {
         // For branch changes, use its diff DDL
-        const branch = useSchemaDesignStore().getSchemaDesignByName(
-          change.source
+        const branch = await useSchemaDesignStore().fetchSchemaDesignByName(
+          change.source,
+          false /* !useCache */
         );
         const source = await fetchBaselineMetadataOfBranch(branch);
         const target = branch.schemaMetadata;

--- a/frontend/src/views/Changelist/ChangelistDetail/AddChangePanel/form/BranchChangeItem.vue
+++ b/frontend/src/views/Changelist/ChangelistDetail/AddChangePanel/form/BranchChangeItem.vue
@@ -40,12 +40,12 @@ import { NButton } from "naive-ui";
 import { computed } from "vue";
 import { RichDatabaseName } from "@/components/v2";
 import { useDatabaseV1Store } from "@/store";
-import { useSchemaDesignStore } from "@/store/modules/schemaDesign";
 import { Changelist_Change as Change } from "@/types/proto/v1/changelist_service";
 import { SchemaDesign } from "@/types/proto/v1/schema_design_service";
 
 const props = defineProps<{
   change: Change;
+  branch: SchemaDesign | undefined;
 }>();
 
 defineEmits<{
@@ -54,11 +54,10 @@ defineEmits<{
 }>();
 
 const branch = computed(() => {
-  const name = props.change.source;
   return (
-    useSchemaDesignStore().getSchemaDesignByName(name) ??
+    props.branch ??
     SchemaDesign.fromPartial({
-      name,
+      name: props.change.source,
       title: "<<Unknown Branch>>",
     })
   );

--- a/frontend/src/views/Changelist/ChangelistDetail/BranchDetailPanel/BranchDetailPanel.vue
+++ b/frontend/src/views/Changelist/ChangelistDetail/BranchDetailPanel/BranchDetailPanel.vue
@@ -22,6 +22,7 @@
 </template>
 
 <script setup lang="ts">
+import { asyncComputed } from "@vueuse/core";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import SchemaDesignEditor from "@/components/Branch/SchemaDesignEditor.vue";
@@ -41,13 +42,16 @@ defineEmits<{
 const { t } = useI18n();
 const title = ref(t("common.branch"));
 
-const branch = computed(() => {
+const branch = asyncComputed(async () => {
   const { branchName } = props;
   if (!branchName) {
     return undefined;
   }
-  return useSchemaDesignStore().getSchemaDesignByName(branchName);
-});
+  return await useSchemaDesignStore().fetchSchemaDesignByName(
+    branchName,
+    true /* useCache */
+  );
+}, undefined);
 
 const editorBindings = computed(() => {
   if (!branch.value) {

--- a/frontend/src/views/Changelist/ChangelistDetail/ChangeTable/ChangeTable.vue
+++ b/frontend/src/views/Changelist/ChangelistDetail/ChangeTable/ChangeTable.vue
@@ -50,14 +50,7 @@
       </div>
 
       <div class="bb-grid-cell">
-        <RichDatabaseName
-          v-if="databaseForChange(change)"
-          :database="databaseForChange(change)!"
-          :show-instance="false"
-          :show-arrow="false"
-          :show-production-environment-icon="false"
-          tooltip="instance"
-        />
+        <DatabaseForChange :change="change" />
       </div>
       <div class="bb-grid-cell">
         <SQL :change="change" />
@@ -74,15 +67,8 @@ import { NCheckbox } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBGrid, BBGridColumn, BBGridRow } from "@/bbkit";
-import { RichDatabaseName } from "@/components/v2";
-import { useDatabaseV1Store } from "@/store";
-import { useSchemaDesignStore } from "@/store/modules/schemaDesign";
 import { Changelist_Change as Change } from "@/types/proto/v1/changelist_service";
-import {
-  extractDatabaseResourceName,
-  isBranchChangeSource,
-  isChangeHistoryChangeSource,
-} from "@/utils";
+import DatabaseForChange from "./DatabaseForChange.vue";
 import RemoveChangeButton from "./RemoveChangeButton.vue";
 import ReorderButtons from "./ReorderButtons.vue";
 import SQL from "./SQL.vue";
@@ -154,20 +140,6 @@ const toggleSelect = (change: Change, on: boolean) => {
       set.delete(change);
       emit("update:selected", Array.from(set));
     }
-  }
-};
-
-const databaseForChange = (change: Change) => {
-  const { source } = change;
-  if (isChangeHistoryChangeSource(change)) {
-    const { full: database } = extractDatabaseResourceName(source);
-    return useDatabaseV1Store().getDatabaseByName(database);
-  } else if (isBranchChangeSource(change)) {
-    const branch = useSchemaDesignStore().getSchemaDesignByName(source);
-    return useDatabaseV1Store().getDatabaseByName(branch.baselineDatabase);
-  } else {
-    // Raw SQL
-    return undefined;
   }
 };
 

--- a/frontend/src/views/Changelist/ChangelistDetail/ChangeTable/DatabaseForChange.vue
+++ b/frontend/src/views/Changelist/ChangelistDetail/ChangeTable/DatabaseForChange.vue
@@ -1,0 +1,44 @@
+<template>
+  <RichDatabaseName
+    v-if="database"
+    :database="database!"
+    :show-instance="false"
+    :show-arrow="false"
+    :show-production-environment-icon="false"
+    tooltip="instance"
+  />
+</template>
+
+<script setup lang="ts">
+import { asyncComputed } from "@vueuse/core";
+import { RichDatabaseName } from "@/components/v2";
+import { useDatabaseV1Store, useSchemaDesignStore } from "@/store";
+import { Changelist_Change as Change } from "@/types/proto/v1/changelist_service";
+import {
+  extractDatabaseResourceName,
+  isBranchChangeSource,
+  isChangeHistoryChangeSource,
+} from "@/utils";
+
+const props = defineProps<{
+  change: Change;
+}>();
+
+const database = asyncComputed(async () => {
+  const { change } = props;
+  const { source } = change;
+  if (isChangeHistoryChangeSource(change)) {
+    const { full: database } = extractDatabaseResourceName(source);
+    return useDatabaseV1Store().getDatabaseByName(database);
+  } else if (isBranchChangeSource(change)) {
+    const branch = await useSchemaDesignStore().fetchSchemaDesignByName(
+      source,
+      true /* useCache */
+    );
+    return useDatabaseV1Store().getDatabaseByName(branch.baselineDatabase);
+  } else {
+    // Raw SQL
+    return undefined;
+  }
+}, undefined);
+</script>

--- a/frontend/src/views/Changelist/ChangelistDetail/ChangeTable/Source.vue
+++ b/frontend/src/views/Changelist/ChangelistDetail/ChangeTable/Source.vue
@@ -28,6 +28,7 @@
 </template>
 
 <script setup lang="ts">
+import { asyncComputed } from "@vueuse/core";
 import { File, GitBranch, History } from "lucide-vue-next";
 import { computed } from "vue";
 import { useChangeHistoryStore, useSchemaDesignStore } from "@/store";
@@ -47,8 +48,11 @@ const changeHistory = computed(() => {
   return useChangeHistoryStore().getChangeHistoryByName(props.change.source);
 });
 
-const branch = computed(() => {
+const branch = asyncComputed(() => {
   if (type.value !== "BRANCH") return undefined;
-  return useSchemaDesignStore().getSchemaDesignByName(props.change.source);
-});
+  return useSchemaDesignStore().fetchSchemaDesignByName(
+    props.change.source,
+    true /* useCache */
+  );
+}, undefined);
 </script>

--- a/frontend/src/views/Changelist/ChangelistDetail/NavBar/export.ts
+++ b/frontend/src/views/Changelist/ChangelistDetail/NavBar/export.ts
@@ -64,8 +64,9 @@ const zipFileForBranch = async (zip: JSZip, change: Change, index: number) => {
   if (!sheet) {
     return;
   }
-  const branch = await useSchemaDesignStore().getOrFetchSchemaDesignByName(
-    change.source
+  const branch = await useSchemaDesignStore().fetchSchemaDesignByName(
+    change.source,
+    false /* !useCache */
   );
   if (!branch) {
     return;

--- a/frontend/src/views/SyncDatabaseSchema/SchemaDesignSelector.vue
+++ b/frontend/src/views/SyncDatabaseSchema/SchemaDesignSelector.vue
@@ -15,6 +15,7 @@
     </div>
     <BBGrid
       class="border"
+      :ready="schemaDesignListReady"
       :show-placeholder="true"
       :column-list="COLUMN_LIST"
       :data-source="schemaDesignList"
@@ -87,7 +88,8 @@ const router = useRouter();
 const userV1Store = useUserStore();
 const projectV1Store = useProjectV1Store();
 const databaseV1Store = useDatabaseV1Store();
-const { schemaDesignList } = useSchemaDesignList();
+const { schemaDesignList, ready: schemaDesignListReady } =
+  useSchemaDesignList();
 const selectedSchemaDesign = ref<SchemaDesign | undefined>(
   props.selectedSchemaDesign
 );

--- a/frontend/src/views/SyncDatabaseSchema/SchemaDesignSelector.vue
+++ b/frontend/src/views/SyncDatabaseSchema/SchemaDesignSelector.vue
@@ -25,22 +25,22 @@
           <NRadio :checked="schemaDesign.name === selectedSchemaDesign?.name" />
         </div>
         <div class="bb-grid-cell">
-          {{ projectV1Name(getFormatedValue(schemaDesign).project) }}
+          {{ projectV1Name(getFormattedValue(schemaDesign).project) }}
         </div>
         <div class="bb-grid-cell">
           <NEllipsis :line-clamp="1">{{ schemaDesign.title }}</NEllipsis>
         </div>
         <div class="bb-grid-cell">
           <NEllipsis :line-clamp="1">{{
-            getFormatedValue(schemaDesign).parentBranch
+            getFormattedValue(schemaDesign).parentBranch
           }}</NEllipsis>
         </div>
         <div class="bb-grid-cell">
-          <DatabaseInfo :database="getFormatedValue(schemaDesign).database" />
+          <DatabaseInfo :database="getFormattedValue(schemaDesign).database" />
         </div>
         <div class="bb-grid-cell">
           <span class="text-gray-400">{{
-            getFormatedValue(schemaDesign).updatedTimeStr
+            getFormattedValue(schemaDesign).updatedTimeStr
           }}</span>
         </div>
 
@@ -66,10 +66,7 @@ import { useRouter } from "vue-router";
 import { BBGridColumn } from "@/bbkit";
 import DatabaseInfo from "@/components/DatabaseInfo.vue";
 import { useDatabaseV1Store, useProjectV1Store, useUserStore } from "@/store";
-import {
-  useSchemaDesignList,
-  useSchemaDesignStore,
-} from "@/store/modules/schemaDesign";
+import { useSchemaDesignList } from "@/store/modules/schemaDesign";
 import { getProjectAndSchemaDesignSheetId } from "@/store/modules/v1/common";
 import {
   SchemaDesign,
@@ -90,7 +87,6 @@ const router = useRouter();
 const userV1Store = useUserStore();
 const projectV1Store = useProjectV1Store();
 const databaseV1Store = useDatabaseV1Store();
-const schemaDesignStore = useSchemaDesignStore();
 const { schemaDesignList } = useSchemaDesignList();
 const selectedSchemaDesign = ref<SchemaDesign | undefined>(
   props.selectedSchemaDesign
@@ -113,13 +109,13 @@ const COLUMN_LIST = computed(() => {
   return columns;
 });
 
-const getFormatedValue = (schemaDesign: SchemaDesign) => {
+const getFormattedValue = (schemaDesign: SchemaDesign) => {
   const [projectName] = getProjectAndSchemaDesignSheetId(schemaDesign.name);
   const project = projectV1Store.getProjectByName(`projects/${projectName}`);
   let parentBranch = "";
   if (schemaDesign.type === SchemaDesign_Type.PERSONAL_DRAFT) {
-    const parentSchemaDesign = schemaDesignStore.getSchemaDesignByName(
-      schemaDesign.baselineSheetName
+    const parentSchemaDesign = schemaDesignList.value.find(
+      (parent) => parent.name === schemaDesign.baselineSheetName
     );
     if (parentSchemaDesign) {
       parentBranch = parentSchemaDesign.title;

--- a/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
+++ b/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
@@ -251,6 +251,7 @@
 
 <script lang="ts" setup>
 import { toClipboard } from "@soerenmartius/vue3-clipboard";
+import { asyncComputed } from "@vueuse/core";
 import { head } from "lodash-es";
 import { NEllipsis } from "naive-ui";
 import { computed, nextTick, onMounted, reactive, ref, watch } from "vue";
@@ -331,12 +332,15 @@ const project = computed(() => {
   return useProjectV1Store().getProjectByUID(props.projectId);
 });
 
-const selectedSchemaDesign = computed(() => {
+const selectedSchemaDesign = asyncComputed(() => {
   if (!props.schemaDesignName) {
     return undefined;
   }
-  return schemaDesignStore.getSchemaDesignByName(props.schemaDesignName);
-});
+  return schemaDesignStore.fetchSchemaDesignByName(
+    props.schemaDesignName,
+    true /* useCache */
+  );
+}, undefined);
 const sourceDatabaseSchema = computed(() => {
   if (props.sourceSchemaType === "SCHEMA_HISTORY_VERSION") {
     return props.databaseSourceSchema?.changeHistory.schema || "";

--- a/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
+++ b/frontend/src/views/SyncDatabaseSchema/SelectTargetDatabasesView.vue
@@ -372,7 +372,7 @@ const engine = computed(() => {
       props.databaseSourceSchema!.databaseId
     ).instanceEntity.engine;
   } else if (props.sourceSchemaType === "SCHEMA_DESIGN") {
-    return selectedSchemaDesign.value!.engine;
+    return selectedSchemaDesign.value?.engine ?? Engine.ENGINE_UNSPECIFIED;
   } else if (props.sourceSchemaType === "RAW_SQL") {
     return props.rawSqlState!.engine;
   } else {

--- a/frontend/src/views/SyncDatabaseSchema/index.vue
+++ b/frontend/src/views/SyncDatabaseSchema/index.vue
@@ -196,8 +196,9 @@ onMounted(async () => {
     .schemaDesignName as string;
   if (schemaDesignName) {
     try {
-      const schemaDesign = await schemaDesignStore.getOrFetchSchemaDesignByName(
-        schemaDesignName
+      const schemaDesign = await schemaDesignStore.fetchSchemaDesignByName(
+        schemaDesignName,
+        false /* !useCache */
       );
       if (schemaDesign) {
         state.sourceSchemaType = "SCHEMA_DESIGN";

--- a/frontend/src/views/branch/BranchDetail.vue
+++ b/frontend/src/views/branch/BranchDetail.vue
@@ -1,17 +1,17 @@
 <template>
-  <template v-if="initialized">
+  <template v-if="data.ready">
     <template v-if="isCreating">
-      <BranchCreateView />
+      <BranchCreateView v-bind="$attrs" />
     </template>
-    <template v-else-if="branchName">
-      <BranchDetailView :schema-design-name="branchName" />
+    <template v-else-if="data.branch">
+      <BranchDetailView :branch="data.branch" v-bind="$attrs" />
     </template>
   </template>
 </template>
 
 <script lang="ts" setup>
-import { useTitle } from "@vueuse/core";
-import { computed, ref, watchEffect } from "vue";
+import { asyncComputed, useTitle } from "@vueuse/core";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import BranchCreateView from "@/components/Branch/BranchCreateView.vue";
@@ -19,43 +19,48 @@ import BranchDetailView from "@/components/Branch/BranchDetailView.vue";
 import { useProjectV1Store, useSheetV1Store } from "@/store";
 import { useSchemaDesignStore } from "@/store/modules/schemaDesign";
 import { getProjectAndSheetId } from "@/store/modules/v1/common";
+import { SchemaDesign } from "@/types/proto/v1/schema_design_service";
 
 const { t } = useI18n();
 const route = useRoute();
 const sheetStore = useSheetV1Store();
 const projectStore = useProjectV1Store();
 const schemaDesignStore = useSchemaDesignStore();
-const initialized = ref(false);
 
 const isCreating = computed(() => route.params.branchName === "new");
-const branchName = computed(() => {
-  return `projects/${route.params.projectName}/schemaDesigns/${route.params.branchName}`;
-});
 
-watchEffect(async () => {
-  if (!isCreating.value) {
-    const sheetId = (route.params.branchName || "") as string;
-    const sheet = await sheetStore.getOrFetchSheetByUID(`${sheetId}`);
-    if (sheet) {
-      const [projectName] = getProjectAndSheetId(sheet.name);
-      await projectStore.getOrFetchProjectByName(`projects/${projectName}`);
-      await schemaDesignStore.getOrFetchSchemaDesignByName(
-        `projects/${projectName}/schemaDesigns/${sheetId}`
-      );
+const data = asyncComputed<{ ready: boolean; branch?: SchemaDesign }>(
+  async () => {
+    if (isCreating.value) {
+      return { ready: true };
+    } else {
+      const sheetId = (route.params.branchName as string) || "";
+      if (!sheetId) {
+        return { ready: false };
+      }
+      const sheet = await sheetStore.getOrFetchSheetByUID(`${sheetId}`);
+      if (sheet) {
+        const [projectName] = getProjectAndSheetId(sheet.name);
+        await projectStore.getOrFetchProjectByName(`projects/${projectName}`);
+        const branch = await schemaDesignStore.fetchSchemaDesignByName(
+          `projects/${projectName}/schemaDesigns/${sheetId}`,
+          true /* useCache */
+        );
+        return { ready: true, branch };
+      }
     }
-  }
-  initialized.value = true;
-});
+
+    return { ready: false };
+  },
+  { ready: false }
+);
 
 const documentTitle = computed(() => {
   if (isCreating.value) {
     return t("schema-designer.new-branch");
   } else {
-    if (branchName.value) {
-      const schemaDesign = schemaDesignStore.getSchemaDesignByName(
-        branchName.value
-      );
-      return `${schemaDesign.title}`;
+    if (data.value.branch) {
+      return data.value.branch.title;
     }
   }
   return t("common.loading");

--- a/frontend/src/views/branch/BranchDetail.vue
+++ b/frontend/src/views/branch/BranchDetail.vue
@@ -1,10 +1,10 @@
 <template>
   <template v-if="data.ready">
     <template v-if="isCreating">
-      <BranchCreateView v-bind="$attrs" />
+      <BranchCreateView />
     </template>
     <template v-else-if="data.branch">
-      <BranchDetailView :branch="data.branch" v-bind="$attrs" />
+      <BranchDetailView :branch="data.branch" />
     </template>
   </template>
 </template>


### PR DESCRIPTION
### Refactor
- results in ListSchemaDesigns will no longer be written to the local cache since they might be just a truncated brief view in the future
- calling no more `getSchemaDesignByName` and `getOrFetchSchemaDesignByName`. Call `fetchSchemaDesignByName` instead, with an explicit `useCache` flag.

### Other minor changes
- Baseline selector when creating branches now will no longer auto-select invalid (DML, actually) change history.
- Loading indicators for
  - Branch list in "Sync Schema -> Branches"
  - Merge branch panel
- Make linter happy