### PR TITLE
chore: remove detail field from completion item

### DIFF
--- a/backend/api/lsp/completion.go
+++ b/backend/api/lsp/completion.go
@@ -66,7 +66,6 @@ func (h *Handler) handleTextDocumentCompletion(ctx context.Context, _ *jsonrpc2.
 				Description: candidate.Definition,
 			},
 			Kind:          convertLSPCompletionItemKind(candidate.Type),
-			Detail:        fmt.Sprintf("<%s> %s", string(candidate.Type), candidate.Definition),
 			Documentation: candidate.Comment,
 			SortText:      generateSortText(params, candidate),
 		}

--- a/frontend/src/components/MonacoEditor/composables/useSuggestOptionByLanguage.ts
+++ b/frontend/src/components/MonacoEditor/composables/useSuggestOptionByLanguage.ts
@@ -12,7 +12,6 @@ export const useSuggestOptionByLanguage = (
 
   const defaultSuggestOption: ISuggestOptions = {
     ...editor.getOption(monaco.editor.EditorOption.suggest),
-    showStatusBar: true,
     preview: true,
   };
 


### PR DESCRIPTION
Close part of BYT-4637

We don't need to show the second panel about details.

### Before

<img width="1114" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/5e357790-e6b5-49bd-bc95-95657fe56db5">

### After

<img width="851" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/1ca307a0-0e98-418e-91f7-6ece175a9671">
