### PR TITLE
chore: support not in operator in the frontend

### DIFF
--- a/frontend/src/components/ExprEditor/ConditionGroup.vue
+++ b/frontend/src/components/ExprEditor/ConditionGroup.vue
@@ -7,17 +7,15 @@
       <div class="flex-1">
         <template v-if="args.length > 0">
           <template v-if="operator === '_||_'">
-            {{ $t("custom-approval.risk-rule.condition.group.or.description") }}
+            {{ $t("cel.condition.group.or.description") }}
           </template>
           <template v-if="operator === '_&&_'">
-            {{
-              $t("custom-approval.risk-rule.condition.group.and.description")
-            }}
+            {{ $t("cel.condition.group.and.description") }}
           </template>
         </template>
         <template v-else>
           <i18n-t
-            keypath="custom-approval.risk-rule.condition.add-condition-in-group-placeholder"
+            keypath="cel.condition.add-condition-in-group-placeholder"
             tag="div"
             class="inline-flex items-center"
           >
@@ -50,9 +48,7 @@
     </div>
 
     <div v-if="root && args.length === 0" class="px-1.5 text-gray-500">
-      {{
-        $t("custom-approval.risk-rule.condition.add-root-condition-placeholder")
-      }}
+      {{ $t("cel.condition.add-root-condition-placeholder") }}
     </div>
     <div
       v-for="(operand, i) in args"
@@ -92,17 +88,17 @@
     <div v-if="root && allowAdmin" class="space-x-1">
       <NButton size="small" quaternary @click="addCondition">
         <template #icon><heroicons:plus class="w-4 h-4" /></template>
-        <span>{{ $t("custom-approval.risk-rule.condition.add") }}</span>
+        <span>{{ $t("cel.condition.add") }}</span>
       </NButton>
       <NButton size="small" quaternary @click="addConditionGroup">
         <template #icon><heroicons:plus class="w-4 h-4" /></template>
-        <span>{{ $t("custom-approval.risk-rule.condition.add-group") }}</span>
+        <span>{{ $t("cel.condition.add-group") }}</span>
         <NTooltip>
           <template #trigger>
             <heroicons:question-mark-circle class="ml-1 w-3 h-3" />
           </template>
           <div class="max-w-[18rem]">
-            {{ $t("custom-approval.risk-rule.condition.group.tooltip") }}
+            {{ $t("cel.condition.group.tooltip") }}
           </div>
         </NTooltip>
       </NButton>

--- a/frontend/src/components/ExprEditor/components/MultiSelect.vue
+++ b/frontend/src/components/ExprEditor/components/MultiSelect.vue
@@ -4,7 +4,7 @@
     :options="options"
     :multiple="true"
     :consistent-menu-width="false"
-    :placeholder="$t('custom-approval.risk-rule.condition.select-value')"
+    :placeholder="$t('cel.condition.select-value')"
     :disabled="!allowAdmin"
     max-tag-count="responsive"
     size="small"

--- a/frontend/src/components/ExprEditor/components/MultiStringInput.vue
+++ b/frontend/src/components/ExprEditor/components/MultiStringInput.vue
@@ -7,18 +7,17 @@
     :show-arrow="false"
     :show="false"
     :consistent-menu-width="false"
-    :placeholder="
-      $t('custom-approval.risk-rule.condition.input-value-press-enter')
-    "
+    :placeholder="$t('cel.condition.input-value-press-enter')"
     :disabled="!allowAdmin"
     max-tag-count="responsive"
     size="small"
     style="min-width: 16rem; width: auto; overflow-x: hidden"
-    @update:value="$emit('update:value', $event)"
+    @update:value="onUpdate"
   />
 </template>
 
 <script lang="ts" setup>
+import { uniq } from "lodash-es";
 import { NSelect } from "naive-ui";
 import { useExprEditorContext } from "../context";
 
@@ -26,10 +25,22 @@ defineProps<{
   value: string[];
 }>();
 
