### PR TITLE
chore: add mysql to naming identifier no keyword rule

### DIFF
--- a/frontend/src/types/sql-review-schema.yaml
+++ b/frontend/src/types/sql-review-schema.yaml
@@ -377,6 +377,7 @@ ruleList:
       - OCEANBASE_ORACLE
       - SNOWFLAKE
       - MSSQL
+      - MYSQL
     componentList: []
   - type: naming.identifier.case
     category: NAMING


### PR DESCRIPTION
Close BYT-4982