### PR TITLE
refactor(db): remove unused transaction mode parsing in drivers

### DIFF
--- a/backend/plugin/db/bigquery/bigquery.go
+++ b/backend/plugin/db/bigquery/bigquery.go
@@ -21,7 +21,6 @@ import (
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/db/util"
-	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
 var (
@@ -89,25 +88,6 @@ func (*Driver) GetDB() *sql.DB {
 
 // Execute executes a SQL statement.
 func (d *Driver) Execute(ctx context.Context, statement string, _ db.ExecuteOptions) (int64, error) {
-	// Parse transaction mode from the script
-	transactionMode, cleanedStatement := base.ParseTransactionMode(statement)
-	statement = cleanedStatement
-
-	// Apply default when transaction mode is not specified
-	if transactionMode == common.TransactionModeUnspecified {
-		transactionMode = common.GetDefaultTransactionMode()
-	}
-
-	// BigQuery doesn't support traditional transactions for DDL operations.
-	// DML operations in BigQuery are automatically atomic at the statement level.
-	// Multi-statement transactions are supported via scripting with BEGIN/COMMIT,
-	// but here we execute statements individually regardless of transaction mode.
-	//
-	// Note: When transactionMode is "on", BigQuery will still execute each statement
-	// atomically, but won't wrap multiple statements in a single transaction.
-	// This is a limitation of BigQuery's architecture.
-	_ = transactionMode // Transaction mode is parsed but not used due to BigQuery limitations
-
 	q := d.client.Query(statement)
 	q.DefaultDatasetID = d.databaseName
 	job, err := q.Run(ctx)

--- a/backend/plugin/db/hive/hive.go
+++ b/backend/plugin/db/hive/hive.go
@@ -110,20 +110,6 @@ func (*Driver) GetDB() *sql.DB {
 // Even in Hive's bucketed transaction table, all the statements are committed automatically by
 // the Hive server.
 func (d *Driver) Execute(ctx context.Context, statementsStr string, _ db.ExecuteOptions) (int64, error) {
-	// Parse transaction mode from the script
-	transactionMode, cleanedStatement := base.ParseTransactionMode(statementsStr)
-	statementsStr = cleanedStatement
-
-	// Apply default when transaction mode is not specified
-	if transactionMode == common.TransactionModeUnspecified {
-		transactionMode = common.GetDefaultTransactionMode()
-	}
-
-	// Note: We parse transactionMode but don't use it for execution since Hive
-	// has very limited transaction support. The variable assignment is kept for consistency
-	// with other database drivers and potential future use.
-	_ = transactionMode
-
 	// Hive has limited transaction support:
 	// - Only ACID tables support transactions, and even then it's limited
 	// - Transaction statements (BEGIN, COMMIT, ROLLBACK) are not supported in Hive 4.0

--- a/backend/plugin/db/trino/trino.go
+++ b/backend/plugin/db/trino/trino.go
@@ -14,7 +14,6 @@ import (
 	// Import Trino driver for side effects
 	_ "github.com/trinodb/trino-go-client/trino"
 
-	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/plugin/db"
@@ -127,20 +126,6 @@ func (d *Driver) GetDB() *sql.DB {
 
 // Execute executes the SQL statement with the given options.
 func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteOptions) (int64, error) {
-	// Parse transaction mode from the script
-	transactionMode, cleanedStatement := base.ParseTransactionMode(statement)
-	statement = cleanedStatement
-
-	// Apply default when transaction mode is not specified
-	if transactionMode == common.TransactionModeUnspecified {
-		transactionMode = common.GetDefaultTransactionMode()
-	}
-
-	// Note: We parse transactionMode but don't use it for execution since Trino
-	// has limited transaction support. The variable assignment is kept for consistency
-	// with other database drivers and potential future use.
-	_ = transactionMode
-
 	conn, err := d.db.Conn(ctx)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get connection")


### PR DESCRIPTION
Remove parsing and handling of transaction mode in BigQuery, Hive, and Trino
database drivers. These drivers have limited or no support for traditional
transactions, making the transaction mode parsing redundant. This cleanup
simplifies the Execute methods and aligns the code with the actual capabilities
of these databases.