### PR TITLE
feat: print version and commit hash early in startup

### DIFF
--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -165,6 +165,8 @@ func start() {
 
 	profile := activeProfile(flags.dataDir)
 
+	fmt.Printf("Starting Bytebase %s(%s)...\n", profile.Version, profile.GitCommit)
+
 	// A safety measure to prevent accidentally resetting user's actual data with demo data.
 	// For emebeded mode, we control where data is stored and we put demo data in a separate directory
 	// from the non-demo data.


### PR DESCRIPTION
## Summary
- Display version and git commit information at the beginning of the startup process, before server initialization
- Users can now see version information immediately when Bytebase starts, rather than waiting for full server initialization

## Changes
The startup output sequence is now:
1. `Starting Bytebase X.X.X(commit)...` - printed early in the process
2. Full ASCII banner with "has started on port X" - printed after successful initialization

## Test plan
- [ ] Build and run Bytebase locally
- [ ] Verify version and commit are displayed immediately on startup
- [ ] Verify the greeting banner still displays after server initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)