### PR TITLE
fix: use correct regexp to check VACUUM statements

### DIFF
--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -582,7 +582,7 @@ var (
 	// VACUUM cannot run inside a transaction block.
 	// VACUUM [ ( option [, ...] ) ] [ table_and_columns [, ...] ]
 	// VACUUM [ FULL ] [ FREEZE ] [ VERBOSE ] [ ANALYZE ] [ table_and_columns [, ...] ].
-	vacuumReg = regexp.MustCompile(`(?i)VACUUM`)
+	vacuumReg = regexp.MustCompile(`(?i)^\s*VACUUM`)
 	// SET ROLE is a special statement that should be run before any other statements containing inside a transaction block or not.
 	setRoleReg = regexp.MustCompile(`(?i)SET\s+((SESSION|LOCAL)\s+)?ROLE`)
 )


### PR DESCRIPTION
close BYT-6270
![image](https://github.com/user-attachments/assets/e83628ea-d6ea-4c2e-b051-69b3465c0945)
