### PR TITLE
chore: replace go-lsp with lsp-protocol

### DIFF
--- a/backend/api/lsp/commands.go
+++ b/backend/api/lsp/commands.go
@@ -1,6 +1,8 @@
 package lsp
 
-import "github.com/sourcegraph/go-lsp"
+import (
+	protocol "github.com/bytebase/lsp-protocol"
+)
 
 type CommandName string
 
@@ -10,7 +12,7 @@ const (
 
 // SetMetadataCommandParams are the parameters to the "setMetadata" command.
 type SetMetadataCommandParams struct {
-	lsp.ExecuteCommandParams
+	protocol.ExecuteCommandParams
 	Arguments []SetMetadataCommandArguments `json:"arguments,omitempty"`
 }
 

--- a/backend/api/lsp/commands.go
+++ b/backend/api/lsp/commands.go
@@ -1,7 +1,7 @@
 package lsp
 
 import (
-	protocol "github.com/bytebase/lsp-protocol"
+	lsp "github.com/bytebase/lsp-protocol"
 )
 
 type CommandName string
@@ -12,7 +12,7 @@ const (
 
 // SetMetadataCommandParams are the parameters to the "setMetadata" command.
 type SetMetadataCommandParams struct {
-	protocol.ExecuteCommandParams
+	lsp.ExecuteCommandParams
 	Arguments []SetMetadataCommandArguments `json:"arguments,omitempty"`
 }
 

--- a/backend/api/lsp/custom.go
+++ b/backend/api/lsp/custom.go
@@ -1,6 +1,6 @@
 package lsp
 
-import "github.com/sourcegraph/go-lsp"
+import lsp "github.com/bytebase/lsp-protocol"
 
 type PingResult struct {
 	Result string `json:"result"`

--- a/backend/api/lsp/fs.go
+++ b/backend/api/lsp/fs.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"sync"
 
+	lsp "github.com/bytebase/lsp-protocol"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/go-lsp"
 )
 
 // MemFS is an in-memory file system.

--- a/backend/api/lsp/fs_handler.go
+++ b/backend/api/lsp/fs_handler.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"os"
 
+	lsp "github.com/bytebase/lsp-protocol"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/bytebase/bytebase/backend/common/log"

--- a/backend/api/lsp/handler.go
+++ b/backend/api/lsp/handler.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"sync"
 
+	lsp "github.com/bytebase/lsp-protocol"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -223,12 +223,8 @@ func (h *Handler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2
 			return nil, err
 		}
 
-		kind := lsp.TDSKIncremental
 		return lsp.InitializeResult{
 			Capabilities: lsp.ServerCapabilities{
-				TextDocumentSync: &lsp.TextDocumentSyncOptionsOrKind{
-					Kind: &kind,
-				},
 				CompletionProvider: &lsp.CompletionOptions{
 					TriggerCharacters: []string{".", " "},
 				},

--- a/backend/api/lsp/handler.go
+++ b/backend/api/lsp/handler.go
@@ -225,6 +225,7 @@ func (h *Handler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2
 
 		return lsp.InitializeResult{
 			Capabilities: lsp.ServerCapabilities{
+				TextDocumentSync: lsp.Incremental,
 				CompletionProvider: &lsp.CompletionOptions{
 					TriggerCharacters: []string{".", " "},
 				},

--- a/backend/api/lsp/utils.go
+++ b/backend/api/lsp/utils.go
@@ -7,8 +7,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	lsp "github.com/bytebase/lsp-protocol"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/go-lsp"
 )
 
 func trimFilePrefix(s string) string {
@@ -43,7 +43,7 @@ func offsetForPosition(content []byte, p lsp.Position) (byteOffset int, whyInval
 	}
 
 	// Validate line number, notes that the Position in LSP is 0-based.
-	if p.Line >= lineNumber {
+	if int(p.Line) >= lineNumber {
 		return 0, errors.Errorf("line number %d out of range [0, %d)", p.Line, lineNumber)
 	}
 
@@ -51,7 +51,7 @@ func offsetForPosition(content []byte, p lsp.Position) (byteOffset int, whyInval
 	trimmedContent := content[offset:]
 
 	col8 := 0
-	for col16 := 0; col16 < p.Character; col16++ {
+	for col16 := 0; col16 < int(p.Character); col16++ {
 		// Unpack the first rune.
 		r, sz := utf8.DecodeRune(trimmedContent)
 		if sz == 0 {
@@ -115,7 +115,7 @@ func getSQLStatementRangesUTF16Position(content []byte) []lsp.Range {
 			continue
 		}
 
-		begin := lsp.Position{Line: line, Character: character}
+		begin := lsp.Position{Line: uint32(line), Character: uint32(character)}
 		for _, r := range statement {
 			if r == '\n' {
 				line++
@@ -147,7 +147,7 @@ func getSQLStatementRangesUTF16Position(content []byte) []lsp.Range {
 				endCharacter++
 			}
 		}
-		end := lsp.Position{Line: endLine, Character: endCharacter}
+		end := lsp.Position{Line: uint32(endLine), Character: uint32(endCharacter)}
 		ranges = append(ranges, lsp.Range{Start: begin, End: end})
 	}
 	return ranges

--- a/backend/api/lsp/utils_test.go
+++ b/backend/api/lsp/utils_test.go
@@ -3,7 +3,7 @@ package lsp
 import (
 	"testing"
 
-	"github.com/sourcegraph/go-lsp"
+	lsp "github.com/bytebase/lsp-protocol"
 	"github.com/stretchr/testify/require"
 )
 

--- a/backend/plugin/parser/base/diagnose.go
+++ b/backend/plugin/parser/base/diagnose.go
@@ -1,6 +1,6 @@
 package base
 
-import "github.com/sourcegraph/go-lsp"
+import lsp "github.com/bytebase/lsp-protocol"
 
 // DiagnosticContext is the context for diagnosing SQL statements.
 type DiagnoseContext struct {
@@ -13,17 +13,17 @@ func ConvertSyntaxErrorToDiagnostic(err *SyntaxError) Diagnostic {
 		Range: lsp.Range{
 			Start: lsp.Position{
 				// Convert to zero-based.
-				Line:      err.Line - 1,
-				Character: err.Column,
+				Line:      uint32(err.Line) - 1,
+				Character: uint32(err.Column),
 			},
 			End: lsp.Position{
 				// Convert to zero-based.
-				Line: err.Line - 1,
+				Line: uint32(err.Line) - 1,
 				// The end position is exclusive.
-				Character: err.Column + 1,
+				Character: uint32(err.Column) + 1,
 			},
 		},
-		Severity: lsp.Error,
+		Severity: lsp.DiagnosticSeverity(lsp.Error),
 		Source:   "Syntax check",
 		// Use RawMessage which created by antlr runtime, do not need our fine-tuned message
 		// because we had indicated the error position in the message.

--- a/backend/plugin/parser/base/diagnose.go
+++ b/backend/plugin/parser/base/diagnose.go
@@ -23,7 +23,7 @@ func ConvertSyntaxErrorToDiagnostic(err *SyntaxError) Diagnostic {
 				Character: uint32(err.Column) + 1,
 			},
 		},
-		Severity: lsp.DiagnosticSeverity(lsp.Error),
+		Severity: lsp.SeverityError,
 		Source:   "Syntax check",
 		// Use RawMessage which created by antlr runtime, do not need our fine-tuned message
 		// because we had indicated the error position in the message.

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bytebase/cosmosdb-parser v0.0.0-20250317064006-c1dcb3ed4fa4
 	github.com/bytebase/google-sql-parser v0.0.0-20250116032737-689a327f9465
+	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
 	github.com/bytebase/mysql-parser v0.0.0-20241224071214-cb9fd84811dd
 	github.com/bytebase/plsql-parser v0.0.0-20250218041636-9fed633593d1
 	github.com/bytebase/postgresql-parser v0.0.0-20250213053010-aeb8220eb3bb
@@ -79,7 +80,6 @@ require (
 	github.com/snowflakedb/gosnowflake v1.13.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/sourcegraph/conc v0.3.0
-	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,6 @@ github.com/bytebase/cosmosdb-parser v0.0.0-20250317064006-c1dcb3ed4fa4 h1:mw6ze5
 github.com/bytebase/cosmosdb-parser v0.0.0-20250317064006-c1dcb3ed4fa4/go.mod h1:sivaOoKlMrXkuude2VGsKv6p83CRRGgblNfeVKQka/Y=
 github.com/bytebase/gh-ost2 v1.1.7-0.20250310031106-33e16ca4b2e0 h1:wm4Set2lwArmC4f9hYdiunXtEYYzr6SyYRepTXNdkm4=
 github.com/bytebase/gh-ost2 v1.1.7-0.20250310031106-33e16ca4b2e0/go.mod h1:X0CGYwIZUnjfrv02/nBlftxqSBMm4mYJzFwiyn2D4d8=
-github.com/bytebase/go-lsp v0.0.0-20240130071507-c04b5c75010c h1:W832GNANCst4C6TgYbQnKKxbuMZKQxTD4++b3HOuzBo=
-github.com/bytebase/go-lsp v0.0.0-20240130071507-c04b5c75010c/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=
 github.com/bytebase/go-mssqldb v0.0.0-20240801091126-3ff3ca07d898 h1:0ggqA9XL4yvtePPvRDRYMed3jtdNk4s0o8AMW8uJPSA=
 github.com/bytebase/go-mssqldb v0.0.0-20240801091126-3ff3ca07d898/go.mod h1:2KhUz4GSLcdJGXSJMXAf2BjmakcgoOkNyPpHdGAxRpY=
 github.com/bytebase/go-obo v0.0.0-20231026081615-705a7fffbfd2 h1:nEHZi8S7PHT4GxP9GfJiuhO8KkYcHmePvy5BfiYxwNk=
@@ -843,6 +841,8 @@ github.com/bytebase/google-sql-parser v0.0.0-20250116032737-689a327f9465 h1:Yk6W
 github.com/bytebase/google-sql-parser v0.0.0-20250116032737-689a327f9465/go.mod h1:edPCw84OriRDnBl+JdtruQ1XoX6dbYR/AkhxyGFRHwg=
 github.com/bytebase/gosasl v0.0.0-20240422091407-6b7481e86f08 h1:S1GgjJLspz4E4z4CvomGvKgxyv0ATfZm27qHM418jWc=
 github.com/bytebase/gosasl v0.0.0-20240422091407-6b7481e86f08/go.mod h1:Qx8cW6jkI8riyzmklj80kAIkv+iezFUTBiGU0qHhHes=
+github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
+github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
 github.com/bytebase/mysql-parser v0.0.0-20241224071214-cb9fd84811dd h1:nKWY30Pq9y/z0+MScRm90KU1U3i0U3j0KGBLN0JL/3M=
 github.com/bytebase/mysql-parser v0.0.0-20241224071214-cb9fd84811dd/go.mod h1:n22yoTeLcphIYQlV6nbufQbHMxNceOjeGDOrpaRIhiY=
 github.com/bytebase/partiql-parser v0.0.0-20240531101102-1962ff456f2c h1:TMANvCCN7gpqXHrzRWeWRkPTXmFvTSEyXTZ1Fz20EvM=


### PR DESCRIPTION
go-lsp is legacy, switch to use [lsp-protocol](https://github.com/bytebase/lsp-protocol)

cc @rebelice 