-defineEmits<{
+const emit = defineEmits<{
   (event: "update:value", value: string[]): void;
 }>();
 
 const context = useExprEditorContext();
 const { allowAdmin } = context;
+
+const onUpdate = (values: string[]) => {
+  emit(
+    "update:value",
+    uniq(
+      values
+        .join(",")
+        .split(",")
+        .filter((val) => val)
+    )
+  );
+};
 </script>

--- a/frontend/src/components/ExprEditor/components/NumberInput.vue
+++ b/frontend/src/components/ExprEditor/components/NumberInput.vue
@@ -2,7 +2,7 @@
   <NInputNumber
     :value="value"
     :show-button="false"
-    :placeholder="$t('custom-approval.risk-rule.condition.input-value')"
+    :placeholder="$t('cel.condition.input-value')"
     :disabled="!allowAdmin"
     size="small"
     style="width: auto; max-width: 5rem; overflow-x: hidden"

--- a/frontend/src/components/ExprEditor/components/OperatorSelect.vue
+++ b/frontend/src/components/ExprEditor/components/OperatorSelect.vue
@@ -49,6 +49,7 @@ const OPERATOR_DICT = new Map([
   ["_<=_", "≤"],
   ["_>=_", "≥"],
   ["_>_", ">"],
+  ["@not_in", "not in"],
 ]);
 
 const options = computed(() => {

--- a/frontend/src/components/ExprEditor/components/SingleSelect.vue
+++ b/frontend/src/components/ExprEditor/components/SingleSelect.vue
@@ -3,7 +3,7 @@
     :value="value"
     :options="options"
     :consistent-menu-width="false"
-    :placeholder="$t('custom-approval.risk-rule.condition.select-value')"
+    :placeholder="$t('cel.condition.select-value')"
     :disabled="!allowAdmin"
     size="small"
     style="min-width: 7rem; width: auto; overflow-x: hidden"

--- a/frontend/src/components/ExprEditor/components/StringInput.vue
+++ b/frontend/src/components/ExprEditor/components/StringInput.vue
@@ -1,7 +1,7 @@
 <template>
   <NInput
     :value="value"
-    :placeholder="$t('custom-approval.risk-rule.condition.input-value')"
+    :placeholder="$t('cel.condition.input-value')"
     :disabled="!allowAdmin"
     size="small"
     style="min-width: 7rem; width: auto; overflow-x: hidden"

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2995,26 +2995,6 @@
           "export": "Request Export"
         }
       },
-      "condition": {
-        "self": "Condition",
-        "description-tips": "A condition is a rule that can be configured via an expression. For example, the condition \"Environment is prod\" will match issues executed in the \"prod\" environment.",
-        "add": "Add condition",
-        "add-group": "Add condition group",
-        "group": {
-          "or": {
-            "description": "Any of the following are true..."
-          },
-          "and": {
-            "description": "All of the following are true..."
-          },
-          "tooltip": "A condition group is a collection of conditions connected by operators \"And\" and \"Or\"."
-        },
-        "input-value": "Input value",
-        "add-condition-in-group-placeholder": "Add {plus} to add condition",
-        "select-value": "Select value",
-        "input-value-press-enter": "Input value, press Enter to confirm",
-        "add-root-condition-placeholder": "Click \"Add condition\" or \"Add condition group\" to add condition"
-      },
       "template": {
         "templates": "Templates",
         "load": "Load",
@@ -3359,6 +3339,26 @@
       "resource_instance_id": "Instance ID",
       "resource_database_name": "Database name",
       "resource_table_name": "Table name"
+    },
+    "condition": {
+      "self": "Condition",
+      "description-tips": "A condition is a rule that can be configured via an expression. For example, the condition \"Environment is prod\" will match issues executed in the \"prod\" environment.",
+      "add": "Add condition",
+      "add-group": "Add condition group",
+      "group": {
+        "or": {
+          "description": "Any of the following are true..."
+        },
+        "and": {
+          "description": "All of the following are true..."
+        },
+        "tooltip": "A condition group is a collection of conditions connected by operators \"And\" and \"Or\"."
+      },
+      "input-value": "Input value",
+      "add-condition-in-group-placeholder": "Add {plus} to add condition",
+      "select-value": "Select value",
+      "input-value-press-enter": "Input value, press Enter to confirm",
+      "add-root-condition-placeholder": "Click \"Add condition\" or \"Add condition group\" to add condition"
     }
   },
   "changelist": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2991,26 +2991,6 @@
           "export": "Solicitar exportación"
         }
       },
