### PR TITLE
feat: add Redshift support for table drop naming convention

### DIFF
--- a/backend/common/engine.go
+++ b/backend/common/engine.go
@@ -181,7 +181,8 @@ func EngineSupportStatementAdvise(e storepb.Engine) bool {
 		storepb.Engine_SNOWFLAKE,
 		storepb.Engine_MSSQL,
 		storepb.Engine_DYNAMODB,
-		storepb.Engine_COCKROACHDB:
+		storepb.Engine_COCKROACHDB,
+		storepb.Engine_REDSHIFT:
 		return true
 	case
 		storepb.Engine_ENGINE_UNSPECIFIED,
@@ -193,7 +194,6 @@ func EngineSupportStatementAdvise(e storepb.Engine) bool {
 		storepb.Engine_CLICKHOUSE,
 		storepb.Engine_SPANNER,
 		storepb.Engine_BIGQUERY,
-		storepb.Engine_REDSHIFT,
 		storepb.Engine_MARIADB,
 		storepb.Engine_STARROCKS,
 		storepb.Engine_RISINGWAVE,

--- a/backend/plugin/advisor/pg/advisor_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/pg/advisor_table_drop_naming_convention.go
@@ -22,6 +22,7 @@ var (
 
 func init() {
 	advisor.Register(storepb.Engine_POSTGRES, advisor.PostgreSQLTableDropNamingConvention, &TableDropNamingConventionAdvisor{})
+	advisor.Register(storepb.Engine_REDSHIFT, advisor.PostgreSQLTableDropNamingConvention, &TableDropNamingConventionAdvisor{})
 }
 
 // TableDropNamingConventionAdvisor is the advisor checking for table drop with naming convention.

--- a/backend/plugin/advisor/sql_review.go
+++ b/backend/plugin/advisor/sql_review.go
@@ -1121,7 +1121,7 @@ func getAdvisorTypeByRule(ruleType SQLReviewRuleType, engine storepb.Engine) (Ty
 		switch engine {
 		case storepb.Engine_MYSQL, storepb.Engine_TIDB, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE:
 			return MySQLTableDropNamingConvention, nil
-		case storepb.Engine_POSTGRES:
+		case storepb.Engine_POSTGRES, storepb.Engine_REDSHIFT:
 			return PostgreSQLTableDropNamingConvention, nil
 		case storepb.Engine_SNOWFLAKE:
 			return SnowflakeTableDropNamingConvention, nil

--- a/frontend/src/types/sql-review-schema.yaml
+++ b/frontend/src/types/sql-review-schema.yaml
@@ -105,6 +105,14 @@
       payload:
         type: STRING
         default: _del$
+  engine: REDSHIFT
+- type: table.drop-naming-convention
+  category: TABLE
+  componentList:
+    - key: format
+      payload:
+        type: STRING
+        default: _del$
   engine: MSSQL
 - type: table.drop-naming-convention
   category: TABLE


### PR DESCRIPTION
Add Redshift engine support to the table drop naming convention advisor by
registering it alongside PostgreSQL. Update the SQL review schema to include
Redshift for this rule type.