### PR TITLE
fix(parser): initialize sourceColumnsInFunction in subquery extractor

### DIFF
--- a/backend/plugin/parser/pg/query_span_extractor.go
+++ b/backend/plugin/parser/pg/query_span_extractor.go
@@ -1618,14 +1618,15 @@ func (q *querySpanExtractor) extractSourceColumnSetFromExpressionNode(node *pgqu
 		// So that the subquery can access the outer schema.
 		// The reason for new extractor is that we still need the current fromFieldList, overriding it is not expected.
 		subqueryExtractor := &querySpanExtractor{
-			ctx:               q.ctx,
-			defaultDatabase:   q.defaultDatabase,
-			searchPath:        q.searchPath,
-			metaCache:         q.metaCache,
-			gCtx:              q.gCtx,
-			ctes:              q.ctes,
-			outerTableSources: append(q.outerTableSources, q.tableSourcesFrom...),
-			tableSourcesFrom:  []base.TableSource{},
+			ctx:                     q.ctx,
+			defaultDatabase:         q.defaultDatabase,
+			searchPath:              q.searchPath,
+			metaCache:               q.metaCache,
+			gCtx:                    q.gCtx,
+			ctes:                    q.ctes,
+			outerTableSources:       append(q.outerTableSources, q.tableSourcesFrom...),
+			tableSourcesFrom:        []base.TableSource{},
+			sourceColumnsInFunction: make(base.SourceColumnSet),
 		}
 		tableSource, err := subqueryExtractor.extractTableSourceFromNode(node.SubLink.Subselect)
 		if err != nil {


### PR DESCRIPTION
Add initialization of sourceColumnsInFunction to the subqueryExtractor struct
in querySpanExtractor. This ensures that source columns used within functions
are properly tracked when extracting table sources from subqueries, preventing
potential issues with column resolution in nested queries.
Close BYT-7839