### PR TITLE
refactor: drop deprecated data_source table

### DIFF
--- a/backend/migrator/migration/3.10/0002##drop_data_source_table.sql
+++ b/backend/migrator/migration/3.10/0002##drop_data_source_table.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS data_source;
+DROP SEQUENCE IF EXISTS data_source_id_seq;

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -143,15 +143,6 @@ CREATE UNIQUE INDEX idx_db_schema_unique_instance_db_name ON db_schema(instance,
 
 ALTER SEQUENCE db_schema_id_seq RESTART WITH 101;
 
--- Deprecated. To be deleted later.
-CREATE TABLE data_source (
-    id serial PRIMARY KEY,
-    instance text NOT NULL REFERENCES instance(resource_id),
-    options jsonb NOT NULL DEFAULT '{}'
-);
-
-ALTER SEQUENCE data_source_id_seq RESTART WITH 101;
-
 CREATE TABLE sheet_blob (
 	sha256 bytea NOT NULL PRIMARY KEY,
 	content text NOT NULL

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.10.1"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.10.2"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/backend/store/instance.go
+++ b/backend/store/instance.go
@@ -591,13 +591,6 @@ func (s *Store) DeleteInstance(ctx context.Context, resourceID string) error {
 		return errors.Wrapf(err, "failed to delete databases for instance %s", resourceID)
 	}
 
-	// Delete data_source entries associated with this instance
-	if _, err := tx.ExecContext(ctx, `
-		DELETE FROM data_source WHERE instance = $1
-	`, resourceID); err != nil {
-		return errors.Wrapf(err, "failed to delete data_source for instance %s", resourceID)
-	}
-
 	// Finally, delete the instance itself (only if it's marked as deleted)
 	result, err := tx.ExecContext(ctx, `
 		DELETE FROM instance


### PR DESCRIPTION
## Summary
- Drop the deprecated `data_source` table that is no longer in use
- Clean up related code references

## Changes
- Added migration file `0002##drop_data_source_table.sql` in version 3.10 to drop the table and sequence
- Removed `data_source` table definition from `LATEST.sql`
- Removed `data_source` deletion logic from `instance.go`

## Test plan
- [x] Migration runs successfully
- [x] No remaining references to `data_source` table in codebase
- [x] Code passes linting

🤖 Generated with [Claude Code](https://claude.ai/code)