### PR TITLE
chore: update change history display

### DIFF
--- a/frontend/src/components/ChangeHistory/ChangeHistoryDataTable.vue
+++ b/frontend/src/components/ChangeHistory/ChangeHistoryDataTable.vue
@@ -8,9 +8,7 @@
     :striped="true"
     :row-props="rowProps"
     :checked-row-keys="selectedChangeHistoryNames"
-    @update:checked-row-keys="
-        (keys) => $emit('update:selected-change-history-names', keys as string[])
-      "
+    @update:checked-row-keys="(keys) => $emit('update:selected-change-history-names', keys as string[])"
   />
 </template>
 
@@ -21,7 +19,6 @@ import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { RouterLink } from "vue-router";
 import { BBAvatar } from "@/bbkit";
-import { useUserStore } from "@/store";
 import { getDateForPbTimestamp } from "@/types";
 import type { ChangeHistory } from "@/types/proto/v1/database_service";
 import {
@@ -31,13 +28,13 @@ import {
 } from "@/types/proto/v1/database_service";
 import {
   extractIssueUID,
-  extractUserResourceName,
   changeHistoryLink,
   getAffectedTablesOfChangeHistory,
   getHistoryChangeType,
   humanizeDurationV1,
   getAffectedTableDisplayName,
   extractChangeHistoryUID,
+  creatorOfChangeHistory,
 } from "@/utils";
 import HumanizeDate from "../misc/HumanizeDate.vue";
 import ChangeHistoryStatusIcon from "./ChangeHistoryStatusIcon.vue";
@@ -233,11 +230,6 @@ const rowProps = (history: ChangeHistory) => {
       }
     },
   };
