### PR TITLE
chore(frontend): use local timezone for change rollout time activity

### DIFF
--- a/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActionSentence.vue
+++ b/frontend/src/components/IssueV1/components/ActivitySection/Activity/ActionSentence.vue
@@ -295,13 +295,14 @@ const renderActionSentence = () => {
       ) as ActivityTaskEarliestAllowedTimeUpdatePayload;
       const newVal = payload.newEarliestAllowedTs;
       const oldVal = payload.oldEarliestAllowedTs;
+      const timeFormat = "YYYY-MM-DD HH:mm:ss UTCZZ";
       return h(
         "span",
         {},
         t("activity.sentence.changed-from-to", {
           name: t("task.rollout-time"),
-          oldValue: oldVal ? dayjs(oldVal * 1000) : "Unset",
-          newValue: newVal ? dayjs(newVal * 1000) : "Unset",
+          oldValue: oldVal ? dayjs(oldVal * 1000).format(timeFormat) : "Unset",
+          newValue: newVal ? dayjs(newVal * 1000).format(timeFormat) : "Unset",
         })
       );
     }


### PR DESCRIPTION
<img width="804" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/8cd2ceac-5cb0-4347-af16-5798cd63278e">
