### PR TITLE
refactor: clarify label types with explicit naming (Project/Issue/Database Labels)

### DIFF
--- a/frontend/src/components/DatabaseDetail/Settings/components/Labels.vue
+++ b/frontend/src/components/DatabaseDetail/Settings/components/Labels.vue
@@ -4,7 +4,7 @@
       <div class="flex-1">
         <div class="flex items-center">
           <p class="text-lg font-medium leading-7 text-main flex">
-            {{ $t("common.labels") }}
+            {{ $t("database.labels") }}
           </p>
         </div>
       </div>

--- a/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
+++ b/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
@@ -21,6 +21,7 @@
               params: {
                 projectId: getProjectName(project.name),
               },
+              hash: '#issue-related',
             }"
             class="textinfolabel normal-link flex items-center gap-x-2"
           >

--- a/frontend/src/components/IssueV1/components/Sidebar/IssueLabels.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/IssueLabels.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col gap-y-1">
     <div class="flex items-center gap-x-1 textlabel">
-      <span>{{ $t("common.labels") }}</span>
+      <span>{{ $t("issue.labels") }}</span>
       <RequiredStar v-if="project.forceIssueLabels" />
     </div>
     <IssueLabelSelector

--- a/frontend/src/components/Project/Settings/ProjectGeneralSettingPanel.vue
+++ b/frontend/src/components/Project/Settings/ProjectGeneralSettingPanel.vue
@@ -24,7 +24,7 @@
     <!-- Project Labels Section -->
     <div>
       <div class="font-medium">
-        {{ $t("common.labels") }}
+        {{ $t("project.settings.project-labels.self") }}
       </div>
       <div class="text-sm text-gray-500 mb-3">
         {{ $t("project.settings.project-labels.description") }}

--- a/frontend/src/components/ProjectSettingPanel.vue
+++ b/frontend/src/components/ProjectSettingPanel.vue
@@ -33,7 +33,7 @@
         </div>
       </div>
 