-      "condition": {
-        "self": "Condición",
-        "description-tips": "Una condición es una regla que se puede configurar mediante una expresión. Por ejemplo, la condición \"Entorno es prod\" coincidirá con las incidencias ejecutadas en el entorno \"prod\".",
-        "add": "Agregar condición",
-        "add-group": "Agregar grupo de condiciones",
-        "group": {
-          "or": {
-            "description": "Cualquiera de los siguientes es verdadero..."
-          },
-          "and": {
-            "description": "Todos los siguientes son verdaderos..."
-          },
-          "tooltip": "Un grupo de condiciones es una colección de condiciones conectadas por operadores \"Y\" y \"O\"."
-        },
-        "input-value": "Valor de entrada",
-        "add-condition-in-group-placeholder": "Agregar {plus} para agregar condición",
-        "select-value": "Seleccionar valor",
-        "input-value-press-enter": "Ingrese el valor, presione Enter para confirmar",
-        "add-root-condition-placeholder": "Haga clic en \"Agregar condición\" o \"Agregar grupo de condiciones\" para agregar una condición"
-      },
       "template": {
         "templates": "Plantillas",
         "load": "Cargar",
@@ -3356,6 +3336,26 @@
       "resource_database_name": "Nombre de la base de datos",
       "resource_table_name": "Nombre de la tabla",
       "table_rows": "Filas de la tabla"
+    },
+    "condition": {
+      "self": "Condición",
+      "description-tips": "Una condición es una regla que se puede configurar mediante una expresión. Por ejemplo, la condición \"Entorno es prod\" coincidirá con las incidencias ejecutadas en el entorno \"prod\".",
+      "add": "Agregar condición",
+      "add-group": "Agregar grupo de condiciones",
+      "group": {
+        "or": {
+          "description": "Cualquiera de los siguientes es verdadero..."
+        },
+        "and": {
+          "description": "Todos los siguientes son verdaderos..."
+        },
+        "tooltip": "Un grupo de condiciones es una colección de condiciones conectadas por operadores \"Y\" y \"O\"."
+      },
+      "input-value": "Valor de entrada",
+      "add-condition-in-group-placeholder": "Agregar {plus} para agregar condición",
+      "select-value": "Seleccionar valor",
+      "input-value-press-enter": "Ingrese el valor, presione Enter para confirmar",
+      "add-root-condition-placeholder": "Haga clic en \"Agregar condición\" o \"Agregar grupo de condiciones\" para agregar una condición"
     }
   },
   "changelist": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2993,26 +2993,6 @@
           "export": "エクスポートのリクエスト"
         }
       },
-      "condition": {
-        "self": "条件",
-        "description-tips": "条件は式を使用して構成できるルールです。たとえば、「環境がprodである」という条件は、「prod」環境で実行される問題に一致します。",
-        "add": "条件を追加する",
-        "add-group": "条件グループを追加する",
-        "group": {
-          "or": {
-            "description": "以下のいずれかが真の場合..."
-          },
-          "and": {
-            "description": "以下のすべてが真の場合..."
-          },
-          "tooltip": "条件グループは、演算子「And」と「Or」で接続された条件のコレクションです。"
-        },
-        "input-value": "入力値",
-        "add-condition-in-group-placeholder": "条件を追加するには{plus}を追加してください",
-        "select-value": "値を選択する",
-        "input-value-press-enter": "値を入力し、Enterキーを押して確認してください",
-        "add-root-condition-placeholder": "条件を追加するか、条件グループを追加するには「条件を追加」または「条件グループを追加」をクリックしてください"
-      },
       "template": {
         "templates": "テンプレート",
         "load": "ロード",
@@ -3357,6 +3337,26 @@
       "resource_database_name": "データベース名",
       "resource_table_name": "テーブル名",
       "table_rows": "テーブルの行"
+    },
+    "condition": {
+      "self": "条件",
+      "description-tips": "条件は式を使用して構成できるルールです。たとえば、「環境がprodである」という条件は、「prod」環境で実行される問題に一致します。",
+      "add": "条件を追加する",
+      "add-group": "条件グループを追加する",
+      "group": {
+        "or": {
+          "description": "以下のいずれかが真の場合..."
+        },
+        "and": {
+          "description": "以下のすべてが真の場合..."
+        },
+        "tooltip": "条件グループは、演算子「And」と「Or」で接続された条件のコレクションです。"
+      },
+      "input-value": "入力値",
+      "add-condition-in-group-placeholder": "条件を追加するには{plus}を追加してください",
+      "select-value": "値を選択する",
+      "input-value-press-enter": "値を入力し、Enterキーを押して確認してください",
+      "add-root-condition-placeholder": "条件を追加するか、条件グループを追加するには「条件を追加」または「条件グループを追加」をクリックしてください"
     }
   },
   "changelist": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2994,26 +2994,6 @@
           "export": "Yêu cầu xuất"
         }
       },
