### PR TITLE
fix: return the right syntax error line for MySQL and TiDB

### DIFF
--- a/backend/plugin/parser/base/base.go
+++ b/backend/plugin/parser/base/base.go
@@ -42,7 +42,8 @@ func (e *SyntaxError) Error() string {
 
 // ParseErrorListener is a custom error listener for PLSQL parser.
 type ParseErrorListener struct {
-	Err *SyntaxError
+	BaseLine int
+	Err      *SyntaxError
 }
 
 // SyntaxError returns the errors.
@@ -62,9 +63,9 @@ func (l *ParseErrorListener) SyntaxError(_ antlr.Recognizer, token any, line, co
 			errMessage = fmt.Sprintf("related text: %s", stream.GetTextFromInterval(antlr.NewInterval(start, stop)))
 		}
 		l.Err = &SyntaxError{
-			Line:    line,
+			Line:    line + l.BaseLine,
 			Column:  column,
-			Message: fmt.Sprintf("Syntax error at line %d:%d \n%s", line, column, errMessage),
+			Message: fmt.Sprintf("Syntax error at line %d:%d \n%s", line+l.BaseLine, column, errMessage),
 		}
 	}
 }

--- a/backend/plugin/parser/mysql/mysql.go
+++ b/backend/plugin/parser/mysql/mysql.go
@@ -141,18 +141,22 @@ func RestoreDelimiter(statement string) (string, error) {
 	return result.String(), nil
 }
 
-func parseSingleStatement(statement string) (antlr.Tree, *antlr.CommonTokenStream, error) {
+func parseSingleStatement(baseLine int, statement string) (antlr.Tree, *antlr.CommonTokenStream, error) {
 	input := antlr.NewInputStream(statement)
 	lexer := parser.NewMySQLLexer(input)
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 
 	p := parser.NewMySQLParser(stream)
 
-	lexerErrorListener := &base.ParseErrorListener{}
+	lexerErrorListener := &base.ParseErrorListener{
+		BaseLine: baseLine,
+	}
 	lexer.RemoveErrorListeners()
 	lexer.AddErrorListener(lexerErrorListener)
 
-	parserErrorListener := &base.ParseErrorListener{}
+	parserErrorListener := &base.ParseErrorListener{
+		BaseLine: baseLine,
+	}
 	p.RemoveErrorListeners()
 	p.AddErrorListener(parserErrorListener)
 
@@ -216,8 +220,9 @@ func parseInputStream(input *antlr.InputStream) ([]*ParseResult, error) {
 		list[len(list)-1].Text = mysqlAddSemicolonIfNeeded(list[len(list)-1].Text)
 	}
 
+	baseLine := 0
 	for _, s := range list {
-		tree, tokens, err := parseSingleStatement(s.Text)
+		tree, tokens, err := parseSingleStatement(baseLine, s.Text)
 		if err != nil {
 			return nil, err
 		}
@@ -231,6 +236,7 @@ func parseInputStream(input *antlr.InputStream) ([]*ParseResult, error) {
 			Tokens:   tokens,
 			BaseLine: s.BaseLine,
 		})
+		baseLine = s.LastLine
 	}
 
 	return result, nil


### PR DESCRIPTION
close BYT-5170
<img width="1631" alt="image" src="https://github.com/bytebase/bytebase/assets/20775801/78472b8a-08f6-4b03-aa2a-550364762fa3">
<img width="1224" alt="image" src="https://github.com/bytebase/bytebase/assets/20775801/99b5a1b1-615d-4648-a8a4-ae2ac22e8a6d">
