### PR TITLE
chore: update rollout permission checks

### DIFF
--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -1546,7 +1546,12 @@ func (s *RolloutService) createPipeline(ctx context.Context, project *store.Proj
 
 // canUserRunStageTasks returns if a user can run the tasks in a stage.
 func canUserRunStageTasks(ctx context.Context, s *store.Store, user *store.UserMessage, issue *store.IssueMessage, stageEnvironmentID int) (bool, error) {
-	// the workspace owner and DBA roles can always run tasks.
+	// For data export issues, only the creator can run tasks.
+	if issue.Type == api.IssueDatabaseDataExport {
+		return issue.Creator.ID == user.ID, nil
+	}
+
+	// The workspace owner and DBA roles can always run tasks.
 	if slices.Contains(user.Roles, api.WorkspaceAdmin) || slices.Contains(user.Roles, api.WorkspaceDBA) {
 		return true, nil
 	}

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -415,7 +415,7 @@ func (s *Store) ListTasksToAutoRollout(ctx context.Context, environmentIDs []int
 		(SELECT 1 AS e FROM task_run WHERE task_run.task_id = task.id LIMIT 1) task_run
 		ON TRUE
 	WHERE task_run.e IS NULL
-	AND issue.type != 'bb.issue.database.data-export'
+	AND task.type != 'bb.task.database.data.export'
 	AND COALESCE((task.payload->>'skipped')::BOOLEAN, FALSE) IS FALSE
 	AND COALESCE(issue.status, 'OPEN') = 'OPEN'
 	AND stage.environment_id = ANY($1)

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -399,7 +399,8 @@ func (s *Store) BatchSkipTasks(ctx context.Context, taskUIDs []int, comment stri
 // 2. are not skipped
 // 3. are associated with an open issue or no issue
 // 4. are in an environment that has auto rollout enabled
-// 5. are in the stage that is the first among the selected stages in the pipeline.
+// 5. are in the stage that is the first among the selected stages in the pipeline
+// 6. are not data export tasks.
 func (s *Store) ListTasksToAutoRollout(ctx context.Context, environmentIDs []int) ([]int, error) {
 	rows, err := s.db.db.QueryContext(ctx, `
 	SELECT
@@ -414,6 +415,7 @@ func (s *Store) ListTasksToAutoRollout(ctx context.Context, environmentIDs []int
 		(SELECT 1 AS e FROM task_run WHERE task_run.task_id = task.id LIMIT 1) task_run
 		ON TRUE
 	WHERE task_run.e IS NULL
+	AND issue.type != 'bb.issue.database.data-export'
 	AND COALESCE((task.payload->>'skipped')::BOOLEAN, FALSE) IS FALSE
 	AND COALESCE(issue.status, 'OPEN') = 'OPEN'
 	AND stage.environment_id = ANY($1)

--- a/frontend/src/components/IssueV1/logic/action/task.ts
+++ b/frontend/src/components/IssueV1/logic/action/task.ts
@@ -1,9 +1,10 @@
 import type { ButtonProps } from "naive-ui";
 import { t } from "@/plugins/i18n";
+import { userNamePrefix } from "@/store/modules/v1/common";
 import type { ComposedIssue } from "@/types";
 import { PresetRoleType } from "@/types";
 import type { User } from "@/types/proto/v1/auth_service";
-import { IssueStatus } from "@/types/proto/v1/issue_service";
+import { IssueStatus, Issue_Type } from "@/types/proto/v1/issue_service";
 import type { Task } from "@/types/proto/v1/rollout_service";
 import { Task_Status, Task_Type } from "@/types/proto/v1/rollout_service";
 
@@ -131,6 +132,11 @@ export const allowUserToApplyTaskRolloutAction = (
   action: TaskRolloutAction,
   releaserCandidates: User[]
 ) => {
+  // For data export issues, only the creator can take actions.
+  if (issue.type === Issue_Type.DATABASE_DATA_EXPORT) {
+    return issue.creator === `${userNamePrefix}${user.email}`;
+  }
+
   // Special for workspace admins and DBAs
   // Still using role-based permission checks
   if (


### PR DESCRIPTION
For data export issues, only creators are allowed to perform rollout action.