### PR TITLE
feat: add rollout ready banner in CICD layout

### DIFF
--- a/frontend/src/views/project/CICDLayout.vue
+++ b/frontend/src/views/project/CICDLayout.vue
@@ -4,20 +4,36 @@
       <PollerProvider>
         <div class="h-full flex flex-col">
           <!-- Banner Section -->
-          <div v-if="showBanner" class="banner-section">
+          <template v-if="showBanner">
             <div
               v-if="showClosedBanner"
-              class="h-8 w-full text-base font-medium bg-gray-400 text-white flex justify-center items-center"
+              class="h-8 w-full text-base font-medium bg-gray-400 text-white flex justify-center items-center shrink-0"
             >
               {{ $t("common.closed") }}
             </div>
             <div
               v-else-if="showSuccessBanner"
-              class="h-8 w-full text-base font-medium bg-success text-white flex justify-center items-center"
+              class="h-8 w-full text-base font-medium bg-success text-white flex justify-center items-center shrink-0"
             >
               {{ $t("common.done") }}
             </div>
-          </div>
+            <div
+              v-else-if="showReadyForRollout"
+              class="h-8 w-full text-base font-medium bg-accent text-white flex justify-center items-center shrink-0"
+            >
+              <NButton
+                text
+                class="!text-white hover:opacity-80"
+                :icon-placement="'right'"
+                @click="goToRollout"
+              >
+                {{ $t("issue.approval.approved-and-waiting-for-rollout") }}
+                <template #icon>
+                  <ArrowRightIcon class="w-4 h-4" />
+                </template>
+              </NButton>
+            </div>
+          </template>
 
           <HeaderSection />
 
@@ -60,14 +76,12 @@
 <script lang="tsx" setup>
 import { useTitle } from "@vueuse/core";
 import {
+  ArrowRightIcon,
   CirclePlayIcon,
   FileDiffIcon,
   Layers2Icon,
-  CheckCircle2Icon,
-  XCircleIcon,
-  ClockIcon,
 } from "lucide-vue-next";
