### PR TITLE
chore: avoid race condition by keeping task run set

### DIFF
--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -353,8 +353,7 @@ func (s *SchedulerV2) scheduleRunningTaskRuns(ctx context.Context) error {
 func (s *SchedulerV2) runTaskRunOnce(ctx context.Context, taskRun *store.TaskRunMessage, task *store.TaskMessage, executor Executor) {
 	defer func() {
 		s.stateCfg.TaskRunExecutionStatuses.Delete(taskRun.ID)
-
-		s.stateCfg.RunningTaskRuns.Delete(taskRun.ID)
+		// We don't need to do s.stateCfg.RunningTaskRuns.Delete(taskRun.ID) to avoid race condition.
 		s.stateCfg.RunningTaskRunsCancelFunc.Delete(taskRun.ID)
 		s.stateCfg.Lock()
 		s.stateCfg.InstanceOutstandingConnections[task.InstanceID]--


### PR DESCRIPTION
1. We only run task run once.
2. We don't have huge amount of task runs. It's not quite costly if we keep it in memory.
3. There is a race condition between task runs from ListTaskRuns() and evicting the task run ID on completion.