### PR TITLE
chore: revert spanner open db

### DIFF
--- a/backend/plugin/db/spanner/spanner.go
+++ b/backend/plugin/db/spanner/spanner.go
@@ -70,13 +70,9 @@ func (d *Driver) Open(ctx context.Context, _ storepb.Engine, config db.Connectio
 	if config.Database != "" {
 		d.databaseName = d.config.Database
 		dsn := getDSN(d.config.Host, d.config.Database)
-		client, err := spanner.NewClientWithConfig(
+		client, err := spanner.NewClient(
 			ctx,
 			dsn,
-			spanner.ClientConfig{
-				SessionPoolConfig:    spanner.DefaultSessionPoolConfig,
-				DisableNativeMetrics: true,
-			},
 			o...,
 		)
 		if err != nil {


### PR DESCRIPTION
spanner version 1.73.0 fixed the issue. remove the workaround.
https://github.com/googleapis/google-cloud-go/issues/11194#issuecomment-2520085230