### PR TITLE
feat(syntax-check): more precise error position

### DIFF
--- a/backend/api/lsp/fs_handler.go
+++ b/backend/api/lsp/fs_handler.go
@@ -158,12 +158,15 @@ func collectDiagnostics(err *base.SyntaxError) []lsp.Diagnostic {
 	syntaxDiagnostic := lsp.Diagnostic{
 		Range: lsp.Range{
 			Start: lsp.Position{
-				Line:      err.Line,
+				// Convert to zero-based.
+				Line:      err.Line - 1,
 				Character: err.Column,
 			},
 			End: lsp.Position{
-				Line:      err.Line,
-				Character: err.Column,
+				// Convert to zero-based.
+				Line: err.Line - 1,
+				// The end position is exclusive.
+				Character: err.Column + 1,
 			},
 		},
 		Severity: lsp.Error,


### PR DESCRIPTION
In backend, we follow the LSP spec which requires the row/character are 0-based. For ANTLR, the line is 1-based and the column is 0-based.

Previous:
![image](https://github.com/user-attachments/assets/f4e72530-9ce8-4fcc-8404-d7e060bdf701)

After:
![CleanShot 2024-08-30 at 15 23 31@2x](https://github.com/user-attachments/assets/f0c85157-5c34-4e46-981d-7c3b5f1212fb)
