### PR TITLE
chore: use create rollout validateOnly instead of preview rollout

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "type-check": "export NODE_OPTIONS=--max_old_space_size=8000 && vue-tsc --build --force",
     "test": "vitest run --passWithNoTests",
     "coverage": "vitest --coverage",
-    "i18n": "TS_NODE_PROJECT='./tsconfig.i18n.json' ts-node i18n.ts && eslint --cache src"
+    "i18n": "TS_NODE_PROJECT='./tsconfig.i18n.json' ts-node i18n.ts && eslint --cache src --fix"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.5.1",

--- a/frontend/src/components/IssueV1/logic/initialize/create.ts
+++ b/frontend/src/components/IssueV1/logic/initialize/create.ts
@@ -101,6 +101,7 @@ const generateRolloutFromPlan = async (
       project: params.project.name,
       plan: plan,
     });
+    // TODO(steven): Remove me after preview rollout is deprecated.
     rollout = await rolloutServiceClientConnect.previewRollout(request);
   }
   // Touch UIDs for each object for local referencing

--- a/frontend/src/components/Plan/components/RolloutView/RolloutView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/RolloutView.vue
@@ -2,21 +2,43 @@
   <div class="w-full h-full flex flex-col">
     <!-- Content area -->
     <div class="w-full flex-1 p-4">
-      <div class="flex items-center gap-1 mb-4 pl-4">
-        <h3 class="text-base font-medium">
-          {{ $t("rollout.stage.self", mergedStages.length) }}
-        </h3>
-        <span class="text-control-light" v-if="mergedStages.length > 1"
-          >({{ mergedStages.length }})</span
-        >
+      <div
+        v-if="mergedStages.length === 0"
+        class="flex items-center justify-center py-12"
+      >
+        <div class="flex flex-col items-center gap-4 max-w-md text-center">
+          <div
+            class="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center"
+          >
+            <LayersIcon class="w-8 h-8 text-gray-400" />
+          </div>
+          <div class="space-y-2">
+            <h3 class="font-medium text-xl text-gray-900">
+              {{ $t("rollout.stage.no-stages.self") }}
+            </h3>
+            <p class="text-base text-gray-500">
+              {{ $t("rollout.stage.no-stages.description") }}
+            </p>
+          </div>
+        </div>
       </div>
-      <StagesView
-        :rollout="rollout"
-        :merged-stages="mergedStages"
-        :readonly="readonly"
-        @run-tasks="handleRunTasks"
-        @create-rollout-to-stage="handleCreateRolloutToStage"
-      />
+      <template v-else>
+        <div class="flex items-center gap-1 mb-4 pl-4">
+          <h3 class="text-base font-medium">
+            {{ $t("rollout.stage.self", mergedStages.length) }}
+          </h3>
+          <span class="text-control-light" v-if="mergedStages.length > 1"
+            >({{ mergedStages.length }})</span
+          >
+        </div>
+        <StagesView
+          :rollout="rollout"
+          :merged-stages="mergedStages"
+          :readonly="readonly"
+          @run-tasks="handleRunTasks"
+          @create-rollout-to-stage="handleCreateRolloutToStage"
+        />
+      </template>
     </div>
 
     <!-- Task Rollout Action Panel -->
@@ -33,6 +55,7 @@
 
 <script setup lang="ts">
 import { create } from "@bufbuild/protobuf";
+import { LayersIcon } from "lucide-vue-next";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { rolloutServiceClientConnect } from "@/grpcweb";

--- a/frontend/src/components/Release/ReleaseDetail/NavBar/ApplyToDatabasePanel.vue
+++ b/frontend/src/components/Release/ReleaseDetail/NavBar/ApplyToDatabasePanel.vue
@@ -51,7 +51,6 @@
 
 <script lang="ts" setup>
 import { create } from "@bufbuild/protobuf";
-import { createContextValues } from "@connectrpc/connect";
 import { NButton } from "naive-ui";
 import { computed, reactive } from "vue";
 import { useRouter } from "vue-router";
