### PR TITLE
chore: show all databases in the database dashboard

### DIFF
--- a/frontend/src/views/DatabaseDashboard.vue
+++ b/frontend/src/views/DatabaseDashboard.vue
@@ -147,7 +147,6 @@ import {
   UNKNOWN_USER_NAME,
   ComposedDatabase,
   ComposedDatabaseGroup,
-  DEFAULT_PROJECT_V1_NAME,
 } from "../types";
 
 interface LocalState {
@@ -268,11 +267,9 @@ const changeSearchText = (searchText: string) => {
 };
 
 const filteredDatabaseList = computed(() => {
-  let list = databaseV1List.value
-    .filter((database) => database.project !== DEFAULT_PROJECT_V1_NAME)
-    .filter((database) =>
-      isDatabaseV1Accessible(database, currentUserV1.value)
-    );
+  let list = databaseV1List.value.filter((database) =>
+    isDatabaseV1Accessible(database, currentUserV1.value)
+  );
   const environment = selectedEnvironment.value;
   if (environment && environment.name !== UNKNOWN_ENVIRONMENT_NAME) {
     list = list.filter((db) => db.effectiveEnvironment === environment.name);


### PR DESCRIPTION
Unassigned databases should be visible on the dashboard when an instance is added, providing a more intuitive user experience. Additionally, consider implementing an unassigned database filter rather than directing users to a separate page.