### PR TITLE
fix: handle error properly in ClickHouse query

### DIFF
--- a/backend/plugin/db/clickhouse/query.go
+++ b/backend/plugin/db/clickhouse/query.go
@@ -81,7 +81,6 @@ func (driver *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement s
 				slog.Error("rowsAffected returns error", log.BBError(err))
 			}
 			return util.BuildAffectedRowsResult(affectedRows), nil
-
 		}()
 		stop := false
 		if err != nil {

--- a/backend/plugin/db/clickhouse/query.go
+++ b/backend/plugin/db/clickhouse/query.go
@@ -51,9 +51,7 @@ func (driver *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement s
 		queryResult, err := func() (*v1pb.QueryResult, error) {
 			rows, err := conn.QueryContext(ctx, statement)
 			if err != nil {
-				// ClickHouse will return "driver: bad connection" if we use non-SELECT statement for Query(). We need to ignore the error.
-				// nolint
-				return nil, nil
+				return nil, err
 			}
 			defer rows.Close()
 			r, err := convertRowsToQueryResult(rows, driver.maximumSQLResultSize)

--- a/backend/plugin/db/clickhouse/query.go
+++ b/backend/plugin/db/clickhouse/query.go
@@ -5,13 +5,14 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/bytebase/bytebase/backend/common/log"
-	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	"log/slog"
 	"math/big"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/bytebase/bytebase/backend/common/log"
+	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 
 	"github.com/paulmach/orb"
 	"github.com/paulmach/orb/encoding/wkt"


### PR DESCRIPTION
### Problem
In the original code, if ClickHouse executed a query and encountered an error, the error was ignored, and the code returned `nil, nil`. This behavior led to potential panics later in the code, which expected non-nil results.

### Solution
This fix ensures that any error encountered during a ClickHouse query is directly returned, preventing panics and allowing proper error handling. 