### PR TITLE
feat: add ANTLR-based statement type detection for PostgreSQL

### DIFF
--- a/backend/plugin/parser/pg/statement_type_antlr_test.go
+++ b/backend/plugin/parser/pg/statement_type_antlr_test.go
@@ -57,39 +57,89 @@ func TestGetStatementTypesANTLR(t *testing.T) {
 			sql:           "DROP SCHEMA schema1;",
 			expectedTypes: []string{"DROP_SCHEMA"},
 		},
-	{
-		name:          "DROP SEQUENCE",
-		sql:           "DROP SEQUENCE seq1;",
-		expectedTypes: []string{"DROP_SEQUENCE"},
-	},
-	{
-		name:          "DROP EXTENSION",
-		sql:           "DROP EXTENSION postgis;",
-		expectedTypes: []string{"DROP_EXTENSION"},
-	},
-	{
-		name:          "DROP DATABASE",
-		sql:           "DROP DATABASE testdb;",
-		expectedTypes: []string{"DROP_DATABASE"},
-	},
-	{
-		name:          "DROP TYPE",
-		sql:           "DROP TYPE custom_type;",
-		expectedTypes: []string{"DROP_TYPE"},
-	},
-	{
-		name:          "DROP TRIGGER",
-		sql:           "DROP TRIGGER trig1 ON t1;",
-		expectedTypes: []string{"DROP_TRIGGER"},
-	},
-	{
-		name:          "DROP VIEW",
-		sql:           "DROP VIEW v1;",
-		expectedTypes: []string{"DROP_TABLE"},
-	},
 		{
-			name:          "ALTER TABLE",
+			name:          "DROP SEQUENCE",
+			sql:           "DROP SEQUENCE seq1;",
+			expectedTypes: []string{"DROP_SEQUENCE"},
+		},
+		{
+			name:          "DROP EXTENSION",
+			sql:           "DROP EXTENSION postgis;",
+			expectedTypes: []string{"DROP_EXTENSION"},
+		},
+		{
+			name:          "DROP DATABASE",
+			sql:           "DROP DATABASE testdb;",
+			expectedTypes: []string{"DROP_DATABASE"},
+		},
+		{
+			name:          "DROP TYPE",
+			sql:           "DROP TYPE custom_type;",
+			expectedTypes: []string{"DROP_TYPE"},
+		},
+		{
+			name:          "DROP TRIGGER",
+			sql:           "DROP TRIGGER trig1 ON t1;",
+			expectedTypes: []string{"DROP_TRIGGER"},
+		},
+		{
+			name:          "DROP VIEW",
+			sql:           "DROP VIEW v1;",
+			expectedTypes: []string{"DROP_TABLE"},
+		},
+		{
+			name:          "DROP FUNCTION",
+			sql:           "DROP FUNCTION func1();",
+			expectedTypes: []string{"DROP_FUNCTION"},
+		},
+		{
+			name:          "CREATE TYPE",
+			sql:           "CREATE TYPE custom_type AS ENUM ('a', 'b', 'c');",
+			expectedTypes: []string{"CREATE_TYPE"},
+		},
+		{
+			name:          "ALTER TABLE ADD COLUMN",
 			sql:           "ALTER TABLE t1 ADD COLUMN name VARCHAR(100);",
+			expectedTypes: []string{"ALTER_TABLE_ADD_COLUMN_LIST"},
+		},
+		{
+			name:          "ALTER TABLE ADD CONSTRAINT",
+			sql:           "ALTER TABLE t1 ADD CONSTRAINT pk_id PRIMARY KEY (id);",
+			expectedTypes: []string{"ALTER_TABLE_ADD_CONSTRAINT"},
+		},
+		{
+			name:          "ALTER TABLE DROP COLUMN",
+			sql:           "ALTER TABLE t1 DROP COLUMN name;",
+			expectedTypes: []string{"DROP_COLUMN"},
+		},
+		{
+			name:          "ALTER TABLE DROP CONSTRAINT",
+			sql:           "ALTER TABLE t1 DROP CONSTRAINT pk_id;",
+			expectedTypes: []string{"DROP_CONSTRAINT"},
+		},
+		{
+			name:          "ALTER TABLE ALTER COLUMN TYPE",
+			sql:           "ALTER TABLE t1 ALTER COLUMN name TYPE TEXT;",
+			expectedTypes: []string{"ALTER_COLUMN_TYPE"},
+		},
+		{
+			name:          "ALTER TABLE ALTER COLUMN DROP DEFAULT",
+			sql:           "ALTER TABLE t1 ALTER COLUMN name DROP DEFAULT;",
+			expectedTypes: []string{"DROP_DEFAULT"},
+		},
+		{
+			name:          "ALTER TABLE ALTER COLUMN DROP NOT NULL",
+			sql:           "ALTER TABLE t1 ALTER COLUMN name DROP NOT NULL;",
+			expectedTypes: []string{"DROP_NOT_NULL"},
+		},
+		{
+			name:          "ALTER VIEW",
+			sql:           "ALTER VIEW v1 OWNER TO user1;",
+			expectedTypes: []string{"ALTER_VIEW"},
+		},
+		{
+			name:          "ALTER TABLE (generic)",
+			sql:           "ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;",
 			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{


### PR DESCRIPTION
## Summary

Implements ANTLR-based versions of statement type detection functions (`GetStatementTypes` and `GetStatementTypesWithPositions`) as a preparatory step for migrating PostgreSQL from pg_query_go legacy parser to ANTLR parser.

This PR adds new functionality without changing existing behavior, making it safe to merge independently.

## Background

Currently, two features rely on statement type detection via the AST cache:

1. **SQL Summary Report** (`backend/runner/plancheck/statement_report_executor.go`)
   - Used in plan checks to determine statement types (CREATE_TABLE, ALTER_INDEX, INSERT, etc.)
   - Calls `pg.GetStatementTypes(asts)` with legacy AST

2. **SDL File Validation** (`backend/api/v1/release_service_check.go`)
   - Validates that SDL files only contain allowed statements (CREATE, COMMENT)
   - Calls `pg.GetStatementTypesWithPositions(asts)` with legacy AST

Both features currently expect `[]ast.Node` from pg_query_go but need to support ANTLR's `*ParseResult`.

## Changes

### New Files

1. **`backend/plugin/parser/pg/statement_type_antlr.go`** (500+ lines)
   - `GetStatementTypesANTLR(parseResult *ParseResult) ([]string, error)`
   - `GetStatementTypesWithPositionsANTLR(parseResult *ParseResult) ([]StatementTypeWithPosition, error)`
   - Implements ANTLR listener pattern with specific `Enter*` methods for each statement type

2. **`backend/plugin/parser/pg/statement_type_antlr_test.go`** (240 lines)
   - Comprehensive test coverage for all statement types
   - Tests position tracking functionality

### Statement Types Supported

**DDL - CREATE:**
- ✅ CREATE TABLE
- ✅ CREATE VIEW
- ✅ CREATE INDEX
- ✅ CREATE SEQUENCE
- ✅ CREATE SCHEMA
- ✅ CREATE FUNCTION
- ✅ CREATE TRIGGER
- ✅ CREATE EXTENSION
- ✅ CREATE DATABASE
- ✅ CREATE TYPE

**DDL - DROP:**
- ✅ DROP TABLE
- ✅ DROP VIEW (returns DROP_TABLE)
- ✅ DROP INDEX
- ✅ DROP SCHEMA
- ✅ DROP SEQUENCE
- ✅ DROP EXTENSION
- ✅ DROP DATABASE
- ✅ DROP TYPE
- ✅ DROP TRIGGER
- ✅ DROP FUNCTION

**DDL - ALTER:**
- ✅ ALTER TABLE (generic)
- ✅ ALTER TABLE sub-operations:
  - ✅ ALTER_TABLE_ADD_COLUMN_LIST
  - ✅ ALTER_TABLE_ADD_CONSTRAINT
  - ✅ DROP_COLUMN
  - ✅ DROP_CONSTRAINT
  - ✅ ALTER_COLUMN_TYPE
  - ✅ DROP_DEFAULT
  - ✅ DROP_NOT_NULL
- ✅ ALTER SEQUENCE
- ✅ ALTER VIEW
- ✅ ALTER TYPE

**DDL - RENAME:**
- ✅ RENAME_TABLE
- ✅ RENAME_COLUMN
- ✅ RENAME_CONSTRAINT
- ✅ RENAME_INDEX
- ✅ RENAME_SCHEMA
- ✅ RENAME_SEQUENCE
- ✅ RENAME_VIEW

**DDL - Other:**
- ✅ COMMENT

**DML:**
- ✅ INSERT
- ✅ UPDATE
- ✅ DELETE

### Implementation Approach

Uses ANTLR listener pattern with dedicated methods:
```go
func (c *statementTypeCollector) EnterCreatestmt(ctx *parser.CreatestmtContext)
func (c *statementTypeCollector) EnterViewstmt(ctx *parser.ViewstmtContext)
func (c *statementTypeCollector) EnterIndexstmt(ctx *parser.IndexstmtContext)
func (c *statementTypeCollector) EnterRenamestmt(ctx *parser.RenamestmtContext)
func (c *statementTypeCollector) EnterAltertablestmt(ctx *parser.AltertablestmtContext)
func (c *statementTypeCollector) EnterDefinestmt(ctx *parser.DefinestmtContext)
func (c *statementTypeCollector) EnterRemovefuncstmt(ctx *parser.RemovefuncstmtContext)
// ... and so on
```

**CREATE TYPE Detection:**

The `EnterDefinestmt()` listener checks for `TYPE_P()` keyword to detect CREATE TYPE statements.

**DROP Statement Detection:**

The `getDropStatementType()` function examines the grammar context:
- Checks for `TYPE_P()` keyword → `DROP_TYPE`
- Checks `object_type_any_name` for TABLE, VIEW, INDEX, SEQUENCE → respective types
- Checks `drop_type_name` for SCHEMA, EXTENSION → respective types
- Checks `object_type_name_on_any_name` for TRIGGER → `DROP_TRIGGER`
- Separate `EnterDropdbstmt()` listener for `DROP_DATABASE`
- Separate `EnterRemovefuncstmt()` listener for `DROP_FUNCTION`

**ALTER TABLE Sub-Operation Detection:**

The `getAlterTableCmdType()` function parses nested `alter_table_cmd` contexts:
- Checks ADD_P() + ColumnDef() → `ALTER_TABLE_ADD_COLUMN_LIST`
- Checks ADD_P() + Tableconstraint() → `ALTER_TABLE_ADD_CONSTRAINT`
- Checks ALTER() + TYPE_P() → `ALTER_COLUMN_TYPE`
- Checks ALTER() + DROP() + NOT() + NULL_P() → `DROP_NOT_NULL`
- Checks ALTER() + Alter_column_default().DROP() → `DROP_DEFAULT`
- Checks DROP() + colid (no CONSTRAINT) → `DROP_COLUMN`
- Checks DROP() + CONSTRAINT() → `DROP_CONSTRAINT`

**Order matters**: ALTER COLUMN checks must precede DROP checks to avoid misclassification.

**ALTER VIEW Detection:**

The `EnterAltertablestmt()` listener checks for `VIEW()` keyword at the beginning to distinguish ALTER VIEW from ALTER TABLE operations.

**RENAME Statement Detection:**

The `getRenameStatementType()` function returns specific types by examining the context:
- Checks for `CONSTRAINT` keyword → `RENAME_CONSTRAINT`
- Counts name elements (2 for column rename, 1 for table rename) → `RENAME_COLUMN` or `RENAME_TABLE`
- Checks for `INDEX`, `SCHEMA`, `SEQUENCE`, `VIEW` keywords → respective specific types
- Returns `UNKNOWN` for unhandled RENAME types (filtered out by helpers)

Works correctly with or without the `COLUMN` keyword in column renames.

## Test Results

```
✅ All 41 tests passing (including 8 RENAME variants, 10 DROP variants, 7 ALTER TABLE sub-operations)
✅ Position tracking working correctly
✅ Multiple statement handling working
✅ Statement text extraction working
```

## Impact

- **No breaking changes** - adds new functions without modifying existing ones
- **No changes to callers** - existing code continues to use legacy functions
- **Safe to merge** - new functions are unused until future migration work

## Next Steps

Future PRs will:
1. Update existing `GetStatementTypes` functions to detect AST type and dispatch to appropriate implementation
2. Update callers to handle both legacy and ANTLR ASTs
3. Eventually switch AST cache to return ANTLR `*ParseResult`

## Dependencies

- Depends on ANTLR parser infrastructure (already merged)
- Depends on ANTLR catalog walkthrough (PR #17878, already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
