### PR TITLE
chore: dml for baseline task and plan backfill

### DIFF
--- a/backend/migrator/migration/3.7/0007##backfill_task_sheet_id.sql
+++ b/backend/migrator/migration/3.7/0007##backfill_task_sheet_id.sql
@@ -1,0 +1,28 @@
+update plan set config = replace(config::text, 'BASELINE', 'MIGRATE')::jsonb where config::text LIKE '%BASELINE%';
+update task set type = 'bb.task.database.schema.update' where type = 'bb.task.database.schema.baseline';
+
+-- Backfill sheetId in task payload from plan config
+UPDATE task
+SET payload = jsonb_set(
+    COALESCE(payload, '{}'::jsonb),
+    '{sheetId}',
+    to_jsonb(CAST(SUBSTRING(spec_sheet FROM 'sheets/([0-9]+)$') AS INTEGER))
+)
+FROM (
+    SELECT 
+        t.id AS task_id,
+        spec->'changeDatabaseConfig'->>'sheet' AS spec_sheet
+    FROM task t
+    JOIN plan p ON t.pipeline_id = p.pipeline_id
+    CROSS JOIN LATERAL jsonb_array_elements(p.config->'steps') AS step
+    CROSS JOIN LATERAL jsonb_array_elements(step->'specs') AS spec
+    WHERE 
+        t.payload IS NOT NULL
+        AND t.payload->>'specId' IS NOT NULL
+        AND (t.payload->>'sheetId' IS NULL OR NOT t.payload ? 'sheetId')
+        AND spec->>'id' = t.payload->>'specId'
+        AND spec->'changeDatabaseConfig'->>'type' = 'MIGRATE'
+        AND spec->'changeDatabaseConfig'->>'sheet' IS NOT NULL
+        AND SUBSTRING(spec->'changeDatabaseConfig'->>'sheet' FROM 'sheets/([0-9]+)$') IS NOT NULL
+) AS plan_spec
+WHERE task.id = plan_spec.task_id;

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.7.6"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.7.7"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
```
bbdev=# select * from task;
 id  | pipeline_id | stage_id | instance | db_name |              type              |                                           payload                                           
-----+-------------+----------+----------+---------+--------------------------------+---------------------------------------------------------------------------------------------
 102 |         102 |      102 | pg       | bbdev   | bb.task.database.schema.update | {"specId": "ebd956de-626d-4088-914f-13cfbeaacf51", "sheetId": 102, "taskReleaseSource": {}}
 101 |         101 |      101 | pg       | bbdev   | bb.task.database.schema.baseline | {"specId": "9480d8fd-457c-4adb-a6de-96b14ef7b066", "taskReleaseSource": {}}
```