### PR TITLE
refactor: migrate project_webhook columns to payload

### DIFF
--- a/backend/component/webhook/manager.go
+++ b/backend/component/webhook/manager.go
@@ -329,17 +329,17 @@ func (m *Manager) postWebhookList(ctx context.Context, webhookCtx *webhook.Conte
 
 	for _, hook := range webhookList {
 		webhookCtx := *webhookCtx
-		webhookCtx.URL = hook.URL
+		webhookCtx.URL = hook.Payload.GetUrl()
 		webhookCtx.CreatedTS = time.Now().Unix()
 		webhookCtx.DirectMessage = hook.Payload.GetDirectMessage()
 		go func(webhookCtx *webhook.Context, hook *store.ProjectWebhookMessage) {
 			if err := common.Retry(ctx, func() error {
-				return webhook.Post(hook.Type, *webhookCtx)
+				return webhook.Post(hook.Payload.GetType(), *webhookCtx)
 			}); err != nil {
 				// The external webhook endpoint might be invalid which is out of our code control, so we just emit a warning
 				slog.Warn("Failed to post webhook event on activity",
-					slog.String("webhook type", hook.Type.String()),
-					slog.String("webhook name", hook.Title),
+					slog.String("webhook type", hook.Payload.GetType().String()),
+					slog.String("webhook name", hook.Payload.GetTitle()),
 					slog.String("activity type", webhookCtx.EventType),
 					slog.String("title", webhookCtx.Title),
 					log.BBError(err))

--- a/backend/generated-go/store/project_webhook.pb.go
+++ b/backend/generated-go/store/project_webhook.pb.go
@@ -217,10 +217,18 @@ func (*Activity) Descriptor() ([]byte, []int) {
 
 type ProjectWebhook struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	// Webhook type.
+	Type ProjectWebhook_Type `protobuf:"varint,1,opt,name=type,proto3,enum=bytebase.store.ProjectWebhook_Type" json:"type,omitempty"`
+	// Webhook title.
+	Title string `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
+	// Webhook URL.
+	Url string `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`
+	// List of activities that trigger this webhook.
+	Activities []Activity_Type `protobuf:"varint,4,rep,packed,name=activities,proto3,enum=bytebase.store.Activity_Type" json:"activities,omitempty"`
 	// If direct_message is set, the notification is sent directly
 	// to the persons and url will be ignored.
 	// IM integration setting should be set for this function to work.
-	DirectMessage bool `protobuf:"varint,1,opt,name=direct_message,json=directMessage,proto3" json:"direct_message,omitempty"`
+	DirectMessage bool `protobuf:"varint,5,opt,name=direct_message,json=directMessage,proto3" json:"direct_message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -255,6 +263,34 @@ func (*ProjectWebhook) Descriptor() ([]byte, []int) {
 	return file_store_project_webhook_proto_rawDescGZIP(), []int{1}
 }
 
+func (x *ProjectWebhook) GetType() ProjectWebhook_Type {
+	if x != nil {
+		return x.Type
+	}
+	return ProjectWebhook_TYPE_UNSPECIFIED
+}
+
+func (x *ProjectWebhook) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *ProjectWebhook) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *ProjectWebhook) GetActivities() []Activity_Type {
+	if x != nil {
+		return x.Activities
+	}
+	return nil
+}
+
 func (x *ProjectWebhook) GetDirectMessage() bool {
 	if x != nil {
 		return x.DirectMessage
@@ -278,9 +314,15 @@ const file_store_project_webhook_proto_rawDesc = "" +
 	"\x13ISSUE_STATUS_UPDATE\x10\x04\x12\x19\n" +
 	"\x15ISSUE_APPROVAL_NOTIFY\x10\x15\x12&\n" +
 	"\"ISSUE_PIPELINE_STAGE_STATUS_UPDATE\x10\x05\x12)\n" +
-	"%ISSUE_PIPELINE_TASK_RUN_STATUS_UPDATE\x10\x16\"\xa7\x01\n" +
-	"\x0eProjectWebhook\x12%\n" +
-	"\x0edirect_message\x18\x01 \x01(\bR\rdirectMessage\"n\n" +
+	"%ISSUE_PIPELINE_TASK_RUN_STATUS_UPDATE\x10\x16\"\xc7\x02\n" +
+	"\x0eProjectWebhook\x127\n" +
+	"\x04type\x18\x01 \x01(\x0e2#.bytebase.store.ProjectWebhook.TypeR\x04type\x12\x14\n" +
+	"\x05title\x18\x02 \x01(\tR\x05title\x12\x10\n" +
+	"\x03url\x18\x03 \x01(\tR\x03url\x12=\n" +
+	"\n" +
+	"activities\x18\x04 \x03(\x0e2\x1d.bytebase.store.Activity.TypeR\n" +
+	"activities\x12%\n" +
+	"\x0edirect_message\x18\x05 \x01(\bR\rdirectMessage\"n\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05SLACK\x10\x01\x12\v\n" +
@@ -313,11 +355,13 @@ var file_store_project_webhook_proto_goTypes = []any{
 	(*ProjectWebhook)(nil),   // 3: bytebase.store.ProjectWebhook
 }
 var file_store_project_webhook_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1, // 0: bytebase.store.ProjectWebhook.type:type_name -> bytebase.store.ProjectWebhook.Type
+	0, // 1: bytebase.store.ProjectWebhook.activities:type_name -> bytebase.store.Activity.Type
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_store_project_webhook_proto_init() }

--- a/backend/generated-go/store/project_webhook_equal.pb.go
+++ b/backend/generated-go/store/project_webhook_equal.pb.go
@@ -20,6 +20,23 @@ func (x *ProjectWebhook) Equal(y *ProjectWebhook) bool {
 	if x == nil || y == nil {
 		return x == nil && y == nil
 	}
+	if x.Type != y.Type {
+		return false
+	}
+	if x.Title != y.Title {
+		return false
+	}
+	if x.Url != y.Url {
+		return false
+	}
+	if len(x.Activities) != len(y.Activities) {
+		return false
+	}
+	for i := 0; i < len(x.Activities); i++ {
+		if x.Activities[i] != y.Activities[i] {
+			return false
+		}
+	}
 	if x.DirectMessage != y.DirectMessage {
 		return false
 	}

--- a/backend/migrator/migration/3.11/0017##migrate_webhook_to_payload.sql
+++ b/backend/migrator/migration/3.11/0017##migrate_webhook_to_payload.sql
@@ -1,0 +1,22 @@
+-- Migrate project_webhook columns to payload.
+-- This migration moves type, name, url, and event_list fields into the JSONB payload column.
+
+-- Step 1: Backfill payload with existing column data
+UPDATE project_webhook
+SET payload = jsonb_build_object(
+    'type', type,
+    'title', name,
+    'url', url,
+    'activities', (
+        SELECT jsonb_agg(event)
+        FROM unnest(event_list) AS event
+    ),
+    'directMessage', COALESCE(payload->'directMessage', 'false'::jsonb)
+)
+WHERE payload = '{}' OR payload->'type' IS NULL;
+
+-- Step 2: Drop the old columns
+ALTER TABLE project_webhook DROP COLUMN IF EXISTS type;
+ALTER TABLE project_webhook DROP COLUMN IF EXISTS name;
+ALTER TABLE project_webhook DROP COLUMN IF EXISTS url;
+ALTER TABLE project_webhook DROP COLUMN IF EXISTS event_list;

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -108,12 +108,6 @@ CREATE UNIQUE INDEX idx_project_unique_resource_id ON project(resource_id);
 CREATE TABLE project_webhook (
     id serial PRIMARY KEY,
     project text NOT NULL REFERENCES project(resource_id),
-    -- Enum name from ProjectWebhook.Type (proto/store/store/project_webhook.proto)
-    type text NOT NULL,
-    name text NOT NULL,
-    url text NOT NULL,
-    -- Array of enum names from Activity.Type (proto/store/store/project_webhook.proto)
-    event_list text ARRAY NOT NULL,
     -- Stored as ProjectWebhook (proto/store/store/project_webhook.proto)
     payload jsonb NOT NULL DEFAULT '{}'
 );

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.11.16"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.11.17"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/backend/plugin/webhook/validator.go
+++ b/backend/plugin/webhook/validator.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	// AllowedDomains maps webhook types to their allowed domains.
-	AllowedDomains = map[storepb.ProjectWebhook_Type][]string{
+	// allowedDomains maps webhook types to their allowed domains.
+	allowedDomains = map[storepb.ProjectWebhook_Type][]string{
 		storepb.ProjectWebhook_SLACK: {
 			"hooks.slack.com",
 			"hooks.slack-gov.com",
@@ -58,13 +58,13 @@ func ValidateWebhookURL(webhookType storepb.ProjectWebhook_Type, webhookURL stri
 	}
 
 	// Get allowed domains for this webhook type
-	allowedDomains, ok := AllowedDomains[webhookType]
+	allowedDomainsForType, ok := allowedDomains[webhookType]
 	if !ok {
 		return errors.Errorf("unknown webhook type: %s", webhookType)
 	}
 
 	// Merge with test-only allowed domains
-	allAllowedDomains := append([]string{}, allowedDomains...)
+	allAllowedDomains := append([]string{}, allowedDomainsForType...)
 	if testDomains, exists := TestOnlyAllowedDomains[webhookType]; exists {
 		allAllowedDomains = append(allAllowedDomains, testDomains...)
 	}
@@ -88,5 +88,5 @@ func ValidateWebhookURL(webhookType storepb.ProjectWebhook_Type, webhookURL stri
 	}
 
 	return errors.Errorf("webhook URL domain %q is not allowed for webhook type %s (allowed domains: %v)",
-		hostname, webhookType, allowedDomains)
+		hostname, webhookType, allowedDomainsForType)
 }

--- a/backend/store/project_webhook.go
+++ b/backend/store/project_webhook.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jackc/pgtype"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -16,14 +15,6 @@ import (
 
 // ProjectWebhookMessage is the store model for an project webhook.
 type ProjectWebhookMessage struct {
-	// Type is the webhook type (e.g. SLACK, DISCORD, etc.).
-	Type storepb.ProjectWebhook_Type
-	// Title is the webhook name.
-	Title string
-	// URL is the webhook URL.
-	URL string
-	// Events is the list of activities that the webhook is interested in.
-	Events []storepb.Activity_Type
 	// Output only fields.
 	//
 	// ID is the unique identifier of the project webhook.
@@ -34,12 +25,6 @@ type ProjectWebhookMessage struct {
 
 // UpdateProjectWebhookMessage is the message for updating project webhooks.
 type UpdateProjectWebhookMessage struct {
-	// Title is the webhook name.
-	Title *string
-	// URL is the webhook URL.
-	URL *string
-	// Events is the list of activities that the webhook is interested in.
-	Events  []storepb.Activity_Type
 	Payload *storepb.ProjectWebhook
 }
 
@@ -57,13 +42,9 @@ func (s *Store) CreateProjectWebhookV2(ctx context.Context, projectID string, cr
 	query := `
 		INSERT INTO project_webhook (
 			project,
-			type,
-			name,
-			url,
-			event_list,
 			payload
 		)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		VALUES ($1, $2)
 		RETURNING id
 	`
 	payload := []byte("{}")
@@ -75,18 +56,8 @@ func (s *Store) CreateProjectWebhookV2(ctx context.Context, projectID string, cr
 		payload = p
 	}
 
-	// Convert events to string array (enum names)
-	events := make([]string, len(create.Events))
-	for i, event := range create.Events {
-		events[i] = event.String()
-	}
-
 	projectWebhook := ProjectWebhookMessage{
-		Type:      create.Type,
-		Title:     create.Title,
-		URL:       create.URL,
-		Events:    create.Events,
-		ProjectID: create.ProjectID,
+		ProjectID: projectID,
 		Payload:   create.Payload,
 	}
 
@@ -97,10 +68,6 @@ func (s *Store) CreateProjectWebhookV2(ctx context.Context, projectID string, cr
 
 	if err := tx.QueryRowContext(ctx, query,
 		projectID,
-		create.Type.String(),
-		create.Title,
-		create.URL,
-		events,
 		payload,
 	).Scan(
 		&projectWebhook.ID,
@@ -168,79 +135,41 @@ func (s *Store) UpdateProjectWebhookV2(ctx context.Context, projectResourceID st
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to begin transaction")
 	}
-	set, args := []string{}, []any{}
-	if v := update.Title; v != nil {
-		set, args = append(set, fmt.Sprintf("name = $%d", len(args)+1)), append(args, *v)
-	}
-	if v := update.URL; v != nil {
-		set, args = append(set, fmt.Sprintf("url = $%d", len(args)+1)), append(args, *v)
-	}
-	if v := update.Events; v != nil {
-		// Convert events to string array (enum names)
-		events := make([]string, len(v))
-		for i, event := range v {
-			events[i] = event.String()
-		}
-		set, args = append(set, fmt.Sprintf("event_list = $%d", len(args)+1)), append(args, events)
-	}
-	if v := update.Payload; v != nil {
-		p, err := protojson.Marshal(v)
+
+	var payload []byte
+	if update.Payload != nil {
+		p, err := protojson.Marshal(update.Payload)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to marshal payload")
 		}
-		set, args = append(set, fmt.Sprintf("payload = $%d", len(args)+1)), append(args, p)
+		payload = p
 	}
-
-	args = append(args, projectWebhookID)
 
 	projectWebhook := ProjectWebhookMessage{
 		Payload: &storepb.ProjectWebhook{},
 	}
-	var txtArray pgtype.TextArray
-	var webhookType string
-	var payload []byte
+	var returnedPayload []byte
 	// Execute update query with RETURNING.
-	if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-	UPDATE project_webhook
-	SET `+strings.Join(set, ", ")+`
-	WHERE id = $%d
-	RETURNING id, project, type, name, url, event_list, payload
-`, len(args)),
-		args...,
+	if err := tx.QueryRowContext(ctx, `
+		UPDATE project_webhook
+		SET payload = $1
+		WHERE id = $2
+		RETURNING id, project, payload
+	`,
+		payload,
+		projectWebhookID,
 	).Scan(
 		&projectWebhook.ID,
 		&projectWebhook.ProjectID,
-		&webhookType,
-		&projectWebhook.Title,
-		&projectWebhook.URL,
-		&txtArray,
-		&payload,
+		&returnedPayload,
 	); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, &common.Error{Code: common.NotFound, Err: errors.Errorf("project hook ID not found: %d", projectWebhookID)}
 		}
 		return nil, err
 	}
-	webhookTypeValue, ok := storepb.ProjectWebhook_Type_value[webhookType]
-	if !ok {
-		return nil, errors.Errorf("invalid webhook type in database: %s", webhookType)
-	}
-	projectWebhook.Type = storepb.ProjectWebhook_Type(webhookTypeValue)
 
-	var eventStrs []string
-	if err := txtArray.AssignTo(&eventStrs); err != nil {
-		return nil, err
-	}
-	projectWebhook.Events = make([]storepb.Activity_Type, len(eventStrs))
-	for i, eventStr := range eventStrs {
-		eventValue, ok := storepb.Activity_Type_value[eventStr]
-		if !ok {
-			return nil, errors.Errorf("invalid activity type in database: %s", eventStr)
-		}
-		projectWebhook.Events[i] = storepb.Activity_Type(eventValue)
-	}
-
-	if err := common.ProtojsonUnmarshaler.Unmarshal(payload, projectWebhook.Payload); err != nil {
+	if err := common.ProtojsonUnmarshaler.Unmarshal(returnedPayload, projectWebhook.Payload); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal")
 	}
 
@@ -281,16 +210,13 @@ func (*Store) findProjectWebhookImplV2(ctx context.Context, txn *sql.Tx, find *F
 		where, args = append(where, fmt.Sprintf("project = $%d", len(args)+1)), append(args, *v)
 	}
 	if v := find.URL; v != nil {
-		where, args = append(where, fmt.Sprintf("url = $%d", len(args)+1)), append(args, *v)
+		where, args = append(where, fmt.Sprintf("payload->>'url' = $%d", len(args)+1)), append(args, *v)
 	}
 
 	rows, err := txn.QueryContext(ctx, `
 		SELECT
 			id,
-			type,
-			name,
-			url,
-			event_list,
+			project,
 			payload
 		FROM project_webhook
 		WHERE `+strings.Join(where, " AND "),
@@ -306,38 +232,14 @@ func (*Store) findProjectWebhookImplV2(ctx context.Context, txn *sql.Tx, find *F
 		projectWebhook := ProjectWebhookMessage{
 			Payload: &storepb.ProjectWebhook{},
 		}
-		var txtArray pgtype.TextArray
-		var webhookType string
 		var payload []byte
 
 		if err := rows.Scan(
 			&projectWebhook.ID,
-			&webhookType,
-			&projectWebhook.Title,
-			&projectWebhook.URL,
-			&txtArray,
+			&projectWebhook.ProjectID,
 			&payload,
 		); err != nil {
 			return nil, err
-		}
-
-		webhookTypeValue, ok := storepb.ProjectWebhook_Type_value[webhookType]
-		if !ok {
-			return nil, errors.Errorf("invalid webhook type in database: %s", webhookType)
-		}
-		projectWebhook.Type = storepb.ProjectWebhook_Type(webhookTypeValue)
-
-		var eventStrs []string
-		if err := txtArray.AssignTo(&eventStrs); err != nil {
-			return nil, err
-		}
-		projectWebhook.Events = make([]storepb.Activity_Type, len(eventStrs))
-		for i, eventStr := range eventStrs {
-			eventValue, ok := storepb.Activity_Type_value[eventStr]
-			if !ok {
-				return nil, errors.Errorf("invalid activity type in database: %s", eventStr)
-			}
-			projectWebhook.Events[i] = storepb.Activity_Type(eventValue)
 		}
 
 		if err := common.ProtojsonUnmarshaler.Unmarshal(payload, projectWebhook.Payload); err != nil {
@@ -345,11 +247,15 @@ func (*Store) findProjectWebhookImplV2(ctx context.Context, txn *sql.Tx, find *F
 		}
 
 		if v := find.EventType; v != nil {
-			for _, activity := range projectWebhook.Events {
+			found := false
+			for _, activity := range projectWebhook.Payload.Activities {
 				if activity == *v {
-					projectWebhooks = append(projectWebhooks, &projectWebhook)
+					found = true
 					break
 				}
+			}
+			if found {
+				projectWebhooks = append(projectWebhooks, &projectWebhook)
 			}
 		} else {
 			projectWebhooks = append(projectWebhooks, &projectWebhook)

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -3881,6 +3881,10 @@ Activity types for webhook notifications.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| type | [ProjectWebhook.Type](#bytebase-store-ProjectWebhook-Type) |  | Webhook type. |
+| title | [string](#string) |  | Webhook title. |
+| url | [string](#string) |  | Webhook URL. |
+| activities | [Activity.Type](#bytebase-store-Activity-Type) | repeated | List of activities that trigger this webhook. |
 | direct_message | [bool](#bool) |  | If direct_message is set, the notification is sent directly to the persons and url will be ignored. IM integration setting should be set for this function to work. |
 
 

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -10521,6 +10521,34 @@ If enabled, issues cannot be created when SQL review finds errors. </p></td>
             <tbody>
               
                 <tr>
+                  <td>type</td>
+                  <td><a href="#bytebase.store.ProjectWebhook.Type">ProjectWebhook.Type</a></td>
+                  <td></td>
+                  <td><p>Webhook type. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>title</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Webhook title. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>url</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Webhook URL. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>activities</td>
+                  <td><a href="#bytebase.store.Activity.Type">Activity.Type</a></td>
+                  <td>repeated</td>
+                  <td><p>List of activities that trigger this webhook. </p></td>
+                </tr>
+              
+                <tr>
                   <td>direct_message</td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>

--- a/proto/store/store/project_webhook.proto
+++ b/proto/store/store/project_webhook.proto
@@ -55,8 +55,16 @@ message ProjectWebhook {
     LARK = 8;
   }
 
+  // Webhook type.
+  Type type = 1;
+  // Webhook title.
+  string title = 2;
+  // Webhook URL.
+  string url = 3;
+  // List of activities that trigger this webhook.
+  repeated Activity.Type activities = 4;
   // If direct_message is set, the notification is sent directly
   // to the persons and url will be ignored.
   // IM integration setting should be set for this function to work.
-  bool direct_message = 1;
+  bool direct_message = 5;
 }


### PR DESCRIPTION
## Summary

This PR migrates the `project_webhook` table from storing webhook metadata in separate columns (`type`, `name`, `url`, `event_list`) to storing all data in a JSONB `payload` column, following the pattern used in other tables.

## Changes

### Database Schema
- Simplified `project_webhook` table to only include `id`, `project`, and `payload` columns
- Created migration `3.11.17` to backfill existing data into payload and drop old columns
- Updated `LATEST.sql` to reflect new schema

### Proto
- Added `type`, `title`, `url`, and `activities` fields to `ProjectWebhook` message
- Renamed `name` field to `title` for consistency

### Backend
- **Store Layer**: Refactored `ProjectWebhookMessage` to use payload-only storage with direct proto getter access
- **API Layer**: Updated converters and handlers to work with payload fields
- **Webhook Manager**: Updated to use payload getters instead of struct fields
- **Validation**: 
  - Added URL validation for webhook updates (was only validating on create)
  - Moved validation logic from converter to handler layer for better separation of concerns
  - Made `allowedDomains` private (unexported)

## Migration Safety

The migration backfills all existing webhook data from columns into the payload before dropping the old columns. The backfill handles:
- Converting enum types to their string representations
- Converting event arrays to JSON arrays
- Preserving any existing `directMessage` settings

## Test Plan

- ✅ All existing tests pass
- ✅ Go linting passes (0 issues)
- ✅ Backend builds successfully
- ✅ Migration test updated to reflect new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)