### PR TITLE
chore: remove isDatabaseQueriable check in SQL Editor

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -47,7 +47,6 @@ import {
   sheetSlugV1,
   connectionV1Slug as makeConnectionV1Slug,
   isSheetReadableV1,
-  isDatabaseV1Queryable,
   getSuggestedTabNameFromConnection,
   isSimilarTab,
 } from "@/utils";
@@ -68,10 +67,6 @@ const tabStore = useTabStore();
 const sheetV1Store = useSheetV1Store();
 
 const prepareAccessControlPolicy = async () => {
-  treeStore.accessControlPolicyList = await policyV1Store.fetchPolicies({
-    policyType: PolicyType.WORKSPACE_IAM,
-    resourceType: PolicyResourceType.WORKSPACE,
-  });
   await policyV1Store.fetchPolicies({
     resourceType: PolicyResourceType.ENVIRONMENT,
     policyType: PolicyType.DISABLE_COPY_DATA,
@@ -95,11 +90,7 @@ const prepareAccessibleDatabaseList = async () => {
       parent: "instances/-",
       filter: filter,
     })
-  ).filter(
-    (db) =>
-      db.syncState === State.ACTIVE &&
-      isDatabaseV1Queryable(db, currentUserV1.value)
-  );
+  ).filter((db) => db.syncState === State.ACTIVE);
 
   treeStore.databaseList = databaseList;
 };

--- a/frontend/src/store/modules/sqlEditorTree.ts
+++ b/frontend/src/store/modules/sqlEditorTree.ts
@@ -29,7 +29,6 @@ import {
   TextTarget,
 } from "@/types";
 import { Environment } from "@/types/proto/v1/environment_service";
