### PR TITLE
chore: reorder project sidebar items

### DIFF
--- a/frontend/src/components/Project/ProjectSidebar.vue
+++ b/frontend/src/components/Project/ProjectSidebar.vue
@@ -96,6 +96,13 @@ const projectSidebarItemList = computed((): ProjectSidebarItem[] => {
           hash: "databases",
         },
         {
+          title: t("common.groups"),
+          hash: "database-groups",
+          hide:
+            isTenantProject.value ||
+            !currentUserIamPolicy.isMemberOfProject(project.value.name),
+        },
+        {
           title: t("common.change-history"),
           hash: "change-history",
           hide:
@@ -108,13 +115,6 @@ const projectSidebarItemList = computed((): ProjectSidebarItem[] => {
           hide: !currentUserIamPolicy.isMemberOfProject(project.value.name),
         },
         // TODO: Anomaly
-        {
-          title: t("common.database-groups"),
-          hash: "database-groups",
-          hide:
-            isTenantProject.value ||
-            !currentUserIamPolicy.isMemberOfProject(project.value.name),
-        },
       ],
     },
     {
@@ -138,23 +138,6 @@ const projectSidebarItemList = computed((): ProjectSidebarItem[] => {
     // TODO: Changelists
     // TODO: Sync schema
     {
-      title: t("common.manage"),
-      icon: h(Users),
-      hide:
-        isDefaultProject.value ||
-        !currentUserIamPolicy.isMemberOfProject(project.value.name),
-      children: [
-        {
-          title: t("common.members"),
-          hash: "members",
-        },
-        {
-          title: t("common.activities"),
-          hash: "activities",
-        },
-      ],
-    },
-    {
       title: t("settings.sidebar.integration"),
       icon: h(Link),
       hide:
@@ -170,6 +153,23 @@ const projectSidebarItemList = computed((): ProjectSidebarItem[] => {
         {
           title: t("common.webhooks"),
           hash: "webhook",
+        },
+      ],
+    },
+    {
+      title: t("common.manage"),
+      icon: h(Users),
+      hide:
+        isDefaultProject.value ||
+        !currentUserIamPolicy.isMemberOfProject(project.value.name),
+      children: [
+        {
+          title: t("common.members"),
+          hash: "members",
+        },
+        {
+          title: t("common.activities"),
+          hash: "activities",
         },
       ],
     },

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -254,6 +254,7 @@
     },
     "expiration": "Expiration",
     "configure": "Configure",
+    "groups": "Groups",
     "database-groups": "Database Groups",
     "members": "Members",
     "warehouse": "Warehouse",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -254,6 +254,7 @@
     },
     "expiration": "Expiración",
     "configure": "Configurar",
+    "groups": "Grupos",
     "database-groups": "Grupo de bases de datos",
     "members": "Miembros",
     "warehouse": "Almacén",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -252,6 +252,7 @@
     },
     "expiration": "过期时间",
     "configure": "配置",
+    "groups": "分组",
     "database-groups": "数据库分组",
     "members": "成员",
     "warehouse": "仓库",


### PR DESCRIPTION
1. Reordered the items in the project sidebar. "Integration / GitOps" is more interesting and valuable than managing members.
2. "Database Groups" to "Groups". Since we've already put it under database section, there is no need to mention it again. This also reduces its form in Español.


Before:
<img width="1338" alt="Screenshot 2023-10-24 at 22 17 57" src="https://github.com/bytebase/bytebase/assets/98006139/dd9b1773-d15b-42f8-8d2d-c95512c2d3cc">

After:
<img width="1338" alt="Screenshot 2023-10-24 at 22 19 00" src="https://github.com/bytebase/bytebase/assets/98006139/6488feee-a099-432a-bd4d-8f590fc5667f">
