### PR TITLE
chore: update list/search api usage

### DIFF
--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -39,18 +39,22 @@ const prepareDatabases = async () => {
 };
 
 onMounted(async () => {
+  // Prepare roles, workspace policies and settings first.
   await Promise.all([
-    useUserStore().fetchUserList(),
-    useSettingV1Store().fetchSettingList(),
     useRoleStore().fetchRoleList(),
-    useEnvironmentV1Store().fetchEnvironments(),
-    useInstanceV1Store().fetchInstanceList(),
-    useProjectV1Store().fetchProjectList(true),
     policyStore.fetchPolicies({
       resourceType: PolicyResourceType.WORKSPACE,
     }),
+    useSettingV1Store().fetchSettingList(),
   ]);
 
+  // Then prepare the other resources.
+  await Promise.all([
+    useUserStore().fetchUserList(),
+    useEnvironmentV1Store().fetchEnvironments(),
+    useInstanceV1Store().fetchInstanceList(),
+    useProjectV1Store().fetchProjectList(),
+  ]);
   await Promise.all([prepareDatabases(), useUIStateStore().restoreState()]);
 
   isLoading.value = false;

--- a/frontend/src/views/ProjectDashboard.vue
+++ b/frontend/src/views/ProjectDashboard.vue
@@ -16,6 +16,7 @@
 import { computed, onMounted, reactive } from "vue";
 import { SearchBox, ProjectV1Table } from "@/components/v2";
 import { useUIStateStore, useProjectV1ListByCurrentUser } from "@/store";
+import { DEFAULT_PROJECT_ID } from "@/types";
 import { filterProjectV1ListByKeyword } from "@/utils";
 
 interface LocalState {
@@ -28,7 +29,9 @@ const state = reactive<LocalState>({
 const { projectList } = useProjectV1ListByCurrentUser();
 
 const filteredProjectList = computed(() => {
-  const list = projectList.value;
+  const list = projectList.value.filter(
+    (project) => project.uid !== String(DEFAULT_PROJECT_ID)
+  );
   return filterProjectV1ListByKeyword(list, state.searchText);
 });
 


### PR DESCRIPTION
e.g., if user has `bb.instances.list`, we'll use `listInstance` instead of `searchInstance`.