### PR TITLE
chore: add consistent menu width to schema selector

### DIFF
--- a/frontend/src/views/sql-editor/EditorPanel/Panels/common/SchemaSelectToolbar.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/common/SchemaSelectToolbar.vue
@@ -7,6 +7,7 @@
       size="small"
       class="min-w-[8rem]"
       v-bind="$attrs"
+      :consistent-menu-width="false"
     />
 
     <div v-else class="w-full flex flex-row justify-between items-center">


### PR DESCRIPTION
### Before

<img width="481" alt="image" src="https://github.com/user-attachments/assets/ca2763fc-cf57-4d66-8b7a-6b6ddba14650">

### After 

<img width="466" alt="image" src="https://github.com/user-attachments/assets/3664a8b6-569b-4495-a251-5b3cbc35ef88">
