### PR TITLE
chore: trim oracle identifier length before 12.2

### DIFF
--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -48,6 +47,11 @@ type Driver struct {
 
 func newDriver(db.DriverConfig) db.Driver {
 	return &Driver{}
+}
+
+// GetVersion gets the Oracle version.
+func (driver *Driver) GetVersion() (*plsqlparser.Version, error) {
+	return plsqlparser.ParseVersion(driver.connectionCtx.EngineVersion)
 }
 
 // Open opens a Oracle driver.
@@ -286,26 +290,4 @@ func (driver *Driver) querySingleSQL(ctx context.Context, conn *sql.Conn, single
 // RunStatement runs a SQL statement in a given connection.
 func (*Driver) RunStatement(ctx context.Context, conn *sql.Conn, statement string) ([]*v1pb.QueryResult, error) {
 	return util.RunStatement(ctx, storepb.Engine_ORACLE, conn, statement)
-}
-
-type oracleVersion struct {
-	first  int
-	second int
-}
-
-func parseVersion(banner string) (*oracleVersion, error) {
-	re := regexp.MustCompile(`(\d+)\.(\d+)`)
-	match := re.FindStringSubmatch(banner)
-	if len(match) >= 3 {
-		firstVersion, err := strconv.Atoi(match[1])
-		if err != nil {
-			return nil, errors.Errorf("failed to parse first version from banner: %s", banner)
-		}
-		secondVersion, err := strconv.Atoi(match[2])
-		if err != nil {
-			return nil, errors.Errorf("failed to parse second version from banner: %s", banner)
-		}
-		return &oracleVersion{first: firstVersion, second: secondVersion}, nil
-	}
-	return nil, errors.Errorf("failed to parse version from banner: %s", banner)
 }

--- a/backend/plugin/db/oracle/oracle_test.go
+++ b/backend/plugin/db/oracle/oracle_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
 func TestParseVersion(t *testing.T) {
@@ -26,9 +28,9 @@ func TestParseVersion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := parseVersion(test.Banner)
+		v, err := plsql.ParseVersion(test.Banner)
 		require.NoError(t, err)
-		require.Equal(t, test.First, v.first)
-		require.Equal(t, test.Second, v.second)
+		require.Equal(t, test.First, v.First)
+		require.Equal(t, test.Second, v.Second)
 	}
 }

--- a/backend/plugin/parser/base/interface.go
+++ b/backend/plugin/parser/base/interface.go
@@ -39,7 +39,7 @@ type GetQuerySpanFunc func(ctx context.Context, gCtx GetQuerySpanContext, statem
 type GetAffectedRowsFunc func(ctx context.Context, stmt any, getAffectedRowsByQuery GetAffectedRowsCountByQueryFunc, getTableDataSizeFunc GetTableDataSizeFunc) (int64, error)
 
 // TransformDMLToSelectFunc is the interface of transforming DML statements to SELECT statements.
-type TransformDMLToSelectFunc func(statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]BackupStatement, error)
+type TransformDMLToSelectFunc func(ctx TransformContext, statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]BackupStatement, error)
 
 type GenerateRestoreSQLFunc func(statement string, backupDatabase string, backupTable string, originalDatabase string, originalTable string) (string, error)
 
@@ -226,12 +226,12 @@ func RegisterTransformDMLToSelect(engine storepb.Engine, f TransformDMLToSelectF
 }
 
 // TransformDMLToSelect transforms the DML statement to SELECT statement.
