### PR TITLE
fix(GitOps): pass oauthContext pointer to make the following api call work well

### DIFF
--- a/backend/api/gitops/webhook.go
+++ b/backend/api/gitops/webhook.go
@@ -703,7 +703,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 				commitID = prFile.LastCommitID
 			}
 			if len(mybatisMapperXMLFiles) > 0 {
-				mapperAdvices, err := s.sqlAdviceForMybatisMapperFiles(ctx, oauthContext, mybatisMapperXMLFiles, commitID, repo)
+				mapperAdvices, err := sqlAdviceForMybatisMapperFiles(ctx, oauthContext, mybatisMapperXMLFiles, commitID, repo)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sql advice for mybatis mapper files").SetInternal(err)
 				}
@@ -735,7 +735,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 	})
 }
 
-func (s *Service) sqlAdviceForMybatisMapperFiles(ctx context.Context, oauthContext *common.OauthContext, mybatisMapperContent map[string]string, commitID string, repoInfo *repoInfo) (map[string][]advisor.Advice, error) {
+func sqlAdviceForMybatisMapperFiles(ctx context.Context, oauthContext *common.OauthContext, mybatisMapperContent map[string]string, commitID string, repoInfo *repoInfo) (map[string][]advisor.Advice, error) {
 	if len(mybatisMapperContent) == 0 {
 		return map[string][]advisor.Advice{}, nil
 	}
@@ -744,7 +744,7 @@ func (s *Service) sqlAdviceForMybatisMapperFiles(ctx context.Context, oauthConte
 	}
 
 	sqlCheckAdvices := make(map[string][]advisor.Advice)
-	mybatisMapperXMLFileData, err := s.buildMybatisMapperXMLFileData(ctx, oauthContext, repoInfo, commitID, mybatisMapperContent)
+	mybatisMapperXMLFileData, err := buildMybatisMapperXMLFileData(ctx, oauthContext, repoInfo, commitID, mybatisMapperContent)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to build mybatis mapper xml file data")
 	}
@@ -2511,7 +2511,7 @@ type mybatisMapperXMLFileDatum struct {
 //	repo: the repository will be list file tree and get file content from.
 //	commitID: the commitID is the snapshot of the file tree and file content.
 //	mapperFiles: the map of the mybatis mapper XML file path and content.
-func (s *Service) buildMybatisMapperXMLFileData(ctx context.Context, oauthContext *common.OauthContext, repoInfo *repoInfo, commitID string, mapperFiles map[string]string) ([]*mybatisMapperXMLFileDatum, error) {
+func buildMybatisMapperXMLFileData(ctx context.Context, oauthContext *common.OauthContext, repoInfo *repoInfo, commitID string, mapperFiles map[string]string) ([]*mybatisMapperXMLFileDatum, error) {
 	if len(mapperFiles) == 0 {
 		return []*mybatisMapperXMLFileDatum{}, nil
 	}

--- a/backend/api/gitops/webhook.go
+++ b/backend/api/gitops/webhook.go
@@ -97,8 +97,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 			if c.Request().Header.Get("X-Gitlab-Token") != repo.WebhookSecretToken {
 				return false, nil
 			}
-
-			return s.isWebhookEventBranch(pushEvent.Ref, repo.BranchFilter)
+			return isWebhookEventBranch(pushEvent.Ref, repo.BranchFilter)
 		}
 		repositoryList, err := s.filterRepository(ctx, c.Param("id"), repositoryID, filter)
 		if err != nil {
@@ -109,12 +108,21 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 			return c.String(http.StatusOK, "OK")
 		}
 
+		repo := repositoryList[0]
+		oauthContext := &common.OauthContext{
+			ClientID:     repo.vcs.ApplicationID,
+			ClientSecret: repo.vcs.Secret,
+			AccessToken:  repo.repository.AccessToken,
+			RefreshToken: repo.repository.RefreshToken,
+			Refresher:    utils.RefreshToken(ctx, s.store, repo.repository.WebURL),
+		}
+
 		baseVCSPushEvent, err := pushEvent.ToVCS()
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to convert GitLab commits").SetInternal(err)
 		}
 
-		createdMessages, err := s.processPushEvent(ctx, repositoryList, baseVCSPushEvent)
+		createdMessages, err := s.processPushEvent(ctx, oauthContext, repositoryList, baseVCSPushEvent)
 		if err != nil {
 			return err
 		}
@@ -170,7 +178,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 				return false, nil
 			}
 
-			return s.isWebhookEventBranch(pushEvent.Ref, repo.BranchFilter)
+			return isWebhookEventBranch(pushEvent.Ref, repo.BranchFilter)
 		}
 		repositoryList, err := s.filterRepository(ctx, c.Param("id"), repositoryID, filter)
 		if err != nil {
@@ -180,10 +188,18 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 			slog.Debug("Empty handle repo list. Ignore this push event.")
 			return c.String(http.StatusOK, "OK")
 		}
+		repo := repositoryList[0]
+		oauthContext := &common.OauthContext{
+			ClientID:     repo.vcs.ApplicationID,
+			ClientSecret: repo.vcs.Secret,
+			AccessToken:  repo.repository.AccessToken,
+			RefreshToken: repo.repository.RefreshToken,
+			Refresher:    utils.RefreshToken(ctx, s.store, repo.repository.WebURL),
+		}
 
 		baseVCSPushEvent := pushEvent.ToVCS()
 
-		createdMessages, err := s.processPushEvent(ctx, repositoryList, baseVCSPushEvent)
+		createdMessages, err := s.processPushEvent(ctx, oauthContext, repositoryList, baseVCSPushEvent)
 		if err != nil {
 			return err
 		}
@@ -230,7 +246,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 
 			ref := "refs/heads/" + change.New.Name
 			filter := func(repo *store.RepositoryMessage) (bool, error) {
-				return s.isWebhookEventBranch(ref, repo.BranchFilter)
+				return isWebhookEventBranch(ref, repo.BranchFilter)
 			}
 			repositoryList, err := s.filterRepository(ctx, c.Param("id"), repositoryID, filter)
 			if err != nil {
@@ -242,6 +258,14 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 			}
 			repo := repositoryList[0]
 
+			oauthContext := &common.OauthContext{
+				ClientID:     repo.vcs.ApplicationID,
+				ClientSecret: repo.vcs.Secret,
+				AccessToken:  repo.repository.AccessToken,
+				RefreshToken: repo.repository.RefreshToken,
+				Refresher:    utils.RefreshToken(ctx, s.store, repo.repository.WebURL),
+			}
+
 			var commitList []vcs.Commit
 			for _, commit := range nonBytebaseCommitList {
 				before := strings.Repeat("0", 40)
@@ -250,13 +274,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 				}
 				fileDiffList, err := vcs.Get(repo.vcs.Type, vcs.ProviderConfig{}).GetDiffFileList(
 					ctx,
-					common.OauthContext{
-						ClientID:     repo.vcs.ApplicationID,
-						ClientSecret: repo.vcs.Secret,
-						AccessToken:  repo.repository.AccessToken,
-						RefreshToken: repo.repository.RefreshToken,
-						Refresher:    utils.RefreshToken(ctx, s.store, repo.repository.WebURL),
-					},
+					oauthContext,
 					repo.vcs.InstanceURL,
 					repo.repository.ExternalID,
 					before,
@@ -305,6 +323,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 
 			createdMessages, err := s.processPushEvent(
 				ctx,
+				oauthContext,
 				repositoryList,
 				vcs.PushEvent{
 					VCSType:            vcs.Bitbucket,
@@ -376,7 +395,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 		// Filter out the repository which does not match the branch filter.
 		filter := func(repo *store.RepositoryMessage) (bool, error) {
 			refUpdate := pushEvent.Resource.RefUpdates[0]
-			return s.isWebhookEventBranch(refUpdate.Name, repo.BranchFilter)
+			return isWebhookEventBranch(refUpdate.Name, repo.BranchFilter)
 		}
 		repositoryList, err := s.filterRepository(ctx, c.Param("id"), repositoryID, filter)
 		if err != nil {
@@ -392,7 +411,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find workspace setting").SetInternal(err)
 		}
 
-		oauthContext := common.OauthContext{
+		oauthContext := &common.OauthContext{
 			ClientID:     repositoryList[0].vcs.ApplicationID,
 			ClientSecret: repositoryList[0].vcs.Secret,
 			AccessToken:  repositoryList[0].repository.AccessToken,
@@ -550,7 +569,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 			CommitList:         backfillCommits,
 		}
 
-		createdMessages, err := s.processPushEvent(ctx, repositoryList, baseVCSPushEvent)
+		createdMessages, err := s.processPushEvent(ctx, oauthContext, repositoryList, baseVCSPushEvent)
 		if err != nil {
 			return err
 		}
@@ -621,16 +640,18 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 		}
 		repo := repositoryList[0]
 
+		oauthContext := &common.OauthContext{
+			ClientID:     repo.vcs.ApplicationID,
+			ClientSecret: repo.vcs.Secret,
+			AccessToken:  repo.repository.AccessToken,
+			RefreshToken: repo.repository.RefreshToken,
+			Refresher:    utils.RefreshToken(ctx, s.store, repo.repository.WebURL),
+			RedirectURL:  fmt.Sprintf("%s/oauth/callback", setting.ExternalUrl),
+		}
+
 		prFiles, err := vcs.Get(repo.vcs.Type, vcs.ProviderConfig{}).ListPullRequestFile(
 			ctx,
-			common.OauthContext{
-				ClientID:     repo.vcs.ApplicationID,
-				ClientSecret: repo.vcs.Secret,
-				AccessToken:  repo.repository.AccessToken,
-				RefreshToken: repo.repository.RefreshToken,
-				Refresher:    utils.RefreshToken(ctx, s.store, repo.repository.WebURL),
-				RedirectURL:  fmt.Sprintf("%s/oauth/callback", setting.ExternalUrl),
-			},
+			oauthContext,
 			repo.vcs.InstanceURL,
 			repo.repository.ExternalID,
 			request.PullRequestID,
@@ -639,7 +660,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to list pull request file").SetInternal(err)
 		}
 
-		sqlFileName2Advice := s.sqlAdviceForSQLFiles(ctx, repositoryList, prFiles, setting.ExternalUrl)
+		sqlFileName2Advice := s.sqlAdviceForSQLFiles(ctx, oauthContext, repositoryList, prFiles, setting.ExternalUrl)
 
 		if s.licenseService.IsFeatureEnabled(api.FeatureMybatisSQLReview) == nil {
 			// If the commit file list contains the file which extension is xml and the content
@@ -663,13 +684,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 				}
 				fileContent, err := vcs.Get(repo.vcs.Type, vcs.ProviderConfig{}).ReadFileContent(
 					ctx,
-					common.OauthContext{
-						ClientID:     repo.vcs.ApplicationID,
-						ClientSecret: repo.vcs.Secret,
-						AccessToken:  repo.repository.AccessToken,
-						RefreshToken: repo.repository.RefreshToken,
-						Refresher:    utils.RefreshToken(ctx, s.store, repo.repository.WebURL),
-					},
+					oauthContext,
 					repo.vcs.InstanceURL,
 					repo.repository.ExternalID,
 					prFile.Path,
@@ -688,7 +703,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 				commitID = prFile.LastCommitID
 			}
 			if len(mybatisMapperXMLFiles) > 0 {
-				mapperAdvices, err := s.sqlAdviceForMybatisMapperFiles(ctx, mybatisMapperXMLFiles, commitID, repo)
+				mapperAdvices, err := s.sqlAdviceForMybatisMapperFiles(ctx, oauthContext, mybatisMapperXMLFiles, commitID, repo)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sql advice for mybatis mapper files").SetInternal(err)
 				}
@@ -720,7 +735,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 	})
 }
 
