### PR TITLE
chore: use different cache for different project

### DIFF
--- a/frontend/src/components/Project/ProjectSidebar.vue
+++ b/frontend/src/components/Project/ProjectSidebar.vue
@@ -60,8 +60,11 @@ interface ProjectSidebarItem {
   }[];
 }
 
+const route = useRoute();
+const projectSlug = computed(() => route.params.projectSlug as string);
+
 const cachedLastPage = useLocalStorage<ProjectHash>(
-  "bb.project.page",
+  `bb.project.${projectSlug.value}.page`,
   "databases"
 );
 
@@ -74,7 +77,6 @@ interface LocalState {
 }
 
 const { t } = useI18n();
-const route = useRoute();
 const router = useRouter();
 const projectV1Store = useProjectV1Store();
 
@@ -87,7 +89,6 @@ watch(
   (hash) => (cachedLastPage.value = hash)
 );
 
-const projectSlug = computed(() => route.params.projectSlug as string);
 const project = computed(() => {
   return projectV1Store.getProjectByUID(String(idFromSlug(projectSlug.value)));
 });

--- a/frontend/src/views/ProjectDetail.vue
+++ b/frontend/src/views/ProjectDetail.vue
@@ -95,7 +95,6 @@ import {
   hasFeature,
   pushNotification,
 } from "@/store";
-import { getUserEmailFromIdentifier } from "@/store/modules/v1/common";
 import {
   QuickActionType,
   DEFAULT_PROJECT_V1_NAME,

--- a/frontend/src/views/ProjectDetail.vue
+++ b/frontend/src/views/ProjectDetail.vue
@@ -164,6 +164,21 @@ const cachedNotifiedActivities = useLocalStorage<string[]>(
 const maximumCachedActivities = 5;
 
 onMounted(() => {
+  const currentUserV1 = useCurrentUserV1();
+
+  if (
+    !hasWorkspacePermissionV1(
+      "bb.permission.workspace.manage-issue",
+      currentUserV1.value.userRole
+    ) &&
+    !hasPermissionInProjectV1(
+      project.value.iamPolicy,
+      currentUserV1.value,
+      "bb.permission.project.change-database"
+    )
+  ) {
+    return;
+  }
   activityV1Store
     .fetchActivityList({
       pageSize: 1,
@@ -172,7 +187,6 @@ onMounted(() => {
       resource: project.value.name,
     })
     .then((resp) => {
-      const currentUserV1 = useCurrentUserV1();
       for (const activity of resp.logEntities) {
         if (cachedNotifiedActivities.value.includes(activity.name)) {
           continue;
@@ -182,29 +196,14 @@ onMounted(() => {
           cachedNotifiedActivities.value.shift();
         }
 
-        // Only show notification for issue creator, project owner, workspace owner/DBA.
-        if (
-          getUserEmailFromIdentifier(activity.creator) ===
-            currentUserV1.value.email ||
-          hasWorkspacePermissionV1(
-            "bb.permission.workspace.manage-issue",
-            currentUserV1.value.userRole
-          ) ||
-          hasPermissionInProjectV1(
-            project.value.iamPolicy,
-            currentUserV1.value,
-            "bb.permission.project.change-database"
-          )
-        ) {
-          pushNotification({
-            module: "bytebase",
-            style: "INFO",
-            title: activityName(activity.action),
-            manualHide: true,
-            link: `/project/${projectV1Slug(project.value)}#activities`,
-            linkTitle: t("common.view"),
-          });
-        }
+        pushNotification({
+          module: "bytebase",
+          style: "INFO",
+          title: activityName(activity.action),
+          manualHide: true,
+          link: `/project/${projectV1Slug(project.value)}#activities`,
+          linkTitle: t("common.view"),
+        });
         break;
       }
     });


### PR DESCRIPTION
- For the default page, use different cache for different project
- Issue creator should have at least one permission, so we just need to check the permission before fetch the activities.