### PR TITLE
chore(frontend): TaskRunLogTable row span calculation

### DIFF
--- a/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunLogTable/DetailCell/common.ts
+++ b/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunLogTable/DetailCell/common.ts
@@ -7,10 +7,6 @@ export const detailCellRowSpan = (entry: FlattenLogEntry) => {
     entry.commandExecute
   ) {
     const { commandExecute } = entry;
-    if (typeof commandExecute.affectedRows !== "undefined") {
-      // Has detailed affectedRows for each command
-      return 1;
-    }
     if (!commandExecute.raw.response) {
       // Not finished yet, combine several rows
       return commandExecute.raw.commandIndexes.length;
@@ -18,6 +14,10 @@ export const detailCellRowSpan = (entry: FlattenLogEntry) => {
     if (commandExecute.raw.response.error) {
       // Error, combine several rows
       return commandExecute.raw.commandIndexes.length;
+    }
+    if (typeof commandExecute.affectedRows !== "undefined") {
+      // Has detailed affectedRows for each command
+      return 1;
     }
   }
   return 1;


### PR DESCRIPTION
Before
![img_v3_02b5_b7e2a30c-08b5-4658-b9ec-198f0531651g](https://github.com/bytebase/bytebase/assets/2749742/6f218b39-a6b2-416e-bca7-a9185c79eb54)

After
![img_v3_02b5_58f34389-6780-43f5-9be9-21b8f53f518g](https://github.com/bytebase/bytebase/assets/2749742/374ae6d1-b4fe-4a4b-8399-1a1eec134b42)
