### PR TITLE
chore: improve export archive task run handling

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1037,8 +1037,8 @@
     "data-export": {
       "options": "Options",
       "format": "Format",
-      "file-downloaded": "File Downloaded",
-      "download-tooltip": "Available for 24 hours"
+      "download-tooltip": "Available for 24 hours",
+      "file-expired": "File Expired"
     },
     "task-run": {
       "logs": "Logs",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1033,8 +1033,8 @@
     "data-export": {
       "options": "Opciones de exportación",
       "format": "Formato",
-      "file-downloaded": "Archivo Descargado",
-      "download-tooltip": "Disponible por 24 horas"
+      "download-tooltip": "Disponible por 24 horas",
+      "file-expired": "Archivo expirado"
     },
     "task-run": {
       "logs": "Registros",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1033,8 +1033,8 @@
     "data-export": {
       "options": "設定項目",
       "format": "エクスポート形式",
-      "file-downloaded": "ダウンロードされたファイル",
-      "download-tooltip": "24 時間利用可能"
+      "download-tooltip": "24 時間利用可能",
+      "file-expired": "ファイルの有効期限が切れました"
     },
     "task-run": {
       "logs": "ログ",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1033,8 +1033,8 @@
     "data-export": {
       "options": "Tùy chọn",
       "format": "Định dạng",
-      "file-downloaded": "Tệp đã tải xuống",
-      "download-tooltip": "Có sẵn trong 24 giờ"
+      "download-tooltip": "Có sẵn trong 24 giờ",
+      "file-expired": "Tệp đã hết hạn"
     },
     "task-run": {
       "logs": "Nhật ký",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1033,8 +1033,8 @@
     "data-export": {
       "options": "配置项",
       "format": "导出格式",
-      "file-downloaded": "文件已下载",
-      "download-tooltip": "24 小时可用"
+      "download-tooltip": "24 小时可用",
+      "file-expired": "文件已过期"
     },
     "task-run": {
       "logs": "日志",


### PR DESCRIPTION
- Fix SQL service to handle both rollout and stage name formats in doExportFromIssue
- Improve task run filtering to get latest task runs for export tasks using proper UID extraction
- Enhance export archive download action with better expired file handling
- Update export download logic to show file expired status instead of downloaded status
