### PR TITLE
refactor: simplify approval status handling and improve code clarity

### DIFF
--- a/backend/api/v1/issue_service_convert.go
+++ b/backend/api/v1/issue_service_convert.go
@@ -39,25 +39,18 @@ func (s *IssueService) convertToIssue(ctx context.Context, issue *store.IssueMes
 	}
 
 	issueV1 := &v1pb.Issue{
-		Name:                common.FormatIssue(issue.Project.ResourceID, issue.UID),
-		Title:               issue.Title,
-		Description:         issue.Description,
-		Type:                convertToIssueType(issue.Type),
-		Status:              convertToIssueStatus(issue.Status),
-		Approvers:           nil,
-		ApprovalTemplates:   nil,
-		Creator:             common.FormatUserEmail(issue.Creator.Email),
-		CreateTime:          timestamppb.New(issue.CreatedAt),
-		UpdateTime:          timestamppb.New(issue.UpdatedAt),
-		Plan:                "",
-		Rollout:             "",
-		GrantRequest:        convertedGrantRequest,
-		Releasers:           releasers,
-		RiskLevel:           v1pb.Issue_RISK_LEVEL_UNSPECIFIED,
-		TaskStatusCount:     issue.TaskStatusCount,
-		Labels:              issuePayload.Labels,
-		ApprovalStatus:      v1pb.Issue_APPROVAL_STATUS_UNSPECIFIED,
-		ApprovalStatusError: "",
+		Name:            common.FormatIssue(issue.Project.ResourceID, issue.UID),
+		Title:           issue.Title,
+		Description:     issue.Description,
+		Type:            convertToIssueType(issue.Type),
+		Status:          convertToIssueStatus(issue.Status),
+		Creator:         common.FormatUserEmail(issue.Creator.Email),
+		CreateTime:      timestamppb.New(issue.CreatedAt),
+		UpdateTime:      timestamppb.New(issue.UpdatedAt),
+		GrantRequest:    convertedGrantRequest,
+		Releasers:       releasers,
+		TaskStatusCount: issue.TaskStatusCount,
+		Labels:          issuePayload.Labels,
 	}
 
 	if issue.PlanUID != nil {
@@ -67,56 +60,57 @@ func (s *IssueService) convertToIssue(ctx context.Context, issue *store.IssueMes
 		issueV1.Rollout = common.FormatRollout(issue.Project.ResourceID, *issue.PipelineUID)
 	}
 
-	if issuePayload.Approval != nil {
-		issueV1.RiskLevel = convertToIssueRiskLevel(issuePayload.Approval.RiskLevel)
-		for _, template := range issuePayload.Approval.ApprovalTemplates {
-			issueV1.ApprovalTemplates = append(issueV1.ApprovalTemplates, convertToApprovalTemplate(template))
-		}
-		for _, approver := range issuePayload.Approval.Approvers {
-			convertedApprover := &v1pb.Issue_Approver{Status: v1pb.Issue_Approver_Status(approver.Status)}
-			user, err := s.store.GetUserByID(ctx, int(approver.PrincipalId))
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to find user by id %v", approver.PrincipalId)
-			}
-			convertedApprover.Principal = fmt.Sprintf("users/%s", user.Email)
-			issueV1.Approvers = append(issueV1.Approvers, convertedApprover)
-		}
-		issueV1.ApprovalStatus, issueV1.ApprovalStatusError = computeApprovalStatus(issuePayload.Approval)
+	approval := issuePayload.GetApproval()
+	issueV1.RiskLevel = convertToIssueRiskLevel(approval.GetRiskLevel())
+	for _, template := range approval.GetApprovalTemplates() {
+		issueV1.ApprovalTemplates = append(issueV1.ApprovalTemplates, convertToApprovalTemplate(template))
 	}
+	for _, approver := range approval.GetApprovers() {
+		convertedApprover := &v1pb.Issue_Approver{Status: v1pb.Issue_Approver_Status(approver.GetStatus())}
+		user, err := s.store.GetUserByID(ctx, int(approver.GetPrincipalId()))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to find user by id %v", approver.GetPrincipalId())
+		}
+		convertedApprover.Principal = fmt.Sprintf("users/%s", user.Email)
+		issueV1.Approvers = append(issueV1.Approvers, convertedApprover)
+	}
+	issueV1.ApprovalStatus = computeApprovalStatus(approval)
+	issueV1.ApprovalStatusError = approval.GetApprovalFindingError()
 
 	return issueV1, nil
 }
 