-func TransformDMLToSelect(engine storepb.Engine, statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]BackupStatement, error) {
+func TransformDMLToSelect(engine storepb.Engine, ctx TransformContext, statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]BackupStatement, error) {
 	f, ok := transformDMLToSelect[engine]
 	if !ok {
 		return nil, errors.Errorf("engine %s is not supported", engine)
 	}
-	return f(statement, sourceDatabase, targetDatabase, tablePrefix)
+	return f(ctx, statement, sourceDatabase, targetDatabase, tablePrefix)
 }
 
 func RegisterGenerateRestoreSQL(engine storepb.Engine, f GenerateRestoreSQLFunc) {

--- a/backend/plugin/parser/base/transform.go
+++ b/backend/plugin/parser/base/transform.go
@@ -1,0 +1,5 @@
+package base
+
+type TransformContext struct {
+	Version any
+}

--- a/backend/plugin/parser/mysql/backup.go
+++ b/backend/plugin/parser/mysql/backup.go
@@ -22,7 +22,7 @@ const (
 	maxTableNameLength = 64
 )
 
-func TransformDMLToSelect(statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
+func TransformDMLToSelect(_ base.TransformContext, statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
 	statementInfoList, err := prepareTransformation(sourceDatabase, statement)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepare transformation")

--- a/backend/plugin/parser/mysql/backup_test.go
+++ b/backend/plugin/parser/mysql/backup_test.go
@@ -37,7 +37,7 @@ func TestBackup(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for i, t := range tests {
-		result, err := TransformDMLToSelect(t.Input, "db", "backupDB", "_rollback")
+		result, err := TransformDMLToSelect(base.TransformContext{}, t.Input, "db", "backupDB", "_rollback")
 		a.NoError(err)
 		sort.Slice(result, func(i, j int) bool {
 			if result[i].TableName == result[j].TableName {

--- a/backend/plugin/parser/pg/backup.go
+++ b/backend/plugin/parser/pg/backup.go
@@ -51,7 +51,7 @@ func init() {
 	base.RegisterTransformDMLToSelect(storebp.Engine_POSTGRES, TransformDMLToSelect)
 }
 
-func TransformDMLToSelect(statement string, _ string, targetSchema string, tablePrefix string) ([]base.BackupStatement, error) {
+func TransformDMLToSelect(_ base.TransformContext, statement string, _ string, targetSchema string, tablePrefix string) ([]base.BackupStatement, error) {
 	statementInfoList, err := prepareTransformation(statement)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to prepare transformation")

--- a/backend/plugin/parser/pg/backup_test.go
+++ b/backend/plugin/parser/pg/backup_test.go
@@ -37,7 +37,7 @@ func TestBackup(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for i, t := range tests {
-		result, err := TransformDMLToSelect(t.Input, "", "backupSchema", "rollback")
+		result, err := TransformDMLToSelect(base.TransformContext{}, t.Input, "", "backupSchema", "rollback")
 		a.NoError(err)
 		sort.Slice(result, func(i, j int) bool {
 			if result[i].TableName == result[j].TableName {

--- a/backend/plugin/parser/plsql/backup.go
+++ b/backend/plugin/parser/plsql/backup.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	maxTableNameLength = 128
+	maxTableNameLengthAfter12_2  = 128
+	maxTableNameLengthBefore12_2 = 30
 )
 
 func init() {
@@ -49,26 +50,38 @@ type statementInfo struct {
 
 // TransformDMLToSelect transforms DML statement to SELECT statement.
 // For Oracle, we only consider the managed on schema mode.
-func TransformDMLToSelect(statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
+func TransformDMLToSelect(ctx base.TransformContext, statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
 	statementInfoList, err := prepareTransformation(sourceDatabase, statement)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepare transformation")
 	}
 
-	return generateSQL(statementInfoList, targetDatabase, tablePrefix)
+	return generateSQL(ctx, statementInfoList, targetDatabase, tablePrefix)
 }
 
-func generateSQL(statementInfoList []statementInfo, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
+func generateSQL(ctx base.TransformContext, statementInfoList []statementInfo, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
 	var result []base.BackupStatement
 	offsetLength := 1
 	if len(statementInfoList) > 1 {
 		offsetLength = getOffsetLength(statementInfoList[len(statementInfoList)-1].offset)
 	}
 
+	version, ok := ctx.Version.(*Version)
+	if !ok {
+		version = &Version{
+			First:  11,
+			Second: 0,
+		}
+	}
+
 	for _, info := range statementInfoList {
 		table := info.table
 		targetTable := fmt.Sprintf("%s_%0*d_%s", tablePrefix, offsetLength, info.offset, table.Table)
-		targetTable, _ = common.TruncateString(targetTable, maxTableNameLength)
+		if version.GTE(&Version{First: 12, Second: 2}) {
+			targetTable, _ = common.TruncateString(targetTable, maxTableNameLengthAfter12_2)
+		} else {
+			targetTable, _ = common.TruncateString(targetTable, maxTableNameLengthBefore12_2)
+		}
 		var buf strings.Builder
 		if _, err := buf.WriteString(fmt.Sprintf(`CREATE TABLE "%s"."%s" AS SELECT `, targetDatabase, targetTable)); err != nil {
 			return nil, errors.Wrap(err, "failed to write to buffer")

--- a/backend/plugin/parser/plsql/backup_test.go
+++ b/backend/plugin/parser/plsql/backup_test.go
@@ -37,7 +37,7 @@ func TestBackup(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for i, t := range tests {
-		result, err := TransformDMLToSelect(t.Input, "db", "backupDB", "rollback")
+		result, err := TransformDMLToSelect(base.TransformContext{}, t.Input, "db", "backupDB", "rollback")
 		a.NoError(err)
 		sort.Slice(result, func(i, j int) bool {
 			if result[i].TableName == result[j].TableName {

--- a/backend/plugin/parser/tidb/backup.go
+++ b/backend/plugin/parser/tidb/backup.go
@@ -18,7 +18,7 @@ func init() {
 	base.RegisterTransformDMLToSelect(store.Engine_TIDB, TransformDMLToSelect)
 }
 
-func TransformDMLToSelect(statement string, sourceDatabase string, targetDatabase string, tableSuffix string) ([]base.BackupStatement, error) {
+func TransformDMLToSelect(_ base.TransformContext, statement string, sourceDatabase string, targetDatabase string, tableSuffix string) ([]base.BackupStatement, error) {
 	tableStatementMap, err := prepareTransformation(sourceDatabase, statement)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepare transformation")

--- a/backend/plugin/parser/tsql/backup.go
+++ b/backend/plugin/parser/tsql/backup.go
@@ -51,7 +51,7 @@ type statementInfo struct {
 	line      int
 }
 
-func TransformDMLToSelect(statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
+func TransformDMLToSelect(_ base.TransformContext, statement string, sourceDatabase string, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
 	statementInfoList, err := prepareTransformation(sourceDatabase, statement)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepare transformation")

--- a/backend/plugin/parser/tsql/backup_test.go
+++ b/backend/plugin/parser/tsql/backup_test.go
@@ -37,7 +37,7 @@ func TestBackup(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for i, t := range tests {
-		result, err := TransformDMLToSelect(t.Input, "db", "backupDB", "rollback")
+		result, err := TransformDMLToSelect(base.TransformContext{}, t.Input, "db", "backupDB", "rollback")
 		a.NoError(err)
 		sort.Slice(result, func(i, j int) bool {
 			if result[i].TableName == result[j].TableName {


### PR DESCRIPTION
<img width="1524" alt="image" src="https://github.com/bytebase/bytebase/assets/20775801/f1dec50a-1dd7-47e6-ac3a-d6b695344704">
<img width="1586" alt="image" src="https://github.com/bytebase/bytebase/assets/20775801/d9553738-176a-464a-a3b4-1a138f57fe55">