-      "condition": {
-        "self": "Tình trạng",
-        "description-tips": "Điều kiện là một quy tắc có thể được cấu hình thông qua một biểu thức. Ví dụ: điều kiện \"Môi trường là sản phẩm\" sẽ khớp với các sự cố được thực thi trong môi trường \"prod\".",
-        "add": "Thêm điều kiện",
-        "add-group": "Thêm nhóm điều kiện",
-        "group": {
-          "or": {
-            "description": "Bất kỳ điều nào sau đây là đúng..."
-          },
-          "and": {
-            "description": "Tất cả những điều sau đây đều đúng..."
-          },
-          "tooltip": "Nhóm điều kiện là tập hợp các điều kiện được kết nối bởi các toán tử \"And\" và \"Or\"."
-        },
-        "input-value": "Giá trị đầu vào",
-        "add-condition-in-group-placeholder": "Thêm {plus} để thêm điều kiện",
-        "select-value": "Chọn giá trị",
-        "input-value-press-enter": "Nhập giá trị, nhấn Enter để xác nhận",
-        "add-root-condition-placeholder": "Nhấp vào \"Thêm điều kiện\" hoặc \"Thêm nhóm điều kiện\" để thêm điều kiện"
-      },
       "template": {
         "templates": "Mẫu",
         "load": "Trọng tải",
@@ -3358,6 +3338,26 @@
       "resource_database_name": "Tên cơ sở dữ liệu",
       "resource_table_name": "Tên bảng",
       "table_rows": "Hàng của bảng"
+    },
+    "condition": {
+      "self": "Tình trạng",
+      "description-tips": "Điều kiện là một quy tắc có thể được cấu hình thông qua một biểu thức. Ví dụ: điều kiện \"Môi trường là sản phẩm\" sẽ khớp với các sự cố được thực thi trong môi trường \"prod\".",
+      "add": "Thêm điều kiện",
+      "add-group": "Thêm nhóm điều kiện",
+      "group": {
+        "or": {
+          "description": "Bất kỳ điều nào sau đây là đúng..."
+        },
+        "and": {
+          "description": "Tất cả những điều sau đây đều đúng..."
+        },
+        "tooltip": "Nhóm điều kiện là tập hợp các điều kiện được kết nối bởi các toán tử \"And\" và \"Or\"."
+      },
+      "input-value": "Giá trị đầu vào",
+      "add-condition-in-group-placeholder": "Thêm {plus} để thêm điều kiện",
+      "select-value": "Chọn giá trị",
+      "input-value-press-enter": "Nhập giá trị, nhấn Enter để xác nhận",
+      "add-root-condition-placeholder": "Nhấp vào \"Thêm điều kiện\" hoặc \"Thêm nhóm điều kiện\" để thêm điều kiện"
     }
   },
   "changelist": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2990,26 +2990,6 @@
           "export": "申请导出数据"
         }
       },
