### PR TITLE
feat: implement the framework of get query span

### DIFF
--- a/backend/api/v1/sql_service_v2.go
+++ b/backend/api/v1/sql_service_v2.go
@@ -37,7 +37,7 @@ func (s *SQLService) QueryV2(ctx context.Context, request *v1pb.QueryRequest) (*
 	}
 
 	// Get query span.
-	spans, err := base.GetQuerySpan(ctx, instance.Engine, statement, s.buildGetDatabaseMetadataFunc(instance))
+	spans, err := base.GetQuerySpan(ctx, instance.Engine, statement, request.ConnectionDatabase, s.buildGetDatabaseMetadataFunc(instance))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/component/masker/masker.go
+++ b/backend/component/masker/masker.go
@@ -154,7 +154,7 @@ type MaskRangeSlice struct {
 	Substitution string
 }
 
-// RangeMasker is the masker that masks the the left and right quarters with "**".
+// RangeMasker is the masker that masks the left and right quarters with "**".
 type RangeMasker struct {
 	// MaskRangeSlice is the slice of the range to be masked.
 	MaskRangeSlice []*MaskRangeSlice
@@ -288,7 +288,7 @@ func (m *RangeMasker) Equal(other Masker) bool {
 	return false
 }
 
-// DefaultRangeMasker is the masker that masks the the left and right quarters with "**".
+// DefaultRangeMasker is the masker that masks the left and right quarters with "**".
 type DefaultRangeMasker struct{}
 
 // NewDefaultRangeMasker returns a new DefaultRangeMasker.

--- a/backend/plugin/parser/base/interface.go
+++ b/backend/plugin/parser/base/interface.go
@@ -31,7 +31,7 @@ type SchemaDiffFunc func(oldStmt, newStmt string, ignoreCaseSensitivity bool) (s
 type CompletionFunc func(statement string, caretLine int, caretOffset int) ([]Candidate, error)
 
 // GetQuerySpanFunc is the interface of getting the query span for a query.
-type GetQuerySpanFunc func(context.Context, string, GetDatabaseMetadataFunc) (*QuerySpan, error)
+type GetQuerySpanFunc func(ctx context.Context, statement, database string, metadataFunc GetDatabaseMetadataFunc) (*QuerySpan, error)
 
 func RegisterQueryValidator(engine storepb.Engine, f ValidateSQLForEditorFunc) {
 	mux.Lock()
@@ -175,7 +175,7 @@ func RegisterGetQuerySpan(engine storepb.Engine, f GetQuerySpanFunc) {
 }
 
 // GetQuerySpan gets the span of a query.
-func GetQuerySpan(ctx context.Context, engine storepb.Engine, statement string, getMetadataFunc GetDatabaseMetadataFunc) ([]*QuerySpan, error) {
+func GetQuerySpan(ctx context.Context, engine storepb.Engine, statement, database string, getMetadataFunc GetDatabaseMetadataFunc) ([]*QuerySpan, error) {
 	f, ok := spans[engine]
 	if !ok {
 		return nil, errors.Errorf("engine %s is not supported", engine)
@@ -186,7 +186,7 @@ func GetQuerySpan(ctx context.Context, engine storepb.Engine, statement string, 
 	}
 	var results []*QuerySpan
 	for _, stmt := range statements {
-		result, err := f(ctx, stmt.Text, getMetadataFunc)
+		result, err := f(ctx, stmt.Text, database, getMetadataFunc)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/base/interface.go
+++ b/backend/plugin/parser/base/interface.go
@@ -30,7 +30,7 @@ type SplitMultiSQLFunc func(string) ([]SingleSQL, error)
 type SchemaDiffFunc func(oldStmt, newStmt string, ignoreCaseSensitivity bool) (string, error)
 type CompletionFunc func(statement string, caretLine int, caretOffset int) ([]Candidate, error)
 
-// GetQuerySpan is the interface of getting the query span for a query.
+// GetQuerySpanFunc is the interface of getting the query span for a query.
 type GetQuerySpanFunc func(context.Context, string, GetDatabaseMetadataFunc) (*QuerySpan, error)
 
 func RegisterQueryValidator(engine storepb.Engine, f ValidateSQLForEditorFunc) {

--- a/backend/plugin/parser/base/masking.go
+++ b/backend/plugin/parser/base/masking.go
@@ -90,7 +90,7 @@ func (m *MaskingAttributes) TransmittedByInExpression(other MaskingAttributes) (
 	return changed
 }
 
-// IsNeverChangeInTransmission returns true if the masking attributes would not never change in transmission, it can be used to do the quit early optimization.
+// IsNeverChangeInTransmission returns true if the masking attributes would never change in transmission, it can be used to do the quit early optimization.
 func (m *MaskingAttributes) IsNeverChangeInTransmission() bool {
 	_, ok := m.Masker.(*masker.FullMasker)
 	return ok

--- a/backend/plugin/parser/pg/v2/masking.go
+++ b/backend/plugin/parser/pg/v2/masking.go
@@ -1,0 +1,24 @@
+package v2
+
+import (
+	"context"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+)
+
+const (
+	// defaultSchemaName is the default schema name in PostgreSQL like DBMS.
+	defaultSchemaName = "public"
+)
+
+func init() {
+	base.RegisterGetQuerySpan(storepb.Engine_POSTGRES, GetQuerySpan)
+	base.RegisterGetQuerySpan(storepb.Engine_REDSHIFT, GetQuerySpan)
+	base.RegisterGetQuerySpan(storepb.Engine_RISINGWAVE, GetQuerySpan)
+}
+
+// GetQuerySpan returns the query span for the given statement.
+func GetQuerySpan(ctx context.Context, statement string, getDatabaseMetadata base.GetDatabaseMetadataFunc) (*base.QuerySpan, error) {
+	return nil, nil
+}

--- a/backend/plugin/parser/pg/v2/masking.go
+++ b/backend/plugin/parser/pg/v2/masking.go
@@ -3,19 +3,38 @@ package v2
 import (
 	"context"
 
+	pgquery "github.com/pganalyze/pg_query_go/v4"
+
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/store/model"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
 const (
 	// defaultSchemaName is the default schema name in PostgreSQL like DBMS.
 	defaultSchemaName = "public"
+	// unknownFieldName is the default field name for unknown field in PostgreSQL like DBMS.
+	unknownFieldName = "?column?"
 )
 
 func init() {
 	base.RegisterGetQuerySpan(storepb.Engine_POSTGRES, GetQuerySpan)
 	base.RegisterGetQuerySpan(storepb.Engine_REDSHIFT, GetQuerySpan)
 	base.RegisterGetQuerySpan(storepb.Engine_RISINGWAVE, GetQuerySpan)
+}
+
+// querySpanExtractor is the extractor to extract the query span from the given pgquery.RawStmt.
+type querySpanExtractor struct {
+	databaseMetadata *model.DatabaseMetadata
+	ast              *pgquery.RawStmt
+}
+
+// newQuerySpanExtractor creates a new query span extractor, the databaseMetadata and the ast are in the read guard.
+func newQuerySpanExtractor(databaseMetadata *model.DatabaseMetadata, ast *pgquery.RawStmt) *querySpanExtractor {
+	return &querySpanExtractor{
+		databaseMetadata: databaseMetadata,
+		ast:              ast,
+	}
 }
 
 // GetQuerySpan returns the query span for the given statement.

--- a/backend/plugin/parser/pg/v2/masking.go
+++ b/backend/plugin/parser/pg/v2/masking.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	pgquery "github.com/pganalyze/pg_query_go/v4"
+	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/backend/store/model"
@@ -25,19 +26,67 @@ func init() {
 
 // querySpanExtractor is the extractor to extract the query span from the given pgquery.RawStmt.
 type querySpanExtractor struct {
-	databaseMetadata *model.DatabaseMetadata
-	ast              *pgquery.RawStmt
+	ctx         context.Context
+	connectedDB string
+	// metaCache is the lazy-load cache for the database metadata, it should not be accessed directly.
+	// Use querySpanExtractor.getDatabaseMetadata to access it.
+	metaCache map[string]*model.DatabaseMetadata
+	ast       *pgquery.RawStmt
+	f         base.GetDatabaseMetadataFunc
 }
 
 // newQuerySpanExtractor creates a new query span extractor, the databaseMetadata and the ast are in the read guard.
-func newQuerySpanExtractor(databaseMetadata *model.DatabaseMetadata, ast *pgquery.RawStmt) *querySpanExtractor {
+func newQuerySpanExtractor(ast *pgquery.RawStmt, connectedDB string, getDatabaseMetadata base.GetDatabaseMetadataFunc) *querySpanExtractor {
 	return &querySpanExtractor{
-		databaseMetadata: databaseMetadata,
-		ast:              ast,
+		connectedDB: connectedDB,
+		metaCache:   make(map[string]*model.DatabaseMetadata),
+		ast:         ast,
+		f:           getDatabaseMetadata,
 	}
 }
 
+func (q *querySpanExtractor) getDatabaseMetadata(database string) (*model.DatabaseMetadata, error) {
+	if meta, ok := q.metaCache[database]; ok {
+		return meta, nil
+	}
+	meta, err := q.f(q.ctx, database)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get database metadata for database: %s", database)
+	}
+	q.metaCache[database] = meta
+	return meta, nil
+}
+
+func (q *querySpanExtractor) getQuerySpan(ctx context.Context) (*base.QuerySpan, error) {
+	q.ctx = ctx
+	return &base.QuerySpan{}, nil
+}
+
 // GetQuerySpan returns the query span for the given statement.
-func GetQuerySpan(ctx context.Context, statement string, getDatabaseMetadata base.GetDatabaseMetadataFunc) (*base.QuerySpan, error) {
-	return nil, nil
+func GetQuerySpan(ctx context.Context, statement, database string, getDatabaseMetadata base.GetDatabaseMetadataFunc) (*base.QuerySpan, error) {
+	res, err := pgquery.Parse(statement)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse statement: %s", statement)
+	}
+	if len(res.Stmts) != 1 {
+		return nil, errors.Errorf("expecting 1 statement, but got %d", len(res.Stmts))
+	}
+	ast := res.Stmts[0]
+	extractor := newQuerySpanExtractor(ast, database, getDatabaseMetadata)
+
+	switch ast.Stmt.Node.(type) {
+	case *pgquery.Node_SelectStmt:
+	case *pgquery.Node_ExplainStmt:
+		// Skip the EXPLAIN statement.
+		return &base.QuerySpan{}, nil
+	default:
+		return nil, errors.Wrapf(err, "expect a query statement but found %T", ast.Stmt.Node)
+	}
+
+	span, err := extractor.getQuerySpan(ctx)
+	// TODO(zp): handle query system schema.
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get query span from statement: %s", statement)
+	}
+	return span, nil
 }

--- a/backend/plugin/parser/pg/v2/query_span.go
+++ b/backend/plugin/parser/pg/v2/query_span.go
@@ -11,13 +11,6 @@ import (
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
-const (
-	// defaultSchemaName is the default schema name in PostgreSQL like DBMS.
-	defaultSchemaName = "public"
-	// unknownFieldName is the default field name for unknown field in PostgreSQL like DBMS.
-	unknownFieldName = "?column?"
-)
-
 func init() {
 	base.RegisterGetQuerySpan(storepb.Engine_POSTGRES, GetQuerySpan)
 	base.RegisterGetQuerySpan(storepb.Engine_REDSHIFT, GetQuerySpan)
@@ -28,8 +21,8 @@ func init() {
 type querySpanExtractor struct {
 	ctx         context.Context
 	connectedDB string
-	// metaCache is the lazy-load cache for the database metadata, it should not be accessed directly.
-	// Use querySpanExtractor.getDatabaseMetadata to access it.
+	// The metaCache serves as a lazy-load cache for the database metadata
+	// and should not be accessed directly. Instead, use querySpanExtractor.getDatabaseMetadata to access it.
 	metaCache map[string]*model.DatabaseMetadata
 	ast       *pgquery.RawStmt
 	f         base.GetDatabaseMetadataFunc
@@ -45,6 +38,7 @@ func newQuerySpanExtractor(ast *pgquery.RawStmt, connectedDB string, getDatabase
 	}
 }
 
+// nolint: unused
 func (q *querySpanExtractor) getDatabaseMetadata(database string) (*model.DatabaseMetadata, error) {
 	if meta, ok := q.metaCache[database]; ok {
 		return meta, nil


### PR DESCRIPTION
Previously, our masking was strongly coupled with the column attributes. We had to spend a lot of time repeatedly modifying the masking logic in different engine packages whenever we extended the masking feature.
We introduce `QuerySpan`, which returns only the query span (including the accessed resources, the source columns of each result column). This allows us to implement access control/masking logic in the caller outside.