### PR TITLE
chore(frontend): update affection table selector

### DIFF
--- a/frontend/src/components/ChangeHistory/AffectedTablesSelect.vue
+++ b/frontend/src/components/ChangeHistory/AffectedTablesSelect.vue
@@ -1,0 +1,98 @@
+<template>
+  <NSelect
+    :value="selectedKeys"
+    :options="affectedTableOptions"
+    filterable
+    multiple
+    tag
+    :placeholder="$t('change-history.select-affection-tables')"
+    :render-label="renderLabel"
+    @update:value="updateSelectedKey"
+  />
+</template>
+
+<script setup lang="tsx">
+import { NSelect } from "naive-ui";
+import type { SelectOption } from "naive-ui";
+import { computed } from "vue";
+import { useDBSchemaV1Store } from "@/store";
+import { type ComposedDatabase, type Table } from "@/types";
+
+type AffectedTablesSelectOption = SelectOption & {
+  table: Table;
+  value: string;
+};
+
+const props = defineProps<{
+  database: ComposedDatabase;
+  tables?: Table[];
+}>();
+const emit = defineEmits<{
+  (event: "update:tables", tables?: Table[]): void;
+}>();
+
+const dbSchemaStore = useDBSchemaV1Store();
+
+const metadata = computed(() => {
+  return dbSchemaStore.getDatabaseMetadata(props.database.name);
+});
+
+const affectedTables = computed((): Table[] => {
+  return metadata.value.schemas
+    .map((schema) =>
+      schema.tables.map((table) => ({
+        schema: schema.name,
+        table: table.name,
+      }))
+    )
+    .flat();
+});
+
+const affectedTableOptions = computed(() => {
+  return affectedTables.value.map<AffectedTablesSelectOption>((table) => {
+    return {
+      value: stringifyTable(table),
+      table: table,
+    };
+  });
+});
+
+const renderLabel = (option: SelectOption) => {
+  const { table, label } = option as AffectedTablesSelectOption;
+  if (!table) return String(label);
+  return <span class="truncate">{stringifyTable(table)}</span>;
+};
+
+const selectedKeys = computed(() => {
+  return props.tables?.map((table) => stringifyTable(table)) || [];
+});
+
+const updateSelectedKey = (
+  _: string,
+  options: AffectedTablesSelectOption[]
+) => {
+  emit(
+    "update:tables",
+    options.map((option) => {
+      const { table, label } = option;
+      if (table) return table;
+
+      let schema = "";
+      let tableName = String(label);
+      if (tableName.includes(".")) {
+        schema = tableName.split(".")[0];
+        tableName = tableName.split(".").slice(1).join(".");
+      }
+      return { schema, table: tableName };
+    })
+  );
+};
+
+const stringifyTable = (table: Table) => {
+  const { schema, table: tableName } = table;
+  if (schema !== "") {
+    return `${schema}.${tableName}`;
+  }
+  return tableName;
+};
+</script>

--- a/frontend/src/components/ChangeHistory/index.ts
+++ b/frontend/src/components/ChangeHistory/index.ts
@@ -1,4 +1,5 @@
 import AffectedTableSelect from "./AffectedTableSelect.vue";
+import AffectedTablesSelect from "./AffectedTablesSelect.vue";
 import ChangeHistoryDataTable from "./ChangeHistoryDataTable.vue";
 import ChangeHistoryDetail from "./ChangeHistoryDetail.vue";
 import ChangeHistoryStatusIcon from "./ChangeHistoryStatusIcon.vue";
@@ -12,4 +13,5 @@ export {
   AffectedTableSelect,
   ChangeHistoryDataTable,
   PagedChangeHistoryTable,
+  AffectedTablesSelect,
 };

--- a/frontend/src/components/Database/DatabaseChangeHistoryPanel.vue
+++ b/frontend/src/components/Database/DatabaseChangeHistoryPanel.vue
@@ -4,10 +4,10 @@
       class="w-full flex flex-row justify-between items-center text-lg leading-6 font-medium text-main space-x-2"
     >
       <div class="flex flex-row justify-start items-center space-x-4">
