### PR TITLE
chore: remove unused draft icon column in PlanDataTable

### DIFF
--- a/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
+++ b/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
@@ -18,7 +18,6 @@ import { NPerformantEllipsis, NDataTable, NTag } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
-import PencilIcon from "~icons/heroicons-outline/pencil";
 import { BBAvatar } from "@/bbkit";
 import Timestamp from "@/components/misc/Timestamp.vue";
 import { useIssueLayoutVersion } from "@/composables/useIssueLayoutVersion";
@@ -45,26 +44,6 @@ const { enabledNewLayout } = useIssueLayoutVersion();
 
 const columnList = computed((): DataTableColumn<Plan>[] => {
   const columns: (DataTableColumn<Plan> & { hide?: boolean })[] = [
-    {
-      key: "state-icon",
-      title: "",
-      width: "24px",
-      render: (plan) => {
-        const showDraftIcon =
-          enabledNewLayout.value && plan.issue === "" && plan.rollout === "";
-        if (!showDraftIcon || plan.state === State.DELETED) {
-          return null;
-        }
-        return (
-          <span
-            class="flex items-center justify-center w-4 h-4 rounded-full border border-control-border text-control opacity-60"
-            title={t("common.draft")}
-          >
-            <PencilIcon class="w-3 h-3" />
-          </span>
-        );
-      },
-    },
     {
       key: "title",
       title: t("issue.table.name"),


### PR DESCRIPTION
Remove the state-icon column as the draft state is now displayed using a tag instead of an icon.
