### PR TITLE
fix: prevent nil pointer panic in sample instance manager shutdown

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -311,7 +311,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 
 	// Shutdown sample instances
-	s.sampleInstanceManager.Stop()
+	if s.sampleInstanceManager != nil {
+		s.sampleInstanceManager.Stop()
+	}
 
 	// Shutdown postgres instances.
 	for _, stopper := range s.stopper {


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference that occurs when `Server.Shutdown()` is called during error handling before `sampleInstanceManager` is initialized
- Add defensive nil check before calling `Stop()` on the sample instance manager

## Problem
When server initialization fails early (e.g., during store creation or schema migration), the deferred cleanup function calls `Shutdown()`, which then attempts to call `Stop()` on a nil `sampleInstanceManager`, causing a panic at `backend/component/sampleinstance/manager.go:137`.

## Solution
Added a nil check in `backend/server/server.go` before calling `sampleInstanceManager.Stop()` to gracefully handle cases where the manager hasn't been initialized yet.

## Test plan
- [x] Build succeeds without errors
- [x] Linting passes with no issues
- [ ] Manual testing: Server shutdown works correctly both with and without sample instances

🤖 Generated with [Claude Code](https://claude.ai/code)