### PR TITLE
chore: update sidebar chevron direction

### DIFF
--- a/frontend/src/components/CommonSidebar.vue
+++ b/frontend/src/components/CommonSidebar.vue
@@ -21,8 +21,11 @@
           <component :is="item.icon" class="mr-2 w-5 h-5 text-gray-500" />
           {{ item.title }}
           <div v-if="item.children.length > 0" class="ml-auto text-gray-500">
-            <ChevronDown v-if="!state.expandedSidebar.has(i)" class="w-4 h-4" />
-            <ChevronUp v-else class="w-4 h-4" />
+            <ChevronRight
+              v-if="!state.expandedSidebar.has(i)"
+              class="w-4 h-4"
+            />
+            <ChevronDown v-else class="w-4 h-4" />
           </div>
         </div>
         <div
@@ -54,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-import { ChevronDown, ChevronUp } from "lucide-vue-next";
+import { ChevronDown, ChevronRight } from "lucide-vue-next";
 import { computed, VNode, reactive, onMounted } from "vue";
 
 export interface SidebarItem {


### PR DESCRIPTION
It's common to see 1) right (unexpanded) and down (expanded), 2) up (unexpanded) and down (expanded), and 3) many others. We have up (unexpanded) and down (expanded) - first one. I haven't figured out a design pattern yet. But GitLab/Chrome/Google Admin and a few tools use right and down - second one for some reasons. Let's try out the second.

Now:
<img width="207" alt="Screenshot 2023-11-17 at 00 00 22" src="https://github.com/bytebase/bytebase/assets/98006139/5217a816-8197-4f0e-9095-4519ebc01fe1">
Before:
<img width="204" alt="Screenshot 2023-11-17 at 00 00 52" src="https://github.com/bytebase/bytebase/assets/98006139/f771aecf-f558-4079-a260-740ede7cc353">

GitLab/Google Admin/Chrome:
<img width="264" alt="Screenshot 2023-11-16 at 23 58 58" src="https://github.com/bytebase/bytebase/assets/98006139/09d3d611-d295-45a4-8937-5f776beca043">
<img width="269" alt="Screenshot 2023-11-17 at 00 10 52" src="https://github.com/bytebase/bytebase/assets/98006139/61b86406-ed79-4f79-a80c-a7688eea8505">
<img width="681" alt="Screenshot 2023-11-17 at 00 12 22" src="https://github.com/bytebase/bytebase/assets/98006139/a8aa47ed-7574-4f56-b8c8-fbde21f23cca">
