### PR TITLE
fix: handle null environments in rollout UI

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/OverviewSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/OverviewSection.vue
@@ -40,6 +40,7 @@
                 <EnvironmentV1Name
                   :environment="getEnvironmentEntity(stage.environment)"
                   :link="false"
+                  :null-environment-placeholder="'Null'"
                 />
               </div>
               <span

--- a/frontend/src/components/Plan/components/RolloutView/StageCard.vue
+++ b/frontend/src/components/Plan/components/RolloutView/StageCard.vue
@@ -22,9 +22,10 @@
                 class="text-base font-medium text-gray-900 whitespace-nowrap truncate"
               >
                 <EnvironmentV1Name
-                  :environment="
-                    environmentStore.getEnvironmentByName(stage.environment)
-                  "
+                  text-class="w-24"
+                  :environment="environment"
+                  :link="false"
+                  :null-environment-placeholder="'Null'"
                 />
               </h3>
               <Timestamp
@@ -255,6 +256,10 @@ const isCreated = computed(() => {
   );
 });
 
+const environment = computed(() => {
+  return environmentStore.getEnvironmentByName(props.stage.environment);
+});
+
 // Toggle state for showing/hiding tasks - default based on parent coordination
 const showTasks = ref(props.defaultShowTasks || false);
 
