### PR TITLE
chore: add instance database route

### DIFF
--- a/frontend/src/components/InstanceDatabaseRedirect.vue
+++ b/frontend/src/components/InstanceDatabaseRedirect.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { INSTANCE_ROUTE_DETAIL } from "@/router/dashboard/instance";
+import { PROJECT_V1_ROUTE_DATABASE_DETAIL } from "@/router/dashboard/projectV1";
+import {
+  databaseNamePrefix,
+  instanceNamePrefix,
+  pushNotification,
+  useDatabaseV1Store,
+} from "@/store";
+import { isValidProjectName } from "@/types";
+import { extractProjectResourceName } from "@/utils/v1";
+
+const route = useRoute();
+const router = useRouter();
+const databaseStore = useDatabaseV1Store();
+
+onMounted(async () => {
+  const instanceId = route.params.instanceId as string;
+  const databaseName = route.params.databaseName as string;
+
+  try {
+    // Fetch the database to get its project information
+    const database = await databaseStore.getOrFetchDatabaseByName(
+      `${instanceNamePrefix}${instanceId}/${databaseNamePrefix}${databaseName}`
+    );
+
+    if (database && isValidProjectName(database.project)) {
+      // Extract project ID from the database's project field
+      const projectId = extractProjectResourceName(database.project);
+
+      // Redirect to the project database detail page
+      router.replace({
+        name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
+        params: {
+          projectId: projectId,
+          instanceId: instanceId,
+          databaseName: databaseName,
+        },
+      });
+    } else {
+      // If database not found, show error and redirect to instance detail
+      pushNotification({
+        module: "bytebase",
+        style: "WARN",
+        title: "Database not found",
+        description: `Database: ${databaseName}`,
+      });
+
+      router.replace({
+        name: INSTANCE_ROUTE_DETAIL,
+        params: {
+          instanceId: instanceId,
+        },
+      });
+    }
+  } catch (error) {
+    console.error("Failed to fetch database:", error);
+
+    // Show error notification
+    pushNotification({
+      module: "bytebase",
+      style: "CRITICAL",
+      title: "Error",
+      description: `Failed to load database: ${databaseName}`,
+    });
+
+    // On error, redirect to instance detail
+    router.replace({
+      name: INSTANCE_ROUTE_DETAIL,
+      params: {
+        instanceId: instanceId,
+      },
+    });
+  }
+});
+</script>

--- a/frontend/src/components/Plan/components/RolloutView/StageCard.vue
+++ b/frontend/src/components/Plan/components/RolloutView/StageCard.vue
@@ -90,17 +90,13 @@
                 round
                 size="small"
                 :bordered="false"
-                :class="isCreated && 'cursor-pointer hover:opacity-80'"
                 @click.stop="handleTaskClick(task)"
               >
                 <template #avatar>
                   <TaskStatus :status="task.status" size="tiny" disabled />
                 </template>
                 <div class="flex items-center flex-nowrap">
-                  <DatabaseDisplay
-                    :database="task.target"
-                    :project="project.name"
-                  />
+                  <DatabaseDisplay :database="task.target" />
                   <NTooltip v-if="task.runTime">
                     <template #trigger>
                       <CalendarClockIcon

--- a/frontend/src/components/Plan/components/RolloutView/TaskRunRollbackDrawer.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskRunRollbackDrawer.vue
@@ -35,10 +35,7 @@
                   :key="preview.taskRunName"
                   class="space-y-2"
                 >
-                  <DatabaseDisplay
-                    :database="preview.task.target"
-                    :project="project.name"
-                  />
+                  <DatabaseDisplay :database="preview.task.target" />
                   <template v-if="!isUndefined(preview.statement)">
                     <MonacoEditor
                       v-if="preview.statement"

--- a/frontend/src/components/Plan/components/RolloutView/TaskView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskView.vue
@@ -6,11 +6,7 @@
         <div class="flex flex-row items-center gap-x-3">
           <TaskStatus :size="'large'" :status="task.status" />
           <div class="flex flex-row items-center text-xl">
-            <DatabaseDisplay
-              :database="database.name"
-              :project="project.name"
-              :size="'large'"
-            />
+            <DatabaseDisplay :database="database.name" :size="'large'" />
           </div>
           <div class="flex flex-row gap-x-2">
             <NTag round>{{ semanticTaskType(task.type) }}</NTag>

--- a/frontend/src/components/Plan/components/SpecDetailView/TargetListSection.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/TargetListSection.vue
@@ -38,11 +38,7 @@
           class="inline-flex items-center gap-x-1 px-2 py-1 border rounded-lg transition-all cursor-default"
         >
           <template v-if="isValidDatabaseName(target)">
