### PR TITLE
chore(sql-editor): some UI improvements

### DIFF
--- a/frontend/src/components/BytebaseLogo.vue
+++ b/frontend/src/components/BytebaseLogo.vue
@@ -20,7 +20,7 @@
       <img
         v-else
         class="h-8 md:h-10 w-auto"
-        src="../assets/logo-full.svg"
+        src="@/assets/logo-full.svg"
         alt="Bytebase"
       />
     </component>

--- a/frontend/src/customAppProfile.ts
+++ b/frontend/src/customAppProfile.ts
@@ -100,6 +100,7 @@ const overrideAppFeatures = (
       "bb.feature.sql-editor.hide-environments": true,
       "bb.feature.sql-editor.disallow-batch-query": true,
       "bb.feature.sql-editor.disallow-share-worksheet": true,
+      "bb.feature.sql-editor.disallow-edit-schema": true,
       "bb.feature.sql-editor.hide-advance-instance-features": true,
     });
   }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -284,7 +284,8 @@
     "rows": {
       "self": "rows",
       "n-rows": "{n} rows"
-    }
+    },
+    "override": "Override"
   },
   "error-page": {
     "go-back-home": "Go back home"
@@ -2443,7 +2444,9 @@
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "Admin data source is disallowed to query when read-only data source is available."
     },
     "manage-connections": "Manage connections",
-    "view-detail": "View detail"
+    "view-detail": "View detail",
+    "generate-sql": "Generate SQL",
+    "current-editing-statement-is-not-empty": "Current editing statement is not empty."
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2442,7 +2442,8 @@
       "admin-data-source-is-disallowed-to-query": "Admin data source is disallowed to query.",
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "Admin data source is disallowed to query when read-only data source is available."
     },
-    "manage-connections": "Manage connections"
+    "manage-connections": "Manage connections",
+    "view-detail": "View detail"
   },
   "schema-editor": {
     "self": "Schema Editor",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2442,7 +2442,8 @@
       "admin-data-source-is-disallowed-to-query": "No se permite realizar consultas a la fuente de datos del administrador.",
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "No se permite realizar consultas a la fuente de datos del administrador cuando la fuente de datos de solo lectura está disponible."
     },
-    "manage-connections": "Gestionar las conexiones"
+    "manage-connections": "Gestionar las conexiones",
+    "view-detail": "Ver detalle"
   },
   "schema-editor": {
     "self": "Editor de esquema",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -284,7 +284,8 @@
     "rows": {
       "self": "filas",
       "n-rows": "{n} filas"
-    }
+    },
+    "override": "Anular"
   },
   "error-page": {
     "go-back-home": "Volver al inicio"
@@ -2443,7 +2444,9 @@
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "No se permite realizar consultas a la fuente de datos del administrador cuando la fuente de datos de solo lectura está disponible."
     },
     "manage-connections": "Gestionar las conexiones",
-    "view-detail": "Ver detalle"
+    "view-detail": "Ver detalle",
+    "generate-sql": "Generar SQL",
+    "current-editing-statement-is-not-empty": "La declaración de edición actual no está vacía."
   },
   "schema-editor": {
     "self": "Editor de esquema",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2442,7 +2442,8 @@
       "admin-data-source-is-disallowed-to-query": "管理者データ ソースはクエリできません。",
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "読み取り専用データ ソースが使用可能な場合、管理データ ソースはクエリを実行できません。"
     },
-    "manage-connections": "接続を管理する"
+    "manage-connections": "接続を管理する",
+    "view-detail": "詳細を見る"
   },
   "schema-editor": {
     "self": "スキーマエディタ",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -284,7 +284,8 @@
     "rows": {
       "self": "行",
       "n-rows": "{n} 行"
-    }
+    },
+    "override": "オーバーライド"
   },
   "error-page": {
     "go-back-home": "ホームページに戻る"
@@ -2443,7 +2444,9 @@
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "読み取り専用データ ソースが使用可能な場合、管理データ ソースはクエリを実行できません。"
     },
     "manage-connections": "接続を管理する",
-    "view-detail": "詳細を見る"
+    "view-detail": "詳細を見る",
+    "generate-sql": "SQLの生成",
+    "current-editing-statement-is-not-empty": "現在編集中のステートメントは空ではありません。"
   },
   "schema-editor": {
     "self": "スキーマエディタ",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -284,7 +284,8 @@
     "rows": {
       "self": "行",
       "n-rows": "{n} 行"
-    }
+    },
+    "override": "覆盖"
   },
   "error-page": {
     "go-back-home": "回到主页"
@@ -2443,7 +2444,9 @@
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "当只读数据源可用时，不允许查询管理员数据源。"
     },
     "manage-connections": "管理连接",
-    "view-detail": "查看详情"
+    "view-detail": "查看详情",
+    "generate-sql": "生成 SQL",
+    "current-editing-statement-is-not-empty": "当前编辑中的语句不为空。"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2442,7 +2442,8 @@
       "admin-data-source-is-disallowed-to-query": "禁止查询管理员数据源。",
       "admin-data-source-is-disallowed-to-query-when-read-only-data-source-is-available": "当只读数据源可用时，不允许查询管理员数据源。"
     },
