### PR TITLE
fix: get active statement range

### DIFF
--- a/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
@@ -124,6 +124,7 @@ const props = withDefaults(
     options: undefined,
     formatContentOptions: undefined,
     placeholder: undefined,
+    enableDecorations: true,
   }
 );
 
@@ -205,7 +206,7 @@ onMounted(async () => {
     const content = useContent(monaco, editor);
     const selection = useSelection(editor);
     const selectedContent = useSelectedContent(editor, selection);
-    const activeRangeByCursor = useActiveRangeByCursor(monaco, editor);
+    const activeRangeByCursor = useActiveRangeByCursor(editor);
     useAdvices(monaco, editor, toRef(props, "advices"));
     useLineHighlights(monaco, editor, toRef(props, "lineHighlights"));
     useAutoHeight(monaco, editor, containerRef, toRef(props, "autoHeight"));

--- a/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
+++ b/frontend/src/components/MonacoEditor/MonacoTextModelEditor.vue
@@ -124,7 +124,6 @@ const props = withDefaults(
     options: undefined,
     formatContentOptions: undefined,
     placeholder: undefined,
-    enableDecorations: true,
   }
 );
 


### PR DESCRIPTION
Before:

If the two statements don't have the blank line between them, for example:

![CleanShot 2025-05-07 at 19 33 58@2x](https://github.com/user-attachments/assets/06efefb5-6b99-413c-94aa-997a2311c644)

The ranges from the WS is `[{startLineNumber: 1, endLineNumber: 3, startColumn: 1, endColumn: 1}, {startLineNumber: 3, endLineNumber: 3, startColumn: 1, endColumn: 11}]`, and the active cursor is `line: 3, column: 6`, we cannot get the valid active block.

After:

![CleanShot 2025-05-07 at 19 21 56@2x](https://github.com/user-attachments/assets/f537669e-aca8-4334-87be-b4891599b000)
![CleanShot 2025-05-07 at 19 25 11@2x](https://github.com/user-attachments/assets/1159abde-4d05-40e4-8535-45f3cb9addba)
