### PR TITLE
chore(frontend): introduce a way to override body layout style

### DIFF
--- a/frontend/src/components/SensitiveData/GlobalMaskingRulesView.vue
+++ b/frontend/src/components/SensitiveData/GlobalMaskingRulesView.vue
@@ -110,6 +110,7 @@ import type { SelectOption } from "naive-ui";
 import { v4 as uuidv4 } from "uuid";
 import { computed, reactive, nextTick, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
+import { useBodyLayoutContext } from "@/layouts/common";
 import { Factor } from "@/plugins/cel";
 import {
   featureToRef,
@@ -160,6 +161,7 @@ const hasPermission = computed(() => {
   return hasWorkspacePermissionV2(currentUser.value, "bb.policies.update");
 });
 const hasSensitiveDataFeature = featureToRef("bb.feature.sensitive-data");
+const { mainContainerRef } = useBodyLayoutContext();
 
 const updateList = async () => {
   const policy = await policyStore.getOrFetchPolicyByParentAndType({
@@ -193,8 +195,7 @@ const addNewRule = () => {
     }),
   });
   nextTick(() => {
-    const elem = document.querySelector("#bb-layout-main");
-    elem?.scrollTo(
+    mainContainerRef.value?.scrollTo(
       0,
       document.body.scrollHeight || document.documentElement.scrollHeight
     );

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -194,7 +194,12 @@
         </HideInStandaloneMode>
 
         <!-- This area may scroll -->
-        <div id="bb-layout-main" class="md:min-w-0 flex-1 overflow-y-auto py-4">
+        <div
+          id="bb-layout-main"
+          ref="mainContainerRef"
+          class="md:min-w-0 flex-1 overflow-y-auto py-4"
+          :class="mainContainerClasses"
+        >
           <HideInStandaloneMode>
             <div class="w-full mx-auto md:flex">
               <div class="md:min-w-0 md:flex-1">
@@ -235,7 +240,7 @@
 
 <script lang="ts" setup>
 import { storeToRefs } from "pinia";
-import { computed, reactive } from "vue";
+import { computed, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import HideInStandaloneMode from "@/components/misc/HideInStandaloneMode.vue";
 import {
@@ -249,6 +254,7 @@ import { hasWorkspacePermissionV2 } from "@/utils";
 import DashboardHeader from "@/views/DashboardHeader.vue";
 import QuickActionPanel from "../components/QuickActionPanel.vue";
 import Quickstart from "../components/Quickstart.vue";
+import { provideBodyLayoutContext } from "./common";
 
 interface LocalState {
   showMobileOverlay: boolean;
@@ -267,6 +273,7 @@ const state = reactive<LocalState>({
 });
 
 const currentUserV1 = useCurrentUserV1();
+const mainContainerRef = ref<HTMLDivElement>();
 
 const hasPermission = hasWorkspacePermissionV2(
   currentUserV1.value,
@@ -337,5 +344,9 @@ const currentPlan = computed((): string => {
 const isFreePlan = computed((): boolean => {
   const plan = subscriptionStore.currentPlan;
   return plan === PlanType.FREE;
+});
+
+const { mainContainerClasses } = provideBodyLayoutContext({
+  mainContainerRef,
 });
 </script>

--- a/frontend/src/layouts/common.ts
+++ b/frontend/src/layouts/common.ts
@@ -1,0 +1,30 @@
+import { type InjectionKey, type Ref, inject, provide } from "vue";
+import { useClassStack } from "@/utils";
+
+export type BodyLayoutContext = ReturnType<typeof provideBodyLayoutContext>;
+
+const BODY_LAYOUT_CONTEXT_KEY = Symbol(
+  "bb.body-layout.context"
+) as InjectionKey<BodyLayoutContext>;
+
+export const provideBodyLayoutContext = (params: {
+  mainContainerRef: Ref<HTMLDivElement | undefined>;
+}) => {
+  const {
+    classes: mainContainerClasses,
+    override: overrideMainContainerClass,
+  } = useClassStack();
+
+  const context = {
+    ...params,
+    overrideMainContainerClass,
+    mainContainerClasses,
+  };
+  provide(BODY_LAYOUT_CONTEXT_KEY, context);
+
+  return context;
+};
+
+export const useBodyLayoutContext = () => {
+  return inject(BODY_LAYOUT_CONTEXT_KEY)!;
+};

--- a/frontend/src/views/project/ProjectIssueDetail.vue
+++ b/frontend/src/views/project/ProjectIssueDetail.vue
@@ -27,6 +27,7 @@ import {
   useBaseIssueContext,
   useInitializeIssue,
 } from "@/components/IssueV1";
+import { useBodyLayoutContext } from "@/layouts/common";
 import { useUIStateStore } from "@/store";
 import { UNKNOWN_ID } from "@/types";
 import { isGrantRequestIssue } from "@/utils";
@@ -73,6 +74,10 @@ provideIssueContext(
   },
   true /* root */
 );
+
+const { overrideMainContainerClass } = useBodyLayoutContext();
+
+overrideMainContainerClass("!py-0");
 
 onMounted(() => {
   if (!uiStateStore.getIntroStateByKey("issue.visit")) {


### PR DESCRIPTION
### Before
<img width="1200" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/c0223038-55ec-4d8d-80b8-a904290744e3">

### After
<img width="1131" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/3ce87744-950b-4e69-8a21-73199499718e">

