### PR TITLE
chore: simplify sql review rule definition in the frontend

### DIFF
--- a/frontend/src/bbkit/BBTextField.vue
+++ b/frontend/src/bbkit/BBTextField.vue
@@ -12,6 +12,7 @@
     :autosize="autosize"
     :status="state.hasError ? 'error' : undefined"
     @blur="onBlur"
+    @focus="$emit('on-focus')"
     @update:value="onInput($event)"
     @keypress.enter="onPressEnter"
     @input="$emit('input', $event)"
@@ -57,6 +58,7 @@ const emit = defineEmits<{
   (event: "end-editing", value: string): void;
   (event: "update:value", value: string): void;
   (event: "input", value: string): void;
+  (event: "on-focus"): void;
 }>();
 
 const inputField = ref();

--- a/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckDetail.vue
+++ b/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckDetail.vue
@@ -49,11 +49,14 @@
           <span class="border-r border-control-border ml-1"></span>
         </template>
         <template
-          v-if="row.checkResult.sqlReviewReport && getActiveRule(row.checkResult.title as RuleType)"
+          v-if="
+            row.checkResult.sqlReviewReport &&
+            getActiveRule(row.checkResult.title)
+          "
         >
           <span
             class="ml-1 normal-link"
-            @click="setActiveRule(row.checkResult.title as RuleType)"
+            @click="setActiveRule(row.checkResult.title)"
             >{{ $t("sql-review.rule-detail") }}</span
           >
           <span class="border-r border-control-border ml-1"></span>
@@ -103,7 +106,6 @@ import { useReviewPolicyByEnvironmentName } from "@/store";
 import {
   GeneralErrorCode,
   RuleTemplate,
-  RuleType,
   SQLReviewPolicyErrorCode,
   UNKNOWN_ENVIRONMENT_NAME,
   findRuleTemplate,
@@ -200,7 +202,7 @@ const categoryAndTitle = (
       const title = messageWithCode(checkResult.title, code);
       return ["", title];
     }
-    const rule = ruleTemplateMap.get(checkResult.title as RuleType);
+    const rule = ruleTemplateMap.get(checkResult.title);
     if (rule) {
       const ruleLocalization = getRuleLocalization(rule.type);
       const key = `sql-review.category.${rule.category.toLowerCase()}`;
@@ -279,7 +281,7 @@ const reviewPolicy = useReviewPolicyByEnvironmentName(
     return props.environment || UNKNOWN_ENVIRONMENT_NAME;
   })
 );
