### PR TITLE
refactor: remove deprecated --pg flag

### DIFF
--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -29,7 +29,7 @@ func getBaseProfile(dataDir string) *config.Profile {
 		Demo:               flags.demo,
 		Version:            version,
 		GitCommit:          gitcommit,
-		PgURL:              flags.pgURL,
+		PgURL:              os.Getenv("PG_URL"),
 		DeployID:           uuid.NewString()[:8],
 	}
 


### PR DESCRIPTION
## Summary
- Removed the deprecated `--pg` command-line flag entirely
- Updated code to use only the `PG_URL` environment variable for external PostgreSQL configuration
- Updated related documentation and comments

## Why
The `--pg` flag was redundant since we already support the `PG_URL` environment variable. Having two ways to configure the same thing adds unnecessary complexity. This change simplifies the codebase and enforces a single, consistent method for configuring external database connections.

## Migration Guide
Users currently using `--pg <connection-string>` should now use:
```bash
export PG_URL="<connection-string>"
./bytebase
```

## Test plan
- [x] Verified build compiles successfully
- [x] Linting passes without issues
- [ ] Test that PG_URL environment variable still works correctly
- [ ] Verify demo mode check still prevents external DB usage

🤖 Generated with [Claude Code](https://claude.ai/code)