-      <div class="py-6 lg:flex">
+      <div id="issue-related" class="py-6 lg:flex">
         <div class="text-left lg:w-1/4">
           <h1 class="text-2xl font-bold">
             {{ $t("project.settings.issue-related.self") }}

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -846,6 +846,7 @@
     "n-similar-activities": "({count} similar activity) | ({count} similar activities)"
   },
   "issue": {
+    "labels": "Issue Labels",
     "my-issues": "My Issues",
     "waiting-approval": "Waiting for Approval",
     "waiting-rollout": "Waiting for Rollout",
@@ -1594,6 +1595,7 @@
     "rollback-tip": "Select a specific DDL changelog to rollback."
   },
   "database": {
+    "labels": "Database Labels",
     "no-environment": "This database has not been bound to the environment",
     "set-environment": "Set environment",
     "sync-database": "Sync Database",
@@ -1851,7 +1853,7 @@
       "issue-related": {
         "self": "Issue Related",
         "labels": {
-          "self": "Labels",
+          "self": "Issue Labels",
           "description": "Labels can be attached in the issues for management",
           "configure-labels": "Configure labels",
           "placeholder": "Press Enter to add tag",
@@ -1907,6 +1909,7 @@
         }
       },
       "project-labels": {
+        "self": "Project Labels",
         "description": "Organize projects with key-value labels (max 64)"
       }
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -846,6 +846,7 @@
     "n-similar-activities": "({count} actividad similar) | ({count} actividades similares)"
   },
   "issue": {
+    "labels": "Etiquetas de problema",
     "my-issues": "Mis Incidencias",
     "waiting-approval": "A la espera de la aprobación",
     "waiting-rollout": "Esperando el lanzamiento",
@@ -1594,6 +1595,7 @@
     "rollback-tip": "Seleccione un historial de DDL específico para revertir."
   },
   "database": {
+    "labels": "Etiquetas de base de datos",
     "no-environment": "Esta base de datos no ha sido vinculada al entorno.",
     "set-environment": "Establecer entorno",
     "sync-database": "Sincronizar base de datos",
@@ -1851,7 +1853,7 @@
       "issue-related": {
         "self": "Problema Relacionado",
         "labels": {
-          "self": "Etiquetas",
+          "self": "Etiquetas de problema",
           "description": "Se pueden colocar etiquetas en los problemas para su gestión.",
           "configure-labels": "Configurar etiquetas",
           "placeholder": "Presione Enter para agregar etiqueta",
@@ -1907,6 +1909,7 @@
         }
       },
       "project-labels": {
+        "self": "Etiquetas de proyecto",
         "description": "Organizar proyectos con etiquetas clave-valor (máximo 64)"
       }
     },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -846,6 +846,7 @@
     "n-similar-activities": "({count} 件の同様のイベント)"
   },
   "issue": {
+    "labels": "イシューラベル",
     "my-issues": "マイイシュー",
     "waiting-approval": "承認待ち",
     "waiting-rollout": "リリース待ち",
@@ -1594,6 +1595,7 @@
     "rollback-tip": "ロールバックする特定の DDL 履歴を選択します。"
   },
   "database": {
+    "labels": "データベースラベル",
     "no-environment": "このデータベースは環境にバインドされていません",
     "set-environment": "環境を設定する",
     "sync-database": "データベースを同期",
@@ -1851,7 +1853,7 @@
       "issue-related": {
         "self": "イシュー関連",
         "labels": {
-          "self": "ラベル",
+          "self": "イシューラベル",
           "description": "問題にラベルを貼って管理できる",
           "configure-labels": "ラベルを設定する",
           "placeholder": "Enterキーを押してタグを追加してください",
@@ -1907,6 +1909,7 @@
         }
       },
       "project-labels": {
+        "self": "プロジェクトラベル",
         "description": "キーバリューラベルでプロジェクトを整理（最大64個）"
       }
     },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -846,6 +846,7 @@
     "n-similar-activities": "({count} hoạt động tương tự) | ({count} hoạt động tương tự)"
   },
   "issue": {
+    "labels": "Nhãn vấn đề",
     "my-issues": "Vấn đề của tôi",
     "waiting-approval": "Đang chờ phê duyệt",
     "waiting-rollout": "Đang chờ triển khai",
@@ -1594,6 +1595,7 @@
     "rollback-tip": "Chọn một nhật ký thay đổi DDL cụ thể để hoàn tác."
   },
   "database": {
+    "labels": "Nhãn cơ sở dữ liệu",
     "no-environment": "Cơ sở dữ liệu này không bị ràng buộc với môi trường",
     "set-environment": "Thiết lập môi trường",
     "sync-database": "Đồng bộ cơ sở dữ liệu",
@@ -1851,7 +1853,7 @@
       "issue-related": {
         "self": "Liên quan đến vấn đề",
         "labels": {
-          "self": "Nhãn",
+          "self": "Nhãn vấn đề",
           "description": "Có thể gắn nhãn vào các vấn đề để quản lý",
           "configure-labels": "Cấu hình nhãn",
           "placeholder": "Nhấn Enter để thêm thẻ",
@@ -1907,6 +1909,7 @@
         }
       },
       "project-labels": {
+        "self": "Nhãn dự án",
         "description": "Tổ chức dự án với nhãn khóa-giá trị (tối đa 64)"
       }
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -846,6 +846,7 @@
     "n-similar-activities": "({count} 个相似的活动)"
   },
   "issue": {
+    "labels": "工单标签",
     "my-issues": "我的工单",
     "waiting-approval": "等待审批",
     "waiting-rollout": "等待发布",
@@ -1594,6 +1595,7 @@
     "rollback-tip": "选择要回滚到的某个 DDL 历史记录。"
   },
   "database": {
+    "labels": "数据库标签",
     "no-environment": "该数据库尚未绑定到环境",
     "set-environment": "设置环境",
     "sync-database": "同步数据库",
@@ -1851,7 +1853,7 @@
       "issue-related": {
         "self": "工单相关",
         "labels": {
-          "self": "标签",
+          "self": "工单标签",
           "description": "可以在工单中附加标签以便管理",
           "configure-labels": "配置标签",
           "placeholder": "按 Enter 键添加标签",
@@ -1907,6 +1909,7 @@
         }
       },
       "project-labels": {
+        "self": "项目标签",
         "description": "用键值标签组织项目（最多64个）"
       }
     },


### PR DESCRIPTION
Addresses customer confusion about multiple "Labels" sections in the UI by using explicit naming:
  - Project settings: "Labels" → "Project Labels" (key-value pairs)
  - Issue Related settings: "Labels" → "Issue Labels" (tags)
  - Issue sidebar: "Labels" → "Issue Labels"
  - Database settings: "Labels" → "Database Labels"

  Additionally, improved the "Configure labels" link in empty issue label dropdowns to navigate directly to the Issue Related section with `#issue-related` hash, instead of landing at the top of settings.

  Changes span all 5 locale files (en-US, zh-CN, ja-JP, vi-VN, es-ES) and affected Vue components.