### PR TITLE
feat(schema-editor): unify default value input for Postgres and MySQL

### DIFF
--- a/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/DefaultValueCell.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/DefaultValueCell.vue
@@ -3,13 +3,13 @@
   <NInput
     v-if="useSimpleInput"
     ref="inputRef"
-    :value="postgresInputValue"
-    :placeholder="postgresPlaceholder"
+    :value="simpleInputValue"
+    :placeholder="simpleInputPlaceholder"
     :disabled="disabled"
     :style="simpleInputStyle"
     @focus="focused = true"
     @blur="focused = false"
-    @update:value="handlePostgresInput"
+    @update:value="handleSimpleInput"
   />
 
   <NDropdown
@@ -123,18 +123,22 @@ const placeholder = computed(() => {
   return getColumnDefaultValuePlaceholder(props.column);
 });
 
-// Computed property for engines that use simple input (currently PostgreSQL)
+// Computed property for engines that use simple input (PostgreSQL and MySQL)
 const useSimpleInput = computed(() => {
-  return props.engine === Engine.POSTGRES;
+  return props.engine === Engine.POSTGRES || props.engine === Engine.MYSQL;
 });
 
-const postgresInputValue = computed(() => {
+const simpleInputValue = computed(() => {
   // For PostgreSQL, we use defaultString field which contains the schema-qualified expression
-  return props.column.defaultString || "";
+  // For MySQL, we also use defaultString for now (until proto types are updated)
+  if (props.engine === Engine.POSTGRES || props.engine === Engine.MYSQL) {
+    return props.column.defaultString || "";
+  }
+  return "";
 });
 
-const postgresPlaceholder = computed(() => {
-  return t("schema-editor.default.postgres-placeholder");
+const simpleInputPlaceholder = computed(() => {
+  return t("schema-editor.default.placeholder");
 });
 
 // TODO: This styling mimics InlineInput component. When all engines use simplified input,
@@ -217,8 +221,8 @@ const handleInput = (value: string) => {
   emit("input", value);
 };
 
-const handlePostgresInput = (value: string) => {
-  // For PostgreSQL, emit the value for the input handler
+const handleSimpleInput = (value: string) => {
+  // Emit the value for the input handler
   emit("input", value);
 
   // Also emit a select event to maintain consistency with the existing API
@@ -227,7 +231,7 @@ const handlePostgresInput = (value: string) => {
     value: {
       hasDefault: !!value.trim(),
       defaultNull: false,
-      defaultString: value.trim(), // For PostgreSQL, store in defaultString
+      defaultString: value.trim(), // Both PostgreSQL and MySQL use defaultString for now
       defaultExpression: "",
     },
   };

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2077,7 +2077,7 @@
       "expression": "Expression",
       "null": "NULL",
       "value": "Value",
-      "postgres-placeholder": "Enter default expression (e.g., 'hello', 42, now(), nextval('seq')) or leave empty for no default"
+      "placeholder": "Enter default value or leave empty for no default"
     },
     "message": {
       "invalid-schema-name": "Invalid schema name",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2077,7 +2077,7 @@
       "expression": "Expresión",
       "null": "NULL",
       "value": "Valor",
-      "postgres-placeholder": "Ingrese una expresión predeterminada (por ejemplo, 'hola', 42, now(), nextval('seq')) o déjela vacía si no hay una expresión predeterminada"
+      "placeholder": "Introduzca un valor predeterminado o déjelo vacío si no hay ningún valor predeterminado"
     },
     "message": {
       "invalid-schema-name": "Nombre de esquema inválido",
@@ -2307,8 +2307,8 @@
       "request": "Pedido",
       "response": "Respuesta",
       "status": "Estatus",
-      "service-data": "Datos del Servicio",
-      "latency": "Estado latente"
+      "latency": "Estado latente",
+      "service-data": "Datos del Servicio"
     },
     "advanced-search": {
       "scope": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2077,7 +2077,7 @@
       "expression": "式",
       "null": "NULL",
       "value": "値",
-      "postgres-placeholder": "デフォルトの式（例：'hello'、42、now()、nextval('seq')）を入力するか、デフォルトがない場合は空白のままにしてください"
+      "placeholder": "デフォルト値を入力するか、デフォルト値がない場合は空白のままにします"
     },
     "message": {
       "invalid-schema-name": "無効なスキーマ名",
@@ -2307,8 +2307,8 @@
       "request": "リクエスト",
       "response": "応答",
       "status": "ポジション",
-      "service-data": "サービスデータ",
-      "latency": "遅延"
+      "latency": "遅延",
+      "service-data": "サービスデータ"
     },
     "advanced-search": {
       "scope": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2077,7 +2077,7 @@
       "expression": "Biểu thức",
       "null": "NULL",
       "value": "Giá trị",
-      "postgres-placeholder": "Nhập biểu thức mặc định (ví dụ: 'hello', 42, now(), nextval('seq')) hoặc để trống nếu không có biểu thức mặc định"
+      "placeholder": "Nhập giá trị mặc định hoặc để trống nếu không có giá trị mặc định"
     },
     "message": {
       "invalid-schema-name": "Tên lược đồ không hợp lệ",
@@ -2307,8 +2307,8 @@
       "request": "Yêu cầu",
       "response": "Phản hồi",
       "status": "Trạng thái",
-      "service-data": "Dữ liệu dịch vụ",
-      "latency": "Độ trễ"
+      "latency": "Độ trễ",
+      "service-data": "Dữ liệu dịch vụ"
     },
     "advanced-search": {
       "scope": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2077,7 +2077,7 @@
       "expression": "表达式",
       "null": "NULL",
       "value": "值",
-      "postgres-placeholder": "输入默认表达式（例如，'hello'、42、now()、nextval('seq')）或留空表示无默认值"
+      "placeholder": "输入默认值或留空以不使用默认值"
     },
     "message": {
       "invalid-schema-name": "无效的 Schema 名称",
@@ -2307,8 +2307,8 @@
       "request": "请求信息",
       "response": "响应信息",
       "status": "状态",
-      "service-data": "服务数据",
-      "latency": "延迟"
+      "latency": "延迟",
+      "service-data": "服务数据"
     },
     "advanced-search": {
       "scope": {


### PR DESCRIPTION
Replace Postgres-specific default value input with a simplified input
component used for both PostgreSQL and MySQL engines. Update computed
properties, event handlers, and placeholders to support this change.

Add a generic placeholder translation for the simplified input and adjust
locales accordingly to improve consistency across supported languages.

This change prepares the codebase for future engine migrations to the
simplified input approach and streamlines default value handling logic.