### PR TITLE
chore: simplify proto linter workflow triggers

### DIFF
--- a/.github/workflows/proto-linter-default.yml
+++ b/.github/workflows/proto-linter-default.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'release/*.*.*'
     paths-ignore:
       - 'proto/**'
 

--- a/.github/workflows/proto-linter.yml
+++ b/.github/workflows/proto-linter.yml
@@ -1,14 +1,9 @@
 name: Proto linter
 
 on:
-  push:
-    branches:
-      - 'main'
-      - 'release/*.*.*'
   pull_request:
     branches:
       - 'main'
-      - 'release/*.*.*'
     paths:
       - 'proto/**'
 


### PR DESCRIPTION
## Summary
- Remove release branch triggers from proto linter workflows
- Simplify CI/CD configuration by only running on pull requests to main branch
- Remove push event trigger from proto-linter.yml

## Test plan
- Verify workflows run correctly on PRs to main
- Confirm workflows no longer trigger on release branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)