### PR TITLE
fix: null pipeline id in issue

### DIFF
--- a/frontend/src/components/IssueV1/components/HeaderSection/Actions/create/CreateButton.vue
+++ b/frontend/src/components/IssueV1/components/HeaderSection/Actions/create/CreateButton.vue
@@ -164,31 +164,29 @@ const doCreateIssue = async () => {
     );
     if (!createdPlan) return;
 
-    issue.value.plan = createdPlan.name;
-    issue.value.planEntity = createdPlan;
-
-    const issueCreate = create(IssueSchema, {
-      ...issue.value,
-      rollout: "",
-    });
-    const request = create(CreateIssueRequestSchema, {
-      parent: issue.value.project,
-      issue: issueCreate,
-    });
-    const createdIssue = await issueServiceClientConnect.createIssue(request);
-
     const rolloutRequest = create(CreateRolloutRequestSchema, {
       parent: issue.value.project,
       rollout: {
         plan: createdPlan.name,
       },
     });
-    await rolloutServiceClientConnect.createRollout(rolloutRequest);
+    const createdRollout =
+      await rolloutServiceClientConnect.createRollout(rolloutRequest);
+
+    const request = create(CreateIssueRequestSchema, {
+      parent: issue.value.project,
+      issue: create(IssueSchema, {
+        ...issue.value,
+        plan: createdPlan.name,
+        rollout: createdRollout.name,
+      }),
+    });
+    const createdIssue = await issueServiceClientConnect.createIssue(request);
 
     router.replace({
       name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
       params: {
-        projectId: extractProjectResourceName(issue.value.project),
+        projectId: extractProjectResourceName(createdIssue.name),
         issueSlug: issueV1Slug(createdIssue.name, createdIssue.title),
       },
     });

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
@@ -475,6 +475,15 @@ const getIssueTypeFromPlan = (planValue: Plan): Issue_Type => {
 };
 
 const doCreateIssue = async () => {
+  const createRolloutRequest = create(CreateRolloutRequestSchema, {
+    parent: project.value.name,
+    rollout: {
+      plan: plan.value.name,
+    },
+  });
+  const rollout =
+    await rolloutServiceClientConnect.createRollout(createRolloutRequest);
+
   const createIssueRequest = create(CreateIssueRequestSchema, {
     parent: project.value.name,
     issue: create(IssueSchema, {
@@ -483,20 +492,11 @@ const doCreateIssue = async () => {
       plan: plan.value.name,
       status: IssueStatus.OPEN,
       type: getIssueTypeFromPlan(plan.value),
-      rollout: "",
+      rollout: rollout.name,
     }),
   });
-  const createRolloutRequest = create(CreateRolloutRequestSchema, {
-    parent: project.value.name,
-    rollout: {
-      plan: plan.value.name,
-    },
-  });
-
-  const [createdIssue] = await Promise.all([
-    issueServiceClientConnect.createIssue(createIssueRequest),
-    rolloutServiceClientConnect.createRollout(createRolloutRequest),
-  ]);
+  const createdIssue =
+    await issueServiceClientConnect.createIssue(createIssueRequest);
 
   // Emit status changed to refresh the UI
   events.emit("status-changed", { eager: true });


### PR DESCRIPTION
The `Auto resolve issue` feature is broken, because the [`issueN` here](https://github.com/bytebase/bytebase/blob/03c21d998f59da350ca940115eb8a813fe8d84bb/backend/runner/taskrun/schedulerv2.go#L914) is nil so we cannot update the issue status.

`issueN` is nil because the pipeline id in the issue is null, this means failed to update the `pipeline_id` in [`updatePipelineUIDOfIssueAndPlan`](https://github.com/bytebase/bytebase/blob/03c21d998f59da350ca940115eb8a813fe8d84bb/backend/store/pipeline.go#L127)

Fix:
- Cannot use `Promise.all` to create both issue and rollout and the same time. In the `CreateRollout`, we will call the `CreatePipelineAIO` to update the pipeline_id for the issue.
- We can create the rollout first, then use the `rollout.name` to create the issue

Close BYT-8224