-        <div class="w-44">
-          <AffectedTableSelect
-            v-model:affected-table="state.selectedAffectedTable"
-            :change-history-list="changeHistoryList"
+        <div class="w-56">
+          <AffectedTablesSelect
+            v-model:tables="state.selectedAffectedTables"
+            :database="database"
           />
         </div>
         <div class="w-44">
@@ -69,9 +69,7 @@
     <PagedChangeHistoryTable
       :database="database"
       :search-change-histories="{
-        tables: state.selectedAffectedTable
-          ? [state.selectedAffectedTable]
-          : undefined,
+        tables: state.selectedAffectedTables,
         types: state.selectedChangeType
           ? [state.selectedChangeType]
           : undefined,
@@ -133,11 +131,11 @@ import { computed, onBeforeMount, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import {
-  AffectedTableSelect,
   ChangeHistoryDataTable,
   ChangeHistoryDetail,
   PagedChangeHistoryTable,
   ChangeTypeSelect,
+  AffectedTablesSelect,
 } from "@/components/ChangeHistory";
 import { useDatabaseDetailContext } from "@/components/Database/context";
 import { TooltipButton } from "@/components/v2";
@@ -146,7 +144,7 @@ import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
 import { useChangeHistoryStore, useDBSchemaV1Store } from "@/store";
 import type { ComposedDatabase } from "@/types";
 import { DEFAULT_PROJECT_V1_NAME } from "@/types";
-import type { AffectedTable } from "@/types/changeHistory";
+import type { Table } from "@/types/changeHistory";
 import {
   ChangeHistory_Status,
   ChangeHistory_Type,
@@ -159,7 +157,7 @@ interface LocalState {
   loading: boolean;
   selectedChangeHistoryNameList: string[];
   isExporting: boolean;
-  selectedAffectedTable?: AffectedTable;
+  selectedAffectedTables: Table[];
   selectedChangeType?: string;
   selectedChangeHistoryId: string;
 }
@@ -178,6 +176,7 @@ const state = reactive<LocalState>({
   loading: false,
   selectedChangeHistoryNameList: [],
   isExporting: false,
+  selectedAffectedTables: [],
   selectedChangeHistoryId: "",
 });
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1612,6 +1612,7 @@
     "need-to-select-first": "Need to select change history first",
     "all-tables": "All tables",
     "affected-tables": "Affected Tables",
+    "select-affection-tables": "Select affected tables",
     "view-full": "View full"
   },
   "database": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1612,6 +1612,7 @@
     "need-to-select-first": "Necesita seleccionar primero el historial de cambios",
     "all-tables": "Todas las tablas",
     "affected-tables": "Tablas afectadas",
+    "select-affection-tables": "Seleccionar tablas afectadas",
     "view-full": "Ver completo"
   },
   "database": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1612,6 +1612,7 @@
     "need-to-select-first": "最初に変更履歴を選択する必要があります",
     "all-tables": "すべてのテーブル",
     "affected-tables": "影響を受けるテーブル",
+    "select-affection-tables": "影響を受けるテーブルを選択",
     "view-full": "すべて見る"
   },
   "database": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1612,6 +1612,7 @@
     "need-to-select-first": "需要先选择变更历史",
     "all-tables": "所有表",
     "affected-tables": "受影响的表",
+    "select-affection-tables": "选择受影响的表",
     "view-full": "查看全部"
   },
   "database": {

--- a/frontend/src/types/changeHistory.ts
+++ b/frontend/src/types/changeHistory.ts
@@ -1,9 +1,12 @@
 import { ChangeHistory } from "@/types/proto/v1/database_service";
 import { Issue } from "@/types/proto/v1/issue_service";
 
-export interface AffectedTable {
+export interface Table {
   schema: string;
   table: string;
+}
+
+export interface AffectedTable extends Table {
   dropped: boolean;
 }
 
@@ -18,6 +21,6 @@ export interface ComposedChangeHistory extends ChangeHistory {
 }
 
 export interface SearchChangeHistoriesParams {
-  tables?: AffectedTable[];
+  tables?: Table[];
   types?: string[];
 }


### PR DESCRIPTION
Close BYT-5677

* show table options from database metadata instead of change histories;
* allow to input table name;

https://github.com/bytebase/bytebase/assets/24653555/0701e973-4a47-43cc-a216-d28cc198e356