-    "manage-connections": "管理连接"
+    "manage-connections": "管理连接",
+    "view-detail": "查看详情"
   },
   "schema-editor": {
     "self": "Schema 编辑器",

--- a/frontend/src/types/appProfile.ts
+++ b/frontend/src/types/appProfile.ts
@@ -33,6 +33,7 @@ export type AppFeatures = {
   "bb.feature.sql-editor.disallow-export-query-data": boolean;
   "bb.feature.sql-editor.disallow-request-query": boolean;
   "bb.feature.sql-editor.disallow-sync-schema": boolean;
+  "bb.feature.sql-editor.disallow-edit-schema": boolean;
   "bb.feature.sql-editor.hide-bytebase-logo": boolean;
   "bb.feature.sql-editor.hide-profile": boolean;
   "bb.feature.sql-editor.hide-readonly-datasource-hint": boolean;
@@ -82,6 +83,7 @@ export const defaultAppProfile = (): AppProfile => ({
     "bb.feature.sql-editor.disallow-export-query-data": false,
     "bb.feature.sql-editor.disallow-request-query": false,
     "bb.feature.sql-editor.disallow-sync-schema": false,
+    "bb.feature.sql-editor.disallow-edit-schema": false,
     "bb.feature.sql-editor.hide-bytebase-logo": false,
     "bb.feature.sql-editor.hide-profile": false,
     "bb.feature.sql-editor.hide-readonly-datasource-hint": false,

--- a/frontend/src/utils/v1/sql.ts
+++ b/frontend/src/utils/v1/sql.ts
@@ -93,6 +93,65 @@ export const generateSimpleSelectAllStatement = (
   return `SELECT * FROM ${schemaAndTable} LIMIT ${limit};`;
 };
 
+export const generateSimpleInsertStatement = (
+  engine: Engine,
+  schema: string,
+  table: string,
+  columns: string[]
+) => {
+  if (engine === Engine.MONGODB) {
+    const kvPairs = columns
+      .map((column, i) => `"${column}": <value${i + 1}>`)
+      .join(", ");
+    return `db.${table}.insert({ ${kvPairs} });`;
+  }
+
+  const schemaAndTable = generateSchemaAndTableNameInSQL(engine, schema, table);
+
+  const columnNames = columns
+    .map((column) => wrapSQLIdentifier(column, engine))
+    .join(", ");
+  const placeholders = columns.map((_) => "?").join(", ");
+
+  return `INSERT INTO ${schemaAndTable} (${columnNames}) VALUES (${placeholders});`;
+};
+
+export const generateSimpleUpdateStatement = (
+  engine: Engine,
+  schema: string,
+  table: string,
+  columns: string[]
+) => {
+  if (engine === Engine.MONGODB) {
+    const kvPairs = columns
+      .map((column, i) => `"${column}": <value${i + 1}>`)
+      .join(", ");
+    return `db.${table}.updateOne({ /* <query> */ }, { $set: { /* ${kvPairs} */} });`;
+  }
+
+  const schemaAndTable = generateSchemaAndTableNameInSQL(engine, schema, table);
+
+  const sets = columns
+    .map((column) => `${wrapSQLIdentifier(column, engine)}=?`)
+    .join(", ");
+
+  return `UPDATE ${schemaAndTable} SET ${sets} WHERE 1=2 /* your condition here */;`;
+};
+
+export const generateSimpleDeleteStatement = (
+  engine: Engine,
+  schema: string,
+  table: string
+) => {
+  if (engine === Engine.MONGODB) {
+    return `db.${table}.deleteOne({ /* query */ });`;
+  }
+
+  const schemaAndTable = generateSchemaAndTableNameInSQL(engine, schema, table);
+
+  return `DELETE FROM ${schemaAndTable} WHERE 1=2 /* your condition here */;`;
+};
+
 export const compareQueryRowValues = (
   type: string,
   a: RowValue,

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
@@ -4,6 +4,10 @@ import {
   CopyIcon,
   ExternalLinkIcon,
   FileCodeIcon,
+  FileDiffIcon,
+  FileMinusIcon,
+  FilePlusIcon,
+  FileSearch2Icon,
   LinkIcon,
   SquarePenIcon,
 } from "lucide-vue-next";
@@ -245,7 +249,7 @@ export const useDropdown = () => {
         generateSQLChildren.push({
           key: "generate-sql--select",
           label: "SELECT",
-          icon: () => <FileCodeIcon class="w-4 h-4" />,
+          icon: () => <FileSearch2Icon class="w-4 h-4" />,
           onSelect: async () => {
             const statement = await formatCode(
               generateSimpleSelectAllStatement(
@@ -265,7 +269,7 @@ export const useDropdown = () => {
           generateSQLChildren.push({
             key: "generate-sql--insert",
             label: "INSERT",
-            icon: () => <FileCodeIcon class="w-4 h-4" />,
+            icon: () => <FilePlusIcon class="w-4 h-4" />,
             onSelect: async () => {
               const statement = await formatCode(
                 generateSimpleInsertStatement(
@@ -282,7 +286,7 @@ export const useDropdown = () => {
           generateSQLChildren.push({
             key: "generate-sql--update",
             label: "UPDATE",
-            icon: () => <FileCodeIcon class="w-4 h-4" />,
+            icon: () => <FileDiffIcon class="w-4 h-4" />,
             onSelect: async () => {
               const statement = await formatCode(
                 generateSimpleUpdateStatement(
@@ -299,7 +303,7 @@ export const useDropdown = () => {
           generateSQLChildren.push({
             key: "generate-sql--delete",
             label: "DELETE",
-            icon: () => <FileCodeIcon class="w-4 h-4" />,
+            icon: () => <FileMinusIcon class="w-4 h-4" />,
             onSelect: async () => {
               const statement = await formatCode(
                 generateSimpleDeleteStatement(engine, schema.name, table.name),

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
@@ -239,21 +239,35 @@ export const useDropdown = () => {
         label: t("sql-editor.view-detail"),
         icon: () => <ExternalLinkIcon class="w-4 h-4" />,
         onSelect: async () => {
-          const tar = target as NodeTarget<
+          const { db, database, schema } = target as NodeTarget<
             "table" | "view" | "procedure" | "function"
           >;
-          const { db, schema } = tar;
           updateViewState({
             view: typeToView(type),
             schema: schema.name,
           });
           await nextTick();
+          const metadata: any = {
+            type,
+            db,
+            database,
+            schema,
+          };
+          if (type === "table") {
+            metadata.table = (target as NodeTarget<"table">).table;
+          }
+          if (type === "view") {
+            metadata.view = (target as NodeTarget<"view">).view;
+          }
+          if (type === "procedure") {
+            metadata.procedure = (target as NodeTarget<"procedure">).procedure;
+          }
+          if (type === "function") {
+            metadata.function = (target as NodeTarget<"function">).function;
+          }
           queuePendingScrollToTarget({
             db,
-            metadata: {
-              type,
-              ...tar,
-            } as any,
+            metadata: metadata as any,
           });
         },
       });

--- a/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
@@ -25,11 +25,7 @@ import AccessDenied from "./AccessDenied.vue";
 import Panels from "./Panels";
 import StandardPanel from "./StandardPanel";
 import TerminalPanel from "./TerminalPanel";
-import { provideEditorPanelContext } from "./context";
 
 const tabStore = useSQLEditorTabStore();
 const { currentTab } = storeToRefs(tabStore);
-provideEditorPanelContext({
-  tab: currentTab,
-});
 </script>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
@@ -101,7 +101,7 @@ useConsumePendingScrollToTarget(
     if (!key) return false;
     await nextAnimationFrame();
     try {
-      console.debug("scroll-to-procedure", vl, target, key);
+      console.debug("scroll-to-function", vl, target, key);
       vl.scrollTo({ key });
     } catch {
       // Do nothing

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
@@ -18,11 +18,7 @@
 </template>
 
 <script setup lang="tsx">
-import {
-  NDataTable,
-  NPerformantEllipsis,
-  type DataTableColumn,
-} from "naive-ui";
+import { NDataTable, type DataTableColumn } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ComposedDatabase } from "@/types";
@@ -66,13 +62,6 @@ const columns = computed(() => {
       title: t("schema-editor.database.name"),
       resizable: true,
       className: "truncate",
-      render: (func) => {
-        return (
-          <NPerformantEllipsis class="w-full leading-6">
-            {func.name}
-          </NPerformantEllipsis>
-        );
-      },
     },
   ];
   return columns;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
@@ -4,7 +4,7 @@
       v-bind="$attrs"
       ref="dataTableRef"
       size="small"
-      :row-key="getFunctionKey"
+      :row-key="(func) => func.name"
       :columns="columns"
       :data="layoutReady ? funcs : []"
       :row-props="rowProps"
@@ -18,8 +18,8 @@
 </template>
 
 <script setup lang="tsx">
-import { NDataTable, type DataTableColumn } from "naive-ui";
-import { computed } from "vue";
+import { NDataTable, type DataTableColumn, type DataTableInst } from "naive-ui";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ComposedDatabase } from "@/types";
 import type {
@@ -27,7 +27,10 @@ import type {
   FunctionMetadata,
   SchemaMetadata,
 } from "@/types/proto/v1/database_service";
+import { nextAnimationFrame } from "@/utils";
 import { useAutoHeightDataTable } from "../../common";
+import { useEditorPanelContext } from "../../context";
+import type { RichFunctionMetadata, RichMetadataWithDB } from "../../types";
 
 const props = defineProps<{
   db: ComposedDatabase;
@@ -50,10 +53,12 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const { containerElRef, tableBodyHeight, layoutReady } =
   useAutoHeightDataTable();
-
-const getFunctionKey = (func: FunctionMetadata) => {
-  return func.name;
-};
+const dataTableRef = ref<DataTableInst>();
+const vlRef = computed(() => {
+  return (dataTableRef.value as any)?.$refs?.mainTableInstRef?.bodyInstRef
+    ?.virtualListRef;
+});
+const { useConsumePendingScrollToTarget } = useEditorPanelContext();
 
 const columns = computed(() => {
   const columns: (DataTableColumn<FunctionMetadata> & { hide?: boolean })[] = [
@@ -78,6 +83,32 @@ const rowProps = (func: FunctionMetadata) => {
     },
   };
 };
+
+useConsumePendingScrollToTarget(
+  (target: RichMetadataWithDB<"function">) => {
+    if (target.db.name !== props.db.name) {
+      return false;
+    }
+    if (target.metadata.type === "function") {
+      const metadata = target.metadata as RichFunctionMetadata;
+      return metadata.schema.name === props.schema.name;
+    }
+    return false;
+  },
+  vlRef,
+  async (target, vl) => {
+    const key = target.metadata.function.name;
+    if (!key) return false;
+    await nextAnimationFrame();
+    try {
+      console.debug("scroll-to-procedure", vl, target, key);
+      vl.scrollTo({ key });
+    } catch {
+      // Do nothing
+    }
+    return true;
+  }
+);
 </script>
 
 <style lang="postcss" scoped>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ProceduresPanel/ProceduresTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ProceduresPanel/ProceduresTable.vue
@@ -18,11 +18,7 @@
 </template>
 
 <script setup lang="tsx">
-import {
-  NDataTable,
-  NPerformantEllipsis,
-  type DataTableColumn,
-} from "naive-ui";
+import { NDataTable, type DataTableColumn } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ComposedDatabase } from "@/types";
@@ -66,13 +62,6 @@ const columns = computed(() => {
       title: t("schema-editor.database.name"),
       resizable: true,
       className: "truncate",
-      render: (view) => {
-        return (
-          <NPerformantEllipsis class="w-full leading-6">
-            {view.name}
-          </NPerformantEllipsis>
-        );
-      },
     },
   ];
   return columns;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
@@ -53,11 +53,6 @@ const { containerElRef, tableBodyHeight, layoutReady } =
 const dataTableRef = ref<DataTableInst>();
 const { t } = useI18n();
 
-// const vlRef = computed(() => {
-//   return (dataTableRef.value as any)?.$refs?.mainTableInstRef?.bodyInstRef
-//     ?.virtualListRef;
-// });
-
 const primaryKey = computed(() => {
   return props.table.indexes.find((idx) => idx.primary);
 });
@@ -175,31 +170,6 @@ const isColumnPrimaryKey = (column: ColumnMetadata): boolean => {
   if (!pk) return false;
   return pk.expressions.includes(column.name);
 };
-
-// useConsumePendingScrollToColumn(
-//   computed(() => ({
-//     db: props.db,
-//     metadata: {
-//       database: props.database,
-//       schema: props.schema,
-//       table: props.table,
-//     },
-//   })),
-//   vlRef,
-//   (params, vl) => {
-//     const key = params.metadata.column.name;
-//     if (!key) return;
-//     requestAnimationFrame(() => {
-//       try {
-//         console.debug("scroll-to-column", vl, params, key);
-//         vl.scrollTo({ key });
-//         // TODO: focus name or type input element
-//       } catch {
-//         // Do nothing
-//       }
-//     });
-//   }
-// );
 </script>
 
 <style lang="postcss" scoped>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
@@ -1,0 +1,232 @@
+<template>
+  <div ref="containerElRef" class="w-full h-full overflow-x-auto">
+    <NDataTable
+      v-bind="$attrs"
+      ref="dataTableRef"
+      size="small"
+      :row-key="(column) => column.name"
+      :columns="columns"
+      :data="layoutReady ? shownColumnList : []"
+      :max-height="tableBodyHeight"
+      :virtual-scroll="true"
+      :striped="true"
+      :bordered="true"
+      :bottom-bordered="true"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { DataTableColumn, DataTableInst } from "naive-ui";
+import { NCheckbox, NDataTable } from "naive-ui";
+import { computed, h, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+  DefaultValueCell,
+  ForeignKeyCell,
+} from "@/components/SchemaEditorLite/Panels/TableColumnEditor/components";
+import type { ComposedDatabase } from "@/types";
+import { Engine } from "@/types/proto/v1/common";
+import type {
+  ColumnMetadata,
+  DatabaseMetadata,
+  SchemaMetadata,
+  TableMetadata,
+} from "@/types/proto/v1/database_service";
+import { useAutoHeightDataTable } from "../../common";
+
+const props = withDefaults(
+  defineProps<{
+    db: ComposedDatabase;
+    database: DatabaseMetadata;
+    schema: SchemaMetadata;
+    table: TableMetadata;
+    filterColumn?: (column: ColumnMetadata) => boolean;
+  }>(),
+  {
+    filterColumn: (_: ColumnMetadata) => true,
+  }
+);
+
+const { containerElRef, tableBodyHeight, layoutReady } =
+  useAutoHeightDataTable();
+const dataTableRef = ref<DataTableInst>();
+const { t } = useI18n();
+
+// const vlRef = computed(() => {
+//   return (dataTableRef.value as any)?.$refs?.mainTableInstRef?.bodyInstRef
+//     ?.virtualListRef;
+// });
+
+const primaryKey = computed(() => {
+  return props.table.indexes.find((idx) => idx.primary);
+});
+
+const columns = computed(() => {
+  const engine = props.db.instanceResource.engine;
+  const columns: (DataTableColumn<ColumnMetadata> & { hide?: boolean })[] = [
+    {
+      key: "name",
+      title: t("schema-editor.column.name"),
+      resizable: true,
+      minWidth: 140,
+      className: "truncate",
+      render: (col) => col.name.repeat(10),
+    },
+    {
+      key: "type",
+      title: t("schema-editor.column.type"),
+      resizable: true,
+      minWidth: 140,
+      maxWidth: 320,
+      className: "truncate",
+    },
+    {
+      key: "default-value",
+      title: t("schema-editor.column.default"),
+      resizable: true,
+      minWidth: 140,
+      maxWidth: 320,
+      className: "input-cell",
+      render: (column) => {
+        return h(DefaultValueCell, {
+          column,
+          disabled: true,
+          engine: engine,
+        });
+      },
+    },
+    {
+      key: "on-update",
+      title: t("schema-editor.column.on-update"),
+      resizable: true,
+      minWidth: 140,
+      maxWidth: 320,
+      hide: engine !== Engine.MYSQL && engine !== Engine.TIDB,
+    },
+    {
+      key: "comment",
+      title: t("schema-editor.column.comment"),
+      resizable: true,
+      minWidth: 140,
+      maxWidth: 320,
+      className: "truncate",
+      ellipsis: true,
+      ellipsisComponent: "performant-ellipsis",
+      render: (column) => column.userComment,
+    },
+    {
+      key: "not-null",
+      title: t("schema-editor.column.not-null"),
+      resizable: true,
+      minWidth: 80,
+      maxWidth: 160,
+      className: "checkbox-cell",
+      render: (column) => {
+        return h(NCheckbox, {
+          checked: !column.nullable,
+          readonly: true,
+        });
+      },
+    },
+    {
+      key: "primary",
+      title: t("schema-editor.column.primary"),
+      resizable: true,
+      minWidth: 80,
+      maxWidth: 160,
+      className: "checkbox-cell",
+      render: (column) => {
+        return h(NCheckbox, {
+          checked: isColumnPrimaryKey(column),
+          readonly: true,
+        });
+      },
+    },
+    {
+      key: "foreign-key",
+      title: t("schema-editor.column.foreign-key"),
+      resizable: true,
+      minWidth: 140,
+      maxWidth: 320,
+      className: "text-cell",
+      render: (column) => {
+        return h(ForeignKeyCell, {
+          db: props.db,
+          database: props.database,
+          schema: props.schema,
+          table: props.table,
+          column: column,
+          readonly: true,
+          disabled: true,
+        });
+      },
+    },
+  ];
+  return columns.filter((header) => !header.hide);
+});
+
+const shownColumnList = computed(() => {
+  return props.table.columns.filter(props.filterColumn);
+});
+
+const isColumnPrimaryKey = (column: ColumnMetadata): boolean => {
+  const pk = primaryKey.value;
+  if (!pk) return false;
+  return pk.expressions.includes(column.name);
+};
+
+// useConsumePendingScrollToColumn(
+//   computed(() => ({
+//     db: props.db,
+//     metadata: {
+//       database: props.database,
+//       schema: props.schema,
+//       table: props.table,
+//     },
+//   })),
+//   vlRef,
+//   (params, vl) => {
+//     const key = params.metadata.column.name;
+//     if (!key) return;
+//     requestAnimationFrame(() => {
+//       try {
+//         console.debug("scroll-to-column", vl, params, key);
+//         vl.scrollTo({ key });
+//         // TODO: focus name or type input element
+//       } catch {
+//         // Do nothing
+//       }
+//     });
+//   }
+// );
+</script>
+
+<style lang="postcss" scoped>
+:deep(.n-data-table-th .n-data-table-resize-button::after) {
+  @apply bg-control-bg h-2/3;
+}
+:deep(.n-data-table-td.input-cell) {
+  @apply pl-0.5 pr-1 py-0;
+}
+
+:deep(.n-data-table-td.input-cell .n-input__placeholder),
+:deep(.n-data-table-td.input-cell .n-base-selection-placeholder) {
+  @apply italic;
+}
+:deep(.n-data-table-td.checkbox-cell) {
+  @apply pr-1 py-0;
+}
+:deep(.n-data-table-td.text-cell) {
+  @apply pr-1 py-0;
+}
+:not(.disable-diff-coloring) :deep(.n-data-table-tr.created .n-data-table-td) {
+  @apply text-green-700 !bg-green-50;
+}
+:not(.disable-diff-coloring) :deep(.n-data-table-tr.dropped .n-data-table-td) {
+  @apply text-red-700 cursor-not-allowed !bg-red-50 opacity-70;
+}
+:not(.disable-diff-coloring) :deep(.n-data-table-tr.updated .n-data-table-td) {
+  @apply text-yellow-700 !bg-yellow-50;
+}
+</style>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesPanel.vue
@@ -16,20 +16,18 @@
     </template>
 
     <template v-if="metadata.table">
-      <TableEditor
+      <div class="w-full flex flex-row gap-x-2 justify-start items-center">
+        <NButton size="small" @click="deselect">
+          <ArrowLeftIcon class="w-4 h-4" />
+        </NButton>
+      </div>
+      <ColumnsTable
         v-if="metadata.table"
         :db="database"
         :database="metadata.database"
         :schema="metadata.schema"
         :table="metadata.table"
-        class="!pt-0"
-      >
-        <template #toolbar-prefix>
-          <NButton size="small" @click="deselect">
-            <ArrowLeftIcon class="w-4 h-4" />
-          </NButton>
-        </template>
-      </TableEditor>
+      />
     </template>
   </div>
 </template>
@@ -39,7 +37,6 @@ import { ArrowLeftIcon } from "lucide-vue-next";
 import { NButton } from "naive-ui";
 import { computed, ref, watch } from "vue";
 import { provideSchemaEditorContext } from "@/components/SchemaEditorLite";
-import TableEditor from "@/components/SchemaEditorLite/Panels/TableEditor.vue";
 import {
   useConnectionOfCurrentSQLEditorTab,
   useDBSchemaV1Store,
@@ -54,6 +51,7 @@ import {
 } from "@/types/proto/v1/database_service";
 import { useEditorPanelContext } from "../../context";
 import { SchemaSelectToolbar } from "../common";
+import ColumnsTable from "./ColumnsTable.vue";
 import TablesTable from "./TablesTable.vue";
 
 const editorStore = useSQLEditorStore();

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
@@ -18,11 +18,7 @@
 </template>
 
 <script setup lang="tsx">
-import {
-  NDataTable,
-  NPerformantEllipsis,
-  type DataTableColumn,
-} from "naive-ui";
+import { NDataTable, type DataTableColumn } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ComposedDatabase } from "@/types";
@@ -71,8 +67,6 @@ const columns = computed(() => {
       title: t("schema-editor.database.name"),
       resizable: true,
       className: "truncate",
-      ellipsis: true,
-      ellipsisComponent: "performant-ellipsis",
     },
     {
       key: "engine",
@@ -81,9 +75,6 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 120,
       maxWidth: 180,
-      render: (table) => {
-        return table.engine;
-      },
     },
     {
       key: "collation",
@@ -92,8 +83,6 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 120,
       maxWidth: 180,
-      ellipsis: true,
-      ellipsisComponent: "performant-ellipsis",
     },
     {
       key: "rowCountEst",
@@ -132,13 +121,8 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 140,
       maxWidth: 320,
-      render: (table) => {
-        return (
-          <NPerformantEllipsis class="w-full leading-6">
-            {table.userComment}
-          </NPerformantEllipsis>
-        );
-      },
+      className: "truncate",
+      render: (table) => table.userComment,
     },
   ];
   return columns.filter((col) => !col.hide);

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
@@ -156,7 +156,7 @@ useConsumePendingScrollToTarget(
     }
     if (target.metadata.type === "table" || target.metadata.type === "column") {
       const metadata = target.metadata as RichTableMetadata;
-      return metadata.schema.name == props.schema.name;
+      return metadata.schema.name === props.schema.name;
     }
     return false;
   },

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
@@ -18,11 +18,7 @@
 </template>
 
 <script setup lang="tsx">
-import {
-  NDataTable,
-  NPerformantEllipsis,
-  type DataTableColumn,
-} from "naive-ui";
+import { NDataTable, type DataTableColumn } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ComposedDatabase } from "@/types";
@@ -66,26 +62,12 @@ const columns = computed(() => {
       title: t("schema-editor.database.name"),
       resizable: true,
       className: "truncate",
-      render: (view) => {
-        return (
-          <NPerformantEllipsis class="w-full leading-6">
-            {view.name}
-          </NPerformantEllipsis>
-        );
-      },
     },
     {
       key: "comment",
       title: t("schema-editor.database.comment"),
       resizable: true,
       className: "truncate",
-      render: (view) => {
-        return (
-          <NPerformantEllipsis class="w-full leading-6">
-            {view.comment}
-          </NPerformantEllipsis>
-        );
-      },
     },
   ];
   return columns;

--- a/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
@@ -12,7 +12,10 @@
       >
         <template v-if="!tab || tab.editMode === 'SQL-EDITOR'">
           <EditorAction @execute="handleExecute" />
-          <div v-if="tab" class="w-full flex-1 flex flex-row items-stretch overflow-hidden">
+          <div
+            v-if="tab"
+            class="w-full flex-1 flex flex-row items-stretch overflow-hidden"
+          >
             <Suspense>
               <SQLEditor @execute="handleExecute" />
               <template #fallback>
@@ -75,7 +78,7 @@ import {
 import { useSQLEditorContext } from "../../context";
 import ReadonlyModeNotSupported from "../ReadonlyModeNotSupported.vue";
 import ResultPanel from "../ResultPanel";
-import Welcome from "../Welcome.vue";
+import Welcome from "../Welcome";
 
 const SQLEditor = defineAsyncComponent(() => import("./SQLEditor.vue"));
 

--- a/frontend/src/views/sql-editor/EditorPanel/Welcome/Button.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Welcome/Button.vue
@@ -1,0 +1,20 @@
+<template>
+  <NButton type="primary" style="--n-height: 7rem; --n-padding: 0 6px; min-width: 7rem;">
+    <div>
+      <slot name="icon" />
+    </div>
+    <div>
+      <slot name="default" />
+    </div>
+  </NButton>
+</template>
+
+<script setup lang="ts">
+import { NButton } from "naive-ui";
+</script>
+
+<style scoped lang="postcss">
+:deep(.n-button__content) {
+  @apply flex flex-col h-full justify-center items-center gap-2;
+}
+</style>

--- a/frontend/src/views/sql-editor/EditorPanel/Welcome/Welcome.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Welcome/Welcome.vue
@@ -5,7 +5,34 @@
   >
     <BytebaseLogo v-if="!hideLogo" component="span" />
 
-    <div class="flex flex-col items-start gap-y-2 w-max">
+    <div
+      class="hidden lg:grid items-center gap-4"
+      style="grid-template-columns: 1fr 1fr 1fr"
+    >
+      <Button
+        v-if="showCreateInstanceButton"
+        type="default"
+        @click="gotoInstanceCreatePage"
+      >
+        <template #icon>
+          <LayersIcon :stroke-width="1.5" class="w-8 h-8" />
+        </template>
+        {{ $t("sql-editor.add-a-new-instance") }}
+      </Button>
+      <Button type="primary" secondary @click="changeConnection">
+        <template #icon>
+          <LinkIcon :stroke-width="1.5" class="w-8 h-8" />
+        </template>
+        {{ $t("sql-editor.connect-to-a-database") }}
+      </Button>
+      <Button type="default" @click="createNewWorksheet">
+        <template #icon>
+          <SquarePenIcon :stroke-width="1.5" class="w-8 h-8" />
+        </template>
+        {{ $t("sql-editor.create-a-worksheet") }}
+      </Button>
+    </div>
+    <div class="flex lg:hidden flex-col items-start gap-y-2 w-max">
       <NButton
         type="primary"
         class="!w-full !justify-start"
@@ -49,8 +76,9 @@ import { useRouter } from "vue-router";
 import BytebaseLogo from "@/components/BytebaseLogo.vue";
 import { SQL_EDITOR_SETTING_INSTANCE_MODULE } from "@/router/sqlEditor";
 import { useAppFeature, useSQLEditorTabStore } from "@/store";
-import { useSidebarItems as useSettingItems } from "../Setting/Sidebar";
-import { useSQLEditorContext } from "../context";
+import { useSidebarItems as useSettingItems } from "../../Setting/Sidebar";
+import { useSQLEditorContext } from "../../context";
+import Button from "./Button.vue";
 
 const { showConnectionPanel } = useSQLEditorContext();
 const { itemList: settingItemList } = useSettingItems();

--- a/frontend/src/views/sql-editor/EditorPanel/Welcome/index.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/Welcome/index.ts
@@ -1,0 +1,3 @@
+import Welcome from "./Welcome.vue";
+
+export default Welcome;

--- a/frontend/src/views/sql-editor/EditorPanel/context/index.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/context/index.ts
@@ -9,8 +9,10 @@ import {
 import type { SQLEditorTab } from "@/types";
 import {
   defaultViewState,
+  typeToView,
   type EditorPanelViewState as ViewState,
-} from "./types";
+} from "../types";
+import { useScroll } from "./scroll";
 
 const KEY = Symbol(
   "bb.sql-editor.editor-panel"
@@ -51,9 +53,11 @@ export const provideEditorPanelContext = (base: {
 
   const context = {
     ...base,
+    ...useScroll(viewState),
     viewState,
     selectedSchemaName,
     updateViewState,
+    typeToView,
   };
 
   provide(KEY, context);

--- a/frontend/src/views/sql-editor/EditorPanel/context/scroll.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/context/scroll.ts
@@ -2,17 +2,9 @@ import { useMounted } from "@vueuse/core";
 import type { Ref } from "vue";
 import { computed, watch } from "vue";
 import {
-  type RichMetadataWithDB, // type EditorPanelView as View,
+  type RichMetadataWithDB,
   type EditorPanelViewState as ViewState,
 } from "../types";
-
-// const typeMapping: Record<string, View> = {
-//   table: "TABLES",
-//   column: "TABLES",
-//   view: "VIEWS",
-//   procedure: "PROCEDURES",
-//   function: "FUNCTIONS",
-// };
 
 export const useScroll = (viewState: Ref<ViewState | undefined>) => {
   const useConsumePendingScrollToTarget = <TTarget, TContext>(

--- a/frontend/src/views/sql-editor/EditorPanel/context/scroll.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/context/scroll.ts
@@ -1,0 +1,67 @@
+import { useMounted } from "@vueuse/core";
+import type { Ref } from "vue";
+import { computed, watch } from "vue";
+import {
+  type RichMetadataWithDB, // type EditorPanelView as View,
+  type EditorPanelViewState as ViewState,
+} from "../types";
+
+// const typeMapping: Record<string, View> = {
+//   table: "TABLES",
+//   column: "TABLES",
+//   view: "VIEWS",
+//   procedure: "PROCEDURES",
+//   function: "FUNCTIONS",
+// };
+
+export const useScroll = (viewState: Ref<ViewState | undefined>) => {
+  const useConsumePendingScrollToTarget = <TTarget, TContext>(
+    predicate: (target: RichMetadataWithDB<TTarget>) => boolean,
+    context: Ref<TContext>,
+    callback: (
+      target: RichMetadataWithDB<TTarget>,
+      context: TContext
+    ) => Promise</* settled */ boolean>
+  ) => {
+    const target = computed(() => {
+      return viewState.value?.pendingScroll;
+    });
+    const mounted = useMounted();
+    const matched = computed(() => {
+      const target = viewState.value?.pendingScroll;
+      if (!target) return false;
+      return predicate(target);
+    });
+    watch(
+      [mounted, matched, context, target],
+      ([mounted, matched, context, target]) => {
+        if (!mounted) return;
+        if (!matched) return;
+        if (!context) return;
+        if (!target) return;
+        callback(target, context).then((settled) => {
+          if (settled && viewState.value) {
+            viewState.value.pendingScroll = undefined;
+          }
+        });
+      },
+      { immediate: true }
+    );
+  };
+  const queuePendingScrollToTarget = <TTarget>(
+    target: RichMetadataWithDB<TTarget>
+  ) => {
+    if (viewState.value) {
+      requestAnimationFrame(() => {
+        if (viewState.value) {
+          viewState.value.pendingScroll = target;
+        }
+      });
+    }
+  };
+
+  return {
+    queuePendingScrollToTarget,
+    useConsumePendingScrollToTarget,
+  };
+};

--- a/frontend/src/views/sql-editor/EditorPanel/types.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/types.ts
@@ -40,7 +40,7 @@ export type RichViewMetadata = BaseRichMetadata<"view"> & {
 };
 export type RichFunctionMetadata = BaseRichMetadata<"function"> & {
   schema: SchemaMetadata;
-  func: FunctionMetadata;
+  function: FunctionMetadata;
 };
 export type RichProcedureMetadata = BaseRichMetadata<"procedure"> & {
   schema: SchemaMetadata;

--- a/frontend/src/views/sql-editor/EditorPanel/types.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/types.ts
@@ -1,3 +1,14 @@
+import type { ComposedDatabase } from "@/types";
+import type {
+  ColumnMetadata,
+  DatabaseMetadata,
+  FunctionMetadata,
+  ProcedureMetadata,
+  SchemaMetadata,
+  TableMetadata,
+  ViewMetadata,
+} from "@/types/proto/v1/database_service";
+
 export type EditorPanelView =
   | "CODE"
   | "INFO"
@@ -7,9 +18,56 @@ export type EditorPanelView =
   | "PROCEDURES"
   | "DIAGRAM";
 
+export type BaseRichMetadata<T> = {
+  type: T;
+  database: DatabaseMetadata;
+};
+export type RichSchemaMetadata = BaseRichMetadata<"schema"> & {
+  schema: SchemaMetadata;
+};
+export type RichTableMetadata = BaseRichMetadata<"table"> & {
+  schema: SchemaMetadata;
+  table: TableMetadata;
+};
+export type RichColumnMetadata = BaseRichMetadata<"column"> & {
+  schema: SchemaMetadata;
+  table: TableMetadata;
+  column: ColumnMetadata;
+};
+export type RichViewMetadata = BaseRichMetadata<"view"> & {
+  schema: SchemaMetadata;
+  view: ViewMetadata;
+};
+export type RichFunctionMetadata = BaseRichMetadata<"function"> & {
+  schema: SchemaMetadata;
+  func: FunctionMetadata;
+};
+export type RichProcedureMetadata = BaseRichMetadata<"procedure"> & {
+  schema: SchemaMetadata;
+  procedure: ProcedureMetadata;
+};
+
+export type RichMetadataWithDB<T> = {
+  db: ComposedDatabase;
+  metadata: T extends "schema"
+    ? RichSchemaMetadata
+    : T extends "table"
+      ? RichTableMetadata
+      : T extends "column"
+        ? RichColumnMetadata
+        : T extends "view"
+          ? RichViewMetadata
+          : T extends "function"
+            ? RichFunctionMetadata
+            : T extends "procedure"
+              ? RichProcedureMetadata
+              : { type: T };
+};
+
 export type EditorPanelViewState = {
   view: EditorPanelView;
   schema?: string;
+  pendingScroll?: RichMetadataWithDB<any>;
 };
 
 export const defaultViewState = (): EditorPanelViewState => {
@@ -17,4 +75,14 @@ export const defaultViewState = (): EditorPanelViewState => {
     view: "CODE",
     schema: undefined,
   };
+};
+
+export const typeToView = (
+  type: "table" | "view" | "function" | "procedure"
+): EditorPanelView => {
+  if (type === "table") return "TABLES";
+  if (type === "view") return "VIEWS";
+  if (type === "function") return "FUNCTIONS";
+  if (type === "procedure") return "PROCEDURES";
+  throw new Error(`unsupported type: "${type}"`);
 };

--- a/frontend/src/views/sql-editor/SQLEditorHomePage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorHomePage.vue
@@ -105,6 +105,7 @@ import { useSheetContext } from "./Sheet";
 import SheetPanel from "./SheetPanel";
 import TabList from "./TabList";
 import { useSQLEditorContext } from "./context";
+import { provideEditorPanelContext } from "./EditorPanel/context";
 
 type LocalState = {
   sidebarExpanded: boolean;
@@ -172,6 +173,10 @@ useEmitteryEventListener(
     }
   }
 );
+
+provideEditorPanelContext({
+  tab: currentTab,
+});
 </script>
 
 <style lang="postcss">


### PR DESCRIPTION
### Schema tree enhancements
* "View detail" now goes to corresponding right metadata panel rather than database detail page
* Double-clicking, "Preview table data" and "Generate SQL" are now more powerful
  * <img width="544" alt="image" src="https://github.com/user-attachments/assets/d8ac1232-807c-40cb-bf80-d61566fbff94">
  * <img width="656" alt="image" src="https://github.com/user-attachments/assets/16e82fa0-5244-4135-ac7f-4b15ba715af4">

### Schema panel enhancements
* When coming from "View detail" of the schema tree, the list will scroll to the element automatically.

### Others
- Tile-style welcome page
  - ![localhost_3000_sql-editor_projects_default(720P)](https://github.com/user-attachments/assets/c62aec0d-e142-468a-8baa-2c15442fce23)


Close BYT-5490, BYT-5773