### PR TITLE
chore(sql-editor): icons improvements

### DIFF
--- a/frontend/src/components/Icon/ColumnIcon.vue
+++ b/frontend/src/components/Icon/ColumnIcon.vue
@@ -17,4 +17,6 @@
   </svg>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+// Based on lucide:columns-3 and removing the second gap line
+</script>

--- a/frontend/src/components/Icon/ColumnIcon.vue
+++ b/frontend/src/components/Icon/ColumnIcon.vue
@@ -1,7 +1,20 @@
 <template>
-  <Columns2Icon v-bind="$attrs" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="lucide lucide-columns-3 text-gray-500"
+    v-bind="$attrs"
+  >
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="M9 3v18" />
+  </svg>
 </template>
 
-<script setup lang="ts">
-import { Columns2Icon } from "lucide-vue-next";
-</script>
+<script setup lang="ts"></script>

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/SchemaPane.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/SchemaPane.vue
@@ -282,6 +282,7 @@ watch(tree, () => {
 }
 .schema-tree :deep(.n-tree-node-indent) {
   width: 20px;
+  height: 20px;
 }
 .schema-tree :deep(.n-tree-node-switcher) {
   width: 20px !important;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ColumnNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ColumnNode.vue
@@ -1,23 +1,23 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <div class="w-4 h-4 inline-flex items-center justify-center">
+  <CommonNode
+    :text="target.column.name"
+    :keyword="keyword"
+    :highlight="true"
+    :indent="1"
+  >
+    <template #icon>
       <PrimaryKeyIcon v-if="isPrimaryKey" class="w-4 h-4" />
-      <IndexIcon v-else-if="isIndex" class="!w-4 !h-4 text-gray-500" />
+      <IndexIcon v-else-if="isIndex" class="!w-4 !h-4 text-accent/80" />
       <ColumnIcon v-else class="w-4 h-4" />
-    </div>
-    <HighlightLabelText
-      :text="target.column.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { ColumnIcon, IndexIcon, PrimaryKeyIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ColumnNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ColumnNode.vue
@@ -3,6 +3,7 @@
     <div class="w-4 h-4 inline-flex items-center justify-center">
       <PrimaryKeyIcon v-if="isPrimaryKey" class="w-4 h-4" />
       <IndexIcon v-else-if="isIndex" class="!w-4 !h-4 text-gray-500" />
+      <ColumnIcon v-else class="w-4 h-4" />
     </div>
     <HighlightLabelText
       :text="target.column.name"
@@ -14,7 +15,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { IndexIcon, PrimaryKeyIcon } from "@/components/Icon";
+import { ColumnIcon, IndexIcon, PrimaryKeyIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
 import HighlightLabelText from "./HighlightLabelText.vue";
 

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/CommonNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/CommonNode.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="flex items-center max-w-full overflow-hidden" v-bind="$attrs">
+    <slot name="default">
+      <span
+        v-for="i in indent"
+        :key="`indent-#${i}`"
+        class="inline-block w-[20px] h-[20px] shrink-0 invisible"
+        :data-indent="i"
+      />
+      <span class="flex items-center justify-center shrink-0 w-[20px] h-[20px]">
+        <slot name="icon" />
+      </span>
+      <slot name="text">
+        <HighlightLabelText
+          v-if="highlight"
+          :text="text"
+          :keyword="keyword ?? ''"
+          class="flex-1 truncate pl-[2px]"
+        />
+        <span v-else class="pl-[2px]">{{ text }}</span>
+      </slot>
+    </slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+import HighlightLabelText from "./HighlightLabelText.vue";
+
+defineProps<{
+  text: string;
+  indent?: number;
+  keyword?: string;
+  highlight?: boolean;
+}>();
+</script>

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DatabaseNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DatabaseNode.vue
@@ -1,18 +1,20 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <InstanceV1EngineIcon :instance="database.instanceResource" />
-
-    <span class="flex-1 truncate">
-      <HighlightLabelText :text="database.databaseName" :keyword="keyword" />
-    </span>
-  </div>
+  <CommonNode
+    :text="database.databaseName"
+    :keyword="keyword"
+    :highlight="true"
+  >
+    <template #icon>
+      <InstanceV1EngineIcon :instance="database.instanceResource" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { InstanceV1EngineIcon } from "@/components/v2";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DummyNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DummyNode.vue
@@ -1,7 +1,7 @@
 <template>
   <NPopover :disabled="!error">
     <template #trigger>
-      <span class="text-control-placeholder">{{ text }}</span>
+      <span class="text-control-placeholder ml-[2px]">{{ text }}</span>
     </template>
     <template #default>
       <div class="text-error max-w-[20rem] break-words break-all">

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ExternalTableNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ExternalTableNode.vue
@@ -1,19 +1,20 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <TableIcon class="w-4 h-4" />
-    <HighlightLabelText
-      :text="target.externalTable.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+  <CommonNode
+    :text="target.externalTable.name"
+    :keyword="keyword"
+    :highlight="true"
+  >
+    <template #icon>
+      <TableIcon class="w-4 h-4" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { TableIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/FunctionNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/FunctionNode.vue
@@ -1,19 +1,21 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <FunctionIcon class="w-4 h-4" />
-    <HighlightLabelText
-      :text="target.function.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+  <CommonNode
+    :text="target.function.name"
+    :keyword="keyword"
+    :highlight="true"
+    :indent="1"
+  >
+    <template #icon>
+      <FunctionIcon class="w-4 h-4" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { FunctionIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/PartitionTableNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/PartitionTableNode.vue
@@ -1,19 +1,21 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <TablePartitionIcon class="w-4 h-4" />
-    <HighlightLabelText
-      :text="target.partition.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+  <CommonNode
+    :text="target.partition.name"
+    :keyword="keyword"
+    :highlight="true"
+    :indent="target.partition.subpartitions.length > 0 ? 0 : 1"
+  >
+    <template #icon>
+      <TablePartitionIcon class="w-4 h-4" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { TablePartitionIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ProcedureNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ProcedureNode.vue
@@ -1,19 +1,21 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <ProcedureIcon class="w-4 h-4" />
-    <HighlightLabelText
-      :text="target.procedure.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+  <CommonNode
+    :text="target.procedure.name"
+    :keyword="keyword"
+    :highlight="true"
+    :indent="1"
+  >
+    <template #icon>
+      <ProcedureIcon class="w-4 h-4" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { ProcedureIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/SchemaNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/SchemaNode.vue
@@ -1,19 +1,16 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <SchemaIcon class="w-4 h-4"/>
-    <HighlightLabelText
-      :text="target.schema.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+  <CommonNode :text="target.schema.name" :keyword="keyword" :highlight="true">
+    <template #icon>
+      <SchemaIcon class="w-4 h-4" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { SchemaIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/TableNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/TableNode.vue
@@ -1,19 +1,16 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <TableIcon class="w-4 h-4" />
-    <HighlightLabelText
-      :text="target.table.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+  <CommonNode :text="target.table.name" :keyword="keyword" :highlight="true">
+    <template #icon>
+      <TableIcon class="w-4 h-4" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { TableIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/TextNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/TextNode.vue
@@ -1,25 +1,21 @@
 <template>
-  <div
-    class="flex flex-row items-center gap-x-1"
-    :data-mock-type="target.mockType"
-  >
-    <component :is="render" v-if="render" />
-
-    <template v-else>
-      <FolderIcon
-        v-if="isFolder"
-        class="w-4 h-4 stroke-accent fill-accent/10"
-      />
-      <span>{{ text }}</span>
+  <CommonNode :text="text" :highlight="false" :data-mock-type="type">
+    <template v-if="render" #default>
+      <component :is="render" />
     </template>
-  </div>
+
+    <template #icon>
+      <FolderIcon class="w-4 h-4 stroke-accent fill-accent/10" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { isFunction } from "lodash-es";
 import { FolderIcon } from "lucide-vue-next";
 import { computed } from "vue";
-import type { NodeType, TreeNode } from "../common";
+import type { TreeNode } from "../common";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;
@@ -32,19 +28,6 @@ const target = computed(() => {
 
 const type = computed(() => {
   return target.value.mockType;
-});
-
-const isFolder = computed(() => {
-  if (!type.value) return false;
-  const types: NodeType[] = [
-    "table",
-    "external-table",
-    "view",
-    "procedure",
-    "function",
-    "partition-table",
-  ];
-  return types.includes(type.value);
 });
 
 const text = computed(() => {

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/TextNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/TextNode.vue
@@ -3,32 +3,23 @@
     class="flex flex-row items-center gap-x-1"
     :data-mock-type="target.mockType"
   >
-    <TableIcon
-      v-if="type === 'table' || type === 'external-table'"
-      class="w-4"
-    />
-    <ViewIcon v-if="type === 'view'" class="w-4 h-4" />
-    <ProcedureIcon v-if="type === 'procedure'" class="w-4 h-4" />
-    <FunctionIcon v-if="type === 'function'" class="w-4 h-4" />
-    <TablePartitionIcon v-if="type === 'partition-table'" class="w-4 h-4" />
-
     <component :is="render" v-if="render" />
 
-    <span v-else>{{ text }}</span>
+    <template v-else>
+      <FolderIcon
+        v-if="isFolder"
+        class="w-4 h-4 stroke-accent fill-accent/10"
+      />
+      <span>{{ text }}</span>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { isFunction } from "lodash-es";
+import { FolderIcon } from "lucide-vue-next";
 import { computed } from "vue";
-import {
-  FunctionIcon,
-  ProcedureIcon,
-  TableIcon,
-  TablePartitionIcon,
-  ViewIcon,
-} from "@/components/Icon";
-import type { TreeNode } from "../common";
+import type { NodeType, TreeNode } from "../common";
 
 const props = defineProps<{
   node: TreeNode;
@@ -42,6 +33,20 @@ const target = computed(() => {
 const type = computed(() => {
   return target.value.mockType;
 });
+
+const isFolder = computed(() => {
+  if (!type.value) return false;
+  const types: NodeType[] = [
+    "table",
+    "external-table",
+    "view",
+    "procedure",
+    "function",
+    "partition-table",
+  ];
+  return types.includes(type.value);
+});
+
 const text = computed(() => {
   const { text } = target.value;
   return isFunction(text) ? text() : text;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ViewNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/ViewNode.vue
@@ -1,19 +1,21 @@
 <template>
-  <div class="flex items-center max-w-full overflow-hidden gap-x-1">
-    <ViewIcon class="w-4 h-4" />
-    <HighlightLabelText
-      :text="target.view.name"
-      :keyword="keyword"
-      class="flex-1 truncate"
-    />
-  </div>
+  <CommonNode
+    :text="target.view.name"
+    :keyword="keyword"
+    :highlight="true"
+    :indent="1"
+  >
+    <template #icon>
+      <ViewIcon class="w-4 h-4" />
+    </template>
+  </CommonNode>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { ViewIcon } from "@/components/Icon";
 import type { TreeNode } from "../common";
-import HighlightLabelText from "./HighlightLabelText.vue";
+import CommonNode from "./CommonNode.vue";
 
 const props = defineProps<{
   node: TreeNode;


### PR DESCRIPTION
- Add `ColumnIcon` to non-pk and non-index columns
- Introduce "folder" icon to "Tables", "Views", etc. 
- Pixel-perfect icon alignment

- <img width="347" alt="image" src="https://github.com/user-attachments/assets/a3f9958a-e0c2-4673-becb-baf8fa01a48b">

- <img width="347" alt="image" src="https://github.com/user-attachments/assets/f7bfaf5a-31f0-4599-a36f-e72a13c8f6ad">


- <img width="300" alt="image" src="https://github.com/user-attachments/assets/b87dafc9-818d-49db-94f8-58544c2c5072">

- <img width="348" alt="image" src="https://github.com/user-attachments/assets/b82b23e4-1658-474a-a26e-a34e9cd91f9a">
