### PR TITLE
fix: allow all project members to view export data issues

### DIFF
--- a/frontend/src/views/ExportCenter/index.vue
+++ b/frontend/src/views/ExportCenter/index.vue
@@ -70,7 +70,6 @@ import IssueTableV1 from "@/components/IssueV1/components/IssueTableV1.vue";
 import { Drawer } from "@/components/v2";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
 import {
-  useCurrentUserV1,
   useProjectByName,
   useIssueV1Store,
   useRefreshIssueList,
@@ -118,7 +117,6 @@ const defaultSearchParams = () => {
   return params;
 };
 
-const currentUser = useCurrentUserV1();
 const state = reactive<LocalState>({
   showRequestExportPanel: false,
   params: defaultSearchParams(),
@@ -136,13 +134,8 @@ const issuePagedTable =
   ref<ComponentExposed<typeof PagedTable<ComposedIssue>>>();
 
 const dataExportIssueSearchParams = computed(() => {
-  // Default scopes with type and creator.
-  const defaultScopes = [
-    {
-      id: "creator",
-      value: currentUser.value.email,
-    },
-  ];
+  // Default scopes with type.
+  const defaultScopes = [];
   // If specific project is provided, add project scope.
   if (specificProject.value) {
     defaultScopes.push({


### PR DESCRIPTION
## Summary
- Removed the creator filter from the Export Center that was limiting visibility to only the user's own export issues
- Now all users with project access can see all export data issues within their project

## Problem
Project owners and team members couldn't see export data issues created by other users in their project. The Export Center was filtering issues to only show those created by the current user.

## Solution
Removed the creator filter entirely from `dataExportIssueSearchParams` in the Export Center component. This allows all users with appropriate project permissions to see all export data issues in their project.

## Test plan
- [ ] Navigate to a project's Export Center as a project owner
- [ ] Verify you can see export data issues created by other users
- [ ] Navigate to the Export Center as a regular project member
- [ ] Verify you can see export data issues from all users in the project
- [ ] Confirm that project scope filtering still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)