### PR TITLE
fix: data source in branch detail page

### DIFF
--- a/frontend/src/store/modules/schemaDesign.ts
+++ b/frontend/src/store/modules/schemaDesign.ts
@@ -119,6 +119,10 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
     return request;
   };
 
+  const getSchemaDesignByName = (name: string) => {
+    return schemaDesignMapByName.get(name);
+  };
+
   const deleteSchemaDesign = async (name: string) => {
     await schemaDesignServiceClient.deleteSchemaDesign({
       name,
@@ -155,6 +159,7 @@ export const useSchemaDesignStore = defineStore("schema_design", () => {
     updateSchemaDesign,
     mergeSchemaDesign,
     fetchSchemaDesignByName,
+    getSchemaDesignByName,
     parseSchemaString,
     deleteSchemaDesign,
   };

--- a/frontend/src/views/branch/BranchDetail.vue
+++ b/frontend/src/views/branch/BranchDetail.vue
@@ -1,17 +1,18 @@
 <template>
-  <template v-if="data.ready">
+  <template v-if="ready">
     <template v-if="isCreating">
       <BranchCreateView />
     </template>
-    <template v-else-if="data.branch">
-      <BranchDetailView :branch="data.branch" />
+    <template v-else-if="branch">
+      <BranchDetailView :branch="branch" />
     </template>
   </template>
 </template>
 
 <script lang="ts" setup>
-import { asyncComputed, useTitle } from "@vueuse/core";
-import { computed } from "vue";
+import { useTitle } from "@vueuse/core";
+import { computed, ref } from "vue";
+import { onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import BranchCreateView from "@/components/Branch/BranchCreateView.vue";
@@ -19,48 +20,50 @@ import BranchDetailView from "@/components/Branch/BranchDetailView.vue";
 import { useProjectV1Store, useSheetV1Store } from "@/store";
 import { useSchemaDesignStore } from "@/store/modules/schemaDesign";
 import { getProjectAndSheetId } from "@/store/modules/v1/common";
-import { SchemaDesign } from "@/types/proto/v1/schema_design_service";
 
 const { t } = useI18n();
 const route = useRoute();
 const sheetStore = useSheetV1Store();
 const projectStore = useProjectV1Store();
 const schemaDesignStore = useSchemaDesignStore();
+const branchName = ref<string>("");
+const ready = ref<boolean>(false);
 
 const isCreating = computed(() => route.params.branchName === "new");
+const branch = computed(() => {
+  return schemaDesignStore.getSchemaDesignByName(branchName.value);
+});
 
-const data = asyncComputed<{ ready: boolean; branch?: SchemaDesign }>(
-  async () => {
-    if (isCreating.value) {
-      return { ready: true };
-    } else {
-      const sheetId = (route.params.branchName as string) || "";
-      if (!sheetId) {
-        return { ready: false };
-      }
-      const sheet = await sheetStore.getOrFetchSheetByUID(`${sheetId}`);
-      if (sheet) {
-        const [projectName] = getProjectAndSheetId(sheet.name);
-        await projectStore.getOrFetchProjectByName(`projects/${projectName}`);
-        const branch = await schemaDesignStore.fetchSchemaDesignByName(
-          `projects/${projectName}/schemaDesigns/${sheetId}`,
-          true /* useCache */
-        );
-        return { ready: true, branch };
-      }
-    }
+onMounted(async () => {
+  if (isCreating.value) {
+    ready.value = true;
+    return;
+  }
 
+  // Prepare branch name from route params.
+  const sheetId = (route.params.branchName as string) || "";
+  if (!sheetId) {
     return { ready: false };
-  },
-  { ready: false }
-);
+  }
+  const sheet = await sheetStore.getOrFetchSheetByUID(`${sheetId}`);
+  if (sheet) {
+    const [projectName] = getProjectAndSheetId(sheet.name);
+    await projectStore.getOrFetchProjectByName(`projects/${projectName}`);
+    branchName.value = `projects/${projectName}/schemaDesigns/${sheetId}`;
+    await schemaDesignStore.fetchSchemaDesignByName(
+      branchName.value,
+      false /* useCache */
+    );
+    ready.value = true;
+  }
+});
 
 const documentTitle = computed(() => {
   if (isCreating.value) {
     return t("schema-designer.new-branch");
   } else {
-    if (data.value.branch) {
-      return data.value.branch.title;
+    if (branch.value) {
+      return branch.value.title;
     }
   }
   return t("common.loading");


### PR DESCRIPTION
Close BYT-4284
The `data.branch` will always remain the same value with `asyncComputed`. But it should comes from the latest data in store.