### PR TITLE
feat: implement collapsed view for plan description section

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/DescriptionSection.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/DescriptionSection.vue
@@ -1,18 +1,46 @@
 <template>
   <div class="flex-1">
-    <MarkdownEditor
-      :content="state.description"
-      mode="editor"
-      :project="project"
-      :placeholder="$t('plan.description.placeholder')"
-      :issue-list="[]"
-      @change="onUpdateValue"
-    />
+    <div v-if="!state.isExpanded" class="py-1 truncate">
+      <span class="text-sm text-control mr-2"
+        >{{ $t("common.description") }}:</span
+      >
+      <span
+        class="text-sm cursor-pointer hover:opacity-80"
+        :class="state.description ? 'text-gray-700' : 'italic text-gray-400'"
+        @click="toggleExpanded"
+      >
+        {{ state.description || $t("plan.description.placeholder") }}
+      </span>
+    </div>
+    <div v-else>
+      <div class="flex items-center justify-between mt-2">
+        <span class="text-base font-medium">{{
+          $t("common.description")
+        }}</span>
+        <NButton
+          size="small"
+          quaternary
+          @click="toggleExpanded"
+          :disabled="state.isUpdating"
+        >
+          {{ $t("common.collapse") }}
+        </NButton>
+      </div>
+      <MarkdownEditor
+        :content="state.description"
+        mode="editor"
+        :project="project"
+        :placeholder="$t('plan.description.placeholder')"
+        :issue-list="[]"
+        @change="onUpdateValue"
+      />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { create } from "@bufbuild/protobuf";
+import { NButton } from "naive-ui";
 import { computed, reactive, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import MarkdownEditor from "@/components/MarkdownEditor";
@@ -36,6 +64,7 @@ const { isCreating, plan, readonly } = usePlanContext();
 const state = reactive({
   isUpdating: false,
   description: plan.value.description,
+  isExpanded: false,
 });
 
 const allowEdit = computed(() => {
@@ -53,6 +82,10 @@ const allowEdit = computed(() => {
   }
   return false;
 });
+
+const toggleExpanded = () => {
+  state.isExpanded = !state.isExpanded;
+};
 
 const onUpdateValue = (value: string) => {
   state.description = value;

--- a/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
@@ -12,12 +12,7 @@
         <Actions />
       </div>
     </div>
-    <div v-if="showDescriptionInput" class="flex flex-col mt-2">
-      <label class="block text-sm text-control-light mb-1">
-        {{ $t("plan.description.add-a-description") }}
-      </label>
-      <DescriptionInput />
-    </div>
+    <DescriptionSection v-if="showDescriptionSection" />
   </div>
 </template>
 
@@ -27,7 +22,7 @@ import { NTag } from "naive-ui";
 import { computed } from "vue";
 import { usePlanContext } from "../../logic";
 import Actions from "./Actions";
-import DescriptionInput from "./DescriptionInput.vue";
+import DescriptionSection from "./DescriptionSection.vue";
 import TitleInput from "./TitleInput.vue";
 
 const { isCreating, plan } = usePlanContext();
@@ -36,7 +31,7 @@ const showDraftTag = computed(() => {
   return !isCreating.value && !plan.value.issue && !plan.value.rollout;
 });
 
-const showDescriptionInput = computed(() => {
+const showDescriptionSection = computed(() => {
   return !plan.value.issue;
 });
 </script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -246,7 +246,8 @@
       "description": "This resource and other related resources will be hard-deleted. @:common.cannot-undo-this-action",
       "double-comfirm": "To confirm deletion, please type: {name}",
       "notification": "Successfully delete the resource '{name}'."
-    }
+    },
+    "collapse": "Collapse"
   },
   "error-page": {
     "go-back-home": "Go back home"
@@ -1174,7 +1175,6 @@
       "reopen-confirm": "Are you sure to reopen this plan?"
     },
     "description": {
-      "add-a-description": "Add a description",
       "placeholder": "Add your description here for this plan..."
     }
   },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -246,7 +246,8 @@
       "description": "Este recurso y otros recursos relacionados se eliminarán definitivamente. @:common.cannot-undo-this-action",
       "double-comfirm": "Para confirmar la eliminación, escriba: {name}",
       "notification": "Se eliminó exitosamente el recurso '{name}'."
-    }
+    },
+    "collapse": "Colapsar"
   },
   "error-page": {
     "go-back-home": "Volver al inicio"
@@ -1174,7 +1175,6 @@
       "reopen-confirm": "¿Estás seguro de que deseas reabrir este plan?"
     },
     "description": {
-      "add-a-description": "Añadir una descripción",
       "placeholder": "Añade tu descripción aquí para este plan..."
     }
   },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -246,7 +246,8 @@
       "description": "このリソースとその他の関連リソースは物理的に削除されます。@:common.cannot-undo-this-action",
       "double-comfirm": "削除を確認するには、{name} と入力してください。",
       "notification": "リソース '{name}' を正常に削除しました。"
-    }
+    },
+    "collapse": "閉じる"
   },
   "error-page": {
     "go-back-home": "ホームページに戻る"
@@ -1174,7 +1175,6 @@
       "reopen-confirm": "このプランを再開してもよろしいですか?"
     },
     "description": {
-      "add-a-description": "説明を追加する",
       "placeholder": "このプランの説明をここに追加してください..."
     }
   },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -246,7 +246,8 @@
       "description": "Tài nguyên này và các tài nguyên liên quan khác sẽ bị xóa cứng. @:common.cannot-undo-this-action",
       "double-comfirm": "Để xác nhận xóa, vui lòng nhập: {name}",
       "notification": "Xóa thành công tài nguyên '{name}'."
-    }
+    },
+    "collapse": "Sụp đổ"
   },
   "error-page": {
     "go-back-home": "Về trang chủ"
@@ -1174,7 +1175,6 @@
       "reopen-confirm": "Bạn có chắc chắn muốn mở lại kế hoạch này không?"
     },
     "description": {
-      "add-a-description": "Thêm mô tả",
       "placeholder": "Thêm mô tả của bạn vào đây cho kế hoạch này..."
     }
   },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -246,7 +246,8 @@
       "description": "此资源和其他相关资源将被硬删除。@:common.cannot-undo-this-action",
       "double-comfirm": "要确认删除，请输入：{name}",
       "notification": "成功删除资源“{name}”。"
-    }
+    },
+    "collapse": "收起"
   },
   "error-page": {
     "go-back-home": "回到主页"
@@ -1174,7 +1175,6 @@
       "reopen-confirm": "确定重新开启该变更计划？"
     },
     "description": {
-      "add-a-description": "添加描述",
       "placeholder": "在此添加该更变计划的描述..."
     }
   },


### PR DESCRIPTION
- Add collapsed/expanded state management to DescriptionSection
- Show compact one-line view by default with clickable description text

<img width="1938" height="542" alt="image" src="https://github.com/user-attachments/assets/32b56344-e534-4620-a30a-6bc78da58129" />

<img width="1954" height="674" alt="image" src="https://github.com/user-attachments/assets/629adeac-eb61-4b9c-ba28-9aae6ecb3041" />
