### PR TITLE
chore: connected wording

### DIFF
--- a/backend/plugin/parser/mysql/query_span_test.go
+++ b/backend/plugin/parser/mysql/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description        string `yaml:"description,omitempty"`
 		Statement          string `yaml:"statement,omitempty"`
-		defaultDatabase    string `yaml:"defaultDatabase,omitempty"`
+		DefaultDatabase    string `yaml:"defaultDatabase,omitempty"`
 		IgnoreCaseSensitve bool   `yaml:"ignoreCaseSensitive,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
@@ -56,7 +56,7 @@ func TestGetQuerySpan(t *testing.T) {
 			result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 				GetDatabaseMetadataFunc: databaseMetadataGetter,
 				ListDatabaseNamesFunc:   databaseNameLister,
-			}, tc.Statement, tc.defaultDatabase, "", tc.IgnoreCaseSensitve)
+			}, tc.Statement, tc.DefaultDatabase, "", tc.IgnoreCaseSensitve)
 			a.NoErrorf(err, "statement: %s", tc.Statement)
 			resultYaml := result.ToYaml()
 			if record {

--- a/backend/plugin/parser/mysql/query_span_test.go
+++ b/backend/plugin/parser/mysql/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description        string `yaml:"description,omitempty"`
 		Statement          string `yaml:"statement,omitempty"`
-		ConnectedDatabase  string `yaml:"connectedDatabase,omitempty"`
+		defaultDatabase    string `yaml:"defaultDatabase,omitempty"`
 		IgnoreCaseSensitve bool   `yaml:"ignoreCaseSensitive,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
