### PR TITLE
chore: best effort adding limit clause

### DIFF
--- a/backend/plugin/db/starrocks/query.go
+++ b/backend/plugin/db/starrocks/query.go
@@ -1,0 +1,77 @@
+package starrocks
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/pkg/errors"
+
+	mysql "github.com/bytebase/mysql-parser"
+
+	"github.com/bytebase/bytebase/backend/common/log"
+	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
+)
+
+func getStatementWithResultLimit(stmt string, limit int) string {
+	stmt, err := getStatementWithResultLimitForMySQL(stmt, limit)
+	if err != nil {
+		slog.Error("fail to add limit clause", "statement", stmt, log.BBError(err))
+		// MySQL 5.7 doesn't support WITH clause.
+		stmt = fmt.Sprintf("SELECT * FROM (%s) result LIMIT %d;", stmt, limit)
+	}
+	return stmt
+}
+
+// singleStatement must be a selectStatement for mysql.
+func getStatementWithResultLimitForMySQL(singleStatement string, limitCount int) (string, error) {
+	list, err := mysqlparser.ParseMySQL(singleStatement)
+	if err != nil {
+		return "", err
+	}
+
+	listener := &mysqlRewriter{
+		limitCount:     limitCount,
+		outerMostQuery: true,
+	}
+
+	for _, stmt := range list {
+		listener.rewriter = *antlr.NewTokenStreamRewriter(stmt.Tokens)
+		antlr.ParseTreeWalkerDefault.Walk(listener, stmt.Tree)
+		if listener.err != nil {
+			return "", errors.Wrapf(listener.err, "statement: %s", singleStatement)
+		}
+	}
+	return listener.rewriter.GetTextDefault(), nil
+}
+
+type mysqlRewriter struct {
+	*mysql.BaseMySQLParserListener
+
+	rewriter       antlr.TokenStreamRewriter
+	err            error
+	outerMostQuery bool
+	limitCount     int
+}
+
+func (r *mysqlRewriter) EnterQueryExpression(ctx *mysql.QueryExpressionContext) {
+	if !r.outerMostQuery {
+		return
+	}
+	r.outerMostQuery = false
+	if ctx.LimitClause() != nil {
+		// limit clause already exists.
+		return
+	}
+
+	if ctx.OrderClause() != nil {
+		r.rewriter.InsertAfterDefault(ctx.OrderClause().GetStop().GetTokenIndex(), fmt.Sprintf(" LIMIT %d", r.limitCount))
+	} else {
+		switch {
+		case ctx.QueryExpressionBody() != nil:
+			r.rewriter.InsertAfterDefault(ctx.QueryExpressionBody().GetStop().GetTokenIndex(), fmt.Sprintf(" LIMIT %d", r.limitCount))
+		case ctx.QueryExpressionParens() != nil:
+			r.rewriter.InsertAfterDefault(ctx.QueryExpressionParens().GetStop().GetTokenIndex(), fmt.Sprintf(" LIMIT %d", r.limitCount))
+		}
+	}
+}

--- a/backend/plugin/db/starrocks/query_test.go
+++ b/backend/plugin/db/starrocks/query_test.go
@@ -1,0 +1,80 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStatementWithResultLimitOfMySQL(t *testing.T) {
+	testCases := []struct {
+		stmt  string
+		count int
+		want  string
+	}{
+		{
+			stmt:  "SELECT * FROM t;",
+			count: 10,
+			want:  "SELECT * FROM t LIMIT 10;",
+		},
+		{
+			stmt:  "SELECT * FROM t LIMIT 5;",
+			count: 10,
+			want:  "SELECT * FROM t LIMIT 5;",
+		},
+		{
+			stmt:  "SELECT * FROM t2 JOIN t1 ON t2.c2 = t1.c2 where t2.c2 > 10;",
+			count: 10,
+			want:  "SELECT * FROM t2 JOIN t1 ON t2.c2 = t1.c2 where t2.c2 > 10 LIMIT 10;",
+		},
+		{
+			stmt:  "SELECT * FROM t1 ORDER BY c2;",
+			count: 10,
+			want:  "SELECT * FROM t1 ORDER BY c2 LIMIT 10;",
+		},
+		{
+			stmt:  "SELECT COUNT(col1) AS col2 FROM t GROUP BY col2 HAVING col2 = 2;",
+			count: 10,
+			want:  "SELECT COUNT(col1) AS col2 FROM t GROUP BY col2 HAVING col2 = 2 LIMIT 10;",
+		},
+		{
+			stmt:  "SELECT firstName, lastName FROM employees UNION SELECT contactFirstName, contactLastName FROM customers;",
+			count: 10,
+			want:  "SELECT firstName, lastName FROM employees UNION SELECT contactFirstName, contactLastName FROM customers LIMIT 10;",
+		}, {
+			stmt:  "SELECT customerNumber, checkNumber, amount FROM payments WHERE amount = (SELECT MAX(amount) FROM payments);",
+			count: 10,
+			want:  "SELECT customerNumber, checkNumber, amount FROM payments WHERE amount = (SELECT MAX(amount) FROM payments) LIMIT 10;",
+		}, {
+			stmt:  "SELECT firstName, lastName FROM employees UNION SELECT contactFirstName, contactLastName FROM customers LIMIT 10;",
+			count: 10,
+			want:  "SELECT firstName, lastName FROM employees UNION SELECT contactFirstName, contactLastName FROM customers LIMIT 10;",
+		}, {
+			stmt:  "WITH RECURSIVE cte_count (n) AS ( SELECT 1 UNION ALL SELECT n + 1 FROM cte_count WHERE n < 3 ) SELECT n FROM cte_count;",
+			count: 10,
+			want:  "WITH RECURSIVE cte_count (n) AS ( SELECT 1 UNION ALL SELECT n + 1 FROM cte_count WHERE n < 3 ) SELECT n FROM cte_count LIMIT 10;",
+		},
+		// EXCEPT need mysql >= 8.0.31
+		// {
+		// 	stmt:  "SELECT firstName FROM employees EXCEPT SELECT contactFirstName FROM customers;",
+		// 	count: 20,
+		// 	want:  "SELECT firstName FROM employees EXCEPT SELECT contactFirstName FROM customers LIMIT 10;",
+		// },
+		{
+			stmt:  "SELECT col1, col2 FROM table1 PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 10 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 ORDER BY col1;",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 ORDER BY col1 LIMIT 10;",
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := getStatementWithResultLimitForMySQL(tc.stmt, tc.count)
+		require.NoError(t, err, tc.stmt)
+		require.Equal(t, tc.want, got, tc.stmt)
+	}
+}

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -369,10 +369,6 @@ func (driver *Driver) querySingleSQL(ctx context.Context, conn *sql.Conn, single
 	return result, nil
 }
 
-func getStatementWithResultLimit(stmt string, limit int) string {
-	return fmt.Sprintf("SELECT * FROM (%s) result LIMIT %d;", stmt, limit)
-}
-
 // RunStatement runs a SQL statement in a given connection.
 func (*Driver) RunStatement(ctx context.Context, conn *sql.Conn, statement string) ([]*v1pb.QueryResult, error) {
 	return util.RunStatement(ctx, storepb.Engine_MYSQL, conn, statement)


### PR DESCRIPTION
""SELECT * FROM (%s) result LIMIT %d;" doesn't guarantee the order if the subquery has a sorting term. We will use parser to add limit clause if possible.