### PR TITLE
chore: optimize result selection/copy

### DIFF
--- a/frontend/src/components/User/Settings/UserDataTable/cells/UserNameCell.vue
+++ b/frontend/src/components/User/Settings/UserDataTable/cells/UserNameCell.vue
@@ -49,6 +49,7 @@
         class="ml-3 text-xs"
       >
         <CopyButton
+          v-if="user.serviceKey"
           quaternary
           size="small"
           :text="false"
@@ -58,7 +59,7 @@
           {{ $t("settings.members.copy-service-key") }}
         </CopyButton>
         <NButton
-          v-if="!user.serviceKey"
+          v-else
           tertiary
           size="small"
           @click.prevent="$emit('reset-service-key', user)"

--- a/frontend/src/components/v2/Button/CopyButton.vue
+++ b/frontend/src/components/v2/Button/CopyButton.vue
@@ -1,6 +1,6 @@
 <template>
   <NButton
-    v-if="isSupported && content"
+    v-if="isSupported && !isEmpty"
     v-bind="$attrs"
     :text="text"
     :size="size"
@@ -18,12 +18,13 @@
 import { useClipboard } from "@vueuse/core";
 import { CopyIcon } from "lucide-vue-next";
 import { NButton } from "naive-ui";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { pushNotification } from "@/store";
 
 const props = withDefaults(
   defineProps<{
-    content: string;
+    content: string | (() => string);
     text?: boolean;
     disabled?: boolean;
     size?: "tiny" | "small" | "medium" | "large";
@@ -40,11 +41,24 @@ const { copy: copyTextToClipboard, isSupported } = useClipboard({
 });
 const { t } = useI18n();
 
+const isEmpty = computed(() => {
+  if (typeof props.content === "function") {
+    return false;
+  }
+  return !props.content;
+});
+
 const handleCopy = () => {
   if (!isSupported.value) {
     return;
   }
-  copyTextToClipboard(props.content).then(() => {
+  let value = "";
+  if (typeof props.content === "function") {
+    value = props.content();
+  } else {
+    value = props.content;
+  }
+  copyTextToClipboard(value).then(() => {
     pushNotification({
       module: "bytebase",
       style: "SUCCESS",

--- a/frontend/src/components/v2/Form/ResourceIdField.vue
+++ b/frontend/src/components/v2/Form/ResourceIdField.vue
@@ -11,7 +11,7 @@
             class="text-gray-600 font-medium mr-1 flex items-center gap-x-1"
           >
             {{ state.resourceId }}
-            <CopyButton v-if="readonly" :content="value" />
+            <CopyButton v-if="readonly && value" :content="value" />
           </div>
           <span v-else class="text-control-placeholder italic">
             &lt;EMPTY&gt;

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
@@ -13,7 +13,7 @@
         }"
       >
         <div
-          v-for="virtualRow in virtualItems"
+          v-for="(virtualRow, i) in virtualItems"
           :key="`row-${offset + virtualRow.index}`"
           class="font-mono mb-5 mx-2"
           :style="{
@@ -33,10 +33,7 @@
             <div
               class="absolute right-2 top-2 z-50 opacity-70 hover:opacity-100"
             >
-              <CopyButton
-                size="small"
-                :content="() => getContent(virtualRow.index)"
-              />
+              <CopyButton size="small" :content="() => getContent(i)" />
             </div>
             <div
               v-for="header in columnHeaders"
@@ -91,7 +88,7 @@
 
 <script setup lang="ts">
 import type { Table } from "@tanstack/vue-table";
-import { useVirtualizer, type VirtualItem } from "@tanstack/vue-virtual";
+import { useVirtualizer } from "@tanstack/vue-virtual";
 import { computed, ref, watch } from "vue";
 import { CopyButton } from "@/components/v2";
 import type { QueryRow, RowValue } from "@/types/proto-es/v1/sql_service_pb";
@@ -149,12 +146,12 @@ watch(
 
 const getContent = (index: number): string => {
   const object = columnHeaders.value.reduce(
-    (obj, header) => {
+    (obj, header, j) => {
       if (!header.column.columnDef.header) {
         return obj;
       }
       obj[`${header.column.columnDef.header}`] =
-        cellRefs.value[index * columnHeaders.value.length + header.index]?.plainValue;
+        cellRefs.value[index * columnHeaders.value.length + j]?.plainValue;
       return obj;
     },
     {} as Record<string, any>

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
@@ -27,13 +27,25 @@
             {{ offset + virtualRow.index + 1 }}. row
             ********************************
           </p>
-          <div class="py-2 px-3 bg-gray-50 dark:bg-gray-700 rounded-sm">
+          <div
+            class="py-2 px-3 bg-gray-50 dark:bg-gray-700 rounded-sm relative"
+          >
+            <div
+              class="absolute right-2 top-2 z-50 opacity-70 hover:opacity-100"
+            >
+              <CopyButton
+                size="small"
+                :content="() => getContent(virtualRow.index)"
+              />
+            </div>
             <div
               v-for="header in columnHeaders"
               :key="`${virtualRow.index}-${header.index}`"
-              class="flex items-center text-gray-500 dark:text-gray-300 text-sm"
+              class="flex items-start text-gray-500 dark:text-gray-300 text-sm"
             >
-              <div class="min-w-[7rem] text-left flex items-center font-medium">
+              <div
+                class="min-w-[7rem] text-left flex items-start font-medium pt-1"
+              >
                 {{ header.column.columnDef.header }}
                 <MaskingReasonPopover
                   v-if="getMaskingReason && getMaskingReason(header.index)"
@@ -48,6 +60,7 @@
               </div>
               <div class="flex-1">
                 <TableCell
+                  ref="cellRefs"
                   :table="table"
                   :value="
                     rows[virtualRow.index]
@@ -59,6 +72,7 @@
                   :row-index="offset + virtualRow.index"
                   :col-index="header.index"
                   :column-type="getColumnType(header)"
+                  :allow-select="true"
                 />
               </div>
             </div>
@@ -77,8 +91,9 @@
 
 <script setup lang="ts">
 import type { Table } from "@tanstack/vue-table";
-import { useVirtualizer } from "@tanstack/vue-virtual";
+import { useVirtualizer, type VirtualItem } from "@tanstack/vue-virtual";
 import { computed, ref, watch } from "vue";
+import { CopyButton } from "@/components/v2";
 import type { QueryRow, RowValue } from "@/types/proto-es/v1/sql_service_pb";
 import TableCell from "./DataTable/TableCell.vue";
 import MaskingReasonPopover from "./DataTable/common/MaskingReasonPopover.vue";
@@ -96,6 +111,7 @@ const props = defineProps<{
 
 const { keyword } = useSQLResultViewContext();
 const containerRef = ref<HTMLDivElement>();
+const cellRefs = ref<InstanceType<typeof TableCell>[]>([]);
 
 const rows = computed(() => props.table.getRowModel().rows);
 
@@ -130,4 +146,20 @@ watch(
     virtualizer.value.scrollToOffset(0);
   }
 );
+
+const getContent = (index: number): string => {
+  const object = columnHeaders.value.reduce(
+    (obj, header) => {
+      if (!header.column.columnDef.header) {
+        return obj;
+      }
+      obj[`${header.column.columnDef.header}`] =
+        cellRefs.value[index + header.index]?.plainValue;
+      return obj;
+    },
+    {} as Record<string, any>
+  );
+
+  return JSON.stringify(object, null, 4);
+};
 </script>

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
@@ -154,7 +154,7 @@ const getContent = (index: number): string => {
         return obj;
       }
       obj[`${header.column.columnDef.header}`] =
-        cellRefs.value[index + header.index]?.plainValue;
+        cellRefs.value[index * columnHeaders.value.length + header.index]?.plainValue;
       return obj;
     },
     {} as Record<string, any>


### PR DESCRIPTION
- Support copy for the whole block

<img width="2730" height="842" alt="CleanShot 2025-09-10 at 11 03 45@2x" src="https://github.com/user-attachments/assets/94176fc8-467d-48e1-b611-83f710d4e090" />

- Allow selection for the single field

<img width="2732" height="808" alt="CleanShot 2025-09-10 at 11 04 02@2x" src="https://github.com/user-attachments/assets/c53e0524-d866-4431-aedd-c59bd17e67cc" />

Close BYT-8053