### PR TITLE
chore: change grpcruntime marshal option

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -257,7 +257,8 @@ func NewServer(ctx context.Context, profile *config.Profile) (*Server, error) {
 	gatewayModifier := auth.GatewayResponseModifier{Store: s.store}
 	mux := grpcruntime.NewServeMux(
 		grpcruntime.WithMarshalerOption(grpcruntime.MIMEWildcard, &grpcruntime.JSONPb{
-			MarshalOptions:   protojson.MarshalOptions{},
+			MarshalOptions: protojson.MarshalOptions{},
+			//nolint:forbidigo
 			UnmarshalOptions: protojson.UnmarshalOptions{},
 		}),
 		grpcruntime.WithForwardResponseOption(gatewayModifier.Modify),

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 
@@ -255,6 +256,10 @@ func NewServer(ctx context.Context, profile *config.Profile) (*Server, error) {
 	// the user has to restart the server to take the latest value.
 	gatewayModifier := auth.GatewayResponseModifier{Store: s.store}
 	mux := grpcruntime.NewServeMux(
+		grpcruntime.WithMarshalerOption(grpcruntime.MIMEWildcard, &grpcruntime.JSONPb{
+			MarshalOptions:   protojson.MarshalOptions{},
+			UnmarshalOptions: protojson.UnmarshalOptions{},
+		}),
 		grpcruntime.WithForwardResponseOption(gatewayModifier.Modify),
 		grpcruntime.WithRoutingErrorHandler(func(ctx context.Context, sm *grpcruntime.ServeMux, m grpcruntime.Marshaler, w http.ResponseWriter, r *http.Request, httpStatus int) {
 			if httpStatus != http.StatusNotFound {


### PR DESCRIPTION
Previous default: https://github.com/grpc-ecosystem/grpc-gateway/blob/c705c3cd08417413979ce1519cd4062ba728d784/runtime/marshaler_registry.go#L20

With this behavior change,
- we will not accept unrecognized fields in the request.
- we will not emit unpopulated fields to the response payload, e.g. ("hello": false) if hello is not set.