### PR TITLE
feat: improve task activity grouping to reduce visual clutter

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentView/common.ts
+++ b/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentView/common.ts
@@ -1,4 +1,3 @@
-import { isEqual } from "lodash-es";
 import { IssueCommentType, getIssueCommentType } from "@/store";
 import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
 import { isNullOrUndefined } from "@/utils";
@@ -25,9 +24,8 @@ export const isSimilarIssueComment = (
     if (!fromTaskUpdate || !toTaskUpdate) {
       return false;
     }
-    if (!isEqual(fromTaskUpdate.tasks, toTaskUpdate.tasks)) {
-      return false;
-    }
+    // Group task updates by status or sheet changes, regardless of specific task IDs
+    // This allows grouping of "completed Task d1", "completed Task d2", etc.
     if (
       fromTaskUpdate.toSheet &&
       fromTaskUpdate.toSheet === toTaskUpdate.toSheet


### PR DESCRIPTION
## Summary
Improves the grouping logic for task activities in the issue comment timeline to reduce visual clutter by grouping similar task updates regardless of specific task IDs.

## Problem
Currently, multiple task completion activities like:
- "Bytebase completed Task d1"
- "Bytebase completed Task d2"  
- "Bytebase completed Task d3"

Are shown as separate entries in the timeline, creating unnecessary visual clutter. These should be grouped together as they represent the same type of action.

## Solution
Removed the restrictive task ID equality check (`isEqual(fromTaskUpdate.tasks, toTaskUpdate.tasks)`) that prevented grouping of task updates with different task IDs.

Now task activities are grouped when:
- They're from the same creator
- They have the same status transition (e.g., all "completed" transitions)
- OR they have the same sheet transition

## Impact
- **Before**: Each task completion shows as a separate activity
- **After**: Similar task completions are grouped with a message like "3 similar activities"
- Significantly cleaner and more scannable activity timeline
- Better UX for issues with many task updates

## Testing
- [x] Verified task activities with same status transitions are grouped
- [x] Verified task activities from different users remain separate
- [x] Verified other activity types still group correctly
- [x] Linting and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)