### PR TITLE
refactor: remove confusing task selection in database export view

### DIFF
--- a/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunDetail.vue
+++ b/frontend/src/components/IssueV1/components/TaskRunSection/TaskRunDetail.vue
@@ -45,7 +45,7 @@ interface LocalState {
 
 const props = defineProps<{
   taskRun: TaskRun;
-  database: Database;
+  database?: Database;
 }>();
 
 const sheetStore = useSheetV1Store();
@@ -62,7 +62,7 @@ const sheet = computed(() =>
 
 const showTaskRunSessionTab = computed(
   () =>
-    props.database.instanceResource &&
+    props.database?.instanceResource &&
     TASK_RUN_SESSION_SUPPORTED_ENGINES.includes(
       props.database.instanceResource.engine
     )

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView.vue
@@ -3,6 +3,9 @@
     <!-- Tasks Section -->
     <TasksSection />
 
+    <!-- Execution History Section -->
+    <ExecutionHistorySection v-if="taskRuns.length > 0" />
+
     <!-- Export Options Section -->
     <OptionsSection />
 
@@ -15,14 +18,20 @@
 import { computed, watchEffect } from "vue";
 import { useDatabaseV1Store, useSheetV1Store } from "@/store";
 import type { Plan_ExportDataConfig } from "@/types/proto-es/v1/plan_service_pb";
+import { usePlanContextWithRollout } from "../../logic";
 import { useSelectedSpec } from "../SpecDetailView/context";
 import StatementSection from "../StatementSection";
-import { TasksSection, OptionsSection } from "./DatabaseExportView";
+import {
+  TasksSection,
+  OptionsSection,
+  ExecutionHistorySection,
+} from "./DatabaseExportView";
 
 const databaseStore = useDatabaseV1Store();
 const sheetStore = useSheetV1Store();
 
 const selectedSpec = useSelectedSpec();
+const { taskRuns } = usePlanContextWithRollout();
 
 const exportDataConfig = computed(() => {
   return selectedSpec.value.config.value as Plan_ExportDataConfig;

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/ExecutionHistorySection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/ExecutionHistorySection.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="space-y-4">
+    <!-- Execution History Section -->
+    <div class="space-y-3">
+      <div class="flex items-center justify-between">
+        <h3 class="text-base font-medium">
+          {{ $t("task-run.history") }}
+        </h3>
+      </div>
+
+      <!-- Task Runs Table -->
+      <div v-if="allTaskRuns.length > 0">
+        <TaskRunTable :task-runs="allTaskRuns" :show-database-column="true" />
+      </div>
+
+      <!-- No task runs message -->
+      <div v-else class="text-center text-control-light py-8">
+        {{ $t("common.no-data") }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import TaskRunTable from "@/components/Plan/components/RolloutView/TaskRunTable.vue";
+import type { TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
+import { extractTaskUID } from "@/utils";
+import { usePlanContext } from "../../../logic";
+import { usePlanContextWithRollout } from "../../../logic";
+
+const { plan, rollout } = usePlanContext();
+const { taskRuns } = usePlanContextWithRollout();
+
+// Get the export data spec
+const exportDataSpec = computed(() => {
+  return plan.value.specs.find(
+    (spec) => spec.config?.case === "exportDataConfig"
+  );
+});
+
+// Find export tasks related to this spec
+const exportTasks = computed(() => {
+  if (!rollout.value || !exportDataSpec.value) return [];
+
+  const tasks = [];
+  for (const stage of rollout.value.stages) {
+    for (const task of stage.tasks) {
+      if (task.specId === exportDataSpec.value.id) {
+        tasks.push(task);
+      }
+    }
+  }
+  return tasks;
+});
+
+// Get all task runs for export tasks
+const allTaskRuns = computed((): TaskRun[] => {
+  if (exportTasks.value.length === 0) return [];
+
+  const exportTaskUIDs = new Set(
+    exportTasks.value.map((task) => extractTaskUID(task.name))
+  );
+
+  return taskRuns.value.filter((taskRun) =>
+    exportTaskUIDs.has(extractTaskUID(taskRun.name))
+  );
+});
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/TasksSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/TasksSection.vue
@@ -14,17 +14,12 @@
         </div>
       </div>
 
-      <!-- Flattened task list -->
+      <!-- Task status display -->
       <div v-if="exportTasks.length > 0" class="flex flex-wrap gap-2">
         <div
           v-for="task in exportTasks"
           :key="task.name"
-          class="inline-flex items-center gap-2 px-2 py-1.5 border rounded transition-colors min-w-0 cursor-pointer"
-          :class="{
-            'bg-blue-50 border-blue-300': selectedTask?.name === task.name,
-            'hover:bg-gray-50': selectedTask?.name !== task.name,
-          }"
-          @click="handleTaskClick(task)"
+          class="inline-flex items-center gap-2 px-2 py-1.5 border rounded transition-colors min-w-0"
         >
           <!-- Task Status -->
           <div class="flex-shrink-0">
@@ -42,17 +37,6 @@
         </div>
       </div>
 
-      <!-- Task Runs for Selected Task -->
-      <div
-        v-if="selectedTask && selectedTaskRuns.length > 0"
-        class="mt-4 space-y-2"
-      >
-        <div class="text-sm font-medium text-control">
-          {{ $t("task-run.history") }}
-        </div>
-        <TaskRunTable :task="selectedTask" :task-runs="selectedTaskRuns" />
-      </div>
-
       <!-- No tasks message -->
       <div
         v-else-if="exportTasks.length === 0"
@@ -65,34 +49,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watchEffect } from "vue";
-import TaskRunTable from "@/components/Plan/components/RolloutView/TaskRunTable.vue";
+import { computed } from "vue";
 import DatabaseDisplay from "@/components/Plan/components/common/DatabaseDisplay.vue";
 import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
-import {
-  Task_Status,
-  type Task,
-  type TaskRun,
-} from "@/types/proto-es/v1/rollout_service_pb";
-import { extractTaskUID } from "@/utils";
 import { usePlanContext } from "../../../logic";
-import { usePlanContextWithRollout } from "../../../logic";
 
 const { plan, rollout } = usePlanContext();
-const { taskRuns } = usePlanContextWithRollout();
-
-// Track selected task for showing task runs
-const selectedTask = ref<Task | null>(null);
-
-// Get task runs for the selected task
-const selectedTaskRuns = computed((): TaskRun[] => {
-  if (!selectedTask.value) return [];
-
-  const taskUID = extractTaskUID(selectedTask.value.name);
-  return taskRuns.value.filter(
-    (taskRun) => extractTaskUID(taskRun.name) === taskUID
-  );
-});
 
 // Get the export data spec
 const exportDataSpec = computed(() => {
@@ -114,56 +76,5 @@ const exportTasks = computed(() => {
     }
   }
   return tasks;
-});
-
-// Auto-select the most relevant task
-const autoSelectTask = () => {
-  if (exportTasks.value.length === 0) {
-    selectedTask.value = null;
-    return;
-  }
-
-  // Priority order: Failed > Not started (Pending) > First task
-  const failedTasks = exportTasks.value.filter(
-    (task) => task.status === Task_Status.FAILED
-  );
-  const pendingTasks = exportTasks.value.filter(
-    (task) =>
-      task.status === Task_Status.PENDING ||
-      task.status === Task_Status.NOT_STARTED ||
-      task.status === Task_Status.RUNNING
-  );
-
-  let taskToSelect: Task | null = null;
-
-  if (failedTasks.length > 0) {
-    // Select first failed task
-    taskToSelect = failedTasks[0];
-  } else if (pendingTasks.length > 0) {
-    // Select first not started (pending) task
-    taskToSelect = pendingTasks[0];
-  } else {
-    // Fallback to first task
-    taskToSelect = exportTasks.value[0];
-  }
-
-  selectedTask.value = taskToSelect;
-};
-
-// Handle task selection
-const handleTaskClick = (task: Task) => {
-  if (selectedTask.value?.name === task.name) {
-    selectedTask.value = null; // Deselect if clicking the same task
-  } else {
-    selectedTask.value = task; // Select the new task
-  }
-};
-
-// Auto-select task when tasks change
-watchEffect(() => {
-  // Only auto-select if no task is currently selected
-  if (!selectedTask.value && exportTasks.value.length > 0) {
-    autoSelectTask();
-  }
 });
 </script>

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/index.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/index.ts
@@ -1,2 +1,3 @@
 export { default as TasksSection } from "./TasksSection.vue";
 export { default as OptionsSection } from "./OptionsSection.vue";
+export { default as ExecutionHistorySection } from "./ExecutionHistorySection.vue";

--- a/frontend/src/components/Plan/components/RolloutView/TaskView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskView.vue
@@ -80,7 +80,7 @@
       <div class="flex items-center justify-between mb-2">
         <span class="text-base font-medium">{{ $t("task-run.history") }}</span>
       </div>
-      <TaskRunTable :task="task" :task-runs="taskRuns" />
+      <TaskRunTable :task-runs="taskRuns" />
     </div>
 
     <!-- Sheet Statement -->


### PR DESCRIPTION
Close BYT-8129

- Remove clickable task selection that was confusing with rollout actions
- Add dedicated ExecutionHistorySection with database column for clarity

<img width="2880" height="1598" alt="image" src="https://github.com/user-attachments/assets/f95f8311-b3e7-4bf6-832c-7d3ec7b8552b" />
