### PR TITLE
chore: use the change history schema version to create plan

### DIFF
--- a/backend/api/v1/changelist_service.go
+++ b/backend/api/v1/changelist_service.go
@@ -274,8 +274,9 @@ func convertV1ChangelistPayload(changelist *v1pb.Changelist) *storepb.Changelist
 	}
 	for _, change := range changelist.Changes {
 		storeChangelist.Changes = append(storeChangelist.Changes, &storepb.Changelist_Change{
-			Sheet:  change.Sheet,
-			Source: change.Source,
+			Sheet:   change.Sheet,
+			Source:  change.Source,
+			Version: change.Version,
 		})
 	}
 	return storeChangelist
@@ -307,8 +308,9 @@ func (s *ChangelistService) convertStoreChangelist(ctx context.Context, changeli
 	}
 	for _, change := range changelist.Payload.Changes {
 		v1Changelist.Changes = append(v1Changelist.Changes, &v1pb.Changelist_Change{
-			Sheet:  change.Sheet,
-			Source: change.Source,
+			Sheet:   change.Sheet,
+			Source:  change.Source,
+			Version: change.Version,
 		})
 	}
 	return v1Changelist, nil

--- a/frontend/src/components/IssueV1/logic/initialize/create.ts
+++ b/frontend/src/components/IssueV1/logic/initialize/create.ts
@@ -282,7 +282,12 @@ export const buildStepsViaChangelist = async (
         const sheetName = `${params.project.name}/sheets/${sheetUID}`;
         const sheet = getLocalSheetByName(sheetName);
         setSheetStatement(sheet, statement);
-        const spec = await buildSpecForTarget(db.name, params, sheetUID);
+        const spec = await buildSpecForTarget(
+          db.name,
+          params,
+          sheetUID,
+          change.version
+        );
         step.specs.push(spec);
       }
     }
@@ -295,7 +300,8 @@ export const buildStepsViaChangelist = async (
 export const buildSpecForTarget = async (
   target: string,
   { project, query }: CreateIssueParams,
-  sheetUID?: string
+  sheetUID?: string,
+  version?: string
 ) => {
   const sheet = `${project.name}/sheets/${sheetUID ?? nextUID()}`;
   const template = query.template as TemplateType | undefined;
@@ -315,6 +321,9 @@ export const buildSpecForTarget = async (
     }
     if (!spec.changeDatabaseConfig.sheet) {
       spec.changeDatabaseConfig.sheet = sheet;
+    }
+    if (version) {
+      spec.changeDatabaseConfig.schemaVersion = version;
     }
   }
   if (template === "bb.issue.database.schema.update") {
@@ -343,6 +352,10 @@ export const buildSpecForTarget = async (
         const statement = getSheetStatement(remoteSheet);
         setSheetStatement(localSheet, statement);
       }
+    }
+
+    if (version) {
+      spec.changeDatabaseConfig.schemaVersion = version;
     }
   }
   if (template === "bb.issue.database.schema.baseline") {


### PR DESCRIPTION
Without assigning version to change in changelist, we will get "Apply change list to target db failed with a duplicate version error" since the version are generated in the backend and all versions are based on now().