### PR TITLE
chore: trim trailing semicolons for ghost

### DIFF
--- a/backend/runner/plancheck/ghost_sync_executor.go
+++ b/backend/runner/plancheck/ghost_sync_executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/github/gh-ost/go/logic"
@@ -94,6 +95,8 @@ func (e *GhostSyncExecutor) Run(ctx context.Context, config *storepb.PlanCheckRu
 	materials := utils.GetSecretMapFromDatabaseMessage(database)
 	// To avoid leaking the rendered statement, the error message should use the original statement and not the rendered statement.
 	renderedStatement := utils.RenderStatement(statement, materials)
+	// Trim trailing semicolons.
+	renderedStatement = strings.TrimRight(renderedStatement, ";")
 
 	tableName, err := ghost.GetTableNameFromStatement(renderedStatement)
 	if err != nil {

--- a/backend/runner/taskrun/schema_update_ghost_executor.go
+++ b/backend/runner/taskrun/schema_update_ghost_executor.go
@@ -81,6 +81,8 @@ func (exec *SchemaUpdateGhostExecutor) RunOnce(ctx context.Context, driverCtx co
 		migrationError := make(chan error, 1)
 
 		statement := strings.TrimSpace(execStatement)
+		// Trim trailing semicolons.
+		statement = strings.TrimRight(statement, ";")
 
 		tableName, err := ghost.GetTableNameFromStatement(statement)
 		if err != nil {


### PR DESCRIPTION
so that gh-ost can build the correct instant ddl statement.