### PR TITLE
feat(sql-editor): AI Assistant improvements

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -3229,7 +3229,8 @@
         "chat": "Chat",
         "explain-code": "Explain code",
         "find-problems": "Find problems",
-        "new-chat": "New chat"
+        "new-chat": "New chat",
+        "insert-at-caret": "Insert at caret"
       },
       "send": "Send",
       "new-line": "New line",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -3229,7 +3229,8 @@
         "chat": "Charlar",
         "explain-code": "Explicar el código",
         "find-problems": "encontrar problemas",
-        "new-chat": "Nuevo chat"
+        "new-chat": "Nuevo chat",
+        "insert-at-caret": "Insertar en el cursor"
       },
       "send": "Enviar",
       "new-line": "Nueva linea",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -3229,7 +3229,8 @@
         "chat": "チャット",
         "explain-code": "コードの説明",
         "find-problems": "問題を見つける",
-        "new-chat": "新しいチャット"
+        "new-chat": "新しいチャット",
+        "insert-at-caret": "キャレットに挿入"
       },
       "send": "送信",
       "new-line": "改行",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -3229,7 +3229,8 @@
         "chat": "对话",
         "explain-code": "解释代码",
         "find-problems": "找出问题",
-        "new-chat": "开启新对话"
+        "new-chat": "开启新对话",
+        "insert-at-caret": "在光标处插入"
       },
       "send": "发送",
       "new-line": "换行",

--- a/frontend/src/plugins/ai/components/ActionBar.vue
+++ b/frontend/src/plugins/ai/components/ActionBar.vue
@@ -45,33 +45,14 @@
           {{ $t("plugin.ai.conversation.new-conversation") }}
         </template>
       </NPopover>
-      <NPopover placement="bottom">
-        <template #trigger>
-          <NButton
-            size="small"
-            quaternary
-            style="--n-padding: 0 5px"
-            @click="showAIPanel = false"
-          >
-            <template #icon>
-              <XIcon class="w-4 h-4" />
-            </template>
-          </NButton>
-        </template>
-        <template #default>
-          {{ $t("common.hide") }}
-        </template>
-      </NPopover>
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { ClockIcon, XIcon, PlusIcon } from "lucide-vue-next";
+import { ClockIcon, PlusIcon } from "lucide-vue-next";
 import { NButton, NPopover } from "naive-ui";
-import { useSQLEditorContext } from "@/views/sql-editor/context";
 import { useAIContext } from "../logic";
 
 const { events, showHistoryDialog } = useAIContext();
-const { showAIPanel } = useSQLEditorContext();
 </script>

--- a/frontend/src/plugins/ai/components/ChatPanel.vue
+++ b/frontend/src/plugins/ai/components/ChatPanel.vue
@@ -11,8 +11,8 @@
       @enter="requestAI"
     />
 
-    <div class="px-2 py-2 flex flex-col gap-2">
-      <DynamicSuggestions class="flex-1 w-full" @enter="requestAI" />
+    <div class="px-2 pb-2 pt-1 flex flex-col gap-1">
+      <DynamicSuggestions class="w-full" @enter="requestAI" />
       <PromptInput v-if="tab" @enter="requestAI" />
     </div>
 

--- a/frontend/src/plugins/ai/components/ChatView/AIMessageView.vue
+++ b/frontend/src/plugins/ai/components/ChatView/AIMessageView.vue
@@ -3,13 +3,19 @@
     class="border rounded shadow py-1 px-1 bg-gray-50 border-gray-400"
     :class="[
       message.status === 'DONE'
-        ? 'w-[60%] min-w-[9rem]'
+        ? 'w-[100%] min-w-[9rem]'
         : message.status === 'FAILED'
           ? 'max-w-[40%] min-w-[9rem]'
           : 'w-auto',
     ]"
   >
-    <Markdown v-if="message.status === 'DONE'" :content="message.content" />
+    <Markdown
+      v-if="message.status === 'DONE'"
+      :content="message.content"
+      :code-block-props="{
+        width: 1.0,
+      }"
+    />
     <div v-else-if="message.status === 'LOADING'" class="flex items-center">
       <BBSpin class="mx-1" :size="18" />
     </div>

--- a/frontend/src/plugins/ai/components/ChatView/Markdown/CodeBlock.vue
+++ b/frontend/src/plugins/ai/components/ChatView/Markdown/CodeBlock.vue
@@ -3,7 +3,7 @@
     ref="containerRef"
     class="flex flex-col overflow-x-hidden border border-gray-500 rounded bg-white"
     :data-message-wrapper-width="messageWrapperWidth"
-    :style="`width: ${width}px`"
+    :style="`width: ${combinedWidth}px`"
   >
     <div class="flex items-center justify-between px-1 pt-1">
       <div class="text-xs">SQL</div>
