### PR TITLE
feat: batch export in the sql editor

### DIFF
--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
@@ -6,6 +6,7 @@
     :data="databaseList"
     :striped="true"
     :bordered="bordered"
+    :pagination="pagination"
     :loading="loading"
     :row-key="(data: ComposedDatabase) => data.name"
     :checked-row-keys="props.selectedDatabaseNames"
@@ -50,6 +51,12 @@ const props = withDefaults(
     selectedDatabaseNames?: string[];
     keyword?: string;
     rowClick?: (e: MouseEvent, val: ComposedDatabase) => void;
+    pagination?:
+      | false
+      | {
+          defaultPageSize: number;
+          disabled: boolean;
+        };
   }>(),
   {
     mode: "ALL",
@@ -58,6 +65,7 @@ const props = withDefaults(
     rowClickable: true,
     keyword: undefined,
     selectedDatabaseNames: () => [],
+    pagination: false,
   }
 );
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1812,6 +1812,11 @@
         "not-match": "Data source not match, expect {expect} but got {actual}."
       }
     },
+    "batch-export": {
+      "self": "Batch export",
+      "tooltip": "Select at most {max} databases to batch export latest query results",
+      "failed-for-db": "Failed to export data for {db}"
+    },
     "execute-query": "Execute query",
     "pending-query": "Pending query",
     "executing-query": "Executing query",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1812,6 +1812,11 @@
         "not-match": "La fuente de datos no coincide, se esperaba {expect} pero se obtuvo {actual}."
       }
     },
+    "batch-export": {
+      "self": "Exportación por lotes",
+      "tooltip": "Seleccione como máximo {max} bases de datos para exportar por lotes los resultados de las últimas consultas",
+      "failed-for-db": "No se pudieron exportar los datos de {db}"
+    },
     "execute-query": "Ejecutar consulta",
     "pending-query": "Consulta pendiente",
     "executing-query": "Ejecutando consulta",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1812,6 +1812,11 @@
         "not-match": "データ ソースが一致しません。{expect} を期待しましたが、{actual} を取得しました。"
       }
     },
+    "batch-export": {
+      "self": "一括エクスポート",
+      "tooltip": "最新のクエリ結果を一括エクスポートするには、最大 {max} 個のデータベースを選択してください",
+      "failed-for-db": "{db} のデータのエクスポートに失敗しました"
+    },
     "execute-query": "クエリを実行する",
     "pending-query": "保留中のクエリ",
     "executing-query": "クエリの実行",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1812,6 +1812,11 @@
         "not-match": "Nguồn dữ liệu không khớp, mong đợi {expect} nhưng lại nhận được {actual}."
       }
     },
+    "batch-export": {
+      "self": "Xuất hàng loạt",
+      "tooltip": "Chọn tối đa {max} cơ sở dữ liệu để xuất hàng loạt kết quả truy vấn mới nhất",
+      "failed-for-db": "Không xuất được dữ liệu cho {db}"
+    },
     "execute-query": "Thực hiện truy vấn",
     "pending-query": "Đang chờ truy vấn",
     "executing-query": "Đang thực hiện truy vấn",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1812,6 +1812,11 @@
         "not-match": "数据源不匹配，预期为 {expect}，但实际使用 {actual}。"
       }
     },
+    "batch-export": {
+      "self": "批量导出",
+      "tooltip": "最多选择 {max} 个数据库，批量导出最后一次执行的查询结果",
+      "failed-for-db": "无法导出 {db} 的数据"
+    },
     "execute-query": "执行查询",
     "pending-query": "待处理查询",
     "executing-query": "执行查询",

