### PR TITLE
chore: use default restore flag with lowercase keyword

### DIFF
--- a/backend/api/v1/schema_design_transformer_tidb.go
+++ b/backend/api/v1/schema_design_transformer_tidb.go
@@ -271,9 +271,7 @@ func tidbRestoreFieldType(fieldType *tidbtypes.FieldType) (string, error) {
 	}
 	var buffer strings.Builder
 	// we want to use Default format flags but with lowercase keyword.
-	flag := tidbformat.DefaultRestoreFlags
-	flag &= ^tidbformat.RestoreKeyWordUppercase
-	flag |= tidbformat.RestoreKeyWordLowercase
+	flag := tidbformat.RestoreKeyWordLowercase | tidbformat.RestoreStringSingleQuotes | tidbformat.RestoreNameBackQuotes
 	ctx := tidbformat.NewRestoreCtx(flag, &buffer)
 	if err := fieldType.Restore(ctx); err != nil {
 		return "", err

--- a/backend/api/v1/schema_design_transformer_tidb.go
+++ b/backend/api/v1/schema_design_transformer_tidb.go
@@ -270,7 +270,10 @@ func tidbRestoreFieldType(fieldType *tidbtypes.FieldType) (string, error) {
 		return fieldType.CompactStr(), nil
 	}
 	var buffer strings.Builder
-	flag := tidbformat.RestoreKeyWordLowercase | tidbformat.RestoreStringSingleQuotes
+	// we want to use Default format flags but with lowercase keyword.
+	flag := tidbformat.DefaultRestoreFlags
+	flag &= ^tidbformat.RestoreKeyWordUppercase
+	flag |= tidbformat.RestoreKeyWordLowercase
 	ctx := tidbformat.NewRestoreCtx(flag, &buffer)
 	if err := fieldType.Restore(ctx); err != nil {
 		return "", err


### PR DESCRIPTION
use more appropriate restore flag instead of ` tidbformat.RestoreKeyWordLowercase | tidbformat.RestoreStringSingleQuotes`

ref https://github.com/bytebase/bytebase/pull/8975