### PR TITLE
fix: environment tab style

### DIFF
--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -338,6 +338,6 @@ const renderTab = (env: Environment, index: number) => {
     }
   }
 
-  return h("div", { class: "flex items-center space-x-2" }, child);
+  return h("div", { class: "flex items-center space-x-2 py-1" }, child);
 };
 </script>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/53b7d820-46e3-4c10-b9bf-780c4bd89dc5)

After:
![CleanShot 2025-02-25 at 11 34 05@2x](https://github.com/user-attachments/assets/0c9bca8b-07e5-478c-853b-91bb1e600c16)
