### PR TITLE
chore(frontend): use naive-ui components in database change histories page

### DIFF
--- a/frontend/src/components/ChangeHistory/AffectedTableSelect.vue
+++ b/frontend/src/components/ChangeHistory/AffectedTableSelect.vue
@@ -1,0 +1,76 @@
+<template>
+  <NSelect
+    :value="selectedKey"
+    :options="affectedTableOptions"
+    @update:value="updateSelectedKey"
+  />
+</template>
+
+<script setup lang="ts">
+import { orderBy, uniqBy } from "lodash-es";
+import { SelectOption } from "naive-ui";
+import { computed, h } from "vue";
+import { AffectedTable, EmptyAffectedTable } from "@/types";
+import { ChangeHistory } from "@/types/proto/v1/database_service";
+import {
+  getAffectedTableDisplayName,
+  getAffectedTablesOfChangeHistory,
+} from "@/utils";
+
+type AffectedTableSelectOption = SelectOption & {
+  affectedTable: AffectedTable;
+  value: string;
+};
+
+const props = defineProps<{
+  affectedTable: AffectedTable;
+  changeHistoryList: ChangeHistory[];
+}>();
+const emit = defineEmits<{
+  (event: "update:affected-table", affectedTable: AffectedTable): void;
+}>();
+
+const affectedTables = computed(() => {
+  return [
+    EmptyAffectedTable,
+    ...orderBy(
+      uniqBy(
+        props.changeHistoryList
+          .map((changeHistory) =>
+            getAffectedTablesOfChangeHistory(changeHistory)
+          )
+          .flat(),
+        (affectedTable) => `${affectedTable.schema}.${affectedTable.table}`
+      ),
+      ["dropped", "table", "schema"]
+    ),
+  ];
+});
+
+const affectedTableOptions = computed(() => {
+  return affectedTables.value.map<AffectedTableSelectOption>((item) => {
+    const key = JSON.stringify(item);
+    const name = getAffectedTableDisplayName(item);
+    return {
+      label: name,
+      value: key,
+      affectedTable: item,
+      renderLabel() {
+        const classes = ["truncate"];
+        if (item.dropped) {
+          classes.push("text-gray-400");
+        }
+        return h("span", { class: classes, "data-key": key }, name);
+      },
+    };
+  });
+});
+
+const selectedKey = computed(() => {
+  return JSON.stringify(props.affectedTable);
+});
+
+const updateSelectedKey = (key: string, opt: AffectedTableSelectOption) => {
+  emit("update:affected-table", opt.affectedTable);
+};
+</script>

--- a/frontend/src/components/ChangeHistory/ChangeHistoryTable.vue
+++ b/frontend/src/components/ChangeHistory/ChangeHistoryTable.vue
@@ -56,7 +56,7 @@
           @update:checked="handleToggleChangeHistorySelected(history)"
         />
       </BBTableCell>
-      <BBTableCell :left-padding="mode !== 'DATABASE' && 4">
+      <BBTableCell :left-padding="mode !== 'DATABASE' ? 4 : undefined">
         <ChangeHistoryStatusIcon class="mx-auto" :status="history.status" />
       </BBTableCell>
       <BBTableCell v-if="mode === 'DATABASE'">

--- a/frontend/src/components/ChangeHistory/index.ts
+++ b/frontend/src/components/ChangeHistory/index.ts
@@ -1,4 +1,5 @@
+import AffectedTableSelect from "./AffectedTableSelect.vue";
 import ChangeHistoryStatusIcon from "./ChangeHistoryStatusIcon.vue";
 import ChangeHistoryTable from "./ChangeHistoryTable.vue";
 
-export { ChangeHistoryTable, ChangeHistoryStatusIcon };
+export { ChangeHistoryTable, ChangeHistoryStatusIcon, AffectedTableSelect };

--- a/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/form/ChangeHistoryTable/Tables.vue
+++ b/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/form/ChangeHistoryTable/Tables.vue
@@ -10,8 +10,10 @@
 import { computed } from "vue";
 import TextOverflowPopover from "@/components/misc/TextOverflowPopover.vue";
 import { ChangeHistory } from "@/types/proto/v1/database_service";
