### PR TITLE
fix: resolve WORKSPACE_APPROVAL migration failures

### DIFF
--- a/backend/migrator/migration/3.7/0001##approval_template_creator.sql
+++ b/backend/migrator/migration/3.7/0001##approval_template_creator.sql
@@ -1,15 +1,20 @@
-UPDATE setting 
+UPDATE setting
 SET value = (
     SELECT jsonb_build_object(
-        'rules', 
-        jsonb_agg(
-            jsonb_set(
-                rule::jsonb,
-                '{template}',
-                (rule->'template')::jsonb - 'creatorId'
-            )
+        'rules',
+        COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_set(
+                        rule::jsonb,
+                        '{template}',
+                        (rule->'template')::jsonb - 'creatorId'
+                    )
+                )
+                FROM jsonb_array_elements(value::jsonb->'rules') AS rule
+            ),
+            '[]'::jsonb
         )
     )
-    FROM jsonb_array_elements(value::jsonb->'rules') AS rule
 )
 WHERE name = 'bb.workspace.approval';


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs causing upgrade failures for users migrating to version 3.11:

### Bug 1: Null Rules (`{"rules": null}`)

**Root Cause**: PostgreSQL's `jsonb_agg()` returns `NULL` when aggregating zero rows, not an empty array.

**Impact**: Users with empty approval rules arrays ended up with corrupted settings: `{"rules": null}`

**Fix**:
- `3.7/0001`: Wrapped `jsonb_agg()` with `COALESCE(..., '[]'::jsonb)` to prevent new corrupted data
- `3.11/0008`: Added cleanup statement to remove null rules field from existing corrupted data

### Bug 2: "Cannot extract elements from a scalar"

**Root Cause**: `jsonb_array_elements()` fails when called on scalar values (strings, numbers) instead of arrays.

**Impact**: Users with malformed data (e.g., `"steps": "scalar_value"`) got SQL error: `ERROR: cannot extract elements from a scalar (SQLSTATE 22023)`

**Fix**:
- Added `jsonb_typeof(...) = 'array'` checks before all `jsonb_array_elements()` calls
- Validates data structure before processing to handle edge cases gracefully

## Changes

### `backend/migrator/migration/3.7/0001##approval_template_creator.sql`
- Wrapped `jsonb_agg()` with `COALESCE()` to return `[]` instead of `NULL` for empty results

### `backend/migrator/migration/3.11/0008##migrate_approval_flow.sql`
- Added cleanup statement at the beginning to fix existing corrupted settings
- Added defensive `jsonb_typeof()` checks to prevent scalar extraction errors
- Added checks for both `setting` table (workspace approval) and `issue` table (issue approval templates)

## Test Plan

- [x] Tested null rules cleanup: `{"rules": null}` → `{}`
- [x] Tested scalar value handling: queries skip malformed data without errors
- [x] Tested COALESCE fix: empty rules array returns `[]` not `NULL`
- [x] Verified backwards compatibility: valid data migrates correctly

## User Impact

This fix resolves the upgrade failures reported by users:
- ✅ Fixes "migration 3.11.8 failed: cannot extract elements from a scalar"
- ✅ Fixes corrupted `WORKSPACE_APPROVAL` settings with null rules
- ✅ Allows successful upgrades from 3.7+ to 3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)