### PR TITLE
fix: filter non-SELECT rules when getting view dependencies (cherry-pick from #17248)

### DIFF
--- a/backend/plugin/db/cockroachdb/sync.go
+++ b/backend/plugin/db/cockroachdb/sync.go
@@ -701,7 +701,9 @@ func getViewDependencies(txn *sql.Tx, schemaName, viewName string) ([]*storepb.D
 	  	WHERE 
 	  		dependency_ns.nspname = '%s'
 	  		AND dependency_view.relname = '%s'
-	  		AND pg_attribute.attnum > 0 
+	  		AND pg_attribute.attnum > 0
+	  		-- Only consider SELECT rules (view definitions), not INSERT/UPDATE/DELETE rules
+	  		AND pg_rewrite.ev_type = '1'
 	  	ORDER BY 1,2,3;
 	`, schemaName, viewName)
 

--- a/backend/plugin/db/pg/sync.go
+++ b/backend/plugin/db/pg/sync.go
@@ -927,7 +927,9 @@ func getViewDependencies(txn *sql.Tx, schemaName, viewName string) ([]*storepb.D
 	  	WHERE 
 	  		dependency_ns.nspname = '%s'
 	  		AND dependency_view.relname = '%s'
-	  		AND pg_attribute.attnum > 0 
+	  		AND pg_attribute.attnum > 0
+	  		-- Only consider SELECT rules (view definitions), not INSERT/UPDATE/DELETE rules
+	  		AND pg_rewrite.ev_type = '1'
 	  	ORDER BY 1,2,3;
 	`, schemaName, viewName)
 


### PR DESCRIPTION
## Summary
Cherry-pick critical fix from #17248 to release/3.9.1 branch.

This fix prevents "graph has cycle" errors that occur when using PostgreSQL routing rules patterns (views with INSERT/UPDATE/DELETE rules that redirect to tables).

## Changes
- Modified `getViewDependencies()` in both `backend/plugin/db/pg/sync.go` and `backend/plugin/db/cockroachdb/sync.go`
- Added filter `pg_rewrite.ev_type = '1'` to only consider SELECT rules (view definitions) when building the dependency graph
- This prevents INSERT/UPDATE/DELETE rules from creating false cycles

## Original PR
See #17248 for full context and testing details.

🤖 Generated with [Claude Code](https://claude.ai/code)