### PR TITLE
chore: migrate_statement_type_executor_mysql to antlr

### DIFF
--- a/backend/plugin/parser/mysql/statement_type_check.go
+++ b/backend/plugin/parser/mysql/statement_type_check.go
@@ -61,99 +61,175 @@ func (checker *StatementTypeChecker) EnterQuery(ctx *mysql.QueryContext) {
 // truncateTableStatement
 // importStatement
 // EnterAlterStatement is called when production alterStatement is entered.
-func (checker *StatementTypeChecker) EnterAlterStatement(_ *mysql.AlterStatementContext) {
-	checker.IsDDL = true
+func (checker *StatementTypeChecker) EnterAlterStatement(ctx *mysql.AlterStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDDL = true
+		}
+	}
 }
 
 // EnterCreateStatement is called when production createStatement is entered.
-func (checker *StatementTypeChecker) EnterCreateStatement(_ *mysql.CreateStatementContext) {
-	checker.IsDDL = true
+func (checker *StatementTypeChecker) EnterCreateStatement(ctx *mysql.CreateStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDDL = true
+		}
+	}
 }
 
 // EnterDropStatement is called when production dropStatement is entered.
-func (checker *StatementTypeChecker) EnterDropStatement(_ *mysql.DropStatementContext) {
-	checker.IsDDL = true
+func (checker *StatementTypeChecker) EnterDropStatement(ctx *mysql.DropStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDDL = true
+		}
+	}
 }
 
 // EnterRenameTableStatement is called when production renameTableStatement is entered.
-func (checker *StatementTypeChecker) EnterRenameTableStatement(_ *mysql.RenameTableStatementContext) {
-	checker.IsDDL = true
+func (checker *StatementTypeChecker) EnterRenameTableStatement(ctx *mysql.RenameTableStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDDL = true
+		}
+	}
 }
 
 // EnterTruncateTableStatement is called when production truncateTableStatement is entered.
-func (checker *StatementTypeChecker) EnterTruncateTableStatement(_ *mysql.TruncateTableStatementContext) {
-	checker.IsDDL = true
+func (checker *StatementTypeChecker) EnterTruncateTableStatement(ctx *mysql.TruncateTableStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDDL = true
+		}
+	}
 }
 
 // EnterImportStatement is called when production importStatement is entered.
-func (checker *StatementTypeChecker) EnterImportStatement(_ *mysql.ImportStatementContext) {
-	checker.IsDDL = true
+func (checker *StatementTypeChecker) EnterImportStatement(ctx *mysql.ImportStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDDL = true
+		}
+	}
 }
 
 // EnterExplainStatement is called when production explainStatement is entered.
-func (checker *StatementTypeChecker) EnterExplainStatement(_ *mysql.ExplainStatementContext) {
-	checker.IsExplain = true
+func (checker *StatementTypeChecker) EnterExplainStatement(ctx *mysql.ExplainStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDDL = true
+		}
+	}
 }
 
 // DML
 // EnterCallStatement is called when production callStatement is entered.
