### PR TITLE
feat: add project mode to sql editor tree store

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -19,6 +19,7 @@ import {
   useUserStore,
 } from "@/store";
 import { useSQLEditorTreeStore } from "@/store/modules/sqlEditorTree";
+import { projectNamePrefix } from "@/store/modules/v1/common";
 import { usePolicyV1Store } from "@/store/modules/v1/policy";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
 import { Connection, CoreTabInfo, TabMode, UNKNOWN_USER_NAME } from "@/types";
@@ -45,6 +46,7 @@ const router = useRouter();
 const { t } = useI18n();
 
 const currentUserV1 = useCurrentUserV1();
+const projectStpre = useProjectV1Store();
 const instanceStore = useInstanceV1Store();
 const databaseStore = useDatabaseV1Store();
 const policyV1Store = usePolicyV1Store();
@@ -87,6 +89,12 @@ const prepareAccessibleDatabaseList = async () => {
 };
 
 const initializeTree = async () => {
+  const project = route.query.project;
+  if (project) {
+    treeStore.selectedProject = await projectStpre.getOrFetchProjectByName(
+      `${projectNamePrefix}${project}`
+    );
+  }
   treeStore.buildTree();
 };
 

--- a/frontend/src/types/sqlEditorTree.ts
+++ b/frontend/src/types/sqlEditorTree.ts
@@ -1,5 +1,6 @@
 import { TreeOption } from "naive-ui";
 import { t } from "@/plugins/i18n";
+import { useSQLEditorTreeStore } from "@/store";
 import { getCustomProjectTitle } from "@/utils/customTheme";
 import { Engine } from "./proto/v1/common";
 import { SchemaMetadata, TableMetadata } from "./proto/v1/database_service";
@@ -108,8 +109,13 @@ export const readableSQLEditorTreeFactor = (
   factor: SQLEditorTreeFactor,
   labelPrefix: string | undefined = ""
 ) => {
+  const treeStore = useSQLEditorTreeStore();
   if (factor === "project") {
-    return getCustomProjectTitle();
+    if (treeStore.projectMode) {
+      return t("common.database");
+    } else {
+      return getCustomProjectTitle();
+    }
   }
   if (factor === "environment") {
     return t("common.environment");

--- a/frontend/src/views/sql-editor/AsidePanel/GroupingBar/GroupingBar.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/GroupingBar/GroupingBar.vue
@@ -9,7 +9,7 @@
         class="grouping-bar--tabs"
         @update:value="selectPresetFactor"
       >
-        <NTab name="project">{{ getCustomProjectTitle() }}</NTab>
+        <NTab name="project">{{ readableSQLEditorTreeFactor("project") }}</NTab>
         <NTab name="instance">{{ $t("common.instance") }}</NTab>
       </NTabs>
       <div
@@ -65,8 +65,10 @@ import { NButton, NPopover, NTab, NTabs } from "naive-ui";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 import { useSQLEditorTreeStore } from "@/store/modules/sqlEditorTree";
-import { StatefulSQLEditorTreeFactor as StatefulFactor } from "@/types";
-import { getCustomProjectTitle } from "@/utils/customTheme";
+import {
+  StatefulSQLEditorTreeFactor as StatefulFactor,
+  readableSQLEditorTreeFactor,
+} from "@/types";
 import FactorPanel from "./FactorPanel.vue";
 import FactorTag from "./FactorTag.vue";
 


### PR DESCRIPTION
Once a project is specified in the routing query (e.g., `?project=bytebase`), the tree will display its database directly.

https://github.com/bytebase/bytebase/assets/24653555/61c7166f-f10a-4847-9e63-3f60070eb8e4

