### PR TITLE
fix: improve plan spec validation reactivity and auto-enable editing

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
@@ -91,7 +91,7 @@ const policyV1Store = usePolicyV1Store();
 const editorState = useEditorState();
 
 // Use the validation hook for all specs
-const { isSpecEmpty } = useSpecsValidation(plan.value.specs);
+const { isSpecEmpty } = useSpecsValidation(computed(() => plan.value.specs));
 
 // Use plan check status for issue creation validation
 const {

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateButton.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateButton.vue
@@ -55,7 +55,7 @@ const sheetStore = useSheetV1Store();
 const loading = ref(false);
 
 // Use the validation hook for all specs
-const { isSpecEmpty } = useSpecsValidation(plan.value.specs);
+const { isSpecEmpty } = useSpecsValidation(computed(() => plan.value.specs));
 
 const planCreateErrorList = computed(() => {
   const errorList: string[] = [];

--- a/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div v-if="showDescriptionInput" class="flex flex-col mt-2">
-      <label class="block text-sm text-control mb-1">
+      <label class="block text-sm text-control-light mb-1">
         {{ $t("plan.description.add-a-description") }}
       </label>
       <DescriptionInput />

--- a/frontend/src/components/Plan/components/common/validateSpec.ts
+++ b/frontend/src/components/Plan/components/common/validateSpec.ts
@@ -1,11 +1,11 @@
-import { ref, watchEffect } from "vue";
+import { ref, watchEffect, type Ref, unref } from "vue";
 import { getLocalSheetByName } from "@/components/Plan";
 import { useSheetV1Store } from "@/store";
 import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import { extractSheetUID, getSheetStatement, sheetNameOfSpec } from "@/utils";
 
 // Hook to validate all specs in a plan
-export const useSpecsValidation = (specs: Plan_Spec[]) => {
+export const useSpecsValidation = (specs: Plan_Spec[] | Ref<Plan_Spec[]>) => {
   const sheetStore = useSheetV1Store();
   const validationMap = ref(new Map<string, boolean>());
 
@@ -43,11 +43,12 @@ export const useSpecsValidation = (specs: Plan_Spec[]) => {
   };
 
   watchEffect(async () => {
+    const currentSpecs = unref(specs);
     const newMap = new Map<string, boolean>();
 
     // Check all specs
     await Promise.all(
-      specs.map(async (spec) => {
+      currentSpecs.map(async (spec) => {
         const isEmpty = await checkSpecStatement(spec);
         newMap.set(spec.id, isEmpty);
       })


### PR DESCRIPTION
- Fix reactivity issue in useSpecsValidation hook by accepting reactive refs
- Auto-enable statement editing when new specs are created