### PR TITLE
feat(frontend): show candidate roles when rollout/review action is not allowed

### DIFF
--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/ReviewActionButton.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/ReviewActionButton.vue
@@ -21,7 +21,6 @@
 import { NButton, NTooltip } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import { ErrorList } from "@/components/IssueV1/components/common";
 import {
   IssueReviewAction,
   issueReviewActionDisplayName,
@@ -29,7 +28,14 @@ import {
   allowUserToApplyReviewAction,
   useIssueContext,
 } from "@/components/IssueV1/logic";
+import ErrorList, { ErrorItem } from "@/components/misc/ErrorList.vue";
 import { useCurrentUserV1 } from "@/store";
+import { PresetRoleType } from "@/types";
+import {
+  ApprovalNode_GroupValue,
+  ApprovalNode_Type,
+} from "@/types/proto/v1/issue_service";
+import { displayRoleTitle } from "@/utils";
 
 const props = defineProps<{
   action: IssueReviewAction;
@@ -44,7 +50,7 @@ const { issue, reviewContext } = useIssueContext();
 const currentUser = useCurrentUserV1();
 
 const errors = computed(() => {
-  const errors: string[] = [];
+  const errors: ErrorItem[] = [];
 
   if (
     !allowUserToApplyReviewAction(
@@ -55,6 +61,47 @@ const errors = computed(() => {
     )
   ) {
     errors.push(t("issue.error.you-are-not-allowed-to-perform-this-action"));
+    const flow = reviewContext.flow.value;
+    const index = flow.currentStepIndex;
+    const steps = flow.template.flow?.steps ?? [];
+    const step = steps[index];
+    if (step) {
+      for (let i = 0; i < step.nodes.length; i++) {
+        const node = step.nodes[i];
+        const {
+          type,
+          groupValue = ApprovalNode_GroupValue.UNRECOGNIZED,
+          role,
+        } = node;
+        if (type !== ApprovalNode_Type.ANY_IN_GROUP) continue;
+        if (groupValue === ApprovalNode_GroupValue.WORKSPACE_OWNER) {
+          errors.push({
+            error: displayRoleTitle(PresetRoleType.WORKSPACE_ADMIN),
+            indent: 1,
+          });
+        } else if (groupValue === ApprovalNode_GroupValue.WORKSPACE_DBA) {
+          errors.push({
+            error: displayRoleTitle(PresetRoleType.WORKSPACE_DBA),
+            indent: 1,
+          });
+        } else if (groupValue === ApprovalNode_GroupValue.PROJECT_OWNER) {
+          errors.push({
+            error: displayRoleTitle(PresetRoleType.PROJECT_OWNER),
+            indent: 1,
+          });
+        } else if (groupValue === ApprovalNode_GroupValue.PROJECT_MEMBER) {
+          errors.push({
+            error: t("common.project-member"),
+            indent: 1,
+          });
+        } else if (role) {
+          errors.push({
+            error: displayRoleTitle(role),
+            indent: 1,
+          });
+        }
+      }
+    }
   }
   return errors;
 });

--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/ReviewActionButton.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/ReviewActionButton.vue
@@ -27,15 +27,10 @@ import {
   issueReviewActionButtonProps,
   allowUserToApplyReviewAction,
   useIssueContext,
+  displayReviewRoleTitle,
 } from "@/components/IssueV1/logic";
 import ErrorList, { ErrorItem } from "@/components/misc/ErrorList.vue";
-import { useCurrentUserV1, useSettingV1Store } from "@/store";
-import { PresetRoleType } from "@/types";
-import {
-  ApprovalNode_GroupValue,
-  ApprovalNode_Type,
-} from "@/types/proto/v1/issue_service";
-import { displayRoleTitle } from "@/utils";
+import { useCurrentUserV1 } from "@/store";
 
 const props = defineProps<{
   action: IssueReviewAction;
@@ -68,57 +63,10 @@ const errors = computed(() => {
     if (step) {
       for (let i = 0; i < step.nodes.length; i++) {
         const node = step.nodes[i];
-        const {
-          externalNodeId,
-          type,
-          groupValue = ApprovalNode_GroupValue.UNRECOGNIZED,
-          role,
-        } = node;
-        if (type !== ApprovalNode_Type.ANY_IN_GROUP) continue;
-
-        if (externalNodeId) {
-          const setting = useSettingV1Store().getSettingByName(
-            "bb.workspace.approval.external"
-          );
-          const nodes =
-            setting?.value?.externalApprovalSettingValue?.nodes ?? [];
-          const node = nodes.find((n) => n.id === externalNodeId);
-          if (node) {
-            errors.push({
-              error: node.title,
-              indent: 1,
-            });
-          } else {
-            errors.push({
-              error: `${t(
-                "custom-approval.approval-flow.external-approval.self"
-              )}: ${externalNodeId}}`,
-              indent: 1,
-            });
-          }
-        } else if (groupValue === ApprovalNode_GroupValue.WORKSPACE_OWNER) {
+        const roleTitle = displayReviewRoleTitle(node);
+        if (node) {
           errors.push({
-            error: displayRoleTitle(PresetRoleType.WORKSPACE_ADMIN),
-            indent: 1,
-          });
-        } else if (groupValue === ApprovalNode_GroupValue.WORKSPACE_DBA) {
-          errors.push({
-            error: displayRoleTitle(PresetRoleType.WORKSPACE_DBA),
-            indent: 1,
-          });
-        } else if (groupValue === ApprovalNode_GroupValue.PROJECT_OWNER) {
-          errors.push({
-            error: displayRoleTitle(PresetRoleType.PROJECT_OWNER),
-            indent: 1,
-          });
-        } else if (groupValue === ApprovalNode_GroupValue.PROJECT_MEMBER) {
-          errors.push({
-            error: t("common.project-member"),
-            indent: 1,
-          });
-        } else if (role) {
-          errors.push({
-            error: displayRoleTitle(role),
+            error: roleTitle,
             indent: 1,
           });
         }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -276,7 +276,8 @@
     "permissions": "Permissions",
     "backup": "Backup",
     "cutover": "Cutover",
-    "baseline": "Baseline"
+    "baseline": "Baseline",
+    "project-member": "Project member"
   },
   "error-page": {
     "go-back-home": "Go back home"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -276,7 +276,8 @@
     "permissions": "Permisos",
     "backup": "Respaldo",
     "cutover": "transición",
-    "baseline": "Base"
+    "baseline": "Base",
+    "project-member": "Miembro del proyecto"
   },
   "error-page": {
     "go-back-home": "Volver al inicio"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -275,7 +275,8 @@
     "permissions": "権限",
     "backup": "バックアップ",
     "cutover": "カットオーバー",
-    "baseline": "ベースライン"
+    "baseline": "ベースライン",
+    "project-member": "プロジェクトメンバー"
   },
   "error-page": {
     "go-back-home": "ホームに戻る"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -276,7 +276,8 @@
     "permissions": "Quyền",
     "backup": "Hỗ trợ",
     "cutover": "Chuyển đổi",
-    "baseline": "Đường cơ sở"
+    "baseline": "Đường cơ sở",
+    "project-member": "Thành viên dự án"
   },
   "error-page": {
     "go-back-home": "Trở về nhà"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -274,7 +274,8 @@
     "permissions": "权限",
     "backup": "备份",
     "cutover": "切换",
-    "baseline": "基线"
+    "baseline": "基线",
+    "project-member": "项目成员"
   },
   "error-page": {
     "go-back-home": "回到主页"


### PR DESCRIPTION
### Rollout actions
- Respect `issue.releasers`.
### Review actions
- Respect current review step's `groupValue` and `role`. (The `step.nodes` is an array but actually have exact 1 value by now)
### Screenshots
<img width="240" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/0b98bb40-aa89-48fe-aa92-65327e5403b1">

Close BYT-4955