### PR TITLE
fix: refine mysql pre-backup

### DIFF
--- a/backend/plugin/parser/base/base.go
+++ b/backend/plugin/parser/base/base.go
@@ -94,3 +94,14 @@ func FilterEmptySQL(list []SingleSQL) []SingleSQL {
 	}
 	return result
 }
+
+func GetOffsetLength(total int) int {
+	length := 1
+	for {
+		if total < 10 {
+			return length
+		}
+		total /= 10
+		length++
+	}
+}

--- a/backend/plugin/parser/base/interface.go
+++ b/backend/plugin/parser/base/interface.go
@@ -40,7 +40,7 @@ type GetQuerySpanFunc func(ctx context.Context, statement, database, schema stri
 type GetAffectedRowsFunc func(ctx context.Context, stmt any, getAffectedRowsByQuery GetAffectedRowsCountByQueryFunc, getTableDataSizeFunc GetTableDataSizeFunc) (int64, error)
 
 // TransformDMLToSelectFunc is the interface of transforming DML statements to SELECT statements.
-type TransformDMLToSelectFunc func(statement string, sourceDatabase string, targetDatabase string, tableSuffix string) ([]BackupStatement, error)
+type TransformDMLToSelectFunc func(statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]BackupStatement, error)
 
 func RegisterQueryValidator(engine storepb.Engine, f ValidateSQLForEditorFunc) {
 	mux.Lock()
@@ -246,10 +246,10 @@ func RegisterTransformDMLToSelect(engine storepb.Engine, f TransformDMLToSelectF
 }
 
 // TransformDMLToSelect transforms the DML statement to SELECT statement.
-func TransformDMLToSelect(engine storepb.Engine, statement string, sourceDatabase string, targetDatabase string, tableSuffix string) ([]BackupStatement, error) {
+func TransformDMLToSelect(engine storepb.Engine, statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]BackupStatement, error) {
 	f, ok := transformDMLToSelect[engine]
 	if !ok {
 		return nil, errors.Errorf("engine %s is not supported", engine)
 	}
-	return f(statement, sourceDatabase, targetDatabase, tableSuffix)
+	return f(statement, sourceDatabase, targetDatabase, tablePrefix)
 }

--- a/backend/plugin/parser/mysql/backup.go
+++ b/backend/plugin/parser/mysql/backup.go
@@ -211,11 +211,6 @@ func (l *suffixSelectStatementListener) EnterUpdateStatement(ctx *parser.UpdateS
 	}
 }
 
