### PR TITLE
chore: oracle parser compatibility

### DIFF
--- a/backend/plugin/parser/plsql/plsql_test.go
+++ b/backend/plugin/parser/plsql/plsql_test.go
@@ -13,6 +13,9 @@ func TestPLSQLParser(t *testing.T) {
 		errorMessage string
 	}{
 		{
+			statement: `UPDATE t1 SET (c1) = 1 WHERE c2 = 2;`,
+		},
+		{
 			statement: `
 			SELECT q'\This is String\' FROM DUAL;
 			`,

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bytebase/bq-parser v0.0.0-20240529032606-614a0230b8f7
 	github.com/bytebase/mysql-parser v0.0.0-20240810145851-ab2c11629c24
-	github.com/bytebase/plsql-parser v0.0.0-20240724030234-55445b9c5491
+	github.com/bytebase/plsql-parser v0.0.0-20240909070200-1468a31cd5a4
 	github.com/bytebase/postgresql-parser v0.0.0-20231221075352-cf5025e0d56f
 	github.com/bytebase/snowsql-parser v0.0.0-20240304100801-bb357ccb5535
 	github.com/bytebase/tidb-parser v0.0.0-20240821091609-162fffe2a839

--- a/go.sum
+++ b/go.sum
@@ -800,8 +800,8 @@ github.com/bytebase/pg_query_go2/v5 v5.0.0-20240429070353-41837024e3d6 h1:BzWyLT
 github.com/bytebase/pg_query_go2/v5 v5.0.0-20240429070353-41837024e3d6/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94/go.mod h1:SQliXeA7Dhkt//vS29v3zpbEwoa+zb2Cn5xj5uO4K5U=
-github.com/bytebase/plsql-parser v0.0.0-20240724030234-55445b9c5491 h1:zAp7T2lcrqbsFN+eTYwv+w1F9r5Lukvf5WHvp64Dht4=
-github.com/bytebase/plsql-parser v0.0.0-20240724030234-55445b9c5491/go.mod h1:sEtLYOfHyi8zz5vo5gKT//A8c4P8FnDZLNVSLtVPxj0=
+github.com/bytebase/plsql-parser v0.0.0-20240909070200-1468a31cd5a4 h1:LbsxZCtDEr/5DcEiAk9ZMjifNH8J6ufWks3KF9sLT6U=
+github.com/bytebase/plsql-parser v0.0.0-20240909070200-1468a31cd5a4/go.mod h1:sEtLYOfHyi8zz5vo5gKT//A8c4P8FnDZLNVSLtVPxj0=
 github.com/bytebase/postgresql-parser v0.0.0-20231221075352-cf5025e0d56f h1:mwn17HA984i5cz1vIkiF265a6LZplCAqIPqQn7c0V0s=
 github.com/bytebase/postgresql-parser v0.0.0-20231221075352-cf5025e0d56f/go.mod h1:Jft7oabwuwD+t5BYiUfTjcNVaihZ8F5KT8TsROG0EaE=
 github.com/bytebase/snowsql-parser v0.0.0-20240304100801-bb357ccb5535 h1:sgEzM1Y8WUAR8n8fOjVtx62Cz7HuUILtONkPQ8IvFNk=


### PR DESCRIPTION
close BYT-6304