### PR TITLE
chore: expose antlr runtime raw error message in syntax checking

### DIFF
--- a/backend/api/lsp/fs_handler.go
+++ b/backend/api/lsp/fs_handler.go
@@ -171,7 +171,9 @@ func collectDiagnostics(err *base.SyntaxError) []lsp.Diagnostic {
 		},
 		Severity: lsp.Error,
 		Source:   "Syntax check",
-		Message:  err.Message,
+		// Use RawMessage which created by antlr runtime, do not need our fine-tuned message
+		// because we had indicated the error position in the message.
+		Message: err.RawMessage,
 	}
 
 	return []lsp.Diagnostic{syntaxDiagnostic}

--- a/backend/plugin/parser/base/base.go
+++ b/backend/plugin/parser/base/base.go
@@ -39,9 +39,10 @@ type SingleSQL struct {
 
 // SyntaxError is a syntax error.
 type SyntaxError struct {
-	Line    int
-	Column  int
-	Message string
+	Line       int
+	Column     int
+	Message    string
+	RawMessage string
 }
 
 // Error returns the error message.
@@ -56,7 +57,7 @@ type ParseErrorListener struct {
 }
 
 // SyntaxError returns the errors.
-func (l *ParseErrorListener) SyntaxError(_ antlr.Recognizer, token any, line, column int, _ string, _ antlr.RecognitionException) {
+func (l *ParseErrorListener) SyntaxError(_ antlr.Recognizer, token any, line, column int, message string, _ antlr.RecognitionException) {
 	if l.Err == nil {
 		errMessage := ""
 		if token, ok := token.(*antlr.CommonToken); ok {
@@ -72,9 +73,10 @@ func (l *ParseErrorListener) SyntaxError(_ antlr.Recognizer, token any, line, co
 			errMessage = fmt.Sprintf("related text: %s", stream.GetTextFromInterval(antlr.NewInterval(start, stop)))
 		}
 		l.Err = &SyntaxError{
-			Line:    line + l.BaseLine,
-			Column:  column,
-			Message: fmt.Sprintf("Syntax error at line %d:%d \n%s", line+l.BaseLine, column, errMessage),
+			Line:       line + l.BaseLine,
+			Column:     column,
+			Message:    fmt.Sprintf("Syntax error at line %d:%d \n%s", line+l.BaseLine, column, errMessage),
+			RawMessage: message,
 		}
 	}
 }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e5bea188-e64e-4910-9195-e9f55d4e9857)

After:
![image](https://github.com/user-attachments/assets/e4d96287-6e80-4ea1-8522-d843e06adbf3)