### PR TITLE
chore: rename workspace developer to member

### DIFF
--- a/frontend/src/components/Role/Setting/components/RoleTableRow.vue
+++ b/frontend/src/components/Role/Setting/components/RoleTableRow.vue
@@ -77,7 +77,7 @@ const title = computed(() => {
     return t("common.role.owner");
   }
   if (role.name === PresetRoleType.DEVELOPER) {
-    return t("common.role.developer");
+    return t("common.role.member");
   }
   if (role.name === PresetRoleType.EXPORTER) {
     return t("common.role.exporter");

--- a/frontend/src/components/User/Settings/UserTable.vue
+++ b/frontend/src/components/User/Settings/UserTable.vue
@@ -253,7 +253,7 @@ const dataSource = computed((): BBTableSectionDataSource<User>[] => {
   });
 
   dataSource.push({
-    title: t("common.role.developer"),
+    title: t("common.role.member"),
     list: developerList,
   });
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -78,7 +78,6 @@
       "self": "Role",
       "dba": "DBA",
       "owner": "Owner",
-      "developer": "Developer",
       "member": "Member",
       "exporter": "Exporter",
       "querier": "Querier",
@@ -1872,7 +1871,7 @@
       "member-placeholder": "Select user",
       "manage-member": "Manage members",
       "owner": "@.upper:common.role.owner",
-      "developer": "@.upper:common.role.developer",
+      "developer": "@.upper:common.role.member",
       "archive": {
         "title": "Archive project",
         "description": "Archived project will not be shown on the normal interface. You can click \"Archive\" on the bottom left to find and restore it.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1871,7 +1871,7 @@
       "member-placeholder": "Seleccionar usuario",
       "manage-member": "Administrar miembros",
       "owner": "@.upper:common.role.owner",
-      "developer": "@.upper:common.role.developer",
+      "developer": "@.upper:common.role.member",
       "archive": {
         "title": "Archivar proyecto",
         "description": "El proyecto archivado no se mostrará en la interfaz normal. Puede hacer clic en \"Archivar\" en la parte inferior izquierda para encontrarlo y restaurarlo.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1867,7 +1867,7 @@
       "member-placeholder": "选择用户",
       "manage-member": "管理成员",
       "owner": "@.upper:common.role.owner",
-      "developer": "@.upper:common.role.developer",
+      "developer": "@.upper:common.role.member",
       "archive": {
         "title": "归档项目",
         "description": "已归档的项目将不会显示在日常界面，您可以通过点击页面左下方的 \"归档\"来恢复。",

--- a/frontend/src/utils/role.ts
+++ b/frontend/src/utils/role.ts
@@ -197,7 +197,7 @@ export const extractRoleResourceName = (resourceId: string): string => {
 export const displayRoleTitle = (role: string): string => {
   // Use i18n-defined readable titles for system roles
   if (role === PresetRoleType.OWNER) return t("common.role.owner");
-  if (role === PresetRoleType.DEVELOPER) return t("common.role.developer");
+  if (role === PresetRoleType.DEVELOPER) return t("common.role.member");
   if (role === PresetRoleType.RELEASER) return t("common.role.releaser");
   if (role === PresetRoleType.EXPORTER) return t("common.role.exporter");
   if (role === PresetRoleType.QUERIER) return t("common.role.querier");

--- a/frontend/src/utils/v1/role.ts
+++ b/frontend/src/utils/v1/role.ts
@@ -8,7 +8,7 @@ export function roleNameV1(role: UserRole): string {
     case UserRole.DBA:
       return t("common.role.dba");
     case UserRole.DEVELOPER:
-      return t("common.role.developer");
+      return t("common.role.member");
   }
   return userRoleToJSON(role);
 }


### PR DESCRIPTION
Make a distinction between the developer (workspace developer) and the developer (project developer) by calling workspace developer -> member.

<img width="954" alt="Screenshot 2023-11-17 at 17 10 44" src="https://github.com/bytebase/bytebase/assets/98006139/04751aa9-05c6-4001-9e9d-52b302033770">
