### PR TITLE
fix: trigger twice when clear rollout time

### DIFF
--- a/frontend/src/components/IssueV1/components/Sidebar/EarliestAllowedTime.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/EarliestAllowedTime.vue
@@ -29,7 +29,7 @@
             :placeholder="$t('task.earliest-allowed-time-unset')"
             :disabled="disallowEditReasons.length > 0 || isUpdating"
             :loading="isUpdating"
-            :actions="['clear', 'confirm']"
+            :actions="['confirm']"
             type="datetime"
             clearable
             @update:value="handleUpdateEarliestAllowedTime"


### PR DESCRIPTION
Close BYT-5641

It's a bug for navie-ui `NDatePicker` component. When users click the "clear" in the datetime panel, will trigger twice for "on-update:value"