### PR TITLE
chore: cancel healthcheck from dockerfile

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -98,6 +98,4 @@ ENV OPENSSL_CONF /etc/ssl/
 
 CMD ["--port", "8080", "--data", "/var/opt/bytebase"]
 
-HEALTHCHECK --interval=5m --timeout=60s CMD curl -f http://localhost:8080/healthz || exit 1
-
 ENTRYPOINT ["bytebase"]

--- a/scripts/Dockerfile.aws
+++ b/scripts/Dockerfile.aws
@@ -100,6 +100,4 @@ ENV AWS_PRODUCT_ID=$PRODUCT_ID
 
 CMD ["--port", "8080", "--data", "/var/opt/bytebase"]
 
-HEALTHCHECK --interval=5m --timeout=60s CMD curl -f http://localhost:8080/healthz || exit 1
-
 ENTRYPOINT ["bytebase"]

--- a/scripts/Dockerfile.depot
+++ b/scripts/Dockerfile.depot
@@ -72,6 +72,4 @@ ENV OPENSSL_CONF /etc/ssl/
 
 CMD ["--port", "8080", "--data", "/var/opt/bytebase"]
 
-HEALTHCHECK --interval=5m --timeout=60s CMD curl -f http://localhost:8080/healthz || exit 1
-
 ENTRYPOINT ["bytebase"]

--- a/scripts/Dockerfile.render-demo
+++ b/scripts/Dockerfile.render-demo
@@ -84,6 +84,4 @@ ENV OPENSSL_CONF /etc/ssl/
 
 CMD ["--port", "8080", "--data", "/var/opt/bytebase"]
 
-HEALTHCHECK --interval=5m --timeout=60s CMD curl -f http://localhost:8080/healthz || exit 1
-
 ENTRYPOINT ["bytebase"]

--- a/scripts/Dockerfile.sql-service
+++ b/scripts/Dockerfile.sql-service
@@ -59,6 +59,4 @@ COPY ./scripts /usr/local/bin/
 
 CMD ["--host", "http://localhost", "--port", "8080"]
 
-HEALTHCHECK --interval=5m --timeout=60s CMD curl -f http://localhost:8080/healthz || exit 1
-
 ENTRYPOINT ["sql-service"]


### PR DESCRIPTION
Users who need healthcheck should add healthcheck explicitly when createing a container.