-            <DatabaseDisplay
-              :database="target"
-              :project="project?.name"
-              show-environment
-            />
+            <DatabaseDisplay :database="target" show-environment />
           </template>
           <template v-else-if="isValidDatabaseGroupName(target)">
             <DatabaseGroupIcon

--- a/frontend/src/components/Plan/components/common/DatabaseDisplay.vue
+++ b/frontend/src/components/Plan/components/common/DatabaseDisplay.vue
@@ -16,16 +16,14 @@
     <span class="truncate text-gray-800">
       {{ databaseDisplayName }}
     </span>
-    <template v-if="project">
-      <router-link
-        class="pl-2 opacity-60 hover:opacity-100"
-        :to="databaseV1UrlWithProject(project, database)"
-        target="_blank"
-        @click.stop
-      >
-        <ExternalLinkIcon :size="16" />
-      </router-link>
-    </template>
+    <router-link
+      class="pl-2 opacity-60 hover:opacity-100"
+      :to="`/${database}`"
+      target="_blank"
+      @click.stop
+    >
+      <ExternalLinkIcon :size="16" />
+    </router-link>
   </div>
 </template>
 
@@ -40,14 +38,12 @@ import {
 } from "@/store";
 import { isValidDatabaseName, unknownInstance } from "@/types";
 import {
-  databaseV1UrlWithProject,
   extractDatabaseResourceName,
   extractInstanceResourceName,
 } from "@/utils";
 
 const props = defineProps<{
   database: string;
-  project?: string;
   showEnvironment?: boolean;
   size?: "small" | "medium" | "large";
 }>();

--- a/frontend/src/router/dashboard/instance.ts
+++ b/frontend/src/router/dashboard/instance.ts
@@ -5,6 +5,7 @@ import DashboardSidebar from "@/views/DashboardSidebar.vue";
 import { INSTANCE_ROUTE_DASHBOARD } from "./workspaceRoutes";
 
 export const INSTANCE_ROUTE_DETAIL = `${INSTANCE_ROUTE_DASHBOARD}.detail`;
+export const INSTANCE_ROUTE_DATABASE_DETAIL = `${INSTANCE_ROUTE_DASHBOARD}.database.detail`;
 
 const instanceRoutes: RouteRecordRaw[] = [
   {
@@ -25,6 +26,15 @@ const instanceRoutes: RouteRecordRaw[] = [
           requiredPermissionList: () => ["bb.instances.get"],
         },
         component: () => import("@/views/InstanceDetail.vue"),
+        props: true,
+      },
+      {
+        path: "databases/:databaseName",
+        name: INSTANCE_ROUTE_DATABASE_DETAIL,
+        meta: {
+          requiredPermissionList: () => ["bb.projects.get", "bb.databases.get"],
+        },
+        component: () => import("@/components/InstanceDatabaseRedirect.vue"),
         props: true,
       },
     ],

--- a/frontend/src/views/project/RolloutDetailLayout.vue
+++ b/frontend/src/views/project/RolloutDetailLayout.vue
@@ -5,13 +5,13 @@
         {{ $t("common.rollout") }}
       </NBreadcrumbItem>
       <NBreadcrumbItem @click="navigateToRollout">
-        {{ $t("rollout.stage.self", 2) }}
-      </NBreadcrumbItem>
-      <NBreadcrumbItem v-if="stageId" :clickable="false">
-        {{ stageTitle }}
+        <span>{{ $t("rollout.stage.self", 2) }}</span>
+        <span v-if="rollout.stages.length > 1" class="opacity-80 ml-1"
+          >({{ rollout.stages.length }})</span
+        >
       </NBreadcrumbItem>
       <NBreadcrumbItem v-if="stageId" @click="navigateToStage">
-        {{ $t("common.task", 2) }}
+        {{ stageTitle }}
       </NBreadcrumbItem>
       <NBreadcrumbItem v-if="taskId" :clickable="false">
         {{ $t("common.task") }} #{{ taskId }}
@@ -29,6 +29,7 @@
 import { NBreadcrumb, NBreadcrumbItem } from "naive-ui";
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { usePlanContextWithRollout } from "@/components/Plan";
 import { provideRolloutViewContext } from "@/components/Plan/components/RolloutView/context";
 import {
   PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
@@ -39,6 +40,7 @@ import { extractProjectResourceName } from "@/utils";
 
 const route = useRoute();
 const router = useRouter();
+const { rollout } = usePlanContextWithRollout();
 const { project } = useCurrentProjectV1();
 const environmentStore = useEnvironmentV1Store();
 const { mergedStages } = provideRolloutViewContext();


### PR DESCRIPTION
Add a new route `/instances/:instanceId/databases/:databaseName` for database detail page. It will always fetch the database info and redirect to `/projects/:projectId/instances/:instanceId/databases/:databaseName`