### PR TITLE
chore(frontend): retire issue assignee

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
+++ b/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
@@ -143,12 +143,6 @@ export const useIssueSearchScopeOptions = (
         options: principalSearchValueOptions.value,
       },
       {
-        id: "assignee",
-        title: t("issue.advanced-search.scope.assignee.title"),
-        description: t("issue.advanced-search.scope.assignee.description"),
-        options: principalSearchValueOptions.value,
-      },
-      {
         id: "approver",
         title: t("issue.advanced-search.scope.approver.title"),
         description: t("issue.advanced-search.scope.approver.description"),

--- a/frontend/src/components/IssueV1/components/IssueTableV1.vue
+++ b/frontend/src/components/IssueV1/components/IssueTableV1.vue
@@ -51,10 +51,7 @@ import CurrentApproverV1 from "@/components/IssueV1/components/CurrentApproverV1
 import { useElementVisibilityInScrollParent } from "@/composables/useElementVisibilityInScrollParent";
 import { emitWindowEvent } from "@/plugins";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import { useCurrentUserV1 } from "@/store";
 import { type ComposedIssue } from "@/types";
-import { IssueStatus } from "@/types/proto/v1/issue_service";
-import { Workflow } from "@/types/proto/v1/project_service";
 import {
   getHighlightHTMLByRegExp,
   issueSlug,
@@ -111,9 +108,7 @@ const columnList = computed((): DataTableColumn<ComposedIssue>[] => {
           h(
             NPerformantEllipsis,
             {
-              class: `flex-1 truncate ${
-                isAssigneeAttentionOn(issue) ? "font-semibold" : ""
-              }`,
+              class: "flex-1 truncate",
             },
             {
               default: () => h("span", { innerHTML: highlight(issue.title) }),
@@ -163,33 +158,9 @@ const columnList = computed((): DataTableColumn<ComposedIssue>[] => {
       key: "approver",
       width: 150,
       resizable: true,
-      title: t("issue.table.approver"),
+      title: t("issue.table.current-approver"),
       hide: !showExtendedColumns.value,
       render: (issue) => h(CurrentApproverV1, { issue }),
-    },
-    {
-      key: "assignee",
-      resizable: true,
-      title: t("issue.table.assignee"),
-      width: 150,
-      hide: !showExtendedColumns.value,
-      render: (issue) => {
-        if (issue.assigneeEntity) {
-          return h(
-            "div",
-            { class: "flex flex-row items-center overflow-hidden gap-x-2" },
-            [
-              h(BBAvatar, {
-                size: "SMALL",
-                username: issue.assigneeEntity.title,
-              }),
-              h("span", { class: "truncate" }, issue.assigneeEntity.title),
-            ]
-          );
-        } else {
-          return h("span", {}, "-");
-        }
-      },
     },
     {
       key: "creator",
@@ -240,7 +211,6 @@ const router = useRouter();
 const state = reactive<LocalState>({
   selectedIssueIdList: new Set(),
 });
-const currentUserV1 = useCurrentUserV1();
 
 const tableRef = ref<HTMLDivElement>();
 const isTableInViewport = useElementVisibilityInScrollParent(tableRef);
@@ -272,21 +242,6 @@ const selectedIssueList = computed(() => {
     state.selectedIssueIdList.has(issue.uid)
   );
 });
-
-const isAssigneeAttentionOn = (issue: ComposedIssue) => {
-  if (issue.projectEntity.workflow === Workflow.VCS) {
-    return false;
-  }
-  if (issue.status !== IssueStatus.OPEN) {
-    return false;
-  }
-  if (currentUserV1.value.name === issue.assignee) {
-    // True if current user is the assignee
-    return issue.assigneeAttention;
-  }
-
-  return false;
-};
 
 const rowProps = (issue: ComposedIssue) => {
   return {

--- a/frontend/src/components/IssueV1/components/Sidebar/Sidebar.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/Sidebar.vue
@@ -3,7 +3,6 @@
     <VCSInfo ref="vcsInfoRef" />
     <RollbackFromTips ref="rollbackFromTipsRef" />
     <ReviewSection ref="reviewSectionRef" />
-    <Assignee ref="assigneeRef" />
     <IssueLabels />
 
     <div v-if="isFirstSectionShown" class="border-t -mx-3" />
@@ -17,7 +16,6 @@
 
 <script lang="ts" setup>
 import { computed, ref } from "vue";
-import Assignee from "./Assignee";
 import EarliestAllowedTime from "./EarliestAllowedTime.vue";
 import GhostSection from "./GhostSection";
 import IssueLabels from "./IssueLabels.vue";
@@ -30,10 +28,9 @@ import VCSInfo from "./VCSInfo.vue";
 const vcsInfoRef = ref<InstanceType<typeof VCSInfo>>();
 const rollbackFromTipsRef = ref<InstanceType<typeof RollbackFromTips>>();
 const reviewSectionRef = ref<InstanceType<typeof ReviewSection>>();
-const assigneeRef = ref<InstanceType<typeof Assignee>>();
 
 const isFirstSectionShown = computed(() => {
-  return [vcsInfoRef, rollbackFromTipsRef, reviewSectionRef, assigneeRef].some(
+  return [vcsInfoRef, rollbackFromTipsRef, reviewSectionRef].some(
     (elemRef) => elemRef.value?.shown
   );
 });

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1066,7 +1066,8 @@
       "updated": "Updated",
       "approver": "Approver",
       "creator": "Creator",
-      "assignee": "Assignee"
+      "assignee": "Assignee",
+      "current-approver": "Current approver"
     },
     "stage-select": {
       "current": "{name} (current)"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1066,7 +1066,8 @@
       "updated": "Actualizado",
       "approver": "Aprobador",
       "creator": "Creador",
-      "assignee": "Asignado"
+      "assignee": "Asignado",
+      "current-approver": "Aprobador actual"
     },
     "stage-select": {
       "current": "{name} (actual)"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1066,7 +1066,8 @@
       "updated": "に更新されました",
       "approver": "承認者",
       "creator": "創設者",
-      "assignee": "被指名者"
+      "assignee": "被指名者",
+      "current-approver": "現在の承認者"
     },
     "stage-select": {
       "current": "{name} (現在)"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1066,7 +1066,8 @@
       "updated": "更新于",
       "approver": "审批人",
       "creator": "创建人",
-      "assignee": "指派人"
+      "assignee": "指派人",
+      "current-approver": "当前审批人"
     },
     "stage-select": {
       "current": "{name}（当前）"

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -171,7 +171,6 @@ import {
 
 const TABS = [
   "CREATED",
-  "ASSIGNED",
   "APPROVAL_REQUESTED",
   "WAITING_ROLLOUT",
   "SUBSCRIBED",
@@ -214,7 +213,6 @@ const defaultScopeIds = computed(() => {
 const tabItemList = computed((): TabFilterItem<TabValue>[] => {
   return [
     { value: "CREATED", label: t("common.created") },
-    { value: "ASSIGNED", label: t("common.assigned") },
     {
       value: "APPROVAL_REQUESTED",
       label: t("issue.approval-requested"),
@@ -241,7 +239,6 @@ const storedTab = useLocalStorage<TabValue>(
 );
 const keyForTab = (tab: TabValue) => {
   if (tab === "CREATED") return "my-issues-created";
-  if (tab === "ASSIGNED") return "my-issues-assigned";
   if (tab === "APPROVAL_REQUESTED") return "my-issues-approval-requested";
   if (tab === "WAITING_ROLLOUT") return "my-issues-waiting-rollout";
   if (tab === "SUBSCRIBED") return "my-issues-subscribed";
@@ -259,12 +256,6 @@ const mergeSearchParamsByTab = (params: SearchParams, tab: TabValue) => {
   if (tab === "CREATED") {
     return upsertScope(common, {
       id: "creator",
-      value: myEmail,
-    });
-  }
-  if (tab === "ASSIGNED") {
-    return upsertScope(common, {
-      id: "assignee",
       value: myEmail,
     });
   }
@@ -324,12 +315,6 @@ const guessTabValueFromSearchParams = (params: SearchParams): TabValue => {
     getValueFromSearchParams(params, "creator") === myEmail
   ) {
     return "CREATED";
-  }
-  if (
-    verifyScopes(["assignee"]) &&
-    getValueFromSearchParams(params, "assignee") === myEmail
-  ) {
-    return "ASSIGNED";
   }
   if (
     verifyScopes(["subscriber"]) &&


### PR DESCRIPTION
- Visible issue assignees (dashboard, issue detail sidebar, issue search filters) are removed.
- Internal assignee logics are kept for legacy data compatibility.