### PR TITLE
chore(frontend): re-terminology "review_status" issue filter to "approval"

### DIFF
--- a/frontend/src/components/AdvancedSearch.vue
+++ b/frontend/src/components/AdvancedSearch.vue
@@ -208,18 +208,16 @@ const fullScopes = computed((): SearchScope[] => {
       }),
     },
     {
-      id: "approval_status",
-      title: t("issue.advanced-search.scope.approval-status.title"),
-      description: t("issue.advanced-search.scope.approval-status.description"),
+      id: "approval",
+      title: t("issue.advanced-search.scope.approval.title"),
+      description: t("issue.advanced-search.scope.approval.description"),
       options: [
         {
-          id: "pending_approval",
+          id: "pending",
           label: h(
             "span",
             {},
-            t(
-              "issue.advanced-search.scope.approval-status.value.pending_approval"
-            )
+            t("issue.advanced-search.scope.approval.value.pending")
           ),
         },
         {
@@ -227,7 +225,7 @@ const fullScopes = computed((): SearchScope[] => {
           label: h(
             "span",
             {},
-            t("issue.advanced-search.scope.approval-status.value.approved")
+            t("issue.advanced-search.scope.approval.value.approved")
           ),
         },
       ],

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -26,7 +26,7 @@
           statusList: [IssueStatus.OPEN],
         }"
         :ui-issue-filter="{
-          approval_status: 'pending_approval',
+          approval: 'pending',
         }"
       >
         <template #table="{ issueList, loading }">

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -964,9 +964,6 @@
           "title": "Approver",
           "description": "Search by the issue approver"
         },
-        "approval-status": {
-          "value": {}
-        },
         "approval": {
           "value": {
             "pending": "Pending approval",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -965,12 +965,15 @@
           "description": "Search by the issue approver"
         },
         "approval-status": {
-          "title": "Approval Status",
+          "value": {}
+        },
+        "approval": {
           "value": {
-            "approved": "Approved",
-            "pending_approval": "Pending approval"
+            "pending": "Pending approval",
+            "approved": "Approved"
           },
-          "description": "Search by the issue approval status"
+          "description": "Search by the issue approval status",
+          "title": "Approval Status"
         }
       }
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -963,13 +963,13 @@
           "title": "Aprobador",
           "description": "Búsqueda por aprobador del problema"
         },
-        "approval-status": {
-          "title": "Estado de aprobación",
+        "approval": {
           "value": {
-            "approved": "Aprobado",
-            "pending_approval": "Aprobación pendiente"
+            "pending": "Aprobación pendiente",
+            "approved": "Aprobado"
           },
-          "description": "Buscar por estado de revisión del problema"
+          "description": "Buscar por estado de revisión del problema",
+          "title": "Estado de aprobación"
         }
       }
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -961,13 +961,13 @@
           "title": "审批人",
           "description": "根据工单审批人搜索"
         },
-        "approval-status": {
-          "title": "审批状态",
+        "approval": {
           "value": {
-            "approved": "审批通过",
-            "pending_approval": "待审批"
+            "pending": "待审批",
+            "approved": "审批通过"
           },
-          "description": "按工单的审批状态搜索"
+          "description": "按工单的审批状态搜索",
+          "title": "审批状态"
         }
       }
     },

