### PR TITLE
refactor: simplify Oracle query handling code

### DIFF
--- a/backend/plugin/db/oracle/query.go
+++ b/backend/plugin/db/oracle/query.go
@@ -24,12 +24,14 @@ import (
 
 const dbVersion12 = 12
 
-func makeValueByTypeName(typeName string, _ *sql.ColumnType) any {
-	// DATE: date.
-	// TIMESTAMPDTY: timestamp.
-	// TIMESTAMPTZ_DTY: timestamp with time zone.
-	// TIMESTAMPLTZ_DTY: timezone with local time zone.
+// ========== Type Conversion Functions ==========
 
+// makeValueByTypeName creates appropriate Go types for Oracle column types.
+// DATE: date.
+// TIMESTAMPDTY: timestamp.
+// TIMESTAMPTZ_DTY: timestamp with time zone.
+// TIMESTAMPLTZ_DTY: timezone with local time zone.
+func makeValueByTypeName(typeName string, _ *sql.ColumnType) any {
 	switch typeName {
 	case "VARCHAR", "TEXT", "UUID":
 		return new(sql.NullString)
@@ -92,52 +94,99 @@ func convertValue(typeName string, columnType *sql.ColumnType, value any) *v1pb.
 		}
 	case *sql.NullTime:
 		if raw.Valid {
-			// The go-ora driver retrieves the database timezone from the wire protocol and appends it to the timestamp.
-			// To ensure consistency with Oracle Date expectations, we should remove the timezone information.
-			// https://github.com/sijms/go-ora/blob/2962e725e7a756a667a546fb360ef09afd4c8bd0/v2/parameter.go#L616
-			_, scale, _ := columnType.DecimalSize()
-			if typeName == "DATE" || typeName == "TIMESTAMPDTY" {
-				timeStripped := time.Date(raw.Time.Year(), raw.Time.Month(), raw.Time.Day(), raw.Time.Hour(), raw.Time.Minute(), raw.Time.Second(), raw.Time.Nanosecond(), time.UTC)
-				return &v1pb.RowValue{
-					Kind: &v1pb.RowValue_TimestampValue{
-						TimestampValue: &v1pb.RowValue_Timestamp{
-							GoogleTimestamp: timestamppb.New(timeStripped),
-							Accuracy:        int32(scale),
-						},
-					},
-				}
-			}
-			if typeName == "TIMESTAMPLTZ_DTY" {
-				s := raw.Time.Format("2006-01-02 15:04:05.000000000")
-				t, err := time.Parse(time.DateTime, s)
-				if err != nil {
-					return util.NullRowValue
-				}
-				// This timestamp is not consistent with sqlplus likely due to db and session timezone.
-				// TODO(d): fix the go-ora library.
-				return &v1pb.RowValue{
-					Kind: &v1pb.RowValue_TimestampValue{
-						TimestampValue: &v1pb.RowValue_Timestamp{
-							GoogleTimestamp: timestamppb.New(t),
-							Accuracy:        int32(scale),
-						},
-					},
-				}
-			}
-			zone, offset := raw.Time.Zone()
-			return &v1pb.RowValue{
-				Kind: &v1pb.RowValue_TimestampTzValue{
-					TimestampTzValue: &v1pb.RowValue_TimestampTZ{
-						GoogleTimestamp: timestamppb.New(raw.Time),
-						Zone:            zone,
-						Offset:          int32(offset),
-						Accuracy:        int32(scale),
-					},
-				},
-			}
+			return convertTimestamp(typeName, columnType, raw.Time)
 		}
 	}
 	return util.NullRowValue
+}
+
+// convertTimestamp handles Oracle timestamp type conversions.
+// The go-ora driver retrieves the database timezone from the wire protocol and appends it to the timestamp.
+// To ensure consistency with Oracle Date expectations, we handle different timestamp types appropriately.
+// https://github.com/sijms/go-ora/blob/2962e725e7a756a667a546fb360ef09afd4c8bd0/v2/parameter.go#L616
+func convertTimestamp(typeName string, columnType *sql.ColumnType, t time.Time) *v1pb.RowValue {
+	_, scale, _ := columnType.DecimalSize()
+
+	switch typeName {
+	case "DATE", "TIMESTAMPDTY":
+		// Strip timezone information for DATE and TIMESTAMP types
+		timeStripped := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
+		return &v1pb.RowValue{
+			Kind: &v1pb.RowValue_TimestampValue{
+				TimestampValue: &v1pb.RowValue_Timestamp{
+					GoogleTimestamp: timestamppb.New(timeStripped),
+					Accuracy:        int32(scale),
+				},
+			},
+		}
+
+	case "TIMESTAMPLTZ_DTY":
+		// Handle local timezone timestamp
+		// This timestamp is not consistent with sqlplus likely due to db and session timezone.
+		// TODO(d): fix the go-ora library.
+		s := t.Format("2006-01-02 15:04:05.000000000")
+		parsedTime, err := time.Parse(time.DateTime, s)
+		if err != nil {
+			return util.NullRowValue
+		}
+		return &v1pb.RowValue{
+			Kind: &v1pb.RowValue_TimestampValue{
+				TimestampValue: &v1pb.RowValue_Timestamp{
+					GoogleTimestamp: timestamppb.New(parsedTime),
+					Accuracy:        int32(scale),
+				},
+			},
+		}
+
+	default:
+		// Handle timestamp with timezone
+		zone, offset := t.Zone()
+		return &v1pb.RowValue{
+			Kind: &v1pb.RowValue_TimestampTzValue{
+				TimestampTzValue: &v1pb.RowValue_TimestampTZ{
+					GoogleTimestamp: timestamppb.New(t),
+					Zone:            zone,
+					Offset:          int32(offset),
+					Accuracy:        int32(scale),
+				},
+			},
+		}
+	}
+}
+
+// ========== Limit Handling Functions ==========
+
+// addResultLimit adds a limit clause to the statement based on Oracle version
+func addResultLimit(stmt string, limit int, engineVersion string) string {
+	// Check if we should skip adding limit (e.g., for simple DUAL queries)
+	if shouldSkipLimit(stmt) {
+		return stmt
+	}
+
+	// Determine Oracle version
+	if isOracle11gOrEarlier(engineVersion) {
+		return addLimitFor11g(stmt, limit)
+	}
+	return addLimitFor12cAndLater(stmt, limit)
+}
+
+// shouldSkipLimit checks if the statement needs a limit clause
+func shouldSkipLimit(stmt string) bool {
+	ok, err := skipAddLimit(stmt)
+	return err == nil && ok
+}
+
+// isOracle11gOrEarlier checks if the Oracle version is 11g or earlier
+func isOracle11gOrEarlier(engineVersion string) bool {
+	versionIdx := strings.Index(engineVersion, ".")
+	if versionIdx < 0 {
+		return true // Default to 11g behavior for invalid version
+	}
+	versionNumber, err := strconv.Atoi(engineVersion[:versionIdx])
+	if err != nil {
+		return true // Default to 11g behavior for parsing errors
+	}
+	return versionNumber < dbVersion12
 }
 
 // addLimitFor11g adds a ROWNUM-based limit for Oracle 11g and earlier versions.
@@ -198,38 +247,7 @@ func addFetchNextClause(statement string, limitCount int) (string, error) {
 	return res, nil
 }
 
-// addResultLimit adds a limit clause to the statement based on Oracle version
-func addResultLimit(stmt string, limit int, engineVersion string) string {
-	// Check if we should skip adding limit (e.g., for simple DUAL queries)
-	if shouldSkipLimit(stmt) {
-		return stmt
-	}
-
-	// Determine Oracle version
-	if isOracle11gOrEarlier(engineVersion) {
-		return addLimitFor11g(stmt, limit)
-	}
-	return addLimitFor12cAndLater(stmt, limit)
-}
-
-// isOracle11gOrEarlier checks if the Oracle version is 11g or earlier
-func isOracle11gOrEarlier(engineVersion string) bool {
-	versionIdx := strings.Index(engineVersion, ".")
-	if versionIdx < 0 {
-		return true // Default to 11g behavior for invalid version
-	}
-	versionNumber, err := strconv.Atoi(engineVersion[:versionIdx])
-	if err != nil {
-		return true // Default to 11g behavior for parsing errors
-	}
-	return versionNumber < dbVersion12
-}
-
-// shouldSkipLimit checks if the statement needs a limit clause
-func shouldSkipLimit(stmt string) bool {
-	ok, err := skipAddLimit(stmt)
-	return err == nil && ok
-}
+// ========== PLSQL AST Walker and Rewriter ==========
 
 type plsqlRewriter struct {
 	*plsql.BasePlSqlParserListener
@@ -287,4 +305,159 @@ func (r *plsqlRewriter) overrideFetchClause(fetchClause plsql.IFetch_clauseConte
 		}
 		r.rewriter.ReplaceDefault(expression.GetStart().GetTokenIndex(), expression.GetStop().GetTokenIndex(), fmt.Sprintf("%d", limit))
 	}
+}
+
+// ========== Skip Limit Logic for DUAL Queries ==========
+
+// skipAddLimit checks if the statement needs a limit clause.
+// For Oracle, we think the statement like "SELECT xxx FROM DUAL" does not need a limit clause.
+// More details, xxx can not be a subquery.
+func skipAddLimit(stmt string) (bool, error) {
+	tree, _, err := plsqlparser.ParsePLSQL(stmt)
+	if err != nil {
+		return false, err
+	}
+
+	selectStatement := extractSimpleSelectStatement(tree)
+	if selectStatement == nil {
+		return false, nil
+	}
+
+	// Check if select has additional clauses that prevent skipping limit
+	if hasAdditionalClauses(selectStatement) {
+		return false, nil
+	}
+
+	queryBlock := extractQueryBlock(selectStatement)
+	if queryBlock == nil {
+		return false, nil
+	}
+
+	// Check if query block has complex features
+	if hasComplexQueryFeatures(queryBlock) {
+		return false, nil
+	}
+
+	// Must be a simple SELECT FROM DUAL
+	if !isFromDual(queryBlock) {
+		return false, nil
+	}
+
+	// Check selected elements don't contain subqueries
+	return !hasSubqueriesInSelection(queryBlock), nil
+}
+
+// extractSimpleSelectStatement extracts a simple SELECT statement from the parse tree.
+// Returns nil if the tree doesn't represent a simple SELECT.
+func extractSimpleSelectStatement(tree antlr.Tree) *plsql.Select_statementContext {
+	sqlScript, ok := tree.(*plsql.Sql_scriptContext)
+	if !ok {
+		return nil
+	}
+
+	if len(sqlScript.AllSql_plus_command()) > 0 || len(sqlScript.AllUnit_statement()) != 1 {
+		return nil
+	}
+
+	unitStatement := sqlScript.Unit_statement(0)
+	if unitStatement == nil {
+		return nil
+	}
+
+	dml := unitStatement.Data_manipulation_language_statements()
+	if dml == nil {
+		return nil
+	}
+
+	if selectStmt := dml.Select_statement(); selectStmt != nil {
+		if stmt, ok := selectStmt.(*plsql.Select_statementContext); ok {
+			return stmt
+		}
+	}
+	return nil
+}
+
+// hasAdditionalClauses checks if a SELECT statement has clauses that prevent limit skipping.
+func hasAdditionalClauses(selectStatement *plsql.Select_statementContext) bool {
+	return len(selectStatement.AllFor_update_clause()) != 0 ||
+		len(selectStatement.AllOrder_by_clause()) != 0 ||
+		len(selectStatement.AllOffset_clause()) != 0 ||
+		len(selectStatement.AllFetch_clause()) != 0
+}
+
+// extractQueryBlock extracts the query block from a SELECT statement.
+func extractQueryBlock(selectStatement *plsql.Select_statementContext) *plsql.Query_blockContext {
+	selectOnly := selectStatement.Select_only_statement()
+	if selectOnly == nil {
+		return nil
+	}
+
+	subquery := selectOnly.Subquery()
+	if subquery == nil || len(subquery.AllSubquery_operation_part()) != 0 {
+		return nil
+	}
+
+	subqueryBasicElements := subquery.Subquery_basic_elements()
+	if subqueryBasicElements == nil || subqueryBasicElements.Subquery() != nil {
+		return nil
+	}
+
+	if queryBlock := subqueryBasicElements.Query_block(); queryBlock != nil {
+		if block, ok := queryBlock.(*plsql.Query_blockContext); ok {
+			return block
+		}
+	}
+	return nil
+}
+
+// hasComplexQueryFeatures checks if a query block has complex features.
+func hasComplexQueryFeatures(queryBlock *plsql.Query_blockContext) bool {
+	return queryBlock.Subquery_factoring_clause() != nil ||
+		queryBlock.DISTINCT() != nil ||
+		queryBlock.ALL() != nil ||
+		queryBlock.UNIQUE() != nil ||
+		queryBlock.Into_clause() != nil ||
+		queryBlock.Where_clause() != nil ||
+		queryBlock.Hierarchical_query_clause() != nil ||
+		queryBlock.Group_by_clause() != nil ||
+		queryBlock.Model_clause() != nil ||
+		queryBlock.Order_by_clause() != nil ||
+		queryBlock.Fetch_clause() != nil
+}
+
+// isFromDual checks if the query is selecting from DUAL table.
+func isFromDual(queryBlock *plsql.Query_blockContext) bool {
+	from := queryBlock.From_clause()
+	return from != nil && strings.EqualFold(from.GetText(), "FROMDUAL")
+}
+
+// hasSubqueriesInSelection checks if the selected elements contain subqueries.
+func hasSubqueriesInSelection(queryBlock *plsql.Query_blockContext) bool {
+	selectedList := queryBlock.Selected_list()
+	if selectedList == nil || selectedList.ASTERISK() != nil {
+		return true
+	}
+
+	for _, selectedElement := range selectedList.AllSelect_list_elements() {
+		if selectedElement.Table_wild() != nil {
+			return true
+		}
+
+		l := subqueryListener{}
+		antlr.ParseTreeWalkerDefault.Walk(&l, selectedElement)
+		if l.hasSubquery {
+			return true
+		}
+	}
+
+	return false
+}
+
+type subqueryListener struct {
+	*plsql.BasePlSqlParserListener
+	hasSubquery bool
+}
+
+func (l *subqueryListener) EnterSubquery(*plsql.SubqueryContext) {
+	l.hasSubquery = true
 }


