### PR TITLE
chore(helm-charts): remove tolerance for all taint

### DIFF
--- a/helm-charts/bytebase/templates/statefulset.yaml
+++ b/helm-charts/bytebase/templates/statefulset.yaml
@@ -221,10 +221,9 @@ spec:
         {{- if .Values.bytebase.affinity }}
         {{ toYaml .Values.bytebase.affinity | nindent 8 }}
         {{- end }}
-      tolerations:
-        {{- if .Values.bytebase.tolerations }}
-        {{ toYaml .Values.bytebase.tolerations | nindent 8 }}
-        {{- end }}
+      {{- if .Values.bytebase.tolerations }}
+      tolerations: {{ toYaml .Values.bytebase.tolerations | nindent 8 }}
+      {{- end }}
 ---
 {{- if and $persistenceEnable (not $persistenceExistingClaim) }}
 apiVersion: v1

--- a/helm-charts/bytebase/values.yaml
+++ b/helm-charts/bytebase/values.yaml
@@ -78,5 +78,5 @@ bytebase:
 
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   # An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.
-  tolerations:
-    - operator: "Exists"
+  tolerations: {}
+  #  - operator: "Exists"

--- a/helm-charts/bytebase/values.yaml
+++ b/helm-charts/bytebase/values.yaml
@@ -78,5 +78,8 @@ bytebase:
 
   # If specified, the pod's tolerations.
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: {}
-  #  - operator: "Exists"
+  tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"

--- a/helm-charts/bytebase/values.yaml
+++ b/helm-charts/bytebase/values.yaml
@@ -76,7 +76,7 @@ bytebase:
     #             values:
     #               - value
 
+  # If specified, the pod's tolerations.
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  # An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.
   tolerations: {}
   #  - operator: "Exists"


### PR DESCRIPTION
Many users are unknow that by default, all taints are tolerated, which leads to pods being scheduled on nodes where they shouldn't be. It is recommended not to set tolerations in the default configuration. Refer to:
- https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L1093
- https://github.com/grafana/helm-charts/blob/main/charts/tempo/values.yaml#L350
- https://github.com/bitnami/charts/blob/main/bitnami/etcd/values.yaml#L496