### PR TITLE
chore: fail the pipeline if the sql review result doesn't succeed

### DIFF
--- a/backend/plugin/vcs/azure/bytebase-sql-review.yml
+++ b/backend/plugin/vcs/azure/bytebase-sql-review.yml
@@ -50,5 +50,5 @@ jobs:
           testResultsFiles: "**/bytebase-sql-review.xml"
         displayName: Upload artifacts
       - bash: |
-          if [[ "$STATUS" == "ERROR" ]]; then exit 1; fi
+          if [[ "$STATUS" != "SUCCESS" ]]; then exit 1; fi
         displayName: Check SQL Review Result


### PR DESCRIPTION
Azure test pipeline cannot show the warning, and will pass the check if the result only contains warnings
Close BYT-4256