### PR TITLE
chore: update issue advanced search filter

### DIFF
--- a/frontend/src/components/AdvancedSearch.vue
+++ b/frontend/src/components/AdvancedSearch.vue
@@ -208,6 +208,76 @@ const fullScopes = computed((): SearchScope[] => {
       }),
     },
     {
+      id: "status",
+      title: t("issue.advanced-search.scope.status.title"),
+      description: t("issue.advanced-search.scope.status.description"),
+      options: [
+        {
+          id: "pending_approval",
+          label: h(
+            "span",
+            {},
+            t("issue.advanced-search.scope.status.value.pending_approval")
+          ),
+        },
+        {
+          id: "pending_rollout",
+          label: h(
+            "span",
+            {},
+            t("issue.advanced-search.scope.status.value.pending_rollout")
+          ),
+        },
+      ],
+    },
+    {
+      id: "creator",
+      title: t("issue.advanced-search.scope.creator.title"),
+      description: t("issue.advanced-search.scope.creator.description"),
+      options: principalSearchOptions.value,
+    },
+    {
+      id: "assignee",
+      title: t("issue.advanced-search.scope.assignee.title"),
+      description: t("issue.advanced-search.scope.assignee.description"),
+      options: principalSearchOptions.value,
+    },
+    {
+      id: "approver",
+      title: t("issue.advanced-search.scope.approver.title"),
+      description: t("issue.advanced-search.scope.approver.description"),
+      options: principalSearchOptions.value.filter(
+        (o) => o.id !== SYSTEM_BOT_EMAIL
+      ),
+    },
+    {
+      id: "subscriber",
+      title: t("issue.advanced-search.scope.subscriber.title"),
+      description: t("issue.advanced-search.scope.subscriber.description"),
+      options: principalSearchOptions.value,
+    },
+    {
+      id: "principal",
+      title: t("issue.advanced-search.scope.principal.title"),
+      description: t("issue.advanced-search.scope.principal.description"),
+      options: principalSearchOptions.value,
+    },
+    {
+      id: "type",
+      title: t("issue.advanced-search.scope.type.title"),
+      description: t("issue.advanced-search.scope.type.description"),
+      options: [
+        {
+          id: "DDL",
+          label: h("span", { innerHTML: "Data Definition Language" }),
+        },
+        {
+          id: "DML",
+          label: h("span", { innerHTML: "Data Manipulation Language" }),
+        },
+      ],
+    },
+    {
       id: "instance",
       title: t("issue.advanced-search.scope.instance.title"),
       description: t("issue.advanced-search.scope.instance.description"),
@@ -241,78 +311,6 @@ const fullScopes = computed((): SearchScope[] => {
           ]),
         };
       }),
-    },
-    {
-      id: "type",
-      title: t("issue.advanced-search.scope.type.title"),
-      description: t("issue.advanced-search.scope.type.description"),
-      options: [
-        {
-          id: "DDL",
-          label: h("span", { innerHTML: "Data Definition Language" }),
-        },
-        {
-          id: "DML",
-          label: h("span", { innerHTML: "Data Manipulation Language" }),
-        },
-      ],
-    },
-    {
-      id: "creator",
-      title: t("issue.advanced-search.scope.creator.title"),
-      description: t("issue.advanced-search.scope.creator.description"),
-      options: principalSearchOptions.value,
-    },
-    {
-      id: "assignee",
-      title: t("issue.advanced-search.scope.assignee.title"),
-      description: t("issue.advanced-search.scope.assignee.description"),
-      options: principalSearchOptions.value,
-    },
-    {
-      id: "subscriber",
-      title: t("issue.advanced-search.scope.subscriber.title"),
-      description: t("issue.advanced-search.scope.subscriber.description"),
-      options: principalSearchOptions.value,
-    },
-    {
-      id: "principal",
-      title: t("issue.advanced-search.scope.principal.title"),
-      description: t("issue.advanced-search.scope.principal.description"),
-      options: principalSearchOptions.value,
-    },
-    {
-      id: "approver",
-      title: t("issue.advanced-search.scope.approver.title"),
-      description: t("issue.advanced-search.scope.approver.description"),
-      options: principalSearchOptions.value.filter(
-        (o) => o.id !== SYSTEM_BOT_EMAIL
-      ),
-    },
-    {
-      id: "review_status",
-      title: t("issue.advanced-search.scope.review-status.title"),
-      description: t("issue.advanced-search.scope.review-status.description"),
-      options: [
-        {
-          id: "pending_approval",
-          label: h(
-            "span",
-            {},
-            t(
-              "issue.advanced-search.scope.review-status.value.pending_approval"
-            )
-          ),
-        },
-        {
-          id: "approved",
-          label: h(
-            "span",
-            {},
-            t("issue.advanced-search.scope.review-status.value.approved")
-          ),
-        },
-      ],
     },
   ];
   return scopes;

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -26,7 +26,7 @@
           statusList: [IssueStatus.OPEN],
         }"
         :ui-issue-filter="{
-          review_status: 'pending_approval',
+          status: 'pending_approval',
         }"
       >
         <template #table="{ issueList, loading }">

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -964,13 +964,13 @@
           "title": "Approver",
           "description": "Search by the issue approver"
         },
