### PR TITLE
fix: prevent flickering during CICD tab navigation

### DIFF
--- a/frontend/src/components/Plan/logic/initialize/index.ts
+++ b/frontend/src/components/Plan/logic/initialize/index.ts
@@ -15,7 +15,12 @@ import type { Plan, PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import { GetRolloutRequestSchema } from "@/types/proto-es/v1/rollout_service_pb";
 import type { Rollout, TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
 import { emptyPlan } from "@/types/v1/issue/plan";
-import { issueV1Slug } from "@/utils";
+import {
+  extractIssueUID,
+  extractPlanUID,
+  extractRolloutUID,
+  issueV1Slug,
+} from "@/utils";
 import { createPlanSkeleton } from "./create";
 
 export * from "./create";
@@ -195,6 +200,30 @@ export function useInitializePlan(
         return;
       }
       const url = route.fullPath;
+
+      // Check if we're navigating between tabs of the same plan/issue/rollout
+      // If data is already loaded, skip the refetch entirely to prevent flickering
+      const currentPlanName = plan.value.name;
+      const currentPlanUid = extractPlanUID(currentPlanName);
+
+      const isTabNavigation =
+        currentPlanName &&
+        (uid === currentPlanUid || // Direct plan tab navigation
+          (uid.startsWith("issue:") &&
+            plan.value.issue &&
+            uid.substring(6) === extractIssueUID(plan.value.issue)) || // Issue tab navigation
+          (uid.startsWith("rollout:") &&
+            plan.value.rollout &&
+            uid.substring(8) === extractRolloutUID(plan.value.rollout))); // Rollout tab navigation
+
+      // If we're just switching tabs within the same plan/issue/rollout, skip refetch
+      if (isTabNavigation) {
+        // Mark as not initializing to ensure UI is ready
+        isInitializing.value = false;
+        return;
+      }
+
+      // Otherwise, perform the full fetch with loading state
       isInitializing.value = true;
 
       try {

--- a/frontend/src/views/project/CICDLayout.vue
+++ b/frontend/src/views/project/CICDLayout.vue
@@ -62,7 +62,9 @@
           </NTabs>
 
           <div class="flex-1 flex">
-            <router-view />
+            <KeepAlive>
+              <router-view />
+            </KeepAlive>
           </div>
         </div>
       </PollerProvider>
@@ -162,10 +164,12 @@ const planBaseContext = useBasePlanContext({
 });
 const { enabledNewLayout } = useIssueLayoutVersion();
 const isLoading = ref(true);
+const isInitialLoad = ref(true);
 const containerRef = ref<HTMLElement>();
 
 const ready = computed(() => {
-  return !isInitializing.value && !!plan.value && !isLoading.value;
+  // Only show loading spinner during initial load, not during tab navigation
+  return !isInitialLoad.value && !!plan.value;
 });
 
 const shouldShowNavigation = computed(() => {
@@ -201,6 +205,11 @@ watch(
       return;
     }
 
+    // Mark initial load as complete once data is loaded
+    if (isInitialLoad.value) {
+      isInitialLoad.value = false;
+    }
+
     // Redirect all non-changeDatabaseConfig plans to the legacy issue page.
     // Including export data plans.
     if (
@@ -223,8 +232,7 @@ watch(
     } else {
       isLoading.value = false;
     }
-  },
-  { once: true }
+  }
 );
 
 const tabKey = computed(() => {


### PR DESCRIPTION
Skip unnecessary data refetch when switching between Plan/Issue/Rollout tabs. Add KeepAlive to cache route components and track initial load state separately to prevent loading spinner from showing during tab navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)