### PR TITLE
chore: fallback to the webhook message if send im direct message fails

### DIFF
--- a/backend/plugin/webhook/feishu/feishu.go
+++ b/backend/plugin/webhook/feishu/feishu.go
@@ -104,16 +104,17 @@ type feishuReceiver struct {
 
 func (*feishuReceiver) Post(context webhook.Context) error {
 	if context.DirectMessage && len(context.MentionEndUsers) > 0 {
-		postDirectMessage(context)
-		return nil
+		if postDirectMessage(context) {
+			return nil
+		}
 	}
 	return postMessage(context)
 }
 
-func postDirectMessage(webhookCtx webhook.Context) {
+func postDirectMessage(webhookCtx webhook.Context) bool {
 	feishu := webhookCtx.IMSetting.GetFeishu()
 	if feishu == nil {
-		return
+		return false
 	}
 	p := newProvider(feishu.AppId, feishu.AppSecret)
 
@@ -155,7 +156,10 @@ func postDirectMessage(webhookCtx webhook.Context) {
 		return errs
 	}); err != nil {
 		slog.Warn("failed to send direct message to feishu user", log.BBError(err))
+		return false
 	}
+
+	return true
 }
 
 func postMessage(context webhook.Context) error {

--- a/backend/plugin/webhook/lark/lark.go
+++ b/backend/plugin/webhook/lark/lark.go
@@ -104,16 +104,17 @@ type larkReceiver struct {
 
 func (*larkReceiver) Post(context webhook.Context) error {
 	if context.DirectMessage && len(context.MentionEndUsers) > 0 {
-		postDirectMessage(context)
-		return nil
+		if postDirectMessage(context) {
+			return nil
+		}
 	}
 	return postMessage(context)
 }
 
-func postDirectMessage(webhookCtx webhook.Context) {
+func postDirectMessage(webhookCtx webhook.Context) bool {
 	lark := webhookCtx.IMSetting.GetLark()
 	if lark == nil {
-		return
+		return false
 	}
 	p := newProvider(lark.AppId, lark.AppSecret)
 
@@ -155,7 +156,10 @@ func postDirectMessage(webhookCtx webhook.Context) {
 		return errs
 	}); err != nil {
 		slog.Warn("failed to send direct message to lark user", log.BBError(err))
+		return false
 	}
+
+	return true
 }
 
 func postMessage(context webhook.Context) error {

--- a/backend/plugin/webhook/slack/slack.go
+++ b/backend/plugin/webhook/slack/slack.go
@@ -126,8 +126,9 @@ func GetBlocks(context webhook.Context) []Block {
 
 func (*Receiver) Post(context webhook.Context) error {
 	if context.DirectMessage && len(context.MentionEndUsers) > 0 {
-		postDirectMessage(context)
-		return nil
+		if postDirectMessage(context) {
+			return nil
+		}
 	}
 	return postMessage(context)
 }
@@ -175,11 +176,11 @@ func postMessage(context webhook.Context) error {
 	return nil
 }
 
-func postDirectMessage(webhookCtx webhook.Context) {
+func postDirectMessage(webhookCtx webhook.Context) bool {
 	ctx := context.Background()
 	t := webhookCtx.IMSetting.GetSlack().GetToken()
 	if t == "" {
-		return
+		return false
 	}
 	p := newProvider(t)
 	sent := map[string]bool{}
@@ -212,5 +213,8 @@ func postDirectMessage(webhookCtx webhook.Context) {
 		return errs
 	}); err != nil {
 		slog.Warn("failed to send direct message to slack user", log.BBError(err))
+		return false
 	}
+
+	return true
 }

--- a/backend/plugin/webhook/wecom/wecom.go
+++ b/backend/plugin/webhook/wecom/wecom.go
@@ -191,7 +191,8 @@ func (*Receiver) sendDirectMessage(webhookCtx webhook.Context) bool {
 
 	if err := common.Retry(ctx, fn); err != nil {
 		slog.Warn("failed to send direct message to wecom users", log.BBError(err))
+		return false
 	}
 
-	return len(sent) == len(webhookCtx.MentionEndUsers)
+	return true
 }

--- a/frontend/src/components/ProjectWebhookForm.vue
+++ b/frontend/src/components/ProjectWebhookForm.vue
@@ -90,9 +90,13 @@
           <div class="text-md leading-6 font-medium text-main">
             {{ $t("project.webhook.direct-messages") }}
           </div>
-          <BBAttention v-if="!imApp?.enabled" class="my-2" type="warning">
+          <BBAttention class="my-2" :type="imApp?.enabled ? 'info' : 'warning'">
             <template #default>
+              <span v-if="imApp?.enabled">
+                {{ $t("project.webhook.direct-messages-tip") }}
+              </span>
               <i18n-t
+                v-else
                 class="textinfolabel"
                 tag="div"
                 keypath="project.webhook.direct-messages-warning"
@@ -110,7 +114,10 @@
             </template>
           </BBAttention>
           <span class="mt-1 textinfolabel">
-            <i18n-t keypath="project.webhook.direct-messages-tip" tag="span">
+            <i18n-t
+              keypath="project.webhook.direct-messages-description"
+              tag="span"
+            >
               <template #events>
                 <ul class="list-disc pl-4">
                   <li

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1759,8 +1759,9 @@
         "confirm-title": "Delete webhook '{title}' and all its execution history?"
       },
       "direct-messages": "Direct messages",
+      "direct-messages-tip": "Bytebase will fall back to posting webhook messages if no users are matched or the delivery of the message fails.",
       "enable-direct-messages": "Enable direct messages",
-      "direct-messages-tip": "Once enabled, Bytebase will send direct messages to the related users (matched by email). Only support: {events}",
+      "direct-messages-description": "Once enabled, Bytebase will send following events as direct messages to the related users (matched by email) {events}",
       "direct-messages-warning": "You need to configure {im} to make it work.",
       "activity-support-direct-message": "Support send direct messages to related users",
       "activity-item": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1759,8 +1759,9 @@
         "confirm-title": "¿Eliminar el '{title}' del webhook y todo su historial de ejecución?"
       },
       "direct-messages": "Mensajes directos",
+      "direct-messages-tip": "Bytebase recurrirá a la publicación de mensajes de webhook si no hay usuarios coincidentes o si falla la entrega del mensaje.",
       "enable-direct-messages": "Habilitar mensajes directos",
-      "direct-messages-tip": "Una vez habilitado, Bytebase enviará mensajes directos a los usuarios relacionados (emparejados por correo electrónico). Solo soporte: {events}",
+      "direct-messages-description": "Una vez habilitado, Bytebase enviará mensajes directos a los usuarios relacionados (emparejados por correo electrónico). Solo soporte: {events}",
       "direct-messages-warning": "Debes configurar {im} para que funcione.",
       "activity-support-direct-message": "Soporte para enviar mensajes directos a usuarios relacionados.",
       "activity-item": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1759,8 +1759,9 @@
         "confirm-title": "Webhook '{title}' とすべての実行履歴を削除しますか?"
       },
       "direct-messages": "プライベートメッセージ通知",
+      "direct-messages-tip": "一致するユーザーがいない場合、またはメッセージの配信が失敗した場合、Bytebase は webhook メッセージの投稿にフォールバックします。",
       "enable-direct-messages": "プライベートメッセージ通知を有効にする",
-      "direct-messages-tip": "有効にすると、Bytebase は関連ユーザー (電子メールで一致) にダイレクト メッセージを送信します。サポートのみ: {events}",
+      "direct-messages-description": "有効にすると、Bytebase は関連ユーザー (電子メールで一致) にダイレクト メッセージを送信します。サポートのみ: {events}",
       "direct-messages-warning": "これを機能させるには、{im} を設定する必要があります。",
       "activity-support-direct-message": "関連するユーザーへのプライベート メッセージ通知の送信のサポート",
       "activity-item": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1759,8 +1759,9 @@
         "confirm-title": "Xóa webhook '{title}' và tất cả lịch sử thực thi của nó?"
       },
       "direct-messages": "Tin nhắn trực tiếp",
+      "direct-messages-tip": "Bytebase sẽ quay lại đăng tin nhắn webhook nếu không có người dùng nào khớp hoặc việc gửi tin nhắn không thành công.",
       "enable-direct-messages": "Bật tin nhắn trực tiếp",
-      "direct-messages-tip": "Khi được bật, Bytebase sẽ gửi tin nhắn trực tiếp đến người dùng liên quan (được khớp bằng email). Chỉ hỗ trợ: {events}",
+      "direct-messages-description": "Khi được bật, Bytebase sẽ gửi tin nhắn trực tiếp đến người dùng liên quan (được khớp bằng email). Chỉ hỗ trợ: {events}",
       "direct-messages-warning": "Bạn cần định cấu hình {im} để làm cho nó hoạt động.",
       "activity-support-direct-message": "Hỗ trợ gửi tin nhắn trực tiếp đến người dùng liên quan",
       "activity-item": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1759,8 +1759,9 @@
         "confirm-title": "删除 webhook '{title}' 以及所有的执行历史?"
       },
       "direct-messages": "私信通知",
+      "direct-messages-tip": "如果没有匹配的用户或者消息发送失败，Bytebase 将回退发布 webhook 消息。",
       "enable-direct-messages": "启用私信通知",
-      "direct-messages-tip": "启用后，Bytebase 将私信通知相关用户（通过电子邮箱匹配）。仅支持：{events}",
+      "direct-messages-description": "启用后，Bytebase 将私信通知相关用户（通过电子邮箱匹配）。仅支持：{events}",
       "direct-messages-warning": "您需要配置 {im} 才能使其正常工作。",
       "activity-support-direct-message": "支持向相关用户发送私信通知",
       "activity-item": {


### PR DESCRIPTION
- Fallback to the webhook message if send IM direct message fails (wecom already supports this)
- Update UI

<img width="1908" height="442" alt="CleanShot 2025-09-03 at 15 27 47@2x" src="https://github.com/user-attachments/assets/a85c46a6-c246-4d16-985b-c866d20c0679" />
