### PR TITLE
chore: update login hint

### DIFF
--- a/frontend/src/bbkit/BBAttention.vue
+++ b/frontend/src/bbkit/BBAttention.vue
@@ -23,9 +23,11 @@
         />
       </div>
       <div class="ml-3">
-        <h3 class="text-sm font-medium" :class="`text-${color}-800`">
-          {{ displayTitle }}
-        </h3>
+        <slot name="title">
+          <h3 class="text-sm font-medium" :class="`text-${color}-800`">
+            {{ displayTitle }}
+          </h3>
+        </slot>
         <slot name="default">
           <div
             v-if="description"

--- a/frontend/src/components/ProfileDropdown.vue
+++ b/frontend/src/components/ProfileDropdown.vue
@@ -17,15 +17,15 @@
         to="/setting/profile"
         role="menuitem"
       >
-        <p class="text-sm flex justify-between">
-          <span class="text-main font-medium truncate">
+        <p class="text-sm flex justify-between space-x-2">
+          <span class="text-main font-medium truncate text-ellipsis">
             {{ currentUserV1.title }}
           </span>
           <span class="text-control">
             {{ roleNameV1(currentUserV1.userRole) }}
           </span>
         </p>
-        <p class="text-sm text-control truncate">
+        <p class="text-sm text-control truncate text-ellipsis">
           {{ currentUserV1.email }}
         </p>
       </router-link>

--- a/frontend/src/layouts/SplashLayout.vue
+++ b/frontend/src/layouts/SplashLayout.vue
@@ -2,15 +2,15 @@
   <div class="min-h-screen overflow-hidden flex">
     <div class="hidden bg-white lg:block relative w-0 flex-1">
       <img
-        v-if="route == 'auth.signin'"
+        v-if="route == 'auth.signup'"
         class="absolute inset-0 h-full w-full object-cover"
-        src="../assets/illustration/signin.webp"
+        src="../assets/illustration/signup.webp"
         alt=""
       />
       <img
-        v-else-if="route == 'auth.signup'"
+        v-else
         class="absolute inset-0 h-full w-full object-cover"
-        src="../assets/illustration/signup.webp"
+        src="../assets/illustration/signin.webp"
         alt=""
       />
     </div>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1426,7 +1426,8 @@
     },
     "password-forget": {
       "title": "Forgot your password?",
-      "content": "Please contact your Bytebase Admin to reset your password.",
+      "selfhost": "Please contact your Bytebase Admin to reset your password.",
+      "cloud": "Please go to the {link} and reset your password.",
       "return-to-sign-in": "Return to Sign in"
     },
     "password-forgot": "Forgot Password",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1425,7 +1425,8 @@
     },
     "password-forget": {
       "title": "¿Olvidaste tu contraseña?",
-      "content": "Póngase en contacto con su administrador de Bytebase para restablecer su contraseña.",
+      "selfhost": "Póngase en contacto con su administrador de Bytebase para restablecer su contraseña.",
+      "cloud": "Vaya al {link} y restablezca su contraseña.",
       "return-to-sign-in": "Volver a iniciar sesión"
     },
     "password-forgot": "Contraseña olvidada",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1423,7 +1423,8 @@
     },
     "password-forget": {
       "title": "忘记了您的密码？",
-      "content": "请联系的您的 Bytebase 管理员重置密码",
+      "selfhost": "请联系的您的 Bytebase 管理员重置密码",
+      "cloud": "请登录 {link} 并重置密码",
       "return-to-sign-in": "返回登录"
     },
     "password-forgot": "忘记密码",

--- a/frontend/src/views/auth/PasswordForgot.vue
+++ b/frontend/src/views/auth/PasswordForgot.vue
@@ -13,9 +13,25 @@
 
     <div class="mt-8">
       <div class="mt-6">
-        <label class="block text-base font-medium leading-5 text-control">
-          {{ $t("auth.password-forget.content") }}
-        </label>
+        <BBAttention :style="`WARN`" :title="hint">
+          <template v-if="actuatorStore.isSaaSMode && !hint" #title>
+            <i18n-t
+              tag="h3"
+              class="text-sm font-medium text-yellow-800"
+              keypath="auth.password-forget.cloud"
+            >
+              <template #link>
+                <a
+                  href="https://hub.bytebase.com/workspace"
+                  target="_blank"
+                  class="normal-link"
+                >
+                  Bytebase Hub
+                </a>
+              </template>
+            </i18n-t>
+          </template>
+        </BBAttention>
       </div>
     </div>
 
@@ -24,7 +40,7 @@
         <div class="w-full border-t border-control-border"></div>
       </div>
       <div class="relative flex justify-center text-sm">
-        <router-link to="/auth/signin" class="accent-link bg-white px-2">
+        <router-link to="/auth" class="accent-link bg-white px-2">
           {{ $t("auth.password-forget.return-to-sign-in") }}
         </router-link>
       </div>
@@ -32,8 +48,25 @@
   </div>
 </template>
 
