### PR TITLE
chore: reword review to approval

### DIFF
--- a/frontend/src/components/AdvancedSearch.vue
+++ b/frontend/src/components/AdvancedSearch.vue
@@ -208,9 +208,9 @@ const fullScopes = computed((): SearchScope[] => {
       }),
     },
     {
-      id: "review_status",
-      title: t("issue.advanced-search.scope.review-status.title"),
-      description: t("issue.advanced-search.scope.review-status.description"),
+      id: "approval_status",
+      title: t("issue.advanced-search.scope.approval-status.title"),
+      description: t("issue.advanced-search.scope.approval-status.description"),
       options: [
         {
           id: "pending_approval",
@@ -218,7 +218,7 @@ const fullScopes = computed((): SearchScope[] => {
             "span",
             {},
             t(
-              "issue.advanced-search.scope.review-status.value.pending_approval"
+              "issue.advanced-search.scope.approval-status.value.pending_approval"
             )
           ),
         },
@@ -227,7 +227,7 @@ const fullScopes = computed((): SearchScope[] => {
           label: h(
             "span",
             {},
-            t("issue.advanced-search.scope.review-status.value.approved")
+            t("issue.advanced-search.scope.approval-status.value.approved")
           ),
         },
       ],

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -26,7 +26,7 @@
           statusList: [IssueStatus.OPEN],
         }"
         :ui-issue-filter="{
-          review_status: 'pending_approval',
+          approval_status: 'pending_approval',
         }"
       >
         <template #table="{ issueList, loading }">

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -964,13 +964,13 @@
           "title": "Approver",
           "description": "Search by the issue approver"
         },
-        "review-status": {
-          "title": "Review Status",
+        "approval-status": {
+          "title": "Approval Status",
           "value": {
             "approved": "Approved",
             "pending_approval": "Pending approval"
           },
-          "description": "Search by the issue review status"
+          "description": "Search by the issue approval status"
         }
       }
     },
@@ -1101,7 +1101,7 @@
       "issue-is-not-open": "The issue is not open",
       "you-don-have-privilege-to-edit-this-issue": "You don't have privilege to edit this issue"
     },
-    "review-requested": "Review Requested"
+    "approval-requested": "Approval Requested"
   },
   "alter-schema": {
     "vcs-enabled": "This project has enabled VCS based version control and selecting database below will navigate you to the corresponding Git repository to initiate the change process.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -963,8 +963,8 @@
           "title": "Aprobador",
           "description": "Búsqueda por aprobador del problema"
         },
