### PR TITLE
chore: several fix

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -344,11 +344,11 @@ func (s *AuthService) UpdateUser(ctx context.Context, request *v1pb.UpdateUserRe
 			if err := validateEmail(request.User.Email, allowedDomains, user.Type == api.ServiceAccount); err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "invalid email %q, error: %v", request.User.Email, err)
 			}
-			user, err := s.store.GetUserByEmail(ctx, request.User.Email)
+			existedUser, err := s.store.GetUserByEmail(ctx, request.User.Email)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to find user list, error: %v", err)
 			}
-			if user != nil {
+			if existedUser != nil && existedUser.ID != user.ID {
 				return nil, status.Errorf(codes.AlreadyExists, "email %s is already existed", request.User.Email)
 			}
 			patch.Email = &request.User.Email

--- a/backend/api/v1/group_service.go
+++ b/backend/api/v1/group_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/component/iam"
+	api "github.com/bytebase/bytebase/backend/legacyapi"
 	"github.com/bytebase/bytebase/backend/store"
 	storepb "github.com/bytebase/bytebase/proto/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/proto/generated-go/v1"
@@ -236,6 +237,9 @@ func (s *GroupService) convertToGroupPayload(ctx context.Context, group *v1pb.Gr
 		}
 		if user == nil {
 			return nil, status.Errorf(codes.InvalidArgument, "cannot found member %s", member.Member)
+		}
+		if user.Type != api.EndUser {
+			return nil, status.Errorf(codes.InvalidArgument, "only allow add end users to the group")
 		}
 
 		m := &storepb.GroupMember{

--- a/frontend/src/components/Quickstart.vue
+++ b/frontend/src/components/Quickstart.vue
@@ -261,9 +261,13 @@ const introList = computed(() => {
   );
 });
 
+const isWorkspaceAdmin = computed(() =>
+  hasWorkspaceLevelRole(PresetRoleType.WORKSPACE_ADMIN)
+);
+
 const showQuickstart = computed(() => {
   // Only show quickstart for those who have workspace admin role.
-  if (!hasWorkspaceLevelRole(PresetRoleType.WORKSPACE_ADMIN)) {
+  if (!isWorkspaceAdmin.value) {
     return false;
   }
   if (!show.value) return false;
@@ -274,7 +278,7 @@ const showQuickstart = computed(() => {
 const showBookDemo = computed(() => {
   if (!show.value) return false;
   if (showQuickstart.value) return false;
-  return true;
+  return isWorkspaceAdmin.value;
 });
 
 const currentStep = computed(() => {


### PR DESCRIPTION
- Only allow adding end users to the group. Close BYT-6610
- Only throw errors when the email is duplicate and not the same user. Close BYT-6485
- Only show "book demo" banner for users with workspace admin roles. Close BYT-6522