### PR TITLE
chore: remove unused pg_query_go replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -396,8 +396,6 @@ replace (
 
 	github.com/microsoft/go-mssqldb => github.com/bytebase/go-mssqldb v0.0.0-20240801091126-3ff3ca07d898
 
-	github.com/pganalyze/pg_query_go/v6 => github.com/bytebase/pg_query_go2/v6 v6.0.0-20250403034815-22c5b71007ed
-
 	github.com/pingcap/tidb => github.com/bytebase/tidb v0.0.0-20251104040057-d29df9dd1b3b
 
 	github.com/pingcap/tidb/pkg/parser => github.com/bytebase/tidb/pkg/parser v0.0.0-20251104040057-d29df9dd1b3b


### PR DESCRIPTION
## Summary
- Removes the unused pg_query_go replace directive from go.mod
- This directive is no longer needed after the removal of the legacy PostgreSQL AST system in #18004

## Test plan
- Verify go.mod is valid
- Verify builds complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)