### PR TITLE
fix: update documentation links to match new URL structure

### DIFF
--- a/action/github/github.go
+++ b/action/github/github.go
@@ -178,7 +178,7 @@ func buildCommentMessage(resp *v1pb.CheckReleaseResponse) string {
 
 func writeAnnotations(resp *v1pb.CheckReleaseResponse) error {
 	// annotation template
-	// `::${advice.status} file=${file},line=${advice.line},col=${advice.column},title=${advice.title} (${advice.code})::${advice.content}. Targets: ${targets.join(', ')} https://docs.bytebase.com/reference/error-code/advisor#${advice.code}`
+	// `::${advice.status} file=${file},line=${advice.line},col=${advice.column},title=${advice.title} (${advice.code})::${advice.content}. Targets: ${targets.join(', ')} https://docs.bytebase.com/sql-review/error-codes#${advice.code}`
 	for _, result := range resp.Results {
 		for _, advice := range result.Advices {
 			var sb strings.Builder
@@ -205,7 +205,7 @@ func writeAnnotations(resp *v1pb.CheckReleaseResponse) error {
 			_, _ = sb.WriteString(". Targets: ")
 			_, _ = sb.WriteString(result.Target)
 			_, _ = sb.WriteString(" ")
-			_, _ = sb.WriteString(" https://docs.bytebase.com/reference/error-code/advisor#")
+			_, _ = sb.WriteString(" https://docs.bytebase.com/sql-review/error-codes#")
 			_, _ = sb.WriteString(strconv.Itoa(int(advice.Code)))
 			fmt.Println(sb.String())
 		}

--- a/frontend/src/components/InstanceForm/BigQueryHostInput.vue
+++ b/frontend/src/components/InstanceForm/BigQueryHostInput.vue
@@ -18,7 +18,7 @@
     <p class="col-span-2 textinfolabel">
       {{ $t("instance.find-gcp-project-id") }}
       <a
-        href="https://docs.bytebase.com/get-started/instance/#specify-google-cloud-project-id-and-spanner-instance-id?source=console"
+        href="https://docs.bytebase.com/get-started/connect/gcp?source=console"
         target="_blank"
         class="normal-link inline-flex items-center"
       >

--- a/frontend/src/components/InstanceForm/DataSourceSection/DataSourceForm.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/DataSourceForm.vue
@@ -568,7 +568,7 @@
             </NRadio>
           </NRadioGroup>
           <LearnMoreLink
-            url="http://docs.bytebase.com/get-started/instance/#use-external-secret-manager"
+            url="https://docs.bytebase.com/get-started/connect/overview#secret-manager-integration"
             class="text-sm"
           />
         </div>
@@ -586,7 +586,7 @@
               {{ $t("instance.password-type.password-tip") }}
             </div>
             <LearnMoreLink
-              url="https://docs.bytebase.com/get-started/instance/#use-secret-manager?source=console"
+              url="https://docs.bytebase.com/get-started/connect/overview/#use-secret-manager?source=console"
               class="ml-1 text-sm"
             />
             <FeatureBadge

--- a/frontend/src/components/InstanceForm/DataSourceSection/GcpCredentialInput.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/GcpCredentialInput.vue
@@ -7,7 +7,7 @@
     <p class="textinfolabel">
       <span>{{ $t("instance.create-gcp-credentials") }}</span>
       <a
-        href="https://docs.bytebase.com/get-started/instance/#create-a-google-cloud-service-account-as-the-credential?source=console"
+        href="https://docs.bytebase.com/get-started/connect/gcp?source=console"
         target="_blank"
         class="normal-link inline-flex items-center ml-1"
       >

--- a/frontend/src/components/InstanceForm/Form.vue
+++ b/frontend/src/components/InstanceForm/Form.vue
@@ -435,7 +435,7 @@
         type="info"
       >
         <a
-          href="https://docs.bytebase.com/get-started/instance#connect-to-the-instance-from-bytebase-cloud"
+          href="https://docs.bytebase.com/get-started/cloud#prerequisites"
           target="_blank"
           rel="noopener noreferrer"
           class="normal-link"

--- a/frontend/src/components/InstanceForm/SpannerHostInput.vue
+++ b/frontend/src/components/InstanceForm/SpannerHostInput.vue
@@ -32,7 +32,7 @@
     <p class="col-span-2 textinfolabel">
       {{ $t("instance.find-gcp-project-id-and-instance-id") }}
       <a
-        href="https://docs.bytebase.com/get-started/instance/#specify-google-cloud-project-id-and-spanner-instance-id?source=console"
+        href="https://docs.bytebase.com/get-started/connect/gcp?source=console"
         target="_blank"
         class="normal-link inline-flex items-center"
       >

--- a/frontend/src/components/Project/ProjectReleasesPanel.vue
+++ b/frontend/src/components/Project/ProjectReleasesPanel.vue
@@ -3,7 +3,7 @@
     <NAlert type="info">
       <span>{{ $t("release.usage-description") }}</span>
       <LearnMoreLink
-        url="https://docs.bytebase.com/vcs-integration/release/?source=console"
+        url="https://docs.bytebase.com/gitops/release/?source=console"
         class="ml-1"
       />
     </NAlert>


### PR DESCRIPTION
## Summary
- Updated all broken documentation links to match the new URL structure
- Fixed links that were causing 404 errors due to documentation reorganization

## Changes
- Updated error code links from `reference/error-code/advisor` to `sql-review/error-codes`
- Updated instance links from `get-started/instance` to `get-started/connect/overview`
- Updated GCP-specific links to `get-started/connect/gcp`
- Updated VCS integration link from `vcs-integration/release` to `gitops/release`
- Updated secret manager link to `get-started/connect/overview#secret-manager-integration`
- Updated cloud prerequisites link to `get-started/cloud#prerequisites`

## Test plan
- [x] All links have been verified to point to valid documentation pages
- [x] Frontend linting passed (`pnpm --dir frontend lint --fix`)
- [x] Frontend type checking passed (`pnpm --dir frontend type-check`)
- [x] Go linting passed (`golangci-lint run --allow-parallel-runners`)

🤖 Generated with [Claude Code](https://claude.ai/code)