### PR TITLE
refactor: unify title/description of plan and issue

### DIFF
--- a/backend/api/v1/issue_service_convert.go
+++ b/backend/api/v1/issue_service_convert.go
@@ -61,7 +61,19 @@ func (s *IssueService) convertToIssue(ctx context.Context, issue *store.IssueMes
 	}
 
 	if issue.PlanUID != nil {
+		plan, err := s.store.GetPlan(ctx, &store.FindPlanMessage{UID: issue.PlanUID})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get plan by uid %v", issue.PlanUID)
+		}
 		issueV1.Plan = common.FormatPlan(issue.Project.ResourceID, *issue.PlanUID)
+		// Unification logic: Plan takes precedence over Issue when both exist.
+		// Use plan's title and description when available (non-empty).
+		if plan.Name != "" {
+			issueV1.Title = plan.Name
+		}
+		if plan.Description != "" {
+			issueV1.Description = plan.Description
+		}
 	}
 	if issue.PipelineUID != nil {
 		issueV1.Rollout = common.FormatRollout(issue.Project.ResourceID, *issue.PipelineUID)

--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -589,6 +589,10 @@ func convertToRollout(ctx context.Context, s *store.Store, project *store.Projec
 	}
 	if plan != nil {
 		rolloutV1.Plan = common.FormatPlan(project.ResourceID, plan.UID)
+		// Use plan's title when available (non-empty).
+		if plan.Name != "" {
+			rolloutV1.Title = plan.Name
+		}
 	}
 
 	if rollout.IssueID != nil {

--- a/backend/migrator/migration/3.9/0004##issue_rollout_title.sql
+++ b/backend/migrator/migration/3.9/0004##issue_rollout_title.sql
@@ -1,0 +1,37 @@
+-- Step 1: Backfill empty plan names and descriptions with their corresponding issue values
+UPDATE plan
+SET 
+    name = CASE 
+        WHEN plan.name = '' THEN issue.name
+        ELSE plan.name
+    END,
+    description = CASE 
+        WHEN plan.description = '' THEN issue.description
+        ELSE plan.description
+    END
+FROM issue
+WHERE plan.id = issue.plan_id
+  AND (plan.name = '' OR plan.description = '');
+
+-- Step 2: Clear issue title (name) and description only when the related plan has non-empty values
+UPDATE issue
+SET 
+    name = CASE 
+        WHEN plan.name != '' THEN ''
+        ELSE issue.name
+    END,
+    description = CASE 
+        WHEN plan.description != '' THEN ''
+        ELSE issue.description
+    END
+FROM plan
+WHERE issue.plan_id = plan.id;
+
+-- Step 3: Clear pipeline title (name) when it's associated with a plan
+UPDATE pipeline
+SET name = ''
+WHERE id IN (
+    SELECT DISTINCT pipeline_id 
+    FROM plan 
+    WHERE pipeline_id IS NOT NULL
+);

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.9.3"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.9.4"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/frontend/src/components/CreateDatabasePrepForm/CreateDatabasePrepForm.vue
+++ b/frontend/src/components/CreateDatabasePrepForm/CreateDatabasePrepForm.vue
@@ -364,15 +364,16 @@ const createV1 = async () => {
     creator: `users/${currentUserV1.value.email}`,
   });
 
-  issueCreate.title = `${t("issue.title.create-database")} '${databaseName}'`;
   spec.config = {
     case: "createDatabaseConfig",
     value: createDatabaseConfig,
   };
 
+  const title = `${t("issue.title.create-database")} '${databaseName}'`;
   state.creating = true;
   try {
     const planCreate = createProto(PlanSchema, {
+      title: title,
       specs: [spec],
       creator: currentUserV1.value.name,
     });

--- a/frontend/src/components/IssueV1/logic/initialize/create.ts
+++ b/frontend/src/components/IssueV1/logic/initialize/create.ts
@@ -74,7 +74,7 @@ const buildIssue = async (params: CreatePlanParams) => {
   issue.name = `${project.name}/issues/${nextUID()}`;
   issue.status = IssueStatus.OPEN;
   // Only set title from query if enforceIssueTitle is false.
-  if (!project.enforceIssueTitle) {
+  if (issue.type === Issue_Type.GRANT_REQUEST && !project.enforceIssueTitle) {
     issue.title = query.name;
   }
 


### PR DESCRIPTION
Close BYT-7713

Title/Description Display Logic

- Plan + Issue: Use Plan's title/description
- Issue only: Use Issue's title/description

Update Restrictions

- Cannot update Issue title/description when Plan exists
- Must update through Plan API instead

Data Migration

- Backfills empty Plan titles/descriptions from Issue
- Clears Issue title/description only when Plan has non-empty values
- Preserves Issue fields when Plan fields are empty