### PR TITLE
chore: update time range in issue dashboard

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
+++ b/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
@@ -51,8 +51,7 @@ const tagProps = (scope: SearchScope): TagProps => {
 const renderValue = (scope: SearchScope, index: number) => {
   if (scope.id === "created") {
     const [begin, end] = scope.value.split(",").map((ts) => parseInt(ts, 10));
-    const format = "YYYY-MM-DD";
-    return [dayjs(begin).format(format), dayjs(end).format(format)].join(" – ");
+    return [dayjs(begin).format("L"), dayjs(end).format("L")].join("-");
   }
   return h("span", {}, scope.value);
 };

--- a/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
+++ b/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
@@ -52,9 +52,7 @@ const renderValue = (scope: SearchScope, index: number) => {
   if (scope.id === "created") {
     const [begin, end] = scope.value.split(",").map((ts) => parseInt(ts, 10));
     const format = "YYYY-MM-DD";
-    return [dayjs(begin).format(format), dayjs(end).format(format)].join(
-      " -> "
-    );
+    return [dayjs(begin).format(format), dayjs(end).format(format)].join(" – ");
   }
   return h("span", {}, scope.value);
 };

--- a/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
+++ b/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
@@ -51,7 +51,7 @@ const tagProps = (scope: SearchScope): TagProps => {
 const renderValue = (scope: SearchScope, index: number) => {
   if (scope.id === "created") {
     const [begin, end] = scope.value.split(",").map((ts) => parseInt(ts, 10));
-    return [dayjs(begin).format("L"), dayjs(end).format("L")].join("-");
+    return [dayjs(begin).format("L"), dayjs(end).format("L")].join(" - ");
   }
   return h("span", {}, scope.value);
 };

--- a/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
+++ b/frontend/src/components/IssueV1/components/IssueSearch/ScopeTags.vue
@@ -51,7 +51,7 @@ const tagProps = (scope: SearchScope): TagProps => {
 const renderValue = (scope: SearchScope, index: number) => {
   if (scope.id === "created") {
     const [begin, end] = scope.value.split(",").map((ts) => parseInt(ts, 10));
-    return [dayjs(begin).format("L"), dayjs(end).format("L")].join(" - ");
+    return [dayjs(begin).format("L"), dayjs(end).format("L")].join("-");
   }
   return h("span", {}, scope.value);
 };

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col gap-y-2 -mt-4">
     <IssueSearch
       v-model:params="state.params"
-      :components="['status', 'time-range']"
+      :components="['status']"
       :component-props="
         statusTabDisabled ? { status: { disabled: true } } : undefined
       "

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col">
     <IssueSearch
       v-model:params="state.params"
-      :components="['status', 'time-range']"
+      :components="['status']"
       :component-props="
         statusTabDisabled ? { status: { disabled: true } } : undefined
       "


### PR DESCRIPTION
1. Remove time range from home issue dashboard and project issue dashboard. Time range is considered to be an advanced search. It's also a bit ambiguous whether it's created time or last update time. Maybe we will add it back later if we combine the classic issue dashboard and advanced issue search dashboard. Or maybe it should be part of constructing scope tags instead of having a separate space for it.
2. Use "-" instead of " -> " separator and localized format to represent the time range.

https://learn.microsoft.com/en-us/style-guide/punctuation/dashes-hyphens/enes
https://day.js.org/docs/en/display/format

Now:
<img width="1202" alt="Screenshot 2023-11-17 at 00 35 30" src="https://github.com/bytebase/bytebase/assets/98006139/b3d33fb4-f5e8-4f6a-a410-e707fc064472">
Before:
<img width="1195" alt="Screenshot 2023-11-17 at 00 36 11" src="https://github.com/bytebase/bytebase/assets/98006139/9f2bb1d3-9394-43fa-a86f-40489fa5d9aa">

Now:
![image](https://github.com/bytebase/bytebase/assets/98006139/56777583-2911-482f-8351-e5021b1e1c0f)
Before:
<img width="946" alt="Screenshot 2023-11-17 at 00 36 33" src="https://github.com/bytebase/bytebase/assets/98006139/396d0c53-5209-458c-b69f-a23428c8749a">