-const getActiveRule = (type: RuleType): PreviewSQLReviewRule | undefined => {
+const getActiveRule = (type: string): PreviewSQLReviewRule | undefined => {
   const rule = reviewPolicy.value?.ruleList.find((rule) => rule.type === type);
   if (!rule) {
     return undefined;
@@ -304,7 +306,7 @@ const getActiveRule = (type: RuleType): PreviewSQLReviewRule | undefined => {
     payload: payload,
   };
 };
-const setActiveRule = (type: RuleType) => {
+const setActiveRule = (type: string) => {
   state.activeRule = getActiveRule(type);
 };
 </script>

--- a/frontend/src/components/SQLReview/SQLReviewCreation.vue
+++ b/frontend/src/components/SQLReview/SQLReviewCreation.vue
@@ -191,6 +191,7 @@ const changeStepIndex = (nextIndex: number) => {
         positiveText: t("common.confirm"),
         onPositiveClick: (_: MouseEvent) => {
           onTemplateApply(state.pendingApplyTemplate);
+          state.currentStep = nextIndex;
         },
       });
       return;

--- a/frontend/src/components/SQLReview/components/SQLReviewCategoryTabFilter.vue
+++ b/frontend/src/components/SQLReview/components/SQLReviewCategoryTabFilter.vue
@@ -3,8 +3,8 @@
     :value="state.selectedTab"
     :items="tabItemList"
     @update:value="
-    (val) => {
-        state.selectedTab = val as string;
+    (val: string) => {
+        state.selectedTab = val;
         $emit('update:value', val == 'all' ? undefined : state.selectedTab);
       }
     "
@@ -14,10 +14,9 @@
 <script lang="ts" setup>
 import { computed, reactive, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { CategoryType } from "@/types/sqlReview";
 
 export interface CategoryFilterItem {
-  id: CategoryType;
+  id: string;
   name: string;
 }
 

--- a/frontend/src/components/SQLReview/components/utils.ts
+++ b/frontend/src/components/SQLReview/components/utils.ts
@@ -3,7 +3,6 @@ import {
   convertPolicyRuleToRuleTemplate,
   RuleConfigComponent,
   RuleTemplate,
-  RuleType,
   SQLReviewPolicy,
   TEMPLATE_LIST,
   IndividualConfigForEngine,
@@ -22,20 +21,20 @@ export const rulesToTemplate = (
   withDisabled = false
 ) => {
   const ruleTemplateList: RuleTemplate[] = [];
-  const ruleTemplateMap: Map<RuleType, RuleTemplate> = TEMPLATE_LIST.reduce(
+  const ruleTemplateMap: Map<string, RuleTemplate> = TEMPLATE_LIST.reduce(
     (map, template) => {
       for (const rule of template.ruleList) {
         map.set(rule.type, rule);
       }
       return map;
     },
-    new Map<RuleType, RuleTemplate>()
+    new Map<string, RuleTemplate>()
   );
 
   const groupByRule = groupBy(review.ruleList, (rule) => rule.type);
 
   for (const [type, ruleList] of Object.entries(groupByRule)) {
-    const rule = ruleTemplateMap.get(type as RuleType);
+    const rule = ruleTemplateMap.get(type);
     if (!rule) {
       continue;
     }

--- a/frontend/src/router/dashboard/workspaceSetting.ts
+++ b/frontend/src/router/dashboard/workspaceSetting.ts
@@ -224,7 +224,10 @@ const workspaceSettingRoutes: RouteRecordRaw[] = [
         meta: {
           title: (route: RouteLocationNormalized) => {
             const slug = route.params.vcsSlug as string;
-            return useVCSV1Store().getVCSByUid(uidFromSlug(slug))?.title ?? "";
+            return (
+              useVCSV1Store().getVCSByUid(uidFromSlug(slug))?.title ??
+              t("settings.sidebar.gitops")
+            );
           },
           requiredWorkspacePermissionList: () => [
             "bb.externalVersionControls.get",
@@ -281,7 +284,7 @@ const workspaceSettingRoutes: RouteRecordRaw[] = [
             return (
               useSQLReviewStore().getReviewPolicyByEnvironmentId(
                 String(uidFromSlug(slug))
-              )?.name ?? ""
+              )?.name ?? t("sql-review.title")
             );
           },
           requiredWorkspacePermissionList: () => ["bb.policies.get"],

--- a/frontend/src/store/modules/sqlReview.ts
+++ b/frontend/src/store/modules/sqlReview.ts
@@ -11,7 +11,6 @@ import {
   SQLReviewPolicy,
   IdType,
   MaybeRef,
-  RuleType,
 } from "@/types";
 import { Environment } from "@/types/proto/v1/environment_service";
 import {
@@ -35,7 +34,7 @@ const convertToSQLReviewPolicy = async (
   const ruleList: SchemaPolicyRule[] = [];
   for (const r of policy.sqlReviewPolicy.rules) {
     const rule: SchemaPolicyRule = {
-      type: r.type as RuleType,
+      type: r.type,
       level: r.level,
       engine: r.engine,
       comment: r.comment,

--- a/frontend/src/types/sql-review-schema.yaml
+++ b/frontend/src/types/sql-review-schema.yaml
@@ -1,21 +1,9 @@
-categoryList:
-  - ENGINE
-  - INDEX
-  - NAMING
-  - STATEMENT
-  - TABLE
-  - SCHEMA
-  - COLUMN
-  - SYSTEM
-  - DATABASE
-  - ADVICE
 ruleList:
   - type: engine.mysql.use-innodb
     category: ENGINE
     engineList:
       - MYSQL
       - MARIADB
-    componentList: []
   - type: table.require-pk
     category: TABLE
     engineList:
@@ -28,7 +16,6 @@ ruleList:
       - SNOWFLAKE
       - MSSQL
       - MARIADB
-    componentList: []
   - type: table.no-foreign-key
     category: TABLE
     engineList:
@@ -41,7 +28,6 @@ ruleList:
       - SNOWFLAKE
       - MSSQL
       - MARIADB
-    componentList: []
   - type: table.drop-naming-convention
     category: TABLE
     engineList:
@@ -81,17 +67,14 @@ ruleList:
       - POSTGRES
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: table.disallow-trigger
     category: TABLE
     engineList:
       - MYSQL
-    componentList: []
   - type: table.no-duplicate-index
     category: TABLE
     engineList:
       - MYSQL
-    componentList: []
   - type: table.text-fields-total-length
     category: TABLE
     engineList:
@@ -105,7 +88,6 @@ ruleList:
     category: TABLE
     engineList:
       - MYSQL
-    componentList: []
   - type: statement.select.no-select-all
     category: STATEMENT
     engineList:
@@ -118,7 +100,6 @@ ruleList:
       - SNOWFLAKE
       - MSSQL
       - MARIADB
-    componentList: []
   - type: statement.where.require
     category: STATEMENT
     engineList:
@@ -131,7 +112,6 @@ ruleList:
       - SNOWFLAKE
       - MSSQL
       - MARIADB
-    componentList: []
   - type: statement.where.no-leading-wildcard-like
     category: STATEMENT
     engineList:
@@ -142,12 +122,10 @@ ruleList:
       - OCEANBASE_ORACLE
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.disallow-cascade
     category: STATEMENT
     engineList:
       - POSTGRES
-    componentList: []
   - type: statement.disallow-commit
     category: STATEMENT
     engineList:
@@ -156,7 +134,6 @@ ruleList:
       - POSTGRES
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.disallow-limit
     category: STATEMENT
     engineList:
@@ -164,7 +141,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.disallow-order-by
     category: STATEMENT
     engineList:
@@ -172,7 +148,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.merge-alter-table
     category: STATEMENT
     engineList:
@@ -181,7 +156,6 @@ ruleList:
       - POSTGRES
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.insert.row-limit
     category: STATEMENT
     engineList:
@@ -204,7 +178,6 @@ ruleList:
       - OCEANBASE_ORACLE
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.insert.disallow-order-by-rand
     category: STATEMENT
     engineList:
@@ -213,7 +186,6 @@ ruleList:
       - POSTGRES
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.affected-row-limit
     category: STATEMENT
     engineList:
@@ -234,59 +206,48 @@ ruleList:
       - OCEANBASE
       - MARIADB
       - TIDB
-    componentList: []
   - type: statement.disallow-add-column-with-default
     category: STATEMENT
     engineList:
       - POSTGRES
-    componentList: []
   - type: statement.add-check-not-valid
     category: STATEMENT
     engineList:
       - POSTGRES
-    componentList: []
   - type: statement.disallow-add-not-null
     category: STATEMENT
     engineList:
       - POSTGRES
-    componentList: []
   - type: statement.select-full-table-scan
     category: STATEMENT
     engineList:
       - MYSQL
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: statement.create-specify-schema
     category: STATEMENT
     engineList:
       - POSTGRES
-    componentList: []
   - type: statement.check-set-role-variable
     category: STATEMENT
     engineList:
       - POSTGRES
-    componentList: []
   - type: statement.disallow-using-temporary
     category: STATEMENT
     engineList:
       - MYSQL
-    componentList: []
   - type: statement.disallow-using-filesort
     category: STATEMENT
     engineList:
       - MYSQL
-    componentList: []
   - type: statement.where.no-equal-null
     category: STATEMENT
     engineList:
       - MYSQL
-    componentList: []
   - type: statement.where.disallow-using-function
     category: STATEMENT
     engineList:
       - MYSQL
-    componentList: []
   - type: statement.where.statement.query.minimum-plan-level
     category: STATEMENT
     engineList:
@@ -336,17 +297,14 @@ ruleList:
     category: STATEMENT
     engineList:
       - MYSQL
-    componentList: []
   - type: statement.disallow-mix-dml
     category: STATEMENT
     engineList:
       - MYSQL
-    componentList: []
   - type: statement.disallow-mix-ddl-dml
     category: STATEMENT
     engineList:
       - MYSQL
-    componentList: []
   - type: naming.table
     category: NAMING
     engineList:
@@ -486,7 +444,6 @@ ruleList:
       - OCEANBASE_ORACLE
       - SNOWFLAKE
       - MSSQL
-    componentList: []
   - type: naming.identifier.no-keyword
     category: NAMING
     engineList:
@@ -495,7 +452,6 @@ ruleList:
       - SNOWFLAKE
       - MSSQL
       - MYSQL
-    componentList: []
   - type: naming.identifier.case
     category: NAMING
     engineList:
@@ -560,7 +516,6 @@ ruleList:
       - SNOWFLAKE
       - MSSQL
       - MARIADB
-    componentList: []
   - type: column.disallow-change-type
     category: COLUMN
     engineList:
@@ -569,7 +524,6 @@ ruleList:
       - POSTGRES
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.set-default-for-not-null
     category: COLUMN
     engineList:
@@ -579,7 +533,6 @@ ruleList:
       - OCEANBASE_ORACLE
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.disallow-change
     category: COLUMN
     engineList:
@@ -587,7 +540,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.disallow-changing-order
     category: COLUMN
     engineList:
@@ -595,7 +547,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.disallow-drop-in-index
     category: COLUMN
     engineList:
@@ -603,7 +554,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.comment
     category: COLUMN
     engineList:
@@ -627,7 +577,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.type-disallow-list
     category: COLUMN
     engineList:
@@ -650,7 +599,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.maximum-character-length
     category: COLUMN
     engineList:
@@ -700,7 +648,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.current-time-count-limit
     category: COLUMN
     engineList:
@@ -708,7 +655,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: column.require-default
     category: COLUMN
     engineList:
@@ -719,7 +665,6 @@ ruleList:
       - OCEANBASE_ORACLE
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: schema.backward-compatibility
     category: SCHEMA
     engineList:
@@ -730,7 +675,6 @@ ruleList:
       - SNOWFLAKE
       - MSSQL
       - MARIADB
-    componentList: []
   - type: database.drop-empty-database
     category: DATABASE
     engineList:
@@ -738,7 +682,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: index.no-duplicate-column
     category: INDEX
     engineList:
@@ -747,7 +690,6 @@ ruleList:
       - POSTGRES
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: index.key-number-limit
     category: INDEX
     engineList:
@@ -770,7 +712,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: index.type-no-blob
     category: INDEX
     engineList:
@@ -778,7 +719,6 @@ ruleList:
       - TIDB
       - OCEANBASE
       - MARIADB
-    componentList: []
   - type: index.total-number-limit
     category: INDEX
     engineList:
@@ -808,7 +748,6 @@ ruleList:
     category: INDEX
     engineList:
       - POSTGRES
-    componentList: []
   - type: index.type-allow-list
     category: INDEX
     engineList:
@@ -857,22 +796,18 @@ ruleList:
     category: SYSTEM
     engineList:
       - MYSQL
-    componentList: []
   - type: system.event.disallow-create
     category: SYSTEM
     engineList:
       - MYSQL
-    componentList: []
   - type: system.view.disallow-create
     category: SYSTEM
     engineList:
       - MYSQL
-    componentList: []
   - type: system.function.disallow-create
     category: SYSTEM
     engineList:
       - MYSQL
-    componentList: []
   - type: system.function.disallowed-list
     category: SYSTEM
     engineList:


### PR DESCRIPTION
- Remove `RuleType` in the frontend. We only need to update the rule convert function if the rule has its custom payload.
- Remove `CategoryType` in the frontend.
- Remove `categoryList` in `sql-review-schema.yaml`, we can build it from the rule list.
- Don't need to add `componentList: []` in `sql-review-schema.yaml` if the rule doesn't have its custom payload.