### PR TITLE
feat: add ANTLR-based statement type detection for PostgreSQL

### DIFF
--- a/backend/plugin/parser/pg/statement_type_antlr_test.go
+++ b/backend/plugin/parser/pg/statement_type_antlr_test.go
@@ -57,39 +57,89 @@ func TestGetStatementTypesANTLR(t *testing.T) {
 			sql:           "DROP SCHEMA schema1;",
 			expectedTypes: []string{"DROP_SCHEMA"},
 		},
-	{
-		name:          "DROP SEQUENCE",
-		sql:           "DROP SEQUENCE seq1;",
-		expectedTypes: []string{"DROP_SEQUENCE"},
-	},
-	{
-		name:          "DROP EXTENSION",
-		sql:           "DROP EXTENSION postgis;",
-		expectedTypes: []string{"DROP_EXTENSION"},
-	},
-	{
-		name:          "DROP DATABASE",
-		sql:           "DROP DATABASE testdb;",
-		expectedTypes: []string{"DROP_DATABASE"},
-	},
-	{
-		name:          "DROP TYPE",
-		sql:           "DROP TYPE custom_type;",
-		expectedTypes: []string{"DROP_TYPE"},
-	},
-	{
-		name:          "DROP TRIGGER",
-		sql:           "DROP TRIGGER trig1 ON t1;",
-		expectedTypes: []string{"DROP_TRIGGER"},
-	},
-	{
-		name:          "DROP VIEW",
-		sql:           "DROP VIEW v1;",
-		expectedTypes: []string{"DROP_TABLE"},
-	},
 		{
-			name:          "ALTER TABLE",
+			name:          "DROP SEQUENCE",
+			sql:           "DROP SEQUENCE seq1;",
+			expectedTypes: []string{"DROP_SEQUENCE"},
+		},
+		{
+			name:          "DROP EXTENSION",
+			sql:           "DROP EXTENSION postgis;",
+			expectedTypes: []string{"DROP_EXTENSION"},
+		},
+		{
+			name:          "DROP DATABASE",
+			sql:           "DROP DATABASE testdb;",
+			expectedTypes: []string{"DROP_DATABASE"},
+		},
+		{
+			name:          "DROP TYPE",
+			sql:           "DROP TYPE custom_type;",
+			expectedTypes: []string{"DROP_TYPE"},
+		},
+		{
+			name:          "DROP TRIGGER",
+			sql:           "DROP TRIGGER trig1 ON t1;",
+			expectedTypes: []string{"DROP_TRIGGER"},
+		},
+		{
+			name:          "DROP VIEW",
+			sql:           "DROP VIEW v1;",
+			expectedTypes: []string{"DROP_TABLE"},
+		},
+		{
+			name:          "DROP FUNCTION",
+			sql:           "DROP FUNCTION func1();",
+			expectedTypes: []string{"DROP_FUNCTION"},
+		},
+		{
+			name:          "CREATE TYPE",
+			sql:           "CREATE TYPE custom_type AS ENUM ('a', 'b', 'c');",
+			expectedTypes: []string{"CREATE_TYPE"},
+		},
+		{
+			name:          "ALTER TABLE ADD COLUMN",
 			sql:           "ALTER TABLE t1 ADD COLUMN name VARCHAR(100);",
+			expectedTypes: []string{"ALTER_TABLE_ADD_COLUMN_LIST"},
+		},
+		{
+			name:          "ALTER TABLE ADD CONSTRAINT",
+			sql:           "ALTER TABLE t1 ADD CONSTRAINT pk_id PRIMARY KEY (id);",
+			expectedTypes: []string{"ALTER_TABLE_ADD_CONSTRAINT"},
+		},
+		{
+			name:          "ALTER TABLE DROP COLUMN",
+			sql:           "ALTER TABLE t1 DROP COLUMN name;",
+			expectedTypes: []string{"DROP_COLUMN"},
+		},
+		{
+			name:          "ALTER TABLE DROP CONSTRAINT",
+			sql:           "ALTER TABLE t1 DROP CONSTRAINT pk_id;",
+			expectedTypes: []string{"DROP_CONSTRAINT"},
+		},
+		{
+			name:          "ALTER TABLE ALTER COLUMN TYPE",
+			sql:           "ALTER TABLE t1 ALTER COLUMN name TYPE TEXT;",
+			expectedTypes: []string{"ALTER_COLUMN_TYPE"},
+		},
+		{
+			name:          "ALTER TABLE ALTER COLUMN DROP DEFAULT",
+			sql:           "ALTER TABLE t1 ALTER COLUMN name DROP DEFAULT;",
+			expectedTypes: []string{"DROP_DEFAULT"},
+		},
+		{
+			name:          "ALTER TABLE ALTER COLUMN DROP NOT NULL",
+			sql:           "ALTER TABLE t1 ALTER COLUMN name DROP NOT NULL;",
+			expectedTypes: []string{"DROP_NOT_NULL"},
+		},
+		{
+			name:          "ALTER VIEW",
+			sql:           "ALTER VIEW v1 OWNER TO user1;",
+			expectedTypes: []string{"ALTER_VIEW"},
+		},
+		{
+			name:          "ALTER TABLE (generic)",
+			sql:           "ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;",
 			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{


### PR DESCRIPTION
## Summary

Implements ANTLR-based versions of statement type detection functions (`GetStatementTypes` and `GetStatementTypesWithPositions`) as a preparatory step for migrating PostgreSQL from pg_query_go legacy parser to ANTLR parser.

This PR adds new functionality without changing existing behavior, making it safe to merge independently.

## Background

Currently, two features rely on statement type detection via the AST cache:

1. **SQL Summary Report** (`backend/runner/plancheck/statement_report_executor.go`)
   - Used in plan checks to determine statement types (CREATE_TABLE, ALTER_INDEX, INSERT, etc.)
   - Calls `pg.GetStatementTypes(asts)` with legacy AST

2. **SDL File Validation** (`backend/api/v1/release_service_check.go`)
   - Validates that SDL files only contain allowed statements (CREATE, COMMENT)
   - Calls `pg.GetStatementTypesWithPositions(asts)` with legacy AST

Both features currently expect `[]ast.Node` from pg_query_go but need to support ANTLR's `*ParseResult`.

## Changes

### New Files

1. **`backend/plugin/parser/pg/statement_type_antlr.go`** (400 lines)
   - `GetStatementTypesANTLR(parseResult *ParseResult) ([]string, error)`
   - `GetStatementTypesWithPositionsANTLR(parseResult *ParseResult) ([]StatementTypeWithPosition, error)`
   - Implements ANTLR listener pattern with specific `Enter*` methods for each statement type

2. **`backend/plugin/parser/pg/statement_type_antlr_test.go`** (170 lines)
   - Comprehensive test coverage for all statement types
   - Tests position tracking functionality

### Statement Types Supported

**DDL - CREATE:**
- ✅ CREATE TABLE
- ✅ CREATE VIEW
- ✅ CREATE INDEX
- ✅ CREATE SEQUENCE
- ✅ CREATE SCHEMA
- ✅ CREATE FUNCTION
- ✅ CREATE TRIGGER
- ✅ CREATE EXTENSION
- ✅ CREATE DATABASE

**DDL - DROP:**
- ✅ DROP TABLE
- ✅ DROP VIEW (returns DROP_TABLE)
- ✅ DROP INDEX
- ✅ DROP SCHEMA
- ✅ DROP SEQUENCE
- ✅ DROP EXTENSION
- ✅ DROP DATABASE
- ✅ DROP TYPE
- ✅ DROP TRIGGER

**DDL - ALTER:**
- ✅ ALTER TABLE
- ✅ ALTER SEQUENCE
- ✅ ALTER TYPE

**DDL - RENAME:**
- ✅ RENAME_TABLE
- ✅ RENAME_COLUMN
- ✅ RENAME_CONSTRAINT
- ✅ RENAME_INDEX
- ✅ RENAME_SCHEMA
- ✅ RENAME_SEQUENCE
- ✅ RENAME_VIEW

**DDL - Other:**
- ✅ COMMENT

**DML:**
- ✅ INSERT
- ✅ UPDATE
- ✅ DELETE

### Implementation Approach

Uses ANTLR listener pattern with dedicated methods:
```go
func (c *statementTypeCollector) EnterCreatestmt(ctx *parser.CreatestmtContext)
func (c *statementTypeCollector) EnterViewstmt(ctx *parser.ViewstmtContext)
func (c *statementTypeCollector) EnterIndexstmt(ctx *parser.IndexstmtContext)
func (c *statementTypeCollector) EnterRenamestmt(ctx *parser.RenamestmtContext)
// ... and so on
```

**RENAME Statement Detection:**

The `getRenameStatementType()` function returns specific types by examining the context:
- Checks for `CONSTRAINT` keyword → `RENAME_CONSTRAINT`
- Counts name elements (2 for column rename, 1 for table rename) → `RENAME_COLUMN` or `RENAME_TABLE`
- Checks for `INDEX`, `SCHEMA`, `SEQUENCE`, `VIEW` keywords → respective specific types
- Returns `UNKNOWN` for unhandled RENAME types (filtered out by helpers)

Works correctly with or without the `COLUMN` keyword in column renames.

## Test Results

```
✅ All 30 tests passing (including 8 RENAME variants, 9 DROP variants)
✅ Position tracking working correctly
✅ Multiple statement handling working
✅ Statement text extraction working
```

## Impact

- **No breaking changes** - adds new functions without modifying existing ones
- **No changes to callers** - existing code continues to use legacy functions
- **Safe to merge** - new functions are unused until future migration work

## Next Steps

Future PRs will:
1. Update existing `GetStatementTypes` functions to detect AST type and dispatch to appropriate implementation
2. Update callers to handle both legacy and ANTLR ASTs
3. Eventually switch AST cache to return ANTLR `*ParseResult`

## Dependencies

- Depends on ANTLR parser infrastructure (already merged)
- Depends on ANTLR catalog walkthrough (PR #17878, already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

