### PR TITLE
chore: use queryContext.schema for other engines

### DIFF
--- a/backend/plugin/db/redshift/redshift.go
+++ b/backend/plugin/db/redshift/redshift.go
@@ -320,6 +320,14 @@ func (driver *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement s
 		return nil, nil
 	}
 
+	// If the queryContext.Schema is not empty, set the search path for the database connection to the specified schema.
+	// Reference: https://docs.aws.amazon.com/redshift/latest/dg/r_search_path.html
+	if queryContext.Schema != "" {
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("set search_path to %s;", queryContext.Schema)); err != nil {
+			return nil, err
+		}
+	}
+
 	var results []*v1pb.QueryResult
 	for _, singleSQL := range singleSQLs {
 		statement := singleSQL.Text

--- a/backend/plugin/db/risingwave/risingwave.go
+++ b/backend/plugin/db/risingwave/risingwave.go
@@ -344,6 +344,14 @@ func (driver *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement s
 		return nil, nil
 	}
 
+	// If the queryContext.Schema is not empty, set the search path for the database connection to the specified schema.
+	// Reference: https://docs.risingwave.com/docs/current/view-configure-runtime-parameters
+	if queryContext.Schema != "" {
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s;", queryContext.Schema)); err != nil {
+			return nil, err
+		}
+	}
+
 	var results []*v1pb.QueryResult
 	for _, singleSQL := range singleSQLs {
 		statement := singleSQL.Text

--- a/backend/plugin/db/snowflake/snowflake.go
+++ b/backend/plugin/db/snowflake/snowflake.go
@@ -280,6 +280,15 @@ func (driver *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement s
 			slog.Error("failed to validate sql", slog.String("statement", statement), log.BBError(err))
 			allQuery = true
 		}
+
+		// If the queryContext.Schema is not empty, set the current schema to the given schema.
+		// Reference: https://docs.snowflake.com/en/sql-reference/sql/use-schema
+		if queryContext.Schema != "" {
+			if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %s;", queryContext.Schema)); err != nil {
+				return nil, err
+			}
+		}
+
 		startTime := time.Now()
 		queryResult, err := func() (*v1pb.QueryResult, error) {
 			if allQuery {

--- a/backend/plugin/parser/pg/query_span_extractor.go
+++ b/backend/plugin/parser/pg/query_span_extractor.go
@@ -68,6 +68,8 @@ type querySpanExtractor struct {
 // newQuerySpanExtractor creates a new query span extractor, the databaseMetadata and the ast are in the read guard.
 func newQuerySpanExtractor(defaultDatabase string, defaultSchema string, gCtx base.GetQuerySpanContext) *querySpanExtractor {
 	if defaultSchema == "" {
+		// Fall back to the default schema `public`.
+		// Reference: https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC
 		defaultSchema = "public"
 	}
 	return &querySpanExtractor{

--- a/backend/plugin/parser/plsql/query_span_test.go
+++ b/backend/plugin/parser/plsql/query_span_test.go
@@ -63,7 +63,7 @@ func TestGetQuerySpan(t *testing.T) {
 			GetDatabaseMetadataFunc:       databaseMetadataGetter,
 			ListDatabaseNamesFunc:         databaseNamesLister,
 			GetLinkedDatabaseMetadataFunc: linkedDatabaseMetadataGetter,
-		}, tc.Statement, tc.DefaultDatabase, tc.DefaultDatabase, false)
+		}, tc.Statement, tc.DefaultDatabase, "", false)
 		a.NoError(err)
 		a.NotNil(result)
 		resultYaml := result.ToYaml()

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -39,6 +39,11 @@ type querySpanExtractor struct {
 }
 
 func newQuerySpanExtractor(defaultDatabase string, defaultSchema string, gCtx base.GetQuerySpanContext, ignoreCaseSensitive bool) *querySpanExtractor {
+	if defaultSchema == "" {
+		// Fall back to the default schema `dbo`.
+		// Reference: https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/ownership-and-user-schema-separation#the-dbo-schema
+		defaultSchema = "dbo"
+	}
 	return &querySpanExtractor{
 		defaultDatabase:     defaultDatabase,
 		defaultSchema:       defaultSchema,


### PR DESCRIPTION
Part of BYT-6223, except SQL Server.

Refer to the schema engine required by the frontend.

![a62c1f70-c3ba-4fd8-b952-3e268d728098](https://github.com/user-attachments/assets/3996c1ee-f569-4a09-8379-75cec9353984)
