### PR TITLE
fix: typo in download tooltip text

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1024,7 +1024,7 @@
       "format": "Format",
       "encrypt": "Encrypt",
       "file-downloaded": "File Downloaded",
-      "download-tooltip": "Aavailable for 24 hours"
+      "download-tooltip": "Available for 24 hours"
     },
     "task-run": {
       "logs": "Logs",


### PR DESCRIPTION
## Summary
- Fixed typo "Aavailable" to "Available" in the English localization file

## Test plan
- [x] Visual inspection of the change
- [x] Verified the typo fix in `frontend/src/locales/en-US.json`

🤖 Generated with [Claude Code](https://claude.ai/code)