### PR TITLE
fix: data not initialized

### DIFF
--- a/frontend/src/views/project/CICDLayout.vue
+++ b/frontend/src/views/project/CICDLayout.vue
@@ -62,9 +62,11 @@
           </NTabs>
 
           <div class="flex-1 flex">
-            <KeepAlive>
-              <router-view />
-            </KeepAlive>
+            <router-view v-slot="{ Component }">
+              <keep-alive>
+                <component :is="Component" />
+              </keep-alive>
+            </router-view>
           </div>
         </div>
       </PollerProvider>
@@ -170,7 +172,7 @@ const containerRef = ref<HTMLElement>();
 
 const ready = computed(() => {
   // Only show loading spinner during initial load, not during tab navigation
-  return !isInitialLoad.value && !!plan.value;
+  return !isInitialLoad.value && !!plan.value && !isInitializing.value;
 });
 
 const shouldShowNavigation = computed(() => {


### PR DESCRIPTION
- Fix UI broken (issue is not initialized) error

```
In IssueDetailV1View.vue:43:18: Issue is required but not available in plan context at
usePlanContextWithIssue (context.ts:55:11)
```

- Fix component warning

```
main.ts:1 [Vue Router warn]: <router-view> can no longer be used directly inside <transition> or <keep-alive>.
Use slot props instead:

<router-view v-slot="{ Component }">
  <keep-alive>
    <component :is="Component" />
  </keep-alive>
</router-view>
```