### PR TITLE
feat: add rate limiting for authentication attempts

### DIFF
--- a/backend/server/grpc_routes.go
+++ b/backend/server/grpc_routes.go
@@ -117,7 +117,7 @@ func configureGrpcRouters(
 			apiv1.NewDebugInterceptor(metricReporter),
 			auth.New(stores, secret, licenseService, stateCfg, profile),
 			apiv1.NewACLInterceptor(stores, secret, iamManager, profile),
-			apiv1.NewAuditInterceptor(stores),
+			apiv1.NewAuditInterceptor(stores, secret, profile),
 		),
 		connect.WithRecover(onPanic),
 	)


### PR DESCRIPTION
Close BYT-8295

Implement rate limiting to protect against brute force attacks on login:
- Password phase: 10 failed attempts within 10 minutes
- MFA phase: 5 failed attempts within 5 minutes
