### PR TITLE
refactor(frontend-iam): workspace level project permission and list/searchDatabases

### DIFF
--- a/frontend/src/components/AnomalyCenter/AnomalyCenterDashboard.vue
+++ b/frontend/src/components/AnomalyCenter/AnomalyCenterDashboard.vue
@@ -175,7 +175,7 @@ const environmentList = useEnvironmentV1List(false /* !showDeleted */);
 const prepareDatabaseList = () => {
   // It will also be called when user logout
   if (currentUserV1.value.name !== UNKNOWN_USER_NAME) {
-    databaseStore.fetchDatabaseList({
+    databaseStore.searchOrListDatabases({
       parent: "instances/-",
     });
   }

--- a/frontend/src/components/Issue/panel/RequestExportPanel/ExportResourceForm/DatabaseResourceSelector.vue
+++ b/frontend/src/components/Issue/panel/RequestExportPanel/ExportResourceForm/DatabaseResourceSelector.vue
@@ -77,7 +77,7 @@ watch(
     loading.value = true;
 
     const project = await useProjectV1Store().getOrFetchProjectByUID(projectId);
-    const databaseList = await databaseStore.fetchDatabaseList({
+    const databaseList = await databaseStore.searchOrListDatabases({
       parent: "instances/-",
       filter: `project == "${project.name}"`,
     });

--- a/frontend/src/components/Issue/panel/RequestQueryPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
+++ b/frontend/src/components/Issue/panel/RequestQueryPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
@@ -80,7 +80,7 @@ watch(
     const project = await useProjectV1Store().getOrFetchProjectByUID(
       props.projectId
     );
-    const databaseList = await databaseStore.fetchDatabaseList({
+    const databaseList = await databaseStore.searchOrListDatabases({
       parent: "instances/-",
       filter: `project == "${project.name}"`,
     });

--- a/frontend/src/components/IssueV1/logic/initialize/create.ts
+++ b/frontend/src/components/IssueV1/logic/initialize/create.ts
@@ -547,7 +547,7 @@ export const prepareDatabaseList = async (
 };
 
 const prepareDatabaseListByProject = async (project: string) => {
-  await useDatabaseV1Store().fetchDatabaseList({
+  await useDatabaseV1Store().searchOrListDatabases({
     parent: `instances/-`,
     filter: `project == "${project}"`,
   });

--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -33,9 +33,9 @@ const prepareDatabases = async () => {
     filter = `project == "${projectNamePrefix}${route.params.projectId}"`;
   }
 
-  await databaseStore.fetchDatabaseList({
+  await databaseStore.searchOrListDatabases({
     parent: "instances/-",
-    filter: filter,
+    filter,
   });
 };
 

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -89,9 +89,10 @@ const prepareDatabases = async () => {
   // `databaseList` is the database list accessible by current user.
   // Only accessible instances and databases will be listed in the tree.
   const databaseList = (
-    await databaseStore.fetchDatabaseList({
+    await databaseStore.searchOrListDatabases({
       parent: "instances/-",
-      filter: filter,
+      filter,
+      permission: "bb.databases.query",
     })
   ).filter((db) => db.syncState === State.ACTIVE);
 

--- a/frontend/src/components/TransferDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm.vue
@@ -142,7 +142,7 @@ const state = reactive<LocalState>({
 const { project } = useProjectV1ByUID(toRef(props, "projectId"));
 
 const prepare = async () => {
-  await databaseStore.fetchDatabaseList({
+  await databaseStore.searchOrListDatabases({
     parent: "instances/-",
   });
 };

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -1,36 +1,8 @@
 import { keyBy } from "lodash-es";
-import { User } from "@/types/proto/v1/auth_service";
 import { Engine } from "@/types/proto/v1/common";
 import { Environment as EnvironmentV1 } from "@/types/proto/v1/environment_service";
-import type { Database, DataSourceType, Environment } from "../types";
-import { hasWorkspacePermissionV2 } from "./iam";
-import { isDev, semverCompare } from "./util";
-
-export function allowDatabaseAccess(
-  database: Database,
-  user: User,
-  type: DataSourceType
-): boolean {
-  // "ADMIN" data source should only be used by the system, thus it shouldn't
-  // touch this method at all. If it touches somehow, we will reject it and
-  // log a warning
-  if (type == "ADMIN") {
-    if (isDev()) {
-      console.trace(
-        "Should not check database access against ADMIN connection"
-      );
-    } else {
-      console.warn("Should not check database access against ADMIN connection");
-    }
-    return false;
-  }
-
-  if (hasWorkspacePermissionV2(user, "bb.instances.update")) {
-    return true;
-  }
-
-  return false;
-}
+import type { Database, Environment } from "../types";
+import { semverCompare } from "./util";
 
 // Sort the list to put prod items first.
 export function sortDatabaseList(

--- a/frontend/src/utils/iam/permission.ts
+++ b/frontend/src/utils/iam/permission.ts
@@ -51,8 +51,28 @@ export const hasProjectPermissionV2 = (
   return permissions.includes(permission);
 };
 
-// hasWorkspaceLevelProjectPermission checks if the user has the given permission on any project in the workspace.
+// hasWorkspaceLevelProjectPermission checks if the user has the given permission on workspace-level-assigned project roles
 export const hasWorkspaceLevelProjectPermission = (
+  user: User,
+  permission: ProjectPermission
+): boolean => {
+  const roleStore = useRoleStore();
+  const workspaceLevelRoles = user.roles.map((roleName) =>
+    roleStore.getRoleByName(roleName)
+  );
+  // For those users who have workspace-level project roles, they should have all project-level permissions.
+  const workspaceLevelPermissions = workspaceLevelRoles.flatMap((role) =>
+    role ? role.permissions : []
+  );
+  if (workspaceLevelPermissions.includes(permission)) {
+    return true;
+  }
+
+  return false;
+};
+
+// hasWorkspaceLevelProjectPermission checks if the user has the given permission on ANY project in the workspace.
+export const hasWorkspaceLevelProjectPermissionInAnyProject = (
   user: User,
   permission: ProjectPermission
 ): boolean => {

--- a/frontend/src/views/InstanceDetail.vue
+++ b/frontend/src/views/InstanceDetail.vue
@@ -85,7 +85,7 @@ import {
   instanceV1HasCreateDatabase,
   instanceV1Name,
   hasWorkspacePermissionV2,
-  hasWorkspaceLevelProjectPermission,
+  hasWorkspaceLevelProjectPermissionInAnyProject,
 } from "@/utils";
 
 interface LocalState {
@@ -123,7 +123,7 @@ const environment = computed(() => {
 });
 
 watchEffect(() => {
-  databaseStore.fetchDatabaseList({
+  databaseStore.searchOrListDatabases({
     parent: instance.value.name,
   });
 });
@@ -146,7 +146,10 @@ const allowSyncInstance = computed(() => {
 const allowCreateDatabase = computed(() => {
   return (
     instance.value.state === State.ACTIVE &&
-    hasWorkspaceLevelProjectPermission(currentUser.value, "bb.issues.create") &&
+    hasWorkspaceLevelProjectPermissionInAnyProject(
+      currentUser.value,
+      "bb.issues.create"
+    ) &&
     instanceV1HasCreateDatabase(instance.value)
   );
 });
@@ -155,7 +158,7 @@ const syncSchema = async () => {
   state.syncingSchema = true;
   try {
     await instanceV1Store.syncInstance(instance.value).then(() => {
-      return databaseStore.fetchDatabaseList({
+      return databaseStore.searchOrListDatabases({
         parent: instance.value.name,
       });
     });

--- a/frontend/src/views/SettingSidebar.vue
+++ b/frontend/src/views/SettingSidebar.vue
@@ -49,7 +49,7 @@ import workspaceSettingRoutes, {
 } from "@/router/dashboard/workspaceSetting";
 import { useCurrentUserV1 } from "@/store";
 import {
-  hasWorkspaceLevelProjectPermission,
+  hasWorkspaceLevelProjectPermissionInAnyProject,
   hasWorkspacePermissionV2,
 } from "@/utils";
 
@@ -266,7 +266,10 @@ const hasRoutePermission = (routeName: string) => {
   } else if (route.meta?.requiredProjectPermissionList) {
     const requiredPermissions = route.meta.requiredProjectPermissionList();
     return requiredPermissions.every((permission) =>
-      hasWorkspaceLevelProjectPermission(currentUser.value, permission)
+      hasWorkspaceLevelProjectPermissionInAnyProject(
+        currentUser.value,
+        permission
+      )
     );
   }
 


### PR DESCRIPTION
- `fetchDatabaseList` is now split into `searchDatabases` and `listDatabases`, and exposed as `searchOrListDatabases` according to `hasWorkspaceLevelProjectPermission`
- `hasWorkspaceLevelProjectPermission` now checks if the user has the given permission on workspace-level-assigned project roles
- introducing `hasWorkspaceLevelProjectPermissionInAnyProject` for special use cases

Close BYT-5071