### PR TITLE
fix(SQL-Server): support using variable in mssql execute

### DIFF
--- a/backend/plugin/db/mssql/mssql.go
+++ b/backend/plugin/db/mssql/mssql.go
@@ -13,6 +13,7 @@ import (
 	// Import go-ora Oracle driver.
 	_ "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/integratedauth/krb5"
+	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/bytebase/bytebase/backend/common/log"
@@ -92,36 +93,26 @@ func (driver *Driver) Execute(ctx context.Context, statement string, createDatab
 		}
 		return 0, nil
 	}
-	totalRowsAffected := int64(0)
 	tx, err := driver.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}
 	defer tx.Rollback()
 
-	f := func(stmt string) error {
-		sqlResult, err := tx.ExecContext(ctx, stmt)
-		if err != nil {
-			return err
-		}
-		rowsAffected, err := sqlResult.RowsAffected()
-		if err != nil {
-			// Since we cannot differentiate DDL and DML yet, we have to ignore the error.
-			slog.Debug("rowsAffected returns error", log.BBError(err))
-		} else {
-			totalRowsAffected += rowsAffected
-		}
-		return nil
+	sqlResult, err := tx.ExecContext(ctx, statement)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to execute statement")
 	}
-
-	if _, err := tsqlparser.SplitMultiSQLStream(strings.NewReader(statement), f); err != nil {
-		return 0, err
+	rowsAffected, err := sqlResult.RowsAffected()
+	if err != nil {
+		// Since we cannot differentiate DDL and DML yet, we have to ignore the error.
+		slog.Debug("rowsAffected returns error", log.BBError(err))
 	}
 
 	if err := tx.Commit(); err != nil {
 		return 0, err
 	}
-	return totalRowsAffected, nil
+	return rowsAffected, nil
 }
 
 // QueryConn queries a SQL statement in a given connection.


### PR DESCRIPTION
Previously, we split the statements into single statement. But it is meaningless for SQL Server which support sending multiple single statement to driver in a batch. **[The scope of a local variable is the batch in which it's declared.](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/declare-local-variable-transact-sql?view=sql-server-ver16#remarks)**

## Previous
![CleanShot 2023-10-23 at 10 29 54@2x](https://github.com/bytebase/bytebase/assets/87714218/d01ca20f-caff-4c96-8dcd-462cfee46f84)

## Current
![CleanShot 2023-10-23 at 10 26 31@2x](https://github.com/bytebase/bytebase/assets/87714218/ece2ebba-5fa5-4fc7-abb1-31929efd3a81)