-};
-
-const creatorOfChangeHistory = (history: ChangeHistory) => {
-  const email = extractUserResourceName(history.creator);
-  return useUserStore().getUserByEmail(email);
 };
 
 const allowToSelectChangeHistory = (history: ChangeHistory) => {

--- a/frontend/src/components/ChangeHistory/ChangeHistoryDataTable.vue
+++ b/frontend/src/components/ChangeHistory/ChangeHistoryDataTable.vue
@@ -31,7 +31,6 @@ import {
   changeHistoryLink,
   getAffectedTablesOfChangeHistory,
   getHistoryChangeType,
-  humanizeDurationV1,
   getAffectedTableDisplayName,
   extractChangeHistoryUID,
   creatorOfChangeHistory,
@@ -169,16 +168,6 @@ const columnList = computed(() => {
       ellipsis: true,
       render: (history) => {
         return <p class="truncate whitespace-nowrap">{history.statement}</p>;
-      },
-    },
-    {
-      key: "duration",
-      title: t("common.duration"),
-      width: "7rem",
-      resizable: true,
-      ellipsis: true,
-      render: (history) => {
-        return humanizeDurationV1(history.executionDuration);
       },
     },
     {

--- a/frontend/src/components/ChangeHistory/ChangeHistoryDetail.vue
+++ b/frontend/src/components/ChangeHistory/ChangeHistoryDetail.vue
@@ -14,9 +14,6 @@
               {{ $t("common.version") }} {{ changeHistory.version }}
             </h1>
             <NTag round>
-              {{ changeHistory_SourceToJSON(changeHistory.source) }}
-            </NTag>
-            <NTag round>
               {{ changeHistory_TypeToJSON(changeHistory.type) }}
             </NTag>
           </div>
@@ -36,13 +33,6 @@
               >
                 #{{ extractIssueUID(changeHistory.issue) }}
               </router-link>
-            </dd>
-            <dt class="sr-only">{{ $t("common.duration") }}</dt>
-            <dd class="flex items-center text-sm md:mr-4">
-              <span class="textlabel"
-                >{{ $t("common.duration") }}&nbsp;-&nbsp;</span
-              >
-              {{ humanizeDurationV1(changeHistory.executionDuration) }}
             </dd>
             <dt class="sr-only">{{ $t("common.creator") }}</dt>
             <dd v-if="creator" class="flex items-center text-sm md:mr-4">
@@ -304,7 +294,6 @@ import { Engine } from "@/types/proto/v1/common";
 import type { ChangeHistory } from "@/types/proto/v1/database_service";
 import {
   ChangeHistory_Type,
-  changeHistory_SourceToJSON,
   changeHistory_TypeToJSON,
   ChangeHistoryView,
 } from "@/types/proto/v1/database_service";

--- a/frontend/src/components/ChangeHistory/ChangeHistoryDetail.vue
+++ b/frontend/src/components/ChangeHistory/ChangeHistoryDetail.vue
@@ -13,12 +13,13 @@
             <h1 class="text-xl font-bold leading-6 text-main truncate">
               {{ $t("common.version") }} {{ changeHistory.version }}
             </h1>
+            <NTag round>
+              {{ changeHistory_SourceToJSON(changeHistory.source) }}
+            </NTag>
+            <NTag round>
+              {{ changeHistory_TypeToJSON(changeHistory.type) }}
+            </NTag>
           </div>
-          <p class="text-control">
-            {{ changeHistory_SourceToJSON(changeHistory.source) }}
-            {{ changeHistory_TypeToJSON(changeHistory.type) }} -
-            {{ changeHistory.description }}
-          </p>
           <dl
             class="flex flex-col space-y-1 md:space-y-0 md:flex-row md:flex-wrap"
           >
@@ -58,8 +59,6 @@
               {{
                 humanizeDate(getDateForPbTimestamp(changeHistory.createTime))
               }}
-              by
-              {{ `version ${changeHistory.releaseVersion}` }}
             </dd>
           </dl>
         </div>
@@ -285,7 +284,7 @@
 <script lang="ts" setup>
 import { useTitle } from "@vueuse/core";
 import { ChevronDownIcon } from "lucide-vue-next";
-import { NButton, NSwitch } from "naive-ui";
+import { NButton, NSwitch, NTag } from "naive-ui";
 import { computed, reactive, watch, ref, unref } from "vue";
 import { BBModal, BBSpin } from "@/bbkit";
 import ChangeHistoryStatusIcon from "@/components/ChangeHistory/ChangeHistoryStatusIcon.vue";

--- a/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunComment.vue
+++ b/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunComment.vue
@@ -115,7 +115,10 @@ const commentLink = computed((): CommentLink => {
     flattenTaskV1List(issue.value.rolloutEntity).find(
       (task) => extractTaskUID(task.name) === taskUID
     ) ?? unknownTask();
-  if (taskRun.status === TaskRun_Status.PENDING || taskRun.status === TaskRun_Status.RUNNING) {
+  if (
+    taskRun.status === TaskRun_Status.PENDING ||
+    taskRun.status === TaskRun_Status.RUNNING
+  ) {
     const task = taskRun.schedulerInfo?.waitingCause?.task;
     if (task) {
       const [, , stageUid, taskUid] = getProjectIdRolloutUidStageUidTaskUid(

--- a/frontend/src/components/Release/ReleaseDataTable.vue
+++ b/frontend/src/components/Release/ReleaseDataTable.vue
@@ -9,9 +9,7 @@
     :row-key="(release: ComposedRelease) => release.name"
     :checked-row-keys="Array.from(state.selectedReleaseNameList)"
     :row-props="rowProps"
-    @update:checked-row-keys="
-        (val) => (state.selectedReleaseNameList = new Set(val as string[]))
-      "
+    @update:checked-row-keys="(val) => (state.selectedReleaseNameList = new Set(val as string[]))"
   />
 </template>
 

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -105,10 +105,8 @@ import { Engine } from "@/types/proto/v1/common";
 import type { ChangeHistory } from "@/types/proto/v1/database_service";
 import {
   ChangeHistoryView,
-  ChangeHistory_Source,
   ChangeHistory_Type,
   DatabaseMetadataView,
-  changeHistory_SourceToJSON,
   changeHistory_TypeToJSON,
 } from "@/types/proto/v1/database_service";
 import {
@@ -266,13 +264,6 @@ const renderSchemaVersionLabel = (option: SelectOption) => {
         customClass="mr-1"
         instance={database.value?.instanceResource}
       />
-    );
-  }
-  if (changeHistory.source !== ChangeHistory_Source.SOURCE_UNSPECIFIED) {
-    children.push(
-      <NTag class="mr-1" round size="small">
-        {changeHistory_SourceToJSON(changeHistory.source)}
-      </NTag>
     );
   }
   if (changeHistory.type !== ChangeHistory_Type.TYPE_UNSPECIFIED) {

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -22,7 +22,7 @@
         {{ $t("common.database") }}
       </span>
       <EnvironmentSelect
-        class="!w-60 mr-4 shrink-0"
+        class="!w-60 mr-3 shrink-0"
         name="environment"
         :environment-name="state.environmentName"
         @update:environment-name="handleEnvironmentSelect"

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -287,11 +287,11 @@ const renderSchemaVersionLabel = (option: SelectOption) => {
       {changeHistory.version}
     </NEllipsis>
   );
-  if (changeHistory.updateTime) {
+  if (changeHistory.createTime) {
     children.push(
       <HumanizeDate
         class="text-control-light"
-        date={getDateForPbTimestamp(changeHistory.updateTime)}
+        date={getDateForPbTimestamp(changeHistory.createTime)}
       />
     );
   }

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -268,30 +268,30 @@ const renderSchemaVersionLabel = (option: SelectOption) => {
       />
     );
   }
-  const { version, updateTime } = changeHistory;
-
+  if (changeHistory.source !== ChangeHistory_Source.SOURCE_UNSPECIFIED) {
+    children.push(
+      <NTag class="mr-1" round size="small">
+        {changeHistory_SourceToJSON(changeHistory.source)}
+      </NTag>
+    );
+  }
+  if (changeHistory.type !== ChangeHistory_Type.TYPE_UNSPECIFIED) {
+    children.push(
+      <NTag class="mr-1" round size="small">
+        {changeHistory_TypeToJSON(changeHistory.type)}
+      </NTag>
+    );
+  }
   children.push(
     <NEllipsis class="flex-1 pr-2" tooltip={false}>
-      <span class="space-x-1 mr-1">
-        {changeHistory.source !== ChangeHistory_Source.SOURCE_UNSPECIFIED && (
-          <NTag round size="small">
-            {changeHistory_SourceToJSON(changeHistory.source)}
-          </NTag>
-        )}
-        {changeHistory.type !== ChangeHistory_Type.TYPE_UNSPECIFIED && (
-          <NTag round size="small">
-            {changeHistory_TypeToJSON(changeHistory.type)}
-          </NTag>
-        )}
-      </span>
-      {version}
+      {changeHistory.version}
     </NEllipsis>
   );
-  if (updateTime) {
+  if (changeHistory.updateTime) {
     children.push(
       <HumanizeDate
         class="text-control-light"
-        date={getDateForPbTimestamp(updateTime)}
+        date={getDateForPbTimestamp(changeHistory.updateTime)}
       />
     );
   }

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -105,6 +105,7 @@ import { Engine } from "@/types/proto/v1/common";
 import type { ChangeHistory } from "@/types/proto/v1/database_service";
 import {
   ChangeHistoryView,
+  ChangeHistory_Source,
   ChangeHistory_Type,
   DatabaseMetadataView,
   changeHistory_SourceToJSON,
@@ -272,12 +273,16 @@ const renderSchemaVersionLabel = (option: SelectOption) => {
   children.push(
     <NEllipsis class="flex-1 pr-2" tooltip={false}>
       <span class="space-x-1 mr-1">
-        <NTag round size="small">
-          {changeHistory_SourceToJSON(changeHistory.source)}
-        </NTag>
-        <NTag round size="small">
-          {changeHistory_TypeToJSON(changeHistory.type)}
-        </NTag>
+        {changeHistory.source !== ChangeHistory_Source.SOURCE_UNSPECIFIED && (
+          <NTag round size="small">
+            {changeHistory_SourceToJSON(changeHistory.source)}
+          </NTag>
+        )}
+        {changeHistory.type !== ChangeHistory_Type.TYPE_UNSPECIFIED && (
+          <NTag round size="small">
+            {changeHistory_TypeToJSON(changeHistory.type)}
+          </NTag>
+        )}
       </span>
       {version}
     </NEllipsis>

--- a/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchema/DatabaseSchemaSelector.vue
@@ -44,7 +44,9 @@
       <span class="flex w-40 items-center shrink-0 text-sm">
         {{ $t("database.sync-schema.schema-version.self") }}
       </span>
-      <div class="w-192 flex flex-row justify-start items-center relative">
+      <div
+        class="w-192 max-w-full flex flex-row justify-start items-center relative"
+      >
         <NSelect
           :loading="isPreparingSchemaVersionOptions"
           :value="state.changeHistoryName"
@@ -74,12 +76,12 @@
   />
 </template>
 
-<script lang="ts" setup>
+<script lang="tsx" setup>
 import { computedAsync } from "@vueuse/core";
 import { head } from "lodash-es";
 import type { SelectOption } from "naive-ui";
-import { NEllipsis, NSelect } from "naive-ui";
-import { computed, h, reactive, ref, watch } from "vue";
+import { NEllipsis, NSelect, NTag } from "naive-ui";
+import { computed, reactive, ref, watch } from "vue";
 import type { VNodeArrayChildren } from "vue";
 import { useI18n } from "vue-i18n";
 import {
@@ -105,6 +107,8 @@ import {
   ChangeHistoryView,
   ChangeHistory_Type,
   DatabaseMetadataView,
+  changeHistory_SourceToJSON,
+  changeHistory_TypeToJSON,
 } from "@/types/proto/v1/database_service";
 import {
   extractChangeHistoryUID,
@@ -256,34 +260,37 @@ const renderSchemaVersionLabel = (option: SelectOption) => {
   const children: VNodeArrayChildren = [];
   if (index > 0) {
     children.push(
-      h(FeatureBadge, {
-        feature: "bb.feature.sync-schema-all-versions",
-        "custom-class": "mr-1",
-        instance: database.value?.instanceResource,
-      })
+      <FeatureBadge
+        feature="bb.feature.sync-schema-all-versions"
+        customClass="mr-1"
+        instance={database.value?.instanceResource}
+      />
     );
   }
-  const { version, description, updateTime } = changeHistory;
+  const { version, updateTime } = changeHistory;
 
   children.push(
-    h(
-      NEllipsis,
-      { class: "flex-1 pr-2", tooltip: false },
-      {
-        default: () => `${version} - ${description}`,
-      }
-    )
+    <NEllipsis class="flex-1 pr-2" tooltip={false}>
+      <span class="space-x-1 mr-1">
+        <NTag round size="small">
+          {changeHistory_SourceToJSON(changeHistory.source)}
+        </NTag>
+        <NTag round size="small">
+          {changeHistory_TypeToJSON(changeHistory.type)}
+        </NTag>
+      </span>
+      {version}
+    </NEllipsis>
   );
   if (updateTime) {
     children.push(
-      h(HumanizeDate, {
-        date: getDateForPbTimestamp(updateTime),
-        class: "text-control-light",
-      })
+      <HumanizeDate
+        class="text-control-light"
+        date={getDateForPbTimestamp(updateTime)}
+      />
     );
   }
-
-  return h("div", { class: "w-full flex justify-between" }, children);
+  return <div class="w-full flex justify-between">{...children}</div>;
 };
 const isMockLatestSchemaChangeHistorySelected = computed(() => {
   if (!state.changeHistoryName) return false;

--- a/frontend/src/utils/v1/changeHistory.ts
+++ b/frontend/src/utils/v1/changeHistory.ts
@@ -1,7 +1,7 @@
 import { isEqual, isUndefined, orderBy, uniqBy } from "lodash-es";
 import Long from "long";
 import { t } from "@/plugins/i18n";
-import { useDBSchemaV1Store, useDatabaseV1Store } from "@/store";
+import { useDBSchemaV1Store, useDatabaseV1Store, useUserStore } from "@/store";
 import type { ComposedDatabase } from "@/types";
 import { EMPTY_ID, UNKNOWN_ID } from "@/types";
 import type { AffectedTable } from "@/types/changeHistory";
@@ -11,6 +11,7 @@ import {
   ChangeHistory,
   ChangeHistory_Type,
 } from "@/types/proto/v1/database_service";
+import { extractUserResourceName } from ".";
 import { databaseV1Url, extractDatabaseResourceName } from "./database";
 
 export const extractChangeHistoryUID = (name: string) => {
@@ -136,6 +137,10 @@ export const mockLatestSchemaChangeHistory = (
       new TextEncoder().encode(schema?.schema).length
     ),
     version: "Latest version",
-    description: "the latest schema of database",
   });
+};
+
+export const creatorOfChangeHistory = (history: ChangeHistory) => {
+  const email = extractUserResourceName(history.creator);
+  return useUserStore().getUserByEmail(email);
 };

--- a/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
@@ -15,7 +15,7 @@
             <div>
               <div class="flex items-center">
                 <h1
-                  class="pb-2.5 text-xl font-bold leading-6 text-main truncate flex items-center gap-x-3"
+                  class="text-xl font-bold text-main truncate flex items-center gap-x-3"
                 >
                   {{ database.databaseName }}
 


### PR DESCRIPTION
Part of BYT-6409

* don't show `releaseVersion`, `description`, `source` and `executionDuration`  of `ChangeHistory` in UI, as the new `Changelog` doesn't has these fields.

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/0d3d2ab5-d2be-4f52-84f7-97f58891c747">

<img width="898" alt="image" src="https://github.com/user-attachments/assets/a4ba5ce3-3677-4ab7-8bce-c4df3543e3e9">
