### PR TITLE
fix(slow-query): use right end timestamp and sync slow query for all PG databases

### DIFF
--- a/backend/runner/slowquerysync/syncer.go
+++ b/backend/runner/slowquerysync/syncer.go
@@ -199,7 +199,7 @@ func (s *Syncer) syncPostgreSQLSlowQuery(ctx context.Context, instance *store.In
 	latestLogDate = latestLogDate.Truncate(24 * time.Hour)
 	nextLogDate := latestLogDate.AddDate(0, 0, 1)
 
-	for _, database := range enabledDatabases {
+	for _, database := range databases {
 		statistics, exists := logMap[database.DatabaseName]
 		if !exists {
 			continue

--- a/frontend/src/components/SlowQuery/Panel/types.ts
+++ b/frontend/src/components/SlowQuery/Panel/types.ts
@@ -35,11 +35,11 @@ export const buildListSlowQueriesRequest = (
     query.push(`project = "projects/${project}"`);
   }
   if (fromTime) {
-    const start = dayjs(fromTime).format("YYYY-MM-DDT00:00:00.000Z");
+    const start = dayjs(fromTime).toISOString();
     query.push(`start_time >= "${start}"`);
   }
   if (toTime) {
-    const end = dayjs(toTime).format("YYYY-MM-DDT00:00:00.000Z");
+    const end = dayjs(toTime).toISOString();
     query.push(`start_time <= "${end}"`);
   }
   if (query.length > 0) {


### PR DESCRIPTION
<img width="2483" alt="image" src="https://github.com/bytebase/bytebase/assets/20775801/06217fe0-b7aa-4f22-8595-fe178d4d4750">
