### PR TITLE
chore(frontend): issue search improvements

### DIFF
--- a/frontend/src/components/v2/TabFilter/TabFilter.vue
+++ b/frontend/src/components/v2/TabFilter/TabFilter.vue
@@ -22,7 +22,7 @@
         class="rounded-md text-sm px-3 py-1 flex items-center disabled:cursor-not-allowed transition-colors duration-150"
         :class="[
           value === item.value
-            ? 'bg-gray-200 text-gray-800 disabled:bg-gray-100'
+            ? 'bg-gray-200 text-gray-800'
             : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100 disabled:text-gray-300 disabled:bg-transparent',
         ]"
         @click.prevent="update(item.value)"


### PR DESCRIPTION
Following #9350 

- Repurpose "Recently Closed" to "All", and enable both "OPEN" and "CLOSED" for it.
- "Approval Requested", "Waiting Approval" and "Waiting Rollout" now only enable "OPEN" in the secondary tab bar.
- Remove redundant `ListIssues` requests.
- Display a loading spinner when changing tabs.