### PR TITLE
fix: set ast node position by tidb splitter

### DIFF
--- a/backend/plugin/advisor/catalog/walk_through.go
+++ b/backend/plugin/advisor/catalog/walk_through.go
@@ -40,7 +40,7 @@ const (
 	ErrorTypeParseError WalkThroughErrorType = 101
 	// ErrorTypeDeparseError is the error in deparsing.
 	ErrorTypeDeparseError WalkThroughErrorType = 102
-	// ErrorTypeDeparseError is the error in setting line for statement.
+	// ErrorTypeSetLineError is the error in setting line for statement.
 	ErrorTypeSetLineError WalkThroughErrorType = 103
 
 	// 201 ~ 299 database error type.
@@ -143,7 +143,7 @@ func NewParseError(content string) *WalkThroughError {
 	}
 }
 
-// NewParseError returns a new ErrorTypeParseError.
+// NewSetLineError returns a new ErrorTypeParseError.
 func NewSetLineError(content string) *WalkThroughError {
 	return &WalkThroughError{
 		Type:    ErrorTypeSetLineError,

--- a/backend/plugin/advisor/catalog/walk_through.go
+++ b/backend/plugin/advisor/catalog/walk_through.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	mysqlparser "github.com/bytebase/mysql-parser"
-
 	tidbparser "github.com/pingcap/tidb/pkg/parser"
 	tidbast "github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
@@ -13,7 +11,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 
-	mysqlbbparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	tidbbbparser "github.com/bytebase/bytebase/backend/plugin/parser/tidb"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
@@ -1354,47 +1352,35 @@ func (*DatabaseState) parse(statement string) ([]tidbast.StmtNode, *WalkThroughE
 	// See https://github.com/bytebase/bytebase/issues/175.
 	p.EnableWindowFunc(true)
 
-	treeList, err := mysqlbbparser.ParseMySQL(statement)
+	list, err := base.SplitMultiSQL(storepb.Engine_TIDB, statement)
 	if err != nil {
 		return nil, NewParseError(err.Error())
 	}
-	if len(treeList) == 0 {
-		return nil, nil
-	}
 
 	var returnNodes []tidbast.StmtNode
-	for _, item := range treeList {
-		tree := item.Tree
-		tokens := item.Tokens
+	for _, item := range list {
+		nodes, _, err := p.Parse(item.Text, "", "")
+		if err != nil {
+			return nil, NewParseError(err.Error())
+		}
 
-		for _, child := range tree.GetChildren() {
-			if child == nil {
-				continue
-			}
+		if len(nodes) != 1 {
+			continue
+		}
 
-			if query, ok := child.(mysqlparser.IQueryContext); ok {
-				text := tokens.GetTextFromRuleContext(query)
-				lastLine := query.GetStop().GetLine() + item.BaseLine
-
-				if nodes, _, err := p.Parse(text, "", ""); err == nil {
-					if len(nodes) != 1 {
-						continue
-					}
-					node := nodes[0]
-					node.SetText(nil, text)
-					node.SetOriginTextPosition(lastLine)
-					if n, ok := node.(*tidbast.CreateTableStmt); ok {
-						if err := tidbbbparser.SetLineForMySQLCreateTableStmt(n); err != nil {
-							return nil, NewParseError(err.Error())
-						}
-					}
-					returnNodes = append(returnNodes, node)
-				}
+		node := nodes[0]
+		node.SetText(nil, item.Text)
+		node.SetOriginTextPosition(item.LastLine)
+		if n, ok := node.(*tidbast.CreateTableStmt); ok {
+			if err := tidbbbparser.SetLineForMySQLCreateTableStmt(n); err != nil {
+				return nil, NewParseError(err.Error())
 			}
 		}
+		returnNodes = append(returnNodes, node)
 	}
 
 	return returnNodes, nil
+	// return nil, NewParseError(err.Error())
 }
 
 func restoreNode(node tidbast.Node, flag format.RestoreFlags) (string, *WalkThroughError) {

--- a/backend/plugin/advisor/sql_review.go
+++ b/backend/plugin/advisor/sql_review.go
@@ -610,7 +610,7 @@ func mysqlSyntaxCheck(statement string) (any, []Advice) {
 }
 
 func tidbSyntaxCheck(statement string) (any, []Advice) {
-	list, err := base.SplitMultiSQL(storepb.Engine_MYSQL, statement)
+	list, err := base.SplitMultiSQL(storepb.Engine_TIDB, statement)
 	if err != nil {
 		return nil, []Advice{
 			{

--- a/backend/plugin/advisor/tidb/test/column_auto_increment_initial_value.yaml
+++ b/backend/plugin/advisor/tidb/test/column_auto_increment_initial_value.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a int auto_increment) auto_increment = 20
   want:
@@ -13,6 +14,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a int auto_increment) auto_increment = 2
   want:
@@ -20,5 +22,6 @@
       code: 416
       title: column.auto-increment-initial-value
       content: The initial auto-increment value in table `t` is 2, which doesn't equal 20
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_auto_increment_must_integer.yaml
+++ b/backend/plugin/advisor/tidb/test/column_auto_increment_must_integer.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a varchar(255) AUTO_INCREMENT)
   want:
@@ -12,7 +13,8 @@
       code: 410
       title: column.auto-increment-must-integer
       content: Auto-increment column `t`.`a` requires integer type
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int);
@@ -22,7 +24,8 @@
       code: 410
       title: column.auto-increment-must-integer
       content: Auto-increment column `t`.`a` requires integer type
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -32,7 +35,8 @@
       code: 410
       title: column.auto-increment-must-integer
       content: Auto-increment column `t`.`a` requires integer type
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int);
@@ -42,5 +46,6 @@
       code: 410
       title: column.auto-increment-must-integer
       content: Auto-increment column `t`.`a` requires integer type
-      line: 1
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_auto_increment_must_unsigned.yaml
+++ b/backend/plugin/advisor/tidb/test/column_auto_increment_must_unsigned.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a INT AUTO_INCREMENT)
   want:
@@ -12,7 +13,8 @@
       code: 417
       title: column.auto-increment-must-unsigned
       content: Auto-increment column `t`.`a` is not UNSIGNED type
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int);
@@ -22,7 +24,8 @@
       code: 417
       title: column.auto-increment-must-unsigned
       content: Auto-increment column `t`.`a` is not UNSIGNED type
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -32,7 +35,8 @@
       code: 417
       title: column.auto-increment-must-unsigned
       content: Auto-increment column `t`.`a` is not UNSIGNED type
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int);
@@ -42,5 +46,6 @@
       code: 417
       title: column.auto-increment-must-unsigned
       content: Auto-increment column `t`.`a` is not UNSIGNED type
-      line: 1
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_comment.yaml
+++ b/backend/plugin/advisor/tidb/test/column_comment.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(
@@ -16,19 +17,22 @@
       code: 409
       title: column.comment
       content: The length of column `t`.`a` comment should be within 10 characters
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 408
       title: column.comment
       content: Column `t`.`b` requires comments
-      line: 2
+      line: 3
+      column: 0
       details: ""
     - status: WARN
       code: 408
       title: column.comment
       content: Column `t`.`c` requires comments
-      line: 3
+      line: 4
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int COMMENT 'comment');
@@ -38,7 +42,8 @@
       code: 408
       title: column.comment
       content: Column `t`.`b` requires comments
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int COMMENT 'this is comment');
@@ -48,13 +53,15 @@
       code: 409
       title: column.comment
       content: The length of column `t`.`a` comment should be within 10 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 408
       title: column.comment
       content: Column `t`.`b` requires comments
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int COMMENT 'It is comment');
@@ -64,13 +71,15 @@
       code: 409
       title: column.comment
       content: The length of column `t`.`b` comment should be within 10 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 408
       title: column.comment
       content: Column `t`.`b` requires comments
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int COMMENT 'It is COMMENT');
@@ -80,11 +89,13 @@
       code: 409
       title: column.comment
       content: The length of column `t`.`b` comment should be within 10 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 409
       title: column.comment
       content: The length of column `t`.`b` comment should be within 10 characters
