### PR TITLE
refactor: remove --disable-sample flag and create SampleInstanceManager component

### DIFF
--- a/backend/api/v1/actuator_service.go
+++ b/backend/api/v1/actuator_service.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"context"
 	"log/slog"
-	"strconv"
 	"time"
 
 	"connectrpc.com/connect"
@@ -16,11 +15,11 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/component/config"
+	"github.com/bytebase/bytebase/backend/component/sampleinstance"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/generated-go/v1/v1connect"
-	"github.com/bytebase/bytebase/backend/resources/postgres"
 	"github.com/bytebase/bytebase/backend/runner/schemasync"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -28,10 +27,11 @@ import (
 // ActuatorService implements the Connect RPC interface for ActuatorService.
 type ActuatorService struct {
 	v1connect.UnimplementedActuatorServiceHandler
-	store          *store.Store
-	profile        *config.Profile
-	licenseService *enterprise.LicenseService
-	schemaSyncer   *schemasync.Syncer
+	store                 *store.Store
+	profile               *config.Profile
+	licenseService        *enterprise.LicenseService
+	schemaSyncer          *schemasync.Syncer
+	sampleInstanceManager *sampleinstance.Manager
 }
 
 // NewActuatorService creates a new ActuatorService.
@@ -40,12 +40,14 @@ func NewActuatorService(
 	profile *config.Profile,
 	schemaSyncer *schemasync.Syncer,
 	licenseService *enterprise.LicenseService,
+	sampleInstanceManager *sampleinstance.Manager,
 ) *ActuatorService {
 	return &ActuatorService{
-		store:          store,
-		profile:        profile,
-		licenseService: licenseService,
-		schemaSyncer:   schemaSyncer,
+		store:                 store,
+		profile:               profile,
+		licenseService:        licenseService,
+		schemaSyncer:          schemaSyncer,
+		sampleInstanceManager: sampleInstanceManager,
 	}
 }
 
@@ -124,158 +126,13 @@ func (s *ActuatorService) SetupSample(
 	if !ok || user == nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.New("user not found"))
 	}
