### PR TITLE
chore(sql-editor): loading spinner for monaco-editor

### DIFF
--- a/frontend/src/components/AnomalyCenter/AnomalyTable.vue
+++ b/frontend/src/components/AnomalyCenter/AnomalyTable.vue
@@ -57,7 +57,7 @@
     @close="dismissModal"
   >
     <div
-      class="space-y-4 flex flex-col overflow-hidden"
+      class="space-y-4 flex flex-col overflow-hidden relative"
       style="width: calc(100vw - 10rem); height: calc(100vh - 12rem)"
     >
       <DiffEditor

--- a/frontend/src/components/Changelist/ChangelistDetail/RawSQLEditor/RawSQLEditor.vue
+++ b/frontend/src/components/Changelist/ChangelistDetail/RawSQLEditor/RawSQLEditor.vue
@@ -8,7 +8,7 @@
 
     <div
       ref="editorWrapperRef"
-      class="flex-1 overflow-hidden"
+      class="flex-1 overflow-hidden relative"
       :data-height="editorWrapperHeight"
     >
       <MonacoEditor

--- a/frontend/src/components/IssueV1/components/GrantRequest/GrantRequestExporterForm.vue
+++ b/frontend/src/components/IssueV1/components/GrantRequest/GrantRequestExporterForm.vue
@@ -27,7 +27,7 @@
       class="w-full flex flex-col justify-start items-start"
     >
       <span class="flex items-center textlabel mb-2">SQL</span>
-      <div class="w-full border rounded">
+      <div class="w-full border rounded min-h-[6rem] relative">
         <MonacoEditor
           class="w-full h-[300px]"
           :content="state.statement"

--- a/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
@@ -117,7 +117,7 @@
       </template>
     </BBAttention>
 
-    <div class="whitespace-pre-wrap overflow-hidden">
+    <div class="whitespace-pre-wrap overflow-hidden min-h-[120px] relative">
       <MonacoEditor
         class="w-full h-auto max-h-[360px] min-h-[120px] border rounded-[3px]"
         :filename="`${selectedTask.name}.sql`"

--- a/frontend/src/components/IssueV1/components/StatementSection/SDLView/SDLView.vue
+++ b/frontend/src/components/IssueV1/components/StatementSection/SDLView/SDLView.vue
@@ -52,37 +52,39 @@
           </NTab>
         </NTabs>
 
-        <DiffEditor
-          v-if="state.tab === 'DIFF'"
-          class="border rounded-[3px] overflow-clip"
-          :original="sdlState.detail.previousSDL"
-          :modified="sdlState.detail.prettyExpectedSDL"
-          :readonly="true"
-          :auto-height="{
-            alignment: 'modified',
-            min: 120,
-            max: 480,
-          }"
-        />
-        <MonacoEditor
-          v-if="state.tab === 'STATEMENT'"
-          class="w-full h-auto border rounded-[3px] overflow-clip"
-          data-label="bb-issue-sql-editor"
-          :content="sdlState.detail.diffDDL"
-          :readonly="true"
-          :auto-focus="false"
-          :auto-height="{ min: 120, max: 360 }"
-        />
-        <MonacoEditor
-          v-if="state.tab === 'SCHEMA'"
-          class="w-full h-auto border rounded-[3px] overflow-clip"
-          data-label="bb-issue-sql-editor"
-          :content="sdlState.detail.expectedSDL"
-          :readonly="true"
-          :auto-focus="false"
-          :auto-height="{ min: 120, max: 360 }"
-          :advices="markers"
-        />
+        <div class="relative min-h-[6rem]">
+          <DiffEditor
+            v-if="state.tab === 'DIFF'"
+            class="border rounded-[3px] overflow-clip"
+            :original="sdlState.detail.previousSDL"
+            :modified="sdlState.detail.prettyExpectedSDL"
+            :readonly="true"
+            :auto-height="{
+              alignment: 'modified',
+              min: 120,
+              max: 480,
+            }"
+          />
+          <MonacoEditor
+            v-if="state.tab === 'STATEMENT'"
+            class="w-full h-auto border rounded-[3px] overflow-clip"
+            data-label="bb-issue-sql-editor"
+            :content="sdlState.detail.diffDDL"
+            :readonly="true"
+            :auto-focus="false"
+            :auto-height="{ min: 120, max: 360 }"
+          />
+          <MonacoEditor
+            v-if="state.tab === 'SCHEMA'"
+            class="w-full h-auto border rounded-[3px] overflow-clip"
+            data-label="bb-issue-sql-editor"
+            :content="sdlState.detail.expectedSDL"
+            :readonly="true"
+            :auto-focus="false"
+            :auto-height="{ min: 120, max: 360 }"
+            :advices="markers"
+          />
+        </div>
       </template>
     </div>
   </div>

