### PR TITLE
fix: pg semantic version

### DIFF
--- a/backend/component/dbfactory/dbfactory.go
+++ b/backend/component/dbfactory/dbfactory.go
@@ -198,7 +198,8 @@ func (d *DBFactory) GetDataSourceDriver(ctx context.Context, instance *store.Ins
 			SchemaTenantMode:       schemaTenantMode,
 		},
 		db.ConnectionContext{
-			InstanceID: instance.ResourceID,
+			InstanceID:    instance.ResourceID,
+			EngineVersion: instance.EngineVersion,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Previously, it's 9.624. Now it should be 9.6.24.