### PR TITLE
chore: remove Aliyun registry tagging from docker-tag-latest workflow

### DIFF
--- a/.github/workflows/docker-tag-latest.yml
+++ b/.github/workflows/docker-tag-latest.yml
@@ -19,19 +19,3 @@ jobs:
           docker buildx imagetools create -t bytebase/bytebase:latest bytebase/bytebase:${RELEASE_VERSION}
           docker buildx imagetools create -t bytebase/bytebase-action:latest bytebase/bytebase-action:${RELEASE_VERSION}
           docker buildx imagetools create -t bytebase/bytebase-action:latest-debian bytebase/bytebase-action:${RELEASE_VERSION}-debian
-      - name: Login to Aliyun Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: registry.cn-shanghai.aliyuncs.com
-          username: ${{ secrets.ALIYUN_USERNAME }}
-          password: ${{ secrets.ALIYUN_PASSWORD }}
-      - name: Tag latest image in Aliyun Container Registry
-        run: |
-          RELEASE_VERSION=${GITHUB_REF_NAME#release/}
-          echo version: ${RELEASE_VERSION}
-          docker buildx imagetools create -t registry.cn-shanghai.aliyuncs.com/bytebase/bytebase:latest bytebase/bytebase:${RELEASE_VERSION}
-          docker buildx imagetools create -t registry.cn-shanghai.aliyuncs.com/bytebase/bytebase:${RELEASE_VERSION} bytebase/bytebase:${RELEASE_VERSION}
-          docker buildx imagetools create -t registry.cn-shanghai.aliyuncs.com/bytebase/bytebase-action:${RELEASE_VERSION} bytebase/bytebase-action:${RELEASE_VERSION}
-          docker buildx imagetools create -t registry.cn-shanghai.aliyuncs.com/bytebase/bytebase-action:${RELEASE_VERSION}-debian bytebase/bytebase-action:${RELEASE_VERSION}-debian
-          docker buildx imagetools create -t registry.cn-shanghai.aliyuncs.com/bytebase/bytebase-action:latest bytebase/bytebase-action:${RELEASE_VERSION}
-          docker buildx imagetools create -t registry.cn-shanghai.aliyuncs.com/bytebase/bytebase-action:latest-debian bytebase/bytebase-action:${RELEASE_VERSION}-debian


### PR DESCRIPTION
## Summary
- Remove Aliyun Container Registry login and tagging steps from the `docker-tag-latest` workflow
- Keeps only DockerHub tagging to improve workflow performance

## Motivation
The Aliyun registry tagging step has been experiencing severe performance issues causing the workflow to take an excessive amount of time to complete. See https://github.com/bytebase/bytebase/actions/runs/18432477347

## Test plan
- [ ] Verify the workflow runs successfully without Aliyun steps
- [ ] Confirm DockerHub tagging still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)