### PR TITLE
refactor(frontend): change history store with new cache mechanism

### DIFF
--- a/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/form/ChangeHistoryForm.vue
+++ b/frontend/src/components/Changelist/ChangelistDetail/AddChangePanel/form/ChangeHistoryForm.vue
@@ -156,8 +156,8 @@ const selectedChangeHistoryList = computed<string[]>({
     const changeHistories: ChangeHistory[] = [];
     for (let i = 0; i < selected.length; i++) {
       const name = selected[i];
-      const changeHistory =
-        useChangeHistoryStore().getChangeHistoryByName(name);
+      const changeHistoryStore = useChangeHistoryStore();
+      const changeHistory = changeHistoryStore.getChangeHistoryByName(name);
       if (changeHistory) {
         changeHistories.push(changeHistory);
       }

--- a/frontend/src/components/Changelist/ChangelistDetail/NavBar/export.ts
+++ b/frontend/src/components/Changelist/ChangelistDetail/NavBar/export.ts
@@ -4,6 +4,7 @@ import { useChangeHistoryStore, useSheetV1Store } from "@/store";
 import { useBranchStore } from "@/store/modules/branch";
 import { Changelist_Change_Source as ChangeSource } from "@/types";
 import { Changelist_Change as Change } from "@/types/proto/v1/changelist_service";
+import { ChangeHistoryView } from "@/types/proto/v1/database_service";
 import {
   escapeFilename,
   getChangelistChangeSourceType,
@@ -33,7 +34,10 @@ const zipFileForChangeHistory = async (
     return;
   }
   const changeHistory =
-    await useChangeHistoryStore().getOrFetchChangeHistoryByName(change.source);
+    await useChangeHistoryStore().getOrFetchChangeHistoryByName(
+      change.source,
+      ChangeHistoryView.CHANGE_HISTORY_VIEW_FULL
+    );
   if (!changeHistory) {
     return;
   }

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -431,21 +431,6 @@ watch(
     immediate: true,
   }
 );
-
-// watch(
-//   () => [state, fullViewChangeHistoryCache.value],
-//   () => {
-//     const fullViewChangeHistory = fullViewChangeHistoryCache.value.get(
-//       state.changeHistory?.name || ""
-//     );
-//     emit("update", {
-//       ...state,
-//       changeHistory: fullViewChangeHistory || state.changeHistory,
-//       conciseHistory: state.conciseHistory,
-//     });
-//   },
-//   { deep: true }
-// );
 </script>
 
 <style lang="postcss">

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -72,6 +72,7 @@
 </template>
 
 <script lang="ts" setup>
+import { computedAsync } from "@vueuse/core";
 import { head, isNull, isUndefined } from "lodash-es";
 import { NEllipsis, NSelect, SelectOption } from "naive-ui";
 import { computed, h, onMounted, reactive, ref, watch } from "vue";
@@ -98,6 +99,7 @@ import {
 } from "@/types/proto/v1/database_service";
 import {
   extractChangeHistoryUID,
+  instanceV1SupportsConciseSchema,
   mockLatestSchemaChangeHistory,
 } from "@/utils";
 import FeatureBadge from "../FeatureGuard/FeatureBadge.vue";
@@ -110,7 +112,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (event: "update", state: LocalState): void;
+  (event: "update", state: ChangeHistorySourceSchema): void;
 }>();
 
 interface LocalState {
@@ -131,7 +133,7 @@ const databaseStore = useDatabaseV1Store();
 const dbSchemaStore = useDBSchemaV1Store();
 const changeHistoryStore = useChangeHistoryStore();
 const environmentStore = useEnvironmentV1Store();
-const fullViewChangeHistoryCache = ref<Map<string, ChangeHistory>>(new Map());
+// const fullViewChangeHistoryCache = ref<Map<string, ChangeHistory>>(new Map());
 
 const database = computed(() => {
   const databaseId = state.databaseId;
@@ -147,16 +149,6 @@ const hasSyncSchemaFeature = computed(() => {
     database.value?.instanceEntity
   );
 });
-
-const prepareChangeHistoryList = async () => {
-  if (!database.value) {
-    return;
-  }
-
-  await changeHistoryStore.getOrFetchChangeHistoryListOfDatabase(
-    database.value.name
-  );
-};
 
 onMounted(async () => {
   if (props.selectState?.databaseId) {
@@ -179,31 +171,16 @@ onMounted(async () => {
   }
 });
 
-watch(() => state.databaseId, prepareChangeHistoryList);
-
-const prepareFullViewChangeHistory = async () => {
-  const changeHistory = state.changeHistory;
-  if (!changeHistory || changeHistory.uid === String(UNKNOWN_ID)) {
-    return;
+const fullViewChangeHistory = computedAsync(async () => {
+  const name = state.changeHistory?.name;
+  if (!name) {
+    return undefined;
   }
-
-  const cache = fullViewChangeHistoryCache.value.get(changeHistory.name);
-  if (!cache) {
-    const fullViewChangeHistory = await changeHistoryStore.fetchChangeHistory({
-      name: changeHistory.name,
-      view: ChangeHistoryView.CHANGE_HISTORY_VIEW_FULL,
-    });
-    fullViewChangeHistoryCache.value.set(
-      fullViewChangeHistory.name,
-      fullViewChangeHistory
-    );
-  }
-};
-
-watch(() => state.changeHistory, prepareFullViewChangeHistory, {
-  immediate: true,
-  deep: true,
-});
+  return changeHistoryStore.getOrFetchChangeHistoryByName(
+    name,
+    ChangeHistoryView.CHANGE_HISTORY_VIEW_FULL
+  );
+}, undefined);
 
 const allowedMigrationTypeList: ChangeHistory_Type[] = [
   ChangeHistory_Type.BASELINE,
@@ -369,7 +346,10 @@ const handleSchemaVersionSelect = async (
     state.showFeatureModal = true;
     return;
   }
-  if (database.value?.instanceEntity.engine === Engine.ORACLE) {
+  if (
+    database.value &&
+    instanceV1SupportsConciseSchema(database.value.instanceEntity)
+  ) {
     const conciseHistory = await changeHistoryStore.fetchChangeHistory({
       name: changeHistory.name,
       view: ChangeHistoryView.CHANGE_HISTORY_VIEW_FULL,
@@ -410,8 +390,8 @@ watch(
         state.changeHistory = mockLatestSchemaChangeHistory(database, schema);
         const conciseSchema = await databaseStore.fetchDatabaseSchema(
           `${database.name}/schema`,
-          false,
-          true
+          /* sdlFormat */ false,
+          /* concise */ instanceV1SupportsConciseSchema(database.instanceEntity)
         );
         state.conciseHistory = conciseSchema.schema;
       }
@@ -422,19 +402,51 @@ watch(
 );
 
 watch(
-  () => [state, fullViewChangeHistoryCache.value],
-  () => {
-    const fullViewChangeHistory = fullViewChangeHistoryCache.value.get(
-      state.changeHistory?.name || ""
-    );
-    emit("update", {
-      ...state,
-      changeHistory: fullViewChangeHistory || state.changeHistory,
-      conciseHistory: state.conciseHistory,
-    });
+  [
+    () => state.projectId,
+    () => state.environmentId,
+    () => state.databaseId,
+    () => state.changeHistory,
+    fullViewChangeHistory,
+    () => state.conciseHistory,
+  ],
+  ([
+    projectId,
+    environmentId,
+    databaseId,
+    basicViewChangeHistory,
+    fullViewChangeHistory,
+    conciseHistory,
+  ]) => {
+    const changeHistory = fullViewChangeHistory ?? basicViewChangeHistory;
+    const params: ChangeHistorySourceSchema = {
+      projectId,
+      environmentId,
+      databaseId,
+      changeHistory,
+      conciseHistory,
+    };
+    emit("update", params);
   },
-  { deep: true }
+  {
+    immediate: true,
+  }
 );
+
+// watch(
+//   () => [state, fullViewChangeHistoryCache.value],
+//   () => {
+//     const fullViewChangeHistory = fullViewChangeHistoryCache.value.get(
+//       state.changeHistory?.name || ""
+//     );
+//     emit("update", {
+//       ...state,
+//       changeHistory: fullViewChangeHistory || state.changeHistory,
+//       conciseHistory: state.conciseHistory,
+//     });
+//   },
+//   { deep: true }
+// );
 </script>
 
 <style lang="postcss">

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -75,7 +75,7 @@
 import { computedAsync } from "@vueuse/core";
 import { head, isNull, isUndefined } from "lodash-es";
 import { NEllipsis, NSelect, SelectOption } from "naive-ui";
-import { computed, h, onMounted, reactive, ref, watch } from "vue";
+import { computed, h, onMounted, reactive, watch } from "vue";
 import { VNodeArrayChildren } from "vue";
 import { useI18n } from "vue-i18n";
 import {
@@ -91,7 +91,6 @@ import {
   useEnvironmentV1Store,
 } from "@/store";
 import { UNKNOWN_ID } from "@/types";
-import { Engine } from "@/types/proto/v1/common";
 import {
   ChangeHistory,
   ChangeHistoryView,

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -133,7 +133,6 @@ const databaseStore = useDatabaseV1Store();
 const dbSchemaStore = useDBSchemaV1Store();
 const changeHistoryStore = useChangeHistoryStore();
 const environmentStore = useEnvironmentV1Store();
-// const fullViewChangeHistoryCache = ref<Map<string, ChangeHistory>>(new Map());
 
 const database = computed(() => {
   const databaseId = state.databaseId;

--- a/frontend/src/components/SyncDatabaseSchema/index.vue
+++ b/frontend/src/components/SyncDatabaseSchema/index.vue
@@ -35,7 +35,7 @@
           v-if="state.sourceSchemaType === 'SCHEMA_HISTORY_VERSION'"
           :select-state="changeHistorySourceSchemaState"
           :disable-project-select="!!project"
-          @update="handleChangeHistorySchameVersionChanges"
+          @update="handleChangeHistorySchemaVersionChanges"
         />
         <RawSQLEditor
           v-if="state.sourceSchemaType === 'RAW_SQL'"
@@ -132,7 +132,7 @@ const projectId = computed(() => {
   }
 });
 
-const handleChangeHistorySchameVersionChanges = (
+const handleChangeHistorySchemaVersionChanges = (
   schemaVersion: ChangeHistorySourceSchema
 ) => {
   Object.assign(changeHistorySourceSchemaState, schemaVersion);

--- a/frontend/src/store/cache.ts
+++ b/frontend/src/store/cache.ts
@@ -1,12 +1,4 @@
-import {
-  Raw,
-  Ref,
-  ShallowRef,
-  reactive,
-  ref,
-  shallowReactive,
-  shallowRef,
-} from "vue";
+import { shallowReactive } from "vue";
 
 export type KeyType = string | number | boolean;
 

--- a/frontend/src/store/cache.ts
+++ b/frontend/src/store/cache.ts
@@ -1,0 +1,142 @@
+import {
+  Raw,
+  Ref,
+  ShallowRef,
+  reactive,
+  ref,
+  shallowReactive,
+  shallowRef,
+} from "vue";
+
+export type KeyType = string | number | boolean;
+
+type RequestCacheEntry<K extends KeyType[], T> = {
+  keys: K;
+  promise: Promise<T>;
+  abortController: AbortController;
+};
+type EntityCacheEntry<K extends KeyType[], T> = {
+  keys: K;
+  entity: T;
+};
+const REQUEST_CACHE = new Map<
+  string,
+  Map<string, RequestCacheEntry<any, any>>
+>();
+const ENTITY_CACHE = new Map<string, Map<string, EntityCacheEntry<any, any>>>();
+
+export const useCache = <K extends KeyType[], T>(namespace: string) => {
+  const requestCacheMap = getRequestCacheMap<K, T>(namespace);
+  const entityCacheMap = getEntityCacheMap<K, T>(namespace);
+
+  const trace = (title: string, keys: KeyType[], ...args: any[]) => {
+    console.debug("cache", namespace, title, JSON.stringify(keys), ...args);
+  };
+
+  const invalidateRequest = (keys: K) => {
+    const key = getKey(keys);
+    const request = requestCacheMap.get(key);
+    if (!request) return;
+    if (!request.abortController.signal.aborted) {
+      request.abortController.abort();
+    }
+    requestCacheMap.delete(key);
+  };
+
+  const getRequest = (keys: K) => {
+    const key = getKey(keys);
+    trace("getRequest", keys, requestCacheMap.has(key));
+    const request = requestCacheMap.get(key);
+    if (!request) {
+      return undefined;
+    }
+    if (request.abortController.signal.aborted) {
+      invalidateRequest(keys);
+      return undefined;
+    }
+    return request.promise;
+  };
+
+  const setRequest = (keys: K, promise: Promise<T>) => {
+    invalidateRequest(keys);
+
+    const key = getKey(keys);
+    const abortController = new AbortController();
+    promise.then((entity: T) => {
+      if (abortController.signal.aborted) {
+        invalidateRequest(keys);
+        return;
+      }
+      setEntity(keys, entity);
+    });
+    requestCacheMap.set(key, {
+      keys,
+      promise,
+      abortController,
+    });
+    // trace("setRequest", keys);
+  };
+
+  const getEntity = (keys: K) => {
+    const key = getKey(keys);
+    trace("getEntity", keys, entityCacheMap.has(key));
+    return entityCacheMap.get(key)?.entity;
+  };
+
+  const setEntity = (keys: K, entity: T) => {
+    const key = getKey(keys);
+    entityCacheMap.set(key, {
+      keys,
+      entity,
+    });
+    // trace("setEntity", keys);
+  };
+
+  const invalidateEntity = (keys: K) => {
+    invalidateRequest(keys);
+    const key = getKey(keys);
+    entityCacheMap.delete(key);
+  };
+
+  return {
+    requestCacheMap,
+    entityCacheMap,
+    getRequest,
+    getEntity,
+    setRequest,
+    setEntity,
+    invalidateRequest,
+    invalidateEntity,
+  };
+};
+
+const getRequestCacheMap = <K extends KeyType[], T>(namespace: string) => {
+  const existed = REQUEST_CACHE.get(namespace) as Map<
+    string,
+    RequestCacheEntry<K, T>
+  >;
+  if (existed) {
+    return existed;
+  }
+  const created = shallowReactive(new Map<string, RequestCacheEntry<K, T>>());
+  REQUEST_CACHE.set(namespace, created);
+  return created;
+};
+
+const getEntityCacheMap = <K extends KeyType[], T>(namespace: string) => {
+  const existed = ENTITY_CACHE.get(namespace) as Map<
+    string,
+    EntityCacheEntry<K, T>
+  >;
+
+  if (existed) {
+    return existed;
+  }
+  const created = shallowReactive(new Map<string, EntityCacheEntry<K, T>>());
+  ENTITY_CACHE.set(namespace, created);
+  return created;
+};
+
+const getKey = (keys: KeyType[]) => {
+  return JSON.stringify(keys);
+};

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -3,3 +3,4 @@ import { createPinia } from "pinia";
 export const pinia = createPinia();
 
 export * from "./modules";
+export * from "./cache";

--- a/frontend/src/store/modules/v1/changeHistory.ts
+++ b/frontend/src/store/modules/v1/changeHistory.ts
@@ -1,6 +1,8 @@
 import { defineStore } from "pinia";
 import { reactive } from "vue";
 import { databaseServiceClient } from "@/grpcweb";
+import { useCache } from "@/store/cache";
+import { UNKNOWN_ID } from "@/types";
 import {
   ChangeHistory,
   ChangeHistoryView,
@@ -8,25 +10,41 @@ import {
   GetChangeHistoryRequest,
   ListChangeHistoriesRequest,
 } from "@/types/proto/v1/database_service";
-import { extractDatabaseResourceName, getStatementSize } from "@/utils";
+import {
+  extractChangeHistoryUID,
+  extractDatabaseResourceName,
+  getStatementSize,
+} from "@/utils";
+
+type CacheKeyType = [string /* name */, ChangeHistoryView];
 
 export const useChangeHistoryStore = defineStore("changeHistory_v1", () => {
-  const changeHistoryMapByName = reactive(new Map<string, ChangeHistory>());
+  const cache = useCache<CacheKeyType, ChangeHistory>(
+    "bb.change-history.by-name"
+  );
+
+  // const changeHistoryMapByName = reactive(new Map<string, ChangeHistory>());
   const changeHistoryListMapByDatabase = reactive(
     new Map<string, ChangeHistory[]>()
   );
 
-  const upsertChangeHistoryMap = async (historyList: ChangeHistory[]) => {
-    for (let i = 0; i < historyList.length; i++) {
-      const history = historyList[i];
-      changeHistoryMapByName.set(history.name, history);
-    }
-  };
+  // const upsertChangeHistoryMap = async (historyList: ChangeHistory[]) => {
+  //   for (let i = 0; i < historyList.length; i++) {
+  //     const history = historyList[i];
+  //     changeHistoryMapByName.set(history.name, history);
+  //   }
+  // };
   const upsertChangeHistoryListMap = async (
     parent: string,
     historyList: ChangeHistory[]
   ) => {
     changeHistoryListMapByDatabase.set(parent, historyList);
+    historyList.forEach((entity) => {
+      cache.setEntity(
+        [entity.name, ChangeHistoryView.CHANGE_HISTORY_VIEW_BASIC],
+        entity
+      );
+    });
   };
 
   const fetchChangeHistoryList = async (
@@ -55,39 +73,45 @@ export const useChangeHistoryStore = defineStore("changeHistory_v1", () => {
     params: Partial<GetChangeHistoryRequest>
   ) => {
     const changeHistory = await databaseServiceClient.getChangeHistory(params);
-    await upsertChangeHistoryMap([changeHistory]);
     return changeHistory;
   };
   const getOrFetchChangeHistoryByName = async (
     name: string,
-    view: ChangeHistoryView = ChangeHistoryView.CHANGE_HISTORY_VIEW_BASIC
+    view: ChangeHistoryView
   ) => {
-    const changeHistory = changeHistoryMapByName.get(name);
-    if (changeHistory) {
-      if (
-        (getStatementSize(changeHistory.statement).eq(
-          changeHistory.statementSize
-        ) &&
-          getStatementSize(changeHistory.schema).eq(
-            changeHistory.schemaSize
-          )) ||
-        view === ChangeHistoryView.CHANGE_HISTORY_VIEW_BASIC
-      ) {
-        return changeHistory;
-      }
+    const uid = extractChangeHistoryUID(name);
+    if (!uid || uid === String(UNKNOWN_ID)) {
+      return undefined;
     }
-    return await fetchChangeHistory({ name, view });
+    const entity = cache.getEntity([name, view]);
+    if (entity) {
+      return entity;
+    }
+    const request = cache.getRequest([name, view]);
+    if (request) {
+      return request;
+    }
+    const promise = fetchChangeHistory({ name, view });
+    cache.setRequest([name, view], promise);
+    return promise;
   };
-  const getChangeHistoryByName = (name: string) => {
-    const detail = changeHistoryMapByName.get(name);
-    if (detail) {
-      return detail;
+  /**
+   * 
+   * @param name 
+   * @param view default undefined to any view (full -> basic)
+   * @returns 
+   */
+  const getChangeHistoryByName = (
+    name: string,
+    view: ChangeHistoryView | undefined = undefined
+  ) => {
+    if (view === undefined) {
+      return (
+        cache.getEntity([name, ChangeHistoryView.CHANGE_HISTORY_VIEW_FULL]) ??
+        cache.getEntity([name, ChangeHistoryView.CHANGE_HISTORY_VIEW_BASIC])
+      );
     }
-    const { full: parent } = extractDatabaseResourceName(name);
-    const brief = changeHistoryListMapByDatabase
-      .get(parent)
-      ?.find((ch) => ch.name === name);
-    return brief;
+    return cache.getEntity([name, view]);
   };
   const exportChangeHistoryFullStatementByName = async (
     name: string

--- a/frontend/src/store/modules/v1/changeHistory.ts
+++ b/frontend/src/store/modules/v1/changeHistory.ts
@@ -10,11 +10,7 @@ import {
   GetChangeHistoryRequest,
   ListChangeHistoriesRequest,
 } from "@/types/proto/v1/database_service";
-import {
-  extractChangeHistoryUID,
-  extractDatabaseResourceName,
-  getStatementSize,
-} from "@/utils";
+import { extractChangeHistoryUID } from "@/utils";
 
 type CacheKeyType = [string /* name */, ChangeHistoryView];
 
@@ -22,18 +18,10 @@ export const useChangeHistoryStore = defineStore("changeHistory_v1", () => {
   const cache = useCache<CacheKeyType, ChangeHistory>(
     "bb.change-history.by-name"
   );
-
-  // const changeHistoryMapByName = reactive(new Map<string, ChangeHistory>());
   const changeHistoryListMapByDatabase = reactive(
     new Map<string, ChangeHistory[]>()
   );
 
-  // const upsertChangeHistoryMap = async (historyList: ChangeHistory[]) => {
-  //   for (let i = 0; i < historyList.length; i++) {
-  //     const history = historyList[i];
-  //     changeHistoryMapByName.set(history.name, history);
-  //   }
-  // };
   const upsertChangeHistoryListMap = async (
     parent: string,
     historyList: ChangeHistory[]
@@ -96,10 +84,10 @@ export const useChangeHistoryStore = defineStore("changeHistory_v1", () => {
     return promise;
   };
   /**
-   * 
-   * @param name 
+   *
+   * @param name
    * @param view default undefined to any view (full -> basic)
-   * @returns 
+   * @returns
    */
   const getChangeHistoryByName = (
     name: string,

--- a/frontend/src/store/modules/v1/changelist.ts
+++ b/frontend/src/store/modules/v1/changelist.ts
@@ -8,6 +8,7 @@ import {
   DeepPartial,
   ListChangelistsRequest,
 } from "@/types/proto/v1/changelist_service";
+import { ChangeHistoryView } from "@/types/proto/v1/database_service";
 import {
   ResourceComposer,
   isBranchChangeSource,
@@ -101,7 +102,10 @@ export const useChangelistStore = defineStore("changelist", () => {
     const { sheet, source } = change;
     if (isChangeHistoryChangeSource(change)) {
       composer.collect(source, () =>
-        useChangeHistoryStore().getOrFetchChangeHistoryByName(source)
+        useChangeHistoryStore().getOrFetchChangeHistoryByName(
+          source,
+          ChangeHistoryView.CHANGE_HISTORY_VIEW_BASIC
+        )
       );
     } else if (isBranchChangeSource(change)) {
       composer.collect(source, () =>

--- a/frontend/src/utils/v1/instance.ts
+++ b/frontend/src/utils/v1/instance.ts
@@ -228,6 +228,13 @@ export const instanceV1AllowsReorderColumns = (
   return [Engine.MYSQL, Engine.TIDB].includes(engine);
 };
 
+export const instanceV1SupportsConciseSchema = (
+  instanceOrEngine: Instance | Engine
+) => {
+  const engine = engineOfInstanceV1(instanceOrEngine);
+  return [Engine.ORACLE].includes(engine);
+};
+
 export const engineOfInstanceV1 = (instanceOrEngine: Instance | Engine) => {
   if (typeof instanceOrEngine === "number") {
     return instanceOrEngine;


### PR DESCRIPTION
### Changes 
- New cache mechanism
  - Cache requests along with entities (to avoid duplicated requests)
  - Cache keys can now be multi-dimensional ([key1, key2, ...])
- Refactored ChangeHistory store
  - ChangeHistories with BASIC or FULL view now have independent caches