### PR TITLE
refactor(schema-editor): use SchemaEditorLite to replace SchemaEditorV1

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -298,7 +298,7 @@ import { State } from "@/types/proto/v1/common";
 import { TenantMode } from "@/types/proto/v1/project_service";
 import type { SearchParams } from "@/utils";
 import {
-  allowUsingSchemaEditorV1,
+  allowUsingSchemaEditor,
   instanceV1HasAlterSchema,
   filterDatabaseV1ByKeyword,
   sortDatabaseV1List,
@@ -590,7 +590,7 @@ const generateMultiDb = async () => {
     (id) => selectableDatabaseList.value.find((db) => db.uid === id)!
   );
 
-  if (isEditSchema.value && allowUsingSchemaEditorV1(selectedDatabaseList)) {
+  if (isEditSchema.value && allowUsingSchemaEditor(selectedDatabaseList)) {
     schemaEditorContext.value.databaseIdList = [
       ...flattenSelectedDatabaseUidList.value,
     ];
@@ -694,7 +694,7 @@ const generateTenant = async () => {
     const databaseList = databaseV1Store.databaseListByProject(
       selectedProject.value.name
     );
-    if (isEditSchema.value && allowUsingSchemaEditorV1(databaseList)) {
+    if (isEditSchema.value && allowUsingSchemaEditor(databaseList)) {
       schemaEditorContext.value.databaseIdList = databaseList
         .filter((database) => database.syncState === State.ACTIVE)
         .map((database) => database.uid);
@@ -717,7 +717,7 @@ const generateTenant = async () => {
         databaseList.push(database);
       }
     }
-    if (isEditSchema.value && allowUsingSchemaEditorV1(databaseList)) {
+    if (isEditSchema.value && allowUsingSchemaEditor(databaseList)) {
       schemaEditorContext.value.databaseIdList = [
         ...flattenSelectedDatabaseUidList.value,
       ];

--- a/frontend/src/components/AlterSchemaPrepForm/DatabaseGroupPrevEditorModal.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/DatabaseGroupPrevEditorModal.vue
@@ -64,7 +64,7 @@ import { computed, onMounted, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { MonacoEditor } from "@/components/MonacoEditor";
-import ActionConfirmModal from "@/components/SchemaEditorV1/Modals/ActionConfirmModal.vue";
+import { ActionConfirmModal } from "@/components/SchemaEditorLite";
 import SQLUploadButton from "@/components/misc/SQLUploadButton.vue";
 import { useDBGroupStore } from "@/store";
 import type { ComposedDatabaseGroup, ComposedSchemaGroup } from "@/types";

--- a/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/SchemaEditorModal.vue
@@ -125,7 +125,7 @@ import type { PropType } from "vue";
 import { computed, onMounted, h, reactive, ref, watch } from "vue";
 import { I18nT, useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
-import ActionConfirmModal from "@/components/SchemaEditorV1/Modals/ActionConfirmModal.vue";
+import { ActionConfirmModal } from "@/components/SchemaEditorLite";
 import SQLUploadButton from "@/components/misc/SQLUploadButton.vue";
 import { databaseServiceClient } from "@/grpcweb";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";

--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -143,7 +143,7 @@ import { computed, nextTick, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import DatabaseInfo from "@/components/DatabaseInfo.vue";
-import { validateDatabaseMetadata } from "@/components/SchemaEditorV1/utils";
+import { validateDatabaseMetadata } from "@/components/SchemaEditorLite";
 import TargetDatabasesSelectPanel from "@/components/SyncDatabaseSchema/TargetDatabasesSelectPanel.vue";
 import {
   PROJECT_V1_ROUTE_BRANCHES,

--- a/frontend/src/components/ColumnDataTable/index.vue
+++ b/frontend/src/components/ColumnDataTable/index.vue
@@ -16,7 +16,7 @@ import type { PropType } from "vue";
 import { computed } from "vue";
 import { h } from "vue";
 import { useI18n } from "vue-i18n";
-import { getColumnDefaultValuePlaceholder } from "@/components/SchemaEditorV1/utils/columnDefaultValue";
+import { getColumnDefaultValuePlaceholder } from "@/components/SchemaEditorLite";
 import {
   useCurrentUserV1,
   useSubscriptionV1Store,
@@ -40,6 +40,10 @@ import {
   updateColumnConfig,
   supportSetClassificationFromComment,
 } from "./utils";
+
+defineOptions({
+  name: "ColumnDataTable",
+});
 
 const props = defineProps({
   database: {

--- a/frontend/src/components/SchemaEditorLite/index.ts
+++ b/frontend/src/components/SchemaEditorLite/index.ts
@@ -1,6 +1,18 @@
+import ActionConfirmModal from "./Modals/ActionConfirmModal.vue";
+import ColumnDefaultValueExpressionModal from "./Modals/ColumnDefaultValueExpressionModal.vue";
+import TableColumnEditor from "./Panels/TableColumnEditor";
 import SchemaEditorLite from "./SchemaEditorLite.vue";
 
 export * from "./types";
 export * from "./common";
 export * from "./spec";
+export * from "./utils";
+export * from "./context";
+export * from "./edit";
+export {
+  ActionConfirmModal,
+  ColumnDefaultValueExpressionModal,
+  TableColumnEditor,
+};
+
 export default SchemaEditorLite;

--- a/frontend/src/components/SchemaTemplate/FieldTemplateForm.vue
+++ b/frontend/src/components/SchemaTemplate/FieldTemplateForm.vue
@@ -249,7 +249,9 @@ import {
   getDefaultValueByKey,
   getColumnDefaultValueOptions,
   isTextOfColumnType,
-} from "@/components/SchemaEditorV1/utils/columnDefaultValue";
+} from "@/components/SchemaEditorLite";
+import { ColumnDefaultValueExpressionModal } from "@/components/SchemaEditorLite";
+import SemanticTypesDrawer from "@/components/SensitiveData/components/SemanticTypesDrawer.vue";
 import {
   DrawerContent,
   DropdownInput,
@@ -270,8 +272,6 @@ import {
   convertKVListToLabels,
   convertLabelsToKVList,
 } from "@/utils";
-import ColumnDefaultValueExpressionModal from "../SchemaEditorV1/Modals/ColumnDefaultValueExpressionModal.vue";
-import SemanticTypesDrawer from "../SensitiveData/components/SemanticTypesDrawer.vue";
 import { engineList, categoryList, classificationConfig } from "./utils";
 
 const props = defineProps<{

--- a/frontend/src/components/SchemaTemplate/FieldTemplateTable.vue
+++ b/frontend/src/components/SchemaTemplate/FieldTemplateTable.vue
@@ -63,7 +63,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { BBGridColumn } from "@/bbkit";
 import { BBGrid } from "@/bbkit";
-import { getColumnDefaultValuePlaceholder } from "@/components/SchemaEditorV1/utils/columnDefaultValue";
+import { getColumnDefaultValuePlaceholder } from "@/components/SchemaEditorLite";
 import { MiniActionButton } from "@/components/v2";
 import { DatabaseLabelsCell } from "@/components/v2/Model/DatabaseV1Table/cells";
 import { useSettingV1Store } from "@/store";

--- a/frontend/src/components/SchemaTemplate/utils.ts
+++ b/frontend/src/components/SchemaTemplate/utils.ts
@@ -1,6 +1,16 @@
-import { computed } from "vue";
+import { cloneDeep } from "lodash-es";
+import { computed, reactive } from "vue";
 import { useSettingV1Store } from "@/store";
+import { unknownDatabase, type ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto/v1/common";
+import {
+  DatabaseMetadata,
+  SchemaConfig,
+  SchemaMetadata,
+  TableConfig,
+  TableMetadata,
+} from "@/types/proto/v1/database_service";
+import { SchemaTemplateSetting_TableTemplate } from "@/types/proto/v1/setting_service";
 
 export const engineList = [Engine.MYSQL, Engine.POSTGRES];
 
@@ -30,3 +40,58 @@ export const classificationConfig = computed(() => {
   // TODO(ed): it's a temporary solution
   return settingStore.classification[0];
 });
+
+export const mockMetadataFromTableTemplate = (
+  template: SchemaTemplateSetting_TableTemplate
+) => {
+  const db = {
+    ...unknownDatabase(),
+  };
+  const table = cloneDeep(template.table) ?? TableMetadata.fromPartial({});
+  const schema = SchemaMetadata.fromPartial({
+    name: "",
+    tables: [table],
+  });
+  const tableConfig =
+    cloneDeep(template.config) ?? TableConfig.fromPartial({ name: "" });
+  const database = DatabaseMetadata.fromPartial({
+    schemas: [schema],
+    schemaConfigs: [
+      SchemaConfig.fromPartial({
+        name: "",
+        tableConfigs: [tableConfig],
+      }),
+    ],
+  });
+  return reactive({
+    db,
+    database,
+    schema,
+    table,
+    id: template.id,
+    category: template.category,
+    engine: template.engine,
+  });
+};
+
+export const rebuildTableTemplateFromMetadata = (params: {
+  db: ComposedDatabase;
+  database: DatabaseMetadata;
+  schema: SchemaMetadata;
+  table: TableMetadata;
+  id: string;
+  category: string;
+  engine: Engine;
+}) => {
+  const { database, schema, table, id, category, engine } = params;
+  const tableConfig = database.schemaConfigs
+    .find((sc) => sc.name === schema.name)
+    ?.tableConfigs.find((tc) => tc.name === table.name);
+  return SchemaTemplateSetting_TableTemplate.fromPartial({
+    table,
+    config: tableConfig,
+    id,
+    category,
+    engine,
+  });
+};

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
@@ -116,7 +116,7 @@ import {
 import {
   isArchivedDatabaseV1,
   instanceV1HasAlterSchema,
-  allowUsingSchemaEditorV1,
+  allowUsingSchemaEditor,
   generateIssueName,
   hasProjectPermissionV2,
   extractProjectResourceName,
@@ -293,7 +293,7 @@ const generateMultiDb = async (
 ) => {
   if (
     type === "bb.issue.database.schema.update" &&
-    allowUsingSchemaEditorV1(props.databases) &&
+    allowUsingSchemaEditor(props.databases) &&
     !isStandaloneMode.value
   ) {
     schemaEditorContext.value.databaseIdList = [

--- a/frontend/src/utils/schemaEditor/index.ts
+++ b/frontend/src/utils/schemaEditor/index.ts
@@ -1,14 +1,7 @@
-import type { ComposedDatabase, Database } from "@/types";
+import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto/v1/common";
 
 export * from "./filter";
-
-// Only allow using Schema Editor with MySQL.
-export const allowUsingSchemaEditor = (databaseList: Database[]): boolean => {
-  return databaseList.every((db) => {
-    return db.instance.engine === "MYSQL" || db.instance.engine === "POSTGRES";
-  });
-};
 
 export const engineSupportsSchemaEditor = (engine: Engine) => {
   if ([Engine.MYSQL, Engine.TIDB].includes(engine)) {
@@ -20,7 +13,7 @@ export const engineSupportsSchemaEditor = (engine: Engine) => {
   return false;
 };
 
-export const allowUsingSchemaEditorV1 = (
+export const allowUsingSchemaEditor = (
   databaseList: ComposedDatabase[]
 ): boolean => {
   return databaseList.every((db) => {

--- a/frontend/src/views/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail.vue
@@ -236,7 +236,7 @@ import { State } from "@/types/proto/v1/common";
 import {
   instanceV1HasAlterSchema,
   isDatabaseV1Queryable,
-  allowUsingSchemaEditorV1,
+  allowUsingSchemaEditor,
   extractProjectResourceName,
 } from "@/utils";
 
@@ -353,7 +353,7 @@ const createMigration = async (
   if (type === "bb.issue.database.schema.update") {
     if (
       database.value.syncState === State.ACTIVE &&
-      allowUsingSchemaEditorV1([database.value])
+      allowUsingSchemaEditor([database.value])
     ) {
       state.showSchemaEditorModal = true;
       return;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/HoverPanel/ColumnInfo.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/HoverPanel/ColumnInfo.vue
@@ -26,7 +26,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { getColumnDefaultValuePlaceholder } from "@/components/SchemaEditorV1/utils/columnDefaultValue";
+import { getColumnDefaultValuePlaceholder } from "@/components/SchemaEditorLite";
 import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto/v1/common";
 import type {

--- a/frontend/src/views/sql-editor/SQLEditorPage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorPage.vue
@@ -120,7 +120,7 @@ import {
   useSQLEditorTabStore,
 } from "@/store";
 import {
-  allowUsingSchemaEditorV1,
+  allowUsingSchemaEditor,
   extractProjectResourceName,
   instanceV1HasReadonlyMode,
 } from "@/utils";
@@ -180,7 +180,7 @@ useEmitteryEventListener(
   "alter-schema",
   ({ databaseUID, schema, table }) => {
     const database = databaseStore.getDatabaseByUID(databaseUID);
-    if (allowUsingSchemaEditorV1([database])) {
+    if (allowUsingSchemaEditor([database])) {
       // TODO: support open selected database tab directly in Schema Editor.
       alterSchemaState.databaseIdList = [databaseUID];
       alterSchemaState.showModal = true;


### PR DESCRIPTION
SchemaEditorV1 and related store codes will be removed in the following PR.