### PR TITLE
fix: expired role deletion not working in member table

### DIFF
--- a/frontend/src/components/Member/MemberDataTableByRole.vue
+++ b/frontend/src/components/Member/MemberDataTableByRole.vue
@@ -112,7 +112,7 @@ const columns = computed(() => {
             row.scope === "project" &&
             props.allowEdit && (
               <NPopconfirm
-                positive-Click={() =>
+                onPositiveClick={() =>
                   emit("revoke-role", row.name, row.id.endsWith(".expired"))
                 }
                 v-slots={{


### PR DESCRIPTION
Fixed event handler prop name from `positive-Click` to `onPositiveClick` in NPopconfirm component. The incorrect prop name prevented the click handler from being registered, causing nothing to happen when trying to delete expired roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)