### PR TITLE
chore: cel parse should not care about the expression order

### DIFF
--- a/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
+++ b/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
@@ -63,7 +63,7 @@ const { project } = useProjectByName(props.projectName);
 
 const parseResourceToKey = (resource: DatabaseResource): string => {
   const data = [
-    resource.databaseName,
+    resource.databaseFullName,
     "schemas",
     resource.schema,
     "tables",

--- a/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/common.ts
+++ b/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/common.ts
@@ -184,7 +184,7 @@ export const parseStringToResource = (
 ): DatabaseResource | undefined => {
   const sections = key.split("/");
   const resource: DatabaseResource = {
-    databaseName: "",
+    databaseFullName: "",
   };
 
   while (sections.length > 0) {
@@ -194,12 +194,18 @@ export const parseStringToResource = (
     switch (keyword) {
       case "instances":
         resource.instanceResourceId = data;
+        if (resource.databaseResourceId) {
+          resource.databaseFullName = `${instanceNamePrefix}${resource.instanceResourceId}/${databaseNamePrefix}${resource.databaseResourceId}`;
+        }
         break;
       case "databases":
         if (!resource.instanceResourceId) {
           return;
         }
-        resource.databaseName = `${instanceNamePrefix}${resource.instanceResourceId}/${databaseNamePrefix}${data}`;
+        resource.databaseResourceId = data;
+        if (resource.instanceResourceId) {
+          resource.databaseFullName = `${instanceNamePrefix}${resource.instanceResourceId}/${databaseNamePrefix}${resource.databaseResourceId}`;
+        }
         break;
       case "schemas":
         resource.schema = data;
@@ -215,7 +221,7 @@ export const parseStringToResource = (
     }
   }
 
-  if (!resource.databaseName) {
+  if (!resource.databaseFullName) {
     return;
   }
 

--- a/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/common.ts
+++ b/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/common.ts
@@ -182,6 +182,7 @@ export const flattenTreeOptions = (
 export const parseStringToResource = (
   key: string
 ): DatabaseResource | undefined => {
+  // The key should in instances/{instance resource id}/databases/{database resource id}/schemas/{schema}/tables/{table}/columns/{column}
   const sections = key.split("/");
   const resource: DatabaseResource = {
     databaseFullName: "",
@@ -192,21 +193,20 @@ export const parseStringToResource = (
     const data = sections.shift() || "";
 
     switch (keyword) {
-      case "instances":
+      case "instances": {
         resource.instanceResourceId = data;
         if (resource.databaseResourceId) {
           resource.databaseFullName = `${instanceNamePrefix}${resource.instanceResourceId}/${databaseNamePrefix}${resource.databaseResourceId}`;
         }
         break;
-      case "databases":
-        if (!resource.instanceResourceId) {
-          return;
-        }
+      }
+      case "databases": {
         resource.databaseResourceId = data;
         if (resource.instanceResourceId) {
           resource.databaseFullName = `${instanceNamePrefix}${resource.instanceResourceId}/${databaseNamePrefix}${resource.databaseResourceId}`;
         }
         break;
+      }
       case "schemas":
         resource.schema = data;
         break;

--- a/frontend/src/components/GrantRequestPanel/GrantRequestPanel.vue
+++ b/frontend/src/components/GrantRequestPanel/GrantRequestPanel.vue
@@ -133,7 +133,7 @@ const extractDatabaseResourcesFromProps = (): Pick<
   const { databaseResource } = props;
   if (
     !databaseResource ||
-    !isValidDatabaseName(databaseResource.databaseName)
+    !isValidDatabaseName(databaseResource.databaseFullName)
   ) {
     return {
       databaseResources: [],
@@ -180,7 +180,7 @@ const doCreateIssue = async () => {
         ? "bb.issue.grant.request.querier"
         : "bb.issue.grant.request.exporter",
       state.databaseResources?.map(
-        (databaseResource) => databaseResource.databaseName
+        (databaseResource) => databaseResource.databaseFullName
       ) ?? []
     ),
     description: state.description,

--- a/frontend/src/components/IssueV1/components/GrantRequest/DatabaseResourceTable.vue
+++ b/frontend/src/components/IssueV1/components/GrantRequest/DatabaseResourceTable.vue
@@ -52,7 +52,7 @@ const databaseStore = useDatabaseV1Store();
 
 const extractDatabaseName = (databaseResource: DatabaseResource) => {
   const database = databaseStore.getDatabaseByName(
-    String(databaseResource.databaseName)
+    databaseResource.databaseFullName
   );
   return database.databaseName;
 };
@@ -71,7 +71,7 @@ const extractTableName = (databaseResource: DatabaseResource) => {
 
 const extractComposedDatabase = (databaseResource: DatabaseResource) => {
   const database = databaseStore.getDatabaseByName(
-    String(databaseResource.databaseName)
+    databaseResource.databaseFullName
   );
   return database;
 };
@@ -81,7 +81,7 @@ watch(
   async () => {
     for (const databaseResource of props.databaseResourceList) {
       await databaseStore.getOrFetchDatabaseByName(
-        databaseResource.databaseName
+        databaseResource.databaseFullName
       );
     }
   },

--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/request/TinySQLEditorButton.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/request/TinySQLEditorButton.vue
@@ -36,7 +36,7 @@ const gotoSQLEditor = async () => {
     conditionExpression.databaseResources.length > 0
   ) {
     const databaseResourceName = conditionExpression.databaseResources[0]
-      .databaseName as string;
+      .databaseFullName as string;
     const db =
       await useDatabaseV1Store().getOrFetchDatabaseByName(databaseResourceName);
     if (isValidDatabaseName(db.name)) {

--- a/frontend/src/components/ProjectMember/AddProjectMember/AddProjectMemberForm.vue
+++ b/frontend/src/components/ProjectMember/AddProjectMember/AddProjectMemberForm.vue
@@ -225,7 +225,7 @@ const generateConditionTitle = () => {
 
 const getDatabaseResourceName = (databaseResource: DatabaseResource) => {
   const { databaseName } = extractDatabaseResourceName(
-    databaseResource.databaseName
+    databaseResource.databaseFullName
   );
   if (databaseResource.table) {
     if (databaseResource.schema) {

--- a/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
@@ -530,14 +530,14 @@ const extractDatabaseName = (databaseResource?: DatabaseResource) => {
     return "*";
   }
   const database = databaseStore.getDatabaseByName(
-    String(databaseResource.databaseName)
+    databaseResource.databaseFullName
   );
   return database.databaseName;
 };
 
 const extractDatabase = (databaseResource: DatabaseResource) => {
   const database = databaseStore.getDatabaseByName(
-    String(databaseResource.databaseName)
+    databaseResource.databaseFullName
   );
   return database;
 };

--- a/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
+++ b/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
@@ -96,9 +96,8 @@ const getDatabaseAccessResource = (access: AccessUser): VNodeChild => {
   if (!access.databaseResource) {
     return <div class="textinfo">{t("database.all")}</div>;
   }
-  // const databaseFullName
   const database = databaseStore.getDatabaseByName(
-    access.databaseResource.databaseName
+    access.databaseResource.databaseFullName
   );
 
   return (

--- a/frontend/src/components/SensitiveData/utils.ts
+++ b/frontend/src/components/SensitiveData/utils.ts
@@ -13,7 +13,7 @@ export const getMaskDataIdentifier = (maskData: MaskData): string => {
 export const convertSensitiveColumnToDatabaseResource = (
   sensitiveColumn: SensitiveColumn
 ): DatabaseResource => ({
-  databaseName: sensitiveColumn.database.name,
+  databaseFullName: sensitiveColumn.database.name,
   schema: sensitiveColumn.maskData.schema,
   table: sensitiveColumn.maskData.table,
   column: sensitiveColumn.maskData.column,
@@ -41,12 +41,12 @@ export const isCurrentColumnException = (
 export const getExpressionsForDatabaseResource = (
   databaseResource: DatabaseResource
 ): string[] => {
-  const resourceName = extractDatabaseResourceName(
-    databaseResource.databaseName
+  const { instanceName, databaseName } = extractDatabaseResourceName(
+    databaseResource.databaseFullName
   );
   const expressions = [
-    `resource.instance_id == "${resourceName.instanceName}"`,
-    `resource.database_name == "${resourceName.databaseName}"`,
+    `resource.instance_id == "${instanceName}"`,
+    `resource.database_name == "${databaseName}"`,
   ];
   if (databaseResource.schema) {
     expressions.push(`resource.schema_name == "${databaseResource.schema}"`);

--- a/frontend/src/store/modules/v1/projectIamPolicy.ts
+++ b/frontend/src/store/modules/v1/projectIamPolicy.ts
@@ -201,7 +201,7 @@ export const checkQuerierPermission = (
         conditionExpr.databaseResources.length > 0
       ) {
         for (const databaseResource of conditionExpr.databaseResources) {
-          if (databaseResource.databaseName === database.name) {
+          if (databaseResource.databaseFullName === database.name) {
             if (isUndefined(schema) && isUndefined(table)) {
               return true;
             } else {

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -1,8 +1,9 @@
 // IAM related resource definition.
 export interface DatabaseResource {
   instanceResourceId?: string;
+  databaseResourceId?: string;
   // the database full name
-  databaseName: string;
+  databaseFullName: string;
   schema?: string;
   table?: string;
   column?: string;

--- a/frontend/src/utils/issue/cel.ts
+++ b/frontend/src/utils/issue/cel.ts
@@ -271,7 +271,7 @@ export const convertFromExpr = (expr: Expr): ConditionExpression => {
               break;
             }
           }
-          conditionExpression.databaseResources!.push(databaseResource);
+          conditionExpression.databaseResources?.push(databaseResource);
         } else if (typeof right === "number") {
           // Deprecated. Use _<=_ instead.
           if (left === "request.row_limit") {

--- a/frontend/src/utils/issue/cel.ts
+++ b/frontend/src/utils/issue/cel.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, last } from "lodash-es";
+import { cloneDeep } from "lodash-es";
 import type { SimpleExpr } from "@/plugins/cel";
 import { isRawStringExpr, resolveCELExpr } from "@/plugins/cel";
 import {
@@ -43,18 +43,18 @@ export const stringifyDatabaseResources = (resources: DatabaseResource[]) => {
     if (resource.table === undefined && resource.schema === undefined) {
       // Database level
       conditionList.push({
-        database: [resource.databaseName],
+        database: [resource.databaseFullName],
       });
     } else if (resource.schema !== undefined && resource.table === undefined) {
       // Schema level
       conditionList.push({
-        database: resource.databaseName,
+        database: resource.databaseFullName,
         schema: [resource.schema],
       });
     } else if (resource.schema !== undefined && resource.table !== undefined) {
       // Table level
       conditionList.push({
-        database: resource.databaseName,
+        database: resource.databaseFullName,
         schema: resource.schema,
         table: [resource.table],
       });
@@ -199,7 +199,7 @@ export const convertFromExpr = (expr: Expr): ConditionExpression => {
         if (property === "resource.database") {
           for (const value of values) {
             const databaseResource: DatabaseResource = {
-              databaseName: value as string,
+              databaseFullName: value as string,
             };
             conditionExpression.databaseResources!.push(databaseResource);
           }
@@ -231,51 +231,47 @@ export const convertFromExpr = (expr: Expr): ConditionExpression => {
       const [left, right] = expr.args;
       if (typeof left === "string") {
         if (typeof right === "string") {
-          const databaseResource = last(conditionExpression.databaseResources);
+          let databaseResource = conditionExpression.databaseResources?.pop();
+          if (!databaseResource) {
+            databaseResource = {
+              databaseFullName: "",
+            };
+          }
           switch (left) {
             case "resource.instance_id": {
-              const databaseResource: DatabaseResource = {
-                instanceResourceId: right,
-                databaseName: "",
-              };
-              conditionExpression.databaseResources!.push(databaseResource);
+              databaseResource.instanceResourceId = right;
+              if (databaseResource.databaseResourceId) {
+                databaseResource.databaseFullName = `${instanceNamePrefix}${databaseResource.instanceResourceId}/${databaseNamePrefix}${databaseResource.databaseResourceId}`;
+              }
               break;
             }
             case "resource.database_name": {
-              if (!databaseResource?.instanceResourceId) {
-                return;
+              databaseResource.databaseResourceId = right;
+              if (databaseResource.instanceResourceId) {
+                databaseResource.databaseFullName = `${instanceNamePrefix}${databaseResource.instanceResourceId}/${databaseNamePrefix}${databaseResource.databaseResourceId}`;
               }
-              databaseResource.databaseName = `${instanceNamePrefix}${databaseResource.instanceResourceId}/${databaseNamePrefix}${right}`;
               break;
             }
             case "resource.database": {
-              const databaseResource: DatabaseResource = {
-                databaseName: right,
-              };
-              conditionExpression.databaseResources!.push(databaseResource);
+              databaseResource.databaseFullName = right;
               break;
             }
             case "resource.schema":
             case "resource.schema_name": {
-              if (databaseResource) {
-                databaseResource.schema = right;
-              }
+              databaseResource.schema = right;
               break;
             }
             case "resource.table":
             case "resource.table_name": {
-              if (databaseResource) {
-                databaseResource.table = right;
-              }
+              databaseResource.table = right;
               break;
             }
             case "resource.column_name": {
-              if (databaseResource) {
-                databaseResource.column = right;
-              }
+              databaseResource.column = right;
               break;
             }
           }
+          conditionExpression.databaseResources!.push(databaseResource);
         } else if (typeof right === "number") {
           // Deprecated. Use _<=_ instead.
           if (left === "request.row_limit") {

--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/TreeNode/DatabaseNode.vue
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/TreeNode/DatabaseNode.vue
@@ -27,7 +27,7 @@
     <RequestQueryButton
       v-if="!disallowRequestQuery && !canQuery"
       :database-resource="{
-        databaseName: database.name,
+        databaseFullName: database.name,
       }"
       :size="'tiny'"
     />

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
@@ -41,11 +41,11 @@ const showPanel = ref(false);
 const dbStore = useDatabaseV1Store();
 
 const database = computed(() =>
-  dbStore.getDatabaseByName(props.databaseResource.databaseName)
+  dbStore.getDatabaseByName(props.databaseResource.databaseFullName)
 );
 
 const available = computed(() => {
-  if (!isValidDatabaseName(props.databaseResource.databaseName)) {
+  if (!isValidDatabaseName(props.databaseResource.databaseFullName)) {
     return false;
   }
 


### PR DESCRIPTION
- Cel parser in the frontend should not care about the expression order.
- Use `databaseFullName` instead of `databaseName` to avoid misunderstanding.

Close BYT-6616