### PR TITLE
chore(frontend): use inconsistent menu width for instance select to prevent text truncation

### DIFF
--- a/frontend/src/components/v2/Select/InstanceSelect.vue
+++ b/frontend/src/components/v2/Select/InstanceSelect.vue
@@ -9,6 +9,7 @@
     :filterable="true"
     :virtual-scroll="true"
     :fallback-option="false"
+    :consistent-menu-width="false"
     class="bb-instance-select"
     @update:value="$emit('update:instance', $event)"
   />


### PR DESCRIPTION
**Before**
<img width="484" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/bee7951d-0c97-4241-94f2-5058d0458759">

**After**
<img width="450" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/208a16a4-3c14-4bc4-b1a6-12882d0320e4">

Close BYT-4842
