### PR TITLE
chore: remove brackets for mssql

### DIFF
--- a/backend/api/lsp/completion.go
+++ b/backend/api/lsp/completion.go
@@ -78,8 +78,8 @@ func (h *Handler) handleTextDocumentCompletion(ctx context.Context, _ *jsonrpc2.
 	var items []lsp.CompletionItem
 	for _, candidate := range candidates {
 		label := candidate.Text
-		// Remove the double quote if it's quoted.
-		if len(label) > 1 && label[0] == '"' && label[len(label)-1] == '"' || label[0] == '`' && label[len(label)-1] == '`' {
+		// Remove quotes or brackets from label.
+		if len(label) > 1 && (label[0] == '"' && label[len(label)-1] == '"' || label[0] == '`' && label[len(label)-1] == '`' || label[0] == '[' && label[len(label)-1] == ']') {
 			label = label[1 : len(label)-1]
 		}
 		completionItem := lsp.CompletionItem{


### PR DESCRIPTION
MSSQL already has keyword check implemented; removing brackets to be consistent with the display in PG/SQL