### PR DESCRIPTION
## Summary
- Refactored Oracle plugin code to improve maintainability and readability
- Moved query-related functions to appropriate files for better organization
- Simplified complex functions by breaking them down into smaller, focused helpers

## Changes
### Code Organization
- Moved `skipAddLimit()` and `subqueryListener` from `oracle.go` to `query.go` where they logically belong
- Added section comments to group related functions (Type Conversion, Limit Handling, PLSQL AST, Skip Limit Logic)

### Function Refactoring
- Extracted `convertTimestamp()` function to handle Oracle timestamp conversions separately, reducing complexity in `convertValue()`
- Broke down the complex `skipAddLimit()` function into smaller helper functions:
  - `extractSimpleSelectStatement()` - Extracts SELECT from parse tree
  - `hasAdditionalClauses()` - Checks for clauses that prevent limit skipping
  - `extractQueryBlock()` - Extracts query block from SELECT
  - `hasComplexQueryFeatures()` - Checks for complex query features
  - `isFromDual()` - Checks if selecting from DUAL
  - `hasSubqueriesInSelection()` - Checks for subqueries in selection

### Code Quality Improvements
- Improved type safety with proper type assertions and safety checks
- Simplified error handling by removing unnecessary error returns
- Removed unused imports from `oracle.go`

## Test Plan
- [x] All existing tests pass
- [x] Code passes golangci-lint without issues
- [x] No functional changes, only refactoring for better code organization

🤖 Generated with [Claude Code](https://claude.ai/code)