### PR TITLE
chore: cleanup WORKSPACE level IAM policies

### DIFF
--- a/backend/migrator/migration/3.11/0007##cleanup_workspace_iam_policy.sql
+++ b/backend/migrator/migration/3.11/0007##cleanup_workspace_iam_policy.sql
@@ -1,0 +1,120 @@
+-- Cleanup WORKSPACE level IAM policies
+--
+-- This migration performs two cleanup operations on WORKSPACE level IAM policies:
+-- 1. Remove projectExporter role and merge row_limit condition into sqlEditorUser role
+-- 2. Remove request.row_limit from IAM policy condition expressions
+--
+-- Background:
+-- The projectExporter role was removed at PROJECT level in migration 3.10/0007, but WORKSPACE
+-- level policies were not handled at that time. Similarly, request.row_limit conditions were
+-- cleaned up at PROJECT level in migration 3.11/0006, but WORKSPACE level was not handled.
+
+-- Step 1: Remove projectExporter role and merge row_limit condition into sqlEditorUser role
+WITH exporter_data AS (
+    -- Collect all projectExporter members and their row_limit conditions
+    SELECT
+        p.id,
+        m.member,
+        substring(b.binding->'condition'->>'expression' from 'request\.row_limit\s*<=\s*\d+') as row_limit
+    FROM policy p,
+        jsonb_array_elements(p.payload->'bindings') b(binding),
+        jsonb_array_elements_text(b.binding->'members') m(member)
+    WHERE p.resource_type = 'WORKSPACE'
+        AND p.type = 'IAM'
+        AND b.binding->>'role' = 'roles/projectExporter'
+        AND b.binding->'condition'->>'expression' ~ 'request\.row_limit\s*<=\s*\d+'
+)
+UPDATE policy p
+SET payload = jsonb_set(
+    p.payload,
+    '{bindings}',
+    (
+        SELECT jsonb_agg(
+            CASE
+                -- Update sqlEditorUser bindings with row_limit if member exists in exporter_data
+                WHEN b.binding->>'role' = 'roles/sqlEditorUser' AND EXISTS (
+                    SELECT 1 FROM exporter_data ed
+                    WHERE ed.id = p.id
+                        AND ed.member IN (SELECT jsonb_array_elements_text(b.binding->'members'))
+                ) THEN
+                    jsonb_set(
+                        b.binding,
+                        '{condition,expression}',
+                        to_jsonb(
+                            COALESCE(b.binding->'condition'->>'expression', '') ||
+                            CASE
+                                WHEN b.binding->'condition'->>'expression' IS NOT NULL THEN ' && '
+                                ELSE ''
+                            END ||
+                            (SELECT ed.row_limit FROM exporter_data ed
+                             WHERE ed.id = p.id
+                                AND ed.member IN (SELECT jsonb_array_elements_text(b.binding->'members'))
+                             LIMIT 1)
+                        )
+                    )
+                -- Keep all other non-projectExporter bindings unchanged
+                ELSE b.binding
+            END
+        )
+        FROM jsonb_array_elements(p.payload->'bindings') b(binding)
+        WHERE b.binding->>'role' != 'roles/projectExporter'
+    )
+)
+WHERE p.resource_type = 'WORKSPACE'
+    AND p.type = 'IAM'
+    AND EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(p.payload->'bindings') b(binding)
+        WHERE b.binding->>'role' = 'roles/projectExporter'
+    );
+
+-- Step 2: Remove request.row_limit from IAM policy condition expressions
+UPDATE policy
+SET payload = (
+    SELECT jsonb_set(
+        payload,
+        '{bindings}',
+        (
+            SELECT jsonb_agg(
+                CASE
+                    -- Only update bindings for sqlEditorUser role that have conditions with request.row_limit
+                    WHEN binding->>'role' = 'roles/sqlEditorUser'
+                         AND binding->'condition'->>'expression' IS NOT NULL
+                         AND binding->'condition'->>'expression' LIKE '%request.row_limit%'
+                    THEN jsonb_set(
+                        binding,
+                        '{condition,expression}',
+                        to_jsonb(
+                            -- Remove " && request.row_limit <operator> <number>" pattern
+                            regexp_replace(
+                                -- Remove "request.row_limit <operator> <number> && " pattern
+                                regexp_replace(
+                                    binding->'condition'->>'expression',
+                                    'request\.row_limit\s*(<=|>=|<|>|==|!=)\s*\d+\s*&&\s*',
+                                    '',
+                                    'g'
+                                ),
+                                '\s*&&\s*request\.row_limit\s*(<=|>=|<|>|==|!=)\s*\d+',
+                                '',
+                                'g'
+                            )
+                        )
+                    )
+                    ELSE binding
+                END
+            )
+            FROM jsonb_array_elements(payload->'bindings') AS binding
+        )
+    )
+    FROM policy p2
+    WHERE p2.id = policy.id
+)
+WHERE type = 'IAM'
+  AND resource_type = 'WORKSPACE'
+  AND payload->'bindings' IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(payload->'bindings') AS binding
+    WHERE binding->>'role' = 'roles/sqlEditorUser'
+      AND binding->'condition'->>'expression' LIKE '%request.row_limit%'
+  );

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.11.6"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.11.7"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
## Summary

This migration performs IAM policy cleanup at the WORKSPACE level, completing the cleanup operations that were previously done for PROJECT level policies.

## Changes

- **New migration**: `backend/migrator/migration/3.11/0007##cleanup_workspace_iam_policy.sql`
  - Step 1: Remove `projectExporter` role and merge row_limit conditions into `sqlEditorUser` role (mirrors 3.10/0007 for WORKSPACE)
  - Step 2: Remove `request.row_limit` from IAM policy condition expressions (mirrors 3.11/0006 for WORKSPACE)
- **Test update**: Updated `backend/migrator/migrator_test.go` from version 3.11.6 to 3.11.7

## Background

The `projectExporter` role was removed at PROJECT level in migration 3.10/0007, and `request.row_limit` conditions were cleaned up at PROJECT level in migration 3.11/0006, but WORKSPACE level policies were not handled in those migrations. This PR completes the cleanup for WORKSPACE level.

## Migration Logic

Both steps follow the exact same SQL patterns as their PROJECT-level counterparts:

1. **Step 1** collects all `projectExporter` members with row_limit conditions and merges them into `sqlEditorUser` bindings for the same members, then removes all `projectExporter` bindings
2. **Step 2** removes `request.row_limit` patterns from condition expressions using regex replacement

If there's no corresponding `sqlEditorUser` binding to merge into, the `projectExporter` binding is simply removed (same behavior as PROJECT-level migration).

## Test plan

- [x] `TestLatestVersion` passes
- [x] `TestVersionUnique` passes
- [ ] Test on staging environment with real WORKSPACE policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)