### PR TITLE
chore: always show on for allow ddl/dml in the free plan

### DIFF
--- a/frontend/src/components/EnvironmentForm/AccessControlConfigure.vue
+++ b/frontend/src/components/EnvironmentForm/AccessControlConfigure.vue
@@ -82,7 +82,9 @@
     <div>
       <div class="w-full inline-flex items-center gap-x-2">
         <Switch
-          :value="!dataSourceQueryPolicy?.disallowDdl"
+          :value="
+            hasAccessControlFeature ? !dataSourceQueryPolicy?.disallowDdl : true
+          "
           :text="true"
           :disabled="!allowUpdatePolicy || !hasAccessControlFeature"
           @update:value="
@@ -97,7 +99,9 @@
       </div>
       <div class="w-full inline-flex items-center gap-x-2">
         <Switch
-          :value="!dataSourceQueryPolicy?.disallowDml"
+          :value="
+            hasAccessControlFeature ? !dataSourceQueryPolicy?.disallowDml : true
+          "
           :text="true"
           :disabled="!allowUpdatePolicy || !hasAccessControlFeature"
           @update:value="


### PR DESCRIPTION
This policy not work for the free plan, so we can always show "on" for "allow DDL/DML" (they're "on" by default)

Close BYT-6669