### PR TITLE
fix: depot build

### DIFF
--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   build-release-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Extract build args


### PR DESCRIPTION
failure: https://github.com/bytebase/bytebase/actions/runs/14368395351/job/40288191192
fix: step 3 in https://github.com/depot/build-push-action?tab=readme-ov-file#authentication
 Don't know why the depot builds start failing this week.