### PR TITLE
chore(cicd): fix last approver rollout policy

### DIFF
--- a/frontend/src/components/IssueV1/components/HeaderSection/Assignee/Assignee.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Assignee/Assignee.vue
@@ -50,6 +50,7 @@ import {
   getCurrentRolloutPolicyForTask,
   useIssueContext,
 } from "@/components/IssueV1/logic";
+import ErrorList, { ErrorItem } from "@/components/misc/ErrorList.vue";
 import { UserSelect } from "@/components/v2";
 import { issueServiceClient } from "@/grpcweb";
 import { pushNotification, useCurrentUserV1, useUserStore } from "@/store";
@@ -69,7 +70,6 @@ import {
   extractUserResourceName,
   extractUserUID,
 } from "@/utils";
-import { ErrorList } from "../../common";
 import AssigneeAttentionButton from "./AssigneeAttentionButton.vue";
 
 const { t } = useI18n();
@@ -100,7 +100,7 @@ const allowChangeAssignee = computed(() => {
 });
 
 const errors = asyncComputed(async () => {
-  const errors: string[] = [];
+  const errors: ErrorItem[] = [];
   if (!allowChangeAssignee.value) {
     errors.push(t("issue.you-are-not-allowed-to-change-this-value"));
   } else if (assigneeCandidates.value.length === 0) {
@@ -112,22 +112,28 @@ const errors = asyncComputed(async () => {
     );
     errors.push(t("issue.allow-any-following-roles-to-be-assignee"));
     if (policy.workspaceRoles.includes(VirtualRoleType.OWNER)) {
-      errors.push(t("policy.rollout.role.workspace-owner"));
+      errors.push({
+        error: t("policy.rollout.role.workspace-owner"),
+        indent: 1,
+      });
     }
     if (policy.workspaceRoles.includes(VirtualRoleType.DBA)) {
-      errors.push(t("policy.rollout.role.dba"));
+      errors.push({ error: t("policy.rollout.role.dba"), indent: 1 });
     }
     if (policy.projectRoles.includes(PresetRoleType.OWNER)) {
-      errors.push(t("policy.rollout.role.project-owner"));
+      errors.push({ error: t("policy.rollout.role.project-owner"), indent: 1 });
     }
     if (policy.projectRoles.includes(PresetRoleType.RELEASER)) {
-      errors.push(t("policy.rollout.role.project-releaser"));
+      errors.push({
+        error: t("policy.rollout.role.project-releaser"),
+        indent: 1,
+      });
     }
     if (policy.issueRoles.includes(VirtualRoleType.CREATOR)) {
-      errors.push(t("policy.rollout.role.issue-creator"));
+      errors.push({ error: t("policy.rollout.role.issue-creator"), indent: 1 });
     }
     if (policy.issueRoles.includes(VirtualRoleType.LAST_APPROVER)) {
-      errors.push(t("policy.rollout.role.last-approver"));
+      errors.push({ error: t("policy.rollout.role.last-approver"), indent: 1 });
     }
   }
 

--- a/frontend/src/components/IssueV1/logic/assignee.ts
+++ b/frontend/src/components/IssueV1/logic/assignee.ts
@@ -181,23 +181,20 @@ export const assigneeCandidatesForIssue = async (issue: ComposedIssue) => {
     }
   }
   if (issueRoles.includes(VirtualRoleType.LAST_APPROVER)) {
-    const lastApprover = lastApproverForIssue(issue);
-    if (lastApprover) {
-      users.push(lastApprover);
-    }
+    const lastApprovers = lastApproverCandidatesForIssue(issue);
+    users.push(...lastApprovers);
   }
 
   return uniqBy(users, (user) => user.name);
 };
 
-const lastApproverForIssue = (issue: ComposedIssue) => {
+const lastApproverCandidatesForIssue = (issue: ComposedIssue) => {
   const context = extractIssueReviewContext(computed(() => issue));
-  if (!context.done) return undefined;
+  if (!context.ready) return [];
 
   const steps = useWrappedReviewStepsV1(issue, context);
   const lastStep = last(steps.value);
-  if (!lastStep) return undefined;
-  if (lastStep.status !== "APPROVED") return undefined;
+  if (!lastStep) return [];
 
-  return lastStep.approver;
+  return lastStep.candidates;
 };

--- a/frontend/src/components/misc/ErrorList.vue
+++ b/frontend/src/components/misc/ErrorList.vue
@@ -3,9 +3,10 @@
     class="flex flex-col whitespace-nowrap"
     :class="[showBullets && 'list-disc pl-4']"
   >
-    <li v-for="(error, i) in errors" :key="i">
+    <li v-for="(item, i) in errors" :key="i" :style="itemStyle(item)">
       <slot name="prefix" />
-      {{ error }}
+
+      {{ itemText(item) }}
     </li>
   </ul>
 </template>
@@ -13,9 +14,15 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+export type NestedError = {
+  error: string;
+  indent: number;
+};
+export type ErrorItem = string | NestedError;
+
 const props = withDefaults(
   defineProps<{
-    errors: string[];
+    errors: ErrorItem[];
     bullets?: "on-demand" | "always" | "none";
   }>(),
   {
@@ -35,4 +42,17 @@ const showBullets = computed(() => {
   console.error("should never reach this line");
   return false;
 });
+
+const itemStyle = (item: ErrorItem) => {
+  if (typeof item === "string") {
+    return "";
+  }
+  return `margin-left: ${item.indent}rem;`;
+};
+const itemText = (item: ErrorItem) => {
+  if (typeof item === "string") {
+    return item;
+  }
+  return item.error;
+};
 </script>


### PR DESCRIPTION
- Error info with indention
<img width="427" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/676c2987-53c0-46f4-8a9c-58ccaee4ba0e">

- Any valid candidates of the last approval node should be valid assignee candidates.