### PR TITLE
chore: remove deprecated VCS permissions in migration 3.10.3

### DIFF
--- a/backend/migrator/migration/3.10/0003##remove_deprecated_vcs_permissions.sql
+++ b/backend/migrator/migration/3.10/0003##remove_deprecated_vcs_permissions.sql
@@ -1,0 +1,17 @@
+-- Remove deprecated VCS permissions from existing roles
+UPDATE role
+SET permissions = jsonb_set(permissions, '{permissions}',  
+    (permissions->'permissions')::jsonb
+    - 'bb.vcsConnectors.create'
+    - 'bb.vcsConnectors.delete'
+    - 'bb.vcsConnectors.get'
+    - 'bb.vcsConnectors.list'
+    - 'bb.vcsConnectors.update'
+    - 'bb.vcsProviders.create'
+    - 'bb.vcsProviders.delete'
+    - 'bb.vcsProviders.get'
+    - 'bb.vcsProviders.list'
+    - 'bb.vcsProviders.listProjects'
+    - 'bb.vcsProviders.searchProjects'
+    - 'bb.vcsProviders.update'
+);

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.10.2"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.10.3"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
## Summary
- Added migration 3.10.3 to remove deprecated VCS permissions from existing roles
- Updated TestLatestVersion to expect version 3.10.3

## Removed permissions
The following deprecated permissions are removed from all existing roles:
- bb.vcsConnectors.create
- bb.vcsConnectors.delete
- bb.vcsConnectors.get
- bb.vcsConnectors.list
- bb.vcsConnectors.update
- bb.vcsProviders.create
- bb.vcsProviders.delete
- bb.vcsProviders.get
- bb.vcsProviders.list
- bb.vcsProviders.listProjects
- bb.vcsProviders.searchProjects
- bb.vcsProviders.update

## Test plan
- Migration will run automatically on upgrade
- Existing roles will have the deprecated permissions removed
- No new permissions are added

🤖 Generated with [Claude Code](https://claude.ai/code)