### PR TITLE
chore: return full view of db group in CreateDatabaseGroup/UpdateDatabaseGroup

### DIFF
--- a/backend/api/v1/database_group_service.go
+++ b/backend/api/v1/database_group_service.go
@@ -96,7 +96,7 @@ func (s *DatabaseGroupService) CreateDatabaseGroup(ctx context.Context, request 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
-	return convertStoreToAPIDatabaseGroupBasic(databaseGroup, projectResourceID), nil
+	return s.convertStoreToAPIDatabaseGroupFull(ctx, databaseGroup, projectResourceID)
 }
 
 // UpdateDatabaseGroup updates a database group.
@@ -163,7 +163,7 @@ func (s *DatabaseGroupService) UpdateDatabaseGroup(ctx context.Context, request 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
-	return convertStoreToAPIDatabaseGroupBasic(databaseGroup, projectResourceID), nil
+	return s.convertStoreToAPIDatabaseGroupFull(ctx, databaseGroup, projectResourceID)
 }
 
 // DeleteDatabaseGroup deletes a database group.


### PR DESCRIPTION
Close BYT-6057

Background: If only basic information is returned in CreateDatabaseGroup/UpdateDatabaseGroup, we need to call GetDatabaseGroup with full view in frontend to get the match/unmatched databases again.