### PR TITLE
chore(frontend): tweaking setting sidebar style

### DIFF
--- a/frontend/src/components/CommonSidebar.vue
+++ b/frontend/src/components/CommonSidebar.vue
@@ -5,6 +5,7 @@
       class="w-full px-4 shrink-0"
       :redirect="logoRedirect"
     />
+    <slot name="prefix" />
     <div class="flex-1 overflow-y-auto px-2.5 space-y-1">
       <div v-for="(item, i) in filteredSidebarList" :key="i">
         <router-link

--- a/frontend/src/components/ProfileDropdown.vue
+++ b/frontend/src/components/ProfileDropdown.vue
@@ -35,6 +35,7 @@ import { PlanType } from "@/types/proto/v1/subscription_service";
 import { hasWorkspacePermissionV2, isDev } from "@/utils";
 import ProfilePreview from "./ProfilePreview.vue";
 import UserAvatar from "./User/UserAvatar.vue";
+import Version from "./misc/Version.vue";
 
 const { t } = useI18n();
 
@@ -305,6 +306,13 @@ const options = computed((): DropdownOption[] => [
   {
     key: "header-divider",
     type: "divider",
+  },
+  {
+    key: "version",
+    type: "render",
+    render() {
+      return h(Version, { tooltipProps: { placement: "left" } });
+    },
   },
   {
     key: "debug",

--- a/frontend/src/components/misc/Version.vue
+++ b/frontend/src/components/misc/Version.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="flex flex-col px-4 whitespace-nowrap text-sm">
+    <div v-if="isDemo" class="flex gap-1 items-center text-accent py-2">
+      <heroicons-outline:presentation-chart-bar class="w-5 h-5" />
+      {{ $t("common.demo-mode") }}
+    </div>
+    <div v-else class="py-2">
+      <div
+        v-if="subscriptionViewMode === 'TRIAL'"
+        class="flex items-center gap-1 text-accent cursor-pointer"
+        @click="state.showTrialModal = true"
+      >
+        <heroicons-solid:sparkles class="w-5 h-5" />
+        <span>{{ $t("subscription.plan.try") }}</span>
+      </div>
+      <router-link
+        v-if="subscriptionViewMode === 'LINK'"
+        :to="{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }"
+        exact-active-class=""
+      >
+        {{ $t(readableCurrentPlan) }}
+      </router-link>
+      <div v-if="subscriptionViewMode === 'PLAIN'">
+        {{ $t(readableCurrentPlan) }}
+      </div>
+    </div>
+
+    <NTooltip v-bind="tooltipProps">
+      <template #trigger>
+        <div
+          class="flex items-center gap-1 py-2"
+          :class="
+            canUpgrade
+              ? 'text-success cursor-pointer'
+              : 'text-control-light cursor-default'
+          "
+          @click="state.showReleaseModal = canUpgrade"
+        >
+          <Volume2Icon v-if="canUpgrade" class="h-5 w-5" />
+          {{ version }}
+        </div>
+      </template>
+      <template #default>
+        <div class="flex flex-col gap-y-1">
+          <div v-if="canUpgrade" class="whitespace-nowrap">
+            {{ $t("settings.release.new-version-available") }}
+          </div>
+          <div>BE Git hash: {{ gitCommitBE }}</div>
+          <div>FE Git hash: {{ gitCommitFE }}</div>
+        </div>
+      </template>
+    </NTooltip>
+  </div>
+
+  <TrialModal
+    v-if="state.showTrialModal"
+    @cancel="state.showTrialModal = false"
+  />
+  <ReleaseRemindModal
+    v-if="!hideReleaseRemind && state.showReleaseModal"
+    @cancel="state.showReleaseModal = false"
+  />
+</template>
+
+<script lang="ts" setup>
+import { Volume2Icon } from "lucide-vue-next";
+import { NTooltip, type TooltipProps } from "naive-ui";
+import { storeToRefs } from "pinia";
+import { computed, reactive } from "vue";
+import { SETTING_ROUTE_WORKSPACE_SUBSCRIPTION } from "@/router/dashboard/workspaceSetting";
+import {
+  useActuatorV1Store,
+  useAppFeature,
+  useSubscriptionV1Store,
+} from "@/store";
+import { PlanType } from "@/types/proto/v1/subscription_service";
+import { hasWorkspacePermissionV2 } from "@/utils";
+import ReleaseRemindModal from "../ReleaseRemindModal.vue";
+import TrialModal from "../TrialModal.vue";
+
+interface LocalState {
+  showTrialModal: boolean;
+  showReleaseModal: boolean;
+}
+
+defineProps<{
+  tooltipProps?: TooltipProps;
+}>();
+
+const actuatorStore = useActuatorV1Store();
+const subscriptionStore = useSubscriptionV1Store();
+const hideReleaseRemind = useAppFeature("bb.feature.hide-release-remind");
+const hideTrial = useAppFeature("bb.feature.hide-trial");
+const disallowNavigateToConsole = useAppFeature(
+  "bb.feature.disallow-navigate-to-console"
+);
+
+const state = reactive<LocalState>({
+  showTrialModal: false,
+  showReleaseModal: false,
+});
+
+const { isDemo } = storeToRefs(actuatorStore);
+const canUpgrade = computed(() => {
+  return actuatorStore.hasNewRelease;
+});
+
+const subscriptionViewMode = computed(() => {
+  if (disallowNavigateToConsole.value) {
+    return "PLAIN";
+  }
+  if (
+    !hideTrial.value &&
+    subscriptionStore.currentPlan === PlanType.FREE &&
+    hasWorkspacePermissionV2("bb.settings.set")
+  ) {
+    return "TRIAL";
+  }
+  return "LINK";
+});
+
+const readableCurrentPlan = computed((): string => {
+  const plan = subscriptionStore.currentPlan;
+  switch (plan) {
+    case PlanType.TEAM:
+      return "subscription.plan.team.title";
+    case PlanType.ENTERPRISE:
+      return "subscription.plan.enterprise.title";
+    default:
+      return "subscription.plan.free.title";
+  }
+});
+
+const version = computed(() => {
+  const v = actuatorStore.version;
+  if (v.split(".").length == 3) {
+    return `v${v}`;
+  }
+  return v;
+});
+
+const gitCommitBE = computed(() => {
+  return `${actuatorStore.gitCommit.substring(0, 7)}`;
+});
+const gitCommitFE = computed(() => {
+  const commitHash = import.meta.env.BB_GIT_COMMIT_ID_FE as string | undefined;
+  return (commitHash ?? "unknown").substring(0, 7);
+});
+</script>

--- a/frontend/src/customAppProfile.ts
+++ b/frontend/src/customAppProfile.ts
@@ -95,6 +95,7 @@ const overrideAppFeatures = (
     actuatorStore.overrideAppFeatures({
       "bb.feature.hide-quick-start": true,
       "bb.feature.hide-help": true,
+      "bb.feature.hide-trial": true,
       "bb.feature.members.hide-groups": true,
       "bb.feature.members.hide-project-roles": true,
       "bb.feature.members.hide-service-account": true,

--- a/frontend/src/types/appProfile.ts
+++ b/frontend/src/types/appProfile.ts
@@ -8,6 +8,7 @@ export type AppFeatures = {
   "bb.feature.hide-banner": boolean;
   "bb.feature.hide-help": boolean;
   "bb.feature.hide-quick-start": boolean;
+  "bb.feature.hide-trial": boolean;
   "bb.feature.hide-release-remind": boolean;
   "bb.feature.members.hide-groups": boolean;
   "bb.feature.members.hide-project-roles": boolean;
@@ -62,6 +63,7 @@ export const defaultAppProfile = (): AppProfile => ({
     "bb.feature.hide-help": false,
     "bb.feature.hide-quick-start": false,
     "bb.feature.hide-release-remind": false,
+    "bb.feature.hide-trial": false,
     "bb.feature.members.hide-groups": false,
     "bb.feature.members.hide-project-roles": false,
     "bb.feature.members.hide-service-account": false,

--- a/frontend/src/views/SettingSidebar.vue
+++ b/frontend/src/views/SettingSidebar.vue
@@ -5,11 +5,28 @@
     :get-item-class="getItemClass"
     :logo-redirect="WORKSPACE_ROUTE_MY_ISSUES"
     @select="onSelect"
-  />
+  >
+    <template #prefix>
+      <div class="px-2.5 mb-2">
+        <router-link
+          class="group flex items-center gap-2 px-2 py-1.5 leading-normal font-medium rounded-md text-main outline-item !text-base"
+          :to="{ name: WORKSPACE_ROUTE_MY_ISSUES }"
+        >
+          <ChevronLeftIcon class="w-5 h-5" />
+          <span>{{ $t("common.setting") }}</span>
+        </router-link>
+      </div>
+    </template>
+  </CommonSidebar>
 </template>
 
 <script lang="ts" setup>
-import { UserCircle, Building, Archive } from "lucide-vue-next";
+import {
+  UserCircle,
+  Building,
+  Archive,
+  ChevronLeftIcon,
+} from "lucide-vue-next";
 import { computed, h } from "vue";
 import { useI18n } from "vue-i18n";
 import type { RouteRecordRaw } from "vue-router";

--- a/frontend/src/views/sql-editor/AsidePanel/GutterBar/GutterBar.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/GutterBar/GutterBar.vue
@@ -15,27 +15,17 @@
 
     <div class="flex flex-col justify-end items-center">
       <OpenAIButton :size="size" />
-
-      <SettingButton
-        v-if="!hideSettingButton"
-        :style="buttonStyle"
-        v-bind="buttonProps"
-      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { storeToRefs } from "pinia";
-import { computed, toRef } from "vue";
-import { useAppFeature, useSQLEditorStore } from "@/store";
-import { SettingButton } from "../../Setting";
 import { useSQLEditorContext, type AsidePanelTab } from "../../context";
 import OpenAIButton from "./OpenAIButton.vue";
 import TabItem from "./TabItem.vue";
-import { useButton, type Size } from "./common";
+import { type Size } from "./common";
 
-const props = withDefaults(
+withDefaults(
   defineProps<{
     size?: Size;
   }>(),
@@ -45,25 +35,6 @@ const props = withDefaults(
 );
 
 const { asidePanelTab } = useSQLEditorContext();
-const { strictProject } = storeToRefs(useSQLEditorStore());
-const disableSetting = useAppFeature("bb.feature.sql-editor.disable-setting");
-
-const { props: buttonProps, style: buttonStyle } = useButton({
-  size: toRef(props, "size"),
-  active: false,
-  disabled: false,
-});
-
-const hideSettingButton = computed(() => {
-  if (disableSetting.value) {
-    return true;
-  }
-  if (strictProject.value) {
-    return true;
-  }
-
-  return false;
-});
 
 const handleClickTab = (target: AsidePanelTab) => {
   asidePanelTab.value = target;

--- a/frontend/src/views/sql-editor/SQLEditorSettingPage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorSettingPage.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex flex-row items-stretch w-full flex-1 overflow-hidden">
-    <Sidebar v-if="windowWidth >= 800" class="w-52 border-r" />
+    <div v-if="windowWidth >= 800" class="border-r">
+      <Sidebar class="w-52" />
+    </div>
     <template v-else>
       <teleport to="body">
         <div
@@ -30,7 +32,9 @@
       </teleport>
     </template>
 
-    <router-view />
+    <div class="flex-1">
+      <router-view />
+    </div>
   </div>
 </template>
 

--- a/frontend/src/views/sql-editor/Setting/SettingButton.vue
+++ b/frontend/src/views/sql-editor/Setting/SettingButton.vue
@@ -1,18 +1,16 @@
 <template>
   <NButton v-if="show" @click="goSetting">
-    <template #icon>
-      <SettingsIcon />
-    </template>
+    <SettingsIcon class="w-4 h-4" />
   </NButton>
 </template>
 
 <script setup lang="ts">
 import { SettingsIcon } from "lucide-vue-next";
+import { NButton } from "naive-ui";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { SQL_EDITOR_SETTING_MODULE } from "@/router/sqlEditor";
 import { useSidebarItems } from "./Sidebar";
-import { NButton } from "naive-ui";
 
 const router = useRouter();
 const { itemList } = useSidebarItems();

--- a/frontend/src/views/sql-editor/Setting/Sidebar/Sidebar.vue
+++ b/frontend/src/views/sql-editor/Setting/Sidebar/Sidebar.vue
@@ -1,31 +1,33 @@
 <template>
   <div class="h-full flex flex-col overflow-y-auto bg-control-bg">
-    <nav class="flex-1 flex flex-col overflow-y-hidden">
+    <nav class="flex-1 flex flex-col overflow-y-hidden text-sm">
       <BytebaseLogo
         class="w-full px-4 shrink-0"
         :redirect="SQL_EDITOR_HOME_MODULE"
       />
 
-      <div class="flex-1 overflow-y-auto px-2.5 space-y-1">
+      <div class="px-2.5 mb-2">
+        <router-link
+          class="group flex items-center gap-2 px-2 py-1.5 leading-normal font-medium rounded-md text-main outline-item !text-base"
+          :to="{ name: SQL_EDITOR_HOME_MODULE }"
+        >
+          <ChevronLeftIcon class="w-5 h-5" />
+          <span>{{ $t("common.setting") }}</span>
+        </router-link>
+      </div>
+
+      <div class="flex-1 overflow-y-auto px-2.5 flex flex-col gap-1">
         <div v-for="item in itemList" :key="item.name">
           <router-link
             :to="{ path: item.path, name: item.name }"
-            class="group flex items-center px-2 py-1.5 leading-normal font-medium rounded-md text-gray-700 outline-item !text-sm"
+            class="group flex items-center gap-2 px-2 py-1.5 leading-normal font-medium rounded-md text-gray-700 outline-item"
           >
-            <component :is="item.icon" class="mr-2 w-5 h-5 text-gray-500" />
+            <component :is="item.icon" class="w-5 h-5 text-gray-500" />
             {{ item.title }}
           </router-link>
         </div>
       </div>
     </nav>
-
-    <router-link
-      class="flex-shrink-0 flex gap-x-2 justify-start items-center border-t border-block-border px-3 py-2 hover:bg-control-bg-hover cursor-pointer text-sm"
-      :to="{ name: SQL_EDITOR_HOME_MODULE }"
-    >
-      <ChevronLeftIcon class="w-5 h-5" />
-      <span>{{ $t("common.back") }}</span>
-    </router-link>
   </div>
 </template>
 

--- a/frontend/src/views/sql-editor/TabList/TabList.vue
+++ b/frontend/src/views/sql-editor/TabList/TabList.vue
@@ -42,7 +42,8 @@
       </button>
     </div>
 
-    <div class="hidden lg:block -mt-0.5">
+    <div class="flex items-center gap-2">
+      <SettingButton v-if="!hideSettingButton" size="small" />
       <ProfileDropdown v-if="!hideProfile" />
     </div>
 
@@ -53,19 +54,26 @@
 <script lang="ts" setup>
 import { useResizeObserver } from "@vueuse/core";
 import { useDialog } from "naive-ui";
+import { storeToRefs } from "pinia";
 import scrollIntoView from "scroll-into-view-if-needed";
 import { ref, reactive, nextTick, computed, onMounted, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import Draggable from "vuedraggable";
 import ProfileDropdown from "@/components/ProfileDropdown.vue";
 import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
-import { useAppFeature, useFilterStore, useSQLEditorTabStore } from "@/store";
+import {
+  useAppFeature,
+  useFilterStore,
+  useSQLEditorStore,
+  useSQLEditorTabStore,
+} from "@/store";
 import type { SQLEditorTab } from "@/types";
 import {
   defer,
   emptySQLEditorConnection,
   suggestedTabTitleForSQLEditorConnection,
 } from "@/utils";
+import { SettingButton } from "../Setting";
 import { useSheetContext } from "../Sheet";
 import ContextMenu from "./ContextMenu.vue";
 import TabItem from "./TabItem";
@@ -87,14 +95,27 @@ const state = reactive<LocalState>({
   hoverTabId: "",
 });
 const hideProfile = useAppFeature("bb.feature.sql-editor.hide-profile");
+const disableSetting = useAppFeature("bb.feature.sql-editor.disable-setting");
 const { events: sheetEvents } = useSheetContext();
 const tabListRef = ref<InstanceType<typeof Draggable>>();
+const { strictProject } = storeToRefs(useSQLEditorStore());
 const context = provideTabListContext();
 const contextMenuRef = ref<InstanceType<typeof ContextMenu>>();
 
 const scrollState = reactive({
   moreLeft: false,
   moreRight: false,
+});
+
+const hideSettingButton = computed(() => {
+  if (disableSetting.value) {
+    return true;
+  }
+  if (strictProject.value) {
+    return true;
+  }
+
+  return false;
 });
 
 const filteredTabIdList = computed(() => {


### PR DESCRIPTION
- Move subscription and version info to the profile dropdown
![Snipaste_2024-08-20_20-53-54](https://github.com/user-attachments/assets/f14ceed8-f814-4ba3-9f44-a647cc6588fe)

- Move SQL Editor setting button to the top-right corner next to the profile icon, similar to console
![localhost_3000_sql-editor_projects_default_instances_pg-5433_databases_pagila_table=city schema=(1600_900)](https://github.com/user-attachments/assets/c9e1a87b-75d5-44e2-badb-d282d0358c8e)

- Unify sidebar and back button style for workspace and SQL Editor settinggg
![localhost_3000_sql-editor_setting_general(1600_900)](https://github.com/user-attachments/assets/3e75b5d7-dfc4-4908-af76-6e6e4604aff4)
![localhost_3000_setting_general(1600_900)](https://github.com/user-attachments/assets/5e67196c-765b-4325-8b9a-6f52a110821e)

