### PR TITLE
fix(structurer): remove field length and direction in index expressions

### DIFF
--- a/backend/plugin/schema/mysql/structurer.go
+++ b/backend/plugin/schema/mysql/structurer.go
@@ -798,9 +798,6 @@ func extractKeyListWithExpression(ctx mysql.IKeyListWithExpressionContext) []str
 	for _, key := range ctx.AllKeyPartOrExpression() {
 		if key.KeyPart() != nil {
 			keyText := mysqlparser.NormalizeMySQLIdentifier(key.KeyPart().Identifier())
-			if key.KeyPart().FieldLength() != nil || key.KeyPart().Direction() != nil {
-				keyText = key.GetParser().GetTokenStream().GetTextFromRuleContext(key.KeyPart())
-			}
 			result = append(result, keyText)
 		} else if key.ExprWithParentheses() != nil {
 			keyText := key.GetParser().GetTokenStream().GetTextFromRuleContext(key.ExprWithParentheses())

--- a/backend/plugin/schema/mysql/structurer_test.go
+++ b/backend/plugin/schema/mysql/structurer_test.go
@@ -67,7 +67,7 @@ type designTest struct {
 
 func TestGetDesignSchema(t *testing.T) {
 	const (
-		record = true
+		record = false
 	)
 	var (
 		filepath = "testdata/get_design_schema.yaml"

--- a/backend/plugin/schema/mysql/structurer_test.go
+++ b/backend/plugin/schema/mysql/structurer_test.go
@@ -67,7 +67,7 @@ type designTest struct {
 
 func TestGetDesignSchema(t *testing.T) {
 	const (
-		record = false
+		record = true
 	)
 	var (
 		filepath = "testdata/get_design_schema.yaml"

--- a/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
+++ b/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
@@ -116,6 +116,81 @@
                   ]
                 }
               ]
+            },
+            {
+              "name": "t5",
+              "engine": "InnoDB",
+              "columns": [
+                {
+                  "name": "id",
+                  "type": "int",
+                  "position": 1
+                },
+                {
+                  "name": "a",
+                  "type": "int",
+                  "nullable": true,
+                  "position": 2,
+                  "defaultNull": true
+                },
+                {
+                  "name": "title",
+                  "type": "text",
+                  "nullable": true,
+                  "position": 3,
+                  "collation": "utf8mb4_general_ci",
+                  "defaultNull": true,
+                  "characterSet": "utf8mb4"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "PRIMARY",
+                  "type": "BTREE",
+                  "unique": true,
+                  "primary": true,
+                  "visible": true,
+                  "expressions": [
+                    "id"
+                  ]
+                },
+                {
+                  "name": "t5_a_plus_5_t_a_plus_3_uniq_idx",
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true,
+                  "expressions": [
+                    "((`a` + 5))",
+                    "((`a` + 3))"
+                  ]
+                },
+                {
+                  "name": "t5_a_plus_5_uniq_idx",
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true,
+                  "expressions": [
+                    "((`a` + 5))"
+                  ]
+                },
+                {
+                  "name": "t5_a_uniq_idx",
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true,
+                  "expressions": [
+                    "a"
+                  ]
+                },
+                {
+                  "name": "t5_title_fulltext_idx",
+                  "type": "FULLTEXT",
+                  "visible": true,
+                  "expressions": [
+                    "title"
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -139,6 +214,16 @@
       `a` int NULL,
       PRIMARY KEY (`b`),
       CONSTRAINT `fk1` FOREIGN KEY (`b`) REFERENCES `t4` (`b`)
+    );
+    CREATE TABLE `t5` (
+      `id` int NOT NULL,
+      `a` int NULL DEFAULT NULL,
+      `title` text NULL DEFAULT NULL,
+      PRIMARY KEY (`id`),
+      UNIQUE KEY `t5_a_plus_5_t_a_plus_3_uniq_idx` (((`a` + 5)),((`a` + 3))) USING BTREE,
+      UNIQUE KEY `t5_a_plus_5_uniq_idx` (((`a` + 5))) USING BTREE,
+      UNIQUE KEY `t5_a_uniq_idx` (`a`) USING BTREE,
+      FULLTEXT KEY `t5_title_fulltext_idx` (`title`)
     );
 
 - baseline: |-

--- a/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
+++ b/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
@@ -119,78 +119,84 @@
             },
             {
               "name": "t5",
-              "engine": "InnoDB",
               "columns": [
-                {
-                  "name": "id",
-                  "type": "int",
-                  "position": 1
-                },
                 {
                   "name": "a",
                   "type": "int",
-                  "nullable": true,
-                  "position": 2,
-                  "defaultNull": true
+                  "comment": "this is comment"
                 },
                 {
-                  "name": "title",
-                  "type": "text",
+                  "name": "b",
+                  "type": "VARCHAR(20)"
+                },
+                {
+                  "name": "c",
+                  "type": "int"
+                },
+                {
+                  "name": "d",
                   "nullable": true,
-                  "position": 3,
-                  "collation": "utf8mb4_general_ci",
-                  "defaultNull": true,
-                  "characterSet": "utf8mb4"
+                  "type": "text"
                 }
               ],
               "indexes": [
                 {
                   "name": "PRIMARY",
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true,
-                  "expressions": [
-                    "id"
-                  ]
-                },
-                {
-                  "name": "t5_a_plus_5_t_a_plus_3_uniq_idx",
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true,
-                  "expressions": [
-                    "((`a` + 5))",
-                    "((`a` + 3))"
-                  ]
-                },
-                {
-                  "name": "t5_a_plus_5_uniq_idx",
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true,
-                  "expressions": [
-                    "((`a` + 5))"
-                  ]
-                },
-                {
-                  "name": "t5_a_uniq_idx",
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true,
                   "expressions": [
                     "a"
-                  ]
+                  ],
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
                 },
                 {
-                  "name": "t5_title_fulltext_idx",
-                  "type": "FULLTEXT",
-                  "visible": true,
+                  "name": "t_c_uniq_idx",
                   "expressions": [
-                    "title"
-                  ]
+                    "c"
+                  ],
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "t_c_plus_5_uniq_idx",
+                  "expressions": [
+                    "((`c` + 5))"
+                  ],
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "t_c_plus_5_t_c_plus_3_uniq_idx",
+                  "expressions": [
+                    "((`c` + 5))",
+                    "((`c` + 3))"
+                  ],
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "idx_c",
+                  "expressions": [
+                    "c"
+                  ],
+                  "visible": true
+                },
+                {
+                  "name": "idx_d",
+                  "expressions": [
+                    "d"
+                  ],
+                  "visible": true
+                },
+                {
+                  "name": "t_d_fulltext_idx",
+                  "expressions": [
+                    "d"
+                  ],
+                  "visible": true
                 }
-              ]
+              ],
+              "comment": "this is comment with ' escaped"
             }
           ]
         }
@@ -216,15 +222,18 @@
       CONSTRAINT `fk1` FOREIGN KEY (`b`) REFERENCES `t4` (`b`)
     );
     CREATE TABLE `t5` (
-      `id` int NOT NULL,
-      `a` int NULL DEFAULT NULL,
-      `title` text NULL DEFAULT NULL,
-      PRIMARY KEY (`id`),
-      UNIQUE KEY `t5_a_plus_5_t_a_plus_3_uniq_idx` (((`a` + 5)),((`a` + 3))) USING BTREE,
-      UNIQUE KEY `t5_a_plus_5_uniq_idx` (((`a` + 5))) USING BTREE,
-      UNIQUE KEY `t5_a_uniq_idx` (`a`) USING BTREE,
-      FULLTEXT KEY `t5_title_fulltext_idx` (`title`)
-    );
+      `a` int NOT NULL COMMENT 'this is comment',
+      `b` VARCHAR(20) NOT NULL,
+      `c` int NOT NULL,
+      `d` text NULL,
+      PRIMARY KEY (`a`),
+      UNIQUE KEY `t_c_uniq_idx` (`c`),
+      UNIQUE KEY `t_c_plus_5_uniq_idx` (((`c` + 5))),
+      UNIQUE KEY `t_c_plus_5_t_c_plus_3_uniq_idx` (((`c` + 5)),((`c` + 3))),
+      KEY `idx_c` (`c`),
+      KEY `idx_d` (`d`),
+      KEY `t_d_fulltext_idx` (`d`)
+    ) COMMENT 'this is comment with '' escaped';
 
 - baseline: |-
     CREATE TABLE `t` (

--- a/backend/plugin/schema/mysql/testdata/parse_to_metadata.yaml
+++ b/backend/plugin/schema/mysql/testdata/parse_to_metadata.yaml
@@ -3,63 +3,101 @@
       (
         `a` int NOT NULL COMMENT 'this is comment',
         `b` VARCHAR(20) NOT NULL,
-        KEY `idx` (((`a` + 20))),
-        UNIQUE KEY `idx2` (`a`),
-        KEY `idx_length` (`b`(10) DESC),
-        PRIMARY KEY (`a`)
+        `c` int NOT NULL,
+        `d` text NULL,
+        PRIMARY KEY (`a`),
+        UNIQUE KEY `t_c_uniq_idx` (`c` DESC),
+        UNIQUE KEY `t_c_plus_5_uniq_idx` (((`c` + 5)) DESC),
+        UNIQUE KEY `t_c_plus_5_t_c_plus_3_uniq_idx` (((`c` + 5)) DESC,((`c` + 3))),
+        KEY `idx_c` (`c`),
+        KEY `idx_d` (`d`(10)),
+        FULLTEXT KEY `t_d_fulltext_idx` (`d`)
       ) COMMENT 'this is comment with '' escaped';
   metadata: |-
     {
-      "schemas":  [
+      "schemas": [
         {
-          "tables":  [
+          "tables": [
             {
-              "name":  "t",
-              "columns":  [
+              "name": "t",
+              "columns": [
                 {
-                  "name":  "a",
-                  "type":  "int",
-                  "comment":  "this is comment"
+                  "name": "a",
+                  "type": "int",
+                  "comment": "this is comment"
                 },
                 {
-                  "name":  "b",
-                  "type":  "VARCHAR(20)"
+                  "name": "b",
+                  "type": "VARCHAR(20)"
+                },
+                {
+                  "name": "c",
+                  "type": "int"
+                },
+                {
+                  "name": "d",
+                  "nullable": true,
+                  "type": "text"
                 }
               ],
-              "indexes":  [
+              "indexes": [
                 {
-                  "name":  "idx",
-                  "expressions":  [
-                    "((`a` + 20))"
-                  ],
-                  "visible":  true
-                },
-                {
-                  "name":  "idx2",
-                  "expressions":  [
+                  "name": "PRIMARY",
+                  "expressions": [
                     "a"
                   ],
-                  "unique":  true,
-                  "visible":  true
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
                 },
                 {
-                  "name":  "idx_length",
-                  "expressions":  [
-                    "`b`(10) DESC"
+                  "name": "t_c_uniq_idx",
+                  "expressions": [
+                    "c"
                   ],
-                  "visible":  true
+                  "unique": true,
+                  "visible": true
                 },
                 {
-                  "name":  "PRIMARY",
-                  "expressions":  [
-                    "a"
+                  "name": "t_c_plus_5_uniq_idx",
+                  "expressions": [
+                    "((`c` + 5))"
                   ],
-                  "unique":  true,
-                  "primary":  true,
-                  "visible":  true
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "t_c_plus_5_t_c_plus_3_uniq_idx",
+                  "expressions": [
+                    "((`c` + 5))",
+                    "((`c` + 3))"
+                  ],
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "idx_c",
+                  "expressions": [
+                    "c"
+                  ],
+                  "visible": true
+                },
+                {
+                  "name": "idx_d",
+                  "expressions": [
+                    "d"
+                  ],
+                  "visible": true
+                },
+                {
+                  "name": "t_d_fulltext_idx",
+                  "expressions": [
+                    "d"
+                  ],
+                  "visible": true
                 }
               ],
-              "comment":  "this is comment with ' escaped"
+              "comment": "this is comment with ' escaped"
             }
           ]
         }
@@ -77,76 +115,76 @@
     create table t2(b int NOT NULL default NULL, primary key (b));
   metadata: |-
     {
-      "schemas":  [
+      "schemas": [
         {
-          "tables":  [
+          "tables": [
             {
-              "name":  "t",
-              "columns":  [
+              "name": "t",
+              "columns": [
                 {
-                  "name":  "c",
-                  "defaultExpression":  "AUTO_INCREMENT",
-                  "nullable":  true,
-                  "type":  "int"
+                  "name": "c",
+                  "defaultExpression": "AUTO_INCREMENT",
+                  "nullable": true,
+                  "type": "int"
                 },
                 {
-                  "name":  "a",
-                  "defaultExpression":  "1",
-                  "nullable":  true,
-                  "type":  "int",
-                  "comment":  "abcdefg"
+                  "name": "a",
+                  "defaultExpression": "1",
+                  "nullable": true,
+                  "type": "int",
+                  "comment": "abcdefg"
                 },
                 {
-                  "name":  "b",
-                  "defaultNull":  true,
-                  "nullable":  true,
-                  "type":  "varchar(20)"
+                  "name": "b",
+                  "defaultNull": true,
+                  "nullable": true,
+                  "type": "varchar(20)"
                 }
               ],
-              "indexes":  [
+              "indexes": [
                 {
-                  "name":  "PRIMARY",
-                  "expressions":  [
+                  "name": "PRIMARY",
+                  "expressions": [
                     "a",
                     "b"
                   ],
-                  "unique":  true,
-                  "primary":  true,
-                  "visible":  true
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
                 }
               ],
-              "comment":  "this is comment with ' escaped",
-              "foreignKeys":  [
+              "comment": "this is comment with ' escaped",
+              "foreignKeys": [
                 {
-                  "name":  "fk1",
-                  "columns":  [
+                  "name": "fk1",
+                  "columns": [
                     "a"
                   ],
-                  "referencedTable":  "t2",
-                  "referencedColumns":  [
+                  "referencedTable": "t2",
+                  "referencedColumns": [
                     "b"
                   ]
                 }
               ]
             },
             {
-              "name":  "t2",
-              "columns":  [
+              "name": "t2",
+              "columns": [
                 {
-                  "name":  "b",
-                  "defaultNull":  true,
-                  "type":  "int"
+                  "name": "b",
+                  "defaultNull": true,
+                  "type": "int"
                 }
               ],
-              "indexes":  [
+              "indexes": [
                 {
-                  "name":  "PRIMARY",
-                  "expressions":  [
+                  "name": "PRIMARY",
+                  "expressions": [
                     "b"
                   ],
-                  "unique":  true,
-                  "primary":  true,
-                  "visible":  true
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
                 }
               ]
             }


### PR DESCRIPTION
This PR is the part of support `INDEX` object in our Branch feature.

Our store protobuf schema metadata struct lacks the fields about `field length` and `direction` of index, and we should align with out store protobuf, so I remove these fields in expression.

THIS MAY CAUSE US LOSE THESE INFORMATION. But it's not a big deal, let's support index step by step.

![CleanShot 2024-01-03 at 17 04 12@2x](https://github.com/bytebase/bytebase/assets/87714218/5a447bf1-df17-4980-864f-e3be09e5e7b6)
