### PR TITLE
chore: multi-export in sql editor

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
@@ -183,7 +183,6 @@ import type {
   SQLEditorQueryParams,
   SQLResultSetV1,
 } from "@/types";
-import { isValidDatabaseName } from "@/types";
 import { ExportFormat } from "@/types/proto-es/v1/common_pb";
 import {
   PolicyType,
@@ -191,10 +190,7 @@ import {
   type QueryDataPolicy,
 } from "@/types/proto-es/v1/org_policy_service_pb";
 import { ExportRequestSchema } from "@/types/proto-es/v1/sql_service_pb";
-import {
-  hasWorkspacePermissionV2,
-  hasPermissionToCreateDataExportIssue,
-} from "@/utils";
+import { hasWorkspacePermissionV2 } from "@/utils";
 import { provideBinaryFormatContext } from "./DataTable/binary-format-store";
 import DetailPanel from "./DetailPanel";
 import EmptyView from "./EmptyView.vue";

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
@@ -286,7 +286,7 @@ const props = defineProps<{
   showExport: boolean;
 }>();
 
-const emit = defineEmits<{
+defineEmits<{
   (
     event: "export",
     option: {


### PR DESCRIPTION
When the user is allowed to export all query results, we just provide 1 button to export all data

![CleanShot 2025-11-03 at 17 22 42](https://github.com/user-attachments/assets/cb380e4e-eee8-470f-8236-38e7ea76d662)

When some of the results are not allowed to export, will fallback to the previous UX

![CleanShot 2025-11-03 at 17 07 33](https://github.com/user-attachments/assets/623c18d4-3c73-4fce-8bde-ccbbe51ff539)

If the query only contains 1 statement, no change for the UX

![CleanShot 2025-11-03 at 17 33 29](https://github.com/user-attachments/assets/0a83646d-7069-455b-bf90-f129a4cf3d01)

Close BYT-8319