--- a/frontend/src/components/MonacoEditor/MonacoEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoEditor.vue
@@ -10,16 +10,9 @@
 import { v4 as uuidv4 } from "uuid";
 import { computed, toRef } from "vue";
 import type { Language } from "@/types";
-
-const [
-  { default: MonacoTextModelEditor },
-  { useMonacoTextModel },
-  { extensionNameOfLanguage },
-] = await Promise.all([
-  import("./MonacoTextModelEditor.vue"),
-  import("./text-model"),
-  import("./utils"),
-]);
+import MonacoTextModelEditor from "./MonacoTextModelEditor.vue";
+import { useMonacoTextModel } from "./text-model";
+import { extensionNameOfLanguage } from "./utils";
 
 const props = withDefaults(
   defineProps<{

--- a/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script lang="ts" setup>
-import type monaco from "monaco-editor";
 import {
   onMounted,
   ref,
@@ -38,18 +37,25 @@ import {
   useSuggestOptionByLanguage,
 } from "./composables";
 import { shouldUseNewLSP } from "./dev";
-import type { AdviceOption, MonacoModule } from "./types";
+import monaco, { createMonacoEditor } from "./editor";
+import type {
+  AdviceOption,
+  IStandaloneCodeEditor,
+  IStandaloneEditorConstructionOptions,
+  ITextModel,
+  MonacoModule,
+} from "./types";
 
 const props = withDefaults(
   defineProps<{
-    model?: monaco.editor.ITextModel;
+    model?: ITextModel;
     sqlDialect?: SQLDialect;
     readonly?: boolean;
     autoFocus?: boolean;
     autoHeight?: AutoHeightOptions;
     autoCompleteContext?: AutoCompleteContext;
     advices?: AdviceOption[];
-    options?: monaco.editor.IStandaloneEditorConstructionOptions;
+    options?: IStandaloneEditorConstructionOptions;
   }>(),
   {
     model: undefined,
@@ -66,21 +72,15 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: "update:content", content: string): void;
   (e: "select-content", content: string): void;
-  (
-    e: "ready",
-    monaco: MonacoModule,
-    editor: monaco.editor.IStandaloneCodeEditor
-  ): void;
+  (e: "ready", monaco: MonacoModule, editor: IStandaloneCodeEditor): void;
 }>();
 
 const containerRef = ref<HTMLDivElement>();
 // use shallowRef to avoid deep conversion which will cause page crash.
-const editorRef = shallowRef<monaco.editor.IStandaloneCodeEditor>();
+const editorRef = shallowRef<IStandaloneCodeEditor>();
 const ready = ref(false);
 
 onMounted(async () => {
-  const { default: monaco, createMonacoEditor } = await import("./editor");
-
   const container = containerRef.value;
   if (!container) {
     // Give up creating monaco editor if the component has been unmounted

--- a/frontend/src/components/MonacoEditor/WrappedDiffEditor.vue
+++ b/frontend/src/components/MonacoEditor/WrappedDiffEditor.vue
@@ -1,9 +1,44 @@
 <template>
   <Suspense>
     <DiffEditor v-bind="($attrs as any)" />
+    <template #fallback>
+      <div ref="spinnerWrapperElRef" :class="classes">
+        <BBSpin />
+      </div>
+    </template>
   </Suspense>
 </template>
 
 <script setup lang="ts">
-import DiffEditor from "./DiffEditor.vue";
+import { useParentElement } from "@vueuse/core";
+import { computed, defineAsyncComponent, ref } from "vue";
+
+const DiffEditor = defineAsyncComponent(() => import("./DiffEditor.vue"));
+
+const spinnerWrapperElRef = ref<HTMLElement>();
+const parentElRef = useParentElement(spinnerWrapperElRef);
+
+const classes = computed(() => {
+  const classes: string[] = [
+    "flex",
+    "flex-col",
+    "items-center",
+    "justify-center",
+  ];
+  const parent = parentElRef.value;
+  if (parent) {
+    const { position, display } = getComputedStyle(parent);
+    if (["relative", "absolute", "fixed"].includes(position)) {
+      classes.push("absolute", "inset-0", "bg-white/50");
+      return classes;
+    }
+    if (["flex", "inline-flex"].includes(display)) {
+      classes.push("w-full", "h-full", "flex-1");
+      return classes;
+    }
+  }
+
+  classes.push("w-full", "h-full");
+  return classes;
+});
 </script>

--- a/frontend/src/components/MonacoEditor/WrappedMonacoEditor.vue
+++ b/frontend/src/components/MonacoEditor/WrappedMonacoEditor.vue
@@ -1,9 +1,46 @@
 <template>
   <Suspense>
     <MonacoEditor v-bind="($attrs as any)" />
+    <template #fallback>
+      <div ref="spinnerWrapperElRef" :class="classes">
+        <BBSpin />
+      </div>
+    </template>
   </Suspense>
 </template>
 
 <script setup lang="ts">
-import MonacoEditor from "./MonacoEditor.vue";
+import { useParentElement } from "@vueuse/core";
+import { defineAsyncComponent, ref } from "vue";
+import { computed } from "vue";
+import { BBSpin } from "@/bbkit";
+
+const MonacoEditor = defineAsyncComponent(() => import("./MonacoEditor.vue"));
+
+const spinnerWrapperElRef = ref<HTMLElement>();
+const parentElRef = useParentElement(spinnerWrapperElRef);
+
+const classes = computed(() => {
+  const classes: string[] = [
+    "flex",
+    "flex-col",
+    "items-center",
+    "justify-center",
+  ];
+  const parent = parentElRef.value;
+  if (parent) {
+    const { position, display } = getComputedStyle(parent);
+    if (["relative", "absolute", "fixed"].includes(position)) {
+      classes.push("absolute", "inset-0", "bg-white/50");
+      return classes;
+    }
+    if (["flex", "inline-flex"].includes(display)) {
+      classes.push("w-full", "h-full", "flex-1");
+      return classes;
+    }
+  }
+
+  classes.push("w-full", "h-full");
+  return classes;
+});
 </script>

--- a/frontend/src/components/MonacoEditor/types.ts
+++ b/frontend/src/components/MonacoEditor/types.ts
@@ -3,7 +3,13 @@ import type * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 export type MonacoModule = typeof monaco;
 
 export type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
+export type IStandaloneEditorConstructionOptions =
+  monaco.editor.IStandaloneEditorConstructionOptions;
 export type IStandaloneDiffEditor = monaco.editor.IStandaloneDiffEditor;
+export type IStandaloneDiffEditorConstructionOptions =
+  monaco.editor.IStandaloneDiffEditorConstructionOptions;
+
+export type ITextModel = monaco.editor.ITextModel;
 
 export type AdviceOption = {
   severity: "ERROR" | "WARNING";

--- a/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
@@ -9,6 +9,13 @@
 
       <Suspense>
         <SQLEditor @execute="handleExecute" />
+        <template #fallback>
+          <div
+            class="w-full h-auto flex-grow flex flex-col items-center justify-center"
+          >
+            <BBSpin />
+          </div>
+        </template>
       </Suspense>
     </template>
 
@@ -27,6 +34,7 @@
 </template>
 
 <script lang="ts" setup>
+import { defineAsyncComponent } from "vue";
 import { useExecuteSQL } from "@/composables/useExecuteSQL";
 import { AIChatToSQL } from "@/plugins/ai";
 import {
@@ -44,8 +52,9 @@ import {
   SaveSheetModal,
 } from "../EditorCommon";
 import { useSQLEditorContext } from "../context";
-import SQLEditor from "./SQLEditor.vue";
 import SheetForIssueTipsBar from "./SheetForIssueTipsBar.vue";
+
+const SQLEditor = defineAsyncComponent(() => import("./SQLEditor.vue"));
 
 const tabStore = useTabStore();
 const tab = useCurrentTab();

--- a/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/SQLEditor.vue
@@ -28,6 +28,11 @@ import type {
   IStandaloneCodeEditor,
   MonacoModule,
 } from "@/components/MonacoEditor";
+import MonacoEditor from "@/components/MonacoEditor/MonacoEditor.vue";
+import {
+  extensionNameOfLanguage,
+  formatEditorContent,
+} from "@/components/MonacoEditor/utils";
 import {
   useTabStore,
   useSQLEditorStore,
@@ -44,14 +49,6 @@ import {
 } from "@/types";
 import { formatEngineV1, useInstanceV1EditorLanguage } from "@/utils";
 import { useSQLEditorContext } from "../context";
-
-const [
-  { default: MonacoEditor },
-  { extensionNameOfLanguage, formatEditorContent },
-] = await Promise.all([
-  import("@/components/MonacoEditor/MonacoEditor.vue"),
-  import("@/components/MonacoEditor/utils"),
-]);
 
 const emit = defineEmits<{
   (

--- a/frontend/src/views/sql-editor/SecondarySidebar/InfoTabPane/SchemaPanel/HoverPanel/ViewInfo.vue
+++ b/frontend/src/views/sql-editor/SecondarySidebar/InfoTabPane/SchemaPanel/HoverPanel/ViewInfo.vue
@@ -10,11 +10,13 @@
         </NCheckbox>
       </div>
     </div>
-    <MonacoEditor
-      :content="format ? formatted.data : view.definition"
-      :readonly="true"
-      class="border w-full flex-1"
-    />
+    <div class="w-full flex-1 relative">
+      <MonacoEditor
+        :content="format ? formatted.data : view.definition"
+        :readonly="true"
+        class="border w-full h-full"
+      />
+    </div>
   </div>
 </template>
 

--- a/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
@@ -29,6 +29,11 @@ import type {
   IStandaloneCodeEditor,
   MonacoModule,
 } from "@/components/MonacoEditor";
+import MonacoEditor from "@/components/MonacoEditor/MonacoEditor.vue";
+import {
+  useEditorContextKey,
+  formatEditorContent,
+} from "@/components/MonacoEditor/utils";
 import { useTabStore, useSQLEditorStore, useInstanceV1ByUID } from "@/store";
 import {
   dialectOfEngineV1,
@@ -37,21 +42,12 @@ import {
   SQLDialect,
 } from "@/types";
 import { formatEngineV1, useInstanceV1EditorLanguage } from "@/utils";
-
-const [
-  { default: MonacoEditor },
-  { useEditorContextKey, formatEditorContent },
-  {
-    checkCursorAtFirstLine,
-    checkCursorAtLast,
-    checkCursorAtLastLine,
-    checkEndsWithSemicolon,
-  },
-] = await Promise.all([
-  import("@/components/MonacoEditor/MonacoEditor.vue"),
-  import("@/components/MonacoEditor/utils"),
-  import("./utils"),
-]);
+import {
+  checkCursorAtFirstLine,
+  checkCursorAtLast,
+  checkCursorAtLastLine,
+  checkEndsWithSemicolon,
+} from "./utils";
 
 const props = defineProps({
   sql: {

--- a/frontend/src/views/sql-editor/TerminalPanel/TerminalPanelV1.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/TerminalPanelV1.vue
@@ -31,6 +31,13 @@
               @history="handleHistory"
               @clear-screen="handleClearScreen"
             />
+            <template #fallback>
+              <div
+                class="w-full min-h-[2rem] flex flex-col items-center justify-center"
+              >
+                <BBSpin />
+              </div>
+            </template>
           </Suspense>
           <ResultViewV1
             v-if="query.params && query.resultSet"
@@ -70,7 +77,8 @@
 
 <script lang="ts" setup>
 import { useElementSize } from "@vueuse/core";
-import { computed, ref, unref, watch } from "vue";
+import { computed, defineAsyncComponent, ref, unref, watch } from "vue";
+import { BBSpin } from "@/bbkit";
 import { useTabStore, useWebTerminalV1Store } from "@/store";
 import { ExecuteConfig, ExecuteOption, WebTerminalQueryItemV1 } from "@/types";
 import {
@@ -79,9 +87,12 @@ import {
   ConnectionHolder,
   ResultViewV1,
 } from "../EditorCommon";
-import CompactSQLEditor from "./CompactSQLEditor.vue";
 import { useAttractFocus } from "./useAttractFocus";
 import { useHistory } from "./useHistory";
+
+const CompactSQLEditor = defineAsyncComponent(
+  () => import("./CompactSQLEditor.vue")
+);
 
 const tabStore = useTabStore();
 const webTerminalStore = useWebTerminalV1Store();


### PR DESCRIPTION
- Make only the entrance component async, the inner components are synchronous. This helps keep the code simple.
- Add loading spinners for each `<MonacoEditor>` and `<DiffEditor>` use cases.