### PR TITLE
chore(frontend): update similar tasks logic

### DIFF
--- a/frontend/src/components/Issue/activity/common.ts
+++ b/frontend/src/components/Issue/activity/common.ts
@@ -1,51 +1,6 @@
-import type {
-  ActivityTaskStatementUpdatePayload,
-  ActivityTaskStatusUpdatePayload,
-} from "@/types";
-import { LogEntity, LogEntity_Action } from "@/types/proto/v1/logging_service";
+import { LogEntity } from "@/types/proto/v1/logging_service";
 
 export type DistinctActivity = {
   activity: LogEntity;
   similar: LogEntity[];
-};
-
-export const isSimilarActivity = (a: LogEntity, b: LogEntity): boolean => {
-  // Now, we recognize two "Change SQL from .... to ...." activities are similar
-  // when they have the same "from" and "to" values.
-  if (
-    a.action === LogEntity_Action.ACTION_PIPELINE_TASK_STATEMENT_UPDATE &&
-    a.action === b.action &&
-    a.resource === b.resource
-  ) {
-    const payloadA = JSON.parse(
-      a.payload
-    ) as ActivityTaskStatementUpdatePayload;
-    const payloadB = JSON.parse(
-      b.payload
-    ) as ActivityTaskStatementUpdatePayload;
-    if (
-      payloadA.oldStatement === payloadB.oldStatement &&
-      payloadB.newStatement === payloadB.newStatement
-    ) {
-      return true;
-    }
-  }
-
-  if (
-    a.action === LogEntity_Action.ACTION_PIPELINE_TASK_STATUS_UPDATE &&
-    a.action === b.action &&
-    a.resource === b.resource &&
-    a.creator === b.creator
-  ) {
-    const payloadA = JSON.parse(a.payload) as ActivityTaskStatusUpdatePayload;
-    const payloadB = JSON.parse(b.payload) as ActivityTaskStatusUpdatePayload;
-    if (
-      payloadA.oldStatus === payloadB.oldStatus &&
-      payloadB.newStatus === payloadB.newStatus
-    ) {
-      return true;
-    }
-  }
-
-  return false;
 };

--- a/frontend/src/components/IssueV1/components/ActivitySection/Activity/common.ts
+++ b/frontend/src/components/IssueV1/components/ActivitySection/Activity/common.ts
@@ -23,10 +23,10 @@ export const isSimilarActivity = (a: LogEntity, b: LogEntity): boolean => {
     const payloadB = JSON.parse(
       b.payload
     ) as ActivityTaskStatementUpdatePayload;
-    if (
-      payloadA.oldStatement === payloadB.oldStatement &&
-      payloadB.newStatement === payloadB.newStatement
-    ) {
+    if (payloadA.newSheetId === payloadB.newSheetId) {
+      // If two "Update statement" activities come from one "Apply to stage"
+      // or "Apply to all tasks" operation, they will share the same newSheetId.
+      // So that we can define they are "similar".
       return true;
     }
   }

--- a/frontend/src/components/IssueV1/components/ActivitySection/ActivityList.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/ActivityList.vue
@@ -116,10 +116,6 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch, watchEffect } from "vue";
 import { useRoute } from "vue-router";
-import {
-  DistinctActivity,
-  isSimilarActivity,
-} from "@/components/Issue/activity";
 import MarkdownEditor from "@/components/MarkdownEditor.vue";
 import { IssueBuiltinFieldId } from "@/plugins";
 import { useActivityV1Store, useCurrentUserV1, useIssueV1Store } from "@/store";
@@ -133,7 +129,7 @@ import type { ComposedIssue } from "@/types";
 import { LogEntity, LogEntity_Action } from "@/types/proto/v1/logging_service";
 import { extractUserResourceName } from "@/utils";
 import { doSubscribeIssue, useIssueContext } from "../../logic";
-import { ActivityItem } from "./Activity";
+import { ActivityItem, DistinctActivity, isSimilarActivity } from "./Activity";
 
 interface LocalState {
   editCommentMode: boolean;


### PR DESCRIPTION
Before: same `oldStatement` and same `newStatement`
After: same `newSheetId`

Reason: old/newStatement fields are legacy. Activities generated by batch "apply to current stage" or "apply to all tasks" statement update operations will share the same `newSheetId`

Also removed unused duplicated legacy codes.