### PR TITLE
feat(branch): display the latest updater info in branch

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
@@ -38,6 +38,7 @@
           :targets="state.targets"
           :loading="state.isPreparingMetadata"
           :diff-when-ready="false"
+          :hide-last-updater="true"
         />
       </NTabPane>
       <NTabPane

--- a/frontend/src/components/Branch/BranchRebaseView/RebaseBranchStep.vue
+++ b/frontend/src/components/Branch/BranchRebaseView/RebaseBranchStep.vue
@@ -28,6 +28,7 @@
           :project="project"
           :readonly="true"
           :branch="validationState.branch"
+          :show-last-updater="true"
         />
       </div>
       <div

--- a/frontend/src/components/Branch/BranchRebaseView/SelectBranchStep.vue
+++ b/frontend/src/components/Branch/BranchRebaseView/SelectBranchStep.vue
@@ -95,6 +95,7 @@
         :readonly="true"
         :loading="isLoadingHeadBranch"
         :branch="headBranch ?? Branch.fromPartial({})"
+        :show-last-updater="true"
       />
       <MaskSpinner v-if="isLoadingHeadBranch" />
     </div>

--- a/frontend/src/components/Branch/BranchRolloutView/BranchRolloutView.vue
+++ b/frontend/src/components/Branch/BranchRolloutView/BranchRolloutView.vue
@@ -75,6 +75,7 @@
         :resource-type="'branch'"
         :branch="virtualBranch"
         :loading="isLoadingVirtualBranch"
+        :show-last-updater="true"
       />
 
       <!-- used as a placeholder -->

--- a/frontend/src/components/Branch/SchemaDesignEditorLite.vue
+++ b/frontend/src/components/Branch/SchemaDesignEditorLite.vue
@@ -45,6 +45,7 @@
           :resource-type="'branch'"
           :branch="branch"
           :diff-when-ready="true"
+          :show-last-updater="true"
           :disable-diff-coloring="disableDiffColoring"
         />
       </div>

--- a/frontend/src/components/Branch/common/BranchComparison.vue
+++ b/frontend/src/components/Branch/common/BranchComparison.vue
@@ -49,6 +49,7 @@
         :readonly="true"
         :branch="virtualBranch ?? Branch.fromPartial({})"
         :loading="combinedLoading"
+        :show-last-updater="true"
       />
     </div>
     <MaskSpinner v-if="combinedLoading" />

--- a/frontend/src/components/Branch/common/BranchDetailViewer.vue
+++ b/frontend/src/components/Branch/common/BranchDetailViewer.vue
@@ -25,6 +25,7 @@
         :readonly="true"
         :branch="branch ?? Branch.fromPartial({})"
         :loading="loading"
+        :show-last-updater="true"
       />
     </div>
     <div

--- a/frontend/src/components/SchemaEditorLite/Panels/CommonCodeEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/CommonCodeEditor.vue
@@ -35,6 +35,7 @@
           </template>
         </template>
       </div>
+      <slot name="header-suffix" />
     </div>
     <MonacoEditor
       :content="state.code"

--- a/frontend/src/components/SchemaEditorLite/Panels/FunctionEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/FunctionEditor.vue
@@ -5,7 +5,16 @@
     :readonly="disallowChangeFunction"
     :status="status"
     @update:code="handleUpdateDefinition"
-  />
+  >
+    <template v-if="functionConfig" #header-suffix>
+      <div class="flex justify-end items-center h-[28px]">
+        <LastUpdater
+          :updater="functionConfig.updater"
+          :update-time="functionConfig.updateTime"
+        />
+      </div>
+    </template>
+  </CommonCodeEditor>
 </template>
 
 <script setup lang="ts">
