### PR TITLE
refactor: cleanup strictUseDb

### DIFF
--- a/backend/demo/demo.go
+++ b/backend/demo/demo.go
@@ -21,7 +21,7 @@ import (
 var demoFS embed.FS
 
 // LoadDemoDataIfNeeded loads the demo data if specified.
-func LoadDemoDataIfNeeded(ctx context.Context, storeDB *store.DB, strictUseDb bool, pgBinDir, demoName string) error {
+func LoadDemoDataIfNeeded(ctx context.Context, storeDB *store.DB, pgBinDir, demoName string) error {
 	if demoName == "" {
 		slog.Debug("Skip setting up demo data. Demo not specified.")
 		return nil
@@ -30,12 +30,12 @@ func LoadDemoDataIfNeeded(ctx context.Context, storeDB *store.DB, strictUseDb bo
 	slog.Info(fmt.Sprintf("Setting up demo %q...", demoName))
 
 	databaseName := storeDB.ConnCfg.Database
-	if !strictUseDb {
+	if !storeDB.ConnCfg.StrictUseDb {
 		// The database storing metadata is the same as user name.
 		databaseName = storeDB.ConnCfg.Username
 	}
 	metadataConnConfig := storeDB.ConnCfg
-	if !strictUseDb {
+	if !storeDB.ConnCfg.StrictUseDb {
 		metadataConnConfig.Database = databaseName
 	}
 	metadataDriver, err := dbdriver.Open(

--- a/backend/migrator/migrator.go
+++ b/backend/migrator/migrator.go
@@ -29,14 +29,14 @@ import (
 var migrationFS embed.FS
 
 // MigrateSchema migrates the schema for metadata database.
-func MigrateSchema(ctx context.Context, storeDB *store.DB, strictUseDb bool, pgBinDir, serverVersion string, mode common.ReleaseMode) (*semver.Version, error) {
+func MigrateSchema(ctx context.Context, storeDB *store.DB, pgBinDir, serverVersion string, mode common.ReleaseMode) (*semver.Version, error) {
 	databaseName := storeDB.ConnCfg.Database
-	if !strictUseDb {
+	if !storeDB.ConnCfg.StrictUseDb {
 		// The database storing metadata is the same as user name.
 		databaseName = storeDB.ConnCfg.Username
 	}
 	metadataConnConfig := storeDB.ConnCfg
-	if !strictUseDb {
+	if !storeDB.ConnCfg.StrictUseDb {
 		metadataConnConfig.Database = databaseName
 	}
 	metadataDriver, err := dbdriver.Open(

--- a/backend/plugin/db/driver.go
+++ b/backend/plugin/db/driver.go
@@ -328,6 +328,7 @@ type ConnectionConfig struct {
 	// ReadOnly is only supported for Postgres at the moment.
 	ReadOnly bool
 	// StrictUseDb will only set as true if the user gives only a database instead of a whole instance to access.
+	// This is only used when connecting PG metadata database.
 	StrictUseDb bool
 	// SRV is only supported for MongoDB now.
 	SRV bool

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -203,10 +203,10 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 	if profile.Readonly {
 		slog.Info("Database is opened in readonly mode. Skip migration and demo data setup.")
 	} else {
-		if err := demo.LoadDemoDataIfNeeded(ctx, storeDB, !profile.UseEmbedDB(), s.pgBinDir, profile.DemoName); err != nil {
+		if err := demo.LoadDemoDataIfNeeded(ctx, storeDB, s.pgBinDir, profile.DemoName); err != nil {
 			return nil, errors.Wrapf(err, "failed to load demo data")
 		}
-		if _, err := migrator.MigrateSchema(ctx, storeDB, !profile.UseEmbedDB(), s.pgBinDir, profile.Version, profile.Mode); err != nil {
+		if _, err := migrator.MigrateSchema(ctx, storeDB, s.pgBinDir, profile.Version, profile.Mode); err != nil {
 			return nil, err
 		}
 	}

--- a/backend/store/pg_engine.go
+++ b/backend/store/pg_engine.go
@@ -16,7 +16,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 )
 
-// DB represents the database connection.
+// DB represents the metdata database connection.
 type DB struct {
 	metadataDriver dbdriver.Driver
 	db             *sql.DB


### PR DESCRIPTION
Already set when constructing the metadb connection config

![CleanShot 2023-11-02 at 00-57-07 png](https://github.com/bytebase/bytebase/assets/230323/40251773-0163-445f-bacf-ea37a0d4eaa7)
