### PR TITLE
chore: patch pgx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -370,3 +370,5 @@ replace github.com/microsoft/go-mssqldb => github.com/bytebase/go-mssqldb v0.0.0
 replace github.com/youmark/pkcs8 => github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94
 
 replace github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos => github.com/bytebase/azure-sdk-for-go/sdk/data/azcosmos v0.0.0-20250109032656-87cf24d45689
+
+replace github.com/jackc/pgx/v5 => github.com/bytebase/pgx/v5 v5.0.0-20250125144644-a7c1db04baf8

--- a/go.sum
+++ b/go.sum
@@ -835,6 +835,8 @@ github.com/bytebase/partiql-parser v0.0.0-20240531101102-1962ff456f2c h1:TMANvCC
 github.com/bytebase/partiql-parser v0.0.0-20240531101102-1962ff456f2c/go.mod h1:hNMKtZBMCbNyhUFR47Ct9mqmpzZVtHgC0OsOIQhR27k=
 github.com/bytebase/pg_query_go2/v5 v5.0.0-20241024030058-bbe7104c5b4b h1:KCrmHI0DqsiibfZMvmcz+zjOXSjq1U+FiUDMqopPA3Q=
 github.com/bytebase/pg_query_go2/v5 v5.0.0-20241024030058-bbe7104c5b4b/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
+github.com/bytebase/pgx/v5 v5.0.0-20250125144644-a7c1db04baf8 h1:0oP4qXAUrO9zLLL5WznlxlOHrxVWi6pgNTyStLhhgJs=
+github.com/bytebase/pgx/v5 v5.0.0-20250125144644-a7c1db04baf8/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94/go.mod h1:SQliXeA7Dhkt//vS29v3zpbEwoa+zb2Cn5xj5uO4K5U=
 github.com/bytebase/plsql-parser v0.0.0-20241217100236-775726d725f9 h1:8G2E1ab2Zd6xIcWneXV6FLvuTr50Qzu5A/3KTvKrx8U=
@@ -1422,8 +1424,6 @@ github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgS
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
 github.com/jackc/pgx/v4 v4.18.3 h1:dE2/TrEsGX3RBprb3qryqSV9Y60iZN1C6i8IrmW9/BA=
 github.com/jackc/pgx/v4 v4.18.3/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
-github.com/jackc/pgx/v5 v5.7.1 h1:x7SYsPBYDkHDksogeSmZZ5xzThcTgRz++I5E+ePFUcs=
-github.com/jackc/pgx/v5 v5.7.1/go.mod h1:e7O26IywZZ+naJtWWos6i6fvWK+29etgITqrqHLfoZA=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=


### PR DESCRIPTION
The current timestamptz respects the session timezone.

https://github.com/bytebase/pgx/commit/a7c1db04baf8f53687876b15acd74b55e77174f5