### PR TITLE
feat(completion): add newline as a trigger symbol

### DIFF
--- a/backend/api/lsp/completion.go
+++ b/backend/api/lsp/completion.go
@@ -81,7 +81,7 @@ func (h *Handler) handleTextDocumentCompletion(ctx context.Context, _ *jsonrpc2.
 
 func generateSortText(params lsp.CompletionParams, candidate base.Candidate) string {
 	switch params.Context.TriggerCharacter {
-	case ".", " ":
+	case ".", " ", "\n":
 		return generateSortTextAfterDot(candidate)
 	default:
 		return string(candidate.Type) + candidate.Text

--- a/backend/api/lsp/handler.go
+++ b/backend/api/lsp/handler.go
@@ -193,7 +193,7 @@ func (h *Handler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2
 					Kind: &kind,
 				},
 				CompletionProvider: &lsp.CompletionOptions{
-					TriggerCharacters: []string{".", " "},
+					TriggerCharacters: []string{".", " ", "\n"},
 				},
 				ExecuteCommandProvider: &lsp.ExecuteCommandOptions{
 					Commands: []string{string(CommandNameSetMetadata)},


### PR DESCRIPTION
close BYT-5299
<img width="756" alt="image" src="https://github.com/bytebase/bytebase/assets/20775801/5c5dec63-a8aa-4a7c-8e93-f12196b7d6cf">
