### PR TITLE
feat: Add permissions required documentation at source of truth for B…

### DIFF
--- a/frontend/src/types/proto-es/v1/actuator_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/actuator_service_pb.d.ts
@@ -306,7 +306,7 @@ export declare const ActuatorService: GenService<{
     output: typeof ActuatorInfoSchema;
   },
   /**
-   * Permissions required: settings.set
+   * Permissions required: bb.settings.set
    *
    * @generated from rpc bytebase.v1.ActuatorService.UpdateActuatorInfo
    */
@@ -316,7 +316,7 @@ export declare const ActuatorService: GenService<{
     output: typeof ActuatorInfoSchema;
   },
   /**
-   * Permissions required: projects.create
+   * Permissions required: bb.projects.create
    *
    * @generated from rpc bytebase.v1.ActuatorService.SetupSample
    */

--- a/frontend/src/types/proto-es/v1/actuator_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/actuator_service_pb.d.ts
@@ -296,6 +296,8 @@ export declare const ActuatorInfo_StatUserSchema: GenMessage<ActuatorInfo_StatUs
  */
 export declare const ActuatorService: GenService<{
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.ActuatorService.GetActuatorInfo
    */
   getActuatorInfo: {
@@ -304,6 +306,8 @@ export declare const ActuatorService: GenService<{
     output: typeof ActuatorInfoSchema;
   },
   /**
+   * Permissions required: settings.set
+   *
    * @generated from rpc bytebase.v1.ActuatorService.UpdateActuatorInfo
    */
   updateActuatorInfo: {
@@ -312,6 +316,8 @@ export declare const ActuatorService: GenService<{
     output: typeof ActuatorInfoSchema;
   },
   /**
+   * Permissions required: projects.create
+   *
    * @generated from rpc bytebase.v1.ActuatorService.SetupSample
    */
   setupSample: {
@@ -320,6 +326,8 @@ export declare const ActuatorService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.ActuatorService.DeleteCache
    */
   deleteCache: {
@@ -328,6 +336,8 @@ export declare const ActuatorService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.ActuatorService.GetResourcePackage
    */
   getResourcePackage: {

--- a/frontend/src/types/proto-es/v1/audit_log_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/audit_log_service_pb.d.ts
@@ -379,6 +379,8 @@ export declare const RequestMetadataSchema: GenMessage<RequestMetadata>;
  */
 export declare const AuditLogService: GenService<{
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.AuditLogService.SearchAuditLogs
    */
   searchAuditLogs: {
@@ -387,6 +389,8 @@ export declare const AuditLogService: GenService<{
     output: typeof SearchAuditLogsResponseSchema;
   },
   /**
+   * Permissions required: auditLogs.export
+   *
    * @generated from rpc bytebase.v1.AuditLogService.ExportAuditLogs
    */
   exportAuditLogs: {

--- a/frontend/src/types/proto-es/v1/audit_log_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/audit_log_service_pb.d.ts
@@ -389,7 +389,7 @@ export declare const AuditLogService: GenService<{
     output: typeof SearchAuditLogsResponseSchema;
   },
   /**
-   * Permissions required: auditLogs.export
+   * Permissions required: bb.auditLogs.export
    *
    * @generated from rpc bytebase.v1.AuditLogService.ExportAuditLogs
    */

--- a/frontend/src/types/proto-es/v1/auth_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/auth_service_pb.d.ts
@@ -182,6 +182,8 @@ export declare const LogoutRequestSchema: GenMessage<LogoutRequest>;
  */
 export declare const AuthService: GenService<{
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.AuthService.Login
    */
   login: {
@@ -190,6 +192,8 @@ export declare const AuthService: GenService<{
     output: typeof LoginResponseSchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.AuthService.Logout
    */
   logout: {

--- a/frontend/src/types/proto-es/v1/cel_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/cel_service_pb.d.ts
@@ -80,6 +80,8 @@ export declare const BatchDeparseResponseSchema: GenMessage<BatchDeparseResponse
  */
 export declare const CelService: GenService<{
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.CelService.BatchParse
    */
   batchParse: {
@@ -88,6 +90,8 @@ export declare const CelService: GenService<{
     output: typeof BatchParseResponseSchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.CelService.BatchDeparse
    */
   batchDeparse: {

--- a/frontend/src/types/proto-es/v1/changelist_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/changelist_service_pb.d.ts
@@ -259,7 +259,7 @@ export declare const Changelist_ChangeSchema: GenMessage<Changelist_Change>;
  */
 export declare const ChangelistService: GenService<{
   /**
-   * Permissions required: changelists.create
+   * Permissions required: bb.changelists.create
    *
    * @generated from rpc bytebase.v1.ChangelistService.CreateChangelist
    */
@@ -269,7 +269,7 @@ export declare const ChangelistService: GenService<{
     output: typeof ChangelistSchema;
   },
   /**
-   * Permissions required: changelists.get
+   * Permissions required: bb.changelists.get
    *
    * @generated from rpc bytebase.v1.ChangelistService.GetChangelist
    */
@@ -279,7 +279,7 @@ export declare const ChangelistService: GenService<{
     output: typeof ChangelistSchema;
   },
   /**
-   * Permissions required: changelists.list
+   * Permissions required: bb.changelists.list
    *
    * @generated from rpc bytebase.v1.ChangelistService.ListChangelists
    */
@@ -289,7 +289,7 @@ export declare const ChangelistService: GenService<{
     output: typeof ListChangelistsResponseSchema;
   },
   /**
-   * Permissions required: changelists.update
+   * Permissions required: bb.changelists.update
    *
    * @generated from rpc bytebase.v1.ChangelistService.UpdateChangelist
    */
@@ -299,7 +299,7 @@ export declare const ChangelistService: GenService<{
     output: typeof ChangelistSchema;
   },
   /**
-   * Permissions required: changelists.delete
+   * Permissions required: bb.changelists.delete
    *
    * @generated from rpc bytebase.v1.ChangelistService.DeleteChangelist
    */

--- a/frontend/src/types/proto-es/v1/changelist_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/changelist_service_pb.d.ts
@@ -259,6 +259,8 @@ export declare const Changelist_ChangeSchema: GenMessage<Changelist_Change>;
  */
 export declare const ChangelistService: GenService<{
   /**
+   * Permissions required: changelists.create
+   *
    * @generated from rpc bytebase.v1.ChangelistService.CreateChangelist
    */
   createChangelist: {
@@ -267,6 +269,8 @@ export declare const ChangelistService: GenService<{
     output: typeof ChangelistSchema;
   },
   /**
+   * Permissions required: changelists.get
+   *
    * @generated from rpc bytebase.v1.ChangelistService.GetChangelist
    */
   getChangelist: {
@@ -275,6 +279,8 @@ export declare const ChangelistService: GenService<{
     output: typeof ChangelistSchema;
   },
   /**
+   * Permissions required: changelists.list
+   *
    * @generated from rpc bytebase.v1.ChangelistService.ListChangelists
    */
   listChangelists: {
@@ -283,6 +289,8 @@ export declare const ChangelistService: GenService<{
     output: typeof ListChangelistsResponseSchema;
   },
   /**
+   * Permissions required: changelists.update
+   *
    * @generated from rpc bytebase.v1.ChangelistService.UpdateChangelist
    */
   updateChangelist: {
@@ -291,6 +299,8 @@ export declare const ChangelistService: GenService<{
     output: typeof ChangelistSchema;
   },
   /**
+   * Permissions required: changelists.delete
+   *
    * @generated from rpc bytebase.v1.ChangelistService.DeleteChangelist
    */
   deleteChangelist: {

--- a/frontend/src/types/proto-es/v1/database_catalog_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/database_catalog_service_pb.d.ts
@@ -302,6 +302,8 @@ export declare const ObjectSchema_TypeSchema: GenEnum<ObjectSchema_Type>;
  */
 export declare const DatabaseCatalogService: GenService<{
   /**
+   * Permissions required: databaseCatalogs.get
+   *
    * @generated from rpc bytebase.v1.DatabaseCatalogService.GetDatabaseCatalog
    */
   getDatabaseCatalog: {
@@ -310,6 +312,8 @@ export declare const DatabaseCatalogService: GenService<{
     output: typeof DatabaseCatalogSchema;
   },
   /**
+   * Permissions required: databaseCatalogs.update
+   *
    * @generated from rpc bytebase.v1.DatabaseCatalogService.UpdateDatabaseCatalog
    */
   updateDatabaseCatalog: {

--- a/frontend/src/types/proto-es/v1/database_catalog_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/database_catalog_service_pb.d.ts
@@ -302,7 +302,7 @@ export declare const ObjectSchema_TypeSchema: GenEnum<ObjectSchema_Type>;
  */
 export declare const DatabaseCatalogService: GenService<{
   /**
-   * Permissions required: databaseCatalogs.get
+   * Permissions required: bb.databaseCatalogs.get
    *
    * @generated from rpc bytebase.v1.DatabaseCatalogService.GetDatabaseCatalog
    */
@@ -312,7 +312,7 @@ export declare const DatabaseCatalogService: GenService<{
     output: typeof DatabaseCatalogSchema;
   },
   /**
-   * Permissions required: databaseCatalogs.update
+   * Permissions required: bb.databaseCatalogs.update
    *
    * @generated from rpc bytebase.v1.DatabaseCatalogService.UpdateDatabaseCatalog
    */

--- a/frontend/src/types/proto-es/v1/database_group_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/database_group_service_pb.d.ts
@@ -317,7 +317,7 @@ export declare const DatabaseGroupViewSchema: GenEnum<DatabaseGroupView>;
  */
 export declare const DatabaseGroupService: GenService<{
   /**
-   * Permissions required: projects.get
+   * Permissions required: bb.projects.get
    *
    * @generated from rpc bytebase.v1.DatabaseGroupService.ListDatabaseGroups
    */
@@ -327,7 +327,7 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof ListDatabaseGroupsResponseSchema;
   },
   /**
-   * Permissions required: projects.get
+   * Permissions required: bb.projects.get
    *
    * @generated from rpc bytebase.v1.DatabaseGroupService.GetDatabaseGroup
    */
@@ -337,7 +337,7 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof DatabaseGroupSchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.DatabaseGroupService.CreateDatabaseGroup
    */
@@ -347,7 +347,7 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof DatabaseGroupSchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.DatabaseGroupService.UpdateDatabaseGroup
    */
@@ -357,7 +357,7 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof DatabaseGroupSchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.DatabaseGroupService.DeleteDatabaseGroup
    */

--- a/frontend/src/types/proto-es/v1/database_group_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/database_group_service_pb.d.ts
@@ -317,6 +317,8 @@ export declare const DatabaseGroupViewSchema: GenEnum<DatabaseGroupView>;
  */
 export declare const DatabaseGroupService: GenService<{
   /**
+   * Permissions required: projects.get
+   *
    * @generated from rpc bytebase.v1.DatabaseGroupService.ListDatabaseGroups
    */
   listDatabaseGroups: {
@@ -325,6 +327,8 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof ListDatabaseGroupsResponseSchema;
   },
   /**
+   * Permissions required: projects.get
+   *
    * @generated from rpc bytebase.v1.DatabaseGroupService.GetDatabaseGroup
    */
   getDatabaseGroup: {
@@ -333,6 +337,8 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof DatabaseGroupSchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.DatabaseGroupService.CreateDatabaseGroup
    */
   createDatabaseGroup: {
@@ -341,6 +347,8 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof DatabaseGroupSchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.DatabaseGroupService.UpdateDatabaseGroup
    */
   updateDatabaseGroup: {
@@ -349,6 +357,8 @@ export declare const DatabaseGroupService: GenService<{
     output: typeof DatabaseGroupSchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.DatabaseGroupService.DeleteDatabaseGroup
    */
   deleteDatabaseGroup: {

--- a/frontend/src/types/proto-es/v1/database_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/database_service_pb.d.ts
@@ -3191,7 +3191,7 @@ export declare const ChangelogViewSchema: GenEnum<ChangelogView>;
  */
 export declare const DatabaseService: GenService<{
   /**
-   * Permissions required: databases.get
+   * Permissions required: bb.databases.get
    *
    * @generated from rpc bytebase.v1.DatabaseService.GetDatabase
    */
@@ -3201,7 +3201,7 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseSchema$;
   },
   /**
-   * Permissions required: databases.get
+   * Permissions required: bb.databases.get
    *
    * @generated from rpc bytebase.v1.DatabaseService.BatchGetDatabases
    */
@@ -3211,7 +3211,7 @@ export declare const DatabaseService: GenService<{
     output: typeof BatchGetDatabasesResponseSchema;
   },
   /**
-   * Permissions required: databases.list
+   * Permissions required: bb.databases.list
    *
    * @generated from rpc bytebase.v1.DatabaseService.ListDatabases
    */
@@ -3221,7 +3221,7 @@ export declare const DatabaseService: GenService<{
     output: typeof ListDatabasesResponseSchema;
   },
   /**
-   * Permissions required: databases.update
+   * Permissions required: bb.databases.update
    *
    * @generated from rpc bytebase.v1.DatabaseService.UpdateDatabase
    */
@@ -3231,7 +3231,7 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseSchema$;
   },
   /**
-   * Permissions required: databases.update
+   * Permissions required: bb.databases.update
    *
    * @generated from rpc bytebase.v1.DatabaseService.BatchUpdateDatabases
    */
@@ -3241,7 +3241,7 @@ export declare const DatabaseService: GenService<{
     output: typeof BatchUpdateDatabasesResponseSchema;
   },
   /**
-   * Permissions required: databases.sync
+   * Permissions required: bb.databases.sync
    *
    * @generated from rpc bytebase.v1.DatabaseService.SyncDatabase
    */
@@ -3251,7 +3251,7 @@ export declare const DatabaseService: GenService<{
     output: typeof SyncDatabaseResponseSchema;
   },
   /**
-   * Permissions required: databases.sync
+   * Permissions required: bb.databases.sync
    *
    * @generated from rpc bytebase.v1.DatabaseService.BatchSyncDatabases
    */
@@ -3261,7 +3261,7 @@ export declare const DatabaseService: GenService<{
     output: typeof BatchSyncDatabasesResponseSchema;
   },
   /**
-   * Permissions required: databases.getSchema
+   * Permissions required: bb.databases.getSchema
    *
    * @generated from rpc bytebase.v1.DatabaseService.GetDatabaseMetadata
    */
@@ -3271,7 +3271,7 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseMetadataSchema;
   },
   /**
-   * Permissions required: databases.getSchema
+   * Permissions required: bb.databases.getSchema
    *
    * @generated from rpc bytebase.v1.DatabaseService.GetDatabaseSchema
    */
@@ -3281,7 +3281,7 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseSchemaSchema;
   },
   /**
-   * Permissions required: databases.get
+   * Permissions required: bb.databases.get
    *
    * @generated from rpc bytebase.v1.DatabaseService.DiffSchema
    */
@@ -3291,7 +3291,7 @@ export declare const DatabaseService: GenService<{
     output: typeof DiffSchemaResponseSchema;
   },
   /**
-   * Permissions required: databaseSecrets.list
+   * Permissions required: bb.databaseSecrets.list
    *
    * @generated from rpc bytebase.v1.DatabaseService.ListSecrets
    */
@@ -3301,7 +3301,7 @@ export declare const DatabaseService: GenService<{
     output: typeof ListSecretsResponseSchema;
   },
   /**
-   * Permissions required: databaseSecrets.update
+   * Permissions required: bb.databaseSecrets.update
    *
    * @generated from rpc bytebase.v1.DatabaseService.UpdateSecret
    */
@@ -3311,7 +3311,7 @@ export declare const DatabaseService: GenService<{
     output: typeof SecretSchema;
   },
   /**
-   * Permissions required: databaseSecrets.delete
+   * Permissions required: bb.databaseSecrets.delete
    *
    * @generated from rpc bytebase.v1.DatabaseService.DeleteSecret
    */
@@ -3321,7 +3321,7 @@ export declare const DatabaseService: GenService<{
     output: typeof EmptySchema;
   },
   /**
-   * Permissions required: changelogs.list
+   * Permissions required: bb.changelogs.list
    *
    * @generated from rpc bytebase.v1.DatabaseService.ListChangelogs
    */

--- a/frontend/src/types/proto-es/v1/database_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/database_service_pb.d.ts
@@ -3191,6 +3191,8 @@ export declare const ChangelogViewSchema: GenEnum<ChangelogView>;
  */
 export declare const DatabaseService: GenService<{
   /**
+   * Permissions required: databases.get
+   *
    * @generated from rpc bytebase.v1.DatabaseService.GetDatabase
    */
   getDatabase: {
@@ -3199,6 +3201,8 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseSchema$;
   },
   /**
+   * Permissions required: databases.get
+   *
    * @generated from rpc bytebase.v1.DatabaseService.BatchGetDatabases
    */
   batchGetDatabases: {
@@ -3207,6 +3211,8 @@ export declare const DatabaseService: GenService<{
     output: typeof BatchGetDatabasesResponseSchema;
   },
   /**
+   * Permissions required: databases.list
+   *
    * @generated from rpc bytebase.v1.DatabaseService.ListDatabases
    */
   listDatabases: {
@@ -3215,6 +3221,8 @@ export declare const DatabaseService: GenService<{
     output: typeof ListDatabasesResponseSchema;
   },
   /**
+   * Permissions required: databases.update
+   *
    * @generated from rpc bytebase.v1.DatabaseService.UpdateDatabase
    */
   updateDatabase: {
@@ -3223,6 +3231,8 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseSchema$;
   },
   /**
+   * Permissions required: databases.update
+   *
    * @generated from rpc bytebase.v1.DatabaseService.BatchUpdateDatabases
    */
   batchUpdateDatabases: {
@@ -3231,6 +3241,8 @@ export declare const DatabaseService: GenService<{
     output: typeof BatchUpdateDatabasesResponseSchema;
   },
   /**
+   * Permissions required: databases.sync
+   *
    * @generated from rpc bytebase.v1.DatabaseService.SyncDatabase
    */
   syncDatabase: {
@@ -3239,6 +3251,8 @@ export declare const DatabaseService: GenService<{
     output: typeof SyncDatabaseResponseSchema;
   },
   /**
+   * Permissions required: databases.sync
+   *
    * @generated from rpc bytebase.v1.DatabaseService.BatchSyncDatabases
    */
   batchSyncDatabases: {
@@ -3247,6 +3261,8 @@ export declare const DatabaseService: GenService<{
     output: typeof BatchSyncDatabasesResponseSchema;
   },
   /**
+   * Permissions required: databases.getSchema
+   *
    * @generated from rpc bytebase.v1.DatabaseService.GetDatabaseMetadata
    */
   getDatabaseMetadata: {
@@ -3255,6 +3271,8 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseMetadataSchema;
   },
   /**
+   * Permissions required: databases.getSchema
+   *
    * @generated from rpc bytebase.v1.DatabaseService.GetDatabaseSchema
    */
   getDatabaseSchema: {
@@ -3263,6 +3281,8 @@ export declare const DatabaseService: GenService<{
     output: typeof DatabaseSchemaSchema;
   },
   /**
+   * Permissions required: databases.get
+   *
    * @generated from rpc bytebase.v1.DatabaseService.DiffSchema
    */
   diffSchema: {
@@ -3271,6 +3291,8 @@ export declare const DatabaseService: GenService<{
     output: typeof DiffSchemaResponseSchema;
   },
   /**
+   * Permissions required: databaseSecrets.list
+   *
    * @generated from rpc bytebase.v1.DatabaseService.ListSecrets
    */
   listSecrets: {
@@ -3279,6 +3301,8 @@ export declare const DatabaseService: GenService<{
     output: typeof ListSecretsResponseSchema;
   },
   /**
+   * Permissions required: databaseSecrets.update
+   *
    * @generated from rpc bytebase.v1.DatabaseService.UpdateSecret
    */
   updateSecret: {
@@ -3287,6 +3311,8 @@ export declare const DatabaseService: GenService<{
     output: typeof SecretSchema;
   },
   /**
+   * Permissions required: databaseSecrets.delete
+   *
    * @generated from rpc bytebase.v1.DatabaseService.DeleteSecret
    */
   deleteSecret: {
@@ -3295,6 +3321,8 @@ export declare const DatabaseService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: changelogs.list
+   *
    * @generated from rpc bytebase.v1.DatabaseService.ListChangelogs
    */
   listChangelogs: {
@@ -3303,6 +3331,8 @@ export declare const DatabaseService: GenService<{
     output: typeof ListChangelogsResponseSchema;
   },
   /**
+   * Permissions required: changelogs.get
+   *
    * @generated from rpc bytebase.v1.DatabaseService.GetChangelog
    */
   getChangelog: {
@@ -3311,6 +3341,8 @@ export declare const DatabaseService: GenService<{
     output: typeof ChangelogSchema;
   },
   /**
+   * Permissions required: databases.getSchema
+   *
    * @generated from rpc bytebase.v1.DatabaseService.GetSchemaString
    */
   getSchemaString: {

--- a/frontend/src/types/proto-es/v1/group_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/group_service_pb.d.ts
@@ -267,7 +267,7 @@ export declare const GroupSchema: GenMessage<Group>;
  */
 export declare const GroupService: GenService<{
   /**
-   * Permissions required: groups.get
+   * Permissions required: bb.groups.get
    *
    * @generated from rpc bytebase.v1.GroupService.GetGroup
    */
@@ -277,7 +277,7 @@ export declare const GroupService: GenService<{
     output: typeof GroupSchema;
   },
   /**
-   * Permissions required: groups.list
+   * Permissions required: bb.groups.list
    *
    * @generated from rpc bytebase.v1.GroupService.ListGroups
    */
@@ -287,7 +287,7 @@ export declare const GroupService: GenService<{
     output: typeof ListGroupsResponseSchema;
   },
   /**
-   * Permissions required: groups.create
+   * Permissions required: bb.groups.create
    *
    * @generated from rpc bytebase.v1.GroupService.CreateGroup
    */
@@ -299,7 +299,7 @@ export declare const GroupService: GenService<{
   /**
    * UpdateGroup updates the group.
    * Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-   * Permissions required: groups.update
+   * Permissions required: bb.groups.update
    *
    * @generated from rpc bytebase.v1.GroupService.UpdateGroup
    */
@@ -309,7 +309,7 @@ export declare const GroupService: GenService<{
     output: typeof GroupSchema;
   },
   /**
-   * Permissions required: groups.delete
+   * Permissions required: bb.groups.delete
    *
    * @generated from rpc bytebase.v1.GroupService.DeleteGroup
    */

--- a/frontend/src/types/proto-es/v1/group_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/group_service_pb.d.ts
@@ -267,6 +267,8 @@ export declare const GroupSchema: GenMessage<Group>;
  */
 export declare const GroupService: GenService<{
   /**
+   * Permissions required: groups.get
+   *
    * @generated from rpc bytebase.v1.GroupService.GetGroup
    */
   getGroup: {
@@ -275,6 +277,8 @@ export declare const GroupService: GenService<{
     output: typeof GroupSchema;
   },
   /**
+   * Permissions required: groups.list
+   *
    * @generated from rpc bytebase.v1.GroupService.ListGroups
    */
   listGroups: {
@@ -283,6 +287,8 @@ export declare const GroupService: GenService<{
     output: typeof ListGroupsResponseSchema;
   },
   /**
+   * Permissions required: groups.create
+   *
    * @generated from rpc bytebase.v1.GroupService.CreateGroup
    */
   createGroup: {
@@ -293,6 +299,7 @@ export declare const GroupService: GenService<{
   /**
    * UpdateGroup updates the group.
    * Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+   * Permissions required: groups.update
    *
    * @generated from rpc bytebase.v1.GroupService.UpdateGroup
    */
@@ -302,6 +309,8 @@ export declare const GroupService: GenService<{
     output: typeof GroupSchema;
   },
   /**
+   * Permissions required: groups.delete
+   *
    * @generated from rpc bytebase.v1.GroupService.DeleteGroup
    */
   deleteGroup: {

--- a/frontend/src/types/proto-es/v1/idp_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/idp_service_pb.d.ts
@@ -653,6 +653,8 @@ export declare const OAuth2AuthStyleSchema: GenEnum<OAuth2AuthStyle>;
  */
 export declare const IdentityProviderService: GenService<{
   /**
+   * Permissions required: identityProviders.get
+   *
    * @generated from rpc bytebase.v1.IdentityProviderService.GetIdentityProvider
    */
   getIdentityProvider: {
@@ -661,6 +663,8 @@ export declare const IdentityProviderService: GenService<{
     output: typeof IdentityProviderSchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.IdentityProviderService.ListIdentityProviders
    */
   listIdentityProviders: {
@@ -669,6 +673,8 @@ export declare const IdentityProviderService: GenService<{
     output: typeof ListIdentityProvidersResponseSchema;
   },
   /**
+   * Permissions required: identityProviders.create
+   *
    * @generated from rpc bytebase.v1.IdentityProviderService.CreateIdentityProvider
    */
   createIdentityProvider: {
@@ -677,6 +683,8 @@ export declare const IdentityProviderService: GenService<{
     output: typeof IdentityProviderSchema;
   },
   /**
+   * Permissions required: identityProviders.update
+   *
    * @generated from rpc bytebase.v1.IdentityProviderService.UpdateIdentityProvider
    */
   updateIdentityProvider: {
@@ -685,6 +693,8 @@ export declare const IdentityProviderService: GenService<{
     output: typeof IdentityProviderSchema;
   },
   /**
+   * Permissions required: identityProviders.delete
+   *
    * @generated from rpc bytebase.v1.IdentityProviderService.DeleteIdentityProvider
    */
   deleteIdentityProvider: {
@@ -693,6 +703,8 @@ export declare const IdentityProviderService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: identityProviders.update
+   *
    * @generated from rpc bytebase.v1.IdentityProviderService.TestIdentityProvider
    */
   testIdentityProvider: {

--- a/frontend/src/types/proto-es/v1/idp_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/idp_service_pb.d.ts
@@ -653,7 +653,7 @@ export declare const OAuth2AuthStyleSchema: GenEnum<OAuth2AuthStyle>;
  */
 export declare const IdentityProviderService: GenService<{
   /**
-   * Permissions required: identityProviders.get
+   * Permissions required: bb.identityProviders.get
    *
    * @generated from rpc bytebase.v1.IdentityProviderService.GetIdentityProvider
    */
@@ -673,7 +673,7 @@ export declare const IdentityProviderService: GenService<{
     output: typeof ListIdentityProvidersResponseSchema;
   },
   /**
-   * Permissions required: identityProviders.create
+   * Permissions required: bb.identityProviders.create
    *
    * @generated from rpc bytebase.v1.IdentityProviderService.CreateIdentityProvider
    */
@@ -683,7 +683,7 @@ export declare const IdentityProviderService: GenService<{
     output: typeof IdentityProviderSchema;
   },
   /**
-   * Permissions required: identityProviders.update
+   * Permissions required: bb.identityProviders.update
    *
    * @generated from rpc bytebase.v1.IdentityProviderService.UpdateIdentityProvider
    */
@@ -693,7 +693,7 @@ export declare const IdentityProviderService: GenService<{
     output: typeof IdentityProviderSchema;
   },
   /**
-   * Permissions required: identityProviders.delete
+   * Permissions required: bb.identityProviders.delete
    *
    * @generated from rpc bytebase.v1.IdentityProviderService.DeleteIdentityProvider
    */
@@ -703,7 +703,7 @@ export declare const IdentityProviderService: GenService<{
     output: typeof EmptySchema;
   },
   /**
-   * Permissions required: identityProviders.update
+   * Permissions required: bb.identityProviders.update
    *
    * @generated from rpc bytebase.v1.IdentityProviderService.TestIdentityProvider
    */

--- a/frontend/src/types/proto-es/v1/instance_role_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/instance_role_service_pb.d.ts
@@ -169,6 +169,8 @@ export declare const InstanceRoleSchema: GenMessage<InstanceRole>;
  */
 export declare const InstanceRoleService: GenService<{
   /**
+   * Permissions required: instanceRoles.get
+   *
    * @generated from rpc bytebase.v1.InstanceRoleService.GetInstanceRole
    */
   getInstanceRole: {
@@ -177,6 +179,8 @@ export declare const InstanceRoleService: GenService<{
     output: typeof InstanceRoleSchema;
   },
   /**
+   * Permissions required: instanceRoles.get
+   *
    * @generated from rpc bytebase.v1.InstanceRoleService.ListInstanceRoles
    */
   listInstanceRoles: {

--- a/frontend/src/types/proto-es/v1/instance_role_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/instance_role_service_pb.d.ts
@@ -169,7 +169,7 @@ export declare const InstanceRoleSchema: GenMessage<InstanceRole>;
  */
 export declare const InstanceRoleService: GenService<{
   /**
-   * Permissions required: instanceRoles.get
+   * Permissions required: bb.instanceRoles.get
    *
    * @generated from rpc bytebase.v1.InstanceRoleService.GetInstanceRole
    */
@@ -179,7 +179,7 @@ export declare const InstanceRoleService: GenService<{
     output: typeof InstanceRoleSchema;
   },
   /**
-   * Permissions required: instanceRoles.get
+   * Permissions required: bb.instanceRoles.get
    *
    * @generated from rpc bytebase.v1.InstanceRoleService.ListInstanceRoles
    */

--- a/frontend/src/types/proto-es/v1/instance_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/instance_service_pb.d.ts
@@ -1288,6 +1288,8 @@ export declare const DataSourceTypeSchema: GenEnum<DataSourceType>;
  */
 export declare const InstanceService: GenService<{
   /**
+   * Permissions required: instances.get
+   *
    * @generated from rpc bytebase.v1.InstanceService.GetInstance
    */
   getInstance: {
@@ -1296,6 +1298,8 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
+   * Permissions required: instances.list
+   *
    * @generated from rpc bytebase.v1.InstanceService.ListInstances
    */
   listInstances: {
@@ -1304,6 +1308,8 @@ export declare const InstanceService: GenService<{
     output: typeof ListInstancesResponseSchema;
   },
   /**
+   * Permissions required: instances.create
+   *
    * @generated from rpc bytebase.v1.InstanceService.CreateInstance
    */
   createInstance: {
@@ -1312,6 +1318,8 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
+   * Permissions required: instances.update
+   *
    * @generated from rpc bytebase.v1.InstanceService.UpdateInstance
    */
   updateInstance: {
@@ -1320,6 +1328,8 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
+   * Permissions required: instances.delete
+   *
    * @generated from rpc bytebase.v1.InstanceService.DeleteInstance
    */
   deleteInstance: {
@@ -1328,6 +1338,8 @@ export declare const InstanceService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: instances.undelete
+   *
    * @generated from rpc bytebase.v1.InstanceService.UndeleteInstance
    */
   undeleteInstance: {
@@ -1336,6 +1348,8 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
+   * Permissions required: instances.sync
+   *
    * @generated from rpc bytebase.v1.InstanceService.SyncInstance
    */
   syncInstance: {
@@ -1344,6 +1358,8 @@ export declare const InstanceService: GenService<{
     output: typeof SyncInstanceResponseSchema;
   },
   /**
+   * Permissions required: instances.get
+   *
    * @generated from rpc bytebase.v1.InstanceService.ListInstanceDatabase
    */
   listInstanceDatabase: {
@@ -1352,6 +1368,8 @@ export declare const InstanceService: GenService<{
     output: typeof ListInstanceDatabaseResponseSchema;
   },
   /**
+   * Permissions required: instances.sync
+   *
    * @generated from rpc bytebase.v1.InstanceService.BatchSyncInstances
    */
   batchSyncInstances: {
@@ -1360,6 +1378,8 @@ export declare const InstanceService: GenService<{
     output: typeof BatchSyncInstancesResponseSchema;
   },
   /**
+   * Permissions required: instances.update
+   *
    * @generated from rpc bytebase.v1.InstanceService.BatchUpdateInstances
    */
   batchUpdateInstances: {
@@ -1368,6 +1388,8 @@ export declare const InstanceService: GenService<{
     output: typeof BatchUpdateInstancesResponseSchema;
   },
   /**
+   * Permissions required: instances.update
+   *
    * @generated from rpc bytebase.v1.InstanceService.AddDataSource
    */
   addDataSource: {
@@ -1376,6 +1398,8 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
+   * Permissions required: instances.update
+   *
    * @generated from rpc bytebase.v1.InstanceService.RemoveDataSource
    */
   removeDataSource: {
@@ -1384,6 +1408,8 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
+   * Permissions required: instances.update
+   *
    * @generated from rpc bytebase.v1.InstanceService.UpdateDataSource
    */
   updateDataSource: {

--- a/frontend/src/types/proto-es/v1/instance_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/instance_service_pb.d.ts
@@ -1288,7 +1288,7 @@ export declare const DataSourceTypeSchema: GenEnum<DataSourceType>;
  */
 export declare const InstanceService: GenService<{
   /**
-   * Permissions required: instances.get
+   * Permissions required: bb.instances.get
    *
    * @generated from rpc bytebase.v1.InstanceService.GetInstance
    */
@@ -1298,7 +1298,7 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
-   * Permissions required: instances.list
+   * Permissions required: bb.instances.list
    *
    * @generated from rpc bytebase.v1.InstanceService.ListInstances
    */
@@ -1308,7 +1308,7 @@ export declare const InstanceService: GenService<{
     output: typeof ListInstancesResponseSchema;
   },
   /**
-   * Permissions required: instances.create
+   * Permissions required: bb.instances.create
    *
    * @generated from rpc bytebase.v1.InstanceService.CreateInstance
    */
@@ -1318,7 +1318,7 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
-   * Permissions required: instances.update
+   * Permissions required: bb.instances.update
    *
    * @generated from rpc bytebase.v1.InstanceService.UpdateInstance
    */
@@ -1328,7 +1328,7 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
-   * Permissions required: instances.delete
+   * Permissions required: bb.instances.delete
    *
    * @generated from rpc bytebase.v1.InstanceService.DeleteInstance
    */
@@ -1338,7 +1338,7 @@ export declare const InstanceService: GenService<{
     output: typeof EmptySchema;
   },
   /**
-   * Permissions required: instances.undelete
+   * Permissions required: bb.instances.undelete
    *
    * @generated from rpc bytebase.v1.InstanceService.UndeleteInstance
    */
@@ -1348,7 +1348,7 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
-   * Permissions required: instances.sync
+   * Permissions required: bb.instances.sync
    *
    * @generated from rpc bytebase.v1.InstanceService.SyncInstance
    */
@@ -1358,7 +1358,7 @@ export declare const InstanceService: GenService<{
     output: typeof SyncInstanceResponseSchema;
   },
   /**
-   * Permissions required: instances.get
+   * Permissions required: bb.instances.get
    *
    * @generated from rpc bytebase.v1.InstanceService.ListInstanceDatabase
    */
@@ -1368,7 +1368,7 @@ export declare const InstanceService: GenService<{
     output: typeof ListInstanceDatabaseResponseSchema;
   },
   /**
-   * Permissions required: instances.sync
+   * Permissions required: bb.instances.sync
    *
    * @generated from rpc bytebase.v1.InstanceService.BatchSyncInstances
    */
@@ -1378,7 +1378,7 @@ export declare const InstanceService: GenService<{
     output: typeof BatchSyncInstancesResponseSchema;
   },
   /**
-   * Permissions required: instances.update
+   * Permissions required: bb.instances.update
    *
    * @generated from rpc bytebase.v1.InstanceService.BatchUpdateInstances
    */
@@ -1388,7 +1388,7 @@ export declare const InstanceService: GenService<{
     output: typeof BatchUpdateInstancesResponseSchema;
   },
   /**
-   * Permissions required: instances.update
+   * Permissions required: bb.instances.update
    *
    * @generated from rpc bytebase.v1.InstanceService.AddDataSource
    */
@@ -1398,7 +1398,7 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
-   * Permissions required: instances.update
+   * Permissions required: bb.instances.update
    *
    * @generated from rpc bytebase.v1.InstanceService.RemoveDataSource
    */
@@ -1408,7 +1408,7 @@ export declare const InstanceService: GenService<{
     output: typeof InstanceSchema;
   },
   /**
-   * Permissions required: instances.update
+   * Permissions required: bb.instances.update
    *
    * @generated from rpc bytebase.v1.InstanceService.UpdateDataSource
    */

--- a/frontend/src/types/proto-es/v1/issue_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/issue_service_pb.d.ts
@@ -1324,6 +1324,8 @@ export declare const IssueStatusSchema: GenEnum<IssueStatus>;
  */
 export declare const IssueService: GenService<{
   /**
+   * Permissions required: issues.get
+   *
    * @generated from rpc bytebase.v1.IssueService.GetIssue
    */
   getIssue: {
@@ -1332,6 +1334,8 @@ export declare const IssueService: GenService<{
     output: typeof IssueSchema;
   },
   /**
+   * Permissions required: issues.create
+   *
    * @generated from rpc bytebase.v1.IssueService.CreateIssue
    */
   createIssue: {
@@ -1340,6 +1344,8 @@ export declare const IssueService: GenService<{
     output: typeof IssueSchema;
   },
   /**
+   * Permissions required: issues.list
+   *
    * @generated from rpc bytebase.v1.IssueService.ListIssues
    */
   listIssues: {
@@ -1349,6 +1355,7 @@ export declare const IssueService: GenService<{
   },
   /**
    * Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+   * Permissions required: issues.get
    *
    * @generated from rpc bytebase.v1.IssueService.SearchIssues
    */
@@ -1358,6 +1365,8 @@ export declare const IssueService: GenService<{
     output: typeof SearchIssuesResponseSchema;
   },
   /**
+   * Permissions required: issues.update
+   *
    * @generated from rpc bytebase.v1.IssueService.UpdateIssue
    */
   updateIssue: {
@@ -1366,6 +1375,8 @@ export declare const IssueService: GenService<{
     output: typeof IssueSchema;
   },
   /**
+   * Permissions required: issueComments.list
+   *
    * @generated from rpc bytebase.v1.IssueService.ListIssueComments
    */
   listIssueComments: {
@@ -1374,6 +1385,8 @@ export declare const IssueService: GenService<{
     output: typeof ListIssueCommentsResponseSchema;
   },
   /**
+   * Permissions required: issueComments.create
+   *
    * @generated from rpc bytebase.v1.IssueService.CreateIssueComment
    */
   createIssueComment: {
@@ -1382,6 +1395,8 @@ export declare const IssueService: GenService<{
     output: typeof IssueCommentSchema;
   },
   /**
+   * Permissions required: issueComments.update
+   *
    * @generated from rpc bytebase.v1.IssueService.UpdateIssueComment
    */
   updateIssueComment: {
@@ -1390,6 +1405,8 @@ export declare const IssueService: GenService<{
     output: typeof IssueCommentSchema;
   },
   /**
+   * Permissions required: issues.update
+   *
    * @generated from rpc bytebase.v1.IssueService.BatchUpdateIssuesStatus
    */
   batchUpdateIssuesStatus: {
@@ -1400,6 +1417,7 @@ export declare const IssueService: GenService<{
   /**
    * ApproveIssue approves the issue.
    * The access is based on approval flow.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.IssueService.ApproveIssue
    */
@@ -1411,6 +1429,7 @@ export declare const IssueService: GenService<{
   /**
    * RejectIssue rejects the issue.
    * The access is based on approval flow.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.IssueService.RejectIssue
    */
@@ -1422,6 +1441,7 @@ export declare const IssueService: GenService<{
   /**
    * RequestIssue requests the issue.
    * The access is based on approval flow.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.IssueService.RequestIssue
    */

--- a/frontend/src/types/proto-es/v1/issue_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/issue_service_pb.d.ts
@@ -1324,7 +1324,7 @@ export declare const IssueStatusSchema: GenEnum<IssueStatus>;
  */
 export declare const IssueService: GenService<{
   /**
-   * Permissions required: issues.get
+   * Permissions required: bb.issues.get
    *
    * @generated from rpc bytebase.v1.IssueService.GetIssue
    */
@@ -1334,7 +1334,7 @@ export declare const IssueService: GenService<{
     output: typeof IssueSchema;
   },
   /**
-   * Permissions required: issues.create
+   * Permissions required: bb.issues.create
    *
    * @generated from rpc bytebase.v1.IssueService.CreateIssue
    */
@@ -1344,7 +1344,7 @@ export declare const IssueService: GenService<{
     output: typeof IssueSchema;
   },
   /**
-   * Permissions required: issues.list
+   * Permissions required: bb.issues.list
    *
    * @generated from rpc bytebase.v1.IssueService.ListIssues
    */
@@ -1355,7 +1355,7 @@ export declare const IssueService: GenService<{
   },
   /**
    * Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-   * Permissions required: issues.get
+   * Permissions required: bb.issues.get
    *
    * @generated from rpc bytebase.v1.IssueService.SearchIssues
    */
@@ -1365,7 +1365,7 @@ export declare const IssueService: GenService<{
     output: typeof SearchIssuesResponseSchema;
   },
   /**
-   * Permissions required: issues.update
+   * Permissions required: bb.issues.update
    *
    * @generated from rpc bytebase.v1.IssueService.UpdateIssue
    */
@@ -1375,7 +1375,7 @@ export declare const IssueService: GenService<{
     output: typeof IssueSchema;
   },
   /**
-   * Permissions required: issueComments.list
+   * Permissions required: bb.issueComments.list
    *
    * @generated from rpc bytebase.v1.IssueService.ListIssueComments
    */
@@ -1385,7 +1385,7 @@ export declare const IssueService: GenService<{
     output: typeof ListIssueCommentsResponseSchema;
   },
   /**
-   * Permissions required: issueComments.create
+   * Permissions required: bb.issueComments.create
    *
    * @generated from rpc bytebase.v1.IssueService.CreateIssueComment
    */
@@ -1395,7 +1395,7 @@ export declare const IssueService: GenService<{
     output: typeof IssueCommentSchema;
   },
   /**
-   * Permissions required: issueComments.update
+   * Permissions required: bb.issueComments.update
    *
    * @generated from rpc bytebase.v1.IssueService.UpdateIssueComment
    */
@@ -1405,7 +1405,7 @@ export declare const IssueService: GenService<{
     output: typeof IssueCommentSchema;
   },
   /**
-   * Permissions required: issues.update
+   * Permissions required: bb.issues.update
    *
    * @generated from rpc bytebase.v1.IssueService.BatchUpdateIssuesStatus
    */

--- a/frontend/src/types/proto-es/v1/org_policy_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/org_policy_service_pb.d.ts
@@ -816,6 +816,8 @@ export declare const SQLReviewRuleLevelSchema: GenEnum<SQLReviewRuleLevel>;
  */
 export declare const OrgPolicyService: GenService<{
   /**
+   * Permissions required: policies.get
+   *
    * @generated from rpc bytebase.v1.OrgPolicyService.GetPolicy
    */
   getPolicy: {
@@ -824,6 +826,8 @@ export declare const OrgPolicyService: GenService<{
     output: typeof PolicySchema;
   },
   /**
+   * Permissions required: policies.list
+   *
    * @generated from rpc bytebase.v1.OrgPolicyService.ListPolicies
    */
   listPolicies: {
@@ -832,6 +836,8 @@ export declare const OrgPolicyService: GenService<{
     output: typeof ListPoliciesResponseSchema;
   },
   /**
+   * Permissions required: policies.create
+   *
    * @generated from rpc bytebase.v1.OrgPolicyService.CreatePolicy
    */
   createPolicy: {
@@ -840,6 +846,8 @@ export declare const OrgPolicyService: GenService<{
     output: typeof PolicySchema;
   },
   /**
+   * Permissions required: policies.update
+   *
    * @generated from rpc bytebase.v1.OrgPolicyService.UpdatePolicy
    */
   updatePolicy: {
@@ -848,6 +856,8 @@ export declare const OrgPolicyService: GenService<{
     output: typeof PolicySchema;
   },
   /**
+   * Permissions required: policies.delete
+   *
    * @generated from rpc bytebase.v1.OrgPolicyService.DeletePolicy
    */
   deletePolicy: {

--- a/frontend/src/types/proto-es/v1/org_policy_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/org_policy_service_pb.d.ts
@@ -816,7 +816,7 @@ export declare const SQLReviewRuleLevelSchema: GenEnum<SQLReviewRuleLevel>;
  */
 export declare const OrgPolicyService: GenService<{
   /**
-   * Permissions required: policies.get
+   * Permissions required: bb.policies.get
    *
    * @generated from rpc bytebase.v1.OrgPolicyService.GetPolicy
    */
@@ -826,7 +826,7 @@ export declare const OrgPolicyService: GenService<{
     output: typeof PolicySchema;
   },
   /**
-   * Permissions required: policies.list
+   * Permissions required: bb.policies.list
    *
    * @generated from rpc bytebase.v1.OrgPolicyService.ListPolicies
    */
@@ -836,7 +836,7 @@ export declare const OrgPolicyService: GenService<{
     output: typeof ListPoliciesResponseSchema;
   },
   /**
-   * Permissions required: policies.create
+   * Permissions required: bb.policies.create
    *
    * @generated from rpc bytebase.v1.OrgPolicyService.CreatePolicy
    */
@@ -846,7 +846,7 @@ export declare const OrgPolicyService: GenService<{
     output: typeof PolicySchema;
   },
   /**
-   * Permissions required: policies.update
+   * Permissions required: bb.policies.update
    *
    * @generated from rpc bytebase.v1.OrgPolicyService.UpdatePolicy
    */
@@ -856,7 +856,7 @@ export declare const OrgPolicyService: GenService<{
     output: typeof PolicySchema;
   },
   /**
-   * Permissions required: policies.delete
+   * Permissions required: bb.policies.delete
    *
    * @generated from rpc bytebase.v1.OrgPolicyService.DeletePolicy
    */

--- a/frontend/src/types/proto-es/v1/plan_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/plan_service_pb.d.ts
@@ -1078,6 +1078,8 @@ export declare const PlanCheckRun_StatusSchema: GenEnum<PlanCheckRun_Status>;
  */
 export declare const PlanService: GenService<{
   /**
+   * Permissions required: plans.get
+   *
    * @generated from rpc bytebase.v1.PlanService.GetPlan
    */
   getPlan: {
@@ -1086,6 +1088,8 @@ export declare const PlanService: GenService<{
     output: typeof PlanSchema;
   },
   /**
+   * Permissions required: plans.list
+   *
    * @generated from rpc bytebase.v1.PlanService.ListPlans
    */
   listPlans: {
@@ -1095,6 +1099,7 @@ export declare const PlanService: GenService<{
   },
   /**
    * Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+   * Permissions required: plans.get
    *
    * @generated from rpc bytebase.v1.PlanService.SearchPlans
    */
@@ -1104,6 +1109,8 @@ export declare const PlanService: GenService<{
     output: typeof SearchPlansResponseSchema;
   },
   /**
+   * Permissions required: plans.create
+   *
    * @generated from rpc bytebase.v1.PlanService.CreatePlan
    */
   createPlan: {
@@ -1114,6 +1121,7 @@ export declare const PlanService: GenService<{
   /**
    * UpdatePlan updates the plan.
    * The plan creator and the user with bb.plans.update permission on the project can update the plan.
+   * Permissions required: plans.update
    *
    * @generated from rpc bytebase.v1.PlanService.UpdatePlan
    */
@@ -1123,6 +1131,8 @@ export declare const PlanService: GenService<{
     output: typeof PlanSchema;
   },
   /**
+   * Permissions required: planCheckRuns.list
+   *
    * @generated from rpc bytebase.v1.PlanService.ListPlanCheckRuns
    */
   listPlanCheckRuns: {
@@ -1131,6 +1141,8 @@ export declare const PlanService: GenService<{
     output: typeof ListPlanCheckRunsResponseSchema;
   },
   /**
+   * Permissions required: planCheckRuns.run
+   *
    * @generated from rpc bytebase.v1.PlanService.RunPlanChecks
    */
   runPlanChecks: {
@@ -1139,6 +1151,8 @@ export declare const PlanService: GenService<{
     output: typeof RunPlanChecksResponseSchema;
   },
   /**
+   * Permissions required: planCheckRuns.run
+   *
    * @generated from rpc bytebase.v1.PlanService.BatchCancelPlanCheckRuns
    */
   batchCancelPlanCheckRuns: {

--- a/frontend/src/types/proto-es/v1/plan_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/plan_service_pb.d.ts
@@ -1078,7 +1078,7 @@ export declare const PlanCheckRun_StatusSchema: GenEnum<PlanCheckRun_Status>;
  */
 export declare const PlanService: GenService<{
   /**
-   * Permissions required: plans.get
+   * Permissions required: bb.plans.get
    *
    * @generated from rpc bytebase.v1.PlanService.GetPlan
    */
@@ -1088,7 +1088,7 @@ export declare const PlanService: GenService<{
     output: typeof PlanSchema;
   },
   /**
-   * Permissions required: plans.list
+   * Permissions required: bb.plans.list
    *
    * @generated from rpc bytebase.v1.PlanService.ListPlans
    */
@@ -1099,7 +1099,7 @@ export declare const PlanService: GenService<{
   },
   /**
    * Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-   * Permissions required: plans.get
+   * Permissions required: bb.plans.get
    *
    * @generated from rpc bytebase.v1.PlanService.SearchPlans
    */
@@ -1109,7 +1109,7 @@ export declare const PlanService: GenService<{
     output: typeof SearchPlansResponseSchema;
   },
   /**
-   * Permissions required: plans.create
+   * Permissions required: bb.plans.create
    *
    * @generated from rpc bytebase.v1.PlanService.CreatePlan
    */
@@ -1121,7 +1121,7 @@ export declare const PlanService: GenService<{
   /**
    * UpdatePlan updates the plan.
    * The plan creator and the user with bb.plans.update permission on the project can update the plan.
-   * Permissions required: plans.update
+   * Permissions required: bb.plans.update
    *
    * @generated from rpc bytebase.v1.PlanService.UpdatePlan
    */
@@ -1131,7 +1131,7 @@ export declare const PlanService: GenService<{
     output: typeof PlanSchema;
   },
   /**
-   * Permissions required: planCheckRuns.list
+   * Permissions required: bb.planCheckRuns.list
    *
    * @generated from rpc bytebase.v1.PlanService.ListPlanCheckRuns
    */
@@ -1141,7 +1141,7 @@ export declare const PlanService: GenService<{
     output: typeof ListPlanCheckRunsResponseSchema;
   },
   /**
-   * Permissions required: planCheckRuns.run
+   * Permissions required: bb.planCheckRuns.run
    *
    * @generated from rpc bytebase.v1.PlanService.RunPlanChecks
    */
@@ -1151,7 +1151,7 @@ export declare const PlanService: GenService<{
     output: typeof RunPlanChecksResponseSchema;
   },
   /**
-   * Permissions required: planCheckRuns.run
+   * Permissions required: bb.planCheckRuns.run
    *
    * @generated from rpc bytebase.v1.PlanService.BatchCancelPlanCheckRuns
    */

--- a/frontend/src/types/proto-es/v1/project_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/project_service_pb.d.ts
@@ -888,6 +888,7 @@ export declare const ProjectService: GenService<{
   /**
    * GetProject retrieves a project by name.
    * Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+   * Permissions required: projects.get
    *
    * @generated from rpc bytebase.v1.ProjectService.GetProject
    */
@@ -897,6 +898,8 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
+   * Permissions required: projects.list
+   *
    * @generated from rpc bytebase.v1.ProjectService.ListProjects
    */
   listProjects: {
@@ -905,6 +908,8 @@ export declare const ProjectService: GenService<{
     output: typeof ListProjectsResponseSchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.ProjectService.SearchProjects
    */
   searchProjects: {
@@ -913,6 +918,8 @@ export declare const ProjectService: GenService<{
     output: typeof SearchProjectsResponseSchema;
   },
   /**
+   * Permissions required: projects.create
+   *
    * @generated from rpc bytebase.v1.ProjectService.CreateProject
    */
   createProject: {
@@ -921,6 +928,8 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.ProjectService.UpdateProject
    */
   updateProject: {
@@ -929,6 +938,8 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
+   * Permissions required: projects.delete
+   *
    * @generated from rpc bytebase.v1.ProjectService.DeleteProject
    */
   deleteProject: {
@@ -937,6 +948,8 @@ export declare const ProjectService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: projects.undelete
+   *
    * @generated from rpc bytebase.v1.ProjectService.UndeleteProject
    */
   undeleteProject: {
@@ -945,6 +958,8 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
+   * Permissions required: projects.delete
+   *
    * @generated from rpc bytebase.v1.ProjectService.BatchDeleteProjects
    */
   batchDeleteProjects: {
@@ -953,6 +968,8 @@ export declare const ProjectService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: projects.getIamPolicy
+   *
    * @generated from rpc bytebase.v1.ProjectService.GetIamPolicy
    */
   getIamPolicy: {
@@ -962,6 +979,7 @@ export declare const ProjectService: GenService<{
   },
   /**
    * Deprecated.
+   * Permissions required: projects.getIamPolicy
    *
    * @generated from rpc bytebase.v1.ProjectService.BatchGetIamPolicy
    */
@@ -971,6 +989,8 @@ export declare const ProjectService: GenService<{
     output: typeof BatchGetIamPolicyResponseSchema;
   },
   /**
+   * Permissions required: projects.setIamPolicy
+   *
    * @generated from rpc bytebase.v1.ProjectService.SetIamPolicy
    */
   setIamPolicy: {
@@ -979,6 +999,8 @@ export declare const ProjectService: GenService<{
     output: typeof IamPolicySchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.ProjectService.AddWebhook
    */
   addWebhook: {
@@ -987,6 +1009,8 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.ProjectService.UpdateWebhook
    */
   updateWebhook: {
@@ -995,6 +1019,8 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.ProjectService.RemoveWebhook
    */
   removeWebhook: {
@@ -1003,6 +1029,8 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
+   * Permissions required: projects.update
+   *
    * @generated from rpc bytebase.v1.ProjectService.TestWebhook
    */
   testWebhook: {

--- a/frontend/src/types/proto-es/v1/project_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/project_service_pb.d.ts
@@ -888,7 +888,7 @@ export declare const ProjectService: GenService<{
   /**
    * GetProject retrieves a project by name.
    * Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-   * Permissions required: projects.get
+   * Permissions required: bb.projects.get
    *
    * @generated from rpc bytebase.v1.ProjectService.GetProject
    */
@@ -898,7 +898,7 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
-   * Permissions required: projects.list
+   * Permissions required: bb.projects.list
    *
    * @generated from rpc bytebase.v1.ProjectService.ListProjects
    */
@@ -918,7 +918,7 @@ export declare const ProjectService: GenService<{
     output: typeof SearchProjectsResponseSchema;
   },
   /**
-   * Permissions required: projects.create
+   * Permissions required: bb.projects.create
    *
    * @generated from rpc bytebase.v1.ProjectService.CreateProject
    */
@@ -928,7 +928,7 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.ProjectService.UpdateProject
    */
@@ -938,7 +938,7 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
-   * Permissions required: projects.delete
+   * Permissions required: bb.projects.delete
    *
    * @generated from rpc bytebase.v1.ProjectService.DeleteProject
    */
@@ -948,7 +948,7 @@ export declare const ProjectService: GenService<{
     output: typeof EmptySchema;
   },
   /**
-   * Permissions required: projects.undelete
+   * Permissions required: bb.projects.undelete
    *
    * @generated from rpc bytebase.v1.ProjectService.UndeleteProject
    */
@@ -958,7 +958,7 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
-   * Permissions required: projects.delete
+   * Permissions required: bb.projects.delete
    *
    * @generated from rpc bytebase.v1.ProjectService.BatchDeleteProjects
    */
@@ -968,7 +968,7 @@ export declare const ProjectService: GenService<{
     output: typeof EmptySchema;
   },
   /**
-   * Permissions required: projects.getIamPolicy
+   * Permissions required: bb.projects.getIamPolicy
    *
    * @generated from rpc bytebase.v1.ProjectService.GetIamPolicy
    */
@@ -979,7 +979,7 @@ export declare const ProjectService: GenService<{
   },
   /**
    * Deprecated.
-   * Permissions required: projects.getIamPolicy
+   * Permissions required: bb.projects.getIamPolicy
    *
    * @generated from rpc bytebase.v1.ProjectService.BatchGetIamPolicy
    */
@@ -989,7 +989,7 @@ export declare const ProjectService: GenService<{
     output: typeof BatchGetIamPolicyResponseSchema;
   },
   /**
-   * Permissions required: projects.setIamPolicy
+   * Permissions required: bb.projects.setIamPolicy
    *
    * @generated from rpc bytebase.v1.ProjectService.SetIamPolicy
    */
@@ -999,7 +999,7 @@ export declare const ProjectService: GenService<{
     output: typeof IamPolicySchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.ProjectService.AddWebhook
    */
@@ -1009,7 +1009,7 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.ProjectService.UpdateWebhook
    */
@@ -1019,7 +1019,7 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.ProjectService.RemoveWebhook
    */
@@ -1029,7 +1029,7 @@ export declare const ProjectService: GenService<{
     output: typeof ProjectSchema;
   },
   /**
-   * Permissions required: projects.update
+   * Permissions required: bb.projects.update
    *
    * @generated from rpc bytebase.v1.ProjectService.TestWebhook
    */

--- a/frontend/src/types/proto-es/v1/release_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/release_service_pb.d.ts
@@ -532,7 +532,7 @@ export declare const ReleaseFileTypeSchema: GenEnum<ReleaseFileType>;
  */
 export declare const ReleaseService: GenService<{
   /**
-   * Permissions required: releases.get
+   * Permissions required: bb.releases.get
    *
    * @generated from rpc bytebase.v1.ReleaseService.GetRelease
    */
@@ -542,7 +542,7 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
-   * Permissions required: releases.list
+   * Permissions required: bb.releases.list
    *
    * @generated from rpc bytebase.v1.ReleaseService.ListReleases
    */
@@ -552,7 +552,7 @@ export declare const ReleaseService: GenService<{
     output: typeof ListReleasesResponseSchema;
   },
   /**
-   * Permissions required: releases.create
+   * Permissions required: bb.releases.create
    *
    * @generated from rpc bytebase.v1.ReleaseService.CreateRelease
    */
@@ -562,7 +562,7 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
-   * Permissions required: releases.update
+   * Permissions required: bb.releases.update
    *
    * @generated from rpc bytebase.v1.ReleaseService.UpdateRelease
    */
@@ -572,7 +572,7 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
-   * Permissions required: releases.delete
+   * Permissions required: bb.releases.delete
    *
    * @generated from rpc bytebase.v1.ReleaseService.DeleteRelease
    */
@@ -582,7 +582,7 @@ export declare const ReleaseService: GenService<{
     output: typeof EmptySchema;
   },
   /**
-   * Permissions required: releases.undelete
+   * Permissions required: bb.releases.undelete
    *
    * @generated from rpc bytebase.v1.ReleaseService.UndeleteRelease
    */
@@ -592,7 +592,7 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
-   * Permissions required: releases.check
+   * Permissions required: bb.releases.check
    *
    * @generated from rpc bytebase.v1.ReleaseService.CheckRelease
    */

--- a/frontend/src/types/proto-es/v1/release_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/release_service_pb.d.ts
@@ -532,6 +532,8 @@ export declare const ReleaseFileTypeSchema: GenEnum<ReleaseFileType>;
  */
 export declare const ReleaseService: GenService<{
   /**
+   * Permissions required: releases.get
+   *
    * @generated from rpc bytebase.v1.ReleaseService.GetRelease
    */
   getRelease: {
@@ -540,6 +542,8 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
+   * Permissions required: releases.list
+   *
    * @generated from rpc bytebase.v1.ReleaseService.ListReleases
    */
   listReleases: {
@@ -548,6 +552,8 @@ export declare const ReleaseService: GenService<{
     output: typeof ListReleasesResponseSchema;
   },
   /**
+   * Permissions required: releases.create
+   *
    * @generated from rpc bytebase.v1.ReleaseService.CreateRelease
    */
   createRelease: {
@@ -556,6 +562,8 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
+   * Permissions required: releases.update
+   *
    * @generated from rpc bytebase.v1.ReleaseService.UpdateRelease
    */
   updateRelease: {
@@ -564,6 +572,8 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
+   * Permissions required: releases.delete
+   *
    * @generated from rpc bytebase.v1.ReleaseService.DeleteRelease
    */
   deleteRelease: {
@@ -572,6 +582,8 @@ export declare const ReleaseService: GenService<{
     output: typeof EmptySchema;
   },
   /**
+   * Permissions required: releases.undelete
+   *
    * @generated from rpc bytebase.v1.ReleaseService.UndeleteRelease
    */
   undeleteRelease: {
@@ -580,6 +592,8 @@ export declare const ReleaseService: GenService<{
     output: typeof ReleaseSchema;
   },
   /**
+   * Permissions required: releases.check
+   *
    * @generated from rpc bytebase.v1.ReleaseService.CheckRelease
    */
   checkRelease: {

--- a/frontend/src/types/proto-es/v1/review_config_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/review_config_service_pb.d.ts
@@ -209,7 +209,7 @@ export declare const ReviewConfigSchema: GenMessage<ReviewConfig>;
  */
 export declare const ReviewConfigService: GenService<{
   /**
-   * Permissions required: reviewConfigs.create
+   * Permissions required: bb.reviewConfigs.create
    *
    * @generated from rpc bytebase.v1.ReviewConfigService.CreateReviewConfig
    */
@@ -219,7 +219,7 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ReviewConfigSchema;
   },
   /**
-   * Permissions required: reviewConfigs.list
+   * Permissions required: bb.reviewConfigs.list
    *
    * @generated from rpc bytebase.v1.ReviewConfigService.ListReviewConfigs
    */
@@ -229,7 +229,7 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ListReviewConfigsResponseSchema;
   },
   /**
-   * Permissions required: reviewConfigs.get
+   * Permissions required: bb.reviewConfigs.get
    *
    * @generated from rpc bytebase.v1.ReviewConfigService.GetReviewConfig
    */
@@ -239,7 +239,7 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ReviewConfigSchema;
   },
   /**
-   * Permissions required: reviewConfigs.update
+   * Permissions required: bb.reviewConfigs.update
    *
    * @generated from rpc bytebase.v1.ReviewConfigService.UpdateReviewConfig
    */
@@ -249,7 +249,7 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ReviewConfigSchema;
   },
   /**
-   * Permissions required: reviewConfigs.delete
+   * Permissions required: bb.reviewConfigs.delete
    *
    * @generated from rpc bytebase.v1.ReviewConfigService.DeleteReviewConfig
    */

--- a/frontend/src/types/proto-es/v1/review_config_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/review_config_service_pb.d.ts
@@ -209,6 +209,8 @@ export declare const ReviewConfigSchema: GenMessage<ReviewConfig>;
  */
 export declare const ReviewConfigService: GenService<{
   /**
+   * Permissions required: reviewConfigs.create
+   *
    * @generated from rpc bytebase.v1.ReviewConfigService.CreateReviewConfig
    */
   createReviewConfig: {
@@ -217,6 +219,8 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ReviewConfigSchema;
   },
   /**
+   * Permissions required: reviewConfigs.list
+   *
    * @generated from rpc bytebase.v1.ReviewConfigService.ListReviewConfigs
    */
   listReviewConfigs: {
@@ -225,6 +229,8 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ListReviewConfigsResponseSchema;
   },
   /**
+   * Permissions required: reviewConfigs.get
+   *
    * @generated from rpc bytebase.v1.ReviewConfigService.GetReviewConfig
    */
   getReviewConfig: {
@@ -233,6 +239,8 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ReviewConfigSchema;
   },
   /**
+   * Permissions required: reviewConfigs.update
+   *
    * @generated from rpc bytebase.v1.ReviewConfigService.UpdateReviewConfig
    */
   updateReviewConfig: {
@@ -241,6 +249,8 @@ export declare const ReviewConfigService: GenService<{
     output: typeof ReviewConfigSchema;
   },
   /**
+   * Permissions required: reviewConfigs.delete
+   *
    * @generated from rpc bytebase.v1.ReviewConfigService.DeleteReviewConfig
    */
   deleteReviewConfig: {

--- a/frontend/src/types/proto-es/v1/revision_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/revision_service_pb.d.ts
@@ -297,7 +297,7 @@ export declare const RevisionSchema: GenMessage<Revision>;
  */
 export declare const RevisionService: GenService<{
   /**
-   * Permissions required: revisions.list
+   * Permissions required: bb.revisions.list
    *
    * @generated from rpc bytebase.v1.RevisionService.ListRevisions
    */
@@ -307,7 +307,7 @@ export declare const RevisionService: GenService<{
     output: typeof ListRevisionsResponseSchema;
   },
   /**
-   * Permissions required: revisions.get
+   * Permissions required: bb.revisions.get
    *
    * @generated from rpc bytebase.v1.RevisionService.GetRevision
    */
@@ -317,7 +317,7 @@ export declare const RevisionService: GenService<{
     output: typeof RevisionSchema;
   },
   /**
-   * Permissions required: revisions.create
+   * Permissions required: bb.revisions.create
    *
    * @generated from rpc bytebase.v1.RevisionService.CreateRevision
    */
@@ -327,7 +327,7 @@ export declare const RevisionService: GenService<{
     output: typeof RevisionSchema;
   },
   /**
-   * Permissions required: revisions.create
+   * Permissions required: bb.revisions.create
    *
    * @generated from rpc bytebase.v1.RevisionService.BatchCreateRevisions
    */
@@ -337,7 +337,7 @@ export declare const RevisionService: GenService<{
     output: typeof BatchCreateRevisionsResponseSchema;
   },
   /**
-   * Permissions required: revisions.delete
+   * Permissions required: bb.revisions.delete
    *
    * @generated from rpc bytebase.v1.RevisionService.DeleteRevision
    */

--- a/frontend/src/types/proto-es/v1/revision_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/revision_service_pb.d.ts
@@ -297,6 +297,8 @@ export declare const RevisionSchema: GenMessage<Revision>;
  */
 export declare const RevisionService: GenService<{
   /**
+   * Permissions required: revisions.list
+   *
    * @generated from rpc bytebase.v1.RevisionService.ListRevisions
    */
   listRevisions: {
@@ -305,6 +307,8 @@ export declare const RevisionService: GenService<{
     output: typeof ListRevisionsResponseSchema;
   },
   /**
+   * Permissions required: revisions.get
+   *
    * @generated from rpc bytebase.v1.RevisionService.GetRevision
    */
   getRevision: {
@@ -313,6 +317,8 @@ export declare const RevisionService: GenService<{
     output: typeof RevisionSchema;
   },
   /**
+   * Permissions required: revisions.create
+   *
    * @generated from rpc bytebase.v1.RevisionService.CreateRevision
    */
   createRevision: {
@@ -321,6 +327,8 @@ export declare const RevisionService: GenService<{
     output: typeof RevisionSchema;
   },
   /**
+   * Permissions required: revisions.create
+   *
    * @generated from rpc bytebase.v1.RevisionService.BatchCreateRevisions
    */
   batchCreateRevisions: {
@@ -329,6 +337,8 @@ export declare const RevisionService: GenService<{
     output: typeof BatchCreateRevisionsResponseSchema;
   },
   /**
+   * Permissions required: revisions.delete
+   *
    * @generated from rpc bytebase.v1.RevisionService.DeleteRevision
    */
   deleteRevision: {

--- a/frontend/src/types/proto-es/v1/risk_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/risk_service_pb.d.ts
@@ -313,7 +313,7 @@ export declare const Risk_SourceSchema: GenEnum<Risk_Source>;
  */
 export declare const RiskService: GenService<{
   /**
-   * Permissions required: risks.list
+   * Permissions required: bb.risks.list
    *
    * @generated from rpc bytebase.v1.RiskService.ListRisks
    */
@@ -323,7 +323,7 @@ export declare const RiskService: GenService<{
     output: typeof ListRisksResponseSchema;
   },
   /**
-   * Permissions required: risks.create
+   * Permissions required: bb.risks.create
    *
    * @generated from rpc bytebase.v1.RiskService.CreateRisk
    */
@@ -333,7 +333,7 @@ export declare const RiskService: GenService<{
     output: typeof RiskSchema;
   },
   /**
-   * Permissions required: risks.list
+   * Permissions required: bb.risks.list
    *
    * @generated from rpc bytebase.v1.RiskService.GetRisk
    */
@@ -343,7 +343,7 @@ export declare const RiskService: GenService<{
     output: typeof RiskSchema;
   },
   /**
-   * Permissions required: risks.update
+   * Permissions required: bb.risks.update
    *
    * @generated from rpc bytebase.v1.RiskService.UpdateRisk
    */
@@ -353,7 +353,7 @@ export declare const RiskService: GenService<{
     output: typeof RiskSchema;
   },
   /**
-   * Permissions required: risks.delete
+   * Permissions required: bb.risks.delete
    *
    * @generated from rpc bytebase.v1.RiskService.DeleteRisk
    */

--- a/frontend/src/types/proto-es/v1/risk_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/risk_service_pb.d.ts
@@ -313,6 +313,8 @@ export declare const Risk_SourceSchema: GenEnum<Risk_Source>;
  */
 export declare const RiskService: GenService<{
   /**
+   * Permissions required: risks.list
+   *
    * @generated from rpc bytebase.v1.RiskService.ListRisks
    */
   listRisks: {
@@ -321,6 +323,8 @@ export declare const RiskService: GenService<{
     output: typeof ListRisksResponseSchema;
   },
   /**
+   * Permissions required: risks.create
+   *
    * @generated from rpc bytebase.v1.RiskService.CreateRisk
    */
   createRisk: {
@@ -329,6 +333,8 @@ export declare const RiskService: GenService<{
     output: typeof RiskSchema;
   },
   /**
+   * Permissions required: risks.list
+   *
    * @generated from rpc bytebase.v1.RiskService.GetRisk
    */
   getRisk: {
@@ -337,6 +343,8 @@ export declare const RiskService: GenService<{
     output: typeof RiskSchema;
   },
   /**
+   * Permissions required: risks.update
+   *
    * @generated from rpc bytebase.v1.RiskService.UpdateRisk
    */
   updateRisk: {
@@ -345,6 +353,8 @@ export declare const RiskService: GenService<{
     output: typeof RiskSchema;
   },
   /**
+   * Permissions required: risks.delete
+   *
    * @generated from rpc bytebase.v1.RiskService.DeleteRisk
    */
   deleteRisk: {

--- a/frontend/src/types/proto-es/v1/role_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/role_service_pb.d.ts
@@ -229,6 +229,8 @@ export declare const Role_TypeSchema: GenEnum<Role_Type>;
  */
 export declare const RoleService: GenService<{
   /**
+   * Permissions required: roles.list
+   *
    * @generated from rpc bytebase.v1.RoleService.ListRoles
    */
   listRoles: {
@@ -237,6 +239,8 @@ export declare const RoleService: GenService<{
     output: typeof ListRolesResponseSchema;
   },
   /**
+   * Permissions required: roles.get
+   *
    * @generated from rpc bytebase.v1.RoleService.GetRole
    */
   getRole: {
@@ -245,6 +249,8 @@ export declare const RoleService: GenService<{
     output: typeof RoleSchema;
   },
   /**
+   * Permissions required: roles.create
+   *
    * @generated from rpc bytebase.v1.RoleService.CreateRole
    */
   createRole: {
@@ -253,6 +259,8 @@ export declare const RoleService: GenService<{
     output: typeof RoleSchema;
   },
   /**
+   * Permissions required: roles.update
+   *
    * @generated from rpc bytebase.v1.RoleService.UpdateRole
    */
   updateRole: {
@@ -261,6 +269,8 @@ export declare const RoleService: GenService<{
     output: typeof RoleSchema;
   },
   /**
+   * Permissions required: roles.delete
+   *
    * @generated from rpc bytebase.v1.RoleService.DeleteRole
    */
   deleteRole: {

--- a/frontend/src/types/proto-es/v1/role_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/role_service_pb.d.ts
@@ -229,7 +229,7 @@ export declare const Role_TypeSchema: GenEnum<Role_Type>;
  */
 export declare const RoleService: GenService<{
   /**
-   * Permissions required: roles.list
+   * Permissions required: bb.roles.list
    *
    * @generated from rpc bytebase.v1.RoleService.ListRoles
    */
@@ -239,7 +239,7 @@ export declare const RoleService: GenService<{
     output: typeof ListRolesResponseSchema;
   },
   /**
-   * Permissions required: roles.get
+   * Permissions required: bb.roles.get
    *
    * @generated from rpc bytebase.v1.RoleService.GetRole
    */
@@ -249,7 +249,7 @@ export declare const RoleService: GenService<{
     output: typeof RoleSchema;
   },
   /**
-   * Permissions required: roles.create
+   * Permissions required: bb.roles.create
    *
    * @generated from rpc bytebase.v1.RoleService.CreateRole
    */
@@ -259,7 +259,7 @@ export declare const RoleService: GenService<{
     output: typeof RoleSchema;
   },
   /**
-   * Permissions required: roles.update
+   * Permissions required: bb.roles.update
    *
    * @generated from rpc bytebase.v1.RoleService.UpdateRole
    */
@@ -269,7 +269,7 @@ export declare const RoleService: GenService<{
     output: typeof RoleSchema;
   },
   /**
-   * Permissions required: roles.delete
+   * Permissions required: bb.roles.delete
    *
    * @generated from rpc bytebase.v1.RoleService.DeleteRole
    */

--- a/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
@@ -1772,7 +1772,7 @@ export declare const PreviewTaskRunRollbackResponseSchema: GenMessage<PreviewTas
  */
 export declare const RolloutService: GenService<{
   /**
-   * Permissions required: rollouts.get
+   * Permissions required: bb.rollouts.get
    *
    * @generated from rpc bytebase.v1.RolloutService.GetRollout
    */
@@ -1782,7 +1782,7 @@ export declare const RolloutService: GenService<{
     output: typeof RolloutSchema;
   },
   /**
-   * Permissions required: rollouts.list
+   * Permissions required: bb.rollouts.list
    *
    * @generated from rpc bytebase.v1.RolloutService.ListRollouts
    */
@@ -1792,8 +1792,7 @@ export declare const RolloutService: GenService<{
     output: typeof ListRolloutsResponseSchema;
   },
   /**
-   * CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-   * Permissions required: rollouts.create
+   * Permissions required: bb.rollouts.create
    *
    * @generated from rpc bytebase.v1.RolloutService.CreateRollout
    */
@@ -1803,7 +1802,7 @@ export declare const RolloutService: GenService<{
     output: typeof RolloutSchema;
   },
   /**
-   * Permissions required: rollouts.preview
+   * Permissions required: bb.rollouts.preview
    *
    * @generated from rpc bytebase.v1.RolloutService.PreviewRollout
    */
@@ -1813,7 +1812,7 @@ export declare const RolloutService: GenService<{
     output: typeof RolloutSchema;
   },
   /**
-   * Permissions required: taskRuns.list
+   * Permissions required: bb.taskRuns.list
    *
    * @generated from rpc bytebase.v1.RolloutService.ListTaskRuns
    */
@@ -1823,7 +1822,7 @@ export declare const RolloutService: GenService<{
     output: typeof ListTaskRunsResponseSchema;
   },
   /**
-   * Permissions required: taskRuns.list
+   * Permissions required: bb.taskRuns.list
    *
    * @generated from rpc bytebase.v1.RolloutService.GetTaskRun
    */
@@ -1833,7 +1832,7 @@ export declare const RolloutService: GenService<{
     output: typeof TaskRunSchema;
   },
   /**
-   * Permissions required: taskRuns.list
+   * Permissions required: bb.taskRuns.list
    *
    * @generated from rpc bytebase.v1.RolloutService.GetTaskRunLog
    */
@@ -1843,7 +1842,7 @@ export declare const RolloutService: GenService<{
     output: typeof TaskRunLogSchema;
   },
   /**
-   * Permissions required: taskRuns.list
+   * Permissions required: bb.taskRuns.list
    *
    * @generated from rpc bytebase.v1.RolloutService.GetTaskRunSession
    */
@@ -1853,10 +1852,6 @@ export declare const RolloutService: GenService<{
     output: typeof TaskRunSessionSchema;
   },
   /**
-   * BatchRunTasks creates task runs for the specified tasks.
-   * DataExport issue only allows the creator to run the task.
-   * Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-   * Follow role-based rollout policy for the environment.
    * Permissions required: None
    *
    * @generated from rpc bytebase.v1.RolloutService.BatchRunTasks
@@ -1867,8 +1862,6 @@ export declare const RolloutService: GenService<{
     output: typeof BatchRunTasksResponseSchema;
   },
   /**
-   * BatchSkipTasks skips the specified tasks.
-   * The access is the same as BatchRunTasks().
    * Permissions required: None
    *
    * @generated from rpc bytebase.v1.RolloutService.BatchSkipTasks
@@ -1879,8 +1872,6 @@ export declare const RolloutService: GenService<{
     output: typeof BatchSkipTasksResponseSchema;
   },
   /**
-   * BatchCancelTaskRuns cancels the specified task runs in batch.
-   * The access is the same as BatchRunTasks().
    * Permissions required: None
    *
    * @generated from rpc bytebase.v1.RolloutService.BatchCancelTaskRuns
@@ -1891,7 +1882,7 @@ export declare const RolloutService: GenService<{
     output: typeof BatchCancelTaskRunsResponseSchema;
   },
   /**
-   * Permissions required: taskRuns.list
+   * Permissions required: bb.taskRuns.list
    *
    * @generated from rpc bytebase.v1.RolloutService.PreviewTaskRunRollback
    */

--- a/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
@@ -1772,6 +1772,8 @@ export declare const PreviewTaskRunRollbackResponseSchema: GenMessage<PreviewTas
  */
 export declare const RolloutService: GenService<{
   /**
+   * Permissions required: rollouts.get
+   *
    * @generated from rpc bytebase.v1.RolloutService.GetRollout
    */
   getRollout: {
@@ -1780,6 +1782,8 @@ export declare const RolloutService: GenService<{
     output: typeof RolloutSchema;
   },
   /**
+   * Permissions required: rollouts.list
+   *
    * @generated from rpc bytebase.v1.RolloutService.ListRollouts
    */
   listRollouts: {
@@ -1789,6 +1793,7 @@ export declare const RolloutService: GenService<{
   },
   /**
    * CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+   * Permissions required: rollouts.create
    *
    * @generated from rpc bytebase.v1.RolloutService.CreateRollout
    */
@@ -1798,6 +1803,8 @@ export declare const RolloutService: GenService<{
     output: typeof RolloutSchema;
   },
   /**
+   * Permissions required: rollouts.preview
+   *
    * @generated from rpc bytebase.v1.RolloutService.PreviewRollout
    */
   previewRollout: {
@@ -1806,6 +1813,8 @@ export declare const RolloutService: GenService<{
     output: typeof RolloutSchema;
   },
   /**
+   * Permissions required: taskRuns.list
+   *
    * @generated from rpc bytebase.v1.RolloutService.ListTaskRuns
    */
   listTaskRuns: {
@@ -1814,6 +1823,8 @@ export declare const RolloutService: GenService<{
     output: typeof ListTaskRunsResponseSchema;
   },
   /**
+   * Permissions required: taskRuns.list
+   *
    * @generated from rpc bytebase.v1.RolloutService.GetTaskRun
    */
   getTaskRun: {
@@ -1822,6 +1833,8 @@ export declare const RolloutService: GenService<{
     output: typeof TaskRunSchema;
   },
   /**
+   * Permissions required: taskRuns.list
+   *
    * @generated from rpc bytebase.v1.RolloutService.GetTaskRunLog
    */
   getTaskRunLog: {
@@ -1830,6 +1843,8 @@ export declare const RolloutService: GenService<{
     output: typeof TaskRunLogSchema;
   },
   /**
+   * Permissions required: taskRuns.list
+   *
    * @generated from rpc bytebase.v1.RolloutService.GetTaskRunSession
    */
   getTaskRunSession: {
@@ -1842,6 +1857,7 @@ export declare const RolloutService: GenService<{
    * DataExport issue only allows the creator to run the task.
    * Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
    * Follow role-based rollout policy for the environment.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.RolloutService.BatchRunTasks
    */
@@ -1853,6 +1869,7 @@ export declare const RolloutService: GenService<{
   /**
    * BatchSkipTasks skips the specified tasks.
    * The access is the same as BatchRunTasks().
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.RolloutService.BatchSkipTasks
    */
@@ -1864,6 +1881,7 @@ export declare const RolloutService: GenService<{
   /**
    * BatchCancelTaskRuns cancels the specified task runs in batch.
    * The access is the same as BatchRunTasks().
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.RolloutService.BatchCancelTaskRuns
    */
@@ -1873,6 +1891,8 @@ export declare const RolloutService: GenService<{
     output: typeof BatchCancelTaskRunsResponseSchema;
   },
   /**
+   * Permissions required: taskRuns.list
+   *
    * @generated from rpc bytebase.v1.RolloutService.PreviewTaskRunRollback
    */
   previewTaskRunRollback: {

--- a/frontend/src/types/proto-es/v1/setting_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/setting_service_pb.d.ts
@@ -1493,7 +1493,7 @@ export declare const DatabaseChangeModeSchema: GenEnum<DatabaseChangeMode>;
  */
 export declare const SettingService: GenService<{
   /**
-   * Permissions required: settings.list
+   * Permissions required: bb.settings.list
    *
    * @generated from rpc bytebase.v1.SettingService.ListSettings
    */
@@ -1503,7 +1503,7 @@ export declare const SettingService: GenService<{
     output: typeof ListSettingsResponseSchema;
   },
   /**
-   * Permissions required: settings.get
+   * Permissions required: bb.settings.get
    *
    * @generated from rpc bytebase.v1.SettingService.GetSetting
    */
@@ -1513,7 +1513,7 @@ export declare const SettingService: GenService<{
     output: typeof SettingSchema;
   },
   /**
-   * Permissions required: settings.set
+   * Permissions required: bb.settings.set
    *
    * @generated from rpc bytebase.v1.SettingService.UpdateSetting
    */

--- a/frontend/src/types/proto-es/v1/setting_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/setting_service_pb.d.ts
@@ -1493,6 +1493,8 @@ export declare const DatabaseChangeModeSchema: GenEnum<DatabaseChangeMode>;
  */
 export declare const SettingService: GenService<{
   /**
+   * Permissions required: settings.list
+   *
    * @generated from rpc bytebase.v1.SettingService.ListSettings
    */
   listSettings: {
@@ -1501,6 +1503,8 @@ export declare const SettingService: GenService<{
     output: typeof ListSettingsResponseSchema;
   },
   /**
+   * Permissions required: settings.get
+   *
    * @generated from rpc bytebase.v1.SettingService.GetSetting
    */
   getSetting: {
@@ -1509,6 +1513,8 @@ export declare const SettingService: GenService<{
     output: typeof SettingSchema;
   },
   /**
+   * Permissions required: settings.set
+   *
    * @generated from rpc bytebase.v1.SettingService.UpdateSetting
    */
   updateSetting: {

--- a/frontend/src/types/proto-es/v1/sheet_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/sheet_service_pb.d.ts
@@ -278,7 +278,7 @@ export declare const SheetCommandSchema: GenMessage<SheetCommand>;
  */
 export declare const SheetService: GenService<{
   /**
-   * Permissions required: sheets.create
+   * Permissions required: bb.sheets.create
    *
    * @generated from rpc bytebase.v1.SheetService.CreateSheet
    */
@@ -288,7 +288,7 @@ export declare const SheetService: GenService<{
     output: typeof SheetSchema;
   },
   /**
-   * Permissions required: sheets.create
+   * Permissions required: bb.sheets.create
    *
    * @generated from rpc bytebase.v1.SheetService.BatchCreateSheets
    */
@@ -298,7 +298,7 @@ export declare const SheetService: GenService<{
     output: typeof BatchCreateSheetsResponseSchema;
   },
   /**
-   * Permissions required: sheets.get
+   * Permissions required: bb.sheets.get
    *
    * @generated from rpc bytebase.v1.SheetService.GetSheet
    */
@@ -308,7 +308,7 @@ export declare const SheetService: GenService<{
     output: typeof SheetSchema;
   },
   /**
-   * Permissions required: sheets.update
+   * Permissions required: bb.sheets.update
    *
    * @generated from rpc bytebase.v1.SheetService.UpdateSheet
    */

--- a/frontend/src/types/proto-es/v1/sheet_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/sheet_service_pb.d.ts
@@ -278,6 +278,8 @@ export declare const SheetCommandSchema: GenMessage<SheetCommand>;
  */
 export declare const SheetService: GenService<{
   /**
+   * Permissions required: sheets.create
+   *
    * @generated from rpc bytebase.v1.SheetService.CreateSheet
    */
   createSheet: {
@@ -286,6 +288,8 @@ export declare const SheetService: GenService<{
     output: typeof SheetSchema;
   },
   /**
+   * Permissions required: sheets.create
+   *
    * @generated from rpc bytebase.v1.SheetService.BatchCreateSheets
    */
   batchCreateSheets: {
@@ -294,6 +298,8 @@ export declare const SheetService: GenService<{
     output: typeof BatchCreateSheetsResponseSchema;
   },
   /**
+   * Permissions required: sheets.get
+   *
    * @generated from rpc bytebase.v1.SheetService.GetSheet
    */
   getSheet: {
@@ -302,6 +308,8 @@ export declare const SheetService: GenService<{
     output: typeof SheetSchema;
   },
   /**
+   * Permissions required: sheets.update
+   *
    * @generated from rpc bytebase.v1.SheetService.UpdateSheet
    */
   updateSheet: {

--- a/frontend/src/types/proto-es/v1/sql_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/sql_service_pb.d.ts
@@ -1350,6 +1350,8 @@ export declare const AICompletionResponse_Candidate_Content_PartSchema: GenMessa
  */
 export declare const SQLService: GenService<{
   /**
+   * Permissions required: databases.get
+   *
    * @generated from rpc bytebase.v1.SQLService.Query
    */
   query: {
@@ -1358,6 +1360,8 @@ export declare const SQLService: GenService<{
     output: typeof QueryResponseSchema;
   },
   /**
+   * Permissions required: sql.admin
+   *
    * @generated from rpc bytebase.v1.SQLService.AdminExecute
    */
   adminExecute: {
@@ -1367,6 +1371,7 @@ export declare const SQLService: GenService<{
   },
   /**
    * SearchQueryHistories searches query histories for the caller.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.SQLService.SearchQueryHistories
    */
@@ -1376,6 +1381,8 @@ export declare const SQLService: GenService<{
     output: typeof SearchQueryHistoriesResponseSchema;
   },
   /**
+   * Permissions required: databases.get
+   *
    * @generated from rpc bytebase.v1.SQLService.Export
    */
   export: {
@@ -1384,6 +1391,8 @@ export declare const SQLService: GenService<{
     output: typeof ExportResponseSchema;
   },
   /**
+   * Permissions required: databases.check
+   *
    * @generated from rpc bytebase.v1.SQLService.Check
    */
   check: {
@@ -1392,6 +1401,8 @@ export declare const SQLService: GenService<{
     output: typeof CheckResponseSchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.SQLService.Pretty
    */
   pretty: {
@@ -1400,6 +1411,8 @@ export declare const SQLService: GenService<{
     output: typeof PrettyResponseSchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.SQLService.DiffMetadata
    */
   diffMetadata: {
@@ -1408,6 +1421,8 @@ export declare const SQLService: GenService<{
     output: typeof DiffMetadataResponseSchema;
   },
   /**
+   * Permissions required: None
+   *
    * @generated from rpc bytebase.v1.SQLService.AICompletion
    */
   aICompletion: {

--- a/frontend/src/types/proto-es/v1/sql_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/sql_service_pb.d.ts
@@ -1350,7 +1350,7 @@ export declare const AICompletionResponse_Candidate_Content_PartSchema: GenMessa
  */
 export declare const SQLService: GenService<{
   /**
-   * Permissions required: databases.get
+   * Permissions required: bb.databases.get
    *
    * @generated from rpc bytebase.v1.SQLService.Query
    */
@@ -1360,7 +1360,7 @@ export declare const SQLService: GenService<{
     output: typeof QueryResponseSchema;
   },
   /**
-   * Permissions required: sql.admin
+   * Permissions required: bb.sql.admin
    *
    * @generated from rpc bytebase.v1.SQLService.AdminExecute
    */
@@ -1381,7 +1381,7 @@ export declare const SQLService: GenService<{
     output: typeof SearchQueryHistoriesResponseSchema;
   },
   /**
-   * Permissions required: databases.get
+   * Permissions required: bb.databases.get
    *
    * @generated from rpc bytebase.v1.SQLService.Export
    */
@@ -1391,7 +1391,7 @@ export declare const SQLService: GenService<{
     output: typeof ExportResponseSchema;
   },
   /**
-   * Permissions required: databases.check
+   * Permissions required: bb.databases.check
    *
    * @generated from rpc bytebase.v1.SQLService.Check
    */

--- a/frontend/src/types/proto-es/v1/subscription_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/subscription_service_pb.d.ts
@@ -569,6 +569,7 @@ export declare const SubscriptionService: GenService<{
    * GetSubscription returns the current subscription.
    * If there is no license, we will return a free plan subscription without expiration time.
    * If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.SubscriptionService.GetSubscription
    */
@@ -578,6 +579,8 @@ export declare const SubscriptionService: GenService<{
     output: typeof SubscriptionSchema;
   },
   /**
+   * Permissions required: settings.set
+   *
    * @generated from rpc bytebase.v1.SubscriptionService.UpdateSubscription
    */
   updateSubscription: {

--- a/frontend/src/types/proto-es/v1/subscription_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/subscription_service_pb.d.ts
@@ -579,7 +579,7 @@ export declare const SubscriptionService: GenService<{
     output: typeof SubscriptionSchema;
   },
   /**
-   * Permissions required: settings.set
+   * Permissions required: bb.settings.set
    *
    * @generated from rpc bytebase.v1.SubscriptionService.UpdateSubscription
    */

--- a/frontend/src/types/proto-es/v1/user_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/user_service_pb.d.ts
@@ -416,6 +416,7 @@ export declare const UserService: GenService<{
   /**
    * Get the user.
    * Any authenticated user can get the user.
+   * Permissions required: users.get
    *
    * @generated from rpc bytebase.v1.UserService.GetUser
    */
@@ -427,6 +428,7 @@ export declare const UserService: GenService<{
   /**
    * Get the users in batch.
    * Any authenticated user can batch get users.
+   * Permissions required: users.get
    *
    * @generated from rpc bytebase.v1.UserService.BatchGetUsers
    */
@@ -437,6 +439,7 @@ export declare const UserService: GenService<{
   },
   /**
    * Get the current authenticated user.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.UserService.GetCurrentUser
    */
@@ -448,6 +451,7 @@ export declare const UserService: GenService<{
   /**
    * List all users.
    * Any authenticated user can list users.
+   * Permissions required: users.list
    *
    * @generated from rpc bytebase.v1.UserService.ListUsers
    */
@@ -460,6 +464,7 @@ export declare const UserService: GenService<{
    * Create a user.
    * When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
    * Otherwise, any unauthenticated user can create a user.
+   * Permissions required: users.create
    *
    * @generated from rpc bytebase.v1.UserService.CreateUser
    */
@@ -470,6 +475,7 @@ export declare const UserService: GenService<{
   },
   /**
    * Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+   * Permissions required: users.update
    *
    * @generated from rpc bytebase.v1.UserService.UpdateUser
    */
@@ -481,6 +487,7 @@ export declare const UserService: GenService<{
   /**
    * Only the user with bb.users.delete permission on the workspace can delete the user.
    * The last remaining workspace admin cannot be deleted.
+   * Permissions required: users.delete
    *
    * @generated from rpc bytebase.v1.UserService.DeleteUser
    */
@@ -491,6 +498,7 @@ export declare const UserService: GenService<{
   },
   /**
    * Only the user with bb.users.undelete permission on the workspace can undelete the user.
+   * Permissions required: users.undelete
    *
    * @generated from rpc bytebase.v1.UserService.UndeleteUser
    */

--- a/frontend/src/types/proto-es/v1/user_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/user_service_pb.d.ts
@@ -416,7 +416,7 @@ export declare const UserService: GenService<{
   /**
    * Get the user.
    * Any authenticated user can get the user.
-   * Permissions required: users.get
+   * Permissions required: bb.users.get
    *
    * @generated from rpc bytebase.v1.UserService.GetUser
    */
@@ -428,7 +428,7 @@ export declare const UserService: GenService<{
   /**
    * Get the users in batch.
    * Any authenticated user can batch get users.
-   * Permissions required: users.get
+   * Permissions required: bb.users.get
    *
    * @generated from rpc bytebase.v1.UserService.BatchGetUsers
    */
@@ -451,7 +451,7 @@ export declare const UserService: GenService<{
   /**
    * List all users.
    * Any authenticated user can list users.
-   * Permissions required: users.list
+   * Permissions required: bb.users.list
    *
    * @generated from rpc bytebase.v1.UserService.ListUsers
    */
@@ -464,7 +464,7 @@ export declare const UserService: GenService<{
    * Create a user.
    * When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
    * Otherwise, any unauthenticated user can create a user.
-   * Permissions required: users.create
+   * Permissions required: bb.users.create
    *
    * @generated from rpc bytebase.v1.UserService.CreateUser
    */
@@ -475,7 +475,7 @@ export declare const UserService: GenService<{
   },
   /**
    * Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-   * Permissions required: users.update
+   * Permissions required: bb.users.update
    *
    * @generated from rpc bytebase.v1.UserService.UpdateUser
    */
@@ -487,7 +487,7 @@ export declare const UserService: GenService<{
   /**
    * Only the user with bb.users.delete permission on the workspace can delete the user.
    * The last remaining workspace admin cannot be deleted.
-   * Permissions required: users.delete
+   * Permissions required: bb.users.delete
    *
    * @generated from rpc bytebase.v1.UserService.DeleteUser
    */
@@ -498,7 +498,7 @@ export declare const UserService: GenService<{
   },
   /**
    * Only the user with bb.users.undelete permission on the workspace can undelete the user.
-   * Permissions required: users.undelete
+   * Permissions required: bb.users.undelete
    *
    * @generated from rpc bytebase.v1.UserService.UndeleteUser
    */

--- a/frontend/src/types/proto-es/v1/worksheet_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/worksheet_service_pb.d.ts
@@ -376,6 +376,7 @@ export declare const Worksheet_VisibilitySchema: GenEnum<Worksheet_Visibility>;
 export declare const WorksheetService: GenService<{
   /**
    * Create a personal worksheet used in SQL Editor.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.WorksheetService.CreateWorksheet
    */
@@ -390,6 +391,7 @@ export declare const WorksheetService: GenService<{
    * - they are the creator of the worksheet;
    * - they have bb.worksheets.get permission on the workspace;
    * - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.WorksheetService.GetWorksheet
    */
@@ -402,6 +404,7 @@ export declare const WorksheetService: GenService<{
    * Search for worksheets.
    * This is used for finding my worksheets or worksheets shared by other people.
    * The sheet accessibility is the same as GetWorksheet().
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.WorksheetService.SearchWorksheets
    */
@@ -416,6 +419,7 @@ export declare const WorksheetService: GenService<{
    * - they are the creator of the worksheet;
    * - they have bb.worksheets.manage permission on the workspace;
    * - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.WorksheetService.UpdateWorksheet
    */
@@ -427,6 +431,7 @@ export declare const WorksheetService: GenService<{
   /**
    * Update the organizer of a worksheet.
    * The access is the same as UpdateWorksheet method.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.WorksheetService.UpdateWorksheetOrganizer
    */
@@ -438,6 +443,7 @@ export declare const WorksheetService: GenService<{
   /**
    * Delete a worksheet.
    * The access is the same as UpdateWorksheet method.
+   * Permissions required: None
    *
    * @generated from rpc bytebase.v1.WorksheetService.DeleteWorksheet
    */

--- a/frontend/src/types/proto-es/v1/workspace_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/workspace_service_pb.d.ts
@@ -15,7 +15,7 @@ export declare const file_v1_workspace_service: GenFile;
  */
 export declare const WorkspaceService: GenService<{
   /**
-   * Permissions required: workspaces.getIamPolicy
+   * Permissions required: bb.workspaces.getIamPolicy
    *
    * @generated from rpc bytebase.v1.WorkspaceService.GetIamPolicy
    */
@@ -25,7 +25,7 @@ export declare const WorkspaceService: GenService<{
     output: typeof IamPolicySchema;
   },
   /**
-   * Permissions required: workspaces.setIamPolicy
+   * Permissions required: bb.workspaces.setIamPolicy
    *
    * @generated from rpc bytebase.v1.WorkspaceService.SetIamPolicy
    */

--- a/frontend/src/types/proto-es/v1/workspace_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/workspace_service_pb.d.ts
@@ -15,6 +15,8 @@ export declare const file_v1_workspace_service: GenFile;
  */
 export declare const WorkspaceService: GenService<{
   /**
+   * Permissions required: workspaces.getIamPolicy
+   *
    * @generated from rpc bytebase.v1.WorkspaceService.GetIamPolicy
    */
   getIamPolicy: {
@@ -23,6 +25,8 @@ export declare const WorkspaceService: GenService<{
     output: typeof IamPolicySchema;
   },
   /**
+   * Permissions required: workspaces.setIamPolicy
+   *
    * @generated from rpc bytebase.v1.WorkspaceService.SetIamPolicy
    */
   setIamPolicy: {

--- a/frontend/src/types/proto/google/protobuf/descriptor.ts
+++ b/frontend/src/types/proto/google/protobuf/descriptor.ts
@@ -829,6 +829,7 @@ export interface FeatureSet {
   messageEncoding?: FeatureSet_MessageEncoding | undefined;
   jsonFormat?: FeatureSet_JsonFormat | undefined;
   enforceNamingStyle?: FeatureSet_EnforceNamingStyle | undefined;
+  defaultSymbolVisibility?: FeatureSet_VisibilityFeature_DefaultSymbolVisibility | undefined;
 }
 
 export enum FeatureSet_FieldPresence {
@@ -1205,6 +1206,92 @@ export function featureSet_EnforceNamingStyleToNumber(object: FeatureSet_Enforce
     case FeatureSet_EnforceNamingStyle.STYLE_LEGACY:
       return 2;
     case FeatureSet_EnforceNamingStyle.UNRECOGNIZED:
+    default:
+      return -1;
+  }
+}
+
+export interface FeatureSet_VisibilityFeature {
+}
+
+export enum FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+  DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN",
+  /** EXPORT_ALL - Default pre-EDITION_2024, all UNSET visibility are export. */
+  EXPORT_ALL = "EXPORT_ALL",
+  /** EXPORT_TOP_LEVEL - All top-level symbols default to export, nested default to local. */
+  EXPORT_TOP_LEVEL = "EXPORT_TOP_LEVEL",
+  /** LOCAL_ALL - All symbols default to local. */
+  LOCAL_ALL = "LOCAL_ALL",
+  /**
+   * STRICT - All symbols local by default. Nested types cannot be exported.
+   * With special case caveat for message { enum {} reserved 1 to max; }
+   * This is the recommended setting for new protos.
+   */
+  STRICT = "STRICT",
+  UNRECOGNIZED = "UNRECOGNIZED",
+}
+
+export function featureSet_VisibilityFeature_DefaultSymbolVisibilityFromJSON(
+  object: any,
+): FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+  switch (object) {
+    case 0:
+    case "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN;
+    case 1:
+    case "EXPORT_ALL":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_ALL;
+    case 2:
+    case "EXPORT_TOP_LEVEL":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_TOP_LEVEL;
+    case 3:
+    case "LOCAL_ALL":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.LOCAL_ALL;
+    case 4:
+    case "STRICT":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.STRICT;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.UNRECOGNIZED;
+  }
+}
+
+export function featureSet_VisibilityFeature_DefaultSymbolVisibilityToJSON(
+  object: FeatureSet_VisibilityFeature_DefaultSymbolVisibility,
+): string {
+  switch (object) {
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN:
+      return "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN";
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_ALL:
+      return "EXPORT_ALL";
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_TOP_LEVEL:
+      return "EXPORT_TOP_LEVEL";
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.LOCAL_ALL:
+      return "LOCAL_ALL";
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.STRICT:
+      return "STRICT";
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
+export function featureSet_VisibilityFeature_DefaultSymbolVisibilityToNumber(
+  object: FeatureSet_VisibilityFeature_DefaultSymbolVisibility,
+): number {
+  switch (object) {
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN:
+      return 0;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_ALL:
+      return 1;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_TOP_LEVEL:
+      return 2;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.LOCAL_ALL:
+      return 3;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.STRICT:
+      return 4;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.UNRECOGNIZED:
     default:
       return -1;
   }
@@ -2270,6 +2357,7 @@ function createBaseFeatureSet(): FeatureSet {
     messageEncoding: FeatureSet_MessageEncoding.MESSAGE_ENCODING_UNKNOWN,
     jsonFormat: FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN,
     enforceNamingStyle: FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN,
+    defaultSymbolVisibility: FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN,
   };
 }
 
@@ -2309,6 +2397,15 @@ export const FeatureSet: MessageFns<FeatureSet> = {
       message.enforceNamingStyle !== FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN
     ) {
       writer.uint32(56).int32(featureSet_EnforceNamingStyleToNumber(message.enforceNamingStyle));
+    }
+    if (
+      message.defaultSymbolVisibility !== undefined &&
+      message.defaultSymbolVisibility !==
+        FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN
+    ) {
+      writer.uint32(64).int32(
+        featureSet_VisibilityFeature_DefaultSymbolVisibilityToNumber(message.defaultSymbolVisibility),
+      );
     }
     return writer;
   },
@@ -2376,6 +2473,16 @@ export const FeatureSet: MessageFns<FeatureSet> = {
           message.enforceNamingStyle = featureSet_EnforceNamingStyleFromJSON(reader.int32());
           continue;
         }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.defaultSymbolVisibility = featureSet_VisibilityFeature_DefaultSymbolVisibilityFromJSON(
+            reader.int32(),
+          );
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2408,6 +2515,9 @@ export const FeatureSet: MessageFns<FeatureSet> = {
       enforceNamingStyle: isSet(object.enforceNamingStyle)
         ? featureSet_EnforceNamingStyleFromJSON(object.enforceNamingStyle)
         : FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN,
+      defaultSymbolVisibility: isSet(object.defaultSymbolVisibility)
+        ? featureSet_VisibilityFeature_DefaultSymbolVisibilityFromJSON(object.defaultSymbolVisibility)
+        : FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN,
     };
   },
 
@@ -2448,6 +2558,15 @@ export const FeatureSet: MessageFns<FeatureSet> = {
     ) {
       obj.enforceNamingStyle = featureSet_EnforceNamingStyleToJSON(message.enforceNamingStyle);
     }
+    if (
+      message.defaultSymbolVisibility !== undefined &&
+      message.defaultSymbolVisibility !==
+        FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN
+    ) {
+      obj.defaultSymbolVisibility = featureSet_VisibilityFeature_DefaultSymbolVisibilityToJSON(
+        message.defaultSymbolVisibility,
+      );
+    }
     return obj;
   },
 
@@ -2465,6 +2584,51 @@ export const FeatureSet: MessageFns<FeatureSet> = {
     message.jsonFormat = object.jsonFormat ?? FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN;
     message.enforceNamingStyle = object.enforceNamingStyle ??
       FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN;
+    message.defaultSymbolVisibility = object.defaultSymbolVisibility ??
+      FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN;
+    return message;
+  },
+};
+
+function createBaseFeatureSet_VisibilityFeature(): FeatureSet_VisibilityFeature {
+  return {};
+}
+
+export const FeatureSet_VisibilityFeature: MessageFns<FeatureSet_VisibilityFeature> = {
+  encode(_: FeatureSet_VisibilityFeature, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): FeatureSet_VisibilityFeature {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFeatureSet_VisibilityFeature();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): FeatureSet_VisibilityFeature {
+    return {};
+  },
+
+  toJSON(_: FeatureSet_VisibilityFeature): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<FeatureSet_VisibilityFeature>): FeatureSet_VisibilityFeature {
+    return FeatureSet_VisibilityFeature.fromPartial(base ?? {});
+  },
+  fromPartial(_: DeepPartial<FeatureSet_VisibilityFeature>): FeatureSet_VisibilityFeature {
+    const message = createBaseFeatureSet_VisibilityFeature();
     return message;
   },
 };

--- a/frontend/src/types/proto/v1/actuator_service.ts
+++ b/frontend/src/types/proto/v1/actuator_service.ts
@@ -954,7 +954,7 @@ export const ActuatorServiceDefinition = {
         },
       },
     },
-    /** Permissions required: settings.set */
+    /** Permissions required: bb.settings.set */
     updateActuatorInfo: {
       name: "UpdateActuatorInfo",
       requestType: UpdateActuatorInfoRequest,
@@ -1027,7 +1027,7 @@ export const ActuatorServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.create */
+    /** Permissions required: bb.projects.create */
     setupSample: {
       name: "SetupSample",
       requestType: SetupSampleRequest,

--- a/frontend/src/types/proto/v1/actuator_service.ts
+++ b/frontend/src/types/proto/v1/actuator_service.ts
@@ -937,6 +937,7 @@ export const ActuatorServiceDefinition = {
   name: "ActuatorService",
   fullName: "bytebase.v1.ActuatorService",
   methods: {
+    /** Permissions required: None */
     getActuatorInfo: {
       name: "GetActuatorInfo",
       requestType: GetActuatorInfoRequest,
@@ -953,6 +954,7 @@ export const ActuatorServiceDefinition = {
         },
       },
     },
+    /** Permissions required: settings.set */
     updateActuatorInfo: {
       name: "UpdateActuatorInfo",
       requestType: UpdateActuatorInfoRequest,
@@ -1025,6 +1027,7 @@ export const ActuatorServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.create */
     setupSample: {
       name: "SetupSample",
       requestType: SetupSampleRequest,
@@ -1071,6 +1074,7 @@ export const ActuatorServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     deleteCache: {
       name: "DeleteCache",
       requestType: DeleteCacheRequest,
@@ -1108,6 +1112,7 @@ export const ActuatorServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     getResourcePackage: {
       name: "GetResourcePackage",
       requestType: GetResourcePackageRequest,

--- a/frontend/src/types/proto/v1/audit_log_service.ts
+++ b/frontend/src/types/proto/v1/audit_log_service.ts
@@ -1060,6 +1060,7 @@ export const AuditLogServiceDefinition = {
   name: "AuditLogService",
   fullName: "bytebase.v1.AuditLogService",
   methods: {
+    /** Permissions required: None */
     searchAuditLogs: {
       name: "SearchAuditLogs",
       requestType: SearchAuditLogsRequest,
@@ -1152,6 +1153,7 @@ export const AuditLogServiceDefinition = {
         },
       },
     },
+    /** Permissions required: auditLogs.export */
     exportAuditLogs: {
       name: "ExportAuditLogs",
       requestType: ExportAuditLogsRequest,

--- a/frontend/src/types/proto/v1/audit_log_service.ts
+++ b/frontend/src/types/proto/v1/audit_log_service.ts
@@ -1153,7 +1153,7 @@ export const AuditLogServiceDefinition = {
         },
       },
     },
-    /** Permissions required: auditLogs.export */
+    /** Permissions required: bb.auditLogs.export */
     exportAuditLogs: {
       name: "ExportAuditLogs",
       requestType: ExportAuditLogsRequest,

--- a/frontend/src/types/proto/v1/auth_service.ts
+++ b/frontend/src/types/proto/v1/auth_service.ts
@@ -585,6 +585,7 @@ export const AuthServiceDefinition = {
   name: "AuthService",
   fullName: "bytebase.v1.AuthService",
   methods: {
+    /** Permissions required: None */
     login: {
       name: "Login",
       requestType: LoginRequest,
@@ -601,6 +602,7 @@ export const AuthServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     logout: {
       name: "Logout",
       requestType: LogoutRequest,

--- a/frontend/src/types/proto/v1/cel_service.ts
+++ b/frontend/src/types/proto/v1/cel_service.ts
@@ -280,6 +280,7 @@ export const CelServiceDefinition = {
   name: "CelService",
   fullName: "bytebase.v1.CelService",
   methods: {
+    /** Permissions required: None */
     batchParse: {
       name: "BatchParse",
       requestType: BatchParseRequest,
@@ -320,6 +321,7 @@ export const CelServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     batchDeparse: {
       name: "BatchDeparse",
       requestType: BatchDeparseRequest,

--- a/frontend/src/types/proto/v1/changelist_service.ts
+++ b/frontend/src/types/proto/v1/changelist_service.ts
@@ -794,6 +794,7 @@ export const ChangelistServiceDefinition = {
   name: "ChangelistService",
   fullName: "bytebase.v1.ChangelistService",
   methods: {
+    /** Permissions required: changelists.create */
     createChangelist: {
       name: "CreateChangelist",
       requestType: CreateChangelistRequest,
@@ -887,6 +888,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
+    /** Permissions required: changelists.get */
     getChangelist: {
       name: "GetChangelist",
       requestType: GetChangelistRequest,
@@ -945,6 +947,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
+    /** Permissions required: changelists.list */
     listChangelists: {
       name: "ListChangelists",
       requestType: ListChangelistsRequest,
@@ -1024,6 +1027,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
+    /** Permissions required: changelists.update */
     updateChangelist: {
       name: "UpdateChangelist",
       requestType: UpdateChangelistRequest,
@@ -1154,6 +1158,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
+    /** Permissions required: changelists.delete */
     deleteChangelist: {
       name: "DeleteChangelist",
       requestType: DeleteChangelistRequest,

--- a/frontend/src/types/proto/v1/changelist_service.ts
+++ b/frontend/src/types/proto/v1/changelist_service.ts
@@ -794,7 +794,7 @@ export const ChangelistServiceDefinition = {
   name: "ChangelistService",
   fullName: "bytebase.v1.ChangelistService",
   methods: {
-    /** Permissions required: changelists.create */
+    /** Permissions required: bb.changelists.create */
     createChangelist: {
       name: "CreateChangelist",
       requestType: CreateChangelistRequest,
@@ -888,7 +888,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
-    /** Permissions required: changelists.get */
+    /** Permissions required: bb.changelists.get */
     getChangelist: {
       name: "GetChangelist",
       requestType: GetChangelistRequest,
@@ -947,7 +947,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
-    /** Permissions required: changelists.list */
+    /** Permissions required: bb.changelists.list */
     listChangelists: {
       name: "ListChangelists",
       requestType: ListChangelistsRequest,
@@ -1027,7 +1027,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
-    /** Permissions required: changelists.update */
+    /** Permissions required: bb.changelists.update */
     updateChangelist: {
       name: "UpdateChangelist",
       requestType: UpdateChangelistRequest,
@@ -1158,7 +1158,7 @@ export const ChangelistServiceDefinition = {
         },
       },
     },
-    /** Permissions required: changelists.delete */
+    /** Permissions required: bb.changelists.delete */
     deleteChangelist: {
       name: "DeleteChangelist",
       requestType: DeleteChangelistRequest,

--- a/frontend/src/types/proto/v1/database_catalog_service.ts
+++ b/frontend/src/types/proto/v1/database_catalog_service.ts
@@ -1168,6 +1168,7 @@ export const DatabaseCatalogServiceDefinition = {
   name: "DatabaseCatalogService",
   fullName: "bytebase.v1.DatabaseCatalogService",
   methods: {
+    /** Permissions required: databaseCatalogs.get */
     getDatabaseCatalog: {
       name: "GetDatabaseCatalog",
       requestType: GetDatabaseCatalogRequest,
@@ -1258,6 +1259,7 @@ export const DatabaseCatalogServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databaseCatalogs.update */
     updateDatabaseCatalog: {
       name: "UpdateDatabaseCatalog",
       requestType: UpdateDatabaseCatalogRequest,

--- a/frontend/src/types/proto/v1/database_catalog_service.ts
+++ b/frontend/src/types/proto/v1/database_catalog_service.ts
@@ -1168,7 +1168,7 @@ export const DatabaseCatalogServiceDefinition = {
   name: "DatabaseCatalogService",
   fullName: "bytebase.v1.DatabaseCatalogService",
   methods: {
-    /** Permissions required: databaseCatalogs.get */
+    /** Permissions required: bb.databaseCatalogs.get */
     getDatabaseCatalog: {
       name: "GetDatabaseCatalog",
       requestType: GetDatabaseCatalogRequest,
@@ -1259,7 +1259,7 @@ export const DatabaseCatalogServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databaseCatalogs.update */
+    /** Permissions required: bb.databaseCatalogs.update */
     updateDatabaseCatalog: {
       name: "UpdateDatabaseCatalog",
       requestType: UpdateDatabaseCatalogRequest,

--- a/frontend/src/types/proto/v1/database_group_service.ts
+++ b/frontend/src/types/proto/v1/database_group_service.ts
@@ -906,7 +906,7 @@ export const DatabaseGroupServiceDefinition = {
   name: "DatabaseGroupService",
   fullName: "bytebase.v1.DatabaseGroupService",
   methods: {
-    /** Permissions required: projects.get */
+    /** Permissions required: bb.projects.get */
     listDatabaseGroups: {
       name: "ListDatabaseGroups",
       requestType: ListDatabaseGroupsRequest,
@@ -966,7 +966,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.get */
+    /** Permissions required: bb.projects.get */
     getDatabaseGroup: {
       name: "GetDatabaseGroup",
       requestType: GetDatabaseGroupRequest,
@@ -1026,7 +1026,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     createDatabaseGroup: {
       name: "CreateDatabaseGroup",
       requestType: CreateDatabaseGroupRequest,
@@ -1129,7 +1129,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     updateDatabaseGroup: {
       name: "UpdateDatabaseGroup",
       requestType: UpdateDatabaseGroupRequest,
@@ -1253,7 +1253,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     deleteDatabaseGroup: {
       name: "DeleteDatabaseGroup",
       requestType: DeleteDatabaseGroupRequest,

--- a/frontend/src/types/proto/v1/database_group_service.ts
+++ b/frontend/src/types/proto/v1/database_group_service.ts
@@ -906,6 +906,7 @@ export const DatabaseGroupServiceDefinition = {
   name: "DatabaseGroupService",
   fullName: "bytebase.v1.DatabaseGroupService",
   methods: {
+    /** Permissions required: projects.get */
     listDatabaseGroups: {
       name: "ListDatabaseGroups",
       requestType: ListDatabaseGroupsRequest,
@@ -965,6 +966,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.get */
     getDatabaseGroup: {
       name: "GetDatabaseGroup",
       requestType: GetDatabaseGroupRequest,
@@ -1024,6 +1026,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     createDatabaseGroup: {
       name: "CreateDatabaseGroup",
       requestType: CreateDatabaseGroupRequest,
@@ -1126,6 +1129,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     updateDatabaseGroup: {
       name: "UpdateDatabaseGroup",
       requestType: UpdateDatabaseGroupRequest,
@@ -1249,6 +1253,7 @@ export const DatabaseGroupServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     deleteDatabaseGroup: {
       name: "DeleteDatabaseGroup",
       requestType: DeleteDatabaseGroupRequest,

--- a/frontend/src/types/proto/v1/database_service.ts
+++ b/frontend/src/types/proto/v1/database_service.ts
@@ -9551,7 +9551,7 @@ export const DatabaseServiceDefinition = {
   name: "DatabaseService",
   fullName: "bytebase.v1.DatabaseService",
   methods: {
-    /** Permissions required: databases.get */
+    /** Permissions required: bb.databases.get */
     getDatabase: {
       name: "GetDatabase",
       requestType: GetDatabaseRequest,
@@ -9607,7 +9607,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.get */
+    /** Permissions required: bb.databases.get */
     batchGetDatabases: {
       name: "BatchGetDatabases",
       requestType: BatchGetDatabasesRequest,
@@ -9717,7 +9717,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.list */
+    /** Permissions required: bb.databases.list */
     listDatabases: {
       name: "ListDatabases",
       requestType: ListDatabasesRequest,
@@ -9849,7 +9849,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.update */
+    /** Permissions required: bb.databases.update */
     updateDatabase: {
       name: "UpdateDatabase",
       requestType: UpdateDatabaseRequest,
@@ -9951,7 +9951,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.update */
+    /** Permissions required: bb.databases.update */
     batchUpdateDatabases: {
       name: "BatchUpdateDatabases",
       requestType: BatchUpdateDatabasesRequest,
@@ -10024,7 +10024,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.sync */
+    /** Permissions required: bb.databases.sync */
     syncDatabase: {
       name: "SyncDatabase",
       requestType: SyncDatabaseRequest,
@@ -10087,7 +10087,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.sync */
+    /** Permissions required: bb.databases.sync */
     batchSyncDatabases: {
       name: "BatchSyncDatabases",
       requestType: BatchSyncDatabasesRequest,
@@ -10155,7 +10155,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.getSchema */
+    /** Permissions required: bb.databases.getSchema */
     getDatabaseMetadata: {
       name: "GetDatabaseMetadata",
       requestType: GetDatabaseMetadataRequest,
@@ -10245,7 +10245,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.getSchema */
+    /** Permissions required: bb.databases.getSchema */
     getDatabaseSchema: {
       name: "GetDatabaseSchema",
       requestType: GetDatabaseSchemaRequest,
@@ -10333,7 +10333,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.get */
+    /** Permissions required: bb.databases.get */
     diffSchema: {
       name: "DiffSchema",
       requestType: DiffSchemaRequest,
@@ -10467,7 +10467,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databaseSecrets.list */
+    /** Permissions required: bb.databaseSecrets.list */
     listSecrets: {
       name: "ListSecrets",
       requestType: ListSecretsRequest,
@@ -10560,7 +10560,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databaseSecrets.update */
+    /** Permissions required: bb.databaseSecrets.update */
     updateSecret: {
       name: "UpdateSecret",
       requestType: UpdateSecretRequest,
@@ -10670,7 +10670,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databaseSecrets.delete */
+    /** Permissions required: bb.databaseSecrets.delete */
     deleteSecret: {
       name: "DeleteSecret",
       requestType: DeleteSecretRequest,
@@ -10765,7 +10765,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: changelogs.list */
+    /** Permissions required: bb.changelogs.list */
     listChangelogs: {
       name: "ListChangelogs",
       requestType: ListChangelogsRequest,

--- a/frontend/src/types/proto/v1/database_service.ts
+++ b/frontend/src/types/proto/v1/database_service.ts
@@ -9551,6 +9551,7 @@ export const DatabaseServiceDefinition = {
   name: "DatabaseService",
   fullName: "bytebase.v1.DatabaseService",
   methods: {
+    /** Permissions required: databases.get */
     getDatabase: {
       name: "GetDatabase",
       requestType: GetDatabaseRequest,
@@ -9606,6 +9607,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.get */
     batchGetDatabases: {
       name: "BatchGetDatabases",
       requestType: BatchGetDatabasesRequest,
@@ -9715,6 +9717,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.list */
     listDatabases: {
       name: "ListDatabases",
       requestType: ListDatabasesRequest,
@@ -9846,6 +9849,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.update */
     updateDatabase: {
       name: "UpdateDatabase",
       requestType: UpdateDatabaseRequest,
@@ -9947,6 +9951,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.update */
     batchUpdateDatabases: {
       name: "BatchUpdateDatabases",
       requestType: BatchUpdateDatabasesRequest,
@@ -10019,6 +10024,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.sync */
     syncDatabase: {
       name: "SyncDatabase",
       requestType: SyncDatabaseRequest,
@@ -10081,6 +10087,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.sync */
     batchSyncDatabases: {
       name: "BatchSyncDatabases",
       requestType: BatchSyncDatabasesRequest,
@@ -10148,6 +10155,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.getSchema */
     getDatabaseMetadata: {
       name: "GetDatabaseMetadata",
       requestType: GetDatabaseMetadataRequest,
@@ -10237,6 +10245,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.getSchema */
     getDatabaseSchema: {
       name: "GetDatabaseSchema",
       requestType: GetDatabaseSchemaRequest,
@@ -10324,6 +10333,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.get */
     diffSchema: {
       name: "DiffSchema",
       requestType: DiffSchemaRequest,
@@ -10457,6 +10467,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databaseSecrets.list */
     listSecrets: {
       name: "ListSecrets",
       requestType: ListSecretsRequest,
@@ -10549,6 +10560,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databaseSecrets.update */
     updateSecret: {
       name: "UpdateSecret",
       requestType: UpdateSecretRequest,
@@ -10658,6 +10670,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databaseSecrets.delete */
     deleteSecret: {
       name: "DeleteSecret",
       requestType: DeleteSecretRequest,
@@ -10752,6 +10765,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: changelogs.list */
     listChangelogs: {
       name: "ListChangelogs",
       requestType: ListChangelogsRequest,
@@ -10822,6 +10836,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: changelogs.get */
     getChangelog: {
       name: "GetChangelog",
       requestType: GetChangelogRequest,
@@ -10890,6 +10905,7 @@ export const DatabaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.getSchema */
     getSchemaString: {
       name: "GetSchemaString",
       requestType: GetSchemaStringRequest,

--- a/frontend/src/types/proto/v1/group_service.ts
+++ b/frontend/src/types/proto/v1/group_service.ts
@@ -808,7 +808,7 @@ export const GroupServiceDefinition = {
   name: "GroupService",
   fullName: "bytebase.v1.GroupService",
   methods: {
-    /** Permissions required: groups.get */
+    /** Permissions required: bb.groups.get */
     getGroup: {
       name: "GetGroup",
       requestType: GetGroupRequest,
@@ -849,7 +849,7 @@ export const GroupServiceDefinition = {
         },
       },
     },
-    /** Permissions required: groups.list */
+    /** Permissions required: bb.groups.list */
     listGroups: {
       name: "ListGroups",
       requestType: ListGroupsRequest,
@@ -865,7 +865,7 @@ export const GroupServiceDefinition = {
         },
       },
     },
-    /** Permissions required: groups.create */
+    /** Permissions required: bb.groups.create */
     createGroup: {
       name: "CreateGroup",
       requestType: CreateGroupRequest,
@@ -887,7 +887,7 @@ export const GroupServiceDefinition = {
     /**
      * UpdateGroup updates the group.
      * Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-     * Permissions required: groups.update
+     * Permissions required: bb.groups.update
      */
     updateGroup: {
       name: "UpdateGroup",
@@ -943,7 +943,7 @@ export const GroupServiceDefinition = {
         },
       },
     },
-    /** Permissions required: groups.delete */
+    /** Permissions required: bb.groups.delete */
     deleteGroup: {
       name: "DeleteGroup",
       requestType: DeleteGroupRequest,

--- a/frontend/src/types/proto/v1/group_service.ts
+++ b/frontend/src/types/proto/v1/group_service.ts
@@ -808,6 +808,7 @@ export const GroupServiceDefinition = {
   name: "GroupService",
   fullName: "bytebase.v1.GroupService",
   methods: {
+    /** Permissions required: groups.get */
     getGroup: {
       name: "GetGroup",
       requestType: GetGroupRequest,
@@ -848,6 +849,7 @@ export const GroupServiceDefinition = {
         },
       },
     },
+    /** Permissions required: groups.list */
     listGroups: {
       name: "ListGroups",
       requestType: ListGroupsRequest,
@@ -863,6 +865,7 @@ export const GroupServiceDefinition = {
         },
       },
     },
+    /** Permissions required: groups.create */
     createGroup: {
       name: "CreateGroup",
       requestType: CreateGroupRequest,
@@ -884,6 +887,7 @@ export const GroupServiceDefinition = {
     /**
      * UpdateGroup updates the group.
      * Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+     * Permissions required: groups.update
      */
     updateGroup: {
       name: "UpdateGroup",
@@ -939,6 +943,7 @@ export const GroupServiceDefinition = {
         },
       },
     },
+    /** Permissions required: groups.delete */
     deleteGroup: {
       name: "DeleteGroup",
       requestType: DeleteGroupRequest,

--- a/frontend/src/types/proto/v1/idp_service.ts
+++ b/frontend/src/types/proto/v1/idp_service.ts
@@ -2189,6 +2189,7 @@ export const IdentityProviderServiceDefinition = {
   name: "IdentityProviderService",
   fullName: "bytebase.v1.IdentityProviderService",
   methods: {
+    /** Permissions required: identityProviders.get */
     getIdentityProvider: {
       name: "GetIdentityProvider",
       requestType: GetIdentityProviderRequest,
@@ -2234,6 +2235,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     listIdentityProviders: {
       name: "ListIdentityProviders",
       requestType: ListIdentityProvidersRequest,
@@ -2248,6 +2250,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
+    /** Permissions required: identityProviders.create */
     createIdentityProvider: {
       name: "CreateIdentityProvider",
       requestType: CreateIdentityProviderRequest,
@@ -2328,6 +2331,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
+    /** Permissions required: identityProviders.update */
     updateIdentityProvider: {
       name: "UpdateIdentityProvider",
       requestType: UpdateIdentityProviderRequest,
@@ -2468,6 +2472,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
+    /** Permissions required: identityProviders.delete */
     deleteIdentityProvider: {
       name: "DeleteIdentityProvider",
       requestType: DeleteIdentityProviderRequest,
@@ -2517,6 +2522,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
+    /** Permissions required: identityProviders.update */
     testIdentityProvider: {
       name: "TestIdentityProvider",
       requestType: TestIdentityProviderRequest,

--- a/frontend/src/types/proto/v1/idp_service.ts
+++ b/frontend/src/types/proto/v1/idp_service.ts
@@ -2189,7 +2189,7 @@ export const IdentityProviderServiceDefinition = {
   name: "IdentityProviderService",
   fullName: "bytebase.v1.IdentityProviderService",
   methods: {
-    /** Permissions required: identityProviders.get */
+    /** Permissions required: bb.identityProviders.get */
     getIdentityProvider: {
       name: "GetIdentityProvider",
       requestType: GetIdentityProviderRequest,
@@ -2250,7 +2250,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
-    /** Permissions required: identityProviders.create */
+    /** Permissions required: bb.identityProviders.create */
     createIdentityProvider: {
       name: "CreateIdentityProvider",
       requestType: CreateIdentityProviderRequest,
@@ -2331,7 +2331,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
-    /** Permissions required: identityProviders.update */
+    /** Permissions required: bb.identityProviders.update */
     updateIdentityProvider: {
       name: "UpdateIdentityProvider",
       requestType: UpdateIdentityProviderRequest,
@@ -2472,7 +2472,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
-    /** Permissions required: identityProviders.delete */
+    /** Permissions required: bb.identityProviders.delete */
     deleteIdentityProvider: {
       name: "DeleteIdentityProvider",
       requestType: DeleteIdentityProviderRequest,
@@ -2522,7 +2522,7 @@ export const IdentityProviderServiceDefinition = {
         },
       },
     },
-    /** Permissions required: identityProviders.update */
+    /** Permissions required: bb.identityProviders.update */
     testIdentityProvider: {
       name: "TestIdentityProvider",
       requestType: TestIdentityProviderRequest,

--- a/frontend/src/types/proto/v1/instance_role_service.ts
+++ b/frontend/src/types/proto/v1/instance_role_service.ts
@@ -480,7 +480,7 @@ export const InstanceRoleServiceDefinition = {
   name: "InstanceRoleService",
   fullName: "bytebase.v1.InstanceRoleService",
   methods: {
-    /** Permissions required: instanceRoles.get */
+    /** Permissions required: bb.instanceRoles.get */
     getInstanceRole: {
       name: "GetInstanceRole",
       requestType: GetInstanceRoleRequest,
@@ -556,7 +556,7 @@ export const InstanceRoleServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instanceRoles.get */
+    /** Permissions required: bb.instanceRoles.get */
     listInstanceRoles: {
       name: "ListInstanceRoles",
       requestType: ListInstanceRolesRequest,

--- a/frontend/src/types/proto/v1/instance_role_service.ts
+++ b/frontend/src/types/proto/v1/instance_role_service.ts
@@ -480,6 +480,7 @@ export const InstanceRoleServiceDefinition = {
   name: "InstanceRoleService",
   fullName: "bytebase.v1.InstanceRoleService",
   methods: {
+    /** Permissions required: instanceRoles.get */
     getInstanceRole: {
       name: "GetInstanceRole",
       requestType: GetInstanceRoleRequest,
@@ -555,6 +556,7 @@ export const InstanceRoleServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instanceRoles.get */
     listInstanceRoles: {
       name: "ListInstanceRoles",
       requestType: ListInstanceRolesRequest,

--- a/frontend/src/types/proto/v1/instance_service.ts
+++ b/frontend/src/types/proto/v1/instance_service.ts
@@ -4071,7 +4071,7 @@ export const InstanceServiceDefinition = {
   name: "InstanceService",
   fullName: "bytebase.v1.InstanceService",
   methods: {
-    /** Permissions required: instances.get */
+    /** Permissions required: bb.instances.get */
     getInstance: {
       name: "GetInstance",
       requestType: GetInstanceRequest,
@@ -4115,7 +4115,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.list */
+    /** Permissions required: bb.instances.list */
     listInstances: {
       name: "ListInstances",
       requestType: ListInstancesRequest,
@@ -4131,7 +4131,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.create */
+    /** Permissions required: bb.instances.create */
     createInstance: {
       name: "CreateInstance",
       requestType: CreateInstanceRequest,
@@ -4179,7 +4179,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.update */
+    /** Permissions required: bb.instances.update */
     updateInstance: {
       name: "UpdateInstance",
       requestType: UpdateInstanceRequest,
@@ -4290,7 +4290,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.delete */
+    /** Permissions required: bb.instances.delete */
     deleteInstance: {
       name: "DeleteInstance",
       requestType: DeleteInstanceRequest,
@@ -4358,7 +4358,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.undelete */
+    /** Permissions required: bb.instances.undelete */
     undeleteInstance: {
       name: "UndeleteInstance",
       requestType: UndeleteInstanceRequest,
@@ -4439,7 +4439,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.sync */
+    /** Permissions required: bb.instances.sync */
     syncInstance: {
       name: "SyncInstance",
       requestType: SyncInstanceRequest,
@@ -4490,7 +4490,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.get */
+    /** Permissions required: bb.instances.get */
     listInstanceDatabase: {
       name: "ListInstanceDatabase",
       requestType: ListInstanceDatabaseRequest,
@@ -4546,7 +4546,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.sync */
+    /** Permissions required: bb.instances.sync */
     batchSyncInstances: {
       name: "BatchSyncInstances",
       requestType: BatchSyncInstancesRequest,
@@ -4593,7 +4593,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.update */
+    /** Permissions required: bb.instances.update */
     batchUpdateInstances: {
       name: "BatchUpdateInstances",
       requestType: BatchUpdateInstancesRequest,
@@ -4666,7 +4666,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.update */
+    /** Permissions required: bb.instances.update */
     addDataSource: {
       name: "AddDataSource",
       requestType: AddDataSourceRequest,
@@ -4750,7 +4750,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.update */
+    /** Permissions required: bb.instances.update */
     removeDataSource: {
       name: "RemoveDataSource",
       requestType: RemoveDataSourceRequest,
@@ -4837,7 +4837,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: instances.update */
+    /** Permissions required: bb.instances.update */
     updateDataSource: {
       name: "UpdateDataSource",
       requestType: UpdateDataSourceRequest,

--- a/frontend/src/types/proto/v1/instance_service.ts
+++ b/frontend/src/types/proto/v1/instance_service.ts
@@ -4071,6 +4071,7 @@ export const InstanceServiceDefinition = {
   name: "InstanceService",
   fullName: "bytebase.v1.InstanceService",
   methods: {
+    /** Permissions required: instances.get */
     getInstance: {
       name: "GetInstance",
       requestType: GetInstanceRequest,
@@ -4114,6 +4115,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.list */
     listInstances: {
       name: "ListInstances",
       requestType: ListInstancesRequest,
@@ -4129,6 +4131,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.create */
     createInstance: {
       name: "CreateInstance",
       requestType: CreateInstanceRequest,
@@ -4176,6 +4179,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.update */
     updateInstance: {
       name: "UpdateInstance",
       requestType: UpdateInstanceRequest,
@@ -4286,6 +4290,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.delete */
     deleteInstance: {
       name: "DeleteInstance",
       requestType: DeleteInstanceRequest,
@@ -4353,6 +4358,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.undelete */
     undeleteInstance: {
       name: "UndeleteInstance",
       requestType: UndeleteInstanceRequest,
@@ -4433,6 +4439,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.sync */
     syncInstance: {
       name: "SyncInstance",
       requestType: SyncInstanceRequest,
@@ -4483,6 +4490,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.get */
     listInstanceDatabase: {
       name: "ListInstanceDatabase",
       requestType: ListInstanceDatabaseRequest,
@@ -4538,6 +4546,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.sync */
     batchSyncInstances: {
       name: "BatchSyncInstances",
       requestType: BatchSyncInstancesRequest,
@@ -4584,6 +4593,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.update */
     batchUpdateInstances: {
       name: "BatchUpdateInstances",
       requestType: BatchUpdateInstancesRequest,
@@ -4656,6 +4666,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.update */
     addDataSource: {
       name: "AddDataSource",
       requestType: AddDataSourceRequest,
@@ -4739,6 +4750,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.update */
     removeDataSource: {
       name: "RemoveDataSource",
       requestType: RemoveDataSourceRequest,
@@ -4825,6 +4837,7 @@ export const InstanceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: instances.update */
     updateDataSource: {
       name: "UpdateDataSource",
       requestType: UpdateDataSourceRequest,

--- a/frontend/src/types/proto/v1/issue_service.ts
+++ b/frontend/src/types/proto/v1/issue_service.ts
@@ -4138,7 +4138,7 @@ export const IssueServiceDefinition = {
   name: "IssueService",
   fullName: "bytebase.v1.IssueService",
   methods: {
-    /** Permissions required: issues.get */
+    /** Permissions required: bb.issues.get */
     getIssue: {
       name: "GetIssue",
       requestType: GetIssueRequest,
@@ -4190,7 +4190,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Permissions required: issues.create */
+    /** Permissions required: bb.issues.create */
     createIssue: {
       name: "CreateIssue",
       requestType: CreateIssueRequest,
@@ -4250,7 +4250,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Permissions required: issues.list */
+    /** Permissions required: bb.issues.list */
     listIssues: {
       name: "ListIssues",
       requestType: ListIssuesRequest,
@@ -4304,7 +4304,7 @@ export const IssueServiceDefinition = {
     },
     /**
      * Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-     * Permissions required: issues.get
+     * Permissions required: bb.issues.get
      */
     searchIssues: {
       name: "SearchIssues",
@@ -4366,7 +4366,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Permissions required: issues.update */
+    /** Permissions required: bb.issues.update */
     updateIssue: {
       name: "UpdateIssue",
       requestType: UpdateIssueRequest,
@@ -4432,7 +4432,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Permissions required: issueComments.list */
+    /** Permissions required: bb.issueComments.list */
     listIssueComments: {
       name: "ListIssueComments",
       requestType: ListIssueCommentsRequest,
@@ -4525,7 +4525,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Permissions required: issueComments.create */
+    /** Permissions required: bb.issueComments.create */
     createIssueComment: {
       name: "CreateIssueComment",
       requestType: CreateIssueCommentRequest,
@@ -4654,7 +4654,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Permissions required: issueComments.update */
+    /** Permissions required: bb.issueComments.update */
     updateIssueComment: {
       name: "UpdateIssueComment",
       requestType: UpdateIssueCommentRequest,
@@ -4795,7 +4795,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Permissions required: issues.update */
+    /** Permissions required: bb.issues.update */
     batchUpdateIssuesStatus: {
       name: "BatchUpdateIssuesStatus",
       requestType: BatchUpdateIssuesStatusRequest,

--- a/frontend/src/types/proto/v1/issue_service.ts
+++ b/frontend/src/types/proto/v1/issue_service.ts
@@ -4138,6 +4138,7 @@ export const IssueServiceDefinition = {
   name: "IssueService",
   fullName: "bytebase.v1.IssueService",
   methods: {
+    /** Permissions required: issues.get */
     getIssue: {
       name: "GetIssue",
       requestType: GetIssueRequest,
@@ -4189,6 +4190,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
+    /** Permissions required: issues.create */
     createIssue: {
       name: "CreateIssue",
       requestType: CreateIssueRequest,
@@ -4248,6 +4250,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
+    /** Permissions required: issues.list */
     listIssues: {
       name: "ListIssues",
       requestType: ListIssuesRequest,
@@ -4299,7 +4302,10 @@ export const IssueServiceDefinition = {
         },
       },
     },
-    /** Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query. */
+    /**
+     * Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+     * Permissions required: issues.get
+     */
     searchIssues: {
       name: "SearchIssues",
       requestType: SearchIssuesRequest,
@@ -4360,6 +4366,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
+    /** Permissions required: issues.update */
     updateIssue: {
       name: "UpdateIssue",
       requestType: UpdateIssueRequest,
@@ -4425,6 +4432,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
+    /** Permissions required: issueComments.list */
     listIssueComments: {
       name: "ListIssueComments",
       requestType: ListIssueCommentsRequest,
@@ -4517,6 +4525,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
+    /** Permissions required: issueComments.create */
     createIssueComment: {
       name: "CreateIssueComment",
       requestType: CreateIssueCommentRequest,
@@ -4645,6 +4654,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
+    /** Permissions required: issueComments.update */
     updateIssueComment: {
       name: "UpdateIssueComment",
       requestType: UpdateIssueCommentRequest,
@@ -4785,6 +4795,7 @@ export const IssueServiceDefinition = {
         },
       },
     },
+    /** Permissions required: issues.update */
     batchUpdateIssuesStatus: {
       name: "BatchUpdateIssuesStatus",
       requestType: BatchUpdateIssuesStatusRequest,
@@ -4860,6 +4871,7 @@ export const IssueServiceDefinition = {
     /**
      * ApproveIssue approves the issue.
      * The access is based on approval flow.
+     * Permissions required: None
      */
     approveIssue: {
       name: "ApproveIssue",
@@ -4925,6 +4937,7 @@ export const IssueServiceDefinition = {
     /**
      * RejectIssue rejects the issue.
      * The access is based on approval flow.
+     * Permissions required: None
      */
     rejectIssue: {
       name: "RejectIssue",
@@ -4989,6 +5002,7 @@ export const IssueServiceDefinition = {
     /**
      * RequestIssue requests the issue.
      * The access is based on approval flow.
+     * Permissions required: None
      */
     requestIssue: {
       name: "RequestIssue",

--- a/frontend/src/types/proto/v1/org_policy_service.ts
+++ b/frontend/src/types/proto/v1/org_policy_service.ts
@@ -2483,7 +2483,7 @@ export const OrgPolicyServiceDefinition = {
   name: "OrgPolicyService",
   fullName: "bytebase.v1.OrgPolicyService",
   methods: {
-    /** Permissions required: policies.get */
+    /** Permissions required: bb.policies.get */
     getPolicy: {
       name: "GetPolicy",
       requestType: GetPolicyRequest,
@@ -2689,7 +2689,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
-    /** Permissions required: policies.list */
+    /** Permissions required: bb.policies.list */
     listPolicies: {
       name: "ListPolicies",
       requestType: ListPoliciesRequest,
@@ -2886,7 +2886,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
-    /** Permissions required: policies.create */
+    /** Permissions required: bb.policies.create */
     createPolicy: {
       name: "CreatePolicy",
       requestType: CreatePolicyRequest,
@@ -3126,7 +3126,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
-    /** Permissions required: policies.update */
+    /** Permissions required: bb.policies.update */
     updatePolicy: {
       name: "UpdatePolicy",
       requestType: UpdatePolicyRequest,
@@ -3412,7 +3412,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
-    /** Permissions required: policies.delete */
+    /** Permissions required: bb.policies.delete */
     deletePolicy: {
       name: "DeletePolicy",
       requestType: DeletePolicyRequest,

--- a/frontend/src/types/proto/v1/org_policy_service.ts
+++ b/frontend/src/types/proto/v1/org_policy_service.ts
@@ -2483,6 +2483,7 @@ export const OrgPolicyServiceDefinition = {
   name: "OrgPolicyService",
   fullName: "bytebase.v1.OrgPolicyService",
   methods: {
+    /** Permissions required: policies.get */
     getPolicy: {
       name: "GetPolicy",
       requestType: GetPolicyRequest,
@@ -2688,6 +2689,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
+    /** Permissions required: policies.list */
     listPolicies: {
       name: "ListPolicies",
       requestType: ListPoliciesRequest,
@@ -2884,6 +2886,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
+    /** Permissions required: policies.create */
     createPolicy: {
       name: "CreatePolicy",
       requestType: CreatePolicyRequest,
@@ -3123,6 +3126,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
+    /** Permissions required: policies.update */
     updatePolicy: {
       name: "UpdatePolicy",
       requestType: UpdatePolicyRequest,
@@ -3408,6 +3412,7 @@ export const OrgPolicyServiceDefinition = {
         },
       },
     },
+    /** Permissions required: policies.delete */
     deletePolicy: {
       name: "DeletePolicy",
       requestType: DeletePolicyRequest,

--- a/frontend/src/types/proto/v1/plan_service.ts
+++ b/frontend/src/types/proto/v1/plan_service.ts
@@ -3396,7 +3396,7 @@ export const PlanServiceDefinition = {
   name: "PlanService",
   fullName: "bytebase.v1.PlanService",
   methods: {
-    /** Permissions required: plans.get */
+    /** Permissions required: bb.plans.get */
     getPlan: {
       name: "GetPlan",
       requestType: GetPlanRequest,
@@ -3447,7 +3447,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
-    /** Permissions required: plans.list */
+    /** Permissions required: bb.plans.list */
     listPlans: {
       name: "ListPlans",
       requestType: ListPlansRequest,
@@ -3500,7 +3500,7 @@ export const PlanServiceDefinition = {
     },
     /**
      * Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-     * Permissions required: plans.get
+     * Permissions required: bb.plans.get
      */
     searchPlans: {
       name: "SearchPlans",
@@ -3562,7 +3562,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
-    /** Permissions required: plans.create */
+    /** Permissions required: bb.plans.create */
     createPlan: {
       name: "CreatePlan",
       requestType: CreatePlanRequest,
@@ -3623,7 +3623,7 @@ export const PlanServiceDefinition = {
     /**
      * UpdatePlan updates the plan.
      * The plan creator and the user with bb.plans.update permission on the project can update the plan.
-     * Permissions required: plans.update
+     * Permissions required: bb.plans.update
      */
     updatePlan: {
       name: "UpdatePlan",
@@ -3687,7 +3687,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
-    /** Permissions required: planCheckRuns.list */
+    /** Permissions required: bb.planCheckRuns.list */
     listPlanCheckRuns: {
       name: "ListPlanCheckRuns",
       requestType: ListPlanCheckRunsRequest,
@@ -3779,7 +3779,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
-    /** Permissions required: planCheckRuns.run */
+    /** Permissions required: bb.planCheckRuns.run */
     runPlanChecks: {
       name: "RunPlanChecks",
       requestType: RunPlanChecksRequest,
@@ -3871,7 +3871,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
-    /** Permissions required: planCheckRuns.run */
+    /** Permissions required: bb.planCheckRuns.run */
     batchCancelPlanCheckRuns: {
       name: "BatchCancelPlanCheckRuns",
       requestType: BatchCancelPlanCheckRunsRequest,

--- a/frontend/src/types/proto/v1/plan_service.ts
+++ b/frontend/src/types/proto/v1/plan_service.ts
@@ -3396,6 +3396,7 @@ export const PlanServiceDefinition = {
   name: "PlanService",
   fullName: "bytebase.v1.PlanService",
   methods: {
+    /** Permissions required: plans.get */
     getPlan: {
       name: "GetPlan",
       requestType: GetPlanRequest,
@@ -3446,6 +3447,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
+    /** Permissions required: plans.list */
     listPlans: {
       name: "ListPlans",
       requestType: ListPlansRequest,
@@ -3496,7 +3498,10 @@ export const PlanServiceDefinition = {
         },
       },
     },
-    /** Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query. */
+    /**
+     * Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+     * Permissions required: plans.get
+     */
     searchPlans: {
       name: "SearchPlans",
       requestType: SearchPlansRequest,
@@ -3557,6 +3562,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
+    /** Permissions required: plans.create */
     createPlan: {
       name: "CreatePlan",
       requestType: CreatePlanRequest,
@@ -3617,6 +3623,7 @@ export const PlanServiceDefinition = {
     /**
      * UpdatePlan updates the plan.
      * The plan creator and the user with bb.plans.update permission on the project can update the plan.
+     * Permissions required: plans.update
      */
     updatePlan: {
       name: "UpdatePlan",
@@ -3680,6 +3687,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
+    /** Permissions required: planCheckRuns.list */
     listPlanCheckRuns: {
       name: "ListPlanCheckRuns",
       requestType: ListPlanCheckRunsRequest,
@@ -3771,6 +3779,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
+    /** Permissions required: planCheckRuns.run */
     runPlanChecks: {
       name: "RunPlanChecks",
       requestType: RunPlanChecksRequest,
@@ -3862,6 +3871,7 @@ export const PlanServiceDefinition = {
         },
       },
     },
+    /** Permissions required: planCheckRuns.run */
     batchCancelPlanCheckRuns: {
       name: "BatchCancelPlanCheckRuns",
       requestType: BatchCancelPlanCheckRunsRequest,

--- a/frontend/src/types/proto/v1/project_service.ts
+++ b/frontend/src/types/proto/v1/project_service.ts
@@ -2611,6 +2611,7 @@ export const ProjectServiceDefinition = {
     /**
      * GetProject retrieves a project by name.
      * Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+     * Permissions required: projects.get
      */
     getProject: {
       name: "GetProject",
@@ -2654,6 +2655,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.list */
     listProjects: {
       name: "ListProjects",
       requestType: ListProjectsRequest,
@@ -2669,6 +2671,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     searchProjects: {
       name: "SearchProjects",
       requestType: SearchProjectsRequest,
@@ -2711,6 +2714,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.create */
     createProject: {
       name: "CreateProject",
       requestType: CreateProjectRequest,
@@ -2755,6 +2759,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     updateProject: {
       name: "UpdateProject",
       requestType: UpdateProjectRequest,
@@ -2839,6 +2844,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.delete */
     deleteProject: {
       name: "DeleteProject",
       requestType: DeleteProjectRequest,
@@ -2883,6 +2889,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.undelete */
     undeleteProject: {
       name: "UndeleteProject",
       requestType: UndeleteProjectRequest,
@@ -2960,6 +2967,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.delete */
     batchDeleteProjects: {
       name: "BatchDeleteProjects",
       requestType: BatchDeleteProjectsRequest,
@@ -3009,6 +3017,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.getIamPolicy */
     getIamPolicy: {
       name: "GetIamPolicy",
       requestType: GetIamPolicyRequest,
@@ -3095,7 +3104,10 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Deprecated. */
+    /**
+     * Deprecated.
+     * Permissions required: projects.getIamPolicy
+     */
     batchGetIamPolicy: {
       name: "BatchGetIamPolicy",
       requestType: BatchGetIamPolicyRequest,
@@ -3180,6 +3192,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.setIamPolicy */
     setIamPolicy: {
       name: "SetIamPolicy",
       requestType: SetIamPolicyRequest,
@@ -3270,6 +3283,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     addWebhook: {
       name: "AddWebhook",
       requestType: AddWebhookRequest,
@@ -3330,6 +3344,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     updateWebhook: {
       name: "UpdateWebhook",
       requestType: UpdateWebhookRequest,
@@ -3433,6 +3448,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     removeWebhook: {
       name: "RemoveWebhook",
       requestType: RemoveWebhookRequest,
@@ -3512,6 +3528,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
+    /** Permissions required: projects.update */
     testWebhook: {
       name: "TestWebhook",
       requestType: TestWebhookRequest,

--- a/frontend/src/types/proto/v1/project_service.ts
+++ b/frontend/src/types/proto/v1/project_service.ts
@@ -2611,7 +2611,7 @@ export const ProjectServiceDefinition = {
     /**
      * GetProject retrieves a project by name.
      * Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-     * Permissions required: projects.get
+     * Permissions required: bb.projects.get
      */
     getProject: {
       name: "GetProject",
@@ -2655,7 +2655,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.list */
+    /** Permissions required: bb.projects.list */
     listProjects: {
       name: "ListProjects",
       requestType: ListProjectsRequest,
@@ -2714,7 +2714,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.create */
+    /** Permissions required: bb.projects.create */
     createProject: {
       name: "CreateProject",
       requestType: CreateProjectRequest,
@@ -2759,7 +2759,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     updateProject: {
       name: "UpdateProject",
       requestType: UpdateProjectRequest,
@@ -2844,7 +2844,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.delete */
+    /** Permissions required: bb.projects.delete */
     deleteProject: {
       name: "DeleteProject",
       requestType: DeleteProjectRequest,
@@ -2889,7 +2889,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.undelete */
+    /** Permissions required: bb.projects.undelete */
     undeleteProject: {
       name: "UndeleteProject",
       requestType: UndeleteProjectRequest,
@@ -2967,7 +2967,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.delete */
+    /** Permissions required: bb.projects.delete */
     batchDeleteProjects: {
       name: "BatchDeleteProjects",
       requestType: BatchDeleteProjectsRequest,
@@ -3017,7 +3017,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.getIamPolicy */
+    /** Permissions required: bb.projects.getIamPolicy */
     getIamPolicy: {
       name: "GetIamPolicy",
       requestType: GetIamPolicyRequest,
@@ -3106,7 +3106,7 @@ export const ProjectServiceDefinition = {
     },
     /**
      * Deprecated.
-     * Permissions required: projects.getIamPolicy
+     * Permissions required: bb.projects.getIamPolicy
      */
     batchGetIamPolicy: {
       name: "BatchGetIamPolicy",
@@ -3192,7 +3192,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.setIamPolicy */
+    /** Permissions required: bb.projects.setIamPolicy */
     setIamPolicy: {
       name: "SetIamPolicy",
       requestType: SetIamPolicyRequest,
@@ -3283,7 +3283,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     addWebhook: {
       name: "AddWebhook",
       requestType: AddWebhookRequest,
@@ -3344,7 +3344,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     updateWebhook: {
       name: "UpdateWebhook",
       requestType: UpdateWebhookRequest,
@@ -3448,7 +3448,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     removeWebhook: {
       name: "RemoveWebhook",
       requestType: RemoveWebhookRequest,
@@ -3528,7 +3528,7 @@ export const ProjectServiceDefinition = {
         },
       },
     },
-    /** Permissions required: projects.update */
+    /** Permissions required: bb.projects.update */
     testWebhook: {
       name: "TestWebhook",
       requestType: TestWebhookRequest,

--- a/frontend/src/types/proto/v1/release_service.ts
+++ b/frontend/src/types/proto/v1/release_service.ts
@@ -1631,6 +1631,7 @@ export const ReleaseServiceDefinition = {
   name: "ReleaseService",
   fullName: "bytebase.v1.ReleaseService",
   methods: {
+    /** Permissions required: releases.get */
     getRelease: {
       name: "GetRelease",
       requestType: GetReleaseRequest,
@@ -1684,6 +1685,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: releases.list */
     listReleases: {
       name: "ListReleases",
       requestType: ListReleasesRequest,
@@ -1737,6 +1739,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: releases.create */
     createRelease: {
       name: "CreateRelease",
       requestType: CreateReleaseRequest,
@@ -1801,6 +1804,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: releases.update */
     updateRelease: {
       name: "UpdateRelease",
       requestType: UpdateReleaseRequest,
@@ -1896,6 +1900,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: releases.delete */
     deleteRelease: {
       name: "DeleteRelease",
       requestType: DeleteReleaseRequest,
@@ -1951,6 +1956,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: releases.undelete */
     undeleteRelease: {
       name: "UndeleteRelease",
       requestType: UndeleteReleaseRequest,
@@ -2036,6 +2042,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
+    /** Permissions required: releases.check */
     checkRelease: {
       name: "CheckRelease",
       requestType: CheckReleaseRequest,

--- a/frontend/src/types/proto/v1/release_service.ts
+++ b/frontend/src/types/proto/v1/release_service.ts
@@ -1631,7 +1631,7 @@ export const ReleaseServiceDefinition = {
   name: "ReleaseService",
   fullName: "bytebase.v1.ReleaseService",
   methods: {
-    /** Permissions required: releases.get */
+    /** Permissions required: bb.releases.get */
     getRelease: {
       name: "GetRelease",
       requestType: GetReleaseRequest,
@@ -1685,7 +1685,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: releases.list */
+    /** Permissions required: bb.releases.list */
     listReleases: {
       name: "ListReleases",
       requestType: ListReleasesRequest,
@@ -1739,7 +1739,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: releases.create */
+    /** Permissions required: bb.releases.create */
     createRelease: {
       name: "CreateRelease",
       requestType: CreateReleaseRequest,
@@ -1804,7 +1804,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: releases.update */
+    /** Permissions required: bb.releases.update */
     updateRelease: {
       name: "UpdateRelease",
       requestType: UpdateReleaseRequest,
@@ -1900,7 +1900,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: releases.delete */
+    /** Permissions required: bb.releases.delete */
     deleteRelease: {
       name: "DeleteRelease",
       requestType: DeleteReleaseRequest,
@@ -1956,7 +1956,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: releases.undelete */
+    /** Permissions required: bb.releases.undelete */
     undeleteRelease: {
       name: "UndeleteRelease",
       requestType: UndeleteReleaseRequest,
@@ -2042,7 +2042,7 @@ export const ReleaseServiceDefinition = {
         },
       },
     },
-    /** Permissions required: releases.check */
+    /** Permissions required: bb.releases.check */
     checkRelease: {
       name: "CheckRelease",
       requestType: CheckReleaseRequest,

--- a/frontend/src/types/proto/v1/review_config_service.ts
+++ b/frontend/src/types/proto/v1/review_config_service.ts
@@ -654,7 +654,7 @@ export const ReviewConfigServiceDefinition = {
   name: "ReviewConfigService",
   fullName: "bytebase.v1.ReviewConfigService",
   methods: {
-    /** Permissions required: reviewConfigs.create */
+    /** Permissions required: bb.reviewConfigs.create */
     createReviewConfig: {
       name: "CreateReviewConfig",
       requestType: CreateReviewConfigRequest,
@@ -735,7 +735,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
-    /** Permissions required: reviewConfigs.list */
+    /** Permissions required: bb.reviewConfigs.list */
     listReviewConfigs: {
       name: "ListReviewConfigs",
       requestType: ListReviewConfigsRequest,
@@ -799,7 +799,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
-    /** Permissions required: reviewConfigs.get */
+    /** Permissions required: bb.reviewConfigs.get */
     getReviewConfig: {
       name: "GetReviewConfig",
       requestType: GetReviewConfigRequest,
@@ -871,7 +871,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
-    /** Permissions required: reviewConfigs.update */
+    /** Permissions required: bb.reviewConfigs.update */
     updateReviewConfig: {
       name: "UpdateReviewConfig",
       requestType: UpdateReviewConfigRequest,
@@ -1004,7 +1004,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
-    /** Permissions required: reviewConfigs.delete */
+    /** Permissions required: bb.reviewConfigs.delete */
     deleteReviewConfig: {
       name: "DeleteReviewConfig",
       requestType: DeleteReviewConfigRequest,

--- a/frontend/src/types/proto/v1/review_config_service.ts
+++ b/frontend/src/types/proto/v1/review_config_service.ts
@@ -654,6 +654,7 @@ export const ReviewConfigServiceDefinition = {
   name: "ReviewConfigService",
   fullName: "bytebase.v1.ReviewConfigService",
   methods: {
+    /** Permissions required: reviewConfigs.create */
     createReviewConfig: {
       name: "CreateReviewConfig",
       requestType: CreateReviewConfigRequest,
@@ -734,6 +735,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
+    /** Permissions required: reviewConfigs.list */
     listReviewConfigs: {
       name: "ListReviewConfigs",
       requestType: ListReviewConfigsRequest,
@@ -797,6 +799,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
+    /** Permissions required: reviewConfigs.get */
     getReviewConfig: {
       name: "GetReviewConfig",
       requestType: GetReviewConfigRequest,
@@ -868,6 +871,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
+    /** Permissions required: reviewConfigs.update */
     updateReviewConfig: {
       name: "UpdateReviewConfig",
       requestType: UpdateReviewConfigRequest,
@@ -1000,6 +1004,7 @@ export const ReviewConfigServiceDefinition = {
         },
       },
     },
+    /** Permissions required: reviewConfigs.delete */
     deleteReviewConfig: {
       name: "DeleteReviewConfig",
       requestType: DeleteReviewConfigRequest,

--- a/frontend/src/types/proto/v1/revision_service.ts
+++ b/frontend/src/types/proto/v1/revision_service.ts
@@ -933,7 +933,7 @@ export const RevisionServiceDefinition = {
   name: "RevisionService",
   fullName: "bytebase.v1.RevisionService",
   methods: {
-    /** Permissions required: revisions.list */
+    /** Permissions required: bb.revisions.list */
     listRevisions: {
       name: "ListRevisions",
       requestType: ListRevisionsRequest,
@@ -1003,7 +1003,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
-    /** Permissions required: revisions.get */
+    /** Permissions required: bb.revisions.get */
     getRevision: {
       name: "GetRevision",
       requestType: GetRevisionRequest,
@@ -1071,7 +1071,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
-    /** Permissions required: revisions.create */
+    /** Permissions required: bb.revisions.create */
     createRevision: {
       name: "CreateRevision",
       requestType: CreateRevisionRequest,
@@ -1171,7 +1171,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
-    /** Permissions required: revisions.create */
+    /** Permissions required: bb.revisions.create */
     batchCreateRevisions: {
       name: "BatchCreateRevisions",
       requestType: BatchCreateRevisionsRequest,
@@ -1276,7 +1276,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
-    /** Permissions required: revisions.delete */
+    /** Permissions required: bb.revisions.delete */
     deleteRevision: {
       name: "DeleteRevision",
       requestType: DeleteRevisionRequest,

--- a/frontend/src/types/proto/v1/revision_service.ts
+++ b/frontend/src/types/proto/v1/revision_service.ts
@@ -933,6 +933,7 @@ export const RevisionServiceDefinition = {
   name: "RevisionService",
   fullName: "bytebase.v1.RevisionService",
   methods: {
+    /** Permissions required: revisions.list */
     listRevisions: {
       name: "ListRevisions",
       requestType: ListRevisionsRequest,
@@ -1002,6 +1003,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
+    /** Permissions required: revisions.get */
     getRevision: {
       name: "GetRevision",
       requestType: GetRevisionRequest,
@@ -1069,6 +1071,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
+    /** Permissions required: revisions.create */
     createRevision: {
       name: "CreateRevision",
       requestType: CreateRevisionRequest,
@@ -1168,6 +1171,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
+    /** Permissions required: revisions.create */
     batchCreateRevisions: {
       name: "BatchCreateRevisions",
       requestType: BatchCreateRevisionsRequest,
@@ -1272,6 +1276,7 @@ export const RevisionServiceDefinition = {
         },
       },
     },
+    /** Permissions required: revisions.delete */
     deleteRevision: {
       name: "DeleteRevision",
       requestType: DeleteRevisionRequest,

--- a/frontend/src/types/proto/v1/risk_service.ts
+++ b/frontend/src/types/proto/v1/risk_service.ts
@@ -785,6 +785,7 @@ export const RiskServiceDefinition = {
   name: "RiskService",
   fullName: "bytebase.v1.RiskService",
   methods: {
+    /** Permissions required: risks.list */
     listRisks: {
       name: "ListRisks",
       requestType: ListRisksRequest,
@@ -800,6 +801,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
+    /** Permissions required: risks.create */
     createRisk: {
       name: "CreateRisk",
       requestType: CreateRiskRequest,
@@ -816,6 +818,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
+    /** Permissions required: risks.list */
     getRisk: {
       name: "GetRisk",
       requestType: GetRiskRequest,
@@ -855,6 +858,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
+    /** Permissions required: risks.update */
     updateRisk: {
       name: "UpdateRisk",
       requestType: UpdateRiskRequest,
@@ -906,6 +910,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
+    /** Permissions required: risks.delete */
     deleteRisk: {
       name: "DeleteRisk",
       requestType: DeleteRiskRequest,

--- a/frontend/src/types/proto/v1/risk_service.ts
+++ b/frontend/src/types/proto/v1/risk_service.ts
@@ -785,7 +785,7 @@ export const RiskServiceDefinition = {
   name: "RiskService",
   fullName: "bytebase.v1.RiskService",
   methods: {
-    /** Permissions required: risks.list */
+    /** Permissions required: bb.risks.list */
     listRisks: {
       name: "ListRisks",
       requestType: ListRisksRequest,
@@ -801,7 +801,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
-    /** Permissions required: risks.create */
+    /** Permissions required: bb.risks.create */
     createRisk: {
       name: "CreateRisk",
       requestType: CreateRiskRequest,
@@ -818,7 +818,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
-    /** Permissions required: risks.list */
+    /** Permissions required: bb.risks.list */
     getRisk: {
       name: "GetRisk",
       requestType: GetRiskRequest,
@@ -858,7 +858,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
-    /** Permissions required: risks.update */
+    /** Permissions required: bb.risks.update */
     updateRisk: {
       name: "UpdateRisk",
       requestType: UpdateRiskRequest,
@@ -910,7 +910,7 @@ export const RiskServiceDefinition = {
         },
       },
     },
-    /** Permissions required: risks.delete */
+    /** Permissions required: bb.risks.delete */
     deleteRisk: {
       name: "DeleteRisk",
       requestType: DeleteRiskRequest,

--- a/frontend/src/types/proto/v1/role_service.ts
+++ b/frontend/src/types/proto/v1/role_service.ts
@@ -706,7 +706,7 @@ export const RoleServiceDefinition = {
   name: "RoleService",
   fullName: "bytebase.v1.RoleService",
   methods: {
-    /** Permissions required: roles.list */
+    /** Permissions required: bb.roles.list */
     listRoles: {
       name: "ListRoles",
       requestType: ListRolesRequest,
@@ -721,7 +721,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
-    /** Permissions required: roles.get */
+    /** Permissions required: bb.roles.get */
     getRole: {
       name: "GetRole",
       requestType: GetRoleRequest,
@@ -761,7 +761,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
-    /** Permissions required: roles.create */
+    /** Permissions required: bb.roles.create */
     createRole: {
       name: "CreateRole",
       requestType: CreateRoleRequest,
@@ -777,7 +777,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
-    /** Permissions required: roles.update */
+    /** Permissions required: bb.roles.update */
     updateRole: {
       name: "UpdateRole",
       requestType: UpdateRoleRequest,
@@ -829,7 +829,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
-    /** Permissions required: roles.delete */
+    /** Permissions required: bb.roles.delete */
     deleteRole: {
       name: "DeleteRole",
       requestType: DeleteRoleRequest,

--- a/frontend/src/types/proto/v1/role_service.ts
+++ b/frontend/src/types/proto/v1/role_service.ts
@@ -706,6 +706,7 @@ export const RoleServiceDefinition = {
   name: "RoleService",
   fullName: "bytebase.v1.RoleService",
   methods: {
+    /** Permissions required: roles.list */
     listRoles: {
       name: "ListRoles",
       requestType: ListRolesRequest,
@@ -720,6 +721,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
+    /** Permissions required: roles.get */
     getRole: {
       name: "GetRole",
       requestType: GetRoleRequest,
@@ -759,6 +761,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
+    /** Permissions required: roles.create */
     createRole: {
       name: "CreateRole",
       requestType: CreateRoleRequest,
@@ -774,6 +777,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
+    /** Permissions required: roles.update */
     updateRole: {
       name: "UpdateRole",
       requestType: UpdateRoleRequest,
@@ -825,6 +829,7 @@ export const RoleServiceDefinition = {
         },
       },
     },
+    /** Permissions required: roles.delete */
     deleteRole: {
       name: "DeleteRole",
       requestType: DeleteRoleRequest,

--- a/frontend/src/types/proto/v1/rollout_service.ts
+++ b/frontend/src/types/proto/v1/rollout_service.ts
@@ -5647,6 +5647,7 @@ export const RolloutServiceDefinition = {
   name: "RolloutService",
   fullName: "bytebase.v1.RolloutService",
   methods: {
+    /** Permissions required: rollouts.get */
     getRollout: {
       name: "GetRollout",
       requestType: GetRolloutRequest,
@@ -5700,6 +5701,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
+    /** Permissions required: rollouts.list */
     listRollouts: {
       name: "ListRollouts",
       requestType: ListRolloutsRequest,
@@ -5753,7 +5755,10 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages. */
+    /**
+     * CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+     * Permissions required: rollouts.create
+     */
     createRollout: {
       name: "CreateRollout",
       requestType: CreateRolloutRequest,
@@ -5819,6 +5824,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
+    /** Permissions required: rollouts.preview */
     previewRollout: {
       name: "PreviewRollout",
       requestType: PreviewRolloutRequest,
@@ -5905,6 +5911,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
+    /** Permissions required: taskRuns.list */
     listTaskRuns: {
       name: "ListTaskRuns",
       requestType: ListTaskRunsRequest,
@@ -5986,6 +5993,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
+    /** Permissions required: taskRuns.list */
     getTaskRun: {
       name: "GetTaskRun",
       requestType: GetTaskRunRequest,
@@ -6067,6 +6075,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
+    /** Permissions required: taskRuns.list */
     getTaskRunLog: {
       name: "GetTaskRunLog",
       requestType: GetTaskRunLogRequest,
@@ -6154,6 +6163,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
+    /** Permissions required: taskRuns.list */
     getTaskRunSession: {
       name: "GetTaskRunSession",
       requestType: GetTaskRunSessionRequest,
@@ -6250,6 +6260,7 @@ export const RolloutServiceDefinition = {
      * DataExport issue only allows the creator to run the task.
      * Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
      * Follow role-based rollout policy for the environment.
+     * Permissions required: None
      */
     batchRunTasks: {
       name: "BatchRunTasks",
@@ -6335,6 +6346,7 @@ export const RolloutServiceDefinition = {
     /**
      * BatchSkipTasks skips the specified tasks.
      * The access is the same as BatchRunTasks().
+     * Permissions required: None
      */
     batchSkipTasks: {
       name: "BatchSkipTasks",
@@ -6421,6 +6433,7 @@ export const RolloutServiceDefinition = {
     /**
      * BatchCancelTaskRuns cancels the specified task runs in batch.
      * The access is the same as BatchRunTasks().
+     * Permissions required: None
      */
     batchCancelTaskRuns: {
       name: "BatchCancelTaskRuns",
@@ -6517,6 +6530,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
+    /** Permissions required: taskRuns.list */
     previewTaskRunRollback: {
       name: "PreviewTaskRunRollback",
       requestType: PreviewTaskRunRollbackRequest,

--- a/frontend/src/types/proto/v1/rollout_service.ts
+++ b/frontend/src/types/proto/v1/rollout_service.ts
@@ -5647,7 +5647,7 @@ export const RolloutServiceDefinition = {
   name: "RolloutService",
   fullName: "bytebase.v1.RolloutService",
   methods: {
-    /** Permissions required: rollouts.get */
+    /** Permissions required: bb.rollouts.get */
     getRollout: {
       name: "GetRollout",
       requestType: GetRolloutRequest,
@@ -5701,7 +5701,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** Permissions required: rollouts.list */
+    /** Permissions required: bb.rollouts.list */
     listRollouts: {
       name: "ListRollouts",
       requestType: ListRolloutsRequest,
@@ -5755,10 +5755,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /**
-     * CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-     * Permissions required: rollouts.create
-     */
+    /** Permissions required: bb.rollouts.create */
     createRollout: {
       name: "CreateRollout",
       requestType: CreateRolloutRequest,
@@ -5824,7 +5821,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** Permissions required: rollouts.preview */
+    /** Permissions required: bb.rollouts.preview */
     previewRollout: {
       name: "PreviewRollout",
       requestType: PreviewRolloutRequest,
@@ -5911,7 +5908,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** Permissions required: taskRuns.list */
+    /** Permissions required: bb.taskRuns.list */
     listTaskRuns: {
       name: "ListTaskRuns",
       requestType: ListTaskRunsRequest,
@@ -5993,7 +5990,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** Permissions required: taskRuns.list */
+    /** Permissions required: bb.taskRuns.list */
     getTaskRun: {
       name: "GetTaskRun",
       requestType: GetTaskRunRequest,
@@ -6075,7 +6072,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** Permissions required: taskRuns.list */
+    /** Permissions required: bb.taskRuns.list */
     getTaskRunLog: {
       name: "GetTaskRunLog",
       requestType: GetTaskRunLogRequest,
@@ -6163,7 +6160,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** Permissions required: taskRuns.list */
+    /** Permissions required: bb.taskRuns.list */
     getTaskRunSession: {
       name: "GetTaskRunSession",
       requestType: GetTaskRunSessionRequest,
@@ -6255,13 +6252,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /**
-     * BatchRunTasks creates task runs for the specified tasks.
-     * DataExport issue only allows the creator to run the task.
-     * Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-     * Follow role-based rollout policy for the environment.
-     * Permissions required: None
-     */
+    /** Permissions required: None */
     batchRunTasks: {
       name: "BatchRunTasks",
       requestType: BatchRunTasksRequest,
@@ -6343,11 +6334,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /**
-     * BatchSkipTasks skips the specified tasks.
-     * The access is the same as BatchRunTasks().
-     * Permissions required: None
-     */
+    /** Permissions required: None */
     batchSkipTasks: {
       name: "BatchSkipTasks",
       requestType: BatchSkipTasksRequest,
@@ -6430,11 +6417,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /**
-     * BatchCancelTaskRuns cancels the specified task runs in batch.
-     * The access is the same as BatchRunTasks().
-     * Permissions required: None
-     */
+    /** Permissions required: None */
     batchCancelTaskRuns: {
       name: "BatchCancelTaskRuns",
       requestType: BatchCancelTaskRunsRequest,
@@ -6530,7 +6513,7 @@ export const RolloutServiceDefinition = {
         },
       },
     },
-    /** Permissions required: taskRuns.list */
+    /** Permissions required: bb.taskRuns.list */
     previewTaskRunRollback: {
       name: "PreviewTaskRunRollback",
       requestType: PreviewTaskRunRollbackRequest,

--- a/frontend/src/types/proto/v1/setting_service.ts
+++ b/frontend/src/types/proto/v1/setting_service.ts
@@ -5038,6 +5038,7 @@ export const SettingServiceDefinition = {
   name: "SettingService",
   fullName: "bytebase.v1.SettingService",
   methods: {
+    /** Permissions required: settings.list */
     listSettings: {
       name: "ListSettings",
       requestType: ListSettingsRequest,
@@ -5053,6 +5054,7 @@ export const SettingServiceDefinition = {
         },
       },
     },
+    /** Permissions required: settings.get */
     getSetting: {
       name: "GetSetting",
       requestType: GetSettingRequest,
@@ -5095,6 +5097,7 @@ export const SettingServiceDefinition = {
         },
       },
     },
+    /** Permissions required: settings.set */
     updateSetting: {
       name: "UpdateSetting",
       requestType: UpdateSettingRequest,

--- a/frontend/src/types/proto/v1/setting_service.ts
+++ b/frontend/src/types/proto/v1/setting_service.ts
@@ -5038,7 +5038,7 @@ export const SettingServiceDefinition = {
   name: "SettingService",
   fullName: "bytebase.v1.SettingService",
   methods: {
-    /** Permissions required: settings.list */
+    /** Permissions required: bb.settings.list */
     listSettings: {
       name: "ListSettings",
       requestType: ListSettingsRequest,
@@ -5054,7 +5054,7 @@ export const SettingServiceDefinition = {
         },
       },
     },
-    /** Permissions required: settings.get */
+    /** Permissions required: bb.settings.get */
     getSetting: {
       name: "GetSetting",
       requestType: GetSettingRequest,
@@ -5097,7 +5097,7 @@ export const SettingServiceDefinition = {
         },
       },
     },
-    /** Permissions required: settings.set */
+    /** Permissions required: bb.settings.set */
     updateSetting: {
       name: "UpdateSetting",
       requestType: UpdateSettingRequest,

--- a/frontend/src/types/proto/v1/sheet_service.ts
+++ b/frontend/src/types/proto/v1/sheet_service.ts
@@ -867,7 +867,7 @@ export const SheetServiceDefinition = {
   name: "SheetService",
   fullName: "bytebase.v1.SheetService",
   methods: {
-    /** Permissions required: sheets.create */
+    /** Permissions required: bb.sheets.create */
     createSheet: {
       name: "CreateSheet",
       requestType: CreateSheetRequest,
@@ -926,7 +926,7 @@ export const SheetServiceDefinition = {
         },
       },
     },
-    /** Permissions required: sheets.create */
+    /** Permissions required: bb.sheets.create */
     batchCreateSheets: {
       name: "BatchCreateSheets",
       requestType: BatchCreateSheetsRequest,
@@ -992,7 +992,7 @@ export const SheetServiceDefinition = {
         },
       },
     },
-    /** Permissions required: sheets.get */
+    /** Permissions required: bb.sheets.get */
     getSheet: {
       name: "GetSheet",
       requestType: GetSheetRequest,
@@ -1044,7 +1044,7 @@ export const SheetServiceDefinition = {
         },
       },
     },
-    /** Permissions required: sheets.update */
+    /** Permissions required: bb.sheets.update */
     updateSheet: {
       name: "UpdateSheet",
       requestType: UpdateSheetRequest,

--- a/frontend/src/types/proto/v1/sheet_service.ts
+++ b/frontend/src/types/proto/v1/sheet_service.ts
@@ -867,6 +867,7 @@ export const SheetServiceDefinition = {
   name: "SheetService",
   fullName: "bytebase.v1.SheetService",
   methods: {
+    /** Permissions required: sheets.create */
     createSheet: {
       name: "CreateSheet",
       requestType: CreateSheetRequest,
@@ -925,6 +926,7 @@ export const SheetServiceDefinition = {
         },
       },
     },
+    /** Permissions required: sheets.create */
     batchCreateSheets: {
       name: "BatchCreateSheets",
       requestType: BatchCreateSheetsRequest,
@@ -990,6 +992,7 @@ export const SheetServiceDefinition = {
         },
       },
     },
+    /** Permissions required: sheets.get */
     getSheet: {
       name: "GetSheet",
       requestType: GetSheetRequest,
@@ -1041,6 +1044,7 @@ export const SheetServiceDefinition = {
         },
       },
     },
+    /** Permissions required: sheets.update */
     updateSheet: {
       name: "UpdateSheet",
       requestType: UpdateSheetRequest,

--- a/frontend/src/types/proto/v1/sql_service.ts
+++ b/frontend/src/types/proto/v1/sql_service.ts
@@ -4274,7 +4274,7 @@ export const SQLServiceDefinition = {
   name: "SQLService",
   fullName: "bytebase.v1.SQLService",
   methods: {
-    /** Permissions required: databases.get */
+    /** Permissions required: bb.databases.get */
     query: {
       name: "Query",
       requestType: QueryRequest,
@@ -4374,7 +4374,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
-    /** Permissions required: sql.admin */
+    /** Permissions required: bb.sql.admin */
     adminExecute: {
       name: "AdminExecute",
       requestType: AdminExecuteRequest,
@@ -4443,7 +4443,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.get */
+    /** Permissions required: bb.databases.get */
     export: {
       name: "Export",
       requestType: ExportRequest,
@@ -4647,7 +4647,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
-    /** Permissions required: databases.check */
+    /** Permissions required: bb.databases.check */
     check: {
       name: "Check",
       requestType: CheckRequest,

--- a/frontend/src/types/proto/v1/sql_service.ts
+++ b/frontend/src/types/proto/v1/sql_service.ts
@@ -4274,6 +4274,7 @@ export const SQLServiceDefinition = {
   name: "SQLService",
   fullName: "bytebase.v1.SQLService",
   methods: {
+    /** Permissions required: databases.get */
     query: {
       name: "Query",
       requestType: QueryRequest,
@@ -4373,6 +4374,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
+    /** Permissions required: sql.admin */
     adminExecute: {
       name: "AdminExecute",
       requestType: AdminExecuteRequest,
@@ -4390,7 +4392,10 @@ export const SQLServiceDefinition = {
         },
       },
     },
-    /** SearchQueryHistories searches query histories for the caller. */
+    /**
+     * SearchQueryHistories searches query histories for the caller.
+     * Permissions required: None
+     */
     searchQueryHistories: {
       name: "SearchQueryHistories",
       requestType: SearchQueryHistoriesRequest,
@@ -4438,6 +4443,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.get */
     export: {
       name: "Export",
       requestType: ExportRequest,
@@ -4641,6 +4647,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
+    /** Permissions required: databases.check */
     check: {
       name: "Check",
       requestType: CheckRequest,
@@ -4659,6 +4666,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     pretty: {
       name: "Pretty",
       requestType: PrettyRequest,
@@ -4674,6 +4682,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     diffMetadata: {
       name: "DiffMetadata",
       requestType: DiffMetadataRequest,
@@ -4725,6 +4734,7 @@ export const SQLServiceDefinition = {
         },
       },
     },
+    /** Permissions required: None */
     aICompletion: {
       name: "AICompletion",
       requestType: AICompletionRequest,

--- a/frontend/src/types/proto/v1/subscription_service.ts
+++ b/frontend/src/types/proto/v1/subscription_service.ts
@@ -1235,7 +1235,7 @@ export const SubscriptionServiceDefinition = {
         },
       },
     },
-    /** Permissions required: settings.set */
+    /** Permissions required: bb.settings.set */
     updateSubscription: {
       name: "UpdateSubscription",
       requestType: UpdateSubscriptionRequest,

--- a/frontend/src/types/proto/v1/subscription_service.ts
+++ b/frontend/src/types/proto/v1/subscription_service.ts
@@ -1217,6 +1217,7 @@ export const SubscriptionServiceDefinition = {
      * GetSubscription returns the current subscription.
      * If there is no license, we will return a free plan subscription without expiration time.
      * If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+     * Permissions required: None
      */
     getSubscription: {
       name: "GetSubscription",
@@ -1234,6 +1235,7 @@ export const SubscriptionServiceDefinition = {
         },
       },
     },
+    /** Permissions required: settings.set */
     updateSubscription: {
       name: "UpdateSubscription",
       requestType: UpdateSubscriptionRequest,

--- a/frontend/src/types/proto/v1/user_service.ts
+++ b/frontend/src/types/proto/v1/user_service.ts
@@ -1261,6 +1261,7 @@ export const UserServiceDefinition = {
     /**
      * Get the user.
      * Any authenticated user can get the user.
+     * Permissions required: users.get
      */
     getUser: {
       name: "GetUser",
@@ -1303,6 +1304,7 @@ export const UserServiceDefinition = {
     /**
      * Get the users in batch.
      * Any authenticated user can batch get users.
+     * Permissions required: users.get
      */
     batchGetUsers: {
       name: "BatchGetUsers",
@@ -1341,7 +1343,10 @@ export const UserServiceDefinition = {
         },
       },
     },
-    /** Get the current authenticated user. */
+    /**
+     * Get the current authenticated user.
+     * Permissions required: None
+     */
     getCurrentUser: {
       name: "GetCurrentUser",
       requestType: Empty,
@@ -1359,6 +1364,7 @@ export const UserServiceDefinition = {
     /**
      * List all users.
      * Any authenticated user can list users.
+     * Permissions required: users.list
      */
     listUsers: {
       name: "ListUsers",
@@ -1378,6 +1384,7 @@ export const UserServiceDefinition = {
      * Create a user.
      * When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
      * Otherwise, any unauthenticated user can create a user.
+     * Permissions required: users.create
      */
     createUser: {
       name: "CreateUser",
@@ -1395,7 +1402,10 @@ export const UserServiceDefinition = {
         },
       },
     },
-    /** Only the user itself and the user with bb.users.update permission on the workspace can update the user. */
+    /**
+     * Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+     * Permissions required: users.update
+     */
     updateUser: {
       name: "UpdateUser",
       requestType: UpdateUserRequest,
@@ -1449,6 +1459,7 @@ export const UserServiceDefinition = {
     /**
      * Only the user with bb.users.delete permission on the workspace can delete the user.
      * The last remaining workspace admin cannot be deleted.
+     * Permissions required: users.delete
      */
     deleteUser: {
       name: "DeleteUser",
@@ -1489,7 +1500,10 @@ export const UserServiceDefinition = {
         },
       },
     },
-    /** Only the user with bb.users.undelete permission on the workspace can undelete the user. */
+    /**
+     * Only the user with bb.users.undelete permission on the workspace can undelete the user.
+     * Permissions required: users.undelete
+     */
     undeleteUser: {
       name: "UndeleteUser",
       requestType: UndeleteUserRequest,

--- a/frontend/src/types/proto/v1/user_service.ts
+++ b/frontend/src/types/proto/v1/user_service.ts
@@ -1261,7 +1261,7 @@ export const UserServiceDefinition = {
     /**
      * Get the user.
      * Any authenticated user can get the user.
-     * Permissions required: users.get
+     * Permissions required: bb.users.get
      */
     getUser: {
       name: "GetUser",
@@ -1304,7 +1304,7 @@ export const UserServiceDefinition = {
     /**
      * Get the users in batch.
      * Any authenticated user can batch get users.
-     * Permissions required: users.get
+     * Permissions required: bb.users.get
      */
     batchGetUsers: {
       name: "BatchGetUsers",
@@ -1364,7 +1364,7 @@ export const UserServiceDefinition = {
     /**
      * List all users.
      * Any authenticated user can list users.
-     * Permissions required: users.list
+     * Permissions required: bb.users.list
      */
     listUsers: {
       name: "ListUsers",
@@ -1384,7 +1384,7 @@ export const UserServiceDefinition = {
      * Create a user.
      * When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
      * Otherwise, any unauthenticated user can create a user.
-     * Permissions required: users.create
+     * Permissions required: bb.users.create
      */
     createUser: {
       name: "CreateUser",
@@ -1404,7 +1404,7 @@ export const UserServiceDefinition = {
     },
     /**
      * Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-     * Permissions required: users.update
+     * Permissions required: bb.users.update
      */
     updateUser: {
       name: "UpdateUser",
@@ -1459,7 +1459,7 @@ export const UserServiceDefinition = {
     /**
      * Only the user with bb.users.delete permission on the workspace can delete the user.
      * The last remaining workspace admin cannot be deleted.
-     * Permissions required: users.delete
+     * Permissions required: bb.users.delete
      */
     deleteUser: {
       name: "DeleteUser",
@@ -1502,7 +1502,7 @@ export const UserServiceDefinition = {
     },
     /**
      * Only the user with bb.users.undelete permission on the workspace can undelete the user.
-     * Permissions required: users.undelete
+     * Permissions required: bb.users.undelete
      */
     undeleteUser: {
       name: "UndeleteUser",

--- a/frontend/src/types/proto/v1/worksheet_service.ts
+++ b/frontend/src/types/proto/v1/worksheet_service.ts
@@ -1067,7 +1067,10 @@ export const WorksheetServiceDefinition = {
   name: "WorksheetService",
   fullName: "bytebase.v1.WorksheetService",
   methods: {
-    /** Create a personal worksheet used in SQL Editor. */
+    /**
+     * Create a personal worksheet used in SQL Editor.
+     * Permissions required: None
+     */
     createWorksheet: {
       name: "CreateWorksheet",
       requestType: CreateWorksheetRequest,
@@ -1119,6 +1122,7 @@ export const WorksheetServiceDefinition = {
      * - they are the creator of the worksheet;
      * - they have bb.worksheets.get permission on the workspace;
      * - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+     * Permissions required: None
      */
     getWorksheet: {
       name: "GetWorksheet",
@@ -1167,6 +1171,7 @@ export const WorksheetServiceDefinition = {
      * Search for worksheets.
      * This is used for finding my worksheets or worksheets shared by other people.
      * The sheet accessibility is the same as GetWorksheet().
+     * Permissions required: None
      */
     searchWorksheets: {
       name: "SearchWorksheets",
@@ -1217,6 +1222,7 @@ export const WorksheetServiceDefinition = {
      * - they are the creator of the worksheet;
      * - they have bb.worksheets.manage permission on the workspace;
      * - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+     * Permissions required: None
      */
     updateWorksheet: {
       name: "UpdateWorksheet",
@@ -1310,6 +1316,7 @@ export const WorksheetServiceDefinition = {
     /**
      * Update the organizer of a worksheet.
      * The access is the same as UpdateWorksheet method.
+     * Permissions required: None
      */
     updateWorksheetOrganizer: {
       name: "UpdateWorksheetOrganizer",
@@ -1418,6 +1425,7 @@ export const WorksheetServiceDefinition = {
     /**
      * Delete a worksheet.
      * The access is the same as UpdateWorksheet method.
+     * Permissions required: None
      */
     deleteWorksheet: {
       name: "DeleteWorksheet",

--- a/frontend/src/types/proto/v1/workspace_service.ts
+++ b/frontend/src/types/proto/v1/workspace_service.ts
@@ -14,6 +14,7 @@ export const WorkspaceServiceDefinition = {
   name: "WorkspaceService",
   fullName: "bytebase.v1.WorkspaceService",
   methods: {
+    /** Permissions required: workspaces.getIamPolicy */
     getIamPolicy: {
       name: "GetIamPolicy",
       requestType: GetIamPolicyRequest,
@@ -104,6 +105,7 @@ export const WorkspaceServiceDefinition = {
         },
       },
     },
+    /** Permissions required: workspaces.setIamPolicy */
     setIamPolicy: {
       name: "SetIamPolicy",
       requestType: SetIamPolicyRequest,

--- a/frontend/src/types/proto/v1/workspace_service.ts
+++ b/frontend/src/types/proto/v1/workspace_service.ts
@@ -14,7 +14,7 @@ export const WorkspaceServiceDefinition = {
   name: "WorkspaceService",
   fullName: "bytebase.v1.WorkspaceService",
   methods: {
-    /** Permissions required: workspaces.getIamPolicy */
+    /** Permissions required: bb.workspaces.getIamPolicy */
     getIamPolicy: {
       name: "GetIamPolicy",
       requestType: GetIamPolicyRequest,
@@ -105,7 +105,7 @@ export const WorkspaceServiceDefinition = {
         },
       },
     },
-    /** Permissions required: workspaces.setIamPolicy */
+    /** Permissions required: bb.workspaces.setIamPolicy */
     setIamPolicy: {
       name: "SetIamPolicy",
       requestType: SetIamPolicyRequest,

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -12,7 +12,7 @@ paths:
                 - ProjectService
             description: |-
                 Deprecated.
-                 Permissions required: projects.getIamPolicy
+                 Permissions required: bb.projects.getIamPolicy
             operationId: ProjectService_BatchGetIamPolicy
             parameters:
                 - name: '*'
@@ -78,7 +78,7 @@ paths:
         patch:
             tags:
                 - ActuatorService
-            description: 'Permissions required: settings.set'
+            description: 'Permissions required: bb.settings.set'
             operationId: ActuatorService_UpdateActuatorInfo
             parameters:
                 - name: updateMask
@@ -129,7 +129,7 @@ paths:
         post:
             tags:
                 - ActuatorService
-            description: 'Permissions required: projects.create'
+            description: 'Permissions required: bb.projects.create'
             operationId: ActuatorService_SetupSample
             responses:
                 "200":
@@ -145,7 +145,7 @@ paths:
         post:
             tags:
                 - AuditLogService
-            description: 'Permissions required: auditLogs.export'
+            description: 'Permissions required: bb.auditLogs.export'
             operationId: AuditLogService_ExportAuditLogs
             requestBody:
                 content:
@@ -292,7 +292,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.list'
+            description: 'Permissions required: bb.policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: environment
@@ -360,7 +360,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.create'
+            description: 'Permissions required: bb.policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: environment
@@ -408,7 +408,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.get'
+            description: 'Permissions required: bb.policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: environment
@@ -439,7 +439,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.delete'
+            description: 'Permissions required: bb.policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: environment
@@ -467,7 +467,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.update'
+            description: 'Permissions required: bb.policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: environment
@@ -518,7 +518,7 @@ paths:
         get:
             tags:
                 - GroupService
-            description: 'Permissions required: groups.list'
+            description: 'Permissions required: bb.groups.list'
             operationId: GroupService_ListGroups
             parameters:
                 - name: pageSize
@@ -559,7 +559,7 @@ paths:
         post:
             tags:
                 - GroupService
-            description: 'Permissions required: groups.create'
+            description: 'Permissions required: bb.groups.create'
             operationId: GroupService_CreateGroup
             parameters:
                 - name: groupEmail
@@ -592,7 +592,7 @@ paths:
         get:
             tags:
                 - GroupService
-            description: 'Permissions required: groups.get'
+            description: 'Permissions required: bb.groups.get'
             operationId: GroupService_GetGroup
             parameters:
                 - name: group
@@ -617,7 +617,7 @@ paths:
         delete:
             tags:
                 - GroupService
-            description: 'Permissions required: groups.delete'
+            description: 'Permissions required: bb.groups.delete'
             operationId: GroupService_DeleteGroup
             parameters:
                 - name: group
@@ -642,7 +642,7 @@ paths:
             description: |-
                 UpdateGroup updates the group.
                  Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-                 Permissions required: groups.update
+                 Permissions required: bb.groups.update
             operationId: GroupService_UpdateGroup
             parameters:
                 - name: group
@@ -728,7 +728,7 @@ paths:
         post:
             tags:
                 - IdentityProviderService
-            description: 'Permissions required: identityProviders.create'
+            description: 'Permissions required: bb.identityProviders.create'
             operationId: IdentityProviderService_CreateIdentityProvider
             parameters:
                 - name: identityProviderId
@@ -769,7 +769,7 @@ paths:
         post:
             tags:
                 - IdentityProviderService
-            description: 'Permissions required: identityProviders.update'
+            description: 'Permissions required: bb.identityProviders.update'
             operationId: IdentityProviderService_TestIdentityProvider
             requestBody:
                 content:
@@ -794,7 +794,7 @@ paths:
         get:
             tags:
                 - IdentityProviderService
-            description: 'Permissions required: identityProviders.get'
+            description: 'Permissions required: bb.identityProviders.get'
             operationId: IdentityProviderService_GetIdentityProvider
             parameters:
                 - name: idp
@@ -819,7 +819,7 @@ paths:
         delete:
             tags:
                 - IdentityProviderService
-            description: 'Permissions required: identityProviders.delete'
+            description: 'Permissions required: bb.identityProviders.delete'
             operationId: IdentityProviderService_DeleteIdentityProvider
             parameters:
                 - name: idp
@@ -841,7 +841,7 @@ paths:
         patch:
             tags:
                 - IdentityProviderService
-            description: 'Permissions required: identityProviders.update'
+            description: 'Permissions required: bb.identityProviders.update'
             operationId: IdentityProviderService_UpdateIdentityProvider
             parameters:
                 - name: idp
@@ -879,7 +879,7 @@ paths:
         get:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.list'
+            description: 'Permissions required: bb.instances.list'
             operationId: InstanceService_ListInstances
             parameters:
                 - name: pageSize
@@ -959,7 +959,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.create'
+            description: 'Permissions required: bb.instances.create'
             operationId: InstanceService_CreateInstance
             parameters:
                 - name: instanceId
@@ -1000,7 +1000,7 @@ paths:
         get:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.get'
+            description: 'Permissions required: bb.instances.get'
             operationId: InstanceService_GetInstance
             parameters:
                 - name: instance
@@ -1025,7 +1025,7 @@ paths:
         delete:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.delete'
+            description: 'Permissions required: bb.instances.delete'
             operationId: InstanceService_DeleteInstance
             parameters:
                 - name: instance
@@ -1052,7 +1052,7 @@ paths:
         patch:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.update'
+            description: 'Permissions required: bb.instances.update'
             operationId: InstanceService_UpdateInstance
             parameters:
                 - name: instance
@@ -1090,7 +1090,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.list'
+            description: 'Permissions required: bb.databases.list'
             operationId: DatabaseService_ListDatabases
             parameters:
                 - name: instance
@@ -1174,7 +1174,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: DatabaseService_GetDatabase
             parameters:
                 - name: instance
@@ -1205,7 +1205,7 @@ paths:
         patch:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.update'
+            description: 'Permissions required: bb.databases.update'
             operationId: DatabaseService_UpdateDatabase
             parameters:
                 - name: instance
@@ -1249,7 +1249,7 @@ paths:
         get:
             tags:
                 - DatabaseCatalogService
-            description: 'Permissions required: databaseCatalogs.get'
+            description: 'Permissions required: bb.databaseCatalogs.get'
             operationId: DatabaseCatalogService_GetDatabaseCatalog
             parameters:
                 - name: instance
@@ -1280,7 +1280,7 @@ paths:
         patch:
             tags:
                 - DatabaseCatalogService
-            description: 'Permissions required: databaseCatalogs.update'
+            description: 'Permissions required: bb.databaseCatalogs.update'
             operationId: DatabaseCatalogService_UpdateDatabaseCatalog
             parameters:
                 - name: instance
@@ -1318,7 +1318,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: changelogs.list'
+            description: 'Permissions required: bb.changelogs.list'
             operationId: DatabaseService_ListChangelogs
             parameters:
                 - name: instance
@@ -1465,7 +1465,7 @@ paths:
         post:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: DatabaseService_DiffSchema
             parameters:
                 - name: instance
@@ -1509,7 +1509,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.getSchema'
+            description: 'Permissions required: bb.databases.getSchema'
             operationId: DatabaseService_GetDatabaseMetadata
             parameters:
                 - name: instance
@@ -1560,7 +1560,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.list'
+            description: 'Permissions required: bb.policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: instance
@@ -1634,7 +1634,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.create'
+            description: 'Permissions required: bb.policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: instance
@@ -1688,7 +1688,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.get'
+            description: 'Permissions required: bb.policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: instance
@@ -1725,7 +1725,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.delete'
+            description: 'Permissions required: bb.policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: instance
@@ -1759,7 +1759,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.update'
+            description: 'Permissions required: bb.policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: instance
@@ -1816,7 +1816,7 @@ paths:
         get:
             tags:
                 - RevisionService
-            description: 'Permissions required: revisions.list'
+            description: 'Permissions required: bb.revisions.list'
             operationId: RevisionService_ListRevisions
             parameters:
                 - name: instance
@@ -1870,7 +1870,7 @@ paths:
         post:
             tags:
                 - RevisionService
-            description: 'Permissions required: revisions.create'
+            description: 'Permissions required: bb.revisions.create'
             operationId: RevisionService_CreateRevision
             parameters:
                 - name: instance
@@ -1908,7 +1908,7 @@ paths:
         get:
             tags:
                 - RevisionService
-            description: 'Permissions required: revisions.get'
+            description: 'Permissions required: bb.revisions.get'
             operationId: RevisionService_GetRevision
             parameters:
                 - name: instance
@@ -1945,7 +1945,7 @@ paths:
         delete:
             tags:
                 - RevisionService
-            description: 'Permissions required: revisions.delete'
+            description: 'Permissions required: bb.revisions.delete'
             operationId: RevisionService_DeleteRevision
             parameters:
                 - name: instance
@@ -1980,7 +1980,7 @@ paths:
         post:
             tags:
                 - RevisionService
-            description: 'Permissions required: revisions.create'
+            description: 'Permissions required: bb.revisions.create'
             operationId: RevisionService_BatchCreateRevisions
             parameters:
                 - name: instance
@@ -2018,7 +2018,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.getSchema'
+            description: 'Permissions required: bb.databases.getSchema'
             operationId: DatabaseService_GetDatabaseSchema
             parameters:
                 - name: instance
@@ -2139,7 +2139,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databaseSecrets.list'
+            description: 'Permissions required: bb.databaseSecrets.list'
             operationId: DatabaseService_ListSecrets
             parameters:
                 - name: instance
@@ -2193,7 +2193,7 @@ paths:
         delete:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databaseSecrets.delete'
+            description: 'Permissions required: bb.databaseSecrets.delete'
             operationId: DatabaseService_DeleteSecret
             parameters:
                 - name: instance
@@ -2227,7 +2227,7 @@ paths:
         patch:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databaseSecrets.update'
+            description: 'Permissions required: bb.databaseSecrets.update'
             operationId: DatabaseService_UpdateSecret
             parameters:
                 - name: instance
@@ -2282,7 +2282,7 @@ paths:
         post:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: DatabaseService_DiffSchema
             parameters:
                 - name: instance
@@ -2320,7 +2320,7 @@ paths:
         post:
             tags:
                 - SQLService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: instance
@@ -2358,7 +2358,7 @@ paths:
         post:
             tags:
                 - SQLService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: SQLService_Query
             parameters:
                 - name: instance
@@ -2396,7 +2396,7 @@ paths:
         post:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.sync'
+            description: 'Permissions required: bb.databases.sync'
             operationId: DatabaseService_SyncDatabase
             parameters:
                 - name: instance
@@ -2434,7 +2434,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: DatabaseService_BatchGetDatabases
             parameters:
                 - name: instance
@@ -2467,7 +2467,7 @@ paths:
         post:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.sync'
+            description: 'Permissions required: bb.databases.sync'
             operationId: DatabaseService_BatchSyncDatabases
             parameters:
                 - name: instance
@@ -2499,7 +2499,7 @@ paths:
         post:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.update'
+            description: 'Permissions required: bb.databases.update'
             operationId: DatabaseService_BatchUpdateDatabases
             parameters:
                 - name: instance
@@ -2531,7 +2531,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.list'
+            description: 'Permissions required: bb.policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: instance
@@ -2599,7 +2599,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.create'
+            description: 'Permissions required: bb.policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: instance
@@ -2647,7 +2647,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.get'
+            description: 'Permissions required: bb.policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: instance
@@ -2678,7 +2678,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.delete'
+            description: 'Permissions required: bb.policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: instance
@@ -2706,7 +2706,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.update'
+            description: 'Permissions required: bb.policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: instance
@@ -2757,7 +2757,7 @@ paths:
         get:
             tags:
                 - InstanceRoleService
-            description: 'Permissions required: instanceRoles.get'
+            description: 'Permissions required: bb.instanceRoles.get'
             operationId: InstanceRoleService_ListInstanceRoles
             parameters:
                 - name: instance
@@ -2810,7 +2810,7 @@ paths:
         get:
             tags:
                 - InstanceRoleService
-            description: 'Permissions required: instanceRoles.get'
+            description: 'Permissions required: bb.instanceRoles.get'
             operationId: InstanceRoleService_GetInstanceRole
             parameters:
                 - name: instance
@@ -2842,7 +2842,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.update'
+            description: 'Permissions required: bb.instances.update'
             operationId: InstanceService_AddDataSource
             parameters:
                 - name: instance
@@ -2874,7 +2874,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.get'
+            description: 'Permissions required: bb.instances.get'
             operationId: InstanceService_ListInstanceDatabase
             parameters:
                 - name: instance
@@ -2906,7 +2906,7 @@ paths:
         post:
             tags:
                 - SQLService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: instance
@@ -2938,7 +2938,7 @@ paths:
         post:
             tags:
                 - SQLService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: SQLService_Query
             parameters:
                 - name: instance
@@ -2970,7 +2970,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.update'
+            description: 'Permissions required: bb.instances.update'
             operationId: InstanceService_RemoveDataSource
             parameters:
                 - name: instance
@@ -3002,7 +3002,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.sync'
+            description: 'Permissions required: bb.instances.sync'
             operationId: InstanceService_SyncInstance
             parameters:
                 - name: instance
@@ -3034,7 +3034,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.undelete'
+            description: 'Permissions required: bb.instances.undelete'
             operationId: InstanceService_UndeleteInstance
             parameters:
                 - name: instance
@@ -3066,7 +3066,7 @@ paths:
         patch:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.update'
+            description: 'Permissions required: bb.instances.update'
             operationId: InstanceService_UpdateDataSource
             parameters:
                 - name: instance
@@ -3098,7 +3098,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.sync'
+            description: 'Permissions required: bb.instances.sync'
             operationId: InstanceService_BatchSyncInstances
             requestBody:
                 content:
@@ -3123,7 +3123,7 @@ paths:
         post:
             tags:
                 - InstanceService
-            description: 'Permissions required: instances.update'
+            description: 'Permissions required: bb.instances.update'
             operationId: InstanceService_BatchUpdateInstances
             requestBody:
                 content:
@@ -3148,7 +3148,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.list'
+            description: 'Permissions required: bb.policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: parent
@@ -3217,7 +3217,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.create'
+            description: 'Permissions required: bb.policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: parent
@@ -3269,7 +3269,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.get'
+            description: 'Permissions required: bb.policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: policy
@@ -3294,7 +3294,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.delete'
+            description: 'Permissions required: bb.policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: policy
@@ -3316,7 +3316,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.update'
+            description: 'Permissions required: bb.policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: policy
@@ -3361,7 +3361,7 @@ paths:
         get:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.list'
+            description: 'Permissions required: bb.projects.list'
             operationId: ProjectService_ListProjects
             parameters:
                 - name: pageSize
@@ -3412,7 +3412,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.create'
+            description: 'Permissions required: bb.projects.create'
             operationId: ProjectService_CreateProject
             parameters:
                 - name: projectId
@@ -3451,7 +3451,7 @@ paths:
             description: |-
                 GetProject retrieves a project by name.
                  Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-                 Permissions required: projects.get
+                 Permissions required: bb.projects.get
             operationId: ProjectService_GetProject
             parameters:
                 - name: project
@@ -3476,7 +3476,7 @@ paths:
         delete:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.delete'
+            description: 'Permissions required: bb.projects.delete'
             operationId: ProjectService_DeleteProject
             parameters:
                 - name: project
@@ -3507,7 +3507,7 @@ paths:
         patch:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: ProjectService_UpdateProject
             parameters:
                 - name: project
@@ -3545,7 +3545,7 @@ paths:
         post:
             tags:
                 - AuditLogService
-            description: 'Permissions required: auditLogs.export'
+            description: 'Permissions required: bb.auditLogs.export'
             operationId: AuditLogService_ExportAuditLogs
             parameters:
                 - name: project
@@ -3609,7 +3609,7 @@ paths:
         get:
             tags:
                 - ChangelistService
-            description: 'Permissions required: changelists.list'
+            description: 'Permissions required: bb.changelists.list'
             operationId: ChangelistService_ListChangelists
             parameters:
                 - name: project
@@ -3656,7 +3656,7 @@ paths:
         post:
             tags:
                 - ChangelistService
-            description: 'Permissions required: changelists.create'
+            description: 'Permissions required: bb.changelists.create'
             operationId: ChangelistService_CreateChangelist
             parameters:
                 - name: project
@@ -3698,7 +3698,7 @@ paths:
         get:
             tags:
                 - ChangelistService
-            description: 'Permissions required: changelists.get'
+            description: 'Permissions required: bb.changelists.get'
             operationId: ChangelistService_GetChangelist
             parameters:
                 - name: project
@@ -3729,7 +3729,7 @@ paths:
         delete:
             tags:
                 - ChangelistService
-            description: 'Permissions required: changelists.delete'
+            description: 'Permissions required: bb.changelists.delete'
             operationId: ChangelistService_DeleteChangelist
             parameters:
                 - name: project
@@ -3757,7 +3757,7 @@ paths:
         patch:
             tags:
                 - ChangelistService
-            description: 'Permissions required: changelists.update'
+            description: 'Permissions required: bb.changelists.update'
             operationId: ChangelistService_UpdateChangelist
             parameters:
                 - name: project
@@ -3801,7 +3801,7 @@ paths:
         get:
             tags:
                 - DatabaseGroupService
-            description: 'Permissions required: projects.get'
+            description: 'Permissions required: bb.projects.get'
             operationId: DatabaseGroupService_ListDatabaseGroups
             parameters:
                 - name: project
@@ -3858,7 +3858,7 @@ paths:
         post:
             tags:
                 - DatabaseGroupService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: DatabaseGroupService_CreateDatabaseGroup
             parameters:
                 - name: project
@@ -3905,7 +3905,7 @@ paths:
         get:
             tags:
                 - DatabaseGroupService
-            description: 'Permissions required: projects.get'
+            description: 'Permissions required: bb.projects.get'
             operationId: DatabaseGroupService_GetDatabaseGroup
             parameters:
                 - name: project
@@ -3946,7 +3946,7 @@ paths:
         delete:
             tags:
                 - DatabaseGroupService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: DatabaseGroupService_DeleteDatabaseGroup
             parameters:
                 - name: project
@@ -3974,7 +3974,7 @@ paths:
         patch:
             tags:
                 - DatabaseGroupService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: DatabaseGroupService_UpdateDatabaseGroup
             parameters:
                 - name: project
@@ -4018,7 +4018,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.list'
+            description: 'Permissions required: bb.databases.list'
             operationId: DatabaseService_ListDatabases
             parameters:
                 - name: project
@@ -4102,7 +4102,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: DatabaseService_BatchGetDatabases
             parameters:
                 - name: project
@@ -4135,7 +4135,7 @@ paths:
         get:
             tags:
                 - IssueService
-            description: 'Permissions required: issues.list'
+            description: 'Permissions required: bb.issues.list'
             operationId: IssueService_ListIssues
             parameters:
                 - name: project
@@ -4210,7 +4210,7 @@ paths:
         post:
             tags:
                 - IssueService
-            description: 'Permissions required: issues.create'
+            description: 'Permissions required: bb.issues.create'
             operationId: IssueService_CreateIssue
             parameters:
                 - name: project
@@ -4242,7 +4242,7 @@ paths:
         get:
             tags:
                 - IssueService
-            description: 'Permissions required: issues.get'
+            description: 'Permissions required: bb.issues.get'
             operationId: IssueService_GetIssue
             parameters:
                 - name: project
@@ -4277,7 +4277,7 @@ paths:
         patch:
             tags:
                 - IssueService
-            description: 'Permissions required: issues.update'
+            description: 'Permissions required: bb.issues.update'
             operationId: IssueService_UpdateIssue
             parameters:
                 - name: project
@@ -4321,7 +4321,7 @@ paths:
         get:
             tags:
                 - IssueService
-            description: 'Permissions required: issueComments.list'
+            description: 'Permissions required: bb.issueComments.list'
             operationId: IssueService_ListIssueComments
             parameters:
                 - name: project
@@ -4414,7 +4414,7 @@ paths:
         post:
             tags:
                 - IssueService
-            description: 'Permissions required: issueComments.create'
+            description: 'Permissions required: bb.issueComments.create'
             operationId: IssueService_CreateIssueComment
             parameters:
                 - name: project
@@ -4451,7 +4451,7 @@ paths:
         patch:
             tags:
                 - IssueService
-            description: 'Permissions required: issueComments.update'
+            description: 'Permissions required: bb.issueComments.update'
             operationId: IssueService_UpdateIssueComment
             parameters:
                 - name: project
@@ -4577,7 +4577,7 @@ paths:
         post:
             tags:
                 - IssueService
-            description: 'Permissions required: issues.update'
+            description: 'Permissions required: bb.issues.update'
             operationId: IssueService_BatchUpdateIssuesStatus
             parameters:
                 - name: project
@@ -4611,7 +4611,7 @@ paths:
                 - IssueService
             description: |-
                 Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-                 Permissions required: issues.get
+                 Permissions required: bb.issues.get
             operationId: IssueService_SearchIssues
             parameters:
                 - name: project
@@ -4643,7 +4643,7 @@ paths:
         get:
             tags:
                 - PlanService
-            description: 'Permissions required: plans.list'
+            description: 'Permissions required: bb.plans.list'
             operationId: PlanService_ListPlans
             parameters:
                 - name: project
@@ -4688,7 +4688,7 @@ paths:
         post:
             tags:
                 - PlanService
-            description: 'Permissions required: plans.create'
+            description: 'Permissions required: bb.plans.create'
             operationId: PlanService_CreatePlan
             parameters:
                 - name: project
@@ -4720,7 +4720,7 @@ paths:
         get:
             tags:
                 - PlanService
-            description: 'Permissions required: plans.get'
+            description: 'Permissions required: bb.plans.get'
             operationId: PlanService_GetPlan
             parameters:
                 - name: project
@@ -4754,7 +4754,7 @@ paths:
             description: |-
                 UpdatePlan updates the plan.
                  The plan creator and the user with bb.plans.update permission on the project can update the plan.
-                 Permissions required: plans.update
+                 Permissions required: bb.plans.update
             operationId: PlanService_UpdatePlan
             parameters:
                 - name: project
@@ -4798,7 +4798,7 @@ paths:
         get:
             tags:
                 - PlanService
-            description: 'Permissions required: planCheckRuns.list'
+            description: 'Permissions required: bb.planCheckRuns.list'
             operationId: PlanService_ListPlanCheckRuns
             parameters:
                 - name: project
@@ -4874,7 +4874,7 @@ paths:
         post:
             tags:
                 - PlanService
-            description: 'Permissions required: planCheckRuns.run'
+            description: 'Permissions required: bb.planCheckRuns.run'
             operationId: PlanService_BatchCancelPlanCheckRuns
             parameters:
                 - name: project
@@ -4912,7 +4912,7 @@ paths:
         post:
             tags:
                 - PlanService
-            description: 'Permissions required: planCheckRuns.run'
+            description: 'Permissions required: bb.planCheckRuns.run'
             operationId: PlanService_RunPlanChecks
             parameters:
                 - name: project
@@ -4952,7 +4952,7 @@ paths:
                 - PlanService
             description: |-
                 Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-                 Permissions required: plans.get
+                 Permissions required: bb.plans.get
             operationId: PlanService_SearchPlans
             parameters:
                 - name: project
@@ -4984,7 +4984,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.list'
+            description: 'Permissions required: bb.policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: project
@@ -5052,7 +5052,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.create'
+            description: 'Permissions required: bb.policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: project
@@ -5100,7 +5100,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.get'
+            description: 'Permissions required: bb.policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: project
@@ -5131,7 +5131,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.delete'
+            description: 'Permissions required: bb.policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: project
@@ -5159,7 +5159,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
-            description: 'Permissions required: policies.update'
+            description: 'Permissions required: bb.policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: project
@@ -5210,7 +5210,7 @@ paths:
         get:
             tags:
                 - ReleaseService
-            description: 'Permissions required: releases.list'
+            description: 'Permissions required: bb.releases.list'
             operationId: ReleaseService_ListReleases
             parameters:
                 - name: project
@@ -5260,7 +5260,7 @@ paths:
         post:
             tags:
                 - ReleaseService
-            description: 'Permissions required: releases.create'
+            description: 'Permissions required: bb.releases.create'
             operationId: ReleaseService_CreateRelease
             parameters:
                 - name: project
@@ -5292,7 +5292,7 @@ paths:
         get:
             tags:
                 - ReleaseService
-            description: 'Permissions required: releases.get'
+            description: 'Permissions required: bb.releases.get'
             operationId: ReleaseService_GetRelease
             parameters:
                 - name: project
@@ -5323,7 +5323,7 @@ paths:
         delete:
             tags:
                 - ReleaseService
-            description: 'Permissions required: releases.delete'
+            description: 'Permissions required: bb.releases.delete'
             operationId: ReleaseService_DeleteRelease
             parameters:
                 - name: project
@@ -5351,7 +5351,7 @@ paths:
         patch:
             tags:
                 - ReleaseService
-            description: 'Permissions required: releases.update'
+            description: 'Permissions required: bb.releases.update'
             operationId: ReleaseService_UpdateRelease
             parameters:
                 - name: project
@@ -5395,7 +5395,7 @@ paths:
         post:
             tags:
                 - ReleaseService
-            description: 'Permissions required: releases.undelete'
+            description: 'Permissions required: bb.releases.undelete'
             operationId: ReleaseService_UndeleteRelease
             parameters:
                 - name: project
@@ -5427,7 +5427,7 @@ paths:
         post:
             tags:
                 - ReleaseService
-            description: 'Permissions required: releases.check'
+            description: 'Permissions required: bb.releases.check'
             operationId: ReleaseService_CheckRelease
             parameters:
                 - name: project
@@ -5459,7 +5459,7 @@ paths:
         get:
             tags:
                 - RolloutService
-            description: 'Permissions required: rollouts.list'
+            description: 'Permissions required: bb.rollouts.list'
             operationId: RolloutService_ListRollouts
             parameters:
                 - name: project
@@ -5504,9 +5504,7 @@ paths:
         post:
             tags:
                 - RolloutService
-            description: |-
-                CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-                 Permissions required: rollouts.create
+            description: 'Permissions required: bb.rollouts.create'
             operationId: RolloutService_CreateRollout
             parameters:
                 - name: project
@@ -5554,7 +5552,7 @@ paths:
         get:
             tags:
                 - RolloutService
-            description: 'Permissions required: rollouts.get'
+            description: 'Permissions required: bb.rollouts.get'
             operationId: RolloutService_GetRollout
             parameters:
                 - name: project
@@ -5586,7 +5584,7 @@ paths:
         get:
             tags:
                 - RolloutService
-            description: 'Permissions required: taskRuns.list'
+            description: 'Permissions required: bb.taskRuns.list'
             operationId: RolloutService_ListTaskRuns
             parameters:
                 - name: project
@@ -5652,7 +5650,7 @@ paths:
         get:
             tags:
                 - RolloutService
-            description: 'Permissions required: taskRuns.list'
+            description: 'Permissions required: bb.taskRuns.list'
             operationId: RolloutService_GetTaskRun
             parameters:
                 - name: project
@@ -5702,7 +5700,7 @@ paths:
         get:
             tags:
                 - RolloutService
-            description: 'Permissions required: taskRuns.list'
+            description: 'Permissions required: bb.taskRuns.list'
             operationId: RolloutService_GetTaskRunLog
             parameters:
                 - name: project
@@ -5752,7 +5750,7 @@ paths:
         get:
             tags:
                 - RolloutService
-            description: 'Permissions required: taskRuns.list'
+            description: 'Permissions required: bb.taskRuns.list'
             operationId: RolloutService_GetTaskRunSession
             parameters:
                 - name: project
@@ -5802,7 +5800,7 @@ paths:
         post:
             tags:
                 - RolloutService
-            description: 'Permissions required: taskRuns.list'
+            description: 'Permissions required: bb.taskRuns.list'
             operationId: RolloutService_PreviewTaskRunRollback
             parameters:
                 - name: project
@@ -5858,10 +5856,7 @@ paths:
         post:
             tags:
                 - RolloutService
-            description: |-
-                BatchCancelTaskRuns cancels the specified task runs in batch.
-                 The access is the same as BatchRunTasks().
-                 Permissions required: None
+            description: 'Permissions required: None'
             operationId: RolloutService_BatchCancelTaskRuns
             parameters:
                 - name: project
@@ -5911,12 +5906,7 @@ paths:
         post:
             tags:
                 - RolloutService
-            description: |-
-                BatchRunTasks creates task runs for the specified tasks.
-                 DataExport issue only allows the creator to run the task.
-                 Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-                 Follow role-based rollout policy for the environment.
-                 Permissions required: None
+            description: 'Permissions required: None'
             operationId: RolloutService_BatchRunTasks
             parameters:
                 - name: project
@@ -5960,10 +5950,7 @@ paths:
         post:
             tags:
                 - RolloutService
-            description: |-
-                BatchSkipTasks skips the specified tasks.
-                 The access is the same as BatchRunTasks().
-                 Permissions required: None
+            description: 'Permissions required: None'
             operationId: RolloutService_BatchSkipTasks
             parameters:
                 - name: project
@@ -6007,7 +5994,7 @@ paths:
         post:
             tags:
                 - SQLService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: project
@@ -6051,7 +6038,7 @@ paths:
         post:
             tags:
                 - SQLService
-            description: 'Permissions required: databases.get'
+            description: 'Permissions required: bb.databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: project
@@ -6089,7 +6076,7 @@ paths:
         post:
             tags:
                 - SheetService
-            description: 'Permissions required: sheets.create'
+            description: 'Permissions required: bb.sheets.create'
             operationId: SheetService_CreateSheet
             parameters:
                 - name: project
@@ -6121,7 +6108,7 @@ paths:
         get:
             tags:
                 - SheetService
-            description: 'Permissions required: sheets.get'
+            description: 'Permissions required: bb.sheets.get'
             operationId: SheetService_GetSheet
             parameters:
                 - name: project
@@ -6157,7 +6144,7 @@ paths:
         patch:
             tags:
                 - SheetService
-            description: 'Permissions required: sheets.update'
+            description: 'Permissions required: bb.sheets.update'
             operationId: SheetService_UpdateSheet
             parameters:
                 - name: project
@@ -6207,7 +6194,7 @@ paths:
         post:
             tags:
                 - SheetService
-            description: 'Permissions required: sheets.create'
+            description: 'Permissions required: bb.sheets.create'
             operationId: SheetService_BatchCreateSheets
             parameters:
                 - name: project
@@ -6239,7 +6226,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: ProjectService_RemoveWebhook
             parameters:
                 - name: project
@@ -6277,7 +6264,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: ProjectService_UpdateWebhook
             parameters:
                 - name: project
@@ -6315,7 +6302,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: ProjectService_AddWebhook
             parameters:
                 - name: project
@@ -6347,7 +6334,7 @@ paths:
         get:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.getIamPolicy'
+            description: 'Permissions required: bb.projects.getIamPolicy'
             operationId: ProjectService_GetIamPolicy
             parameters:
                 - name: project
@@ -6373,7 +6360,7 @@ paths:
         post:
             tags:
                 - RolloutService
-            description: 'Permissions required: rollouts.preview'
+            description: 'Permissions required: bb.rollouts.preview'
             operationId: RolloutService_PreviewRollout
             parameters:
                 - name: project
@@ -6405,7 +6392,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.setIamPolicy'
+            description: 'Permissions required: bb.projects.setIamPolicy'
             operationId: ProjectService_SetIamPolicy
             parameters:
                 - name: project
@@ -6437,7 +6424,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.update'
+            description: 'Permissions required: bb.projects.update'
             operationId: ProjectService_TestWebhook
             parameters:
                 - name: project
@@ -6469,7 +6456,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.undelete'
+            description: 'Permissions required: bb.projects.undelete'
             operationId: ProjectService_UndeleteProject
             parameters:
                 - name: project
@@ -6501,7 +6488,7 @@ paths:
         post:
             tags:
                 - ProjectService
-            description: 'Permissions required: projects.delete'
+            description: 'Permissions required: bb.projects.delete'
             operationId: ProjectService_BatchDeleteProjects
             requestBody:
                 content:
@@ -6575,7 +6562,7 @@ paths:
         get:
             tags:
                 - ReviewConfigService
-            description: 'Permissions required: reviewConfigs.list'
+            description: 'Permissions required: bb.reviewConfigs.list'
             operationId: ReviewConfigService_ListReviewConfigs
             parameters:
                 - name: pageSize
@@ -6615,7 +6602,7 @@ paths:
         post:
             tags:
                 - ReviewConfigService
-            description: 'Permissions required: reviewConfigs.create'
+            description: 'Permissions required: bb.reviewConfigs.create'
             operationId: ReviewConfigService_CreateReviewConfig
             requestBody:
                 content:
@@ -6640,7 +6627,7 @@ paths:
         get:
             tags:
                 - ReviewConfigService
-            description: 'Permissions required: reviewConfigs.get'
+            description: 'Permissions required: bb.reviewConfigs.get'
             operationId: ReviewConfigService_GetReviewConfig
             parameters:
                 - name: reviewConfig
@@ -6665,7 +6652,7 @@ paths:
         delete:
             tags:
                 - ReviewConfigService
-            description: 'Permissions required: reviewConfigs.delete'
+            description: 'Permissions required: bb.reviewConfigs.delete'
             operationId: ReviewConfigService_DeleteReviewConfig
             parameters:
                 - name: reviewConfig
@@ -6687,7 +6674,7 @@ paths:
         patch:
             tags:
                 - ReviewConfigService
-            description: 'Permissions required: reviewConfigs.update'
+            description: 'Permissions required: bb.reviewConfigs.update'
             operationId: ReviewConfigService_UpdateReviewConfig
             parameters:
                 - name: reviewConfig
@@ -6732,7 +6719,7 @@ paths:
         get:
             tags:
                 - RiskService
-            description: 'Permissions required: risks.list'
+            description: 'Permissions required: bb.risks.list'
             operationId: RiskService_ListRisks
             parameters:
                 - name: pageSize
@@ -6773,7 +6760,7 @@ paths:
         post:
             tags:
                 - RiskService
-            description: 'Permissions required: risks.create'
+            description: 'Permissions required: bb.risks.create'
             operationId: RiskService_CreateRisk
             requestBody:
                 content:
@@ -6798,7 +6785,7 @@ paths:
         get:
             tags:
                 - RiskService
-            description: 'Permissions required: risks.list'
+            description: 'Permissions required: bb.risks.list'
             operationId: RiskService_GetRisk
             parameters:
                 - name: risk
@@ -6823,7 +6810,7 @@ paths:
         delete:
             tags:
                 - RiskService
-            description: 'Permissions required: risks.delete'
+            description: 'Permissions required: bb.risks.delete'
             operationId: RiskService_DeleteRisk
             parameters:
                 - name: risk
@@ -6845,7 +6832,7 @@ paths:
         patch:
             tags:
                 - RiskService
-            description: 'Permissions required: risks.update'
+            description: 'Permissions required: bb.risks.update'
             operationId: RiskService_UpdateRisk
             parameters:
                 - name: risk
@@ -6883,7 +6870,7 @@ paths:
         get:
             tags:
                 - RoleService
-            description: 'Permissions required: roles.list'
+            description: 'Permissions required: bb.roles.list'
             operationId: RoleService_ListRoles
             parameters:
                 - name: pageSize
@@ -6924,7 +6911,7 @@ paths:
         post:
             tags:
                 - RoleService
-            description: 'Permissions required: roles.create'
+            description: 'Permissions required: bb.roles.create'
             operationId: RoleService_CreateRole
             parameters:
                 - name: roleId
@@ -6960,7 +6947,7 @@ paths:
         get:
             tags:
                 - RoleService
-            description: 'Permissions required: roles.get'
+            description: 'Permissions required: bb.roles.get'
             operationId: RoleService_GetRole
             parameters:
                 - name: role
@@ -6985,7 +6972,7 @@ paths:
         delete:
             tags:
                 - RoleService
-            description: 'Permissions required: roles.delete'
+            description: 'Permissions required: bb.roles.delete'
             operationId: RoleService_DeleteRole
             parameters:
                 - name: role
@@ -7007,7 +6994,7 @@ paths:
         patch:
             tags:
                 - RoleService
-            description: 'Permissions required: roles.update'
+            description: 'Permissions required: bb.roles.update'
             operationId: RoleService_UpdateRole
             parameters:
                 - name: role
@@ -7074,7 +7061,7 @@ paths:
         get:
             tags:
                 - SettingService
-            description: 'Permissions required: settings.list'
+            description: 'Permissions required: bb.settings.list'
             operationId: SettingService_ListSettings
             parameters:
                 - name: pageSize
@@ -7116,7 +7103,7 @@ paths:
         get:
             tags:
                 - SettingService
-            description: 'Permissions required: settings.get'
+            description: 'Permissions required: bb.settings.get'
             operationId: SettingService_GetSetting
             parameters:
                 - name: setting
@@ -7141,7 +7128,7 @@ paths:
         patch:
             tags:
                 - SettingService
-            description: 'Permissions required: settings.set'
+            description: 'Permissions required: bb.settings.set'
             operationId: SettingService_UpdateSetting
             parameters:
                 - name: setting
@@ -7214,7 +7201,7 @@ paths:
         post:
             tags:
                 - SQLService
-            description: 'Permissions required: databases.check'
+            description: 'Permissions required: bb.databases.check'
             operationId: SQLService_Check
             requestBody:
                 content:
@@ -7286,7 +7273,7 @@ paths:
         patch:
             tags:
                 - SubscriptionService
-            description: 'Permissions required: settings.set'
+            description: 'Permissions required: bb.settings.set'
             operationId: SubscriptionService_UpdateSubscription
             requestBody:
                 content:
@@ -7314,7 +7301,7 @@ paths:
             description: |-
                 List all users.
                  Any authenticated user can list users.
-                 Permissions required: users.list
+                 Permissions required: bb.users.list
             operationId: UserService_ListUsers
             parameters:
                 - name: pageSize
@@ -7390,7 +7377,7 @@ paths:
                 Create a user.
                  When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
                  Otherwise, any unauthenticated user can create a user.
-                 Permissions required: users.create
+                 Permissions required: bb.users.create
             operationId: UserService_CreateUser
             requestBody:
                 content:
@@ -7439,7 +7426,7 @@ paths:
             description: |-
                 Get the user.
                  Any authenticated user can get the user.
-                 Permissions required: users.get
+                 Permissions required: bb.users.get
             operationId: UserService_GetUser
             parameters:
                 - name: user
@@ -7467,7 +7454,7 @@ paths:
             description: |-
                 Only the user with bb.users.delete permission on the workspace can delete the user.
                  The last remaining workspace admin cannot be deleted.
-                 Permissions required: users.delete
+                 Permissions required: bb.users.delete
             operationId: UserService_DeleteUser
             parameters:
                 - name: user
@@ -7491,7 +7478,7 @@ paths:
                 - UserService
             description: |-
                 Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-                 Permissions required: users.update
+                 Permissions required: bb.users.update
             operationId: UserService_UpdateUser
             parameters:
                 - name: user
@@ -7548,7 +7535,7 @@ paths:
                 - UserService
             description: |-
                 Only the user with bb.users.undelete permission on the workspace can undelete the user.
-                 Permissions required: users.undelete
+                 Permissions required: bb.users.undelete
             operationId: UserService_UndeleteUser
             parameters:
                 - name: user
@@ -7583,7 +7570,7 @@ paths:
             description: |-
                 Get the users in batch.
                  Any authenticated user can batch get users.
-                 Permissions required: users.get
+                 Permissions required: bb.users.get
             operationId: UserService_BatchGetUsers
             parameters:
                 - name: names
@@ -7821,7 +7808,7 @@ paths:
         get:
             tags:
                 - DatabaseService
-            description: 'Permissions required: databases.list'
+            description: 'Permissions required: bb.databases.list'
             operationId: DatabaseService_ListDatabases
             parameters:
                 - name: workspace
@@ -7905,7 +7892,7 @@ paths:
         get:
             tags:
                 - WorkspaceService
-            description: 'Permissions required: workspaces.getIamPolicy'
+            description: 'Permissions required: bb.workspaces.getIamPolicy'
             operationId: WorkspaceService_GetIamPolicy
             parameters:
                 - name: workspace
@@ -7931,7 +7918,7 @@ paths:
         post:
             tags:
                 - WorkspaceService
-            description: 'Permissions required: workspaces.setIamPolicy'
+            description: 'Permissions required: bb.workspaces.setIamPolicy'
             operationId: WorkspaceService_SetIamPolicy
             parameters:
                 - name: workspace
@@ -7963,7 +7950,7 @@ paths:
         get:
             tags:
                 - SQLService
-            description: 'Permissions required: sql.admin'
+            description: 'Permissions required: bb.sql.admin'
             operationId: SQLService_AdminExecute
             parameters:
                 - name: name

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -10,7 +10,9 @@ paths:
         get:
             tags:
                 - ProjectService
-            description: Deprecated.
+            description: |-
+                Deprecated.
+                 Permissions required: projects.getIamPolicy
             operationId: ProjectService_BatchGetIamPolicy
             parameters:
                 - name: '*'
@@ -42,6 +44,7 @@ paths:
         delete:
             tags:
                 - ActuatorService
+            description: 'Permissions required: None'
             operationId: ActuatorService_DeleteCache
             responses:
                 "200":
@@ -57,6 +60,7 @@ paths:
         get:
             tags:
                 - ActuatorService
+            description: 'Permissions required: None'
             operationId: ActuatorService_GetActuatorInfo
             responses:
                 "200":
@@ -74,6 +78,7 @@ paths:
         patch:
             tags:
                 - ActuatorService
+            description: 'Permissions required: settings.set'
             operationId: ActuatorService_UpdateActuatorInfo
             parameters:
                 - name: updateMask
@@ -105,6 +110,7 @@ paths:
         get:
             tags:
                 - ActuatorService
+            description: 'Permissions required: None'
             operationId: ActuatorService_GetResourcePackage
             responses:
                 "200":
@@ -123,6 +129,7 @@ paths:
         post:
             tags:
                 - ActuatorService
+            description: 'Permissions required: projects.create'
             operationId: ActuatorService_SetupSample
             responses:
                 "200":
@@ -138,6 +145,7 @@ paths:
         post:
             tags:
                 - AuditLogService
+            description: 'Permissions required: auditLogs.export'
             operationId: AuditLogService_ExportAuditLogs
             requestBody:
                 content:
@@ -162,6 +170,7 @@ paths:
         post:
             tags:
                 - AuditLogService
+            description: 'Permissions required: None'
             operationId: AuditLogService_SearchAuditLogs
             requestBody:
                 content:
@@ -186,6 +195,7 @@ paths:
         post:
             tags:
                 - AuthService
+            description: 'Permissions required: None'
             operationId: AuthService_Login
             requestBody:
                 content:
@@ -210,6 +220,7 @@ paths:
         post:
             tags:
                 - AuthService
+            description: 'Permissions required: None'
             operationId: AuthService_Logout
             requestBody:
                 content:
@@ -231,6 +242,7 @@ paths:
         post:
             tags:
                 - CelService
+            description: 'Permissions required: None'
             operationId: CelService_BatchDeparse
             requestBody:
                 content:
@@ -255,6 +267,7 @@ paths:
         post:
             tags:
                 - CelService
+            description: 'Permissions required: None'
             operationId: CelService_BatchParse
             requestBody:
                 content:
@@ -279,6 +292,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: environment
@@ -346,6 +360,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: environment
@@ -393,6 +408,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: environment
@@ -423,6 +439,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: environment
@@ -450,6 +467,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: environment
@@ -500,6 +518,7 @@ paths:
         get:
             tags:
                 - GroupService
+            description: 'Permissions required: groups.list'
             operationId: GroupService_ListGroups
             parameters:
                 - name: pageSize
@@ -540,6 +559,7 @@ paths:
         post:
             tags:
                 - GroupService
+            description: 'Permissions required: groups.create'
             operationId: GroupService_CreateGroup
             parameters:
                 - name: groupEmail
@@ -572,6 +592,7 @@ paths:
         get:
             tags:
                 - GroupService
+            description: 'Permissions required: groups.get'
             operationId: GroupService_GetGroup
             parameters:
                 - name: group
@@ -596,6 +617,7 @@ paths:
         delete:
             tags:
                 - GroupService
+            description: 'Permissions required: groups.delete'
             operationId: GroupService_DeleteGroup
             parameters:
                 - name: group
@@ -620,6 +642,7 @@ paths:
             description: |-
                 UpdateGroup updates the group.
                  Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+                 Permissions required: groups.update
             operationId: GroupService_UpdateGroup
             parameters:
                 - name: group
@@ -664,6 +687,7 @@ paths:
         get:
             tags:
                 - IdentityProviderService
+            description: 'Permissions required: None'
             operationId: IdentityProviderService_ListIdentityProviders
             parameters:
                 - name: pageSize
@@ -704,6 +728,7 @@ paths:
         post:
             tags:
                 - IdentityProviderService
+            description: 'Permissions required: identityProviders.create'
             operationId: IdentityProviderService_CreateIdentityProvider
             parameters:
                 - name: identityProviderId
@@ -744,6 +769,7 @@ paths:
         post:
             tags:
                 - IdentityProviderService
+            description: 'Permissions required: identityProviders.update'
             operationId: IdentityProviderService_TestIdentityProvider
             requestBody:
                 content:
@@ -768,6 +794,7 @@ paths:
         get:
             tags:
                 - IdentityProviderService
+            description: 'Permissions required: identityProviders.get'
             operationId: IdentityProviderService_GetIdentityProvider
             parameters:
                 - name: idp
@@ -792,6 +819,7 @@ paths:
         delete:
             tags:
                 - IdentityProviderService
+            description: 'Permissions required: identityProviders.delete'
             operationId: IdentityProviderService_DeleteIdentityProvider
             parameters:
                 - name: idp
@@ -813,6 +841,7 @@ paths:
         patch:
             tags:
                 - IdentityProviderService
+            description: 'Permissions required: identityProviders.update'
             operationId: IdentityProviderService_UpdateIdentityProvider
             parameters:
                 - name: idp
@@ -850,6 +879,7 @@ paths:
         get:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.list'
             operationId: InstanceService_ListInstances
             parameters:
                 - name: pageSize
@@ -929,6 +959,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.create'
             operationId: InstanceService_CreateInstance
             parameters:
                 - name: instanceId
@@ -969,6 +1000,7 @@ paths:
         get:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.get'
             operationId: InstanceService_GetInstance
             parameters:
                 - name: instance
@@ -993,6 +1025,7 @@ paths:
         delete:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.delete'
             operationId: InstanceService_DeleteInstance
             parameters:
                 - name: instance
@@ -1019,6 +1052,7 @@ paths:
         patch:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.update'
             operationId: InstanceService_UpdateInstance
             parameters:
                 - name: instance
@@ -1056,6 +1090,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.list'
             operationId: DatabaseService_ListDatabases
             parameters:
                 - name: instance
@@ -1139,6 +1174,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.get'
             operationId: DatabaseService_GetDatabase
             parameters:
                 - name: instance
@@ -1169,6 +1205,7 @@ paths:
         patch:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.update'
             operationId: DatabaseService_UpdateDatabase
             parameters:
                 - name: instance
@@ -1212,6 +1249,7 @@ paths:
         get:
             tags:
                 - DatabaseCatalogService
+            description: 'Permissions required: databaseCatalogs.get'
             operationId: DatabaseCatalogService_GetDatabaseCatalog
             parameters:
                 - name: instance
@@ -1242,6 +1280,7 @@ paths:
         patch:
             tags:
                 - DatabaseCatalogService
+            description: 'Permissions required: databaseCatalogs.update'
             operationId: DatabaseCatalogService_UpdateDatabaseCatalog
             parameters:
                 - name: instance
@@ -1279,6 +1318,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: changelogs.list'
             operationId: DatabaseService_ListChangelogs
             parameters:
                 - name: instance
@@ -1373,6 +1413,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: changelogs.get'
             operationId: DatabaseService_GetChangelog
             parameters:
                 - name: instance
@@ -1424,6 +1465,7 @@ paths:
         post:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.get'
             operationId: DatabaseService_DiffSchema
             parameters:
                 - name: instance
@@ -1467,6 +1509,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.getSchema'
             operationId: DatabaseService_GetDatabaseMetadata
             parameters:
                 - name: instance
@@ -1517,6 +1560,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: instance
@@ -1590,6 +1634,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: instance
@@ -1643,6 +1688,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: instance
@@ -1679,6 +1725,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: instance
@@ -1712,6 +1759,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: instance
@@ -1768,6 +1816,7 @@ paths:
         get:
             tags:
                 - RevisionService
+            description: 'Permissions required: revisions.list'
             operationId: RevisionService_ListRevisions
             parameters:
                 - name: instance
@@ -1821,6 +1870,7 @@ paths:
         post:
             tags:
                 - RevisionService
+            description: 'Permissions required: revisions.create'
             operationId: RevisionService_CreateRevision
             parameters:
                 - name: instance
@@ -1858,6 +1908,7 @@ paths:
         get:
             tags:
                 - RevisionService
+            description: 'Permissions required: revisions.get'
             operationId: RevisionService_GetRevision
             parameters:
                 - name: instance
@@ -1894,6 +1945,7 @@ paths:
         delete:
             tags:
                 - RevisionService
+            description: 'Permissions required: revisions.delete'
             operationId: RevisionService_DeleteRevision
             parameters:
                 - name: instance
@@ -1928,6 +1980,7 @@ paths:
         post:
             tags:
                 - RevisionService
+            description: 'Permissions required: revisions.create'
             operationId: RevisionService_BatchCreateRevisions
             parameters:
                 - name: instance
@@ -1965,6 +2018,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.getSchema'
             operationId: DatabaseService_GetDatabaseSchema
             parameters:
                 - name: instance
@@ -2001,6 +2055,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.getSchema'
             operationId: DatabaseService_GetSchemaString
             parameters:
                 - name: instance
@@ -2084,6 +2139,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databaseSecrets.list'
             operationId: DatabaseService_ListSecrets
             parameters:
                 - name: instance
@@ -2137,6 +2193,7 @@ paths:
         delete:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databaseSecrets.delete'
             operationId: DatabaseService_DeleteSecret
             parameters:
                 - name: instance
@@ -2170,6 +2227,7 @@ paths:
         patch:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databaseSecrets.update'
             operationId: DatabaseService_UpdateSecret
             parameters:
                 - name: instance
@@ -2224,6 +2282,7 @@ paths:
         post:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.get'
             operationId: DatabaseService_DiffSchema
             parameters:
                 - name: instance
@@ -2261,6 +2320,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: instance
@@ -2298,6 +2358,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: databases.get'
             operationId: SQLService_Query
             parameters:
                 - name: instance
@@ -2335,6 +2396,7 @@ paths:
         post:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.sync'
             operationId: DatabaseService_SyncDatabase
             parameters:
                 - name: instance
@@ -2372,6 +2434,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.get'
             operationId: DatabaseService_BatchGetDatabases
             parameters:
                 - name: instance
@@ -2404,6 +2467,7 @@ paths:
         post:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.sync'
             operationId: DatabaseService_BatchSyncDatabases
             parameters:
                 - name: instance
@@ -2435,6 +2499,7 @@ paths:
         post:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.update'
             operationId: DatabaseService_BatchUpdateDatabases
             parameters:
                 - name: instance
@@ -2466,6 +2531,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: instance
@@ -2533,6 +2599,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: instance
@@ -2580,6 +2647,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: instance
@@ -2610,6 +2678,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: instance
@@ -2637,6 +2706,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: instance
@@ -2687,6 +2757,7 @@ paths:
         get:
             tags:
                 - InstanceRoleService
+            description: 'Permissions required: instanceRoles.get'
             operationId: InstanceRoleService_ListInstanceRoles
             parameters:
                 - name: instance
@@ -2739,6 +2810,7 @@ paths:
         get:
             tags:
                 - InstanceRoleService
+            description: 'Permissions required: instanceRoles.get'
             operationId: InstanceRoleService_GetInstanceRole
             parameters:
                 - name: instance
@@ -2770,6 +2842,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.update'
             operationId: InstanceService_AddDataSource
             parameters:
                 - name: instance
@@ -2801,6 +2874,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.get'
             operationId: InstanceService_ListInstanceDatabase
             parameters:
                 - name: instance
@@ -2832,6 +2906,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: instance
@@ -2863,6 +2938,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: databases.get'
             operationId: SQLService_Query
             parameters:
                 - name: instance
@@ -2894,6 +2970,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.update'
             operationId: InstanceService_RemoveDataSource
             parameters:
                 - name: instance
@@ -2925,6 +3002,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.sync'
             operationId: InstanceService_SyncInstance
             parameters:
                 - name: instance
@@ -2956,6 +3034,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.undelete'
             operationId: InstanceService_UndeleteInstance
             parameters:
                 - name: instance
@@ -2987,6 +3066,7 @@ paths:
         patch:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.update'
             operationId: InstanceService_UpdateDataSource
             parameters:
                 - name: instance
@@ -3018,6 +3098,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.sync'
             operationId: InstanceService_BatchSyncInstances
             requestBody:
                 content:
@@ -3042,6 +3123,7 @@ paths:
         post:
             tags:
                 - InstanceService
+            description: 'Permissions required: instances.update'
             operationId: InstanceService_BatchUpdateInstances
             requestBody:
                 content:
@@ -3066,6 +3148,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: parent
@@ -3134,6 +3217,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: parent
@@ -3185,6 +3269,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: policy
@@ -3209,6 +3294,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: policy
@@ -3230,6 +3316,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: policy
@@ -3274,6 +3361,7 @@ paths:
         get:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.list'
             operationId: ProjectService_ListProjects
             parameters:
                 - name: pageSize
@@ -3324,6 +3412,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.create'
             operationId: ProjectService_CreateProject
             parameters:
                 - name: projectId
@@ -3362,6 +3451,7 @@ paths:
             description: |-
                 GetProject retrieves a project by name.
                  Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+                 Permissions required: projects.get
             operationId: ProjectService_GetProject
             parameters:
                 - name: project
@@ -3386,6 +3476,7 @@ paths:
         delete:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.delete'
             operationId: ProjectService_DeleteProject
             parameters:
                 - name: project
@@ -3416,6 +3507,7 @@ paths:
         patch:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.update'
             operationId: ProjectService_UpdateProject
             parameters:
                 - name: project
@@ -3453,6 +3545,7 @@ paths:
         post:
             tags:
                 - AuditLogService
+            description: 'Permissions required: auditLogs.export'
             operationId: AuditLogService_ExportAuditLogs
             parameters:
                 - name: project
@@ -3484,6 +3577,7 @@ paths:
         post:
             tags:
                 - AuditLogService
+            description: 'Permissions required: None'
             operationId: AuditLogService_SearchAuditLogs
             parameters:
                 - name: project
@@ -3515,6 +3609,7 @@ paths:
         get:
             tags:
                 - ChangelistService
+            description: 'Permissions required: changelists.list'
             operationId: ChangelistService_ListChangelists
             parameters:
                 - name: project
@@ -3561,6 +3656,7 @@ paths:
         post:
             tags:
                 - ChangelistService
+            description: 'Permissions required: changelists.create'
             operationId: ChangelistService_CreateChangelist
             parameters:
                 - name: project
@@ -3602,6 +3698,7 @@ paths:
         get:
             tags:
                 - ChangelistService
+            description: 'Permissions required: changelists.get'
             operationId: ChangelistService_GetChangelist
             parameters:
                 - name: project
@@ -3632,6 +3729,7 @@ paths:
         delete:
             tags:
                 - ChangelistService
+            description: 'Permissions required: changelists.delete'
             operationId: ChangelistService_DeleteChangelist
             parameters:
                 - name: project
@@ -3659,6 +3757,7 @@ paths:
         patch:
             tags:
                 - ChangelistService
+            description: 'Permissions required: changelists.update'
             operationId: ChangelistService_UpdateChangelist
             parameters:
                 - name: project
@@ -3702,6 +3801,7 @@ paths:
         get:
             tags:
                 - DatabaseGroupService
+            description: 'Permissions required: projects.get'
             operationId: DatabaseGroupService_ListDatabaseGroups
             parameters:
                 - name: project
@@ -3758,6 +3858,7 @@ paths:
         post:
             tags:
                 - DatabaseGroupService
+            description: 'Permissions required: projects.update'
             operationId: DatabaseGroupService_CreateDatabaseGroup
             parameters:
                 - name: project
@@ -3804,6 +3905,7 @@ paths:
         get:
             tags:
                 - DatabaseGroupService
+            description: 'Permissions required: projects.get'
             operationId: DatabaseGroupService_GetDatabaseGroup
             parameters:
                 - name: project
@@ -3844,6 +3946,7 @@ paths:
         delete:
             tags:
                 - DatabaseGroupService
+            description: 'Permissions required: projects.update'
             operationId: DatabaseGroupService_DeleteDatabaseGroup
             parameters:
                 - name: project
@@ -3871,6 +3974,7 @@ paths:
         patch:
             tags:
                 - DatabaseGroupService
+            description: 'Permissions required: projects.update'
             operationId: DatabaseGroupService_UpdateDatabaseGroup
             parameters:
                 - name: project
@@ -3914,6 +4018,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.list'
             operationId: DatabaseService_ListDatabases
             parameters:
                 - name: project
@@ -3997,6 +4102,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.get'
             operationId: DatabaseService_BatchGetDatabases
             parameters:
                 - name: project
@@ -4029,6 +4135,7 @@ paths:
         get:
             tags:
                 - IssueService
+            description: 'Permissions required: issues.list'
             operationId: IssueService_ListIssues
             parameters:
                 - name: project
@@ -4103,6 +4210,7 @@ paths:
         post:
             tags:
                 - IssueService
+            description: 'Permissions required: issues.create'
             operationId: IssueService_CreateIssue
             parameters:
                 - name: project
@@ -4134,6 +4242,7 @@ paths:
         get:
             tags:
                 - IssueService
+            description: 'Permissions required: issues.get'
             operationId: IssueService_GetIssue
             parameters:
                 - name: project
@@ -4168,6 +4277,7 @@ paths:
         patch:
             tags:
                 - IssueService
+            description: 'Permissions required: issues.update'
             operationId: IssueService_UpdateIssue
             parameters:
                 - name: project
@@ -4211,6 +4321,7 @@ paths:
         get:
             tags:
                 - IssueService
+            description: 'Permissions required: issueComments.list'
             operationId: IssueService_ListIssueComments
             parameters:
                 - name: project
@@ -4265,6 +4376,7 @@ paths:
             description: |-
                 ApproveIssue approves the issue.
                  The access is based on approval flow.
+                 Permissions required: None
             operationId: IssueService_ApproveIssue
             parameters:
                 - name: project
@@ -4302,6 +4414,7 @@ paths:
         post:
             tags:
                 - IssueService
+            description: 'Permissions required: issueComments.create'
             operationId: IssueService_CreateIssueComment
             parameters:
                 - name: project
@@ -4338,6 +4451,7 @@ paths:
         patch:
             tags:
                 - IssueService
+            description: 'Permissions required: issueComments.update'
             operationId: IssueService_UpdateIssueComment
             parameters:
                 - name: project
@@ -4384,6 +4498,7 @@ paths:
             description: |-
                 RejectIssue rejects the issue.
                  The access is based on approval flow.
+                 Permissions required: None
             operationId: IssueService_RejectIssue
             parameters:
                 - name: project
@@ -4424,6 +4539,7 @@ paths:
             description: |-
                 RequestIssue requests the issue.
                  The access is based on approval flow.
+                 Permissions required: None
             operationId: IssueService_RequestIssue
             parameters:
                 - name: project
@@ -4461,6 +4577,7 @@ paths:
         post:
             tags:
                 - IssueService
+            description: 'Permissions required: issues.update'
             operationId: IssueService_BatchUpdateIssuesStatus
             parameters:
                 - name: project
@@ -4492,7 +4609,9 @@ paths:
         post:
             tags:
                 - IssueService
-            description: Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+            description: |-
+                Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+                 Permissions required: issues.get
             operationId: IssueService_SearchIssues
             parameters:
                 - name: project
@@ -4524,6 +4643,7 @@ paths:
         get:
             tags:
                 - PlanService
+            description: 'Permissions required: plans.list'
             operationId: PlanService_ListPlans
             parameters:
                 - name: project
@@ -4568,6 +4688,7 @@ paths:
         post:
             tags:
                 - PlanService
+            description: 'Permissions required: plans.create'
             operationId: PlanService_CreatePlan
             parameters:
                 - name: project
@@ -4599,6 +4720,7 @@ paths:
         get:
             tags:
                 - PlanService
+            description: 'Permissions required: plans.get'
             operationId: PlanService_GetPlan
             parameters:
                 - name: project
@@ -4632,6 +4754,7 @@ paths:
             description: |-
                 UpdatePlan updates the plan.
                  The plan creator and the user with bb.plans.update permission on the project can update the plan.
+                 Permissions required: plans.update
             operationId: PlanService_UpdatePlan
             parameters:
                 - name: project
@@ -4675,6 +4798,7 @@ paths:
         get:
             tags:
                 - PlanService
+            description: 'Permissions required: planCheckRuns.list'
             operationId: PlanService_ListPlanCheckRuns
             parameters:
                 - name: project
@@ -4750,6 +4874,7 @@ paths:
         post:
             tags:
                 - PlanService
+            description: 'Permissions required: planCheckRuns.run'
             operationId: PlanService_BatchCancelPlanCheckRuns
             parameters:
                 - name: project
@@ -4787,6 +4912,7 @@ paths:
         post:
             tags:
                 - PlanService
+            description: 'Permissions required: planCheckRuns.run'
             operationId: PlanService_RunPlanChecks
             parameters:
                 - name: project
@@ -4824,7 +4950,9 @@ paths:
         post:
             tags:
                 - PlanService
-            description: Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+            description: |-
+                Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+                 Permissions required: plans.get
             operationId: PlanService_SearchPlans
             parameters:
                 - name: project
@@ -4856,6 +4984,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.list'
             operationId: OrgPolicyService_ListPolicies
             parameters:
                 - name: project
@@ -4923,6 +5052,7 @@ paths:
         post:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.create'
             operationId: OrgPolicyService_CreatePolicy
             parameters:
                 - name: project
@@ -4970,6 +5100,7 @@ paths:
         get:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.get'
             operationId: OrgPolicyService_GetPolicy
             parameters:
                 - name: project
@@ -5000,6 +5131,7 @@ paths:
         delete:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.delete'
             operationId: OrgPolicyService_DeletePolicy
             parameters:
                 - name: project
@@ -5027,6 +5159,7 @@ paths:
         patch:
             tags:
                 - OrgPolicyService
+            description: 'Permissions required: policies.update'
             operationId: OrgPolicyService_UpdatePolicy
             parameters:
                 - name: project
@@ -5077,6 +5210,7 @@ paths:
         get:
             tags:
                 - ReleaseService
+            description: 'Permissions required: releases.list'
             operationId: ReleaseService_ListReleases
             parameters:
                 - name: project
@@ -5126,6 +5260,7 @@ paths:
         post:
             tags:
                 - ReleaseService
+            description: 'Permissions required: releases.create'
             operationId: ReleaseService_CreateRelease
             parameters:
                 - name: project
@@ -5157,6 +5292,7 @@ paths:
         get:
             tags:
                 - ReleaseService
+            description: 'Permissions required: releases.get'
             operationId: ReleaseService_GetRelease
             parameters:
                 - name: project
@@ -5187,6 +5323,7 @@ paths:
         delete:
             tags:
                 - ReleaseService
+            description: 'Permissions required: releases.delete'
             operationId: ReleaseService_DeleteRelease
             parameters:
                 - name: project
@@ -5214,6 +5351,7 @@ paths:
         patch:
             tags:
                 - ReleaseService
+            description: 'Permissions required: releases.update'
             operationId: ReleaseService_UpdateRelease
             parameters:
                 - name: project
@@ -5257,6 +5395,7 @@ paths:
         post:
             tags:
                 - ReleaseService
+            description: 'Permissions required: releases.undelete'
             operationId: ReleaseService_UndeleteRelease
             parameters:
                 - name: project
@@ -5288,6 +5427,7 @@ paths:
         post:
             tags:
                 - ReleaseService
+            description: 'Permissions required: releases.check'
             operationId: ReleaseService_CheckRelease
             parameters:
                 - name: project
@@ -5319,6 +5459,7 @@ paths:
         get:
             tags:
                 - RolloutService
+            description: 'Permissions required: rollouts.list'
             operationId: RolloutService_ListRollouts
             parameters:
                 - name: project
@@ -5363,7 +5504,9 @@ paths:
         post:
             tags:
                 - RolloutService
-            description: CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+            description: |-
+                CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+                 Permissions required: rollouts.create
             operationId: RolloutService_CreateRollout
             parameters:
                 - name: project
@@ -5411,6 +5554,7 @@ paths:
         get:
             tags:
                 - RolloutService
+            description: 'Permissions required: rollouts.get'
             operationId: RolloutService_GetRollout
             parameters:
                 - name: project
@@ -5442,6 +5586,7 @@ paths:
         get:
             tags:
                 - RolloutService
+            description: 'Permissions required: taskRuns.list'
             operationId: RolloutService_ListTaskRuns
             parameters:
                 - name: project
@@ -5507,6 +5652,7 @@ paths:
         get:
             tags:
                 - RolloutService
+            description: 'Permissions required: taskRuns.list'
             operationId: RolloutService_GetTaskRun
             parameters:
                 - name: project
@@ -5556,6 +5702,7 @@ paths:
         get:
             tags:
                 - RolloutService
+            description: 'Permissions required: taskRuns.list'
             operationId: RolloutService_GetTaskRunLog
             parameters:
                 - name: project
@@ -5605,6 +5752,7 @@ paths:
         get:
             tags:
                 - RolloutService
+            description: 'Permissions required: taskRuns.list'
             operationId: RolloutService_GetTaskRunSession
             parameters:
                 - name: project
@@ -5654,6 +5802,7 @@ paths:
         post:
             tags:
                 - RolloutService
+            description: 'Permissions required: taskRuns.list'
             operationId: RolloutService_PreviewTaskRunRollback
             parameters:
                 - name: project
@@ -5712,6 +5861,7 @@ paths:
             description: |-
                 BatchCancelTaskRuns cancels the specified task runs in batch.
                  The access is the same as BatchRunTasks().
+                 Permissions required: None
             operationId: RolloutService_BatchCancelTaskRuns
             parameters:
                 - name: project
@@ -5766,6 +5916,7 @@ paths:
                  DataExport issue only allows the creator to run the task.
                  Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
                  Follow role-based rollout policy for the environment.
+                 Permissions required: None
             operationId: RolloutService_BatchRunTasks
             parameters:
                 - name: project
@@ -5812,6 +5963,7 @@ paths:
             description: |-
                 BatchSkipTasks skips the specified tasks.
                  The access is the same as BatchRunTasks().
+                 Permissions required: None
             operationId: RolloutService_BatchSkipTasks
             parameters:
                 - name: project
@@ -5855,6 +6007,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: project
@@ -5898,6 +6051,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: databases.get'
             operationId: SQLService_Export
             parameters:
                 - name: project
@@ -5935,6 +6089,7 @@ paths:
         post:
             tags:
                 - SheetService
+            description: 'Permissions required: sheets.create'
             operationId: SheetService_CreateSheet
             parameters:
                 - name: project
@@ -5966,6 +6121,7 @@ paths:
         get:
             tags:
                 - SheetService
+            description: 'Permissions required: sheets.get'
             operationId: SheetService_GetSheet
             parameters:
                 - name: project
@@ -6001,6 +6157,7 @@ paths:
         patch:
             tags:
                 - SheetService
+            description: 'Permissions required: sheets.update'
             operationId: SheetService_UpdateSheet
             parameters:
                 - name: project
@@ -6050,6 +6207,7 @@ paths:
         post:
             tags:
                 - SheetService
+            description: 'Permissions required: sheets.create'
             operationId: SheetService_BatchCreateSheets
             parameters:
                 - name: project
@@ -6081,6 +6239,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.update'
             operationId: ProjectService_RemoveWebhook
             parameters:
                 - name: project
@@ -6118,6 +6277,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.update'
             operationId: ProjectService_UpdateWebhook
             parameters:
                 - name: project
@@ -6155,6 +6315,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.update'
             operationId: ProjectService_AddWebhook
             parameters:
                 - name: project
@@ -6186,6 +6347,7 @@ paths:
         get:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.getIamPolicy'
             operationId: ProjectService_GetIamPolicy
             parameters:
                 - name: project
@@ -6211,6 +6373,7 @@ paths:
         post:
             tags:
                 - RolloutService
+            description: 'Permissions required: rollouts.preview'
             operationId: RolloutService_PreviewRollout
             parameters:
                 - name: project
@@ -6242,6 +6405,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.setIamPolicy'
             operationId: ProjectService_SetIamPolicy
             parameters:
                 - name: project
@@ -6273,6 +6437,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.update'
             operationId: ProjectService_TestWebhook
             parameters:
                 - name: project
@@ -6304,6 +6469,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.undelete'
             operationId: ProjectService_UndeleteProject
             parameters:
                 - name: project
@@ -6335,6 +6501,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: projects.delete'
             operationId: ProjectService_BatchDeleteProjects
             requestBody:
                 content:
@@ -6356,6 +6523,7 @@ paths:
         post:
             tags:
                 - ProjectService
+            description: 'Permissions required: None'
             operationId: ProjectService_SearchProjects
             requestBody:
                 content:
@@ -6380,7 +6548,9 @@ paths:
         post:
             tags:
                 - SQLService
-            description: SearchQueryHistories searches query histories for the caller.
+            description: |-
+                SearchQueryHistories searches query histories for the caller.
+                 Permissions required: None
             operationId: SQLService_SearchQueryHistories
             requestBody:
                 content:
@@ -6405,6 +6575,7 @@ paths:
         get:
             tags:
                 - ReviewConfigService
+            description: 'Permissions required: reviewConfigs.list'
             operationId: ReviewConfigService_ListReviewConfigs
             parameters:
                 - name: pageSize
@@ -6444,6 +6615,7 @@ paths:
         post:
             tags:
                 - ReviewConfigService
+            description: 'Permissions required: reviewConfigs.create'
             operationId: ReviewConfigService_CreateReviewConfig
             requestBody:
                 content:
@@ -6468,6 +6640,7 @@ paths:
         get:
             tags:
                 - ReviewConfigService
+            description: 'Permissions required: reviewConfigs.get'
             operationId: ReviewConfigService_GetReviewConfig
             parameters:
                 - name: reviewConfig
@@ -6492,6 +6665,7 @@ paths:
         delete:
             tags:
                 - ReviewConfigService
+            description: 'Permissions required: reviewConfigs.delete'
             operationId: ReviewConfigService_DeleteReviewConfig
             parameters:
                 - name: reviewConfig
@@ -6513,6 +6687,7 @@ paths:
         patch:
             tags:
                 - ReviewConfigService
+            description: 'Permissions required: reviewConfigs.update'
             operationId: ReviewConfigService_UpdateReviewConfig
             parameters:
                 - name: reviewConfig
@@ -6557,6 +6732,7 @@ paths:
         get:
             tags:
                 - RiskService
+            description: 'Permissions required: risks.list'
             operationId: RiskService_ListRisks
             parameters:
                 - name: pageSize
@@ -6597,6 +6773,7 @@ paths:
         post:
             tags:
                 - RiskService
+            description: 'Permissions required: risks.create'
             operationId: RiskService_CreateRisk
             requestBody:
                 content:
@@ -6621,6 +6798,7 @@ paths:
         get:
             tags:
                 - RiskService
+            description: 'Permissions required: risks.list'
             operationId: RiskService_GetRisk
             parameters:
                 - name: risk
@@ -6645,6 +6823,7 @@ paths:
         delete:
             tags:
                 - RiskService
+            description: 'Permissions required: risks.delete'
             operationId: RiskService_DeleteRisk
             parameters:
                 - name: risk
@@ -6666,6 +6845,7 @@ paths:
         patch:
             tags:
                 - RiskService
+            description: 'Permissions required: risks.update'
             operationId: RiskService_UpdateRisk
             parameters:
                 - name: risk
@@ -6703,6 +6883,7 @@ paths:
         get:
             tags:
                 - RoleService
+            description: 'Permissions required: roles.list'
             operationId: RoleService_ListRoles
             parameters:
                 - name: pageSize
@@ -6743,6 +6924,7 @@ paths:
         post:
             tags:
                 - RoleService
+            description: 'Permissions required: roles.create'
             operationId: RoleService_CreateRole
             parameters:
                 - name: roleId
@@ -6778,6 +6960,7 @@ paths:
         get:
             tags:
                 - RoleService
+            description: 'Permissions required: roles.get'
             operationId: RoleService_GetRole
             parameters:
                 - name: role
@@ -6802,6 +6985,7 @@ paths:
         delete:
             tags:
                 - RoleService
+            description: 'Permissions required: roles.delete'
             operationId: RoleService_DeleteRole
             parameters:
                 - name: role
@@ -6823,6 +7007,7 @@ paths:
         patch:
             tags:
                 - RoleService
+            description: 'Permissions required: roles.update'
             operationId: RoleService_UpdateRole
             parameters:
                 - name: role
@@ -6864,6 +7049,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: None'
             operationId: SQLService_DiffMetadata
             requestBody:
                 content:
@@ -6888,6 +7074,7 @@ paths:
         get:
             tags:
                 - SettingService
+            description: 'Permissions required: settings.list'
             operationId: SettingService_ListSettings
             parameters:
                 - name: pageSize
@@ -6929,6 +7116,7 @@ paths:
         get:
             tags:
                 - SettingService
+            description: 'Permissions required: settings.get'
             operationId: SettingService_GetSetting
             parameters:
                 - name: setting
@@ -6953,6 +7141,7 @@ paths:
         patch:
             tags:
                 - SettingService
+            description: 'Permissions required: settings.set'
             operationId: SettingService_UpdateSetting
             parameters:
                 - name: setting
@@ -7000,6 +7189,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: None'
             operationId: SQLService_AICompletion
             requestBody:
                 content:
@@ -7024,6 +7214,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: databases.check'
             operationId: SQLService_Check
             requestBody:
                 content:
@@ -7048,6 +7239,7 @@ paths:
         post:
             tags:
                 - SQLService
+            description: 'Permissions required: None'
             operationId: SQLService_Pretty
             requestBody:
                 content:
@@ -7076,6 +7268,7 @@ paths:
                 GetSubscription returns the current subscription.
                  If there is no license, we will return a free plan subscription without expiration time.
                  If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+                 Permissions required: None
             operationId: SubscriptionService_GetSubscription
             responses:
                 "200":
@@ -7093,6 +7286,7 @@ paths:
         patch:
             tags:
                 - SubscriptionService
+            description: 'Permissions required: settings.set'
             operationId: SubscriptionService_UpdateSubscription
             requestBody:
                 content:
@@ -7120,6 +7314,7 @@ paths:
             description: |-
                 List all users.
                  Any authenticated user can list users.
+                 Permissions required: users.list
             operationId: UserService_ListUsers
             parameters:
                 - name: pageSize
@@ -7195,6 +7390,7 @@ paths:
                 Create a user.
                  When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
                  Otherwise, any unauthenticated user can create a user.
+                 Permissions required: users.create
             operationId: UserService_CreateUser
             requestBody:
                 content:
@@ -7219,7 +7415,9 @@ paths:
         get:
             tags:
                 - UserService
-            description: Get the current authenticated user.
+            description: |-
+                Get the current authenticated user.
+                 Permissions required: None
             operationId: UserService_GetCurrentUser
             responses:
                 "200":
@@ -7241,6 +7439,7 @@ paths:
             description: |-
                 Get the user.
                  Any authenticated user can get the user.
+                 Permissions required: users.get
             operationId: UserService_GetUser
             parameters:
                 - name: user
@@ -7268,6 +7467,7 @@ paths:
             description: |-
                 Only the user with bb.users.delete permission on the workspace can delete the user.
                  The last remaining workspace admin cannot be deleted.
+                 Permissions required: users.delete
             operationId: UserService_DeleteUser
             parameters:
                 - name: user
@@ -7289,7 +7489,9 @@ paths:
         patch:
             tags:
                 - UserService
-            description: Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+            description: |-
+                Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+                 Permissions required: users.update
             operationId: UserService_UpdateUser
             parameters:
                 - name: user
@@ -7344,7 +7546,9 @@ paths:
         post:
             tags:
                 - UserService
-            description: Only the user with bb.users.undelete permission on the workspace can undelete the user.
+            description: |-
+                Only the user with bb.users.undelete permission on the workspace can undelete the user.
+                 Permissions required: users.undelete
             operationId: UserService_UndeleteUser
             parameters:
                 - name: user
@@ -7379,6 +7583,7 @@ paths:
             description: |-
                 Get the users in batch.
                  Any authenticated user can batch get users.
+                 Permissions required: users.get
             operationId: UserService_BatchGetUsers
             parameters:
                 - name: names
@@ -7407,7 +7612,9 @@ paths:
         post:
             tags:
                 - WorksheetService
-            description: Create a personal worksheet used in SQL Editor.
+            description: |-
+                Create a personal worksheet used in SQL Editor.
+                 Permissions required: None
             operationId: WorksheetService_CreateWorksheet
             requestBody:
                 content:
@@ -7438,6 +7645,7 @@ paths:
                  - they are the creator of the worksheet;
                  - they have bb.worksheets.get permission on the workspace;
                  - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+                 Permissions required: None
             operationId: WorksheetService_GetWorksheet
             parameters:
                 - name: worksheet
@@ -7465,6 +7673,7 @@ paths:
             description: |-
                 Delete a worksheet.
                  The access is the same as UpdateWorksheet method.
+                 Permissions required: None
             operationId: WorksheetService_DeleteWorksheet
             parameters:
                 - name: worksheet
@@ -7492,6 +7701,7 @@ paths:
                  - they are the creator of the worksheet;
                  - they have bb.worksheets.manage permission on the workspace;
                  - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+                 Permissions required: None
             operationId: WorksheetService_UpdateWorksheet
             parameters:
                 - name: worksheet
@@ -7540,6 +7750,7 @@ paths:
             description: |-
                 Update the organizer of a worksheet.
                  The access is the same as UpdateWorksheet method.
+                 Permissions required: None
             operationId: WorksheetService_UpdateWorksheetOrganizer
             parameters:
                 - name: worksheet
@@ -7585,6 +7796,7 @@ paths:
                 Search for worksheets.
                  This is used for finding my worksheets or worksheets shared by other people.
                  The sheet accessibility is the same as GetWorksheet().
+                 Permissions required: None
             operationId: WorksheetService_SearchWorksheets
             requestBody:
                 content:
@@ -7609,6 +7821,7 @@ paths:
         get:
             tags:
                 - DatabaseService
+            description: 'Permissions required: databases.list'
             operationId: DatabaseService_ListDatabases
             parameters:
                 - name: workspace
@@ -7692,6 +7905,7 @@ paths:
         get:
             tags:
                 - WorkspaceService
+            description: 'Permissions required: workspaces.getIamPolicy'
             operationId: WorkspaceService_GetIamPolicy
             parameters:
                 - name: workspace
@@ -7717,6 +7931,7 @@ paths:
         post:
             tags:
                 - WorkspaceService
+            description: 'Permissions required: workspaces.setIamPolicy'
             operationId: WorkspaceService_SetIamPolicy
             parameters:
                 - name: workspace
@@ -7748,6 +7963,7 @@ paths:
         get:
             tags:
                 - SQLService
+            description: 'Permissions required: sql.admin'
             operationId: SQLService_AdminExecute
             parameters:
                 - name: name

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -1106,8 +1106,8 @@ The catalog&#39;s `name` field is used to identify the database catalog to updat
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetDatabaseCatalog | [GetDatabaseCatalogRequest](#bytebase-v1-GetDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) |  |
-| UpdateDatabaseCatalog | [UpdateDatabaseCatalogRequest](#bytebase-v1-UpdateDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) |  |
+| GetDatabaseCatalog | [GetDatabaseCatalogRequest](#bytebase-v1-GetDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) | Permissions required: databaseCatalogs.get |
+| UpdateDatabaseCatalog | [UpdateDatabaseCatalogRequest](#bytebase-v1-UpdateDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) | Permissions required: databaseCatalogs.update |
 
  
 
@@ -1204,8 +1204,8 @@ When paginating, all other parameters provided to `ListInstanceRoles` must match
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetInstanceRole | [GetInstanceRoleRequest](#bytebase-v1-GetInstanceRoleRequest) | [InstanceRole](#bytebase-v1-InstanceRole) |  |
-| ListInstanceRoles | [ListInstanceRolesRequest](#bytebase-v1-ListInstanceRolesRequest) | [ListInstanceRolesResponse](#bytebase-v1-ListInstanceRolesResponse) |  |
+| GetInstanceRole | [GetInstanceRoleRequest](#bytebase-v1-GetInstanceRoleRequest) | [InstanceRole](#bytebase-v1-InstanceRole) | Permissions required: instanceRoles.get |
+| ListInstanceRoles | [ListInstanceRolesRequest](#bytebase-v1-ListInstanceRolesRequest) | [ListInstanceRolesResponse](#bytebase-v1-ListInstanceRolesResponse) | Permissions required: instanceRoles.get |
 
  
 
@@ -1828,19 +1828,19 @@ The instance&#39;s `name` field is used to identify the instance to update. Form
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetInstance | [GetInstanceRequest](#bytebase-v1-GetInstanceRequest) | [Instance](#bytebase-v1-Instance) |  |
-| ListInstances | [ListInstancesRequest](#bytebase-v1-ListInstancesRequest) | [ListInstancesResponse](#bytebase-v1-ListInstancesResponse) |  |
-| CreateInstance | [CreateInstanceRequest](#bytebase-v1-CreateInstanceRequest) | [Instance](#bytebase-v1-Instance) |  |
-| UpdateInstance | [UpdateInstanceRequest](#bytebase-v1-UpdateInstanceRequest) | [Instance](#bytebase-v1-Instance) |  |
-| DeleteInstance | [DeleteInstanceRequest](#bytebase-v1-DeleteInstanceRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| UndeleteInstance | [UndeleteInstanceRequest](#bytebase-v1-UndeleteInstanceRequest) | [Instance](#bytebase-v1-Instance) |  |
-| SyncInstance | [SyncInstanceRequest](#bytebase-v1-SyncInstanceRequest) | [SyncInstanceResponse](#bytebase-v1-SyncInstanceResponse) |  |
-| ListInstanceDatabase | [ListInstanceDatabaseRequest](#bytebase-v1-ListInstanceDatabaseRequest) | [ListInstanceDatabaseResponse](#bytebase-v1-ListInstanceDatabaseResponse) |  |
-| BatchSyncInstances | [BatchSyncInstancesRequest](#bytebase-v1-BatchSyncInstancesRequest) | [BatchSyncInstancesResponse](#bytebase-v1-BatchSyncInstancesResponse) |  |
-| BatchUpdateInstances | [BatchUpdateInstancesRequest](#bytebase-v1-BatchUpdateInstancesRequest) | [BatchUpdateInstancesResponse](#bytebase-v1-BatchUpdateInstancesResponse) |  |
-| AddDataSource | [AddDataSourceRequest](#bytebase-v1-AddDataSourceRequest) | [Instance](#bytebase-v1-Instance) |  |
-| RemoveDataSource | [RemoveDataSourceRequest](#bytebase-v1-RemoveDataSourceRequest) | [Instance](#bytebase-v1-Instance) |  |
-| UpdateDataSource | [UpdateDataSourceRequest](#bytebase-v1-UpdateDataSourceRequest) | [Instance](#bytebase-v1-Instance) |  |
+| GetInstance | [GetInstanceRequest](#bytebase-v1-GetInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.get |
+| ListInstances | [ListInstancesRequest](#bytebase-v1-ListInstancesRequest) | [ListInstancesResponse](#bytebase-v1-ListInstancesResponse) | Permissions required: instances.list |
+| CreateInstance | [CreateInstanceRequest](#bytebase-v1-CreateInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.create |
+| UpdateInstance | [UpdateInstanceRequest](#bytebase-v1-UpdateInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
+| DeleteInstance | [DeleteInstanceRequest](#bytebase-v1-DeleteInstanceRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: instances.delete |
+| UndeleteInstance | [UndeleteInstanceRequest](#bytebase-v1-UndeleteInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.undelete |
+| SyncInstance | [SyncInstanceRequest](#bytebase-v1-SyncInstanceRequest) | [SyncInstanceResponse](#bytebase-v1-SyncInstanceResponse) | Permissions required: instances.sync |
+| ListInstanceDatabase | [ListInstanceDatabaseRequest](#bytebase-v1-ListInstanceDatabaseRequest) | [ListInstanceDatabaseResponse](#bytebase-v1-ListInstanceDatabaseResponse) | Permissions required: instances.get |
+| BatchSyncInstances | [BatchSyncInstancesRequest](#bytebase-v1-BatchSyncInstancesRequest) | [BatchSyncInstancesResponse](#bytebase-v1-BatchSyncInstancesResponse) | Permissions required: instances.sync |
+| BatchUpdateInstances | [BatchUpdateInstancesRequest](#bytebase-v1-BatchUpdateInstancesRequest) | [BatchUpdateInstancesResponse](#bytebase-v1-BatchUpdateInstancesResponse) | Permissions required: instances.update |
+| AddDataSource | [AddDataSourceRequest](#bytebase-v1-AddDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
+| RemoveDataSource | [RemoveDataSourceRequest](#bytebase-v1-RemoveDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
+| UpdateDataSource | [UpdateDataSourceRequest](#bytebase-v1-UpdateDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
 
  
 
@@ -3187,22 +3187,22 @@ LIST, HASH (https://www.postgresql.org/docs/current/ddl-partitioning.html)
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetDatabase | [GetDatabaseRequest](#bytebase-v1-GetDatabaseRequest) | [Database](#bytebase-v1-Database) |  |
-| BatchGetDatabases | [BatchGetDatabasesRequest](#bytebase-v1-BatchGetDatabasesRequest) | [BatchGetDatabasesResponse](#bytebase-v1-BatchGetDatabasesResponse) |  |
-| ListDatabases | [ListDatabasesRequest](#bytebase-v1-ListDatabasesRequest) | [ListDatabasesResponse](#bytebase-v1-ListDatabasesResponse) |  |
-| UpdateDatabase | [UpdateDatabaseRequest](#bytebase-v1-UpdateDatabaseRequest) | [Database](#bytebase-v1-Database) |  |
-| BatchUpdateDatabases | [BatchUpdateDatabasesRequest](#bytebase-v1-BatchUpdateDatabasesRequest) | [BatchUpdateDatabasesResponse](#bytebase-v1-BatchUpdateDatabasesResponse) |  |
-| SyncDatabase | [SyncDatabaseRequest](#bytebase-v1-SyncDatabaseRequest) | [SyncDatabaseResponse](#bytebase-v1-SyncDatabaseResponse) |  |
-| BatchSyncDatabases | [BatchSyncDatabasesRequest](#bytebase-v1-BatchSyncDatabasesRequest) | [BatchSyncDatabasesResponse](#bytebase-v1-BatchSyncDatabasesResponse) |  |
-| GetDatabaseMetadata | [GetDatabaseMetadataRequest](#bytebase-v1-GetDatabaseMetadataRequest) | [DatabaseMetadata](#bytebase-v1-DatabaseMetadata) |  |
-| GetDatabaseSchema | [GetDatabaseSchemaRequest](#bytebase-v1-GetDatabaseSchemaRequest) | [DatabaseSchema](#bytebase-v1-DatabaseSchema) |  |
-| DiffSchema | [DiffSchemaRequest](#bytebase-v1-DiffSchemaRequest) | [DiffSchemaResponse](#bytebase-v1-DiffSchemaResponse) |  |
-| ListSecrets | [ListSecretsRequest](#bytebase-v1-ListSecretsRequest) | [ListSecretsResponse](#bytebase-v1-ListSecretsResponse) |  |
-| UpdateSecret | [UpdateSecretRequest](#bytebase-v1-UpdateSecretRequest) | [Secret](#bytebase-v1-Secret) |  |
-| DeleteSecret | [DeleteSecretRequest](#bytebase-v1-DeleteSecretRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| ListChangelogs | [ListChangelogsRequest](#bytebase-v1-ListChangelogsRequest) | [ListChangelogsResponse](#bytebase-v1-ListChangelogsResponse) |  |
-| GetChangelog | [GetChangelogRequest](#bytebase-v1-GetChangelogRequest) | [Changelog](#bytebase-v1-Changelog) |  |
-| GetSchemaString | [GetSchemaStringRequest](#bytebase-v1-GetSchemaStringRequest) | [GetSchemaStringResponse](#bytebase-v1-GetSchemaStringResponse) |  |
+| GetDatabase | [GetDatabaseRequest](#bytebase-v1-GetDatabaseRequest) | [Database](#bytebase-v1-Database) | Permissions required: databases.get |
+| BatchGetDatabases | [BatchGetDatabasesRequest](#bytebase-v1-BatchGetDatabasesRequest) | [BatchGetDatabasesResponse](#bytebase-v1-BatchGetDatabasesResponse) | Permissions required: databases.get |
+| ListDatabases | [ListDatabasesRequest](#bytebase-v1-ListDatabasesRequest) | [ListDatabasesResponse](#bytebase-v1-ListDatabasesResponse) | Permissions required: databases.list |
+| UpdateDatabase | [UpdateDatabaseRequest](#bytebase-v1-UpdateDatabaseRequest) | [Database](#bytebase-v1-Database) | Permissions required: databases.update |
+| BatchUpdateDatabases | [BatchUpdateDatabasesRequest](#bytebase-v1-BatchUpdateDatabasesRequest) | [BatchUpdateDatabasesResponse](#bytebase-v1-BatchUpdateDatabasesResponse) | Permissions required: databases.update |
+| SyncDatabase | [SyncDatabaseRequest](#bytebase-v1-SyncDatabaseRequest) | [SyncDatabaseResponse](#bytebase-v1-SyncDatabaseResponse) | Permissions required: databases.sync |
+| BatchSyncDatabases | [BatchSyncDatabasesRequest](#bytebase-v1-BatchSyncDatabasesRequest) | [BatchSyncDatabasesResponse](#bytebase-v1-BatchSyncDatabasesResponse) | Permissions required: databases.sync |
+| GetDatabaseMetadata | [GetDatabaseMetadataRequest](#bytebase-v1-GetDatabaseMetadataRequest) | [DatabaseMetadata](#bytebase-v1-DatabaseMetadata) | Permissions required: databases.getSchema |
+| GetDatabaseSchema | [GetDatabaseSchemaRequest](#bytebase-v1-GetDatabaseSchemaRequest) | [DatabaseSchema](#bytebase-v1-DatabaseSchema) | Permissions required: databases.getSchema |
+| DiffSchema | [DiffSchemaRequest](#bytebase-v1-DiffSchemaRequest) | [DiffSchemaResponse](#bytebase-v1-DiffSchemaResponse) | Permissions required: databases.get |
+| ListSecrets | [ListSecretsRequest](#bytebase-v1-ListSecretsRequest) | [ListSecretsResponse](#bytebase-v1-ListSecretsResponse) | Permissions required: databaseSecrets.list |
+| UpdateSecret | [UpdateSecretRequest](#bytebase-v1-UpdateSecretRequest) | [Secret](#bytebase-v1-Secret) | Permissions required: databaseSecrets.update |
+| DeleteSecret | [DeleteSecretRequest](#bytebase-v1-DeleteSecretRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: databaseSecrets.delete |
+| ListChangelogs | [ListChangelogsRequest](#bytebase-v1-ListChangelogsRequest) | [ListChangelogsResponse](#bytebase-v1-ListChangelogsResponse) | Permissions required: changelogs.list |
+| GetChangelog | [GetChangelogRequest](#bytebase-v1-GetChangelogRequest) | [Changelog](#bytebase-v1-Changelog) | Permissions required: changelogs.get |
+| GetSchemaString | [GetSchemaStringRequest](#bytebase-v1-GetSchemaStringRequest) | [GetSchemaStringResponse](#bytebase-v1-GetSchemaStringResponse) | Permissions required: databases.getSchema |
 
  
 
@@ -3895,18 +3895,18 @@ ANY means approving any node will proceed.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetIssue | [GetIssueRequest](#bytebase-v1-GetIssueRequest) | [Issue](#bytebase-v1-Issue) |  |
-| CreateIssue | [CreateIssueRequest](#bytebase-v1-CreateIssueRequest) | [Issue](#bytebase-v1-Issue) |  |
-| ListIssues | [ListIssuesRequest](#bytebase-v1-ListIssuesRequest) | [ListIssuesResponse](#bytebase-v1-ListIssuesResponse) |  |
-| SearchIssues | [SearchIssuesRequest](#bytebase-v1-SearchIssuesRequest) | [SearchIssuesResponse](#bytebase-v1-SearchIssuesResponse) | Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter &amp; query. |
-| UpdateIssue | [UpdateIssueRequest](#bytebase-v1-UpdateIssueRequest) | [Issue](#bytebase-v1-Issue) |  |
-| ListIssueComments | [ListIssueCommentsRequest](#bytebase-v1-ListIssueCommentsRequest) | [ListIssueCommentsResponse](#bytebase-v1-ListIssueCommentsResponse) |  |
-| CreateIssueComment | [CreateIssueCommentRequest](#bytebase-v1-CreateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) |  |
-| UpdateIssueComment | [UpdateIssueCommentRequest](#bytebase-v1-UpdateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) |  |
-| BatchUpdateIssuesStatus | [BatchUpdateIssuesStatusRequest](#bytebase-v1-BatchUpdateIssuesStatusRequest) | [BatchUpdateIssuesStatusResponse](#bytebase-v1-BatchUpdateIssuesStatusResponse) |  |
-| ApproveIssue | [ApproveIssueRequest](#bytebase-v1-ApproveIssueRequest) | [Issue](#bytebase-v1-Issue) | ApproveIssue approves the issue. The access is based on approval flow. |
-| RejectIssue | [RejectIssueRequest](#bytebase-v1-RejectIssueRequest) | [Issue](#bytebase-v1-Issue) | RejectIssue rejects the issue. The access is based on approval flow. |
-| RequestIssue | [RequestIssueRequest](#bytebase-v1-RequestIssueRequest) | [Issue](#bytebase-v1-Issue) | RequestIssue requests the issue. The access is based on approval flow. |
+| GetIssue | [GetIssueRequest](#bytebase-v1-GetIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: issues.get |
+| CreateIssue | [CreateIssueRequest](#bytebase-v1-CreateIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: issues.create |
+| ListIssues | [ListIssuesRequest](#bytebase-v1-ListIssuesRequest) | [ListIssuesResponse](#bytebase-v1-ListIssuesResponse) | Permissions required: issues.list |
+| SearchIssues | [SearchIssuesRequest](#bytebase-v1-SearchIssuesRequest) | [SearchIssuesResponse](#bytebase-v1-SearchIssuesResponse) | Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter &amp; query. Permissions required: issues.get |
+| UpdateIssue | [UpdateIssueRequest](#bytebase-v1-UpdateIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: issues.update |
+| ListIssueComments | [ListIssueCommentsRequest](#bytebase-v1-ListIssueCommentsRequest) | [ListIssueCommentsResponse](#bytebase-v1-ListIssueCommentsResponse) | Permissions required: issueComments.list |
+| CreateIssueComment | [CreateIssueCommentRequest](#bytebase-v1-CreateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) | Permissions required: issueComments.create |
+| UpdateIssueComment | [UpdateIssueCommentRequest](#bytebase-v1-UpdateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) | Permissions required: issueComments.update |
+| BatchUpdateIssuesStatus | [BatchUpdateIssuesStatusRequest](#bytebase-v1-BatchUpdateIssuesStatusRequest) | [BatchUpdateIssuesStatusResponse](#bytebase-v1-BatchUpdateIssuesStatusResponse) | Permissions required: issues.update |
+| ApproveIssue | [ApproveIssueRequest](#bytebase-v1-ApproveIssueRequest) | [Issue](#bytebase-v1-Issue) | ApproveIssue approves the issue. The access is based on approval flow. Permissions required: None |
+| RejectIssue | [RejectIssueRequest](#bytebase-v1-RejectIssueRequest) | [Issue](#bytebase-v1-Issue) | RejectIssue rejects the issue. The access is based on approval flow. Permissions required: None |
+| RequestIssue | [RequestIssueRequest](#bytebase-v1-RequestIssueRequest) | [Issue](#bytebase-v1-Issue) | RequestIssue requests the issue. The access is based on approval flow. Permissions required: None |
 
  
 
@@ -4731,9 +4731,9 @@ We support three levels of AlertLevel: INFO, WARNING, and ERROR.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListSettings | [ListSettingsRequest](#bytebase-v1-ListSettingsRequest) | [ListSettingsResponse](#bytebase-v1-ListSettingsResponse) |  |
-| GetSetting | [GetSettingRequest](#bytebase-v1-GetSettingRequest) | [Setting](#bytebase-v1-Setting) |  |
-| UpdateSetting | [UpdateSettingRequest](#bytebase-v1-UpdateSettingRequest) | [Setting](#bytebase-v1-Setting) |  |
+| ListSettings | [ListSettingsRequest](#bytebase-v1-ListSettingsRequest) | [ListSettingsResponse](#bytebase-v1-ListSettingsResponse) | Permissions required: settings.list |
+| GetSetting | [GetSettingRequest](#bytebase-v1-GetSettingRequest) | [Setting](#bytebase-v1-Setting) | Permissions required: settings.get |
+| UpdateSetting | [UpdateSettingRequest](#bytebase-v1-UpdateSettingRequest) | [Setting](#bytebase-v1-Setting) | Permissions required: settings.set |
 
  
 
@@ -4967,14 +4967,14 @@ The user&#39;s `name` field is used to identify the user to update. Format: user
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetUser | [GetUserRequest](#bytebase-v1-GetUserRequest) | [User](#bytebase-v1-User) | Get the user. Any authenticated user can get the user. |
-| BatchGetUsers | [BatchGetUsersRequest](#bytebase-v1-BatchGetUsersRequest) | [BatchGetUsersResponse](#bytebase-v1-BatchGetUsersResponse) | Get the users in batch. Any authenticated user can batch get users. |
-| GetCurrentUser | [.google.protobuf.Empty](#google-protobuf-Empty) | [User](#bytebase-v1-User) | Get the current authenticated user. |
-| ListUsers | [ListUsersRequest](#bytebase-v1-ListUsersRequest) | [ListUsersResponse](#bytebase-v1-ListUsersResponse) | List all users. Any authenticated user can list users. |
-| CreateUser | [CreateUserRequest](#bytebase-v1-CreateUserRequest) | [User](#bytebase-v1-User) | Create a user. When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user. Otherwise, any unauthenticated user can create a user. |
-| UpdateUser | [UpdateUserRequest](#bytebase-v1-UpdateUserRequest) | [User](#bytebase-v1-User) | Only the user itself and the user with bb.users.update permission on the workspace can update the user. |
-| DeleteUser | [DeleteUserRequest](#bytebase-v1-DeleteUserRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Only the user with bb.users.delete permission on the workspace can delete the user. The last remaining workspace admin cannot be deleted. |
-| UndeleteUser | [UndeleteUserRequest](#bytebase-v1-UndeleteUserRequest) | [User](#bytebase-v1-User) | Only the user with bb.users.undelete permission on the workspace can undelete the user. |
+| GetUser | [GetUserRequest](#bytebase-v1-GetUserRequest) | [User](#bytebase-v1-User) | Get the user. Any authenticated user can get the user. Permissions required: users.get |
+| BatchGetUsers | [BatchGetUsersRequest](#bytebase-v1-BatchGetUsersRequest) | [BatchGetUsersResponse](#bytebase-v1-BatchGetUsersResponse) | Get the users in batch. Any authenticated user can batch get users. Permissions required: users.get |
+| GetCurrentUser | [.google.protobuf.Empty](#google-protobuf-Empty) | [User](#bytebase-v1-User) | Get the current authenticated user. Permissions required: None |
+| ListUsers | [ListUsersRequest](#bytebase-v1-ListUsersRequest) | [ListUsersResponse](#bytebase-v1-ListUsersResponse) | List all users. Any authenticated user can list users. Permissions required: users.list |
+| CreateUser | [CreateUserRequest](#bytebase-v1-CreateUserRequest) | [User](#bytebase-v1-User) | Create a user. When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user. Otherwise, any unauthenticated user can create a user. Permissions required: users.create |
+| UpdateUser | [UpdateUserRequest](#bytebase-v1-UpdateUserRequest) | [User](#bytebase-v1-User) | Only the user itself and the user with bb.users.update permission on the workspace can update the user. Permissions required: users.update |
+| DeleteUser | [DeleteUserRequest](#bytebase-v1-DeleteUserRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Only the user with bb.users.delete permission on the workspace can delete the user. The last remaining workspace admin cannot be deleted. Permissions required: users.delete |
+| UndeleteUser | [UndeleteUserRequest](#bytebase-v1-UndeleteUserRequest) | [User](#bytebase-v1-User) | Only the user with bb.users.undelete permission on the workspace can undelete the user. Permissions required: users.undelete |
 
  
 
@@ -5125,11 +5125,11 @@ The theme resources.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetActuatorInfo | [GetActuatorInfoRequest](#bytebase-v1-GetActuatorInfoRequest) | [ActuatorInfo](#bytebase-v1-ActuatorInfo) |  |
-| UpdateActuatorInfo | [UpdateActuatorInfoRequest](#bytebase-v1-UpdateActuatorInfoRequest) | [ActuatorInfo](#bytebase-v1-ActuatorInfo) |  |
-| SetupSample | [SetupSampleRequest](#bytebase-v1-SetupSampleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| DeleteCache | [DeleteCacheRequest](#bytebase-v1-DeleteCacheRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| GetResourcePackage | [GetResourcePackageRequest](#bytebase-v1-GetResourcePackageRequest) | [ResourcePackage](#bytebase-v1-ResourcePackage) |  |
+| GetActuatorInfo | [GetActuatorInfoRequest](#bytebase-v1-GetActuatorInfoRequest) | [ActuatorInfo](#bytebase-v1-ActuatorInfo) | Permissions required: None |
+| UpdateActuatorInfo | [UpdateActuatorInfoRequest](#bytebase-v1-UpdateActuatorInfoRequest) | [ActuatorInfo](#bytebase-v1-ActuatorInfo) | Permissions required: settings.set |
+| SetupSample | [SetupSampleRequest](#bytebase-v1-SetupSampleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.create |
+| DeleteCache | [DeleteCacheRequest](#bytebase-v1-DeleteCacheRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: None |
+| GetResourcePackage | [GetResourcePackageRequest](#bytebase-v1-GetResourcePackageRequest) | [ResourcePackage](#bytebase-v1-ResourcePackage) | Permissions required: None |
 
  
 
@@ -5438,8 +5438,8 @@ For example: - filter = &#34;method == &#39;/bytebase.v1.SQLService/Query&#39;&#
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| SearchAuditLogs | [SearchAuditLogsRequest](#bytebase-v1-SearchAuditLogsRequest) | [SearchAuditLogsResponse](#bytebase-v1-SearchAuditLogsResponse) |  |
-| ExportAuditLogs | [ExportAuditLogsRequest](#bytebase-v1-ExportAuditLogsRequest) | [ExportAuditLogsResponse](#bytebase-v1-ExportAuditLogsResponse) |  |
+| SearchAuditLogs | [SearchAuditLogsRequest](#bytebase-v1-SearchAuditLogsRequest) | [SearchAuditLogsResponse](#bytebase-v1-SearchAuditLogsResponse) | Permissions required: None |
+| ExportAuditLogs | [ExportAuditLogsRequest](#bytebase-v1-ExportAuditLogsRequest) | [ExportAuditLogsResponse](#bytebase-v1-ExportAuditLogsResponse) | Permissions required: auditLogs.export |
 
  
 
@@ -5556,8 +5556,8 @@ For example: - filter = &#34;method == &#39;/bytebase.v1.SQLService/Query&#39;&#
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| Login | [LoginRequest](#bytebase-v1-LoginRequest) | [LoginResponse](#bytebase-v1-LoginResponse) |  |
-| Logout | [LogoutRequest](#bytebase-v1-LogoutRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| Login | [LoginRequest](#bytebase-v1-LoginRequest) | [LoginResponse](#bytebase-v1-LoginResponse) | Permissions required: None |
+| Logout | [LogoutRequest](#bytebase-v1-LogoutRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: None |
 
  
 
@@ -5643,8 +5643,8 @@ For example: - filter = &#34;method == &#39;/bytebase.v1.SQLService/Query&#39;&#
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| BatchParse | [BatchParseRequest](#bytebase-v1-BatchParseRequest) | [BatchParseResponse](#bytebase-v1-BatchParseResponse) |  |
-| BatchDeparse | [BatchDeparseRequest](#bytebase-v1-BatchDeparseRequest) | [BatchDeparseResponse](#bytebase-v1-BatchDeparseResponse) |  |
+| BatchParse | [BatchParseRequest](#bytebase-v1-BatchParseRequest) | [BatchParseResponse](#bytebase-v1-BatchParseResponse) | Permissions required: None |
+| BatchDeparse | [BatchDeparseRequest](#bytebase-v1-BatchDeparseRequest) | [BatchDeparseResponse](#bytebase-v1-BatchDeparseResponse) | Permissions required: None |
 
  
 
@@ -5807,11 +5807,11 @@ The changelist&#39;s `name` field is used to identify the changelist to update. 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateChangelist | [CreateChangelistRequest](#bytebase-v1-CreateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) |  |
-| GetChangelist | [GetChangelistRequest](#bytebase-v1-GetChangelistRequest) | [Changelist](#bytebase-v1-Changelist) |  |
-| ListChangelists | [ListChangelistsRequest](#bytebase-v1-ListChangelistsRequest) | [ListChangelistsResponse](#bytebase-v1-ListChangelistsResponse) |  |
-| UpdateChangelist | [UpdateChangelistRequest](#bytebase-v1-UpdateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) |  |
-| DeleteChangelist | [DeleteChangelistRequest](#bytebase-v1-DeleteChangelistRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| CreateChangelist | [CreateChangelistRequest](#bytebase-v1-CreateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: changelists.create |
+| GetChangelist | [GetChangelistRequest](#bytebase-v1-GetChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: changelists.get |
+| ListChangelists | [ListChangelistsRequest](#bytebase-v1-ListChangelistsRequest) | [ListChangelistsResponse](#bytebase-v1-ListChangelistsResponse) | Permissions required: changelists.list |
+| UpdateChangelist | [UpdateChangelistRequest](#bytebase-v1-UpdateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: changelists.update |
+| DeleteChangelist | [DeleteChangelistRequest](#bytebase-v1-DeleteChangelistRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: changelists.delete |
 
  
 
@@ -5993,11 +5993,11 @@ The database group&#39;s `name` field is used to identify the database group to 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListDatabaseGroups | [ListDatabaseGroupsRequest](#bytebase-v1-ListDatabaseGroupsRequest) | [ListDatabaseGroupsResponse](#bytebase-v1-ListDatabaseGroupsResponse) |  |
-| GetDatabaseGroup | [GetDatabaseGroupRequest](#bytebase-v1-GetDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) |  |
-| CreateDatabaseGroup | [CreateDatabaseGroupRequest](#bytebase-v1-CreateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) |  |
-| UpdateDatabaseGroup | [UpdateDatabaseGroupRequest](#bytebase-v1-UpdateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) |  |
-| DeleteDatabaseGroup | [DeleteDatabaseGroupRequest](#bytebase-v1-DeleteDatabaseGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| ListDatabaseGroups | [ListDatabaseGroupsRequest](#bytebase-v1-ListDatabaseGroupsRequest) | [ListDatabaseGroupsResponse](#bytebase-v1-ListDatabaseGroupsResponse) | Permissions required: projects.get |
+| GetDatabaseGroup | [GetDatabaseGroupRequest](#bytebase-v1-GetDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: projects.get |
+| CreateDatabaseGroup | [CreateDatabaseGroupRequest](#bytebase-v1-CreateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: projects.update |
+| UpdateDatabaseGroup | [UpdateDatabaseGroupRequest](#bytebase-v1-UpdateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: projects.update |
+| DeleteDatabaseGroup | [DeleteDatabaseGroupRequest](#bytebase-v1-DeleteDatabaseGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.update |
 
  
 
@@ -6172,11 +6172,11 @@ The group&#39;s `name` field is used to identify the group to update. Format: gr
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetGroup | [GetGroupRequest](#bytebase-v1-GetGroupRequest) | [Group](#bytebase-v1-Group) |  |
-| ListGroups | [ListGroupsRequest](#bytebase-v1-ListGroupsRequest) | [ListGroupsResponse](#bytebase-v1-ListGroupsResponse) |  |
-| CreateGroup | [CreateGroupRequest](#bytebase-v1-CreateGroupRequest) | [Group](#bytebase-v1-Group) |  |
-| UpdateGroup | [UpdateGroupRequest](#bytebase-v1-UpdateGroupRequest) | [Group](#bytebase-v1-Group) | UpdateGroup updates the group. Users with &#34;bb.groups.update&#34; permission on the workspace or the group owner can access this method. |
-| DeleteGroup | [DeleteGroupRequest](#bytebase-v1-DeleteGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| GetGroup | [GetGroupRequest](#bytebase-v1-GetGroupRequest) | [Group](#bytebase-v1-Group) | Permissions required: groups.get |
+| ListGroups | [ListGroupsRequest](#bytebase-v1-ListGroupsRequest) | [ListGroupsResponse](#bytebase-v1-ListGroupsResponse) | Permissions required: groups.list |
+| CreateGroup | [CreateGroupRequest](#bytebase-v1-CreateGroupRequest) | [Group](#bytebase-v1-Group) | Permissions required: groups.create |
+| UpdateGroup | [UpdateGroupRequest](#bytebase-v1-UpdateGroupRequest) | [Group](#bytebase-v1-Group) | UpdateGroup updates the group. Users with &#34;bb.groups.update&#34; permission on the workspace or the group owner can access this method. Permissions required: groups.update |
+| DeleteGroup | [DeleteGroupRequest](#bytebase-v1-DeleteGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: groups.delete |
 
  
 
@@ -6546,12 +6546,12 @@ The identity provider&#39;s `name` field is used to identify the identity provid
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetIdentityProvider | [GetIdentityProviderRequest](#bytebase-v1-GetIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) |  |
-| ListIdentityProviders | [ListIdentityProvidersRequest](#bytebase-v1-ListIdentityProvidersRequest) | [ListIdentityProvidersResponse](#bytebase-v1-ListIdentityProvidersResponse) |  |
-| CreateIdentityProvider | [CreateIdentityProviderRequest](#bytebase-v1-CreateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) |  |
-| UpdateIdentityProvider | [UpdateIdentityProviderRequest](#bytebase-v1-UpdateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) |  |
-| DeleteIdentityProvider | [DeleteIdentityProviderRequest](#bytebase-v1-DeleteIdentityProviderRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| TestIdentityProvider | [TestIdentityProviderRequest](#bytebase-v1-TestIdentityProviderRequest) | [TestIdentityProviderResponse](#bytebase-v1-TestIdentityProviderResponse) |  |
+| GetIdentityProvider | [GetIdentityProviderRequest](#bytebase-v1-GetIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: identityProviders.get |
+| ListIdentityProviders | [ListIdentityProvidersRequest](#bytebase-v1-ListIdentityProvidersRequest) | [ListIdentityProvidersResponse](#bytebase-v1-ListIdentityProvidersResponse) | Permissions required: None |
+| CreateIdentityProvider | [CreateIdentityProviderRequest](#bytebase-v1-CreateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: identityProviders.create |
+| UpdateIdentityProvider | [UpdateIdentityProviderRequest](#bytebase-v1-UpdateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: identityProviders.update |
+| DeleteIdentityProvider | [DeleteIdentityProviderRequest](#bytebase-v1-DeleteIdentityProviderRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: identityProviders.delete |
+| TestIdentityProvider | [TestIdentityProviderRequest](#bytebase-v1-TestIdentityProviderRequest) | [TestIdentityProviderResponse](#bytebase-v1-TestIdentityProviderResponse) | Permissions required: identityProviders.update |
 
  
 
@@ -7002,11 +7002,11 @@ The policy&#39;s `name` field is used to identify the instance to update. Format
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetPolicy | [GetPolicyRequest](#bytebase-v1-GetPolicyRequest) | [Policy](#bytebase-v1-Policy) |  |
-| ListPolicies | [ListPoliciesRequest](#bytebase-v1-ListPoliciesRequest) | [ListPoliciesResponse](#bytebase-v1-ListPoliciesResponse) |  |
-| CreatePolicy | [CreatePolicyRequest](#bytebase-v1-CreatePolicyRequest) | [Policy](#bytebase-v1-Policy) |  |
-| UpdatePolicy | [UpdatePolicyRequest](#bytebase-v1-UpdatePolicyRequest) | [Policy](#bytebase-v1-Policy) |  |
-| DeletePolicy | [DeletePolicyRequest](#bytebase-v1-DeletePolicyRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| GetPolicy | [GetPolicyRequest](#bytebase-v1-GetPolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: policies.get |
+| ListPolicies | [ListPoliciesRequest](#bytebase-v1-ListPoliciesRequest) | [ListPoliciesResponse](#bytebase-v1-ListPoliciesResponse) | Permissions required: policies.list |
+| CreatePolicy | [CreatePolicyRequest](#bytebase-v1-CreatePolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: policies.create |
+| UpdatePolicy | [UpdatePolicyRequest](#bytebase-v1-UpdatePolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: policies.update |
+| DeletePolicy | [DeletePolicyRequest](#bytebase-v1-DeletePolicyRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: policies.delete |
 
  
 
@@ -7553,14 +7553,14 @@ Type is the database change type.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetPlan | [GetPlanRequest](#bytebase-v1-GetPlanRequest) | [Plan](#bytebase-v1-Plan) |  |
-| ListPlans | [ListPlansRequest](#bytebase-v1-ListPlansRequest) | [ListPlansResponse](#bytebase-v1-ListPlansResponse) |  |
-| SearchPlans | [SearchPlansRequest](#bytebase-v1-SearchPlansRequest) | [SearchPlansResponse](#bytebase-v1-SearchPlansResponse) | Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter &amp; query. |
-| CreatePlan | [CreatePlanRequest](#bytebase-v1-CreatePlanRequest) | [Plan](#bytebase-v1-Plan) |  |
-| UpdatePlan | [UpdatePlanRequest](#bytebase-v1-UpdatePlanRequest) | [Plan](#bytebase-v1-Plan) | UpdatePlan updates the plan. The plan creator and the user with bb.plans.update permission on the project can update the plan. |
-| ListPlanCheckRuns | [ListPlanCheckRunsRequest](#bytebase-v1-ListPlanCheckRunsRequest) | [ListPlanCheckRunsResponse](#bytebase-v1-ListPlanCheckRunsResponse) |  |
-| RunPlanChecks | [RunPlanChecksRequest](#bytebase-v1-RunPlanChecksRequest) | [RunPlanChecksResponse](#bytebase-v1-RunPlanChecksResponse) |  |
-| BatchCancelPlanCheckRuns | [BatchCancelPlanCheckRunsRequest](#bytebase-v1-BatchCancelPlanCheckRunsRequest) | [BatchCancelPlanCheckRunsResponse](#bytebase-v1-BatchCancelPlanCheckRunsResponse) |  |
+| GetPlan | [GetPlanRequest](#bytebase-v1-GetPlanRequest) | [Plan](#bytebase-v1-Plan) | Permissions required: plans.get |
+| ListPlans | [ListPlansRequest](#bytebase-v1-ListPlansRequest) | [ListPlansResponse](#bytebase-v1-ListPlansResponse) | Permissions required: plans.list |
+| SearchPlans | [SearchPlansRequest](#bytebase-v1-SearchPlansRequest) | [SearchPlansResponse](#bytebase-v1-SearchPlansResponse) | Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter &amp; query. Permissions required: plans.get |
+| CreatePlan | [CreatePlanRequest](#bytebase-v1-CreatePlanRequest) | [Plan](#bytebase-v1-Plan) | Permissions required: plans.create |
+| UpdatePlan | [UpdatePlanRequest](#bytebase-v1-UpdatePlanRequest) | [Plan](#bytebase-v1-Plan) | UpdatePlan updates the plan. The plan creator and the user with bb.plans.update permission on the project can update the plan. Permissions required: plans.update |
+| ListPlanCheckRuns | [ListPlanCheckRunsRequest](#bytebase-v1-ListPlanCheckRunsRequest) | [ListPlanCheckRunsResponse](#bytebase-v1-ListPlanCheckRunsResponse) | Permissions required: planCheckRuns.list |
+| RunPlanChecks | [RunPlanChecksRequest](#bytebase-v1-RunPlanChecksRequest) | [RunPlanChecksResponse](#bytebase-v1-RunPlanChecksResponse) | Permissions required: planCheckRuns.run |
+| BatchCancelPlanCheckRuns | [BatchCancelPlanCheckRunsRequest](#bytebase-v1-BatchCancelPlanCheckRunsRequest) | [BatchCancelPlanCheckRunsResponse](#bytebase-v1-BatchCancelPlanCheckRunsResponse) | Permissions required: planCheckRuns.run |
 
  
 
@@ -8020,21 +8020,21 @@ TYPE_ISSUE_CREATE represents creating an issue. |
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetProject | [GetProjectRequest](#bytebase-v1-GetProjectRequest) | [Project](#bytebase-v1-Project) | GetProject retrieves a project by name. Users with &#34;bb.projects.get&#34; permission on the workspace or the project owner can access this method. |
-| ListProjects | [ListProjectsRequest](#bytebase-v1-ListProjectsRequest) | [ListProjectsResponse](#bytebase-v1-ListProjectsResponse) |  |
-| SearchProjects | [SearchProjectsRequest](#bytebase-v1-SearchProjectsRequest) | [SearchProjectsResponse](#bytebase-v1-SearchProjectsResponse) |  |
-| CreateProject | [CreateProjectRequest](#bytebase-v1-CreateProjectRequest) | [Project](#bytebase-v1-Project) |  |
-| UpdateProject | [UpdateProjectRequest](#bytebase-v1-UpdateProjectRequest) | [Project](#bytebase-v1-Project) |  |
-| DeleteProject | [DeleteProjectRequest](#bytebase-v1-DeleteProjectRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| UndeleteProject | [UndeleteProjectRequest](#bytebase-v1-UndeleteProjectRequest) | [Project](#bytebase-v1-Project) |  |
-| BatchDeleteProjects | [BatchDeleteProjectsRequest](#bytebase-v1-BatchDeleteProjectsRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) |  |
-| BatchGetIamPolicy | [BatchGetIamPolicyRequest](#bytebase-v1-BatchGetIamPolicyRequest) | [BatchGetIamPolicyResponse](#bytebase-v1-BatchGetIamPolicyResponse) | Deprecated. |
-| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) |  |
-| AddWebhook | [AddWebhookRequest](#bytebase-v1-AddWebhookRequest) | [Project](#bytebase-v1-Project) |  |
-| UpdateWebhook | [UpdateWebhookRequest](#bytebase-v1-UpdateWebhookRequest) | [Project](#bytebase-v1-Project) |  |
-| RemoveWebhook | [RemoveWebhookRequest](#bytebase-v1-RemoveWebhookRequest) | [Project](#bytebase-v1-Project) |  |
-| TestWebhook | [TestWebhookRequest](#bytebase-v1-TestWebhookRequest) | [TestWebhookResponse](#bytebase-v1-TestWebhookResponse) |  |
+| GetProject | [GetProjectRequest](#bytebase-v1-GetProjectRequest) | [Project](#bytebase-v1-Project) | GetProject retrieves a project by name. Users with &#34;bb.projects.get&#34; permission on the workspace or the project owner can access this method. Permissions required: projects.get |
+| ListProjects | [ListProjectsRequest](#bytebase-v1-ListProjectsRequest) | [ListProjectsResponse](#bytebase-v1-ListProjectsResponse) | Permissions required: projects.list |
+| SearchProjects | [SearchProjectsRequest](#bytebase-v1-SearchProjectsRequest) | [SearchProjectsResponse](#bytebase-v1-SearchProjectsResponse) | Permissions required: None |
+| CreateProject | [CreateProjectRequest](#bytebase-v1-CreateProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.create |
+| UpdateProject | [UpdateProjectRequest](#bytebase-v1-UpdateProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
+| DeleteProject | [DeleteProjectRequest](#bytebase-v1-DeleteProjectRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.delete |
+| UndeleteProject | [UndeleteProjectRequest](#bytebase-v1-UndeleteProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.undelete |
+| BatchDeleteProjects | [BatchDeleteProjectsRequest](#bytebase-v1-BatchDeleteProjectsRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.delete |
+| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: projects.getIamPolicy |
+| BatchGetIamPolicy | [BatchGetIamPolicyRequest](#bytebase-v1-BatchGetIamPolicyRequest) | [BatchGetIamPolicyResponse](#bytebase-v1-BatchGetIamPolicyResponse) | Deprecated. Permissions required: projects.getIamPolicy |
+| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: projects.setIamPolicy |
+| AddWebhook | [AddWebhookRequest](#bytebase-v1-AddWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
+| UpdateWebhook | [UpdateWebhookRequest](#bytebase-v1-UpdateWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
+| RemoveWebhook | [RemoveWebhookRequest](#bytebase-v1-RemoveWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
+| TestWebhook | [TestWebhookRequest](#bytebase-v1-TestWebhookRequest) | [TestWebhookResponse](#bytebase-v1-TestWebhookResponse) | Permissions required: projects.update |
 
  
 
@@ -8705,14 +8705,14 @@ For example: project == &#34;projects/{project}&#34; database == &#34;instances/
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| Query | [QueryRequest](#bytebase-v1-QueryRequest) | [QueryResponse](#bytebase-v1-QueryResponse) |  |
-| AdminExecute | [AdminExecuteRequest](#bytebase-v1-AdminExecuteRequest) stream | [AdminExecuteResponse](#bytebase-v1-AdminExecuteResponse) stream |  |
-| SearchQueryHistories | [SearchQueryHistoriesRequest](#bytebase-v1-SearchQueryHistoriesRequest) | [SearchQueryHistoriesResponse](#bytebase-v1-SearchQueryHistoriesResponse) | SearchQueryHistories searches query histories for the caller. |
-| Export | [ExportRequest](#bytebase-v1-ExportRequest) | [ExportResponse](#bytebase-v1-ExportResponse) |  |
-| Check | [CheckRequest](#bytebase-v1-CheckRequest) | [CheckResponse](#bytebase-v1-CheckResponse) |  |
-| Pretty | [PrettyRequest](#bytebase-v1-PrettyRequest) | [PrettyResponse](#bytebase-v1-PrettyResponse) |  |
-| DiffMetadata | [DiffMetadataRequest](#bytebase-v1-DiffMetadataRequest) | [DiffMetadataResponse](#bytebase-v1-DiffMetadataResponse) |  |
-| AICompletion | [AICompletionRequest](#bytebase-v1-AICompletionRequest) | [AICompletionResponse](#bytebase-v1-AICompletionResponse) |  |
+| Query | [QueryRequest](#bytebase-v1-QueryRequest) | [QueryResponse](#bytebase-v1-QueryResponse) | Permissions required: databases.get |
+| AdminExecute | [AdminExecuteRequest](#bytebase-v1-AdminExecuteRequest) stream | [AdminExecuteResponse](#bytebase-v1-AdminExecuteResponse) stream | Permissions required: sql.admin |
+| SearchQueryHistories | [SearchQueryHistoriesRequest](#bytebase-v1-SearchQueryHistoriesRequest) | [SearchQueryHistoriesResponse](#bytebase-v1-SearchQueryHistoriesResponse) | SearchQueryHistories searches query histories for the caller. Permissions required: None |
+| Export | [ExportRequest](#bytebase-v1-ExportRequest) | [ExportResponse](#bytebase-v1-ExportResponse) | Permissions required: databases.get |
+| Check | [CheckRequest](#bytebase-v1-CheckRequest) | [CheckResponse](#bytebase-v1-CheckResponse) | Permissions required: databases.check |
+| Pretty | [PrettyRequest](#bytebase-v1-PrettyRequest) | [PrettyResponse](#bytebase-v1-PrettyResponse) | Permissions required: None |
+| DiffMetadata | [DiffMetadataRequest](#bytebase-v1-DiffMetadataRequest) | [DiffMetadataResponse](#bytebase-v1-DiffMetadataResponse) | Permissions required: None |
+| AICompletion | [AICompletionRequest](#bytebase-v1-AICompletionRequest) | [AICompletionResponse](#bytebase-v1-AICompletionResponse) | Permissions required: None |
 
  
 
@@ -9006,13 +9006,13 @@ The sheet that holds the content. Format: projects/{project}/sheets/{sheet} |
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetRelease | [GetReleaseRequest](#bytebase-v1-GetReleaseRequest) | [Release](#bytebase-v1-Release) |  |
-| ListReleases | [ListReleasesRequest](#bytebase-v1-ListReleasesRequest) | [ListReleasesResponse](#bytebase-v1-ListReleasesResponse) |  |
-| CreateRelease | [CreateReleaseRequest](#bytebase-v1-CreateReleaseRequest) | [Release](#bytebase-v1-Release) |  |
-| UpdateRelease | [UpdateReleaseRequest](#bytebase-v1-UpdateReleaseRequest) | [Release](#bytebase-v1-Release) |  |
-| DeleteRelease | [DeleteReleaseRequest](#bytebase-v1-DeleteReleaseRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
-| UndeleteRelease | [UndeleteReleaseRequest](#bytebase-v1-UndeleteReleaseRequest) | [Release](#bytebase-v1-Release) |  |
-| CheckRelease | [CheckReleaseRequest](#bytebase-v1-CheckReleaseRequest) | [CheckReleaseResponse](#bytebase-v1-CheckReleaseResponse) |  |
+| GetRelease | [GetReleaseRequest](#bytebase-v1-GetReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.get |
+| ListReleases | [ListReleasesRequest](#bytebase-v1-ListReleasesRequest) | [ListReleasesResponse](#bytebase-v1-ListReleasesResponse) | Permissions required: releases.list |
+| CreateRelease | [CreateReleaseRequest](#bytebase-v1-CreateReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.create |
+| UpdateRelease | [UpdateReleaseRequest](#bytebase-v1-UpdateReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.update |
+| DeleteRelease | [DeleteReleaseRequest](#bytebase-v1-DeleteReleaseRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: releases.delete |
+| UndeleteRelease | [UndeleteReleaseRequest](#bytebase-v1-UndeleteReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.undelete |
+| CheckRelease | [CheckReleaseRequest](#bytebase-v1-CheckReleaseRequest) | [CheckReleaseResponse](#bytebase-v1-CheckReleaseResponse) | Permissions required: releases.check |
 
  
 
@@ -9155,11 +9155,11 @@ The name field is used to identify the sql review to update. |
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateReviewConfig | [CreateReviewConfigRequest](#bytebase-v1-CreateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) |  |
-| ListReviewConfigs | [ListReviewConfigsRequest](#bytebase-v1-ListReviewConfigsRequest) | [ListReviewConfigsResponse](#bytebase-v1-ListReviewConfigsResponse) |  |
-| GetReviewConfig | [GetReviewConfigRequest](#bytebase-v1-GetReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) |  |
-| UpdateReviewConfig | [UpdateReviewConfigRequest](#bytebase-v1-UpdateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) |  |
-| DeleteReviewConfig | [DeleteReviewConfigRequest](#bytebase-v1-DeleteReviewConfigRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| CreateReviewConfig | [CreateReviewConfigRequest](#bytebase-v1-CreateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: reviewConfigs.create |
+| ListReviewConfigs | [ListReviewConfigsRequest](#bytebase-v1-ListReviewConfigsRequest) | [ListReviewConfigsResponse](#bytebase-v1-ListReviewConfigsResponse) | Permissions required: reviewConfigs.list |
+| GetReviewConfig | [GetReviewConfigRequest](#bytebase-v1-GetReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: reviewConfigs.get |
+| UpdateReviewConfig | [UpdateReviewConfigRequest](#bytebase-v1-UpdateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: reviewConfigs.update |
+| DeleteReviewConfig | [DeleteReviewConfigRequest](#bytebase-v1-DeleteReviewConfigRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: reviewConfigs.delete |
 
  
 
@@ -9325,11 +9325,11 @@ When paginating, all other parameters provided to `ListRevisions` must match the
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListRevisions | [ListRevisionsRequest](#bytebase-v1-ListRevisionsRequest) | [ListRevisionsResponse](#bytebase-v1-ListRevisionsResponse) |  |
-| GetRevision | [GetRevisionRequest](#bytebase-v1-GetRevisionRequest) | [Revision](#bytebase-v1-Revision) |  |
-| CreateRevision | [CreateRevisionRequest](#bytebase-v1-CreateRevisionRequest) | [Revision](#bytebase-v1-Revision) |  |
-| BatchCreateRevisions | [BatchCreateRevisionsRequest](#bytebase-v1-BatchCreateRevisionsRequest) | [BatchCreateRevisionsResponse](#bytebase-v1-BatchCreateRevisionsResponse) |  |
-| DeleteRevision | [DeleteRevisionRequest](#bytebase-v1-DeleteRevisionRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| ListRevisions | [ListRevisionsRequest](#bytebase-v1-ListRevisionsRequest) | [ListRevisionsResponse](#bytebase-v1-ListRevisionsResponse) | Permissions required: revisions.list |
+| GetRevision | [GetRevisionRequest](#bytebase-v1-GetRevisionRequest) | [Revision](#bytebase-v1-Revision) | Permissions required: revisions.get |
+| CreateRevision | [CreateRevisionRequest](#bytebase-v1-CreateRevisionRequest) | [Revision](#bytebase-v1-Revision) | Permissions required: revisions.create |
+| BatchCreateRevisions | [BatchCreateRevisionsRequest](#bytebase-v1-BatchCreateRevisionsRequest) | [BatchCreateRevisionsResponse](#bytebase-v1-BatchCreateRevisionsResponse) | Permissions required: revisions.create |
+| DeleteRevision | [DeleteRevisionRequest](#bytebase-v1-DeleteRevisionRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: revisions.delete |
 
  
 
@@ -9502,11 +9502,11 @@ The risk&#39;s `name` field is used to identify the risk to update. Format: risk
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListRisks | [ListRisksRequest](#bytebase-v1-ListRisksRequest) | [ListRisksResponse](#bytebase-v1-ListRisksResponse) |  |
-| CreateRisk | [CreateRiskRequest](#bytebase-v1-CreateRiskRequest) | [Risk](#bytebase-v1-Risk) |  |
-| GetRisk | [GetRiskRequest](#bytebase-v1-GetRiskRequest) | [Risk](#bytebase-v1-Risk) |  |
-| UpdateRisk | [UpdateRiskRequest](#bytebase-v1-UpdateRiskRequest) | [Risk](#bytebase-v1-Risk) |  |
-| DeleteRisk | [DeleteRiskRequest](#bytebase-v1-DeleteRiskRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| ListRisks | [ListRisksRequest](#bytebase-v1-ListRisksRequest) | [ListRisksResponse](#bytebase-v1-ListRisksResponse) | Permissions required: risks.list |
+| CreateRisk | [CreateRiskRequest](#bytebase-v1-CreateRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: risks.create |
+| GetRisk | [GetRiskRequest](#bytebase-v1-GetRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: risks.list |
+| UpdateRisk | [UpdateRiskRequest](#bytebase-v1-UpdateRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: risks.update |
+| DeleteRisk | [DeleteRiskRequest](#bytebase-v1-DeleteRiskRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: risks.delete |
 
  
 
@@ -9663,11 +9663,11 @@ When paginating, all other parameters provided to `ListRoles` must match the cal
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListRoles | [ListRolesRequest](#bytebase-v1-ListRolesRequest) | [ListRolesResponse](#bytebase-v1-ListRolesResponse) |  |
-| GetRole | [GetRoleRequest](#bytebase-v1-GetRoleRequest) | [Role](#bytebase-v1-Role) |  |
-| CreateRole | [CreateRoleRequest](#bytebase-v1-CreateRoleRequest) | [Role](#bytebase-v1-Role) |  |
-| UpdateRole | [UpdateRoleRequest](#bytebase-v1-UpdateRoleRequest) | [Role](#bytebase-v1-Role) |  |
-| DeleteRole | [DeleteRoleRequest](#bytebase-v1-DeleteRoleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| ListRoles | [ListRolesRequest](#bytebase-v1-ListRolesRequest) | [ListRolesResponse](#bytebase-v1-ListRolesResponse) | Permissions required: roles.list |
+| GetRole | [GetRoleRequest](#bytebase-v1-GetRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: roles.get |
+| CreateRole | [CreateRoleRequest](#bytebase-v1-CreateRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: roles.create |
+| UpdateRole | [UpdateRoleRequest](#bytebase-v1-UpdateRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: roles.update |
+| DeleteRole | [DeleteRoleRequest](#bytebase-v1-DeleteRoleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: roles.delete |
 
  
 
@@ -10576,18 +10576,18 @@ Read from `pg_stat_activity`
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetRollout | [GetRolloutRequest](#bytebase-v1-GetRolloutRequest) | [Rollout](#bytebase-v1-Rollout) |  |
-| ListRollouts | [ListRolloutsRequest](#bytebase-v1-ListRolloutsRequest) | [ListRolloutsResponse](#bytebase-v1-ListRolloutsResponse) |  |
-| CreateRollout | [CreateRolloutRequest](#bytebase-v1-CreateRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages. |
-| PreviewRollout | [PreviewRolloutRequest](#bytebase-v1-PreviewRolloutRequest) | [Rollout](#bytebase-v1-Rollout) |  |
-| ListTaskRuns | [ListTaskRunsRequest](#bytebase-v1-ListTaskRunsRequest) | [ListTaskRunsResponse](#bytebase-v1-ListTaskRunsResponse) |  |
-| GetTaskRun | [GetTaskRunRequest](#bytebase-v1-GetTaskRunRequest) | [TaskRun](#bytebase-v1-TaskRun) |  |
-| GetTaskRunLog | [GetTaskRunLogRequest](#bytebase-v1-GetTaskRunLogRequest) | [TaskRunLog](#bytebase-v1-TaskRunLog) |  |
-| GetTaskRunSession | [GetTaskRunSessionRequest](#bytebase-v1-GetTaskRunSessionRequest) | [TaskRunSession](#bytebase-v1-TaskRunSession) |  |
-| BatchRunTasks | [BatchRunTasksRequest](#bytebase-v1-BatchRunTasksRequest) | [BatchRunTasksResponse](#bytebase-v1-BatchRunTasksResponse) | BatchRunTasks creates task runs for the specified tasks. DataExport issue only allows the creator to run the task. Users with &#34;bb.taskRuns.create&#34; permission can run the task, e.g. Workspace Admin and DBA. Follow role-based rollout policy for the environment. |
-| BatchSkipTasks | [BatchSkipTasksRequest](#bytebase-v1-BatchSkipTasksRequest) | [BatchSkipTasksResponse](#bytebase-v1-BatchSkipTasksResponse) | BatchSkipTasks skips the specified tasks. The access is the same as BatchRunTasks(). |
-| BatchCancelTaskRuns | [BatchCancelTaskRunsRequest](#bytebase-v1-BatchCancelTaskRunsRequest) | [BatchCancelTaskRunsResponse](#bytebase-v1-BatchCancelTaskRunsResponse) | BatchCancelTaskRuns cancels the specified task runs in batch. The access is the same as BatchRunTasks(). |
-| PreviewTaskRunRollback | [PreviewTaskRunRollbackRequest](#bytebase-v1-PreviewTaskRunRollbackRequest) | [PreviewTaskRunRollbackResponse](#bytebase-v1-PreviewTaskRunRollbackResponse) |  |
+| GetRollout | [GetRolloutRequest](#bytebase-v1-GetRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | Permissions required: rollouts.get |
+| ListRollouts | [ListRolloutsRequest](#bytebase-v1-ListRolloutsRequest) | [ListRolloutsResponse](#bytebase-v1-ListRolloutsResponse) | Permissions required: rollouts.list |
+| CreateRollout | [CreateRolloutRequest](#bytebase-v1-CreateRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages. Permissions required: rollouts.create |
+| PreviewRollout | [PreviewRolloutRequest](#bytebase-v1-PreviewRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | Permissions required: rollouts.preview |
+| ListTaskRuns | [ListTaskRunsRequest](#bytebase-v1-ListTaskRunsRequest) | [ListTaskRunsResponse](#bytebase-v1-ListTaskRunsResponse) | Permissions required: taskRuns.list |
+| GetTaskRun | [GetTaskRunRequest](#bytebase-v1-GetTaskRunRequest) | [TaskRun](#bytebase-v1-TaskRun) | Permissions required: taskRuns.list |
+| GetTaskRunLog | [GetTaskRunLogRequest](#bytebase-v1-GetTaskRunLogRequest) | [TaskRunLog](#bytebase-v1-TaskRunLog) | Permissions required: taskRuns.list |
+| GetTaskRunSession | [GetTaskRunSessionRequest](#bytebase-v1-GetTaskRunSessionRequest) | [TaskRunSession](#bytebase-v1-TaskRunSession) | Permissions required: taskRuns.list |
+| BatchRunTasks | [BatchRunTasksRequest](#bytebase-v1-BatchRunTasksRequest) | [BatchRunTasksResponse](#bytebase-v1-BatchRunTasksResponse) | BatchRunTasks creates task runs for the specified tasks. DataExport issue only allows the creator to run the task. Users with &#34;bb.taskRuns.create&#34; permission can run the task, e.g. Workspace Admin and DBA. Follow role-based rollout policy for the environment. Permissions required: None |
+| BatchSkipTasks | [BatchSkipTasksRequest](#bytebase-v1-BatchSkipTasksRequest) | [BatchSkipTasksResponse](#bytebase-v1-BatchSkipTasksResponse) | BatchSkipTasks skips the specified tasks. The access is the same as BatchRunTasks(). Permissions required: None |
+| BatchCancelTaskRuns | [BatchCancelTaskRunsRequest](#bytebase-v1-BatchCancelTaskRunsRequest) | [BatchCancelTaskRunsResponse](#bytebase-v1-BatchCancelTaskRunsResponse) | BatchCancelTaskRuns cancels the specified task runs in batch. The access is the same as BatchRunTasks(). Permissions required: None |
+| PreviewTaskRunRollback | [PreviewTaskRunRollbackRequest](#bytebase-v1-PreviewTaskRunRollbackRequest) | [PreviewTaskRunRollbackResponse](#bytebase-v1-PreviewTaskRunRollbackResponse) | Permissions required: taskRuns.list |
 
  
 
@@ -10760,10 +10760,10 @@ Type of the SheetPayload.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateSheet | [CreateSheetRequest](#bytebase-v1-CreateSheetRequest) | [Sheet](#bytebase-v1-Sheet) |  |
-| BatchCreateSheets | [BatchCreateSheetsRequest](#bytebase-v1-BatchCreateSheetsRequest) | [BatchCreateSheetsResponse](#bytebase-v1-BatchCreateSheetsResponse) |  |
-| GetSheet | [GetSheetRequest](#bytebase-v1-GetSheetRequest) | [Sheet](#bytebase-v1-Sheet) |  |
-| UpdateSheet | [UpdateSheetRequest](#bytebase-v1-UpdateSheetRequest) | [Sheet](#bytebase-v1-Sheet) |  |
+| CreateSheet | [CreateSheetRequest](#bytebase-v1-CreateSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: sheets.create |
+| BatchCreateSheets | [BatchCreateSheetsRequest](#bytebase-v1-BatchCreateSheetsRequest) | [BatchCreateSheetsResponse](#bytebase-v1-BatchCreateSheetsResponse) | Permissions required: sheets.create |
+| GetSheet | [GetSheetRequest](#bytebase-v1-GetSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: sheets.get |
+| UpdateSheet | [UpdateSheetRequest](#bytebase-v1-UpdateSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: sheets.update |
 
  
 
@@ -10967,8 +10967,8 @@ PlanFeature represents the available features in Bytebase
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetSubscription | [GetSubscriptionRequest](#bytebase-v1-GetSubscriptionRequest) | [Subscription](#bytebase-v1-Subscription) | GetSubscription returns the current subscription. If there is no license, we will return a free plan subscription without expiration time. If there is expired license, we will return a free plan subscription with the expiration time of the expired license. |
-| UpdateSubscription | [UpdateSubscriptionRequest](#bytebase-v1-UpdateSubscriptionRequest) | [Subscription](#bytebase-v1-Subscription) |  |
+| GetSubscription | [GetSubscriptionRequest](#bytebase-v1-GetSubscriptionRequest) | [Subscription](#bytebase-v1-Subscription) | GetSubscription returns the current subscription. If there is no license, we will return a free plan subscription without expiration time. If there is expired license, we will return a free plan subscription with the expiration time of the expired license. Permissions required: None |
+| UpdateSubscription | [UpdateSubscriptionRequest](#bytebase-v1-UpdateSubscriptionRequest) | [Subscription](#bytebase-v1-Subscription) | Permissions required: settings.set |
 
  
 
@@ -11169,12 +11169,12 @@ The worksheet&#39;s `name` field is used to identify the worksheet to update. Fo
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateWorksheet | [CreateWorksheetRequest](#bytebase-v1-CreateWorksheetRequest) | [Worksheet](#bytebase-v1-Worksheet) | Create a personal worksheet used in SQL Editor. |
-| GetWorksheet | [GetWorksheetRequest](#bytebase-v1-GetWorksheetRequest) | [Worksheet](#bytebase-v1-Worksheet) | Get a worksheet by name. The users can access this method if, - they are the creator of the worksheet; - they have bb.worksheets.get permission on the workspace; - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project. |
-| SearchWorksheets | [SearchWorksheetsRequest](#bytebase-v1-SearchWorksheetsRequest) | [SearchWorksheetsResponse](#bytebase-v1-SearchWorksheetsResponse) | Search for worksheets. This is used for finding my worksheets or worksheets shared by other people. The sheet accessibility is the same as GetWorksheet(). |
-| UpdateWorksheet | [UpdateWorksheetRequest](#bytebase-v1-UpdateWorksheetRequest) | [Worksheet](#bytebase-v1-Worksheet) | Update a worksheet. The users can access this method if, - they are the creator of the worksheet; - they have bb.worksheets.manage permission on the workspace; - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project. |
-| UpdateWorksheetOrganizer | [UpdateWorksheetOrganizerRequest](#bytebase-v1-UpdateWorksheetOrganizerRequest) | [WorksheetOrganizer](#bytebase-v1-WorksheetOrganizer) | Update the organizer of a worksheet. The access is the same as UpdateWorksheet method. |
-| DeleteWorksheet | [DeleteWorksheetRequest](#bytebase-v1-DeleteWorksheetRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Delete a worksheet. The access is the same as UpdateWorksheet method. |
+| CreateWorksheet | [CreateWorksheetRequest](#bytebase-v1-CreateWorksheetRequest) | [Worksheet](#bytebase-v1-Worksheet) | Create a personal worksheet used in SQL Editor. Permissions required: None |
+| GetWorksheet | [GetWorksheetRequest](#bytebase-v1-GetWorksheetRequest) | [Worksheet](#bytebase-v1-Worksheet) | Get a worksheet by name. The users can access this method if, - they are the creator of the worksheet; - they have bb.worksheets.get permission on the workspace; - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project. Permissions required: None |
+| SearchWorksheets | [SearchWorksheetsRequest](#bytebase-v1-SearchWorksheetsRequest) | [SearchWorksheetsResponse](#bytebase-v1-SearchWorksheetsResponse) | Search for worksheets. This is used for finding my worksheets or worksheets shared by other people. The sheet accessibility is the same as GetWorksheet(). Permissions required: None |
+| UpdateWorksheet | [UpdateWorksheetRequest](#bytebase-v1-UpdateWorksheetRequest) | [Worksheet](#bytebase-v1-Worksheet) | Update a worksheet. The users can access this method if, - they are the creator of the worksheet; - they have bb.worksheets.manage permission on the workspace; - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project. Permissions required: None |
+| UpdateWorksheetOrganizer | [UpdateWorksheetOrganizerRequest](#bytebase-v1-UpdateWorksheetOrganizerRequest) | [WorksheetOrganizer](#bytebase-v1-WorksheetOrganizer) | Update the organizer of a worksheet. The access is the same as UpdateWorksheet method. Permissions required: None |
+| DeleteWorksheet | [DeleteWorksheetRequest](#bytebase-v1-DeleteWorksheetRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Delete a worksheet. The access is the same as UpdateWorksheet method. Permissions required: None |
 
  
 
@@ -11200,8 +11200,8 @@ The worksheet&#39;s `name` field is used to identify the worksheet to update. Fo
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) |  |
-| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) |  |
+| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: workspaces.getIamPolicy |
+| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: workspaces.setIamPolicy |
 
  
 

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -1106,8 +1106,8 @@ The catalog&#39;s `name` field is used to identify the database catalog to updat
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetDatabaseCatalog | [GetDatabaseCatalogRequest](#bytebase-v1-GetDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) | Permissions required: databaseCatalogs.get |
-| UpdateDatabaseCatalog | [UpdateDatabaseCatalogRequest](#bytebase-v1-UpdateDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) | Permissions required: databaseCatalogs.update |
+| GetDatabaseCatalog | [GetDatabaseCatalogRequest](#bytebase-v1-GetDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) | Permissions required: bb.databaseCatalogs.get |
+| UpdateDatabaseCatalog | [UpdateDatabaseCatalogRequest](#bytebase-v1-UpdateDatabaseCatalogRequest) | [DatabaseCatalog](#bytebase-v1-DatabaseCatalog) | Permissions required: bb.databaseCatalogs.update |
 
  
 
@@ -1204,8 +1204,8 @@ When paginating, all other parameters provided to `ListInstanceRoles` must match
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetInstanceRole | [GetInstanceRoleRequest](#bytebase-v1-GetInstanceRoleRequest) | [InstanceRole](#bytebase-v1-InstanceRole) | Permissions required: instanceRoles.get |
-| ListInstanceRoles | [ListInstanceRolesRequest](#bytebase-v1-ListInstanceRolesRequest) | [ListInstanceRolesResponse](#bytebase-v1-ListInstanceRolesResponse) | Permissions required: instanceRoles.get |
+| GetInstanceRole | [GetInstanceRoleRequest](#bytebase-v1-GetInstanceRoleRequest) | [InstanceRole](#bytebase-v1-InstanceRole) | Permissions required: bb.instanceRoles.get |
+| ListInstanceRoles | [ListInstanceRolesRequest](#bytebase-v1-ListInstanceRolesRequest) | [ListInstanceRolesResponse](#bytebase-v1-ListInstanceRolesResponse) | Permissions required: bb.instanceRoles.get |
 
  
 
@@ -1828,19 +1828,19 @@ The instance&#39;s `name` field is used to identify the instance to update. Form
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetInstance | [GetInstanceRequest](#bytebase-v1-GetInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.get |
-| ListInstances | [ListInstancesRequest](#bytebase-v1-ListInstancesRequest) | [ListInstancesResponse](#bytebase-v1-ListInstancesResponse) | Permissions required: instances.list |
-| CreateInstance | [CreateInstanceRequest](#bytebase-v1-CreateInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.create |
-| UpdateInstance | [UpdateInstanceRequest](#bytebase-v1-UpdateInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
-| DeleteInstance | [DeleteInstanceRequest](#bytebase-v1-DeleteInstanceRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: instances.delete |
-| UndeleteInstance | [UndeleteInstanceRequest](#bytebase-v1-UndeleteInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.undelete |
-| SyncInstance | [SyncInstanceRequest](#bytebase-v1-SyncInstanceRequest) | [SyncInstanceResponse](#bytebase-v1-SyncInstanceResponse) | Permissions required: instances.sync |
-| ListInstanceDatabase | [ListInstanceDatabaseRequest](#bytebase-v1-ListInstanceDatabaseRequest) | [ListInstanceDatabaseResponse](#bytebase-v1-ListInstanceDatabaseResponse) | Permissions required: instances.get |
-| BatchSyncInstances | [BatchSyncInstancesRequest](#bytebase-v1-BatchSyncInstancesRequest) | [BatchSyncInstancesResponse](#bytebase-v1-BatchSyncInstancesResponse) | Permissions required: instances.sync |
-| BatchUpdateInstances | [BatchUpdateInstancesRequest](#bytebase-v1-BatchUpdateInstancesRequest) | [BatchUpdateInstancesResponse](#bytebase-v1-BatchUpdateInstancesResponse) | Permissions required: instances.update |
-| AddDataSource | [AddDataSourceRequest](#bytebase-v1-AddDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
-| RemoveDataSource | [RemoveDataSourceRequest](#bytebase-v1-RemoveDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
-| UpdateDataSource | [UpdateDataSourceRequest](#bytebase-v1-UpdateDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: instances.update |
+| GetInstance | [GetInstanceRequest](#bytebase-v1-GetInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: bb.instances.get |
+| ListInstances | [ListInstancesRequest](#bytebase-v1-ListInstancesRequest) | [ListInstancesResponse](#bytebase-v1-ListInstancesResponse) | Permissions required: bb.instances.list |
+| CreateInstance | [CreateInstanceRequest](#bytebase-v1-CreateInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: bb.instances.create |
+| UpdateInstance | [UpdateInstanceRequest](#bytebase-v1-UpdateInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: bb.instances.update |
+| DeleteInstance | [DeleteInstanceRequest](#bytebase-v1-DeleteInstanceRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.instances.delete |
+| UndeleteInstance | [UndeleteInstanceRequest](#bytebase-v1-UndeleteInstanceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: bb.instances.undelete |
+| SyncInstance | [SyncInstanceRequest](#bytebase-v1-SyncInstanceRequest) | [SyncInstanceResponse](#bytebase-v1-SyncInstanceResponse) | Permissions required: bb.instances.sync |
+| ListInstanceDatabase | [ListInstanceDatabaseRequest](#bytebase-v1-ListInstanceDatabaseRequest) | [ListInstanceDatabaseResponse](#bytebase-v1-ListInstanceDatabaseResponse) | Permissions required: bb.instances.get |
+| BatchSyncInstances | [BatchSyncInstancesRequest](#bytebase-v1-BatchSyncInstancesRequest) | [BatchSyncInstancesResponse](#bytebase-v1-BatchSyncInstancesResponse) | Permissions required: bb.instances.sync |
+| BatchUpdateInstances | [BatchUpdateInstancesRequest](#bytebase-v1-BatchUpdateInstancesRequest) | [BatchUpdateInstancesResponse](#bytebase-v1-BatchUpdateInstancesResponse) | Permissions required: bb.instances.update |
+| AddDataSource | [AddDataSourceRequest](#bytebase-v1-AddDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: bb.instances.update |
+| RemoveDataSource | [RemoveDataSourceRequest](#bytebase-v1-RemoveDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: bb.instances.update |
+| UpdateDataSource | [UpdateDataSourceRequest](#bytebase-v1-UpdateDataSourceRequest) | [Instance](#bytebase-v1-Instance) | Permissions required: bb.instances.update |
 
  
 
@@ -3187,20 +3187,20 @@ LIST, HASH (https://www.postgresql.org/docs/current/ddl-partitioning.html)
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetDatabase | [GetDatabaseRequest](#bytebase-v1-GetDatabaseRequest) | [Database](#bytebase-v1-Database) | Permissions required: databases.get |
-| BatchGetDatabases | [BatchGetDatabasesRequest](#bytebase-v1-BatchGetDatabasesRequest) | [BatchGetDatabasesResponse](#bytebase-v1-BatchGetDatabasesResponse) | Permissions required: databases.get |
-| ListDatabases | [ListDatabasesRequest](#bytebase-v1-ListDatabasesRequest) | [ListDatabasesResponse](#bytebase-v1-ListDatabasesResponse) | Permissions required: databases.list |
-| UpdateDatabase | [UpdateDatabaseRequest](#bytebase-v1-UpdateDatabaseRequest) | [Database](#bytebase-v1-Database) | Permissions required: databases.update |
-| BatchUpdateDatabases | [BatchUpdateDatabasesRequest](#bytebase-v1-BatchUpdateDatabasesRequest) | [BatchUpdateDatabasesResponse](#bytebase-v1-BatchUpdateDatabasesResponse) | Permissions required: databases.update |
-| SyncDatabase | [SyncDatabaseRequest](#bytebase-v1-SyncDatabaseRequest) | [SyncDatabaseResponse](#bytebase-v1-SyncDatabaseResponse) | Permissions required: databases.sync |
-| BatchSyncDatabases | [BatchSyncDatabasesRequest](#bytebase-v1-BatchSyncDatabasesRequest) | [BatchSyncDatabasesResponse](#bytebase-v1-BatchSyncDatabasesResponse) | Permissions required: databases.sync |
-| GetDatabaseMetadata | [GetDatabaseMetadataRequest](#bytebase-v1-GetDatabaseMetadataRequest) | [DatabaseMetadata](#bytebase-v1-DatabaseMetadata) | Permissions required: databases.getSchema |
-| GetDatabaseSchema | [GetDatabaseSchemaRequest](#bytebase-v1-GetDatabaseSchemaRequest) | [DatabaseSchema](#bytebase-v1-DatabaseSchema) | Permissions required: databases.getSchema |
-| DiffSchema | [DiffSchemaRequest](#bytebase-v1-DiffSchemaRequest) | [DiffSchemaResponse](#bytebase-v1-DiffSchemaResponse) | Permissions required: databases.get |
-| ListSecrets | [ListSecretsRequest](#bytebase-v1-ListSecretsRequest) | [ListSecretsResponse](#bytebase-v1-ListSecretsResponse) | Permissions required: databaseSecrets.list |
-| UpdateSecret | [UpdateSecretRequest](#bytebase-v1-UpdateSecretRequest) | [Secret](#bytebase-v1-Secret) | Permissions required: databaseSecrets.update |
-| DeleteSecret | [DeleteSecretRequest](#bytebase-v1-DeleteSecretRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: databaseSecrets.delete |
-| ListChangelogs | [ListChangelogsRequest](#bytebase-v1-ListChangelogsRequest) | [ListChangelogsResponse](#bytebase-v1-ListChangelogsResponse) | Permissions required: changelogs.list |
+| GetDatabase | [GetDatabaseRequest](#bytebase-v1-GetDatabaseRequest) | [Database](#bytebase-v1-Database) | Permissions required: bb.databases.get |
+| BatchGetDatabases | [BatchGetDatabasesRequest](#bytebase-v1-BatchGetDatabasesRequest) | [BatchGetDatabasesResponse](#bytebase-v1-BatchGetDatabasesResponse) | Permissions required: bb.databases.get |
+| ListDatabases | [ListDatabasesRequest](#bytebase-v1-ListDatabasesRequest) | [ListDatabasesResponse](#bytebase-v1-ListDatabasesResponse) | Permissions required: bb.databases.list |
+| UpdateDatabase | [UpdateDatabaseRequest](#bytebase-v1-UpdateDatabaseRequest) | [Database](#bytebase-v1-Database) | Permissions required: bb.databases.update |
+| BatchUpdateDatabases | [BatchUpdateDatabasesRequest](#bytebase-v1-BatchUpdateDatabasesRequest) | [BatchUpdateDatabasesResponse](#bytebase-v1-BatchUpdateDatabasesResponse) | Permissions required: bb.databases.update |
+| SyncDatabase | [SyncDatabaseRequest](#bytebase-v1-SyncDatabaseRequest) | [SyncDatabaseResponse](#bytebase-v1-SyncDatabaseResponse) | Permissions required: bb.databases.sync |
+| BatchSyncDatabases | [BatchSyncDatabasesRequest](#bytebase-v1-BatchSyncDatabasesRequest) | [BatchSyncDatabasesResponse](#bytebase-v1-BatchSyncDatabasesResponse) | Permissions required: bb.databases.sync |
+| GetDatabaseMetadata | [GetDatabaseMetadataRequest](#bytebase-v1-GetDatabaseMetadataRequest) | [DatabaseMetadata](#bytebase-v1-DatabaseMetadata) | Permissions required: bb.databases.getSchema |
+| GetDatabaseSchema | [GetDatabaseSchemaRequest](#bytebase-v1-GetDatabaseSchemaRequest) | [DatabaseSchema](#bytebase-v1-DatabaseSchema) | Permissions required: bb.databases.getSchema |
+| DiffSchema | [DiffSchemaRequest](#bytebase-v1-DiffSchemaRequest) | [DiffSchemaResponse](#bytebase-v1-DiffSchemaResponse) | Permissions required: bb.databases.get |
+| ListSecrets | [ListSecretsRequest](#bytebase-v1-ListSecretsRequest) | [ListSecretsResponse](#bytebase-v1-ListSecretsResponse) | Permissions required: bb.databaseSecrets.list |
+| UpdateSecret | [UpdateSecretRequest](#bytebase-v1-UpdateSecretRequest) | [Secret](#bytebase-v1-Secret) | Permissions required: bb.databaseSecrets.update |
+| DeleteSecret | [DeleteSecretRequest](#bytebase-v1-DeleteSecretRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.databaseSecrets.delete |
+| ListChangelogs | [ListChangelogsRequest](#bytebase-v1-ListChangelogsRequest) | [ListChangelogsResponse](#bytebase-v1-ListChangelogsResponse) | Permissions required: bb.changelogs.list |
 | GetChangelog | [GetChangelogRequest](#bytebase-v1-GetChangelogRequest) | [Changelog](#bytebase-v1-Changelog) | Permissions required: changelogs.get |
 | GetSchemaString | [GetSchemaStringRequest](#bytebase-v1-GetSchemaStringRequest) | [GetSchemaStringResponse](#bytebase-v1-GetSchemaStringResponse) | Permissions required: databases.getSchema |
 
@@ -3895,15 +3895,15 @@ ANY means approving any node will proceed.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetIssue | [GetIssueRequest](#bytebase-v1-GetIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: issues.get |
-| CreateIssue | [CreateIssueRequest](#bytebase-v1-CreateIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: issues.create |
-| ListIssues | [ListIssuesRequest](#bytebase-v1-ListIssuesRequest) | [ListIssuesResponse](#bytebase-v1-ListIssuesResponse) | Permissions required: issues.list |
-| SearchIssues | [SearchIssuesRequest](#bytebase-v1-SearchIssuesRequest) | [SearchIssuesResponse](#bytebase-v1-SearchIssuesResponse) | Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter &amp; query. Permissions required: issues.get |
-| UpdateIssue | [UpdateIssueRequest](#bytebase-v1-UpdateIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: issues.update |
-| ListIssueComments | [ListIssueCommentsRequest](#bytebase-v1-ListIssueCommentsRequest) | [ListIssueCommentsResponse](#bytebase-v1-ListIssueCommentsResponse) | Permissions required: issueComments.list |
-| CreateIssueComment | [CreateIssueCommentRequest](#bytebase-v1-CreateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) | Permissions required: issueComments.create |
-| UpdateIssueComment | [UpdateIssueCommentRequest](#bytebase-v1-UpdateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) | Permissions required: issueComments.update |
-| BatchUpdateIssuesStatus | [BatchUpdateIssuesStatusRequest](#bytebase-v1-BatchUpdateIssuesStatusRequest) | [BatchUpdateIssuesStatusResponse](#bytebase-v1-BatchUpdateIssuesStatusResponse) | Permissions required: issues.update |
+| GetIssue | [GetIssueRequest](#bytebase-v1-GetIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: bb.issues.get |
+| CreateIssue | [CreateIssueRequest](#bytebase-v1-CreateIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: bb.issues.create |
+| ListIssues | [ListIssuesRequest](#bytebase-v1-ListIssuesRequest) | [ListIssuesResponse](#bytebase-v1-ListIssuesResponse) | Permissions required: bb.issues.list |
+| SearchIssues | [SearchIssuesRequest](#bytebase-v1-SearchIssuesRequest) | [SearchIssuesResponse](#bytebase-v1-SearchIssuesResponse) | Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter &amp; query. Permissions required: bb.issues.get |
+| UpdateIssue | [UpdateIssueRequest](#bytebase-v1-UpdateIssueRequest) | [Issue](#bytebase-v1-Issue) | Permissions required: bb.issues.update |
+| ListIssueComments | [ListIssueCommentsRequest](#bytebase-v1-ListIssueCommentsRequest) | [ListIssueCommentsResponse](#bytebase-v1-ListIssueCommentsResponse) | Permissions required: bb.issueComments.list |
+| CreateIssueComment | [CreateIssueCommentRequest](#bytebase-v1-CreateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) | Permissions required: bb.issueComments.create |
+| UpdateIssueComment | [UpdateIssueCommentRequest](#bytebase-v1-UpdateIssueCommentRequest) | [IssueComment](#bytebase-v1-IssueComment) | Permissions required: bb.issueComments.update |
+| BatchUpdateIssuesStatus | [BatchUpdateIssuesStatusRequest](#bytebase-v1-BatchUpdateIssuesStatusRequest) | [BatchUpdateIssuesStatusResponse](#bytebase-v1-BatchUpdateIssuesStatusResponse) | Permissions required: bb.issues.update |
 | ApproveIssue | [ApproveIssueRequest](#bytebase-v1-ApproveIssueRequest) | [Issue](#bytebase-v1-Issue) | ApproveIssue approves the issue. The access is based on approval flow. Permissions required: None |
 | RejectIssue | [RejectIssueRequest](#bytebase-v1-RejectIssueRequest) | [Issue](#bytebase-v1-Issue) | RejectIssue rejects the issue. The access is based on approval flow. Permissions required: None |
 | RequestIssue | [RequestIssueRequest](#bytebase-v1-RequestIssueRequest) | [Issue](#bytebase-v1-Issue) | RequestIssue requests the issue. The access is based on approval flow. Permissions required: None |
@@ -4731,9 +4731,9 @@ We support three levels of AlertLevel: INFO, WARNING, and ERROR.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListSettings | [ListSettingsRequest](#bytebase-v1-ListSettingsRequest) | [ListSettingsResponse](#bytebase-v1-ListSettingsResponse) | Permissions required: settings.list |
-| GetSetting | [GetSettingRequest](#bytebase-v1-GetSettingRequest) | [Setting](#bytebase-v1-Setting) | Permissions required: settings.get |
-| UpdateSetting | [UpdateSettingRequest](#bytebase-v1-UpdateSettingRequest) | [Setting](#bytebase-v1-Setting) | Permissions required: settings.set |
+| ListSettings | [ListSettingsRequest](#bytebase-v1-ListSettingsRequest) | [ListSettingsResponse](#bytebase-v1-ListSettingsResponse) | Permissions required: bb.settings.list |
+| GetSetting | [GetSettingRequest](#bytebase-v1-GetSettingRequest) | [Setting](#bytebase-v1-Setting) | Permissions required: bb.settings.get |
+| UpdateSetting | [UpdateSettingRequest](#bytebase-v1-UpdateSettingRequest) | [Setting](#bytebase-v1-Setting) | Permissions required: bb.settings.set |
 
  
 
@@ -4967,14 +4967,14 @@ The user&#39;s `name` field is used to identify the user to update. Format: user
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetUser | [GetUserRequest](#bytebase-v1-GetUserRequest) | [User](#bytebase-v1-User) | Get the user. Any authenticated user can get the user. Permissions required: users.get |
-| BatchGetUsers | [BatchGetUsersRequest](#bytebase-v1-BatchGetUsersRequest) | [BatchGetUsersResponse](#bytebase-v1-BatchGetUsersResponse) | Get the users in batch. Any authenticated user can batch get users. Permissions required: users.get |
+| GetUser | [GetUserRequest](#bytebase-v1-GetUserRequest) | [User](#bytebase-v1-User) | Get the user. Any authenticated user can get the user. Permissions required: bb.users.get |
+| BatchGetUsers | [BatchGetUsersRequest](#bytebase-v1-BatchGetUsersRequest) | [BatchGetUsersResponse](#bytebase-v1-BatchGetUsersResponse) | Get the users in batch. Any authenticated user can batch get users. Permissions required: bb.users.get |
 | GetCurrentUser | [.google.protobuf.Empty](#google-protobuf-Empty) | [User](#bytebase-v1-User) | Get the current authenticated user. Permissions required: None |
-| ListUsers | [ListUsersRequest](#bytebase-v1-ListUsersRequest) | [ListUsersResponse](#bytebase-v1-ListUsersResponse) | List all users. Any authenticated user can list users. Permissions required: users.list |
-| CreateUser | [CreateUserRequest](#bytebase-v1-CreateUserRequest) | [User](#bytebase-v1-User) | Create a user. When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user. Otherwise, any unauthenticated user can create a user. Permissions required: users.create |
-| UpdateUser | [UpdateUserRequest](#bytebase-v1-UpdateUserRequest) | [User](#bytebase-v1-User) | Only the user itself and the user with bb.users.update permission on the workspace can update the user. Permissions required: users.update |
-| DeleteUser | [DeleteUserRequest](#bytebase-v1-DeleteUserRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Only the user with bb.users.delete permission on the workspace can delete the user. The last remaining workspace admin cannot be deleted. Permissions required: users.delete |
-| UndeleteUser | [UndeleteUserRequest](#bytebase-v1-UndeleteUserRequest) | [User](#bytebase-v1-User) | Only the user with bb.users.undelete permission on the workspace can undelete the user. Permissions required: users.undelete |
+| ListUsers | [ListUsersRequest](#bytebase-v1-ListUsersRequest) | [ListUsersResponse](#bytebase-v1-ListUsersResponse) | List all users. Any authenticated user can list users. Permissions required: bb.users.list |
+| CreateUser | [CreateUserRequest](#bytebase-v1-CreateUserRequest) | [User](#bytebase-v1-User) | Create a user. When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user. Otherwise, any unauthenticated user can create a user. Permissions required: bb.users.create |
+| UpdateUser | [UpdateUserRequest](#bytebase-v1-UpdateUserRequest) | [User](#bytebase-v1-User) | Only the user itself and the user with bb.users.update permission on the workspace can update the user. Permissions required: bb.users.update |
+| DeleteUser | [DeleteUserRequest](#bytebase-v1-DeleteUserRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Only the user with bb.users.delete permission on the workspace can delete the user. The last remaining workspace admin cannot be deleted. Permissions required: bb.users.delete |
+| UndeleteUser | [UndeleteUserRequest](#bytebase-v1-UndeleteUserRequest) | [User](#bytebase-v1-User) | Only the user with bb.users.undelete permission on the workspace can undelete the user. Permissions required: bb.users.undelete |
 
  
 
@@ -5126,8 +5126,8 @@ The theme resources.
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | GetActuatorInfo | [GetActuatorInfoRequest](#bytebase-v1-GetActuatorInfoRequest) | [ActuatorInfo](#bytebase-v1-ActuatorInfo) | Permissions required: None |
-| UpdateActuatorInfo | [UpdateActuatorInfoRequest](#bytebase-v1-UpdateActuatorInfoRequest) | [ActuatorInfo](#bytebase-v1-ActuatorInfo) | Permissions required: settings.set |
-| SetupSample | [SetupSampleRequest](#bytebase-v1-SetupSampleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.create |
+| UpdateActuatorInfo | [UpdateActuatorInfoRequest](#bytebase-v1-UpdateActuatorInfoRequest) | [ActuatorInfo](#bytebase-v1-ActuatorInfo) | Permissions required: bb.settings.set |
+| SetupSample | [SetupSampleRequest](#bytebase-v1-SetupSampleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.projects.create |
 | DeleteCache | [DeleteCacheRequest](#bytebase-v1-DeleteCacheRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: None |
 | GetResourcePackage | [GetResourcePackageRequest](#bytebase-v1-GetResourcePackageRequest) | [ResourcePackage](#bytebase-v1-ResourcePackage) | Permissions required: None |
 
@@ -5439,7 +5439,7 @@ For example: - filter = &#34;method == &#39;/bytebase.v1.SQLService/Query&#39;&#
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | SearchAuditLogs | [SearchAuditLogsRequest](#bytebase-v1-SearchAuditLogsRequest) | [SearchAuditLogsResponse](#bytebase-v1-SearchAuditLogsResponse) | Permissions required: None |
-| ExportAuditLogs | [ExportAuditLogsRequest](#bytebase-v1-ExportAuditLogsRequest) | [ExportAuditLogsResponse](#bytebase-v1-ExportAuditLogsResponse) | Permissions required: auditLogs.export |
+| ExportAuditLogs | [ExportAuditLogsRequest](#bytebase-v1-ExportAuditLogsRequest) | [ExportAuditLogsResponse](#bytebase-v1-ExportAuditLogsResponse) | Permissions required: bb.auditLogs.export |
 
  
 
@@ -5807,11 +5807,11 @@ The changelist&#39;s `name` field is used to identify the changelist to update. 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateChangelist | [CreateChangelistRequest](#bytebase-v1-CreateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: changelists.create |
-| GetChangelist | [GetChangelistRequest](#bytebase-v1-GetChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: changelists.get |
-| ListChangelists | [ListChangelistsRequest](#bytebase-v1-ListChangelistsRequest) | [ListChangelistsResponse](#bytebase-v1-ListChangelistsResponse) | Permissions required: changelists.list |
-| UpdateChangelist | [UpdateChangelistRequest](#bytebase-v1-UpdateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: changelists.update |
-| DeleteChangelist | [DeleteChangelistRequest](#bytebase-v1-DeleteChangelistRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: changelists.delete |
+| CreateChangelist | [CreateChangelistRequest](#bytebase-v1-CreateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: bb.changelists.create |
+| GetChangelist | [GetChangelistRequest](#bytebase-v1-GetChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: bb.changelists.get |
+| ListChangelists | [ListChangelistsRequest](#bytebase-v1-ListChangelistsRequest) | [ListChangelistsResponse](#bytebase-v1-ListChangelistsResponse) | Permissions required: bb.changelists.list |
+| UpdateChangelist | [UpdateChangelistRequest](#bytebase-v1-UpdateChangelistRequest) | [Changelist](#bytebase-v1-Changelist) | Permissions required: bb.changelists.update |
+| DeleteChangelist | [DeleteChangelistRequest](#bytebase-v1-DeleteChangelistRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.changelists.delete |
 
  
 
@@ -5993,11 +5993,11 @@ The database group&#39;s `name` field is used to identify the database group to 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListDatabaseGroups | [ListDatabaseGroupsRequest](#bytebase-v1-ListDatabaseGroupsRequest) | [ListDatabaseGroupsResponse](#bytebase-v1-ListDatabaseGroupsResponse) | Permissions required: projects.get |
-| GetDatabaseGroup | [GetDatabaseGroupRequest](#bytebase-v1-GetDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: projects.get |
-| CreateDatabaseGroup | [CreateDatabaseGroupRequest](#bytebase-v1-CreateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: projects.update |
-| UpdateDatabaseGroup | [UpdateDatabaseGroupRequest](#bytebase-v1-UpdateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: projects.update |
-| DeleteDatabaseGroup | [DeleteDatabaseGroupRequest](#bytebase-v1-DeleteDatabaseGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.update |
+| ListDatabaseGroups | [ListDatabaseGroupsRequest](#bytebase-v1-ListDatabaseGroupsRequest) | [ListDatabaseGroupsResponse](#bytebase-v1-ListDatabaseGroupsResponse) | Permissions required: bb.projects.get |
+| GetDatabaseGroup | [GetDatabaseGroupRequest](#bytebase-v1-GetDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: bb.projects.get |
+| CreateDatabaseGroup | [CreateDatabaseGroupRequest](#bytebase-v1-CreateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: bb.projects.update |
+| UpdateDatabaseGroup | [UpdateDatabaseGroupRequest](#bytebase-v1-UpdateDatabaseGroupRequest) | [DatabaseGroup](#bytebase-v1-DatabaseGroup) | Permissions required: bb.projects.update |
+| DeleteDatabaseGroup | [DeleteDatabaseGroupRequest](#bytebase-v1-DeleteDatabaseGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.projects.update |
 
  
 
@@ -6172,11 +6172,11 @@ The group&#39;s `name` field is used to identify the group to update. Format: gr
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetGroup | [GetGroupRequest](#bytebase-v1-GetGroupRequest) | [Group](#bytebase-v1-Group) | Permissions required: groups.get |
-| ListGroups | [ListGroupsRequest](#bytebase-v1-ListGroupsRequest) | [ListGroupsResponse](#bytebase-v1-ListGroupsResponse) | Permissions required: groups.list |
-| CreateGroup | [CreateGroupRequest](#bytebase-v1-CreateGroupRequest) | [Group](#bytebase-v1-Group) | Permissions required: groups.create |
-| UpdateGroup | [UpdateGroupRequest](#bytebase-v1-UpdateGroupRequest) | [Group](#bytebase-v1-Group) | UpdateGroup updates the group. Users with &#34;bb.groups.update&#34; permission on the workspace or the group owner can access this method. Permissions required: groups.update |
-| DeleteGroup | [DeleteGroupRequest](#bytebase-v1-DeleteGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: groups.delete |
+| GetGroup | [GetGroupRequest](#bytebase-v1-GetGroupRequest) | [Group](#bytebase-v1-Group) | Permissions required: bb.groups.get |
+| ListGroups | [ListGroupsRequest](#bytebase-v1-ListGroupsRequest) | [ListGroupsResponse](#bytebase-v1-ListGroupsResponse) | Permissions required: bb.groups.list |
+| CreateGroup | [CreateGroupRequest](#bytebase-v1-CreateGroupRequest) | [Group](#bytebase-v1-Group) | Permissions required: bb.groups.create |
+| UpdateGroup | [UpdateGroupRequest](#bytebase-v1-UpdateGroupRequest) | [Group](#bytebase-v1-Group) | UpdateGroup updates the group. Users with &#34;bb.groups.update&#34; permission on the workspace or the group owner can access this method. Permissions required: bb.groups.update |
+| DeleteGroup | [DeleteGroupRequest](#bytebase-v1-DeleteGroupRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.groups.delete |
 
  
 
@@ -6546,12 +6546,12 @@ The identity provider&#39;s `name` field is used to identify the identity provid
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetIdentityProvider | [GetIdentityProviderRequest](#bytebase-v1-GetIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: identityProviders.get |
+| GetIdentityProvider | [GetIdentityProviderRequest](#bytebase-v1-GetIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: bb.identityProviders.get |
 | ListIdentityProviders | [ListIdentityProvidersRequest](#bytebase-v1-ListIdentityProvidersRequest) | [ListIdentityProvidersResponse](#bytebase-v1-ListIdentityProvidersResponse) | Permissions required: None |
-| CreateIdentityProvider | [CreateIdentityProviderRequest](#bytebase-v1-CreateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: identityProviders.create |
-| UpdateIdentityProvider | [UpdateIdentityProviderRequest](#bytebase-v1-UpdateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: identityProviders.update |
-| DeleteIdentityProvider | [DeleteIdentityProviderRequest](#bytebase-v1-DeleteIdentityProviderRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: identityProviders.delete |
-| TestIdentityProvider | [TestIdentityProviderRequest](#bytebase-v1-TestIdentityProviderRequest) | [TestIdentityProviderResponse](#bytebase-v1-TestIdentityProviderResponse) | Permissions required: identityProviders.update |
+| CreateIdentityProvider | [CreateIdentityProviderRequest](#bytebase-v1-CreateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: bb.identityProviders.create |
+| UpdateIdentityProvider | [UpdateIdentityProviderRequest](#bytebase-v1-UpdateIdentityProviderRequest) | [IdentityProvider](#bytebase-v1-IdentityProvider) | Permissions required: bb.identityProviders.update |
+| DeleteIdentityProvider | [DeleteIdentityProviderRequest](#bytebase-v1-DeleteIdentityProviderRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.identityProviders.delete |
+| TestIdentityProvider | [TestIdentityProviderRequest](#bytebase-v1-TestIdentityProviderRequest) | [TestIdentityProviderResponse](#bytebase-v1-TestIdentityProviderResponse) | Permissions required: bb.identityProviders.update |
 
  
 
@@ -7002,11 +7002,11 @@ The policy&#39;s `name` field is used to identify the instance to update. Format
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetPolicy | [GetPolicyRequest](#bytebase-v1-GetPolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: policies.get |
-| ListPolicies | [ListPoliciesRequest](#bytebase-v1-ListPoliciesRequest) | [ListPoliciesResponse](#bytebase-v1-ListPoliciesResponse) | Permissions required: policies.list |
-| CreatePolicy | [CreatePolicyRequest](#bytebase-v1-CreatePolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: policies.create |
-| UpdatePolicy | [UpdatePolicyRequest](#bytebase-v1-UpdatePolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: policies.update |
-| DeletePolicy | [DeletePolicyRequest](#bytebase-v1-DeletePolicyRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: policies.delete |
+| GetPolicy | [GetPolicyRequest](#bytebase-v1-GetPolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: bb.policies.get |
+| ListPolicies | [ListPoliciesRequest](#bytebase-v1-ListPoliciesRequest) | [ListPoliciesResponse](#bytebase-v1-ListPoliciesResponse) | Permissions required: bb.policies.list |
+| CreatePolicy | [CreatePolicyRequest](#bytebase-v1-CreatePolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: bb.policies.create |
+| UpdatePolicy | [UpdatePolicyRequest](#bytebase-v1-UpdatePolicyRequest) | [Policy](#bytebase-v1-Policy) | Permissions required: bb.policies.update |
+| DeletePolicy | [DeletePolicyRequest](#bytebase-v1-DeletePolicyRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.policies.delete |
 
  
 
@@ -7553,14 +7553,14 @@ Type is the database change type.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetPlan | [GetPlanRequest](#bytebase-v1-GetPlanRequest) | [Plan](#bytebase-v1-Plan) | Permissions required: plans.get |
-| ListPlans | [ListPlansRequest](#bytebase-v1-ListPlansRequest) | [ListPlansResponse](#bytebase-v1-ListPlansResponse) | Permissions required: plans.list |
-| SearchPlans | [SearchPlansRequest](#bytebase-v1-SearchPlansRequest) | [SearchPlansResponse](#bytebase-v1-SearchPlansResponse) | Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter &amp; query. Permissions required: plans.get |
-| CreatePlan | [CreatePlanRequest](#bytebase-v1-CreatePlanRequest) | [Plan](#bytebase-v1-Plan) | Permissions required: plans.create |
-| UpdatePlan | [UpdatePlanRequest](#bytebase-v1-UpdatePlanRequest) | [Plan](#bytebase-v1-Plan) | UpdatePlan updates the plan. The plan creator and the user with bb.plans.update permission on the project can update the plan. Permissions required: plans.update |
-| ListPlanCheckRuns | [ListPlanCheckRunsRequest](#bytebase-v1-ListPlanCheckRunsRequest) | [ListPlanCheckRunsResponse](#bytebase-v1-ListPlanCheckRunsResponse) | Permissions required: planCheckRuns.list |
-| RunPlanChecks | [RunPlanChecksRequest](#bytebase-v1-RunPlanChecksRequest) | [RunPlanChecksResponse](#bytebase-v1-RunPlanChecksResponse) | Permissions required: planCheckRuns.run |
-| BatchCancelPlanCheckRuns | [BatchCancelPlanCheckRunsRequest](#bytebase-v1-BatchCancelPlanCheckRunsRequest) | [BatchCancelPlanCheckRunsResponse](#bytebase-v1-BatchCancelPlanCheckRunsResponse) | Permissions required: planCheckRuns.run |
+| GetPlan | [GetPlanRequest](#bytebase-v1-GetPlanRequest) | [Plan](#bytebase-v1-Plan) | Permissions required: bb.plans.get |
+| ListPlans | [ListPlansRequest](#bytebase-v1-ListPlansRequest) | [ListPlansResponse](#bytebase-v1-ListPlansResponse) | Permissions required: bb.plans.list |
+| SearchPlans | [SearchPlansRequest](#bytebase-v1-SearchPlansRequest) | [SearchPlansResponse](#bytebase-v1-SearchPlansResponse) | Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter &amp; query. Permissions required: bb.plans.get |
+| CreatePlan | [CreatePlanRequest](#bytebase-v1-CreatePlanRequest) | [Plan](#bytebase-v1-Plan) | Permissions required: bb.plans.create |
+| UpdatePlan | [UpdatePlanRequest](#bytebase-v1-UpdatePlanRequest) | [Plan](#bytebase-v1-Plan) | UpdatePlan updates the plan. The plan creator and the user with bb.plans.update permission on the project can update the plan. Permissions required: bb.plans.update |
+| ListPlanCheckRuns | [ListPlanCheckRunsRequest](#bytebase-v1-ListPlanCheckRunsRequest) | [ListPlanCheckRunsResponse](#bytebase-v1-ListPlanCheckRunsResponse) | Permissions required: bb.planCheckRuns.list |
+| RunPlanChecks | [RunPlanChecksRequest](#bytebase-v1-RunPlanChecksRequest) | [RunPlanChecksResponse](#bytebase-v1-RunPlanChecksResponse) | Permissions required: bb.planCheckRuns.run |
+| BatchCancelPlanCheckRuns | [BatchCancelPlanCheckRunsRequest](#bytebase-v1-BatchCancelPlanCheckRunsRequest) | [BatchCancelPlanCheckRunsResponse](#bytebase-v1-BatchCancelPlanCheckRunsResponse) | Permissions required: bb.planCheckRuns.run |
 
  
 
@@ -8020,21 +8020,21 @@ TYPE_ISSUE_CREATE represents creating an issue. |
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetProject | [GetProjectRequest](#bytebase-v1-GetProjectRequest) | [Project](#bytebase-v1-Project) | GetProject retrieves a project by name. Users with &#34;bb.projects.get&#34; permission on the workspace or the project owner can access this method. Permissions required: projects.get |
-| ListProjects | [ListProjectsRequest](#bytebase-v1-ListProjectsRequest) | [ListProjectsResponse](#bytebase-v1-ListProjectsResponse) | Permissions required: projects.list |
+| GetProject | [GetProjectRequest](#bytebase-v1-GetProjectRequest) | [Project](#bytebase-v1-Project) | GetProject retrieves a project by name. Users with &#34;bb.projects.get&#34; permission on the workspace or the project owner can access this method. Permissions required: bb.projects.get |
+| ListProjects | [ListProjectsRequest](#bytebase-v1-ListProjectsRequest) | [ListProjectsResponse](#bytebase-v1-ListProjectsResponse) | Permissions required: bb.projects.list |
 | SearchProjects | [SearchProjectsRequest](#bytebase-v1-SearchProjectsRequest) | [SearchProjectsResponse](#bytebase-v1-SearchProjectsResponse) | Permissions required: None |
-| CreateProject | [CreateProjectRequest](#bytebase-v1-CreateProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.create |
-| UpdateProject | [UpdateProjectRequest](#bytebase-v1-UpdateProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
-| DeleteProject | [DeleteProjectRequest](#bytebase-v1-DeleteProjectRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.delete |
-| UndeleteProject | [UndeleteProjectRequest](#bytebase-v1-UndeleteProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.undelete |
-| BatchDeleteProjects | [BatchDeleteProjectsRequest](#bytebase-v1-BatchDeleteProjectsRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: projects.delete |
-| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: projects.getIamPolicy |
-| BatchGetIamPolicy | [BatchGetIamPolicyRequest](#bytebase-v1-BatchGetIamPolicyRequest) | [BatchGetIamPolicyResponse](#bytebase-v1-BatchGetIamPolicyResponse) | Deprecated. Permissions required: projects.getIamPolicy |
-| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: projects.setIamPolicy |
-| AddWebhook | [AddWebhookRequest](#bytebase-v1-AddWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
-| UpdateWebhook | [UpdateWebhookRequest](#bytebase-v1-UpdateWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
-| RemoveWebhook | [RemoveWebhookRequest](#bytebase-v1-RemoveWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: projects.update |
-| TestWebhook | [TestWebhookRequest](#bytebase-v1-TestWebhookRequest) | [TestWebhookResponse](#bytebase-v1-TestWebhookResponse) | Permissions required: projects.update |
+| CreateProject | [CreateProjectRequest](#bytebase-v1-CreateProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: bb.projects.create |
+| UpdateProject | [UpdateProjectRequest](#bytebase-v1-UpdateProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: bb.projects.update |
+| DeleteProject | [DeleteProjectRequest](#bytebase-v1-DeleteProjectRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.projects.delete |
+| UndeleteProject | [UndeleteProjectRequest](#bytebase-v1-UndeleteProjectRequest) | [Project](#bytebase-v1-Project) | Permissions required: bb.projects.undelete |
+| BatchDeleteProjects | [BatchDeleteProjectsRequest](#bytebase-v1-BatchDeleteProjectsRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.projects.delete |
+| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: bb.projects.getIamPolicy |
+| BatchGetIamPolicy | [BatchGetIamPolicyRequest](#bytebase-v1-BatchGetIamPolicyRequest) | [BatchGetIamPolicyResponse](#bytebase-v1-BatchGetIamPolicyResponse) | Deprecated. Permissions required: bb.projects.getIamPolicy |
+| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: bb.projects.setIamPolicy |
+| AddWebhook | [AddWebhookRequest](#bytebase-v1-AddWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: bb.projects.update |
+| UpdateWebhook | [UpdateWebhookRequest](#bytebase-v1-UpdateWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: bb.projects.update |
+| RemoveWebhook | [RemoveWebhookRequest](#bytebase-v1-RemoveWebhookRequest) | [Project](#bytebase-v1-Project) | Permissions required: bb.projects.update |
+| TestWebhook | [TestWebhookRequest](#bytebase-v1-TestWebhookRequest) | [TestWebhookResponse](#bytebase-v1-TestWebhookResponse) | Permissions required: bb.projects.update |
 
  
 
@@ -8705,11 +8705,11 @@ For example: project == &#34;projects/{project}&#34; database == &#34;instances/
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| Query | [QueryRequest](#bytebase-v1-QueryRequest) | [QueryResponse](#bytebase-v1-QueryResponse) | Permissions required: databases.get |
-| AdminExecute | [AdminExecuteRequest](#bytebase-v1-AdminExecuteRequest) stream | [AdminExecuteResponse](#bytebase-v1-AdminExecuteResponse) stream | Permissions required: sql.admin |
+| Query | [QueryRequest](#bytebase-v1-QueryRequest) | [QueryResponse](#bytebase-v1-QueryResponse) | Permissions required: bb.databases.get |
+| AdminExecute | [AdminExecuteRequest](#bytebase-v1-AdminExecuteRequest) stream | [AdminExecuteResponse](#bytebase-v1-AdminExecuteResponse) stream | Permissions required: bb.sql.admin |
 | SearchQueryHistories | [SearchQueryHistoriesRequest](#bytebase-v1-SearchQueryHistoriesRequest) | [SearchQueryHistoriesResponse](#bytebase-v1-SearchQueryHistoriesResponse) | SearchQueryHistories searches query histories for the caller. Permissions required: None |
-| Export | [ExportRequest](#bytebase-v1-ExportRequest) | [ExportResponse](#bytebase-v1-ExportResponse) | Permissions required: databases.get |
-| Check | [CheckRequest](#bytebase-v1-CheckRequest) | [CheckResponse](#bytebase-v1-CheckResponse) | Permissions required: databases.check |
+| Export | [ExportRequest](#bytebase-v1-ExportRequest) | [ExportResponse](#bytebase-v1-ExportResponse) | Permissions required: bb.databases.get |
+| Check | [CheckRequest](#bytebase-v1-CheckRequest) | [CheckResponse](#bytebase-v1-CheckResponse) | Permissions required: bb.databases.check |
 | Pretty | [PrettyRequest](#bytebase-v1-PrettyRequest) | [PrettyResponse](#bytebase-v1-PrettyResponse) | Permissions required: None |
 | DiffMetadata | [DiffMetadataRequest](#bytebase-v1-DiffMetadataRequest) | [DiffMetadataResponse](#bytebase-v1-DiffMetadataResponse) | Permissions required: None |
 | AICompletion | [AICompletionRequest](#bytebase-v1-AICompletionRequest) | [AICompletionResponse](#bytebase-v1-AICompletionResponse) | Permissions required: None |
@@ -9006,13 +9006,13 @@ The sheet that holds the content. Format: projects/{project}/sheets/{sheet} |
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetRelease | [GetReleaseRequest](#bytebase-v1-GetReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.get |
-| ListReleases | [ListReleasesRequest](#bytebase-v1-ListReleasesRequest) | [ListReleasesResponse](#bytebase-v1-ListReleasesResponse) | Permissions required: releases.list |
-| CreateRelease | [CreateReleaseRequest](#bytebase-v1-CreateReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.create |
-| UpdateRelease | [UpdateReleaseRequest](#bytebase-v1-UpdateReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.update |
-| DeleteRelease | [DeleteReleaseRequest](#bytebase-v1-DeleteReleaseRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: releases.delete |
-| UndeleteRelease | [UndeleteReleaseRequest](#bytebase-v1-UndeleteReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: releases.undelete |
-| CheckRelease | [CheckReleaseRequest](#bytebase-v1-CheckReleaseRequest) | [CheckReleaseResponse](#bytebase-v1-CheckReleaseResponse) | Permissions required: releases.check |
+| GetRelease | [GetReleaseRequest](#bytebase-v1-GetReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: bb.releases.get |
+| ListReleases | [ListReleasesRequest](#bytebase-v1-ListReleasesRequest) | [ListReleasesResponse](#bytebase-v1-ListReleasesResponse) | Permissions required: bb.releases.list |
+| CreateRelease | [CreateReleaseRequest](#bytebase-v1-CreateReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: bb.releases.create |
+| UpdateRelease | [UpdateReleaseRequest](#bytebase-v1-UpdateReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: bb.releases.update |
+| DeleteRelease | [DeleteReleaseRequest](#bytebase-v1-DeleteReleaseRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.releases.delete |
+| UndeleteRelease | [UndeleteReleaseRequest](#bytebase-v1-UndeleteReleaseRequest) | [Release](#bytebase-v1-Release) | Permissions required: bb.releases.undelete |
+| CheckRelease | [CheckReleaseRequest](#bytebase-v1-CheckReleaseRequest) | [CheckReleaseResponse](#bytebase-v1-CheckReleaseResponse) | Permissions required: bb.releases.check |
 
  
 
@@ -9155,11 +9155,11 @@ The name field is used to identify the sql review to update. |
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateReviewConfig | [CreateReviewConfigRequest](#bytebase-v1-CreateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: reviewConfigs.create |
-| ListReviewConfigs | [ListReviewConfigsRequest](#bytebase-v1-ListReviewConfigsRequest) | [ListReviewConfigsResponse](#bytebase-v1-ListReviewConfigsResponse) | Permissions required: reviewConfigs.list |
-| GetReviewConfig | [GetReviewConfigRequest](#bytebase-v1-GetReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: reviewConfigs.get |
-| UpdateReviewConfig | [UpdateReviewConfigRequest](#bytebase-v1-UpdateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: reviewConfigs.update |
-| DeleteReviewConfig | [DeleteReviewConfigRequest](#bytebase-v1-DeleteReviewConfigRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: reviewConfigs.delete |
+| CreateReviewConfig | [CreateReviewConfigRequest](#bytebase-v1-CreateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: bb.reviewConfigs.create |
+| ListReviewConfigs | [ListReviewConfigsRequest](#bytebase-v1-ListReviewConfigsRequest) | [ListReviewConfigsResponse](#bytebase-v1-ListReviewConfigsResponse) | Permissions required: bb.reviewConfigs.list |
+| GetReviewConfig | [GetReviewConfigRequest](#bytebase-v1-GetReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: bb.reviewConfigs.get |
+| UpdateReviewConfig | [UpdateReviewConfigRequest](#bytebase-v1-UpdateReviewConfigRequest) | [ReviewConfig](#bytebase-v1-ReviewConfig) | Permissions required: bb.reviewConfigs.update |
+| DeleteReviewConfig | [DeleteReviewConfigRequest](#bytebase-v1-DeleteReviewConfigRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.reviewConfigs.delete |
 
  
 
@@ -9325,11 +9325,11 @@ When paginating, all other parameters provided to `ListRevisions` must match the
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListRevisions | [ListRevisionsRequest](#bytebase-v1-ListRevisionsRequest) | [ListRevisionsResponse](#bytebase-v1-ListRevisionsResponse) | Permissions required: revisions.list |
-| GetRevision | [GetRevisionRequest](#bytebase-v1-GetRevisionRequest) | [Revision](#bytebase-v1-Revision) | Permissions required: revisions.get |
-| CreateRevision | [CreateRevisionRequest](#bytebase-v1-CreateRevisionRequest) | [Revision](#bytebase-v1-Revision) | Permissions required: revisions.create |
-| BatchCreateRevisions | [BatchCreateRevisionsRequest](#bytebase-v1-BatchCreateRevisionsRequest) | [BatchCreateRevisionsResponse](#bytebase-v1-BatchCreateRevisionsResponse) | Permissions required: revisions.create |
-| DeleteRevision | [DeleteRevisionRequest](#bytebase-v1-DeleteRevisionRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: revisions.delete |
+| ListRevisions | [ListRevisionsRequest](#bytebase-v1-ListRevisionsRequest) | [ListRevisionsResponse](#bytebase-v1-ListRevisionsResponse) | Permissions required: bb.revisions.list |
+| GetRevision | [GetRevisionRequest](#bytebase-v1-GetRevisionRequest) | [Revision](#bytebase-v1-Revision) | Permissions required: bb.revisions.get |
+| CreateRevision | [CreateRevisionRequest](#bytebase-v1-CreateRevisionRequest) | [Revision](#bytebase-v1-Revision) | Permissions required: bb.revisions.create |
+| BatchCreateRevisions | [BatchCreateRevisionsRequest](#bytebase-v1-BatchCreateRevisionsRequest) | [BatchCreateRevisionsResponse](#bytebase-v1-BatchCreateRevisionsResponse) | Permissions required: bb.revisions.create |
+| DeleteRevision | [DeleteRevisionRequest](#bytebase-v1-DeleteRevisionRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.revisions.delete |
 
  
 
@@ -9502,11 +9502,11 @@ The risk&#39;s `name` field is used to identify the risk to update. Format: risk
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListRisks | [ListRisksRequest](#bytebase-v1-ListRisksRequest) | [ListRisksResponse](#bytebase-v1-ListRisksResponse) | Permissions required: risks.list |
-| CreateRisk | [CreateRiskRequest](#bytebase-v1-CreateRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: risks.create |
-| GetRisk | [GetRiskRequest](#bytebase-v1-GetRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: risks.list |
-| UpdateRisk | [UpdateRiskRequest](#bytebase-v1-UpdateRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: risks.update |
-| DeleteRisk | [DeleteRiskRequest](#bytebase-v1-DeleteRiskRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: risks.delete |
+| ListRisks | [ListRisksRequest](#bytebase-v1-ListRisksRequest) | [ListRisksResponse](#bytebase-v1-ListRisksResponse) | Permissions required: bb.risks.list |
+| CreateRisk | [CreateRiskRequest](#bytebase-v1-CreateRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: bb.risks.create |
+| GetRisk | [GetRiskRequest](#bytebase-v1-GetRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: bb.risks.list |
+| UpdateRisk | [UpdateRiskRequest](#bytebase-v1-UpdateRiskRequest) | [Risk](#bytebase-v1-Risk) | Permissions required: bb.risks.update |
+| DeleteRisk | [DeleteRiskRequest](#bytebase-v1-DeleteRiskRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.risks.delete |
 
  
 
@@ -9663,11 +9663,11 @@ When paginating, all other parameters provided to `ListRoles` must match the cal
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListRoles | [ListRolesRequest](#bytebase-v1-ListRolesRequest) | [ListRolesResponse](#bytebase-v1-ListRolesResponse) | Permissions required: roles.list |
-| GetRole | [GetRoleRequest](#bytebase-v1-GetRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: roles.get |
-| CreateRole | [CreateRoleRequest](#bytebase-v1-CreateRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: roles.create |
-| UpdateRole | [UpdateRoleRequest](#bytebase-v1-UpdateRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: roles.update |
-| DeleteRole | [DeleteRoleRequest](#bytebase-v1-DeleteRoleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: roles.delete |
+| ListRoles | [ListRolesRequest](#bytebase-v1-ListRolesRequest) | [ListRolesResponse](#bytebase-v1-ListRolesResponse) | Permissions required: bb.roles.list |
+| GetRole | [GetRoleRequest](#bytebase-v1-GetRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: bb.roles.get |
+| CreateRole | [CreateRoleRequest](#bytebase-v1-CreateRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: bb.roles.create |
+| UpdateRole | [UpdateRoleRequest](#bytebase-v1-UpdateRoleRequest) | [Role](#bytebase-v1-Role) | Permissions required: bb.roles.update |
+| DeleteRole | [DeleteRoleRequest](#bytebase-v1-DeleteRoleRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Permissions required: bb.roles.delete |
 
  
 
@@ -10576,18 +10576,18 @@ Read from `pg_stat_activity`
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetRollout | [GetRolloutRequest](#bytebase-v1-GetRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | Permissions required: rollouts.get |
-| ListRollouts | [ListRolloutsRequest](#bytebase-v1-ListRolloutsRequest) | [ListRolloutsResponse](#bytebase-v1-ListRolloutsResponse) | Permissions required: rollouts.list |
-| CreateRollout | [CreateRolloutRequest](#bytebase-v1-CreateRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages. Permissions required: rollouts.create |
-| PreviewRollout | [PreviewRolloutRequest](#bytebase-v1-PreviewRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | Permissions required: rollouts.preview |
-| ListTaskRuns | [ListTaskRunsRequest](#bytebase-v1-ListTaskRunsRequest) | [ListTaskRunsResponse](#bytebase-v1-ListTaskRunsResponse) | Permissions required: taskRuns.list |
-| GetTaskRun | [GetTaskRunRequest](#bytebase-v1-GetTaskRunRequest) | [TaskRun](#bytebase-v1-TaskRun) | Permissions required: taskRuns.list |
-| GetTaskRunLog | [GetTaskRunLogRequest](#bytebase-v1-GetTaskRunLogRequest) | [TaskRunLog](#bytebase-v1-TaskRunLog) | Permissions required: taskRuns.list |
-| GetTaskRunSession | [GetTaskRunSessionRequest](#bytebase-v1-GetTaskRunSessionRequest) | [TaskRunSession](#bytebase-v1-TaskRunSession) | Permissions required: taskRuns.list |
-| BatchRunTasks | [BatchRunTasksRequest](#bytebase-v1-BatchRunTasksRequest) | [BatchRunTasksResponse](#bytebase-v1-BatchRunTasksResponse) | BatchRunTasks creates task runs for the specified tasks. DataExport issue only allows the creator to run the task. Users with &#34;bb.taskRuns.create&#34; permission can run the task, e.g. Workspace Admin and DBA. Follow role-based rollout policy for the environment. Permissions required: None |
-| BatchSkipTasks | [BatchSkipTasksRequest](#bytebase-v1-BatchSkipTasksRequest) | [BatchSkipTasksResponse](#bytebase-v1-BatchSkipTasksResponse) | BatchSkipTasks skips the specified tasks. The access is the same as BatchRunTasks(). Permissions required: None |
-| BatchCancelTaskRuns | [BatchCancelTaskRunsRequest](#bytebase-v1-BatchCancelTaskRunsRequest) | [BatchCancelTaskRunsResponse](#bytebase-v1-BatchCancelTaskRunsResponse) | BatchCancelTaskRuns cancels the specified task runs in batch. The access is the same as BatchRunTasks(). Permissions required: None |
-| PreviewTaskRunRollback | [PreviewTaskRunRollbackRequest](#bytebase-v1-PreviewTaskRunRollbackRequest) | [PreviewTaskRunRollbackResponse](#bytebase-v1-PreviewTaskRunRollbackResponse) | Permissions required: taskRuns.list |
+| GetRollout | [GetRolloutRequest](#bytebase-v1-GetRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | Permissions required: bb.rollouts.get |
+| ListRollouts | [ListRolloutsRequest](#bytebase-v1-ListRolloutsRequest) | [ListRolloutsResponse](#bytebase-v1-ListRolloutsResponse) | Permissions required: bb.rollouts.list |
+| CreateRollout | [CreateRolloutRequest](#bytebase-v1-CreateRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | Permissions required: bb.rollouts.create |
+| PreviewRollout | [PreviewRolloutRequest](#bytebase-v1-PreviewRolloutRequest) | [Rollout](#bytebase-v1-Rollout) | Permissions required: bb.rollouts.preview |
+| ListTaskRuns | [ListTaskRunsRequest](#bytebase-v1-ListTaskRunsRequest) | [ListTaskRunsResponse](#bytebase-v1-ListTaskRunsResponse) | Permissions required: bb.taskRuns.list |
+| GetTaskRun | [GetTaskRunRequest](#bytebase-v1-GetTaskRunRequest) | [TaskRun](#bytebase-v1-TaskRun) | Permissions required: bb.taskRuns.list |
+| GetTaskRunLog | [GetTaskRunLogRequest](#bytebase-v1-GetTaskRunLogRequest) | [TaskRunLog](#bytebase-v1-TaskRunLog) | Permissions required: bb.taskRuns.list |
+| GetTaskRunSession | [GetTaskRunSessionRequest](#bytebase-v1-GetTaskRunSessionRequest) | [TaskRunSession](#bytebase-v1-TaskRunSession) | Permissions required: bb.taskRuns.list |
+| BatchRunTasks | [BatchRunTasksRequest](#bytebase-v1-BatchRunTasksRequest) | [BatchRunTasksResponse](#bytebase-v1-BatchRunTasksResponse) | Permissions required: None |
+| BatchSkipTasks | [BatchSkipTasksRequest](#bytebase-v1-BatchSkipTasksRequest) | [BatchSkipTasksResponse](#bytebase-v1-BatchSkipTasksResponse) | Permissions required: None |
+| BatchCancelTaskRuns | [BatchCancelTaskRunsRequest](#bytebase-v1-BatchCancelTaskRunsRequest) | [BatchCancelTaskRunsResponse](#bytebase-v1-BatchCancelTaskRunsResponse) | Permissions required: None |
+| PreviewTaskRunRollback | [PreviewTaskRunRollbackRequest](#bytebase-v1-PreviewTaskRunRollbackRequest) | [PreviewTaskRunRollbackResponse](#bytebase-v1-PreviewTaskRunRollbackResponse) | Permissions required: bb.taskRuns.list |
 
  
 
@@ -10760,10 +10760,10 @@ Type of the SheetPayload.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateSheet | [CreateSheetRequest](#bytebase-v1-CreateSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: sheets.create |
-| BatchCreateSheets | [BatchCreateSheetsRequest](#bytebase-v1-BatchCreateSheetsRequest) | [BatchCreateSheetsResponse](#bytebase-v1-BatchCreateSheetsResponse) | Permissions required: sheets.create |
-| GetSheet | [GetSheetRequest](#bytebase-v1-GetSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: sheets.get |
-| UpdateSheet | [UpdateSheetRequest](#bytebase-v1-UpdateSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: sheets.update |
+| CreateSheet | [CreateSheetRequest](#bytebase-v1-CreateSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: bb.sheets.create |
+| BatchCreateSheets | [BatchCreateSheetsRequest](#bytebase-v1-BatchCreateSheetsRequest) | [BatchCreateSheetsResponse](#bytebase-v1-BatchCreateSheetsResponse) | Permissions required: bb.sheets.create |
+| GetSheet | [GetSheetRequest](#bytebase-v1-GetSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: bb.sheets.get |
+| UpdateSheet | [UpdateSheetRequest](#bytebase-v1-UpdateSheetRequest) | [Sheet](#bytebase-v1-Sheet) | Permissions required: bb.sheets.update |
 
  
 
@@ -10968,7 +10968,7 @@ PlanFeature represents the available features in Bytebase
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | GetSubscription | [GetSubscriptionRequest](#bytebase-v1-GetSubscriptionRequest) | [Subscription](#bytebase-v1-Subscription) | GetSubscription returns the current subscription. If there is no license, we will return a free plan subscription without expiration time. If there is expired license, we will return a free plan subscription with the expiration time of the expired license. Permissions required: None |
-| UpdateSubscription | [UpdateSubscriptionRequest](#bytebase-v1-UpdateSubscriptionRequest) | [Subscription](#bytebase-v1-Subscription) | Permissions required: settings.set |
+| UpdateSubscription | [UpdateSubscriptionRequest](#bytebase-v1-UpdateSubscriptionRequest) | [Subscription](#bytebase-v1-Subscription) | Permissions required: bb.settings.set |
 
  
 
@@ -11200,8 +11200,8 @@ The worksheet&#39;s `name` field is used to identify the worksheet to update. Fo
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: workspaces.getIamPolicy |
-| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: workspaces.setIamPolicy |
+| GetIamPolicy | [GetIamPolicyRequest](#bytebase-v1-GetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: bb.workspaces.getIamPolicy |
+| SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Permissions required: bb.workspaces.setIamPolicy |
 
  
 

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -3770,14 +3770,14 @@ Format: instances/{instance}/databases/{database}/catalog </p></td>
                 <td>GetDatabaseCatalog</td>
                 <td><a href="#bytebase.v1.GetDatabaseCatalogRequest">GetDatabaseCatalogRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseCatalog">DatabaseCatalog</a></td>
-                <td><p>Permissions required: databaseCatalogs.get</p></td>
+                <td><p>Permissions required: bb.databaseCatalogs.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDatabaseCatalog</td>
                 <td><a href="#bytebase.v1.UpdateDatabaseCatalogRequest">UpdateDatabaseCatalogRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseCatalog">DatabaseCatalog</a></td>
-                <td><p>Permissions required: databaseCatalogs.update</p></td>
+                <td><p>Permissions required: bb.databaseCatalogs.update</p></td>
               </tr>
             
           </tbody>
@@ -4024,14 +4024,14 @@ If this field is omitted, there are no subsequent pages. </p></td>
                 <td>GetInstanceRole</td>
                 <td><a href="#bytebase.v1.GetInstanceRoleRequest">GetInstanceRoleRequest</a></td>
                 <td><a href="#bytebase.v1.InstanceRole">InstanceRole</a></td>
-                <td><p>Permissions required: instanceRoles.get</p></td>
+                <td><p>Permissions required: bb.instanceRoles.get</p></td>
               </tr>
             
               <tr>
                 <td>ListInstanceRoles</td>
                 <td><a href="#bytebase.v1.ListInstanceRolesRequest">ListInstanceRolesRequest</a></td>
                 <td><a href="#bytebase.v1.ListInstanceRolesResponse">ListInstanceRolesResponse</a></td>
-                <td><p>Permissions required: instanceRoles.get</p></td>
+                <td><p>Permissions required: bb.instanceRoles.get</p></td>
               </tr>
             
           </tbody>
@@ -5655,91 +5655,91 @@ Format: instances/{instance} </p></td>
                 <td>GetInstance</td>
                 <td><a href="#bytebase.v1.GetInstanceRequest">GetInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p>Permissions required: instances.get</p></td>
+                <td><p>Permissions required: bb.instances.get</p></td>
               </tr>
             
               <tr>
                 <td>ListInstances</td>
                 <td><a href="#bytebase.v1.ListInstancesRequest">ListInstancesRequest</a></td>
                 <td><a href="#bytebase.v1.ListInstancesResponse">ListInstancesResponse</a></td>
-                <td><p>Permissions required: instances.list</p></td>
+                <td><p>Permissions required: bb.instances.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateInstance</td>
                 <td><a href="#bytebase.v1.CreateInstanceRequest">CreateInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p>Permissions required: instances.create</p></td>
+                <td><p>Permissions required: bb.instances.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateInstance</td>
                 <td><a href="#bytebase.v1.UpdateInstanceRequest">UpdateInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p>Permissions required: instances.update</p></td>
+                <td><p>Permissions required: bb.instances.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteInstance</td>
                 <td><a href="#bytebase.v1.DeleteInstanceRequest">DeleteInstanceRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: instances.delete</p></td>
+                <td><p>Permissions required: bb.instances.delete</p></td>
               </tr>
             
               <tr>
                 <td>UndeleteInstance</td>
                 <td><a href="#bytebase.v1.UndeleteInstanceRequest">UndeleteInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p>Permissions required: instances.undelete</p></td>
+                <td><p>Permissions required: bb.instances.undelete</p></td>
               </tr>
             
               <tr>
                 <td>SyncInstance</td>
                 <td><a href="#bytebase.v1.SyncInstanceRequest">SyncInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.SyncInstanceResponse">SyncInstanceResponse</a></td>
-                <td><p>Permissions required: instances.sync</p></td>
+                <td><p>Permissions required: bb.instances.sync</p></td>
               </tr>
             
               <tr>
                 <td>ListInstanceDatabase</td>
                 <td><a href="#bytebase.v1.ListInstanceDatabaseRequest">ListInstanceDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.ListInstanceDatabaseResponse">ListInstanceDatabaseResponse</a></td>
-                <td><p>Permissions required: instances.get</p></td>
+                <td><p>Permissions required: bb.instances.get</p></td>
               </tr>
             
               <tr>
                 <td>BatchSyncInstances</td>
                 <td><a href="#bytebase.v1.BatchSyncInstancesRequest">BatchSyncInstancesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchSyncInstancesResponse">BatchSyncInstancesResponse</a></td>
-                <td><p>Permissions required: instances.sync</p></td>
+                <td><p>Permissions required: bb.instances.sync</p></td>
               </tr>
             
               <tr>
                 <td>BatchUpdateInstances</td>
                 <td><a href="#bytebase.v1.BatchUpdateInstancesRequest">BatchUpdateInstancesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchUpdateInstancesResponse">BatchUpdateInstancesResponse</a></td>
-                <td><p>Permissions required: instances.update</p></td>
+                <td><p>Permissions required: bb.instances.update</p></td>
               </tr>
             
               <tr>
                 <td>AddDataSource</td>
                 <td><a href="#bytebase.v1.AddDataSourceRequest">AddDataSourceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p>Permissions required: instances.update</p></td>
+                <td><p>Permissions required: bb.instances.update</p></td>
               </tr>
             
               <tr>
                 <td>RemoveDataSource</td>
                 <td><a href="#bytebase.v1.RemoveDataSourceRequest">RemoveDataSourceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p>Permissions required: instances.update</p></td>
+                <td><p>Permissions required: bb.instances.update</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDataSource</td>
                 <td><a href="#bytebase.v1.UpdateDataSourceRequest">UpdateDataSourceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p>Permissions required: instances.update</p></td>
+                <td><p>Permissions required: bb.instances.update</p></td>
               </tr>
             
           </tbody>
@@ -9588,98 +9588,98 @@ The API will default to the BASIC view.</p></td>
                 <td>GetDatabase</td>
                 <td><a href="#bytebase.v1.GetDatabaseRequest">GetDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.Database">Database</a></td>
-                <td><p>Permissions required: databases.get</p></td>
+                <td><p>Permissions required: bb.databases.get</p></td>
               </tr>
             
               <tr>
                 <td>BatchGetDatabases</td>
                 <td><a href="#bytebase.v1.BatchGetDatabasesRequest">BatchGetDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchGetDatabasesResponse">BatchGetDatabasesResponse</a></td>
-                <td><p>Permissions required: databases.get</p></td>
+                <td><p>Permissions required: bb.databases.get</p></td>
               </tr>
             
               <tr>
                 <td>ListDatabases</td>
                 <td><a href="#bytebase.v1.ListDatabasesRequest">ListDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.ListDatabasesResponse">ListDatabasesResponse</a></td>
-                <td><p>Permissions required: databases.list</p></td>
+                <td><p>Permissions required: bb.databases.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDatabase</td>
                 <td><a href="#bytebase.v1.UpdateDatabaseRequest">UpdateDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.Database">Database</a></td>
-                <td><p>Permissions required: databases.update</p></td>
+                <td><p>Permissions required: bb.databases.update</p></td>
               </tr>
             
               <tr>
                 <td>BatchUpdateDatabases</td>
                 <td><a href="#bytebase.v1.BatchUpdateDatabasesRequest">BatchUpdateDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchUpdateDatabasesResponse">BatchUpdateDatabasesResponse</a></td>
-                <td><p>Permissions required: databases.update</p></td>
+                <td><p>Permissions required: bb.databases.update</p></td>
               </tr>
             
               <tr>
                 <td>SyncDatabase</td>
                 <td><a href="#bytebase.v1.SyncDatabaseRequest">SyncDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.SyncDatabaseResponse">SyncDatabaseResponse</a></td>
-                <td><p>Permissions required: databases.sync</p></td>
+                <td><p>Permissions required: bb.databases.sync</p></td>
               </tr>
             
               <tr>
                 <td>BatchSyncDatabases</td>
                 <td><a href="#bytebase.v1.BatchSyncDatabasesRequest">BatchSyncDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchSyncDatabasesResponse">BatchSyncDatabasesResponse</a></td>
-                <td><p>Permissions required: databases.sync</p></td>
+                <td><p>Permissions required: bb.databases.sync</p></td>
               </tr>
             
               <tr>
                 <td>GetDatabaseMetadata</td>
                 <td><a href="#bytebase.v1.GetDatabaseMetadataRequest">GetDatabaseMetadataRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseMetadata">DatabaseMetadata</a></td>
-                <td><p>Permissions required: databases.getSchema</p></td>
+                <td><p>Permissions required: bb.databases.getSchema</p></td>
               </tr>
             
               <tr>
                 <td>GetDatabaseSchema</td>
                 <td><a href="#bytebase.v1.GetDatabaseSchemaRequest">GetDatabaseSchemaRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseSchema">DatabaseSchema</a></td>
-                <td><p>Permissions required: databases.getSchema</p></td>
+                <td><p>Permissions required: bb.databases.getSchema</p></td>
               </tr>
             
               <tr>
                 <td>DiffSchema</td>
                 <td><a href="#bytebase.v1.DiffSchemaRequest">DiffSchemaRequest</a></td>
                 <td><a href="#bytebase.v1.DiffSchemaResponse">DiffSchemaResponse</a></td>
-                <td><p>Permissions required: databases.get</p></td>
+                <td><p>Permissions required: bb.databases.get</p></td>
               </tr>
             
               <tr>
                 <td>ListSecrets</td>
                 <td><a href="#bytebase.v1.ListSecretsRequest">ListSecretsRequest</a></td>
                 <td><a href="#bytebase.v1.ListSecretsResponse">ListSecretsResponse</a></td>
-                <td><p>Permissions required: databaseSecrets.list</p></td>
+                <td><p>Permissions required: bb.databaseSecrets.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateSecret</td>
                 <td><a href="#bytebase.v1.UpdateSecretRequest">UpdateSecretRequest</a></td>
                 <td><a href="#bytebase.v1.Secret">Secret</a></td>
-                <td><p>Permissions required: databaseSecrets.update</p></td>
+                <td><p>Permissions required: bb.databaseSecrets.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteSecret</td>
                 <td><a href="#bytebase.v1.DeleteSecretRequest">DeleteSecretRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: databaseSecrets.delete</p></td>
+                <td><p>Permissions required: bb.databaseSecrets.delete</p></td>
               </tr>
             
               <tr>
                 <td>ListChangelogs</td>
                 <td><a href="#bytebase.v1.ListChangelogsRequest">ListChangelogsRequest</a></td>
                 <td><a href="#bytebase.v1.ListChangelogsResponse">ListChangelogsResponse</a></td>
-                <td><p>Permissions required: changelogs.list</p></td>
+                <td><p>Permissions required: bb.changelogs.list</p></td>
               </tr>
             
               <tr>
@@ -11570,21 +11570,21 @@ Format: projects/{project}/issues/{issue} </p></td>
                 <td>GetIssue</td>
                 <td><a href="#bytebase.v1.GetIssueRequest">GetIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
-                <td><p>Permissions required: issues.get</p></td>
+                <td><p>Permissions required: bb.issues.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateIssue</td>
                 <td><a href="#bytebase.v1.CreateIssueRequest">CreateIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
-                <td><p>Permissions required: issues.create</p></td>
+                <td><p>Permissions required: bb.issues.create</p></td>
               </tr>
             
               <tr>
                 <td>ListIssues</td>
                 <td><a href="#bytebase.v1.ListIssuesRequest">ListIssuesRequest</a></td>
                 <td><a href="#bytebase.v1.ListIssuesResponse">ListIssuesResponse</a></td>
-                <td><p>Permissions required: issues.list</p></td>
+                <td><p>Permissions required: bb.issues.list</p></td>
               </tr>
             
               <tr>
@@ -11592,42 +11592,42 @@ Format: projects/{project}/issues/{issue} </p></td>
                 <td><a href="#bytebase.v1.SearchIssuesRequest">SearchIssuesRequest</a></td>
                 <td><a href="#bytebase.v1.SearchIssuesResponse">SearchIssuesResponse</a></td>
                 <td><p>Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter &amp; query.
-Permissions required: issues.get</p></td>
+Permissions required: bb.issues.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateIssue</td>
                 <td><a href="#bytebase.v1.UpdateIssueRequest">UpdateIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
-                <td><p>Permissions required: issues.update</p></td>
+                <td><p>Permissions required: bb.issues.update</p></td>
               </tr>
             
               <tr>
                 <td>ListIssueComments</td>
                 <td><a href="#bytebase.v1.ListIssueCommentsRequest">ListIssueCommentsRequest</a></td>
                 <td><a href="#bytebase.v1.ListIssueCommentsResponse">ListIssueCommentsResponse</a></td>
-                <td><p>Permissions required: issueComments.list</p></td>
+                <td><p>Permissions required: bb.issueComments.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateIssueComment</td>
                 <td><a href="#bytebase.v1.CreateIssueCommentRequest">CreateIssueCommentRequest</a></td>
                 <td><a href="#bytebase.v1.IssueComment">IssueComment</a></td>
-                <td><p>Permissions required: issueComments.create</p></td>
+                <td><p>Permissions required: bb.issueComments.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateIssueComment</td>
                 <td><a href="#bytebase.v1.UpdateIssueCommentRequest">UpdateIssueCommentRequest</a></td>
                 <td><a href="#bytebase.v1.IssueComment">IssueComment</a></td>
-                <td><p>Permissions required: issueComments.update</p></td>
+                <td><p>Permissions required: bb.issueComments.update</p></td>
               </tr>
             
               <tr>
                 <td>BatchUpdateIssuesStatus</td>
                 <td><a href="#bytebase.v1.BatchUpdateIssuesStatusRequest">BatchUpdateIssuesStatusRequest</a></td>
                 <td><a href="#bytebase.v1.BatchUpdateIssuesStatusResponse">BatchUpdateIssuesStatusResponse</a></td>
-                <td><p>Permissions required: issues.update</p></td>
+                <td><p>Permissions required: bb.issues.update</p></td>
               </tr>
             
               <tr>
@@ -13747,21 +13747,21 @@ Default to this mode.</p></td>
                 <td>ListSettings</td>
                 <td><a href="#bytebase.v1.ListSettingsRequest">ListSettingsRequest</a></td>
                 <td><a href="#bytebase.v1.ListSettingsResponse">ListSettingsResponse</a></td>
-                <td><p>Permissions required: settings.list</p></td>
+                <td><p>Permissions required: bb.settings.list</p></td>
               </tr>
             
               <tr>
                 <td>GetSetting</td>
                 <td><a href="#bytebase.v1.GetSettingRequest">GetSettingRequest</a></td>
                 <td><a href="#bytebase.v1.Setting">Setting</a></td>
-                <td><p>Permissions required: settings.get</p></td>
+                <td><p>Permissions required: bb.settings.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateSetting</td>
                 <td><a href="#bytebase.v1.UpdateSettingRequest">UpdateSettingRequest</a></td>
                 <td><a href="#bytebase.v1.Setting">Setting</a></td>
-                <td><p>Permissions required: settings.set</p></td>
+                <td><p>Permissions required: bb.settings.set</p></td>
               </tr>
             
           </tbody>
@@ -14330,7 +14330,7 @@ Could be empty. </p></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
                 <td><p>Get the user.
 Any authenticated user can get the user.
-Permissions required: users.get</p></td>
+Permissions required: bb.users.get</p></td>
               </tr>
             
               <tr>
@@ -14339,7 +14339,7 @@ Permissions required: users.get</p></td>
                 <td><a href="#bytebase.v1.BatchGetUsersResponse">BatchGetUsersResponse</a></td>
                 <td><p>Get the users in batch.
 Any authenticated user can batch get users.
-Permissions required: users.get</p></td>
+Permissions required: bb.users.get</p></td>
               </tr>
             
               <tr>
@@ -14356,7 +14356,7 @@ Permissions required: None</p></td>
                 <td><a href="#bytebase.v1.ListUsersResponse">ListUsersResponse</a></td>
                 <td><p>List all users.
 Any authenticated user can list users.
-Permissions required: users.list</p></td>
+Permissions required: bb.users.list</p></td>
               </tr>
             
               <tr>
@@ -14366,7 +14366,7 @@ Permissions required: users.list</p></td>
                 <td><p>Create a user.
 When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 Otherwise, any unauthenticated user can create a user.
-Permissions required: users.create</p></td>
+Permissions required: bb.users.create</p></td>
               </tr>
             
               <tr>
@@ -14374,7 +14374,7 @@ Permissions required: users.create</p></td>
                 <td><a href="#bytebase.v1.UpdateUserRequest">UpdateUserRequest</a></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
                 <td><p>Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-Permissions required: users.update</p></td>
+Permissions required: bb.users.update</p></td>
               </tr>
             
               <tr>
@@ -14383,7 +14383,7 @@ Permissions required: users.update</p></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
                 <td><p>Only the user with bb.users.delete permission on the workspace can delete the user.
 The last remaining workspace admin cannot be deleted.
-Permissions required: users.delete</p></td>
+Permissions required: bb.users.delete</p></td>
               </tr>
             
               <tr>
@@ -14391,7 +14391,7 @@ Permissions required: users.delete</p></td>
                 <td><a href="#bytebase.v1.UndeleteUserRequest">UndeleteUserRequest</a></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
                 <td><p>Only the user with bb.users.undelete permission on the workspace can undelete the user.
-Permissions required: users.undelete</p></td>
+Permissions required: bb.users.undelete</p></td>
               </tr>
             
           </tbody>
@@ -14821,14 +14821,14 @@ Permissions required: users.undelete</p></td>
                 <td>UpdateActuatorInfo</td>
                 <td><a href="#bytebase.v1.UpdateActuatorInfoRequest">UpdateActuatorInfoRequest</a></td>
                 <td><a href="#bytebase.v1.ActuatorInfo">ActuatorInfo</a></td>
-                <td><p>Permissions required: settings.set</p></td>
+                <td><p>Permissions required: bb.settings.set</p></td>
               </tr>
             
               <tr>
                 <td>SetupSample</td>
                 <td><a href="#bytebase.v1.SetupSampleRequest">SetupSampleRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: projects.create</p></td>
+                <td><p>Permissions required: bb.projects.create</p></td>
               </tr>
             
               <tr>
@@ -15652,7 +15652,7 @@ to retrieve the next page of log entities. </p></td>
                 <td>ExportAuditLogs</td>
                 <td><a href="#bytebase.v1.ExportAuditLogsRequest">ExportAuditLogsRequest</a></td>
                 <td><a href="#bytebase.v1.ExportAuditLogsResponse">ExportAuditLogsResponse</a></td>
-                <td><p>Permissions required: auditLogs.export</p></td>
+                <td><p>Permissions required: bb.auditLogs.export</p></td>
               </tr>
             
           </tbody>
@@ -16472,35 +16472,35 @@ Format: projects/{project}/changelists/{changelist} </p></td>
                 <td>CreateChangelist</td>
                 <td><a href="#bytebase.v1.CreateChangelistRequest">CreateChangelistRequest</a></td>
                 <td><a href="#bytebase.v1.Changelist">Changelist</a></td>
-                <td><p>Permissions required: changelists.create</p></td>
+                <td><p>Permissions required: bb.changelists.create</p></td>
               </tr>
             
               <tr>
                 <td>GetChangelist</td>
                 <td><a href="#bytebase.v1.GetChangelistRequest">GetChangelistRequest</a></td>
                 <td><a href="#bytebase.v1.Changelist">Changelist</a></td>
-                <td><p>Permissions required: changelists.get</p></td>
+                <td><p>Permissions required: bb.changelists.get</p></td>
               </tr>
             
               <tr>
                 <td>ListChangelists</td>
                 <td><a href="#bytebase.v1.ListChangelistsRequest">ListChangelistsRequest</a></td>
                 <td><a href="#bytebase.v1.ListChangelistsResponse">ListChangelistsResponse</a></td>
-                <td><p>Permissions required: changelists.list</p></td>
+                <td><p>Permissions required: bb.changelists.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateChangelist</td>
                 <td><a href="#bytebase.v1.UpdateChangelistRequest">UpdateChangelistRequest</a></td>
                 <td><a href="#bytebase.v1.Changelist">Changelist</a></td>
-                <td><p>Permissions required: changelists.update</p></td>
+                <td><p>Permissions required: bb.changelists.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteChangelist</td>
                 <td><a href="#bytebase.v1.DeleteChangelistRequest">DeleteChangelistRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: changelists.delete</p></td>
+                <td><p>Permissions required: bb.changelists.delete</p></td>
               </tr>
             
           </tbody>
@@ -16947,35 +16947,35 @@ The API will default to the BASIC view.</p></td>
                 <td>ListDatabaseGroups</td>
                 <td><a href="#bytebase.v1.ListDatabaseGroupsRequest">ListDatabaseGroupsRequest</a></td>
                 <td><a href="#bytebase.v1.ListDatabaseGroupsResponse">ListDatabaseGroupsResponse</a></td>
-                <td><p>Permissions required: projects.get</p></td>
+                <td><p>Permissions required: bb.projects.get</p></td>
               </tr>
             
               <tr>
                 <td>GetDatabaseGroup</td>
                 <td><a href="#bytebase.v1.GetDatabaseGroupRequest">GetDatabaseGroupRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseGroup">DatabaseGroup</a></td>
-                <td><p>Permissions required: projects.get</p></td>
+                <td><p>Permissions required: bb.projects.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateDatabaseGroup</td>
                 <td><a href="#bytebase.v1.CreateDatabaseGroupRequest">CreateDatabaseGroupRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseGroup">DatabaseGroup</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDatabaseGroup</td>
                 <td><a href="#bytebase.v1.UpdateDatabaseGroupRequest">UpdateDatabaseGroupRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseGroup">DatabaseGroup</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteDatabaseGroup</td>
                 <td><a href="#bytebase.v1.DeleteDatabaseGroupRequest">DeleteDatabaseGroupRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
           </tbody>
@@ -17387,21 +17387,21 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td>GetGroup</td>
                 <td><a href="#bytebase.v1.GetGroupRequest">GetGroupRequest</a></td>
                 <td><a href="#bytebase.v1.Group">Group</a></td>
-                <td><p>Permissions required: groups.get</p></td>
+                <td><p>Permissions required: bb.groups.get</p></td>
               </tr>
             
               <tr>
                 <td>ListGroups</td>
                 <td><a href="#bytebase.v1.ListGroupsRequest">ListGroupsRequest</a></td>
                 <td><a href="#bytebase.v1.ListGroupsResponse">ListGroupsResponse</a></td>
-                <td><p>Permissions required: groups.list</p></td>
+                <td><p>Permissions required: bb.groups.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateGroup</td>
                 <td><a href="#bytebase.v1.CreateGroupRequest">CreateGroupRequest</a></td>
                 <td><a href="#bytebase.v1.Group">Group</a></td>
-                <td><p>Permissions required: groups.create</p></td>
+                <td><p>Permissions required: bb.groups.create</p></td>
               </tr>
             
               <tr>
@@ -17410,14 +17410,14 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td><a href="#bytebase.v1.Group">Group</a></td>
                 <td><p>UpdateGroup updates the group.
 Users with &#34;bb.groups.update&#34; permission on the workspace or the group owner can access this method.
-Permissions required: groups.update</p></td>
+Permissions required: bb.groups.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteGroup</td>
                 <td><a href="#bytebase.v1.DeleteGroupRequest">DeleteGroupRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: groups.delete</p></td>
+                <td><p>Permissions required: bb.groups.delete</p></td>
               </tr>
             
           </tbody>
@@ -18336,7 +18336,7 @@ This is an optional style described in the OAuth2 RFC 6749 section 2.3.1.</p></t
                 <td>GetIdentityProvider</td>
                 <td><a href="#bytebase.v1.GetIdentityProviderRequest">GetIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.IdentityProvider">IdentityProvider</a></td>
-                <td><p>Permissions required: identityProviders.get</p></td>
+                <td><p>Permissions required: bb.identityProviders.get</p></td>
               </tr>
             
               <tr>
@@ -18350,28 +18350,28 @@ This is an optional style described in the OAuth2 RFC 6749 section 2.3.1.</p></t
                 <td>CreateIdentityProvider</td>
                 <td><a href="#bytebase.v1.CreateIdentityProviderRequest">CreateIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.IdentityProvider">IdentityProvider</a></td>
-                <td><p>Permissions required: identityProviders.create</p></td>
+                <td><p>Permissions required: bb.identityProviders.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateIdentityProvider</td>
                 <td><a href="#bytebase.v1.UpdateIdentityProviderRequest">UpdateIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.IdentityProvider">IdentityProvider</a></td>
-                <td><p>Permissions required: identityProviders.update</p></td>
+                <td><p>Permissions required: bb.identityProviders.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteIdentityProvider</td>
                 <td><a href="#bytebase.v1.DeleteIdentityProviderRequest">DeleteIdentityProviderRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: identityProviders.delete</p></td>
+                <td><p>Permissions required: bb.identityProviders.delete</p></td>
               </tr>
             
               <tr>
                 <td>TestIdentityProvider</td>
                 <td><a href="#bytebase.v1.TestIdentityProviderRequest">TestIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.TestIdentityProviderResponse">TestIdentityProviderResponse</a></td>
-                <td><p>Permissions required: identityProviders.update</p></td>
+                <td><p>Permissions required: bb.identityProviders.update</p></td>
               </tr>
             
           </tbody>
@@ -19482,35 +19482,35 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td>GetPolicy</td>
                 <td><a href="#bytebase.v1.GetPolicyRequest">GetPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.Policy">Policy</a></td>
-                <td><p>Permissions required: policies.get</p></td>
+                <td><p>Permissions required: bb.policies.get</p></td>
               </tr>
             
               <tr>
                 <td>ListPolicies</td>
                 <td><a href="#bytebase.v1.ListPoliciesRequest">ListPoliciesRequest</a></td>
                 <td><a href="#bytebase.v1.ListPoliciesResponse">ListPoliciesResponse</a></td>
-                <td><p>Permissions required: policies.list</p></td>
+                <td><p>Permissions required: bb.policies.list</p></td>
               </tr>
             
               <tr>
                 <td>CreatePolicy</td>
                 <td><a href="#bytebase.v1.CreatePolicyRequest">CreatePolicyRequest</a></td>
                 <td><a href="#bytebase.v1.Policy">Policy</a></td>
-                <td><p>Permissions required: policies.create</p></td>
+                <td><p>Permissions required: bb.policies.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdatePolicy</td>
                 <td><a href="#bytebase.v1.UpdatePolicyRequest">UpdatePolicyRequest</a></td>
                 <td><a href="#bytebase.v1.Policy">Policy</a></td>
-                <td><p>Permissions required: policies.update</p></td>
+                <td><p>Permissions required: bb.policies.update</p></td>
               </tr>
             
               <tr>
                 <td>DeletePolicy</td>
                 <td><a href="#bytebase.v1.DeletePolicyRequest">DeletePolicyRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: policies.delete</p></td>
+                <td><p>Permissions required: bb.policies.delete</p></td>
               </tr>
             
           </tbody>
@@ -21046,14 +21046,14 @@ Format: projects/{project}/plans/{plan} </p></td>
                 <td>GetPlan</td>
                 <td><a href="#bytebase.v1.GetPlanRequest">GetPlanRequest</a></td>
                 <td><a href="#bytebase.v1.Plan">Plan</a></td>
-                <td><p>Permissions required: plans.get</p></td>
+                <td><p>Permissions required: bb.plans.get</p></td>
               </tr>
             
               <tr>
                 <td>ListPlans</td>
                 <td><a href="#bytebase.v1.ListPlansRequest">ListPlansRequest</a></td>
                 <td><a href="#bytebase.v1.ListPlansResponse">ListPlansResponse</a></td>
-                <td><p>Permissions required: plans.list</p></td>
+                <td><p>Permissions required: bb.plans.list</p></td>
               </tr>
             
               <tr>
@@ -21061,14 +21061,14 @@ Format: projects/{project}/plans/{plan} </p></td>
                 <td><a href="#bytebase.v1.SearchPlansRequest">SearchPlansRequest</a></td>
                 <td><a href="#bytebase.v1.SearchPlansResponse">SearchPlansResponse</a></td>
                 <td><p>Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter &amp; query.
-Permissions required: plans.get</p></td>
+Permissions required: bb.plans.get</p></td>
               </tr>
             
               <tr>
                 <td>CreatePlan</td>
                 <td><a href="#bytebase.v1.CreatePlanRequest">CreatePlanRequest</a></td>
                 <td><a href="#bytebase.v1.Plan">Plan</a></td>
-                <td><p>Permissions required: plans.create</p></td>
+                <td><p>Permissions required: bb.plans.create</p></td>
               </tr>
             
               <tr>
@@ -21077,28 +21077,28 @@ Permissions required: plans.get</p></td>
                 <td><a href="#bytebase.v1.Plan">Plan</a></td>
                 <td><p>UpdatePlan updates the plan.
 The plan creator and the user with bb.plans.update permission on the project can update the plan.
-Permissions required: plans.update</p></td>
+Permissions required: bb.plans.update</p></td>
               </tr>
             
               <tr>
                 <td>ListPlanCheckRuns</td>
                 <td><a href="#bytebase.v1.ListPlanCheckRunsRequest">ListPlanCheckRunsRequest</a></td>
                 <td><a href="#bytebase.v1.ListPlanCheckRunsResponse">ListPlanCheckRunsResponse</a></td>
-                <td><p>Permissions required: planCheckRuns.list</p></td>
+                <td><p>Permissions required: bb.planCheckRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>RunPlanChecks</td>
                 <td><a href="#bytebase.v1.RunPlanChecksRequest">RunPlanChecksRequest</a></td>
                 <td><a href="#bytebase.v1.RunPlanChecksResponse">RunPlanChecksResponse</a></td>
-                <td><p>Permissions required: planCheckRuns.run</p></td>
+                <td><p>Permissions required: bb.planCheckRuns.run</p></td>
               </tr>
             
               <tr>
                 <td>BatchCancelPlanCheckRuns</td>
                 <td><a href="#bytebase.v1.BatchCancelPlanCheckRunsRequest">BatchCancelPlanCheckRunsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCancelPlanCheckRunsResponse">BatchCancelPlanCheckRunsResponse</a></td>
-                <td><p>Permissions required: planCheckRuns.run</p></td>
+                <td><p>Permissions required: bb.planCheckRuns.run</p></td>
               </tr>
             
           </tbody>
@@ -22248,14 +22248,14 @@ TYPE_ISSUE_CREATE represents creating an issue.</p></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
                 <td><p>GetProject retrieves a project by name.
 Users with &#34;bb.projects.get&#34; permission on the workspace or the project owner can access this method.
-Permissions required: projects.get</p></td>
+Permissions required: bb.projects.get</p></td>
               </tr>
             
               <tr>
                 <td>ListProjects</td>
                 <td><a href="#bytebase.v1.ListProjectsRequest">ListProjectsRequest</a></td>
                 <td><a href="#bytebase.v1.ListProjectsResponse">ListProjectsResponse</a></td>
-                <td><p>Permissions required: projects.list</p></td>
+                <td><p>Permissions required: bb.projects.list</p></td>
               </tr>
             
               <tr>
@@ -22269,42 +22269,42 @@ Permissions required: projects.get</p></td>
                 <td>CreateProject</td>
                 <td><a href="#bytebase.v1.CreateProjectRequest">CreateProjectRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p>Permissions required: projects.create</p></td>
+                <td><p>Permissions required: bb.projects.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateProject</td>
                 <td><a href="#bytebase.v1.UpdateProjectRequest">UpdateProjectRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteProject</td>
                 <td><a href="#bytebase.v1.DeleteProjectRequest">DeleteProjectRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: projects.delete</p></td>
+                <td><p>Permissions required: bb.projects.delete</p></td>
               </tr>
             
               <tr>
                 <td>UndeleteProject</td>
                 <td><a href="#bytebase.v1.UndeleteProjectRequest">UndeleteProjectRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p>Permissions required: projects.undelete</p></td>
+                <td><p>Permissions required: bb.projects.undelete</p></td>
               </tr>
             
               <tr>
                 <td>BatchDeleteProjects</td>
                 <td><a href="#bytebase.v1.BatchDeleteProjectsRequest">BatchDeleteProjectsRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: projects.delete</p></td>
+                <td><p>Permissions required: bb.projects.delete</p></td>
               </tr>
             
               <tr>
                 <td>GetIamPolicy</td>
                 <td><a href="#bytebase.v1.GetIamPolicyRequest">GetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p>Permissions required: projects.getIamPolicy</p></td>
+                <td><p>Permissions required: bb.projects.getIamPolicy</p></td>
               </tr>
             
               <tr>
@@ -22312,42 +22312,42 @@ Permissions required: projects.get</p></td>
                 <td><a href="#bytebase.v1.BatchGetIamPolicyRequest">BatchGetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.BatchGetIamPolicyResponse">BatchGetIamPolicyResponse</a></td>
                 <td><p>Deprecated.
-Permissions required: projects.getIamPolicy</p></td>
+Permissions required: bb.projects.getIamPolicy</p></td>
               </tr>
             
               <tr>
                 <td>SetIamPolicy</td>
                 <td><a href="#bytebase.v1.SetIamPolicyRequest">SetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p>Permissions required: projects.setIamPolicy</p></td>
+                <td><p>Permissions required: bb.projects.setIamPolicy</p></td>
               </tr>
             
               <tr>
                 <td>AddWebhook</td>
                 <td><a href="#bytebase.v1.AddWebhookRequest">AddWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
               <tr>
                 <td>UpdateWebhook</td>
                 <td><a href="#bytebase.v1.UpdateWebhookRequest">UpdateWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
               <tr>
                 <td>RemoveWebhook</td>
                 <td><a href="#bytebase.v1.RemoveWebhookRequest">RemoveWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
               <tr>
                 <td>TestWebhook</td>
                 <td><a href="#bytebase.v1.TestWebhookRequest">TestWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.TestWebhookResponse">TestWebhookResponse</a></td>
-                <td><p>Permissions required: projects.update</p></td>
+                <td><p>Permissions required: bb.projects.update</p></td>
               </tr>
             
           </tbody>
@@ -24177,14 +24177,14 @@ Pass this value in the page_token field in the subsequent call to
                 <td>Query</td>
                 <td><a href="#bytebase.v1.QueryRequest">QueryRequest</a></td>
                 <td><a href="#bytebase.v1.QueryResponse">QueryResponse</a></td>
-                <td><p>Permissions required: databases.get</p></td>
+                <td><p>Permissions required: bb.databases.get</p></td>
               </tr>
             
               <tr>
                 <td>AdminExecute</td>
                 <td><a href="#bytebase.v1.AdminExecuteRequest">AdminExecuteRequest</a> stream</td>
                 <td><a href="#bytebase.v1.AdminExecuteResponse">AdminExecuteResponse</a> stream</td>
-                <td><p>Permissions required: sql.admin</p></td>
+                <td><p>Permissions required: bb.sql.admin</p></td>
               </tr>
             
               <tr>
@@ -24199,14 +24199,14 @@ Permissions required: None</p></td>
                 <td>Export</td>
                 <td><a href="#bytebase.v1.ExportRequest">ExportRequest</a></td>
                 <td><a href="#bytebase.v1.ExportResponse">ExportResponse</a></td>
-                <td><p>Permissions required: databases.get</p></td>
+                <td><p>Permissions required: bb.databases.get</p></td>
               </tr>
             
               <tr>
                 <td>Check</td>
                 <td><a href="#bytebase.v1.CheckRequest">CheckRequest</a></td>
                 <td><a href="#bytebase.v1.CheckResponse">CheckResponse</a></td>
-                <td><p>Permissions required: databases.check</p></td>
+                <td><p>Permissions required: bb.databases.check</p></td>
               </tr>
             
               <tr>
@@ -25013,49 +25013,49 @@ Format: projects/{project}/releases/{release} </p></td>
                 <td>GetRelease</td>
                 <td><a href="#bytebase.v1.GetReleaseRequest">GetReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p>Permissions required: releases.get</p></td>
+                <td><p>Permissions required: bb.releases.get</p></td>
               </tr>
             
               <tr>
                 <td>ListReleases</td>
                 <td><a href="#bytebase.v1.ListReleasesRequest">ListReleasesRequest</a></td>
                 <td><a href="#bytebase.v1.ListReleasesResponse">ListReleasesResponse</a></td>
-                <td><p>Permissions required: releases.list</p></td>
+                <td><p>Permissions required: bb.releases.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateRelease</td>
                 <td><a href="#bytebase.v1.CreateReleaseRequest">CreateReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p>Permissions required: releases.create</p></td>
+                <td><p>Permissions required: bb.releases.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateRelease</td>
                 <td><a href="#bytebase.v1.UpdateReleaseRequest">UpdateReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p>Permissions required: releases.update</p></td>
+                <td><p>Permissions required: bb.releases.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRelease</td>
                 <td><a href="#bytebase.v1.DeleteReleaseRequest">DeleteReleaseRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: releases.delete</p></td>
+                <td><p>Permissions required: bb.releases.delete</p></td>
               </tr>
             
               <tr>
                 <td>UndeleteRelease</td>
                 <td><a href="#bytebase.v1.UndeleteReleaseRequest">UndeleteReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p>Permissions required: releases.undelete</p></td>
+                <td><p>Permissions required: bb.releases.undelete</p></td>
               </tr>
             
               <tr>
                 <td>CheckRelease</td>
                 <td><a href="#bytebase.v1.CheckReleaseRequest">CheckReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.CheckReleaseResponse">CheckReleaseResponse</a></td>
-                <td><p>Permissions required: releases.check</p></td>
+                <td><p>Permissions required: bb.releases.check</p></td>
               </tr>
             
           </tbody>
@@ -25416,35 +25416,35 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td>CreateReviewConfig</td>
                 <td><a href="#bytebase.v1.CreateReviewConfigRequest">CreateReviewConfigRequest</a></td>
                 <td><a href="#bytebase.v1.ReviewConfig">ReviewConfig</a></td>
-                <td><p>Permissions required: reviewConfigs.create</p></td>
+                <td><p>Permissions required: bb.reviewConfigs.create</p></td>
               </tr>
             
               <tr>
                 <td>ListReviewConfigs</td>
                 <td><a href="#bytebase.v1.ListReviewConfigsRequest">ListReviewConfigsRequest</a></td>
                 <td><a href="#bytebase.v1.ListReviewConfigsResponse">ListReviewConfigsResponse</a></td>
-                <td><p>Permissions required: reviewConfigs.list</p></td>
+                <td><p>Permissions required: bb.reviewConfigs.list</p></td>
               </tr>
             
               <tr>
                 <td>GetReviewConfig</td>
                 <td><a href="#bytebase.v1.GetReviewConfigRequest">GetReviewConfigRequest</a></td>
                 <td><a href="#bytebase.v1.ReviewConfig">ReviewConfig</a></td>
-                <td><p>Permissions required: reviewConfigs.get</p></td>
+                <td><p>Permissions required: bb.reviewConfigs.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateReviewConfig</td>
                 <td><a href="#bytebase.v1.UpdateReviewConfigRequest">UpdateReviewConfigRequest</a></td>
                 <td><a href="#bytebase.v1.ReviewConfig">ReviewConfig</a></td>
-                <td><p>Permissions required: reviewConfigs.update</p></td>
+                <td><p>Permissions required: bb.reviewConfigs.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteReviewConfig</td>
                 <td><a href="#bytebase.v1.DeleteReviewConfigRequest">DeleteReviewConfigRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: reviewConfigs.delete</p></td>
+                <td><p>Permissions required: bb.reviewConfigs.delete</p></td>
               </tr>
             
           </tbody>
@@ -25884,35 +25884,35 @@ projects/{project}/rollouts/{rollout}/stages/{stage}/tasks/{task}/taskRuns/{task
                 <td>ListRevisions</td>
                 <td><a href="#bytebase.v1.ListRevisionsRequest">ListRevisionsRequest</a></td>
                 <td><a href="#bytebase.v1.ListRevisionsResponse">ListRevisionsResponse</a></td>
-                <td><p>Permissions required: revisions.list</p></td>
+                <td><p>Permissions required: bb.revisions.list</p></td>
               </tr>
             
               <tr>
                 <td>GetRevision</td>
                 <td><a href="#bytebase.v1.GetRevisionRequest">GetRevisionRequest</a></td>
                 <td><a href="#bytebase.v1.Revision">Revision</a></td>
-                <td><p>Permissions required: revisions.get</p></td>
+                <td><p>Permissions required: bb.revisions.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateRevision</td>
                 <td><a href="#bytebase.v1.CreateRevisionRequest">CreateRevisionRequest</a></td>
                 <td><a href="#bytebase.v1.Revision">Revision</a></td>
-                <td><p>Permissions required: revisions.create</p></td>
+                <td><p>Permissions required: bb.revisions.create</p></td>
               </tr>
             
               <tr>
                 <td>BatchCreateRevisions</td>
                 <td><a href="#bytebase.v1.BatchCreateRevisionsRequest">BatchCreateRevisionsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCreateRevisionsResponse">BatchCreateRevisionsResponse</a></td>
-                <td><p>Permissions required: revisions.create</p></td>
+                <td><p>Permissions required: bb.revisions.create</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRevision</td>
                 <td><a href="#bytebase.v1.DeleteRevisionRequest">DeleteRevisionRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: revisions.delete</p></td>
+                <td><p>Permissions required: bb.revisions.delete</p></td>
               </tr>
             
           </tbody>
@@ -26368,35 +26368,35 @@ Format: risks/{risk} </p></td>
                 <td>ListRisks</td>
                 <td><a href="#bytebase.v1.ListRisksRequest">ListRisksRequest</a></td>
                 <td><a href="#bytebase.v1.ListRisksResponse">ListRisksResponse</a></td>
-                <td><p>Permissions required: risks.list</p></td>
+                <td><p>Permissions required: bb.risks.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateRisk</td>
                 <td><a href="#bytebase.v1.CreateRiskRequest">CreateRiskRequest</a></td>
                 <td><a href="#bytebase.v1.Risk">Risk</a></td>
-                <td><p>Permissions required: risks.create</p></td>
+                <td><p>Permissions required: bb.risks.create</p></td>
               </tr>
             
               <tr>
                 <td>GetRisk</td>
                 <td><a href="#bytebase.v1.GetRiskRequest">GetRiskRequest</a></td>
                 <td><a href="#bytebase.v1.Risk">Risk</a></td>
-                <td><p>Permissions required: risks.list</p></td>
+                <td><p>Permissions required: bb.risks.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateRisk</td>
                 <td><a href="#bytebase.v1.UpdateRiskRequest">UpdateRiskRequest</a></td>
                 <td><a href="#bytebase.v1.Risk">Risk</a></td>
-                <td><p>Permissions required: risks.update</p></td>
+                <td><p>Permissions required: bb.risks.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRisk</td>
                 <td><a href="#bytebase.v1.DeleteRiskRequest">DeleteRiskRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: risks.delete</p></td>
+                <td><p>Permissions required: bb.risks.delete</p></td>
               </tr>
             
           </tbody>
@@ -26772,35 +26772,35 @@ If this field is omitted, there are no subsequent pages. </p></td>
                 <td>ListRoles</td>
                 <td><a href="#bytebase.v1.ListRolesRequest">ListRolesRequest</a></td>
                 <td><a href="#bytebase.v1.ListRolesResponse">ListRolesResponse</a></td>
-                <td><p>Permissions required: roles.list</p></td>
+                <td><p>Permissions required: bb.roles.list</p></td>
               </tr>
             
               <tr>
                 <td>GetRole</td>
                 <td><a href="#bytebase.v1.GetRoleRequest">GetRoleRequest</a></td>
                 <td><a href="#bytebase.v1.Role">Role</a></td>
-                <td><p>Permissions required: roles.get</p></td>
+                <td><p>Permissions required: bb.roles.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateRole</td>
                 <td><a href="#bytebase.v1.CreateRoleRequest">CreateRoleRequest</a></td>
                 <td><a href="#bytebase.v1.Role">Role</a></td>
-                <td><p>Permissions required: roles.create</p></td>
+                <td><p>Permissions required: bb.roles.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateRole</td>
                 <td><a href="#bytebase.v1.UpdateRoleRequest">UpdateRoleRequest</a></td>
                 <td><a href="#bytebase.v1.Role">Role</a></td>
-                <td><p>Permissions required: roles.update</p></td>
+                <td><p>Permissions required: bb.roles.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRole</td>
                 <td><a href="#bytebase.v1.DeleteRoleRequest">DeleteRoleRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p>Permissions required: roles.delete</p></td>
+                <td><p>Permissions required: bb.roles.delete</p></td>
               </tr>
             
           </tbody>
@@ -29062,93 +29062,84 @@ Format: instances/{instance}/databases/{database} </p></td>
                 <td>GetRollout</td>
                 <td><a href="#bytebase.v1.GetRolloutRequest">GetRolloutRequest</a></td>
                 <td><a href="#bytebase.v1.Rollout">Rollout</a></td>
-                <td><p>Permissions required: rollouts.get</p></td>
+                <td><p>Permissions required: bb.rollouts.get</p></td>
               </tr>
             
               <tr>
                 <td>ListRollouts</td>
                 <td><a href="#bytebase.v1.ListRolloutsRequest">ListRolloutsRequest</a></td>
                 <td><a href="#bytebase.v1.ListRolloutsResponse">ListRolloutsResponse</a></td>
-                <td><p>Permissions required: rollouts.list</p></td>
+                <td><p>Permissions required: bb.rollouts.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateRollout</td>
                 <td><a href="#bytebase.v1.CreateRolloutRequest">CreateRolloutRequest</a></td>
                 <td><a href="#bytebase.v1.Rollout">Rollout</a></td>
-                <td><p>CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-Permissions required: rollouts.create</p></td>
+                <td><p>Permissions required: bb.rollouts.create</p></td>
               </tr>
             
               <tr>
                 <td>PreviewRollout</td>
                 <td><a href="#bytebase.v1.PreviewRolloutRequest">PreviewRolloutRequest</a></td>
                 <td><a href="#bytebase.v1.Rollout">Rollout</a></td>
-                <td><p>Permissions required: rollouts.preview</p></td>
+                <td><p>Permissions required: bb.rollouts.preview</p></td>
               </tr>
             
               <tr>
                 <td>ListTaskRuns</td>
                 <td><a href="#bytebase.v1.ListTaskRunsRequest">ListTaskRunsRequest</a></td>
                 <td><a href="#bytebase.v1.ListTaskRunsResponse">ListTaskRunsResponse</a></td>
-                <td><p>Permissions required: taskRuns.list</p></td>
+                <td><p>Permissions required: bb.taskRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>GetTaskRun</td>
                 <td><a href="#bytebase.v1.GetTaskRunRequest">GetTaskRunRequest</a></td>
                 <td><a href="#bytebase.v1.TaskRun">TaskRun</a></td>
-                <td><p>Permissions required: taskRuns.list</p></td>
+                <td><p>Permissions required: bb.taskRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>GetTaskRunLog</td>
                 <td><a href="#bytebase.v1.GetTaskRunLogRequest">GetTaskRunLogRequest</a></td>
                 <td><a href="#bytebase.v1.TaskRunLog">TaskRunLog</a></td>
-                <td><p>Permissions required: taskRuns.list</p></td>
+                <td><p>Permissions required: bb.taskRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>GetTaskRunSession</td>
                 <td><a href="#bytebase.v1.GetTaskRunSessionRequest">GetTaskRunSessionRequest</a></td>
                 <td><a href="#bytebase.v1.TaskRunSession">TaskRunSession</a></td>
-                <td><p>Permissions required: taskRuns.list</p></td>
+                <td><p>Permissions required: bb.taskRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>BatchRunTasks</td>
                 <td><a href="#bytebase.v1.BatchRunTasksRequest">BatchRunTasksRequest</a></td>
                 <td><a href="#bytebase.v1.BatchRunTasksResponse">BatchRunTasksResponse</a></td>
-                <td><p>BatchRunTasks creates task runs for the specified tasks.
-DataExport issue only allows the creator to run the task.
-Users with &#34;bb.taskRuns.create&#34; permission can run the task, e.g. Workspace Admin and DBA.
-Follow role-based rollout policy for the environment.
-Permissions required: None</p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>BatchSkipTasks</td>
                 <td><a href="#bytebase.v1.BatchSkipTasksRequest">BatchSkipTasksRequest</a></td>
                 <td><a href="#bytebase.v1.BatchSkipTasksResponse">BatchSkipTasksResponse</a></td>
-                <td><p>BatchSkipTasks skips the specified tasks.
-The access is the same as BatchRunTasks().
-Permissions required: None</p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>BatchCancelTaskRuns</td>
                 <td><a href="#bytebase.v1.BatchCancelTaskRunsRequest">BatchCancelTaskRunsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCancelTaskRunsResponse">BatchCancelTaskRunsResponse</a></td>
-                <td><p>BatchCancelTaskRuns cancels the specified task runs in batch.
-The access is the same as BatchRunTasks().
-Permissions required: None</p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>PreviewTaskRunRollback</td>
                 <td><a href="#bytebase.v1.PreviewTaskRunRollbackRequest">PreviewTaskRunRollbackRequest</a></td>
                 <td><a href="#bytebase.v1.PreviewTaskRunRollbackResponse">PreviewTaskRunRollbackResponse</a></td>
-                <td><p>Permissions required: taskRuns.list</p></td>
+                <td><p>Permissions required: bb.taskRuns.list</p></td>
               </tr>
             
           </tbody>
@@ -29641,28 +29632,28 @@ Only support update the following fields for now:
                 <td>CreateSheet</td>
                 <td><a href="#bytebase.v1.CreateSheetRequest">CreateSheetRequest</a></td>
                 <td><a href="#bytebase.v1.Sheet">Sheet</a></td>
-                <td><p>Permissions required: sheets.create</p></td>
+                <td><p>Permissions required: bb.sheets.create</p></td>
               </tr>
             
               <tr>
                 <td>BatchCreateSheets</td>
                 <td><a href="#bytebase.v1.BatchCreateSheetsRequest">BatchCreateSheetsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCreateSheetsResponse">BatchCreateSheetsResponse</a></td>
-                <td><p>Permissions required: sheets.create</p></td>
+                <td><p>Permissions required: bb.sheets.create</p></td>
               </tr>
             
               <tr>
                 <td>GetSheet</td>
                 <td><a href="#bytebase.v1.GetSheetRequest">GetSheetRequest</a></td>
                 <td><a href="#bytebase.v1.Sheet">Sheet</a></td>
-                <td><p>Permissions required: sheets.get</p></td>
+                <td><p>Permissions required: bb.sheets.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateSheet</td>
                 <td><a href="#bytebase.v1.UpdateSheetRequest">UpdateSheetRequest</a></td>
                 <td><a href="#bytebase.v1.Sheet">Sheet</a></td>
-                <td><p>Permissions required: sheets.update</p></td>
+                <td><p>Permissions required: bb.sheets.update</p></td>
               </tr>
             
           </tbody>
@@ -30426,7 +30417,7 @@ Permissions required: None</p></td>
                 <td>UpdateSubscription</td>
                 <td><a href="#bytebase.v1.UpdateSubscriptionRequest">UpdateSubscriptionRequest</a></td>
                 <td><a href="#bytebase.v1.Subscription">Subscription</a></td>
-                <td><p>Permissions required: settings.set</p></td>
+                <td><p>Permissions required: bb.settings.set</p></td>
               </tr>
             
           </tbody>
@@ -31075,14 +31066,14 @@ Permissions required: None</p></td>
                 <td>GetIamPolicy</td>
                 <td><a href="#bytebase.v1.GetIamPolicyRequest">GetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p>Permissions required: workspaces.getIamPolicy</p></td>
+                <td><p>Permissions required: bb.workspaces.getIamPolicy</p></td>
               </tr>
             
               <tr>
                 <td>SetIamPolicy</td>
                 <td><a href="#bytebase.v1.SetIamPolicyRequest">SetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p>Permissions required: workspaces.setIamPolicy</p></td>
+                <td><p>Permissions required: bb.workspaces.setIamPolicy</p></td>
               </tr>
             
           </tbody>

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -3770,14 +3770,14 @@ Format: instances/{instance}/databases/{database}/catalog </p></td>
                 <td>GetDatabaseCatalog</td>
                 <td><a href="#bytebase.v1.GetDatabaseCatalogRequest">GetDatabaseCatalogRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseCatalog">DatabaseCatalog</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databaseCatalogs.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDatabaseCatalog</td>
                 <td><a href="#bytebase.v1.UpdateDatabaseCatalogRequest">UpdateDatabaseCatalogRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseCatalog">DatabaseCatalog</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databaseCatalogs.update</p></td>
               </tr>
             
           </tbody>
@@ -4024,14 +4024,14 @@ If this field is omitted, there are no subsequent pages. </p></td>
                 <td>GetInstanceRole</td>
                 <td><a href="#bytebase.v1.GetInstanceRoleRequest">GetInstanceRoleRequest</a></td>
                 <td><a href="#bytebase.v1.InstanceRole">InstanceRole</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instanceRoles.get</p></td>
               </tr>
             
               <tr>
                 <td>ListInstanceRoles</td>
                 <td><a href="#bytebase.v1.ListInstanceRolesRequest">ListInstanceRolesRequest</a></td>
                 <td><a href="#bytebase.v1.ListInstanceRolesResponse">ListInstanceRolesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instanceRoles.get</p></td>
               </tr>
             
           </tbody>
@@ -5655,91 +5655,91 @@ Format: instances/{instance} </p></td>
                 <td>GetInstance</td>
                 <td><a href="#bytebase.v1.GetInstanceRequest">GetInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.get</p></td>
               </tr>
             
               <tr>
                 <td>ListInstances</td>
                 <td><a href="#bytebase.v1.ListInstancesRequest">ListInstancesRequest</a></td>
                 <td><a href="#bytebase.v1.ListInstancesResponse">ListInstancesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateInstance</td>
                 <td><a href="#bytebase.v1.CreateInstanceRequest">CreateInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateInstance</td>
                 <td><a href="#bytebase.v1.UpdateInstanceRequest">UpdateInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteInstance</td>
                 <td><a href="#bytebase.v1.DeleteInstanceRequest">DeleteInstanceRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.delete</p></td>
               </tr>
             
               <tr>
                 <td>UndeleteInstance</td>
                 <td><a href="#bytebase.v1.UndeleteInstanceRequest">UndeleteInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.undelete</p></td>
               </tr>
             
               <tr>
                 <td>SyncInstance</td>
                 <td><a href="#bytebase.v1.SyncInstanceRequest">SyncInstanceRequest</a></td>
                 <td><a href="#bytebase.v1.SyncInstanceResponse">SyncInstanceResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.sync</p></td>
               </tr>
             
               <tr>
                 <td>ListInstanceDatabase</td>
                 <td><a href="#bytebase.v1.ListInstanceDatabaseRequest">ListInstanceDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.ListInstanceDatabaseResponse">ListInstanceDatabaseResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.get</p></td>
               </tr>
             
               <tr>
                 <td>BatchSyncInstances</td>
                 <td><a href="#bytebase.v1.BatchSyncInstancesRequest">BatchSyncInstancesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchSyncInstancesResponse">BatchSyncInstancesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.sync</p></td>
               </tr>
             
               <tr>
                 <td>BatchUpdateInstances</td>
                 <td><a href="#bytebase.v1.BatchUpdateInstancesRequest">BatchUpdateInstancesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchUpdateInstancesResponse">BatchUpdateInstancesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.update</p></td>
               </tr>
             
               <tr>
                 <td>AddDataSource</td>
                 <td><a href="#bytebase.v1.AddDataSourceRequest">AddDataSourceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.update</p></td>
               </tr>
             
               <tr>
                 <td>RemoveDataSource</td>
                 <td><a href="#bytebase.v1.RemoveDataSourceRequest">RemoveDataSourceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.update</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDataSource</td>
                 <td><a href="#bytebase.v1.UpdateDataSourceRequest">UpdateDataSourceRequest</a></td>
                 <td><a href="#bytebase.v1.Instance">Instance</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: instances.update</p></td>
               </tr>
             
           </tbody>
@@ -9588,112 +9588,112 @@ The API will default to the BASIC view.</p></td>
                 <td>GetDatabase</td>
                 <td><a href="#bytebase.v1.GetDatabaseRequest">GetDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.Database">Database</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.get</p></td>
               </tr>
             
               <tr>
                 <td>BatchGetDatabases</td>
                 <td><a href="#bytebase.v1.BatchGetDatabasesRequest">BatchGetDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchGetDatabasesResponse">BatchGetDatabasesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.get</p></td>
               </tr>
             
               <tr>
                 <td>ListDatabases</td>
                 <td><a href="#bytebase.v1.ListDatabasesRequest">ListDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.ListDatabasesResponse">ListDatabasesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDatabase</td>
                 <td><a href="#bytebase.v1.UpdateDatabaseRequest">UpdateDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.Database">Database</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.update</p></td>
               </tr>
             
               <tr>
                 <td>BatchUpdateDatabases</td>
                 <td><a href="#bytebase.v1.BatchUpdateDatabasesRequest">BatchUpdateDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchUpdateDatabasesResponse">BatchUpdateDatabasesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.update</p></td>
               </tr>
             
               <tr>
                 <td>SyncDatabase</td>
                 <td><a href="#bytebase.v1.SyncDatabaseRequest">SyncDatabaseRequest</a></td>
                 <td><a href="#bytebase.v1.SyncDatabaseResponse">SyncDatabaseResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.sync</p></td>
               </tr>
             
               <tr>
                 <td>BatchSyncDatabases</td>
                 <td><a href="#bytebase.v1.BatchSyncDatabasesRequest">BatchSyncDatabasesRequest</a></td>
                 <td><a href="#bytebase.v1.BatchSyncDatabasesResponse">BatchSyncDatabasesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.sync</p></td>
               </tr>
             
               <tr>
                 <td>GetDatabaseMetadata</td>
                 <td><a href="#bytebase.v1.GetDatabaseMetadataRequest">GetDatabaseMetadataRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseMetadata">DatabaseMetadata</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.getSchema</p></td>
               </tr>
             
               <tr>
                 <td>GetDatabaseSchema</td>
                 <td><a href="#bytebase.v1.GetDatabaseSchemaRequest">GetDatabaseSchemaRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseSchema">DatabaseSchema</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.getSchema</p></td>
               </tr>
             
               <tr>
                 <td>DiffSchema</td>
                 <td><a href="#bytebase.v1.DiffSchemaRequest">DiffSchemaRequest</a></td>
                 <td><a href="#bytebase.v1.DiffSchemaResponse">DiffSchemaResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.get</p></td>
               </tr>
             
               <tr>
                 <td>ListSecrets</td>
                 <td><a href="#bytebase.v1.ListSecretsRequest">ListSecretsRequest</a></td>
                 <td><a href="#bytebase.v1.ListSecretsResponse">ListSecretsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databaseSecrets.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateSecret</td>
                 <td><a href="#bytebase.v1.UpdateSecretRequest">UpdateSecretRequest</a></td>
                 <td><a href="#bytebase.v1.Secret">Secret</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databaseSecrets.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteSecret</td>
                 <td><a href="#bytebase.v1.DeleteSecretRequest">DeleteSecretRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databaseSecrets.delete</p></td>
               </tr>
             
               <tr>
                 <td>ListChangelogs</td>
                 <td><a href="#bytebase.v1.ListChangelogsRequest">ListChangelogsRequest</a></td>
                 <td><a href="#bytebase.v1.ListChangelogsResponse">ListChangelogsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: changelogs.list</p></td>
               </tr>
             
               <tr>
                 <td>GetChangelog</td>
                 <td><a href="#bytebase.v1.GetChangelogRequest">GetChangelogRequest</a></td>
                 <td><a href="#bytebase.v1.Changelog">Changelog</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: changelogs.get</p></td>
               </tr>
             
               <tr>
                 <td>GetSchemaString</td>
                 <td><a href="#bytebase.v1.GetSchemaStringRequest">GetSchemaStringRequest</a></td>
                 <td><a href="#bytebase.v1.GetSchemaStringResponse">GetSchemaStringResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.getSchema</p></td>
               </tr>
             
           </tbody>
@@ -11570,63 +11570,64 @@ Format: projects/{project}/issues/{issue} </p></td>
                 <td>GetIssue</td>
                 <td><a href="#bytebase.v1.GetIssueRequest">GetIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issues.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateIssue</td>
                 <td><a href="#bytebase.v1.CreateIssueRequest">CreateIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issues.create</p></td>
               </tr>
             
               <tr>
                 <td>ListIssues</td>
                 <td><a href="#bytebase.v1.ListIssuesRequest">ListIssuesRequest</a></td>
                 <td><a href="#bytebase.v1.ListIssuesResponse">ListIssuesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issues.list</p></td>
               </tr>
             
               <tr>
                 <td>SearchIssues</td>
                 <td><a href="#bytebase.v1.SearchIssuesRequest">SearchIssuesRequest</a></td>
                 <td><a href="#bytebase.v1.SearchIssuesResponse">SearchIssuesResponse</a></td>
-                <td><p>Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter &amp; query.</p></td>
+                <td><p>Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter &amp; query.
+Permissions required: issues.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateIssue</td>
                 <td><a href="#bytebase.v1.UpdateIssueRequest">UpdateIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issues.update</p></td>
               </tr>
             
               <tr>
                 <td>ListIssueComments</td>
                 <td><a href="#bytebase.v1.ListIssueCommentsRequest">ListIssueCommentsRequest</a></td>
                 <td><a href="#bytebase.v1.ListIssueCommentsResponse">ListIssueCommentsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issueComments.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateIssueComment</td>
                 <td><a href="#bytebase.v1.CreateIssueCommentRequest">CreateIssueCommentRequest</a></td>
                 <td><a href="#bytebase.v1.IssueComment">IssueComment</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issueComments.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateIssueComment</td>
                 <td><a href="#bytebase.v1.UpdateIssueCommentRequest">UpdateIssueCommentRequest</a></td>
                 <td><a href="#bytebase.v1.IssueComment">IssueComment</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issueComments.update</p></td>
               </tr>
             
               <tr>
                 <td>BatchUpdateIssuesStatus</td>
                 <td><a href="#bytebase.v1.BatchUpdateIssuesStatusRequest">BatchUpdateIssuesStatusRequest</a></td>
                 <td><a href="#bytebase.v1.BatchUpdateIssuesStatusResponse">BatchUpdateIssuesStatusResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: issues.update</p></td>
               </tr>
             
               <tr>
@@ -11634,7 +11635,8 @@ Format: projects/{project}/issues/{issue} </p></td>
                 <td><a href="#bytebase.v1.ApproveIssueRequest">ApproveIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
                 <td><p>ApproveIssue approves the issue.
-The access is based on approval flow.</p></td>
+The access is based on approval flow.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -11642,7 +11644,8 @@ The access is based on approval flow.</p></td>
                 <td><a href="#bytebase.v1.RejectIssueRequest">RejectIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
                 <td><p>RejectIssue rejects the issue.
-The access is based on approval flow.</p></td>
+The access is based on approval flow.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -11650,7 +11653,8 @@ The access is based on approval flow.</p></td>
                 <td><a href="#bytebase.v1.RequestIssueRequest">RequestIssueRequest</a></td>
                 <td><a href="#bytebase.v1.Issue">Issue</a></td>
                 <td><p>RequestIssue requests the issue.
-The access is based on approval flow.</p></td>
+The access is based on approval flow.
+Permissions required: None</p></td>
               </tr>
             
           </tbody>
@@ -13743,21 +13747,21 @@ Default to this mode.</p></td>
                 <td>ListSettings</td>
                 <td><a href="#bytebase.v1.ListSettingsRequest">ListSettingsRequest</a></td>
                 <td><a href="#bytebase.v1.ListSettingsResponse">ListSettingsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: settings.list</p></td>
               </tr>
             
               <tr>
                 <td>GetSetting</td>
                 <td><a href="#bytebase.v1.GetSettingRequest">GetSettingRequest</a></td>
                 <td><a href="#bytebase.v1.Setting">Setting</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: settings.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateSetting</td>
                 <td><a href="#bytebase.v1.UpdateSettingRequest">UpdateSettingRequest</a></td>
                 <td><a href="#bytebase.v1.Setting">Setting</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: settings.set</p></td>
               </tr>
             
           </tbody>
@@ -14325,7 +14329,8 @@ Could be empty. </p></td>
                 <td><a href="#bytebase.v1.GetUserRequest">GetUserRequest</a></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
                 <td><p>Get the user.
-Any authenticated user can get the user.</p></td>
+Any authenticated user can get the user.
+Permissions required: users.get</p></td>
               </tr>
             
               <tr>
@@ -14333,14 +14338,16 @@ Any authenticated user can get the user.</p></td>
                 <td><a href="#bytebase.v1.BatchGetUsersRequest">BatchGetUsersRequest</a></td>
                 <td><a href="#bytebase.v1.BatchGetUsersResponse">BatchGetUsersResponse</a></td>
                 <td><p>Get the users in batch.
-Any authenticated user can batch get users.</p></td>
+Any authenticated user can batch get users.
+Permissions required: users.get</p></td>
               </tr>
             
               <tr>
                 <td>GetCurrentUser</td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
-                <td><p>Get the current authenticated user.</p></td>
+                <td><p>Get the current authenticated user.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -14348,7 +14355,8 @@ Any authenticated user can batch get users.</p></td>
                 <td><a href="#bytebase.v1.ListUsersRequest">ListUsersRequest</a></td>
                 <td><a href="#bytebase.v1.ListUsersResponse">ListUsersResponse</a></td>
                 <td><p>List all users.
-Any authenticated user can list users.</p></td>
+Any authenticated user can list users.
+Permissions required: users.list</p></td>
               </tr>
             
               <tr>
@@ -14357,14 +14365,16 @@ Any authenticated user can list users.</p></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
                 <td><p>Create a user.
 When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
-Otherwise, any unauthenticated user can create a user.</p></td>
+Otherwise, any unauthenticated user can create a user.
+Permissions required: users.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateUser</td>
                 <td><a href="#bytebase.v1.UpdateUserRequest">UpdateUserRequest</a></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
-                <td><p>Only the user itself and the user with bb.users.update permission on the workspace can update the user.</p></td>
+                <td><p>Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+Permissions required: users.update</p></td>
               </tr>
             
               <tr>
@@ -14372,14 +14382,16 @@ Otherwise, any unauthenticated user can create a user.</p></td>
                 <td><a href="#bytebase.v1.DeleteUserRequest">DeleteUserRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
                 <td><p>Only the user with bb.users.delete permission on the workspace can delete the user.
-The last remaining workspace admin cannot be deleted.</p></td>
+The last remaining workspace admin cannot be deleted.
+Permissions required: users.delete</p></td>
               </tr>
             
               <tr>
                 <td>UndeleteUser</td>
                 <td><a href="#bytebase.v1.UndeleteUserRequest">UndeleteUserRequest</a></td>
                 <td><a href="#bytebase.v1.User">User</a></td>
-                <td><p>Only the user with bb.users.undelete permission on the workspace can undelete the user.</p></td>
+                <td><p>Only the user with bb.users.undelete permission on the workspace can undelete the user.
+Permissions required: users.undelete</p></td>
               </tr>
             
           </tbody>
@@ -14802,35 +14814,35 @@ The last remaining workspace admin cannot be deleted.</p></td>
                 <td>GetActuatorInfo</td>
                 <td><a href="#bytebase.v1.GetActuatorInfoRequest">GetActuatorInfoRequest</a></td>
                 <td><a href="#bytebase.v1.ActuatorInfo">ActuatorInfo</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>UpdateActuatorInfo</td>
                 <td><a href="#bytebase.v1.UpdateActuatorInfoRequest">UpdateActuatorInfoRequest</a></td>
                 <td><a href="#bytebase.v1.ActuatorInfo">ActuatorInfo</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: settings.set</p></td>
               </tr>
             
               <tr>
                 <td>SetupSample</td>
                 <td><a href="#bytebase.v1.SetupSampleRequest">SetupSampleRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.create</p></td>
               </tr>
             
               <tr>
                 <td>DeleteCache</td>
                 <td><a href="#bytebase.v1.DeleteCacheRequest">DeleteCacheRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>GetResourcePackage</td>
                 <td><a href="#bytebase.v1.GetResourcePackageRequest">GetResourcePackageRequest</a></td>
                 <td><a href="#bytebase.v1.ResourcePackage">ResourcePackage</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
           </tbody>
@@ -15633,14 +15645,14 @@ to retrieve the next page of log entities. </p></td>
                 <td>SearchAuditLogs</td>
                 <td><a href="#bytebase.v1.SearchAuditLogsRequest">SearchAuditLogsRequest</a></td>
                 <td><a href="#bytebase.v1.SearchAuditLogsResponse">SearchAuditLogsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>ExportAuditLogs</td>
                 <td><a href="#bytebase.v1.ExportAuditLogsRequest">ExportAuditLogsRequest</a></td>
                 <td><a href="#bytebase.v1.ExportAuditLogsResponse">ExportAuditLogsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: auditLogs.export</p></td>
               </tr>
             
           </tbody>
@@ -15913,14 +15925,14 @@ Format: idps/{idp} </p></td>
                 <td>Login</td>
                 <td><a href="#bytebase.v1.LoginRequest">LoginRequest</a></td>
                 <td><a href="#bytebase.v1.LoginResponse">LoginResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>Logout</td>
                 <td><a href="#bytebase.v1.LogoutRequest">LogoutRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
           </tbody>
@@ -16087,14 +16099,14 @@ Format: idps/{idp} </p></td>
                 <td>BatchParse</td>
                 <td><a href="#bytebase.v1.BatchParseRequest">BatchParseRequest</a></td>
                 <td><a href="#bytebase.v1.BatchParseResponse">BatchParseResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>BatchDeparse</td>
                 <td><a href="#bytebase.v1.BatchDeparseRequest">BatchDeparseRequest</a></td>
                 <td><a href="#bytebase.v1.BatchDeparseResponse">BatchDeparseResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
           </tbody>
@@ -16460,35 +16472,35 @@ Format: projects/{project}/changelists/{changelist} </p></td>
                 <td>CreateChangelist</td>
                 <td><a href="#bytebase.v1.CreateChangelistRequest">CreateChangelistRequest</a></td>
                 <td><a href="#bytebase.v1.Changelist">Changelist</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: changelists.create</p></td>
               </tr>
             
               <tr>
                 <td>GetChangelist</td>
                 <td><a href="#bytebase.v1.GetChangelistRequest">GetChangelistRequest</a></td>
                 <td><a href="#bytebase.v1.Changelist">Changelist</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: changelists.get</p></td>
               </tr>
             
               <tr>
                 <td>ListChangelists</td>
                 <td><a href="#bytebase.v1.ListChangelistsRequest">ListChangelistsRequest</a></td>
                 <td><a href="#bytebase.v1.ListChangelistsResponse">ListChangelistsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: changelists.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateChangelist</td>
                 <td><a href="#bytebase.v1.UpdateChangelistRequest">UpdateChangelistRequest</a></td>
                 <td><a href="#bytebase.v1.Changelist">Changelist</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: changelists.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteChangelist</td>
                 <td><a href="#bytebase.v1.DeleteChangelistRequest">DeleteChangelistRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: changelists.delete</p></td>
               </tr>
             
           </tbody>
@@ -16935,35 +16947,35 @@ The API will default to the BASIC view.</p></td>
                 <td>ListDatabaseGroups</td>
                 <td><a href="#bytebase.v1.ListDatabaseGroupsRequest">ListDatabaseGroupsRequest</a></td>
                 <td><a href="#bytebase.v1.ListDatabaseGroupsResponse">ListDatabaseGroupsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.get</p></td>
               </tr>
             
               <tr>
                 <td>GetDatabaseGroup</td>
                 <td><a href="#bytebase.v1.GetDatabaseGroupRequest">GetDatabaseGroupRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseGroup">DatabaseGroup</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateDatabaseGroup</td>
                 <td><a href="#bytebase.v1.CreateDatabaseGroupRequest">CreateDatabaseGroupRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseGroup">DatabaseGroup</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
               <tr>
                 <td>UpdateDatabaseGroup</td>
                 <td><a href="#bytebase.v1.UpdateDatabaseGroupRequest">UpdateDatabaseGroupRequest</a></td>
                 <td><a href="#bytebase.v1.DatabaseGroup">DatabaseGroup</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteDatabaseGroup</td>
                 <td><a href="#bytebase.v1.DeleteDatabaseGroupRequest">DeleteDatabaseGroupRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
           </tbody>
@@ -17375,21 +17387,21 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td>GetGroup</td>
                 <td><a href="#bytebase.v1.GetGroupRequest">GetGroupRequest</a></td>
                 <td><a href="#bytebase.v1.Group">Group</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: groups.get</p></td>
               </tr>
             
               <tr>
                 <td>ListGroups</td>
                 <td><a href="#bytebase.v1.ListGroupsRequest">ListGroupsRequest</a></td>
                 <td><a href="#bytebase.v1.ListGroupsResponse">ListGroupsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: groups.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateGroup</td>
                 <td><a href="#bytebase.v1.CreateGroupRequest">CreateGroupRequest</a></td>
                 <td><a href="#bytebase.v1.Group">Group</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: groups.create</p></td>
               </tr>
             
               <tr>
@@ -17397,14 +17409,15 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td><a href="#bytebase.v1.UpdateGroupRequest">UpdateGroupRequest</a></td>
                 <td><a href="#bytebase.v1.Group">Group</a></td>
                 <td><p>UpdateGroup updates the group.
-Users with &#34;bb.groups.update&#34; permission on the workspace or the group owner can access this method.</p></td>
+Users with &#34;bb.groups.update&#34; permission on the workspace or the group owner can access this method.
+Permissions required: groups.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteGroup</td>
                 <td><a href="#bytebase.v1.DeleteGroupRequest">DeleteGroupRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: groups.delete</p></td>
               </tr>
             
           </tbody>
@@ -18323,42 +18336,42 @@ This is an optional style described in the OAuth2 RFC 6749 section 2.3.1.</p></t
                 <td>GetIdentityProvider</td>
                 <td><a href="#bytebase.v1.GetIdentityProviderRequest">GetIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.IdentityProvider">IdentityProvider</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: identityProviders.get</p></td>
               </tr>
             
               <tr>
                 <td>ListIdentityProviders</td>
                 <td><a href="#bytebase.v1.ListIdentityProvidersRequest">ListIdentityProvidersRequest</a></td>
                 <td><a href="#bytebase.v1.ListIdentityProvidersResponse">ListIdentityProvidersResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>CreateIdentityProvider</td>
                 <td><a href="#bytebase.v1.CreateIdentityProviderRequest">CreateIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.IdentityProvider">IdentityProvider</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: identityProviders.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateIdentityProvider</td>
                 <td><a href="#bytebase.v1.UpdateIdentityProviderRequest">UpdateIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.IdentityProvider">IdentityProvider</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: identityProviders.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteIdentityProvider</td>
                 <td><a href="#bytebase.v1.DeleteIdentityProviderRequest">DeleteIdentityProviderRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: identityProviders.delete</p></td>
               </tr>
             
               <tr>
                 <td>TestIdentityProvider</td>
                 <td><a href="#bytebase.v1.TestIdentityProviderRequest">TestIdentityProviderRequest</a></td>
                 <td><a href="#bytebase.v1.TestIdentityProviderResponse">TestIdentityProviderResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: identityProviders.update</p></td>
               </tr>
             
           </tbody>
@@ -19469,35 +19482,35 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td>GetPolicy</td>
                 <td><a href="#bytebase.v1.GetPolicyRequest">GetPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.Policy">Policy</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: policies.get</p></td>
               </tr>
             
               <tr>
                 <td>ListPolicies</td>
                 <td><a href="#bytebase.v1.ListPoliciesRequest">ListPoliciesRequest</a></td>
                 <td><a href="#bytebase.v1.ListPoliciesResponse">ListPoliciesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: policies.list</p></td>
               </tr>
             
               <tr>
                 <td>CreatePolicy</td>
                 <td><a href="#bytebase.v1.CreatePolicyRequest">CreatePolicyRequest</a></td>
                 <td><a href="#bytebase.v1.Policy">Policy</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: policies.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdatePolicy</td>
                 <td><a href="#bytebase.v1.UpdatePolicyRequest">UpdatePolicyRequest</a></td>
                 <td><a href="#bytebase.v1.Policy">Policy</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: policies.update</p></td>
               </tr>
             
               <tr>
                 <td>DeletePolicy</td>
                 <td><a href="#bytebase.v1.DeletePolicyRequest">DeletePolicyRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: policies.delete</p></td>
               </tr>
             
           </tbody>
@@ -21033,28 +21046,29 @@ Format: projects/{project}/plans/{plan} </p></td>
                 <td>GetPlan</td>
                 <td><a href="#bytebase.v1.GetPlanRequest">GetPlanRequest</a></td>
                 <td><a href="#bytebase.v1.Plan">Plan</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: plans.get</p></td>
               </tr>
             
               <tr>
                 <td>ListPlans</td>
                 <td><a href="#bytebase.v1.ListPlansRequest">ListPlansRequest</a></td>
                 <td><a href="#bytebase.v1.ListPlansResponse">ListPlansResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: plans.list</p></td>
               </tr>
             
               <tr>
                 <td>SearchPlans</td>
                 <td><a href="#bytebase.v1.SearchPlansRequest">SearchPlansRequest</a></td>
                 <td><a href="#bytebase.v1.SearchPlansResponse">SearchPlansResponse</a></td>
-                <td><p>Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter &amp; query.</p></td>
+                <td><p>Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter &amp; query.
+Permissions required: plans.get</p></td>
               </tr>
             
               <tr>
                 <td>CreatePlan</td>
                 <td><a href="#bytebase.v1.CreatePlanRequest">CreatePlanRequest</a></td>
                 <td><a href="#bytebase.v1.Plan">Plan</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: plans.create</p></td>
               </tr>
             
               <tr>
@@ -21062,28 +21076,29 @@ Format: projects/{project}/plans/{plan} </p></td>
                 <td><a href="#bytebase.v1.UpdatePlanRequest">UpdatePlanRequest</a></td>
                 <td><a href="#bytebase.v1.Plan">Plan</a></td>
                 <td><p>UpdatePlan updates the plan.
-The plan creator and the user with bb.plans.update permission on the project can update the plan.</p></td>
+The plan creator and the user with bb.plans.update permission on the project can update the plan.
+Permissions required: plans.update</p></td>
               </tr>
             
               <tr>
                 <td>ListPlanCheckRuns</td>
                 <td><a href="#bytebase.v1.ListPlanCheckRunsRequest">ListPlanCheckRunsRequest</a></td>
                 <td><a href="#bytebase.v1.ListPlanCheckRunsResponse">ListPlanCheckRunsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: planCheckRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>RunPlanChecks</td>
                 <td><a href="#bytebase.v1.RunPlanChecksRequest">RunPlanChecksRequest</a></td>
                 <td><a href="#bytebase.v1.RunPlanChecksResponse">RunPlanChecksResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: planCheckRuns.run</p></td>
               </tr>
             
               <tr>
                 <td>BatchCancelPlanCheckRuns</td>
                 <td><a href="#bytebase.v1.BatchCancelPlanCheckRunsRequest">BatchCancelPlanCheckRunsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCancelPlanCheckRunsResponse">BatchCancelPlanCheckRunsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: planCheckRuns.run</p></td>
               </tr>
             
           </tbody>
@@ -22232,105 +22247,107 @@ TYPE_ISSUE_CREATE represents creating an issue.</p></td>
                 <td><a href="#bytebase.v1.GetProjectRequest">GetProjectRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
                 <td><p>GetProject retrieves a project by name.
-Users with &#34;bb.projects.get&#34; permission on the workspace or the project owner can access this method.</p></td>
+Users with &#34;bb.projects.get&#34; permission on the workspace or the project owner can access this method.
+Permissions required: projects.get</p></td>
               </tr>
             
               <tr>
                 <td>ListProjects</td>
                 <td><a href="#bytebase.v1.ListProjectsRequest">ListProjectsRequest</a></td>
                 <td><a href="#bytebase.v1.ListProjectsResponse">ListProjectsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.list</p></td>
               </tr>
             
               <tr>
                 <td>SearchProjects</td>
                 <td><a href="#bytebase.v1.SearchProjectsRequest">SearchProjectsRequest</a></td>
                 <td><a href="#bytebase.v1.SearchProjectsResponse">SearchProjectsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>CreateProject</td>
                 <td><a href="#bytebase.v1.CreateProjectRequest">CreateProjectRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateProject</td>
                 <td><a href="#bytebase.v1.UpdateProjectRequest">UpdateProjectRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteProject</td>
                 <td><a href="#bytebase.v1.DeleteProjectRequest">DeleteProjectRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.delete</p></td>
               </tr>
             
               <tr>
                 <td>UndeleteProject</td>
                 <td><a href="#bytebase.v1.UndeleteProjectRequest">UndeleteProjectRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.undelete</p></td>
               </tr>
             
               <tr>
                 <td>BatchDeleteProjects</td>
                 <td><a href="#bytebase.v1.BatchDeleteProjectsRequest">BatchDeleteProjectsRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.delete</p></td>
               </tr>
             
               <tr>
                 <td>GetIamPolicy</td>
                 <td><a href="#bytebase.v1.GetIamPolicyRequest">GetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.getIamPolicy</p></td>
               </tr>
             
               <tr>
                 <td>BatchGetIamPolicy</td>
                 <td><a href="#bytebase.v1.BatchGetIamPolicyRequest">BatchGetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.BatchGetIamPolicyResponse">BatchGetIamPolicyResponse</a></td>
-                <td><p>Deprecated.</p></td>
+                <td><p>Deprecated.
+Permissions required: projects.getIamPolicy</p></td>
               </tr>
             
               <tr>
                 <td>SetIamPolicy</td>
                 <td><a href="#bytebase.v1.SetIamPolicyRequest">SetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.setIamPolicy</p></td>
               </tr>
             
               <tr>
                 <td>AddWebhook</td>
                 <td><a href="#bytebase.v1.AddWebhookRequest">AddWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
               <tr>
                 <td>UpdateWebhook</td>
                 <td><a href="#bytebase.v1.UpdateWebhookRequest">UpdateWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
               <tr>
                 <td>RemoveWebhook</td>
                 <td><a href="#bytebase.v1.RemoveWebhookRequest">RemoveWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.Project">Project</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
               <tr>
                 <td>TestWebhook</td>
                 <td><a href="#bytebase.v1.TestWebhookRequest">TestWebhookRequest</a></td>
                 <td><a href="#bytebase.v1.TestWebhookResponse">TestWebhookResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: projects.update</p></td>
               </tr>
             
           </tbody>
@@ -24160,56 +24177,57 @@ Pass this value in the page_token field in the subsequent call to
                 <td>Query</td>
                 <td><a href="#bytebase.v1.QueryRequest">QueryRequest</a></td>
                 <td><a href="#bytebase.v1.QueryResponse">QueryResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.get</p></td>
               </tr>
             
               <tr>
                 <td>AdminExecute</td>
                 <td><a href="#bytebase.v1.AdminExecuteRequest">AdminExecuteRequest</a> stream</td>
                 <td><a href="#bytebase.v1.AdminExecuteResponse">AdminExecuteResponse</a> stream</td>
-                <td><p></p></td>
+                <td><p>Permissions required: sql.admin</p></td>
               </tr>
             
               <tr>
                 <td>SearchQueryHistories</td>
                 <td><a href="#bytebase.v1.SearchQueryHistoriesRequest">SearchQueryHistoriesRequest</a></td>
                 <td><a href="#bytebase.v1.SearchQueryHistoriesResponse">SearchQueryHistoriesResponse</a></td>
-                <td><p>SearchQueryHistories searches query histories for the caller.</p></td>
+                <td><p>SearchQueryHistories searches query histories for the caller.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>Export</td>
                 <td><a href="#bytebase.v1.ExportRequest">ExportRequest</a></td>
                 <td><a href="#bytebase.v1.ExportResponse">ExportResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.get</p></td>
               </tr>
             
               <tr>
                 <td>Check</td>
                 <td><a href="#bytebase.v1.CheckRequest">CheckRequest</a></td>
                 <td><a href="#bytebase.v1.CheckResponse">CheckResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: databases.check</p></td>
               </tr>
             
               <tr>
                 <td>Pretty</td>
                 <td><a href="#bytebase.v1.PrettyRequest">PrettyRequest</a></td>
                 <td><a href="#bytebase.v1.PrettyResponse">PrettyResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>DiffMetadata</td>
                 <td><a href="#bytebase.v1.DiffMetadataRequest">DiffMetadataRequest</a></td>
                 <td><a href="#bytebase.v1.DiffMetadataResponse">DiffMetadataResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>AICompletion</td>
                 <td><a href="#bytebase.v1.AICompletionRequest">AICompletionRequest</a></td>
                 <td><a href="#bytebase.v1.AICompletionResponse">AICompletionResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: None</p></td>
               </tr>
             
           </tbody>
@@ -24995,49 +25013,49 @@ Format: projects/{project}/releases/{release} </p></td>
                 <td>GetRelease</td>
                 <td><a href="#bytebase.v1.GetReleaseRequest">GetReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: releases.get</p></td>
               </tr>
             
               <tr>
                 <td>ListReleases</td>
                 <td><a href="#bytebase.v1.ListReleasesRequest">ListReleasesRequest</a></td>
                 <td><a href="#bytebase.v1.ListReleasesResponse">ListReleasesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: releases.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateRelease</td>
                 <td><a href="#bytebase.v1.CreateReleaseRequest">CreateReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: releases.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateRelease</td>
                 <td><a href="#bytebase.v1.UpdateReleaseRequest">UpdateReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: releases.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRelease</td>
                 <td><a href="#bytebase.v1.DeleteReleaseRequest">DeleteReleaseRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: releases.delete</p></td>
               </tr>
             
               <tr>
                 <td>UndeleteRelease</td>
                 <td><a href="#bytebase.v1.UndeleteReleaseRequest">UndeleteReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.Release">Release</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: releases.undelete</p></td>
               </tr>
             
               <tr>
                 <td>CheckRelease</td>
                 <td><a href="#bytebase.v1.CheckReleaseRequest">CheckReleaseRequest</a></td>
                 <td><a href="#bytebase.v1.CheckReleaseResponse">CheckReleaseResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: releases.check</p></td>
               </tr>
             
           </tbody>
@@ -25398,35 +25416,35 @@ In this situation, `update_mask` is ignored. </p></td>
                 <td>CreateReviewConfig</td>
                 <td><a href="#bytebase.v1.CreateReviewConfigRequest">CreateReviewConfigRequest</a></td>
                 <td><a href="#bytebase.v1.ReviewConfig">ReviewConfig</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: reviewConfigs.create</p></td>
               </tr>
             
               <tr>
                 <td>ListReviewConfigs</td>
                 <td><a href="#bytebase.v1.ListReviewConfigsRequest">ListReviewConfigsRequest</a></td>
                 <td><a href="#bytebase.v1.ListReviewConfigsResponse">ListReviewConfigsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: reviewConfigs.list</p></td>
               </tr>
             
               <tr>
                 <td>GetReviewConfig</td>
                 <td><a href="#bytebase.v1.GetReviewConfigRequest">GetReviewConfigRequest</a></td>
                 <td><a href="#bytebase.v1.ReviewConfig">ReviewConfig</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: reviewConfigs.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateReviewConfig</td>
                 <td><a href="#bytebase.v1.UpdateReviewConfigRequest">UpdateReviewConfigRequest</a></td>
                 <td><a href="#bytebase.v1.ReviewConfig">ReviewConfig</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: reviewConfigs.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteReviewConfig</td>
                 <td><a href="#bytebase.v1.DeleteReviewConfigRequest">DeleteReviewConfigRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: reviewConfigs.delete</p></td>
               </tr>
             
           </tbody>
@@ -25866,35 +25884,35 @@ projects/{project}/rollouts/{rollout}/stages/{stage}/tasks/{task}/taskRuns/{task
                 <td>ListRevisions</td>
                 <td><a href="#bytebase.v1.ListRevisionsRequest">ListRevisionsRequest</a></td>
                 <td><a href="#bytebase.v1.ListRevisionsResponse">ListRevisionsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: revisions.list</p></td>
               </tr>
             
               <tr>
                 <td>GetRevision</td>
                 <td><a href="#bytebase.v1.GetRevisionRequest">GetRevisionRequest</a></td>
                 <td><a href="#bytebase.v1.Revision">Revision</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: revisions.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateRevision</td>
                 <td><a href="#bytebase.v1.CreateRevisionRequest">CreateRevisionRequest</a></td>
                 <td><a href="#bytebase.v1.Revision">Revision</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: revisions.create</p></td>
               </tr>
             
               <tr>
                 <td>BatchCreateRevisions</td>
                 <td><a href="#bytebase.v1.BatchCreateRevisionsRequest">BatchCreateRevisionsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCreateRevisionsResponse">BatchCreateRevisionsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: revisions.create</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRevision</td>
                 <td><a href="#bytebase.v1.DeleteRevisionRequest">DeleteRevisionRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: revisions.delete</p></td>
               </tr>
             
           </tbody>
@@ -26350,35 +26368,35 @@ Format: risks/{risk} </p></td>
                 <td>ListRisks</td>
                 <td><a href="#bytebase.v1.ListRisksRequest">ListRisksRequest</a></td>
                 <td><a href="#bytebase.v1.ListRisksResponse">ListRisksResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: risks.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateRisk</td>
                 <td><a href="#bytebase.v1.CreateRiskRequest">CreateRiskRequest</a></td>
                 <td><a href="#bytebase.v1.Risk">Risk</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: risks.create</p></td>
               </tr>
             
               <tr>
                 <td>GetRisk</td>
                 <td><a href="#bytebase.v1.GetRiskRequest">GetRiskRequest</a></td>
                 <td><a href="#bytebase.v1.Risk">Risk</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: risks.list</p></td>
               </tr>
             
               <tr>
                 <td>UpdateRisk</td>
                 <td><a href="#bytebase.v1.UpdateRiskRequest">UpdateRiskRequest</a></td>
                 <td><a href="#bytebase.v1.Risk">Risk</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: risks.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRisk</td>
                 <td><a href="#bytebase.v1.DeleteRiskRequest">DeleteRiskRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: risks.delete</p></td>
               </tr>
             
           </tbody>
@@ -26754,35 +26772,35 @@ If this field is omitted, there are no subsequent pages. </p></td>
                 <td>ListRoles</td>
                 <td><a href="#bytebase.v1.ListRolesRequest">ListRolesRequest</a></td>
                 <td><a href="#bytebase.v1.ListRolesResponse">ListRolesResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: roles.list</p></td>
               </tr>
             
               <tr>
                 <td>GetRole</td>
                 <td><a href="#bytebase.v1.GetRoleRequest">GetRoleRequest</a></td>
                 <td><a href="#bytebase.v1.Role">Role</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: roles.get</p></td>
               </tr>
             
               <tr>
                 <td>CreateRole</td>
                 <td><a href="#bytebase.v1.CreateRoleRequest">CreateRoleRequest</a></td>
                 <td><a href="#bytebase.v1.Role">Role</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: roles.create</p></td>
               </tr>
             
               <tr>
                 <td>UpdateRole</td>
                 <td><a href="#bytebase.v1.UpdateRoleRequest">UpdateRoleRequest</a></td>
                 <td><a href="#bytebase.v1.Role">Role</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: roles.update</p></td>
               </tr>
             
               <tr>
                 <td>DeleteRole</td>
                 <td><a href="#bytebase.v1.DeleteRoleRequest">DeleteRoleRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: roles.delete</p></td>
               </tr>
             
           </tbody>
@@ -29044,56 +29062,57 @@ Format: instances/{instance}/databases/{database} </p></td>
                 <td>GetRollout</td>
                 <td><a href="#bytebase.v1.GetRolloutRequest">GetRolloutRequest</a></td>
                 <td><a href="#bytebase.v1.Rollout">Rollout</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: rollouts.get</p></td>
               </tr>
             
               <tr>
                 <td>ListRollouts</td>
                 <td><a href="#bytebase.v1.ListRolloutsRequest">ListRolloutsRequest</a></td>
                 <td><a href="#bytebase.v1.ListRolloutsResponse">ListRolloutsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: rollouts.list</p></td>
               </tr>
             
               <tr>
                 <td>CreateRollout</td>
                 <td><a href="#bytebase.v1.CreateRolloutRequest">CreateRolloutRequest</a></td>
                 <td><a href="#bytebase.v1.Rollout">Rollout</a></td>
-                <td><p>CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.</p></td>
+                <td><p>CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+Permissions required: rollouts.create</p></td>
               </tr>
             
               <tr>
                 <td>PreviewRollout</td>
                 <td><a href="#bytebase.v1.PreviewRolloutRequest">PreviewRolloutRequest</a></td>
                 <td><a href="#bytebase.v1.Rollout">Rollout</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: rollouts.preview</p></td>
               </tr>
             
               <tr>
                 <td>ListTaskRuns</td>
                 <td><a href="#bytebase.v1.ListTaskRunsRequest">ListTaskRunsRequest</a></td>
                 <td><a href="#bytebase.v1.ListTaskRunsResponse">ListTaskRunsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: taskRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>GetTaskRun</td>
                 <td><a href="#bytebase.v1.GetTaskRunRequest">GetTaskRunRequest</a></td>
                 <td><a href="#bytebase.v1.TaskRun">TaskRun</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: taskRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>GetTaskRunLog</td>
                 <td><a href="#bytebase.v1.GetTaskRunLogRequest">GetTaskRunLogRequest</a></td>
                 <td><a href="#bytebase.v1.TaskRunLog">TaskRunLog</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: taskRuns.list</p></td>
               </tr>
             
               <tr>
                 <td>GetTaskRunSession</td>
                 <td><a href="#bytebase.v1.GetTaskRunSessionRequest">GetTaskRunSessionRequest</a></td>
                 <td><a href="#bytebase.v1.TaskRunSession">TaskRunSession</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: taskRuns.list</p></td>
               </tr>
             
               <tr>
@@ -29103,7 +29122,8 @@ Format: instances/{instance}/databases/{database} </p></td>
                 <td><p>BatchRunTasks creates task runs for the specified tasks.
 DataExport issue only allows the creator to run the task.
 Users with &#34;bb.taskRuns.create&#34; permission can run the task, e.g. Workspace Admin and DBA.
-Follow role-based rollout policy for the environment.</p></td>
+Follow role-based rollout policy for the environment.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -29111,7 +29131,8 @@ Follow role-based rollout policy for the environment.</p></td>
                 <td><a href="#bytebase.v1.BatchSkipTasksRequest">BatchSkipTasksRequest</a></td>
                 <td><a href="#bytebase.v1.BatchSkipTasksResponse">BatchSkipTasksResponse</a></td>
                 <td><p>BatchSkipTasks skips the specified tasks.
-The access is the same as BatchRunTasks().</p></td>
+The access is the same as BatchRunTasks().
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -29119,14 +29140,15 @@ The access is the same as BatchRunTasks().</p></td>
                 <td><a href="#bytebase.v1.BatchCancelTaskRunsRequest">BatchCancelTaskRunsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCancelTaskRunsResponse">BatchCancelTaskRunsResponse</a></td>
                 <td><p>BatchCancelTaskRuns cancels the specified task runs in batch.
-The access is the same as BatchRunTasks().</p></td>
+The access is the same as BatchRunTasks().
+Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>PreviewTaskRunRollback</td>
                 <td><a href="#bytebase.v1.PreviewTaskRunRollbackRequest">PreviewTaskRunRollbackRequest</a></td>
                 <td><a href="#bytebase.v1.PreviewTaskRunRollbackResponse">PreviewTaskRunRollbackResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: taskRuns.list</p></td>
               </tr>
             
           </tbody>
@@ -29619,28 +29641,28 @@ Only support update the following fields for now:
                 <td>CreateSheet</td>
                 <td><a href="#bytebase.v1.CreateSheetRequest">CreateSheetRequest</a></td>
                 <td><a href="#bytebase.v1.Sheet">Sheet</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: sheets.create</p></td>
               </tr>
             
               <tr>
                 <td>BatchCreateSheets</td>
                 <td><a href="#bytebase.v1.BatchCreateSheetsRequest">BatchCreateSheetsRequest</a></td>
                 <td><a href="#bytebase.v1.BatchCreateSheetsResponse">BatchCreateSheetsResponse</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: sheets.create</p></td>
               </tr>
             
               <tr>
                 <td>GetSheet</td>
                 <td><a href="#bytebase.v1.GetSheetRequest">GetSheetRequest</a></td>
                 <td><a href="#bytebase.v1.Sheet">Sheet</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: sheets.get</p></td>
               </tr>
             
               <tr>
                 <td>UpdateSheet</td>
                 <td><a href="#bytebase.v1.UpdateSheetRequest">UpdateSheetRequest</a></td>
                 <td><a href="#bytebase.v1.Sheet">Sheet</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: sheets.update</p></td>
               </tr>
             
           </tbody>
@@ -30396,14 +30418,15 @@ Only support update the following fields for now:
                 <td><a href="#bytebase.v1.Subscription">Subscription</a></td>
                 <td><p>GetSubscription returns the current subscription.
 If there is no license, we will return a free plan subscription without expiration time.
-If there is expired license, we will return a free plan subscription with the expiration time of the expired license.</p></td>
+If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
                 <td>UpdateSubscription</td>
                 <td><a href="#bytebase.v1.UpdateSubscriptionRequest">UpdateSubscriptionRequest</a></td>
                 <td><a href="#bytebase.v1.Subscription">Subscription</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: settings.set</p></td>
               </tr>
             
           </tbody>
@@ -30888,7 +30911,8 @@ Format: worksheets/{worksheet} </p></td>
                 <td>CreateWorksheet</td>
                 <td><a href="#bytebase.v1.CreateWorksheetRequest">CreateWorksheetRequest</a></td>
                 <td><a href="#bytebase.v1.Worksheet">Worksheet</a></td>
-                <td><p>Create a personal worksheet used in SQL Editor.</p></td>
+                <td><p>Create a personal worksheet used in SQL Editor.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -30899,7 +30923,8 @@ Format: worksheets/{worksheet} </p></td>
 The users can access this method if,
 - they are the creator of the worksheet;
 - they have bb.worksheets.get permission on the workspace;
-- the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.</p></td>
+- the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -30908,7 +30933,8 @@ The users can access this method if,
                 <td><a href="#bytebase.v1.SearchWorksheetsResponse">SearchWorksheetsResponse</a></td>
                 <td><p>Search for worksheets.
 This is used for finding my worksheets or worksheets shared by other people.
-The sheet accessibility is the same as GetWorksheet().</p></td>
+The sheet accessibility is the same as GetWorksheet().
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -30919,7 +30945,8 @@ The sheet accessibility is the same as GetWorksheet().</p></td>
 The users can access this method if,
 - they are the creator of the worksheet;
 - they have bb.worksheets.manage permission on the workspace;
-- the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.</p></td>
+- the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -30927,7 +30954,8 @@ The users can access this method if,
                 <td><a href="#bytebase.v1.UpdateWorksheetOrganizerRequest">UpdateWorksheetOrganizerRequest</a></td>
                 <td><a href="#bytebase.v1.WorksheetOrganizer">WorksheetOrganizer</a></td>
                 <td><p>Update the organizer of a worksheet.
-The access is the same as UpdateWorksheet method.</p></td>
+The access is the same as UpdateWorksheet method.
+Permissions required: None</p></td>
               </tr>
             
               <tr>
@@ -30935,7 +30963,8 @@ The access is the same as UpdateWorksheet method.</p></td>
                 <td><a href="#bytebase.v1.DeleteWorksheetRequest">DeleteWorksheetRequest</a></td>
                 <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
                 <td><p>Delete a worksheet.
-The access is the same as UpdateWorksheet method.</p></td>
+The access is the same as UpdateWorksheet method.
+Permissions required: None</p></td>
               </tr>
             
           </tbody>
@@ -31046,14 +31075,14 @@ The access is the same as UpdateWorksheet method.</p></td>
                 <td>GetIamPolicy</td>
                 <td><a href="#bytebase.v1.GetIamPolicyRequest">GetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: workspaces.getIamPolicy</p></td>
               </tr>
             
               <tr>
                 <td>SetIamPolicy</td>
                 <td><a href="#bytebase.v1.SetIamPolicyRequest">SetIamPolicyRequest</a></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
-                <td><p></p></td>
+                <td><p>Permissions required: workspaces.setIamPolicy</p></td>
               </tr>
             
           </tbody>

--- a/proto/generated-go/v1/actuator_service.pb.gw.go
+++ b/proto/generated-go/v1/actuator_service.pb.gw.go
@@ -40,7 +40,9 @@ func request_ActuatorService_GetActuatorInfo_0(ctx context.Context, marshaler ru
 		protoReq GetActuatorInfoRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.GetActuatorInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -67,6 +69,9 @@ func request_ActuatorService_UpdateActuatorInfo_0(ctx context.Context, marshaler
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Actuator); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Actuator); err != nil {
@@ -119,7 +124,9 @@ func request_ActuatorService_SetupSample_0(ctx context.Context, marshaler runtim
 		protoReq SetupSampleRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.SetupSample(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -138,7 +145,9 @@ func request_ActuatorService_DeleteCache_0(ctx context.Context, marshaler runtim
 		protoReq DeleteCacheRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.DeleteCache(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -157,7 +166,9 @@ func request_ActuatorService_GetResourcePackage_0(ctx context.Context, marshaler
 		protoReq GetResourcePackageRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.GetResourcePackage(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }

--- a/proto/generated-go/v1/actuator_service_grpc.pb.go
+++ b/proto/generated-go/v1/actuator_service_grpc.pb.go
@@ -33,9 +33,9 @@ const (
 type ActuatorServiceClient interface {
 	// Permissions required: None
 	GetActuatorInfo(ctx context.Context, in *GetActuatorInfoRequest, opts ...grpc.CallOption) (*ActuatorInfo, error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateActuatorInfo(ctx context.Context, in *UpdateActuatorInfoRequest, opts ...grpc.CallOption) (*ActuatorInfo, error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	SetupSample(ctx context.Context, in *SetupSampleRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Permissions required: None
 	DeleteCache(ctx context.Context, in *DeleteCacheRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -107,9 +107,9 @@ func (c *actuatorServiceClient) GetResourcePackage(ctx context.Context, in *GetR
 type ActuatorServiceServer interface {
 	// Permissions required: None
 	GetActuatorInfo(context.Context, *GetActuatorInfoRequest) (*ActuatorInfo, error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateActuatorInfo(context.Context, *UpdateActuatorInfoRequest) (*ActuatorInfo, error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	SetupSample(context.Context, *SetupSampleRequest) (*emptypb.Empty, error)
 	// Permissions required: None
 	DeleteCache(context.Context, *DeleteCacheRequest) (*emptypb.Empty, error)

--- a/proto/generated-go/v1/actuator_service_grpc.pb.go
+++ b/proto/generated-go/v1/actuator_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ActuatorServiceClient interface {
+	// Permissions required: None
 	GetActuatorInfo(ctx context.Context, in *GetActuatorInfoRequest, opts ...grpc.CallOption) (*ActuatorInfo, error)
+	// Permissions required: settings.set
 	UpdateActuatorInfo(ctx context.Context, in *UpdateActuatorInfoRequest, opts ...grpc.CallOption) (*ActuatorInfo, error)
+	// Permissions required: projects.create
 	SetupSample(ctx context.Context, in *SetupSampleRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: None
 	DeleteCache(ctx context.Context, in *DeleteCacheRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: None
 	GetResourcePackage(ctx context.Context, in *GetResourcePackageRequest, opts ...grpc.CallOption) (*ResourcePackage, error)
 }
 
@@ -100,10 +105,15 @@ func (c *actuatorServiceClient) GetResourcePackage(ctx context.Context, in *GetR
 // All implementations must embed UnimplementedActuatorServiceServer
 // for forward compatibility.
 type ActuatorServiceServer interface {
+	// Permissions required: None
 	GetActuatorInfo(context.Context, *GetActuatorInfoRequest) (*ActuatorInfo, error)
+	// Permissions required: settings.set
 	UpdateActuatorInfo(context.Context, *UpdateActuatorInfoRequest) (*ActuatorInfo, error)
+	// Permissions required: projects.create
 	SetupSample(context.Context, *SetupSampleRequest) (*emptypb.Empty, error)
+	// Permissions required: None
 	DeleteCache(context.Context, *DeleteCacheRequest) (*emptypb.Empty, error)
+	// Permissions required: None
 	GetResourcePackage(context.Context, *GetResourcePackageRequest) (*ResourcePackage, error)
 	mustEmbedUnimplementedActuatorServiceServer()
 }

--- a/proto/generated-go/v1/audit_log_service.pb.gw.go
+++ b/proto/generated-go/v1/audit_log_service.pb.gw.go
@@ -44,6 +44,9 @@ func request_AuditLogService_SearchAuditLogs_0(ctx context.Context, marshaler ru
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -85,6 +88,9 @@ func request_AuditLogService_SearchAuditLogs_1(ctx context.Context, marshaler ru
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.SearchAuditLogs(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -109,6 +115,9 @@ func request_AuditLogService_ExportAuditLogs_0(ctx context.Context, marshaler ru
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -150,6 +159,9 @@ func request_AuditLogService_ExportAuditLogs_1(ctx context.Context, marshaler ru
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.ExportAuditLogs(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err

--- a/proto/generated-go/v1/audit_log_service_grpc.pb.go
+++ b/proto/generated-go/v1/audit_log_service_grpc.pb.go
@@ -29,7 +29,7 @@ const (
 type AuditLogServiceClient interface {
 	// Permissions required: None
 	SearchAuditLogs(ctx context.Context, in *SearchAuditLogsRequest, opts ...grpc.CallOption) (*SearchAuditLogsResponse, error)
-	// Permissions required: auditLogs.export
+	// Permissions required: bb.auditLogs.export
 	ExportAuditLogs(ctx context.Context, in *ExportAuditLogsRequest, opts ...grpc.CallOption) (*ExportAuditLogsResponse, error)
 }
 
@@ -67,7 +67,7 @@ func (c *auditLogServiceClient) ExportAuditLogs(ctx context.Context, in *ExportA
 type AuditLogServiceServer interface {
 	// Permissions required: None
 	SearchAuditLogs(context.Context, *SearchAuditLogsRequest) (*SearchAuditLogsResponse, error)
-	// Permissions required: auditLogs.export
+	// Permissions required: bb.auditLogs.export
 	ExportAuditLogs(context.Context, *ExportAuditLogsRequest) (*ExportAuditLogsResponse, error)
 	mustEmbedUnimplementedAuditLogServiceServer()
 }

--- a/proto/generated-go/v1/audit_log_service_grpc.pb.go
+++ b/proto/generated-go/v1/audit_log_service_grpc.pb.go
@@ -27,7 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type AuditLogServiceClient interface {
+	// Permissions required: None
 	SearchAuditLogs(ctx context.Context, in *SearchAuditLogsRequest, opts ...grpc.CallOption) (*SearchAuditLogsResponse, error)
+	// Permissions required: auditLogs.export
 	ExportAuditLogs(ctx context.Context, in *ExportAuditLogsRequest, opts ...grpc.CallOption) (*ExportAuditLogsResponse, error)
 }
 
@@ -63,7 +65,9 @@ func (c *auditLogServiceClient) ExportAuditLogs(ctx context.Context, in *ExportA
 // All implementations must embed UnimplementedAuditLogServiceServer
 // for forward compatibility.
 type AuditLogServiceServer interface {
+	// Permissions required: None
 	SearchAuditLogs(context.Context, *SearchAuditLogsRequest) (*SearchAuditLogsResponse, error)
+	// Permissions required: auditLogs.export
 	ExportAuditLogs(context.Context, *ExportAuditLogsRequest) (*ExportAuditLogsResponse, error)
 	mustEmbedUnimplementedAuditLogServiceServer()
 }

--- a/proto/generated-go/v1/auth_service.pb.gw.go
+++ b/proto/generated-go/v1/auth_service.pb.gw.go
@@ -43,6 +43,9 @@ func request_AuthService_Login_0(ctx context.Context, marshaler runtime.Marshale
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.Login(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -66,6 +69,9 @@ func request_AuthService_Logout_0(ctx context.Context, marshaler runtime.Marshal
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.Logout(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err

--- a/proto/generated-go/v1/auth_service_grpc.pb.go
+++ b/proto/generated-go/v1/auth_service_grpc.pb.go
@@ -28,7 +28,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type AuthServiceClient interface {
+	// Permissions required: None
 	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
+	// Permissions required: None
 	Logout(ctx context.Context, in *LogoutRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -64,7 +66,9 @@ func (c *authServiceClient) Logout(ctx context.Context, in *LogoutRequest, opts 
 // All implementations must embed UnimplementedAuthServiceServer
 // for forward compatibility.
 type AuthServiceServer interface {
+	// Permissions required: None
 	Login(context.Context, *LoginRequest) (*LoginResponse, error)
+	// Permissions required: None
 	Logout(context.Context, *LogoutRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedAuthServiceServer()
 }

--- a/proto/generated-go/v1/cel_service.pb.gw.go
+++ b/proto/generated-go/v1/cel_service.pb.gw.go
@@ -43,6 +43,9 @@ func request_CelService_BatchParse_0(ctx context.Context, marshaler runtime.Mars
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.BatchParse(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -66,6 +69,9 @@ func request_CelService_BatchDeparse_0(ctx context.Context, marshaler runtime.Ma
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.BatchDeparse(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err

--- a/proto/generated-go/v1/cel_service_grpc.pb.go
+++ b/proto/generated-go/v1/cel_service_grpc.pb.go
@@ -27,7 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type CelServiceClient interface {
+	// Permissions required: None
 	BatchParse(ctx context.Context, in *BatchParseRequest, opts ...grpc.CallOption) (*BatchParseResponse, error)
+	// Permissions required: None
 	BatchDeparse(ctx context.Context, in *BatchDeparseRequest, opts ...grpc.CallOption) (*BatchDeparseResponse, error)
 }
 
@@ -63,7 +65,9 @@ func (c *celServiceClient) BatchDeparse(ctx context.Context, in *BatchDeparseReq
 // All implementations must embed UnimplementedCelServiceServer
 // for forward compatibility.
 type CelServiceServer interface {
+	// Permissions required: None
 	BatchParse(context.Context, *BatchParseRequest) (*BatchParseResponse, error)
+	// Permissions required: None
 	BatchDeparse(context.Context, *BatchDeparseRequest) (*BatchDeparseResponse, error)
 	mustEmbedUnimplementedCelServiceServer()
 }

--- a/proto/generated-go/v1/changelist_service.pb.gw.go
+++ b/proto/generated-go/v1/changelist_service.pb.gw.go
@@ -46,6 +46,9 @@ func request_ChangelistService_CreateChangelist_0(ctx context.Context, marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Changelist); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -97,7 +100,9 @@ func request_ChangelistService_GetChangelist_0(ctx context.Context, marshaler ru
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -136,7 +141,9 @@ func request_ChangelistService_ListChangelists_0(ctx context.Context, marshaler 
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -193,6 +200,9 @@ func request_ChangelistService_UpdateChangelist_0(ctx context.Context, marshaler
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Changelist); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Changelist); err != nil {
@@ -263,7 +273,9 @@ func request_ChangelistService_DeleteChangelist_0(ctx context.Context, marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/changelist_service_grpc.pb.go
+++ b/proto/generated-go/v1/changelist_service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ChangelistServiceClient interface {
-	// Permissions required: changelists.create
+	// Permissions required: bb.changelists.create
 	CreateChangelist(ctx context.Context, in *CreateChangelistRequest, opts ...grpc.CallOption) (*Changelist, error)
-	// Permissions required: changelists.get
+	// Permissions required: bb.changelists.get
 	GetChangelist(ctx context.Context, in *GetChangelistRequest, opts ...grpc.CallOption) (*Changelist, error)
-	// Permissions required: changelists.list
+	// Permissions required: bb.changelists.list
 	ListChangelists(ctx context.Context, in *ListChangelistsRequest, opts ...grpc.CallOption) (*ListChangelistsResponse, error)
-	// Permissions required: changelists.update
+	// Permissions required: bb.changelists.update
 	UpdateChangelist(ctx context.Context, in *UpdateChangelistRequest, opts ...grpc.CallOption) (*Changelist, error)
-	// Permissions required: changelists.delete
+	// Permissions required: bb.changelists.delete
 	DeleteChangelist(ctx context.Context, in *DeleteChangelistRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -105,15 +105,15 @@ func (c *changelistServiceClient) DeleteChangelist(ctx context.Context, in *Dele
 // All implementations must embed UnimplementedChangelistServiceServer
 // for forward compatibility.
 type ChangelistServiceServer interface {
-	// Permissions required: changelists.create
+	// Permissions required: bb.changelists.create
 	CreateChangelist(context.Context, *CreateChangelistRequest) (*Changelist, error)
-	// Permissions required: changelists.get
+	// Permissions required: bb.changelists.get
 	GetChangelist(context.Context, *GetChangelistRequest) (*Changelist, error)
-	// Permissions required: changelists.list
+	// Permissions required: bb.changelists.list
 	ListChangelists(context.Context, *ListChangelistsRequest) (*ListChangelistsResponse, error)
-	// Permissions required: changelists.update
+	// Permissions required: bb.changelists.update
 	UpdateChangelist(context.Context, *UpdateChangelistRequest) (*Changelist, error)
-	// Permissions required: changelists.delete
+	// Permissions required: bb.changelists.delete
 	DeleteChangelist(context.Context, *DeleteChangelistRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedChangelistServiceServer()
 }

--- a/proto/generated-go/v1/changelist_service_grpc.pb.go
+++ b/proto/generated-go/v1/changelist_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ChangelistServiceClient interface {
+	// Permissions required: changelists.create
 	CreateChangelist(ctx context.Context, in *CreateChangelistRequest, opts ...grpc.CallOption) (*Changelist, error)
+	// Permissions required: changelists.get
 	GetChangelist(ctx context.Context, in *GetChangelistRequest, opts ...grpc.CallOption) (*Changelist, error)
+	// Permissions required: changelists.list
 	ListChangelists(ctx context.Context, in *ListChangelistsRequest, opts ...grpc.CallOption) (*ListChangelistsResponse, error)
+	// Permissions required: changelists.update
 	UpdateChangelist(ctx context.Context, in *UpdateChangelistRequest, opts ...grpc.CallOption) (*Changelist, error)
+	// Permissions required: changelists.delete
 	DeleteChangelist(ctx context.Context, in *DeleteChangelistRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -100,10 +105,15 @@ func (c *changelistServiceClient) DeleteChangelist(ctx context.Context, in *Dele
 // All implementations must embed UnimplementedChangelistServiceServer
 // for forward compatibility.
 type ChangelistServiceServer interface {
+	// Permissions required: changelists.create
 	CreateChangelist(context.Context, *CreateChangelistRequest) (*Changelist, error)
+	// Permissions required: changelists.get
 	GetChangelist(context.Context, *GetChangelistRequest) (*Changelist, error)
+	// Permissions required: changelists.list
 	ListChangelists(context.Context, *ListChangelistsRequest) (*ListChangelistsResponse, error)
+	// Permissions required: changelists.update
 	UpdateChangelist(context.Context, *UpdateChangelistRequest) (*Changelist, error)
+	// Permissions required: changelists.delete
 	DeleteChangelist(context.Context, *DeleteChangelistRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedChangelistServiceServer()
 }

--- a/proto/generated-go/v1/database_catalog_service.pb.gw.go
+++ b/proto/generated-go/v1/database_catalog_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_DatabaseCatalogService_GetDatabaseCatalog_0(ctx context.Context, ma
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -80,6 +82,9 @@ func request_DatabaseCatalogService_UpdateDatabaseCatalog_0(ctx context.Context,
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Catalog); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["catalog.name"]
 	if !ok {

--- a/proto/generated-go/v1/database_catalog_service_grpc.pb.go
+++ b/proto/generated-go/v1/database_catalog_service_grpc.pb.go
@@ -27,7 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DatabaseCatalogServiceClient interface {
+	// Permissions required: databaseCatalogs.get
 	GetDatabaseCatalog(ctx context.Context, in *GetDatabaseCatalogRequest, opts ...grpc.CallOption) (*DatabaseCatalog, error)
+	// Permissions required: databaseCatalogs.update
 	UpdateDatabaseCatalog(ctx context.Context, in *UpdateDatabaseCatalogRequest, opts ...grpc.CallOption) (*DatabaseCatalog, error)
 }
 
@@ -63,7 +65,9 @@ func (c *databaseCatalogServiceClient) UpdateDatabaseCatalog(ctx context.Context
 // All implementations must embed UnimplementedDatabaseCatalogServiceServer
 // for forward compatibility.
 type DatabaseCatalogServiceServer interface {
+	// Permissions required: databaseCatalogs.get
 	GetDatabaseCatalog(context.Context, *GetDatabaseCatalogRequest) (*DatabaseCatalog, error)
+	// Permissions required: databaseCatalogs.update
 	UpdateDatabaseCatalog(context.Context, *UpdateDatabaseCatalogRequest) (*DatabaseCatalog, error)
 	mustEmbedUnimplementedDatabaseCatalogServiceServer()
 }

--- a/proto/generated-go/v1/database_catalog_service_grpc.pb.go
+++ b/proto/generated-go/v1/database_catalog_service_grpc.pb.go
@@ -27,9 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DatabaseCatalogServiceClient interface {
-	// Permissions required: databaseCatalogs.get
+	// Permissions required: bb.databaseCatalogs.get
 	GetDatabaseCatalog(ctx context.Context, in *GetDatabaseCatalogRequest, opts ...grpc.CallOption) (*DatabaseCatalog, error)
-	// Permissions required: databaseCatalogs.update
+	// Permissions required: bb.databaseCatalogs.update
 	UpdateDatabaseCatalog(ctx context.Context, in *UpdateDatabaseCatalogRequest, opts ...grpc.CallOption) (*DatabaseCatalog, error)
 }
 
@@ -65,9 +65,9 @@ func (c *databaseCatalogServiceClient) UpdateDatabaseCatalog(ctx context.Context
 // All implementations must embed UnimplementedDatabaseCatalogServiceServer
 // for forward compatibility.
 type DatabaseCatalogServiceServer interface {
-	// Permissions required: databaseCatalogs.get
+	// Permissions required: bb.databaseCatalogs.get
 	GetDatabaseCatalog(context.Context, *GetDatabaseCatalogRequest) (*DatabaseCatalog, error)
-	// Permissions required: databaseCatalogs.update
+	// Permissions required: bb.databaseCatalogs.update
 	UpdateDatabaseCatalog(context.Context, *UpdateDatabaseCatalogRequest) (*DatabaseCatalog, error)
 	mustEmbedUnimplementedDatabaseCatalogServiceServer()
 }

--- a/proto/generated-go/v1/database_group_service.pb.gw.go
+++ b/proto/generated-go/v1/database_group_service.pb.gw.go
@@ -43,7 +43,9 @@ func request_DatabaseGroupService_ListDatabaseGroups_0(ctx context.Context, mars
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -94,7 +96,9 @@ func request_DatabaseGroupService_GetDatabaseGroup_0(ctx context.Context, marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -147,6 +151,9 @@ func request_DatabaseGroupService_CreateDatabaseGroup_0(ctx context.Context, mar
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.DatabaseGroup); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -207,6 +214,9 @@ func request_DatabaseGroupService_UpdateDatabaseGroup_0(ctx context.Context, mar
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.DatabaseGroup); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.DatabaseGroup); err != nil {
@@ -277,7 +287,9 @@ func request_DatabaseGroupService_DeleteDatabaseGroup_0(ctx context.Context, mar
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/database_group_service_grpc.pb.go
+++ b/proto/generated-go/v1/database_group_service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DatabaseGroupServiceClient interface {
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	ListDatabaseGroups(ctx context.Context, in *ListDatabaseGroupsRequest, opts ...grpc.CallOption) (*ListDatabaseGroupsResponse, error)
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetDatabaseGroup(ctx context.Context, in *GetDatabaseGroupRequest, opts ...grpc.CallOption) (*DatabaseGroup, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	CreateDatabaseGroup(ctx context.Context, in *CreateDatabaseGroupRequest, opts ...grpc.CallOption) (*DatabaseGroup, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateDatabaseGroup(ctx context.Context, in *UpdateDatabaseGroupRequest, opts ...grpc.CallOption) (*DatabaseGroup, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	DeleteDatabaseGroup(ctx context.Context, in *DeleteDatabaseGroupRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -105,15 +105,15 @@ func (c *databaseGroupServiceClient) DeleteDatabaseGroup(ctx context.Context, in
 // All implementations must embed UnimplementedDatabaseGroupServiceServer
 // for forward compatibility.
 type DatabaseGroupServiceServer interface {
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	ListDatabaseGroups(context.Context, *ListDatabaseGroupsRequest) (*ListDatabaseGroupsResponse, error)
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetDatabaseGroup(context.Context, *GetDatabaseGroupRequest) (*DatabaseGroup, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	CreateDatabaseGroup(context.Context, *CreateDatabaseGroupRequest) (*DatabaseGroup, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateDatabaseGroup(context.Context, *UpdateDatabaseGroupRequest) (*DatabaseGroup, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	DeleteDatabaseGroup(context.Context, *DeleteDatabaseGroupRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedDatabaseGroupServiceServer()
 }

--- a/proto/generated-go/v1/database_group_service_grpc.pb.go
+++ b/proto/generated-go/v1/database_group_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DatabaseGroupServiceClient interface {
+	// Permissions required: projects.get
 	ListDatabaseGroups(ctx context.Context, in *ListDatabaseGroupsRequest, opts ...grpc.CallOption) (*ListDatabaseGroupsResponse, error)
+	// Permissions required: projects.get
 	GetDatabaseGroup(ctx context.Context, in *GetDatabaseGroupRequest, opts ...grpc.CallOption) (*DatabaseGroup, error)
+	// Permissions required: projects.update
 	CreateDatabaseGroup(ctx context.Context, in *CreateDatabaseGroupRequest, opts ...grpc.CallOption) (*DatabaseGroup, error)
+	// Permissions required: projects.update
 	UpdateDatabaseGroup(ctx context.Context, in *UpdateDatabaseGroupRequest, opts ...grpc.CallOption) (*DatabaseGroup, error)
+	// Permissions required: projects.update
 	DeleteDatabaseGroup(ctx context.Context, in *DeleteDatabaseGroupRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -100,10 +105,15 @@ func (c *databaseGroupServiceClient) DeleteDatabaseGroup(ctx context.Context, in
 // All implementations must embed UnimplementedDatabaseGroupServiceServer
 // for forward compatibility.
 type DatabaseGroupServiceServer interface {
+	// Permissions required: projects.get
 	ListDatabaseGroups(context.Context, *ListDatabaseGroupsRequest) (*ListDatabaseGroupsResponse, error)
+	// Permissions required: projects.get
 	GetDatabaseGroup(context.Context, *GetDatabaseGroupRequest) (*DatabaseGroup, error)
+	// Permissions required: projects.update
 	CreateDatabaseGroup(context.Context, *CreateDatabaseGroupRequest) (*DatabaseGroup, error)
+	// Permissions required: projects.update
 	UpdateDatabaseGroup(context.Context, *UpdateDatabaseGroupRequest) (*DatabaseGroup, error)
+	// Permissions required: projects.update
 	DeleteDatabaseGroup(context.Context, *DeleteDatabaseGroupRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedDatabaseGroupServiceServer()
 }

--- a/proto/generated-go/v1/database_service.pb.gw.go
+++ b/proto/generated-go/v1/database_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_DatabaseService_GetDatabase_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -80,7 +82,9 @@ func request_DatabaseService_BatchGetDatabases_0(ctx context.Context, marshaler 
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -131,7 +135,9 @@ func request_DatabaseService_BatchGetDatabases_1(ctx context.Context, marshaler 
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -182,7 +188,9 @@ func request_DatabaseService_ListDatabases_0(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -233,7 +241,9 @@ func request_DatabaseService_ListDatabases_1(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -284,7 +294,9 @@ func request_DatabaseService_ListDatabases_2(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -341,6 +353,9 @@ func request_DatabaseService_UpdateDatabase_0(ctx context.Context, marshaler run
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Database); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Database); err != nil {
@@ -414,6 +429,9 @@ func request_DatabaseService_BatchUpdateDatabases_0(ctx context.Context, marshal
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -455,6 +473,9 @@ func request_DatabaseService_SyncDatabase_0(ctx context.Context, marshaler runti
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {
@@ -498,6 +519,9 @@ func request_DatabaseService_BatchSyncDatabases_0(ctx context.Context, marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -539,7 +563,9 @@ func request_DatabaseService_GetDatabaseMetadata_0(ctx context.Context, marshale
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -590,7 +616,9 @@ func request_DatabaseService_GetDatabaseSchema_0(ctx context.Context, marshaler 
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -642,6 +670,9 @@ func request_DatabaseService_DiffSchema_0(ctx context.Context, marshaler runtime
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -684,6 +715,9 @@ func request_DatabaseService_DiffSchema_1(ctx context.Context, marshaler runtime
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -725,7 +759,9 @@ func request_DatabaseService_ListSecrets_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -782,6 +818,9 @@ func request_DatabaseService_UpdateSecret_0(ctx context.Context, marshaler runti
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Secret); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Secret); err != nil {
@@ -852,7 +891,9 @@ func request_DatabaseService_DeleteSecret_0(ctx context.Context, marshaler runti
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -891,7 +932,9 @@ func request_DatabaseService_ListChangelogs_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -942,7 +985,9 @@ func request_DatabaseService_GetChangelog_0(ctx context.Context, marshaler runti
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -993,7 +1038,9 @@ func request_DatabaseService_GetSchemaString_0(ctx context.Context, marshaler ru
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/database_service_grpc.pb.go
+++ b/proto/generated-go/v1/database_service_grpc.pb.go
@@ -42,21 +42,37 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DatabaseServiceClient interface {
+	// Permissions required: databases.get
 	GetDatabase(ctx context.Context, in *GetDatabaseRequest, opts ...grpc.CallOption) (*Database, error)
+	// Permissions required: databases.get
 	BatchGetDatabases(ctx context.Context, in *BatchGetDatabasesRequest, opts ...grpc.CallOption) (*BatchGetDatabasesResponse, error)
+	// Permissions required: databases.list
 	ListDatabases(ctx context.Context, in *ListDatabasesRequest, opts ...grpc.CallOption) (*ListDatabasesResponse, error)
+	// Permissions required: databases.update
 	UpdateDatabase(ctx context.Context, in *UpdateDatabaseRequest, opts ...grpc.CallOption) (*Database, error)
+	// Permissions required: databases.update
 	BatchUpdateDatabases(ctx context.Context, in *BatchUpdateDatabasesRequest, opts ...grpc.CallOption) (*BatchUpdateDatabasesResponse, error)
+	// Permissions required: databases.sync
 	SyncDatabase(ctx context.Context, in *SyncDatabaseRequest, opts ...grpc.CallOption) (*SyncDatabaseResponse, error)
+	// Permissions required: databases.sync
 	BatchSyncDatabases(ctx context.Context, in *BatchSyncDatabasesRequest, opts ...grpc.CallOption) (*BatchSyncDatabasesResponse, error)
+	// Permissions required: databases.getSchema
 	GetDatabaseMetadata(ctx context.Context, in *GetDatabaseMetadataRequest, opts ...grpc.CallOption) (*DatabaseMetadata, error)
+	// Permissions required: databases.getSchema
 	GetDatabaseSchema(ctx context.Context, in *GetDatabaseSchemaRequest, opts ...grpc.CallOption) (*DatabaseSchema, error)
+	// Permissions required: databases.get
 	DiffSchema(ctx context.Context, in *DiffSchemaRequest, opts ...grpc.CallOption) (*DiffSchemaResponse, error)
+	// Permissions required: databaseSecrets.list
 	ListSecrets(ctx context.Context, in *ListSecretsRequest, opts ...grpc.CallOption) (*ListSecretsResponse, error)
+	// Permissions required: databaseSecrets.update
 	UpdateSecret(ctx context.Context, in *UpdateSecretRequest, opts ...grpc.CallOption) (*Secret, error)
+	// Permissions required: databaseSecrets.delete
 	DeleteSecret(ctx context.Context, in *DeleteSecretRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: changelogs.list
 	ListChangelogs(ctx context.Context, in *ListChangelogsRequest, opts ...grpc.CallOption) (*ListChangelogsResponse, error)
+	// Permissions required: changelogs.get
 	GetChangelog(ctx context.Context, in *GetChangelogRequest, opts ...grpc.CallOption) (*Changelog, error)
+	// Permissions required: databases.getSchema
 	GetSchemaString(ctx context.Context, in *GetSchemaStringRequest, opts ...grpc.CallOption) (*GetSchemaStringResponse, error)
 }
 
@@ -232,21 +248,37 @@ func (c *databaseServiceClient) GetSchemaString(ctx context.Context, in *GetSche
 // All implementations must embed UnimplementedDatabaseServiceServer
 // for forward compatibility.
 type DatabaseServiceServer interface {
+	// Permissions required: databases.get
 	GetDatabase(context.Context, *GetDatabaseRequest) (*Database, error)
+	// Permissions required: databases.get
 	BatchGetDatabases(context.Context, *BatchGetDatabasesRequest) (*BatchGetDatabasesResponse, error)
+	// Permissions required: databases.list
 	ListDatabases(context.Context, *ListDatabasesRequest) (*ListDatabasesResponse, error)
+	// Permissions required: databases.update
 	UpdateDatabase(context.Context, *UpdateDatabaseRequest) (*Database, error)
+	// Permissions required: databases.update
 	BatchUpdateDatabases(context.Context, *BatchUpdateDatabasesRequest) (*BatchUpdateDatabasesResponse, error)
+	// Permissions required: databases.sync
 	SyncDatabase(context.Context, *SyncDatabaseRequest) (*SyncDatabaseResponse, error)
+	// Permissions required: databases.sync
 	BatchSyncDatabases(context.Context, *BatchSyncDatabasesRequest) (*BatchSyncDatabasesResponse, error)
+	// Permissions required: databases.getSchema
 	GetDatabaseMetadata(context.Context, *GetDatabaseMetadataRequest) (*DatabaseMetadata, error)
+	// Permissions required: databases.getSchema
 	GetDatabaseSchema(context.Context, *GetDatabaseSchemaRequest) (*DatabaseSchema, error)
+	// Permissions required: databases.get
 	DiffSchema(context.Context, *DiffSchemaRequest) (*DiffSchemaResponse, error)
+	// Permissions required: databaseSecrets.list
 	ListSecrets(context.Context, *ListSecretsRequest) (*ListSecretsResponse, error)
+	// Permissions required: databaseSecrets.update
 	UpdateSecret(context.Context, *UpdateSecretRequest) (*Secret, error)
+	// Permissions required: databaseSecrets.delete
 	DeleteSecret(context.Context, *DeleteSecretRequest) (*emptypb.Empty, error)
+	// Permissions required: changelogs.list
 	ListChangelogs(context.Context, *ListChangelogsRequest) (*ListChangelogsResponse, error)
+	// Permissions required: changelogs.get
 	GetChangelog(context.Context, *GetChangelogRequest) (*Changelog, error)
+	// Permissions required: databases.getSchema
 	GetSchemaString(context.Context, *GetSchemaStringRequest) (*GetSchemaStringResponse, error)
 	mustEmbedUnimplementedDatabaseServiceServer()
 }

--- a/proto/generated-go/v1/database_service_grpc.pb.go
+++ b/proto/generated-go/v1/database_service_grpc.pb.go
@@ -42,33 +42,33 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DatabaseServiceClient interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	GetDatabase(ctx context.Context, in *GetDatabaseRequest, opts ...grpc.CallOption) (*Database, error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	BatchGetDatabases(ctx context.Context, in *BatchGetDatabasesRequest, opts ...grpc.CallOption) (*BatchGetDatabasesResponse, error)
-	// Permissions required: databases.list
+	// Permissions required: bb.databases.list
 	ListDatabases(ctx context.Context, in *ListDatabasesRequest, opts ...grpc.CallOption) (*ListDatabasesResponse, error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	UpdateDatabase(ctx context.Context, in *UpdateDatabaseRequest, opts ...grpc.CallOption) (*Database, error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	BatchUpdateDatabases(ctx context.Context, in *BatchUpdateDatabasesRequest, opts ...grpc.CallOption) (*BatchUpdateDatabasesResponse, error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	SyncDatabase(ctx context.Context, in *SyncDatabaseRequest, opts ...grpc.CallOption) (*SyncDatabaseResponse, error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	BatchSyncDatabases(ctx context.Context, in *BatchSyncDatabasesRequest, opts ...grpc.CallOption) (*BatchSyncDatabasesResponse, error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseMetadata(ctx context.Context, in *GetDatabaseMetadataRequest, opts ...grpc.CallOption) (*DatabaseMetadata, error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseSchema(ctx context.Context, in *GetDatabaseSchemaRequest, opts ...grpc.CallOption) (*DatabaseSchema, error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	DiffSchema(ctx context.Context, in *DiffSchemaRequest, opts ...grpc.CallOption) (*DiffSchemaResponse, error)
-	// Permissions required: databaseSecrets.list
+	// Permissions required: bb.databaseSecrets.list
 	ListSecrets(ctx context.Context, in *ListSecretsRequest, opts ...grpc.CallOption) (*ListSecretsResponse, error)
-	// Permissions required: databaseSecrets.update
+	// Permissions required: bb.databaseSecrets.update
 	UpdateSecret(ctx context.Context, in *UpdateSecretRequest, opts ...grpc.CallOption) (*Secret, error)
-	// Permissions required: databaseSecrets.delete
+	// Permissions required: bb.databaseSecrets.delete
 	DeleteSecret(ctx context.Context, in *DeleteSecretRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Permissions required: changelogs.list
+	// Permissions required: bb.changelogs.list
 	ListChangelogs(ctx context.Context, in *ListChangelogsRequest, opts ...grpc.CallOption) (*ListChangelogsResponse, error)
 	// Permissions required: changelogs.get
 	GetChangelog(ctx context.Context, in *GetChangelogRequest, opts ...grpc.CallOption) (*Changelog, error)
@@ -248,33 +248,33 @@ func (c *databaseServiceClient) GetSchemaString(ctx context.Context, in *GetSche
 // All implementations must embed UnimplementedDatabaseServiceServer
 // for forward compatibility.
 type DatabaseServiceServer interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	GetDatabase(context.Context, *GetDatabaseRequest) (*Database, error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	BatchGetDatabases(context.Context, *BatchGetDatabasesRequest) (*BatchGetDatabasesResponse, error)
-	// Permissions required: databases.list
+	// Permissions required: bb.databases.list
 	ListDatabases(context.Context, *ListDatabasesRequest) (*ListDatabasesResponse, error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	UpdateDatabase(context.Context, *UpdateDatabaseRequest) (*Database, error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	BatchUpdateDatabases(context.Context, *BatchUpdateDatabasesRequest) (*BatchUpdateDatabasesResponse, error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	SyncDatabase(context.Context, *SyncDatabaseRequest) (*SyncDatabaseResponse, error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	BatchSyncDatabases(context.Context, *BatchSyncDatabasesRequest) (*BatchSyncDatabasesResponse, error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseMetadata(context.Context, *GetDatabaseMetadataRequest) (*DatabaseMetadata, error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseSchema(context.Context, *GetDatabaseSchemaRequest) (*DatabaseSchema, error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	DiffSchema(context.Context, *DiffSchemaRequest) (*DiffSchemaResponse, error)
-	// Permissions required: databaseSecrets.list
+	// Permissions required: bb.databaseSecrets.list
 	ListSecrets(context.Context, *ListSecretsRequest) (*ListSecretsResponse, error)
-	// Permissions required: databaseSecrets.update
+	// Permissions required: bb.databaseSecrets.update
 	UpdateSecret(context.Context, *UpdateSecretRequest) (*Secret, error)
-	// Permissions required: databaseSecrets.delete
+	// Permissions required: bb.databaseSecrets.delete
 	DeleteSecret(context.Context, *DeleteSecretRequest) (*emptypb.Empty, error)
-	// Permissions required: changelogs.list
+	// Permissions required: bb.changelogs.list
 	ListChangelogs(context.Context, *ListChangelogsRequest) (*ListChangelogsResponse, error)
 	// Permissions required: changelogs.get
 	GetChangelog(context.Context, *GetChangelogRequest) (*Changelog, error)

--- a/proto/generated-go/v1/group_service.pb.gw.go
+++ b/proto/generated-go/v1/group_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_GroupService_GetGroup_0(ctx context.Context, marshaler runtime.Mars
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -79,7 +81,9 @@ func request_GroupService_ListGroups_0(ctx context.Context, marshaler runtime.Ma
 		protoReq ListGroupsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -114,6 +118,9 @@ func request_GroupService_CreateGroup_0(ctx context.Context, marshaler runtime.M
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Group); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -157,6 +164,9 @@ func request_GroupService_UpdateGroup_0(ctx context.Context, marshaler runtime.M
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Group); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Group); err != nil {
@@ -227,7 +237,9 @@ func request_GroupService_DeleteGroup_0(ctx context.Context, marshaler runtime.M
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/group_service_grpc.pb.go
+++ b/proto/generated-go/v1/group_service_grpc.pb.go
@@ -31,12 +31,17 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type GroupServiceClient interface {
+	// Permissions required: groups.get
 	GetGroup(ctx context.Context, in *GetGroupRequest, opts ...grpc.CallOption) (*Group, error)
+	// Permissions required: groups.list
 	ListGroups(ctx context.Context, in *ListGroupsRequest, opts ...grpc.CallOption) (*ListGroupsResponse, error)
+	// Permissions required: groups.create
 	CreateGroup(ctx context.Context, in *CreateGroupRequest, opts ...grpc.CallOption) (*Group, error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+	// Permissions required: groups.update
 	UpdateGroup(ctx context.Context, in *UpdateGroupRequest, opts ...grpc.CallOption) (*Group, error)
+	// Permissions required: groups.delete
 	DeleteGroup(ctx context.Context, in *DeleteGroupRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -102,12 +107,17 @@ func (c *groupServiceClient) DeleteGroup(ctx context.Context, in *DeleteGroupReq
 // All implementations must embed UnimplementedGroupServiceServer
 // for forward compatibility.
 type GroupServiceServer interface {
+	// Permissions required: groups.get
 	GetGroup(context.Context, *GetGroupRequest) (*Group, error)
+	// Permissions required: groups.list
 	ListGroups(context.Context, *ListGroupsRequest) (*ListGroupsResponse, error)
+	// Permissions required: groups.create
 	CreateGroup(context.Context, *CreateGroupRequest) (*Group, error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+	// Permissions required: groups.update
 	UpdateGroup(context.Context, *UpdateGroupRequest) (*Group, error)
+	// Permissions required: groups.delete
 	DeleteGroup(context.Context, *DeleteGroupRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedGroupServiceServer()
 }

--- a/proto/generated-go/v1/group_service_grpc.pb.go
+++ b/proto/generated-go/v1/group_service_grpc.pb.go
@@ -31,17 +31,17 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type GroupServiceClient interface {
-	// Permissions required: groups.get
+	// Permissions required: bb.groups.get
 	GetGroup(ctx context.Context, in *GetGroupRequest, opts ...grpc.CallOption) (*Group, error)
-	// Permissions required: groups.list
+	// Permissions required: bb.groups.list
 	ListGroups(ctx context.Context, in *ListGroupsRequest, opts ...grpc.CallOption) (*ListGroupsResponse, error)
-	// Permissions required: groups.create
+	// Permissions required: bb.groups.create
 	CreateGroup(ctx context.Context, in *CreateGroupRequest, opts ...grpc.CallOption) (*Group, error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-	// Permissions required: groups.update
+	// Permissions required: bb.groups.update
 	UpdateGroup(ctx context.Context, in *UpdateGroupRequest, opts ...grpc.CallOption) (*Group, error)
-	// Permissions required: groups.delete
+	// Permissions required: bb.groups.delete
 	DeleteGroup(ctx context.Context, in *DeleteGroupRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -107,17 +107,17 @@ func (c *groupServiceClient) DeleteGroup(ctx context.Context, in *DeleteGroupReq
 // All implementations must embed UnimplementedGroupServiceServer
 // for forward compatibility.
 type GroupServiceServer interface {
-	// Permissions required: groups.get
+	// Permissions required: bb.groups.get
 	GetGroup(context.Context, *GetGroupRequest) (*Group, error)
-	// Permissions required: groups.list
+	// Permissions required: bb.groups.list
 	ListGroups(context.Context, *ListGroupsRequest) (*ListGroupsResponse, error)
-	// Permissions required: groups.create
+	// Permissions required: bb.groups.create
 	CreateGroup(context.Context, *CreateGroupRequest) (*Group, error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-	// Permissions required: groups.update
+	// Permissions required: bb.groups.update
 	UpdateGroup(context.Context, *UpdateGroupRequest) (*Group, error)
-	// Permissions required: groups.delete
+	// Permissions required: bb.groups.delete
 	DeleteGroup(context.Context, *DeleteGroupRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedGroupServiceServer()
 }

--- a/proto/generated-go/v1/idp_service.pb.gw.go
+++ b/proto/generated-go/v1/idp_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_IdentityProviderService_GetIdentityProvider_0(ctx context.Context, 
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -79,7 +81,9 @@ func request_IdentityProviderService_ListIdentityProviders_0(ctx context.Context
 		protoReq ListIdentityProvidersRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -114,6 +118,9 @@ func request_IdentityProviderService_CreateIdentityProvider_0(ctx context.Contex
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.IdentityProvider); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -157,6 +164,9 @@ func request_IdentityProviderService_UpdateIdentityProvider_0(ctx context.Contex
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.IdentityProvider); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.IdentityProvider); err != nil {
@@ -227,7 +237,9 @@ func request_IdentityProviderService_DeleteIdentityProvider_0(ctx context.Contex
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -265,6 +277,9 @@ func request_IdentityProviderService_TestIdentityProvider_0(ctx context.Context,
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.TestIdentityProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err

--- a/proto/generated-go/v1/idp_service_grpc.pb.go
+++ b/proto/generated-go/v1/idp_service_grpc.pb.go
@@ -32,11 +32,17 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type IdentityProviderServiceClient interface {
+	// Permissions required: identityProviders.get
 	GetIdentityProvider(ctx context.Context, in *GetIdentityProviderRequest, opts ...grpc.CallOption) (*IdentityProvider, error)
+	// Permissions required: None
 	ListIdentityProviders(ctx context.Context, in *ListIdentityProvidersRequest, opts ...grpc.CallOption) (*ListIdentityProvidersResponse, error)
+	// Permissions required: identityProviders.create
 	CreateIdentityProvider(ctx context.Context, in *CreateIdentityProviderRequest, opts ...grpc.CallOption) (*IdentityProvider, error)
+	// Permissions required: identityProviders.update
 	UpdateIdentityProvider(ctx context.Context, in *UpdateIdentityProviderRequest, opts ...grpc.CallOption) (*IdentityProvider, error)
+	// Permissions required: identityProviders.delete
 	DeleteIdentityProvider(ctx context.Context, in *DeleteIdentityProviderRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: identityProviders.update
 	TestIdentityProvider(ctx context.Context, in *TestIdentityProviderRequest, opts ...grpc.CallOption) (*TestIdentityProviderResponse, error)
 }
 
@@ -112,11 +118,17 @@ func (c *identityProviderServiceClient) TestIdentityProvider(ctx context.Context
 // All implementations must embed UnimplementedIdentityProviderServiceServer
 // for forward compatibility.
 type IdentityProviderServiceServer interface {
+	// Permissions required: identityProviders.get
 	GetIdentityProvider(context.Context, *GetIdentityProviderRequest) (*IdentityProvider, error)
+	// Permissions required: None
 	ListIdentityProviders(context.Context, *ListIdentityProvidersRequest) (*ListIdentityProvidersResponse, error)
+	// Permissions required: identityProviders.create
 	CreateIdentityProvider(context.Context, *CreateIdentityProviderRequest) (*IdentityProvider, error)
+	// Permissions required: identityProviders.update
 	UpdateIdentityProvider(context.Context, *UpdateIdentityProviderRequest) (*IdentityProvider, error)
+	// Permissions required: identityProviders.delete
 	DeleteIdentityProvider(context.Context, *DeleteIdentityProviderRequest) (*emptypb.Empty, error)
+	// Permissions required: identityProviders.update
 	TestIdentityProvider(context.Context, *TestIdentityProviderRequest) (*TestIdentityProviderResponse, error)
 	mustEmbedUnimplementedIdentityProviderServiceServer()
 }

--- a/proto/generated-go/v1/idp_service_grpc.pb.go
+++ b/proto/generated-go/v1/idp_service_grpc.pb.go
@@ -32,17 +32,17 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type IdentityProviderServiceClient interface {
-	// Permissions required: identityProviders.get
+	// Permissions required: bb.identityProviders.get
 	GetIdentityProvider(ctx context.Context, in *GetIdentityProviderRequest, opts ...grpc.CallOption) (*IdentityProvider, error)
 	// Permissions required: None
 	ListIdentityProviders(ctx context.Context, in *ListIdentityProvidersRequest, opts ...grpc.CallOption) (*ListIdentityProvidersResponse, error)
-	// Permissions required: identityProviders.create
+	// Permissions required: bb.identityProviders.create
 	CreateIdentityProvider(ctx context.Context, in *CreateIdentityProviderRequest, opts ...grpc.CallOption) (*IdentityProvider, error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	UpdateIdentityProvider(ctx context.Context, in *UpdateIdentityProviderRequest, opts ...grpc.CallOption) (*IdentityProvider, error)
-	// Permissions required: identityProviders.delete
+	// Permissions required: bb.identityProviders.delete
 	DeleteIdentityProvider(ctx context.Context, in *DeleteIdentityProviderRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	TestIdentityProvider(ctx context.Context, in *TestIdentityProviderRequest, opts ...grpc.CallOption) (*TestIdentityProviderResponse, error)
 }
 
@@ -118,17 +118,17 @@ func (c *identityProviderServiceClient) TestIdentityProvider(ctx context.Context
 // All implementations must embed UnimplementedIdentityProviderServiceServer
 // for forward compatibility.
 type IdentityProviderServiceServer interface {
-	// Permissions required: identityProviders.get
+	// Permissions required: bb.identityProviders.get
 	GetIdentityProvider(context.Context, *GetIdentityProviderRequest) (*IdentityProvider, error)
 	// Permissions required: None
 	ListIdentityProviders(context.Context, *ListIdentityProvidersRequest) (*ListIdentityProvidersResponse, error)
-	// Permissions required: identityProviders.create
+	// Permissions required: bb.identityProviders.create
 	CreateIdentityProvider(context.Context, *CreateIdentityProviderRequest) (*IdentityProvider, error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	UpdateIdentityProvider(context.Context, *UpdateIdentityProviderRequest) (*IdentityProvider, error)
-	// Permissions required: identityProviders.delete
+	// Permissions required: bb.identityProviders.delete
 	DeleteIdentityProvider(context.Context, *DeleteIdentityProviderRequest) (*emptypb.Empty, error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	TestIdentityProvider(context.Context, *TestIdentityProviderRequest) (*TestIdentityProviderResponse, error)
 	mustEmbedUnimplementedIdentityProviderServiceServer()
 }

--- a/proto/generated-go/v1/instance_role_service.pb.gw.go
+++ b/proto/generated-go/v1/instance_role_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_InstanceRoleService_GetInstanceRole_0(ctx context.Context, marshale
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -80,7 +82,9 @@ func request_InstanceRoleService_ListInstanceRoles_0(ctx context.Context, marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")

--- a/proto/generated-go/v1/instance_role_service_grpc.pb.go
+++ b/proto/generated-go/v1/instance_role_service_grpc.pb.go
@@ -27,7 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type InstanceRoleServiceClient interface {
+	// Permissions required: instanceRoles.get
 	GetInstanceRole(ctx context.Context, in *GetInstanceRoleRequest, opts ...grpc.CallOption) (*InstanceRole, error)
+	// Permissions required: instanceRoles.get
 	ListInstanceRoles(ctx context.Context, in *ListInstanceRolesRequest, opts ...grpc.CallOption) (*ListInstanceRolesResponse, error)
 }
 
@@ -63,7 +65,9 @@ func (c *instanceRoleServiceClient) ListInstanceRoles(ctx context.Context, in *L
 // All implementations must embed UnimplementedInstanceRoleServiceServer
 // for forward compatibility.
 type InstanceRoleServiceServer interface {
+	// Permissions required: instanceRoles.get
 	GetInstanceRole(context.Context, *GetInstanceRoleRequest) (*InstanceRole, error)
+	// Permissions required: instanceRoles.get
 	ListInstanceRoles(context.Context, *ListInstanceRolesRequest) (*ListInstanceRolesResponse, error)
 	mustEmbedUnimplementedInstanceRoleServiceServer()
 }

--- a/proto/generated-go/v1/instance_role_service_grpc.pb.go
+++ b/proto/generated-go/v1/instance_role_service_grpc.pb.go
@@ -27,9 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type InstanceRoleServiceClient interface {
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	GetInstanceRole(ctx context.Context, in *GetInstanceRoleRequest, opts ...grpc.CallOption) (*InstanceRole, error)
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	ListInstanceRoles(ctx context.Context, in *ListInstanceRolesRequest, opts ...grpc.CallOption) (*ListInstanceRolesResponse, error)
 }
 
@@ -65,9 +65,9 @@ func (c *instanceRoleServiceClient) ListInstanceRoles(ctx context.Context, in *L
 // All implementations must embed UnimplementedInstanceRoleServiceServer
 // for forward compatibility.
 type InstanceRoleServiceServer interface {
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	GetInstanceRole(context.Context, *GetInstanceRoleRequest) (*InstanceRole, error)
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	ListInstanceRoles(context.Context, *ListInstanceRolesRequest) (*ListInstanceRolesResponse, error)
 	mustEmbedUnimplementedInstanceRoleServiceServer()
 }

--- a/proto/generated-go/v1/instance_service.pb.gw.go
+++ b/proto/generated-go/v1/instance_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_InstanceService_GetInstance_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -79,7 +81,9 @@ func request_InstanceService_ListInstances_0(ctx context.Context, marshaler runt
 		protoReq ListInstancesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -114,6 +118,9 @@ func request_InstanceService_CreateInstance_0(ctx context.Context, marshaler run
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Instance); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -157,6 +164,9 @@ func request_InstanceService_UpdateInstance_0(ctx context.Context, marshaler run
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Instance); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Instance); err != nil {
@@ -229,7 +239,9 @@ func request_InstanceService_DeleteInstance_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -281,6 +293,9 @@ func request_InstanceService_UndeleteInstance_0(ctx context.Context, marshaler r
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -322,6 +337,9 @@ func request_InstanceService_SyncInstance_0(ctx context.Context, marshaler runti
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {
@@ -365,6 +383,9 @@ func request_InstanceService_ListInstanceDatabase_0(ctx context.Context, marshal
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -406,6 +427,9 @@ func request_InstanceService_BatchSyncInstances_0(ctx context.Context, marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.BatchSyncInstances(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -429,6 +453,9 @@ func request_InstanceService_BatchUpdateInstances_0(ctx context.Context, marshal
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.BatchUpdateInstances(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -454,6 +481,9 @@ func request_InstanceService_AddDataSource_0(ctx context.Context, marshaler runt
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {
@@ -497,6 +527,9 @@ func request_InstanceService_RemoveDataSource_0(ctx context.Context, marshaler r
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -538,6 +571,9 @@ func request_InstanceService_UpdateDataSource_0(ctx context.Context, marshaler r
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {

--- a/proto/generated-go/v1/instance_service_grpc.pb.go
+++ b/proto/generated-go/v1/instance_service_grpc.pb.go
@@ -39,31 +39,31 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type InstanceServiceClient interface {
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	GetInstance(ctx context.Context, in *GetInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
-	// Permissions required: instances.list
+	// Permissions required: bb.instances.list
 	ListInstances(ctx context.Context, in *ListInstancesRequest, opts ...grpc.CallOption) (*ListInstancesResponse, error)
-	// Permissions required: instances.create
+	// Permissions required: bb.instances.create
 	CreateInstance(ctx context.Context, in *CreateInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateInstance(ctx context.Context, in *UpdateInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
-	// Permissions required: instances.delete
+	// Permissions required: bb.instances.delete
 	DeleteInstance(ctx context.Context, in *DeleteInstanceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Permissions required: instances.undelete
+	// Permissions required: bb.instances.undelete
 	UndeleteInstance(ctx context.Context, in *UndeleteInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	SyncInstance(ctx context.Context, in *SyncInstanceRequest, opts ...grpc.CallOption) (*SyncInstanceResponse, error)
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	ListInstanceDatabase(ctx context.Context, in *ListInstanceDatabaseRequest, opts ...grpc.CallOption) (*ListInstanceDatabaseResponse, error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	BatchSyncInstances(ctx context.Context, in *BatchSyncInstancesRequest, opts ...grpc.CallOption) (*BatchSyncInstancesResponse, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	BatchUpdateInstances(ctx context.Context, in *BatchUpdateInstancesRequest, opts ...grpc.CallOption) (*BatchUpdateInstancesResponse, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	AddDataSource(ctx context.Context, in *AddDataSourceRequest, opts ...grpc.CallOption) (*Instance, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	RemoveDataSource(ctx context.Context, in *RemoveDataSourceRequest, opts ...grpc.CallOption) (*Instance, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateDataSource(ctx context.Context, in *UpdateDataSourceRequest, opts ...grpc.CallOption) (*Instance, error)
 }
 
@@ -209,31 +209,31 @@ func (c *instanceServiceClient) UpdateDataSource(ctx context.Context, in *Update
 // All implementations must embed UnimplementedInstanceServiceServer
 // for forward compatibility.
 type InstanceServiceServer interface {
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	GetInstance(context.Context, *GetInstanceRequest) (*Instance, error)
-	// Permissions required: instances.list
+	// Permissions required: bb.instances.list
 	ListInstances(context.Context, *ListInstancesRequest) (*ListInstancesResponse, error)
-	// Permissions required: instances.create
+	// Permissions required: bb.instances.create
 	CreateInstance(context.Context, *CreateInstanceRequest) (*Instance, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateInstance(context.Context, *UpdateInstanceRequest) (*Instance, error)
-	// Permissions required: instances.delete
+	// Permissions required: bb.instances.delete
 	DeleteInstance(context.Context, *DeleteInstanceRequest) (*emptypb.Empty, error)
-	// Permissions required: instances.undelete
+	// Permissions required: bb.instances.undelete
 	UndeleteInstance(context.Context, *UndeleteInstanceRequest) (*Instance, error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	SyncInstance(context.Context, *SyncInstanceRequest) (*SyncInstanceResponse, error)
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	ListInstanceDatabase(context.Context, *ListInstanceDatabaseRequest) (*ListInstanceDatabaseResponse, error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	BatchSyncInstances(context.Context, *BatchSyncInstancesRequest) (*BatchSyncInstancesResponse, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	BatchUpdateInstances(context.Context, *BatchUpdateInstancesRequest) (*BatchUpdateInstancesResponse, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	AddDataSource(context.Context, *AddDataSourceRequest) (*Instance, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	RemoveDataSource(context.Context, *RemoveDataSourceRequest) (*Instance, error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateDataSource(context.Context, *UpdateDataSourceRequest) (*Instance, error)
 	mustEmbedUnimplementedInstanceServiceServer()
 }

--- a/proto/generated-go/v1/instance_service_grpc.pb.go
+++ b/proto/generated-go/v1/instance_service_grpc.pb.go
@@ -39,18 +39,31 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type InstanceServiceClient interface {
+	// Permissions required: instances.get
 	GetInstance(ctx context.Context, in *GetInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
+	// Permissions required: instances.list
 	ListInstances(ctx context.Context, in *ListInstancesRequest, opts ...grpc.CallOption) (*ListInstancesResponse, error)
+	// Permissions required: instances.create
 	CreateInstance(ctx context.Context, in *CreateInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
+	// Permissions required: instances.update
 	UpdateInstance(ctx context.Context, in *UpdateInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
+	// Permissions required: instances.delete
 	DeleteInstance(ctx context.Context, in *DeleteInstanceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: instances.undelete
 	UndeleteInstance(ctx context.Context, in *UndeleteInstanceRequest, opts ...grpc.CallOption) (*Instance, error)
+	// Permissions required: instances.sync
 	SyncInstance(ctx context.Context, in *SyncInstanceRequest, opts ...grpc.CallOption) (*SyncInstanceResponse, error)
+	// Permissions required: instances.get
 	ListInstanceDatabase(ctx context.Context, in *ListInstanceDatabaseRequest, opts ...grpc.CallOption) (*ListInstanceDatabaseResponse, error)
+	// Permissions required: instances.sync
 	BatchSyncInstances(ctx context.Context, in *BatchSyncInstancesRequest, opts ...grpc.CallOption) (*BatchSyncInstancesResponse, error)
+	// Permissions required: instances.update
 	BatchUpdateInstances(ctx context.Context, in *BatchUpdateInstancesRequest, opts ...grpc.CallOption) (*BatchUpdateInstancesResponse, error)
+	// Permissions required: instances.update
 	AddDataSource(ctx context.Context, in *AddDataSourceRequest, opts ...grpc.CallOption) (*Instance, error)
+	// Permissions required: instances.update
 	RemoveDataSource(ctx context.Context, in *RemoveDataSourceRequest, opts ...grpc.CallOption) (*Instance, error)
+	// Permissions required: instances.update
 	UpdateDataSource(ctx context.Context, in *UpdateDataSourceRequest, opts ...grpc.CallOption) (*Instance, error)
 }
 
@@ -196,18 +209,31 @@ func (c *instanceServiceClient) UpdateDataSource(ctx context.Context, in *Update
 // All implementations must embed UnimplementedInstanceServiceServer
 // for forward compatibility.
 type InstanceServiceServer interface {
+	// Permissions required: instances.get
 	GetInstance(context.Context, *GetInstanceRequest) (*Instance, error)
+	// Permissions required: instances.list
 	ListInstances(context.Context, *ListInstancesRequest) (*ListInstancesResponse, error)
+	// Permissions required: instances.create
 	CreateInstance(context.Context, *CreateInstanceRequest) (*Instance, error)
+	// Permissions required: instances.update
 	UpdateInstance(context.Context, *UpdateInstanceRequest) (*Instance, error)
+	// Permissions required: instances.delete
 	DeleteInstance(context.Context, *DeleteInstanceRequest) (*emptypb.Empty, error)
+	// Permissions required: instances.undelete
 	UndeleteInstance(context.Context, *UndeleteInstanceRequest) (*Instance, error)
+	// Permissions required: instances.sync
 	SyncInstance(context.Context, *SyncInstanceRequest) (*SyncInstanceResponse, error)
+	// Permissions required: instances.get
 	ListInstanceDatabase(context.Context, *ListInstanceDatabaseRequest) (*ListInstanceDatabaseResponse, error)
+	// Permissions required: instances.sync
 	BatchSyncInstances(context.Context, *BatchSyncInstancesRequest) (*BatchSyncInstancesResponse, error)
+	// Permissions required: instances.update
 	BatchUpdateInstances(context.Context, *BatchUpdateInstancesRequest) (*BatchUpdateInstancesResponse, error)
+	// Permissions required: instances.update
 	AddDataSource(context.Context, *AddDataSourceRequest) (*Instance, error)
+	// Permissions required: instances.update
 	RemoveDataSource(context.Context, *RemoveDataSourceRequest) (*Instance, error)
+	// Permissions required: instances.update
 	UpdateDataSource(context.Context, *UpdateDataSourceRequest) (*Instance, error)
 	mustEmbedUnimplementedInstanceServiceServer()
 }

--- a/proto/generated-go/v1/issue_service.pb.gw.go
+++ b/proto/generated-go/v1/issue_service.pb.gw.go
@@ -43,7 +43,9 @@ func request_IssueService_GetIssue_0(ctx context.Context, marshaler runtime.Mars
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -95,6 +97,9 @@ func request_IssueService_CreateIssue_0(ctx context.Context, marshaler runtime.M
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Issue); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -136,7 +141,9 @@ func request_IssueService_ListIssues_0(ctx context.Context, marshaler runtime.Ma
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -188,6 +195,9 @@ func request_IssueService_SearchIssues_0(ctx context.Context, marshaler runtime.
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -235,6 +245,9 @@ func request_IssueService_UpdateIssue_0(ctx context.Context, marshaler runtime.M
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Issue); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Issue); err != nil {
@@ -307,7 +320,9 @@ func request_IssueService_ListIssueComments_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -359,6 +374,9 @@ func request_IssueService_CreateIssueComment_0(ctx context.Context, marshaler ru
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.IssueComment); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -406,6 +424,9 @@ func request_IssueService_UpdateIssueComment_0(ctx context.Context, marshaler ru
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.IssueComment); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.IssueComment); err != nil {
@@ -479,6 +500,9 @@ func request_IssueService_BatchUpdateIssuesStatus_0(ctx context.Context, marshal
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -520,6 +544,9 @@ func request_IssueService_ApproveIssue_0(ctx context.Context, marshaler runtime.
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {
@@ -563,6 +590,9 @@ func request_IssueService_RejectIssue_0(ctx context.Context, marshaler runtime.M
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -604,6 +634,9 @@ func request_IssueService_RequestIssue_0(ctx context.Context, marshaler runtime.
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {

--- a/proto/generated-go/v1/issue_service_grpc.pb.go
+++ b/proto/generated-go/v1/issue_service_grpc.pb.go
@@ -37,24 +37,36 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type IssueServiceClient interface {
+	// Permissions required: issues.get
 	GetIssue(ctx context.Context, in *GetIssueRequest, opts ...grpc.CallOption) (*Issue, error)
+	// Permissions required: issues.create
 	CreateIssue(ctx context.Context, in *CreateIssueRequest, opts ...grpc.CallOption) (*Issue, error)
+	// Permissions required: issues.list
 	ListIssues(ctx context.Context, in *ListIssuesRequest, opts ...grpc.CallOption) (*ListIssuesResponse, error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+	// Permissions required: issues.get
 	SearchIssues(ctx context.Context, in *SearchIssuesRequest, opts ...grpc.CallOption) (*SearchIssuesResponse, error)
+	// Permissions required: issues.update
 	UpdateIssue(ctx context.Context, in *UpdateIssueRequest, opts ...grpc.CallOption) (*Issue, error)
+	// Permissions required: issueComments.list
 	ListIssueComments(ctx context.Context, in *ListIssueCommentsRequest, opts ...grpc.CallOption) (*ListIssueCommentsResponse, error)
+	// Permissions required: issueComments.create
 	CreateIssueComment(ctx context.Context, in *CreateIssueCommentRequest, opts ...grpc.CallOption) (*IssueComment, error)
+	// Permissions required: issueComments.update
 	UpdateIssueComment(ctx context.Context, in *UpdateIssueCommentRequest, opts ...grpc.CallOption) (*IssueComment, error)
+	// Permissions required: issues.update
 	BatchUpdateIssuesStatus(ctx context.Context, in *BatchUpdateIssuesStatusRequest, opts ...grpc.CallOption) (*BatchUpdateIssuesStatusResponse, error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	ApproveIssue(ctx context.Context, in *ApproveIssueRequest, opts ...grpc.CallOption) (*Issue, error)
 	// RejectIssue rejects the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RejectIssue(ctx context.Context, in *RejectIssueRequest, opts ...grpc.CallOption) (*Issue, error)
 	// RequestIssue requests the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RequestIssue(ctx context.Context, in *RequestIssueRequest, opts ...grpc.CallOption) (*Issue, error)
 }
 
@@ -190,24 +202,36 @@ func (c *issueServiceClient) RequestIssue(ctx context.Context, in *RequestIssueR
 // All implementations must embed UnimplementedIssueServiceServer
 // for forward compatibility.
 type IssueServiceServer interface {
+	// Permissions required: issues.get
 	GetIssue(context.Context, *GetIssueRequest) (*Issue, error)
+	// Permissions required: issues.create
 	CreateIssue(context.Context, *CreateIssueRequest) (*Issue, error)
+	// Permissions required: issues.list
 	ListIssues(context.Context, *ListIssuesRequest) (*ListIssuesResponse, error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+	// Permissions required: issues.get
 	SearchIssues(context.Context, *SearchIssuesRequest) (*SearchIssuesResponse, error)
+	// Permissions required: issues.update
 	UpdateIssue(context.Context, *UpdateIssueRequest) (*Issue, error)
+	// Permissions required: issueComments.list
 	ListIssueComments(context.Context, *ListIssueCommentsRequest) (*ListIssueCommentsResponse, error)
+	// Permissions required: issueComments.create
 	CreateIssueComment(context.Context, *CreateIssueCommentRequest) (*IssueComment, error)
+	// Permissions required: issueComments.update
 	UpdateIssueComment(context.Context, *UpdateIssueCommentRequest) (*IssueComment, error)
+	// Permissions required: issues.update
 	BatchUpdateIssuesStatus(context.Context, *BatchUpdateIssuesStatusRequest) (*BatchUpdateIssuesStatusResponse, error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	ApproveIssue(context.Context, *ApproveIssueRequest) (*Issue, error)
 	// RejectIssue rejects the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RejectIssue(context.Context, *RejectIssueRequest) (*Issue, error)
 	// RequestIssue requests the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RequestIssue(context.Context, *RequestIssueRequest) (*Issue, error)
 	mustEmbedUnimplementedIssueServiceServer()
 }

--- a/proto/generated-go/v1/issue_service_grpc.pb.go
+++ b/proto/generated-go/v1/issue_service_grpc.pb.go
@@ -37,24 +37,24 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type IssueServiceClient interface {
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	GetIssue(ctx context.Context, in *GetIssueRequest, opts ...grpc.CallOption) (*Issue, error)
-	// Permissions required: issues.create
+	// Permissions required: bb.issues.create
 	CreateIssue(ctx context.Context, in *CreateIssueRequest, opts ...grpc.CallOption) (*Issue, error)
-	// Permissions required: issues.list
+	// Permissions required: bb.issues.list
 	ListIssues(ctx context.Context, in *ListIssuesRequest, opts ...grpc.CallOption) (*ListIssuesResponse, error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	SearchIssues(ctx context.Context, in *SearchIssuesRequest, opts ...grpc.CallOption) (*SearchIssuesResponse, error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	UpdateIssue(ctx context.Context, in *UpdateIssueRequest, opts ...grpc.CallOption) (*Issue, error)
-	// Permissions required: issueComments.list
+	// Permissions required: bb.issueComments.list
 	ListIssueComments(ctx context.Context, in *ListIssueCommentsRequest, opts ...grpc.CallOption) (*ListIssueCommentsResponse, error)
-	// Permissions required: issueComments.create
+	// Permissions required: bb.issueComments.create
 	CreateIssueComment(ctx context.Context, in *CreateIssueCommentRequest, opts ...grpc.CallOption) (*IssueComment, error)
-	// Permissions required: issueComments.update
+	// Permissions required: bb.issueComments.update
 	UpdateIssueComment(ctx context.Context, in *UpdateIssueCommentRequest, opts ...grpc.CallOption) (*IssueComment, error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	BatchUpdateIssuesStatus(ctx context.Context, in *BatchUpdateIssuesStatusRequest, opts ...grpc.CallOption) (*BatchUpdateIssuesStatusResponse, error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.
@@ -202,24 +202,24 @@ func (c *issueServiceClient) RequestIssue(ctx context.Context, in *RequestIssueR
 // All implementations must embed UnimplementedIssueServiceServer
 // for forward compatibility.
 type IssueServiceServer interface {
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	GetIssue(context.Context, *GetIssueRequest) (*Issue, error)
-	// Permissions required: issues.create
+	// Permissions required: bb.issues.create
 	CreateIssue(context.Context, *CreateIssueRequest) (*Issue, error)
-	// Permissions required: issues.list
+	// Permissions required: bb.issues.list
 	ListIssues(context.Context, *ListIssuesRequest) (*ListIssuesResponse, error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	SearchIssues(context.Context, *SearchIssuesRequest) (*SearchIssuesResponse, error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	UpdateIssue(context.Context, *UpdateIssueRequest) (*Issue, error)
-	// Permissions required: issueComments.list
+	// Permissions required: bb.issueComments.list
 	ListIssueComments(context.Context, *ListIssueCommentsRequest) (*ListIssueCommentsResponse, error)
-	// Permissions required: issueComments.create
+	// Permissions required: bb.issueComments.create
 	CreateIssueComment(context.Context, *CreateIssueCommentRequest) (*IssueComment, error)
-	// Permissions required: issueComments.update
+	// Permissions required: bb.issueComments.update
 	UpdateIssueComment(context.Context, *UpdateIssueCommentRequest) (*IssueComment, error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	BatchUpdateIssuesStatus(context.Context, *BatchUpdateIssuesStatusRequest) (*BatchUpdateIssuesStatusResponse, error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.

--- a/proto/generated-go/v1/org_policy_service.pb.gw.go
+++ b/proto/generated-go/v1/org_policy_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_OrgPolicyService_GetPolicy_0(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -78,7 +80,9 @@ func request_OrgPolicyService_GetPolicy_1(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -115,7 +119,9 @@ func request_OrgPolicyService_GetPolicy_2(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -152,7 +158,9 @@ func request_OrgPolicyService_GetPolicy_3(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -189,7 +197,9 @@ func request_OrgPolicyService_GetPolicy_4(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -227,7 +237,9 @@ func request_OrgPolicyService_ListPolicies_0(ctx context.Context, marshaler runt
 		protoReq ListPoliciesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -261,7 +273,9 @@ func request_OrgPolicyService_ListPolicies_1(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -312,7 +326,9 @@ func request_OrgPolicyService_ListPolicies_2(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -363,7 +379,9 @@ func request_OrgPolicyService_ListPolicies_3(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -414,7 +432,9 @@ func request_OrgPolicyService_ListPolicies_4(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -467,6 +487,9 @@ func request_OrgPolicyService_CreatePolicy_0(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -505,6 +528,9 @@ func request_OrgPolicyService_CreatePolicy_1(ctx context.Context, marshaler runt
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -562,6 +588,9 @@ func request_OrgPolicyService_CreatePolicy_2(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -618,6 +647,9 @@ func request_OrgPolicyService_CreatePolicy_3(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -673,6 +705,9 @@ func request_OrgPolicyService_CreatePolicy_4(ctx context.Context, marshaler runt
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -733,6 +768,9 @@ func request_OrgPolicyService_UpdatePolicy_0(ctx context.Context, marshaler runt
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Policy); err != nil {
@@ -812,6 +850,9 @@ func request_OrgPolicyService_UpdatePolicy_1(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Policy); err != nil {
 			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -889,6 +930,9 @@ func request_OrgPolicyService_UpdatePolicy_2(ctx context.Context, marshaler runt
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Policy); err != nil {
@@ -968,6 +1012,9 @@ func request_OrgPolicyService_UpdatePolicy_3(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Policy); err != nil {
 			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -1046,6 +1093,9 @@ func request_OrgPolicyService_UpdatePolicy_4(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Policy); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Policy); err != nil {
 			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -1115,7 +1165,9 @@ func request_OrgPolicyService_DeletePolicy_0(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -1152,7 +1204,9 @@ func request_OrgPolicyService_DeletePolicy_1(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -1189,7 +1243,9 @@ func request_OrgPolicyService_DeletePolicy_2(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -1226,7 +1282,9 @@ func request_OrgPolicyService_DeletePolicy_3(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -1263,7 +1321,9 @@ func request_OrgPolicyService_DeletePolicy_4(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/org_policy_service_grpc.pb.go
+++ b/proto/generated-go/v1/org_policy_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type OrgPolicyServiceClient interface {
+	// Permissions required: policies.get
 	GetPolicy(ctx context.Context, in *GetPolicyRequest, opts ...grpc.CallOption) (*Policy, error)
+	// Permissions required: policies.list
 	ListPolicies(ctx context.Context, in *ListPoliciesRequest, opts ...grpc.CallOption) (*ListPoliciesResponse, error)
+	// Permissions required: policies.create
 	CreatePolicy(ctx context.Context, in *CreatePolicyRequest, opts ...grpc.CallOption) (*Policy, error)
+	// Permissions required: policies.update
 	UpdatePolicy(ctx context.Context, in *UpdatePolicyRequest, opts ...grpc.CallOption) (*Policy, error)
+	// Permissions required: policies.delete
 	DeletePolicy(ctx context.Context, in *DeletePolicyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -100,10 +105,15 @@ func (c *orgPolicyServiceClient) DeletePolicy(ctx context.Context, in *DeletePol
 // All implementations must embed UnimplementedOrgPolicyServiceServer
 // for forward compatibility.
 type OrgPolicyServiceServer interface {
+	// Permissions required: policies.get
 	GetPolicy(context.Context, *GetPolicyRequest) (*Policy, error)
+	// Permissions required: policies.list
 	ListPolicies(context.Context, *ListPoliciesRequest) (*ListPoliciesResponse, error)
+	// Permissions required: policies.create
 	CreatePolicy(context.Context, *CreatePolicyRequest) (*Policy, error)
+	// Permissions required: policies.update
 	UpdatePolicy(context.Context, *UpdatePolicyRequest) (*Policy, error)
+	// Permissions required: policies.delete
 	DeletePolicy(context.Context, *DeletePolicyRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedOrgPolicyServiceServer()
 }

--- a/proto/generated-go/v1/org_policy_service_grpc.pb.go
+++ b/proto/generated-go/v1/org_policy_service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type OrgPolicyServiceClient interface {
-	// Permissions required: policies.get
+	// Permissions required: bb.policies.get
 	GetPolicy(ctx context.Context, in *GetPolicyRequest, opts ...grpc.CallOption) (*Policy, error)
-	// Permissions required: policies.list
+	// Permissions required: bb.policies.list
 	ListPolicies(ctx context.Context, in *ListPoliciesRequest, opts ...grpc.CallOption) (*ListPoliciesResponse, error)
-	// Permissions required: policies.create
+	// Permissions required: bb.policies.create
 	CreatePolicy(ctx context.Context, in *CreatePolicyRequest, opts ...grpc.CallOption) (*Policy, error)
-	// Permissions required: policies.update
+	// Permissions required: bb.policies.update
 	UpdatePolicy(ctx context.Context, in *UpdatePolicyRequest, opts ...grpc.CallOption) (*Policy, error)
-	// Permissions required: policies.delete
+	// Permissions required: bb.policies.delete
 	DeletePolicy(ctx context.Context, in *DeletePolicyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -105,15 +105,15 @@ func (c *orgPolicyServiceClient) DeletePolicy(ctx context.Context, in *DeletePol
 // All implementations must embed UnimplementedOrgPolicyServiceServer
 // for forward compatibility.
 type OrgPolicyServiceServer interface {
-	// Permissions required: policies.get
+	// Permissions required: bb.policies.get
 	GetPolicy(context.Context, *GetPolicyRequest) (*Policy, error)
-	// Permissions required: policies.list
+	// Permissions required: bb.policies.list
 	ListPolicies(context.Context, *ListPoliciesRequest) (*ListPoliciesResponse, error)
-	// Permissions required: policies.create
+	// Permissions required: bb.policies.create
 	CreatePolicy(context.Context, *CreatePolicyRequest) (*Policy, error)
-	// Permissions required: policies.update
+	// Permissions required: bb.policies.update
 	UpdatePolicy(context.Context, *UpdatePolicyRequest) (*Policy, error)
-	// Permissions required: policies.delete
+	// Permissions required: bb.policies.delete
 	DeletePolicy(context.Context, *DeletePolicyRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedOrgPolicyServiceServer()
 }

--- a/proto/generated-go/v1/plan_service.pb.gw.go
+++ b/proto/generated-go/v1/plan_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_PlanService_GetPlan_0(ctx context.Context, marshaler runtime.Marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -80,7 +82,9 @@ func request_PlanService_ListPlans_0(ctx context.Context, marshaler runtime.Mars
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -132,6 +136,9 @@ func request_PlanService_SearchPlans_0(ctx context.Context, marshaler runtime.Ma
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -173,6 +180,9 @@ func request_PlanService_CreatePlan_0(ctx context.Context, marshaler runtime.Mar
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Plan); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -221,6 +231,9 @@ func request_PlanService_UpdatePlan_0(ctx context.Context, marshaler runtime.Mar
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Plan); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Plan); err != nil {
@@ -293,7 +306,9 @@ func request_PlanService_ListPlanCheckRuns_0(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -345,6 +360,9 @@ func request_PlanService_RunPlanChecks_0(ctx context.Context, marshaler runtime.
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -386,6 +404,9 @@ func request_PlanService_BatchCancelPlanCheckRuns_0(ctx context.Context, marshal
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {

--- a/proto/generated-go/v1/plan_service_grpc.pb.go
+++ b/proto/generated-go/v1/plan_service_grpc.pb.go
@@ -33,24 +33,24 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type PlanServiceClient interface {
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	GetPlan(ctx context.Context, in *GetPlanRequest, opts ...grpc.CallOption) (*Plan, error)
-	// Permissions required: plans.list
+	// Permissions required: bb.plans.list
 	ListPlans(ctx context.Context, in *ListPlansRequest, opts ...grpc.CallOption) (*ListPlansResponse, error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	SearchPlans(ctx context.Context, in *SearchPlansRequest, opts ...grpc.CallOption) (*SearchPlansResponse, error)
-	// Permissions required: plans.create
+	// Permissions required: bb.plans.create
 	CreatePlan(ctx context.Context, in *CreatePlanRequest, opts ...grpc.CallOption) (*Plan, error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
-	// Permissions required: plans.update
+	// Permissions required: bb.plans.update
 	UpdatePlan(ctx context.Context, in *UpdatePlanRequest, opts ...grpc.CallOption) (*Plan, error)
-	// Permissions required: planCheckRuns.list
+	// Permissions required: bb.planCheckRuns.list
 	ListPlanCheckRuns(ctx context.Context, in *ListPlanCheckRunsRequest, opts ...grpc.CallOption) (*ListPlanCheckRunsResponse, error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	RunPlanChecks(ctx context.Context, in *RunPlanChecksRequest, opts ...grpc.CallOption) (*RunPlanChecksResponse, error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	BatchCancelPlanCheckRuns(ctx context.Context, in *BatchCancelPlanCheckRunsRequest, opts ...grpc.CallOption) (*BatchCancelPlanCheckRunsResponse, error)
 }
 
@@ -146,24 +146,24 @@ func (c *planServiceClient) BatchCancelPlanCheckRuns(ctx context.Context, in *Ba
 // All implementations must embed UnimplementedPlanServiceServer
 // for forward compatibility.
 type PlanServiceServer interface {
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	GetPlan(context.Context, *GetPlanRequest) (*Plan, error)
-	// Permissions required: plans.list
+	// Permissions required: bb.plans.list
 	ListPlans(context.Context, *ListPlansRequest) (*ListPlansResponse, error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	SearchPlans(context.Context, *SearchPlansRequest) (*SearchPlansResponse, error)
-	// Permissions required: plans.create
+	// Permissions required: bb.plans.create
 	CreatePlan(context.Context, *CreatePlanRequest) (*Plan, error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
-	// Permissions required: plans.update
+	// Permissions required: bb.plans.update
 	UpdatePlan(context.Context, *UpdatePlanRequest) (*Plan, error)
-	// Permissions required: planCheckRuns.list
+	// Permissions required: bb.planCheckRuns.list
 	ListPlanCheckRuns(context.Context, *ListPlanCheckRunsRequest) (*ListPlanCheckRunsResponse, error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	RunPlanChecks(context.Context, *RunPlanChecksRequest) (*RunPlanChecksResponse, error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	BatchCancelPlanCheckRuns(context.Context, *BatchCancelPlanCheckRunsRequest) (*BatchCancelPlanCheckRunsResponse, error)
 	mustEmbedUnimplementedPlanServiceServer()
 }

--- a/proto/generated-go/v1/plan_service_grpc.pb.go
+++ b/proto/generated-go/v1/plan_service_grpc.pb.go
@@ -33,16 +33,24 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type PlanServiceClient interface {
+	// Permissions required: plans.get
 	GetPlan(ctx context.Context, in *GetPlanRequest, opts ...grpc.CallOption) (*Plan, error)
+	// Permissions required: plans.list
 	ListPlans(ctx context.Context, in *ListPlansRequest, opts ...grpc.CallOption) (*ListPlansResponse, error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+	// Permissions required: plans.get
 	SearchPlans(ctx context.Context, in *SearchPlansRequest, opts ...grpc.CallOption) (*SearchPlansResponse, error)
+	// Permissions required: plans.create
 	CreatePlan(ctx context.Context, in *CreatePlanRequest, opts ...grpc.CallOption) (*Plan, error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
+	// Permissions required: plans.update
 	UpdatePlan(ctx context.Context, in *UpdatePlanRequest, opts ...grpc.CallOption) (*Plan, error)
+	// Permissions required: planCheckRuns.list
 	ListPlanCheckRuns(ctx context.Context, in *ListPlanCheckRunsRequest, opts ...grpc.CallOption) (*ListPlanCheckRunsResponse, error)
+	// Permissions required: planCheckRuns.run
 	RunPlanChecks(ctx context.Context, in *RunPlanChecksRequest, opts ...grpc.CallOption) (*RunPlanChecksResponse, error)
+	// Permissions required: planCheckRuns.run
 	BatchCancelPlanCheckRuns(ctx context.Context, in *BatchCancelPlanCheckRunsRequest, opts ...grpc.CallOption) (*BatchCancelPlanCheckRunsResponse, error)
 }
 
@@ -138,16 +146,24 @@ func (c *planServiceClient) BatchCancelPlanCheckRuns(ctx context.Context, in *Ba
 // All implementations must embed UnimplementedPlanServiceServer
 // for forward compatibility.
 type PlanServiceServer interface {
+	// Permissions required: plans.get
 	GetPlan(context.Context, *GetPlanRequest) (*Plan, error)
+	// Permissions required: plans.list
 	ListPlans(context.Context, *ListPlansRequest) (*ListPlansResponse, error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+	// Permissions required: plans.get
 	SearchPlans(context.Context, *SearchPlansRequest) (*SearchPlansResponse, error)
+	// Permissions required: plans.create
 	CreatePlan(context.Context, *CreatePlanRequest) (*Plan, error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
+	// Permissions required: plans.update
 	UpdatePlan(context.Context, *UpdatePlanRequest) (*Plan, error)
+	// Permissions required: planCheckRuns.list
 	ListPlanCheckRuns(context.Context, *ListPlanCheckRunsRequest) (*ListPlanCheckRunsResponse, error)
+	// Permissions required: planCheckRuns.run
 	RunPlanChecks(context.Context, *RunPlanChecksRequest) (*RunPlanChecksResponse, error)
+	// Permissions required: planCheckRuns.run
 	BatchCancelPlanCheckRuns(context.Context, *BatchCancelPlanCheckRunsRequest) (*BatchCancelPlanCheckRunsResponse, error)
 	mustEmbedUnimplementedPlanServiceServer()
 }

--- a/proto/generated-go/v1/project_service.pb.gw.go
+++ b/proto/generated-go/v1/project_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_ProjectService_GetProject_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -79,7 +81,9 @@ func request_ProjectService_ListProjects_0(ctx context.Context, marshaler runtim
 		protoReq ListProjectsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -113,6 +117,9 @@ func request_ProjectService_SearchProjects_0(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.SearchProjects(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -138,6 +145,9 @@ func request_ProjectService_CreateProject_0(ctx context.Context, marshaler runti
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Project); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -181,6 +191,9 @@ func request_ProjectService_UpdateProject_0(ctx context.Context, marshaler runti
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Project); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Project); err != nil {
@@ -253,7 +266,9 @@ func request_ProjectService_DeleteProject_0(ctx context.Context, marshaler runti
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -305,6 +320,9 @@ func request_ProjectService_UndeleteProject_0(ctx context.Context, marshaler run
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -346,6 +364,9 @@ func request_ProjectService_BatchDeleteProjects_0(ctx context.Context, marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.BatchDeleteProjects(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -368,7 +389,9 @@ func request_ProjectService_GetIamPolicy_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["resource"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "resource")
@@ -407,7 +430,9 @@ func request_ProjectService_BatchGetIamPolicy_0(ctx context.Context, marshaler r
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["scope"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "scope")
@@ -459,6 +484,9 @@ func request_ProjectService_SetIamPolicy_0(ctx context.Context, marshaler runtim
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["resource"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "resource")
@@ -500,6 +528,9 @@ func request_ProjectService_AddWebhook_0(ctx context.Context, marshaler runtime.
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["project"]
 	if !ok {
@@ -543,6 +574,9 @@ func request_ProjectService_UpdateWebhook_0(ctx context.Context, marshaler runti
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["webhook.name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "webhook.name")
@@ -585,6 +619,9 @@ func request_ProjectService_RemoveWebhook_0(ctx context.Context, marshaler runti
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["webhook.name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "webhook.name")
@@ -626,6 +663,9 @@ func request_ProjectService_TestWebhook_0(ctx context.Context, marshaler runtime
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["project"]
 	if !ok {

--- a/proto/generated-go/v1/project_service_grpc.pb.go
+++ b/proto/generated-go/v1/project_service_grpc.pb.go
@@ -43,36 +43,36 @@ const (
 type ProjectServiceClient interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetProject(ctx context.Context, in *GetProjectRequest, opts ...grpc.CallOption) (*Project, error)
-	// Permissions required: projects.list
+	// Permissions required: bb.projects.list
 	ListProjects(ctx context.Context, in *ListProjectsRequest, opts ...grpc.CallOption) (*ListProjectsResponse, error)
 	// Permissions required: None
 	SearchProjects(ctx context.Context, in *SearchProjectsRequest, opts ...grpc.CallOption) (*SearchProjectsResponse, error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	CreateProject(ctx context.Context, in *CreateProjectRequest, opts ...grpc.CallOption) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateProject(ctx context.Context, in *UpdateProjectRequest, opts ...grpc.CallOption) (*Project, error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	DeleteProject(ctx context.Context, in *DeleteProjectRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Permissions required: projects.undelete
+	// Permissions required: bb.projects.undelete
 	UndeleteProject(ctx context.Context, in *UndeleteProjectRequest, opts ...grpc.CallOption) (*Project, error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	BatchDeleteProjects(ctx context.Context, in *BatchDeleteProjectsRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	GetIamPolicy(ctx context.Context, in *GetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
 	// Deprecated.
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	BatchGetIamPolicy(ctx context.Context, in *BatchGetIamPolicyRequest, opts ...grpc.CallOption) (*BatchGetIamPolicyResponse, error)
-	// Permissions required: projects.setIamPolicy
+	// Permissions required: bb.projects.setIamPolicy
 	SetIamPolicy(ctx context.Context, in *SetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	AddWebhook(ctx context.Context, in *AddWebhookRequest, opts ...grpc.CallOption) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateWebhook(ctx context.Context, in *UpdateWebhookRequest, opts ...grpc.CallOption) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	RemoveWebhook(ctx context.Context, in *RemoveWebhookRequest, opts ...grpc.CallOption) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	TestWebhook(ctx context.Context, in *TestWebhookRequest, opts ...grpc.CallOption) (*TestWebhookResponse, error)
 }
 
@@ -240,36 +240,36 @@ func (c *projectServiceClient) TestWebhook(ctx context.Context, in *TestWebhookR
 type ProjectServiceServer interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetProject(context.Context, *GetProjectRequest) (*Project, error)
-	// Permissions required: projects.list
+	// Permissions required: bb.projects.list
 	ListProjects(context.Context, *ListProjectsRequest) (*ListProjectsResponse, error)
 	// Permissions required: None
 	SearchProjects(context.Context, *SearchProjectsRequest) (*SearchProjectsResponse, error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	CreateProject(context.Context, *CreateProjectRequest) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateProject(context.Context, *UpdateProjectRequest) (*Project, error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	DeleteProject(context.Context, *DeleteProjectRequest) (*emptypb.Empty, error)
-	// Permissions required: projects.undelete
+	// Permissions required: bb.projects.undelete
 	UndeleteProject(context.Context, *UndeleteProjectRequest) (*Project, error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	BatchDeleteProjects(context.Context, *BatchDeleteProjectsRequest) (*emptypb.Empty, error)
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	GetIamPolicy(context.Context, *GetIamPolicyRequest) (*IamPolicy, error)
 	// Deprecated.
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	BatchGetIamPolicy(context.Context, *BatchGetIamPolicyRequest) (*BatchGetIamPolicyResponse, error)
-	// Permissions required: projects.setIamPolicy
+	// Permissions required: bb.projects.setIamPolicy
 	SetIamPolicy(context.Context, *SetIamPolicyRequest) (*IamPolicy, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	AddWebhook(context.Context, *AddWebhookRequest) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateWebhook(context.Context, *UpdateWebhookRequest) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	RemoveWebhook(context.Context, *RemoveWebhookRequest) (*Project, error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	TestWebhook(context.Context, *TestWebhookRequest) (*TestWebhookResponse, error)
 	mustEmbedUnimplementedProjectServiceServer()
 }

--- a/proto/generated-go/v1/project_service_grpc.pb.go
+++ b/proto/generated-go/v1/project_service_grpc.pb.go
@@ -43,21 +43,36 @@ const (
 type ProjectServiceClient interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+	// Permissions required: projects.get
 	GetProject(ctx context.Context, in *GetProjectRequest, opts ...grpc.CallOption) (*Project, error)
+	// Permissions required: projects.list
 	ListProjects(ctx context.Context, in *ListProjectsRequest, opts ...grpc.CallOption) (*ListProjectsResponse, error)
+	// Permissions required: None
 	SearchProjects(ctx context.Context, in *SearchProjectsRequest, opts ...grpc.CallOption) (*SearchProjectsResponse, error)
+	// Permissions required: projects.create
 	CreateProject(ctx context.Context, in *CreateProjectRequest, opts ...grpc.CallOption) (*Project, error)
+	// Permissions required: projects.update
 	UpdateProject(ctx context.Context, in *UpdateProjectRequest, opts ...grpc.CallOption) (*Project, error)
+	// Permissions required: projects.delete
 	DeleteProject(ctx context.Context, in *DeleteProjectRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: projects.undelete
 	UndeleteProject(ctx context.Context, in *UndeleteProjectRequest, opts ...grpc.CallOption) (*Project, error)
+	// Permissions required: projects.delete
 	BatchDeleteProjects(ctx context.Context, in *BatchDeleteProjectsRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: projects.getIamPolicy
 	GetIamPolicy(ctx context.Context, in *GetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
 	// Deprecated.
+	// Permissions required: projects.getIamPolicy
 	BatchGetIamPolicy(ctx context.Context, in *BatchGetIamPolicyRequest, opts ...grpc.CallOption) (*BatchGetIamPolicyResponse, error)
+	// Permissions required: projects.setIamPolicy
 	SetIamPolicy(ctx context.Context, in *SetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
+	// Permissions required: projects.update
 	AddWebhook(ctx context.Context, in *AddWebhookRequest, opts ...grpc.CallOption) (*Project, error)
+	// Permissions required: projects.update
 	UpdateWebhook(ctx context.Context, in *UpdateWebhookRequest, opts ...grpc.CallOption) (*Project, error)
+	// Permissions required: projects.update
 	RemoveWebhook(ctx context.Context, in *RemoveWebhookRequest, opts ...grpc.CallOption) (*Project, error)
+	// Permissions required: projects.update
 	TestWebhook(ctx context.Context, in *TestWebhookRequest, opts ...grpc.CallOption) (*TestWebhookResponse, error)
 }
 
@@ -225,21 +240,36 @@ func (c *projectServiceClient) TestWebhook(ctx context.Context, in *TestWebhookR
 type ProjectServiceServer interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+	// Permissions required: projects.get
 	GetProject(context.Context, *GetProjectRequest) (*Project, error)
+	// Permissions required: projects.list
 	ListProjects(context.Context, *ListProjectsRequest) (*ListProjectsResponse, error)
+	// Permissions required: None
 	SearchProjects(context.Context, *SearchProjectsRequest) (*SearchProjectsResponse, error)
+	// Permissions required: projects.create
 	CreateProject(context.Context, *CreateProjectRequest) (*Project, error)
+	// Permissions required: projects.update
 	UpdateProject(context.Context, *UpdateProjectRequest) (*Project, error)
+	// Permissions required: projects.delete
 	DeleteProject(context.Context, *DeleteProjectRequest) (*emptypb.Empty, error)
+	// Permissions required: projects.undelete
 	UndeleteProject(context.Context, *UndeleteProjectRequest) (*Project, error)
+	// Permissions required: projects.delete
 	BatchDeleteProjects(context.Context, *BatchDeleteProjectsRequest) (*emptypb.Empty, error)
+	// Permissions required: projects.getIamPolicy
 	GetIamPolicy(context.Context, *GetIamPolicyRequest) (*IamPolicy, error)
 	// Deprecated.
+	// Permissions required: projects.getIamPolicy
 	BatchGetIamPolicy(context.Context, *BatchGetIamPolicyRequest) (*BatchGetIamPolicyResponse, error)
+	// Permissions required: projects.setIamPolicy
 	SetIamPolicy(context.Context, *SetIamPolicyRequest) (*IamPolicy, error)
+	// Permissions required: projects.update
 	AddWebhook(context.Context, *AddWebhookRequest) (*Project, error)
+	// Permissions required: projects.update
 	UpdateWebhook(context.Context, *UpdateWebhookRequest) (*Project, error)
+	// Permissions required: projects.update
 	RemoveWebhook(context.Context, *RemoveWebhookRequest) (*Project, error)
+	// Permissions required: projects.update
 	TestWebhook(context.Context, *TestWebhookRequest) (*TestWebhookResponse, error)
 	mustEmbedUnimplementedProjectServiceServer()
 }

--- a/proto/generated-go/v1/release_service.pb.gw.go
+++ b/proto/generated-go/v1/release_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_ReleaseService_GetRelease_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -80,7 +82,9 @@ func request_ReleaseService_ListReleases_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -132,6 +136,9 @@ func request_ReleaseService_CreateRelease_0(ctx context.Context, marshaler runti
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Release); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -179,6 +186,9 @@ func request_ReleaseService_UpdateRelease_0(ctx context.Context, marshaler runti
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Release); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Release); err != nil {
@@ -249,7 +259,9 @@ func request_ReleaseService_DeleteRelease_0(ctx context.Context, marshaler runti
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -286,7 +298,9 @@ func request_ReleaseService_UndeleteRelease_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -325,6 +339,9 @@ func request_ReleaseService_CheckRelease_0(ctx context.Context, marshaler runtim
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {

--- a/proto/generated-go/v1/release_service_grpc.pb.go
+++ b/proto/generated-go/v1/release_service_grpc.pb.go
@@ -33,19 +33,19 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ReleaseServiceClient interface {
-	// Permissions required: releases.get
+	// Permissions required: bb.releases.get
 	GetRelease(ctx context.Context, in *GetReleaseRequest, opts ...grpc.CallOption) (*Release, error)
-	// Permissions required: releases.list
+	// Permissions required: bb.releases.list
 	ListReleases(ctx context.Context, in *ListReleasesRequest, opts ...grpc.CallOption) (*ListReleasesResponse, error)
-	// Permissions required: releases.create
+	// Permissions required: bb.releases.create
 	CreateRelease(ctx context.Context, in *CreateReleaseRequest, opts ...grpc.CallOption) (*Release, error)
-	// Permissions required: releases.update
+	// Permissions required: bb.releases.update
 	UpdateRelease(ctx context.Context, in *UpdateReleaseRequest, opts ...grpc.CallOption) (*Release, error)
-	// Permissions required: releases.delete
+	// Permissions required: bb.releases.delete
 	DeleteRelease(ctx context.Context, in *DeleteReleaseRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	// Permissions required: releases.undelete
+	// Permissions required: bb.releases.undelete
 	UndeleteRelease(ctx context.Context, in *UndeleteReleaseRequest, opts ...grpc.CallOption) (*Release, error)
-	// Permissions required: releases.check
+	// Permissions required: bb.releases.check
 	CheckRelease(ctx context.Context, in *CheckReleaseRequest, opts ...grpc.CallOption) (*CheckReleaseResponse, error)
 }
 
@@ -131,19 +131,19 @@ func (c *releaseServiceClient) CheckRelease(ctx context.Context, in *CheckReleas
 // All implementations must embed UnimplementedReleaseServiceServer
 // for forward compatibility.
 type ReleaseServiceServer interface {
-	// Permissions required: releases.get
+	// Permissions required: bb.releases.get
 	GetRelease(context.Context, *GetReleaseRequest) (*Release, error)
-	// Permissions required: releases.list
+	// Permissions required: bb.releases.list
 	ListReleases(context.Context, *ListReleasesRequest) (*ListReleasesResponse, error)
-	// Permissions required: releases.create
+	// Permissions required: bb.releases.create
 	CreateRelease(context.Context, *CreateReleaseRequest) (*Release, error)
-	// Permissions required: releases.update
+	// Permissions required: bb.releases.update
 	UpdateRelease(context.Context, *UpdateReleaseRequest) (*Release, error)
-	// Permissions required: releases.delete
+	// Permissions required: bb.releases.delete
 	DeleteRelease(context.Context, *DeleteReleaseRequest) (*emptypb.Empty, error)
-	// Permissions required: releases.undelete
+	// Permissions required: bb.releases.undelete
 	UndeleteRelease(context.Context, *UndeleteReleaseRequest) (*Release, error)
-	// Permissions required: releases.check
+	// Permissions required: bb.releases.check
 	CheckRelease(context.Context, *CheckReleaseRequest) (*CheckReleaseResponse, error)
 	mustEmbedUnimplementedReleaseServiceServer()
 }

--- a/proto/generated-go/v1/release_service_grpc.pb.go
+++ b/proto/generated-go/v1/release_service_grpc.pb.go
@@ -33,12 +33,19 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ReleaseServiceClient interface {
+	// Permissions required: releases.get
 	GetRelease(ctx context.Context, in *GetReleaseRequest, opts ...grpc.CallOption) (*Release, error)
+	// Permissions required: releases.list
 	ListReleases(ctx context.Context, in *ListReleasesRequest, opts ...grpc.CallOption) (*ListReleasesResponse, error)
+	// Permissions required: releases.create
 	CreateRelease(ctx context.Context, in *CreateReleaseRequest, opts ...grpc.CallOption) (*Release, error)
+	// Permissions required: releases.update
 	UpdateRelease(ctx context.Context, in *UpdateReleaseRequest, opts ...grpc.CallOption) (*Release, error)
+	// Permissions required: releases.delete
 	DeleteRelease(ctx context.Context, in *DeleteReleaseRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Permissions required: releases.undelete
 	UndeleteRelease(ctx context.Context, in *UndeleteReleaseRequest, opts ...grpc.CallOption) (*Release, error)
+	// Permissions required: releases.check
 	CheckRelease(ctx context.Context, in *CheckReleaseRequest, opts ...grpc.CallOption) (*CheckReleaseResponse, error)
 }
 
@@ -124,12 +131,19 @@ func (c *releaseServiceClient) CheckRelease(ctx context.Context, in *CheckReleas
 // All implementations must embed UnimplementedReleaseServiceServer
 // for forward compatibility.
 type ReleaseServiceServer interface {
+	// Permissions required: releases.get
 	GetRelease(context.Context, *GetReleaseRequest) (*Release, error)
+	// Permissions required: releases.list
 	ListReleases(context.Context, *ListReleasesRequest) (*ListReleasesResponse, error)
+	// Permissions required: releases.create
 	CreateRelease(context.Context, *CreateReleaseRequest) (*Release, error)
+	// Permissions required: releases.update
 	UpdateRelease(context.Context, *UpdateReleaseRequest) (*Release, error)
+	// Permissions required: releases.delete
 	DeleteRelease(context.Context, *DeleteReleaseRequest) (*emptypb.Empty, error)
+	// Permissions required: releases.undelete
 	UndeleteRelease(context.Context, *UndeleteReleaseRequest) (*Release, error)
+	// Permissions required: releases.check
 	CheckRelease(context.Context, *CheckReleaseRequest) (*CheckReleaseResponse, error)
 	mustEmbedUnimplementedReleaseServiceServer()
 }

--- a/proto/generated-go/v1/review_config_service.pb.gw.go
+++ b/proto/generated-go/v1/review_config_service.pb.gw.go
@@ -43,6 +43,9 @@ func request_ReviewConfigService_CreateReviewConfig_0(ctx context.Context, marsh
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.ReviewConfig); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateReviewConfig(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -66,7 +69,9 @@ func request_ReviewConfigService_ListReviewConfigs_0(ctx context.Context, marsha
 		protoReq ListReviewConfigsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -98,7 +103,9 @@ func request_ReviewConfigService_GetReviewConfig_0(ctx context.Context, marshale
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -143,6 +150,9 @@ func request_ReviewConfigService_UpdateReviewConfig_0(ctx context.Context, marsh
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.ReviewConfig); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.ReviewConfig); err != nil {
@@ -213,7 +223,9 @@ func request_ReviewConfigService_DeleteReviewConfig_0(ctx context.Context, marsh
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/review_config_service_grpc.pb.go
+++ b/proto/generated-go/v1/review_config_service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ReviewConfigServiceClient interface {
-	// Permissions required: reviewConfigs.create
+	// Permissions required: bb.reviewConfigs.create
 	CreateReviewConfig(ctx context.Context, in *CreateReviewConfigRequest, opts ...grpc.CallOption) (*ReviewConfig, error)
-	// Permissions required: reviewConfigs.list
+	// Permissions required: bb.reviewConfigs.list
 	ListReviewConfigs(ctx context.Context, in *ListReviewConfigsRequest, opts ...grpc.CallOption) (*ListReviewConfigsResponse, error)
-	// Permissions required: reviewConfigs.get
+	// Permissions required: bb.reviewConfigs.get
 	GetReviewConfig(ctx context.Context, in *GetReviewConfigRequest, opts ...grpc.CallOption) (*ReviewConfig, error)
-	// Permissions required: reviewConfigs.update
+	// Permissions required: bb.reviewConfigs.update
 	UpdateReviewConfig(ctx context.Context, in *UpdateReviewConfigRequest, opts ...grpc.CallOption) (*ReviewConfig, error)
-	// Permissions required: reviewConfigs.delete
+	// Permissions required: bb.reviewConfigs.delete
 	DeleteReviewConfig(ctx context.Context, in *DeleteReviewConfigRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -105,15 +105,15 @@ func (c *reviewConfigServiceClient) DeleteReviewConfig(ctx context.Context, in *
 // All implementations must embed UnimplementedReviewConfigServiceServer
 // for forward compatibility.
 type ReviewConfigServiceServer interface {
-	// Permissions required: reviewConfigs.create
+	// Permissions required: bb.reviewConfigs.create
 	CreateReviewConfig(context.Context, *CreateReviewConfigRequest) (*ReviewConfig, error)
-	// Permissions required: reviewConfigs.list
+	// Permissions required: bb.reviewConfigs.list
 	ListReviewConfigs(context.Context, *ListReviewConfigsRequest) (*ListReviewConfigsResponse, error)
-	// Permissions required: reviewConfigs.get
+	// Permissions required: bb.reviewConfigs.get
 	GetReviewConfig(context.Context, *GetReviewConfigRequest) (*ReviewConfig, error)
-	// Permissions required: reviewConfigs.update
+	// Permissions required: bb.reviewConfigs.update
 	UpdateReviewConfig(context.Context, *UpdateReviewConfigRequest) (*ReviewConfig, error)
-	// Permissions required: reviewConfigs.delete
+	// Permissions required: bb.reviewConfigs.delete
 	DeleteReviewConfig(context.Context, *DeleteReviewConfigRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedReviewConfigServiceServer()
 }

--- a/proto/generated-go/v1/review_config_service_grpc.pb.go
+++ b/proto/generated-go/v1/review_config_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ReviewConfigServiceClient interface {
+	// Permissions required: reviewConfigs.create
 	CreateReviewConfig(ctx context.Context, in *CreateReviewConfigRequest, opts ...grpc.CallOption) (*ReviewConfig, error)
+	// Permissions required: reviewConfigs.list
 	ListReviewConfigs(ctx context.Context, in *ListReviewConfigsRequest, opts ...grpc.CallOption) (*ListReviewConfigsResponse, error)
+	// Permissions required: reviewConfigs.get
 	GetReviewConfig(ctx context.Context, in *GetReviewConfigRequest, opts ...grpc.CallOption) (*ReviewConfig, error)
+	// Permissions required: reviewConfigs.update
 	UpdateReviewConfig(ctx context.Context, in *UpdateReviewConfigRequest, opts ...grpc.CallOption) (*ReviewConfig, error)
+	// Permissions required: reviewConfigs.delete
 	DeleteReviewConfig(ctx context.Context, in *DeleteReviewConfigRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -100,10 +105,15 @@ func (c *reviewConfigServiceClient) DeleteReviewConfig(ctx context.Context, in *
 // All implementations must embed UnimplementedReviewConfigServiceServer
 // for forward compatibility.
 type ReviewConfigServiceServer interface {
+	// Permissions required: reviewConfigs.create
 	CreateReviewConfig(context.Context, *CreateReviewConfigRequest) (*ReviewConfig, error)
+	// Permissions required: reviewConfigs.list
 	ListReviewConfigs(context.Context, *ListReviewConfigsRequest) (*ListReviewConfigsResponse, error)
+	// Permissions required: reviewConfigs.get
 	GetReviewConfig(context.Context, *GetReviewConfigRequest) (*ReviewConfig, error)
+	// Permissions required: reviewConfigs.update
 	UpdateReviewConfig(context.Context, *UpdateReviewConfigRequest) (*ReviewConfig, error)
+	// Permissions required: reviewConfigs.delete
 	DeleteReviewConfig(context.Context, *DeleteReviewConfigRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedReviewConfigServiceServer()
 }

--- a/proto/generated-go/v1/revision_service.pb.gw.go
+++ b/proto/generated-go/v1/revision_service.pb.gw.go
@@ -43,7 +43,9 @@ func request_RevisionService_ListRevisions_0(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -92,7 +94,9 @@ func request_RevisionService_GetRevision_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -131,6 +135,9 @@ func request_RevisionService_CreateRevision_0(ctx context.Context, marshaler run
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Revision); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -174,6 +181,9 @@ func request_RevisionService_BatchCreateRevisions_0(ctx context.Context, marshal
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -213,7 +223,9 @@ func request_RevisionService_DeleteRevision_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/revision_service_grpc.pb.go
+++ b/proto/generated-go/v1/revision_service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RevisionServiceClient interface {
-	// Permissions required: revisions.list
+	// Permissions required: bb.revisions.list
 	ListRevisions(ctx context.Context, in *ListRevisionsRequest, opts ...grpc.CallOption) (*ListRevisionsResponse, error)
-	// Permissions required: revisions.get
+	// Permissions required: bb.revisions.get
 	GetRevision(ctx context.Context, in *GetRevisionRequest, opts ...grpc.CallOption) (*Revision, error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	CreateRevision(ctx context.Context, in *CreateRevisionRequest, opts ...grpc.CallOption) (*Revision, error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	BatchCreateRevisions(ctx context.Context, in *BatchCreateRevisionsRequest, opts ...grpc.CallOption) (*BatchCreateRevisionsResponse, error)
-	// Permissions required: revisions.delete
+	// Permissions required: bb.revisions.delete
 	DeleteRevision(ctx context.Context, in *DeleteRevisionRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -105,15 +105,15 @@ func (c *revisionServiceClient) DeleteRevision(ctx context.Context, in *DeleteRe
 // All implementations must embed UnimplementedRevisionServiceServer
 // for forward compatibility.
 type RevisionServiceServer interface {
-	// Permissions required: revisions.list
+	// Permissions required: bb.revisions.list
 	ListRevisions(context.Context, *ListRevisionsRequest) (*ListRevisionsResponse, error)
-	// Permissions required: revisions.get
+	// Permissions required: bb.revisions.get
 	GetRevision(context.Context, *GetRevisionRequest) (*Revision, error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	CreateRevision(context.Context, *CreateRevisionRequest) (*Revision, error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	BatchCreateRevisions(context.Context, *BatchCreateRevisionsRequest) (*BatchCreateRevisionsResponse, error)
-	// Permissions required: revisions.delete
+	// Permissions required: bb.revisions.delete
 	DeleteRevision(context.Context, *DeleteRevisionRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedRevisionServiceServer()
 }

--- a/proto/generated-go/v1/revision_service_grpc.pb.go
+++ b/proto/generated-go/v1/revision_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RevisionServiceClient interface {
+	// Permissions required: revisions.list
 	ListRevisions(ctx context.Context, in *ListRevisionsRequest, opts ...grpc.CallOption) (*ListRevisionsResponse, error)
+	// Permissions required: revisions.get
 	GetRevision(ctx context.Context, in *GetRevisionRequest, opts ...grpc.CallOption) (*Revision, error)
+	// Permissions required: revisions.create
 	CreateRevision(ctx context.Context, in *CreateRevisionRequest, opts ...grpc.CallOption) (*Revision, error)
+	// Permissions required: revisions.create
 	BatchCreateRevisions(ctx context.Context, in *BatchCreateRevisionsRequest, opts ...grpc.CallOption) (*BatchCreateRevisionsResponse, error)
+	// Permissions required: revisions.delete
 	DeleteRevision(ctx context.Context, in *DeleteRevisionRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -100,10 +105,15 @@ func (c *revisionServiceClient) DeleteRevision(ctx context.Context, in *DeleteRe
 // All implementations must embed UnimplementedRevisionServiceServer
 // for forward compatibility.
 type RevisionServiceServer interface {
+	// Permissions required: revisions.list
 	ListRevisions(context.Context, *ListRevisionsRequest) (*ListRevisionsResponse, error)
+	// Permissions required: revisions.get
 	GetRevision(context.Context, *GetRevisionRequest) (*Revision, error)
+	// Permissions required: revisions.create
 	CreateRevision(context.Context, *CreateRevisionRequest) (*Revision, error)
+	// Permissions required: revisions.create
 	BatchCreateRevisions(context.Context, *BatchCreateRevisionsRequest) (*BatchCreateRevisionsResponse, error)
+	// Permissions required: revisions.delete
 	DeleteRevision(context.Context, *DeleteRevisionRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedRevisionServiceServer()
 }

--- a/proto/generated-go/v1/risk_service.pb.gw.go
+++ b/proto/generated-go/v1/risk_service.pb.gw.go
@@ -42,7 +42,9 @@ func request_RiskService_ListRisks_0(ctx context.Context, marshaler runtime.Mars
 		protoReq ListRisksRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -76,6 +78,9 @@ func request_RiskService_CreateRisk_0(ctx context.Context, marshaler runtime.Mar
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Risk); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateRisk(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -98,7 +103,9 @@ func request_RiskService_GetRisk_0(ctx context.Context, marshaler runtime.Marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -143,6 +150,9 @@ func request_RiskService_UpdateRisk_0(ctx context.Context, marshaler runtime.Mar
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Risk); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Risk); err != nil {
@@ -213,7 +223,9 @@ func request_RiskService_DeleteRisk_0(ctx context.Context, marshaler runtime.Mar
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/risk_service_grpc.pb.go
+++ b/proto/generated-go/v1/risk_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RiskServiceClient interface {
+	// Permissions required: risks.list
 	ListRisks(ctx context.Context, in *ListRisksRequest, opts ...grpc.CallOption) (*ListRisksResponse, error)
+	// Permissions required: risks.create
 	CreateRisk(ctx context.Context, in *CreateRiskRequest, opts ...grpc.CallOption) (*Risk, error)
+	// Permissions required: risks.list
 	GetRisk(ctx context.Context, in *GetRiskRequest, opts ...grpc.CallOption) (*Risk, error)
+	// Permissions required: risks.update
 	UpdateRisk(ctx context.Context, in *UpdateRiskRequest, opts ...grpc.CallOption) (*Risk, error)
+	// Permissions required: risks.delete
 	DeleteRisk(ctx context.Context, in *DeleteRiskRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -100,10 +105,15 @@ func (c *riskServiceClient) DeleteRisk(ctx context.Context, in *DeleteRiskReques
 // All implementations must embed UnimplementedRiskServiceServer
 // for forward compatibility.
 type RiskServiceServer interface {
+	// Permissions required: risks.list
 	ListRisks(context.Context, *ListRisksRequest) (*ListRisksResponse, error)
+	// Permissions required: risks.create
 	CreateRisk(context.Context, *CreateRiskRequest) (*Risk, error)
+	// Permissions required: risks.list
 	GetRisk(context.Context, *GetRiskRequest) (*Risk, error)
+	// Permissions required: risks.update
 	UpdateRisk(context.Context, *UpdateRiskRequest) (*Risk, error)
+	// Permissions required: risks.delete
 	DeleteRisk(context.Context, *DeleteRiskRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedRiskServiceServer()
 }

--- a/proto/generated-go/v1/risk_service_grpc.pb.go
+++ b/proto/generated-go/v1/risk_service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RiskServiceClient interface {
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	ListRisks(ctx context.Context, in *ListRisksRequest, opts ...grpc.CallOption) (*ListRisksResponse, error)
-	// Permissions required: risks.create
+	// Permissions required: bb.risks.create
 	CreateRisk(ctx context.Context, in *CreateRiskRequest, opts ...grpc.CallOption) (*Risk, error)
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	GetRisk(ctx context.Context, in *GetRiskRequest, opts ...grpc.CallOption) (*Risk, error)
-	// Permissions required: risks.update
+	// Permissions required: bb.risks.update
 	UpdateRisk(ctx context.Context, in *UpdateRiskRequest, opts ...grpc.CallOption) (*Risk, error)
-	// Permissions required: risks.delete
+	// Permissions required: bb.risks.delete
 	DeleteRisk(ctx context.Context, in *DeleteRiskRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -105,15 +105,15 @@ func (c *riskServiceClient) DeleteRisk(ctx context.Context, in *DeleteRiskReques
 // All implementations must embed UnimplementedRiskServiceServer
 // for forward compatibility.
 type RiskServiceServer interface {
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	ListRisks(context.Context, *ListRisksRequest) (*ListRisksResponse, error)
-	// Permissions required: risks.create
+	// Permissions required: bb.risks.create
 	CreateRisk(context.Context, *CreateRiskRequest) (*Risk, error)
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	GetRisk(context.Context, *GetRiskRequest) (*Risk, error)
-	// Permissions required: risks.update
+	// Permissions required: bb.risks.update
 	UpdateRisk(context.Context, *UpdateRiskRequest) (*Risk, error)
-	// Permissions required: risks.delete
+	// Permissions required: bb.risks.delete
 	DeleteRisk(context.Context, *DeleteRiskRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedRiskServiceServer()
 }

--- a/proto/generated-go/v1/role_service.pb.gw.go
+++ b/proto/generated-go/v1/role_service.pb.gw.go
@@ -42,7 +42,9 @@ func request_RoleService_ListRoles_0(ctx context.Context, marshaler runtime.Mars
 		protoReq ListRolesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -74,7 +76,9 @@ func request_RoleService_GetRole_0(ctx context.Context, marshaler runtime.Marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -114,6 +118,9 @@ func request_RoleService_CreateRole_0(ctx context.Context, marshaler runtime.Mar
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Role); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -157,6 +164,9 @@ func request_RoleService_UpdateRole_0(ctx context.Context, marshaler runtime.Mar
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Role); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Role); err != nil {
@@ -227,7 +237,9 @@ func request_RoleService_DeleteRole_0(ctx context.Context, marshaler runtime.Mar
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/role_service_grpc.pb.go
+++ b/proto/generated-go/v1/role_service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RoleServiceClient interface {
-	// Permissions required: roles.list
+	// Permissions required: bb.roles.list
 	ListRoles(ctx context.Context, in *ListRolesRequest, opts ...grpc.CallOption) (*ListRolesResponse, error)
-	// Permissions required: roles.get
+	// Permissions required: bb.roles.get
 	GetRole(ctx context.Context, in *GetRoleRequest, opts ...grpc.CallOption) (*Role, error)
-	// Permissions required: roles.create
+	// Permissions required: bb.roles.create
 	CreateRole(ctx context.Context, in *CreateRoleRequest, opts ...grpc.CallOption) (*Role, error)
-	// Permissions required: roles.update
+	// Permissions required: bb.roles.update
 	UpdateRole(ctx context.Context, in *UpdateRoleRequest, opts ...grpc.CallOption) (*Role, error)
-	// Permissions required: roles.delete
+	// Permissions required: bb.roles.delete
 	DeleteRole(ctx context.Context, in *DeleteRoleRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -105,15 +105,15 @@ func (c *roleServiceClient) DeleteRole(ctx context.Context, in *DeleteRoleReques
 // All implementations must embed UnimplementedRoleServiceServer
 // for forward compatibility.
 type RoleServiceServer interface {
-	// Permissions required: roles.list
+	// Permissions required: bb.roles.list
 	ListRoles(context.Context, *ListRolesRequest) (*ListRolesResponse, error)
-	// Permissions required: roles.get
+	// Permissions required: bb.roles.get
 	GetRole(context.Context, *GetRoleRequest) (*Role, error)
-	// Permissions required: roles.create
+	// Permissions required: bb.roles.create
 	CreateRole(context.Context, *CreateRoleRequest) (*Role, error)
-	// Permissions required: roles.update
+	// Permissions required: bb.roles.update
 	UpdateRole(context.Context, *UpdateRoleRequest) (*Role, error)
-	// Permissions required: roles.delete
+	// Permissions required: bb.roles.delete
 	DeleteRole(context.Context, *DeleteRoleRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedRoleServiceServer()
 }

--- a/proto/generated-go/v1/role_service_grpc.pb.go
+++ b/proto/generated-go/v1/role_service_grpc.pb.go
@@ -31,10 +31,15 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RoleServiceClient interface {
+	// Permissions required: roles.list
 	ListRoles(ctx context.Context, in *ListRolesRequest, opts ...grpc.CallOption) (*ListRolesResponse, error)
+	// Permissions required: roles.get
 	GetRole(ctx context.Context, in *GetRoleRequest, opts ...grpc.CallOption) (*Role, error)
+	// Permissions required: roles.create
 	CreateRole(ctx context.Context, in *CreateRoleRequest, opts ...grpc.CallOption) (*Role, error)
+	// Permissions required: roles.update
 	UpdateRole(ctx context.Context, in *UpdateRoleRequest, opts ...grpc.CallOption) (*Role, error)
+	// Permissions required: roles.delete
 	DeleteRole(ctx context.Context, in *DeleteRoleRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -100,10 +105,15 @@ func (c *roleServiceClient) DeleteRole(ctx context.Context, in *DeleteRoleReques
 // All implementations must embed UnimplementedRoleServiceServer
 // for forward compatibility.
 type RoleServiceServer interface {
+	// Permissions required: roles.list
 	ListRoles(context.Context, *ListRolesRequest) (*ListRolesResponse, error)
+	// Permissions required: roles.get
 	GetRole(context.Context, *GetRoleRequest) (*Role, error)
+	// Permissions required: roles.create
 	CreateRole(context.Context, *CreateRoleRequest) (*Role, error)
+	// Permissions required: roles.update
 	UpdateRole(context.Context, *UpdateRoleRequest) (*Role, error)
+	// Permissions required: roles.delete
 	DeleteRole(context.Context, *DeleteRoleRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedRoleServiceServer()
 }

--- a/proto/generated-go/v1/rollout_service.pb.gw.go
+++ b/proto/generated-go/v1/rollout_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_RolloutService_GetRollout_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -80,7 +82,9 @@ func request_RolloutService_ListRollouts_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -133,6 +137,9 @@ func request_RolloutService_CreateRollout_0(ctx context.Context, marshaler runti
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Rollout); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -188,6 +195,9 @@ func request_RolloutService_PreviewRollout_0(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["project"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "project")
@@ -229,7 +239,9 @@ func request_RolloutService_ListTaskRuns_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -278,7 +290,9 @@ func request_RolloutService_GetTaskRun_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -315,7 +329,9 @@ func request_RolloutService_GetTaskRunLog_0(ctx context.Context, marshaler runti
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -352,7 +368,9 @@ func request_RolloutService_GetTaskRunSession_0(ctx context.Context, marshaler r
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -391,6 +409,9 @@ func request_RolloutService_BatchRunTasks_0(ctx context.Context, marshaler runti
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["parent"]
 	if !ok {
@@ -434,6 +455,9 @@ func request_RolloutService_BatchSkipTasks_0(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -476,6 +500,9 @@ func request_RolloutService_BatchCancelTaskRuns_0(ctx context.Context, marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -517,6 +544,9 @@ func request_RolloutService_PreviewTaskRunRollback_0(ctx context.Context, marsha
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {

--- a/proto/generated-go/v1/rollout_service_grpc.pb.go
+++ b/proto/generated-go/v1/rollout_service_grpc.pb.go
@@ -37,26 +37,38 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RolloutServiceClient interface {
+	// Permissions required: rollouts.get
 	GetRollout(ctx context.Context, in *GetRolloutRequest, opts ...grpc.CallOption) (*Rollout, error)
+	// Permissions required: rollouts.list
 	ListRollouts(ctx context.Context, in *ListRolloutsRequest, opts ...grpc.CallOption) (*ListRolloutsResponse, error)
 	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+	// Permissions required: rollouts.create
 	CreateRollout(ctx context.Context, in *CreateRolloutRequest, opts ...grpc.CallOption) (*Rollout, error)
+	// Permissions required: rollouts.preview
 	PreviewRollout(ctx context.Context, in *PreviewRolloutRequest, opts ...grpc.CallOption) (*Rollout, error)
+	// Permissions required: taskRuns.list
 	ListTaskRuns(ctx context.Context, in *ListTaskRunsRequest, opts ...grpc.CallOption) (*ListTaskRunsResponse, error)
+	// Permissions required: taskRuns.list
 	GetTaskRun(ctx context.Context, in *GetTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error)
+	// Permissions required: taskRuns.list
 	GetTaskRunLog(ctx context.Context, in *GetTaskRunLogRequest, opts ...grpc.CallOption) (*TaskRunLog, error)
+	// Permissions required: taskRuns.list
 	GetTaskRunSession(ctx context.Context, in *GetTaskRunSessionRequest, opts ...grpc.CallOption) (*TaskRunSession, error)
 	// BatchRunTasks creates task runs for the specified tasks.
 	// DataExport issue only allows the creator to run the task.
 	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
 	// Follow role-based rollout policy for the environment.
+	// Permissions required: None
 	BatchRunTasks(ctx context.Context, in *BatchRunTasksRequest, opts ...grpc.CallOption) (*BatchRunTasksResponse, error)
 	// BatchSkipTasks skips the specified tasks.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchSkipTasks(ctx context.Context, in *BatchSkipTasksRequest, opts ...grpc.CallOption) (*BatchSkipTasksResponse, error)
 	// BatchCancelTaskRuns cancels the specified task runs in batch.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchCancelTaskRuns(ctx context.Context, in *BatchCancelTaskRunsRequest, opts ...grpc.CallOption) (*BatchCancelTaskRunsResponse, error)
+	// Permissions required: taskRuns.list
 	PreviewTaskRunRollback(ctx context.Context, in *PreviewTaskRunRollbackRequest, opts ...grpc.CallOption) (*PreviewTaskRunRollbackResponse, error)
 }
 
@@ -192,26 +204,38 @@ func (c *rolloutServiceClient) PreviewTaskRunRollback(ctx context.Context, in *P
 // All implementations must embed UnimplementedRolloutServiceServer
 // for forward compatibility.
 type RolloutServiceServer interface {
+	// Permissions required: rollouts.get
 	GetRollout(context.Context, *GetRolloutRequest) (*Rollout, error)
+	// Permissions required: rollouts.list
 	ListRollouts(context.Context, *ListRolloutsRequest) (*ListRolloutsResponse, error)
 	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+	// Permissions required: rollouts.create
 	CreateRollout(context.Context, *CreateRolloutRequest) (*Rollout, error)
+	// Permissions required: rollouts.preview
 	PreviewRollout(context.Context, *PreviewRolloutRequest) (*Rollout, error)
+	// Permissions required: taskRuns.list
 	ListTaskRuns(context.Context, *ListTaskRunsRequest) (*ListTaskRunsResponse, error)
+	// Permissions required: taskRuns.list
 	GetTaskRun(context.Context, *GetTaskRunRequest) (*TaskRun, error)
+	// Permissions required: taskRuns.list
 	GetTaskRunLog(context.Context, *GetTaskRunLogRequest) (*TaskRunLog, error)
+	// Permissions required: taskRuns.list
 	GetTaskRunSession(context.Context, *GetTaskRunSessionRequest) (*TaskRunSession, error)
 	// BatchRunTasks creates task runs for the specified tasks.
 	// DataExport issue only allows the creator to run the task.
 	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
 	// Follow role-based rollout policy for the environment.
+	// Permissions required: None
 	BatchRunTasks(context.Context, *BatchRunTasksRequest) (*BatchRunTasksResponse, error)
 	// BatchSkipTasks skips the specified tasks.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchSkipTasks(context.Context, *BatchSkipTasksRequest) (*BatchSkipTasksResponse, error)
 	// BatchCancelTaskRuns cancels the specified task runs in batch.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchCancelTaskRuns(context.Context, *BatchCancelTaskRunsRequest) (*BatchCancelTaskRunsResponse, error)
+	// Permissions required: taskRuns.list
 	PreviewTaskRunRollback(context.Context, *PreviewTaskRunRollbackRequest) (*PreviewTaskRunRollbackResponse, error)
 	mustEmbedUnimplementedRolloutServiceServer()
 }

--- a/proto/generated-go/v1/rollout_service_grpc.pb.go
+++ b/proto/generated-go/v1/rollout_service_grpc.pb.go
@@ -37,38 +37,29 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RolloutServiceClient interface {
-	// Permissions required: rollouts.get
+	// Permissions required: bb.rollouts.get
 	GetRollout(ctx context.Context, in *GetRolloutRequest, opts ...grpc.CallOption) (*Rollout, error)
-	// Permissions required: rollouts.list
+	// Permissions required: bb.rollouts.list
 	ListRollouts(ctx context.Context, in *ListRolloutsRequest, opts ...grpc.CallOption) (*ListRolloutsResponse, error)
-	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-	// Permissions required: rollouts.create
+	// Permissions required: bb.rollouts.create
 	CreateRollout(ctx context.Context, in *CreateRolloutRequest, opts ...grpc.CallOption) (*Rollout, error)
-	// Permissions required: rollouts.preview
+	// Permissions required: bb.rollouts.preview
 	PreviewRollout(ctx context.Context, in *PreviewRolloutRequest, opts ...grpc.CallOption) (*Rollout, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	ListTaskRuns(ctx context.Context, in *ListTaskRunsRequest, opts ...grpc.CallOption) (*ListTaskRunsResponse, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRun(ctx context.Context, in *GetTaskRunRequest, opts ...grpc.CallOption) (*TaskRun, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunLog(ctx context.Context, in *GetTaskRunLogRequest, opts ...grpc.CallOption) (*TaskRunLog, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunSession(ctx context.Context, in *GetTaskRunSessionRequest, opts ...grpc.CallOption) (*TaskRunSession, error)
-	// BatchRunTasks creates task runs for the specified tasks.
-	// DataExport issue only allows the creator to run the task.
-	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-	// Follow role-based rollout policy for the environment.
 	// Permissions required: None
 	BatchRunTasks(ctx context.Context, in *BatchRunTasksRequest, opts ...grpc.CallOption) (*BatchRunTasksResponse, error)
-	// BatchSkipTasks skips the specified tasks.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchSkipTasks(ctx context.Context, in *BatchSkipTasksRequest, opts ...grpc.CallOption) (*BatchSkipTasksResponse, error)
-	// BatchCancelTaskRuns cancels the specified task runs in batch.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchCancelTaskRuns(ctx context.Context, in *BatchCancelTaskRunsRequest, opts ...grpc.CallOption) (*BatchCancelTaskRunsResponse, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	PreviewTaskRunRollback(ctx context.Context, in *PreviewTaskRunRollbackRequest, opts ...grpc.CallOption) (*PreviewTaskRunRollbackResponse, error)
 }
 
@@ -204,38 +195,29 @@ func (c *rolloutServiceClient) PreviewTaskRunRollback(ctx context.Context, in *P
 // All implementations must embed UnimplementedRolloutServiceServer
 // for forward compatibility.
 type RolloutServiceServer interface {
-	// Permissions required: rollouts.get
+	// Permissions required: bb.rollouts.get
 	GetRollout(context.Context, *GetRolloutRequest) (*Rollout, error)
-	// Permissions required: rollouts.list
+	// Permissions required: bb.rollouts.list
 	ListRollouts(context.Context, *ListRolloutsRequest) (*ListRolloutsResponse, error)
-	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-	// Permissions required: rollouts.create
+	// Permissions required: bb.rollouts.create
 	CreateRollout(context.Context, *CreateRolloutRequest) (*Rollout, error)
-	// Permissions required: rollouts.preview
+	// Permissions required: bb.rollouts.preview
 	PreviewRollout(context.Context, *PreviewRolloutRequest) (*Rollout, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	ListTaskRuns(context.Context, *ListTaskRunsRequest) (*ListTaskRunsResponse, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRun(context.Context, *GetTaskRunRequest) (*TaskRun, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunLog(context.Context, *GetTaskRunLogRequest) (*TaskRunLog, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunSession(context.Context, *GetTaskRunSessionRequest) (*TaskRunSession, error)
-	// BatchRunTasks creates task runs for the specified tasks.
-	// DataExport issue only allows the creator to run the task.
-	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-	// Follow role-based rollout policy for the environment.
 	// Permissions required: None
 	BatchRunTasks(context.Context, *BatchRunTasksRequest) (*BatchRunTasksResponse, error)
-	// BatchSkipTasks skips the specified tasks.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchSkipTasks(context.Context, *BatchSkipTasksRequest) (*BatchSkipTasksResponse, error)
-	// BatchCancelTaskRuns cancels the specified task runs in batch.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchCancelTaskRuns(context.Context, *BatchCancelTaskRunsRequest) (*BatchCancelTaskRunsResponse, error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	PreviewTaskRunRollback(context.Context, *PreviewTaskRunRollbackRequest) (*PreviewTaskRunRollbackResponse, error)
 	mustEmbedUnimplementedRolloutServiceServer()
 }

--- a/proto/generated-go/v1/setting_service.pb.gw.go
+++ b/proto/generated-go/v1/setting_service.pb.gw.go
@@ -42,7 +42,9 @@ func request_SettingService_ListSettings_0(ctx context.Context, marshaler runtim
 		protoReq ListSettingsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -74,7 +76,9 @@ func request_SettingService_GetSetting_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -119,6 +123,9 @@ func request_SettingService_UpdateSetting_0(ctx context.Context, marshaler runti
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Setting); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Setting); err != nil {

--- a/proto/generated-go/v1/setting_service_grpc.pb.go
+++ b/proto/generated-go/v1/setting_service_grpc.pb.go
@@ -28,8 +28,11 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SettingServiceClient interface {
+	// Permissions required: settings.list
 	ListSettings(ctx context.Context, in *ListSettingsRequest, opts ...grpc.CallOption) (*ListSettingsResponse, error)
+	// Permissions required: settings.get
 	GetSetting(ctx context.Context, in *GetSettingRequest, opts ...grpc.CallOption) (*Setting, error)
+	// Permissions required: settings.set
 	UpdateSetting(ctx context.Context, in *UpdateSettingRequest, opts ...grpc.CallOption) (*Setting, error)
 }
 
@@ -75,8 +78,11 @@ func (c *settingServiceClient) UpdateSetting(ctx context.Context, in *UpdateSett
 // All implementations must embed UnimplementedSettingServiceServer
 // for forward compatibility.
 type SettingServiceServer interface {
+	// Permissions required: settings.list
 	ListSettings(context.Context, *ListSettingsRequest) (*ListSettingsResponse, error)
+	// Permissions required: settings.get
 	GetSetting(context.Context, *GetSettingRequest) (*Setting, error)
+	// Permissions required: settings.set
 	UpdateSetting(context.Context, *UpdateSettingRequest) (*Setting, error)
 	mustEmbedUnimplementedSettingServiceServer()
 }

--- a/proto/generated-go/v1/setting_service_grpc.pb.go
+++ b/proto/generated-go/v1/setting_service_grpc.pb.go
@@ -28,11 +28,11 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SettingServiceClient interface {
-	// Permissions required: settings.list
+	// Permissions required: bb.settings.list
 	ListSettings(ctx context.Context, in *ListSettingsRequest, opts ...grpc.CallOption) (*ListSettingsResponse, error)
-	// Permissions required: settings.get
+	// Permissions required: bb.settings.get
 	GetSetting(ctx context.Context, in *GetSettingRequest, opts ...grpc.CallOption) (*Setting, error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSetting(ctx context.Context, in *UpdateSettingRequest, opts ...grpc.CallOption) (*Setting, error)
 }
 
@@ -78,11 +78,11 @@ func (c *settingServiceClient) UpdateSetting(ctx context.Context, in *UpdateSett
 // All implementations must embed UnimplementedSettingServiceServer
 // for forward compatibility.
 type SettingServiceServer interface {
-	// Permissions required: settings.list
+	// Permissions required: bb.settings.list
 	ListSettings(context.Context, *ListSettingsRequest) (*ListSettingsResponse, error)
-	// Permissions required: settings.get
+	// Permissions required: bb.settings.get
 	GetSetting(context.Context, *GetSettingRequest) (*Setting, error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSetting(context.Context, *UpdateSettingRequest) (*Setting, error)
 	mustEmbedUnimplementedSettingServiceServer()
 }

--- a/proto/generated-go/v1/sheet_service.pb.gw.go
+++ b/proto/generated-go/v1/sheet_service.pb.gw.go
@@ -44,6 +44,9 @@ func request_SheetService_CreateSheet_0(ctx context.Context, marshaler runtime.M
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Sheet); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -86,6 +89,9 @@ func request_SheetService_BatchCreateSheets_0(ctx context.Context, marshaler run
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["parent"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "parent")
@@ -127,7 +133,9 @@ func request_SheetService_GetSheet_0(ctx context.Context, marshaler runtime.Mars
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -184,6 +192,9 @@ func request_SheetService_UpdateSheet_0(ctx context.Context, marshaler runtime.M
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Sheet); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Sheet); err != nil {

--- a/proto/generated-go/v1/sheet_service_grpc.pb.go
+++ b/proto/generated-go/v1/sheet_service_grpc.pb.go
@@ -29,9 +29,13 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SheetServiceClient interface {
+	// Permissions required: sheets.create
 	CreateSheet(ctx context.Context, in *CreateSheetRequest, opts ...grpc.CallOption) (*Sheet, error)
+	// Permissions required: sheets.create
 	BatchCreateSheets(ctx context.Context, in *BatchCreateSheetsRequest, opts ...grpc.CallOption) (*BatchCreateSheetsResponse, error)
+	// Permissions required: sheets.get
 	GetSheet(ctx context.Context, in *GetSheetRequest, opts ...grpc.CallOption) (*Sheet, error)
+	// Permissions required: sheets.update
 	UpdateSheet(ctx context.Context, in *UpdateSheetRequest, opts ...grpc.CallOption) (*Sheet, error)
 }
 
@@ -87,9 +91,13 @@ func (c *sheetServiceClient) UpdateSheet(ctx context.Context, in *UpdateSheetReq
 // All implementations must embed UnimplementedSheetServiceServer
 // for forward compatibility.
 type SheetServiceServer interface {
+	// Permissions required: sheets.create
 	CreateSheet(context.Context, *CreateSheetRequest) (*Sheet, error)
+	// Permissions required: sheets.create
 	BatchCreateSheets(context.Context, *BatchCreateSheetsRequest) (*BatchCreateSheetsResponse, error)
+	// Permissions required: sheets.get
 	GetSheet(context.Context, *GetSheetRequest) (*Sheet, error)
+	// Permissions required: sheets.update
 	UpdateSheet(context.Context, *UpdateSheetRequest) (*Sheet, error)
 	mustEmbedUnimplementedSheetServiceServer()
 }

--- a/proto/generated-go/v1/sheet_service_grpc.pb.go
+++ b/proto/generated-go/v1/sheet_service_grpc.pb.go
@@ -29,13 +29,13 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SheetServiceClient interface {
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	CreateSheet(ctx context.Context, in *CreateSheetRequest, opts ...grpc.CallOption) (*Sheet, error)
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	BatchCreateSheets(ctx context.Context, in *BatchCreateSheetsRequest, opts ...grpc.CallOption) (*BatchCreateSheetsResponse, error)
-	// Permissions required: sheets.get
+	// Permissions required: bb.sheets.get
 	GetSheet(ctx context.Context, in *GetSheetRequest, opts ...grpc.CallOption) (*Sheet, error)
-	// Permissions required: sheets.update
+	// Permissions required: bb.sheets.update
 	UpdateSheet(ctx context.Context, in *UpdateSheetRequest, opts ...grpc.CallOption) (*Sheet, error)
 }
 
@@ -91,13 +91,13 @@ func (c *sheetServiceClient) UpdateSheet(ctx context.Context, in *UpdateSheetReq
 // All implementations must embed UnimplementedSheetServiceServer
 // for forward compatibility.
 type SheetServiceServer interface {
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	CreateSheet(context.Context, *CreateSheetRequest) (*Sheet, error)
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	BatchCreateSheets(context.Context, *BatchCreateSheetsRequest) (*BatchCreateSheetsResponse, error)
-	// Permissions required: sheets.get
+	// Permissions required: bb.sheets.get
 	GetSheet(context.Context, *GetSheetRequest) (*Sheet, error)
-	// Permissions required: sheets.update
+	// Permissions required: bb.sheets.update
 	UpdateSheet(context.Context, *UpdateSheetRequest) (*Sheet, error)
 	mustEmbedUnimplementedSheetServiceServer()
 }

--- a/proto/generated-go/v1/sql_service.pb.gw.go
+++ b/proto/generated-go/v1/sql_service.pb.gw.go
@@ -44,6 +44,9 @@ func request_SQLService_Query_0(ctx context.Context, marshaler runtime.Marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -85,6 +88,9 @@ func request_SQLService_Query_1(ctx context.Context, marshaler runtime.Marshaler
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {
@@ -170,6 +176,9 @@ func request_SQLService_SearchQueryHistories_0(ctx context.Context, marshaler ru
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.SearchQueryHistories(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -194,6 +203,9 @@ func request_SQLService_Export_0(ctx context.Context, marshaler runtime.Marshale
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {
@@ -237,6 +249,9 @@ func request_SQLService_Export_1(ctx context.Context, marshaler runtime.Marshale
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -278,6 +293,9 @@ func request_SQLService_Export_2(ctx context.Context, marshaler runtime.Marshale
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {
@@ -321,6 +339,9 @@ func request_SQLService_Export_3(ctx context.Context, marshaler runtime.Marshale
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -362,6 +383,9 @@ func request_SQLService_Check_0(ctx context.Context, marshaler runtime.Marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.Check(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -385,6 +409,9 @@ func request_SQLService_Pretty_0(ctx context.Context, marshaler runtime.Marshale
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.Pretty(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -410,6 +437,9 @@ func request_SQLService_DiffMetadata_0(ctx context.Context, marshaler runtime.Ma
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.DiffMetadata(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -433,6 +463,9 @@ func request_SQLService_AICompletion_0(ctx context.Context, marshaler runtime.Ma
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.AICompletion(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err

--- a/proto/generated-go/v1/sql_service_grpc.pb.go
+++ b/proto/generated-go/v1/sql_service_grpc.pb.go
@@ -33,16 +33,16 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SQLServiceClient interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Query(ctx context.Context, in *QueryRequest, opts ...grpc.CallOption) (*QueryResponse, error)
-	// Permissions required: sql.admin
+	// Permissions required: bb.sql.admin
 	AdminExecute(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[AdminExecuteRequest, AdminExecuteResponse], error)
 	// SearchQueryHistories searches query histories for the caller.
 	// Permissions required: None
 	SearchQueryHistories(ctx context.Context, in *SearchQueryHistoriesRequest, opts ...grpc.CallOption) (*SearchQueryHistoriesResponse, error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Export(ctx context.Context, in *ExportRequest, opts ...grpc.CallOption) (*ExportResponse, error)
-	// Permissions required: databases.check
+	// Permissions required: bb.databases.check
 	Check(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
 	// Permissions required: None
 	Pretty(ctx context.Context, in *PrettyRequest, opts ...grpc.CallOption) (*PrettyResponse, error)
@@ -147,16 +147,16 @@ func (c *sQLServiceClient) AICompletion(ctx context.Context, in *AICompletionReq
 // All implementations must embed UnimplementedSQLServiceServer
 // for forward compatibility.
 type SQLServiceServer interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Query(context.Context, *QueryRequest) (*QueryResponse, error)
-	// Permissions required: sql.admin
+	// Permissions required: bb.sql.admin
 	AdminExecute(grpc.BidiStreamingServer[AdminExecuteRequest, AdminExecuteResponse]) error
 	// SearchQueryHistories searches query histories for the caller.
 	// Permissions required: None
 	SearchQueryHistories(context.Context, *SearchQueryHistoriesRequest) (*SearchQueryHistoriesResponse, error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Export(context.Context, *ExportRequest) (*ExportResponse, error)
-	// Permissions required: databases.check
+	// Permissions required: bb.databases.check
 	Check(context.Context, *CheckRequest) (*CheckResponse, error)
 	// Permissions required: None
 	Pretty(context.Context, *PrettyRequest) (*PrettyResponse, error)

--- a/proto/generated-go/v1/sql_service_grpc.pb.go
+++ b/proto/generated-go/v1/sql_service_grpc.pb.go
@@ -33,14 +33,22 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SQLServiceClient interface {
+	// Permissions required: databases.get
 	Query(ctx context.Context, in *QueryRequest, opts ...grpc.CallOption) (*QueryResponse, error)
+	// Permissions required: sql.admin
 	AdminExecute(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[AdminExecuteRequest, AdminExecuteResponse], error)
 	// SearchQueryHistories searches query histories for the caller.
+	// Permissions required: None
 	SearchQueryHistories(ctx context.Context, in *SearchQueryHistoriesRequest, opts ...grpc.CallOption) (*SearchQueryHistoriesResponse, error)
+	// Permissions required: databases.get
 	Export(ctx context.Context, in *ExportRequest, opts ...grpc.CallOption) (*ExportResponse, error)
+	// Permissions required: databases.check
 	Check(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (*CheckResponse, error)
+	// Permissions required: None
 	Pretty(ctx context.Context, in *PrettyRequest, opts ...grpc.CallOption) (*PrettyResponse, error)
+	// Permissions required: None
 	DiffMetadata(ctx context.Context, in *DiffMetadataRequest, opts ...grpc.CallOption) (*DiffMetadataResponse, error)
+	// Permissions required: None
 	AICompletion(ctx context.Context, in *AICompletionRequest, opts ...grpc.CallOption) (*AICompletionResponse, error)
 }
 
@@ -139,14 +147,22 @@ func (c *sQLServiceClient) AICompletion(ctx context.Context, in *AICompletionReq
 // All implementations must embed UnimplementedSQLServiceServer
 // for forward compatibility.
 type SQLServiceServer interface {
+	// Permissions required: databases.get
 	Query(context.Context, *QueryRequest) (*QueryResponse, error)
+	// Permissions required: sql.admin
 	AdminExecute(grpc.BidiStreamingServer[AdminExecuteRequest, AdminExecuteResponse]) error
 	// SearchQueryHistories searches query histories for the caller.
+	// Permissions required: None
 	SearchQueryHistories(context.Context, *SearchQueryHistoriesRequest) (*SearchQueryHistoriesResponse, error)
+	// Permissions required: databases.get
 	Export(context.Context, *ExportRequest) (*ExportResponse, error)
+	// Permissions required: databases.check
 	Check(context.Context, *CheckRequest) (*CheckResponse, error)
+	// Permissions required: None
 	Pretty(context.Context, *PrettyRequest) (*PrettyResponse, error)
+	// Permissions required: None
 	DiffMetadata(context.Context, *DiffMetadataRequest) (*DiffMetadataResponse, error)
+	// Permissions required: None
 	AICompletion(context.Context, *AICompletionRequest) (*AICompletionResponse, error)
 	mustEmbedUnimplementedSQLServiceServer()
 }

--- a/proto/generated-go/v1/subscription_service.pb.gw.go
+++ b/proto/generated-go/v1/subscription_service.pb.gw.go
@@ -40,7 +40,9 @@ func request_SubscriptionService_GetSubscription_0(ctx context.Context, marshale
 		protoReq GetSubscriptionRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.GetSubscription(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -61,6 +63,9 @@ func request_SubscriptionService_UpdateSubscription_0(ctx context.Context, marsh
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.License); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.UpdateSubscription(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err

--- a/proto/generated-go/v1/subscription_service_grpc.pb.go
+++ b/proto/generated-go/v1/subscription_service_grpc.pb.go
@@ -30,7 +30,9 @@ type SubscriptionServiceClient interface {
 	// GetSubscription returns the current subscription.
 	// If there is no license, we will return a free plan subscription without expiration time.
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+	// Permissions required: None
 	GetSubscription(ctx context.Context, in *GetSubscriptionRequest, opts ...grpc.CallOption) (*Subscription, error)
+	// Permissions required: settings.set
 	UpdateSubscription(ctx context.Context, in *UpdateSubscriptionRequest, opts ...grpc.CallOption) (*Subscription, error)
 }
 
@@ -69,7 +71,9 @@ type SubscriptionServiceServer interface {
 	// GetSubscription returns the current subscription.
 	// If there is no license, we will return a free plan subscription without expiration time.
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+	// Permissions required: None
 	GetSubscription(context.Context, *GetSubscriptionRequest) (*Subscription, error)
+	// Permissions required: settings.set
 	UpdateSubscription(context.Context, *UpdateSubscriptionRequest) (*Subscription, error)
 	mustEmbedUnimplementedSubscriptionServiceServer()
 }

--- a/proto/generated-go/v1/subscription_service_grpc.pb.go
+++ b/proto/generated-go/v1/subscription_service_grpc.pb.go
@@ -32,7 +32,7 @@ type SubscriptionServiceClient interface {
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
 	// Permissions required: None
 	GetSubscription(ctx context.Context, in *GetSubscriptionRequest, opts ...grpc.CallOption) (*Subscription, error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSubscription(ctx context.Context, in *UpdateSubscriptionRequest, opts ...grpc.CallOption) (*Subscription, error)
 }
 
@@ -73,7 +73,7 @@ type SubscriptionServiceServer interface {
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
 	// Permissions required: None
 	GetSubscription(context.Context, *GetSubscriptionRequest) (*Subscription, error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSubscription(context.Context, *UpdateSubscriptionRequest) (*Subscription, error)
 	mustEmbedUnimplementedSubscriptionServiceServer()
 }

--- a/proto/generated-go/v1/user_service.pb.gw.go
+++ b/proto/generated-go/v1/user_service.pb.gw.go
@@ -42,7 +42,9 @@ func request_UserService_GetUser_0(ctx context.Context, marshaler runtime.Marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -80,7 +82,9 @@ func request_UserService_BatchGetUsers_0(ctx context.Context, marshaler runtime.
 		protoReq BatchGetUsersRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -111,7 +115,9 @@ func request_UserService_GetCurrentUser_0(ctx context.Context, marshaler runtime
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.GetCurrentUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -132,7 +138,9 @@ func request_UserService_ListUsers_0(ctx context.Context, marshaler runtime.Mars
 		protoReq ListUsersRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -166,6 +174,9 @@ func request_UserService_CreateUser_0(ctx context.Context, marshaler runtime.Mar
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.User); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -196,6 +207,9 @@ func request_UserService_UpdateUser_0(ctx context.Context, marshaler runtime.Mar
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.User); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.User); err != nil {
@@ -266,7 +280,9 @@ func request_UserService_DeleteUser_0(ctx context.Context, marshaler runtime.Mar
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -305,6 +321,9 @@ func request_UserService_UndeleteUser_0(ctx context.Context, marshaler runtime.M
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["name"]
 	if !ok {

--- a/proto/generated-go/v1/user_service_grpc.pb.go
+++ b/proto/generated-go/v1/user_service_grpc.pb.go
@@ -36,25 +36,33 @@ const (
 type UserServiceClient interface {
 	// Get the user.
 	// Any authenticated user can get the user.
+	// Permissions required: users.get
 	GetUser(ctx context.Context, in *GetUserRequest, opts ...grpc.CallOption) (*User, error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
+	// Permissions required: users.get
 	BatchGetUsers(ctx context.Context, in *BatchGetUsersRequest, opts ...grpc.CallOption) (*BatchGetUsersResponse, error)
 	// Get the current authenticated user.
+	// Permissions required: None
 	GetCurrentUser(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*User, error)
 	// List all users.
 	// Any authenticated user can list users.
+	// Permissions required: users.list
 	ListUsers(ctx context.Context, in *ListUsersRequest, opts ...grpc.CallOption) (*ListUsersResponse, error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
+	// Permissions required: users.create
 	CreateUser(ctx context.Context, in *CreateUserRequest, opts ...grpc.CallOption) (*User, error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+	// Permissions required: users.update
 	UpdateUser(ctx context.Context, in *UpdateUserRequest, opts ...grpc.CallOption) (*User, error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
+	// Permissions required: users.delete
 	DeleteUser(ctx context.Context, in *DeleteUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
+	// Permissions required: users.undelete
 	UndeleteUser(ctx context.Context, in *UndeleteUserRequest, opts ...grpc.CallOption) (*User, error)
 }
 
@@ -152,25 +160,33 @@ func (c *userServiceClient) UndeleteUser(ctx context.Context, in *UndeleteUserRe
 type UserServiceServer interface {
 	// Get the user.
 	// Any authenticated user can get the user.
+	// Permissions required: users.get
 	GetUser(context.Context, *GetUserRequest) (*User, error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
+	// Permissions required: users.get
 	BatchGetUsers(context.Context, *BatchGetUsersRequest) (*BatchGetUsersResponse, error)
 	// Get the current authenticated user.
+	// Permissions required: None
 	GetCurrentUser(context.Context, *emptypb.Empty) (*User, error)
 	// List all users.
 	// Any authenticated user can list users.
+	// Permissions required: users.list
 	ListUsers(context.Context, *ListUsersRequest) (*ListUsersResponse, error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
+	// Permissions required: users.create
 	CreateUser(context.Context, *CreateUserRequest) (*User, error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+	// Permissions required: users.update
 	UpdateUser(context.Context, *UpdateUserRequest) (*User, error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
+	// Permissions required: users.delete
 	DeleteUser(context.Context, *DeleteUserRequest) (*emptypb.Empty, error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
+	// Permissions required: users.undelete
 	UndeleteUser(context.Context, *UndeleteUserRequest) (*User, error)
 	mustEmbedUnimplementedUserServiceServer()
 }

--- a/proto/generated-go/v1/user_service_grpc.pb.go
+++ b/proto/generated-go/v1/user_service_grpc.pb.go
@@ -36,33 +36,33 @@ const (
 type UserServiceClient interface {
 	// Get the user.
 	// Any authenticated user can get the user.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	GetUser(ctx context.Context, in *GetUserRequest, opts ...grpc.CallOption) (*User, error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	BatchGetUsers(ctx context.Context, in *BatchGetUsersRequest, opts ...grpc.CallOption) (*BatchGetUsersResponse, error)
 	// Get the current authenticated user.
 	// Permissions required: None
 	GetCurrentUser(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*User, error)
 	// List all users.
 	// Any authenticated user can list users.
-	// Permissions required: users.list
+	// Permissions required: bb.users.list
 	ListUsers(ctx context.Context, in *ListUsersRequest, opts ...grpc.CallOption) (*ListUsersResponse, error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
-	// Permissions required: users.create
+	// Permissions required: bb.users.create
 	CreateUser(ctx context.Context, in *CreateUserRequest, opts ...grpc.CallOption) (*User, error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-	// Permissions required: users.update
+	// Permissions required: bb.users.update
 	UpdateUser(ctx context.Context, in *UpdateUserRequest, opts ...grpc.CallOption) (*User, error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
-	// Permissions required: users.delete
+	// Permissions required: bb.users.delete
 	DeleteUser(ctx context.Context, in *DeleteUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
-	// Permissions required: users.undelete
+	// Permissions required: bb.users.undelete
 	UndeleteUser(ctx context.Context, in *UndeleteUserRequest, opts ...grpc.CallOption) (*User, error)
 }
 
@@ -160,33 +160,33 @@ func (c *userServiceClient) UndeleteUser(ctx context.Context, in *UndeleteUserRe
 type UserServiceServer interface {
 	// Get the user.
 	// Any authenticated user can get the user.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	GetUser(context.Context, *GetUserRequest) (*User, error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	BatchGetUsers(context.Context, *BatchGetUsersRequest) (*BatchGetUsersResponse, error)
 	// Get the current authenticated user.
 	// Permissions required: None
 	GetCurrentUser(context.Context, *emptypb.Empty) (*User, error)
 	// List all users.
 	// Any authenticated user can list users.
-	// Permissions required: users.list
+	// Permissions required: bb.users.list
 	ListUsers(context.Context, *ListUsersRequest) (*ListUsersResponse, error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
-	// Permissions required: users.create
+	// Permissions required: bb.users.create
 	CreateUser(context.Context, *CreateUserRequest) (*User, error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-	// Permissions required: users.update
+	// Permissions required: bb.users.update
 	UpdateUser(context.Context, *UpdateUserRequest) (*User, error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
-	// Permissions required: users.delete
+	// Permissions required: bb.users.delete
 	DeleteUser(context.Context, *DeleteUserRequest) (*emptypb.Empty, error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
-	// Permissions required: users.undelete
+	// Permissions required: bb.users.undelete
 	UndeleteUser(context.Context, *UndeleteUserRequest) (*User, error)
 	mustEmbedUnimplementedUserServiceServer()
 }

--- a/proto/generated-go/v1/v1connect/actuator_service.connect.go
+++ b/proto/generated-go/v1/v1connect/actuator_service.connect.go
@@ -53,10 +53,15 @@ const (
 
 // ActuatorServiceClient is a client for the bytebase.v1.ActuatorService service.
 type ActuatorServiceClient interface {
+	// Permissions required: None
 	GetActuatorInfo(context.Context, *connect.Request[v1.GetActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
+	// Permissions required: settings.set
 	UpdateActuatorInfo(context.Context, *connect.Request[v1.UpdateActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
+	// Permissions required: projects.create
 	SetupSample(context.Context, *connect.Request[v1.SetupSampleRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: None
 	DeleteCache(context.Context, *connect.Request[v1.DeleteCacheRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: None
 	GetResourcePackage(context.Context, *connect.Request[v1.GetResourcePackageRequest]) (*connect.Response[v1.ResourcePackage], error)
 }
 
@@ -140,10 +145,15 @@ func (c *actuatorServiceClient) GetResourcePackage(ctx context.Context, req *con
 
 // ActuatorServiceHandler is an implementation of the bytebase.v1.ActuatorService service.
 type ActuatorServiceHandler interface {
+	// Permissions required: None
 	GetActuatorInfo(context.Context, *connect.Request[v1.GetActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
+	// Permissions required: settings.set
 	UpdateActuatorInfo(context.Context, *connect.Request[v1.UpdateActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
+	// Permissions required: projects.create
 	SetupSample(context.Context, *connect.Request[v1.SetupSampleRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: None
 	DeleteCache(context.Context, *connect.Request[v1.DeleteCacheRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: None
 	GetResourcePackage(context.Context, *connect.Request[v1.GetResourcePackageRequest]) (*connect.Response[v1.ResourcePackage], error)
 }
 

--- a/proto/generated-go/v1/v1connect/actuator_service.connect.go
+++ b/proto/generated-go/v1/v1connect/actuator_service.connect.go
@@ -55,9 +55,9 @@ const (
 type ActuatorServiceClient interface {
 	// Permissions required: None
 	GetActuatorInfo(context.Context, *connect.Request[v1.GetActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateActuatorInfo(context.Context, *connect.Request[v1.UpdateActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	SetupSample(context.Context, *connect.Request[v1.SetupSampleRequest]) (*connect.Response[emptypb.Empty], error)
 	// Permissions required: None
 	DeleteCache(context.Context, *connect.Request[v1.DeleteCacheRequest]) (*connect.Response[emptypb.Empty], error)
@@ -147,9 +147,9 @@ func (c *actuatorServiceClient) GetResourcePackage(ctx context.Context, req *con
 type ActuatorServiceHandler interface {
 	// Permissions required: None
 	GetActuatorInfo(context.Context, *connect.Request[v1.GetActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateActuatorInfo(context.Context, *connect.Request[v1.UpdateActuatorInfoRequest]) (*connect.Response[v1.ActuatorInfo], error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	SetupSample(context.Context, *connect.Request[v1.SetupSampleRequest]) (*connect.Response[emptypb.Empty], error)
 	// Permissions required: None
 	DeleteCache(context.Context, *connect.Request[v1.DeleteCacheRequest]) (*connect.Response[emptypb.Empty], error)

--- a/proto/generated-go/v1/v1connect/audit_log_service.connect.go
+++ b/proto/generated-go/v1/v1connect/audit_log_service.connect.go
@@ -45,7 +45,7 @@ const (
 type AuditLogServiceClient interface {
 	// Permissions required: None
 	SearchAuditLogs(context.Context, *connect.Request[v1.SearchAuditLogsRequest]) (*connect.Response[v1.SearchAuditLogsResponse], error)
-	// Permissions required: auditLogs.export
+	// Permissions required: bb.auditLogs.export
 	ExportAuditLogs(context.Context, *connect.Request[v1.ExportAuditLogsRequest]) (*connect.Response[v1.ExportAuditLogsResponse], error)
 }
 
@@ -95,7 +95,7 @@ func (c *auditLogServiceClient) ExportAuditLogs(ctx context.Context, req *connec
 type AuditLogServiceHandler interface {
 	// Permissions required: None
 	SearchAuditLogs(context.Context, *connect.Request[v1.SearchAuditLogsRequest]) (*connect.Response[v1.SearchAuditLogsResponse], error)
-	// Permissions required: auditLogs.export
+	// Permissions required: bb.auditLogs.export
 	ExportAuditLogs(context.Context, *connect.Request[v1.ExportAuditLogsRequest]) (*connect.Response[v1.ExportAuditLogsResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/audit_log_service.connect.go
+++ b/proto/generated-go/v1/v1connect/audit_log_service.connect.go
@@ -43,7 +43,9 @@ const (
 
 // AuditLogServiceClient is a client for the bytebase.v1.AuditLogService service.
 type AuditLogServiceClient interface {
+	// Permissions required: None
 	SearchAuditLogs(context.Context, *connect.Request[v1.SearchAuditLogsRequest]) (*connect.Response[v1.SearchAuditLogsResponse], error)
+	// Permissions required: auditLogs.export
 	ExportAuditLogs(context.Context, *connect.Request[v1.ExportAuditLogsRequest]) (*connect.Response[v1.ExportAuditLogsResponse], error)
 }
 
@@ -91,7 +93,9 @@ func (c *auditLogServiceClient) ExportAuditLogs(ctx context.Context, req *connec
 
 // AuditLogServiceHandler is an implementation of the bytebase.v1.AuditLogService service.
 type AuditLogServiceHandler interface {
+	// Permissions required: None
 	SearchAuditLogs(context.Context, *connect.Request[v1.SearchAuditLogsRequest]) (*connect.Response[v1.SearchAuditLogsResponse], error)
+	// Permissions required: auditLogs.export
 	ExportAuditLogs(context.Context, *connect.Request[v1.ExportAuditLogsRequest]) (*connect.Response[v1.ExportAuditLogsResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/auth_service.connect.go
+++ b/proto/generated-go/v1/v1connect/auth_service.connect.go
@@ -42,7 +42,9 @@ const (
 
 // AuthServiceClient is a client for the bytebase.v1.AuthService service.
 type AuthServiceClient interface {
+	// Permissions required: None
 	Login(context.Context, *connect.Request[v1.LoginRequest]) (*connect.Response[v1.LoginResponse], error)
+	// Permissions required: None
 	Logout(context.Context, *connect.Request[v1.LogoutRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -90,7 +92,9 @@ func (c *authServiceClient) Logout(ctx context.Context, req *connect.Request[v1.
 
 // AuthServiceHandler is an implementation of the bytebase.v1.AuthService service.
 type AuthServiceHandler interface {
+	// Permissions required: None
 	Login(context.Context, *connect.Request[v1.LoginRequest]) (*connect.Response[v1.LoginResponse], error)
+	// Permissions required: None
 	Logout(context.Context, *connect.Request[v1.LogoutRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/cel_service.connect.go
+++ b/proto/generated-go/v1/v1connect/cel_service.connect.go
@@ -41,7 +41,9 @@ const (
 
 // CelServiceClient is a client for the bytebase.v1.CelService service.
 type CelServiceClient interface {
+	// Permissions required: None
 	BatchParse(context.Context, *connect.Request[v1.BatchParseRequest]) (*connect.Response[v1.BatchParseResponse], error)
+	// Permissions required: None
 	BatchDeparse(context.Context, *connect.Request[v1.BatchDeparseRequest]) (*connect.Response[v1.BatchDeparseResponse], error)
 }
 
@@ -89,7 +91,9 @@ func (c *celServiceClient) BatchDeparse(ctx context.Context, req *connect.Reques
 
 // CelServiceHandler is an implementation of the bytebase.v1.CelService service.
 type CelServiceHandler interface {
+	// Permissions required: None
 	BatchParse(context.Context, *connect.Request[v1.BatchParseRequest]) (*connect.Response[v1.BatchParseResponse], error)
+	// Permissions required: None
 	BatchDeparse(context.Context, *connect.Request[v1.BatchDeparseRequest]) (*connect.Response[v1.BatchDeparseResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/changelist_service.connect.go
+++ b/proto/generated-go/v1/v1connect/changelist_service.connect.go
@@ -53,15 +53,15 @@ const (
 
 // ChangelistServiceClient is a client for the bytebase.v1.ChangelistService service.
 type ChangelistServiceClient interface {
-	// Permissions required: changelists.create
+	// Permissions required: bb.changelists.create
 	CreateChangelist(context.Context, *connect.Request[v1.CreateChangelistRequest]) (*connect.Response[v1.Changelist], error)
-	// Permissions required: changelists.get
+	// Permissions required: bb.changelists.get
 	GetChangelist(context.Context, *connect.Request[v1.GetChangelistRequest]) (*connect.Response[v1.Changelist], error)
-	// Permissions required: changelists.list
+	// Permissions required: bb.changelists.list
 	ListChangelists(context.Context, *connect.Request[v1.ListChangelistsRequest]) (*connect.Response[v1.ListChangelistsResponse], error)
-	// Permissions required: changelists.update
+	// Permissions required: bb.changelists.update
 	UpdateChangelist(context.Context, *connect.Request[v1.UpdateChangelistRequest]) (*connect.Response[v1.Changelist], error)
-	// Permissions required: changelists.delete
+	// Permissions required: bb.changelists.delete
 	DeleteChangelist(context.Context, *connect.Request[v1.DeleteChangelistRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -145,15 +145,15 @@ func (c *changelistServiceClient) DeleteChangelist(ctx context.Context, req *con
 
 // ChangelistServiceHandler is an implementation of the bytebase.v1.ChangelistService service.
 type ChangelistServiceHandler interface {
-	// Permissions required: changelists.create
+	// Permissions required: bb.changelists.create
 	CreateChangelist(context.Context, *connect.Request[v1.CreateChangelistRequest]) (*connect.Response[v1.Changelist], error)
-	// Permissions required: changelists.get
+	// Permissions required: bb.changelists.get
 	GetChangelist(context.Context, *connect.Request[v1.GetChangelistRequest]) (*connect.Response[v1.Changelist], error)
-	// Permissions required: changelists.list
+	// Permissions required: bb.changelists.list
 	ListChangelists(context.Context, *connect.Request[v1.ListChangelistsRequest]) (*connect.Response[v1.ListChangelistsResponse], error)
-	// Permissions required: changelists.update
+	// Permissions required: bb.changelists.update
 	UpdateChangelist(context.Context, *connect.Request[v1.UpdateChangelistRequest]) (*connect.Response[v1.Changelist], error)
-	// Permissions required: changelists.delete
+	// Permissions required: bb.changelists.delete
 	DeleteChangelist(context.Context, *connect.Request[v1.DeleteChangelistRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/changelist_service.connect.go
+++ b/proto/generated-go/v1/v1connect/changelist_service.connect.go
@@ -53,10 +53,15 @@ const (
 
 // ChangelistServiceClient is a client for the bytebase.v1.ChangelistService service.
 type ChangelistServiceClient interface {
+	// Permissions required: changelists.create
 	CreateChangelist(context.Context, *connect.Request[v1.CreateChangelistRequest]) (*connect.Response[v1.Changelist], error)
+	// Permissions required: changelists.get
 	GetChangelist(context.Context, *connect.Request[v1.GetChangelistRequest]) (*connect.Response[v1.Changelist], error)
+	// Permissions required: changelists.list
 	ListChangelists(context.Context, *connect.Request[v1.ListChangelistsRequest]) (*connect.Response[v1.ListChangelistsResponse], error)
+	// Permissions required: changelists.update
 	UpdateChangelist(context.Context, *connect.Request[v1.UpdateChangelistRequest]) (*connect.Response[v1.Changelist], error)
+	// Permissions required: changelists.delete
 	DeleteChangelist(context.Context, *connect.Request[v1.DeleteChangelistRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,10 +145,15 @@ func (c *changelistServiceClient) DeleteChangelist(ctx context.Context, req *con
 
 // ChangelistServiceHandler is an implementation of the bytebase.v1.ChangelistService service.
 type ChangelistServiceHandler interface {
+	// Permissions required: changelists.create
 	CreateChangelist(context.Context, *connect.Request[v1.CreateChangelistRequest]) (*connect.Response[v1.Changelist], error)
+	// Permissions required: changelists.get
 	GetChangelist(context.Context, *connect.Request[v1.GetChangelistRequest]) (*connect.Response[v1.Changelist], error)
+	// Permissions required: changelists.list
 	ListChangelists(context.Context, *connect.Request[v1.ListChangelistsRequest]) (*connect.Response[v1.ListChangelistsResponse], error)
+	// Permissions required: changelists.update
 	UpdateChangelist(context.Context, *connect.Request[v1.UpdateChangelistRequest]) (*connect.Response[v1.Changelist], error)
+	// Permissions required: changelists.delete
 	DeleteChangelist(context.Context, *connect.Request[v1.DeleteChangelistRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/database_catalog_service.connect.go
+++ b/proto/generated-go/v1/v1connect/database_catalog_service.connect.go
@@ -43,7 +43,9 @@ const (
 
 // DatabaseCatalogServiceClient is a client for the bytebase.v1.DatabaseCatalogService service.
 type DatabaseCatalogServiceClient interface {
+	// Permissions required: databaseCatalogs.get
 	GetDatabaseCatalog(context.Context, *connect.Request[v1.GetDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
+	// Permissions required: databaseCatalogs.update
 	UpdateDatabaseCatalog(context.Context, *connect.Request[v1.UpdateDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
 }
 
@@ -92,7 +94,9 @@ func (c *databaseCatalogServiceClient) UpdateDatabaseCatalog(ctx context.Context
 // DatabaseCatalogServiceHandler is an implementation of the bytebase.v1.DatabaseCatalogService
 // service.
 type DatabaseCatalogServiceHandler interface {
+	// Permissions required: databaseCatalogs.get
 	GetDatabaseCatalog(context.Context, *connect.Request[v1.GetDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
+	// Permissions required: databaseCatalogs.update
 	UpdateDatabaseCatalog(context.Context, *connect.Request[v1.UpdateDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
 }
 

--- a/proto/generated-go/v1/v1connect/database_catalog_service.connect.go
+++ b/proto/generated-go/v1/v1connect/database_catalog_service.connect.go
@@ -43,9 +43,9 @@ const (
 
 // DatabaseCatalogServiceClient is a client for the bytebase.v1.DatabaseCatalogService service.
 type DatabaseCatalogServiceClient interface {
-	// Permissions required: databaseCatalogs.get
+	// Permissions required: bb.databaseCatalogs.get
 	GetDatabaseCatalog(context.Context, *connect.Request[v1.GetDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
-	// Permissions required: databaseCatalogs.update
+	// Permissions required: bb.databaseCatalogs.update
 	UpdateDatabaseCatalog(context.Context, *connect.Request[v1.UpdateDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
 }
 
@@ -94,9 +94,9 @@ func (c *databaseCatalogServiceClient) UpdateDatabaseCatalog(ctx context.Context
 // DatabaseCatalogServiceHandler is an implementation of the bytebase.v1.DatabaseCatalogService
 // service.
 type DatabaseCatalogServiceHandler interface {
-	// Permissions required: databaseCatalogs.get
+	// Permissions required: bb.databaseCatalogs.get
 	GetDatabaseCatalog(context.Context, *connect.Request[v1.GetDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
-	// Permissions required: databaseCatalogs.update
+	// Permissions required: bb.databaseCatalogs.update
 	UpdateDatabaseCatalog(context.Context, *connect.Request[v1.UpdateDatabaseCatalogRequest]) (*connect.Response[v1.DatabaseCatalog], error)
 }
 

--- a/proto/generated-go/v1/v1connect/database_group_service.connect.go
+++ b/proto/generated-go/v1/v1connect/database_group_service.connect.go
@@ -53,10 +53,15 @@ const (
 
 // DatabaseGroupServiceClient is a client for the bytebase.v1.DatabaseGroupService service.
 type DatabaseGroupServiceClient interface {
+	// Permissions required: projects.get
 	ListDatabaseGroups(context.Context, *connect.Request[v1.ListDatabaseGroupsRequest]) (*connect.Response[v1.ListDatabaseGroupsResponse], error)
+	// Permissions required: projects.get
 	GetDatabaseGroup(context.Context, *connect.Request[v1.GetDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
+	// Permissions required: projects.update
 	CreateDatabaseGroup(context.Context, *connect.Request[v1.CreateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
+	// Permissions required: projects.update
 	UpdateDatabaseGroup(context.Context, *connect.Request[v1.UpdateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
+	// Permissions required: projects.update
 	DeleteDatabaseGroup(context.Context, *connect.Request[v1.DeleteDatabaseGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,10 +145,15 @@ func (c *databaseGroupServiceClient) DeleteDatabaseGroup(ctx context.Context, re
 
 // DatabaseGroupServiceHandler is an implementation of the bytebase.v1.DatabaseGroupService service.
 type DatabaseGroupServiceHandler interface {
+	// Permissions required: projects.get
 	ListDatabaseGroups(context.Context, *connect.Request[v1.ListDatabaseGroupsRequest]) (*connect.Response[v1.ListDatabaseGroupsResponse], error)
+	// Permissions required: projects.get
 	GetDatabaseGroup(context.Context, *connect.Request[v1.GetDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
+	// Permissions required: projects.update
 	CreateDatabaseGroup(context.Context, *connect.Request[v1.CreateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
+	// Permissions required: projects.update
 	UpdateDatabaseGroup(context.Context, *connect.Request[v1.UpdateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
+	// Permissions required: projects.update
 	DeleteDatabaseGroup(context.Context, *connect.Request[v1.DeleteDatabaseGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/database_group_service.connect.go
+++ b/proto/generated-go/v1/v1connect/database_group_service.connect.go
@@ -53,15 +53,15 @@ const (
 
 // DatabaseGroupServiceClient is a client for the bytebase.v1.DatabaseGroupService service.
 type DatabaseGroupServiceClient interface {
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	ListDatabaseGroups(context.Context, *connect.Request[v1.ListDatabaseGroupsRequest]) (*connect.Response[v1.ListDatabaseGroupsResponse], error)
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetDatabaseGroup(context.Context, *connect.Request[v1.GetDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	CreateDatabaseGroup(context.Context, *connect.Request[v1.CreateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateDatabaseGroup(context.Context, *connect.Request[v1.UpdateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	DeleteDatabaseGroup(context.Context, *connect.Request[v1.DeleteDatabaseGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -145,15 +145,15 @@ func (c *databaseGroupServiceClient) DeleteDatabaseGroup(ctx context.Context, re
 
 // DatabaseGroupServiceHandler is an implementation of the bytebase.v1.DatabaseGroupService service.
 type DatabaseGroupServiceHandler interface {
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	ListDatabaseGroups(context.Context, *connect.Request[v1.ListDatabaseGroupsRequest]) (*connect.Response[v1.ListDatabaseGroupsResponse], error)
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetDatabaseGroup(context.Context, *connect.Request[v1.GetDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	CreateDatabaseGroup(context.Context, *connect.Request[v1.CreateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateDatabaseGroup(context.Context, *connect.Request[v1.UpdateDatabaseGroupRequest]) (*connect.Response[v1.DatabaseGroup], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	DeleteDatabaseGroup(context.Context, *connect.Request[v1.DeleteDatabaseGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/database_service.connect.go
+++ b/proto/generated-go/v1/v1connect/database_service.connect.go
@@ -86,33 +86,33 @@ const (
 
 // DatabaseServiceClient is a client for the bytebase.v1.DatabaseService service.
 type DatabaseServiceClient interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	GetDatabase(context.Context, *connect.Request[v1.GetDatabaseRequest]) (*connect.Response[v1.Database], error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	BatchGetDatabases(context.Context, *connect.Request[v1.BatchGetDatabasesRequest]) (*connect.Response[v1.BatchGetDatabasesResponse], error)
-	// Permissions required: databases.list
+	// Permissions required: bb.databases.list
 	ListDatabases(context.Context, *connect.Request[v1.ListDatabasesRequest]) (*connect.Response[v1.ListDatabasesResponse], error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	UpdateDatabase(context.Context, *connect.Request[v1.UpdateDatabaseRequest]) (*connect.Response[v1.Database], error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	BatchUpdateDatabases(context.Context, *connect.Request[v1.BatchUpdateDatabasesRequest]) (*connect.Response[v1.BatchUpdateDatabasesResponse], error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	SyncDatabase(context.Context, *connect.Request[v1.SyncDatabaseRequest]) (*connect.Response[v1.SyncDatabaseResponse], error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	BatchSyncDatabases(context.Context, *connect.Request[v1.BatchSyncDatabasesRequest]) (*connect.Response[v1.BatchSyncDatabasesResponse], error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseMetadata(context.Context, *connect.Request[v1.GetDatabaseMetadataRequest]) (*connect.Response[v1.DatabaseMetadata], error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseSchema(context.Context, *connect.Request[v1.GetDatabaseSchemaRequest]) (*connect.Response[v1.DatabaseSchema], error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	DiffSchema(context.Context, *connect.Request[v1.DiffSchemaRequest]) (*connect.Response[v1.DiffSchemaResponse], error)
-	// Permissions required: databaseSecrets.list
+	// Permissions required: bb.databaseSecrets.list
 	ListSecrets(context.Context, *connect.Request[v1.ListSecretsRequest]) (*connect.Response[v1.ListSecretsResponse], error)
-	// Permissions required: databaseSecrets.update
+	// Permissions required: bb.databaseSecrets.update
 	UpdateSecret(context.Context, *connect.Request[v1.UpdateSecretRequest]) (*connect.Response[v1.Secret], error)
-	// Permissions required: databaseSecrets.delete
+	// Permissions required: bb.databaseSecrets.delete
 	DeleteSecret(context.Context, *connect.Request[v1.DeleteSecretRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: changelogs.list
+	// Permissions required: bb.changelogs.list
 	ListChangelogs(context.Context, *connect.Request[v1.ListChangelogsRequest]) (*connect.Response[v1.ListChangelogsResponse], error)
 	// Permissions required: changelogs.get
 	GetChangelog(context.Context, *connect.Request[v1.GetChangelogRequest]) (*connect.Response[v1.Changelog], error)
@@ -332,33 +332,33 @@ func (c *databaseServiceClient) GetSchemaString(ctx context.Context, req *connec
 
 // DatabaseServiceHandler is an implementation of the bytebase.v1.DatabaseService service.
 type DatabaseServiceHandler interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	GetDatabase(context.Context, *connect.Request[v1.GetDatabaseRequest]) (*connect.Response[v1.Database], error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	BatchGetDatabases(context.Context, *connect.Request[v1.BatchGetDatabasesRequest]) (*connect.Response[v1.BatchGetDatabasesResponse], error)
-	// Permissions required: databases.list
+	// Permissions required: bb.databases.list
 	ListDatabases(context.Context, *connect.Request[v1.ListDatabasesRequest]) (*connect.Response[v1.ListDatabasesResponse], error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	UpdateDatabase(context.Context, *connect.Request[v1.UpdateDatabaseRequest]) (*connect.Response[v1.Database], error)
-	// Permissions required: databases.update
+	// Permissions required: bb.databases.update
 	BatchUpdateDatabases(context.Context, *connect.Request[v1.BatchUpdateDatabasesRequest]) (*connect.Response[v1.BatchUpdateDatabasesResponse], error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	SyncDatabase(context.Context, *connect.Request[v1.SyncDatabaseRequest]) (*connect.Response[v1.SyncDatabaseResponse], error)
-	// Permissions required: databases.sync
+	// Permissions required: bb.databases.sync
 	BatchSyncDatabases(context.Context, *connect.Request[v1.BatchSyncDatabasesRequest]) (*connect.Response[v1.BatchSyncDatabasesResponse], error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseMetadata(context.Context, *connect.Request[v1.GetDatabaseMetadataRequest]) (*connect.Response[v1.DatabaseMetadata], error)
-	// Permissions required: databases.getSchema
+	// Permissions required: bb.databases.getSchema
 	GetDatabaseSchema(context.Context, *connect.Request[v1.GetDatabaseSchemaRequest]) (*connect.Response[v1.DatabaseSchema], error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	DiffSchema(context.Context, *connect.Request[v1.DiffSchemaRequest]) (*connect.Response[v1.DiffSchemaResponse], error)
-	// Permissions required: databaseSecrets.list
+	// Permissions required: bb.databaseSecrets.list
 	ListSecrets(context.Context, *connect.Request[v1.ListSecretsRequest]) (*connect.Response[v1.ListSecretsResponse], error)
-	// Permissions required: databaseSecrets.update
+	// Permissions required: bb.databaseSecrets.update
 	UpdateSecret(context.Context, *connect.Request[v1.UpdateSecretRequest]) (*connect.Response[v1.Secret], error)
-	// Permissions required: databaseSecrets.delete
+	// Permissions required: bb.databaseSecrets.delete
 	DeleteSecret(context.Context, *connect.Request[v1.DeleteSecretRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: changelogs.list
+	// Permissions required: bb.changelogs.list
 	ListChangelogs(context.Context, *connect.Request[v1.ListChangelogsRequest]) (*connect.Response[v1.ListChangelogsResponse], error)
 	// Permissions required: changelogs.get
 	GetChangelog(context.Context, *connect.Request[v1.GetChangelogRequest]) (*connect.Response[v1.Changelog], error)

--- a/proto/generated-go/v1/v1connect/database_service.connect.go
+++ b/proto/generated-go/v1/v1connect/database_service.connect.go
@@ -86,21 +86,37 @@ const (
 
 // DatabaseServiceClient is a client for the bytebase.v1.DatabaseService service.
 type DatabaseServiceClient interface {
+	// Permissions required: databases.get
 	GetDatabase(context.Context, *connect.Request[v1.GetDatabaseRequest]) (*connect.Response[v1.Database], error)
+	// Permissions required: databases.get
 	BatchGetDatabases(context.Context, *connect.Request[v1.BatchGetDatabasesRequest]) (*connect.Response[v1.BatchGetDatabasesResponse], error)
+	// Permissions required: databases.list
 	ListDatabases(context.Context, *connect.Request[v1.ListDatabasesRequest]) (*connect.Response[v1.ListDatabasesResponse], error)
+	// Permissions required: databases.update
 	UpdateDatabase(context.Context, *connect.Request[v1.UpdateDatabaseRequest]) (*connect.Response[v1.Database], error)
+	// Permissions required: databases.update
 	BatchUpdateDatabases(context.Context, *connect.Request[v1.BatchUpdateDatabasesRequest]) (*connect.Response[v1.BatchUpdateDatabasesResponse], error)
+	// Permissions required: databases.sync
 	SyncDatabase(context.Context, *connect.Request[v1.SyncDatabaseRequest]) (*connect.Response[v1.SyncDatabaseResponse], error)
+	// Permissions required: databases.sync
 	BatchSyncDatabases(context.Context, *connect.Request[v1.BatchSyncDatabasesRequest]) (*connect.Response[v1.BatchSyncDatabasesResponse], error)
+	// Permissions required: databases.getSchema
 	GetDatabaseMetadata(context.Context, *connect.Request[v1.GetDatabaseMetadataRequest]) (*connect.Response[v1.DatabaseMetadata], error)
+	// Permissions required: databases.getSchema
 	GetDatabaseSchema(context.Context, *connect.Request[v1.GetDatabaseSchemaRequest]) (*connect.Response[v1.DatabaseSchema], error)
+	// Permissions required: databases.get
 	DiffSchema(context.Context, *connect.Request[v1.DiffSchemaRequest]) (*connect.Response[v1.DiffSchemaResponse], error)
+	// Permissions required: databaseSecrets.list
 	ListSecrets(context.Context, *connect.Request[v1.ListSecretsRequest]) (*connect.Response[v1.ListSecretsResponse], error)
+	// Permissions required: databaseSecrets.update
 	UpdateSecret(context.Context, *connect.Request[v1.UpdateSecretRequest]) (*connect.Response[v1.Secret], error)
+	// Permissions required: databaseSecrets.delete
 	DeleteSecret(context.Context, *connect.Request[v1.DeleteSecretRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: changelogs.list
 	ListChangelogs(context.Context, *connect.Request[v1.ListChangelogsRequest]) (*connect.Response[v1.ListChangelogsResponse], error)
+	// Permissions required: changelogs.get
 	GetChangelog(context.Context, *connect.Request[v1.GetChangelogRequest]) (*connect.Response[v1.Changelog], error)
+	// Permissions required: databases.getSchema
 	GetSchemaString(context.Context, *connect.Request[v1.GetSchemaStringRequest]) (*connect.Response[v1.GetSchemaStringResponse], error)
 }
 
@@ -316,21 +332,37 @@ func (c *databaseServiceClient) GetSchemaString(ctx context.Context, req *connec
 
 // DatabaseServiceHandler is an implementation of the bytebase.v1.DatabaseService service.
 type DatabaseServiceHandler interface {
+	// Permissions required: databases.get
 	GetDatabase(context.Context, *connect.Request[v1.GetDatabaseRequest]) (*connect.Response[v1.Database], error)
+	// Permissions required: databases.get
 	BatchGetDatabases(context.Context, *connect.Request[v1.BatchGetDatabasesRequest]) (*connect.Response[v1.BatchGetDatabasesResponse], error)
+	// Permissions required: databases.list
 	ListDatabases(context.Context, *connect.Request[v1.ListDatabasesRequest]) (*connect.Response[v1.ListDatabasesResponse], error)
+	// Permissions required: databases.update
 	UpdateDatabase(context.Context, *connect.Request[v1.UpdateDatabaseRequest]) (*connect.Response[v1.Database], error)
+	// Permissions required: databases.update
 	BatchUpdateDatabases(context.Context, *connect.Request[v1.BatchUpdateDatabasesRequest]) (*connect.Response[v1.BatchUpdateDatabasesResponse], error)
+	// Permissions required: databases.sync
 	SyncDatabase(context.Context, *connect.Request[v1.SyncDatabaseRequest]) (*connect.Response[v1.SyncDatabaseResponse], error)
+	// Permissions required: databases.sync
 	BatchSyncDatabases(context.Context, *connect.Request[v1.BatchSyncDatabasesRequest]) (*connect.Response[v1.BatchSyncDatabasesResponse], error)
+	// Permissions required: databases.getSchema
 	GetDatabaseMetadata(context.Context, *connect.Request[v1.GetDatabaseMetadataRequest]) (*connect.Response[v1.DatabaseMetadata], error)
+	// Permissions required: databases.getSchema
 	GetDatabaseSchema(context.Context, *connect.Request[v1.GetDatabaseSchemaRequest]) (*connect.Response[v1.DatabaseSchema], error)
+	// Permissions required: databases.get
 	DiffSchema(context.Context, *connect.Request[v1.DiffSchemaRequest]) (*connect.Response[v1.DiffSchemaResponse], error)
+	// Permissions required: databaseSecrets.list
 	ListSecrets(context.Context, *connect.Request[v1.ListSecretsRequest]) (*connect.Response[v1.ListSecretsResponse], error)
+	// Permissions required: databaseSecrets.update
 	UpdateSecret(context.Context, *connect.Request[v1.UpdateSecretRequest]) (*connect.Response[v1.Secret], error)
+	// Permissions required: databaseSecrets.delete
 	DeleteSecret(context.Context, *connect.Request[v1.DeleteSecretRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: changelogs.list
 	ListChangelogs(context.Context, *connect.Request[v1.ListChangelogsRequest]) (*connect.Response[v1.ListChangelogsResponse], error)
+	// Permissions required: changelogs.get
 	GetChangelog(context.Context, *connect.Request[v1.GetChangelogRequest]) (*connect.Response[v1.Changelog], error)
+	// Permissions required: databases.getSchema
 	GetSchemaString(context.Context, *connect.Request[v1.GetSchemaStringRequest]) (*connect.Response[v1.GetSchemaStringResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/group_service.connect.go
+++ b/proto/generated-go/v1/v1connect/group_service.connect.go
@@ -51,17 +51,17 @@ const (
 
 // GroupServiceClient is a client for the bytebase.v1.GroupService service.
 type GroupServiceClient interface {
-	// Permissions required: groups.get
+	// Permissions required: bb.groups.get
 	GetGroup(context.Context, *connect.Request[v1.GetGroupRequest]) (*connect.Response[v1.Group], error)
-	// Permissions required: groups.list
+	// Permissions required: bb.groups.list
 	ListGroups(context.Context, *connect.Request[v1.ListGroupsRequest]) (*connect.Response[v1.ListGroupsResponse], error)
-	// Permissions required: groups.create
+	// Permissions required: bb.groups.create
 	CreateGroup(context.Context, *connect.Request[v1.CreateGroupRequest]) (*connect.Response[v1.Group], error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-	// Permissions required: groups.update
+	// Permissions required: bb.groups.update
 	UpdateGroup(context.Context, *connect.Request[v1.UpdateGroupRequest]) (*connect.Response[v1.Group], error)
-	// Permissions required: groups.delete
+	// Permissions required: bb.groups.delete
 	DeleteGroup(context.Context, *connect.Request[v1.DeleteGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -145,17 +145,17 @@ func (c *groupServiceClient) DeleteGroup(ctx context.Context, req *connect.Reque
 
 // GroupServiceHandler is an implementation of the bytebase.v1.GroupService service.
 type GroupServiceHandler interface {
-	// Permissions required: groups.get
+	// Permissions required: bb.groups.get
 	GetGroup(context.Context, *connect.Request[v1.GetGroupRequest]) (*connect.Response[v1.Group], error)
-	// Permissions required: groups.list
+	// Permissions required: bb.groups.list
 	ListGroups(context.Context, *connect.Request[v1.ListGroupsRequest]) (*connect.Response[v1.ListGroupsResponse], error)
-	// Permissions required: groups.create
+	// Permissions required: bb.groups.create
 	CreateGroup(context.Context, *connect.Request[v1.CreateGroupRequest]) (*connect.Response[v1.Group], error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-	// Permissions required: groups.update
+	// Permissions required: bb.groups.update
 	UpdateGroup(context.Context, *connect.Request[v1.UpdateGroupRequest]) (*connect.Response[v1.Group], error)
-	// Permissions required: groups.delete
+	// Permissions required: bb.groups.delete
 	DeleteGroup(context.Context, *connect.Request[v1.DeleteGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/group_service.connect.go
+++ b/proto/generated-go/v1/v1connect/group_service.connect.go
@@ -51,12 +51,17 @@ const (
 
 // GroupServiceClient is a client for the bytebase.v1.GroupService service.
 type GroupServiceClient interface {
+	// Permissions required: groups.get
 	GetGroup(context.Context, *connect.Request[v1.GetGroupRequest]) (*connect.Response[v1.Group], error)
+	// Permissions required: groups.list
 	ListGroups(context.Context, *connect.Request[v1.ListGroupsRequest]) (*connect.Response[v1.ListGroupsResponse], error)
+	// Permissions required: groups.create
 	CreateGroup(context.Context, *connect.Request[v1.CreateGroupRequest]) (*connect.Response[v1.Group], error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+	// Permissions required: groups.update
 	UpdateGroup(context.Context, *connect.Request[v1.UpdateGroupRequest]) (*connect.Response[v1.Group], error)
+	// Permissions required: groups.delete
 	DeleteGroup(context.Context, *connect.Request[v1.DeleteGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,12 +145,17 @@ func (c *groupServiceClient) DeleteGroup(ctx context.Context, req *connect.Reque
 
 // GroupServiceHandler is an implementation of the bytebase.v1.GroupService service.
 type GroupServiceHandler interface {
+	// Permissions required: groups.get
 	GetGroup(context.Context, *connect.Request[v1.GetGroupRequest]) (*connect.Response[v1.Group], error)
+	// Permissions required: groups.list
 	ListGroups(context.Context, *connect.Request[v1.ListGroupsRequest]) (*connect.Response[v1.ListGroupsResponse], error)
+	// Permissions required: groups.create
 	CreateGroup(context.Context, *connect.Request[v1.CreateGroupRequest]) (*connect.Response[v1.Group], error)
 	// UpdateGroup updates the group.
 	// Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+	// Permissions required: groups.update
 	UpdateGroup(context.Context, *connect.Request[v1.UpdateGroupRequest]) (*connect.Response[v1.Group], error)
+	// Permissions required: groups.delete
 	DeleteGroup(context.Context, *connect.Request[v1.DeleteGroupRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/idp_service.connect.go
+++ b/proto/generated-go/v1/v1connect/idp_service.connect.go
@@ -56,17 +56,17 @@ const (
 
 // IdentityProviderServiceClient is a client for the bytebase.v1.IdentityProviderService service.
 type IdentityProviderServiceClient interface {
-	// Permissions required: identityProviders.get
+	// Permissions required: bb.identityProviders.get
 	GetIdentityProvider(context.Context, *connect.Request[v1.GetIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
 	// Permissions required: None
 	ListIdentityProviders(context.Context, *connect.Request[v1.ListIdentityProvidersRequest]) (*connect.Response[v1.ListIdentityProvidersResponse], error)
-	// Permissions required: identityProviders.create
+	// Permissions required: bb.identityProviders.create
 	CreateIdentityProvider(context.Context, *connect.Request[v1.CreateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	UpdateIdentityProvider(context.Context, *connect.Request[v1.UpdateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
-	// Permissions required: identityProviders.delete
+	// Permissions required: bb.identityProviders.delete
 	DeleteIdentityProvider(context.Context, *connect.Request[v1.DeleteIdentityProviderRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	TestIdentityProvider(context.Context, *connect.Request[v1.TestIdentityProviderRequest]) (*connect.Response[v1.TestIdentityProviderResponse], error)
 }
 
@@ -163,17 +163,17 @@ func (c *identityProviderServiceClient) TestIdentityProvider(ctx context.Context
 // IdentityProviderServiceHandler is an implementation of the bytebase.v1.IdentityProviderService
 // service.
 type IdentityProviderServiceHandler interface {
-	// Permissions required: identityProviders.get
+	// Permissions required: bb.identityProviders.get
 	GetIdentityProvider(context.Context, *connect.Request[v1.GetIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
 	// Permissions required: None
 	ListIdentityProviders(context.Context, *connect.Request[v1.ListIdentityProvidersRequest]) (*connect.Response[v1.ListIdentityProvidersResponse], error)
-	// Permissions required: identityProviders.create
+	// Permissions required: bb.identityProviders.create
 	CreateIdentityProvider(context.Context, *connect.Request[v1.CreateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	UpdateIdentityProvider(context.Context, *connect.Request[v1.UpdateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
-	// Permissions required: identityProviders.delete
+	// Permissions required: bb.identityProviders.delete
 	DeleteIdentityProvider(context.Context, *connect.Request[v1.DeleteIdentityProviderRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: identityProviders.update
+	// Permissions required: bb.identityProviders.update
 	TestIdentityProvider(context.Context, *connect.Request[v1.TestIdentityProviderRequest]) (*connect.Response[v1.TestIdentityProviderResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/idp_service.connect.go
+++ b/proto/generated-go/v1/v1connect/idp_service.connect.go
@@ -56,11 +56,17 @@ const (
 
 // IdentityProviderServiceClient is a client for the bytebase.v1.IdentityProviderService service.
 type IdentityProviderServiceClient interface {
+	// Permissions required: identityProviders.get
 	GetIdentityProvider(context.Context, *connect.Request[v1.GetIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
+	// Permissions required: None
 	ListIdentityProviders(context.Context, *connect.Request[v1.ListIdentityProvidersRequest]) (*connect.Response[v1.ListIdentityProvidersResponse], error)
+	// Permissions required: identityProviders.create
 	CreateIdentityProvider(context.Context, *connect.Request[v1.CreateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
+	// Permissions required: identityProviders.update
 	UpdateIdentityProvider(context.Context, *connect.Request[v1.UpdateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
+	// Permissions required: identityProviders.delete
 	DeleteIdentityProvider(context.Context, *connect.Request[v1.DeleteIdentityProviderRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: identityProviders.update
 	TestIdentityProvider(context.Context, *connect.Request[v1.TestIdentityProviderRequest]) (*connect.Response[v1.TestIdentityProviderResponse], error)
 }
 
@@ -157,11 +163,17 @@ func (c *identityProviderServiceClient) TestIdentityProvider(ctx context.Context
 // IdentityProviderServiceHandler is an implementation of the bytebase.v1.IdentityProviderService
 // service.
 type IdentityProviderServiceHandler interface {
+	// Permissions required: identityProviders.get
 	GetIdentityProvider(context.Context, *connect.Request[v1.GetIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
+	// Permissions required: None
 	ListIdentityProviders(context.Context, *connect.Request[v1.ListIdentityProvidersRequest]) (*connect.Response[v1.ListIdentityProvidersResponse], error)
+	// Permissions required: identityProviders.create
 	CreateIdentityProvider(context.Context, *connect.Request[v1.CreateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
+	// Permissions required: identityProviders.update
 	UpdateIdentityProvider(context.Context, *connect.Request[v1.UpdateIdentityProviderRequest]) (*connect.Response[v1.IdentityProvider], error)
+	// Permissions required: identityProviders.delete
 	DeleteIdentityProvider(context.Context, *connect.Request[v1.DeleteIdentityProviderRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: identityProviders.update
 	TestIdentityProvider(context.Context, *connect.Request[v1.TestIdentityProviderRequest]) (*connect.Response[v1.TestIdentityProviderResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/instance_role_service.connect.go
+++ b/proto/generated-go/v1/v1connect/instance_role_service.connect.go
@@ -43,7 +43,9 @@ const (
 
 // InstanceRoleServiceClient is a client for the bytebase.v1.InstanceRoleService service.
 type InstanceRoleServiceClient interface {
+	// Permissions required: instanceRoles.get
 	GetInstanceRole(context.Context, *connect.Request[v1.GetInstanceRoleRequest]) (*connect.Response[v1.InstanceRole], error)
+	// Permissions required: instanceRoles.get
 	ListInstanceRoles(context.Context, *connect.Request[v1.ListInstanceRolesRequest]) (*connect.Response[v1.ListInstanceRolesResponse], error)
 }
 
@@ -91,7 +93,9 @@ func (c *instanceRoleServiceClient) ListInstanceRoles(ctx context.Context, req *
 
 // InstanceRoleServiceHandler is an implementation of the bytebase.v1.InstanceRoleService service.
 type InstanceRoleServiceHandler interface {
+	// Permissions required: instanceRoles.get
 	GetInstanceRole(context.Context, *connect.Request[v1.GetInstanceRoleRequest]) (*connect.Response[v1.InstanceRole], error)
+	// Permissions required: instanceRoles.get
 	ListInstanceRoles(context.Context, *connect.Request[v1.ListInstanceRolesRequest]) (*connect.Response[v1.ListInstanceRolesResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/instance_role_service.connect.go
+++ b/proto/generated-go/v1/v1connect/instance_role_service.connect.go
@@ -43,9 +43,9 @@ const (
 
 // InstanceRoleServiceClient is a client for the bytebase.v1.InstanceRoleService service.
 type InstanceRoleServiceClient interface {
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	GetInstanceRole(context.Context, *connect.Request[v1.GetInstanceRoleRequest]) (*connect.Response[v1.InstanceRole], error)
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	ListInstanceRoles(context.Context, *connect.Request[v1.ListInstanceRolesRequest]) (*connect.Response[v1.ListInstanceRolesResponse], error)
 }
 
@@ -93,9 +93,9 @@ func (c *instanceRoleServiceClient) ListInstanceRoles(ctx context.Context, req *
 
 // InstanceRoleServiceHandler is an implementation of the bytebase.v1.InstanceRoleService service.
 type InstanceRoleServiceHandler interface {
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	GetInstanceRole(context.Context, *connect.Request[v1.GetInstanceRoleRequest]) (*connect.Response[v1.InstanceRole], error)
-	// Permissions required: instanceRoles.get
+	// Permissions required: bb.instanceRoles.get
 	ListInstanceRoles(context.Context, *connect.Request[v1.ListInstanceRolesRequest]) (*connect.Response[v1.ListInstanceRolesResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/instance_service.connect.go
+++ b/proto/generated-go/v1/v1connect/instance_service.connect.go
@@ -77,18 +77,31 @@ const (
 
 // InstanceServiceClient is a client for the bytebase.v1.InstanceService service.
 type InstanceServiceClient interface {
+	// Permissions required: instances.get
 	GetInstance(context.Context, *connect.Request[v1.GetInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.list
 	ListInstances(context.Context, *connect.Request[v1.ListInstancesRequest]) (*connect.Response[v1.ListInstancesResponse], error)
+	// Permissions required: instances.create
 	CreateInstance(context.Context, *connect.Request[v1.CreateInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.update
 	UpdateInstance(context.Context, *connect.Request[v1.UpdateInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.delete
 	DeleteInstance(context.Context, *connect.Request[v1.DeleteInstanceRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: instances.undelete
 	UndeleteInstance(context.Context, *connect.Request[v1.UndeleteInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.sync
 	SyncInstance(context.Context, *connect.Request[v1.SyncInstanceRequest]) (*connect.Response[v1.SyncInstanceResponse], error)
+	// Permissions required: instances.get
 	ListInstanceDatabase(context.Context, *connect.Request[v1.ListInstanceDatabaseRequest]) (*connect.Response[v1.ListInstanceDatabaseResponse], error)
+	// Permissions required: instances.sync
 	BatchSyncInstances(context.Context, *connect.Request[v1.BatchSyncInstancesRequest]) (*connect.Response[v1.BatchSyncInstancesResponse], error)
+	// Permissions required: instances.update
 	BatchUpdateInstances(context.Context, *connect.Request[v1.BatchUpdateInstancesRequest]) (*connect.Response[v1.BatchUpdateInstancesResponse], error)
+	// Permissions required: instances.update
 	AddDataSource(context.Context, *connect.Request[v1.AddDataSourceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.update
 	RemoveDataSource(context.Context, *connect.Request[v1.RemoveDataSourceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.update
 	UpdateDataSource(context.Context, *connect.Request[v1.UpdateDataSourceRequest]) (*connect.Response[v1.Instance], error)
 }
 
@@ -268,18 +281,31 @@ func (c *instanceServiceClient) UpdateDataSource(ctx context.Context, req *conne
 
 // InstanceServiceHandler is an implementation of the bytebase.v1.InstanceService service.
 type InstanceServiceHandler interface {
+	// Permissions required: instances.get
 	GetInstance(context.Context, *connect.Request[v1.GetInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.list
 	ListInstances(context.Context, *connect.Request[v1.ListInstancesRequest]) (*connect.Response[v1.ListInstancesResponse], error)
+	// Permissions required: instances.create
 	CreateInstance(context.Context, *connect.Request[v1.CreateInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.update
 	UpdateInstance(context.Context, *connect.Request[v1.UpdateInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.delete
 	DeleteInstance(context.Context, *connect.Request[v1.DeleteInstanceRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: instances.undelete
 	UndeleteInstance(context.Context, *connect.Request[v1.UndeleteInstanceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.sync
 	SyncInstance(context.Context, *connect.Request[v1.SyncInstanceRequest]) (*connect.Response[v1.SyncInstanceResponse], error)
+	// Permissions required: instances.get
 	ListInstanceDatabase(context.Context, *connect.Request[v1.ListInstanceDatabaseRequest]) (*connect.Response[v1.ListInstanceDatabaseResponse], error)
+	// Permissions required: instances.sync
 	BatchSyncInstances(context.Context, *connect.Request[v1.BatchSyncInstancesRequest]) (*connect.Response[v1.BatchSyncInstancesResponse], error)
+	// Permissions required: instances.update
 	BatchUpdateInstances(context.Context, *connect.Request[v1.BatchUpdateInstancesRequest]) (*connect.Response[v1.BatchUpdateInstancesResponse], error)
+	// Permissions required: instances.update
 	AddDataSource(context.Context, *connect.Request[v1.AddDataSourceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.update
 	RemoveDataSource(context.Context, *connect.Request[v1.RemoveDataSourceRequest]) (*connect.Response[v1.Instance], error)
+	// Permissions required: instances.update
 	UpdateDataSource(context.Context, *connect.Request[v1.UpdateDataSourceRequest]) (*connect.Response[v1.Instance], error)
 }
 

--- a/proto/generated-go/v1/v1connect/instance_service.connect.go
+++ b/proto/generated-go/v1/v1connect/instance_service.connect.go
@@ -77,31 +77,31 @@ const (
 
 // InstanceServiceClient is a client for the bytebase.v1.InstanceService service.
 type InstanceServiceClient interface {
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	GetInstance(context.Context, *connect.Request[v1.GetInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.list
+	// Permissions required: bb.instances.list
 	ListInstances(context.Context, *connect.Request[v1.ListInstancesRequest]) (*connect.Response[v1.ListInstancesResponse], error)
-	// Permissions required: instances.create
+	// Permissions required: bb.instances.create
 	CreateInstance(context.Context, *connect.Request[v1.CreateInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateInstance(context.Context, *connect.Request[v1.UpdateInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.delete
+	// Permissions required: bb.instances.delete
 	DeleteInstance(context.Context, *connect.Request[v1.DeleteInstanceRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: instances.undelete
+	// Permissions required: bb.instances.undelete
 	UndeleteInstance(context.Context, *connect.Request[v1.UndeleteInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	SyncInstance(context.Context, *connect.Request[v1.SyncInstanceRequest]) (*connect.Response[v1.SyncInstanceResponse], error)
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	ListInstanceDatabase(context.Context, *connect.Request[v1.ListInstanceDatabaseRequest]) (*connect.Response[v1.ListInstanceDatabaseResponse], error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	BatchSyncInstances(context.Context, *connect.Request[v1.BatchSyncInstancesRequest]) (*connect.Response[v1.BatchSyncInstancesResponse], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	BatchUpdateInstances(context.Context, *connect.Request[v1.BatchUpdateInstancesRequest]) (*connect.Response[v1.BatchUpdateInstancesResponse], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	AddDataSource(context.Context, *connect.Request[v1.AddDataSourceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	RemoveDataSource(context.Context, *connect.Request[v1.RemoveDataSourceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateDataSource(context.Context, *connect.Request[v1.UpdateDataSourceRequest]) (*connect.Response[v1.Instance], error)
 }
 
@@ -281,31 +281,31 @@ func (c *instanceServiceClient) UpdateDataSource(ctx context.Context, req *conne
 
 // InstanceServiceHandler is an implementation of the bytebase.v1.InstanceService service.
 type InstanceServiceHandler interface {
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	GetInstance(context.Context, *connect.Request[v1.GetInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.list
+	// Permissions required: bb.instances.list
 	ListInstances(context.Context, *connect.Request[v1.ListInstancesRequest]) (*connect.Response[v1.ListInstancesResponse], error)
-	// Permissions required: instances.create
+	// Permissions required: bb.instances.create
 	CreateInstance(context.Context, *connect.Request[v1.CreateInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateInstance(context.Context, *connect.Request[v1.UpdateInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.delete
+	// Permissions required: bb.instances.delete
 	DeleteInstance(context.Context, *connect.Request[v1.DeleteInstanceRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: instances.undelete
+	// Permissions required: bb.instances.undelete
 	UndeleteInstance(context.Context, *connect.Request[v1.UndeleteInstanceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	SyncInstance(context.Context, *connect.Request[v1.SyncInstanceRequest]) (*connect.Response[v1.SyncInstanceResponse], error)
-	// Permissions required: instances.get
+	// Permissions required: bb.instances.get
 	ListInstanceDatabase(context.Context, *connect.Request[v1.ListInstanceDatabaseRequest]) (*connect.Response[v1.ListInstanceDatabaseResponse], error)
-	// Permissions required: instances.sync
+	// Permissions required: bb.instances.sync
 	BatchSyncInstances(context.Context, *connect.Request[v1.BatchSyncInstancesRequest]) (*connect.Response[v1.BatchSyncInstancesResponse], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	BatchUpdateInstances(context.Context, *connect.Request[v1.BatchUpdateInstancesRequest]) (*connect.Response[v1.BatchUpdateInstancesResponse], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	AddDataSource(context.Context, *connect.Request[v1.AddDataSourceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	RemoveDataSource(context.Context, *connect.Request[v1.RemoveDataSourceRequest]) (*connect.Response[v1.Instance], error)
-	// Permissions required: instances.update
+	// Permissions required: bb.instances.update
 	UpdateDataSource(context.Context, *connect.Request[v1.UpdateDataSourceRequest]) (*connect.Response[v1.Instance], error)
 }
 

--- a/proto/generated-go/v1/v1connect/issue_service.connect.go
+++ b/proto/generated-go/v1/v1connect/issue_service.connect.go
@@ -71,24 +71,24 @@ const (
 
 // IssueServiceClient is a client for the bytebase.v1.IssueService service.
 type IssueServiceClient interface {
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	GetIssue(context.Context, *connect.Request[v1.GetIssueRequest]) (*connect.Response[v1.Issue], error)
-	// Permissions required: issues.create
+	// Permissions required: bb.issues.create
 	CreateIssue(context.Context, *connect.Request[v1.CreateIssueRequest]) (*connect.Response[v1.Issue], error)
-	// Permissions required: issues.list
+	// Permissions required: bb.issues.list
 	ListIssues(context.Context, *connect.Request[v1.ListIssuesRequest]) (*connect.Response[v1.ListIssuesResponse], error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	SearchIssues(context.Context, *connect.Request[v1.SearchIssuesRequest]) (*connect.Response[v1.SearchIssuesResponse], error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	UpdateIssue(context.Context, *connect.Request[v1.UpdateIssueRequest]) (*connect.Response[v1.Issue], error)
-	// Permissions required: issueComments.list
+	// Permissions required: bb.issueComments.list
 	ListIssueComments(context.Context, *connect.Request[v1.ListIssueCommentsRequest]) (*connect.Response[v1.ListIssueCommentsResponse], error)
-	// Permissions required: issueComments.create
+	// Permissions required: bb.issueComments.create
 	CreateIssueComment(context.Context, *connect.Request[v1.CreateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
-	// Permissions required: issueComments.update
+	// Permissions required: bb.issueComments.update
 	UpdateIssueComment(context.Context, *connect.Request[v1.UpdateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	BatchUpdateIssuesStatus(context.Context, *connect.Request[v1.BatchUpdateIssuesStatusRequest]) (*connect.Response[v1.BatchUpdateIssuesStatusResponse], error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.
@@ -268,24 +268,24 @@ func (c *issueServiceClient) RequestIssue(ctx context.Context, req *connect.Requ
 
 // IssueServiceHandler is an implementation of the bytebase.v1.IssueService service.
 type IssueServiceHandler interface {
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	GetIssue(context.Context, *connect.Request[v1.GetIssueRequest]) (*connect.Response[v1.Issue], error)
-	// Permissions required: issues.create
+	// Permissions required: bb.issues.create
 	CreateIssue(context.Context, *connect.Request[v1.CreateIssueRequest]) (*connect.Response[v1.Issue], error)
-	// Permissions required: issues.list
+	// Permissions required: bb.issues.list
 	ListIssues(context.Context, *connect.Request[v1.ListIssuesRequest]) (*connect.Response[v1.ListIssuesResponse], error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-	// Permissions required: issues.get
+	// Permissions required: bb.issues.get
 	SearchIssues(context.Context, *connect.Request[v1.SearchIssuesRequest]) (*connect.Response[v1.SearchIssuesResponse], error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	UpdateIssue(context.Context, *connect.Request[v1.UpdateIssueRequest]) (*connect.Response[v1.Issue], error)
-	// Permissions required: issueComments.list
+	// Permissions required: bb.issueComments.list
 	ListIssueComments(context.Context, *connect.Request[v1.ListIssueCommentsRequest]) (*connect.Response[v1.ListIssueCommentsResponse], error)
-	// Permissions required: issueComments.create
+	// Permissions required: bb.issueComments.create
 	CreateIssueComment(context.Context, *connect.Request[v1.CreateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
-	// Permissions required: issueComments.update
+	// Permissions required: bb.issueComments.update
 	UpdateIssueComment(context.Context, *connect.Request[v1.UpdateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
-	// Permissions required: issues.update
+	// Permissions required: bb.issues.update
 	BatchUpdateIssuesStatus(context.Context, *connect.Request[v1.BatchUpdateIssuesStatusRequest]) (*connect.Response[v1.BatchUpdateIssuesStatusResponse], error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.

--- a/proto/generated-go/v1/v1connect/issue_service.connect.go
+++ b/proto/generated-go/v1/v1connect/issue_service.connect.go
@@ -71,24 +71,36 @@ const (
 
 // IssueServiceClient is a client for the bytebase.v1.IssueService service.
 type IssueServiceClient interface {
+	// Permissions required: issues.get
 	GetIssue(context.Context, *connect.Request[v1.GetIssueRequest]) (*connect.Response[v1.Issue], error)
+	// Permissions required: issues.create
 	CreateIssue(context.Context, *connect.Request[v1.CreateIssueRequest]) (*connect.Response[v1.Issue], error)
+	// Permissions required: issues.list
 	ListIssues(context.Context, *connect.Request[v1.ListIssuesRequest]) (*connect.Response[v1.ListIssuesResponse], error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+	// Permissions required: issues.get
 	SearchIssues(context.Context, *connect.Request[v1.SearchIssuesRequest]) (*connect.Response[v1.SearchIssuesResponse], error)
+	// Permissions required: issues.update
 	UpdateIssue(context.Context, *connect.Request[v1.UpdateIssueRequest]) (*connect.Response[v1.Issue], error)
+	// Permissions required: issueComments.list
 	ListIssueComments(context.Context, *connect.Request[v1.ListIssueCommentsRequest]) (*connect.Response[v1.ListIssueCommentsResponse], error)
+	// Permissions required: issueComments.create
 	CreateIssueComment(context.Context, *connect.Request[v1.CreateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
+	// Permissions required: issueComments.update
 	UpdateIssueComment(context.Context, *connect.Request[v1.UpdateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
+	// Permissions required: issues.update
 	BatchUpdateIssuesStatus(context.Context, *connect.Request[v1.BatchUpdateIssuesStatusRequest]) (*connect.Response[v1.BatchUpdateIssuesStatusResponse], error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	ApproveIssue(context.Context, *connect.Request[v1.ApproveIssueRequest]) (*connect.Response[v1.Issue], error)
 	// RejectIssue rejects the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RejectIssue(context.Context, *connect.Request[v1.RejectIssueRequest]) (*connect.Response[v1.Issue], error)
 	// RequestIssue requests the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RequestIssue(context.Context, *connect.Request[v1.RequestIssueRequest]) (*connect.Response[v1.Issue], error)
 }
 
@@ -256,24 +268,36 @@ func (c *issueServiceClient) RequestIssue(ctx context.Context, req *connect.Requ
 
 // IssueServiceHandler is an implementation of the bytebase.v1.IssueService service.
 type IssueServiceHandler interface {
+	// Permissions required: issues.get
 	GetIssue(context.Context, *connect.Request[v1.GetIssueRequest]) (*connect.Response[v1.Issue], error)
+	// Permissions required: issues.create
 	CreateIssue(context.Context, *connect.Request[v1.CreateIssueRequest]) (*connect.Response[v1.Issue], error)
+	// Permissions required: issues.list
 	ListIssues(context.Context, *connect.Request[v1.ListIssuesRequest]) (*connect.Response[v1.ListIssuesResponse], error)
 	// Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+	// Permissions required: issues.get
 	SearchIssues(context.Context, *connect.Request[v1.SearchIssuesRequest]) (*connect.Response[v1.SearchIssuesResponse], error)
+	// Permissions required: issues.update
 	UpdateIssue(context.Context, *connect.Request[v1.UpdateIssueRequest]) (*connect.Response[v1.Issue], error)
+	// Permissions required: issueComments.list
 	ListIssueComments(context.Context, *connect.Request[v1.ListIssueCommentsRequest]) (*connect.Response[v1.ListIssueCommentsResponse], error)
+	// Permissions required: issueComments.create
 	CreateIssueComment(context.Context, *connect.Request[v1.CreateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
+	// Permissions required: issueComments.update
 	UpdateIssueComment(context.Context, *connect.Request[v1.UpdateIssueCommentRequest]) (*connect.Response[v1.IssueComment], error)
+	// Permissions required: issues.update
 	BatchUpdateIssuesStatus(context.Context, *connect.Request[v1.BatchUpdateIssuesStatusRequest]) (*connect.Response[v1.BatchUpdateIssuesStatusResponse], error)
 	// ApproveIssue approves the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	ApproveIssue(context.Context, *connect.Request[v1.ApproveIssueRequest]) (*connect.Response[v1.Issue], error)
 	// RejectIssue rejects the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RejectIssue(context.Context, *connect.Request[v1.RejectIssueRequest]) (*connect.Response[v1.Issue], error)
 	// RequestIssue requests the issue.
 	// The access is based on approval flow.
+	// Permissions required: None
 	RequestIssue(context.Context, *connect.Request[v1.RequestIssueRequest]) (*connect.Response[v1.Issue], error)
 }
 

--- a/proto/generated-go/v1/v1connect/org_policy_service.connect.go
+++ b/proto/generated-go/v1/v1connect/org_policy_service.connect.go
@@ -53,15 +53,15 @@ const (
 
 // OrgPolicyServiceClient is a client for the bytebase.v1.OrgPolicyService service.
 type OrgPolicyServiceClient interface {
-	// Permissions required: policies.get
+	// Permissions required: bb.policies.get
 	GetPolicy(context.Context, *connect.Request[v1.GetPolicyRequest]) (*connect.Response[v1.Policy], error)
-	// Permissions required: policies.list
+	// Permissions required: bb.policies.list
 	ListPolicies(context.Context, *connect.Request[v1.ListPoliciesRequest]) (*connect.Response[v1.ListPoliciesResponse], error)
-	// Permissions required: policies.create
+	// Permissions required: bb.policies.create
 	CreatePolicy(context.Context, *connect.Request[v1.CreatePolicyRequest]) (*connect.Response[v1.Policy], error)
-	// Permissions required: policies.update
+	// Permissions required: bb.policies.update
 	UpdatePolicy(context.Context, *connect.Request[v1.UpdatePolicyRequest]) (*connect.Response[v1.Policy], error)
-	// Permissions required: policies.delete
+	// Permissions required: bb.policies.delete
 	DeletePolicy(context.Context, *connect.Request[v1.DeletePolicyRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -145,15 +145,15 @@ func (c *orgPolicyServiceClient) DeletePolicy(ctx context.Context, req *connect.
 
 // OrgPolicyServiceHandler is an implementation of the bytebase.v1.OrgPolicyService service.
 type OrgPolicyServiceHandler interface {
-	// Permissions required: policies.get
+	// Permissions required: bb.policies.get
 	GetPolicy(context.Context, *connect.Request[v1.GetPolicyRequest]) (*connect.Response[v1.Policy], error)
-	// Permissions required: policies.list
+	// Permissions required: bb.policies.list
 	ListPolicies(context.Context, *connect.Request[v1.ListPoliciesRequest]) (*connect.Response[v1.ListPoliciesResponse], error)
-	// Permissions required: policies.create
+	// Permissions required: bb.policies.create
 	CreatePolicy(context.Context, *connect.Request[v1.CreatePolicyRequest]) (*connect.Response[v1.Policy], error)
-	// Permissions required: policies.update
+	// Permissions required: bb.policies.update
 	UpdatePolicy(context.Context, *connect.Request[v1.UpdatePolicyRequest]) (*connect.Response[v1.Policy], error)
-	// Permissions required: policies.delete
+	// Permissions required: bb.policies.delete
 	DeletePolicy(context.Context, *connect.Request[v1.DeletePolicyRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/org_policy_service.connect.go
+++ b/proto/generated-go/v1/v1connect/org_policy_service.connect.go
@@ -53,10 +53,15 @@ const (
 
 // OrgPolicyServiceClient is a client for the bytebase.v1.OrgPolicyService service.
 type OrgPolicyServiceClient interface {
+	// Permissions required: policies.get
 	GetPolicy(context.Context, *connect.Request[v1.GetPolicyRequest]) (*connect.Response[v1.Policy], error)
+	// Permissions required: policies.list
 	ListPolicies(context.Context, *connect.Request[v1.ListPoliciesRequest]) (*connect.Response[v1.ListPoliciesResponse], error)
+	// Permissions required: policies.create
 	CreatePolicy(context.Context, *connect.Request[v1.CreatePolicyRequest]) (*connect.Response[v1.Policy], error)
+	// Permissions required: policies.update
 	UpdatePolicy(context.Context, *connect.Request[v1.UpdatePolicyRequest]) (*connect.Response[v1.Policy], error)
+	// Permissions required: policies.delete
 	DeletePolicy(context.Context, *connect.Request[v1.DeletePolicyRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,10 +145,15 @@ func (c *orgPolicyServiceClient) DeletePolicy(ctx context.Context, req *connect.
 
 // OrgPolicyServiceHandler is an implementation of the bytebase.v1.OrgPolicyService service.
 type OrgPolicyServiceHandler interface {
+	// Permissions required: policies.get
 	GetPolicy(context.Context, *connect.Request[v1.GetPolicyRequest]) (*connect.Response[v1.Policy], error)
+	// Permissions required: policies.list
 	ListPolicies(context.Context, *connect.Request[v1.ListPoliciesRequest]) (*connect.Response[v1.ListPoliciesResponse], error)
+	// Permissions required: policies.create
 	CreatePolicy(context.Context, *connect.Request[v1.CreatePolicyRequest]) (*connect.Response[v1.Policy], error)
+	// Permissions required: policies.update
 	UpdatePolicy(context.Context, *connect.Request[v1.UpdatePolicyRequest]) (*connect.Response[v1.Policy], error)
+	// Permissions required: policies.delete
 	DeletePolicy(context.Context, *connect.Request[v1.DeletePolicyRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/plan_service.connect.go
+++ b/proto/generated-go/v1/v1connect/plan_service.connect.go
@@ -56,16 +56,24 @@ const (
 
 // PlanServiceClient is a client for the bytebase.v1.PlanService service.
 type PlanServiceClient interface {
+	// Permissions required: plans.get
 	GetPlan(context.Context, *connect.Request[v1.GetPlanRequest]) (*connect.Response[v1.Plan], error)
+	// Permissions required: plans.list
 	ListPlans(context.Context, *connect.Request[v1.ListPlansRequest]) (*connect.Response[v1.ListPlansResponse], error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+	// Permissions required: plans.get
 	SearchPlans(context.Context, *connect.Request[v1.SearchPlansRequest]) (*connect.Response[v1.SearchPlansResponse], error)
+	// Permissions required: plans.create
 	CreatePlan(context.Context, *connect.Request[v1.CreatePlanRequest]) (*connect.Response[v1.Plan], error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
+	// Permissions required: plans.update
 	UpdatePlan(context.Context, *connect.Request[v1.UpdatePlanRequest]) (*connect.Response[v1.Plan], error)
+	// Permissions required: planCheckRuns.list
 	ListPlanCheckRuns(context.Context, *connect.Request[v1.ListPlanCheckRunsRequest]) (*connect.Response[v1.ListPlanCheckRunsResponse], error)
+	// Permissions required: planCheckRuns.run
 	RunPlanChecks(context.Context, *connect.Request[v1.RunPlanChecksRequest]) (*connect.Response[v1.RunPlanChecksResponse], error)
+	// Permissions required: planCheckRuns.run
 	BatchCancelPlanCheckRuns(context.Context, *connect.Request[v1.BatchCancelPlanCheckRunsRequest]) (*connect.Response[v1.BatchCancelPlanCheckRunsResponse], error)
 }
 
@@ -185,16 +193,24 @@ func (c *planServiceClient) BatchCancelPlanCheckRuns(ctx context.Context, req *c
 
 // PlanServiceHandler is an implementation of the bytebase.v1.PlanService service.
 type PlanServiceHandler interface {
+	// Permissions required: plans.get
 	GetPlan(context.Context, *connect.Request[v1.GetPlanRequest]) (*connect.Response[v1.Plan], error)
+	// Permissions required: plans.list
 	ListPlans(context.Context, *connect.Request[v1.ListPlansRequest]) (*connect.Response[v1.ListPlansResponse], error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+	// Permissions required: plans.get
 	SearchPlans(context.Context, *connect.Request[v1.SearchPlansRequest]) (*connect.Response[v1.SearchPlansResponse], error)
+	// Permissions required: plans.create
 	CreatePlan(context.Context, *connect.Request[v1.CreatePlanRequest]) (*connect.Response[v1.Plan], error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
+	// Permissions required: plans.update
 	UpdatePlan(context.Context, *connect.Request[v1.UpdatePlanRequest]) (*connect.Response[v1.Plan], error)
+	// Permissions required: planCheckRuns.list
 	ListPlanCheckRuns(context.Context, *connect.Request[v1.ListPlanCheckRunsRequest]) (*connect.Response[v1.ListPlanCheckRunsResponse], error)
+	// Permissions required: planCheckRuns.run
 	RunPlanChecks(context.Context, *connect.Request[v1.RunPlanChecksRequest]) (*connect.Response[v1.RunPlanChecksResponse], error)
+	// Permissions required: planCheckRuns.run
 	BatchCancelPlanCheckRuns(context.Context, *connect.Request[v1.BatchCancelPlanCheckRunsRequest]) (*connect.Response[v1.BatchCancelPlanCheckRunsResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/plan_service.connect.go
+++ b/proto/generated-go/v1/v1connect/plan_service.connect.go
@@ -56,24 +56,24 @@ const (
 
 // PlanServiceClient is a client for the bytebase.v1.PlanService service.
 type PlanServiceClient interface {
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	GetPlan(context.Context, *connect.Request[v1.GetPlanRequest]) (*connect.Response[v1.Plan], error)
-	// Permissions required: plans.list
+	// Permissions required: bb.plans.list
 	ListPlans(context.Context, *connect.Request[v1.ListPlansRequest]) (*connect.Response[v1.ListPlansResponse], error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	SearchPlans(context.Context, *connect.Request[v1.SearchPlansRequest]) (*connect.Response[v1.SearchPlansResponse], error)
-	// Permissions required: plans.create
+	// Permissions required: bb.plans.create
 	CreatePlan(context.Context, *connect.Request[v1.CreatePlanRequest]) (*connect.Response[v1.Plan], error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
-	// Permissions required: plans.update
+	// Permissions required: bb.plans.update
 	UpdatePlan(context.Context, *connect.Request[v1.UpdatePlanRequest]) (*connect.Response[v1.Plan], error)
-	// Permissions required: planCheckRuns.list
+	// Permissions required: bb.planCheckRuns.list
 	ListPlanCheckRuns(context.Context, *connect.Request[v1.ListPlanCheckRunsRequest]) (*connect.Response[v1.ListPlanCheckRunsResponse], error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	RunPlanChecks(context.Context, *connect.Request[v1.RunPlanChecksRequest]) (*connect.Response[v1.RunPlanChecksResponse], error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	BatchCancelPlanCheckRuns(context.Context, *connect.Request[v1.BatchCancelPlanCheckRunsRequest]) (*connect.Response[v1.BatchCancelPlanCheckRunsResponse], error)
 }
 
@@ -193,24 +193,24 @@ func (c *planServiceClient) BatchCancelPlanCheckRuns(ctx context.Context, req *c
 
 // PlanServiceHandler is an implementation of the bytebase.v1.PlanService service.
 type PlanServiceHandler interface {
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	GetPlan(context.Context, *connect.Request[v1.GetPlanRequest]) (*connect.Response[v1.Plan], error)
-	// Permissions required: plans.list
+	// Permissions required: bb.plans.list
 	ListPlans(context.Context, *connect.Request[v1.ListPlansRequest]) (*connect.Response[v1.ListPlansResponse], error)
 	// Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-	// Permissions required: plans.get
+	// Permissions required: bb.plans.get
 	SearchPlans(context.Context, *connect.Request[v1.SearchPlansRequest]) (*connect.Response[v1.SearchPlansResponse], error)
-	// Permissions required: plans.create
+	// Permissions required: bb.plans.create
 	CreatePlan(context.Context, *connect.Request[v1.CreatePlanRequest]) (*connect.Response[v1.Plan], error)
 	// UpdatePlan updates the plan.
 	// The plan creator and the user with bb.plans.update permission on the project can update the plan.
-	// Permissions required: plans.update
+	// Permissions required: bb.plans.update
 	UpdatePlan(context.Context, *connect.Request[v1.UpdatePlanRequest]) (*connect.Response[v1.Plan], error)
-	// Permissions required: planCheckRuns.list
+	// Permissions required: bb.planCheckRuns.list
 	ListPlanCheckRuns(context.Context, *connect.Request[v1.ListPlanCheckRunsRequest]) (*connect.Response[v1.ListPlanCheckRunsResponse], error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	RunPlanChecks(context.Context, *connect.Request[v1.RunPlanChecksRequest]) (*connect.Response[v1.RunPlanChecksResponse], error)
-	// Permissions required: planCheckRuns.run
+	// Permissions required: bb.planCheckRuns.run
 	BatchCancelPlanCheckRuns(context.Context, *connect.Request[v1.BatchCancelPlanCheckRunsRequest]) (*connect.Response[v1.BatchCancelPlanCheckRunsResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/project_service.connect.go
+++ b/proto/generated-go/v1/v1connect/project_service.connect.go
@@ -85,21 +85,36 @@ const (
 type ProjectServiceClient interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+	// Permissions required: projects.get
 	GetProject(context.Context, *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.list
 	ListProjects(context.Context, *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error)
+	// Permissions required: None
 	SearchProjects(context.Context, *connect.Request[v1.SearchProjectsRequest]) (*connect.Response[v1.SearchProjectsResponse], error)
+	// Permissions required: projects.create
 	CreateProject(context.Context, *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	UpdateProject(context.Context, *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.delete
 	DeleteProject(context.Context, *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: projects.undelete
 	UndeleteProject(context.Context, *connect.Request[v1.UndeleteProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.delete
 	BatchDeleteProjects(context.Context, *connect.Request[v1.BatchDeleteProjectsRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: projects.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 	// Deprecated.
+	// Permissions required: projects.getIamPolicy
 	BatchGetIamPolicy(context.Context, *connect.Request[v1.BatchGetIamPolicyRequest]) (*connect.Response[v1.BatchGetIamPolicyResponse], error)
+	// Permissions required: projects.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
+	// Permissions required: projects.update
 	AddWebhook(context.Context, *connect.Request[v1.AddWebhookRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	UpdateWebhook(context.Context, *connect.Request[v1.UpdateWebhookRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	RemoveWebhook(context.Context, *connect.Request[v1.RemoveWebhookRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	TestWebhook(context.Context, *connect.Request[v1.TestWebhookRequest]) (*connect.Response[v1.TestWebhookResponse], error)
 }
 
@@ -305,21 +320,36 @@ func (c *projectServiceClient) TestWebhook(ctx context.Context, req *connect.Req
 type ProjectServiceHandler interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+	// Permissions required: projects.get
 	GetProject(context.Context, *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.list
 	ListProjects(context.Context, *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error)
+	// Permissions required: None
 	SearchProjects(context.Context, *connect.Request[v1.SearchProjectsRequest]) (*connect.Response[v1.SearchProjectsResponse], error)
+	// Permissions required: projects.create
 	CreateProject(context.Context, *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	UpdateProject(context.Context, *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.delete
 	DeleteProject(context.Context, *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: projects.undelete
 	UndeleteProject(context.Context, *connect.Request[v1.UndeleteProjectRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.delete
 	BatchDeleteProjects(context.Context, *connect.Request[v1.BatchDeleteProjectsRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: projects.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 	// Deprecated.
+	// Permissions required: projects.getIamPolicy
 	BatchGetIamPolicy(context.Context, *connect.Request[v1.BatchGetIamPolicyRequest]) (*connect.Response[v1.BatchGetIamPolicyResponse], error)
+	// Permissions required: projects.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
+	// Permissions required: projects.update
 	AddWebhook(context.Context, *connect.Request[v1.AddWebhookRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	UpdateWebhook(context.Context, *connect.Request[v1.UpdateWebhookRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	RemoveWebhook(context.Context, *connect.Request[v1.RemoveWebhookRequest]) (*connect.Response[v1.Project], error)
+	// Permissions required: projects.update
 	TestWebhook(context.Context, *connect.Request[v1.TestWebhookRequest]) (*connect.Response[v1.TestWebhookResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/project_service.connect.go
+++ b/proto/generated-go/v1/v1connect/project_service.connect.go
@@ -85,36 +85,36 @@ const (
 type ProjectServiceClient interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetProject(context.Context, *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.list
+	// Permissions required: bb.projects.list
 	ListProjects(context.Context, *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error)
 	// Permissions required: None
 	SearchProjects(context.Context, *connect.Request[v1.SearchProjectsRequest]) (*connect.Response[v1.SearchProjectsResponse], error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	CreateProject(context.Context, *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateProject(context.Context, *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	DeleteProject(context.Context, *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: projects.undelete
+	// Permissions required: bb.projects.undelete
 	UndeleteProject(context.Context, *connect.Request[v1.UndeleteProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	BatchDeleteProjects(context.Context, *connect.Request[v1.BatchDeleteProjectsRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 	// Deprecated.
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	BatchGetIamPolicy(context.Context, *connect.Request[v1.BatchGetIamPolicyRequest]) (*connect.Response[v1.BatchGetIamPolicyResponse], error)
-	// Permissions required: projects.setIamPolicy
+	// Permissions required: bb.projects.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	AddWebhook(context.Context, *connect.Request[v1.AddWebhookRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateWebhook(context.Context, *connect.Request[v1.UpdateWebhookRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	RemoveWebhook(context.Context, *connect.Request[v1.RemoveWebhookRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	TestWebhook(context.Context, *connect.Request[v1.TestWebhookRequest]) (*connect.Response[v1.TestWebhookResponse], error)
 }
 
@@ -320,36 +320,36 @@ func (c *projectServiceClient) TestWebhook(ctx context.Context, req *connect.Req
 type ProjectServiceHandler interface {
 	// GetProject retrieves a project by name.
 	// Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-	// Permissions required: projects.get
+	// Permissions required: bb.projects.get
 	GetProject(context.Context, *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.list
+	// Permissions required: bb.projects.list
 	ListProjects(context.Context, *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error)
 	// Permissions required: None
 	SearchProjects(context.Context, *connect.Request[v1.SearchProjectsRequest]) (*connect.Response[v1.SearchProjectsResponse], error)
-	// Permissions required: projects.create
+	// Permissions required: bb.projects.create
 	CreateProject(context.Context, *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateProject(context.Context, *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	DeleteProject(context.Context, *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: projects.undelete
+	// Permissions required: bb.projects.undelete
 	UndeleteProject(context.Context, *connect.Request[v1.UndeleteProjectRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.delete
+	// Permissions required: bb.projects.delete
 	BatchDeleteProjects(context.Context, *connect.Request[v1.BatchDeleteProjectsRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 	// Deprecated.
-	// Permissions required: projects.getIamPolicy
+	// Permissions required: bb.projects.getIamPolicy
 	BatchGetIamPolicy(context.Context, *connect.Request[v1.BatchGetIamPolicyRequest]) (*connect.Response[v1.BatchGetIamPolicyResponse], error)
-	// Permissions required: projects.setIamPolicy
+	// Permissions required: bb.projects.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	AddWebhook(context.Context, *connect.Request[v1.AddWebhookRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	UpdateWebhook(context.Context, *connect.Request[v1.UpdateWebhookRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	RemoveWebhook(context.Context, *connect.Request[v1.RemoveWebhookRequest]) (*connect.Response[v1.Project], error)
-	// Permissions required: projects.update
+	// Permissions required: bb.projects.update
 	TestWebhook(context.Context, *connect.Request[v1.TestWebhookRequest]) (*connect.Response[v1.TestWebhookResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/release_service.connect.go
+++ b/proto/generated-go/v1/v1connect/release_service.connect.go
@@ -59,12 +59,19 @@ const (
 
 // ReleaseServiceClient is a client for the bytebase.v1.ReleaseService service.
 type ReleaseServiceClient interface {
+	// Permissions required: releases.get
 	GetRelease(context.Context, *connect.Request[v1.GetReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.list
 	ListReleases(context.Context, *connect.Request[v1.ListReleasesRequest]) (*connect.Response[v1.ListReleasesResponse], error)
+	// Permissions required: releases.create
 	CreateRelease(context.Context, *connect.Request[v1.CreateReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.update
 	UpdateRelease(context.Context, *connect.Request[v1.UpdateReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.delete
 	DeleteRelease(context.Context, *connect.Request[v1.DeleteReleaseRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: releases.undelete
 	UndeleteRelease(context.Context, *connect.Request[v1.UndeleteReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.check
 	CheckRelease(context.Context, *connect.Request[v1.CheckReleaseRequest]) (*connect.Response[v1.CheckReleaseResponse], error)
 }
 
@@ -172,12 +179,19 @@ func (c *releaseServiceClient) CheckRelease(ctx context.Context, req *connect.Re
 
 // ReleaseServiceHandler is an implementation of the bytebase.v1.ReleaseService service.
 type ReleaseServiceHandler interface {
+	// Permissions required: releases.get
 	GetRelease(context.Context, *connect.Request[v1.GetReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.list
 	ListReleases(context.Context, *connect.Request[v1.ListReleasesRequest]) (*connect.Response[v1.ListReleasesResponse], error)
+	// Permissions required: releases.create
 	CreateRelease(context.Context, *connect.Request[v1.CreateReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.update
 	UpdateRelease(context.Context, *connect.Request[v1.UpdateReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.delete
 	DeleteRelease(context.Context, *connect.Request[v1.DeleteReleaseRequest]) (*connect.Response[emptypb.Empty], error)
+	// Permissions required: releases.undelete
 	UndeleteRelease(context.Context, *connect.Request[v1.UndeleteReleaseRequest]) (*connect.Response[v1.Release], error)
+	// Permissions required: releases.check
 	CheckRelease(context.Context, *connect.Request[v1.CheckReleaseRequest]) (*connect.Response[v1.CheckReleaseResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/release_service.connect.go
+++ b/proto/generated-go/v1/v1connect/release_service.connect.go
@@ -59,19 +59,19 @@ const (
 
 // ReleaseServiceClient is a client for the bytebase.v1.ReleaseService service.
 type ReleaseServiceClient interface {
-	// Permissions required: releases.get
+	// Permissions required: bb.releases.get
 	GetRelease(context.Context, *connect.Request[v1.GetReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.list
+	// Permissions required: bb.releases.list
 	ListReleases(context.Context, *connect.Request[v1.ListReleasesRequest]) (*connect.Response[v1.ListReleasesResponse], error)
-	// Permissions required: releases.create
+	// Permissions required: bb.releases.create
 	CreateRelease(context.Context, *connect.Request[v1.CreateReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.update
+	// Permissions required: bb.releases.update
 	UpdateRelease(context.Context, *connect.Request[v1.UpdateReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.delete
+	// Permissions required: bb.releases.delete
 	DeleteRelease(context.Context, *connect.Request[v1.DeleteReleaseRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: releases.undelete
+	// Permissions required: bb.releases.undelete
 	UndeleteRelease(context.Context, *connect.Request[v1.UndeleteReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.check
+	// Permissions required: bb.releases.check
 	CheckRelease(context.Context, *connect.Request[v1.CheckReleaseRequest]) (*connect.Response[v1.CheckReleaseResponse], error)
 }
 
@@ -179,19 +179,19 @@ func (c *releaseServiceClient) CheckRelease(ctx context.Context, req *connect.Re
 
 // ReleaseServiceHandler is an implementation of the bytebase.v1.ReleaseService service.
 type ReleaseServiceHandler interface {
-	// Permissions required: releases.get
+	// Permissions required: bb.releases.get
 	GetRelease(context.Context, *connect.Request[v1.GetReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.list
+	// Permissions required: bb.releases.list
 	ListReleases(context.Context, *connect.Request[v1.ListReleasesRequest]) (*connect.Response[v1.ListReleasesResponse], error)
-	// Permissions required: releases.create
+	// Permissions required: bb.releases.create
 	CreateRelease(context.Context, *connect.Request[v1.CreateReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.update
+	// Permissions required: bb.releases.update
 	UpdateRelease(context.Context, *connect.Request[v1.UpdateReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.delete
+	// Permissions required: bb.releases.delete
 	DeleteRelease(context.Context, *connect.Request[v1.DeleteReleaseRequest]) (*connect.Response[emptypb.Empty], error)
-	// Permissions required: releases.undelete
+	// Permissions required: bb.releases.undelete
 	UndeleteRelease(context.Context, *connect.Request[v1.UndeleteReleaseRequest]) (*connect.Response[v1.Release], error)
-	// Permissions required: releases.check
+	// Permissions required: bb.releases.check
 	CheckRelease(context.Context, *connect.Request[v1.CheckReleaseRequest]) (*connect.Response[v1.CheckReleaseResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/review_config_service.connect.go
+++ b/proto/generated-go/v1/v1connect/review_config_service.connect.go
@@ -53,15 +53,15 @@ const (
 
 // ReviewConfigServiceClient is a client for the bytebase.v1.ReviewConfigService service.
 type ReviewConfigServiceClient interface {
-	// Permissions required: reviewConfigs.create
+	// Permissions required: bb.reviewConfigs.create
 	CreateReviewConfig(context.Context, *connect.Request[v1.CreateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
-	// Permissions required: reviewConfigs.list
+	// Permissions required: bb.reviewConfigs.list
 	ListReviewConfigs(context.Context, *connect.Request[v1.ListReviewConfigsRequest]) (*connect.Response[v1.ListReviewConfigsResponse], error)
-	// Permissions required: reviewConfigs.get
+	// Permissions required: bb.reviewConfigs.get
 	GetReviewConfig(context.Context, *connect.Request[v1.GetReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
-	// Permissions required: reviewConfigs.update
+	// Permissions required: bb.reviewConfigs.update
 	UpdateReviewConfig(context.Context, *connect.Request[v1.UpdateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
-	// Permissions required: reviewConfigs.delete
+	// Permissions required: bb.reviewConfigs.delete
 	DeleteReviewConfig(context.Context, *connect.Request[v1.DeleteReviewConfigRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -145,15 +145,15 @@ func (c *reviewConfigServiceClient) DeleteReviewConfig(ctx context.Context, req 
 
 // ReviewConfigServiceHandler is an implementation of the bytebase.v1.ReviewConfigService service.
 type ReviewConfigServiceHandler interface {
-	// Permissions required: reviewConfigs.create
+	// Permissions required: bb.reviewConfigs.create
 	CreateReviewConfig(context.Context, *connect.Request[v1.CreateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
-	// Permissions required: reviewConfigs.list
+	// Permissions required: bb.reviewConfigs.list
 	ListReviewConfigs(context.Context, *connect.Request[v1.ListReviewConfigsRequest]) (*connect.Response[v1.ListReviewConfigsResponse], error)
-	// Permissions required: reviewConfigs.get
+	// Permissions required: bb.reviewConfigs.get
 	GetReviewConfig(context.Context, *connect.Request[v1.GetReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
-	// Permissions required: reviewConfigs.update
+	// Permissions required: bb.reviewConfigs.update
 	UpdateReviewConfig(context.Context, *connect.Request[v1.UpdateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
-	// Permissions required: reviewConfigs.delete
+	// Permissions required: bb.reviewConfigs.delete
 	DeleteReviewConfig(context.Context, *connect.Request[v1.DeleteReviewConfigRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/review_config_service.connect.go
+++ b/proto/generated-go/v1/v1connect/review_config_service.connect.go
@@ -53,10 +53,15 @@ const (
 
 // ReviewConfigServiceClient is a client for the bytebase.v1.ReviewConfigService service.
 type ReviewConfigServiceClient interface {
+	// Permissions required: reviewConfigs.create
 	CreateReviewConfig(context.Context, *connect.Request[v1.CreateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
+	// Permissions required: reviewConfigs.list
 	ListReviewConfigs(context.Context, *connect.Request[v1.ListReviewConfigsRequest]) (*connect.Response[v1.ListReviewConfigsResponse], error)
+	// Permissions required: reviewConfigs.get
 	GetReviewConfig(context.Context, *connect.Request[v1.GetReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
+	// Permissions required: reviewConfigs.update
 	UpdateReviewConfig(context.Context, *connect.Request[v1.UpdateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
+	// Permissions required: reviewConfigs.delete
 	DeleteReviewConfig(context.Context, *connect.Request[v1.DeleteReviewConfigRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,10 +145,15 @@ func (c *reviewConfigServiceClient) DeleteReviewConfig(ctx context.Context, req 
 
 // ReviewConfigServiceHandler is an implementation of the bytebase.v1.ReviewConfigService service.
 type ReviewConfigServiceHandler interface {
+	// Permissions required: reviewConfigs.create
 	CreateReviewConfig(context.Context, *connect.Request[v1.CreateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
+	// Permissions required: reviewConfigs.list
 	ListReviewConfigs(context.Context, *connect.Request[v1.ListReviewConfigsRequest]) (*connect.Response[v1.ListReviewConfigsResponse], error)
+	// Permissions required: reviewConfigs.get
 	GetReviewConfig(context.Context, *connect.Request[v1.GetReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
+	// Permissions required: reviewConfigs.update
 	UpdateReviewConfig(context.Context, *connect.Request[v1.UpdateReviewConfigRequest]) (*connect.Response[v1.ReviewConfig], error)
+	// Permissions required: reviewConfigs.delete
 	DeleteReviewConfig(context.Context, *connect.Request[v1.DeleteReviewConfigRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/revision_service.connect.go
+++ b/proto/generated-go/v1/v1connect/revision_service.connect.go
@@ -53,15 +53,15 @@ const (
 
 // RevisionServiceClient is a client for the bytebase.v1.RevisionService service.
 type RevisionServiceClient interface {
-	// Permissions required: revisions.list
+	// Permissions required: bb.revisions.list
 	ListRevisions(context.Context, *connect.Request[v1.ListRevisionsRequest]) (*connect.Response[v1.ListRevisionsResponse], error)
-	// Permissions required: revisions.get
+	// Permissions required: bb.revisions.get
 	GetRevision(context.Context, *connect.Request[v1.GetRevisionRequest]) (*connect.Response[v1.Revision], error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	CreateRevision(context.Context, *connect.Request[v1.CreateRevisionRequest]) (*connect.Response[v1.Revision], error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	BatchCreateRevisions(context.Context, *connect.Request[v1.BatchCreateRevisionsRequest]) (*connect.Response[v1.BatchCreateRevisionsResponse], error)
-	// Permissions required: revisions.delete
+	// Permissions required: bb.revisions.delete
 	DeleteRevision(context.Context, *connect.Request[v1.DeleteRevisionRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -145,15 +145,15 @@ func (c *revisionServiceClient) DeleteRevision(ctx context.Context, req *connect
 
 // RevisionServiceHandler is an implementation of the bytebase.v1.RevisionService service.
 type RevisionServiceHandler interface {
-	// Permissions required: revisions.list
+	// Permissions required: bb.revisions.list
 	ListRevisions(context.Context, *connect.Request[v1.ListRevisionsRequest]) (*connect.Response[v1.ListRevisionsResponse], error)
-	// Permissions required: revisions.get
+	// Permissions required: bb.revisions.get
 	GetRevision(context.Context, *connect.Request[v1.GetRevisionRequest]) (*connect.Response[v1.Revision], error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	CreateRevision(context.Context, *connect.Request[v1.CreateRevisionRequest]) (*connect.Response[v1.Revision], error)
-	// Permissions required: revisions.create
+	// Permissions required: bb.revisions.create
 	BatchCreateRevisions(context.Context, *connect.Request[v1.BatchCreateRevisionsRequest]) (*connect.Response[v1.BatchCreateRevisionsResponse], error)
-	// Permissions required: revisions.delete
+	// Permissions required: bb.revisions.delete
 	DeleteRevision(context.Context, *connect.Request[v1.DeleteRevisionRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/revision_service.connect.go
+++ b/proto/generated-go/v1/v1connect/revision_service.connect.go
@@ -53,10 +53,15 @@ const (
 
 // RevisionServiceClient is a client for the bytebase.v1.RevisionService service.
 type RevisionServiceClient interface {
+	// Permissions required: revisions.list
 	ListRevisions(context.Context, *connect.Request[v1.ListRevisionsRequest]) (*connect.Response[v1.ListRevisionsResponse], error)
+	// Permissions required: revisions.get
 	GetRevision(context.Context, *connect.Request[v1.GetRevisionRequest]) (*connect.Response[v1.Revision], error)
+	// Permissions required: revisions.create
 	CreateRevision(context.Context, *connect.Request[v1.CreateRevisionRequest]) (*connect.Response[v1.Revision], error)
+	// Permissions required: revisions.create
 	BatchCreateRevisions(context.Context, *connect.Request[v1.BatchCreateRevisionsRequest]) (*connect.Response[v1.BatchCreateRevisionsResponse], error)
+	// Permissions required: revisions.delete
 	DeleteRevision(context.Context, *connect.Request[v1.DeleteRevisionRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,10 +145,15 @@ func (c *revisionServiceClient) DeleteRevision(ctx context.Context, req *connect
 
 // RevisionServiceHandler is an implementation of the bytebase.v1.RevisionService service.
 type RevisionServiceHandler interface {
+	// Permissions required: revisions.list
 	ListRevisions(context.Context, *connect.Request[v1.ListRevisionsRequest]) (*connect.Response[v1.ListRevisionsResponse], error)
+	// Permissions required: revisions.get
 	GetRevision(context.Context, *connect.Request[v1.GetRevisionRequest]) (*connect.Response[v1.Revision], error)
+	// Permissions required: revisions.create
 	CreateRevision(context.Context, *connect.Request[v1.CreateRevisionRequest]) (*connect.Response[v1.Revision], error)
+	// Permissions required: revisions.create
 	BatchCreateRevisions(context.Context, *connect.Request[v1.BatchCreateRevisionsRequest]) (*connect.Response[v1.BatchCreateRevisionsResponse], error)
+	// Permissions required: revisions.delete
 	DeleteRevision(context.Context, *connect.Request[v1.DeleteRevisionRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/risk_service.connect.go
+++ b/proto/generated-go/v1/v1connect/risk_service.connect.go
@@ -48,10 +48,15 @@ const (
 
 // RiskServiceClient is a client for the bytebase.v1.RiskService service.
 type RiskServiceClient interface {
+	// Permissions required: risks.list
 	ListRisks(context.Context, *connect.Request[v1.ListRisksRequest]) (*connect.Response[v1.ListRisksResponse], error)
+	// Permissions required: risks.create
 	CreateRisk(context.Context, *connect.Request[v1.CreateRiskRequest]) (*connect.Response[v1.Risk], error)
+	// Permissions required: risks.list
 	GetRisk(context.Context, *connect.Request[v1.GetRiskRequest]) (*connect.Response[v1.Risk], error)
+	// Permissions required: risks.update
 	UpdateRisk(context.Context, *connect.Request[v1.UpdateRiskRequest]) (*connect.Response[v1.Risk], error)
+	// Permissions required: risks.delete
 	DeleteRisk(context.Context, *connect.Request[v1.DeleteRiskRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -135,10 +140,15 @@ func (c *riskServiceClient) DeleteRisk(ctx context.Context, req *connect.Request
 
 // RiskServiceHandler is an implementation of the bytebase.v1.RiskService service.
 type RiskServiceHandler interface {
+	// Permissions required: risks.list
 	ListRisks(context.Context, *connect.Request[v1.ListRisksRequest]) (*connect.Response[v1.ListRisksResponse], error)
+	// Permissions required: risks.create
 	CreateRisk(context.Context, *connect.Request[v1.CreateRiskRequest]) (*connect.Response[v1.Risk], error)
+	// Permissions required: risks.list
 	GetRisk(context.Context, *connect.Request[v1.GetRiskRequest]) (*connect.Response[v1.Risk], error)
+	// Permissions required: risks.update
 	UpdateRisk(context.Context, *connect.Request[v1.UpdateRiskRequest]) (*connect.Response[v1.Risk], error)
+	// Permissions required: risks.delete
 	DeleteRisk(context.Context, *connect.Request[v1.DeleteRiskRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/risk_service.connect.go
+++ b/proto/generated-go/v1/v1connect/risk_service.connect.go
@@ -48,15 +48,15 @@ const (
 
 // RiskServiceClient is a client for the bytebase.v1.RiskService service.
 type RiskServiceClient interface {
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	ListRisks(context.Context, *connect.Request[v1.ListRisksRequest]) (*connect.Response[v1.ListRisksResponse], error)
-	// Permissions required: risks.create
+	// Permissions required: bb.risks.create
 	CreateRisk(context.Context, *connect.Request[v1.CreateRiskRequest]) (*connect.Response[v1.Risk], error)
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	GetRisk(context.Context, *connect.Request[v1.GetRiskRequest]) (*connect.Response[v1.Risk], error)
-	// Permissions required: risks.update
+	// Permissions required: bb.risks.update
 	UpdateRisk(context.Context, *connect.Request[v1.UpdateRiskRequest]) (*connect.Response[v1.Risk], error)
-	// Permissions required: risks.delete
+	// Permissions required: bb.risks.delete
 	DeleteRisk(context.Context, *connect.Request[v1.DeleteRiskRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,15 +140,15 @@ func (c *riskServiceClient) DeleteRisk(ctx context.Context, req *connect.Request
 
 // RiskServiceHandler is an implementation of the bytebase.v1.RiskService service.
 type RiskServiceHandler interface {
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	ListRisks(context.Context, *connect.Request[v1.ListRisksRequest]) (*connect.Response[v1.ListRisksResponse], error)
-	// Permissions required: risks.create
+	// Permissions required: bb.risks.create
 	CreateRisk(context.Context, *connect.Request[v1.CreateRiskRequest]) (*connect.Response[v1.Risk], error)
-	// Permissions required: risks.list
+	// Permissions required: bb.risks.list
 	GetRisk(context.Context, *connect.Request[v1.GetRiskRequest]) (*connect.Response[v1.Risk], error)
-	// Permissions required: risks.update
+	// Permissions required: bb.risks.update
 	UpdateRisk(context.Context, *connect.Request[v1.UpdateRiskRequest]) (*connect.Response[v1.Risk], error)
-	// Permissions required: risks.delete
+	// Permissions required: bb.risks.delete
 	DeleteRisk(context.Context, *connect.Request[v1.DeleteRiskRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/role_service.connect.go
+++ b/proto/generated-go/v1/v1connect/role_service.connect.go
@@ -48,10 +48,15 @@ const (
 
 // RoleServiceClient is a client for the bytebase.v1.RoleService service.
 type RoleServiceClient interface {
+	// Permissions required: roles.list
 	ListRoles(context.Context, *connect.Request[v1.ListRolesRequest]) (*connect.Response[v1.ListRolesResponse], error)
+	// Permissions required: roles.get
 	GetRole(context.Context, *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.Role], error)
+	// Permissions required: roles.create
 	CreateRole(context.Context, *connect.Request[v1.CreateRoleRequest]) (*connect.Response[v1.Role], error)
+	// Permissions required: roles.update
 	UpdateRole(context.Context, *connect.Request[v1.UpdateRoleRequest]) (*connect.Response[v1.Role], error)
+	// Permissions required: roles.delete
 	DeleteRole(context.Context, *connect.Request[v1.DeleteRoleRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -135,10 +140,15 @@ func (c *roleServiceClient) DeleteRole(ctx context.Context, req *connect.Request
 
 // RoleServiceHandler is an implementation of the bytebase.v1.RoleService service.
 type RoleServiceHandler interface {
+	// Permissions required: roles.list
 	ListRoles(context.Context, *connect.Request[v1.ListRolesRequest]) (*connect.Response[v1.ListRolesResponse], error)
+	// Permissions required: roles.get
 	GetRole(context.Context, *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.Role], error)
+	// Permissions required: roles.create
 	CreateRole(context.Context, *connect.Request[v1.CreateRoleRequest]) (*connect.Response[v1.Role], error)
+	// Permissions required: roles.update
 	UpdateRole(context.Context, *connect.Request[v1.UpdateRoleRequest]) (*connect.Response[v1.Role], error)
+	// Permissions required: roles.delete
 	DeleteRole(context.Context, *connect.Request[v1.DeleteRoleRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/role_service.connect.go
+++ b/proto/generated-go/v1/v1connect/role_service.connect.go
@@ -48,15 +48,15 @@ const (
 
 // RoleServiceClient is a client for the bytebase.v1.RoleService service.
 type RoleServiceClient interface {
-	// Permissions required: roles.list
+	// Permissions required: bb.roles.list
 	ListRoles(context.Context, *connect.Request[v1.ListRolesRequest]) (*connect.Response[v1.ListRolesResponse], error)
-	// Permissions required: roles.get
+	// Permissions required: bb.roles.get
 	GetRole(context.Context, *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.Role], error)
-	// Permissions required: roles.create
+	// Permissions required: bb.roles.create
 	CreateRole(context.Context, *connect.Request[v1.CreateRoleRequest]) (*connect.Response[v1.Role], error)
-	// Permissions required: roles.update
+	// Permissions required: bb.roles.update
 	UpdateRole(context.Context, *connect.Request[v1.UpdateRoleRequest]) (*connect.Response[v1.Role], error)
-	// Permissions required: roles.delete
+	// Permissions required: bb.roles.delete
 	DeleteRole(context.Context, *connect.Request[v1.DeleteRoleRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -140,15 +140,15 @@ func (c *roleServiceClient) DeleteRole(ctx context.Context, req *connect.Request
 
 // RoleServiceHandler is an implementation of the bytebase.v1.RoleService service.
 type RoleServiceHandler interface {
-	// Permissions required: roles.list
+	// Permissions required: bb.roles.list
 	ListRoles(context.Context, *connect.Request[v1.ListRolesRequest]) (*connect.Response[v1.ListRolesResponse], error)
-	// Permissions required: roles.get
+	// Permissions required: bb.roles.get
 	GetRole(context.Context, *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.Role], error)
-	// Permissions required: roles.create
+	// Permissions required: bb.roles.create
 	CreateRole(context.Context, *connect.Request[v1.CreateRoleRequest]) (*connect.Response[v1.Role], error)
-	// Permissions required: roles.update
+	// Permissions required: bb.roles.update
 	UpdateRole(context.Context, *connect.Request[v1.UpdateRoleRequest]) (*connect.Response[v1.Role], error)
-	// Permissions required: roles.delete
+	// Permissions required: bb.roles.delete
 	DeleteRole(context.Context, *connect.Request[v1.DeleteRoleRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/rollout_service.connect.go
+++ b/proto/generated-go/v1/v1connect/rollout_service.connect.go
@@ -73,38 +73,29 @@ const (
 
 // RolloutServiceClient is a client for the bytebase.v1.RolloutService service.
 type RolloutServiceClient interface {
-	// Permissions required: rollouts.get
+	// Permissions required: bb.rollouts.get
 	GetRollout(context.Context, *connect.Request[v1.GetRolloutRequest]) (*connect.Response[v1.Rollout], error)
-	// Permissions required: rollouts.list
+	// Permissions required: bb.rollouts.list
 	ListRollouts(context.Context, *connect.Request[v1.ListRolloutsRequest]) (*connect.Response[v1.ListRolloutsResponse], error)
-	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-	// Permissions required: rollouts.create
+	// Permissions required: bb.rollouts.create
 	CreateRollout(context.Context, *connect.Request[v1.CreateRolloutRequest]) (*connect.Response[v1.Rollout], error)
-	// Permissions required: rollouts.preview
+	// Permissions required: bb.rollouts.preview
 	PreviewRollout(context.Context, *connect.Request[v1.PreviewRolloutRequest]) (*connect.Response[v1.Rollout], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	ListTaskRuns(context.Context, *connect.Request[v1.ListTaskRunsRequest]) (*connect.Response[v1.ListTaskRunsResponse], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRun(context.Context, *connect.Request[v1.GetTaskRunRequest]) (*connect.Response[v1.TaskRun], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunLog(context.Context, *connect.Request[v1.GetTaskRunLogRequest]) (*connect.Response[v1.TaskRunLog], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunSession(context.Context, *connect.Request[v1.GetTaskRunSessionRequest]) (*connect.Response[v1.TaskRunSession], error)
-	// BatchRunTasks creates task runs for the specified tasks.
-	// DataExport issue only allows the creator to run the task.
-	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-	// Follow role-based rollout policy for the environment.
 	// Permissions required: None
 	BatchRunTasks(context.Context, *connect.Request[v1.BatchRunTasksRequest]) (*connect.Response[v1.BatchRunTasksResponse], error)
-	// BatchSkipTasks skips the specified tasks.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchSkipTasks(context.Context, *connect.Request[v1.BatchSkipTasksRequest]) (*connect.Response[v1.BatchSkipTasksResponse], error)
-	// BatchCancelTaskRuns cancels the specified task runs in batch.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchCancelTaskRuns(context.Context, *connect.Request[v1.BatchCancelTaskRunsRequest]) (*connect.Response[v1.BatchCancelTaskRunsResponse], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	PreviewTaskRunRollback(context.Context, *connect.Request[v1.PreviewTaskRunRollbackRequest]) (*connect.Response[v1.PreviewTaskRunRollbackResponse], error)
 }
 
@@ -272,38 +263,29 @@ func (c *rolloutServiceClient) PreviewTaskRunRollback(ctx context.Context, req *
 
 // RolloutServiceHandler is an implementation of the bytebase.v1.RolloutService service.
 type RolloutServiceHandler interface {
-	// Permissions required: rollouts.get
+	// Permissions required: bb.rollouts.get
 	GetRollout(context.Context, *connect.Request[v1.GetRolloutRequest]) (*connect.Response[v1.Rollout], error)
-	// Permissions required: rollouts.list
+	// Permissions required: bb.rollouts.list
 	ListRollouts(context.Context, *connect.Request[v1.ListRolloutsRequest]) (*connect.Response[v1.ListRolloutsResponse], error)
-	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-	// Permissions required: rollouts.create
+	// Permissions required: bb.rollouts.create
 	CreateRollout(context.Context, *connect.Request[v1.CreateRolloutRequest]) (*connect.Response[v1.Rollout], error)
-	// Permissions required: rollouts.preview
+	// Permissions required: bb.rollouts.preview
 	PreviewRollout(context.Context, *connect.Request[v1.PreviewRolloutRequest]) (*connect.Response[v1.Rollout], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	ListTaskRuns(context.Context, *connect.Request[v1.ListTaskRunsRequest]) (*connect.Response[v1.ListTaskRunsResponse], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRun(context.Context, *connect.Request[v1.GetTaskRunRequest]) (*connect.Response[v1.TaskRun], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunLog(context.Context, *connect.Request[v1.GetTaskRunLogRequest]) (*connect.Response[v1.TaskRunLog], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	GetTaskRunSession(context.Context, *connect.Request[v1.GetTaskRunSessionRequest]) (*connect.Response[v1.TaskRunSession], error)
-	// BatchRunTasks creates task runs for the specified tasks.
-	// DataExport issue only allows the creator to run the task.
-	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-	// Follow role-based rollout policy for the environment.
 	// Permissions required: None
 	BatchRunTasks(context.Context, *connect.Request[v1.BatchRunTasksRequest]) (*connect.Response[v1.BatchRunTasksResponse], error)
-	// BatchSkipTasks skips the specified tasks.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchSkipTasks(context.Context, *connect.Request[v1.BatchSkipTasksRequest]) (*connect.Response[v1.BatchSkipTasksResponse], error)
-	// BatchCancelTaskRuns cancels the specified task runs in batch.
-	// The access is the same as BatchRunTasks().
 	// Permissions required: None
 	BatchCancelTaskRuns(context.Context, *connect.Request[v1.BatchCancelTaskRunsRequest]) (*connect.Response[v1.BatchCancelTaskRunsResponse], error)
-	// Permissions required: taskRuns.list
+	// Permissions required: bb.taskRuns.list
 	PreviewTaskRunRollback(context.Context, *connect.Request[v1.PreviewTaskRunRollbackRequest]) (*connect.Response[v1.PreviewTaskRunRollbackResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/rollout_service.connect.go
+++ b/proto/generated-go/v1/v1connect/rollout_service.connect.go
@@ -73,26 +73,38 @@ const (
 
 // RolloutServiceClient is a client for the bytebase.v1.RolloutService service.
 type RolloutServiceClient interface {
+	// Permissions required: rollouts.get
 	GetRollout(context.Context, *connect.Request[v1.GetRolloutRequest]) (*connect.Response[v1.Rollout], error)
+	// Permissions required: rollouts.list
 	ListRollouts(context.Context, *connect.Request[v1.ListRolloutsRequest]) (*connect.Response[v1.ListRolloutsResponse], error)
 	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+	// Permissions required: rollouts.create
 	CreateRollout(context.Context, *connect.Request[v1.CreateRolloutRequest]) (*connect.Response[v1.Rollout], error)
+	// Permissions required: rollouts.preview
 	PreviewRollout(context.Context, *connect.Request[v1.PreviewRolloutRequest]) (*connect.Response[v1.Rollout], error)
+	// Permissions required: taskRuns.list
 	ListTaskRuns(context.Context, *connect.Request[v1.ListTaskRunsRequest]) (*connect.Response[v1.ListTaskRunsResponse], error)
+	// Permissions required: taskRuns.list
 	GetTaskRun(context.Context, *connect.Request[v1.GetTaskRunRequest]) (*connect.Response[v1.TaskRun], error)
+	// Permissions required: taskRuns.list
 	GetTaskRunLog(context.Context, *connect.Request[v1.GetTaskRunLogRequest]) (*connect.Response[v1.TaskRunLog], error)
+	// Permissions required: taskRuns.list
 	GetTaskRunSession(context.Context, *connect.Request[v1.GetTaskRunSessionRequest]) (*connect.Response[v1.TaskRunSession], error)
 	// BatchRunTasks creates task runs for the specified tasks.
 	// DataExport issue only allows the creator to run the task.
 	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
 	// Follow role-based rollout policy for the environment.
+	// Permissions required: None
 	BatchRunTasks(context.Context, *connect.Request[v1.BatchRunTasksRequest]) (*connect.Response[v1.BatchRunTasksResponse], error)
 	// BatchSkipTasks skips the specified tasks.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchSkipTasks(context.Context, *connect.Request[v1.BatchSkipTasksRequest]) (*connect.Response[v1.BatchSkipTasksResponse], error)
 	// BatchCancelTaskRuns cancels the specified task runs in batch.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchCancelTaskRuns(context.Context, *connect.Request[v1.BatchCancelTaskRunsRequest]) (*connect.Response[v1.BatchCancelTaskRunsResponse], error)
+	// Permissions required: taskRuns.list
 	PreviewTaskRunRollback(context.Context, *connect.Request[v1.PreviewTaskRunRollbackRequest]) (*connect.Response[v1.PreviewTaskRunRollbackResponse], error)
 }
 
@@ -260,26 +272,38 @@ func (c *rolloutServiceClient) PreviewTaskRunRollback(ctx context.Context, req *
 
 // RolloutServiceHandler is an implementation of the bytebase.v1.RolloutService service.
 type RolloutServiceHandler interface {
+	// Permissions required: rollouts.get
 	GetRollout(context.Context, *connect.Request[v1.GetRolloutRequest]) (*connect.Response[v1.Rollout], error)
+	// Permissions required: rollouts.list
 	ListRollouts(context.Context, *connect.Request[v1.ListRolloutsRequest]) (*connect.Response[v1.ListRolloutsResponse], error)
 	// CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+	// Permissions required: rollouts.create
 	CreateRollout(context.Context, *connect.Request[v1.CreateRolloutRequest]) (*connect.Response[v1.Rollout], error)
+	// Permissions required: rollouts.preview
 	PreviewRollout(context.Context, *connect.Request[v1.PreviewRolloutRequest]) (*connect.Response[v1.Rollout], error)
+	// Permissions required: taskRuns.list
 	ListTaskRuns(context.Context, *connect.Request[v1.ListTaskRunsRequest]) (*connect.Response[v1.ListTaskRunsResponse], error)
+	// Permissions required: taskRuns.list
 	GetTaskRun(context.Context, *connect.Request[v1.GetTaskRunRequest]) (*connect.Response[v1.TaskRun], error)
+	// Permissions required: taskRuns.list
 	GetTaskRunLog(context.Context, *connect.Request[v1.GetTaskRunLogRequest]) (*connect.Response[v1.TaskRunLog], error)
+	// Permissions required: taskRuns.list
 	GetTaskRunSession(context.Context, *connect.Request[v1.GetTaskRunSessionRequest]) (*connect.Response[v1.TaskRunSession], error)
 	// BatchRunTasks creates task runs for the specified tasks.
 	// DataExport issue only allows the creator to run the task.
 	// Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
 	// Follow role-based rollout policy for the environment.
+	// Permissions required: None
 	BatchRunTasks(context.Context, *connect.Request[v1.BatchRunTasksRequest]) (*connect.Response[v1.BatchRunTasksResponse], error)
 	// BatchSkipTasks skips the specified tasks.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchSkipTasks(context.Context, *connect.Request[v1.BatchSkipTasksRequest]) (*connect.Response[v1.BatchSkipTasksResponse], error)
 	// BatchCancelTaskRuns cancels the specified task runs in batch.
 	// The access is the same as BatchRunTasks().
+	// Permissions required: None
 	BatchCancelTaskRuns(context.Context, *connect.Request[v1.BatchCancelTaskRunsRequest]) (*connect.Response[v1.BatchCancelTaskRunsResponse], error)
+	// Permissions required: taskRuns.list
 	PreviewTaskRunRollback(context.Context, *connect.Request[v1.PreviewTaskRunRollbackRequest]) (*connect.Response[v1.PreviewTaskRunRollbackResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/setting_service.connect.go
+++ b/proto/generated-go/v1/v1connect/setting_service.connect.go
@@ -46,11 +46,11 @@ const (
 
 // SettingServiceClient is a client for the bytebase.v1.SettingService service.
 type SettingServiceClient interface {
-	// Permissions required: settings.list
+	// Permissions required: bb.settings.list
 	ListSettings(context.Context, *connect.Request[v1.ListSettingsRequest]) (*connect.Response[v1.ListSettingsResponse], error)
-	// Permissions required: settings.get
+	// Permissions required: bb.settings.get
 	GetSetting(context.Context, *connect.Request[v1.GetSettingRequest]) (*connect.Response[v1.Setting], error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSetting(context.Context, *connect.Request[v1.UpdateSettingRequest]) (*connect.Response[v1.Setting], error)
 }
 
@@ -110,11 +110,11 @@ func (c *settingServiceClient) UpdateSetting(ctx context.Context, req *connect.R
 
 // SettingServiceHandler is an implementation of the bytebase.v1.SettingService service.
 type SettingServiceHandler interface {
-	// Permissions required: settings.list
+	// Permissions required: bb.settings.list
 	ListSettings(context.Context, *connect.Request[v1.ListSettingsRequest]) (*connect.Response[v1.ListSettingsResponse], error)
-	// Permissions required: settings.get
+	// Permissions required: bb.settings.get
 	GetSetting(context.Context, *connect.Request[v1.GetSettingRequest]) (*connect.Response[v1.Setting], error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSetting(context.Context, *connect.Request[v1.UpdateSettingRequest]) (*connect.Response[v1.Setting], error)
 }
 

--- a/proto/generated-go/v1/v1connect/setting_service.connect.go
+++ b/proto/generated-go/v1/v1connect/setting_service.connect.go
@@ -46,8 +46,11 @@ const (
 
 // SettingServiceClient is a client for the bytebase.v1.SettingService service.
 type SettingServiceClient interface {
+	// Permissions required: settings.list
 	ListSettings(context.Context, *connect.Request[v1.ListSettingsRequest]) (*connect.Response[v1.ListSettingsResponse], error)
+	// Permissions required: settings.get
 	GetSetting(context.Context, *connect.Request[v1.GetSettingRequest]) (*connect.Response[v1.Setting], error)
+	// Permissions required: settings.set
 	UpdateSetting(context.Context, *connect.Request[v1.UpdateSettingRequest]) (*connect.Response[v1.Setting], error)
 }
 
@@ -107,8 +110,11 @@ func (c *settingServiceClient) UpdateSetting(ctx context.Context, req *connect.R
 
 // SettingServiceHandler is an implementation of the bytebase.v1.SettingService service.
 type SettingServiceHandler interface {
+	// Permissions required: settings.list
 	ListSettings(context.Context, *connect.Request[v1.ListSettingsRequest]) (*connect.Response[v1.ListSettingsResponse], error)
+	// Permissions required: settings.get
 	GetSetting(context.Context, *connect.Request[v1.GetSettingRequest]) (*connect.Response[v1.Setting], error)
+	// Permissions required: settings.set
 	UpdateSetting(context.Context, *connect.Request[v1.UpdateSettingRequest]) (*connect.Response[v1.Setting], error)
 }
 

--- a/proto/generated-go/v1/v1connect/sheet_service.connect.go
+++ b/proto/generated-go/v1/v1connect/sheet_service.connect.go
@@ -48,9 +48,13 @@ const (
 
 // SheetServiceClient is a client for the bytebase.v1.SheetService service.
 type SheetServiceClient interface {
+	// Permissions required: sheets.create
 	CreateSheet(context.Context, *connect.Request[v1.CreateSheetRequest]) (*connect.Response[v1.Sheet], error)
+	// Permissions required: sheets.create
 	BatchCreateSheets(context.Context, *connect.Request[v1.BatchCreateSheetsRequest]) (*connect.Response[v1.BatchCreateSheetsResponse], error)
+	// Permissions required: sheets.get
 	GetSheet(context.Context, *connect.Request[v1.GetSheetRequest]) (*connect.Response[v1.Sheet], error)
+	// Permissions required: sheets.update
 	UpdateSheet(context.Context, *connect.Request[v1.UpdateSheetRequest]) (*connect.Response[v1.Sheet], error)
 }
 
@@ -122,9 +126,13 @@ func (c *sheetServiceClient) UpdateSheet(ctx context.Context, req *connect.Reque
 
 // SheetServiceHandler is an implementation of the bytebase.v1.SheetService service.
 type SheetServiceHandler interface {
+	// Permissions required: sheets.create
 	CreateSheet(context.Context, *connect.Request[v1.CreateSheetRequest]) (*connect.Response[v1.Sheet], error)
+	// Permissions required: sheets.create
 	BatchCreateSheets(context.Context, *connect.Request[v1.BatchCreateSheetsRequest]) (*connect.Response[v1.BatchCreateSheetsResponse], error)
+	// Permissions required: sheets.get
 	GetSheet(context.Context, *connect.Request[v1.GetSheetRequest]) (*connect.Response[v1.Sheet], error)
+	// Permissions required: sheets.update
 	UpdateSheet(context.Context, *connect.Request[v1.UpdateSheetRequest]) (*connect.Response[v1.Sheet], error)
 }
 

--- a/proto/generated-go/v1/v1connect/sheet_service.connect.go
+++ b/proto/generated-go/v1/v1connect/sheet_service.connect.go
@@ -48,13 +48,13 @@ const (
 
 // SheetServiceClient is a client for the bytebase.v1.SheetService service.
 type SheetServiceClient interface {
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	CreateSheet(context.Context, *connect.Request[v1.CreateSheetRequest]) (*connect.Response[v1.Sheet], error)
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	BatchCreateSheets(context.Context, *connect.Request[v1.BatchCreateSheetsRequest]) (*connect.Response[v1.BatchCreateSheetsResponse], error)
-	// Permissions required: sheets.get
+	// Permissions required: bb.sheets.get
 	GetSheet(context.Context, *connect.Request[v1.GetSheetRequest]) (*connect.Response[v1.Sheet], error)
-	// Permissions required: sheets.update
+	// Permissions required: bb.sheets.update
 	UpdateSheet(context.Context, *connect.Request[v1.UpdateSheetRequest]) (*connect.Response[v1.Sheet], error)
 }
 
@@ -126,13 +126,13 @@ func (c *sheetServiceClient) UpdateSheet(ctx context.Context, req *connect.Reque
 
 // SheetServiceHandler is an implementation of the bytebase.v1.SheetService service.
 type SheetServiceHandler interface {
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	CreateSheet(context.Context, *connect.Request[v1.CreateSheetRequest]) (*connect.Response[v1.Sheet], error)
-	// Permissions required: sheets.create
+	// Permissions required: bb.sheets.create
 	BatchCreateSheets(context.Context, *connect.Request[v1.BatchCreateSheetsRequest]) (*connect.Response[v1.BatchCreateSheetsResponse], error)
-	// Permissions required: sheets.get
+	// Permissions required: bb.sheets.get
 	GetSheet(context.Context, *connect.Request[v1.GetSheetRequest]) (*connect.Response[v1.Sheet], error)
-	// Permissions required: sheets.update
+	// Permissions required: bb.sheets.update
 	UpdateSheet(context.Context, *connect.Request[v1.UpdateSheetRequest]) (*connect.Response[v1.Sheet], error)
 }
 

--- a/proto/generated-go/v1/v1connect/sql_service.connect.go
+++ b/proto/generated-go/v1/v1connect/sql_service.connect.go
@@ -54,16 +54,16 @@ const (
 
 // SQLServiceClient is a client for the bytebase.v1.SQLService service.
 type SQLServiceClient interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Query(context.Context, *connect.Request[v1.QueryRequest]) (*connect.Response[v1.QueryResponse], error)
-	// Permissions required: sql.admin
+	// Permissions required: bb.sql.admin
 	AdminExecute(context.Context) *connect.BidiStreamForClient[v1.AdminExecuteRequest, v1.AdminExecuteResponse]
 	// SearchQueryHistories searches query histories for the caller.
 	// Permissions required: None
 	SearchQueryHistories(context.Context, *connect.Request[v1.SearchQueryHistoriesRequest]) (*connect.Response[v1.SearchQueryHistoriesResponse], error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Export(context.Context, *connect.Request[v1.ExportRequest]) (*connect.Response[v1.ExportResponse], error)
-	// Permissions required: databases.check
+	// Permissions required: bb.databases.check
 	Check(context.Context, *connect.Request[v1.CheckRequest]) (*connect.Response[v1.CheckResponse], error)
 	// Permissions required: None
 	Pretty(context.Context, *connect.Request[v1.PrettyRequest]) (*connect.Response[v1.PrettyResponse], error)
@@ -189,16 +189,16 @@ func (c *sQLServiceClient) AICompletion(ctx context.Context, req *connect.Reques
 
 // SQLServiceHandler is an implementation of the bytebase.v1.SQLService service.
 type SQLServiceHandler interface {
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Query(context.Context, *connect.Request[v1.QueryRequest]) (*connect.Response[v1.QueryResponse], error)
-	// Permissions required: sql.admin
+	// Permissions required: bb.sql.admin
 	AdminExecute(context.Context, *connect.BidiStream[v1.AdminExecuteRequest, v1.AdminExecuteResponse]) error
 	// SearchQueryHistories searches query histories for the caller.
 	// Permissions required: None
 	SearchQueryHistories(context.Context, *connect.Request[v1.SearchQueryHistoriesRequest]) (*connect.Response[v1.SearchQueryHistoriesResponse], error)
-	// Permissions required: databases.get
+	// Permissions required: bb.databases.get
 	Export(context.Context, *connect.Request[v1.ExportRequest]) (*connect.Response[v1.ExportResponse], error)
-	// Permissions required: databases.check
+	// Permissions required: bb.databases.check
 	Check(context.Context, *connect.Request[v1.CheckRequest]) (*connect.Response[v1.CheckResponse], error)
 	// Permissions required: None
 	Pretty(context.Context, *connect.Request[v1.PrettyRequest]) (*connect.Response[v1.PrettyResponse], error)

--- a/proto/generated-go/v1/v1connect/sql_service.connect.go
+++ b/proto/generated-go/v1/v1connect/sql_service.connect.go
@@ -54,14 +54,22 @@ const (
 
 // SQLServiceClient is a client for the bytebase.v1.SQLService service.
 type SQLServiceClient interface {
+	// Permissions required: databases.get
 	Query(context.Context, *connect.Request[v1.QueryRequest]) (*connect.Response[v1.QueryResponse], error)
+	// Permissions required: sql.admin
 	AdminExecute(context.Context) *connect.BidiStreamForClient[v1.AdminExecuteRequest, v1.AdminExecuteResponse]
 	// SearchQueryHistories searches query histories for the caller.
+	// Permissions required: None
 	SearchQueryHistories(context.Context, *connect.Request[v1.SearchQueryHistoriesRequest]) (*connect.Response[v1.SearchQueryHistoriesResponse], error)
+	// Permissions required: databases.get
 	Export(context.Context, *connect.Request[v1.ExportRequest]) (*connect.Response[v1.ExportResponse], error)
+	// Permissions required: databases.check
 	Check(context.Context, *connect.Request[v1.CheckRequest]) (*connect.Response[v1.CheckResponse], error)
+	// Permissions required: None
 	Pretty(context.Context, *connect.Request[v1.PrettyRequest]) (*connect.Response[v1.PrettyResponse], error)
+	// Permissions required: None
 	DiffMetadata(context.Context, *connect.Request[v1.DiffMetadataRequest]) (*connect.Response[v1.DiffMetadataResponse], error)
+	// Permissions required: None
 	AICompletion(context.Context, *connect.Request[v1.AICompletionRequest]) (*connect.Response[v1.AICompletionResponse], error)
 }
 
@@ -181,14 +189,22 @@ func (c *sQLServiceClient) AICompletion(ctx context.Context, req *connect.Reques
 
 // SQLServiceHandler is an implementation of the bytebase.v1.SQLService service.
 type SQLServiceHandler interface {
+	// Permissions required: databases.get
 	Query(context.Context, *connect.Request[v1.QueryRequest]) (*connect.Response[v1.QueryResponse], error)
+	// Permissions required: sql.admin
 	AdminExecute(context.Context, *connect.BidiStream[v1.AdminExecuteRequest, v1.AdminExecuteResponse]) error
 	// SearchQueryHistories searches query histories for the caller.
+	// Permissions required: None
 	SearchQueryHistories(context.Context, *connect.Request[v1.SearchQueryHistoriesRequest]) (*connect.Response[v1.SearchQueryHistoriesResponse], error)
+	// Permissions required: databases.get
 	Export(context.Context, *connect.Request[v1.ExportRequest]) (*connect.Response[v1.ExportResponse], error)
+	// Permissions required: databases.check
 	Check(context.Context, *connect.Request[v1.CheckRequest]) (*connect.Response[v1.CheckResponse], error)
+	// Permissions required: None
 	Pretty(context.Context, *connect.Request[v1.PrettyRequest]) (*connect.Response[v1.PrettyResponse], error)
+	// Permissions required: None
 	DiffMetadata(context.Context, *connect.Request[v1.DiffMetadataRequest]) (*connect.Response[v1.DiffMetadataResponse], error)
+	// Permissions required: None
 	AICompletion(context.Context, *connect.Request[v1.AICompletionRequest]) (*connect.Response[v1.AICompletionResponse], error)
 }
 

--- a/proto/generated-go/v1/v1connect/subscription_service.connect.go
+++ b/proto/generated-go/v1/v1connect/subscription_service.connect.go
@@ -46,7 +46,9 @@ type SubscriptionServiceClient interface {
 	// GetSubscription returns the current subscription.
 	// If there is no license, we will return a free plan subscription without expiration time.
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+	// Permissions required: None
 	GetSubscription(context.Context, *connect.Request[v1.GetSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
+	// Permissions required: settings.set
 	UpdateSubscription(context.Context, *connect.Request[v1.UpdateSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
 }
 
@@ -97,7 +99,9 @@ type SubscriptionServiceHandler interface {
 	// GetSubscription returns the current subscription.
 	// If there is no license, we will return a free plan subscription without expiration time.
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+	// Permissions required: None
 	GetSubscription(context.Context, *connect.Request[v1.GetSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
+	// Permissions required: settings.set
 	UpdateSubscription(context.Context, *connect.Request[v1.UpdateSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
 }
 

--- a/proto/generated-go/v1/v1connect/subscription_service.connect.go
+++ b/proto/generated-go/v1/v1connect/subscription_service.connect.go
@@ -48,7 +48,7 @@ type SubscriptionServiceClient interface {
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
 	// Permissions required: None
 	GetSubscription(context.Context, *connect.Request[v1.GetSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSubscription(context.Context, *connect.Request[v1.UpdateSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
 }
 
@@ -101,7 +101,7 @@ type SubscriptionServiceHandler interface {
 	// If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
 	// Permissions required: None
 	GetSubscription(context.Context, *connect.Request[v1.GetSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
-	// Permissions required: settings.set
+	// Permissions required: bb.settings.set
 	UpdateSubscription(context.Context, *connect.Request[v1.UpdateSubscriptionRequest]) (*connect.Response[v1.Subscription], error)
 }
 

--- a/proto/generated-go/v1/v1connect/user_service.connect.go
+++ b/proto/generated-go/v1/v1connect/user_service.connect.go
@@ -59,33 +59,33 @@ const (
 type UserServiceClient interface {
 	// Get the user.
 	// Any authenticated user can get the user.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	GetUser(context.Context, *connect.Request[v1.GetUserRequest]) (*connect.Response[v1.User], error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
 	// Get the current authenticated user.
 	// Permissions required: None
 	GetCurrentUser(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[v1.User], error)
 	// List all users.
 	// Any authenticated user can list users.
-	// Permissions required: users.list
+	// Permissions required: bb.users.list
 	ListUsers(context.Context, *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
-	// Permissions required: users.create
+	// Permissions required: bb.users.create
 	CreateUser(context.Context, *connect.Request[v1.CreateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-	// Permissions required: users.update
+	// Permissions required: bb.users.update
 	UpdateUser(context.Context, *connect.Request[v1.UpdateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
-	// Permissions required: users.delete
+	// Permissions required: bb.users.delete
 	DeleteUser(context.Context, *connect.Request[v1.DeleteUserRequest]) (*connect.Response[emptypb.Empty], error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
-	// Permissions required: users.undelete
+	// Permissions required: bb.users.undelete
 	UndeleteUser(context.Context, *connect.Request[v1.UndeleteUserRequest]) (*connect.Response[v1.User], error)
 }
 
@@ -207,33 +207,33 @@ func (c *userServiceClient) UndeleteUser(ctx context.Context, req *connect.Reque
 type UserServiceHandler interface {
 	// Get the user.
 	// Any authenticated user can get the user.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	GetUser(context.Context, *connect.Request[v1.GetUserRequest]) (*connect.Response[v1.User], error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
-	// Permissions required: users.get
+	// Permissions required: bb.users.get
 	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
 	// Get the current authenticated user.
 	// Permissions required: None
 	GetCurrentUser(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[v1.User], error)
 	// List all users.
 	// Any authenticated user can list users.
-	// Permissions required: users.list
+	// Permissions required: bb.users.list
 	ListUsers(context.Context, *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
-	// Permissions required: users.create
+	// Permissions required: bb.users.create
 	CreateUser(context.Context, *connect.Request[v1.CreateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-	// Permissions required: users.update
+	// Permissions required: bb.users.update
 	UpdateUser(context.Context, *connect.Request[v1.UpdateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
-	// Permissions required: users.delete
+	// Permissions required: bb.users.delete
 	DeleteUser(context.Context, *connect.Request[v1.DeleteUserRequest]) (*connect.Response[emptypb.Empty], error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
-	// Permissions required: users.undelete
+	// Permissions required: bb.users.undelete
 	UndeleteUser(context.Context, *connect.Request[v1.UndeleteUserRequest]) (*connect.Response[v1.User], error)
 }
 

--- a/proto/generated-go/v1/v1connect/user_service.connect.go
+++ b/proto/generated-go/v1/v1connect/user_service.connect.go
@@ -59,25 +59,33 @@ const (
 type UserServiceClient interface {
 	// Get the user.
 	// Any authenticated user can get the user.
+	// Permissions required: users.get
 	GetUser(context.Context, *connect.Request[v1.GetUserRequest]) (*connect.Response[v1.User], error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
+	// Permissions required: users.get
 	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
 	// Get the current authenticated user.
+	// Permissions required: None
 	GetCurrentUser(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[v1.User], error)
 	// List all users.
 	// Any authenticated user can list users.
+	// Permissions required: users.list
 	ListUsers(context.Context, *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
+	// Permissions required: users.create
 	CreateUser(context.Context, *connect.Request[v1.CreateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+	// Permissions required: users.update
 	UpdateUser(context.Context, *connect.Request[v1.UpdateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
+	// Permissions required: users.delete
 	DeleteUser(context.Context, *connect.Request[v1.DeleteUserRequest]) (*connect.Response[emptypb.Empty], error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
+	// Permissions required: users.undelete
 	UndeleteUser(context.Context, *connect.Request[v1.UndeleteUserRequest]) (*connect.Response[v1.User], error)
 }
 
@@ -199,25 +207,33 @@ func (c *userServiceClient) UndeleteUser(ctx context.Context, req *connect.Reque
 type UserServiceHandler interface {
 	// Get the user.
 	// Any authenticated user can get the user.
+	// Permissions required: users.get
 	GetUser(context.Context, *connect.Request[v1.GetUserRequest]) (*connect.Response[v1.User], error)
 	// Get the users in batch.
 	// Any authenticated user can batch get users.
+	// Permissions required: users.get
 	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
 	// Get the current authenticated user.
+	// Permissions required: None
 	GetCurrentUser(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[v1.User], error)
 	// List all users.
 	// Any authenticated user can list users.
+	// Permissions required: users.list
 	ListUsers(context.Context, *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error)
 	// Create a user.
 	// When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
 	// Otherwise, any unauthenticated user can create a user.
+	// Permissions required: users.create
 	CreateUser(context.Context, *connect.Request[v1.CreateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+	// Permissions required: users.update
 	UpdateUser(context.Context, *connect.Request[v1.UpdateUserRequest]) (*connect.Response[v1.User], error)
 	// Only the user with bb.users.delete permission on the workspace can delete the user.
 	// The last remaining workspace admin cannot be deleted.
+	// Permissions required: users.delete
 	DeleteUser(context.Context, *connect.Request[v1.DeleteUserRequest]) (*connect.Response[emptypb.Empty], error)
 	// Only the user with bb.users.undelete permission on the workspace can undelete the user.
+	// Permissions required: users.undelete
 	UndeleteUser(context.Context, *connect.Request[v1.UndeleteUserRequest]) (*connect.Response[v1.User], error)
 }
 

--- a/proto/generated-go/v1/v1connect/worksheet_service.connect.go
+++ b/proto/generated-go/v1/v1connect/worksheet_service.connect.go
@@ -57,28 +57,34 @@ const (
 // WorksheetServiceClient is a client for the bytebase.v1.WorksheetService service.
 type WorksheetServiceClient interface {
 	// Create a personal worksheet used in SQL Editor.
+	// Permissions required: None
 	CreateWorksheet(context.Context, *connect.Request[v1.CreateWorksheetRequest]) (*connect.Response[v1.Worksheet], error)
 	// Get a worksheet by name.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.get permission on the workspace;
 	// - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	GetWorksheet(context.Context, *connect.Request[v1.GetWorksheetRequest]) (*connect.Response[v1.Worksheet], error)
 	// Search for worksheets.
 	// This is used for finding my worksheets or worksheets shared by other people.
 	// The sheet accessibility is the same as GetWorksheet().
+	// Permissions required: None
 	SearchWorksheets(context.Context, *connect.Request[v1.SearchWorksheetsRequest]) (*connect.Response[v1.SearchWorksheetsResponse], error)
 	// Update a worksheet.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.manage permission on the workspace;
 	// - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	UpdateWorksheet(context.Context, *connect.Request[v1.UpdateWorksheetRequest]) (*connect.Response[v1.Worksheet], error)
 	// Update the organizer of a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	UpdateWorksheetOrganizer(context.Context, *connect.Request[v1.UpdateWorksheetOrganizerRequest]) (*connect.Response[v1.WorksheetOrganizer], error)
 	// Delete a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	DeleteWorksheet(context.Context, *connect.Request[v1.DeleteWorksheetRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -175,28 +181,34 @@ func (c *worksheetServiceClient) DeleteWorksheet(ctx context.Context, req *conne
 // WorksheetServiceHandler is an implementation of the bytebase.v1.WorksheetService service.
 type WorksheetServiceHandler interface {
 	// Create a personal worksheet used in SQL Editor.
+	// Permissions required: None
 	CreateWorksheet(context.Context, *connect.Request[v1.CreateWorksheetRequest]) (*connect.Response[v1.Worksheet], error)
 	// Get a worksheet by name.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.get permission on the workspace;
 	// - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	GetWorksheet(context.Context, *connect.Request[v1.GetWorksheetRequest]) (*connect.Response[v1.Worksheet], error)
 	// Search for worksheets.
 	// This is used for finding my worksheets or worksheets shared by other people.
 	// The sheet accessibility is the same as GetWorksheet().
+	// Permissions required: None
 	SearchWorksheets(context.Context, *connect.Request[v1.SearchWorksheetsRequest]) (*connect.Response[v1.SearchWorksheetsResponse], error)
 	// Update a worksheet.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.manage permission on the workspace;
 	// - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	UpdateWorksheet(context.Context, *connect.Request[v1.UpdateWorksheetRequest]) (*connect.Response[v1.Worksheet], error)
 	// Update the organizer of a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	UpdateWorksheetOrganizer(context.Context, *connect.Request[v1.UpdateWorksheetOrganizerRequest]) (*connect.Response[v1.WorksheetOrganizer], error)
 	// Delete a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	DeleteWorksheet(context.Context, *connect.Request[v1.DeleteWorksheetRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/generated-go/v1/v1connect/workspace_service.connect.go
+++ b/proto/generated-go/v1/v1connect/workspace_service.connect.go
@@ -43,9 +43,9 @@ const (
 
 // WorkspaceServiceClient is a client for the bytebase.v1.WorkspaceService service.
 type WorkspaceServiceClient interface {
-	// Permissions required: workspaces.getIamPolicy
+	// Permissions required: bb.workspaces.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
-	// Permissions required: workspaces.setIamPolicy
+	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 }
 
@@ -93,9 +93,9 @@ func (c *workspaceServiceClient) SetIamPolicy(ctx context.Context, req *connect.
 
 // WorkspaceServiceHandler is an implementation of the bytebase.v1.WorkspaceService service.
 type WorkspaceServiceHandler interface {
-	// Permissions required: workspaces.getIamPolicy
+	// Permissions required: bb.workspaces.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
-	// Permissions required: workspaces.setIamPolicy
+	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 }
 

--- a/proto/generated-go/v1/v1connect/workspace_service.connect.go
+++ b/proto/generated-go/v1/v1connect/workspace_service.connect.go
@@ -43,7 +43,9 @@ const (
 
 // WorkspaceServiceClient is a client for the bytebase.v1.WorkspaceService service.
 type WorkspaceServiceClient interface {
+	// Permissions required: workspaces.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
+	// Permissions required: workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 }
 
@@ -91,7 +93,9 @@ func (c *workspaceServiceClient) SetIamPolicy(ctx context.Context, req *connect.
 
 // WorkspaceServiceHandler is an implementation of the bytebase.v1.WorkspaceService service.
 type WorkspaceServiceHandler interface {
+	// Permissions required: workspaces.getIamPolicy
 	GetIamPolicy(context.Context, *connect.Request[v1.GetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
+	// Permissions required: workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
 }
 

--- a/proto/generated-go/v1/worksheet_service.pb.gw.go
+++ b/proto/generated-go/v1/worksheet_service.pb.gw.go
@@ -43,6 +43,9 @@ func request_WorksheetService_CreateWorksheet_0(ctx context.Context, marshaler r
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Worksheet); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateWorksheet(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -65,7 +68,9 @@ func request_WorksheetService_GetWorksheet_0(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -104,6 +109,9 @@ func request_WorksheetService_SearchWorksheets_0(ctx context.Context, marshaler 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.SearchWorksheets(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -134,6 +142,9 @@ func request_WorksheetService_UpdateWorksheet_0(ctx context.Context, marshaler r
 	}
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Worksheet); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Worksheet); err != nil {
@@ -213,6 +224,9 @@ func request_WorksheetService_UpdateWorksheetOrganizer_0(ctx context.Context, ma
 	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq.Organizer); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if protoReq.UpdateMask == nil || len(protoReq.UpdateMask.GetPaths()) == 0 {
 		if fieldMask, err := runtime.FieldMaskFromRequestBody(newReader(), protoReq.Organizer); err != nil {
 			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -282,7 +296,9 @@ func request_WorksheetService_DeleteWorksheet_0(ctx context.Context, marshaler r
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")

--- a/proto/generated-go/v1/worksheet_service_grpc.pb.go
+++ b/proto/generated-go/v1/worksheet_service_grpc.pb.go
@@ -33,28 +33,34 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type WorksheetServiceClient interface {
 	// Create a personal worksheet used in SQL Editor.
+	// Permissions required: None
 	CreateWorksheet(ctx context.Context, in *CreateWorksheetRequest, opts ...grpc.CallOption) (*Worksheet, error)
 	// Get a worksheet by name.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.get permission on the workspace;
 	// - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	GetWorksheet(ctx context.Context, in *GetWorksheetRequest, opts ...grpc.CallOption) (*Worksheet, error)
 	// Search for worksheets.
 	// This is used for finding my worksheets or worksheets shared by other people.
 	// The sheet accessibility is the same as GetWorksheet().
+	// Permissions required: None
 	SearchWorksheets(ctx context.Context, in *SearchWorksheetsRequest, opts ...grpc.CallOption) (*SearchWorksheetsResponse, error)
 	// Update a worksheet.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.manage permission on the workspace;
 	// - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	UpdateWorksheet(ctx context.Context, in *UpdateWorksheetRequest, opts ...grpc.CallOption) (*Worksheet, error)
 	// Update the organizer of a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	UpdateWorksheetOrganizer(ctx context.Context, in *UpdateWorksheetOrganizerRequest, opts ...grpc.CallOption) (*WorksheetOrganizer, error)
 	// Delete a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	DeleteWorksheet(ctx context.Context, in *DeleteWorksheetRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -131,28 +137,34 @@ func (c *worksheetServiceClient) DeleteWorksheet(ctx context.Context, in *Delete
 // for forward compatibility.
 type WorksheetServiceServer interface {
 	// Create a personal worksheet used in SQL Editor.
+	// Permissions required: None
 	CreateWorksheet(context.Context, *CreateWorksheetRequest) (*Worksheet, error)
 	// Get a worksheet by name.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.get permission on the workspace;
 	// - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	GetWorksheet(context.Context, *GetWorksheetRequest) (*Worksheet, error)
 	// Search for worksheets.
 	// This is used for finding my worksheets or worksheets shared by other people.
 	// The sheet accessibility is the same as GetWorksheet().
+	// Permissions required: None
 	SearchWorksheets(context.Context, *SearchWorksheetsRequest) (*SearchWorksheetsResponse, error)
 	// Update a worksheet.
 	// The users can access this method if,
 	// - they are the creator of the worksheet;
 	// - they have bb.worksheets.manage permission on the workspace;
 	// - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+	// Permissions required: None
 	UpdateWorksheet(context.Context, *UpdateWorksheetRequest) (*Worksheet, error)
 	// Update the organizer of a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	UpdateWorksheetOrganizer(context.Context, *UpdateWorksheetOrganizerRequest) (*WorksheetOrganizer, error)
 	// Delete a worksheet.
 	// The access is the same as UpdateWorksheet method.
+	// Permissions required: None
 	DeleteWorksheet(context.Context, *DeleteWorksheetRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedWorksheetServiceServer()
 }

--- a/proto/generated-go/v1/workspace_service.pb.gw.go
+++ b/proto/generated-go/v1/workspace_service.pb.gw.go
@@ -41,7 +41,9 @@ func request_WorkspaceService_GetIamPolicy_0(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["resource"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "resource")
@@ -80,6 +82,9 @@ func request_WorkspaceService_SetIamPolicy_0(ctx context.Context, marshaler runt
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["resource"]
 	if !ok {

--- a/proto/generated-go/v1/workspace_service_grpc.pb.go
+++ b/proto/generated-go/v1/workspace_service_grpc.pb.go
@@ -27,9 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type WorkspaceServiceClient interface {
-	// Permissions required: workspaces.getIamPolicy
+	// Permissions required: bb.workspaces.getIamPolicy
 	GetIamPolicy(ctx context.Context, in *GetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
-	// Permissions required: workspaces.setIamPolicy
+	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(ctx context.Context, in *SetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
 }
 
@@ -65,9 +65,9 @@ func (c *workspaceServiceClient) SetIamPolicy(ctx context.Context, in *SetIamPol
 // All implementations must embed UnimplementedWorkspaceServiceServer
 // for forward compatibility.
 type WorkspaceServiceServer interface {
-	// Permissions required: workspaces.getIamPolicy
+	// Permissions required: bb.workspaces.getIamPolicy
 	GetIamPolicy(context.Context, *GetIamPolicyRequest) (*IamPolicy, error)
-	// Permissions required: workspaces.setIamPolicy
+	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *SetIamPolicyRequest) (*IamPolicy, error)
 	mustEmbedUnimplementedWorkspaceServiceServer()
 }

--- a/proto/generated-go/v1/workspace_service_grpc.pb.go
+++ b/proto/generated-go/v1/workspace_service_grpc.pb.go
@@ -27,7 +27,9 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type WorkspaceServiceClient interface {
+	// Permissions required: workspaces.getIamPolicy
 	GetIamPolicy(ctx context.Context, in *GetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
+	// Permissions required: workspaces.setIamPolicy
 	SetIamPolicy(ctx context.Context, in *SetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
 }
 
@@ -63,7 +65,9 @@ func (c *workspaceServiceClient) SetIamPolicy(ctx context.Context, in *SetIamPol
 // All implementations must embed UnimplementedWorkspaceServiceServer
 // for forward compatibility.
 type WorkspaceServiceServer interface {
+	// Permissions required: workspaces.getIamPolicy
 	GetIamPolicy(context.Context, *GetIamPolicyRequest) (*IamPolicy, error)
+	// Permissions required: workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *SetIamPolicyRequest) (*IamPolicy, error)
 	mustEmbedUnimplementedWorkspaceServiceServer()
 }

--- a/proto/v1/v1/README.md
+++ b/proto/v1/v1/README.md
@@ -9,15 +9,14 @@ To ensure that required permissions for each API endpoint are clearly documented
 - **For every `rpc` operation**, add a comment immediately above the `rpc` definition indicating the required permissions.
 - The comment must be of the form:
   - `// Permissions required: None` (if no permission is required)
-  - `// Permissions required: permission.name` (if one permission is required, with the `bb.` prefix stripped)
-  - `// Permissions required: permission.one, permission.two` (if multiple permissions are required, all listed, `bb.` prefix stripped)
+  - `// Permissions required: bb.permission.name` (if one permission is required, with the `bb.` prefix included)
+  - `// Permissions required: bb.permission.one, bb.permission.two` (if multiple permissions are required, all listed, `bb.` prefix included)
 - The comment must be placed **immediately above the `rpc` line** so that OpenAPI generators (such as gnostic) include it in the endpoint's description.
-- Do **not** include the `bb.` prefix in the comment.
 
 ## Example
 
 ```proto
-// Permissions required: projects.get
+// Permissions required: bb.projects.get
 rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
   option (bytebase.v1.permission) = "bb.projects.get";
   // ...
@@ -28,7 +27,7 @@ rpc GetStatus(GetStatusRequest) returns (StatusResponse) {
   // ...
 }
 
-// Permissions required: projects.update, projects.delete
+// Permissions required: bb.projects.update, bb.projects.delete
 rpc UpdateOrDelete(UpdateOrDeleteRequest) returns (UpdateOrDeleteResponse) {
   option (bytebase.v1.permission) = "bb.projects.update,bb.projects.delete";
   // ...

--- a/proto/v1/v1/README.md
+++ b/proto/v1/v1/README.md
@@ -1,0 +1,52 @@
+# Proto Service Permission Comment Convention
+
+## Purpose
+
+To ensure that required permissions for each API endpoint are clearly documented and included in the generated OpenAPI documentation, we follow a strict convention for annotating RPCs in all service `.proto` files in this directory.
+
+## Convention
+
+- **For every `rpc` operation**, add a comment immediately above the `rpc` definition indicating the required permissions.
+- The comment must be of the form:
+  - `// Permissions required: None` (if no permission is required)
+  - `// Permissions required: permission.name` (if one permission is required, with the `bb.` prefix stripped)
+  - `// Permissions required: permission.one, permission.two` (if multiple permissions are required, all listed, `bb.` prefix stripped)
+- The comment must be placed **immediately above the `rpc` line** so that OpenAPI generators (such as gnostic) include it in the endpoint's description.
+- Do **not** include the `bb.` prefix in the comment.
+
+## Example
+
+```proto
+// Permissions required: projects.get
+rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
+  option (bytebase.v1.permission) = "bb.projects.get";
+  // ...
+}
+
+// Permissions required: None
+rpc GetStatus(GetStatusRequest) returns (StatusResponse) {
+  // ...
+}
+
+// Permissions required: projects.update, projects.delete
+rpc UpdateOrDelete(UpdateOrDeleteRequest) returns (UpdateOrDeleteResponse) {
+  option (bytebase.v1.permission) = "bb.projects.update,bb.projects.delete";
+  // ...
+}
+```
+
+## Why?
+
+- This ensures that permission requirements are visible to both developers and API consumers.
+- The comments are automatically included in the OpenAPI `description` field for each endpoint when using gnostic.
+- It helps maintain consistency and clarity as the API evolves.
+
+## Maintenance
+
+- When adding or modifying an `rpc`, always update or add the permission comment accordingly.
+- If you add a new service file, ensure this convention is followed for all its RPCs.
+- If you change permission requirements, update the comment to match.
+
+## Questions?
+
+Contact the maintainers or check with the team if you are unsure about the correct permissions for an endpoint. 

--- a/proto/v1/v1/actuator_service.proto
+++ b/proto/v1/v1/actuator_service.proto
@@ -23,7 +23,7 @@ service ActuatorService {
     option (bytebase.v1.allow_without_credential) = true;
   }
 
-  // Permissions required: settings.set
+  // Permissions required: bb.settings.set
   rpc UpdateActuatorInfo(UpdateActuatorInfoRequest) returns (ActuatorInfo) {
     option (google.api.http) = {
       patch: "/v1/actuator/info"
@@ -34,7 +34,7 @@ service ActuatorService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.create
+  // Permissions required: bb.projects.create
   rpc SetupSample(SetupSampleRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/actuator:setupSample"

--- a/proto/v1/v1/actuator_service.proto
+++ b/proto/v1/v1/actuator_service.proto
@@ -16,12 +16,14 @@ import "v1/user_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service ActuatorService {
+  // Permissions required: None
   rpc GetActuatorInfo(GetActuatorInfoRequest) returns (ActuatorInfo) {
     option (google.api.http) = {get: "/v1/actuator/info"};
     option (google.api.method_signature) = "";
     option (bytebase.v1.allow_without_credential) = true;
   }
 
+  // Permissions required: settings.set
   rpc UpdateActuatorInfo(UpdateActuatorInfoRequest) returns (ActuatorInfo) {
     option (google.api.http) = {
       patch: "/v1/actuator/info"
@@ -32,6 +34,7 @@ service ActuatorService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.create
   rpc SetupSample(SetupSampleRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/actuator:setupSample"
@@ -41,11 +44,13 @@ service ActuatorService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: None
   rpc DeleteCache(DeleteCacheRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/actuator/cache"};
     option (bytebase.v1.allow_without_credential) = true;
   }
 
+  // Permissions required: None
   rpc GetResourcePackage(GetResourcePackageRequest) returns (ResourcePackage) {
     option (google.api.http) = {get: "/v1/actuator/resources"};
     option (google.api.method_signature) = "";

--- a/proto/v1/v1/audit_log_service.proto
+++ b/proto/v1/v1/audit_log_service.proto
@@ -15,6 +15,7 @@ import "v1/iam_policy.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service AuditLogService {
+  // Permissions required: None
   rpc SearchAuditLogs(SearchAuditLogsRequest) returns (SearchAuditLogsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/auditLogs:search"
@@ -27,6 +28,7 @@ service AuditLogService {
     option (bytebase.v1.permission) = "bb.auditLogs.search";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: auditLogs.export
   rpc ExportAuditLogs(ExportAuditLogsRequest) returns (ExportAuditLogsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/auditLogs:export"

--- a/proto/v1/v1/audit_log_service.proto
+++ b/proto/v1/v1/audit_log_service.proto
@@ -28,7 +28,8 @@ service AuditLogService {
     option (bytebase.v1.permission) = "bb.auditLogs.search";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: auditLogs.export
+
+  // Permissions required: bb.auditLogs.export
   rpc ExportAuditLogs(ExportAuditLogsRequest) returns (ExportAuditLogsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/auditLogs:export"

--- a/proto/v1/v1/auth_service.proto
+++ b/proto/v1/v1/auth_service.proto
@@ -10,6 +10,7 @@ import "v1/user_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service AuthService {
+  // Permissions required: None
   rpc Login(LoginRequest) returns (LoginResponse) {
     option (google.api.http) = {
       post: "/v1/auth/login"
@@ -19,6 +20,7 @@ service AuthService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: None
   rpc Logout(LogoutRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/auth/logout"

--- a/proto/v1/v1/cel_service.proto
+++ b/proto/v1/v1/cel_service.proto
@@ -17,6 +17,7 @@ service CelService {
     };
     option (bytebase.v1.allow_without_credential) = true;
   }
+
   // Permissions required: None
   rpc BatchDeparse(BatchDeparseRequest) returns (BatchDeparseResponse) {
     option (google.api.http) = {

--- a/proto/v1/v1/cel_service.proto
+++ b/proto/v1/v1/cel_service.proto
@@ -9,6 +9,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service CelService {
+  // Permissions required: None
   rpc BatchParse(BatchParseRequest) returns (BatchParseResponse) {
     option (google.api.http) = {
       post: "/v1/cel/batchParse"
@@ -16,6 +17,7 @@ service CelService {
     };
     option (bytebase.v1.allow_without_credential) = true;
   }
+  // Permissions required: None
   rpc BatchDeparse(BatchDeparseRequest) returns (BatchDeparseResponse) {
     option (google.api.http) = {
       post: "/v1/cel/batchDeparse"

--- a/proto/v1/v1/changelist_service.proto
+++ b/proto/v1/v1/changelist_service.proto
@@ -14,6 +14,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service ChangelistService {
+  // Permissions required: changelists.create
   rpc CreateChangelist(CreateChangelistRequest) returns (Changelist) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/changelists"
@@ -24,6 +25,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: changelists.get
   rpc GetChangelist(GetChangelistRequest) returns (Changelist) {
     option (google.api.http) = {get: "/v1/{name=projects/*/changelists/*}"};
     option (google.api.method_signature) = "name";
@@ -31,6 +33,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: changelists.list
   rpc ListChangelists(ListChangelistsRequest) returns (ListChangelistsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/changelists"};
     option (google.api.method_signature) = "parent";
@@ -38,6 +41,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: changelists.update
   rpc UpdateChangelist(UpdateChangelistRequest) returns (Changelist) {
     option (google.api.http) = {
       patch: "/v1/{changelist.name=projects/*/changelists/*}"
@@ -48,6 +52,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: changelists.delete
   rpc DeleteChangelist(DeleteChangelistRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*/changelists/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/changelist_service.proto
+++ b/proto/v1/v1/changelist_service.proto
@@ -14,7 +14,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service ChangelistService {
-  // Permissions required: changelists.create
+  // Permissions required: bb.changelists.create
   rpc CreateChangelist(CreateChangelistRequest) returns (Changelist) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/changelists"
@@ -25,7 +25,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: changelists.get
+  // Permissions required: bb.changelists.get
   rpc GetChangelist(GetChangelistRequest) returns (Changelist) {
     option (google.api.http) = {get: "/v1/{name=projects/*/changelists/*}"};
     option (google.api.method_signature) = "name";
@@ -33,7 +33,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: changelists.list
+  // Permissions required: bb.changelists.list
   rpc ListChangelists(ListChangelistsRequest) returns (ListChangelistsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/changelists"};
     option (google.api.method_signature) = "parent";
@@ -41,7 +41,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: changelists.update
+  // Permissions required: bb.changelists.update
   rpc UpdateChangelist(UpdateChangelistRequest) returns (Changelist) {
     option (google.api.http) = {
       patch: "/v1/{changelist.name=projects/*/changelists/*}"
@@ -52,7 +52,7 @@ service ChangelistService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: changelists.delete
+  // Permissions required: bb.changelists.delete
   rpc DeleteChangelist(DeleteChangelistRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*/changelists/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/database_catalog_service.proto
+++ b/proto/v1/v1/database_catalog_service.proto
@@ -11,7 +11,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service DatabaseCatalogService {
-  // Permissions required: databaseCatalogs.get
+  // Permissions required: bb.databaseCatalogs.get
   rpc GetDatabaseCatalog(GetDatabaseCatalogRequest) returns (DatabaseCatalog) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/catalog}"};
     option (google.api.method_signature) = "name";
@@ -19,7 +19,7 @@ service DatabaseCatalogService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databaseCatalogs.update
+  // Permissions required: bb.databaseCatalogs.update
   rpc UpdateDatabaseCatalog(UpdateDatabaseCatalogRequest) returns (DatabaseCatalog) {
     option (google.api.http) = {
       patch: "/v1/{catalog.name=instances/*/databases/*/catalog}"

--- a/proto/v1/v1/database_catalog_service.proto
+++ b/proto/v1/v1/database_catalog_service.proto
@@ -11,6 +11,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service DatabaseCatalogService {
+  // Permissions required: databaseCatalogs.get
   rpc GetDatabaseCatalog(GetDatabaseCatalogRequest) returns (DatabaseCatalog) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/catalog}"};
     option (google.api.method_signature) = "name";
@@ -18,6 +19,7 @@ service DatabaseCatalogService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databaseCatalogs.update
   rpc UpdateDatabaseCatalog(UpdateDatabaseCatalogRequest) returns (DatabaseCatalog) {
     option (google.api.http) = {
       patch: "/v1/{catalog.name=instances/*/databases/*/catalog}"

--- a/proto/v1/v1/database_group_service.proto
+++ b/proto/v1/v1/database_group_service.proto
@@ -14,6 +14,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service DatabaseGroupService {
+  // Permissions required: projects.get
   rpc ListDatabaseGroups(ListDatabaseGroupsRequest) returns (ListDatabaseGroupsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/databaseGroups"};
     option (google.api.method_signature) = "parent";
@@ -21,6 +22,7 @@ service DatabaseGroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.get
   rpc GetDatabaseGroup(GetDatabaseGroupRequest) returns (DatabaseGroup) {
     option (google.api.http) = {get: "/v1/{name=projects/*/databaseGroups/*}"};
     option (google.api.method_signature) = "name";
@@ -28,6 +30,7 @@ service DatabaseGroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.update
   rpc CreateDatabaseGroup(CreateDatabaseGroupRequest) returns (DatabaseGroup) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/databaseGroups"
@@ -39,6 +42,7 @@ service DatabaseGroupService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: projects.update
   rpc UpdateDatabaseGroup(UpdateDatabaseGroupRequest) returns (DatabaseGroup) {
     option (google.api.http) = {
       patch: "/v1/{database_group.name=projects/*/databaseGroups/*}"
@@ -50,6 +54,7 @@ service DatabaseGroupService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: projects.update
   rpc DeleteDatabaseGroup(DeleteDatabaseGroupRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*/databaseGroups/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/database_group_service.proto
+++ b/proto/v1/v1/database_group_service.proto
@@ -14,7 +14,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service DatabaseGroupService {
-  // Permissions required: projects.get
+  // Permissions required: bb.projects.get
   rpc ListDatabaseGroups(ListDatabaseGroupsRequest) returns (ListDatabaseGroupsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/databaseGroups"};
     option (google.api.method_signature) = "parent";
@@ -22,7 +22,7 @@ service DatabaseGroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.get
+  // Permissions required: bb.projects.get
   rpc GetDatabaseGroup(GetDatabaseGroupRequest) returns (DatabaseGroup) {
     option (google.api.http) = {get: "/v1/{name=projects/*/databaseGroups/*}"};
     option (google.api.method_signature) = "name";
@@ -30,7 +30,7 @@ service DatabaseGroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc CreateDatabaseGroup(CreateDatabaseGroupRequest) returns (DatabaseGroup) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/databaseGroups"
@@ -42,7 +42,7 @@ service DatabaseGroupService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc UpdateDatabaseGroup(UpdateDatabaseGroupRequest) returns (DatabaseGroup) {
     option (google.api.http) = {
       patch: "/v1/{database_group.name=projects/*/databaseGroups/*}"
@@ -54,7 +54,7 @@ service DatabaseGroupService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc DeleteDatabaseGroup(DeleteDatabaseGroupRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*/databaseGroups/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/database_service.proto
+++ b/proto/v1/v1/database_service.proto
@@ -16,7 +16,7 @@ import "v1/instance_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service DatabaseService {
-  // Permissions required: databases.get
+  // Permissions required: bb.databases.get
   rpc GetDatabase(GetDatabaseRequest) returns (Database) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*}"};
     option (google.api.method_signature) = "name";
@@ -24,7 +24,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databases.get
+  // Permissions required: bb.databases.get
   rpc BatchGetDatabases(BatchGetDatabasesRequest) returns (BatchGetDatabasesResponse) {
     option (google.api.http) = {
       get: "/v1/{parent=projects/*}/databases:batchGet"
@@ -34,7 +34,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // Permissions required: databases.list
+  // Permissions required: bb.databases.list
   rpc ListDatabases(ListDatabasesRequest) returns (ListDatabasesResponse) {
     option (google.api.http) = {
       get: "/v1/{parent=projects/*}/databases"
@@ -48,7 +48,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // Permissions required: databases.update
+  // Permissions required: bb.databases.update
   rpc UpdateDatabase(UpdateDatabaseRequest) returns (Database) {
     option (google.api.http) = {
       patch: "/v1/{database.name=instances/*/databases/*}"
@@ -60,7 +60,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: databases.update
+  // Permissions required: bb.databases.update
   rpc BatchUpdateDatabases(BatchUpdateDatabasesRequest) returns (BatchUpdateDatabasesResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*}/databases:batchUpdate"
@@ -71,7 +71,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: databases.sync
+  // Permissions required: bb.databases.sync
   rpc SyncDatabase(SyncDatabaseRequest) returns (SyncDatabaseResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:sync"
@@ -81,7 +81,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databases.sync
+  // Permissions required: bb.databases.sync
   rpc BatchSyncDatabases(BatchSyncDatabasesRequest) returns (BatchSyncDatabasesResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*}/databases:batchSync"
@@ -91,21 +91,21 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databases.getSchema
+  // Permissions required: bb.databases.getSchema
   rpc GetDatabaseMetadata(GetDatabaseMetadataRequest) returns (DatabaseMetadata) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/metadata}"};
     option (bytebase.v1.permission) = "bb.databases.getSchema";
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databases.getSchema
+  // Permissions required: bb.databases.getSchema
   rpc GetDatabaseSchema(GetDatabaseSchemaRequest) returns (DatabaseSchema) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/schema}"};
     option (bytebase.v1.permission) = "bb.databases.getSchema";
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databases.get
+  // Permissions required: bb.databases.get
   rpc DiffSchema(DiffSchemaRequest) returns (DiffSchemaResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:diffSchema"
@@ -121,7 +121,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databaseSecrets.list
+  // Permissions required: bb.databaseSecrets.list
   rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*/databases/*}/secrets"};
     option (google.api.method_signature) = "parent";
@@ -129,7 +129,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: databaseSecrets.update
+  // Permissions required: bb.databaseSecrets.update
   rpc UpdateSecret(UpdateSecretRequest) returns (Secret) {
     option (google.api.http) = {
       patch: "/v1/{secret.name=instances/*/databases/*/secrets/*}"
@@ -140,7 +140,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: databaseSecrets.delete
+  // Permissions required: bb.databaseSecrets.delete
   rpc DeleteSecret(DeleteSecretRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=instances/*/databases/*/secrets/*}"};
     option (bytebase.v1.permission) = "bb.databaseSecrets.delete";
@@ -148,7 +148,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: changelogs.list
+  // Permissions required: bb.changelogs.list
   rpc ListChangelogs(ListChangelogsRequest) returns (ListChangelogsResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*/databases/*}/changelogs"};
     option (google.api.method_signature) = "parent";

--- a/proto/v1/v1/database_service.proto
+++ b/proto/v1/v1/database_service.proto
@@ -16,6 +16,7 @@ import "v1/instance_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service DatabaseService {
+  // Permissions required: databases.get
   rpc GetDatabase(GetDatabaseRequest) returns (Database) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*}"};
     option (google.api.method_signature) = "name";
@@ -23,6 +24,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databases.get
   rpc BatchGetDatabases(BatchGetDatabasesRequest) returns (BatchGetDatabasesResponse) {
     option (google.api.http) = {
       get: "/v1/{parent=projects/*}/databases:batchGet"
@@ -32,6 +34,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
+  // Permissions required: databases.list
   rpc ListDatabases(ListDatabasesRequest) returns (ListDatabasesResponse) {
     option (google.api.http) = {
       get: "/v1/{parent=projects/*}/databases"
@@ -45,6 +48,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
+  // Permissions required: databases.update
   rpc UpdateDatabase(UpdateDatabaseRequest) returns (Database) {
     option (google.api.http) = {
       patch: "/v1/{database.name=instances/*/databases/*}"
@@ -56,6 +60,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: databases.update
   rpc BatchUpdateDatabases(BatchUpdateDatabasesRequest) returns (BatchUpdateDatabasesResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*}/databases:batchUpdate"
@@ -66,6 +71,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: databases.sync
   rpc SyncDatabase(SyncDatabaseRequest) returns (SyncDatabaseResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:sync"
@@ -75,6 +81,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databases.sync
   rpc BatchSyncDatabases(BatchSyncDatabasesRequest) returns (BatchSyncDatabasesResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*}/databases:batchSync"
@@ -84,18 +91,21 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databases.getSchema
   rpc GetDatabaseMetadata(GetDatabaseMetadataRequest) returns (DatabaseMetadata) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/metadata}"};
     option (bytebase.v1.permission) = "bb.databases.getSchema";
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databases.getSchema
   rpc GetDatabaseSchema(GetDatabaseSchemaRequest) returns (DatabaseSchema) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/schema}"};
     option (bytebase.v1.permission) = "bb.databases.getSchema";
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databases.get
   rpc DiffSchema(DiffSchemaRequest) returns (DiffSchemaResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:diffSchema"
@@ -111,6 +121,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databaseSecrets.list
   rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*/databases/*}/secrets"};
     option (google.api.method_signature) = "parent";
@@ -118,6 +129,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databaseSecrets.update
   rpc UpdateSecret(UpdateSecretRequest) returns (Secret) {
     option (google.api.http) = {
       patch: "/v1/{secret.name=instances/*/databases/*/secrets/*}"
@@ -128,6 +140,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: databaseSecrets.delete
   rpc DeleteSecret(DeleteSecretRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=instances/*/databases/*/secrets/*}"};
     option (bytebase.v1.permission) = "bb.databaseSecrets.delete";
@@ -135,6 +148,7 @@ service DatabaseService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: changelogs.list
   rpc ListChangelogs(ListChangelogsRequest) returns (ListChangelogsResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*/databases/*}/changelogs"};
     option (google.api.method_signature) = "parent";
@@ -142,6 +156,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: changelogs.get
   rpc GetChangelog(GetChangelogRequest) returns (Changelog) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/changelogs/*}"};
     option (google.api.method_signature) = "name";
@@ -149,6 +164,7 @@ service DatabaseService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: databases.getSchema
   rpc GetSchemaString(GetSchemaStringRequest) returns (GetSchemaStringResponse) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/schemaString}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/group_service.proto
+++ b/proto/v1/v1/group_service.proto
@@ -13,6 +13,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service GroupService {
+  // Permissions required: groups.get
   rpc GetGroup(GetGroupRequest) returns (Group) {
     option (google.api.http) = {get: "/v1/{name=groups/*}"};
     option (google.api.method_signature) = "name";
@@ -20,6 +21,7 @@ service GroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: groups.list
   rpc ListGroups(ListGroupsRequest) returns (ListGroupsResponse) {
     option (google.api.http) = {get: "/v1/groups"};
     option (google.api.method_signature) = "";
@@ -27,6 +29,7 @@ service GroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: groups.create
   rpc CreateGroup(CreateGroupRequest) returns (Group) {
     option (google.api.http) = {
       post: "/v1/groups"
@@ -40,6 +43,7 @@ service GroupService {
 
   // UpdateGroup updates the group.
   // Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
+  // Permissions required: groups.update
   rpc UpdateGroup(UpdateGroupRequest) returns (Group) {
     option (google.api.http) = {
       patch: "/v1/{group.name=groups/*}"
@@ -51,6 +55,7 @@ service GroupService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: groups.delete
   rpc DeleteGroup(DeleteGroupRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=groups/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/group_service.proto
+++ b/proto/v1/v1/group_service.proto
@@ -13,7 +13,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service GroupService {
-  // Permissions required: groups.get
+  // Permissions required: bb.groups.get
   rpc GetGroup(GetGroupRequest) returns (Group) {
     option (google.api.http) = {get: "/v1/{name=groups/*}"};
     option (google.api.method_signature) = "name";
@@ -21,7 +21,7 @@ service GroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: groups.list
+  // Permissions required: bb.groups.list
   rpc ListGroups(ListGroupsRequest) returns (ListGroupsResponse) {
     option (google.api.http) = {get: "/v1/groups"};
     option (google.api.method_signature) = "";
@@ -29,7 +29,7 @@ service GroupService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: groups.create
+  // Permissions required: bb.groups.create
   rpc CreateGroup(CreateGroupRequest) returns (Group) {
     option (google.api.http) = {
       post: "/v1/groups"
@@ -43,7 +43,7 @@ service GroupService {
 
   // UpdateGroup updates the group.
   // Users with "bb.groups.update" permission on the workspace or the group owner can access this method.
-  // Permissions required: groups.update
+  // Permissions required: bb.groups.update
   rpc UpdateGroup(UpdateGroupRequest) returns (Group) {
     option (google.api.http) = {
       patch: "/v1/{group.name=groups/*}"
@@ -55,7 +55,7 @@ service GroupService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: groups.delete
+  // Permissions required: bb.groups.delete
   rpc DeleteGroup(DeleteGroupRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=groups/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/idp_service.proto
+++ b/proto/v1/v1/idp_service.proto
@@ -13,7 +13,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service IdentityProviderService {
-  // Permissions required: identityProviders.get
+  // Permissions required: bb.identityProviders.get
   rpc GetIdentityProvider(GetIdentityProviderRequest) returns (IdentityProvider) {
     option (google.api.http) = {get: "/v1/{name=idps/*}"};
     option (google.api.method_signature) = "name";
@@ -29,7 +29,7 @@ service IdentityProviderService {
     // The method requires no authentication thus no authorization.
   }
 
-  // Permissions required: identityProviders.create
+  // Permissions required: bb.identityProviders.create
   rpc CreateIdentityProvider(CreateIdentityProviderRequest) returns (IdentityProvider) {
     option (google.api.http) = {
       post: "/v1/idps"
@@ -41,7 +41,7 @@ service IdentityProviderService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: identityProviders.update
+  // Permissions required: bb.identityProviders.update
   rpc UpdateIdentityProvider(UpdateIdentityProviderRequest) returns (IdentityProvider) {
     option (google.api.http) = {
       patch: "/v1/{identity_provider.name=idps/*}"
@@ -53,7 +53,7 @@ service IdentityProviderService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: identityProviders.delete
+  // Permissions required: bb.identityProviders.delete
   rpc DeleteIdentityProvider(DeleteIdentityProviderRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=idps/*}"};
     option (google.api.method_signature) = "name";
@@ -62,7 +62,7 @@ service IdentityProviderService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: identityProviders.update
+  // Permissions required: bb.identityProviders.update
   rpc TestIdentityProvider(TestIdentityProviderRequest) returns (TestIdentityProviderResponse) {
     option (google.api.http) = {
       post: "/v1/idps/*:test"

--- a/proto/v1/v1/idp_service.proto
+++ b/proto/v1/v1/idp_service.proto
@@ -13,6 +13,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service IdentityProviderService {
+  // Permissions required: identityProviders.get
   rpc GetIdentityProvider(GetIdentityProviderRequest) returns (IdentityProvider) {
     option (google.api.http) = {get: "/v1/{name=idps/*}"};
     option (google.api.method_signature) = "name";
@@ -20,6 +21,7 @@ service IdentityProviderService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: None
   rpc ListIdentityProviders(ListIdentityProvidersRequest) returns (ListIdentityProvidersResponse) {
     option (google.api.http) = {get: "/v1/idps"};
     option (google.api.method_signature) = "";
@@ -27,6 +29,7 @@ service IdentityProviderService {
     // The method requires no authentication thus no authorization.
   }
 
+  // Permissions required: identityProviders.create
   rpc CreateIdentityProvider(CreateIdentityProviderRequest) returns (IdentityProvider) {
     option (google.api.http) = {
       post: "/v1/idps"
@@ -38,6 +41,7 @@ service IdentityProviderService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: identityProviders.update
   rpc UpdateIdentityProvider(UpdateIdentityProviderRequest) returns (IdentityProvider) {
     option (google.api.http) = {
       patch: "/v1/{identity_provider.name=idps/*}"
@@ -49,6 +53,7 @@ service IdentityProviderService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: identityProviders.delete
   rpc DeleteIdentityProvider(DeleteIdentityProviderRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=idps/*}"};
     option (google.api.method_signature) = "name";
@@ -57,6 +62,7 @@ service IdentityProviderService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: identityProviders.update
   rpc TestIdentityProvider(TestIdentityProviderRequest) returns (TestIdentityProviderResponse) {
     option (google.api.http) = {
       post: "/v1/idps/*:test"

--- a/proto/v1/v1/instance_role_service.proto
+++ b/proto/v1/v1/instance_role_service.proto
@@ -11,6 +11,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service InstanceRoleService {
+  // Permissions required: instanceRoles.get
   rpc GetInstanceRole(GetInstanceRoleRequest) returns (InstanceRole) {
     option (google.api.http) = {get: "/v1/{name=instances/*/roles/*}"};
     option (google.api.method_signature) = "name";
@@ -18,6 +19,7 @@ service InstanceRoleService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: instanceRoles.get
   rpc ListInstanceRoles(ListInstanceRolesRequest) returns (ListInstanceRolesResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*}/roles"};
     option (google.api.method_signature) = "parent";

--- a/proto/v1/v1/instance_role_service.proto
+++ b/proto/v1/v1/instance_role_service.proto
@@ -11,7 +11,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service InstanceRoleService {
-  // Permissions required: instanceRoles.get
+  // Permissions required: bb.instanceRoles.get
   rpc GetInstanceRole(GetInstanceRoleRequest) returns (InstanceRole) {
     option (google.api.http) = {get: "/v1/{name=instances/*/roles/*}"};
     option (google.api.method_signature) = "name";
@@ -19,7 +19,7 @@ service InstanceRoleService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: instanceRoles.get
+  // Permissions required: bb.instanceRoles.get
   rpc ListInstanceRoles(ListInstanceRolesRequest) returns (ListInstanceRolesResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*}/roles"};
     option (google.api.method_signature) = "parent";

--- a/proto/v1/v1/instance_service.proto
+++ b/proto/v1/v1/instance_service.proto
@@ -17,7 +17,7 @@ import "v1/instance_role_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service InstanceService {
-  // Permissions required: instances.get
+  // Permissions required: bb.instances.get
   rpc GetInstance(GetInstanceRequest) returns (Instance) {
     option (google.api.http) = {get: "/v1/{name=instances/*}"};
     option (google.api.method_signature) = "name";
@@ -25,7 +25,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: instances.list
+  // Permissions required: bb.instances.list
   rpc ListInstances(ListInstancesRequest) returns (ListInstancesResponse) {
     option (google.api.http) = {get: "/v1/instances"};
     option (google.api.method_signature) = "";
@@ -33,7 +33,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: instances.create
+  // Permissions required: bb.instances.create
   rpc CreateInstance(CreateInstanceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/instances"
@@ -45,7 +45,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: instances.update
+  // Permissions required: bb.instances.update
   rpc UpdateInstance(UpdateInstanceRequest) returns (Instance) {
     option (google.api.http) = {
       patch: "/v1/{instance.name=instances/*}"
@@ -57,7 +57,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: instances.delete
+  // Permissions required: bb.instances.delete
   rpc DeleteInstance(DeleteInstanceRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=instances/*}"};
     option (google.api.method_signature) = "name";
@@ -66,7 +66,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: instances.undelete
+  // Permissions required: bb.instances.undelete
   rpc UndeleteInstance(UndeleteInstanceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:undelete"
@@ -77,7 +77,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: instances.sync
+  // Permissions required: bb.instances.sync
   rpc SyncInstance(SyncInstanceRequest) returns (SyncInstanceResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:sync"
@@ -87,7 +87,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: instances.get
+  // Permissions required: bb.instances.get
   rpc ListInstanceDatabase(ListInstanceDatabaseRequest) returns (ListInstanceDatabaseResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:databases"
@@ -97,7 +97,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: instances.sync
+  // Permissions required: bb.instances.sync
   rpc BatchSyncInstances(BatchSyncInstancesRequest) returns (BatchSyncInstancesResponse) {
     option (google.api.http) = {
       post: "/v1/instances:batchSync"
@@ -107,7 +107,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: instances.update
+  // Permissions required: bb.instances.update
   rpc BatchUpdateInstances(BatchUpdateInstancesRequest) returns (BatchUpdateInstancesResponse) {
     option (google.api.http) = {
       post: "/v1/instances:batchUpdate"
@@ -118,7 +118,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: instances.update
+  // Permissions required: bb.instances.update
   rpc AddDataSource(AddDataSourceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:addDataSource"
@@ -129,7 +129,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: instances.update
+  // Permissions required: bb.instances.update
   rpc RemoveDataSource(RemoveDataSourceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:removeDataSource"
@@ -140,7 +140,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: instances.update
+  // Permissions required: bb.instances.update
   rpc UpdateDataSource(UpdateDataSourceRequest) returns (Instance) {
     option (google.api.http) = {
       patch: "/v1/{name=instances/*}:updateDataSource"

--- a/proto/v1/v1/instance_service.proto
+++ b/proto/v1/v1/instance_service.proto
@@ -17,6 +17,7 @@ import "v1/instance_role_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service InstanceService {
+  // Permissions required: instances.get
   rpc GetInstance(GetInstanceRequest) returns (Instance) {
     option (google.api.http) = {get: "/v1/{name=instances/*}"};
     option (google.api.method_signature) = "name";
@@ -24,6 +25,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: instances.list
   rpc ListInstances(ListInstancesRequest) returns (ListInstancesResponse) {
     option (google.api.http) = {get: "/v1/instances"};
     option (google.api.method_signature) = "";
@@ -31,6 +33,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: instances.create
   rpc CreateInstance(CreateInstanceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/instances"
@@ -42,6 +45,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: instances.update
   rpc UpdateInstance(UpdateInstanceRequest) returns (Instance) {
     option (google.api.http) = {
       patch: "/v1/{instance.name=instances/*}"
@@ -53,6 +57,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: instances.delete
   rpc DeleteInstance(DeleteInstanceRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=instances/*}"};
     option (google.api.method_signature) = "name";
@@ -61,6 +66,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: instances.undelete
   rpc UndeleteInstance(UndeleteInstanceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:undelete"
@@ -71,6 +77,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: instances.sync
   rpc SyncInstance(SyncInstanceRequest) returns (SyncInstanceResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:sync"
@@ -80,6 +87,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: instances.get
   rpc ListInstanceDatabase(ListInstanceDatabaseRequest) returns (ListInstanceDatabaseResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:databases"
@@ -89,6 +97,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: instances.sync
   rpc BatchSyncInstances(BatchSyncInstancesRequest) returns (BatchSyncInstancesResponse) {
     option (google.api.http) = {
       post: "/v1/instances:batchSync"
@@ -98,6 +107,7 @@ service InstanceService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: instances.update
   rpc BatchUpdateInstances(BatchUpdateInstancesRequest) returns (BatchUpdateInstancesResponse) {
     option (google.api.http) = {
       post: "/v1/instances:batchUpdate"
@@ -108,6 +118,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: instances.update
   rpc AddDataSource(AddDataSourceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:addDataSource"
@@ -118,6 +129,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: instances.update
   rpc RemoveDataSource(RemoveDataSourceRequest) returns (Instance) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*}:removeDataSource"
@@ -128,6 +140,7 @@ service InstanceService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: instances.update
   rpc UpdateDataSource(UpdateDataSourceRequest) returns (Instance) {
     option (google.api.http) = {
       patch: "/v1/{name=instances/*}:updateDataSource"

--- a/proto/v1/v1/issue_service.proto
+++ b/proto/v1/v1/issue_service.proto
@@ -15,6 +15,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service IssueService {
+  // Permissions required: issues.get
   rpc GetIssue(GetIssueRequest) returns (Issue) {
     option (google.api.http) = {get: "/v1/{name=projects/*/issues/*}"};
     option (google.api.method_signature) = "name";
@@ -22,6 +23,7 @@ service IssueService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: issues.create
   rpc CreateIssue(CreateIssueRequest) returns (Issue) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/issues"
@@ -34,6 +36,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: issues.list
   rpc ListIssues(ListIssuesRequest) returns (ListIssuesResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/issues"};
     option (google.api.method_signature) = "parent";
@@ -42,6 +45,7 @@ service IssueService {
   }
 
   // Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
+  // Permissions required: issues.get
   rpc SearchIssues(SearchIssuesRequest) returns (SearchIssuesResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/issues:search"
@@ -51,6 +55,7 @@ service IssueService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
+  // Permissions required: issues.update
   rpc UpdateIssue(UpdateIssueRequest) returns (Issue) {
     option (google.api.http) = {
       patch: "/v1/{issue.name=projects/*/issues/*}"
@@ -62,6 +67,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: issueComments.list
   rpc ListIssueComments(ListIssueCommentsRequest) returns (ListIssueCommentsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/issues/*}/issueComments"};
     option (google.api.method_signature) = "parent";
@@ -69,6 +75,7 @@ service IssueService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: issueComments.create
   rpc CreateIssueComment(CreateIssueCommentRequest) returns (IssueComment) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/issues/*}:comment"
@@ -80,6 +87,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: issueComments.update
   rpc UpdateIssueComment(UpdateIssueCommentRequest) returns (IssueComment) {
     option (google.api.http) = {
       patch: "/v1/{parent=projects/*/issues/*}:comment"
@@ -91,6 +99,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: issues.update
   rpc BatchUpdateIssuesStatus(BatchUpdateIssuesStatusRequest) returns (BatchUpdateIssuesStatusResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/issues:batchUpdateStatus"
@@ -103,6 +112,7 @@ service IssueService {
 
   // ApproveIssue approves the issue.
   // The access is based on approval flow.
+  // Permissions required: None
   rpc ApproveIssue(ApproveIssueRequest) returns (Issue) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*/issues/*}:approve"
@@ -114,6 +124,7 @@ service IssueService {
 
   // RejectIssue rejects the issue.
   // The access is based on approval flow.
+  // Permissions required: None
   rpc RejectIssue(RejectIssueRequest) returns (Issue) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*/issues/*}:reject"
@@ -125,6 +136,7 @@ service IssueService {
 
   // RequestIssue requests the issue.
   // The access is based on approval flow.
+  // Permissions required: None
   rpc RequestIssue(RequestIssueRequest) returns (Issue) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*/issues/*}:request"

--- a/proto/v1/v1/issue_service.proto
+++ b/proto/v1/v1/issue_service.proto
@@ -15,7 +15,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service IssueService {
-  // Permissions required: issues.get
+  // Permissions required: bb.issues.get
   rpc GetIssue(GetIssueRequest) returns (Issue) {
     option (google.api.http) = {get: "/v1/{name=projects/*/issues/*}"};
     option (google.api.method_signature) = "name";
@@ -23,7 +23,7 @@ service IssueService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: issues.create
+  // Permissions required: bb.issues.create
   rpc CreateIssue(CreateIssueRequest) returns (Issue) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/issues"
@@ -36,7 +36,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: issues.list
+  // Permissions required: bb.issues.list
   rpc ListIssues(ListIssuesRequest) returns (ListIssuesResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/issues"};
     option (google.api.method_signature) = "parent";
@@ -45,7 +45,7 @@ service IssueService {
   }
 
   // Search for issues that the caller has the bb.issues.get permission on and also satisfy the specified filter & query.
-  // Permissions required: issues.get
+  // Permissions required: bb.issues.get
   rpc SearchIssues(SearchIssuesRequest) returns (SearchIssuesResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/issues:search"
@@ -55,7 +55,7 @@ service IssueService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // Permissions required: issues.update
+  // Permissions required: bb.issues.update
   rpc UpdateIssue(UpdateIssueRequest) returns (Issue) {
     option (google.api.http) = {
       patch: "/v1/{issue.name=projects/*/issues/*}"
@@ -67,7 +67,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: issueComments.list
+  // Permissions required: bb.issueComments.list
   rpc ListIssueComments(ListIssueCommentsRequest) returns (ListIssueCommentsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/issues/*}/issueComments"};
     option (google.api.method_signature) = "parent";
@@ -75,7 +75,7 @@ service IssueService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: issueComments.create
+  // Permissions required: bb.issueComments.create
   rpc CreateIssueComment(CreateIssueCommentRequest) returns (IssueComment) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/issues/*}:comment"
@@ -87,7 +87,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: issueComments.update
+  // Permissions required: bb.issueComments.update
   rpc UpdateIssueComment(UpdateIssueCommentRequest) returns (IssueComment) {
     option (google.api.http) = {
       patch: "/v1/{parent=projects/*/issues/*}:comment"
@@ -99,7 +99,7 @@ service IssueService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: issues.update
+  // Permissions required: bb.issues.update
   rpc BatchUpdateIssuesStatus(BatchUpdateIssuesStatusRequest) returns (BatchUpdateIssuesStatusResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/issues:batchUpdateStatus"

--- a/proto/v1/v1/org_policy_service.proto
+++ b/proto/v1/v1/org_policy_service.proto
@@ -16,7 +16,7 @@ import "v1/common.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service OrgPolicyService {
-  // Permissions required: policies.get
+  // Permissions required: bb.policies.get
   rpc GetPolicy(GetPolicyRequest) returns (Policy) {
     option (google.api.http) = {
       get: "/v1/{name=policies/*}"
@@ -31,7 +31,7 @@ service OrgPolicyService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: policies.list
+  // Permissions required: bb.policies.list
   rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse) {
     option (google.api.http) = {
       get: "/v1/policies"
@@ -46,7 +46,7 @@ service OrgPolicyService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: policies.create
+  // Permissions required: bb.policies.create
   rpc CreatePolicy(CreatePolicyRequest) returns (Policy) {
     option (google.api.http) = {
       post: "/v1/policies"
@@ -75,7 +75,7 @@ service OrgPolicyService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: policies.update
+  // Permissions required: bb.policies.update
   rpc UpdatePolicy(UpdatePolicyRequest) returns (Policy) {
     option (google.api.http) = {
       patch: "/v1/{policy.name=policies/*}"
@@ -104,7 +104,7 @@ service OrgPolicyService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: policies.delete
+  // Permissions required: bb.policies.delete
   rpc DeletePolicy(DeletePolicyRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1/{name=policies/*}"

--- a/proto/v1/v1/org_policy_service.proto
+++ b/proto/v1/v1/org_policy_service.proto
@@ -16,6 +16,7 @@ import "v1/common.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service OrgPolicyService {
+  // Permissions required: policies.get
   rpc GetPolicy(GetPolicyRequest) returns (Policy) {
     option (google.api.http) = {
       get: "/v1/{name=policies/*}"
@@ -30,6 +31,7 @@ service OrgPolicyService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: policies.list
   rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse) {
     option (google.api.http) = {
       get: "/v1/policies"
@@ -44,6 +46,7 @@ service OrgPolicyService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: policies.create
   rpc CreatePolicy(CreatePolicyRequest) returns (Policy) {
     option (google.api.http) = {
       post: "/v1/policies"
@@ -72,6 +75,7 @@ service OrgPolicyService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: policies.update
   rpc UpdatePolicy(UpdatePolicyRequest) returns (Policy) {
     option (google.api.http) = {
       patch: "/v1/{policy.name=policies/*}"
@@ -100,6 +104,7 @@ service OrgPolicyService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: policies.delete
   rpc DeletePolicy(DeletePolicyRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1/{name=policies/*}"

--- a/proto/v1/v1/plan_service.proto
+++ b/proto/v1/v1/plan_service.proto
@@ -15,6 +15,7 @@ import "v1/database_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service PlanService {
+  // Permissions required: plans.get
   rpc GetPlan(GetPlanRequest) returns (Plan) {
     option (google.api.http) = {get: "/v1/{name=projects/*/plans/*}"};
     option (google.api.method_signature) = "name";
@@ -22,6 +23,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: plans.list
   rpc ListPlans(ListPlansRequest) returns (ListPlansResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/plans"};
     option (google.api.method_signature) = "parent";
@@ -30,6 +32,7 @@ service PlanService {
   }
 
   // Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
+  // Permissions required: plans.get
   rpc SearchPlans(SearchPlansRequest) returns (SearchPlansResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/plans:search"
@@ -40,6 +43,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
+  // Permissions required: plans.create
   rpc CreatePlan(CreatePlanRequest) returns (Plan) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/plans"
@@ -53,6 +57,7 @@ service PlanService {
 
   // UpdatePlan updates the plan.
   // The plan creator and the user with bb.plans.update permission on the project can update the plan.
+  // Permissions required: plans.update
   rpc UpdatePlan(UpdatePlanRequest) returns (Plan) {
     option (google.api.http) = {
       patch: "/v1/{plan.name=projects/*/plans/*}"
@@ -64,6 +69,7 @@ service PlanService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: planCheckRuns.list
   rpc ListPlanCheckRuns(ListPlanCheckRunsRequest) returns (ListPlanCheckRunsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/plans/*}/planCheckRuns"};
     option (google.api.method_signature) = "parent";
@@ -71,6 +77,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: planCheckRuns.run
   rpc RunPlanChecks(RunPlanChecksRequest) returns (RunPlanChecksResponse) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*/plans/*}:runPlanChecks"
@@ -81,6 +88,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: planCheckRuns.run
   rpc BatchCancelPlanCheckRuns(BatchCancelPlanCheckRunsRequest) returns (BatchCancelPlanCheckRunsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/plans/*}/planCheckRuns:batchCancel"

--- a/proto/v1/v1/plan_service.proto
+++ b/proto/v1/v1/plan_service.proto
@@ -15,7 +15,7 @@ import "v1/database_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service PlanService {
-  // Permissions required: plans.get
+  // Permissions required: bb.plans.get
   rpc GetPlan(GetPlanRequest) returns (Plan) {
     option (google.api.http) = {get: "/v1/{name=projects/*/plans/*}"};
     option (google.api.method_signature) = "name";
@@ -23,7 +23,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: plans.list
+  // Permissions required: bb.plans.list
   rpc ListPlans(ListPlansRequest) returns (ListPlansResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/plans"};
     option (google.api.method_signature) = "parent";
@@ -32,7 +32,7 @@ service PlanService {
   }
 
   // Search for plans that the caller has the bb.plans.get permission on and also satisfy the specified filter & query.
-  // Permissions required: plans.get
+  // Permissions required: bb.plans.get
   rpc SearchPlans(SearchPlansRequest) returns (SearchPlansResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/plans:search"
@@ -43,7 +43,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // Permissions required: plans.create
+  // Permissions required: bb.plans.create
   rpc CreatePlan(CreatePlanRequest) returns (Plan) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/plans"
@@ -57,7 +57,7 @@ service PlanService {
 
   // UpdatePlan updates the plan.
   // The plan creator and the user with bb.plans.update permission on the project can update the plan.
-  // Permissions required: plans.update
+  // Permissions required: bb.plans.update
   rpc UpdatePlan(UpdatePlanRequest) returns (Plan) {
     option (google.api.http) = {
       patch: "/v1/{plan.name=projects/*/plans/*}"
@@ -69,7 +69,7 @@ service PlanService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: planCheckRuns.list
+  // Permissions required: bb.planCheckRuns.list
   rpc ListPlanCheckRuns(ListPlanCheckRunsRequest) returns (ListPlanCheckRunsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/plans/*}/planCheckRuns"};
     option (google.api.method_signature) = "parent";
@@ -77,7 +77,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: planCheckRuns.run
+  // Permissions required: bb.planCheckRuns.run
   rpc RunPlanChecks(RunPlanChecksRequest) returns (RunPlanChecksResponse) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*/plans/*}:runPlanChecks"
@@ -88,7 +88,7 @@ service PlanService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: planCheckRuns.run
+  // Permissions required: bb.planCheckRuns.run
   rpc BatchCancelPlanCheckRuns(BatchCancelPlanCheckRunsRequest) returns (BatchCancelPlanCheckRunsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/plans/*}/planCheckRuns:batchCancel"

--- a/proto/v1/v1/project_service.proto
+++ b/proto/v1/v1/project_service.proto
@@ -17,6 +17,7 @@ option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 service ProjectService {
   // GetProject retrieves a project by name.
   // Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
+  // Permissions required: projects.get
   rpc GetProject(GetProjectRequest) returns (Project) {
     option (google.api.http) = {get: "/v1/{name=projects/*}"};
     option (google.api.method_signature) = "name";
@@ -24,6 +25,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.list
   rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
     option (google.api.http) = {get: "/v1/projects"};
     option (google.api.method_signature) = "";
@@ -31,6 +33,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: None
   rpc SearchProjects(SearchProjectsRequest) returns (SearchProjectsResponse) {
     option (google.api.http) = {
       post: "/v1/projects:search"
@@ -41,6 +44,7 @@ service ProjectService {
     // TODO(d): secure it.
   }
 
+  // Permissions required: projects.create
   rpc CreateProject(CreateProjectRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/projects"
@@ -51,6 +55,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.update
   rpc UpdateProject(UpdateProjectRequest) returns (Project) {
     option (google.api.http) = {
       patch: "/v1/{project.name=projects/*}"
@@ -61,6 +66,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.delete
   rpc DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*}"};
     option (google.api.method_signature) = "name";
@@ -68,6 +74,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.undelete
   rpc UndeleteProject(UndeleteProjectRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*}:undelete"
@@ -77,6 +84,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.delete
   rpc BatchDeleteProjects(BatchDeleteProjectsRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/projects:batchDelete"
@@ -86,6 +94,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.getIamPolicy
   rpc GetIamPolicy(GetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {get: "/v1/{resource=projects/*}:getIamPolicy"};
     option (bytebase.v1.permission) = "bb.projects.getIamPolicy";
@@ -93,12 +102,14 @@ service ProjectService {
   }
 
   // Deprecated.
+  // Permissions required: projects.getIamPolicy
   rpc BatchGetIamPolicy(BatchGetIamPolicyRequest) returns (BatchGetIamPolicyResponse) {
     option (google.api.http) = {get: "/v1/{scope=*/*}/iamPolicies:batchGet"};
     option (bytebase.v1.permission) = "bb.projects.getIamPolicy";
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
+  // Permissions required: projects.setIamPolicy
   rpc SetIamPolicy(SetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {
       post: "/v1/{resource=projects/*}:setIamPolicy"
@@ -109,6 +120,7 @@ service ProjectService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: projects.update
   rpc AddWebhook(AddWebhookRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{project=projects/*}:addWebhook"
@@ -118,6 +130,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.update
   rpc UpdateWebhook(UpdateWebhookRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{webhook.name=projects/*/webhooks/*}:updateWebhook"
@@ -128,6 +141,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.update
   rpc RemoveWebhook(RemoveWebhookRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{webhook.name=projects/*/webhooks/*}:removeWebhook"
@@ -137,6 +151,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: projects.update
   rpc TestWebhook(TestWebhookRequest) returns (TestWebhookResponse) {
     option (google.api.http) = {
       post: "/v1/{project=projects/*}:testWebhook"

--- a/proto/v1/v1/project_service.proto
+++ b/proto/v1/v1/project_service.proto
@@ -17,7 +17,7 @@ option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 service ProjectService {
   // GetProject retrieves a project by name.
   // Users with "bb.projects.get" permission on the workspace or the project owner can access this method.
-  // Permissions required: projects.get
+  // Permissions required: bb.projects.get
   rpc GetProject(GetProjectRequest) returns (Project) {
     option (google.api.http) = {get: "/v1/{name=projects/*}"};
     option (google.api.method_signature) = "name";
@@ -25,7 +25,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.list
+  // Permissions required: bb.projects.list
   rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
     option (google.api.http) = {get: "/v1/projects"};
     option (google.api.method_signature) = "";
@@ -44,7 +44,7 @@ service ProjectService {
     // TODO(d): secure it.
   }
 
-  // Permissions required: projects.create
+  // Permissions required: bb.projects.create
   rpc CreateProject(CreateProjectRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/projects"
@@ -55,7 +55,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc UpdateProject(UpdateProjectRequest) returns (Project) {
     option (google.api.http) = {
       patch: "/v1/{project.name=projects/*}"
@@ -66,7 +66,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.delete
+  // Permissions required: bb.projects.delete
   rpc DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*}"};
     option (google.api.method_signature) = "name";
@@ -74,7 +74,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.undelete
+  // Permissions required: bb.projects.undelete
   rpc UndeleteProject(UndeleteProjectRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*}:undelete"
@@ -84,7 +84,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.delete
+  // Permissions required: bb.projects.delete
   rpc BatchDeleteProjects(BatchDeleteProjectsRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/projects:batchDelete"
@@ -94,7 +94,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.getIamPolicy
+  // Permissions required: bb.projects.getIamPolicy
   rpc GetIamPolicy(GetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {get: "/v1/{resource=projects/*}:getIamPolicy"};
     option (bytebase.v1.permission) = "bb.projects.getIamPolicy";
@@ -102,14 +102,14 @@ service ProjectService {
   }
 
   // Deprecated.
-  // Permissions required: projects.getIamPolicy
+  // Permissions required: bb.projects.getIamPolicy
   rpc BatchGetIamPolicy(BatchGetIamPolicyRequest) returns (BatchGetIamPolicyResponse) {
     option (google.api.http) = {get: "/v1/{scope=*/*}/iamPolicies:batchGet"};
     option (bytebase.v1.permission) = "bb.projects.getIamPolicy";
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // Permissions required: projects.setIamPolicy
+  // Permissions required: bb.projects.setIamPolicy
   rpc SetIamPolicy(SetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {
       post: "/v1/{resource=projects/*}:setIamPolicy"
@@ -120,7 +120,7 @@ service ProjectService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc AddWebhook(AddWebhookRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{project=projects/*}:addWebhook"
@@ -130,7 +130,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc UpdateWebhook(UpdateWebhookRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{webhook.name=projects/*/webhooks/*}:updateWebhook"
@@ -141,7 +141,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc RemoveWebhook(RemoveWebhookRequest) returns (Project) {
     option (google.api.http) = {
       post: "/v1/{webhook.name=projects/*/webhooks/*}:removeWebhook"
@@ -151,7 +151,7 @@ service ProjectService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: projects.update
+  // Permissions required: bb.projects.update
   rpc TestWebhook(TestWebhookRequest) returns (TestWebhookResponse) {
     option (google.api.http) = {
       post: "/v1/{project=projects/*}:testWebhook"

--- a/proto/v1/v1/release_service.proto
+++ b/proto/v1/v1/release_service.proto
@@ -16,21 +16,23 @@ import "v1/sql_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service ReleaseService {
-  // Permissions required: releases.get
+  // Permissions required: bb.releases.get
   rpc GetRelease(GetReleaseRequest) returns (Release) {
     option (google.api.http) = {get: "/v1/{name=projects/*/releases/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.releases.get";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: releases.list
+
+  // Permissions required: bb.releases.list
   rpc ListReleases(ListReleasesRequest) returns (ListReleasesResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/releases"};
     option (google.api.method_signature) = "parent";
     option (bytebase.v1.permission) = "bb.releases.list";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: releases.create
+
+  // Permissions required: bb.releases.create
   rpc CreateRelease(CreateReleaseRequest) returns (Release) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/releases"
@@ -40,7 +42,8 @@ service ReleaseService {
     option (bytebase.v1.permission) = "bb.releases.create";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: releases.update
+
+  // Permissions required: bb.releases.update
   rpc UpdateRelease(UpdateReleaseRequest) returns (Release) {
     option (google.api.http) = {
       patch: "/v1/{release.name=projects/*/releases/*}"
@@ -50,20 +53,23 @@ service ReleaseService {
     option (bytebase.v1.permission) = "bb.releases.update";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: releases.delete
+
+  // Permissions required: bb.releases.delete
   rpc DeleteRelease(DeleteReleaseRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*/releases/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.releases.delete";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: releases.undelete
+
+  // Permissions required: bb.releases.undelete
   rpc UndeleteRelease(UndeleteReleaseRequest) returns (Release) {
     option (google.api.http) = {post: "/v1/{name=projects/*/releases/*}:undelete"};
     option (bytebase.v1.permission) = "bb.releases.undelete";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: releases.check
+
+  // Permissions required: bb.releases.check
   rpc CheckRelease(CheckReleaseRequest) returns (CheckReleaseResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/releases:check"

--- a/proto/v1/v1/release_service.proto
+++ b/proto/v1/v1/release_service.proto
@@ -16,18 +16,21 @@ import "v1/sql_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service ReleaseService {
+  // Permissions required: releases.get
   rpc GetRelease(GetReleaseRequest) returns (Release) {
     option (google.api.http) = {get: "/v1/{name=projects/*/releases/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.releases.get";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: releases.list
   rpc ListReleases(ListReleasesRequest) returns (ListReleasesResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/releases"};
     option (google.api.method_signature) = "parent";
     option (bytebase.v1.permission) = "bb.releases.list";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: releases.create
   rpc CreateRelease(CreateReleaseRequest) returns (Release) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/releases"
@@ -37,6 +40,7 @@ service ReleaseService {
     option (bytebase.v1.permission) = "bb.releases.create";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: releases.update
   rpc UpdateRelease(UpdateReleaseRequest) returns (Release) {
     option (google.api.http) = {
       patch: "/v1/{release.name=projects/*/releases/*}"
@@ -46,17 +50,20 @@ service ReleaseService {
     option (bytebase.v1.permission) = "bb.releases.update";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: releases.delete
   rpc DeleteRelease(DeleteReleaseRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=projects/*/releases/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.releases.delete";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: releases.undelete
   rpc UndeleteRelease(UndeleteReleaseRequest) returns (Release) {
     option (google.api.http) = {post: "/v1/{name=projects/*/releases/*}:undelete"};
     option (bytebase.v1.permission) = "bb.releases.undelete";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: releases.check
   rpc CheckRelease(CheckReleaseRequest) returns (CheckReleaseResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/releases:check"

--- a/proto/v1/v1/review_config_service.proto
+++ b/proto/v1/v1/review_config_service.proto
@@ -14,6 +14,7 @@ import "v1/org_policy_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service ReviewConfigService {
+  // Permissions required: reviewConfigs.create
   rpc CreateReviewConfig(CreateReviewConfigRequest) returns (ReviewConfig) {
     option (google.api.http) = {
       post: "/v1/reviewConfigs"
@@ -24,6 +25,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: reviewConfigs.list
   rpc ListReviewConfigs(ListReviewConfigsRequest) returns (ListReviewConfigsResponse) {
     option (google.api.http) = {get: "/v1/reviewConfigs"};
     option (google.api.method_signature) = "";
@@ -31,6 +33,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: reviewConfigs.get
   rpc GetReviewConfig(GetReviewConfigRequest) returns (ReviewConfig) {
     option (google.api.http) = {get: "/v1/{name=reviewConfigs/*}"};
     option (google.api.method_signature) = "name";
@@ -38,6 +41,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: reviewConfigs.update
   rpc UpdateReviewConfig(UpdateReviewConfigRequest) returns (ReviewConfig) {
     option (google.api.http) = {
       patch: "/v1/{review_config.name=reviewConfigs/*}"
@@ -48,6 +52,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: reviewConfigs.delete
   rpc DeleteReviewConfig(DeleteReviewConfigRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=reviewConfigs/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/review_config_service.proto
+++ b/proto/v1/v1/review_config_service.proto
@@ -14,7 +14,7 @@ import "v1/org_policy_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service ReviewConfigService {
-  // Permissions required: reviewConfigs.create
+  // Permissions required: bb.reviewConfigs.create
   rpc CreateReviewConfig(CreateReviewConfigRequest) returns (ReviewConfig) {
     option (google.api.http) = {
       post: "/v1/reviewConfigs"
@@ -25,7 +25,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: reviewConfigs.list
+  // Permissions required: bb.reviewConfigs.list
   rpc ListReviewConfigs(ListReviewConfigsRequest) returns (ListReviewConfigsResponse) {
     option (google.api.http) = {get: "/v1/reviewConfigs"};
     option (google.api.method_signature) = "";
@@ -33,7 +33,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: reviewConfigs.get
+  // Permissions required: bb.reviewConfigs.get
   rpc GetReviewConfig(GetReviewConfigRequest) returns (ReviewConfig) {
     option (google.api.http) = {get: "/v1/{name=reviewConfigs/*}"};
     option (google.api.method_signature) = "name";
@@ -41,7 +41,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: reviewConfigs.update
+  // Permissions required: bb.reviewConfigs.update
   rpc UpdateReviewConfig(UpdateReviewConfigRequest) returns (ReviewConfig) {
     option (google.api.http) = {
       patch: "/v1/{review_config.name=reviewConfigs/*}"
@@ -52,7 +52,7 @@ service ReviewConfigService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: reviewConfigs.delete
+  // Permissions required: bb.reviewConfigs.delete
   rpc DeleteReviewConfig(DeleteReviewConfigRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=reviewConfigs/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/revision_service.proto
+++ b/proto/v1/v1/revision_service.proto
@@ -13,18 +13,21 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RevisionService {
+  // Permissions required: revisions.list
   rpc ListRevisions(ListRevisionsRequest) returns (ListRevisionsResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*/databases/*}/revisions"};
     option (google.api.method_signature) = "parent";
     option (bytebase.v1.permission) = "bb.revisions.list";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: revisions.get
   rpc GetRevision(GetRevisionRequest) returns (Revision) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/revisions/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.revisions.get";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: revisions.create
   rpc CreateRevision(CreateRevisionRequest) returns (Revision) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*/databases/*}/revisions"
@@ -33,6 +36,7 @@ service RevisionService {
     option (bytebase.v1.permission) = "bb.revisions.create";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: revisions.create
   rpc BatchCreateRevisions(BatchCreateRevisionsRequest) returns (BatchCreateRevisionsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*/databases/*}/revisions:batchCreate"
@@ -41,6 +45,7 @@ service RevisionService {
     option (bytebase.v1.permission) = "bb.revisions.create";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: revisions.delete
   rpc DeleteRevision(DeleteRevisionRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=instances/*/databases/*/revisions/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/revision_service.proto
+++ b/proto/v1/v1/revision_service.proto
@@ -13,21 +13,23 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RevisionService {
-  // Permissions required: revisions.list
+  // Permissions required: bb.revisions.list
   rpc ListRevisions(ListRevisionsRequest) returns (ListRevisionsResponse) {
     option (google.api.http) = {get: "/v1/{parent=instances/*/databases/*}/revisions"};
     option (google.api.method_signature) = "parent";
     option (bytebase.v1.permission) = "bb.revisions.list";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: revisions.get
+
+  // Permissions required: bb.revisions.get
   rpc GetRevision(GetRevisionRequest) returns (Revision) {
     option (google.api.http) = {get: "/v1/{name=instances/*/databases/*/revisions/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.revisions.get";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: revisions.create
+
+  // Permissions required: bb.revisions.create
   rpc CreateRevision(CreateRevisionRequest) returns (Revision) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*/databases/*}/revisions"
@@ -36,7 +38,8 @@ service RevisionService {
     option (bytebase.v1.permission) = "bb.revisions.create";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: revisions.create
+
+  // Permissions required: bb.revisions.create
   rpc BatchCreateRevisions(BatchCreateRevisionsRequest) returns (BatchCreateRevisionsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=instances/*/databases/*}/revisions:batchCreate"
@@ -45,7 +48,8 @@ service RevisionService {
     option (bytebase.v1.permission) = "bb.revisions.create";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: revisions.delete
+
+  // Permissions required: bb.revisions.delete
   rpc DeleteRevision(DeleteRevisionRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=instances/*/databases/*/revisions/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/risk_service.proto
+++ b/proto/v1/v1/risk_service.proto
@@ -14,7 +14,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RiskService {
-  // Permissions required: risks.list
+  // Permissions required: bb.risks.list
   rpc ListRisks(ListRisksRequest) returns (ListRisksResponse) {
     option (google.api.http) = {get: "/v1/risks"};
     option (google.api.method_signature) = "";
@@ -22,7 +22,7 @@ service RiskService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: risks.create
+  // Permissions required: bb.risks.create
   rpc CreateRisk(CreateRiskRequest) returns (Risk) {
     option (google.api.http) = {
       post: "/v1/risks"
@@ -34,7 +34,7 @@ service RiskService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: risks.list
+  // Permissions required: bb.risks.list
   rpc GetRisk(GetRiskRequest) returns (Risk) {
     option (google.api.http) = {get: "/v1/{name=risks/*}"};
     option (google.api.method_signature) = "name";
@@ -42,7 +42,7 @@ service RiskService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: risks.update
+  // Permissions required: bb.risks.update
   rpc UpdateRisk(UpdateRiskRequest) returns (Risk) {
     option (google.api.http) = {
       patch: "/v1/{risk.name=risks/*}"
@@ -54,7 +54,7 @@ service RiskService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: risks.delete
+  // Permissions required: bb.risks.delete
   rpc DeleteRisk(DeleteRiskRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=risks/*}"};
     option (bytebase.v1.permission) = "bb.risks.delete";

--- a/proto/v1/v1/risk_service.proto
+++ b/proto/v1/v1/risk_service.proto
@@ -14,6 +14,7 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RiskService {
+  // Permissions required: risks.list
   rpc ListRisks(ListRisksRequest) returns (ListRisksResponse) {
     option (google.api.http) = {get: "/v1/risks"};
     option (google.api.method_signature) = "";
@@ -21,6 +22,7 @@ service RiskService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: risks.create
   rpc CreateRisk(CreateRiskRequest) returns (Risk) {
     option (google.api.http) = {
       post: "/v1/risks"
@@ -32,6 +34,7 @@ service RiskService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: risks.list
   rpc GetRisk(GetRiskRequest) returns (Risk) {
     option (google.api.http) = {get: "/v1/{name=risks/*}"};
     option (google.api.method_signature) = "name";
@@ -39,6 +42,7 @@ service RiskService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: risks.update
   rpc UpdateRisk(UpdateRiskRequest) returns (Risk) {
     option (google.api.http) = {
       patch: "/v1/{risk.name=risks/*}"
@@ -50,6 +54,7 @@ service RiskService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: risks.delete
   rpc DeleteRisk(DeleteRiskRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=risks/*}"};
     option (bytebase.v1.permission) = "bb.risks.delete";

--- a/proto/v1/v1/role_service.proto
+++ b/proto/v1/v1/role_service.proto
@@ -13,17 +13,20 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RoleService {
+  // Permissions required: roles.list
   rpc ListRoles(ListRolesRequest) returns (ListRolesResponse) {
     option (google.api.http) = {get: "/v1/roles"};
     option (bytebase.v1.permission) = "bb.roles.list";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: roles.get
   rpc GetRole(GetRoleRequest) returns (Role) {
     option (google.api.http) = {get: "/v1/{name=roles/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.roles.get";
     option (bytebase.v1.auth_method) = IAM;
   }
+  // Permissions required: roles.create
   rpc CreateRole(CreateRoleRequest) returns (Role) {
     option (google.api.http) = {
       post: "/v1/roles"
@@ -33,6 +36,7 @@ service RoleService {
     option (bytebase.v1.auth_method) = IAM;
     option (bytebase.v1.audit) = true;
   }
+  // Permissions required: roles.update
   rpc UpdateRole(UpdateRoleRequest) returns (Role) {
     option (google.api.http) = {
       patch: "/v1/{role.name=roles/*}"
@@ -43,6 +47,7 @@ service RoleService {
     option (bytebase.v1.auth_method) = IAM;
     option (bytebase.v1.audit) = true;
   }
+  // Permissions required: roles.delete
   rpc DeleteRole(DeleteRoleRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=roles/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/role_service.proto
+++ b/proto/v1/v1/role_service.proto
@@ -13,20 +13,22 @@ import "v1/annotation.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RoleService {
-  // Permissions required: roles.list
+  // Permissions required: bb.roles.list
   rpc ListRoles(ListRolesRequest) returns (ListRolesResponse) {
     option (google.api.http) = {get: "/v1/roles"};
     option (bytebase.v1.permission) = "bb.roles.list";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: roles.get
+
+  // Permissions required: bb.roles.get
   rpc GetRole(GetRoleRequest) returns (Role) {
     option (google.api.http) = {get: "/v1/{name=roles/*}"};
     option (google.api.method_signature) = "name";
     option (bytebase.v1.permission) = "bb.roles.get";
     option (bytebase.v1.auth_method) = IAM;
   }
-  // Permissions required: roles.create
+
+  // Permissions required: bb.roles.create
   rpc CreateRole(CreateRoleRequest) returns (Role) {
     option (google.api.http) = {
       post: "/v1/roles"
@@ -36,7 +38,8 @@ service RoleService {
     option (bytebase.v1.auth_method) = IAM;
     option (bytebase.v1.audit) = true;
   }
-  // Permissions required: roles.update
+
+  // Permissions required: bb.roles.update
   rpc UpdateRole(UpdateRoleRequest) returns (Role) {
     option (google.api.http) = {
       patch: "/v1/{role.name=roles/*}"
@@ -47,7 +50,8 @@ service RoleService {
     option (bytebase.v1.auth_method) = IAM;
     option (bytebase.v1.audit) = true;
   }
-  // Permissions required: roles.delete
+
+  // Permissions required: bb.roles.delete
   rpc DeleteRole(DeleteRoleRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=roles/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/rollout_service.proto
+++ b/proto/v1/v1/rollout_service.proto
@@ -14,7 +14,7 @@ import "v1/plan_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RolloutService {
-  // Permissions required: rollouts.get
+  // Permissions required: bb.rollouts.get
   rpc GetRollout(GetRolloutRequest) returns (Rollout) {
     option (google.api.http) = {get: "/v1/{name=projects/*/rollouts/*}"};
     option (google.api.method_signature) = "name";
@@ -22,7 +22,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: rollouts.list
+  // Permissions required: bb.rollouts.list
   rpc ListRollouts(ListRolloutsRequest) returns (ListRolloutsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/rollouts"};
     option (google.api.method_signature) = "parent";
@@ -30,8 +30,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
-  // Permissions required: rollouts.create
+  // Permissions required: bb.rollouts.create
   rpc CreateRollout(CreateRolloutRequest) returns (Rollout) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/rollouts"
@@ -43,7 +42,7 @@ service RolloutService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: rollouts.preview
+  // Permissions required: bb.rollouts.preview
   rpc PreviewRollout(PreviewRolloutRequest) returns (Rollout) {
     option (google.api.http) = {
       post: "/v1/{project=projects/*}:previewRollout"
@@ -54,7 +53,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: taskRuns.list
+  // Permissions required: bb.taskRuns.list
   rpc ListTaskRuns(ListTaskRunsRequest) returns (ListTaskRunsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/rollouts/*/stages/*/tasks/*}/taskRuns"};
     option (google.api.method_signature) = "parent";
@@ -62,7 +61,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: taskRuns.list
+  // Permissions required: bb.taskRuns.list
   rpc GetTaskRun(GetTaskRunRequest) returns (TaskRun) {
     option (google.api.http) = {get: "/v1/{name=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}"};
     option (google.api.method_signature) = "name";
@@ -70,7 +69,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: taskRuns.list
+  // Permissions required: bb.taskRuns.list
   rpc GetTaskRunLog(GetTaskRunLogRequest) returns (TaskRunLog) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}/log"};
     option (google.api.method_signature) = "parent";
@@ -78,7 +77,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: taskRuns.list
+  // Permissions required: bb.taskRuns.list
   rpc GetTaskRunSession(GetTaskRunSessionRequest) returns (TaskRunSession) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}/session"};
     option (google.api.method_signature) = "parent";
@@ -86,10 +85,6 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // BatchRunTasks creates task runs for the specified tasks.
-  // DataExport issue only allows the creator to run the task.
-  // Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
-  // Follow role-based rollout policy for the environment.
   // Permissions required: None
   rpc BatchRunTasks(BatchRunTasksRequest) returns (BatchRunTasksResponse) {
     option (google.api.http) = {
@@ -100,8 +95,6 @@ service RolloutService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // BatchSkipTasks skips the specified tasks.
-  // The access is the same as BatchRunTasks().
   // Permissions required: None
   rpc BatchSkipTasks(BatchSkipTasksRequest) returns (BatchSkipTasksResponse) {
     option (google.api.http) = {
@@ -112,8 +105,6 @@ service RolloutService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // BatchCancelTaskRuns cancels the specified task runs in batch.
-  // The access is the same as BatchRunTasks().
   // Permissions required: None
   rpc BatchCancelTaskRuns(BatchCancelTaskRunsRequest) returns (BatchCancelTaskRunsResponse) {
     option (google.api.http) = {
@@ -124,7 +115,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // Permissions required: taskRuns.list
+  // Permissions required: bb.taskRuns.list
   rpc PreviewTaskRunRollback(PreviewTaskRunRollbackRequest) returns (PreviewTaskRunRollbackResponse) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}:previewRollback"

--- a/proto/v1/v1/rollout_service.proto
+++ b/proto/v1/v1/rollout_service.proto
@@ -14,6 +14,7 @@ import "v1/plan_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service RolloutService {
+  // Permissions required: rollouts.get
   rpc GetRollout(GetRolloutRequest) returns (Rollout) {
     option (google.api.http) = {get: "/v1/{name=projects/*/rollouts/*}"};
     option (google.api.method_signature) = "name";
@@ -21,6 +22,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: rollouts.list
   rpc ListRollouts(ListRolloutsRequest) returns (ListRolloutsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*}/rollouts"};
     option (google.api.method_signature) = "parent";
@@ -29,6 +31,7 @@ service RolloutService {
   }
 
   // CreateRollout can be called multiple times with the same rollout.plan but different stage_id to promote rollout stages.
+  // Permissions required: rollouts.create
   rpc CreateRollout(CreateRolloutRequest) returns (Rollout) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/rollouts"
@@ -40,6 +43,7 @@ service RolloutService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: rollouts.preview
   rpc PreviewRollout(PreviewRolloutRequest) returns (Rollout) {
     option (google.api.http) = {
       post: "/v1/{project=projects/*}:previewRollout"
@@ -50,6 +54,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: taskRuns.list
   rpc ListTaskRuns(ListTaskRunsRequest) returns (ListTaskRunsResponse) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/rollouts/*/stages/*/tasks/*}/taskRuns"};
     option (google.api.method_signature) = "parent";
@@ -57,6 +62,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: taskRuns.list
   rpc GetTaskRun(GetTaskRunRequest) returns (TaskRun) {
     option (google.api.http) = {get: "/v1/{name=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}"};
     option (google.api.method_signature) = "name";
@@ -64,6 +70,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: taskRuns.list
   rpc GetTaskRunLog(GetTaskRunLogRequest) returns (TaskRunLog) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}/log"};
     option (google.api.method_signature) = "parent";
@@ -71,6 +78,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: taskRuns.list
   rpc GetTaskRunSession(GetTaskRunSessionRequest) returns (TaskRunSession) {
     option (google.api.http) = {get: "/v1/{parent=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}/session"};
     option (google.api.method_signature) = "parent";
@@ -82,6 +90,7 @@ service RolloutService {
   // DataExport issue only allows the creator to run the task.
   // Users with "bb.taskRuns.create" permission can run the task, e.g. Workspace Admin and DBA.
   // Follow role-based rollout policy for the environment.
+  // Permissions required: None
   rpc BatchRunTasks(BatchRunTasksRequest) returns (BatchRunTasksResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/rollouts/*/stages/*}/tasks:batchRun"
@@ -93,6 +102,7 @@ service RolloutService {
 
   // BatchSkipTasks skips the specified tasks.
   // The access is the same as BatchRunTasks().
+  // Permissions required: None
   rpc BatchSkipTasks(BatchSkipTasksRequest) returns (BatchSkipTasksResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/rollouts/*/stages/*}/tasks:batchSkip"
@@ -104,6 +114,7 @@ service RolloutService {
 
   // BatchCancelTaskRuns cancels the specified task runs in batch.
   // The access is the same as BatchRunTasks().
+  // Permissions required: None
   rpc BatchCancelTaskRuns(BatchCancelTaskRunsRequest) returns (BatchCancelTaskRunsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/rollouts/*/stages/*/tasks/*}/taskRuns:batchCancel"
@@ -113,6 +124,7 @@ service RolloutService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
+  // Permissions required: taskRuns.list
   rpc PreviewTaskRunRollback(PreviewTaskRunRollbackRequest) returns (PreviewTaskRunRollbackResponse) {
     option (google.api.http) = {
       post: "/v1/{name=projects/*/rollouts/*/stages/*/tasks/*/taskRuns/*}:previewRollback"

--- a/proto/v1/v1/setting_service.proto
+++ b/proto/v1/v1/setting_service.proto
@@ -18,7 +18,7 @@ import "v1/issue_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service SettingService {
-  // Permissions required: settings.list
+  // Permissions required: bb.settings.list
   rpc ListSettings(ListSettingsRequest) returns (ListSettingsResponse) {
     option (google.api.http) = {get: "/v1/settings"};
     option (google.api.method_signature) = "";
@@ -26,7 +26,7 @@ service SettingService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: settings.get
+  // Permissions required: bb.settings.get
   rpc GetSetting(GetSettingRequest) returns (Setting) {
     option (google.api.http) = {get: "/v1/{name=settings/*}"};
     option (google.api.method_signature) = "name";
@@ -34,7 +34,7 @@ service SettingService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: settings.set
+  // Permissions required: bb.settings.set
   rpc UpdateSetting(UpdateSettingRequest) returns (Setting) {
     option (google.api.http) = {
       patch: "/v1/{setting.name=settings/*}"

--- a/proto/v1/v1/setting_service.proto
+++ b/proto/v1/v1/setting_service.proto
@@ -18,6 +18,7 @@ import "v1/issue_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service SettingService {
+  // Permissions required: settings.list
   rpc ListSettings(ListSettingsRequest) returns (ListSettingsResponse) {
     option (google.api.http) = {get: "/v1/settings"};
     option (google.api.method_signature) = "";
@@ -25,6 +26,7 @@ service SettingService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: settings.get
   rpc GetSetting(GetSettingRequest) returns (Setting) {
     option (google.api.http) = {get: "/v1/{name=settings/*}"};
     option (google.api.method_signature) = "name";
@@ -32,6 +34,7 @@ service SettingService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: settings.set
   rpc UpdateSetting(UpdateSettingRequest) returns (Setting) {
     option (google.api.http) = {
       patch: "/v1/{setting.name=settings/*}"

--- a/proto/v1/v1/sheet_service.proto
+++ b/proto/v1/v1/sheet_service.proto
@@ -14,7 +14,7 @@ import "v1/common.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service SheetService {
-  // Permissions required: sheets.create
+  // Permissions required: bb.sheets.create
   rpc CreateSheet(CreateSheetRequest) returns (Sheet) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/sheets"
@@ -25,7 +25,7 @@ service SheetService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: sheets.create
+  // Permissions required: bb.sheets.create
   rpc BatchCreateSheets(BatchCreateSheetsRequest) returns (BatchCreateSheetsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/sheets:batchCreate"
@@ -35,7 +35,7 @@ service SheetService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: sheets.get
+  // Permissions required: bb.sheets.get
   rpc GetSheet(GetSheetRequest) returns (Sheet) {
     option (google.api.http) = {get: "/v1/{name=projects/*/sheets/*}"};
     option (google.api.method_signature) = "name";
@@ -43,7 +43,7 @@ service SheetService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: sheets.update
+  // Permissions required: bb.sheets.update
   rpc UpdateSheet(UpdateSheetRequest) returns (Sheet) {
     option (google.api.http) = {
       patch: "/v1/{sheet.name=projects/*/sheets/*}"

--- a/proto/v1/v1/sheet_service.proto
+++ b/proto/v1/v1/sheet_service.proto
@@ -14,6 +14,7 @@ import "v1/common.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service SheetService {
+  // Permissions required: sheets.create
   rpc CreateSheet(CreateSheetRequest) returns (Sheet) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/sheets"
@@ -24,6 +25,7 @@ service SheetService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: sheets.create
   rpc BatchCreateSheets(BatchCreateSheetsRequest) returns (BatchCreateSheetsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*}/sheets:batchCreate"
@@ -33,6 +35,7 @@ service SheetService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: sheets.get
   rpc GetSheet(GetSheetRequest) returns (Sheet) {
     option (google.api.http) = {get: "/v1/{name=projects/*/sheets/*}"};
     option (google.api.method_signature) = "name";
@@ -40,6 +43,7 @@ service SheetService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: sheets.update
   rpc UpdateSheet(UpdateSheetRequest) returns (Sheet) {
     option (google.api.http) = {
       patch: "/v1/{sheet.name=projects/*/sheets/*}"

--- a/proto/v1/v1/sql_service.proto
+++ b/proto/v1/v1/sql_service.proto
@@ -16,6 +16,7 @@ import "v1/database_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service SQLService {
+  // Permissions required: databases.get
   rpc Query(QueryRequest) returns (QueryResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:query"
@@ -31,6 +32,7 @@ service SQLService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: sql.admin
   rpc AdminExecute(stream AdminExecuteRequest) returns (stream AdminExecuteResponse) {
     // GRPC streaming / websocket requires GET method instead of POST.
     option (google.api.http) = {get: "/v1:adminExecute"};
@@ -40,6 +42,7 @@ service SQLService {
   }
 
   // SearchQueryHistories searches query histories for the caller.
+  // Permissions required: None
   rpc SearchQueryHistories(SearchQueryHistoriesRequest) returns (SearchQueryHistoriesResponse) {
     option (google.api.http) = {
       post: "/v1/queryHistories:search"
@@ -48,6 +51,7 @@ service SQLService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
+  // Permissions required: databases.get
   rpc Export(ExportRequest) returns (ExportResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:export"
@@ -71,6 +75,7 @@ service SQLService {
     option (bytebase.v1.audit) = true;
   }
 
+  // Permissions required: databases.check
   rpc Check(CheckRequest) returns (CheckResponse) {
     option (google.api.http) = {
       post: "/v1/sql/check"
@@ -80,6 +85,7 @@ service SQLService {
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: None
   rpc Pretty(PrettyRequest) returns (PrettyResponse) {
     option (google.api.http) = {
       post: "/v1/sql/pretty"
@@ -88,6 +94,7 @@ service SQLService {
     option (bytebase.v1.allow_without_credential) = true;
   }
 
+  // Permissions required: None
   rpc DiffMetadata(DiffMetadataRequest) returns (DiffMetadataResponse) {
     option (google.api.http) = {
       post: "/v1/schemaDesign:diffMetadata"
@@ -97,6 +104,7 @@ service SQLService {
     // This is a util method requiring no authentication thus no authorization.
   }
 
+  // Permissions required: None
   rpc AICompletion(AICompletionRequest) returns (AICompletionResponse) {
     option (google.api.http) = {
       post: "/v1/sql/aiCompletion"

--- a/proto/v1/v1/sql_service.proto
+++ b/proto/v1/v1/sql_service.proto
@@ -16,7 +16,7 @@ import "v1/database_service.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service SQLService {
-  // Permissions required: databases.get
+  // Permissions required: bb.databases.get
   rpc Query(QueryRequest) returns (QueryResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:query"
@@ -32,7 +32,7 @@ service SQLService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: sql.admin
+  // Permissions required: bb.sql.admin
   rpc AdminExecute(stream AdminExecuteRequest) returns (stream AdminExecuteResponse) {
     // GRPC streaming / websocket requires GET method instead of POST.
     option (google.api.http) = {get: "/v1:adminExecute"};
@@ -51,7 +51,7 @@ service SQLService {
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
-  // Permissions required: databases.get
+  // Permissions required: bb.databases.get
   rpc Export(ExportRequest) returns (ExportResponse) {
     option (google.api.http) = {
       post: "/v1/{name=instances/*/databases/*}:export"
@@ -75,7 +75,7 @@ service SQLService {
     option (bytebase.v1.audit) = true;
   }
 
-  // Permissions required: databases.check
+  // Permissions required: bb.databases.check
   rpc Check(CheckRequest) returns (CheckResponse) {
     option (google.api.http) = {
       post: "/v1/sql/check"

--- a/proto/v1/v1/subscription_service.proto
+++ b/proto/v1/v1/subscription_service.proto
@@ -21,7 +21,7 @@ service SubscriptionService {
     option (bytebase.v1.allow_without_credential) = true;
   }
 
-  // Permissions required: settings.set
+  // Permissions required: bb.settings.set
   rpc UpdateSubscription(UpdateSubscriptionRequest) returns (Subscription) {
     option (google.api.http) = {
       patch: "/v1/subscription"

--- a/proto/v1/v1/subscription_service.proto
+++ b/proto/v1/v1/subscription_service.proto
@@ -14,12 +14,14 @@ service SubscriptionService {
   // GetSubscription returns the current subscription.
   // If there is no license, we will return a free plan subscription without expiration time.
   // If there is expired license, we will return a free plan subscription with the expiration time of the expired license.
+  // Permissions required: None
   rpc GetSubscription(GetSubscriptionRequest) returns (Subscription) {
     option (google.api.http) = {get: "/v1/subscription"};
     option (google.api.method_signature) = "";
     option (bytebase.v1.allow_without_credential) = true;
   }
 
+  // Permissions required: settings.set
   rpc UpdateSubscription(UpdateSubscriptionRequest) returns (Subscription) {
     option (google.api.http) = {
       patch: "/v1/subscription"

--- a/proto/v1/v1/user_service.proto
+++ b/proto/v1/v1/user_service.proto
@@ -17,6 +17,7 @@ option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 service UserService {
   // Get the user.
   // Any authenticated user can get the user.
+  // Permissions required: users.get
   rpc GetUser(GetUserRequest) returns (User) {
     option (google.api.http) = {get: "/v1/{name=users/*}"};
     option (google.api.method_signature) = "name";
@@ -25,12 +26,14 @@ service UserService {
 
   // Get the users in batch.
   // Any authenticated user can batch get users.
+  // Permissions required: users.get
   rpc BatchGetUsers(BatchGetUsersRequest) returns (BatchGetUsersResponse) {
     option (google.api.http) = {get: "/v1/users:batchGet"};
     option (bytebase.v1.auth_method) = CUSTOM;
   }
 
   // Get the current authenticated user.
+  // Permissions required: None
   rpc GetCurrentUser(google.protobuf.Empty) returns (User) {
     option (google.api.http) = {get: "/v1/users/me"};
     option (bytebase.v1.allow_without_credential) = true;
@@ -39,6 +42,7 @@ service UserService {
 
   // List all users.
   // Any authenticated user can list users.
+  // Permissions required: users.list
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option (google.api.http) = {get: "/v1/users"};
     option (google.api.method_signature) = "parent";
@@ -48,6 +52,7 @@ service UserService {
   // Create a user.
   // When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
   // Otherwise, any unauthenticated user can create a user.
+  // Permissions required: users.create
   rpc CreateUser(CreateUserRequest) returns (User) {
     option (google.api.http) = {
       post: "/v1/users"
@@ -60,6 +65,7 @@ service UserService {
   }
 
   // Only the user itself and the user with bb.users.update permission on the workspace can update the user.
+  // Permissions required: users.update
   rpc UpdateUser(UpdateUserRequest) returns (User) {
     option (google.api.http) = {
       patch: "/v1/{user.name=users/*}"
@@ -72,6 +78,7 @@ service UserService {
 
   // Only the user with bb.users.delete permission on the workspace can delete the user.
   // The last remaining workspace admin cannot be deleted.
+  // Permissions required: users.delete
   rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=users/*}"};
     option (google.api.method_signature) = "name";
@@ -80,6 +87,7 @@ service UserService {
   }
 
   // Only the user with bb.users.undelete permission on the workspace can undelete the user.
+  // Permissions required: users.undelete
   rpc UndeleteUser(UndeleteUserRequest) returns (User) {
     option (google.api.http) = {
       post: "/v1/{name=users/*}:undelete"

--- a/proto/v1/v1/user_service.proto
+++ b/proto/v1/v1/user_service.proto
@@ -17,7 +17,7 @@ option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 service UserService {
   // Get the user.
   // Any authenticated user can get the user.
-  // Permissions required: users.get
+  // Permissions required: bb.users.get
   rpc GetUser(GetUserRequest) returns (User) {
     option (google.api.http) = {get: "/v1/{name=users/*}"};
     option (google.api.method_signature) = "name";
@@ -26,7 +26,7 @@ service UserService {
 
   // Get the users in batch.
   // Any authenticated user can batch get users.
-  // Permissions required: users.get
+  // Permissions required: bb.users.get
   rpc BatchGetUsers(BatchGetUsersRequest) returns (BatchGetUsersResponse) {
     option (google.api.http) = {get: "/v1/users:batchGet"};
     option (bytebase.v1.auth_method) = CUSTOM;
@@ -42,7 +42,7 @@ service UserService {
 
   // List all users.
   // Any authenticated user can list users.
-  // Permissions required: users.list
+  // Permissions required: bb.users.list
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option (google.api.http) = {get: "/v1/users"};
     option (google.api.method_signature) = "parent";
@@ -52,7 +52,7 @@ service UserService {
   // Create a user.
   // When Disallow Signup is enabled, only the caller with bb.users.create on the workspace can create a user.
   // Otherwise, any unauthenticated user can create a user.
-  // Permissions required: users.create
+  // Permissions required: bb.users.create
   rpc CreateUser(CreateUserRequest) returns (User) {
     option (google.api.http) = {
       post: "/v1/users"
@@ -65,7 +65,7 @@ service UserService {
   }
 
   // Only the user itself and the user with bb.users.update permission on the workspace can update the user.
-  // Permissions required: users.update
+  // Permissions required: bb.users.update
   rpc UpdateUser(UpdateUserRequest) returns (User) {
     option (google.api.http) = {
       patch: "/v1/{user.name=users/*}"
@@ -78,7 +78,7 @@ service UserService {
 
   // Only the user with bb.users.delete permission on the workspace can delete the user.
   // The last remaining workspace admin cannot be deleted.
-  // Permissions required: users.delete
+  // Permissions required: bb.users.delete
   rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=users/*}"};
     option (google.api.method_signature) = "name";
@@ -87,7 +87,7 @@ service UserService {
   }
 
   // Only the user with bb.users.undelete permission on the workspace can undelete the user.
-  // Permissions required: users.undelete
+  // Permissions required: bb.users.undelete
   rpc UndeleteUser(UndeleteUserRequest) returns (User) {
     option (google.api.http) = {
       post: "/v1/{name=users/*}:undelete"

--- a/proto/v1/v1/worksheet_service.proto
+++ b/proto/v1/v1/worksheet_service.proto
@@ -14,6 +14,7 @@ option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service WorksheetService {
   // Create a personal worksheet used in SQL Editor.
+  // Permissions required: None
   rpc CreateWorksheet(CreateWorksheetRequest) returns (Worksheet) {
     option (google.api.http) = {
       post: "/v1/worksheets"
@@ -28,6 +29,7 @@ service WorksheetService {
   // - they are the creator of the worksheet;
   // - they have bb.worksheets.get permission on the workspace;
   // - the sheet is shared with them with PROJECT_READ and PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+  // Permissions required: None
   rpc GetWorksheet(GetWorksheetRequest) returns (Worksheet) {
     option (google.api.http) = {get: "/v1/{name=worksheets/*}"};
     option (google.api.method_signature) = "name";
@@ -37,6 +39,7 @@ service WorksheetService {
   // Search for worksheets.
   // This is used for finding my worksheets or worksheets shared by other people.
   // The sheet accessibility is the same as GetWorksheet().
+  // Permissions required: None
   rpc SearchWorksheets(SearchWorksheetsRequest) returns (SearchWorksheetsResponse) {
     option (google.api.http) = {
       post: "/v1/worksheets:search"
@@ -50,6 +53,7 @@ service WorksheetService {
   // - they are the creator of the worksheet;
   // - they have bb.worksheets.manage permission on the workspace;
   // - the sheet is shared with them with PROJECT_WRITE visibility, and they have bb.projects.get permission on the project.
+  // Permissions required: None
   rpc UpdateWorksheet(UpdateWorksheetRequest) returns (Worksheet) {
     option (google.api.http) = {
       patch: "/v1/{worksheet.name=worksheets/*}"
@@ -61,6 +65,7 @@ service WorksheetService {
 
   // Update the organizer of a worksheet.
   // The access is the same as UpdateWorksheet method.
+  // Permissions required: None
   rpc UpdateWorksheetOrganizer(UpdateWorksheetOrganizerRequest) returns (WorksheetOrganizer) {
     option (google.api.http) = {
       patch: "/v1/{organizer.worksheet=worksheets/*}/organizer"
@@ -72,6 +77,7 @@ service WorksheetService {
 
   // Delete a worksheet.
   // The access is the same as UpdateWorksheet method.
+  // Permissions required: None
   rpc DeleteWorksheet(DeleteWorksheetRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/v1/{name=worksheets/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/v1/v1/workspace_service.proto
+++ b/proto/v1/v1/workspace_service.proto
@@ -9,14 +9,14 @@ import "v1/iam_policy.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service WorkspaceService {
-  // Permissions required: workspaces.getIamPolicy
+  // Permissions required: bb.workspaces.getIamPolicy
   rpc GetIamPolicy(GetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {get: "/v1/{resource=workspaces/*}:getIamPolicy"};
     option (bytebase.v1.permission) = "bb.workspaces.getIamPolicy";
     option (bytebase.v1.auth_method) = IAM;
   }
 
-  // Permissions required: workspaces.setIamPolicy
+  // Permissions required: bb.workspaces.setIamPolicy
   rpc SetIamPolicy(SetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {
       post: "/v1/{resource=workspaces/*}:setIamPolicy"

--- a/proto/v1/v1/workspace_service.proto
+++ b/proto/v1/v1/workspace_service.proto
@@ -9,12 +9,14 @@ import "v1/iam_policy.proto";
 option go_package = "github.com/bytebase/bytebase/proto/generated-go/v1";
 
 service WorkspaceService {
+  // Permissions required: workspaces.getIamPolicy
   rpc GetIamPolicy(GetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {get: "/v1/{resource=workspaces/*}:getIamPolicy"};
     option (bytebase.v1.permission) = "bb.workspaces.getIamPolicy";
     option (bytebase.v1.auth_method) = IAM;
   }
 
+  // Permissions required: workspaces.setIamPolicy
   rpc SetIamPolicy(SetIamPolicyRequest) returns (IamPolicy) {
     option (google.api.http) = {
       post: "/v1/{resource=workspaces/*}:setIamPolicy"


### PR DESCRIPTION
This is regarding issue: [BYT-7365] https://linear.app/bytebase/issue/BYT-7365

The goal of this PR is to:

- add documentation to the proto/v1/v1 .proto files such that each rpc call has documentation wrt which permissions are necessary to call it.
- run `buf generate` to update the derived data including openapi.yaml, as https://raw.githubusercontent.com/bytebase/bytebase/main/proto/gen/grpc-doc/openapi.yaml is the source of truth for: https://api.bytebase.com/

Also added a README outlining the convention used for this permission documentation

I wasn't sure of our procedure for calling 'buf generate' so did it locally and included the result in the PR, sorry is this is the totally wrong thing :-)

N.B.: I also didn't know which branch to target, so I'm targeting main for now.  The main reason for creating this PR is to discuss changes with Danny before moving forward.