### PR TITLE
fix: add `bb.sheets.get` permission to project releaser

### DIFF
--- a/backend/component/iam/acl.yaml
+++ b/backend/component/iam/acl.yaml
@@ -407,6 +407,7 @@ roles:
       - bb.projects.get
       - bb.projects.getIamPolicy
       - bb.rollouts.get
+      - bb.sheets.get
       - bb.taskRuns.list
   - name: roles/projectViewer
     title: Project viewer


### PR DESCRIPTION
Close BYT-6399