### PR TITLE
perf: reduce schema sync operations from 3 to 2 during migration

### DIFF
--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -352,8 +352,8 @@ func (s *Syncer) SyncInstance(ctx context.Context, instance *store.InstanceMessa
 	return updatedInstance, instanceMeta.Databases, newDatabases, nil
 }
 
-// syncDatabaseSchemaImpl is the internal implementation that handles both regular sync and sync with history.
-func (s *Syncer) syncDatabaseSchemaImpl(ctx context.Context, database *store.DatabaseMessage, createSyncHistory bool) (syncHistoryID int64, retErr error) {
+// doSyncDatabaseSchema is the core implementation that syncs the schema for a database and optionally creates a sync history record.
+func (s *Syncer) doSyncDatabaseSchema(ctx context.Context, database *store.DatabaseMessage, createSyncHistory bool) (syncHistoryID int64, retErr error) {
 	instance, err := s.store.GetInstanceV2(ctx, &store.FindInstanceMessage{ResourceID: &database.InstanceID})
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to get instance %q", database.InstanceID)
@@ -480,12 +480,12 @@ func (s *Syncer) syncDatabaseSchemaImpl(ctx context.Context, database *store.Dat
 
 // SyncDatabaseSchemaToHistory will sync the schema for a database and create a sync history record.
 func (s *Syncer) SyncDatabaseSchemaToHistory(ctx context.Context, database *store.DatabaseMessage) (int64, error) {
-	return s.syncDatabaseSchemaImpl(ctx, database, true)
+	return s.doSyncDatabaseSchema(ctx, database, true)
 }
 
 // SyncDatabaseSchema will sync the schema for a database.
 func (s *Syncer) SyncDatabaseSchema(ctx context.Context, database *store.DatabaseMessage) error {
-	_, err := s.syncDatabaseSchemaImpl(ctx, database, false)
+	_, err := s.doSyncDatabaseSchema(ctx, database, false)
 	return err
 }
 

--- a/backend/runner/taskrun/schema_update_executor.go
+++ b/backend/runner/taskrun/schema_update_executor.go
@@ -2,10 +2,7 @@ package taskrun
 
 import (
 	"context"
-	"log/slog"
-	"time"
 
-	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	"github.com/bytebase/bytebase/backend/component/state"
@@ -39,47 +36,11 @@ type SchemaUpdateExecutor struct {
 
 // RunOnce will run the schema update (DDL) task executor once.
 func (exec *SchemaUpdateExecutor) RunOnce(ctx context.Context, driverCtx context.Context, task *store.TaskMessage, taskRunUID int) (bool, *storepb.TaskRunResult, error) {
-	instance, err := exec.store.GetInstanceV2(ctx, &store.FindInstanceMessage{ResourceID: &task.InstanceID})
-	if err != nil {
-		return true, nil, err
-	}
-	database, err := exec.store.GetDatabaseV2(ctx, &store.FindDatabaseMessage{InstanceID: &task.InstanceID, DatabaseName: task.DatabaseName})
-	if err != nil {
-		return true, nil, err
-	}
-
 	sheetID := int(task.Payload.GetSheetId())
 	statement, err := exec.store.GetSheetStatementByID(ctx, sheetID)
 	if err != nil {
 		return true, nil, err
 	}
 
-	terminated, result, err := runMigration(ctx, driverCtx, exec.store, exec.dbFactory, exec.stateCfg, exec.schemaSyncer, exec.profile, task, taskRunUID, statement, task.Payload.GetSchemaVersion(), &sheetID)
-	// sync database schema anyways
-	exec.store.CreateTaskRunLogS(ctx, taskRunUID, time.Now(), exec.profile.DeployID, &storepb.TaskRunLog{
-		Type:              storepb.TaskRunLog_DATABASE_SYNC_START,
-		DatabaseSyncStart: &storepb.TaskRunLog_DatabaseSyncStart{},
-	})
-	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, database); err != nil {
-		exec.store.CreateTaskRunLogS(ctx, taskRunUID, time.Now(), exec.profile.DeployID, &storepb.TaskRunLog{
-			Type: storepb.TaskRunLog_DATABASE_SYNC_END,
-			DatabaseSyncEnd: &storepb.TaskRunLog_DatabaseSyncEnd{
-				Error: err.Error(),
-			},
-		})
-		slog.Error("failed to sync database schema",
-			slog.String("instanceName", instance.ResourceID),
-			slog.String("databaseName", database.DatabaseName),
-			log.BBError(err),
-		)
-	} else {
-		exec.store.CreateTaskRunLogS(ctx, taskRunUID, time.Now(), exec.profile.DeployID, &storepb.TaskRunLog{
-			Type: storepb.TaskRunLog_DATABASE_SYNC_END,
-			DatabaseSyncEnd: &storepb.TaskRunLog_DatabaseSyncEnd{
-				Error: "",
-			},
-		})
-	}
-
-	return terminated, result, err
+	return runMigration(ctx, driverCtx, exec.store, exec.dbFactory, exec.stateCfg, exec.schemaSyncer, exec.profile, task, taskRunUID, statement, task.Payload.GetSchemaVersion(), &sheetID)
 }

--- a/backend/runner/taskrun/schema_update_ghost_executor.go
+++ b/backend/runner/taskrun/schema_update_ghost_executor.go
@@ -149,32 +149,5 @@ func (exec *SchemaUpdateGhostExecutor) RunOnce(ctx context.Context, driverCtx co
 		}
 	}
 
-	terminated, result, err := runMigrationWithFunc(ctx, driverCtx, exec.s, exec.dbFactory, exec.stateCfg, exec.schemaSyncer, exec.profile, task, taskRunUID, statement, task.Payload.GetSchemaVersion(), &sheetID, execFunc)
-	// sync database schema anyways
-	exec.s.CreateTaskRunLogS(ctx, taskRunUID, time.Now(), exec.profile.DeployID, &storepb.TaskRunLog{
-		Type:              storepb.TaskRunLog_DATABASE_SYNC_START,
-		DatabaseSyncStart: &storepb.TaskRunLog_DatabaseSyncStart{},
-	})
-	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, database); err != nil {
-		exec.s.CreateTaskRunLogS(ctx, taskRunUID, time.Now(), exec.profile.DeployID, &storepb.TaskRunLog{
-			Type: storepb.TaskRunLog_DATABASE_SYNC_END,
-			DatabaseSyncEnd: &storepb.TaskRunLog_DatabaseSyncEnd{
-				Error: err.Error(),
-			},
-		})
-		slog.Error("failed to sync database schema",
-			slog.String("instanceName", instance.ResourceID),
-			slog.String("databaseName", database.DatabaseName),
-			log.BBError(err),
-		)
-	} else {
-		exec.s.CreateTaskRunLogS(ctx, taskRunUID, time.Now(), exec.profile.DeployID, &storepb.TaskRunLog{
-			Type: storepb.TaskRunLog_DATABASE_SYNC_END,
-			DatabaseSyncEnd: &storepb.TaskRunLog_DatabaseSyncEnd{
-				Error: "",
-			},
-		})
-	}
-
-	return terminated, result, err
+	return runMigrationWithFunc(ctx, driverCtx, exec.s, exec.dbFactory, exec.stateCfg, exec.schemaSyncer, exec.profile, task, taskRunUID, statement, task.Payload.GetSchemaVersion(), &sheetID, execFunc)
 }


### PR DESCRIPTION
## Summary
- Optimized schema migration process to reduce sync operations from 3 to 2
- Combined post-migration history sync with metadata update into a single operation
- Removed ~78 lines of redundant sync code from executor implementations

## Problem
During each schema migration, we were performing 3 separate database sync operations:
1. Pre-migration: Creates history snapshot
2. Post-migration: Creates history snapshot
3. Final: Updates live metadata

This was inefficient as operations 2 and 3 could be combined.

## Solution
Refactored the sync process to combine the post-migration history creation with metadata update:
1. Pre-migration: Creates history snapshot
2. Post-migration: Creates history AND updates metadata in one operation

### Changes Made
- **syncer.go**: Renamed internal implementation to `doSyncDatabaseSchema()` to avoid naming conflicts
- **executor.go**: Updated `endMigration()` to always perform schema sync (with or without history)
- **All executor files**: Removed redundant sync code since sync is now always done in `endMigration()`

## Performance Impact
- Reduces database operations by 33% during migrations
- Maintains all functionality for audit trails, rollback capabilities, and metadata accuracy
- Cleaner codebase with ~78 lines of redundant code removed

## Test Plan
- [ ] Verify schema migrations work correctly
- [ ] Confirm both pre and post migration history are created
- [ ] Validate metadata is properly updated after migration
- [ ] Test with different migration types (DDL, SDL, Ghost, Data)

🤖 Generated with [Claude Code](https://claude.ai/code)