### PR TITLE
feat: migrate PostgreSQL parser from CGO to ANTLR in sync

### DIFF
--- a/backend/plugin/db/pg/sync.go
+++ b/backend/plugin/db/pg/sync.go
@@ -1374,7 +1374,7 @@ func (l *indexListener) EnterIndexstmt(ctx *parser.IndexstmtContext) {
 	}
 }
 
-func (l *indexListener) extractIndexElem(ctx parser.IIndex_elemContext) string {
+func (*indexListener) extractIndexElem(ctx parser.IIndex_elemContext) string {
 	if ctx == nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary

  This PR migrates the PostgreSQL parser from the legacy CGO-based implementation to the ANTLR-based parser in the database synchronization process. The migration focuses on index statement parsing in `backend/plugin/db/pg/sync.go`.

  ## Changes

  - **Migrated `parseIndexStatement()` function**: Replaced CGO-based parser with ANTLR-based PostgreSQL parser
  - **Implemented listener pattern**: Used `indexListener` with `EnterIndexstmt()` to extract index metadata (type, uniqueness, expressions)
  - **Enhanced integration tests**: Added comprehensive index test cases covering primary key, regular, unique, composite, partial, expression, and hash indexes
  - **Removed legacy parser dependencies**: Eliminated CGO parser usage from the sync process

  ## Breaking Changes ⚠️

  **Expression format changes for function-based indexes:**

  - **Before (CGO parser)**: `lower(name::text)`
  - **After (ANTLR parser)**: `lower((name)::text)`

  This change affects the `expressions` field in index metadata returned by the database sync API. The ANTLR parser provides the more accurate representation that matches PostgreSQL's actual storage format.

  **Impact:**
  - API responses for database schema synchronization will return different expression formats for function-based indexes
  - Any client code that parses or processes index expressions may need updates
  - The change aligns with PostgreSQL's native expression format, improving accuracy

  ## Test Plan

  - [x] All existing integration tests pass
  - [x] Added comprehensive test coverage for various index types
  - [x] Verified ANTLR parser correctly extracts all index metadata
  - [x] Confirmed expression format matches PostgreSQL's native storage

  ## Migration Notes

  - The migration trusts the ANTLR parser completely without fallbacks
  - No regexp-based parsing is used, following the ANTLR-first approach
  - Index definitions in database metadata now reflect PostgreSQL's exact format