### PR TITLE
chore: update minHeight of markdown renderer

### DIFF
--- a/frontend/src/assets/css/github-markdown-style.css
+++ b/frontend/src/assets/css/github-markdown-style.css
@@ -518,7 +518,7 @@
   margin-top: 0 !important;
 }
 
-.markdown-body > *:last-child {
+.markdown-body > p:last-of-type {
   margin-bottom: 0 !important;
 }
 

--- a/frontend/src/components/MarkdownEditor/useRenderMarkdown.ts
+++ b/frontend/src/components/MarkdownEditor/useRenderMarkdown.ts
@@ -14,7 +14,7 @@ export type UseRenderMarkdownOptions = {
 };
 
 const defaultOptions = (): UseRenderMarkdownOptions => ({
-  minHeight: 48 /* 3rem */,
+  minHeight: 0, // Let the iframe shrink to fit the content.
   maxHeight: 192 /* 12rem */,
   placeholder: "",
 });

--- a/frontend/src/components/MarkdownEditor/useRenderMarkdown.ts
+++ b/frontend/src/components/MarkdownEditor/useRenderMarkdown.ts
@@ -14,7 +14,7 @@ export type UseRenderMarkdownOptions = {
 };
 
 const defaultOptions = (): UseRenderMarkdownOptions => ({
-  minHeight: 0, // Let the iframe shrink to fit the content.
+  minHeight: 24 /* 1 line */,
   maxHeight: 192 /* 12rem */,
   placeholder: "",
 });


### PR DESCRIPTION
### Before

![image](https://github.com/bytebase/bytebase/assets/24653555/3712fc9a-b1d8-4896-9765-d9f530b137be)

### After

<img width="802" alt="image" src="https://github.com/bytebase/bytebase/assets/24653555/dd402736-ccff-457e-81b6-ef5ee409fa8c">
