### PR TITLE
fix(mysql, tidb): remove redundant ON UPDATE clause from column definitions

### DIFF
--- a/backend/plugin/schema/mysql/get_database_definition.go
+++ b/backend/plugin/schema/mysql/get_database_definition.go
@@ -1132,12 +1132,6 @@ func printDefaultClause(buf *strings.Builder, column *storepb.ColumnMetadata) er
 		}
 	}
 
-	if column.OnUpdate != "" {
-		if _, err := fmt.Fprintf(buf, " ON UPDATE %s", column.OnUpdate); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/backend/plugin/schema/tidb/get_database_definition.go
+++ b/backend/plugin/schema/tidb/get_database_definition.go
@@ -1221,12 +1221,6 @@ func printDefaultClause(buf *strings.Builder, column *storepb.ColumnMetadata) er
 		}
 	}
 
-	if column.OnUpdate != "" {
-		if _, err := fmt.Fprintf(buf, " ON UPDATE %s", column.OnUpdate); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Remove the ON UPDATE clause generation in MySQL and TiDB schema
plugins to prevent incorrect or unsupported syntax in database
definitions. This change ensures compatibility and correctness when
retrieving column definitions.