### PR TITLE
fix: pg error line

### DIFF
--- a/backend/component/sheet/sheet.go
+++ b/backend/component/sheet/sheet.go
@@ -476,7 +476,7 @@ func calculatePostgresErrorLine(statement string) int {
 
 	for _, singleSQL := range singleSQLs {
 		if _, err := pgrawparser.Parse(pgrawparser.ParseContext{}, singleSQL.Text); err != nil {
-			return singleSQL.LastLine
+			return singleSQL.LastLine + 1
 		}
 	}
 


### PR DESCRIPTION
> // LastLine is the line number of the last line of the SQL in the original SQL.
> // HINT: ZERO based.
> LastLine int
> 
> https://github.com/bytebase/bytebase/blob/main/backend/plugin/parser/base/base.go#L22

<img width="847" alt="image" src="https://github.com/user-attachments/assets/34a0ec18-67ad-4fb7-8cb9-f253bf35f207" />
