### PR TITLE
chore(sql-editor): use warning color for RO datasource indicator

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ReadonlyDatasourceHint.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ReadonlyDatasourceHint.vue
@@ -2,7 +2,7 @@
   <NPopover v-if="showReadonlyDatasourceHint" trigger="hover">
     <template #trigger>
       <TriangleAlertIcon
-        class="h-4 w-4 flex-shrink-0 text-info"
+        class="h-4 w-4 flex-shrink-0 text-warning"
         v-bind="$attrs"
       />
     </template>


### PR DESCRIPTION
<img width="676" alt="image" src="https://github.com/bytebase/bytebase/assets/2749742/21fcc6d6-0c19-4acd-aee8-af1223aa6063">

A temp way to BYT-5378. Not the final answer.