### PR TITLE
chore: support filter by address

### DIFF
--- a/frontend/src/components/AdvancedSearch/useCommonSearchScopeOptions.ts
+++ b/frontend/src/components/AdvancedSearch/useCommonSearchScopeOptions.ts
@@ -1,6 +1,5 @@
 import type { Ref, VNode } from "vue";
 import { computed, h, unref } from "vue";
-import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import GitIcon from "@/components/GitIcon.vue";
 import {
@@ -9,6 +8,7 @@ import {
   RichDatabaseName,
   EnvironmentV1Name,
 } from "@/components/v2";
+import { t } from "@/plugins/i18n";
 import {
   useDatabaseV1Store,
   useEnvironmentV1List,
@@ -33,7 +33,6 @@ export const useCommonSearchScopeOptions = (
   params: Ref<SearchParams>,
   supportOptionIdList: MaybeRef<SearchScopeId[]>
 ) => {
-  const { t } = useI18n();
   const route = useRoute();
   const databaseV1Store = useDatabaseV1Store();
   const environmentStore = useEnvironmentV1Store();
@@ -41,7 +40,7 @@ export const useCommonSearchScopeOptions = (
   const projectList = useProjectV1Store().projectList;
 
   const project = computed(() => {
-    const { projectId } = route.params;
+    const { projectId } = route?.params ?? {};
     if (projectId && typeof projectId === "string") {
       return `projects/${projectId}`;
     }

--- a/frontend/src/components/PasswordSigninForm.vue
+++ b/frontend/src/components/PasswordSigninForm.vue
@@ -107,6 +107,9 @@ const props = withDefaults(
     showForgotPassword?: boolean;
   }>(),
   {
+    email: "",
+    password: "",
+    showPassword: false,
     showForgotPassword: true,
   }
 );
@@ -116,9 +119,9 @@ const route = useRoute();
 const authStore = useAuthStore();
 
 const state = reactive<LocalState>({
-  email: props.email || "",
-  password: props.password || "",
-  showPassword: props.showPassword || false,
+  email: props.email,
+  password: props.password,
+  showPassword: props.showPassword,
   isLoading: false,
 });
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1557,6 +1557,14 @@
       "default-value": "Default (10)",
       "description": "Limiting connection and resource usage is achieved by setting the maximum number of connections to the instance.",
       "max-value": "Maximum {value} connections"
+    },
+    "advanced-search": {
+      "scope": {
+        "address": {
+          "title": "Address",
+          "description": "Filter by address"
+        }
+      }
     }
   },
   "environment": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1557,6 +1557,14 @@
       "default-value": "Predeterminado (10)",
       "description": "Limitar la conexión y el uso de recursos se logra estableciendo el número máximo de conexiones a la instancia.",
       "max-value": "Máximo {value} conexiones"
+    },
+    "advanced-search": {
+      "scope": {
+        "address": {
+          "title": "DIRECCIÓN",
+          "description": "Filtrar por dirección"
+        }
+      }
     }
   },
   "environment": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1557,6 +1557,14 @@
       "default-value": "デフォルト (10 接続)",
       "description": "インスタンスの最大接続数を設定して、接続とリソースの使用を制限します。",
       "max-value": "最大接続数 {value}"
+    },
+    "advanced-search": {
+      "scope": {
+        "address": {
+          "title": "住所",
+          "description": "住所でフィルタリング"
+        }
+      }
     }
   },
   "environment": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1557,6 +1557,14 @@
       "default-value": "默认 (10 个连接)",
       "description": "通过设置实例的最大连接数来限制连接和资源的使用。",
       "max-value": "最大连接数 {value} 个"
