### PR TITLE
chore(sql-server): specify tlsmin

### DIFF
--- a/backend/plugin/db/mssql/mssql.go
+++ b/backend/plugin/db/mssql/mssql.go
@@ -54,6 +54,7 @@ func (driver *Driver) Open(_ context.Context, _ storepb.Engine, config db.Connec
 	}
 
 	// In order to be compatible with db servers that only support old versions of tls.
+	// See: https://github.com/microsoft/go-mssqldb/issues/33
 	query.Add("tlsmin", "1.0")
 	u := &url.URL{
 		Scheme:   "sqlserver",


### PR DESCRIPTION
close BYT-4275

follow this https://github.com/microsoft/go-mssqldb/issues/33, we can be compatible with sql-servers which only support old versions of tls.
