### PR TITLE
fix: NButton slot syntax

### DIFF
--- a/frontend/src/components/ProjectWebhookPanel.vue
+++ b/frontend/src/components/ProjectWebhookPanel.vue
@@ -113,7 +113,7 @@ const columnList = computed((): DataTableColumn<Webhook>[] => {
                 });
               },
             },
-            t("common.view")
+            { default: () => t("common.view") }
           )
         ),
     },


### PR DESCRIPTION
Changed the NButton slot from passing a plain string t("common.view") to
using a function { default: () => t("common.view") } to fix the 
"Non-function value encountered for default slot" warnings