### PR TITLE
chore(branch): using head of merge to as ancestor

### DIFF
--- a/backend/api/v1/branch_service.go
+++ b/backend/api/v1/branch_service.go
@@ -416,7 +416,8 @@ func (s *BranchService) MergeBranch(ctx context.Context, request *v1pb.MergeBran
 
 	// Restrict merging only when the head branch is not updated.
 	// Maybe we can support auto-merging in the future.
-	mergedMetadata, err := tryMerge(headBranch.Base.Metadata, headBranch.Head.Metadata, baseBranch.Head.Metadata)
+	mergedMetadata, err := tryMerge(baseBranch.Head.Metadata, headBranch.Head.Metadata, headBranch.Base.Metadata)
+	// mergedMetadata, err := tryMerge(headBranch.Base.Metadata, headBranch.Head.Metadata, baseBranch.Head.Metadata)
 	if err != nil {
 		slog.Info("cannot merge branches", log.BBError(err))
 		return nil, status.Errorf(codes.Aborted, "cannot merge branches without conflict, error: %v", err)

--- a/backend/api/v1/branch_service.go
+++ b/backend/api/v1/branch_service.go
@@ -417,7 +417,6 @@ func (s *BranchService) MergeBranch(ctx context.Context, request *v1pb.MergeBran
 	// Restrict merging only when the head branch is not updated.
 	// Maybe we can support auto-merging in the future.
 	mergedMetadata, err := tryMerge(baseBranch.Head.Metadata, headBranch.Head.Metadata, headBranch.Base.Metadata)
-	// mergedMetadata, err := tryMerge(headBranch.Base.Metadata, headBranch.Head.Metadata, baseBranch.Head.Metadata)
 	if err != nil {
 		slog.Info("cannot merge branches", log.BBError(err))
 		return nil, status.Errorf(codes.Aborted, "cannot merge branches without conflict, error: %v", err)

--- a/backend/api/v1/schema_design_merge.go
+++ b/backend/api/v1/schema_design_merge.go
@@ -503,8 +503,8 @@ func (n *metadataDiffColumnNode) tryMerge(other *metadataDiffColumnNode) (bool, 
 		if n.head.Type != other.head.Type {
 			return true, fmt.Sprintf("conflict column type, one is %s, the other is %s", n.head.Type, other.head.Type)
 		}
-		if n.head.DefaultValue != other.head.DefaultValue {
-			return true, fmt.Sprintf("conflict column default value, one is %s, the other is %s", n.head.DefaultValue, other.head.DefaultValue)
+		if cmp.Diff(n.head.DefaultValue, other.head.DefaultValue, protocmp.Transform()) != "" {
+			return true, fmt.Sprintf("conflict column default value, one is %v, the other is %v", n.head.DefaultValue, other.head.DefaultValue)
 		}
 		if n.head.Nullable != other.head.Nullable {
 			return true, fmt.Sprintf("conflict column nullable, one is %t, the other is %t", n.head.Nullable, other.head.Nullable)


### PR DESCRIPTION
Consider the following steps:
1. Create branch `main`
2. Create branch `child` which parent is `main` created in step 1.
3. Add column `t1.c1` on branch `child`.
4. Add column `t1.c1` on database.
5. Rebase branch `child`.
6. Merge `child` to `main`.

Previous, we use `child`'s base as ancestor, and our tryDiff will compute the diff between `ancestor and child's head`, `ancestor and main's head`, merge them, and apply the result(drop column `t1.c1` in this case) to `ancestor`(`child`'s base in this case), finally, set the apply result as main's new head.