### PR TITLE
feat(sql-editor): show function signature instead of name

### DIFF
--- a/backend/api/v1/branch_service.go
+++ b/backend/api/v1/branch_service.go
@@ -1032,6 +1032,7 @@ func filterDatabaseMetadataByEngine(metadata *storepb.DatabaseSchemaMetadata, en
 				filteredFunction := &storepb.FunctionMetadata{
 					Name:       function.Name,
 					Definition: function.Definition,
+					Signature:  function.Signature,
 				}
 				filteredSchema.Functions = append(filteredSchema.Functions, filteredFunction)
 			}

--- a/backend/api/v1/database_converter.go
+++ b/backend/api/v1/database_converter.go
@@ -83,6 +83,7 @@ func convertStoreDatabaseMetadata(ctx context.Context, metadata *storepb.Databas
 			v1Func := &v1pb.FunctionMetadata{
 				Name:       function.Name,
 				Definition: function.Definition,
+				Signature:  function.Signature,
 			}
 			s.Functions = append(s.Functions, v1Func)
 		}
@@ -509,6 +510,7 @@ func convertV1DatabaseMetadata(ctx context.Context, metadata *v1pb.DatabaseMetad
 			storeFunc := &storepb.FunctionMetadata{
 				Name:       function.Name,
 				Definition: function.Definition,
+				Signature:  function.Signature,
 			}
 			s.Functions = append(s.Functions, storeFunc)
 		}

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/FunctionNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/FunctionNode.vue
@@ -1,6 +1,6 @@
 <template>
   <CommonNode
-    :text="target.function.name"
+    :text="target.function.signature || target.function.name"
     :keyword="keyword"
     :highlight="true"
     :indent="0"


### PR DESCRIPTION
close BYT-6512

We only support function signatures for Postgres currently.

<img width="715" alt="image" src="https://github.com/user-attachments/assets/c91bdf88-00d7-4142-8dae-24c4fd1b1f13">
 