### PR TITLE
chore: change helm svc to use 80 port

### DIFF
--- a/helm-charts/bytebase/templates/service.yaml
+++ b/helm-charts/bytebase/templates/service.yaml
@@ -12,5 +12,5 @@ spec:
     app: bytebase
   ports:
   - protocol: TCP
-    port: {{ $port }}
+    port: 80
     targetPort: {{ $port }}

--- a/helm-charts/bytebase/templates/service.yaml
+++ b/helm-charts/bytebase/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "bytebase.labels" . | nindent 4}}
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: bytebase
   ports:


### PR DESCRIPTION
To make service `bytebase-entrypoint` better cooperate with Ingress
- `bytebase-entrypoint` expose 80 port
- use `ClusterIP` type