### PR TITLE
chore(sql-editor): some minor fixes

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -53,7 +53,7 @@ const { t } = useI18n();
 const isLoading = ref<boolean>(true);
 
 const currentUserV1 = useCurrentUserV1();
-const projectStpre = useProjectV1Store();
+const projectStore = useProjectV1Store();
 const instanceStore = useInstanceV1Store();
 const databaseStore = useDatabaseV1Store();
 const policyV1Store = usePolicyV1Store();
@@ -99,7 +99,7 @@ const initializeTree = async () => {
   const projectName = route.query.project;
   if (projectName) {
     try {
-      const project = await projectStpre.getOrFetchProjectByName(
+      const project = await projectStore.getOrFetchProjectByName(
         `${projectNamePrefix}${projectName}`,
         true /* silent */
       );

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -313,9 +313,12 @@ const syncURLWithConnection = () => {
 
 onMounted(async () => {
   await useUserStore().fetchUserList();
+  await useSettingV1Store().fetchSettingList();
 
   if (treeStore.state === "UNSET") {
     treeStore.state = "LOADING";
+    await setConnectionFromQuery();
+    await sqlEditorStore.fetchQueryHistoryList();
 
     // Initialize project list state for iam policy.
     await useProjectV1Store().fetchProjectList(true /* include archived */);
@@ -341,10 +344,6 @@ onMounted(async () => {
       }
     }
   );
-
-  await setConnectionFromQuery();
-  await sqlEditorStore.fetchQueryHistoryList();
-  await useSettingV1Store().fetchSettingList();
 
   syncURLWithConnection();
   isLoading.value = false;

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -317,8 +317,6 @@ onMounted(async () => {
 
   if (treeStore.state === "UNSET") {
     treeStore.state = "LOADING";
-    await setConnectionFromQuery();
-    await sqlEditorStore.fetchQueryHistoryList();
 
     // Initialize project list state for iam policy.
     await useProjectV1Store().fetchProjectList(true /* include archived */);
@@ -329,6 +327,9 @@ onMounted(async () => {
     await usePolicyV1Store().getOrFetchPolicyByName("policies/WORKSPACE_IAM");
     await prepareAccessControlPolicy();
     await prepareAccessibleDatabaseList();
+
+    await setConnectionFromQuery();
+    await sqlEditorStore.fetchQueryHistoryList();
 
     await initializeTree();
     treeStore.state = "READY";

--- a/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/DatabaseTree.vue
@@ -16,7 +16,11 @@
         </template>
       </NInput>
     </div>
-    <div class="sql-editor-tree--tree flex-1 overflow-y-auto select-none">
+    <div
+      ref="treeContainerElRef"
+      class="sql-editor-tree--tree flex-1 pb-1 text-sm overflow-hidden select-none"
+      :data-height="treeContainerHeight"
+    >
       <NTree
         ref="treeRef"
         v-model:expanded-keys="treeStore.expandedKeys"
@@ -58,7 +62,7 @@
 </template>
 
 <script lang="ts" setup>
-import { useMounted, useThrottleFn } from "@vueuse/core";
+import { useElementSize, useMounted, useThrottleFn } from "@vueuse/core";
 import { head } from "lodash-es";
 import { NTree, NInput, NDropdown, DropdownOption, TreeOption } from "naive-ui";
 import { storeToRefs } from "pinia";
@@ -140,6 +144,14 @@ const hoverPanelPosition = ref<Position>({
 });
 
 const mounted = useMounted();
+const treeContainerElRef = ref<HTMLElement>();
+const { height: treeContainerHeight } = useElementSize(
+  treeContainerElRef,
+  undefined,
+  {
+    box: "content-box",
+  }
+);
 const treeRef = ref<InstanceType<typeof NTree>>();
 const throttledSearchPattern = ref(props.searchPattern);
 const showDropdown = ref(false);


### PR DESCRIPTION
- Explicitly set tree height to avoid virtual list overheads
- Recover `tabList` and `expandedKeys` correctly after the `localStorage` has been cleared. FYI @boojack 