### PR TITLE
feat: scheduler versioned

### DIFF
--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -17,22 +17,22 @@ func getBaseProfile(dataDir string) *config.Profile {
 	}
 
 	return &config.Profile{
-		ExternalURL:        flags.externalURL,
-		Port:               flags.port,     // Using flags.port as our gRPC server port.
-		DatastorePort:      flags.port + 2, // Using flags.port + 2 as our datastore port.
-		SampleDatabasePort: sampleDatabasePort,
-		Readonly:           flags.readonly,
-		SaaS:               flags.saas,
-		Debug:              flags.debug,
-		DataDir:            dataDir,
-		ResourceDir:        common.GetResourceDir(dataDir),
-		DemoName:           flags.demoName,
-		Version:            version,
-		GitCommit:          gitcommit,
-		PgURL:              flags.pgURL,
-		DeployID:           uuid.NewString()[:8],
-		LastActiveTs:       time.Now().Unix(),
-		Lsp:                flags.lsp,
+		ExternalURL:          flags.externalURL,
+		Port:                 flags.port,     // Using flags.port as our gRPC server port.
+		DatastorePort:        flags.port + 2, // Using flags.port + 2 as our datastore port.
+		SampleDatabasePort:   sampleDatabasePort,
+		Readonly:             flags.readonly,
+		SaaS:                 flags.saas,
+		Debug:                flags.debug,
+		DataDir:              dataDir,
+		ResourceDir:          common.GetResourceDir(dataDir),
+		DemoName:             flags.demoName,
+		Version:              version,
+		GitCommit:            gitcommit,
+		PgURL:                flags.pgURL,
+		DeployID:             uuid.NewString()[:8],
+		LastActiveTs:         time.Now().Unix(),
+		Lsp:                  flags.lsp,
 		DevelopmentVersioned: flags.developmentVersioned,
 	}
 }

--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -33,5 +33,6 @@ func getBaseProfile(dataDir string) *config.Profile {
 		DeployID:           uuid.NewString()[:8],
 		LastActiveTs:       time.Now().Unix(),
 		Lsp:                flags.lsp,
+		DevelopmentVersioned: flags.developmentVersioned,
 	}
 }

--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -80,6 +80,8 @@ var (
 		// disableSample is the flag to disable the sample instance.
 		disableSample bool
 		lsp           bool
+
+		developmentVersioned bool
 	}
 
 	rootCmd = &cobra.Command{
@@ -124,6 +126,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flags.lsp, "lsp", true, "whether to enable lsp in SQL Editor")
 	rootCmd.PersistentFlags().BoolVar(&flags.disableMetric, "disable-metric", false, "disable the metric collector")
 	rootCmd.PersistentFlags().BoolVar(&flags.disableSample, "disable-sample", false, "disable the sample instance")
+
+	rootCmd.PersistentFlags().BoolVar(&flags.developmentVersioned, "development-versioned", false, "(WIP) versioned workflow")
 }
 
 // -----------------------------------Command Line Config END--------------------------------------

--- a/backend/component/config/profile.go
+++ b/backend/component/config/profile.go
@@ -70,6 +70,9 @@ type Profile struct {
 
 	// can be set in runtime
 	RuntimeDebug atomic.Bool
+
+	// Development flag, enables the versioned workflow.
+	DevelopmentVersioned bool
 }
 
 // UseEmbedDB returns whether to use embedDB.

--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -346,7 +346,7 @@ func (s *SchedulerV2) schedulePendingTaskRun(ctx context.Context, taskRun *store
 				return true, nil
 			}
 
-			taskIDs, err := s.store.FindLtVersionTasks(ctx, *task.DatabaseID, Version.Version)
+			taskIDs, err := s.store.FindBlockingTasksByVersion(ctx, *task.DatabaseID, Version.Version)
 			if err != nil {
 				return false, errors.Wrapf(err, "failed to find blocking versioned tasks")
 			}

--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -330,7 +330,7 @@ func (s *SchedulerV2) schedulePendingTaskRun(ctx context.Context, taskRun *store
 		}
 	}
 
-	if common.IsDev() {
+	if common.IsDev() && s.profile.DevelopmentVersioned {
 		doSchedule, err := func() (bool, error) {
 			if task.DatabaseID == nil {
 				return true, nil

--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -336,17 +336,17 @@ func (s *SchedulerV2) schedulePendingTaskRun(ctx context.Context, taskRun *store
 				return true, nil
 			}
 
-			var Version struct {
+			var version struct {
 				Version string `json:"schemaVersion"`
 			}
-			if err := json.Unmarshal([]byte(task.Payload), &Version); err != nil {
+			if err := json.Unmarshal([]byte(task.Payload), &version); err != nil {
 				return false, errors.Wrapf(err, "failed to unmarshal task payload")
 			}
-			if Version.Version == "" {
+			if version.Version == "" {
 				return true, nil
 			}
 
-			taskIDs, err := s.store.FindBlockingTasksByVersion(ctx, *task.DatabaseID, Version.Version)
+			taskIDs, err := s.store.FindBlockingTasksByVersion(ctx, *task.DatabaseID, version.Version)
 			if err != nil {
 				return false, errors.Wrapf(err, "failed to find blocking versioned tasks")
 			}

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -61,7 +61,7 @@ func (s *Store) GetTaskV2ByID(ctx context.Context, id int) (*TaskMessage, error)
 	return tasks[0], nil
 }
 
-func (s *Store) FindLtVersionTasks(ctx context.Context, databaseUID int, version string) ([]int, error) {
+func (s *Store) FindBlockingTasksByVersion(ctx context.Context, databaseUID int, version string) ([]int, error) {
 	query := `
 		SELECT
 			task.id

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -64,7 +64,7 @@ func (s *Store) GetTaskV2ByID(ctx context.Context, id int) (*TaskMessage, error)
 func (s *Store) FindLtVersionTasks(ctx context.Context, databaseUID int, version string) ([]int, error) {
 	query := `
 		SELECT
-			task.id,
+			task.id
 		FROM task
 		LEFT JOIN pipeline ON task.pipeline_id = pipeline.id
 		LEFT JOIN issue ON pipeline.id = issue.pipeline_id
@@ -80,8 +80,8 @@ func (s *Store) FindLtVersionTasks(ctx context.Context, databaseUID int, version
 			) AS status
 		) AS latest_task_run ON TRUE
 		WHERE task.database_id = $1
-		AND task.payload->>'version' IS NOT NULL
-		AND task.payload->>'version' < $2
+		AND task.payload->>'schemaVersion' IS NOT NULL
+		AND task.payload->>'schemaVersion' < $2
 		AND (task.payload->>'skipped')::BOOLEAN IS NOT TRUE
 		AND latest_task_run.status != 'DONE'
 		AND COALESCE(issue.status, 'OPEN') = 'OPEN'


### PR DESCRIPTION
pass `--development-versioned` to enable.

The scheduler schedules tasks on the same database by the order of the version. The order is undefined if the version is the same.