@@ -77,9 +77,15 @@ import { useAIContext } from "@/plugins/ai/logic";
 import { pushNotification } from "@/store";
 import { findAncestor, toClipboard } from "@/utils";
 
-const props = defineProps<{
-  code: string;
-}>();
+export type CodeBlockProps = {
+  width: number;
+};
+
+const props = defineProps<
+  CodeBlockProps & {
+    code: string;
+  }
+>();
 
 const { t } = useI18n();
 const { events, showHistoryDialog } = useAIContext();
@@ -88,10 +94,10 @@ const messageWrapperRef = computed(() =>
   findAncestor(containerRef.value, ".message")
 );
 const { width: messageWrapperWidth } = useElementSize(messageWrapperRef);
-const width = computed(() => {
+const combinedWidth = computed(() => {
   const PADDING = 8;
   const min = 8 * 16; /* 8rem */
-  const auto = messageWrapperWidth.value * 0.6 - PADDING * 2;
+  const auto = messageWrapperWidth.value * props.width - PADDING * 2;
   return Math.max(min, auto);
 });
 

--- a/frontend/src/plugins/ai/components/ChatView/Markdown/CodeBlock.vue
+++ b/frontend/src/plugins/ai/components/ChatView/Markdown/CodeBlock.vue
@@ -1,66 +1,68 @@
 <template>
   <div
     ref="containerRef"
-    class="flex items-start"
+    class="flex flex-col overflow-x-hidden border border-gray-500 rounded bg-white"
     :data-message-wrapper-width="messageWrapperWidth"
     :style="`width: ${width}px`"
   >
-    <div class="flex-1 overflow-x-hidden">
-      <MonacoEditor
-        :content="code"
-        :readonly="true"
-        :auto-focus="false"
-        :auto-height="{
-          min: 48,
-          max: 120,
-          padding: 2,
-        }"
-        :options="{
-          automaticLayout: true,
-          fontSize: 12,
-          lineHeight: 14,
-          lineNumbers: 'off',
-          wordWrap: 'on',
-          scrollbar: {
-            vertical: 'hidden',
-            horizontal: 'hidden',
-            useShadows: false,
-            verticalScrollbarSize: 0,
-            horizontalScrollbarSize: 0,
-            alwaysConsumeMouseWheel: false,
-          },
-        }"
-        class="border h-auto bg-white"
-      />
+    <div class="flex items-center justify-between px-1 pt-1">
+      <div class="text-xs">SQL</div>
+      <div class="flex items-center justify-end gap-2">
+        <NPopover placement="bottom">
+          <template #trigger>
+            <button
+              class="inline-flex items-center justify-center hover:text-accent cursor-pointer"
+              @click="handleExecute"
+            >
+              <PlayIcon class="w-3.5 h-3.5" />
+            </button>
+          </template>
+          <div class="whitespace-nowrap">
+            {{ $t("common.run") }}
+          </div>
+        </NPopover>
+        <NPopover placement="bottom">
+          <template #trigger>
+            <button
+              class="inline-flex items-center justify-center hover:text-accent cursor-pointer"
+              @click="handleCopy"
+            >
+              <ClipboardIcon class="w-3.5 h-3.5" />
+            </button>
+          </template>
+          <div class="whitespace-nowrap">
+            {{ $t("common.copy") }}
+          </div>
+        </NPopover>
+      </div>
     </div>
-    <div class="flex flex-col gap-y-2 ml-0.5 mt-1">
-      <NPopover placement="right">
-        <template #trigger>
-          <button
-            class="inline-flex items-center justify-center hover:text-accent cursor-pointer"
-            @click="handleExecute"
-          >
-            <PlayIcon class="w-3.5 h-3.5" />
-          </button>
-        </template>
-        <div class="whitespace-nowrap">
-          {{ $t("common.run") }}
-        </div>
-      </NPopover>
-      <NPopover placement="right">
-        <template #trigger>
-          <button
-            class="inline-flex items-center justify-center hover:text-accent cursor-pointer"
-            @click="handleCopy"
-          >
-            <ClipboardIcon class="w-3.5 h-3.5" />
-          </button>
-        </template>
-        <div class="whitespace-nowrap">
-          {{ $t("common.copy") }}
-        </div>
-      </NPopover>
-    </div>
+
+    <MonacoEditor
+      :content="code"
+      :readonly="true"
+      :auto-focus="false"
+      :auto-height="{
+        min: 20,
+        max: 120,
+        padding: 2,
+      }"
+      :options="{
+        automaticLayout: true,
+        fontSize: 12,
+        lineHeight: 14,
+        lineNumbers: 'off',
+        wordWrap: 'on',
+        scrollbar: {
+          vertical: 'hidden',
+          horizontal: 'hidden',
+          useShadows: false,
+          verticalScrollbarSize: 0,
+          horizontalScrollbarSize: 0,
+          alwaysConsumeMouseWheel: false,
+        },
+      }"
+      class="h-auto"
+    />
   </div>
 </template>
 

