### PR TITLE
fix: avoid unnecessary CREATE TRIGGER when trigger definition is unchanged in schema diff

### DIFF
--- a/backend/plugin/parser/mysql/differ.go
+++ b/backend/plugin/parser/mysql/differ.go
@@ -546,10 +546,12 @@ func (diff *diffNode) diffTrigger(oldSchema, newSchema *schemaDef) error {
 		if ok {
 			if !isTriggerEqual(oldTrigger, trigger) {
 				diff.dropTriggerList = append(diff.dropTriggerList, oldTrigger)
+				diff.createTriggerList = append(diff.createTriggerList, trigger)
 			}
 			delete(oldSchema.triggers, triggerName)
+		} else {
+			diff.createTriggerList = append(diff.createTriggerList, trigger)
 		}
-		diff.createTriggerList = append(diff.createTriggerList, trigger)
 	}
 	for _, trigger := range oldSchema.triggers {
 		diff.dropTriggerList = append(diff.dropTriggerList, trigger)

--- a/backend/plugin/parser/mysql/test-data/differ/test_differ_trigger.yaml
+++ b/backend/plugin/parser/mysql/test-data/differ/test_differ_trigger.yaml
@@ -34,3 +34,11 @@
     CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = sum + NEW.amount * NEW.price;;
     DELIMITER ;
 
+- oldSchema: |
+    CREATE TABLE `account`(`acct_num` INT, `amount` DECIMAL(10,2));
+    CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = @sum + NEW.amount;
+  newSchema: |
+    CREATE TABLE `account`(`acct_num` INT, `amount` DECIMAL(10,2), `price` INT);
+    CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = @sum + NEW.amount;
+  diff: |+
+    ALTER TABLE `account` ADD COLUMN `price` INT AFTER `amount`;

--- a/backend/plugin/parser/mysql/test-data/differ/test_differ_trigger.yaml
+++ b/backend/plugin/parser/mysql/test-data/differ/test_differ_trigger.yaml
@@ -42,3 +42,4 @@
     CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON account FOR EACH ROW SET @sum = @sum + NEW.amount;
   diff: |+
     ALTER TABLE `account` ADD COLUMN `price` INT AFTER `amount`;
+


### PR DESCRIPTION
## Background

Previously, when diffing MySQL schemas, the differ would always generate a CREATE TRIGGER statement for triggers present in both the old and new schemas, even if their definitions were identical. This led to unnecessary DDL statements and could cause errors if the trigger already existed.

## What’s Changed

- Updated the trigger diff logic to only generate CREATE TRIGGER statements when:
  - The trigger is new (does not exist in the old schema), or
  - The trigger definition has changed (requires DROP and CREATE).
- If a trigger exists in both schemas and is unchanged, no DDL is generated for it.

## Why

This change ensures that the diff output is minimal and accurate, avoiding redundant operations and potential errors. It also aligns the trigger diff behavior with best practices for schema migration.

## Test Coverage

- Updated/added test cases in `test_differ_trigger.yaml` to cover unchanged, added, removed, and modified triggers.
- All existing and new tests pass.

---

If you have any feedback or suggestions, please let me know!