-        "review-status": {
-          "title": "Estado de revisión",
+        "approval-status": {
+          "title": "Estado de aprobación",
           "value": {
             "approved": "Aprobado",
             "pending_approval": "Aprobación pendiente"
@@ -1100,7 +1100,7 @@
       "issue-is-not-open": "El tema no está abierto.",
       "you-don-have-privilege-to-edit-this-issue": "No tienes privilegios para editar este número."
     },
-    "review-requested": "Revisión solicitada"
+    "approval-requested": "Aprobación solicitada"
   },
   "alter-schema": {
     "vcs-enabled": "Este proyecto ha habilitado el control de versiones basado en VCS y seleccionar la base de datos a continuación lo llevará al repositorio Git correspondiente para iniciar el proceso de cambio.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -961,7 +961,7 @@
           "title": "审批人",
           "description": "根据工单审批人搜索"
         },
-        "review-status": {
+        "approval-status": {
           "title": "审批状态",
           "value": {
             "approved": "审批通过",
@@ -1098,7 +1098,7 @@
       "issue-is-not-open": "工单不是开启状态",
       "you-don-have-privilege-to-edit-this-issue": "您没有权限编辑此工单"
     },
-    "review-requested": "审批请求"
+    "approval-requested": "审批请求"
   },
   "alter-schema": {
     "vcs-enabled": "该项目开启了基于 VCS 的版本管理，选择下面的数据库会将您导航到相应的 Git 仓库以发起变更流程。",

--- a/frontend/src/utils/v1/issue/ui-filter.ts
+++ b/frontend/src/utils/v1/issue/ui-filter.ts
@@ -5,7 +5,10 @@ import {
 import { ComposedIssue } from "@/types";
 import { Issue_Approver_Status } from "@/types/proto/v1/issue_service";
 
-export const UIIssueFilterScopeIdList = ["approver", "review_status"] as const;
+export const UIIssueFilterScopeIdList = [
+  "approver",
+  "approval_status",
+] as const;
 export type UIIssueFilterScopeId = typeof UIIssueFilterScopeIdList[number];
 
 export const IssueReviewStatusList = ["pending_approval", "approved"] as const;
@@ -17,7 +20,7 @@ export const isValidIssueReviewStatus = (s: string): s is IssueReviewStatus => {
 // Use snake_case to keep consistent with the advanced search query string
 export interface UIIssueFilter {
   approver?: string;
-  review_status?: IssueReviewStatus;
+  approval_status?: IssueReviewStatus;
 }
 
 export const filterIssueByApprover = (
@@ -77,5 +80,7 @@ export const applyUIIssueFilter = (
   if (!filter) return list;
   return list
     .filter((issue) => filterIssueByApprover(issue, filter.approver))
-    .filter((issue) => filterIssueByReviewStatus(issue, filter.review_status));
+    .filter((issue) =>
+      filterIssueByReviewStatus(issue, filter.approval_status)
+    );
 };

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -16,7 +16,7 @@
         </router-link>
       </div>
     </div>
-    <div v-show="tab === 'REVIEW_REQUESTED'" class="mt-2">
+    <div v-show="tab === 'APPROVAL_REQUESTED'" class="mt-2">
       <PagedIssueTableV1
         v-if="hasCustomApprovalFeature"
         session-key="home-waiting-approval"
@@ -224,9 +224,9 @@ import { IssueFilter, planTypeToString } from "../types";
 import { extractUserUID } from "../utils";
 
 const TABS = [
-  "REVIEW_REQUESTED",
-  "WAITING_ROLLOUT",
   "CREATED",
+  "APPROVAL_REQUESTED",
+  "WAITING_ROLLOUT",
   "SUBSCRIBED",
   "RECENTLY_CLOSED",
 ] as const;
@@ -245,11 +245,11 @@ const subscriptionStore = useSubscriptionV1Store();
 const onboardingStateStore = useOnboardingStateStore();
 const tab = useLocalStorage<TabValue>(
   "bb.home.issue-list-tab",
-  "REVIEW_REQUESTED",
+  "APPROVAL_REQUESTED",
   {
     serializer: {
       read(raw: TabValue) {
-        if (!TABS.includes(raw)) return "REVIEW_REQUESTED";
+        if (!TABS.includes(raw)) return "APPROVAL_REQUESTED";
         return raw;
       },
       write(value) {
@@ -268,15 +268,15 @@ const currentUserUID = computed(() => extractUserUID(currentUserV1.value.name));
 const hasCustomApprovalFeature = featureToRef("bb.feature.custom-approval");
 
 const tabItemList = computed((): TabFilterItem<TabValue>[] => {
-  const REVIEW_REQUESTED: TabFilterItem<TabValue> = {
-    value: "REVIEW_REQUESTED",
-    label: t("issue.review-requested"),
+  const APPROVAL_REQUESTED: TabFilterItem<TabValue> = {
+    value: "APPROVAL_REQUESTED",
+    label: t("issue.approval-requested"),
   };
-  const list = hasCustomApprovalFeature.value ? [REVIEW_REQUESTED] : [];
+  const list = hasCustomApprovalFeature.value ? [APPROVAL_REQUESTED] : [];
   return [
+    { value: "CREATED", label: t("common.created") },
     ...list,
     { value: "WAITING_ROLLOUT", label: t("issue.waiting-rollout") },
-    { value: "CREATED", label: t("common.created") },
     { value: "SUBSCRIBED", label: t("common.subscribed") },
     { value: "RECENTLY_CLOSED", label: t("project.overview.recently-closed") },
   ];
@@ -306,7 +306,7 @@ const commonIssueFilter = computed((): IssueFilter => {
 watch(
   [hasCustomApprovalFeature, tab],
   () => {
-    if (!hasCustomApprovalFeature.value && tab.value === "REVIEW_REQUESTED") {
+    if (!hasCustomApprovalFeature.value && tab.value === "APPROVAL_REQUESTED") {
       tab.value = "WAITING_ROLLOUT";
     }
   },

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -26,7 +26,7 @@
         }"
         :ui-issue-filter="{
           approver: `users/${currentUserV1.email}`,
-          review_status: 'pending_approval',
+          approval_status: 'pending_approval',
         }"
       >
         <template #table="{ issueList, loading }">
@@ -50,7 +50,7 @@
           assignee: `${userNamePrefix}${currentUserV1.email}`,
         }"
         :ui-issue-filter="{
-          review_status: 'approved',
+          approval_status: 'approved',
         }"
         :page-size="OPEN_ISSUE_LIST_PAGE_SIZE"
       >

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -346,13 +346,13 @@ const issueFilter = computed((): IssueFilter => {
 const uiIssueFilter = computed((): UIIssueFilter => {
   const { scopes } = state.searchParams;
   const approverScope = scopes.find((s) => s.id === "approver");
-  const reviewStatusScope = scopes.find((s) => s.id === "review_status");
+  const reviewStatusScope = scopes.find((s) => s.id === "approval_status");
   const uiIssueFilter: UIIssueFilter = {};
   if (approverScope && approverScope.value) {
     uiIssueFilter.approver = `users/${approverScope.value}`;
   }
   if (reviewStatusScope && isValidIssueReviewStatus(reviewStatusScope.value)) {
-    uiIssueFilter.review_status = reviewStatusScope.value;
+    uiIssueFilter.approval_status = reviewStatusScope.value;
   }
 
   return uiIssueFilter;


### PR DESCRIPTION
1. Changed word review to approval to be consistent with other approval related wording within the product, e.g. custom approval.
2. (Experiment) Reorder default filter tabs. Moved "Created" to the left because it's more friendly to developers.