### PR TITLE
feat: emit log instead of fail when generating onboarding data fails

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -334,7 +334,10 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 		if firstEndUser {
 			if profile.SampleDatabasePort != 0 {
 				if err := s.generateOnboardingData(ctx, user); err != nil {
-					return status.Errorf(codes.Internal, "failed to prepare onboarding data, error: %v", err)
+					// When running inside docker on mac, we sometimes get database does not exist error.
+					// This is due to the docker overlay storage incompatibility with mac OS file system.
+					// Onboarding error is not critical, so we just emit an error log.
+					slog.Error("failed to prepare onboarding data", log.BBError(err))
 				}
 			}
 		}


### PR DESCRIPTION
![image](https://github.com/bytebase/bytebase/assets/230323/20f2caaa-6f34-43e3-8bec-285a8956f581)

Sometimes fail due to mac docker engine bug with mac os file system