### PR TITLE
chore: redirect to configure labels

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
+++ b/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
@@ -10,7 +10,27 @@
     :render-tag="renderTag"
     :value="issueLabels"
     @update:value="onLablesUpdate"
-  />
+  >
+    <template #empty>
+      <div class="flex flex-col items-center justify-center mb-4">
+        <NoDataPlaceholder
+          :border="false"
+          :img-attrs="{ class: '!max-h-[6vh]' }"
+        />
+        <router-link
+          :to="{
+            name: PROJECT_V1_ROUTE_SETTINGS,
+            params: {
+              projectId: getProjectName(project.name),
+            },
+          }"
+          class="textinfolabel normal-link"
+        >
+          {{ $t("project.settings.configure-labels") }}
+        </router-link>
+      </div>
+    </template>
+  </NSelect>
 </template>
 
 <script setup lang="ts">
@@ -18,7 +38,9 @@ import { NCheckbox, NSelect, NTag } from "naive-ui";
 import type { SelectOption } from "naive-ui";
 import type { SelectBaseOption } from "naive-ui/lib/select/src/interface";
 import { computed, h } from "vue";
-import { Label } from "@/types/proto/v1/project_service";
+import { PROJECT_V1_ROUTE_SETTINGS } from "@/router/dashboard/projectV1";
+import { getProjectName } from "@/store/modules/v1/common";
+import { Project } from "@/types/proto/v1/project_service";
 
 type IsseuLabelOption = SelectOption & {
   value: string;
@@ -29,7 +51,7 @@ const props = withDefaults(
   defineProps<{
     disabled: boolean;
     selected: string[];
-    labels: Label[];
+    project: Project;
     size: "small" | "medium" | "large";
     maxTagCount: number | "responsive";
   }>(),
@@ -44,12 +66,12 @@ const emit = defineEmits<{
 }>();
 
 const issueLabels = computed(() => {
-  const pool = new Set(props.labels.map((label) => label.value));
+  const pool = new Set(props.project.issueLabels.map((label) => label.value));
   return props.selected.filter((label) => pool.has(label));
 });
 
 const options = computed(() => {
-  return props.labels.map<IsseuLabelOption>((label) => ({
+  return props.project.issueLabels.map<IsseuLabelOption>((label) => ({
     label: label.value,
     value: label.value,
     color: label.color,

--- a/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
+++ b/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
@@ -12,19 +12,20 @@
     @update:value="onLablesUpdate"
   >
     <template #empty>
-      <div class="flex flex-col items-center justify-center mb-4">
+      <div class="flex flex-col items-center justify-center">
         <NoDataPlaceholder
           :border="false"
           :img-attrs="{ class: '!max-h-[6vh]' }"
         />
         <router-link
+          v-if="hasPermission"
           :to="{
             name: PROJECT_V1_ROUTE_SETTINGS,
             params: {
               projectId: getProjectName(project.name),
             },
           }"
-          class="textinfolabel normal-link"
+          class="textinfolabel normal-link mb-4"
         >
           {{ $t("project.settings.configure-labels") }}
         </router-link>
@@ -39,8 +40,10 @@ import type { SelectOption } from "naive-ui";
 import type { SelectBaseOption } from "naive-ui/lib/select/src/interface";
 import { computed, h } from "vue";
 import { PROJECT_V1_ROUTE_SETTINGS } from "@/router/dashboard/projectV1";
+import { useCurrentUserV1 } from "@/store";
 import { getProjectName } from "@/store/modules/v1/common";
-import { Project } from "@/types/proto/v1/project_service";
+import type { ComposedProject } from "@/types";
+import { hasProjectPermissionV2 } from "@/utils";
 
 type IsseuLabelOption = SelectOption & {
   value: string;
@@ -51,7 +54,7 @@ const props = withDefaults(
   defineProps<{
     disabled: boolean;
     selected: string[];
-    project: Project;
+    project: ComposedProject;
     size: "small" | "medium" | "large";
     maxTagCount: number | "responsive";
   }>(),
@@ -64,6 +67,15 @@ const props = withDefaults(
 const emit = defineEmits<{
   (event: "update:selected", selected: string[]): void;
 }>();
+
+const currentUser = useCurrentUserV1();
+const hasPermission = computed(() => {
+  return hasProjectPermissionV2(
+    props.project,
+    currentUser.value,
+    "bb.projects.update"
+  );
+});
 
 const issueLabels = computed(() => {
   const pool = new Set(props.project.issueLabels.map((label) => label.value));

--- a/frontend/src/components/IssueV1/components/IssueTableV1.vue
+++ b/frontend/src/components/IssueV1/components/IssueTableV1.vue
@@ -148,7 +148,7 @@ const columnList = computed((): DataTableColumn<ComposedIssue>[] => {
           selected: labels,
           size: "small",
           maxTagCount: "responsive",
-          labels: issue.projectEntity.issueLabels,
+          project: issue.projectEntity,
         });
       },
     },

--- a/frontend/src/components/IssueV1/components/Sidebar/IssueLabels.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/IssueLabels.vue
@@ -6,7 +6,7 @@
     <IssueLabelSelector
       :disabled="!hasEditPermission"
       :selected="issue.labels"
-      :labels="issue.projectEntity.issueLabels"
+      :project="issue.projectEntity"
       :size="'medium'"
       @update:selected="onLablesUpdate"
     />

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1953,7 +1953,8 @@
         "no-protection-rule-configured": "No protection rule configured.",
         "only-apply-to-main-branches": "Only apply to main branches"
       },
-      "issue-labels": "Issue Labels"
+      "issue-labels": "Issue Labels",
+      "configure-labels": "Configure labels"
     },
     "members": {
       "description": "Project members determine the permission to operate database and issues inside the project. Project Owner, Workspace Admin and Workspace DBA all have full project permissions.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1953,7 +1953,8 @@
         "no-protection-rule-configured": "No hay regla de protección configurada",
         "only-apply-to-main-branches": "Sólo aplica en sucursales principales"
       },
-      "issue-labels": "Etiquetas de problemas"
+      "issue-labels": "Etiquetas de problemas",
+      "configure-labels": "Configurar etiquetas"
     },
     "members": {
       "description": "Los miembros del proyecto determinan el permiso para operar la base de datos y los problemas dentro del proyecto. El propietario del proyecto, el administrador del espacio de trabajo y el DBA del espacio de trabajo tienen permisos completos para el proyecto.",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1953,7 +1953,8 @@
         "no-protection-rule-configured": "ブランチ保護ルールは構成されていません。",
         "only-apply-to-main-branches": "メインブランチでのみ有効です"
       },
-      "issue-labels": "作業指示タグ"
+      "issue-labels": "作業指示タグ",
+      "configure-labels": "ラベルを設定する"
     },
     "members": {
       "description": "プロジェクト メンバーの役割により、プロジェクト内のデータベースと作業指示書を操作するための権限が決まります。プロジェクト所有者、ワークスペース管理者、および DBA はすべて、プロジェクトに対する完全な権限を持っています。",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1953,7 +1953,8 @@
         "no-protection-rule-configured": "Không có quy tắc bảo vệ nào được cấu hình.",
         "only-apply-to-main-branches": "Chỉ áp dụng cho chi nhánh chính"
       },
-      "issue-labels": "Nhãn phát hành"
+      "issue-labels": "Nhãn phát hành",
+      "configure-labels": "Định cấu hình nhãn"
     },
     "members": {
       "description": "Các thành viên dự án xác định quyền vận hành cơ sở dữ liệu và các vấn đề bên trong dự án. Chủ dự án, Quản trị viên Workspace và DBA Workspace đều có đầy đủ quyền đối với dự án.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1953,7 +1953,8 @@
         "no-protection-rule-configured": "没有配置分支保护规则。",
         "only-apply-to-main-branches": "只对主分支生效"
       },
-      "issue-labels": "工单标签"
+      "issue-labels": "工单标签",
+      "configure-labels": "配置标签"
     },
     "members": {
       "description": "项目成员角色决定了操作项目中的数据库和工单的权限。项目的所有者，工作空间管理员和 DBA 都具有项目所有的权限。",


### PR DESCRIPTION
GitHub will redirect you to the label management page, while Linear will pop up a model to configure the new label.

I prefer to add the new label on the issue page, but before we figure out a better UX experience, just simply redirect users to the project setting page.

![CleanShot 2024-05-14 at 10 00 59@2x](https://github.com/bytebase/bytebase/assets/10706318/7f283aee-872a-46d2-a460-b0a26bcec676)
