### PR TITLE
chore: add BB_VERSION for docker-compose quickstart

### DIFF
--- a/quickstart/.env
+++ b/quickstart/.env
@@ -1,0 +1,1 @@
+BB_VERSION=latest


### PR DESCRIPTION
When running `docker compose` in the [quickstart guide](https://github.com/bytebase/bytebase/tree/main/quickstart), I noticed that BB_VERSION wasn't specified. I resolved this by creating a .env file to define it.

<img width="714" alt="image" src="https://github.com/user-attachments/assets/b6f2a701-1d9e-49c5-b8da-05bb38d62d4d">

