### PR TITLE
chore: minimal demo data

### DIFF
--- a/backend/demo/data/default/README.md
+++ b/backend/demo/data/default/README.md
@@ -8,8 +8,7 @@ This is the demo data for https://demo.bytebase.com.
 
 1. Sample test and prod PG instances running on port `8083` and `8084`.
 1. [GitHub hr-sample](https://github.com/s-bytebase/hr-sample) to demonstrate GitOps Workflow.
-1. Enterprise license. https://demo.bytebase.com runs in dev mode, thus it bundles a dev license. If
-   you want to run the demo in release mode. You need to supply your own release license.
+2. Enterprise license. https://demo.bytebase.com runs in dev mode using a dev license.
 
 # How to use
 

--- a/backend/migrator/migration/3.4/0000##sheet_statement.sql
+++ b/backend/migrator/migration/3.4/0000##sheet_statement.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sheet DROP COLUMN IF EXISTS statement;

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -217,5 +217,5 @@ func TestMigrationCompatibility(t *testing.T) {
 func TestGetCutoffVersion(t *testing.T) {
 	releaseVersion, err := getProdCutoffVersion()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.3.8"), releaseVersion)
+	require.Equal(t, semver.MustParse("3.4.0"), releaseVersion)
 }


### PR DESCRIPTION
demo.bytebase.com failed to start since 3.3.1 because it took too long to feed the dataset.