### PR TITLE
chore: change auto-close quote to never

### DIFF
--- a/frontend/src/components/MonacoEditor/editor.ts
+++ b/frontend/src/components/MonacoEditor/editor.ts
@@ -90,7 +90,7 @@ export const defaultEditorOptions =
       theme: "bb",
       tabSize: 2,
       insertSpaces: true,
-      autoClosingQuotes: "always",
+      autoClosingQuotes: "never",
       detectIndentation: false,
       folding: false,
       automaticLayout: true,
@@ -127,7 +127,7 @@ export const defaultDiffEditorOptions =
       accessibilitySupport: "off",
       renderValidationDecorations: "on",
       theme: "bb",
-      autoClosingQuotes: "always",
+      autoClosingQuotes: "never",
       folding: false,
       automaticLayout: true,
       minimap: {


### PR DESCRIPTION
References:

* https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IEditorConstructionOptions.html#autoClosingQuotes

Currently Bytebase automatically adds a " when the user types one ", which users have said is annoying.