### PR TITLE
fix: ux

### DIFF
--- a/frontend/src/components/MonacoEditor/composables/useSelectedContent.ts
+++ b/frontend/src/components/MonacoEditor/composables/useSelectedContent.ts
@@ -38,8 +38,8 @@ export const getActiveContentByCursor = (
   }
   return model.getValueInRange({
     startLineNumber: position.lineNumber,
-    startColumn: 0,
-    endLineNumber: position.lineNumber,
-    endColumn: editor.getBottomForLineNumber(position.lineNumber),
+    startColumn: 1,
+    endLineNumber: position.lineNumber + 1,
+    endColumn: 0,
   });
 };

--- a/frontend/src/components/SensitiveData/ClassificationView.vue
+++ b/frontend/src/components/SensitiveData/ClassificationView.vue
@@ -11,7 +11,9 @@
       <div class="flex items-center space-x-2">
         <NSwitch
           :value="!state.classification.classificationFromConfig"
-          :disabled="!allowEdit || !hasSensitiveDataFeature"
+          :disabled="
+            !allowEdit || !hasSensitiveDataFeature || !hasClassificationConfig
+          "
           @update:value="onClassificationConfigChange"
         />
         <div class="font-medium leading-7 text-main">
@@ -138,6 +140,10 @@ const formerConfig = computed(() =>
     id: uuidv4(),
     ...head(settingStore.classification),
   })
+);
+
+const hasClassificationConfig = computed(
+  () => settingStore.classification.length > 0
 );
 
 const state = reactive<LocalState>({


### PR DESCRIPTION
- Disallow toggle `classificationFromConfig` when no classification
- Fix get line value in the monaco editor. Close BYT-6911