-func computeApprovalStatus(approval *storepb.IssuePayloadApproval) (v1pb.Issue_ApprovalStatus, string) {
+func computeApprovalStatus(approval *storepb.IssuePayloadApproval) v1pb.Issue_ApprovalStatus {
 	// If approval finding is not done, status is checking
-	if !approval.ApprovalFindingDone {
-		return v1pb.Issue_CHECKING, ""
+	// Note: approval.GetApprovalFindingDone() returns false when approval is nil
+	if !approval.GetApprovalFindingDone() {
+		return v1pb.Issue_CHECKING
 	}
 
 	// If there's an error finding approval, status is error
-	if approval.ApprovalFindingError != "" {
-		return v1pb.Issue_ERROR, approval.ApprovalFindingError
+	if approval.GetApprovalFindingError() != "" {
+		return v1pb.Issue_ERROR
 	}
 
 	// If no approval templates, approval is skipped (not required)
-	if len(approval.ApprovalTemplates) == 0 {
-		return v1pb.Issue_SKIPPED, ""
+	if len(approval.GetApprovalTemplates()) == 0 {
+		return v1pb.Issue_SKIPPED
 	}
 
 	// If no approvers are assigned yet, it's pending
-	if len(approval.Approvers) == 0 {
-		return v1pb.Issue_PENDING, ""
+	if len(approval.GetApprovers()) == 0 {
+		return v1pb.Issue_PENDING
 	}
 
 	// Check approver statuses
-	hasRejected := false
 	hasPending := false
 	allApproved := true
 
-	for _, approver := range approval.Approvers {
-		switch approver.Status {
+	for _, approver := range approval.GetApprovers() {
+		switch approver.GetStatus() {
 		case storepb.IssuePayloadApproval_Approver_REJECTED:
-			hasRejected = true
+			// Short-circuit: if any approver rejected, overall status is rejected
+			return v1pb.Issue_REJECTED
 		case storepb.IssuePayloadApproval_Approver_PENDING:
 			hasPending = true
 			allApproved = false
@@ -127,22 +121,19 @@ func computeApprovalStatus(approval *storepb.IssuePayloadApproval) (v1pb.Issue_A
 		}
 	}
 
-	// If any approver rejected, overall status is rejected
-	if hasRejected {
-		return v1pb.Issue_REJECTED, ""
-	}
-
 	// If all approvers approved, overall status is approved
 	if allApproved {
-		return v1pb.Issue_APPROVED, ""
+		return v1pb.Issue_APPROVED
 	}
 
 	// If there are pending approvers, overall status is pending
 	if hasPending {
-		return v1pb.Issue_PENDING, ""
+		return v1pb.Issue_PENDING
 	}
 
-	return v1pb.Issue_APPROVAL_STATUS_UNSPECIFIED, ""
+	// Fallback: should not reach here in normal cases, but treat as pending
+	// This handles edge cases where approvers exist but none are in expected states
+	return v1pb.Issue_PENDING
 }
 
 func (s *IssueService) convertToIssueReleasers(ctx context.Context, issue *store.IssueMessage) ([]string, error) {

--- a/frontend/src/components/IssueV1/components/BannerSection.vue
+++ b/frontend/src/components/IssueV1/components/BannerSection.vue
@@ -61,19 +61,18 @@ import {
   isUnfinishedResolvedTask as checkUnfinishedResolvedTask,
 } from "../logic";
 
-const { isCreating, issue, reviewContext } = useIssueContext();
-const { status: reviewStatus } = reviewContext;
+const { isCreating, issue } = useIssueContext();
 
 const showPendingReview = computed(() => {
   if (isCreating.value) return false;
   if (issue.value.status !== IssueStatus.OPEN) return false;
-  return reviewStatus.value === Issue_ApprovalStatus.PENDING;
+  return issue.value.approvalStatus === Issue_ApprovalStatus.PENDING;
 });
 
 const showRejectedReview = computed(() => {
   if (isCreating.value) return false;
   if (issue.value.status !== IssueStatus.OPEN) return false;
-  return reviewStatus.value === Issue_ApprovalStatus.REJECTED;
+  return issue.value.approvalStatus === Issue_ApprovalStatus.REJECTED;
 });
 
 const showClosedBanner = computed(() => {

--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/IssueReviewButtonGroup.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/IssueReviewButtonGroup.vue
@@ -44,10 +44,21 @@ import ReviewActionButton from "./ReviewActionButton.vue";
 
 const { t } = useI18n();
 const currentUser = useCurrentUserV1();
-const { issue, phase, reviewContext, events, selectedTask, selectedStage } =
-  useIssueContext();
+const { issue, phase, events, selectedTask, selectedStage } = useIssueContext();
 const { project } = useCurrentProjectV1();
-const { ready, status, done } = reviewContext;
+
+const approvalFlowReady = computed(() => {
+  const approvalStatus = issue.value.approvalStatus;
+  return approvalStatus !== Issue_ApprovalStatus.CHECKING;
+});
+
+const rolloutReady = computed(() => {
+  const approvalStatus = issue.value.approvalStatus;
+  return (
+    approvalStatus === Issue_ApprovalStatus.APPROVED ||
+    approvalStatus === Issue_ApprovalStatus.SKIPPED
+  );
+});
 
 const shouldShowApproveOrReject = computed(() => {
   if (
@@ -69,23 +80,23 @@ const shouldShowApproveOrReject = computed(() => {
     return false;
   }
 
-  if (!ready.value) return false;
-  if (done.value) return false;
+  if (!approvalFlowReady.value) return false;
+  if (rolloutReady.value) return false;
 
   return true;
 });
 const shouldShowApprove = computed(() => {
   if (!shouldShowApproveOrReject.value) return false;
-  return status.value === Issue_ApprovalStatus.PENDING;
+  return issue.value.approvalStatus === Issue_ApprovalStatus.PENDING;
 });
 const shouldShowReject = computed(() => {
   if (!shouldShowApproveOrReject.value) return false;
-  return status.value === Issue_ApprovalStatus.PENDING;
+  return issue.value.approvalStatus === Issue_ApprovalStatus.PENDING;
 });
 const shouldShowReRequestReview = computed(() => {
   return (
     extractUserId(issue.value.creator) === currentUser.value.email &&
-    status.value === Issue_ApprovalStatus.REJECTED
+    issue.value.approvalStatus === Issue_ApprovalStatus.REJECTED
   );
 });
 const issueReviewActionList = computed(() => {

--- a/frontend/src/components/IssueV1/logic/action/review.ts
+++ b/frontend/src/components/IssueV1/logic/action/review.ts
@@ -9,6 +9,7 @@ import type { ComposedIssue } from "@/types";
 import {
   IssueStatus,
   Issue_Approver_Status,
+  Issue_ApprovalStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import { isUserIncludedInList } from "@/utils";
 import type { ReviewContext } from "../context";
@@ -63,7 +64,12 @@ export const allowUserToApplyReviewAction = (
   context: ReviewContext,
   action: IssueReviewAction
 ) => {
-  const { ready, done, flow } = context;
+  const { flow } = context;
+  const approvalFlowReady =
+    issue.approvalStatus !== Issue_ApprovalStatus.CHECKING;
+  const rolloutReady =
+    issue.approvalStatus === Issue_ApprovalStatus.APPROVED ||
+    issue.approvalStatus === Issue_ApprovalStatus.SKIPPED;
 
   if (
     issue.status === IssueStatus.CANCELED ||
@@ -72,8 +78,8 @@ export const allowUserToApplyReviewAction = (
     return false;
   }
 
-  if (!ready.value) return false;
-  if (done.value) return false;
+  if (!approvalFlowReady) return false;
+  if (rolloutReady) return false;
 
   const me = useCurrentUserV1();
 

--- a/frontend/src/components/IssueV1/logic/base.ts
+++ b/frontend/src/components/IssueV1/logic/base.ts
@@ -6,6 +6,7 @@ import { useRoute, useRouter } from "vue-router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
 import { useUIStateStore } from "@/store";
 import { emptyStage, emptyTask } from "@/types";
+import { Issue_ApprovalStatus } from "@/types/proto-es/v1/issue_service_pb";
 import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
 import {
@@ -134,7 +135,11 @@ export const useBaseIssueContext = (
   const phase = computed((): IssuePhase => {
     if (isCreating.value) return "CREATE";
 
-    return reviewContext.done.value ? "ROLLOUT" : "REVIEW";
+    const approvalStatus = issue.value.approvalStatus;
+    const rolloutReady =
+      approvalStatus === Issue_ApprovalStatus.APPROVED ||
+      approvalStatus === Issue_ApprovalStatus.SKIPPED;
+    return rolloutReady ? "ROLLOUT" : "REVIEW";
   });
 
   const formatOnSave = computed({

--- a/frontend/src/components/IssueV1/logic/context.ts
+++ b/frontend/src/components/IssueV1/logic/context.ts
@@ -4,7 +4,6 @@ import { v4 as uuidv4 } from "uuid";
 import type { InjectionKey, Ref, ComputedRef } from "vue";
 import { inject, provide } from "vue";
 import type { ComposedIssue, ReviewFlow } from "@/types";
-import type { Issue_ApprovalStatus } from "@/types/proto-es/v1/issue_service_pb";
 import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
 import type {
@@ -24,18 +23,9 @@ export type IssueEvents = Emittery<{
 }>;
 
 export type ReviewContext = {
-  // true if the approval flow is generated
-  ready: Ref<boolean>;
   // The review flow.
   // Now we have only one flow in an issue
   flow: Ref<ReviewFlow>;
-  // The overall status of the entire review flow
-  status: Ref<Issue_ApprovalStatus>;
-  // Whether the review flow is finished successfully.
-  // A shortcut to `status === Issue_ApprovalStatus.APPROVED`
-  done: Ref<boolean>;
-  // Whether the review finding has error.
-  error: Ref<string | undefined>;
 };
 
 export type IssueContext = {

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
@@ -50,7 +50,6 @@ import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useSpecsValidation } from "@/components/Plan/components/common";
 import { usePlanContext, usePlanCheckStatus } from "@/components/Plan/logic";
-import { useIssueReviewContext } from "@/components/Plan/logic/issue-review";
 import { useResourcePoller } from "@/components/Plan/logic/poller";
 import { useEditorState } from "@/components/Plan/logic/useEditorState";
 import {
@@ -116,8 +115,6 @@ const {
   getOverallStatus: planCheckSummaryStatus,
   hasRunning: hasRunningPlanChecks,
 } = usePlanCheckStatus(plan);
-
-const reviewContext = useIssueReviewContext();
 
 // Policy for restricting issue creation when plan checks fail
 
@@ -232,9 +229,12 @@ const availableActions = computed(() => {
   }
 
   // Check for review actions
+  const rolloutReady =
+    issueValue.approvalStatus === Issue_ApprovalStatus.APPROVED ||
+    issueValue.approvalStatus === Issue_ApprovalStatus.SKIPPED;
   if (
     issueValue.approvalStatus !== Issue_ApprovalStatus.CHECKING &&
-    !reviewContext.done.value
+    !rolloutReady
   ) {
     const issueCreator = extractUserId(issueValue.creator);
     const { approvers, approvalTemplates } = issueValue;
@@ -289,7 +289,7 @@ const availableActions = computed(() => {
           [Task_Status.DONE, Task_Status.SKIPPED].includes(task.status)
         );
 
-      if (allTasksFinished && reviewContext.done.value) {
+      if (allTasksFinished && rolloutReady) {
         actions.push("ISSUE_STATUS_RESOLVE");
       }
     }

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/IssueStatusSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/IssueStatusSection.vue
@@ -19,14 +19,12 @@ import {
   Issue_ApprovalStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
-import { useIssueReviewContext } from "../../../logic/";
 
 const props = defineProps<{
   issue: Issue;
 }>();
 
 const { t } = useI18n();
-const reviewContext = useIssueReviewContext();
 
 const issueStatusText = computed(() => {
   const issueValue = props.issue;
@@ -36,7 +34,10 @@ const issueStatusText = computed(() => {
     return t("issue.table.open");
   }
 
-  const reviewStatus = reviewContext.done.value
+  const rolloutReady =
+    issueValue.approvalStatus === Issue_ApprovalStatus.APPROVED ||
+    issueValue.approvalStatus === Issue_ApprovalStatus.SKIPPED;
+  const reviewStatus = rolloutReady
     ? Issue_Approver_Status.APPROVED
     : issueValue.approvers.some(
           (app) => app.status === Issue_Approver_Status.REJECTED
@@ -64,7 +65,10 @@ const issueStatusTagType = computed(() => {
         return "info";
       }
 
-      const reviewStatus = reviewContext.done.value
+      const rolloutReady =
+        issueValue.approvalStatus === Issue_ApprovalStatus.APPROVED ||
+        issueValue.approvalStatus === Issue_ApprovalStatus.SKIPPED;
+      const reviewStatus = rolloutReady
         ? Issue_Approver_Status.APPROVED
         : issueValue.approvers.some(
               (app) => app.status === Issue_Approver_Status.REJECTED

--- a/frontend/src/components/Plan/logic/issue-review.ts
+++ b/frontend/src/components/Plan/logic/issue-review.ts
@@ -24,7 +24,7 @@ export const provideIssueReviewContext = (
     return tempIssue.approvalStatus;
   });
 
-  const done = computed(() => {
+  const rolloutReady = computed(() => {
     return (
       status.value === Issue_ApprovalStatus.APPROVED ||
       status.value === Issue_ApprovalStatus.SKIPPED
@@ -36,7 +36,7 @@ export const provideIssueReviewContext = (
   });
 
   const context = {
-    done,
+    rolloutReady,
     error,
   };
 

--- a/frontend/src/utils/v1/advanced-search/issue/ui-filter.ts
+++ b/frontend/src/utils/v1/advanced-search/issue/ui-filter.ts
@@ -1,7 +1,7 @@
 import {
-  extractReviewContext,
   releaserCandidatesForIssue,
   useWrappedReviewStepsV1,
+  extractReviewContext,
 } from "@/components/IssueV1/logic";
 import { userNamePrefix } from "@/store";
 import type { ComposedIssue } from "@/types";
@@ -77,14 +77,14 @@ export const filterIssueByApprovalStatus = (
 ) => {
   if (!status) return true;
 
-  const reviewContext = extractReviewContext(issue);
+  const approvalStatus = issue.approvalStatus;
   if (status === "pending") {
-    return reviewContext.status.value === Issue_ApprovalStatus.PENDING;
+    return approvalStatus === Issue_ApprovalStatus.PENDING;
   }
   if (status === "approved") {
     return (
-      reviewContext.status.value === Issue_ApprovalStatus.APPROVED ||
-      reviewContext.status.value === Issue_ApprovalStatus.SKIPPED
+      approvalStatus === Issue_ApprovalStatus.APPROVED ||
+      approvalStatus === Issue_ApprovalStatus.SKIPPED
     );
   }
 


### PR DESCRIPTION
## Summary
- Simplify approval status computation logic in both backend and frontend
- Improve code clarity with better variable naming and reduced coupling
- Use defensive programming patterns with protobuf Get methods
- Optimize performance with caching and short-circuit evaluation

## Backend Changes
- Simplify `computeApprovalStatus` to only return status (not error message)
- Use nil-safe `Get` methods for all approval field access
- Remove unnecessary nil checks by relying on protobuf Get methods
- Cache approval object to avoid repeated `GetApproval()` calls
- Short-circuit REJECTED status check for better performance
- Remove redundant struct field initializations
- Ensure backend never returns `APPROVAL_STATUS_UNSPECIFIED`

## Frontend Changes
- Simplify `ReviewContext` to only include `flow` field (removed `ready`, `status`, `done`, `error`)
- Remove unnecessary `extractReviewContext` calls
- Rename approval status variables for clarity:
  - `done`/`isApproved`/`approvalDone` → `rolloutReady`
  - `ready` → `approvalFlowReady`
- Compute approval status locally instead of from context
- Remove `APPROVAL_STATUS_UNSPECIFIED` checks (backend never returns it)

## Test plan
- [ ] Verify approval flow works correctly for database change issues
- [ ] Verify approval flow works correctly for grant request issues
- [ ] Verify approval flow works correctly for data export issues
- [ ] Verify approval status displays correctly in issue detail page
- [ ] Verify approval actions (approve/reject/re-request) work correctly
- [ ] Verify rollout actions are shown/hidden correctly based on approval status

🤖 Generated with [Claude Code](https://claude.com/claude-code)