### PR TITLE
chore(frontend): filter database metadata

### DIFF
--- a/frontend/src/components/Branch/BranchRolloutView/useVirtualBranch.ts
+++ b/frontend/src/components/Branch/BranchRolloutView/useVirtualBranch.ts
@@ -7,6 +7,7 @@ import {
   DatabaseMetadata,
   DatabaseMetadataView,
 } from "@/types/proto/v1/database_service";
+import { filterDatabaseMetadata } from "@/utils";
 
 /**
  * Create a "virtual" branch to show the diff between a branch's head and a database's head
@@ -40,7 +41,7 @@ export const useVirtualBranch = (
       view: DatabaseMetadataView.DATABASE_METADATA_VIEW_FULL,
     });
     if (signal.aborted) return;
-    databaseHeadMetadata.value = metadata;
+    databaseHeadMetadata.value = filterDatabaseMetadata(metadata);
     state.isLoadingDatabaseMetadata = false;
   };
 

--- a/frontend/src/components/SchemaEditorLite/algorithm/apply-selected.ts
+++ b/frontend/src/components/SchemaEditorLite/algorithm/apply-selected.ts
@@ -9,6 +9,7 @@ import {
   TableConfig,
   TableMetadata,
 } from "@/types/proto/v1/database_service";
+import { filterColumnMetadata, filterTableMetadata } from "@/utils";
 import { SchemaEditorContext } from "../context";
 import { keyForResource, keyForResourceName } from "../context/common";
 import { RolloutObject } from "../types";
@@ -97,7 +98,9 @@ export const useApplySelectedMetadataEdit = (context: SchemaEditorContext) => {
           const sourceColumn = sourceColumnMap.get(key);
           if (sourceColumn) {
             // collect the original column
-            pickedColumns.push(cloneDeep(sourceColumn.column));
+            pickedColumns.push(
+              filterColumnMetadata(cloneDeep(sourceColumn.column))
+            );
             // together with its original columnConfig
             const columnConfig = sourceColumnConfigMap.get(key)?.columnConfig;
             if (columnConfig) {
@@ -151,7 +154,7 @@ export const useApplySelectedMetadataEdit = (context: SchemaEditorContext) => {
           const sourceTable = sourceTableMap.get(key);
           if (sourceTable) {
             // Collect the original table
-            tables.push(cloneDeep(sourceTable.table));
+            tables.push(filterTableMetadata(cloneDeep(sourceTable.table)));
             // Together with its tableConfig
             const sourceTableConfig =
               sourceTableConfigMap.get(key)?.tableConfig;

--- a/frontend/src/components/SchemaEditorLite/algorithm/diff-merge.ts
+++ b/frontend/src/components/SchemaEditorLite/algorithm/diff-merge.ts
@@ -239,10 +239,6 @@ export class DiffMerge {
           pick(targetForeignKey, ComparableForeignKeyFields)
         )
       ) {
-        console.log(
-          pick(sourceForeignKey, ComparableForeignKeyFields),
-          pick(targetForeignKey, ComparableForeignKeyFields)
-        );
         return false;
       }
     }
@@ -264,8 +260,6 @@ export class DiffMerge {
           pick(targetIndex, ComparableIndexFields)
         )
       ) {
-        console.log(JSON.stringify(pick(sourceIndex, ComparableIndexFields)));
-        console.log(JSON.stringify(pick(targetIndex, ComparableIndexFields)));
         return false;
       }
     }
@@ -352,8 +346,6 @@ export class DiffMerge {
         pick(targetColumn, ComparableColumnFields)
       )
     ) {
-      console.log(JSON.stringify(pick(sourceColumn, ComparableColumnFields)));
-      console.log(JSON.stringify(pick(targetColumn, ComparableColumnFields)));
       const key = keyForResourceName(
         this.database.name,
         targetSchema.name,

--- a/frontend/src/utils/schemaEditor/filter.ts
+++ b/frontend/src/utils/schemaEditor/filter.ts
@@ -1,0 +1,112 @@
+import {
+  ColumnMetadata,
+  DatabaseMetadata,
+  ForeignKeyMetadata,
+  IndexMetadata,
+  SchemaMetadata,
+  TableMetadata,
+} from "@/types/proto/v1/database_service";
+
+// filterDatabaseMetadata filter out the objects/attributes we do not support.
+// TODO: While supporting new objects/attributes, we should update this function.
+// see backend's api/v1/branch_service.go
+export const filterDatabaseMetadata = (metadata: DatabaseMetadata) => {
+  return DatabaseMetadata.fromPartial({
+    name: metadata.name,
+    schemaConfigs: metadata.schemaConfigs,
+    schemas: metadata.schemas.map((schema) => {
+      return SchemaMetadata.fromPartial({
+        name: schema.name,
+        tables: schema.tables.map((table) => filterTableMetadata(table)),
+      });
+    }),
+  });
+};
+
+export const filterColumnMetadata = (column: ColumnMetadata) => {
+  return ColumnMetadata.fromPartial({
+    name: column.name,
+    comment: column.comment,
+    userComment: column.comment,
+    classification: column.classification,
+    type: column.type,
+    hasDefault: column.hasDefault,
+    defaultExpression: column.defaultExpression,
+    defaultNull: column.defaultNull,
+    defaultString: column.defaultString,
+    nullable: column.nullable,
+    position: column.position,
+  });
+};
+
+export const filterIndexMetadata = (index: IndexMetadata) => {
+  return IndexMetadata.fromPartial({
+    name: index.name,
+    definition: index.definition,
+    primary: index.primary,
+    unique: index.unique,
+    comment: index.comment,
+    expressions: index.expressions,
+  });
+};
+
+export const filterForeignKeyMetadata = (fk: ForeignKeyMetadata) => {
+  return ForeignKeyMetadata.fromPartial({
+    name: fk.name,
+    columns: fk.columns,
+    referencedSchema: fk.referencedSchema,
+    referencedTable: fk.referencedTable,
+    referencedColumns: fk.referencedColumns,
+  });
+};
+
+export const filterTableMetadata = (table: TableMetadata) => {
+  return TableMetadata.fromPartial({
+    name: table.name,
+    classification: table.classification,
+    comment: table.comment,
+    userComment: table.userComment,
+    collation: table.collation,
+    engine: table.engine,
+    columns: table.columns.map((column) => filterColumnMetadata(column)),
+    indexes: table.indexes.map((index) => filterIndexMetadata(index)),
+    foreignKeys: table.foreignKeys.map((fk) => filterForeignKeyMetadata(fk)),
+  });
+};
+
+export const ComparableTableFields: (keyof TableMetadata)[] = [
+  "name",
+  "classification",
+  "comment",
+  "userComment",
+  "collation",
+  "engine",
+];
+export const ComparableIndexFields: (keyof IndexMetadata)[] = [
+  "name",
+  "definition",
+  "primary",
+  "unique",
+  "comment",
+  "expressions",
+];
+export const ComparableForeignKeyFields: (keyof ForeignKeyMetadata)[] = [
+  "name",
+  "columns",
+  "referencedSchema",
+  "referencedTable",
+  "referencedColumns",
+];
+export const ComparableColumnFields: (keyof ColumnMetadata)[] = [
+  "name",
+  "comment",
+  "userComment",
+  "classification",
+  "type",
+  "hasDefault",
+  "defaultExpression",
+  "defaultNull",
+  "defaultString",
+  "nullable",
+  "position",
+];

--- a/frontend/src/utils/schemaEditor/index.ts
+++ b/frontend/src/utils/schemaEditor/index.ts
@@ -1,6 +1,8 @@
 import { ComposedDatabase, Database } from "@/types";
 import { Engine } from "@/types/proto/v1/common";
 
+export * from "./filter";
+
 // Only allow using Schema Editor with MySQL.
 export const allowUsingSchemaEditor = (databaseList: Database[]): boolean => {
   return databaseList.every((db) => {


### PR DESCRIPTION
like the backend does, we filter the database metadata fields we supported to compare and edit.
When diffing and coloring, we also only consider fields that we supported.
PTAL @h3n4l 