@@ -368,7 +373,7 @@ const handleClickStageTitle = () => {
   const rolloutId = props.rollout.name.split("/").pop();
   const stageId = props.stage.name.split("/").pop();
 
-  if (!rolloutId || !stageId) return;
+  if (!rolloutId) return;
 
   // Navigate to the stage detail route
   router.push({
@@ -376,7 +381,7 @@ const handleClickStageTitle = () => {
     params: {
       projectId: extractProjectResourceName(project.value.name),
       rolloutId,
-      stageId,
+      stageId: stageId || "_", // Use placeholder for empty stageId
     },
   });
 };
@@ -388,7 +393,7 @@ const handleTaskStatusClick = (status: Task_Status) => {
   const rolloutId = props.rollout.name.split("/").pop();
   const stageId = props.stage.name.split("/").pop();
 
-  if (!rolloutId || !stageId) return;
+  if (!rolloutId) return;
 
   // Navigate to the stage detail route with task status filter
   router.push({
@@ -396,7 +401,7 @@ const handleTaskStatusClick = (status: Task_Status) => {
     params: {
       projectId: extractProjectResourceName(project.value.name),
       rolloutId,
-      stageId,
+      stageId: stageId || "_", // Use placeholder for empty stageId
     },
     query: {
       taskStatus: Task_Status[status],
@@ -412,7 +417,7 @@ const handleTaskClick = (task: Task) => {
   const stageId = props.stage.name.split("/").pop();
   const taskId = task.name.split("/").pop();
 
-  if (!rolloutId || !stageId || !taskId) return;
+  if (!rolloutId || !taskId) return;
 
   // Navigate to the task detail route
   router.push({
@@ -420,7 +425,7 @@ const handleTaskClick = (task: Task) => {
     params: {
       projectId: extractProjectResourceName(project.value.name),
       rolloutId,
-      stageId,
+      stageId: stageId || "_", // Use placeholder for empty stageId
       taskId,
     },
   });

--- a/frontend/src/components/Plan/components/RolloutView/StageView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/StageView.vue
@@ -8,6 +8,8 @@
             :environment="
               environmentStore.getEnvironmentByName(stage.environment)
             "
+            :null-environment-placeholder="'Null'"
+            :link="false"
           />
         </span>
 
@@ -41,7 +43,7 @@ import TaskTableView from "./TaskTableView.vue";
 
 const props = defineProps<{
   rolloutId: string;
-  stageId: string;
+  stageId?: string; // Could be undefined for null environment.
 }>();
 
 const route = useRoute();
@@ -49,7 +51,8 @@ const environmentStore = useEnvironmentV1Store();
 const { rollout } = usePlanContextWithRollout();
 
 const stage = computed(() => {
-  return rollout.value.stages.find((s) => s.id === props.stageId) as Stage;
+  const stageId = props.stageId || "";
+  return rollout.value.stages.find((s) => s.id === stageId) as Stage;
 });
 
 const taskStatusFilter = ref<Task_Status[]>([]);

--- a/frontend/src/components/Plan/components/RolloutView/TaskTable.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskTable.vue
@@ -141,7 +141,7 @@ const handleRowClick = (task: Task) => {
       params: {
         projectId: extractProjectResourceName(project.value.name),
         rolloutId: params.rolloutId,
-        stageId: params.stageId,
+        stageId: params.stageId || "_", // Use placeholder for empty stageId
         taskId: params.taskId,
       },
     });

--- a/frontend/src/components/Plan/components/RolloutView/TaskView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskView.vue
@@ -159,7 +159,7 @@ import TaskStatusActions from "./TaskStatusActions.vue";
 
 const props = defineProps<{
   rolloutId: string;
-  stageId: string;
+  stageId?: string; // Could be undefined for null environment.
   taskId: string;
 }>();
 
@@ -174,9 +174,10 @@ const {
 const sheetStore = useSheetV1Store();
 
 const task = computed(() => {
+  const stageId = props.stageId || "";
   return (
     rollout.value.stages
-      .find((s) => s.id === props.stageId)
+      .find((s) => s.id === stageId)
       ?.tasks.find((t) => t.name.endsWith(`/${props.taskId}`)) || unknownTask()
   );
 });

--- a/frontend/src/components/Plan/components/SpecDetailView/FailedTaskRunsSection.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/FailedTaskRunsSection.vue
@@ -301,7 +301,7 @@ const navigateToTaskDetail = (taskRun: ComposedTaskRun) => {
       params: {
         projectId: extractProjectResourceName(project.value.name),
         rolloutId: params.rolloutId,
-        stageId: params.stageId,
+        stageId: params.stageId || "_", // Use placeholder for empty stageId
         taskId: params.taskId,
       },
     });

--- a/frontend/src/components/v2/Model/EnvironmentV1Name.vue
+++ b/frontend/src/components/v2/Model/EnvironmentV1Name.vue
@@ -5,22 +5,16 @@
     class="inline-flex items-center gap-x-1"
     :class="[isLink && !plain && 'normal-link', isLink && 'hover:underline']"
   >
-    <NEllipsis :line-clamp="1">
-      <span class="select-none" :class="textClass">
-        {{ prefix }}
-        <span v-if="isUnknown" class="text-gray-400 italic">
-          NULL ENVIRONMENT
-        </span>
-        <HighlightLabelText
-          v-else
-          :text="environment.title"
-          :keyword="keyword"
-        />
-        <slot name="suffix">
-          {{ suffix }}
-        </slot>
+    <span class="select-none inline-block truncate" :class="textClass">
+      {{ prefix }}
+      <span v-if="isUnknown" class="text-gray-400 italic">
+        {{ nullEnvironmentPlaceholder }}
       </span>
-    </NEllipsis>
+      <HighlightLabelText v-else :text="environment.title" :keyword="keyword" />
+      <slot name="suffix">
+        {{ suffix }}
+      </slot>
+    </span>
     <ProductionEnvironmentV1Icon
       v-if="showIcon"
       :environment="environment"
@@ -31,7 +25,6 @@
 </template>
 
 <script lang="ts" setup>
-import { NEllipsis } from "naive-ui";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { UNKNOWN_ENVIRONMENT_NAME } from "@/types";
@@ -54,6 +47,7 @@ const props = withDefaults(
     showIcon?: boolean;
     textClass?: string;
     keyword?: string;
+    nullEnvironmentPlaceholder?: string; // Placeholder for null/unknown environment.
   }>(),
   {
     tag: "span",
@@ -66,6 +60,7 @@ const props = withDefaults(
     showIcon: true,
     textClass: "",
     keyword: "",
+    nullEnvironmentPlaceholder: "NULL ENVIRONMENT",
   }
 );
 

--- a/frontend/src/router/dashboard/projectV1.ts
+++ b/frontend/src/router/dashboard/projectV1.ts
@@ -103,14 +103,24 @@ const cicdRoutes: RouteRecordRaw[] = [
             name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL_STAGE_DETAIL,
             component: () =>
               import("@/components/Plan/components/RolloutView/StageView.vue"),
-            props: true,
+            props: (route) => ({
+              ...route.params,
+              // Convert placeholder back to undefined for empty stageId
+              stageId:
+                route.params.stageId === "_" ? undefined : route.params.stageId,
+            }),
           },
           {
             path: "stages/:stageId/tasks/:taskId",
             name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL_TASK_DETAIL,
             component: () =>
               import("@/components/Plan/components/RolloutView/TaskView.vue"),
-            props: true,
+            props: (route) => ({
+              ...route.params,
+              // Convert placeholder back to undefined for empty stageId
+              stageId:
+                route.params.stageId === "_" ? undefined : route.params.stageId,
+            }),
           },
         ],
       },


### PR DESCRIPTION
* Use placeholder "_" in routes for empty stageId (null environment)
* Handle missing stageId in navigation and routing logic

<img width="1338" height="628" alt="image" src="https://github.com/user-attachments/assets/25eb3cb8-25d7-4c59-bee2-78bb21e19007" />
