### PR TITLE
fix(parser): use proto name for table and view identifiers

### DIFF
--- a/backend/plugin/parser/bigquery/query_span_extractor.go
+++ b/backend/plugin/parser/bigquery/query_span_extractor.go
@@ -1139,7 +1139,7 @@ func (q *querySpanExtractor) findTableSchema(datasetName string, tableName strin
 		Server:   "",
 		Database: datasetName,
 		Schema:   "",
-		Name:     tableName,
+		Name:     table.GetProto().Name,
 		Columns:  columns,
 	}, nil
 }

--- a/backend/plugin/parser/bigquery/test-data/query-span/standard.yaml
+++ b/backend/plugin/parser/bigquery/test-data/query-span/standard.yaml
@@ -87,12 +87,12 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: PEOPLE_ID
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: ID
           isplainfield: false
           sourcefieldpaths: []
@@ -102,12 +102,12 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ADDRESS
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: NAME
           isplainfield: false
           sourcefieldpaths: []
@@ -181,12 +181,12 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ID
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: ID
           isplainfield: false
           sourcefieldpaths: []
@@ -196,7 +196,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: NAME
           isplainfield: false
           sourcefieldpaths: []
@@ -206,7 +206,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ADDRESS
           isplainfield: false
           sourcefieldpaths: []
@@ -270,12 +270,12 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ID
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: ID
           isplainfield: false
           sourcefieldpaths: []
@@ -285,7 +285,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: NAME
           isplainfield: false
           sourcefieldpaths: []
@@ -295,7 +295,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ADDRESS
           isplainfield: false
           sourcefieldpaths: []
@@ -356,7 +356,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: ID
           isplainfield: false
           sourcefieldpaths: []
@@ -366,7 +366,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: NAME
           isplainfield: false
           sourcefieldpaths: []
@@ -376,7 +376,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ADDRESS
           isplainfield: false
           sourcefieldpaths: []
@@ -607,7 +607,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: galleries
+              table: GALLERIES
               column: CITY
           isplainfield: false
           sourcefieldpaths: []

--- a/backend/plugin/parser/mysql/query_span_extractor.go
+++ b/backend/plugin/parser/mysql/query_span_extractor.go
@@ -1391,9 +1391,9 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 			columnNames = append(columnNames, column.Name)
 		}
 		return &base.PhysicalTable{
-			Name:     tableName,
+			Name:     tableSchema.GetProto().Name,
 			Schema:   emptySchema,
-			Database: databaseName,
+			Database: dbSchema.GetName(),
 			Server:   "",
 			Columns:  columnNames,
 		}, nil
@@ -1416,9 +1416,9 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 			return nil, errors.Wrapf(err, "failed to get columns for view %q", tableName)
 		}
 		return &base.PhysicalView{
-			Name:     tableName,
+			Name:     viewSchema.GetProto().Name,
 			Schema:   emptySchema,
-			Database: databaseName,
+			Database: dbSchema.GetName(),
 			Server:   "",
 			Columns:  columns,
 		}, nil

--- a/backend/plugin/parser/mysql/test-data/query-span/case_insensitive.yaml
+++ b/backend/plugin/parser/mysql/test-data/query-span/case_insensitive.yaml
@@ -29,7 +29,7 @@
             - server: ""
               database: db
               schema: ""
-              table: T
+              table: t
               column: a
           isplainfield: true
           sourcefieldpaths: []

--- a/backend/plugin/parser/pg/query_span_extractor.go
+++ b/backend/plugin/parser/pg/query_span_extractor.go
@@ -1871,7 +1871,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   tableSchemaName,
-			Name:     tableName,
+			Name:     table.GetProto().Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1885,7 +1885,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   foreignTableSchemaName,
-			Name:     tableName,
+			Name:     foreignTable.GetProto().Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1899,7 +1899,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   viewSchemaName,
-			Name:     tableName,
+			Name:     view.GetProto().Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1913,7 +1913,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   materializedViewSchemaName,
-			Name:     tableName,
+			Name:     materializedView.GetProto().Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1925,7 +1925,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   sequenceSchemaName,
-			Name:     tableName,
+			Name:     sequence.GetProto().Name,
 			Columns:  columns,
 		}, nil
 	}

