### PR TITLE
chore: update db dashboard in standalone mode

### DIFF
--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseTableRow.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseTableRow.vue
@@ -9,6 +9,7 @@
   <div class="bb-grid-cell">
     <div class="flex items-center space-x-2">
       <SQLEditorButtonV1
+        v-if="!isStandaloneMode"
         :database="database"
         :disabled="!allowQuery"
         :tooltip="true"
@@ -53,9 +54,10 @@
 </template>
 
 <script lang="ts" setup>
+import { storeToRefs } from "pinia";
 import { computed } from "vue";
 import { InstanceV1Name, EnvironmentV1Name } from "@/components/v2";
-import { useEnvironmentV1Store } from "@/store";
+import { useActuatorV1Store, useEnvironmentV1Store } from "@/store";
 import { ComposedDatabase } from "@/types";
 import { isPITRDatabaseV1 } from "@/utils";
 import LabelsColumn from "./LabelsColumn.vue";
@@ -77,9 +79,16 @@ const props = defineProps<{
 
 defineEmits(["goto-sql-editor-failed"]);
 
+const actuatorStore = useActuatorV1Store();
+const { pageMode } = storeToRefs(actuatorStore);
+
 const environment = computed(() => {
   return useEnvironmentV1Store().getEnvironmentByName(
     props.database.environment
   );
+});
+
+const isStandaloneMode = computed(() => {
+  return pageMode.value === "STANDALONE";
 });
 </script>

--- a/frontend/src/views/DatabaseDashboard.vue
+++ b/frontend/src/views/DatabaseDashboard.vue
@@ -8,7 +8,7 @@
       />
 
       <div class="flex items-center space-x-4">
-        <NTooltip v-if="canVisitUnassignedDatabases">
+        <NTooltip v-if="canVisitUnassignedDatabases && !isStandaloneMode">
           <template #trigger>
             <router-link
               :to="{
@@ -62,6 +62,9 @@
       :database-group-list="filteredDatabaseGroupList"
       :show-placeholder="true"
       :show-selection-column="true"
+      :custom-click="isStandaloneMode"
+      @select-database="(db: ComposedDatabase) =>
+                  toggleDatabasesSelection([db as ComposedDatabase], !isDatabaseSelected(db))"
     >
       <template #selection-all="{ databaseList }">
         <input
@@ -107,6 +110,7 @@
 
 <script lang="ts" setup>
 import { NInputGroup, NTooltip } from "naive-ui";
+import { storeToRefs } from "pinia";
 import { computed, watchEffect, onMounted, reactive, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import {
@@ -117,6 +121,7 @@ import {
 } from "@/components/v2";
 import { isDatabase } from "@/components/v2/Model/DatabaseV1Table/utils";
 import {
+  useActuatorV1Store,
   useCurrentUserV1,
   useDBGroupStore,
   useDatabaseV1Store,
@@ -159,6 +164,8 @@ const router = useRouter();
 const uiStateStore = useUIStateStore();
 const environmentV1Store = useEnvironmentV1Store();
 const { projectList } = useProjectV1ListByCurrentUser();
+const actuatorStore = useActuatorV1Store();
+const { pageMode } = storeToRefs(actuatorStore);
 
 const state = reactive<LocalState>({
   instanceFilter: String(UNKNOWN_ID),
@@ -183,6 +190,10 @@ const preparePolicyList = () => {
 };
 
 watchEffect(preparePolicyList);
+
+const isStandaloneMode = computed(() => {
+  return pageMode.value === "STANDALONE";
+});
 
 const selectedEnvironment = computed(() => {
   const { environment } = route.query;


### PR DESCRIPTION
* hide `transfer`/`sync`/`edit labels` buttons in standalone mode;
* hide sql editor entry in standalone mode;
* skip schema editor dialog in standalone mode;

https://github.com/bytebase/bytebase/assets/24653555/dd7523ea-56e4-4e3c-873a-c28667920412
