### PR TITLE
fix: sql editor initial

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -66,8 +66,8 @@ import {
   getDefaultPagination,
 } from "@/utils";
 import {
-  extractWorksheetConnection,
   useSheetContext,
+  extractWorksheetConnection,
 } from "@/views/sql-editor/Sheet";
 import {
   useSQLEditorContext,
@@ -228,9 +228,10 @@ const prepareSheetLegacy = async () => {
     return true;
   }
 
+  const connection = await extractWorksheetConnection(sheet);
   // Open the sheet in a new tab otherwise.
   tabStore.addTab({
-    connection: extractWorksheetConnection(sheet),
+    connection,
     worksheet: sheet.name,
     title: sheet.title,
     statement: getSheetStatement(sheet),
@@ -239,6 +240,7 @@ const prepareSheetLegacy = async () => {
 
   return true;
 };
+
 const prepareSheet = async () => {
   const projectId = route.params.project;
   const sheetId = route.params.sheet;
@@ -285,16 +287,23 @@ const prepareSheet = async () => {
     return false;
   }
 
+  const connection = await extractWorksheetConnection(sheet);
   if (openingSheetTab) {
     // Switch to a sheet tab if it's open already.
     // and don't touch it
     tabStore.setCurrentTabId(openingSheetTab.id);
+    tabStore.updateCurrentTab({
+      connection,
+      worksheet: sheet.name,
+      statement: getSheetStatement(sheet),
+      status: "CLEAN",
+    });
     return true;
   }
 
   // Open the sheet in a new tab otherwise.
   tabStore.addTab({
-    connection: extractWorksheetConnection(sheet),
+    connection,
     worksheet: sheet.name,
     title: sheet.title,
     statement: getSheetStatement(sheet),

--- a/frontend/src/store/modules/sqlEditor/tab.ts
+++ b/frontend/src/store/modules/sqlEditor/tab.ts
@@ -264,7 +264,10 @@ export const useSQLEditorTabStore = defineStore("sqlEditorTab", () => {
   const updateTab = (id: string, payload: Partial<SQLEditorTab>) => {
     const tab = tabById(id);
     if (!tab) return;
-    Object.assign(tab, payload);
+    tabsById.set(id, {
+      ...tab,
+      ...payload,
+    });
   };
   const updateCurrentTab = (payload: Partial<SQLEditorTab>) => {
     const id = currentTabId.value;
@@ -377,6 +380,7 @@ export const useSQLEditorTabStore = defineStore("sqlEditorTab", () => {
   const setCurrentTabId = (id: string) => {
     currentTabId.value = id;
   };
+
   const selectOrAddSimilarNewTab = (
     tab: CoreSQLEditorTab,
     beside = false,

--- a/frontend/src/views/sql-editor/Sheet/context.ts
+++ b/frontend/src/views/sql-editor/Sheet/context.ts
@@ -122,11 +122,11 @@ export const provideSheetContext = () => {
   return context;
 };
 
-export const extractWorksheetConnection = (worksheet: Worksheet) => {
+export const extractWorksheetConnection = async (worksheet: Worksheet) => {
   const connection = emptySQLEditorConnection();
   if (worksheet.database) {
     try {
-      const database = useDatabaseV1Store().getDatabaseByName(
+      const database = await useDatabaseV1Store().getOrFetchDatabaseByName(
         worksheet.database
       );
       connection.instance = database.instance;
@@ -175,9 +175,10 @@ export const openWorksheetByName = async (
   );
 
   const statement = getSheetStatement(worksheet);
+  const connection = await extractWorksheetConnection(worksheet);
 
   const newTab: Partial<SQLEditorTab> = {
-    connection: extractWorksheetConnection(worksheet),
+    connection,
     worksheet: worksheet.name,
     title: worksheet.title,
     statement,


### PR DESCRIPTION
- Fix: during the initialization, the tab is changed but the UI (MonacoEditor content) is not reactive to the content
- Fix: initial database for worksheet

Close BYT-7953