### PR TITLE
chore: improve editor height and responsive layout

### DIFF
--- a/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
@@ -1,14 +1,16 @@
 <template>
-  <div class="flex-1 flex flex-col">
+  <div class="w-full flex-1 flex flex-col min-h-0 h-full">
     <SpecListSection v-if="shouldShowSpecList" />
-    <div class="w-full flex flex-col gap-3 px-4 divide-y overflow-x-hidden">
+    <div
+      class="w-full flex-1 flex flex-col gap-3 px-4 divide-y overflow-x-auto"
+    >
       <TargetListSection />
       <FailedTaskRunsSection v-if="!isCreating && rollout" />
       <template v-if="!specHasRelease">
         <SQLCheckV1Section v-if="isCreating" />
         <PlanCheckSection v-else />
       </template>
-      <div class="w-full space-y-3 pt-3 overflow-x-hidden">
+      <div class="w-full flex-1 space-y-3 pt-3 overflow-x-auto flex flex-col">
         <StatementSection />
         <Configuration />
       </div>

--- a/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex-1 flex flex-col min-h-0 h-full">
+  <div class="w-full flex-1 flex flex-col">
     <SpecListSection v-if="shouldShowSpecList" />
     <div
       class="w-full flex-1 flex flex-col gap-3 px-4 divide-y overflow-x-auto"

--- a/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-y-2">
+  <div class="flex-1 flex flex-col gap-y-2">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-x-4">
         <div class="flex items-center gap-x-1 text-sm">
@@ -93,10 +93,10 @@
       </template>
     </BBAttention>
 
-    <div class="relative">
+    <div class="relative flex-1">
       <MonacoEditor
         ref="monacoEditorRef"
-        class="w-full h-auto max-h-[240px] min-h-[120px] border rounded-[3px]"
+        class="w-full h-full min-h-[200px] border rounded-[3px]"
         :filename="filename"
         :content="state.statement"
         :language="language"
@@ -104,7 +104,7 @@
         :readonly="isEditorReadonly"
         :dialect="dialect"
         :advices="isEditorReadonly || isCreating ? markers : []"
-        :auto-height="{ min: 160, max: 240 }"
+        :auto-height="false"
         :auto-complete-context="{
           instance: database.instance,
           database: database.name,

--- a/frontend/src/components/Plan/components/StatementSection/StatementSection.vue
+++ b/frontend/src/components/Plan/components/StatementSection/StatementSection.vue
@@ -1,5 +1,8 @@
 <template>
-  <div v-show="viewMode !== 'NONE'" class="flex flex-col gap-y-2">
+  <div
+    v-show="viewMode !== 'NONE'"
+    class="flex-1 max-h-[50vh] flex flex-col gap-y-2"
+  >
     <EditorView v-if="viewMode === 'EDITOR'" :key="editorViewKey" />
     <ReleaseView v-else-if="viewMode === 'RELEASE'" />
   </div>


### PR DESCRIPTION
Close BYT-8041

- Make SpecDetailView responsive with proper flex layout and height constraints
- Expand editor to use available vertical space while maintaining minimum height
- Add viewport-based height limits to prevent oversized components

<img width="3414" height="2014" alt="image" src="https://github.com/user-attachments/assets/36777884-ac10-445e-b56e-30f0e497b78b" />
