### PR TITLE
refactor: use NTabs for markdown editor tabs

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentList.vue
+++ b/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-y-4">
+  <div class="flex flex-col">
     <ul>
       <IssueCreatedComment :issue-comments="issueComments" :issue="issue" />
       <IssueCommentView
@@ -68,9 +68,6 @@
         </div>
         <div class="min-w-0 flex-1">
           <h3 class="sr-only" id="issue-comment-editor"></h3>
-          <label for="comment" class="sr-only">
-            {{ $t("issue.add-a-comment") }}
-          </label>
           <MarkdownEditor
             mode="editor"
             :content="state.newComment"
@@ -79,10 +76,9 @@
             @change="(val: string) => (state.newComment = val)"
             @submit="doCreateComment(state.newComment)"
           />
-          <div class="mt-3 flex items-center justify-start">
+          <div class="mt-3 flex items-center justify-end">
             <NButton
               type="primary"
-              size="small"
               :disabled="state.newComment.length == 0"
               @click.prevent="doCreateComment(state.newComment)"
             >

--- a/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentView/IssueCommentView.vue
+++ b/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentView/IssueCommentView.vue
@@ -7,7 +7,9 @@
         aria-hidden="true"
       ></span>
       <div class="relative flex items-start">
-        <ActionIcon :issue-comment="issueComment" />
+        <div class="pt-1.5">
+          <ActionIcon :issue-comment="issueComment" />
+        </div>
 
         <IssueCommentAction
           :issue="issue"

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -857,7 +857,6 @@
       }
     },
     "add-some-description": "Add some description...",
-    "add-a-comment": "Add a comment",
     "leave-a-comment": "Leave a comment...",
     "comment-editor": {
       "write": "Write",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -857,7 +857,6 @@
       }
     },
     "add-some-description": "Agregar alguna descripción...",
-    "add-a-comment": "Agregar un comentario",
     "leave-a-comment": "Dejar un comentario...",
     "comment-editor": {
       "write": "Escribir",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -857,7 +857,6 @@
       }
     },
     "add-some-description": "説明を追加してください…",
-    "add-a-comment": "コメントを追加",
     "leave-a-comment": "コメントを残す…",
     "comment-editor": {
       "write": "編集",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -857,7 +857,6 @@
       }
     },
     "add-some-description": "Thêm mô tả...",
-    "add-a-comment": "Thêm bình luận",
     "leave-a-comment": "Để lại bình luận...",
     "comment-editor": {
       "write": "Viết",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -857,7 +857,6 @@
       }
     },
     "add-some-description": "添加一些描述…",
-    "add-a-comment": "添加评论",
     "leave-a-comment": "发表一条评论…",
     "comment-editor": {
       "write": "编辑",


### PR DESCRIPTION
Replace custom tab implementation with naive-ui's NTabs component for better consistency and maintainability.