### PR TITLE
fix(schema-editor): minor bug fixes

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
@@ -381,7 +381,12 @@ const generateDiffDDLMap = async (silent: boolean) => {
     const editing = cloneDeep(target.metadata);
     await applyMetadataEdit(database, editing);
 
-    const result = await generateSingleDiffDDL(database, source, editing);
+    const result = await generateSingleDiffDDL(
+      database,
+      source,
+      editing,
+      /* !allowEmptyDiffDDLWithConfigChange */ false
+    );
     if (result.fatal && !silent) {
       pushNotification({
         module: "bytebase",

--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -433,7 +433,12 @@ const handleApplyToDatabase = async (databaseIdList: string[]) => {
   const source =
     branch.baselineSchemaMetadata ?? DatabaseMetadata.fromPartial({});
   const target = branch.schemaMetadata ?? DatabaseMetadata.fromPartial({});
-  const result = await generateDiffDDL(database.value, source, target);
+  const result = await generateDiffDDL(
+    database.value,
+    source,
+    target,
+    /* !allowEmptyDiffDDLWithConfigChange */ false
+  );
 
   if (result.fatal) {
     pushNotification({

--- a/frontend/src/components/SchemaEditorLite/algorithm/index.ts
+++ b/frontend/src/components/SchemaEditorLite/algorithm/index.ts
@@ -75,6 +75,7 @@ const cleanupUnusedConfigs = (metadata: DatabaseMetadata) => {
     tableConfig: TableConfig
   ) => {
     const columnMap = keyBy(table.columns, (column) => column.name);
+    // Remove unused column configs
     tableConfig.columnConfigs = tableConfig.columnConfigs.filter((cc) =>
       columnMap.has(cc.name)
     );
@@ -84,21 +85,33 @@ const cleanupUnusedConfigs = (metadata: DatabaseMetadata) => {
     schemaConfig: SchemaConfig
   ) => {
     const tableMap = keyBy(schema.tables, (table) => table.name);
+    // Remove unused table configs
     schemaConfig.tableConfigs = schemaConfig.tableConfigs.filter((tc) =>
       tableMap.has(tc.name)
     );
+    // Recursively cleanup column configs
     schemaConfig.tableConfigs.forEach((tc) => {
       cleanupColumnConfigs(tableMap.get(tc.name)!, tc);
     });
+    // Cleanup empty table configs
+    schemaConfig.tableConfigs = schemaConfig.tableConfigs.filter(
+      (tc) => tc.columnConfigs.length > 0
+    );
   };
   const cleanupSchemaConfigs = (metadata: DatabaseMetadata) => {
     const schemaMap = keyBy(metadata.schemas, (schema) => schema.name);
+    // Remove unused schema configs
     metadata.schemaConfigs = metadata.schemaConfigs.filter((sc) =>
       schemaMap.has(sc.name)
     );
+    // Recursively cleanup table configs
     metadata.schemaConfigs.forEach((sc) => {
       cleanupTableConfigs(schemaMap.get(sc.name)!, sc);
     });
+    // Cleanup empty schema configs
+    metadata.schemaConfigs = metadata.schemaConfigs.filter(
+      (sc) => sc.tableConfigs.length > 0
+    );
   };
 
   cleanupSchemaConfigs(metadata);

--- a/frontend/src/components/SchemaEditorLite/common.ts
+++ b/frontend/src/components/SchemaEditorLite/common.ts
@@ -20,7 +20,8 @@ export type GenerateDiffDDLResult = {
 export const generateDiffDDL = async (
   database: ComposedDatabase,
   source: DatabaseMetadata,
-  target: DatabaseMetadata
+  target: DatabaseMetadata,
+  allowEmptyDiffDDLWithConfigChange = true
 ): Promise<GenerateDiffDDLResult> => {
   const finish = (statement: string, errors: string[], fatal: boolean) => {
     _generateDiffDDLTimer.end("generateDiffDDL");
@@ -56,7 +57,10 @@ export const generateDiffDDL = async (
     );
     const { diff } = diffResponse;
     if (diff.length === 0) {
-      if (!isEqual(source.schemaConfigs, target.schemaConfigs)) {
+      if (
+        !allowEmptyDiffDDLWithConfigChange &&
+        !isEqual(source.schemaConfigs, target.schemaConfigs)
+      ) {
         return finish(
           "",
           [t("schema-editor.message.cannot-change-config")],

--- a/frontend/src/components/SchemaEditorLite/context/edit.ts
+++ b/frontend/src/components/SchemaEditorLite/context/edit.ts
@@ -45,7 +45,9 @@ export const useEditStatus = () => {
   ) => {
     const key = keyForResource(database, metadata);
     const keys = recursive
-      ? dirtyPathsArray.value.filter((path) => path.startsWith(key))
+      ? dirtyPathsArray.value.filter(
+          (path) => path === key || path.startsWith(`${key}/`)
+        )
       : [key];
 
     keys.forEach((key) => dirtyPaths.value.delete(key));
@@ -62,7 +64,7 @@ export const useEditStatus = () => {
     if (dirtyPaths.value.has(key)) {
       return dirtyPaths.value.get(key)!;
     }
-    if (dirtyPathsArray.value.some((path) => path.startsWith(key))) {
+    if (dirtyPathsArray.value.some((path) => path.startsWith(`${key}/`))) {
       return "updated";
     }
     return "normal";
@@ -80,7 +82,7 @@ export const useEditStatus = () => {
     if (dirtyPaths.value.has(key)) {
       return dirtyPaths.value.get(key)!;
     }
-    if (dirtyPathsArray.value.some((path) => path.startsWith(key))) {
+    if (dirtyPathsArray.value.some((path) => path.startsWith(`${key}/`))) {
       return "updated";
     }
     return "normal";
@@ -99,7 +101,7 @@ export const useEditStatus = () => {
     if (dirtyPaths.value.has(key)) {
       return dirtyPaths.value.get(key)!;
     }
-    if (dirtyPathsArray.value.some((path) => path.startsWith(key))) {
+    if (dirtyPathsArray.value.some((path) => path.startsWith(`${key}/`))) {
       return "updated";
     }
     return "normal";


### PR DESCRIPTION
1. Cleanup unused schema/table/column configs when saving editing metadata.
2. Strict conditions to avoid confusing edit status coloring when a table's name is another's prefix.