### PR TITLE
chore: deprecate issue keyword filter

### DIFF
--- a/frontend/src/components/IssueV1/components/PagedIssueTableV1.vue
+++ b/frontend/src/components/IssueV1/components/PagedIssueTableV1.vue
@@ -75,7 +75,7 @@ const props = defineProps({
   },
   pageSize: {
     type: Number,
-    default: 10,
+    default: 50,
   },
   hideLoadMore: {
     type: Boolean,

--- a/frontend/src/components/IssueV1/components/WaitingForMyApprovalIssueTableV1.vue
+++ b/frontend/src/components/IssueV1/components/WaitingForMyApprovalIssueTableV1.vue
@@ -2,7 +2,7 @@
   <PagedIssueTableV1
     method="LIST"
     :session-key="sessionKey"
-    :page-size="20"
+    :page-size="50"
     :issue-filter="{
       project,
       query: '',

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -27,12 +27,6 @@
             <heroicons-outline:search class="h-3.5 w-3.5 text-control" />
           </button>
         </div>
-        <SearchBox
-          :value="state.searchText"
-          :placeholder="$t('common.filter-by-name')"
-          :autofocus="true"
-          @update:value="changeSearchText($event)"
-        />
       </div>
     </div>
 
@@ -46,7 +40,7 @@
           <IssueTableV1
             :mode="'PROJECT'"
             :show-placeholder="!loading"
-            :issue-list="issueList.filter(keywordFilter)"
+            :issue-list="issueList"
             title=""
           />
         </template>
@@ -68,7 +62,7 @@
           <IssueTableV1
             class="-mt-px"
             :mode="'PROJECT'"
-            :issue-list="issueList.filter(keywordFilter)"
+            :issue-list="issueList"
             :show-placeholder="!loading"
             title=""
           />
@@ -94,7 +88,7 @@
             class="-mt-px"
             :mode="'PROJECT'"
             :title="$t('project.overview.recently-closed')"
-            :issue-list="issueList.filter(keywordFilter)"
+            :issue-list="issueList"
             :show-placeholder="!loading"
           />
         </template>
@@ -122,7 +116,7 @@ import WaitingForMyApprovalIssueTableV1 from "@/components/IssueV1/components/Wa
 import { TabFilterItem } from "@/components/v2";
 import { featureToRef, useCurrentUserV1 } from "@/store";
 import { userNamePrefix } from "@/store/modules/v1/common";
-import { ComposedIssue, IssueFilter } from "@/types";
+import { IssueFilter } from "@/types";
 import { IssueStatus } from "@/types/proto/v1/issue_service";
 import { Project } from "@/types/proto/v1/project_service";
 import { hasWorkspacePermissionV1 } from "@/utils";
@@ -133,7 +127,6 @@ type TabValue = typeof TABS[number];
 
 interface LocalState {
   tab: TabValue;
-  searchText: string;
   isFetchingActivityList: boolean;
 }
 
@@ -146,7 +139,6 @@ const props = defineProps({
 
 const state = reactive<LocalState>({
   tab: "WAITING_APPROVAL",
-  searchText: "",
   isFetchingActivityList: false,
 });
 const { t } = useI18n();
@@ -185,20 +177,6 @@ const commonIssueFilter = computed((): IssueFilter => {
     principal,
   };
 });
-
-const keywordFilter = (issue: ComposedIssue) => {
-  const keyword = state.searchText.trim().toLowerCase();
-  if (keyword) {
-    if (!issue.title.toLowerCase().includes(keyword)) {
-      return false;
-    }
-  }
-  return true;
-};
-
-const changeSearchText = (searchText: string) => {
-  state.searchText = searchText;
-};
 
 watch(
   [hasCustomApprovalFeature, () => state.tab],

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -96,7 +96,6 @@
 <script lang="ts" setup>
 import { reactive, PropType, computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
 import IssueTableV1 from "@/components/IssueV1/components/IssueTableV1.vue";
 import PagedIssueTableV1 from "@/components/IssueV1/components/PagedIssueTableV1.vue";
 import WaitingForMyApprovalIssueTableV1 from "@/components/IssueV1/components/WaitingForMyApprovalIssueTableV1.vue";
@@ -129,7 +128,6 @@ const state = reactive<LocalState>({
   isFetchingActivityList: false,
 });
 const { t } = useI18n();
-const router = useRouter();
 const currentUserV1 = useCurrentUserV1();
 
 const hasCustomApprovalFeature = featureToRef("bb.feature.custom-approval");

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -5,28 +5,15 @@
         <TabFilter v-model:value="state.tab" :items="tabItemList" />
       </div>
       <div class="flex flex-row space-x-4 p-0.5">
-        <div class="flex items-center gap-x-1">
-          <p class="font-medium leading-7 text-main">
-            {{ $t("issue.advanced-search.self") }}
-          </p>
-          <button
-            type="button"
-            class="p-1 rounded bg-gray-200 hover:bg-gray-300 border border-gray-300"
-            @click="
-              () => {
-                router.replace({
-                  name: 'workspace.issue',
-                  query: {
-                    project: project.uid,
-                    autofocus: 1,
-                  },
-                });
-              }
-            "
-          >
-            <heroicons-outline:search class="h-3.5 w-3.5 text-control" />
-          </button>
-        </div>
+        <router-link
+          :to="`/issue?project=${project.uid}`"
+          class="flex space-x-1 items-center normal-link !whitespace-nowrap"
+        >
+          <heroicons-outline:search class="h-4 w-4" />
+          <span class="hidden md:block">{{
+            $t("issue.advanced-search.self")
+          }}</span>
+        </router-link>
       </div>
     </div>
 

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -56,7 +56,7 @@
           ...commonIssueFilter,
           statusList: [IssueStatus.OPEN],
         }"
-        :page-size="10"
+        :page-size="50"
       >
         <template #table="{ issueList, loading }">
           <IssueTableV1
@@ -80,7 +80,7 @@
           ...commonIssueFilter,
           statusList: [IssueStatus.DONE, IssueStatus.CANCELED],
         }"
-        :page-size="5"
+        :page-size="50"
         :hide-load-more="true"
       >
         <template #table="{ issueList, loading }">

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -14,12 +14,6 @@
             $t("issue.advanced-search.self")
           }}</span>
         </router-link>
-        <NInput
-          :value="state.searchText"
-          :placeholder="$t('common.filter-by-name')"
-          :autofocus="true"
-          @update:value="changeSearchText($event)"
-        />
       </div>
     </div>
     <div v-show="tab === 'WAITING_APPROVAL'" class="mt-2">
@@ -32,8 +26,7 @@
           <IssueTableV1
             class="border-x-0"
             :show-placeholder="!loading"
-            :issue-list="issueList.filter(keywordFilter)"
-            :highlight-text="state.searchText"
+            :issue-list="issueList"
             title=""
           />
         </template>
@@ -56,8 +49,7 @@
           <IssueTableV1
             class="border-x-0"
             :show-placeholder="!loading"
-            :issue-list="issueList.filter(keywordFilter)"
-            :highlight-text="state.searchText"
+            :issue-list="issueList"
             title=""
           />
         </template>
@@ -80,8 +72,7 @@
           <IssueTableV1
             class="border-x-0"
             :show-placeholder="!loading"
-            :issue-list="issueList.filter(keywordFilter)"
-            :highlight-text="state.searchText"
+            :issue-list="issueList"
             title=""
           />
         </template>
@@ -104,8 +95,7 @@
           <IssueTableV1
             class="border-x-0"
             :show-placeholder="!loading"
-            :issue-list="issueList.filter(keywordFilter)"
-            :highlight-text="state.searchText"
+            :issue-list="issueList"
             title=""
           />
         </template>
@@ -130,8 +120,7 @@
           <IssueTableV1
             class="border-x-0"
             :show-placeholder="!loading"
-            :issue-list="issueList.filter(keywordFilter)"
-            :highlight-text="state.searchText"
+            :issue-list="issueList"
             title=""
           />
         </template>
@@ -226,7 +215,7 @@ import {
 } from "@/store";
 import { userNamePrefix } from "@/store/modules/v1/common";
 import { IssueStatus } from "@/types/proto/v1/issue_service";
-import { ComposedIssue, IssueFilter, planTypeToString } from "../types";
+import { IssueFilter, planTypeToString } from "../types";
 import { extractUserUID } from "../utils";
 
 const TABS = [
@@ -240,7 +229,6 @@ const TABS = [
 type TabValue = typeof TABS[number];
 
 interface LocalState {
-  searchText: string;
   showTrialStartModal: boolean;
 }
 
@@ -267,7 +255,6 @@ const tab = useLocalStorage<TabValue>(
 );
 
 const state = reactive<LocalState>({
-  searchText: "",
   showTrialStartModal: false,
 });
 
@@ -310,20 +297,6 @@ const commonIssueFilter = computed((): IssueFilter => {
     query: "",
   };
 });
-
-const keywordFilter = (issue: ComposedIssue) => {
-  const keyword = state.searchText.trim().toLowerCase();
-  if (keyword) {
-    if (!issue.title.toLowerCase().includes(keyword)) {
-      return false;
-    }
-  }
-  return true;
-};
-
-const changeSearchText = (searchText: string) => {
-  state.searchText = searchText;
-};
 
 watch(
   [hasCustomApprovalFeature, tab],

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -232,8 +232,8 @@ interface LocalState {
   showTrialStartModal: boolean;
 }
 
-const OPEN_ISSUE_LIST_PAGE_SIZE = 10;
-const MAX_CLOSED_ISSUE = 5;
+const OPEN_ISSUE_LIST_PAGE_SIZE = 50;
+const MAX_CLOSED_ISSUE = 50;
 
 const { t } = useI18n();
 const subscriptionStore = useSubscriptionV1Store();

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -52,7 +52,7 @@
           ...issueFilter,
           statusList: [IssueStatus.OPEN],
         }"
-        :page-size="10"
+        :page-size="50"
       >
         <template #table="{ issueList, loading }">
           <IssueTableV1
@@ -75,7 +75,7 @@
           ...issueFilter,
           statusList: [IssueStatus.DONE, IssueStatus.CANCELED],
         }"
-        :page-size="10"
+        :page-size="50"
       >
         <template #table="{ issueList, loading }">
           <IssueTableV1


### PR DESCRIPTION
The current issue filter takes much space and causes distraction. The filter isn't useful at all because the page-size is set to a low number. Chrome Ctrl+F serves better purpose for searching keywords on the page. Dev tools don't usually have a keyword filter. For complex scenarios, users should use advanced search for searching issues.

This PR also increased page size to 50 and made advanced search button consistent.

Before:
<img width="1268" alt="Screenshot 2023-11-04 at 20 58 21" src="https://github.com/bytebase/bytebase/assets/98006139/6d81e047-2c96-4e56-8011-b59999e68a59">

After:
<img width="1271" alt="Screenshot 2023-11-04 at 20 58 11" src="https://github.com/bytebase/bytebase/assets/98006139/9d7af3f5-cea6-44d9-949d-cf896965aebe">
