### PR TITLE
feat: ignore alloydbmetadata database

### DIFF
--- a/backend/plugin/parser/pg/system_objects.go
+++ b/backend/plugin/parser/pg/system_objects.go
@@ -13,9 +13,10 @@ var (
 		// aws
 		"rdsadmin": true,
 		// gcp
-		"cloudsql":      true,
-		"cloudsqladmin": true,
-		"alloydbadmin":  true,
+		"cloudsql":        true,
+		"cloudsqladmin":   true,
+		"alloydbadmin":    true,
+		"alloydbmetadata": true,
 		// system templates.
 		"template0": true,
 		"template1": true,


### PR DESCRIPTION
AlloyDB has two internal DBs: alloydbmetadata is the other.