### PR TITLE
fix(mongodb): fix mongodb readonly user with only `readAnyDatabase` roles

### DIFF
--- a/frontend/src/components/InstanceForm/DataSourceSection/CreateDataSourceExample.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/CreateDataSourceExample.vue
@@ -561,9 +561,7 @@ db.createUser({
   user: "${DATASOURCE_READONLY_USER_NAME}",
   pwd: "YOUR_DB_PWD",
   roles: [
-    {role: "readAnyDatabase", db: "admin"},
-    {role: "dbAdminAnyDatabase", db: "admin"},
-    {role: "userAdminAnyDatabase", db: "admin"}
+    {role: "readAnyDatabase", db: "admin"}
   ]
 });
         `;


### PR DESCRIPTION
Change from
```
use admin;
db.createUser({
  user: "${DATASOURCE_READONLY_USER_NAME}",
  pwd: "YOUR_DB_PWD",
  roles: [
    {role: "readAnyDatabase", db: "admin"},
    {role: "dbAdminAnyDatabase", db: "admin"},
    {role: "userAdminAnyDatabase", db: "admin"}
  ]
});
```
to
```
use admin;
db.createUser({
  user: "${DATASOURCE_READONLY_USER_NAME}",
  pwd: "YOUR_DB_PWD",
  roles: [
    {role: "readAnyDatabase", db: "admin"}
  ]
});
```