### PR TITLE
fix: update sidebar style

### DIFF
--- a/frontend/src/components/CommonSidebar.vue
+++ b/frontend/src/components/CommonSidebar.vue
@@ -1,12 +1,12 @@
 <template>
   <nav class="flex-1 flex flex-col overflow-y-hidden">
     <BytebaseLogo v-if="showLogo" class="w-full px-4 shrink-0" />
-    <div class="flex-1 overflow-y-auto px-2">
+    <div class="flex-1 overflow-y-auto px-2.5">
       <div v-for="(item, i) in filteredSidebarList" :key="i">
         <router-link
           v-if="item.type === 'route'"
           :to="item.path ?? ''"
-          class="outline-item group w-full font-medium flex items-center px-2 py-1.5 !text-base"
+          class="outline-item group w-full font-medium flex items-center px-2 py-1.5 !text--sm rounded-md mb-1"
           :class="getItemClass(item.path)"
         >
           <component :is="item.icon" class="mr-2 w-5 h-5 text-gray-500" />
@@ -40,7 +40,7 @@
         </a>
         <div
           v-else-if="item.type === 'divider'"
-          class="border-t border-gray-300 my-2"
+          class="border-t border-gray-300 my-2.5 mr-4 ml-2"
         />
         <div
           v-if="item.children.length > 0 && state.expandedSidebar.has(i)"


### PR DESCRIPTION
<img width="209" alt="image" src="https://github.com/bytebase/bytebase/assets/94903075/8d552ee1-f9a1-4172-b3b1-fba260060133">
<img width="209" alt="image" src="https://github.com/bytebase/bytebase/assets/94903075/caf25b7f-c69e-4771-8e45-6874f495b496">

1. There's no font-size in between, so the smaller one is picked
2. add small corner while chosen/hovered
3. add margin bottom to the list item to give more space
4. shrink the divider line a bit and add margin 