### PR TITLE
feat: implement part of standalone rollout pages

### DIFF
--- a/backend/store/pipeline.go
+++ b/backend/store/pipeline.go
@@ -125,7 +125,8 @@ func (s *Store) ListPipelineV2(ctx context.Context, find *PipelineFind) ([]*Pipe
 			pipeline.name
 		FROM pipeline
 		LEFT JOIN project ON pipeline.project_id = project.id
-		WHERE %s`, strings.Join(where, " AND "))
+		WHERE %s
+		ORDER BY id DESC`, strings.Join(where, " AND "))
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "splitpanes": "3.1.5",
     "sql-formatter": "15.4.2",
     "string-width": "^7.2.0",
+    "tailwind-merge": "^2.5.4",
     "uuid": "10.0.0",
     "vdirs": "^0.1.8",
     "vscode": "npm:@codingame/monaco-vscode-api@1.85.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       string-width:
         specifier: ^7.2.0
         version: 7.2.0
+      tailwind-merge:
+        specifier: ^2.5.4
+        version: 2.5.4
       uuid:
         specifier: 10.0.0
         version: 10.0.0
@@ -3757,6 +3760,9 @@ packages:
   synckit@0.9.1:
     resolution: {integrity: sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwind-merge@2.5.4:
+    resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
 
   tailwindcss@3.4.14:
     resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
@@ -8057,6 +8063,8 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.1.1
       tslib: 2.6.2
+
+  tailwind-merge@2.5.4: {}
 
   tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.5.4)):
     dependencies:

--- a/frontend/src/components/IssueV1/logic/utils.ts
+++ b/frontend/src/components/IssueV1/logic/utils.ts
@@ -69,7 +69,7 @@ export const databaseForTask = (issue: ComposedIssue, task: Task) => {
   return unknownDatabase();
 };
 
