### PR TITLE
fix: task section layout in rollout drawer

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
@@ -7,7 +7,7 @@
     @close="$emit('close')"
   >
     <template #default>
-      <div class="flex flex-col gap-y-4 h-full overflow-y-hidden px-1">
+      <div class="flex flex-col gap-y-4 h-full px-1">
         <!-- Error Alert -->
         <NAlert
           v-if="validationErrors.length > 0"
@@ -67,10 +67,7 @@
         </div>
 
         <!-- Task information -->
-        <div
-          v-if="shouldShowTaskInfo"
-          class="flex flex-col gap-y-1 shrink overflow-y-hidden justify-start"
-        >
+        <div v-if="shouldShowTaskInfo" class="flex flex-col gap-y-1 shrink-0">
           <div class="flex items-center justify-between">
             <label class="text-control">
               <span class="font-medium">{{
@@ -88,7 +85,7 @@
               </span>
             </label>
           </div>
-          <div class="flex-1 overflow-y-auto">
+          <div>
             <template v-if="useVirtualScroll">
               <NVirtualList
                 :items="eligibleTasks"


### PR DESCRIPTION
Close BYT-8197. Fixed task section being compressed abnormally and not scrollable by removing overflow-y-hidden and flex-1 classes that prevented proper scrolling behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)