### PR TITLE
chore: upgrade Go from 1.25.0 to 1.25.1

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0'
+          go-version: '1.25.1'
           cache: false # Caching is slow.
       - name: Verify go.mod is tidy
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0'
+          go-version: '1.25.1'
           cache: false # Caching is slow.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/test_link.yml
+++ b/.github/workflows/test_link.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0'
+          go-version: '1.25.1'
           cache: false # Caching is slow.
       - name: Validate links
         run: go test -timeout 600s -v ./scripts/... | tee test.log; exit ${PIPESTATUS[0]}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bytebase/bytebase
 
-go 1.25.0
+go 1.25.1
 
 // workaround mssql-docker default TLS cert negative serial number problem
 // https://github.com/microsoft/mssql-docker/issues/895

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN pnpm --dir ./frontend i
 RUN pnpm --dir ./frontend release-docker
 
-FROM golang:1.25.0-alpine3.21 AS backend
+FROM golang:1.25.1-alpine3.21 AS backend
 ARG VERSION
 ARG GIT_COMMIT
 ARG RELEASE="release"

--- a/scripts/Dockerfile.action
+++ b/scripts/Dockerfile.action
@@ -1,4 +1,4 @@
-FROM golang:1.25.0-alpine3.21 AS builder
+FROM golang:1.25.1-alpine3.21 AS builder
 ARG VERSION
 ARG GIT_COMMIT
 WORKDIR /action-build

--- a/scripts/Dockerfile.action-debian
+++ b/scripts/Dockerfile.action-debian
@@ -1,4 +1,4 @@
-FROM golang:1.25.0-bookworm AS builder
+FROM golang:1.25.1-bookworm AS builder
 ARG VERSION
 ARG GIT_COMMIT
 WORKDIR /action-build

--- a/scripts/Dockerfile.aws
+++ b/scripts/Dockerfile.aws
@@ -10,7 +10,7 @@ COPY . .
 RUN pnpm --dir ./frontend i
 RUN pnpm --dir ./frontend release-aws
 
-FROM golang:1.25.0-alpine3.21 AS backend
+FROM golang:1.25.1-alpine3.21 AS backend
 ARG VERSION
 ARG GIT_COMMIT
 ARG RELEASE="release"


### PR DESCRIPTION
## Summary
- Upgraded Go version from 1.25.0 to 1.25.1 across all configuration files
- Updated go.mod, GitHub Actions workflows, and Docker images

## Test plan
- [ ] CI/CD pipelines pass with the new Go version
- [ ] Docker builds complete successfully
- [ ] Backend tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)