### PR TITLE
chore(frontend): remove duplicated rings for naive-ui input components globally

### DIFF
--- a/frontend/src/assets/css/tailwind.css
+++ b/frontend/src/assets/css/tailwind.css
@@ -359,3 +359,10 @@
     transform: rotate(0deg);
   }
 }
+
+/* compatibility fixes for tailwindcss and naive-ui */
+.n-base-selection-input:focus,
+.n-base-selection-input-tag__input:focus,
+.n-input__input-el:focus {
+  @apply ring-0;
+}

--- a/frontend/src/components/Branch/BranchSelector.vue
+++ b/frontend/src/components/Branch/BranchSelector.vue
@@ -111,9 +111,3 @@ const renderLabel: SelectRenderLabel = (option) => {
   );
 };
 </script>
-
-<style lang="postcss" scoped>
-.bb-branch-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleSelect.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleSelect.vue
@@ -97,9 +97,3 @@ const toApprovalFlow = () => {
   };
 };
 </script>
-
-<style lang="postcss" scoped>
-.bb-rule-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseLabelFilter.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseLabelFilter.vue
@@ -131,10 +131,3 @@ const updateCascaderValues = (
   );
 };
 </script>
-
-<style lang="postcss" scoped>
-.bb-database-label-filter.n-cascader
-  :deep(.n-base-selection-input-tag__input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/components/v2/Select/DatabaseSelect.vue
+++ b/frontend/src/components/v2/Select/DatabaseSelect.vue
@@ -190,9 +190,3 @@ watch(
   }
 );
 </script>
-
-<style lang="postcss" scoped>
-.bb-database-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/components/v2/Select/EnvironmentSelect.vue
+++ b/frontend/src/components/v2/Select/EnvironmentSelect.vue
@@ -91,9 +91,3 @@ const filterByName = (pattern: string, option: SelectOption) => {
 
 watchEffect(prepare);
 </script>
-
-<style lang="postcss" scoped>
-.bb-environment-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/components/v2/Select/InstanceSelect.vue
+++ b/frontend/src/components/v2/Select/InstanceSelect.vue
@@ -158,8 +158,4 @@ watch([() => props.instance, combinedInstanceList], resetInvalidSelection, {
   :deep(.n-base-selection--active .bb-instance-select--engine-icon) {
   opacity: 0.3;
 }
-
-.bb-instance-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
 </style>

--- a/frontend/src/components/v2/Select/ProjectMemberRoleSelect.vue
+++ b/frontend/src/components/v2/Select/ProjectMemberRoleSelect.vue
@@ -105,9 +105,3 @@ const filterByName = (pattern: string, option: SelectOption) => {
   return role.name.toLowerCase().includes(pattern);
 };
 </script>
-
-<style lang="postcss" scoped>
-.bb-project-member-role-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/components/v2/Select/ProjectSelect.vue
+++ b/frontend/src/components/v2/Select/ProjectSelect.vue
@@ -184,9 +184,3 @@ const filterByName = (pattern: string, option: SelectOption) => {
 
 watchEffect(prepare);
 </script>
-
-<style lang="postcss" scoped>
-.bb-project-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/components/v2/Select/UserSelect.vue
+++ b/frontend/src/components/v2/Select/UserSelect.vue
@@ -304,8 +304,4 @@ watch(
 .bb-user-select :deep(.n-base-selection--active .bb-user-select--avatar) {
   opacity: 0.3;
 }
-.bb-user-select :deep(.n-base-selection-input:focus),
-.bb-user-select :deep(.n-base-selection-input-tag__input:focus) {
-  @apply !ring-0;
-}
 </style>

--- a/frontend/src/components/v2/Select/WorkspaceRoleSelect.vue
+++ b/frontend/src/components/v2/Select/WorkspaceRoleSelect.vue
@@ -38,9 +38,3 @@ const filterByTitle = (pattern: string, option: SelectOption) => {
   return String(value).toLowerCase().includes(pattern);
 };
 </script>
-
-<style lang="postcss" scoped>
-.bb-workspace-role-select :deep(.n-base-selection-input:focus) {
-  @apply !ring-0;
-}
-</style>

--- a/frontend/src/plugins/ai/components/MockInputPlaceholder.vue
+++ b/frontend/src/plugins/ai/components/MockInputPlaceholder.vue
@@ -51,6 +51,6 @@ const handleDismiss = () => {
 
 <style lang="postcss">
 .bb-ai-mock-input .n-input__input-el {
-  @apply !ring-0 !cursor-pointer !placeholder-current;
+  @apply !cursor-pointer !placeholder-current;
 }
 </style>

--- a/frontend/src/plugins/ai/components/PromptInput.vue
+++ b/frontend/src/plugins/ai/components/PromptInput.vue
@@ -56,9 +56,3 @@ const handlePressEnter = () => {
   applyValue(state.value);
 };
 </script>
-
-<style lang="postcss">
-.bb-ai-prompt-input .n-input__input-el {
-  @apply !ring-0;
-}
-</style>


### PR DESCRIPTION

<img width="319" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/a861d108-bd62-489f-887e-8f06e330ea2c">


maybe introduced by upgrading tailwindcss' version sometime. but we now fix it globally.