-func (checker *StatementTypeChecker) EnterCallStatement(_ *mysql.CallStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterCallStatement(ctx *mysql.CallStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterDeleteStatement is called when production deleteStatement is entered.
-func (checker *StatementTypeChecker) EnterDeleteStatement(_ *mysql.DeleteStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterDeleteStatement(ctx *mysql.DeleteStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterDoStatement is called when production doStatement is entered.
-func (checker *StatementTypeChecker) EnterDoStatement(_ *mysql.DoStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterDoStatement(ctx *mysql.DoStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterHandlerStatement is called when production handlerStatement is entered.
-func (checker *StatementTypeChecker) EnterHandlerStatement(_ *mysql.HandlerStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterHandlerStatement(ctx *mysql.HandlerStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterInsertStatement is called when production insertStatement is entered.
-func (checker *StatementTypeChecker) EnterInsertStatement(_ *mysql.InsertStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterInsertStatement(ctx *mysql.InsertStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterLoadDataFileTail is called when production loadDataFileTail is entered.
-func (checker *StatementTypeChecker) EnterLoadDataFileTail(_ *mysql.LoadDataFileTailContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterLoadDataFileTail(ctx *mysql.LoadDataFileTailContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterReplaceStatement is called when production replaceStatement is entered.
-func (checker *StatementTypeChecker) EnterReplaceStatement(_ *mysql.ReplaceStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterReplaceStatement(ctx *mysql.ReplaceStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterSelectStatement is called when production selectStatement is entered.
-func (checker *StatementTypeChecker) EnterSelectStatement(_ *mysql.SelectStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterSelectStatement(ctx *mysql.SelectStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterUpdateStatement is called when production updateStatement is entered.
-func (checker *StatementTypeChecker) EnterUpdateStatement(_ *mysql.UpdateStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterUpdateStatement(ctx *mysql.UpdateStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterTransactionOrLockingStatement is called when production transactionOrLockingStatement is entered.
-func (checker *StatementTypeChecker) EnterTransactionOrLockingStatement(_ *mysql.TransactionOrLockingStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterTransactionOrLockingStatement(ctx *mysql.TransactionOrLockingStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterReplicationStatement is called when production replicationStatement is entered.
-func (checker *StatementTypeChecker) EnterReplicationStatement(_ *mysql.ReplicationStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterReplicationStatement(ctx *mysql.ReplicationStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 // EnterPreparedStatement is called when production preparedStatement is entered.
-func (checker *StatementTypeChecker) EnterPreparedStatement(_ *mysql.PreparedStatementContext) {
-	checker.IsDML = true
+func (checker *StatementTypeChecker) EnterPreparedStatement(ctx *mysql.PreparedStatementContext) {
+	if parent, ok := ctx.GetParent().(*mysql.SimpleStatementContext); ok {
+		if _, ok := parent.GetParent().(*mysql.QueryContext); ok {
+			checker.IsDML = true
+		}
+	}
 }
 
 type SDLTypeChecker struct {

--- a/backend/plugin/parser/mysql/statement_type_check.go
+++ b/backend/plugin/parser/mysql/statement_type_check.go
@@ -1,0 +1,308 @@
+package mysql
+
+import (
+	"fmt"
+
+	mysql "github.com/bytebase/mysql-parser"
+
+	"github.com/bytebase/bytebase/backend/common"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+)
+
+type CreateAndDropDatabaseChecker struct {
+	*mysql.BaseMySQLParserListener
+
+	Text    string
+	Results []*storepb.PlanCheckRunResult_Result
+}
+
+func (checker *CreateAndDropDatabaseChecker) EnterQuery(ctx *mysql.QueryContext) {
+	checker.Text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
+}
+
+// EnterCreateDatabase is called when production createDatabase is entered.
+func (checker *CreateAndDropDatabaseChecker) EnterCreateDatabase(_ *mysql.CreateDatabaseContext) {
+	checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+		Status:  storepb.PlanCheckRunResult_Result_ERROR,
+		Code:    common.TaskTypeCreateDatabase.Int32(),
+		Title:   "Cannot create database",
+		Content: fmt.Sprintf(`The statement "%s" creates database`, checker.Text),
+	})
+}
+
+// EnterDropDatabase is called when production dropDatabase is entered.
+func (checker *CreateAndDropDatabaseChecker) EnterDropDatabase(_ *mysql.DropDatabaseContext) {
+	checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+		Status:  storepb.PlanCheckRunResult_Result_ERROR,
+		Code:    common.TaskTypeDropDatabase.Int32(),
+		Title:   "Cannot drop database",
+		Content: fmt.Sprintf(`The statement "%s" drops database`, checker.Text),
+	})
+}
+
+type StatementTypeChecker struct {
+	*mysql.BaseMySQLParserListener
+
+	IsDDL     bool
+	IsDML     bool
+	IsExplain bool
+	Text      string
+}
+
+func (checker *StatementTypeChecker) EnterQuery(ctx *mysql.QueryContext) {
+	checker.Text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
+}
+
+// DDL from g4
+// alterStatement
+// createStatement
+// dropStatement
+// renameTableStatement
+// truncateTableStatement
+// importStatement
+// EnterAlterStatement is called when production alterStatement is entered.
+func (checker *StatementTypeChecker) EnterAlterStatement(_ *mysql.AlterStatementContext) {
+	checker.IsDDL = true
+}
+
+// EnterCreateStatement is called when production createStatement is entered.
+func (checker *StatementTypeChecker) EnterCreateStatement(_ *mysql.CreateStatementContext) {
+	checker.IsDDL = true
+}
+
+// EnterDropStatement is called when production dropStatement is entered.
+func (checker *StatementTypeChecker) EnterDropStatement(_ *mysql.DropStatementContext) {
+	checker.IsDDL = true
+}
+
+// EnterRenameTableStatement is called when production renameTableStatement is entered.
+func (checker *StatementTypeChecker) EnterRenameTableStatement(_ *mysql.RenameTableStatementContext) {
+	checker.IsDDL = true
+}
+
+// EnterTruncateTableStatement is called when production truncateTableStatement is entered.
+func (checker *StatementTypeChecker) EnterTruncateTableStatement(_ *mysql.TruncateTableStatementContext) {
+	checker.IsDDL = true
+}
+
+// EnterImportStatement is called when production importStatement is entered.
+func (checker *StatementTypeChecker) EnterImportStatement(_ *mysql.ImportStatementContext) {
+	checker.IsDDL = true
+}
+
+// EnterExplainStatement is called when production explainStatement is entered.
+func (checker *StatementTypeChecker) EnterExplainStatement(_ *mysql.ExplainStatementContext) {
+	checker.IsExplain = true
+}
+
+// DML
+// EnterCallStatement is called when production callStatement is entered.
+func (checker *StatementTypeChecker) EnterCallStatement(_ *mysql.CallStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterDeleteStatement is called when production deleteStatement is entered.
+func (checker *StatementTypeChecker) EnterDeleteStatement(_ *mysql.DeleteStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterDoStatement is called when production doStatement is entered.
+func (checker *StatementTypeChecker) EnterDoStatement(_ *mysql.DoStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterHandlerStatement is called when production handlerStatement is entered.
+func (checker *StatementTypeChecker) EnterHandlerStatement(_ *mysql.HandlerStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterInsertStatement is called when production insertStatement is entered.
+func (checker *StatementTypeChecker) EnterInsertStatement(_ *mysql.InsertStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterLoadDataFileTail is called when production loadDataFileTail is entered.
+func (checker *StatementTypeChecker) EnterLoadDataFileTail(_ *mysql.LoadDataFileTailContext) {
+	checker.IsDML = true
+}
+
+// EnterReplaceStatement is called when production replaceStatement is entered.
+func (checker *StatementTypeChecker) EnterReplaceStatement(_ *mysql.ReplaceStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterSelectStatement is called when production selectStatement is entered.
+func (checker *StatementTypeChecker) EnterSelectStatement(_ *mysql.SelectStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterUpdateStatement is called when production updateStatement is entered.
+func (checker *StatementTypeChecker) EnterUpdateStatement(_ *mysql.UpdateStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterTransactionOrLockingStatement is called when production transactionOrLockingStatement is entered.
+func (checker *StatementTypeChecker) EnterTransactionOrLockingStatement(_ *mysql.TransactionOrLockingStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterReplicationStatement is called when production replicationStatement is entered.
+func (checker *StatementTypeChecker) EnterReplicationStatement(_ *mysql.ReplicationStatementContext) {
+	checker.IsDML = true
+}
+
+// EnterPreparedStatement is called when production preparedStatement is entered.
+func (checker *StatementTypeChecker) EnterPreparedStatement(_ *mysql.PreparedStatementContext) {
+	checker.IsDML = true
+}
+
+type SDLTypeChecker struct {
+	*mysql.BaseMySQLParserListener
+
+	baseLine int
+	Results  []*storepb.PlanCheckRunResult_Result
+}
+
+// for SDL.
+// EnterDropTable is called when production dropTable is entered.
+func (checker *SDLTypeChecker) EnterDropTable(ctx *mysql.DropTableContext) {
+	if ctx.TableRefList() == nil {
+		return
+	}
+
+	for _, tableRef := range ctx.TableRefList().AllTableRef() {
+		_, tableName := NormalizeMySQLTableRef(tableRef)
+		checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+			Status:  storepb.PlanCheckRunResult_Result_WARNING,
+			Code:    common.TaskTypeDropTable.Int32(),
+			Title:   "Plan to drop table",
+			Content: fmt.Sprintf("Plan to drop table `%s`", tableName),
+			Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+				SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+					Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+					Detail: "",
+					Code:   0,
+				},
+			},
+		})
+	}
+}
+
+// EnterDropIndex is called when production dropIndex is entered.
+func (checker *SDLTypeChecker) EnterDropIndex(ctx *mysql.DropIndexContext) {
+	if ctx.IndexRef() == nil || ctx.TableRef() == nil {
+		return
+	}
+
+	_, _, indexName := NormalizeIndexRef(ctx.IndexRef())
+	_, tableName := NormalizeMySQLTableRef(ctx.TableRef())
+	checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+		Status:  storepb.PlanCheckRunResult_Result_WARNING,
+		Code:    common.TaskTypeDropIndex.Int32(),
+		Title:   "Plan to drop index",
+		Content: fmt.Sprintf("Plan to drop index `%s` on table `%s`", indexName, tableName),
+		Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+			SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+				Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+				Detail: "",
+				Code:   0,
+			},
+		},
+	})
+}
+
+// EnterAlterTable is called when production alterTable is entered.
+func (checker *SDLTypeChecker) EnterAlterTable(ctx *mysql.AlterTableContext) {
+	if ctx.TableRef() == nil {
+		// todo: maybe need to do error handle.
+		return
+	}
+
+	_, tableName := NormalizeMySQLTableRef(ctx.TableRef())
+
+	if ctx.AlterTableActions() == nil {
+		return
+	}
+	if ctx.AlterTableActions().AlterCommandList() == nil {
+		return
+	}
+	if ctx.AlterTableActions().AlterCommandList().AlterList() == nil {
+		return
+	}
+
+	for _, alterListItem := range ctx.AlterTableActions().AlterCommandList().AlterList().AllAlterListItem() {
+		if alterListItem == nil {
+			continue
+		}
+
+		switch {
+		case alterListItem.DROP_SYMBOL() != nil:
+			switch {
+			// drop column.
+			case alterListItem.ColumnInternalRef() != nil:
+				columnName := NormalizeMySQLColumnInternalRef(alterListItem.ColumnInternalRef())
+				checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropColumn.Int32(),
+					Title:   "Plan to drop column",
+					Content: fmt.Sprintf("Plan to drop column `%s` on table `%s`", columnName, tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + alterListItem.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			// drop primary key.
+			case alterListItem.PRIMARY_SYMBOL() != nil && alterListItem.KEY_SYMBOL() != nil:
+				checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropPrimaryKey.Int32(),
+					Title:   "Plan to drop primary key",
+					Content: fmt.Sprintf("Plan to drop primary key on table `%s`", tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			// drop foreign key.
+			case alterListItem.FOREIGN_SYMBOL() != nil && alterListItem.KEY_SYMBOL() != nil && alterListItem.ColumnInternalRef() != nil:
+				name := NormalizeMySQLColumnInternalRef(alterListItem.ColumnInternalRef())
+				checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropForeignKey.Int32(),
+					Title:   "Plan to drop foreign key",
+					Content: fmt.Sprintf("Plan to drop foreign key `%s` on table `%s`", name, tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			// drop check.
+			case alterListItem.CHECK_SYMBOL() != nil && alterListItem.Identifier() != nil:
+				constraintName := NormalizeMySQLIdentifier(alterListItem.Identifier())
+				checker.Results = append(checker.Results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropCheck.Int32(),
+					Title:   "Plan to drop check constraint",
+					Content: fmt.Sprintf("Plan to drop check constraint `%s` on table `%s`", constraintName, tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			}
+		default:
+		}
+	}
+}

--- a/backend/runner/plancheck/statement_type_executor.go
+++ b/backend/runner/plancheck/statement_type_executor.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/antlr4-go/antlr/v4"
 	tidbp "github.com/pingcap/tidb/parser"
 	tidbast "github.com/pingcap/tidb/parser/ast"
 	"github.com/pkg/errors"
+
+	mysql "github.com/bytebase/mysql-parser"
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	api "github.com/bytebase/bytebase/backend/legacyapi"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	"github.com/bytebase/bytebase/backend/plugin/parser/sql/ast"
 	pgrawparser "github.com/bytebase/bytebase/backend/plugin/parser/sql/engine/pg"
 	tidbparser "github.com/bytebase/bytebase/backend/plugin/parser/tidb"
@@ -125,8 +129,21 @@ func (e *StatementTypeExecutor) runForDatabaseTarget(ctx context.Context, config
 			return nil, err
 		}
 		results = append(results, checkResults...)
-	case storepb.Engine_MYSQL, storepb.Engine_TIDB, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE:
-		checkResults, err := mysqlStatementTypeCheck(renderedStatement, dbSchema.GetMetadata().CharacterSet, dbSchema.GetMetadata().Collation, changeType)
+	case storepb.Engine_TIDB:
+		checkResults, err := tidbStatementTypeCheck(renderedStatement, dbSchema.GetMetadata().CharacterSet, dbSchema.GetMetadata().Collation, changeType)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, checkResults...)
+		if changeType == storepb.PlanCheckRunConfig_SDL {
+			sdlAdvice, err := e.tidbSDLTypeCheck(ctx, renderedStatement, instance, database)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, sdlAdvice...)
+		}
+	case storepb.Engine_MYSQL, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE:
+		checkResults, err := mysqlStatementTypeCheck(renderedStatement, changeType)
 		if err != nil {
 			return nil, err
 		}
@@ -287,8 +304,21 @@ func (e *StatementTypeExecutor) runForDatabaseGroupTarget(ctx context.Context, c
 						return nil, err
 					}
 					results = append(results, checkResults...)
-				case storepb.Engine_MYSQL, storepb.Engine_TIDB, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE:
-					checkResults, err := mysqlStatementTypeCheck(renderedStatement, dbSchema.GetMetadata().CharacterSet, dbSchema.GetMetadata().Collation, changeType)
+				case storepb.Engine_TIDB:
+					checkResults, err := tidbStatementTypeCheck(renderedStatement, dbSchema.GetMetadata().CharacterSet, dbSchema.GetMetadata().Collation, changeType)
+					if err != nil {
+						return nil, err
+					}
+					results = append(results, checkResults...)
+					if changeType == storepb.PlanCheckRunConfig_SDL {
+						sdlAdvice, err := e.tidbSDLTypeCheck(ctx, renderedStatement, instance, database)
+						if err != nil {
+							return nil, err
+						}
+						results = append(results, sdlAdvice...)
+					}
+				case storepb.Engine_MYSQL, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE:
+					checkResults, err := mysqlStatementTypeCheck(renderedStatement, changeType)
 					if err != nil {
 						return nil, err
 					}
@@ -335,7 +365,7 @@ func (e *StatementTypeExecutor) runForDatabaseGroupTarget(ctx context.Context, c
 	return results, nil
 }
 
-func (e *StatementTypeExecutor) mysqlSDLTypeCheck(ctx context.Context, newSchema string, instance *store.InstanceMessage, database *store.DatabaseMessage) ([]*storepb.PlanCheckRunResult_Result, error) {
+func (e *StatementTypeExecutor) tidbSDLTypeCheck(ctx context.Context, newSchema string, instance *store.InstanceMessage, database *store.DatabaseMessage) ([]*storepb.PlanCheckRunResult_Result, error) {
 	ddl, err := runnerutils.ComputeDatabaseSchemaDiff(ctx, instance, database, e.dbFactory, newSchema)
 	if err != nil {
 		return nil, err
@@ -456,7 +486,7 @@ func (e *StatementTypeExecutor) mysqlSDLTypeCheck(ctx context.Context, newSchema
 	return results, nil
 }
 
-func mysqlCreateAndDropDatabaseCheck(nodeList []tidbast.StmtNode) []*storepb.PlanCheckRunResult_Result {
+func tidbCreateAndDropDatabaseCheck(nodeList []tidbast.StmtNode) []*storepb.PlanCheckRunResult_Result {
 	var results []*storepb.PlanCheckRunResult_Result
 	for _, node := range nodeList {
 		switch node.(type) {
@@ -480,7 +510,406 @@ func mysqlCreateAndDropDatabaseCheck(nodeList []tidbast.StmtNode) []*storepb.Pla
 	return results
 }
 
-func mysqlStatementTypeCheck(statement string, charset string, collation string, changeType storepb.PlanCheckRunConfig_ChangeDatabaseType) ([]*storepb.PlanCheckRunResult_Result, error) {
+func mysqlStatementTypeCheck(statement string, changeType storepb.PlanCheckRunConfig_ChangeDatabaseType) ([]*storepb.PlanCheckRunResult_Result, error) {
+	stmts, err := mysqlparser.ParseMySQL(statement)
+	if err != nil {
+		// nolint:nilerr
+		return []*storepb.PlanCheckRunResult_Result{
+			{
+				Status:  storepb.PlanCheckRunResult_Result_ERROR,
+				Code:    0,
+				Title:   "Syntax error",
+				Content: err.Error(),
+				Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+					SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+						Line:   0,
+						Detail: "",
+						Code:   advisor.StatementSyntaxError.Int32(),
+					},
+				},
+			},
+		}, nil
+	}
+
+	var results []*storepb.PlanCheckRunResult_Result
+
+	// Disallow CREATE/DROP DATABASE statements.
+	results = append(results, mysqlCreateAndDropDatabaseCheck(stmts)...)
+
+	switch changeType {
+	case storepb.PlanCheckRunConfig_DML:
+		for _, node := range stmts {
+			checker := &mysqlTypeChecker{}
+			antlr.ParseTreeWalkerDefault.Walk(checker, node.Tree)
+			// We only want to disallow DDL statements in CHANGE DATA.
+			// We need to run some common statements, e.g. COMMIT.
+			if checker.isDDL {
+				results = append(results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Title:   "Data change can only run DML",
+					Content: fmt.Sprintf("\"%s\" is not DML", checker.text),
+					Code:    common.TaskTypeNotDML.Int32(),
+					Report:  nil,
+				})
+			}
+		}
+	case storepb.PlanCheckRunConfig_DDL, storepb.PlanCheckRunConfig_SDL:
+		for _, node := range stmts {
+			checker := &mysqlTypeChecker{}
+			antlr.ParseTreeWalkerDefault.Walk(checker, node.Tree)
+			if checker.isDML || checker.isExplain {
+				results = append(results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Title:   "Alter schema can only run DDL",
+					Content: fmt.Sprintf("\"%s\" is not DDL", checker.text),
+					Code:    common.TaskTypeNotDDL.Int32(),
+					Report:  nil,
+				})
+			}
+		}
+	default:
+		return nil, common.Errorf(common.Invalid, "invalid check statement type task type: %s", changeType)
+	}
+
+	return results, nil
+}
+
+func mysqlCreateAndDropDatabaseCheck(stmtList []*mysqlparser.ParseResult) []*storepb.PlanCheckRunResult_Result {
+	checker := &mysqlCreateAndDropDatabaseChecker{}
+	for _, stmt := range stmtList {
+		antlr.ParseTreeWalkerDefault.Walk(checker, stmt.Tree)
+	}
+
+	return checker.results
+}
+
+type mysqlCreateAndDropDatabaseChecker struct {
+	*mysql.BaseMySQLParserListener
+
+	text    string
+	results []*storepb.PlanCheckRunResult_Result
+}
+
+func (checker *mysqlCreateAndDropDatabaseChecker) EnterQuery(ctx *mysql.QueryContext) {
+	checker.text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
+}
+
+// EnterCreateDatabase is called when production createDatabase is entered.
+func (checker *mysqlCreateAndDropDatabaseChecker) EnterCreateDatabase(ctx *mysql.CreateDatabaseContext) {
+	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+		Status:  storepb.PlanCheckRunResult_Result_ERROR,
+		Code:    common.TaskTypeCreateDatabase.Int32(),
+		Title:   "Cannot create database",
+		Content: fmt.Sprintf(`The statement "%s" creates database`, checker.text),
+	})
+}
+
+// EnterDropDatabase is called when production dropDatabase is entered.
+func (checker *mysqlCreateAndDropDatabaseChecker) EnterDropDatabase(ctx *mysql.DropDatabaseContext) {
+	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+		Status:  storepb.PlanCheckRunResult_Result_ERROR,
+		Code:    common.TaskTypeDropDatabase.Int32(),
+		Title:   "Cannot drop database",
+		Content: fmt.Sprintf(`The statement "%s" drops database`, checker.text),
+	})
+}
+
+type mysqlTypeChecker struct {
+	*mysql.BaseMySQLParserListener
+
+	isDDL     bool
+	isDML     bool
+	isExplain bool
+	text      string
+}
+
+func (checker *mysqlTypeChecker) EnterQuery(ctx *mysql.QueryContext) {
+	checker.text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
+}
+
+// DDL from MySQLParser.g4
+// alterStatement
+// createStatement
+// dropStatement
+// renameTableStatement
+// truncateTableStatement
+// importStatement
+// EnterAlterStatement is called when production alterStatement is entered.
+func (checker *mysqlTypeChecker) EnterAlterStatement(ctx *mysql.AlterStatementContext) {
+	checker.isDDL = true
+}
+
+// EnterCreateStatement is called when production createStatement is entered.
+func (checker *mysqlTypeChecker) EnterCreateStatement(ctx *mysql.CreateStatementContext) {
+	checker.isDDL = true
+}
+
+// EnterDropStatement is called when production dropStatement is entered.
+func (checker *mysqlTypeChecker) EnterDropStatement(ctx *mysql.DropStatementContext) {
+	checker.isDDL = true
+}
+
+// EnterRenameTableStatement is called when production renameTableStatement is entered.
+func (checker *mysqlTypeChecker) EnterRenameTableStatement(ctx *mysql.RenameTableStatementContext) {
+	checker.isDDL = true
+}
+
+// EnterTruncateTableStatement is called when production truncateTableStatement is entered.
+func (checker *mysqlTypeChecker) EnterTruncateTableStatement(ctx *mysql.TruncateTableStatementContext) {
+	checker.isDDL = true
+}
+
+// EnterImportStatement is called when production importStatement is entered.
+func (checker *mysqlTypeChecker) EnterImportStatement(ctx *mysql.ImportStatementContext) {
+	checker.isDDL = true
+}
+
+// EnterExplainStatement is called when production explainStatement is entered.
+func (checker *mysqlTypeChecker) EnterExplainStatement(ctx *mysql.ExplainStatementContext) {
+	checker.isExplain = true
+}
+
+// DML
+// EnterCallStatement is called when production callStatement is entered.
+func (checker *mysqlTypeChecker) EnterCallStatement(ctx *mysql.CallStatementContext) {
+	checker.isDML = true
+}
+
+// EnterDeleteStatement is called when production deleteStatement is entered.
+func (checker *mysqlTypeChecker) EnterDeleteStatement(ctx *mysql.DeleteStatementContext) {
+	checker.isDML = true
+}
+
+// EnterDoStatement is called when production doStatement is entered.
+func (checker *mysqlTypeChecker) EnterDoStatement(ctx *mysql.DoStatementContext) {
+	checker.isDML = true
+}
+
+// EnterHandlerStatement is called when production handlerStatement is entered.
+func (checker *mysqlTypeChecker) EnterHandlerStatement(ctx *mysql.HandlerStatementContext) {
+	checker.isDML = true
+}
+
+// EnterInsertStatement is called when production insertStatement is entered.
+func (checker *mysqlTypeChecker) EnterInsertStatement(ctx *mysql.InsertStatementContext) {
+	checker.isDML = true
+}
+
+// EnterLoadDataFileTail is called when production loadDataFileTail is entered.
+func (checker *mysqlTypeChecker) EnterLoadDataFileTail(ctx *mysql.LoadDataFileTailContext) {
+	checker.isDML = true
+}
+
+// EnterReplaceStatement is called when production replaceStatement is entered.
+func (checker *mysqlTypeChecker) EnterReplaceStatement(ctx *mysql.ReplaceStatementContext) {
+	checker.isDML = true
+}
+
+// EnterSelectStatement is called when production selectStatement is entered.
+func (checker *mysqlTypeChecker) EnterSelectStatement(ctx *mysql.SelectStatementContext) {
+	checker.isDML = true
+}
+
+// EnterUpdateStatement is called when production updateStatement is entered.
+func (checker *mysqlTypeChecker) EnterUpdateStatement(ctx *mysql.UpdateStatementContext) {
+	checker.isDML = true
+}
+
+// EnterTransactionOrLockingStatement is called when production transactionOrLockingStatement is entered.
+func (checker *mysqlTypeChecker) EnterTransactionOrLockingStatement(ctx *mysql.TransactionOrLockingStatementContext) {
+	checker.isDML = true
+}
+
+// EnterReplicationStatement is called when production replicationStatement is entered.
+func (checker *mysqlTypeChecker) EnterReplicationStatement(ctx *mysql.ReplicationStatementContext) {
+	checker.isDML = true
+}
+
+// EnterPreparedStatement is called when production preparedStatement is entered.
+func (checker *mysqlTypeChecker) EnterPreparedStatement(ctx *mysql.PreparedStatementContext) {
+	checker.isDML = true
+}
+
+func (e *StatementTypeExecutor) mysqlSDLTypeCheck(ctx context.Context, newSchema string, instance *store.InstanceMessage, database *store.DatabaseMessage) ([]*storepb.PlanCheckRunResult_Result, error) {
+	ddl, err := runnerutils.ComputeDatabaseSchemaDiff(ctx, instance, database, e.dbFactory, newSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := base.SplitMultiSQL(storepb.Engine_MYSQL, ddl)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to split SQL")
+	}
+
+	var results []*storepb.PlanCheckRunResult_Result
+	for _, stmt := range list {
+		nodeList, err := mysqlparser.ParseMySQL(stmt.Text)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse schema %q", stmt.Text)
+		}
+		if len(nodeList) != 1 {
+			return nil, errors.Errorf("Expect one statement after splitting but found %d", len(nodeList))
+		}
+
+		checker := &tidbSDLTypeChecker{}
+		antlr.ParseTreeWalkerDefault.Walk(checker, nodeList[0].Tree)
+	}
+
+	return results, nil
+}
+
+type tidbSDLTypeChecker struct {
+	*mysql.BaseMySQLParserListener
+
+	baseLine int
+	results  []*storepb.PlanCheckRunResult_Result
+}
+
+// for SDL.
+// EnterDropTable is called when production dropTable is entered.
+func (checker *tidbSDLTypeChecker) EnterDropTable(ctx *mysql.DropTableContext) {
+	if ctx.TableRefList() == nil {
+		return
+	}
+
+	for _, tableRef := range ctx.TableRefList().AllTableRef() {
+		_, tableName := mysqlparser.NormalizeMySQLTableRef(tableRef)
+		checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+			Status:  storepb.PlanCheckRunResult_Result_WARNING,
+			Code:    common.TaskTypeDropTable.Int32(),
+			Title:   "Plan to drop table",
+			Content: fmt.Sprintf("Plan to drop table `%s`", tableName),
+			Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+				SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+					Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+					Detail: "",
+					Code:   0,
+				},
+			},
+		})
+	}
+}
+
+// EnterDropIndex is called when production dropIndex is entered.
+func (checker *tidbSDLTypeChecker) EnterDropIndex(ctx *mysql.DropIndexContext) {
+	if ctx.IndexRef() == nil || ctx.TableRef() == nil {
+		return
+	}
+
+	_, _, indexName := mysqlparser.NormalizeIndexRef(ctx.IndexRef())
+	_, tableName := mysqlparser.NormalizeMySQLTableRef(ctx.TableRef())
+	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+		Status:  storepb.PlanCheckRunResult_Result_WARNING,
+		Code:    common.TaskTypeDropIndex.Int32(),
+		Title:   "Plan to drop index",
+		Content: fmt.Sprintf("Plan to drop index `%s` on table `%s`", indexName, tableName),
+		Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+			SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+				Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+				Detail: "",
+				Code:   0,
+			},
+		},
+	})
+}
+
+// EnterAlterTable is called when production alterTable is entered.
+func (checker *tidbSDLTypeChecker) EnterAlterTable(ctx *mysql.AlterTableContext) {
+	if ctx.TableRef() == nil {
+		// todo: maybe need to do error handle.
+		return
+	}
+
+	_, tableName := mysqlparser.NormalizeMySQLTableRef(ctx.TableRef())
+
+	if ctx.AlterTableActions() == nil {
+		return
+	}
+	if ctx.AlterTableActions().AlterCommandList() == nil {
+		return
+	}
+	if ctx.AlterTableActions().AlterCommandList().AlterList() == nil {
+		return
+	}
+
+	for _, alterListItem := range ctx.AlterTableActions().AlterCommandList().AlterList().AllAlterListItem() {
+		if alterListItem == nil {
+			continue
+		}
+
+		switch {
+		case alterListItem.DROP_SYMBOL() != nil:
+			switch {
+			// drop column.
+			case alterListItem.ColumnInternalRef() != nil:
+				columnName := mysqlparser.NormalizeMySQLColumnInternalRef(alterListItem.ColumnInternalRef())
+				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropColumn.Int32(),
+					Title:   "Plan to drop column",
+					Content: fmt.Sprintf("Plan to drop column `%s` on table `%s`", columnName, tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + alterListItem.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			// drop primary key.
+			case alterListItem.PRIMARY_SYMBOL() != nil && alterListItem.KEY_SYMBOL() != nil:
+				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropPrimaryKey.Int32(),
+					Title:   "Plan to drop primary key",
+					Content: fmt.Sprintf("Plan to drop primary key on table `%s`", tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			// drop foreign key.
+			case alterListItem.FOREIGN_SYMBOL() != nil && alterListItem.KEY_SYMBOL() != nil && alterListItem.ColumnInternalRef() != nil:
+				name := mysqlparser.NormalizeMySQLColumnInternalRef(alterListItem.ColumnInternalRef())
+				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropForeignKey.Int32(),
+					Title:   "Plan to drop foreign key",
+					Content: fmt.Sprintf("Plan to drop foreign key `%s` on table `%s`", name, tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			// drop check.
+			case alterListItem.CHECK_SYMBOL() != nil && alterListItem.Identifier() != nil:
+				constraintName := mysqlparser.NormalizeMySQLIdentifier(alterListItem.Identifier())
+				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
+					Status:  storepb.PlanCheckRunResult_Result_WARNING,
+					Code:    common.TaskTypeDropCheck.Int32(),
+					Title:   "Plan to drop check constraint",
+					Content: fmt.Sprintf("Plan to drop check constraint `%s` on table `%s`", constraintName, tableName),
+					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
+						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
+							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
+							Detail: "",
+							Code:   0,
+						},
+					},
+				})
+			}
+		default:
+		}
+	}
+}
+
+func tidbStatementTypeCheck(statement string, charset string, collation string, changeType storepb.PlanCheckRunConfig_ChangeDatabaseType) ([]*storepb.PlanCheckRunResult_Result, error) {
 	// Due to the limitation of TiDB parser, we should split the multi-statement into single statements, and extract
 	// the TiDB unsupported statements, otherwise, the parser will panic or return the error.
 	unsupportStmt, supportStmt, err := tidbparser.ExtractTiDBUnsupportedStmts(statement)
@@ -534,7 +963,7 @@ func mysqlStatementTypeCheck(statement string, charset string, collation string,
 	var results []*storepb.PlanCheckRunResult_Result
 
 	// Disallow CREATE/DROP DATABASE statements.
-	results = append(results, mysqlCreateAndDropDatabaseCheck(stmts)...)
+	results = append(results, tidbCreateAndDropDatabaseCheck(stmts)...)
 
 	switch changeType {
 	case storepb.PlanCheckRunConfig_DML:

--- a/backend/runner/plancheck/statement_type_executor.go
+++ b/backend/runner/plancheck/statement_type_executor.go
@@ -9,8 +9,6 @@ import (
 	tidbast "github.com/pingcap/tidb/parser/ast"
 	"github.com/pkg/errors"
 
-	mysql "github.com/bytebase/mysql-parser"
-
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	api "github.com/bytebase/bytebase/backend/legacyapi"
@@ -539,15 +537,15 @@ func mysqlStatementTypeCheck(statement string, changeType storepb.PlanCheckRunCo
 	switch changeType {
 	case storepb.PlanCheckRunConfig_DML:
 		for _, node := range stmts {
-			checker := &mysqlTypeChecker{}
+			checker := &mysqlparser.StatementTypeChecker{}
 			antlr.ParseTreeWalkerDefault.Walk(checker, node.Tree)
 			// We only want to disallow DDL statements in CHANGE DATA.
 			// We need to run some common statements, e.g. COMMIT.
-			if checker.isDDL {
+			if checker.IsDDL {
 				results = append(results, &storepb.PlanCheckRunResult_Result{
 					Status:  storepb.PlanCheckRunResult_Result_WARNING,
 					Title:   "Data change can only run DML",
-					Content: fmt.Sprintf("\"%s\" is not DML", checker.text),
+					Content: fmt.Sprintf("\"%s\" is not DML", checker.Text),
 					Code:    common.TaskTypeNotDML.Int32(),
 					Report:  nil,
 				})
@@ -555,13 +553,13 @@ func mysqlStatementTypeCheck(statement string, changeType storepb.PlanCheckRunCo
 		}
 	case storepb.PlanCheckRunConfig_DDL, storepb.PlanCheckRunConfig_SDL:
 		for _, node := range stmts {
-			checker := &mysqlTypeChecker{}
+			checker := &mysqlparser.StatementTypeChecker{}
 			antlr.ParseTreeWalkerDefault.Walk(checker, node.Tree)
-			if checker.isDML || checker.isExplain {
+			if checker.IsDML || checker.IsExplain {
 				results = append(results, &storepb.PlanCheckRunResult_Result{
 					Status:  storepb.PlanCheckRunResult_Result_WARNING,
 					Title:   "Alter schema can only run DDL",
-					Content: fmt.Sprintf("\"%s\" is not DDL", checker.text),
+					Content: fmt.Sprintf("\"%s\" is not DDL", checker.Text),
 					Code:    common.TaskTypeNotDDL.Int32(),
 					Report:  nil,
 				})
@@ -575,159 +573,12 @@ func mysqlStatementTypeCheck(statement string, changeType storepb.PlanCheckRunCo
 }
 
 func mysqlCreateAndDropDatabaseCheck(stmtList []*mysqlparser.ParseResult) []*storepb.PlanCheckRunResult_Result {
-	checker := &mysqlCreateAndDropDatabaseChecker{}
+	checker := &mysqlparser.CreateAndDropDatabaseChecker{}
 	for _, stmt := range stmtList {
 		antlr.ParseTreeWalkerDefault.Walk(checker, stmt.Tree)
 	}
 
-	return checker.results
-}
-
-type mysqlCreateAndDropDatabaseChecker struct {
-	*mysql.BaseMySQLParserListener
-
-	text    string
-	results []*storepb.PlanCheckRunResult_Result
-}
-
-func (checker *mysqlCreateAndDropDatabaseChecker) EnterQuery(ctx *mysql.QueryContext) {
-	checker.text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
-}
-
-// EnterCreateDatabase is called when production createDatabase is entered.
-func (checker *mysqlCreateAndDropDatabaseChecker) EnterCreateDatabase(_ *mysql.CreateDatabaseContext) {
-	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-		Status:  storepb.PlanCheckRunResult_Result_ERROR,
-		Code:    common.TaskTypeCreateDatabase.Int32(),
-		Title:   "Cannot create database",
-		Content: fmt.Sprintf(`The statement "%s" creates database`, checker.text),
-	})
-}
-
-// EnterDropDatabase is called when production dropDatabase is entered.
-func (checker *mysqlCreateAndDropDatabaseChecker) EnterDropDatabase(_ *mysql.DropDatabaseContext) {
-	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-		Status:  storepb.PlanCheckRunResult_Result_ERROR,
-		Code:    common.TaskTypeDropDatabase.Int32(),
-		Title:   "Cannot drop database",
-		Content: fmt.Sprintf(`The statement "%s" drops database`, checker.text),
-	})
-}
-
-type mysqlTypeChecker struct {
-	*mysql.BaseMySQLParserListener
-
-	isDDL     bool
-	isDML     bool
-	isExplain bool
-	text      string
-}
-
-func (checker *mysqlTypeChecker) EnterQuery(ctx *mysql.QueryContext) {
-	checker.text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
-}
-
-// DDL from MySQLParser.g4
-// alterStatement
-// createStatement
-// dropStatement
-// renameTableStatement
-// truncateTableStatement
-// importStatement
-// EnterAlterStatement is called when production alterStatement is entered.
-func (checker *mysqlTypeChecker) EnterAlterStatement(_ *mysql.AlterStatementContext) {
-	checker.isDDL = true
-}
-
-// EnterCreateStatement is called when production createStatement is entered.
-func (checker *mysqlTypeChecker) EnterCreateStatement(_ *mysql.CreateStatementContext) {
-	checker.isDDL = true
-}
-
-// EnterDropStatement is called when production dropStatement is entered.
-func (checker *mysqlTypeChecker) EnterDropStatement(_ *mysql.DropStatementContext) {
-	checker.isDDL = true
-}
-
-// EnterRenameTableStatement is called when production renameTableStatement is entered.
-func (checker *mysqlTypeChecker) EnterRenameTableStatement(_ *mysql.RenameTableStatementContext) {
-	checker.isDDL = true
-}
-
-// EnterTruncateTableStatement is called when production truncateTableStatement is entered.
-func (checker *mysqlTypeChecker) EnterTruncateTableStatement(_ *mysql.TruncateTableStatementContext) {
-	checker.isDDL = true
-}
-
-// EnterImportStatement is called when production importStatement is entered.
-func (checker *mysqlTypeChecker) EnterImportStatement(_ *mysql.ImportStatementContext) {
-	checker.isDDL = true
-}
-
-// EnterExplainStatement is called when production explainStatement is entered.
-func (checker *mysqlTypeChecker) EnterExplainStatement(_ *mysql.ExplainStatementContext) {
-	checker.isExplain = true
-}
-
-// DML
-// EnterCallStatement is called when production callStatement is entered.
-func (checker *mysqlTypeChecker) EnterCallStatement(_ *mysql.CallStatementContext) {
-	checker.isDML = true
-}
-
-// EnterDeleteStatement is called when production deleteStatement is entered.
-func (checker *mysqlTypeChecker) EnterDeleteStatement(_ *mysql.DeleteStatementContext) {
-	checker.isDML = true
-}
-
-// EnterDoStatement is called when production doStatement is entered.
-func (checker *mysqlTypeChecker) EnterDoStatement(_ *mysql.DoStatementContext) {
-	checker.isDML = true
-}
-
-// EnterHandlerStatement is called when production handlerStatement is entered.
-func (checker *mysqlTypeChecker) EnterHandlerStatement(_ *mysql.HandlerStatementContext) {
-	checker.isDML = true
-}
-
-// EnterInsertStatement is called when production insertStatement is entered.
-func (checker *mysqlTypeChecker) EnterInsertStatement(_ *mysql.InsertStatementContext) {
-	checker.isDML = true
-}
-
-// EnterLoadDataFileTail is called when production loadDataFileTail is entered.
-func (checker *mysqlTypeChecker) EnterLoadDataFileTail(_ *mysql.LoadDataFileTailContext) {
-	checker.isDML = true
-}
-
-// EnterReplaceStatement is called when production replaceStatement is entered.
-func (checker *mysqlTypeChecker) EnterReplaceStatement(_ *mysql.ReplaceStatementContext) {
-	checker.isDML = true
-}
-
-// EnterSelectStatement is called when production selectStatement is entered.
-func (checker *mysqlTypeChecker) EnterSelectStatement(_ *mysql.SelectStatementContext) {
-	checker.isDML = true
-}
-
-// EnterUpdateStatement is called when production updateStatement is entered.
-func (checker *mysqlTypeChecker) EnterUpdateStatement(_ *mysql.UpdateStatementContext) {
-	checker.isDML = true
-}
-
-// EnterTransactionOrLockingStatement is called when production transactionOrLockingStatement is entered.
-func (checker *mysqlTypeChecker) EnterTransactionOrLockingStatement(_ *mysql.TransactionOrLockingStatementContext) {
-	checker.isDML = true
-}
-
-// EnterReplicationStatement is called when production replicationStatement is entered.
-func (checker *mysqlTypeChecker) EnterReplicationStatement(_ *mysql.ReplicationStatementContext) {
-	checker.isDML = true
-}
-
-// EnterPreparedStatement is called when production preparedStatement is entered.
-func (checker *mysqlTypeChecker) EnterPreparedStatement(_ *mysql.PreparedStatementContext) {
-	checker.isDML = true
+	return checker.Results
 }
 
 func (e *StatementTypeExecutor) mysqlSDLTypeCheck(ctx context.Context, newSchema string, instance *store.InstanceMessage, database *store.DatabaseMessage) ([]*storepb.PlanCheckRunResult_Result, error) {
@@ -751,162 +602,11 @@ func (e *StatementTypeExecutor) mysqlSDLTypeCheck(ctx context.Context, newSchema
 			return nil, errors.Errorf("Expect one statement after splitting but found %d", len(nodeList))
 		}
 
-		checker := &tidbSDLTypeChecker{}
+		checker := &mysqlparser.SDLTypeChecker{}
 		antlr.ParseTreeWalkerDefault.Walk(checker, nodeList[0].Tree)
 	}
 
 	return results, nil
-}
-
-type tidbSDLTypeChecker struct {
-	*mysql.BaseMySQLParserListener
-
-	baseLine int
-	results  []*storepb.PlanCheckRunResult_Result
-}
-
-// for SDL.
-// EnterDropTable is called when production dropTable is entered.
-func (checker *tidbSDLTypeChecker) EnterDropTable(ctx *mysql.DropTableContext) {
-	if ctx.TableRefList() == nil {
-		return
-	}
-
-	for _, tableRef := range ctx.TableRefList().AllTableRef() {
-		_, tableName := mysqlparser.NormalizeMySQLTableRef(tableRef)
-		checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-			Status:  storepb.PlanCheckRunResult_Result_WARNING,
-			Code:    common.TaskTypeDropTable.Int32(),
-			Title:   "Plan to drop table",
-			Content: fmt.Sprintf("Plan to drop table `%s`", tableName),
-			Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
-				SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
-					Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
-					Detail: "",
-					Code:   0,
-				},
-			},
-		})
-	}
-}
-
-// EnterDropIndex is called when production dropIndex is entered.
-func (checker *tidbSDLTypeChecker) EnterDropIndex(ctx *mysql.DropIndexContext) {
-	if ctx.IndexRef() == nil || ctx.TableRef() == nil {
-		return
-	}
-
-	_, _, indexName := mysqlparser.NormalizeIndexRef(ctx.IndexRef())
-	_, tableName := mysqlparser.NormalizeMySQLTableRef(ctx.TableRef())
-	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-		Status:  storepb.PlanCheckRunResult_Result_WARNING,
-		Code:    common.TaskTypeDropIndex.Int32(),
-		Title:   "Plan to drop index",
-		Content: fmt.Sprintf("Plan to drop index `%s` on table `%s`", indexName, tableName),
-		Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
-			SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
-				Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
-				Detail: "",
-				Code:   0,
-			},
-		},
-	})
-}
-
-// EnterAlterTable is called when production alterTable is entered.
-func (checker *tidbSDLTypeChecker) EnterAlterTable(ctx *mysql.AlterTableContext) {
-	if ctx.TableRef() == nil {
-		// todo: maybe need to do error handle.
-		return
-	}
-
-	_, tableName := mysqlparser.NormalizeMySQLTableRef(ctx.TableRef())
-
-	if ctx.AlterTableActions() == nil {
-		return
-	}
-	if ctx.AlterTableActions().AlterCommandList() == nil {
-		return
-	}
-	if ctx.AlterTableActions().AlterCommandList().AlterList() == nil {
-		return
-	}
-
-	for _, alterListItem := range ctx.AlterTableActions().AlterCommandList().AlterList().AllAlterListItem() {
-		if alterListItem == nil {
-			continue
-		}
-
-		switch {
-		case alterListItem.DROP_SYMBOL() != nil:
-			switch {
-			// drop column.
-			case alterListItem.ColumnInternalRef() != nil:
-				columnName := mysqlparser.NormalizeMySQLColumnInternalRef(alterListItem.ColumnInternalRef())
-				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-					Status:  storepb.PlanCheckRunResult_Result_WARNING,
-					Code:    common.TaskTypeDropColumn.Int32(),
-					Title:   "Plan to drop column",
-					Content: fmt.Sprintf("Plan to drop column `%s` on table `%s`", columnName, tableName),
-					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
-						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
-							Line:   int32(checker.baseLine + alterListItem.GetStart().GetLine()),
-							Detail: "",
-							Code:   0,
-						},
-					},
-				})
-			// drop primary key.
-			case alterListItem.PRIMARY_SYMBOL() != nil && alterListItem.KEY_SYMBOL() != nil:
-				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-					Status:  storepb.PlanCheckRunResult_Result_WARNING,
-					Code:    common.TaskTypeDropPrimaryKey.Int32(),
-					Title:   "Plan to drop primary key",
-					Content: fmt.Sprintf("Plan to drop primary key on table `%s`", tableName),
-					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
-						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
-							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
-							Detail: "",
-							Code:   0,
-						},
-					},
-				})
-			// drop foreign key.
-			case alterListItem.FOREIGN_SYMBOL() != nil && alterListItem.KEY_SYMBOL() != nil && alterListItem.ColumnInternalRef() != nil:
-				name := mysqlparser.NormalizeMySQLColumnInternalRef(alterListItem.ColumnInternalRef())
-				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-					Status:  storepb.PlanCheckRunResult_Result_WARNING,
-					Code:    common.TaskTypeDropForeignKey.Int32(),
-					Title:   "Plan to drop foreign key",
-					Content: fmt.Sprintf("Plan to drop foreign key `%s` on table `%s`", name, tableName),
-					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
-						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
-							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
-							Detail: "",
-							Code:   0,
-						},
-					},
-				})
-			// drop check.
-			case alterListItem.CHECK_SYMBOL() != nil && alterListItem.Identifier() != nil:
-				constraintName := mysqlparser.NormalizeMySQLIdentifier(alterListItem.Identifier())
-				checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
-					Status:  storepb.PlanCheckRunResult_Result_WARNING,
-					Code:    common.TaskTypeDropCheck.Int32(),
-					Title:   "Plan to drop check constraint",
-					Content: fmt.Sprintf("Plan to drop check constraint `%s` on table `%s`", constraintName, tableName),
-					Report: &storepb.PlanCheckRunResult_Result_SqlReviewReport_{
-						SqlReviewReport: &storepb.PlanCheckRunResult_Result_SqlReviewReport{
-							Line:   int32(checker.baseLine + ctx.GetStart().GetLine()),
-							Detail: "",
-							Code:   0,
-						},
-					},
-				})
-			}
-		default:
-		}
-	}
 }
 
 func tidbStatementTypeCheck(statement string, charset string, collation string, changeType storepb.PlanCheckRunConfig_ChangeDatabaseType) ([]*storepb.PlanCheckRunResult_Result, error) {

--- a/backend/runner/plancheck/statement_type_executor.go
+++ b/backend/runner/plancheck/statement_type_executor.go
@@ -595,7 +595,7 @@ func (checker *mysqlCreateAndDropDatabaseChecker) EnterQuery(ctx *mysql.QueryCon
 }
 
 // EnterCreateDatabase is called when production createDatabase is entered.
-func (checker *mysqlCreateAndDropDatabaseChecker) EnterCreateDatabase(ctx *mysql.CreateDatabaseContext) {
+func (checker *mysqlCreateAndDropDatabaseChecker) EnterCreateDatabase(_ *mysql.CreateDatabaseContext) {
 	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
 		Status:  storepb.PlanCheckRunResult_Result_ERROR,
 		Code:    common.TaskTypeCreateDatabase.Int32(),
@@ -605,7 +605,7 @@ func (checker *mysqlCreateAndDropDatabaseChecker) EnterCreateDatabase(ctx *mysql
 }
 
 // EnterDropDatabase is called when production dropDatabase is entered.
-func (checker *mysqlCreateAndDropDatabaseChecker) EnterDropDatabase(ctx *mysql.DropDatabaseContext) {
+func (checker *mysqlCreateAndDropDatabaseChecker) EnterDropDatabase(_ *mysql.DropDatabaseContext) {
 	checker.results = append(checker.results, &storepb.PlanCheckRunResult_Result{
 		Status:  storepb.PlanCheckRunResult_Result_ERROR,
 		Code:    common.TaskTypeDropDatabase.Int32(),
@@ -635,98 +635,98 @@ func (checker *mysqlTypeChecker) EnterQuery(ctx *mysql.QueryContext) {
 // truncateTableStatement
 // importStatement
 // EnterAlterStatement is called when production alterStatement is entered.
-func (checker *mysqlTypeChecker) EnterAlterStatement(ctx *mysql.AlterStatementContext) {
+func (checker *mysqlTypeChecker) EnterAlterStatement(_ *mysql.AlterStatementContext) {
 	checker.isDDL = true
 }
 
 // EnterCreateStatement is called when production createStatement is entered.
-func (checker *mysqlTypeChecker) EnterCreateStatement(ctx *mysql.CreateStatementContext) {
+func (checker *mysqlTypeChecker) EnterCreateStatement(_ *mysql.CreateStatementContext) {
 	checker.isDDL = true
 }
 
 // EnterDropStatement is called when production dropStatement is entered.
-func (checker *mysqlTypeChecker) EnterDropStatement(ctx *mysql.DropStatementContext) {
+func (checker *mysqlTypeChecker) EnterDropStatement(_ *mysql.DropStatementContext) {
 	checker.isDDL = true
 }
 
 // EnterRenameTableStatement is called when production renameTableStatement is entered.
-func (checker *mysqlTypeChecker) EnterRenameTableStatement(ctx *mysql.RenameTableStatementContext) {
+func (checker *mysqlTypeChecker) EnterRenameTableStatement(_ *mysql.RenameTableStatementContext) {
 	checker.isDDL = true
 }
 
 // EnterTruncateTableStatement is called when production truncateTableStatement is entered.
-func (checker *mysqlTypeChecker) EnterTruncateTableStatement(ctx *mysql.TruncateTableStatementContext) {
+func (checker *mysqlTypeChecker) EnterTruncateTableStatement(_ *mysql.TruncateTableStatementContext) {
 	checker.isDDL = true
 }
 
 // EnterImportStatement is called when production importStatement is entered.
-func (checker *mysqlTypeChecker) EnterImportStatement(ctx *mysql.ImportStatementContext) {
+func (checker *mysqlTypeChecker) EnterImportStatement(_ *mysql.ImportStatementContext) {
 	checker.isDDL = true
 }
 
 // EnterExplainStatement is called when production explainStatement is entered.
-func (checker *mysqlTypeChecker) EnterExplainStatement(ctx *mysql.ExplainStatementContext) {
+func (checker *mysqlTypeChecker) EnterExplainStatement(_ *mysql.ExplainStatementContext) {
 	checker.isExplain = true
 }
 
 // DML
 // EnterCallStatement is called when production callStatement is entered.
-func (checker *mysqlTypeChecker) EnterCallStatement(ctx *mysql.CallStatementContext) {
+func (checker *mysqlTypeChecker) EnterCallStatement(_ *mysql.CallStatementContext) {
 	checker.isDML = true
 }
 
 // EnterDeleteStatement is called when production deleteStatement is entered.
-func (checker *mysqlTypeChecker) EnterDeleteStatement(ctx *mysql.DeleteStatementContext) {
+func (checker *mysqlTypeChecker) EnterDeleteStatement(_ *mysql.DeleteStatementContext) {
 	checker.isDML = true
 }
 
 // EnterDoStatement is called when production doStatement is entered.
-func (checker *mysqlTypeChecker) EnterDoStatement(ctx *mysql.DoStatementContext) {
+func (checker *mysqlTypeChecker) EnterDoStatement(_ *mysql.DoStatementContext) {
 	checker.isDML = true
 }
 
 // EnterHandlerStatement is called when production handlerStatement is entered.
-func (checker *mysqlTypeChecker) EnterHandlerStatement(ctx *mysql.HandlerStatementContext) {
+func (checker *mysqlTypeChecker) EnterHandlerStatement(_ *mysql.HandlerStatementContext) {
 	checker.isDML = true
 }
 
 // EnterInsertStatement is called when production insertStatement is entered.
-func (checker *mysqlTypeChecker) EnterInsertStatement(ctx *mysql.InsertStatementContext) {
+func (checker *mysqlTypeChecker) EnterInsertStatement(_ *mysql.InsertStatementContext) {
 	checker.isDML = true
 }
 
 // EnterLoadDataFileTail is called when production loadDataFileTail is entered.
-func (checker *mysqlTypeChecker) EnterLoadDataFileTail(ctx *mysql.LoadDataFileTailContext) {
+func (checker *mysqlTypeChecker) EnterLoadDataFileTail(_ *mysql.LoadDataFileTailContext) {
 	checker.isDML = true
 }
 
 // EnterReplaceStatement is called when production replaceStatement is entered.
-func (checker *mysqlTypeChecker) EnterReplaceStatement(ctx *mysql.ReplaceStatementContext) {
+func (checker *mysqlTypeChecker) EnterReplaceStatement(_ *mysql.ReplaceStatementContext) {
 	checker.isDML = true
 }
 
 // EnterSelectStatement is called when production selectStatement is entered.
-func (checker *mysqlTypeChecker) EnterSelectStatement(ctx *mysql.SelectStatementContext) {
+func (checker *mysqlTypeChecker) EnterSelectStatement(_ *mysql.SelectStatementContext) {
 	checker.isDML = true
 }
 
 // EnterUpdateStatement is called when production updateStatement is entered.
-func (checker *mysqlTypeChecker) EnterUpdateStatement(ctx *mysql.UpdateStatementContext) {
+func (checker *mysqlTypeChecker) EnterUpdateStatement(_ *mysql.UpdateStatementContext) {
 	checker.isDML = true
 }
 
 // EnterTransactionOrLockingStatement is called when production transactionOrLockingStatement is entered.
-func (checker *mysqlTypeChecker) EnterTransactionOrLockingStatement(ctx *mysql.TransactionOrLockingStatementContext) {
+func (checker *mysqlTypeChecker) EnterTransactionOrLockingStatement(_ *mysql.TransactionOrLockingStatementContext) {
 	checker.isDML = true
 }
 
 // EnterReplicationStatement is called when production replicationStatement is entered.
-func (checker *mysqlTypeChecker) EnterReplicationStatement(ctx *mysql.ReplicationStatementContext) {
+func (checker *mysqlTypeChecker) EnterReplicationStatement(_ *mysql.ReplicationStatementContext) {
 	checker.isDML = true
 }
 
 // EnterPreparedStatement is called when production preparedStatement is entered.
-func (checker *mysqlTypeChecker) EnterPreparedStatement(ctx *mysql.PreparedStatementContext) {
+func (checker *mysqlTypeChecker) EnterPreparedStatement(_ *mysql.PreparedStatementContext) {
 	checker.isDML = true
 }
 

--- a/backend/runner/plancheck/statement_type_executor_test.go
+++ b/backend/runner/plancheck/statement_type_executor_test.go
@@ -1,0 +1,90 @@
+package plancheck
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/testing/protocmp"
+	"gopkg.in/yaml.v3"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+)
+
+type statementTypeCheckData struct {
+	Statement  string
+	ChangeType storepb.PlanCheckRunConfig_ChangeDatabaseType
+	Want       []string
+}
+
+func TestMySQLStatementTypeCheck(t *testing.T) {
+	tests := []string{
+		"mysql_statement_type_check",
+	}
+
+	for _, test := range tests {
+		runStatementTypeCheck(t, test, storepb.Engine_MYSQL, false /* record */)
+	}
+}
+
+func runStatementTypeCheck(t *testing.T, file string, engineType storepb.Engine, record bool) {
+	filepath := filepath.Join("test", file+".yaml")
+	yamlFile, err := os.Open(filepath)
+	require.NoError(t, err)
+	defer yamlFile.Close()
+
+	byteValue, err := io.ReadAll(yamlFile)
+	require.NoError(t, err)
+
+	tests := []statementTypeCheckData{}
+	err = yaml.Unmarshal(byteValue, &tests)
+	require.NoError(t, err)
+
+	for i, test := range tests {
+		var checkResults []*storepb.PlanCheckRunResult_Result
+		var err error
+		switch engineType {
+		case storepb.Engine_MYSQL:
+			checkResults, err = mysqlStatementTypeCheck(test.Statement, test.ChangeType)
+			require.NoError(t, err)
+		default:
+		}
+
+		if record {
+			resultSet := []string{}
+			for _, result := range checkResults {
+				resultSet = append(resultSet, protojson.Format(result))
+			}
+			tests[i].Want = resultSet
+		} else {
+			want := []*storepb.PlanCheckRunResult_Result{}
+			for _, result := range tests[i].Want {
+				res := &storepb.PlanCheckRunResult_Result{}
+				err := protojson.Unmarshal([]byte(result), res)
+				require.NoError(t, err)
+				want = append(want, res)
+			}
+			equalCheckRunResultProtos(t, want, checkResults, tests[i].Statement)
+		}
+	}
+
+	if record {
+		byteValue, err = yaml.Marshal(tests)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath, byteValue, 0644)
+		require.NoError(t, err)
+	}
+}
+
+func equalCheckRunResultProtos(t *testing.T, want, got []*storepb.PlanCheckRunResult_Result, message string) {
+	require.Equal(t, len(want), len(got))
+	for i := 0; i < len(want); i++ {
+		diff := cmp.Diff(want[i], got[i], protocmp.Transform())
+		require.Equal(t, "", diff, message)
+	}
+}

--- a/backend/runner/plancheck/test/mysql_statement_type_check.yaml
+++ b/backend/runner/plancheck/test/mysql_statement_type_check.yaml
@@ -54,28 +54,6 @@
   changetype: 1
   want: []
 - statement: |-
-    CREATE SPATIAL REFERENCE SYSTEM 4120
-    NAME 'Greek'
-    ORGANIZATION 'EPSG' IDENTIFIED BY 4120
-    DEFINITION
-      'GEOGCS["Greek",DATUM["Greek",SPHEROID["Bessel 1841",
-      6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],
-      AUTHORITY["EPSG","6120"]],PRIMEM["Greenwich",0,
-      AUTHORITY["EPSG","8901"]],UNIT["degree",0.017453292519943278,
-      AUTHORITY["EPSG","9122"]],AXIS["Lat",NORTH],AXIS["Lon",EAST],
-      AUTHORITY["EPSG","4120"]]';
-  changetype: 1
-  want:
-    - |-
-      {
-        "status":  "ERROR",
-        "title":  "Syntax error",
-        "content":  "Syntax error at line 2:5 \nrelated text: EATE SPATIAL REFERENCE SYSTEM 4120\nNAME 'Greek'",
-        "sqlReviewReport":  {
-          "code":  201
-        }
-      }
-- statement: |-
     CREATE EVENT e
         ON SCHEDULE
           EVERY 5 SECOND

--- a/backend/runner/plancheck/test/mysql_statement_type_check.yaml
+++ b/backend/runner/plancheck/test/mysql_statement_type_check.yaml
@@ -1,3 +1,243 @@
+- statement: |-
+    UPDATE items,
+       (SELECT id FROM items
+        WHERE id IN
+            (SELECT id FROM items
+             WHERE retail / wholesale >= 1.3 AND quantity < 100))
+        AS discounted
+    SET items.retail = items.retail * 0.9
+    WHERE items.id = discounted.id;
+  changetype: 2
+  want: []
+- statement: REPLACE INTO test2 VALUES (1, 'Old', '2014-08-20 18:47:00');
+  changetype: 2
+  want: []
+- statement: |-
+    (SELECT 1 AS result UNION SELECT 2)
+       ORDER BY result DESC LIMIT 1;
+  changetype: 2
+  want: []
+- statement: |-
+    INSERT INTO tbl_temp2 (fld_id)
+    SELECT tbl_temp1.fld_order_id
+    FROM tbl_temp1 WHERE tbl_temp1.fld_order_id > 100;
+  changetype: 1
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Alter schema can only run DDL",
+        "content":  "\"INSERT INTO tbl_temp2 (fld_id)\nSELECT tbl_temp1.fld_order_id\nFROM tbl_temp1 WHERE tbl_temp1.fld_order_id > 100;\" is not DDL",
+        "code":  402
+      }
+- statement: IMPORT TABLE FROM '/tmp/mysql-files/*.sdi';
+  changetype: 1
+  want: []
+- statement: TABLE a EXCEPT TABLE b;
+  changetype: 1
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Alter schema can only run DDL",
+        "content":  "\"TABLE a EXCEPT TABLE b;\" is not DDL",
+        "code":  402
+      }
+- statement: EXPLAIN SELECT c->>"$.name" AS name FROM jempn WHERE g > 2;
+  changetype: 1
+  want: []
+- statement: |-
+    CREATE TABLE artists_and_works
+    SELECT artist.name, COUNT(work.artist_id) AS number_of_works
+    FROM artist LEFT JOIN work ON artist.id = work.artist_id
+    GROUP BY artist.id;
+  changetype: 1
+  want: []
+- statement: |-
+    CREATE SPATIAL REFERENCE SYSTEM 4120
+    NAME 'Greek'
+    ORGANIZATION 'EPSG' IDENTIFIED BY 4120
+    DEFINITION
+      'GEOGCS["Greek",DATUM["Greek",SPHEROID["Bessel 1841",
+      6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],
+      AUTHORITY["EPSG","6120"]],PRIMEM["Greenwich",0,
+      AUTHORITY["EPSG","8901"]],UNIT["degree",0.017453292519943278,
+      AUTHORITY["EPSG","9122"]],AXIS["Lat",NORTH],AXIS["Lon",EAST],
+      AUTHORITY["EPSG","4120"]]';
+  changetype: 1
+  want:
+    - |-
+      {
+        "status":  "ERROR",
+        "title":  "Syntax error",
+        "content":  "Syntax error at line 2:5 \nrelated text: EATE SPATIAL REFERENCE SYSTEM 4120\nNAME 'Greek'",
+        "sqlReviewReport":  {
+          "code":  201
+        }
+      }
+- statement: |-
+    CREATE EVENT e
+        ON SCHEDULE
+          EVERY 5 SECOND
+        DO
+          BEGIN
+            DECLARE v INTEGER;
+            DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+
+            SET v = 0;
+
+            WHILE v < 5 DO
+              INSERT INTO t1 VALUES (0);
+              UPDATE t2 SET s1 = s1 + 1;
+              SET v = v + 1;
+            END WHILE;
+        END;
+  changetype: 1
+  want: []
+- statement: |-
+    CREATE TABLE customers (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    modified DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    custinfo JSON,
+    INDEX zips( (CAST(custinfo->'$.zipcode' AS UNSIGNED ARRAY)) )
+    );
+  changetype: 1
+  want: []
+- statement: |-
+    CREATE TABLE t1 (c1 INT);
+    ALTER TABLE t1 ADD COLUMN c2 INT GENERATED ALWAYS AS (c1 + 1) STORED;
+  changetype: 1
+  want: []
+- statement: |-
+    CREATE TABLE t1 (
+        id INT,
+        year_col INT
+    )
+    PARTITION BY RANGE (year_col) (
+        PARTITION p0 VALUES LESS THAN (1991),
+        PARTITION p1 VALUES LESS THAN (1995),
+        PARTITION p2 VALUES LESS THAN (1999)
+    );
+  changetype: 1
+  want: []
+- statement: ALTER SERVER s OPTIONS (USER 'sally');
+  changetype: 1
+  want: []
+- statement: |-
+    ALTER LOGFILE GROUP lg_3
+    ADD UNDOFILE 'undo_10.dat'
+    INITIAL_SIZE=32M
+    ENGINE=NDBCLUSTER;
+  changetype: 1
+  want: []
+- statement: ALTER FUNCTION hello COMMENT 'hello function';
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"ALTER FUNCTION hello COMMENT 'hello function';\" is not DML",
+        "code":  401
+      }
+- statement: |-
+    CREATE DEFINER = 'admin'@'localhost' PROCEDURE account_count()
+    BEGIN
+      SELECT 'Number of accounts:', COUNT(*) FROM mysql.user;
+    END;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"CREATE DEFINER = 'admin'@'localhost' PROCEDURE account_count()\nBEGIN\n  SELECT 'Number of accounts:', COUNT(*) FROM mysql.user;\nEND;\" is not DML",
+        "code":  401
+      }
+- statement: ALTER PROCEDURE account_count COMMENT 'this account_count';
+  changetype: 1
+  want: []
+- statement: |-
+    CREATE FUNCTION hello (s CHAR(20))
+    RETURNS CHAR(50) DETERMINISTIC
+    RETURN CONCAT('Hello, ',s,'!');
+
+    SELECT hello('world');
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"CREATE FUNCTION hello (s CHAR(20))\nRETURNS CHAR(50) DETERMINISTIC\nRETURN CONCAT('Hello, ',s,'!');\" is not DML",
+        "code":  401
+      }
+- statement: |-
+    delimiter //
+    CREATE PROCEDURE citycount (IN country CHAR(3), OUT cities INT)
+       BEGIN
+         SELECT COUNT(*) INTO cities FROM world.city
+         WHERE CountryCode = country;
+       END//
+    delimiter ;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"CREATE PROCEDURE citycount (IN country CHAR(3), OUT cities INT)\n   BEGIN\n     SELECT COUNT(*) INTO cities FROM world.city\n     WHERE CountryCode = country;\n   END;\" is not DML",
+        "code":  401
+      }
+- statement: CALL citycount('JPN', @cities); -- cities in Japan
+  changetype: 2
+  want: []
+- statement: ALTER EVENT no_such_event ON SCHEDULE EVERY '2:3' DAY_HOUR;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"ALTER EVENT no_such_event ON SCHEDULE EVERY '2:3' DAY_HOUR;\" is not DML",
+        "code":  401
+      }
+- statement: |-
+    CREATE EVENT myevent
+    ON SCHEDULE
+      EVERY 6 HOUR
+    COMMENT 'A sample comment.'
+    DO
+      UPDATE myschema.mytable SET mycol = mycol + 1;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"CREATE EVENT myevent\nON SCHEDULE\n  EVERY 6 HOUR\nCOMMENT 'A sample comment.'\nDO\n  UPDATE myschema.mytable SET mycol = mycol + 1;\" is not DML",
+        "code":  401
+      }
+- statement: ALTER DATABASE bbdev READ ONLY = DEFAULT;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"ALTER DATABASE bbdev READ ONLY = DEFAULT;\" is not DML",
+        "code":  401
+      }
+- statement: ALTER SCHEMA bbdev READ ONLY = DEFAULT;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"ALTER SCHEMA bbdev READ ONLY = DEFAULT;\" is not DML",
+        "code":  401
+      }
 - statement: CREATE TABLE t1(a INT);
   changetype: 1
   want: []
@@ -6,10 +246,10 @@
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Alter schema can only run DDL",
-        "content": "\"DELETE FROM t1;\" is not DDL",
-        "code": 402
+        "status":  "WARNING",
+        "title":  "Alter schema can only run DDL",
+        "content":  "\"DELETE FROM t1;\" is not DDL",
+        "code":  402
       }
 - statement: SELECT 1;
   changetype: 2
@@ -19,97 +259,97 @@
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Data change can only run DML",
-        "content": "\"DROP TABLE t1;\" is not DML",
-        "code": 401
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"DROP TABLE t1;\" is not DML",
+        "code":  401
       }
 - statement: CREATE DATABASE bbdev;
   changetype: 1
   want:
     - |-
       {
-        "status": "ERROR",
-        "title": "Cannot create database",
-        "content": "The statement \"CREATE DATABASE bbdev;\" creates database",
-        "code": 404
+        "status":  "ERROR",
+        "title":  "Cannot create database",
+        "content":  "The statement \"CREATE DATABASE bbdev;\" creates database",
+        "code":  404
       }
 - statement: DROP DATABASE bbdev;
   changetype: 2
   want:
     - |-
       {
-        "status": "ERROR",
-        "title": "Cannot drop database",
-        "content": "The statement \"DROP DATABASE bbdev;\" drops database",
-        "code": 403
+        "status":  "ERROR",
+        "title":  "Cannot drop database",
+        "content":  "The statement \"DROP DATABASE bbdev;\" drops database",
+        "code":  403
       }
     - |-
       {
-        "status": "WARNING",
-        "title": "Data change can only run DML",
-        "content": "\"DROP DATABASE bbdev;\" is not DML",
-        "code": 401
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"DROP DATABASE bbdev;\" is not DML",
+        "code":  401
       }
 - statement: RENAME TABLE t1 To t2;
   changetype: 2
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Data change can only run DML",
-        "content": "\"RENAME TABLE t1 To t2;\" is not DML",
-        "code": 401
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"RENAME TABLE t1 To t2;\" is not DML",
+        "code":  401
       }
 - statement: TRUNCATE TABLE t1;
   changetype: 2
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Data change can only run DML",
-        "content": "\"TRUNCATE TABLE t1;\" is not DML",
-        "code": 401
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"TRUNCATE TABLE t1;\" is not DML",
+        "code":  401
       }
 - statement: ALTER TABLE t1 ADD COLUMN col1 INT;
   changetype: 2
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Data change can only run DML",
-        "content": "\"ALTER TABLE t1 ADD COLUMN col1 INT;\" is not DML",
-        "code": 401
+        "status":  "WARNING",
+        "title":  "Data change can only run DML",
+        "content":  "\"ALTER TABLE t1 ADD COLUMN col1 INT;\" is not DML",
+        "code":  401
       }
 - statement: DELETE FROM t1 WHERE id = 1;
   changetype: 1
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Alter schema can only run DDL",
-        "content": "\"DELETE FROM t1 WHERE id = 1;\" is not DDL",
-        "code": 402
+        "status":  "WARNING",
+        "title":  "Alter schema can only run DDL",
+        "content":  "\"DELETE FROM t1 WHERE id = 1;\" is not DDL",
+        "code":  402
       }
 - statement: INSERT INTO t1(id) VALUE(1);
   changetype: 1
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Alter schema can only run DDL",
-        "content": "\"INSERT INTO t1(id) VALUE(1);\" is not DDL",
-        "code": 402
+        "status":  "WARNING",
+        "title":  "Alter schema can only run DDL",
+        "content":  "\"INSERT INTO t1(id) VALUE(1);\" is not DDL",
+        "code":  402
       }
 - statement: UPDATE t1 SET name = 'zp' WHERE id = 1;
   changetype: 1
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Alter schema can only run DDL",
-        "content": "\"UPDATE t1 SET name = 'zp' WHERE id = 1;\" is not DDL",
-        "code": 402
+        "status":  "WARNING",
+        "title":  "Alter schema can only run DDL",
+        "content":  "\"UPDATE t1 SET name = 'zp' WHERE id = 1;\" is not DDL",
+        "code":  402
       }
 - statement: |-
     update t_ci_job_artifact_config c
@@ -131,10 +371,10 @@
   want:
     - |-
       {
-        "status": "WARNING",
-        "title": "Alter schema can only run DDL",
-        "content": "\"update t_ci_job_artifact_config c\ninner join (\nselect\nstructure.id as structure_id,\nstructure.job_id as job_id\nfrom\nt_ci_job_stage_group_structure structure,\nt_ci_stage_template_group stg\nwhere\nstructure.stage_template_group_id = stg.id\nand stg.template_type = 3\nand stg.artifact_type in (4,5,6,7)\n) tmp on c.job_id = tmp.job_id and c.type in (4,5,6,7)\nset c.structure_id = tmp.structure_id\nwhere c.structure_id is null;\" is not DDL",
-        "code": 402
+        "status":  "WARNING",
+        "title":  "Alter schema can only run DDL",
+        "content":  "\"update t_ci_job_artifact_config c\ninner join (\nselect\nstructure.id as structure_id,\nstructure.job_id as job_id\nfrom\nt_ci_job_stage_group_structure structure,\nt_ci_stage_template_group stg\nwhere\nstructure.stage_template_group_id = stg.id\nand stg.template_type = 3\nand stg.artifact_type in (4,5,6,7)\n) tmp on c.job_id = tmp.job_id and c.type in (4,5,6,7)\nset c.structure_id = tmp.structure_id\nwhere c.structure_id is null;\" is not DDL",
+        "code":  402
       }
 - statement: |-
     update t_ci_job_artifact_config c

--- a/backend/runner/plancheck/test/mysql_statement_type_check.yaml
+++ b/backend/runner/plancheck/test/mysql_statement_type_check.yaml
@@ -1,0 +1,156 @@
+- statement: CREATE TABLE t1(a INT);
+  changetype: 1
+  want: []
+- statement: DELETE FROM t1;
+  changetype: 1
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Alter schema can only run DDL",
+        "content": "\"DELETE FROM t1;\" is not DDL",
+        "code": 402
+      }
+- statement: SELECT 1;
+  changetype: 2
+  want: []
+- statement: DROP TABLE t1;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Data change can only run DML",
+        "content": "\"DROP TABLE t1;\" is not DML",
+        "code": 401
+      }
+- statement: CREATE DATABASE bbdev;
+  changetype: 1
+  want:
+    - |-
+      {
+        "status": "ERROR",
+        "title": "Cannot create database",
+        "content": "The statement \"CREATE DATABASE bbdev;\" creates database",
+        "code": 404
+      }
+- statement: DROP DATABASE bbdev;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status": "ERROR",
+        "title": "Cannot drop database",
+        "content": "The statement \"DROP DATABASE bbdev;\" drops database",
+        "code": 403
+      }
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Data change can only run DML",
+        "content": "\"DROP DATABASE bbdev;\" is not DML",
+        "code": 401
+      }
+- statement: RENAME TABLE t1 To t2;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Data change can only run DML",
+        "content": "\"RENAME TABLE t1 To t2;\" is not DML",
+        "code": 401
+      }
+- statement: TRUNCATE TABLE t1;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Data change can only run DML",
+        "content": "\"TRUNCATE TABLE t1;\" is not DML",
+        "code": 401
+      }
+- statement: ALTER TABLE t1 ADD COLUMN col1 INT;
+  changetype: 2
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Data change can only run DML",
+        "content": "\"ALTER TABLE t1 ADD COLUMN col1 INT;\" is not DML",
+        "code": 401
+      }
+- statement: DELETE FROM t1 WHERE id = 1;
+  changetype: 1
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Alter schema can only run DDL",
+        "content": "\"DELETE FROM t1 WHERE id = 1;\" is not DDL",
+        "code": 402
+      }
+- statement: INSERT INTO t1(id) VALUE(1);
+  changetype: 1
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Alter schema can only run DDL",
+        "content": "\"INSERT INTO t1(id) VALUE(1);\" is not DDL",
+        "code": 402
+      }
+- statement: UPDATE t1 SET name = 'zp' WHERE id = 1;
+  changetype: 1
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Alter schema can only run DDL",
+        "content": "\"UPDATE t1 SET name = 'zp' WHERE id = 1;\" is not DDL",
+        "code": 402
+      }
+- statement: |-
+    update t_ci_job_artifact_config c
+    inner join (
+    select
+    structure.id as structure_id,
+    structure.job_id as job_id
+    from
+    t_ci_job_stage_group_structure structure,
+    t_ci_stage_template_group stg
+    where
+    structure.stage_template_group_id = stg.id
+    and stg.template_type = 3
+    and stg.artifact_type in (4,5,6,7)
+    ) tmp on c.job_id = tmp.job_id and c.type in (4,5,6,7)
+    set c.structure_id = tmp.structure_id
+    where c.structure_id is null;
+  changetype: 1
+  want:
+    - |-
+      {
+        "status": "WARNING",
+        "title": "Alter schema can only run DDL",
+        "content": "\"update t_ci_job_artifact_config c\ninner join (\nselect\nstructure.id as structure_id,\nstructure.job_id as job_id\nfrom\nt_ci_job_stage_group_structure structure,\nt_ci_stage_template_group stg\nwhere\nstructure.stage_template_group_id = stg.id\nand stg.template_type = 3\nand stg.artifact_type in (4,5,6,7)\n) tmp on c.job_id = tmp.job_id and c.type in (4,5,6,7)\nset c.structure_id = tmp.structure_id\nwhere c.structure_id is null;\" is not DDL",
+        "code": 402
+      }
+- statement: |-
+    update t_ci_job_artifact_config c
+    inner join (
+    select
+    structure.id as structure_id,
+    structure.job_id as job_id
+    from
+    t_ci_job_stage_group_structure structure,
+    t_ci_stage_template_group stg
+    where
+    structure.stage_template_group_id = stg.id
+    and stg.template_type = 3
+    and stg.artifact_type in (4,5,6,7)
+    ) tmp on c.job_id = tmp.job_id and c.type in (4,5,6,7)
+    set c.structure_id = tmp.structure_id
+    where c.structure_id is null;
+  changetype: 2
+  want: []


### PR DESCRIPTION
- rename old `mysqlStatementTypeCheck` to `tidbStatementTypeCheck`.
- rename old `mysqlSDLTypeCheck` to `tidbSDLTypeCheck`.
- rename old `mysqlCreateAndDropDatabaseCheck` to `tidbCreateAndDropDatabaseCheck`
- add new `mysqlStatementTypeCheck`
- add new `mysqlSDLTypeCheck` 
- add new `mysqlCreateAndDropDatabaseCheck`