### PR TITLE
fix: remove command count limit for MSSQL to fix task run log display

### DIFF
--- a/backend/component/sheet/sheet.go
+++ b/backend/component/sheet/sheet.go
@@ -185,9 +185,8 @@ func getSheetCommandsForMSSQL(statement string) []*storepb.SheetCommand {
 			batch.Reset(nil)
 		default:
 		}
-		if len(sheetCommands) > common.MaximumCommands {
-			return nil
-		}
+		// No command count limit for MSSQL to ensure consistency between sheet payload
+		// and actual execution in mssql.go which splits and executes all batches
 	}
 	return sheetCommands
 }


### PR DESCRIPTION
## Summary
  - Remove the 200 command count limit for MSSQL in sheet command parsing
  - Fixes frontend task run log display issue when SQL contains >200 commands

  ## Problem
  When executing MSSQL statements with more than 200 commands, the task run log display breaks in the frontend. The root cause is a mismatch between:
  - `backend/component/sheet/sheet.go`: Stops recording command positions after 200 commands
  - `backend/plugin/db/mssql/mssql.go`: Continues to split and execute all commands, logging their indexes

  This causes the frontend to fail when mapping command indexes to their SQL text for commands beyond 200.

  ## Solution
  Remove the artificial 200 command limit for MSSQL. We use an efficient T-SQL batch splitter (`tsqlbatch.NewBatcher`) that:
  - Parses SQL into batches delimited by GO statements
  - Has minimal memory overhead - only maintains position markers
  - Already handles large SQL scripts efficiently in production

  The limit was overly conservative and unnecessary given our efficient splitter implementation.