-      line: 1
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_current_time_count_limit.yaml
+++ b/backend/plugin/advisor/tidb/test/column_current_time_count_limit.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(
@@ -17,7 +18,8 @@
       code: 418
       title: column.current-time-count-limit
       content: Table `t` has 3 DEFAULT CURRENT_TIMESTAMP() columns. The count greater than 2.
-      line: 4
+      line: 5
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(
@@ -29,7 +31,8 @@
       code: 419
       title: column.current-time-count-limit
       content: Table `t` has 2 ON UPDATE CURRENT_TIMESTAMP() columns. The count greater than 1.
-      line: 3
+      line: 4
+      column: 0
       details: ""
 - statement: |-
     ALTER TABLE tech_book ADD COLUMN a timestamp default now() on update localtime;
@@ -39,5 +42,6 @@
       code: 419
       title: column.current-time-count-limit
       content: Table `tech_book` has 2 ON UPDATE CURRENT_TIMESTAMP() columns. The count greater than 1.
-      line: 1
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_disallow_change.yaml
+++ b/backend/plugin/advisor/tidb/test/column_disallow_change.yaml
@@ -7,6 +7,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int);
@@ -15,8 +16,7 @@
     - status: WARN
       code: 406
       title: column.disallow-change
-      content: |-
-        "
-        ALTER TABLE t CHANGE COLUMN b a int;" contains CHANGE COLUMN statement
-      line: 1
+      content: '"ALTER TABLE t CHANGE COLUMN b a int" contains CHANGE COLUMN statement'
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_disallow_change_type.yaml
+++ b/backend/plugin/advisor/tidb/test/column_disallow_change_type.yaml
@@ -3,9 +3,9 @@
     - status: WARN
       code: 403
       title: column.disallow-change-type
-      content: |-
-        "ALTER TABLE tech_book MODIFY id INTEGER UNSIGNED;" changes column type
-      line: 0
+      content: '"ALTER TABLE tech_book MODIFY id INTEGER UNSIGNED" changes column type'
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY id int
   want:
@@ -14,22 +14,23 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY id bigint
   want:
     - status: WARN
       code: 403
       title: column.disallow-change-type
-      content: |-
-        "ALTER TABLE tech_book MODIFY id bigint;" changes column type
-      line: 0
+      content: '"ALTER TABLE tech_book MODIFY id bigint" changes column type'
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book CHANGE name uname varchar(20)
   want:
     - status: WARN
       code: 403
       title: column.disallow-change-type
-      content: |-
-        "ALTER TABLE tech_book CHANGE name uname varchar(20);" changes column type
-      line: 0
+      content: '"ALTER TABLE tech_book CHANGE name uname varchar(20)" changes column type'
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_disallow_changing_order.yaml
+++ b/backend/plugin/advisor/tidb/test/column_disallow_changing_order.yaml
@@ -7,6 +7,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -15,10 +16,9 @@
     - status: WARN
       code: 407
       title: column.disallow-changing-order
-      content: |-
-        "
-        ALTER TABLE t MODIFY COLUMN a int FIRST;" changes column order
-      line: 1
+      content: '"ALTER TABLE t MODIFY COLUMN a int FIRST" changes column order'
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int, a1 int);
@@ -27,10 +27,9 @@
     - status: WARN
       code: 407
       title: column.disallow-changing-order
-      content: |-
-        "
-        ALTER TABLE t CHANGE COLUMN a1 a int FIRST;" changes column order
-      line: 1
+      content: '"ALTER TABLE t CHANGE COLUMN a1 a int FIRST" changes column order'
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int, b int);
@@ -39,10 +38,9 @@
     - status: WARN
       code: 407
       title: column.disallow-changing-order
-      content: |-
-        "
-        ALTER TABLE t MODIFY COLUMN a int AFTER b;" changes column order
-      line: 1
+      content: '"ALTER TABLE t MODIFY COLUMN a int AFTER b" changes column order'
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a1 int, b int);
@@ -51,8 +49,7 @@
     - status: WARN
       code: 407
       title: column.disallow-changing-order
-      content: |-
-        "
-        ALTER TABLE t CHANGE COLUMN a1 a int AFTER b;" changes column order
-      line: 1
+      content: '"ALTER TABLE t CHANGE COLUMN a1 a int AFTER b" changes column order'
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_disallow_drop_in_index.yaml
+++ b/backend/plugin/advisor/tidb/test/column_disallow_drop_in_index.yaml
@@ -7,17 +7,18 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
-
 - statement: |-
     CREATE TABLE t(a int, b int, INDEX idx_b(b));
     ALTER TABLE t DROP COLUMN b
   want:
     - status: WARN
       code: 424
-      title: "column.disallow-drop-in-index"
-      content: "`t`.`b` cannot drop index column"
-      line: 1
+      title: column.disallow-drop-in-index
+      content: '`t`.`b` cannot drop index column'
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int, c int, INDEX idx_ac(a,c));
@@ -25,11 +26,11 @@
   want:
     - status: WARN
       code: 424
-      title: "column.disallow-drop-in-index"
-      content: "`t`.`c` cannot drop index column"
-      line: 1
+      title: column.disallow-drop-in-index
+      content: '`t`.`c` cannot drop index column'
+      line: 2
+      column: 0
       details: ""
-
 - statement: |-
     CREATE TABLE t(a int, b int, INDEX idx_a(a));
     CREATE TABLE y(a int, b int);
@@ -37,11 +38,11 @@
   want:
     - status: SUCCESS
       code: 0
-      title: "OK"
+      title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
-
 - statement: |-
     CREATE TABLE t(a int,b int, c int, INDEX idx_ac(a,c));
     ALTER TABLE t DROP COLUMN a;
@@ -49,13 +50,15 @@
   want:
     - status: WARN
       code: 424
-      title: "column.disallow-drop-in-index"
-      content: "`t`.`a` cannot drop index column"
-      line: 1
+      title: column.disallow-drop-in-index
+      content: '`t`.`a` cannot drop index column'
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 424
-      title: "column.disallow-drop-in-index"
-      content: "`t`.`c` cannot drop index column"
-      line: 2
+      title: column.disallow-drop-in-index
+      content: '`t`.`c` cannot drop index column'
+      line: 3
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_disallow_set_charset.yaml
+++ b/backend/plugin/advisor/tidb/test/column_disallow_set_charset.yaml
@@ -7,6 +7,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a varchar(20))
   want:
@@ -15,40 +16,41 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a varchar(20) CHARSET ascii)
   want:
     - status: WARN
       code: 414
       title: column.disallow-set-charset
-      content: |-
-        Disallow set column charset but "CREATE TABLE t(a varchar(20) CHARSET ascii);" does
-      line: 0
+      content: Disallow set column charset but "CREATE TABLE t(a varchar(20) CHARSET ascii)" does
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD COLUMN a varchar(20) CHARSET ascii
   want:
     - status: WARN
       code: 414
       title: column.disallow-set-charset
-      content: |-
-        Disallow set column charset but "ALTER TABLE tech_book ADD COLUMN a varchar(20) CHARSET ascii;" does
-      line: 0
+      content: Disallow set column charset but "ALTER TABLE tech_book ADD COLUMN a varchar(20) CHARSET ascii" does
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY COLUMN id varchar(20) CHARSET ascii
   want:
     - status: WARN
       code: 414
       title: column.disallow-set-charset
-      content: |-
-        Disallow set column charset but "ALTER TABLE tech_book MODIFY COLUMN id varchar(20) CHARSET ascii;" does
-      line: 0
+      content: Disallow set column charset but "ALTER TABLE tech_book MODIFY COLUMN id varchar(20) CHARSET ascii" does
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book CHANGE COLUMN name name varchar(20) CHARSET ascii
   want:
     - status: WARN
       code: 414
       title: column.disallow-set-charset
-      content: |-
-        Disallow set column charset but "ALTER TABLE tech_book CHANGE COLUMN name name varchar(20) CHARSET ascii;" does
-      line: 0
+      content: Disallow set column charset but "ALTER TABLE tech_book CHANGE COLUMN name name varchar(20) CHARSET ascii" does
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_maximum_character_length.yaml
+++ b/backend/plugin/advisor/tidb/test/column_maximum_character_length.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(name varchar(225));
   want:
@@ -13,6 +14,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(name char(225));
   want:
@@ -20,7 +22,8 @@
       code: 415
       title: column.maximum-character-length
       content: The length of the CHAR column `name` is bigger than 20, please use VARCHAR instead
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD COLUMN name_2 char(225)
   want:
@@ -28,7 +31,8 @@
       code: 415
       title: column.maximum-character-length
       content: The length of the CHAR column `name_2` is bigger than 20, please use VARCHAR instead
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book CHANGE COLUMN name name char(225)
   want:
