### PR TITLE
chore(frontend): statement change activity improvements

### DIFF
--- a/frontend/src/bbkit/BBModal.vue
+++ b/frontend/src/bbkit/BBModal.vue
@@ -9,7 +9,7 @@
     @mask-click="maskClosable && tryClose()"
   >
     <div v-bind="$attrs" class="bb-modal">
-      <div class="modal-header">
+      <div class="modal-header" :class="headerClass">
         <div class="text-xl text-main mr-2 flex-1 overflow-hidden">
           <slot name="title"><component :is="renderTitle" /></slot>
           <slot name="subtitle"><component :is="renderSubtitle" /></slot>

--- a/frontend/src/components/IssueV1/components/ActivitySection/Activity/StatementUpdate.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/Activity/StatementUpdate.vue
@@ -1,0 +1,80 @@
+<template>
+  <NButton text type="primary" v-bind="$attrs" @click="showPanel = true">
+    {{ $t("common.view-details") }}
+  </NButton>
+
+  <BBModal
+    v-if="showPanel"
+    :title="$t('common.detail')"
+    header-class="!border-0"
+    container-class="!pt-0"
+    @close="showPanel = false"
+  >
+    <div
+      style="width: calc(100vw - 9rem); height: calc(100vh - 10rem)"
+      class="relative"
+    >
+      <DiffEditor
+        v-if="!isPreparingOldStatement && !isPreparingNewStatement"
+        class="w-full h-full border rounded-md overflow-clip"
+        :original="oldStatement"
+        :value="newStatement"
+        :readonly="true"
+      />
+      <div
+        v-else
+        class="absolute inset-0 flex flex-col items-center justify-center"
+      >
+        <BBSpin />
+      </div>
+    </div>
+  </BBModal>
+</template>
+
+<script setup lang="ts">
+import { asyncComputed } from "@vueuse/core";
+import { NButton } from "naive-ui";
+import { ref } from "vue";
+import { BBModal, BBSpin } from "@/bbkit";
+import DiffEditor from "@/components/MonacoEditor/DiffEditor.vue";
+import { useSheetV1Store } from "@/store";
+import { UNKNOWN_ID } from "@/types";
+import { getSheetStatement } from "@/utils";
+
+const props = defineProps<{
+  oldSheetId: string;
+  newSheetId: string;
+}>();
+
+const showPanel = ref(false);
+
+const prepareStatement = async (uid: string) => {
+  if (uid === String(UNKNOWN_ID)) return "";
+  const sheet = await useSheetV1Store().getOrFetchSheetByUID(uid);
+  if (!sheet) return "";
+  return getSheetStatement(sheet);
+};
+const isPreparingOldStatement = ref(false);
+const isPreparingNewStatement = ref(false);
+
+const oldStatement = asyncComputed(
+  () => {
+    return prepareStatement(props.oldSheetId);
+  },
+  "",
+  {
+    evaluating: isPreparingOldStatement,
+    lazy: true,
+  }
+);
+const newStatement = asyncComputed(
+  () => {
+    return prepareStatement(props.newSheetId);
+  },
+  "",
+  {
+    evaluating: isPreparingNewStatement,
+    lazy: true,
+  }
+);
+</script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -275,7 +275,8 @@
     "filter-by-name": "Filter by name",
     "tenant": "Tenant",
     "license": "License",
-    "show-all": "Show all"
+    "show-all": "Show all",
+    "view-details": "View details"
   },
   "error-page": {
     "go-back-home": "Go back home"
@@ -866,7 +867,8 @@
       "schema-version": "schema version {version}",
       "xxx-automatically": "{verb} automatically",
       "verb-type-target-by-people": "{verb} {type} {target}",
-      "verb-type-target-by-system-bot": "{type} {target} {verb}"
+      "verb-type-target-by-system-bot": "{type} {target} {verb}",
+      "changed-x-link": "changed {name}. {link}"
     },
     "subject-prefix": {
       "task": "Task",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -275,7 +275,8 @@
     "filter-by-name": "Filtrar por nombre",
     "tenant": "Arrendataria",
     "license": "Licencia",
-    "show-all": "Mostrar todo"
+    "show-all": "Mostrar todo",
+    "view-details": "Ver detalles"
   },
   "error-page": {
     "go-back-home": "Volver al inicio"
@@ -865,7 +866,8 @@
       "schema-version": "versión de esquema {version}",
       "xxx-automatically": "{verb} automáticamente",
       "verb-type-target-by-people": "{verb} {type} {target}",
-      "verb-type-target-by-system-bot": "{type} {target} {verb}"
+      "verb-type-target-by-system-bot": "{type} {target} {verb}",
+      "changed-x-link": "cambiado {name}. \n{link}"
     },
     "subject-prefix": {
       "task": "Tarea",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -273,7 +273,8 @@
     "filter-by-name": "按名称过滤",
     "tenant": "租户",
     "license": "证书",
-    "show-all": "显示全部"
+    "show-all": "显示全部",
+    "view-details": "查看详情"
   },
   "error-page": {
     "go-back-home": "回到主页"
@@ -863,7 +864,8 @@
       "schema-version": "schema 版本 {version}",
       "xxx-automatically": "自动{verb}",
       "verb-type-target-by-people": "{verb}{type} {target}",
-      "verb-type-target-by-system-bot": "{type} {target} {verb}"
+      "verb-type-target-by-system-bot": "{type} {target} {verb}",
+      "changed-x-link": "修改了 {name}。{link}"
     },
     "subject-prefix": {
       "task": "任务",


### PR DESCRIPTION
### Before

- Statement changed activity will be unreadable in real-world scenes if statements are very long.
- Sheets will be pre-loaded even if they are actually not rendered to the screen.

![img_v2_a8a799d1-14d8-4062-be84-74a0580e846g](https://github.com/bytebase/bytebase/assets/2749742/b420a747-c6b9-4ed4-9c8e-51f777606964)

### After

- Show only the activity brief in the activity list. Show the full statement diff when clicking on "View details".
- Full statements will only be loaded when the detail dialog opens.

https://github.com/bytebase/bytebase/assets/2749742/3c14442a-684f-4d18-94ce-73e9f91b9fbf

FYI @adela-bytebase 

