### PR TITLE
feat: add configurable transaction mode for database migrations

### DIFF
--- a/backend/common/testcontainer/testcontainer.go
+++ b/backend/common/testcontainer/testcontainer.go
@@ -99,6 +99,17 @@ func GetMySQLContainer(ctx context.Context) (retc *Container, retErr error) {
 	}, nil
 }
 
+// GetTestMySQLContainer is a helper function for tests that creates a MySQL container
+// and handles the error by failing the test if container creation fails
+func GetTestMySQLContainer(ctx context.Context, t testing.TB) *Container {
+	t.Helper()
+	container, err := GetMySQLContainer(ctx)
+	if err != nil {
+		t.Fatalf("failed to create MySQL container: %v", err)
+	}
+	return container
+}
+
 // GetPgContainer creates a PostgreSQL container for testing
 func GetPgContainer(ctx context.Context) (retC *Container, retErr error) {
 	req := testcontainers.ContainerRequest{

--- a/backend/plugin/db/cockroachdb/cockroachdb.go
+++ b/backend/plugin/db/cockroachdb/cockroachdb.go
@@ -250,6 +250,15 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		return 0, nil
 	}
 
+	// Parse transaction mode from the script
+	transactionMode, cleanedStatement := base.ParseTransactionMode(statement)
+	statement = cleanedStatement
+
+	// Apply default when transaction mode is not specified
+	if transactionMode == common.TransactionModeUnspecified {
+		transactionMode = common.GetDefaultTransactionMode()
+	}
+
 	owner, err := d.GetCurrentDatabaseOwner(ctx)
 	if err != nil {
 		return 0, err
@@ -302,6 +311,17 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		tmpOriginalIndex = append(tmpOriginalIndex, originalIndex[i])
 	}
 	commands, originalIndex = tmpCommands, tmpOriginalIndex
+
+	// For auto-commit mode, treat all statements as non-transactional
+	if transactionMode == common.TransactionModeOff {
+		// Move all commands to non-transaction list for auto-commit execution
+		for i, command := range commands {
+			nonTransactionAndSetRoleStmts = append(nonTransactionAndSetRoleStmts, command.Text)
+			nonTransactionAndSetRoleStmtsIndex = append(nonTransactionAndSetRoleStmtsIndex, originalIndex[i])
+		}
+		commands = nil
+		originalIndex = nil
+	}
 
 	conn, err := d.db.Conn(ctx)
 	if err != nil {

--- a/backend/plugin/db/tidb/tidb.go
+++ b/backend/plugin/db/tidb/tidb.go
@@ -156,6 +156,15 @@ func parseVersion(version string) (string, error) {
 
 // Execute executes a SQL statement.
 func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteOptions) (int64, error) {
+	// Parse transaction mode from the script
+	transactionMode, cleanedStatement := base.ParseTransactionMode(statement)
+	statement = cleanedStatement
+
+	// Apply default when transaction mode is not specified
+	if transactionMode == common.TransactionModeUnspecified {
+		transactionMode = common.GetDefaultTransactionMode()
+	}
+
 	statement, err := mysqlparser.DealWithDelimiter(statement)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to deal with delimiter")
@@ -174,7 +183,7 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 	slog.Debug("connectionID", slog.String("connectionID", connectionID))
 
 	var remainingSQLsIndex, nonTransactionStmtsIndex []int
-	var nonTransactionStmts []string
+	var nonTransactionStmts []base.SingleSQL
 	var totalCommands int
 	var commands []base.SingleSQL
 	var originalIndex []int32
@@ -196,7 +205,7 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 			var remainingSQLs []base.SingleSQL
 			for i, singleSQL := range singleSQLs {
 				if isNonTransactionStatement(singleSQL.Text) {
-					nonTransactionStmts = append(nonTransactionStmts, singleSQL.Text)
+					nonTransactionStmts = append(nonTransactionStmts, singleSQL)
 					nonTransactionStmtsIndex = append(nonTransactionStmtsIndex, i)
 					continue
 				}
@@ -216,7 +225,17 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		remainingSQLsIndex = []int{0}
 	}
 
+	// Execute based on transaction mode
+	if transactionMode == common.TransactionModeOff {
+		return d.executeInAutoCommitMode(ctx, conn, commands, nonTransactionStmts, remainingSQLsIndex, nonTransactionStmtsIndex, originalIndex, opts, connectionID)
+	}
+	return d.executeInTransactionMode(ctx, conn, commands, nonTransactionStmts, remainingSQLsIndex, nonTransactionStmtsIndex, originalIndex, opts, connectionID)
+}
+
+// executeInTransactionMode executes statements within a single transaction
+func (d *Driver) executeInTransactionMode(ctx context.Context, conn *sql.Conn, commands []base.SingleSQL, nonTransactionStmts []base.SingleSQL, remainingSQLsIndex, nonTransactionStmtsIndex []int, originalIndex []int32, opts db.ExecuteOptions, connectionID string) (int64, error) {
 	var totalRowsAffected int64
+
 	if err := conn.Raw(func(driverConn any) error {
 		//nolint
 		exer := driverConn.(driver.ExecerContext)
@@ -224,9 +243,24 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		txer := driverConn.(driver.ConnBeginTx)
 		tx, err := txer.BeginTx(ctx, driver.TxOptions{})
 		if err != nil {
+			opts.LogTransactionControl(storepb.TaskRunLog_TransactionControl_BEGIN, err.Error())
 			return err
+		} else {
+			opts.LogTransactionControl(storepb.TaskRunLog_TransactionControl_BEGIN, "")
 		}
-		defer tx.Rollback()
+
+		committed := false
+		defer func() {
+			err := tx.Rollback()
+			if committed {
+				return
+			}
+			var rerr string
+			if err != nil {
+				rerr = err.Error()
+			}
+			opts.LogTransactionControl(storepb.TaskRunLog_TransactionControl_ROLLBACK, rerr)
+		}()
 
 		for i, command := range commands {
 			indexes := []int32{originalIndex[remainingSQLsIndex[i]]}
@@ -265,6 +299,9 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 
 		if err := tx.Commit(); err != nil {
 			return errors.Wrapf(err, "failed to commit execute transaction")
+		} else {
+			opts.LogTransactionControl(storepb.TaskRunLog_TransactionControl_COMMIT, "")
+			committed = true
 		}
 		return nil
 	}); err != nil {
@@ -273,14 +310,92 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 
 	// Run non-transaction statements at the end.
 	for i, stmt := range nonTransactionStmts {
-		indexes := []int32{int32(originalIndex[nonTransactionStmtsIndex[i]])}
+		indexes := []int32{originalIndex[nonTransactionStmtsIndex[i]]}
 		opts.LogCommandExecute(indexes)
-		if _, err := d.db.ExecContext(ctx, stmt); err != nil {
+		if _, err := d.db.ExecContext(ctx, stmt.Text); err != nil {
 			opts.LogCommandResponse(indexes, 0, []int32{0}, err.Error())
 			return 0, err
 		}
 		opts.LogCommandResponse(indexes, 0, []int32{0}, "")
 	}
+	return totalRowsAffected, nil
+}
+
+// executeInAutoCommitMode executes statements sequentially in auto-commit mode
+func (d *Driver) executeInAutoCommitMode(ctx context.Context, conn *sql.Conn, commands []base.SingleSQL, nonTransactionStmts []base.SingleSQL, remainingSQLsIndex, nonTransactionStmtsIndex []int, originalIndex []int32, opts db.ExecuteOptions, connectionID string) (int64, error) {
+	var totalRowsAffected int64
+
+	// Execute all statements (including non-transactional ones) in order
+	allCommands := make([]base.SingleSQL, 0, len(commands)+len(nonTransactionStmts))
+	allIndexes := make([]int, 0, len(commands)+len(nonTransactionStmts))
+
+	// Merge commands and non-transactional statements while preserving original order
+	cmdIdx, nonTxIdx := 0, 0
+	for cmdIdx < len(commands) || nonTxIdx < len(nonTransactionStmts) {
+		if cmdIdx >= len(commands) {
+			allCommands = append(allCommands, nonTransactionStmts[nonTxIdx])
+			allIndexes = append(allIndexes, nonTransactionStmtsIndex[nonTxIdx])
+			nonTxIdx++
+		} else if nonTxIdx >= len(nonTransactionStmts) {
+			allCommands = append(allCommands, commands[cmdIdx])
+			allIndexes = append(allIndexes, remainingSQLsIndex[cmdIdx])
+			cmdIdx++
+		} else if remainingSQLsIndex[cmdIdx] < nonTransactionStmtsIndex[nonTxIdx] {
+			allCommands = append(allCommands, commands[cmdIdx])
+			allIndexes = append(allIndexes, remainingSQLsIndex[cmdIdx])
+			cmdIdx++
+		} else {
+			allCommands = append(allCommands, nonTransactionStmts[nonTxIdx])
+			allIndexes = append(allIndexes, nonTransactionStmtsIndex[nonTxIdx])
+			nonTxIdx++
+		}
+	}
+
+	if err := conn.Raw(func(driverConn any) error {
+		//nolint
+		exer := driverConn.(driver.ExecerContext)
+
+		for i, command := range allCommands {
+			indexes := []int32{originalIndex[allIndexes[i]]}
+			opts.LogCommandExecute(indexes)
+
+			sqlWithBytebaseAppComment := util.MySQLPrependBytebaseAppComment(command.Text)
+			sqlResult, err := exer.ExecContext(ctx, sqlWithBytebaseAppComment, nil)
+			if err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					slog.Info("cancel connection", slog.String("connectionID", connectionID))
+					if err := d.StopConnectionByID(connectionID); err != nil {
+						slog.Error("failed to cancel connection", slog.String("connectionID", connectionID), log.BBError(err))
+					}
+				}
+
+				opts.LogCommandResponse(indexes, 0, nil, err.Error())
+				// In auto-commit mode, we stop at the first error
+				// The database is left in a partially migrated state
+				return &db.ErrorWithPosition{
+					Err:   errors.Wrapf(err, "failed to execute statement %d in auto-commit mode", i+1),
+					Start: command.Start,
+					End:   command.End,
+				}
+			}
+
+			allRowsAffected := sqlResult.(mysql.Result).AllRowsAffected()
+			var rowsAffected int64
+			var allRowsAffectedInt32 []int32
+			for _, a := range allRowsAffected {
+				rowsAffected += a
+				allRowsAffectedInt32 = append(allRowsAffectedInt32, int32(a))
+			}
+			totalRowsAffected += rowsAffected
+
+			opts.LogCommandResponse(indexes, int32(rowsAffected), allRowsAffectedInt32, "")
+		}
+
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+
 	return totalRowsAffected, nil
 }
 

--- a/backend/plugin/parser/base/transaction_mode_test.go
+++ b/backend/plugin/parser/base/transaction_mode_test.go
@@ -1,0 +1,118 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+)
+
+// TestParseTransactionMode tests the transaction mode parser functionality.
+func TestParseTransactionMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		script       string
+		expectedMode common.TransactionMode
+		expectedSQL  string
+	}{
+		{
+			name:         "Transaction mode on",
+			script:       "-- txn-mode = on\nSELECT 1;",
+			expectedMode: common.TransactionModeOn,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "Transaction mode off",
+			script:       "-- txn-mode = off\nSELECT 1;",
+			expectedMode: common.TransactionModeOff,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "No transaction mode directive",
+			script:       "SELECT 1;",
+			expectedMode: common.TransactionModeUnspecified,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "Case insensitive ON",
+			script:       "-- TXN-MODE = ON\nSELECT 1;",
+			expectedMode: common.TransactionModeOn,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "Case insensitive off",
+			script:       "-- Txn-Mode = Off\nSELECT 1;",
+			expectedMode: common.TransactionModeOff,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "Extra spaces",
+			script:       "--  txn-mode  =  on  \nSELECT 1;",
+			expectedMode: common.TransactionModeOn,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "Multiple lines after directive",
+			script:       "-- txn-mode = off\n\n-- Another comment\nSELECT 1;\nSELECT 2;",
+			expectedMode: common.TransactionModeOff,
+			expectedSQL:  "-- Another comment\nSELECT 1;\nSELECT 2;",
+		},
+		{
+			name:         "Directive not on first line",
+			script:       "-- Regular comment\n-- txn-mode = on\nSELECT 1;",
+			expectedMode: common.TransactionModeUnspecified,
+			expectedSQL:  "-- Regular comment\n-- txn-mode = on\nSELECT 1;",
+		},
+		{
+			name:         "Invalid directive value",
+			script:       "-- txn-mode = invalid\nSELECT 1;",
+			expectedMode: common.TransactionModeUnspecified,
+			expectedSQL:  "-- txn-mode = invalid\nSELECT 1;",
+		},
+		{
+			name:         "Empty script",
+			script:       "",
+			expectedMode: common.TransactionModeUnspecified,
+			expectedSQL:  "",
+		},
+		{
+			name:         "Only directive",
+			script:       "-- txn-mode = on",
+			expectedMode: common.TransactionModeOn,
+			expectedSQL:  "",
+		},
+		{
+			name:         "Windows line endings",
+			script:       "-- txn-mode = on\r\nSELECT 1;",
+			expectedMode: common.TransactionModeOn,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "Tab after comment",
+			script:       "--\ttxn-mode = on\nSELECT 1;",
+			expectedMode: common.TransactionModeOn,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "No space around equals",
+			script:       "-- txn-mode=on\nSELECT 1;",
+			expectedMode: common.TransactionModeOn,
+			expectedSQL:  "SELECT 1;",
+		},
+		{
+			name:         "Multiple spaces in comment",
+			script:       "-- -- txn-mode = on\nSELECT 1;",
+			expectedMode: common.TransactionModeUnspecified,
+			expectedSQL:  "-- -- txn-mode = on\nSELECT 1;",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mode, sql := ParseTransactionMode(test.script)
+			require.Equal(t, test.expectedMode, mode, "Transaction mode mismatch")
+			require.Equal(t, test.expectedSQL, sql, "SQL mismatch")
+		})
+	}
+}

--- a/backend/tests/transaction_mode_test.go
+++ b/backend/tests/transaction_mode_test.go
@@ -1,0 +1,284 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/plugin/db"
+)
+
+// TestTransactionMode tests the configurable transaction mode feature across different database engines.
+func TestTransactionMode(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		dbType           storepb.Engine
+		containerFunc    func(context.Context, *testing.T) *testcontainer.Container
+		setupScript      string
+		testScriptOn     string
+		testScriptOff    string
+		expectRollbackOn bool // Whether we expect rollback for transaction mode on
+		skipTransaction  bool // Some engines don't support transactions well
+	}{
+		{
+			name:   "MySQL",
+			dbType: storepb.Engine_MYSQL,
+			containerFunc: func(ctx context.Context, t *testing.T) *testcontainer.Container {
+				return testcontainer.GetTestMySQLContainer(ctx, t)
+			},
+			setupScript: `
+				CREATE TABLE test_table (
+					id INT PRIMARY KEY,
+					value VARCHAR(100)
+				);
+			`,
+			testScriptOn: `-- txn-mode = on
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			testScriptOff: `-- txn-mode = off
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			expectRollbackOn: true,
+		},
+		{
+			name:   "PostgreSQL",
+			dbType: storepb.Engine_POSTGRES,
+			containerFunc: func(ctx context.Context, t *testing.T) *testcontainer.Container {
+				return testcontainer.GetTestPgContainer(ctx, t)
+			},
+			setupScript: `
+				CREATE TABLE test_table (
+					id INTEGER PRIMARY KEY,
+					value VARCHAR(100)
+				);
+			`,
+			testScriptOn: `-- txn-mode = on
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			testScriptOff: `-- txn-mode = off
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			expectRollbackOn: true,
+		},
+		{
+			name:   "Oracle",
+			dbType: storepb.Engine_ORACLE,
+			containerFunc: func(ctx context.Context, t *testing.T) *testcontainer.Container {
+				return testcontainer.GetTestOracleContainer(ctx, t)
+			},
+			setupScript: `
+				CREATE TABLE test_table (
+					id NUMBER PRIMARY KEY,
+					value VARCHAR2(100)
+				)
+			`,
+			testScriptOn: `-- txn-mode = on
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			testScriptOff: `-- txn-mode = off
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			expectRollbackOn: true,
+		},
+		{
+			name:   "SQL Server",
+			dbType: storepb.Engine_MSSQL,
+			containerFunc: func(ctx context.Context, t *testing.T) *testcontainer.Container {
+				return testcontainer.GetTestMSSQLContainer(ctx, t)
+			},
+			setupScript: `
+				CREATE TABLE test_table (
+					id INT PRIMARY KEY,
+					value VARCHAR(100)
+				);
+			`,
+			testScriptOn: `-- txn-mode = on
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			testScriptOff: `-- txn-mode = off
+				INSERT INTO test_table (id, value) VALUES (1, 'test1');
+				INSERT INTO test_table (id, value) VALUES (2, 'test2');
+				INSERT INTO test_table (id, value) VALUES (1, 'duplicate'); -- This will fail
+			`,
+			expectRollbackOn: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Skip transaction tests for engines that don't support them well
+			if test.skipTransaction {
+				t.Skip("Skipping transaction test for engine with limited transaction support")
+			}
+
+			// Create container
+			container := test.containerFunc(ctx, t)
+			defer container.Close(ctx)
+
+			// Create test database if needed
+			testDBName := fmt.Sprintf("txnmode_test_%d", time.Now().UnixNano())
+			if test.dbType == storepb.Engine_MYSQL {
+				_, err := container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", testDBName))
+				require.NoError(t, err)
+			}
+
+			// Get database connection
+			driver, err := getDriver(ctx, test.dbType, container, testDBName)
+			require.NoError(t, err)
+			defer driver.Close(ctx)
+
+			// Setup test table
+			_, err = driver.Execute(ctx, test.setupScript, db.ExecuteOptions{})
+			require.NoError(t, err)
+
+			// Test transaction mode ON - expect rollback on failure
+			t.Run("TransactionModeOn", func(t *testing.T) {
+				// Execute script with transaction mode ON
+				_, err := driver.Execute(ctx, test.testScriptOn, db.ExecuteOptions{})
+				require.Error(t, err, "Expected error due to duplicate key")
+
+				// Check if rollback occurred
+				rowCount := getRowCount(ctx, t, driver, test.dbType)
+				if test.expectRollbackOn {
+					require.Equal(t, 0, rowCount, "Expected 0 rows due to rollback")
+				} else {
+					require.Greater(t, rowCount, 0, "Expected some rows even with error")
+				}
+
+				// Cleanup
+				cleanupTable(ctx, t, driver, test.dbType)
+			})
+
+			// Test transaction mode OFF - expect partial success
+			t.Run("TransactionModeOff", func(t *testing.T) {
+				// Execute script with transaction mode OFF
+				_, err := driver.Execute(ctx, test.testScriptOff, db.ExecuteOptions{})
+				require.Error(t, err, "Expected error due to duplicate key")
+
+				// Check if partial success occurred (first 2 inserts should succeed)
+				rowCount := getRowCount(ctx, t, driver, test.dbType)
+				require.Equal(t, 2, rowCount, "Expected 2 rows from successful inserts before failure")
+
+				// Cleanup
+				cleanupTable(ctx, t, driver, test.dbType)
+			})
+		})
+	}
+}
+
+// Helper functions
+func getDriver(ctx context.Context, engine storepb.Engine, container *testcontainer.Container, testDBName string) (db.Driver, error) {
+	var dbDatabase string
+	switch engine {
+	case storepb.Engine_MYSQL:
+		dbDatabase = testDBName
+	case storepb.Engine_POSTGRES:
+		dbDatabase = "postgres"
+	case storepb.Engine_ORACLE:
+		dbDatabase = "FREEPDB1"
+	case storepb.Engine_MSSQL:
+		dbDatabase = "master"
+	default:
+		dbDatabase = ""
+	}
+
+	config := db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Host:     container.GetHost(),
+			Port:     container.GetPort(),
+			Username: "root",
+			Database: dbDatabase,
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: dbDatabase,
+		},
+		Password: "root",
+	}
+
+	// Special handling for different engines based on testcontainer setup
+	switch engine {
+	case storepb.Engine_MYSQL:
+		config.DataSource.Username = "root"
+		config.Password = "root-password"
+	case storepb.Engine_POSTGRES:
+		config.DataSource.Username = "postgres"
+		config.Password = "root-password"
+	case storepb.Engine_ORACLE:
+		config.DataSource.Username = "testuser"
+		config.Password = "testpass"
+		config.DataSource.Database = ""
+		config.ConnectionContext.DatabaseName = ""
+		// Set service name for Oracle
+		config.DataSource.ServiceName = "FREEPDB1"
+	case storepb.Engine_MSSQL:
+		config.DataSource.Username = "sa"
+		config.Password = "Test123!"
+	}
+
+	driver, err := db.Open(ctx, engine, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return driver, nil
+}
+
+func getRowCount(ctx context.Context, t *testing.T, driver db.Driver, _ storepb.Engine) int {
+	query := "SELECT COUNT(*) FROM test_table"
+
+	// Use QueryConn to get results
+	conn, err := driver.GetDB().Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	results, err := driver.QueryConn(ctx, conn, query, db.QueryContext{})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Rows, 1)
+	require.Len(t, results[0].Rows[0].Values, 1)
+
+	// Extract count value
+	switch v := results[0].Rows[0].Values[0].Kind.(type) {
+	case *v1pb.RowValue_Int32Value:
+		return int(v.Int32Value)
+	case *v1pb.RowValue_Int64Value:
+		return int(v.Int64Value)
+	case *v1pb.RowValue_StringValue:
+		// Some databases return count as string
+		count := 0
+		if _, err := fmt.Sscanf(v.StringValue, "%d", &count); err != nil {
+			t.Fatalf("Failed to parse count from string: %v", err)
+		}
+		return count
+	default:
+		t.Fatalf("Unexpected count value type: %T", v)
+		return 0
+	}
+}
+
+func cleanupTable(ctx context.Context, t *testing.T, driver db.Driver, _ storepb.Engine) {
+	_, err := driver.Execute(ctx, "DELETE FROM test_table", db.ExecuteOptions{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What

  Adds support for configurable transaction mode in database migrations via SQL script directives.

## Why

  - Some databases (like Redshift) have limited transactional DDL support
  - Users need control over whether migrations run in a transaction or auto-commit mode
  - Provides flexibility for complex migration scenarios

## How

  - Added `-- txn-mode = on|off` directive parser
  - Implemented dual-mode execution (transactional vs auto-commit) for all SQL engines
  - Added UI toggle in SQL editor
  - Defaults to `on` for backward compatibility

## Example

  ```sql
  -- txn-mode = off
  CREATE TABLE users (id INT PRIMARY KEY);
  INSERT INTO users VALUES (1), (2);

  When txn-mode = off, statements execute independently. If one fails, previous statements remain committed.
  ```