### PR TITLE
chore: action bar for database info

### DIFF
--- a/frontend/src/views/sql-editor/AsidePanel/ActionBar/ActionBar.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/ActionBar/ActionBar.vue
@@ -1,0 +1,20 @@
+<template>
+  <div
+    class="h-full flex flex-col items-stretch justify-between overflow-hidden text-sm p-1 shrink-0"
+  >
+    <div class="flex flex-col gap-y-1">
+      <TabItem
+        v-for="action in availableActions"
+        :key="action.view"
+        :action="action"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useCurrentTabViewStateContext } from "../../EditorPanel/context/viewState.tsx";
+import TabItem from "./TabItem.vue";
+
+const { availableActions } = useCurrentTabViewStateContext();
+</script>

--- a/frontend/src/views/sql-editor/AsidePanel/ActionBar/TabItem.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/ActionBar/TabItem.vue
@@ -1,0 +1,66 @@
+<template>
+  <NTooltip placement="right" :delay="300" :disabled="disabled">
+    <template #trigger>
+      <NButton
+        :style="buttonStyle"
+        v-bind="{ ...buttonProps, ...$attrs }"
+        @click="handleClick"
+      >
+        <template #icon>
+          <component :is="action.icon" :class="iconClass" />
+        </template>
+      </NButton>
+    </template>
+    <template #default>
+      {{ action.title }}
+    </template>
+  </NTooltip>
+</template>
+
+<script setup lang="ts">
+import { NButton, NTooltip } from "naive-ui";
+import { computed, toRef } from "vue";
+import type { VNodeChild } from "vue";
+import { useConnectionOfCurrentSQLEditorTab } from "@/store";
+import type { EditorPanelView } from "@/types";
+import { useActions } from "../../AsidePanel/SchemaPane/actions";
+import { useCurrentTabViewStateContext } from "../../EditorPanel/context/viewState.tsx";
+import { useButton } from "./common";
+
+const props = defineProps<{
+  action: {
+    view: EditorPanelView;
+    title: string;
+    icon: () => VNodeChild;
+  };
+  disabled?: boolean;
+}>();
+
+const active = computed(() => props.action.view === viewState.value?.view);
+const { viewState } = useCurrentTabViewStateContext();
+const { database } = useConnectionOfCurrentSQLEditorTab();
+
+const { props: buttonProps, style: buttonStyle } = useButton({
+  active,
+  disabled: toRef(props, "disabled"),
+});
+
+const iconClass = computed(() => {
+  const classes = ["w-4", "h-4"];
+  if (active.value) {
+    classes.push("!text-current");
+  } else {
+    classes.push("text-main");
+  }
+  return classes;
+});
+
+const { openNewTab } = useActions();
+
+const handleClick = () => {
+  openNewTab({
+    title: `[${database.value.databaseName}] ${props.action.title}`,
+    view: props.action.view,
+  });
+};
+</script>

--- a/frontend/src/views/sql-editor/AsidePanel/ActionBar/common.ts
+++ b/frontend/src/views/sql-editor/AsidePanel/ActionBar/common.ts
@@ -1,0 +1,34 @@
+import type { ButtonProps } from "naive-ui";
+import { computed, unref, type MaybeRef } from "vue";
+
+export const useButton = (options: {
+  active: MaybeRef<boolean>;
+  disabled: MaybeRef<boolean>;
+}) => {
+  const props = computed(() => {
+    const props: ButtonProps = {
+      tag: "div",
+      disabled: unref(options.disabled),
+      size: "small",
+    };
+    if (unref(options.active)) {
+      props.secondary = true;
+      props.type = "primary";
+    } else {
+      props.quaternary = true;
+      props.type = "default";
+    }
+    props.disabled = unref(options.disabled);
+
+    return props;
+  });
+  const style = computed(() => {
+    const parts: string[] = [];
+
+    parts.push("--n-height: 32px");
+    parts.push("--n-padding: 4px 8px");
+    parts.push("--n-icon-size: 16px");
+    return parts.join("; ");
+  });
+  return { props, style };
+};

--- a/frontend/src/views/sql-editor/AsidePanel/ActionBar/index.ts
+++ b/frontend/src/views/sql-editor/AsidePanel/ActionBar/index.ts
@@ -1,0 +1,3 @@
+import ActionBar from "./ActionBar.vue";
+
+export default ActionBar;

--- a/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/AsidePanel.vue
@@ -7,6 +7,12 @@
     <div class="h-full border-r shrink-0">
       <GutterBar size="medium" />
     </div>
+    <div
+      v-if="asidePanelTab === 'SCHEMA' && !isDisconnected"
+      class="h-full border-r shrink-0"
+    >
+      <ActionBar />
+    </div>
     <div class="h-full flex-1 flex flex-col overflow-hidden">
       <div
         v-if="!strictProject && !hideProjects"
@@ -63,10 +69,15 @@ import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 import { ProjectSelect } from "@/components/v2";
 import { SQL_EDITOR_SETTING_PROJECT_MODULE } from "@/router/sqlEditor";
-import { useSQLEditorStore, useAppFeature } from "@/store";
+import {
+  useSQLEditorStore,
+  useAppFeature,
+  useSQLEditorTabStore,
+} from "@/store";
 import { defaultProject, isValidProjectName } from "@/types";
 import { hasProjectPermissionV2, hasWorkspacePermissionV2 } from "@/utils";
 import { useSQLEditorContext } from "../context";
+import ActionBar from "./ActionBar";
 import GutterBar from "./GutterBar";
 import HistoryPane from "./HistoryPane";
 import SchemaPane from "./SchemaPane";
@@ -74,6 +85,8 @@ import WorksheetPane from "./WorksheetPane";
 
 const editorStore = useSQLEditorStore();
 const { asidePanelTab } = useSQLEditorContext();
+const { isDisconnected } = storeToRefs(useSQLEditorTabStore());
+
 const { project, projectContextReady, strictProject } =
   storeToRefs(editorStore);
 const containerRef = ref<HTMLDivElement>();

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/actions.tsx
@@ -309,7 +309,7 @@ export const useDropdown = () => {
           icon: action.icon,
           onSelect: () => {
             openNewTab({
-              title: `[schema ${schema}] ${action.title}`,
+              title: `[${db.databaseName}] ${action.title}`,
               view: action.view,
               schema,
             })


### PR DESCRIPTION
![CleanShot 2025-05-12 at 16 29 53@2x](https://github.com/user-attachments/assets/3065b421-ae0d-4f05-8298-9fffa8d722af)

---

Background: we move them into the schema context menu few versions before

![CleanShot 2025-05-12 at 16 35 24@2x](https://github.com/user-attachments/assets/328298c7-4642-47b8-97f3-cecd3f76541e)

However, there's no way to show these actions for schemaless databases

![CleanShot 2025-05-12 at 16 35 39@2x](https://github.com/user-attachments/assets/5ad0d4af-b28e-436c-80be-63448058a991)

