### PR TITLE
chore: minor updates

### DIFF
--- a/frontend/src/components/Member/MemberDataTable/cells/UserOperationsCell.vue
+++ b/frontend/src/components/Member/MemberDataTable/cells/UserOperationsCell.vue
@@ -33,8 +33,7 @@
 import { PencilIcon, Trash2Icon } from "lucide-vue-next";
 import { NButton, NPopconfirm } from "naive-ui";
 import { computed } from "vue";
-import { unknownUser } from "@/types";
-import { UserType } from "@/types/proto/v1/user_service";
+import { unknownUser, SYSTEM_BOT_USER_NAME } from "@/types";
 import { State } from "@/types/proto/v1/common";
 import type { MemberBinding } from "../../types";
 
@@ -54,7 +53,8 @@ const allowUpdate = computed(() => {
   }
 
   const user = props.binding.user ?? unknownUser();
-  if (user.userType === UserType.SYSTEM_BOT) {
+  if (user.name === SYSTEM_BOT_USER_NAME) {
+    // Cannot edit the member binding for support@bytebase.com, but can edit allUsers
     return false;
   }
   return user.state === State.ACTIVE;

--- a/frontend/src/utils/pagination.ts
+++ b/frontend/src/utils/pagination.ts
@@ -1,8 +1,3 @@
-import { useCurrentUserV1 } from "@/store";
-
 export const getDefaultPagination = () => {
-  if (useCurrentUserV1().value.email.endsWith("@bytebase.com")) {
-    return 1;
-  }
   return 50;
 };

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -1,7 +1,6 @@
-const PERMISSION_PREFIX = "bb.";
-
 // displayPermissionTitle return the formatted permission title.
-// e.g., bb.databases.get -> databases.get
+// Some API users may need to check permissions from the UI.
+// We will show the raw permission for now till we support more readable UX and have docs for these permissions.
 export const displayPermissionTitle = (permission: string): string => {
-  return permission.slice(PERMISSION_PREFIX.length);
+  return permission;
 };


### PR DESCRIPTION
- Show the raw permission name. Since we don't have the permissions docs, the API/Terraform users need to check permissions from the UX.
- Increase the hack for default pagination to 10 (thus it's still easy to test in the local, but not much effect for regular use)
- Not support editing the member binding for support@bytebase.com, but should support edit "allUsers"