### PR TITLE
chore(migrator): remove redundant log message in column default migrator

### DIFF
--- a/backend/runner/migrator/column_default_migrator.go
+++ b/backend/runner/migrator/column_default_migrator.go
@@ -44,7 +44,6 @@ func (m *ColumnDefaultMigrator) Run(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		select {
 		case <-ticker.C:
-			slog.Info("Running column default value migrator...")
 			if err := m.migrate(ctx); err != nil {
 				slog.Error("Failed to run column default value migrator", log.BBError(err))
 			}


### PR DESCRIPTION
Remove the info log "Running column default value migrator..." from the
ticker loop to reduce log noise during migration runs. This change helps
keep logs cleaner and focuses on error reporting only.