### PR TITLE
chore: deprecate issue principal filter

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -162,15 +162,6 @@ func (s *IssueService) ListIssues(ctx context.Context, request *v1pb.ListIssuesR
 	}
 	for _, spec := range filters {
 		switch spec.key {
-		case "principal":
-			if spec.operator != comparatorTypeEqual {
-				return nil, status.Errorf(codes.InvalidArgument, `only support "=" operation for "principal" filter`)
-			}
-			user, err := s.getUserByIdentifier(ctx, spec.value)
-			if err != nil {
-				return nil, err
-			}
-			issueFind.PrincipalID = &user.ID
 		case "creator":
 			if spec.operator != comparatorTypeEqual {
 				return nil, status.Errorf(codes.InvalidArgument, `only support "=" operation for "creator" filter`)

--- a/frontend/src/components/AdvancedSearch.vue
+++ b/frontend/src/components/AdvancedSearch.vue
@@ -259,12 +259,6 @@ const fullScopes = computed((): SearchScope[] => {
       options: principalSearchOptions.value,
     },
     {
-      id: "principal",
-      title: t("issue.advanced-search.scope.principal.title"),
-      description: t("issue.advanced-search.scope.principal.description"),
-      options: principalSearchOptions.value,
-    },
-    {
       id: "type",
       title: t("issue.advanced-search.scope.type.title"),
       description: t("issue.advanced-search.scope.type.description"),
@@ -367,21 +361,6 @@ const searchScopes = computed((): SearchScope[] => {
   return filteredScopes.value.filter((scope) => {
     if (existedScope.has(scope.id)) {
       return false;
-    }
-    // The principal scope cannot used with creator/assignee/subscriber
-    if (scope.id === "principal") {
-      return (
-        !existedScope.has("creator") &&
-        !existedScope.has("assignee") &&
-        !existedScope.has("subscriber")
-      );
-    }
-    if (
-      scope.id === "creator" ||
-      scope.id === "assignee" ||
-      scope.id === "subscriber"
-    ) {
-      return !existedScope.has("principal");
     }
     return true;
   });

--- a/frontend/src/utils/v1/issue/advanced-search.ts
+++ b/frontend/src/utils/v1/issue/advanced-search.ts
@@ -8,7 +8,6 @@ export type SearchScopeId =
   | "creator"
   | "assignee"
   | "subscriber"
-  | "principal"
   | UIIssueFilterScopeId;
 
 export interface SearchParams {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -6,7 +6,7 @@
       </div>
       <div class="flex items-center space-x-2 p-0.5">
         <router-link
-          :to="`/issue?user=${currentUserUID}`"
+          :to="issueLink"
           class="flex space-x-1 items-center normal-link !whitespace-nowrap"
         >
           <heroicons-outline:search class="h-4 w-4" />
@@ -294,6 +294,21 @@ const planImage = computed(() => {
     ).toLowerCase()}.png`,
     import.meta.url
   ).href;
+});
+
+const issueLink = computed(() => {
+  if (tab.value === "CREATED") {
+    return "/issue?creator=" + currentUserUID.value;
+  }
+  if (tab.value === "APPROVAL_REQUESTED") {
+    return "/issue?approver=" + currentUserUID.value;
+  }
+  if (tab.value === "SUBSCRIBED") {
+    return "/issue?subscriber=" + currentUserUID.value;
+  }
+
+  // TODO(d): use closed filter for WAITING_ROLLOUT and RECENTLY_CLOSED.
+  return "/issue";
 });
 
 const commonIssueFilter = computed((): IssueFilter => {

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -150,7 +150,7 @@ const autofocus = computed((): boolean => {
 
 const initializeSearchParamsFromQuery = (): SearchParams => {
   const projectName = project.value?.name ?? "";
-  const userEmail = selectedPrincipal.value?.email ?? "";
+  const { creator, assignee, approver, subscriber } = route.query;
   const query = (route.query.query as string) ?? "";
 
   const params: SearchParams = {
@@ -164,11 +164,44 @@ const initializeSearchParamsFromQuery = (): SearchParams => {
       value: extractProjectResourceName(projectName),
     });
   }
-  if (userEmail && hasPermission.value) {
-    params.scopes.push({
-      id: "principal",
-      value: userEmail,
-    });
+  if (creator && hasPermission.value) {
+    const creatorEmail = userStore.getUserById(creator as string)?.email ?? "";
+    if (creatorEmail) {
+      params.scopes.push({
+        id: "creator",
+        value: creatorEmail,
+      });
+    }
+  }
+  if (assignee && hasPermission.value) {
+    const assigneeEmail =
+      userStore.getUserById(assignee as string)?.email ?? "";
+    if (assigneeEmail) {
+      params.scopes.push({
+        id: "creator",
+        value: assigneeEmail,
+      });
+    }
+  }
+  if (approver && hasPermission.value) {
+    const approverEmail =
+      userStore.getUserById(approver as string)?.email ?? "";
+    if (approverEmail) {
+      params.scopes.push({
+        id: "approver",
+        value: approverEmail,
+      });
+    }
+  }
+  if (subscriber && hasPermission.value) {
+    const subscriberEmail =
+      userStore.getUserById(subscriber as string)?.email ?? "";
+    if (subscriberEmail) {
+      params.scopes.push({
+        id: "subscriber",
+        value: subscriberEmail,
+      });
+    }
   }
 
   return params;
@@ -233,14 +266,6 @@ const isDateDisabled = (ts: number) => {
 const selectedProjectId = computed((): string | undefined => {
   const { project } = route.query;
   return project ? (project as string) : undefined;
-});
-
-const selectedPrincipal = computed(() => {
-  const { user } = route.query;
-  if (!user) {
-    return;
-  }
-  return userStore.getUserById(user as string);
 });
 
 const state = reactive<LocalState>({
@@ -336,7 +361,6 @@ const issueFilter = computed((): IssueFilter => {
       ? selectedTimeRange.value[1]
       : undefined,
     type: typeScope?.value,
-    principal: getValueFromIssueFilter(userNamePrefix, "principal"),
     creator: getValueFromIssueFilter(userNamePrefix, "creator"),
     assignee: getValueFromIssueFilter(userNamePrefix, "assignee"),
     subscriber: getValueFromIssueFilter(userNamePrefix, "subscriber"),


### PR DESCRIPTION
The principal should also cover approver and releaser ideally, but it's difficult to implement such principal filter. In this case, let's deprecate the principal filter to eliminate the confusion and making the issue role more explicit. Future work includes adding releaser filter and making advanced search and simple filter compatible.