@@ -59,20 +58,15 @@ import DatabaseAndGroupSelector, {
   type DatabaseSelectState,
 } from "@/components/DatabaseAndGroupSelector/";
 import { Drawer, DrawerContent, ErrorTipsButton } from "@/components/v2";
-import {
-  planServiceClientConnect,
-  rolloutServiceClientConnect,
-} from "@/grpcweb";
-import { silentContextKey } from "@/grpcweb/context-key";
+import { planServiceClientConnect } from "@/grpcweb";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import { pushNotification, useDatabaseV1Store, useDBGroupStore } from "@/store";
+import { useDatabaseV1Store, useDBGroupStore } from "@/store";
 import { DatabaseGroupSchema } from "@/types/proto-es/v1/database_group_service_pb";
 import { CreatePlanRequestSchema } from "@/types/proto-es/v1/plan_service_pb";
 import {
   PlanSchema,
   Plan_ChangeDatabaseConfigSchema,
 } from "@/types/proto-es/v1/plan_service_pb";
-import { PreviewRolloutRequestSchema } from "@/types/proto-es/v1/rollout_service_pb";
 import {
   extractProjectResourceName,
   generateIssueTitle,
@@ -143,24 +137,6 @@ const handleCreate = async () => {
       },
     ],
   });
-  try {
-    const previewRolloutRequest = create(PreviewRolloutRequestSchema, {
-      project: project.value.name,
-      plan: newPlan,
-    });
-    await rolloutServiceClientConnect.previewRollout(previewRolloutRequest, {
-      contextValues: createContextValues().set(silentContextKey, true),
-    });
-  } catch (error) {
-    pushNotification({
-      module: "bytebase",
-      style: "CRITICAL",
-      title: "Preview Rollout Failed",
-      description: `${error instanceof Error ? error.message : "Unknown error"}\nPlease check if you had applied the release to the selected databases.`,
-    });
-    return;
-  }
-
   const request = create(CreatePlanRequestSchema, {
     parent: project.value.name,
     plan: newPlan,

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1125,7 +1125,11 @@
     "force-rollout": "Force run",
     "stage": {
       "self": "Stage | Stages",
-      "start-stage": "Start stage"
+      "start-stage": "Start stage",
+      "no-stages": {
+        "self": "No stages",
+        "description": "No stages are defined for this rollout."
+      }
     }
   },
   "quick-action": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1125,7 +1125,11 @@
     "force-rollout": "Ejecución forzada",
     "stage": {
       "self": "Escenario | Escenarios",
-      "start-stage": "Etapa de inicio"
+      "start-stage": "Etapa de inicio",
+      "no-stages": {
+        "self": "Sin etapas",
+        "description": "No se definen etapas para este lanzamiento."
+      }
     }
   },
   "quick-action": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1125,7 +1125,11 @@
     "force-rollout": "強制実行",
     "stage": {
       "self": "ステージ | ステージ",
-      "start-stage": "スタートステージ"
+      "start-stage": "スタートステージ",
+      "no-stages": {
+        "self": "ステージなし",
+        "description": "このロールアウトにはステージが定義されていません。"
+      }
     }
   },
   "quick-action": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1125,7 +1125,11 @@
     "force-rollout": "Chạy bắt buộc",
     "stage": {
       "self": "Giai đoạn | Các giai đoạn",
-      "start-stage": "Giai đoạn bắt đầu"
+      "start-stage": "Giai đoạn bắt đầu",
+      "no-stages": {
+        "self": "Không có giai đoạn",
+        "description": "Không có giai đoạn nào được xác định cho lần triển khai này."
+      }
     }
   },
   "quick-action": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1125,7 +1125,11 @@
     "force-rollout": "强制执行",
     "stage": {
       "self": "阶段 | 阶段",
-      "start-stage": "开始该阶段"
+      "start-stage": "开始该阶段",
+      "no-stages": {
+        "self": "没有阶段",
+        "description": "本次发布任务未定义任何阶段。"
+      }
     }
   },
   "quick-action": {


### PR DESCRIPTION
Close BYT-7707

Sadly, we cannot remove `previewRollout` as it's still used in legacy issue pages.