-func (s *Service) sqlAdviceForMybatisMapperFiles(ctx context.Context, mybatisMapperContent map[string]string, commitID string, repoInfo *repoInfo) (map[string][]advisor.Advice, error) {
+func (s *Service) sqlAdviceForMybatisMapperFiles(ctx context.Context, oauthContext *common.OauthContext, mybatisMapperContent map[string]string, commitID string, repoInfo *repoInfo) (map[string][]advisor.Advice, error) {
 	if len(mybatisMapperContent) == 0 {
 		return map[string][]advisor.Advice{}, nil
 	}
@@ -729,7 +744,7 @@ func (s *Service) sqlAdviceForMybatisMapperFiles(ctx context.Context, mybatisMap
 	}
 
 	sqlCheckAdvices := make(map[string][]advisor.Advice)
-	mybatisMapperXMLFileData, err := s.buildMybatisMapperXMLFileData(ctx, repoInfo, commitID, mybatisMapperContent)
+	mybatisMapperXMLFileData, err := s.buildMybatisMapperXMLFileData(ctx, oauthContext, repoInfo, commitID, mybatisMapperContent)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to build mybatis mapper xml file data")
 	}
@@ -856,6 +871,7 @@ func (s *Service) sqlAdviceForMybatisMapperFile(ctx context.Context, datum *myba
 
 func (s *Service) sqlAdviceForSQLFiles(
 	ctx context.Context,
+	oauthContext *common.OauthContext,
 	repoInfoList []*repoInfo,
 	prFiles []*vcs.PullRequestFile,
 	externalURL string,
@@ -883,7 +899,7 @@ func (s *Service) sqlAdviceForSQLFiles(
 			wg.Add(1)
 			go func(file fileInfo) {
 				defer wg.Done()
-				adviceList, err := s.sqlAdviceForFile(ctx, file, externalURL)
+				adviceList, err := s.sqlAdviceForFile(ctx, oauthContext, file, externalURL)
 				if err != nil {
 					slog.Error(
 						"Failed to take SQL review for file",
@@ -912,6 +928,7 @@ func (s *Service) sqlAdviceForSQLFiles(
 
 func (s *Service) sqlAdviceForFile(
 	ctx context.Context,
+	oauthContext *common.OauthContext,
 	fileInfo fileInfo,
 	externalURL string,
 ) ([]advisor.Advice, error) {
@@ -949,14 +966,7 @@ func (s *Service) sqlAdviceForFile(
 
 	fileContent, err := vcs.Get(fileInfo.repoInfo.vcs.Type, vcs.ProviderConfig{}).ReadFileContent(
 		ctx,
-		common.OauthContext{
-			ClientID:     fileInfo.repoInfo.vcs.ApplicationID,
-			ClientSecret: fileInfo.repoInfo.vcs.Secret,
-			AccessToken:  fileInfo.repoInfo.repository.AccessToken,
-			RefreshToken: fileInfo.repoInfo.repository.RefreshToken,
-			Refresher:    utils.RefreshToken(ctx, s.store, fileInfo.repoInfo.repository.WebURL),
-			RedirectURL:  fmt.Sprintf("%s/oauth/callback", externalURL),
-		},
+		oauthContext,
 		fileInfo.repoInfo.vcs.InstanceURL,
 		fileInfo.repoInfo.repository.ExternalID,
 		fileInfo.item.FileName,
@@ -1132,7 +1142,7 @@ func (s *Service) filterRepository(ctx context.Context, webhookEndpointID string
 	return filteredRepos, nil
 }
 
-func (*Service) isWebhookEventBranch(pushEventRef, branchFilter string) (bool, error) {
+func isWebhookEventBranch(pushEventRef, branchFilter string) (bool, error) {
 	branch, err := parseBranchNameFromRefs(pushEventRef)
 	if err != nil {
 		return false, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid ref: %s", pushEventRef)).SetInternal(err)
@@ -1180,7 +1190,7 @@ func parseBranchNameFromRefs(ref string) (string, error) {
 	return ref[len(expectedPrefix):], nil
 }
 
-func (s *Service) processPushEvent(ctx context.Context, repoInfoList []*repoInfo, baseVCSPushEvent vcs.PushEvent) ([]string, error) {
+func (s *Service) processPushEvent(ctx context.Context, oauthContext *common.OauthContext, repoInfoList []*repoInfo, baseVCSPushEvent vcs.PushEvent) ([]string, error) {
 	if len(repoInfoList) == 0 {
 		return nil, errors.Errorf("empty repository list")
 	}
@@ -1205,7 +1215,7 @@ func (s *Service) processPushEvent(ctx context.Context, repoInfoList []*repoInfo
 		if baseVCSPushEvent.Before == strings.Repeat("0", 40) {
 			return distinctFileList, nil
 		}
-		return s.filterFilesByCommitsDiff(ctx, repo, distinctFileList, baseVCSPushEvent.Before, baseVCSPushEvent.After)
+		return s.filterFilesByCommitsDiff(ctx, oauthContext, repo, distinctFileList, baseVCSPushEvent.Before, baseVCSPushEvent.After)
 	}()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to filtered distinct files by commits diff")
@@ -1227,6 +1237,7 @@ func (s *Service) processPushEvent(ctx context.Context, repoInfoList []*repoInfo
 			pushEvent.BaseDirectory = repoInfo.repository.BaseDirectory
 			createdMessage, created, activityCreateList, err := s.processFilesInProject(
 				ctx,
+				oauthContext,
 				pushEvent,
 				repoInfo,
 				fileInfoListSorted,
@@ -1264,19 +1275,14 @@ func (s *Service) processPushEvent(ctx context.Context, repoInfoList []*repoInfo
 // TODO(dragonly): generate distinct file change list from the commits diff instead of filter.
 func (s *Service) filterFilesByCommitsDiff(
 	ctx context.Context,
+	oauthContext *common.OauthContext,
 	repoInfo *repoInfo,
 	distinctFileList []vcs.DistinctFileItem,
 	beforeCommit, afterCommit string,
 ) ([]vcs.DistinctFileItem, error) {
 	fileDiffList, err := vcs.Get(repoInfo.vcs.Type, vcs.ProviderConfig{}).GetDiffFileList(
 		ctx,
-		common.OauthContext{
-			ClientID:     repoInfo.vcs.ApplicationID,
-			ClientSecret: repoInfo.vcs.Secret,
-			AccessToken:  repoInfo.repository.AccessToken,
-			RefreshToken: repoInfo.repository.RefreshToken,
-			Refresher:    utils.RefreshToken(ctx, s.store, repoInfo.repository.WebURL),
-		},
+		oauthContext,
 		repoInfo.vcs.InstanceURL,
 		repoInfo.repository.ExternalID,
 		beforeCommit,
@@ -1433,12 +1439,12 @@ func getFileInfo(fileItem vcs.DistinctFileItem, repoInfoList []*repoInfo) (*db.M
 // It returns "created=true" when new issue(s) has been created,
 // along with the creation message to be presented in the UI. An *echo.HTTPError
 // is returned in case of the error during the process.
-func (s *Service) processFilesInProject(ctx context.Context, pushEvent vcs.PushEvent, repoInfo *repoInfo, fileInfoList []fileInfo) (string, bool, []*store.ActivityMessage, *echo.HTTPError) {
+func (s *Service) processFilesInProject(ctx context.Context, oauthContext *common.OauthContext, pushEvent vcs.PushEvent, repoInfo *repoInfo, fileInfoList []fileInfo) (string, bool, []*store.ActivityMessage, *echo.HTTPError) {
 	if repoInfo.project.TenantMode == api.TenantModeTenant {
 		if err := s.licenseService.IsFeatureEnabled(api.FeatureMultiTenancy); err != nil {
 			return "", false, nil, echo.NewHTTPError(http.StatusForbidden, err.Error())
 		}
-		return s.processFilesInBatchProject(ctx, pushEvent, repoInfo, fileInfoList)
+		return s.processFilesInBatchProject(ctx, oauthContext, pushEvent, repoInfo, fileInfoList)
 	}
 
 	var migrationDetailList []*migrationDetail
@@ -1451,7 +1457,7 @@ func (s *Service) processFilesInProject(ctx context.Context, pushEvent vcs.PushE
 		if fileInfo.fType == fileTypeSchema {
 			if fileInfo.repoInfo.project.SchemaChangeType == api.ProjectSchemaChangeTypeSDL {
 				// Create one issue per schema file for SDL project.
-				migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromSDLFile(ctx, repoInfo, pushEvent, fileInfo.migrationInfo, fileInfo.item.FileName)
+				migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromSDLFile(ctx, oauthContext, repoInfo, pushEvent, fileInfo.migrationInfo, fileInfo.item.FileName)
 				activityCreateList = append(activityCreateList, activityCreateListForFile...)
 				if len(migrationDetailListForFile) != 0 {
 					databaseName := fileInfo.migrationInfo.Database
@@ -1472,7 +1478,7 @@ func (s *Service) processFilesInProject(ctx context.Context, pushEvent vcs.PushE
 			// 1) DML is always migration-based.
 			// 2) We may have a limitation in SDL implementation.
 			// 3) User just wants to break the glass.
-			migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromFile(ctx, repoInfo, pushEvent, fileInfo)
+			migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromFile(ctx, oauthContext, repoInfo, pushEvent, fileInfo)
 			activityCreateList = append(activityCreateList, activityCreateListForFile...)
 			migrationDetailList = append(migrationDetailList, migrationDetailListForFile...)
 			if len(migrationDetailListForFile) != 0 {
@@ -1507,7 +1513,7 @@ func (s *Service) processFilesInProject(ctx context.Context, pushEvent vcs.PushE
 }
 
 // processFilesInBatchProject creates issues for a batch project.
-func (s *Service) processFilesInBatchProject(ctx context.Context, pushEvent vcs.PushEvent, repoInfo *repoInfo, fileInfoList []fileInfo) (string, bool, []*store.ActivityMessage, *echo.HTTPError) {
+func (s *Service) processFilesInBatchProject(ctx context.Context, oauthContext *common.OauthContext, pushEvent vcs.PushEvent, repoInfo *repoInfo, fileInfoList []fileInfo) (string, bool, []*store.ActivityMessage, *echo.HTTPError) {
 	var activityCreateList []*store.ActivityMessage
 	var createdIssueList []string
 
@@ -1516,7 +1522,7 @@ func (s *Service) processFilesInBatchProject(ctx context.Context, pushEvent vcs.
 		if fileInfo.fType == fileTypeSchema {
 			if fileInfo.repoInfo.project.SchemaChangeType == api.ProjectSchemaChangeTypeSDL {
 				// Create one issue per schema file for SDL project.
-				migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromSDLFile(ctx, repoInfo, pushEvent, fileInfo.migrationInfo, fileInfo.item.FileName)
+				migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromSDLFile(ctx, oauthContext, repoInfo, pushEvent, fileInfo.migrationInfo, fileInfo.item.FileName)
 				activityCreateList = append(activityCreateList, activityCreateListForFile...)
 				if len(migrationDetailListForFile) != 0 {
 					databaseName := fileInfo.migrationInfo.Database
@@ -1531,7 +1537,7 @@ func (s *Service) processFilesInBatchProject(ctx context.Context, pushEvent vcs.
 				slog.Debug("Ignored schema file for non-SDL project", slog.String("fileName", fileInfo.item.FileName), slog.String("type", string(fileInfo.item.ItemType)))
 			}
 		} else { // fileInfo.fType == fileTypeMigration
-			migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromFile(ctx, repoInfo, pushEvent, fileInfo)
+			migrationDetailListForFile, activityCreateListForFile := s.prepareIssueFromFile(ctx, oauthContext, repoInfo, pushEvent, fileInfo)
 			if len(migrationDetailListForFile) != 1 {
 				slog.Error("Unexpected number of file number")
 			}
@@ -1843,7 +1849,7 @@ func getIgnoredFileActivityCreate(projectID int, pushEvent vcs.PushEvent, file s
 }
 
 // readFileContent reads the content of the given file from the given repository.
-func (s *Service) readFileContent(ctx context.Context, pushEvent vcs.PushEvent, repoInfo *repoInfo, file string) (string, error) {
+func (s *Service) readFileContent(ctx context.Context, oauthContext *common.OauthContext, pushEvent vcs.PushEvent, repoInfo *repoInfo, file string) (string, error) {
 	// Retrieve the latest AccessToken and RefreshToken as the previous
 	// ReadFileContent call may have updated the stored token pair. ReadFileContent
 	// will fetch and store the new token pair if the existing token pair has
@@ -1866,13 +1872,7 @@ func (s *Service) readFileContent(ctx context.Context, pushEvent vcs.PushEvent, 
 
 	content, err := vcs.Get(externalVCS.Type, vcs.ProviderConfig{}).ReadFileContent(
 		ctx,
-		common.OauthContext{
-			ClientID:     externalVCS.ApplicationID,
-			ClientSecret: externalVCS.Secret,
-			AccessToken:  repo.AccessToken,
-			RefreshToken: repo.RefreshToken,
-			Refresher:    utils.RefreshToken(ctx, s.store, repo.WebURL),
-		},
+		oauthContext,
 		externalVCS.InstanceURL,
 		repo.ExternalID,
 		file,
@@ -1889,14 +1889,14 @@ func (s *Service) readFileContent(ctx context.Context, pushEvent vcs.PushEvent, 
 
 // prepareIssueFromSDLFile returns the migration info and a list of update
 // schema details derived from the given push event for SDL.
-func (s *Service) prepareIssueFromSDLFile(ctx context.Context, repoInfo *repoInfo, pushEvent vcs.PushEvent, schemaInfo *db.MigrationInfo, file string) ([]*migrationDetail, []*store.ActivityMessage) {
+func (s *Service) prepareIssueFromSDLFile(ctx context.Context, oauthContext *common.OauthContext, repoInfo *repoInfo, pushEvent vcs.PushEvent, schemaInfo *db.MigrationInfo, file string) ([]*migrationDetail, []*store.ActivityMessage) {
 	dbName := schemaInfo.Database
 	if dbName == "" && repoInfo.project.TenantMode == api.TenantModeDisabled {
 		slog.Debug("Ignored schema file without a database name", slog.String("file", file))
 		return nil, nil
 	}
 
-	sdl, err := s.readFileContent(ctx, pushEvent, repoInfo, file)
+	sdl, err := s.readFileContent(ctx, oauthContext, pushEvent, repoInfo, file)
 	if err != nil {
 		activityCreate := getIgnoredFileActivityCreate(repoInfo.project.UID, pushEvent, file, errors.Wrap(err, "Failed to read file content"))
 		return nil, []*store.ActivityMessage{activityCreate}
@@ -1955,11 +1955,12 @@ func (s *Service) prepareIssueFromSDLFile(ctx context.Context, repoInfo *repoInf
 // from the given push event for DDL.
 func (s *Service) prepareIssueFromFile(
 	ctx context.Context,
+	oauthContext *common.OauthContext,
 	repoInfo *repoInfo,
 	pushEvent vcs.PushEvent,
 	fileInfo fileInfo,
 ) ([]*migrationDetail, []*store.ActivityMessage) {
-	content, err := s.readFileContent(ctx, pushEvent, repoInfo, fileInfo.item.FileName)
+	content, err := s.readFileContent(ctx, oauthContext, pushEvent, repoInfo, fileInfo.item.FileName)
 	if err != nil {
 		return nil, []*store.ActivityMessage{
 			getIgnoredFileActivityCreate(
@@ -2510,7 +2511,7 @@ type mybatisMapperXMLFileDatum struct {
 //	repo: the repository will be list file tree and get file content from.
 //	commitID: the commitID is the snapshot of the file tree and file content.
 //	mapperFiles: the map of the mybatis mapper XML file path and content.
-func (s *Service) buildMybatisMapperXMLFileData(ctx context.Context, repoInfo *repoInfo, commitID string, mapperFiles map[string]string) ([]*mybatisMapperXMLFileDatum, error) {
+func (s *Service) buildMybatisMapperXMLFileData(ctx context.Context, oauthContext *common.OauthContext, repoInfo *repoInfo, commitID string, mapperFiles map[string]string) ([]*mybatisMapperXMLFileDatum, error) {
 	if len(mapperFiles) == 0 {
 		return []*mybatisMapperXMLFileDatum{}, nil
 	}
@@ -2547,13 +2548,7 @@ func (s *Service) buildMybatisMapperXMLFileData(ctx context.Context, repoInfo *r
 
 			filesInDir, err := vcs.Get(repoInfo.vcs.Type, vcs.ProviderConfig{}).FetchRepositoryFileList(
 				ctx,
-				common.OauthContext{
-					ClientID:     repoInfo.vcs.ApplicationID,
-					ClientSecret: repoInfo.vcs.Secret,
-					AccessToken:  repoInfo.repository.AccessToken,
-					RefreshToken: repoInfo.repository.RefreshToken,
-					Refresher:    utils.RefreshToken(ctx, s.store, repoInfo.repository.WebURL),
-				},
+				oauthContext,
 				repoInfo.vcs.InstanceURL,
 				repoInfo.repository.ExternalID,
 				commitID,
@@ -2569,13 +2564,7 @@ func (s *Service) buildMybatisMapperXMLFileData(ctx context.Context, repoInfo *r
 				}
 				fileContent, err := vcs.Get(repoInfo.vcs.Type, vcs.ProviderConfig{}).ReadFileContent(
 					ctx,
-					common.OauthContext{
-						ClientID:     repoInfo.vcs.ApplicationID,
-						ClientSecret: repoInfo.vcs.Secret,
-						AccessToken:  repoInfo.repository.AccessToken,
-						RefreshToken: repoInfo.repository.RefreshToken,
-						Refresher:    utils.RefreshToken(ctx, s.store, repoInfo.repository.WebURL),
-					},
+					oauthContext,
 					repoInfo.vcs.InstanceURL,
 					repoInfo.repository.ExternalID,
 					file.Path,

--- a/backend/api/gitops/webhook.go
+++ b/backend/api/gitops/webhook.go
@@ -703,7 +703,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 				commitID = prFile.LastCommitID
 			}
 			if len(mybatisMapperXMLFiles) > 0 {
-				mapperAdvices, err := sqlAdviceForMybatisMapperFiles(ctx, oauthContext, mybatisMapperXMLFiles, commitID, repo)
+				mapperAdvices, err := s.sqlAdviceForMybatisMapperFiles(ctx, oauthContext, mybatisMapperXMLFiles, commitID, repo)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sql advice for mybatis mapper files").SetInternal(err)
 				}
@@ -735,7 +735,7 @@ func (s *Service) RegisterWebhookRoutes(g *echo.Group) {
 	})
 }
 
-func sqlAdviceForMybatisMapperFiles(ctx context.Context, oauthContext *common.OauthContext, mybatisMapperContent map[string]string, commitID string, repoInfo *repoInfo) (map[string][]advisor.Advice, error) {
+func (s *Service) sqlAdviceForMybatisMapperFiles(ctx context.Context, oauthContext *common.OauthContext, mybatisMapperContent map[string]string, commitID string, repoInfo *repoInfo) (map[string][]advisor.Advice, error) {
 	if len(mybatisMapperContent) == 0 {
 		return map[string][]advisor.Advice{}, nil
 	}

--- a/backend/api/gitops/webhook.go
+++ b/backend/api/gitops/webhook.go
@@ -1215,7 +1215,7 @@ func (s *Service) processPushEvent(ctx context.Context, oauthContext *common.Oau
 		if baseVCSPushEvent.Before == strings.Repeat("0", 40) {
 			return distinctFileList, nil
 		}
-		return s.filterFilesByCommitsDiff(ctx, oauthContext, repo, distinctFileList, baseVCSPushEvent.Before, baseVCSPushEvent.After)
+		return filterFilesByCommitsDiff(ctx, oauthContext, repo, distinctFileList, baseVCSPushEvent.Before, baseVCSPushEvent.After)
 	}()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to filtered distinct files by commits diff")
@@ -1273,7 +1273,7 @@ func (s *Service) processPushEvent(ctx context.Context, oauthContext *common.Oau
 // In that case, the commits in the push event contains files which are not added in this PR/MR.
 // We use the compare API to get the file diffs and filter files by the diffs.
 // TODO(dragonly): generate distinct file change list from the commits diff instead of filter.
-func (s *Service) filterFilesByCommitsDiff(
+func filterFilesByCommitsDiff(
 	ctx context.Context,
 	oauthContext *common.OauthContext,
 	repoInfo *repoInfo,

--- a/backend/api/v1/externalvs_service.go
+++ b/backend/api/v1/externalvs_service.go
@@ -161,7 +161,7 @@ func (s *ExternalVersionControlService) SearchExternalVersionControlProjects(ctx
 
 	apiExternalProjectList, err := vcs.Get(externalVersionControl.Type, vcs.ProviderConfig{}).FetchAllRepositoryList(
 		ctx,
-		common.OauthContext{
+		&common.OauthContext{
 			ClientID:     externalVersionControl.ApplicationID,
 			ClientSecret: externalVersionControl.Secret,
 			AccessToken:  request.AccessToken,

--- a/backend/plugin/vcs/azure/azure.go
+++ b/backend/plugin/vcs/azure/azure.go
@@ -239,7 +239,7 @@ type ChangesResponse struct {
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-changes?view=azure-devops-rest-7.0&tabs=HTTP
 // TODO(zp): We should GET the changes pagenated, otherwise it may hit the Azure DevOps API limit.
-func GetChangesByCommit(ctx context.Context, oauthCtx common.OauthContext, externalRepositoryID, commitID string) (*ChangesResponse, error) {
+func GetChangesByCommit(ctx context.Context, oauthCtx *common.OauthContext, externalRepositoryID, commitID string) (*ChangesResponse, error) {
 	client := &http.Client{}
 	apiURL, err := getRepositoryAPIURL(externalRepositoryID)
 	if err != nil {
@@ -285,7 +285,7 @@ func GetChangesByCommit(ctx context.Context, oauthCtx common.OauthContext, exter
 // FetchCommitByID fetches the commit data by its ID from the repository.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthContext, _, externalRepositoryID, commitID string) (*vcs.Commit, error) {
+func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx *common.OauthContext, _, externalRepositoryID, commitID string) (*vcs.Commit, error) {
 	apiURL, err := getRepositoryAPIURL(externalRepositoryID)
 	if err != nil {
 		return nil, err
@@ -334,7 +334,7 @@ func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthCon
 // GetDiffFileList gets the diff files list between two commits.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get?view=azure-devops-rest-7.0&tabs=HTTP#between-commit-ids
-func (p *Provider) GetDiffFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string, repositoryID string, beforeCommit string, afterCommit string) ([]vcs.FileDiff, error) {
+func (p *Provider) GetDiffFileList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL string, repositoryID string, beforeCommit string, afterCommit string) ([]vcs.FileDiff, error) {
 	var result []vcs.FileDiff
 	page := 0
 	for {
@@ -352,7 +352,7 @@ func (p *Provider) GetDiffFileList(ctx context.Context, oauthCtx common.OauthCon
 }
 
 // getPaginatedDiffFileList gets the diff file list between two commits with pagination.
-func (p *Provider) getPaginatedDiffFileList(ctx context.Context, oauthCtx common.OauthContext, _ string, repositoryID string, beforeCommit string, afterCommit string, page int) ([]vcs.FileDiff, bool, error) {
+func (p *Provider) getPaginatedDiffFileList(ctx context.Context, oauthCtx *common.OauthContext, _ string, repositoryID string, beforeCommit string, afterCommit string, page int) ([]vcs.FileDiff, bool, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return nil, false, err
@@ -436,7 +436,7 @@ func (p *Provider) getPaginatedDiffFileList(ctx context.Context, oauthCtx common
 // The request included in this function requires the following scopes:
 // vso.profile, vso.project.
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/list?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.OauthContext, _ string) ([]*vcs.Repository, error) {
+func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx *common.OauthContext, _ string) ([]*vcs.Repository, error) {
 	publicAlias, err := p.getAuthenticatedProfilePublicAlias(ctx, oauthCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get authenticated profile public alias")
@@ -516,7 +516,7 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 // profile response.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/profile/profiles/get?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) getAuthenticatedProfilePublicAlias(ctx context.Context, oauthCtx common.OauthContext) (string, error) {
+func (p *Provider) getAuthenticatedProfilePublicAlias(ctx context.Context, oauthCtx *common.OauthContext) (string, error) {
 	values := &url.Values{}
 	values.Set("api-version", "7.0")
 	url := fmt.Sprintf("https://app.vssps.visualstudio.com/_apis/profile/profiles/me?%s", values.Encode())
@@ -551,7 +551,7 @@ func (p *Provider) getAuthenticatedProfilePublicAlias(ctx context.Context, oauth
 // listOrganizationsForMember lists all organization for a given member.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) listOrganizationsForMember(ctx context.Context, oauthCtx common.OauthContext, memberID string) ([]string, error) {
+func (p *Provider) listOrganizationsForMember(ctx context.Context, oauthCtx *common.OauthContext, memberID string) ([]string, error) {
 	urlParams := &url.Values{}
 	urlParams.Set("memberId", memberID)
 	urlParams.Set("api-version", "7.0")
@@ -596,7 +596,7 @@ func (p *Provider) listOrganizationsForMember(ctx context.Context, oauthCtx comm
 // FetchRepositoryFileList fetches the all files from the given repository tree recursively.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/trees/get?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, _ string, repositoryID string, ref string, filePath string) ([]*vcs.RepositoryTreeNode, error) {
+func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx *common.OauthContext, _ string, repositoryID string, ref string, filePath string) ([]*vcs.RepositoryTreeNode, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return nil, err
@@ -650,12 +650,12 @@ func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.
 }
 
 // CreateFile creates a file at given path in the repository.
-func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
+func (p *Provider) CreateFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
 	return p.createOrUpdateFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, fileCommitCreate, true)
 }
 
 // OverwriteFile overwrites an existing file at given path in the repository.
-func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
+func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
 	create := true
 	if fileCommitCreate.LastCommitID != "" {
 		create = false
@@ -663,7 +663,7 @@ func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthConte
 	return p.createOrUpdateFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, fileCommitCreate, create)
 }
 
-func (p *Provider) getLatestCommitIDOnBranch(ctx context.Context, oauthCtx common.OauthContext, repositoryID, branchName string) (string, error) {
+func (p *Provider) getLatestCommitIDOnBranch(ctx context.Context, oauthCtx *common.OauthContext, repositoryID, branchName string) (string, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return "", err
@@ -707,7 +707,7 @@ func (p *Provider) getLatestCommitIDOnBranch(ctx context.Context, oauthCtx commo
 // createOrUpdateFile update or create the file.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pushes/create?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) createOrUpdateFile(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate, create bool) error {
+func (p *Provider) createOrUpdateFile(ctx context.Context, oauthCtx *common.OauthContext, _, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate, create bool) error {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return err
@@ -832,7 +832,7 @@ func (p *Provider) createOrUpdateFile(ctx context.Context, oauthCtx common.Oauth
 // Docs:
 // - https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.0&tabs=HTTP
 // - https://learn.microsoft.com/en-us/rest/api/azure/devops/git/blobs/get-blob?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx *common.OauthContext, _, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return nil, err
@@ -941,7 +941,7 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 // ReadFileContent reads the content of the given file in the repository.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, _ string, repositoryID string, filePath string, refInfo vcs.RefInfo) (string, error) {
+func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx *common.OauthContext, _ string, repositoryID string, filePath string, refInfo vcs.RefInfo) (string, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return "", err
@@ -992,7 +992,7 @@ func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthCon
 // - branchName: The branch name.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/stats/get?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) GetBranch(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID, branchName string) (*vcs.BranchInfo, error) {
+func (p *Provider) GetBranch(ctx context.Context, oauthCtx *common.OauthContext, _, repositoryID, branchName string) (*vcs.BranchInfo, error) {
 	if branchName == "" {
 		return nil, errors.New("branch name is required")
 	}
@@ -1043,7 +1043,7 @@ func (p *Provider) GetBranch(ctx context.Context, oauthCtx common.OauthContext, 
 // CreateBranch creates the branch in the repository.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pushes/create?view=azure-devops-rest-7.1
-func (p *Provider) CreateBranch(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID string, branch *vcs.BranchInfo) error {
+func (p *Provider) CreateBranch(ctx context.Context, oauthCtx *common.OauthContext, _, repositoryID string, branch *vcs.BranchInfo) error {
 	type refUpdate struct {
 		Name        string `json:"name"`
 		OldObjectID string `json:"oldObjectId"`
@@ -1103,7 +1103,7 @@ func (p *Provider) CreateBranch(ctx context.Context, oauthCtx common.OauthContex
 // ListPullRequestFile lists the changed files in the pull request.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/get-pull-request?view=azure-devops-rest-7.1
-func (p *Provider) ListPullRequestFile(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID, pullRequestID string) ([]*vcs.PullRequestFile, error) {
+func (p *Provider) ListPullRequestFile(ctx context.Context, oauthCtx *common.OauthContext, _, repositoryID, pullRequestID string) ([]*vcs.PullRequestFile, error) {
 	type mergeCommit struct {
 		CommitID string `json:"commitId"`
 	}
@@ -1168,7 +1168,7 @@ func (p *Provider) ListPullRequestFile(ctx context.Context, oauthCtx common.Oaut
 // CreatePullRequest creates the pull request in the repository.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/create?view=azure-devops-rest-7.1&tabs=HTTP
-func (p *Provider) CreatePullRequest(ctx context.Context, oauthCtx common.OauthContext, _, repositoryID string, pullRequestCreate *vcs.PullRequestCreate) (*vcs.PullRequest, error) {
+func (p *Provider) CreatePullRequest(ctx context.Context, oauthCtx *common.OauthContext, _, repositoryID string, pullRequestCreate *vcs.PullRequestCreate) (*vcs.PullRequest, error) {
 	type azurePullRequest struct {
 		Title         string      `json:"title"`
 		Description   string      `json:"description"`
@@ -1240,7 +1240,7 @@ func (p *Provider) CreatePullRequest(ctx context.Context, oauthCtx common.OauthC
 }
 
 // UpsertEnvironmentVariable creates or updates the environment variable in the repository.
-func (*Provider) UpsertEnvironmentVariable(context.Context, common.OauthContext, string, string, string, string) error {
+func (*Provider) UpsertEnvironmentVariable(context.Context, *common.OauthContext, string, string, string, string) error {
 	// We will set the variable in pipeline. Check sql_review.go/createSQLReviewPipeline function.
 	return nil
 }
@@ -1249,7 +1249,7 @@ func (*Provider) UpsertEnvironmentVariable(context.Context, common.OauthContext,
 // API Version 7.0 do not specify the OAuth scope for creating webhook explicitly, but it works.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/hooks/subscriptions/create?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, _, externalRepositoryID string, payload []byte) (string, error) {
+func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx *common.OauthContext, _, externalRepositoryID string, payload []byte) (string, error) {
 	parts := strings.Split(externalRepositoryID, "/")
 	if len(parts) != 3 {
 		return "", errors.Errorf("invalid repository ID %q", externalRepositoryID)
@@ -1296,14 +1296,14 @@ func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthConte
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/hooks/subscriptions/replace-subscription?view=azure-devops-rest-7.0&tabs=HTTP
 // (2023/07/07, zp): It seems that the PatchWebhook API of each provider is not used by Bytebase, should we remove it?
-func (*Provider) PatchWebhook(_ context.Context, _ common.OauthContext, _, _, _ string, _ []byte) error {
+func (*Provider) PatchWebhook(_ context.Context, _ *common.OauthContext, _, _, _ string, _ []byte) error {
 	return errors.New("not implemented")
 }
 
 // DeleteWebhook deletes the webhook in the repository.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/hooks/subscriptions/delete?view=azure-devops-rest-7.0&tabs=HTTP
-func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, _, _, webhookID string) error {
+func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx *common.OauthContext, _, _, webhookID string) error {
 	// By design, we encode the webhook ID as <organization>/<webhookID> for Azure DevOps.
 	parts := strings.Split(webhookID, "/")
 	if len(parts) != 2 {
@@ -1353,7 +1353,7 @@ type CommitsInPush struct {
 // GetPushCommitsByPushID gets the commits in the push by batch, it is useful when the push contains a lot of commits.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-push-commits?view=azure-devops-rest-7.0&tabs=HTTP
-func GetPushCommitsByPushID(ctx context.Context, oauthCtx common.OauthContext, repositoryID string, pushID uint64) (*CommitsInPush, error) {
+func GetPushCommitsByPushID(ctx context.Context, oauthCtx *common.OauthContext, repositoryID string, pushID uint64) (*CommitsInPush, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return nil, err
@@ -1405,7 +1405,7 @@ type PullRequest struct {
 // QueryPullRequest queries the pull request by the last merge commit.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-query/get?view=azure-devops-rest-7.0#gitpullrequestqueryinput
-func QueryPullRequest(ctx context.Context, oauthCtx common.OauthContext, repositoryID string, lastMergeCommit string) ([]*PullRequest, error) {
+func QueryPullRequest(ctx context.Context, oauthCtx *common.OauthContext, repositoryID string, lastMergeCommit string) ([]*PullRequest, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return nil, err
@@ -1501,7 +1501,7 @@ func QueryPullRequest(ctx context.Context, oauthCtx common.OauthContext, reposit
 // GetPullRequestCommits gets the commits in the pull request.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-commits/get-pull-request-commits?view=azure-devops-rest-7.0
-func GetPullRequestCommits(ctx context.Context, oauthCtx common.OauthContext, repositoryID string, pullRequestID uint64) ([]ServiceHookCodePushEventResourceCommit, error) {
+func GetPullRequestCommits(ctx context.Context, oauthCtx *common.OauthContext, repositoryID string, pullRequestID uint64) ([]ServiceHookCodePushEventResourceCommit, error) {
 	apiURL, err := getRepositoryAPIURL(repositoryID)
 	if err != nil {
 		return nil, err
@@ -1599,6 +1599,8 @@ func tokenRefresher(oauthCtx oauthContext, refresher common.TokenRefresher) oaut
 		}
 
 		*oldToken = r.AccessToken
+
+		slog.Debug("token refresh to", slog.String("access_token", r.AccessToken), slog.String("refresh_token", r.RefreshToken), slog.String("expires_in", r.ExpiresIn))
 
 		var expiresIn int64
 		if r.ExpiresIn != "" {

--- a/backend/plugin/vcs/azure/sql_review.go
+++ b/backend/plugin/vcs/azure/sql_review.go
@@ -98,7 +98,7 @@ type policy struct {
 }
 
 // EnableSQLReviewCI enables the SQL review pipeline and policy.
-func EnableSQLReviewCI(ctx context.Context, oauthCtx common.OauthContext, repositoryTitle, repositoryID, branch, token string) error {
+func EnableSQLReviewCI(ctx context.Context, oauthCtx *common.OauthContext, repositoryTitle, repositoryID, branch, token string) error {
 	pipeline, err := createSQLReviewPipeline(ctx, oauthCtx, repositoryTitle, repositoryID, token)
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func EnableSQLReviewCI(ctx context.Context, oauthCtx common.OauthContext, reposi
 // createSQLReviewPipeline creates the SQL Review pipeline.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/pipelines/create?view=azure-devops-rest-7.1
-func createSQLReviewPipeline(ctx context.Context, oauthCtx common.OauthContext, repositoryTitle, repositoryID, token string) (*pipeline, error) {
+func createSQLReviewPipeline(ctx context.Context, oauthCtx *common.OauthContext, repositoryTitle, repositoryID, token string) (*pipeline, error) {
 	parts := strings.Split(repositoryID, "/")
 	if len(parts) != 3 {
 		return nil, errors.Errorf("invalid repository ID %q", repositoryID)
@@ -178,7 +178,7 @@ func createSQLReviewPipeline(ctx context.Context, oauthCtx common.OauthContext, 
 // createSQLReviewPolicy creates the SQL Review policy.
 //
 // Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/policy/configurations/create?view=azure-devops-rest-7.0
-func createSQLReviewBranchPolicy(ctx context.Context, oauthCtx common.OauthContext, repositoryID, branch string, pipelineID int) error {
+func createSQLReviewBranchPolicy(ctx context.Context, oauthCtx *common.OauthContext, repositoryID, branch string, pipelineID int) error {
 	parts := strings.Split(repositoryID, "/")
 	if len(parts) != 3 {
 		return errors.Errorf("invalid repository ID %q", repositoryID)

--- a/backend/plugin/vcs/bitbucket/bitbucket.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket.go
@@ -142,7 +142,7 @@ type Commit struct {
 // FetchCommitByID fetches the commit data by its ID from the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-commit-commit-get
-func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, commitID string) (*vcs.Commit, error) {
+func (p *Provider) FetchCommitByID(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, commitID string) (*vcs.Commit, error) {
 	url := fmt.Sprintf("%s/repositories/%s/commit/%s", p.APIURL(instanceURL), url.PathEscape(repositoryID), commitID)
 	code, _, body, err := oauth.Get(
 		ctx,
@@ -198,7 +198,7 @@ type CommitDiffStat struct {
 // GetDiffFileList gets the diff files list between two commits.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-diffstat-spec-get
-func (p *Provider) GetDiffFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, beforeCommit, afterCommit string) ([]vcs.FileDiff, error) {
+func (p *Provider) GetDiffFileList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, beforeCommit, afterCommit string) ([]vcs.FileDiff, error) {
 	var bbcDiffs []*CommitDiffStat
 	next := fmt.Sprintf("%s/repositories/%s/diffstat/%s..%s?pagelen=%d", p.APIURL(instanceURL), repositoryID, afterCommit, beforeCommit, apiPageSize)
 	for next != "" {
@@ -235,7 +235,7 @@ func (p *Provider) GetDiffFileList(ctx context.Context, oauthCtx common.OauthCon
 	return diffs, nil
 }
 
-func (p *Provider) fetchPaginatedDiffFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, url string) (diffs []*CommitDiffStat, next string, err error) {
+func (p *Provider) fetchPaginatedDiffFileList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, url string) (diffs []*CommitDiffStat, next string, err error) {
 	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
@@ -293,7 +293,7 @@ type RepositoryPermission struct {
 // has admin permissions, which is required to create webhook in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-user-permissions-repositories-get
-func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]*vcs.Repository, error) {
+func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL string) ([]*vcs.Repository, error) {
 	var bbcRepos []*Repository
 	params := url.Values{}
 	params.Add("q", `permission="admin"`)
@@ -326,7 +326,7 @@ func (p *Provider) FetchAllRepositoryList(ctx context.Context, oauthCtx common.O
 // fetchPaginatedRepositoryList fetches repositories in given page. It returns
 // the paginated results along with a string indicating the URL of the next page
 // (if exists).
-func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, url string) (repos []*Repository, next string, err error) {
+func (p *Provider) fetchPaginatedRepositoryList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, url string) (repos []*Repository, next string, err error) {
 	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
@@ -390,7 +390,7 @@ type TreeEntry struct {
 // recursively.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#directory-listings
-func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*vcs.RepositoryTreeNode, error) {
+func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*vcs.RepositoryTreeNode, error) {
 	var bbcTreeEntries []*TreeEntry
 	params := url.Values{}
 	// NOTE: There is no way to ask the Bitbucket Cloud API to return all
@@ -424,7 +424,7 @@ func (p *Provider) FetchRepositoryFileList(ctx context.Context, oauthCtx common.
 // fetchPaginatedRepositoryFileList fetches files under a repository tree
 // recursively in given page. It returns the paginated results along with a
 // string indicating URL of the next page (if exists).
-func (p *Provider) fetchPaginatedRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, url string) (_ []*TreeEntry, next string, err error) {
+func (p *Provider) fetchPaginatedRepositoryFileList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, url string) (_ []*TreeEntry, next string, err error) {
 	code, _, body, err := oauth.Get(
 		ctx,
 		p.client,
@@ -468,7 +468,7 @@ func (p *Provider) fetchPaginatedRepositoryFileList(ctx context.Context, oauthCt
 // CreateFile creates a file at given path in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-post
-func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
+func (p *Provider) CreateFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
 	var body bytes.Buffer
 	w := multipart.NewWriter(&body)
 	part, err := w.CreateFormField(filePath)
@@ -523,14 +523,14 @@ func (p *Provider) CreateFile(ctx context.Context, oauthCtx common.OauthContext,
 // OverwriteFile overwrites an existing file at given path in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-post
-func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
+func (p *Provider) OverwriteFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, fileCommitCreate vcs.FileCommitCreate) error {
 	return p.CreateFile(ctx, oauthCtx, instanceURL, repositoryID, filePath, fileCommitCreate)
 }
 
 // ReadFileMeta reads the metadata of the given file in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#file-meta-data
-func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
+func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (*vcs.FileMeta, error) {
 	url := fmt.Sprintf("%s/repositories/%s/src/%s/%s?format=meta", p.APIURL(instanceURL), repositoryID, url.PathEscape(refInfo.RefName), url.PathEscape(filePath))
 	code, _, body, err := oauth.Get(
 		ctx,
@@ -582,7 +582,7 @@ func (p *Provider) ReadFileMeta(ctx context.Context, oauthCtx common.OauthContex
 // ReadFileContent reads the content of the given file in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#raw-file-contents
-func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (string, error) {
+func (p *Provider) ReadFileContent(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, refInfo vcs.RefInfo) (string, error) {
 	url := fmt.Sprintf("%s/repositories/%s/src/%s/%s", p.APIURL(instanceURL), repositoryID, url.PathEscape(refInfo.RefName), url.PathEscape(filePath))
 	code, _, body, err := oauth.Get(
 		ctx,
@@ -630,7 +630,7 @@ type Branch struct {
 // GetBranch gets the given branch in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-branches-name-get
-func (p *Provider) GetBranch(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, branchName string) (*vcs.BranchInfo, error) {
+func (p *Provider) GetBranch(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, branchName string) (*vcs.BranchInfo, error) {
 	url := fmt.Sprintf("%s/repositories/%s/refs/branches/%s", p.APIURL(instanceURL), repositoryID, branchName)
 	code, _, body, err := oauth.Get(
 		ctx,
@@ -684,7 +684,7 @@ type branchCreate struct {
 // CreateBranch creates the branch in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-branches-post
-func (p *Provider) CreateBranch(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, branch *vcs.BranchInfo) error {
+func (p *Provider) CreateBranch(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID string, branch *vcs.BranchInfo) error {
 	body, err := json.Marshal(
 		branchCreate{
 			Name:   branch.Name,
@@ -731,7 +731,7 @@ func (p *Provider) CreateBranch(ctx context.Context, oauthCtx common.OauthContex
 // ListPullRequestFile lists the changed files in the pull request.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-diffstat-get
-func (p *Provider) ListPullRequestFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, pullRequestID string) ([]*vcs.PullRequestFile, error) {
+func (p *Provider) ListPullRequestFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, pullRequestID string) ([]*vcs.PullRequestFile, error) {
 	var bbcDiffs []*CommitDiffStat
 	next := fmt.Sprintf("%s/repositories/%s/pullrequests/%s/diffstat?pagelen=%d", p.APIURL(instanceURL), url.PathEscape(repositoryID), pullRequestID, apiPageSize)
 	for next != "" {
@@ -786,7 +786,7 @@ type pullRequestCreate struct {
 // CreatePullRequest creates the pull request in the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-post
-func (p *Provider) CreatePullRequest(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, create *vcs.PullRequestCreate) (*vcs.PullRequest, error) {
+func (p *Provider) CreatePullRequest(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID string, create *vcs.PullRequestCreate) (*vcs.PullRequest, error) {
 	payload, err := json.Marshal(
 		pullRequestCreate{
 			Title:             create.Title,
@@ -854,7 +854,7 @@ func (p *Provider) CreatePullRequest(ctx context.Context, oauthCtx common.OauthC
 // UpsertEnvironmentVariable creates or updates the environment variable in the repository.
 //
 // WARNING: This is not supported in Bitbucket Cloud.
-func (*Provider) UpsertEnvironmentVariable(context.Context, common.OauthContext, string, string, string, string) error {
+func (*Provider) UpsertEnvironmentVariable(context.Context, *common.OauthContext, string, string, string, string) error {
 	return errors.New("not supported")
 }
 
@@ -922,7 +922,7 @@ type Webhook struct {
 // CreateWebhook creates a webhook in the repository with given payload.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-post
-func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error) {
+func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error) {
 	url := fmt.Sprintf("%s/repositories/%s/hooks", p.APIURL(instanceURL), repositoryID)
 	code, _, body, err := oauth.Post(
 		ctx,
@@ -968,7 +968,7 @@ func (p *Provider) CreateWebhook(ctx context.Context, oauthCtx common.OauthConte
 // PatchWebhook patches the webhook in the repository with given payload.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-uid-put
-func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error {
+func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error {
 	url := fmt.Sprintf("%s/repositories/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
 	code, _, body, err := oauth.Put(
 		ctx,
@@ -1005,7 +1005,7 @@ func (p *Provider) PatchWebhook(ctx context.Context, oauthCtx common.OauthContex
 // DeleteWebhook deletes the webhook from the repository.
 //
 // Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-uid-delete
-func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string) error {
+func (p *Provider) DeleteWebhook(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, webhookID string) error {
 	url := fmt.Sprintf("%s/repositories/%s/hooks/%s", p.APIURL(instanceURL), repositoryID, webhookID)
 	code, _, body, err := oauth.Delete(
 		ctx,

--- a/backend/plugin/vcs/bitbucket/bitbucket_test.go
+++ b/backend/plugin/vcs/bitbucket/bitbucket_test.go
@@ -171,7 +171,7 @@ func TestProvider_FetchCommitByID(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.FetchCommitByID(ctx, common.OauthContext{}, bitbucketCloudURL, "bitbucket/geordi", "f7591a1")
+	got, err := p.FetchCommitByID(ctx, &common.OauthContext{}, bitbucketCloudURL, "bitbucket/geordi", "f7591a1")
 	require.NoError(t, err)
 
 	want := &vcs.Commit{
@@ -227,7 +227,7 @@ func TestProvider_GetDiffFileList(t *testing.T) {
 	},
 	)
 	ctx := context.Background()
-	got, err := p.GetDiffFileList(ctx, common.OauthContext{}, bitbucketCloudURL, "1", "before_sha", "after_sha")
+	got, err := p.GetDiffFileList(ctx, &common.OauthContext{}, bitbucketCloudURL, "1", "before_sha", "after_sha")
 	require.NoError(t, err)
 
 	want := []vcs.FileDiff{
@@ -275,7 +275,7 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.FetchAllRepositoryList(ctx, common.OauthContext{}, bitbucketCloudURL)
+	got, err := p.FetchAllRepositoryList(ctx, &common.OauthContext{}, bitbucketCloudURL)
 	require.NoError(t, err)
 
 	want := []*vcs.Repository{
@@ -336,7 +336,7 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 			}, nil
 		})
 
-		got, err := p.FetchRepositoryFileList(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "eefd5ef", "")
+		got, err := p.FetchRepositoryFileList(ctx, &common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "eefd5ef", "")
 		require.NoError(t, err)
 
 		want := []*vcs.RepositoryTreeNode{
@@ -358,7 +358,7 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 			}, nil
 		})
 
-		got, err := p.FetchRepositoryFileList(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "eefd5ef", "tests")
+		got, err := p.FetchRepositoryFileList(ctx, &common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "eefd5ef", "tests")
 		require.NoError(t, err)
 
 		// Non-blob type should be excluded
@@ -390,7 +390,7 @@ func TestProvider_CreateFile(t *testing.T) {
 	ctx := context.Background()
 	err := p.CreateFile(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		bitbucketCloudURL,
 		"username/slug",
 		"repo/path/to/image.png",
@@ -421,7 +421,7 @@ func TestProvider_OverwriteFile(t *testing.T) {
 	ctx := context.Background()
 	err := p.OverwriteFile(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		bitbucketCloudURL,
 		"username/slug",
 		"repo/path/to/image.png",
@@ -474,7 +474,7 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", vcs.RefInfo{
+	got, err := p.ReadFileMeta(ctx, &common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", vcs.RefInfo{
 		RefType: vcs.RefTypeCommit,
 		RefName: "eefd5ef",
 	})
@@ -500,7 +500,7 @@ func TestProvider_ReadFileContent(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileContent(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", vcs.RefInfo{
+	got, err := p.ReadFileContent(ctx, &common.OauthContext{}, bitbucketCloudURL, "atlassian/bbql", "tests/__init__.py", vcs.RefInfo{
 		RefType: vcs.RefTypeCommit,
 		RefName: "eefd5ef",
 	})
@@ -626,7 +626,7 @@ func TestProvider_GetBranch(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.GetBranch(ctx, common.OauthContext{}, bitbucketCloudURL, "atlassian/aui", "master")
+	got, err := p.GetBranch(ctx, &common.OauthContext{}, bitbucketCloudURL, "atlassian/aui", "master")
 	require.NoError(t, err)
 
 	want := &vcs.BranchInfo{
@@ -654,7 +654,7 @@ func TestProvider_CreateBranch(t *testing.T) {
 	ctx := context.Background()
 	err := p.CreateBranch(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		bitbucketCloudURL,
 		"seanfarley/hg",
 		&vcs.BranchInfo{
@@ -710,7 +710,7 @@ func TestProvider_ListPullRequestFile(t *testing.T) {
 	},
 	)
 	ctx := context.Background()
-	got, err := p.ListPullRequestFile(ctx, common.OauthContext{}, bitbucketCloudURL, "1", "10086")
+	got, err := p.ListPullRequestFile(ctx, &common.OauthContext{}, bitbucketCloudURL, "1", "10086")
 	require.NoError(t, err)
 
 	want := []*vcs.PullRequestFile{
@@ -775,7 +775,7 @@ func TestProvider_CreatePullRequest(t *testing.T) {
 	ctx := context.Background()
 	got, err := p.CreatePullRequest(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		bitbucketCloudURL,
 		"octocat/Hello-World",
 		&vcs.PullRequestCreate{
@@ -816,7 +816,7 @@ func TestProvider_CreateWebhook(t *testing.T) {
 	ctx := context.Background()
 	got, err := p.CreateWebhook(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		bitbucketCloudURL,
 		"1",
 		[]byte(`
@@ -847,7 +847,7 @@ func TestProvider_PatchWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.PatchWebhook(ctx, common.OauthContext{}, bitbucketCloudURL, "1", "1", []byte(""))
+	err := p.PatchWebhook(ctx, &common.OauthContext{}, bitbucketCloudURL, "1", "1", []byte(""))
 	require.NoError(t, err)
 }
 
@@ -863,7 +863,7 @@ func TestProvider_DeleteWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.DeleteWebhook(ctx, common.OauthContext{}, bitbucketCloudURL, "1", "1")
+	err := p.DeleteWebhook(ctx, &common.OauthContext{}, bitbucketCloudURL, "1", "1")
 	require.NoError(t, err)
 }
 

--- a/backend/plugin/vcs/github/github_test.go
+++ b/backend/plugin/vcs/github/github_test.go
@@ -63,7 +63,7 @@ func TestProvider_FetchCommitByID(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.FetchCommitByID(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "7638417db6d59f3c431d3e1f261cc637155684cd")
+	got, err := p.FetchCommitByID(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "7638417db6d59f3c431d3e1f261cc637155684cd")
 	require.NoError(t, err)
 
 	want := &vcs.Commit{
@@ -261,7 +261,7 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.FetchAllRepositoryList(ctx, common.OauthContext{}, githubComURL)
+	got, err := p.FetchAllRepositoryList(ctx, &common.OauthContext{}, githubComURL)
 	require.NoError(t, err)
 
 	// Repositories without admin permissions should be excluded
@@ -328,7 +328,7 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 
 	t.Run("no path prefix", func(t *testing.T) {
 		ctx := context.Background()
-		got, err := p.FetchRepositoryFileList(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "main", "")
+		got, err := p.FetchRepositoryFileList(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "main", "")
 		require.NoError(t, err)
 
 		// Non-blob type should excluded
@@ -351,7 +351,7 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 
 	t.Run("has path prefix", func(t *testing.T) {
 		ctx := context.Background()
-		got, err := p.FetchRepositoryFileList(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "main", "subdir")
+		got, err := p.FetchRepositoryFileList(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "main", "subdir")
 		require.NoError(t, err)
 
 		// Non-blob type should be excluded
@@ -437,7 +437,7 @@ func TestProvider_CreateFile(t *testing.T) {
 	ctx := context.Background()
 	err := p.CreateFile(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		githubComURL,
 		"octocat/Hello-World",
 		"notes/hello.txt",
@@ -522,7 +522,7 @@ func TestProvider_OverwriteFile(t *testing.T) {
 	ctx := context.Background()
 	err := p.OverwriteFile(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		githubComURL,
 		"octocat/Hello-World",
 		"notes/hello.txt",
@@ -589,7 +589,7 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", vcs.RefInfo{
+	got, err := p.ReadFileMeta(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", vcs.RefInfo{
 		RefType: vcs.RefTypeBranch,
 		RefName: "master",
 	})
@@ -628,7 +628,7 @@ You can look around to get an idea how to structure your project and, when done,
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileContent(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", vcs.RefInfo{
+	got, err := p.ReadFileContent(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "README.md", vcs.RefInfo{
 		RefType: vcs.RefTypeBranch,
 		RefName: "master",
 	})
@@ -676,7 +676,7 @@ func TestProvider_CreateWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.CreateWebhook(ctx, common.OauthContext{}, githubComURL, "1", []byte(""))
+	got, err := p.CreateWebhook(ctx, &common.OauthContext{}, githubComURL, "1", []byte(""))
 	require.NoError(t, err)
 	assert.Equal(t, "12345678", got)
 }
@@ -692,7 +692,7 @@ func TestProvider_PatchWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.PatchWebhook(ctx, common.OauthContext{}, githubComURL, "1", "1", []byte(""))
+	err := p.PatchWebhook(ctx, &common.OauthContext{}, githubComURL, "1", "1", []byte(""))
 	require.NoError(t, err)
 }
 
@@ -707,7 +707,7 @@ func TestProvider_DeleteWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.DeleteWebhook(ctx, common.OauthContext{}, githubComURL, "1", "1")
+	err := p.DeleteWebhook(ctx, &common.OauthContext{}, githubComURL, "1", "1")
 	require.NoError(t, err)
 }
 
@@ -791,7 +791,7 @@ func TestProvider_GetBranch(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.GetBranch(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "featureA")
+	got, err := p.GetBranch(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "featureA")
 	require.NoError(t, err)
 
 	want := &vcs.BranchInfo{
@@ -825,7 +825,7 @@ func TestProvider_CreateBranch(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.CreateBranch(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", &vcs.BranchInfo{
+	err := p.CreateBranch(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", &vcs.BranchInfo{
 		Name:         "featureA",
 		LastCommitID: "aa218f56b14c9653891f9e74264a383fa43fefbd",
 	})
@@ -935,7 +935,7 @@ func TestProvider_CreatePullRequest(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	res, err := p.CreatePullRequest(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", &vcs.PullRequestCreate{
+	res, err := p.CreatePullRequest(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", &vcs.PullRequestCreate{
 		Title:                 "Amazing new feature",
 		Body:                  "Please pull these awesome changes in!",
 		Head:                  "new-topic",
@@ -975,7 +975,7 @@ func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.UpsertEnvironmentVariable(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "1", "new value")
+	err := p.UpsertEnvironmentVariable(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "1", "new value")
 	require.NoError(t, err)
 }
 
@@ -1011,7 +1011,7 @@ func TestProvider_ListPullRequestFile(t *testing.T) {
 	},
 	)
 	ctx := context.Background()
-	got, err := p.ListPullRequestFile(ctx, common.OauthContext{}, githubComURL, "octocat/Hello-World", "1")
+	got, err := p.ListPullRequestFile(ctx, &common.OauthContext{}, githubComURL, "octocat/Hello-World", "1")
 	require.NoError(t, err)
 
 	want := []*vcs.PullRequestFile{
@@ -1052,7 +1052,7 @@ func TestProvider_GetDiffFileList(t *testing.T) {
 	},
 	)
 	ctx := context.Background()
-	got, err := p.GetDiffFileList(ctx, common.OauthContext{}, "", "1", "before_sha", "after_sha")
+	got, err := p.GetDiffFileList(ctx, &common.OauthContext{}, "", "1", "before_sha", "after_sha")
 	require.NoError(t, err)
 
 	want := []vcs.FileDiff{

--- a/backend/plugin/vcs/gitlab/gitlab_test.go
+++ b/backend/plugin/vcs/gitlab/gitlab_test.go
@@ -58,7 +58,7 @@ func TestProvider_FetchCommitByID(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.FetchCommitByID(ctx, common.OauthContext{}, "", "5", "6104942438c14ec7bd21c6cd5bd995272b3faff6")
+	got, err := p.FetchCommitByID(ctx, &common.OauthContext{}, "", "5", "6104942438c14ec7bd21c6cd5bd995272b3faff6")
 	require.NoError(t, err)
 
 	want := &vcs.Commit{
@@ -151,7 +151,7 @@ func TestProvider_FetchAllRepositoryList(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.FetchAllRepositoryList(ctx, common.OauthContext{}, "")
+	got, err := p.FetchAllRepositoryList(ctx, &common.OauthContext{}, "")
 	require.NoError(t, err)
 
 	want := []*vcs.Repository{
@@ -194,7 +194,7 @@ func TestProvider_FetchRepositoryFileList(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.FetchRepositoryFileList(ctx, common.OauthContext{}, "", "1", "main", "")
+	got, err := p.FetchRepositoryFileList(ctx, &common.OauthContext{}, "", "1", "main", "")
 	require.NoError(t, err)
 
 	// Non-blob type should excluded
@@ -231,7 +231,7 @@ func TestProvider_CreateFile(t *testing.T) {
 	ctx := context.Background()
 	err := p.CreateFile(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		"",
 		"1",
 		"lib/class.rb",
@@ -268,7 +268,7 @@ func TestProvider_OverwriteFile(t *testing.T) {
 	ctx := context.Background()
 	err := p.OverwriteFile(
 		ctx,
-		common.OauthContext{},
+		&common.OauthContext{},
 		"",
 		"1",
 		"lib/class.rb",
@@ -300,7 +300,7 @@ func TestProvider_ReadFileMeta(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileMeta(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", vcs.RefInfo{
+	got, err := p.ReadFileMeta(ctx, &common.OauthContext{}, "", "1", "app/models/key.rb", vcs.RefInfo{
 		RefType: vcs.RefTypeBranch,
 		RefName: "master",
 	})
@@ -338,7 +338,7 @@ You can look around to get an idea how to structure your project and, when done,
 	)
 
 	ctx := context.Background()
-	got, err := p.ReadFileContent(ctx, common.OauthContext{}, "", "1", "app/models/key.rb", vcs.RefInfo{
+	got, err := p.ReadFileContent(ctx, &common.OauthContext{}, "", "1", "app/models/key.rb", vcs.RefInfo{
 		RefType: vcs.RefTypeBranch,
 		RefName: "master",
 	})
@@ -389,7 +389,7 @@ func TestProvider_CreateWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.CreateWebhook(ctx, common.OauthContext{}, "", "1", []byte(""))
+	got, err := p.CreateWebhook(ctx, &common.OauthContext{}, "", "1", []byte(""))
 	require.NoError(t, err)
 	assert.Equal(t, "1", got)
 }
@@ -405,7 +405,7 @@ func TestProvider_PatchWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.PatchWebhook(ctx, common.OauthContext{}, "", "1", "1", []byte(""))
+	err := p.PatchWebhook(ctx, &common.OauthContext{}, "", "1", "1", []byte(""))
 	require.NoError(t, err)
 }
 
@@ -420,7 +420,7 @@ func TestProvider_DeleteWebhook(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.DeleteWebhook(ctx, common.OauthContext{}, "", "1", "1")
+	err := p.DeleteWebhook(ctx, &common.OauthContext{}, "", "1", "1")
 	require.NoError(t, err)
 }
 
@@ -518,7 +518,7 @@ func TestProvider_GetBranch(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	got, err := p.GetBranch(ctx, common.OauthContext{}, "", "1", "main")
+	got, err := p.GetBranch(ctx, &common.OauthContext{}, "", "1", "main")
 	require.NoError(t, err)
 
 	want := &vcs.BranchInfo{
@@ -567,7 +567,7 @@ func TestProvider_CreateBranch(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.CreateBranch(ctx, common.OauthContext{}, "", "1", &vcs.BranchInfo{
+	err := p.CreateBranch(ctx, &common.OauthContext{}, "", "1", &vcs.BranchInfo{
 		Name:         "newbranch",
 		LastCommitID: "7b5c3cc8be40ee161ae89a06bba6229da1032a0c",
 	})
@@ -670,7 +670,7 @@ func TestProvider_CreatePullRequest(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	res, err := p.CreatePullRequest(ctx, common.OauthContext{}, "", "1", &vcs.PullRequestCreate{
+	res, err := p.CreatePullRequest(ctx, &common.OauthContext{}, "", "1", &vcs.PullRequestCreate{
 		Title:                 "test1",
 		Body:                  "fixed login page css paddings",
 		Head:                  "test1",
@@ -739,7 +739,7 @@ func TestProvider_UpsertEnvironmentVariable(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := p.UpsertEnvironmentVariable(ctx, common.OauthContext{}, "", "1", "1", "new value")
+	err := p.UpsertEnvironmentVariable(ctx, &common.OauthContext{}, "", "1", "1", "new value")
 	require.NoError(t, err)
 }
 
@@ -790,7 +790,7 @@ func TestProvider_ListPullRequestFile(t *testing.T) {
 	},
 	)
 	ctx := context.Background()
-	got, err := p.ListPullRequestFile(ctx, common.OauthContext{}, "", "1", "1")
+	got, err := p.ListPullRequestFile(ctx, &common.OauthContext{}, "", "1", "1")
 	require.NoError(t, err)
 
 	want := []*vcs.PullRequestFile{
@@ -847,7 +847,7 @@ func TestProvider_GetDiffFileList(t *testing.T) {
 	},
 	)
 	ctx := context.Background()
-	got, err := p.GetDiffFileList(ctx, common.OauthContext{}, "", "1", "before_sha", "after_sha")
+	got, err := p.GetDiffFileList(ctx, &common.OauthContext{}, "", "1", "before_sha", "after_sha")
 	require.NoError(t, err)
 
 	want := []vcs.FileDiff{

--- a/backend/plugin/vcs/vcs.go
+++ b/backend/plugin/vcs/vcs.go
@@ -229,7 +229,7 @@ type Provider interface {
 	// instanceURL: VCS instance URL
 	// externalRepositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// commitID: the commit ID
-	FetchCommitByID(ctx context.Context, oauthCtx common.OauthContext, instanceURL, externalRepositoryID, commitID string) (*Commit, error)
+	FetchCommitByID(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, externalRepositoryID, commitID string) (*Commit, error)
 	// Get the diff files list between two commits
 	//
 	// oauthCtx: OAuth context to fetch commit
@@ -237,13 +237,13 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// beforeCommit: the previous commit
 	// afterCommit: the current commit
-	GetDiffFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, beforeCommit, afterCommit string) ([]FileDiff, error)
+	GetDiffFileList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, beforeCommit, afterCommit string) ([]FileDiff, error)
 
 	// Fetch all repository within a given user's scope
 	//
 	// oauthCtx: OAuth context to write the file content
 	// instanceURL: VCS instance URL
-	FetchAllRepositoryList(ctx context.Context, oauthCtx common.OauthContext, instanceURL string) ([]*Repository, error)
+	FetchAllRepositoryList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL string) ([]*Repository, error)
 
 	// Fetch the repository file list
 	//
@@ -252,7 +252,7 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// ref: the unique name of a repository tree, could be a branch name in GitLab or a tree sha in GitHub
 	// filePath: the path inside repository, used to get content of subdirectories
-	FetchRepositoryFileList(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*RepositoryTreeNode, error)
+	FetchRepositoryFileList(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, ref, filePath string) ([]*RepositoryTreeNode, error)
 
 	// Commits a new file
 	//
@@ -261,11 +261,11 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// filePath: file path to be written
 	// fileCommit: the new file commit info
-	CreateFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
+	CreateFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
 	// Overwrites an existing file
 	//
 	// Similar to CreateFile except it overwrites an existing file. The fileCommit should includes the "LastCommitID" field which is used to detect conflicting writes.
-	OverwriteFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
+	OverwriteFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, fileCommit FileCommitCreate) error
 	// Reads the file metadata
 	//
 	// oauthCtx: OAuth context to fetch the file metadata
@@ -273,7 +273,7 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// filePath: file path to be read
 	// ref: the specific file version to be read, could be a name of branch, tag or commit
-	ReadFileMeta(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo RefInfo) (*FileMeta, error)
+	ReadFileMeta(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, refInfo RefInfo) (*FileMeta, error)
 	// Reads the file content
 	//
 	// oauthCtx: OAuth context to read the file content
@@ -281,30 +281,30 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// filePath: file path to be read
 	// ref: the specific file version to be read, could be a name of branch, tag or commit
-	ReadFileContent(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, filePath string, refInfo RefInfo) (string, error)
+	ReadFileContent(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, filePath string, refInfo RefInfo) (string, error)
 	// GetBranch gets the given branch in the repository.
 	//
 	// oauthCtx: OAuth context to create the webhook
 	// instanceURL: VCS instance URL
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// branchName: the target branch name
-	GetBranch(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, branchName string) (*BranchInfo, error)
+	GetBranch(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, branchName string) (*BranchInfo, error)
 	// CreateBranch creates the branch in the repository.
 	//
 	// oauthCtx: OAuth context to create the webhook
 	// instanceURL: VCS instance URL
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// branch: the new branch info
-	CreateBranch(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, branch *BranchInfo) error
+	CreateBranch(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID string, branch *BranchInfo) error
 	// CreatePullRequest creates the pull request in the repository.
 	//
 	// oauthCtx: OAuth context to create the webhook
 	// instanceURL: VCS instance URL
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// pullRequestID: the pull request id
-	ListPullRequestFile(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, pullRequestID string) ([]*PullRequestFile, error)
+	ListPullRequestFile(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, pullRequestID string) ([]*PullRequestFile, error)
 	// pullRequestCreate: the new pull request info
-	CreatePullRequest(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, pullRequestCreate *PullRequestCreate) (*PullRequest, error)
+	CreatePullRequest(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID string, pullRequestCreate *PullRequestCreate) (*PullRequest, error)
 	// UpsertEnvironmentVariable creates or updates the environment variable in the repository.
 	//
 	// oauthCtx: OAuth context to create the webhook
@@ -312,20 +312,20 @@ type Provider interface {
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// key: the environment variable name
 	// value: the environment variable value
-	UpsertEnvironmentVariable(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, key, value string) error
+	UpsertEnvironmentVariable(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID string, key, value string) error
 	// Creates a webhook. Returns the created webhook ID on success.
 	//
 	// oauthCtx: OAuth context to create the webhook
 	// instanceURL: VCS instance URL
 	// repositoryID: the repository ID from the external VCS system (note this is NOT the ID of Bytebase's own repository resource)
 	// payload: the webhook payload
-	CreateWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error)
+	CreateWebhook(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID string, payload []byte) (string, error)
 	// Patches a webhook.
 	//
 	// The payload stores the patched field(s).
-	PatchWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error
+	PatchWebhook(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, webhookID string, payload []byte) error
 	// Deletes a webhook.
-	DeleteWebhook(ctx context.Context, oauthCtx common.OauthContext, instanceURL, repositoryID, webhookID string) error
+	DeleteWebhook(ctx context.Context, oauthCtx *common.OauthContext, instanceURL, repositoryID, webhookID string) error
 }
 
 var (

--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -657,15 +657,16 @@ func writeBackLatestSchema(
 	mi *db.MigrationInfo,
 	writebackBranch, latestSchemaFile string, schema string, bytebaseURL string,
 ) (string, error) {
+	oauthContext := &common.OauthContext{
+		ClientID:     vcs.ApplicationID,
+		ClientSecret: vcs.Secret,
+		AccessToken:  repository.AccessToken,
+		RefreshToken: repository.RefreshToken,
+		Refresher:    utils.RefreshToken(ctx, storage, repository.WebURL),
+	}
 	schemaFileMeta, err := vcsplugin.Get(vcs.Type, vcsplugin.ProviderConfig{}).ReadFileMeta(
 		ctx,
-		common.OauthContext{
-			ClientID:     vcs.ApplicationID,
-			ClientSecret: vcs.Secret,
-			AccessToken:  repository.AccessToken,
-			RefreshToken: repository.RefreshToken,
-			Refresher:    utils.RefreshToken(ctx, storage, repository.WebURL),
-		},
+		oauthContext,
 		vcs.InstanceURL,
 		repository.ExternalID,
 		latestSchemaFile,
@@ -736,13 +737,7 @@ func writeBackLatestSchema(
 
 		err := vcsplugin.Get(vcs2.Type, vcsplugin.ProviderConfig{}).CreateFile(
 			ctx,
-			common.OauthContext{
-				ClientID:     vcs2.ApplicationID,
-				ClientSecret: vcs2.Secret,
-				AccessToken:  repo2.AccessToken,
-				RefreshToken: repo2.RefreshToken,
-				Refresher:    utils.RefreshToken(ctx, storage, repo2.WebURL),
-			},
+			oauthContext,
 			vcs2.InstanceURL,
 			repo2.ExternalID,
 			latestSchemaFile,
@@ -760,13 +755,7 @@ func writeBackLatestSchema(
 		schemaFileCommit.SHA = schemaFileMeta.SHA
 		err := vcsplugin.Get(vcs2.Type, vcsplugin.ProviderConfig{}).OverwriteFile(
 			ctx,
-			common.OauthContext{
-				ClientID:     vcs2.ApplicationID,
-				ClientSecret: vcs2.Secret,
-				AccessToken:  repo2.AccessToken,
-				RefreshToken: repo2.RefreshToken,
-				Refresher:    utils.RefreshToken(ctx, storage, repo2.WebURL),
-			},
+			oauthContext,
 			vcs2.InstanceURL,
 			repo2.ExternalID,
 			latestSchemaFile,
@@ -788,13 +777,7 @@ func writeBackLatestSchema(
 	// VCS such as GitLab API doesn't return the commit on write, so we have to call ReadFileMeta again
 	schemaFileMeta, err = vcsplugin.Get(vcs2.Type, vcsplugin.ProviderConfig{}).ReadFileMeta(
 		ctx,
-		common.OauthContext{
-			ClientID:     vcs2.ApplicationID,
-			ClientSecret: vcs2.Secret,
-			AccessToken:  repo2.AccessToken,
-			RefreshToken: repo2.RefreshToken,
-			Refresher:    utils.RefreshToken(ctx, storage, repo2.WebURL),
-		},
+		oauthContext,
 		vcs2.InstanceURL,
 		repo2.ExternalID,
 		latestSchemaFile,


### PR DESCRIPTION
Previously, the follow up VCS api call after the token refresh will failed because they take the legacy access token. For example in Azure DevOps:
![CleanShot 2023-11-02 at 11 44 46@2x](https://github.com/bytebase/bytebase/assets/87714218/6aa2dbe2-edb0-4bc9-b03c-5aa0b7fb8d1a)

The token refresh patch the store but do not update the value in memory correctly because the we pass the struct which is a value type in golang. This pr switch to pass the `*common.OauthContext` which is a pointer instead of struct. 