-import { getAffectedTablesOfChangeHistory } from "@/utils";
-import { getAffectedTableDisplayName } from "../utils";
+import {
+  getAffectedTableDisplayName,
+  getAffectedTablesOfChangeHistory,
+} from "@/utils";
 
 const props = defineProps<{
   changeHistory: ChangeHistory;

--- a/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/form/utils.ts
+++ b/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/form/utils.ts
@@ -1,6 +1,5 @@
-import { isEqual, orderBy, uniqBy } from "lodash-es";
-import { t } from "@/plugins/i18n";
-import { AffectedTable, EmptyAffectedTable } from "@/types/changeHistory";
+import { orderBy, uniqBy } from "lodash-es";
+import { EmptyAffectedTable } from "@/types/changeHistory";
 import {
   ChangeHistory,
   ChangeHistory_Type,
@@ -24,26 +23,6 @@ export const getAffectedTablesFromChangeHistoryList = (
       ["dropped", "table", "schema"]
     ),
   ];
-};
-
-export const getAffectedTableKey = (affectedTable: AffectedTable) => {
-  return JSON.stringify(affectedTable);
-};
-
-export const getAffectedTableDisplayName = (affectedTable: AffectedTable) => {
-  if (isEqual(affectedTable, EmptyAffectedTable)) {
-    return t("change-history.all-tables");
-  }
-
-  const { schema, table, dropped } = affectedTable;
-  let name = table;
-  if (schema !== "") {
-    name = `${schema}.${table}`;
-  }
-  if (dropped) {
-    name = `${name} (deleted)`;
-  }
-  return name;
 };
 
 export const semanticChangeHistoryType = (type: ChangeHistory_Type) => {

--- a/frontend/src/components/v2/Button/TooltipButton.vue
+++ b/frontend/src/components/v2/Button/TooltipButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <NTooltip v-bind="tooltipProps" :disabled="!tooltipDisabled">
+  <NTooltip v-bind="tooltipProps" :disabled="!tooltipEnabled">
     <template #trigger>
       <NButton
         v-bind="$attrs"
@@ -52,9 +52,13 @@ defineEmits<{
 
 const slots = useSlots();
 
-const tooltipDisabled = computed(() => {
-  if (props.tooltipMode === "ALWAYS") return false;
-  if (!slots.tooltip) return true;
+const tooltipEnabled = computed(() => {
+  // Enable tooltip when tooltipMode is "ALWAYS"
+  if (props.tooltipMode === "ALWAYS") return true;
+  // Disable tooltip if no tooltip contents
+  if (!slots.tooltip) return false;
+  // Enable tooltip if button is disabled
+  // Disable tooltip otherwise
   return props.disabled;
 });
 </script>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,5 +43,6 @@ export * from "./slowQuery";
 export * from "./dbGroup";
 export * from "./quickAction";
 export * from "./setting";
+export * from "./changeHistory";
 
 export * from "./v1";

--- a/frontend/src/utils/v1/changeHistory.ts
+++ b/frontend/src/utils/v1/changeHistory.ts
@@ -1,7 +1,8 @@
-import { isUndefined, orderBy, uniqBy } from "lodash-es";
+import { isEqual, isUndefined, orderBy, uniqBy } from "lodash-es";
 import slug from "slug";
+import { t } from "@/plugins/i18n";
 import { useDBSchemaV1Store, useDatabaseV1Store } from "@/store";
-import { AffectedTable } from "@/types/changeHistory";
+import { AffectedTable, EmptyAffectedTable } from "@/types/changeHistory";
 import {
   ChangeHistory,
   ChangeHistory_Type,
@@ -84,6 +85,22 @@ export const getAffectedTablesOfChangeHistory = (
     ),
     (affectedTable) => `${affectedTable.schema}.${affectedTable.table}`
   );
+};
+
+export const getAffectedTableDisplayName = (affectedTable: AffectedTable) => {
+  if (isEqual(affectedTable, EmptyAffectedTable)) {
+    return t("change-history.all-tables");
+  }
+
+  const { schema, table, dropped } = affectedTable;
+  let name = table;
+  if (schema !== "") {
+    name = `${schema}.${table}`;
+  }
+  if (dropped) {
+    name = `${name} (deleted)`;
+  }
+  return name;
 };
 
 export const getHistoryChangeType = (type: ChangeHistory_Type) => {


### PR DESCRIPTION
- Use naive-ui buttons
- Create `<AffectedTableSelect>` component using naive-ui select and shared with changelist-related UI