### PR TITLE
fix(structurer): restore delimiter

### DIFF
--- a/backend/plugin/parser/mysql/mysql.go
+++ b/backend/plugin/parser/mysql/mysql.go
@@ -74,7 +74,7 @@ func DealWithDelimiter(statement string, options ...tokenizer.Option) (string, e
 // -- DELIMITER ;
 // SELECT 1;
 // SELECT 2;
-// -- DELIMITER ;
+// -- DELIMITER ;.
 func RestoreDelimiter(statement string) (string, error) {
 	delimiterRegexp := regexp.MustCompile(`(?i)^-- DELIMITER\s+(?P<DELIMITER>[^\s\\]+)\s*`)
 	lines := strings.Split(statement, "\n")

--- a/backend/plugin/parser/mysql/mysql_test.go
+++ b/backend/plugin/parser/mysql/mysql_test.go
@@ -184,6 +184,85 @@ CREATE TABLE u (
 		},
 
 		{
+			// Semicolon in body after delimiter
+			input: `
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+--
+-- Table structure for u
+--
+CREATE TABLE u (
+	b blob NOT NULL,
+	t text NOT NULL,
+	g geometry NOT NULL,
+	j json NOT NULL,
+	ti tinyint(1) NOT NULL,
+	tb tinyblob
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- DELIMITER ;;
+CREATE DEFINER=root@localhost PROCEDURE GetEmployeeFullName(IN in_employee_id INT, OUT out_full_name VARCHAR(100))
+BEGIN
+    -- Declare variables
+    DECLARE first_name VARCHAR(50);
+    DECLARE last_name VARCHAR(50);
+
+    -- Initialize variables
+    SET out_full_name = NULL;
+
+    -- Retrieve employee details based on employee_id
+    SELECT first_name, last_name INTO first_name, last_name
+    FROM employees
+    WHERE employee_id = in_employee_id;
+
+    -- Check if employee exists
+    IF first_name IS NOT NULL THEN
+        -- Concatenate first and last names
+        SET out_full_name = CONCAT(first_name, ' ', last_name);
+    END IF;
+END ;
+-- DELIMITER ;
+`,
+			want: `
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+--
+-- Table structure for u
+--
+CREATE TABLE u (
+	b blob NOT NULL,
+	t text NOT NULL,
+	g geometry NOT NULL,
+	j json NOT NULL,
+	ti tinyint(1) NOT NULL,
+	tb tinyblob
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+DELIMITER ;;
+CREATE DEFINER=root@localhost PROCEDURE GetEmployeeFullName(IN in_employee_id INT, OUT out_full_name VARCHAR(100))
+BEGIN
+    -- Declare variables
+    DECLARE first_name VARCHAR(50);
+    DECLARE last_name VARCHAR(50);
+
+    -- Initialize variables
+    SET out_full_name = NULL;
+
+    -- Retrieve employee details based on employee_id
+    SELECT first_name, last_name INTO first_name, last_name
+    FROM employees
+    WHERE employee_id = in_employee_id;
+
+    -- Check if employee exists
+    IF first_name IS NOT NULL THEN
+        -- Concatenate first and last names
+        SET out_full_name = CONCAT(first_name, ' ', last_name);
+    END IF;
+END ;;
+DELIMITER ;
+`,
+		},
+		{
 			// One delimiter
 			input: `
 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;

--- a/backend/plugin/parser/mysql/mysql_test.go
+++ b/backend/plugin/parser/mysql/mysql_test.go
@@ -324,6 +324,7 @@ CREATE TABLE u (
 CREATE FUNCTION hello(s CHAR(20)) RETURNS char(50) CHARSET utf8mb4
     DETERMINISTIC
 RETURN CONCAT('Hello, ',s,'!') ;
+-- DELIMITER ;
 CREATE FUNCTION hello2(s CHAR(20)) RETURNS char(50) CHARSET utf8mb4
     DETERMINISTIC
 RETURN CONCAT('Hello, ',s,'!') ;
@@ -352,9 +353,10 @@ DELIMITER ;;
 CREATE FUNCTION hello(s CHAR(20)) RETURNS char(50) CHARSET utf8mb4
     DETERMINISTIC
 RETURN CONCAT('Hello, ',s,'!') ;;
+DELIMITER ;
 CREATE FUNCTION hello2(s CHAR(20)) RETURNS char(50) CHARSET utf8mb4
     DETERMINISTIC
-RETURN CONCAT('Hello, ',s,'!') ;;
+RETURN CONCAT('Hello, ',s,'!') ;
 DELIMITER ??
 CREATE FUNCTION hello3(s CHAR(20)) RETURNS char(50) CHARSET utf8mb4
     DETERMINISTIC
@@ -365,9 +367,9 @@ DROP FUNCTION hello3;
 		},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		got, err := RestoreDelimiter(tc.input)
 		require.NoError(t, err)
-		require.Equal(t, tc.want, got)
+		require.Equalf(t, tc.want, got, "test cases: %d", i)
 	}
 }


### PR DESCRIPTION
After `DealWithDelimiter`, cannot distinguish the semicolon is the end of sql statement or routine body statement. So assuming contains only one sql statement between two delimiter comment after `DealWithDelimiter`.

Previous:
<img width="1300" alt="img_v3_0275_ac22f132-d58d-4f3b-a3d4-e9c9b5fa06cg" src="https://github.com/bytebase/bytebase/assets/87714218/82db4291-a77c-4c1a-b55d-730c1fcbd273">

After:
<img width="967" alt="CleanShot 2024-01-16 at 21 00 25@2x" src="https://github.com/bytebase/bytebase/assets/87714218/7fa442a6-8a19-4830-8e35-a6c27e00b8a4">
