### PR TITLE
chore(sql-editor): add `silent` option to fetch database

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -155,11 +155,16 @@ const prepareSheet = async () => {
   let insId = String(UNKNOWN_ID);
   let dbId = String(UNKNOWN_ID);
   if (sheet.database) {
-    const database = await databaseStore.getOrFetchDatabaseByName(
-      sheet.database
-    );
-    insId = database.instanceEntity.uid;
-    dbId = database.uid;
+    try {
+      const database = await databaseStore.getOrFetchDatabaseByName(
+        sheet.database,
+        true /* silent */
+      );
+      insId = database.instanceEntity.uid;
+      dbId = database.uid;
+    } catch {
+      // Skip.
+    }
   }
 
   tabStore.updateCurrentTab({

--- a/frontend/src/grpcweb/middlewares/authInterceptorMiddleware.ts
+++ b/frontend/src/grpcweb/middlewares/authInterceptorMiddleware.ts
@@ -5,7 +5,7 @@ import { useAuthStore } from "@/store";
 
 export type IgnoreErrorsOptions = {
   /**
-   * If set to true, will NOT show redirect to other pages(403, 404).
+   * If set to true, will NOT show redirect to other pages(e.g., 403).
    */
   silent?: boolean;
 

--- a/frontend/src/grpcweb/middlewares/authInterceptorMiddleware.ts
+++ b/frontend/src/grpcweb/middlewares/authInterceptorMiddleware.ts
@@ -5,6 +5,11 @@ import { useAuthStore } from "@/store";
 
 export type IgnoreErrorsOptions = {
   /**
+   * If set to true, will NOT show redirect to other pages(403, 404).
+   */
+  silent?: boolean;
+
+  /**
    * If set, will NOT handle specified status codes is this array.
    */
   ignoredCodes?: Status[];
@@ -34,6 +39,7 @@ export const authInterceptorMiddleware: ClientMiddleware<IgnoreErrorsOptions> =
               router.push({ name: "auth.signin" });
             }
           } else if (code === Status.PERMISSION_DENIED) {
+            if (options.silent) return;
             // Jump to 403 page
             router.push({ name: "error.403" });
           }

--- a/frontend/src/grpcweb/middlewares/errorNotificationMiddleware.ts
+++ b/frontend/src/grpcweb/middlewares/errorNotificationMiddleware.ts
@@ -5,7 +5,7 @@ import { pushNotification } from "@/store";
 
 export type SilentRequestOptions = {
   /**
-   * if set to true, will NOT show push notifications when request error occurs.
+   * If set to true, will NOT show push notifications when request error occurs.
    */
   silent?: boolean;
 

--- a/frontend/src/store/modules/sqlEditorTree.ts
+++ b/frontend/src/store/modules/sqlEditorTree.ts
@@ -184,7 +184,10 @@ export const useSQLEditorTreeStore = defineStore("SQL-Editor-Tree", () => {
   ): Promise<Connection> => {
     try {
       const [db, _] = await Promise.all([
-        useDatabaseV1Store().getOrFetchDatabaseByUID(databaseId),
+        useDatabaseV1Store().getOrFetchDatabaseByUID(
+          databaseId,
+          true /* silent */
+        ),
         useInstanceV1Store().getOrFetchInstanceByUID(instanceId),
       ]);
       await useDBSchemaV1Store().getOrFetchTableList(db.name);

--- a/frontend/src/store/modules/v1/database.ts
+++ b/frontend/src/store/modules/v1/database.ts
@@ -101,21 +101,26 @@ export const useDatabaseV1Store = defineStore("database_v1", () => {
   const getDatabaseByName = (name: string) => {
     return databaseMapByName.get(name) ?? unknownDatabase();
   };
-  const fetchDatabaseByName = async (name: string) => {
-    const database = await databaseServiceClient.getDatabase({
-      name,
-    });
+  const fetchDatabaseByName = async (name: string, silent = false) => {
+    const database = await databaseServiceClient.getDatabase(
+      {
+        name,
+      },
+      {
+        silent,
+      }
+    );
 
     const [composed] = await upsertDatabaseMap([database]);
 
     return composed;
   };
-  const getOrFetchDatabaseByName = async (name: string) => {
+  const getOrFetchDatabaseByName = async (name: string, silent = false) => {
     const existed = databaseMapByName.get(name);
     if (existed) {
       return existed;
     }
-    await fetchDatabaseByName(name);
+    await fetchDatabaseByName(name, silent);
     return getDatabaseByName(name);
   };
   const getDatabaseByUID = (uid: string) => {

--- a/frontend/src/store/modules/v1/database.ts
+++ b/frontend/src/store/modules/v1/database.ts
@@ -129,15 +129,20 @@ export const useDatabaseV1Store = defineStore("database_v1", () => {
 
     return databaseMapByUID.get(uid) ?? unknownDatabase();
   };
-  const fetchDatabaseByUID = async (uid: string) => {
-    const database = await databaseServiceClient.getDatabase({
-      name: `instances/-/databases/${uid}`,
-    });
+  const fetchDatabaseByUID = async (uid: string, silent = false) => {
+    const database = await databaseServiceClient.getDatabase(
+      {
+        name: `instances/-/databases/${uid}`,
+      },
+      {
+        silent,
+      }
+    );
     const [composed] = await upsertDatabaseMap([database]);
 
     return composed;
   };
-  const getOrFetchDatabaseByUID = async (uid: string) => {
+  const getOrFetchDatabaseByUID = async (uid: string, silent = false) => {
     if (uid === String(EMPTY_ID)) return emptyDatabase();
     if (uid === String(UNKNOWN_ID)) return unknownDatabase();
 
@@ -145,7 +150,7 @@ export const useDatabaseV1Store = defineStore("database_v1", () => {
     if (existed) {
       return existed;
     }
-    await fetchDatabaseByUID(uid);
+    await fetchDatabaseByUID(uid, silent);
     return getDatabaseByUID(uid);
   };
   const updateDatabase = async (params: UpdateDatabaseRequest) => {
@@ -232,6 +237,8 @@ export const useDatabaseV1ByName = (name: MaybeRef<string>) => {
   };
 };
 
+// useDatabaseV1ByUID returns a database by uid.
+// Mainly using in SQL Editor.
 export const useDatabaseV1ByUID = (uid: MaybeRef<string>) => {
   const store = useDatabaseV1Store();
   const ready = ref(true);
@@ -241,7 +248,7 @@ export const useDatabaseV1ByUID = (uid: MaybeRef<string>) => {
       if (uid !== String(UNKNOWN_ID)) {
         if (store.getDatabaseByUID(uid).uid === String(UNKNOWN_ID)) {
           ready.value = false;
-          store.fetchDatabaseByUID(uid).then(() => {
+          store.fetchDatabaseByUID(uid, true /* silent */).then(() => {
             ready.value = true;
           });
         }

--- a/frontend/src/views/sql-editor/EditorCommon/SaveSheetModal.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/SaveSheetModal.vue
@@ -61,7 +61,10 @@ const doSaveSheet = async (title: string) => {
   const sheetId = Number(extractSheetUID(sheetName ?? ""));
 
   const conn = tabStore.currentTab.connection;
-  const database = await databaseStore.getOrFetchDatabaseByUID(conn.databaseId);
+  const database = await databaseStore.getOrFetchDatabaseByUID(
+    conn.databaseId,
+    true /* silent */
+  );
 
   let sheet: Sheet | undefined;
   if (sheetId !== UNKNOWN_ID) {

--- a/frontend/src/views/sql-editor/Sheet/context.ts
+++ b/frontend/src/views/sql-editor/Sheet/context.ts
@@ -142,11 +142,16 @@ export const openSheet = async (sheet: Sheet, forceNewTab = false) => {
   let insId = String(UNKNOWN_ID);
   let dbId = String(UNKNOWN_ID);
   if (sheet.database) {
-    const database = await useDatabaseV1Store().getOrFetchDatabaseByName(
-      sheet.database
-    );
-    insId = database.instanceEntity.uid;
-    dbId = database.uid;
+    try {
+      const database = await useDatabaseV1Store().getOrFetchDatabaseByName(
+        sheet.database,
+        true /* silent */
+      );
+      insId = database.instanceEntity.uid;
+      dbId = database.uid;
+    } catch (error) {
+      return;
+    }
   }
 
   tabStore.updateCurrentTab({

--- a/frontend/src/views/sql-editor/Sheet/context.ts
+++ b/frontend/src/views/sql-editor/Sheet/context.ts
@@ -142,16 +142,12 @@ export const openSheet = async (sheet: Sheet, forceNewTab = false) => {
   let insId = String(UNKNOWN_ID);
   let dbId = String(UNKNOWN_ID);
   if (sheet.database) {
-    try {
-      const database = await useDatabaseV1Store().getOrFetchDatabaseByName(
-        sheet.database,
-        true /* silent */
-      );
-      insId = database.instanceEntity.uid;
-      dbId = database.uid;
-    } catch (error) {
-      return;
-    }
+    const database = await useDatabaseV1Store().getOrFetchDatabaseByName(
+      sheet.database,
+      true /* silent */
+    );
+    insId = database.instanceEntity.uid;
+    dbId = database.uid;
   }
 
   tabStore.updateCurrentTab({

--- a/frontend/src/views/sql-editor/Sheet/context.ts
+++ b/frontend/src/views/sql-editor/Sheet/context.ts
@@ -142,12 +142,16 @@ export const openSheet = async (sheet: Sheet, forceNewTab = false) => {
   let insId = String(UNKNOWN_ID);
   let dbId = String(UNKNOWN_ID);
   if (sheet.database) {
-    const database = await useDatabaseV1Store().getOrFetchDatabaseByName(
-      sheet.database,
-      true /* silent */
-    );
-    insId = database.instanceEntity.uid;
-    dbId = database.uid;
+    try {
+      const database = await useDatabaseV1Store().getOrFetchDatabaseByName(
+        sheet.database,
+        true /* silent */
+      );
+      insId = database.instanceEntity.uid;
+      dbId = database.uid;
+    } catch {
+      // Skip.
+    }
   }
 
   tabStore.updateCurrentTab({


### PR DESCRIPTION
If user A creates a sheet and makes some queries while he has query access to the `employee` database. When his query privileges expire or are removed, SQL Editor will keep redirecting to 403 page unless the local cache is cleared. Because the user does not have permissions to the `employee` database.

This PR will fix the above problem.

### Before


https://github.com/bytebase/bytebase/assets/24653555/9544ca2e-de41-4ff5-8b7f-e9ae73d5127c


### After

<img width="1633" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/14762f31-c967-4b38-8e26-d81e9df163d8">
