### PR TITLE
feat: add redshift character/bit type length to metadata

### DIFF
--- a/backend/plugin/db/redshift/sync.go
+++ b/backend/plugin/db/redshift/sync.go
@@ -446,6 +446,7 @@ func getTableColumns(txn *sql.Tx) (map[db.TableKey][]*storepb.ColumnMetadata, er
 		cols.table_name,
 		cols.column_name,
 		cols.data_type,
+		cols.character_maximum_length,
 		cols.ordinal_position,
 		cols.column_default,
 		cols.is_nullable,
@@ -467,8 +468,8 @@ func getTableColumns(txn *sql.Tx) (map[db.TableKey][]*storepb.ColumnMetadata, er
 	for rows.Next() {
 		column := &storepb.ColumnMetadata{}
 		var schemaName, tableName, nullable string
-		var defaultStr, collation, udtSchema, udtName, comment sql.NullString
-		if err := rows.Scan(&schemaName, &tableName, &column.Name, &column.Type, &column.Position, &defaultStr, &nullable, &collation, &udtSchema, &udtName, &comment); err != nil {
+		var characterMaxLength, defaultStr, collation, udtSchema, udtName, comment sql.NullString
+		if err := rows.Scan(&schemaName, &tableName, &column.Name, &column.Type, &characterMaxLength, &column.Position, &defaultStr, &nullable, &collation, &udtSchema, &udtName, &comment); err != nil {
 			return nil, err
 		}
 		if defaultStr.Valid {
@@ -485,6 +486,8 @@ func getTableColumns(txn *sql.Tx) (map[db.TableKey][]*storepb.ColumnMetadata, er
 			column.Type = fmt.Sprintf("%s.%s", udtSchema.String, udtName.String)
 		case "ARRAY":
 			column.Type = udtName.String
+		case "character", "character varying", "bit", "bit varying":
+			column.Type = fmt.Sprintf("%s(%s)", column.Type, characterMaxLength.String)
 		}
 		column.Collation = collation.String
 		column.Comment = comment.String


### PR DESCRIPTION
after: 
![image](https://github.com/bytebase/bytebase/assets/71714656/93179262-3ec2-4a2f-9d0d-06087940d963)