--- a/frontend/src/store/modules/v1/auditLog.ts
+++ b/frontend/src/store/modules/v1/auditLog.ts
@@ -49,10 +49,12 @@ export const useAuditLogStore = defineStore("audit_log", () => {
     search,
     format,
     pageSize,
+    pageToken,
   }: {
     search: SearchAuditLogsParams;
     format: ExportFormat;
     pageSize: number;
+    pageToken: string;
   }): Promise<{
     content: BinaryLike | Blob;
     nextPageToken: string;
@@ -63,6 +65,7 @@ export const useAuditLogStore = defineStore("audit_log", () => {
       orderBy: search.order ? `create_time ${search.order}` : undefined,
       format,
       pageSize,
+      pageToken,
     });
   };
 

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -5,7 +5,6 @@
       <template #searchbox-suffix>
         <DataExportButton
           size="medium"
-          :file-type="'raw'"
           :support-formats="[
             ExportFormat.CSV,
             ExportFormat.JSON,
@@ -40,14 +39,16 @@
 <script lang="ts" setup>
 import dayjs from "dayjs";
 import { NEmpty } from "naive-ui";
-import type { BinaryLike } from "node:crypto";
 import { reactive, computed, watch, ref } from "vue";
 import type { ComponentExposed } from "vue-component-type-helpers";
 import { useI18n } from "vue-i18n";
 import AuditLogDataTable from "@/components/AuditLog/AuditLogDataTable.vue";
 import AuditLogSearch from "@/components/AuditLog/AuditLogSearch";
 import { buildSearchAuditLogParams } from "@/components/AuditLog/AuditLogSearch/utils";
-import type { ExportOption } from "@/components/DataExportButton.vue";
+import type {
+  ExportOption,
+  DownloadContent,
+} from "@/components/DataExportButton.vue";
 import DataExportButton from "@/components/DataExportButton.vue";
 import { FeatureAttention } from "@/components/FeatureGuard";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
@@ -55,7 +56,6 @@ import {
   featureToRef,
   useAuditLogStore,
   batchGetOrFetchProjects,
-  pushNotification,
   useUserStore,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
@@ -145,32 +145,37 @@ const disableExportTip = computed(() => {
   return "";
 });
 
-const handleExport = async (
-  options: ExportOption,
-  callback: (content: BinaryLike | Blob, filename: string) => void
-) => {
+const handleExport = async ({
+  options,
+  resolve,
+  reject,
+}: {
+  options: ExportOption;
+  reject: (reason?: any) => void;
+  resolve: (content: DownloadContent) => void;
+}) => {
   let pageToken = "";
   let i = 0;
+  const contents: DownloadContent = [];
 
-  while (i === 0 || pageToken !== "") {
-    i++;
-    const { content, nextPageToken } = await auditLogStore.exportAuditLogs({
-      search: searchAuditLogs.value,
-      format: options.format,
-      pageSize: 10000,
-    });
-    pageToken = nextPageToken;
-    callback(
-      content,
-      `audit-log${!pageToken && i === 1 ? "" : `.file${i}`}.${dayjs(new Date()).format("YYYY-MM-DDTHH-mm-ss")}`
-    );
+  try {
+    while (i === 0 || pageToken !== "") {
+      i++;
+      const { content, nextPageToken } = await auditLogStore.exportAuditLogs({
+        search: searchAuditLogs.value,
+        format: options.format,
+        pageSize: 1,
+        pageToken,
+      });
+      pageToken = nextPageToken;
+      contents.push({
+        content,
+        filename: `audit-log.file${i}.${dayjs(new Date()).format("YYYY-MM-DDTHH-mm-ss")}`,
+      });
+    }
+    resolve(contents);
+  } catch (err) {
+    reject(err);
   }
-
-  pushNotification({
-    module: "bytebase",
-    style: "SUCCESS",
-    title: t("common.success"),
-    description: t("audit-log.export-finished"),
-  });
 };
 </script>


### PR DESCRIPTION
Users can select limited (maximum 20) databases to export, I call it "batch export lite", and this should cover maybe 80% use case.
To real batch export a lot of databases or database group, they need to export via issue.

![CleanShot 2025-06-01 at 10 43 43](https://github.com/user-attachments/assets/1e6e1dd3-a4aa-4ff5-93d6-915c00a4df29)
