### PR TITLE
fix: prevent splitpanes error when clicking admin mode button

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/AdminModeButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/AdminModeButton.vue
@@ -5,7 +5,7 @@
     type="warning"
     :ghost="true"
     :disabled="isDisconnected"
-    @click="enterAdminMode"
+    @click.stop="enterAdminMode"
   >
     <template #icon>
       <WrenchIcon class="w-4 h-4" />

--- a/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/EditorAction.vue
@@ -12,7 +12,7 @@
         type="default"
         :dashed="true"
         style="--n-padding: 0 8px 0 3px"
-        @click="exitAdminMode"
+        @click.stop="exitAdminMode"
       >
         <template #icon>
           <ChevronLeftIcon class="w-4 h-4 text-control" />

--- a/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/EditorPanel.vue
@@ -2,12 +2,19 @@
   <div class="w-full flex-1 flex flex-row items-stretch overflow-hidden">
     <Panels>
       <template #code-panel>
-        <StandardPanel v-if="!currentTab || currentTab.mode === 'WORKSHEET'" />
+        <StandardPanel
+          v-if="!currentTab || currentTab.mode === 'WORKSHEET'"
+          :key="`standard-${currentTab?.id || 'default'}`"
+        />
 
-        <TerminalPanel v-else-if="currentTab.mode === 'ADMIN'" />
+        <TerminalPanel
+          v-else-if="currentTab.mode === 'ADMIN'"
+          :key="`terminal-${currentTab?.id || 'default'}`"
+        />
 
         <NoPermissionPlaceholder
           v-else
+          :key="`no-permission-${currentTab?.id || 'default'}`"
           :description="$t('database.access-denied')"
         />
       </template>


### PR DESCRIPTION
fix the following error

<img width="1722" height="1040" alt="image" src="https://github.com/user-attachments/assets/dadcafe9-f70f-46e6-89ff-21c33669f99d" />

- Add `@click.stop` to admin mode buttons to prevent event bubbling
- Add unique keys to panel components for proper unmounting
- Fixes TypeError when switching between WORKSHEET and ADMIN modes
