### PR TITLE
feat: support sql server tls

### DIFF
--- a/backend/plugin/db/mssql/mssql.go
+++ b/backend/plugin/db/mssql/mssql.go
@@ -8,10 +8,11 @@ import (
 	"io"
 	"log/slog"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
-	// Import go-ora Oracle driver.
+	// Import MSSQL driver.
 	_ "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/integratedauth/krb5"
 	"github.com/pkg/errors"
@@ -39,6 +40,9 @@ func init() {
 type Driver struct {
 	db           *sql.DB
 	databaseName string
+
+	// certificate file path should be deleted if calling closed.
+	certFilePath string
 }
 
 func newDriver(db.DriverConfig) db.Driver {
@@ -56,13 +60,48 @@ func (driver *Driver) Open(_ context.Context, _ storepb.Engine, config db.Connec
 	// In order to be compatible with db servers that only support old versions of tls.
 	// See: https://github.com/microsoft/go-mssqldb/issues/33
 	query.Add("tlsmin", "1.0")
+	// We should not TrustServerCertificate in production environment, otherwise, TLS is susceptible
+	// to man-in-the middle attacks. TrustServerCertificate makes driver accepts any certificate presented by the server
+	// and any host name in that certificate.
+	// Due to Golang runtime limitation, x509 package will throw the error of 'certificate relies on legacy Common Name field, use SANs instead' if
+	// TrustServerCertificate is false.
+	query.Add("TrustServerCertificate", "false")
+
+	var err error
+	if config.TLSConfig.SslCA != "" {
+		// Driver reads the certificate from file instead of regarding it as certificate content.
+		// https://github.com/microsoft/go-mssqldb/blob/main/msdsn/conn_str.go#L159
+		// TODO(zp): Driver supports .der format also.
+		const pattern string = "cert-*.pem"
+		file, err := os.CreateTemp(os.TempDir(), pattern)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create temporary file with pattern %s", pattern)
+		}
+		fName := file.Name()
+		defer func() {
+			if err != nil {
+				_ = os.Remove(fName)
+			} else {
+				driver.certFilePath = fName
+			}
+		}()
+		_, err = file.WriteString(config.TLSConfig.SslCA)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to write certificate to file %s", fName)
+		}
+		if err = file.Close(); err != nil {
+			return nil, errors.Wrapf(err, "failed to close file %s", fName)
+		}
+		query.Add("certificate", fName)
+	}
 	u := &url.URL{
 		Scheme:   "sqlserver",
 		User:     url.UserPassword(config.Username, config.Password),
 		Host:     fmt.Sprintf("%s:%s", config.Host, config.Port),
 		RawQuery: query.Encode(),
 	}
-	db, err := sql.Open("sqlserver", u.String())
+	var db *sql.DB
+	db, err = sql.Open("sqlserver", u.String())
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +112,12 @@ func (driver *Driver) Open(_ context.Context, _ storepb.Engine, config db.Connec
 
 // Close closes the driver.
 func (driver *Driver) Close(_ context.Context) error {
-	return driver.db.Close()
+	if driver.certFilePath != "" {
+		if err := os.Remove(driver.certFilePath); err != nil {
+			slog.Warn("failed to delete temporary file", slog.String("path", driver.certFilePath), slog.Any("error", err))
+		}
+	}
+	return nil
 }
 
 // Ping pings the database.

--- a/frontend/src/components/InstanceForm/DataSourceSection/SslCertificateForm.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/SslCertificateForm.vue
@@ -168,7 +168,7 @@ function guessSslType(value: WithSslOptions): SslType {
 }
 
 function sslTypeCandidatesOfEngine(engineType: Engine): SslType[] {
-  if (engineType === Engine.MONGODB) {
+  if (engineType === Engine.MONGODB || engineType === Engine.MSSQL) {
     return ["NONE", "CA"];
   }
   return ["NONE", "CA", "CA+KEY+CERT"];

--- a/frontend/src/utils/v1/instance.ts
+++ b/frontend/src/utils/v1/instance.ts
@@ -173,6 +173,7 @@ export const instanceV1HasSSL = (
     Engine.DORIS,
     Engine.MONGODB,
     Engine.ELASTICSEARCH,
+    Engine.MSSQL,
   ].includes(engine);
 };
 


### PR DESCRIPTION
Test Steps:
Using openssl to generate self sign certificate with SAN:
```bash
openssl req -x509 -nodes -newkey rsa:2048 -subj '/CN=ec2-18-163-181-181.ap-east-1.compute.amazonaws.com' -addext 'subjectAltName = DNS:ec2-18-163-181-181.ap-east-1.compute.amazonaws.com' -keyout mssql.key -out mssql.pem -days 365
sudo chown mssql:mssql mssql.pem mssql.key
sudo chmod 600 mssql.pem mssql.key
#Saving the certificate to the certs folder under /etc/ssl/ which has the following permission 755(drwxr-xr-x)
sudo mv mssql.pem /var/opt/mssql/sslcert
#Saving the private key to the private folder under /etc/ssl/ with permissions set to 755(drwxr-xr-x)
sudo mv mssql.key /var/opt/mssql/sslcert
```
Configuring SQL Server enforce TLS/SSL:
```bash
systemctl stop mssql-server
sudo cat /var/opt/mssql/mssql.conf
sudo /opt/mssql/bin/mssql-conf set network.tlscert /var/opt/mssql/sslcert/mssql.pem
sudo /opt/mssql/bin/mssql-conf set network.tlskey /var/opt/mssql/sslcert/mssql.key
sudo /opt/mssql/bin/mssql-conf set network.tlsprotocols 1.2
sudo /opt/mssql/bin/mssql-conf set network.forceencryption 1
systemctl restart mssql-server
```

![CleanShot 2024-06-14 at 10 47 21@2x](https://github.com/bytebase/bytebase/assets/87714218/abfcec8b-7e29-48ee-b0b8-1358798c4e23)

![CleanShot 2024-06-14 at 10 48 01@2x](https://github.com/bytebase/bytebase/assets/87714218/badcf78a-5e26-4cb0-856d-4dc8ae317e80)
