### PR TITLE
feat(frontend): SQL Editor height improvement for issue detail page

### DIFF
--- a/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/IssueV1/components/StatementSection/EditorView/EditorView.vue
@@ -164,20 +164,22 @@
     v-model:show="state.showEditorModal"
     :title="statementTitle"
     :trap-focus="true"
-    header-class="!border-b-0 !mx-4"
-    container-class="!pt-0 !px-4"
+    header-class="!border-b-0"
+    container-class="!pt-0 !overflow-hidden"
   >
     <div
       id="modal-editor-container"
       style="
-        width: calc(100vw - 8rem);
-        height: calc(100vh - 8rem);
+        width: calc(100vw - 10rem);
+        height: calc(100vh - 10rem);
+        overflow: hidden;
         position: relative;
       "
+      class="border rounded-[3px]"
     >
       <MonacoEditor
         v-if="state.showEditorModal"
-        class="w-full h-full border"
+        class="w-full h-full"
         :filename="filename"
         :content="state.statement"
         :language="language"


### PR DESCRIPTION
The Editor's height varies from 120px to 240px (~= 5 rows to 10 rows). The expand button shows once the editor's height exceeds the upper limit (240px). Clicking on it will open the fullscreen editor.

https://github.com/bytebase/bytebase/assets/2749742/b8b2d063-a2c7-4132-97d1-4605085ee8e4

Close BYT-4407