### PR TITLE
fix: list tasks sql

### DIFF
--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -190,8 +190,8 @@ func (s *Store) ListTasks(ctx context.Context, find *api.TaskFind) ([]*TaskMessa
 		where = append(where, fmt.Sprintf("task.status in (%s)", strings.Join(list, ",")))
 	}
 	if v := find.LatestTaskRunStatusList; v != nil {
-		where = append(where, fmt.Sprintf("COALESCE(latest_task_run.status, 'NOT_STARTED') = ANY($%d)", len(args)+1))
-		args = append(args, *v)
+		where = append(where, fmt.Sprintf("COALESCE(latest_task_run.status, $%d) = ANY($%d)", len(args)+1, len(args)+2))
+		args = append(args, api.TaskRunNotStarted, *v)
 	}
 	if v := find.TypeList; v != nil {
 		var list []string

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -190,7 +190,7 @@ func (s *Store) ListTasks(ctx context.Context, find *api.TaskFind) ([]*TaskMessa
 		where = append(where, fmt.Sprintf("task.status in (%s)", strings.Join(list, ",")))
 	}
 	if v := find.LatestTaskRunStatusList; v != nil {
-		where = append(where, fmt.Sprintf("latest_task_run.status = ANY($%d)", len(args)+1))
+		where = append(where, fmt.Sprintf("COALESCE(latest_task_run.status, 'NOT_STARTED') = ANY($%d)", len(args)+1))
 		args = append(args, *v)
 	}
 	if v := find.TypeList; v != nil {


### PR DESCRIPTION
We should refer `COALESCE(latest_task_run.status, 'NOT_STARTED')` to get the latest_task_run_status, otherwise, t cannot list the `NOT_STARTED` task, then the GitOps cannot update the task content unless the task had failed. https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/backend/api/gitops/webhook.go?L2118
