### PR TITLE
fix: visibility enum

### DIFF
--- a/frontend/src/store/modules/v1/worksheet.ts
+++ b/frontend/src/store/modules/v1/worksheet.ts
@@ -204,7 +204,7 @@ export const useWorkSheetStore = defineStore("worksheet_v1", () => {
   const fetchSharedWorksheetList = async () => {
     const me = useCurrentUserV1();
     const request = create(SearchWorksheetsRequestSchema, {
-      filter: `creator != "users/${me.value.email}" && visibility in ["PROJECT_READ","PROJECT_WRITE"]`,
+      filter: `creator != "users/${me.value.email}" && visibility in ["VISIBILITY_PROJECT_READ","VISIBILITY_PROJECT_WRITE"]`,
     });
     const response =
       await worksheetServiceClientConnect.searchWorksheets(request);


### PR DESCRIPTION
Close BYT-7604.


protobuf-es removes the VISIBILITY prefix, causing enum string mismatches between the frontend and backend. This is unfortunate. I am thinking if we should use enum numbers to avoid this issue.
```
If all enum values share a prefix that corresponds with the enum's name, the prefix is dropped from all enum value names. For example, given the following enum declaration:

enum PhoneType {
  PHONE_TYPE_UNSPECIFIED = 0;
  PHONE_TYPE_MOBILE = 1;
  PHONE_TYPE_LAND_LINE = 2;
}
Protobuf-ES generates the following TypeScript enum:

/**
 * @generated from enum example.PhoneType
 */
export enum PhoneType {
  UNSPECIFIED = 0,
  MOBILE = 1,
  LAND_LINE = 2,
}
```