### PR TITLE
chore: remove sql editor button in database table

### DIFF
--- a/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/AlterSchemaPrepForm.vue
@@ -151,7 +151,6 @@
                 </div>
                 <DatabaseV1Table
                   mode="ALL_SHORT"
-                  :show-sql-editor-button="false"
                   :database-list="selectableDatabaseList"
                   @update:selected-databases="handleDatabasesSelectionChanged"
                 />

--- a/frontend/src/components/AlterSchemaPrepForm/SchemalessDatabaseTable.vue
+++ b/frontend/src/components/AlterSchemaPrepForm/SchemalessDatabaseTable.vue
@@ -11,7 +11,6 @@
       :schemaless="true"
       :database-list="databaseList"
       :show-selection="false"
-      :show-sql-editor-button="false"
     />
   </div>
 </template>

--- a/frontend/src/components/DataExportPrepForm/DataExportPrepForm.vue
+++ b/frontend/src/components/DataExportPrepForm/DataExportPrepForm.vue
@@ -28,7 +28,6 @@
           <DatabaseV1Table
             mode="ALL_SHORT"
             :database-list="filteredDatabaseList"
-            :show-sql-editor-button="false"
             :single-selection="true"
             @update:selected-databases="handleDatabasesSelectionChanged"
           />

--- a/frontend/src/components/DatabaseInfo.vue
+++ b/frontend/src/components/DatabaseInfo.vue
@@ -43,21 +43,17 @@
           :text-class="link ? 'hover:underline' : ''"
         />
       </template>
-
-      <SQLEditorButtonV1 v-if="showSQLEditorButton" :database="database" />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { SQLEditorButtonV1 } from "@/components/DatabaseDetail";
 import { DatabaseV1Name, InstanceV1Name } from "@/components/v2";
 import type { ComposedDatabase } from "@/types";
 
 withDefaults(
   defineProps<{
     database: ComposedDatabase;
-    showSQLEditorButton?: boolean;
     link?: boolean;
   }>(),
   {

--- a/frontend/src/components/IssueV1/components/StageSection/StageInfo/DatabaseInfo.vue
+++ b/frontend/src/components/IssueV1/components/StageSection/StageInfo/DatabaseInfo.vue
@@ -62,8 +62,6 @@
             : $t("task.database-create.pending")
         }}
       </span>
-
-      <SQLEditorButtonV1 v-if="showSQLEditorButton" :database="database" />
     </div>
   </div>
 </template>
@@ -71,10 +69,9 @@
 <script lang="ts" setup>
 import { computedAsync } from "@vueuse/core";
 import { computed } from "vue";
-import { SQLEditorButtonV1 } from "@/components/DatabaseDetail";
 import { databaseForTask, useIssueContext } from "@/components/IssueV1/logic";
 import { DatabaseV1Name, InstanceV1Name } from "@/components/v2";
-import { useDatabaseV1Store, usePageMode } from "@/store";
+import { useDatabaseV1Store } from "@/store";
 import { UNKNOWN_ID } from "@/types";
 import { Task_Status, Task_Type } from "@/types/proto/v1/rollout_service";
 
@@ -90,7 +87,6 @@ withDefaults(
 );
 
 const { issue, selectedTask } = useIssueContext();
-const pageMode = usePageMode();
 
 const coreDatabaseInfo = computed(() => {
   return databaseForTask(issue.value, selectedTask.value);
@@ -123,8 +119,4 @@ const database = computedAsync(async () => {
   }
   return undefined;
 }, undefined);
-
-const showSQLEditorButton = computed(() => {
-  return pageMode.value === "BUNDLED" && database.value;
-});
 </script>

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
@@ -53,14 +53,12 @@ const props = withDefaults(
     singleSelection?: boolean;
     schemaless?: boolean;
     customClick?: boolean;
-    showSqlEditorButton?: boolean;
     rowClickable?: boolean;
   }>(),
   {
     mode: "ALL",
     bordered: true,
     showSelection: true,
-    showSqlEditorButton: true,
     rowClickable: true,
   }
 );
@@ -93,12 +91,7 @@ const columnList = computed((): DatabaseDataTableColumn[] => {
     title: t("common.name"),
     resizable: true,
     render: (data) => {
-      return (
-        <DatabaseNameCell
-          database={data as ComposedDatabase}
-          showSQLEditorButton={props.showSqlEditorButton}
-        />
-      );
+      return <DatabaseNameCell database={data as ComposedDatabase} />;
     },
   };
   const ENVIRONMENT: DatabaseDataTableColumn = {

--- a/frontend/src/components/v2/Model/DatabaseV1Table/cells/DatabaseNameCell.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/cells/DatabaseNameCell.vue
@@ -1,39 +1,14 @@
 <template>
   <div class="flex items-center space-x-2">
-    <SQLEditorButtonV1
-      v-if="showSQLEditorButton"
-      :database="database"
-      :disabled="!allowQuery"
-      :tooltip="true"
-      @failed="handleGotoSQLEditorFailed"
-    />
     <DatabaseV1Name :database="database" :link="false" tag="span" />
   </div>
 </template>
 
 <script setup lang="ts">
-import SQLEditorButtonV1 from "@/components/DatabaseDetail/SQLEditorButtonV1.vue";
 import { DatabaseV1Name } from "@/components/v2";
-import { pushNotification, useCurrentUserV1 } from "@/store";
 import type { ComposedDatabase } from "@/types";
-import { isDatabaseV1Queryable } from "@/utils";
 
-const props = defineProps<{
+defineProps<{
   database: ComposedDatabase;
-  showSQLEditorButton: boolean;
 }>();
-
-const currentUser = useCurrentUserV1();
-
-const allowQuery = () => {
-  return isDatabaseV1Queryable(props.database, currentUser.value);
-};
-
-const handleGotoSQLEditorFailed = () => {
-  pushNotification({
-    module: "bytebase",
-    style: "CRITICAL",
-    title: `Failed to go to SQL editor for database ${props.database.name}`,
-  });
-};
 </script>

--- a/frontend/src/views/sql-editor/Setting/Project/Detail.vue
+++ b/frontend/src/views/sql-editor/Setting/Project/Detail.vue
@@ -23,7 +23,6 @@
         :database-list="databaseList"
         :custom-click="true"
         :show-selection="false"
-        :show-sql-editor-button="false"
         :row-clickable="false"
       />
     </div>


### PR DESCRIPTION
Only show SQL editor button in 
* database detail page;
* table detail drawer;
* external table detail drawer.