### PR TITLE
feat: flatten the parition tables in build table metadata

### DIFF
--- a/backend/store/model/database_test.go
+++ b/backend/store/model/database_test.go
@@ -15,6 +15,24 @@ func TestBuildTablesMetadata(t *testing.T) {
 		wantNames   []string
 		wantColumns []*storepb.ColumnMetadata
 	}{
+		// No partitions.
+		{
+			input: &storepb.TableMetadata{
+				Name: "orders",
+				Columns: []*storepb.ColumnMetadata{
+					{
+						Name: "id",
+					},
+				},
+			},
+			wantNames: []string{"orders"},
+			wantColumns: []*storepb.ColumnMetadata{
+				{
+					Name: "id",
+				},
+			},
+		},
+		// Nested partitions.
 		{
 			input: &storepb.TableMetadata{
 				Name: "orders",

--- a/backend/store/model/database_test.go
+++ b/backend/store/model/database_test.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
+)
+
+func TestBuildTablesMetadata(t *testing.T) {
+	testCases := []struct {
+		input       *storepb.TableMetadata
+		wantNames   []string
+		wantColumns []*storepb.ColumnMetadata
+	}{
+		{
+			input: &storepb.TableMetadata{
+				Name: "orders",
+				Columns: []*storepb.ColumnMetadata{
+					{
+						Name: "id",
+					},
+				},
+				Partitions: []*storepb.TablePartitionMetadata{
+					{
+						Name: "orders_0_100",
+						Subpartitions: []*storepb.TablePartitionMetadata{
+							{
+								Name: "orders_0_50",
+							},
+							{
+								Name: "orders_50_100",
+							},
+						},
+					},
+					{
+						Name: "orders_100_200",
+						Subpartitions: []*storepb.TablePartitionMetadata{
+							{
+								Name: "orders_100_150",
+							},
+							{
+								Name: "orders_150_200",
+							},
+						},
+					},
+				},
+			},
+			wantNames: []string{"orders", "orders_0_100", "orders_0_50", "orders_50_100", "orders_100_200", "orders_100_150", "orders_150_200"},
+			wantColumns: []*storepb.ColumnMetadata{
+				{
+					Name: "id",
+				},
+			},
+		},
+	}
+
+	a := require.New(t)
+	for _, tc := range testCases {
+		tables, names := buildTablesMetadata(tc.input)
+
+		// The length of the tables should be the same as the length of the names.
+		a.Equal(len(tables), len(names))
+
+		// The names should be the same as the expected names.
+		a.Equal(sort.StringSlice(names), sort.StringSlice(tc.wantNames))
+
+		// Each table should have the same columns as the input.
+		for _, table := range tables {
+			a.Equal(len(table.GetColumns()), len(tc.wantColumns))
+			for _, column := range tc.wantColumns {
+				a.NotNil(table.GetColumn(column.Name))
+			}
+		}
+	}
+}


### PR DESCRIPTION
We flatten the partition tables in model.DatabaseMetadata, enabling smooth auto-completion and query functionality. I avoid using slices to represent the partition tree structure as it would negatively impact lookup performance.
By the way, **there is still a long way to go before being production-ready**, such as inheriting the parent's database configuration and implementing a masking policy.

![CleanShot 2023-11-28 at 18 26 31@2x](https://github.com/bytebase/bytebase/assets/87714218/41db6b08-d155-4028-8df4-5af9644cc7be)

