### PR TITLE
chore: remove unnecessary blocking session icon

### DIFF
--- a/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunSession/PostgresSessionTable.vue
+++ b/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunSession/PostgresSessionTable.vue
@@ -9,7 +9,6 @@
     />
 
     <div class="pt-2 flex flex-row justify-start items-center">
-      <AlignHorizontalJustifyEndIcon class="w-4 h-auto mr-2 opacity-80" />
       <span class="textlabel">
         {{ $t("issue.task-run.task-run-session.blocking-sessions.self") }}
       </span>
@@ -49,10 +48,7 @@
 </template>
 
 <script setup lang="tsx">
-import {
-  AlignHorizontalJustifyEndIcon,
-  AlignHorizontalJustifyStartIcon,
-} from "lucide-vue-next";
+import { AlignHorizontalJustifyStartIcon } from "lucide-vue-next";
 import { NDataTable, type DataTableColumn } from "naive-ui";
 import { computed } from "vue";
 import {


### PR DESCRIPTION
![CleanShot 2024-08-02 at 15 27 43](https://github.com/user-attachments/assets/55738946-2099-4079-a012-9b3b3888d581)

We have space to put wording, no need to use an icon