### PR TITLE
feat: automate i18n translation via Google Translate API

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,6 +5,7 @@ node_modules
 components.d.ts
 
 # local env files
+.env.i18n
 .env.local
 .env.*.local
 

--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -1,0 +1,178 @@
+import { config } from "dotenv";
+import { promises as fs } from "fs";
+import { basename } from "path";
+
+// Create a file .env.i18n and add
+// GOOGLE_TRANSLATE_API_KEY=xxxx
+config({ path: "./.env.i18n" });
+
+// Replace 'YOUR_API_KEY' with your actual Google Cloud API key
+const apiKey = process.env.GOOGLE_TRANSLATE_API_KEY;
+const url = `https://translation.googleapis.com/language/translate/v2?key=${apiKey}`;
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | { [key: string]: JsonValue }
+  | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+type JsonArray = Array<JsonValue>;
+
+const SOURCE_LANG = "en-US";
+
+const TARGET_LANGS = ["es-ES", "ja-JP", "vi-VN", "zh-CN"];
+
+// Function to translate text using Google Cloud Translation API
+async function translateText(
+  text: string,
+  targetLang: string,
+  sourceLang: string = "en"
+): Promise<string> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      q: text,
+      target: targetLang,
+      source: sourceLang,
+      format: "text",
+    }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      `Google Cloud Translation API Error: ${data.error?.message || "Unknown error"}\nPlease create .env.i18n locally and set GOOGLE_TRANSLATE_API_KEY=xxx.`
+    );
+  }
+
+  return data.data.translations[0].translatedText;
+}
+
+// Function specifically for JsonObject translation
+async function translateJsonObject(
+  obj: JsonObject,
+  targetLang: string
+): Promise<JsonObject> {
+  const result: JsonObject = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = await translateJsonValue(value, targetLang);
+  }
+
+  return result;
+}
+
+// Function to process and translate any JsonValue
+async function translateJsonValue(
+  value: JsonValue,
+  targetLang: string
+): Promise<JsonValue> {
+  if (typeof value === "string") {
+    // Translate string values
+    return await translateText(value, targetLang);
+  } else if (Array.isArray(value)) {
+    // Recursively handle arrays
+    const result: JsonArray = [];
+    for (const item of value) {
+      result.push(await translateJsonValue(item, targetLang));
+    }
+    return result;
+  } else if (typeof value === "object" && value !== null) {
+    // Recursively handle objects
+    return await translateJsonObject(value, targetLang);
+  } else {
+    // Return other types (numbers, booleans, etc.) directly
+    return value;
+  }
+}
+
+async function loadJsonFile(filePath: string): Promise<any> {
+  try {
+    const data = await fs.readFile(filePath, "utf8");
+    return JSON.parse(data);
+  } catch (error) {
+    console.error(`Error reading file ${filePath}:`, error);
+    return null;
+  }
+}
+
+async function saveJsonFile(filePath: string, data: any): Promise<void> {
+  try {
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2), "utf8");
+    console.log(`Updated ${filePath}`);
+  } catch (error) {
+    console.error(`Error writing file ${filePath}:`, error);
+  }
+}
+
+async function addMissingKeysFromSource(
+  source: JsonObject,
+  target: JsonObject,
+  lang: string
+): Promise<JsonObject> {
+  const merged: JsonObject = {};
+  const keys = new Set([...Object.keys(source), ...Object.keys(target)]);
+
+  keys.forEach((key) => {
+    (async () => {
+      if (key in source && !(key in target)) {
+        // Key exists in source but not in target
+        merged[key] = await translateJsonValue(source[key], lang);
+      } else if (
+        key in source &&
+        key in target &&
+        typeof source[key] === "object" &&
+        !Array.isArray(source[key]) &&
+        typeof target[key] === "object" &&
+        !Array.isArray(target[key])
+      ) {
+        // Both have the key and its value is an object, merge recursively
+        merged[key] = await addMissingKeysFromSource(
+          source[key] as JsonObject,
+          target[key] as JsonObject,
+          lang
+        );
+      } else {
+        // Key exists in target or both, prefer target's value
+        merged[key] = target[key];
+      }
+    })();
+  });
+
+  return merged;
+}
+
+// Main function to load the source file and update each target file
+async function updateLocalizationFiles() {
+  const sourceData = await loadJsonFile(`src/locales/${SOURCE_LANG}.json`);
+  const sourceSQLReviewData = await loadJsonFile(
+    `src/locales/sql-review/${SOURCE_LANG}.json`
+  );
+
+  for (const lang of TARGET_LANGS) {
+    const langFile = `src/locales/${lang}.json`;
+    const targetData = await loadJsonFile(langFile);
+    const updatedData = await addMissingKeysFromSource(
+      sourceData,
+      targetData,
+      lang.split("-")[0]
+    );
+    await saveJsonFile(langFile, updatedData);
+
+    const langSQLReviewFile = `src/locales/sql-review/${lang}.json`;
+    const targetSQLReviewData = await loadJsonFile(langFile);
+    const updatedSQLReviewData = await addMissingKeysFromSource(
+      sourceSQLReviewData,
+      targetSQLReviewData,
+      lang.split("-")[0]
+    );
+    await saveJsonFile(langSQLReviewFile, updatedSQLReviewData);
+  }
+}
+
+updateLocalizationFiles().catch(console.error);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "type-check": "vue-tsc --build --force",
     "test": "vitest run --passWithNoTests",
     "coverage": "vitest --coverage",
