### PR TITLE
chore: improve github application id error msg

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1836,7 +1836,7 @@
           "create-oauth-app": "Create your Bytebase OAuth application with the following info.",
           "gitlab-application-id-error": "Application ID must be a 64-character alphanumeric string",
           "gitlab-secret-error": "Secret must be a 64-character alphanumeric string",
-          "github-application-id-error": "Application ID must be a 20-character alphanumeric string",
+          "github-application-id-error": "Application ID must be a 20-character alphanumeric string. Please make sure it is a OAuth App instead of a GitHub App.",
           "github-secret-error": "Secret must be a 40-character alphanumeric string",
           "bitbucket-application-id-error": "Application ID must be a 18-character alphanumeric string",
           "bitbucket-secret-error": "Secret must be a 32-character alphanumeric string"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1834,7 +1834,7 @@
           "create-oauth-app": "Cree su aplicación OAuth de Bytebase con la siguiente información.",
           "gitlab-application-id-error": "El ID de aplicación debe ser una cadena alfanumérica de 64 caracteres",
           "gitlab-secret-error": "El secreto debe ser una cadena alfanumérica de 64 caracteres",
-          "github-application-id-error": "El ID de aplicación debe ser una cadena alfanumérica de 20 caracteres",
+          "github-application-id-error": "El ID de aplicación debe ser una cadena alfanumérica de 20 caracteres. Asegúrese de que sea una aplicación OAuth en lugar de una aplicación GitHub.",
           "github-secret-error": "El secreto debe ser una cadena alfanumérica de 40 caracteres",
           "bitbucket-application-id-error": "El ID de aplicación debe ser una cadena alfanumérica de 18 caracteres",
           "bitbucket-secret-error": "El secreto debe ser una cadena alfanumérica de 32 caracteres",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1830,7 +1830,7 @@
           "create-oauth-app": "使用如下信息来创建您的 Bytebase OAuth 应用。",
           "gitlab-application-id-error": "应用 ID 必须是 64 个字母长度",
           "gitlab-secret-error": "Secret 必须是 64 个字母长度",
-          "github-application-id-error": "应用 ID 必须是 20 个字母长度",
+          "github-application-id-error": "应用 ID 必须是 20 个字母长度。请确认这是一个 OAuth 应用而不是 GitHub 应用。",
           "github-secret-error": "Secret 必须是 40 个字母长度",
           "bitbucket-application-id-error": "应用 ID 必须是 18 个字母长度",
           "bitbucket-secret-error": "Secret 必须是 32 个字母长度",


### PR DESCRIPTION
![image](https://github.com/bytebase/bytebase/assets/230323/5612ef2f-d43f-46d0-ae39-04bff35d8b07)

Customer accidentally creates a GitHub app instead of an OAuth app.