### PR TITLE
fix: nil map error

### DIFF
--- a/backend/store/role.go
+++ b/backend/store/role.go
@@ -160,7 +160,9 @@ func (s *Store) ListRoles(ctx context.Context) ([]*RoleMessage, error) {
 	)
 
 	for rows.Next() {
-		role := &RoleMessage{}
+		role := &RoleMessage{
+			Permissions: map[string]bool{},
+		}
 		var permissionBytes []byte
 		if err := rows.Scan(&role.CreatorID, &role.ResourceID, &role.Name, &role.Description, &permissionBytes); err != nil {
 			return nil, err


### PR DESCRIPTION
fix the following error in the latest main branch

```
time=2024-07-12T13:46:42.850+08:00 level=ERROR source=server/server.go:291 msg="v1 server panic error" error="error: assignment to entry in nil map\nruntime.mapassign_faststr\n\t/usr/local/go/src/runtime/map_faststr.go:205\ngithub.com/bytebase/bytebase/backend/store.(*Store).ListRoles\n\t/Users/steven/Projects/bytebase/bytebase/backend/store/role.go:173\ngithub.com/bytebase/bytebase/backend/api/v1.(*RoleService).ListRoles\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/role_service.go:40\ngithub.com/bytebase/bytebase/proto/generated-go/v1._RoleService_ListRoles_Handler.func1\n\t/Users/steven/Projects/bytebase/bytebase/proto/generated-go/v1/role_service_grpc.pb.go:140\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1\n\t/Users/steven/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:34\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*AuditInterceptor).AuditInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/audit.go:95\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*ACLInterceptor).ACLInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/acl.go:64\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*ContextProvider).UnaryInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/ctx.go:38\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/auth.(*APIAuthInterceptor).AuthenticationInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/auth/auth.go:104\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*DebugInterceptor).DebugInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/debug_interceptor.go:41\ngoogle.golang.org/grpc.chainUnaryInterceptors.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1187\ngithub.com/bytebase/bytebase/proto/generated-go/v1._RoleService_ListRoles_Handler\n\t/Users/steven/Projects/bytebase/bytebase/proto/generated-go/v1/role_service_grpc.pb.go:142\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1379\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1790\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1029\ngithub.com/bytebase/bytebase/backend/server.NewServer.func2\n\t/Users/steven/Projects/bytebase/bytebase/backend/server/server.go:291\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.WithRecoveryHandler.func1.1\n\t/Users/steven/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/options.go:36\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.recoverFrom\n\t/Users/steven/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:54\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1.1\n\t/Users/steven/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:30\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:770\nruntime.mapassign_faststr\n\t/usr/local/go/src/runtime/map_faststr.go:205\ngithub.com/bytebase/bytebase/backend/store.(*Store).ListRoles\n\t/Users/steven/Projects/bytebase/bytebase/backend/store/role.go:173\ngithub.com/bytebase/bytebase/backend/api/v1.(*RoleService).ListRoles\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/role_service.go:40\ngithub.com/bytebase/bytebase/proto/generated-go/v1._RoleService_ListRoles_Handler.func1\n\t/Users/steven/Projects/bytebase/bytebase/proto/generated-go/v1/role_service_grpc.pb.go:140\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1\n\t/Users/steven/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:34\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*AuditInterceptor).AuditInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/audit.go:95\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*ACLInterceptor).ACLInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/acl.go:64\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*ContextProvider).UnaryInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/ctx.go:38\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/auth.(*APIAuthInterceptor).AuthenticationInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/auth/auth.go:104\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1196\ngithub.com/bytebase/bytebase/backend/api/v1.(*DebugInterceptor).DebugInterceptor\n\t/Users/steven/Projects/bytebase/bytebase/backend/api/v1/debug_interceptor.go:41\ngoogle.golang.org/grpc.chainUnaryInterceptors.func1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1187\ngithub.com/bytebase/bytebase/proto/generated-go/v1._RoleService_ListRoles_Handler\n\t/Users/steven/Projects/bytebase/bytebase/proto/generated-go/v1/role_service_grpc.pb.go:142\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1379\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1790\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\t/Users/steven/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1029\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1222"
```