-<script lang="ts">
-export default {
-  name: "PasswordForgot",
-};
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
+import { useActuatorV1Store } from "@/store";
+
+const route = useRoute();
+const { t } = useI18n();
+const actuatorStore = useActuatorV1Store();
+
+const hint = computed(() => {
+  const hint = route.query.hint as string;
+  if (hint) {
+    return hint;
+  }
+  if (!actuatorStore.isSaaSMode) {
+    return t("auth.password-forget.selfhost");
+  }
+
+  return "";
+});
 </script>

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -47,11 +47,17 @@
                     <span class="text-red-600">*</span>
                   </div>
                   <router-link
-                    to="/auth/password-forgot"
+                    :to="{
+                      path: '/auth/password-forgot',
+                      query: {
+                        hint: route.query.hint,
+                      },
+                    }"
                     class="text-sm font-normal text-control-light hover:underline focus:outline-none"
                     tabindex="-1"
-                    >{{ $t("auth.sign-in.forget-password") }}</router-link
                   >
+                    {{ $t("auth.sign-in.forget-password") }}
+                  </router-link>
                 </label>
                 <div
                   class="relative flex flex-row items-center mt-1 rounded-md shadow-sm"
@@ -98,9 +104,14 @@
               <div
                 class="flex justify-center items-center text-sm text-control"
               >
-                <template v-if="state.loginHint">
+                <template v-if="isDemo">
                   <span class="text-accent">
-                    {{ state.loginHint }}
+                    {{
+                      $t("auth.sign-in.demo-note", {
+                        username: "demo@example.com",
+                        password: "1024",
+                      })
+                    }}
                   </span>
                 </template>
                 <template v-else-if="!disallowSignup">
@@ -239,7 +250,6 @@
 <script lang="ts" setup>
 import { storeToRefs } from "pinia";
 import { computed, onMounted, reactive } from "vue";
-import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import {
   useActuatorV1Store,
@@ -256,11 +266,9 @@ import AuthFooter from "./AuthFooter.vue";
 interface LocalState {
   email: string;
   password: string;
-  loginHint: string;
   showPassword: boolean;
 }
 
-const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 const actuatorStore = useActuatorV1Store();
@@ -270,7 +278,6 @@ const identityProviderStore = useIdentityProviderStore();
 const state = reactive<LocalState>({
   email: "",
   password: "",
-  loginHint: "",
   showPassword: false,
 });
 const { isDemo, disallowSignup } = storeToRefs(actuatorStore);
@@ -298,14 +305,6 @@ onMounted(async () => {
   const params = new URLSearchParams(url.search);
   state.email = params.get("email") ?? (isDemo.value ? "demo@example.com" : "");
   state.password = params.get("password") ?? (isDemo.value ? "1024" : "");
-  state.loginHint =
-    params.get("hint") ??
-    (isDemo.value
-      ? t("auth.sign-in.demo-note", {
-          username: "demo@example.com",
-          password: "1024",
-        })
-      : "");
   state.showPassword = isDemo.value != null;
 
   await identityProviderStore.fetchIdentityProviderList();

--- a/frontend/src/views/auth/Signin.vue
+++ b/frontend/src/views/auth/Signin.vue
@@ -94,22 +94,22 @@
               </div>
             </form>
 
-            <div class="mt-6 relative">
-              <div class="relative flex justify-center text-sm">
-                <template v-if="isDemo">
-                  <span class="pl-2 bg-white text-red-600 text-xl">{{
-                    state.loginHint
-                  }}</span>
+            <div class="mt-3">
+              <div
+                class="flex justify-center items-center text-sm text-control"
+              >
+                <template v-if="state.loginHint">
+                  <span class="text-accent">
+                    {{ state.loginHint }}
+                  </span>
                 </template>
                 <template v-else-if="!disallowSignup">
-                  <span class="pl-2 bg-white text-control">{{
-                    $t("auth.sign-in.new-user")
-                  }}</span>
-                  <router-link
-                    to="/auth/signup"
-                    class="accent-link bg-white px-2"
-                    >{{ $t("common.sign-up") }}</router-link
-                  >
+                  <span>
+                    {{ $t("auth.sign-in.new-user") }}
+                  </span>
+                  <router-link to="/auth/signup" class="accent-link px-2">
+                    {{ $t("common.sign-up") }}
+                  </router-link>
                 </template>
               </div>
             </div>


### PR DESCRIPTION
If the URL query has a hint..
![CleanShot 2023-12-19 at 18 58 28@2x](https://github.com/bytebase/bytebase/assets/10706318/48e122bc-2669-4312-b31c-13b8f4ee1b23)

Otherwise if is self host
![CleanShot 2023-12-19 at 18 58 45@2x](https://github.com/bytebase/bytebase/assets/10706318/18dad9c1-5ee2-4478-a8d0-02f152a2be88)

Or is SaaS
![CleanShot 2023-12-19 at 18 58 14@2x](https://github.com/bytebase/bytebase/assets/10706318/77f85093-900c-4c11-a2b7-0d3906d0cae5)

BTW, actually we need different hints for different roles, for example, the hint might be:

```
For the workspace owner, please go to the Bytebase Hub and reset your password;
For other users, please contact your Bytebase admin to reset the password
```

But that would be too complicated.