### PR TITLE
fix(frontend): fix Monaco editor decoration position bug

### DIFF
--- a/frontend/src/utils/v1/position.ts
+++ b/frontend/src/utils/v1/position.ts
@@ -30,12 +30,14 @@ export function batchConvertPositionToMonacoPosition(
 
     const line = lines[lineNumber - 1];
     let column = 1;
+    let pushed = false;
     for (let i = 0; i < line.length; i++) {
       if (position.column <= i + 1) {
         result.push({
           lineNumber: lineNumber,
           column: column,
         });
+        pushed = true;
         break;
       }
       const codePoint = line.codePointAt(i);
@@ -45,10 +47,12 @@ export function batchConvertPositionToMonacoPosition(
       const codeUnitCount = codePoint > 0xffff ? 2 : 1;
       column += codeUnitCount;
     }
-    result.push({
-      lineNumber: lineNumber,
-      column: column,
-    });
+    if (!pushed) {
+      result.push({
+        lineNumber: lineNumber,
+        column: column,
+      });
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary

Fixed a critical bug in `batchConvertPositionToMonacoPosition` that caused Monaco editor decorations (squiggly lines) to appear at incorrect line numbers in the SQL editor.

## The Bug

The `batchConvertPositionToMonacoPosition` function was returning **duplicate positions**, causing a mismatch between the advice array and the position arrays.

### Root Cause

```typescript
for (let i = 0; i < line.length; i++) {
  if (position.column <= i + 1) {
    result.push({ lineNumber, column });
    break;  // ← Breaks out of loop
  }
  ...
}
result.push({ lineNumber, column });  // ← ALWAYS runs, even after break!
```

This caused each position to be pushed **twice** when `position.column <= i + 1` was true.

### Impact

**Example**: Input positions `[line 1, line 9]` returned `[line 1, line 1, line 9, line 9]`

This caused index misalignment:
- `monacoStartPosition[0]` → line 1 ✓
- `monacoStartPosition[1]` → line 1 (duplicate) ✗ 
- `monacoStartPosition[2]` → line 9 ✗ (should be index 1)

Result: Decorations for errors on lines 1 and 9 appeared at wrong positions in the editor.

## The Fix

Added a `pushed` flag to ensure each position is added to the result array **exactly once**:

```typescript
let pushed = false;
for (let i = 0; i < line.length; i++) {
  if (position.column <= i + 1) {
    result.push({ lineNumber, column });
    pushed = true;
    break;
  }
  ...
}
if (!pushed) {
  result.push({ lineNumber, column });
}
```

## Testing

- ✅ Frontend type checking passes
- ✅ Frontend linting passes
- ✅ Manual testing with test data confirms correct position mapping

## Related

This fix complements PR #17961 which improved backend line number accuracy for SQL Review advisors.