@@ -36,7 +40,8 @@
       code: 415
       title: column.maximum-character-length
       content: The length of the CHAR column `name` is bigger than 20, please use VARCHAR instead
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY COLUMN name char(225)
   want:
@@ -44,5 +49,6 @@
       code: 415
       title: column.maximum-character-length
       content: The length of the CHAR column `name` is bigger than 20, please use VARCHAR instead
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_no_null.yaml
+++ b/backend/plugin/advisor/tidb/test/column_no_null.yaml
@@ -6,30 +6,34 @@
     - status: WARN
       code: 402
       title: column.no-null
-      content: "`book`.`id` cannot have NULL value"
-      line: 1
+      content: '`book`.`id` cannot have NULL value'
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 402
       title: column.no-null
-      content: "`book`.`name` cannot have NULL value"
-      line: 2
+      content: '`book`.`name` cannot have NULL value'
+      line: 3
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id int PRIMARY KEY, name varchar(255))
   want:
     - status: WARN
       code: 402
       title: column.no-null
-      content: "`book`.`name` cannot have NULL value"
-      line: 0
+      content: '`book`.`name` cannot have NULL value'
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id int NOT NULL, name varchar(255))
   want:
     - status: WARN
       code: 402
       title: column.no-null
-      content: "`book`.`name` cannot have NULL value"
-      line: 0
+      content: '`book`.`name` cannot have NULL value'
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id int PRIMARY KEY, name varchar(255) NOT NULL)
   want:
@@ -38,6 +42,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(a int NOT NULL);
@@ -46,8 +51,9 @@
     - status: WARN
       code: 402
       title: column.no-null
-      content: "`book`.`id` cannot have NULL value"
-      line: 1
+      content: '`book`.`id` cannot have NULL value'
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(a int NOT NULL);
@@ -58,6 +64,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(id int NOT NULL);
@@ -66,8 +73,9 @@
     - status: WARN
       code: 402
       title: column.no-null
-      content: "`book`.`name` cannot have NULL value"
-      line: 1
+      content: '`book`.`name` cannot have NULL value'
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(id int NOT NULL);
@@ -78,4 +86,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_require_default.yaml
+++ b/backend/plugin/advisor/tidb/test/column_require_default.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(
@@ -16,7 +17,8 @@
       code: 420
       title: column.require-default
       content: Column `t`.`a` doesn't have DEFAULT.
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     ALTER TABLE tech_book ADD COLUMN a BLOB;
@@ -27,11 +29,13 @@
       code: 420
       title: column.require-default
       content: Column `tech_book`.`b` doesn't have DEFAULT.
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 420
       title: column.require-default
       content: Column `tech_book`.`a` doesn't have DEFAULT.
-      line: 2
+      line: 3
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_required.yaml
+++ b/backend/plugin/advisor/tidb/test/column_required.yaml
@@ -3,8 +3,9 @@
     - status: WARN
       code: 401
       title: column.required
-      content: "Table `book` requires columns: created_ts, creator_id, updated_ts, updater_id"
-      line: 0
+      content: 'Table `book` requires columns: created_ts, creator_id, updated_ts, updater_id'
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -19,6 +20,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -32,8 +34,9 @@
     - status: WARN
       code: 401
       title: column.required
-      content: "Table `book` requires columns: creator_id"
-      line: 6
+      content: 'Table `book` requires columns: creator_id'
+      line: 7
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -49,6 +52,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -62,8 +66,9 @@
     - status: WARN
       code: 401
       title: column.required
-      content: "Table `book` requires columns: creator_id"
-      line: 6
+      content: 'Table `book` requires columns: creator_id'
+      line: 7
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -79,6 +84,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -92,8 +98,9 @@
     - status: WARN
       code: 401
       title: column.required
-      content: "Table `book` requires columns: creator_id"
-      line: 6
+      content: 'Table `book` requires columns: creator_id'
+      line: 7
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -110,6 +117,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -122,8 +130,9 @@
     - status: WARN
       code: 401
       title: column.required
-      content: "Table `book` requires columns: updater_id"
-      line: 4
+      content: 'Table `book` requires columns: updater_id'
+      line: 5
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -139,6 +148,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -154,14 +164,16 @@
     - status: WARN
       code: 401
       title: column.required
-      content: "Table `book` requires columns: creator_id"
-      line: 4
+      content: 'Table `book` requires columns: creator_id'
+      line: 5
+      column: 0
       details: ""
     - status: WARN
       code: 401
       title: column.required
-      content: "Table `student` requires columns: creator_id, updater_id"
-      line: 8
+      content: 'Table `student` requires columns: creator_id, updater_id'
+      line: 9
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -177,4 +189,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_set_default_for_not_null.yaml
+++ b/backend/plugin/advisor/tidb/test/column_set_default_for_not_null.yaml
@@ -8,6 +8,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -19,6 +20,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -29,7 +31,8 @@
       code: 404
       title: column.set-default-for-not-null
       content: Column `book`.`id` is NOT NULL but doesn't have DEFAULT
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -41,7 +44,8 @@
       code: 404
       title: column.set-default-for-not-null
       content: Column `book`.`id` is NOT NULL but doesn't have DEFAULT
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(a int);
@@ -52,6 +56,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(a int);
@@ -61,7 +66,8 @@
       code: 404
       title: column.set-default-for-not-null
       content: Column `book`.`id` is NOT NULL but doesn't have DEFAULT
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(id int);
@@ -71,7 +77,8 @@
       code: 404
       title: column.set-default-for-not-null
       content: Column `book`.`id` is NOT NULL but doesn't have DEFAULT
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(id int);
@@ -82,6 +89,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(uid int);
@@ -92,6 +100,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(uid int);
@@ -101,7 +110,8 @@
       code: 404
       title: column.set-default-for-not-null
       content: Column `book`.`id` is NOT NULL but doesn't have DEFAULT
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: "\n\t\t\t\tCREATE TABLE book(uid int, id int);\n\t\t\t\tALTER TABLE book \n\t\t\t\t\tCHANGE COLUMN uid uid int NOT NULL DEFAULT 0,\n\t\t\t\t\tMODIFY COLUMN id int PRIMARY KEY DEFAULT 0,\n\t\t\t\t\tADD COLUMN name varchar(20) NOT NULL DEFAULT ''\n\t\t\t\t"
   want:
@@ -110,4 +120,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/column_type_disallow_list.yaml
+++ b/backend/plugin/advisor/tidb/test/column_type_disallow_list.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a JSON, b BLOB, c TEXT)
   want:
@@ -12,7 +13,8 @@
       code: 411
       title: column.type-disallow-list
       content: Disallow column type JSON but column `t`.`a` is
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(d int);
@@ -22,7 +24,8 @@
       code: 411
       title: column.type-disallow-list
       content: Disallow column type JSON but column `t`.`a` is
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(c int, b int);
@@ -32,5 +35,6 @@
       code: 411
       title: column.type-disallow-list
       content: Disallow column type JSON but column `t`.`a` is
-      line: 1
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/database_drop_empty_database.yaml
+++ b/backend/plugin/advisor/tidb/test/database_drop_empty_database.yaml
@@ -4,5 +4,6 @@
       code: 701
       title: database.drop-empty-database
       content: Database `test` is not allowed to drop if not empty
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/index_key_number_limit.yaml
+++ b/backend/plugin/advisor/tidb/test/index_key_number_limit.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(
@@ -16,7 +17,8 @@
       code: 802
       title: index.key-number-limit
       content: The number of index `pk` in table `t` should be not greater than 5
-      line: 3
+      line: 4
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int, b int, c int, d int, e int, f int, g int);
@@ -26,7 +28,8 @@
       code: 802
       title: index.key-number-limit
       content: The number of index `idx` in table `t` should be not greater than 5
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int, b int, c int, d int, e int, f int, g int);
@@ -36,7 +39,8 @@
       code: 802
       title: index.key-number-limit
       content: The number of index `uk` in table `t` should be not greater than 5
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int, b int, c int, d int, e int, f int, g int);
@@ -46,5 +50,6 @@
       code: 802
       title: index.key-number-limit
       content: The number of index `uk` in table `t` should be not greater than 5
