### PR TITLE
chore: respect the min(user limit, request limit)

### DIFF
--- a/backend/plugin/db/mysql/query.go
+++ b/backend/plugin/db/mysql/query.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
@@ -60,9 +61,17 @@ func (r *mysqlRewriter) EnterQueryExpression(ctx *mysql.QueryExpressionContext) 
 		return
 	}
 	r.outerMostQuery = false
-	if ctx.LimitClause() != nil {
+	limitCluase := ctx.LimitClause()
+	if limitCluase != nil {
 		// limit clause already exists.
-		r.rewriter.ReplaceDefault(ctx.LimitClause().GetStart().GetTokenIndex(), ctx.LimitClause().GetStop().GetTokenIndex(), fmt.Sprintf("LIMIT %d", r.limitCount))
+		userLimitText := limitCluase.LimitOptions().GetText()
+		limit, err := strconv.Atoi(userLimitText)
+		if err == nil {
+			if r.limitCount < limit {
+				limit = r.limitCount
+			}
+		}
+		r.rewriter.ReplaceDefault(limitCluase.GetStart().GetTokenIndex(), limitCluase.GetStop().GetTokenIndex(), fmt.Sprintf("LIMIT %d", limit))
 		return
 	}
 

--- a/backend/plugin/db/mysql/query.go
+++ b/backend/plugin/db/mysql/query.go
@@ -62,6 +62,7 @@ func (r *mysqlRewriter) EnterQueryExpression(ctx *mysql.QueryExpressionContext) 
 	r.outerMostQuery = false
 	if ctx.LimitClause() != nil {
 		// limit clause already exists.
+		r.rewriter.ReplaceDefault(ctx.LimitClause().GetStart().GetTokenIndex(), ctx.LimitClause().GetStop().GetTokenIndex(), fmt.Sprintf("LIMIT %d", r.limitCount))
 		return
 	}
 

--- a/backend/plugin/db/mysql/query_test.go
+++ b/backend/plugin/db/mysql/query_test.go
@@ -18,9 +18,14 @@ func TestGetStatementWithResultLimitOfMySQL(t *testing.T) {
 			want:  "SELECT * FROM t LIMIT 10;",
 		},
 		{
+			stmt:  "SELECT * FROM t LIMIT 10;",
+			count: 5,
+			want:  "SELECT * FROM t LIMIT 5;",
+		},
+		{
 			stmt:  "SELECT * FROM t LIMIT 5;",
 			count: 10,
-			want:  "SELECT * FROM t LIMIT 10;",
+			want:  "SELECT * FROM t LIMIT 5;",
 		},
 		{
 			stmt:  "SELECT * FROM t LIMIT 123;",

--- a/backend/plugin/db/mysql/query_test.go
+++ b/backend/plugin/db/mysql/query_test.go
@@ -20,7 +20,12 @@ func TestGetStatementWithResultLimitOfMySQL(t *testing.T) {
 		{
 			stmt:  "SELECT * FROM t LIMIT 5;",
 			count: 10,
-			want:  "SELECT * FROM t LIMIT 5;",
+			want:  "SELECT * FROM t LIMIT 10;",
+		},
+		{
+			stmt:  "SELECT * FROM t LIMIT 123;",
+			count: 10,
+			want:  "SELECT * FROM t LIMIT 10;",
 		},
 		{
 			stmt:  "SELECT * FROM t2 JOIN t1 ON t2.c2 = t1.c2 where t2.c2 > 10;",

--- a/backend/plugin/db/mysql/query_test.go
+++ b/backend/plugin/db/mysql/query_test.go
@@ -25,7 +25,7 @@ func TestGetStatementWithResultLimitOfMySQL(t *testing.T) {
 		{
 			stmt:  "SELECT * FROM t LIMIT 5;",
 			count: 10,
-			want:  "SELECT * FROM t LIMIT 10;",
+			want:  "SELECT * FROM t LIMIT 5;",
 		},
 		{
 			stmt:  "SELECT * FROM t LIMIT 123;",


### PR DESCRIPTION
This will be consistent behavior with fmt.Sprintf("SELECT * FROM (%s) result LIMIT %d;", util.TrimStatement(stmt), limit).