### PR TITLE
feat(sql-editor): UI improvements (part.2)

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -187,8 +187,15 @@ const connect = (connection: SQLEditorConnection) => {
       mode: DEFAULT_SQL_EDITOR_TAB_MODE,
     },
     /* beside */ false,
-    /* defaultTitle */ suggestedTabTitleForSQLEditorConnection(connection)
+    /* defaultTitle */ suggestedTabTitleForSQLEditorConnection(connection),
+    /* ignoreMode */ true
   );
+  if (tabStore.currentTab?.mode === "ADMIN") {
+    // Don't enter ADMIN mode initially
+    tabStore.updateCurrentTab({
+      mode: DEFAULT_SQL_EDITOR_TAB_MODE,
+    });
+  }
 };
 
 const prepareSheetLegacy = async () => {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2376,7 +2376,8 @@
     "connect": "Connect",
     "connect-in-admin-mode": "Connect in admin mode",
     "admin-mode": {
-      "self": "Admin mode"
+      "self": "Admin mode",
+      "exit": "Exit admin mode"
     },
     "allow-admin-mode-only": "Instance {instance} is accessible in admin mode only.",
     "run-selected": "Run selected",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1885,7 +1885,10 @@
     "external-database-name": "External Database Name",
     "foreign-table-detail": "Foreign table detail",
     "view-definition": "View definition",
-    "foreign-keys": "Foreign keys"
+    "foreign-keys": "Foreign keys",
+    "foreign-key": {
+      "reference": "Reference"
+    }
   },
   "repository": {
     "our-webhook-link": "The webhook created by Bytebase can be found at {webhookLink}.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2376,7 +2376,8 @@
     "connect": "Conectar",
     "connect-in-admin-mode": "Conectar en modo administrador",
     "admin-mode": {
-      "self": "Modo administrador"
+      "self": "Modo administrador",
+      "exit": "Salir del modo administrador"
     },
     "allow-admin-mode-only": "La instancia {instance} solo es accesible en modo administrador.",
     "run-selected": "Ejecutar selección",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1885,7 +1885,10 @@
     "external-database-name": "Nombre de la base de datos externa",
     "foreign-table-detail": "Detalle de la tabla externa",
     "view-definition": "Ver definición",
-    "foreign-keys": "claves foráneas"
+    "foreign-keys": "claves foráneas",
+    "foreign-key": {
+      "reference": "Referencia"
+    }
   },
   "repository": {
     "our-webhook-link": "El webhook creado por Bytebase se puede encontrar en {webhookLink}.",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2376,7 +2376,8 @@
     "connect": "接続する",
     "connect-in-admin-mode": "管理者モードで接続する",
     "admin-mode": {
-      "self": "管理者モード"
+      "self": "管理者モード",
+      "exit": "管理者モードを終了する"
     },
     "allow-admin-mode-only": "インスタンス {instance} には管理者モードでのみアクセスできます。",
     "run-selected": "選択したステートメントを実行する",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1885,7 +1885,10 @@
     "external-database-name": "外部データベース名",
     "foreign-table-detail": "外部テーブルの詳細",
     "view-definition": "ビューの定義",
-    "foreign-keys": "外部キー"
+    "foreign-keys": "外部キー",
+    "foreign-key": {
+      "reference": "参照"
+    }
   },
   "repository": {
     "our-webhook-link": "Bytebase によって作成された Webhook は、{webhookLink} にあります。",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2376,7 +2376,8 @@
     "connect": "连接",
     "connect-in-admin-mode": "以管理员模式连接",
     "admin-mode": {
-      "self": "管理员模式"
+      "self": "管理员模式",
+      "exit": "退出管理员模式"
     },
     "allow-admin-mode-only": "实例{instance}只能通过管理员模式访问。",
     "run-selected": "运行选中的语句",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1885,7 +1885,10 @@
     "external-database-name": "外部数据库名称",
     "foreign-table-detail": "外部表详情",
     "view-definition": "查看定义",
-    "foreign-keys": "外键"
+    "foreign-keys": "外键",
+    "foreign-key": {
+      "reference": "引用"
+    }
   },
   "repository": {
     "our-webhook-link": "Bytebase 创建的 webhook 可以在 {webhookLink} 中找到。",

--- a/frontend/src/store/modules/sqlEditor/tab.ts
+++ b/frontend/src/store/modules/sqlEditor/tab.ts
@@ -9,7 +9,7 @@ import type {
   CoreSQLEditorTab,
   SQLEditorTab,
 } from "@/types";
-import { UNKNOWN_ID } from "@/types";
+import { DEFAULT_SQL_EDITOR_TAB_MODE, UNKNOWN_ID } from "@/types";
 import {
   WebStorageHelper,
   defaultSQLEditorTab,
@@ -78,6 +78,10 @@ export const useSQLEditorTabStore = defineStore("sqlEditorTab", () => {
       ...stored,
       id,
     });
+    if (tab.mode === "ADMIN") {
+      // Do not enter ADMIN mode initially
+      tab.mode = DEFAULT_SQL_EDITOR_TAB_MODE;
+    }
     watchTab(tab, false /* !immediate */);
     tabsById.set(id, tab);
     return tab;
@@ -218,13 +222,14 @@ export const useSQLEditorTabStore = defineStore("sqlEditorTab", () => {
   const selectOrAddSimilarNewTab = (
     tab: CoreSQLEditorTab,
     beside = false,
-    defaultTitle?: string
+    defaultTitle?: string,
+    ignoreMode?: boolean
   ) => {
     const curr = currentTab.value;
     if (curr) {
       if (
         isDisconnectedSQLEditorTab(curr) ||
-        isSimilarSQLEditorTab(tab, curr)
+        isSimilarSQLEditorTab(tab, curr, ignoreMode)
       ) {
         curr.connection = tab.connection;
         curr.worksheet = tab.worksheet;

--- a/frontend/src/utils/sqlEditor.ts
+++ b/frontend/src/utils/sqlEditor.ts
@@ -83,13 +83,13 @@ const isSameSQLEditorConnection = (
 
 export const isSimilarSQLEditorTab = (
   a: CoreSQLEditorTab,
-  b: CoreSQLEditorTab
+  b: CoreSQLEditorTab,
+  ignoreMode?: boolean
 ): boolean => {
-  return (
-    isSameSQLEditorConnection(a.connection, b.connection) &&
-    a.worksheet === b.worksheet &&
-    a.mode === b.mode
-  );
+  if (!isSameSQLEditorConnection(a.connection, b.connection)) return false;
+  if (a.worksheet !== b.worksheet) return false;
+  if (!ignoreMode && a.mode !== b.mode) return false;
+  return true;
 };
 
 export const isSimilarToDefaultSQLEditorTabTitle = (title: string) => {

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
@@ -170,6 +170,9 @@ export const useActions = () => {
       "view",
       "procedure",
       "function",
+      "index",
+      "foreign-key",
+      "partition-table",
     ] as const;
     if (!SUPPORTED_TYPES.includes(type)) {
       return;
@@ -208,7 +211,15 @@ export const useActions = () => {
     }
 
     const { schema } = target as NodeTarget<
-      "table" | "column" | "view" | "procedure" | "function" | "external-table"
+      | "table"
+      | "column"
+      | "view"
+      | "procedure"
+      | "function"
+      | "external-table"
+      | "index"
+      | "foreign-key"
+      | "partition-table"
     >;
     updateViewState({
       view: typeToView(type),
@@ -216,7 +227,12 @@ export const useActions = () => {
     });
     await nextTick();
     const detail: EditorPanelViewState["detail"] = {};
-    if (type === "table") {
+    if (
+      type === "table" ||
+      type === "index" ||
+      type === "foreign-key" ||
+      type === "partition-table"
+    ) {
       detail.table = (target as NodeTarget<"table">).table.name;
     }
     if (type === "column" && node.parent?.parent?.meta.type === "table") {
@@ -248,6 +264,17 @@ export const useActions = () => {
       detail.externalTable = (
         target as NodeTarget<"external-table">
       ).externalTable.name;
+    }
+    if (type === "index") {
+      detail.index = (target as NodeTarget<"index">).index.name;
+    }
+    if (type === "foreign-key") {
+      detail.foreignKey = (target as NodeTarget<"foreign-key">).foreignKey.name;
+    }
+    if (type === "partition-table") {
+      detail.partition = (
+        target as NodeTarget<"partition-table">
+      ).partition.name;
     }
     updateViewState({
       detail,

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
@@ -219,11 +219,14 @@ export const useActions = () => {
     if (type === "table") {
       detail.table = (target as NodeTarget<"table">).table.name;
     }
-    if (type === "column" && node.parent?.meta.type === "table") {
+    if (type === "column" && node.parent?.parent?.meta.type === "table") {
       detail.table = (target as NodeTarget<"table">).table.name;
       detail.column = (target as NodeTarget<"column">).column.name;
     }
-    if (type === "column" && node.parent?.meta.type === "external-table") {
+    if (
+      type === "column" &&
+      node.parent?.parent?.meta.type === "external-table"
+    ) {
       detail.externalTable = (
         target as NodeTarget<"external-table">
       ).externalTable.name;

--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPanel.vue
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPanel.vue
@@ -2,7 +2,7 @@
   <Drawer
     :show="show"
     :close-on-esc="false"
-    placement="left"
+    placement="right"
     style="--n-body-padding: 4px 0"
     @update:show="$emit('update:show', $event)"
   >

--- a/frontend/src/views/sql-editor/EditorCommon/AdminModeButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/AdminModeButton.vue
@@ -21,11 +21,7 @@ import { storeToRefs } from "pinia";
 import { computed } from "vue";
 import type { PropType } from "vue";
 import { useSQLEditorTabStore } from "@/store";
-import type { CoreSQLEditorTab } from "@/types";
-import {
-  hasWorkspacePermissionV2,
-  suggestedTabTitleForSQLEditorConnection,
-} from "@/utils";
+import { hasWorkspacePermissionV2 } from "@/utils";
 
 const emit = defineEmits<{
   (e: "enter"): void;
@@ -61,16 +57,10 @@ const enterAdminMode = async () => {
     return;
   }
 
-  const target: CoreSQLEditorTab = {
-    connection: { ...tab.connection },
+  tabStore.updateCurrentTab({
     mode: "ADMIN",
-    worksheet: "",
-  };
-  tabStore.selectOrAddSimilarNewTab(
-    target,
-    /* beside */ true,
-    /* title */ suggestedTabTitleForSQLEditorConnection(tab.connection)
-  );
+    statement: "",
+  });
 
   emit("enter");
 };

--- a/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
@@ -18,13 +18,13 @@
             <PlayIcon class="w-4 h-4 !fill-current" />
           </template>
           <template #default>
-            <div class="flex items-center gap-1">
-              <span>{{ $t("common.run") }}</span>
-              <div v-if="currentTab?.mode !== 'ADMIN'">
-                <span>(</span>
-                <span>limit&nbsp;{{ resultRowsLimit }}</span>
-                <span>)</span>
-              </div>
+            <div
+              v-if="currentTab?.mode !== 'ADMIN'"
+              class="inline-flex items-center"
+            >
+              <span>(</span>
+              <span>limit&nbsp;{{ resultRowsLimit }}</span>
+              <span>)</span>
             </div>
           </template>
         </NButton>

--- a/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
@@ -6,7 +6,21 @@
     <div
       class="action-left gap-x-2 flex overflow-x-auto sm:overflow-x-hidden items-center"
     >
-      <NButtonGroup>
+      <NButton
+        v-if="currentTab?.mode === 'ADMIN'"
+        size="small"
+        type="default"
+        :dashed="true"
+        style="--n-padding: 0 8px 0 3px"
+        @click="exitAdminMode"
+      >
+        <template #icon>
+          <ChevronLeftIcon class="w-4 h-4 text-control" />
+        </template>
+        <span>{{ $t("sql-editor.admin-mode.exit") }}</span>
+      </NButton>
+
+      <NButtonGroup v-if="currentTab?.mode !== 'ADMIN'">
         <NButton
           :disabled="!allowQuery"
           type="primary"
@@ -18,10 +32,7 @@
             <PlayIcon class="w-4 h-4 !fill-current" />
           </template>
           <template #default>
-            <div
-              v-if="currentTab?.mode !== 'ADMIN'"
-              class="inline-flex items-center"
-            >
+            <div class="inline-flex items-center">
               <span>(</span>
               <span>limit&nbsp;{{ resultRowsLimit }}</span>
               <span>)</span>
@@ -32,25 +43,6 @@
           :disabled="!showQueryContextSettingPopover || !allowQuery"
         />
       </NButtonGroup>
-
-      <NPopover v-if="currentTab?.mode === 'ADMIN'" placement="bottom">
-        <template #trigger>
-          <NButton
-            size="small"
-            type="default"
-            :dashed="true"
-            style="--n-padding: 0 5px"
-            @click="exitAdminMode"
-          >
-            <template #icon>
-              <WrenchIcon class="w-4 h-4 text-control-placeholder" />
-            </template>
-          </NButton>
-        </template>
-        <template #default>
-          <span>{{ $t("sql-editor.admin-mode.exit") }}</span>
-        </template>
-      </NPopover>
 
       <NPopover placement="bottom">
         <template #trigger>
@@ -139,7 +131,12 @@
 </template>
 
 <script lang="ts" setup>
-import { PlayIcon, SaveIcon, Share2Icon, WrenchIcon } from "lucide-vue-next";
+import {
+  ChevronLeftIcon,
+  PlayIcon,
+  SaveIcon,
+  Share2Icon,
+} from "lucide-vue-next";
 import { NButtonGroup, NButton, NPopover } from "naive-ui";
 import { storeToRefs } from "pinia";
 import { computed, reactive } from "vue";

--- a/frontend/src/views/sql-editor/EditorCommon/QueryContextSettingPopover.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/QueryContextSettingPopover.vue
@@ -1,5 +1,10 @@
 <template>
-  <NPopover placement="bottom-end" trigger="click" :disabled="disabled">
+  <NPopover
+    v-if="show"
+    placement="bottom-end"
+    trigger="click"
+    :disabled="disabled"
+  >
     <template #trigger>
       <NButton
         :disabled="disabled"
@@ -114,6 +119,10 @@ const tabStore = useSQLEditorTabStore();
 const { standardModeEnabled } = useSQLEditorContext();
 const { connection, database } = useConnectionOfCurrentSQLEditorTab();
 const policyStore = usePolicyV1Store();
+
+const show = computed(() => {
+  return tabStore.currentTab?.mode !== "ADMIN";
+});
 
 const isExecutingSQL = computed(
   () => tabStore.currentTab?.queryContext?.status === "EXECUTING"

--- a/frontend/src/views/sql-editor/EditorCommon/SheetConnectionIcon.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/SheetConnectionIcon.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="inline-flex items-center justify-center">
     <EngineIcon v-if="instance" :engine="instance.engine" />
-    <octicon:unlink-16 v-else class="w-3.5 h-3.5 text-control opacity-50" />
+    <UnlinkIcon v-else class="w-3.5 h-3.5 text-control opacity-50" />
   </div>
 </template>
 
 <script setup lang="ts">
+import { UnlinkIcon } from "lucide-vue-next";
 import { computed } from "vue";
 import { EngineIcon } from "@/components/Icon";
 import { useDatabaseV1Store } from "@/store";

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTableColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTableColumnsTable.vue
@@ -55,7 +55,7 @@ const filteredColumns = computed(() => {
   const keyword = props.keyword?.trim().toLowerCase();
   if (keyword) {
     return props.externalTable.columns.filter((column) =>
-      column.name.includes(keyword)
+      column.name.toLowerCase().includes(keyword)
     );
   }
   return props.externalTable.columns;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTablesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTablesTable.vue
@@ -63,7 +63,7 @@ const filteredExternalTables = computed(() => {
   const keyword = props.keyword?.trim().toLowerCase();
   if (keyword) {
     return props.externalTables.filter((externalTable) =>
-      externalTable.name.includes(keyword)
+      externalTable.name.toLowerCase().includes(keyword)
     );
   }
   return props.externalTables;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
@@ -63,7 +63,9 @@ const { viewState } = useEditorPanelContext();
 const filteredFuncs = computed(() => {
   const keyword = props.keyword?.trim().toLowerCase();
   if (keyword) {
-    return props.funcs.filter((func) => func.name.includes(keyword));
+    return props.funcs.filter((func) =>
+      func.name.toLowerCase().includes(keyword)
+    );
   }
   return props.funcs;
 });

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ProceduresPanel/ProceduresTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ProceduresPanel/ProceduresTable.vue
@@ -64,7 +64,7 @@ const filteredProcedures = computed(() => {
   const keyword = props.keyword?.trim().toLowerCase();
   if (keyword) {
     return props.procedures.filter((procedure) =>
-      procedure.name.includes(keyword)
+      procedure.name.toLowerCase().includes(keyword)
     );
   }
   return props.procedures;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
@@ -59,7 +59,7 @@ const filteredColumns = computed(() => {
   const keyword = props.keyword?.trim().toLowerCase();
   if (keyword) {
     return props.table.columns.filter((column) =>
-      column.name.includes(keyword)
+      column.name.toLowerCase().includes(keyword)
     );
   }
   return props.table.columns;
@@ -213,14 +213,5 @@ watch(
 }
 :deep(.n-data-table-td.text-cell) {
   @apply pr-1 py-0;
-}
-:not(.disable-diff-coloring) :deep(.n-data-table-tr.created .n-data-table-td) {
-  @apply text-green-700 !bg-green-50;
-}
-:not(.disable-diff-coloring) :deep(.n-data-table-tr.dropped .n-data-table-td) {
-  @apply text-red-700 cursor-not-allowed !bg-red-50 opacity-70;
-}
-:not(.disable-diff-coloring) :deep(.n-data-table-tr.updated .n-data-table-td) {
-  @apply text-yellow-700 !bg-yellow-50;
 }
 </style>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ForeignKeysTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ForeignKeysTable.vue
@@ -1,0 +1,169 @@
+<template>
+  <div ref="containerElRef" class="w-full h-full overflow-x-auto">
+    <NDataTable
+      v-bind="$attrs"
+      ref="dataTableRef"
+      size="small"
+      :row-key="(fk) => fk.name"
+      :columns="columns"
+      :data="layoutReady ? filteredForeignKeys : []"
+      :max-height="tableBodyHeight"
+      :virtual-scroll="true"
+      :striped="true"
+      :bordered="true"
+      :bottom-bordered="true"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { DataTableColumn, DataTableInst } from "naive-ui";
+import { NDataTable } from "naive-ui";
+import { computed, h, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import type { ComposedDatabase } from "@/types";
+import { Engine } from "@/types/proto/v1/common";
+import type {
+  DatabaseMetadata,
+  ForeignKeyMetadata,
+  SchemaMetadata,
+  TableMetadata,
+} from "@/types/proto/v1/database_service";
+import { getHighlightHTMLByRegExp } from "@/utils";
+import { useAutoHeightDataTable } from "../../common";
+import { useEditorPanelContext } from "../../context";
+
+const props = defineProps<{
+  db: ComposedDatabase;
+  database: DatabaseMetadata;
+  schema: SchemaMetadata;
+  table: TableMetadata;
+  keyword?: string;
+}>();
+
+const { viewState } = useEditorPanelContext();
+const { containerElRef, tableBodyHeight, layoutReady } =
+  useAutoHeightDataTable();
+const dataTableRef = ref<DataTableInst>();
+const vlRef = computed(() => {
+  return (dataTableRef.value as any)?.$refs?.mainTableInstRef?.bodyInstRef
+    ?.virtualListRef;
+});
+const { t } = useI18n();
+
+const filteredForeignKeys = computed(() => {
+  const keyword = props.keyword?.trim().toLowerCase();
+  if (!keyword) return props.table.foreignKeys;
+  return props.table.foreignKeys.filter(
+    (fk) =>
+      fk.name.toLowerCase().includes(keyword) ||
+      fk.columns.some((column) => column.toLowerCase().includes(keyword)) ||
+      fk.referencedSchema.toLowerCase().includes(keyword) ||
+      fk.referencedTable.toLowerCase().includes(keyword) ||
+      fk.referencedColumns.some((column) =>
+        column.toLowerCase().includes(keyword)
+      )
+  );
+});
+
+const columns = computed(() => {
+  const columns: (DataTableColumn<ForeignKeyMetadata> & { hide?: boolean })[] =
+    [
+      {
+        key: "name",
+        title: t("schema-editor.column.name"),
+        resizable: true,
+        minWidth: 140,
+        className: "truncate",
+        render: (index) => {
+          return h("span", {
+            innerHTML: getHighlightHTMLByRegExp(
+              index.name,
+              props.keyword ?? ""
+            ),
+          });
+        },
+      },
+      {
+        key: "columns",
+        title: t("schema-editor.columns"),
+        resizable: true,
+        minWidth: 140,
+        render: (fk) => {
+          const keyword = props.keyword ?? "";
+          const columns = fk.columns.map((column) => {
+            return h("span", {
+              innerHTML: getHighlightHTMLByRegExp(column, keyword),
+            });
+          });
+          return h("div", { class: "flex flex-col gap-1" }, columns);
+        },
+      },
+      {
+        key: "referencedColumns",
+        title: t("database.foreign-key.reference"),
+        resizable: true,
+        minWidth: 140,
+        render: (fk) => {
+          const keyword = props.keyword ?? "";
+          const columns = fk.referencedColumns.map((column) => {
+            const parts: string[] = [];
+            if (fk.referencedSchema) parts.push(fk.referencedSchema);
+            parts.push(fk.referencedTable);
+            parts.push(column);
+            return h("span", {
+              innerHTML: getHighlightHTMLByRegExp(parts.join("."), keyword),
+            });
+          });
+          return h("div", { class: "flex flex-col gap-1" }, columns);
+        },
+      },
+      {
+        key: "onDelete",
+        title: "ON DELETE",
+        resizable: true,
+        minWidth: 140,
+        hide: props.table.foreignKeys.every((fk) => !fk.onDelete),
+      },
+      {
+        key: "onUpdate",
+        title: "ON UPDATE",
+        resizable: true,
+        minWidth: 140,
+        hide: props.table.foreignKeys.every((fk) => !fk.onUpdate),
+      },
+      {
+        key: "matchType",
+        title: "Match type",
+        resizable: true,
+        minWidth: 140,
+        hide: props.db.instanceResource.engine !== Engine.POSTGRES,
+      },
+    ];
+  return columns.filter((header) => !header.hide);
+});
+
+watch(
+  [() => viewState.value?.detail.foreignKey, vlRef],
+  ([fk, vl]) => {
+    if (fk && vl) {
+      requestAnimationFrame(() => {
+        vl.scrollTo({ key: fk });
+      });
+    }
+  },
+  { immediate: true }
+);
+</script>
+
+<style lang="postcss" scoped>
+:deep(.n-data-table-th .n-data-table-resize-button::after) {
+  @apply bg-control-bg h-2/3;
+}
+:deep(.n-data-table-td.input-cell) {
+  @apply pl-0.5 pr-1 py-0;
+}
+:deep(.n-data-table-td.checkbox-cell) {
+  @apply pr-1 py-0;
+}
+</style>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/IndexesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/IndexesTable.vue
@@ -1,0 +1,144 @@
+<template>
+  <div ref="containerElRef" class="w-full h-full overflow-x-auto">
+    <NDataTable
+      v-bind="$attrs"
+      ref="dataTableRef"
+      size="small"
+      :row-key="(index) => index.name"
+      :columns="columns"
+      :data="layoutReady ? filteredIndexes : []"
+      :max-height="tableBodyHeight"
+      :virtual-scroll="true"
+      :striped="true"
+      :bordered="true"
+      :bottom-bordered="true"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { DataTableColumn, DataTableInst } from "naive-ui";
+import { NCheckbox, NDataTable } from "naive-ui";
+import { computed, h, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import type { ComposedDatabase } from "@/types";
+import type {
+  DatabaseMetadata,
+  IndexMetadata,
+  SchemaMetadata,
+  TableMetadata,
+} from "@/types/proto/v1/database_service";
+import { getHighlightHTMLByRegExp } from "@/utils";
+import { useAutoHeightDataTable } from "../../common";
+import { useEditorPanelContext } from "../../context";
+
+const props = defineProps<{
+  db: ComposedDatabase;
+  database: DatabaseMetadata;
+  schema: SchemaMetadata;
+  table: TableMetadata;
+  keyword?: string;
+}>();
+
+const { viewState } = useEditorPanelContext();
+const { containerElRef, tableBodyHeight, layoutReady } =
+  useAutoHeightDataTable();
+const dataTableRef = ref<DataTableInst>();
+const vlRef = computed(() => {
+  return (dataTableRef.value as any)?.$refs?.mainTableInstRef?.bodyInstRef
+    ?.virtualListRef;
+});
+const { t } = useI18n();
+
+const filteredIndexes = computed(() => {
+  const keyword = props.keyword?.trim().toLowerCase();
+  if (!keyword) return props.table.indexes;
+  return props.table.indexes.filter(
+    (index) =>
+      index.name.toLowerCase().includes(keyword) ||
+      index.expressions.some((column) => column.toLowerCase().includes(keyword))
+  );
+});
+
+const columns = computed(() => {
+  const columns: (DataTableColumn<IndexMetadata> & { hide?: boolean })[] = [
+    {
+      key: "name",
+      title: t("schema-editor.column.name"),
+      resizable: true,
+      minWidth: 140,
+      className: "truncate",
+      render: (index) => {
+        return h("span", {
+          innerHTML: getHighlightHTMLByRegExp(index.name, props.keyword ?? ""),
+        });
+      },
+    },
+    {
+      key: "columns",
+      title: t("schema-editor.columns"),
+      resizable: true,
+      minWidth: 360,
+      render: (index) => {
+        const tags = index.expressions.map((column) => {
+          return `<span>${getHighlightHTMLByRegExp(column, props.keyword ?? "")}</span>`;
+        });
+        return h("div", { class: "truncate", innerHTML: tags.join(", ") });
+      },
+    },
+    {
+      key: "comment",
+      title: t("schema-editor.column.comment"),
+      resizable: true,
+      minWidth: 140,
+      maxWidth: 320,
+      className: "truncate",
+    },
+    {
+      key: "primary",
+      title: t("schema-editor.column.primary"),
+      resizable: false,
+      width: 80,
+      className: "checkbox-cell",
+      render: (index) => {
+        return h(NCheckbox, { checked: index.primary, readonly: true });
+      },
+    },
+    {
+      key: "unique",
+      title: t("schema-editor.index.unique"),
+      resizable: false,
+      width: 80,
+      className: "checkbox-cell",
+      render: (index) => {
+        return h(NCheckbox, { checked: index.unique, readonly: true });
+      },
+    },
+  ];
+  return columns.filter((header) => !header.hide);
+});
+
+watch(
+  [() => viewState.value?.detail.index, vlRef],
+  ([index, vl]) => {
+    if (index && vl) {
+      requestAnimationFrame(() => {
+        vl.scrollTo({ key: index });
+      });
+    }
+  },
+  { immediate: true }
+);
+</script>
+
+<style lang="postcss" scoped>
+:deep(.n-data-table-th .n-data-table-resize-button::after) {
+  @apply bg-control-bg h-2/3;
+}
+:deep(.n-data-table-td.input-cell) {
+  @apply pl-0.5 pr-1 py-0;
+}
+:deep(.n-data-table-td.checkbox-cell) {
+  @apply pr-1 py-0;
+}
+</style>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/PartitionsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/PartitionsTable.vue
@@ -1,0 +1,187 @@
+<template>
+  <div ref="containerElRef" class="w-full h-full overflow-x-auto">
+    <NDataTable
+      v-bind="$attrs"
+      ref="dataTableRef"
+      size="small"
+      :row-key="partitionKey"
+      :columns="columns"
+      :data="layoutReady ? flattenItemList : []"
+      :max-height="tableBodyHeight"
+      :virtual-scroll="true"
+      :striped="true"
+      :bordered="true"
+      :bottom-bordered="true"
+    />
+  </div>
+</template>
+
+<script setup lang="tsx">
+import { ChevronDownIcon } from "lucide-vue-next";
+import { NDataTable, type DataTableColumn, type DataTableInst } from "naive-ui";
+import { computed, h, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import type { ComposedDatabase } from "@/types";
+import {
+  TablePartitionMetadata,
+  type DatabaseMetadata,
+  type SchemaMetadata,
+  type TableMetadata,
+} from "@/types/proto/v1/database_service";
+import { getHighlightHTMLByRegExp } from "@/utils";
+import { useAutoHeightDataTable } from "../../common";
+import { useEditorPanelContext } from "../../context";
+
+type FlattenTablePartitionMetadata = {
+  partition: TablePartitionMetadata;
+  parent?: TablePartitionMetadata;
+};
+
+const props = defineProps<{
+  db: ComposedDatabase;
+  database: DatabaseMetadata;
+  schema: SchemaMetadata;
+  table: TableMetadata;
+  keyword?: string;
+}>();
+
+const { t } = useI18n();
+const { viewState } = useEditorPanelContext();
+const { containerElRef, tableBodyHeight, layoutReady } =
+  useAutoHeightDataTable();
+const dataTableRef = ref<DataTableInst>();
+const vlRef = computed(() => {
+  return (dataTableRef.value as any)?.$refs?.mainTableInstRef?.bodyInstRef
+    ?.virtualListRef;
+});
+
+const filteredPartitions = computed(() => {
+  const keyword = props.keyword?.trim().toLowerCase();
+  if (!keyword) {
+    return props.table.partitions;
+  }
+  return props.table.partitions.filter((partition) => {
+    return (
+      partition.name.toLowerCase().includes(keyword) ||
+      partition.subpartitions.some((sub) =>
+        sub.name.toLowerCase().includes(keyword)
+      )
+    );
+  });
+});
+
+const flattenItemList = computed(() => {
+  const list: FlattenTablePartitionMetadata[] = [];
+  const dfsWalk = (
+    partition: TablePartitionMetadata,
+    parent?: TablePartitionMetadata
+  ) => {
+    list.push({
+      partition,
+      parent,
+    });
+    partition.subpartitions?.forEach((child) => {
+      dfsWalk(child, partition);
+    });
+  };
+  filteredPartitions.value.forEach((partition) =>
+    dfsWalk(partition, undefined)
+  );
+  return list;
+});
+
+const partitionKey = (item: FlattenTablePartitionMetadata) => {
+  const keys: string[] = [];
+
+  if (item.parent) keys.push(item.parent.name);
+  keys.push(item.partition.name);
+  return keys.join("/");
+};
+
+const columns = computed(() => {
+  const columns: (DataTableColumn<FlattenTablePartitionMetadata> & {
+    hide?: boolean;
+  })[] = [
+    {
+      key: "parent",
+      resizable: false,
+      width: 24,
+      render: (item) => {
+        if (item.partition.subpartitions?.length > 0) {
+          return <ChevronDownIcon class="w-4 h-4" />;
+        }
+      },
+    },
+    {
+      key: "name",
+      title: t("common.name"),
+      resizable: true,
+      minWidth: 140,
+      maxWidth: 320,
+      className: "truncate",
+      render: (item) => {
+        return h("span", {
+          innerHTML: getHighlightHTMLByRegExp(
+            item.partition.name,
+            props.keyword ?? ""
+          ),
+        });
+      },
+    },
+    {
+      key: "type",
+      title: t("common.type"),
+      resizable: true,
+      minWidth: 140,
+      className: "truncate",
+    },
+    {
+      key: "expression",
+      title: t("schema-editor.table-partition.expression"),
+      resizable: true,
+      minWidth: 140,
+      className: "truncate",
+    },
+    {
+      key: "value",
+      title: t("schema-editor.table-partition.value"),
+      resizable: true,
+      minWidth: 140,
+      className: "truncate",
+    },
+  ];
+  return columns.filter((header) => !header.hide);
+});
+
+watch(
+  [() => viewState.value?.detail.partition, vlRef],
+  ([partition, vl]) => {
+    if (partition && vl) {
+      requestAnimationFrame(() => {
+        vl.scrollTo({ key: partition });
+      });
+    }
+  },
+  { immediate: true }
+);
+</script>
+
+<style lang="postcss" scoped>
+:deep(.n-data-table-th .n-data-table-resize-button::after) {
+  @apply bg-control-bg h-2/3;
+}
+:deep(.n-data-table-td.input-cell) {
+  @apply pl-0.5 pr-1 py-0;
+}
+
+:deep(.n-data-table-td.input-cell .n-input__placeholder),
+:deep(.n-data-table-td.input-cell .n-base-selection-placeholder) {
+  @apply italic;
+}
+:deep(.n-data-table-td.checkbox-cell) {
+  @apply pr-1 py-0;
+}
+:deep(.n-data-table-td.text-cell) {
+  @apply pr-1 py-0;
+}
+</style>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TableDetail.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TableDetail.vue
@@ -1,0 +1,181 @@
+<template>
+  <div
+    class="w-full h-[28px] flex flex-row gap-x-2 justify-between items-center"
+  >
+    <NTabs
+      v-model:value="state.view"
+      size="small"
+      style="height: 28px; --n-tab-gap: 1rem"
+    >
+      <template #prefix>
+        <NButton text @click="deselect">
+          <ChevronLeftIcon class="w-5 h-5" />
+          <div class="flex items-center gap-1">
+            <TableIcon class="w-4 h-4" />
+            <span>{{ table.name }}</span>
+          </div>
+        </NButton>
+      </template>
+      <template v-if="tabItems.length > 1">
+        <NTab v-for="tab in tabItems" :key="tab.view" :name="tab.view">
+          <div class="flex items-center gap-1">
+            <component :is="{ render: tab.icon }" class="w-4 h-4" />
+            {{ tab.text }}
+          </div>
+        </NTab>
+      </template>
+      <template #suffix>
+        <SearchBox
+          v-model:value="state.keyword"
+          size="small"
+          style="width: 10rem"
+        />
+      </template>
+    </NTabs>
+  </div>
+  <ColumnsTable
+    v-show="state.view === 'COLUMNS'"
+    :db="db"
+    :database="database"
+    :schema="schema"
+    :table="table"
+    :keyword="state.keyword"
+  />
+  <IndexesTable
+    v-show="state.view === 'INDEXES'"
+    :db="db"
+    :database="database"
+    :schema="schema"
+    :table="table"
+    :keyword="state.keyword"
+  />
+  <ForeignKeysTable
+    v-show="state.view === 'FOREIGN-KEYS'"
+    :db="db"
+    :database="database"
+    :schema="schema"
+    :table="table"
+    :keyword="state.keyword"
+  />
+  <PartitionsTable
+    v-show="state.view === 'PARTITIONS'"
+    :db="db"
+    :database="database"
+    :schema="schema"
+    :table="table"
+    :keyword="state.keyword"
+  />
+</template>
+
+<script setup lang="ts">
+import { ChevronLeftIcon } from "lucide-vue-next";
+import { NButton, NTab, NTabs } from "naive-ui";
+import { computed, h, reactive, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+  ColumnIcon,
+  ForeignKeyIcon,
+  IndexIcon,
+  TableIcon,
+  TablePartitionIcon,
+} from "@/components/Icon";
+import { SearchBox } from "@/components/v2";
+import type { ComposedDatabase } from "@/types";
+import type {
+  DatabaseMetadata,
+  SchemaMetadata,
+  TableMetadata,
+} from "@/types/proto/v1/database_service";
+import { useEditorPanelContext } from "../../context";
+import ColumnsTable from "./ColumnsTable.vue";
+import ForeignKeysTable from "./ForeignKeysTable.vue";
+import IndexesTable from "./IndexesTable.vue";
+import PartitionsTable from "./PartitionsTable.vue";
+
+type View = "COLUMNS" | "INDEXES" | "FOREIGN-KEYS" | "PARTITIONS";
+type LocalState = {
+  view: View;
+  keyword: string;
+};
+
+const props = defineProps<{
+  db: ComposedDatabase;
+  database: DatabaseMetadata;
+  schema: SchemaMetadata;
+  table: TableMetadata;
+}>();
+
+const { t } = useI18n();
+const { viewState, updateViewState } = useEditorPanelContext();
+const state = reactive<LocalState>({
+  view: "COLUMNS",
+  keyword: "",
+});
+
+const tabItems = computed(() => {
+  const items = [
+    { view: "COLUMNS", text: t("database.columns"), icon: () => h(ColumnIcon) },
+  ];
+  const { table } = props;
+  if (table.indexes.length > 0) {
+    items.push({
+      view: "INDEXES",
+      text: t("schema-editor.index.indexes"),
+      icon: () => h(IndexIcon),
+    });
+  }
+  if (table.foreignKeys.length > 0) {
+    items.push({
+      view: "FOREIGN-KEYS",
+      text: t("database.foreign-keys"),
+      icon: () => h(ForeignKeyIcon),
+    });
+  }
+  if (table.partitions.length > 0) {
+    items.push({
+      view: "PARTITIONS",
+      text: t("schema-editor.table-partition.partitions"),
+      icon: () => h(TablePartitionIcon),
+    });
+  }
+  return items;
+});
+
+const deselect = () => {
+  updateViewState({
+    detail: {},
+  });
+};
+
+watch(
+  [
+    () => viewState.value?.detail.table,
+    () => viewState.value?.detail.column,
+    () => viewState.value?.detail.index,
+    () => viewState.value?.detail.foreignKey,
+    () => viewState.value?.detail.partition,
+  ],
+  ([table, column, index, foreignKey, partition]) => {
+    if (!table) return;
+    if (column) {
+      state.view = "COLUMNS";
+      return;
+    }
+    if (index) {
+      state.view = "INDEXES";
+      return;
+    }
+    if (foreignKey) {
+      state.view = "FOREIGN-KEYS";
+      return;
+    }
+    if (partition) {
+      state.view = "PARTITIONS";
+      return;
+    }
+    // fallback
+    state.view = "COLUMNS";
+  },
+  { immediate: true }
+);
+</script>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesPanel.vue
@@ -29,43 +29,18 @@
       @click="select"
     />
 
-    <template v-if="metadata.table">
-      <div
-        class="w-full h-[28px] flex flex-row gap-x-2 justify-between items-center"
-      >
-        <div class="flex items-center justify-start">
-          <NButton text @click="deselect">
-            <ChevronLeftIcon class="w-5 h-5" />
-            <div class="flex items-center gap-1">
-              <TableIcon class="w-4 h-4" />
-              <span>{{ metadata.table.name }}</span>
-            </div>
-          </NButton>
-        </div>
-        <div class="flex items-center justify-end">
-          <SearchBox
-            v-model:value="state.keywords.column"
-            size="small"
-            style="width: 10rem"
-          />
-        </div>
-      </div>
-      <ColumnsTable
-        :db="database"
-        :database="metadata.database"
-        :schema="metadata.schema"
-        :table="metadata.table"
-        :keyword="state.keywords.column"
-      />
-    </template>
+    <TableDetail
+      v-if="metadata.table"
+      :db="database"
+      :database="metadata.database"
+      :schema="metadata.schema"
+      :table="metadata.table"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ChevronLeftIcon } from "lucide-vue-next";
-import { NButton } from "naive-ui";
 import { computed, reactive } from "vue";
-import { TableIcon } from "@/components/Icon";
 import { SearchBox } from "@/components/v2";
 import {
   useConnectionOfCurrentSQLEditorTab,
@@ -76,11 +51,12 @@ import {
   DatabaseMetadataView,
   SchemaMetadata,
   TableMetadata,
+  TablePartitionMetadata,
 } from "@/types/proto/v1/database_service";
 import DatabaseChooser from "@/views/sql-editor/EditorCommon/DatabaseChooser.vue";
 import { useEditorPanelContext } from "../../context";
 import { SchemaSelectToolbar } from "../common";
-import ColumnsTable from "./ColumnsTable.vue";
+import TableDetail from "./TableDetail.vue";
 import TablesTable from "./TablesTable.vue";
 
 const { database } = useConnectionOfCurrentSQLEditorTab();
@@ -94,7 +70,6 @@ const databaseMetadata = computed(() => {
 const state = reactive({
   keywords: {
     table: "",
-    column: "",
   },
 });
 
@@ -112,16 +87,14 @@ const metadata = computed(() => {
 const select = (selected: {
   database: DatabaseMetadata;
   schema: SchemaMetadata;
-  table: TableMetadata;
+  table?: TableMetadata;
+  partition?: TablePartitionMetadata;
 }) => {
   updateViewState({
-    detail: { table: selected.table.name },
-  });
-};
-
-const deselect = () => {
-  updateViewState({
-    detail: {},
+    detail: {
+      table: selected.table?.name,
+      partition: selected.partition?.name,
+    },
   });
 };
 </script>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
@@ -72,7 +72,9 @@ const instanceEngine = computed(() => {
 const filteredTables = computed(() => {
   const keyword = props.keyword?.trim().toLowerCase();
   if (keyword) {
-    return props.tables.filter((table) => table.name.includes(keyword));
+    return props.tables.filter((table) =>
+      table.name.toLowerCase().includes(keyword)
+    );
   }
   return props.tables;
 });

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
@@ -63,7 +63,9 @@ const { viewState } = useEditorPanelContext();
 const filteredViews = computed(() => {
   const keyword = props.keyword?.trim().toLowerCase();
   if (keyword) {
-    return props.views.filter((view) => view.name.includes(keyword));
+    return props.views.filter((view) =>
+      view.name.toLowerCase().includes(keyword)
+    );
   }
   return props.views;
 });

--- a/frontend/src/views/sql-editor/EditorPanel/types.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/types.ts
@@ -18,6 +18,9 @@ export type EditorPanelViewState = {
     procedure?: string;
     func?: string;
     externalTable?: string;
+    partition?: string;
+    index?: string;
+    foreignKey?: string;
   };
 };
 

--- a/frontend/src/views/sql-editor/EditorPanel/types.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/types.ts
@@ -33,7 +33,14 @@ export const defaultViewState = (): EditorPanelViewState => {
 };
 
 export const typeToView = (type: string): EditorPanelView => {
-  if (type === "table" || type === "column") return "TABLES";
+  if (
+    type === "table" ||
+    type === "column" ||
+    type === "index" ||
+    type === "foreign-key" ||
+    type === "partition-table"
+  )
+    return "TABLES";
   if (type === "view") return "VIEWS";
   if (type === "function") return "FUNCTIONS";
   if (type === "procedure") return "PROCEDURES";

--- a/frontend/src/views/sql-editor/TabList/TabItem/AdminLabel.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/AdminLabel.vue
@@ -1,25 +1,28 @@
 <template>
   <label class="flex items-center text-sm h-5 ml-0.5 whitespace-nowrap">
-    <EnvironmentV1Name
-      :environment="database.effectiveEnvironmentEntity"
-      :link="false"
-    />
+    <template v-if="!hideEnvironment">
+      <EnvironmentV1Name
+        :environment="database.effectiveEnvironmentEntity"
+        :link="false"
+      />
+      <ChevronRightIcon class="flex-shrink-0 h-4 w-4 opacity-70" />
+    </template>
     <template v-if="isValidInstanceName(instance.name)">
-      <heroicons-solid:chevron-right class="flex-shrink-0 h-4 w-4 opacity-70" />
       <span>{{ instance.title }}</span>
+      <ChevronRightIcon class="flex-shrink-0 h-4 w-4 opacity-70" />
     </template>
     <template v-if="isValidDatabaseName(database.name)">
-      <heroicons-solid:chevron-right class="flex-shrink-0 h-4 w-4 opacity-70" />
       <span>{{ database.databaseName }}</span>
     </template>
   </label>
 </template>
 
 <script lang="ts" setup>
+import { ChevronRightIcon } from "lucide-vue-next";
 import type { PropType } from "vue";
 import { computed } from "vue";
 import { EnvironmentV1Name } from "@/components/v2";
-import { useDatabaseV1Store } from "@/store";
+import { useAppFeature, useDatabaseV1Store } from "@/store";
 import type { SQLEditorTab } from "@/types";
 import { isValidInstanceName, isValidDatabaseName } from "@/types";
 
@@ -34,6 +37,9 @@ const props = defineProps({
   },
 });
 
+const hideEnvironment = useAppFeature(
+  "bb.feature.sql-editor.hide-environments"
+);
 const connection = computed(() => props.tab.connection);
 
 const database = computed(() => {

--- a/frontend/src/views/sql-editor/TabList/TabItem/Prefix.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/Prefix.vue
@@ -8,11 +8,12 @@
     class="w-4 h-4"
   />
   <template v-if="tab.mode === 'ADMIN'">
-    <heroicons-outline:wrench class="w-4 h-4" />
+    <WrenchIcon class="w-4 h-4" />
   </template>
 </template>
 
 <script lang="ts" setup>
+import { WrenchIcon } from "lucide-vue-next";
 import type { PropType } from "vue";
 import { computed } from "vue";
 import { useWorkSheetStore } from "@/store";


### PR DESCRIPTION
Following #13407

- Add indexes, foreign keys and partition tables table in the right, and can be navigated through the tree.
![localhost_3000_sql-editor_projects_default_instances_prod-sample-instance_databases_hr_prod_table=city schema=(1280_800) (1)](https://github.com/user-attachments/assets/0e58bb25-cfdf-44f7-a886-37239ebd130c)
![localhost_3000_sql-editor_projects_default_instances_prod-sample-instance_databases_hr_prod_table=city schema=(1280_800) (2)](https://github.com/user-attachments/assets/7694371b-104a-472c-b945-0a24d30dc9e3)
- Minor changes
  - The set connection drawer now opens from the right side of the window.
  - "Explain" button is removed. While cmd/ctrl + E keyboard shortcut is still working. Same to "Explain" in the context menu.
  - Show no "Run / Run selected" text in the run button.
  - Admin mode changes
    - Show no "Run" button in admin mode.
    - Entering admin mode will not open a new tab, either bringing the current tab's statements.
    - Admin mode is dangerous, so when the page is refreshed or reopened, all admin mode tabs will be turned back to normal tabs.