### PR TITLE
chore: unique binding members when setting project iam policy

### DIFF
--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -2960,12 +2960,8 @@ func validateBindings(bindings []*v1pb.Binding, roles []*v1pb.Role) error {
 		}
 
 		// Users within each binding must be unique.
-		userMap := make(map[string]bool)
+		binding.Members = uniqueBindingMembers(binding.Members)
 		for _, member := range binding.Members {
-			if _, ok := userMap[member]; ok {
-				return errors.Errorf("duplicate user %s in role %s", member, binding.Role)
-			}
-			userMap[member] = true
 			if err := validateMember(member); err != nil {
 				return err
 			}
@@ -2981,6 +2977,18 @@ func validateBindings(bindings []*v1pb.Binding, roles []*v1pb.Role) error {
 		return errors.Errorf("IAM Policy must have at least one binding with role PROJECT_OWNER")
 	}
 	return nil
+}
+
+func uniqueBindingMembers(members []string) []string {
+	temp := []string{}
+	flag := make(map[string]bool)
+	for _, member := range members {
+		if !flag[member] {
+			temp = append(temp, member)
+			flag[member] = true
+		}
+	}
+	return temp
 }
 
 func validateMember(member string) error {

--- a/frontend/src/store/modules/v1/projectIamPolicy.ts
+++ b/frontend/src/store/modules/v1/projectIamPolicy.ts
@@ -1,4 +1,4 @@
-import { isUndefined } from "lodash-es";
+import { isUndefined, uniq } from "lodash-es";
 import { defineStore } from "pinia";
 import { computed, ref, unref, watch, watchEffect } from "vue";
 import { projectServiceClient } from "@/grpcweb";
@@ -68,6 +68,11 @@ export const useProjectIamPolicyStore = defineStore(
       project: string,
       policy: IamPolicy
     ) => {
+      policy.bindings.forEach((binding) => {
+        if (binding.members) {
+          binding.members = uniq(binding.members);
+        }
+      });
       const updated = await projectServiceClient.setIamPolicy({
         project,
         policy,


### PR DESCRIPTION
Make binding members unique both in frontend and backend when setting project iam policy