### PR TITLE
chore(mysql): use default expression to add auto_increment

### DIFF
--- a/backend/api/v1/testdata/design.yaml
+++ b/backend/api/v1/testdata/design.yaml
@@ -46,7 +46,9 @@
                 },
                 {
                   "name": "c",
-                  "type": "int"
+                  "type": "int",
+                  "hasDefault": true,
+                  "defaultExpression": "auto_increment"
                 },
                 {
                   "name": "e",
@@ -128,7 +130,7 @@
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
     CREATE TABLE `t4` (
       `a` varchar(10) NOT NULL DEFAULT 'default value' COMMENT 'this is comment, aha',
-      `c` int NOT NULL,
+      `c` int NOT NULL auto_increment,
       `e` int  NULL,
       `b` char(10) NOT NULL,
       PRIMARY KEY (`a`, `b`, `c`),

--- a/backend/api/v1/testdata/schema.yaml
+++ b/backend/api/v1/testdata/schema.yaml
@@ -2,7 +2,7 @@
   schema: |
     create table t
       (
-        c int,
+        c int auto_increment,
         a int default 1 comment 'abcdefg',
         b varchar(20) default 'NULL' comment '',
         primary key (a, b),
@@ -19,6 +19,8 @@
               "columns": [
                 {
                   "name": "c",
+                  "hasDefault": true,
+                  "defaultExpression": "auto_increment",
                   "nullable": true,
                   "type": "int"
                 },


### PR DESCRIPTION
now: we use default to store `auto_increment` attribute for mysql.


https://github.com/bytebase/bytebase/assets/71714656/32eca4df-714e-4c48-8879-d8dff783a78c

