### PR TITLE
chore: change oracle default timeout

### DIFF
--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -55,6 +55,7 @@ func (driver *Driver) Open(ctx context.Context, _ storepb.Engine, config db.Conn
 		return nil, errors.Errorf("invalid port %q", config.Port)
 	}
 	options := make(map[string]string)
+	options["CONNECTION TIMEOUT"] = "0"
 	if config.SID != "" {
 		options["SID"] = config.SID
 	}


### PR DESCRIPTION
The driver timeout is 2-minute by default. We change it to zero meaning no timeout.