### PR TITLE
chore: standardize vertical padding in Plan components

### DIFF
--- a/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
+++ b/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="shouldShow" class="pt-3 flex flex-col gap-y-1 overflow-hidden">
+  <div v-if="shouldShow" class="py-3 flex flex-col gap-y-1 overflow-hidden">
     <div class="flex items-center justify-between gap-2">
       <div class="flex items-center gap-2">
         <h3 class="text-base">{{ $t("plan.checks.self") }}</h3>

--- a/frontend/src/components/Plan/components/SQLCheckV1Section/SQLCheckV1Section.vue
+++ b/frontend/src/components/Plan/components/SQLCheckV1Section/SQLCheckV1Section.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="show" class="pt-3 flex flex-col gap-y-1 overflow-hidden">
+  <div v-if="show" class="py-3 flex flex-col gap-y-1 overflow-hidden">
     <div class="flex items-center justify-between gap-2">
       <div class="flex items-center gap-2">
         <h3 class="text-base font-medium">{{ $t("plan.checks.self") }}</h3>

--- a/frontend/src/components/Plan/components/SpecDetailView/FailedTaskRunsSection.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/FailedTaskRunsSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="shouldShowSection" class="w-full space-y-2 pt-3">
+  <div v-if="shouldShowSection" class="w-full space-y-2 py-3">
     <div class="text-sm text-control">
       {{ $t("task-run.failed-runs") }}
     </div>

--- a/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="w-full flex-1 flex flex-col">
     <SpecListSection v-if="shouldShowSpecList" />
-    <div
-      class="w-full flex-1 flex flex-col gap-3 px-4 divide-y overflow-x-auto"
-    >
+    <div class="w-full flex-1 flex flex-col px-4 divide-y overflow-x-auto">
       <TargetListSection />
       <DataExportOptionsSection v-if="isDataExportPlan" />
       <FailedTaskRunsSection v-if="!isCreating && rollout" />
@@ -11,7 +9,7 @@
         <SQLCheckV1Section v-if="isCreating" />
         <PlanCheckSection v-else />
       </template>
-      <div class="w-full flex-1 space-y-3 pt-3 flex flex-col">
+      <div class="w-full flex-1 space-y-3 py-3 flex flex-col">
         <StatementSection />
         <Configuration />
       </div>

--- a/frontend/src/components/Plan/components/SpecDetailView/TargetListSection.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/TargetListSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-y-2 pt-2">
+  <div class="flex flex-col gap-y-2 py-3">
     <div class="flex items-center justify-between gap-2">
       <div class="flex items-center gap-1">
         <h3 class="text-base">{{ $t("plan.targets.title") }}</h3>


### PR DESCRIPTION
## Summary

Standardize padding in Plan components for consistent vertical spacing by:
- Changing from top-only padding (`pt-*`) to vertical padding (`py-*`) in multiple Plan component sections
- Removing unnecessary `gap-3` class from parent container in SpecDetailView
- Ensuring consistent spacing across all Plan detail sections

## Changes

- `PlanCheckSection.vue`: `pt-3` → `py-3`
- `SQLCheckV1Section.vue`: `pt-3` → `py-3`  
- `FailedTaskRunsSection.vue`: `pt-3` → `py-3`
- `SpecDetailView.vue`: Removed `gap-3`, changed `pt-3` → `py-3`
- `TargetListSection.vue`: `pt-2` → `py-3`

## Test plan

- [x] Verify Plan detail view displays correctly
- [x] Check spacing consistency across all sections
- [x] Ensure no visual regression in Plan components

🤖 Generated with [Claude Code](https://claude.com/claude-code)