### PR TITLE
chore: update i18n script

### DIFF
--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -37,6 +37,9 @@ async function translateText(
   text: string,
   targetLang: string
 ): Promise<string> {
+  // Replace all templates like `{user}` in the text before translation.
+  // For example, "创建用户 {user}，密码 {password}" will be formatted to "创建用户 {0}，密码 {1}"
+  // This can avoid translation for the template text in mistake.
   const matches = text.match(/\{.+?\}/g);
   const replacements: { source: string; target: string }[] = [];
   let sourceText = text;

--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -5,6 +5,19 @@ import { promises as fs } from "fs";
 // GOOGLE_TRANSLATE_API_KEY=xxxx
 config({ path: "./.env.i18n" });
 
+// Exec script
+// pnpm i18n: will use en-US.json as source file to translate all other files
+// pnpm --source=zh-CN --target=ja-JP,es-ES i18n: specific the source file and target files
+const SOURCE_LANG = process.env.npm_config_source ?? "en-US";
+const TARGET_LANGS = process.env.npm_config_target?.split(".") ?? [
+  "es-ES",
+  "ja-JP",
+  "vi-VN",
+  "zh-CN",
+];
+
+console.log(`source file: ${SOURCE_LANG}, targets: ${TARGET_LANGS.join(", ")}`);
+
 // Replace 'YOUR_API_KEY' with your actual Google Cloud API key
 const apiKey = process.env.GOOGLE_TRANSLATE_API_KEY;
 const url = `https://translation.googleapis.com/language/translate/v2?key=${apiKey}`;
@@ -18,25 +31,33 @@ type JsonValue =
 type JsonObject = { [key: string]: JsonValue };
 type JsonArray = Array<JsonValue>;
 
-const SOURCE_LANG = "en-US";
-
-const TARGET_LANGS = ["es-ES", "ja-JP", "vi-VN", "zh-CN"];
-
 // Function to translate text using Google Cloud Translation API
+// ref: https://cloud.google.com/translate/docs/basic/translate-text-basic
 async function translateText(
   text: string,
-  targetLang: string,
-  sourceLang: string = "en"
+  targetLang: string
 ): Promise<string> {
+  const matches = text.match(/\{.+?\}/g);
+  const replacements: { source: string; target: string }[] = [];
+  let sourceText = text;
+
+  if (matches) {
+    for (let i = 0; i < matches.length; i++) {
+      const convert = `{${i}}`;
+      replacements.push({ source: matches[i], target: convert });
+      sourceText = sourceText.replace(matches[i], convert);
+    }
+  }
+
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      q: text,
+      q: sourceText,
       target: targetLang,
-      source: sourceLang,
+      source: SOURCE_LANG.split("-")[0],
       format: "text",
     }),
   });
@@ -49,7 +70,14 @@ async function translateText(
     );
   }
 
