### PR TITLE
chore: add default execute permission to projectQuerier

### DIFF
--- a/backend/component/iam/acl.yaml
+++ b/backend/component/iam/acl.yaml
@@ -373,6 +373,7 @@ roles:
       - bb.databases.getSchema
       - bb.databases.list
       - bb.databases.query
+      - bb.databases.execute
       - bb.projects.get
       - bb.projects.getIamPolicy
       - bb.worksheets.get


### PR DESCRIPTION
Still need to respect ACL in SQLService.Execute