### PR TITLE
fix: resolve circular dependency in user store

### DIFF
--- a/frontend/src/store/modules/user.ts
+++ b/frontend/src/store/modules/user.ts
@@ -77,10 +77,6 @@ export const useUserStore = defineStore("user", () => {
     return user;
   };
 
-  const systemBotUser = computedAsync(() => {
-    return getOrFetchUserByIdentifier(SYSTEM_BOT_USER_NAME);
-  });
-
   const fetchCurrentUser = async () => {
     const response = await userServiceClientConnect.getCurrentUser({});
     setUser(response);
@@ -224,6 +220,10 @@ export const useUserStore = defineStore("user", () => {
     }
     return userMapByName.value.get(`${userNamePrefix}${id}`);
   };
+
+  const systemBotUser = computedAsync(() => {
+    return getOrFetchUserByIdentifier(SYSTEM_BOT_USER_NAME);
+  });
 
   return {
     allUser,


### PR DESCRIPTION
## Summary
- Fixed "Cannot access 'getOrFetchUserByIdentifier' before initialization" error in user store
- Moved `systemBotUser` definition after `getOrFetchUserByIdentifier` function declaration

## Technical Details
The issue was caused by `systemBotUser` (line 80) referencing `getOrFetchUserByIdentifier` before it was defined (line 195). Since arrow functions are not hoisted in JavaScript, this caused a ReferenceError at runtime.

## Test plan
- [x] Verify the error no longer appears in browser console
- [x] Test user store functionality works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)