### PR TITLE
fix(executor): update task type handling for database tasks

### DIFF
--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -605,12 +605,12 @@ func needDump(taskType storepb.Task_Type) bool {
 	case
 		storepb.Task_DATABASE_SCHEMA_UPDATE,
 		storepb.Task_DATABASE_SCHEMA_UPDATE_SDL,
-		storepb.Task_DATABASE_SCHEMA_UPDATE_GHOST:
+		storepb.Task_DATABASE_SCHEMA_UPDATE_GHOST,
+		storepb.Task_DATABASE_CREATE,
+		storepb.Task_DATABASE_DATA_UPDATE:
 		return true
 	case
 		storepb.Task_TASK_TYPE_UNSPECIFIED,
-		storepb.Task_DATABASE_CREATE,
-		storepb.Task_DATABASE_DATA_UPDATE,
 		storepb.Task_DATABASE_EXPORT:
 		return false
 	default:

--- a/backend/tests/schema_update_test.go
+++ b/backend/tests/schema_update_test.go
@@ -99,8 +99,8 @@ func TestSchemaAndDataUpdate(t *testing.T) {
 		{
 			Type:       v1pb.Changelog_DATA,
 			Status:     v1pb.Changelog_DONE,
-			Schema:     "",
-			PrevSchema: "",
+			Schema:     dumpedSchema,
+			PrevSchema: dumpedSchema,
 			Version:    "",
 		},
 		{


### PR DESCRIPTION
Add Task_DATABASE_CREATE and Task_DATABASE_DATA_UPDATE to the list of
task types that return true in the executor's task type check. This
corrects the classification logic to ensure these database-related tasks
are properly recognized and handled during execution.