### PR TITLE
fix: return ALTER_TABLE instead of sub-operation types for PostgreSQL ALTER TABLE statements

### DIFF
--- a/backend/plugin/parser/pg/statement_type_antlr.go
+++ b/backend/plugin/parser/pg/statement_type_antlr.go
@@ -132,16 +132,10 @@ func (c *statementTypeCollectorWithPosition) EnterAltertablestmt(ctx *parser.Alt
 		return
 	}
 
-	// Parse ALTER TABLE sub-operations if alter_table_cmds exists
-	if cmds := ctx.Alter_table_cmds(); cmds != nil {
-		for _, cmd := range cmds.AllAlter_table_cmd() {
-			stmtType := getAlterTableCmdType(cmd)
-			c.addStatement(stmtType, ctx)
-		}
-	} else {
-		// Fallback to generic ALTER_TABLE if no cmds
-		c.addStatement("ALTER_TABLE", ctx)
-	}
+	// Always return ALTER_TABLE for ALTER TABLE statements
+	// The sub-operations (ADD COLUMN, DROP COLUMN, etc.) are child nodes in the AST,
+	// not separate statements
+	c.addStatement("ALTER_TABLE", ctx)
 }
 
 func (c *statementTypeCollectorWithPosition) EnterAlterseqstmt(ctx *parser.AlterseqstmtContext) {
@@ -285,58 +279,6 @@ func getDropStatementType(ctx *parser.DropstmtContext) string {
 
 	// Default for unhandled cases
 	return "UNKNOWN"
-}
-
-// getAlterTableCmdType determines the specific ALTER TABLE sub-operation type.
-func getAlterTableCmdType(cmd parser.IAlter_table_cmdContext) string {
-	if cmd == nil {
-		return "ALTER_TABLE"
-	}
-
-	// ADD COLUMN
-	if cmd.ADD_P() != nil && cmd.ColumnDef() != nil {
-		return "ALTER_TABLE_ADD_COLUMN_LIST"
-	}
-
-	// ADD CONSTRAINT
-	if cmd.ADD_P() != nil && cmd.Tableconstraint() != nil {
-		return "ALTER_TABLE_ADD_CONSTRAINT"
-	}
-
-	// ALTER COLUMN operations (check these BEFORE DROP to avoid conflicts)
-	if cmd.ALTER() != nil && len(cmd.AllColid()) > 0 {
-		// ALTER COLUMN ... TYPE
-		if cmd.TYPE_P() != nil {
-			return "ALTER_COLUMN_TYPE"
-		}
-
-		// ALTER COLUMN ... DROP NOT NULL
-		if cmd.DROP() != nil && cmd.NOT() != nil && cmd.NULL_P() != nil {
-			return "DROP_NOT_NULL"
-		}
-
-		// ALTER COLUMN ... DROP DEFAULT
-		if cmd.Alter_column_default() != nil {
-			alterDefault := cmd.Alter_column_default()
-			// Check if it's DROP DEFAULT (not SET DEFAULT)
-			if alterDefault.DROP() != nil {
-				return "DROP_DEFAULT"
-			}
-		}
-	}
-
-	// DROP COLUMN (must be after ALTER COLUMN checks)
-	if cmd.DROP() != nil && len(cmd.AllColid()) > 0 && cmd.CONSTRAINT() == nil {
-		return "DROP_COLUMN"
-	}
-
-	// DROP CONSTRAINT
-	if cmd.DROP() != nil && cmd.CONSTRAINT() != nil {
-		return "DROP_CONSTRAINT"
-	}
-
-	// Default to ALTER_TABLE for other operations
-	return "ALTER_TABLE"
 }
 
 // getRenameStatementType determines the specific RENAME statement type.

--- a/backend/plugin/parser/pg/statement_type_antlr_test.go
+++ b/backend/plugin/parser/pg/statement_type_antlr_test.go
@@ -100,37 +100,37 @@ func TestGetStatementTypesANTLR(t *testing.T) {
 		{
 			name:          "ALTER TABLE ADD COLUMN",
 			sql:           "ALTER TABLE t1 ADD COLUMN name VARCHAR(100);",
-			expectedTypes: []string{"ALTER_TABLE_ADD_COLUMN_LIST"},
+			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{
 			name:          "ALTER TABLE ADD CONSTRAINT",
 			sql:           "ALTER TABLE t1 ADD CONSTRAINT pk_id PRIMARY KEY (id);",
-			expectedTypes: []string{"ALTER_TABLE_ADD_CONSTRAINT"},
+			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{
 			name:          "ALTER TABLE DROP COLUMN",
 			sql:           "ALTER TABLE t1 DROP COLUMN name;",
-			expectedTypes: []string{"DROP_COLUMN"},
+			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{
 			name:          "ALTER TABLE DROP CONSTRAINT",
 			sql:           "ALTER TABLE t1 DROP CONSTRAINT pk_id;",
-			expectedTypes: []string{"DROP_CONSTRAINT"},
+			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{
 			name:          "ALTER TABLE ALTER COLUMN TYPE",
 			sql:           "ALTER TABLE t1 ALTER COLUMN name TYPE TEXT;",
-			expectedTypes: []string{"ALTER_COLUMN_TYPE"},
+			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{
 			name:          "ALTER TABLE ALTER COLUMN DROP DEFAULT",
 			sql:           "ALTER TABLE t1 ALTER COLUMN name DROP DEFAULT;",
-			expectedTypes: []string{"DROP_DEFAULT"},
+			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{
 			name:          "ALTER TABLE ALTER COLUMN DROP NOT NULL",
 			sql:           "ALTER TABLE t1 ALTER COLUMN name DROP NOT NULL;",
-			expectedTypes: []string{"DROP_NOT_NULL"},
+			expectedTypes: []string{"ALTER_TABLE"},
 		},
 		{
 			name:          "ALTER VIEW",


### PR DESCRIPTION
## Summary

Fixes the statement type detection for ALTER TABLE statements in the ANTLR-based PostgreSQL parser to correctly return `ALTER_TABLE` instead of child operation types (like `ALTER_TABLE_ADD_COLUMN_LIST`, `DROP_COLUMN`, etc.).

This bug was introduced in PR #17890 which added ANTLR-based statement type detection.

## Problem (Cause)

The ANTLR implementation was incorrectly returning **child operation types** instead of the **root statement type** for ALTER TABLE statements.

### Example of Incorrect Behavior:
```sql
ALTER TABLE t ADD COLUMN z TEXT
```
- **Expected**: `ALTER_TABLE` (root statement type)
- **Actual (buggy)**: `ALTER_TABLE_ADD_COLUMN_LIST` (child operation type)

### Why This Was Wrong:

Looking at the legacy pg_query_go AST structure in `backend/plugin/parser/pg/legacy/convert.go`:

```go
type AlterTableStmt struct {
    Table         *TableDef
    AlterItemList []Node  // Child nodes: AddColumnListStmt, DropColumnStmt, etc.
}
```

The design shows that:
1. **`AlterTableStmt`** is the **ROOT node** representing the entire ALTER TABLE statement
2. **`AlterItemList`** contains **CHILD nodes** representing sub-operations (ADD COLUMN, DROP COLUMN, ADD CONSTRAINT, etc.)

The ANTLR implementation incorrectly iterated through `alter_table_cmds` and added each sub-operation as a **separate statement type**, violating the principle that **one SQL statement should return one statement type**.

### Impact on Consumers:

The statement type detection is used by:
1. **SQL Summary Report** (`backend/runner/plancheck/statement_report_executor.go`) - for plan checks
2. **SDL File Validation** (`backend/api/v1/release_service_check.go`) - for release validation

Both consumers call `GetStatementTypes()` and expect **one type per SQL statement**, not multiple types for sub-operations within a single statement.

## Solution (Effect)

Modified `EnterAltertablestmt()` in `backend/plugin/parser/pg/statement_type_antlr.go` to:
- Always return `ALTER_TABLE` for ALTER TABLE statements
- Treat sub-operations (ADD COLUMN, DROP COLUMN, etc.) as child nodes in the AST, not as separate statements
- Preserve existing logic for `ALTER VIEW` statements

Removed the now-unused `getAlterTableCmdType()` helper function (60+ lines).

### After Fix:
```sql
ALTER TABLE t ADD COLUMN z TEXT       → ALTER_TABLE ✅
ALTER TABLE t DROP COLUMN x           → ALTER_TABLE ✅
ALTER TABLE t ADD CONSTRAINT pk ...   → ALTER_TABLE ✅
ALTER TABLE t ALTER COLUMN x TYPE ... → ALTER_TABLE ✅
```

## Changes

**Modified Files:**
- `backend/plugin/parser/pg/statement_type_antlr.go`
  - Simplified `EnterAltertablestmt()` to always return `ALTER_TABLE`
  - Removed unused `getAlterTableCmdType()` helper function (60+ lines)
  
- `backend/plugin/parser/pg/statement_type_antlr_test.go`
  - Updated 7 test cases to expect `ALTER_TABLE` instead of sub-operation types

## Testing

```bash
✅ All 41 tests passing
✅ No linting errors  
✅ Code formatted with gofmt
```

### Test Results:
```bash
$ go test -v github.com/bytebase/bytebase/backend/plugin/parser/pg -run "^TestGetStatementTypesANTLR$"
PASS: TestGetStatementTypesANTLR/ALTER_TABLE_ADD_COLUMN
PASS: TestGetStatementTypesANTLR/ALTER_TABLE_DROP_COLUMN
PASS: TestGetStatementTypesANTLR/ALTER_TABLE_ADD_CONSTRAINT
... (all 41 tests passing)
```

## Before/After Comparison

| SQL Statement | Before (Wrong) | After (Correct) |
|---------------|----------------|-----------------|
| `ALTER TABLE t ADD COLUMN x INT` | `ALTER_TABLE_ADD_COLUMN_LIST` | `ALTER_TABLE` |
| `ALTER TABLE t DROP COLUMN x` | `DROP_COLUMN` | `ALTER_TABLE` |
| `ALTER TABLE t ADD CONSTRAINT ...` | `ALTER_TABLE_ADD_CONSTRAINT` | `ALTER_TABLE` |
| `ALTER TABLE t DROP CONSTRAINT ...` | `DROP_CONSTRAINT` | `ALTER_TABLE` |
| `ALTER TABLE t ALTER COLUMN x TYPE TEXT` | `ALTER_COLUMN_TYPE` | `ALTER_TABLE` |
| `ALTER TABLE t ALTER COLUMN x DROP DEFAULT` | `DROP_DEFAULT` | `ALTER_TABLE` |
| `ALTER TABLE t ALTER COLUMN x DROP NOT NULL` | `DROP_NOT_NULL` | `ALTER_TABLE` |

## Related PRs

- #17890 - Original PR that introduced ANTLR-based statement type detection
- #17882 - Migration from pg_query_go to ANTLR parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>