### PR TITLE
fix: migrate legacy statement.where.require SQL review rules

### DIFF
--- a/backend/migrator/migration/3.12/0002##migrate_statement_where_require_rule.sql
+++ b/backend/migrator/migration/3.12/0002##migrate_statement_where_require_rule.sql
@@ -1,0 +1,53 @@
+-- Migrate old statement.where.require rules to the new split rules
+--
+-- Context: In commit 2470780e8b (Sep 2024), the statement.where.require rule was split into two:
+--   - statement.where.require.select (for SELECT statements)
+--   - statement.where.require.update-delete (for UPDATE/DELETE statements)
+--
+-- This migration finds any remaining statement.where.require rules in review_config
+-- and replaces each one with both new rule types, preserving the original level and engine.
+--
+-- Note: The JSONB column stores JSON marshaled by protojson.Marshal, which produces
+-- camelCased keys. So we access fields as: type, level, engine (not Type, Level, Engine).
+
+UPDATE review_config
+SET payload = jsonb_set(
+    payload,
+    '{sqlReviewRules}',
+    (
+        WITH expanded_rules AS (
+            SELECT
+                CASE
+                    -- When we find a statement.where.require rule, expand it into two rules
+                    WHEN rule->>'type' = 'statement.where.require' THEN
+                        jsonb_build_array(
+                            jsonb_build_object(
+                                'type', 'statement.where.require.select',
+                                'level', rule->>'level',
+                                'payload', COALESCE(rule->>'payload', ''),
+                                'engine', rule->>'engine',
+                                'comment', COALESCE(rule->>'comment', '')
+                            ),
+                            jsonb_build_object(
+                                'type', 'statement.where.require.update-delete',
+                                'level', rule->>'level',
+                                'payload', COALESCE(rule->>'payload', ''),
+                                'engine', rule->>'engine',
+                                'comment', COALESCE(rule->>'comment', '')
+                            )
+                        )
+                    -- Keep all other rules as-is, wrapped in array for consistency
+                    ELSE jsonb_build_array(rule)
+                END AS rules
+            FROM jsonb_array_elements(payload->'sqlReviewRules') AS rule
+        )
+        SELECT jsonb_agg(expanded_rule)
+        FROM expanded_rules, jsonb_array_elements(expanded_rules.rules) AS expanded_rule
+    )
+)
+WHERE payload ? 'sqlReviewRules'
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(payload->'sqlReviewRules') AS rule
+      WHERE rule->>'type' = 'statement.where.require'
+  );

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.12.1"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.12.2"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #BYT-8264 - "unknown advisor statement.where.require for MYSQL" error

This PR adds a database migration to update legacy SQL review rules that were left behind when the `statement.where.require` rule was split in September 2024.

## Root Cause Analysis

The issue has **two underlying causes** that combined to surface this error:

### 1. Missing Migration (Sep 2024, commit 2470780e8b)

In September 2024, the `statement.where.require` advisor rule was split into two separate rules to provide more granular control:
- `statement.where.require.select` - for SELECT statements
- `statement.where.require.update-delete` - for UPDATE/DELETE statements

**However, no database migration was provided** to update existing SQL review configurations in users' databases. This meant:
- New installations used the new rule types
- Existing installations retained `statement.where.require` in their `review_config` table
- The old rule type was no longer recognized by the advisor system

### 2. Behavior Change (Sep 2025, commit e3861d41df)

In September 2025, a refactoring removed the `getAdvisorTypeByRule()` function that had been mapping rule type strings to advisor implementations.

**Before refactoring:**
- When an unknown advisor type was encountered, it would log a warning and skip the rule
- Errors were never propagated to the frontend
- Users never saw the issue

**After refactoring:**
- Unknown advisor types now directly return errors from the `Check()` function
- These errors are propagated back to the frontend as error messages
- Users started seeing "unknown advisor statement.where.require for MYSQL" errors

## Solution

This PR adds a proper database migration instead of reverting to the warning-and-skip approach (which would be technical debt).

### Migration: `3.12/0002##migrate_statement_where_require_rule.sql`

The migration:
1. Finds all legacy `statement.where.require` rules in the `review_config` table
2. Replaces each legacy rule with **both** new rule types:
   - `statement.where.require.select`
   - `statement.where.require.update-delete`
3. Preserves all original rule properties:
   - `level` (ERROR, WARNING)
   - `payload` (rule-specific configuration JSON)
   - `engine` (MYSQL, POSTGRES, etc.)
   - `comment` (user notes)
4. Keeps all other rules unchanged

The migration is:
- ✅ Idempotent (safe to run multiple times)
- ✅ Non-destructive (only updates affected rules)
- ✅ Handles missing fields gracefully (uses COALESCE)

### Example Transformation

**Before migration:**
```json
{
  "sqlReviewRules": [
    {
      "type": "statement.where.require",
      "level": "ERROR",
      "engine": "MYSQL",
      "payload": "",
      "comment": "Require WHERE clause"
    }
  ]
}
```

**After migration:**
```json
{
  "sqlReviewRules": [
    {
      "type": "statement.where.require.select",
      "level": "ERROR",
      "engine": "MYSQL",
      "payload": "",
      "comment": "Require WHERE clause"
    },
    {
      "type": "statement.where.require.update-delete",
      "level": "ERROR",
      "engine": "MYSQL",
      "payload": "",
      "comment": "Require WHERE clause"
    }
  ]
}
```

## Testing

- ✅ Tested migration with sample data (both with and without payload field)
- ✅ All migrator unit tests pass
- ✅ Correctly handles JSONB structure from protojson.Marshal (camelCased keys)
- ✅ Verified migration is idempotent

## Files Changed

- `backend/migrator/migration/3.12/0002##migrate_statement_where_require_rule.sql` - New migration
- `backend/migrator/migrator_test.go` - Updated expected version to 3.12.2

## Test Plan

1. Apply migration to a database with legacy rules
2. Verify the "unknown advisor" error no longer appears
3. Verify SQL review policies work correctly with both new rule types

🤖 Generated with [Claude Code](https://claude.com/claude-code)