### PR TITLE
fix: reset search_path after loading demo data to prevent migration errors

### DIFF
--- a/backend/demo/demo.go
+++ b/backend/demo/demo.go
@@ -44,6 +44,13 @@ func LoadDemoData(ctx context.Context, db *sql.DB) error {
 		return err
 	}
 
+	// Reset the search_path to public after loading demo data
+	// The dump.sql contains pg_catalog.set_config('search_path', '', false) which
+	// clears the search_path for the session, causing subsequent queries to fail
+	if _, err := db.Exec("SET search_path TO public"); err != nil {
+		return err
+	}
+
 	slog.Info("Completed demo data setup.")
 	return nil
 }


### PR DESCRIPTION
## Summary
- Fixed an issue where running Bytebase with `--demo` flag would fail with "relation 'instance_change_history' does not exist" error
- The root cause was that demo dump.sql clears the search_path for the database session, causing subsequent migration queries to fail
- Added a fix to restore the search_path to 'public' after loading demo data

## Problem
When starting Bytebase with the `--demo` flag, the server initialization would fail with:
```
ERROR: relation "instance_change_history" does not exist (SQLSTATE 42P01)
```

This occurred because:
1. The demo dump.sql file contains `pg_catalog.set_config('search_path', '', false)` which clears the search_path for the entire database session
2. After loading demo data, the migrator would run and try to query tables without schema prefixes
3. With an empty search_path, PostgreSQL couldn't find the tables, resulting in the error

## Solution
After loading the demo data and committing the transaction, we now explicitly reset the search_path to 'public'. This ensures that subsequent queries in the migrator can find tables correctly.

## Test plan
- [x] Start Bytebase with `--demo` flag and verify it starts successfully
- [x] Verify demo data is loaded correctly
- [x] Confirm migration completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)