### PR TITLE
fix: initialize database schema should use database user

### DIFF
--- a/backend/migrator/migrator.go
+++ b/backend/migrator/migrator.go
@@ -102,7 +102,7 @@ func initializeSchema(ctx context.Context, storeInstance *store.Store, metadataD
 	stmt := fmt.Sprintf("%s\n%s", buf, dataBuf)
 
 	version := model.Version{Semantic: true, Version: cutoffSchemaVersion.String(), Suffix: time.Now().Format("20060102150405")}
-	if _, err := metadataDriver.GetDB().ExecContext(ctx, stmt); err != nil {
+	if _, err := metadataDriver.Execute(ctx, stmt, false /* createDatabase */, dbdriver.ExecuteOptions{}); err != nil {
 		return err
 	}
 	if err := storeInstance.CreateInstanceChangeHistoryForMigrator(ctx, &store.InstanceChangeHistoryMessage{


### PR DESCRIPTION
because initializeSchema use [metadataDriver.GetDB().ExecContext](https://sourcegraph.com/github.com/bytebase/bytebase@734b2a6c2b5141a7dda238ccbe169557d1730a45/-/blob/backend/migrator/migrator.go?L105) which use the `user from postgres connect url`, but migration use [dbdriver.Execute](https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/backend/utils/utils.go?L224) which will use the `database owner`. These two different logics will cause database object owner inconsistency.

This PR wants to uniformly use `db.Execute` for metadb migration. And we still need to change the `database object user` of the already used user by a sql script.