### PR TITLE
fix: project developer can only see "Databases" in the sidebar

### DIFF
--- a/frontend/src/components/Project/ProjectSidebar.vue
+++ b/frontend/src/components/Project/ProjectSidebar.vue
@@ -96,7 +96,7 @@ watch(
 );
 
 const project = computed(() => {
-  if (issue.value) {
+  if (props.issueSlug) {
     return issue.value.projectEntity;
   } else if (props.projectSlug) {
     return projectV1Store.getProjectByUID(


### PR DESCRIPTION
This should close BYT-4492. Need CP to 2.11.1