### PR TITLE
fix: incorrect directive usage in ReleaseDataTable JSX

### DIFF
--- a/frontend/src/components/Release/ReleaseDataTable.vue
+++ b/frontend/src/components/Release/ReleaseDataTable.vue
@@ -102,9 +102,11 @@ const columnList = computed(
             <div class="flex flex-col items-start gap-1">
               {showFiles.map((file) => (
                 <p class="w-full truncate">
-                  <NTag class="mr-2" v-if="schemaVersion" size="small" round>
-                    {file.version}
-                  </NTag>
+                  {file.version && (
+                    <NTag class="mr-2" size="small" round>
+                      {file.version}
+                    </NTag>
+                  )}
                   {getReleaseFileStatement(file)}
                 </p>
               ))}


### PR DESCRIPTION
Replace invalid v-if directive with JSX conditional expression. Vue template directives cannot be used in JSX render functions. Also replaced undefined schemaVersion with file.version check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)