### PR TITLE
perf: add partial index on plan_check_run for RUNNING status

### DIFF
--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -295,6 +295,8 @@ CREATE TABLE plan_check_run (
 
 CREATE INDEX idx_plan_check_run_plan_id ON plan_check_run (plan_id);
 
+CREATE INDEX idx_plan_check_run_active_status ON plan_check_run(status, id) WHERE status = 'RUNNING';
+
 ALTER SEQUENCE plan_check_run_id_seq RESTART WITH 101;
 
 -- Plan related END

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.11.20"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.11.21"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add partial index `idx_plan_check_run_active_status` on `plan_check_run(status, id)` for `RUNNING` status
- Optimizes the plan check scheduler's hot path query that runs every 5 seconds
- Follows the same pattern as `task_run`'s `idx_task_run_active_status_id`

## Problem

The plan check scheduler polls every 5 seconds with:
```sql
SELECT ... FROM plan_check_run WHERE status = 'RUNNING' ORDER BY id ASC
```

This query was performing sequential scans with cost 133.43 because there was no index on the status column.

## Solution

Use a partial index that only covers `RUNNING` status:
```sql
CREATE INDEX idx_plan_check_run_active_status ON plan_check_run(status, id) 
WHERE status = 'RUNNING';
```

## Benefits

- ✅ Eliminates sequential scan (cost drops from 133.43 to near-instant index scan)
- ✅ Smaller index size (only RUNNING rows, not all historical completed checks)
- ✅ Better cache efficiency (smaller index fits in memory)
- ✅ Supports `ORDER BY id ASC` efficiently with the composite `(status, id)` columns
- ✅ Consistent with existing `task_run` indexing strategy

## Test Plan

- [x] Created migration file `3.11/0021##plan_check_run_status_index.sql`
- [x] Updated `LATEST.sql` with the new index
- [x] Updated `migrator_test.go` to version 3.11.21
- [x] Verified `TestLatestVersion` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)