### PR TITLE
fix: remove \restrict command from demo data dump

### DIFF
--- a/backend/demo/data/dump.sql
+++ b/backend/demo/data/dump.sql
@@ -2,8 +2,6 @@
 -- PostgreSQL database dump
 --
 
-\restrict uQwlm8d2TDQFk78h5V1ggn4GYM3YjpU9IYPF3SjUMjaQniDS2TDDpGeD3r8Xv5A
-
 -- Dumped from database version 16.10 (Homebrew)
 -- Dumped by pg_dump version 16.10 (Homebrew)
 
@@ -5873,6 +5871,3 @@ ALTER TABLE ONLY public.worksheet
 --
 -- PostgreSQL database dump complete
 --
-
-\unrestrict uQwlm8d2TDQFk78h5V1ggn4GYM3YjpU9IYPF3SjUMjaQniDS2TDDpGeD3r8Xv5A
-


### PR DESCRIPTION
## Summary

- Removes the `\restrict` command from the demo data dump file that was preventing the demo server from starting
- The `\restrict` command requires a specific password/token to restore the dump, which breaks demo server initialization

## Root Cause

Commit b215db11e9748886b2f2a1d7ee436f075fabe5f4 accidentally included a `\restrict uQwlm8d2TDQFk78h5V1ggn4GYM3YjpU9IYPF3SjUMjaQniDS2TDDpGeD3r8Xv5A` line in the demo data dump file when updating the demo data.

## Test plan

- [ ] Verify demo server can start successfully with the updated dump file
- [ ] Confirm demo data loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)