### PR TITLE
chore: match word boundary, more robust

### DIFF
--- a/backend/utils/database_group.go
+++ b/backend/utils/database_group.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -77,7 +78,11 @@ func GetStatementsAndSchemaGroupsFromSchemaGroups(statement string, engine store
 			continue
 		}
 		for _, schemaGroup := range schemaGroups {
-			if strings.Contains(singleStatement.Text, schemaGroup.Placeholder) {
+			re, err := regexp.Compile(`\b` + schemaGroup.Placeholder + `\b`)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "failed to compile regexp")
+			}
+			if re.MatchString(singleStatement.Text) {
 				curMatch = schemaGroup
 				break
 			}


### PR DESCRIPTION
This allows handling the below case, where strings.Contains("test") matches both "test" and "sbtest".

```
UPDATE test SET <<column>> = <<value>> WHERE <<condition>>;


UPDATE sbtest SET <<column>> = <<value>> WHERE <<condition>>
```


Thanks @LiuJi-Jim 