### PR TITLE
chore: search database

### DIFF
--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -127,7 +127,7 @@ func (s *DatabaseService) SearchDatabases(ctx context.Context, request *v1pb.Sea
 		return nil, err
 	}
 
-	permission := iam.PermissionDatabasesList
+	permission := iam.PermissionDatabasesGet
 	if request.GetPermission() == iam.PermissionDatabasesQuery.String() {
 		permission = iam.PermissionDatabasesQuery
 	}

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -127,7 +127,7 @@ func (s *DatabaseService) SearchDatabases(ctx context.Context, request *v1pb.Sea
 		return nil, err
 	}
 
-	permission := iam.PermissionDatabasesGet
+	permission := iam.PermissionDatabasesList
 	if request.GetPermission() == iam.PermissionDatabasesQuery.String() {
 		permission = iam.PermissionDatabasesQuery
 	}
@@ -135,6 +135,7 @@ func (s *DatabaseService) SearchDatabases(ctx context.Context, request *v1pb.Sea
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
+
 	response := &v1pb.SearchDatabasesResponse{}
 	for _, databaseMessage := range databases {
 		database, err := s.convertToDatabase(ctx, databaseMessage)
@@ -160,6 +161,7 @@ func (s *DatabaseService) ListDatabases(ctx context.Context, request *v1pb.ListD
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
+
 	find := &store.FindDatabaseMessage{}
 	if instanceID != "-" {
 		find.InstanceID = &instanceID
@@ -184,6 +186,7 @@ func (s *DatabaseService) ListDatabases(ctx context.Context, request *v1pb.ListD
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to filter databases, error: %v", err)
 	}
+
 	response := &v1pb.ListDatabasesResponse{}
 	for _, databaseMessage := range databaseMessages {
 		database, err := s.convertToDatabase(ctx, databaseMessage)
@@ -272,32 +275,6 @@ func filterProjectDatabasesV2(ctx context.Context, s *store.Store, iamManager *i
 		}
 	}
 
-	for _, binding := range policy.Bindings {
-		if binding.Role == api.ProjectQuerier || binding.Role == api.ProjectExporter {
-			continue
-		}
-		permissions, err := iamManager.GetPermissions(ctx, common.FormatRole(binding.Role.String()))
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get permissions")
-		}
-		if !slices.Contains(permissions, needPermission) {
-			continue
-		}
-		ok, err := common.EvalBindingCondition(binding.Condition.GetExpression(), time.Now())
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to eval binding condition")
-		}
-		if !ok {
-			continue
-		}
-		for _, member := range binding.Members {
-			if member.ID != user.ID && member.Email != api.AllUsers {
-				continue
-			}
-			return databases, nil
-		}
-	}
-
 	expressionDBsFromAllRoles := make(map[string]bool)
 	for _, binding := range policy.Bindings {
 		if binding.Role != api.ProjectQuerier && binding.Role != api.ProjectExporter {
@@ -317,23 +294,26 @@ func filterProjectDatabasesV2(ctx context.Context, s *store.Store, iamManager *i
 		if !ok {
 			continue
 		}
+
+		expressionDBs := getDatabasesFromExpression(binding.Condition.Expression)
+		if len(expressionDBs) == 0 {
+			return databases, nil
+		}
 		for _, member := range binding.Members {
 			if member.ID != user.ID && member.Email != api.AllUsers {
 				continue
 			}
-			expressionDBs := getDatabasesFromExpression(binding.Condition.Expression)
-			if len(expressionDBs) == 0 {
-				return databases, nil
-			}
 			for db := range expressionDBs {
 				expressionDBsFromAllRoles[db] = true
 			}
+			break
 		}
+		break
 	}
 
 	var filteredDatabases []*store.DatabaseMessage
 	for _, database := range databases {
-		databaseName := fmt.Sprintf("instances/%s/databases/%s", database.InstanceID, database.DatabaseName)
+		databaseName := common.FormatDatabase(database.InstanceID, database.DatabaseName)
 		if expressionDBsFromAllRoles[databaseName] {
 			filteredDatabases = append(filteredDatabases, database)
 		}
@@ -859,25 +839,9 @@ func (s *DatabaseService) ListChangeHistories(ctx context.Context, request *v1pb
 		return nil, status.Errorf(codes.NotFound, "database %q not found", databaseName)
 	}
 
-	var limit, offset int
-	if request.PageToken != "" {
-		var pageToken storepb.PageToken
-		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
-		}
-		if pageToken.Limit < 0 {
-			return nil, status.Errorf(codes.InvalidArgument, "page size cannot be negative")
-		}
-		limit = int(pageToken.Limit)
-		offset = int(pageToken.Offset)
-	} else {
-		limit = int(request.PageSize)
-	}
-	if limit <= 0 {
-		limit = 10
-	}
-	if limit > 1000 {
-		limit = 1000
+	limit, offset, err := parseLimitAndOffset(request.PageToken, int(request.PageSize))
+	if err != nil {
+		return nil, err
 	}
 	limitPlusOne := limit + 1
 

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -301,20 +301,9 @@ func (s *IssueService) ListIssues(ctx context.Context, request *v1pb.ListIssuesR
 		return nil, status.Errorf(codes.Internal, "failed to get project ids and issue types filter, error: %v", err)
 	}
 
-	limit := int(request.PageSize)
-	offset := 0
-	if request.PageToken != "" {
-		var pageToken storepb.PageToken
-		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
-		}
-		offset = int(pageToken.Offset)
-	}
-	if limit == 0 {
-		limit = 10
-	}
-	if limit > 1000 {
-		limit = 1000
+	limit, offset, err := parseLimitAndOffset(request.PageToken, int(request.PageSize))
+	if err != nil {
+		return nil, err
 	}
 	limitPlusOne := limit + 1
 
@@ -368,20 +357,9 @@ func (s *IssueService) SearchIssues(ctx context.Context, request *v1pb.SearchIss
 		return nil, status.Errorf(codes.Internal, "failed to get project ids and issue types filter, error: %v", err)
 	}
 
-	limit := int(request.PageSize)
-	offset := 0
-	if request.PageToken != "" {
-		var pageToken storepb.PageToken
-		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
-		}
-		offset = int(pageToken.Offset)
-	}
-	if limit == 0 {
-		limit = 10
-	}
-	if limit > 1000 {
-		limit = 1000
+	limit, offset, err := parseLimitAndOffset(request.PageToken, int(request.PageSize))
+	if err != nil {
+		return nil, err
 	}
 	limitPlusOne := limit + 1
 
@@ -1797,20 +1775,9 @@ func (s *IssueService) ListIssueComments(ctx context.Context, request *v1pb.List
 		return nil, err
 	}
 
-	limit := int(request.PageSize)
-	offset := 0
-	if request.PageToken != "" {
-		var pageToken storepb.PageToken
-		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
-		}
-		offset = int(pageToken.Offset)
-	}
-	if limit == 0 {
-		limit = 10
-	}
-	if limit > 1000 {
-		limit = 1000
+	limit, offset, err := parseLimitAndOffset(request.PageToken, int(request.PageSize))
+	if err != nil {
+		return nil, err
 	}
 	limitPlusOne := limit + 1
 

--- a/backend/api/v1/logging_service.go
+++ b/backend/api/v1/logging_service.go
@@ -68,24 +68,11 @@ var defaultResourceActionTypeMap = map[string][]api.ActivityType{
 
 // SearchLogs search the logs.
 func (s *LoggingService) SearchLogs(ctx context.Context, request *v1pb.SearchLogsRequest) (*v1pb.SearchLogsResponse, error) {
-	var pageToken storepb.PageToken
-	if request.PageToken != "" {
-		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
-		}
-	} else {
-		pageToken.Limit = request.PageSize
-	}
-
-	limit := int(pageToken.Limit)
-	if limit <= 0 {
-		limit = 10
-	}
-	if limit > 1000 {
-		limit = 1000
+	limit, offset, err := parseLimitAndOffset(request.PageToken, int(request.PageSize))
+	if err != nil {
+		return nil, err
 	}
 	limitPlusOne := limit + 1
-	offset := int(pageToken.Offset)
 
 	activityFind := &store.FindActivityMessage{
 		Limit:  &limitPlusOne,

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -97,23 +97,9 @@ func (s *RolloutService) ListPlans(ctx context.Context, request *v1pb.ListPlansR
 		return nil, status.Errorf(codes.Internal, "failed to get projectIDs, error: %v", err)
 	}
 
-	var limit, offset int
-	if request.PageToken != "" {
-		var pageToken storepb.PageToken
-		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
-		}
-		if pageToken.Limit < 0 {
-			return nil, status.Errorf(codes.InvalidArgument, "page size cannot be negative")
-		}
-		limit = int(pageToken.Limit)
-		offset = int(pageToken.Offset)
-	}
-	if limit <= 0 {
-		limit = 50
-	}
-	if limit > 1000 {
-		limit = 1000
+	limit, offset, err := parseLimitAndOffset(request.PageToken, int(request.PageSize))
+	if err != nil {
+		return nil, err
 	}
 	limitPlusOne := limit + 1
 

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -671,24 +671,11 @@ func (s *SQLService) createExportActivity(ctx context.Context, user *store.UserM
 
 // SearchQueryHistories lists query histories.
 func (s *SQLService) SearchQueryHistories(ctx context.Context, request *v1pb.SearchQueryHistoriesRequest) (*v1pb.SearchQueryHistoriesResponse, error) {
-	var pageToken storepb.PageToken
-	if request.PageToken != "" {
-		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
-		}
-	} else {
-		pageToken.Limit = request.PageSize
-	}
-
-	limit := int(pageToken.Limit)
-	if limit <= 0 {
-		limit = 10
-	}
-	if limit > 1000 {
-		limit = 1000
+	limit, offset, err := parseLimitAndOffset(request.PageToken, int(request.PageSize))
+	if err != nil {
+		return nil, err
 	}
 	limitPlusOne := limit + 1
-	offset := int(pageToken.Offset)
 
 	principalID, ok := ctx.Value(common.PrincipalIDContextKey).(int)
 	if !ok {


### PR DESCRIPTION
- Extract page token logic
- Fix `filterProjectDatabasesV2`. It looks like contains duplicate logic and inefficient

TODO:
Support search/list databases with the page token.
Because we will [filter databases with permission](https://github.com/bytebase/bytebase/blob/8230b4c6917fe0f77b4e3802d73770204b8c2139/backend/api/v1/database_service.go#L134), we need to move it (the project & database filter) to the `FindDatabaseMessage` before we support the page token.