--- a/frontend/src/utils/v1/issue/ui-filter.ts
+++ b/frontend/src/utils/v1/issue/ui-filter.ts
@@ -5,22 +5,21 @@ import {
 import { ComposedIssue } from "@/types";
 import { Issue_Approver_Status } from "@/types/proto/v1/issue_service";
 
-export const UIIssueFilterScopeIdList = [
-  "approver",
-  "approval_status",
-] as const;
+export const UIIssueFilterScopeIdList = ["approver", "approval"] as const;
 export type UIIssueFilterScopeId = typeof UIIssueFilterScopeIdList[number];
 
-export const IssueReviewStatusList = ["pending_approval", "approved"] as const;
-export type IssueReviewStatus = typeof IssueReviewStatusList[number];
-export const isValidIssueReviewStatus = (s: string): s is IssueReviewStatus => {
-  return IssueReviewStatusList.includes(s as IssueReviewStatus);
+export const IssueApprovalStatusList = ["pending", "approved"] as const;
+export type IssueApprovalStatus = typeof IssueApprovalStatusList[number];
+export const isValidIssueApprovalStatus = (
+  s: string
+): s is IssueApprovalStatus => {
+  return IssueApprovalStatusList.includes(s as IssueApprovalStatus);
 };
 
 // Use snake_case to keep consistent with the advanced search query string
 export interface UIIssueFilter {
   approver?: string;
-  approval_status?: IssueReviewStatus;
+  approval?: IssueApprovalStatus;
 }
 
 export const filterIssueByApprover = (
@@ -52,14 +51,14 @@ export const filterIssueByApprover = (
   return false;
 };
 
-export const filterIssueByReviewStatus = (
+export const filterIssueByApprovalStatus = (
   issue: ComposedIssue,
-  status: IssueReviewStatus | undefined
+  status: IssueApprovalStatus | undefined
 ) => {
   if (!status) return true;
 
   const reviewContext = extractReviewContext(issue);
-  if (status === "pending_approval") {
+  if (status === "pending") {
     return reviewContext.status.value === Issue_Approver_Status.PENDING;
   }
   if (status === "approved") {
@@ -67,7 +66,7 @@ export const filterIssueByReviewStatus = (
   }
 
   console.error(
-    "[filterIssueByReviewStatus] should never reach this line",
+    "[filterIssueByApprovalStatus] should never reach this line",
     status
   );
   return false;
@@ -80,7 +79,5 @@ export const applyUIIssueFilter = (
   if (!filter) return list;
   return list
     .filter((issue) => filterIssueByApprover(issue, filter.approver))
-    .filter((issue) =>
-      filterIssueByReviewStatus(issue, filter.approval_status)
-    );
+    .filter((issue) => filterIssueByApprovalStatus(issue, filter.approval));
 };

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -26,7 +26,7 @@
         }"
         :ui-issue-filter="{
           approver: `users/${currentUserV1.email}`,
-          approval_status: 'pending_approval',
+          approval: 'pending',
         }"
       >
         <template #table="{ issueList, loading }">
@@ -50,7 +50,7 @@
           assignee: `${userNamePrefix}${currentUserV1.email}`,
         }"
         :ui-issue-filter="{
-          approval_status: 'approved',
+          approval: 'approved',
         }"
         :page-size="OPEN_ISSUE_LIST_PAGE_SIZE"
       >

--- a/frontend/src/views/IssueDashboard.vue
+++ b/frontend/src/views/IssueDashboard.vue
@@ -116,7 +116,7 @@ import {
   SearchParams,
   SearchScopeId,
   UIIssueFilter,
-  isValidIssueReviewStatus,
+  isValidIssueApprovalStatus,
 } from "@/utils";
 
 const TABS = ["OPEN", "CLOSED"] as const;
@@ -370,13 +370,13 @@ const issueFilter = computed((): IssueFilter => {
 const uiIssueFilter = computed((): UIIssueFilter => {
   const { scopes } = state.searchParams;
   const approverScope = scopes.find((s) => s.id === "approver");
-  const reviewStatusScope = scopes.find((s) => s.id === "approval_status");
+  const approvalScope = scopes.find((s) => s.id === "approval");
   const uiIssueFilter: UIIssueFilter = {};
   if (approverScope && approverScope.value) {
     uiIssueFilter.approver = `users/${approverScope.value}`;
   }
-  if (reviewStatusScope && isValidIssueReviewStatus(reviewStatusScope.value)) {
-    uiIssueFilter.approval_status = reviewStatusScope.value;
+  if (approvalScope && isValidIssueApprovalStatus(approvalScope.value)) {
+    uiIssueFilter.approval = approvalScope.value;
   }
 
   return uiIssueFilter;


### PR DESCRIPTION
### Details

- `review_status` -> `approval`
  - `pending_review` -> `pending`
  - `approved` -> `approved` (no change)