### PR TITLE
chore: improve mobile UI responsiveness

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/TaskView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskView.vue
@@ -2,13 +2,15 @@
   <div v-if="task" class="w-full h-full flex flex-col gap-y-4 p-4">
     <!-- Task Basic Info -->
     <div class="w-full flex flex-col gap-y-3">
-      <div class="flex flex-row items-center justify-between">
-        <div class="flex flex-row items-center gap-x-3">
+      <div
+        class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+      >
+        <div class="flex flex-row items-center gap-x-3 flex-wrap">
           <TaskStatus :size="'large'" :status="task.status" />
-          <div class="flex flex-row items-center text-xl">
+          <div class="flex flex-row items-center text-xl min-w-0">
             <DatabaseDisplay :database="database.name" :size="'large'" />
           </div>
-          <div class="flex flex-row gap-x-2">
+          <div class="flex flex-row gap-x-2 flex-wrap">
             <NTag round>
               {{ semanticTaskType(task.type) }}
             </NTag>
@@ -43,7 +45,7 @@
           </div>
         </div>
 
-        <div class="flex justify-end">
+        <div class="flex justify-start sm:justify-end">
           <!-- Task Status Actions -->
           <TaskStatusActions
             :task="task"

--- a/frontend/src/components/Project/ProjectSwitch/ProjectSwitchPopover.vue
+++ b/frontend/src/components/Project/ProjectSwitch/ProjectSwitchPopover.vue
@@ -1,7 +1,7 @@
 <template>
   <NPopover
     v-model:show="state.showPopover"
-    class="max-h-[80vh] w-[24rem] max-w-full"
+    class="max-h-[80vh] w-[24rem] max-w-[90vw]"
     placement="bottom-start"
     scrollable
     trigger="click"

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -22,7 +22,7 @@
 
       <router-link
         :to="sqlEditorLink"
-        class="flex flex-row justify-center items-center"
+        class="flex"
         exact-active-class=""
         target="_blank"
       >
@@ -30,23 +30,20 @@
           <template #icon>
             <SquareTerminalIcon class="w-4 h-auto" />
           </template>
-          <span class="whitespace-nowrap">{{ $t("sql-editor.self") }}</span>
+          <span v-if="windowWidth >= 640" class="whitespace-nowrap">{{
+            $t("sql-editor.self")
+          }}</span>
         </NButton>
       </router-link>
 
-      <NTooltip :disabled="windowWidth >= 640">
-        <template #trigger>
-          <router-link :to="myIssueLink" class="flex">
-            <NButton size="small" @click="goToMyIssues">
-              <template #icon>
-                <CircleDotIcon class="w-4" />
-              </template>
-              <span class="hidden sm:block">{{ $t("issue.my-issues") }}</span>
-            </NButton>
-          </router-link>
-        </template>
-        {{ $t("issue.my-issues") }}
-      </NTooltip>
+      <router-link :to="myIssueLink" class="flex">
+        <NButton size="small" @click="goToMyIssues">
+          <template #icon>
+            <CircleDotIcon class="w-4" />
+          </template>
+          <span v-if="windowWidth >= 640">{{ $t("issue.my-issues") }}</span>
+        </NButton>
+      </router-link>
 
       <ProfileBrandingLogo>
         <ProfileDropdown :link="true" />
@@ -68,7 +65,7 @@ import {
   SquareTerminalIcon,
   MessagesSquareIcon,
 } from "lucide-vue-next";
-import { NButton, NTooltip } from "naive-ui";
+import { NButton } from "naive-ui";
 import { storeToRefs } from "pinia";
 import { v4 as uuidv4 } from "uuid";
 import { computed, reactive } from "vue";


### PR DESCRIPTION
- Hide SQL Editor and My Issues button text on mobile screens to reduce header crowding
- Make TaskView layout responsive with flex-wrap for better content overflow handling
- Improve ProjectSwitchPopover max width on mobile devices
- Use conditional rendering based on window width for better mobile UX
