### PR TITLE
chore(frontend): also emit window events to window.opener

### DIFF
--- a/frontend/src/plugins/window-events.ts
+++ b/frontend/src/plugins/window-events.ts
@@ -13,4 +13,8 @@ export const emitWindowEvent = (
     data.params = params;
   }
   window.parent.postMessage(data, "*");
+
+  if (window.opener && typeof window.opener.postMessage === "function") {
+    window.opener.postMessage(data, "*");
+  }
 };


### PR DESCRIPTION
useful if Bytebase is opened via `window.open` (popup window, for example)