### PR TITLE
chore: enter without semi will trigger execute for redis in sql editor admin mode

### DIFF
--- a/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
+++ b/frontend/src/views/sql-editor/TerminalPanel/CompactSQLEditor.vue
@@ -47,7 +47,7 @@ import {
   checkCursorAtFirstLine,
   checkCursorAtLast,
   checkCursorAtLastLine,
-  checkEndsWithSemicolon,
+  checkIsEnterEndsStatement,
 } from "./utils";
 
 const props = defineProps({
@@ -179,13 +179,13 @@ const handleEditorReady = (
   });
 
   // Create an editor context value to check if the SQL ends with semicolon ";"
-  const endsWithSemicolon = useEditorContextKey(
+  const isEnterEndsStatement = useEditorContextKey(
     editor,
-    "endsWithSemicolon",
-    checkEndsWithSemicolon(editor)
+    "isEnterEndsStatement",
+    checkIsEnterEndsStatement(editor, language.value)
   );
   editor.onDidChangeModelContent(() => {
-    endsWithSemicolon.set(checkEndsWithSemicolon(editor));
+    isEnterEndsStatement.set(checkIsEnterEndsStatement(editor, language.value));
   });
   // Another editor context value to check if the cursor is at the end of the
   // editor.
@@ -209,7 +209,7 @@ const handleEditorReady = (
     },
     // Tell the editor this should be only
     // triggered when both of the two conditions are satisfied.
-    "!readonly && endsWithSemicolon && cursorAtLast && editorTextFocus && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible"
+    "!readonly && isEnterEndsStatement && cursorAtLast && editorTextFocus && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible"
   );
 
   const cursorAtFirstLine = useEditorContextKey(

--- a/frontend/src/views/sql-editor/TerminalPanel/utils.ts
+++ b/frontend/src/views/sql-editor/TerminalPanel/utils.ts
@@ -1,13 +1,17 @@
 import type { editor as Editor } from "monaco-editor";
+import type { Language } from "@/types";
 
-export const checkEndsWithSemicolon = (
-  editor: Editor.IStandaloneCodeEditor
+export const checkIsEnterEndsStatement = (
+  editor: Editor.IStandaloneCodeEditor,
+  lang: Language
 ): boolean => {
   const value = editor.getValue();
-  if (value.endsWith(";")) {
-    return true;
+  switch (lang) {
+    case "redis":
+      return true;
+    default:
+      return value.endsWith(";");
   }
-  return false;
 };
 
 export const checkCursorAtLast = (


### PR DESCRIPTION
If I typed `GET a;`, the key is `a;` instead of `a`.