@@ -60,6 +69,14 @@ const disallowChangeFunction = computed(() => {
     return true;
   }
   return statusForSchema() === "dropped" || status.value === "dropped";
+});
+
+const functionConfig = computed(() => {
+  const sc = props.database.schemaConfigs.find(
+    (sc) => sc.name === props.schema.name
+  );
+  if (!sc) return undefined;
+  return sc.functionConfigs.find((pc) => pc.name === props.func.name);
 });
 
 const handleUpdateDefinition = (code: string) => {

--- a/frontend/src/components/SchemaEditorLite/Panels/FunctionEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/FunctionEditor.vue
@@ -6,7 +6,7 @@
     :status="status"
     @update:code="handleUpdateDefinition"
   >
-    <template v-if="functionConfig" #header-suffix>
+    <template v-if="showLastUpdater && functionConfig" #header-suffix>
       <div class="flex justify-end items-center h-[28px]">
         <LastUpdater
           :updater="functionConfig.updater"
@@ -36,8 +36,13 @@ const props = defineProps<{
   func: FunctionMetadata;
 }>();
 
-const { readonly, markEditStatus, getSchemaStatus, getFunctionStatus } =
-  useSchemaEditorContext();
+const {
+  readonly,
+  showLastUpdater,
+  markEditStatus,
+  getSchemaStatus,
+  getFunctionStatus,
+} = useSchemaEditorContext();
 
 const statusForSchema = () => {
   return getSchemaStatus(props.db, {

--- a/frontend/src/components/SchemaEditorLite/Panels/ProcedureEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/ProcedureEditor.vue
@@ -6,7 +6,7 @@
     :status="status"
     @update:code="handleUpdateDefinition"
   >
-    <template v-if="procedureConfig" #header-suffix>
+    <template v-if="showLastUpdater && procedureConfig" #header-suffix>
       <div class="flex justify-end items-center h-[28px]">
         <LastUpdater
           :updater="procedureConfig.updater"
@@ -37,8 +37,13 @@ const props = defineProps<{
   procedure: ProcedureMetadata;
 }>();
 
-const { readonly, markEditStatus, getSchemaStatus, getProcedureStatus } =
-  useSchemaEditorContext();
+const {
+  readonly,
+  showLastUpdater,
+  markEditStatus,
+  getSchemaStatus,
+  getProcedureStatus,
+} = useSchemaEditorContext();
 
 const statusForSchema = () => {
   return getSchemaStatus(props.db, {

--- a/frontend/src/components/SchemaEditorLite/Panels/ProcedureEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/ProcedureEditor.vue
@@ -5,7 +5,16 @@
     :readonly="disallowChangeProcedure"
     :status="status"
     @update:code="handleUpdateDefinition"
-  />
+  >
+    <template v-if="procedureConfig" #header-suffix>
+      <div class="flex justify-end items-center h-[28px]">
+        <LastUpdater
+          :updater="procedureConfig.updater"
+          :update-time="procedureConfig.updateTime"
+        />
+      </div>
+    </template>
+  </CommonCodeEditor>
 </template>
 
 <script setup lang="ts">
@@ -19,6 +28,7 @@ import type {
 import { useSchemaEditorContext } from "../context";
 import type { EditStatus } from "../types";
 import CommonCodeEditor from "./CommonCodeEditor.vue";
+import { LastUpdater } from "./common";
 
 const props = defineProps<{
   db: ComposedDatabase;
@@ -60,6 +70,14 @@ const disallowChangeProcedure = computed(() => {
     return true;
   }
   return statusForSchema() === "dropped" || status.value === "dropped";
+});
+
+const procedureConfig = computed(() => {
+  const sc = props.database.schemaConfigs.find(
+    (sc) => sc.name === props.schema.name
+  );
+  if (!sc) return undefined;
+  return sc.procedureConfigs.find((pc) => pc.name === props.procedure.name);
 });
 
 const handleUpdateDefinition = (code: string) => {

--- a/frontend/src/components/SchemaEditorLite/Panels/TableEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col pt-2 gap-y-2 w-full h-full overflow-y-hidden px-1 -mx-1"
+    class="flex flex-col pt-2 gap-y-2 w-full h-full overflow-y-hidden"
   >
     <div class="w-full flex flex-row justify-between items-center">
       <div class="w-full flex justify-start items-center gap-x-2">
@@ -94,6 +94,11 @@
             }"
           />
         </div>
+        <LastUpdater
+          v-if="tableConfig"
+          :updater="tableConfig.updater"
+          :update-time="tableConfig.updateTime"
+        />
       </div>
     </div>
 
@@ -341,6 +346,14 @@ const disableAlterColumn = (column: ColumnMetadata): boolean => {
     isDroppedSchema.value || isDroppedTable.value || isDroppedColumn(column)
   );
 };
+
+const tableConfig = computed(() => {
+  const sc = props.database.schemaConfigs.find(
+    (sc) => sc.name === props.schema.name
+  );
+  if (!sc) return undefined;
+  return sc.tableConfigs.find((pc) => pc.name === props.table.name);
+});
 
 const setColumnPrimaryKey = (column: ColumnMetadata, isPrimaryKey: boolean) => {
   if (isPrimaryKey) {

--- a/frontend/src/components/SchemaEditorLite/Panels/TableEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableEditor.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="flex flex-col pt-2 gap-y-2 w-full h-full overflow-y-hidden"
-  >
+  <div class="flex flex-col pt-2 gap-y-2 w-full h-full overflow-y-hidden">
     <div class="w-full flex flex-row justify-between items-center">
       <div class="w-full flex justify-start items-center gap-x-2">
         <template
@@ -95,7 +93,7 @@
           />
         </div>
         <LastUpdater
-          v-if="tableConfig"
+          v-if="(showLastUpdater, tableConfig)"
           :updater="tableConfig.updater"
           :update-time="tableConfig.updateTime"
         />
@@ -253,6 +251,7 @@ const { t } = useI18n();
 const {
   project,
   readonly,
+  showLastUpdater,
   events,
   addTab,
   markEditStatus,

--- a/frontend/src/components/SchemaEditorLite/Panels/common/LastUpdater.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/common/LastUpdater.vue
@@ -1,0 +1,46 @@
+<template>
+  <NPopover>
+    <template #trigger>
+      <NButton size="tiny" text>
+        <template #icon>
+          <FileClockIcon class="w-4 h-4" />
+        </template>
+      </NButton>
+    </template>
+    <template #default>
+      <div class="flex flex-col items-stretch gap-2 text-sm">
+        <div class="flex justify-between gap-4">
+          <div>
+            {{ $t("branch.last-update.self") }}
+          </div>
+
+          <div class="flex justify-end gap-1">
+            <UserAvatar :user="user" size="TINY" />
+            {{ user?.title }}
+          </div>
+        </div>
+        <div v-if="updateTime" class="flex justify-end gap-1 text-xs">
+          {{ dayjs(updateTime).format("YYYY-MM-DD HH:mm:ss UTCZZ") }}
+        </div>
+      </div>
+    </template>
+  </NPopover>
+</template>
+
+<script setup lang="ts">
+import { FileClockIcon } from "lucide-vue-next";
+import { NButton, NPopover } from "naive-ui";
+import { computed } from "vue";
+import UserAvatar from "@/components/User/UserAvatar.vue";
+import { extractUserEmail, useUserStore } from "@/store";
+
+const props = defineProps<{
+  updater: string; // Format: users/{email}
+  updateTime: Date | undefined;
+}>();
+
+const user = computed(() => {
+  const email = extractUserEmail(props.updater);
+  return useUserStore().getUserByEmail(email);
+});
+</script>

--- a/frontend/src/components/SchemaEditorLite/Panels/common/common.ts
+++ b/frontend/src/components/SchemaEditorLite/Panels/common/common.ts
@@ -1,5 +1,5 @@
 import { v1 as uuidv1 } from "uuid";
-import type { EditStatus } from "../types";
+import type { EditStatus } from "../../types";
 
 export const markUUID = (obj: any) => {
   // column.name is editable, so we need to insert another hidden field

--- a/frontend/src/components/SchemaEditorLite/Panels/common/index.ts
+++ b/frontend/src/components/SchemaEditorLite/Panels/common/index.ts
@@ -1,0 +1,4 @@
+import LastUpdater from "./LastUpdater.vue";
+
+export * from "./common";
+export { LastUpdater };

--- a/frontend/src/components/SchemaEditorLite/SchemaEditorLite.vue
+++ b/frontend/src/components/SchemaEditorLite/SchemaEditorLite.vue
@@ -43,6 +43,7 @@ const props = defineProps<{
   branch?: Branch;
   loading?: boolean;
   diffWhenReady?: boolean;
+  showLastUpdater?: boolean;
   disableDiffColoring?: boolean;
 }>();
 const emit = defineEmits<{
@@ -98,6 +99,7 @@ const context = provideSchemaEditorContext({
   resourceType: toRef(props, "resourceType"),
   readonly: toRef(props, "readonly"),
   selectedRolloutObjects: toRef(props, "selectedRolloutObjects"),
+  showLastUpdater: toRef(props, "showLastUpdater"),
   disableDiffColoring: toRef(props, "disableDiffColoring"),
 });
 const { rebuildMetadataEdit, applyMetadataEdit, applySelectedMetadataEdit } =

--- a/frontend/src/components/SchemaEditorLite/algorithm/utils.ts
+++ b/frontend/src/components/SchemaEditorLite/algorithm/utils.ts
@@ -60,6 +60,36 @@ export const cleanupUnusedConfigs = (metadata: DatabaseMetadata) => {
       (tc) => tc.columnConfigs.length > 0 || tc.classificationId
     );
   };
+  const cleanupViewConfigs = (
+    schema: SchemaMetadata,
+    schemaConfig: SchemaConfig
+  ) => {
+    const viewMap = keyBy(schema.views, (view) => view.name);
+    // Remove unused view configs
+    schemaConfig.viewConfigs = schemaConfig.viewConfigs.filter((tc) =>
+      viewMap.has(tc.name)
+    );
+  };
+  const cleanupFunctionConfigs = (
+    schema: SchemaMetadata,
+    schemaConfig: SchemaConfig
+  ) => {
+    const functionMap = keyBy(schema.functions, (func) => func.name);
+    // Remove unused function configs
+    schemaConfig.functionConfigs = schemaConfig.functionConfigs.filter((tc) =>
+      functionMap.has(tc.name)
+    );
+  };
+  const cleanupProcedureConfigs = (
+    schema: SchemaMetadata,
+    schemaConfig: SchemaConfig
+  ) => {
+    const procedureMap = keyBy(schema.procedures, (p) => p.name);
+    // Remove unused procedure configs
+    schemaConfig.procedureConfigs = schemaConfig.procedureConfigs.filter((tc) =>
+      procedureMap.has(tc.name)
+    );
+  };
   const cleanupSchemaConfigs = (metadata: DatabaseMetadata) => {
     const schemaMap = keyBy(metadata.schemas, (schema) => schema.name);
     // Remove unused schema configs
@@ -68,11 +98,19 @@ export const cleanupUnusedConfigs = (metadata: DatabaseMetadata) => {
     );
     // Recursively cleanup table configs
     metadata.schemaConfigs.forEach((sc) => {
-      cleanupTableConfigs(schemaMap.get(sc.name)!, sc);
+      const schema = schemaMap.get(sc.name)!;
+      cleanupTableConfigs(schema, sc);
+      cleanupViewConfigs(schema, sc);
+      cleanupFunctionConfigs(schema, sc);
+      cleanupProcedureConfigs(schema, sc);
     });
     // Cleanup empty schema configs
     metadata.schemaConfigs = metadata.schemaConfigs.filter(
-      (sc) => sc.tableConfigs.length > 0
+      (sc) =>
+        sc.tableConfigs.length > 0 ||
+        sc.viewConfigs.length > 0 ||
+        sc.functionConfigs.length > 0 ||
+        sc.procedureConfigs.length > 0
     );
   };
 

--- a/frontend/src/components/SchemaEditorLite/algorithm/utils.ts
+++ b/frontend/src/components/SchemaEditorLite/algorithm/utils.ts
@@ -54,11 +54,7 @@ export const cleanupUnusedConfigs = (metadata: DatabaseMetadata) => {
     // Recursively cleanup column configs
     schemaConfig.tableConfigs.forEach((tc) => {
       cleanupColumnConfigs(tableMap.get(tc.name)!, tc);
-    });
-    // Cleanup empty table configs
-    schemaConfig.tableConfigs = schemaConfig.tableConfigs.filter(
-      (tc) => tc.columnConfigs.length > 0 || tc.classificationId
-    );
+    })
   };
   const cleanupViewConfigs = (
     schema: SchemaMetadata,

--- a/frontend/src/components/SchemaEditorLite/context/index.ts
+++ b/frontend/src/components/SchemaEditorLite/context/index.ts
@@ -30,6 +30,7 @@ export const provideSchemaEditorContext = (params: {
   project: Ref<ComposedProject>;
   targets: Ref<EditTarget[]>;
   selectedRolloutObjects: Ref<RolloutObject[] | undefined>;
+  showLastUpdater: Ref<boolean>;
   disableDiffColoring: Ref<boolean>;
 }) => {
   const events = new Emittery() as SchemaEditorEvents;

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -3515,6 +3515,9 @@
     "table-partition": {
       "drop-partition-confirm": "Drop table partition?",
       "drop-partition-with-subpartitions-confirm": "Will also drop all its subpartitions."
+    },
+    "last-update": {
+      "self": "Last update"
     }
   }
 }

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -3515,6 +3515,9 @@
     "table-partition": {
       "drop-partition-confirm": "¿Eliminar partición de mesa?",
       "drop-partition-with-subpartitions-confirm": "También eliminará todas sus subparticiones."
+    },
+    "last-update": {
+      "self": "Última actualización"
     }
   }
 }

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -3515,6 +3515,9 @@
     "table-partition": {
       "drop-partition-confirm": "テーブルパーティションを削除しますか?",
       "drop-partition-with-subpartitions-confirm": "すべてのサブパーティションが同時に削除されます。"
+    },
+    "last-update": {
+      "self": "最後の更新"
     }
   }
 }

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -3515,6 +3515,9 @@
     "table-partition": {
       "drop-partition-confirm": "Bỏ phân vùng bảng?",
       "drop-partition-with-subpartitions-confirm": "Cũng sẽ bỏ tất cả các phân vùng của nó."
+    },
+    "last-update": {
+      "self": "Cập nhật cuối cùng"
     }
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -3515,6 +3515,9 @@
     "table-partition": {
       "drop-partition-confirm": "删除表分区？",
       "drop-partition-with-subpartitions-confirm": "将会同时删除其所有子分区。"
+    },
+    "last-update": {
+      "self": "最后更新"
     }
   }
 }


### PR DESCRIPTION
@h3n4l It's weird that when a branch is merged or rebased, all `updater`s and `updateTime`s will be refreshed (including those not edited tables/functions blahblah). I consider this is not working as intended.

<img width="1053" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/94d49640-11c5-4671-8371-bd7c8338f7fc">
