### PR TITLE
chore: return syntax error instead of panic for pg splitter

### DIFF
--- a/backend/plugin/parser/pg/split.go
+++ b/backend/plugin/parser/pg/split.go
@@ -43,7 +43,6 @@ func splitByParser(lexer *parser.PostgreSQLLexer, stream *antlr.CommonTokenStrea
 	p.AddErrorListener(parserErrorListener)
 
 	p.BuildParseTrees = true
-	p.SetErrorHandler(antlr.NewBailErrorStrategy())
 
 	tree := p.Root()
 	if lexerErrorListener.Err != nil {


### PR DESCRIPTION
close BYT-6417