### PR TITLE
fix(smtp): fix host name error in smtp authentication

### DIFF
--- a/backend/plugin/mail/mail.go
+++ b/backend/plugin/mail/mail.go
@@ -188,7 +188,7 @@ func (c *SMTPClient) SendMail(e *Email) error {
 	case SMTPEncryptionTypeNone:
 		return e.e.Send(fmt.Sprintf("%s:%d", c.host, c.port), c.getAuth())
 	case SMTPEncryptionTypeSSLTLS:
-		return e.e.SendWithTLS(fmt.Sprintf("%s:%d", c.host, c.port), c.getAuth(), &tls.Config{})
+		return e.e.SendWithTLS(fmt.Sprintf("%s:%d", c.host, c.port), c.getAuth(), &tls.Config{ServerName: c.host})
 	case SMTPEncryptionTypeSTARTTLS:
 		return e.e.SendWithStartTLS(fmt.Sprintf("%s:%d", c.host, c.port), c.getAuth(), &tls.Config{InsecureSkipVerify: true})
 	default:


### PR DESCRIPTION
Fixed the problem that in SMTP configuration, when Authentication Method is PLAIN and Encryption is SSL/TLS, SMTP authentication will throw `wrong host name` error:

```
Code 3: /bytebase.v1.SettingService/SetSetting INVALID_ARGUMENT: failed to validate smtp setting: rpc error: code = Internal desc = failed to send test email: wrong host name

failed to validate smtp setting: rpc error: code = Internal desc = failed to send test email: wrong host name
```