### PR TITLE
chore: fix project selector filter

### DIFF
--- a/frontend/src/components/Issue/panel/RequestExportPanel/index.vue
+++ b/frontend/src/components/Issue/panel/RequestExportPanel/index.vue
@@ -18,11 +18,7 @@
           <ProjectSelect
             class="!w-60 shrink-0"
             :project="state.projectId"
-            :allowed-project-role-list="[
-              PresetRoleType.PROJECT_OWNER,
-              PresetRoleType.PROJECT_DEVELOPER,
-              PresetRoleType.PROJECT_VIEWER,
-            ]"
+            :filter="filterProject"
             @update:project="handleProjectSelect"
           />
         </div>
@@ -163,6 +159,7 @@ import {
   UNKNOWN_ID,
   dialectOfEngineV1,
   PresetRoleType,
+  ComposedProject,
 } from "@/types";
 import { Duration } from "@/types/proto/google/protobuf/duration";
 import { Expr } from "@/types/proto/google/type/expr";
@@ -170,6 +167,7 @@ import { Engine } from "@/types/proto/v1/common";
 import { Issue, Issue_Type } from "@/types/proto/v1/issue_service";
 import {
   extractProjectResourceName,
+  hasProjectPermissionV2,
   issueSlug,
   memberListInProjectV1,
 } from "@/utils";
@@ -275,6 +273,10 @@ onMounted(async () => {
     state.statement = props.statement;
   }
 });
+
+const filterProject = (project: ComposedProject) => {
+  return hasProjectPermissionV2(project, currentUser.value, "bb.databases.get");
+};
 
 const handleProjectSelect = async (projectId: string | undefined) => {
   state.projectId = projectId;

--- a/frontend/src/components/v2/Select/ProjectSelect.vue
+++ b/frontend/src/components/v2/Select/ProjectSelect.vue
@@ -19,7 +19,12 @@ import { NSelect, SelectOption } from "naive-ui";
 import { computed, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import { useCurrentUserV1, useProjectV1Store, useProjectV1List } from "@/store";
-import { DEFAULT_PROJECT_ID, UNKNOWN_ID, unknownProject } from "@/types";
+import {
+  ComposedProject,
+  DEFAULT_PROJECT_ID,
+  UNKNOWN_ID,
+  unknownProject,
+} from "@/types";
 import { State } from "@/types/proto/v1/common";
 import {
   Project,
@@ -43,7 +48,7 @@ const props = withDefaults(
     includeAll?: boolean;
     includeDefaultProject?: boolean;
     includeArchived?: boolean;
-    filter?: (project: Project, index: number) => boolean;
+    filter?: (project: ComposedProject, index: number) => boolean;
   }>(),
   {
     disabled: false,


### PR DESCRIPTION
### Before
hardcoded to be `[PresetRoleType.PROJECT_OWNER, PresetRoleType.PROJECT_DEVELOPER, PresetRoleType.PROJECT_VIEWER]`
### After
anyone with `bb.databases.get` permission in a project.

Part of BYT-5103