### PR TITLE
fix: skip CONCURRENTLY check for indexes on newly created tables

### DIFF
--- a/backend/plugin/advisor/pg/advisor_column_maximum_character_length.go
+++ b/backend/plugin/advisor/pg/advisor_column_maximum_character_length.go
@@ -73,7 +73,7 @@ func (checker *columnMaximumCharacterLengthChecker) Visit(in ast.Node) ast.Visit
 		for _, column := range node.ColumnList {
 			charLength := getCharLength(column)
 			if charLength > checker.maximum {
-				tableName = normalizeTableName(node.Name, "")
+				tableName = normalizeTableName(node.Name)
 				columnName = column.ColumnName
 				line = column.LastLine()
 				break
@@ -86,7 +86,7 @@ func (checker *columnMaximumCharacterLengthChecker) Visit(in ast.Node) ast.Visit
 				for _, column := range itemNode.ColumnList {
 					charLength := getCharLength(column)
 					if charLength > checker.maximum {
-						tableName = normalizeTableName(node.Table, "")
+						tableName = normalizeTableName(node.Table)
 						columnName = column.ColumnName
 						line = itemNode.LastLine()
 					}
@@ -94,7 +94,7 @@ func (checker *columnMaximumCharacterLengthChecker) Visit(in ast.Node) ast.Visit
 			case *ast.AlterColumnTypeStmt:
 				if char, ok := itemNode.Type.(*ast.Character); ok {
 					if char.Size > checker.maximum {
-						tableName = normalizeTableName(node.Table, "")
+						tableName = normalizeTableName(node.Table)
 						columnName = itemNode.ColumnName
 						line = itemNode.LastLine()
 					}

--- a/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
+++ b/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
@@ -37,9 +37,20 @@ func (*IndexConcurrentlyAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 	if err != nil {
 		return nil, err
 	}
+
+	// First pass: collect all newly created tables
+	newlyCreatedTables := make(map[string]bool)
+	for _, stmt := range stmtList {
+		if createTable, ok := stmt.(*ast.CreateTableStmt); ok {
+			tableName := normalizeTableName(createTable.Name, "")
+			newlyCreatedTables[tableName] = true
+		}
+	}
+
 	checker := &indexCreateConcurrentlyChecker{
-		level: level,
-		title: string(checkCtx.Rule.Type),
+		level:              level,
+		title:              string(checkCtx.Rule.Type),
+		newlyCreatedTables: newlyCreatedTables,
 	}
 
 	for _, stmt := range stmtList {
@@ -50,9 +61,10 @@ func (*IndexConcurrentlyAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 }
 
 type indexCreateConcurrentlyChecker struct {
-	adviceList []*storepb.Advice
-	level      storepb.Advice_Status
-	title      string
+	adviceList         []*storepb.Advice
+	level              storepb.Advice_Status
+	title              string
+	newlyCreatedTables map[string]bool
 }
 
 // Visit implements ast.Visitor interface.
@@ -60,6 +72,15 @@ func (checker *indexCreateConcurrentlyChecker) Visit(in ast.Node) ast.Visitor {
 	switch node := in.(type) {
 	case *ast.CreateIndexStmt:
 		if !node.Concurrently {
+			// Check if the index is being created on a newly created table
+			if node.Index != nil && node.Index.Table != nil {
+				tableName := normalizeTableName(node.Index.Table, "")
+				// Skip the check if the table is newly created
+				if checker.newlyCreatedTables[tableName] {
+					return checker
+				}
+			}
+
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
 				Code:          advisor.CreateIndexUnconcurrently.Int32(),

--- a/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
+++ b/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
@@ -42,7 +42,7 @@ func (*IndexConcurrentlyAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 	newlyCreatedTables := make(map[string]bool)
 	for _, stmt := range stmtList {
 		if createTable, ok := stmt.(*ast.CreateTableStmt); ok {
-			tableName := normalizeTableName(createTable.Name, "")
+			tableName := normalizeTableName(createTable.Name)
 			newlyCreatedTables[tableName] = true
 		}
 	}
@@ -74,7 +74,7 @@ func (checker *indexCreateConcurrentlyChecker) Visit(in ast.Node) ast.Visitor {
 		if !node.Concurrently {
 			// Check if the index is being created on a newly created table
 			if node.Index != nil && node.Index.Table != nil {
-				tableName := normalizeTableName(node.Index.Table, "")
+				tableName := normalizeTableName(node.Index.Table)
 				// Skip the check if the table is newly created
 				if checker.newlyCreatedTables[tableName] {
 					return checker

--- a/backend/plugin/advisor/pg/test/index_create_concurrently.yaml
+++ b/backend/plugin/advisor/pg/test/index_create_concurrently.yaml
@@ -11,3 +11,12 @@
       endposition: null
 - statement: create index concurrently on tech_book(id);
   changeType: 1
+- statement: |
+    CREATE TABLE feed_subscription (
+      id uuid NOT NULL DEFAULT gen_random_uuid(),
+      userId uuid NOT NULL,
+      projectId uuid,
+      CONSTRAINT PK_feed_subscription PRIMARY KEY (id)
+    );
+    CREATE INDEX IDX_feed_subscription_userId ON feed_subscription (userId);
+  changeType: 1

--- a/backend/plugin/advisor/pg/utils.go
+++ b/backend/plugin/advisor/pg/utils.go
@@ -35,11 +35,8 @@ func normalizeSchemaName(name string) string {
 	return "public"
 }
 
-func normalizeTableName(table *ast.TableDef, defaultSchema string) string {
+func normalizeTableName(table *ast.TableDef) string {
 	schema := table.Schema
-	if schema == "" && defaultSchema != "" {
-		schema = defaultSchema
-	}
 
 	if schema == "" {
 		return fmt.Sprintf("%q", table.Name)


### PR DESCRIPTION
## Summary
  This PR fixes an issue where the PostgreSQL advisor incorrectly flagged CREATE INDEX statements for missing the CONCURRENTLY keyword when the index was being created on a newly created table in the
   same script.

  Since newly created tables are empty, there's no need for the CONCURRENTLY keyword as there are no existing operations to block.

  ## Problem
  When running a script like:
  ```sql
  CREATE TABLE feed_subscription (
    id uuid NOT NULL DEFAULT uuid_generate_v4(),
    userId uuid NOT NULL,
    CONSTRAINT PK_feed_subscription PRIMARY KEY (id)
  );
  CREATE INDEX IDX_feed_subscription_userId ON feed_subscription (userId);
```

  The advisor would incorrectly report:
  "Creating indexes will block writes on the table, unless use CONCURRENTLY"

  This warning is unnecessary because the table is newly created and empty.

  Solution

  - Modified the IndexConcurrentlyAdvisor to track tables created within the same batch of SQL statements
  - Skip the CONCURRENTLY check when an index is being created on a newly created table