### PR TITLE
chore: better error for wrong API url

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -266,11 +266,10 @@ func NewServer(ctx context.Context, profile *config.Profile) (*Server, error) {
 
 			err := &grpcruntime.HTTPStatusError{
 				HTTPStatus: httpStatus,
-				Err:        status.Errorf(codes.NotFound, fmt.Sprintf("Routing error. Please check the request URI %v", r.RequestURI)),
+				Err:        status.Errorf(codes.NotFound, "Routing error. Please check the request URI %v", r.RequestURI),
 			}
 
 			grpcruntime.DefaultHTTPErrorHandler(ctx, sm, m, w, r, err)
-			return
 		}),
 	)
 


### PR DESCRIPTION
Help API users find URL errors.

## Now
```
{
  "code": 5,
  "message": "Routing error. Please check request URI /v1/projets/tnt/releases",
  "details": []
}
```
## Before

```
{
  "code": 5,
  "message": "Not Found",
  "details": []
}
```