### PR TITLE
feat: add status indicators to CI/CD tabs for better visibility

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseChangeView.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseChangeView.vue
@@ -76,13 +76,13 @@ import { useCurrentProjectV1, useEnvironmentV1Store } from "@/store";
 import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
 import { PlanCheckRun_Result_Status } from "@/types/proto-es/v1/plan_service_pb";
 import { extractProjectResourceName, getStageStatus } from "@/utils";
-import { usePlanContextWithIssue } from "../..";
 import { usePlanContext, usePlanCheckStatus } from "../../logic";
 import ChecksDrawer from "../ChecksView/ChecksDrawer.vue";
 import PlanCheckStatusCount from "../PlanCheckStatusCount.vue";
 
-const { issue, rollout } = usePlanContextWithIssue();
-const { plan } = usePlanContext();
+// Use usePlanContext instead of usePlanContextWithIssue to handle plan creation
+// where issue doesn't exist yet
+const { plan, rollout, issue } = usePlanContext();
 const environmentStore = useEnvironmentV1Store();
 const router = useRouter();
 const { project } = useCurrentProjectV1();
@@ -93,7 +93,7 @@ const selectedResultStatus = ref<PlanCheckRun_Result_Status | undefined>(
 );
 
 const shouldShowOverview = computed(() => {
-  return issue.value.type === Issue_Type.DATABASE_CHANGE || rollout?.value;
+  return issue.value?.type === Issue_Type.DATABASE_CHANGE || rollout?.value;
 });
 
 const getEnvironmentEntity = (environmentName: string) => {


### PR DESCRIPTION
## Summary

Add visual status indicators to Overview, Changes, and Rollout tabs to improve at-a-glance visibility of issue approval status and rollout completion.

### Changes
- **Overview & Changes tabs** display approval status icons:
  - ✅ Green checkmark when approved/ready to rollout
  - ❌ Red X when rejected
  - 🕐 Yellow clock when pending approval
  - No icon during initial checking state
- **Rollout tab** displays green checkmark when all tasks are completed

### Context
Users reported difficulty noticing whether changes were ready to rollout when viewing the Overview and Changes tabs. The rollout readiness status was only visible in a small sidebar badge, making it easy to miss.

This implementation uses tab-level indicators instead of banner content to keep the UI clean while providing immediate status visibility.

## Screenshots

### Before
Rollout status was only visible in small sidebar tag

### After
Status indicators appear directly in tab labels for immediate visibility

## Test plan
- [x] Lint and type check pass
- [ ] Test with issue in approved state - verify green checkmark appears
- [ ] Test with issue in rejected state - verify red X appears
- [ ] Test with issue in pending state - verify yellow clock appears
- [ ] Test with issue in checking state - verify no icon appears
- [ ] Test with completed rollout - verify green checkmark on Rollout tab
- [ ] Test during plan creation - verify no errors when issue doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)