### PR TITLE
feat: use simple input block for PostgreSQL column default in schema editor

### DIFF
--- a/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/DefaultValueCell.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/DefaultValueCell.vue
@@ -1,10 +1,12 @@
 <template>
+  <!-- TODO: When all engines migrate to simplified input, replace NInput with InlineInput component -->
   <NInput
     v-if="useSimpleInput"
     ref="inputRef"
     :value="postgresInputValue"
     :placeholder="postgresPlaceholder"
     :disabled="disabled"
+    :style="simpleInputStyle"
     @focus="focused = true"
     @blur="focused = false"
     @update:value="handlePostgresInput"
@@ -133,6 +135,26 @@ const postgresInputValue = computed(() => {
 
 const postgresPlaceholder = computed(() => {
   return t("schema-editor.default.postgres-placeholder");
+});
+
+// TODO: This styling mimics InlineInput component. When all engines use simplified input,
+// replace NInput + simpleInputStyle with InlineInput component directly
+const simpleInputStyle = computed(() => {
+  const style: CSSProperties = {
+    cursor: "default",
+    "--n-color": "transparent",
+    "--n-color-disabled": "transparent",
+    "--n-padding-left": "6px",
+    "--n-padding-right": "4px",
+    "--n-text-color-disabled": "rgb(var(--color-main))",
+  };
+  const border = focused.value
+    ? "1px solid rgb(var(--color-control-border))"
+    : "none";
+  style["--n-border"] = border;
+  style["--n-border-disabled"] = border;
+
+  return style;
 });
 
 const options = computed((): DefaultValueSelectOption[] => {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2062,7 +2062,8 @@
       "no-default": "No default",
       "expression": "Expression",
       "null": "NULL",
-      "value": "Value"
+      "value": "Value",
+      "postgres-placeholder": "Enter default expression (e.g., 'hello', 42, now(), nextval('seq')) or leave empty for no default"
     },
     "message": {
       "invalid-schema-name": "Invalid schema name",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2062,7 +2062,8 @@
       "no-default": "Sin valor predeterminado",
       "expression": "Expresión",
       "null": "NULL",
-      "value": "Valor"
+      "value": "Valor",
+      "postgres-placeholder": "Ingrese una expresión predeterminada (por ejemplo, 'hola', 42, now(), nextval('seq')) o déjela vacía si no hay una expresión predeterminada"
     },
     "message": {
       "invalid-schema-name": "Nombre de esquema inválido",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2062,7 +2062,8 @@
       "no-default": "デフォルト値なし",
       "expression": "式",
       "null": "NULL",
-      "value": "値"
+      "value": "値",
+      "postgres-placeholder": "デフォルトの式（例：'hello'、42、now()、nextval('seq')）を入力するか、デフォルトがない場合は空白のままにしてください"
     },
     "message": {
       "invalid-schema-name": "無効なスキーマ名",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2062,7 +2062,8 @@
       "no-default": "Không mặc định",
       "expression": "Biểu thức",
       "null": "NULL",
-      "value": "Giá trị"
+      "value": "Giá trị",
+      "postgres-placeholder": "Nhập biểu thức mặc định (ví dụ: 'hello', 42, now(), nextval('seq')) hoặc để trống nếu không có biểu thức mặc định"
     },
     "message": {
       "invalid-schema-name": "Tên lược đồ không hợp lệ",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2062,7 +2062,8 @@
       "no-default": "无默认值",
       "expression": "表达式",
       "null": "NULL",
-      "value": "值"
+      "value": "值",
+      "postgres-placeholder": "输入默认表达式（例如，'hello'、42、now()、nextval('seq')）或留空表示无默认值"
     },
     "message": {
       "invalid-schema-name": "无效的 Schema 名称",


### PR DESCRIPTION
 Replaces the dropdown-based default value selector with a simple text input for PostgreSQL columns in the schema editor.

  Changes:
  - Replace 3-option dropdown (NULL/expression/value) with single input field for PostgreSQL
  - Use column.defaultString to store PostgreSQL default expressions
  - Add universal useSimpleInput computed property for future engine migrations
  - Fix BigInt serialization error in preview pane
  - Fix preview updates when column defaults are modified
  - Add PostgreSQL-specific placeholder text via i18n

  Benefits:
  - Simplified UX for PostgreSQL users - no need to select default type first
  - Prepares codebase for migrating other engines to simplified input
  - Resolves schema editor hanging issues caused by BigInt serialization
  
  
  PostgreSQL:
  
![CleanShot X 2025-07-01 11 03 38](https://github.com/user-attachments/assets/84f135b7-05b7-4869-a15a-b8577cbbec7f)
![CleanShot X 2025-07-01 11 03 35](https://github.com/user-attachments/assets/36046a76-fa01-4dd7-87d6-9572c9d6520a)


Part of BYT-7410