### PR TITLE
feat: add GitHub-style status indicators to plan list

### DIFF
--- a/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
+++ b/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
@@ -1,31 +1,27 @@
 <template>
   <span
-    class="flex items-center justify-center rounded-full select-none overflow-hidden"
+    v-if="hasAnyChecks"
+    class="flex items-center justify-center select-none flex-shrink-0"
     :class="iconClass()"
   >
     <template v-if="planCheckRunStatus === PlanCheckRun_Result_Status.ERROR">
-      <span
-        class="h-2 w-2 rounded-full text-center pb-6 font-normal text-base"
-        aria-hidden="true"
-        >!</span
-      >
+      <XIcon />
     </template>
     <template
       v-else-if="planCheckRunStatus === PlanCheckRun_Result_Status.WARNING"
     >
-      <span
-        class="h-2 w-2 rounded-full text-center pb-6 font-normal text-base"
-        aria-hidden="true"
-        >!</span
-      >
+      <span class="text-xs font-bold" aria-hidden="true">!</span>
     </template>
     <template
       v-else-if="planCheckRunStatus === PlanCheckRun_Result_Status.SUCCESS"
     >
-      <heroicons-solid:check class="w-4 h-4" />
+      <CheckIcon />
     </template>
-    <template v-else>
-      <span class="h-3 w-3 bg-white rounded-full" aria-hidden="true"></span>
+    <template v-else-if="hasRunningChecks">
+      <span
+        class="w-1.5 h-1.5 rounded-full bg-warning animate-pulse"
+        aria-hidden="true"
+      ></span>
     </template>
   </span>
 </template>
@@ -33,6 +29,8 @@
 <script lang="ts" setup>
 import type { PropType } from "vue";
 import { computed } from "vue";
+import CheckIcon from "~icons/heroicons-solid/check";
+import XIcon from "~icons/heroicons-solid/x";
 import {
   PlanCheckRun_Result_Status,
   type Plan,
@@ -52,21 +50,23 @@ const props = defineProps({
   },
 });
 
-const { getOverallStatus: planCheckRunStatus } = usePlanCheckStatus(
-  computed(() => props.plan)
-);
+const {
+  getOverallStatus: planCheckRunStatus,
+  hasAnyStatus: hasAnyChecks,
+  hasRunning: hasRunningChecks,
+} = usePlanCheckStatus(computed(() => props.plan));
 
 const iconClass = () => {
-  const iconClass = props.size === "normal" ? "w-5 h-5" : "w-4 h-4";
+  const sizeClass = props.size === "normal" ? "w-4 h-4" : "w-3.5 h-3.5";
   switch (planCheckRunStatus.value) {
     case PlanCheckRun_Result_Status.ERROR:
-      return iconClass + " bg-error text-white";
+      return `${sizeClass} text-error`;
     case PlanCheckRun_Result_Status.WARNING:
-      return iconClass + " bg-warning text-white";
+      return `${sizeClass} text-warning`;
     case PlanCheckRun_Result_Status.SUCCESS:
-      return iconClass + " bg-success text-white";
+      return `${sizeClass} text-success`;
     default:
-      return iconClass + " bg-control text-white";
+      return `${sizeClass} text-warning`;
   }
 };
 </script>

--- a/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
+++ b/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
@@ -18,7 +18,7 @@
       <CheckIcon />
     </template>
     <template v-else-if="hasRunningChecks">
-      <ClockIcon class="animate-spin" style="animation-duration: 2s" />
+      <span class="w-2 h-2 rounded-full bg-warning" aria-hidden="true"></span>
     </template>
   </span>
 </template>
@@ -28,7 +28,6 @@ import type { PropType } from "vue";
 import { computed } from "vue";
 import CheckIcon from "~icons/heroicons-solid/check";
 import XIcon from "~icons/heroicons-solid/x";
