### PR TITLE
chore: disable monaco-editor's inline suggest toolbar

### DIFF
--- a/frontend/src/components/MonacoEditor/editor.ts
+++ b/frontend/src/components/MonacoEditor/editor.ts
@@ -112,6 +112,9 @@ export const defaultEditorOptions =
       scrollbar: {
         alwaysConsumeMouseWheel: false,
       },
+      inlineSuggest: {
+        showToolbar: "never",
+      },
     };
   };
 
@@ -143,6 +146,9 @@ export const defaultDiffEditorOptions =
       codeLens: false,
       scrollbar: {
         alwaysConsumeMouseWheel: false,
+      },
+      inlineSuggest: {
+        showToolbar: "never",
       },
     };
   };


### PR DESCRIPTION
Disable this 
![image](https://github.com/user-attachments/assets/fc7a4f49-4736-4961-b605-b7ccc54cd96b)
