### PR TITLE
chore(frontend): refactor project protection rules store cache

### DIFF
--- a/frontend/src/store/cache.ts
+++ b/frontend/src/store/cache.ts
@@ -90,6 +90,18 @@ export const useCache = <K extends KeyType[], T>(namespace: string) => {
     entityCacheMap.delete(key);
   };
 
+  const clear = () => {
+    // abort and invalidate all flying requests
+    for (const request of requestCacheMap.values()) {
+      if (!request.abortController.signal.aborted) {
+        request.abortController.abort();
+      }
+    }
+    // clear all cache entries
+    requestCacheMap.clear();
+    entityCacheMap.clear();
+  };
+
   return {
     requestCacheMap,
     entityCacheMap,
@@ -99,6 +111,7 @@ export const useCache = <K extends KeyType[], T>(namespace: string) => {
     setEntity,
     invalidateRequest,
     invalidateEntity,
+    clear,
   };
 };
 


### PR DESCRIPTION
Useful to avoid duplicated requests when calling `getOrFetchProjectProtectionRules` concurrently

Before
<img width="892" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/1ecdb748-97bf-4c97-abd3-04c5cc42693a">

After
<img width="537" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/c3f0889a-5b2c-4c31-ab6a-8319168fec8a">
