### PR TITLE
chore: upgrade Docker base images and dependencies

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -33,7 +33,7 @@ RUN CC=clang go build \
   -ldflags="-extldflags '-Wl,-z,stack-size=0x1000000' -w -s -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.version=${VERSION}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.gitcommit=${GIT_COMMIT}'" \
   -o bytebase ./backend/bin/server/main.go
 
-FROM alpine:3.22 AS monolithic
+FROM alpine:3.23 AS monolithic
 ARG VERSION
 ARG GIT_COMMIT
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:23.11.1-slim AS frontend
 ARG GIT_COMMIT
 
-RUN npm i -g pnpm@10.17.1
+RUN npm i -g pnpm@10.18.0
 
 WORKDIR /frontend-build
 
@@ -10,7 +10,7 @@ COPY . .
 RUN pnpm --dir ./frontend i
 RUN pnpm --dir ./frontend release-docker
 
-FROM golang:1.25.1-alpine3.21 AS backend
+FROM golang:1.25.1-alpine3.22 AS backend
 ARG VERSION
 ARG GIT_COMMIT
 ARG RELEASE="release"
@@ -33,7 +33,7 @@ RUN CC=clang go build \
   -ldflags="-extldflags '-Wl,-z,stack-size=0x1000000' -w -s -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.version=${VERSION}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.gitcommit=${GIT_COMMIT}'" \
   -o bytebase ./backend/bin/server/main.go
 
-FROM alpine:3.23 AS monolithic
+FROM alpine:3.22 AS monolithic
 ARG VERSION
 ARG GIT_COMMIT
 
@@ -57,7 +57,7 @@ RUN apk add postgresql16
 
 # Install mongosh.
 RUN apk add --no-cache npm
-RUN npm install -g mongosh@2.5.0
+RUN npm install -g mongosh@2.5.8
 
 # The file indicates running in docker environment.
 RUN touch /etc/bb.env

--- a/scripts/Dockerfile.action
+++ b/scripts/Dockerfile.action
@@ -8,7 +8,7 @@ RUN go build \
 --ldflags="-w -s -X 'github.com/bytebase/bytebase/action/args.Version=${VERSION}' -X 'github.com/bytebase/bytebase/action/args.Gitcommit=${GIT_COMMIT}'" \
 -o bytebase-action action/*.go
 
-FROM alpine:3.22
+FROM alpine:3.23
 RUN apk update
 # Azure DevOps pipeline requires bash.
 RUN apk add --no-cache jq bash gcompat

--- a/scripts/Dockerfile.action
+++ b/scripts/Dockerfile.action
@@ -1,4 +1,4 @@
-FROM golang:1.25.1-alpine3.21 AS builder
+FROM golang:1.25.1-alpine3.22 AS builder
 ARG VERSION
 ARG GIT_COMMIT
 WORKDIR /action-build
@@ -8,7 +8,7 @@ RUN go build \
 --ldflags="-w -s -X 'github.com/bytebase/bytebase/action/args.Version=${VERSION}' -X 'github.com/bytebase/bytebase/action/args.Gitcommit=${GIT_COMMIT}'" \
 -o bytebase-action action/*.go
 
-FROM alpine:3.23
+FROM alpine:3.22
 RUN apk update
 # Azure DevOps pipeline requires bash.
 RUN apk add --no-cache jq bash gcompat

--- a/scripts/Dockerfile.aws
+++ b/scripts/Dockerfile.aws
@@ -1,7 +1,7 @@
 FROM node:23.11.1-slim AS frontend
 ARG GIT_COMMIT
 
-RUN npm i -g pnpm@10.17.1
+RUN npm i -g pnpm@10.18.0
 
 WORKDIR /frontend-build
 
@@ -10,7 +10,7 @@ COPY . .
 RUN pnpm --dir ./frontend i
 RUN pnpm --dir ./frontend release-aws
 
-FROM golang:1.25.1-alpine3.21 AS backend
+FROM golang:1.25.1-alpine3.22 AS backend
 ARG VERSION
 ARG GIT_COMMIT
 ARG RELEASE="release"
@@ -33,7 +33,7 @@ RUN CC=clang go build \
   -ldflags="-extldflags '-Wl,-z,stack-size=0x1000000' -w -s -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.version=${VERSION}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.gitcommit=${GIT_COMMIT}'" \
   -o bytebase ./backend/bin/server/main.go
 
-FROM alpine:3.23 AS monolithic
+FROM alpine:3.22 AS monolithic
 ARG VERSION
 ARG GIT_COMMIT
 
@@ -57,7 +57,7 @@ RUN apk add postgresql16
 
 # Install mongosh.
 RUN apk add --no-cache npm
-RUN npm install -g mongosh@2.5.0
+RUN npm install -g mongosh@2.5.8
 
 # The file indicates running in docker environment.
 RUN touch /etc/bb.env

--- a/scripts/Dockerfile.aws
+++ b/scripts/Dockerfile.aws
@@ -33,7 +33,7 @@ RUN CC=clang go build \
   -ldflags="-extldflags '-Wl,-z,stack-size=0x1000000' -w -s -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.version=${VERSION}' -X 'github.com/bytebase/bytebase/backend/bin/server/cmd.gitcommit=${GIT_COMMIT}'" \
   -o bytebase ./backend/bin/server/main.go
 
-FROM alpine:3.22 AS monolithic
+FROM alpine:3.23 AS monolithic
 ARG VERSION
 ARG GIT_COMMIT
 


### PR DESCRIPTION
## Summary
- Upgrade Alpine base images to 3.22 (corrects previous attempt to use non-existent 3.23)
- Upgrade golang base images from alpine3.21 to alpine3.22
- Upgrade pnpm from 10.17.1 to 10.18.0
- Upgrade mongosh from 2.5.0 to 2.5.8

## Note on OpenSSL CVEs
Alpine 3.23 does not exist yet. Alpine 3.22 is the latest available version but still contains OpenSSL 3.5.1-r0 with CVE-2025-9230, CVE-2025-9231, and CVE-2025-9232. These CVEs cannot be resolved until Alpine releases updated OpenSSL packages.

## Files Changed
- `scripts/Dockerfile`
- `scripts/Dockerfile.aws`
- `scripts/Dockerfile.action`

## Test plan
- [ ] Build Docker images from updated Dockerfiles
- [ ] Verify all containers start and function correctly
- [ ] Monitor for Alpine OpenSSL security updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)