### PR TITLE
fix: add domain allowlisting to prevent SSRF in webhooks

### DIFF
--- a/backend/api/v1/project_service_converter.go
+++ b/backend/api/v1/project_service_converter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common/log"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	webhookplugin "github.com/bytebase/bytebase/backend/plugin/webhook"
 	"github.com/bytebase/bytebase/backend/store"
 	"github.com/bytebase/bytebase/backend/utils"
 )
@@ -39,6 +40,12 @@ func convertToStoreProjectWebhookMessage(webhook *v1pb.Webhook) (*store.ProjectW
 	if err != nil {
 		return nil, err
 	}
+
+	// Validate webhook URL against allowed domains
+	if err := webhookplugin.ValidateWebhookURL(tp, webhook.Url); err != nil {
+		return nil, common.Errorf(common.Invalid, "invalid webhook URL: %v", err)
+	}
+
 	activityTypes, err := convertToActivityTypeStrings(webhook.NotificationTypes)
 	if err != nil {
 		return nil, err

--- a/backend/plugin/webhook/validator.go
+++ b/backend/plugin/webhook/validator.go
@@ -1,0 +1,90 @@
+package webhook
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// AllowedDomains maps webhook types to their allowed domains.
+	AllowedDomains = map[string][]string{
+		"bb.plugin.webhook.slack": {
+			"hooks.slack.com",
+			"hooks.slack-gov.com",
+		},
+		"bb.plugin.webhook.discord": {
+			"discord.com",
+			"discordapp.com",
+		},
+		"bb.plugin.webhook.teams": {
+			".office.com",    // Matches *.office.com
+			".office365.com", // Matches *.office365.com
+		},
+		"bb.plugin.webhook.dingtalk": {
+			"oapi.dingtalk.com",
+			"api.dingtalk.com",
+		},
+		"bb.plugin.webhook.feishu": {
+			"open.feishu.cn",
+		},
+		"bb.plugin.webhook.lark": {
+			"open.larksuite.com",
+		},
+		"bb.plugin.webhook.wecom": {
+			"qyapi.weixin.qq.com",
+		},
+	}
+
+	// TestOnlyAllowedDomains contains additional domains allowed for testing purposes only.
+	// This should only be modified in test files.
+	TestOnlyAllowedDomains = map[string][]string{}
+)
+
+// ValidateWebhookURL validates that the webhook URL matches the allowed domains for the webhook type.
+func ValidateWebhookURL(webhookType, webhookURL string) error {
+	// Parse URL
+	u, err := url.Parse(webhookURL)
+	if err != nil {
+		return errors.Wrapf(err, "invalid URL format")
+	}
+
+	// Only allow http/https
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.Errorf("invalid URL scheme: %s (only http and https are allowed)", u.Scheme)
+	}
+
+	// Get allowed domains for this webhook type
+	allowedDomains, ok := AllowedDomains[webhookType]
+	if !ok {
+		return errors.Errorf("unknown webhook type: %s", webhookType)
+	}
+
+	// Merge with test-only allowed domains
+	allAllowedDomains := append([]string{}, allowedDomains...)
+	if testDomains, exists := TestOnlyAllowedDomains[webhookType]; exists {
+		allAllowedDomains = append(allAllowedDomains, testDomains...)
+	}
+
+	// Check if hostname matches any allowed domain
+	hostname := strings.ToLower(u.Hostname())
+	for _, domain := range allAllowedDomains {
+		domain = strings.ToLower(domain)
+
+		// Support wildcard subdomains (e.g., ".office.com" matches "outlook.office.com")
+		if strings.HasPrefix(domain, ".") {
+			if hostname == domain[1:] || strings.HasSuffix(hostname, domain) {
+				return nil
+			}
+		} else {
+			// Exact match
+			if hostname == domain {
+				return nil
+			}
+		}
+	}
+
+	return errors.Errorf("webhook URL domain %q is not allowed for webhook type %s (allowed domains: %v)",
+		hostname, webhookType, allowedDomains)
+}

