### PR TITLE
chore: preloading database engine utils at build time

### DIFF
--- a/scripts/Dockerfile.render-demo
+++ b/scripts/Dockerfile.render-demo
@@ -40,10 +40,27 @@ COPY ./scripts/VERSION .
 # -ldflags="-w -s" means omit DWARF symbol table and the symbol table and debug information
 # go-sqlite3 requires CGO_ENABLED
 RUN VERSION=`cat ./VERSION` && CGO_ENABLED=1 go build \
-        --tags "${RELEASE},embed_frontend,minimal,minidemo" \
+        --tags "${RELEASE},embed_frontend,minimal,minidemo,docker" \
         -ldflags="-w -s -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.version=${VERSION}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.goversion=${GO_VERSION}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.gitcommit=${RENDER_GIT_COMMIT}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.buildtime=${BUILD_TIME}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.builduser=${BUILD_USER}'" \
         -o bytebase \
         ./backend/bin/server/main.go
+
+# Use debian to decompress tar files.
+FROM debian:bookworm-slim as decompressor
+
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y xz-utils
+COPY ./backend/resources /tmp/bytebase/resources/
+# These paths must match the paths in backened/resources/utils/utils_dir.go.
+# The real resource dir is decided by the backend at runtime. But we can only extract these at build time. 
+# we extract resources to a specific dir here and the backend will create symlinks at runtime.
+RUN mkdir -p /var/opt/bytebase/resources/mongoutil-1.6.1-linux-${TARGETARCH}/
+RUN tar -Jxf /tmp/bytebase/resources/mongoutil/mongoutil-1.6.1-linux-${TARGETARCH}.txz -C /var/opt/bytebase/resources/mongoutil-1.6.1-linux-${TARGETARCH}/
+RUN mkdir -p /var/opt/bytebase/resources/mysqlutil-8.0.33-linux-${TARGETARCH}/
+RUN tar -zxf /tmp/bytebase/resources/mysqlutil/mysqlutil-8.0.33-linux-${TARGETARCH}.tar.gz -C /var/opt/bytebase/resources/mysqlutil-8.0.33-linux-${TARGETARCH}/
+RUN mkdir -p /var/opt/bytebase/resources/postgres-linux-${TARGETARCH}-16
+RUN tar -Jxf /tmp/bytebase/resources/postgres/postgres-linux-${TARGETARCH}.txz -C /var/opt/bytebase/resources/postgres-linux-${TARGETARCH}-16/
 
 # Use debian because mysql requires glibc.
 FROM debian:bookworm-slim as monolithic
@@ -71,7 +88,7 @@ RUN apt-get update && apt-get install -y locales curl psmisc procps libncurses5
 # Generate en_US.UTF-8 locale which is needed to start postgres server.
 # Fix the posgres server issue (invalid value for parameter "lc_messages": "en_US.UTF-8").
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
-ENV PATH="${PATH}:/var/opt/bytebase/resources/postgres-linux-amd64-16/bin:/var/opt/bytebase/resources/postgres-linux-arm64-16/bin"
+ENV PATH="${PATH}:/var/opt/bytebase/resources/postgres-linux-amd64-16/bin"
 
 # Copy utility scripts, we have
 # - Demo script to launch Bytebase in readonly demo mode
@@ -79,6 +96,7 @@ COPY ./scripts /usr/local/bin/
 COPY ./scripts/.psqlrc /root/.psqlrc
 COPY --from=backend /backend-build/bytebase /usr/local/bin/
 COPY --from=backend /etc/ssl/certs /etc/ssl/certs
+COPY --from=decompressor /var/opt/bytebase/resources /var/opt/bytebase/resources
 
 ENV OPENSSL_CONF /etc/ssl/
 


### PR DESCRIPTION
enable preloading database engine utils for render-demo