### PR TITLE
feat: support null environments in rollouts with placeholder handling

### DIFF
--- a/backend/api/v1/revision_service.go
+++ b/backend/api/v1/revision_service.go
@@ -153,7 +153,7 @@ func (s *RevisionService) CreateRevision(
 		}
 		if taskRun.ProjectID != projectID ||
 			taskRun.PipelineUID != rolloutID ||
-			taskRun.Environment != stageID ||
+			taskRun.Environment != formatEnvironmentFromStageID(stageID) ||
 			taskRun.TaskUID != taskID {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("taskRun %q not found", request.Revision.TaskRun))
 		}

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -642,7 +642,8 @@ func (s *RolloutService) BatchRunTasks(ctx context.Context, req *connect.Request
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
-		taskEnvironments[stageID] = append(taskEnvironments[stageID], taskID)
+		environment := formatEnvironmentFromStageID(stageID)
+		taskEnvironments[environment] = append(taskEnvironments[environment], taskID)
 		taskIDsToRunMap[taskID] = true
 	}
 	if len(taskEnvironments) > 1 {
@@ -896,7 +897,8 @@ func (s *RolloutService) BatchCancelTaskRuns(ctx context.Context, req *connect.R
 		return nil, connect.NewError(connect.CodeInternal, errors.New("user not found"))
 	}
 
-	ok, err = s.canUserCancelEnvironmentTaskRun(ctx, user, project, issueN, stageID, rollout.CreatorUID)
+	environment := formatEnvironmentFromStageID(stageID)
+	ok, err = s.canUserCancelEnvironmentTaskRun(ctx, user, project, issueN, environment, rollout.CreatorUID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to check if the user can run tasks, error: %v", err))
 	}

--- a/backend/component/webhook/manager.go
+++ b/backend/component/webhook/manager.go
@@ -129,7 +129,11 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 	case common.EventTypeStageStatusUpdate:
 		u := e.StageStatusUpdate
 		if e.Issue != nil {
-			link = fmt.Sprintf("%s/projects/%s/issues/%s-%d?stage=%s", setting.ExternalUrl, e.Project.ResourceID, slug.Make(e.Issue.Title), e.Issue.UID, u.StageID)
+			stageID := u.StageID
+			if stageID == "" {
+				stageID = "-" // Use "-" as a placeholder if StageID is not set.
+			}
+			link = fmt.Sprintf("%s/projects/%s/issues/%s-%d?stage=%s", setting.ExternalUrl, e.Project.ResourceID, slug.Make(e.Issue.Title), e.Issue.UID, stageID)
 		}
 		title = "Stage ends"
 		titleZh = "阶段结束"

--- a/backend/generated-go/v1/rollout_service.pb.go
+++ b/backend/generated-go/v1/rollout_service.pb.go
@@ -1402,12 +1402,14 @@ func (x *Rollout) GetIssue() string {
 type Stage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Format: projects/{project}/rollouts/{rollout}/stages/{stage}
+	// Use "-" for {stage} when the stage has no environment or deleted environment.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// id is the environment id of the stage.
 	// e.g. "prod".
+	// Use "-" when the stage has no environment or deleted environment.
 	Id string `protobuf:"bytes,3,opt,name=id,proto3" json:"id,omitempty"`
 	// environment is the environment of the stage.
-	// Format: environments/{environment}.
+	// Format: environments/{environment} for valid environments, or "environments/-" for stages without environment or with deleted environments.
 	Environment   string  `protobuf:"bytes,4,opt,name=environment,proto3" json:"environment,omitempty"`
 	Tasks         []*Task `protobuf:"bytes,5,rep,name=tasks,proto3" json:"tasks,omitempty"`
 	unknownFields protoimpl.UnknownFields

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -24,7 +24,7 @@ type TaskMessage struct {
 	// Related fields
 	PipelineID     int
 	InstanceID     string
-	Environment    string
+	Environment    string // The environment ID (was stage_id). Could be empty if the task does not have an environment.
 	DatabaseName   *string
 	TaskRunRawList []*TaskRunMessage
 

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -17,7 +17,7 @@ import (
 // TaskRunMessage is message for task run.
 type TaskRunMessage struct {
 	TaskUID     int
-	Environment string // The environment ID (was stage_id)
+	Environment string // Refer to the task's environment.
 	PipelineUID int
 	Status      storepb.TaskRun_Status
 	Code        common.Code

--- a/frontend/src/components/Plan/components/RolloutView/StageView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/StageView.vue
@@ -43,7 +43,7 @@ import TaskTableView from "./TaskTableView.vue";
 
 const props = defineProps<{
   rolloutId: string;
-  stageId?: string; // Could be undefined for null environment.
+  stageId: string;
 }>();
 
 const route = useRoute();
@@ -51,8 +51,7 @@ const environmentStore = useEnvironmentV1Store();
 const { rollout } = usePlanContextWithRollout();
 
 const stage = computed(() => {
-  const stageId = props.stageId || "";
-  return rollout.value.stages.find((s) => s.id === stageId) as Stage;
+  return rollout.value.stages.find((s) => s.id === props.stageId) as Stage;
 });
 
 const taskStatusFilter = ref<Task_Status[]>([]);

--- a/frontend/src/components/Plan/components/RolloutView/TaskView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskView.vue
@@ -159,7 +159,7 @@ import TaskStatusActions from "./TaskStatusActions.vue";
 
 const props = defineProps<{
   rolloutId: string;
-  stageId?: string; // Could be undefined for null environment.
+  stageId: string;
   taskId: string;
 }>();
 
@@ -174,10 +174,9 @@ const {
 const sheetStore = useSheetV1Store();
 
 const task = computed(() => {
-  const stageId = props.stageId || "";
   return (
     rollout.value.stages
-      .find((s) => s.id === stageId)
+      .find((s) => s.id === props.stageId)
       ?.tasks.find((t) => t.name.endsWith(`/${props.taskId}`)) || unknownTask()
   );
 });

--- a/frontend/src/components/Plan/components/common/DatabaseDisplay.vue
+++ b/frontend/src/components/Plan/components/common/DatabaseDisplay.vue
@@ -7,7 +7,11 @@
       :size="props.size || 'small'"
     />
     <span v-if="showEnvironment" class="text-gray-400 mr-1">
-      <EnvironmentV1Name :link="false" :environment="environment" />
+      <EnvironmentV1Name
+        :link="false"
+        :environment="environment"
+        :null-environment-placeholder="'Null'"
+      />
     </span>
     <span class="truncate text-gray-600">
       {{ instanceDisplayName }}

--- a/frontend/src/components/v2/Model/EnvironmentV1Name.vue
+++ b/frontend/src/components/v2/Model/EnvironmentV1Name.vue
@@ -6,7 +6,6 @@
     :class="[isLink && !plain && 'normal-link', isLink && 'hover:underline']"
   >
     <span class="select-none inline-block truncate" :class="textClass">
-      {{ prefix }}
       <span v-if="isUnknown" class="text-gray-400 italic">
         {{ nullEnvironmentPlaceholder }}
       </span>
@@ -27,7 +26,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 import { useRouter } from "vue-router";
-import { UNKNOWN_ENVIRONMENT_NAME } from "@/types";
+import { UNKNOWN_ENVIRONMENT_NAME, NULL_ENVIRONMENT_NAME } from "@/types";
 import type { Environment } from "@/types/v1/environment";
 import type { VueClass } from "@/utils";
 import { autoEnvironmentRoute } from "@/utils";
@@ -43,7 +42,6 @@ const props = withDefaults(
     iconClass?: VueClass;
     tooltip?: boolean;
     suffix?: string;
-    prefix?: string;
     showIcon?: boolean;
     textClass?: string;
     keyword?: string;
@@ -67,7 +65,9 @@ const props = withDefaults(
 const router = useRouter();
 
 const isUnknown = computed(
-  () => props.environment.name === UNKNOWN_ENVIRONMENT_NAME
+  () =>
+    props.environment.name === UNKNOWN_ENVIRONMENT_NAME ||
+    props.environment.name === NULL_ENVIRONMENT_NAME
 );
 
 const isLink = computed(() => props.link && !isUnknown.value);

--- a/frontend/src/components/v2/Model/Instance/InstanceV1Table/InstanceV1Table.vue
+++ b/frontend/src/components/v2/Model/Instance/InstanceV1Table/InstanceV1Table.vue
@@ -119,6 +119,7 @@ const columnList = computed((): InstanceDataTableColumn[] => {
       <EnvironmentV1Name
         environment={instance.environmentEntity}
         link={false}
+        nullEnvironmentPlaceholder="Null"
       />
     ),
   };

--- a/frontend/src/router/dashboard/projectV1.ts
+++ b/frontend/src/router/dashboard/projectV1.ts
@@ -103,24 +103,14 @@ const cicdRoutes: RouteRecordRaw[] = [
             name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL_STAGE_DETAIL,
             component: () =>
               import("@/components/Plan/components/RolloutView/StageView.vue"),
-            props: (route) => ({
-              ...route.params,
-              // Convert placeholder back to undefined for empty stageId
-              stageId:
-                route.params.stageId === "_" ? undefined : route.params.stageId,
-            }),
+            props: true,
           },
           {
             path: "stages/:stageId/tasks/:taskId",
             name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL_TASK_DETAIL,
             component: () =>
               import("@/components/Plan/components/RolloutView/TaskView.vue"),
-            props: (route) => ({
-              ...route.params,
-              // Convert placeholder back to undefined for empty stageId
-              stageId:
-                route.params.stageId === "_" ? undefined : route.params.stageId,
-            }),
+            props: true,
           },
         ],
       },

--- a/frontend/src/store/modules/v1/environment.ts
+++ b/frontend/src/store/modules/v1/environment.ts
@@ -6,7 +6,11 @@ import { computed } from "vue";
 import { settingServiceClientConnect } from "@/grpcweb";
 import { silentContextKey } from "@/grpcweb/context-key";
 import type { ResourceId } from "@/types";
-import { unknownEnvironment } from "@/types";
+import {
+  unknownEnvironment,
+  nullEnvironment,
+  NULL_ENVIRONMENT_NAME,
+} from "@/types";
 import type {
   EnvironmentSetting,
   EnvironmentSetting_Environment,
@@ -233,6 +237,9 @@ export const useEnvironmentV1Store = defineStore("environment_v1", {
       return environment;
     },
     getEnvironmentByName(name: string) {
+      if (name === NULL_ENVIRONMENT_NAME) {
+        return nullEnvironment();
+      }
       const id = name.replace(environmentNamePrefix, "");
       return this.environmentMapById.get(id) ?? unknownEnvironment();
     },

--- a/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
@@ -506,6 +506,7 @@ export declare const RolloutSchema: GenMessage<Rollout>;
 export declare type Stage = Message<"bytebase.v1.Stage"> & {
   /**
    * Format: projects/{project}/rollouts/{rollout}/stages/{stage}
+   * Use "-" for {stage} when the stage has no environment or deleted environment.
    *
    * @generated from field: string name = 1;
    */
@@ -514,6 +515,7 @@ export declare type Stage = Message<"bytebase.v1.Stage"> & {
   /**
    * id is the environment id of the stage.
    * e.g. "prod".
+   * Use "-" when the stage has no environment or deleted environment.
    *
    * @generated from field: string id = 3;
    */
@@ -521,7 +523,7 @@ export declare type Stage = Message<"bytebase.v1.Stage"> & {
 
   /**
    * environment is the environment of the stage.
-   * Format: environments/{environment}.
+   * Format: environments/{environment} for valid environments, or "environments/-" for stages without environment or with deleted environments.
    *
    * @generated from field: string environment = 4;
    */

--- a/frontend/src/types/v1/environment.ts
+++ b/frontend/src/types/v1/environment.ts
@@ -6,9 +6,9 @@ import {
   type EnvironmentSetting_Environment,
 } from "../proto-es/v1/setting_service_pb";
 
-export const ENVIRONMENT_ALL_NAME = "environments/-";
 export const EMPTY_ENVIRONMENT_NAME = `environments/${EMPTY_ID}`;
 export const UNKNOWN_ENVIRONMENT_NAME = `environments/${UNKNOWN_ID}`;
+export const NULL_ENVIRONMENT_NAME = "environments/-";
 
 export interface Environment extends EnvironmentSetting_Environment {
   order: number;
@@ -27,12 +27,26 @@ export const unknownEnvironment = (): Environment => {
   };
 };
 
+export const nullEnvironment = (): Environment => {
+  return {
+    ...create(EnvironmentSetting_EnvironmentSchema, {
+      name: NULL_ENVIRONMENT_NAME,
+      id: "-",
+      title: "No Environment",
+      tags: {},
+      color: "",
+    }),
+    order: -1,
+  };
+};
+
 export const isValidEnvironmentName = (name: any): name is string => {
   return (
     typeof name === "string" &&
     name.startsWith("environments/") &&
     name !== EMPTY_ENVIRONMENT_NAME &&
-    name !== UNKNOWN_ENVIRONMENT_NAME
+    name !== UNKNOWN_ENVIRONMENT_NAME &&
+    name !== NULL_ENVIRONMENT_NAME
   );
 };
 

--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -306,7 +306,6 @@ const renderTab = (env: Environment, index: number) => {
     h(EnvironmentV1Name, {
       environment: env,
       link: false,
-      prefix: state.reorder ? "" : `${index + 1}.`,
     }),
   ];
   if (state.reorder) {
@@ -336,6 +335,8 @@ const renderTab = (env: Environment, index: number) => {
         )
       );
     }
+  } else {
+    child.unshift(h("span", { class: "text-opacity-60" }, `${index + 1}.`));
   }
 
   return h("div", { class: "flex items-center space-x-2 py-1" }, child);

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -13560,18 +13560,21 @@ components:
             properties:
                 name:
                     type: string
-                    description: 'Format: projects/{project}/rollouts/{rollout}/stages/{stage}'
+                    description: |-
+                        Format: projects/{project}/rollouts/{rollout}/stages/{stage}
+                         Use "-" for {stage} when the stage has no environment or deleted environment.
                 id:
                     readOnly: true
                     type: string
                     description: |-
                         id is the environment id of the stage.
                          e.g. "prod".
+                         Use "-" when the stage has no environment or deleted environment.
                 environment:
                     type: string
                     description: |-
                         environment is the environment of the stage.
-                         Format: environments/{environment}.
+                         Format: environments/{environment} for valid environments, or "environments/-" for stages without environment or with deleted environments.
                 tasks:
                     type: array
                     items:

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -10177,9 +10177,9 @@ When paginating, all other parameters provided to `ListTaskRuns` must match the 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | Format: projects/{project}/rollouts/{rollout}/stages/{stage} |
-| id | [string](#string) |  | id is the environment id of the stage. e.g. &#34;prod&#34;. |
-| environment | [string](#string) |  | environment is the environment of the stage. Format: environments/{environment}. |
+| name | [string](#string) |  | Format: projects/{project}/rollouts/{rollout}/stages/{stage} Use &#34;-&#34; for {stage} when the stage has no environment or deleted environment. |
+| id | [string](#string) |  | id is the environment id of the stage. e.g. &#34;prod&#34;. Use &#34;-&#34; when the stage has no environment or deleted environment. |
+| environment | [string](#string) |  | environment is the environment of the stage. Format: environments/{environment} for valid environments, or &#34;environments/-&#34; for stages without environment or with deleted environments. |
 | tasks | [Task](#bytebase-v1-Task) | repeated |  |
 
 

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -28113,7 +28113,8 @@ Format: projects/{project}/issues/{issue} </p></td>
                   <td>name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Format: projects/{project}/rollouts/{rollout}/stages/{stage} </p></td>
+                  <td><p>Format: projects/{project}/rollouts/{rollout}/stages/{stage}
+Use &#34;-&#34; for {stage} when the stage has no environment or deleted environment. </p></td>
                 </tr>
               
                 <tr>
@@ -28121,7 +28122,8 @@ Format: projects/{project}/issues/{issue} </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>id is the environment id of the stage.
-e.g. &#34;prod&#34;. </p></td>
+e.g. &#34;prod&#34;.
+Use &#34;-&#34; when the stage has no environment or deleted environment. </p></td>
                 </tr>
               
                 <tr>
@@ -28129,7 +28131,7 @@ e.g. &#34;prod&#34;. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>environment is the environment of the stage.
-Format: environments/{environment}. </p></td>
+Format: environments/{environment} for valid environments, or &#34;environments/-&#34; for stages without environment or with deleted environments. </p></td>
                 </tr>
               
                 <tr>

--- a/proto/v1/v1/rollout_service.proto
+++ b/proto/v1/v1/rollout_service.proto
@@ -354,14 +354,16 @@ message Stage {
   reserved 2;
 
   // Format: projects/{project}/rollouts/{rollout}/stages/{stage}
+  // Use "-" for {stage} when the stage has no environment or deleted environment.
   string name = 1;
 
   // id is the environment id of the stage.
   // e.g. "prod".
+  // Use "-" when the stage has no environment or deleted environment.
   string id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // environment is the environment of the stage.
-  // Format: environments/{environment}.
+  // Format: environments/{environment} for valid environments, or "environments/-" for stages without environment or with deleted environments.
   string environment = 4;
 
   repeated Task tasks = 5;


### PR DESCRIPTION
Add support for stages with null/empty environments by introducing a "-" placeholder:
- Add formatStageIDFromEnvironment/formatEnvironmentFromStageID helper functions
- Update proto documentation to clarify "-" usage for null environments
- Handle null environment display across rollout UI components

🤖 Generated with [Claude Code](https://claude.ai/code)