### PR TITLE
refactor: consolidate PostgreSQL statement type functions

### DIFF
--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -655,7 +655,7 @@ type statementTypeWithPosition struct {
 func getStatementTypesWithPositionsForEngine(engine storepb.Engine, asts any) ([]statementTypeWithPosition, error) {
 	switch engine {
 	case storepb.Engine_POSTGRES, storepb.Engine_COCKROACHDB, storepb.Engine_REDSHIFT:
-		pgStmts, err := pg.GetStatementTypesWithPositions(asts)
+		pgStmts, err := pg.GetStatementTypes(asts)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/pg/statement_type_antlr.go
+++ b/backend/plugin/parser/pg/statement_type_antlr.go
@@ -3,23 +3,7 @@ package pg
 import (
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/postgresql"
-	"github.com/pkg/errors"
 )
-
-// GetStatementTypesWithPositionsANTLR returns statement types with position information from ANTLR parse result.
-func GetStatementTypesWithPositionsANTLR(parseResult *ParseResult) ([]StatementTypeWithPosition, error) {
-	if parseResult == nil || parseResult.Tree == nil {
-		return nil, errors.New("invalid parse result")
-	}
-
-	collector := &statementTypeCollectorWithPosition{
-		tokens: parseResult.Tokens,
-	}
-
-	antlr.ParseTreeWalkerDefault.Walk(collector, parseResult.Tree)
-
-	return collector.results, nil
-}
 
 // statementTypeCollectorWithPosition collects statement types with positions.
 type statementTypeCollectorWithPosition struct {

--- a/backend/plugin/parser/pg/statement_type_antlr_test.go
+++ b/backend/plugin/parser/pg/statement_type_antlr_test.go
@@ -221,7 +221,7 @@ func TestGetStatementTypesANTLR(t *testing.T) {
 			parseResult, err := ParsePostgreSQL(tt.sql)
 			require.NoError(t, err)
 
-			stmtsWithPos, err := GetStatementTypesWithPositionsANTLR(parseResult)
+			stmtsWithPos, err := GetStatementTypes(parseResult)
 			require.NoError(t, err)
 
 			// Extract types from statements with positions
@@ -234,7 +234,7 @@ func TestGetStatementTypesANTLR(t *testing.T) {
 	}
 }
 
-func TestGetStatementTypesWithPositionsANTLR(t *testing.T) {
+func TestGetStatementTypesWithPositions(t *testing.T) {
 	tests := []struct {
 		name     string
 		sql      string
@@ -278,7 +278,7 @@ INSERT INTO t1 VALUES (1);`,
 			parseResult, err := ParsePostgreSQL(tt.sql)
 			require.NoError(t, err)
 
-			results, err := GetStatementTypesWithPositionsANTLR(parseResult)
+			results, err := GetStatementTypes(parseResult)
 			require.NoError(t, err)
 			require.Len(t, results, len(tt.expected))
 

--- a/backend/runner/plancheck/statement_report_executor.go
+++ b/backend/runner/plancheck/statement_report_executor.go
@@ -186,7 +186,7 @@ func GetSQLSummaryReport(ctx context.Context, stores *store.Store, sheetManager 
 		}
 		explainCalculator = pd.CountAffectedRows
 
-		stmtsWithPos, err := pg.GetStatementTypesWithPositions(asts)
+		stmtsWithPos, err := pg.GetStatementTypes(asts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- Consolidated `GetStatementTypes` and `GetStatementTypesWithPositions` into a single function
- Removed redundant ANTLR-specific function variants (`GetStatementTypesANTLR` and `GetStatementTypesWithPositionsANTLR`)
- Removed the simpler `statementTypeCollector` type that didn't track position information
- Updated all callers to use the consolidated `GetStatementTypes` function which now returns `StatementTypeWithPosition` structs
- Net reduction of ~200 lines of duplicate code

## Changes
- **backend/plugin/parser/pg/statement_type.go**: Merged `GetStatementTypesWithPositions` functionality into `GetStatementTypes`
- **backend/plugin/parser/pg/statement_type_antlr.go**: Removed duplicate collector implementation and intermediate functions
- **backend/api/v1/release_service_check.go**: Updated to call renamed function
- **backend/runner/plancheck/statement_report_executor.go**: Updated to extract types from position-aware results
- **backend/plugin/parser/pg/statement_type_antlr_test.go**: Updated test names and adapted to new function signature

## Test plan
- [x] Existing tests updated and passing
- [x] `TestGetStatementTypesANTLR` adapted to work with the new consolidated function
- [x] `TestGetStatementTypesWithPositions` continues to validate position tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)