### PR TITLE
feat: render empty deployment matrix properly

### DIFF
--- a/frontend/src/components/DeploymentConfigTool/DeploymentMatrix.vue
+++ b/frontend/src/components/DeploymentConfigTool/DeploymentMatrix.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="space-y-2 w-192 px-1">
-    <template v-if="databaseList.length != 0">
       <div class="flex justify-end items-center">
         <NInputGroup style="width: auto" class="py-0.5">
           <NInputGroupLabel
@@ -28,7 +27,6 @@
           :deployment="deployment"
         />
       </div>
-    </template>
   </div>
 </template>
 

--- a/frontend/src/components/DeploymentConfigTool/SelectorItemV2.vue
+++ b/frontend/src/components/DeploymentConfigTool/SelectorItemV2.vue
@@ -143,8 +143,7 @@ const values = computed(() => {
   if (!props.selector.key) return [];
   return getLabelValuesFromDatabaseV1List(
     props.selector.key,
-    props.databaseList,
-    false /* !withEmptyValue */
+    props.databaseList
   );
 });
 const valueOptions = computed(() => {

--- a/frontend/src/components/TenantDatabaseTable/DeploymentMatrixDataTable.vue
+++ b/frontend/src/components/TenantDatabaseTable/DeploymentMatrixDataTable.vue
@@ -60,8 +60,7 @@ const databaseGroupList = computed(() => {
   );
   const rows = getLabelValuesFromDatabaseV1List(
     props.label,
-    props.databaseList,
-    true /* withEmptyValue */
+    props.databaseList
   ).map((labelValue) => {
     const databaseList = dict[labelValue] || [];
     return {
@@ -70,9 +69,10 @@ const databaseGroupList = computed(() => {
     };
   });
 
-  if (rows.length > 0 && rows[rows.length - 1].databaseList.length === 0) {
-    // ignore "<empty value>" row if no databases
-    rows.pop();
+  // Add the empty label value row only if it matches any db.
+  const emptyLabelDBList = dict[""] || [];
+  if (emptyLabelDBList.length > 0) {
+    rows.push({labelValue: "", databaseList: emptyLabelDBList})
   }
 
   return rows;

--- a/frontend/src/utils/label.ts
+++ b/frontend/src/utils/label.ts
@@ -35,8 +35,7 @@ export const convertKVListToLabels = (
 
 export const getLabelValuesFromDatabaseV1List = (
   key: string,
-  databaseList: ComposedDatabase[],
-  withEmptyValue = false
+  databaseList: ComposedDatabase[]
 ): string[] => {
   if (key === "environment") {
     const environmentList = useEnvironmentV1Store().getEnvironmentList();
@@ -51,15 +50,9 @@ export const getLabelValuesFromDatabaseV1List = (
     }
     return [];
   });
+
   // Select all distinct database label values of {{key}}
-  const distinctValueList = uniq(valueList);
-
-  if (withEmptyValue) {
-    // plus one more "<empty value>" if needed
-    distinctValueList.push("");
-  }
-
-  return distinctValueList;
+  return uniq(valueList);
 };
 
 export const getSemanticLabelValue = (db: ComposedDatabase, key: string) => {


### PR DESCRIPTION
We still want to show the matrix in empty db state. However there was a bug removing the last row. The intended logic was only to remove the last empty label row. But as the screenshot shows, it would remove the valid label row as well.

## Before
![CleanShot 2024-09-21 at 11 28 42](https://github.com/user-attachments/assets/0a5f8aed-c218-4ab9-8bd9-b6f89935c32a)

## After
![CleanShot 2024-09-21 at 11 42 15](https://github.com/user-attachments/assets/8e105eb7-8a3f-4a43-80cd-8607cd3f6675)
