### PR TITLE
fix: chaos of metadata cache

### DIFF
--- a/frontend/src/components/ColumnDataTable/MaskingLevelCell.vue
+++ b/frontend/src/components/ColumnDataTable/MaskingLevelCell.vue
@@ -1,18 +1,20 @@
 <template>
   <div class="flex items-center">
     <span class="mr-2">
-      <template v-if="isColumnConfigMasking">
-        {{ maskingLevelText }}
-      </template>
-      <template v-else
-        >({{
+      {{ maskingLevelText }}
+      <span
+        v-if="
+          columnMasking.maskingLevel === MaskingLevel.MASKING_LEVEL_UNSPECIFIED
+        "
+      >
+        ({{
           $t(
             `settings.sensitive-data.masking-level.${maskingLevelToJSON(
               column.effectiveMaskingLevel
             ).toLowerCase()}`
           )
-        }})</template
-      >
+        }})
+      </span>
     </span>
     <NTooltip v-if="!isColumnConfigMasking">
       <template #trigger>

--- a/frontend/src/components/ColumnDataTable/SemanticTypeCell.vue
+++ b/frontend/src/components/ColumnDataTable/SemanticTypeCell.vue
@@ -53,6 +53,7 @@ import {
   ColumnConfig,
   SchemaConfig,
   TableConfig,
+  DatabaseMetadataView,
 } from "@/types/proto/v1/database_service";
 
 type LocalState = {
@@ -96,7 +97,10 @@ const semanticTypeList = computed(() => {
 });
 
 const databaseMetadata = computed(() => {
-  return dbSchemaV1Store.getDatabaseMetadata(props.database.name);
+  return dbSchemaV1Store.getDatabaseMetadata(
+    props.database.name,
+    DatabaseMetadataView.DATABASE_METADATA_VIEW_FULL
+  );
 });
 
 const schemaConfig = computed(() => {


### PR DESCRIPTION
Fix the cache for metadata, for example, 
- Semantic type is not updated because of the wrong cache (we get FULL but cache BASIC)
- Cache override by mistake
- Inconsistent view for request and cache

The metadata cache is really hard to maintain or debug
- Different views (FULL vs BASIC)
- Partial update & cache
- Invalid cache override