-      "condition": {
-        "self": "条件",
-        "description-tips": "条件是通过表达式配置的规则。例如：条件「环境 为 prod」将会匹配在「prod」环境中执行的工单。",
-        "add": "添加条件",
-        "add-group": "添加条件组",
-        "group": {
-          "or": {
-            "description": "以下任一为真…"
-          },
-          "and": {
-            "description": "以下全部为真…"
-          },
-          "tooltip": "条件组是一系列由「与」或「或」运算符连接的条件的集合。"
-        },
-        "input-value": "输入值",
-        "add-condition-in-group-placeholder": "点击{plus}添加条件",
-        "select-value": "选择值",
-        "input-value-press-enter": "输入值，按回车确认",
-        "add-root-condition-placeholder": "点击「添加条件」或「添加条件组」以添加条件"
-      },
       "template": {
         "templates": "模板",
         "load": "加载",
@@ -3353,6 +3333,26 @@
       "resource_instance_id": "实例 ID",
       "resource_database_name": "数据库名",
       "resource_table_name": "表名"
+    },
+    "condition": {
+      "self": "条件",
+      "description-tips": "条件是通过表达式配置的规则。例如：条件「环境 为 prod」将会匹配在「prod」环境中执行的工单。",
+      "add": "添加条件",
+      "add-group": "添加条件组",
+      "group": {
+        "or": {
+          "description": "以下任一为真…"
+        },
+        "and": {
+          "description": "以下全部为真…"
+        },
+        "tooltip": "条件组是一系列由「与」或「或」运算符连接的条件的集合。"
+      },
+      "input-value": "输入值",
+      "add-condition-in-group-placeholder": "点击{plus}添加条件",
+      "select-value": "选择值",
+      "input-value-press-enter": "输入值，按回车确认",
+      "add-root-condition-placeholder": "点击「添加条件」或「添加条件组」以添加条件"
     }
   },
   "changelist": {

--- a/frontend/src/plugins/cel/logic/build.ts
+++ b/frontend/src/plugins/cel/logic/build.ts
@@ -52,6 +52,11 @@ export const buildCELExpr = (expr: SimpleExpr): CELExpr | undefined => {
     if (isCollectionExpr(condition)) {
       const { operator, args } = condition;
       const [factor, values] = args;
+      if (operator === "@not_in") {
+        return wrapCallExpr("!_", [
+          wrapCallExpr("@in", [wrapIdentExpr(factor), wrapListExpr(values)]),
+        ]);
+      }
       return wrapCallExpr(operator, [
         wrapIdentExpr(factor),
         wrapListExpr(values),

--- a/frontend/src/plugins/cel/types/operator.ts
+++ b/frontend/src/plugins/cel/types/operator.ts
@@ -1,6 +1,9 @@
 import { uniq } from "lodash-es";
 import { Factor } from "./factor";
 
+export const NegativeOperatorList = ["!_"] as const;
+export type NegativeOperator = typeof NegativeOperatorList[number];
+
 export const LogicalOperatorList = ["_&&_", "_||_"] as const;
 export type LogicalOperator = typeof LogicalOperatorList[number];
 
@@ -10,7 +13,7 @@ export type EqualityOperator = typeof EqualityOperatorList[number];
 export const CompareOperatorList = ["_<_", "_<=_", "_>=_", "_>_"] as const;
 export type CompareOperator = typeof CompareOperatorList[number];
 
-export const CollectionOperatorList = ["@in"] as const;
+export const CollectionOperatorList = ["@in", "@not_in"] as const;
 export type CollectionOperator = typeof CollectionOperatorList[number];
 
 export const StringOperatorList = [
@@ -26,8 +29,11 @@ export type ConditionOperator =
   | CompareOperator
   | CollectionOperator
   | StringOperator;
-export type Operator = LogicalOperator | ConditionOperator;
+export type Operator = LogicalOperator | NegativeOperator | ConditionOperator;
 
+export const isNegativeOperator = (op: Operator): op is NegativeOperator => {
+  return NegativeOperatorList.includes(op as NegativeOperator);
+};
 export const isLogicalOperator = (op: Operator): op is LogicalOperator => {
   return LogicalOperatorList.includes(op as LogicalOperator);
 };


### PR DESCRIPTION
The standard expr doesn't support `not in` syntax, but `!` instead.
So the expression for `database not in (a, b, c)` should be `!(database in (a, b, c))`

I'm not sure if we need to support `!` in the backend (I guess we need?)

![CleanShot 2024-02-23 at 23 49 40@2x](https://github.com/bytebase/bytebase/assets/10706318/c92bc6dd-34be-4241-99ef-9899a326b575)
