### PR TITLE
fix: cmux grpc

### DIFF
--- a/backend/server/grpc_routes.go
+++ b/backend/server/grpc_routes.go
@@ -128,7 +128,9 @@ func configureGrpcRouters(
 	}
 
 	// Sort by service name, align with api.bytebase.com.
-	// ActuatorService uses Connect RPC only, no gRPC gateway handler needed
+	if err := v1pb.RegisterActuatorServiceHandler(ctx, mux, grpcConn); err != nil {
+		return nil, err
+	}
 	if err := v1pb.RegisterUserServiceHandler(ctx, mux, grpcConn); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
During the migration, the migrated services are not registered and not available on the grpc server.
When we complete the migration, the grpc traffic will be directed to connect rpc handlers. The connect rpc can talk multiple protocols, so only echo server is needed. The routes setup will be simplified.
```
{
  "code": 12,
  "message": "unknown service bytebase.v1.ActuatorService"
}
```