### PR TITLE
fix: block insecure MySQL allowAllFiles parameter

### DIFF
--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -6,6 +6,77 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateMySQLExtraConnectionParameters(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    map[string]string
+		wantError bool
+	}{
+		{
+			name:      "empty parameters",
+			params:    map[string]string{},
+			wantError: false,
+		},
+		{
+			name: "safe parameters",
+			params: map[string]string{
+				"timeout":      "10s",
+				"readTimeout":  "30s",
+				"writeTimeout": "30s",
+			},
+			wantError: false,
+		},
+		{
+			name: "dangerous parameter - allowAllFiles",
+			params: map[string]string{
+				"allowAllFiles": "true",
+			},
+			wantError: true,
+		},
+		{
+			name: "dangerous parameter - allowAllFiles lowercase",
+			params: map[string]string{
+				"allowallfiles": "true",
+			},
+			wantError: true,
+		},
+		{
+			name: "dangerous parameter - allowAllFiles with mixed case",
+			params: map[string]string{
+				"AllowAllFiles": "true",
+			},
+			wantError: true,
+		},
+		{
+			name: "mixed safe and dangerous parameters",
+			params: map[string]string{
+				"timeout":       "10s",
+				"allowAllFiles": "true",
+			},
+			wantError: true,
+		},
+		{
+			name: "parameter with whitespace",
+			params: map[string]string{
+				"  allowAllFiles  ": "true",
+			},
+			wantError: true,
+		},
+	}
+
+	a := require.New(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(_ *testing.T) {
+			err := validateMySQLExtraConnectionParameters(tc.params)
+			if tc.wantError {
+				a.Error(err, "expected error for test case: %s", tc.name)
+			} else {
+				a.NoError(err, "expected no error for test case: %s", tc.name)
+			}
+		})
+	}
+}
+
 func TestParseVersion(t *testing.T) {
 	tests := []struct {
 		version  string


### PR DESCRIPTION
Block allowAllFiles connection parameter for MySQL/MariaDB/OceanBase
as it disables file allowlist for LOAD DATA LOCAL INFILE, allowing
malicious servers to read arbitrary files from the client.

Validation implemented at both API and driver layers with case-
insensitive matching.

Fixes BYT-8187