-        "review-status": {
-          "title": "Review Status",
+        "status": {
+          "title": "Status",
           "value": {
-            "approved": "Approved",
-            "pending_approval": "Pending approval"
+            "pending_approval": "Pending approval",
+            "pending_rollout": "Pending rollout"
           },
-          "description": "Search by the issue review status"
+          "description": "Search by the issue status"
         }
       }
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -963,13 +963,13 @@
           "title": "Aprobador",
           "description": "Búsqueda por aprobador del problema"
         },
-        "review-status": {
-          "title": "Estado de revisión",
+        "status": {
+          "title": "Situación",
           "value": {
-            "approved": "Aprobado",
-            "pending_approval": "Aprobación pendiente"
+            "pending_approval": "Aprobación pendiente",
+            "pending_rollout": "Lanzamiento pendiente"
           },
-          "description": "Buscar por estado de revisión del problema"
+          "description": "Buscar por estado del problema"
         }
       }
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -961,13 +961,13 @@
           "title": "审批人",
           "description": "根据工单审批人搜索"
         },
-        "review-status": {
-          "title": "审批状态",
+        "status": {
+          "title": "状态",
           "value": {
-            "approved": "审批通过",
-            "pending_approval": "待审批"
+            "pending_approval": "待审批",
+            "pending_rollout": "待发布"
           },
-          "description": "按工单的审批状态搜索"
+          "description": "按工单的状态搜索"
         }
       }
     },

--- a/frontend/src/utils/v1/issue/ui-filter.ts
+++ b/frontend/src/utils/v1/issue/ui-filter.ts
@@ -5,10 +5,13 @@ import {
 import { ComposedIssue } from "@/types";
 import { Issue_Approver_Status } from "@/types/proto/v1/issue_service";
 
-export const UIIssueFilterScopeIdList = ["approver", "review_status"] as const;
+export const UIIssueFilterScopeIdList = ["approver", "status"] as const;
 export type UIIssueFilterScopeId = typeof UIIssueFilterScopeIdList[number];
 
-export const IssueReviewStatusList = ["pending_approval", "approved"] as const;
+export const IssueReviewStatusList = [
+  "pending_approval",
+  "pending_rollout",
+] as const;
 export type IssueReviewStatus = typeof IssueReviewStatusList[number];
 export const isValidIssueReviewStatus = (s: string): s is IssueReviewStatus => {
   return IssueReviewStatusList.includes(s as IssueReviewStatus);
@@ -17,7 +20,7 @@ export const isValidIssueReviewStatus = (s: string): s is IssueReviewStatus => {
 // Use snake_case to keep consistent with the advanced search query string
 export interface UIIssueFilter {
   approver?: string;
-  review_status?: IssueReviewStatus;
+  status?: IssueReviewStatus;
 }
 
 export const filterIssueByApprover = (
@@ -59,7 +62,7 @@ export const filterIssueByReviewStatus = (
   if (status === "pending_approval") {
     return reviewContext.status.value === Issue_Approver_Status.PENDING;
   }
-  if (status === "approved") {
+  if (status === "pending_rollout") {
     return reviewContext.status.value === Issue_Approver_Status.APPROVED;
   }
 
@@ -77,5 +80,5 @@ export const applyUIIssueFilter = (
   if (!filter) return list;
   return list
     .filter((issue) => filterIssueByApprover(issue, filter.approver))
-    .filter((issue) => filterIssueByReviewStatus(issue, filter.review_status));
+    .filter((issue) => filterIssueByReviewStatus(issue, filter.status));
 };

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -26,7 +26,7 @@
         }"
         :ui-issue-filter="{
           approver: `users/${currentUserV1.email}`,
-          review_status: 'pending_approval',
+          status: 'pending_approval',
         }"
       >
         <template #table="{ issueList, loading }">
@@ -50,7 +50,7 @@
           assignee: `${userNamePrefix}${currentUserV1.email}`,
         }"
         :ui-issue-filter="{
-          review_status: 'approved',
+          status: 'pending_rollout',
         }"
         :page-size="OPEN_ISSUE_LIST_PAGE_SIZE"
       >

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -346,13 +346,13 @@ const issueFilter = computed((): IssueFilter => {
 const uiIssueFilter = computed((): UIIssueFilter => {
   const { scopes } = state.searchParams;
   const approverScope = scopes.find((s) => s.id === "approver");
-  const reviewStatusScope = scopes.find((s) => s.id === "review_status");
+  const reviewStatusScope = scopes.find((s) => s.id === "status");
   const uiIssueFilter: UIIssueFilter = {};
   if (approverScope && approverScope.value) {
     uiIssueFilter.approver = `users/${approverScope.value}`;
   }
   if (reviewStatusScope && isValidIssueReviewStatus(reviewStatusScope.value)) {
-    uiIssueFilter.review_status = reviewStatusScope.value;
+    uiIssueFilter.status = reviewStatusScope.value;
   }
 
   return uiIssueFilter;


### PR DESCRIPTION
1. Reorder the filter keys by usage.
2. Rebrand review_status to status which includes all kinds to issue status, 1) open, 2) pending approval, 3) pending rollout, 4) closed.
3. TODO, filterIssueByReviewStatus() needs to be fixed.