### PR TITLE
chore: only show error line for latest plan check run

### DIFF
--- a/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckDetail.vue
+++ b/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckDetail.vue
@@ -42,7 +42,7 @@
             class="ml-1 normal-link"
             @click="
               state.activeResultDefinition =
-                row.checkResult.sqlReviewReport.detail
+                row.checkResult.sqlReviewReport!.detail
             "
             >{{ $t("sql-review.view-definition") }}</span
           >
@@ -76,13 +76,14 @@
           </a>
         </HideInStandaloneMode>
 
-        <template v-if="row.checkResult.sqlReviewReport?.line">
+        <!-- Only show the error line for latest plan check run -->
+        <template v-if="isLatest && row.checkResult.sqlReviewReport?.line">
           <span class="border-r border-control-border ml-1"></span>
           <span
             class="ml-1 normal-link"
             @click="
               handleClickPlanCheckDetailLine(
-                row.checkResult.sqlReviewReport.line
+                row.checkResult.sqlReviewReport!.line
               )
             "
           >
@@ -161,6 +162,7 @@ type LocalState = {
 const props = defineProps<{
   planCheckRun: PlanCheckRun;
   environment?: string;
+  isLatest?: boolean;
 }>();
 
 const { t } = useI18n();

--- a/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckPanel.vue
+++ b/frontend/src/components/IssueV1/components/PlanCheckSection/PlanCheckBar/PlanCheckPanel.vue
@@ -25,6 +25,7 @@
         v-if="selectedPlanCheckRun"
         :plan-check-run="selectedPlanCheckRun"
         :environment="environment"
+        :is-latest="isLatestPlanCheckRun"
         @close="$emit('close')"
       />
     </div>
@@ -79,6 +80,10 @@ const selectedPlanCheckRun = computed(() => {
   return selectedPlanCheckRunList.value.find(
     (checkRun) => checkRun.uid === uid
   );
+});
+
+const isLatestPlanCheckRun = computed(() => {
+  return selectedPlanCheckRunUID.value === first(selectedPlanCheckRunList.value)?.uid;
 });
 
 const tabItemList = computed(() => {

--- a/frontend/src/components/SQLCheck/SQLCheckPanel.vue
+++ b/frontend/src/components/SQLCheck/SQLCheckPanel.vue
@@ -8,7 +8,11 @@
     container-class="!pt-0 -mt-px"
     @close="$emit('close')"
   >
-    <PlanCheckDetail :plan-check-run="planCheckRun" :environment="environment">
+    <PlanCheckDetail
+      :plan-check-run="planCheckRun"
+      :environment="environment"
+      :is-latest="true"
+    >
       <template #row-extra="{ row }">
         <slot name="row-extra" :row="row" />
       </template>


### PR DESCRIPTION
No need to show error lines for the previous SQL review result.

Part of BYT-5556