-import { Policy } from "@/types/proto/v1/org_policy_service";
 import { emptyConnection, getSemanticLabelValue, groupBy } from "@/utils";
 import { useTabStore } from "./tab";
 import {
@@ -85,7 +84,6 @@ const factorListInLocalStorage = useLocalStorage<StatefulFactor[]>(
 export const useSQLEditorTreeStore = defineStore("SQL-Editor-Tree", () => {
   const nodeListMapById = reactive(new Map<string, TreeNode[]>());
   // states
-  const accessControlPolicyList = ref<Policy[]>([]);
   const databaseList = ref<ComposedDatabase[]>([]);
   const factorList = ref<StatefulFactor[]>(
     cloneDeep(factorListInLocalStorage.value)
@@ -217,7 +215,6 @@ export const useSQLEditorTreeStore = defineStore("SQL-Editor-Tree", () => {
     }
   };
   const cleanup = () => {
-    accessControlPolicyList.value = [];
     databaseList.value = [];
     selectedProject.value = undefined;
     tree.value = [];
@@ -237,7 +234,6 @@ export const useSQLEditorTreeStore = defineStore("SQL-Editor-Tree", () => {
 
   return {
     expandedKeys,
-    accessControlPolicyList,
     databaseList,
     factorList,
     filteredFactorList,

--- a/frontend/src/views/sql-editor/SQLEditorPage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorPage.vue
@@ -41,70 +41,66 @@
         <TabList />
 
         <div class="w-full flex-1 overflow-hidden">
-          <template v-if="allowAccess">
-            <template v-if="tabStore.currentTab.mode === TabMode.ReadOnly">
-              <Splitpanes
-                v-if="allowReadOnlyMode"
-                horizontal
-                class="default-theme"
-                :dbl-click-splitter="false"
-              >
-                <Pane class="flex flex-row overflow-hidden">
-                  <div class="h-full flex-1 overflow-hidden">
-                    <Splitpanes
-                      vertical
-                      class="default-theme"
-                      :dbl-click-splitter="false"
-                    >
-                      <Pane>
-                        <EditorPanel />
-                      </Pane>
-                      <Pane
-                        v-if="showSecondarySidebar && windowWidth >= 1024"
-                        :size="25"
-                      >
-                        <SecondarySidebar />
-                      </Pane>
-                    </Splitpanes>
-                  </div>
-
-                  <div
-                    v-if="windowWidth >= 1024"
-                    class="h-full border-l shrink-0"
+          <template v-if="tabStore.currentTab.mode === TabMode.ReadOnly">
+            <Splitpanes
+              v-if="allowReadOnlyMode"
+              horizontal
+              class="default-theme"
+              :dbl-click-splitter="false"
+            >
+              <Pane class="flex flex-row overflow-hidden">
+                <div class="h-full flex-1 overflow-hidden">
+                  <Splitpanes
+                    vertical
+                    class="default-theme"
+                    :dbl-click-splitter="false"
                   >
-                    <SecondaryGutterBar />
-                  </div>
-                </Pane>
-                <Pane v-if="!isDisconnected" class="relative" :size="40">
-                  <ResultPanel />
-                </Pane>
-              </Splitpanes>
+                    <Pane>
+                      <EditorPanel />
+                    </Pane>
+                    <Pane
+                      v-if="showSecondarySidebar && windowWidth >= 1024"
+                      :size="25"
+                    >
+                      <SecondarySidebar />
+                    </Pane>
+                  </Splitpanes>
+                </div>
 
-              <div
-                v-else
-                class="w-full h-full flex flex-col items-center justify-center gap-y-2"
-              >
-                <img
-                  src="../../assets/illustration/403.webp"
-                  class="max-h-[40%]"
-                />
-                <i18n-t
-                  class="textinfolabel flex items-center"
-                  keypath="sql-editor.allow-admin-mode-only"
-                  tag="div"
+                <div
+                  v-if="windowWidth >= 1024"
+                  class="h-full border-l shrink-0"
                 >
-                  <template #instance>
-                    <InstanceV1Name :instance="instance" :link="false" />
-                  </template>
-                </i18n-t>
-                <AdminModeButton />
-              </div>
-            </template>
+                  <SecondaryGutterBar />
+                </div>
+              </Pane>
+              <Pane v-if="!isDisconnected" class="relative" :size="40">
+                <ResultPanel />
+              </Pane>
+            </Splitpanes>
 
-            <TerminalPanelV1
-              v-if="tabStore.currentTab.mode === TabMode.Admin"
-            />
+            <div
+              v-else
+              class="w-full h-full flex flex-col items-center justify-center gap-y-2"
+            >
+              <img
+                src="../../assets/illustration/403.webp"
+                class="max-h-[40%]"
+              />
+              <i18n-t
+                class="textinfolabel flex items-center"
+                keypath="sql-editor.allow-admin-mode-only"
+                tag="div"
+              >
+                <template #instance>
+                  <InstanceV1Name :instance="instance" :link="false" />
+                </template>
+              </i18n-t>
+              <AdminModeButton />
+            </div>
           </template>
+
+          <TerminalPanelV1 v-if="tabStore.currentTab.mode === TabMode.Admin" />
           <div
             v-else
             class="w-full h-full flex flex-col items-center justify-center"
@@ -153,18 +149,13 @@ import { Drawer, DrawerContent, InstanceV1Name } from "@/components/v2";
 import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
 import {
   useActuatorV1Store,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useInstanceV1ByUID,
   useSQLEditorStore,
   useTabStore,
 } from "@/store";
-import { DatabaseId, TabMode, UNKNOWN_ID } from "@/types";
-import {
-  allowUsingSchemaEditorV1,
-  instanceV1HasReadonlyMode,
-  isDatabaseV1Queryable,
-} from "@/utils";
+import { DatabaseId, TabMode } from "@/types";
+import { allowUsingSchemaEditorV1, instanceV1HasReadonlyMode } from "@/utils";
 import AsidePanel from "./AsidePanel/AsidePanel.vue";
 import AdminModeButton from "./EditorCommon/AdminModeButton.vue";
 import EditorPanel from "./EditorPanel/EditorPanel.vue";
@@ -197,7 +188,6 @@ const tabStore = useTabStore();
 const databaseStore = useDatabaseV1Store();
 const actuatorStore = useActuatorV1Store();
 const sqlEditorStore = useSQLEditorStore();
-const currentUserV1 = useCurrentUserV1();
 // provide context for SQL Editor
 const { events: editorEvents } = provideSQLEditorContext();
 // provide context for sheets
@@ -210,16 +200,6 @@ const isDisconnected = computed(() => tabStore.isDisconnected);
 const isFetchingSheet = computed(() => sqlEditorStore.isFetchingSheet);
 
 const { width: windowWidth } = useWindowSize();
-
-const allowAccess = computed(() => {
-  const { databaseId } = tabStore.currentTab.connection;
-  const database = databaseStore.getDatabaseByUID(databaseId);
-  if (database.uid === String(UNKNOWN_ID)) {
-    // Allowed if connected to an instance
-    return true;
-  }
-  return isDatabaseV1Queryable(database, currentUserV1.value);
-});
 
 const { instance } = useInstanceV1ByUID(
   computed(() => tabStore.currentTab.connection.instanceId)

--- a/scripts/.air.toml
+++ b/scripts/.air.toml
@@ -15,6 +15,7 @@ cmd = """
 delay = 500
 exclude_dir = [
   ".air",
+  "backend/server/dist",
   "bytebase-build",
   "docs",
   "frontend",


### PR DESCRIPTION
We should just show all databases to the users in SQL Editor. Users should see all databases, query, and request permissions if not. Hiding databases would just cause confusion especially we hide databases but not schemas or tables with right ACL check.