### PR TITLE
fix: export task timeout error handling

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -889,7 +889,7 @@ func DoExport(
 		storepb.MaskingExceptionPolicy_MaskingException_EXPORT,
 	)
 	if queryErr != nil {
-		return nil, duration, err
+		return nil, duration, queryErr
 	}
 	// only return the last result
 	if len(results) > 1 {


### PR DESCRIPTION
Part of BYT-8009

Export tasks were completing with empty downloads when queries timed out after 10 minutes. The bug was in DoExport() returning the wrong error variable - it returned 'err' (connection error, usually nil) instead of 'queryErr' (the actual timeout error), causing tasks to appear successful with empty export archives.
