### PR TITLE
chore(identity-provider): add detailed delete confirmation message

### DIFF
--- a/frontend/src/components/IdentityProvider/IdentityProviderEditForm.vue
+++ b/frontend/src/components/IdentityProvider/IdentityProviderEditForm.vue
@@ -207,7 +207,7 @@
               :button-text="$t('settings.sso.delete')"
               :ok-text="$t('common.delete')"
               :confirm-title="$t('settings.sso.delete')"
-              :confirm-description="$t('common.cannot-undo-this-action')"
+              :confirm-description="deleteConfirmDescription"
               :require-confirm="true"
               @confirm="handleDelete"
             />
@@ -382,6 +382,10 @@ const canUpdate = computed(() => {
 
 const allowTestConnection = computed(() => {
   return isFormValid.value;
+});
+
+const deleteConfirmDescription = computed(() => {
+  return t("identity-provider.delete-warning");
 });
 
 // Methods

--- a/frontend/src/components/IdentityProvider/IdentityProviderEditForm.vue
+++ b/frontend/src/components/IdentityProvider/IdentityProviderEditForm.vue
@@ -207,7 +207,7 @@
               :button-text="$t('settings.sso.delete')"
               :ok-text="$t('common.delete')"
               :confirm-title="$t('settings.sso.delete')"
-              :confirm-description="deleteConfirmDescription"
+              :confirm-description="t('identity-provider.delete-warning')"
               :require-confirm="true"
               @confirm="handleDelete"
             />
@@ -382,10 +382,6 @@ const canUpdate = computed(() => {
 
 const allowTestConnection = computed(() => {
   return isFormValid.value;
-});
-
-const deleteConfirmDescription = computed(() => {
-  return t("identity-provider.delete-warning");
 });
 
 // Methods

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2308,7 +2308,8 @@
     "identity-provider-update-failed": "Failed to update identity provider",
     "identity-provider-create-failed": "Failed to create identity provider",
     "identity-provider-delete-failed": "Failed to delete identity provider",
-    "identity-provider-permission-denied": "Permission denied"
+    "identity-provider-permission-denied": "Permission denied",
+    "delete-warning": "Are you sure you want to delete this identity provider? Users who signed up via this SSO will not be able to sign in with it anymore. If password sign-in is disabled in your workspace settings, these users may be locked out completely."
   },
   "sensitive-data": {
     "self": "Sensitive Data"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2308,7 +2308,8 @@
     "identity-provider-update-failed": "No se pudo actualizar el proveedor de identidad",
     "identity-provider-create-failed": "No se pudo crear el proveedor de identidad",
     "identity-provider-delete-failed": "No se pudo eliminar el proveedor de identidad",
-    "identity-provider-permission-denied": "Permiso denegado"
+    "identity-provider-permission-denied": "Permiso denegado",
+    "delete-warning": "¿Seguro que desea eliminar este proveedor de identidad? Los usuarios que se registraron con este SSO ya no podrán iniciar sesión con él. Si el inicio de sesión con contraseña está deshabilitado en la configuración de su espacio de trabajo, es posible que estos usuarios queden completamente bloqueados."
   },
   "sensitive-data": {
     "self": "Datos Sensibles"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2308,7 +2308,8 @@
     "identity-provider-update-failed": "IDプロバイダの更新に失敗しました",
     "identity-provider-create-failed": "IDプロバイダの作成に失敗しました",
     "identity-provider-delete-failed": "IDプロバイダの削除に失敗しました",
-    "identity-provider-permission-denied": "許可が拒否されました"
+    "identity-provider-permission-denied": "許可が拒否されました",
+    "delete-warning": "このアイデンティティプロバイダを削除してもよろしいですか？このSSO経由でサインアップしたユーザーは、今後このSSOでサインインできなくなります。ワークスペースの設定でパスワードによるサインインが無効になっている場合、これらのユーザーは完全にロックアウトされる可能性があります。"
   },
   "sensitive-data": {
     "self": "機密データ"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2308,7 +2308,8 @@
     "identity-provider-update-failed": "Không cập nhật được nhà cung cấp danh tính",
     "identity-provider-create-failed": "Không tạo được nhà cung cấp danh tính",
     "identity-provider-delete-failed": "Không xóa được nhà cung cấp danh tính",
-    "identity-provider-permission-denied": "Quyền bị từ chối"
+    "identity-provider-permission-denied": "Quyền bị từ chối",
+    "delete-warning": "Bạn có chắc chắn muốn xóa nhà cung cấp danh tính này không? Người dùng đã đăng ký qua SSO này sẽ không thể đăng nhập bằng SSO này nữa. Nếu đăng nhập bằng mật khẩu bị vô hiệu hóa trong cài đặt không gian làm việc của bạn, những người dùng này có thể bị khóa hoàn toàn."
   },
   "sensitive-data": {
     "self": "Dữ liệu nhạy cảm"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2308,7 +2308,8 @@
     "identity-provider-update-failed": "无法更新身份提供商",
     "identity-provider-create-failed": "无法创建身份提供商",
     "identity-provider-delete-failed": "无法删除身份提供商",
-    "identity-provider-permission-denied": "没有权限"
+    "identity-provider-permission-denied": "没有权限",
+    "delete-warning": "您确定要删除此身份提供者吗？通过此 SSO 注册的用户将无法再使用该身份提供者登录。如果您在工作区设置中禁用了密码登录，这些用户可能会被完全锁定。"
   },
   "sensitive-data": {
     "self": "敏感数据"


### PR DESCRIPTION
Detailed warning explaining the impact of deleting an identity provider, including potential user lockout if password sign-in is disabled