### PR TITLE
chore(sql-editor): some fixes

### DIFF
--- a/frontend/src/components/GeneralSetting/DatabaseChangeModeSetting.vue
+++ b/frontend/src/components/GeneralSetting/DatabaseChangeModeSetting.vue
@@ -16,7 +16,11 @@
         />
       </p>
       <div>
-        <NRadioGroup v-model:value="state.databaseChangeMode" size="large">
+        <NRadioGroup
+          v-model:value="state.databaseChangeMode"
+          :disabled="!allowEdit"
+          size="large"
+        >
           <NSpace vertical>
             <NRadio key="PIPELINE" :value="DatabaseChangeMode.PIPELINE">
               <div class="flex flex-col gap-1">

--- a/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
@@ -225,4 +225,10 @@ defineExpose({
   left: 52px;
   top: 8px;
 }
+.bb-monaco-editor :deep(.monaco-editor .peekview-title .filename) {
+  display: none !important;
+}
+.bb-monaco-editor :deep(.monaco-editor .peekview-title .dirname) {
+  margin-left: 0 !important;
+}
 </style>

--- a/frontend/src/components/v2/Form/SearchBox.vue
+++ b/frontend/src/components/v2/Form/SearchBox.vue
@@ -48,4 +48,8 @@ onMounted(() => {
     inputRef.value?.inputElRef?.focus();
   }
 });
+
+defineExpose({
+  inputRef,
+});
 </script>

