### PR TITLE
chore: white list for discord image

### DIFF
--- a/backend/server/echo_routes.go
+++ b/backend/server/echo_routes.go
@@ -109,7 +109,7 @@ func securityHeadersMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	csp := "default-src 'self'; " +
 		"script-src 'self' " + strings.Join(scriptHashes, " ") + " 'wasm-unsafe-eval'; " +
 		"style-src 'self' 'unsafe-inline'; " +
-		"img-src 'self' data: blob:; " +
+		"img-src 'self' data: blob: discordapp.com; " +
 		"connect-src 'self' data: ws: wss: https://api.github.com; " +
 		"font-src 'self'; " +
 		"object-src 'none'; " +


### PR DESCRIPTION
The image is generated dynamically (showing the current online users count), maybe we can also consider using a static image and store it on the local