### PR TITLE
chore(syntax-check): remove useless code for TiDB and MySQL

### DIFF
--- a/backend/plugin/advisor/sql_review.go
+++ b/backend/plugin/advisor/sql_review.go
@@ -581,7 +581,7 @@ func newTiDBParser() *tidbparser.Parser {
 }
 
 func mysqlSyntaxCheck(statement string) (any, []Advice) {
-	res, err := mysqlparser.ParseMySQL(statement + ";")
+	res, err := mysqlparser.ParseMySQL(statement)
 	if err != nil {
 		if syntaxErr, ok := err.(*base.SyntaxError); ok {
 			return nil, []Advice{
@@ -610,7 +610,7 @@ func mysqlSyntaxCheck(statement string) (any, []Advice) {
 }
 
 func tidbSyntaxCheck(statement string) (any, []Advice) {
-	list, err := mysqlparser.SplitSQL(statement)
+	list, err := base.SplitMultiSQL(storepb.Engine_MYSQL, statement)
 	if err != nil {
 		return nil, []Advice{
 			{
@@ -629,33 +629,15 @@ func tidbSyntaxCheck(statement string) (any, []Advice) {
 	for _, item := range list {
 		nodes, _, err := p.Parse(item.Text, "", "")
 		if err != nil {
-			// TiDB parser doesn't fully support MySQL syntax, so we need to use MySQL parser to parse the statement.
-			// But MySQL parser has some performance issue, so we only use it to parse the statement after TiDB parser failed.
-			if _, err := mysqlparser.ParseMySQL(item.Text); err != nil {
-				if syntaxErr, ok := err.(*base.SyntaxError); ok {
-					return nil, []Advice{
-						{
-							Status:  Error,
-							Code:    StatementSyntaxError,
-							Title:   SyntaxErrorTitle,
-							Content: syntaxErr.Message,
-							Line:    syntaxErr.Line,
-							Column:  syntaxErr.Column,
-						},
-					}
-				}
-				return nil, []Advice{
-					{
-						Status:  Warn,
-						Code:    Internal,
-						Title:   "Parse error",
-						Content: err.Error(),
-						Line:    1,
-					},
-				}
+			return nil, []Advice{
+				{
+					Status:  Warn,
+					Code:    Internal,
+					Title:   "Parse error",
+					Content: err.Error(),
+					Line:    1,
+				},
 			}
-			// If MySQL parser can parse the statement, but TiDB parser can't, we just ignore the statement.
-			continue
 		}
 
 		if len(nodes) != 1 {


### PR DESCRIPTION
We have separated the TiDB syntax check and MySQL syntax check, so there is no need to use the MySQL parser in the TiDB syntax check.
For the MySQL parser, we add a semicolon if needed in the `ParseMySQL`, there is no need to add a semicolon here.