### PR TITLE
fix: update tag policy for reivew config

### DIFF
--- a/backend/api/v1/org_policy_service.go
+++ b/backend/api/v1/org_policy_service.go
@@ -546,7 +546,7 @@ func (s *OrgPolicyService) convertToPolicy(ctx context.Context, policyMessage *s
 	case storepb.Policy_TAG:
 		p := &v1pb.TagPolicy{}
 		if err := common.ProtojsonUnmarshaler.Unmarshal([]byte(policyMessage.Payload), p); err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal rollout policy payload")
+			return nil, errors.Wrapf(err, "failed to unmarshal tag policy payload")
 		}
 		policy.Policy = &v1pb.Policy_TagPolicy{
 			TagPolicy: p,

--- a/backend/store/policy.go
+++ b/backend/store/policy.go
@@ -260,7 +260,7 @@ func (s *Store) getReviewConfigByResource(ctx context.Context, resourceType stor
 		return nil, errors.Wrapf(err, "failed to unmarshal tag policy payload")
 	}
 
-	reviewConfigName, ok := payload.Tags[string(common.ReservedTagReviewConfig)]
+	reviewConfigName, ok := payload.Tags[common.ReservedTagReviewConfig]
 	if !ok {
 		return nil, &common.Error{Code: common.NotFound, Err: errors.Errorf("review config tag for resource %v/%s not found", resourceType, resource)}
 	}

--- a/backend/tests/sql_review_test.go
+++ b/backend/tests/sql_review_test.go
@@ -117,7 +117,7 @@ func TestSQLReviewForPostgreSQL(t *testing.T) {
 			Policy: &v1pb.Policy_TagPolicy{
 				TagPolicy: &v1pb.TagPolicy{
 					Tags: map[string]string{
-						string(common.ReservedTagReviewConfig): createdConfig.Msg.Name,
+						common.ReservedTagReviewConfig: createdConfig.Msg.Name,
 					},
 				},
 			},
@@ -286,7 +286,7 @@ func TestSQLReviewForMySQL(t *testing.T) {
 			Policy: &v1pb.Policy_TagPolicy{
 				TagPolicy: &v1pb.TagPolicy{
 					Tags: map[string]string{
-						string(common.ReservedTagReviewConfig): createdConfig.Msg.Name,
+						common.ReservedTagReviewConfig: createdConfig.Msg.Name,
 					},
 				},
 			},

--- a/frontend/src/components/SQLReview/SQLReviewCreation.vue
+++ b/frontend/src/components/SQLReview/SQLReviewCreation.vue
@@ -42,6 +42,7 @@
 </template>
 
 <script lang="ts" setup>
+import { isEqual } from "lodash-es";
 import { useDialog } from "naive-ui";
 import { reactive, computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -227,7 +228,9 @@ const tryFinishSetup = async () => {
     const policy = await store.upsertReviewPolicy({
       title: state.name,
       ruleList: convertRuleMapToPolicyRuleList(state.selectedRuleMapByEngine),
-      resources: state.attachedResources,
+      resources: isEqual(props.selectedResources, state.attachedResources)
+        ? undefined
+        : state.attachedResources,
       id: `${reviewConfigNamePrefix}${state.resourceId}`,
       enforce: isUpdate.value ? undefined : true,
     });

--- a/frontend/src/store/modules/sqlReview.ts
+++ b/frontend/src/store/modules/sqlReview.ts
@@ -94,8 +94,8 @@ interface SQLReviewState {
   reviewPolicyList: SQLReviewPolicy[];
 }
 
-const getTagPolicyName = (environmentPath: string): string => {
-  return `${environmentPath}/${policyNamePrefix}tag`;
+const getTagPolicyName = (resourcePath: string): string => {
+  return `${resourcePath}/${policyNamePrefix}tag`;
 };
 
 export const useSQLReviewStore = defineStore("sqlReview", {
@@ -161,8 +161,6 @@ export const useSQLReviewStore = defineStore("sqlReview", {
         name: targetPolicy.id,
       });
       await reviewConfigServiceClientConnect.deleteReviewConfig(request);
-
-      await removeReviewConfigTag(targetPolicy.resources);
 
       pullAt(this.reviewPolicyList, index);
     },


### PR DESCRIPTION
- Update the tag policy in the backend when the review config is removed
- Do not update the tag policy when updating the review config

Close BYT-7970