### PR TITLE
chore: add pgantlr infrastructure for PostgreSQL advisor migration

### DIFF
--- a/backend/plugin/advisor/pgantlr/advisor_hello_world.go
+++ b/backend/plugin/advisor/pgantlr/advisor_hello_world.go
@@ -1,0 +1,41 @@
+package pgantlr
+
+import (
+	"context"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor"
+)
+
+var (
+	_ advisor.Advisor = (*HelloWorldAdvisor)(nil)
+)
+
+const (
+	// HelloWorldRule is a test-only rule type for hello world advisor
+	HelloWorldRule advisor.SQLReviewRuleType = "hello-world"
+)
+
+func init() {
+	advisor.Register(storepb.Engine_POSTGRES, HelloWorldRule, &HelloWorldAdvisor{})
+}
+
+// HelloWorldAdvisor is a test advisor that always reports "hello world".
+type HelloWorldAdvisor struct {
+}
+
+// Check always returns a warning at line 0 column 0 with message "hello world".
+func (*HelloWorldAdvisor) Check(_ context.Context, _ advisor.Context) ([]*storepb.Advice, error) {
+	return []*storepb.Advice{
+		{
+			Status:  storepb.Advice_WARNING,
+			Code:    advisor.Ok.Int32(),
+			Title:   "Hello World Test",
+			Content: "hello world",
+			StartPosition: &storepb.Position{
+				Line:   0,
+				Column: 0,
+			},
+		},
+	}, nil
+}

--- a/backend/plugin/advisor/pgantlr/pgantlr_test.go
+++ b/backend/plugin/advisor/pgantlr/pgantlr_test.go
@@ -1,0 +1,31 @@
+package pgantlr
+
+import (
+	"testing"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor"
+)
+
+func TestPostgreSQLANTLRRules(t *testing.T) {
+	antlrRules := []advisor.SQLReviewRuleType{
+		HelloWorldRule, // Test advisor to verify framework works
+		// Add real rules here as you migrate them from legacy pg/ folder
+		// Example:
+		// advisor.SchemaRuleStatementDisallowCommit,
+		// advisor.SchemaRuleStatementInsertMustSpecifyColumn,
+		// advisor.SchemaRuleTableNaming,
+		// etc.
+	}
+
+	for _, rule := range antlrRules {
+		needMetaData := advisorNeedMockData[rule]
+		RunANTLRAdvisorRuleTest(t, rule, storepb.Engine_POSTGRES, needMetaData, false /* record */)
+	}
+}
+
+// Add SQL review type here if you need metadata for test.
+var advisorNeedMockData = map[advisor.SQLReviewRuleType]bool{
+	// advisor.SchemaRuleFullyQualifiedObjectName: true,
+	// advisor.BuiltinRulePriorBackupCheck:        true,
+}

--- a/backend/plugin/advisor/pgantlr/test/hello_world.yaml
+++ b/backend/plugin/advisor/pgantlr/test/hello_world.yaml
@@ -1,0 +1,35 @@
+- statement: SELECT 1
+  changeType: 1
+  want:
+    - status: 2
+      code: 0
+      title: Hello World Test
+      content: hello world
+      startposition:
+        line: 0
+        column: 0
+      endposition: null
+- statement: ""
+  changeType: 1
+  want:
+    - status: 2
+      code: 0
+      title: Hello World Test
+      content: hello world
+      startposition:
+        line: 0
+        column: 0
+      endposition: null
+- statement: |-
+    CREATE TABLE test(id int);
+    INSERT INTO test VALUES (1);
+  changeType: 1
+  want:
+    - status: 2
+      code: 0
+      title: Hello World Test
+      content: hello world
+      startposition:
+        line: 0
+        column: 0
+      endposition: null


### PR DESCRIPTION
## Summary

  This PR sets up the infrastructure for migrating PostgreSQL advisors from pg_query_go to ANTLR parser.

  ## Context

  Currently, PostgreSQL advisors use pg_query_go with 100+ custom AST wrapper files in `backend/plugin/parser/pg/legacy/ast/`. We're migrating to ANTLR-based parsing to:

  - Eliminate custom AST layer maintenance burden
  - Improve consistency with ANTLR-based query span extraction
  - Reduce code complexity and improve maintainability

  ## Approach: Big Bang with Parallel Development

  - Build new ANTLR advisors in separate `pgantlr/` folder
  - Legacy `pg/` advisors remain untouched and continue working
  - Once all 54 advisors migrated, do atomic switch: delete `pg/`, rename `pgantlr/` → `pg/`

  ## What's Included

  ### 1. Test Infrastructure
  - `test_helper.go` - `RunANTLRAdvisorRuleTest()` function (mirrors legacy test framework)
  - `pgantlr_test.go` - Test runner that reads YAML test files
  - `test/` - Directory for YAML test files (same format as legacy)

  ### 2. Hello World Advisor
  - Demonstrates complete workflow: advisor implementation → registration → YAML tests
  - Validates that the test framework works correctly
  - Will be removed once real advisors are migrated

  ## Testing

  ```bash
  go test ./backend/plugin/advisor/pgantlr/... -v

  Output:
  === RUN   TestPostgreSQLANTLRRules
  --- PASS: TestPostgreSQLANTLRRules (0.00s)
  PASS
```

 ## Next Steps

  Start migrating advisors one-by-one:
  1. Implement advisor using ANTLR in pgantlr/
  2. Copy test YAML file from pg/test/ to pgantlr/test/
  3. Add rule to test list
  4. Verify identical behavior