@@ -56,7 +56,7 @@ func TestGetQuerySpan(t *testing.T) {
 			result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 				GetDatabaseMetadataFunc: databaseMetadataGetter,
 				ListDatabaseNamesFunc:   databaseNameLister,
-			}, tc.Statement, tc.ConnectedDatabase, "", tc.IgnoreCaseSensitve)
+			}, tc.Statement, tc.defaultDatabase, "", tc.IgnoreCaseSensitve)
 			a.NoErrorf(err, "statement: %s", tc.Statement)
 			resultYaml := result.ToYaml()
 			if record {

--- a/backend/plugin/parser/mysql/test-data/query-span/case_insensitive.yaml
+++ b/backend/plugin/parser/mysql/test-data/query-span/case_insensitive.yaml
@@ -1,6 +1,6 @@
 - description: Test Case Insensitive
   statement: SELECT * FROM T;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/mysql/test-data/query-span/standard.yaml
+++ b/backend/plugin/parser/mysql/test-data/query-span/standard.yaml
@@ -17,7 +17,7 @@
             product_price DECIMAL(10, 2) PATH '$.price'
         )
     ) AS jt;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -77,7 +77,7 @@
             product_price DECIMAL(10, 2) PATH '$.price'
         )
     ) AS jt;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -135,7 +135,7 @@
           column: ""
 - description: Test For alias.* with join
   statement: SELECT t1.*, t2.* FROM t t1 JOIN (select * from t) t2 ON t1.a = t2.a;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -179,7 +179,7 @@
           column: ""
 - description: Test For Explain statements
   statement: EXPLAIN SELECT 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -204,7 +204,7 @@
     sourcecolumns: []
 - description: Test for simple select const
   statement: SELECT 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -231,7 +231,7 @@
     sourcecolumns: []
 - description: Test asterisk and column
   statement: SELECT *, a FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -305,7 +305,7 @@
           column: ""
 - description: Happy path for a simple select statement
   statement: SELECT * FROM t
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -372,7 +372,7 @@
           column: ""
 - description: Referenced table fields by different format
   statement: SELECT a, t.b, t.c, db.t.d FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -439,7 +439,7 @@
           column: ""
 - description: Scalar subquery in select fields
   statement: SELECT 1 AS col_1, (SELECT(2)) AS col_2, (SELECT AVG(a + b * c) FROM t) AS avg_a_b_c FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -499,7 +499,7 @@
           column: ""
 - description: Multiple-Row subquery in where clause
   statement: SELECT 1 FROM t WHERE a IN (SELECT a FROM t);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -540,7 +540,7 @@
           column: ""
 - description: Correlated subquery in the target field clause.
   statement: SELECT city, (SELECT COUNT(*) FROM paintings p WHERE g.id = p.gallery_id) AS total_paintings FROM galleries g;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -604,7 +604,7 @@
           column: ""
 - description: Test for functions
   statement: SELECT max(a), a-b AS c1, a=b AS c2, a>b, b in (a, c, d) from (SELECT * FROM t) result;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -708,7 +708,7 @@
           column: ""
 - description: Test for SELECT partial FROM JOIN clause
   statement: SELECT t1.*, t2.c, 0 FROM t1 JOIN t2 ON 1 = 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -780,7 +780,7 @@
           column: ""
 - description: Test for JOIN with USING clause
   statement: SELECT * FROM t AS t1 JOIN t AS t2 USING(a);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -868,7 +868,7 @@
           column: ""
 - description: Simple CTE
   statement: WITH t1 AS (SELECT * FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -940,7 +940,7 @@
           column: ""
 - description: Multi-level CTE
   statement: WITH tt2 AS (WITH tt2 AS (SELECT * FROM t) SELECT MAX(a) FROM tt2) SELECT * FROM tt2;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -991,7 +991,7 @@
           column: ""
 - description: Test for CTE rename fields name
   statement: WITH t1(d, c, b, a) AS (SELECT * FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1063,7 +1063,7 @@
           column: ""
 - description: Test for Recursive Common Table Expression dependent closures
   statement: WITH RECURSIVE t1(cc1, cc2, cc3, n) AS (SELECT a AS c1, b AS c2, c AS c3, 1 AS n FROM t UNION SELECT cc1*cc2, cc2 + cc1, cc3 * cc2, n+1 FROM t1 WHERE n < 10) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1150,7 +1150,7 @@
           column: ""
 - description: Test for Non-Recursive Common Table Expression with RECURSIVE key words
   statement: WITH RECURSIVE t1 AS (SELECT 1 AS c1, 2 AS c2, 3 AS c3, 4 AS c4 UNION SELECT a, b, d, c FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",

--- a/backend/plugin/parser/pg/query_span_test.go
+++ b/backend/plugin/parser/pg/query_span_test.go
@@ -18,9 +18,9 @@ import (
 
 func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
-		Description       string `yaml:"description,omitempty"`
-		Statement         string `yaml:"statement,omitempty"`
-		ConnectedDatabase string `yaml:"connectedDatabase,omitempty"`
+		Description     string `yaml:"description,omitempty"`
+		Statement       string `yaml:"statement,omitempty"`
+		defaultDatabase string `yaml:"defaultDatabase,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
 		Metadata  string              `yaml:"metadata,omitempty"`
@@ -49,7 +49,7 @@ func TestGetQuerySpan(t *testing.T) {
 		result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 			GetDatabaseMetadataFunc: databaseMetadataGetter,
 			ListDatabaseNamesFunc:   databaseNameLister,
-		}, tc.Statement, tc.ConnectedDatabase, "", false)
+		}, tc.Statement, tc.defaultDatabase, "", false)
 		a.NoError(err)
 		resultYaml := result.ToYaml()
 		if record {

--- a/backend/plugin/parser/pg/query_span_test.go
+++ b/backend/plugin/parser/pg/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description     string `yaml:"description,omitempty"`
 		Statement       string `yaml:"statement,omitempty"`
-		defaultDatabase string `yaml:"defaultDatabase,omitempty"`
+		DefaultDatabase string `yaml:"defaultDatabase,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
 		Metadata  string              `yaml:"metadata,omitempty"`
@@ -49,7 +49,7 @@ func TestGetQuerySpan(t *testing.T) {
 		result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 			GetDatabaseMetadataFunc: databaseMetadataGetter,
 			ListDatabaseNamesFunc:   databaseNameLister,
-		}, tc.Statement, tc.defaultDatabase, "", false)
+		}, tc.Statement, tc.DefaultDatabase, "", false)
 		a.NoError(err)
 		resultYaml := result.ToYaml()
 		if record {

--- a/backend/plugin/parser/pg/test-data/query_span.yaml
+++ b/backend/plugin/parser/pg/test-data/query_span.yaml
@@ -1,6 +1,6 @@
 - description: Test For PLpgSQL User Defined Function in expression
   statement: SELECT plpgsql_t(1);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -51,7 +51,7 @@
           column: ""
 - description: json_object as target field
   statement: 'SELECT json_object(''id'': a) FROM t'
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -88,7 +88,7 @@
           column: ""
 - description: json_array as target field
   statement: SELECT json_array(a) FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -125,7 +125,7 @@
           column: ""
 - description: json_each as target field
   statement: SELECT jsonb_each(a) FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -162,7 +162,7 @@
           column: ""
 - description: json_each acted as table source
   statement: SELECT * FROM t, jsonb_each(a) WHERE id = 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -213,7 +213,7 @@
           column: ""
 - description: to_jsonb accept table as argument with from table alias
   statement: SELECT to_jsonb(t1) FROM t t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -250,7 +250,7 @@
           column: ""
 - description: Test for JSON function
   statement: SELECT row_to_json(t) FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -287,7 +287,7 @@
           column: ""
 - description: Test For unnest function
   statement: SELECT * FROM unnest(ARRAY[1,2,3], ARRAY[4,5,6]);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -316,7 +316,7 @@
     sourcecolumns: []
 - description: Test For unnest function
   statement: SELECT * FROM unnest(ARRAY[1,2,3]);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -343,7 +343,7 @@
     sourcecolumns: []
 - description: Test For System Function As Table Source
   statement: SELECT * FROM generate_series(1, 3);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -370,7 +370,7 @@
     sourcecolumns: []
 - description: Test For System Function As Table Source
   statement: SELECT * FROM generate_subscripts(ARRAY[1,2,3], 1);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -397,7 +397,7 @@
     sourcecolumns: []
 - description: Test For alias.* with join
   statement: SELECT t1.*, t2.* FROM t t1 JOIN (select * from t) t2 ON t1.a = t2.a;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -441,7 +441,7 @@
           column: ""
 - description: Test For Complex PLpgSQL Function As Table Source
   statement: SELECT * FROM plpgsql_complex_t(1);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -502,7 +502,7 @@
           column: ""
 - description: Test For PLpgSQL Function As Table Source
   statement: SELECT * FROM plpgsql_t(1);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -545,7 +545,7 @@
           column: ""
 - description: Test For Cascade Function As Table Source
   statement: SELECT * FROM cascade_t(1);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -592,7 +592,7 @@
           column: ""
 - description: Test For Function As Table Source
   statement: SELECT * FROM select_t(1);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -635,7 +635,7 @@
           column: ""
 - description: Test For Explain statements
   statement: EXPLAIN SELECT 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -660,7 +660,7 @@
     sourcecolumns: []
 - description: Test for simple select const
   statement: SELECT 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -687,7 +687,7 @@
     sourcecolumns: []
 - description: Test asterisk and column
   statement: SELECT a, * FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -761,7 +761,7 @@
           column: ""
 - description: Happy path for a simple select statement
   statement: SELECT * FROM t
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -828,7 +828,7 @@
           column: ""
 - description: Referenced table fields by different format
   statement: SELECT a, t.b, public.t.c, db.public.t.d FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -895,7 +895,7 @@
           column: ""
 - description: Scalar subquery in select fields
   statement: SELECT 1 AS col_1, (SELECT(2)) AS col_2, (SELECT AVG(a + b * c) FROM t) AS avg_a_b_c FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -955,7 +955,7 @@
           column: ""
 - description: Multiple-Row subquery in where clause
   statement: SELECT 1 FROM t WHERE a IN (SELECT a FROM t);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -996,7 +996,7 @@
           column: ""
 - description: Correlated subquery in the target field clause.
   statement: SELECT city, (SELECT COUNT(*) FROM paintings p WHERE g.id = p.gallery_id) AS total_paintings FROM galleries g;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1060,7 +1060,7 @@
           column: ""
 - description: Test for functions
   statement: SELECT max(a), a-b AS c1, a=b AS c2, a>b, b in (a, c, d) from (SELECT * FROM t) result;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1164,7 +1164,7 @@
           column: ""
 - description: Test for SELECT partial FROM JOIN clause
   statement: SELECT t1.*, t2.c, 0 FROM t1 JOIN t2 ON 1 = 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1236,7 +1236,7 @@
           column: ""
 - description: Test for JOIN with USING clause
   statement: SELECT * FROM t AS t1 JOIN t AS t2 USING(a);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1324,7 +1324,7 @@
           column: ""
 - description: Simple CTE
   statement: WITH t1 AS (SELECT * FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1391,7 +1391,7 @@
           column: ""
 - description: Multi-level CTE
   statement: WITH tt2 AS (WITH tt2 AS (SELECT * FROM t) SELECT MAX(a) FROM tt2) SELECT * FROM tt2;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1437,7 +1437,7 @@
           column: ""
 - description: Test for CTE rename fields name
   statement: WITH t1(d, c, b, a) AS (SELECT * FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1504,7 +1504,7 @@
           column: ""
 - description: Test for Recursive Common Table Expression dependent closures
   statement: WITH RECURSIVE t1(cc1, cc2, cc3, n) AS (SELECT a AS c1, b AS c2, c AS c3, 1 AS n FROM t UNION SELECT cc1*cc2, cc2 + cc1, cc3 * cc2, n+1 FROM t1 WHERE n < 10) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1586,7 +1586,7 @@
           column: ""
 - description: Test for Non-Recursive Common Table Expression with RECURSIVE key words
   statement: WITH RECURSIVE t1 AS (SELECT 1 AS c1, 2 AS c2, 3 AS c3, 4 AS c4 UNION SELECT a, b, d, c FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -1653,7 +1653,7 @@
           column: ""
 - description: query system tables
   statement: select * from information_schema.tables;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",

--- a/backend/plugin/parser/plsql/query_span_test.go
+++ b/backend/plugin/parser/plsql/query_span_test.go
@@ -23,9 +23,9 @@ const (
 
 func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
-		Description       string `yaml:"description,omitempty"`
-		Statement         string `yaml:"statement,omitempty"`
-		ConnectedDatabase string `yaml:"connectedDatabase,omitempty"`
+		Description     string `yaml:"description,omitempty"`
+		Statement       string `yaml:"statement,omitempty"`
+		defaultDatabase string `yaml:"defaultDatabase,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
 		Metadata              string              `yaml:"metadata,omitempty"`
@@ -63,7 +63,7 @@ func TestGetQuerySpan(t *testing.T) {
 			GetDatabaseMetadataFunc:       databaseMetadataGetter,
 			ListDatabaseNamesFunc:         databaseNamesLister,
 			GetLinkedDatabaseMetadataFunc: linkedDatabaseMetadataGetter,
-		}, tc.Statement, tc.ConnectedDatabase, tc.ConnectedDatabase, false)
+		}, tc.Statement, tc.defaultDatabase, tc.defaultDatabase, false)
 		a.NoError(err)
 		a.NotNil(result)
 		resultYaml := result.ToYaml()

--- a/backend/plugin/parser/plsql/query_span_test.go
+++ b/backend/plugin/parser/plsql/query_span_test.go
@@ -25,7 +25,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description     string `yaml:"description,omitempty"`
 		Statement       string `yaml:"statement,omitempty"`
-		defaultDatabase string `yaml:"defaultDatabase,omitempty"`
+		DefaultDatabase string `yaml:"defaultDatabase,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
 		Metadata              string              `yaml:"metadata,omitempty"`
@@ -63,7 +63,7 @@ func TestGetQuerySpan(t *testing.T) {
 			GetDatabaseMetadataFunc:       databaseMetadataGetter,
 			ListDatabaseNamesFunc:         databaseNamesLister,
 			GetLinkedDatabaseMetadataFunc: linkedDatabaseMetadataGetter,
-		}, tc.Statement, tc.defaultDatabase, tc.defaultDatabase, false)
+		}, tc.Statement, tc.DefaultDatabase, tc.DefaultDatabase, false)
 		a.NoError(err)
 		a.NotNil(result)
 		resultYaml := result.ToYaml()

--- a/backend/plugin/parser/plsql/test-data/query_span.yaml
+++ b/backend/plugin/parser/plsql/test-data/query_span.yaml
@@ -1,6 +1,6 @@
 - description: Test for cross-schema view
   statement: SELECT * FROM SCHEMA1.V1;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -75,7 +75,7 @@
           column: ""
 - description: Test for alias.* with join
   statement: SELECT t1.*, alias1.* FROM t1 JOIN (select * from t1) alias1 on t1.a = alias1.a;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -136,7 +136,7 @@
           column: ""
 - description: Test for Join
   statement: SELECT T1.* FROM T1 JOIN T2;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -196,7 +196,7 @@
           column: ""
 - description: Test For Database Link With View
   statement: SELECT * FROM SCHEMA1.LV1@REMOTE;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -241,7 +241,7 @@
     sourcecolumns: []
 - description: Test For Database Link
   statement: SELECT * FROM SCHEMA1.LT1@REMOTE;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -279,7 +279,7 @@
     sourcecolumns: []
 - description: Test For Explain statements
   statement: EXPLAIN PLAN for SELECT 1 FROM DUAL;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -304,7 +304,7 @@
     sourcecolumns: []
 - description: Test for simple select const
   statement: SELECT 1 FROM DUAL;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -331,7 +331,7 @@
     sourcecolumns: []
 - description: Test asterisk and column
   statement: SELECT A, T.* FROM T;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -405,7 +405,7 @@
           column: ""
 - description: Happy path for A simple select statement
   statement: SELECT * FROM T
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -472,7 +472,7 @@
           column: ""
 - description: Referenced table fields by different format
   statement: SELECT A, T.B, PUBLIC.T.C, PUBLIC.T.D FROM T;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -539,7 +539,7 @@
           column: ""
 - description: Scalar subquery in select fields
   statement: SELECT 1 AS col_1, (SELECT(2) FROM DUAL) AS col_2, (SELECT AVG(A + B * C) FROM T) AS avg_a_b_c FROM T;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -599,7 +599,7 @@
           column: ""
 - description: Multiple-Row subquery in where clause
   statement: SELECT 1 FROM T WHERE A IN (SELECT A FROM T);
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -640,7 +640,7 @@
           column: ""
 - description: Correlated subquery in the target field clause.
   statement: SELECT CITY, (SELECT COUNT(*) FROM PAINTINGS p WHERE g.ID = p.GALLERY_ID) AS total_paintings FROM GALLERIES g;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -704,7 +704,7 @@
           column: ""
 - description: Test for functions
   statement: SELECT max(A), A-B AS c1, A=B AS c2, A>B, B in (A, C, D) from (SELECT * FROM T) result;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -808,7 +808,7 @@
           column: ""
 - description: Test for SELECT partial FROM JOIN clause
   statement: SELECT T1.*, T2.C, 0 FROM T1 JOIN T2 ON 1 = 1;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -880,7 +880,7 @@
           column: ""
 - description: Test for JOIN with USING clause
   statement: SELECT * FROM T T1 JOIN T T2 USING(A);
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -968,7 +968,7 @@
           column: ""
 - description: Simple CTE
   statement: WITH T1 AS (SELECT * FROM T) SELECT * FROM T1;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -1035,7 +1035,7 @@
           column: ""
 - description: Multi-level CTE
   statement: WITH tt2 AS (WITH tt2 AS (SELECT * FROM T) SELECT MAX(A) FROM tt2) SELECT * FROM tt2;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -1081,7 +1081,7 @@
           column: ""
 - description: Test for CTE rename fields name
   statement: WITH T1(D, C, B, A) AS (SELECT * FROM T) SELECT * FROM T1;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -1148,7 +1148,7 @@
           column: ""
 - description: Test for Recursive Common Table Expression dependent closures
   statement: WITH T1(cc1, cc2, cc3, n) AS (SELECT A AS c1, B AS c2, C AS c3, 1 AS n FROM T UNION ALL SELECT cc1*cc2, cc2 + cc1, cc3 * cc2, n+1 FROM T1 WHERE n < 10) SELECT * FROM T1;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",
@@ -1230,7 +1230,7 @@
           column: ""
 - description: Test for Non-Recursive Common Table Expression with RECURSIVE key words
   statement: WITH T1 AS (SELECT 1 AS c1, 2 AS c2, 3 AS c3, 4 AS c4 FROM DUAL UNION ALL SELECT A, B, D, C FROM T) SELECT * FROM T1;
-  connectedDatabase: PUBLIC
+  defaultDatabase: PUBLIC
   metadata: |-
     {
       "name":  "PUBLIC",

--- a/backend/plugin/parser/snowflake/query_span_test.go
+++ b/backend/plugin/parser/snowflake/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description        string `yaml:"description,omitempty"`
 		Statement          string `yaml:"statement,omitempty"`
-		ConnectedDatabase  string `yaml:"connectedDatabase,omitempty"`
+		defaultDatabase    string `yaml:"defaultDatabase,omitempty"`
 		IgnoreCaseSensitve bool   `yaml:"ignoreCaseSensitive,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
@@ -59,7 +59,7 @@ func TestGetQuerySpan(t *testing.T) {
 			result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 				GetDatabaseMetadataFunc: databaseMetadataGetter,
 				ListDatabaseNamesFunc:   databaseNameLister,
-			}, tc.Statement, tc.ConnectedDatabase, "PUBLIC", tc.IgnoreCaseSensitve)
+			}, tc.Statement, tc.defaultDatabase, "PUBLIC", tc.IgnoreCaseSensitve)
 			a.NoErrorf(err, "statement: %s", tc.Statement)
 			resultYaml := result.ToYaml()
 			if record {

--- a/backend/plugin/parser/snowflake/query_span_test.go
+++ b/backend/plugin/parser/snowflake/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description        string `yaml:"description,omitempty"`
 		Statement          string `yaml:"statement,omitempty"`
-		defaultDatabase    string `yaml:"defaultDatabase,omitempty"`
+		DefaultDatabase    string `yaml:"defaultDatabase,omitempty"`
 		IgnoreCaseSensitve bool   `yaml:"ignoreCaseSensitive,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
@@ -59,7 +59,7 @@ func TestGetQuerySpan(t *testing.T) {
 			result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 				GetDatabaseMetadataFunc: databaseMetadataGetter,
 				ListDatabaseNamesFunc:   databaseNameLister,
-			}, tc.Statement, tc.defaultDatabase, "PUBLIC", tc.IgnoreCaseSensitve)
+			}, tc.Statement, tc.DefaultDatabase, "PUBLIC", tc.IgnoreCaseSensitve)
 			a.NoErrorf(err, "statement: %s", tc.Statement)
 			resultYaml := result.ToYaml()
 			if record {

--- a/backend/plugin/parser/snowflake/test-data/query-span/cte.yaml
+++ b/backend/plugin/parser/snowflake/test-data/query-span/cte.yaml
@@ -6,7 +6,7 @@
       SELECT C1 * C2, C2 + C1, C3 * C2, N + 1 FROM CTE_01 WHERE N < 5
     )
     SELECT * FROM CTE_01;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/snowflake/test-data/query-span/pivot.yaml
+++ b/backend/plugin/parser/snowflake/test-data/query-span/pivot.yaml
@@ -1,6 +1,6 @@
 - description: Unpivot
   statement: SELECT * FROM T1 UNPIVOT(E FOR F IN (B, C, D));
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -88,7 +88,7 @@
           column: ""
 - description: Pivot
   statement: SELECT TT1.* FROM T1 PIVOT(MAX(A) FOR B IN ('a', 'b', 'c')) AS TT1
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/snowflake/test-data/query-span/set-operator.yaml
+++ b/backend/plugin/parser/snowflake/test-data/query-span/set-operator.yaml
@@ -1,6 +1,6 @@
 - description: Union and Intersect
   statement: SELECT A, B FROM T1 UNION SELECT * FROM T2 INTERSECT SELECT * FROM T3;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/snowflake/test-data/query-span/standard.yaml
+++ b/backend/plugin/parser/snowflake/test-data/query-span/standard.yaml
@@ -1,6 +1,6 @@
 - description: Alias
   statement: SELECT A AS X, B AS Z, C, T.D FROM T1 T;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -96,7 +96,7 @@
           column: ""
 - description: If do not specify the JOIN type explicitly, the default JOIN type is CROSS JOIN.
   statement: SELECT * FROM T1, T2, T3;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -244,7 +244,7 @@
           column: ""
 - description: Natural Join
   statement: SELECT A, E, F FROM T1 NATURAL JOIN T2 NATURAL JOIN T3;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -343,7 +343,7 @@
           column: ""
 - description: Column name projection
   statement: SELECT A, B FROM T1;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -397,7 +397,7 @@
           column: ""
 - description: Simple select asterisk statement
   statement: SELECT * FROM T1;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/snowflake/test-data/query-span/subquery.yaml
+++ b/backend/plugin/parser/snowflake/test-data/query-span/subquery.yaml
@@ -1,6 +1,6 @@
 - description: Uncorrelated Subquery In From Clause
   statement: SELECT A, B, C, D FROM (SELECT * FROM T1) T;
-  connectedDatabase: SNOWFLAKE
+  defaultDatabase: SNOWFLAKE
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/tidb/query_span_test.go
+++ b/backend/plugin/parser/tidb/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description     string `yaml:"description,omitempty"`
 		Statement       string `yaml:"statement,omitempty"`
-		defaultDatabase string `yaml:"defaultDatabase,omitempty"`
+		DefaultDatabase string `yaml:"defaultDatabase,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
 		Metadata  string              `yaml:"metadata,omitempty"`
@@ -49,7 +49,7 @@ func TestGetQuerySpan(t *testing.T) {
 		result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 			GetDatabaseMetadataFunc: databaseMetadataGetter,
 			ListDatabaseNamesFunc:   databaseNamesLister,
-		}, tc.Statement, tc.defaultDatabase, "", false)
+		}, tc.Statement, tc.DefaultDatabase, "", false)
 		a.NoError(err)
 		resultYaml := result.ToYaml()
 		if record {

--- a/backend/plugin/parser/tidb/query_span_test.go
+++ b/backend/plugin/parser/tidb/query_span_test.go
@@ -18,9 +18,9 @@ import (
 
 func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
-		Description       string `yaml:"description,omitempty"`
-		Statement         string `yaml:"statement,omitempty"`
-		ConnectedDatabase string `yaml:"connectedDatabase,omitempty"`
+		Description     string `yaml:"description,omitempty"`
+		Statement       string `yaml:"statement,omitempty"`
+		defaultDatabase string `yaml:"defaultDatabase,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
 		Metadata  string              `yaml:"metadata,omitempty"`
@@ -49,7 +49,7 @@ func TestGetQuerySpan(t *testing.T) {
 		result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 			GetDatabaseMetadataFunc: databaseMetadataGetter,
 			ListDatabaseNamesFunc:   databaseNamesLister,
-		}, tc.Statement, tc.ConnectedDatabase, "", false)
+		}, tc.Statement, tc.defaultDatabase, "", false)
 		a.NoError(err)
 		resultYaml := result.ToYaml()
 		if record {

--- a/backend/plugin/parser/tidb/test-data/query_span.yaml
+++ b/backend/plugin/parser/tidb/test-data/query_span.yaml
@@ -1,6 +1,6 @@
 - description: Test For alias.* with join
   statement: SELECT t1.*, t2.* FROM t t1 JOIN (select * from t) t2 ON t1.a = t2.a;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -44,7 +44,7 @@
         column: ""
 - description: Test For Explain statements
   statement: EXPLAIN SELECT 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -69,7 +69,7 @@
     sourcecolumns: []
 - description: Test for simple select const
   statement: SELECT 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -96,7 +96,7 @@
     sourcecolumns: []
 - description: Test asterisk and column
   statement: SELECT a, * FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -170,7 +170,7 @@
         column: ""
 - description: Happy path for a simple select statement
   statement: SELECT * FROM t
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -237,7 +237,7 @@
         column: ""
 - description: Referenced table fields by different format
   statement: SELECT a, t.b, t.c, db.t.d FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -304,7 +304,7 @@
         column: ""
 - description: Scalar subquery in select fields
   statement: SELECT 1 AS col_1, (SELECT(2)) AS col_2, (SELECT AVG(a + b * c) FROM t) AS avg_a_b_c FROM t;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -364,7 +364,7 @@
         column: ""
 - description: Multiple-Row subquery in where clause
   statement: SELECT 1 FROM t WHERE a IN (SELECT a FROM t);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -405,7 +405,7 @@
         column: ""
 - description: Correlated subquery in the target field clause.
   statement: SELECT city, (SELECT COUNT(*) FROM paintings p WHERE g.id = p.gallery_id) AS total_paintings FROM galleries g;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -469,7 +469,7 @@
         column: ""
 - description: Test for functions
   statement: SELECT max(a), a-b AS c1, a=b AS c2, a>b, b in (a, c, d) from (SELECT * FROM t) result;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -573,7 +573,7 @@
         column: ""
 - description: Test for SELECT partial FROM JOIN clause
   statement: SELECT t1.*, t2.c, 0 FROM t1 JOIN t2 ON 1 = 1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -645,7 +645,7 @@
         column: ""
 - description: Test for JOIN with USING clause
   statement: SELECT * FROM t AS t1 JOIN t AS t2 USING(a);
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -733,7 +733,7 @@
         column: ""
 - description: Simple CTE
   statement: WITH t1 AS (SELECT * FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -800,7 +800,7 @@
         column: ""
 - description: Multi-level CTE
   statement: WITH tt2 AS (WITH tt2 AS (SELECT * FROM t) SELECT MAX(a) FROM tt2) SELECT * FROM tt2;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -846,7 +846,7 @@
         column: ""
 - description: Test for CTE rename fields name
   statement: WITH t1(d, c, b, a) AS (SELECT * FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -913,7 +913,7 @@
         column: ""
 - description: Test for Recursive Common Table Expression dependent closures
   statement: WITH RECURSIVE t1(cc1, cc2, cc3, n) AS (SELECT a AS c1, b AS c2, c AS c3, 1 AS n FROM t UNION SELECT cc1*cc2, cc2 + cc1, cc3 * cc2, n+1 FROM t1 WHERE n < 10) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",
@@ -995,7 +995,7 @@
         column: ""
 - description: Test for Non-Recursive Common Table Expression with RECURSIVE key words
   statement: WITH RECURSIVE t1 AS (SELECT 1 AS c1, 2 AS c2, 3 AS c3, 4 AS c4 UNION SELECT a, b, d, c FROM t) SELECT * FROM t1;
-  connectedDatabase: db
+  defaultDatabase: db
   metadata: |-
     {
       "name":  "db",

--- a/backend/plugin/parser/tsql/query_span_test.go
+++ b/backend/plugin/parser/tsql/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description        string `yaml:"description,omitempty"`
 		Statement          string `yaml:"statement,omitempty"`
-		ConnectedDatabase  string `yaml:"connectedDatabase,omitempty"`
+		defaultDatabase    string `yaml:"defaultDatabase,omitempty"`
 		IgnoreCaseSensitve bool   `yaml:"ignoreCaseSensitive,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
@@ -57,7 +57,7 @@ func TestGetQuerySpan(t *testing.T) {
 			result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 				GetDatabaseMetadataFunc: databaseMetadataGetter,
 				ListDatabaseNamesFunc:   databaseNameLister,
-			}, tc.Statement, tc.ConnectedDatabase, "dbo", tc.IgnoreCaseSensitve)
+			}, tc.Statement, tc.defaultDatabase, "dbo", tc.IgnoreCaseSensitve)
 			a.NoErrorf(err, "statement: %s", tc.Statement)
 			resultYaml := result.ToYaml()
 			if record {

--- a/backend/plugin/parser/tsql/query_span_test.go
+++ b/backend/plugin/parser/tsql/query_span_test.go
@@ -20,7 +20,7 @@ func TestGetQuerySpan(t *testing.T) {
 	type testCase struct {
 		Description        string `yaml:"description,omitempty"`
 		Statement          string `yaml:"statement,omitempty"`
-		defaultDatabase    string `yaml:"defaultDatabase,omitempty"`
+		DefaultDatabase    string `yaml:"defaultDatabase,omitempty"`
 		IgnoreCaseSensitve bool   `yaml:"ignoreCaseSensitive,omitempty"`
 		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
 		// if it's empty, we will use the defaultDatabaseMetadata.
@@ -57,7 +57,7 @@ func TestGetQuerySpan(t *testing.T) {
 			result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
 				GetDatabaseMetadataFunc: databaseMetadataGetter,
 				ListDatabaseNamesFunc:   databaseNameLister,
-			}, tc.Statement, tc.defaultDatabase, "dbo", tc.IgnoreCaseSensitve)
+			}, tc.Statement, tc.DefaultDatabase, "dbo", tc.IgnoreCaseSensitve)
 			a.NoErrorf(err, "statement: %s", tc.Statement)
 			resultYaml := result.ToYaml()
 			if record {

--- a/backend/plugin/parser/tsql/test-data/query-span/case-sensitivity.yaml
+++ b/backend/plugin/parser/tsql/test-data/query-span/case-sensitivity.yaml
@@ -1,6 +1,6 @@
 - description: Case insensitive query but resource column should take original case.
   statement: SELECT dbo.mytable1.a FROM dbo.[mytable1] ;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/tsql/test-data/query-span/join.yaml
+++ b/backend/plugin/parser/tsql/test-data/query-span/join.yaml
@@ -1,6 +1,6 @@
 - description: Join Alias and Asterisk
   statement: SELECT t.* FROM MyTable1 t JOIN MyTable2 u ON t.a = u.id;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -64,7 +64,7 @@
           column: ""
 - description: Join Alias
   statement: SELECT t.a, t.b FROM MyTable1 t JOIN MyTable2 u ON t.a = u.id;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/backend/plugin/parser/tsql/test-data/query-span/standard.yaml
+++ b/backend/plugin/parser/tsql/test-data/query-span/standard.yaml
@@ -1,6 +1,6 @@
 - description: Test for builtin functions
   statement: SELECT NEWID() as uuid;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -37,7 +37,7 @@
     sourcecolumns: []
 - description: Test for view
   statement: SELECT * FROM MyView1;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -91,7 +91,7 @@
           column: ""
 - description: Simple select asterisk statement
   statement: SELECT * FROM MyTable1;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -139,7 +139,7 @@
           column: ""
 - description: Alias table source
   statement: SELECT T1.* FROM MyTable1 AS T1;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -187,7 +187,7 @@
           column: ""
 - description: Subquery in Select target list
   statement: SELECT (SELECT MAX(d) FROM MyTable2) FROM MyTable1;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -244,7 +244,7 @@
           column: ""
 - description: Union
   statement: SELECT a FROM MyTable1 UNION SELECT c FROM MyTable2;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -306,7 +306,7 @@
           column: ""
 - description: Join
   statement: SELECT a, b, c, d FROM MyTable1 JOIN MyTable2 ON MyTable1.a = MyTable2.d;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -384,7 +384,7 @@
           column: ""
 - description: Table Source List
   statement: SELECT a, b, c, d FROM MyTable1, MyTable2;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -462,7 +462,7 @@
           column: ""
 - description: Test for subquery in from cluase with as alias.
   statement: SELECT tt.a, b FROM (SELECT * FROM MyTable1) AS tt;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -521,7 +521,7 @@
           column: ""
 - description: Test for CTE
   statement: WITH tt1(aa, bb) AS ( SELECT a, b FROM MyTable1 ) SELECT tt1.aa, bb FROM tt1;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -592,7 +592,7 @@
       SELECT c FROM MyTable2
     )
     SELECT * FROM tt1 JOIN tt2 ON tt1.aa = tt2.cc;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {
@@ -679,7 +679,7 @@
       SELECT c1 * c2, c2 + c1, c3 * c2, n + 1 FROM cte_01 WHERE n < 5
     )
     SELECT * FROM cte_01;
-  connectedDatabase: db
+  defaultDatabase: db
   ignoreCaseSensitive: true
   metadata: |-
     {

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
@@ -54,7 +54,7 @@
                 !disallowRequestQuery &&
                 resultSet.status === Status.PERMISSION_DENIED
               "
-              :database="database ?? defaultDatabase"
+              :database="database ?? connectedDatabase"
             />
             <SyncDatabaseButton
               v-else-if="
@@ -63,7 +63,7 @@
               "
               :type="'primary'"
               :text="true"
-              :database="database ?? defaultDatabase"
+              :database="database ?? connectedDatabase"
             />
           </template>
         </ErrorView>
@@ -149,7 +149,7 @@ const props = defineProps({
 
 const { t } = useI18n();
 const policyStore = usePolicyV1Store();
-const { instance, database: defaultDatabase } =
+const { instance, database: connectedDatabase } =
   useConnectionOfCurrentSQLEditorTab();
 const disallowRequestQuery = useAppFeature(
   "bb.feature.sql-editor.disallow-request-query"

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
@@ -54,7 +54,7 @@
                 !disallowRequestQuery &&
                 resultSet.status === Status.PERMISSION_DENIED
               "
-              :database="database ?? connectedDb"
+              :database="database ?? defaultDatabase"
             />
             <SyncDatabaseButton
               v-else-if="
@@ -63,7 +63,7 @@
               "
               :type="'primary'"
               :text="true"
-              :database="database ?? connectedDb"
+              :database="database ?? defaultDatabase"
             />
           </template>
         </ErrorView>
@@ -149,7 +149,7 @@ const props = defineProps({
 
 const { t } = useI18n();
 const policyStore = usePolicyV1Store();
-const { instance, database: connectedDb } =
+const { instance, database: defaultDatabase } =
   useConnectionOfCurrentSQLEditorTab();
 const disallowRequestQuery = useAppFeature(
   "bb.feature.sql-editor.disallow-request-query"


### PR DESCRIPTION
"default" is better than "connected". It's consistent with other products, and database/schema in views with fully qualified names are not "connected".