### PR TITLE
feat: add ghost flags assume master host

### DIFF
--- a/backend/component/ghost/config.go
+++ b/backend/component/ghost/config.go
@@ -64,6 +64,7 @@ type UserFlags struct {
 	niceRatio                     *float64
 	throttleControlReplicas       *string
 	attemptInstantDDL             *bool
+	assumeMasterHost              *bool // use datasource host if true
 }
 
 var knownKeys = map[string]bool{
@@ -81,6 +82,7 @@ var knownKeys = map[string]bool{
 	"nice-ratio":                       true,
 	"throttle-control-replicas":        true,
 	"attempt-instant-ddl":              true,
+	"assume-master-host":               true,
 }
 
 func GetUserFlags(flags map[string]string) (*UserFlags, error) {
@@ -187,6 +189,13 @@ func GetUserFlags(flags map[string]string) (*UserFlags, error) {
 			return nil, errors.Wrapf(err, "failed to convert attempt-instant-ddl %q to bool", v)
 		}
 		f.attemptInstantDDL = &attemptInstantDDL
+	}
+	if v, ok := flags["assume-master-host"]; ok {
+		assumeMasterHost, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to convert assume-master-host %q to bool", v)
+		}
+		f.assumeMasterHost = &assumeMasterHost
 	}
 	return f, nil
 }
@@ -331,6 +340,12 @@ func NewMigrationContext(ctx context.Context, taskID int, database *store.Databa
 	if v := userFlags.throttleControlReplicas; v != nil {
 		if err := migrationContext.ReadThrottleControlReplicaKeys(*v); err != nil {
 			return nil, errors.Wrapf(err, "failed to set throttleControlReplicas")
+		}
+	}
+	if v := userFlags.assumeMasterHost; v != nil && *v {
+		migrationContext.AssumeMasterHostname = dataSource.GetHost()
+		if dataSource.GetPort() != "" {
+			migrationContext.AssumeMasterHostname += ":" + dataSource.GetPort()
 		}
 	}
 	// Uses specified port. GCP, Aliyun, Azure are equivalent here.

--- a/frontend/src/components/IssueV1/components/Sidebar/GhostSection/FlagsForm/constants.ts
+++ b/frontend/src/components/IssueV1/components/Sidebar/GhostSection/FlagsForm/constants.ts
@@ -7,9 +7,10 @@ export type GhostParameter<T extends GhostParameterType = any> = {
 };
 
 export const SupportedGhostParameters: GhostParameter[] = [
-  { key: "attempt-instant-ddl", type: "bool", defaults: "true"},
+  { key: "attempt-instant-ddl", type: "bool", defaults: "true" },
   { key: "allow-on-master", type: "bool", defaults: "true" },
   { key: "assume-rbr", type: "bool", defaults: "false" },
+  { key: "assume-master-host", type: "bool", defaults: "false" },
   { key: "chunk-size", type: "int", defaults: "1000" },
   { key: "cut-over-lock-timeout-seconds", type: "int", defaults: "10" },
   { key: "default-retries", type: "int", defaults: "60" },
@@ -20,7 +21,7 @@ export const SupportedGhostParameters: GhostParameter[] = [
   { key: "max-lag-millis", type: "int", defaults: "1500" },
   { key: "nice-ratio", type: "float", defaults: "0" },
   { key: "switch-to-rbr", type: "bool", defaults: "false" },
-  { key: "throttle-control-replicas", type: "string", defaults: ""},
+  { key: "throttle-control-replicas", type: "string", defaults: "" },
 ];
 
 export const isBoolParameter = (


### PR DESCRIPTION
gh-ost `assume-master-host` receives the `host:port` string. I changed it to receive a bool on Bytebase to save the copy & paste.

Close BYT-7169