-	if s.profile.SampleDatabasePort != 0 {
-		if err := s.generateOnboardingData(ctx, user); err != nil {
-			// When running inside docker on mac, we sometimes get database does not exist error.
-			// This is due to the docker overlay storage incompatibility with mac OS file system.
-			// Onboarding error is not critical, so we just emit an error log.
-			slog.Error("failed to prepare onboarding data", log.BBError(err))
-		}
+	if err := s.sampleInstanceManager.GenerateOnboardingData(ctx, user.ID, s.schemaSyncer); err != nil {
+		// When running inside docker on mac, we sometimes get database does not exist error.
+		// This is due to the docker overlay storage incompatibility with mac OS file system.
+		// Onboarding error is not critical, so we just emit an error log.
+		slog.Error("failed to prepare onboarding data", log.BBError(err))
 	}
 	return connect.NewResponse(&emptypb.Empty{}), nil
-}
-
-// generateOnboardingData generates onboarding data including project and instance.
-func (s *ActuatorService) generateOnboardingData(ctx context.Context, user *store.UserMessage) error {
-	userID := user.ID
-	setting := &storepb.Project{
-		AllowModifyStatement: true,
-		AutoResolveIssue:     true,
-	}
-
-	projectID := "project-sample"
-	project, err := s.store.GetProjectV2(ctx, &store.FindProjectMessage{
-		ResourceID: &projectID,
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to find onboarding project %v", projectID)
-	}
-	if project == nil {
-		sampleProject, err := s.store.CreateProjectV2(ctx, &store.ProjectMessage{
-			ResourceID: "project-sample",
-			Title:      "Sample Project",
-			Setting:    setting,
-		}, userID)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create onboarding project")
-		}
-		project = sampleProject
-	}
-
-	testEnvID := common.DefaultTestEnvironmentID
-	prodEnvID := common.DefaultProdEnvironmentID
-	instanceMessages := []*store.InstanceMessage{
-		{
-			ResourceID:    "test-sample-instance",
-			EnvironmentID: &testEnvID,
-			Metadata: &storepb.Instance{
-				Title: "Test Sample Instance",
-				DataSources: []*storepb.DataSource{
-					{
-						Port:     strconv.Itoa(s.profile.SampleDatabasePort),
-						Database: postgres.SampleDatabaseTest,
-					},
-				},
-			},
-		},
-		{
-			ResourceID:    "prod-sample-instance",
-			EnvironmentID: &prodEnvID,
-			Metadata: &storepb.Instance{
-				Title: "Prod Sample Instance",
-				DataSources: []*storepb.DataSource{
-					{
-						Port:     strconv.Itoa(s.profile.SampleDatabasePort + 1),
-						Database: postgres.SampleDatabaseProd,
-					},
-				},
-			},
-		},
-	}
-	for _, instanceMessage := range instanceMessages {
-		if err := s.generateInstance(ctx, project.ResourceID, instanceMessage); err != nil {
-			slog.Error("failed to prepare onboarding instance", log.BBError(err), slog.String("instance", instanceMessage.ResourceID))
-		}
-	}
-
-	return nil
-}
-
-func (s *ActuatorService) generateInstance(
-	ctx context.Context,
-	projectID string,
-	instanceMessage *store.InstanceMessage,
-) error {
-	// Generate Sample Instance
-	instance, err := s.store.GetInstanceV2(ctx, &store.FindInstanceMessage{
-		ResourceID: &instanceMessage.ResourceID,
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to find onboarding instance %v", instanceMessage.ResourceID)
-	}
-	if instance == nil {
-		sampleInstance, err := s.store.CreateInstanceV2(ctx, &store.InstanceMessage{
-			ResourceID:    instanceMessage.ResourceID,
-			EnvironmentID: instanceMessage.EnvironmentID,
-			Metadata: &storepb.Instance{
-				Title:        instanceMessage.Metadata.Title,
-				Engine:       storepb.Engine_POSTGRES,
-				ExternalLink: "",
-				Activation:   false,
-				DataSources: []*storepb.DataSource{
-					{
-						Id:       "admin",
-						Type:     storepb.DataSourceType_ADMIN,
-						Username: postgres.SampleUser,
-						Password: "",
-						Host:     common.GetPostgresSocketDir(),
-						Port:     instanceMessage.Metadata.DataSources[0].Port,
-						Database: instanceMessage.Metadata.DataSources[0].Database,
-					},
-				},
-			},
-		})
-		if err != nil {
-			return errors.Wrapf(err, "failed to create onboarding instance %v", instanceMessage.ResourceID)
-		}
-		instance = sampleInstance
-	}
-
-	// Sync the instance schema so we can transfer the sample database later.
-	if _, _, _, err := s.schemaSyncer.SyncInstance(ctx, instance); err != nil {
-		return errors.Wrapf(err, "failed to sync onboarding instance %v", instance.ResourceID)
-	}
-
-	dbName := instanceMessage.Metadata.DataSources[0].Database
-	// Transfer sample database to the just created project.
-	transferDatabaseMessage := &store.UpdateDatabaseMessage{
-		InstanceID:   instance.ResourceID,
-		DatabaseName: dbName,
-		ProjectID:    &projectID,
-	}
-	_, err = s.store.UpdateDatabase(ctx, transferDatabaseMessage)
-	if err != nil {
-		return errors.Wrapf(err, "failed to transfer sample database %v", dbName)
-	}
-
-	testDatabase, err := s.store.GetDatabaseV2(ctx, &store.FindDatabaseMessage{
-		InstanceID:      &instance.ResourceID,
-		DatabaseName:    &dbName,
-		IsCaseSensitive: store.IsObjectCaseSensitive(instance),
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to find onboarding database %v", dbName)
-	}
-	if testDatabase == nil {
-		return errors.Errorf("database %q not found", dbName)
-	}
-
-	// Need to sync database schema so we can configure sensitive data policy and create the schema
-	// update issue later.
-	if err := s.schemaSyncer.SyncDatabaseSchema(ctx, testDatabase); err != nil {
-		return errors.Wrapf(err, "failed to sync sample database schema %v", dbName)
-	}
-	return nil
 }
 
 func (s *ActuatorService) getServerInfo(ctx context.Context) (*v1pb.ActuatorInfo, error) {
@@ -310,6 +167,9 @@ func (s *ActuatorService) getServerInfo(ctx context.Context) (*v1pb.ActuatorInfo
 		unlicensedFeaturesString = append(unlicensedFeaturesString, f.String())
 	}
 
+	// Check if sample instances are available
+	hasSampleInstances, _ := s.store.HasSampleInstances(ctx)
+
 	serverInfo := v1pb.ActuatorInfo{
 		Version:                s.profile.Version,
 		GitCommit:              s.profile.GitCommit,
@@ -326,7 +186,7 @@ func (s *ActuatorService) getServerInfo(ctx context.Context) (*v1pb.ActuatorInfo
 		UnlicensedFeatures:     unlicensedFeaturesString,
 		DisallowPasswordSignin: setting.DisallowPasswordSignin,
 		PasswordRestriction:    passwordSetting,
-		EnableSample:           s.profile.SampleDatabasePort != 0,
+		EnableSample:           hasSampleInstances,
 	}
 
 	stats, err := s.store.StatUsers(ctx)

--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -10,19 +10,12 @@ import (
 )
 
 func getBaseProfile(dataDir string) *config.Profile {
-	sampleDatabasePort := 0
-	if !flags.disableSample && !flags.saas {
-		// Using flags.port + 3 as our sample database port if not disabled and not in SaaS mode.
-		sampleDatabasePort = flags.port + 3
-	}
-
 	config := &config.Profile{
-		ExternalURL:        flags.externalURL,
-		Port:               flags.port,     // Using flags.port as our gRPC server port.
-		DatastorePort:      flags.port + 2, // Using flags.port + 2 as our datastore port.
-		SampleDatabasePort: sampleDatabasePort,
-		HA:                 flags.ha,
-		SaaS:               flags.saas,
+		ExternalURL:   flags.externalURL,
+		Port:          flags.port,     // Using flags.port as our gRPC server port.
+		DatastorePort: flags.port + 2, // Using flags.port + 2 as our datastore port.
+		HA:            flags.ha,
+		SaaS:          flags.saas,
 		EnableJSONLogging:  flags.enableJSONLogging,
 		IsDocker:           isDocker(),
 		DataDir:            dataDir,

--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -11,19 +11,19 @@ import (
 
 func getBaseProfile(dataDir string) *config.Profile {
 	config := &config.Profile{
-		ExternalURL:   flags.externalURL,
-		Port:          flags.port,     // Using flags.port as our gRPC server port.
-		DatastorePort: flags.port + 2, // Using flags.port + 2 as our datastore port.
-		HA:            flags.ha,
-		SaaS:          flags.saas,
-		EnableJSONLogging:  flags.enableJSONLogging,
-		IsDocker:           isDocker(),
-		DataDir:            dataDir,
-		Demo:               flags.demo,
-		Version:            version,
-		GitCommit:          gitcommit,
-		PgURL:              os.Getenv("PG_URL"),
-		DeployID:           uuid.NewString()[:8],
+		ExternalURL:       flags.externalURL,
+		Port:              flags.port,     // Using flags.port as our gRPC server port.
+		DatastorePort:     flags.port + 2, // Using flags.port + 2 as our datastore port.
+		HA:                flags.ha,
+		SaaS:              flags.saas,
+		EnableJSONLogging: flags.enableJSONLogging,
+		IsDocker:          isDocker(),
+		DataDir:           dataDir,
+		Demo:              flags.demo,
+		Version:           version,
+		GitCommit:         gitcommit,
+		PgURL:             os.Getenv("PG_URL"),
+		DeployID:          uuid.NewString()[:8],
 	}
 
 	config.LastActiveTS.Store(time.Now().Unix())

--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -69,8 +69,6 @@ var (
 		// demo mode.
 		demo  bool
 		debug bool
-		// disableSample is the flag to disable the sample instance.
-		disableSample bool
 		// memoryProfileThreshold is the threshold of memory usage in bytes to trigger a memory profile.
 		memoryProfileThreshold uint64
 	}
@@ -106,7 +104,6 @@ func init() {
 	// Must be one of the subpath name in the ../migrator/demo directory
 	rootCmd.PersistentFlags().BoolVar(&flags.demo, "demo", false, "run in demo mode.")
 	rootCmd.PersistentFlags().BoolVar(&flags.debug, "debug", false, "whether to enable debug level logging")
-	rootCmd.PersistentFlags().BoolVar(&flags.disableSample, "disable-sample", false, "disable the sample instance")
 	rootCmd.PersistentFlags().Uint64Var(&flags.memoryProfileThreshold, "memory-profile-threshold", 0, "the threshold of memory usage in bytes to trigger a memory profile")
 }
 

--- a/backend/component/config/profile.go
+++ b/backend/component/config/profile.go
@@ -18,9 +18,6 @@ type Profile struct {
 	// DatastorePort is the binding port for database instance for storing Bytebase metadata.
 	// Only applicable when using embedded PG (PgURL is empty).
 	DatastorePort int
-	// SampleDatabasePort is the start binding port for sample database instance.
-	// If SampleDatabasePort is not 0, then we start 2 sample instance at SampleDatabasePort and SampleDatabasePort+1.
-	SampleDatabasePort int
 	// Port is the binding port for the server.
 	Port int
 	// When we are running in SaaS mode, some features are not allowed to edit by users.

--- a/backend/component/sampleinstance/manager.go
+++ b/backend/component/sampleinstance/manager.go
@@ -1,0 +1,299 @@
+// Package sampleinstance manages sample database instances.
+package sampleinstance
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/log"
+	"github.com/bytebase/bytebase/backend/component/config"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/resources/postgres"
+	"github.com/bytebase/bytebase/backend/runner/schemasync"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+// Manager manages sample database instances lifecycle.
+type Manager struct {
+	mu       sync.Mutex
+	store    *store.Store
+	profile  *config.Profile
+	stoppers []func()
+	port     int // The base port for sample instances
+}
+
+// NewManager creates a new sample instance manager.
+func NewManager(store *store.Store, profile *config.Profile) *Manager {
+	// Using profile.Port + 3 as our sample database port.
+	// The actual startup of sample instances will be determined by checking the instance table.
+	port := profile.Port + 3
+
+	return &Manager{
+		store:   store,
+		profile: profile,
+		port:    port,
+	}
+}
+
+// StartIfExist starts sample instances if they exist in the database.
+func (m *Manager) StartIfExist(ctx context.Context) error {
+	// Check if sample instances exist in the database
+	hasSampleInstances, err := m.store.HasSampleInstances(ctx)
+	if err != nil {
+		slog.Warn("failed to check for sample instances", log.BBError(err))
+		return nil // Non-fatal error
+	}
+
+	if !hasSampleInstances {
+		slog.Info("no sample instances found in database, skipping sample instance startup")
+		return nil
+	}
+
+	// Start all sample instances
+	slog.Info("starting sample instances")
+	stoppers := postgres.StartAllSampleInstances(ctx, m.profile.DataDir, m.port)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.stoppers = stoppers
+
+	return nil
+}
+
+// HandleInstanceDeletion handles the deletion of a sample instance.
+// We stop all sample instances only when both have been deleted.
+func (m *Manager) HandleInstanceDeletion(ctx context.Context, instanceID string) error {
+	if instanceID != "test-sample-instance" && instanceID != "prod-sample-instance" {
+		// Not a sample instance
+		return nil
+	}
+
+	// Check if any sample instances still exist after this deletion
+	hasSampleInstances, err := m.store.HasSampleInstances(ctx)
+	if err != nil {
+		slog.Warn("failed to check for remaining sample instances", log.BBError(err))
+		return nil // Non-fatal error
+	}
+
+	if hasSampleInstances {
+		// At least one sample instance still exists, don't stop
+		slog.Info("sample instance deleted but others remain, keeping processes running", slog.String("instance", instanceID))
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.stoppers) == 0 {
+		// No sample instances running
+		return nil
+	}
+
+	// Stop all sample instances when both have been deleted
+	slog.Info("stopping all sample instances as none remain in database", slog.String("instance", instanceID))
+	for _, stopper := range m.stoppers {
+		if stopper != nil {
+			stopper()
+		}
+	}
+	m.stoppers = nil
+
+	return nil
+}
+
+// HandleInstanceCreation handles the creation of a sample instance.
+// When any sample instance is created, we start all sample instances.
+func (m *Manager) HandleInstanceCreation(ctx context.Context, instanceID string) error {
+	if instanceID != "test-sample-instance" && instanceID != "prod-sample-instance" {
+		// Not a sample instance
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if already running
+	if len(m.stoppers) > 0 {
+		slog.Info("sample instances already running", slog.String("instance", instanceID))
+		return nil
+	}
+
+	// Start all sample instances when any one is created
+	slog.Info("starting all sample instances due to creation", slog.String("instance", instanceID))
+	stoppers := postgres.StartAllSampleInstances(ctx, m.profile.DataDir, m.port)
+	m.stoppers = stoppers
+
+	return nil
+}
+
+// Stop stops all sample instances.
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, stopper := range m.stoppers {
+		if stopper != nil {
+			stopper()
+		}
+	}
+	m.stoppers = nil
+}
+
+// Port returns the base port for sample instances.
+func (m *Manager) Port() int {
+	return m.port
+}
+
+// GenerateOnboardingData generates onboarding data including project and instance.
+func (m *Manager) GenerateOnboardingData(ctx context.Context, userID int, schemaSyncer *schemasync.Syncer) error {
+	setting := &storepb.Project{
+		AllowModifyStatement: true,
+		AutoResolveIssue:     true,
+	}
+
+	projectID := "project-sample"
+	project, err := m.store.GetProjectV2(ctx, &store.FindProjectMessage{
+		ResourceID: &projectID,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find onboarding project %v", projectID)
+	}
+	if project == nil {
+		sampleProject, err := m.store.CreateProjectV2(ctx, &store.ProjectMessage{
+			ResourceID: "project-sample",
+			Title:      "Sample Project",
+			Setting:    setting,
+		}, userID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create onboarding project")
+		}
+		project = sampleProject
+	}
+
+	testEnvID := common.DefaultTestEnvironmentID
+	prodEnvID := common.DefaultProdEnvironmentID
+	instanceMessages := []*store.InstanceMessage{
+		{
+			ResourceID:    "test-sample-instance",
+			EnvironmentID: &testEnvID,
+			Metadata: &storepb.Instance{
+				Title: "Test Sample Instance",
+				DataSources: []*storepb.DataSource{
+					{
+						Port:     strconv.Itoa(m.port),
+						Database: postgres.SampleDatabaseTest,
+					},
+				},
+			},
+		},
+		{
+			ResourceID:    "prod-sample-instance",
+			EnvironmentID: &prodEnvID,
+			Metadata: &storepb.Instance{
+				Title: "Prod Sample Instance",
+				DataSources: []*storepb.DataSource{
+					{
+						Port:     strconv.Itoa(m.port + 1),
+						Database: postgres.SampleDatabaseProd,
+					},
+				},
+			},
+		},
+	}
+	for _, instanceMessage := range instanceMessages {
+		if err := m.generateInstance(ctx, project.ResourceID, instanceMessage, schemaSyncer); err != nil {
+			slog.Error("failed to prepare onboarding instance", log.BBError(err), slog.String("instance", instanceMessage.ResourceID))
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) generateInstance(
+	ctx context.Context,
+	projectID string,
+	instanceMessage *store.InstanceMessage,
+	schemaSyncer *schemasync.Syncer,
+) error {
+	// Generate Sample Instance
+	instance, err := m.store.GetInstanceV2(ctx, &store.FindInstanceMessage{
+		ResourceID: &instanceMessage.ResourceID,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find onboarding instance %v", instanceMessage.ResourceID)
+	}
+	if instance == nil {
+		sampleInstance, err := m.store.CreateInstanceV2(ctx, &store.InstanceMessage{
+			ResourceID:    instanceMessage.ResourceID,
+			EnvironmentID: instanceMessage.EnvironmentID,
+			Metadata: &storepb.Instance{
+				Title:        instanceMessage.Metadata.Title,
+				Engine:       storepb.Engine_POSTGRES,
+				ExternalLink: "",
+				Activation:   false,
+				DataSources: []*storepb.DataSource{
+					{
+						Id:       "admin",
+						Type:     storepb.DataSourceType_ADMIN,
+						Username: postgres.SampleUser,
+						Password: "",
+						Host:     common.GetPostgresSocketDir(),
+						Port:     instanceMessage.Metadata.DataSources[0].Port,
+						Database: instanceMessage.Metadata.DataSources[0].Database,
+					},
+				},
+			},
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to create onboarding instance %v", instanceMessage.ResourceID)
+		}
+		instance = sampleInstance
+
+		// Start the sample instance if needed
+		if err := m.HandleInstanceCreation(ctx, instance.ResourceID); err != nil {
+			slog.Warn("failed to start sample instance during onboarding", log.BBError(err), slog.String("instance", instance.ResourceID))
+		}
+	}
+
+	// Sync the instance schema so we can transfer the sample database later.
+	if _, _, _, err := schemaSyncer.SyncInstance(ctx, instance); err != nil {
+		return errors.Wrapf(err, "failed to sync onboarding instance %v", instance.ResourceID)
+	}
+
+	dbName := instanceMessage.Metadata.DataSources[0].Database
+	// Transfer sample database to the just created project.
+	transferDatabaseMessage := &store.UpdateDatabaseMessage{
+		InstanceID:   instance.ResourceID,
+		DatabaseName: dbName,
+		ProjectID:    &projectID,
+	}
+	_, err = m.store.UpdateDatabase(ctx, transferDatabaseMessage)
+	if err != nil {
+		return errors.Wrapf(err, "failed to transfer sample database %v", dbName)
+	}
+
+	testDatabase, err := m.store.GetDatabaseV2(ctx, &store.FindDatabaseMessage{
+		InstanceID:      &instance.ResourceID,
+		DatabaseName:    &dbName,
+		IsCaseSensitive: store.IsObjectCaseSensitive(instance),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find onboarding database %v", dbName)
+	}
+	if testDatabase == nil {
+		return errors.Errorf("database %q not found", dbName)
+	}
+
+	// Need to sync database schema so we can configure sensitive data policy and create the schema
+	// update issue later.
+	if err := schemaSyncer.SyncDatabaseSchema(ctx, testDatabase); err != nil {
+		return errors.Wrapf(err, "failed to sync sample database schema %v", dbName)
+	}
+	return nil
+}

--- a/backend/server/grpc_routes.go
+++ b/backend/server/grpc_routes.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	"github.com/bytebase/bytebase/backend/component/iam"
+	"github.com/bytebase/bytebase/backend/component/sampleinstance"
 	"github.com/bytebase/bytebase/backend/component/sheet"
 	"github.com/bytebase/bytebase/backend/component/state"
 	"github.com/bytebase/bytebase/backend/component/webhook"
@@ -49,6 +50,7 @@ func configureGrpcRouters(
 	webhookManager *webhook.Manager,
 	iamManager *iam.Manager,
 	secret string,
+	sampleInstanceManager *sampleinstance.Manager,
 ) error {
 	// Note: the gateway response modifier takes the token duration on server startup. If the value is changed,
 	// the user has to restart the server to take the latest value.
@@ -74,7 +76,7 @@ func configureGrpcRouters(
 			grpcruntime.DefaultHTTPErrorHandler(ctx, sm, m, w, r, err)
 		}),
 	)
-	actuatorService := apiv1.NewActuatorService(stores, profile, schemaSyncer, licenseService)
+	actuatorService := apiv1.NewActuatorService(stores, profile, schemaSyncer, licenseService, sampleInstanceManager)
 	auditLogService := apiv1.NewAuditLogService(stores, iamManager, licenseService)
 	authService := apiv1.NewAuthService(stores, secret, licenseService, metricReporter, profile, stateCfg, iamManager)
 	celService := apiv1.NewCelService()
@@ -85,7 +87,7 @@ func configureGrpcRouters(
 	groupService := apiv1.NewGroupService(stores, iamManager, licenseService)
 	identityProviderService := apiv1.NewIdentityProviderService(stores, licenseService)
 	instanceRoleService := apiv1.NewInstanceRoleService(stores, dbFactory)
-	instanceService := apiv1.NewInstanceService(stores, licenseService, metricReporter, stateCfg, dbFactory, schemaSyncer, iamManager)
+	instanceService := apiv1.NewInstanceService(stores, licenseService, metricReporter, stateCfg, dbFactory, schemaSyncer, iamManager, sampleInstanceManager)
 	issueService := apiv1.NewIssueService(stores, webhookManager, stateCfg, licenseService, profile, iamManager, metricReporter)
 	orgPolicyService := apiv1.NewOrgPolicyService(stores, licenseService)
 	planService := apiv1.NewPlanService(stores, sheetManager, licenseService, dbFactory, stateCfg, profile, iamManager)

--- a/backend/store/instance.go
+++ b/backend/store/instance.go
@@ -466,3 +466,15 @@ func (s *Store) unObfuscateInstance(ctx context.Context, instance *storepb.Insta
 	}
 	return nil
 }
+
+// HasSampleInstances checks if there are sample instances in the database.
+func (s *Store) HasSampleInstances(ctx context.Context) (bool, error) {
+	instances, err := s.ListInstancesV2(ctx, &FindInstanceMessage{
+		ResourceIDs: &[]string{"test-sample-instance", "prod-sample-instance"},
+		ShowDeleted: false,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(instances) > 0, nil
+}

--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -242,11 +242,10 @@ func (ctl *controller) initWorkspaceProfile(ctx context.Context) error {
 // pgURL for connect to Postgres.
 func getTestProfileWithExternalPg(port int, pgURL string) *component.Profile {
 	return &component.Profile{
-		Mode:               common.ReleaseModeDev,
-		ExternalURL:        fmt.Sprintf("http://localhost:%d", port),
-		Port:               port,
-		SampleDatabasePort: 0,
-		PgURL:              pgURL,
+		Mode:        common.ReleaseModeDev,
+		ExternalURL: fmt.Sprintf("http://localhost:%d", port),
+		Port:        port,
+		PgURL:       pgURL,
 	}
 }
 

--- a/frontend/src/views/Setup/AdminSetup.vue
+++ b/frontend/src/views/Setup/AdminSetup.vue
@@ -72,10 +72,7 @@
                 </div>
               </div>
             </NRadio>
-            <NRadio
-              v-if="actuatorV1Store.serverInfo?.enableSample"
-              :value="'builtin-sample'"
-            >
+            <NRadio :value="'builtin-sample'">
               <div>
                 <p class="font-medium">
                   {{ $t("setup.data.built-in") }}


### PR DESCRIPTION
## Summary
This PR removes the `--disable-sample` command-line flag and replaces it with a database-driven approach for managing sample Postgres instances. A new dedicated `SampleInstanceManager` component has been created to centralize all sample instance logic.

## Key Changes
- ✅ Removed `--disable-sample` command-line flag from server startup
- ✅ Created `SampleInstanceManager` component under `backend/component/sampleinstance`
- ✅ Sample instances now start/stop based on their existence in the database
- ✅ Moved onboarding data generation logic to the component
- ✅ Simplified code by removing SaaS-specific logic

## Behavior Changes
### Before
- Sample instances controlled by `--disable-sample` flag at server startup
- Required server restart to enable/disable samples
- SaaS deployments had special handling

### After
- Sample instances automatically start when they exist in the instance table
- Sample instances stop when all are deleted from the database  
- Can be controlled through UI without server restart
- Consistent behavior across all deployment types

## Implementation Details
The new `SampleInstanceManager` component handles:
- Starting sample instances on server startup if they exist
- Starting sample instances when created via UI onboarding
- Stopping sample instances only when both test and prod instances are deleted
- Managing sample database ports
- Generating onboarding data

## Test Plan
- [x] Build passes
- [x] Linting passes (golangci-lint)
- [x] Sample instances start when present in database
- [x] Sample instances stop when all deleted
- [x] Onboarding flow creates sample instances correctly

🤖 Generated with [Claude Code](https://claude.ai/code)