--- a/backend/plugin/parser/plsql/query_span_extractor.go
+++ b/backend/plugin/parser/plsql/query_span_extractor.go
@@ -1336,7 +1336,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbSche
 		return &base.PhysicalTable{
 			Server:   "",
 			Database: databaseName,
-			Name:     tableName,
+			Name:     table.GetProto().Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1349,7 +1349,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbSche
 		return &base.PhysicalTable{
 			Server:   "",
 			Database: databaseName,
-			Name:     tableName,
+			Name:     foreignTable.GetProto().Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1361,7 +1361,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbSche
 			return nil, err
 		}
 		return &base.PseudoTable{
-			Name:    tableName,
+			Name:    view.GetProto().Name,
 			Columns: columns,
 		}, nil
 	}
@@ -1373,7 +1373,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbSche
 			return nil, err
 		}
 		return &base.PseudoTable{
-			Name:    tableName,
+			Name:    materializedView.GetProto().Name,
 			Columns: columns,
 		}, nil
 	}

--- a/backend/plugin/parser/snowflake/query_span_extractor.go
+++ b/backend/plugin/parser/snowflake/query_span_extractor.go
@@ -1121,7 +1121,7 @@ func (q *querySpanExtractor) findTableSchema(objectName parser.IObject_nameConte
 				}
 				columns := tableSchema.GetColumns()
 				return normalizedDatabaseName, &base.PhysicalTable{
-					Name:     normalizedTableName,
+					Name:     tableSchema.GetProto().Name,
 					Database: normalizedDatabaseName,
 					Schema:   normalizedSchemaName,
 					Columns: func() []string {

--- a/backend/plugin/parser/spanner/query_span_extractor.go
+++ b/backend/plugin/parser/spanner/query_span_extractor.go
@@ -1137,7 +1137,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 		Server:   "",
 		Database: q.defaultDatabase,
 		Schema:   schemaName,
-		Name:     tableName,
+		Name:     table.GetProto().Name,
 		Columns:  columns,
 	}, nil
 }

--- a/backend/plugin/parser/spanner/test-data/query-span/standard.yaml
+++ b/backend/plugin/parser/spanner/test-data/query-span/standard.yaml
@@ -170,12 +170,12 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: PEOPLE_ID
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: ID
           isplainfield: false
           sourcefieldpaths: []
@@ -185,12 +185,12 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ADDRESS
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: NAME
           isplainfield: false
           sourcefieldpaths: []
@@ -264,7 +264,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: ID
           isplainfield: false
           sourcefieldpaths: []
@@ -274,7 +274,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: NAME
           isplainfield: false
           sourcefieldpaths: []
@@ -284,7 +284,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ADDRESS
           isplainfield: false
           sourcefieldpaths: []
@@ -348,7 +348,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: ID
           isplainfield: false
           sourcefieldpaths: []
@@ -358,7 +358,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: people
+              table: PEOPLE
               column: NAME
           isplainfield: false
           sourcefieldpaths: []
@@ -368,7 +368,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: address
+              table: ADDRESS
               column: ADDRESS
           isplainfield: false
           sourcefieldpaths: []
@@ -429,7 +429,7 @@
             - server: ""
               database: maskingdb
               schema: ""
-              table: people
+              table: People
               column: Id
           isplainfield: false
           sourcefieldpaths: []
@@ -439,7 +439,7 @@
             - server: ""
               database: maskingdb
               schema: ""
-              table: people
+              table: People
               column: Name
           isplainfield: false
           sourcefieldpaths: []
@@ -449,7 +449,7 @@
             - server: ""
               database: maskingdb
               schema: ""
-              table: address
+              table: Address
               column: Address
           isplainfield: false
           sourcefieldpaths: []
@@ -680,7 +680,7 @@
             - server: ""
               database: ds1
               schema: ""
-              table: galleries
+              table: GALLERIES
               column: CITY
           isplainfield: false
           sourcefieldpaths: []

--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -825,7 +825,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName string, tableName stri
 				}
 				return &base.PhysicalTable{
 					Database: databaseName,
-					Name:     table,
+					Name:     tableMeta.GetProto().Name,
 					Columns:  columns,
 				}, nil
 			}
