### PR TITLE
fix: remove sql review rule without engine

### DIFF
--- a/frontend/src/types/sql-review-schema.yaml
+++ b/frontend/src/types/sql-review-schema.yaml
@@ -177,21 +177,6 @@
       payload:
         type: NUMBER
         default: 64
-- type: table.comment
-  category: TABLE
-  componentList:
-    - key: required
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: maxLength
-      payload:
-        type: NUMBER
-        default: 64
   engine: POSTGRES
 - type: table.comment
   category: TABLE
@@ -1520,21 +1505,6 @@
         type: NUMBER
         default: 64
   engine: OCEANBASE
-- type: column.comment
-  category: COLUMN
-  componentList:
-    - key: required
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: maxLength
-      payload:
-        type: NUMBER
-        default: 64
 - type: column.comment
   category: COLUMN
   componentList:


### PR DESCRIPTION
Since we add engine-specific rules.

This caused the problem in generating SQL review guide for bytebase.com