### PR TITLE
fix(mongodb): fix mongodb collection name contains special characters

### DIFF
--- a/frontend/src/utils/v1/sql.ts
+++ b/frontend/src/utils/v1/sql.ts
@@ -177,7 +177,7 @@ export const generateSimpleSelectAllStatement = (
 
   switch (engine) {
     case Engine.MONGODB:
-      return `db.${table}.find().limit(${limit});`;
+      return `db['${table}'].find().limit(${limit});`;
     case Engine.COSMOSDB:
       return `SELECT * FROM ${table}`;
     case Engine.ELASTICSEARCH:
@@ -206,7 +206,7 @@ export const generateSimpleInsertStatement = (
     const kvPairs = columns
       .map((column, i) => `"${column}": <value${i + 1}>`)
       .join(", ");
-    return `db.${table}.insert({ ${kvPairs} });`;
+    return `db['${table}'].insert({ ${kvPairs} });`;
   }
 
   const schemaAndTable = generateSchemaAndTableNameInSQL(engine, schema, table);
@@ -229,7 +229,7 @@ export const generateSimpleUpdateStatement = (
     const kvPairs = columns
       .map((column, i) => `"${column}": <value${i + 1}>`)
       .join(", ");
-    return `db.${table}.updateOne({ /* <query> */ }, { $set: { /* ${kvPairs} */} });`;
+    return `db['${table}'].updateOne({ /* <query> */ }, { $set: { /* ${kvPairs} */} });`;
   }
 
   const schemaAndTable = generateSchemaAndTableNameInSQL(engine, schema, table);
@@ -247,7 +247,7 @@ export const generateSimpleDeleteStatement = (
   table: string
 ) => {
   if (engine === Engine.MONGODB) {
-    return `db.${table}.deleteOne({ /* query */ });`;
+    return `db['${table}'].deleteOne({ /* query */ });`;
   }
 
   const schemaAndTable = generateSchemaAndTableNameInSQL(engine, schema, table);


### PR DESCRIPTION
fix mongodb collection name contains special characters

like: "#/\\"

```bash
[mongos] admin> use xxx;
switched to db xxx
[mongos] xxx> show collections;
_test_audit
#RES_DATA
xxxx
restaurant
test_audit
test_audit(AI)
test_audit(Password***)
testData
[mongos] xxx> db."#RES_DATA".find()
Uncaught:
SyntaxError: Unexpected token (1:3)

> 1 | db."#RES_DATA".find()
    |    ^
  2 |

[mongos] xxx> db.getCollection("#RES_DATA").find()
[
  {
    _id: ObjectId('68a3f78a3d554cd5087c5020'),
    idx: 0,
    time: ISODate('2025-08-19T04:03:22.422Z')
  }
]

[mongos] xxx> db['#RES_DATA'].find()
[
  {
    _id: ObjectId('68a3f78a3d554cd5087c5020'),
    idx: 0,
    time: ISODate('2025-08-19T04:03:22.422Z')
  }
]
```