### PR TITLE
feat: activate ANTLR-based PostgreSQL parser and advisors

### DIFF
--- a/backend/plugin/parser/pg/legacy/parser.go
+++ b/backend/plugin/parser/pg/legacy/parser.go
@@ -15,9 +15,10 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/parser/pg/legacy/ast"
 )
 
-func init() {
-	base.RegisterParseFunc(storepb.Engine_POSTGRES, parsePostgresForRegistry)
-}
+// Disabled legacy parser registration - now using ANTLR parser
+// func init() {
+// 	base.RegisterParseFunc(storepb.Engine_POSTGRES, parsePostgresForRegistry)
+// }
 
 // parsePostgresForRegistry is the ParseFunc for PostgreSQL.
 // Returns []ast.Node (github.com/bytebase/bytebase/backend/plugin/parser/pg/legacy/ast) on success.

--- a/backend/plugin/parser/pg/pg.go
+++ b/backend/plugin/parser/pg/pg.go
@@ -6,8 +6,19 @@ import (
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/postgresql"
 
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
+
+func init() {
+	base.RegisterParseFunc(storepb.Engine_POSTGRES, parsePostgreSQLForRegistry)
+}
+
+// parsePostgreSQLForRegistry is the ParseFunc for PostgreSQL.
+// Returns *ParseResult containing the ANTLR tree.
+func parsePostgreSQLForRegistry(statement string) (any, error) {
+	return ParsePostgreSQL(statement)
+}
 
 type ParseResult struct {
 	Tree   antlr.Tree


### PR DESCRIPTION
## Summary
Activates the ANTLR-based parser and advisors for PostgreSQL by switching the Parse function registration from the legacy pg_query_go implementation to the new ANTLR parser.

This PR completes the PostgreSQL migration to ANTLR that was started in #17878.

## Changes
- **Registered ANTLR parser**: Added `init()` function in `backend/plugin/parser/pg/pg.go` to register the ANTLR-based `ParsePostgreSQL` function
- **Disabled legacy parser**: Commented out the legacy parser registration in `backend/plugin/parser/pg/legacy/parser.go`
- **AST type change**: The Parse function now returns `*ParseResult` (containing ANTLR tree) instead of `[]ast.Node` (pg_query_go AST)

## Impact
### ✅ Working Systems
- **ANTLR Advisors**: All 55+ ANTLR-based advisors in `backend/plugin/advisor/pgantlr/` are now active
- **Catalog Walkthrough**: The ANTLR-based catalog walkthrough (from #17878) handles all DDL operations
- **SQL Review Checks**: Full advisor functionality with ANTLR trees

### ❌ Legacy Systems (Now Obsolete)
- **Legacy Advisors**: The 55+ advisors in `backend/plugin/advisor/pg/` no longer work (expected)
- **Legacy Tests**: Tests in `backend/plugin/advisor/pg/` fail with "failed to convert to Node" (expected)

## Testing
- ✅ `TestPostgreSQLANTLRWalkThrough` passes - Catalog walkthrough works with ANTLR
- ✅ `TestPostgreSQLANTLRRules` passes - All ANTLR advisors work correctly
- ❌ Legacy advisor tests fail (expected and acceptable)

## Migration Status
This PR completes the PostgreSQL ANTLR migration:
- [x] Implement ANTLR catalog walkthrough (#17878)
- [x] Implement all 55+ ANTLR advisors (completed previously)  
- [x] Switch Parse registration to ANTLR (this PR)
- [x] Verify all ANTLR tests pass (this PR)

## Next Steps (Future PRs)
- Remove legacy advisor code from `backend/plugin/advisor/pg/` directory
- Update documentation to reference ANTLR instead of pg_query_go
- Consider removing pg_query_go dependency entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)