### PR TITLE
chore: remove unused table-core package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
     "@joe-re/sql-parser": "^1.7.0",
     "@markdoc/markdoc": "0.4.0",
     "@soerenmartius/vue3-clipboard": "0.1.2",
-    "@tanstack/table-core": "8.10.7",
     "@tanstack/vue-table": "8.10.7",
     "@vueuse/core": "10.4.1",
     "abort-controller-x": "^0.4.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,9 +17,6 @@ dependencies:
   '@soerenmartius/vue3-clipboard':
     specifier: 0.1.2
     version: 0.1.2
-  '@tanstack/table-core':
-    specifier: 8.10.7
-    version: 8.10.7
   '@tanstack/vue-table':
     specifier: 8.10.7
     version: 8.10.7(vue@3.2.47)

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/ColumnSortedIcon.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/ColumnSortedIcon.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts" setup>
-import { SortDirection } from "@tanstack/table-core";
+import { SortDirection } from "@tanstack/vue-table";
 import { ArrowUpWideNarrow, ArrowDownWideNarrow } from "lucide-vue-next";
 
 defineProps<{


### PR DESCRIPTION
> `@tanstack/vue-table` re-exports all of `@tanstack/table-core`'s and the following. https://tanstack.com/table/v8/docs/adapters/vue-table#exports

Close BYT-4674 