### PR TITLE
chore: check workspace id in claims

### DIFF
--- a/backend/api/v1/setting_service.go
+++ b/backend/api/v1/setting_service.go
@@ -57,6 +57,7 @@ func NewSettingService(
 // Some settings contain secret info so we only return settings that are needed by the client.
 var whitelistSettings = []api.SettingName{
 	api.SettingBrandingLogo,
+	api.SettingWorkspaceID,
 	api.SettingAppIM,
 	api.SettingWatermark,
 	api.SettingPluginOpenAIKey,

--- a/frontend/src/components/GeneralSetting/SecuritySetting.vue
+++ b/frontend/src/components/GeneralSetting/SecuritySetting.vue
@@ -160,6 +160,9 @@ const { isSaaSMode } = storeToRefs(actuatorStore);
 const hasWatermarkFeature = featureToRef("bb.feature.branding");
 const has2FAFeature = featureToRef("bb.feature.2fa");
 const hasDisallowSignupFeature = featureToRef("bb.feature.disallow-signup");
+const hasRestrictIssueCreationFeature = featureToRef(
+  "bb.feature.access-control"
+);
 
 const watermarkEnabled = computed((): boolean => {
   return (
@@ -242,6 +245,10 @@ const handleWatermarkToggle = async (on: boolean) => {
 };
 
 const handleRestrictIssueCreationForSQLReviewToggle = async (on: boolean) => {
+  if (!hasRestrictIssueCreationFeature.value && on) {
+    state.featureNameForModal = "bb.feature.access-control";
+    return;
+  }
   await policyV1Store.createPolicy("", {
     type: PolicyType.RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW,
     resourceType: PolicyResourceType.WORKSPACE,

--- a/frontend/src/components/SensitiveData/components/ClassificationExampleModal.vue
+++ b/frontend/src/components/SensitiveData/components/ClassificationExampleModal.vue
@@ -9,6 +9,7 @@
   >
     <div class="my-4 rounded-sm p-4 bg-gray-100 relative">
       <div
+        v-if="isSupported"
         class="absolute top-2 right-2 p-2 rounded bg-gray-200 text-gray-500 hover:text-gray-700 hover:bg-gray-300 cursor-pointer"
         @click="handleCopy"
       >
@@ -100,20 +101,12 @@ const { copy: copyTextToClipboard, isSupported } = useClipboard({
 const { t } = useI18n();
 
 const handleCopy = () => {
-  if (!isSupported.value) {
+  copyTextToClipboard(JSON.stringify(example, null, 2)).then(() => {
     pushNotification({
       module: "bytebase",
-      style: "CRITICAL",
-      title: "Copy to clipboard is not enabled in your browser.",
+      style: "SUCCESS",
+      title: t("settings.sensitive-data.classification.copy-succeed"),
     });
-    return;
-  }
-
-  copyTextToClipboard(JSON.stringify(example, null, 2));
-  pushNotification({
-    module: "bytebase",
-    style: "SUCCESS",
-    title: t("settings.sensitive-data.classification.copy-succeed"),
   });
 };
 </script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -591,6 +591,8 @@
     },
     "general": {
       "workspace": {
+        "id": "Workspace ID",
+        "id-description": "The unique, read-only workspace id.",
         "branding": "Branding",
         "only-admin-can-edit": "Only workspace admin can update the settings.",
         "logo": "Logo",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -591,6 +591,8 @@
     },
     "general": {
       "workspace": {
+        "id": "ID del espacio de trabajo",
+        "id-description": "La identificación única del espacio de trabajo de solo lectura.",
         "branding": "Marca",
         "only-admin-can-edit": "Solo el administrador del espacio de trabajo puede actualizar la configuración.",
         "logo": "Logo",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -591,6 +591,8 @@
     },
     "general": {
       "workspace": {
+        "id": "ワークスペースID",
+        "id-description": "一意の読み取り専用ワークスペース ID。",
         "branding": "ブランディング",
         "only-admin-can-edit": "設定の更新はワークスペース管理者のみが行えます。",
         "logo": "ロゴ",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -591,6 +591,8 @@
     },
     "general": {
       "workspace": {
+        "id": "ID không gian làm việc",
+        "id-description": "Id không gian làm việc duy nhất, chỉ đọc.",
         "branding": "Xây dựng thương hiệu",
         "only-admin-can-edit": "Chỉ quản trị viên không gian làm việc mới có thể cập nhật cài đặt.",
         "logo": "Logo",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -591,6 +591,8 @@
     },
     "general": {
       "workspace": {
+        "id": "工作空间 ID",
+        "id-description": "唯一且只读的工作空间 ID",
         "branding": "品牌",
         "only-admin-can-edit": "仅管理员可以更改此设置",
         "logo": "Logo",

--- a/frontend/src/types/setting.ts
+++ b/frontend/src/types/setting.ts
@@ -1,5 +1,6 @@
 export type SettingName =
   | "bb.branding.logo"
+  | "bb.workspace.id"
   | "bb.app.im"
   | "bb.workspace.watermark"
   | "bb.workspace.profile"


### PR DESCRIPTION
- Check workspace id in claims for enterprise plan (only if the license contains the workspace id filed)
- Expose the workspace id to the frontend

![CleanShot 2024-03-01 at 15 18 40@2x](https://github.com/bytebase/bytebase/assets/10706318/d1d20a15-9473-4d99-93d0-d65ad987d96d)