-      line: 1
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/index_no_duplicate_column.yaml
+++ b/backend/plugin/advisor/tidb/test/index_no_duplicate_column.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t (
@@ -15,7 +16,8 @@
       code: 812
       title: index.no-duplicate-column
       content: INDEX `idx_a` has duplicate column `t`.`a`
-      line: 2
+      line: 3
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -25,7 +27,8 @@
       code: 812
       title: index.no-duplicate-column
       content: INDEX `idx_a` has duplicate column `t`.`a`
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -35,7 +38,8 @@
       code: 812
       title: index.no-duplicate-column
       content: INDEX `idx_a` has duplicate column `t`.`a`
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -45,7 +49,8 @@
       code: 812
       title: index.no-duplicate-column
       content: PRIMARY KEY `pk_a` has duplicate column `t`.`a`
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -55,7 +60,8 @@
       code: 812
       title: index.no-duplicate-column
       content: UNIQUE KEY `uk_a` has duplicate column `t`.`a`
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -65,5 +71,6 @@
       code: 812
       title: index.no-duplicate-column
       content: FOREIGN KEY `fk_a` has duplicate column `t`.`a`
-      line: 1
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/index_pk_type_limit.yaml
+++ b/backend/plugin/advisor/tidb/test/index_pk_type_limit.yaml
@@ -4,7 +4,8 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id` is varchar(5)
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT PRIMARY KEY)
   want:
@@ -13,6 +14,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id VARCHAR(5), PRIMARY KEY(id))
   want:
@@ -20,7 +22,8 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id` is varchar(5)
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, id2 VARCHAR(5), id3 VARCHAR(5), PRIMARY KEY(id, id2, id3))
   want:
@@ -28,13 +31,15 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id2` is varchar(5)
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id3` is varchar(5)
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, id2 BIGINT, PRIMARY KEY(id, id2))
   want:
@@ -43,6 +48,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, PRIMARY KEY(id))
   want:
@@ -51,6 +57,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -60,7 +67,8 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -71,6 +79,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -80,7 +89,8 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -90,13 +100,15 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id2` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id3` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -107,6 +119,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -117,6 +130,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id VARCHAR(5));
@@ -126,7 +140,8 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT, id2 VARCHAR(5), id3 VARCHAR(5));
@@ -136,13 +151,15 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id2` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id3` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT, id2 BIGINT);
@@ -153,6 +170,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id BIGINT);
@@ -163,6 +181,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -172,7 +191,8 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -183,6 +203,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -192,7 +213,8 @@
       code: 803
       title: index.pk-type-limit
       content: Columns in primary key must be INT/BIGINT but `t`.`id2` is varchar(5)
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -203,4 +225,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/index_primary_key_type_allowlist.yaml
+++ b/backend/plugin/advisor/tidb/test/index_primary_key_type_allowlist.yaml
@@ -4,7 +4,8 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT PRIMARY KEY)
   want:
@@ -13,6 +14,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id VARCHAR(5), PRIMARY KEY(id))
   want:
@@ -20,7 +22,8 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, id2 VARCHAR(5), id3 VARCHAR(5), PRIMARY KEY(id, id2, id3))
   want:
@@ -28,13 +31,15 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id2` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id3` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, id2 BIGINT, PRIMARY KEY(id, id2))
   want:
@@ -43,6 +48,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, PRIMARY KEY(id))
   want:
@@ -51,6 +57,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -60,7 +67,8 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -71,6 +79,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -80,7 +89,8 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -90,13 +100,15 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id2` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id3` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -107,6 +119,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -117,6 +130,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id VARCHAR(5));
@@ -126,7 +140,8 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT, id2 VARCHAR(5), id3 VARCHAR(5));
@@ -136,13 +151,15 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id2` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id3` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT, id2 BIGINT);
@@ -153,6 +170,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id BIGINT);
@@ -163,6 +181,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -172,7 +191,8 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -183,6 +203,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -192,7 +213,8 @@
       code: 803
       title: index.primary-key-type-allowlist
       content: The column `id2` in table `t` is one of the primary key, but its type "varchar" is not in allowlist
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id int);
@@ -203,4 +225,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/index_total_number_limit.yaml
+++ b/backend/plugin/advisor/tidb/test/index_total_number_limit.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE INDEX idx_id_name on tech_book(id, name)
   want:
@@ -13,6 +14,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE INDEX idx_id_name_1 on tech_book(id, name);
@@ -25,7 +27,8 @@
       code: 813
       title: index.total-number-limit
       content: The count of index in table `tech_book` should be no more than 5, but found 8
-      line: 4
+      line: 5
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int PRIMARY KEY, b int, c int);
@@ -39,7 +42,8 @@
       code: 813
       title: index.total-number-limit
       content: The count of index in table `t` should be no more than 5, but found 6
-      line: 5
+      line: 6
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(
@@ -56,5 +60,6 @@
       code: 813
       title: index.total-number-limit
       content: The count of index in table `t` should be no more than 5, but found 6
-      line: 8
+      line: 9
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/index_type_no_blob.yaml
+++ b/backend/plugin/advisor/tidb/test/index_type_no_blob.yaml
@@ -4,7 +4,8 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(b BLOB, mb MEDIUMBLOB, lb LONGBLOB, id INT, PRIMARY KEY(b(1), mb(2), lb(3), id))
   want:
@@ -12,19 +13,22 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`lb` is longblob
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`mb` is mediumblob
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(b BLOB, mb MEDIUMBLOB, lb LONGBLOB, id INT, UNIQUE INDEX(b(1), mb(2), lb(3), id))
   want:
@@ -32,19 +36,22 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`lb` is longblob
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`mb` is mediumblob
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(b BLOB, mb MEDIUMBLOB, lb LONGBLOB, id iNT, INDEX(b(1), mb(2), lb(3), id))
   want:
@@ -52,19 +59,22 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`lb` is longblob
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`mb` is mediumblob
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, PRIMARY KEY(id))
   want:
@@ -73,6 +83,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -82,7 +93,8 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -92,19 +104,22 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`lb` is longblob
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`mb` is mediumblob
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -114,19 +129,22 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`lb` is longblob
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`mb` is mediumblob
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -137,6 +155,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b blob, mb mediumblob, lb longblob, id int);
@@ -149,19 +168,22 @@
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`b` is blob
-      line: 1
+      line: 2
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`mb` is mediumblob
-      line: 2
+      line: 3
+      column: 0
       details: ""
     - status: WARN
       code: 804
       title: index.type-no-blob
       content: Columns in index must not be BLOB but `t`.`lb` is longblob
-      line: 3
+      line: 4
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b blob, mb mediumblob, lb longblob, id int);
@@ -172,4 +194,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/naming_column.yaml
+++ b/backend/plugin/advisor/tidb/test/naming_column.yaml
@@ -4,15 +4,17 @@
       code: 302
       title: naming.column
       content: '`book`.`creatorId` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id int, gbhzmtchhsjzyrhdroxmyouwloxqezowdvhcbqalqcgqhfbjnvmhwrbggezmzeusx int)
   want:
     - status: WARN
       code: 302
       title: naming.column
-      content: "`book`.`gbhzmtchhsjzyrhdroxmyouwloxqezowdvhcbqalqcgqhfbjnvmhwrbggezmzeusx` mismatches column naming convention, its length should be within 64 characters"
-      line: 0
+      content: '`book`.`gbhzmtchhsjzyrhdroxmyouwloxqezowdvhcbqalqcgqhfbjnvmhwrbggezmzeusx` mismatches column naming convention, its length should be within 64 characters'
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id int, creator_id int)
   want:
@@ -21,6 +23,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(id int, creator_id int);
@@ -30,7 +33,8 @@
       code: 302
       title: naming.column
       content: '`book`.`creatorId` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book RENAME COLUMN id TO creator_id;
   want:
@@ -39,6 +43,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -53,7 +58,8 @@
       code: 302
       title: naming.column
       content: '`book`.`creatorId` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 6
+      line: 7
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book CHANGE COLUMN id creator_id int;
   want:
@@ -62,6 +68,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book DROP COLUMN id;
   want:
@@ -70,6 +77,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -83,7 +91,8 @@
       code: 302
       title: naming.column
       content: '`book`.`contentString` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 5