-  return data.data.translations[0].translatedText;
+  let translatedText = data.data.translations[0].translatedText;
+  for (const replacement of replacements) {
+    translatedText = translatedText.replace(
+      replacement.target,
+      replacement.source
+    );
+  }
+  return translatedText;
 }
 
 // Function specifically for JsonObject translation

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1,293 +1,293 @@
 {
   "common": {
-    "view": "ビュー",
+    "view": "チェック",
     "you": "あなた",
-    "general": "一般的な",
+    "general": "ユニバーサル",
     "slack": "スラック",
     "discord": "不和",
     "teams": "チーム",
     "dingtalk": "ディントーク",
-    "feishu": "フェイシュウ",
-    "wecom": "ウィコム",
+    "feishu": "フェイシュ",
+    "wecom": "エンタープライズ WeChat",
     "system": "システム",
-    "custom": "カスタム",
+    "custom": "カスタマイズ",
     "im": "私は",
     "overview": "概要",
     "change-history": "変更履歴",
-    "webhook": "ウェブフック",
-    "webhooks": "ウェブフック",
-    "key": "鍵",
+    "webhook": "Webhook",
+    "webhooks": "Webhook",
+    "key": "キー値",
     "workflow": "ワークフロー",
     "unread": "未読",
-    "read": "読む",
+    "read": "読んだことがある",
     "activity": "活動",
     "activities": "活動",
-    "sign-in": "サインイン",
-    "sign-up": "サインアップ",
-    "email": "Eメール",
+    "sign-in": "ログイン",
+    "sign-up": "登録する",
+    "email": "郵便",
     "username": "ユーザー名",
     "credentials": "資格",
     "password": "パスワード",
-    "activate": "活性化",
+    "activate": "アクティベーション",
     "save": "保存",
     "cancel": "キャンセル",
     "cancelled": "キャンセル",
     "comment": "コメント",
-    "home": "家",
+    "home": "ホームページ",
     "setting": "設定",
     "settings": "設定",
     "project": "プロジェクト",
     "projects": "プロジェクト",
-    "default-project": "デフォルトプロジェクト",
-    "visit-default-project": "@:common.visit @:common.default-project",
+    "default-project": "デフォルトのプロジェクト",
+    "visit-default-project": "@:common.visit@:common.default-project",
     "help": "ヘルプ",
     "database": "データベース",
     "databases": "データベース",
-    "description": "説明",
+    "description": "説明する",
     "instance": "実例",
     "instances": "インスタンス",
     "environment": "環境",
     "environments": "環境",
     "environment-name": "環境名",
-    "quick-action": "素早い動作",
+    "quick-action": "素早い操作",
     "archive": "アーカイブ",
     "archived": "アーカイブ済み",
-    "no-license": "ライセンスなし",
-    "logout": "ログアウト",
-    "close": "近い",
-    "latest": "最新",
-    "error": "エラー",
+    "no-license": "証明書がありません",
+    "logout": "サインアウト",
+    "close": "閉鎖",
+    "latest": "最新の",
+    "error": "間違い",
     "canceled": "キャンセル",
-    "approval": "承認",
+    "approval": "承認する",
     "approve": "承認する",
-    "done": "終わり",
+    "done": "仕上げる",
     "create": "作成する",
     "run": "走る",
     "retry": "リトライ",
-    "skip": "スキップ",
+    "skip": "飛び越える",
     "reopen": "再開",
-    "dismiss": "却下する",
+    "dismiss": "閉鎖",
     "back": "戻る",
-    "next": "次",
+    "next": "次のステップ",
     "edit": "編集",
-    "update": "アップデート",
+    "update": "更新する",
     "updated": "更新しました",
-    "visit": "訪問",
+    "visit": "アクセス",
     "role": {
       "self": "役割"
     },
-    "assignee": "譲受人",
-    "revert": "元に戻す",
-    "apply": "適用する",
-    "reorder": "並べ替え",
+    "assignee": "被指名者",
+    "revert": "回復する",
+    "apply": "応用",
+    "reorder": "選別",
     "id": "ID",
     "name": "名前",
-    "creator": "クリエイター",
-    "updater": "アップデータ",
+    "creator": "創設者",
+    "updater": "アップデーター",
     "version": "バージョン",
-    "issue": "問題",
-    "issues": "問題",
+    "issue": "作業命令",
+    "issues": "作業命令",
     "duration": "間隔",
-    "created-at": "作成した",
-    "updated-at": "更新しました",
-    "commit": "専念",
+    "created-at": "内蔵",
+    "updated-at": "に更新されました",
+    "commit": "提出する",
     "statement": "声明",
-    "sql-statement": "SQL文",
+    "sql-statement": "SQL@:{'common.statement'}",
     "snapshot": "スナップショット",
-    "status": "状態",
+    "status": "州",
     "stage": "ステージ",
     "task": "タスク",
     "tasks": "タスク",
-    "sql": "構文",
-    "unassigned": "未割り当て",
-    "new": "新しい",
-    "add": "追加",
+    "sql": "SQL",
+    "unassigned": "割り当てられていない",
+    "new": "作成する",
+    "add": "に追加",
     "confirm-and-add": "確認して追加",
-    "confirm-and-update": "確認して更新",
-    "query": "クエリ",
+    "confirm-and-update": "確認して更新する",
+    "query": "お問い合わせ",
     "transfer": "移行",
-    "migration": "移住",
+    "migration": "変化",
     "schema": "スキーマ",
-    "anomalies": "異常",
+    "anomalies": "異常な",
     "do-not-show-again": "再び表示しない",
     "detail": "詳細",
     "type": "タイプ",
     "language": "言語",
-    "repository": "リポジトリ",
+    "repository": "倉庫",
     "change": "変化",
     "branch": "支店",
     "required-placeholder": "必須のプレースホルダー",
-    "optional-placeholder": "オプションのプレースホルダー",
+    "optional-placeholder": "オプションのプレースホルダ",
     "optional-directory-wildcard": "オプションのディレクトリワイルドカード",
-    "sensitive-placeholder": "機密 - 書き込みのみ",
-    "enabled": "有効",
+    "sensitive-placeholder": "機密データ - 書き込みのみ",
+    "enabled": "オンにする",
     "default": "デフォルト",
-    "gitops": "ギットオプス",
-    "restore": "復元する",
+    "gitops": "GitOps",
+    "restore": "回復する",
     "detailed-guide": "詳細ガイド",
     "workspace": "ワークスペース",
     "application": "応用",
     "confirm": "確認する",
-    "coming-later": "後日公開",
+    "coming-later": "乞うご期待",
     "learn-more": "もっと詳しく知る",
     "troubleshoot": "トラブルシューティング",
-    "schema-version": "スキーマバージョン",
+    "schema-version": "スキーマのバージョン",
     "time": "時間",
     "manual": "マニュアル",
     "automatic": "自動",
     "Default": "デフォルト",
     "definition": "意味",
-    "empty": "空の",
+    "empty": "ヌル",
     "connecting": "接続中...",
     "creating": "作成...",
     "updating": "更新中...",
     "Address": "住所",
     "User": "ユーザー",
-    "assigned": "割り当て済み",
-    "subscribed": "購読済み",
+    "assigned": "割り当てられた",
+    "subscribed": "購読しました",
     "created": "作成した",
     "label": "ラベル",
     "labels": "ラベル",
-    "mode": "モード",
-    "roletype": "役割タイプ",
+    "mode": "モデル",
+    "roletype": "役割の種類",
     "readonly": "読み取り専用",
     "user": "ユーザー",
-    "added-time": "追加時間",
+    "added-time": "時間を追加する",
     "data-source": "情報元",
     "grant": "付与",
     "admin": "管理者",
     "read-only": "読み取り専用",
     "connection-string": "接続文字列",
     "agents": "エージェント",
-    "billings": "ビリングス",
+    "billings": "請求する",
     "all": "全て",
-    "recent": "最近の",
-    "deployment-config": "デプロイメント構成",
+    "recent": "最近の訪問",
+    "deployment-config": "導入構成",
     "by": "による",
     "ok": "わかりました",
     "share": "共有",
-    "others": "その他",
+    "others": "他の",
     "or": "または",
     "export": "輸出",
-    "tips": "チップ",
+    "tips": "プロンプトメッセージ",
     "template": "テンプレート",
     "delete": "消去",
-    "history": "歴史",
+    "history": "歴史の記録",
     "loading": "読み込み中",
     "from": "から",
     "copy": "コピー",
-    "copied": "コピーしました",
+    "copied": "コピーされました",
     "manage": "管理",
-    "table": "テーブル",
+    "table": "表面",
     "search": "検索",
-    "warning": "警告",
-    "edited": "編集済み",
+    "warning": "警告する",
+    "edited": "編集日時",
     "preview": "プレビュー",
     "file-selector": {
-      "type-limit": "{extension} ファイルのみサポートします",
+      "type-limit": "タイプ {extension} のファイルのみがサポートされます",
       "size-limit": "ファイルサイズは {size} MiB 未満である必要があります"
     },
     "no-data": "データなし",
     "visibility": "可視性",
-    "duplicate": "重複",
+    "duplicate": "コピー",
     "clear-search": "検索をクリア",
-    "enable": "有効にする",
+    "enable": "オンにする",
     "disable": "無効にする",
     "view-doc": "ドキュメントを見る",
-    "write-only": "書き込みのみ",
-    "pitr": "ピトル",
+    "write-only": "書くだけ",
+    "pitr": "PITR",
     "fix": "修理",
     "go-now": "今行く",
-    "sync": "同期",
-    "sync-now": "今すぐ同期",
-    "show-help": "ヘルプを表示",
-    "success": "成功する",
-    "failed": "失敗した",
+    "sync": "同期する",
+    "sync-now": "今すぐ同期する",
+    "show-help": "ヘルプを見る",
+    "success": "成功",
+    "failed": "失敗",
     "load-more": "もっと読み込む",
     "access-denied": "アクセスが拒否されました",
     "no": "いいえ",
     "yes": "はい",
     "advanced": "高度な",
     "restart": "再起動",
-    "want-help": "助けが必要",
-    "operation": "手術",
+    "want-help": "ユーザーグループに参加する",
+    "operation": "操作する",
     "rollback": "ロールバック",
     "total": "合計",
-    "discard-changes": "変更を破棄",
+    "discard-changes": "変更をキャンセルする",
     "error-message": "エラーメッセージ",
-    "demo-mode": "デモ",
-    "operations": "オペレーション",
-    "on": "の上",
-    "off": "オフ",
+    "demo-mode": "デモモード",
+    "operations": "操作する",
+    "on": "開ける",
+    "off": "近い",
     "verify": "確認する",
     "regenerate": "再生する",
     "download": "ダウンロード",
-    "will-lose-unsaved-data": "保存されていないデータは失われます。",
+    "will-lose-unsaved-data": "これにより、現在保存されていないデータはすべて失われます。",
     "deleted": "削除されました",
-    "will-override-current-data": "現在のデータを上書きします。",
-    "rollout": "ロールアウトする",
-    "uploading": "アップロード中",
-    "active": "アクティブ",
-    "added": "追加した",
-    "revoke": "取り消す",
-    "cannot-undo-this-action": "この操作を元に戻すことはできません",
-    "expand": "展開します",
-    "collapse": "しまいます",
-    "select": "選択する",
+    "will-override-current-data": "現在のデータは上書きされます。",
+    "rollout": "リリース",
+    "uploading": "アップロードする",
+    "active": "オンにする",
+    "added": "作成した",
+    "revoke": "キャンセル",
+    "cannot-undo-this-action": "この操作は元に戻せません",
+    "expand": "拡大する",
+    "collapse": "近い",
+    "select": "選ぶ",
     "optional": "オプション",
     "reason": "理由",
     "date": {
       "days": "{days} 日",
-      "months": "{months}ヶ月",
-      "years": "{years} 年"
+      "months": "{months}か月",
+      "years": "{years}年"
     },
     "expiration": "有効期限",
-    "configure": "構成、設定",
+    "configure": "構成",
     "groups": "グループ",
-    "database-groups": "データベースグループ",
+    "database-groups": "データベースのグループ化",
     "members": "メンバー",
     "warehouse": "倉庫",
-    "schedule": "スケジュール",
+    "schedule": "プラン",
     "state": "州",
     "condition": "状態",
-    "search-user": "ユーザーを検索",
+    "search-user": "ユーザーを検索する",
     "branches": "支店",
     "merge": "マージ",
     "info": "情報",
     "minutes": "分",
-    "go-to-configure": "構成、設定",
-    "updated-at-by": "{user} によって {time} 更新されました",
+    "go-to-configure": "設定に移動",
+    "updated-at-by": "{user} から {time} に更新されました",
     "created-at-by": "{time} に {user} によって作成されました",
-    "filter-by-name": "名前でフィルタリング",
+    "filter-by-name": "名前でフィルタリングする",
     "tenant": "テナント",
-    "license": "ライセンス",
-    "show-all": "すべて表示する",
-    "view-details": "詳細を見る",
-    "force-verb": "強制する {verb}",
-    "nothing-changed": "何も変わっていません",
-    "untitled": "無題",
+    "license": "証明書",
+    "show-all": "すべて表示",
+    "view-details": "詳細を確認する",
+    "force-verb": "フォース{verb}",
+    "nothing-changed": "変化なし",
+    "untitled": "名前のない",
     "nickname": "ニックネーム",
     "missing-permission": "必要な権限がありません",
-    "continue-anyway": "とにかく続けます",
+    "continue-anyway": "まだ続けたい",
     "permissions": "権限",
-    "cutover": "カットオーバー",
+    "cutover": "スイッチ",
     "baseline": "ベースライン",
     "project-member": "プロジェクトメンバー",
-    "leave-without-saving": "保存せずに終了しますか?",
-    "configure-now": "今すぐ設定",
-    "connection": "繋がり"
+    "leave-without-saving": "変更を保存していませんか?",
+    "configure-now": "今すぐ設定する",
+    "connection": "接続する"
   },
   "error-page": {
-    "go-back-home": "家に帰ります"
+    "go-back-home": "ホームページに戻る"
   },
-  "anomaly-center": "異常センター",
+  "anomaly-center": "異常な中心",
   "kbar": {
-    "recently-visited": "最近訪問した",
+    "recently-visited": "最近の訪問",
     "navigation": "ナビゲーション",
     "help": {
-      "navigate": "ナビゲートする",
-      "perform": "実行する",
-      "close": "閉じる",
+      "navigate": "選ぶ",
+      "perform": "埋め込む",
+      "close": "閉鎖",
       "back": "戻る"
     },
     "options": {
@@ -299,293 +299,293 @@
     }
   },
   "task": {
-    "checking": "チェック中...",
-    "run-task": "チェックを実行する",
+    "checking": "検査中…",
+    "run-task": "実行チェック",
     "check-result": {
-      "title": "{name} の結果を確認する",
-      "title-general": "結果を確認する"
+      "title": "{name} の結果を確認します",
+      "title-general": "テスト結果"
     },
     "check-type": {
       "fake": "偽物",
-      "syntax": "構文",
+      "syntax": "文法",
       "compatibility": "互換性",
-      "connection": "繋がり",
-      "sql-review": "SQLレビュー",
-      "earliest-allowed-time": "最も早い許可時間",
-      "ghost-sync": "gh-ost 同期",
-      "statement-type": "ステートメントタイプ",
+      "connection": "接続する",
+      "sql-review": "SQL監査",
+      "earliest-allowed-time": "最も早い実行時間",
+      "ghost-sync": "gh-ost同期",
+      "statement-type": "ステートメントの種類",
       "lgtm": "LGTM",
-      "pitr": "ピトル",
-      "affected-rows": "影響を受ける行（統計情報に基づく推定）",
-      "sql-type": "SQLタイプ",
+      "pitr": "PITR",
+      "affected-rows": "影響を受ける行数 (統計に基づいて推定)",
+      "sql-type": "SQLの種類",
       "summary-report": "概略報告"
     },
-    "rollout-time": "ロールアウト時間",
-    "earliest-allowed-time-hint": "@:{'task.rollout-time'} は、タスクを実行するタイミングです。指定されていない場合は、すべての条件が満たされたときに実行されます。",
-    "earliest-allowed-time-unset": "設定解除",
+    "rollout-time": "公開時間を指定する",
+    "earliest-allowed-time-hint": "「@:{'task.rollout-time'}」はタスクを実行する時刻です。指定しない場合、タスクは条件が満たされるとすぐに実行されます。",
+    "earliest-allowed-time-unset": "設定されていません",
     "comment": "コメント",
-    "invoker": "召喚者",
-    "started": "開始",
-    "ended": "終了しました",
-    "view-change": "表示の変更",
-    "view-change-history": "変更履歴を表示",
+    "invoker": "執行者",
+    "started": "から始まりました",
+    "ended": "で終わる",
+    "view-change": "変更を表示する",
+    "view-change-history": "変更履歴を表示する",
     "status": {
       "running": "ランニング",
-      "failed": "失敗した",
+      "failed": "失敗",
       "canceled": "キャンセル",
       "success": "成功",
-      "warn": "警告",
-      "error": "エラー"
+      "warn": "警告する",
+      "error": "間違い"
     },
-    "earliest-allowed-time-no-modify": "問題の担当者ではないか、実行が保留中ではないため、このフィールドを変更することはできません。",
+    "earliest-allowed-time-no-modify": "チケットのレビュー担当者ではないか、チケットが保留中ではないため、このフィールドは変更できません。",
     "type": {
-      "bb-task-database-schema-update-ghost-sync": "データを同期する",
-      "bb-task-database-schema-update-ghost-cutover": "テーブルを切り替える",
-      "bb-task-database-schema-update-ghost-drop-original-table": "元のテーブルを削除"
+      "bb-task-database-schema-update-ghost-sync": "同期データ",
+      "bb-task-database-schema-update-ghost-cutover": "スイッチテーブル",
+      "bb-task-database-schema-update-ghost-drop-original-table": "元のテーブルを削除する"
     },
     "progress": {
-      "completed-units": "{units} を完了しました",
+      "completed-units": "完了しました{units}",
       "total-units": "合計 {units}",
-      "eta": "到着予定時刻",
+      "eta": "予想終了時間",
       "units": {
-        "unit": "ユニット",
+        "unit": "ユニット数",
         "row": "行"
       },
-      "counting": "カウント"
+      "counting": "統計の下"
     },
-    "n-similar-tasks": "({count} 件の類似タスク)",
-    "skip": "スキップ",
-    "skip-modal-title": "タスク[{name}]をスキップしますか?",
-    "task-checks": "タスクチェック",
-    "prior-backup": "事前のバックアップ",
+    "n-similar-tasks": "({count} 件の同様のタスク)",
+    "skip": "飛び越える",
+    "skip-modal-title": "タスク [{name}] をスキップしますか?",
+    "task-checks": "タスクのチェック項目",
+    "prior-backup": "事前にデータをバックアップしておくこと",
     "rollback": {
-      "sql-rollback": "SQL ロールバック",
-      "failed": "失敗した",
-      "preview-rollback-issue": "プレビューのロールバックの問題",
+      "sql-rollback": "SQLロールバック",
+      "failed": "失敗",
+      "preview-rollback-issue": "ロールバック作業指示のプレビュー",
       "generating": "生成中",
-      "empty-rollback-statement": "ロールバックステートメントが空です",
-      "cancel-generating": "SQLロールバックの生成をキャンセル",
-      "sql-rollback-tips": "有効にすると、Bytebase はデータ変更のロールバック ログを保持し、この変更を元に戻すための新しい問題を作成できるようになります。\n警告: テーブルに主キーがない場合、Undo SQL は重複行に影響する可能性があります。実行する前に慎重に確認してください。\n{link}",
-      "maximum-size-tips": "サポートされるロールバックデータの最大サイズは32MBです"
+      "empty-rollback-statement": "ロールバック ステートメントが空です",
+      "cancel-generating": "ロールバックステートメントの生成をキャンセルします",
+      "sql-rollback-tips": "有効にすると、データ変更のロールバック ログが保持され、この変更をロールバックするための新しい作業指示を作成するために使用できます。\n警告: データ テーブルに主キーがない場合、ロールバック ステートメントは重複行に影響を与える可能性があります。実行前にご確認ください。\n{link}",
+      "maximum-size-tips": "サポートされるロールバック データの最大サイズは 32MB です"
     },
-    "skip-failed-in-current-stage": "現在のステージで失敗したタスクをスキップする",
+    "skip-failed-in-current-stage": "現在のステージで失敗したタスクをスキップします",
     "apply-change-to-all-pending-tasks": {
-      "title": "すべての保留中のタスクに変更を適用しますか?",
-      "self": "すべての保留中のタスクに変更を適用する",
-      "current-only": "現在のタスクにのみ変更を適用する"
+      "title": "すべての未処理のタスクに適用しますか?",
+      "self": "すべての未処理のタスクに適用する",
+      "current-only": "現在のタスクにのみ適用されます"
     },
     "execution-time": "実行時間",
-    "run-checks": "チェックを実行する",
-    "run-checks-in-current-stage": "現在のステージでチェックを実行する",
+    "run-checks": "実行チェック",
+    "run-checks-in-current-stage": "現在のステージのすべてのチェックを実行します",
     "database-create": {
-      "pending": "(作成保留中)",
+      "pending": "(作成予定)",
       "created": "（作成した）"
     },
-    "action-failed-in-current-stage": "現在のステージで失敗したタスクが {action} 件あります",
-    "action-all-tasks-in-current-stage": "{action} 現在のステージのすべてのタスク",
-    "cancel-task": "タスクをキャンセル | タスクをキャンセル",
-    "created": "作成した",
+    "action-failed-in-current-stage": "{action}現在のステージで失敗したタスク",
+    "action-all-tasks-in-current-stage": "{action}現在のステージのすべてのタスク",
+    "cancel-task": "タスクをキャンセルする",
+    "created": "内蔵",
     "online-migration": {
-      "self": "オンライン移行",
-      "configure-ghost-parameters-for-db": "データベース '{db}' の gh-ost パラメータを設定します",
-      "configure-ghost-parameters": "gh-ostパラメータを設定する",
-      "ghost-parameters": "gh-ost パラメータ",
-      "configure": "構成、設定",
+      "self": "オンラインでの大規模なテーブル変更",
+      "configure-ghost-parameters-for-db": "データベース「{db}」の gh-ost パラメータを構成します",
+      "configure-ghost-parameters": "gh-ost パラメータを構成する",
+      "ghost-parameters": "gh-ostパラメータ",
+      "configure": "構成",
       "error": {
-        "some-tasks-are-not-editable-in-batch-mode": "一部のタスクはバッチモードでは編集できません",
+        "some-tasks-are-not-editable-in-batch-mode": "一部のタスクはバッチ モードでは編集できません",
         "task-is-not-editable": "このタスクは編集できません",
-        "x-status-task-is-not-editable": "{status} タスクは編集できません",
-        "nothing-changed": "何も変わっていません",
+        "x-status-task-is-not-editable": "{status} のタスクは編集できません",
+        "nothing-changed": "変化なし",
         "not-applicable": {
           "some-tasks-dont-meet-ghost-requirement": "一部のタスクは gh-ost の要件を満たしていません"
         }
       },
       "show-default-parameters": "デフォルトパラメータを表示",
-      "hide-default-parameters": "デフォルトパラメータを非表示",
-      "enable": "オンライン移行を有効にする"
+      "hide-default-parameters": "デフォルトパラメータを非表示にする",
+      "enable": "オンラインでの大規模なテーブル変更を有効にする"
     },
     "prior-backup-tips": "影響を受けるデータを事前にバックアップする"
   },
   "task-run": {
     "status": {
-      "enqueued": "実行を待機しています。",
-      "enqueued-with-rollout-time": "{time} 後に実行を待機しています。",
-      "dumping-schema-before-executing-sql": "実行の準備、スキーマのダンプ中。",
-      "preparing-to-export-data": "データをエクスポートする準備をしています。",
+      "enqueued": "処刑を待っています。",
+      "enqueued-with-rollout-time": "実行を待機しています。{time} の後に実行されます。",
+      "dumping-schema-before-executing-sql": "実行の準備、スキーマのエクスポート。",
+      "preparing-to-export-data": "データをエクスポートする準備をします。",
       "exporting-data": "データをエクスポートしています。",
-      "executing-sql": "SQL を実行しています。",
-      "executing-sql-detail": "SQL {current} / {total}、({startLine}, {startColumn}) から ({endLine}, {endColumn}) までを実行しています。",
-      "dumping-schema-after-executing-sql": "SQL 実行が完了し、スキーマをダンプしています。",
-      "failed-sql-detail": "({startLine}, {startColumn}) から ({endLine}, {endColumn}) までの実行に失敗しました: {message}。"
+      "executing-sql": "SQLを実行しています。",
+      "executing-sql-detail": "SQL {current}/{total} を ({startLine}, {startColumn}) から ({endLine}, {endColumn}) まで実行しています。",
+      "dumping-schema-after-executing-sql": "SQL の実行が完了し、スキーマがエクスポートされています。",
+      "failed-sql-detail": "({startLine}、{startColumn}) から ({endLine}、{endColumn}) までの実行が失敗しました: {message}。"
     }
   },
   "banner": {
-    "update-license": "ライセンスの更新",
-    "license-expires": "{plan} のライセンスは {expireAt} に期限切れになりました。",
-    "trial-expires": "{plan} の無料トライアルは、{days} 日後の {expireAt} に期限切れになります。",
-    "trial-expired": "{plan} の無料トライアルの有効期限が切れました。",
-    "extend-trial": "トライアル期間を延長する",
-    "deploy": "セルフホスト",
-    "cloud": "雲",
+    "update-license": "証明書を更新する",
+    "license-expires": "{plan} 証明書は {expireAt} に期限切れになりました",
+    "trial-expires": "{plan} トライアルは {days} 日後に期限切れになります",
+    "trial-expired": "{plan} のトライアル期間が終了しました",
+    "extend-trial": "トライアル延長を申請する",
+    "deploy": "ローカル展開",
+    "cloud": "クラウドサービス",
     "request-demo": "30 分間の製品デモを予約してください。",
-    "readonly": "Bytebase は読み取り専用モードです。コンソールを表示することはできますが、変更を試みても失敗します。",
-    "external-url": "Bytebase は --external-url を設定していません"
+    "readonly": "バイトベースは読み取り専用モードです。コンソールを表示することはできますが、変更を加えようとすると失敗します。",
+    "external-url": "Bytebase は --extern-url を構成していません"
   },
   "intro": {
-    "doc": "ドキュメント",
-    "issue": "問題",
-    "quickstart": "クイックスタート"
+    "doc": "書類",
+    "issue": "作業命令",
+    "quickstart": "初心者のタスク"
   },
   "bbkit": {
     "common": {
-      "ok": "わかりました",
+      "ok": "確認する",
       "cancel": "キャンセル",
       "back": "戻る",
-      "next": "次",
+      "next": "次のステップ",
       "finish": "仕上げる",
       "step": "ステップ"
     },
     "attention": {
-      "default": "注意が必要"
+      "default": "注意してください"
     },
     "confirm-button": {
-      "sure-to-delete": "本当に削除しますか?",
-      "cannot-undo": "この操作を元に戻すことはできません。"
+      "sure-to-delete": "本当に削除してもよろしいですか?",
+      "cannot-undo": "この操作は元に戻すことができません。"
     }
   },
   "settings": {
     "sidebar": {
       "account": "アカウント",
-      "profile": "プロフィール",
+      "profile": "個人情報",
       "workspace": "ワークスペース",
-      "security-and-policy": "セキュリティポリシー",
-      "integration": "統合",
-      "general": "一般的な",
+      "security-and-policy": "セキュリティ戦略",
+      "integration": "統合された",
+      "general": "ユニバーサル",
       "members": "メンバー",
       "im-integration": "私は",
-      "sso": "シングルサインオン",
-      "gitops": "ギットオプス",
+      "sso": "SSO",
+      "gitops": "GitOps",
       "subscription": "サブスクリプション",
       "labels": "ラベル",
       "debug-log": "デバッグログ",
-      "sensitive-data": "データマスキング",
+      "sensitive-data": "データの非感作化",
       "access-control": "データアクセス制御",
       "audit-log": "監査ログ",
       "custom-roles": "カスタムロール",
-      "mail-delivery": "郵便配達"
+      "mail-delivery": "メール送信"
     },
     "profile": {
-      "email": "Eメール",
+      "email": "郵便",
       "role": "役割",
-      "phone": "電話",
-      "country-code": "国コード",
+      "phone": "電話番号",
+      "country-code": "国または地域コード",
       "password": "パスワード",
-      "password-confirm": "パスワードの確認",
-      "password-confirm-placeholder": "新しいパスワードを確認",
+      "password-confirm": "パスワードを認証する",
+      "password-confirm-placeholder": "新しいパスワードを確認します",
       "password-mismatch": "新しいパスワードが一致しません",
-      "subscription": "(ロール管理を有効にするにはアップグレードしてください)"
+      "subscription": "(有料プランにアップグレードするとキャラクター管理が可能になります)"
     },
     "members": {
-      "active": "アクティブメンバー",
-      "inactive": "非アクティブなメンバー",
-      "helper": "メールアドレスで追加または招待する",
-      "add-more": "+ さらに追加",
-      "add": "追加",
-      "invites": "招待状を送る",
-      "invited": "招待",
-      "yourself": "あなた",
-      "upgrade": "ロール管理を有効にするにはアップグレードしてください",
-      "select-role": "役割を選択",
+      "active": "アクティブ化された",
+      "inactive": "不活性化された",
+      "helper": "電子メールでメンバーを追加または招待する",
+      "add-more": "+ メンバーを追加",
+      "add": "に追加",
+      "invites": "招待状を送信する",
+      "invited": "招待されました",
+      "yourself": "あなた自身",
+      "upgrade": "有料プランにアップグレードしてキャラクター管理のロックを解除する",
+      "select-role": "役割の選択",
       "not-assigned": "割り当てられていない",
       "table": {
         "account": "アカウント",
         "role": "役割",
-        "update-time": "更新日時",
-        "granted-time": "与えられた時間",
+        "update-time": "更新時間",
+        "granted-time": "の承認",
         "roles": "役割"
       },
       "action": {
-        "deactivate": "無効化",
-        "deactivate-confirm-title": "本当に無効にしますか",
-        "deactivate-confirm-description": "後で再度有効にすることもできます",
-        "reactivate": "再アクティブ化",
-        "reactivate-confirm-title": "再度アクティブ化してもよろしいですか"
+        "deactivate": "無効にする",
+        "deactivate-confirm-title": "無効にしてもOK",
+        "deactivate-confirm-description": "後で再度有効にすることができます",
+        "reactivate": "有効にする",
+        "reactivate-confirm-title": "[OK] を有効にします"
       },
       "tooltip": {
-        "upgrade": "ロール管理を有効にするにはアップグレードしてください",
-        "not-allow-edit": "役割を変更できるのは管理者のみです",
+        "upgrade": "有料プランにアップグレードしてキャラクター管理のロックを解除する",
+        "not-allow-edit": "管理者のみがロールを変更できる",
         "not-allow-remove": "最後の管理者を削除できません",
-        "project-role-provider-gitlab": "対応する GitLab プロジェクトの {rawRole} ロールからマップされます。",
-        "cannot-change-role-of-systembot-or-service-account": "システムボットまたはサービスアカウントの役割を変更できません"
+        "project-role-provider-gitlab": "対応する GitLab プロジェクトから {rawRole} ロールを同期します",
+        "cannot-change-role-of-systembot-or-service-account": "ロボット アシスタントとサービス アカウントの役割は変更できません。"
       },
-      "system-bot": "システムボット",
+      "system-bot": "ロボットアシスタント",
       "service-account": "サービスアカウント",
-      "copy-service-key": "サービスキーをコピー",
-      "reset-service-key": "サービスキーをリセットする",
-      "reset-service-key-alert": "この操作は元に戻せません。古いキーは直ちに機能しなくなります。このサービス キーをリセットしてもよろしいですか?",
-      "service-key-copied": "サービス キーがクリップボードにコピーされました。秘密にしておいてください。",
+      "copy-service-key": "サービスキーをコピーする",
+      "reset-service-key": "サービスキーのリセット",
+      "reset-service-key-alert": "古いサービス キーはすぐにリセットされ、この操作は元に戻すことはできません。サービス キーをリセットしてもよろしいですか?",
+      "service-key-copied": "サービスキーはコピーされています。公開しないでください",
       "create-as-service-account": "サービスアカウントとして作成",
-      "show-inactive": "非アクティブなメンバーを表示",
+      "show-inactive": "非アクティブなメンバーを表示する",
       "remove-self-admin": {
-        "title": "@.lower:role.workspace-admin.self を自分自身から取り消してもよろしいですか?",
-        "description": "残りの @.lower:role.workspace-admin.self がサインインできることを確認してください。そうでない場合、誰もユーザーを管理できません。"
+        "title": "@.lower:role.workspace-admin.self ロールを削除することを確認してください。",
+        "description": "残りの @.lower:role.workspace-admin.self メンバーがログインできることを確認してください。ログインできない場合は、誰もユーザーを管理できません。"
       },
-      "view-by-principals": "プリンシパル別に表示",
-      "view-by-roles": "役割別に表示",
+      "view-by-principals": "メンバー別に見る",
+      "view-by-roles": "役割ごとに表示",
       "add-member": "メンバーを追加",
-      "update-member": "メンバーを更新",
-      "workspace-role-at-least-one": "少なくとも 1 つのワークスペース ロールが必要です"
+      "update-member": "メンバーを更新する",
+      "workspace-role-at-least-one": "少なくとも 1 つのワークスペースレベルの役割を選択してください"
     },
     "im-integration": {
       "enable": "有効にする",
-      "description": "ユーザーが IM から直接問題を承認できるようにします。",
-      "feishu-updated-tip": "Feishu統合を正常に更新しました"
+      "description": "ユーザーが IM で作業指示書を直接承認できるようにします。",
+      "feishu-updated-tip": "フェイシュの設定が正常に更新されました"
     },
     "sso": {
-      "create": "SSO を作成する",
-      "description": "シングル サインオン (SSO) は、ユーザーが単一の資格情報セットを使用して複数のアプリケーションや Web サイトで認証できるようにする認証方法です。",
+      "create": "SSOの作成",
+      "description": "シングル サインオン (SSO) は、ユーザーが他のアプリケーションや Web サイトからログインできるようにする認証方法です。",
       "archive": "この SSO をアーカイブする",
-      "archive-info": "アーカイブされた SSO は表示されません。",
-      "restore": "このSSOを復元する",
+      "archive-info": "アーカイブされた SSO は表示されなくなります。",
+      "restore": "この SSO を復元する",
       "form": {
         "type": "タイプ",
-        "learn-more-with-user-doc": "構成の詳細",
-        "redirect-url": "認証リダイレクト URL",
-        "redirect-url-description": "これは、アイデンティティ プロバイダー申請フォームの適切なフィールドに入力するために使用されます。",
+        "learn-more-with-user-doc": "設定方法の詳細については、こちらをご覧ください",
+        "redirect-url": "コールバックアドレス",
+        "redirect-url-description": "ID プロバイダー要求フォームの対応するフィールドに入力するために使用されます。",
         "use-template": "テンプレートを使用する",
         "select-template": "テンプレートを選択",
         "basic-information": "基本情報",
         "name": "名前",
-        "name-description": "ユーザーに表示される表示名",
+        "name-description": "ログインユーザーに表示される名前",
         "resource-id": "リソースID",
         "resource-id-description": "一意の文字列。有効な文字は /[a-z][0-9]-/ です。",
-        "domain": "ドメイン",
-        "domain-description": "アイデンティティプロバイダのドメイン名",
-        "identity-provider-information": "アイデンティティプロバイダ情報",
-        "identity-provider-information-description": "情報は ID プロバイダーによって提供されます。",
+        "domain": "ドメイン名",
+        "domain-description": "OAuthプロバイダーのドメイン名",
+        "identity-provider-information": "ID プロバイダー情報",
+        "identity-provider-information-description": "この情報は ID プロバイダーによって提供されます。",
         "identity-provider-needed-information": "次の情報を使用して SSO アプリケーションを作成します。",
-        "endpoints": "エンドポイント",
-        "endpoints-description": "OAuth プロバイダーによって提供される関連 URL。",
-        "auth-url-description": "OAuthログインページへのリンク",
-        "scopes-description": "Auth URL にアクセスするときに使用されるスコープのスペース区切りリスト",
-        "token-url-description": "accessTokenを取得するためのAPIアドレス",
-        "user-info-url-description": "accessTokenでユーザー情報を取得するためのAPIアドレス",
+        "endpoints": "リンク情報",
+        "endpoints-description": "リンク情報は OAuth プロバイダーによって提供されます。",
+        "auth-url-description": "ログインページへのリンク",
+        "scopes-description": "認証 URL にアクセスするときに渡される範囲パラメーター。複数の値を区切るにはスペースを使用します。",
+        "token-url-description": "accessTokenの取得に使用するAPIアドレス",
+        "user-info-url-description": "accessTokenによるユーザー情報の取得に使用するAPIアドレス",
         "security-protocol": "セキュリティプロトコル",
-        "connection-security": "接続セキュリティ",
-        "connection-security-skip-tls-verify": "TLS検証をスキップ",
-        "user-information-mapping": "ユーザー情報マッピング",
-        "user-information-mapping-description": "ユーザー情報 API からのフィールド名を Bytebase ユーザーにマップします。",
-        "identifier": "Bytebaseユーザーのメールアドレス",
-        "identifier-tips": "一意の文字列である必要があります。また、電子メール形式でない場合は、ドメインで結合されます。",
-        "display-name": "Bytebaseユーザーの表示名",
-        "phone": "Bytebaseユーザーの電話番号",
+        "connection-security": "セキュリティオプション",
+        "connection-security-skip-tls-verify": "証明書の検証をスキップする",
+        "user-information-mapping": "ユーザー情報のマッピング",
+        "user-information-mapping-description": "フィールド マップには、API ユーザー情報のフィールド名が保持されます。",
+        "identifier": "バイトベースユーザーの電子メールアドレス",
+        "identifier-tips": "電子メールは一意である必要があります。実際の値がメールボックス形式でない場合は、ドメインと連結されます。",
+        "display-name": "バイトベースユーザーのニックネーム",
+        "phone": "Bytebase ユーザーの携帯電話番号",
         "auth-style": {
-          "self": "認証スタイル",
+          "self": "認証パラメータの引き渡し方法",
           "in-params": {
-            "self": "パラメータ内"
+            "self": "リクエストパラメータ経由"
           },
           "in-header": {
-            "self": "ヘッダー内"
+            "self": "リクエストヘッダー経由"
           }
         }
       },
@@ -594,124 +594,124 @@
     "general": {
       "workspace": {
         "id": "ワークスペースID",
-        "id-description": "一意の読み取り専用のワークスペース ID。",
-        "branding": "ブランディング",
-        "only-admin-can-edit": "ワークスペース管理者のみが設定を更新できます。",
+        "id-description": "一意の読み取り専用ワークスペース ID",
+        "branding": "ブランド",
+        "only-admin-can-edit": "この設定を変更できるのは管理者だけです",
         "logo": "ロゴ",
-        "logo-aspect": "推奨されるロゴのサイズは、アスペクト比 5:2 (例: 100 x 40) です。",
-        "select-logo": "ファイルをアップロードする",
-        "drag-logo": "またはここにドラッグ",
-        "logo-upload-tip": "{extension} 最大 {size} MiB",
-        "logo-upload-succeed": "ロゴを更新しました",
-        "security": "安全",
+        "logo-aspect": "推奨されるロゴの幅:高さの比率 (例: 100 x 40 ピクセル)",
+        "select-logo": "選ぶ",
+        "drag-logo": "またはファイルをドラッグ アンド ドロップします",
+        "logo-upload-tip": "{extension} タイプのファイルをサポートします。{size} MiB より大きくすることはできません",
+        "logo-upload-succeed": "ロゴ更新完了",
+        "security": "安全性",
         "watermark": {
           "self": "透かし",
-          "update-success": "透かし設定が更新されました",
-          "description": "ユーザー名、ID、電子メールなどの透かしをページに表示します。",
-          "only-admin-can-edit": "透かし設定を更新できるのはワークスペース管理者のみです。",
-          "enable": "透かしを有効にする"
+          "update-success": "ウォーターマーク設定が更新されました",
+          "description": "ユーザー名、ID、メールアドレスを含むページにウォーターマークを表示します。",
+          "only-admin-can-edit": "管理者のみがウォーターマーク設定を更新できます",
+          "enable": "ウォーターマークをオンにする"
         },
         "disallow-signup": {
-          "enable": "セルフサービスサインアップを無効にする",
-          "description": "無効にすると、ユーザーはセルフサービスサインアップできなくなり、ワークスペース管理者によってのみ招待されるようになります。"
+          "enable": "セルフサービス登録を無効にする",
+          "description": "無効化されると、新しいユーザーは自己登録できなくなり、管理者の招待を通じてのみアカウントを作成できます。"
         },
         "require-2fa": {
-          "enable": "すべてのユーザーに2要素認証を要求する",
-          "description": "有効にすると、個人アカウントで 2 要素認証を有効にしていないユーザーは強制的に設定が必要になります。",
-          "need-all-user-2fa-enabled": "まずすべてのユーザーが 2FA を有効にする必要があります。まだ 2FA を有効にしていないユーザーが {count} 人います: {users}"
+          "enable": "すべてのユーザーに 2 要素認証の構成を要求する",
+          "description": "有効にすると、2 要素認証が設定されていないユーザーは強制的に設定されます。",
+          "need-all-user-2fa-enabled": "これを有効にする前に、すべてのユーザーが 2 要素認証を構成する必要があります。 2 要素認証が構成されていないユーザーが {count} 人います: {users}"
         },
         "network": "通信網",
         "external-url": {
           "self": "外部URL",
-          "description": "ユーザーが Bytebase にアクセスする外部 URL は、http:// または https:// で始まる必要があります。"
+          "description": "ユーザーまたはコールバックがアクセスできるバイトベース URL は、http:// または https:// で始まる必要があります。"
         },
         "gitops-webhook-url": {
-          "self": "GitOps ウェブフック URL",
-          "description": "GitOps Webhook を Bytebase インスタンスに送信するために使用される URL。",
-          "default-to-external-url": "デフォルトは外部URL"
+          "self": "GitOps Webhook URL",
+          "description": "GitOps のサードパーティ サービスが Webhook を Bytebase に送信するために使用する URL。",
+          "default-to-external-url": "デフォルト値は外部 URL です。"
         },
         "sign-in-frequency": {
-          "self": "サインイン頻度",
-          "description": "サインイン頻度は、ユーザーが再度サインインするまでの期間です。",
-          "hours": "時間）",
-          "days": "日々）",
-          "config-updated": "設定が更新されました。有効にするには、Bytebase を再起動して再度ログインする必要があります。"
+          "self": "ログイン頻度",
+          "description": "ログイン頻度は、ユーザーが再度ログインする必要がある間隔を指定します。",
+          "hours": "時間",
+          "days": "日々",
+          "config-updated": "構成が更新されたため、有効にするには Bytebase を再起動し、再度ログインする必要があります。"
         },
-        "config-updated": "設定が更新されました。",
+        "config-updated": "構成が更新されました。",
         "plugin": {
           "openai": {
-            "ai-augmentation": "AI拡張",
+            "ai-augmentation": "AIの強化",
             "openai-key": {
               "self": "OpenAI APIキー",
-              "description": "SQL エディターで ChatSQL 機能を有効にするには、OpenAI API キーを指定します。{viewDoc}",
+              "description": "SQL エディターで ChatSQL を開く機能を有効にする OpenAI API キーを提供します。 {viewDoc}",
               "find-my-key": "鍵を探す",
-              "placeholder": "OpenAI APIキーは通常sk-*****で始まります"
+              "placeholder": "OpenAI API キーは通常 sk-***** で始まります"
             },
             "openai-endpoint": {
-              "self": "OpenAI APIエンドポイント",
-              "description": "OpenAI API エンドポイントのプライベート展開を提供します。"
+              "self": "OpenAI API エンドポイント",
+              "description": "プライベート展開用の OpenAI API エンドポイントを提供します。"
             }
           }
         },
         "announcement": {
           "self": "発表",
           "update-success": "アナウンス設定が更新されました。",
-          "admin-or-dba-can-edit": "アナウンス設定を更新できるのは、ワークスペース管理者または DBA のみです。"
+          "admin-or-dba-can-edit": "管理者または DBA のみがアナウンス設定を更新できます。"
         },
         "announcement-alert-level": {
-          "description": "レベル",
+          "description": "学年",
           "field": {
             "info": "普通",
-            "warning": "警告",
-            "critical": "致命的"
+            "warning": "警告する",
+            "critical": "重要"
           }
         },
         "announcement-text": {
           "self": "タイトル",
-          "description": "お知らせを非表示にするには、空白のままにしておきます。",
-          "placeholder": "アナウンスのタイトルを入力してください"
+          "description": "お知らせを非表示にしたい場合は空白のままにしてください。",
+          "placeholder": "お知らせのタイトルを入力してください"
         },
         "extra-link": {
           "self": "リンク",
-          "placeholder": "アナウンスリンクを入力"
+          "placeholder": "お知らせリンクを入力してください"
         },
-        "confirm-delete-custom-logo": "カスタムブランドロゴを削除しますか?",
+        "confirm-delete-custom-logo": "カスタム ブランド ロゴを削除しますか?",
         "restrict-issue-creation-for-sql-review": {
-          "title": "エラーのあるSQLレビューの問題作成を禁止する",
-          "description": "有効にすると、SQL レビューにエラーが含まれていない場合にのみ、ユーザーは問題を作成できるようになります。"
+          "title": "エラーアラートを含む作業指示書の提出は禁止されています",
+          "description": "有効にすると、プレビュー段階で「エラー」レベルのアラームを含まない作業指示のみを送信できます。"
         }
       }
     },
     "sensitive-data": {
-      "description": "次の列にはマスキング レベルが明示的に割り当てられ、グローバル マスキング ルールよりも優先されます。",
-      "remove-sensitive-column-tips": "このコラムを公開しますか?",
-      "sensitive-column-list": "明示的にマスクされた列",
-      "global-masking-rule": "グローバルマスキングルール",
-      "grant-access": "アクセス許可",
-      "never-expires": "期限切れなし",
+      "description": "次の感度解除列には、感度解除レベルが明示的にマークされており、グローバルな感度解除ルールよりも高い優先順位を持ちます。",
+      "remove-sensitive-column-tips": "このデータ列の感度を下げなくなりますか?",
+      "sensitive-column-list": "明示的にマークされたマスクされた列",
+      "global-masking-rule": "グローバルな減感作ルール",
+      "grant-access": "許可されたアクセス",
+      "never-expires": "有効期限なし",
       "global-rules": {
-        "self": "グローバルマスキングルール",
-        "description": "グローバル ルールを使用して、マスキング レベルをバッチで適用します。たとえば、「email」という名前のすべての列は、「Partial」レベルでマスキングされます。",
-        "condition-order": "条件順",
-        "re-order": "再注文",
+        "self": "グローバルな減感作ルール",
+        "description": "たとえば、列名が email のすべてのフィールドは、半鈍感化に設定されます。",
+        "condition-order": "条件付きシーケンス",
+        "re-order": "選別",
         "delete-rule-tip": "このルールを削除しますか?",
-        "check-rules": "グローバルルールを確認する"
+        "check-rules": "グローバル構成を表示する"
       },
       "semantic-types": {
         "self": "セマンティックタイプ",
-        "label": "同じセマンティック タイプを持つ列では、同じマスキング アルゴリズムが使用されます。",
-        "use-predefined-type": "定義済みタイプを使用する",
+        "label": "同じセマンティック タイプの列は、同じマスキング アルゴリズムを使用します。",
+        "use-predefined-type": "事前定義されたタイプを使用する",
         "add-from-template": "テンプレートから追加",
         "table": {
           "semantic-type": "セマンティックタイプ",
-          "description": "説明",
-          "full-masking-algorithm": "フルマスキングアルゴリズム",
-          "partial-masking-algorithm": "部分マスキングアルゴリズム",
+          "description": "説明する",
+          "full-masking-algorithm": "完全な減感アルゴリズム",
+          "partial-masking-algorithm": "半減感アルゴリズム",
           "delete": "このセマンティック タイプを削除しますか?"
         },
         "template": {
           "address": {
-            "title": "住所",
+            "title": "中国の詳細な住所",
             "description": ""
           },
           "secret_key": {
@@ -719,15 +719,15 @@
             "description": ""
           },
           "card_number": {
-            "title": "銀行カード、クレジットカードなど",
+            "title": "銀行カード、クレジットカード",
             "description": ""
           },
           "email": {
-            "title": "電子メールアドレス",
+            "title": "Eメール",
             "description": ""
           },
           "id_number": {
-            "title": "個人ID番号",
+            "title": "識別番号",
             "description": ""
           },
           "ipv4_address": {
@@ -735,7 +735,7 @@
             "description": ""
           },
           "license_plate_number": {
-            "title": "プレートナンバー",
+            "title": "ナンバープレートの番号",
             "description": ""
           },
           "mac_address": {
@@ -753,1047 +753,1047 @@
         }
       },
       "column-detail": {
-        "masking-setting-for-column": "「{column}」のマスキング設定",
-        "access-user-list": "アクセスユーザーリスト",
-        "access-user-list-desc": "マスク解除されたデータへのアクセスを許可されたユーザー。",
-        "remove-user-permission": "ユーザー権限を削除しますか?",
-        "remove-sensitive-warning": "列が公開されます。",
-        "column-effective-masking-tips": "この列は独自のマスキング レベルを構成しません。\nグローバル マスキング ルールを使用して、有効なマスキング レベルを表示しています。{link}"
+        "masking-setting-for-column": "「{column}」の感度解除設定",
+        "access-user-list": "ユーザーアクセスリスト",
+        "access-user-list-desc": "許可されたユーザーは、感度を下げられていない生データにアクセスできます。",
+        "remove-user-permission": "このユーザー権限を削除しますか?",
+        "remove-sensitive-warning": "データはクリア テキストに設定され、感度が解除されます。",
+        "column-effective-masking-tips": "このフィールドには、独自の感度解除レベルが設定されていません。\nここでは、世界的なルールに基づいた減感レベルを示します。 {link}"
       },
       "algorithms": {
-        "self": "マスキングアルゴリズム",
+        "self": "減感アルゴリズム",
         "default": "デフォルト",
-        "default-desc": "***をデータマスクとして使用します",
+        "default-desc": "*** を使用してデータをマスクする",
         "table": {
-          "title": "タイトル",
-          "description": "説明",
-          "masking-type": "マスキングタイプ",
-          "delete": "このアルゴリズムを削除しますか?"
+          "title": "名前",
+          "description": "説明する",
+          "masking-type": "アルゴリズムの種類",
+          "delete": "アルゴリズムを削除しますか?"
         },
         "error": {
-          "title-required": "タイトルは必須です",
-          "substitution-required": "代替品が必要です",
-          "substitution-length": "置換は16バイト未満にする必要があります",
-          "salt-required": "塩は必須",
-          "slice-required": "スライスが必要です",
-          "slice-invalid-number": "スライスの開始または終了が有効な数値ではありません",
-          "slice-number-range": "スライスの終了点は開始点より小さくなければなりません",
-          "slice-overlap": "スライス範囲は重複できません"
+          "title-required": "アルゴリズム名を入力してください",
+          "substitution-required": "マスク文字列を入力してください",
+          "substitution-length": "マスク文字列の長さは 16 文字を超えることはできません",
+          "salt-required": "塩分値を入力してください",
+          "slice-required": "マスク範囲を空にすることはできません",
+          "slice-invalid-number": "マスク範囲の開始値と終了値は数値である必要があります",
+          "slice-number-range": "マスク範囲の終了値は開始値より小さくなければなりません",
+          "slice-overlap": "マスキング範囲は重複できません"
         },
-        "mask": "マスク",
+        "mask": "隠れた",
         "hash": "ハッシュ",
         "full-mask": {
-          "self": "フルマスク",
-          "substitution": "代替",
-          "substitution-label": "置換は元の値を置き換えるために使用される文字列であり、文字列の最大長は 16 バイトです。"
+          "self": "完全なカバー範囲",
+          "substitution": "マスク文字列",
+          "substitution-label": "マスキング文字列は、元の値を置換するために使用される文字列であり、最大長 16 文字を超えることはできません。"
         },
         "range-mask": {
-          "self": "範囲マスク",
-          "label": "範囲マスクは、開始インデックスから終了インデックス（終了は含まれません）までの元の値を置換値に置き換えます。",
-          "slice-start": "スライス開始",
-          "slice-start-label": "スライスの開始は元の値の開始インデックスであり、0 から始まり、停止より小さくする必要があります。",
-          "slice-end": "スライス終了",
-          "slice-end-label": "スライス ストップは元の値のストップ インデックスであり、元の値の長さよりも小さくする必要があります。",
-          "substitution": "代替",
-          "substitution-label": "置換は、元の値 [start:end) を置き換えるために使用される文字列です。"
+          "self": "範囲マスキング",
+          "label": "範囲マスキングでは、マスクされた文字列を使用して、開始インデックスから終了インデックスまでの元の値を置き換えます (排他的)。",
+          "slice-start": "出発点",
+          "slice-start-label": "開始位置は元の値の開始インデックスであり、0 から始まり、終了位置より小さい値になります。",
+          "slice-end": "終了位置",
+          "slice-end-label": "終了位置は元の値の停止インデックスであり、元の値の長さより小さくなければなりません。",
+          "substitution": "マスク文字列",
+          "substitution-label": "マスキング文字列は、開始位置から終了位置までの文字列を置換するために使用されます。"
         },
         "md5-mask": {
-          "self": "MD5マスク",
+          "self": "MD5ハッシュ",
           "salt": "塩",
-          "salt-label": "ソルトは元の値からハッシュを生成するために使用されます。"
+          "salt-label": "ソルトは、元の値からハッシュ値を生成するために使用されます。"
         }
       },
       "masking-level": {
-        "self": "マスキングレベル",
-        "selet-level": "レベルを選択",
-        "masking_level_unspecified": "グローバルルールに従う",
-        "none": "なし",
-        "partial": "部分的",
-        "full": "満杯"
+        "self": "脱感作の程度",
+        "selet-level": "減感作のレベルを選択します",
+        "masking_level_unspecified": "全体像に従ってください",
+        "none": "プレーンテキスト",
+        "partial": "半鈍感症",
+        "full": "完全な脱感作"
       },
       "action": {
-        "self": "アクション",
-        "query": "クエリ",
+        "self": "操作の種類",
+        "query": "お問い合わせ",
         "export": "輸出"
       },
       "classification": {
-        "self": "データ分類",
-        "upload": "アップロード分類",
-        "upload-succeed": "アップロード成功",
-        "search": "検索分類",
-        "label": "分類ファイルをJSON形式でアップロードできます。",
-        "view-example": "例を見る",
-        "json-format-example": "分類JSON形式の例",
-        "copy-succeed": "コピー例成功",
-        "override-title": "分類データの上書き",
-        "override-desc": "既存の分類データは上書きされ、すべてのプロジェクトに影響します。",
-        "override-confirm": "まだアップロード中"
+        "self": "データの分類とグレーディング",
+        "upload": "輸入分類と格付け",
+        "upload-succeed": "インポート成功",
+        "search": "検索分類の評価",
+        "label": "データを分類・分類したJSON形式ファイルをアップロードできます。",
+        "view-example": "サンプルを見る",
+        "json-format-example": "分類と格付けの JSON 形式の例",
+        "copy-succeed": "サンプルをコピーしました",
+        "override-title": "カバレッジの分類および等級付けされたデータ",
+        "override-desc": "既存の分類およびグレーディング データは上書きされ、関連するすべてのプロジェクトが影響を受けます。",
+        "override-confirm": "インポートを続行する"
       }
     },
     "release": {
-      "new-version-available": "新しいバージョンが利用可能になりました",
-      "new-version-content": "新しいバージョン {tag} が利用可能になりました。インストールについてはドキュメントを確認してください。",
-      "not-show-till-next-release": "次のバージョンまでこれを表示しない"
+      "new-version-available": "更新する新しいバージョンがあります",
+      "new-version-content": "新しいバージョン {tag} が正式にリリースされました。新しいバージョンを入手するには、ドキュメントに従ってください。",
+      "not-show-till-next-release": "次の更新までは通知しないでください"
     },
     "mail-delivery": {
-      "description": "SMTP 情報を構成すると、ユーザーはスロークエリの週次レポートなどのデータベースレポートを電子メールで受信できるようになります。",
+      "description": "電子メール情報を構成すると、ユーザーはスロー クエリの週次レポートなど、データベース関連のレポートを電子メールで受信できるようになります。",
       "field": {
-        "smtp-server-host": "SMTP サーバーホスト",
-        "smtp-server-port": "SMTP サーバー ポート",
-        "from": "から",
+        "smtp-server-host": "SMTPサーバーホスト",
+        "smtp-server-port": "SMTPサーバーポート",
+        "from": "送信者のアドレス",
         "smtp-username": "SMTPユーザー名",
         "smtp-password": "SMTPパスワード",
-        "send-test-email-to": "テストメールを送信する",
+        "send-test-email-to": "受信者テストアドレス",
         "send": "送信",
-        "authentication-method": "認証方法",
+        "authentication-method": "識別方法",
         "encryption": "暗号化"
       },
-      "updated-tip": "メール配信設定が正常に更新されました",
-      "tested-tip": "送信に成功しました。{address} の受信トレイを確認してください。"
+      "updated-tip": "メールトランスポート構成が正常に更新されました",
+      "tested-tip": "正常に送信されました。{address} の受信箱を確認してください。"
     }
   },
   "activity": {
     "name": "名前",
     "comment": "コメント",
-    "created": "作成した",
-    "invoker": "召喚者",
+    "created": "内蔵",
+    "invoker": "執行者",
     "type": {
-      "issue-create": "問題を作成",
-      "comment-create": "コメントを作成",
-      "issue-field-update": "問題フィールドを更新",
-      "issue-status-update": "問題ステータスの更新",
-      "pipeline-stage-status-update": "問題ステージのステータスを更新",
-      "pipeline-task-status-update": "問題タスクのステータスを更新する",
-      "pipeline-task-statement-update": "SQL 更新",
-      "pipeline-task-prior-backup": "データの事前バックアップ",
-      "member-create": "メンバーを作成",
-      "member-role-update": "役割の更新",
-      "member-activate": "メンバーをアクティブ化",
-      "member-deactivate": "メンバーを非アクティブ化する",
-      "project-repository-push": "リポジトリプッシュイベント",
-      "project-database-transfer": "データベース転送",
-      "project-member-create": "プロジェクトメンバーを追加",
-      "project-member-delete": "プロジェクトメンバーを削除",
+      "issue-create": "作業指示書を作成する",
+      "comment-create": "コメントを作成する",
+      "issue-field-update": "チケットフィールドを更新する",
+      "issue-status-update": "作業指示ステータスを更新する",
+      "pipeline-stage-status-update": "作業指示書のステージステータスを更新する",
+      "pipeline-task-status-update": "作業指示タスクのステータスを更新する",
+      "pipeline-task-statement-update": "SQLを更新する",
+      "pipeline-task-prior-backup": "事前にデータをバックアップしておくこと",
+      "member-create": "メンバーの作成",
+      "member-role-update": "役割を更新する",
+      "member-activate": "メンバーをアクティブ化する",
+      "member-deactivate": "メンバーを無効にする",
+      "project-repository-push": "倉庫プッシュイベント",
+      "project-database-transfer": "転送データベース",
+      "project-member-create": "プロジェクトメンバーを追加する",
+      "project-member-delete": "プロジェクトメンバーを削除する",
       "project-member-role-update": "プロジェクトメンバーの役割を変更する",
-      "pipeline-task-earliest-allowed-time-update": "最も早い許可された時間を更新する",
-      "database-recovery-pitr-done": "データベースを特定の時点に復元する",
-      "external-approval-rejected": "外部承認が拒否されました"
+      "pipeline-task-earliest-allowed-time-update": "許可される最も早い実行時間を更新する",
+      "database-recovery-pitr-done": "データベースを指定した時点にリカバリする",
+      "external-approval-rejected": "外部の承認を拒否する"
     },
     "sentence": {
-      "created-issue": "問題を作成しました",
-      "commented": "コメントした",
-      "reassigned-issue": "問題を {oldName} から {newName} に再割り当てしました",
-      "assigned-issue": "{newName} に問題を割り当てました",
-      "unassigned-issue": "{oldName} からの未割り当ての問題",
-      "invalid-assignee-update": "無効な譲受人更新",
-      "changed-description": "説明を変更しました",
-      "changed-from-to": "{name} を「{oldValue}」から「{newValue}」に変更しました",
-      "unset-from": "「{oldValue}」から {name} の設定を解除します",
-      "set-to": "{name} を \"{newValue}\" に設定します",
-      "changed-update": "{name} の更新を変更しました",
-      "reopened-issue": "再開された問題",
-      "resolved-issue": "解決された問題",
-      "canceled-issue": "キャンセルされた問題",
+      "created-issue": "作業指示書を作成する",
+      "commented": "コメント",
+      "reassigned-issue": "作業指示書を {oldName} から {newName} に再割り当てします",
+      "assigned-issue": "作業指示書を {newName} に割り当てます",
+      "unassigned-issue": "{oldName} からの作業指示の割り当てを解除する",
+      "invalid-assignee-update": "無効な代入操作",
+      "changed-description": "説明の変更",
+      "changed-from-to": "{name} を「{oldValue}」から「{newValue}」に変更します",
+      "unset-from": "{name} の値を元に戻します (「{oldValue}」から)",
+      "set-to": "{name} を「{newValue}」に設定します",
+      "changed-update": "{name}を編集",
+      "reopened-issue": "作業指示を再開する",
+      "resolved-issue": "作業指示を完了する",
+      "canceled-issue": "作業指示をキャンセルする",
       "empty": "",
-      "changed": "かわった",
-      "updated": "更新しました",
+      "changed": "改訂",
+      "updated": "更新する",
       "canceled": "キャンセル",
-      "approved": "承認された",
-      "started": "開始",
-      "completed": "完了",
-      "failed": "失敗した",
-      "task-name": "タスク {name}",
-      "committed-to-at": "{file} を {branch}{'@'}{repo} にコミットしました",
-      "dismissed-stale-approval": "{task} の古い承認を却下しました",
-      "external-approval-rejected": "ステージ「{stageName}」の {imName} からの外部承認を拒否しました",
-      "skipped": "スキップ",
-      "rolled-out": "ロールアウト",
-      "schema-version": "スキーマ バージョン {version}",
-      "xxx-automatically": "{verb} 自動的に",
-      "verb-type-target-by-people": "{verb} {type} {target}",
+      "approved": "承認する",
+      "started": "始める",
+      "completed": "仕上げる",
+      "failed": "失敗",
+      "task-name": "タスク{name}",
+      "committed-to-at": "{file} を {branch}{'@'}{repo} に送信します",
+      "dismissed-stale-approval": "{task} を更新しました。以前の承認は取り消されました",
+      "external-approval-rejected": "{imName} 拒否ステージ「{stageName}」に対する外部承認",
+      "skipped": "飛び越える",
+      "rolled-out": "リリース",
+      "schema-version": "スキーマのバージョン {version}",
+      "xxx-automatically": "自動{verb}",
+      "verb-type-target-by-people": "{verb}{type} {target}",
       "verb-type-target-by-system-bot": "{type} {target} {verb}",
-      "changed-x-link": "{name} を変更しました。{link}",
-      "prior-back-table": "データベース {database} とテーブル {tables} へのデータ バックアップ",
-      "prior-back-table-for-line": "行 {line} の DML のデータベース {database} とテーブル {tables} へのデータ バックアップ"
+      "changed-x-link": "{name} が変更されました。 {link}",
+      "prior-back-table": "データベース {database} のテーブル {tables} にバックアップされました",
+      "prior-back-table-for-line": "DML のデータベース {database} とテーブル {tables} の行 {line} へのデータのバックアップ"
     },
     "subject-prefix": {
       "task": "タスク",
       "stage": "ステージ"
     },
-    "n-similar-activities": "({count} 件の類似アクティビティ) | ({count} 件の類似アクティビティ)"
+    "n-similar-activities": "({count} 件の同様のイベント)"
   },
   "issue": {
-    "my-issues": "私の問題",
+    "my-issues": "私の仕事の命令",
     "waiting-approval": "承認待ち",
-    "waiting-rollout": "ロールアウトを待つ",
-    "opened-by-at": "{creater} によって {time} に開かれました",
-    "commit-by-at": "{id} {title} を {author} が {time} にコミットしました",
+    "waiting-rollout": "リリースを待っています",
+    "opened-by-at": "{id} は {creator} から {time} まで始まりました",
+    "commit-by-at": "{id} {title} は {time} に {author} によって送信されました",
     "status-transition": {
       "modal": {
-        "resolve": "問題を解決しますか?",
-        "cancel": "この号全体をキャンセルしますか?",
-        "reopen": "問題を再開しますか?",
-        "title": "{action} {type} [{name}]?",
-        "action-to-stage": "{action} ステージ ({n} タスク)"
+        "resolve": "作業指示は完了しましたか?",
+        "cancel": "作業指示全体をキャンセルしますか?",
+        "reopen": "作業指示を再開しますか?",
+        "title": "{action}{type} [{name}]?",
+        "action-to-stage": "{action} ステージ ({n} 個のタスク)"
       },
       "dropdown": {
-        "resolve": "問題を解決する",
-        "cancel": "問題をキャンセル",
-        "reopen": "問題を再開する"
+        "resolve": "作業指示を完了する",
+        "cancel": "作業指示をキャンセルする",
+        "reopen": "再開"
       },
       "form": {
-        "note": "注記",
-        "placeholder": "(オプション) メモを追加します..."
+        "note": "ノート",
+        "placeholder": "(オプション) メモを追加します…"
       },
       "error": {
         "some-tasks-are-still-running": "一部のタスクはまだ実行中です"
       }
     },
-    "subscribe": "購読する",
-    "unsubscribe": "登録解除",
-    "subscriber": "購読者なし | 購読者 1 人 | 購読者 {n} 人",
-    "apply-to-other-tasks": "他のタスクに適用する",
-    "add-sql-statement": "SQL ステートメントを追加します...",
-    "optional-add-sql-statement": "(オプション) SQL ステートメントを追加します...",
-    "edit-description": "説明を編集",
-    "add-some-description": "説明を追加します...",
+    "subscribe": "サブスクリプション",
+    "unsubscribe": "購読を解除する",
+    "subscriber": "購読者なし | 購読者 1 人 | {n} 人の購読者",
+    "apply-to-other-tasks": "@:{'common.apply'} から他の @:{'common.task'}",
+    "add-sql-statement": "SQL @:{'common.statement'}…を追加",
+    "optional-add-sql-statement": "(オプション) SQL @:{'common.statement'}…を追加します。",
+    "edit-description": "説明の編集",
+    "add-some-description": "説明を追加してください…",
     "add-a-comment": "コメントを追加",
-    "edit-comment": "コメントを編集",
-    "leave-a-comment": "コメントを残す...",
+    "edit-comment": "編集者のコメント",
+    "leave-a-comment": "コメントを残す…",
     "comment-editor": {
-      "write": "書く",
+      "write": "編集",
       "preview": "プレビュー",
-      "nothing-to-preview": "プレビューするものがありません",
+      "nothing-to-preview": "まだプレビューはありません",
       "toolbar": {
-        "header": "見出しテキストを挿入",
-        "bold": "太字テキストを挿入",
+        "header": "タイトルを挿入",
+        "bold": "太字のテキストを挿入する",
         "code": "SQLコードスニペットを挿入",
         "link": "リンクを挿入",
-        "hashtag": "問題のリンクを ID で挿入します。ハッシュタグ「#」の後に問題 ID を入力します。"
+        "hashtag": "ID によるチケットリンクを挿入します。 「#」の後に作業指示書 ID を入力してください"
       }
     },
-    "view-commit": "コミットを表示",
+    "view-commit": "提出物を見る",
     "advanced-search": {
-      "self": "詳細検索",
+      "self": "高度な検索",
       "filter": "フィルター",
       "scope": {
         "project": {
           "title": "プロジェクト",
-          "description": "プロジェクトでフィルタリング"
+          "description": "プロジェクトでフィルターする"
         },
         "instance": {
-          "title": "実例",
-          "description": "インスタンスでフィルタリング"
+          "title": "例",
+          "description": "インスタンスによるフィルター"
         },
         "environment": {
           "title": "環境",
-          "description": "環境でフィルタリング"
+          "description": "環境に基づいてフィルタリングする"
         },
         "database": {
           "title": "データベース",
-          "description": "データベースでフィルタリング"
+          "description": "データベースに基づいてフィルタリングする"
         },
         "type": {
-          "title": "タイプの変更",
-          "description": "問題のデータベース変更タイプ"
+          "title": "種類の変更",
+          "description": "データベース変更タイプによる検索"
         },
         "creator": {
-          "title": "クリエイター",
-          "description": "問題作成者による検索"
+          "title": "創設者",
+          "description": "チケット作成者で検索"
         },
         "assignee": {
-          "title": "譲受人",
-          "description": "課題担当者による検索"
+          "title": "被指名者",
+          "description": "作業指示の担当者で検索"
         },
         "subscriber": {
           "title": "購読者",
-          "description": "号購読者による検索"
+          "description": "チケット購入者から探す"
         },
         "principal": {
-          "title": "関連するプリンシパル",
-          "description": "問題の作成者、担当者、またはサブスクライバーで検索"
+          "title": "関連ユーザー",
+          "description": "チケットの作成者、譲受人、または購読者"
         },
         "approver": {
           "title": "承認者",
-          "description": "問題承認者による検索"
+          "description": "作業指示書の承認者で検索"
         },
         "approval": {
           "value": {
-            "pending": "承認待ちの",
+            "pending": "保留中",
             "approved": "承認された"
           },
-          "description": "問題の承認ステータスで検索",
+          "description": "作業指示書の承認ステータスで検索する",
           "title": "承認状況"
         },
         "project-assigned": {
           "title": "割り当てられたプロジェクト",
-          "description": "プロジェクトに割り当てられているデータベースで検索します。",
+          "description": "データベースのプロジェクト割り当て状況から検索",
           "value": {
             "yes": "はい",
             "no": "いいえ"
           }
         }
       },
-      "hide": "詳細検索を非表示"
+      "hide": "詳細検索を非表示にする"
     },
     "table": {
-      "open": "開ける",
+      "open": "オープニング",
       "closed": "閉まっている",
-      "status": "状態",
+      "status": "州",
       "project": "プロジェクト",
       "name": "名前",
       "environment": "環境",
-      "db": "デービッド",
-      "progress": "進捗",
-      "updated": "更新しました",
+      "db": "データベース",
+      "progress": "スケジュール",
+      "updated": "に更新されました",
       "approver": "承認者",
-      "creator": "クリエイター",
-      "assignee": "譲受人"
+      "creator": "創設者",
+      "assignee": "被指名者"
     },
     "stage-select": {
       "active": "{name} (アクティブ)"
     },
-    "not-allowed-to-operate-unassigned-database": "割り当てられていないデータベースに対しては {operation} を実行できません。\nまずプロジェクトに転送する必要があります。",
+    "not-allowed-to-operate-unassigned-database": "未割り当てのデータベースは {operation} できません。\nまずプロジェクトに転送する必要があります。",
     "migration-mode": {
-      "title": "移行モード",
+      "title": "モードを変更する",
       "normal": {
-        "title": "通常の移行（通常サイズのテーブルの場合）",
-        "description": "ターゲット テーブルで直接スキーマ変更を実行します。移行中はロックが保持されます。"
+        "title": "通常の変更 (通常サイズのテーブルの場合)",
+        "description": "ターゲットテーブルに対して直接スキーマ変更を実行すると、テーブルは変更中ずっとロックされます。"
       },
       "online": {
-        "title": "オンライン移行（大規模テーブルの場合）",
-        "description": "gh-ost に基づいています。大きなテーブルの場合、テーブル ロックの継続時間を数時間から数秒に短縮できます {link}。"
+        "title": "オンラインでの大規模なテーブル変更 (大量のデータを含むテーブルに適用)",
+        "description": "gh-ostをベースにしています。大規模なテーブルの場合、テーブルのロック時間を数時間から数秒 {link} に短縮できます。"
       }
     },
-    "new-issue": "@:common.new @:common.issue",
+    "new-issue": "@:common.new@:common.issue",
     "format-on-save": "保存時にフォーマットする",
-    "action-to-current-stage": "{action} 現在のステージ",
-    "edit-sql-statement-in-vcs": "このプロジェクトでは、VCS ベースのバージョン管理が有効になっています。対応する Git リポジトリ内の SQL ファイルを変更し、コミットして新しい問題を作成してください。",
+    "action-to-current-stage": "{action}現在の段階",
+    "edit-sql-statement-in-vcs": "このプロジェクトにより、VCS ベースのバージョン管理が可能になります。対応する Git リポジトリ内の SQL ファイルを変更し、それを送信して新しい作業指示をオープンしてください。",
     "edit-sql-statement": "SQL文を編集する",
-    "upload-sql": "SQL をアップロード",
-    "upload-sql-as-sheet": "SQL をシートとしてアップロード",
-    "statement-from-sheet-warning": "SQL のサイズが大きすぎるため、インライン編集は許可されていません。新しい SQL ファイルをアップロードして上書きすることができます。",
-    "overwrite-current-statement": "現在のSQL文を上書きする",
-    "upload-sql-file-max-size-exceeded": "最大ファイルサイズ ({size}) を超えました。",
-    "waiting-earliest-allowed-time": "{time} 後に実行されます",
+    "upload-sql": "SQLのアップロード",
+    "upload-sql-as-sheet": "SQLをワークシートにアップロード",
+    "statement-from-sheet-warning": "SQL は大きすぎて直接編集できません。新しい SQL ファイルをアップロードして上書きできます。",
+    "overwrite-current-statement": "現在の SQL ステートメントを上書きする",
+    "upload-sql-file-max-size-exceeded": "アップロード ファイルのサイズは {size} を超えることはできません。",
+    "waiting-earliest-allowed-time": "{time}の後に実行されます",
     "batch-transition": {
-      "not-allowed-tips": "選択した問題の一部は{operation}できません",
-      "resolve": "解決する",
-      "resolved": "解決済み",
+      "not-allowed-tips": "選択した作業指示の一部を {operation} にすることはできません",
+      "resolve": "仕上げる",
+      "resolved": "仕上げる",
       "cancel": "キャンセル",
       "cancelled": "キャンセル",
       "reopen": "再開",
       "reopened": "再開",
-      "action-n-issues": "{action} {n} 件の問題 | {action} {n} 件の問題",
-      "successfully-updated-n-issues": "{n} 件の問題を正常に更新しました | {n} 件の問題を正常に更新しました"
+      "action-n-issues": "{action} {n} 枚のチケット",
+      "successfully-updated-n-issues": "{n} 個のチケットが正常に更新されました"
     },
     "sql-hint": {
-      "change-will-apply-to-all-tasks-in-tenant-mode": "変更はすべてのタスクに適用されます",
-      "dont-apply-to-database-in-baseline-migration": "ベースライン設定では、変更履歴に現在のスキーマのみが記録され、SQLはデータベースに適用されません。",
-      "snowflake": "Snowflakeテーブルを指定するには、<<schema>>.<<table>>を使用します。"
+      "change-will-apply-to-all-tasks-in-tenant-mode": "変更は他のすべてのタスクに適用されます",
+      "dont-apply-to-database-in-baseline-migration": "ベースラインを確立すると、現在のスキーマが変更履歴に記録されるだけで、データベースに SQL は適用されません。",
+      "snowflake": "<<schema>>.<<table>> を使用して SnowFlake テーブルに注釈を付けます"
     },
-    "will-rollback": "このタスクはロールバックします {link}",
-    "issue-link-with-task": "問題 {issue} - タスク {task}",
+    "will-rollback": "現在のタスクはロールバックされます {link}",
+    "issue-link-with-task": "チケット {issue} - タスク {task}",
     "assignee-attention": {
-      "send-approval-request-successfully": "{im} 承認リクエストを正常に送信しました",
-      "send-attention-request-successfully": "担当者 {principal} の注意を正常にリクエストしました",
-      "needs-attention": "注意が必要",
-      "click-to-mark": "クリックして担当者の注意を喚起する"
+      "send-approval-request-successfully": "{im}承認リクエストは正常に送信されました",
+      "send-attention-request-successfully": "レビューアー {principal} がフォローリクエストを受け取りました",
+      "needs-attention": "注意が必要です",
+      "click-to-mark": "クリックして査読者の注意をリクエストします"
     },
     "sdl": {
       "schema-change": "スキーマの変更",
       "generated-ddl-statements": "生成されたDDLステートメント",
       "full-schema": "完全なスキーマ",
-      "left-schema-may-change": "問題が適用される前に、左側のスキーマが変更される場合があります。"
+      "left-schema-may-change": "左側のスキーマは、チケットが実行される前に変更される可能性があります。"
     },
-    "assignee-tooltip": "担当者は問題の責任者であり、問題が割り当てられると、割り当てられた問題のリストに表示されます。",
+    "assignee-tooltip": "担当者は、問題に取り組む責任のある人であり、問題が割り当てられると、その担当者の [割り当て済み問題] リストに表示されます。",
     "approval-flow": {
-      "self": "承認フロー",
-      "tooltip": "承認者は、フローで指定された順序で問題を確認し、承認します。問題は、フローのすべてのステップが承認された後にのみ適用できます。リスクごとにカスタム承認フローを構成できます。",
-      "pre-issue-created-tips": "問題が作成されると、Bytebase は問題の種類とリスク レベルに基づいて、対応するカスタム承認を自動的に一致させます。"
+      "self": "承認の流れ",
+      "tooltip": "承認者は、承認フローで指定された順序で作業指示書を確認し、承認する必要があります。作業指示は、承認フローのすべてのステップが承認された後にのみ実行できます。リスクレベルごとに承認をカスタマイズできます。",
+      "pre-issue-created-tips": "作業指示書が作成されると、システムは作業指示書のタイプとリスク レベルに基づいて、対応するカスタム承認を自動的に照合します。"
     },
-    "waiting-to-rollout": "ロールアウトを待つ",
-    "waiting-for-review": "レビュー待ち",
-    "issue-name": "問題名",
+    "waiting-to-rollout": "リリースを待っています",
+    "waiting-for-review": "モデレート済み",
+    "issue-name": "作業指示書名",
     "grant-request": {
-      "export-rows": "最大エクスポート行数",
-      "expire-days": "有効期限日数",
+      "export-rows": "エクスポート行の最大数",
+      "expire-days": "有効期限日",
       "expired-at": "有効期限",
-      "all-databases": "全て",
-      "all-databases-tip": "このプロジェクトの現在のデータベースと将来のデータベースすべて。",
-      "manually-select": "手動で選択",
-      "custom": "カスタム",
-      "data-export-attention": "データはファイルにエクスポートされ、ローカル マシンにダウンロードされます。エクスポート操作は 1 回のみ実行できます。",
+      "all-databases": "すべてのデータベース",
+      "all-databases-tip": "このプロジェクトに属する現在および将来のすべてのデータベース。",
+      "manually-select": "手動選択",
+      "custom": "カスタマイズ",
+      "data-export-attention": "データはファイルにエクスポートされ、自動的にダウンロードされます。また、エクスポート操作は 1 回しか完了できません。",
       "export-method": "エクスポート方法",
-      "request-sent": "リクエストを送信しました",
+      "request-sent": "エクスポートリクエストが送信されました",
       "please-select-database-first": "最初にデータベースを選択してください"
     },
-    "review-sent-back": "レビューを返送しました",
+    "review-sent-back": "レビューが返されました",
     "update-statement": {
-      "self": "{type} を更新",
+      "self": "{type}を更新します",
       "apply-current-change-to": "現在の変更を適用する",
       "target": {
-        "selected-task": "選択されたタスク",
+        "selected-task": "選択したタスク",
         "selected-stage": "選択したステージ",
         "all-tasks": "すべてのタスク"
       },
-      "current-change-will-apply-to-all-tasks-in-batch-mode": "バッチモードでは、現在の変更がすべてのタスクに適用されます。"
+      "current-change-will-apply-to-all-tasks-in-batch-mode": "バッチ モードでは、現在の変更がすべてのタスクに適用されます。"
     },
-    "not-editable-legacy-issue": "この問題は、Bytebase の古いバージョンで作成されたため編集できません。",
-    "action-anyway": "とにかく{action}",
+    "not-editable-legacy-issue": "このチケットは古いバージョンの Bytebase で作成されたため編集できません。",
+    "action-anyway": "まだ {action} が必要です",
     "disallow-edit-reasons": {
-      "issue-is-done": "問題は解決した",
-      "issue-is-canceled": "問題はキャンセルされました",
-      "task-is-x-status": "タスクは{status}です",
-      "task-is-running-cancel-first": "タスクは実行中です。この値を変更する前にタスクをキャンセルしてください。"
+      "issue-is-done": "作業指示が完了しました",
+      "issue-is-canceled": "作業指示がキャンセルされました",
+      "task-is-x-status": "タスクのステータスは {status} です",
+      "task-is-running-cancel-first": "タスクが実行中です。この値を変更するには、タスクをキャンセルする必要があります。"
     },
-    "you-are-not-allowed-to-change-this-value": "この値を変更することはできません",
+    "you-are-not-allowed-to-change-this-value": "この値を変更する権限がありません",
     "sql-check": {
-      "sql-checks": "SQL チェック",
+      "sql-checks": "SQLチェック項目",
       "not-executed-yet": "まだ実行されていません",
       "no-configured-sql-review-policy": {
-        "admin": "{environment} 環境では SQL レビュー ポリシーが構成されていません。{link}",
-        "developer": "{environment} 環境では SQL レビュー ポリシーが構成されていません。DBA に構成を依頼してください。"
+        "admin": "{environment}環境には SQL 監査ポリシーが構成されていません。 {link}",
+        "developer": "{environment} 環境には SQL 監査ポリシーが構成されていません。DBA に構成を依頼してください。"
       },
-      "statement-is-too-large": "文が大きすぎます",
+      "statement-is-too-large": "ステートメントが大きすぎます",
       "back-to-edit": "編集に戻る",
-      "continue-anyway": "とにかく続けます",
-      "sql-review-violations": "SQLレビュー違反"
+      "continue-anyway": "まだ続く",
+      "sql-review-violations": "SQL監査ルール違反"
     },
     "error": {
-      "issue-is-not-open": "この問題は未解決である",
-      "you-don-have-privilege-to-edit-this-issue": "この問題を編集する権限がありません",
-      "you-are-not-allowed-to-perform-this-action": "この操作を実行することは許可されていません"
+      "issue-is-not-open": "作業指示はオープンされていません",
+      "you-don-have-privilege-to-edit-this-issue": "このチケットを編集する権限がありません",
+      "you-are-not-allowed-to-perform-this-action": "このアクションを実行する権限がありません"
     },
-    "approval-requested": "承認をリクエスト",
+    "approval-requested": "承認リクエスト",
     "assignee": {
       "current-assignee": "現在の譲受人",
-      "workspace-admins": "ワークスペース管理者",
+      "workspace-admins": "バイトベースワークスペース管理者",
       "workspace-dbas": "DBA",
       "project-owners": "プロジェクトオーナー",
-      "releasers-of-current-stage": "現在のステージのリリース者",
+      "releasers-of-current-stage": "現在のステージの発行元",
       "approvers-of-current-step": "現在のステップの承認者"
     },
-    "unfinished-resolved-issue-tips": "この問題は「完了」としてマークされていますが、一部のタスクは正常に実行されていません。",
-    "some-tasks-are-not-executed-successfully": "(一部のタスクは正常に実行されません)",
-    "preview": "プレビュー号",
-    "missing-sql-statement": "SQL ステートメントがありません。この変更をすべてのタスクに適用するには、@:{'issue.apply-to-other-tasks'} ボタンをクリックしてください。",
-    "task-summary-tooltip": "{failed} タスクが失敗しました | {failed} タスクが失敗しました",
+    "unfinished-resolved-issue-tips": "作業指示書は「完了」とマークされましたが、一部のタスクは正常に実行されませんでした。",
+    "some-tasks-are-not-executed-successfully": "(一部のタスクは正常に実行されませんでした)",
+    "preview": "作業指示のプレビュー",
+    "missing-sql-statement": "SQL ステートメントが欠落しています。この変更をすべてのタスクに適用するには、「@:{'issue.apply-to-other-tasks'}」ボタンをクリックします。",
+    "task-summary-tooltip": "{failed} 個のタスクが失敗しました",
     "data-export": {
-      "options": "オプション",
-      "format": "フォーマット",
+      "options": "設定項目",
+      "format": "エクスポート形式",
       "encrypt": "暗号化",
-      "file-downloaded": "ファイルをダウンロードしました"
+      "file-downloaded": "ダウンロードされたファイル"
     }
   },
   "alter-schema": {
-    "vcs-enabled": "このプロジェクトでは VCS ベースのバージョン管理が有効になっており、以下のデータベースを選択すると、対応する Git リポジトリに移動して変更プロセスが開始されます。",
-    "vcs-info": "VCS が有効です。これを選択すると、対応する Git リポジトリに移動して変更プロセスが開始されます。",
-    "alter-single-db": "単一データベースの変更",
-    "alter-multiple-db": "手動選択",
-    "alter-db-group": "デプロイメント構成別",
-    "no-databases-in-project": "このプロジェクトにはデータベースがありません。データベースを追加するには、[新しい DB] または [DB の転送] をクリックしてください。"
+    "vcs-enabled": "このプロジェクトでは、VCS ベースのバージョン管理が有効になっています。以下のデータベースを選択すると、対応する Git リポジトリに移動して、変更プロセスを開始します。",
+    "vcs-info": "VCS バージョン管理が有効になっています。データベースを選択すると、対応する Git リポジトリにジャンプし、変更プロセスが開始されます。",
+    "alter-single-db": "単一のデータベースを変更する",
+    "alter-multiple-db": "データベースを手動で選択する",
+    "alter-db-group": "デプロイされた構成による",
+    "no-databases-in-project": "このプロジェクトにはデータベースがありません。 「データベースの作成」または「データベースの転送」をクリックしてデータベースを追加します。"
   },
   "quick-action": {
-    "create-db": "データベースを作成する",
-    "new-db": "新しいDB",
-    "add-instance": "@:common.add @:common.instance",
-    "create-instance": "@:common.create @:common.instance",
-    "manage-user": "ユーザーの管理",
-    "add-environment": "@:common.add @:common.environment",
-    "create-environment": "@:common.create @:common.environment",
-    "new-project": "@:common.new @:common.project",
-    "create-project": "@:common.create @:common.project",
-    "edit-data": "データを編集",
+    "create-db": "データベースの作成",
+    "new-db": "データベースの作成",
+    "add-instance": "@:common.add@:common.instance",
+    "create-instance": "@:common.create@:common.instance",
+    "manage-user": "会員管理",
+    "add-environment": "@:common.add@:common.environment",
+    "create-environment": "@:common.create@:common.environment",
+    "new-project": "@:common.new@:common.project",
+    "create-project": "@:common.create@:common.project",
+    "edit-data": "データ編集",
     "troubleshoot": "トラブルシューティング",
-    "transfer-in-db": "DBでの転送",
-    "request-db": "リクエストDB",
-    "from-unassigned-databases": "割り当てられていないデータベースを転送する",
-    "from-projects": "他のプロジェクトからの移行",
+    "transfer-in-db": "データベースへの転送",
+    "request-db": "データベースの申請",
+    "from-unassigned-databases": "未割り当てのデータベースを転送する",
+    "from-projects": "他のプロジェクトからの移管",
     "transfer-in-db-title": "データベースへの転送",
     "transfer-in-db-alert": "「{ dbName }」をプロジェクトに転送してもよろしいですか?",
-    "unassigned-db-hint": "新しく同期されたデータベースは割り当てられていない状態で開始され、使用するにはプロジェクトに移動する必要があります。",
-    "transfer-out-db": "DBを転送",
-    "transfer-out-db-title": "データベースの転送",
-    "request-export-data": "エクスポートをリクエスト"
+    "unassigned-db-hint": "新しく同期されたデータベースは最初は割り当てられていないため、使用するにはプロジェクトに移動する必要があります。",
+    "transfer-out-db": "データベースを転送する",
+    "transfer-out-db-title": "データベースを転送する",
+    "request-export-data": "データのエクスポートに適用する"
   },
   "create-db": {
     "new-database-name": "新しいデータベース名",
-    "database-owner-name": "データベース所有者名",
+    "database-owner-name": "データベース所有者",
     "cluster": "集まる",
-    "reserved-db-error": "{databaseName} は予約名です",
+    "reserved-db-error": "{databaseName} は予約された名前です",
     "generated-database-name": "生成されたデータベース名",
-    "db-name-generated-by-template": "テンプレート「{template}」によって生成されました",
+    "db-name-generated-by-template": "テンプレート「{template}」に基づいて生成されました",
     "input-label-value": "{key}を入力してください",
     "new-collection-name": "新しいコレクション名"
   },
   "db": {
-    "encoding": "エンコーディング",
+    "encoding": "文字コード",
     "character-set": "キャラクターセット",
-    "collation": "照合",
-    "select": "データベースを選択",
-    "select-instance-first": "最初にインスタンスを選択",
-    "select-environment-first": "まず環境を選択してください",
-    "tables": "テーブル",
-    "collections": "コレクション",
+    "collation": "文字の並べ替え規則",
+    "select": "データベースの選択",
+    "select-instance-first": "最初にインスタンスを選択します",
+    "select-environment-first": "まずは環境を選ぶ",
+    "tables": "表面",
+    "collections": "集める",
     "views": "ビュー",
-    "extensions": "拡張機能",
+    "extensions": "プラグイン",
     "external-tables": "外部テーブル",
-    "functions": "機能",
+    "functions": "関数",
     "streams": "ストリーム",
     "tasks": "タスク",
-    "parent": "親",
-    "labels-for-resource": "{resource} のラベル",
-    "last-successful-sync": "最後に成功した同期",
+    "parent": "母親",
+    "labels-for-resource": "{resource} のタグ",
+    "last-successful-sync": "最後に正常に同期された日",
     "sync-status": "同期ステータス",
     "failed-to-sync-schema-for-database-database-value-name": "データベース '{0}' のスキーマを同期できませんでした。",
     "successfully-synced-schema-for-database-database-value-name": "データベース '{0}' のスキーマが正常に同期されました。",
-    "start-to-sync-schema": "スキーマの同期を開始する",
+    "start-to-sync-schema": "スキーマの同期を開始します",
     "failed-to-sync-schema": "スキーマの同期に失敗しました",
-    "successfully-synced-schema": "スキーマが正常に同期されました",
-    "create": "データベースを作成する",
-    "procedures": "手順",
+    "successfully-synced-schema": "スキーマの同期が完了しました",
+    "create": "データベースの作成",
+    "procedures": "ストアドプロシージャ",
     "partitions": "パーティション"
   },
   "instance": {
-    "select": "インスタンスを選択",
-    "select-database-user": "データベースユーザーを選択",
-    "new-database": "新しいデータベース",
-    "syncing": "同期中...",
-    "selected-n-instances": "{n} 個のインスタンスが選択されました | {n} 個のインスタンスが選択されました",
-    "create-migration-schema": "移行スキーマを作成する",
-    "missing-migration-schema": "移行スキーマがありません",
-    "unable-to-connect-instance-to-check-migration-schema": "移行スキーマを確認するためにインスタンスに接続できません",
-    "bytebase-relies-on-migration-schema-to-manage-gitops-based-schema-migration-for-databases-belonged-to-this-instance": "Bytebase は、このインスタンス上のデータベース スキーマの移行を記録するために移行スキーマに依存しています。移行スキーマを設定しないと、インスタンス上のどのデータベースのスキーマも編集したりデータを変更したりすることはできません。",
-    "please-contact-your-dba-to-configure-it": "設定するには DBA にお問い合わせください。",
-    "please-check-the-instance-connection-info-is-correct": "インスタンス接続情報が正しいことを確認してください。",
+    "select": "インスタンスの選択",
+    "select-database-user": "データベースユーザーの選択",
+    "new-database": "@:common.new@:common.database",
+    "syncing": "同期中 ...",
+    "selected-n-instances": "{n} 個のインスタンスが選択されました",
+    "create-migration-schema": "@:common.create@:common.migration @:{'common.schema'}",
+    "missing-migration-schema": "@:common.migration @:common.schema がありません",
+    "unable-to-connect-instance-to-check-migration-schema": "@:{'common.migration'} @:{'common.schema'} を確認するために @:{'common.instance'} に接続できません",
+    "bytebase-relies-on-migration-schema-to-manage-gitops-based-schema-migration-for-databases-belonged-to-this-instance": "Bytebase は、このインスタンスのデータベース スキーマの変更を記録するために「スキーマの変更」に依存する必要があります。 「スキーマの変更」が設定されていない場合、このインスタンスのデータベースに対してテーブル構造やデータを変更することはできません。",
+    "please-contact-your-dba-to-configure-it": "構成については DBA に問い合わせてください。",
+    "please-check-the-instance-connection-info-is-correct": "インスタンスの接続情報が正しいか確認してください。",
     "users": "ユーザー",
-    "successfully-archived-instance-updatedinstance-name": "インスタンス '{0}' を正常にアーカイブしました。",
+    "successfully-archived-instance-updatedinstance-name": "インスタンス '{0}' が正常にアーカイブされました。",
     "successfully-restored-instance-updatedinstance-name": "インスタンス '{0}' が正常に復元されました。",
-    "failed-to-create-migration-schema-for-instance-instance-value-name": "インスタンス '{0}' の移行スキーマを作成できませんでした。",
-    "successfully-created-migration-schema-for-instance-value-name": "'{0}' の移行スキーマが正常に作成されました。",
+    "failed-to-create-migration-schema-for-instance-instance-value-name": "インスタンス '{0}' の変更スキーマを作成できませんでした。",
+    "successfully-created-migration-schema-for-instance-value-name": "'{0}' の変更スキーマが正常に作成されました。",
     "failed-to-sync-schema-for-instance-instance-value-name": "インスタンス '{0}' のスキーマを同期できませんでした。",
     "successfully-synced-schema-for-instance-instance-value-name": "インスタンス '{0}' のスキーマが正常に同期されました。",
     "archive-this-instance": "このインスタンスをアーカイブする",
-    "archive-instance-instance-name": "アーカイブインスタンス '{0}'?",
-    "archived-instances-will-not-be-displayed": "アーカイブされたインスタンスは表示されません。",
-    "restore-this-instance": "このインスタンスを復元する",
-    "restore": "復元する",
+    "archive-instance-instance-name": "インスタンス '{0}' をアーカイブしますか?",
+    "archived-instances-will-not-be-displayed": "アーカイブされたインスタンスは表示されなくなります。",
+    "restore-this-instance": "インスタンスを復元する",
+    "restore": "回復する",
     "restore-instance-instance-name-to-normal-state": "インスタンス '{0}' を通常の状態に復元しますか?",
     "account-locator": "アカウントロケーター",
     "account": "アカウント",
     "name": "名前",
     "host-or-socket": "ホストまたはソケット",
-    "project-id-and-instance-id": "プロジェクトIDとインスタンスID",
+    "project-id-and-instance-id": "プロジェクト ID とインスタンス ID",
     "project-id": "プロジェクトID",
     "instance-id": "インスタンスID",
-    "your-snowflake-account-locator": "Snowflakeアカウントロケーター",
+    "your-snowflake-account-locator": "Snowflake アカウント ロケーター",
     "port": "ポート",
     "authentication-database": "認証データベース",
-    "instance-name": "インスタンス名",
-    "snowflake-web-console": "スノーフレークウェブコンソール",
+    "instance-name": "@:common.instance@:instance.name",
+    "snowflake-web-console": "スノーフレーク@:{'instance.web-console'}",
     "external-link": "外部リンク",
-    "web-console": "ウェブコンソール",
+    "web-console": "Webコンソール",
     "connection-info": "接続情報",
-    "show-how-to-create": "作成方法を表示",
-    "below-is-an-example-to-create-user-bytebase-with-password": "以下はパスワード付きのユーザー「bytebase{'@'}%」を作成する例です。",
-    "your_db_pwd": "あなたのDBパスワード",
-    "no-read-only-data-source-warn-for-admin-dba": "インスタンスには読み取り専用接続が設定されていません。追加することを検討してください。",
-    "no-read-only-data-source-warn-for-developer": "インスタンスには読み取り専用接続が設定されていません。DBA に追加を依頼してください。",
+    "show-how-to-create": "作成方法",
+    "below-is-an-example-to-create-user-bytebase-with-password": "ユーザー「bytebase{'@'}%」とそのパスワードを作成する例は次のとおりです。",
+    "your_db_pwd": "YOUR_DB_PWD",
+    "no-read-only-data-source-warn-for-admin-dba": "このインスタンスは読み取り専用接続で構成されていません。構成を検討してください。",
+    "no-read-only-data-source-warn-for-developer": "このインスタンスには読み取り専用接続が構成されていません。構成するように DBA に依頼してください。",
     "sentence": {
       "host": {
-        "snowflake": "例: host.docker.internal {'|'} <<ip>> {'|'} <<local socket>>"
+        "snowflake": "たとえば、host.docker.internal {'|'} <<ip>> {'|'} <<ローカルソケット>>"
       },
       "proxy": {
-        "snowflake": "プロキシサーバーの場合は、{'@'}PROXY_HOSTを追加し、ポートにPROXY_PORTを指定します。"
+        "snowflake": "プロキシ サーバーの場合は、{'@'}PROXY_HOST を追加し、ポートに PROXY_PORT を指定します。"
       },
       "console": {
-        "snowflake": "このインスタンスを管理する外部コンソール URL (例: AWS RDS コンソール、社内 DB インスタンス コンソール)"
+        "snowflake": "この @:{'common.instance'} を管理する外部コンソール URL (AWS RDS コンソール、@:{'common.database'} コンソールなど)"
       },
-      "outbound-ip-list": "データベース インスタンスに受信ファイアウォール ルールを使用する場合は、Bytebase Cloud によるアクセスを許可するために、次の IP アドレスを許可リストに含めてください。",
-      "create-admin-user": "これは、Bytebase が DDL および DML (非 SELECT) 操作を実行するために使用する接続ユーザーです。",
-      "create-readonly-user": "これは、Bytebase が SELECT クエリなどの読み取り専用操作を実行するために使用する接続です。",
-      "create-admin-user-non-sql": "これは、Bytebase が書き込みおよび管理操作を実行するために使用する接続ユーザーです。",
-      "create-readonly-user-non-sql": "これは、Bytebase が読み取り専用操作を実行するために使用する接続です。",
+      "outbound-ip-list": "データベースが受信 IP ホワイトリストを使用している場合は、次の IP をホワイトリストに登録して、Bytebase Cloud への接続を許可します。",
+      "create-admin-user": "これは、データベースに接続し、DDL および DML (非 SELECT) 操作を実行するために Bytebase によって使用されるユーザーです。",
+      "create-readonly-user": "これは、データベースに接続し、SELECT などの読み取り専用操作を実行するために Bytebase によって使用されるユーザーです。",
+      "create-admin-user-non-sql": "これは、データベースに接続し、書き込みおよび管理操作を実行するために Bytebase によって使用されるユーザーです。",
+      "create-readonly-user-non-sql": "これは、データベースに接続して読み取り専用操作を実行するために Bytebase によって使用されるユーザーです。",
       "google-cloud-sql": {
         "instance-name": "インスタンス接続名",
-        "instance-name-tips": "インスタンス接続名は、project-id:region:instance-name のようになります。",
+        "instance-name-tips": "インスタンス接続名は project-id:region:instance-name である必要があります。",
         "mysql": {
-          "template": "{user} という名前のサービス アカウントを作成し、それを IAM ユーザー {user}{'@'}'%' として Google Cloud SQL に追加します。このユーザーに必要な権限を付与します。"
+          "template": "{user} という名前のサービス アカウントを作成し、IAM ユーザー {user}{'@'}'%' として Google Cloud SQL に追加します。このユーザーに必要な権限を付与します。"
         },
         "postgresql": {
-          "template": "{user} という名前のサービス アカウントを作成し、それを IAM ユーザー {user}{'@'}project-id.iam として Google Cloud SQL に追加します。ユーザーに必要な権限を付与します。"
+          "template": "{user} という名前のサービス アカウントを作成し、IAM ユーザー {user}{'@'}project-id.iam として Google Cloud SQL に追加します。ユーザーに必要な権限を付与します。"
         }
       },
       "create-user-example": {
         "snowflake": {
-          "template": "以下は、{warehouse} のパスワード {password} を持つユーザー '{user}' を作成し、そのユーザーに必要な権限を付与する例です。"
+          "template": "ユーザー {user}、パスワード {password}、ウェアハウス {warehouse} を作成し、必要な権限を付与する例は次のとおりです。"
         },
         "mysql": {
-          "template": "以下は、パスワード {password} を持つユーザー {user}{'@'}% を作成し、そのユーザーに必要な権限を付与する例です。"
+          "template": "ユーザー {user}、パスワード {password} を作成し、必要な権限を付与する例は次のとおりです。"
         },
         "clickhouse": {
-          "template": "以下は、パスワード {password} を持つユーザー '{user}' を作成し、必要な権限をユーザーに付与する例です。まず、ClickHouse SQL 駆動型ワークフロー {link} を有効にし、次のクエリを実行してユーザーを作成する必要があります。",
-          "sql-driven-workflow": "SQL駆動型ワークフロー"
+          "template": "ユーザー {user}、パスワード {password} を作成し、必要な権限を付与する例は次のとおりです。次のコマンドを実行してユーザーを作成する前に、{link} を有効にする必要があります。",
+          "sql-driven-workflow": "SQLワークフロー"
         },
         "postgresql": {
-          "warn": "接続インスタンスがクラウド プロバイダーによって管理されている場合、SUPERUSER は利用できないため、そのプロバイダーの管理コンソールからユーザーを作成する必要があります。作成されたユーザーには、プロバイダー固有の準 SUPERUSER 権限が付与されます。既存のすべてのロールに対して、「GRANT role_name TO bytebase;」を使用して Bytebase 権限を付与する必要があります。そうしないと、Bytebase が既存のデータベースまたはテーブルにアクセスできない可能性があります。",
-          "template": "以下は、パスワード {password} を使用してユーザー '{user}' を作成し、必要な権限をユーザーに付与する例です。接続インスタンスがセルフホストされている場合は、SUPERUSER を付与できます。"
+          "warn": "接続しているインスタンスがクラウド サービス プロバイダーによって管理されている場合、SUPERUSER は使用できないため、プロバイダーの管理者コンソールを通じてユーザーを作成する必要があります。作成したユーザーには、ベンダー固有の準 SUPERUSER 権限が与えられます。 「GRANT role_name TO bytebase;」ステートメントを使用して、すべてのロールに Bytebase 権限を付与する必要があります。そうしないと、Bytebase に既存のデータベースまたはテーブルを操作する権限がない可能性があり、操作が失敗します。",
+          "template": "ユーザー {user}、パスワード {password} を作成し、必要な権限を付与する例は次のとおりです。接続しているインスタンスが自己ホスト型の場合は、SUPERUSER を付与できます。"
         },
         "redis": {
-          "template": "以下は、パスワード {password} を持つユーザー {user} を作成し、そのユーザーに必要な権限を付与する例です。"
+          "template": "ユーザー {user}、パスワード {password} を作成し、必要な権限を付与する例は次のとおりです。"
         }
       }
     },
-    "no-password": "パスワードなし",
+    "no-password": "パスワードがありません",
     "type-or-paste-credentials": "資格情報を入力または貼り付けます",
     "type-or-paste-credentials-write-only": "資格情報を入力または貼り付けます - 書き込みのみ",
-    "password-write-only": "YOUR_DB_PWD - 書き込みのみ",
+    "password-write-only": "YOUR_DB_PWD - 書き込み専用",
     "password-type": {
       "password": "パスワード",
-      "password-tip": "外部シークレット管理エンドポイントを指定することもできます",
-      "google-iam": "Google CloudSQLIAM",
+      "password-tip": "外部のパスワード管理サービスのエンドポイントを指定することもできます",
+      "google-iam": "Google CloudSQL IAM",
       "external-secret-vault": "ボールト (KV v2)",
       "external-secret-aws": "AWS シークレットマネージャー",
       "external-secret-gcp": "GCP シークレット マネージャー"
     },
     "external-secret-gcp": {
-      "secret-name": "秘密のフルネーム",
-      "secret-name-tips": "シークレット名は「projects/project-id/secrets/secret-id」のようになります。"
+      "secret-name": "キーのフルパス",
+      "secret-name-tips": "キーへのフルパスは、「projects/project-id/secrets/secret-id」のようなものである必要があります。"
     },
     "external-secret-vault": {
-      "vault-url": "ボールト URL",
+      "vault-url": "ボールトの URL",
       "vault-auth-type": {
-        "self": "認証タイプ",
+        "self": "ボールトの検証方法",
         "token": {
           "self": "トークン",
-          "tips": "TTL のないルート トークン。"
+          "tips": "有効期限のないルートトークン"
         },
         "approle": {
           "self": "アプリロール",
           "role-id": "認証ロールID",
           "secret-id": "認証シークレットID",
-          "secret-id-plain-text": "ロールシークレットIDのプレーンテキスト",
-          "secret-id-environment": "ロールシークレットIDの環境名",
+          "secret-id-plain-text": "シークレットIDのプレーンテキスト",
+          "secret-id-environment": "シークレットIDを格納する環境変数の名前",
           "secret-plain-text": "プレーンテキスト",
-          "secret-env-name": "環境名",
-          "secret-tips": "TTL のないラップされていないシークレット ID。プレーン テキストを使用することも、環境またはローカル ファイルに配置することもできます。{learn_more}"
+          "secret-env-name": "環境変数名",
+          "secret-tips": "有効期限のないカプセル化されていないシークレット ID は、プレーン テキスト、環境変数名、またはファイル パスを使用できます。 {learn_more}"
         }
       },
-      "vault-secret-engine-name": "秘密のエンジン名",
+      "vault-secret-engine-name": "シークレットエンジン名",
       "vault-secret-path": "秘密の道",
       "vault-secret-key": "秘密鍵",
-      "vault-secret-engine-tips": "KV v2 エンジンのみをサポートします。"
+      "vault-secret-engine-tips": "KV v2 ストレージのみをサポートします"
     },
     "external-secret": {
       "secret-name": "秘密の名前",
       "key-name": "秘密鍵"
     },
     "test-connection": "テスト接続",
-    "ignore-and-create": "無視して創造する",
-    "add-a-postgresql-sample-instance": "代わりにPostgreSQLサンプルインスタンスを追加する",
-    "successfully-added-postgresql-instance": "PostgreSQL サンプル インスタンスが正常に追加され、接続情報が入力されました。",
+    "ignore-and-create": "無視して作成する",
+    "add-a-postgresql-sample-instance": "PostgreSQL サンプル インスタンスを追加する",
+    "successfully-added-postgresql-instance": "PostgreSQL サンプル インスタンスが正常に追加されました。そして接続情報を入力します。",
     "connection-info-seems-to-be-incorrect": "接続情報が間違っているようです",
     "new-instance": "新しいインスタンス",
-    "unable-to-connect": "Bytebase はインスタンスに接続できません。接続情報を再度確認することをお勧めします。ただし、今のところこの警告は無視しても問題ありません。インスタンス作成後、インスタンスの詳細ページから接続情報を修正できます。\n\nエラーの詳細: {0}",
+    "unable-to-connect": "Bytebase はインスタンスに接続できません。接続情報を再度確認することをお勧めします。ただし、今のところこの警告は無視してかまいません。作成後もインスタンスの詳細ページで接続情報を修正できます。\n\nエラーの詳細:{0}",
     "successfully-created-instance-createdinstance-name": "インスタンス '{0}' が正常に作成されました。",
     "successfully-updated-instance-instance-name": "インスタンス '{0}' が正常に更新されました。",
-    "copy-grant-statement": "CREATE USER および GRANT ステートメントがクリップボードにコピーされました。適用するには、{engine} クライアントに貼り付けてください。",
-    "successfully-connected-instance": "インスタンスが正常に接続されました。",
+    "copy-grant-statement": "CREATE USER および GRANT ステートメントがクリップボードにコピーされました。 {engine} クライアントに貼り付けます。",
+    "successfully-connected-instance": "インスタンスに正常に接続されました。",
     "failed-to-connect-instance": "インスタンスへの接続に失敗しました。",
-    "failed-to-connect-instance-localhost": "Bytebase を Docker で実行する場合は、ホスト アドレスとして「host.docker.internal」を試してください。",
-    "filter-instance-name": "フィルターインスタンス名",
-    "grants": "助成金",
-    "find-gcp-project-id-and-instance-id": "GCPプロジェクトIDとインスタンスIDを見つけるには、",
-    "create-gcp-credentials": "資格情報を作成するには、",
-    "used-for-testing-connection": "接続テストのみに使用",
+    "failed-to-connect-instance-localhost": "Docker デプロイメントを使用している場合は、ホスト アドレスとして「host.docker.internal」を使用してみてください。",
+    "filter-instance-name": "インスタンス名のフィルタリング",
+    "grants": "権限",
+    "find-gcp-project-id-and-instance-id": "GCP プロジェクト ID とインスタンス ID を表示するには、次を参照してください。",
+    "create-gcp-credentials": "認証情報の作成方法については、を参照してください。",
+    "used-for-testing-connection": "テスト接続のみ",
     "all": "すべてのインスタンス",
-    "force-archive-description": "強制的にアーカイブします。関連するすべての問題が解決され、関連するすべてのシートが削除されます。",
+    "force-archive-description": "アーカイブを強制します。関連するすべての作業指示書は完了としてマークされ、関連するすべてのワークシートが削除されます。",
     "sync-mode": {
       "self": "同期モード",
       "database": {
-        "self": "データベースに基づいて管理",
-        "description": "データベース全体が管理対象オブジェクトとして扱われ、CDB と PDB は別個のデータベースとして扱われます。(CDB モードと非 CDB モードをサポート)"
+        "self": "データベースで管理",
+        "description": "データベース全体を単一の管理オブジェクトとして扱うと、CDBとPDBは別のデータベースとして扱われます。 (CDB モードと非 CDB モードをサポート)"
       },
       "schema": {
-        "self": "スキーマに基づいて管理する",
-        "description": "各スキーマは管理対象オブジェクトとして扱われます。(非CDBモードのみサポート)"
+        "self": "スキーマによる管理",
+        "description": "各スキーマを管理対象オブジェクトとして扱います。 (非CDBモードでのみサポートされます)"
       }
     },
     "scan-interval": {
       "self": "スキャン間隔",
-      "default-never": "デフォルト（なし）",
-      "description": "Bytebase はインスタンス スキーマを定期的に同期し、異常を検出します。",
-      "min-value": "最小値 {value} 分"
+      "default-never": "デフォルト (なし)",
+      "description": "Bytebase は定期的にインスタンスのスキーマを同期し、異常検出を実行します。",
+      "min-value": "最短 {value} 分"
     },
     "maximum-connections": {
       "self": "最大接続数",
-      "default-value": "デフォルト (10)",
-      "description": "接続とリソースの使用を制限するには、インスタンスへの最大接続数を設定します。",
-      "max-value": "最大 {value} 接続"
+      "default-value": "デフォルト (10 接続)",
+      "description": "インスタンスの最大接続数を設定して、接続とリソースの使用を制限します。",
+      "max-value": "最大接続数 {value}"
     }
   },
   "environment": {
     "all": "すべての環境",
     "id": "環境ID",
-    "id-description": "環境 ID は環境の一意の識別子です。作成後は変更できません。",
-    "select": "環境を選択",
+    "id-description": "環境 ID は、環境の一意の識別子です。一度作成すると変更することはできません。",
+    "select": "環境を選ぶ",
     "archive": "この環境をアーカイブする",
-    "archive-info": "アーカイブされた環境は表示されません。",
+    "archive-info": "アーカイブされた環境は表示されなくなります。",
     "create": "環境を作成する",
     "restore": "この環境を復元する",
-    "successfully-updated-environment": "環境 '{name}' が正常に更新されました。",
+    "successfully-updated-environment": "環境「{name}」は正常に更新されました",
     "production-environment": "本番環境",
     "access-control": {
       "title": "アクセス制御",
-      "disable-copy-data-from-sql-editor": "SQL エディターからのデータのコピーを無効にする"
+      "disable-copy-data-from-sql-editor": "SQLエディタからのデータのコピーを無効にする"
     }
   },
   "quick-start": {
-    "self": "クイックスタート",
-    "guide": "試してみるにはステップをクリックしてください",
-    "view-an-issue": "問題を表示",
-    "visit-project": "@:common.visit @:common.projects",
-    "visit-instance": "@:common.visit @:common.instances",
-    "visit-database": "@:common.visit @:common.databases",
-    "visit-environment": "@:common.visit @:common.environments",
-    "visit-member": "@:common.visit @:common.members",
-    "use-kbar": "kbar（{shortcut}）を使用する",
+    "self": "初心者のタスク",
+    "guide": "手順をクリックして試してください",
+    "view-an-issue": "作業指示を表示する",
+    "visit-project": "@:common.visit@:common.projects",
+    "visit-instance": "@:common.visit@:common.instances",
+    "visit-database": "@:common.visit@:common.databases",
+    "visit-environment": "@:common.visit@:common.environments",
+    "visit-member": "@:common.visit@:common.members",
+    "use-kbar": "kbar ({shortcut}) を使用する",
     "query-data": "クエリデータ",
     "notice": {
-      "title": "クイックスタートガイドは閉じられました",
-      "desc": "右上のメニューから後で戻すこともできます"
+      "title": "初心者向けタスクは終了しました",
+      "desc": "右上隅のメニューから後でもう一度初心者ミッションを開くこともできます"
     }
   },
   "auth": {
     "sign-up": {
-      "title": "アカウントを登録する",
-      "admin-title": "{account} を設定する",
+      "title": "アカウントを登録してください",
+      "admin-title": "設定{account}",
       "admin-account": "管理者アカウント",
-      "create-admin-account": "管理者アカウントを作成する",
+      "create-admin-account": "登録管理者",
       "confirm-password": "パスワードを認証する",
-      "confirm-password-placeholder": "パスワードを認証する",
+      "confirm-password-placeholder": "あなたのパスワードを確認",
       "password-mismatch": "ミスマッチ",
       "existing-user": "すでにアカウントをお持ちですか？",
-      "accept-terms-and-policy": "Bytebaseの{terms}と{policy}に同意します",
+      "accept-terms-and-policy": "{terms} と {policy} のバイトベースを受け入れます",
       "terms-of-service": "利用規約",
       "privacy-policy": "プライバシーポリシー"
     },
     "sign-in": {
-      "title": "アカウントにサインイン",
-      "forget-password": "パスワードをお忘れですか？",
-      "new-user": "Bytebase は初めてですか?",
-      "demo-note": "メールアドレス:{username} パスワード:{password}",
-      "gitlab": "GitLabでログイン",
-      "github": "GitHubでログイン",
-      "gitlab-oauth": "GitLabログインを有効にするには管理者に連絡してください",
-      "sign-in-with-idp": "{idp}でサインイン"
+      "title": "あなたのアカウントにログイン",
+      "forget-password": "パスワードを忘れましたか？",
+      "new-user": "Bytebase を初めて使用しますか?",
+      "demo-note": "メールアドレス: {username} パスワード: {password}",
+      "gitlab": "GitLab経由でログインする",
+      "github": "GitHub 経由でサインインする",
+      "gitlab-oauth": "管理者に問い合わせて、GitLab ログインを有効にしてください。",
+      "sign-in-with-idp": "{idp} 経由でログイン"
     },
     "password-forget": {
       "title": "パスワードをお忘れですか？",
-      "selfhost": "パスワードをリセットするには、Bytebase 管理者に連絡してください。",
-      "cloud": "{link} にアクセスしてパスワードをリセットしてください。",
-      "return-to-sign-in": "サインインに戻る"
+      "selfhost": "Bytebase 管理者に連絡してパスワードをリセットしてください",
+      "cloud": "{link} にログインしてパスワードをリセットしてください",
+      "return-to-sign-in": "ログインに戻る"
     },
-    "password-forgot": "パスワードをお忘れですか",
+    "password-forgot": "パスワードを忘れる",
     "password-reset": {
       "title": "あなたのパスワードをリセット",
-      "content": "メールアドレスを入力すると、パスワードリセットリンクが送信されます",
-      "send-reset-link": "リセットリンクを送信",
-      "return-to-sign-in": "サインインに戻る"
+      "content": "パスワードをリセットするリンクをメールに送信します",
+      "send-reset-link": "リセットリンクを送信する",
+      "return-to-sign-in": "ログインに戻る"
     },
     "activate": {
-      "title": "{type} アカウントを有効にする"
+      "title": "{type} アカウントをアクティブ化します"
     }
   },
   "policy": {
     "rollout": {
-      "name": "ロールアウトポリシー",
-      "tip": "このポリシーは遡及的に問題に適用されます。",
-      "info": "データベースの変更をロールアウトする場合、この設定はロールアウトに手動の承認が必要かどうかを制御します。",
-      "auto": "自動ロールアウト",
-      "auto-info": "すべてのチェックに合格すると、変更は自動的にロールアウトされ、実行されます。",
+      "name": "リリース戦略",
+      "tip": "新しいポリシーは古い作業指示にも適用されます",
+      "info": "このオプションは、データベースへの変更を公開するときに手動で公開する必要があるかどうかを制御します。",
+      "auto": "自動公開",
+      "auto-info": "すべての事前チェックに合格すると、自動的にリリースされ、変更が実装されます。",
       "manual-by-project-owner": "プロジェクトオーナー",
-      "manual-by-project-releaser": "プロジェクトリリース者",
-      "manual-by-issue-creator": "問題作成者",
-      "manual-by-last-approver": "カスタム承認からの最終承認者による手動ロールアウト",
-      "manual-by-dedicated-roles": "専用ロールによる手動ロールアウト",
-      "manual-by-dedicated-roles-info": "以下の選択されたロールのいずれかが「ロールアウト」ボタンをクリックできるようにすると、変更が実行されます。",
+      "manual-by-project-releaser": "プロジェクトの発行者",
+      "manual-by-issue-creator": "チケットの作成者",
+      "manual-by-last-approver": "カスタム承認の最終承認者が公開されます",
+      "manual-by-dedicated-roles": "特定の役割の手動リリース",
+      "manual-by-dedicated-roles-info": "以下の選択したロールのいずれかを許可し、「公開」ボタンをクリックして変更を実行します。",
       "manual-by-dba": "DBA",
-      "manual-by-workspace-admin": "ワークスペース管理者",
+      "manual-by-workspace-admin": "バイトベースワークスペース管理者",
       "manual-by-custom-project-roles": "カスタムプロジェクトロール"
     },
     "environment-tier": {
-      "name": "環境層",
-      "description": "環境は他の環境とは異なって表示されます。",
-      "mark-env-as-production": "本番環境としてマーク"
+      "name": "環境レベル",
+      "description": "この環境を他の環境とは異なって見えるようにします。",
+      "mark-env-as-production": "実稼働環境としてマークする"
     }
   },
   "change-history": {
     "self": "変更履歴",
-    "select": "スキーマバージョンは、Bytebase経由でスキーマ変更が適用されるたびに記録されます。",
+    "select": "スキーマのバージョンは、Bytebase を通じてスキーマの変更が実行されるたびに記録されます。",
     "workflow": "ワークフロー",
     "change-type": "タイプ",
-    "commit-info": "{author} による {time}",
-    "no-schema-change": "この移行ではスキーマの変更はありません",
-    "schema-drift": "スキーマドリフト",
-    "schema-drift-detected": "スキーマドリフトが検出されました。",
-    "view-drift": "ビュードリフト",
-    "before-left-schema-choice": "スキーマを比較する",
-    "left-schema-choice-prev-history-schema": "前回の変更後",
+    "commit-info": "{author}から{time}まで",
+    "no-schema-change": "この変更ではスキーマの変更はありません",
+    "schema-drift": "スキーマの逸脱",
+    "schema-drift-detected": "最後の変更後のスキーマは、この変更前のスキーマと矛盾しています。",
+    "view-drift": "ビューの偏差",
+    "before-left-schema-choice": "比較する",
+    "left-schema-choice-prev-history-schema": "前回の変更以降",
     "left-schema-choice-current-history-schema-prev": "この変更前",
-    "after-left-schema-choice": "そしてこの変化の後",
-    "show-diff": "差分を表示",
-    "left-vs-right": "前のバージョン {prevLink} とこのバージョン",
-    "schema-snapshot-after-change": "この変更を適用した後に記録されたスキーマスナップショット",
+    "after-left-schema-choice": "この変更後のスキーマ",
+    "show-diff": "違いを表示",
+    "left-vs-right": "以前の{prevLink}バージョンと現在のバージョン",
+    "schema-snapshot-after-change": "この変更を完了した後のスキーマのスナップショット",
     "current-schema-empty": "現在のスキーマは空です",
-    "list-limit": "変更履歴のあるデータベースについては、最新の 5 つの履歴が以下にリストされます。データベース名をクリックすると、すべての履歴を表示できます。",
-    "no-history-in-project": "このプロジェクトのどのデータベースからも変更履歴が見つかりません。",
+    "list-limit": "変更履歴のあるデータベースの場合、以下に最大 5 件のレコードがリストされます。データベース名をクリックすると、すべてのレコードをさらに表示できます。",
+    "no-history-in-project": "このプロジェクトでは変更履歴のあるデータベースが見つかりませんでした。",
     "recording-info": "データベース スキーマが変更されるたびに、変更履歴が記録されます。",
     "establish-baseline": "新しいベースラインを確立する",
-    "refreshing-history": "歴史を振り返る...",
-    "config-instance": "構成インスタンス",
-    "establish-baseline-description": "Bytebase は現在のスキーマを新しいベースラインとして使用します。これにより、実際のスキーマ状態が Bytebase に記録されたスキーマ状態と調整され、報告されたスキーマ ドリフトが修正されます。現在のスキーマが目的の状態を反映している場合にのみ、これを実行してください。",
-    "establish-database-baseline": "「{name}」ベースラインを確立する",
-    "instance-missing-change-schema": "インスタンス「{name}」に変更履歴スキーマがありません。",
-    "instance-bad-connection": "インスタンス「{name}」に接続して変更履歴を取得できません。",
-    "contact-dba": "設定するにはDBAにお問い合わせください",
+    "refreshing-history": "履歴を更新中...",
+    "config-instance": "インスタンスの構成",
+    "establish-baseline-description": "Bytebase は、現在のスキーマを新しいベースラインとして使用します。これにより、データベースの現在のスキーマ状態が Bytebase によって記録されたスキーマ状態と同期され、スキーマの逸脱の問題が解決されます。これを行う前に、現在のベースラインが実際に望ましい状態を反映していることを確認する必要があります。",
+    "establish-database-baseline": "ベースライン「{name}」を作成します",
+    "instance-missing-change-schema": "インスタンス '{name}' には、変更履歴を記録するためのスキーマがありません。",
+    "instance-bad-connection": "インスタンス '{name}' に接続して変更履歴を取得できません。",
+    "contact-dba": "構成については DBA にお問い合わせください。",
     "export": "変更履歴のエクスポート",
     "need-to-select-first": "最初に変更履歴を選択する必要があります",
     "all-tables": "すべてのテーブル",
     "affected-tables": "影響を受けるテーブル",
-    "view-full": "全文を見る"
+    "view-full": "すべて見る"
   },
   "database": {
-    "select": "データベースを選択",
-    "the-list-might-be-out-of-date-and-is-refreshed-roughly-every-10-minutes": "リストは古くなっている可能性があり、約10分ごとに更新されます。",
-    "no-anomalies-detected": "異常は検出されませんでした",
+    "select": "データベースの選択",
+    "the-list-might-be-out-of-date-and-is-refreshed-roughly-every-10-minutes": "表は約10分ごとに更新されるため、表示される情報は最新ではない場合があります。",
+    "no-anomalies-detected": "例外は検出されませんでした",
     "sync-status": "同期ステータス",
     "last-successful-sync": "最後に成功した同期",
-    "filter-database": "データベースをフィルタリング",
-    "transfer-project": "移転プロジェクト",
-    "unassign": "割り当て解除",
-    "unassign-alert-title": "データベースの割り当て解除",
-    "unassign-alert-description": "選択したデータベースはプロジェクトから削除されます",
-    "edit-schema": "スキーマの編集",
-    "edit-schema-in-vcs": "VCS でスキーマを編集する",
-    "edit-labels": "ラベルを編集",
-    "mixed-values-for-label": "選択されたラベルには混合値があります",
-    "mixed-label-values-warning": "選択したリソースの一部には、同じキーの値が混在しています",
-    "change-data": "データの変更",
-    "change-data-in-vcs": "VCS でデータを変更する",
+    "filter-database": "フィルターデータベース",
+    "transfer-project": "転送アイテム",
+    "unassign": "割り当てを解除する",
+    "unassign-alert-title": "データベースの割り当てを解除する",
+    "unassign-alert-description": "選択したデータベースがプロジェクトから削除されます",
+    "edit-schema": "スキーマの変更",
+    "edit-schema-in-vcs": "スキーマの変更 (VCS)",
+    "edit-labels": "タグを編集する",
+    "mixed-values-for-label": "タグの値が異なります",
+    "mixed-label-values-warning": "一部のタグには異なる値があり、タグの編集はバッチで適用されます",
+    "change-data": "データ変更",
+    "change-data-in-vcs": "データ変更 (VCS)",
     "branch": "支店",
     "branches": "支店",
-    "branching": "分岐",
-    "new-branch": "新しい支店",
+    "branching": "支店",
+    "new-branch": "新しいブランチを作成する",
     "branch-name": "支店名",
-    "select-branch": "ブランチを選択",
-    "delete-this-branch": "このブランチを削除",
+    "select-branch": "ブランチを選択してください",
+    "delete-this-branch": "このブランチを削除します",
     "table-detail": "テーブルの詳細",
-    "batch-action-not-support-alter-schema": "一部のデータベースはスキーマの変更をサポートしていません",
-    "batch-action-permission-denied": "データベースに対する{action}の権限がありません",
-    "batch-action-disabled": "異なるプロジェクトのデータベースに対しては{action}を実行できません",
-    "batch-action-disabled-for-unassigned": "割り当てられていないデータベースに対して{action}を実行できません",
-    "data-export-action-disabled": "複数のデータベースのデータをエクスポートすることはできません",
-    "successfully-transferred-databases": "データベースの転送に成功しました",
-    "successfully-transferred-updateddatabase-name-to-project-updateddatabase-project-name": "'{0}' をプロジェクト '{1}' に正常に転送しました。",
-    "last-sync-status": "最終同期ステータス",
-    "last-sync-status-long": "最終同期ステータス {0} ({1})",
-    "gitops-enabled": "GitOps が有効",
-    "nullable": "ヌル可能",
+    "batch-action-not-support-alter-schema": "一部のデータベースはテーブル構造の変更をサポートしていません",
+    "batch-action-permission-denied": "データベース {action} に対する権限がありません",
+    "batch-action-disabled": "異なるプロジェクトのデータベース {action} を比較できません",
+    "batch-action-disabled-for-unassigned": "未割り当てのデータベース {action} にアクセスできません",
+    "data-export-action-disabled": "複数のデータベースからデータをエクスポートできない",
+    "successfully-transferred-databases": "データベースの移行が完了しました",
+    "successfully-transferred-updateddatabase-name-to-project-updateddatabase-project-name": "「{0}」をプロジェクト「{1}」に正常に転送しました。",
+    "last-sync-status": "前回の同期ステータス",
+    "last-sync-status-long": "最後の同期は {0} で、ステータスは {1} です",
+    "gitops-enabled": "GitOps が有効になっている",
+    "nullable": "null も可能",
     "expression": "表現",
     "position": "位置",
     "unique": "個性的",
     "visible": "見える",
     "comment": "コメント",
     "engine": "エンジン",
-    "row-count-estimate": "行数の推定",
+    "row-count-estimate": "推定行数",
     "data-size": "データサイズ",
     "index-size": "インデックスサイズ",
-    "column": "カラム",
-    "columns": "コラム",
-    "data-type": "データ・タイプ",
-    "indexes": "インデックス",
-    "row-count-est": "行数推定",
-    "incorrect-project-warning": "SQL エディターは、ユーザーが使用できるプロジェクト内のデータベースのみをクエリできます。まず、このデータベースをプロジェクトに転送する必要があります。",
-    "go-to-transfer": "転送へ進む",
+    "column": "リスト",
+    "columns": "リスト",
+    "data-type": "データの種類",
+    "indexes": "索引",
+    "row-count-est": "推定行数",
+    "incorrect-project-warning": "SQL エディターは、ユーザーが使用できるプロジェクト内のデータベースのみをクエリできます。まず、このデータベースを作業中のプロジェクトに転送する必要があります。",
+    "go-to-transfer": "転送に行く",
     "pitr": {
-      "restore": "@:common.restore @:common.database",
-      "no-available-backup": "利用可能なバックアップはありません",
+      "restore": "@:common.restore@:common.database",
+      "no-available-backup": "利用可能なバックアップがありません",
       "point-in-time": "時点",
-      "help-info": "データベースの状態を特定の時点に復元します。{link}。",
+      "help-info": "データベースの状態を特定の時点に復元します。 {link}。",
       "minimum-supported-engine-and-version": "{engine} >= {min_version} が必要です",
-      "restore-to-point-in-time": "特定時点への復元",
-      "no-earlier-than": "復元ポイントは [{earliest}] (利用可能な最も古いバックアップ) より前にすることはできません。",
-      "no-later-than-now": "復元ポイントを現在より後にすることはできません。",
-      "will-overwrite-current-database": "現在のデータベースを上書きします",
-      "restore-before-last-migration": "最後の移行前の時点に復元する",
-      "restore-before-last-migration-help-info": "@:{'database.pitr.restore-before-last-migration'}. {link}.",
-      "restore-to": "復元する",
-      "restore-to-new-db": "新しいデータベースへ",
-      "restore-to-in-place": "所定の位置に"
+      "restore-to-point-in-time": "指定した時点に復元する",
+      "no-earlier-than": "[{earliest}] (利用可能な最も古いバックアップ) よりも古い時点から復元することはできません。",
+      "no-later-than-now": "回復時刻を現在時刻より遅くすることはできません。",
+      "will-overwrite-current-database": "既存のデータベースを上書きします",
+      "restore-before-last-migration": "最後の変更前の履歴に戻す",
+      "restore-before-last-migration-help-info": "@:{'database.pitr.restore-before-last-migration'}。 {link}。",
+      "restore-to": "再開しました",
+      "restore-to-new-db": "新しいデータベース",
+      "restore-to-in-place": "オリジナルデータベース"
     },
-    "show-reserved-tables": "Bytebase 予約テーブルを表示",
-    "show-reserved-databases": "Bytebase 予約データベースを表示",
-    "synced-at": "{time} に同期されました",
-    "not-found-last-successful-sync-was": "見つかりません。最後に同期に成功したのは {time} です。",
-    "view-unassigned-databases": "割り当てられていないデータベースを表示する",
-    "unassigned-databases": "割り当てられていないデータベース",
+    "show-reserved-tables": "バイトベース予約テーブルを表示",
+    "show-reserved-databases": "Bytebase によって保持されているデータベースを表示する",
+    "synced-at": "{time} と同期しました",
+    "not-found-last-successful-sync-was": "見つかりません。最後に正常に同期されたのは {time} です",
+    "view-unassigned-databases": "未割り当てのデータベースを表示する",
+    "unassigned-databases": "未割り当てのデータベース",
     "restore-database": "データベースを復元する",
-    "selected-n-databases": "{n} 個のデータベースが選択されました | {n} 個のデータベースが選択されました",
-    "n-databases": "{n} データベース | {n} データベース",
-    "select-databases-from-same-project": "同じプロジェクトからデータベースを選択してください",
+    "selected-n-databases": "{n} 個のデータベースが選択されました",
+    "n-databases": "{n} データベース",
+    "select-databases-from-same-project": "同じプロジェクト内のデータベースを選択してください",
     "sync-schema": {
-      "title": "同期スキーマ",
-      "description": "Bytebase は、スキーマを 1 つまたは複数のターゲット データベースに同期することをサポートします。",
-      "schema-history-version": "スキーマ履歴バージョン",
-      "copy-schema": "スキーマをコピー",
-      "select-source-schema": "ソーススキーマを選択",
-      "select-target-databases": "対象データベースを選択",
-      "select-project": "プロジェクトを選択",
-      "select-database-placeholder": "データベースを選択 (MySQL、PostgreSQL、TiDB、Oracle のみ)",
+      "title": "データベーステーブルの同期",
+      "description": "Bytebase は、指定されたスキーマと 1 つ以上のターゲット データベースの同期をサポートします。",
+      "schema-history-version": "スキーマの履歴バージョン",
+      "copy-schema": "スキーマテキストを貼り付け",
+      "select-source-schema": "ソーススキーマの選択",
+      "select-target-databases": "ターゲットデータベースを選択してください",
+      "select-project": "アイテムを選択",
+      "select-database-placeholder": "データベースの選択 (MySQL、PostgreSQL、TiDB、Oracle のみ)",
       "source-database": "ソースデータベース",
       "source-schema": "ソーススキーマ",
       "schema-version": {
-        "self": "スキーマバージョン",
-        "description": "スキーマバージョンは、Bytebase経由でスキーマ変更が適用されるたびに記録されます。"
+        "self": "スキーマのバージョン",
+        "description": "Bytebase を通じてスキーマの変更が適用されるたびに、スキーマのバージョンが記録されます。"
       },
-      "target-databases": "対象データベース",
-      "with-diff": "差分あり",
-      "no-diff": "違いはない",
+      "target-databases": "ターゲットデータベース",
+      "with-diff": "違い",
+      "no-diff": "変わりはない",
       "message": {
-        "select-a-target-database-first": "まずターゲット データベースを選択してください。",
-        "no-target-databases": "対象データベースなし",
-        "no-diff-found": "差分が見つかりません。"
+        "select-a-target-database-first": "最初にターゲット データベースを選択してください。",
+        "no-target-databases": "ターゲットデータベースがありません",
+        "no-diff-found": "違いは見つかりませんでした。"
       },
-      "to-database": "データベースに適用",
-      "from-database": "データベースから",
-      "schema-change-preview": "'{database}' のスキーマ変更をプレビューします",
-      "schema-change-preview-no-database": "スキーマの変更をプレビュー",
-      "synchronize-statements": "対応する生成されたDDLステートメント",
-      "synchronize-statements-description": "生成されたDDL文をさらに編集することができます",
-      "select-from-database-and-schema-tip": "同期するデータベースとスキーマのバージョンを選択します",
-      "select-to-database-tip": "適用するデータベースを選択してください",
-      "no-difference-tip": "差分が見つかりません。",
+      "to-database": "同期するデータベースを選択してください",
+      "from-database": "ソースデータベースの選択",
+      "schema-change-preview": "「{database}」のスキーマ変更をプレビューします",
+      "schema-change-preview-no-database": "スキーマの変更をプレビューする",
+      "synchronize-statements": "生成されたDDLステートメントに対応",
+      "synchronize-statements-description": "生成されたスキーマ DDL ステートメントの編集を続けることができます。",
+      "select-from-database-and-schema-tip": "ソースデータベースとスキーマバージョンを選択してください",
+      "select-to-database-tip": "同期するデータベースを選択してください",
+      "no-difference-tip": "違いは見つかりませんでした",
       "more-version": "もっと...",
-      "character-sets-diff-found": "文字セットによって違いがあります。",
-      "preview-issue": "プレビュー号",
+      "character-sets-diff-found": "文字セットはスキーマ間で異なります",
+      "preview-issue": "作業指示のプレビュー",
       "schema-change": "スキーマの変更",
       "generated-ddl-statement": "生成されたDDLステートメント"
     },
     "sensitive": "センシティブ",
-    "access-denied": "このデータベースにアクセスする権限がありません。",
+    "access-denied": "データベースにアクセスする権限がありません",
     "schema": {
-      "select": "スキーマを選択"
+      "select": "スキーマの選択"
     },
-    "show-missing-databases": "不足しているデータベースを表示",
-    "n-selected-m-in-total": "(選択済み: {selected}、合計: {total})",
-    "doesnt-match-database-name-template": "テナント データベース名テンプレートと一致しません",
-    "doesnt-match-tenant-value": "ラベル値と一致しません",
-    "should-follow-database-name-template": "テナントデータベース名テンプレートに従う必要があります",
+    "show-missing-databases": "データベースが見つからないことを表示",
+    "n-selected-m-in-total": "({selected} 個が選択され、合計 {total} 個)",
+    "doesnt-match-database-name-template": "テナントデータベース名のテンプレートに準拠していません",
+    "doesnt-match-tenant-value": "テナントタグ値と一致しません",
+    "should-follow-database-name-template": "テナントデータベース名のテンプレートに従う必要があります",
     "all": "すべてのデータベース",
-    "unassigned": "未割り当て",
-    "show-schemaless-databases": "スキーマレス データベースを表示します。(スキーマの編集は、スキーマレス データベースには適用されません。)",
+    "unassigned": "もう割り当てられていません",
+    "show-schemaless-databases": "スキーマレス データベースを示します。 (スキーマの変更は、スキーマのないデータベースでは機能しません。)",
     "secret": {
-      "self": "秘密",
-      "new": "新たな秘密",
-      "edit": "シークレットを編集",
-      "name-placeholder": "シークレット名を入力してください",
+      "self": "秘密変数",
+      "new": "シークレット変数を追加する",
+      "edit": "シークレット変数を編集する",
+      "name-placeholder": "シークレット変数名を入力してください",
       "validation": {
-        "cannot-be-changed-later": "後で変更することはできません",
-        "duplicated-name": "重複した秘密の名前",
-        "name-is-required": "秘密の名前が必要です",
-        "name-pattern-mismatch": "シークレット名には大文字、数字、_ (アンダースコア) のみを含めることができます",
-        "name-cannot-prefix-with-bytebase": "シークレット名に 'BYTEBASE_' をプレフィックスとして付けることはできません",
-        "name-cannot-start-with-number": "シークレット名は数字で始めることはできません"
+        "cannot-be-changed-later": "作成後に変更することはできません",
+        "duplicated-name": "シークレット変数名が重複しています",
+        "name-is-required": "変数名が必要です",
+        "name-pattern-mismatch": "シークレット名は大文字、数字、_ (アンダースコア) のみで構成する必要があります。",
+        "name-cannot-prefix-with-bytebase": "シークレット名に「BYTEBASE_」という接頭辞を付けることはできません",
+        "name-cannot-start-with-number": "シークレット名を数字で始めることはできません"
       },
-      "description-placeholder": "入力説明",
+      "description-placeholder": "説明を入力してください",
       "value": "価値",
-      "value-placeholder": "入力値（書き込みのみ）",
-      "delete-tips": "シークレットを削除",
-      "description": "変更スクリプトで secret を使用して機密情報を非表示にすることができます。{guide} を参照してください。"
+      "value-placeholder": "値を入力してください (書き込みのみ)",
+      "delete-tips": "シークレット変数の削除",
+      "description": "変更スクリプトでシークレット変数を使用すると、機密情報を非表示にすることができます。{guide} を参照してください。"
     },
     "transfer": {
       "source-project": "ソースプロジェクト",
       "target-project": "対象プロジェクト",
       "errors": {
         "select-target-project": "対象プロジェクトを選択",
-        "select-at-least-one-database": "少なくとも1つのデータベースを選択してください"
+        "select-at-least-one-database": "少なくとも 1 つのデータベースを選択してください"
       },
-      "select-databases": "データベースを選択",
+      "select-databases": "データベースの選択",
       "select-target-project": "対象プロジェクトを選択"
     },
-    "transfer-database-to": "データベースをターゲットプロジェクトに転送する",
-    "transfer-database-from-to": "ソースプロジェクトからターゲットプロジェクトにデータベースを転送する",
+    "transfer-database-to": "データベースをターゲットプロジェクトに転送します",
+    "transfer-database-from-to": "データベースをソース プロジェクトからターゲット プロジェクトに転送する",
     "classification": {
-      "self": "分類"
+      "self": "分類と格付け"
     },
-    "recent": "最近の",
-    "partitioned": "パーティション分割",
+    "recent": "最近の訪問",
+    "partitioned": "パーティション",
     "partition-tables": "パーティションテーブル",
     "external-server-name": "外部サーバー名",
     "external-database-name": "外部データベース名",
     "foreign-table-detail": "外部テーブルの詳細",
-    "view-definition": "定義を表示"
+    "view-definition": "ビューの定義"
   },
   "repository": {
-    "our-webhook-link": "Bytebase によって作成された webhook は {webhookLink} にあります。",
-    "branch-observe-file-change": "Bytebase がファイルの変更を監視するブランチ。",
-    "database-group-description": "デフォルトでは、変更はプロジェクト内のすべてのデータベースに適用されます。または、データベース グループに適用することもできます。",
-    "base-directory": "ベースディレクトリ",
-    "base-directory-description": "Bytebase がファイルの変更を監視するルート ディレクトリ。ファイルがリポジトリのルート ディレクトリに保存されている場合は、「/」を使用します。",
+    "our-webhook-link": "Bytebase によって作成された Webhook は、{webhookLink} にあります。",
+    "branch-observe-file-change": "バイトベースはファイルへのブランチ変更を追跡します。",
+    "database-group-description": "デフォルトでは、変更はプロジェクト内のすべてのデータベースに適用されます。あるいは、データベース グループに適用することもできます。",
+    "base-directory": "ルートディレクトリ",
+    "base-directory-description": "Bytebase は、ファイルの変更を監視するためのルート ディレクトリです。ファイルがリポジトリ ルートに保存されている場合は、「/」を使用します。",
     "merge-request": "マージリクエスト",
     "pull-request": "プルリクエスト",
-    "git-provider": "Git プロバイダー",
+    "git-provider": "Gitプロバイダー",
     "gitops-naming-format": "命名形式",
-    "gitops-description-file-path": "データベース移行スクリプトは {fullPath} に保存されます。データベースを変更するには、開発者は {naming} に準拠した移行スクリプトを作成します。",
-    "gitops-description-branch": "スクリプトが承認され、{branch} ブランチにマージされると、Bytebase はデータベースの変更を適用するための問題を自動的に作成します。",
-    "setup-wizard-guide": "プロセス中にエラーが発生した場合は、{guide}を参照してください。",
-    "add-git-provider": "Gitプロバイダーを追加する",
-    "choose-git-provider": "Gitプロバイダーを選択",
-    "select-repository": "リポジトリを選択",
-    "configure-deploy": "デプロイを構成する",
-    "choose-git-provider-description": "データベース スキーマ スクリプト (.sql) がホストされている Git プロバイダーを選択します。変更されたスクリプトを Git リポジトリにプッシュすると、Bytebase は自動的にパイプラインを作成し、スキーマの変更をデータベースに適用します。",
-    "choose-git-provider-visit-workspace": "Git プロバイダーをさらに追加するには、{workspace} 設定にアクセスしてください。",
-    "choose-git-provider-contact-workspace-admin": "他の Git プロバイダーをここに表示させたい場合は、Bytebase ワークスペース管理者に連絡してください。Bytebase は現在、セルフホスト GitLab EE/CE をサポートしており、後で GitLab.com と GitHub Enterprise を追加する予定です。",
-    "select-repository-attention-gitlab": "Bytebase には、少なくとも「メンテナー」ロールを付与する GitLab プロジェクトのみがリストされます。これにより、コード プッシュ イベントを監視するようにプロジェクト Webhook を構成できます。",
-    "select-repository-attention-github": "Bytebase は、管理者権限を持つ GitHub リポジトリのみをリストします。これにより、リポジトリ Webhook を構成してコード プッシュ イベントを監視できるようになります。",
-    "select-repository-attention-bitbucket": "Bytebase には、管理者権限を持つ Bitbucket リポジトリのみがリストされるため、リポジトリ Webhook を構成してコード プッシュ イベントを監視できます。",
-    "select-repository-attention-azure-devops": "Bytebase には、OAuth 経由のサードパーティ アプリケーション アクセスが許可されている組織内の Azure DevOps リポジトリのみがリストされます。必要なリポジトリが表示されない場合は、[組織] -> [組織の設定] -> [ポリシー] に移動して、サードパーティ アプリケーション アクセスを有効にしてください。",
-    "select-repository-search": "リポジトリを検索",
-    "linked": "リンクされたリポジトリ"
+    "gitops-description-file-path": "データベース変更スクリプトは {fullPath} にあります。変更を加えるには、開発者は {naming} に一致する変更スクリプトを作成する必要があります。",
+    "gitops-description-branch": "スクリプトが承認され、{branch} ブランチにマージされると、Bytebase はデータベースを変更するための作業指示書を自動的に作成します。",
+    "setup-wizard-guide": "プロセス中に問題が発生した場合は、{guide} を参照してください。",
+    "add-git-provider": "Gitプロバイダーの追加",
+    "choose-git-provider": "Git プロバイダーを選択する",
+    "select-repository": "倉庫を選択してください",
+    "configure-deploy": "デプロイメントの構成",
+    "choose-git-provider-description": "データベース スキーマ スクリプトをホストする Git プロバイダーを選択します。変更スクリプトを Git リポジトリにプッシュすると、Bytebase はデータベースの変更をデータベースに適用するための作業指示書を自動的に作成します。",
+    "choose-git-provider-visit-workspace": "さらに Git プロバイダを追加するには、{workspace} 設定にアクセスしてください。",
+    "choose-git-provider-contact-workspace-admin": "他の Git プロバイダーをリストに表示したい場合は、Bytebase ワークスペース管理者に問い合わせてください。現在、Bytebase は独自にホストされた GitLab EE/CE をサポートしていますが、将来的には GitLab.com と GitHub Enterprise もサポートする予定です",
+    "select-repository-attention-gitlab": "Bytebase には、少なくとも「Maintainer」権限を持つ GitLab プロジェクトのみがリストされます。少なくともこの権限を持っている場合にのみ、コード プッシュ イベントをリッスンするようにプロジェクトの Webhook を構成できるためです。",
+    "select-repository-attention-github": "Bytebase には、管理者権限を持つ GitHub リポジトリのみがリストされます。この権限があればのみ、コード プッシュ イベントをリッスンするようにウェアハウスの Webhook を構成できるためです。",
+    "select-repository-attention-bitbucket": "Bytebase には、管理者権限がある Bitbucket リポジトリのみがリストされます。この権限があればのみ、コード プッシュ イベントをリッスンするようにウェアハウスの Webhook を構成できるためです。",
+    "select-repository-attention-azure-devops": "Bytebase には、OAuth を介してサードパーティ アプリケーションへのアクセスを許可する組織に属する Azure DevOps リポジトリのみがリストされます。\n必要なリポジトリが表示されない場合は、[組織] -> [組織の設定] -> [ポリシー] に移動して、サードパーティ アプリケーションのアクセスを有効にします。",
+    "select-repository-search": "倉庫を検索する",
+    "linked": "関連倉庫"
   },
   "workflow": {
-    "gitops-workflow": "GitOpsワークフロー",
-    "gitops-workflow-description": "データベース移行スクリプトは、git リポジトリに保存されます。データベースを変更するには、開発者が移行スクリプトを作成し、GitLab などの対応する VCS でレビューのために送信します。スクリプトが承認され、構成されたブランチにマージされると、Bytebase はデータベースの変更を適用するタスクを自動的に開始します。"
+    "gitops-workflow": "GitOps ワークフロー",
+    "gitops-workflow-description": "データベース変更スクリプトは Git リポジトリに保存されます。データベースを変更するには、開発者は変更スクリプトを作成し、レビューのために GitLab などの VCS に送信します。レビューが合格し、構成されたブランチにマージされると、Bytebase はデータベースを変更するための作業指示を自動的に生成します。"
   },
   "anomaly": {
     "attention-title": "異常検出",
-    "attention-desc": "Bytebase は、インスタンス スキャン間隔に基づいて定期的に異常を検出し、その結果をここに表示します。",
-    "table-search-placeholder": "{type}または環境を検索",
-    "table-placeholder": "やったー、{type} 異常は検出されませんでした!",
-    "tooltip": "{env} には、{criticalCount} 件の CRITICAL、{highCount} 件の HIGH、{mediumCount} 件の MEDIUM の異常があります",
+    "attention-desc": "Bytebase は、インスタンスに設定されたスキャン間隔に基づいて異常を検出し、ここに表示します。",
+    "table-search-placeholder": "{type} または環境を検索",
+    "table-placeholder": "すばらしいです。{type} 例外は検出されませんでした。",
+    "tooltip": "{env} 環境には、{criticalCount} の重大な異常、{highCount} の高レベルの異常、{mediumCount} 中レベルの異常があります",
     "types": {
-      "connection-failure": "接続失敗",
-      "missing-migration-schema": "移行スキーマがありません",
-      "backup-enforcement-violation": "バックアップ強制違反",
+      "connection-failure": "接続に失敗しました",
+      "missing-migration-schema": "変更スキーマがありません",
+      "backup-enforcement-violation": "バックアップポリシーの制約違反",
       "missing-backup": "バックアップがありません",
-      "schema-drift": "スキーマドリフト"
+      "schema-drift": "スキーマの逸脱"
     },
     "action": {
-      "check-instance": "インスタンスを確認する",
-      "view-diff": "差分を表示"
+      "check-instance": "インスタンスをチェックする",
+      "view-diff": "違いを表示する"
     },
     "last-seen": "最後に見たのは",
-    "first-seen": "初登場"
+    "first-seen": "第一印象"
   },
   "project": {
     "dashboard": {
       "modal": {
-        "title": "'@:{'common.project'}' を設定するにはどうすればいいですか?",
-        "content": "Bytebase プロジェクトは、他の一般的な開発ツールのプロジェクト コンセプトに似ています。\n\nプロジェクトには独自のメンバーがあり、すべての問題とデータベースは常に 1 つのプロジェクトに属します。\n\nプロジェクトをリポジトリにリンクするように構成して、GitOps ワークフローを有効にすることもできます。",
-        "cancel": "却下する",
-        "confirm": "再び表示しない"
+        "title": "「@:{'common.project'}」を作成するにはどうすればよいですか?",
+        "content": "Bytebase では、プロジェクトの概念は他の一般的な開発ツールと似ています。\n\nプロジェクトには共同作業者がおり、各データベースと作業指示書は常に特定のプロジェクトに属します。\n\n同時に、プロジェクトをコード リポジトリに関連付け、これを使用して GitOps ワークフローを開始できます。",
+        "cancel": "閉鎖",
+        "confirm": "二度と現れないでください"
       }
     },
     "table": {
@@ -1801,153 +1801,153 @@
       "name": "@:common.name"
     },
     "create-modal": {
-      "project-name": "@:common.project @:common.name",
+      "project-name": "@:{'common.project'}@:{'common.name'}",
       "key": "@:common.key",
-      "cancel": "@:common.cancel",
+      "cancel": "@:common.キャンセル",
       "confirm": "@:common.create",
-      "success-prompt": "プロジェクト {name} が正常に作成されました。"
+      "success-prompt": "{name} が正常に作成されました。"
     },
     "overview": {
-      "view-all": "すべて表示",
-      "view-all-closed": "すべて閉じた状態を表示",
-      "recent-activity": "最近の @.lower:{'common.activities'}",
+      "view-all": "すべて見る",
+      "view-all-closed": "終了した作業指示書をすべて表示する",
+      "recent-activity": "最近の@.lower:{'common.activities'}",
       "in-progress": "進行中",
-      "recently-closed": "最近閉店した",
-      "info-slot-content": "Bytebase はインスタンス スキーマを定期的に同期します。新しく同期されたデータベースは最初にここに配置されます。ユーザーはそれらを適切なアプリケーション プロジェクトに転送する必要があります。",
-      "no-db-prompt": "このプロジェクトにはデータベースが属していません。上部のアクション バーから {newDb} または {transferInDb} をクリックしてデータベースを追加できます。"
+      "recently-closed": "最近終了しました",
+      "info-slot-content": "Bytebase はインスタンスのスキーマを定期的に同期します。新しく同期されたデータベースは最初にここに配置され、その後、それらを適切なプロジェクトに転送できます。",
+      "no-db-prompt": "現在のプロジェクトに属しているデータベースはありません。上のメニュー バーの {newDb} または {transferInDb} をクリックすると、データベースを追加できます。"
     },
     "webhook": {
-      "success-created-prompt": "Webhook {name} が正常に作成されました。",
-      "success-updated-prompt": "Webhook {name} を正常に更新しました。",
-      "success-deleted-prompt": "Webhook {name} を正常に削除しました。",
-      "success-tested-prompt": "Webhook イベントのテストは成功しました。",
-      "fail-tested-title": "テスト Webhook イベントが失敗しました。",
-      "add-a-webhook": "ウェブフックを追加する",
-      "create-webhook": "ウェブフックを作成する",
+      "success-created-prompt": "{name} Webhook が正常に作成されました。",
+      "success-updated-prompt": "{name} Webhook が正常に更新されました。",
+      "success-deleted-prompt": "{name} Webhook が正常に削除されました。",
+      "success-tested-prompt": "Webhook イベントのテストが成功しました。",
+      "fail-tested-title": "Webhook イベントのテストに失敗しました。",
+      "add-a-webhook": "Webhook を追加する",
+      "create-webhook": "Webhook の作成",
       "last-updated-by": "最終更新者",
-      "destination": "行き先",
-      "webhook-url": "ウェブフックURL",
-      "triggering-activity": "トリガーとなるアクティビティ",
-      "test-webhook": "Webhookのテスト",
+      "destination": "外部アプリケーション",
+      "webhook-url": "Webhook URL",
+      "triggering-activity": "トリガーイベント",
+      "test-webhook": "Webhook のテスト",
       "no-webhook": {
-        "title": "このプロジェクトには Webhook が設定されていません。",
-        "content": "さまざまなイベント時に Bytebase が外部システムに通知を投稿できるように、Webhook を構成します。"
+        "title": "現在のプロジェクトはまだ Webhook を構成していません",
+        "content": "タスクが完了したときに Bytebase が外部システムに通知をプッシュできるように Webhook を構成する"
       },
       "creation": {
-        "title": "ウェブフックを作成する",
-        "desc": "メッセージを受信する {destination} チャネルに対応する Webhook を作成します。",
-        "how-to-protect": "キーワード リストを使用して Webhook を保護する場合は、そのリストに「Bytebase」を追加できます。",
-        "view-doc": "{destination} のドキュメントを表示"
+        "title": "Webhook の作成",
+        "desc": "{destination} の Webhook を作成します",
+        "how-to-protect": "Webhook キーワードのホワイトリストに「Bytebase」を追加することで Webhook を保護できます",
+        "view-doc": "{destination} の公式ドキュメント"
       },
       "deletion": {
-        "btn-text": "このウェブフックを削除する",
-        "confirm-title": "Webhook '{title}' とそのすべての実行履歴を削除しますか?"
+        "btn-text": "この Webhook を削除します",
+        "confirm-title": "Webhook '{title}' とすべての実行履歴を削除しますか?"
       },
       "activity-item": {
         "issue-creation": {
-          "title": "問題の作成",
-          "label": "新しい問題が作成されたとき"
+          "title": "@:common.issue を作成する",
+          "label": "新しいチケットが作成されたとき"
         },
         "issue-status-change": {
-          "title": "問題ステータスの変更",
-          "label": "問題ステータスが変更された場合"
+          "title": "作業指示書のステータスの変更",
+          "label": "作業指示書のステータスが変更されたとき"
         },
         "issue-stage-status-change": {
-          "title": "問題ステージのステータス変更",
-          "label": "問題の包含ステージのステータスが変更された場合"
+          "title": "作業指示ステージのステータスの変更",
+          "label": "作業指示書に含まれるステージステータスが変更されたとき"
         },
         "issue-task-status-change": {
-          "title": "タスクステータスの変更を発行",
-          "label": "課題を囲むタスクのステータスが変更された場合"
+          "title": "作業指示タスクのステータスの変更",
+          "label": "作業指示書に含まれるタスクのステータスが変更されたとき"
         },
         "issue-info-change": {
-          "title": "問題情報の変更",
-          "label": "問題情報（担当者、タイトル、説明など）が変更された場合"
+          "title": "作業指示情報の変更",
+          "label": "作業指示書の情報 (例: 担当者、タイトル、説明) が変更されたとき"
         },
         "issue-comment-creation": {
-          "title": "問題コメントの作成",
-          "label": "新しい問題コメントが作成されたとき"
+          "title": "作業指示のコメント付き",
+          "label": "新しいチケットコメントが作成されたとき"
         },
         "issue-approval-notify": {
-          "title": "問題の承認が必要",
-          "label": "問題が承認待ちの場合"
+          "title": "作業指示は承認待ちです",
+          "label": "作業指示書に承認が必要な場合"
         },
         "issue-task-run-status-change": {
-          "title": "タスク実行ステータスの変更を発行",
-          "label": "問題タスクの実行ステータスが変更されたとき"
+          "title": "作業指示タスクの実行ステータスの変更",
+          "label": "作業指示書に含まれるタスクの実行ステータスが変更された場合"
         },
         "notify-issue-approved": {
-          "title": "発行承認",
-          "label": "発行が承認されると"
+          "title": "作業指示書が承認されました",
+          "label": "作業指示が承認されたとき"
         },
         "notify-pipeline-rollout": {
-          "title": "問題の展開が必要",
-          "label": "問題がロールアウトを待っている場合"
+          "title": "リリースされる作業命令",
+          "label": "作業指示書がリリース保留中の場合"
         }
       }
     },
     "settings": {
-      "success-updated": "プロジェクト設定が正常に更新されました。",
-      "success-member-added-prompt": "プロジェクトに正常に追加されました。",
-      "success-member-deleted-prompt": "プロジェクトから {name} のアクセスを正常に取り消しました。",
-      "member-placeholder": "ユーザーを選択",
-      "manage-member": "メンバーを管理する",
+      "success-updated": "プロジェクト設定が正常に更新されました",
+      "success-member-added-prompt": "現在のプロジェクトに正常に追加されました。",
+      "success-member-deleted-prompt": "現在のプロジェクトから {name} が正常に削除されました。",
+      "member-placeholder": "ユーザーの選択",
+      "manage-member": "メンバーの管理",
       "owner": "@.upper:role.project-owner.self",
       "developer": "@.upper:role.project-member.self",
       "archive": {
-        "title": "アーカイブプロジェクト",
-        "description": "アーカイブされたプロジェクトは表示されません。",
-        "btn-text": "@.lower:{'common.project'} をアーカイブする"
+        "title": "アーカイブアイテム",
+        "description": "アーカイブされたアイテムは表示されなくなります。",
+        "btn-text": "この @:common.project をアーカイブする"
       },
       "restore": {
-        "title": "復元プロジェクト",
-        "btn-text": "これを復元します @.lower:{'common.project'}"
+        "title": "アイテムを復元する",
+        "btn-text": "この @:common.project を復元します"
       },
       "schema-change-type": "スキーマ変更タイプ",
-      "select-schema-change-type-ddl": "命令型 - 任意の DDL ステートメントを使用して変更を指定します。",
-      "select-schema-change-type-sdl": "宣言型 - 必要なスキーマを指定します。CREATE TABLE/INDEX のみを使用します。",
-      "schema-path-template-sdl-description": "スキーマ ファイルは、データベースの完全なスキーマを記述します。",
+      "select-schema-change-type-ddl": "命令的 - 任意の DDL ステートメントを使用して変更コマンドを記述します。",
+      "select-schema-change-type-sdl": "宣言型 - 最終的に必要なスキーマを直接記述するには、CREATE TABLE/INDEX のみを使用します。",
+      "schema-path-template-sdl-description": "スキーマ ファイルには、完全なデータベース構造が記述されます。",
       "branch-protection-rules": {
         "self": "ブランチ保護ルール",
-        "add-rule": "ルールを追加",
+        "add-rule": "ブランチを追加",
         "branch-name-pattern": {
-          "self": "支店名のパターン",
-          "description": "feature/* や *-stable などのワイルドカードをサポートします。空の文字列はすべてのブランチに一致します。"
+          "self": "ブランチ名のパターン",
+          "description": "feature/* や *-stable などのワイルドカードがサポートされています。すべてのブランチと一致させるには空白のままにします。"
         },
-        "applies-to-n-branches": "{n} ブランチに適用 | {n} ブランチに適用",
+        "applies-to-n-branches": "{n} ブランチに適用",
         "only-allow-specified-roles-to-create-branch": "指定されたロールのみにブランチの作成を許可する",
-        "no-protection-rule-configured": "保護ルールが構成されていません。",
-        "only-apply-to-main-branches": "メインブランチにのみ適用"
+        "no-protection-rule-configured": "ブランチ保護ルールは構成されていません。",
+        "only-apply-to-main-branches": "メインブランチでのみ有効です"
       }
     },
     "members": {
-      "description": "プロジェクト メンバーは、プロジェクト内のデータベースと問題を操作する権限を決定します。プロジェクト所有者、ワークスペース管理者、ワークスペース DBA はすべて、完全なプロジェクト権限を持ちます。",
+      "description": "プロジェクト メンバーの役割により、プロジェクト内のデータベースと作業指示書を操作するための権限が決まります。プロジェクト所有者、ワークスペース管理者、および DBA はすべて、プロジェクトに対する完全な権限を持っています。",
       "add-member": "メンバーを追加",
-      "revoke-member": "メンバーの取り消し",
+      "revoke-member": "メンバーシップを取り消す",
       "revoke-access": "アクセス権を取り消す",
-      "grant-access": "アクセス許可",
-      "edit": "メンバーを編集 - {member}",
-      "view-by-principals": "プリンシパル別に表示",
-      "view-by-roles": "役割別に表示",
+      "grant-access": "許可されたアクセス",
+      "edit": "メンバーの編集 - {member}",
+      "view-by-principals": "担当者ごとに見る",
+      "view-by-roles": "役割ごとに表示",
       "cannot-remove-last-owner": "プロジェクトの最後の所有者を削除できません",
-      "revoke-role-from-user": "'{user}' から '{role}' を取り消します",
+      "revoke-role-from-user": "「{user}」{role} のロールを削除します",
       "inactive-members": "非アクティブなメンバー",
-      "show-inactive": "非アクティブなメンバーを表示",
-      "select-users": "ユーザーを選択",
-      "assign-role": "役割を割り当てる",
+      "show-inactive": "非アクティブなメンバーを表示する",
+      "select-users": "ユーザーの選択",
+      "assign-role": "役割の割り当て",
       "assign-reason": "(オプション) 理由",
-      "never-expires": "一度もない",
+      "never-expires": "有効期限が切れることはありません",
       "expired": "期限切れ",
       "role-description": "役割の説明",
-      "role-never-expires": "この役割には有効期限がありません。",
+      "role-never-expires": "この役割には有効期限はありません。",
       "add-more": "さらに追加",
       "role-name": "役割名",
       "condition-name": "条件名",
       "users": "ユーザー",
       "roles": "役割",
-      "search-member": "メンバーを検索",
-      "revoke-members": "これらのメンバーを取り消す",
-      "clean-up-expired-roles": "期限切れのロールをクリーンアップする",
+      "search-member": "メンバーを検索する",
+      "revoke-members": "メンバーシップを取り消す",
+      "clean-up-expired-roles": "期限切れのロールをクリアする",
       "workspace-level-roles": "ワークスペースレベルの役割",
       "project-level-roles": "プロジェクトレベルの役割"
     },
@@ -1955,142 +1955,142 @@
       "standard": "標準モード",
       "batch": "バッチモード"
     },
-    "db-name-template": "テナント データベース名テンプレート",
-    "select": "プロジェクトを選択",
+    "db-name-template": "テナントデータベース名のテンプレート",
+    "select": "アイテムを選択",
     "lgtm-check": {
-      "self": "LGTMチェック",
-      "disabled": "LGTMチェックをスキップ",
-      "project-member": "プロジェクトメンバーにLGTMを要求する",
-      "project-owner": "プロジェクトオーナーからのLGTMを要求する"
+      "self": "LGTM検査",
+      "disabled": "LGTM チェックをスキップする",
+      "project-member": "プロジェクトメンバーにLGTMを要求",
+      "project-owner": "プロジェクトオーナーからのLGTMの要求"
     },
-    "successfully-updated-db-name-template": "データベース名テンプレートが正常に更新されました。",
-    "all": "すべてのプロジェクト",
-    "key-hint": "このプロジェクトを識別するための短い説明的な英数字。",
+    "successfully-updated-db-name-template": "データベース名のテンプレートが正常に更新されました。",
+    "all": "全てのアイテム",
+    "key-hint": "アイテムを識別するには、短く識別可能な英数字の組み合わせが使用されます。",
     "gitops-connector": {
-      "self": "GitOps コネクタ",
-      "add": "GitOpsコネクタを追加する",
-      "delete": "GitOpsコネクタを削除する",
-      "update-success": "GitOps コネクタが正常に更新されました",
-      "create-success": "GitOps コネクタが正常に作成されました",
-      "delete-success": "GitOpsコネクタが削除されました"
+      "self": "GitOps接続",
+      "add": "新しい GitOps 接続を追加",
+      "delete": "GitOps接続を削除する",
+      "update-success": "GitOps 接続が更新されました",
+      "create-success": "GitOps 接続が作成されました",
+      "delete-success": "GitOps 接続が削除されました"
     }
   },
   "gitops": {
     "setting": {
-      "description": "Bytebase の GitOps ワークフローでは、開発者は移行スクリプトを VCS に保存します。プル リクエストにより SQL レビューが促され、マージされたリクエストにより移行計画が開始されます。管理者は VCS プロバイダーを構成し、プロジェクト所有者はプロジェクト内で VCS 接続を確立します。",
+      "description": "Bytebase GitOps ワークフローでは、開発者は移行スクリプトを VCS に保存します。プル リクエストにより SQL レビューがトリガーされ、マージ時に移行計画が開始されます。管理者は VCS プロバイダーを構成し、プロジェクト所有者はプロジェクト内で VCS 接続を確立します。",
       "add-git-provider": {
-        "self": "Gitプロバイダーを追加する",
-        "description": "プロジェクトで GitOps ワークフローを有効にする前に、Bytebase はまず、対応するバージョン管理システム (VCS) に OAuth アプリケーションとして登録して、その VCS と統合する必要があります。",
-        "gitlab-self-host": "GitLab セルフホスト",
+        "self": "Gitプロバイダーの追加",
+        "description": "プロジェクトで GitOps ワークフローを有効にする前に、まず Bytebase を VCS に OAuth アプリケーションとして登録して VCS と統合する必要があります。",
+        "gitlab-self-host": "自己ホスト型 GitLab",
         "gitlab-self-host-admin-requirement": "GitLab インスタンスの管理者である必要があります。",
         "gitlab-com-admin-requirement": "プロジェクトまたはグループの管理者である必要があります。",
-        "github-self-host": "GitHub セルフホスト",
+        "github-self-host": "セルフホスト型 GitHub",
         "github-com-admin-requirement": "GitHub 組織の管理者である必要があります。",
         "bitbucket-admin-requirement": "Bitbucket ワークスペースの管理者である必要があります。",
         "azure-devops-service": "Azure DevOps サービス",
         "azure-admin-requirement": "Azure DevOps 組織の管理者である必要があります。",
-        "add-success": "Git プロバイダー {vcs} を正常に追加しました",
-        "choose": "Gitプロバイダーを選択",
+        "add-success": "Git プロバイダー「{vcs}」が正常に追加されました",
+        "choose": "Git プロバイダーを選択する",
         "basic-info": {
           "self": "基本情報",
-          "gitlab-instance-url": "GitLabインスタンスURL",
-          "gitlab-instance-url-label": "VCS インスタンスの URL。このインスタンスと Bytebase が相互にネットワークで到達可能であることを確認してください。",
-          "github-instance-url": "GitHub インスタンス URL",
-          "bitbucket-instance-url": "Bitbucket インスタンス URL",
-          "azure-instance-url": "Azure DevOps インスタンス URL",
+          "gitlab-instance-url": "GitLab インスタンスの URL",
+          "gitlab-instance-url-label": "VCS インスタンスの URL。このインスタンスと Bytebase の間のネットワークが相互接続されていることを確認してください。",
+          "github-instance-url": "GitHub インスタンスの URL",
+          "bitbucket-instance-url": "Bitbucket インスタンスの URL",
+          "azure-instance-url": "Azure DevOps インスタンスの URL",
           "instance-url-error": "インスタンス URL は https:// または http:// で始まる必要があります",
           "display-name": "表示名",
-          "display-name-label": "同じ Git プロバイダーを使用するさまざまな構成を識別するのに役立つオプションの表示名。"
+          "display-name-label": "異なる Git プロバイダーを区別するためのオプションの表示名。"
         },
         "access-token": {
-          "self": "OAuth アプリケーション情報",
+          "self": "OAuthアプリケーション情報",
           "personal-access-token": "個人アクセストークン",
-          "github-fine-grained-token": "きめ細かな個人アクセストークン",
-          "gitlab-personal-access-token": "専用のサービス ユーザーを作成し、メンテナー ロールと、管理対象のグループまたはプロジェクトに対する少なくとも次の権限を持つ {token} を生成します。単一のプロジェクトを管理するためのプロジェクト アクセス トークンを生成することも、グループ内のすべてのプロジェクトを管理するためのグループ アクセス トークンを生成することもできます。",
-          "github-personal-access-token": "専用のサービス ユーザーを作成し、管理対象となる組織またはすべてのプロジェクトのメンバー ロールを持つ {token} を生成します。",
-          "bitbucket-app-access-token": "特定のサービス ユーザーを生成し、管理する関連組織、プロジェクト、またはリポジトリに対して少なくとも次の権限を持つ {app_password} を作成します。以下に '<bitbucket ユーザー名>:<生成されたアプリ パスワード>' を挿入します。",
-          "bitbucket-app-password": "アプリパスワード",
-          "azure-devops-personal-access-token": "専用のサービス ユーザーを作成し、次のスコープを持つアクセス可能なすべての組織のメンバー ロールを持つ {token} を生成します。[組織] フィールドは [アクセス可能なすべての組織] に設定する必要があります。"
+          "github-fine-grained-token": "きめ細かい個人アクセス トークン",
+          "gitlab-personal-access-token": "専用のサービス ユーザーを作成し、メンテナー ロールと、管理するグループまたはプロジェクトに対する少なくとも次の権限を持つ {token} を生成します。プロジェクト アクセス トークンを生成して単一のプロジェクトを管理することも、グループ アクセス トークンを生成してグループ内のすべてのプロジェクトを管理することもできます。",
+          "github-personal-access-token": "専用のサービス ユーザーを作成し、組織または管理する必要があるすべてのプロジェクトのメンバー ロールを持つ {token} を生成します。",
+          "bitbucket-app-access-token": "特定のサービス ユーザーを生成し、関連する組織、プロジェクト、またはリポジトリを管理するための少なくとも次の権限を持つ 1 つの {app_password} を作成します。以下に「<bitbucket ユーザー名>:<生成されたアプリケーション パスワード>」を挿入します。",
+          "bitbucket-app-password": "アプリケーションパスワード",
+          "azure-devops-personal-access-token": "専用のサービス ユーザーを作成し、次のスコープを持つアクセス可能なすべての組織のメンバー ロールを持つ {token} を生成します。 「組織」フィールドは「アクセス可能なすべての組織」に設定する必要があります。"
         },
         "confirm": {
           "confirm-info": "情報を確認する",
-          "confirm-description": "作成後、この Git プロバイダーはプロジェクト所有者がプロジェクト ダッシュボードの「GitOps」タブで選択できます。"
+          "confirm-description": "作成後、Git サプライヤーはプロジェクト パネルの [GitOps] タブに表示され、プロジェクト所有者が選択できます。"
         }
       },
       "git-provider": {
-        "gitlab-self-host-application-id-label": "登録された GitLab インスタンス全体の OAuth アプリケーションのアプリケーション ID。",
-        "gitlab-com-application-id-label": "登録された GitLab OAuth アプリケーションのアプリケーション ID。",
-        "view-in-gitlab": "GitLabで見る",
-        "view-in-azure": "Azure で表示",
-        "gitlab-self-host-secret-label": "登録された GitLab インスタンス全体の OAuth アプリケーションのシークレット。",
-        "gitlab-com-secret-label": "登録された GitLab OAuth アプリケーションのシークレット。",
-        "azure-secret-label": "登録された Azure OAuth アプリケーションのクライアント シークレット。",
-        "github-application-id-label": "登録された GitHub 組織全体の OAuth アプリケーションのクライアント ID。",
-        "azure-application-id-label": "登録された Azure 組織全体の OAuth アプリケーションのクライアント ID。",
-        "secret-label-github": "登録された GitHub 組織全体の OAuth アプリケーションのクライアント シークレット。",
-        "delete-forbidden": "このプロバイダーを削除するには、まずすべてのリポジトリのリンクを解除します。",
-        "delete": "この Git プロバイダーを削除する",
-        "delete-confirm": "Gitプロバイダー「{name}」を削除しますか?"
+        "gitlab-self-host-application-id-label": "GitLab インスタンスレベルの OAuth アプリケーションとして登録されたアプリケーション ID。",
+        "gitlab-com-application-id-label": "GitLab OAuth アプリケーションとして登録されたアプリケーション ID。",
+        "view-in-gitlab": "GitLab アプリを表示する",
+        "view-in-azure": "Azure アプリを見る",
+        "gitlab-self-host-secret-label": "GitLab インスタンス レベルの OAuth アプリケーションとして登録されたシークレット。",
+        "gitlab-com-secret-label": "GitLab OAuth アプリケーションのシークレットとして登録します。",
+        "azure-secret-label": "Azure OAuth アプリのクライアント シークレットとして登録します。",
+        "github-application-id-label": "GitHub 組織レベルの OAuth アプリとして登録されたクライアント ID。",
+        "azure-application-id-label": "Azure 組織レベルの OAuth アプリとして登録されたクライアント ID。",
+        "secret-label-github": "GitHub 組織レベルの OAuth アプリとして登録されたクライアント シークレット。",
+        "delete-forbidden": "このプロバイダーを削除する前に、すべてのウェアハウスの関連付けを解除する必要があります。",
+        "delete": "Git プロバイダーを削除する",
+        "delete-confirm": "Git プロバイダー「{name}」を削除しますか?"
       }
     }
   },
   "deployment-config": {
     "stage-n": "ステージ{n}",
-    "add-selector": "セレクターを追加",
-    "update-success": "デプロイメント構成が正常に更新されました。",
-    "this-is-example-deployment-config": "これはデプロイメント構成の例です。編集して保存する必要があります。",
-    "n-databases": "{n} データベース | {n} データベース",
-    "selectors": "セレクター",
+    "add-selector": "選択基準を追加する",
+    "update-success": "デプロイメント構成が正常に更新されました",
+    "this-is-example-deployment-config": "これはサンプルの展開構成であり、編集して保存する必要があります。",
+    "n-databases": "{n} データベース",
+    "selectors": "選定基準",
     "add-stage": "ステージを追加",
-    "confirm-to-revert": "編集内容を元に戻しますか?",
-    "name-placeholder": "芸名...",
+    "confirm-to-revert": "編集を元に戻してもよろしいですか?",
+    "name-placeholder": "芸名…",
     "error": {
-      "at-least-one-stage": "少なくとも1ステージ",
-      "stage-name-required": "芸名は必須です",
-      "at-least-one-selector": "各ステージに少なくとも 1 つのセレクター",
-      "env-in-selector-required": "各ステージで必要な「環境」",
-      "env-selector-must-has-one-value": "「環境ID」には必ず1つの値が必要です",
-      "key-required": "キーが必要です",
-      "values-required": "値は必須です"
+      "at-least-one-stage": "少なくとも 1 つのステージが必要です",
+      "stage-name-required": "ステージ名の指定が必要です",
+      "at-least-one-selector": "各ステージには少なくとも 1 つの選択基準が必要です",
+      "env-in-selector-required": "各ステージには「環境」の選択条件が必要です",
+      "env-selector-must-has-one-value": "「環境 ID」の値は 1 つだけでなければなりません",
+      "key-required": "キーを指定する必要があります",
+      "values-required": "値を指定する必要があります"
     },
-    "project-has-no-deployment-config": "このプロジェクトにはまだデプロイメント構成がありません。まずは {go} してください。",
-    "go-and-config": "設定して実行",
-    "wont-be-deployed-explanation": "これらのデータベースは、いずれのセレクタにも該当しないため、デプロイされません。",
-    "wont-be-deployed": "展開されません",
-    "pipeline-generated-from-deployment-config": "デプロイメント パイプラインは、プロジェクトの {deployment_config} に従って生成されます。",
-    "preview-deployment-pipeline": "プレビュー展開パイプライン",
-    "select-database-group": "データベースグループを選択"
+    "project-has-no-deployment-config": "このプロジェクトにはまだデプロイメント構成がありません。まず {go} してください。",
+    "go-and-config": "設定に移動",
+    "wont-be-deployed-explanation": "どの選択基準も満たされなかったため、これらのデータベースは展開されません。",
+    "wont-be-deployed": "導入には関与しない",
+    "pipeline-generated-from-deployment-config": "デプロイ パイプラインはプロジェクト {deployment_config} に基づいて生成されます。",
+    "preview-deployment-pipeline": "導入パイプラインのプレビュー",
+    "select-database-group": "データベースグループの選択"
   },
   "data-source": {
-    "role-type": "役割タイプ",
-    "successfully-deleted-data-source-name": "データ ソース '{0}' が正常に削除されました。",
-    "create-data-source": "データソースを作成する",
+    "role-type": "権限の種類",
+    "successfully-deleted-data-source-name": "データ ソース '{0}' は正常に削除されました。",
+    "create-data-source": "データソースの作成",
     "data-source-list": "データソースリスト",
     "all-data-source": "すべてのデータソース",
-    "search-name": "名前を検索",
-    "search-name-database": "名前、データベースを検索",
+    "search-name": "検索名",
+    "search-name-database": "検索名、データベース",
     "successfully-created-data-source-datasource-name": "データ ソース '{0}' が正常に作成されました。",
     "select-database-first": "最初にデータベースを選択してください",
-    "select-data-source": "データソースを選択",
-    "search-user": "ユーザーを検索",
+    "select-data-source": "データソースの選択",
+    "search-user": "ユーザーを検索する",
     "user-list": "ユーザーリスト",
-    "revoke-access": "'{1}' から '{0}' へのアクセスを取り消してもよろしいですか?",
-    "grant-data-source": "助成金データソース",
-    "grant-database": "助成金データベース",
-    "requested-issue": "リクエストされた問題",
-    "successfully-revoked-member-principal-name-access-from-props-datasource-name": "'{1}' から '{0}' へのアクセスを正常に取り消しました。",
-    "your-issue-id-e-g-1234": "問題ID（例：1234）",
+    "revoke-access": "「{0}」の「{1}」へのアクセスを削除してもよろしいですか?",
+    "grant-data-source": "付与データソース",
+    "grant-database": "認可データベース",
+    "requested-issue": "作業指示を申請する",
+    "successfully-revoked-member-principal-name-access-from-props-datasource-name": "「{0}」の「{1}」へのアクセスが正常に取り消されました。",
+    "your-issue-id-e-g-1234": "チケット ID (例: 1234)",
     "member-principal-name-already-exists": "{0} はすでに存在します",
-    "successfully-granted-datasource-name-to-addedmember-principal-name": "'{0}' を '{1}' に正常に付与しました。",
-    "we-also-linked-the-granted-database-to-the-requested-issue-linkedissue-name": "許可されたデータベースを要求された問題 '{0}' にリンクしました。",
+    "successfully-granted-datasource-name-to-addedmember-principal-name": "「{0}」「{1}」が正常に付与されました",
+    "we-also-linked-the-granted-database-to-the-requested-issue-linkedissue-name": "また、付与されたデータベースをチケット '{0}' にリンクしました。",
     "new-data-source": "新しいデータソース",
     "connection-name-string-copied-to-clipboard": "{0} 文字列がクリップボードにコピーされました。",
-    "jdbc-cant-connect-to-socket-database-value-instance-host": "JDBC はソケット {0} に接続できません",
+    "jdbc-cant-connect-to-socket-database-value-instance-host": "JDBC がソケット {0} に接続できません",
     "snowflake-keypair-tip": "キーペア認証",
     "ssl-type": {
-      "ca": "@:{'データソース.ssl.ca-cert'}",
+      "ca": "@:{'data-source.ssl.ca-cert'}",
       "ca-and-key-and-cert": "@:{'data-source.ssl.ca-cert'} + @:{'data-source.ssl.client-key'} + @:{'data-source.ssl.client-cert'}",
-      "none": "なし"
+      "none": "使ってはいけません"
     },
     "ssl": {
       "ca-cert": "CA証明書",
@@ -2098,14 +2098,14 @@
       "client-cert": "クライアント証明書"
     },
     "ssh-type": {
-      "tunnel": "@:{'データソース.ssh.トンネル'}",
+      "tunnel": "@:{'data-source.ssh.tunnel'}",
       "tunnel-and-private-key": "@:{'data-source.ssh.tunnel'} + @:{'data-source.ssh.private-key'}",
-      "none": "なし"
+      "none": "使ってはいけません"
     },
     "ssh": {
       "host": "サーバ",
       "port": "ポート",
-      "user": "ユーザー",
+      "user": "ユーザー名",
       "password": "パスワード",
       "ssh-key": "SSHキー",
       "tunnel": "トンネル",
@@ -2113,677 +2113,677 @@
     },
     "ssl-connection": "SSL接続",
     "ssh-connection": "SSH接続",
-    "read-replica-host": "読み取りレプリカホスト",
-    "read-replica-port": "読み取りレプリカポート",
+    "read-replica-host": "リードレプリカホスト",
+    "read-replica-port": "リードレプリカポート",
     "delete-read-only-data-source": "読み取り専用データソースを削除する",
-    "connection-string-schema": "接続文字列スキーマ",
-    "admin": "管理者",
-    "read-only": "ロ"
+    "connection-string-schema": "接続文字列モード",
+    "admin": "メインライブラリ",
+    "read-only": "図書館から"
   },
   "setting": {
     "project": {
-      "description": "これは、Bytebase 内のすべてのプロジェクトを一覧表示する管理プロジェクト パネルです。",
-      "show-archived": "アーカイブされたプロジェクトを表示"
+      "description": "これは、Bytebase 上のすべてのプロジェクトをリストするプロジェクト管理者インターフェイスです。",
+      "show-archived": "アーカイブされたアイテムを表示する"
     },
     "label": {
       "key": "鍵",
-      "values": "価値観",
-      "value-placeholder": "ラベル値...",
-      "key-placeholder": "ラベルキー..."
+      "values": "価値",
+      "value-placeholder": "タグ値…",
+      "key-placeholder": "タグキー..."
     }
   },
   "sql-editor": {
-    "self": "SQL エディター",
-    "select-connection": "接続を選択してください",
-    "search-databases": "データベースを検索",
+    "self": "SQLエディタ",
+    "select-connection": "データ接続を選択してください",
+    "search-databases": "データベースを検索する",
     "search-results": "の検索結果",
-    "loading-databases": "データベースを読み込んでいます...",
-    "close-pane": "ウィンドウを閉じる",
+    "loading-databases": "データベース情報をロードしています...",
+    "close-pane": "パネルを閉じる",
     "loading-data": "データのロード...",
-    "table-empty-placeholder": "クエリを実行するには、[実行] をクリックします。",
+    "table-empty-placeholder": "「実行」をクリックしてクエリを実行します。",
     "no-data-available": "データなし",
-    "download-as-file": "{file} としてダウンロード",
-    "only-select-allowed": "実行できるのは {select} ステートメントのみです。",
-    "want-to-action": "{want}したい場合は、{action}ボタン{reaction}をクリックしてください。",
-    "and-submit-an-issue": "問題を提出する",
-    "to-enable-admin-mode": "管理者モードを有効にする",
-    "table-schema-placeholder": "テーブルを選択してそのスキーマを表示します",
-    "notify-empty-statement": "エディタにSQL文を入力してください",
-    "notify-multiple-statements": "複数の SQL ステートメントが検出されました。SQL エディターは最初のステートメントのみを実行します。別のステートメントを選択して個別に実行できます。",
-    "goto-edit-schema-hint": "エディターの上部からデータベース接続を選択してください",
-    "notify-invalid-sql-statement": "無効な SQL ステートメントです。",
-    "can-not-execute-query": "データのロード時にクエリを実行できません。",
-    "rows": "行 | 行",
-    "vertical-display": "縦表示",
-    "no-history-found": "履歴が見つかりません",
-    "no-sheet-found": "シートが見つかりません",
+    "download-as-file": "{file} 形式でダウンロード",
+    "only-select-allowed": "{select} ステートメントのみが実行を許可されます",
+    "want-to-action": "{want} が必要な場合は、「{action}」ボタン {reaction} をクリックしてください。",
+    "and-submit-an-issue": "そしてチケットを提出してください",
+    "to-enable-admin-mode": "管理者モードを有効にするには",
+    "table-schema-placeholder": "スキーマを表示するテーブルを選択してください",
+    "notify-empty-statement": "エディターに SQL ステートメントを入力してください",
+    "notify-multiple-statements": "複数の SQL ステートメントを入力したことが検出されました。 SQL エディターは、最初のステートメントの実行のみをサポートします。他のステートメントを選択して個別に実行できます。",
+    "goto-edit-schema-hint": "エディタの上部からデータベース接続を選択してください",
+    "notify-invalid-sql-statement": "SQL ステートメントを確認してください。",
+    "can-not-execute-query": "データのロード中にクエリを実行できません",
+    "rows": "記録",
+    "vertical-display": "縦型表示",
+    "no-history-found": "まだ履歴がありません",
+    "no-sheet-found": "ワークシートはまだありません",
     "search-history": "検索履歴",
-    "search-sheets": "検索シート",
+    "search-sheets": "ワークシートの検索",
     "hint-tips": {
-      "confirm-to-delete-this-history": "この履歴を削除しますか?",
+      "confirm-to-delete-this-history": "このレコードを削除してもよろしいですか?",
       "confirm-to-close-unsaved-sheet": {
-        "title": "保存されていないシートを閉じますか?",
-        "content": "シートを閉じると保存されていないデータは失われますか?"
+        "title": "未保存のワークシートを閉じてもよろしいですか?",
+        "content": "現在のワークシートを閉じると、保存されていないデータはすべて失われますか?"
       }
     },
-    "please-input-the-tab-label": "タブラベルを入力してください。",
-    "copy-code": "コードをコピー",
+    "please-input-the-tab-label": "タブ名を入力してください。",
+    "copy-code": "コードをコピーする",
     "copy-url": "URLをコピー",
     "notify": {
-      "copy-code-succeed": "コードのコピーに成功",
-      "copy-share-link": "共有リンクがクリップボードにコピーされました。",
-      "sheet-is-read-only": "共有シートは読み取り専用です。"
+      "copy-code-succeed": "コードが正常にコピーされました",
+      "copy-share-link": "共有リンクがクリップボードにコピーされました",
+      "sheet-is-read-only": "共有ワークシートは読み取り専用であり、編集できません。"
     },
     "view-all-tabs": "すべてのタブを表示",
-    "sheets": "シート",
+    "sheets": "ワークシート",
     "connect-to-a-database": "データベースに接続する",
     "link-access": "リンクアクセス",
     "private": "プライベート",
     "private-desc": "このシートにアクセスできるのはあなただけです",
-    "project-read": "プロジェクトを読む",
-    "project-read-desc": "シートの所有者とプロジェクトの所有者は読み取り/書き込みが可能で、他のプロジェクトメンバーは読み取り/書き込みが可能です。",
-    "project-write": "プロジェクト書き込み",
-    "project-write-desc": "シートの所有者とプロジェクトメンバーの両方が読み取り/書き込み可能",
-    "create-read-only-data-source": "作成へ進む",
+    "project-read": "プロジェクト内で読み取り可能",
+    "project-read-desc": "ワークシート所有者またはプロジェクト所有者は読み取りおよび書き込み権限を持ち、他のメンバーは読み取り専用権限を持ちます。",
+    "project-write": "プロジェクト内での読み取りと書き込み",
+    "project-write-desc": "ワークシート所有者とプロジェクト内のメンバーには読み取りおよび書き込み権限があります。",
+    "create-read-only-data-source": "作成に行く",
     "go-back": "戻る",
-    "save-sheet": "シートを保存",
-    "save-sheet-input-placeholder": "シート名を入力してください",
-    "untitled-sheet": "無題のシート",
+    "save-sheet": "ワークシートの保存",
+    "save-sheet-input-placeholder": "ワークシート名を入力してください",
+    "untitled-sheet": "名前のないワークシート",
     "format": "フォーマット",
-    "sql-review-result": "SQLレビュー結果",
-    "alter-table": "他の机",
-    "visualize-explain": "視覚化して説明する",
-    "sql-execute-in-production-environment": "注意してください。実稼働環境のデータベースにアクセスしています。",
-    "rows-upper-limit": "クエリ結果の上限に達しました",
+    "sql-review-result": "SQLチェック結果",
+    "alter-table": "テーブル構造の変更",
+    "visualize-explain": "視覚化の説明",
+    "sql-execute-in-production-environment": "実稼働データベースを使用していることに注意してください。",
+    "rows-upper-limit": "クエリ結果の数が上限に達しました",
     "tab-mode": {
       "readonly": "読み取り専用",
       "admin": "管理者"
     },
-    "close-sheet": "シートを閉じる",
+    "close-sheet": "ワークシートを閉じる",
     "connect": "接続する",
     "connect-in-admin-mode": "管理者モードで接続する",
     "admin-mode": {
       "self": "管理者モード"
     },
-    "allow-admin-mode-only": "インスタンス {instance} は管理者モードでのみアクセスできます。",
-    "run-selected": "選択した項目を実行",
-    "clear-screen": "画面をクリア",
+    "allow-admin-mode-only": "インスタンス {instance} には管理者モードでのみアクセスできます。",
+    "run-selected": "選択したステートメントを実行する",
+    "clear-screen": "クリアスクリーン",
     "query-time": "クエリ時間",
-    "connection-lost": "接続が失われました。次のクエリを実行するときに再接続を試みます。",
+    "connection-lost": "接続切断。次回クエリが実行されるときに再接続が試行されます。",
     "sheet": {
-      "choose-sheet": "シートを選択",
-      "self": "シート",
-      "connection": "繋がり"
+      "choose-sheet": "ワークシートを選択",
+      "self": "ワークシート",
+      "connection": "接続する"
     },
     "tab": {
       "unsaved": "保存されていません",
       "context-menu": {
         "actions": {
-          "close": "近い",
+          "close": "閉鎖",
           "close-others": "その他を閉じる",
-          "close-to-the-right": "右に近づく",
-          "close-saved": "閉じる保存しました",
+          "close-to-the-right": "右側をすべて閉じます",
+          "close-saved": "保存済みを閉じる",
           "close-all": "すべて閉じる",
-          "rename": "名前を変更"
+          "rename": "名前の変更"
         }
       }
     },
     "batch-query": {
       "batch": "バッチ",
       "select-database": "以下のデータベースを選択してください",
-      "description": "{project} の下にある {count} 個の追加データベースをバッチ クエリします。"
+      "description": "{project} の下にある {count} データベースをバッチクエリします。"
     },
-    "executing-query": "クエリを実行しています",
-    "grouping": "グループ化",
+    "executing-query": "クエリの実行",
+    "grouping": "グループ",
     "previous-row": "前の行",
     "next-row": "次の行",
-    "copy-success": "コピー成功",
-    "missing-permission-to-load-db-metadata": "db {db} のメタデータをロードするために必要な権限がありません。",
-    "connect-in-new-tab": "新しいタブで接続",
-    "copy-name": "名前をコピー",
-    "copy-select-statement": "SELECT文をコピー",
+    "copy-success": "正常にコピーされました",
+    "missing-permission-to-load-db-metadata": "データベース {db} のメタデータをロードする権限がありません。",
+    "connect-in-new-tab": "新しいタブで接続する",
+    "copy-name": "名前をコピーする",
+    "copy-select-statement": "SELECT ステートメントをコピーする",
     "preview-table-data": "テーブルデータのプレビュー",
-    "view-table-detail": "テーブルの詳細を表示",
-    "view-database-detail": "データベースの詳細を表示",
-    "copy-all-column-names": "すべての列名をコピー",
-    "view-schema-text": "スキーマテキストを表示",
+    "view-table-detail": "テーブルの詳細を表示する",
+    "view-database-detail": "データベースの詳細を表示する",
+    "copy-all-column-names": "すべての列名をコピーします",
+    "view-schema-text": "テキストの表示 スキーマ",
     "override-current-statement": "現在のステートメントを上書きする",
-    "last-synced": "最終同期: {time}",
-    "click-to-sync-now": "今すぐ同期するにはクリックしてください",
+    "last-synced": "最終同期時間: {time}",
+    "click-to-sync-now": "クリックして今すぐ同期します",
     "sync-in-progress": "同期中",
     "create-a-worksheet": "新しいワークシートを作成する",
-    "select-a-database-to-start": "開始するデータベースを選択してください",
-    "select-encoding": "エンコードを選択"
+    "select-a-database-to-start": "開始するにはデータベースを選択してください",
+    "select-encoding": "エンコーディングの選択"
   },
   "schema-editor": {
-    "self": "スキーマ エディター",
-    "use-tips": "開始するにはデータベース/テーブルをクリックします。",
-    "preview-issue": "プレビュー号",
-    "sync-sql-from-schema-editor": "スキーマ エディターから SQL を同期する",
-    "raw-sql": "生のSQL",
-    "search-database-and-table": "データベースとテーブルを検索",
+    "self": "スキーマエディタ",
+    "use-tips": "編集するデータベースまたはテーブルを選択します",
+    "preview-issue": "作業指示のプレビュー",
+    "sync-sql-from-schema-editor": "スキーマエディタからSQLを同期する",
+    "raw-sql": "SQL文",
+    "search-database-and-table": "データベースとテーブルを検索する",
     "search-table": "検索テーブル",
-    "search-column": "検索列",
+    "search-column": "検索欄",
     "actions": {
-      "create-schema": "スキーマを作成する",
-      "drop-schema": "スキーマを削除する",
-      "create-table": "新しいテーブル",
-      "rename": "名前を変更",
-      "drop-table": "テーブルをドロップ",
-      "restore": "復元する",
-      "add-column": "列を追加",
+      "create-schema": "新しいスキーマ",
+      "drop-schema": "スキーマの削除",
+      "create-table": "新しいテーブルを作成する",
+      "rename": "名前の変更",
+      "drop-table": "テーブルの削除",
+      "restore": "回復する",
+      "add-column": "列の追加",
       "add-from-template": "テンプレートから追加",
-      "drop-column": "列を削除",
-      "sql-preview": "SQL プレビュー",
+      "drop-column": "列の削除",
+      "sql-preview": "SQLのプレビュー",
       "reset": "リセット",
       "save": "保存"
     },
     "database": {
       "name": "名前",
-      "row-count": "行数",
+      "row-count": "データ行数",
       "data-size": "データサイズ",
       "engine": "エンジン",
-      "collation": "照合",
+      "collation": "文字の並べ替え規則",
       "comment": "コメント"
     },
     "schema": {
-      "select": "スキーマを選択",
+      "select": "スキーマの選択",
       "name": "スキーマ名"
     },
-    "tables": "テーブル",
+    "tables": "表面",
     "table": {
-      "select": "テーブルを選択",
+      "select": "テーブルの選択",
       "name": "テーブル名"
     },
-    "columns": "コラム",
+    "columns": "リスト",
     "column": {
       "select": "列を選択",
       "name": "名前",
       "type": "タイプ",
-      "default": "デフォルト",
+      "default": "デフォルト値",
       "comment": "コメント",
-      "not-null": "NULLではない",
-      "primary": "主要な",
+      "not-null": "空にすることはできません",
+      "primary": "主キー",
       "foreign-key": "外部キー",
-      "classification": "分類",
-      "on-update": "更新時"
+      "classification": "分類と格付け",
+      "on-update": "アップデート時"
     },
     "default": {
-      "no-default": "デフォルトなし",
+      "no-default": "デフォルト値なし",
       "empty-string": "空の文字列",
       "expression": "表現",
       "zero": "0",
       "true": "真実",
       "false": "間違い"
     },
-    "nothing-changed-for-database": "データベース {database} には何も変更されていません",
+    "nothing-changed-for-database": "データベース {database} 変更なし",
     "message": {
       "invalid-schema-name": "無効なスキーマ名",
-      "duplicated-schema-name": "重複したスキーマ名",
-      "invalid-table-name": "テーブル名が無効です",
-      "duplicated-table-name": "重複したテーブル名",
-      "invalid-column-name": "列名が無効です",
-      "duplicated-column-name": "重複した列名",
-      "invalid-column-type": "無効な列タイプ",
+      "duplicated-schema-name": "スキーマ名が重複しています",
+      "invalid-table-name": "無効なテーブル名です",
+      "duplicated-table-name": "テーブル名が重複しています",
+      "invalid-column-name": "無効な列名です",
+      "duplicated-column-name": "列名が重複しています",
+      "invalid-column-type": "無効な列タイプです",
       "schema-not-found": "スキーマが見つかりません",
-      "failed-to-fetch-database-schema": "データベース スキーマの取得に失敗しました",
+      "failed-to-fetch-database-schema": "データベース スキーマの要求に失敗しました",
       "invalid-schema": "無効なスキーマ",
-      "cannot-drop-the-last-column": "最後の列を削除できません",
-      "cannot-change-config": "データベース構成はスキーマに合わせて変更する必要があります"
+      "cannot-drop-the-last-column": "最後の列は削除できません",
+      "cannot-change-config": "データベース構成はスキーマとともに変更する必要があります"
     },
     "confirm-to-close": {
-      "title": "閉じるには確認",
-      "description": "パネルを閉じてもよろしいですか? 変更内容は失われます。"
+      "title": "閉じることを確認しますか？",
+      "description": "変更は閉じると失われます。"
     },
-    "tenant-mode-tips": "「問題をプレビュー」をクリックすると、選択したすべてのテナント データベースに変更が適用されます。",
-    "edit-foreign-key": "外部キーを編集",
-    "select-reference-schema": "参照するスキーマを選択してください",
-    "select-reference-table": "参照するテーブルを選択してください",
-    "select-reference-column": "参照する列を選択",
+    "tenant-mode-tips": "[チケットのプレビュー] をクリックすると、現在の変更が選択したすべてのテナント データベースに適用されます。",
+    "edit-foreign-key": "外部キーを変更する",
+    "select-reference-schema": "外部キーのスキーマを選択します",
+    "select-reference-table": "外部キーのあるテーブルを選択",
+    "select-reference-column": "外部キー列を選択します",
     "index": {
-      "indexes": "インデックス",
-      "edit-indexes": "インデックスを編集する",
-      "unique": "個性的"
+      "indexes": "索引",
+      "edit-indexes": "インデックスの編集",
+      "unique": "のみ"
     },
-    "generated-ddl-is-empty": "生成されたDDLは空です",
+    "generated-ddl-is-empty": "生成された DDL は空です",
     "table-partition": {
       "partitions": "パーティション",
-      "edit-partitions": "パーティションを編集する",
+      "edit-partitions": "パーティションの編集",
       "expression": "表現",
       "value": "価値",
-      "add-sub-partition": "サブパーティションを追加",
+      "add-sub-partition": "サブパーティションの追加",
       "type": "タイプ"
     }
   },
   "label": {
-    "empty-label-value": "空の",
+    "empty-label-value": "ヌル",
     "no-label": "ラベルなし",
     "error": {
-      "key-necessary": "キーが必要です",
-      "value-necessary": "値が要求されます",
-      "key-duplicated": "重複したキー",
-      "value-duplicated": "重複した値",
-      "max-length-exceeded": "長さは {len} 文字を超えることはできません",
-      "max-label-count-exceeded": "{count} ラベルを超えることはできません",
-      "cannot-edit-reserved-label": "予約済みラベル「{key}」を編集できません",
-      "max-value-length-exceeded": "値の長さは {length} 文字を超えることはできません",
-      "key-format": "英数字 ([a-z0-9A-Z])、ハイフン (-)、アンダースコア (_)、ドット (.) のみ使用できます。先頭と末尾は英数字にする必要があります。",
-      "x-is-reserved-key": "「{key}」はシステム予約キーです"
+      "key-necessary": "キーを指定する必要があります",
+      "value-necessary": "値を指定する必要があります",
+      "key-duplicated": "キーが繰り返されました",
+      "value-duplicated": "値が重複しています",
+      "max-length-exceeded": "{len} 文字を超えることはできません",
+      "max-label-count-exceeded": "{count} 個を超えるタグを含めることはできません",
+      "cannot-edit-reserved-label": "予約されたラベル「{key}」を編集できません",
+      "max-value-length-exceeded": "値は {length} 文字を超えることはできません",
+      "key-format": "文字と数字 ([a-z0-9A-Z])、ハイフン (-)、アンダースコア (_)、およびドット (.) のみが使用できます。\nまた、先頭と末尾は文字と数字にする必要があります。",
+      "x-is-reserved-key": "「{key}」はシステムで予約されているキーです"
     },
     "placeholder": {
-      "select-key": "キーを選択...",
-      "select-value": "値を選択...",
-      "select-values": "値を選択..."
+      "select-key": "キーを選択…",
+      "select-value": "値を選択してください…",
+      "select-values": "値を選択してください…"
     },
     "setting": {
-      "description": "ラベルは、データベースのテナントを識別するのに役立つキーと値のペアです。{link}。"
+      "description": "タグは、データベース テナントを識別するために使用できるキーと値のペアのセットです。 {link}。"
     },
-    "db-name-template-tips": "データベースの命名を強制するテンプレートを指定します。たとえば、データベース db1 が米国、アジア、ヨーロッパに地理的に分割されており、db1__US、db1__ASIA、db1__EU という名前を強制する場合、テンプレートは {placeholder}. {link} になります。",
-    "confirm-change": "「{label}」を変更してもよろしいですか?",
-    "parsed-from-template": "テンプレート {template} によって {name} から解析されました。",
-    "cannot-transfer-template-not-match": "データベース '{name}' はこのプロジェクトに転送できません。名前がテンプレート {template} と一致しないためです。",
-    "add-label": "ラベルを追加",
-    "filter-by-label": "ラベルでフィルタリング"
+    "db-name-template-tips": "テンプレートを使用してデータベースの名前付けを制限します。たとえば、データベース db1 が地域に従って米国、アジア、ヨーロッパに分割されており、それらの名前を db1__US、db1__ASIA、db1__EU にしたい場合、テンプレートは {placeholder} として指定できます。 {link}。",
+    "confirm-change": "「{label}」を編集してもよろしいですか?",
+    "parsed-from-template": "テンプレート {template} に従って {name} から解析されました",
+    "cannot-transfer-template-not-match": "データベース '{name}' は、名前がテンプレート {template} と一致しないため、このプロジェクトに転送できません。",
+    "add-label": "タグ付けする",
+    "filter-by-label": "タグでフィルタリングする"
   },
   "oauth": {
-    "unknown-event": "予期しないイベント タイプです。OAuth が失敗しました。"
+    "unknown-event": "不明なイベント タイプ、認証に失敗しました"
   },
   "subscription": {
     "try-for-free": "無料トライアル",
-    "inquire-enterprise-plan": "エンタープライズプランのお問い合わせ",
-    "enterprise-free-trial": "{days} 日間の無料エンタープライズ トライアル",
+    "inquire-enterprise-plan": "Enterprise版のお問い合わせ",
+    "enterprise-free-trial": "Enterprise の {days} 日間の無料トライアル",
     "button": {
-      "free-trial": "{days}日間無料トライアル",
+      "free-trial": "{days} 日間の無料トライアル",
       "upgrade": "アップグレード",
       "contact-us": "お問い合わせ",
-      "view-subscription": "サブスクリプションを表示"
+      "view-subscription": "サブスクリプションを表示する"
     },
     "trial-start-modal": {
-      "title": "{plan} のトライアルを開始する",
-      "content": "{plan} の試用が開始されました。{date} より前に {plan} の機能にアクセスできます。",
-      "button": "わかった",
+      "title": "{plan} トライアルが開始されました",
+      "content": "{plan} のトライアルが開始されました。 {date} より前のすべての {plan} 機能は制限されません。",
+      "button": "学ぶ",
       "subscription-page": "購読ページ",
-      "subscription": "これらの機能と当社のプランについて詳しくは、{page} をご覧ください。"
+      "subscription": "サブスクリプション プランと有料機能は {page} でご覧いただけます。"
     },
-    "description": "Bytebase ライセンスをアップロードすると、プロ/エンタープライズ機能のロックを解除できます。",
-    "upload-license": "アップロードライセンス",
+    "description": "ここで購入した Bytebase 証明書をアップロードして、プロフェッショナル/エンタープライズ機能のロックを解除できます。",
+    "upload-license": "証明書のアップロード",
     "upgrade-trial-button": "アップグレードトライアル",
-    "request-n-days-trial": "{days} 日間のトライアルをリクエスト (クレジットカードは不要)",
-    "request-with-qr": "QRコードをスキャン",
-    "successfully-start-trial": "{days} 日間の無料トライアルを開始しました",
-    "successfully-upgrade-trial": "無料トライアルを {plan} にアップグレードしました",
-    "require-subscription": "この機能には {requiredPlan} サブスクリプションが必要です。ロックを解除するには Bytebase ライセンスを購入してください。",
-    "feature-require-subscription": "{feature} には {requiredPlan} サブスクリプションが必要です。",
-    "required-plan-with-trial": "この機能には {requiredPlan} が必要です。{startTrial}",
-    "trial-for-plan": "{plan} の {days} 日間の無料トライアルを開始できます。クレジットカードは必要ありません。",
-    "trial-for-days": "{days} 日間の無料トライアルを開始できます。クレジットカードは必要ありません。",
-    "upgrade-trial": "無料トライアルをこのプランにアップグレードできます。",
-    "contact-to-upgrade": "プランをアップグレードするには、Workspace 管理者にお問い合わせください。",
+    "request-n-days-trial": "{days} 日間のトライアルをリクエストします (クレジット カードは必要ありません)",
+    "request-with-qr": "QRコードを読み取ってトライアルを申し込みます",
+    "successfully-start-trial": "{days} 日間の無料トライアルが正常に開始されました",
+    "successfully-upgrade-trial": "{plan} 試用版に正常にアップグレードされました",
+    "require-subscription": "この機能には、{requiredPlan} のサブスクリプションが必要です。この機能のロックを解除するには、Bytebase 証明書を購入してください。",
+    "feature-require-subscription": "{feature} には {requiredPlan} が必要です。",
+    "required-plan-with-trial": "この機能には、{requiredPlan} のサブスクリプション、{startTrial} が必要です",
+    "trial-for-plan": "{plan} の {days} 日間の無料トライアルを開始できます。クレジット カードや前払いは必要ありません。",
+    "trial-for-days": "{days} 日間の無料トライアルを開始できます。クレジット カードや前払いは必要ありません。",
+    "upgrade-trial": "既存の試用版をこのバージョンに直接アップグレードできます。",
+    "contact-to-upgrade": "試用版にアップグレードするには、ワークスペースの所有者に問い合わせてください。",
     "upgrade-now": "今すぐアップグレード",
     "instance-assignment": {
-      "license": "ライセンス",
-      "assign-license": "ライセンスの割り当て",
-      "require-license": "インスタンスライセンスが必要",
-      "missing-license-attention": "この機能を有効にするには、インスタンスにライセンスを割り当てる必要があります。",
-      "n-license-remain": "残る",
-      "manage-license": "インスタンスライセンスの管理",
-      "used-and-total-license": "割り当てられた/インスタンスライセンスの合計",
-      "success-notification": "ライセンスの割り当てが正常に更新されました",
-      "missing-license-for-instances": "この機能のロックを解除するために必要なライセンスが不足しているインスタンス ({name}) が {count} 個あります。",
-      "missing-license-for-feature": "{feature} を有効にするためのインスタンス ライセンスがありません。クリックして今すぐ割り当てます。"
+      "license": "証明書",
+      "assign-license": "証明書の割り当て",
+      "require-license": "インスタンス証明書が必要です",
+      "missing-license-attention": "この機能のロックを解除するには、インスタンスに証明書を割り当ててください。",
+      "n-license-remain": "残り {n}",
+      "manage-license": "証明書の管理",
+      "used-and-total-license": "割り当てられた/合計インスタンス証明書",
+      "success-notification": "証明書の割り当てが正常に更新されました",
+      "missing-license-for-instances": "この機能を有効にするための証明書が不足しているインスタンス ({count}) があります。",
+      "missing-license-for-feature": "{feature} を有効にするためのインスタンス証明書がありません。クリックして証明書を割り当てます。"
     },
     "update": {
       "success": {
-        "title": "ライセンスの更新に成功しました",
-        "description": "サブスクリプションプランのプレミアム機能がロック解除されました。"
+        "title": "証明書が正常に更新されました",
+        "description": "サブスクリプション版のプレミアム機能がロック解除されました"
       },
       "failure": {
-        "title": "ライセンスの更新に失敗しました",
-        "description": "ライセンスが有効かどうかを確認してください。"
+        "title": "証明書の更新に失敗しました",
+        "description": "証明書が有効かどうかを確認してください"
       }
     },
-    "plan-features": "{plan} 機能",
-    "overuse-warning": "{currentPlan} の {neededPlan} は制限されます。継続的なアクセスを確保するには、今すぐアップグレードしてください。",
+    "plan-features": "{plan} 関数",
+    "overuse-warning": "{neededPlan} は {currentPlan} で制限されます。通常どおり使用できるように、できるだけ早くアップグレードしてください。",
     "overuse-modal": {
-      "description": "{plan} では利用できない機能を使用しています。引き続きアクセスできるようにするには、今すぐアップグレードしてください。",
+      "description": "現在「{plan}」に含まれていない機能を使用しています。使用に影響を与えないように、すぐにアップグレードしてください。",
       "instance-count-exceeds": "インスタンス数 {count} が制限 {limit} を超えています"
     },
     "features": {
       "bb-feature-external-secret-manager": {
-        "title": "外部シークレットを設定する",
-        "desc": "データベース パスワードの外部シークレットとして Vault またはカスタム URL を使用します。"
+        "title": "外部キーを設定する",
+        "desc": "データベース パスワードの外部キーとして Vault またはカスタム URL を設定します。"
       },
       "bb-feature-task-schedule-time": {
-        "title": "タスクスケジュール時間を設定する",
-        "desc": "タスクのスケジュール時間を設定すると、タスクを実行する特定の時間を設定できます。"
+        "title": "タスクの実行時間を設定する",
+        "desc": "「タスク実行時刻の設定」では、特定の時刻に実行するタスクを設定できます"
       },
       "bb-feature-instance-count": {
-        "title": "インスタンス数の制限",
-        "desc": "最大インスタンス数の制限に達しました。インスタンスの割り当てを増やすにはアップグレードしてください。",
-        "remaining": "インスタンスの合計割り当ては {total} で、残っているインスタンスは {count} 個のみです。",
-        "runoutof": "{total} インスタンスのクォータが不足しています。",
-        "upgrade": "インスタンスのクォータを増やすには、@:{'subscription.upgrade'} を使用します。"
+        "title": "インスタンスの制限",
+        "desc": "インスタンスの最大制限に達しました。追加のインスタンス割り当てを取得するには、アップグレードに料金を支払ってください。",
+        "remaining": "現在の合計インスタンス割り当ては {total} で、使用可能な共有は {count} 個のみです。",
+        "runoutof": "すべての {total} インスタンス クレジットが使用されました。",
+        "upgrade": "@:{'subscription.upgrade'} を使用して、より多くのインスタンス割り当てを取得します。"
       },
       "bb-feature-user-count": {
-        "title": "ユーザー数制限",
-        "desc": "ユーザー数の上限に達しました。無制限のユーザー割り当てを取得するにはアップグレードしてください。",
-        "remaining": "合計ユーザー割り当ては {total} で、残っているユーザーは {count} 人だけです。",
-        "runoutof": "{total} ユーザークォータが不足しています。",
-        "upgrade": "@:{'subscription.upgrade'} を使用すると、ユーザー割り当てが無制限になります。"
+        "title": "ユーザー制限",
+        "desc": "ユーザーの最大数に達しました。無制限のユーザー割り当てを取得するには、アップグレードに料金を支払ってください。",
+        "remaining": "現在の合計ユーザー割り当ては {total} で、使用できる共有は {count} 個のみです。",
+        "runoutof": "{total} 個のユーザー クレジットがすべて使用されました。",
+        "upgrade": "@:{'subscription.upgrade'} を使用すると、無制限のユーザー割り当てを取得できます。"
       },
       "bb-feature-multi-tenancy": {
         "title": "バッチモード",
-        "desc": "異なるテナントまたはパーティションからのデータベースのグループを一括変更します。"
+        "desc": "異なるテナントまたはデータベース シャードに属するデータベースのグループに対するバッチ変更。"
       },
       "bb-feature-approval-policy": {
-        "title": "ロールアウトポリシー",
-        "desc": "ロールアウト ポリシーは、スキーマ変更タスクに手動のロールアウトが必要かどうかを制御します。"
+        "title": "リリース戦略",
+        "desc": "「リリース戦略」は、データベーススキーマへの変更を手動でリリースする必要があるかどうかを制御できます。"
       },
       "bb-feature-environment-tier-policy": {
-        "title": "環境層",
-        "desc": "環境を本番環境としてマークします。"
+        "title": "環境レベル",
+        "desc": "「環境レベル」では、環境を実稼働環境としてマークできます。"
       },
       "bb-feature-sensitive-data": {
         "title": "機密データ",
-        "desc": "テーブル列を機密データとしてマークすると、そのクエリ結果は「******」として表示されます。"
+        "desc": "データ テーブルの列を機密データとしてマークすると、クエリ結果に「******」として表示されます。"
       },
       "bb-feature-access-control": {
         "title": "データアクセス制御",
-        "desc": "ユーザーによるデータ クエリ結果のコピーを禁止するなど、データへのユーザー アクセスを制限します。"
+        "desc": "ユーザーによるデータ クエリ結果のコピーの禁止など、データへのユーザー アクセスを制限します。"
       },
       "bb-feature-lgtm": {
-        "title": "LGTMチェック",
-        "desc": "問題に「LGTM」コメントがあるかどうかを確認します。"
+        "title": "LGTM検査",
+        "desc": "チケットに「LGTM」コメントがあるかどうかを確認してください。"
       },
       "bb-feature-im-approval": {
-        "title": "IM承認",
-        "desc": "IM 統合に関する承認の問題。"
+        "title": "IMの統合",
+        "desc": "統合された IM を使用して作業指示を承認します。"
       },
       "bb-feature-sql-review": {
-        "title": "100以上のSQLレビューチェックをアンロック",
-        "desc": "SQL のベスト プラクティスを採用し、エンジニアリング組織全体でスキーマの一貫性を強化するために、SQL lint ルールを指定します。"
+        "title": "100 を超える SQL 監査ポリシーのロックを解除します",
+        "desc": "さまざまな SQL lint ルールを構成して、研究開発組織に SQL のベスト プラクティスを実装し、スキーマ仕様の一貫性を確保します。"
       },
       "bb-feature-custom-approval": {
         "title": "カスタム承認",
-        "desc": "さまざまなタスクのリスク レベルと承認フローを構成します。"
+        "desc": "さまざまなタスクのリスク レベルとカスタム承認フローを構成します。"
       },
       "bb-feature-vcs-sql-review": {
-        "title": "GitOps ワークフローでの SQL レビュー",
-        "desc": "SQL レビュー CI を VCS リポジトリ パイプラインに追加します。変更された SQL ファイルのプル リクエストで SQL レビューがトリガーされます。"
+        "title": "GitOps ワークフローでの SQL 監査",
+        "desc": "SQL 監査 CI を VCS リポジトリ パイプラインに追加して、プル リクエストで変更された SQL ファイルを自動的に監査します。"
       },
       "bb-feature-rbac": {
         "title": "役割管理",
-        "desc": "ロール管理では、メンバーに特定のロール (DBA など) を割り当てることができます。"
+        "desc": "「ロール管理」では、DBAなどのメンバーに特定のロールを割り当てることができます。"
       },
       "bb-feature-custom-role": {
         "title": "カスタムロール",
-        "desc": "カスタム ロールを定義します。プロジェクト メンバーに適用し、カスタム承認に使用できます。"
+        "desc": "カスタム承認を構成するためにプロジェクト メンバーに適用できるカスタム ロールを定義します。"
       },
       "bb-feature-watermark": {
-        "title": "透かし",
-        "desc": "ユーザー名、ID、電子メールなどの透かしをページ上に表示します。"
+        "title": "ウォーターマークの設定",
+        "desc": "ユーザー名、ID、メールアドレスを含むページにウォーターマークを表示します。"
       },
       "bb-feature-audit-log": {
         "title": "監査ログ",
-        "desc": "ワークスペースでユーザーが実行した操作を記録および照会します。"
+        "desc": "ワークスペースでユーザーが実行したアクションを記録およびクエリします。"
       },
       "bb-feature-schema-drift": {
-        "title": "スキーマドリフト",
-        "desc": "帯域外のスキーマ変更を検出し、スキーマのドリフトを報告します。"
+        "title": "スキーマの逸脱",
+        "desc": "予期しないスキーマ変更を検出し、スキーマの逸脱を報告します。"
       },
       "bb-feature-branding": {
-        "title": "ブランディング",
-        "desc": "ロゴをカスタマイズします。"
+        "title": "カスタムブランド情報",
+        "desc": "カスタマイズされたロゴ"
       },
       "bb-feature-online-migration": {
-        "title": "オンライン移行",
-        "desc": "gh-ost に基づいています。大きなテーブルの場合、テーブル ロックの継続時間を数時間から数秒に短縮できます。"
+        "title": "オンラインでの大規模なテーブル変更",
+        "desc": "gh-ostをベースにしています。大きなテーブルの場合、テーブルのロック時間を数時間から数秒に短縮できます。"
       },
       "bb-feature-sync-schema-all-versions": {
-        "title": "すべてのバージョンのスキーマを同期する",
-        "desc": "ベース データベースから任意の移行バージョンを選択し、ターゲット データベースに同期します。"
+        "title": "データベーステーブルの同期",
+        "desc": "データベースのスキーマ バージョンを選択し、ターゲット データベースと同期します。"
       },
       "bb-feature-read-replica-connection": {
         "title": "リードレプリカ接続",
-        "desc": "読み取り専用データ ソースの読み取りレプリカに接続します。"
+        "desc": "リードレプリカを使用して、読み取り専用データ ソースに接続します。"
       },
       "bb-feature-instance-ssh-connection": {
-        "title": "インスタンスSSH接続",
+        "title": "SSHインスタンス接続",
         "desc": "SSH 経由でインスタンスに接続します。"
       },
       "bb-feature-custom-instance-scan-interval": {
-        "title": "カスタムインスタンススキャン間隔",
-        "desc": "インスタンスのスキーマと異常スキャン間隔をカスタマイズする"
+        "title": "カスタムインスタンスのスキャン間隔",
+        "desc": "インスタンス スキーマと例外スキャン間隔をカスタマイズする"
       },
       "bb-feature-index-advisor": {
-        "title": "インデックスアドバイザー",
-        "desc": "インデックス アドバイザーは、遅いクエリで欠落しているインデックスを見つけるのに役立ちます。"
+        "title": "インデックスの提案",
+        "desc": "インデックスの推奨事項により、クエリの遅延の原因となっているインデックスを検出し、関連する最適化の推奨事項を提供できます。"
       },
       "bb-feature-sso": {
-        "title": "シングルサインオン (SSO)",
-        "desc": "ユーザーは、単一の資格情報セットを使用して、複数のアプリケーションや Web サイトで安全に認証できます。"
+        "title": "シングル サインオン (SSO)",
+        "desc": "ユーザーが SSO を通じて Bytebase に安全にログインできるようにします。"
       },
       "bb-feature-2fa": {
-        "title": "2要素認証（2FA）",
-        "desc": "2 要素認証は、メンバー アカウントのセキュリティをさらに強化します。サインインするときに、認証アプリによって生成されたセキュリティ コードを入力する必要があります。"
+        "title": "二要素認証",
+        "desc": "2 要素認証は、システム メンバーに追加のセキュリティ層を提供します。ログインするとき、ユーザーは認証アプリケーションによって生成されたセキュリティ コードを入力する必要があります。"
       },
       "bb-feature-plugin-openai": {
-        "title": "AI拡張",
-        "desc": "OpenAI を搭載した AI 拡張 SQL エディターとインデックス アドバイザー機能。"
+        "title": "AIの強化",
+        "desc": "OpenAI テクノロジーを活用した、AI で強化された SQL エディターとインデックス提案機能。"
       },
       "bb-feature-batch-query": {
         "title": "バッチクエリ",
-        "desc": "SQL エディターで同じプロジェクトの下にある追加のデータベースをバッチ クエリします。"
+        "desc": "SQL エディターで複数のデータベースに対してバッチ クエリを実行します。"
       },
       "bb-feature-shared-sql-script": {
         "title": "共有SQLスクリプト",
-        "desc": "SQL スクリプトをプロジェクト チームメイトと共有するか、全員に公開します。"
+        "desc": "SQL スクリプトをプロジェクト メンバーと共有するか、誰でも利用できるようにします。"
       },
       "bb-feature-announcement": {
         "title": "発表",
-        "desc": "アナウンスバナーを設定します。"
+        "desc": "お知らせバナーを設定します。"
       },
       "bb-feature-encrypted-secrets": {
-        "title": "暗号化された秘密",
-        "desc": "データベースの秘密を保存し、発行 SQL スクリプトで使用します。"
+        "title": "秘密変数",
+        "desc": "シークレット変数をデータベースに保存し、チケットの SQL で使用します。"
       },
       "bb-feature-database-grouping": {
-        "title": "データベースグループ",
-        "desc": "データベース グループを使用すると、データベース グループのデータベースにバッチ操作を適用できます。"
+        "title": "データベースのグループ化",
+        "desc": "データベースをグループ化すると、データベース グループ内のデータベースに対してバッチ操作を実行できます。"
       },
       "bb-feature-disallow-signup": {
-        "title": "セルフサービスサインアップを無効にする",
-        "desc": "無効にすると、ユーザーはセルフサービスサインアップできなくなり、ワークスペース管理者によってのみ招待されるようになります。"
+        "title": "セルフサービス登録を無効にする",
+        "desc": "無効化されると、新しいユーザーは自己登録できなくなり、管理者の招待を通じてのみアカウントを作成できます。"
       },
       "bb-feature-schema-template": {
         "title": "スキーマテンプレート",
-        "desc": "フィールド テンプレートを事前に定義し、スキーマの変更時にテンプレートを適用します。"
+        "desc": "スキーマの変更または設計時に適用できるスキーマ テンプレートを事前定義します。"
       },
       "bb-feature-secure-token": {
-        "title": "サインイン頻度",
-        "desc": "サインイン頻度は、ユーザーが再度サインインするまでの期間です。"
+        "title": "ログイン頻度",
+        "desc": "ログイン頻度は、ユーザーが再度ログインする必要がある間隔を指定します。"
       },
       "bb-feature-issue-advanced-search": {
-        "title": "高度な問題検索",
-        "desc": "高度な問題検索により、無制限の問題履歴にアクセスできます。"
+        "title": "チケットの詳細検索",
+        "desc": "高度な検索機能を使用して、無制限の過去のチケットにアクセスできます。"
       }
     }
   },
   "sheet": {
-    "self": "シート",
-    "my-sheets": "私のシート",
+    "self": "ワークシート",
+    "my-sheets": "私のワークシート",
     "mine": "私の",
-    "star": "星",
-    "unstar": "スターを外す",
-    "starred": "スター付き",
+    "star": "お気に入りに追加",
+    "unstar": "お気に入りをキャンセルする",
+    "starred": "集めました",
     "shared": "共有",
     "actions": {
-      "sync-from-vcs": "VCSからSQLスクリプトを同期する"
+      "sync-from-vcs": "VCS から SQL スクリプトを同期する"
     },
     "notifications": {
-      "duplicate-success": "「マイシート」に正常に複製されました"
+      "duplicate-success": "「マイワークシート」にコピーされました"
     },
     "hint-tips": {
-      "confirm-to-sync-sheet": "シートを同期しますか?",
-      "confirm-to-delete-this-sheet": "このシートを削除しますか?",
-      "confirm-to-duplicate-sheet": "このシートを複製しますか?"
+      "confirm-to-sync-sheet": "ワークシートを同期してもよろしいですか?",
+      "confirm-to-delete-this-sheet": "このワークシートを削除してもよろしいですか?",
+      "confirm-to-duplicate-sheet": "このワークシートをコピーしてもよろしいですか?"
     },
-    "linked-issue": "関連問題",
-    "from-issue-warning": "このシートは、読み取り専用モードで発行された {issue} から取得されました。{oversize}",
-    "content-oversize-warning": "SQL のサイズが大きすぎるため、インライン編集は許可されません。",
-    "sheets": "シート",
-    "search-sheets": "検索シート",
-    "sheet": "シート",
+    "linked-issue": "関連する作業指示書",
+    "from-issue-warning": "このシートはチケット {issue} のもので、読み取り専用モードです。 {oversize}",
+    "content-oversize-warning": "SQL は大きすぎて直接編集できません。",
+    "sheets": "ワークシート",
+    "search-sheets": "ワークシートの検索",
+    "sheet": "ワークシート",
     "unconnected": "接続されていません",
     "draft": "下書き"
   },
   "engine": {
-    "mysql": "マイグレーション",
-    "common": "一般"
+    "mysql": "MySQL",
+    "common": "ユニバーサル"
   },
   "sql-review": {
-    "title": "SQLレビュー",
-    "description": "SQL レビュー ポリシーでは、それぞれの環境に対して異なる SQL lint ルールのセットを定義できます。これにより、チームは SQL のベスト プラクティスを採用し、異なるデータベース間でスキーマの一貫性を確保できます。DDL/DML の変更を試みたり、SQL エディターを使用してデータをクエリしたりするたびに、クエリは構成された SQL レビュー ポリシーと照合されます。",
+    "title": "SQL監査ポリシー",
+    "description": "SQL 監査ポリシーは、さまざまな環境に対してさまざまな SQL lint ルールのセットを定義でき、チームが SQL のベスト プラクティスを採用し、さまざまなデータベースでスキーマの一貫性を制約するのに役立ちます。 DDL/DML を変更しようとしたり、SQL エディターを使用してデータをクエリしようとしたりすると、設定された SQL 監査ルールによって対応する実行ステートメントがチェックされます。",
     "disabled": "無効",
-    "no-policy-set": "SQLレビューポリシーなし",
-    "create-policy": "ポリシーを作成する",
-    "duplicate-policy": "重複SQLレビューポリシー",
-    "configure-policy": "ポリシーを構成する",
-    "policy-removed": "レビュー ポリシーが正常に削除されました。",
-    "policy-created": "レビュー ポリシーが正常に作成されました。",
-    "policy-updated": "レビュー ポリシーが正常に更新されました。",
-    "policy-duplicated": "レビュー ポリシーが正常に複製されました。",
+    "no-policy-set": "SQL監査ポリシーなし",
+    "create-policy": "監査ポリシーを作成する",
+    "duplicate-policy": "監査ポリシーをコピーする",
+    "configure-policy": "監査ポリシーを構成する",
+    "policy-removed": "監査ポリシーが削除されました",
+    "policy-created": "監査ポリシーが作成されました",
+    "policy-updated": "監査ポリシーが更新されました",
+    "policy-duplicated": "監査ポリシーがコピーされました",
     "rules": "ルール",
     "filter": "フィルター",
-    "no-permission": "レビュー ポリシーを作成または更新する権限を持つのは DBA または管理者のみです。",
-    "disable": "無効にする",
-    "enable": "有効にする",
-    "delete": "SQLレビューポリシーを削除する",
-    "input-then-press-enter": "値を入力してEnterキーを押して追加します",
-    "not-available-for-free": "ルールは {plan} では利用できません",
-    "unlock-full-feature": "100以上のSQL lintルールをアンロック",
+    "no-permission": "管理者または DBA のみが監査ポリシーを作成または更新する権限を持っています。",
+    "disable": "監査ポリシーを無効にする",
+    "enable": "監査ポリシーを有効にする",
+    "delete": "監査ポリシーの削除",
+    "input-then-press-enter": "入力後、Enterを押して追加します",
+    "not-available-for-free": "{plan}定期購入ではこのルールを使用できません",
+    "unlock-full-feature": "100 を超える SQL レビュー ルールのロックを解除する",
     "create": {
-      "breadcrumb": "SQLレビューポリシーを作成する",
+      "breadcrumb": "監査ポリシーを作成する",
       "basic-info": {
         "name": "基本情報",
-        "display-name": "表示名",
-        "display-name-placeholder": "レビューポリシー名",
-        "display-name-default": "SQLレビューポリシー",
-        "display-name-label": "さまざまなレビュー ポリシーを識別するのに役立つ表示名。",
+        "display-name": "名前",
+        "display-name-placeholder": "監査ポリシー名",
+        "display-name-default": "SQL監査ポリシー",
+        "display-name-label": "さまざまな監査ポリシーを区別するために使用される名前。",
         "environments": "環境",
-        "environments-label": "選択した環境にレビュー ポリシーを適用します。 1 つの環境には 1 つのポリシーのみをリンクできます。",
-        "environments-select": "環境を選択",
-        "no-linked-environments": "リンクされた環境はありません",
-        "no-available-environment": "利用可能な環境がありません",
-        "no-available-environment-desc": "利用可能な環境がありません。 1 つの環境でリンクできる SQL レビュー ポリシーは 1 つだけです。",
+        "environments-label": "この監査ポリシーが適用される環境。 1 つの環境に関連付けることができる監査ポリシーは 1 つだけです。",
+        "environments-select": "環境を選ぶ",
+        "no-linked-environments": "環境が選択されていません",
+        "no-available-environment": "代わりの環境がない",
+        "no-available-environment-desc": "代わりの環境はありません。 1 つの環境に関連付けることができる監査ポリシーは 1 つだけです。",
         "choose-template": "テンプレートを選択"
       },
       "configure-rule": {
-        "name": "ルールを設定する",
-        "change-template": "テンプレートを変更する",
-        "confirm-override-title": "変更を確認",
-        "confirm-override-description": "あなたのルールは上書きされます"
+        "name": "ルールを構成する",
+        "change-template": "テンプレートの変更",
+        "confirm-override-title": "ルール変更",
+        "confirm-override-description": "以前のルールは上書きされます"
       },
       "preview": {
         "name": "プレビュー"
       }
     },
     "edit-rule": {
-      "self": "SQLレビュールールの編集",
-      "readonly": "SQL レビュールール"
+      "self": "SQL監査ルールを編集する",
+      "readonly": "SQL監査ルール"
     },
     "rule": {
-      "active": "アクティブ"
+      "active": "オンにする"
     },
-    "enabled-rules": "有効なルール",
+    "enabled-rules": "開かれたルールの数",
     "rule-detail": "ルールの詳細",
-    "view-definition": "定義を表示",
-    "other-engines": "その他のエンジン"
+    "view-definition": "ビューの定義",
+    "other-engines": "他の種類のデータベース"
   },
   "debug-log": {
     "title": "デバッグログ",
-    "no-logs": "デバッグログなし",
-    "count-of-logs": "サーバーから最新の {count} 個のログを取得しました。",
-    "debug-log-detail": "デバッグログの詳細",
-    "enabled": "デバッグモードが有効になっています。",
-    "open-debug-mode": "デバッグを有効にする",
+    "no-logs": "デバッグログはまだありません",
+    "count-of-logs": "サーバーから取得した最新の {count} ログ。",
+    "debug-log-detail": "ログの詳細",
+    "enabled": "デバッグモードがオンになっています",
+    "open-debug-mode": "デバッグモードをオンにする",
     "table": {
       "record-ts": "時間",
       "method": "方法",
       "request-path": "リクエストパス",
       "role": "役割",
-      "error": "エラー",
-      "stack-trace": "スタックトレース",
-      "empty": "<空>",
+      "error": "間違った情報",
+      "stack-trace": "コールスタック",
+      "empty": "<なし>",
       "operation": {
-        "operation": "手術",
-        "view-details": "詳細を見る",
+        "operation": "操作する",
+        "view-details": "詳細を確認する",
         "copy": "コピー",
-        "copy-all": "すべてコピー",
-        "copied": "コピーしました！",
+        "copy-all": "すべてコピーする",
+        "copied": "コピーされました",
         "export": "輸出"
       }
     }
   },
   "audit-log": {
-    "no-logs": "監査ログなし",
-    "audit-log-detail": "監査ログの詳細",
+    "no-logs": "監査ログはまだありません",
+    "audit-log-detail": "監査の詳細",
     "table": {
       "created-ts": "時間",
       "created-time": "作成時間",
-      "updated-time": "更新日時",
-      "actor": "俳優",
-      "type": "監査タイプ",
-      "level": "監査レベル",
+      "updated-time": "更新時間",
+      "actor": "オペレーター",
+      "type": "イベントタイプ",
+      "level": "イベントレベル",
       "comment": "コメント",
       "payload": "ペイロード",
       "empty": "<空>",
-      "view-details": "詳細を見る",
-      "select-type": "タイプを選択"
+      "view-details": "詳細を確認する",
+      "select-type": "タイプを選択してください"
     },
     "type": {
       "workspace": {
-        "member-create": "ワークスペースメンバーの作成",
+        "member-create": "ワークスペースメンバーを追加する",
         "member-role-update": "ワークスペースメンバーの役割を更新する",
-        "member-activate": "ワークスペースメンバーをアクティブ化",
-        "member-deactivate": "ワークスペースメンバーを非アクティブ化する"
+        "member-activate": "ワークスペースメンバーをアクティブ化する",
+        "member-deactivate": "ワークスペースのメンバーを無効にする"
       },
       "project": {
         "member-role-update": "プロジェクトメンバーの役割を更新する",
         "database-transfer": "転送データベース"
       },
-      "sql-editor-query": "SQL エディター クエリ",
+      "sql-editor-query": "SQLエディタのクエリ",
       "sql-export": "SQL エクスポート"
     }
   },
   "onboarding-guide": {
     "create-database-guide": {
-      "let-add-a-instance": "インスタンスを追加してみましょう",
-      "go-to-project-list-page": "プロジェクト一覧ページへ",
-      "click-new-project": "「新しいプロジェクト」をクリックしてプロジェクトを作成します",
-      "click-new-database": "「新しいデータベース」をクリックしてデータベースを作成します",
-      "click-approve": "変更を実行するには「承認」をクリックしてください",
-      "wait-issue-finished": "変更が完了するのを待っています...",
-      "back-to-home": "家に帰る",
+      "let-add-a-instance": "まずインスタンスを追加しましょう",
+      "go-to-project-list-page": "プロジェクトページに移動",
+      "click-new-project": "「プロジェクトの作成」ボタンをクリックします",
+      "click-new-database": "「データベースの作成」ボタンをクリックします",
+      "click-approve": "この作業指示を実行するには、「承認」ボタンをクリックしてください",
+      "wait-issue-finished": "作業指示の実行が完了するのを待っています...",
+      "back-to-home": "ホームページに戻る",
       "finished-dialog": {
-        "you-have-done": "完了しました:",
-        "add-an-instance": "インスタンスを追加する",
-        "create-a-project": "プロジェクトを作成する",
-        "create-an-issue": "問題を作成する",
-        "create-a-new-database": "新しいデータベースを作成する",
-        "keep-going-with-bytebase": "Bytebase を使い続けてください!"
+        "you-have-done": "正常に完了しました:",
+        "add-an-instance": "インスタンスを追加しました",
+        "create-a-project": "プロジェクトを作成しました",
+        "create-an-issue": "作業指示書を作成しました",
+        "create-a-new-database": "データベースを作成しました",
+        "keep-going-with-bytebase": "Bytebase を使い続けてください。"
       }
     }
   },
   "schema-diagram": {
     "self": "スキーマ図",
-    "fit-content-with-view": "コンテンツをビュー内に収める"
+    "fit-content-with-view": "ビューに自動的に適応します"
   },
   "identity-provider": {
     "test-connection": "テスト接続",
     "test-modal": {
-      "title": "OAuth2接続をテストする",
-      "start-test": "テストを開始するにはサインインをクリックしてください"
+      "title": "OAuth2 接続をテストする",
+      "start-test": "ログインボタンをクリックしてテストを開始してください"
     }
   },
   "sensitive-data": {
@@ -2791,193 +2791,193 @@
   },
   "resource": {
     "environment": "環境",
-    "instance": "実例",
+    "instance": "例",
     "project": "プロジェクト",
-    "idp": "アイデンティティプロバイダ",
+    "idp": "アイデンティティプロバイダー",
     "role": "役割",
-    "database-group": "データベースグループ",
-    "schema-group": "テーブルグループ",
+    "database-group": "データベースのグループ化",
+    "schema-group": "テーブルのグループ化",
     "changelist": "変更リスト",
-    "vcs-provider": "GitOps プロバイダー",
-    "vcs-connector": "GitOps コネクタ"
+    "vcs-provider": "GitOpsプロバイダー",
+    "vcs-connector": "GitOps接続"
   },
   "resource-id": {
     "self": "{resource} ID",
-    "description": "{resource} ID は一意の識別子です。作成後は変更できません。",
-    "cannot-be-changed-later": "後から変更することはできません。",
+    "description": "{resource} ID は一意の識別子です。作成後に変更することはできません。",
+    "cannot-be-changed-later": "作成後に変更することはできません。",
     "validation": {
-      "duplicated": "{resource} ID は既に存在します。別の ID を選択してください。",
-      "pattern": "{resource} ID には、小文字、数字、ハイフンのみを含めることができます。小文字で始まる必要があります。",
-      "minlength": "{resource} ID が短すぎます。少なくとも 1 文字必要です。",
-      "overflow": "{resource} ID が長すぎます。64 文字未満にする必要があります。"
+      "duplicated": "{resource} ID はすでに存在します。別のIDを使用してください。",
+      "pattern": "{resource} ID には小文字、数字、ハイフンのみを含めることができます。小文字で始める必要があります。",
+      "minlength": "{resource} ID には少なくとも 1 文字が含まれている必要があります。",
+      "overflow": "{resource} ID は 64 文字未満である必要があります。"
     }
   },
   "multi-factor": {
     "self": "多要素認証",
     "auth-code": "認証コード",
-    "recovery-code": "リカバリコード",
+    "recovery-code": "リカバリーコード",
     "other-methods": {
       "self": "その他の方法",
       "use-auth-app": {
         "self": "認証アプリを使用する",
-        "description": "モバイル デバイスで 2 要素認証 (TOTP) アプリを開き、認証コードを表示します。"
+        "description": "モバイル デバイスで Two-Factor Authenticator (TOTP) アプリを開き、認証コードを表示します。"
       },
       "use-recovery-code": {
-        "self": "リカバリコードを使用する",
-        "description": "モバイル デバイスにアクセスできない場合は、リカバリ コードのいずれかを入力して本人確認を行ってください。"
+        "self": "リカバリーコードを使用する",
+        "description": "モバイルデバイスにアクセスできない場合は、回復コードを入力して身元を確認してください。"
       }
     }
   },
   "two-factor": {
-    "self": "2要素認証",
-    "description": "2 要素認証は、メンバー アカウントのセキュリティをさらに強化します。サインインするときに、認証アプリによって生成されたセキュリティ コードを入力する必要があります。",
-    "enabled": "2FA 有効",
+    "self": "二要素認証",
+    "description": "2 要素認証は、システム メンバーに追加のセキュリティ層を提供します。ログインするとき、ユーザーは認証アプリケーションによって生成されたセキュリティ コードを入力する必要があります。",
+    "enabled": "二要素認証がオンになっています",
     "setup-steps": {
       "setup-auth-app": {
-        "self": "認証アプリの設定",
-        "description": "サインイン時に求められたら、Google Authenticator、Microsoft Authenticator、Authy などの電話アプリを使用して 2FA コードを取得します。",
+        "self": "認証アプリケーションをセットアップする",
+        "description": "2 要素認証には、Google Authenticator、Microsoft Authenticator、Authy などのモバイル アプリを使用します。",
         "scan-qr-code": {
-          "self": "QRコードをスキャンする",
-          "description": "スキャンするには、携帯電話の認証アプリを使用してください。スキャンできない場合は、代わりに {action} を実行してください。",
+          "self": "QRコードをスキャンします",
+          "description": "携帯電話の認証アプリを使用してスキャンします。スキャンできない場合は、{action} を実行できます。",
           "enter-the-text": "テキストを入力してください"
         },
-        "verify-code": "アプリからコードを確認する"
+        "verify-code": "アプリケーションのコードを検証する"
       },
       "download-recovery-codes": {
-        "self": "リカバリコードをダウンロードする",
-        "tips": "リカバリ コードはパスワードと同じくらい安全に保管してください。Lastpass、1Password、Keeper などのパスワード マネージャーを使用して保存することをお勧めします。",
+        "self": "リカバリーコードをダウンロード",
+        "tips": "リカバリ コードもパスワードと同じくらい安全に保管してください。 Lastpass、1Password、Keeper などのパスワード マネージャーに保存することをお勧めします。",
         "keep-safe": {
-          "self": "リカバリコードは安全な場所に保管してください。",
-          "description": "これらのコードは、2 要素認証コードを紛失した場合にアカウントにアクセスするための最後の手段です。これらのコードが見つからない場合は、アカウントにアクセスできなくなります。"
+          "self": "リカバリ コードは安全な場所に保管してください。",
+          "description": "これらのコードは、2 要素認証コードを受信できない場合にアカウントにアクセスするために使用されます。これらのコードが見つからない場合は、アカウントにアクセスできなくなります。"
         }
       },
-      "recovery-codes-saved": "リカバリコードを保存しました"
+      "recovery-codes-saved": "リカバリーコードを保存したことを確認してください"
     },
     "recovery-codes": {
-      "self": "リカバリコード",
+      "self": "リカバリーコード",
       "description": "2 要素認証コードを受信できない場合は、リカバリ コードを使用してアカウントにアクセスできます。"
     },
     "disable": {
-      "self": "2要素認証を無効にする",
-      "description": "アカウントの 2 要素認証を無効にしようとしています。サインイン時に、認証アプリによって生成されたセキュリティ コードを入力する必要がなくなります。"
+      "self": "二要素認証を無効にする",
+      "description": "アカウントの 2 要素認証を無効にしようとしています。ログイン時に認証アプリによって生成されたセキュリティ コードを入力する必要がなくなりました。"
     },
     "your-two-factor-secret": {
-      "self": "2要素認証の秘密",
-      "description": "コードをコピーして、TOTP アプリに手動で入力します。",
-      "copy-succeed": "シークレットがクリップボードにコピーされました。アプリに貼り付けてください。"
+      "self": "二要素認証キー",
+      "description": "キーをコピーし、アプリケーションに手動で入力します。",
+      "copy-succeed": "正常にコピーされました。申請書に入力してください。"
     },
     "messages": {
-      "2fa-enabled": "2要素認証が有効になっています。",
-      "2fa-disabled": "2要素認証は無効になっています。",
-      "recovery-codes-regenerated": "リカバリコードが再生成されます。",
-      "2fa-required": "ワークスペースでは 2 要素認証が必要です。続行する前に有効にしてください。",
-      "cannot-disable": "管理者がワークスペースで 2 要素認証を要求しているため、これを無効にすることはできません。"
+      "2fa-enabled": "二要素認証が正常にオンになりました",
+      "2fa-disabled": "二要素認証が正常に無効になりました",
+      "recovery-codes-regenerated": "リカバリコードが再生成されました",
+      "2fa-required": "管理者は、すべてのユーザーに 2 要素認証を構成するよう要求します。引き続き使用する前に、2 要素認証を設定してください。",
+      "cannot-disable": "管理者は、すべてのユーザーに 2 要素認証を構成するよう要求します。 2 要素認証を無効にすることはできません。"
     }
   },
   "plugin": {
     "ai": {
       "examples": "例",
-      "text-to-sql-placeholder": "自然言語を使用すると、BytebaseがそれをSQLに変換します。",
-      "text-to-sql-disabled-placeholder": "OpenAI API キーを指定して ChatSQL 機能を有効にします。",
-      "run-automatically": "自動的に実行",
+      "text-to-sql-placeholder": "ここに自然言語を入力すると、Bytebase はすぐにそれを SQL ステートメントに変換します。",
+      "text-to-sql-disabled-placeholder": "OpenAI API キーを指定して、ChatSQL 機能を有効にします。",
+      "run-automatically": "自動運転",
       "conversation": {
-        "conversations": "会話",
-        "untitled": "無題の会話",
-        "delete": "会話を削除",
-        "rename": "会話の名前を変更する",
-        "select-or-create": "会話を選択するか、{create}して開始します。",
-        "exit-conversation-mode": "チャットモードを終了する",
-        "history-conversations": "歴史の会話",
-        "view-history-conversations": "会話履歴を表示する",
-        "new-conversation": "新しい会話を始める",
-        "no-message": "この会話にはメッセージはありません",
+        "conversations": "セッション",
+        "untitled": "名前のないセッション",
+        "delete": "セッションの削除",
+        "rename": "セッション名の変更",
+        "select-or-create": "開始するセッションを選択または {create} します。",
+        "exit-conversation-mode": "会話モードを終了する",
+        "history-conversations": "歴史対話",
+        "view-history-conversations": "過去の会話を表示する",
+        "new-conversation": "新しい会話を開始する",
+        "no-message": "ニュースはありません",
         "tips": {
-          "suggest-prompt": "プロンプトを提案しています...",
+          "suggest-prompt": "プロンプト単語を生成...",
           "more": "もっと",
-          "no-more": "もうない"
+          "no-more": "何も残っていない"
         }
       },
       "preset-suggestion": {
-        "1": "どの部門に最も多くの従業員がいますか?",
-        "2": "各部門で直属の部下が最も多いマネージャーは誰ですか?",
-        "3": "各部門の男女比はどうですか？"
+        "1": "従業員数が最も多い部門はどこですか?",
+        "2": "どの部長が最も多くの部下を持っていますか?",
+        "3": "部署間の男女比はどのくらいですか？"
       },
-      "statement-copied": "ステートメントをクリップボードにコピーしました",
-      "dont-show-again": "再度表示しない",
+      "statement-copied": "ステートメントがクリップボードにコピーされました",
+      "dont-show-again": "再び表示しない",
       "chat-sql": "チャットSQL",
-      "disable-chat-sql": "ChatSQLを無効にする",
-      "enable-chat-sql": "ChatSQLを有効にする"
+      "disable-chat-sql": "ChatSQLを閉じる",
+      "enable-chat-sql": "ChatSQLを開く"
     }
   },
   "custom-approval": {
     "self": "カスタム承認",
     "risk-rule": {
-      "self": "リスクルール",
-      "risk-rules": "リスクルール",
+      "self": "安全規約",
+      "risk-rules": "安全規約",
       "x-risk-rules": {
         "low": "低リスクルール",
-        "moderate": "中程度のリスクのルール",
-        "high": "高リスクルール"
+        "moderate": "中リスクルール",
+        "high": "ハイリスクルール"
       },
-      "active": "アクティブ",
-      "edit-rule": "ルールを編集",
-      "delete": "リスクルールの削除",
+      "active": "オンにする",
+      "edit-rule": "ルールの編集",
+      "delete": "セキュリティルールを削除する",
       "default-rules": {
         "self": "デフォルトのルール",
-        "description": "問題がカスタム ルールに準拠しない場合は、デフォルトのルールが実行されます。"
+        "description": "作業指示がカスタム ルールを満たさない場合、デフォルト ルールが実行されます。"
       },
       "risk": {
         "self": "危険",
-        "select": "リスクを選択",
+        "select": "リスクを選択する",
         "risk-level": {
           "0": "デフォルト",
           "100": "低い",
-          "200": "適度",
+          "200": "真ん中",
           "300": "高い"
         },
         "namespace": {
-          "dml": "DMML の",
+          "dml": "DML",
           "ddl": "DDL",
           "create_database": "データベースの作成",
           "data_export": "データのエクスポート",
-          "request_query": "リクエストクエリーロール",
-          "request_export": "エクスポーターロールのリクエスト"
+          "request_query": "クエリ権限を申請する",
+          "request_export": "輸出許可を申請する"
         }
       },
       "template": {
         "templates": "テンプレート",
         "load": "負荷",
         "presets": {
-          "environment-prod-high": "実稼働環境に対するリスクは高いと考えられます。",
-          "environment-dev-low": "開発環境のリスク値は低いと考えられます。",
-          "dml-in-environment-prod-10k-rows-high": "本番環境では、更新または削除する行数が 10000 を超える場合、リスクが高いと考えられます。",
-          "create-database-in-environment-prod-moderate": "実稼働環境でデータベースを作成することは、中程度のリスクであると考えられます。"
+          "environment-prod-high": "運用環境、デフォルトで高リスク",
+          "environment-dev-low": "開発環境、デフォルトでは低リスク",
+          "dml-in-environment-prod-10k-rows-high": "運用環境で更新または削除されたデータ行の数が 10,000 を超えており、デフォルトで高リスクとみなされます。",
+          "create-database-in-environment-prod-moderate": "本番環境でデータベースを作成します。デフォルトは中リスクです"
         },
-        "load-template": "テンプレートを読み込む",
+        "load-template": "テンプレートをロードする",
         "view": "テンプレートを表示"
       },
       "rule-name": "ルール名",
-      "view-rule": "ルールを表示",
+      "view-rule": "ルールを表示する",
       "source": {
-        "select": "タイプを選択",
+        "select": "タイプを選択してください",
         "self": "タイプ"
       },
       "input-rule-name": "ルール名を入力してください",
       "search": "検索ルール"
     },
     "approval-flow": {
-      "self": "承認フロー",
-      "description": "操作タイプごとに、カスタム条件、リスク、承認フローを構成します。",
-      "approval-flows": "承認フロー",
+      "self": "承認の流れ",
+      "description": "アクションの種類ごとに、カスタム条件、リスク、承認フローを構成します。",
+      "approval-flows": "承認の流れ",
       "approval-nodes": "承認ノード",
       "delete": "承認フローの削除",
       "search": "検索承認フロー",
-      "select": "承認フローを選択",
-      "create-approval-flow": "承認フローを作成する",
+      "select": "承認フローの選択",
+      "create-approval-flow": "承認フローの作成",
       "edit-approval-flow": "承認フローの編集",
       "node": {
         "nodes": "承認ノード",
-        "description": "承認者が複数いる場合、このノードでは 1 つの承認のみが必要です。",
+        "description": "ノードに複数の承認者がいる場合、必要な承認は 1 つだけです。",
         "order": "注文",
         "approver": "承認者",
         "group": {
@@ -2986,42 +2986,42 @@
           "PROJECT_OWNER": "プロジェクトオーナー",
           "PROJECT_MEMBER": "プロジェクトメンバー"
         },
-        "add": "ノードを追加",
-        "delete": "承認ノードを削除",
-        "select-approver": "承認者を選択",
+        "add": "ノードの追加",
+        "delete": "承認ノードの削除",
+        "select-approver": "承認者の選択",
         "roles": {
           "system": "システムの役割",
           "custom": "カスタムロール"
         }
       },
       "presets": {
-        "owner-dba": "システムでは承認プロセスが定義されており、最初にプロジェクト所有者が承認し、次に DBA が承認します。",
-        "owner": "システムは承認プロセスを定義し、プロジェクト所有者の承認のみを必要とします。",
-        "dba": "システムでは承認プロセスが定義されており、DBA の承認のみが必要です。",
-        "admin": "システムは承認プロセスを定義し、管理者の承認のみを必要とします。",
-        "owner-dba-admin": "システムでは承認プロセスが定義されており、最初にプロジェクト所有者が承認し、次に DBA が承認し、最後に管理者が承認します。"
+        "owner-dba": "システム定義のプロセス。承認は最初にプロジェクト所有者によって行われ、次に DBA によって行われます。",
+        "owner": "システム定義のプロセス。プロジェクト所有者の承認のみが必要です。",
+        "dba": "システム定義のプロセス。 DBA の承認のみが必要です。",
+        "admin": "システム定義のプロセス。管理者の承認のみが必要です。",
+        "owner-dba-admin": "システム定義のプロセス。承認は、最初にプロジェクト所有者によって行われ、次に DBA、最後に管理者によって行われます。"
       },
-      "view-approval-flow": "承認フローを表示",
-      "skip": "手動承認をスキップ",
+      "view-approval-flow": "承認フローを見る",
+      "skip": "手動承認をスキップする",
       "risk-not-configured-tips": "{link} が定義されていることを確認してください。",
       "the-related-risk-rules": "関連するリスクルール",
       "external-approval": {
         "self": "外部承認",
         "delete": "外部承認ノードを削除しますか?",
         "endpoint": "終点",
-        "view-node": "外部承認ノードを表示",
-        "create-node": "外部承認ノードを作成する",
-        "edit-node": "外部承認ノードを編集"
+        "view-node": "外部承認ノードを表示する",
+        "create-node": "新しい外部承認ノードを作成する",
+        "edit-node": "外部承認ノードを編集する"
       },
       "issue-review": {
-        "sent-back": "返送",
-        "review-sent-back-by": "{user} から返信されたレビュー"
+        "sent-back": "戻ってきた",
+        "review-sent-back-by": "{user} から承認が返されました"
       }
     },
     "risk": {
       "self": "危険",
       "risk-center": "リスクセンター",
-      "description": "リスク センターは、さまざまな条件下でのさまざまなデータベース操作のリスク レベルを定義します。リスク レベルによって、対応するカスタム承認フローが決まります。"
+      "description": "リスク センターは、さまざまな条件下でのさまざまなデータベース操作のリスク レベルを定義します。リスク レベルによって、作業指示書のカスタム承認プロセスが決まります。"
     },
     "workflow-center": {
       "workflow": "ワークフロー"
@@ -3030,263 +3030,263 @@
       "rules": "ルール"
     },
     "issue-review": {
-      "approve-issue": "問題を承認しますか?",
+      "approve-issue": "作業指示を承認しますか?",
       "form": {
-        "placeholder": "(オプション) メモを追加します...",
-        "note": "注記"
+        "placeholder": "(オプション) メモを追加します…",
+        "note": "ノート"
       },
       "you": "あなた",
-      "generating-approval-flow": "承認フローの生成",
-      "approved-issue": "承認された問題",
+      "generating-approval-flow": "承認フローが生成されています",
+      "approved-issue": "作業指示を承認する",
       "disallow-approve-reason": {
-        "some-task-checks-didnt-pass": "一部のタスクチェックに合格しませんでした",
-        "some-task-checks-are-still-running": "一部のタスクチェックはまだ実行中です",
+        "some-task-checks-didnt-pass": "失敗したタスクチェックがまだあります",
+        "some-task-checks-are-still-running": "確認すべき実行中のタスクがまだあります",
         "x-field-is-required": "{field}は必須です"
       },
-      "send-back": "送り返す",
-      "send-back-issue": "問題を返送しますか?",
-      "re-request-review": "再審査リクエスト",
-      "re-request-review-issue": "レビューの問題を再リクエストしますか?",
-      "sent-back-issue": "返送された問題",
-      "re-requested-review": "問題の再検討を依頼",
-      "no-one-matches-role": "役割に一致する人がいません。プロジェクト所有者に連絡して役割を割り当ててください。",
-      "any-n-role-can-approve": "どの{role}でも承認できます",
+      "send-back": "戻る",
+      "send-back-issue": "作業指示書を返しますか?",
+      "re-request-review": "再度承認をリクエストする",
+      "re-request-review-issue": "作業指示書の承認を再度リクエストしますか?",
+      "sent-back-issue": "作業指示書を返却する",
+      "re-requested-review": "作業指示書の承認を再度リクエストします",
+      "no-one-matches-role": "このロールに一致するユーザーはいません。プロジェクト管理者に連絡してロールを割り当ててください。",
+      "any-n-role-can-approve": "任意の {role} を承認できます",
       "approved-by-n": "{approver} によって承認されました"
     },
-    "send-back": "送り返す"
+    "send-back": "戻る"
   },
   "slow-query": {
     "self": "遅いクエリ",
     "slow-queries": "遅いクエリ",
     "report": "報告",
-    "last-query-time": "最終クエリ時間",
+    "last-query-time": "最終実行時刻",
     "database-name": "データベース名",
     "sql-statement": "SQL文",
-    "total-query-count": "総クエリ数",
-    "query-count-percent": "クエリ数 %",
-    "max-query-time": "最大クエリ時間",
-    "avg-query-time": "平均クエリ時間",
-    "query-time-percent": "クエリ時間 %",
-    "max-rows-examined": "検査された最大行数",
-    "avg-rows-examined": "検査された行の平均数",
-    "max-rows-sent": "送信された最大行数",
-    "avg-rows-sent": "送信された平均行数",
-    "query-start-time": "クエリ開始時間",
-    "rows-examined": "検査された行",
-    "rows-sent": "送信された行",
-    "lock-time": "ロック時間",
-    "query-time": "クエリ時間",
-    "attention-description": "Bytebase は、インスタンスからスロー クエリ ログを定期的に同期します。MySQL インスタンスの場合、まず slow_query を有効にする必要があります。PostgreSQL インスタンスの場合、pg_stat_statements が有効になっているデータベースのみがスロー クエリを収集します。",
-    "sync-job-started": "同期ジョブが開始されました。ジョブが完了するまでお待ちください。",
+    "total-query-count": "合計実行時間",
+    "query-count-percent": "約定比率",
+    "max-query-time": "最大実行時間",
+    "avg-query-time": "平均実行時間",
+    "query-time-percent": "実行時間比率",
+    "max-rows-examined": "最大走査線数",
+    "avg-rows-examined": "平均スキャンライン数",
+    "max-rows-sent": "返される行の最大数",
+    "avg-rows-sent": "返される平均行数",
+    "query-start-time": "実行開始時刻",
+    "rows-examined": "解析された行数",
+    "rows-sent": "行数を返す",
+    "lock-time": "ロックが保持される時間",
+    "query-time": "実行時間",
+    "attention-description": "Bytebase は、インスタンスからの低速クエリ ログを定期的に同期します。 MySQL インスタンスの場合は、まず、slow_query を有効にする必要があります。 PostgreSQL インスタンスの場合、pg_stat_statements がオンになっているデータベースのみが遅いクエリを収集します。",
+    "sync-job-started": "同期ジョブが開始されました。同期が完了するまでお待ちください。",
     "detail": "遅いクエリの詳細",
     "filter": {
       "from-date": "開始日",
-      "to-date": "現在まで"
+      "to-date": "終了日"
     },
     "advise-index": {
       "current-index": "現在のインデックス",
       "suggestion": "提案",
-      "create-index": "インデックスを作成",
-      "setup-openai-key-to-enable": "インデックスアドバイザーを有効にするためにOpenAIキーを設定する"
+      "create-index": "インデックスの作成",
+      "setup-openai-key-to-enable": "OpenAI API キーを設定して、インデックス提案機能を有効にします。"
     },
     "no-log-placeholder": {
-      "admin": "「構成」ボタンをクリックしてデータベースインスタンスからスロークエリを取得するか、「今すぐ同期」ボタンをクリックしてスロークエリログをすぐに同期します。",
-      "developer": "「今すぐ同期」ボタンをクリックしてスロークエリログをすぐに同期するか、Bytebase管理者/DBAに連絡してスロークエリを構成してください。"
+      "admin": "[構成] ボタンをクリックしてデータベース インスタンスからスロー クエリ ログを取得するか、[今すぐ同期] ボタンをクリックしてスロー クエリ ログをすぐに同期します。",
+      "developer": "[今すぐ同期] ボタンをクリックしてスロー クエリ ログをすぐに同期するか、ワークスペース管理者または DBA に問い合わせてスロー クエリ機能を設定してください。"
     }
   },
   "schema-template": {
     "self": "スキーマテンプレート",
     "field-template": {
       "self": "フィールドテンプレート",
-      "description": "フィールド テンプレートを事前に定義し、スキーマの変更時にテンプレートを適用できます。"
+      "description": "後でスキーマを変更または設計するときに適用できる、事前定義されたフィールド テンプレート。"
     },
     "column-type-restriction": {
-      "self": "列タイプの制限",
-      "description": "各データベース エンジンごとに許可される列タイプを制限できます。",
-      "allow-all": "すべて許可",
-      "allow-limited-types": "限定されたタイプを許可する",
+      "self": "列の型の制約",
+      "description": "各データベース エンジンで、許可される列の種類を制限できます。",
+      "allow-all": "すべてのタイプが許可される",
+      "allow-limited-types": "一部のタイプのみが許可されます",
       "back-to-edit": "編集に戻る",
       "add-and-save": "追加して保存",
       "messages": {
         "unable-to-update": "制限を更新できません",
-        "following-column-types-are-used": "次の列タイプは、フィールドテンプレートで引き続き使用されます",
-        "one-allowed-type-per-line": "1行につき1つのデータ型が許可されます"
+        "following-column-types-are-used": "次のタイプは引き続きフィールド テンプレートで使用されます。",
+        "one-allowed-type-per-line": "許可されるデータ型を 1 行に 1 つずつ入力します"
       }
     },
     "table-template": {
       "self": "テーブルテンプレート",
-      "description": "テーブル テンプレートを事前に定義し、スキーマの変更時にそのテンプレートを適用できます。"
+      "description": "後でスキーマを変更または設計するときに適用できるテーブル テンプレートを事前定義します。"
     },
-    "search-by-name-or-comment": "名前またはコメントで検索",
+    "search-by-name-or-comment": "名前やメモで検索",
     "form": {
-      "category": "カテゴリー",
-      "category-desc": "既存のカテゴリを選択するか、新しいカテゴリを作成してください",
-      "unclassified": "非公開",
-      "column-name": "列名",
-      "column-type": "列タイプ",
-      "default-value": "デフォルト",
-      "comment": "コメント",
-      "nullable": "ヌル可能",
+      "category": "分類",
+      "category-desc": "既存のカテゴリを選択するか、新しいカテゴリを作成します",
+      "unclassified": "未分類",
+      "column-name": "フィールド名",
+      "column-type": "フィールドタイプ",
+      "default-value": "デフォルト値",
+      "comment": "述べる",
+      "nullable": "null も可能",
       "table-name": "テーブル名",
-      "on-update": "更新時"
+      "on-update": "アップデート時"
     },
     "classification": {
-      "self": "データ分類",
-      "select": "分類を選択",
-      "search": "検索分類"
+      "self": "データの分類とグレーディング",
+      "select": "カテゴリを選択してください",
+      "search": "カテゴリを検索する"
     }
   },
   "principal": {
-    "select": "ユーザーを選択"
+    "select": "ユーザーの選択"
   },
   "role": {
     "self": "役割",
     "setting": {
-      "description": "カスタム ロールを定義します。プロジェクト メンバーに適用し、カスタム承認に使用できます。",
-      "add": "役割を追加",
-      "edit": "役割を編集",
-      "title-placeholder": "役割のタイトルを入力",
+      "description": "プロジェクト メンバーとカスタム承認に適用できるカスタム ロールを定義します。",
+      "add": "役割の追加",
+      "edit": "役割の編集",
+      "title-placeholder": "役割のタイトルを入力してください",
       "name-placeholder": "ロール名を入力してください",
-      "description-placeholder": "入力ロールの説明",
+      "description-placeholder": "役割の説明を入力してください",
       "validation": {
-        "duplicated": "重複した{resource}",
-        "required": "{resource} は必須です",
-        "pattern": "{resource} には小文字、数字、ハイフンのみを含めることができます。小文字で始まる必要があります。",
-        "max-length": "{resource} には最大 {length} 文字を含めることができます"
+        "duplicated": "{resource} はすでに存在します",
+        "required": "{resource}は必須です",
+        "pattern": "{resource} には小文字、数字、ハイフンのみを含めることができ、小文字で始まります。",
+        "max-length": "{resource} には最大で {length} 文字が含まれます"
       },
-      "delete": "役割を削除"
+      "delete": "役割の削除"
     },
-    "select": "役割を選択",
-    "select-roles": "役割を選択",
+    "select": "役割の選択",
+    "select-roles": "役割の選択",
     "title": "タイトル",
-    "select-role": "役割を選択",
+    "select-role": "役割の選択",
     "expired-tip": "役割の有効期限が切れている可能性があります。",
-    "import-from-role": "ロールからのインポート",
+    "import-from-role": "ロールからインポート",
     "workspace-roles": "ワークスペースの役割",
     "project-roles": {
       "self": "プロジェクトの役割",
-      "apply-to-all-projects": "すべてのプロジェクトに適用"
+      "apply-to-all-projects": "すべてのプロジェクトに適用する"
     },
     "custom-roles": "カスタムロール",
     "workspace-admin": {
       "self": "ワークスペース管理者",
-      "description": "ワークスペース管理者には、ワークスペース内のすべての権限があります。"
+      "description": "ワークスペース内のすべての権限。"
     },
     "workspace-dba": {
-      "self": "ワークスペース DBA",
-      "description": "ワークスペース DBA には、ワークスペース メンバーの管理を除く、ワークスペース内のすべての権限があります。"
+      "self": "ワークスペースDBA",
+      "description": "ワークスペースのすべてのデータベースとインスタンスを管理できます"
     },
     "workspace-member": {
       "self": "ワークスペースメンバー",
-      "description": "ワークスペース メンバーは、ワークスペース内で最も基本的な役割です。"
+      "description": "ワークスペースの通常のユーザー"
     },
     "project-owner": {
       "self": "プロジェクトオーナー",
-      "description": "プロジェクト内のすべての権限"
+      "description": "プロジェクト内のすべての権限。"
     },
     "project-developer": {
       "self": "プロジェクト開発者",
-      "description": "すべての閲覧者権限に加え、データベースの変更を要求する権限。"
+      "description": "基本的なプロジェクト情報を表示し、データベースの変更、データ クエリ、およびデータ エクスポート リクエストを自分で開始できます。"
     },
     "project-releaser": {
-      "self": "プロジェクトリリース者",
-      "description": "すべての閲覧者権限に加え、リリース目的でデータベース変更要求を確認する権限。"
+      "self": "プロジェクト発行者",
+      "description": "プロジェクトの基本情報を表示し、指定したプロセスの変更をリリースできます。"
     },
     "project-querier": {
-      "self": "プロジェクトクエリ",
-      "description": "データベース データを照会するための権限。"
+      "self": "プロジェクトの問い合わせ者",
+      "description": "指定した範囲内のデータをクエリできます。"
     },
     "project-exporter": {
       "self": "プロジェクトエクスポーター",
-      "description": "データベース データをエクスポートするための権限。"
+      "description": "指定した範囲のデータをエクスポートできます。"
     },
     "project-viewer": {
-      "self": "プロジェクト閲覧者",
-      "description": "基本的なプロジェクト情報の表示、データベースへのアクセス、権限要求の開始を行うための読み取り専用権限。"
+      "self": "プロジェクトビューア",
+      "description": "基本的なプロジェクト情報を表示し、独自にデータ クエリとデータ エクスポート リクエストを開始できます。"
     }
   },
   "database-group": {
-    "self": "データベースグループ",
-    "select": "データベースグループを選択",
-    "create": "新しいデータベースグループ",
-    "edit": "データベースグループを編集",
-    "matched-database": "一致したデータベース",
-    "unmatched-database": "比類のないデータベース",
-    "matched-table": "マッチしたテーブル",
-    "unmatched-table": "一致しないテーブル",
+    "self": "データベースのグループ化",
+    "select": "データベースグループの選択",
+    "create": "新しいデータベースグループを作成する",
+    "edit": "データベースグループの編集",
+    "matched-database": "マッチングデータベース",
+    "unmatched-database": "データベースが一致しません",
+    "matched-table": "マッチングテーブル",
+    "unmatched-table": "不一致のテーブル",
     "table-group": {
-      "self": "テーブルグループ",
-      "create": "新しいテーブルグループ",
-      "edit": "テーブルグループを編集"
+      "self": "テーブルのグループ化",
+      "create": "新しいテーブルグループを作成する",
+      "edit": "テーブルのグループ化を編集する"
     },
     "condition": {
       "self": "状態"
     },
     "prev-editor": {
-      "description": "テーブル グループからテーブルを一括変更するには、SQL でそのテーブル グループを参照します。Bytebase は、テーブル グループ内の各テーブルに対して個別の SQL を生成します。"
+      "description": "SQL でテーブル グループを参照して、テーブル グループ内のすべてのテーブルに一括変更を加えることができます。 Bytebase はテーブルごとに個別の SQL を生成します。"
     }
   },
   "export-center": {
     "self": "輸出センター",
-    "permission-denied": "許可が拒否されました"
+    "permission-denied": "この操作を実行する権限がありません"
   },
   "schema-designer": {
-    "self": "スキーマ デザイナー",
+    "self": "スキーマデザイナー",
     "schema-design": "スキーマ設計",
     "schema-design-list": "スキーマ設計リスト",
-    "new-schema-design": "新しいスキーマ設計",
-    "baseline-database": "ベースラインデータベース",
-    "schema-version": "スキーマバージョン",
-    "personal-draft": "個人ドラフト",
-    "baseline-version": "ベースライン",
-    "baseline-version-from-parent": "親ブランチからのベースライン",
-    "new-branch": "新しい支店",
-    "parent-branch": "親",
+    "new-schema-design": "スキーマ設計の作成",
+    "baseline-database": "ベンチマークデータベース",
+    "schema-version": "スキーマのバージョン",
+    "personal-draft": "個人的な草稿",
+    "baseline-version": "ベースラインバージョン",
+    "baseline-version-from-parent": "親ブランチのベースライン バージョン",
+    "new-branch": "新しいブランチを作成する",
+    "parent-branch": "親ブランチ",
     "save-draft": "下書きを保存",
-    "merge-branch": "ブランチをマージ",
-    "raw-sql-preview": "生のSQLプレビュー",
+    "merge-branch": "ブランチをマージする",
+    "raw-sql-preview": "生の SQL プレビュー",
     "diff-editor": {
       "self": "差分エディタ",
       "resolve": "解決する",
       "auto-merge-failed": "自動マージに失敗しました",
-      "need-to-resolve-conflicts": "ブランチは他のユーザーによって更新されました。マージする前に競合を解決する必要があります。",
-      "resolve-and-merge-again": "解決して再度マージする",
+      "need-to-resolve-conflicts": "親ブランチは別のユーザーによって更新されているため、最初に考えられる競合を解決する必要があります。",
+      "resolve-and-merge-again": "競合を解決して再度マージします",
       "discard-changes": "変更を破棄",
       "action-confirm": "アクションの確認",
-      "duplicated-branch-name-found": "重複したブランチ名が見つかりました。",
+      "duplicated-branch-name-found": "重複するブランチ名が見つかりました。",
       "discard-changes-confirm": "すべての変更を破棄してもよろしいですか?"
     },
-    "tables": "テーブル",
+    "tables": "表面",
     "search-tables": "検索テーブル",
-    "use-tips": "開始するにはテーブルをクリックします。",
-    "apply-to-database": "データベースに変更を適用する",
-    "select-database-placeholder": "データベースを選択してください（MySQL、PostgreSQL、TiDB、Oracleのみ）",
+    "use-tips": "デザインするテーブルを選択してください",
+    "apply-to-database": "変更をデータベースに適用する",
+    "select-database-placeholder": "データベースを選択します (MySQL、PostgreSQL、TiDB、Oracle のみ)",
     "message": {
       "created-succeed": "ブランチが正常に作成されました",
       "updated-succeed": "ブランチが正常に更新されました",
-      "merge-to-main-successfully": "メインに正常にマージされました",
-      "updated-time-by-user": "{user} によって {time} 更新されました"
+      "merge-to-main-successfully": "メインバージョンに正常にマージされました",
+      "updated-time-by-user": "{time} に {user} によって更新されました"
     },
     "action": {
       "use-the-existing-branch": "既存のブランチを使用する",
-      "create-new-branch": "新しいブランチを作成"
+      "create-new-branch": "新しいブランチを作成する"
     }
   },
   "cel": {
     "factor": {
-      "affected_rows": "影響を受ける行",
-      "table_rows": "表の行",
+      "affected_rows": "影響を受ける行数",
+      "table_rows": "テーブルの行数",
       "environment_id": "環境ID",
       "project_id": "プロジェクトID",
       "instance_id": "インスタンスID",
-      "database_name": "データベース名",
-      "db_engine": "DBエンジン",
-      "sql_type": "SQLタイプ",
-      "expiration_days": "有効期限",
-      "export_rows": "行をエクスポート",
+      "database_name": "名前データベース",
+      "db_engine": "データベースエンジン",
+      "sql_type": "SQLの種類",
+      "expiration_days": "有効期限日",
+      "export_rows": "エクスポート行数",
       "table_name": "テーブル名",
-      "column_name": "列名",
-      "classification_level": "分類レベル",
+      "column_name": "フィールド名",
+      "classification_level": "データの分類",
       "resource_instance_id": "インスタンスID",
       "resource_environment_name": "環境",
       "resource_database_name": "データベース名",
@@ -3294,23 +3294,23 @@
     },
     "condition": {
       "self": "状態",
-      "description-tips": "条件は、式を介して構成できるルールです。たとえば、「環境は prod」という条件は、「prod」環境で実行された問題と一致します。",
-      "add": "条件を追加",
-      "add-group": "条件グループを追加",
+      "description-tips": "条件は、式を通じて設定されるルールです。たとえば、「環境は本番」という条件は、「本番」環境で実行されたチケットと一致します。",
+      "add": "条件を追加する",
+      "add-group": "条件グループの追加",
       "group": {
         "or": {
-          "description": "次のいずれかに当てはまります..."
+          "description": "次のいずれかが当てはまります…"
         },
         "and": {
-          "description": "以下のすべてが真実です..."
+          "description": "以下はすべて真実です…"
         },
-        "tooltip": "条件グループは、演算子「And」と「Or」によって接続された条件の集合です。"
+        "tooltip": "条件グループは、AND または OR 演算子で接続された条件の集合です。"
       },
       "input-value": "入力値",
-      "add-condition-in-group-placeholder": "条件を追加するには{plus}を追加します",
-      "select-value": "値を選択",
-      "input-value-press-enter": "値を入力し、Enterキーを押して確定します",
-      "add-root-condition-placeholder": "条件を追加するには、「条件を追加」または「条件グループを追加」をクリックします"
+      "add-condition-in-group-placeholder": "{plus} をクリックして条件を追加します",
+      "select-value": "値を選択してください",
+      "input-value-press-enter": "値を入力し、Enter キーを押して確定します",
+      "add-root-condition-placeholder": "「条件を追加」または「条件グループを追加」をクリックして条件を追加します。"
     }
   },
   "changelist": {
@@ -3318,93 +3318,93 @@
     "changelists": "変更リスト",
     "change-center": "チェンジセンター",
     "new": "新しい変更リスト",
-    "name": "変更リスト名",
+    "name": "リスト名の変更",
     "name-placeholder": "私の変更リスト",
     "error": {
-      "project-is-required": "プロジェクトは必須です",
-      "name-is-required": "変更リスト名は必須です",
+      "project-is-required": "項目を空にすることはできません",
+      "name-is-required": "変更リスト名を空にすることはできません",
       "invalid-resource-id": "無効なリソース ID",
-      "nothing-changed": "何も変わっていません",
-      "sql-cannot-be-empty": "SQLが必要です",
-      "select-at-least-one-change": "少なくとも1つの変更を選択してください",
+      "nothing-changed": "変化なし",
+      "sql-cannot-be-empty": "SQL を空にすることはできません",
+      "select-at-least-one-change": "少なくとも 1 つの変更を選択してください",
       "select-at-least-one-change-to-export": "エクスポートする変更を少なくとも 1 つ選択してください",
-      "add-at-least-one-change": "少なくとも1つの変更を追加",
-      "select-at-least-one-database": "少なくとも1つのデータベースを選択してください",
-      "you-are-not-allowed-to-perform-this-action": "この操作を実行することは許可されていません"
+      "add-at-least-one-change": "少なくとも 1 つの変更を追加する",
+      "select-at-least-one-database": "少なくとも 1 つのデータベースを選択してください",
+      "you-are-not-allowed-to-perform-this-action": "このアクションを実行する権限がありません"
     },
-    "apply-to-database": "データベースに適用",
+    "apply-to-database": "データベースに適用する",
     "add-change": {
       "self": "変更を追加",
       "change-history": {
-        "select-at-least-one-history-below": "以下の履歴を少なくとも 1 つ選択してください"
+        "select-at-least-one-history-below": "以下から少なくとも 1 つのレコードを選択してください"
       },
       "branch": {
-        "select-at-least-one-branch-below": "以下のブランチを少なくとも 1 つ選択してください"
+        "select-at-least-one-branch-below": "以下から少なくとも 1 つのレコードを選択してください"
       }
     },
     "change-source": {
-      "self": "ソースを変更",
-      "raw-sql": "生のSQL",
+      "self": "ソースを変更する",
+      "raw-sql": "SQL文",
       "change-history": {
-        "tables": "テーブル"
+        "tables": "表面"
       },
       "source": "ソース"
     },
     "confirm-remove-change": "この変更を削除しますか?",
-    "delete-this-changelist": "この変更リストを削除する",
-    "confirm-delete-changelist": "この変更リストを削除しますか?"
+    "delete-this-changelist": "この変更リストを削除します",
+    "confirm-delete-changelist": "変更リストを削除しますか?"
   },
   "export-data": {
-    "export-rows": "行をエクスポート",
+    "export-rows": "エクスポート行数",
     "error": {
-      "export-rows-required": "エクスポート行が必要です",
-      "export-rows-must-gt-zero": "エクスポート行は0より大きくなければなりません"
+      "export-rows-required": "エクスポート行数を指定する必要があります",
+      "export-rows-must-gt-zero": "エクスポート行の数は 0 より大きくなければなりません"
     },
     "export-format": "エクスポート形式",
-    "password-optional": "パスワードで暗号化（オプション）",
-    "password-info": "エクスポート ファイルを暗号化するためのパスワードを入力します。"
+    "password-optional": "パスワード暗号化の設定 (オプション)",
+    "password-info": "エクスポートされたファイルを暗号化するためのパスワードを入力します"
   },
   "branch": {
     "rollout": {
-      "select-target-database": "ターゲットデータベースを選択"
+      "select-target-database": "ターゲットデータベースを選択してください"
     },
-    "select-tables-to-rollout": "ロールアウトするテーブルを選択",
-    "branch-is-protected": "このブランチはブランチ保護ルールによって保護されています。",
-    "default-branches": "デフォルト",
+    "select-tables-to-rollout": "公開するテーブルを選択してください",
+    "branch-is-protected": "このブランチは保護されています",
+    "default-branches": "デフォルトのブランチ",
     "your-branches": "あなたの支店",
     "active-branches": "アクティブなブランチ",
     "select-branch": "ブランチを選択",
     "merge-rebase": {
-      "select-branches-to-merge": "マージするブランチを選択",
-      "select-branches-to-rebase": "リベースするブランチを選択",
-      "validating-branch": "ブランチの検証",
-      "able-to-merge": "合併可能",
+      "select-branches-to-merge": "マージするブランチを選択してください",
+      "select-branches-to-rebase": "リベースするブランチを選択してください",
+      "validating-branch": "ブランチの検証中",
+      "able-to-merge": "統合可能",
       "able-to-rebase": "リベース可能",
-      "cannot-automatically-merge": "自動的にマージできません。まず {rebase_branch} を実行してください。",
+      "cannot-automatically-merge": "自動的に結合できません。まず {rebase_branch} してください。",
       "cannot-automatically-rebase": "自動的にリベースできません。競合を手動で解決してください。",
       "go-rebase": "ブランチをリベースする",
-      "changes-of-branch": "{branch}の変更",
+      "changes-of-branch": "{branch} への変更",
       "merge-succeeded": "マージが成功しました",
-      "rebase-succeeded": "リベースに成功しました",
+      "rebase-succeeded": "リベースが成功しました",
       "delete-branch-after-merged": "マージ後にブランチを削除する",
-      "merge-branch": "ブランチをマージ",
-      "rebase-branch": "ブランチをリベース",
+      "merge-branch": "ブランチをマージする",
+      "rebase-branch": "ブランチをリベースする",
       "confirm-rebase": "リベースを確認しますか?",
-      "conflict-not-resolved": "いくつかの紛争はまだ解決されていないようです。",
-      "resolve-conflicts-to-rebase": "リベース時の競合を解決する",
-      "preview-merge-result": "マージ後の {branch} の変更をプレビューする",
-      "preview-rebase-result": "リベース後の {branch} の変更をプレビューする",
-      "diffs-between": "{left} と {right} の相違点",
+      "conflict-not-resolved": "未解決の競合があるようです。",
+      "resolve-conflicts-to-rebase": "リベースの競合を解決する",
+      "preview-merge-result": "結合された {branch} の変更をプレビューする",
+      "preview-rebase-result": "リベース後に {branch} の変更をプレビューする",
+      "diffs-between": "{left} と {right} の違い",
       "base-branch": "ベースブランチ",
-      "head-branch": "ヘッドブランチ",
+      "head-branch": "本支店",
       "preview": "プレビュー",
       "before-merge": "合併前",
       "after-merge": "合併後",
       "before-rebase": "リベース前",
       "after-rebase": "リベース後",
       "post-merge-action": {
-        "rebase": "ブランチをマージしてリベースする",
-        "delete": "ブランチをマージして削除する"
+        "rebase": "ブランチのマージと同期",
+        "delete": "ブランチのマージと削除"
       }
     },
     "source": {
@@ -3416,15 +3416,15 @@
       "drop-index-confirm": "インデックスを削除しますか?"
     },
     "force-delete": "強制削除",
-    "deleting-parent-branch": "親ブランチを削除します。",
-    "visualized-schema": "視覚化されたスキーマ",
-    "schema-text": "スキーマテキスト",
+    "deleting-parent-branch": "親ブランチが削除されようとしています。",
+    "visualized-schema": "ビジュアルスキーマ",
+    "schema-text": "テキストスキーマ",
     "baseline": "ベースライン",
-    "head": "頭",
-    "show-diff-with-branch-baseline": "ブランチベースラインとの差分を表示",
+    "head": "現在",
+    "show-diff-with-branch-baseline": "ブランチのベースラインとの違いを示します",
     "table-partition": {
       "drop-partition-confirm": "テーブルパーティションを削除しますか?",
-      "drop-partition-with-subpartitions-confirm": "すべてのサブパーティションも削除されます。"
+      "drop-partition-with-subpartitions-confirm": "すべてのサブパーティションが同時に削除されます。"
     }
   }
 }


### PR DESCRIPTION
- Update i18n script, support specific the source and target. For example:

```bash
# use en-US.json as source file to translate all other files
$ pnpm i18n

# use zh-CN.json as source to translate the ja-JP, and es-ES
$ pnpm --source=zh-CN --target=ja-JP,es-ES i18n
```

- Replace all templates like `{user}` in the text before translation. For example, `创建用户 {user}，密码 {password}` will be formatted to `创建用户 {0}，密码 {1}`. This can avoid translation for the template text in mistake.

- Use ZH to translate the JP