### PR TITLE
fix: return valid instance after creation

### DIFF
--- a/backend/server/onboard.go
+++ b/backend/server/onboard.go
@@ -59,7 +59,7 @@ func (s *Server) generateOnboardingData(ctx context.Context, user *store.UserMes
 	}
 
 	// Sync the instance schema so we can transfer the sample database later.
-	if err := s.schemaSyncer.SyncInstance(ctx, testInstance); err != nil {
+	if _, err := s.schemaSyncer.SyncInstance(ctx, testInstance); err != nil {
 		return errors.Wrapf(err, "failed to sync test onboarding instance")
 	}
 
@@ -118,7 +118,7 @@ func (s *Server) generateOnboardingData(ctx context.Context, user *store.UserMes
 	}
 
 	// Sync the instance schema so we can transfer the sample database later.
-	if err := s.schemaSyncer.SyncInstance(ctx, prodInstance); err != nil {
+	if _, err := s.schemaSyncer.SyncInstance(ctx, prodInstance); err != nil {
 		return errors.Wrapf(err, "failed to sync prod onboarding instance")
 	}
 

--- a/frontend/src/components/DatabaseDetail/Settings/DatabaseSettingsPanel.vue
+++ b/frontend/src/components/DatabaseDetail/Settings/DatabaseSettingsPanel.vue
@@ -9,7 +9,7 @@
         :environment="environment?.uid"
         :disabled="!allowEdit"
         :default-environment-name="database.instanceEntity.environment"
-        @select-environment-id="handleSelectEnvironmentUID"
+        @update:environment="handleSelectEnvironmentUID"
       />
     </div>
     <Labels :database="database" class="pt-5" />
@@ -20,8 +20,13 @@
 <script setup lang="ts">
 import { cloneDeep } from "lodash-es";
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { EnvironmentSelect } from "@/components/v2";
-import { useDatabaseV1Store, useEnvironmentV1Store } from "@/store";
+import {
+  useDatabaseV1Store,
+  useEnvironmentV1Store,
+  pushNotification,
+} from "@/store";
 import { type ComposedDatabase } from "@/types";
 import Labels from "./components/Labels.vue";
 import Secrets from "./components/Secrets.vue";
@@ -33,12 +38,13 @@ const props = defineProps<{
 
 const databaseStore = useDatabaseV1Store();
 const envStore = useEnvironmentV1Store();
+const { t } = useI18n();
 
 const environment = computed(() => {
   return envStore.getEnvironmentByName(props.database.effectiveEnvironment);
 });
 
-const handleSelectEnvironmentUID = async (uid: number | string) => {
+const handleSelectEnvironmentUID = async (uid?: string) => {
   const environment = envStore.getEnvironmentByUID(String(uid));
   if (environment.name === props.database.effectiveEnvironment) {
     return;
@@ -48,6 +54,11 @@ const handleSelectEnvironmentUID = async (uid: number | string) => {
   await databaseStore.updateDatabase({
     database: databasePatch,
     updateMask: ["environment"],
+  });
+  pushNotification({
+    module: "bytebase",
+    style: "INFO",
+    title: t("common.updated"),
   });
 };
 </script>

--- a/frontend/src/components/SQLReview/SQLReviewPolicyTable.vue
+++ b/frontend/src/components/SQLReview/SQLReviewPolicyTable.vue
@@ -31,7 +31,7 @@
         <div class="bb-grid-cell justify-center">
           <NCheckbox
             :disabled="!review || !hasPermission"
-            :checked="review?.enforce"
+            :checked="review?.enforce ?? false"
             @update:checked="toggleReviewEnabled(review!, $event)"
           />
         </div>


### PR DESCRIPTION
- fix BYT-4800: I found we will sync necessary instance info synchronously ([code](https://sourcegraph.com/github.com/bytebase/bytebase@22e61ae527f824dedf445be45c75ca1940954381/-/blob/backend/api/v1/instance_service.go?L198)), but the returned data is out of data.
- fix: cannot change the effective environment for database