### PR TITLE
chore: update eslint config

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -32,7 +32,7 @@ export default [
           "src": "./src",
           "extensions": [".js", ".vue", ".ts", ".tsx"],
           "ignores": [],
-          "enableFix": false
+          "enableFix": true
         }
       ],
       "@intlify/vue-i18n/no-missing-keys": "off",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "release-docker": "export NODE_OPTIONS=--max_old_space_size=8000 && npm run copy:all && vite build --mode release",
     "release-aws": "export NODE_OPTIONS=--max_old_space_size=8000 && npm run copy:all && vite build --mode release-aws",
     "lint": "eslint --cache src",
-    "lint:fix": "eslint --cache --fix src",
     "bundle-visualize": "vite-bundle-visualizer -c vite.config.ts",
     "type-check": "export NODE_OPTIONS=--max_old_space_size=8000 && vue-tsc --build --force",
     "test": "vitest run --passWithNoTests",


### PR DESCRIPTION
1. "pnpm lint --fix" should already work because "--fix" can be appended to the "lint" command. We don't need the extra "lint:fix" command.
2. Enable "enableFix" by default.