-const extractCoreDatabaseInfoFromDatabaseCreateTask = (
+export const extractCoreDatabaseInfoFromDatabaseCreateTask = (
   project: ComposedProject,
   task: Task
 ) => {

--- a/frontend/src/components/Project/ProjectRolloutsPanel.vue
+++ b/frontend/src/components/Project/ProjectRolloutsPanel.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="w-full flex flex-col gap-y-2">
+    <PagedRolloutTable
+      :key="project.name"
+      :session-key="`project-${project.name}-releases`"
+      :project="project.name"
+      :page-size="50"
+    >
+      <template #table="{ rolloutList, loading }">
+        <RolloutDataTable
+          :bordered="true"
+          :loading="loading"
+          :rollout-list="rolloutList"
+        />
+      </template>
+    </PagedRolloutTable>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { ComposedProject } from "@/types";
+import PagedRolloutTable from "../Rollout/PagedRolloutTable.vue";
+import RolloutDataTable from "../Rollout/RolloutDataTable.vue";
+
+defineProps<{
+  project: ComposedProject;
+}>();
+</script>

--- a/frontend/src/components/Release/ReleaseDetail/BasicInfo.vue
+++ b/frontend/src/components/Release/ReleaseDetail/BasicInfo.vue
@@ -37,9 +37,9 @@ import VCSIcon from "@/components/VCS/VCSIcon.vue";
 import { getDateForPbTimestamp } from "@/types";
 import { VCSType } from "@/types/proto/v1/common";
 import { humanizeDate } from "@/utils";
-import { provideReleaseDetailContext } from "./context";
+import { useReleaseDetailContext } from "./context";
 
-const { release } = provideReleaseDetailContext();
+const { release } = useReleaseDetailContext();
 
 const vcsSource = computed(() => release.value.vcsSource);
 

--- a/frontend/src/components/Rollout/PagedRolloutTable.vue
+++ b/frontend/src/components/Rollout/PagedRolloutTable.vue
@@ -1,0 +1,172 @@
+<template>
+  <slot
+    name="table"
+    :rollout-list="state.rolloutList"
+    :loading="state.loading"
+  />
+
+  <div
+    v-if="state.loadingMore"
+    class="flex items-center justify-center py-2 text-gray-400 text-sm"
+  >
+    <BBSpin />
+  </div>
+
+  <slot
+    v-if="!state.loadingMore"
+    name="more"
+    :has-more="!!state.paginationToken"
+    :fetch-next-page="fetchNextPage"
+  >
+    <div
+      v-if="!hideLoadMore && pageSize > 0 && state.paginationToken"
+      class="flex items-center justify-center py-2 text-gray-400 text-sm hover:bg-gray-200 cursor-pointer"
+      @click="fetchNextPage"
+    >
+      {{ $t("common.load-more") }}
+    </div>
+  </slot>
+</template>
+
+<script lang="ts" setup>
+import { useSessionStorage } from "@vueuse/core";
+import { computed, reactive, watch } from "vue";
+import { BBSpin } from "@/bbkit";
+import { useIsLoggedIn, useRolloutStore } from "@/store";
+import type { ComposedRollout, Pagination } from "@/types";
+
+type LocalState = {
+  loading: boolean;
+  rolloutList: ComposedRollout[];
+  paginationToken: string;
+  loadingMore: boolean;
+};
+
+type SessionState = {
+  // How many times the user clicks the "load more" button.
+  page: number;
+  // Help us to check if the session is outdated.
+  updatedTs: number;
+};
+
+const MAX_PAGE_SIZE = 1000;
+const SESSION_LIFE = 1 * 60 * 1000; // 1 minute
+
+const props = defineProps({
+  // A unique key to identify the session state.
+  sessionKey: {
+    type: String,
+    required: true,
+  },
+  project: {
+    type: String,
+    required: true,
+  },
+  pageSize: {
+    type: Number,
+    default: 50,
+  },
+  hideLoadMore: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const state = reactive<LocalState>({
+  loading: false,
+  rolloutList: [],
+  paginationToken: "",
+  loadingMore: false,
+});
+
+const sessionState = useSessionStorage<SessionState>(
+  `bb.paged-rollout-data-table.${props.sessionKey}`,
+  {
+    page: 1,
+    updatedTs: 0,
+  }
+);
+
+const rolloutStore = useRolloutStore();
+const isLoggedIn = useIsLoggedIn();
+
+const limit = computed(() => {
+  if (props.pageSize <= 0) return MAX_PAGE_SIZE;
+  return props.pageSize;
+});
+
+const latestPagination = computed((): Pagination => {
+  return {
+    pageSize: props.pageSize,
+    pageToken: state.paginationToken,
+  };
+});
+
+const fetchData = (refresh = false) => {
+  if (!isLoggedIn.value) {
+    return;
+  }
+
+  state.loading = true;
+
+  const isFirstFetch = state.paginationToken === "";
+  if (!isFirstFetch) {
+    state.loadingMore = true;
+  }
+  const expectedRowCount = isFirstFetch
+    ? // Load one or more page for the first fetch to restore the session
+      limit.value * sessionState.value.page
+    : // Always load one page if NOT the first fetch
+      limit.value;
+
+  const request = rolloutStore.fetchRolloutsByProject(
+    props.project,
+    latestPagination.value
+  );
+
+  request
+    .then(({ nextPageToken, rollouts }) => {
+      if (refresh) {
+        state.rolloutList = rollouts;
+      } else {
+        state.rolloutList.push(...rollouts);
+      }
+
+      if (rollouts.length >= expectedRowCount && !isFirstFetch) {
+        // If we didn't reach the end, memorize we've clicked the "load more" button.
+        sessionState.value.page++;
+      }
+
+      sessionState.value.updatedTs = Date.now();
+      state.paginationToken = nextPageToken;
+    })
+    .finally(() => {
+      state.loading = false;
+      state.loadingMore = false;
+    });
+};
+
+const resetSession = () => {
+  sessionState.value = {
+    page: 1,
+    updatedTs: 0,
+  };
+};
+
+const fetchNextPage = () => {
+  fetchData(false);
+};
+
+if (Date.now() - sessionState.value.updatedTs > SESSION_LIFE) {
+  // Reset session if it's outdated.
+  resetSession();
+}
+fetchData(true);
+
+watch(isLoggedIn, () => {
+  // Reset session when logged out.
+  if (!isLoggedIn.value) {
+    resetSession();
+  }
+});
+</script>

--- a/frontend/src/components/Rollout/RolloutDataTable.vue
+++ b/frontend/src/components/Rollout/RolloutDataTable.vue
@@ -1,0 +1,96 @@
+<template>
+  <NDataTable
+    size="small"
+    :columns="columnList"
+    :data="sortedRolloutList"
+    :striped="true"
+    :bordered="bordered"
+    :loading="loading"
+    :row-key="(rollout: ComposedRollout) => rollout.name"
+    :row-props="rowProps"
+  />
+</template>
+
+<script lang="tsx" setup>
+import type { DataTableColumn } from "naive-ui";
+import { NDataTable } from "naive-ui";
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import { BBAvatar } from "@/bbkit";
+import { getTimeForPbTimestamp, type ComposedRollout } from "@/types";
+import { humanizeTs } from "@/utils";
+
+const props = withDefaults(
+  defineProps<{
+    rolloutList: ComposedRollout[];
+    bordered?: boolean;
+    loading?: boolean;
+    showSelection?: boolean;
+  }>(),
+  {
+    loading: true,
+    bordered: false,
+    showSelection: false,
+  }
+);
+
+const { t } = useI18n();
+const router = useRouter();
+
+const columnList = computed(
+  (): (DataTableColumn<ComposedRollout> & { hide?: boolean })[] => {
+    const columns: (DataTableColumn<ComposedRollout> & { hide?: boolean })[] = [
+      {
+        key: "title",
+        width: 160,
+        title: t("common.title"),
+        render: (rollout) => {
+          return (
+            <p class="inline-flex w-full">
+              <span class="shrink truncate">{rollout.title}</span>
+            </p>
+          );
+        },
+      },
+      {
+        key: "creator",
+        title: t("common.creator"),
+        width: 128,
+        render: (rollout) => (
+          <div class="flex flex-row items-center overflow-hidden gap-x-2">
+            <BBAvatar size="SMALL" username={rollout.creatorEntity.title} />
+            <span class="truncate">{rollout.creatorEntity.title}</span>
+          </div>
+        ),
+      },
+      {
+        key: "createTime",
+        title: t("common.created-at"),
+        width: 128,
+        render: (rollout) =>
+          humanizeTs(getTimeForPbTimestamp(rollout.createTime, 0) / 1000),
+      },
+    ];
+    return columns.filter((column) => !column.hide);
+  }
+);
+
+const sortedRolloutList = computed(() => {
+  return props.rolloutList;
+});
+
+const rowProps = (rollout: ComposedRollout) => {
+  return {
+    style: "cursor: pointer;",
+    onClick: (e: MouseEvent) => {
+      const url = `/${rollout.name}`;
+      if (e.ctrlKey || e.metaKey) {
+        window.open(url, "_blank");
+      } else {
+        router.push(url);
+      }
+    },
+  };
+};
+</script>

--- a/frontend/src/components/Rollout/RolloutDetail/BasicInfo.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/BasicInfo.vue
@@ -1,0 +1,25 @@
+<template>
+  <h2 class="text-2xl">{{ rollout.title }}</h2>
+  <div class="flex flex-row items-center gap-4">
+    <div class="flex items-center gap-1">
+      <BBAvatar size="MINI" :username="rollout.creatorEntity.title" />
+      <span class="textlabel truncate">{{ rollout.creatorEntity.title }}</span>
+    </div>
+    <div class="flex items-center gap-1">
+      <Clock4Icon class="w-4 h-auto textinfolabel" />
+      <span class="textlabel">{{
+        humanizeDate(getDateForPbTimestamp(rollout.createTime))
+      }}</span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Clock4Icon } from "lucide-vue-next";
+import { BBAvatar } from "@/bbkit";
+import { getDateForPbTimestamp } from "@/types";
+import { humanizeDate } from "@/utils";
+import { useRolloutDetailContext } from "./context";
+
+const { rollout } = useRolloutDetailContext();
+</script>

--- a/frontend/src/components/Rollout/RolloutDetail/Panels/Overview.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/Panels/Overview.vue
@@ -1,0 +1,6 @@
+<template>
+  <!-- TODO: implement me please -->
+  <div>Overview placeholder</div>
+</template>
+
+<script lang="ts" setup></script>

--- a/frontend/src/components/Rollout/RolloutDetail/Panels/Stages.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/Panels/Stages.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="w-full flex grow overflow-auto bg-zinc-100 p-6 rounded-md">
+    <div class="relative w-auto flex flex-row items-start justify-start gap-6">
+      <div class="absolute top-5 border-2 w-full"></div>
+      <div
+        v-for="stage in stages"
+        :key="stage.name"
+        class="!w-80 bg-white z-[1] rounded-lg p-1 hover:shadow"
+        content-class="flex flex-col gap-2"
+      >
+        <p class="textlabel px-2 mt-2 mb-1">{{ stage.title }}</p>
+        <div
+          v-for="task in stage.tasks"
+          :key="task.name"
+          class="w-full flex flex-row items-center justify-start truncate gap-2 px-2 py-1 rounded-md cursor-pointer hover:bg-zinc-50"
+          @click="onTaskClick(task)"
+        >
+          <TaskStatus :status="task.status" />
+          <div class="truncate">
+            <div class="w-auto flex flex-row items-center text-sm truncate">
+              <InstanceV1EngineIcon
+                class="inline-block mr-1"
+                :instance="
+                  databaseForTask(rollout.projectEntity, task).instanceResource
+                "
+              />
+              <span class="truncate">
+                {{
+                  databaseForTask(rollout.projectEntity, task).instanceResource
+                    .title
+                }}
+              </span>
+              <ChevronRightIcon class="inline opacity-60 w-4 shrink-0" />
+              <span class="truncate">
+                {{ databaseForTask(rollout.projectEntity, task).databaseName }}
+              </span>
+            </div>
+            <p class="space-x-1 mt-0.5 leading-4">
+              <NTag round size="tiny">{{ semanticTaskType(task.type) }}</NTag>
+              <NTag
+                v-if="extractSchemaVersionFromTask(task)"
+                round
+                size="tiny"
+                >{{ extractSchemaVersionFromTask(task) }}</NTag
+              >
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ChevronRightIcon } from "lucide-vue-next";
+import { NTag } from "naive-ui";
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import { semanticTaskType } from "@/components/IssueV1";
+import { InstanceV1EngineIcon } from "@/components/v2";
+import { type Task } from "@/types/proto/v1/rollout_service";
+import { extractSchemaVersionFromTask } from "@/utils";
+import { useRolloutDetailContext } from "../context";
+import { databaseForTask } from "../utils";
+import TaskStatus from "./kits/TaskStatus.vue";
+
+const router = useRouter();
+const { rollout } = useRolloutDetailContext();
+
+const stages = computed(() => rollout.value.stages);
+
+const onTaskClick = (task: Task) => {
+  router.push(`/${task.name}`);
+};
+</script>

--- a/frontend/src/components/Rollout/RolloutDetail/Panels/Tasks.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/Panels/Tasks.vue
@@ -1,0 +1,6 @@
+<template>
+  <!-- TODO: implement me please -->
+  <div>Tasks placeholder</div>
+</template>
+
+<script lang="ts" setup></script>

--- a/frontend/src/components/Rollout/RolloutDetail/Panels/kits/TaskStatus.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/Panels/kits/TaskStatus.vue
@@ -1,0 +1,118 @@
+<template>
+  <NTooltip>
+    <template #trigger>
+      <div
+        :class="
+          twMerge(
+            'relative flex flex-shrink-0 items-center justify-center rounded-full select-none overflow-hidden',
+            classes
+          )
+        "
+      >
+        <template
+          v-if="
+            status === Task_Status.NOT_STARTED ||
+            status === Task_Status.STATUS_UNSPECIFIED
+          "
+        >
+          <span
+            class="h-1/2 w-1/2 bg-control rounded-full"
+            aria-hidden="true"
+          />
+        </template>
+        <template v-else-if="status === Task_Status.PENDING">
+          <PauseIcon class="w-3/4 h-auto" />
+        </template>
+        <template v-else-if="status === Task_Status.RUNNING">
+          <div class="flex h-1/2 w-1/2 relative overflow-visible">
+            <span
+              class="w-full h-full rounded-full z-0 absolute animate-ping-slow"
+              style="background-color: rgba(37, 99, 235, 0.5); /* bg-info/50 */"
+              aria-hidden="true"
+            />
+            <span
+              class="w-full h-full rounded-full z-[1] bg-info"
+              aria-hidden="true"
+            />
+          </div>
+        </template>
+        <template v-else-if="status === Task_Status.SKIPPED">
+          <FastForwardIcon class="w-3/4 h-auto" />
+        </template>
+        <template v-else-if="status === Task_Status.DONE">
+          <heroicons-solid:check class="w-3/4 h-3/4" />
+        </template>
+        <template v-else-if="status === Task_Status.FAILED">
+          <span
+            class="rounded-full text-center font-medium text-base"
+            aria-hidden="true"
+            >!</span
+          >
+        </template>
+        <template v-else-if="status === Task_Status.CANCELED">
+          <heroicons-solid:minus-sm
+            class="w-full h-full rounded-full select-none bg-white border-2 border-gray-400 text-gray-400"
+          />
+        </template>
+      </div>
+    </template>
+    {{ status }}
+  </NTooltip>
+</template>
+
+<script lang="ts" setup>
+import { FastForwardIcon, PauseIcon } from "lucide-vue-next";
+import { NTooltip } from "naive-ui";
+import { twMerge } from "tailwind-merge";
+import { computed } from "vue";
+import { Task_Status } from "@/types/proto/v1/rollout_service";
+
+const props = defineProps<{
+  status: Task_Status;
+  size?: "small" | "medium" | "large";
+}>();
+
+const classes = computed((): string => {
+  let sizeClass = "";
+  switch (props.size) {
+    case "small":
+      sizeClass = "w-5 h-5";
+      break;
+    case "medium":
+      sizeClass = "w-6 h-6";
+      break;
+    case "large":
+      sizeClass = "w-7 h-7";
+      break;
+    default:
+      sizeClass = "w-6 h-6"; // default to medium if size is not specified
+  }
+
+  let statusClass = "";
+  switch (props.status) {
+    case Task_Status.NOT_STARTED:
+    case Task_Status.STATUS_UNSPECIFIED:
+      statusClass = "bg-white border-2 border-control";
+      break;
+    case Task_Status.PENDING:
+      statusClass = "bg-white border-2 border-yellow-600 text-yellow-600";
+      break;
+    case Task_Status.RUNNING:
+      statusClass = "bg-white border-2 border-info text-info";
+      break;
+    case Task_Status.SKIPPED:
+      statusClass = "bg-white border-2 text-gray-500";
+      break;
+    case Task_Status.DONE:
+      statusClass = "bg-success text-white";
+      break;
+    case Task_Status.FAILED:
+      statusClass = "bg-error text-white";
+      break;
+    default:
+      statusClass = "";
+  }
+
+  return `${sizeClass} ${statusClass}`;
+});
+</script>

--- a/frontend/src/components/Rollout/RolloutDetail/RolloutDetail.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/RolloutDetail.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="w-full min-h-full flex flex-col items-start gap-y-4 relative">
+    <BasicInfo />
+    <NTabs
+      v-model:value="state.selectedTab"
+      class="w-full grow"
+      type="line"
+      pane-class="flex w-full grow"
+      pane-wrapper-class="flex w-full grow"
+    >
+      <NTabPane name="overview" :tab="$t('common.overview')">
+        <Overview />
+      </NTabPane>
+      <NTabPane name="stages" :tab="$t('common.stages')">
+        <Stages />
+      </NTabPane>
+      <NTabPane name="tasks" :tab="$t('common.tasks')">
+        <Tasks />
+      </NTabPane>
+    </NTabs>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { NTabs, NTabPane } from "naive-ui";
+import { computed, reactive, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { PROJECT_V1_ROUTE_ROLLOUT_DETAIL } from "@/router/dashboard/projectV1";
+import BasicInfo from "./BasicInfo.vue";
+import Overview from "./Panels/Overview.vue";
+import Stages from "./Panels/Stages.vue";
+import Tasks from "./Panels/Tasks.vue";
+import { useRolloutDetailContext } from "./context";
+
+const hashList = ["overview", "stages", "tasks"] as const;
+
+interface LocalState {
+  selectedTab?: "overview" | "stages" | "tasks";
+}
+
+const route = useRoute();
+const router = useRouter();
+const { rollout } = useRolloutDetailContext();
+const state = reactive<LocalState>({});
+
+watch(
+  () => route.hash,
+  () => {
+    const hash = route.hash.replace(/^#?/g, "") as (typeof hashList)[number];
+    if (hashList.includes(hash)) {
+      state.selectedTab = hash;
+    }
+  },
+  { immediate: true }
+);
+
+watch(
+  () => state.selectedTab,
+  (tab) => {
+    router.replace({
+      hash: `#${tab}`,
+      query: route.query,
+    });
+  }
+);
+
+const documentTitle = computed(() => {
+  if (route.name !== PROJECT_V1_ROUTE_ROLLOUT_DETAIL) {
+    return undefined;
+  }
+  return rollout.value.title;
+});
+
+watch(
+  documentTitle,
+  (title) => {
+    if (title) {
+      document.title = title;
+    }
+  },
+  { immediate: true }
+);
+</script>

--- a/frontend/src/components/Rollout/RolloutDetail/RolloutDetailLayout.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/RolloutDetailLayout.vue
@@ -1,0 +1,22 @@
+<template>
+  <router-view v-bind="$attrs" />
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import { provideRolloutDetailContext } from "./context";
+import { usePollRollout } from "./poll";
+
+const route = useRoute();
+
+const rolloutName = computed(
+  () =>
+    `${projectNamePrefix}${route.params.projectId}/rollouts/${route.params.rolloutId}`
+);
+
+provideRolloutDetailContext(rolloutName.value);
+
+usePollRollout(rolloutName.value);
+</script>

--- a/frontend/src/components/Rollout/RolloutDetail/TaskDetail/TaskDetail.vue
+++ b/frontend/src/components/Rollout/RolloutDetail/TaskDetail/TaskDetail.vue
@@ -1,0 +1,151 @@
+<template>
+  <NBreadcrumb class="mb-4">
+    <NBreadcrumbItem @click="router.push(`/${rollout.name}`)">
+      {{ rollout.title }}
+    </NBreadcrumbItem>
+    <NBreadcrumbItem @click="router.push(`/${rollout.name}#stages`)">
+      {{ $t("common.tasks") }}
+    </NBreadcrumbItem>
+    <NBreadcrumbItem :clickable="false">
+      {{ taskId }}
+    </NBreadcrumbItem>
+  </NBreadcrumb>
+  <div v-if="task" class="w-full flex flex-col">
+    <div class="w-full flex flex-row items-center gap-2">
+      <TaskStatus :size="'large'" :status="task.status" />
+      <p class="text-2xl flex flex-row items-center">
+        <InstanceV1EngineIcon
+          class="inline-block mr-1 w-6"
+          :instance="
+            databaseForTask(rollout.projectEntity, task).instanceResource
+          "
+        />
+        <span class="truncate flex items-center">
+          {{
+            databaseForTask(rollout.projectEntity, task).instanceResource.title
+          }}
+          <ChevronRightIcon class="inline opacity-60 mx-0.5 w-5" />
+          {{ databaseForTask(rollout.projectEntity, task).databaseName }}
+        </span>
+      </p>
+    </div>
+    <p class="mt-2 text-sm text-gray-500">
+      {{ task.title }}
+    </p>
+    <div class="mt-2 space-x-2">
+      <NTag round>{{ semanticTaskType(task.type) }}</NTag>
+      <NTag v-if="extractSchemaVersionFromTask(task)" round>{{
+        extractSchemaVersionFromTask(task)
+      }}</NTag>
+    </div>
+    <NDivider />
+    <p class="w-auto flex items-center text-base text-main mb-2">
+      {{ $t("common.statement") }}
+      <button
+        tabindex="-1"
+        class="btn-icon ml-1"
+        @click.prevent="copyStatement"
+      >
+        <ClipboardIcon class="w-4 h-4" />
+      </button>
+    </p>
+    <MonacoEditor
+      class="h-auto max-h-[480px] min-h-[120px] border rounded-[3px] text-sm overflow-clip relative"
+      :content="statement"
+      :readonly="true"
+      :auto-height="{ min: 256, max: 512 }"
+    />
+    <NDivider />
+    <div v-if="latestTaskRun">
+      <p class="w-auto flex items-center text-base text-main mb-2">
+        {{ $t("issue.task-run.logs") }}
+      </p>
+      <TaskRunLogTable
+        :task-run="latestTaskRun"
+        :sheet="sheetStore.getSheetByName(sheetNameOfTaskV1(task))"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { head, isEqual } from "lodash-es";
+import { ClipboardIcon, ChevronRightIcon } from "lucide-vue-next";
+import { NBreadcrumb, NBreadcrumbItem, NDivider, NTag } from "naive-ui";
+import { computed, ref, watchEffect } from "vue";
+import { useRouter } from "vue-router";
+import { semanticTaskType } from "@/components/IssueV1";
+import TaskRunLogTable from "@/components/IssueV1/components/TaskRunSection/TaskRunLogTable/TaskRunLogTable.vue";
+import { MonacoEditor } from "@/components/MonacoEditor";
+import { InstanceV1EngineIcon } from "@/components/v2";
+import { rolloutServiceClient } from "@/grpcweb";
+import { pushNotification, useSheetV1Store } from "@/store";
+import { unknownTask } from "@/types";
+import type { TaskRun } from "@/types/proto/v1/rollout_service";
+import {
+  extractSchemaVersionFromTask,
+  getSheetStatement,
+  isValidTaskName,
+  sheetNameOfTaskV1,
+  toClipboard,
+} from "@/utils";
+import TaskStatus from "../Panels/kits/TaskStatus.vue";
+import { useRolloutDetailContext } from "../context";
+import { databaseForTask } from "../utils";
+
+const props = defineProps<{
+  stageId: string;
+  taskId: string;
+}>();
+
+const router = useRouter();
+const { rollout } = useRolloutDetailContext();
+const sheetStore = useSheetV1Store();
+const latestTaskRun = ref<TaskRun | undefined>(undefined);
+
+const task = computed(() => {
+  return (
+    rollout.value.stages
+      .flatMap((stage) => stage.tasks)
+      .find((task) => task.name.endsWith(`/${props.taskId}`)) || unknownTask()
+  );
+});
+
+const statement = computed(() => {
+  const sheet = sheetStore.getSheetByName(sheetNameOfTaskV1(task.value));
+  if (sheet) {
+    return getSheetStatement(sheet);
+  }
+  return "";
+});
+
+watchEffect(async () => {
+  if (!isValidTaskName(task.value.name)) {
+    return;
+  }
+
+  // Prepare the sheet for the task.
+  const sheet = sheetNameOfTaskV1(task.value);
+  if (sheet) {
+    await sheetStore.getOrFetchSheetByName(sheet);
+  }
+
+  // Prepare the latest task run logs.
+  const { taskRuns } = await rolloutServiceClient.listTaskRuns({
+    parent: task.value.name,
+  });
+  if (!isEqual(latestTaskRun.value, head(taskRuns))) {
+    latestTaskRun.value = head(taskRuns);
+  }
+});
+
+const copyStatement = async () => {
+  toClipboard(statement.value).then(() => {
+    pushNotification({
+      module: "bytebase",
+      style: "SUCCESS",
+      title: `Statement copied to clipboard.`,
+    });
+  });
+};
+</script>

--- a/frontend/src/components/Rollout/RolloutDetail/TaskDetail/index.ts
+++ b/frontend/src/components/Rollout/RolloutDetail/TaskDetail/index.ts
@@ -1,0 +1,3 @@
+import TaskDetail from "./TaskDetail.vue";
+
+export default TaskDetail;

--- a/frontend/src/components/Rollout/RolloutDetail/context.ts
+++ b/frontend/src/components/Rollout/RolloutDetail/context.ts
@@ -1,0 +1,51 @@
+import type { ComputedRef, InjectionKey, Ref } from "vue";
+import { computed, inject, provide, watchEffect } from "vue";
+import { useRoute } from "vue-router";
+import { useProjectV1Store, useRolloutStore } from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import type { ComposedProject, ComposedRollout } from "@/types";
+import { unknownProject, unknownRollout } from "@/types";
+
+export type RolloutDetailContext = {
+  rollout: Ref<ComposedRollout>;
+  project: ComputedRef<ComposedProject>;
+};
+
+export const KEY = Symbol(
+  "bb.rollout.detail"
+) as InjectionKey<RolloutDetailContext>;
+
+export const useRolloutDetailContext = () => {
+  return inject(KEY)!;
+};
+
+export const provideRolloutDetailContext = (rolloutName: string) => {
+  const route = useRoute();
+  const projectV1Store = useProjectV1Store();
+  const rolloutStore = useRolloutStore();
+
+  const project = computed(() => {
+    const projectId = route.params.projectId as string;
+    if (!projectId) {
+      return unknownProject();
+    }
+    return projectV1Store.getProjectByName(`${projectNamePrefix}${projectId}`);
+  });
+
+  watchEffect(async () => {
+    await rolloutStore.fetchRolloutByName(rolloutName);
+  });
+
+  const rollout = computed(() => {
+    return rolloutStore.getRolloutByName(rolloutName) ?? unknownRollout();
+  });
+
+  const context: RolloutDetailContext = {
+    rollout,
+    project,
+  };
+
+  provide(KEY, context);
+
+  return context;
+};

--- a/frontend/src/components/Rollout/RolloutDetail/index.ts
+++ b/frontend/src/components/Rollout/RolloutDetail/index.ts
@@ -1,0 +1,3 @@
+import RolloutDetail from "./RolloutDetail.vue";
+
+export default RolloutDetail;

--- a/frontend/src/components/Rollout/RolloutDetail/poll.ts
+++ b/frontend/src/components/Rollout/RolloutDetail/poll.ts
@@ -1,0 +1,21 @@
+import { useProgressivePoll } from "@/composables/useProgressivePoll";
+import { useRolloutStore } from "@/store";
+
+export const usePollRollout = (rolloutName: string) => {
+  const rolloutStore = useRolloutStore();
+
+  const refreshRollout = async () => {
+    await rolloutStore.fetchRolloutByName(rolloutName);
+  };
+
+  const poller = useProgressivePoll(refreshRollout, {
+    interval: {
+      min: 500,
+      max: 10000,
+      growth: 2,
+      jitter: 500,
+    },
+  });
+
+  poller.start();
+};

--- a/frontend/src/components/Rollout/RolloutDetail/utils.ts
+++ b/frontend/src/components/Rollout/RolloutDetail/utils.ts
@@ -1,0 +1,54 @@
+import { extractCoreDatabaseInfoFromDatabaseCreateTask } from "@/components/IssueV1";
+import {
+  composeInstanceResourceForDatabase,
+  useDatabaseV1Store,
+  useEnvironmentV1Store,
+} from "@/store";
+import {
+  isValidDatabaseName,
+  unknownDatabase,
+  unknownEnvironment,
+  type ComposedProject,
+} from "@/types";
+import { State } from "@/types/proto/v1/common";
+import { Task_Type, type Task } from "@/types/proto/v1/rollout_service";
+import { extractDatabaseResourceName } from "@/utils";
+
+export const databaseForTask = (project: ComposedProject, task: Task) => {
+  if (task.type === Task_Type.DATABASE_CREATE) {
+    // The database is not created yet.
+    // extract database info from the task's and payload's properties.
+    return extractCoreDatabaseInfoFromDatabaseCreateTask(project, task);
+  } else {
+    if (
+      task.databaseDataUpdate ||
+      task.databaseSchemaUpdate ||
+      task.databaseDataExport ||
+      task.type === Task_Type.DATABASE_SCHEMA_UPDATE_GHOST_CUTOVER ||
+      task.type === Task_Type.DATABASE_SCHEMA_BASELINE
+    ) {
+      const db = useDatabaseV1Store().getDatabaseByName(task.target);
+      if (!isValidDatabaseName(db.name)) {
+        // Database not found, it's probably NOT_FOUND (maybe dropped actually)
+        // Mock a database using all known resources
+        db.project = project.name;
+        db.projectEntity = project;
+
+        db.name = task.target;
+        const { instance, databaseName } = extractDatabaseResourceName(db.name);
+        db.databaseName = databaseName;
+        db.instance = instance;
+        const ir = composeInstanceResourceForDatabase(instance, db);
+        db.instanceResource = ir;
+        db.environment = ir.environment;
+        db.effectiveEnvironment = ir.environment;
+        db.effectiveEnvironmentEntity =
+          useEnvironmentV1Store().getEnvironmentByName(ir.environment) ??
+          unknownEnvironment();
+        db.syncState = State.DELETED;
+      }
+      return db;
+    }
+  }
+  return unknownDatabase();
+};

--- a/frontend/src/components/v2/Model/Instance/InstanceV1EngineIcon.vue
+++ b/frontend/src/components/v2/Model/Instance/InstanceV1EngineIcon.vue
@@ -2,7 +2,7 @@
   <NTooltip :disabled="!tooltip || !instance.engineVersion">
     <template #trigger>
       <div class="relative w-4 shrink-0" v-bind="$attrs">
-        <EngineIcon :engine="instance.engine" />
+        <EngineIcon class="w-full h-auto" :engine="instance.engine" />
         <div
           v-if="showStatus"
           class="bg-green-400 border-surface-high rounded-full absolute border-2"

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -97,6 +97,7 @@
     "snapshot": "Snapshot",
     "status": "Status",
     "stage": "Stage",
+    "stages": "Stages",
     "task": "Task",
     "tasks": "Tasks",
     "blocking-task": "Blocking task",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -97,6 +97,7 @@
     "snapshot": "Instantánea",
     "status": "Estado",
     "stage": "Etapa",
+    "stages": "Etapas",
     "task": "Tarea",
     "tasks": "Tareas",
     "blocking-task": "Tarea de bloqueo",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -97,6 +97,7 @@
     "snapshot": "スナップショット",
     "status": "州",
     "stage": "ステージ",
+    "stages": "ステージ",
     "task": "タスク",
     "tasks": "タスク",
     "blocking-task": "タスクをブロック中",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -97,6 +97,7 @@
     "snapshot": "快照",
     "status": "状态",
     "stage": "阶段",
+    "stages": "阶段",
     "task": "任务",
     "tasks": "任务",
     "blocking-task": "阻塞任务",

--- a/frontend/src/router/dashboard/projectV1.ts
+++ b/frontend/src/router/dashboard/projectV1.ts
@@ -41,6 +41,9 @@ export const PROJECT_V1_ROUTE_REVIEW_CENTER = `${PROJECT_V1_ROUTE_DASHBOARD}.rev
 export const PROJECT_V1_ROUTE_RELEASES = `${PROJECT_V1_ROUTE_DASHBOARD}.release`;
 export const PROJECT_V1_ROUTE_RELEASE_CREATE = `${PROJECT_V1_ROUTE_DASHBOARD}.release.create`;
 export const PROJECT_V1_ROUTE_RELEASE_DETAIL = `${PROJECT_V1_ROUTE_DASHBOARD}.release.detail`;
+export const PROJECT_V1_ROUTE_ROLLOUTS = `${PROJECT_V1_ROUTE_DASHBOARD}.rollout`;
+export const PROJECT_V1_ROUTE_ROLLOUT_DETAIL = `${PROJECT_V1_ROUTE_ROLLOUTS}.detail`;
+export const PROJECT_V1_ROUTE_ROLLOUT_DETAIL_TASK_DETAIL = `${PROJECT_V1_ROUTE_ROLLOUT_DETAIL}.task.detail`;
 
 const projectV1Routes: RouteRecordRaw[] = [
   {
@@ -590,6 +593,56 @@ const projectV1Routes: RouteRecordRaw[] = [
             },
             component: () => import("@/components/Release/ReleaseDetail/"),
             props: true,
+          },
+        ],
+      },
+      {
+        path: "rollouts",
+        meta: {
+          overrideTitle: true,
+        },
+        props: true,
+        children: [
+          {
+            path: "",
+            name: PROJECT_V1_ROUTE_ROLLOUTS,
+            meta: {
+              overrideTitle: true,
+              requiredProjectPermissionList: () => ["bb.projects.get"],
+            },
+            component: () =>
+              import("@/views/project/ProjectRolloutDashboard.vue"),
+            props: true,
+          },
+          {
+            path: ":rolloutId",
+            component: () =>
+              import(
+                "@/components/Rollout/RolloutDetail/RolloutDetailLayout.vue"
+              ),
+            props: true,
+            children: [
+              {
+                path: "",
+                name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
+                meta: {
+                  overrideTitle: true,
+                  requiredProjectPermissionList: () => ["bb.projects.get"],
+                },
+                component: () => import("@/components/Rollout/RolloutDetail/"),
+                props: true,
+              },
+              {
+                path: "stages/:stageId/tasks/:taskId",
+                name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL_TASK_DETAIL,
+                meta: {
+                  overrideTitle: true,
+                },
+                component: () =>
+                  import("@/components/Rollout/RolloutDetail/TaskDetail/"),
+                props: true,
+              },
+            ],
           },
         ],
       },

--- a/frontend/src/store/modules/index.ts
+++ b/frontend/src/store/modules/index.ts
@@ -19,5 +19,6 @@ export * from "./utils";
 export * from "./branch";
 export * from "./release";
 export * from "./revision";
+export * from "./rollout";
 
 export * from "./v1";

--- a/frontend/src/store/modules/rollout.ts
+++ b/frontend/src/store/modules/rollout.ts
@@ -1,0 +1,119 @@
+import { head, uniq } from "lodash-es";
+import { defineStore } from "pinia";
+import { computed, reactive, ref, unref, watch } from "vue";
+import { rolloutServiceClient } from "@/grpcweb";
+import type { MaybeRef, Pagination, ComposedRollout } from "@/types";
+import { isValidRolloutName, unknownRollout, unknownUser } from "@/types";
+import { DEFAULT_PROJECT_NAME } from "@/types";
+import type { Rollout } from "@/types/proto/v1/rollout_service";
+import { extractUserResourceName } from "@/utils";
+import { DEFAULT_PAGE_SIZE } from "./common";
+import { useUserStore } from "./user";
+import { useProjectV1Store } from "./v1";
+import { getProjectNameRolloutId, projectNamePrefix } from "./v1/common";
+
+export const useRolloutStore = defineStore("rollout", () => {
+  const rolloutMapByName = reactive(new Map<string, ComposedRollout>());
+
+  const rolloutList = computed(() => {
+    return Array.from(rolloutMapByName.values());
+  });
+
+  const fetchRolloutsByProject = async (
+    project: string,
+    pagination?: Pagination
+  ) => {
+    const resp = await rolloutServiceClient.listRollouts({
+      parent: project,
+      pageSize: pagination?.pageSize || DEFAULT_PAGE_SIZE,
+      pageToken: pagination?.pageToken,
+    });
+    const composedRolloutList = await batchComposeRollout(resp.rollouts);
+    composedRolloutList.forEach((rollout) => {
+      rolloutMapByName.set(rollout.name, rollout);
+    });
+    return {
+      rollouts: composedRolloutList,
+      nextPageToken: resp.nextPageToken,
+    };
+  };
+
+  const fetchRolloutByName = async (name: string, silent = false) => {
+    const rollout = await rolloutServiceClient.getRollout({ name }, { silent });
+    const [composedRollout] = await batchComposeRollout([rollout]);
+    rolloutMapByName.set(composedRollout.name, composedRollout);
+    return composedRollout;
+  };
+
+  const getRolloutsByProject = (project: string) => {
+    return rolloutList.value.filter((rollout) => rollout.project === project);
+  };
+
+  const getRolloutByName = (name: string) => {
+    return rolloutMapByName.get(name) ?? unknownRollout();
+  };
+
+  return {
+    rolloutList,
+    fetchRolloutsByProject,
+    fetchRolloutByName,
+    getRolloutsByProject,
+    getRolloutByName,
+  };
+});
+
+export const useRolloutByName = (name: MaybeRef<string>) => {
+  const store = useRolloutStore();
+  const ready = ref(true);
+  watch(
+    () => unref(name),
+    async (name) => {
+      if (!isValidRolloutName(name)) {
+        return;
+      }
+
+      const cached = store.getRolloutByName(name);
+      if (!isValidRolloutName(cached.name)) {
+        ready.value = false;
+        await store.fetchRolloutByName(name);
+        ready.value = true;
+      }
+    },
+    { immediate: true }
+  );
+  const rollout = computed(() => store.getRolloutByName(unref(name)));
+
+  return {
+    rollout,
+    ready,
+  };
+};
+
+export const batchComposeRollout = async (rolloutList: Rollout[]) => {
+  const userStore = useUserStore();
+  const composedRolloutList = rolloutList.map((rollout) => {
+    const composed = rollout as ComposedRollout;
+    composed.project = `${projectNamePrefix}${head(getProjectNameRolloutId(rollout.name))}`;
+    composed.creatorEntity =
+      userStore.getUserByEmail(extractUserResourceName(composed.creator)) ??
+      unknownUser();
+    return composed;
+  });
+  const distinctProjectList = uniq(
+    composedRolloutList.map((rollout) => rollout.project)
+  );
+
+  const projectV1Store = useProjectV1Store();
+  await Promise.all(
+    distinctProjectList.map((project) => {
+      if (project === DEFAULT_PROJECT_NAME) {
+        return;
+      }
+      return projectV1Store.getOrFetchProjectByName(project);
+    })
+  );
+  return composedRolloutList.map((rollout) => {
+    rollout.projectEntity = projectV1Store.getProjectByName(rollout.project);
+    return rollout;
+  });
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -31,6 +31,7 @@ export * from "./iam";
 export * from "./misc";
 export * from "./appProfile";
 export * from "./release";
+export * from "./rollout";
 
 export * from "./v1";
 export * from "./timestamp";

--- a/frontend/src/types/rollout.ts
+++ b/frontend/src/types/rollout.ts
@@ -1,61 +1,63 @@
-import { getProjectNameReleaseId } from "@/store/modules/v1/common";
+import { getProjectNameRolloutId } from "@/store/modules/v1/common";
 import { EMPTY_ID, UNKNOWN_ID } from "./const";
 import type { User } from "./proto/v1/auth_service";
-import { Release } from "./proto/v1/release_service";
+import { Rollout } from "./proto/v1/rollout_service";
 import { emptyUser, unknownUser } from "./v1";
 import {
+  EMPTY_PROJECT_NAME,
   emptyProject,
   UNKNOWN_PROJECT_NAME,
   unknownProject,
   type ComposedProject,
 } from "./v1/project";
 
-export interface ComposedRelease extends Release {
+export interface ComposedRollout extends Rollout {
   // Format: projects/{project}
   project: string;
   projectEntity: ComposedProject;
   creatorEntity: User;
 }
 
-export const UNKNOWN_RELEASE_NAME = `${UNKNOWN_PROJECT_NAME}/releases/${UNKNOWN_ID}`;
+export const EMPTY_ROLLOUT_NAME = `${EMPTY_PROJECT_NAME}/rollouts/${EMPTY_ID}`;
+export const UNKNOWN_ROLLOUT_NAME = `${UNKNOWN_PROJECT_NAME}/rollouts/${UNKNOWN_ID}`;
 
-export const emptyRelease = (): ComposedRelease => {
+export const emptyRollout = (): ComposedRollout => {
   const projectEntity = emptyProject();
-  const release = Release.fromJSON({
-    name: `${projectEntity.name}/releases/${EMPTY_ID}`,
+  const rollout = Rollout.fromJSON({
+    name: `${projectEntity.name}/rollouts/${EMPTY_ID}`,
     uid: String(EMPTY_ID),
     project: projectEntity.name,
   });
   return {
-    ...release,
+    ...rollout,
     project: projectEntity.name,
     projectEntity,
     creatorEntity: emptyUser(),
   };
 };
 
-export const unknownRelease = (): ComposedRelease => {
+export const unknownRollout = (): ComposedRollout => {
   const projectEntity = unknownProject();
-  const release = Release.fromJSON({
-    name: `${projectEntity.name}/releases/${UNKNOWN_ID}`,
+  const rollout = Rollout.fromJSON({
+    name: `${projectEntity.name}/rollouts/${UNKNOWN_ID}`,
     uid: String(UNKNOWN_ID),
     project: projectEntity.name,
   });
   return {
-    ...release,
+    ...rollout,
     project: projectEntity.name,
     projectEntity,
     creatorEntity: unknownUser(),
   };
 };
 
-export const isValidReleaseName = (name: any): name is string => {
+export const isValidRolloutName = (name: any): name is string => {
   if (typeof name !== "string") return false;
-  const [projectName, releaseName] = getProjectNameReleaseId(name);
+  const [projectName, rolloutName] = getProjectNameRolloutId(name);
   return Boolean(
     projectName &&
       projectName !== String(UNKNOWN_ID) &&
-      releaseName &&
-      releaseName !== String(UNKNOWN_ID)
+      rolloutName &&
+      rolloutName !== String(UNKNOWN_ID)
   );
 };

--- a/frontend/src/types/v1/issue/issue.ts
+++ b/frontend/src/types/v1/issue/issue.ts
@@ -6,13 +6,14 @@ import {
   unknownProject,
   emptyUser,
   unknownUser,
+  EMPTY_ROLLOUT_NAME,
+  UNKNOWN_ROLLOUT_NAME,
 } from "@/types";
 import type { Rollout } from "@/types//proto/v1/rollout_service";
 import { type User } from "@/types/proto/v1/auth_service";
 import { Issue, IssueStatus, Issue_Type } from "@/types/proto/v1/issue_service";
 import type { Plan, PlanCheckRun } from "@/types/proto/v1/plan_service";
 import { EMPTY_ID, UNKNOWN_ID } from "../../const";
-import { EMPTY_ROLLOUT_NAME, UNKNOWN_ROLLOUT_NAME } from "./rollout";
 
 // For grant request issue, it has no plan and rollout.
 // For sql review issue, it has no rollout.

--- a/frontend/src/types/v1/issue/rollout.ts
+++ b/frontend/src/types/v1/issue/rollout.ts
@@ -1,34 +1,20 @@
 import { EMPTY_ID, UNKNOWN_ID } from "@/types/const";
 import {
-  Rollout,
   Stage,
   Task,
   Task_Type,
   TaskRun,
   TaskRunLog,
 } from "@/types/proto/v1/rollout_service";
+import { EMPTY_ROLLOUT_NAME, UNKNOWN_ROLLOUT_NAME } from "@/types/rollout";
 import {
   EMPTY_ENVIRONMENT_NAME,
   UNKNOWN_ENVIRONMENT_NAME,
 } from "../environment";
 
-export const EMPTY_ROLLOUT_NAME = `projects/${EMPTY_ID}/rollouts/${EMPTY_ID}`;
-export const UNKNOWN_ROLLOUT_NAME = `projects/${UNKNOWN_ID}/rollouts/${UNKNOWN_ID}`;
-export const emptyRollout = () => {
-  return Rollout.fromJSON({
-    name: EMPTY_ROLLOUT_NAME,
-    uid: String(EMPTY_ID),
-  });
-};
-export const unknownRollout = () => {
-  return Rollout.fromJSON({
-    name: UNKNOWN_ROLLOUT_NAME,
-    uid: String(UNKNOWN_ID),
-  });
-};
-
 export const EMPTY_STAGE_NAME = `${EMPTY_ROLLOUT_NAME}/stages/${EMPTY_ID}`;
 export const UNKNOWN_STAGE_NAME = `${UNKNOWN_ROLLOUT_NAME}/stages/${UNKNOWN_ID}`;
+
 export const emptyStage = () => {
   return Stage.fromJSON({
     name: EMPTY_STAGE_NAME,

--- a/frontend/src/views/project/ProjectRolloutDashboard.vue
+++ b/frontend/src/views/project/ProjectRolloutDashboard.vue
@@ -1,0 +1,18 @@
+<template>
+  <ProjectRolloutsPanel :project="project" />
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import ProjectRolloutsPanel from "@/components/Project/ProjectRolloutsPanel.vue";
+import { useProjectByName } from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+
+const props = defineProps<{
+  projectId: string;
+}>();
+
+const { project } = useProjectByName(
+  computed(() => `${projectNamePrefix}${props.projectId}`)
+);
+</script>


### PR DESCRIPTION
Part of BYT-6405

Page routes:
* rollouts: `/projects/project_id/rollouts`
* rollout detail: `/projects/project_id/rollouts/rollout_id`
* task detail: `/projects/project_id/rollouts/rollout_id/stages/stage_id/tasks/task_id`

Rollout detail page:

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/c118e1b5-7a73-4e11-bac8-b74fa523c284">

Task detail page:

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/fab14372-6cef-45dd-a5ed-11d34a5ea941">
