### PR TITLE
fix(mssql): align default value handling with other engines

### DIFF
--- a/backend/common/engine.go
+++ b/backend/common/engine.go
@@ -468,7 +468,7 @@ func EngineDBSchemaReadyToMigrate(e storepb.Engine) bool {
 	//exhaustive:enforce
 	switch e {
 	case
-		storepb.Engine_POSTGRES, storepb.Engine_MYSQL:
+		storepb.Engine_POSTGRES, storepb.Engine_MYSQL, storepb.Engine_MSSQL:
 		return true
 	case
 
@@ -479,7 +479,6 @@ func EngineDBSchemaReadyToMigrate(e storepb.Engine) bool {
 		storepb.Engine_OCEANBASE,
 		storepb.Engine_SNOWFLAKE,
 		storepb.Engine_DM,
-		storepb.Engine_MSSQL,
 		storepb.Engine_CLICKHOUSE,
 		storepb.Engine_COCKROACHDB,
 		storepb.Engine_SPANNER,

--- a/backend/plugin/db/mssql/sync.go
+++ b/backend/plugin/db/mssql/sync.go
@@ -467,7 +467,7 @@ func getTableColumns(txn *sql.Tx, schemas []string) (map[db.TableKey][]*storepb.
 			column.Collation = collationName.String
 		}
 		if defaultValue.Valid {
-			column.DefaultExpression = defaultValue.String
+			column.Default = defaultValue.String
 		}
 		if defaultName.Valid {
 			column.DefaultConstraintName = defaultName.String

--- a/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/DefaultValueCell.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/DefaultValueCell.vue
@@ -123,15 +123,15 @@ const placeholder = computed(() => {
   return getColumnDefaultValuePlaceholder(props.column);
 });
 
-// Computed property for engines that use simple input (PostgreSQL and MySQL)
+// Computed property for engines that use simple input (PostgreSQL, MySQL, and MSSQL)
 const useSimpleInput = computed(() => {
-  return props.engine === Engine.POSTGRES || props.engine === Engine.MYSQL;
+  return props.engine === Engine.POSTGRES || props.engine === Engine.MYSQL || props.engine === Engine.MSSQL;
 });
 
 const simpleInputValue = computed(() => {
   // For PostgreSQL, we use defaultString field which contains the schema-qualified expression
-  // For MySQL, we also use defaultString for now (until proto types are updated)
-  if (props.engine === Engine.POSTGRES || props.engine === Engine.MYSQL) {
+  // For MySQL and MSSQL, we also use defaultString for now (until proto types are updated)
+  if (props.engine === Engine.POSTGRES || props.engine === Engine.MYSQL || props.engine === Engine.MSSQL) {
     return props.column.defaultString || "";
   }
   return "";


### PR DESCRIPTION
Change column.DefaultExpression to column.Default in MSSQL sync code to
match expected field usage. Update engine checks to include MSSQL for
simple input handling in the frontend schema editor. Remove MSSQL from
excluded engine list to ensure consistent behavior across supported
engines. These changes improve default value support and UI consistency
for MSSQL.