### PR TITLE
fix(bit-bucket): rename file should trigger creating issue

### DIFF
--- a/backend/plugin/vcs/bitbucket/bitbucket.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket.go
@@ -223,6 +223,9 @@ func (p *Provider) GetDiffFileList(ctx context.Context, oauthCtx common.OauthCon
 			diff.Type = vcs.FileDiffTypeModified
 		case "removed":
 			diff.Type = vcs.FileDiffTypeRemoved
+		// To be consistent with GitLab, we treat renamed as added.
+		case "renamed":
+			diff.Type = vcs.FileDiffTypeAdded
 		default:
 			// Skip because we don't care about file diff in other status
 			continue


### PR DESCRIPTION
For the rename file operation, gitlab.com(16.4) treated it as added only in push event:
![CleanShot 2023-10-27 at 18 44 31@2x](https://github.com/bytebase/bytebase/assets/87714218/9c523463-52d0-42a2-b433-5c5fb37b8536)
But in bitbucket, it treats it as renamed changed type:
![CleanShot 2023-10-27 at 18 45 36@2x](https://github.com/bytebase/bytebase/assets/87714218/2fee6789-9430-4e13-8b54-cb515c72993b)

After this PR, bitbucket will treated renamed as a added changed type to be consistent with GitLab.
![CleanShot 2023-10-27 at 18 51 12@2x](https://github.com/bytebase/bytebase/assets/87714218/220d3e8e-2dea-4e91-afa4-f09531de380a)
