### PR TITLE
chore: add logging and stack trace for multiple plans error

### DIFF
--- a/backend/store/plan.go
+++ b/backend/store/plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/log"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
@@ -114,6 +116,14 @@ func (s *Store) GetPlan(ctx context.Context, find *FindPlanMessage) (*PlanMessag
 		return nil, nil
 	}
 	if len(plans) > 1 {
+		slog.Error("expect to find one plan, found multiple",
+			slog.Int("count", len(plans)),
+			slog.Any("uid", find.UID),
+			slog.Any("project_id", find.ProjectID),
+			slog.Any("project_ids", find.ProjectIDs),
+			slog.Any("pipeline_id", find.PipelineID),
+			log.BBStack("stack"),
+		)
 		return nil, errors.Errorf("expect to find one plan, found %d", len(plans))
 	}
 	return plans[0], nil


### PR DESCRIPTION
Part of BYT-8218. Add detailed logging when GetPlan unexpectedly finds multiple plans. Logs search parameters and stack trace to help debug root cause.