--- a/frontend/src/plugins/ai/components/ChatView/Markdown/CodeBlock.vue
+++ b/frontend/src/plugins/ai/components/ChatView/Markdown/CodeBlock.vue
@@ -25,6 +25,19 @@
           <template #trigger>
             <button
               class="inline-flex items-center justify-center hover:text-accent cursor-pointer"
+              @click.capture="handleInsertAtCaret"
+            >
+              <InsertAtCaretIcon :size="14" />
+            </button>
+          </template>
+          <div class="whitespace-nowrap">
+            {{ $t("plugin.ai.actions.insert-at-caret") }}
+          </div>
+        </NPopover>
+        <NPopover placement="bottom">
+          <template #trigger>
+            <button
+              class="inline-flex items-center justify-center hover:text-accent cursor-pointer"
               @click="handleCopy"
             >
               <ClipboardIcon class="w-3.5 h-3.5" />
@@ -76,6 +89,8 @@ import { MonacoEditor } from "@/components/MonacoEditor";
 import { useAIContext } from "@/plugins/ai/logic";
 import { pushNotification } from "@/store";
 import { findAncestor, toClipboard } from "@/utils";
+import { useSQLEditorContext } from "@/views/sql-editor/context";
+import InsertAtCaretIcon from "./InsertAtCaretIcon.vue";
 
 export type CodeBlockProps = {
   width: number;
@@ -89,6 +104,7 @@ const props = defineProps<
 
 const { t } = useI18n();
 const { events, showHistoryDialog } = useAIContext();
+const { events: editorEvents } = useSQLEditorContext();
 const containerRef = ref<HTMLElement>();
 const messageWrapperRef = computed(() =>
   findAncestor(containerRef.value, ".message")
@@ -104,6 +120,14 @@ const combinedWidth = computed(() => {
 const handleExecute = () => {
   events.emit("run-statement", {
     statement: props.code,
+  });
+  showHistoryDialog.value = false;
+};
+
+const handleInsertAtCaret = () => {
+  const { code } = props;
+  editorEvents.emit("insert-at-caret", {
+    content: code,
   });
   showHistoryDialog.value = false;
 };

--- a/frontend/src/plugins/ai/components/ChatView/Markdown/InsertAtCaretIcon.vue
+++ b/frontend/src/plugins/ai/components/ChatView/Markdown/InsertAtCaretIcon.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="inline-block relative">
+    <AlignLeftIcon
+      :style="{
+        width: `${size}px`,
+        height: `${size}px`,
+      }"
+    />
+    <ArrowLeftIcon
+      class="text-accent absolute"
+      :stroke-width="4"
+      :style="{
+        width: `${size * 0.7}px`,
+        height: `${size * 0.7}px`,
+        right: `${size * -0.2}px`,
+        bottom: `${size * 0.035}px`,
+      }"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { AlignLeftIcon, ArrowLeftIcon } from "lucide-vue-next";
+
+defineProps<{
+  size: number;
+}>();
+</script>

--- a/frontend/src/plugins/ai/components/ChatView/Markdown/Markdown.vue
+++ b/frontend/src/plugins/ai/components/ChatView/Markdown/Markdown.vue
@@ -1,10 +1,13 @@
 <template>
   <AstToMarkdown :ast="mdast" class="text-sm">
     <template #code="parsedAst">
-      <CodeBlock :code="parsedAst.value" />
+      <CodeBlock :code="parsedAst.value" v-bind="codeBlockProps" />
     </template>
     <template #inlineCode="parsedAst">
-      <HighlightCodeBlock :code="parsedAst.value" class="inline-block bg-gray-200 px-0.5 mx-0.5" />
+      <HighlightCodeBlock
+        :code="parsedAst.value"
+        class="inline-block bg-gray-200 px-0.5 mx-0.5"
+      />
     </template>
     <template #image="parsedAst">
       <img :src="parsedAst.url" />
@@ -19,10 +22,11 @@ import { unified } from "unified";
 import { computed } from "vue";
 import HighlightCodeBlock from "@/components/HighlightCodeBlock";
 import AstToMarkdown from "./AstToVNode.vue";
-import CodeBlock from "./CodeBlock.vue";
+import CodeBlock, { type CodeBlockProps } from "./CodeBlock.vue";
 
 const props = defineProps<{
   content: string;
+  codeBlockProps: CodeBlockProps;
 }>();
 
 const processor = unified().use(remarkParse).use(remarkGfm);

--- a/frontend/src/plugins/ai/components/ChatView/UserMessageView.vue
+++ b/frontend/src/plugins/ai/components/ChatView/UserMessageView.vue
@@ -2,7 +2,12 @@
   <div
     class="user-message max-w-[60%] min-w-[9rem] border rounded shadow py-1 px-2 bg-indigo-100 border-indigo-400"
   >
-    <Markdown :content="message.content" />
+    <Markdown
+      :content="message.content"
+      :code-block-props="{
+        width: 0.6,
+      }"
+    />
   </div>
 </template>
 

--- a/frontend/src/plugins/ai/components/DynamicSuggestions.vue
+++ b/frontend/src/plugins/ai/components/DynamicSuggestions.vue
@@ -1,54 +1,48 @@
 <template>
-  <div
-    v-if="!ready || suggestions.length > 0"
-    class="flex items-center overflow-hidden h-[22px]"
-  >
+  <div v-if="show" class="flex items-center overflow-hidden h-[22px]">
     <template v-if="dynamicSuggestions && !ready">
-      <BBSpin :size="20" class="mr-2" />
-      <span class="text-sm">{{
-        $t("plugin.ai.conversation.tips.suggest-prompt")
-      }}</span>
+      <BBSpin :size="16" class="mr-2" />
+      <span class="text-sm">
+        {{ $t("plugin.ai.conversation.tips.suggest-prompt") }}
+      </span>
     </template>
 
-    <template v-if="ready && suggestions.length > 0">
-      <div
-        class="relative flex items-center gap-x-2 overflow-hidden text-xs leading-4"
+    <div
+      v-if="ready"
+      class="relative flex items-center gap-1 overflow-hidden text-xs leading-4"
+    >
+      <NButton
+        v-if="current"
+        size="tiny"
+        class="flex-1 overflow-hidden"
+        @click.capture="consume"
       >
-        <div
-          class="flex items-stretch gap-x-2 whitespace-nowrap overflow-x-auto hide-scrollbar"
-        >
-          <NEllipsis
-            v-for="(sug, i) in suggestions"
-            :key="i"
-            style="max-width: 20rem"
-            class="border rounded-sm shrink-0 py-0.5 px-2 cursor-pointer hover:bg-indigo-100 hover:border-indigo-500"
-            @click.capture="consume(sug)"
-          >
-            {{ sug }}
-          </NEllipsis>
-
-          <div class="shrink-0 flex items-center">
-            <BBSpin v-if="state === 'LOADING'" :size="16" />
-            <NButton
-              v-if="state === 'IDLE'"
-              size="tiny"
-              quaternary
-              @click="dynamicSuggestions?.fetch()"
-            >
-              {{ $t("plugin.ai.conversation.tips.more") }}
-            </NButton>
-            <span v-if="state === 'ENDED'" class="text-gray-500">
-              {{ $t("plugin.ai.conversation.tips.no-more") }}
-            </span>
-          </div>
+        <div class="w-full truncate">
+          {{ current }}
         </div>
-      </div>
-    </template>
+      </NButton>
+
+      <BBSpin v-if="state === 'LOADING'" :size="16" class="shrink-0" />
+      <NButton
+        v-if="state === 'IDLE'"
+        size="tiny"
+        type="primary"
+        quaternary
+        class="shrink-0"
+        @click="dynamicSuggestions?.consume()"
+      >
+        <RefreshCwIcon class="w-3.5 h-3.5" />
+      </NButton>
+      <span v-if="state === 'ENDED'" class="shrink-0 text-gray-500">
+        {{ $t("plugin.ai.conversation.tips.no-more") }}
+      </span>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { NButton, NEllipsis } from "naive-ui";
+import { RefreshCwIcon } from "lucide-vue-next";
+import { NButton } from "naive-ui";
 import { computed } from "vue";
 import { BBSpin } from "@/bbkit";
 import { useDynamicSuggestions } from "../logic";
@@ -62,11 +56,19 @@ const dynamicSuggestions = useDynamicSuggestions();
 const ready = computed(() => dynamicSuggestions.value?.ready ?? false);
 const state = computed(() => dynamicSuggestions.value?.state ?? "IDLE");
 const suggestions = computed(() => dynamicSuggestions.value?.suggestions ?? []);
+const current = computed(() => dynamicSuggestions.value?.current());
 
-const consume = (sug: string) => {
-  const suggestions = dynamicSuggestions.value;
-  if (!suggestions) return;
-  suggestions.consume(sug);
-  emit("enter", sug);
+const show = computed(() => {
+  if (!ready.value) return true; // show a spinner
+  return suggestions.value.length > 0 || state.value === "LOADING";
+});
+
+const consume = () => {
+  const suggestion = dynamicSuggestions.value;
+  if (!suggestion) return;
+  const curr = current.value;
+  if (!curr) return;
+  emit("enter", curr);
+  suggestion.consume();
 };
 </script>

--- a/frontend/src/plugins/ai/components/HistoryPanel/HistoryPanel.vue
+++ b/frontend/src/plugins/ai/components/HistoryPanel/HistoryPanel.vue
@@ -10,7 +10,7 @@
           <ConversationList />
         </aside>
 
-        <div class="flex-1 flex flex-col bg-gray-100 overflow-hidden">
+        <div class="flex-1 flex flex-col py-2 bg-gray-100 overflow-hidden">
           <ChatView mode="VIEW" :conversation="selected" />
         </div>
       </div>

--- a/frontend/src/plugins/ai/components/PromptInput.vue
+++ b/frontend/src/plugins/ai/components/PromptInput.vue
@@ -50,6 +50,7 @@
 <script lang="ts" setup>
 import { NButton, NInput, NPopover, type InputInst } from "naive-ui";
 import { onMounted, reactive, ref, watch } from "vue";
+import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
 import { keyboardShortcutStr, nextAnimationFrame } from "@/utils";
 import { useAIContext } from "../logic";
 
@@ -74,7 +75,7 @@ const state = reactive<LocalState>({
   value: "",
 });
 
-const { pendingPreInput } = useAIContext();
+const { pendingPreInput, events } = useAIContext();
 const inputRef = ref<InputInst>();
 
 const applyValue = (value: string) => {
@@ -108,4 +109,8 @@ watch(
     flush: "post",
   }
 );
+
+useEmitteryEventListener(events, "new-conversation", () => {
+  inputRef.value?.focus();
+});
 </script>

--- a/frontend/src/plugins/ai/components/PromptInput.vue
+++ b/frontend/src/plugins/ai/components/PromptInput.vue
@@ -86,8 +86,9 @@ const handlePressEnter = (e?: KeyboardEvent) => {
   if (e?.shiftKey) {
     return;
   }
-  applyValue(state.value);
   e?.preventDefault();
+  if (!state.value.trim()) return;
+  applyValue(state.value);
 };
 
 onMounted(() => {

--- a/frontend/src/plugins/ai/components/PromptInput.vue
+++ b/frontend/src/plugins/ai/components/PromptInput.vue
@@ -13,12 +13,9 @@
     }"
     size="small"
     type="textarea"
-    style="--n-padding-left: 8px; --n-padding-right: 4px"
+    style="--n-padding-left: 6px; --n-padding-right: 0px"
     @keypress.enter="handlePressEnter"
   >
-    <template #prefix>
-      <heroicons-outline:sparkles class="w-3.5 h-3.5 text-accent" />
-    </template>
     <template #suffix>
       <NPopover placement="bottom" style="--n-padding: 6px 8px">
         <template #trigger>

--- a/frontend/src/plugins/ai/components/editor-actions.ts
+++ b/frontend/src/plugins/ai/components/editor-actions.ts
@@ -84,17 +84,7 @@ export const useAIActions = async (
         actions.value.push(action);
       }
       if (opts.actions.includes("new-chat")) {
-        const action1 = editor.addAction({
-          id: "new-chat",
-          label: "New chat",
-          precondition: "bb.ai.selectedContentEmpty",
-          contextMenuGroupId: "2_ai_assistant",
-          contextMenuOrder: 2,
-          run: async () => {
-            opts.callback("new-chat", monaco, editor);
-          },
-        });
-        const action2 = editor.addAction({
+        const action = editor.addAction({
           id: "new-chat-using-selection",
           label: "New chat using selection",
           precondition: "!bb.ai.selectedContentEmpty",
@@ -104,8 +94,7 @@ export const useAIActions = async (
             opts.callback("new-chat", monaco, editor);
           },
         });
-        actions.value.push(action1);
-        actions.value.push(action2);
+        actions.value.push(action);
       }
     } else {
       // When the language is "javascript" we do not have AI Assistant actions

--- a/frontend/src/plugins/ai/logic/prompt.ts
+++ b/frontend/src/plugins/ai/logic/prompt.ts
@@ -82,6 +82,8 @@ export const wrapStatementMarkdown = (statement: string, engine?: Engine) => {
   let openTag = "```";
   if (engine) {
     openTag += engineNameV1(engine).toLowerCase();
+  } else {
+    openTag += "SQL";
   }
   const closeTag = "```";
   return [openTag, statement, closeTag].join("\n");

--- a/frontend/src/views/sql-editor/EditorCommon/OpenAIButton/OpenAIButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/OpenAIButton/OpenAIButton.vue
@@ -109,7 +109,6 @@ const options = computed(() => {
       label: t("plugin.ai.actions.find-problems"),
       disabled: !statement,
     },
-    { value: "new-chat", label: t("plugin.ai.actions.new-chat") },
   ];
   return options.filter((opt) => {
     if (props.actions && !props.actions.includes(opt.value)) return false;
@@ -153,13 +152,10 @@ const handleSelect = async (action: ChatAction) => {
       });
     }
   }
-  if (action === "new-chat") {
-    events.emit("new-conversation", { input: "" });
-  }
 };
 
 const handleClickButton = () => {
-  showAIPanel.value = true;
+  showAIPanel.value = !showAIPanel.value;
 };
 
 const goConfigure = () => {

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/Panels.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/Panels.vue
@@ -3,7 +3,13 @@
     <GutterBar class="border-r border-control-border" :class="gutterBarClass" />
 
     <div class="flex-1 overflow-y-hidden overflow-x-auto" :class="contentClass">
-      <slot v-if="!viewState || viewState.view === 'CODE'" name="code-panel" />
+      <!-- <slot v-if="!viewState || viewState.view === 'CODE'" name="code-panel" /> -->
+      <div
+        v-show="!viewState || viewState.view === 'CODE'"
+        class="w-full h-full overflow-hidden"
+      >
+        <slot name="code-panel" />
+      </div>
 
       <template v-if="viewState">
         <InfoPanel v-if="viewState.view === 'INFO'" :key="tab?.id" />

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/Panels.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/Panels.vue
@@ -3,7 +3,6 @@
     <GutterBar class="border-r border-control-border" :class="gutterBarClass" />
 
     <div class="flex-1 overflow-y-hidden overflow-x-auto" :class="contentClass">
-      <!-- <slot v-if="!viewState || viewState.view === 'CODE'" name="code-panel" /> -->
       <div
         v-show="!viewState || viewState.view === 'CODE'"
         class="w-full h-full overflow-hidden"

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
@@ -18,7 +18,7 @@
       class="overflow-hidden flex flex-col"
     >
       <Suspense>
-        <AIChatToSQL />
+        <AIChatToSQL key="ai-chat-to-sql" />
         <template #fallback>
           <div
             class="w-full h-full flex-grow flex flex-col items-center justify-center"

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
@@ -1,6 +1,7 @@
 <template>
   <Splitpanes
     class="default-theme flex flex-row items-stretch flex-1 w-full overflow-hidden"
+    @resized="handleAIPanelResize($event, 1)"
   >
     <Pane>
       <MonacoEditor
@@ -11,7 +12,11 @@
         @ready="handleEditorReady"
       />
     </Pane>
-    <Pane v-if="showAIPanel" :size="30" class="overflow-hidden flex flex-col">
+    <Pane
+      v-if="showAIPanel"
+      :size="AIPanelSize"
+      class="overflow-hidden flex flex-col"
+    >
       <Suspense>
         <AIChatToSQL />
         <template #fallback>
@@ -56,7 +61,7 @@ const emit = defineEmits<{
   (event: "back"): void;
 }>();
 
-const { showAIPanel } = useSQLEditorContext();
+const { showAIPanel, AIPanelSize, handleAIPanelResize } = useSQLEditorContext();
 const instanceEngine = computed(() => props.db.instanceResource.engine);
 const AIContext = useAIContext();
 const selectedStatement = ref("");

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewDetail.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewDetail.vue
@@ -41,7 +41,7 @@
           </NCheckbox>
           <OpenAIButton
             size="small"
-            :statement="view.definition"
+            :statement="selectedStatement || view.definition"
             :actions="['explain-code']"
           />
         </div>
@@ -53,6 +53,7 @@
     :db="db"
     :code="view.definition"
     :format="format"
+    @select-content="selectedStatement = $event"
   />
   <ColumnsTable
     v-show="state.mode === 'COLUMNS'"
@@ -76,7 +77,7 @@
 import { useLocalStorage } from "@vueuse/core";
 import { ChevronLeftIcon, CodeIcon, FileSymlinkIcon } from "lucide-vue-next";
 import { NButton, NCheckbox, NTab, NTabs } from "naive-ui";
-import { computed, h, reactive, watch } from "vue";
+import { computed, h, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { ColumnIcon, ViewIcon } from "@/components/Icon";
 import { SearchBox } from "@/components/v2";
@@ -115,6 +116,7 @@ const format = useLocalStorage<boolean>(
   "bb.sql-editor.editor-panel.code-viewer.format",
   false
 );
+const selectedStatement = ref("");
 
 const tabItems = computed(() => {
   const items = [

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
@@ -17,7 +17,7 @@
       </NCheckbox>
       <OpenAIButton
         size="small"
-        :statement="code"
+        :statement="selectedStatement || content"
         :actions="['explain-code']"
       />
     </div>
@@ -35,6 +35,7 @@
           callback: handleFormatContent,
         }"
         class="w-full h-full relative"
+        @select-content="selectedStatement = $event"
         @ready="handleEditorReady"
       />
     </Pane>
@@ -58,7 +59,7 @@ import { computedAsync, useLocalStorage } from "@vueuse/core";
 import { ChevronLeftIcon } from "lucide-vue-next";
 import { NButton, NCheckbox } from "naive-ui";
 import { Pane, Splitpanes } from "splitpanes";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { BBSpin } from "@/bbkit";
 import {
   MonacoEditor,
@@ -92,6 +93,7 @@ const format = useLocalStorage<boolean>(
   false
 );
 const instanceEngine = computed(() => props.db.instanceResource.engine);
+const selectedStatement = ref("");
 
 const formatted = computedAsync(
   async () => {
@@ -139,10 +141,12 @@ const handleEditorReady = (
       showAIPanel.value = true;
       if (action !== "explain-code") return;
 
+      const statement = selectedStatement.value || content.value;
+
       await nextAnimationFrame();
       AIContext.events.emit("send-chat", {
         content: promptUtils.explainCode(
-          props.code,
+          statement,
           props.db.instanceResource.engine
         ),
         newChat,

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
@@ -46,7 +46,7 @@
       class="overflow-hidden flex flex-col"
     >
       <Suspense>
-        <AIChatToSQL />
+        <AIChatToSQL key="ai-chat-to-sql" />
         <template #fallback>
           <div
             class="w-full h-full flex-grow flex flex-col items-center justify-center"

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
@@ -25,6 +25,7 @@
 
   <Splitpanes
     class="default-theme flex flex-row items-stretch flex-1 w-full overflow-hidden"
+    @resized="handleAIPanelResize($event, 1)"
   >
     <Pane>
       <MonacoEditor
@@ -39,7 +40,11 @@
         @ready="handleEditorReady"
       />
     </Pane>
-    <Pane v-if="showAIPanel" :size="30" class="overflow-hidden flex flex-col">
+    <Pane
+      v-if="showAIPanel"
+      :size="AIPanelSize"
+      class="overflow-hidden flex flex-col"
+    >
       <Suspense>
         <AIChatToSQL />
         <template #fallback>
@@ -86,7 +91,7 @@ defineEmits<{
   (event: "back"): void;
 }>();
 
-const { showAIPanel } = useSQLEditorContext();
+const { showAIPanel, AIPanelSize, handleAIPanelResize } = useSQLEditorContext();
 const AIContext = useAIContext();
 const format = useLocalStorage<boolean>(
   "bb.sql-editor.editor-panel.code-viewer.format",

--- a/frontend/src/views/sql-editor/EditorPanel/StandardPanel/SQLEditor.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/StandardPanel/SQLEditor.vue
@@ -217,11 +217,11 @@ const handleEditorReady = (
       }
       if (action === "new-chat") {
         const statement = tab?.selectedStatement ?? "";
-        const inputs: string[] = [];
-        if (statement) {
-          inputs.push(`// ${t("plugin.ai.text-to-sql-placeholder")}`);
-          inputs.push(promptUtils.wrapStatementMarkdown(statement));
-        }
+        if (!statement) return;
+        const inputs = [
+          `// ${t("plugin.ai.text-to-sql-placeholder")}`,
+          promptUtils.wrapStatementMarkdown(statement),
+        ];
         AIContext.events.emit("new-conversation", {
           input: inputs.join("\n"),
         });

--- a/frontend/src/views/sql-editor/EditorPanel/StandardPanel/SQLEditor.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/StandardPanel/SQLEditor.vue
@@ -28,7 +28,6 @@
 import { storeToRefs } from "pinia";
 import { v1 as uuidv1 } from "uuid";
 import { computed, nextTick, ref, watch } from "vue";
-import { useI18n } from "vue-i18n";
 import type {
   AdviceOption,
   IStandaloneCodeEditor,
@@ -62,7 +61,6 @@ const emit = defineEmits<{
   (e: "execute", params: SQLEditorQueryParams): void;
 }>();
 
-const { t } = useI18n();
 const tabStore = useSQLEditorTabStore();
 const sheetAndTabStore = useWorkSheetAndTabStore();
 const uiStateStore = useUIStateStore();
@@ -219,7 +217,7 @@ const handleEditorReady = (
         const statement = tab?.selectedStatement ?? "";
         if (!statement) return;
         const inputs = [
-          `// ${t("plugin.ai.text-to-sql-placeholder")}`,
+          "", // just an empty line
           promptUtils.wrapStatementMarkdown(statement),
         ];
         AIContext.events.emit("new-conversation", {

--- a/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
@@ -32,7 +32,7 @@
             class="overflow-hidden flex flex-col"
           >
             <Suspense>
-              <AIChatToSQL />
+              <AIChatToSQL key="ai-chat-to-sql" />
               <template #fallback>
                 <div
                   class="w-full h-full flex-grow flex flex-col items-center justify-center"

--- a/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
@@ -9,7 +9,11 @@
       <template v-if="isDisconnected || allowReadonlyMode">
         <EditorAction @execute="handleExecute" />
 
-        <Splitpanes v-if="tab" class="default-theme overflow-hidden">
+        <Splitpanes
+          v-if="tab"
+          class="default-theme overflow-hidden"
+          @resized="handleAIPanelResize($event, 1)"
+        >
           <Pane>
             <Suspense>
               <SQLEditor @execute="handleExecute" />
@@ -24,7 +28,7 @@
           </Pane>
           <Pane
             v-if="showAIPanel"
-            :size="33"
+            :size="AIPanelSize"
             class="overflow-hidden flex flex-col"
           >
             <Suspense>
@@ -88,7 +92,7 @@ const SQLEditor = defineAsyncComponent(() => import("./SQLEditor.vue"));
 const tabStore = useSQLEditorTabStore();
 const { currentTab: tab, isDisconnected } = storeToRefs(tabStore);
 const { instance } = useConnectionOfCurrentSQLEditorTab();
-const { showAIPanel } = useSQLEditorContext();
+const { showAIPanel, AIPanelSize, handleAIPanelResize } = useSQLEditorContext();
 
 const allowReadonlyMode = computed(() => {
   if (isDisconnected.value) return false;

--- a/frontend/src/views/sql-editor/SQLEditorHomePage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorHomePage.vue
@@ -106,7 +106,11 @@ const state = reactive<LocalState>({
 const router = useRouter();
 const databaseStore = useDatabaseV1Store();
 const tabStore = useSQLEditorTabStore();
-const { events: editorEvents, showConnectionPanel } = useSQLEditorContext();
+const {
+  events: editorEvents,
+  showConnectionPanel,
+  pendingInsertAtCaret,
+} = useSQLEditorContext();
 const { showPanel: showSheetPanel } = useSheetContext();
 
 const { currentTab, isDisconnected } = storeToRefs(tabStore);
@@ -146,9 +150,23 @@ useEmitteryEventListener(
   }
 );
 
-provideEditorPanelContext({
+const editorPanelContext = provideEditorPanelContext({
   tab: currentTab,
 });
+
+useEmitteryEventListener(
+  editorEvents,
+  "insert-at-caret",
+  async ({ content }) => {
+    if (!tabStore.currentTab) return;
+    editorPanelContext.updateViewState({
+      view: "CODE",
+    });
+    requestAnimationFrame(() => {
+      pendingInsertAtCaret.value = content;
+    });
+  }
+);
 </script>
 
 <style lang="postcss">

--- a/frontend/src/views/sql-editor/context.ts
+++ b/frontend/src/views/sql-editor/context.ts
@@ -9,10 +9,7 @@ import type { Worksheet } from "@/types/proto/v1/worksheet_service";
 export type AsidePanelTab = "SCHEMA" | "WORKSHEET" | "HISTORY";
 
 // 30% by default
-export const storedAIPanelSize = useLocalStorage(
-  "bb.plugin.ai.panel-size",
-  30
-);
+export const storedAIPanelSize = useLocalStorage("bb.plugin.ai.panel-size", 30);
 
 type SQLEditorEvents = Emittery<{
   "save-sheet": {
@@ -35,6 +32,9 @@ type SQLEditorEvents = Emittery<{
     start: { line: number; column: number };
     end?: { line: number; column: number };
   };
+  "insert-at-caret": {
+    content: string;
+  };
 }>;
 
 export type SQLEditorContext = {
@@ -50,6 +50,8 @@ export type SQLEditorContext = {
       }
     | undefined
   >;
+
+  pendingInsertAtCaret: Ref<string | undefined>;
 
   events: SQLEditorEvents;
 
@@ -73,6 +75,7 @@ export const provideSQLEditorContext = () => {
     showAIPanel: ref(false),
     AIPanelSize: storedAIPanelSize,
     schemaViewer: ref(undefined),
+    pendingInsertAtCaret: ref(),
     events: new Emittery(),
 
     maybeSwitchProject: (project) => {


### PR DESCRIPTION
- Re-layout AI message and add "Insert at caret" button. (Close BYT-6468, BYT-6470)
- "Explain code" and "Find problems" will always respect code editor's selection state. (Close BYT-6469)
- Display and consume prompt suggestions one-by-one. (Close BYT-6471)
- Remember AI Assistant panel's width. (Close BYT-6472)
- Re-org AI Assistant actions (Close BYT-6473)
  - Remove "New chat"
  - Clicking the AI button now toggles the panel (instead of opening only)
- Remove sparkle icon in AI prompt input box. (Close BYT-6474)
- Update the default input template of "New chat using selection". (Close BYT-6475)