+    },
+    "advanced-search": {
+      "scope": {
+        "address": {
+          "title": "地址",
+          "description": "按地址过滤"
+        }
+      }
     }
   },
   "environment": {

--- a/frontend/src/utils/v1/advanced-search/common.ts
+++ b/frontend/src/utils/v1/advanced-search/common.ts
@@ -28,6 +28,8 @@ export const SearchScopeIdList = [
   "method",
   "level",
   "actor",
+  // instance related search scopes.
+  "address",
 ] as const;
 
 export type SearchScopeId =

--- a/frontend/src/utils/v1/instance.ts
+++ b/frontend/src/utils/v1/instance.ts
@@ -1,6 +1,7 @@
 import { keyBy, orderBy } from "lodash-es";
 import { computed, unref } from "vue";
 import { useI18n } from "vue-i18n";
+import { t } from "@/plugins/i18n";
 import { useEnvironmentV1Store, useSubscriptionV1Store } from "@/store";
 import type { ComposedInstance, MaybeRef } from "@/types";
 import { isValidProjectName, languageOfEngineV1 } from "@/types";
@@ -10,11 +11,13 @@ import type {
   Instance,
   InstanceResource,
 } from "@/types/proto/v1/instance_service";
-import { DataSourceType } from "@/types/proto/v1/instance_service";
+import {
+  DataSourceType,
+  type DataSource,
+} from "@/types/proto/v1/instance_service";
 import { PlanType } from "@/types/proto/v1/subscription_service";
 
 export function instanceV1Name(instance: Instance | InstanceResource) {
-  const { t } = useI18n();
   const store = useSubscriptionV1Store();
   let name = instance.title;
   // instance cannot be deleted and activated at the same time.
@@ -52,10 +55,17 @@ export const sortInstanceV1List = (
   );
 };
 
-export const hostPortOfInstanceV1 = (instance: Instance | InstanceResource) => {
-  const ds =
-    instance.dataSources.find((ds) => ds.type === DataSourceType.ADMIN) ??
-    instance.dataSources[0];
+export const readableDataSourceType = (type: DataSourceType): string => {
+  if (type === DataSourceType.ADMIN) {
+    return t("data-source.admin");
+  } else if (type === DataSourceType.READ_ONLY) {
+    return t("data-source.read-only");
+  } else {
+    return "Unknown";
+  }
+};
+
+export const hostPortOfDataSource = (ds: DataSource | undefined): string => {
   if (!ds) {
     return "";
   }
@@ -64,6 +74,13 @@ export const hostPortOfInstanceV1 = (instance: Instance | InstanceResource) => {
     parts.push(ds.port);
   }
   return parts.join(":");
+};
+
+export const hostPortOfInstanceV1 = (instance: Instance | InstanceResource) => {
+  const ds =
+    instance.dataSources.find((ds) => ds.type === DataSourceType.ADMIN) ??
+    instance.dataSources[0];
+  return hostPortOfDataSource(ds);
 };
 
 // Sort the list to put prod items first.

--- a/frontend/src/views/InstanceDashboard.vue
+++ b/frontend/src/views/InstanceDashboard.vue
@@ -17,14 +17,20 @@
       :loading="!ready"
       :instance-list="filteredInstanceV1List"
       :can-assign-license="subscriptionStore.currentPlan !== PlanType.FREE"
+      :default-expand-dataSource="state.dataSourceToggle"
     />
   </div>
 </template>
 
-<script lang="ts" setup>
-import { computed, onMounted, reactive } from "vue";
+<script lang="tsx" setup>
+import { NTag } from "naive-ui";
+import { computed, onMounted, reactive, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import AdvancedSearch from "@/components/AdvancedSearch";
+import type {
+  ScopeOption,
+  ValueOption,
+} from "@/components/AdvancedSearch/types";
 import { useCommonSearchScopeOptions } from "@/components/AdvancedSearch/useCommonSearchScopeOptions";
 import { FeatureAttention } from "@/components/FeatureGuard";
 import { InstanceV1Table } from "@/components/v2";
@@ -35,16 +41,22 @@ import {
   useInstanceV1List,
   useInstanceV1Store,
 } from "@/store";
-import { UNKNOWN_ID } from "@/types";
-import { PlanType } from "@/types/proto/v1/subscription_service";
-import type { SearchParams } from "@/utils";
 import {
+  dataSourceTypeToJSON,
+  type DataSourceType,
+} from "@/types/proto/v1/instance_service";
+import { PlanType } from "@/types/proto/v1/subscription_service";
+import {
+  type SearchParams,
+  hostPortOfDataSource,
+  readableDataSourceType,
   sortInstanceV1ListByEnvironmentV1,
   extractEnvironmentResourceName,
 } from "@/utils";
 
 interface LocalState {
   params: SearchParams;
+  dataSourceToggle: string[];
 }
 
 const { t } = useI18n();
@@ -59,18 +71,93 @@ const state = reactive<LocalState>({
     query: "",
     scopes: [],
   },
+  dataSourceToggle: [],
 });
-
-const scopeOptions = useCommonSearchScopeOptions(
-  computed(() => state.params),
-  ["environment"]
-);
 
 const selectedEnvironment = computed(() => {
   return (
-    state.params.scopes.find((scope) => scope.id === "environment")?.value ??
-    `${UNKNOWN_ID}`
+    state.params.scopes.find((scope) => scope.id === "environment")?.value ?? ""
   );
+});
+
+const selectedAddress = computed(() => {
+  return (
+    state.params.scopes.find((scope) => scope.id === "address")?.value ?? ""
+  );
+});
+
+watch(
+  () => selectedAddress.value,
+  (selectedAddress) => {
+    if (!selectedAddress) {
+      state.dataSourceToggle = [];
+    }
+  }
+);
+
+const addressOptions = computed(() => {
+  const addressMap: Map<
+    string,
+    {
+      keywords: string[];
+      types: Set<string>;
+    }
+  > = new Map();
+
+  for (const instance of instanceList.value) {
+    for (const ds of instance.dataSources) {
+      const host = hostPortOfDataSource(ds);
+      if (!host) {
+        continue;
+      }
+      if (!addressMap.has(host)) {
+        addressMap.set(host, {
+          keywords: [ds.host, ds.port],
+          types: new Set(),
+        });
+      }
+      addressMap.get(host)?.types?.add(readableDataSourceType(ds.type));
+    }
+  }
+
+  const options: ValueOption[] = [];
+  for (const [host, item] of addressMap.entries()) {
+    options.push({
+      value: host,
+      keywords: [...item.keywords, ...item.types],
+      render: () => {
+        return (
+          <div class={"flex items-center gap-x-2"}>
+            {host}
+            <div class={"flex items-center gap-x-1"}>
+              {[...item.types].map((type) => (
+                <NTag size="small" round>
+                  {type}
+                </NTag>
+              ))}
+            </div>
+          </div>
+        );
+      },
+    });
+  }
+
+  return options;
+});
+
+const scopeOptions = computed((): ScopeOption[] => {
+  return [
+    ...useCommonSearchScopeOptions(
+      computed(() => state.params),
+      ["environment"]
+    ).value,
+    {
+      id: "address",
+      title: t("instance.advanced-search.scope.address.title"),
+      description: t("instance.advanced-search.scope.address.description"),
+      options: addressOptions.value,
+    },
+  ];
 });
 
 onMounted(() => {
@@ -83,20 +170,32 @@ onMounted(() => {
 });
 
 const filteredInstanceV1List = computed(() => {
-  let list = [...instanceList.value];
-  if (selectedEnvironment.value !== `${UNKNOWN_ID}`) {
-    list = list.filter(
-      (instance) =>
-        extractEnvironmentResourceName(instance.environment) ===
-        selectedEnvironment.value
-    );
-  }
   const keyword = state.params.query.trim().toLowerCase();
-  if (keyword) {
-    list = list.filter((instance) =>
-      instance.title.toLowerCase().includes(keyword)
-    );
-  }
+  const list = instanceList.value.filter((instance) => {
+    if (keyword) {
+      if (!instance.title.toLowerCase().includes(keyword)) {
+        return false;
+      }
+    }
+    if (selectedEnvironment.value) {
+      if (
+        extractEnvironmentResourceName(instance.environment) !==
+        selectedEnvironment.value
+      ) {
+        return false;
+      }
+    }
+    if (selectedAddress.value) {
+      const matched = instance.dataSources.some(
+        (ds) => hostPortOfDataSource(ds) === selectedAddress.value
+      );
+      if (matched) {
+        state.dataSourceToggle.push(instance.name);
+      }
+      return matched;
+    }
+    return true;
+  });
 
   return sortInstanceV1ListByEnvironmentV1(list, environmentList.value);
 });

--- a/frontend/src/views/InstanceDashboard.vue
+++ b/frontend/src/views/InstanceDashboard.vue
@@ -17,7 +17,7 @@
       :loading="!ready"
       :instance-list="filteredInstanceV1List"
       :can-assign-license="subscriptionStore.currentPlan !== PlanType.FREE"
-      :default-expand-dataSource="state.dataSourceToggle"
+      :default-expand-data-source="state.dataSourceToggle"
     />
   </div>
 </template>
@@ -41,10 +41,6 @@ import {
   useInstanceV1List,
   useInstanceV1Store,
 } from "@/store";
-import {
-  dataSourceTypeToJSON,
-  type DataSourceType,
-} from "@/types/proto/v1/instance_service";
 import { PlanType } from "@/types/proto/v1/subscription_service";
 import {
   type SearchParams,

--- a/frontend/src/views/sql-editor/EditorCommon/QueryContextSettingPopover.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/QueryContextSettingPopover.vue
@@ -99,6 +99,7 @@ import {
   DataSourceQueryPolicy_Restriction,
   PolicyType,
 } from "@/types/proto/v1/org_policy_service";
+import { readableDataSourceType } from "@/utils";
 import { getAdminDataSourceRestrictionOfDatabase } from "@/utils";
 import { useSQLEditorContext } from "../context";
 import QueryModeSelect from "./QueryModeSelect.vue";
@@ -188,16 +189,6 @@ const onDataSourceSelected = (dataSourceId?: string) => {
       dataSourceId: dataSourceId,
     },
   });
-};
-
-const readableDataSourceType = (type: DataSourceType): string => {
-  if (type === DataSourceType.ADMIN) {
-    return t("data-source.admin");
-  } else if (type === DataSourceType.READ_ONLY) {
-    return t("data-source.read-only");
-  } else {
-    return "Unknown";
-  }
 };
 
 watch(


### PR DESCRIPTION
- Show multi-data sources in the instance table

![CleanShot 2024-08-17 at 18 10 37](https://github.com/user-attachments/assets/d61a9ba9-daa2-42e0-afa4-79158dcd09c9)

- Support filter by address

![CleanShot 2024-08-17 at 18 11 14](https://github.com/user-attachments/assets/23ba08c1-c7ac-4d5c-ae06-58a41da0a92f)

- The address can be filtered by host, port or type

![CleanShot 2024-08-17 at 18 13 08](https://github.com/user-attachments/assets/cdadf7ab-62dd-43e6-a59d-8c253a0d6c56)
