### PR TITLE
chore(frontend): move some data initialize logic to root component

### DIFF
--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -24,11 +24,7 @@ import {
   useDBGroupStore,
   useProjectV1ListByCurrentUser,
 } from "@/store";
-import {
-  DEFAULT_PROJECT_V1_NAME,
-  UNKNOWN_ID,
-  UNKNOWN_USER_NAME,
-} from "@/types";
+import { DEFAULT_PROJECT_V1_NAME, UNKNOWN_ID } from "@/types";
 import { State } from "@/types/proto/v1/common";
 import {
   PolicyResourceType,
@@ -136,19 +132,6 @@ const preparePolicyList = () => {
 };
 
 watchEffect(preparePolicyList);
-
-// Prepare database and database group list.
-const prepareDataList = () => {
-  // It will also be called when user logout
-  if (currentUserV1.value.name !== UNKNOWN_USER_NAME) {
-    databaseV1Store.searchDatabaseList({
-      parent: "instances/-",
-    });
-    dbGroupStore.fetchAllDatabaseGroupList();
-  }
-};
-
-watchEffect(prepareDataList);
 
 // Use this to make the list reactive when project is transferred.
 const databaseList = computed(() => {

--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -11,6 +11,8 @@ import {
   useUserStore,
   useProjectV1Store,
   usePolicyV1Store,
+  useDatabaseV1Store,
+  useDBGroupStore,
 } from "@/store";
 import { useInstanceV1Store } from "@/store/modules/v1/instance";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
@@ -24,6 +26,10 @@ export default defineComponent({
       useUserStore().fetchUserList(),
       useEnvironmentV1Store().fetchEnvironments(),
       useInstanceV1Store().fetchInstanceList(),
+      useDatabaseV1Store().searchDatabaseList({
+        parent: "instances/-",
+      }),
+      useDBGroupStore().fetchAllDatabaseGroupList(),
       useProjectV1Store().fetchProjectList(true),
       usePolicyV1Store().getOrFetchPolicyByName("policies/WORKSPACE_IAM"),
       useUIStateStore().restoreState(),


### PR DESCRIPTION
It's bad practice to implicitly depend on some components' data. So we move the data initialize logic from `DatabaseListSidePanel` to `ProvideDashboardContext`

Close BYT-4408