### PR TITLE
fix(frontend): make create environment drawer closeable

### DIFF
--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -52,7 +52,7 @@
     </NTabs>
   </div>
 
-  <Drawer :show="state.showCreateModal" @close="discardReorder">
+  <Drawer :show="state.showCreateModal" @close="state.showCreateModal = false">
     <EnvironmentForm
       :create="true"
       :environment="getEnvironmentCreate()"


### PR DESCRIPTION
Fixed an issue where the create environment drawer could not be closed by clicking outside or using the close button. The @close handler was incorrectly set to discardReorder (for the reorder drawer) instead of properly closing the create modal.
