### PR TITLE
chore: update branch tree checks

### DIFF
--- a/backend/api/v1/schema_design_service.go
+++ b/backend/api/v1/schema_design_service.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strconv"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,10 +19,6 @@ import (
 	"github.com/bytebase/bytebase/backend/store"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
-)
-
-var (
-	schemaDesignCache, _ = lru.New[string, *v1pb.SchemaDesign](32768)
 )
 
 // SchemaDesignService implements SchemaDesignServiceServer interface.
@@ -43,9 +38,6 @@ func NewSchemaDesignService(store *store.Store, licenseService enterprise.Licens
 
 // GetSchemaDesign gets the schema design.
 func (s *SchemaDesignService) GetSchemaDesign(ctx context.Context, request *v1pb.GetSchemaDesignRequest) (*v1pb.SchemaDesign, error) {
-	if v, ok := schemaDesignCache.Get(request.Name); ok {
-		return v, nil
-	}
 	_, sheetID, err := common.GetProjectResourceIDAndSchemaDesignSheetID(request.Name)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
@@ -71,7 +63,6 @@ func (s *SchemaDesignService) GetSchemaDesign(ctx context.Context, request *v1pb
 	if err != nil {
 		return nil, err
 	}
-	schemaDesignCache.Add(request.Name, schemaDesign)
 	return schemaDesign, nil
 }
 

--- a/backend/api/v1/schema_design_service.go
+++ b/backend/api/v1/schema_design_service.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strconv"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -19,6 +20,10 @@ import (
 	"github.com/bytebase/bytebase/backend/store"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
+)
+
+var (
+	schemaDesignCache, _ = lru.New[string, *v1pb.SchemaDesign](32768)
 )
 
 // SchemaDesignService implements SchemaDesignServiceServer interface.
@@ -38,6 +43,9 @@ func NewSchemaDesignService(store *store.Store, licenseService enterprise.Licens
 
 // GetSchemaDesign gets the schema design.
 func (s *SchemaDesignService) GetSchemaDesign(ctx context.Context, request *v1pb.GetSchemaDesignRequest) (*v1pb.SchemaDesign, error) {
+	if v, ok := schemaDesignCache.Get(request.Name); ok {
+		return v, nil
+	}
 	_, sheetID, err := common.GetProjectResourceIDAndSchemaDesignSheetID(request.Name)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
@@ -63,6 +71,7 @@ func (s *SchemaDesignService) GetSchemaDesign(ctx context.Context, request *v1pb
 	if err != nil {
 		return nil, err
 	}
+	schemaDesignCache.Add(request.Name, schemaDesign)
 	return schemaDesign, nil
 }
 

--- a/frontend/src/components/SchemaEditorV1/utils/branch.ts
+++ b/frontend/src/components/SchemaEditorV1/utils/branch.ts
@@ -1,3 +1,4 @@
+import { markRaw } from "vue";
 import { useSchemaDesignStore } from "@/store/modules/schemaDesign";
 import { DatabaseMetadata } from "@/types/proto/v1/database_service";
 import {
@@ -26,9 +27,9 @@ export const convertBranchToBranchSchema = async (
   );
 
   return {
-    branch,
+    branch: markRaw(branch),
     schemaList: editableSchemas,
-    originSchemaList: originalSchemas,
+    originSchemaList: markRaw(originalSchemas),
   };
 };
 

--- a/frontend/src/components/SchemaEditorV1/utils/database.ts
+++ b/frontend/src/components/SchemaEditorV1/utils/database.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from "lodash-es";
+import { markRaw } from "vue";
 import {
   useDBSchemaV1Store,
   useDatabaseV1Store,
@@ -38,7 +39,7 @@ export const fetchSchemaListByDatabaseName = async ({
   schemaEditorV1Store.resourceMap.database.set(database, {
     database: db,
     schemaList,
-    originSchemaList: cloneDeep(schemaList),
+    originSchemaList: markRaw(cloneDeep(schemaList)),
   });
   return schemaList;
 };


### PR DESCRIPTION
* Skip check if schema changed for branches. (Because checking for changes is very resource intensive, especially if there are a lot of tables.)
* Add `markRaw` to those objects don't need to be reactive.