### PR TITLE
fix: UpdatePolicy update mask

### DIFF
--- a/backend/api/v1/org_policy_service.go
+++ b/backend/api/v1/org_policy_service.go
@@ -184,7 +184,7 @@ func (s *OrgPolicyService) UpdatePolicy(ctx context.Context, req *connect.Reques
 		case "enforce":
 			patch.Enforce = &req.Msg.Policy.Enforce
 		default:
-			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unknown path %s", path))
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unexpected path %s", path))
 		}
 	}
 

--- a/backend/api/v1/org_policy_service.go
+++ b/backend/api/v1/org_policy_service.go
@@ -160,7 +160,19 @@ func (s *OrgPolicyService) UpdatePolicy(ctx context.Context, req *connect.Reques
 		switch path {
 		case "inherit_from_parent":
 			patch.InheritFromParent = &req.Msg.Policy.InheritFromParent
-		case "payload":
+		case
+			"rollout_policy",
+			"disable_copy_data_policy",
+			"masking_rule_policy",
+			"masking_exception_policy",
+			"restrict_issue_creation_for_sql_review_policy",
+			"tag_policy",
+			"data_source_query_policy",
+			"export_data_policy",
+			"query_data_policy":
+			if !pathMatchType(path, policy.Type) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid path %s for policy type %s", path, policy.Type.String()))
+			}
 			if err := validatePolicyPayload(policy.Type, req.Msg.Policy); err != nil {
 				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrap(err, "invalid policy"))
 			}
@@ -172,6 +184,7 @@ func (s *OrgPolicyService) UpdatePolicy(ctx context.Context, req *connect.Reques
 		case "enforce":
 			patch.Enforce = &req.Msg.Policy.Enforce
 		default:
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unknown path %s", path))
 		}
 	}
 
@@ -186,6 +199,31 @@ func (s *OrgPolicyService) UpdatePolicy(ctx context.Context, req *connect.Reques
 	}
 
 	return connect.NewResponse(response), nil
+}
+
+func pathMatchType(path string, policyType storepb.Policy_Type) bool {
+	switch policyType {
+	case storepb.Policy_ROLLOUT:
+		return path == "rollout_policy"
+	case storepb.Policy_DISABLE_COPY_DATA:
+		return path == "disable_copy_data_policy"
+	case storepb.Policy_MASKING_RULE:
+		return path == "masking_rule_policy"
+	case storepb.Policy_MASKING_EXCEPTION:
+		return path == "masking_exception_policy"
+	case storepb.Policy_RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW:
+		return path == "restrict_issue_creation_for_sql_review_policy"
+	case storepb.Policy_TAG:
+		return path == "tag_policy"
+	case storepb.Policy_DATA_SOURCE_QUERY:
+		return path == "data_source_query_policy"
+	case storepb.Policy_EXPORT_DATA:
+		return path == "export_data_policy"
+	case storepb.Policy_QUERY_DATA:
+		return path == "query_data_policy"
+	default:
+		return false
+	}
 }
 
 // DeletePolicy deletes a policy for a specific resource.

--- a/frontend/src/store/modules/v1/policy.ts
+++ b/frontend/src/store/modules/v1/policy.ts
@@ -185,7 +185,7 @@ export const usePolicyV1Store = defineStore("policy_v1", {
       });
       const request = create(UpdatePolicyRequestSchema, {
         policy: fullPolicy,
-        updateMask: { paths: ["payload"] },
+        updateMask: { paths: getUpdateMaskFromPolicyType(policy.type) },
         allowMissing: true,
       });
       const response =
@@ -200,6 +200,33 @@ export const usePolicyV1Store = defineStore("policy_v1", {
     },
   },
 });
+
+const getUpdateMaskFromPolicyType = (policyType: PolicyType) => {
+  switch (policyType) {
+    case PolicyType.ROLLOUT_POLICY:
+      return [PolicySchema.field.rolloutPolicy.name];
+    case PolicyType.MASKING_EXCEPTION:
+      return [PolicySchema.field.maskingExceptionPolicy.name];
+    case PolicyType.MASKING_RULE:
+      return [PolicySchema.field.maskingRulePolicy.name];
+    case PolicyType.DATA_EXPORT:
+      return [PolicySchema.field.exportDataPolicy.name];
+    case PolicyType.DATA_QUERY:
+      return [PolicySchema.field.queryDataPolicy.name];
+    case PolicyType.DATA_SOURCE_QUERY:
+      return [PolicySchema.field.dataSourceQueryPolicy.name];
+    case PolicyType.DISABLE_COPY_DATA:
+      return [PolicySchema.field.disableCopyDataPolicy.name];
+    case PolicyType.RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW:
+      return [PolicySchema.field.restrictIssueCreationForSqlReviewPolicy.name];
+    case PolicyType.TAG:
+      return [PolicySchema.field.tagPolicy.name];
+    case PolicyType.POLICY_TYPE_UNSPECIFIED:
+      throw new Error("unexpected POLICY_TYPE_UNSPECIFIED");
+    default:
+      throw new Error(`unknown policyType ${policyType satisfies never}`);
+  }
+};
 
 export const usePolicyListByResourceTypeAndPolicyType = (
   params: MaybeRef<{


### PR DESCRIPTION
BREAKING

Per AIP, update mask should be
1. field names
2. oneofs are omitted


```
 # Field Masks and Oneof Fields
 Field masks treat fields in oneofs just as regular fields. Consider the
 following message:
     message SampleMessage {
       oneof test_oneof {
         string name = 4;
         SubMessage sub_message = 9;
       }
     }
 The field mask can be:
     mask {
       paths: "name"
     }
 Or:
     mask {
       paths: "sub_message"
     }
 Note that oneof type names ("test_oneof" in this case) cannot be used in
 paths.
```
https://protobuf.dev/reference/java/api-docs/com/google/protobuf/FieldMask.html#:~:text=%23%20Field%20Masks%20and,used%20in%0A%20paths.