### PR TITLE
refactor: use backend Issue_ApprovalStatus directly in frontend

### DIFF
--- a/frontend/src/components/IssueV1/components/BannerSection.vue
+++ b/frontend/src/components/IssueV1/components/BannerSection.vue
@@ -52,7 +52,7 @@ import dayjs from "dayjs";
 import { computed } from "vue";
 import {
   IssueStatus,
-  Issue_Approver_Status,
+  Issue_ApprovalStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { activeTaskInRollout, isDatabaseChangeRelatedIssue } from "@/utils";
@@ -67,13 +67,13 @@ const { status: reviewStatus } = reviewContext;
 const showPendingReview = computed(() => {
   if (isCreating.value) return false;
   if (issue.value.status !== IssueStatus.OPEN) return false;
-  return reviewStatus.value === Issue_Approver_Status.PENDING;
+  return reviewStatus.value === Issue_ApprovalStatus.PENDING;
 });
 
 const showRejectedReview = computed(() => {
   if (isCreating.value) return false;
   if (issue.value.status !== IssueStatus.OPEN) return false;
-  return reviewStatus.value === Issue_Approver_Status.REJECTED;
+  return reviewStatus.value === Issue_ApprovalStatus.REJECTED;
 });
 
 const showClosedBanner = computed(() => {

--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/IssueReviewButtonGroup.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/IssueReviewButtonGroup.vue
@@ -31,7 +31,7 @@ import {
 import { useCurrentUserV1, extractUserId, useCurrentProjectV1 } from "@/store";
 import {
   IssueStatus,
-  Issue_Approver_Status,
+  Issue_ApprovalStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import {
   isDatabaseChangeRelatedIssue,
@@ -76,16 +76,16 @@ const shouldShowApproveOrReject = computed(() => {
 });
 const shouldShowApprove = computed(() => {
   if (!shouldShowApproveOrReject.value) return false;
-  return status.value === Issue_Approver_Status.PENDING;
+  return status.value === Issue_ApprovalStatus.PENDING;
 });
 const shouldShowReject = computed(() => {
   if (!shouldShowApproveOrReject.value) return false;
-  return status.value === Issue_Approver_Status.PENDING;
+  return status.value === Issue_ApprovalStatus.PENDING;
 });
 const shouldShowReRequestReview = computed(() => {
   return (
     extractUserId(issue.value.creator) === currentUser.value.email &&
-    status.value === Issue_Approver_Status.REJECTED
+    status.value === Issue_ApprovalStatus.REJECTED
   );
 });
 const issueReviewActionList = computed(() => {
@@ -104,10 +104,7 @@ const issueReviewActionList = computed(() => {
 });
 
 const issueStatusActionList = computed(() => {
-  return getApplicableIssueStatusActionList(
-    issue.value,
-    reviewContext.status.value
-  );
+  return getApplicableIssueStatusActionList(issue.value);
 });
 const forceRolloutActionList = computed((): ExtraActionOption[] => {
   // If it's not a database change related issue, no force rollout actions.

--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/rollout/CombinedRolloutButtonGroup.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/rollout/CombinedRolloutButtonGroup.vue
@@ -37,20 +37,11 @@ import RolloutActionButtonGroup from "./RolloutActionButtonGroup.vue";
 import type { RolloutAction } from "./common";
 
 const { t } = useI18n();
-const {
-  issue,
-  selectedStage,
-  selectedTask,
-  events,
-  releaserCandidates,
-  reviewContext,
-} = useIssueContext();
+const { issue, selectedStage, selectedTask, events, releaserCandidates } =
+  useIssueContext();
 
 const issueStatusActionList = computed(() => {
-  return getApplicableIssueStatusActionList(
-    issue.value,
-    reviewContext.status.value
-  );
+  return getApplicableIssueStatusActionList(issue.value);
 });
 
 const taskRolloutActionList = computed(() => {

--- a/frontend/src/components/IssueV1/logic/action/issue.ts
+++ b/frontend/src/components/IssueV1/logic/action/issue.ts
@@ -2,10 +2,7 @@ import type { ButtonProps } from "naive-ui";
 import { t } from "@/plugins/i18n";
 import { useCurrentUserV1, extractUserId } from "@/store";
 import type { ComposedIssue } from "@/types";
-import {
-  IssueStatus,
-  Issue_Approver_Status,
-} from "@/types/proto-es/v1/issue_service_pb";
+import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import {
   flattenTaskV1List,
@@ -40,8 +37,7 @@ export const PossibleIssueStatusActionMap: Record<
 };
 
 export const getApplicableIssueStatusActionList = (
-  issue: ComposedIssue,
-  _reviewStatus?: Issue_Approver_Status
+  issue: ComposedIssue
 ): IssueStatusAction[] => {
   const list = PossibleIssueStatusActionMap[issue.status];
   return list.filter((action) => {

--- a/frontend/src/components/IssueV1/logic/context.ts
+++ b/frontend/src/components/IssueV1/logic/context.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { InjectionKey, Ref, ComputedRef } from "vue";
 import { inject, provide } from "vue";
 import type { ComposedIssue, ReviewFlow } from "@/types";
-import type { Issue_Approver_Status } from "@/types/proto-es/v1/issue_service_pb";
+import type { Issue_ApprovalStatus } from "@/types/proto-es/v1/issue_service_pb";
 import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
 import type {
@@ -30,9 +30,9 @@ export type ReviewContext = {
   // Now we have only one flow in an issue
   flow: Ref<ReviewFlow>;
   // The overall status of the entire review flow
-  status: Ref<Issue_Approver_Status>;
+  status: Ref<Issue_ApprovalStatus>;
   // Whether the review flow is finished successfully.
-  // A shortcut to `status === Review_Approver_Status.APPROVED`
+  // A shortcut to `status === Issue_ApprovalStatus.APPROVED`
   done: Ref<boolean>;
   // Whether the review finding has error.
   error: Ref<string | undefined>;

--- a/frontend/src/components/IssueV1/logic/review.ts
+++ b/frontend/src/components/IssueV1/logic/review.ts
@@ -52,40 +52,13 @@ export const extractReviewContext = (issue: MaybeRef<Issue>): ReviewContext => {
     };
   });
   const status = computed(() => {
-    if (!ready.value) {
-      return Issue_Approver_Status.PENDING;
-    }
-    if (unref(issue).approvalStatusError) {
-      return Issue_Approver_Status.PENDING;
-    }
-
-    const { template, approvers } = flow.value;
-    const steps = template.flow?.steps ?? [];
-
-    if (steps.length === 0) {
-      // No review flow steps. That means need not manual review.
-      return Issue_Approver_Status.APPROVED;
-    }
-
-    if (
-      approvers.some((app) => app.status === Issue_Approver_Status.REJECTED)
-    ) {
-      // If any of the approvers down voted, the overall status should be 'REJECTED'
-      return Issue_Approver_Status.REJECTED;
-    }
-
-    // For an N-steps approval flow, we need exactly N upvote approvals to
-    // pass the entire flow.
-    const upVotes = approvers.filter(
-      (app) => app.status === Issue_Approver_Status.APPROVED
-    );
-    if (upVotes.length === steps.length) {
-      return Issue_Approver_Status.APPROVED;
-    }
-    return Issue_Approver_Status.PENDING;
+    return unref(issue).approvalStatus;
   });
   const done = computed(() => {
-    return status.value === Issue_Approver_Status.APPROVED;
+    return (
+      status.value === Issue_ApprovalStatus.APPROVED ||
+      status.value === Issue_ApprovalStatus.SKIPPED
+    );
   });
   const error = computed(() => {
     return unref(issue).approvalStatusError;

--- a/frontend/src/components/Plan/logic/issue-review.ts
+++ b/frontend/src/components/Plan/logic/issue-review.ts
@@ -1,8 +1,6 @@
-import { head } from "lodash-es";
 import type { ComputedRef, InjectionKey } from "vue";
 import { computed, inject, provide, unref } from "vue";
 import {
-  Issue_Approver_Status,
   Issue_ApprovalStatus,
   type Issue,
 } from "@/types/proto-es/v1/issue_service_pb";
@@ -21,39 +19,16 @@ export const provideIssueReviewContext = (
   const status = computed(() => {
     const tempIssue = issue.value;
     if (!tempIssue) {
-      return Issue_Approver_Status.PENDING;
+      return Issue_ApprovalStatus.PENDING;
     }
-    if (tempIssue?.approvalStatus === Issue_ApprovalStatus.CHECKING) {
-      return Issue_Approver_Status.PENDING;
-    }
-    if (tempIssue?.approvalStatus === Issue_ApprovalStatus.ERROR) {
-      return Issue_Approver_Status.PENDING;
-    }
-
-    const { approvalTemplates, approvers } = tempIssue;
-    const steps = head(approvalTemplates)?.flow?.steps ?? [];
-    // No review flow steps. That means need not manual review.
-    if (steps.length === 0) {
-      return Issue_Approver_Status.APPROVED;
-    }
-    // If any of the approvers rejected, the overall status should be 'REJECTED'
-    if (
-      approvers.some((app) => app.status === Issue_Approver_Status.REJECTED)
-    ) {
-      return Issue_Approver_Status.REJECTED;
-    }
-
-    if (
-      approvers.length === steps.length &&
-      approvers.every((app) => app.status === Issue_Approver_Status.APPROVED)
-    ) {
-      return Issue_Approver_Status.APPROVED;
-    }
-    return Issue_Approver_Status.PENDING;
+    return tempIssue.approvalStatus;
   });
 
   const done = computed(() => {
-    return status.value === Issue_Approver_Status.APPROVED;
+    return (
+      status.value === Issue_ApprovalStatus.APPROVED ||
+      status.value === Issue_ApprovalStatus.SKIPPED
+    );
   });
 
   const error = computed(() => {

--- a/frontend/src/utils/v1/advanced-search/issue/ui-filter.ts
+++ b/frontend/src/utils/v1/advanced-search/issue/ui-filter.ts
@@ -5,7 +5,7 @@ import {
 } from "@/components/IssueV1/logic";
 import { userNamePrefix } from "@/store";
 import type { ComposedIssue } from "@/types";
-import { Issue_Approver_Status } from "@/types/proto-es/v1/issue_service_pb";
+import { Issue_ApprovalStatus } from "@/types/proto-es/v1/issue_service_pb";
 import { isUserIncludedInList } from "@/utils";
 import type { SearchParams } from "../common";
 import { getValueFromSearchParams } from "../common";
@@ -79,10 +79,13 @@ export const filterIssueByApprovalStatus = (
 
   const reviewContext = extractReviewContext(issue);
   if (status === "pending") {
-    return reviewContext.status.value === Issue_Approver_Status.PENDING;
+    return reviewContext.status.value === Issue_ApprovalStatus.PENDING;
   }
   if (status === "approved") {
-    return reviewContext.status.value === Issue_Approver_Status.APPROVED;
+    return (
+      reviewContext.status.value === Issue_ApprovalStatus.APPROVED ||
+      reviewContext.status.value === Issue_ApprovalStatus.SKIPPED
+    );
   }
 
   console.error(


### PR DESCRIPTION
## Summary

Replace frontend's manual approval status computation with the backend's `Issue_ApprovalStatus` field. This eliminates duplicated logic and establishes a single source of truth for approval state.

## Changes

- **Update `ReviewContext` type** to use `Issue_ApprovalStatus` instead of `Issue_Approver_Status`
- **Remove helper functions** that converted between status types (`convertApprovalStatusToApproverStatus`)
- **Simplify context providers** (`extractReviewContext` and `provideIssueReviewContext`) to return `issue.approvalStatus` directly
- **Update all callers** to use `Issue_ApprovalStatus` constants (`APPROVED`, `REJECTED`, `PENDING`, `SKIPPED`, etc.)
- **Include `SKIPPED` status** in "done" check (approval not required = can proceed to rollout)
- **Remove unused parameter** `_reviewStatus` from `getApplicableIssueStatusActionList`

## Impact

- ✅ **Reduces code by ~65 lines** across 8 files (33 insertions, 98 deletions)
- ✅ **Eliminates complex logic** that manually computed approval status from approvers/templates
- ✅ **Single source of truth**: All approval decisions now rely on backend's `computeApprovalStatus()`
- ✅ **Type-safe**: TypeScript enforces correct usage of `Issue_ApprovalStatus` enum
- ✅ **Better semantics**: `SKIPPED` (no approval needed) explicitly treated same as `APPROVED`

## Files Changed

- `frontend/src/components/IssueV1/logic/review.ts` - Removed 28 lines of status computation
- `frontend/src/components/Plan/logic/issue-review.ts` - Removed 28 lines of status computation  
- `frontend/src/components/IssueV1/logic/context.ts` - Updated type definitions
- `frontend/src/components/IssueV1/logic/action/issue.ts` - Removed unused parameter
- `frontend/src/utils/v1/advanced-search/issue/ui-filter.ts` - Updated status checks
- `frontend/src/components/IssueV1/components/BannerSection.vue` - Updated status constants
- `frontend/src/components/IssueV1/components/HeaderSection/Actions/review/IssueReviewButtonGroup.vue` - Updated status constants
- `frontend/src/components/IssueV1/components/HeaderSection/Actions/rollout/CombinedRolloutButtonGroup.vue` - Removed unused variable

## Test Plan

- [x] Frontend lint passes
- [x] Frontend type-check passes
- [ ] Manual testing: Verify approval flow UI shows correct states
- [ ] Manual testing: Verify issues with no approval templates (SKIPPED) can proceed to rollout
- [ ] Manual testing: Verify approval/rejection actions work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)