### PR TITLE
fix(pg-parser): handle nil index metadata in DropIndexStmt

### DIFF
--- a/backend/plugin/parser/pg/resource_change.go
+++ b/backend/plugin/parser/pg/resource_change.go
@@ -241,6 +241,9 @@ func collectResourceChanges(database string, searchPath []string, node ast.Node,
 				)
 			} else {
 				schema, indexMetadata := databaseMetadata.SearchIndex(searchPath, index.Name)
+				if indexMetadata == nil {
+					continue
+				}
 				tableMetadata := indexMetadata.GetTableProto()
 				if tableMetadata == nil {
 					continue


### PR DESCRIPTION
Adds a nil check for  when processing  statements
in the PostgreSQL parser. This prevents a nil pointer dereference panic that occurs when  returns nil for a non-existent index, and  is subsequently called on the nil object.