### PR TITLE
chore(sql-editor): mixed table rendering strategy

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/DataTable.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/DataTable.vue
@@ -1,6 +1,9 @@
 <template>
   <div
     class="bb-data-table relative w-full flex-1 overflow-hidden flex flex-col"
+    :style="{
+      maxHeight: maxHeight ? `${maxHeight}px` : undefined,
+    }"
   >
     <div class="w-full flex-1 flex flex-col overflow-hidden">
       <div
@@ -131,6 +134,7 @@ const props = defineProps<{
   offset: number;
   isSensitiveColumn: (index: number) => boolean;
   isColumnMissingSensitive: (index: number) => boolean;
+  maxHeight?: number;
 }>();
 
 const scrollerRef = ref<HTMLDivElement>();

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
@@ -125,15 +125,26 @@
         :is-sensitive-column="isSensitiveColumn"
         :is-column-missing-sensitive="isColumnMissingSensitive"
       />
-      <DataTableLite
-        v-else
-        :table="table"
-        :set-index="setIndex"
-        :offset="pageIndex * pageSize"
-        :is-sensitive-column="isSensitiveColumn"
-        :is-column-missing-sensitive="isColumnMissingSensitive"
-        :max-height="maxDataTableHeight"
-      />
+      <template v-else>
+        <DataTableLite
+          v-if="useDataTableLite"
+          :table="table"
+          :set-index="setIndex"
+          :offset="pageIndex * pageSize"
+          :is-sensitive-column="isSensitiveColumn"
+          :is-column-missing-sensitive="isColumnMissingSensitive"
+          :max-height="maxDataTableHeight"
+        />
+        <DataTable
+          v-else
+          :table="table"
+          :set-index="setIndex"
+          :offset="pageIndex * pageSize"
+          :is-sensitive-column="isSensitiveColumn"
+          :is-column-missing-sensitive="isColumnMissingSensitive"
+          :max-height="maxDataTableHeight"
+        />
+      </template>
     </div>
 
     <div
@@ -231,6 +242,7 @@ import {
   isNullOrUndefined,
 } from "@/utils";
 import DataBlock from "./DataBlock.vue";
+import DataTable from "./DataTable";
 import DataTableLite from "./DataTableLite";
 import EmptyView from "./EmptyView.vue";
 import ErrorView from "./ErrorView";
@@ -367,6 +379,18 @@ const data = computed(() => {
     });
   }
   return temp;
+});
+
+const useDataTableLite = computed(() => {
+  // In admin mode, always use DataTableLite to keep consistent
+  if (currentTab.value?.mode === "ADMIN") return true;
+
+  // Otherwise, use DataTableLite if the result set has too many columns
+  // or too many rows in a page.
+  const colCount = table.getFlatHeaders().length;
+  const rowCount = Math.min(pageSize.value, props.result.rows.length);
+
+  return colCount >= 50 || rowCount >= 200;
 });
 
 const isSensitiveColumn = (columnIndex: number): boolean => {


### PR DESCRIPTION
- Use `<DataTable>` for small result sets.
- Use `<DataTableLite>` for large ones (either >= 200 rows or >= 50 cols)