### PR TITLE
refactor: restrict RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW policy to project level only

### DIFF
--- a/backend/api/v1/org_policy_service.go
+++ b/backend/api/v1/org_policy_service.go
@@ -27,7 +27,7 @@ var (
 		storepb.Policy_QUERY_DATA:                             {storepb.Policy_WORKSPACE, storepb.Policy_ENVIRONMENT, storepb.Policy_PROJECT},
 		storepb.Policy_MASKING_RULE:                           {storepb.Policy_WORKSPACE},
 		storepb.Policy_MASKING_EXCEPTION:                      {storepb.Policy_PROJECT},
-		storepb.Policy_RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW: {storepb.Policy_WORKSPACE, storepb.Policy_PROJECT},
+		storepb.Policy_RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW: {storepb.Policy_PROJECT},
 		storepb.Policy_IAM:                                    {storepb.Policy_WORKSPACE},
 		storepb.Policy_DATA_SOURCE_QUERY:                      {storepb.Policy_ENVIRONMENT, storepb.Policy_PROJECT},
 	}

--- a/backend/migrator/migration/3.10/0005##migrate_restrict_issue_creation_for_sql_review_policy.sql
+++ b/backend/migrator/migration/3.10/0005##migrate_restrict_issue_creation_for_sql_review_policy.sql
@@ -1,0 +1,34 @@
+-- Migrate RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW policy from workspace to project level
+-- This will copy the workspace-level policy to all projects that don't already have this policy
+
+-- First, insert the policy for all projects that don't already have it
+INSERT INTO policy (resource_type, resource, type, payload, enforce, inherit_from_parent)
+SELECT
+    'PROJECT' as resource_type,
+    CONCAT('projects/', p.resource_id) as resource,
+    'RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW' as type,
+    wp.payload,
+    wp.enforce,
+    false as inherit_from_parent
+FROM project p
+CROSS JOIN (
+    SELECT payload, enforce
+    FROM policy
+    WHERE resource_type = 'WORKSPACE'
+    AND resource = ''
+    AND type = 'RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW'
+    LIMIT 1
+) wp
+WHERE p.deleted = false
+AND NOT EXISTS (
+    SELECT 1 FROM policy pp
+    WHERE pp.resource_type = 'PROJECT'
+    AND pp.resource = CONCAT('projects/', p.resource_id)
+    AND pp.type = 'RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW'
+);
+
+-- Delete the workspace-level policy
+DELETE FROM policy
+WHERE resource_type = 'WORKSPACE'
+AND resource = ''
+AND type = 'RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW';

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.10.4"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.10.5"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/frontend/src/components/GeneralSetting/SecuritySetting.vue
+++ b/frontend/src/components/GeneralSetting/SecuritySetting.vue
@@ -43,12 +43,6 @@
           {{ $t("settings.general.workspace.data-export.description") }}
         </div>
       </div>
-      <RestrictIssueCreationConfigure
-        ref="restrictIssueCreationConfigureRef"
-        :resource="''"
-        :allow-edit="allowEdit"
-        text-class="font-medium"
-      />
       <MaximumSQLResultSizeSetting
         ref="maximumSQLResultSizeSettingRef"
         :allow-edit="allowEdit"
@@ -92,7 +86,6 @@ import DomainRestrictionSetting from "./DomainRestrictionSetting.vue";
 import MaximumRoleExpirationSetting from "./MaximumRoleExpirationSetting.vue";
 import MaximumSQLResultSizeSetting from "./MaximumSQLResultSizeSetting.vue";
 import QueryDataPolicySetting from "./QueryDataPolicySetting.vue";
-import RestrictIssueCreationConfigure from "./RestrictIssueCreationConfigure.vue";
 
 interface LocalState {
   enableWatermark: boolean;
@@ -114,8 +107,6 @@ const maximumRoleExpirationSettingRef =
   ref<InstanceType<typeof MaximumRoleExpirationSetting>>();
 const maximumSQLResultSizeSettingRef =
   ref<InstanceType<typeof MaximumSQLResultSizeSetting>>();
-const restrictIssueCreationConfigureRef =
-  ref<InstanceType<typeof RestrictIssueCreationConfigure>>();
 const queryDataPolicySettingRef =
   ref<InstanceType<typeof QueryDataPolicySetting>>();
 
@@ -123,7 +114,6 @@ const settingRefList = computed(() => [
   domainRestrictionSettingRef,
   maximumRoleExpirationSettingRef,
   maximumSQLResultSizeSettingRef,
-  restrictIssueCreationConfigureRef,
   queryDataPolicySettingRef,
 ]);
 

--- a/frontend/src/components/SQLCheck/SQLCheckPanel.vue
+++ b/frontend/src/components/SQLCheck/SQLCheckPanel.vue
@@ -125,20 +125,6 @@ const riskLevelText = computed(() => {
 });
 
 watchEffect(async () => {
-  const workspaceLevelPolicy =
-    await policyV1Store.getOrFetchPolicyByParentAndType({
-      parentPath: "",
-      policyType: PolicyType.RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW,
-    });
-  if (
-    workspaceLevelPolicy?.policy?.case ===
-      "restrictIssueCreationForSqlReviewPolicy" &&
-    workspaceLevelPolicy.policy.value.disallow
-  ) {
-    restrictIssueCreationForSqlReviewPolicy.value = true;
-    return;
-  }
-
   const projectLevelPolicy =
     await policyV1Store.getOrFetchPolicyByParentAndType({
       parentPath: props.project,


### PR DESCRIPTION
## Summary
- Removed workspace-level support for RESTRICT_ISSUE_CREATION_FOR_SQL_REVIEW policy
- Policy is now configurable at project level only for better granular control
- Added migration to automatically backfill existing workspace policies to all projects

## Changes
### Backend
- Updated `org_policy_service.go` to remove workspace resource type from allowed resources
- Created migration `3.10/0005##migrate_restrict_issue_creation_for_sql_review_policy.sql` to backfill settings
- Updated migrator test to version 3.10.5

### Frontend  
- Removed RestrictIssueCreationConfigure component from workspace security settings
- Updated SQLCheckPanel to only check project-level policy (removed workspace check)
- Kept the component in project settings where it belongs

## Migration Strategy
The migration will automatically copy any existing workspace-level policy to all active projects that don't already have this policy configured. This ensures no disruption to existing configurations.

## Test Plan
- [ ] Migration successfully copies workspace policy to all projects
- [ ] Workspace settings no longer show the restriction option
- [ ] Project settings still allow configuring the restriction
- [ ] SQL review correctly checks only project-level policy

🤖 Generated with [Claude Code](https://claude.ai/code)