### PR TITLE
fix: respect the timezone

### DIFF
--- a/frontend/src/utils/v1/sql.ts
+++ b/frontend/src/utils/v1/sql.ts
@@ -4,7 +4,10 @@ import { getDateForPbTimestamp } from "@/types";
 import { NullValue } from "@/types/proto/google/protobuf/struct";
 import type { Timestamp } from "@/types/proto/google/protobuf/timestamp";
 import { Engine } from "@/types/proto/v1/common";
-import { RowValue } from "@/types/proto/v1/sql_service";
+import {
+  RowValue,
+  type RowValue_TimestampTZ,
+} from "@/types/proto/v1/sql_service";
 import { isNullOrUndefined } from "../util";
 
 // extractSQLRowValuePlain extracts a plain value from a RowValue.
@@ -36,7 +39,7 @@ export const extractSQLRowValuePlain = (value: RowValue | undefined) => {
     return formatTimestamp(value.timestampValue);
   }
   if (value.timestampTzValue && value.timestampTzValue.timestamp) {
-    return formatTimestampWithTz(value.timestampTzValue.timestamp);
+    return formatTimestampWithTz(value.timestampTzValue);
   }
   const key = keys[0];
   return plainObject[key];
@@ -52,13 +55,19 @@ const formatTimestamp = (timestamp: Timestamp) => {
   return formattedTimestamp;
 };
 
-const formatTimestampWithTz = (timestamp: Timestamp) => {
-  const fullDayjs = dayjs(getDateForPbTimestamp(timestamp));
-  const microseconds = Math.floor(timestamp.nanos / 1000);
-  let timezoneOffset = fullDayjs.format("Z");
-  if (timezoneOffset.endsWith(":00")) {
-    timezoneOffset = timezoneOffset.slice(0, -3);
-  }
+const formatTimestampWithTz = (timestampTzValue: RowValue_TimestampTZ) => {
+  const fullDayjs = dayjs(getDateForPbTimestamp(timestampTzValue.timestamp))
+    .utc()
+    .add(timestampTzValue.offset, "seconds");
+
+  const hourOffset = Math.floor(timestampTzValue.offset / 60 / 60);
+  const timezoneOffsetPrefix = Math.abs(hourOffset) < 10 ? "0" : "";
+  const timezoneOffset =
+    hourOffset > 0
+      ? `+${timezoneOffsetPrefix}${hourOffset}`
+      : `-${timezoneOffsetPrefix}${Math.abs(hourOffset)}`;
+
+  const microseconds = Math.floor(timestampTzValue.timestamp!.nanos / 1000);
   const formattedTimestamp =
     microseconds > 0
       ? `${fullDayjs.format("YYYY-MM-DD HH:mm:ss")}.${microseconds.toString().padStart(6, "0")}${timezoneOffset}`

--- a/frontend/src/utils/v1/sql.ts
+++ b/frontend/src/utils/v1/sql.ts
@@ -67,7 +67,9 @@ const formatTimestampWithTz = (timestampTzValue: RowValue_TimestampTZ) => {
       ? `+${timezoneOffsetPrefix}${hourOffset}`
       : `-${timezoneOffsetPrefix}${Math.abs(hourOffset)}`;
 
-  const microseconds = Math.floor(timestampTzValue.timestamp!.nanos / 1000);
+  const microseconds = Math.floor(
+    timestampTzValue.timestamp?.nanos ?? 0 / 1000
+  );
   const formattedTimestamp =
     microseconds > 0
       ? `${fullDayjs.format("YYYY-MM-DD HH:mm:ss")}.${microseconds.toString().padStart(6, "0")}${timezoneOffset}`


### PR DESCRIPTION
![CleanShot 2025-01-28 at 11 31 18@2x](https://github.com/user-attachments/assets/ada7346c-049b-4f71-81f2-433108c8243c)
---
![CleanShot 2025-01-28 at 11 31 12@2x](https://github.com/user-attachments/assets/9f7787a9-31cc-4b8f-8ece-b43f747df8c4)
---
![CleanShot 2025-01-28 at 11 30 35@2x](https://github.com/user-attachments/assets/58a24680-e46d-442d-8f60-77ea1a3de929)
---
![CleanShot 2025-01-28 at 11 30 26@2x](https://github.com/user-attachments/assets/7224a776-4205-4f81-b22f-3e5a7bd9b83e)
---

BTW, some `zone` in the response is not supported so we cannot use the dayjs timezone plugin.