### PR TITLE
chore: add exceeded commands

### DIFF
--- a/backend/common/util.go
+++ b/backend/common/util.go
@@ -28,6 +28,8 @@ const (
 	// The maximum number of bytes for sql results in response body.
 	// 100 MB.
 	MaximumSQLResultSize = 100 * 1024 * 1024
+	// MaximumCommands is the maximum number of commands that can be executed in a single transaction.
+	MaximumCommands = 200
 
 	// ExternalURLPlaceholder is the docs link to configure --external-url.
 	ExternalURLPlaceholder = "https://www.bytebase.com/docs/get-started/install/external-url"

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -311,6 +311,7 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 	var totalCommands int
 	var commands []base.SingleSQL
 	var originalIndex []int32
+	exceeded := false
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := mysqlparser.SplitSQL(statement)
 		if err != nil {
@@ -320,9 +321,15 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		if len(singleSQLs) == 0 {
 			return 0, nil
 		}
-		totalCommands = len(singleSQLs)
 		commands = singleSQLs
+		totalCommands = len(commands)
+		if totalCommands > common.MaximumCommands {
+			exceeded = true
+		}
 	} else {
+		exceeded = true
+	}
+	if exceeded {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -311,7 +311,7 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 	var totalCommands int
 	var commands []base.SingleSQL
 	var originalIndex []int32
-	exceeded := false
+	oneshot := true
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := mysqlparser.SplitSQL(statement)
 		if err != nil {
@@ -323,13 +323,11 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		}
 		commands = singleSQLs
 		totalCommands = len(commands)
-		if totalCommands > common.MaximumCommands {
-			exceeded = true
+		if totalCommands <= common.MaximumCommands {
+			oneshot = false
 		}
-	} else {
-		exceeded = true
 	}
-	if exceeded {
+	if oneshot {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,

--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -367,6 +367,7 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 	var commands []base.SingleSQL
 	var originalIndex []int32
 	var isPlsql bool
+	exceeded := false
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := pgparser.SplitSQL(statement)
 		if err != nil {
@@ -381,7 +382,13 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 		if len(singleSQLs) == 1 && isPlSQLBlock(singleSQLs[0].Text) {
 			isPlsql = true
 		}
+		if len(commands) > common.MaximumCommands {
+			exceeded = true
+		}
 	} else {
+		exceeded = true
+	}
+	if exceeded {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,

--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -367,7 +367,7 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 	var commands []base.SingleSQL
 	var originalIndex []int32
 	var isPlsql bool
-	exceeded := false
+	oneshot := true
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := pgparser.SplitSQL(statement)
 		if err != nil {
@@ -382,13 +382,11 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 		if len(singleSQLs) == 1 && isPlSQLBlock(singleSQLs[0].Text) {
 			isPlsql = true
 		}
-		if len(commands) > common.MaximumCommands {
-			exceeded = true
+		if len(commands) <= common.MaximumCommands {
+			oneshot = false
 		}
-	} else {
-		exceeded = true
 	}
-	if exceeded {
+	if oneshot {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,

--- a/backend/plugin/db/redshift/redshift.go
+++ b/backend/plugin/db/redshift/redshift.go
@@ -180,13 +180,20 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 	}
 
 	var commands []base.SingleSQL
+	exceeded := false
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := pgparser.SplitSQL(statement)
 		if err != nil {
 			return 0, err
 		}
 		commands = base.FilterEmptySQL(singleSQLs)
+		if len(commands) > common.MaximumCommands {
+			exceeded = true
+		}
 	} else {
+		exceeded = true
+	}
+	if exceeded {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,

--- a/backend/plugin/db/redshift/redshift.go
+++ b/backend/plugin/db/redshift/redshift.go
@@ -180,20 +180,18 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 	}
 
 	var commands []base.SingleSQL
-	exceeded := false
+	oneshot := true
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := pgparser.SplitSQL(statement)
 		if err != nil {
 			return 0, err
 		}
 		commands = base.FilterEmptySQL(singleSQLs)
-		if len(commands) > common.MaximumCommands {
-			exceeded = true
+		if len(commands) <= common.MaximumCommands {
+			oneshot = false
 		}
-	} else {
-		exceeded = true
 	}
-	if exceeded {
+	if oneshot {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,

--- a/backend/plugin/db/risingwave/risingwave.go
+++ b/backend/plugin/db/risingwave/risingwave.go
@@ -245,20 +245,18 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 	}
 
 	var commands []base.SingleSQL
-	exceeded := false
+	oneshot := true
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := pgparser.SplitSQL(statement)
 		if err != nil {
 			return 0, err
 		}
 		commands = base.FilterEmptySQL(singleSQLs)
-		if len(commands) > common.MaximumCommands {
-			exceeded = true
+		if len(commands) <= common.MaximumCommands {
+			oneshot = false
 		}
-	} else {
-		exceeded = true
 	}
-	if exceeded {
+	if oneshot {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,

--- a/backend/plugin/db/risingwave/risingwave.go
+++ b/backend/plugin/db/risingwave/risingwave.go
@@ -245,13 +245,20 @@ func (driver *Driver) Execute(ctx context.Context, statement string, opts db.Exe
 	}
 
 	var commands []base.SingleSQL
+	exceeded := false
 	if len(statement) <= common.MaxSheetCheckSize {
 		singleSQLs, err := pgparser.SplitSQL(statement)
 		if err != nil {
 			return 0, err
 		}
 		commands = base.FilterEmptySQL(singleSQLs)
+		if len(commands) > common.MaximumCommands {
+			exceeded = true
+		}
 	} else {
+		exceeded = true
+	}
+	if exceeded {
 		commands = []base.SingleSQL{
 			{
 				Text: statement,


### PR DESCRIPTION
oneshot if too many commands, otherwise too many task run logs and round-trips will cause pain.