-    "postinstall": "npm run copy:monaco-workers && monaco-treemending"
+    "postinstall": "npm run copy:monaco-workers && monaco-treemending",
+    "i18n": "ts-node i18n.ts"
   },
   "dependencies": {
     "@bytebase/vue-kbar": "0.1.8",
@@ -131,6 +132,7 @@
     "@vue/tsconfig": "0.5.1",
     "autoprefixer": "10.4.19",
     "code-inspector-plugin": "^0.11.0",
+    "dotenv": "^16.4.5",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
@@ -145,6 +147,7 @@
     "protobufjs": "^7.2.5",
     "rollup": "4.13.2",
     "tailwindcss": "3.4.3",
+    "ts-node": "^10.9.2",
     "ts-proto": "^1.165.1",
     "typescript": "5.4.3",
     "unplugin-icons": "0.18.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -337,6 +337,9 @@ devDependencies:
   code-inspector-plugin:
     specifier: ^0.11.0
     version: 0.11.0
+  dotenv:
+    specifier: ^16.4.5
+    version: 16.4.5
   eslint:
     specifier: 8.57.0
     version: 8.57.0
@@ -378,7 +381,10 @@ devDependencies:
     version: 4.13.2
   tailwindcss:
     specifier: 3.4.3
-    version: 3.4.3
+    version: 3.4.3(ts-node@10.9.2)
+  ts-node:
+    specifier: ^10.9.2
+    version: 10.9.2(@types/node@20.12.2)(typescript@5.4.3)
   ts-proto:
     specifier: ^1.165.1
     version: 1.171.0
@@ -933,6 +939,13 @@ packages:
       vscode: /@codingame/monaco-vscode-api@1.85.5
     dev: false
 
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
   /@css-render/plugin-bem@0.15.12(css-render@0.15.12):
     resolution: {integrity: sha512-Lq2jSOZn+wYQtsyaFj6QRz2EzAnd3iW5fZeHO1WSXQdVYwvwGX0ZiH3X2JQgtgYLT1yeGtrwrqJdNdMEUD2xTw==}
     peerDependencies:
@@ -1437,6 +1450,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /@juggle/resize-observer@3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: false
@@ -1696,7 +1716,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.3
+      tailwindcss: 3.4.3(ts-node@10.9.2)
     dev: true
 
   /@tailwindcss/typography@0.5.12(tailwindcss@3.4.3):
@@ -1708,7 +1728,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.3
+      tailwindcss: 3.4.3(ts-node@10.9.2)
     dev: true
 
   /@tanstack/table-core@8.15.3:
@@ -1745,6 +1765,22 @@ packages:
       prettier: 3.2.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@tsconfig/node10@1.0.11:
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
   /@tsconfig/node20@20.1.4:
@@ -2668,6 +2704,10 @@ packages:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
     dev: true
@@ -3072,6 +3112,10 @@ packages:
       parse-json: 5.2.0
       typescript: 5.4.3
     dev: false
+
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -3502,6 +3546,11 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
+
   /dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
     dev: false
@@ -3531,6 +3580,11 @@ packages:
   /dompurify@3.0.11:
     resolution: {integrity: sha512-Fan4uMuyB26gFV3ovPoEoQbxRRPfTu3CvImyZnhGq5fsIEO+gEFLp45ISFt+kQBWsK5ulDdT0oV28jS1UrwQLg==}
     dev: false
+
+  /dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+    dev: true
 
   /double-ended-queue@2.1.0-0:
     resolution: {integrity: sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==}
@@ -4812,6 +4866,10 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
   /markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
@@ -5505,7 +5563,7 @@ packages:
       postcss: 8.4.38
     dev: true
 
-  /postcss-load-config@4.0.2(postcss@8.4.38):
+  /postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -5519,6 +5577,7 @@ packages:
     dependencies:
       lilconfig: 3.0.0
       postcss: 8.4.38
+      ts-node: 10.9.2(@types/node@20.12.2)(typescript@5.4.3)
       yaml: 2.3.4
     dev: true
 
@@ -6267,7 +6326,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /tailwindcss@3.4.3:
+  /tailwindcss@3.4.3(ts-node@10.9.2):
     resolution: {integrity: sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -6289,7 +6348,7 @@ packages:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2)
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.0.16
       resolve: 1.22.8
@@ -6413,6 +6472,37 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
+  /ts-node@10.9.2(@types/node@20.12.2)(typescript@5.4.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.2
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
     dev: true
 
   /ts-poet@6.7.0:
@@ -6601,6 +6691,10 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
     dev: false
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
 
   /vdirs@0.1.8(vue@3.4.21):
     resolution: {integrity: sha512-H9V1zGRLQZg9b+GdMk8MXDN2Lva0zx72MPahDKc30v+DtwKjfyOSXWRIX4t2mhDubM1H09gPhWeth/BJWPHGUw==}
@@ -7174,6 +7268,11 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: true
 
   /yocto-queue@0.1.0:


### PR DESCRIPTION
# Environment setup

1. Create `.env.i18n` file under frontend/
1. Set GOOGLE_TRANSLATE_API_KEY=xxx in the file

# Translation

1. Add the key to en-US.json
1. Run `pnpm i18n`. It will call the google translate API to translate the text in other locales, and preserve the order
1. Manually inspect the translation, the translation API may go a bit far to translate the placeholder (which shouldn't be translated)
1. Start the frontend app to make sure it runs.