### PR TITLE
chore: update assignee options

### DIFF
--- a/frontend/src/components/IssueV1/components/HeaderSection/Assignee/Assignee.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Assignee/Assignee.vue
@@ -181,13 +181,27 @@ const mapUserOptions = (users: User[]) => {
   };
 
   // Groups in order
+  // - current assignee
   // - approvers of current step (CI phase only)
   // - releasers of current stage (CD phase only)
   // - project owners
-  // - other project members
   // - other non-member assignee candidates
   //   - workspace owners
   //   - workspace DBAs
+  if (assigneeEmail.value) {
+    const assignee = userStore.getUserByEmail(assigneeEmail.value);
+    if (assignee) {
+      addGroup(
+        {
+          type: "group",
+          label: t("issue.assignee.current-assignee"),
+          key: "current-assignee",
+        },
+        [assignee]
+      );
+    }
+  }
+
   if (phase === "CI") {
     const steps = useWrappedReviewStepsV1(issue, reviewContext);
     const currentStep = steps.value?.find((step) => step.status === "CURRENT");
@@ -222,17 +236,6 @@ const mapUserOptions = (users: User[]) => {
       key: "project-owners",
     },
     projectOwners
-  );
-  const projectMembers = users.filter((user) =>
-    isMemberOfProjectV1(project.iamPolicy, user)
-  );
-  addGroup(
-    {
-      type: "group",
-      label: t("issue.assignee.project-members"),
-      key: "project-members",
-    },
-    projectMembers
   );
 
   // Add non-project members (workspace admins and DBAs)

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1116,7 +1116,7 @@
     },
     "approval-requested": "Approval Requested",
     "assignee": {
-      "project-members": "Project members",
+      "current-assignee": "Current assignee",
       "workspace-admins": "Workspace admins",
       "workspace-dbas": "DBA",
       "project-owners": "Project owners",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1115,7 +1115,7 @@
     },
     "approval-requested": "Aprobación solicitada",
     "assignee": {
-      "project-members": "Miembros del proyecto",
+      "current-assignee": "Asignatario actual",
       "workspace-admins": "Administrador del espacio de trabajo",
       "workspace-dbas": "DBA",
       "project-owners": "Propietarios del proyecto",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1113,7 +1113,7 @@
     },
     "approval-requested": "审批请求",
     "assignee": {
-      "project-members": "项目成员",
+      "current-assignee": "当前指派人",
       "workspace-admins": "Bytebase 工作空间管理员",
       "workspace-dbas": "DBA",
       "project-owners": "项目所有者",


### PR DESCRIPTION
1. Show current assignee, otherwise we will get unknown user error.
2. Remove project member group since it could be too noisy to show.

Before:
<img width="376" alt="Screenshot 2023-11-19 at 19 20 58" src="https://github.com/bytebase/bytebase/assets/98006139/25ba337f-3afa-4cdc-85e9-a67485d3dea8">