-import ClockIcon from "~icons/heroicons-outline/clock";
 import {
   PlanCheckRun_Result_Status,
   type Plan,

--- a/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
+++ b/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
@@ -18,10 +18,7 @@
       <CheckIcon />
     </template>
     <template v-else-if="hasRunningChecks">
-      <span
-        class="w-1.5 h-1.5 rounded-full bg-warning animate-pulse"
-        aria-hidden="true"
-      ></span>
+      <ClockIcon class="animate-spin" style="animation-duration: 2s" />
     </template>
   </span>
 </template>
@@ -31,6 +28,7 @@ import type { PropType } from "vue";
 import { computed } from "vue";
 import CheckIcon from "~icons/heroicons-solid/check";
 import XIcon from "~icons/heroicons-solid/x";
+import ClockIcon from "~icons/heroicons-outline/clock";
 import {
   PlanCheckRun_Result_Status,
   type Plan,

--- a/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
+++ b/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
@@ -18,7 +18,7 @@
       <CheckIcon />
     </template>
     <template v-else-if="hasRunningChecks">
-      <span class="w-2 h-2 rounded-full bg-warning" aria-hidden="true"></span>
+      <span class="w-2 h-2 rounded-full bg-control" aria-hidden="true"></span>
     </template>
   </span>
 </template>

--- a/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
+++ b/frontend/src/components/Plan/components/PlanCheckRunStatusIcon.vue
@@ -18,7 +18,10 @@
       <CheckIcon />
     </template>
     <template v-else-if="hasRunningChecks">
-      <span class="w-2 h-2 rounded-full bg-control" aria-hidden="true"></span>
+      <span
+        class="w-2.5 h-2.5 rounded-full border-2 border-control"
+        aria-hidden="true"
+      ></span>
     </template>
   </span>
 </template>

--- a/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
+++ b/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
@@ -18,6 +18,7 @@ import { NPerformantEllipsis, NDataTable, NTag } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
+import PencilIcon from "~icons/heroicons-outline/pencil";
 import { BBAvatar } from "@/bbkit";
 import Timestamp from "@/components/misc/Timestamp.vue";
 import { useIssueLayoutVersion } from "@/composables/useIssueLayoutVersion";
@@ -45,10 +46,24 @@ const { enabledNewLayout } = useIssueLayoutVersion();
 const columnList = computed((): DataTableColumn<Plan>[] => {
   const columns: (DataTableColumn<Plan> & { hide?: boolean })[] = [
     {
-      key: "status",
+      key: "state-icon",
       title: "",
-      width: "36px",
-      render: (plan) => <PlanCheckRunStatusIcon plan={plan} />,
+      width: "24px",
+      render: (plan) => {
+        const showDraftIcon =
+          enabledNewLayout.value && plan.issue === "" && plan.rollout === "";
+        if (!showDraftIcon || plan.state === State.DELETED) {
+          return null;
+        }
+        return (
+          <span
+            class="flex items-center justify-center w-4 h-4 rounded-full border border-control-border text-control opacity-60"
+            title={t("common.draft")}
+          >
+            <PencilIcon class="w-3 h-3" />
+          </span>
+        );
+      },
     },
     {
       key: "title",
@@ -79,6 +94,7 @@ const columnList = computed((): DataTableColumn<Plan>[] => {
             ) : (
               <span class="opacity-60 italic">{t("common.untitled")}</span>
             )}
+            <PlanCheckRunStatusIcon plan={plan} size="small" />
             {isDeleted && (
               <NTag type="warning" round size="small">
                 {t("common.closed")}


### PR DESCRIPTION
## Summary

Implements GitHub PR dashboard pattern for better plan status visibility in the plan list view.

### Changes
- **Left icon**: Shows draft state with pencil icon (only displayed for draft plans)
- **Right icon**: Moved check status from left column to inline position after plan title
- **Visual improvements**: Smaller, more subtle icons matching GitHub's minimalist style
- **Smart hiding**: Check status icon only appears when checks exist, reducing visual clutter

### Status Indicators
- ✅ Green check: All checks passed
- ❌ Red X: Checks failed  
- ⚠️ Yellow !: Warnings detected
- ⭕ Outlined circle: Checks running

### Design Rationale

Following GitHub's PR list pattern:
- **Left icon** = Document/plan state (draft vs active)
- **Right icon** = CI check status
- No green checkmarks for plan state to avoid confusion with check status
- Draft plans clearly marked without being visually overwhelming

### Screenshots

Before: Green checkmark on left was confusing (looked like plan was complete)
After: Clear draft indicator on left, check status on right (matches GitHub UX)

## Test plan
- [x] Lint passed
- [x] Type check passed
- [ ] Manual testing: Verify draft plans show pencil icon
- [ ] Manual testing: Verify check status appears after plan title
- [ ] Manual testing: Verify icons look good at different zoom levels
- [ ] Manual testing: Verify no layout shifts when icons appear/disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)