### PR TITLE
chore: restructure workspace sidebar

### DIFF
--- a/frontend/src/components/ColumnDataTable/MaskingLevelCell.vue
+++ b/frontend/src/components/ColumnDataTable/MaskingLevelCell.vue
@@ -29,7 +29,7 @@
           <router-link
             class="flex items-center light-link text-sm"
             :to="{
-              name: WORKSPACE_ROUTE_SENSITIVE_DATA,
+              name: WORKSPACE_ROUTE_DATA_MASKING,
               hash: 'global-masking-rule',
             }"
           >
@@ -66,10 +66,11 @@
 </template>
 
 <script lang="ts" setup>
+import { NTooltip } from "naive-ui";
 import { computed } from "vue";
 import { reactive } from "vue";
 import { useI18n } from "vue-i18n";
-import { WORKSPACE_ROUTE_SENSITIVE_DATA } from "@/router/dashboard/workspaceRoutes";
+import { WORKSPACE_ROUTE_DATA_MASKING } from "@/router/dashboard/workspaceRoutes";
 import { useSubscriptionV1Store } from "@/store";
 import type { ComposedDatabase } from "@/types";
 import { MaskingLevel, maskingLevelToJSON } from "@/types/proto/v1/common";
@@ -80,7 +81,6 @@ import type {
 import type { MaskData } from "@/types/proto/v1/org_policy_service";
 import FeatureModal from "../FeatureGuard/FeatureModal.vue";
 import SensitiveColumnDrawer from "../SensitiveData/SensitiveColumnDrawer.vue";
-import { NTooltip } from "naive-ui";
 
 type LocalState = {
   showFeatureModal: boolean;

--- a/frontend/src/components/User/Settings/RemoveGroupButton.vue
+++ b/frontend/src/components/User/Settings/RemoveGroupButton.vue
@@ -21,7 +21,7 @@ import { useI18n } from "vue-i18n";
 import { RouterLink, type RouteLocationRaw } from "vue-router";
 import ProjectV1Name from "@/components/v2/Model/ProjectV1Name.vue";
 import { PROJECT_V1_ROUTE_MEMBERS } from "@/router/dashboard/projectV1";
-import { WORKSPACE_ROUTE_SENSITIVE_DATA } from "@/router/dashboard/workspaceRoutes";
+import { WORKSPACE_ROUTE_DATA_ACCESS_CONTROL } from "@/router/dashboard/workspaceRoutes";
 import {
   useCurrentUserV1,
   useGroupStore,
@@ -174,12 +174,11 @@ const handleDeleteGroup = async () => {
           )}
 
           {renderProjectResources(
-            t("settings.sidebar.sensitive-data"),
+            t("settings.sidebar.data-masking"),
             resources.filter((r) => r.policy).map((r) => r.project),
             $dialog,
             (_) => ({
-              name: WORKSPACE_ROUTE_SENSITIVE_DATA,
-              hash: "#sensitive-column-list",
+              name: WORKSPACE_ROUTE_DATA_ACCESS_CONTROL,
             })
           )}
           <p>{t("bbkit.confirm-button.sure-to-delete")}</p>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -475,8 +475,10 @@
       "gitops": "GitOps",
       "subscription": "Subscription",
       "labels": "Labels",
-      "sensitive-data": "Data Masking",
-      "access-control": "Data Access Control",
+      "data-masking": "Data Masking",
+      "data-classification": "Data Classification",
+      "access-control": "Access Control",
+      "data-access": "Data Access",
       "audit-log": "Audit Log",
       "custom-roles": "Custom Roles",
       "mail-delivery": "Mail Delivery"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -475,8 +475,10 @@
       "gitops": "GitOps",
       "subscription": "Suscripción",
       "labels": "Etiquetas",
-      "sensitive-data": "Enmascaramiento de Datos",
-      "access-control": "Control de Acceso a Datos",
+      "data-masking": "Enmascaramiento de datos",
+      "data-classification": "Clasificación de datos",
+      "access-control": "Control de acceso",
+      "data-access": "Acceso a datos",
       "audit-log": "Registro de auditoría",
       "custom-roles": "Roles personalizados",
       "mail-delivery": "Entrega de Correo"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -475,8 +475,10 @@
       "gitops": "GitOps",
       "subscription": "サブスクリプション",
       "labels": "ラベル",
-      "sensitive-data": "データマスキング",
-      "access-control": "データアクセス制御",
+      "data-masking": "データマスキング",
+      "data-classification": "データ分類",
+      "access-control": "アクセス制御",
+      "data-access": "データアクセス",
       "audit-log": "監査ログ",
       "custom-roles": "カスタムロール",
       "mail-delivery": "メール送信"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -475,8 +475,10 @@
       "gitops": "GitOps",
       "subscription": "订阅",
       "labels": "标签",
-      "sensitive-data": "数据脱敏",
-      "access-control": "数据访问控制",
+      "data-masking": "数据屏蔽",
+      "data-classification": "数据分类",
+      "access-control": "访问控制",
+      "data-access": "数据访问",
       "audit-log": "审计日志",
       "custom-roles": "自定义角色",
       "mail-delivery": "邮件发送"

--- a/frontend/src/router/dashboard/workspace.ts
+++ b/frontend/src/router/dashboard/workspace.ts
@@ -9,7 +9,6 @@ import {
   ENVIRONMENT_V1_ROUTE_DASHBOARD,
   WORKSPACE_ROOT_MODULE,
   WORKSPACE_ROUTE_MY_ISSUES,
-  WORKSPACE_ROUTE_ANOMALY_CENTER,
   WORKSPACE_ROUTE_USER_PROFILE,
   WORKSPACE_ROUTE_SQL_REVIEW,
   WORKSPACE_ROUTE_SQL_REVIEW_CREATE,
@@ -17,7 +16,9 @@ import {
   WORKSPACE_ROUTE_SCHEMA_TEMPLATE,
   WORKSPACE_ROUTE_CUSTOM_APPROVAL,
   WORKSPACE_ROUTE_RISK_CENTER,
-  WORKSPACE_ROUTE_SENSITIVE_DATA,
+  WORKSPACE_ROUTE_DATA_MASKING,
+  WORKSPACE_ROUTE_DATA_CLASSIFICATION,
+  WORKSPACE_ROUTE_DATA_ACCESS_CONTROL,
   WORKSPACE_ROUTE_AUDIT_LOG,
   WORKSPACE_ROUTE_GITOPS,
   WORKSPACE_ROUTE_GITOPS_CREATE,
@@ -128,19 +129,6 @@ const workspaceRoutes: RouteRecordRaw[] = [
       leftSidebar: () => import("@/views/DashboardSidebar.vue"),
     },
     props: { content: true, leftSidebar: true },
-  },
-  {
-    path: "anomaly-center",
-    name: WORKSPACE_ROUTE_ANOMALY_CENTER,
-    meta: { title: () => t("anomaly-center") },
-    components: {
-      content: () => import("@/views/AnomalyCenterDashboard.vue"),
-      leftSidebar: () => import("@/views/DashboardSidebar.vue"),
-    },
-    props: {
-      content: true,
-      leftSidebar: true,
-    },
   },
   {
     path: "users/:principalEmail",
@@ -351,13 +339,35 @@ const workspaceRoutes: RouteRecordRaw[] = [
         props: true,
       },
       {
-        path: "sensitive-data",
-        name: WORKSPACE_ROUTE_SENSITIVE_DATA,
+        path: "data-masking",
+        name: WORKSPACE_ROUTE_DATA_MASKING,
         meta: {
-          title: () => t("settings.sidebar.sensitive-data"),
+          title: () => t("settings.sidebar.data-masking"),
           requiredWorkspacePermissionList: () => ["bb.policies.get"],
         },
-        component: () => import("@/views/SettingWorkspaceSensitiveData.vue"),
+        component: () => import("@/views/SettingWorkspaceDataMasking.vue"),
+        props: true,
+      },
+      {
+        path: "data-classification",
+        name: WORKSPACE_ROUTE_DATA_CLASSIFICATION,
+        meta: {
+          title: () => t("settings.sidebar.data-classification"),
+          requiredWorkspacePermissionList: () => ["bb.policies.get"],
+        },
+        component: () =>
+          import("@/views/SettingWorkspaceDataClassification.vue"),
+        props: true,
+      },
+      {
+        path: "data-access-control",
+        name: WORKSPACE_ROUTE_DATA_ACCESS_CONTROL,
+        meta: {
+          title: () => t("settings.sidebar.access-control"),
+          requiredWorkspacePermissionList: () => ["bb.policies.get"],
+        },
+        component: () =>
+          import("@/views/SettingWorkspaceDataAccessControl.vue"),
         props: true,
       },
       {

--- a/frontend/src/router/dashboard/workspaceRoutes.ts
+++ b/frontend/src/router/dashboard/workspaceRoutes.ts
@@ -1,7 +1,6 @@
 export const WORKSPACE_ROOT_MODULE = "workspace.root";
 export const WORKSPACE_ROUTE_MY_ISSUES = "workspace.my-issues";
 export const WORKSPACE_ROUTE_EXPORT_CENTER = "workspace.export-center";
-export const WORKSPACE_ROUTE_ANOMALY_CENTER = "workspace.anomaly-center";
 export const WORKSPACE_ROUTE_USER_PROFILE = "workspace.user-profile";
 
 export const DATABASE_ROUTE_DASHBOARD = "workspace.database";
@@ -16,7 +15,10 @@ export const WORKSPACE_ROUTE_SQL_REVIEW_DETAIL = `${WORKSPACE_ROUTE_SQL_REVIEW}.
 export const WORKSPACE_ROUTE_SCHEMA_TEMPLATE = "workspace.schema-template";
 export const WORKSPACE_ROUTE_CUSTOM_APPROVAL = "workspace.custom-approval";
 export const WORKSPACE_ROUTE_RISK_CENTER = "workspace.risk-center";
-export const WORKSPACE_ROUTE_SENSITIVE_DATA = "workspace.sensitive-data";
+export const WORKSPACE_ROUTE_DATA_MASKING = "workspace.data-masking";
+export const WORKSPACE_ROUTE_DATA_CLASSIFICATION =
+  "workspace.data-classification";
+export const WORKSPACE_ROUTE_DATA_ACCESS_CONTROL = "workspace.access-control";
 export const WORKSPACE_ROUTE_AUDIT_LOG = "workspace.audit-log";
 export const WORKSPACE_ROUTE_MAIL_DELIVERY = "workspace.mail-delivery";
 export const WORKSPACE_ROUTE_USERS = "workspace.users";

--- a/frontend/src/views/DashboardSidebar.vue
+++ b/frontend/src/views/DashboardSidebar.vue
@@ -15,11 +15,12 @@ import {
   LinkIcon,
   HomeIcon,
   DatabaseIcon,
-  ShieldAlertIcon,
+  WorkflowIcon,
   GalleryHorizontalEndIcon,
   LayersIcon,
   SquareStackIcon,
   ShieldCheck,
+  UsersIcon,
 } from "lucide-vue-next";
 import { computed, h } from "vue";
 import { useI18n } from "vue-i18n";
@@ -36,12 +37,13 @@ import {
   INSTANCE_ROUTE_DASHBOARD,
   PROJECT_V1_ROUTE_DASHBOARD,
   WORKSPACE_ROUTE_MY_ISSUES,
-  WORKSPACE_ROUTE_ANOMALY_CENTER,
   WORKSPACE_ROUTE_SQL_REVIEW,
   WORKSPACE_ROUTE_SCHEMA_TEMPLATE,
   WORKSPACE_ROUTE_CUSTOM_APPROVAL,
   WORKSPACE_ROUTE_RISK_CENTER,
-  WORKSPACE_ROUTE_SENSITIVE_DATA,
+  WORKSPACE_ROUTE_DATA_MASKING,
+  WORKSPACE_ROUTE_DATA_CLASSIFICATION,
+  WORKSPACE_ROUTE_DATA_ACCESS_CONTROL,
   WORKSPACE_ROUTE_AUDIT_LOG,
   WORKSPACE_ROUTE_GITOPS,
   WORKSPACE_ROUTE_SSO,
@@ -199,16 +201,8 @@ const dashboardSidebarItemList = computed((): DashboardSidebarItem[] => {
       name: "",
     },
     {
-      navigationId: "bb.navigation.anomaly-center",
-      title: t("anomaly-center"),
-      icon: () => h(ShieldAlertIcon),
-      name: WORKSPACE_ROUTE_ANOMALY_CENTER,
-      type: "route",
-      shortcuts: ["g", "a", "c"],
-    },
-    {
-      title: t("settings.sidebar.security-and-policy"),
-      icon: () => h(ShieldCheck),
+      title: "IAM & Admin",
+      icon: () => h(UsersIcon),
       type: "div",
       children: [
         {
@@ -228,13 +222,25 @@ const dashboardSidebarItemList = computed((): DashboardSidebarItem[] => {
           type: "route",
         },
         {
-          title: t("sql-review.title"),
-          name: WORKSPACE_ROUTE_SQL_REVIEW,
+          title: t("settings.sidebar.sso"),
+          name: WORKSPACE_ROUTE_SSO,
           type: "route",
         },
         {
-          title: t("schema-template.self"),
-          name: WORKSPACE_ROUTE_SCHEMA_TEMPLATE,
+          title: t("settings.sidebar.audit-log"),
+          name: WORKSPACE_ROUTE_AUDIT_LOG,
+          type: "route",
+        },
+      ],
+    },
+    {
+      title: "CI/CD",
+      icon: () => h(WorkflowIcon),
+      type: "div",
+      children: [
+        {
+          title: t("sql-review.title"),
+          name: WORKSPACE_ROUTE_SQL_REVIEW,
           type: "route",
         },
         {
@@ -248,13 +254,35 @@ const dashboardSidebarItemList = computed((): DashboardSidebarItem[] => {
           type: "route",
         },
         {
-          title: t("settings.sidebar.sensitive-data"),
-          name: WORKSPACE_ROUTE_SENSITIVE_DATA,
+          title: t("schema-template.self"),
+          name: WORKSPACE_ROUTE_SCHEMA_TEMPLATE,
           type: "route",
         },
         {
-          title: t("settings.sidebar.audit-log"),
-          name: WORKSPACE_ROUTE_AUDIT_LOG,
+          title: t("settings.sidebar.gitops"),
+          name: WORKSPACE_ROUTE_GITOPS,
+          type: "route",
+        },
+      ],
+    },
+    {
+      title: t("settings.sidebar.data-access"),
+      icon: () => h(ShieldCheck),
+      type: "div",
+      children: [
+        {
+          title: t("settings.sidebar.data-classification"),
+          name: WORKSPACE_ROUTE_DATA_CLASSIFICATION,
+          type: "route",
+        },
+        {
+          title: t("settings.sidebar.data-masking"),
+          name: WORKSPACE_ROUTE_DATA_MASKING,
+          type: "route",
+        },
+        {
+          title: t("settings.sidebar.access-control"),
+          name: WORKSPACE_ROUTE_DATA_ACCESS_CONTROL,
           type: "route",
         },
       ],
@@ -264,16 +292,6 @@ const dashboardSidebarItemList = computed((): DashboardSidebarItem[] => {
       icon: () => h(LinkIcon),
       type: "div",
       children: [
-        {
-          title: t("settings.sidebar.gitops"),
-          name: WORKSPACE_ROUTE_GITOPS,
-          type: "route",
-        },
-        {
-          title: t("settings.sidebar.sso"),
-          name: WORKSPACE_ROUTE_SSO,
-          type: "route",
-        },
         {
           title: t("settings.sidebar.mail-delivery"),
           name: WORKSPACE_ROUTE_MAIL_DELIVERY,

--- a/frontend/src/views/SettingWorkspaceDataAccessControl.vue
+++ b/frontend/src/views/SettingWorkspaceDataAccessControl.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="w-full space-y-4">
+    <FeatureAttention
+      v-if="!hasSensitiveDataFeature"
+      feature="bb.feature.sensitive-data"
+    />
+    <SensitiveColumnView />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FeatureAttention } from "@/components/FeatureGuard";
+import { SensitiveColumnView } from "@/components/SensitiveData";
+import { featureToRef } from "@/store";
+
+const hasSensitiveDataFeature = featureToRef("bb.feature.sensitive-data");
+</script>

--- a/frontend/src/views/SettingWorkspaceDataClassification.vue
+++ b/frontend/src/views/SettingWorkspaceDataClassification.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="w-full space-y-4">
+    <FeatureAttention
+      v-if="!hasSensitiveDataFeature"
+      feature="bb.feature.sensitive-data"
+    />
+    <ClassificationView />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FeatureAttention } from "@/components/FeatureGuard";
+import { ClassificationView } from "@/components/SensitiveData";
+import { featureToRef } from "@/store";
+
+const hasSensitiveDataFeature = featureToRef("bb.feature.sensitive-data");
+</script>

--- a/frontend/src/views/SettingWorkspaceDataMasking.vue
+++ b/frontend/src/views/SettingWorkspaceDataMasking.vue
@@ -12,12 +12,6 @@
         <GlobalMaskingRulesView />
       </NTabPane>
       <NTabPane
-        name="sensitive-column-list"
-        :tab="$t('settings.sensitive-data.sensitive-column-list')"
-      >
-        <SensitiveColumnView />
-      </NTabPane>
-      <NTabPane
         name="semantic-types"
         :tab="$t('settings.sensitive-data.semantic-types.self')"
       >
@@ -29,12 +23,6 @@
       >
         <MaskingAlgorithmsView />
       </NTabPane>
-      <NTabPane
-        name="classification"
-        :tab="$t('settings.sensitive-data.classification.self')"
-      >
-        <ClassificationView />
-      </NTabPane>
     </NTabs>
   </div>
 </template>
@@ -45,20 +33,16 @@ import { reactive, watch } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import { FeatureAttention } from "@/components/FeatureGuard";
 import {
-  SensitiveColumnView,
   GlobalMaskingRulesView,
   SemanticTypesView,
-  ClassificationView,
 } from "@/components/SensitiveData";
 import MaskingAlgorithmsView from "@/components/SensitiveData/MaskingAlgorithmsView.vue";
 import { featureToRef } from "@/store";
 
 const dataMaskingTabList = [
-  "sensitive-column-list",
   "global-masking-rule",
   "semantic-types",
   "masking-algorithms",
-  "classification",
 ] as const;
 type DataMaskingTab = (typeof dataMaskingTabList)[number];
 const isDataMaskingTab = (tab: any): tab is DataMaskingTab =>

--- a/frontend/src/views/sql-editor/EditorCommon/DataTable/SensitiveDataIcon.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/DataTable/SensitiveDataIcon.vue
@@ -19,7 +19,7 @@
 import { NTooltip } from "naive-ui";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
-import { WORKSPACE_ROUTE_SENSITIVE_DATA } from "@/router/dashboard/workspaceRoutes";
+import { WORKSPACE_ROUTE_DATA_ACCESS_CONTROL } from "@/router/dashboard/workspaceRoutes";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
 const router = useRouter();
@@ -32,7 +32,7 @@ const handleClick = () => {
   if (!clickable.value) {
     return;
   }
-  const url = router.resolve({ name: WORKSPACE_ROUTE_SENSITIVE_DATA });
+  const url = router.resolve({ name: WORKSPACE_ROUTE_DATA_ACCESS_CONTROL });
   window.open(url.href, "_BLANK");
 };
 </script>

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/SensitiveDataIcon.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/SensitiveDataIcon.vue
@@ -19,7 +19,7 @@
 import { NTooltip } from "naive-ui";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
-import { WORKSPACE_ROUTE_SENSITIVE_DATA } from "@/router/dashboard/workspaceRoutes";
+import { WORKSPACE_ROUTE_DATA_ACCESS_CONTROL } from "@/router/dashboard/workspaceRoutes";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
 const router = useRouter();
@@ -32,7 +32,7 @@ const handleClick = () => {
   if (!clickable.value) {
     return;
   }
-  const url = router.resolve({ name: WORKSPACE_ROUTE_SENSITIVE_DATA });
+  const url = router.resolve({ name: WORKSPACE_ROUTE_DATA_ACCESS_CONTROL });
   window.open(url.href, "_BLANK");
 };
 </script>


### PR DESCRIPTION
**BREAK CHANGES**

- Deprecate `/anomaly-center`
- Deprecate `/sensitive-data`, and split it into `/data-masking`, `/data-classification`, `/data-access-control`

![CleanShot 2024-09-09 at 13 34 48@2x](https://github.com/user-attachments/assets/e492f679-b673-4220-b736-f190dfd96de6)
