### PR TITLE
fix(span): table asterisk in target field and from contains join for pg

### DIFF
--- a/backend/plugin/parser/pg/query_span_extractor.go
+++ b/backend/plugin/parser/pg/query_span_extractor.go
@@ -309,9 +309,15 @@ func (q *querySpanExtractor) extractTableSourceFromSelect(node *pgquery.Node_Sel
 						sources, ok := q.getAllTableColumnSources(schemaName, tableName)
 						if ok {
 							result.Columns = append(result.Columns, sources...)
-							break
+							find = true
 						}
-						return nil, errors.Errorf("failed to get all table column sources for schema: %s, table: %s", schemaName, tableName)
+					}
+					if !find {
+						return nil, &parsererror.ResourceNotFoundError{
+							Err:    errors.New("failed to find table to calculate asterisk"),
+							Schema: &schemaName,
+							Table:  &tableName,
+						}
 					}
 				}
 			} else {

--- a/backend/plugin/parser/pg/test-data/query_span.yaml
+++ b/backend/plugin/parser/pg/test-data/query_span.yaml
@@ -1,3 +1,75 @@
+- description: Test for SELECT partial FROM JOIN clause
+  statement: SELECT t1.*, t2.c, 0 FROM t1 JOIN t2 ON 1 = 1;
+  connectedDatabase: db
+  metadata: |-
+    {
+      "name":  "db",
+      "schemas":  [
+        {
+          "name": "public",
+          "tables":  [
+            {
+              "name":  "t1",
+              "columns":  [
+                {
+                  "name":  "a"
+                },
+                {
+                  "name":  "b"
+                }
+              ]
+            },
+            {
+              "name":  "t2",
+              "columns":  [
+                {
+                  "name":  "c"
+                },
+                {
+                  "name":  "d"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  querySpan:
+    results:
+        - name: a
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: public
+              table: t1
+              column: a
+        - name: b
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: public
+              table: t1
+              column: b
+        - name: c
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: public
+              table: t2
+              column: c
+        - name: ?column?
+          sourcecolumns: []
+    sourcecolumns:
+        - server: ""
+          database: db
+          schema: public
+          table: t1
+          column: ""
+        - server: ""
+          database: db
+          schema: public
+          table: t2
+          column: ""
 - description: Test For Explain statements
   statement: EXPLAIN SELECT 1;
   connectedDatabase: db

--- a/backend/plugin/parser/pg/test-data/query_span.yaml
+++ b/backend/plugin/parser/pg/test-data/query_span.yaml
@@ -1,75 +1,3 @@
-- description: Test for SELECT partial FROM JOIN clause
-  statement: SELECT t1.*, t2.c, 0 FROM t1 JOIN t2 ON 1 = 1;
-  connectedDatabase: db
-  metadata: |-
-    {
-      "name":  "db",
-      "schemas":  [
-        {
-          "name": "public",
-          "tables":  [
-            {
-              "name":  "t1",
-              "columns":  [
-                {
-                  "name":  "a"
-                },
-                {
-                  "name":  "b"
-                }
-              ]
-            },
-            {
-              "name":  "t2",
-              "columns":  [
-                {
-                  "name":  "c"
-                },
-                {
-                  "name":  "d"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  querySpan:
-    results:
-        - name: a
-          sourcecolumns:
-            - server: ""
-              database: db
-              schema: public
-              table: t1
-              column: a
-        - name: b
-          sourcecolumns:
-            - server: ""
-              database: db
-              schema: public
-              table: t1
-              column: b
-        - name: c
-          sourcecolumns:
-            - server: ""
-              database: db
-              schema: public
-              table: t2
-              column: c
-        - name: ?column?
-          sourcecolumns: []
-    sourcecolumns:
-        - server: ""
-          database: db
-          schema: public
-          table: t1
-          column: ""
-        - server: ""
-          database: db
-          schema: public
-          table: t2
-          column: ""
 - description: Test For Explain statements
   statement: EXPLAIN SELECT 1;
   connectedDatabase: db
@@ -598,6 +526,78 @@
           database: db
           schema: public
           table: t
+          column: ""
+- description: Test for SELECT partial FROM JOIN clause
+  statement: SELECT t1.*, t2.c, 0 FROM t1 JOIN t2 ON 1 = 1;
+  connectedDatabase: db
+  metadata: |-
+    {
+      "name":  "db",
+      "schemas":  [
+        {
+          "name": "public",
+          "tables":  [
+            {
+              "name":  "t1",
+              "columns":  [
+                {
+                  "name":  "a"
+                },
+                {
+                  "name":  "b"
+                }
+              ]
+            },
+            {
+              "name":  "t2",
+              "columns":  [
+                {
+                  "name":  "c"
+                },
+                {
+                  "name":  "d"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  querySpan:
+    results:
+        - name: a
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: public
+              table: t1
+              column: a
+        - name: b
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: public
+              table: t1
+              column: b
+        - name: c
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: public
+              table: t2
+              column: c
+        - name: ?column?
+          sourcecolumns: []
+    sourcecolumns:
+        - server: ""
+          database: db
+          schema: public
+          table: t1
+          column: ""
+        - server: ""
+          database: db
+          schema: public
+          table: t2
           column: ""
 - description: Test for JOIN with USING clause
   statement: SELECT * FROM t AS t1 JOIN t AS t2 USING(a);

--- a/backend/plugin/parser/tidb/test-data/query_span.yaml
+++ b/backend/plugin/parser/tidb/test-data/query_span.yaml
@@ -527,6 +527,78 @@
         schema: ""
         table: t
         column: ""
+- description: Test for SELECT partial FROM JOIN clause
+  statement: SELECT t1.*, t2.c, 0 FROM t1 JOIN t2 ON 1 = 1;
+  connectedDatabase: db
+  metadata: |-
+    {
+      "name":  "db",
+      "schemas":  [
+        {
+          "name": "",
+          "tables":  [
+            {
+              "name":  "t1",
+              "columns":  [
+                {
+                  "name":  "a"
+                },
+                {
+                  "name":  "b"
+                }
+              ]
+            },
+            {
+              "name":  "t2",
+              "columns":  [
+                {
+                  "name":  "c"
+                },
+                {
+                  "name":  "d"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  querySpan:
+    results:
+        - name: a
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: ""
+              table: t1
+              column: a
+        - name: b
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: ""
+              table: t1
+              column: b
+        - name: c
+          sourcecolumns:
+            - server: ""
+              database: db
+              schema: ""
+              table: t2
+              column: c
+        - name: "0"
+          sourcecolumns: []
+    sourcecolumns:
+        - server: ""
+          database: db
+          schema: ""
+          table: t1
+          column: ""
+        - server: ""
+          database: db
+          schema: ""
+          table: t2
+          column: ""
 - description: Test for JOIN with USING clause
   statement: SELECT * FROM t AS t1 JOIN t AS t2 USING(a);
   connectedDatabase: db


### PR DESCRIPTION
Previous, we regard the `JOIN` returns a single pseudo, by example:
```
SELECT * FROM t1 JOIN t2;
```
We will generate a pseudo table to contains the result of `t1 JOIN t2`.
But users can refer to the t1 or t2 in target field list for the above case, likes `SELECT t1.*, t2.c FROM t1 JOIN t2`, so we add the `t1` and `t2` to the from field list to search.