### PR TITLE
chore: Use globalThis to set global in frontend

### DIFF
--- a/frontend/explain-visualizer.html
+++ b/frontend/explain-visualizer.html
@@ -9,9 +9,5 @@
 
   <body class="text-base">
     <script type="module" src="/src/explain-visualizer-main.ts"></script>
-    <script>
-      // redefine global use globalThis
-      global = globalThis;
-    </script>
   </body>
 </html>

--- a/frontend/src/explain-visualizer-main.ts
+++ b/frontend/src/explain-visualizer-main.ts
@@ -2,6 +2,9 @@ import "bootstrap/dist/css/bootstrap.css";
 import { createApp } from "vue";
 import ExplainVisualizerApp from "./ExplainVisualizerApp.vue";
 
+// Redefine global using globalThis
+(globalThis as any).global = globalThis;
+
 const app = createApp(ExplainVisualizerApp);
 
 app.mount("body");


### PR DESCRIPTION
Set the global variable in the explain visualizer frontend using globalThis to ensure a consistent global reference in the browser environment. This removes an inline script from explain-visualizer.html and centralizes the global definition in explain-visualizer-main.ts for better maintainability and to avoid polluting the HTML with script tags.

- Removed inline script that assigned global = globalThis from the HTML file.
- Added (globalThis as any).global = globalThis in the main TypeScript entry to redefine global in a type-safe place.