### PR TITLE
chore: update display title of permissions

### DIFF
--- a/frontend/src/components/Role/Setting/components/ImportPermissionFromRoleModal.vue
+++ b/frontend/src/components/Role/Setting/components/ImportPermissionFromRoleModal.vue
@@ -19,13 +19,13 @@
               selectedRole.permissions.length
             }})
           </p>
-          <div class="max-h-[10em] overflow-auto">
+          <div class="max-h-[10em] overflow-auto border rounded p-2">
             <p
               v-for="permission in selectedRole.permissions"
               :key="permission"
-              class="text-sm"
+              class="text-sm leading-5"
             >
-              {{ permission }}
+              {{ displayPermissionTitle(permission) }}
             </p>
           </div>
         </div>
@@ -51,6 +51,7 @@ import { NSelect, NButton } from "naive-ui";
 import { computed, reactive } from "vue";
 import { useRoleStore } from "@/store";
 import { displayRoleTitle, displayRoleDescription } from "@/utils";
+import { displayPermissionTitle } from "@/utils/permission";
 
 interface LocalState {
   selectedRole?: string;

--- a/frontend/src/components/Role/Setting/components/RolePanel.vue
+++ b/frontend/src/components/Role/Setting/components/RolePanel.vue
@@ -111,6 +111,7 @@ import {
 } from "@/types";
 import { Role } from "@/types/proto/v1/role_service";
 import { extractRoleResourceName } from "@/utils";
+import { displayPermissionTitle } from "@/utils/permission";
 import { useCustomRoleSettingContext } from "../context";
 import ImportPermissionFromRoleModal from "./ImportPermissionFromRoleModal.vue";
 
@@ -153,7 +154,7 @@ const resourceId = computed({
 
 const permissionOptions = computed(() => {
   return [...WORKSPACE_PERMISSIONS, ...PROJECT_PERMISSIONS].sort().map((p) => ({
-    label: p,
+    label: displayPermissionTitle(p),
     value: p,
   }));
 });

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -1,5 +1,7 @@
+const PERMISSION_PREFIX = "bb.";
+
 // displayPermissionTitle return the formatted permission title.
 // e.g., bb.databases.get -> databases.get
 export const displayPermissionTitle = (permission: string): string => {
-  return permission.slice(3);
+  return permission.slice(PERMISSION_PREFIX.length);
 };

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -1,0 +1,5 @@
+// displayPermissionTitle return the formatted permission title.
+// e.g., bb.databases.get -> databases.get
+export const displayPermissionTitle = (permission: string): string => {
+  return permission.slice(3);
+};


### PR DESCRIPTION
Remove the redundant `bb.` prefix.

<img width="697" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/1f6cb3b8-67d2-4165-8db9-3f05135dc936">
