### PR TITLE
feat: get design schema for mysql views

### DIFF
--- a/backend/plugin/parser/mysql/equal.go
+++ b/backend/plugin/parser/mysql/equal.go
@@ -1,0 +1,67 @@
+package mysql
+
+import (
+	"github.com/antlr4-go/antlr/v4"
+	parser "github.com/bytebase/mysql-parser"
+	"github.com/pkg/errors"
+)
+
+// IsViewTailEqual returns true if the two view tails are equal.
+func IsViewTailEqual(a, b parser.IViewTailContext) bool {
+	return a.GetText() == b.GetText()
+}
+
+type isViewTailEqualViewStmtListener struct {
+	*parser.BaseMySQLParserListener
+
+	target parser.IViewTailContext
+	equal  bool
+	err    error
+}
+
+func (l *isViewTailEqualViewStmtListener) EnterCreateView(ctx *parser.CreateViewContext) {
+	if l.err != nil {
+		return
+	}
+	p := ctx.GetParent()
+	if _, ok := p.(*parser.CreateStatementContext); !ok {
+		l.err = errors.New("Expecting CreateStatementContext as parent")
+		return
+	}
+	pp := p.GetParent()
+	if _, ok := pp.(*parser.SimpleStatementContext); !ok {
+		l.err = errors.New("Expecting SimpleStatementContext as parent")
+		return
+	}
+	ppp := pp.GetParent()
+	if _, ok := ppp.(*parser.QueryContext); !ok {
+		l.err = errors.New("Expecting QueryContext as parent")
+		return
+	}
+
+	if IsViewTailEqual(l.target, ctx.ViewTail()) {
+		l.equal = true
+	}
+}
+
+// IsViewTailEqualViewStmt returns true if the view tail is equal to the view statement.
+func IsViewTailEqualViewStmt(a parser.IViewTailContext, b string) (bool, error) {
+	parseResults, err := ParseMySQL(b)
+	if err != nil {
+		return false, err
+	}
+	if len(parseResults) != 1 {
+		return false, errors.Errorf("Expecting one statement, but got %d", len(parseResults))
+	}
+
+	stmt := parseResults[0]
+	listener := &isViewTailEqualViewStmtListener{
+		target: a,
+	}
+	antlr.ParseTreeWalkerDefault.Walk(listener, stmt.Tree)
+	if listener.err != nil {
+		return false, listener.err
+	}
+
+	return listener.equal, nil
+}

--- a/backend/plugin/parser/mysql/normalize.go
+++ b/backend/plugin/parser/mysql/normalize.go
@@ -145,6 +145,16 @@ func NormalizeMySQLIdentifierList(ctx parser.IIdentifierListContext) []string {
 	return result
 }
 
