### PR TITLE
fix(frontend): set creator field before creating issue

### DIFF
--- a/frontend/src/components/CreateDatabasePrepForm/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm/CreateDatabasePrepForm.vue
@@ -448,8 +448,9 @@ const createV1 = async () => {
   });
   specs.push(spec);
 
-  const issueCreate = Issue.fromJSON({
+  const issueCreate = Issue.fromPartial({
     type: Issue_Type.DATABASE_CHANGE,
+    creator: `users/${currentUserV1.value.email}`,
   });
 
   if (props.backup) {

--- a/frontend/src/components/DatabaseBackup/BackupTable.vue
+++ b/frontend/src/components/DatabaseBackup/BackupTable.vue
@@ -351,10 +351,10 @@ const doRestoreInPlaceV1 = async () => {
         target: database.name, // in-place
       },
     });
-    const planCreate = Plan.fromJSON({
+    const planCreate = Plan.fromPartial({
       steps: [{ specs: [restoreDatabaseSpec] }],
     });
-    const issueCreate = Issue.fromJSON({
+    const issueCreate = Issue.fromPartial({
       title: issueNameParts.join(" "),
       type: Issue_Type.DATABASE_CHANGE,
       creator: `users/${me.value.email}`,

--- a/frontend/src/components/DatabaseBackup/BackupTable.vue
+++ b/frontend/src/components/DatabaseBackup/BackupTable.vue
@@ -156,7 +156,11 @@ import {
 import EllipsisText from "@/components/EllipsisText.vue";
 import HumanizeDate from "@/components/misc/HumanizeDate.vue";
 import { Drawer, DrawerContent } from "@/components/v2";
-import { experimentalCreateIssueByPlan, useSubscriptionV1Store } from "@/store";
+import {
+  experimentalCreateIssueByPlan,
+  useCurrentUserV1,
+  useSubscriptionV1Store,
+} from "@/store";
 import { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto/v1/common";
 import {
@@ -212,6 +216,7 @@ const state = reactive<LocalState>({
   creatingRestoreIssue: false,
   showFeatureModal: false,
 });
+const me = useCurrentUserV1();
 
 const allowRestoreInPlace = computed((): boolean => {
   return props.database.instanceEntity.engine === Engine.POSTGRES;
@@ -352,6 +357,7 @@ const doRestoreInPlaceV1 = async () => {
     const issueCreate = Issue.fromJSON({
       title: issueNameParts.join(" "),
       type: Issue_Type.DATABASE_CHANGE,
+      creator: `users/${me.value.email}`,
     });
     await trySetDefaultAssigneeByEnvironment(
       issueCreate,

--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -377,7 +377,7 @@ const onConfirmV1 = async () => {
       restoreDatabaseConfig,
     });
 
-    const planCreate = Plan.fromJSON({
+    const planCreate = Plan.fromPartial({
       steps: [{ specs: [spec] }],
     });
 

--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -394,7 +394,7 @@ const onConfirmV1 = async () => {
         `before migration version [${lastChangeHistory.value!.version}]`
       );
     }
-    const issueCreate = Issue.fromJSON({
+    const issueCreate = Issue.fromPartial({
       title: issueNameParts.join(" "),
       type: Issue_Type.DATABASE_CHANGE,
       creator: `users/${me.value.email}`,

--- a/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
+++ b/frontend/src/components/DatabaseDetail/PITRRestoreButton.vue
@@ -155,7 +155,11 @@ import BBContextMenuButton, {
 } from "@/bbkit/BBContextMenuButton.vue";
 import { Drawer, DrawerContent } from "@/components/v2";
 import { usePITRLogic } from "@/plugins";
-import { experimentalCreateIssueByPlan, useSubscriptionV1Store } from "@/store";
+import {
+  experimentalCreateIssueByPlan,
+  useCurrentUserV1,
+  useSubscriptionV1Store,
+} from "@/store";
 import { ComposedDatabase } from "@/types";
 import { Issue, Issue_Type } from "@/types/proto/v1/issue_service";
 import {
@@ -210,6 +214,7 @@ const state = reactive<LocalState>({
   loading: false,
   showFeatureModal: false,
 });
+const me = useCurrentUserV1();
 
 const createDatabaseForm = ref<InstanceType<typeof CreatePITRDatabaseForm>>();
 
@@ -392,6 +397,7 @@ const onConfirmV1 = async () => {
     const issueCreate = Issue.fromJSON({
       title: issueNameParts.join(" "),
       type: Issue_Type.DATABASE_CHANGE,
+      creator: `users/${me.value.email}`,
     });
     await trySetDefaultAssigneeByEnvironment(
       issueCreate,


### PR DESCRIPTION
If the first stage's environment rollout policy is set to "auto" or "creator", we will set the default assignee as the creator.
FYI @RainbowDashy 
Close BYT-4251