-type tableStatement struct {
-	tree  *ParseResult
-	table *TableReference
-}
-
 func extractTables(databaseName string, parseResult *ParseResult, offset int) ([]statementInfo, error) {
 	listener := &tableReferenceListener{
 		databaseName: databaseName,

--- a/backend/plugin/parser/mysql/backup.go
+++ b/backend/plugin/parser/mysql/backup.go
@@ -9,6 +9,7 @@ import (
 
 	parser "github.com/bytebase/mysql-parser"
 
+	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/proto/generated-go/store"
 )
@@ -17,126 +18,119 @@ func init() {
 	base.RegisterTransformDMLToSelect(store.Engine_MYSQL, TransformDMLToSelect)
 }
 
-func TransformDMLToSelect(statement string, sourceDatabase string, targetDatabase string, tableSuffix string) ([]base.BackupStatement, error) {
-	tableStatementMap, err := prepareTransformation(sourceDatabase, statement)
+const (
+	maxTableNameLength = 64
+)
+
+func TransformDMLToSelect(statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
+	statementInfoList, err := prepareTransformation(sourceDatabase, statement)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepare transformation")
 	}
 
-	return generateSQL(tableStatementMap, targetDatabase, tableSuffix)
+	return generateSQL(statementInfoList, targetDatabase, tablePrefix)
 }
 
-func prepareTransformation(databaseName, statement string) (map[string][]*tableStatement, error) {
+type StatementType int
+
+const (
+	StatementTypeUnknown StatementType = iota
+	StatementTypeUpdate
+	StatementTypeInsert
+	StatementTypeDelete
+)
+
+type TableReference struct {
+	Table         string
+	Alias         string
+	StatementType StatementType
+}
+
+type statementInfo struct {
+	offset    int
+	statement string
+	tree      antlr.Tree
+	table     *TableReference
+	line      int
+}
+
+func prepareTransformation(databaseName, statement string) ([]statementInfo, error) {
 	list, err := SplitSQL(statement)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to split sql")
 	}
 
-	result := make(map[string][]*tableStatement)
-	tableStatementTypeMap := make(map[string]StatementType)
+	var result []statementInfo
 
-	for _, sql := range list {
+	for i, sql := range list {
 		if len(sql.Text) == 0 || sql.Empty {
 			continue
 		}
-		parseResult, isDML, isDDL, err := getSQLType(sql.Text)
+		parseResult, err := ParseMySQL(sql.Text)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get sql type")
-		}
-		if isDDL {
-			return nil, errors.New("cannot transform mixed DDL and DML statements")
-		}
-		if !isDML {
-			continue
+			return nil, errors.Wrap(err, "failed to parse sql")
 		}
 
-		tables, err := extractTables(databaseName, parseResult)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to extract tables")
-		}
-		for _, table := range tables {
-			if table.StatementType == StatementTypeUnknown {
-				return nil, errors.Errorf("unknown statement type for table %q", table.Table)
+		for _, sql := range parseResult {
+			// After splitting the SQL, we should have only one statement in the list.
+			// The FOR loop is just for safety.
+			// So we can use the i as the offset.
+			tables, err := extractTables(databaseName, sql, i)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to extract tables")
 			}
-
-			tp, exists := tableStatementTypeMap[table.Table]
-			if exists && tp != table.StatementType {
-				return nil, errors.Errorf("cannot transform mixed DML statements for table %q", table.Table)
-			}
-
-			if !exists {
-				tableStatementTypeMap[table.Table] = table.StatementType
-			}
-
-			result[table.Table] = append(result[table.Table], &tableStatement{
-				tree:  parseResult,
-				table: &TableReference{Table: table.Table, Alias: table.Alias},
-			})
+			result = append(result, tables...)
 		}
 	}
 
 	return result, nil
 }
 
-func getSQLType(statement string) (*ParseResult, bool, bool, error) {
-	listener := &StatementTypeChecker{}
-
-	stmts, err := ParseMySQL(statement)
-	if err != nil {
-		return nil, false, false, errors.Wrap(err, "failed to parse sql")
-	}
-
-	if len(stmts) != 1 {
-		return nil, false, false, errors.New("statement is not single sql")
-	}
-
-	antlr.ParseTreeWalkerDefault.Walk(listener, stmts[0].Tree)
-	return stmts[0], listener.IsDML, listener.IsDDL, nil
-}
-
-func generateSQL(tableStatementMap map[string][]*tableStatement, databaseName string, tableSuffix string) ([]base.BackupStatement, error) {
+func generateSQL(statementInfoList []statementInfo, databaseName string, tablePrefix string) ([]base.BackupStatement, error) {
 	var result []base.BackupStatement
-	for tableName, tableStatements := range tableStatementMap {
-		targetTable := fmt.Sprintf("%s%s", tableName, tableSuffix)
+	offsetLength := 1
+	if len(statementInfoList) > 1 {
+		offsetLength = base.GetOffsetLength(statementInfoList[len(statementInfoList)-1].offset)
+	}
+
+	for _, statementInfo := range statementInfoList {
+		table := statementInfo.table
+		targetTable := fmt.Sprintf("%s_%0*d_%s", tablePrefix, offsetLength, statementInfo.offset, table.Table)
+		targetTable, _ = common.TruncateString(targetTable, maxTableNameLength)
+		// If enforce_gtid_consistency = true on MySQL 5.6+, we cannot run CREATE TABLE .. AS SELECT.
+		// So we need to create the table first and then run INSERT INTO .. SELECT.
 		var buf strings.Builder
-		if _, err := buf.WriteString(fmt.Sprintf("CREATE TABLE `%s`.`%s` AS ", databaseName, targetTable)); err != nil {
+		if _, err := buf.WriteString(fmt.Sprintf("CREATE TABLE `%s`.`%s` LIKE `%s`;\n", databaseName, targetTable, table.Table)); err != nil {
 			return nil, errors.Wrap(err, "failed to write create table statement")
 		}
-		for i, tableStatement := range tableStatements {
-			if i > 0 {
-				if _, err := buf.WriteString(" UNION "); err != nil {
-					return nil, errors.Wrap(err, "failed to write union all statement")
-				}
-			}
-			tableName := tableStatement.table.Table
-			if len(tableStatement.table.Alias) > 0 {
-				tableName = tableStatement.table.Alias
-			}
-			if _, err := buf.WriteString(fmt.Sprintf("SELECT `%s`.* FROM ", tableName)); err != nil {
-				return nil, errors.Wrap(err, "failed to write select statement")
-			}
-
-			if err := extractSuffixSelectStatement(tableStatement.tree, &buf); err != nil {
-				return nil, errors.Wrap(err, "failed to extract suffix select statement")
-			}
+		tableNameOrAlias := table.Table
+		if len(table.Alias) > 0 {
+			tableNameOrAlias = table.Alias
+		}
+		if _, err := buf.WriteString(fmt.Sprintf("INSERT INTO `%s`.`%s` SELECT `%s`.* FROM ", databaseName, targetTable, tableNameOrAlias)); err != nil {
+			return nil, errors.Wrap(err, "failed to write insert into statement")
+		}
+		if err := extractSuffixSelectStatement(statementInfo.tree, &buf); err != nil {
+			return nil, errors.Wrap(err, "failed to extract suffix select statement")
 		}
 		if err := buf.WriteByte(';'); err != nil {
 			return nil, errors.Wrap(err, "failed to write semicolon")
 		}
 		result = append(result, base.BackupStatement{
-			Statement: buf.String(),
-			TableName: targetTable,
+			Statement:    buf.String(),
+			TableName:    targetTable,
+			OriginalLine: statementInfo.line,
 		})
 	}
 	return result, nil
 }
 
-func extractSuffixSelectStatement(parseResult *ParseResult, buf *strings.Builder) error {
+func extractSuffixSelectStatement(tree antlr.Tree, buf *strings.Builder) error {
 	listener := &suffixSelectStatementListener{
 		buf: buf,
 	}
 
-	antlr.ParseTreeWalkerDefault.Walk(listener, parseResult.Tree)
+	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
 	return listener.err
 }
 
@@ -148,6 +142,9 @@ type suffixSelectStatementListener struct {
 }
 
 func (l *suffixSelectStatementListener) EnterDeleteStatement(ctx *parser.DeleteStatementContext) {
+	if !isTopLevel(ctx.GetParent()) {
+		return
+	}
 	if ctx.TableRef() != nil {
 		// Single table delete statement.
 		if _, err := l.buf.WriteString(ctx.GetParser().GetTokenStream().GetTextFromTokens(
@@ -172,6 +169,9 @@ func (l *suffixSelectStatementListener) EnterDeleteStatement(ctx *parser.DeleteS
 }
 
 func (l *suffixSelectStatementListener) EnterUpdateStatement(ctx *parser.UpdateStatementContext) {
+	if !isTopLevel(ctx.GetParent()) {
+		return
+	}
 	if _, err := l.buf.WriteString(ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx.TableReferenceList())); err != nil {
 		l.err = errors.Wrap(err, "failed to write suffix select statement")
 		return
@@ -216,24 +216,10 @@ type tableStatement struct {
 	table *TableReference
 }
 
-type StatementType int
-
-const (
-	StatementTypeUnknown StatementType = iota
-	StatementTypeUpdate
-	StatementTypeInsert
-	StatementTypeDelete
-)
-
-type TableReference struct {
-	Table         string
-	Alias         string
-	StatementType StatementType
-}
-
-func extractTables(databaseName string, parseResult *ParseResult) ([]*TableReference, error) {
+func extractTables(databaseName string, parseResult *ParseResult, offset int) ([]statementInfo, error) {
 	listener := &tableReferenceListener{
 		databaseName: databaseName,
+		offset:       offset,
 	}
 
 	antlr.ParseTreeWalkerDefault.Walk(listener, parseResult.Tree)
@@ -245,12 +231,27 @@ type tableReferenceListener struct {
 	*parser.BaseMySQLParserListener
 
 	databaseName string
-	tables       []*TableReference
+	offset       int
+	tables       []statementInfo
 	err          error
 }
 
+func isTopLevel(ctx antlr.Tree) bool {
+	if ctx == nil {
+		return true
+	}
+	switch ctx := ctx.(type) {
+	case *parser.SimpleStatementContext:
+		return isTopLevel(ctx.GetParent())
+	case *parser.QueryContext, *parser.ScriptContext:
+		return true
+	default:
+		return false
+	}
+}
+
 func (l *tableReferenceListener) EnterDeleteStatement(ctx *parser.DeleteStatementContext) {
-	if _, ok := ctx.GetParent().(*parser.SimpleStatementContext); !ok {
+	if !isTopLevel(ctx.GetParent()) {
 		return
 	}
 
@@ -268,10 +269,16 @@ func (l *tableReferenceListener) EnterDeleteStatement(ctx *parser.DeleteStatemen
 			alias = NormalizeMySQLIdentifier(ctx.TableAlias().Identifier())
 		}
 
-		l.tables = append(l.tables, &TableReference{
-			Table:         table,
-			Alias:         alias,
-			StatementType: StatementTypeDelete,
+		l.tables = append(l.tables, statementInfo{
+			offset:    l.offset,
+			statement: ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx),
+			tree:      ctx,
+			table: &TableReference{
+				Table:         table,
+				Alias:         alias,
+				StatementType: StatementTypeDelete,
+			},
+			line: ctx.GetStart().GetLine(),
 		})
 		return
 	}
@@ -299,13 +306,19 @@ func (l *tableReferenceListener) EnterDeleteStatement(ctx *parser.DeleteStatemen
 			}
 
 			singleTable.StatementType = StatementTypeDelete
-			l.tables = append(l.tables, singleTable)
+			l.tables = append(l.tables, statementInfo{
+				offset:    l.offset,
+				statement: ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx),
+				tree:      ctx,
+				table:     singleTable,
+				line:      ctx.GetStart().GetLine(),
+			})
 		}
 	}
 }
 
 func (l *tableReferenceListener) EnterUpdateStatement(ctx *parser.UpdateStatementContext) {
-	if _, ok := ctx.GetParent().(*parser.SimpleStatementContext); !ok {
+	if !isTopLevel(ctx.GetParent()) {
 		return
 	}
 
@@ -341,7 +354,13 @@ func (l *tableReferenceListener) EnterUpdateStatement(ctx *parser.UpdateStatemen
 		}
 
 		singleTable.StatementType = StatementTypeUpdate
-		l.tables = append(l.tables, singleTable)
+		l.tables = append(l.tables, statementInfo{
+			offset:    l.offset,
+			statement: ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx),
+			tree:      ctx,
+			table:     singleTable,
+			line:      ctx.GetStart().GetLine(),
+		})
 	}
 }
 

--- a/backend/plugin/parser/mysql/test-data/test_backup.yaml
+++ b/backend/plugin/parser/mysql/test-data/test_backup.yaml
@@ -1,48 +1,92 @@
 - input: DELETE test FROM test, test2 as t2 where test.id = t2.id;
   result:
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `test`.* FROM test, test2 as t2 where test.id = t2.id;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `test`.* FROM test, test2 as t2 where test.id = t2.id;
+      tablename: _rollback_0_test
+      originalline: 1
 - input: DELETE t1, t2 FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
   result:
-    - statement: CREATE TABLE `backupDB`.`test2_rollback` AS SELECT `t2`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
-      tablename: test2_rollback
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `t1`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `t1`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
+      tablename: _rollback_0_test
+      originalline: 1
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test2` LIKE `test2`;
+        INSERT INTO `backupDB`.`_rollback_0_test2` SELECT `t2`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
+      tablename: _rollback_0_test2
+      originalline: 1
 - input: DELETE FROM t1, t2 USING test as t1, test2 as t2 WHERE t1.id = t2.id;
   result:
-    - statement: CREATE TABLE `backupDB`.`test2_rollback` AS SELECT `t2`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
-      tablename: test2_rollback
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `t1`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `t1`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
+      tablename: _rollback_0_test
+      originalline: 1
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test2` LIKE `test2`;
+        INSERT INTO `backupDB`.`_rollback_0_test2` SELECT `t2`.* FROM test as t1, test2 as t2 WHERE t1.id = t2.id;
+      tablename: _rollback_0_test2
+      originalline: 1
 - input: DELETE FROM test as t1 WHERE t1.c1 = 1;
   result:
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `t1`.* FROM test as t1 WHERE t1.c1 = 1;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `t1`.* FROM test as t1 WHERE t1.c1 = 1;
+      tablename: _rollback_0_test
+      originalline: 1
 - input: DELETE FROM test WHERE c1 = 1;
   result:
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `test`.* FROM test WHERE c1 = 1;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `test`.* FROM test WHERE c1 = 1;
+      tablename: _rollback_0_test
+      originalline: 1
 - input: UPDATE test x SET x.c1 = 1 WHERE x.c1 = 1
   result:
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `x`.* FROM test x WHERE x.c1 = 1;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `x`.* FROM test x WHERE x.c1 = 1;
+      tablename: _rollback_0_test
+      originalline: 1
 - input: UPDATE test SET c1 = 1 WHERE c1=2;
   result:
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `test`.* FROM test WHERE c1=2;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `test`.* FROM test WHERE c1=2;
+      tablename: _rollback_0_test
+      originalline: 1
 - input: UPDATE test t1, test2 t2 SET t1.c1 = 1 WHERE t1.c1 = t2.c1;
   result:
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `t1`.* FROM test t1, test2 t2 WHERE t1.c1 = t2.c1;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `t1`.* FROM test t1, test2 t2 WHERE t1.c1 = t2.c1;
+      tablename: _rollback_0_test
+      originalline: 1
 - input: UPDATE test t1, test2 t2 SET t1.c1 = 1, t2.c2 = 2 WHERE t1.c1 = t2.c1;
   result:
-    - statement: CREATE TABLE `backupDB`.`test2_rollback` AS SELECT `t2`.* FROM test t1, test2 t2 WHERE t1.c1 = t2.c1;
-      tablename: test2_rollback
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `t1`.* FROM test t1, test2 t2 WHERE t1.c1 = t2.c1;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `t1`.* FROM test t1, test2 t2 WHERE t1.c1 = t2.c1;
+      tablename: _rollback_0_test
+      originalline: 1
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test2` LIKE `test2`;
+        INSERT INTO `backupDB`.`_rollback_0_test2` SELECT `t2`.* FROM test t1, test2 t2 WHERE t1.c1 = t2.c1;
+      tablename: _rollback_0_test2
+      originalline: 1
 - input: |-
     UPDATE test t1 SET t1.c1 = 2 WHERE t1.c1 = 1 ;
     UPDATE test t2 SET t2.c1 = 3 WHERE t2.c1 = 5 ;
   result:
-    - statement: CREATE TABLE `backupDB`.`test_rollback` AS SELECT `t1`.* FROM test t1 WHERE t1.c1 = 1 UNION SELECT `t2`.* FROM test t2 WHERE t2.c1 = 5;
-      tablename: test_rollback
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_0_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_0_test` SELECT `t1`.* FROM test t1 WHERE t1.c1 = 1;
+      tablename: _rollback_0_test
+      originalline: 1
+    - statement: |-
+        CREATE TABLE `backupDB`.`_rollback_1_test` LIKE `test`;
+        INSERT INTO `backupDB`.`_rollback_1_test` SELECT `t2`.* FROM test t2 WHERE t2.c1 = 5;
+      tablename: _rollback_1_test
+      originalline: 2

--- a/backend/plugin/parser/tsql/backup.go
+++ b/backend/plugin/parser/tsql/backup.go
@@ -63,7 +63,7 @@ func generateSQL(statementInfoList []statementInfo, targetDatabase string, table
 	var result []base.BackupStatement
 	offsetLength := 1
 	if len(statementInfoList) > 1 {
-		offsetLength = getOffsetLength(statementInfoList[len(statementInfoList)-1].offset)
+		offsetLength = base.GetOffsetLength(statementInfoList[len(statementInfoList)-1].offset)
 	}
 	for _, statementInfo := range statementInfoList {
 		table := statementInfo.table
@@ -257,17 +257,6 @@ func (e *suffixSelectStatementExtractor) EnterDelete_statement(ctx *parser.Delet
 			return
 		}
 		e.fromClause = buf.String()
-	}
-}
-
-func getOffsetLength(total int) int {
-	length := 1
-	for {
-		if total < 10 {
-			return length
-		}
-		total /= 10
-		length++
 	}
 }
 

--- a/backend/runner/taskrun/data_update_executor.go
+++ b/backend/runner/taskrun/data_update_executor.go
@@ -127,8 +127,8 @@ func (exec *DataUpdateExecutor) backupData(
 	}
 	defer backupDriver.Close(driverCtx)
 
-	suffix := "_" + time.Now().Format("20060102150405")
-	statements, err := base.TransformDMLToSelect(instance.Engine, statement, database.DatabaseName, backupDatabaseName, suffix)
+	prefix := "_" + time.Now().Format("20060102150405")
+	statements, err := base.TransformDMLToSelect(instance.Engine, statement, database.DatabaseName, backupDatabaseName, prefix)
 	if err != nil {
 		return errors.Wrap(err, "failed to transform DML to select")
 	}


### PR DESCRIPTION
close BYT-5502

If enforce_gtid_consistency = true on MySQL 5.6+, we cannot run CREATE TABLE .. AS SELECT.
So we need to create the table first and then run INSERT INTO .. SELECT.

On the other hand, I re-implement this feature for new design. We'll back up to a separate table for each UPDATE/DELETE.

