### PR TITLE
chore(action): add gcompat

### DIFF
--- a/scripts/Dockerfile.action
+++ b/scripts/Dockerfile.action
@@ -10,7 +10,7 @@ RUN go build \
 FROM alpine:3.21
 RUN apk update
 # Azure DevOps pipeline requires bash.
-RUN apk add --no-cache jq bash
+RUN apk add --no-cache jq bash gcompat
 WORKDIR /
 COPY --from=builder /action-build/bytebase-action /usr/local/bin/bytebase-action
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs


### PR DESCRIPTION
azure devops pipeline runs a nodejs binary on startup.
```
/usr/bin/docker create --name 41a7b9d666bf40529413de24cd686f6f_bytebasebytebaseaction362_97c922 --label 76f4a4 --network vsts_network_1762cd09e20c468cb912c62a65b01f74  -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/vsts/work/1":"/__w/1" -v "/home/vsts/work/_temp":"/__w/_temp" -v "/home/vsts/work/_tasks":"/__w/_tasks" -v "/opt/hostedtoolcache":"/__t" -v "/home/vsts/agents/4.255.0/externals":"/__a/externals":ro -v "/home/vsts/work/.taskkey":"/__w/.taskkey" bytebase/bytebase-action:3.6.2 bash -c "'/__a/externals/node20_1/bin/node' --version && echo 'container-startup-using-node-20' && '/__a/externals/node20_1/bin/node' -e 'setInterval(function(){}, 24 * 60 * 60 * 1000);' || '/__a/externals/node16/bin/node' --version && echo 'container-startup-using-node-16' && '/__a/externals/node16/bin/node' -e 'setInterval(function(){}, 24 * 60 * 60 * 1000);' || echo 'container-startup-failed'"
```
![CleanShot 2025-05-14 at 10 47 45@2x](https://github.com/user-attachments/assets/5679dd8a-e9da-4fe5-91f1-fa3b241fd2a6)
