### PR TITLE
perf: optimize string concatenation in instance service

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -1030,6 +1030,9 @@ func buildRoleName(b *strings.Builder, instanceID, roleName string) string {
 	if _, err := b.WriteString(common.RolePrefix); err != nil {
 		return ""
 	}
+	if _, err := b.WriteString(roleName); err != nil {
+		return ""
+	}
 	return b.String()
 }
 

--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 
@@ -968,6 +967,24 @@ func getInstanceMessage(ctx context.Context, stores *store.Store, name string) (
 	return instance, nil
 }
 
+// buildInstanceName builds the instance name with the given instance ID.
+func buildInstanceName(instanceID string) string {
+	var b strings.Builder
+	b.Grow(len(common.InstanceNamePrefix) + len(instanceID))
+	b.WriteString(common.InstanceNamePrefix)
+	b.WriteString(instanceID)
+	return b.String()
+}
+
+// buildEnvironmentName builds the environment name with the given environment ID.
+func buildEnvironmentName(environmentID string) string {
+	var b strings.Builder
+	b.Grow(len("environments/") + len(environmentID))
+	b.WriteString("environments/")
+	b.WriteString(environmentID)
+	return b.String()
+}
+
 func convertToInstance(instance *store.InstanceMessage) (*v1pb.Instance, error) {
 	engine := convertToEngine(instance.Engine)
 	dataSourceList, err := convertToV1DataSources(instance.DataSources)
@@ -976,25 +993,41 @@ func convertToInstance(instance *store.InstanceMessage) (*v1pb.Instance, error) 
 	}
 
 	return &v1pb.Instance{
-		Name:          fmt.Sprintf("%s%s", common.InstanceNamePrefix, instance.ResourceID),
+		Name:          buildInstanceName(instance.ResourceID),
 		Title:         instance.Title,
 		Engine:        engine,
 		EngineVersion: instance.EngineVersion,
 		ExternalLink:  instance.ExternalLink,
 		DataSources:   dataSourceList,
 		State:         convertDeletedToState(instance.Deleted),
-		Environment:   fmt.Sprintf("environments/%s", instance.EnvironmentID),
+		Environment:   buildEnvironmentName(instance.EnvironmentID),
 		Activation:    instance.Activation,
 		Options:       convertToInstanceOptions(instance.Options),
 		Roles:         convertToInstanceRoles(instance, instance.Metadata.GetRoles()),
 	}, nil
 }
 