--- a/frontend/src/store/modules/sqlEditor/tab.ts
+++ b/frontend/src/store/modules/sqlEditor/tab.ts
@@ -195,6 +195,8 @@ export const useSQLEditorTabStore = defineStore("sqlEditorTab", () => {
     }
     currentTabId.value = id;
     tabsById.set(id, newTab);
+
+    return newTab;
   };
   const removeTab = (tab: SQLEditorTab) => {
     const { id } = tab;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/SchemaPane.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/SchemaPane.vue
@@ -5,6 +5,7 @@
     <div class="px-1 flex flex-row gap-1">
       <div class="flex-1 overflow-hidden">
         <SearchBox
+          ref="searchBoxRef"
           v-model:value="searchPattern"
           :disabled="!currentTab"
           size="small"
@@ -75,6 +76,7 @@ import {
   computedAsync,
   refDebounced,
   useElementSize,
+  useEventListener,
   useMounted,
 } from "@vueuse/core";
 import { head, uniq, without } from "lodash-es";
@@ -115,6 +117,7 @@ import {
 } from "./common";
 
 const mounted = useMounted();
+const searchBoxRef = ref<InstanceType<typeof SearchBox>>();
 const treeRef = ref<TreeInst>();
 const treeContainerElRef = ref<HTMLElement>();
 const { height: treeContainerHeight } = useElementSize(
@@ -399,6 +402,10 @@ watch(
     immediate: true,
   }
 );
+
+useEventListener(treeContainerElRef, "keydown", (e) => {
+  searchBoxRef.value?.inputRef?.focus()
+});
 </script>
 
 <style lang="postcss" scoped>

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/SchemaPane.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/SchemaPane.vue
@@ -77,7 +77,7 @@ import {
   useElementSize,
   useMounted,
 } from "@vueuse/core";
-import { head, uniq } from "lodash-es";
+import { head, uniq, without } from "lodash-es";
 import {
   NDropdown,
   NEmpty,
@@ -188,6 +188,11 @@ const upsertExpandedKeys = (keys: string[]) => {
   const curr = expandedKeys.value;
   if (!curr) return;
   expandedKeys.value = uniq([...curr, ...keys]);
+};
+const removeExpandedKeys = (keys: string[]) => {
+  const curr = expandedKeys.value;
+  if (!curr) return;
+  expandedKeys.value = without(curr, ...keys);
 };
 
 const defaultExpandedKeys = () => {
@@ -323,6 +328,16 @@ const expandNode = (node: TreeNode) => {
   walk(node);
   upsertExpandedKeys(keysToExpand);
 };
+const collapseNode = (node: TreeNode) => {
+  removeExpandedKeys([node.key]);
+};
+const toggleNode = (node: TreeNode) => {
+  if (expandedKeys.value.includes(node.key)) {
+    collapseNode(node);
+  } else {
+    expandNode(node);
+  }
+};
 
 const singleClick = (node: TreeNode) => {
   expandNode(node);
@@ -343,6 +358,11 @@ useEmitteryEventListener(nodeClickEvents, "single-click", ({ node }) => {
 useEmitteryEventListener(nodeClickEvents, "double-click", ({ node }) => {
   if (node.meta.type === "table" || node.meta.type === "view") {
     selectAllFromTableOrView(node);
+  } else if (
+    node.meta.type === "expandable-text" ||
+    node.meta.type === "schema"
+  ) {
+    toggleNode(node);
   } else {
     singleClick(node);
   }

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DependentColumnNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DependentColumnNode.vue
@@ -3,26 +3,12 @@
     <template #icon>
       <ColumnIcon class="w-4 h-4" />
     </template>
-    <template #suffix>
-      <div
-        class="flex items-center justify-end gap-1 overflow-hidden whitespace-nowrap shrink-0"
-      >
-        <NButton size="tiny" text @click.stop="goRef">
-          <template #icon>
-            <FileSymlinkIcon class="w-4 h-4" />
-          </template>
-        </NButton>
-      </div>
-    </template>
   </CommonNode>
 </template>
 
 <script setup lang="ts">
-import { FileSymlinkIcon } from "lucide-vue-next";
-import { NButton } from "naive-ui";
 import { computed } from "vue";
 import { ColumnIcon } from "@/components/Icon";
-import { useEditorPanelContext } from "@/views/sql-editor/EditorPanel";
 import type { TreeNode } from "../common";
 import CommonNode from "./CommonNode.vue";
 
@@ -30,7 +16,6 @@ const props = defineProps<{
   node: TreeNode;
   keyword: string;
 }>();
-const { updateViewState } = useEditorPanelContext();
 
 const target = computed(
   () => (props.node as TreeNode<"dependent-column">).meta.target
@@ -42,16 +27,4 @@ const text = computed(() => {
   if (schema) parts.unshift(schema);
   return parts.join(".");
 });
-
-const goRef = () => {
-  const { schema, table, column } = target.value.dependentColumn;
-  updateViewState({
-    view: "TABLES",
-    schema,
-    detail: {
-      table,
-      column,
-    },
-  });
-};
 </script>

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
@@ -293,9 +293,29 @@ export const useActions = () => {
       detail.view = (target as NodeTarget<"view">).view.name;
     }
     if (type === "dependent-column") {
-      detail.dependentColumn = keyForDependentColumn(
-        (target as NodeTarget<"dependent-column">).dependentColumn
+      const { database, dependentColumn } =
+        target as NodeTarget<"dependent-column">;
+      const depSchema = database.schemas.find(
+        (s) => s.name === dependentColumn.schema
       );
+      if (
+        depSchema &&
+        depSchema.views.find((v) => v.name === dependentColumn.table)
+      ) {
+        updateViewState({
+          view: "VIEWS",
+          schema: dependentColumn.schema,
+        });
+        detail.view = dependentColumn.table;
+        detail.column = dependentColumn.column;
+      } else {
+        updateViewState({
+          view: "TABLES",
+          schema: dependentColumn.schema,
+        });
+        detail.table = dependentColumn.table;
+        detail.column = dependentColumn.column;
+      }
     }
     if (type === "procedure") {
       const { procedure, position } = target as NodeTarget<"procedure">;

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/common.ts
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/common.ts
@@ -202,7 +202,7 @@ export const keyForNodeTarget = <T extends NodeType>(
     return [
       db.name,
       `schemas/${schema.name}`,
-      `views/${view}`,
+      `views/${view.name}`,
       `dependentColumns/${keyForDependentColumn(dependentColumn)}`,
     ].join("/");
   }

--- a/frontend/src/views/sql-editor/AsidePanel/WorksheetPane/WorksheetPane.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/WorksheetPane/WorksheetPane.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="h-full flex flex-col gap-1 overflow-hidden pb-1 text-sm">
-    <div class="flex items-center gap-x-1 px-1 pt-1">
+    <div class="flex items-center gap-x-1 px-1">
       <SearchBox
         v-model:value="keyword"
         size="small"

--- a/frontend/src/views/sql-editor/EditorCommon/SaveSheetModal.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/SaveSheetModal.vue
@@ -54,7 +54,7 @@ const doSaveSheet = async (
 ) => {
   const { title, statement, worksheet } = tab;
 
-  if (title === "" || statement === "") {
+  if (title === "") {
     return;
   }
 

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTableColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTableColumnsTable.vue
@@ -31,6 +31,7 @@ import type {
   ExternalTableMetadata,
 } from "@/types/proto/v1/database_service";
 import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import { EllipsisCell } from "../../common";
 import { useEditorPanelContext } from "../../context";
 
 const props = defineProps<{
@@ -59,6 +60,7 @@ const filteredColumns = computed(() => {
 
 const columns = computed(() => {
   const engine = props.db.instanceResource.engine;
+  const downGrade = filteredColumns.value.length > 50;
   const columns: (DataTableColumn<ColumnMetadata> & { hide?: boolean })[] = [
     {
       key: "name",
@@ -101,10 +103,13 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 140,
       maxWidth: 320,
-      className: "truncate",
-      ellipsis: true,
-      ellipsisComponent: "performant-ellipsis",
-      render: (column) => column.userComment,
+      className: "overflow-hidden",
+      render: (column) => {
+        return h(EllipsisCell, {
+          content: column.userComment,
+          downGrade,
+        });
+      },
     },
     {
       key: "not-null",

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
@@ -35,6 +35,7 @@ import type {
   TableMetadata,
 } from "@/types/proto/v1/database_service";
 import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import { EllipsisCell } from "../../common";
 import { useEditorPanelContext } from "../../context";
 
 const props = defineProps<{
@@ -67,6 +68,7 @@ const primaryKey = computed(() => {
 
 const columns = computed(() => {
   const engine = props.db.instanceResource.engine;
+  const downGrade = filteredColumns.value.length > 50;
   const columns: (DataTableColumn<ColumnMetadata> & { hide?: boolean })[] = [
     {
       key: "name",
@@ -110,6 +112,13 @@ const columns = computed(() => {
       minWidth: 140,
       maxWidth: 320,
       hide: engine !== Engine.MYSQL && engine !== Engine.TIDB,
+      className: "overflow-hidden",
+      render: (column) => {
+        return h(EllipsisCell, {
+          content: column.onUpdate,
+          downGrade,
+        });
+      },
     },
     {
       key: "comment",
@@ -117,10 +126,13 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 140,
       maxWidth: 320,
-      className: "truncate",
-      ellipsis: true,
-      ellipsisComponent: "performant-ellipsis",
-      render: (column) => column.userComment,
+      className: "overflow-hidden",
+      render: (column) => {
+        return h(EllipsisCell, {
+          content: column.userComment,
+          downGrade,
+        });
+      },
     },
     {
       key: "not-null",

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/IndexesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/IndexesTable.vue
@@ -30,6 +30,7 @@ import type {
   TableMetadata,
 } from "@/types/proto/v1/database_service";
 import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import { EllipsisCell } from "../../common";
 import { useEditorPanelContext } from "../../context";
 
 const props = defineProps<{
@@ -61,6 +62,7 @@ const filteredIndexes = computed(() => {
 });
 
 const columns = computed(() => {
+  const downGrade = filteredIndexes.value.length > 50;
   const columns: (DataTableColumn<IndexMetadata> & { hide?: boolean })[] = [
     {
       key: "name",
@@ -92,7 +94,13 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 140,
       maxWidth: 320,
-      className: "truncate",
+      className: "overflow-hidden",
+      render: (index) => {
+        return h(EllipsisCell, {
+          content: index.comment,
+          downGrade,
+        });
+      },
     },
     {
       key: "primary",

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
@@ -36,6 +36,7 @@ import {
   hasTableEngineProperty,
   useAutoHeightDataTable,
 } from "@/utils";
+import { EllipsisCell } from "../../common";
 import { useEditorPanelContext } from "../../context";
 
 const props = defineProps<{
@@ -87,6 +88,7 @@ const {
 );
 
 const columns = computed(() => {
+  const downGrade = filteredTables.value.length > 50;
   const columns: (DataTableColumn<TableMetadata> & { hide?: boolean })[] = [
     {
       key: "name",
@@ -152,8 +154,13 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 140,
       maxWidth: 320,
-      className: "truncate",
-      render: (table) => table.userComment,
+      className: "overflow-hidden",
+      render: (table) => {
+        return h(EllipsisCell, {
+          content: table.comment,
+          downGrade,
+        });
+      },
     },
   ];
   return columns.filter((col) => !col.hide);

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ColumnsTable.vue
@@ -31,6 +31,7 @@ import type {
   ViewMetadata,
 } from "@/types/proto/v1/database_service";
 import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import { EllipsisCell } from "../../common";
 import { useEditorPanelContext } from "../../context";
 
 const props = defineProps<{
@@ -63,6 +64,7 @@ const filteredColumns = computed(() => {
 
 const columns = computed(() => {
   const engine = props.db.instanceResource.engine;
+  const downGrade = filteredColumns.value.length > 50;
   const columns: (DataTableColumn<ColumnMetadata> & { hide?: boolean })[] = [
     {
       key: "name",
@@ -105,10 +107,13 @@ const columns = computed(() => {
       resizable: true,
       minWidth: 140,
       maxWidth: 320,
-      className: "truncate",
-      ellipsis: true,
-      ellipsisComponent: "performant-ellipsis",
-      render: (column) => column.userComment,
+      className: "overflow-hidden",
+      render: (column) => {
+        return h(EllipsisCell, {
+          content: column.userComment,
+          downGrade,
+        });
+      },
     },
     {
       key: "not-null",

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
@@ -29,6 +29,7 @@ import type {
   SchemaMetadata,
 } from "@/types/proto/v1/database_service";
 import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import { EllipsisCell } from "../../common";
 import { useEditorPanelContext } from "../../context";
 
 const props = defineProps<{
@@ -78,6 +79,7 @@ const {
 );
 
 const columns = computed(() => {
+  const downGrade = filteredViews.value.length > 50;
   const columns: (DataTableColumn<ViewMetadata> & { hide?: boolean })[] = [
     {
       key: "name",
@@ -94,7 +96,13 @@ const columns = computed(() => {
       key: "comment",
       title: t("schema-editor.database.comment"),
       resizable: true,
-      className: "truncate",
+      className: "overflow-hidden",
+      render: (view) => {
+        return h(EllipsisCell, {
+          content: view.comment,
+          downGrade,
+        });
+      },
     },
   ];
   return columns;

--- a/frontend/src/views/sql-editor/EditorPanel/common/EllipsisCell.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/common/EllipsisCell.vue
@@ -1,0 +1,23 @@
+<template>
+  <NPerformantEllipsis v-if="!downGrade">
+    <template #default>{{ content }}</template>
+    <template #tooltip>
+      <div
+        class="text-wrap whitespace-pre break-words break-all"
+        style="max-width: calc(min(33vw, 320px))"
+      >
+        {{ content }}
+      </div>
+    </template>
+  </NPerformantEllipsis>
+  <div v-else :title="content" class="truncate">{{ content }}</div>
+</template>
+
+<script setup lang="ts">
+import { NPerformantEllipsis } from "naive-ui";
+
+defineProps<{
+  content: string;
+  downGrade?: boolean;
+}>();
+</script>

--- a/frontend/src/views/sql-editor/EditorPanel/common/EllipsisCell.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/common/EllipsisCell.vue
@@ -10,7 +10,9 @@
       </div>
     </template>
   </NPerformantEllipsis>
-  <div v-else :title="content" class="truncate">{{ content }}</div>
+  <div v-else :title="content" class="truncate">
+    {{ content }}
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/views/sql-editor/EditorPanel/common/common.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/common/common.ts
@@ -7,7 +7,7 @@ import {
 } from "@/store";
 import { DatabaseMetadataView } from "@/types/proto/v1/database_service";
 import { hasSchemaProperty } from "@/utils";
-import { useEditorPanelContext } from "./context";
+import { useEditorPanelContext } from "../context";
 
 export const useSelectSchema = () => {
   const { database, instance } = useConnectionOfCurrentSQLEditorTab();

--- a/frontend/src/views/sql-editor/EditorPanel/common/index.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/common/index.ts
@@ -1,0 +1,5 @@
+import EllipsisCell from "./EllipsisCell.vue";
+
+export * from "./common";
+
+export { EllipsisCell };

--- a/frontend/src/views/sql-editor/EditorPanel/context/index.ts
+++ b/frontend/src/views/sql-editor/EditorPanel/context/index.ts
@@ -1,4 +1,4 @@
-import { head } from "lodash-es";
+import { cloneDeep, head } from "lodash-es";
 import {
   computed,
   inject,
@@ -71,6 +71,12 @@ export const provideEditorPanelContext = (base: {
     viewStateByTab.set(tab.value.id, curr);
   };
 
+  const cloneViewState = (from: string, to: string) => {
+    const vs = viewStateByTab.get(from);
+    if (!vs) return;
+    viewStateByTab.set(to, cloneDeep(vs));
+  };
+
   watch(
     [() => viewState.value?.view, availableViews],
     ([view, availableViews]) => {
@@ -111,6 +117,7 @@ export const provideEditorPanelContext = (base: {
     selectedSchemaName,
     availableViews,
     updateViewState,
+    cloneViewState,
     typeToView,
   };
 


### PR DESCRIPTION
- tooltips for comment columns. (Close BYT-6383)
- disable database change mode radio buttons when not allowed to editor. (Close BYT-6385)
- adjust gaps. (Close BYT-6394)
- double click on folders now toggle collapse/expand. (Close BYT-6392)
- hide filename in monaco-editor problem viewer widgets. (Close BYT-6391)
- handle saving empty worksheets. (Close BYT-6389)
- clone ui state from current tab when opening new tab. (Close BYT-6390)
- clicking on dependent column nodes now goes to the referenced column's definition. (Close BYT-6387)
- capture keydown inputs in sidebar, and auto focus the search box when keys pressed. (Close BYT-6386)