### PR TITLE
chore: remove fetchBaselineMetadataOfBranch since branches are independent

### DIFF
--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -133,9 +133,9 @@ import {
   projectNamePrefix,
 } from "@/store/modules/v1/common";
 import { Branch } from "@/types/proto/v1/branch_service";
+import { DatabaseMetadata } from "@/types/proto/v1/database_service";
 import { projectV1Slug } from "@/utils";
 import { provideSQLCheckContext } from "../SQLCheck";
-import { fetchBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
 import MergeBranchPanel from "./MergeBranchPanel.vue";
 import SchemaDesignEditor from "./SchemaDesignEditor.vue";
 import { generateForkedBranchName, validateBranchName } from "./utils";
@@ -323,9 +323,9 @@ const handleCancelEdit = async () => {
     return;
   }
 
-  const baselineMetadata = await fetchBaselineMetadataOfBranch(
-    branchSchema.branch
-  );
+  const baselineMetadata =
+    branchSchema.branch.baselineSchemaMetadata ||
+    DatabaseMetadata.fromPartial({});
   const mergedMetadata = mergeSchemaEditToMetadata(
     branchSchema.schemaList,
     cloneDeep(baselineMetadata)
@@ -358,9 +358,9 @@ const handleSaveBranch = async () => {
     return;
   }
 
-  const baselineMetadata = await fetchBaselineMetadataOfBranch(
-    branchSchema.branch
-  );
+  const baselineMetadata =
+    branchSchema.branch.baselineSchemaMetadata ||
+    DatabaseMetadata.fromPartial({});
   const mergedMetadata = mergeSchemaEditToMetadata(
     branchSchema.schemaList,
     cloneDeep(baselineMetadata)
@@ -448,10 +448,6 @@ const handleSaveBranch = async () => {
       await branchStore.updateBranch(
         Branch.fromPartial({
           name: branch.value.name,
-          branchId: state.branchId,
-          engine: branch.value.engine,
-          baselineDatabase: branch.value.baselineDatabase,
-          baselineSchema: branch.value.baselineSchema,
           schemaMetadata: mergedMetadata,
         }),
         updateMask

--- a/frontend/src/components/Branch/SchemaDesignEditor.vue
+++ b/frontend/src/components/Branch/SchemaDesignEditor.vue
@@ -69,12 +69,12 @@ import {
 } from "@/store";
 import { ComposedProject } from "@/types";
 import { Branch } from "@/types/proto/v1/branch_service";
+import { DatabaseMetadata } from "@/types/proto/v1/database_service";
 import { MonacoEditor } from "../MonacoEditor";
 import {
   mergeSchemaEditToMetadata,
   validateDatabaseMetadata,
 } from "../SchemaEditorV1/utils";
-import { fetchBaselineMetadataOfBranch } from "../SchemaEditorV1/utils/branch";
 
 type TabType = "schema-editor" | "raw-sql-preview";
 
@@ -119,7 +119,6 @@ const fetchRawSQLPreview = async () => {
     return;
   }
 
-  const sourceMetadata = await fetchBaselineMetadataOfBranch(props.branch);
   const branchSchema = schemaEditorV1Store.resourceMap["branch"].get(
     props.branch.name
   );
@@ -127,9 +126,10 @@ const fetchRawSQLPreview = async () => {
     return undefined;
   }
 
-  const baselineMetadata = await fetchBaselineMetadataOfBranch(
-    branchSchema.branch
-  );
+  const sourceMetadata = props.branch.baselineSchemaMetadata;
+  const baselineMetadata =
+    branchSchema.branch.baselineSchemaMetadata ||
+    DatabaseMetadata.fromPartial({});
   const metadata = mergeSchemaEditToMetadata(
     branchSchema.schemaList,
     cloneDeep(baselineMetadata)

--- a/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/AddChangePanel.vue
+++ b/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/AddChangePanel.vue
@@ -84,7 +84,6 @@ import { NRadio, NRadioGroup } from "naive-ui";
 import { zindexable as vZindexable } from "vdirs";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { fetchBaselineMetadataOfBranch } from "@/components/SchemaEditorV1/utils/branch";
 import { Drawer, DrawerContent, ErrorTipsButton } from "@/components/v2";
 import { branchServiceClient } from "@/grpcweb";
 import {
@@ -174,12 +173,10 @@ const doAddChange = async () => {
           change.source,
           false /* !useCache */
         );
-        const source = await fetchBaselineMetadataOfBranch(branch);
-        const target = branch.schemaMetadata;
 
         const { diff } = await branchServiceClient.diffMetadata({
-          sourceMetadata: source,
-          targetMetadata: target,
+          sourceMetadata: branch.baselineSchemaMetadata,
+          targetMetadata: branch.schemaMetadata,
           engine: branch.engine,
         });
         setSheetStatement(sheet, diff);

--- a/frontend/src/components/SchemaEditorV1/utils/branch.ts
+++ b/frontend/src/components/SchemaEditorV1/utils/branch.ts
@@ -1,5 +1,4 @@
 import { markRaw } from "vue";
-import { useBranchStore } from "@/store/modules/branch";
 import { Branch } from "@/types/proto/v1/branch_service";
 import { DatabaseMetadata } from "@/types/proto/v1/database_service";
 import {
@@ -11,7 +10,8 @@ import { rebuildEditableSchemas } from "./metadata";
 export const convertBranchToBranchSchema = async (
   branch: Branch
 ): Promise<BranchSchema> => {
-  const baselineMetadata = await fetchBaselineMetadataOfBranch(branch);
+  const baselineMetadata =
+    branch.baselineSchemaMetadata || DatabaseMetadata.fromPartial({});
   const originalSchemas = convertSchemaMetadataList(
     baselineMetadata.schemas || [],
     baselineMetadata.schemaConfigs || []
@@ -28,20 +28,4 @@ export const convertBranchToBranchSchema = async (
     schemaList: editableSchemas,
     originSchemaList: markRaw(originalSchemas),
   };
-};
-
-export const fetchBaselineMetadataOfBranch = async (
-  branch: Branch
-): Promise<DatabaseMetadata> => {
-  // For personal branches, we use its parent branch's schema as the original schema in editing state.
-  if (branch.parentBranch !== "") {
-    const parentBranch = await useBranchStore().fetchBranchByName(
-      branch.parentBranch,
-      false /* !useCache */
-    );
-    return (
-      parentBranch.baselineSchemaMetadata || DatabaseMetadata.fromPartial({})
-    );
-  }
-  return branch.baselineSchemaMetadata || DatabaseMetadata.fromPartial({});
 };


### PR DESCRIPTION
Child branch should never depend on parent branch for anything. Once we've created a branch, it has nothing to do with the parent branch even for merging branches.