### PR TITLE
chore: move setting foreign key checks

### DIFF
--- a/backend/plugin/parser/mysql/differ.go
+++ b/backend/plugin/parser/mysql/differ.go
@@ -21,11 +21,6 @@ func init() {
 	base.RegisterSchemaDiffFunc(storepb.Engine_OCEANBASE, SchemaDiff)
 }
 
-const (
-	disableFKCheckStmt string = "SET FOREIGN_KEY_CHECKS=0;\n\n"
-	enableFKCheckStmt  string = "SET FOREIGN_KEY_CHECKS=1;\n"
-)
-
 // SchemaDiffer is the parser for MySQL dialect.
 type SchemaDiffer struct {
 }
@@ -839,11 +834,7 @@ func (diff *diffNode) deparse() (string, error) {
 		return "", err
 	}
 
-	text := buf.String()
-	if len(text) > 0 {
-		return fmt.Sprintf("%s%s%s", disableFKCheckStmt, buf.String(), enableFKCheckStmt), nil
-	}
-	return "", nil
+	return buf.String(), nil
 }
 
 func sortAndWriteAlertTableOptionList(buf *strings.Builder, tableOptions []*tableOptionDef) error {

--- a/backend/plugin/parser/mysql/differ_test.go
+++ b/backend/plugin/parser/mysql/differ_test.go
@@ -52,7 +52,7 @@ func runDifferTest(t *testing.T, file string, record bool) {
 
 func TestSchemaDiffTable(t *testing.T) {
 	testFile := "test_differ_table.yaml"
-	runDifferTest(t, testFile, true /* record */)
+	runDifferTest(t, testFile, false /* record */)
 }
 
 func TestSchemaDiffColumn(t *testing.T) {

--- a/backend/plugin/parser/mysql/differ_test.go
+++ b/backend/plugin/parser/mysql/differ_test.go
@@ -33,12 +33,6 @@ func runDifferTest(t *testing.T, file string, record bool) {
 	for i, test := range tests {
 		diff, err := SchemaDiff(base.DiffContext{IgnoreCaseSensitive: false, StrictMode: true}, test.OldSchema, test.NewSchema)
 		require.NoErrorf(t, err, "Test Cases[%02d] Failed", i+1)
-		if len(diff) > 0 {
-			require.Equalf(t, disableFKCheckStmt, diff[:len(disableFKCheckStmt)], "Test Cases[%02d] Failed", i+1)
-			diff = diff[len(disableFKCheckStmt):]
-			require.Equalf(t, enableFKCheckStmt, diff[len(diff)-len(enableFKCheckStmt):], "Test Cases[%02d] Failed", i+1)
-			diff = diff[:len(diff)-len(enableFKCheckStmt)]
-		}
 		if record {
 			tests[i].Diff = diff
 		} else {
@@ -58,7 +52,7 @@ func runDifferTest(t *testing.T, file string, record bool) {
 
 func TestSchemaDiffTable(t *testing.T) {
 	testFile := "test_differ_table.yaml"
-	runDifferTest(t, testFile, false /* record */)
+	runDifferTest(t, testFile, true /* record */)
 }
 
 func TestSchemaDiffColumn(t *testing.T) {

--- a/backend/plugin/parser/tidb/differ.go
+++ b/backend/plugin/parser/tidb/differ.go
@@ -28,11 +28,6 @@ func init() {
 	base.RegisterSchemaDiffFunc(storepb.Engine_TIDB, SchemaDiff)
 }
 
-const (
-	disableFKCheckStmt string = "SET FOREIGN_KEY_CHECKS=0;\n\n"
-	enableFKCheckStmt  string = "SET FOREIGN_KEY_CHECKS=1;\n"
-)
-
 // diffNode defines different modification types as the safe change order.
 // The safe change order means we can change them with no dependency conflicts as this order.
 type diffNode struct {
@@ -460,11 +455,7 @@ func (diff *diffNode) deparse() (string, error) {
 		return "", err
 	}
 
-	text := buf.String()
-	if len(text) > 0 {
-		return fmt.Sprintf("%s%s%s", disableFKCheckStmt, buf.String(), enableFKCheckStmt), nil
-	}
-	return "", nil
+	return buf.String(), nil
 }
 
 // constraintMap returns a map of constraint name to constraint.

--- a/backend/plugin/parser/tidb/differ_test.go
+++ b/backend/plugin/parser/tidb/differ_test.go
@@ -22,12 +22,6 @@ func testDiffWithoutDisableForeignKeyCheck(t *testing.T, testCases []testCase) {
 			StrictMode:          true,
 		}, test.old, test.new)
 		a.NoError(err)
-		if len(out) > 0 {
-			a.Equal(disableFKCheckStmt, out[:len(disableFKCheckStmt)])
-			out = out[len(disableFKCheckStmt):]
-			a.Equal(enableFKCheckStmt, out[len(out)-len(enableFKCheckStmt):])
-			out = out[:len(out)-len(enableFKCheckStmt)]
-		}
 		a.Equalf(test.want, out, "old: %s\nnew: %s\n", test.old, test.new)
 	}
 }


### PR DESCRIPTION
Dropping table referenced by a foreign key is the only case we don't support well. But we probably should not allow users do so as it will leave the schema in a strange state.