### PR TITLE
refactor(dependency): remove vue-query dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,6 @@
     "@connectrpc/connect-web": "^2.0.2",
     "@markdoc/markdoc": "0.5.2",
     "@soerenmartius/vue3-clipboard": "0.1.2",
-    "@tanstack/vue-query": "^5.79.2",
     "@tanstack/vue-table": "8.21.3",
     "@vueuse/core": "12.8.2",
     "axios": "1.9.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -46,9 +46,6 @@ importers:
       '@soerenmartius/vue3-clipboard':
         specifier: 0.1.2
         version: 0.1.2
-      '@tanstack/vue-query':
-        specifier: ^5.79.2
-        version: 5.79.2(vue@3.5.16(typescript@5.8.3))
       '@tanstack/vue-table':
         specifier: 8.21.3
         version: 8.21.3(vue@3.5.16(typescript@5.8.3))
@@ -2056,25 +2053,9 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
-  '@tanstack/match-sorter-utils@8.19.4':
-    resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
-    engines: {node: '>=12'}
-
-  '@tanstack/query-core@5.79.2':
-    resolution: {integrity: sha512-kr+KQrBuqd6495eP9S41BoftFI1H50XA9O+6FmbnTx/Te6bjiq1mj8rt9rJjW3YZSO2aaUNUres0TWesJW1j1g==}
-
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
-
-  '@tanstack/vue-query@5.79.2':
-    resolution: {integrity: sha512-eJ7pIt+E3+IYhSWoIj1HSYeG3ABka/n63/aD6ZfTm5bAKVxyll43OET+UXp2GTC0C1U3dNDbky/D2Lac6xMfxQ==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.2
-      vue: ^2.6.0 || ^3.3.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
 
   '@tanstack/vue-table@8.21.3':
     resolution: {integrity: sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==}
@@ -7502,21 +7483,7 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.8.3))
 
-  '@tanstack/match-sorter-utils@8.19.4':
-    dependencies:
-      remove-accents: 0.5.0
-
-  '@tanstack/query-core@5.79.2': {}
-
   '@tanstack/table-core@8.21.3': {}
-
-  '@tanstack/vue-query@5.79.2(vue@3.5.16(typescript@5.8.3))':
-    dependencies:
-      '@tanstack/match-sorter-utils': 8.19.4
-      '@tanstack/query-core': 5.79.2
-      '@vue/devtools-api': 6.6.4
-      vue: 3.5.16(typescript@5.8.3)
-      vue-demi: 0.14.10(vue@3.5.16(typescript@5.8.3))
 
   '@tanstack/vue-table@8.21.3(vue@3.5.16(typescript@5.8.3))':
     dependencies:


### PR DESCRIPTION
## Summary

Removes `@tanstack/vue-query` dependency (used in only one component) and fixes schema editor preview not updating when columns are modified.

## Problem

  1. Schema editor preview wasn't updating when users changed column properties
  2. BigInt serialization errors after ConnectRPC migration (int64 → BigInt)
  3. Unnecessary dependency for a single component

## Solution

  - Replaced `useQuery` with simple Vue reactive implementation
  - Fixed reactivity to ensure preview updates with latest metadata
  - Eliminated BigInt serialization issues