### PR TITLE
chore: update remove role alert

### DIFF
--- a/backend/component/iam/manager.go
+++ b/backend/component/iam/manager.go
@@ -90,6 +90,9 @@ func (m *Manager) GetPermissions(ctx context.Context, roleName string) ([]Permis
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get role %q", roleID)
 	}
+	if role == nil {
+		return nil, nil
+	}
 	var permissions []Permission
 	for _, permission := range role.Permissions.GetPermissions() {
 		permissions = append(permissions, NewPermission(permission))

--- a/frontend/src/components/Role/Setting/components/RoleDataTable/cells/RoleOperationsCell.vue
+++ b/frontend/src/components/Role/Setting/components/RoleDataTable/cells/RoleOperationsCell.vue
@@ -7,19 +7,27 @@
     >
       {{ $t("common.edit") }}
     </NButton>
-    <SpinnerButton
+
+    <NButton
+      v-if="hasPermission('bb.roles.delete')"
       size="tiny"
-      :disabled="!hasPermission('bb.roles.delete')"
-      :tooltip="$t('role.setting.delete')"
-      :on-confirm="deleteRole"
+      @click="handleDeleteRole"
     >
       {{ $t("common.delete") }}
-    </SpinnerButton>
+    </NButton>
   </div>
 </template>
 
-<script lang="ts" setup>
-import { useCurrentUserV1, useRoleStore } from "@/store";
+<script lang="tsx" setup>
+import { useDialog } from "naive-ui";
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+  useCurrentUserV1,
+  useRoleStore,
+  useUserStore,
+  pushNotification,
+} from "@/store";
 import type { WorkspacePermission } from "@/types";
 import type { Role } from "@/types/proto/v1/role_service";
 import { hasWorkspacePermissionV2, isCustomRole } from "@/utils";
