### PR TITLE
fix: stored XSS in triggers view via trigger name

### DIFF
--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -200,6 +200,9 @@ export function getHighlightHTMLByRegExp(
   caseSensitive = false,
   className = "text-accent"
 ) {
+  if (!pattern || (Array.isArray(pattern) && pattern.length === 0)) {
+    return s;
+  }
   pattern = Array.isArray(pattern)
     ? pattern.map((kw) => escapeRegExp(kw)).join("|")
     : escapeRegExp(pattern);

--- a/frontend/src/views/sql-editor/EditorPanel/common/EllipsisCell.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/common/EllipsisCell.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script setup lang="ts">
+import { escape } from "lodash-es";
 import { NPerformantEllipsis } from "naive-ui";
 import { computed } from "vue";
 import { getHighlightHTMLByRegExp, type VueClass } from "@/utils";
@@ -37,14 +38,29 @@ const props = defineProps<{
 
 const html = computed(() => {
   const { content, keyword } = props;
-  if (!keyword) return content;
-  return getHighlightHTMLByRegExp(content, keyword);
+  const kw = (keyword ?? "").trim();
+  if (!kw) {
+    return escape(content);
+  }
+  return getHighlightHTMLByRegExp(
+    escape(content),
+    escape(kw),
+    false /* !caseSensitive */
+  );
 });
 
 const tooltipHTML = computed(() => {
   const { keyword, tooltip } = props;
   if (typeof tooltip === "string") {
-    return getHighlightHTMLByRegExp(tooltip, keyword ?? "");
+    const kw = (keyword ?? "").trim();
+    if (!kw) {
+      return escape(tooltip);
+    }
+    return getHighlightHTMLByRegExp(
+      escape(tooltip),
+      escape(kw),
+      false /* !caseSensitive */
+    );
   }
   return html.value;
 });


### PR DESCRIPTION
Close BYT-8179

Escape trigger names and other user-supplied content in EllipsisCell component to prevent XSS attacks. Use lodash escape() to sanitize content before rendering with v-html, following the same pattern as TableCell and other components in the codebase.