+func NormalizeMySQLViewRef(ctx parser.IViewRefContext) (string, string) {
+	if ctx.QualifiedIdentifier() != nil {
+		return normalizeMySQLQualifiedIdentifier(ctx.QualifiedIdentifier())
+	}
+	if ctx.DotIdentifier() != nil {
+		return "", NormalizeMySQLIdentifier(ctx.DotIdentifier().Identifier())
+	}
+	return "", ""
+}
+
 // NormalizeMySQLViewName normalizes the given view name.
 func NormalizeMySQLViewName(ctx parser.IViewNameContext) (string, string) {
 	if ctx.QualifiedIdentifier() != nil {

--- a/backend/plugin/schema/mysql/get_design_schema_test.go
+++ b/backend/plugin/schema/mysql/get_design_schema_test.go
@@ -13,30 +13,50 @@ import (
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
 
-func TestGetDesignSchema(t *testing.T) {
-	type designTest struct {
-		Description string
-		Baseline    string
-		Target      string
-		Result      string
+func TestGetDesignSchema_Debug(t *testing.T) {
+	if true {
+		t.Skip()
 	}
 
-	const (
-		record = false
-	)
-	var (
-		filepaths = []string{
-			"testdata/get-design-schema/get_design_schema.yaml",
-			"testdata/get-design-schema/partition/range.yaml",
-			"testdata/get-design-schema/partition/list.yaml",
-			"testdata/get-design-schema/partition/hash.yaml",
-			"testdata/get-design-schema/partition/key.yaml",
-			"testdata/get-design-schema/partition/write-default.yaml",
-			"testdata/get-design-schema/partition/keep-algorithm.yaml",
-			"testdata/get-design-schema/partition/keep-version-comment.yaml",
-		}
-	)
+	TestGetDesignSchema_Basic(t)
+	TestGetDesignSchema_Partition(t)
+	TestGetDesignSchema_View(t)
+}
 
+func TestGetDesignSchema_Basic(t *testing.T) {
+	testGetDesignSchema(t, []string{
+		"testdata/get-design-schema/get_design_schema.yaml",
+	}, false)
+}
+
+func TestGetDesignSchema_Partition(t *testing.T) {
+	testGetDesignSchema(t, []string{
+		"testdata/get-design-schema/partition/range.yaml",
+		"testdata/get-design-schema/partition/list.yaml",
+		"testdata/get-design-schema/partition/hash.yaml",
+		"testdata/get-design-schema/partition/key.yaml",
+		"testdata/get-design-schema/partition/write-default.yaml",
+		"testdata/get-design-schema/partition/keep-algorithm.yaml",
+		"testdata/get-design-schema/partition/keep-version-comment.yaml",
+	}, false)
+}
+
+func TestGetDesignSchema_View(t *testing.T) {
+	testGetDesignSchema(t, []string{
+		"testdata/get-design-schema/view/add-new-view.yaml",
+		"testdata/get-design-schema/view/drop-view.yaml",
+		"testdata/get-design-schema/view/modify-view.yaml",
+	}, false)
+}
+
+type designTest struct {
+	Description string
+	Baseline    string
+	Target      string
+	Result      string
+}
+
+func testGetDesignSchema(t *testing.T, filepaths []string, writeback bool) {
 	a := require.New(t)
 	for _, filepath := range filepaths {
 		yamlFile, err := os.Open(filepath)
@@ -58,14 +78,14 @@ func TestGetDesignSchema(t *testing.T) {
 			_, err = parser.ParseMySQL(result)
 			a.NoErrorf(err, "[%s] test case %d: %s\n content:\n%s", filepath, i, t.Description, result)
 
-			if record {
+			if writeback {
 				tests[i].Result = result
 			} else {
 				a.Equalf(t.Result, result, "[%s] test case %d: %s", filepath, i, t.Description)
 			}
 		}
 
-		if record {
+		if writeback {
 			byteValue, err := yaml.Marshal(tests)
 			a.NoError(err)
 			err = os.WriteFile(filepath, byteValue, 0644)

--- a/backend/plugin/schema/mysql/testdata/get-design-schema/view/add-new-view.yaml
+++ b/backend/plugin/schema/mysql/testdata/get-design-schema/view/add-new-view.yaml
@@ -1,0 +1,166 @@
+- description: Add new view in schema with view
+  baseline: |-
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Temporary view structure for `v1`
+    --
+    CREATE VIEW `v1` AS SELECT
+      1 AS `id`;
+
+
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v1`;
+    --
+    -- View structure for `v1`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v1` AS select `t`.`id` AS `id` from `t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+  target: |-
+    {
+      "name": "test_view",
+      "schemas": [
+        {
+          "views": [
+            {
+              "name": "v1",
+              "comment": "VIEW",
+              "definition": "select `t`.`id` AS `id` from `t`"
+            },
+            {
+              "name": "v2",
+              "comment": "VIEW",
+              "definition": "select (`t`.`id` + 1) AS `id + 1` from `t`"
+            }
+          ],
+          "tables": [
+            {
+              "name": "t",
+              "engine": "InnoDB",
+              "columns": [
+                {
+                  "name": "id",
+                  "type": "int",
+                  "nullable": true,
+                  "position": 1,
+                  "defaultNull": true
+                }
+              ],
+              "dataSize": "16384",
+              "collation": "utf8mb4_0900_ai_ci"
+            }
+          ]
+        }
+      ],
+      "collation": "utf8mb4_0900_ai_ci",
+      "characterSet": "utf8mb4"
+    }
+  result: |
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Temporary view structure for `v1`
+    --
+    CREATE VIEW `v1` AS SELECT
+      1 AS `id`;
+
+
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v1`;
+    --
+    -- View structure for `v1`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v1` AS select `t`.`id` AS `id` from `t`;
+
+    DROP VIEW IF EXISTS `v2`;
+    --
+    -- View structure for `v2`
+    --
+    CREATE VIEW `v2` AS select (`t`.`id` + 1) AS `id + 1` from `t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+- description: Add new view in schema without views
+  baseline: |-
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `qty` int DEFAULT NULL,
+      `price` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+  target: |-
+    {
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t",
+              "engine": "InnoDB",
+              "columns": [
+                {
+                  "name": "qty",
+                  "type": "int",
+                  "nullable": true,
+                  "position": 1,
+                  "defaultNull": true
+                },
+                {
+                  "name": "price",
+                  "type": "int",
+                  "nullable": true,
+                  "position": 2,
+                  "defaultNull": true
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci"
+            }
+          ],
+          "views": [
+            {
+              "name": "v",
+              "comment": "VIEW",
+              "definition": "select * from `test_view`.`t`"
+            }
+          ]
+        }
+      ]
+    }
+  result: |
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `qty` int DEFAULT NULL,
+      `price` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v`;
+    --
+    -- View structure for `v`
+    --
+    CREATE VIEW `v` AS select * from `test_view`.`t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/backend/plugin/schema/mysql/testdata/get-design-schema/view/drop-view.yaml
+++ b/backend/plugin/schema/mysql/testdata/get-design-schema/view/drop-view.yaml
@@ -1,0 +1,176 @@
+- description: Drop view in schema with multiple views
+  baseline: |-
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Temporary view structure for `v1`
+    --
+    CREATE VIEW `v1` AS SELECT
+      1 AS `id`;
+
+
+    --
+    -- Temporary view structure for `v2`
+    --
+    CREATE VIEW `v2` AS SELECT
+      1 AS `id + 1`;
+
+
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v1`;
+    --
+    -- View structure for `v1`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v1` AS select `t`.`id` AS `id` from `t`;
+
+    DROP VIEW IF EXISTS `v2`;
+    --
+    -- View structure for `v2`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v2` AS select (`t`.`id` + 1) AS `id + 1` from `t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+  target: |-
+    {
+      "name": "test_view",
+      "schemas": [
+        {
+          "views": [
+            {
+              "name": "v1",
+              "comment": "VIEW",
+              "definition": "select `t`.`id` AS `id` from `t`"
+            }
+          ],
+          "tables": [
+            {
+              "name": "t",
+              "engine": "InnoDB",
+              "columns": [
+                {
+                  "name": "id",
+                  "type": "int",
+                  "nullable": true,
+                  "position": 1,
+                  "defaultNull": true
+                }
+              ],
+              "dataSize": "16384",
+              "collation": "utf8mb4_0900_ai_ci"
+            }
+          ]
+        }
+      ],
+      "collation": "utf8mb4_0900_ai_ci",
+      "characterSet": "utf8mb4"
+    }
+  result: |
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Temporary view structure for `v1`
+    --
+    CREATE VIEW `v1` AS SELECT
+      1 AS `id`;
+
+
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v1`;
+    --
+    -- View structure for `v1`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v1` AS select `t`.`id` AS `id` from `t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+- description: Drop all views
+  baseline: |-
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Temporary view structure for `v1`
+    --
+    CREATE VIEW `v1` AS SELECT
+      1 AS `id`;
+
+
+    --
+    -- Temporary view structure for `v2`
+    --
+    CREATE VIEW `v2` AS SELECT
+      1 AS `id + 1`;
+
+
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v1`;
+    --
+    -- View structure for `v1`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v1` AS select `t`.`id` AS `id` from `t`;
+
+    DROP VIEW IF EXISTS `v2`;
+    --
+    -- View structure for `v2`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v2` AS select (`t`.`id` + 1) AS `id + 1` from `t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+  target: |-
+    {
+      "name": "test_view",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t",
+              "engine": "InnoDB",
+              "columns": [
+                {
+                  "name": "id",
+                  "type": "int",
+                  "nullable": true,
+                  "position": 1,
+                  "defaultNull": true
+                }
+              ],
+              "dataSize": "16384",
+              "collation": "utf8mb4_0900_ai_ci"
+            }
+          ]
+        }
+      ],
+      "collation": "utf8mb4_0900_ai_ci",
+      "characterSet": "utf8mb4"
+    }
+  result: |
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/backend/plugin/schema/mysql/testdata/get-design-schema/view/modify-view.yaml
+++ b/backend/plugin/schema/mysql/testdata/get-design-schema/view/modify-view.yaml
@@ -1,0 +1,102 @@
+- description: Modify views
+  baseline: |-
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Temporary view structure for `v1`
+    --
+    CREATE VIEW `v1` AS SELECT
+      1 AS `id`;
+
+
+    --
+    -- Temporary view structure for `v2`
+    --
+    CREATE VIEW `v2` AS SELECT
+      1 AS `id + 1`;
+
+
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v1`;
+    --
+    -- View structure for `v1`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v1` AS select `t`.`id` AS `id` from `t`;
+
+    DROP VIEW IF EXISTS `v2`;
+    --
+    -- View structure for `v2`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v2` AS select (`t`.`id` + 1) AS `id + 1` from `t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+  target: |-
+    {
+      "name": "test_view",
+      "schemas": [
+        {
+          "views": [
+            {
+              "name": "v1",
+              "comment": "VIEW",
+              "definition": "select `t`.`id` + 20 AS `id` from `t`"
+            },
+            {
+              "name": "v2",
+              "comment": "VIEW",
+              "definition": "select (`t`.`id` + 30) AS `id + 30` from `t`"
+            }
+          ],
+          "tables": [
+            {
+              "name": "t",
+              "engine": "InnoDB",
+              "columns": [
+                {
+                  "name": "id",
+                  "type": "int",
+                  "nullable": true,
+                  "position": 1,
+                  "defaultNull": true
+                }
+              ],
+              "dataSize": "16384",
+              "collation": "utf8mb4_0900_ai_ci"
+            }
+          ]
+        }
+      ],
+      "collation": "utf8mb4_0900_ai_ci",
+      "characterSet": "utf8mb4"
+    }
+  result: |
+    SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+    SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+    --
+    -- Table structure for `t`
+    --
+    CREATE TABLE `t` (
+      `id` int DEFAULT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    DROP VIEW IF EXISTS `v1`;
+    --
+    -- View structure for `v1`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v1` AS select `t`.`id` + 20 AS `id` from `t`;
+
+    DROP VIEW IF EXISTS `v2`;
+    --
+    -- View structure for `v2`
+    --
+    CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v2` AS select (`t`.`id` + 30) AS `id + 30` from `t`;
+
+    SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+    SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;


### PR DESCRIPTION
1. Reconcile the view def in dump and view.Definition proto field. We use dump format to trim all the leading database field in identifiers. (i.e. select \`db\`.\`table\`.\`column\` to select \`table\`.\`column\`)
2. Our dump contains temporary view definition to avoid causes view dependency error while applying the dump. But it's not-worth for us the depend query-span to get all the fields name to generate the temporary views. So we follow the strategies below:
- If user do not modify the view, we keep the temporary view.
- If user modified the view, we drop the temporary view, and rewrite the "true" view.
- If user drop view, we drop the temporary view.
- If user add view, we do not generate the temporary view.