@@ -36,6 +44,9 @@ defineEmits<{
 const { hasCustomRoleFeature, showFeatureModal } =
   useCustomRoleSettingContext();
 const currentUser = useCurrentUserV1();
+const userStore = useUserStore();
+const $dialog = useDialog();
+const { t } = useI18n();
 
 const hasPermission = (permission: WorkspacePermission) => {
   return hasWorkspacePermissionV2(currentUser.value, permission);
@@ -48,5 +59,59 @@ const deleteRole = async () => {
   }
 
   await useRoleStore().deleteRole(props.role);
+};
+
+const usersWithRole = computed(() => {
+  return userStore.activeUserList.filter((user) => {
+    return user.roles.includes(props.role.name);
+  });
+});
+
+const handleDeleteRole = async () => {
+  if (!hasCustomRoleFeature.value) {
+    showFeatureModal.value = true;
+    return;
+  }
+
+  $dialog.warning({
+    title: t("common.warning"),
+    style: "z-index: 100000",
+    negativeText: t("common.cancel"),
+    positiveText: t("common.continue-anyway"),
+    content: () => {
+      if (usersWithRole.value.length === 0) {
+        return t("role.setting.delete-warning", {
+          name: props.role.title,
+        });
+      }
+      return (
+        <div class="space-y-2">
+          <p>
+            {t("role.setting.delete-warning-with-resources", {
+              name: props.role.title,
+            })}
+          </p>
+          <ul class="list-disc ml-4 textinfolabel">
+            {usersWithRole.value.map((user) => (
+              <li>
+                {user.title} ({user.email})
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    },
+    onPositiveClick: () => {
+      useRoleStore()
+        .deleteRole(props.role)
+        .then(() => {
+          pushNotification({
+            module: "bytebase",
+            style: "SUCCESS",
+            title: t("common.deleted"),
+          });
+        });
+    },
+  });
 };
 </script>

--- a/frontend/src/components/Role/Setting/components/RoleDataTable/cells/RoleOperationsCell.vue
+++ b/frontend/src/components/Role/Setting/components/RoleDataTable/cells/RoleOperationsCell.vue
@@ -52,15 +52,6 @@ const hasPermission = (permission: WorkspacePermission) => {
   return hasWorkspacePermissionV2(currentUser.value, permission);
 };
 
-const deleteRole = async () => {
-  if (!hasCustomRoleFeature.value) {
-    showFeatureModal.value = true;
-    return;
-  }
-
-  await useRoleStore().deleteRole(props.role);
-};
-
 const usersWithRole = computed(() => {
   return userStore.activeUserList.filter((user) => {
     return user.roles.includes(props.role.name);

--- a/frontend/src/components/User/Settings/UserDataTable/cells/UserRolesCell.vue
+++ b/frontend/src/components/User/Settings/UserDataTable/cells/UserRolesCell.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-row items-center flex-wrap gap-2">
-    <NTag v-for="role in sortRoles(user.roles)" :key="role">
+    <NTag v-for="role in sortRoles(roles)" :key="role">
       {{ displayRoleTitle(role) }}
     </NTag>
   </div>
@@ -8,10 +8,9 @@
 
 <script lang="ts" setup>
 import { NTag } from "naive-ui";
-import type { User } from "@/types/proto/v1/auth_service";
 import { displayRoleTitle, sortRoles } from "@/utils";
 
 defineProps<{
-  user: User;
+  roles: string[];
 }>();
 </script>

--- a/frontend/src/components/User/Settings/UserDataTable/index.vue
+++ b/frontend/src/components/User/Settings/UserDataTable/index.vue
@@ -71,7 +71,7 @@ const columns = computed(() => {
       resizable: true,
       render: (user: User) => {
         return h(UserRolesCell, {
-          user,
+          roles: user.roles,
         });
       },
     },

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -3258,7 +3258,9 @@
         "pattern": "{resource} can only contain lowercase letters, numbers, and hyphens. It must start with a lowercase letter.",
         "max-length": "{resource} can contain up to {length} characters"
       },
-      "delete": "Delete role"
+      "delete": "Delete role",
+      "delete-warning": "The role \"{name}\" will be deleted. This action cannot be undone.",
+      "delete-warning-with-resources": "The role \"{name}\" is assigned to following users:"
     },
     "select": "Select role",
     "select-roles": "Select roles",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -3258,7 +3258,9 @@
         "pattern": "{recurso} solo puede contener letras minúsculas, números y guiones. Debe comenzar con una letra minúscula.",
         "max-length": "{recurso} puede contener hasta {length} caracteres"
       },
-      "delete": "Eliminar rol"
+      "delete": "Eliminar rol",
+      "delete-warning": "Se eliminará el rol \"{name}\". Esta acción no se puede deshacer.",
+      "delete-warning-with-resources": "El rol \"{name}\" está asignado a los siguientes usuarios:"
     },
     "select": "Seleccionar rol",
     "select-roles": "Seleccionar roles",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -3258,7 +3258,9 @@
         "pattern": "{resource} には小文字、数字、ハイフンのみを含めることができ、小文字で始まります。",
         "max-length": "{resource} には最大で {length} 文字が含まれます"
       },
-      "delete": "役割の削除"
+      "delete": "役割の削除",
+      "delete-warning": "ロール「{name}」は削除されます。この操作は元に戻すことができません。",
+      "delete-warning-with-resources": "ロール「{name}」は次のユーザーに割り当てられています:"
     },
     "select": "役割の選択",
     "select-roles": "役割の選択",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -3258,7 +3258,9 @@
         "pattern": "{resource}只能包含小写字母、数字和连字符，并以小写字母开头。",
         "max-length": "{resource}至多包含 {length} 个字符"
       },
-      "delete": "删除角色"
+      "delete": "删除角色",
+      "delete-warning": "角色“{name}”将被删除。此操作无法撤消。",
+      "delete-warning-with-resources": "角色“{name}”已分配给以下用户："
     },
     "select": "选择角色",
     "select-roles": "选择角色",


### PR DESCRIPTION
I'm also considering to hide removed roles for users in the frontend.
It's better to also update the binding for users in the backend when the role is removed, but it's inefficient. So for now just optimize the remove role alert

![CleanShot 2024-06-14 at 22 51 00@2x](https://github.com/bytebase/bytebase/assets/10706318/066aaa8c-de70-4bf7-9e40-0ce233d29902)
