### PR TITLE
chore: ssl mode

### DIFF
--- a/backend/plugin/db/cockroachdb/cockroachdb.go
+++ b/backend/plugin/db/cockroachdb/cockroachdb.go
@@ -151,8 +151,9 @@ func getCockroachConnectionConfig(config db.ConnectionConfig) (*pgx.ConnConfig, 
 	}
 
 	connStr := fmt.Sprintf("host=%s port=%s", config.DataSource.Host, config.DataSource.Port)
-	sslMode := util.GetPGSSLMode(config.DataSource)
-	connStr += fmt.Sprintf(" sslmode=%s", sslMode)
+	if config.DataSource.GetUseSsl() {
+		connStr += fmt.Sprintf(" sslmode=%s", util.GetPGSSLMode(config.DataSource))
+	}
 
 	routingID := getRoutingIDFromCockroachCloudURL(config.DataSource.Host)
 	if routingID != "" {

--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -152,8 +152,9 @@ func getPGConnectionConfig(config db.ConnectionConfig) (*pgx.ConnConfig, error) 
 	}
 
 	connStr := fmt.Sprintf("host=%s port=%s", config.DataSource.Host, config.DataSource.Port)
-	sslMode := util.GetPGSSLMode(config.DataSource)
-	connStr += fmt.Sprintf(" sslmode=%s", sslMode)
+	if config.DataSource.GetUseSsl() {
+		connStr += fmt.Sprintf(" sslmode=%s", util.GetPGSSLMode(config.DataSource))
+	}
 
 	// Add target_session_attrs=read-write if specified in ExtraConnectionParameters
 	if len(config.DataSource.GetExtraConnectionParameters()) > 0 {

--- a/backend/plugin/db/util/ssl.go
+++ b/backend/plugin/db/util/ssl.go
@@ -82,25 +82,17 @@ func GetTLSConfig(ds *storepb.DataSource) (*tls.Config, error) {
 type SSLMode string
 
 const (
-	// Unused.
-	// sslModeDisable SSLMode = "disable"
-	// sslModeAllow   SSLMode = "allow"
-	// It is the default mode of sslmode.
-	// https://www.postgresql.org/docs/current/libpq-ssl.html
-	sslModePrefer     SSLMode = "prefer"
-	sslModeRequire    SSLMode = "require"
 	sslModeVerifyCA   SSLMode = "verify-ca"
 	sslModeVerifyFull SSLMode = "verify-full"
 )
 
+// GetPGSSLMode is used only when SSL is enabled.
+// We should consider allowing user to override this default in the future even if SSL is enabled.
 func GetPGSSLMode(ds *storepb.DataSource) SSLMode {
-	sslMode := sslModePrefer
-	if ds.GetUseSsl() {
-		sslMode = sslModeVerifyFull
-		if ds.GetSslCa() != "" {
-			if ds.GetSshHost() != "" {
-				sslMode = sslModeVerifyCA
-			}
+	sslMode := sslModeVerifyFull
+	if ds.GetSslCa() != "" {
+		if ds.GetSshHost() != "" {
+			sslMode = sslModeVerifyCA
 		}
 	}
 	return sslMode


### PR DESCRIPTION
1. We will not set sslmode explicitly when ssl is not enabled. The default is prefer which will not break existing users - majority.
2. Users can use extra-parameter feature to set sslmode override (disable).
3. We need to design the sslmode override mechanism to be straightforward for anyone who wishes to customize it in the future.