-import { NSpin, NTab, NTabs, NTag } from "naive-ui";
+import { NButton, NSpin, NTab, NTabs, NTag } from "naive-ui";
 import { computed, ref, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import {
@@ -105,6 +119,7 @@ import {
 } from "@/types/proto-es/v1/issue_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import {
+  activeTaskInRollout,
   extractIssueUID,
   extractPlanUID,
   extractProjectResourceName,
@@ -248,99 +263,13 @@ const availableTabs = computed<TabKey[]>(() => {
   return tabs;
 });
 
-const approvalStatusInfo = computed(() => {
-  if (!issue.value) return null;
-
-  const approvalStatus = issue.value.approvalStatus;
-
-  // Approved or skipped - ready to rollout
-  if (
-    approvalStatus === Issue_ApprovalStatus.APPROVED ||
-    approvalStatus === Issue_ApprovalStatus.SKIPPED
-  ) {
-    return {
-      icon: CheckCircle2Icon,
-      class: "text-success",
-      ariaLabel: t("issue.approval.approved-and-waiting-for-rollout"),
-    };
-  }
-
-  // Rejected
-  if (approvalStatus === Issue_ApprovalStatus.REJECTED) {
-    return {
-      icon: XCircleIcon,
-      class: "text-error",
-      ariaLabel: t("issue.approval.rejected-error"),
-    };
-  }
-
-  // Pending
-  if (approvalStatus === Issue_ApprovalStatus.PENDING) {
-    return {
-      icon: ClockIcon,
-      class: "text-warning",
-      ariaLabel: t("issue.approval.pending-error"),
-    };
-  }
-
-  // Checking state - no indicator
-  return null;
-});
-
-const rolloutStatusInfo = computed(() => {
-  if (!rollout.value || rollout.value.stages.length === 0) return null;
-
-  // Collect all tasks from all stages
-  const allTasks = rollout.value.stages.flatMap((stage) => stage.tasks);
-
-  // No tasks means no status to show
-  if (allTasks.length === 0) return null;
-
-  // Check for failed or canceled tasks
-  const anyFailed = allTasks.some(
-    (task) =>
-      task.status === Task_Status.FAILED || task.status === Task_Status.CANCELED
-  );
-  if (anyFailed) {
-    return {
-      icon: XCircleIcon,
-      class: "text-error",
-    };
-  }
-
-  // Check if all tasks are done
-  const allDone = allTasks.every((task) => task.status === Task_Status.DONE);
-  if (allDone) {
-    return {
-      icon: CheckCircle2Icon,
-      class: "text-success",
-    };
-  }
-
-  // Tasks are still in progress - no indicator
-  return null;
-});
-
 const tabRender = (tab: TabKey) => {
-  const approvalStatusIcon = approvalStatusInfo.value?.icon;
-  const approvalStatusClass = approvalStatusInfo.value?.class;
-  const approvalStatusAriaLabel = approvalStatusInfo.value?.ariaLabel;
-  const rolloutStatusIcon = rolloutStatusInfo.value?.icon;
-  const rolloutStatusClass = rolloutStatusInfo.value?.class;
-
   switch (tab) {
     case TabKey.Issue:
       return (
         <div class="flex items-center gap-2">
           <Layers2Icon size={18} />
           <span>{t("common.overview")}</span>
-          {approvalStatusIcon && (
-            <approvalStatusIcon
-              size={16}
-              class={approvalStatusClass}
-              aria-label={approvalStatusAriaLabel}
-            />
-          )}
         </div>
       );
     case TabKey.Plan:
@@ -353,13 +282,6 @@ const tabRender = (tab: TabKey) => {
               {plan.value.specs.length}
             </NTag>
           )}
-          {!isCreating.value && approvalStatusIcon && (
-            <approvalStatusIcon
-              size={16}
-              class={approvalStatusClass}
-              aria-label={approvalStatusAriaLabel}
-            />
-          )}
         </div>
       );
     case TabKey.Rollout:
@@ -367,9 +289,6 @@ const tabRender = (tab: TabKey) => {
         <div class="flex items-center gap-2">
           <CirclePlayIcon size={18} />
           <span>{t("plan.navigator.rollout")}</span>
-          {rolloutStatusIcon && (
-            <rolloutStatusIcon size={16} class={rolloutStatusClass} />
-          )}
         </div>
       );
     default:
@@ -452,9 +371,53 @@ const showSuccessBanner = computed(() => {
   return issue.value && issue.value.status === IssueStatus.DONE;
 });
 
-const showBanner = computed(() => {
-  return showClosedBanner.value || showSuccessBanner.value;
+const showReadyForRollout = computed(() => {
+  // Only show for OPEN issues
+  if (!issue.value || issue.value.status !== IssueStatus.OPEN) return false;
+
+  // Check if issue is approved
+  if (
+    issue.value.approvalStatus !== Issue_ApprovalStatus.APPROVED &&
+    issue.value.approvalStatus !== Issue_ApprovalStatus.SKIPPED
+  ) {
+    return false;
+  }
+
+  // Hide if on rollout tab
+  if (tabKey.value === TabKey.Rollout) {
+    return false;
+  }
+
+  // Check if there's an active task that needs action
+  const activeTask = activeTaskInRollout(rollout.value);
+  return (
+    activeTask.status === Task_Status.NOT_STARTED ||
+    activeTask.status === Task_Status.PENDING ||
+    activeTask.status === Task_Status.RUNNING ||
+    activeTask.status === Task_Status.FAILED ||
+    activeTask.status === Task_Status.CANCELED
+  );
 });
+
+const showBanner = computed(() => {
+  return (
+    showClosedBanner.value ||
+    showSuccessBanner.value ||
+    showReadyForRollout.value
+  );
+});
+
+const goToRollout = () => {
+  if (!rollout.value) return;
+
+  router.push({
+    name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
+    params: {
+      projectId: extractProjectResourceName(plan.value.name),
+      rolloutId: extractRolloutUID(rollout.value.name),
+    },
+  });
+};
 
 useTitle(documentTitle);
 


### PR DESCRIPTION
Close BYT-8190

<img width="2272" height="1092" alt="image" src="https://github.com/user-attachments/assets/19dcd738-56f1-44b4-9cbe-f6bdbe658832" />

Add a banner notification in the new CICD layout to inform users when an issue is approved and ready for rollout. The banner:

- Shows when issue is OPEN and approved/skipped
- Shows when there are active tasks that can be rolled out
- Hides automatically when on rollout tab
- Provides a button to navigate to rollout page

Also removes approval/rollout status icons from tabs to reduce visual clutter.