### PR TITLE
chore(sql-editor): update isDatabaseV1Queryable logic

### DIFF
--- a/frontend/src/store/modules/v1/projectIamPolicy.ts
+++ b/frontend/src/store/modules/v1/projectIamPolicy.ts
@@ -158,8 +158,7 @@ const checkProjectIAMPolicyWithExpr = (
     const permissions =
       roleStore.getRoleByName(binding.role)?.permissions || [];
 
-    for (let i = 0; i < permissions.length; i++) {
-      const permission = permissions[i];
+    for (const permission of permissions) {
       if (requiredPermissions.includes(permission as QueryPermission)) {
         // If binding expr check passes, then return true.
         if (bindingExprCheck(binding.parsedExpr)) {

--- a/frontend/src/store/modules/v1/projectIamPolicy.ts
+++ b/frontend/src/store/modules/v1/projectIamPolicy.ts
@@ -2,11 +2,12 @@ import { isUndefined, uniq } from "lodash-es";
 import { defineStore } from "pinia";
 import { computed, ref, unref, watch } from "vue";
 import { projectServiceClient } from "@/grpcweb";
-import type {
-  ComposedDatabase,
-  ComposedProject,
-  MaybeRef,
-  Permission,
+import {
+  QueryPermissionQueryAny,
+  type ComposedDatabase,
+  type ComposedProject,
+  type MaybeRef,
+  type QueryPermission,
 } from "@/types";
 import type { Expr } from "@/types/proto/google/api/expr/v1alpha1/syntax";
 import type { User } from "@/types/proto/v1/auth_service";
@@ -139,7 +140,7 @@ export const useProjectIamPolicy = (project: MaybeRef<string>) => {
 const checkProjectIAMPolicyWithExpr = (
   user: User,
   project: ComposedProject,
-  permission: Permission,
+  requiredPermissions: QueryPermission[],
   bindingExprCheck: (expr?: Expr) => boolean
 ): boolean => {
   const roleStore = useRoleStore();
@@ -156,12 +157,15 @@ const checkProjectIAMPolicyWithExpr = (
     // If the role does not have the permission, then skip.
     const permissions =
       roleStore.getRoleByName(binding.role)?.permissions || [];
-    if (!permissions.includes(permission)) {
-      continue;
-    }
-    // If binding expr check passes, then return true.
-    if (bindingExprCheck(binding.parsedExpr)) {
-      return true;
+
+    for (let i = 0; i < permissions.length; i++) {
+      const permission = permissions[i];
+      if (requiredPermissions.includes(permission as QueryPermission)) {
+        // If binding expr check passes, then return true.
+        if (bindingExprCheck(binding.parsedExpr)) {
+          return true;
+        }
+      }
     }
   }
 
@@ -170,13 +174,14 @@ const checkProjectIAMPolicyWithExpr = (
 
 export const checkQuerierPermission = (
   database: ComposedDatabase,
+  permissions: QueryPermission[] = QueryPermissionQueryAny,
   schema?: string,
   table?: string
 ) => {
   return checkProjectIAMPolicyWithExpr(
     useCurrentUserV1().value,
     database.projectEntity,
-    "bb.databases.query",
+    permissions,
     (expr?: Expr): boolean => {
       // If no condition is set, then return true.
       if (!expr) {

--- a/frontend/src/types/iam/permission.ts
+++ b/frontend/src/types/iam/permission.ts
@@ -1,3 +1,5 @@
+import type { PickLiteral } from "../utils";
+
 export type Permission =
   | "bb.auditLogs.export"
   | "bb.auditLogs.search"
@@ -30,6 +32,10 @@ export type Permission =
   | "bb.databases.list"
   | "bb.databases.query"
   | "bb.databases.execute"
+  | "bb.databases.queryInfo"
+  | "bb.databases.queryExplain"
+  | "bb.databases.queryDML"
+  | "bb.databases.queryDDL"
   | "bb.databases.sync"
   | "bb.databases.update"
   | "bb.issueComments.list"
@@ -112,3 +118,25 @@ export type Permission =
   | "bb.settings.set"
   | "bb.worksheets.manage"
   | "bb.worksheets.get";
+
+export type QueryPermission = PickLiteral<
+  Permission,
+  | "bb.databases.query"
+  | "bb.databases.queryInfo"
+  | "bb.databases.queryExplain"
+  | "bb.databases.queryDDL"
+  | "bb.databases.queryDML"
+  | "bb.databases.execute"
+>;
+
+export const QueryPermissionQueryOnly: QueryPermission[] = [
+  "bb.databases.query",
+];
+export const QueryPermissionQueryAny: QueryPermission[] = [
+  "bb.databases.query",
+  "bb.databases.queryInfo",
+  "bb.databases.queryExplain",
+  "bb.databases.queryDDL",
+  "bb.databases.queryDML",
+  "bb.databases.execute",
+];

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -6,3 +6,5 @@ export type ValidatedMessage = {
   type: "warning" | "error";
   message: string;
 };
+
+export type PickLiteral<A, B extends A> = B;

--- a/frontend/src/utils/v1/database.ts
+++ b/frontend/src/utils/v1/database.ts
@@ -5,8 +5,8 @@ import {
   databaseNamePrefix,
   instanceNamePrefix,
 } from "@/store/modules/v1/common";
-import { UNKNOWN_ID } from "@/types";
-import type { ComposedDatabase } from "@/types";
+import { QueryPermissionQueryAny, UNKNOWN_ID } from "@/types";
+import type { ComposedDatabase, QueryPermission } from "@/types";
 import { State } from "@/types/proto/v1/common";
 import {
   hasPermissionToCreateChangeDatabaseIssue,
@@ -88,6 +88,7 @@ export const isDatabaseV1Alterable = (database: ComposedDatabase): boolean => {
 // isDatabaseV1Queryable checks if database allowed to query in SQL Editor.
 export const isDatabaseV1Queryable = (
   database: ComposedDatabase,
+  permissions: QueryPermission[] = QueryPermissionQueryAny,
   schema?: string,
   table?: string
 ): boolean => {
@@ -97,11 +98,11 @@ export const isDatabaseV1Queryable = (
     return true;
   }
 
-  if (hasWorkspacePermissionV2("bb.databases.query")) {
+  if (permissions.some((permission) => hasWorkspacePermissionV2(permission))) {
     return true;
   }
 
-  if (checkQuerierPermission(database, schema, table)) {
+  if (checkQuerierPermission(database, permissions, schema, table)) {
     return true;
   }
 


### PR DESCRIPTION
roles with
- `bb.databases.execute` 
- `bb.databases.queryDML`
- `bb.databases.queryDDL`
- `bb.databases.queryInfo`
- `bb.databases.queryExplain`

should also be allowed to choose databases in SQL Editor. 
That allows admins to set up some roles that can only access the database schema but cannot query the data.