### PR TITLE
chore(frontend): ghost improvements

### DIFF
--- a/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSection.vue
+++ b/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSection.vue
@@ -26,7 +26,7 @@
       <FeatureBadge feature="bb.feature.online-migration" />
       <FeatureBadgeForInstanceLicense
         feature="bb.feature.online-migration"
-        :show="hasOnlineMigrationFeature"
+        :show="hasOnlineMigrationFeature && showMissingInstanceLicense"
         :instance="instance"
       >
         <LockIcon class="w-4 h-4 text-accent" />
@@ -58,15 +58,12 @@ import { flattenTaskV1List } from "@/utils";
 import GhostConfigButton from "./GhostConfigButton.vue";
 import GhostFlagsPanel from "./GhostFlagsPanel.vue";
 import GhostSwitch from "./GhostSwitch.vue";
-import {
-  allowGhostForTask,
-  ghostViewTypeForTask,
-  provideIssueGhostContext,
-} from "./common";
+import { ghostViewTypeForTask, provideIssueGhostContext } from "./common";
 
 const { isCreating, issue, selectedTask: task } = useIssueContext();
 
-const { viewType, showFeatureModal } = provideIssueGhostContext();
+const { viewType, showFeatureModal, showMissingInstanceLicense } =
+  provideIssueGhostContext();
 
 const shouldShowGhostSection = computed(() => {
   // We need all tasks and specs to be gh-ost-able to enable gh-ost mode.
@@ -75,9 +72,7 @@ const shouldShowGhostSection = computed(() => {
     // When an issue is pending create, we should show the gh-ost section
     // whenever gh-ost is on or off.
     return tasks.every(
-      (task) =>
-        allowGhostForTask(issue.value, task) &&
-        ghostViewTypeForTask(issue.value, task) !== "NONE"
+      (task) => ghostViewTypeForTask(issue.value, task) !== "NONE"
     );
   } else {
     return viewType.value === "ON";

--- a/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSwitch.vue
+++ b/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSwitch.vue
@@ -1,30 +1,59 @@
 <template>
-  <NSwitch
-    :value="checked"
-    :disabled="!allowChange"
-    :loading="isUpdating"
-    class="bb-ghost-switch"
-    @update:value="toggleChecked"
-  >
-    <template #checked>
-      <span style="font-size: 10px">{{ $t("common.on") }}</span>
+  <NTooltip :disabled="errors.length === 0">
+    <template #trigger>
+      <NSwitch
+        :value="checked"
+        :disabled="!allowChange"
+        :loading="isUpdating"
+        class="bb-ghost-switch"
+        @update:value="toggleChecked"
+      >
+        <template #checked>
+          <span style="font-size: 10px">{{ $t("common.on") }}</span>
+        </template>
+        <template #unchecked>
+          <span style="font-size: 10px">{{ $t("common.off") }}</span>
+        </template>
+      </NSwitch>
     </template>
-    <template #unchecked>
-      <span style="font-size: 10px">{{ $t("common.off") }}</span>
+    <template #default>
+      <ErrorList :errors="errors" />
     </template>
-  </NSwitch>
+  </NTooltip>
+
+  <InstanceAssignment
+    v-if="showMissingInstanceLicense"
+    :show="showInstanceAssignmentDrawer"
+    @dismiss="showInstanceAssignmentDrawer = false"
+  />
 </template>
 
 <script setup lang="ts">
-import { NSwitch } from "naive-ui";
+import { NSwitch, NTooltip } from "naive-ui";
 import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { specForTask, useIssueContext } from "@/components/IssueV1/logic";
-import { hasFeature } from "@/store";
-import { useIssueGhostContext } from "./common";
+import {
+  ErrorItem,
+  default as ErrorList,
+} from "@/components/misc/ErrorList.vue";
+import { hasFeature, useCurrentUserV1 } from "@/store";
+import { Engine } from "@/types/proto/v1/common";
+import {
+  MIN_GHOST_SUPPORT_MYSQL_VERSION,
+  engineNameV1,
+  flattenTaskV1List,
+  hasWorkspacePermissionV1,
+} from "@/utils";
+import { allowGhostForTask, useIssueGhostContext } from "./common";
 
+const { t } = useI18n();
+const me = useCurrentUserV1();
 const { isCreating, issue, selectedTask: task } = useIssueContext();
-const { viewType, toggleGhost, showFeatureModal } = useIssueGhostContext();
+const { viewType, toggleGhost, showFeatureModal, showMissingInstanceLicense } =
+  useIssueGhostContext();
 const isUpdating = ref(false);
+const showInstanceAssignmentDrawer = ref(false);
 
 const allowChange = computed(() => {
   return isCreating.value;
@@ -34,9 +63,56 @@ const checked = computed(() => {
   return viewType.value === "ON";
 });
 
+const canManageSubscription = computed((): boolean => {
+  return hasWorkspacePermissionV1(
+    "bb.permission.workspace.manage-subscription",
+    me.value.userRole
+  );
+});
+
+const allowGhostForEveryDatabase = computed(() => {
+  const tasks = flattenTaskV1List(issue.value.rolloutEntity);
+  return tasks.every((task) => allowGhostForTask(issue.value, task));
+});
+
+const errors = computed(() => {
+  const errors: ErrorItem[] = [];
+  if (showMissingInstanceLicense.value && !canManageSubscription.value) {
+    // Only show the tooltip when current user is not allowed to manage subscription
+    // since we will show the InstanceAssignmentDrawer for high-privileged users
+    // when clicking on the switch
+    errors.push(
+      t("subscription.instance-assignment.missing-license-attention")
+    );
+  }
+  if (!allowGhostForEveryDatabase.value) {
+    errors.push(
+      t(
+        "task.online-migration.error.not-applicable.some-tasks-are-not-applicable-for-online-migration"
+      )
+    );
+    errors.push({
+      error: `${engineNameV1(
+        Engine.MYSQL
+      )} >= ${MIN_GHOST_SUPPORT_MYSQL_VERSION}`,
+      indent: 1,
+    });
+  }
+  return errors;
+});
+
 const toggleChecked = async (on: boolean) => {
   if (!hasFeature("bb.feature.online-migration")) {
     showFeatureModal.value = true;
+    return;
+  }
+  if (showMissingInstanceLicense.value) {
+    if (canManageSubscription.value) {
+      showInstanceAssignmentDrawer.value = true;
+    }
+    return;
+  }
+  if (errors.value.length > 0) {
     return;
   }
 

--- a/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSwitch.vue
+++ b/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSwitch.vue
@@ -72,6 +72,15 @@ const canManageSubscription = computed((): boolean => {
 
 const allowGhostForEveryDatabase = computed(() => {
   const tasks = flattenTaskV1List(issue.value.rolloutEntity);
+  if (
+    tasks.some(
+      (t) =>
+        t.target ===
+        "instances/instance-0e0ee52e/databases/news_management__cn_sh"
+    )
+  ) {
+    return false;
+  }
   return tasks.every((task) => allowGhostForTask(issue.value, task));
 });
 
@@ -88,7 +97,7 @@ const errors = computed(() => {
   if (!allowGhostForEveryDatabase.value) {
     errors.push(
       t(
-        "task.online-migration.error.not-applicable.some-tasks-are-not-applicable-for-online-migration"
+        "task.online-migration.error.not-applicable.some-tasks-dont-meet-ghost-requirement"
       )
     );
     errors.push({

--- a/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSwitch.vue
+++ b/frontend/src/components/IssueV1/components/StageSection/Actions/GhostSection/GhostSwitch.vue
@@ -72,15 +72,6 @@ const canManageSubscription = computed((): boolean => {
 
 const allowGhostForEveryDatabase = computed(() => {
   const tasks = flattenTaskV1List(issue.value.rolloutEntity);
-  if (
-    tasks.some(
-      (t) =>
-        t.target ===
-        "instances/instance-0e0ee52e/databases/news_management__cn_sh"
-    )
-  ) {
-    return false;
-  }
   return tasks.every((task) => allowGhostForTask(issue.value, task));
 });
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -395,7 +395,7 @@
         "x-status-task-is-not-editable": "{status} task is not editable",
         "nothing-changed": "Nothing changed",
         "not-applicable": {
-          "some-tasks-are-not-applicable-for-online-migration": "Some tasks are not applicable for online migration"
+          "some-tasks-dont-meet-ghost-requirement": "Some tasks don't meet gh-ost's requirement"
         }
       },
       "show-default-parameters": "Show default parameters",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -393,7 +393,10 @@
         "some-tasks-are-not-editable-in-batch-mode": "Some tasks are not editable in batch mode",
         "task-is-not-editable": "This task is not editable",
         "x-status-task-is-not-editable": "{status} task is not editable",
-        "nothing-changed": "Nothing changed"
+        "nothing-changed": "Nothing changed",
+        "not-applicable": {
+          "some-tasks-are-not-applicable-for-online-migration": "Some tasks are not applicable for online migration"
+        }
       },
       "show-default-parameters": "Show default parameters",
       "hide-default-parameters": "Hide default parameters"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -393,7 +393,10 @@
         "some-tasks-are-not-editable-in-batch-mode": "Algunas tareas no se pueden editar en modo por lotes",
         "task-is-not-editable": "Esta tarea no es editable",
         "x-status-task-is-not-editable": "La tarea {status} no es editable",
-        "nothing-changed": "nada ha cambiado"
+        "nothing-changed": "nada ha cambiado",
+        "not-applicable": {
+          "some-tasks-are-not-applicable-for-online-migration": "Algunas tareas no son aplicables para la migración en línea"
+        }
       },
       "show-default-parameters": "Mostrar parámetros predeterminados",
       "hide-default-parameters": "Ocultar parámetros predeterminados"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -395,7 +395,7 @@
         "x-status-task-is-not-editable": "La tarea {status} no es editable",
         "nothing-changed": "nada ha cambiado",
         "not-applicable": {
-          "some-tasks-are-not-applicable-for-online-migration": "Algunas tareas no son aplicables para la migración en línea"
+          "some-tasks-dont-meet-ghost-requirement": "Algunas tareas no cumplen con los requisitos de gh-ost."
         }
       },
       "show-default-parameters": "Mostrar parámetros predeterminados",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -391,7 +391,10 @@
         "some-tasks-are-not-editable-in-batch-mode": "某些任务在批量模式下不可编辑",
         "task-is-not-editable": "该任务不可编辑",
         "x-status-task-is-not-editable": "{status} 的任务不可编辑",
-        "nothing-changed": "无任何改变"
+        "nothing-changed": "无任何改变",
+        "not-applicable": {
+          "some-tasks-are-not-applicable-for-online-migration": "部分任务不适用于在线迁移"
+        }
       },
       "show-default-parameters": "显示默认参数",
       "hide-default-parameters": "隐藏默认参数"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -393,7 +393,7 @@
         "x-status-task-is-not-editable": "{status} 的任务不可编辑",
         "nothing-changed": "无任何改变",
         "not-applicable": {
-          "some-tasks-are-not-applicable-for-online-migration": "部分任务不适用于在线迁移"
+          "some-tasks-dont-meet-ghost-requirement": "部分任务不符合 gh-ost 的要求"
         }
       },
       "show-default-parameters": "显示默认参数",


### PR DESCRIPTION
### Changes
- The "Online migration" section will show when previewing any DDL issues. (Except database group changes)
  - If some tasks are not applicable for gh-ost (MySQL >= 5.7) we will still show the section with an error tooltip. And the switch will be unclickable.
- Online migration will be not applicable if any of the tasks' instances are missing licenses. This comes with an error tooltip.

### Fixes
- The "missing instance license" indicator (aka. the lock icon) will correctly disappear after assigning licenses to the instance s via the popover drawer.

<img width="531" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/45278030-538a-4984-a64c-d12d74a5ac1e">

FYI @RainbowDashy @adela-bytebase 
