### PR TITLE
fix: populate RoleArn and ExternalId fields for AWS RDS IAM authentication

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -792,6 +792,8 @@ func (s *InstanceService) UpdateDataSource(ctx context.Context, req *connect.Req
 							AccessKeyId:     awsCredential.AccessKeyId,
 							SecretAccessKey: awsCredential.SecretAccessKey,
 							SessionToken:    awsCredential.SessionToken,
+							RoleArn:         awsCredential.RoleArn,
+							ExternalId:      awsCredential.ExternalId,
 						},
 					}
 				} else {

--- a/backend/api/v1/instance_service_converter.go
+++ b/backend/api/v1/instance_service_converter.go
@@ -228,7 +228,10 @@ func convertDataSources(dataSources []*storepb.DataSource) []*v1pb.DataSource {
 		case v1pb.DataSource_AWS_RDS_IAM:
 			if awsCredential := ds.GetAwsCredential(); awsCredential != nil {
 				dataSource.IamExtension = &v1pb.DataSource_AwsCredential{
-					AwsCredential: &v1pb.DataSource_AWSCredential{},
+					AwsCredential: &v1pb.DataSource_AWSCredential{
+						RoleArn:    awsCredential.RoleArn,
+						ExternalId: awsCredential.ExternalId,
+					},
 				}
 			}
 		case v1pb.DataSource_GOOGLE_CLOUD_SQL_IAM:
@@ -496,6 +499,8 @@ func convertV1DataSource(dataSource *v1pb.DataSource) (*storepb.DataSource, erro
 					AccessKeyId:     awsCredential.AccessKeyId,
 					SecretAccessKey: awsCredential.SecretAccessKey,
 					SessionToken:    awsCredential.SessionToken,
+					RoleArn:         awsCredential.RoleArn,
+					ExternalId:      awsCredential.ExternalId,
 				},
 			}
 		}


### PR DESCRIPTION
  ## Summary

  Fixes missing field mappings for `role_arn` and `external_id` in AWS RDS IAM authentication, which prevented cross-account role assumption from working.

  ## Changes

  PR #17719 added `role_arn` and `external_id` fields to the `AWSCredential` proto but didn't update the backend code that copies these fields between API and storage layers.

  Updated three locations:

  1. **`instance_service.go`**: `UpdateDataSource` - now copies RoleArn/ExternalId when updating data sources
  2. **`instance_service_converter.go`**: `convertV1DataSource` - now copies RoleArn/ExternalId when creating instances
  3. **`instance_service_converter.go`**: `convertDataSources` - now returns RoleArn/ExternalId in API responses (for UI display)
