### PR TITLE
fix: add hostname verification to TLS certificate validation

### DIFF
--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -229,7 +229,7 @@ func (d *Driver) getRDSConnection(ctx context.Context, connCfg db.ConnectionConf
 			RootCAs:            rootCertPool,
 			InsecureSkipVerify: true, // We use custom verification
 		}
-		tlsConfig.VerifyPeerCertificate = util.CreateCertificateVerifier(rootCertPool)
+		tlsConfig.VerifyPeerCertificate = util.CreateCertificateVerifier(rootCertPool, connCfg.DataSource.Host)
 	} else {
 		// Backward compatible config without verification
 		tlsConfig = &tls.Config{


### PR DESCRIPTION
## Summary

  Fixes a security vulnerability in TLS certificate verification where hostname validation was missing, enabling potential Man-in-the-Middle attacks.

  ## Problem

  When `verify_tls_certificate=true`, the custom certificate verifier validated the certificate chain and CA signature but **did not verify the hostname matched the certificate**. This allowed an attacker to present any validly-signed certificate (even for a different domain) and the connection would be accepted.

  ## Solution

  - Added `hostname` parameter to `CreateCertificateVerifier()`
  - Set `DNSName` field in `x509.VerifyOptions` to enforce hostname validation
  - Updated both `GetTLSConfig()` and MySQL RDS code paths