### PR TITLE
chore: fix link styles in task comment

### DIFF
--- a/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunComment.vue
+++ b/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunComment.vue
@@ -4,21 +4,22 @@
       <span>{{ comment }}</span>
     </NEllipsis>
     <template v-if="commentLink.link">
-      <template v-if="commentLink.link.startsWith('/')">
-        <router-link class="inline normal-link" :to="commentLink.link">
-          {{ commentLink.title }}
-        </router-link>
-      </template>
-      <template v-else>
-        <a
-          class="inline normal-link"
-          :href="commentLink.link"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {{ commentLink.title }}
-        </a>
-      </template>
+      <router-link
+        v-if="commentLink.link.startsWith('/')"
+        class="inline normal-link shrink-0"
+        :to="commentLink.link"
+      >
+        {{ commentLink.title }}
+      </router-link>
+      <a
+        v-else
+        class="inline normal-link shrink-0"
+        :href="commentLink.link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {{ commentLink.title }}
+      </a>
     </template>
   </div>
 </template>


### PR DESCRIPTION
### Before

<img width="747" alt="image" src="https://github.com/user-attachments/assets/befeb854-42a2-4170-a091-325a2bdd220c">

### After

<img width="818" alt="image" src="https://github.com/user-attachments/assets/b4e7cf4c-9df5-4be6-af18-76a2ceb927ac">
