### PR TITLE
fix(instance_service): correct project ID usage in database listing

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -466,7 +466,7 @@ func (s *InstanceService) syncSlowQueriesForProject(ctx context.Context, project
 	if project.Deleted {
 		return nil, status.Errorf(codes.NotFound, "project %q has been deleted", projectName)
 	}
-	databases, err := s.store.ListDatabases(ctx, &store.FindDatabaseMessage{InstanceID: &project.ResourceID})
+	databases, err := s.store.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &project.ResourceID})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list databases: %s", err.Error())
 	}


### PR DESCRIPTION
- Updated the database listing method to use ProjectID instead of InstanceID, ensuring accurate retrieval of databases associated with the project.
- This change improves the correctness of the slow query synchronization process by aligning the database query with the intended project context.