### PR TITLE
fix: stored XSS in SSO flow via malicious auth endpoint

### DIFF
--- a/frontend/src/utils/sso.ts
+++ b/frontend/src/utils/sso.ts
@@ -5,6 +5,19 @@ import { IdentityProviderType } from "@/types/proto-es/v1/idp_service_pb";
 
 export const SSOConfigSessionKey = "sso-config";
 
+/**
+ * Validates that a URL is a safe HTTP/HTTPS URL to prevent XSS attacks.
+ * Rejects javascript:, data:, and other dangerous protocols.
+ */
+function isValidHttpUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export async function openWindowForSSO(
   identityProvider: IdentityProvider,
   popup = true,
@@ -30,6 +43,14 @@ export async function openWindowForSSO(
       return null;
     }
     const oauth2Config = identityProvider.config.config.value;
+
+    // Validate auth URL to prevent XSS via javascript: URIs
+    if (!isValidHttpUrl(oauth2Config.authUrl)) {
+      throw new Error(
+        "Invalid authentication URL: must be a valid HTTP or HTTPS URL"
+      );
+    }
+
     uri.basePath = oauth2Config.authUrl;
     Object.assign(uri.query, {
       client_id: oauth2Config.clientId,
@@ -46,6 +67,14 @@ export async function openWindowForSSO(
         `Invalid authentication URL from issuer ${oidcConfig.issuer}, please check your configuration`
       );
     }
+
+    // Validate auth endpoint to prevent XSS via javascript: URIs
+    if (!isValidHttpUrl(oidcConfig.authEndpoint)) {
+      throw new Error(
+        "Invalid authentication endpoint: must be a valid HTTP or HTTPS URL"
+      );
+    }
+
     uri.basePath = oidcConfig.authEndpoint;
     Object.assign(uri.query, {
       client_id: oidcConfig.clientId,
@@ -58,20 +87,25 @@ export async function openWindowForSSO(
     );
   }
 
-  const authUrl = `${uri.basePath}?${stringify(uri.query)}`;
+  // Use URL API for safe URL construction with query parameters
+  const authUrl = new URL(uri.basePath);
+  Object.entries(uri.query).forEach(([key, value]) => {
+    authUrl.searchParams.set(key, value);
+  });
 
-  if (!authUrl) {
+  const authUrlString = authUrl.toString();
+  if (!authUrlString) {
     throw new Error("Invalid authentication URL");
   }
 
   if (popup) {
     window.open(
-      authUrl,
+      authUrlString,
       "oauth",
       "location=yes,left=200,top=200,height=640,width=480,scrollbars=yes,status=yes"
     );
   } else {
     // Redirect to the auth URL.
-    window.location.href = authUrl;
+    window.location.href = authUrlString;
   }
 }


### PR DESCRIPTION
Close BYT-8178

Validate SSO authentication URLs to prevent XSS attacks via javascript: URIs. Add isValidHttpUrl() to ensure only HTTP/HTTPS protocols are allowed for OAuth2 authUrl and OIDC authEndpoint. Use URL API for safe query parameter construction instead of string concatenation.
