### PR TITLE
feat: improve plan description field UX

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1175,7 +1175,7 @@
       "reopen-confirm": "Are you sure to reopen this plan?"
     },
     "description": {
-      "placeholder": "Add your description here for this plan..."
+      "placeholder": "Add a description"
     }
   },
   "rollout": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1175,7 +1175,7 @@
       "reopen-confirm": "¿Estás seguro de que deseas reabrir este plan?"
     },
     "description": {
-      "placeholder": "Añade tu descripción aquí para este plan..."
+      "placeholder": "Añadir descripción"
     }
   },
   "rollout": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1175,7 +1175,7 @@
       "reopen-confirm": "このプランを再開してもよろしいですか?"
     },
     "description": {
-      "placeholder": "このプランの説明をここに追加してください..."
+      "placeholder": "説明を追加"
     }
   },
   "rollout": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1175,7 +1175,7 @@
       "reopen-confirm": "Bạn có chắc chắn muốn mở lại kế hoạch này không?"
     },
     "description": {
-      "placeholder": "Thêm mô tả của bạn vào đây cho kế hoạch này..."
+      "placeholder": "Thêm mô tả"
     }
   },
   "rollout": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1175,7 +1175,7 @@
       "reopen-confirm": "确定重新开启该变更计划？"
     },
     "description": {
-      "placeholder": "在此添加该更变计划的描述..."
+      "placeholder": "添加描述"
     }
   },
   "rollout": {


### PR DESCRIPTION
## Summary
- Improved the UX for the plan description field with better visual cues and interactions
- Made the collapsed/expanded states more intuitive and polished

## Changes
- Added expand icon (plus) next to placeholder text when field is empty for better discoverability
- Show Markdown preview in collapsed state instead of raw text for better readability
- Added prominent collapse button with chevron icon for better visibility
- Implemented click-outside-to-collapse behavior for smoother interaction flow
- Updated placeholder text from "Add your description here..." to simpler "Add a description"
- Applied compact styling to Markdown preview with fade effect for long content
- Updated all i18n translations (en-US, zh-CN, ja-JP, es-ES, vi-VN)

## Screenshots
Before: Description field was hard to notice and collapse button was too subtle
After: Clear visual cues with expand icon, proper Markdown preview, and prominent collapse button

## Test Plan
- [ ] Click on "Add a description" with plus icon to expand the field
- [ ] Enter some Markdown content (headers, lists, code blocks)
- [ ] Click collapse button or click outside to collapse
- [ ] Verify Markdown is properly rendered in collapsed state
- [ ] Verify all translations work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)