+      line: 6
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE book(
@@ -100,23 +109,27 @@
       code: 302
       title: naming.column
       content: '`book`.`createdTs` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 2
+      line: 3
+      column: 0
       details: ""
     - status: WARN
       code: 302
       title: naming.column
       content: '`book`.`updaterId` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 3
+      line: 4
+      column: 0
       details: ""
     - status: WARN
       code: 302
       title: naming.column
       content: '`student`.`createdTs` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 7
+      line: 8
+      column: 0
       details: ""
     - status: WARN
       code: 302
       title: naming.column
       content: '`student`.`updatedTs` mismatches column naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 8
+      line: 9
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/naming_column_auto_increment.yaml
+++ b/backend/plugin/advisor/tidb/test/naming_column_auto_increment.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE book(a int AUTO_INCREMENT)
   want:
@@ -12,7 +13,8 @@
       code: 307
       title: naming.column.auto-increment
       content: '`book`.`a` mismatches auto_increment column naming convention, naming format should be "^id$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD COLUMN a int AUTO_INCREMENT
   want:
@@ -20,7 +22,8 @@
       code: 307
       title: naming.column.auto-increment
       content: '`tech_book`.`a` mismatches auto_increment column naming convention, naming format should be "^id$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book CHANGE COLUMN id a int AUTO_INCREMENT
   want:
@@ -28,7 +31,8 @@
       code: 307
       title: naming.column.auto-increment
       content: '`tech_book`.`a` mismatches auto_increment column naming convention, naming format should be "^id$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY COLUMN name int AUTO_INCREMENT
   want:
@@ -36,5 +40,6 @@
       code: 307
       title: naming.column.auto-increment
       content: '`tech_book`.`name` mismatches auto_increment column naming convention, naming format should be "^id$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/naming_index_fk.yaml
+++ b/backend/plugin/advisor/tidb/test/naming_index_fk.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD CONSTRAINT fk_author_id FOREIGN KEY (author_id) REFERENCES author (id)
   want:
@@ -12,7 +13,8 @@
       code: 305
       title: naming.index.fk
       content: Foreign key in table `tech_book` mismatches the naming convention, expect "^$|^fk_tech_book_author_id_author_id$" but found `fk_author_id`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD CONSTRAINT rvemempmcmmhutaskvcidmwaldtfjdgmcpkhmibtadfydtkexpuzczrrneucthfwk FOREIGN KEY (author_id) REFERENCES author (id)
   want:
@@ -20,13 +22,15 @@
       code: 305
       title: naming.index.fk
       content: Foreign key `rvemempmcmmhutaskvcidmwaldtfjdgmcpkhmibtadfydtkexpuzczrrneucthfwk` in table `tech_book` mismatches the naming convention, its length should be within 64 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 305
       title: naming.index.fk
       content: Foreign key in table `tech_book` mismatches the naming convention, expect "^$|^fk_tech_book_author_id_author_id$" but found `rvemempmcmmhutaskvcidmwaldtfjdgmcpkhmibtadfydtkexpuzczrrneucthfwk`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id INT, author_id INT, FOREIGN KEY fk_book_author_id_author_id (author_id) REFERENCES author (id))
   want:
@@ -35,6 +39,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id INT, author_id INT, FOREIGN KEY (author_id) REFERENCES author (id))
   want:
@@ -43,6 +48,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id INT, author_id INT, FOREIGN KEY fk_book_author_id (author_id) REFERENCES author (id))
   want:
@@ -50,5 +56,6 @@
       code: 305
       title: naming.index.fk
       content: Foreign key in table `book` mismatches the naming convention, expect "^$|^fk_book_author_id_author_id$" but found `fk_book_author_id`
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/naming_index_idx.yaml
+++ b/backend/plugin/advisor/tidb/test/naming_index_idx.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE INDEX tech_book_id_name ON tech_book(id, name)
   want:
@@ -12,7 +13,8 @@
       code: 303
       title: naming.index.idx
       content: Index in table `tech_book` mismatches the naming convention, expect "^$|^idx_tech_book_id_name$" but found `tech_book_id_name`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE INDEX afvjwsgrbgqzjfrkmbcoxzstznuypasijbbcdykoboredqovetzfcmmqliaelyavw ON tech_book(id, name)
   want:
@@ -20,13 +22,15 @@
       code: 303
       title: naming.index.idx
       content: Index `afvjwsgrbgqzjfrkmbcoxzstznuypasijbbcdykoboredqovetzfcmmqliaelyavw` in table `tech_book` mismatches the naming convention, its length should be within 64 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 303
       title: naming.index.idx
       content: Index in table `tech_book` mismatches the naming convention, expect "^$|^idx_tech_book_id_name$" but found `afvjwsgrbgqzjfrkmbcoxzstznuypasijbbcdykoboredqovetzfcmmqliaelyavw`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book RENAME INDEX old_index TO idx_tech_book_id_name
   want:
@@ -35,6 +39,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book RENAME INDEX old_index TO idx_tech_book
   want:
@@ -42,7 +47,8 @@
       code: 303
       title: naming.index.idx
       content: Index in table `tech_book` mismatches the naming convention, expect "^$|^idx_tech_book_id_name$" but found `idx_tech_book`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD INDEX idx_tech_book_id_name (id, name)
   want:
@@ -51,6 +57,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD INDEX tech_book_id_name (id, name)
   want:
@@ -58,7 +65,8 @@
       code: 303
       title: naming.index.idx
       content: Index in table `tech_book` mismatches the naming convention, expect "^$|^idx_tech_book_id_name$" but found `tech_book_id_name`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE tech_book_copy(id INT PRIMARY KEY, name VARCHAR(20), INDEX idx_tech_book_copy_name (name))
   want:
@@ -67,6 +75,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE tech_book_copy(id INT PRIMARY KEY, name VARCHAR(20), INDEX (name))
   want:
@@ -75,4 +84,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/naming_index_uk.yaml
+++ b/backend/plugin/advisor/tidb/test/naming_index_uk.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE UNIQUE INDEX tech_book_id_name ON tech_book(id, name)
   want:
@@ -12,7 +13,8 @@
       code: 304
       title: naming.index.uk
       content: Unique key in table `tech_book` mismatches the naming convention, expect "^$|^uk_tech_book_id_name$" but found `tech_book_id_name`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE UNIQUE INDEX qtzmquwvlnttctfluoouxelxeliltcfzzstrtyocogwwyiyrflmrkbhbfasynlacy ON tech_book(id, name)
   want:
@@ -20,13 +22,15 @@
       code: 304
       title: naming.index.uk
       content: Unique key `qtzmquwvlnttctfluoouxelxeliltcfzzstrtyocogwwyiyrflmrkbhbfasynlacy` in table `tech_book` mismatches the naming convention, its length should be within 64 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 304
       title: naming.index.uk
       content: Unique key in table `tech_book` mismatches the naming convention, expect "^$|^uk_tech_book_id_name$" but found `qtzmquwvlnttctfluoouxelxeliltcfzzstrtyocogwwyiyrflmrkbhbfasynlacy`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD UNIQUE uk_tech_book_id_name (id, name)
   want:
@@ -35,6 +39,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD UNIQUE tech_book_id_name (id, name)
   want:
@@ -42,7 +47,8 @@
       code: 304
       title: naming.index.uk
       content: Unique key in table `tech_book` mismatches the naming convention, expect "^$|^uk_tech_book_id_name$" but found `tech_book_id_name`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book RENAME INDEX old_uk TO uk_tech_book_id_name
   want:
@@ -51,6 +57,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book RENAME INDEX old_uk TO uk_tech_book
   want:
@@ -58,7 +65,8 @@
       code: 304
       title: naming.index.uk
       content: Unique key in table `tech_book` mismatches the naming convention, expect "^$|^uk_tech_book_id_name$" but found `uk_tech_book`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id INT PRIMARY KEY, name VARCHAR(20), UNIQUE INDEX uk_book_name (name))
   want:
@@ -67,6 +75,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id INT PRIMARY KEY, name VARCHAR(20), UNIQUE KEY (name))
   want:
@@ -75,6 +84,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id INT PRIMARY KEY, name VARCHAR(20), UNIQUE INDEX (name))
   want:
@@ -83,4 +93,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/naming_table.yaml
+++ b/backend/plugin/advisor/tidb/test/naming_table.yaml
@@ -4,7 +4,8 @@
       code: 301
       title: naming.table
       content: '`techBook` mismatches table naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE tech_book_copy(id int, name varchar(255))
   want:
@@ -13,14 +14,16 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE cjnubexocfhqoogdmihudyahmmghviqkzvpixnwvxtxumvuannpwdcbtsgwrvzpde(id int, name varchar(255))
   want:
     - status: WARN
       code: 301
       title: naming.table
