### PR TITLE
chore: write-through for empty etags

### DIFF
--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -410,7 +410,7 @@ func (s *ProjectService) SetIamPolicy(ctx context.Context, request *v1pb.SetIamP
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to find project iam policy with error: %v", err.Error())
 	}
-	if request.Etag != policyMessage.Etag {
+	if request.Etag != "" && request.Etag != policyMessage.Etag {
 		return nil, status.Errorf(codes.Aborted, "there is concurrent update to the project iam policy, please refresh and try again.")
 	}
 	oldIamPolicyMsg = policyMessage

--- a/backend/api/v1/workspace_service.go
+++ b/backend/api/v1/workspace_service.go
@@ -44,7 +44,7 @@ func (s *WorkspaceService) SetIamPolicy(ctx context.Context, request *v1pb.SetIa
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to find workspace iam policy with error: %v", err.Error())
 	}
-	if request.Etag != policyMessage.Etag {
+	if request.Etag != "" && request.Etag != policyMessage.Etag {
 		return nil, status.Errorf(codes.Aborted, "there is concurrent update to the workspace iam policy, please refresh and try again.")
 	}
 


### PR DESCRIPTION
https://google.aip.dev/154

Let's use the weak consistency requirement for simpler usages such as Terraform.

```
If the user does not send an etag value at all, the service should permit the request. However, services with strong consistency or parallelism requirements may require users to send etags all the time and reject the request with an INVALID_ARGUMENT error in this case.
```