### PR TITLE
refactor: simplify review context and remove unnecessary abstractions

### DIFF
--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/ReviewActionButton.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/review/ReviewActionButton.vue
@@ -48,7 +48,7 @@ const errors = computed(() => {
 
   if (!allowUserToApplyReviewAction(issue.value, reviewContext, props.action)) {
     errors.push(t("issue.error.you-are-not-allowed-to-perform-this-action"));
-    const flow = reviewContext.flow.value;
+    const flow = reviewContext.value;
     const index = flow.currentStepIndex;
     const steps = flow.template.flow?.steps ?? [];
     const step = steps[index];

--- a/frontend/src/components/IssueV1/logic/action/review.ts
+++ b/frontend/src/components/IssueV1/logic/action/review.ts
@@ -1,18 +1,18 @@
 import type { ButtonProps } from "naive-ui";
+import type { ComputedRef } from "vue";
 import { t } from "@/plugins/i18n";
 import {
   candidatesOfApprovalStepV1,
   useCurrentUserV1,
   extractUserId,
 } from "@/store";
-import type { ComposedIssue } from "@/types";
+import type { ComposedIssue, ReviewFlow } from "@/types";
 import {
   IssueStatus,
   Issue_Approver_Status,
   Issue_ApprovalStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import { isUserIncludedInList } from "@/utils";
-import type { ReviewContext } from "../context";
 
 export type IssueReviewAction = "APPROVE" | "SEND_BACK" | "RE_REQUEST";
 
@@ -61,10 +61,9 @@ export const issueReviewActionButtonProps = (
 
 export const allowUserToApplyReviewAction = (
   issue: ComposedIssue,
-  context: ReviewContext,
+  flow: ComputedRef<ReviewFlow>,
   action: IssueReviewAction
 ) => {
-  const { flow } = context;
   const approvalFlowReady =
     issue.approvalStatus !== Issue_ApprovalStatus.CHECKING;
   const rolloutReady =

--- a/frontend/src/components/IssueV1/logic/context.ts
+++ b/frontend/src/components/IssueV1/logic/context.ts
@@ -22,12 +22,6 @@ export type IssueEvents = Emittery<{
   "perform-task-rollout-action": { action: TaskRolloutAction; tasks: Task[] };
 }>;
 
-export type ReviewContext = {
-  // The review flow.
-  // Now we have only one flow in an issue
-  flow: Ref<ReviewFlow>;
-};
-
 export type IssueContext = {
   // Basic fields
   isCreating: Ref<boolean>;
@@ -37,7 +31,7 @@ export type IssueContext = {
   allowChange: ComputedRef<boolean>;
 
   // review status
-  reviewContext: ReviewContext;
+  reviewContext: ComputedRef<ReviewFlow>;
   // The release candidates of the issue.
   // Format: users/{email}
   releaserCandidates: Ref<string[]>;

--- a/frontend/src/components/IssueV1/logic/review.ts
+++ b/frontend/src/components/IssueV1/logic/review.ts
@@ -1,33 +1,19 @@
-import { computed, unref, watchEffect } from "vue";
-import {
-  candidatesOfApprovalStepV1,
-  useCurrentUserV1,
-  userNamePrefix,
-  useUserStore,
-} from "@/store";
-import type {
-  ReviewFlow,
-  MaybeRef,
-  ComposedIssue,
-  WrappedReviewStep,
-} from "@/types";
+import { computed, unref } from "vue";
+import type { ComputedRef } from "vue";
+import type { ReviewFlow, MaybeRef } from "@/types";
 import { emptyFlow } from "@/types";
-import type {
-  ApprovalNode,
-  ApprovalStep,
-  Issue,
-} from "@/types/proto-es/v1/issue_service_pb";
+import type { ApprovalNode, Issue } from "@/types/proto-es/v1/issue_service_pb";
 import {
   ApprovalNode_Type,
   Issue_Approver_Status,
   Issue_ApprovalStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import { displayRoleTitle } from "@/utils";
-import { isUserIncludedInList } from "@/utils";
-import type { ReviewContext } from "./context";
 
-export const extractReviewContext = (issue: MaybeRef<Issue>): ReviewContext => {
-  const flow = computed((): ReviewFlow => {
+export const extractReviewContext = (
+  issue: MaybeRef<Issue>
+): ComputedRef<ReviewFlow> => {
+  return computed((): ReviewFlow => {
     const issueValue = unref(issue);
     const approvalStatus = issueValue.approvalStatus;
     if (
@@ -51,86 +37,6 @@ export const extractReviewContext = (issue: MaybeRef<Issue>): ReviewContext => {
       approvers,
       currentStepIndex,
     };
-  });
-
-  return {
-    flow,
-  };
-};
-
-export const useWrappedReviewStepsV1 = (
-  issue: MaybeRef<ComposedIssue>,
-  context: ReviewContext
-) => {
-  const userStore = useUserStore();
-  const currentUser = useCurrentUserV1();
-  // Format: users/{email}
-  const currentUserName = computed(
-    () => `${userNamePrefix}${currentUser.value.email}`
-  );
-
-  watchEffect(async () => {
-    const { flow } = context;
-    const approvers = flow.value.approvers;
-    const steps = flow.value.template.flow?.steps;
-    const distinctUsers = steps?.map((_, i) => approvers[i]?.principal) ?? [];
-    await userStore.batchGetUsers(distinctUsers);
-  });
-
-  return computed(() => {
-    const { flow } = context;
-    const steps = flow.value.template.flow?.steps || [];
-    const approvers = flow.value.approvers;
-    const currentStepIndex = flow.value.currentStepIndex ?? -1;
-    const issueValue = unref(issue);
-    const rolloutReady =
-      issueValue.approvalStatus === Issue_ApprovalStatus.APPROVED ||
-      issueValue.approvalStatus === Issue_ApprovalStatus.SKIPPED;
-
-    const statusOfStep = (index: number) => {
-      if (rolloutReady) {
-        return "APPROVED";
-      }
-      if (index >= (steps?.length ?? 0)) {
-        // Out of index
-        return "PENDING";
-      }
-      const approval = approvers[index];
-      if (approval && approval.status === Issue_Approver_Status.REJECTED) {
-        return "REJECTED";
-      }
-      if (index < currentStepIndex) {
-        return "APPROVED";
-      }
-      if (index === currentStepIndex) {
-        return "CURRENT";
-      }
-      return "PENDING";
-    };
-
-    const approverOfStep = (index: number) => {
-      return approvers[index]?.principal;
-    };
-
-    const candidatesOfStep = (step: ApprovalStep) => {
-      const users = candidatesOfApprovalStepV1(unref(issue), step);
-      if (isUserIncludedInList(currentUserName.value, users)) {
-        const idx = users.indexOf(currentUserName.value);
-        if (idx >= 0) {
-          users.splice(idx, 1);
-        }
-        users.unshift(currentUserName.value);
-      }
-      return users;
-    };
-
-    return steps.map<WrappedReviewStep>((step, index) => ({
-      index,
-      step,
-      status: statusOfStep(index),
-      approver: approverOfStep(index),
-      candidates: candidatesOfStep(step),
-    }));
   });
 };
 

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -1,6 +1,5 @@
 import { create as createProto } from "@bufbuild/protobuf";
 import type {
-  ApprovalStep,
   Issue_Approver,
   ApprovalTemplate,
 } from "./proto-es/v1/issue_service_pb";
@@ -10,14 +9,6 @@ export type ReviewFlow = {
   template: ApprovalTemplate;
   approvers: Issue_Approver[];
   currentStepIndex: number; // -1 if finished
-};
-
-export type WrappedReviewStep = {
-  index: number;
-  step: ApprovalStep;
-  status: "APPROVED" | "REJECTED" | "CURRENT" | "PENDING";
-  approver: string | undefined;
-  candidates: string[];
 };
 
 export const emptyFlow = (): ReviewFlow => {


### PR DESCRIPTION
## Summary
This refactoring removes multiple layers of abstraction that were making the approval flow logic unnecessarily complex.

## Changes

### Removed
- `ReviewContext` type (replaced with `ComputedRef<ReviewFlow>`)
- `useWrappedReviewStepsV1` function
- `WrappedReviewStep` type  
- `useCurrentReviewStep` function
- `getCurrentStepCandidates` function

### Key Simplifications
- `extractReviewContext` now returns `ComputedRef<ReviewFlow>` directly
- `filterIssueByApprover` simplified to only check PENDING status
- `CurrentApproverV1.vue` split into `rejectedApprover` and `currentApprover` computeds
- Removed complex step status tracking in favor of issue-level status

## Insight
The issue-level `approvalStatus` (PENDING/REJECTED/APPROVED) provides all the information needed. If an approver rejects, the issue status becomes REJECTED, so we don't need to check individual step rejection status.

## Impact
- Reduces code by ~100 lines
- Maintains all existing functionality
- Improves code clarity and maintainability
- No breaking changes

## Test plan
- [x] Frontend lint passes
- [x] Frontend type-check passes
- Manual testing needed for approval flow scenarios:
  - [ ] Issue pending approval displays correct approver
  - [ ] Rejected issue displays who rejected it
  - [ ] Approved issue shows correct status
  - [ ] Issue filter by approver works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)