-      content: "`cjnubexocfhqoogdmihudyahmmghviqkzvpixnwvxtxumvuannpwdcbtsgwrvzpde` mismatches table naming convention, its length should be within 64 characters"
-      line: 0
+      content: '`cjnubexocfhqoogdmihudyahmmghviqkzvpixnwvxtxumvuannpwdcbtsgwrvzpde` mismatches table naming convention, its length should be within 64 characters'
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book RENAME TO TechBook
   want:
@@ -28,7 +31,8 @@
       code: 301
       title: naming.table
       content: '`TechBook` mismatches table naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book RENAME TO tech_book_copy
   want:
@@ -37,6 +41,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: RENAME TABLE tech_book TO tech_book_copy, tech_book_copy TO LiteraryBook
   want:
@@ -44,7 +49,8 @@
       code: 301
       title: naming.table
       content: '`LiteraryBook` mismatches table naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE literary_book(a int);RENAME TABLE tech_book TO TechBook, literary_book TO LiteraryBook
   want:
@@ -52,13 +58,15 @@
       code: 301
       title: naming.table
       content: '`LiteraryBook` mismatches table naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
     - status: WARN
       code: 301
       title: naming.table
       content: '`TechBook` mismatches table naming convention, naming format should be "^[a-z]+(_[a-z]+)*$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE literary_book(a int);RENAME TABLE tech_book TO tech_book_copy, literary_book TO literary_book_copy
   want:
@@ -67,4 +75,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/schema_backward_compatibility.yaml
+++ b/backend/plugin/advisor/tidb/test/schema_backward_compatibility.yaml
@@ -3,43 +3,43 @@
     - status: WARN
       code: 111
       title: schema.backward-compatibility
-      content: |-
-        "ALTER TABLE tech_book CHANGE name f2 TEXT;" may cause incompatibility with the existing data and code
-      line: 0
+      content: '"ALTER TABLE tech_book CHANGE name f2 TEXT" may cause incompatibility with the existing data and code'
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY name TEXT
   want:
     - status: WARN
       code: 111
       title: schema.backward-compatibility
-      content: |-
-        "ALTER TABLE tech_book MODIFY name TEXT;" may cause incompatibility with the existing data and code
-      line: 0
+      content: '"ALTER TABLE tech_book MODIFY name TEXT" may cause incompatibility with the existing data and code'
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY name TEXT NULL
   want:
     - status: WARN
       code: 111
       title: schema.backward-compatibility
-      content: |-
-        "ALTER TABLE tech_book MODIFY name TEXT NULL;" may cause incompatibility with the existing data and code
-      line: 0
+      content: '"ALTER TABLE tech_book MODIFY name TEXT NULL" may cause incompatibility with the existing data and code'
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY name TEXT NOT NULL
   want:
     - status: WARN
       code: 111
       title: schema.backward-compatibility
-      content: |-
-        "ALTER TABLE tech_book MODIFY name TEXT NOT NULL;" may cause incompatibility with the existing data and code
-      line: 0
+      content: '"ALTER TABLE tech_book MODIFY name TEXT NOT NULL" may cause incompatibility with the existing data and code'
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY name TEXT COMMENT 'bla'
   want:
     - status: WARN
       code: 111
       title: schema.backward-compatibility
-      content: |-
-        "ALTER TABLE tech_book MODIFY name TEXT COMMENT 'bla';" may cause incompatibility with the existing data and code
-      line: 0
+      content: '"ALTER TABLE tech_book MODIFY name TEXT COMMENT ''bla''" may cause incompatibility with the existing data and code'
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_disallow_commit.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_disallow_commit.yaml
@@ -6,10 +6,9 @@
     - status: WARN
       code: 206
       title: statement.disallow-commit
-      content: |-
-        Commit is not allowed, related statement: "
-        COMMIT;"
-      line: 2
+      content: 'Commit is not allowed, related statement: "COMMIT;"'
+      line: 3
+      column: 0
       details: ""
 - statement: |-
     START TRANSACTION;
@@ -23,16 +22,14 @@
     - status: WARN
       code: 206
       title: statement.disallow-commit
-      content: |-
-        Commit is not allowed, related statement: "
-        COMMIT;"
-      line: 2
+      content: 'Commit is not allowed, related statement: "COMMIT;"'
+      line: 3
+      column: 0
       details: ""
     - status: WARN
       code: 206
       title: statement.disallow-commit
-      content: |-
-        Commit is not allowed, related statement: "
-        COMMIT;"
-      line: 6
+      content: 'Commit is not allowed, related statement: "COMMIT;"'
+      line: 7
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_disallow_limit.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_disallow_limit.yaml
@@ -5,40 +5,41 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: INSERT INTO tech_book SELECT * FROM tech_book LIMIT 1
   want:
     - status: WARN
       code: 1103
       title: statement.disallow-limit
-      content: |-
-        LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "INSERT INTO tech_book SELECT * FROM tech_book LIMIT 1;" uses
-      line: 0
+      content: LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "INSERT INTO tech_book SELECT * FROM tech_book LIMIT 1" uses
+      line: 1
+      column: 0
       details: ""
 - statement: INSERT INTO tech_book SELECT * FROM tech_book UNION SELECT * FROM tech_book LIMIT 1
   want:
     - status: WARN
       code: 1103
       title: statement.disallow-limit
-      content: |-
-        LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "INSERT INTO tech_book SELECT * FROM tech_book UNION SELECT * FROM tech_book LIMIT 1;" uses
-      line: 0
+      content: LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "INSERT INTO tech_book SELECT * FROM tech_book UNION SELECT * FROM tech_book LIMIT 1" uses
+      line: 1
+      column: 0
       details: ""
 - statement: UPDATE tech_book SET name = 'my name' LIMIT 10
   want:
     - status: WARN
       code: 1102
       title: statement.disallow-limit
-      content: |-
-        LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "UPDATE tech_book SET name = 'my name' LIMIT 10;" uses
-      line: 0
+      content: LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "UPDATE tech_book SET name = 'my name' LIMIT 10" uses
+      line: 1
+      column: 0
       details: ""
 - statement: DELETE FROM tech_book LIMIT 10
   want:
     - status: WARN
       code: 1106
       title: statement.disallow-limit
-      content: |-
-        LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "DELETE FROM tech_book LIMIT 10;" uses
-      line: 0
+      content: LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "DELETE FROM tech_book LIMIT 10" uses
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_disallow_order_by.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_disallow_order_by.yaml
@@ -5,22 +5,23 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: UPDATE tech_book SET name = 'my name' ORDER BY id
   want:
     - status: WARN
       code: 1104
       title: statement.disallow-order-by
-      content: |-
-        ORDER BY clause is forbidden in DELETE and UPDATE statements, but "UPDATE tech_book SET name = 'my name' ORDER BY id;" uses
-      line: 0
+      content: ORDER BY clause is forbidden in DELETE and UPDATE statements, but "UPDATE tech_book SET name = 'my name' ORDER BY id" uses
+      line: 1
+      column: 0
       details: ""
 - statement: DELETE FROM tech_book ORDER BY id
   want:
     - status: WARN
       code: 1105
       title: statement.disallow-order-by
-      content: |-
-        ORDER BY clause is forbidden in DELETE and UPDATE statements, but "DELETE FROM tech_book ORDER BY id;" uses
-      line: 0
+      content: ORDER BY clause is forbidden in DELETE and UPDATE statements, but "DELETE FROM tech_book ORDER BY id" uses
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_dml_dry_run.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_dml_dry_run.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: DELETE FROM tech_book
   want:
@@ -13,4 +14,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_insert_disallow_order_by_rand.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_insert_disallow_order_by_rand.yaml
@@ -5,13 +5,14 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: INSERT INTO tech_book SELECT * FROM tech_book ORDER BY rand()
   want:
     - status: WARN
       code: 1108
       title: statement.insert.disallow-order-by-rand
-      content: |-
-        "INSERT INTO tech_book SELECT * FROM tech_book ORDER BY rand();" uses ORDER BY RAND in the INSERT statement
-      line: 0
+      content: '"INSERT INTO tech_book SELECT * FROM tech_book ORDER BY rand()" uses ORDER BY RAND in the INSERT statement'
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_insert_must_specify_column.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_insert_must_specify_column.yaml
@@ -5,13 +5,14 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: INSERT INTO tech_book VALUES (1, '1')
   want:
     - status: WARN
       code: 1107
       title: statement.insert.must-specify-column