--- a/backend/plugin/webhook/validator_test.go
+++ b/backend/plugin/webhook/validator_test.go
@@ -1,0 +1,221 @@
+package webhook
+
+import (
+	"testing"
+)
+
+func TestValidateWebhookURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		webhookType string
+		webhookURL  string
+		wantErr     bool
+	}{
+		// Slack tests
+		{
+			name:        "valid slack URL",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXX",
+			wantErr:     false,
+		},
+		{
+			name:        "valid slack-gov URL",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "https://hooks.slack-gov.com/services/T00000000/B00000000/XXXXXXXXXXXX",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid slack domain",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "https://evil.com/hooks",
+			wantErr:     true,
+		},
+		{
+			name:        "slack SSRF attempt localhost",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "http://127.0.0.1:8080/",
+			wantErr:     true,
+		},
+		{
+			name:        "slack SSRF attempt private IP",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "http://192.168.1.1/",
+			wantErr:     true,
+		},
+		// Discord tests
+		{
+			name:        "valid discord URL",
+			webhookType: "bb.plugin.webhook.discord",
+			webhookURL:  "https://discord.com/api/webhooks/123456789/abcdefg",
+			wantErr:     false,
+		},
+		{
+			name:        "valid discordapp URL (legacy)",
+			webhookType: "bb.plugin.webhook.discord",
+			webhookURL:  "https://discordapp.com/api/webhooks/123456789/abcdefg",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid discord domain",
+			webhookType: "bb.plugin.webhook.discord",
+			webhookURL:  "https://evil-discord.com/api/webhooks/123456789/abcdefg",
+			wantErr:     true,
+		},
+		// Teams tests
+		{
+			name:        "valid teams office.com URL",
+			webhookType: "bb.plugin.webhook.teams",
+			webhookURL:  "https://outlook.office.com/webhook/xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "valid teams office365.com URL",
+			webhookType: "bb.plugin.webhook.teams",
+			webhookURL:  "https://outlook.office365.com/webhook/xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "valid teams subdomain",
+			webhookType: "bb.plugin.webhook.teams",
+			webhookURL:  "https://example.office.com/webhook/xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid teams domain",
+			webhookType: "bb.plugin.webhook.teams",
+			webhookURL:  "https://evil-office.com/webhook/xxx",
+			wantErr:     true,
+		},
+		// DingTalk tests
+		{
+			name:        "valid dingtalk oapi URL",
+			webhookType: "bb.plugin.webhook.dingtalk",
+			webhookURL:  "https://oapi.dingtalk.com/robot/send?access_token=xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "valid dingtalk api URL",
+			webhookType: "bb.plugin.webhook.dingtalk",
+			webhookURL:  "https://api.dingtalk.com/robot/send?access_token=xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid dingtalk domain",
+			webhookType: "bb.plugin.webhook.dingtalk",
+			webhookURL:  "https://evil.dingtalk.com/robot/send",
+			wantErr:     true,
+		},
+		// Feishu tests
+		{
+			name:        "valid feishu URL",
+			webhookType: "bb.plugin.webhook.feishu",
+			webhookURL:  "https://open.feishu.cn/open-apis/bot/v2/hook/xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid feishu domain",
+			webhookType: "bb.plugin.webhook.feishu",
+			webhookURL:  "https://evil.feishu.cn/open-apis/bot/v2/hook/xxx",
+			wantErr:     true,
+		},
+		// Lark tests
+		{
+			name:        "valid lark URL",
+			webhookType: "bb.plugin.webhook.lark",
+			webhookURL:  "https://open.larksuite.com/open-apis/bot/v2/hook/xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid lark domain",
+			webhookType: "bb.plugin.webhook.lark",
+			webhookURL:  "https://evil.larksuite.com/open-apis/bot/v2/hook/xxx",
+			wantErr:     true,
+		},
+		// WeCom tests
+		{
+			name:        "valid wecom URL",
+			webhookType: "bb.plugin.webhook.wecom",
+			webhookURL:  "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid wecom domain",
+			webhookType: "bb.plugin.webhook.wecom",
+			webhookURL:  "https://evil.weixin.qq.com/cgi-bin/webhook/send?key=xxx",
+			wantErr:     true,
+		},
+		// URL format tests
+		{
+			name:        "invalid URL format",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "not-a-url",
+			wantErr:     true,
+		},
+		{
+			name:        "invalid scheme ftp",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "ftp://hooks.slack.com/services/xxx",
+			wantErr:     true,
+		},
+		{
+			name:        "invalid scheme file",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "file:///etc/passwd",
+			wantErr:     true,
+		},
+		// Unknown webhook type
+		{
+			name:        "unknown webhook type",
+			webhookType: "bb.plugin.webhook.unknown",
+			webhookURL:  "https://example.com/webhook",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateWebhookURL(tt.webhookType, tt.webhookURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateWebhookURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateWebhookURL_CaseInsensitive(t *testing.T) {
+	// Test that domain matching is case-insensitive
+	tests := []struct {
+		name        string
+		webhookType string
+		webhookURL  string
+		wantErr     bool
+	}{
+		{
+			name:        "slack uppercase domain",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "https://HOOKS.SLACK.COM/services/xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "slack mixed case domain",
+			webhookType: "bb.plugin.webhook.slack",
+			webhookURL:  "https://Hooks.Slack.Com/services/xxx",
+			wantErr:     false,
+		},
+		{
+			name:        "discord uppercase",
+			webhookType: "bb.plugin.webhook.discord",
+			webhookURL:  "https://DISCORD.COM/api/webhooks/123/abc",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateWebhookURL(tt.webhookType, tt.webhookURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateWebhookURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/backend/tests/webhook_test.go
+++ b/backend/tests/webhook_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	webhookplugin "github.com/bytebase/bytebase/backend/plugin/webhook"
 )
 
 // webhookCollector collects webhook requests for testing.
@@ -99,6 +100,13 @@ func parseSlackWebhook(body []byte) (title, description string, err error) {
 
 // TestWebhookIntegration tests webhook functionality.
 func TestWebhookIntegration(t *testing.T) {
+	// Allow localhost for testing
+	webhookplugin.TestOnlyAllowedDomains["bb.plugin.webhook.slack"] = []string{"127.0.0.1", "localhost", "[::1]"}
+	defer func() {
+		// Clean up after test
+		delete(webhookplugin.TestOnlyAllowedDomains, "bb.plugin.webhook.slack")
+	}()
+
 	ctx := context.Background()
 	ctl := &controller{}
 	ctx, err := ctl.StartServerWithExternalPg(ctx)


### PR DESCRIPTION
## Summary

This PR implements domain allowlisting to mitigate Server-Side Request Forgery (SSRF) vulnerabilities in the webhook feature. The vulnerability was reported by Govtech and allowed authenticated users to configure webhook URLs pointing to internal IP addresses, potentially exposing the system to SSRF attacks.

## Changes

### New Files
- `backend/plugin/webhook/validator.go` - Core URL validation logic with domain allowlisting
- `backend/plugin/webhook/validator_test.go` - Comprehensive test suite (28+ test cases)

### Modified Files
- `backend/api/v1/project_service_converter.go` - Integration of URL validation
- `backend/tests/webhook_test.go` - Updated integration tests for test environment support

## Implementation Details

### Domain Allowlisting by Webhook Type

| Webhook Type | Allowed Domains |
|-------------|-----------------|
| Slack | `hooks.slack.com`, `hooks.slack-gov.com` |
| Discord | `discord.com`, `discordapp.com` |
| Teams | `*.office.com`, `*.office365.com` |
| DingTalk | `oapi.dingtalk.com`, `api.dingtalk.com` |
| Feishu | `open.feishu.cn` |
| Lark | `open.larksuite.com` |
| WeCom | `qyapi.weixin.qq.com` |

### Security Features

- ✅ Blocks all internal IP addresses (localhost, 127.0.0.1, 192.168.x.x, 10.x.x.x, etc.)
- ✅ Validates URL schemes (only http/https allowed)
- ✅ Whitelist-based approach (not blacklist)
- ✅ Case-insensitive domain matching
- ✅ Wildcard subdomain support for Teams
- ✅ Test environment support via `TestOnlyAllowedDomains`

## Security Impact

### Vulnerability Mitigated
- **Type**: Server-Side Request Forgery (SSRF)
- **Severity**: High
- **Attack Vector**: Authenticated users could set webhook URLs to internal resources (e.g., `http://127.0.0.1:8080/`)
- **Impact**: Potential information disclosure and DoS attacks

### Mitigation Effectiveness
- Completely blocks the reported SSRF attack vector
- No breaking changes for legitimate webhook configurations
- All webhook URLs are validated at creation/update time

## Test Coverage

### Unit Tests (`validator_test.go`)
- Valid URLs for all webhook types
- SSRF attack attempts (localhost, private IPs)
- Invalid domains
- Invalid URL schemes (ftp, file)
- Case-insensitive domain matching
- Unknown webhook types

### Integration Tests
- Updated `webhook_test.go` to allow localhost in test environment
- All existing webhook tests pass

### Test Results
```
✅ Validator unit tests: 28/28 passed
✅ Webhook integration tests: PASSED
✅ Linter: 0 issues
```

## Additional Notes

- This is **Step 1 & 2** of the complete SSRF mitigation strategy
- **Step 3** (HTTP client hardening for GZIP bomb DoS and redirect prevention) can be addressed in a follow-up PR
- No configuration changes required
- No database migrations needed

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Linter passes
- [x] Manual testing with valid webhook URLs
- [x] Manual testing with SSRF attempts (verified blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)