### PR TITLE
chore: upgrade pnpm and golangci-lint versions

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: '10.14.0'
+          version: '10.17.1'
       - uses: actions/setup-node@v4
         with:
           node-version: '23.11.0'
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: '10.14.0'
+          version: '10.17.1'
       - uses: actions/setup-node@v4
         with:
           node-version: '23.11.0'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,5 +29,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4.0
+          version: v2.5.0
           args: --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -160,5 +160,5 @@
   "browserslist": [
     "> 0.08%, not dead"
   ],
-  "packageManager": "pnpm@10.14.0"
+  "packageManager": "pnpm@10.17.1"
 }

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:23.11.1-slim AS frontend
 ARG GIT_COMMIT
 
-RUN npm i -g pnpm@10.14.0
+RUN npm i -g pnpm@10.17.1
 
 WORKDIR /frontend-build
 

--- a/scripts/Dockerfile.aws
+++ b/scripts/Dockerfile.aws
@@ -1,7 +1,7 @@
 FROM node:23.11.1-slim AS frontend
 ARG GIT_COMMIT
 
-RUN npm i -g pnpm@10.14.0
+RUN npm i -g pnpm@10.17.1
 
 WORKDIR /frontend-build
 


### PR DESCRIPTION
## Summary
- Upgraded pnpm from 10.14.0 to 10.17.1 across all configuration files
- Upgraded golangci-lint from v2.4.0 to v2.5.0 in GitHub Actions workflow

## Changes
- Updated `frontend/package.json` packageManager field
- Updated pnpm version in `.github/workflows/frontend-tests.yml` (2 occurrences)
- Updated pnpm version in `scripts/Dockerfile` and `scripts/Dockerfile.aws`
- Updated golangci-lint version in `.github/workflows/golangci-lint.yml`

## Test plan
- [ ] CI/CD pipelines pass with updated tool versions
- [ ] Frontend builds successfully with pnpm 10.17.1
- [ ] golangci-lint runs without issues

🤖 Generated with [Claude Code](https://claude.ai/code)