### PR TITLE
refactor: cleanup backup data related codes part I

### DIFF
--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -5,15 +5,9 @@ import (
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/component/config"
-	api "github.com/bytebase/bytebase/backend/legacyapi"
 )
 
 func getBaseProfile(dataDir string) config.Profile {
-	backupStorageBackend := api.BackupStorageBackendLocal
-	if flags.backupBucket != "" {
-		backupStorageBackend = api.BackupStorageBackendS3
-	}
-
 	sampleDatabasePort := 0
 	if !flags.disableSample {
 		// Using flags.port + 3 as our sample database port if not disabled.
@@ -34,7 +28,6 @@ func getBaseProfile(dataDir string) config.Profile {
 		Version:              version,
 		GitCommit:            gitcommit,
 		PgURL:                flags.pgURL,
-		BackupStorageBackend: backupStorageBackend,
 		BackupRegion:         flags.backupRegion,
 		BackupBucket:         flags.backupBucket,
 		BackupCredentialFile: flags.backupCredential,

--- a/backend/component/config/profile.go
+++ b/backend/component/config/profile.go
@@ -44,8 +44,6 @@ type Profile struct {
 	AppRunnerInterval time.Duration
 	// BackupRunnerInterval is the interval for backup runner.
 	BackupRunnerInterval time.Duration
-	// BackupStorageBackend is the backup storage backend.
-	BackupStorageBackend api.BackupStorageBackend
 
 	// Cloud backup related fields
 	BackupRegion         string

--- a/backend/legacyapi/activity.go
+++ b/backend/legacyapi/activity.go
@@ -76,6 +76,4 @@ const (
 	ActivitySQLQuery ActivityType = "bb.sql.query"
 	// ActivitySQLExport is the type for exporting SQL.
 	ActivitySQLExport ActivityType = "bb.sql.export"
-
-	// Database related.
 )

--- a/backend/legacyapi/backup.go
+++ b/backend/legacyapi/backup.go
@@ -13,24 +13,3 @@ const (
 	// BackupStorageBackendOSS is the AliCloud Object Storage Service (OSS) storage backend for a backup. Not used yet.
 	BackupStorageBackendOSS BackupStorageBackend = "OSS"
 )
-
-// BinlogInfo is the binlog coordination for MySQL.
-type BinlogInfo struct {
-	FileName string `json:"fileName"`
-	Position int64  `json:"position"`
-}
-
-// IsEmpty return true if the BinlogInfo is empty.
-func (b BinlogInfo) IsEmpty() bool {
-	return b == BinlogInfo{}
-}
-
-// BackupPayload contains backup related database specific info, it differs for different database types.
-// It is encoded in JSON and stored in the backup table.
-type BackupPayload struct {
-	// MySQL related fields
-	// BinlogInfo is recorded when taking the backup.
-	// It is recorded within the same transaction as the dump so that the binlog position is consistent with the dump.
-	// Please refer to https://github.com/bytebase/bytebase/blob/main/docs/design/pitr-mysql.md#full-backup for details.
-	BinlogInfo BinlogInfo `json:"binlogInfo"`
-}

--- a/backend/plugin/advisor/utils_for_tests.go
+++ b/backend/plugin/advisor/utils_for_tests.go
@@ -309,7 +309,7 @@ func (*MockDriver) SyncDBSchema(_ context.Context) (*storepb.DatabaseSchemaMetad
 }
 
 // Dump implements the Driver interface.
-func (*MockDriver) Dump(_ context.Context, _ io.Writer, _ bool) (string, error) {
+func (*MockDriver) Dump(_ context.Context, _ io.Writer) (string, error) {
 	return "", nil
 }
 

--- a/backend/plugin/db/bigquery/dump.go
+++ b/backend/plugin/db/bigquery/dump.go
@@ -6,6 +6,6 @@ import (
 )
 
 // Dump dumps the database.
-func (*Driver) Dump(_ context.Context, _ io.Writer, _ bool) (string, error) {
+func (*Driver) Dump(_ context.Context, _ io.Writer) (string, error) {
 	return "", nil
 }

--- a/backend/plugin/db/clickhouse/dump.go
+++ b/backend/plugin/db/clickhouse/dump.go
@@ -32,7 +32,7 @@ const (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, _ bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/databricks/dump.go
+++ b/backend/plugin/db/databricks/dump.go
@@ -27,7 +27,7 @@ var (
 	dftSchema  = "default"
 )
 
-func (d *Driver) Dump(ctx context.Context, writer io.Writer, _ bool) (string, error) {
+func (d *Driver) Dump(ctx context.Context, writer io.Writer) (string, error) {
 	catalogMap, err := d.listCatologTables(ctx, "")
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/dm/dump.go
+++ b/backend/plugin/db/dm/dump.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, _ bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/driver.go
+++ b/backend/plugin/db/driver.go
@@ -311,11 +311,8 @@ type Driver interface {
 	// DeleteRole deletes the role by name.
 	DeleteRole(ctx context.Context, roleName string) error
 
-	// Dump and restore
-	// Dump the database.
-	// The returned string is the JSON encoded metadata for the logical dump.
-	// For MySQL, the payload contains the binlog filename and position when the dump is generated.
-	Dump(ctx context.Context, out io.Writer, schemaOnly bool) (string, error)
+	// Dump dumps the schema of database.
+	Dump(ctx context.Context, out io.Writer) (string, error)
 }
 
 // Register makes a database driver available by the provided type.

--- a/backend/plugin/db/dynamodb/dump.go
+++ b/backend/plugin/db/dynamodb/dump.go
@@ -6,6 +6,6 @@ import (
 )
 
 // Dump dumps the database.
-func (*Driver) Dump(_ context.Context, _ io.Writer, _ bool) (string, error) {
+func (*Driver) Dump(_ context.Context, _ io.Writer) (string, error) {
 	return "", nil
 }

--- a/backend/plugin/db/elasticsearch/dump.go
+++ b/backend/plugin/db/elasticsearch/dump.go
@@ -6,6 +6,6 @@ import (
 )
 
 // Dump() is not applicable to Elasticsearch.
-func (*Driver) Dump(_ context.Context, _ io.Writer, _ bool) (string, error) {
+func (*Driver) Dump(_ context.Context, _ io.Writer) (string, error) {
 	return "", nil
 }

--- a/backend/plugin/db/hive/dump.go
+++ b/backend/plugin/db/hive/dump.go
@@ -52,7 +52,7 @@ type MaterializedViewDDLOptions struct {
 	as             string
 }
 
-func (d *Driver) Dump(ctx context.Context, out io.Writer, _ bool) (string, error) {
+func (d *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	instanceMetadata, err := d.SyncInstance(ctx)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to sync instance")

--- a/backend/plugin/db/mongodb/mongodb.go
+++ b/backend/plugin/db/mongodb/mongodb.go
@@ -155,7 +155,7 @@ func (driver *Driver) Execute(ctx context.Context, statement string, _ db.Execut
 }
 
 // Dump dumps the database.
-func (*Driver) Dump(_ context.Context, _ io.Writer, _ bool) (string, error) {
+func (*Driver) Dump(_ context.Context, _ io.Writer) (string, error) {
 	return "", nil
 }
 

--- a/backend/plugin/db/mssql/dump.go
+++ b/backend/plugin/db/mssql/dump.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, _ bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/obo/dump.go
+++ b/backend/plugin/db/obo/dump.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, _ bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/oracle/dump.go
+++ b/backend/plugin/db/oracle/dump.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, _ bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/redis/redis.go
+++ b/backend/plugin/db/redis/redis.go
@@ -178,10 +178,7 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 // Dump and restore
 // Dump the database, if dbName is empty, then dump all databases.
 // Redis is schemaless, we don't support dump Redis data currently.
-func (*Driver) Dump(_ context.Context, _ io.Writer, schemaOnly bool) (string, error) {
-	if !schemaOnly {
-		return "", errors.New("redis: not supported")
-	}
+func (*Driver) Dump(_ context.Context, _ io.Writer) (string, error) {
 	return "", nil
 }
 

--- a/backend/plugin/db/redshift/dump.go
+++ b/backend/plugin/db/redshift/dump.go
@@ -7,6 +7,6 @@ import (
 )
 
 // Dump dumps the database to the writer. But not implemented yet.
-func (*Driver) Dump(context.Context, io.Writer, bool) (string, error) {
+func (*Driver) Dump(context.Context, io.Writer) (string, error) {
 	return "", nil
 }

--- a/backend/plugin/db/risingwave/dump.go
+++ b/backend/plugin/db/risingwave/dump.go
@@ -7,6 +7,6 @@ import (
 
 // Dump dumps the database.
 // TODO: RisingWave doesn't support pg_dump yet.
-func (*Driver) Dump(_ context.Context, _ io.Writer, _ bool) (string, error) {
+func (*Driver) Dump(_ context.Context, _ io.Writer) (string, error) {
 	return "", nil
 }

--- a/backend/plugin/db/snowflake/dump.go
+++ b/backend/plugin/db/snowflake/dump.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, _ bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/spanner/dump.go
+++ b/backend/plugin/db/spanner/dump.go
@@ -10,10 +10,7 @@ import (
 )
 
 // Dump dumps the database.
-func (d *Driver) Dump(ctx context.Context, out io.Writer, schemaOnly bool) (string, error) {
-	if !schemaOnly {
-		return "", errors.New("Dump can only dump schemas")
-	}
+func (d *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	instance, err := d.SyncInstance(ctx)
 	if err != nil {
 		return "", err

--- a/backend/plugin/db/sqlite/dump.go
+++ b/backend/plugin/db/sqlite/dump.go
@@ -85,7 +85,6 @@ func (driver *Driver) dumpOneDatabase(ctx context.Context, out io.Writer) error 
 		if _, err := io.WriteString(out, fmt.Sprintf("%s;\n", s.statement)); err != nil {
 			return err
 		}
-
 	}
 
 	return txn.Commit()

--- a/backend/plugin/db/sqlite/dump.go
+++ b/backend/plugin/db/sqlite/dump.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -13,7 +12,7 @@ import (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, schemaOnly bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	if driver.databaseName == "" {
 		return "", errors.Errorf("SQLite can dump one database only at a time")
 	}
@@ -34,7 +33,7 @@ func (driver *Driver) Dump(ctx context.Context, out io.Writer, schemaOnly bool) 
 		return "", errors.Errorf("database %s not found", driver.databaseName)
 	}
 
-	if err := driver.dumpOneDatabase(ctx, out, schemaOnly); err != nil {
+	if err := driver.dumpOneDatabase(ctx, out); err != nil {
 		return "", err
 	}
 
@@ -47,7 +46,7 @@ type sqliteSchema struct {
 	statement  string
 }
 
-func (driver *Driver) dumpOneDatabase(ctx context.Context, out io.Writer, schemaOnly bool) error {
+func (driver *Driver) dumpOneDatabase(ctx context.Context, out io.Writer) error {
 	txn, err := driver.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return err
@@ -87,61 +86,7 @@ func (driver *Driver) dumpOneDatabase(ctx context.Context, out io.Writer, schema
 			return err
 		}
 
-		// Dump table data.
-		if !schemaOnly && s.schemaType == "table" {
-			if err := exportTableData(txn, s.name, out); err != nil {
-				return err
-			}
-		}
 	}
 
 	return txn.Commit()
-}
-
-// exportTableData gets the data of a table.
-func exportTableData(txn *sql.Tx, tblName string, out io.Writer) error {
-	query := fmt.Sprintf("SELECT * FROM `%s`;", tblName)
-	rows, err := txn.Query(query)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	cols, err := rows.ColumnTypes()
-	if err != nil {
-		return err
-	}
-	if len(cols) == 0 {
-		return nil
-	}
-	values := make([]*sql.NullString, len(cols))
-	refs := make([]any, len(cols))
-	for i := 0; i < len(cols); i++ {
-		refs[i] = &values[i]
-	}
-	for rows.Next() {
-		if err := rows.Scan(refs...); err != nil {
-			return err
-		}
-		tokens := make([]string, len(cols))
-		for i, v := range values {
-			switch {
-			case v == nil || !v.Valid:
-				tokens[i] = "NULL"
-			default:
-				tokens[i] = fmt.Sprintf("'%s'", v.String)
-			}
-		}
-		stmt := fmt.Sprintf("INSERT INTO '%s' VALUES (%s);\n", tblName, strings.Join(tokens, ", "))
-		if _, err := io.WriteString(out, stmt); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(out, "\n"); err != nil {
-		return err
-	}
-	return nil
 }

--- a/backend/plugin/db/tidb/dump.go
+++ b/backend/plugin/db/tidb/dump.go
@@ -3,7 +3,6 @@ package tidb
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,8 +13,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/log"
-	api "github.com/bytebase/bytebase/backend/legacyapi"
 	"github.com/bytebase/bytebase/backend/plugin/db/util"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 )
@@ -88,7 +85,7 @@ var (
 )
 
 // Dump dumps the database.
-func (driver *Driver) Dump(ctx context.Context, out io.Writer, schemaOnly bool) (string, error) {
+func (driver *Driver) Dump(ctx context.Context, out io.Writer) (string, error) {
 	// mysqldump -u root --databases dbName --no-data --routines --events --triggers --compact
 
 	// We must use the same MySQL connection to lock and unlock tables.
@@ -99,47 +96,21 @@ func (driver *Driver) Dump(ctx context.Context, out io.Writer, schemaOnly bool) 
 	defer conn.Close()
 
 	var payloadBytes []byte
-	// Before we dump the real data, we should record the binlog position for PITR.
-	// Please refer to https://github.com/bytebase/bytebase/blob/main/docs/design/pitr-mysql.md#full-backup for details.
-	if !schemaOnly {
-		slog.Debug("flush tables in database with read locks",
-			slog.String("database", driver.databaseName))
-		if err := FlushTablesWithReadLock(ctx, driver.dbType, conn, driver.databaseName); err != nil {
-			slog.Error("flush tables failed", log.BBError(err))
-			return "", err
-		}
-
-		binlog, err := GetBinlogInfo(ctx, conn)
-		if err != nil {
-			return "", err
-		}
-		slog.Debug("binlog coordinate at dump time",
-			slog.String("fileName", binlog.FileName),
-			slog.Int64("position", binlog.Position))
-
-		payload := api.BackupPayload{BinlogInfo: binlog}
-		payloadBytes, err = json.Marshal(payload)
-		if err != nil {
-			return "", err
-		}
-	}
 
 	options := sql.TxOptions{}
 	// TiDB does not support readonly, so we only set for MySQL and OceanBase.
 	if driver.dbType == storepb.Engine_MYSQL || driver.dbType == storepb.Engine_MARIADB || driver.dbType == storepb.Engine_OCEANBASE {
 		options.ReadOnly = true
 	}
-	// If `schemaOnly` is false, now we are still holding the tables' exclusive locks.
-	// Beginning a transaction in the same session will implicitly release existing table locks.
-	// ref: https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html, section "Interaction of Table Locking and Transactions".
+
 	txn, err := conn.BeginTx(ctx, &options)
 	if err != nil {
 		return "", err
 	}
 	defer txn.Rollback()
 
-	slog.Debug("begin to dump database", slog.String("database", driver.databaseName), slog.Bool("schemaOnly", schemaOnly))
-	if err := dumpTxn(txn, driver.dbType, driver.databaseName, out, schemaOnly); err != nil {
+	slog.Debug("begin to dump database", slog.String("database", driver.databaseName))
+	if err := dumpTxn(txn, driver.dbType, driver.databaseName, out); err != nil {
 		return "", err
 	}
 
@@ -186,7 +157,7 @@ func FlushTablesWithReadLock(ctx context.Context, dbType storepb.Engine, conn *s
 	return txn.Commit()
 }
 
-func dumpTxn(txn *sql.Tx, dbType storepb.Engine, database string, out io.Writer, schemaOnly bool) error {
+func dumpTxn(txn *sql.Tx, dbType storepb.Engine, database string, out io.Writer) error {
 	// Disable foreign key check.
 	// mysqldump uses the same mechanism. When there is any schema or data dependency, we have to disable
 	// the unique and foreign key check so that the restoring will not fail.
@@ -230,16 +201,9 @@ func dumpTxn(txn *sql.Tx, dbType storepb.Engine, database string, out io.Writer,
 		if tbl.TableType == viewTableType {
 			continue
 		}
-		if schemaOnly {
-			tbl.Statement = excludeSchemaAutoValues(tbl.Statement)
-		}
+		tbl.Statement = excludeSchemaAutoValues(tbl.Statement)
 		if _, err := io.WriteString(out, fmt.Sprintf("%s\n", tbl.Statement)); err != nil {
 			return err
-		}
-		if !schemaOnly && tbl.TableType == baseTableType {
-			if err := exportTableData(txn, database, tbl.Name, out); err != nil {
-				return err
-			}
 		}
 	}
 	// Construct final views.
@@ -318,69 +282,6 @@ func getTemporaryView(name string, columns []string) string {
 func excludeSchemaAutoValues(s string) string {
 	s = excludeAutoRandomBase.ReplaceAllString(s, ``)
 	return excludeAutoIncrement.ReplaceAllString(s, ``)
-}
-
-// GetBinlogInfo queries current binlog info from MySQL server.
-func GetBinlogInfo(ctx context.Context, conn *sql.Conn) (api.BinlogInfo, error) {
-	query := "SHOW MASTER STATUS"
-	binlogInfo := api.BinlogInfo{}
-	var unused any
-	rows, err := conn.QueryContext(ctx, query)
-	if err != nil {
-		return api.BinlogInfo{}, errors.Wrapf(err, "cannot execute %q query", query)
-	}
-	defer rows.Close()
-	columns, err := rows.Columns()
-	if err != nil {
-		return api.BinlogInfo{}, errors.Wrapf(err, "cannot get columns from %q query", query)
-	}
-
-	findFileName := false
-	findPosition := false
-	for _, columnName := range columns {
-		switch columnName {
-		case "File":
-			findFileName = true
-		case "Position":
-			findPosition = true
-		}
-	}
-	if !findFileName || !findPosition {
-		return api.BinlogInfo{}, errors.Errorf("cannot find File and Position columns from %q query", query)
-	}
-
-	scanOneRow := false
-
-	for rows.Next() {
-		if scanOneRow {
-			return api.BinlogInfo{}, errors.Errorf("unexpected multiple rows returned from %q query", query)
-		}
-		cols := make([]any, len(columns))
-		scanOneRow = true
-		// The query SHOW MASTER STATUS returns uncertain number of columns, especially for the RDS, which may returns 4 columns.
-		// So we have to dynamically scan the columns, and return the error if we cannot find the File and Position columns.
-		for i := 0; i < len(columns); i++ {
-			switch columns[i] {
-			case "File":
-				cols[i] = &binlogInfo.FileName
-			case "Position":
-				cols[i] = &binlogInfo.Position
-			default:
-				cols[i] = &unused
-			}
-		}
-		if err := rows.Scan(cols...); err != nil {
-			return api.BinlogInfo{}, errors.Wrapf(err, "cannot scan row from %q query", query)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return api.BinlogInfo{}, err
-	}
-	if !scanOneRow {
-		// SHOW MASTER STATUS returns empty row when binlog is off. We should not fail migration in this case for this expected case.
-		return api.BinlogInfo{}, nil
-	}
-	return binlogInfo, nil
 }
 
 // TableSchema describes the schema of a table or view.
@@ -525,62 +426,6 @@ func getViewColumns(txn *sql.Tx, dbName, tblName string) ([]string, error) {
 		return nil, err
 	}
 	return fields, nil
-}
-
-// exportTableData gets the data of a table.
-func exportTableData(txn *sql.Tx, dbName, tblName string, out io.Writer) error {
-	query := fmt.Sprintf("SELECT * FROM `%s`.`%s`;", dbName, tblName)
-	rows, err := txn.Query(query)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	cols, err := rows.ColumnTypes()
-	if err != nil {
-		return err
-	}
-	if len(cols) == 0 {
-		return nil
-	}
-	values := make([]*sql.NullString, len(cols))
-	refs := make([]any, len(cols))
-	for i := 0; i < len(cols); i++ {
-		refs[i] = &values[i]
-	}
-	for rows.Next() {
-		if err := rows.Scan(refs...); err != nil {
-			return err
-		}
-		tokens := make([]string, len(cols))
-		for i, v := range values {
-			switch {
-			case v == nil || !v.Valid:
-				tokens[i] = "NULL"
-			case isNumeric(cols[i].ScanType().Name()):
-				tokens[i] = v.String
-			default:
-				tokens[i] = fmt.Sprintf("'%s'", v.String)
-			}
-		}
-		stmt := fmt.Sprintf("INSERT INTO `%s` VALUES (%s);\n", tblName, strings.Join(tokens, ", "))
-		if _, err := io.WriteString(out, stmt); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(out, "\n"); err != nil {
-		return err
-	}
-	return nil
-}
-
-// isNumeric determines whether the value needs quotes.
-// Even if the function returns incorrect result, the data dump will still work.
-func isNumeric(t string) bool {
-	return strings.Contains(t, "int") || strings.Contains(t, "bool") || strings.Contains(t, "float") || strings.Contains(t, "byte")
 }
 
 // getRoutines gets all routines of a database.

--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -384,7 +384,7 @@ func (s *Syncer) SyncDatabaseSchema(ctx context.Context, database *store.Databas
 		// if oldDatabaseMetadata is nil and databaseMetadata is not, they are not equal resulting a sync.
 		if force || !equalDatabaseMetadata(oldDatabaseMetadata, databaseMetadata) {
 			var schemaBuf bytes.Buffer
-			if _, err := driver.Dump(ctx, &schemaBuf, true /* schemaOnly */); err != nil {
+			if _, err := driver.Dump(ctx, &schemaBuf); err != nil {
 				return errors.Wrapf(err, "failed to dump database schema for database %q", database.DatabaseName)
 			}
 			rawDump = schemaBuf.Bytes()

--- a/backend/runner/taskrun/database_create_executor.go
+++ b/backend/runner/taskrun/database_create_executor.go
@@ -500,7 +500,7 @@ func (*DatabaseCreateExecutor) getSchemaFromPeerTenantDatabase(ctx context.Conte
 	}
 
 	var schemaBuf bytes.Buffer
-	if _, err := driver.Dump(ctx, &schemaBuf, true /* schemaOnly */); err != nil {
+	if _, err := driver.Dump(ctx, &schemaBuf); err != nil {
 		return nil, model.Version{}, "", err
 	}
 	return similarDB, schemaVersion, schemaBuf.String(), nil

--- a/backend/runner/utils/sdl_utils.go
+++ b/backend/runner/utils/sdl_utils.go
@@ -29,7 +29,7 @@ func ComputeDatabaseSchemaDiff(ctx context.Context, instance *store.InstanceMess
 	}()
 
 	var schema bytes.Buffer
-	_, err = driver.Dump(ctx, &schema, true /* schemaOnly */)
+	_, err = driver.Dump(ctx, &schema)
 	if err != nil {
 		return "", errors.Wrap(err, "dump old schema")
 	}

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -131,10 +131,6 @@ func NewServer(ctx context.Context, profile config.Profile) (*Server, error) {
 	slog.Info(fmt.Sprintf("resourceDir=%s", profile.ResourceDir))
 	slog.Info(fmt.Sprintf("readonly=%t", profile.Readonly))
 	slog.Info(fmt.Sprintf("demoName=%s", profile.DemoName))
-	slog.Info(fmt.Sprintf("backupStorageBackend=%s", profile.BackupStorageBackend))
-	slog.Info(fmt.Sprintf("backupBucket=%s", profile.BackupBucket))
-	slog.Info(fmt.Sprintf("backupRegion=%s", profile.BackupRegion))
-	slog.Info(fmt.Sprintf("backupCredentialFile=%s", profile.BackupCredentialFile))
 	slog.Info("-----Config END-------")
 
 	serverStarted := false

--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -314,7 +314,6 @@ func getTestProfile(dataDir, resourceDir string, port int, readOnly bool) compon
 		ResourceDir:          resourceDir,
 		AppRunnerInterval:    1 * time.Second,
 		BackupRunnerInterval: 10 * time.Second,
-		BackupStorageBackend: api.BackupStorageBackendLocal,
 	}
 }
 
@@ -332,7 +331,6 @@ func getTestProfileWithExternalPg(dataDir, resourceDir string, port int, pgUser 
 		ResourceDir:                resourceDir,
 		AppRunnerInterval:          1 * time.Second,
 		BackupRunnerInterval:       10 * time.Second,
-		BackupStorageBackend:       api.BackupStorageBackendLocal,
 		PgURL:                      pgURL,
 		TestOnlySkipOnboardingData: skipOnboardingData,
 	}

--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -252,7 +252,7 @@ func ExecuteMigrationWithFunc(ctx context.Context, driverCtx context.Context, s 
 	// Don't record schema if the database hasn't existed yet or is schemaless, e.g. MongoDB.
 	// For baseline migration, we also record the live schema to detect the schema drift.
 	// See https://bytebase.com/blog/what-is-database-schema-drift
-	if _, err := driver.Dump(ctx, &prevSchemaBuf, true /* schemaOnly */); err != nil {
+	if _, err := driver.Dump(ctx, &prevSchemaBuf); err != nil {
 		opts.LogSchemaDumpEnd(err.Error())
 		return "", "", err
 	}
@@ -324,7 +324,7 @@ func ExecuteMigrationWithFunc(ctx context.Context, driverCtx context.Context, s 
 	opts.LogSchemaDumpStart()
 	// Phase 4 - Dump the schema after migration
 	var afterSchemaBuf bytes.Buffer
-	if _, err := driver.Dump(ctx, &afterSchemaBuf, true /* schemaOnly */); err != nil {
+	if _, err := driver.Dump(ctx, &afterSchemaBuf); err != nil {
 		// We will ignore the dump error if the database is dropped.
 		if strings.Contains(err.Error(), "not found") {
 			return insertedID, "", nil


### PR DESCRIPTION
- Delete the `schemaOnly` argument in driver `Dump` interface.
- Delete the `BinlogInfo` related codes.