### PR TITLE
chore: search databases by project assigned status

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/useSearchScopeOptions.ts
+++ b/frontend/src/components/IssueV1/components/IssueSearch/useSearchScopeOptions.ts
@@ -270,6 +270,31 @@ export const useSearchScopeOptions = (
           },
         ],
       },
+      {
+        id: "project-assigned",
+        title: t("issue.advanced-search.scope.project-assigned.title"),
+        description: t(
+          "issue.advanced-search.scope.project-assigned.description"
+        ),
+        options: [
+          {
+            value: "yes",
+            keywords: ["yes"],
+            render: () =>
+              renderSpan(
+                t("issue.advanced-search.scope.project-assigned.value.yes")
+              ),
+          },
+          {
+            value: "no",
+            keywords: ["no"],
+            render: () =>
+              renderSpan(
+                t("issue.advanced-search.scope.project-assigned.value.no")
+              ),
+          },
+        ],
+      },
     ];
     const supportOptionIdSet = new Set(supportOptionIdList);
     return scopes.filter((scope) => supportOptionIdSet.has(scope.id));

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1018,6 +1018,14 @@
           },
           "description": "Search by the issue approval status",
           "title": "Approval Status"
+        },
+        "project-assigned": {
+          "title": "Project Assigned",
+          "description": "Search by databases that are assigned to a project.",
+          "value": {
+            "yes": "yes",
+            "no": "no"
+          }
         }
       },
       "hide": "Hide advanced search"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1017,6 +1017,14 @@
           },
           "description": "Buscar por estado de revisión del problema",
           "title": "Estado de aprobación"
+        },
+        "project-assigned": {
+          "title": "Proyecto asignado",
+          "description": "Buscar en las bases de datos con proyecto asignado",
+          "value": {
+            "yes": "yes",
+            "no": "no"
+          }
         }
       },
       "hide": "Ocultar búsqueda avanzada"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1015,6 +1015,14 @@
           },
           "description": "按工单的审批状态搜索",
           "title": "审批状态"
+        },
+        "project-assigned": {
+          "title": "已分配项目",
+          "description": "按数据库的项目分配状态搜索",
+          "value": {
+            "yes": "是",
+            "no": "否"
+          }
         }
       },
       "hide": "隐藏高级搜索"

--- a/frontend/src/utils/v1/issue/search/common.ts
+++ b/frontend/src/utils/v1/issue/search/common.ts
@@ -8,6 +8,8 @@ export const UIIssueFilterScopeIdList = [
   "releaser",
 ] as const;
 type UIIssueFilterScopeId = typeof UIIssueFilterScopeIdList[number];
+export const DatabaseFilterScopeIdList = ["project-assigned"] as const;
+type DatabaseFilterScopeId = typeof DatabaseFilterScopeIdList[number];
 
 export const CommonFilterScopeIdList = ["environment", "instance"] as const;
 type CommonFilterScopeId = typeof CommonFilterScopeIdList[number];
@@ -27,6 +29,7 @@ export const SearchScopeIdList = [
 export type SearchScopeId =
   | typeof SearchScopeIdList[number]
   | UIIssueFilterScopeId
+  | DatabaseFilterScopeId
   | CommonFilterScopeId;
 
 export type SearchScope = {

--- a/frontend/src/views/DatabaseDashboard.vue
+++ b/frontend/src/views/DatabaseDashboard.vue
@@ -161,6 +161,13 @@ const selectedEnvironment = computed(() => {
   );
 });
 
+const selectedProjectAssigned = computed(() => {
+  return (
+    state.params.scopes.find((scope) => scope.id === "project-assigned")
+      ?.value ?? `${UNKNOWN_ID}`
+  );
+});
+
 const selectedProject = computed(() => {
   return (
     state.params.scopes.find((scope) => scope.id === "project")?.value ??
@@ -221,6 +228,15 @@ const filteredDatabaseList = computed(() => {
         extractEnvironmentResourceName(db.effectiveEnvironment) ===
         selectedEnvironment.value
     );
+  }
+  if (selectedProjectAssigned.value !== `${UNKNOWN_ID}`) {
+    list = list.filter((db) => {
+      if (selectedProjectAssigned.value == "yes") {
+        return db.project !== DEFAULT_PROJECT_V1_NAME;
+      } else {
+        return db.project === DEFAULT_PROJECT_V1_NAME;
+      }
+    });
   }
   if (selectedInstance.value !== `${UNKNOWN_ID}`) {
     list = list.filter(
@@ -330,5 +346,6 @@ const selectedDatabases = computed((): ComposedDatabase[] => {
 const supportOptionIdList = computed((): SearchScopeId[] => [
   ...CommonFilterScopeIdList,
   "project",
+  "project-assigned",
 ]);
 </script>


### PR DESCRIPTION
I'd like to get rid of default project/unassigned magic in both backend and frontend. In this case, the current project scope search by "default" or "unassigned" will force project-id != default/unassigned. I couldn't think of a better way than introducing "project-assigned" filter scope.

<img width="936" alt="Screenshot 2023-12-12 at 05 50 28" src="https://github.com/bytebase/bytebase/assets/98006139/68495ed2-bda9-4271-82d6-baff197c98f4">
<img width="977" alt="Screenshot 2023-12-12 at 05 50 32" src="https://github.com/bytebase/bytebase/assets/98006139/ce003602-722f-499f-83c2-87afa63f437f">