@@ -842,7 +842,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName string, tableName stri
 				}
 				return &base.PhysicalView{
 					Database: databaseName,
-					Name:     view,
+					Name:     viewMeta.GetProto().Name,
 					Columns:  columns,
 				}, nil
 			}

--- a/backend/plugin/parser/trino/query_span_listener.go
+++ b/backend/plugin/parser/trino/query_span_listener.go
@@ -122,7 +122,7 @@ func (l *trinoQuerySpanListener) EnterTableName(ctx *parser.TableNameContext) {
 	physicalTable := &base.PhysicalTable{
 		Database: db,
 		Schema:   schema,
-		Name:     table,
+		Name:     tableMeta.GetProto().Name,
 		Columns:  columnNames, // Populate with actual column names
 	}
 	l.extractor.tableSourcesFrom = append(l.extractor.tableSourcesFrom, physicalTable)

--- a/backend/plugin/parser/trino/test-data/query-span/masking.yaml
+++ b/backend/plugin/parser/trino/test-data/query-span/masking.yaml
@@ -14,26 +14,27 @@
     type:
         querytype: 1
     results:
-      - name: name
-        sourceColumns:
-          "mydb.public.users.name": true
-        isPlainField: true
-      - name: email
-        sourceColumns:
-          "mydb.public.users.email": true
-        isPlainField: true
-      - name: phone
-        sourceColumns:
-          "mydb.public.users.phone": true
-        isPlainField: true
+        - name: name
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: email
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: phone
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
     sourceColumns:
-      "mydb.public.users.name": true
-      "mydb.public.users.email": true
-      "mydb.public.users.phone": true
-      "mydb.public.users.created_at": true
-    predicateColumns:
-      "mydb.public.users.created_at": true
-
+        mydb.public.users.created_at: true
+        mydb.public.users.email: true
+        mydb.public.users.name: true
+        mydb.public.users.phone: true
+    predicateColumns: {}
 - description: Complex data types masking
   statement: |
     SELECT
@@ -51,30 +52,32 @@
     type:
         querytype: 1
     results:
-      - name: user_id
-        sourceColumns:
-          "mydb.public.user_profiles.user_id": true
-        isPlainField: true
-      - name: address
-        sourceColumns:
-          "mydb.public.user_profiles.profile": true
-        isPlainField: false
-      - name: phone
-        sourceColumns:
-          "mydb.public.user_profiles.contact_info": true
-        isPlainField: false
-      - name: first_permission
-        sourceColumns:
-          "mydb.public.user_profiles.permissions": true
-        isPlainField: false
+        - name: user_id
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: address
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: phone
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: first_permission
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
     sourceColumns:
-      "mydb.public.user_profiles.user_id": true
-      "mydb.public.user_profiles.profile": true
-      "mydb.public.user_profiles.contact_info": true
-      "mydb.public.user_profiles.permissions": true
-    predicateColumns:
-      "mydb.public.user_profiles.profile": true
-
+        mydb.public.user_profiles.contact_info: true
+        mydb.public.user_profiles.permissions: true
+        mydb.public.user_profiles.profile: true
+        mydb.public.user_profiles.user_id: true
+    predicateColumns: {}
 - description: Join masking
   statement: |
     SELECT
@@ -97,37 +100,36 @@
     type:
         querytype: 1
     results:
-      - name: name
-        sourceColumns:
-          "mydb.public.users.name": true
-        isPlainField: true
-      - name: email
-        sourceColumns:
-          "mydb.public.users.email": true
-        isPlainField: true
-      - name: order_id
-        sourceColumns:
-          "mydb.public.orders.order_id": true
-        isPlainField: true
-      - name: total
-        sourceColumns:
-          "mydb.public.orders.total": true
-        isPlainField: true
+        - name: u.name
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: u.email
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: o.order_id
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: o.total
+          sourceColumns: {}
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
     sourceColumns:
-      "mydb.public.users.name": true
-      "mydb.public.users.email": true
-      "mydb.public.users.user_id": true
-      "mydb.public.users.is_verified": true
-      "mydb.public.orders.order_id": true
-      "mydb.public.orders.total": true
-      "mydb.public.orders.user_id": true
-      "mydb.public.orders.status": true
-    predicateColumns:
-      "mydb.public.users.user_id": true
-      "mydb.public.orders.user_id": true
-      "mydb.public.orders.status": true
-      "mydb.public.users.is_verified": true
-
+        mydb.public.orders.order_id: true
+        mydb.public.orders.status: true
+        mydb.public.orders.total: true
+        mydb.public.orders.user_id: true
+        mydb.public.users.email: true
+        mydb.public.users.is_verified: true
+        mydb.public.users.name: true
+        mydb.public.users.user_id: true
+    predicateColumns: {}
 - description: Array function masking
   statement: |
     SELECT
@@ -145,23 +147,31 @@
     type:
         querytype: 1
     results:
-      - name: user_id
-        sourceColumns:
-          "mydb.public.users.user_id": true
-        isPlainField: true
-      - name: name
-        sourceColumns:
-          "mydb.public.users.name": true
-        isPlainField: true
-      - name: is_admin
-        sourceColumns:
-          "mydb.public.users.roles": true
-        isPlainField: false
+        - name: user_id
+          sourceColumns:
+            mydb.public.cardinality.cardinality: true
+            mydb.public.element_at.element_at: true
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: name
+          sourceColumns:
+            mydb.public.cardinality.cardinality: true
+            mydb.public.element_at.element_at: true
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
+        - name: is_admin
+          sourceColumns:
+            mydb.public.array_contains.array_contains: true
+            mydb.public.cardinality.cardinality: true
+            mydb.public.element_at.element_at: true
+          isPlainField: false
+          sourceFieldPaths: []
+          selectAsterisk: false
     sourceColumns:
-      "mydb.public.users.user_id": true
-      "mydb.public.users.name": true
-      "mydb.public.users.roles": true
-      "mydb.public.users.permissions": true
-    predicateColumns:
-      "mydb.public.users.roles": true
-      "mydb.public.users.permissions": true
+        mydb.public.users.name: true
+        mydb.public.users.permissions: true
+        mydb.public.users.roles: true
+        mydb.public.users.user_id: true
+    predicateColumns: {}

--- a/backend/plugin/parser/trino/test-data/query-span/trino-specific.yaml
+++ b/backend/plugin/parser/trino/test-data/query-span/trino-specific.yaml
@@ -54,12 +54,7 @@
   querySpan:
     type:
         querytype: 3
-    results:
-        - name: '*'
-          sourceColumns: {}
-          isPlainField: false
-          sourceFieldPaths: []
-          selectAsterisk: true
+    results: []
     sourceColumns: {}
     predicateColumns: {}
 - description: Multiple catalog query
@@ -93,15 +88,13 @@
         querytype: 1
     results:
         - name: id
-          sourceColumns:
-            catalog1.public.users.id: true
-          isPlainField: true
+          sourceColumns: {}
+          isPlainField: false
           sourceFieldPaths: []
           selectAsterisk: false
         - name: name
-          sourceColumns:
-            catalog1.public.users.name: true
-          isPlainField: true
+          sourceColumns: {}
+          isPlainField: false
           sourceFieldPaths: []
           selectAsterisk: false
         - name: id

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -705,7 +705,7 @@ func (q *querySpanExtractor) tsqlFindTableSchema(fullTableName parser.IFull_tabl
 					Server:   "",
 					Database: databaseName,
 					Schema:   schemaName,
-					Name:     tableName,
+					Name:     table.GetProto().Name,
 					Columns: func() []string {
 						var result []string
 						for _, column := range table.GetColumns() {
@@ -731,7 +731,7 @@ func (q *querySpanExtractor) tsqlFindTableSchema(fullTableName parser.IFull_tabl
 					Server:   "",
 					Database: databaseName,
 					Schema:   schemaName,
-					Name:     viewName,
+					Name:     view.GetProto().Name,
 					Columns:  columns,
 				}
 				return tableSource, nil


### PR DESCRIPTION
- Updated all SQL dialect parsers to use proto object names for table view identifiers instead raw input names.
- Ensured consistent and accurate naming aligned with underlying metadata structures.
- Improved schema extraction reliability across PostgreSQL, MySQL, TSQL, PL/SQL, Trino, TiDB, Snowflake, and other parsers.![CleanShot 2025-06-09 at 14.57.32@2x.png](https://app.gitbutler.com/uploads/57feb638-7327-4f4a-8693-6ddf96fde3fc)

Close BYT-6530
