### PR TITLE
chore: map task run log index

### DIFF
--- a/backend/plugin/parser/base/base.go
+++ b/backend/plugin/parser/base/base.go
@@ -95,6 +95,18 @@ func FilterEmptySQL(list []SingleSQL) []SingleSQL {
 	return result
 }
 
+func FilterEmptySQLWithIndexes(list []SingleSQL) ([]SingleSQL, map[int]int) {
+	var result []SingleSQL
+	originalIndex := map[int]int{}
+	for i, sql := range list {
+		if !sql.Empty {
+			result = append(result, sql)
+			originalIndex[len(result)-1] = i
+		}
+	}
+	return result, originalIndex
+}
+
 func GetOffsetLength(total int) int {
 	length := 1
 	for {


### PR DESCRIPTION
SheetPayload.SheetCommands contains unfiltered singleSQLs, while in executor only singleSQLs with Empty=false are executed. So we need to remap the indexes.