### PR TITLE
fix: remove creator filter from plan dashboard default view

### DIFF
--- a/frontend/src/views/project/ProjectPlanDashboard.vue
+++ b/frontend/src/views/project/ProjectPlanDashboard.vue
@@ -117,10 +117,6 @@ const defaultSearchParams = () => {
         id: "state",
         value: "ACTIVE",
       },
-      {
-        id: "creator",
-        value: me.value.email,
-      },
     ],
   };
   return params;


### PR DESCRIPTION
## Summary
- Remove default creator filter from plan dashboard to show all plans in the project
- Align behavior with GitHub PR dashboard which shows all PRs by default
- Users can still filter by creator using the advanced search functionality

## Before
Plan dashboard filtered to only show plans created by the current user (`creator: d@bytebase.com`)

## After  
Plan dashboard shows all active plans in the project by default

## Test plan
- [ ] Navigate to plan dashboard and verify all plans in the project are shown
- [ ] Verify creator filter still works when manually applied via advanced search
- [ ] Verify state filter (Active/Closed) continues to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)