### PR TITLE
chore: resource names

### DIFF
--- a/backend/api/gitops/webhook.go
+++ b/backend/api/gitops/webhook.go
@@ -462,7 +462,7 @@ func (s *Service) createIssueFromPRInfo(ctx context.Context, project *store.Proj
 			Title: prInfo.title,
 			Steps: steps,
 			VcsSource: &v1pb.Plan_VCSSource{
-				VcsConnector:   fmt.Sprintf("%s%s/%s%s", common.ProjectNamePrefix, vcsConnector.ProjectID, common.VCSConnectorPrefix, vcsConnector.ResourceID),
+				VcsConnector:   fmt.Sprintf("%s/%s%s", common.FormatProject(vcsConnector.ProjectID), common.VCSConnectorPrefix, vcsConnector.ResourceID),
 				PullRequestUrl: prInfo.url,
 				VcsType:        v1pb.VCSType(vcsProvider.Type),
 			},

--- a/backend/api/v1/branch_service.go
+++ b/backend/api/v1/branch_service.go
@@ -905,7 +905,7 @@ func (s *BranchService) convertBranchToBranch(ctx context.Context, project *stor
 	}
 
 	v1Branch := &v1pb.Branch{
-		Name:             fmt.Sprintf("%s%s/%s%v", common.ProjectNamePrefix, project.ResourceID, common.BranchPrefix, branch.ResourceID),
+		Name:             common.FormatBranchResourceID(project.ResourceID, branch.ResourceID),
 		BranchId:         branch.ResourceID,
 		Etag:             fmt.Sprintf("%d", branch.UpdatedTime.UnixMilli()),
 		ParentBranch:     baselineBranch,

--- a/backend/api/v1/database_group_service.go
+++ b/backend/api/v1/database_group_service.go
@@ -294,7 +294,7 @@ func (s *DatabaseGroupService) convertStoreToAPIDatabaseGroupFull(ctx context.Co
 
 func convertStoreToAPIDatabaseGroupBasic(databaseGroup *store.DatabaseGroupMessage, projectResourceID string) *v1pb.DatabaseGroup {
 	databaseGroupV1 := &v1pb.DatabaseGroup{
-		Name:                fmt.Sprintf("%s%s/%s%s", common.ProjectNamePrefix, projectResourceID, common.DatabaseGroupNamePrefix, databaseGroup.ResourceID),
+		Name:                fmt.Sprintf("%s/%s%s", common.FormatProject(projectResourceID), common.DatabaseGroupNamePrefix, databaseGroup.ResourceID),
 		DatabasePlaceholder: databaseGroup.Placeholder,
 		DatabaseExpr:        databaseGroup.Expression,
 	}

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -1094,10 +1094,10 @@ func (s *DatabaseService) convertToChangeHistory(ctx context.Context, h *store.I
 		projectID = p.ResourceID
 	}
 	if h.SheetID != nil && projectID != "" {
-		v1pbHistory.StatementSheet = fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, projectID, common.SheetIDPrefix, *h.SheetID)
+		v1pbHistory.StatementSheet = common.FormatSheet(projectID, *h.SheetID)
 	}
 	if h.IssueUID != nil && projectID != "" {
-		v1pbHistory.Issue = fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, projectID, common.IssueNamePrefix, *h.IssueUID)
+		v1pbHistory.Issue = common.FormatIssue(projectID, *h.IssueUID)
 	}
 	if h.Payload != nil && h.Payload.ChangedResources != nil {
 		v1pbHistory.ChangedResources = convertToChangedResources(h.Payload.ChangedResources)
@@ -1674,7 +1674,7 @@ func validSlowQueryOrderByKey(keys []orderByKey) error {
 func convertToSlowQueryLog(instanceID string, databaseName string, projectID string, log *v1pb.SlowQueryLog) *v1pb.SlowQueryLog {
 	return &v1pb.SlowQueryLog{
 		Resource:   fmt.Sprintf("%s%s/%s%s", common.InstanceNamePrefix, instanceID, common.DatabaseIDPrefix, databaseName),
-		Project:    fmt.Sprintf("%s%s", common.ProjectNamePrefix, projectID),
+		Project:    common.FormatProject(projectID),
 		Statistics: log.Statistics,
 	}
 }
@@ -1709,7 +1709,7 @@ func (s *DatabaseService) convertToDatabase(ctx context.Context, database *store
 		Name:                 common.FormatDatabase(database.InstanceID, database.DatabaseName),
 		SyncState:            syncState,
 		SuccessfulSyncTime:   timestamppb.New(time.Unix(database.SuccessfulSyncTimeTs, 0)),
-		Project:              fmt.Sprintf("%s%s", common.ProjectNamePrefix, database.ProjectID),
+		Project:              common.FormatProject(database.ProjectID),
 		Environment:          environment,
 		EffectiveEnvironment: effectiveEnvironment,
 		SchemaVersion:        database.SchemaVersion.Version,

--- a/backend/api/v1/database_service_revision.go
+++ b/backend/api/v1/database_service_revision.go
@@ -258,7 +258,7 @@ func convertToRevision(ctx context.Context, s *store.Store, parent string, revis
 			return nil, errors.Wrapf(err, "failed to get issue by rollout %q", rolloutUID)
 		}
 		if issue != nil {
-			issueName = fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, issue.Project.ResourceID, common.IssueNamePrefix, issue.UID)
+			issueName = common.FormatIssue(issue.Project.ResourceID, issue.UID)
 		}
 	}
 

--- a/backend/api/v1/issue_service_convert.go
+++ b/backend/api/v1/issue_service_convert.go
@@ -41,7 +41,7 @@ func (s *IssueService) convertToIssue(ctx context.Context, issue *store.IssueMes
 	}
 
 	issueV1 := &v1pb.Issue{
-		Name:                 fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, issue.Project.ResourceID, common.IssueNamePrefix, issue.UID),
+		Name:                 common.FormatIssue(issue.Project.ResourceID, issue.UID),
 		Title:                issue.Title,
 		Description:          issue.Description,
 		Type:                 convertToIssueType(issue.Type),
@@ -64,10 +64,10 @@ func (s *IssueService) convertToIssue(ctx context.Context, issue *store.IssueMes
 	}
 
 	if issue.PlanUID != nil {
-		issueV1.Plan = fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, issue.Project.ResourceID, common.PlanPrefix, *issue.PlanUID)
+		issueV1.Plan = common.FormatPlan(issue.Project.ResourceID, *issue.PlanUID)
 	}
 	if issue.PipelineUID != nil {
-		issueV1.Rollout = fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, issue.Project.ResourceID, common.RolloutPrefix, *issue.PipelineUID)
+		issueV1.Rollout = common.FormatRollout(issue.Project.ResourceID, *issue.PipelineUID)
 	}
 
 	for _, subscriber := range issue.Subscribers {

--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -880,7 +880,11 @@ func (s *ProjectService) TestWebhook(ctx context.Context, request *v1pb.TestWebh
 				Type:        "bb.issue.database.create",
 				Description: "This is a test issue",
 			},
-			Project: &webhookplugin.Project{Name: project.Title},
+
+			Project: &webhookplugin.Project{
+				Name:  common.FormatProject(project.ResourceID),
+				Title: project.Title,
+			},
 		},
 	)
 	if err != nil {
@@ -1255,7 +1259,7 @@ func convertToProject(projectMessage *store.ProjectMessage) *v1pb.Project {
 	var projectWebhooks []*v1pb.Webhook
 	for _, webhook := range projectMessage.Webhooks {
 		projectWebhooks = append(projectWebhooks, &v1pb.Webhook{
-			Name:              fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, projectMessage.ResourceID, common.WebhookIDPrefix, webhook.ID),
+			Name:              fmt.Sprintf("%s/%s%d", common.FormatProject(projectMessage.ResourceID), common.WebhookIDPrefix, webhook.ID),
 			Type:              convertWebhookTypeString(webhook.Type),
 			Title:             webhook.Title,
 			Url:               webhook.URL,
@@ -1274,7 +1278,7 @@ func convertToProject(projectMessage *store.ProjectMessage) *v1pb.Project {
 	}
 
 	return &v1pb.Project{
-		Name:                       fmt.Sprintf("%s%s", common.ProjectNamePrefix, projectMessage.ResourceID),
+		Name:                       common.FormatProject(projectMessage.ResourceID),
 		State:                      convertDeletedToState(projectMessage.Deleted),
 		Title:                      projectMessage.Title,
 		Key:                        projectMessage.Key,

--- a/backend/api/v1/sheet_service.go
+++ b/backend/api/v1/sheet_service.go
@@ -292,7 +292,7 @@ func (s *SheetService) convertToAPISheetMessage(ctx context.Context, sheet *stor
 	}
 
 	return &v1pb.Sheet{
-		Name:        fmt.Sprintf("%s%s/%s%d", common.ProjectNamePrefix, project.ResourceID, common.SheetIDPrefix, sheet.UID),
+		Name:        common.FormatSheet(project.ResourceID, sheet.UID),
 		Title:       sheet.Title,
 		Creator:     fmt.Sprintf("users/%s", creator.Email),
 		CreateTime:  timestamppb.New(sheet.CreatedTime),

--- a/backend/api/v1/vcs_connector_service.go
+++ b/backend/api/v1/vcs_connector_service.go
@@ -393,7 +393,7 @@ func convertStoreVCSConnector(ctx context.Context, stores *store.Store, vcsConne
 	}
 
 	v1VCSConnector := &v1pb.VCSConnector{
-		Name:          fmt.Sprintf("%s%s/%s%s", common.ProjectNamePrefix, vcsConnector.ProjectID, common.VCSConnectorPrefix, vcsConnector.ResourceID),
+		Name:          fmt.Sprintf("%s/%s%s", common.FormatProject(vcsConnector.ProjectID), common.VCSConnectorPrefix, vcsConnector.ResourceID),
 		CreateTime:    timestamppb.New(vcsConnector.CreatedTime),
 		UpdateTime:    timestamppb.New(vcsConnector.UpdatedTime),
 		Creator:       fmt.Sprintf("users/%s", creator.Email),

--- a/backend/api/v1/worksheet_service.go
+++ b/backend/api/v1/worksheet_service.go
@@ -573,7 +573,7 @@ func (s *WorksheetService) convertToAPIWorksheetMessage(ctx context.Context, wor
 	}
 	return &v1pb.Worksheet{
 		Name:        fmt.Sprintf("%s%d", common.WorksheetIDPrefix, worksheet.UID),
-		Project:     fmt.Sprintf("%s%s", common.ProjectNamePrefix, project.ResourceID),
+		Project:     common.FormatProject(project.ResourceID),
 		Database:    databaseParent,
 		Title:       worksheet.Title,
 		Creator:     fmt.Sprintf("users/%s", creator.Email),

--- a/backend/common/resource_name.go
+++ b/backend/common/resource_name.go
@@ -685,27 +685,35 @@ func FormatRole(role string) string {
 }
 
 func FormatSheet(projectID string, sheetUID int) string {
-	return fmt.Sprintf("%s%s/%s%d", ProjectNamePrefix, projectID, SheetIDPrefix, sheetUID)
+	return fmt.Sprintf("%s/%s%d", FormatProject(projectID), SheetIDPrefix, sheetUID)
 }
 
 func FormatIssue(projectID string, issueUID int) string {
-	return fmt.Sprintf("%s%s/%s%d", ProjectNamePrefix, projectID, IssueNamePrefix, issueUID)
+	return fmt.Sprintf("%s/%s%d", FormatProject(projectID), IssueNamePrefix, issueUID)
+}
+
+func FormatRollout(projectID string, pipelineUID int) string {
+	return fmt.Sprintf("%s/%s%d", FormatProject(projectID), RolloutPrefix, pipelineUID)
+}
+
+func FormatStage(projectID string, pipelineUID, stageUID int) string {
+	return fmt.Sprintf("%s/%s%d", FormatRollout(projectID, pipelineUID), StagePrefix, stageUID)
 }
 
 func FormatTask(projectID string, pipelineUID, stageUID, taskUID int) string {
-	return fmt.Sprintf("%s%s/%s%d/%s%d/%s%d", ProjectNamePrefix, projectID, RolloutPrefix, pipelineUID, StagePrefix, stageUID, TaskPrefix, taskUID)
+	return fmt.Sprintf("%s/%s%d", FormatStage(projectID, pipelineUID, stageUID), TaskPrefix, taskUID)
 }
 
 func FormatTaskRun(projectID string, pipelineUID, stageUID, taskUID, taskRunUID int) string {
-	return fmt.Sprintf("%s%s/%s%d/%s%d/%s%d/%s%d", ProjectNamePrefix, projectID, RolloutPrefix, pipelineUID, StagePrefix, stageUID, TaskPrefix, taskUID, TaskRunPrefix, taskRunUID)
+	return fmt.Sprintf("%s/%s%d", FormatTask(projectID, pipelineUID, stageUID, taskUID), TaskRunPrefix, taskRunUID)
 }
 
 func FormatBranchResourceID(projectID string, branchID string) string {
-	return fmt.Sprintf("%s%s/%s%s", ProjectNamePrefix, projectID, BranchPrefix, branchID)
+	return fmt.Sprintf("%s/%s%s", FormatProject(projectID), BranchPrefix, branchID)
 }
 
 func FormatReleaseName(projectID string, releaseUID int64) string {
-	return fmt.Sprintf("%s%s/%s%d", ProjectNamePrefix, projectID, ReleaseNamePrefix, releaseUID)
+	return fmt.Sprintf("%s/%s%d", FormatProject(projectID), ReleaseNamePrefix, releaseUID)
 }
 
 func FormatReleaseFile(release string, fileID string) string {
@@ -718,4 +726,12 @@ func FormatRevision(instanceID, databaseID string, revisionUID int64) string {
 
 func FormatChangelog(instanceID, databaseID string, changelogUID int64) string {
 	return fmt.Sprintf("%s/%s%d", FormatDatabase(instanceID, databaseID), ChangelogPrefix, changelogUID)
+}
+
+func FormatPlan(projectID string, planUID int64) string {
+	return fmt.Sprintf("%s/%s%d", FormatProject(projectID), PlanPrefix, planUID)
+}
+
+func FormatPlanCheckRun(projectID string, planUID, runUID int64) string {
+	return fmt.Sprintf("%s/%s%d", FormatPlan(projectID, planUID), PlanCheckRunPrefix, runUID)
 }

--- a/backend/component/webhook/manager.go
+++ b/backend/component/webhook/manager.go
@@ -329,8 +329,8 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, acti
 			Creator:     e.Issue.Creator,
 		},
 		Project: &webhook.Project{
-			ID:   e.Project.UID,
-			Name: e.Project.Title,
+			Name:  common.FormatProject(e.Project.ResourceID),
+			Title: e.Project.Title,
 		},
 		Stage:               nil,
 		TaskResult:          nil,

--- a/backend/plugin/webhook/webhook.go
+++ b/backend/plugin/webhook/webhook.go
@@ -106,9 +106,13 @@ func (c *Context) GetMetaList() []Meta {
 
 	if c.Project != nil {
 		m = append(m, Meta{
-			Name:  "Project",
-			Value: c.Project.Name,
-		})
+			Name:  "Project Title",
+			Value: c.Project.Title,
+		},
+			Meta{
+				Name:  "Project ID",
+				Value: c.Project.Name,
+			})
 	}
 
 	if c.Issue != nil {
@@ -167,7 +171,10 @@ func (c *Context) GetMetaListZh() []Meta {
 
 	if c.Project != nil {
 		m = append(m, Meta{
-			Name:  "项目",
+			Name:  "项目名称",
+			Value: c.Project.Title,
+		}, Meta{
+			Name:  "项目 ID",
 			Value: c.Project.Name,
 		})
 	}

--- a/backend/plugin/webhook/webhook.go
+++ b/backend/plugin/webhook/webhook.go
@@ -67,8 +67,8 @@ type TaskResult struct {
 
 // Project object of project.
 type Project struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	Name  string `json:"name"`
+	Title string `json:"title"`
 }
 
 // Context is the context of webhook.

--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -766,7 +766,7 @@ func (s *SchedulerV2) ListenTaskSkippedOrDone(ctx context.Context) {
 					p := &storepb.IssueCommentPayload{
 						Event: &storepb.IssueCommentPayload_StageEnd_{
 							StageEnd: &storepb.IssueCommentPayload_StageEnd{
-								Stage: fmt.Sprintf("%s%s/%s%d/%s%d", common.ProjectNamePrefix, issue.Project.ResourceID, common.RolloutPrefix, taskStage.PipelineID, common.StagePrefix, taskStage.ID),
+								Stage: common.FormatStage(issue.Project.ResourceID, taskStage.PipelineID, taskStage.ID),
 							},
 						},
 					}


### PR DESCRIPTION
- Use resource name formatter
- Use `projects/{project resource id}` in `webhook.project.name` instead of the project title.