### PR TITLE
fix: sort temp view columns order

### DIFF
--- a/backend/plugin/parser/mysql/differ.go
+++ b/backend/plugin/parser/mysql/differ.go
@@ -2098,7 +2098,7 @@ func (t *mysqlTransformer) ExitCreateView(ctx *mysql.CreateViewContext) {
 	for _, field := range fields {
 		result = append(result, field.Name)
 	}
-	// the column order of create view is decided by create view statement.
+	// the column order of createView is decided by createView statement.
 	// we get columns here only for create temp view.
 	// only for test-case.
 	sort.Slice(result, func(i, j int) bool {

--- a/backend/plugin/parser/mysql/differ.go
+++ b/backend/plugin/parser/mysql/differ.go
@@ -2098,6 +2098,12 @@ func (t *mysqlTransformer) ExitCreateView(ctx *mysql.CreateViewContext) {
 	for _, field := range fields {
 		result = append(result, field.Name)
 	}
+	// the column order of create view is decided by create view statement.
+	// we get columns here only for create temp view.
+	// only for test-case.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i] < result[j]
+	})
 	view.columns = result
 }
 


### PR DESCRIPTION
the return value of `extractor.mysqlExtractCreateView` is out of order. so sometimes go tests will fail, like https://github.com/bytebase/bytebase/actions/runs/6662460038/job/18106845688?pr=8957#logs . 
but we only use this result for create temp view. the final column order is decided by createView statement.

ref: https://github.com/bytebase/bytebase/pull/3032