### PR TITLE
chore(structurer): handle default value in structurer for MySQL

### DIFF
--- a/backend/plugin/schema/mysql/get_design_schema_test.go
+++ b/backend/plugin/schema/mysql/get_design_schema_test.go
@@ -51,7 +51,7 @@ func TestGetDesignSchema(t *testing.T) {
 		if record {
 			tests[i].Result = result
 		} else {
-			a.Equal(t.Result, result)
+			a.Equalf(t.Result, result, "test case %d: %s", i, t.Description)
 		}
 	}
 

--- a/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
+++ b/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
@@ -7,6 +7,7 @@
     --
     CREATE TABLE `u` (
       `t` text NOT NULL,
+
       `g` geometry NOT NULL,
       `j` json NOT NULL,
       `ti` tinyint(1) NOT NULL,

--- a/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
+++ b/backend/plugin/schema/mysql/testdata/get_design_schema.yaml
@@ -7,7 +7,6 @@
     --
     CREATE TABLE `u` (
       `t` text NOT NULL,
-
       `g` geometry NOT NULL,
       `j` json NOT NULL,
       `ti` tinyint(1) NOT NULL,

--- a/backend/plugin/schema/mysql/testdata/parse_to_metadata.yaml
+++ b/backend/plugin/schema/mysql/testdata/parse_to_metadata.yaml
@@ -5,6 +5,7 @@
         `b` VARCHAR(20) NOT NULL,
         `c` int NOT NULL,
         `d` text NULL,
+        `t_not_null` text NOT NULL,
         `e` varchar(20),
         PRIMARY KEY (`a`),
         UNIQUE KEY `t_c_uniq_idx` (`c` DESC),
@@ -17,141 +18,147 @@
       ) ENGINE=InnoDB COLLATE=utf8mb4_0900_ai_ci COMMENT 'this is comment with '' escaped';
   metadata: |-
     {
-      "schemas": [
+      "schemas":  [
         {
-          "tables": [
+          "tables":  [
             {
-              "name": "t",
-              "columns": [
+              "name":  "t",
+              "columns":  [
                 {
-                  "name": "a",
-                  "position": 1,
-                  "type": "int",
-                  "comment": "this is comment"
+                  "name":  "a",
+                  "position":  1,
+                  "type":  "int",
+                  "comment":  "this is comment"
                 },
                 {
-                  "name": "b",
-                  "position": 2,
-                  "type": "VARCHAR(20)"
+                  "name":  "b",
+                  "position":  2,
+                  "type":  "VARCHAR(20)"
                 },
                 {
-                  "name": "c",
-                  "position": 3,
-                  "type": "int"
+                  "name":  "c",
+                  "position":  3,
+                  "type":  "int"
                 },
                 {
-                  "name": "d",
-                  "position": 4,
-                  "defaultNull": true,
-                  "nullable": true,
-                  "type": "text"
+                  "name":  "d",
+                  "position":  4,
+                  "defaultNull":  true,
+                  "nullable":  true,
+                  "type":  "text"
                 },
                 {
-                  "name": "e",
-                  "position": 5,
-                  "nullable": true,
-                  "type": "varchar(20)"
+                  "name":  "t_not_null",
+                  "position":  5,
+                  "type":  "text"
+                },
+                {
+                  "name":  "e",
+                  "position":  6,
+                  "defaultNull":  true,
+                  "nullable":  true,
+                  "type":  "varchar(20)"
                 }
               ],
-              "indexes": [
+              "indexes":  [
                 {
-                  "name": "PRIMARY",
-                  "expressions": [
+                  "name":  "PRIMARY",
+                  "expressions":  [
                     "a"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1"
                   ],
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
+                  "unique":  true,
+                  "primary":  true,
+                  "visible":  true
                 },
                 {
-                  "name": "t_c_uniq_idx",
-                  "expressions": [
+                  "name":  "t_c_uniq_idx",
+                  "expressions":  [
                     "c"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1"
                   ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
+                  "type":  "BTREE",
+                  "unique":  true,
+                  "visible":  true
                 },
                 {
-                  "name": "t_c_plus_5_uniq_idx",
-                  "expressions": [
+                  "name":  "t_c_plus_5_uniq_idx",
+                  "expressions":  [
                     "((`c` + 5))"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1"
                   ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
+                  "type":  "BTREE",
+                  "unique":  true,
+                  "visible":  true
                 },
                 {
-                  "name": "t_c_plus_5_t_c_plus_3_uniq_idx",
-                  "expressions": [
+                  "name":  "t_c_plus_5_t_c_plus_3_uniq_idx",
+                  "expressions":  [
                     "((`c` + 5))",
                     "((`c` + 3))"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1",
                     "-1"
                   ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
+                  "type":  "BTREE",
+                  "unique":  true,
+                  "visible":  true
                 },
                 {
-                  "name": "idx_c",
-                  "expressions": [
+                  "name":  "idx_c",
+                  "expressions":  [
                     "c"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1"
                   ],
-                  "type": "BTREE",
-                  "visible": true
+                  "type":  "BTREE",
+                  "visible":  true
                 },
                 {
-                  "name": "idx_d",
-                  "expressions": [
+                  "name":  "idx_d",
+                  "expressions":  [
                     "d"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "10"
                   ],
-                  "type": "BTREE",
-                  "visible": true
+                  "type":  "BTREE",
+                  "visible":  true
                 },
                 {
-                  "name": "idx_e",
-                  "expressions": [
+                  "name":  "idx_e",
+                  "expressions":  [
                     "e"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "10"
                   ],
-                  "type": "BTREE",
-                  "visible": true
+                  "type":  "BTREE",
+                  "visible":  true
                 },
                 {
-                  "name": "t_d_fulltext_idx",
-                  "expressions": [
+                  "name":  "t_d_fulltext_idx",
+                  "expressions":  [
                     "d"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1"
                   ],
-                  "type": "FULLTEXT",
-                  "visible": true
+                  "type":  "FULLTEXT",
+                  "visible":  true
                 }
               ],
-              "engine": "InnoDB",
-              "collation": "utf8mb4_0900_ai_ci",
-              "comment": "this is comment with ' escaped"
+              "engine":  "InnoDB",
+              "collation":  "utf8mb4_0900_ai_ci",
+              "comment":  "this is comment with ' escaped"
             }
           ]
         }
@@ -169,87 +176,87 @@
     create table t2(b int NOT NULL default NULL, primary key (b));
   metadata: |-
     {
-      "schemas": [
+      "schemas":  [
         {
-          "tables": [
+          "tables":  [
             {
-              "name": "t",
-              "columns": [
+              "name":  "t",
+              "columns":  [
                 {
-                  "name": "c",
-                  "position": 1,
-                  "defaultExpression": "AUTO_INCREMENT",
-                  "nullable": true,
-                  "type": "int"
+                  "name":  "c",
+                  "position":  1,
+                  "defaultExpression":  "AUTO_INCREMENT",
+                  "nullable":  true,
+                  "type":  "int"
                 },
                 {
-                  "name": "a",
-                  "position": 2,
-                  "defaultExpression": "1",
-                  "nullable": true,
-                  "type": "int",
-                  "comment": "abcdefg"
+                  "name":  "a",
+                  "position":  2,
+                  "defaultExpression":  "1",
+                  "nullable":  true,
+                  "type":  "int",
+                  "comment":  "abcdefg"
                 },
                 {
-                  "name": "b",
-                  "position": 3,
-                  "defaultNull": true,
-                  "nullable": true,
-                  "type": "varchar(20)"
+                  "name":  "b",
+                  "position":  3,
+                  "defaultNull":  true,
+                  "nullable":  true,
+                  "type":  "varchar(20)"
                 }
               ],
-              "indexes": [
+              "indexes":  [
                 {
-                  "name": "PRIMARY",
-                  "expressions": [
+                  "name":  "PRIMARY",
+                  "expressions":  [
                     "a",
                     "b"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1",
                     "-1"
                   ],
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
+                  "unique":  true,
+                  "primary":  true,
+                  "visible":  true
                 }
               ],
-              "comment": "this is comment with ' escaped",
-              "foreignKeys": [
+              "comment":  "this is comment with ' escaped",
+              "foreignKeys":  [
                 {
-                  "name": "fk1",
-                  "columns": [
+                  "name":  "fk1",
+                  "columns":  [
                     "a"
                   ],
-                  "referencedTable": "t2",
-                  "referencedColumns": [
+                  "referencedTable":  "t2",
+                  "referencedColumns":  [
                     "b"
                   ]
                 }
               ]
             },
             {
-              "name": "t2",
-              "columns": [
+              "name":  "t2",
+              "columns":  [
                 {
-                  "name": "b",
-                  "position": 1,
-                  "defaultNull": true,
-                  "type": "int"
+                  "name":  "b",
+                  "position":  1,
+                  "defaultNull":  true,
+                  "type":  "int"
                 }
               ],
-              "indexes": [
+              "indexes":  [
                 {
-                  "name": "PRIMARY",
-                  "expressions": [
+                  "name":  "PRIMARY",
+                  "expressions":  [
                     "b"
                   ],
-                  "keyLength": [
+                  "keyLength":  [
                     "-1"
                   ],
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
+                  "unique":  true,
+                  "primary":  true,
+                  "visible":  true
                 }
               ]
             }


### PR DESCRIPTION
This PR handles default NULL/other carefully.

## Background
Our protobuf defines the default value as:
```protobuf
// The default_value is the default value of a column.
oneof default_value {
  // The default is the default of a column. Use google.protobuf.StringValue to distinguish between an empty string default value or no default.
  google.protobuf.StringValue default = 3;
  bool default_null = 4;
  string default_expression = 5;
}
```
We define the `default_null` to make us can distinguish the `DEFAULT NULL` and no default in `NOT NULL` column.


## What we do in sync

We get the column info from `INFORMATION_SCHEMA.COLUMNS`, and get the default from `COLUMN_DEFAULT` field.

>[The default value for the column. This is NULL if the column has an explicit default of NULL, or if the column definition includes no DEFAULT clause.](https://dev.mysql.com/doc/refman/8.0/en/information-schema-columns-table.html)

We set the default value as default null if the `COLUMN_DEFAULT` value is NULL and column is nullable.
https://sourcegraph.com/github.com/bytebase/bytebase/-/blob/backend/plugin/db/mysql/sync.go?L291-298

## What should we do in structurer

### ParseToMetadata
ParseToMetadata is no need to align with the engine behavior, **the only special work for us is to remember to set the default value  to default null if the column definition includes no `DEFAULT` clause and column is nullable** likes the docs says:
> [If a data type specification includes no explicit DEFAULT value, MySQL determines the default value as follows:
If the column can take NULL as a value, the column is defined with an explicit DEFAULT NULL clause.
If the column cannot take NULL as a value, MySQL defines the column with no explicit DEFAULT clause.](https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#data-type-defaults-implicit)

### GetDesignSchema
The column family `BLOB`, `TEXT`, `JSON`, `GEOMETRY` is special - `SHOW CREATE TABLE` would not generate `DEFAULT NULL` clause for them, because NULL is not acceptable literal default value). https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#data-type-defaults-implicit
So for us, we shouldn't generate `DEFAULT NULL` for these column if their default value is `DEFAULT NULL`. 
NOTE: Actual testing found that only blob/text does not generate DEFAULT NULL, while JSON and GEOMETRY do, which is a discrepancy with the documentation.
```SQL
CREATE TABLE t2(t text, b blob, j json, g geometry);

+-------+--------------------------------------------------------------------+
| Table | Create Table                                                       |
+-------+--------------------------------------------------------------------+
| t2    | CREATE TABLE `t2` (                                                |
|       |   `t` text,                                                        |
|       |   `b` blob,                                                        |
|       |   `j` json DEFAULT NULL,                                           |
|       |   `g` geometry DEFAULT NULL                                        |
|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+-------+--------------------------------------------------------------------+
```
