### PR TITLE
chore: optimize multi-line mongo json display

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
@@ -63,7 +63,7 @@ const database = computed(() => {
 const valueContainerAdditionalClass = computed(() => {
   // Always only show the first line for MongoDB.
   if (database.value.instanceEntity.engine === Engine.MONGODB) {
-    return "line-clamp-1";
+    return "!whitespace-nowrap";
   }
   return "";
 });
@@ -72,8 +72,10 @@ const clickable = computed(() => {
   if (truncated.value) return true;
   if (database.value.instanceEntity.engine === Engine.MONGODB) {
     // A cheap way to check JSON string without paying the parsing cost.
+    const maybeJSON = String(props.value).trim();
     return (
-      String(props.value).startsWith("{") && String(props.value).endsWith("}")
+      (maybeJSON.startsWith("{") && maybeJSON.endsWith("}")) ||
+      (maybeJSON.startsWith("[") && maybeJSON.endsWith("]"))
     );
   }
   return false;


### PR DESCRIPTION
- No longer apply `line-clamp-1` to MongoDB results
- Apply `whitespace-nowrap` instead
- Array-like JSON should also be "clickable" to expand the detail panel.

**Before**
![20231204-135342-2](https://github.com/bytebase/bytebase/assets/2749742/8d674f7a-e6fc-4360-b14f-c0314fd7b6c4)

**After**
<img width="1011" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/56dcb114-243e-4eb7-a75b-4387b619a725">
