### PR TITLE
chore: update release description in all translations

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2846,7 +2846,7 @@
     },
     "actions": {},
     "messages": {},
-    "usage-description": "The release is only used in custom GitOps with API integration."
+    "usage-description": "A release is a versioned application artifact whose deployment to an environment is triggered by a GitOps workflow."
   },
   "export-data": {
     "export-rows": "Export rows",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2846,7 +2846,7 @@
     },
     "actions": {},
     "messages": {},
-    "usage-description": "El lanzamiento solo se utiliza en GitOps personalizado con integración de API."
+    "usage-description": "Un lanzamiento es un artefacto de aplicación versionado cuyo despliegue a un entorno es activado por un flujo de trabajo GitOps."
   },
   "export-data": {
     "export-rows": "Exportar filas",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2846,7 +2846,7 @@
     },
     "actions": {},
     "messages": {},
-    "usage-description": "このリリースは、API統合を使用したカスタムGitOpsでのみ使用されます。"
+    "usage-description": "リリースは、GitOpsワークフローによって環境へのデプロイがトリガーされるバージョン管理されたアプリケーションアーティファクトです。"
   },
   "export-data": {
     "export-rows": "エクスポート行数",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2846,7 +2846,7 @@
     },
     "actions": {},
     "messages": {},
-    "usage-description": "Bản phát hành chỉ được sử dụng trong GitOps tùy chỉnh với tích hợp API."
+    "usage-description": "Bản phát hành là một artifact ứng dụng có phiên bản mà việc triển khai vào môi trường được kích hoạt bởi quy trình GitOps."
   },
   "export-data": {
     "export-rows": "Xuất số dòng",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2846,7 +2846,7 @@
     },
     "actions": {},
     "messages": {},
-    "usage-description": "发布包仅用于自定义的 GitOps 与 Bytebase API 集成。"
+    "usage-description": "发布是一个版本化的应用程序工件，其部署到环境由 GitOps 工作流触发。"
   },
   "export-data": {
     "export-rows": "导出行数",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2846,7 +2846,7 @@
     },
     "actions": {},
     "messages": {},
-    "usage-description": "发布是一个版本化的应用程序工件，其部署到环境由 GitOps 工作流触发。"
+    "usage-description": "发布包是版本化的应用制品。GitOps 工作流将发布包部署到环境。"
   },
   "export-data": {
     "export-rows": "导出行数",


### PR DESCRIPTION
## Summary
- Updated the release "usage-description" text across all language files (en-US, zh-CN, ja-JP, es-ES, vi-VN)
- Changed from describing releases as "only used in custom GitOps with API integration" to the clearer definition: "A release is a versioned application artifact whose deployment to an environment is triggered by a GitOps workflow"

## Test plan
- [x] Verify all translation files have been updated
- [ ] Check that the new descriptions display correctly in the UI for each language

🤖 Generated with [Claude Code](https://claude.ai/code)