### PR TITLE
chore: update air.toml to disable optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ docs/openapi/swagger.json
 docs/sqlservice/swagger.json
 frontend/src/types/sql-review.*.yaml
 frontend/src/types/plan.yaml
+
+scripts/.air.toml

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -5,8 +5,11 @@ tmp_dir = ".air"
 [build]
 bin = './.air/bytebase --port 8080 --data . --debug --disable-sample'
 ## Use --tags "store.db" to enable SQL query logging against our metadata db.
+## Use -gcflags="all=-N -l" to disable inlining and optimization
+
 cmd = """
   go build \
+  -gcflags="all=-N -l" \
   --tags "minimal" \
   -o ./.air/bytebase ./backend/bin/server/main.go"""
 delay = 500


### PR DESCRIPTION
1. Use -gcflags="all= -N -l" to disable inlining and optimization, and then the dlv can read values of some process variable which would be optimized originally. `(dlv) (unreadable could not find loclist entry at 0x49e7a for address 0x44f9b9)`

2. add .air.toml to gitignore, parser members use ultimate tag most of time. Use `git add scripts/.air.toml -f` can staged it forcely`.
