### PR TITLE
chore(frontend): fix skipCache when rollout branch

### DIFF
--- a/frontend/src/components/Branch/BranchRolloutView/useVirtualBranch.ts
+++ b/frontend/src/components/Branch/BranchRolloutView/useVirtualBranch.ts
@@ -37,7 +37,7 @@ export const useVirtualBranch = (
     state.isLoadingDatabaseMetadata = true;
     const metadata = await useDBSchemaV1Store().getOrFetchDatabaseMetadata({
       database: db.name,
-      skipCache: false /* ensure using the latest */,
+      skipCache: true, // ensure using the latest
       view: DatabaseMetadataView.DATABASE_METADATA_VIEW_FULL,
     });
     if (signal.aborted) return;


### PR DESCRIPTION
This fixes:

If we altered the schema of a database via issue. Then (WITHOUT refreshing the page) the page and rollout a branch of this database. We will see the schema diff with the old version of the database.