### PR TITLE
fix: add DROP DATABASE to the PG non-transactional statement

### DIFF
--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -448,6 +448,9 @@ func isIgnoredStatement(stmt string) bool {
 }
 
 var (
+	// DROP DATABASE cannot run inside a transaction block.
+	// DROP DATABASE [ IF EXISTS ] name [ [ WITH ] ( option [, ...] ) ]。
+	dropDatabaseReg = regexp.MustCompile(`(?i)DROP DATABASE`)
 	// CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
 	// CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ [ IF NOT EXISTS ] name ] ON [ ONLY ] table_name [ USING method ] ...
 	createIndexReg = regexp.MustCompile(`(?i)CREATE(\s+(UNIQUE\s+)?)INDEX(\s+)CONCURRENTLY`)
@@ -461,6 +464,9 @@ var (
 )
 
 func isNonTransactionStatement(stmt string) bool {
+	if len(dropDatabaseReg.FindString(stmt)) > 0 {
+		return true
+	}
 	if len(createIndexReg.FindString(stmt)) > 0 {
 		return true
 	}


### PR DESCRIPTION
The issue has existed for a while, it is likely unmasked by https://github.com/bytebase/bytebase/pull/10132

I noticed this when seeing sample instance that throws an error during startup. In startup, we will try to drop the default postgres database https://github.com/bytebase/bytebase/blob/21fe05caa1e4ff2b21e0162723a3c5681b9e05d3/backend/resources/postgres/sample_instance.go#L289

![CleanShot 2024-01-09 at 23-34-08 png](https://github.com/bytebase/bytebase/assets/230323/5e61e0ec-1291-4709-9d64-6db0586a1e06)
