### PR TITLE
chore: support table constraint in create-table statement

### DIFF
--- a/backend/plugin/advisor/catalog/test/mysqlv2_walk_through.yaml
+++ b/backend/plugin/advisor/catalog/test/mysqlv2_walk_through.yaml
@@ -1,5 +1,99 @@
 - statement: |-
     CREATE TABLE t1(
+      a INT PRIMARY KEY,
+      b INT NOT NULL DEFAULT 1,
+      c INT,
+      d VARCHAR(255) NOT NULL,
+      e VARCHAR(255),
+      UNIQUE KEY uk1 (b, c),
+      KEY idx1 (c),
+      FULLTEXT(d, e) WITH PARSER ngram INVISIBLE
+    );
+  ignore_case_sensitive: false
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "type": "int"
+                },
+                {
+                  "name": "b",
+                  "position": 2,
+                  "default": "1",
+                  "type": "int"
+                },
+                {
+                  "name": "c",
+                  "position": 3,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "d",
+                  "position": 4,
+                  "type": "varchar"
+                },
+                {
+                  "name": "e",
+                  "position": 5,
+                  "nullable": true,
+                  "type": "varchar"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "PRIMARY",
+                  "expressions": [
+                    "a"
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
+                },
+                {
+                  "name": "d",
+                  "expressions": [
+                    "d",
+                    "e"
+                  ],
+                  "type": "FULLTEXT"
+                },
+                {
+                  "name": "idx1",
+                  "expressions": [
+                    "c"
+                  ],
+                  "type": "BTREE",
+                  "visible": true
+                },
+                {
+                  "name": "uk1",
+                  "expressions": [
+                    "b",
+                    "c"
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  err: null
+- statement: |-
+    CREATE TABLE t1(
       a INT NOT NULL DEFAULT NULL
     );
   ignore_case_sensitive: false
@@ -43,70 +137,70 @@
   ignore_case_sensitive: false
   want: |-
     {
-      "name":  "test",
-      "schemas":  [
+      "name": "test",
+      "schemas": [
         {
-          "tables":  [
+          "tables": [
             {
-              "name":  "t1",
-              "columns":  [
+              "name": "t1",
+              "columns": [
                 {
-                  "name":  "a",
-                  "position":  1,
-                  "default":  "1",
-                  "type":  "int"
+                  "name": "a",
+                  "position": 1,
+                  "default": "1",
+                  "type": "int"
                 },
                 {
-                  "name":  "b",
-                  "position":  2,
-                  "nullable":  true,
-                  "type":  "int"
+                  "name": "b",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "int"
                 },
                 {
-                  "name":  "c",
-                  "position":  3,
-                  "default":  "NULL",
-                  "type":  "varchar",
-                  "comment":  "column c"
+                  "name": "c",
+                  "position": 3,
+                  "default": "NULL",
+                  "type": "varchar",
+                  "comment": "column c"
                 },
                 {
-                  "name":  "e",
-                  "position":  4,
-                  "nullable":  true,
-                  "type":  "int"
+                  "name": "e",
+                  "position": 4,
+                  "nullable": true,
+                  "type": "int"
                 },
                 {
-                  "name":  "f",
-                  "position":  5,
-                  "type":  "varchar",
-                  "collation":  "utf8mb4_polish_ci"
+                  "name": "f",
+                  "position": 5,
+                  "type": "varchar",
+                  "collation": "utf8mb4_polish_ci"
                 },
                 {
-                  "name":  "g",
-                  "position":  6,
-                  "type":  "varchar",
-                  "characterSet":  "utf8mb4"
+                  "name": "g",
+                  "position": 6,
+                  "type": "varchar",
+                  "characterSet": "utf8mb4"
                 }
               ],
-              "indexes":  [
+              "indexes": [
                 {
-                  "name":  "PRIMARY",
-                  "expressions":  [
+                  "name": "PRIMARY",
+                  "expressions": [
                     "a"
                   ],
-                  "type":  "BTREE",
-                  "unique":  true,
-                  "primary":  true,
-                  "visible":  true
+                  "type": "BTREE",
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
                 },
                 {
-                  "name":  "b",
-                  "expressions":  [
+                  "name": "b",
+                  "expressions": [
                     "b"
                   ],
-                  "type":  "BTREE",
-                  "unique":  true,
-                  "visible":  true
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
                 }
               ]
             }


### PR DESCRIPTION
Support create constraint in `create table` statement. 

Although antlr parser. supports creating index in the `create table` statement which tidb parser does not support, we only do migration this time.
 