### PR TITLE
fix: one migration at the same time

### DIFF
--- a/backend/component/state/state.go
+++ b/backend/component/state/state.go
@@ -42,6 +42,8 @@ type State struct {
 	RunningTaskRuns sync.Map // map[taskRunID]bool
 	// RunningTaskRunsCancelFunc is the cancelFunc of running taskruns.
 	RunningTaskRunsCancelFunc sync.Map // map[taskRunID]context.CancelFunc
+	// RunningDatabaseMigration denotes if there is a running migration on the database.
+	RunningDatabaseMigration sync.Map // map[databaseID]bool
 
 	// RunningPlanChecks is the set of running plan checks.
 	RunningPlanChecks sync.Map


### PR DESCRIPTION
At any given time, we want at most one migration running on a database. However, with our current logic, it's not always true.

consider task 1, task 2, both changing database 1. 

1. Update task 1 status to RUNNING
2. The scheduler picks up task 1 and executes
3. Update task 2 status to RUNNING
4. nothing is stopping the scheduler from executing task 2!