+// buildRoleName builds the role name with the given instance ID and role name.
+func buildRoleName(b *strings.Builder, instanceID, roleName string) string {
+	b.Reset()
+	b.WriteString(common.InstanceNamePrefix)
+	b.WriteString(instanceID)
+	b.WriteString("/")
+	b.WriteString(common.RolePrefix)
+	b.WriteString(roleName)
+	return b.String()
+}
+
 func convertToInstanceRoles(instance *store.InstanceMessage, roles []*storepb.InstanceRole) []*v1pb.InstanceRole {
 	var v1Roles []*v1pb.InstanceRole
+	var b strings.Builder
+
+	// preallocate memory for the builder
+	b.Grow(len(common.InstanceNamePrefix) + len(instance.ResourceID) + 1 + len(common.RolePrefix) + 20)
+
 	for _, role := range roles {
 		v1Roles = append(v1Roles, &v1pb.InstanceRole{
-			Name:      fmt.Sprintf("%s%s/%s%s", common.InstanceNamePrefix, instance.ResourceID, common.RolePrefix, role.Name),
+			Name:      buildRoleName(&b, instance.ResourceID, role.Name),
 			RoleName:  role.Name,
 			Attribute: role.Attribute,
 		})

--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -971,8 +971,12 @@ func getInstanceMessage(ctx context.Context, stores *store.Store, name string) (
 func buildInstanceName(instanceID string) string {
 	var b strings.Builder
 	b.Grow(len(common.InstanceNamePrefix) + len(instanceID))
-	b.WriteString(common.InstanceNamePrefix)
-	b.WriteString(instanceID)
+	if _, err := b.WriteString(common.InstanceNamePrefix); err != nil {
+		return ""
+	}
+	if _, err := b.WriteString(instanceID); err != nil {
+		return ""
+	}
 	return b.String()
 }
 
@@ -980,8 +984,12 @@ func buildInstanceName(instanceID string) string {
 func buildEnvironmentName(environmentID string) string {
 	var b strings.Builder
 	b.Grow(len("environments/") + len(environmentID))
-	b.WriteString("environments/")
-	b.WriteString(environmentID)
+	if _, err := b.WriteString("environments/"); err != nil {
+		return ""
+	}
+	if _, err := b.WriteString(environmentID); err != nil {
+		return ""
+	}
 	return b.String()
 }
 
@@ -1010,11 +1018,18 @@ func convertToInstance(instance *store.InstanceMessage) (*v1pb.Instance, error) 
 // buildRoleName builds the role name with the given instance ID and role name.
 func buildRoleName(b *strings.Builder, instanceID, roleName string) string {
 	b.Reset()
-	b.WriteString(common.InstanceNamePrefix)
-	b.WriteString(instanceID)
-	b.WriteString("/")
-	b.WriteString(common.RolePrefix)
-	b.WriteString(roleName)
+	if _, err := b.WriteString(common.InstanceNamePrefix); err != nil {
+		return ""
+	}
+	if _, err := b.WriteString(instanceID); err != nil {
+		return ""
+	}
+	if _, err := b.WriteString("/"); err != nil {
+		return ""
+	}
+	if _, err := b.WriteString(common.RolePrefix); err != nil {
+		return ""
+	}
 	return b.String()
 }
 

--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -971,12 +971,8 @@ func getInstanceMessage(ctx context.Context, stores *store.Store, name string) (
 func buildInstanceName(instanceID string) string {
 	var b strings.Builder
 	b.Grow(len(common.InstanceNamePrefix) + len(instanceID))
-	if _, err := b.WriteString(common.InstanceNamePrefix); err != nil {
-		return ""
-	}
-	if _, err := b.WriteString(instanceID); err != nil {
-		return ""
-	}
+	_, _ = b.WriteString(common.InstanceNamePrefix)
+	_, _ = b.WriteString(instanceID)
 	return b.String()
 }
 
@@ -984,12 +980,8 @@ func buildInstanceName(instanceID string) string {
 func buildEnvironmentName(environmentID string) string {
 	var b strings.Builder
 	b.Grow(len("environments/") + len(environmentID))
-	if _, err := b.WriteString("environments/"); err != nil {
-		return ""
-	}
-	if _, err := b.WriteString(environmentID); err != nil {
-		return ""
-	}
+	_, _ = b.WriteString("environments/")
+	_, _ = b.WriteString(environmentID)
 	return b.String()
 }
 
@@ -1018,21 +1010,11 @@ func convertToInstance(instance *store.InstanceMessage) (*v1pb.Instance, error) 
 // buildRoleName builds the role name with the given instance ID and role name.
 func buildRoleName(b *strings.Builder, instanceID, roleName string) string {
 	b.Reset()
-	if _, err := b.WriteString(common.InstanceNamePrefix); err != nil {
-		return ""
-	}
-	if _, err := b.WriteString(instanceID); err != nil {
-		return ""
-	}
-	if _, err := b.WriteString("/"); err != nil {
-		return ""
-	}
-	if _, err := b.WriteString(common.RolePrefix); err != nil {
-		return ""
-	}
-	if _, err := b.WriteString(roleName); err != nil {
-		return ""
-	}
+	_, _ = b.WriteString(common.InstanceNamePrefix)
+	_, _ = b.WriteString(instanceID)
+	_, _ = b.WriteString("/")
+	_, _ = b.WriteString(common.RolePrefix)
+	_, _ = b.WriteString(roleName)
 	return b.String()
 }
 


### PR DESCRIPTION
Optimize memory allocation and string concatenation in instance service:

1. Replace fmt.Sprintf with strings.Builder in convertToInstanceRoles
2. Pre-allocate Builder capacity to avoid reallocation
3. Extract buildRoleName function to improve code reusability
4. Keep using simple string concatenation for one-time operations

This change reduces memory allocations and improves performance in hot paths.

Fixes profile showing high memory usage from fmt.Sprintf.

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/517b90c0-3702-4680-af93-469a5eaf61d6">
