### PR TITLE
fix: slow query panel

### DIFF
--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -1720,7 +1720,7 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
-				t = t.AddDate(0, 0, 1).UTC()
+				t = t.AddDate(0, 0, 1)
 				startLogDate = &t
 			case comparatorTypeGreaterEqual:
 				if startLogDate != nil {
@@ -1730,7 +1730,6 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
-				t = t.UTC()
 				startLogDate = &t
 			case comparatorTypeLess:
 				if endLogDate != nil {
@@ -1740,7 +1739,6 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
-				t = t.UTC()
 				endLogDate = &t
 			case comparatorTypeLessEqual:
 				if endLogDate != nil {
@@ -1750,7 +1748,7 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
-				t = t.AddDate(0, 0, 1).UTC()
+				t = t.AddDate(0, 0, 1)
 				endLogDate = &t
 			default:
 				return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q %q %q", expr.key, expr.operator, expr.value)

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -1720,7 +1720,7 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
-				t = t.AddDate(0, 0, 1)
+				t = t.AddDate(0, 0, 1).UTC()
 				startLogDate = &t
 			case comparatorTypeGreaterEqual:
 				if startLogDate != nil {
@@ -1730,6 +1730,7 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
+				t = t.UTC()
 				startLogDate = &t
 			case comparatorTypeLess:
 				if endLogDate != nil {
@@ -1739,6 +1740,7 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
+				t = t.UTC()
 				endLogDate = &t
 			case comparatorTypeLessEqual:
 				if endLogDate != nil {
@@ -1748,7 +1750,7 @@ func (s *DatabaseService) ListSlowQueries(ctx context.Context, request *v1pb.Lis
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q", expr.value)
 				}
-				t = t.AddDate(0, 0, 1)
+				t = t.AddDate(0, 0, 1).UTC()
 				endLogDate = &t
 			default:
 				return nil, status.Errorf(codes.InvalidArgument, "invalid start_time filter %q %q %q", expr.key, expr.operator, expr.value)

--- a/backend/store/slow_query.go
+++ b/backend/store/slow_query.go
@@ -223,7 +223,7 @@ func (s *Store) UpsertSlowLog(ctx context.Context, upsert *UpsertSlowLogMessage)
 		}
 	}
 
-	logDate, err := strconv.Atoi(upsert.LogDate.Format("20060102"))
+	logDate, err := strconv.Atoi(upsert.LogDate.UTC().Format("20060102"))
 	if err != nil {
 		return err
 	}

--- a/frontend/src/components/Project/ProjectSidebar.vue
+++ b/frontend/src/components/Project/ProjectSidebar.vue
@@ -312,8 +312,10 @@ const selectProjectTabOnHash = () => {
       state.selectedHash = "issues";
       return;
     case "workspace.database.detail":
-    case "workspace.database.history.detail":
       state.selectedHash = "databases";
+      return;
+    case "workspace.database.history.detail":
+      state.selectedHash = "change-history";
       return;
   }
 };

--- a/frontend/src/components/SlowQuery/Panel/IndexAdvisor.vue
+++ b/frontend/src/components/SlowQuery/Panel/IndexAdvisor.vue
@@ -27,14 +27,14 @@
     </div>
   </div>
   <div v-else-if="!hasIndexAdvisorFeature">
-    <div class="btn btn-primary !w-auto" @click="state.showFeatureModal = true">
+    <NButton type="primary" @click="state.showFeatureModal = true">
       {{ $t("subscription.features.bb-feature-index-advisor.title") }}
       <FeatureBadge
-        custom-class="ml-1"
+        custom-class="ml-1 text-white"
         feature="bb.feature.index-advisor"
         :instance="slowQueryLog.database.instanceEntity"
       />
-    </div>
+    </NButton>
   </div>
   <div v-else-if="!hasOpenAIKeySetup">
     <router-link class="normal-link" to="/setting/general">{{

--- a/frontend/src/components/SlowQuery/Panel/LogFilter.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogFilter.vue
@@ -20,7 +20,7 @@
           :placeholder="$t('slow-query.filter.from-date')"
           type="date"
           clearable
-          format="yyyy-MM-dd z"
+          format="yyyy-MM-dd"
           style="width: 12rem"
           @update:value="changeFromTime($event)"
         />
@@ -31,7 +31,7 @@
           :placeholder="$t('slow-query.filter.to-date')"
           type="date"
           clearable
-          format="yyyy-MM-dd z"
+          format="yyyy-MM-dd"
           style="width: 12rem"
           @update:value="changeToTime($event)"
         />

--- a/frontend/src/components/SlowQuery/Panel/LogTable.vue
+++ b/frontend/src/components/SlowQuery/Panel/LogTable.vue
@@ -1,106 +1,18 @@
 <template>
-  <BBGrid
-    :column-list="columns"
-    :data-source="slowQueryLogList"
-    :show-placeholder="showPlaceholder"
-    :is-row-clickable="(row) => true"
-    :is-row-expanded="isSelectedRow"
-    class="border w-auto overflow-x-auto"
-    header-class="capitalize"
-    @click-row="(log: ComposedSlowQueryLog) => $emit('select', log)"
+  <NDataTable
+    v-model:expanded-row-keys="expandedRowKeys"
+    class="min-w-[120rem]"
+    :columns="dataTableColumns"
+    :data="slowQueryLogList"
+    :max-height="'100%'"
+    :row-key="rowKey"
+    :row-props="rowProps"
+    :virtual-scroll="true"
+    :striped="true"
+    :bordered="true"
+    :bottom-bordered="true"
   >
-    <template #item="{ item }: SlowQueryLogRow">
-      <template v-if="item.log.statistics">
-        <div class="bb-grid-cell whitespace-nowrap !pl-1 !pr-1">
-          <NButton quaternary size="tiny" @click.stop="toggleExpandRow(item)">
-            <heroicons:chevron-right
-              class="w-4 h-4 transition-transform duration-150 cursor-pointer"
-              :class="[isSelectedRow(item) && 'rotate-90']"
-            />
-          </NButton>
-        </div>
-        <div class="bb-grid-cell text-xs font-mono">
-          <div class="truncate">
-            {{ item.log.statistics.sqlFingerprint }}
-          </div>
-        </div>
-        <div class="bb-grid-cell">
-          {{ item.log.statistics.count }}
-        </div>
-        <div class="bb-grid-cell">
-          {{ (item.log.statistics.countPercent * 100).toFixed(2) }}%
-        </div>
-        <div class="bb-grid-cell">
-          {{ durationText(item.log.statistics.maximumQueryTime) }}
-        </div>
-        <div class="bb-grid-cell">
-          {{ durationText(item.log.statistics.averageQueryTime) }}
-        </div>
-        <div class="bb-grid-cell">
-          {{ (item.log.statistics.queryTimePercent * 100).toFixed(2) }}%
-        </div>
-        <div class="bb-grid-cell">
-          {{
-            instanceV1HasSlowQueryDetail(item.database.instanceEntity)
-              ? item.log.statistics.maximumRowsExamined
-              : "-"
-          }}
-        </div>
-        <div class="bb-grid-cell">
-          {{
-            instanceV1HasSlowQueryDetail(item.database.instanceEntity)
-              ? item.log.statistics.averageRowsExamined
-              : "-"
-          }}
-        </div>
-        <div class="bb-grid-cell">
-          {{
-            instanceV1HasSlowQueryDetail(item.database.instanceEntity)
-              ? item.log.statistics.maximumRowsSent
-              : "-"
-          }}
-        </div>
-        <div class="bb-grid-cell">
-          {{ item.log.statistics.averageRowsSent }}
-        </div>
-        <div v-if="showProjectColumn" class="bb-grid-cell">
-          <ProjectV1Name :project="item.database.projectEntity" :link="false" />
-        </div>
-        <div v-if="showEnvironmentColumn" class="bb-grid-cell">
-          <EnvironmentV1Name
-            :environment="item.database.effectiveEnvironmentEntity"
-            :link="false"
-          />
-        </div>
-        <div v-if="showInstanceColumn" class="bb-grid-cell">
-          <InstanceV1Name
-            :instance="item.database.instanceEntity"
-            :link="false"
-          />
-        </div>
-        <div v-if="showDatabaseColumn" class="bb-grid-cell">
-          <DatabaseV1Name :database="item.database" :link="false" />
-        </div>
-        <div class="bb-grid-cell whitespace-nowrap !pr-4">
-          {{
-            dayjs(item.log.statistics.latestLogTime).format(
-              "YYYY-MM-DD HH:mm:ss"
-            )
-          }}
-        </div>
-      </template>
-    </template>
-
-    <template #expanded-item="{ item }: SlowQueryLogRow">
-      <div class="w-full max-h-[20rem] overflow-auto text-xs pl-2">
-        <HighlightCodeBlock
-          :code="item.log.statistics?.sqlFingerprint"
-          class="whitespace-pre-wrap"
-        />
-      </div>
-    </template>
-
-    <template #placeholder-content>
+    <template #empty>
       <div class="py-8 px-8 text-center">
         <p v-if="allowAdmin">
           {{ $t("slow-query.no-log-placeholder.admin") }}
@@ -110,14 +22,17 @@
         </p>
       </div>
     </template>
-  </BBGrid>
+  </NDataTable>
 </template>
 
 <script lang="ts" setup>
-import { computed, shallowRef, watch } from "vue";
+import dayjs from "dayjs";
+import { NDataTable, DataTableColumn } from "naive-ui";
+import { computed, h, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { type BBGridColumn, type BBGridRow, BBGrid } from "@/bbkit";
+import HighlightCodeBlock from "@/components/HighlightCodeBlock";
 import {
+  ProjectV1Name,
   DatabaseV1Name,
   InstanceV1Name,
   EnvironmentV1Name,
@@ -125,8 +40,6 @@ import {
 import type { ComposedSlowQueryLog } from "@/types";
 import type { Duration } from "@/types/proto/google/protobuf/duration";
 import { instanceV1HasSlowQueryDetail } from "@/utils";
-
-export type SlowQueryLogRow = BBGridRow<ComposedSlowQueryLog>;
 
 const props = withDefaults(
   defineProps<{
@@ -148,106 +61,195 @@ const props = withDefaults(
   }
 );
 
-defineEmits<{
+const emit = defineEmits<{
   (event: "select", log: ComposedSlowQueryLog): void;
 }>();
 
 const { t } = useI18n();
-const selectedSlowQueryLog = shallowRef<ComposedSlowQueryLog>();
 
-const columns = computed(() => {
-  const columns = [
-    {
-      width: "auto",
-    },
-    {
-      title: t("slow-query.sql-statement"),
-      width: "minmax(10rem, 1fr)",
-    },
-    {
-      title: t("slow-query.total-query-count"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.query-count-percent"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.max-query-time"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.avg-query-time"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.query-time-percent"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.max-rows-examined"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.avg-rows-examined"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.max-rows-sent"),
-      width: "6rem",
-    },
-    {
-      title: t("slow-query.avg-rows-sent"),
-      width: "6rem",
-    },
-    props.showProjectColumn && {
-      title: t("common.project"),
-      width: "minmax(6rem, auto)",
-    },
-    props.showEnvironmentColumn && {
-      title: t("common.environment"),
-      width: "8rem",
-    },
-    props.showInstanceColumn && {
-      title: t("common.instance"),
-      width: "12rem",
-    },
-    props.showDatabaseColumn && {
-      title: t("common.database"),
-      width: "8rem",
-    },
-    {
+const dataTableColumns = computed(
+  (): DataTableColumn<ComposedSlowQueryLog>[] => {
+    const columns: DataTableColumn<ComposedSlowQueryLog>[] = [
+      {
+        type: "expand",
+        expandable: (_) => true,
+        renderExpand: (item) =>
+          h(
+            "div",
+            { class: "w-full max-h-[20rem] overflow-auto text-xs pl-2" },
+            h(HighlightCodeBlock, {
+              class: "whitespace-pre-wrap",
+              code: item.log.statistics?.sqlFingerprint ?? "",
+            })
+          ),
+      },
+      {
+        title: t("slow-query.sql-statement"),
+        key: "statement",
+        render: (item) =>
+          h("div", { class: "truncate" }, item.log.statistics?.sqlFingerprint),
+      },
+      {
+        title: t("slow-query.total-query-count"),
+        key: "total_query_count",
+        sorter: (rowA, rowB) =>
+          (rowA.log.statistics?.count ?? 0) - (rowB.log.statistics?.count ?? 0),
+        render: (item) => item.log.statistics?.count,
+      },
+      {
+        title: t("slow-query.query-count-percent"),
+        key: "query_count_percentage",
+        render: (item) =>
+          `${((item.log.statistics?.countPercent ?? 0) * 100).toFixed(2)}%`,
+      },
+      {
+        title: t("slow-query.max-query-time"),
+        key: "max_query_time",
+        sorter: (rowA, rowB) =>
+          durationSeconds(rowA.log.statistics?.maximumQueryTime) -
+          durationSeconds(rowB.log.statistics?.maximumQueryTime),
+        render: (item) => durationText(item.log.statistics?.maximumQueryTime),
+      },
+      {
+        title: t("slow-query.avg-query-time"),
+        key: "avg_query_time",
+        sorter: (rowA, rowB) =>
+          durationSeconds(rowA.log.statistics?.averageQueryTime) -
+          durationSeconds(rowB.log.statistics?.averageQueryTime),
+        render: (item) => durationText(item.log.statistics?.averageQueryTime),
+      },
+      {
+        title: t("slow-query.query-time-percent"),
+        key: "query_time_percentage",
+        render: (item) =>
+          `${((item.log.statistics?.queryTimePercent ?? 0) * 100).toFixed(2)}%`,
+      },
+      {
+        title: t("slow-query.max-rows-examined"),
+        key: "max_rows_examined",
+        sorter: (rowA, rowB) =>
+          (rowA.log.statistics?.maximumRowsExamined ?? 0) -
+          (rowB.log.statistics?.maximumRowsExamined ?? 0),
+        render: (item) =>
+          instanceV1HasSlowQueryDetail(item.database.instanceEntity)
+            ? item.log.statistics?.maximumRowsExamined
+            : "-",
+      },
+      {
+        title: t("slow-query.avg-rows-examined"),
+        key: "avg_rows_examined",
+        sorter: (rowA, rowB) =>
+          (rowA.log.statistics?.averageRowsExamined ?? 0) -
+          (rowB.log.statistics?.averageRowsExamined ?? 0),
+        render: (item) =>
+          instanceV1HasSlowQueryDetail(item.database.instanceEntity)
+            ? item.log.statistics?.averageRowsExamined
+            : "-",
+      },
+      {
+        title: t("slow-query.max-rows-sent"),
+        key: "max_rows_sent",
+        sorter: (rowA, rowB) =>
+          (rowA.log.statistics?.maximumRowsSent ?? 0) -
+          (rowB.log.statistics?.maximumRowsSent ?? 0),
+        render: (item) =>
+          instanceV1HasSlowQueryDetail(item.database.instanceEntity)
+            ? item.log.statistics?.maximumRowsSent
+            : "-",
+      },
+      {
+        title: t("slow-query.avg-rows-sent"),
+        key: "avg_rows_sent",
+        sorter: (rowA, rowB) =>
+          (rowA.log.statistics?.averageRowsSent ?? 0) -
+          (rowB.log.statistics?.averageRowsSent ?? 0),
+        render: (item) => item.log.statistics?.averageRowsSent,
+      },
+    ];
+
+    if (props.showProjectColumn) {
+      columns.push({
+        title: t("common.project"),
+        key: "project",
+        render: (item) =>
+          h(ProjectV1Name, {
+            project: item.database.projectEntity,
+            link: false,
+          }),
+      });
+    }
+    if (props.showEnvironmentColumn) {
+      columns.push({
+        title: t("common.environment"),
+        key: "environment",
+        render: (item) =>
+          h(EnvironmentV1Name, {
+            environment: item.database.effectiveEnvironmentEntity,
+            link: false,
+          }),
+      });
+    }
+    if (props.showInstanceColumn) {
+      columns.push({
+        title: t("common.instance"),
+        key: "instance",
+        render: (item) =>
+          h(InstanceV1Name, {
+            instance: item.database.instanceEntity,
+            link: false,
+          }),
+      });
+    }
+    if (props.showDatabaseColumn) {
+      columns.push({
+        title: t("common.database"),
+        key: "database",
+        render: (item) =>
+          h(DatabaseV1Name, {
+            database: item.database,
+            link: false,
+          }),
+      });
+    }
+
+    columns.push({
       title: t("slow-query.last-query-time"),
-      width: "auto",
-    },
-  ].filter((col) => !!col) as BBGridColumn[];
-  return columns;
-});
+      key: "last_query_time",
+      sorter: (rowA, rowB) =>
+        (rowA.log.statistics?.latestLogTime?.getTime() ?? 0) -
+        (rowB.log.statistics?.latestLogTime?.getTime() ?? 0),
+      render: (item) =>
+        dayjs(item.log.statistics?.latestLogTime).format("YYYY-MM-DD HH:mm:ss"),
+    });
 
-const isSelectedRow = (item: ComposedSlowQueryLog) => {
-  return selectedSlowQueryLog.value === item;
+    return columns;
+  }
+);
+
+const rowKey = (item: ComposedSlowQueryLog) => {
+  return item.id;
 };
 
-const toggleExpandRow = (item: ComposedSlowQueryLog) => {
-  if (selectedSlowQueryLog.value === item) {
-    selectedSlowQueryLog.value = undefined;
-  } else {
-    selectedSlowQueryLog.value = item;
-  }
+const expandedRowKeys = ref<string[]>([]);
+
+const durationSeconds = (duration: Duration | undefined) => {
+  if (!duration) return 0;
+  const { seconds, nanos } = duration;
+  return seconds.toNumber() + nanos / 1e9;
 };
 
 const durationText = (duration: Duration | undefined) => {
   if (!duration) return "-";
-  const { seconds, nanos } = duration;
-  const total = seconds.toNumber() + nanos / 1e9;
+  const total = durationSeconds(duration);
   return total.toFixed(2) + "s";
 };
 
-watch(
-  () => props.slowQueryLogList,
-  () => {
-    selectedSlowQueryLog.value = undefined;
-  },
-  { immediate: true }
-);
+const rowProps = (row: ComposedSlowQueryLog) => {
+  return {
+    style: "cursor: pointer;",
+    onClick: () => {
+      emit("select", row);
+    },
+  };
+};
 </script>

--- a/frontend/src/components/SlowQuery/Panel/types.ts
+++ b/frontend/src/components/SlowQuery/Panel/types.ts
@@ -35,11 +35,11 @@ export const buildListSlowQueriesRequest = (
     query.push(`project = "projects/${project}"`);
   }
   if (fromTime) {
-    const start = dayjs(fromTime).toISOString();
+    const start = dayjs(fromTime).format("YYYY-MM-DDT00:00:00.000Z");
     query.push(`start_time >= "${start}"`);
   }
   if (toTime) {
-    const end = dayjs(toTime).toISOString();
+    const end = dayjs(toTime).format("YYYY-MM-DDT00:00:00.000Z");
     query.push(`start_time <= "${end}"`);
   }
   if (query.length > 0) {

--- a/frontend/src/store/modules/slowQuery.ts
+++ b/frontend/src/store/modules/slowQuery.ts
@@ -50,7 +50,8 @@ const composeSlowQueryLogDatabase = async (
       return getOrFetchV1Database(name);
     })
   );
-  return slowQueryLogList.map<ComposedSlowQueryLog>((log) => ({
+  return slowQueryLogList.map<ComposedSlowQueryLog>((log, index) => ({
+    id: `${index}`,
     log,
     database: useDatabaseV1Store().getDatabaseByName(log.resource),
   }));

--- a/frontend/src/types/slowQuery.ts
+++ b/frontend/src/types/slowQuery.ts
@@ -3,6 +3,7 @@ import type { ComposedDatabase } from "./v1/database";
 import { ComposedInstance } from "./v1/instance";
 
 export type ComposedSlowQueryLog = {
+  id: string;
   log: SlowQueryLog;
   database: ComposedDatabase;
 };


### PR DESCRIPTION
- Use `NDataTable` for slow query table, and support sorting. Close BYT-4816

![CleanShot 2024-01-09 at 13 56 52@2x](https://github.com/bytebase/bytebase/assets/10706318/22e370b2-dc10-4fe9-8f75-c20e2a48ac2f)

- Fix: invalid slow query time filter.

Before this, if users select the time range `[2024-01-02, 2024-01-09]`, the request filter is `startTime >= 2024-01-01T16:00:00.000Z AND startTime <= 2024-01-09T15:59:59.999Z`, this will be formatted as `logDate >= 20240101 && logDate < 20240110`, which is incorrect. We just simply convert them to the UTC time and drop the time and timezone info.