-      content: |-
-        The INSERT statement must specify columns but "INSERT INTO tech_book VALUES (1, '1');" does not
-      line: 0
+      content: The INSERT statement must specify columns but "INSERT INTO tech_book VALUES (1, '1')" does not
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_merge_alter_table.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_merge_alter_table.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     ALTER TABLE tech_book ADD COLUMN a int;
@@ -14,7 +15,8 @@
       code: 207
       title: statement.merge-alter-table
       content: There are 2 statements to modify table `tech_book`
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -26,13 +28,15 @@
       code: 207
       title: statement.merge-alter-table
       content: There are 2 statements to modify table `t`
-      line: 2
+      line: 3
+      column: 0
       details: ""
     - status: WARN
       code: 207
       title: statement.merge-alter-table
       content: There are 2 statements to modify table `tech_book`
-      line: 3
+      line: 4
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -44,11 +48,13 @@
       code: 207
       title: statement.merge-alter-table
       content: There are 2 statements to modify table `tech_book`
-      line: 2
+      line: 3
+      column: 0
       details: ""
     - status: WARN
       code: 207
       title: statement.merge-alter-table
       content: There are 2 statements to modify table `t`
-      line: 3
+      line: 4
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_select_no_select_all.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_select_no_select_all.yaml
@@ -3,9 +3,9 @@
     - status: WARN
       code: 203
       title: statement.select.no-select-all
-      content: |-
-        "SELECT * FROM t;" uses SELECT all
-      line: 0
+      content: '"SELECT * FROM t" uses SELECT all'
+      line: 1
+      column: 0
       details: ""
 - statement: SELECT a, b FROM t
   want:
@@ -14,13 +14,14 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: SELECT a, b FROM (SELECT * from t1 JOIN t2) t
   want:
     - status: WARN
       code: 203
       title: statement.select.no-select-all
-      content: |-
-        "SELECT a, b FROM (SELECT * from t1 JOIN t2) t;" uses SELECT all
-      line: 0
+      content: '"SELECT a, b FROM (SELECT * from t1 JOIN t2) t" uses SELECT all'
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
@@ -5,40 +5,41 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: SELECT * FROM t WHERE a LIKE '%abc'
   want:
     - status: WARN
       code: 204
       title: statement.where.no-leading-wildcard-like
-      content: |-
-        "SELECT * FROM t WHERE a LIKE '%abc';" uses leading wildcard LIKE
-      line: 0
+      content: '"SELECT * FROM t WHERE a LIKE ''%abc''" uses leading wildcard LIKE'
+      line: 1
+      column: 0
       details: ""
 - statement: SELECT * FROM t WHERE a LIKE 'abc' OR a LIKE '%abc'
   want:
     - status: WARN
       code: 204
       title: statement.where.no-leading-wildcard-like
-      content: |-
-        "SELECT * FROM t WHERE a LIKE 'abc' OR a LIKE '%abc';" uses leading wildcard LIKE
-      line: 0
+      content: '"SELECT * FROM t WHERE a LIKE ''abc'' OR a LIKE ''%abc''" uses leading wildcard LIKE'
+      line: 1
+      column: 0
       details: ""
 - statement: SELECT * FROM t WHERE a LIKE '%acc' OR a LIKE '%abc'
   want:
     - status: WARN
       code: 204
       title: statement.where.no-leading-wildcard-like
-      content: |-
-        "SELECT * FROM t WHERE a LIKE '%acc' OR a LIKE '%abc';" uses leading wildcard LIKE
-      line: 0
+      content: '"SELECT * FROM t WHERE a LIKE ''%acc'' OR a LIKE ''%abc''" uses leading wildcard LIKE'
+      line: 1
+      column: 0
       details: ""
 - statement: SELECT * FROM (SELECT * FROM t WHERE a LIKE '%acc' OR a LIKE '%abc') t1
   want:
     - status: WARN
       code: 204
       title: statement.where.no-leading-wildcard-like
-      content: |-
-        "SELECT * FROM (SELECT * FROM t WHERE a LIKE '%acc' OR a LIKE '%abc') t1;" uses leading wildcard LIKE
-      line: 0
+      content: '"SELECT * FROM (SELECT * FROM t WHERE a LIKE ''%acc'' OR a LIKE ''%abc'') t1" uses leading wildcard LIKE'
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/statement_where_require.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_where_require.yaml
@@ -5,24 +5,25 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: DELETE FROM tech_book
   want:
     - status: WARN
       code: 202
       title: statement.where.require
-      content: |-
-        "DELETE FROM tech_book;" requires WHERE clause
-      line: 0
+      content: '"DELETE FROM tech_book" requires WHERE clause'
+      line: 1
+      column: 0
       details: ""
 - statement: UPDATE tech_book SET id = 1
   want:
     - status: WARN
       code: 202
       title: statement.where.require
-      content: |-
-        "UPDATE tech_book SET id = 1;" requires WHERE clause
-      line: 0
+      content: '"UPDATE tech_book SET id = 1" requires WHERE clause'
+      line: 1
+      column: 0
       details: ""
 - statement: DELETE FROM tech_book WHERE id > 0
   want:
@@ -31,6 +32,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: UPDATE tech_book SET id = 1 WHERE id > 10
   want:
@@ -39,15 +41,16 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: SELECT id FROM tech_book
   want:
     - status: WARN
       code: 202
       title: statement.where.require
-      content: |-
-        "SELECT id FROM tech_book;" requires WHERE clause
-      line: 0
+      content: '"SELECT id FROM tech_book" requires WHERE clause'
+      line: 1
+      column: 0
       details: ""
 - statement: SELECT id FROM tech_book WHERE id > 0
   want:
@@ -56,13 +59,14 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: SELECT id FROM tech_book WHERE id > (SELECT max(id) FROM tech_book)
   want:
     - status: WARN
       code: 202
       title: statement.where.require
-      content: |-
-        "SELECT id FROM tech_book WHERE id > (SELECT max(id) FROM tech_book);" requires WHERE clause
-      line: 0
+      content: '"SELECT id FROM tech_book WHERE id > (SELECT max(id) FROM tech_book)" requires WHERE clause'
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/system_charset_allowlist.yaml
+++ b/backend/plugin/advisor/tidb/test/system_charset_allowlist.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a varchar(255))
   want:
@@ -13,15 +14,16 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a int) CHARSET ascii
   want:
     - status: WARN
       code: 1001
       title: system.charset.allowlist
-      content: |-
-        "CREATE TABLE t(a int) CHARSET ascii;" used disabled charset 'ascii'
-      line: 0
+      content: '"CREATE TABLE t(a int) CHARSET ascii" used disabled charset ''ascii'''
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -30,28 +32,27 @@
     - status: WARN
       code: 1001
       title: system.charset.allowlist
-      content: |-
-        "
-        ALTER TABLE t CHARSET ascii;" used disabled charset 'ascii'
-      line: 1
+      content: '"ALTER TABLE t CHARSET ascii" used disabled charset ''ascii'''
+      line: 2
+      column: 0
       details: ""
 - statement: ALTER DATABASE test CHARSET ascii
   want:
     - status: WARN
       code: 1001
       title: system.charset.allowlist
-      content: |-
-        "ALTER DATABASE test CHARSET ascii;" used disabled charset 'ascii'
-      line: 0
+      content: '"ALTER DATABASE test CHARSET ascii" used disabled charset ''ascii'''
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a varchar(255) CHARSET ascii)
   want:
     - status: WARN
       code: 1001
       title: system.charset.allowlist
-      content: |-
-        "CREATE TABLE t(a varchar(255) CHARSET ascii);" used disabled charset 'ascii'
-      line: 0
+      content: '"CREATE TABLE t(a varchar(255) CHARSET ascii)" used disabled charset ''ascii'''
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int);
@@ -60,10 +61,9 @@
     - status: WARN
       code: 1001
       title: system.charset.allowlist
-      content: |-
-        "
-        ALTER TABLE t ADD COLUMN a varchar(255) CHARSET ascii;" used disabled charset 'ascii'
-      line: 1
+      content: '"ALTER TABLE t ADD COLUMN a varchar(255) CHARSET ascii" used disabled charset ''ascii'''
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -72,10 +72,9 @@
     - status: WARN
       code: 1001
       title: system.charset.allowlist
-      content: |-
-        "
-        ALTER TABLE t MODIFY COLUMN a varchar(255) CHARSET ascii;" used disabled charset 'ascii'
-      line: 1
+      content: '"ALTER TABLE t MODIFY COLUMN a varchar(255) CHARSET ascii" used disabled charset ''ascii'''
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -84,10 +83,9 @@
     - status: WARN
       code: 1001
       title: system.charset.allowlist
