### PR TITLE
perf: optimize database and query history fetching in SQL Editor

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -83,12 +83,17 @@ const prepareAccessibleDatabaseList = async () => {
   if (currentUserV1.value.name === UNKNOWN_USER_NAME) {
     return;
   }
+  let filter = "";
+  if (treeStore.selectedProject) {
+    filter = `project == "${treeStore.selectedProject.name}"`;
+  }
 
   // `databaseList` is the database list accessible by current user.
   // Only accessible instances and databases will be listed in the tree.
   const databaseList = (
     await databaseStore.fetchDatabaseList({
       parent: "instances/-",
+      filter: filter,
     })
   ).filter(
     (db) =>
@@ -99,7 +104,7 @@ const prepareAccessibleDatabaseList = async () => {
   treeStore.databaseList = databaseList;
 };
 
-const initializeTree = async () => {
+const prepareProject = async () => {
   const projectName = route.query.project;
   if (projectName) {
     try {
@@ -112,6 +117,9 @@ const initializeTree = async () => {
       treeStore.selectedProject = unknownProject();
     }
   }
+};
+
+const initializeTree = async () => {
   treeStore.buildTree();
 };
 
@@ -326,6 +334,7 @@ onMounted(async () => {
 
     await initCommonModelStores();
 
+    await prepareProject();
     await prepareAccessControlPolicy();
     await prepareAccessibleDatabaseList();
 

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -330,7 +330,6 @@ onMounted(async () => {
     await prepareAccessibleDatabaseList();
 
     await setConnectionFromQuery();
-    await sqlEditorStore.fetchQueryHistoryList();
 
     await initializeTree();
     treeStore.state = "READY";

--- a/frontend/src/views/sql-editor/SecondarySidebar/HistoryTabPane/HistoryTabPane.vue
+++ b/frontend/src/views/sql-editor/SecondarySidebar/HistoryTabPane/HistoryTabPane.vue
@@ -64,7 +64,7 @@
 import { useClipboard } from "@vueuse/core";
 import dayjs from "dayjs";
 import { escape } from "lodash-es";
-import { computed, reactive } from "vue";
+import { computed, onMounted, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   pushNotification,
@@ -168,4 +168,8 @@ const handleQueryHistoryClick = async (queryHistory: QueryHistory) => {
     statement,
   });
 };
+
+onMounted(async () => {
+  await sqlEditorStore.fetchQueryHistoryList();
+});
 </script>


### PR DESCRIPTION
- Moved query history fetching to history tab panel mounting. Save one request on opening SQL Editor initially.
- Added project filter to list databases if SQL Editor is opened in project mode.