### PR TITLE
chore(frontend): performance optimization (part.2)

### DIFF
--- a/frontend/src/components/Branch/BranchCreateView.vue
+++ b/frontend/src/components/Branch/BranchCreateView.vue
@@ -145,7 +145,7 @@ const isPreparingBranch = ref(false);
 const EMPTY_BRANCH = Branch.fromPartial({});
 
 const allowCreateBranchFromDatabase = computed(() => {
-  return isOwnerOfProjectV1(props.project.iamPolicy, me.value);
+  return isOwnerOfProjectV1(props.project, me.value);
 });
 
 const debouncedDatabaseId = useDebounce(databaseId, DEBOUNCE_RATE);

--- a/frontend/src/components/Branch/BranchDetailView.vue
+++ b/frontend/src/components/Branch/BranchDetailView.vue
@@ -273,7 +273,7 @@ const showMergeBranchButton = computed(() => {
 const showRebaseBranchButton = computed(() => {
   // For main branches: only project owners are allowed
   if (!parentBranch.value) {
-    return isOwnerOfProjectV1(props.project.iamPolicy, currentUser.value);
+    return isOwnerOfProjectV1(props.project, currentUser.value);
   }
 
   // For feature branches: project owners and branch creator
@@ -284,7 +284,7 @@ const showRebaseBranchButton = computed(() => {
 const showApplyBranchButton = computed(() => {
   return (
     !parentBranch.value &&
-    isOwnerOfProjectV1(props.project.iamPolicy, currentUser.value)
+    isOwnerOfProjectV1(props.project, currentUser.value)
   );
 });
 

--- a/frontend/src/components/Branch/BranchMergeView/BranchMergeView.vue
+++ b/frontend/src/components/Branch/BranchMergeView/BranchMergeView.vue
@@ -145,7 +145,7 @@ const parentBranchOnly = computed(() => {
   if (!head.parentBranch) {
     return false; // parent-less (main) branches
   }
-  if (isOwnerOfProjectV1(props.project.iamPolicy, me.value)) {
+  if (isOwnerOfProjectV1(props.project, me.value)) {
     return false; // project owners are not limited
   }
   return true;

--- a/frontend/src/components/Branch/BranchRebaseView/BranchRebaseView.vue
+++ b/frontend/src/components/Branch/BranchRebaseView/BranchRebaseView.vue
@@ -183,7 +183,7 @@ const parentBranchOnly = computed(() => {
   if (!head.parentBranch) {
     return false; // parent-less (main) branches
   }
-  if (isOwnerOfProjectV1(props.project.iamPolicy, me.value)) {
+  if (isOwnerOfProjectV1(props.project, me.value)) {
     return false; // project owners are not limited
   }
   return true;

--- a/frontend/src/components/KBar/useDatabaseActions.ts
+++ b/frontend/src/components/KBar/useDatabaseActions.ts
@@ -86,21 +86,25 @@ const useDatabaseActions = (databaseList: MaybeRef<ComposedDatabase[]>) => {
 };
 
 export const useProjectDatabaseActions = (
-  project: MaybeRef<ComposedProject>
+  project: MaybeRef<ComposedProject>,
+  limit: number
 ) => {
   const projectDatabaseList = computed(() => {
-    return useDatabaseV1Store().databaseListByProject(unref(project).name);
+    return useDatabaseV1Store()
+      .databaseListByProject(unref(project).name)
+      .slice(0, limit); // Don't create too many actions
   });
   useDatabaseActions(projectDatabaseList);
 };
 
-export const useGlobalDatabaseActions = () => {
+export const useGlobalDatabaseActions = (limit: number) => {
   const me = useCurrentUserV1();
   // Use this to make the list reactive when project is transferred.
   const databaseList = computed(() => {
     return useDatabaseV1Store()
       .databaseListByUser(me.value)
-      .filter((db) => db.project !== DEFAULT_PROJECT_V1_NAME);
+      .filter((db) => db.project !== DEFAULT_PROJECT_V1_NAME)
+      .slice(0, limit); // Don't create too many actions
   });
   useDatabaseActions(databaseList);
 };

--- a/frontend/src/components/KBar/useProjectActions.ts
+++ b/frontend/src/components/KBar/useProjectActions.ts
@@ -7,7 +7,7 @@ import { useCurrentUserV1, useProjectV1List } from "@/store";
 import { DEFAULT_PROJECT_ID } from "@/types";
 import { hasProjectPermissionV2 } from "@/utils";
 
-export const useProjectActions = () => {
+export const useProjectActions = (limit: number) => {
   const { t } = useI18n();
   const router = useRouter();
   const me = useCurrentUserV1();
@@ -23,7 +23,7 @@ export const useProjectActions = () => {
   });
 
   const sortedProjectList = computed(() => {
-    return [...accessibleProjectList.value].sort((a, b) =>
+    return [...accessibleProjectList.value.slice(0, limit)].sort((a, b) =>
       a.title.localeCompare(b.title)
     );
   });

--- a/frontend/src/components/Project/ProjectSidebarV1.vue
+++ b/frontend/src/components/Project/ProjectSidebarV1.vue
@@ -86,5 +86,5 @@ const navigationKbarActions = computed(() => {
 });
 useRegisterActions(navigationKbarActions);
 
-useProjectDatabaseActions(project);
+useProjectDatabaseActions(project, 10);
 </script>

--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -57,9 +57,12 @@ const fetchDatabases = async (project: string) => {
   });
 };
 
+const instanceAndDatabaseInitialized = new Set<string /* project */>();
 const fetchInstancesAndDatabases = async (project: string) => {
+  if (instanceAndDatabaseInitialized.has(project || "")) return;
   await fetchInstances(project);
   await fetchDatabases(project);
+  instanceAndDatabaseInitialized.add(project || "");
 };
 
 onMounted(async () => {

--- a/frontend/src/components/ProvideDashboardContext.vue
+++ b/frontend/src/components/ProvideDashboardContext.vue
@@ -1,10 +1,18 @@
 <template>
-  <slot v-if="!isLoading" />
+  <slot v-if="!isInitializing" />
   <MaskSpinner v-else class="!bg-white" />
+
+  <div
+    v-if="!isInitializing && isSwitchingProject"
+    class="fixed inset-0 z-[1000000] bg-white/50 flex flex-col items-center justify-center"
+  >
+    <NSpin />
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, watch } from "vue";
+import { NSpin } from "naive-ui";
+import { ref, onMounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import {
   useEnvironmentV1Store,
@@ -24,7 +32,8 @@ import MaskSpinner from "./misc/MaskSpinner.vue";
 
 const route = useRoute();
 const router = useRouter();
-const isLoading = ref<boolean>(true);
+const isInitializing = ref<boolean>(true);
+const isSwitchingProject = ref(false);
 
 const policyStore = usePolicyV1Store();
 const databaseStore = useDatabaseV1Store();
@@ -47,6 +56,7 @@ const fetchDatabases = async (project: string) => {
     filter: filters.join(" && "),
   });
 };
+
 const fetchInstancesAndDatabases = async (project: string) => {
   await fetchInstances(project);
   await fetchDatabases(project);
@@ -74,14 +84,25 @@ onMounted(async () => {
   await Promise.all([useUIStateStore().restoreState()]);
   await fetchInstancesAndDatabases(route.params.projectId as string);
 
-  watch(
-    () => route.params.projectId,
-    (project) => {
-      fetchInstancesAndDatabases(project as string);
-    },
-    { immediate: false }
-  );
+  isInitializing.value = false;
 
-  isLoading.value = false;
+  router.beforeEach((to, from, next) => {
+    const fromProject = from.params.projectId as string;
+    const toProject = to.params.projectId as string;
+    if (fromProject !== toProject) {
+      console.debug(
+        `[ProvideDashboardContext] project switched ${fromProject} -> ${toProject}`
+      );
+      isSwitchingProject.value = true;
+      fetchInstancesAndDatabases(toProject).finally(() => {
+        isSwitchingProject.value = false;
+
+        next();
+      });
+      return;
+    }
+
+    next();
+  });
 });
 </script>

--- a/frontend/src/components/v2/Select/ProjectSelect.vue
+++ b/frontend/src/components/v2/Select/ProjectSelect.vue
@@ -22,7 +22,12 @@ import { NSelect } from "naive-ui";
 import { computed, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import { ProjectNameCell } from "@/components/v2/Model/DatabaseV1Table/cells";
-import { useCurrentUserV1, useProjectV1Store, useProjectV1List } from "@/store";
+import {
+  useCurrentUserV1,
+  useProjectV1Store,
+  useProjectV1List,
+  usePermissionStore,
+} from "@/store";
 import type { ComposedProject } from "@/types";
 import {
   DEFAULT_PROJECT_ID,
@@ -33,7 +38,7 @@ import {
 import { State } from "@/types/proto/v1/common";
 import type { Project } from "@/types/proto/v1/project_service";
 import { Workflow } from "@/types/proto/v1/project_service";
-import { hasWorkspacePermissionV2, roleListInProjectV1 } from "@/utils";
+import { hasWorkspacePermissionV2 } from "@/utils";
 
 interface ProjectSelectOption extends SelectOption {
   value: string;
@@ -77,6 +82,7 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const currentUserV1 = useCurrentUserV1();
 const projectV1Store = useProjectV1Store();
+const permissionStore = usePermissionStore();
 
 const prepare = () => {
   projectV1Store.fetchProjectList(true /* showDeleted */);
@@ -146,7 +152,10 @@ const combinedProjectList = computed(() => {
     props.allowedProjectRoleList.length > 0
   ) {
     list = list.filter((project) => {
-      const roles = roleListInProjectV1(project.iamPolicy, currentUserV1.value);
+      const roles = permissionStore.roleListInProjectV1(
+        project,
+        currentUserV1.value
+      );
       return intersection(props.allowedProjectRoleList, roles).length > 0;
     });
   }

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -3,99 +3,99 @@
     <div class="flex-1 flex overflow-hidden">
       <HideInStandaloneMode>
         <!-- Off-canvas menu for mobile, show/hide based on off-canvas menu state. -->
-        <div v-if="state.showMobileOverlay" class="md:hidden">
-          <div class="fixed inset-0 flex z-40">
-            <div class="fixed inset-0">
-              <div
-                class="absolute inset-0 bg-gray-600 opacity-75"
+        <div
+          v-show="state.showMobileOverlay"
+          :class="[sidebarView === 'MOBILE' ? 'block' : 'hidden']"
+          class="fixed inset-0 flex z-40"
+        >
+          <div class="fixed inset-0">
+            <div
+              class="absolute inset-0 bg-gray-600 opacity-75"
+              @click.prevent="state.showMobileOverlay = false"
+            ></div>
+          </div>
+          <div
+            tabindex="0"
+            class="relative flex-1 flex flex-col max-w-xs w-full bg-white focus:outline-none"
+          >
+            <div class="absolute top-0 right-0 -mr-12 pt-2">
+              <button
+                type="button"
+                class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
                 @click.prevent="state.showMobileOverlay = false"
-              ></div>
+              >
+                <span class="sr-only">Close sidebar</span>
+                <!-- Heroicon name: x -->
+                <heroicons-solid:x class="h-6 w-6 text-white" />
+              </button>
+            </div>
+            <!-- Mobile Sidebar -->
+            <div id="sidebar-mobile" class="flex-1 h-0 py-0 overflow-y-auto">
+              <!-- Empty as teleport placeholder -->
             </div>
             <div
-              tabindex="0"
-              class="relative flex-1 flex flex-col max-w-xs w-full bg-white focus:outline-none"
+              class="flex-shrink-0 flex border-t border-block-border px-3 py-1.5"
             >
-              <div class="absolute top-0 right-0 -mr-12 pt-2">
-                <button
-                  type="button"
-                  class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
-                  @click.prevent="state.showMobileOverlay = false"
-                >
-                  <span class="sr-only">Close sidebar</span>
-                  <!-- Heroicon name: x -->
-                  <heroicons-solid:x class="h-6 w-6 text-white" />
-                </button>
-              </div>
-              <!-- Mobile Sidebar -->
-              <div class="flex-1 h-0 py-0 overflow-y-auto">
-                <router-view
-                  name="leftSidebar"
-                  @click="state.showMobileOverlay = false"
+              <div
+                v-if="isDemo"
+                class="text-sm flex whitespace-nowrap text-accent"
+              >
+                <heroicons-outline:presentation-chart-bar
+                  class="w-5 h-5 mr-1"
                 />
+                {{ $t("common.demo-mode") }}
+              </div>
+              <router-link
+                v-else-if="!isFreePlan || !hasPermission"
+                :to="{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }"
+                exact-active-class=""
+                class="text-sm flex"
+              >
+                {{ $t(currentPlan) }}
+              </router-link>
+              <div
+                v-else
+                class="text-sm flex whitespace-nowrap mr-1 text-accent cursor-pointer"
+                @click="state.showTrialModal = true"
+              >
+                <heroicons-solid:sparkles class="w-5 h-5" />
+                {{ $t(currentPlan) }}
               </div>
               <div
-                class="flex-shrink-0 flex border-t border-block-border px-3 py-1.5"
+                class="text-sm flex items-center gap-x-1 ml-auto"
+                :class="
+                  canUpgrade
+                    ? 'text-success cursor-pointer'
+                    : 'text-control-light cursor-default'
+                "
+                @click="state.showReleaseModal = canUpgrade"
               >
-                <div
-                  v-if="isDemo"
-                  class="text-sm flex whitespace-nowrap text-accent"
-                >
-                  <heroicons-outline:presentation-chart-bar
-                    class="w-5 h-5 mr-1"
-                  />
-                  {{ $t("common.demo-mode") }}
-                </div>
-                <router-link
-                  v-else-if="!isFreePlan || !hasPermission"
-                  :to="{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }"
-                  exact-active-class=""
-                  class="text-sm flex"
-                >
-                  {{ $t(currentPlan) }}
-                </router-link>
-                <div
-                  v-else
-                  class="text-sm flex whitespace-nowrap mr-1 text-accent cursor-pointer"
-                  @click="state.showTrialModal = true"
-                >
-                  <heroicons-solid:sparkles class="w-5 h-5" />
-                  {{ $t(currentPlan) }}
-                </div>
-                <div
-                  class="text-sm flex items-center gap-x-1 ml-auto"
-                  :class="
-                    canUpgrade
-                      ? 'text-success cursor-pointer'
-                      : 'text-control-light cursor-default'
-                  "
-                  @click="state.showReleaseModal = canUpgrade"
-                >
-                  <heroicons-outline:volume-up
-                    v-if="canUpgrade"
-                    class="h-4 w-4"
-                  />
-                  {{ version }}
-                </div>
+                <heroicons-outline:volume-up
+                  v-if="canUpgrade"
+                  class="h-4 w-4"
+                />
+                {{ version }}
               </div>
             </div>
-            <div class="flex-shrink-0 w-14" aria-hidden="true">
-              <!-- Force sidebar to shrink to fit close icon -->
-            </div>
+          </div>
+          <div class="flex-shrink-0 w-14" aria-hidden="true">
+            <!-- Force sidebar to shrink to fit close icon -->
           </div>
         </div>
 
         <!-- Static sidebar for desktop -->
         <aside
-          class="hidden md:flex md:flex-shrink-0"
+          class="flex-shrink-0"
           data-label="bb-dashboard-static-sidebar"
+          :class="[sidebarView === 'DESKTOP' ? 'flex' : 'hidden']"
         >
           <div class="flex flex-col w-52 bg-control-bg">
             <!-- Sidebar component, swap this element with another sidebar if you like -->
-            <div class="flex-1 flex flex-col py-0 overflow-y-auto">
-              <router-view
-                name="leftSidebar"
-                @click="state.showMobileOverlay = false"
-              />
+            <div
+              id="sidebar-desktop"
+              class="flex-1 flex flex-col py-0 overflow-y-auto"
+            >
+              <!-- Empty as teleport placeholder -->
             </div>
             <div
               class="flex-shrink-0 flex justify-between border-t border-block-border px-3 py-1.5"
@@ -156,6 +156,20 @@
             </div>
           </div>
         </aside>
+
+        <!--
+          Do not render two instances of sidebars to desktop and mobile sidebars
+          but render one sidebar and teleport it to a correct container when
+          screen size varies
+        -->
+        <teleport
+          v-if="mounted"
+          :to="
+            sidebarView === 'DESKTOP' ? '#sidebar-desktop' : '#sidebar-mobile'
+          "
+        >
+          <router-view name="leftSidebar" />
+        </teleport>
       </HideInStandaloneMode>
 
       <div
@@ -239,6 +253,7 @@
 </template>
 
 <script lang="ts" setup>
+import { useMounted, useWindowSize } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
@@ -267,6 +282,7 @@ interface LocalState {
 const actuatorStore = useActuatorV1Store();
 const subscriptionStore = useSubscriptionV1Store();
 const router = useRouter();
+const mounted = useMounted();
 
 const state = reactive<LocalState>({
   showMobileOverlay: false,
@@ -276,10 +292,14 @@ const state = reactive<LocalState>({
 
 const currentUserV1 = useCurrentUserV1();
 const mainContainerRef = ref<HTMLDivElement>();
+const { width: windowWidth } = useWindowSize();
 
-const hasPermission = hasWorkspacePermissionV2(
-  currentUserV1.value,
-  "bb.settings.set"
+const sidebarView = computed(() => {
+  return windowWidth.value >= 768 ? "DESKTOP" : "MOBILE";
+});
+
+const hasPermission = computed(() =>
+  hasWorkspacePermissionV2(currentUserV1.value, "bb.settings.set")
 );
 
 const { pageMode, isDemo } = storeToRefs(actuatorStore);
@@ -336,7 +356,7 @@ const currentPlan = computed((): string => {
     case PlanType.ENTERPRISE:
       return "subscription.plan.enterprise.title";
     default:
-      if (hasPermission) {
+      if (hasPermission.value) {
         return "subscription.plan.try";
       }
       return "subscription.plan.free.title";

--- a/frontend/src/store/modules/v1/index.ts
+++ b/frontend/src/store/modules/v1/index.ts
@@ -25,3 +25,4 @@ export * from "./changelist";
 export * from "./issueComment";
 export * from "./auditLog";
 export * from "./userGroup";
+export * from "./permission";

--- a/frontend/src/store/modules/v1/permission.ts
+++ b/frontend/src/store/modules/v1/permission.ts
@@ -1,0 +1,154 @@
+import { uniq } from "lodash-es";
+import { defineStore } from "pinia";
+import { shallowReactive } from "vue";
+import {
+  ALL_USERS_USER_EMAIL,
+  getUserEmailInBinding,
+  groupBindingPrefix,
+  PRESET_WORKSPACE_ROLES,
+  type ComposedProject,
+  type ProjectPermission,
+  type WorkspacePermission,
+} from "@/types";
+import type { User } from "@/types/proto/v1/auth_service";
+import { isBindingPolicyExpired } from "@/utils";
+import { useRoleStore } from "../role";
+import { userNamePrefix } from "./common";
+import { useUserGroupStore } from "./userGroup";
+
+export const usePermissionStore = defineStore("permission", () => {
+  const projectRoleListCache = shallowReactive(new Map<string, string[]>());
+  const projectPermissionsCache = shallowReactive(
+    new Map<string, Set<ProjectPermission>>()
+  );
+  const workspaceLevelPermissionsMapByUserName = shallowReactive(
+    new Map<string, Set<WorkspacePermission | ProjectPermission>>()
+  );
+  const roleStore = useRoleStore();
+
+  const workspaceLevelPermissionsByUser = (
+    user: User
+  ): Set<WorkspacePermission | ProjectPermission> => {
+    const cached = workspaceLevelPermissionsMapByUserName.get(user.name);
+    if (cached) {
+      return cached;
+    }
+    const roleStore = useRoleStore();
+    const permissions = new Set(
+      user.roles
+        .map((role) => roleStore.getRoleByName(role))
+        .flatMap(
+          (role) =>
+            (role ? role.permissions : []) as (
+              | WorkspacePermission
+              | ProjectPermission
+            )[]
+        )
+    );
+    workspaceLevelPermissionsMapByUserName.set(user.name, permissions);
+    return permissions;
+  };
+
+  const roleListInProjectV1 = (project: ComposedProject, user: User) => {
+    const key = `${user.name}@@${project.name}`;
+    const cached = projectRoleListCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const groupStore = useUserGroupStore();
+    const userInBinding = getUserEmailInBinding(user.email);
+
+    const workspaceLevelProjectRoles = user.roles.filter(
+      (role) => !PRESET_WORKSPACE_ROLES.includes(role)
+    );
+
+    const { iamPolicy } = project;
+    const projectBindingRoles = iamPolicy.bindings
+      .filter((binding) => {
+        if (isBindingPolicyExpired(binding)) {
+          return false;
+        }
+        for (const member of binding.members) {
+          if (member === ALL_USERS_USER_EMAIL) {
+            return true;
+          }
+          if (member === userInBinding) {
+            return true;
+          }
+
+          if (member.startsWith(groupBindingPrefix)) {
+            const group = groupStore.getGroupByIdentifier(member);
+            if (!group) {
+              continue;
+            }
+
+            return group.members.some(
+              (m) => m.member === `${userNamePrefix}${user.email}`
+            );
+          }
+        }
+        return false;
+      })
+      .map((binding) => binding.role);
+
+    const result = uniq([
+      ...projectBindingRoles,
+      ...workspaceLevelProjectRoles,
+    ]);
+    projectRoleListCache.set(key, result);
+    return result;
+  };
+
+  const permissionsInProjectV1 = (project: ComposedProject, user: User) => {
+    const key = `${user.name}@@${project.name}`;
+    const cached = projectPermissionsCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const roles = roleListInProjectV1(project, user);
+    const permissions = new Set(
+      roles
+        .map((role) => roleStore.getRoleByName(role))
+        .flatMap(
+          (role) => (role ? role.permissions : []) as ProjectPermission[]
+        )
+    );
+    projectPermissionsCache.set(key, permissions);
+    return permissions;
+  };
+
+  const invalidCacheByProject = (project: string) => {
+    const roleListKeys = Array.from(projectRoleListCache.keys()).filter((key) =>
+      key.endsWith(`@@${project}`)
+    );
+    roleListKeys.forEach((key) => projectRoleListCache.delete(key));
+
+    const permissionsKeys = Array.from(projectPermissionsCache.keys()).filter(
+      (key) => key.endsWith(`@@${project}`)
+    );
+    permissionsKeys.forEach((key) => projectPermissionsCache.delete(key));
+  };
+  const invalidCacheByUser = (user: User) => {
+    workspaceLevelPermissionsMapByUserName.delete(user.name);
+
+    const roleListKeys = Array.from(projectRoleListCache.keys()).filter((key) =>
+      key.startsWith(`${user.name}@@`)
+    );
+    roleListKeys.forEach((key) => projectRoleListCache.delete(key));
+
+    const permissionsKeys = Array.from(projectPermissionsCache.keys()).filter(
+      (key) => key.startsWith(`${user.name}@@`)
+    );
+    permissionsKeys.forEach((key) => projectPermissionsCache.delete(key));
+  };
+
+  return {
+    workspaceLevelPermissionsByUser,
+    roleListInProjectV1,
+    permissionsInProjectV1,
+    invalidCacheByProject,
+    invalidCacheByUser,
+  };
+});

--- a/frontend/src/store/modules/v1/projectIamPolicy.ts
+++ b/frontend/src/store/modules/v1/projectIamPolicy.ts
@@ -14,6 +14,7 @@ import {
 import { getUserEmailListInBinding, memberListInProjectV1 } from "@/utils";
 import { convertFromExpr } from "@/utils/issue/cel";
 import { useCurrentUserV1 } from "../auth";
+import { usePermissionStore } from "./permission";
 import { useProjectV1Store } from "./project";
 
 export const useProjectIamPolicyStore = defineStore(
@@ -71,6 +72,8 @@ export const useProjectIamPolicyStore = defineStore(
         policy,
       });
       policyMap.value.set(project, updated);
+
+      usePermissionStore().invalidCacheByProject(project);
     };
 
     const getProjectIamPolicy = (project: string) => {
@@ -157,13 +160,17 @@ export const useCurrentUserIamPolicy = () => {
       return true;
     }
 
+    const project = projectStore.getProjectByName(projectName);
+    if (!project) {
+      return false;
+    }
     const policy = iamPolicyStore.policyMap.get(projectName);
     if (!policy) {
       return false;
     }
     return (
-      isOwnerOfProjectV1(policy, currentUser.value) ||
-      isDeveloperOfProjectV1(policy, currentUser.value)
+      isOwnerOfProjectV1(project, currentUser.value) ||
+      isDeveloperOfProjectV1(project, currentUser.value)
     );
   };
 
@@ -176,9 +183,13 @@ export const useCurrentUserIamPolicy = () => {
     if (!policy) {
       return false;
     }
+    const project = projectStore.getProjectByName(projectName);
+    if (!project) {
+      return false;
+    }
     return (
       isProjectOwnerOrDeveloper(projectName) ||
-      isViewerOfProjectV1(policy, currentUser.value)
+      isViewerOfProjectV1(project, currentUser.value)
     );
   };
 

--- a/frontend/src/utils/iam/permission.ts
+++ b/frontend/src/utils/iam/permission.ts
@@ -5,30 +5,14 @@ import type {
   WorkspacePermission,
 } from "@/types";
 import type { User } from "@/types/proto/v1/auth_service";
-import { TinyTimer } from "../TinyTimer";
-
-const timer = new TinyTimer<
-  | "hasWorkspacePermissionV2"
-  | "hasProjectPermissionV2.1"
-  | "hasProjectPermissionV2.2"
-  | "hasProjectPermissionV2.3"
-  | "hasProjectPermissionV2.3.1"
-  | "hasProjectPermissionV2.3.2"
-  | "hasWorkspaceLevelProjectPermission"
-  | "hasWorkspaceLevelProjectPermissionInAnyProject"
->("permission");
-(window as any).__permissionTimer = timer;
 
 export const hasWorkspacePermissionV2 = (
   user: User,
   permission: WorkspacePermission
 ): boolean => {
-  timer.begin("hasWorkspacePermissionV2");
   const permissions =
     usePermissionStore().workspaceLevelPermissionsByUser(user);
-  const ok = permissions.has(permission);
-  timer.end("hasWorkspacePermissionV2");
-  return ok;
+  return permissions.has(permission);
 };
 
 // hasProjectPermissionV2 checks if the user has the given permission on the project.
@@ -39,43 +23,25 @@ export const hasProjectPermissionV2 = (
 ): boolean => {
   const permissionStore = usePermissionStore();
 
-  timer.begin("hasProjectPermissionV2.1");
   // If the project is not provided, then check if the user has the given permission on any project in the workspace.
   if (!project) {
     const { projectList } = useProjectV1List();
-    const ok = projectList.value.some((project) =>
+    return projectList.value.some((project) =>
       hasProjectPermissionV2(project, user, permission)
     );
-    timer.end("hasProjectPermissionV2.1", projectList.value.length);
-    return ok;
-  } else {
-    timer.end("hasProjectPermissionV2.1");
   }
-
-  timer.begin("hasProjectPermissionV2.2");
 
   // Check workspace-level permissions first.
   // For those users who have workspace-level project roles, they should have all project-level permissions.
   const workspaceLevelPermissions =
     permissionStore.workspaceLevelPermissionsByUser(user);
-
   if (workspaceLevelPermissions.has(permission)) {
-    timer.end("hasProjectPermissionV2.2", workspaceLevelPermissions.size);
     return true;
-  } else {
-    timer.end("hasProjectPermissionV2.2", workspaceLevelPermissions.size);
   }
 
-  timer.begin("hasProjectPermissionV2.3");
   // Check project-level permissions.
-
-  timer.begin("hasProjectPermissionV2.3.2");
   const permissions = permissionStore.permissionsInProjectV1(project, user);
-  timer.end("hasProjectPermissionV2.3.2");
-  const ok = permissions.has(permission);
-  timer.end("hasProjectPermissionV2.3", permissions.size);
-
-  return ok;
+  return permissions.has(permission);
 };
 
 // hasWorkspaceLevelProjectPermission checks if the user has the given permission on workspace-level-assigned project roles
@@ -83,12 +49,9 @@ export const hasWorkspaceLevelProjectPermission = (
   user: User,
   permission: ProjectPermission
 ): boolean => {
-  timer.begin("hasWorkspaceLevelProjectPermission");
   const permissions =
     usePermissionStore().workspaceLevelPermissionsByUser(user);
-  const ok = permissions.has(permission);
-  timer.end("hasWorkspaceLevelProjectPermission");
-  return ok;
+  return permissions.has(permission);
 };
 
 // hasWorkspaceLevelProjectPermission checks if the user has the given permission on ANY project in the workspace.
@@ -96,11 +59,8 @@ export const hasWorkspaceLevelProjectPermissionInAnyProject = (
   user: User,
   permission: ProjectPermission
 ): boolean => {
-  timer.begin("hasWorkspaceLevelProjectPermissionInAnyProject");
   const { projectList } = useProjectV1List();
-  const ok = projectList.value.some((project) =>
+  return projectList.value.some((project) =>
     hasProjectPermissionV2(project, user, permission)
   );
-  timer.end("hasWorkspaceLevelProjectPermissionInAnyProject");
-  return ok;
 };

--- a/frontend/src/utils/v1/database.ts
+++ b/frontend/src/utils/v1/database.ts
@@ -96,8 +96,8 @@ export const isDatabaseV1Alterable = (
 
   // If user is owner or developer of its projects, we will show the database in the UI.
   if (
-    isOwnerOfProjectV1(database.projectEntity.iamPolicy, user) ||
-    isDeveloperOfProjectV1(database.projectEntity.iamPolicy, user)
+    isOwnerOfProjectV1(database.projectEntity, user) ||
+    isDeveloperOfProjectV1(database.projectEntity, user)
   ) {
     return true;
   }

--- a/frontend/src/utils/v1/worksheet.ts
+++ b/frontend/src/utils/v1/worksheet.ts
@@ -36,7 +36,7 @@ export const isWorksheetReadableV1 = (sheet: Worksheet) => {
     case Worksheet_Visibility.VISIBILITY_PROJECT_READ:
     case Worksheet_Visibility.VISIBILITY_PROJECT_WRITE: {
       const projectV1 = useProjectV1Store().getProjectByName(sheet.project);
-      return isMemberOfProjectV1(projectV1.iamPolicy, currentUserV1.value);
+      return isMemberOfProjectV1(projectV1, currentUserV1.value);
     }
   }
   return false;
@@ -65,9 +65,9 @@ export const isWorksheetWritableV1 = (sheet: Worksheet) => {
     case Worksheet_Visibility.VISIBILITY_PRIVATE:
       return false;
     case Worksheet_Visibility.VISIBILITY_PROJECT_WRITE:
-      return isMemberOfProjectV1(projectV1.iamPolicy, currentUserV1.value);
+      return isMemberOfProjectV1(projectV1, currentUserV1.value);
     case Worksheet_Visibility.VISIBILITY_PROJECT_READ:
-      return isOwnerOfProjectV1(projectV1.iamPolicy, currentUserV1.value);
+      return isOwnerOfProjectV1(projectV1, currentUserV1.value);
   }
 
   return false;

--- a/frontend/src/views/DashboardSidebar.vue
+++ b/frontend/src/views/DashboardSidebar.vue
@@ -1,6 +1,7 @@
 <template>
   <!-- Navigation -->
   <CommonSidebar
+    :key="'dashboard'"
     :item-list="dashboardSidebarItemList"
     :get-item-class="getItemClass"
   />

--- a/frontend/src/views/DashboardSidebar.vue
+++ b/frontend/src/views/DashboardSidebar.vue
@@ -1,7 +1,6 @@
 <template>
   <!-- Navigation -->
   <CommonSidebar
-    :key="'dashboard'"
     :item-list="dashboardSidebarItemList"
     :get-item-class="getItemClass"
   />
@@ -349,6 +348,6 @@ const navigationKbarActions = computed((): Action[] => {
 });
 useRegisterActions(navigationKbarActions);
 
-useProjectActions();
-useGlobalDatabaseActions();
+useProjectActions(10);
+useGlobalDatabaseActions(10);
 </script>


### PR DESCRIPTION
- Add a full-screen mask spinner when needed. Especially switching between projects or the workspace. (Will fetch instance and database resources, which might be slow). Blocking users from clicking the page elements too quickly. This request will be cached if possible.
- [IMPORTANT] permission module refactored
  - Cache workspace-level and project-level permission calculation results, which might be called tens of thousands of times. The cache entries will be and should be expired manually when a user is updated (e.g. role changed) or a `projectIamPolicy` is updated (e.g. a project's iam bindings changed).
  - Permission check utility functions have been refactored to `usePermissionStore`.
- Optimize `<BodyLayout>` implementation, will not render 2 `<router-view>`s for desktop/mobile view's sidebars.
