### PR TITLE
perf: optimize GetSchemaString API calls in schema editor

### DIFF
--- a/frontend/src/components/Plan/components/AddSpecDrawer.vue
+++ b/frontend/src/components/Plan/components/AddSpecDrawer.vue
@@ -453,11 +453,17 @@ const handlePreviewDDL = async () => {
   try {
     const target = schemaEditTargets.value[0];
     const applyMetadataEdit = schemaEditorRef.value?.applyMetadataEdit;
+    const refreshPreview = schemaEditorRef.value?.refreshPreview;
 
     if (typeof applyMetadataEdit === "function") {
       const { database, metadata, catalog, baselineMetadata, baselineCatalog } =
         target;
       applyMetadataEdit(database, metadata, catalog);
+
+      // Trigger preview refresh in the schema editor
+      if (typeof refreshPreview === "function") {
+        refreshPreview();
+      }
 
       const result = await generateDiffDDL({
         database,
@@ -509,6 +515,7 @@ const handleConfirm = async () => {
     ) {
       const target = schemaEditTargets.value[0];
       const applyMetadataEdit = schemaEditorRef.value?.applyMetadataEdit;
+      const refreshPreview = schemaEditorRef.value?.refreshPreview;
 
       if (typeof applyMetadataEdit === "function") {
         const {
@@ -519,6 +526,11 @@ const handleConfirm = async () => {
           baselineCatalog,
         } = target;
         applyMetadataEdit(database, metadata, catalog);
+
+        // Trigger preview refresh before generating final DDL
+        if (typeof refreshPreview === "function") {
+          refreshPreview();
+        }
 
         const result = await generateDiffDDL({
           database,

--- a/frontend/src/components/SchemaEditorLite/Panels/PreviewPane.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/PreviewPane.vue
@@ -45,7 +45,6 @@
 <script setup lang="ts">
 import { create } from "@bufbuild/protobuf";
 import {
-  refDebounced,
   useElementSize,
   useLocalStorage,
   useParentElement,
@@ -54,6 +53,7 @@ import { ChevronDownIcon } from "lucide-vue-next";
 import { computed, toRef, ref, watch } from "vue";
 import { MonacoEditor } from "@/components/MonacoEditor";
 import MaskSpinner from "@/components/misc/MaskSpinner.vue";
+import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
 import { databaseServiceClientConnect } from "@/grpcweb";
 import type { ComposedDatabase } from "@/types";
 import type { DatabaseCatalog } from "@/types/proto-es/v1/database_catalog_service_pb";
@@ -74,7 +74,7 @@ const props = defineProps<{
   mocked: { metadata: DatabaseMetadata; catalog: DatabaseCatalog } | undefined;
 }>();
 
-const { hidePreview } = useSchemaEditorContext();
+const { hidePreview, events } = useSchemaEditorContext();
 const expanded = useLocalStorage("bb.schema-editor.preview.expanded", true);
 const parentElement = useParentElement();
 const { height: parentHeight } = useElementSize(parentElement);
@@ -87,21 +87,23 @@ const panelHeight = computed(() => {
 });
 
 const mocked = toRef(props, "mocked");
-const debouncedMocked = refDebounced(mocked, 500);
 
 // Simple replacement for useQuery to avoid @tanstack/vue-query dependency
-const status = ref<"pending" | "success" | "error">("pending");
+const status = ref<"pending" | "success" | "error">("success");
 const data = ref<string>("");
 const error = ref<Error | null>(null);
 
-const fetchSchemaString = async (currentMocked = debouncedMocked.value) => {
+// Track whether we've fetched at least once when expanded
+const hasFetchedOnce = ref(false);
+
+const fetchSchemaString = async () => {
   if (!expanded.value) {
     data.value = "";
     status.value = "success";
     return;
   }
 
-  if (!currentMocked) {
+  if (!mocked.value) {
     data.value = "";
     status.value = "success";
     return;
@@ -111,7 +113,7 @@ const fetchSchemaString = async (currentMocked = debouncedMocked.value) => {
   error.value = null;
 
   try {
-    const { metadata } = currentMocked;
+    const { metadata } = mocked.value;
     const request = create(GetSchemaStringRequestSchema, {
       name: props.db.name,
       metadata: metadata,
@@ -119,26 +121,44 @@ const fetchSchemaString = async (currentMocked = debouncedMocked.value) => {
     const response =
       await databaseServiceClientConnect.getSchemaString(request);
 
-    // Only update if this is still the latest request (avoid race conditions)
-    if (currentMocked === debouncedMocked.value) {
-      data.value = response.schemaString;
-      status.value = "success";
-    }
+    data.value = response.schemaString;
+    status.value = "success";
+    hasFetchedOnce.value = true;
   } catch (err) {
-    // Only update error if this is still the latest request
-    if (currentMocked === debouncedMocked.value) {
-      error.value = new Error(extractGrpcErrorMessage(err));
-      status.value = "error";
-    }
+    error.value = new Error(extractGrpcErrorMessage(err));
+    status.value = "error";
   }
 };
 
-// Watch for changes and refetch
+// Only fetch when the panel is expanded for the first time
+// Subsequent fetches will only happen on manual trigger
 watch(
-  [debouncedMocked, expanded],
-  ([newMocked]) => {
-    fetchSchemaString(newMocked);
+  expanded,
+  (newExpanded) => {
+    if (newExpanded && !hasFetchedOnce.value && mocked.value) {
+      fetchSchemaString();
+    }
   },
   { immediate: true }
 );
+
+// Reset hasFetchedOnce when panel is collapsed
+watch(expanded, (newExpanded) => {
+  if (!newExpanded) {
+    hasFetchedOnce.value = false;
+    data.value = "";
+  }
+});
+
+// Listen for refresh-preview events
+useEmitteryEventListener(events, "refresh-preview", () => {
+  if (expanded.value && mocked.value) {
+    fetchSchemaString();
+  }
+});
+
+// Expose method to trigger manual refresh
+defineExpose({
+  refresh: fetchSchemaString,
+});
 </script>

--- a/frontend/src/components/SchemaEditorLite/SchemaEditorLite.vue
+++ b/frontend/src/components/SchemaEditorLite/SchemaEditorLite.vue
@@ -120,9 +120,14 @@ useEmitteryEventListener(
   }
 );
 
+const refreshPreview = () => {
+  context.events.emit("refresh-preview");
+};
+
 defineExpose({
   rebuildMetadataEdit,
   applyMetadataEdit,
+  refreshPreview,
 });
 </script>
 

--- a/frontend/src/components/SchemaEditorLite/context/index.ts
+++ b/frontend/src/components/SchemaEditorLite/context/index.ts
@@ -22,6 +22,7 @@ export type SchemaEditorEvents = Emittery<{
   };
   ["rebuild-edit-status"]: { resets: RebuildMetadataEditReset[] };
   ["clear-tabs"]: undefined;
+  ["refresh-preview"]: undefined;
 }>;
 
 export type SchemaEditorOptions = {


### PR DESCRIPTION
Only call GetSchemaString on explicit user actions (preview/confirm) instead of on every database structure update

🤖 Generated with [Claude Code](https://claude.ai/code)