### PR TITLE
fix: error message when explaining redis command

### DIFF
--- a/backend/plugin/db/redis/redis.go
+++ b/backend/plugin/db/redis/redis.go
@@ -224,7 +224,7 @@ func (*Driver) Dump(_ context.Context, _ io.Writer) (string, error) {
 // QueryConn queries a SQL statement in a given connection.
 func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, queryContext *db.QueryContext) ([]*v1pb.QueryResult, error) {
 	if queryContext != nil && queryContext.Explain {
-		return nil, errors.New("MongoDB does not support EXPLAIN")
+		return nil, errors.New("Redis does not support EXPLAIN")
 	}
 
 	startTime := time.Now()


### PR DESCRIPTION
fix wrong error message when explaining redis command, which was "MongoDB does not support EXPLAIN"