### PR TITLE
chore(sql-editor): fail when no queriable data source

### DIFF
--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -317,6 +317,18 @@ const useExecuteSQL = () => {
               : undefined,
             database
           ) ?? "";
+
+        if (!dataSourceId) {
+          fail(database, {
+            advices: [],
+            allowExport: false,
+            error: "No queriable data source.",
+            results: [],
+            status: Status.NOT_FOUND,
+          });
+          continue;
+        }
+
         const resultSet = await sqlStore.query(
           {
             name: database.name,


### PR DESCRIPTION
This also works when one (or some) of the database of batch queries doesn't have a queriable data source.

This happens when the admin data source is not allowed to query, and not allowed to fallback to the admin data source either, and there is no read-only data source.

![image](https://github.com/user-attachments/assets/9048c5a5-a800-44a2-8054-ca9d9124f9fc)

![image](https://github.com/user-attachments/assets/93496d86-ed32-4b0a-97e9-f404704f08dd)

Close BYT-6756