-      content: |-
-        "
-        ALTER TABLE t CHANGE COLUMN a a varchar(255) CHARSET ascii;" used disabled charset 'ascii'
-      line: 1
+      content: '"ALTER TABLE t CHANGE COLUMN a a varchar(255) CHARSET ascii" used disabled charset ''ascii'''
+      line: 2
+      column: 0
       details: ""
 - statement: /* this is a comment */
   want:
@@ -96,4 +94,5 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/system_collation_allowlist.yaml
+++ b/backend/plugin/advisor/tidb/test/system_collation_allowlist.yaml
@@ -3,9 +3,9 @@
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "CREATE TABLE t(a int) COLLATE utf8mb4_polish_ci;" used disabled collation 'utf8mb4_polish_ci'
-      line: 0
+      content: '"CREATE TABLE t(a int) COLLATE utf8mb4_polish_ci" used disabled collation ''utf8mb4_polish_ci'''
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a varchar(255))
   want:
@@ -14,15 +14,16 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a int) COLLATE latin1_bin
   want:
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "CREATE TABLE t(a int) COLLATE latin1_bin;" used disabled collation 'latin1_bin'
-      line: 0
+      content: '"CREATE TABLE t(a int) COLLATE latin1_bin" used disabled collation ''latin1_bin'''
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -31,28 +32,27 @@
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "
-        ALTER TABLE t COLLATE latin1_bin;" used disabled collation 'latin1_bin'
-      line: 1
+      content: '"ALTER TABLE t COLLATE latin1_bin" used disabled collation ''latin1_bin'''
+      line: 2
+      column: 0
       details: ""
 - statement: ALTER DATABASE test COLLATE latin1_bin
   want:
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "ALTER DATABASE test COLLATE latin1_bin;" used disabled collation 'latin1_bin'
-      line: 0
+      content: '"ALTER DATABASE test COLLATE latin1_bin" used disabled collation ''latin1_bin'''
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin)
   want:
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "CREATE TABLE t(a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin);" used disabled collation 'latin1_bin'
-      line: 0
+      content: '"CREATE TABLE t(a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin)" used disabled collation ''latin1_bin'''
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(b int);
@@ -61,10 +61,9 @@
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "
-        ALTER TABLE t ADD COLUMN a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin;" used disabled collation 'latin1_bin'
-      line: 1
+      content: '"ALTER TABLE t ADD COLUMN a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin" used disabled collation ''latin1_bin'''
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -73,10 +72,9 @@
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "
-        ALTER TABLE t MODIFY COLUMN a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin;" used disabled collation 'latin1_bin'
-      line: 1
+      content: '"ALTER TABLE t MODIFY COLUMN a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin" used disabled collation ''latin1_bin'''
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int);
@@ -85,8 +83,7 @@
     - status: WARN
       code: 1201
       title: system.collation.allowlist
-      content: |-
-        "
-        ALTER TABLE t CHANGE COLUMN a a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin;" used disabled collation 'latin1_bin'
-      line: 1
+      content: '"ALTER TABLE t CHANGE COLUMN a a varchar(255) CHARACTER SET latin1 COLLATE latin1_bin" used disabled collation ''latin1_bin'''
+      line: 2
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/table_comment.yaml
+++ b/backend/plugin/advisor/tidb/test/table_comment.yaml
@@ -4,7 +4,8 @@
       code: 606
       title: table.comment
       content: The length of table `t` comment should be within 10 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a int)
   want:
@@ -12,7 +13,8 @@
       code: 605
       title: table.comment
       content: Table `t` requires comments
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE t(a int) COMMENT 'sdlfkjalkseblkjduafelbnlsdfkljayue'
   want:
@@ -20,5 +22,6 @@
       code: 606
       title: table.comment
       content: The length of table `t` comment should be within 10 characters
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/table_disallow_partition.yaml
+++ b/backend/plugin/advisor/tidb/test/table_disallow_partition.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(a int) PARTITION BY RANGE (a) (
@@ -19,8 +20,9 @@
         Table partition is forbidden, but "CREATE TABLE t(a int) PARTITION BY RANGE (a) (
                 PARTITION p0 VALUES LESS THAN (6),
                 PARTITION p1 VALUES LESS THAN (11)
-              );" creates
-      line: 3
+              )" creates
+      line: 4
+      column: 0
       details: ""
 - statement: |-
     ALTER TABLE tech_book PARTITION BY RANGE (a) (
@@ -35,6 +37,7 @@
         Table partition is forbidden, but "ALTER TABLE tech_book PARTITION BY RANGE (a) (
                 PARTITION p0 VALUES LESS THAN (6),
                 PARTITION p1 VALUES LESS THAN (11)
-              );" creates
-      line: 3
+              )" creates
+      line: 4
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/table_drop_naming_convention.yaml
+++ b/backend/plugin/advisor/tidb/test/table_drop_naming_convention.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: DROP TABLE IF EXISTS foo
   want:
@@ -12,7 +13,8 @@
       code: 603
       title: table.drop-naming-convention
       content: '`foo` mismatches drop table naming convention, naming format should be "_delete$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: DROP TABLE IF EXISTS foo_delete, bar
   want:
@@ -20,5 +22,6 @@
       code: 603
       title: table.drop-naming-convention
       content: '`bar` mismatches drop table naming convention, naming format should be "_delete$"'
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/table_no_foreign_key.yaml
+++ b/backend/plugin/advisor/tidb/test/table_no_foreign_key.yaml
@@ -4,7 +4,8 @@
       code: 602
       title: table.no-foreign-key
       content: Foreign key is not allowed in the table `tech_book`
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: CREATE TABLE book(id INT, author_id INT, FOREIGN KEY fk_book_author_id_author_id (author_id) REFERENCES author (id))
   want:
@@ -12,5 +13,6 @@
       code: 602
       title: table.no-foreign-key
       content: Foreign key is not allowed in the table `book`
-      line: 0
+      line: 1
+      column: 0
       details: ""

--- a/backend/plugin/advisor/tidb/test/table_require_pk.yaml
+++ b/backend/plugin/advisor/tidb/test/table_require_pk.yaml
@@ -5,6 +5,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT, PRIMARY KEY (id))
   want:
@@ -13,6 +14,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: CREATE TABLE t(id INT)
   want:
@@ -20,7 +22,8 @@
       code: 601
       title: table.require-pk
       content: Table `t` requires PRIMARY KEY
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT);
@@ -31,6 +34,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT);
@@ -41,6 +45,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT PRIMARY KEY);
@@ -50,7 +55,8 @@
       code: 601
       title: table.require-pk
       content: Table `t` requires PRIMARY KEY
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT PRIMARY KEY);
@@ -60,7 +66,8 @@
       code: 601
       title: table.require-pk
       content: Table `t` requires PRIMARY KEY
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT);
@@ -71,6 +78,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT);
@@ -81,6 +89,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book CHANGE COLUMN id uid INT
   want:
@@ -89,6 +98,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT);
@@ -99,6 +109,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book MODIFY COLUMN id INT
   want:
@@ -107,6 +118,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT, name varchar(30), PRIMARY KEY(id, name));
@@ -117,6 +129,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     CREATE TABLE t(id INT, name varchar(30), comment varchar(255), PRIMARY KEY(id, name));
@@ -126,7 +139,8 @@
       code: 601
       title: table.require-pk
       content: Table `t` requires PRIMARY KEY
-      line: 1
+      line: 2
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book ADD COLUMN a int, DROP COLUMN id, DROP COLUMN name
   want:
@@ -134,7 +148,8 @@
       code: 601
       title: table.require-pk
       content: Table `tech_book` requires PRIMARY KEY
-      line: 0
+      line: 1
+      column: 0
       details: ""
 - statement: ALTER TABLE tech_book DROP COLUMN name
   want:
@@ -143,6 +158,7 @@
       title: OK
       content: ""
       line: 0
+      column: 0
       details: ""
 - statement: |-
     ALTER TABLE tech_book CHANGE COLUMN id uid int;
@@ -152,5 +168,6 @@
       code: 601
       title: table.require-pk
       content: Table `tech_book` requires PRIMARY KEY
-      line: 1
+      line: 2
+      column: 0
       details: ""


### PR DESCRIPTION
close BYT-4641

I want to use tidb splitter to set line number for tidb ast node for tidb walk_through, because of mysql parser compatilbility.