### PR TITLE
fix: use mongosh binary installation for multi-arch Docker builds

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -56,8 +56,21 @@ RUN apk add postgresql16
 #RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
 
 # Install mongosh.
-RUN apk add --no-cache npm
-RUN npm install -g mongosh@2.5.8
+# Alpine's nodejs package may be too old, so we download mongosh binary directly
+RUN apk add --no-cache curl
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        MONGOSH_ARCH="x64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        MONGOSH_ARCH="arm64"; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    curl -L https://downloads.mongodb.com/compass/mongosh-2.5.8-linux-${MONGOSH_ARCH}.tgz -o /tmp/mongosh.tgz && \
+    tar -xzf /tmp/mongosh.tgz -C /tmp && \
+    mv /tmp/mongosh-2.5.8-linux-${MONGOSH_ARCH}/bin/mongosh /usr/local/bin/ && \
+    mv /tmp/mongosh-2.5.8-linux-${MONGOSH_ARCH}/bin/mongosh_crypt_v1.so /usr/local/lib/ && \
+    rm -rf /tmp/mongosh*
 
 # The file indicates running in docker environment.
 RUN touch /etc/bb.env


### PR DESCRIPTION
## Summary
- Replace npm-based mongosh@2.5.8 installation with direct binary download
- Add architecture detection to support both x64 and arm64 builds
- Fix Docker build failures caused by npm installation timeouts

## Problem
The previous approach using `npm install -g mongosh@2.5.8` was failing because:
- mongosh is a large npm package that times out during Docker builds
- Version 2.5.8 appears to have increased size/complexity compared to earlier versions
- npm installation is slower and less reliable than binary installation

## Solution
- Download pre-built mongosh binaries directly from MongoDB's official downloads
- Detect architecture (`x86_64` → `x64`, `aarch64` → `arm64`) at build time
- Extract and install binaries to system paths

## Test plan
- [ ] Build Docker image for x64 architecture
- [ ] Build Docker image for arm64 architecture
- [ ] Verify mongosh runs correctly in both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)