### PR TITLE
chore: move branches from header to sidebar

### DIFF
--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -13,13 +13,6 @@
           >
 
           <router-link
-            to="/branches"
-            class="bar-link px-2 py-1 rounded-md"
-            :class="getRouteLinkClass('/branches')"
-            >{{ $t("common.branches") }}</router-link
-          >
-
-          <router-link
             to="/project"
             class="bar-link px-2 py-1 rounded-md"
             :class="getRouteLinkClass('/project')"

--- a/frontend/src/views/DashboardSidebar.vue
+++ b/frontend/src/views/DashboardSidebar.vue
@@ -40,6 +40,13 @@
         {{ $t("database.sync-schema.title") }}
       </router-link>
       <router-link
+        to="/branches"
+        class="outline-item group flex items-center px-2 py-1.5 capitalize"
+      >
+        <GitBranch class="w-5 h-5 mr-2" />
+        {{ $t("common.branches") }}
+      </router-link>
+      <router-link
         to="/slow-query"
         class="outline-item group flex items-center px-2 py-1.5 capitalize"
       >
@@ -84,7 +91,7 @@
 
 <script lang="ts" setup>
 import { useKBarHandler } from "@bytebase/vue-kbar";
-import { PencilRuler } from "lucide-vue-next";
+import { GitBranch, PencilRuler } from "lucide-vue-next";
 import { computed } from "vue";
 import BookmarkListSidePanel from "@/components/BookmarkListSidePanel.vue";
 import BytebaseLogo from "@/components/BytebaseLogo.vue";


### PR DESCRIPTION
Move branches from header to sidebar.
1. Branches should not belong to header since it's not as important as other resources such as projects, databases, instances.
2. There is limited space in the header.
3. We will renovate the header later so let's make a little change now.

Before:
<img width="1205" alt="Screenshot 2023-10-25 at 10 19 09" src="https://github.com/bytebase/bytebase/assets/98006139/85287b06-1462-493e-8297-8c70e0e3607e">

After:
<img width="1207" alt="Screenshot 2023-10-25 at 10 18 49" src="https://github.com/bytebase/bytebase/assets/98006139/1b00c1f5-dbff-44c6-b401-347bcd78c2a6">
