### PR TITLE
chore: remove go back button (experiment)

### DIFF
--- a/frontend/src/components/CommonSidebar.vue
+++ b/frontend/src/components/CommonSidebar.vue
@@ -2,17 +2,6 @@
   <nav class="flex-1 flex flex-col overflow-y-hidden">
     <BytebaseLogo class="w-full px-4 shrink-0" />
     <div class="flex-1 overflow-y-auto px-2 pb-4">
-      <button
-        v-if="showGoBack"
-        class="group shrink-0 flex items-center px-2 py-2 text-base leading-5 font-normal rounded-md text-gray-700 hover:opacity-80 focus:outline-none"
-        @click.prevent="goBack"
-      >
-        <heroicons-outline:chevron-left
-          class="mr-1 w-5 h-auto text-gray-500 group-hover:text-gray-500 group-focus:text-gray-600"
-        />
-        {{ $t("common.back") }}
-      </button>
-
       <div v-for="(item, i) in filteredSidebarList" :key="i">
         <router-link
           v-if="type === 'route' && item.path"
@@ -67,8 +56,6 @@
 <script setup lang="ts">
 import { ChevronDown, ChevronUp } from "lucide-vue-next";
 import { computed, VNode, reactive, onMounted } from "vue";
-import { useRouter } from "vue-router";
-import { useRouterStore } from "@/store";
 
 export interface SidebarItem {
   title: string;
@@ -90,11 +77,9 @@ const props = withDefaults(
   defineProps<{
     itemList: SidebarItem[];
     type: "route" | "div";
-    showGoBack?: boolean;
     getItemClass: (path: string | undefined) => string[];
   }>(),
   {
-    showGoBack: false,
     getItemClass: (_: string | undefined) => [],
   }
 );
@@ -103,15 +88,9 @@ const emit = defineEmits<{
   (event: "select", path: string | undefined): void;
 }>();
 
-const routerStore = useRouterStore();
-const router = useRouter();
 const state = reactive<LocalState>({
   expandedSidebar: new Set(),
 });
-
-const goBack = () => {
-  router.push(routerStore.backPath());
-};
 
 const filteredSidebarList = computed(() => {
   return props.itemList


### PR DESCRIPTION
1. Both GitLab and GitHub lack this button in the sidebar. It appears that clicking on the logo icon is a commonly used method to return to the home page. Taking an experiment to remove this button in the next release.
2. Save the space taken by go back button.
3. Answer from GPT "Users often expect the logo or company/brand name in the top left corner of a website or application to serve as a link to the home page. It's a widely recognized convention. Therefore, if you have your logo in the header, users may already know that they can click it to go back home."
<img width="641" alt="Screenshot 2023-11-09 at 00 56 12" src="https://github.com/bytebase/bytebase/assets/98006139/8c4b56f7-0e99-4593-b909-ac2541e0a4fd">

