### PR TITLE
feat: simplify Risk Center filters to search-only

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/RiskCenter/RiskCenter.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/RiskCenter/RiskCenter.vue
@@ -27,10 +27,10 @@ import { create } from "@bufbuild/protobuf";
 import { groupBy } from "lodash-es";
 import { PlusIcon } from "lucide-vue-next";
 import { NButton } from "naive-ui";
-import { computed, watch } from "vue";
+import { computed } from "vue";
 import { useRiskStore } from "@/store";
 import { PresetRiskLevelList, useSupportedSourceList } from "@/types";
-import { Risk_Source, RiskSchema } from "@/types/proto-es/v1/risk_service_pb";
+import { RiskSchema } from "@/types/proto-es/v1/risk_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
 import { RiskFilter, orderByLevelDesc, useRiskFilter } from "../common";
 import RiskSection from "./RiskSection.vue";
@@ -48,16 +48,7 @@ const allowCreateRisk = computed(() => {
 
 const filteredRiskList = computed(() => {
   let list = [...riskStore.riskList];
-  const { source, levels } = filter;
   const search = filter.search.value.trim();
-  // Risk_Source.SOURCE_UNSPECIFIED to "ALL"
-  if (source.value !== Risk_Source.SOURCE_UNSPECIFIED) {
-    list = list.filter((risk) => risk.source === source.value);
-  }
-  // empty to "ALL"
-  if (levels.value.size > 0) {
-    list = list.filter((risk) => levels.value.has(risk.level));
-  }
   if (search) {
     list = list.filter((risk) => risk.title.includes(search));
   }
@@ -71,21 +62,11 @@ const riskListGroupBySource = computed(() => {
     riskList.sort(orderByLevelDesc);
     return { source, riskList };
   });
-  if (filter.source.value === Risk_Source.SOURCE_UNSPECIFIED) {
-    // Show "ALL" sources
-    return groups;
-  }
-
-  return groups.filter((group) => {
-    return group.riskList.length > 0 || group.source === filter.source.value;
-  });
+  return groups;
 });
 
 const addRisk = () => {
-  let source = filter.source.value;
-  if (source === Risk_Source.SOURCE_UNSPECIFIED) {
-    source = supportedSourceList.value[0];
-  }
+  const source = supportedSourceList.value[0];
   const risk = create(RiskSchema, {
     level: PresetRiskLevelList[0].level,
     source: source,
@@ -100,16 +81,4 @@ const addRisk = () => {
     risk,
   };
 };
-
-watch(
-  context.dialog,
-  (dialog) => {
-    const source = dialog?.risk?.source;
-    if (!source) return;
-    if (filter.source.value !== Risk_Source.SOURCE_UNSPECIFIED) {
-      filter.source.value = source;
-    }
-  },
-  { immediate: true }
-);
 </script>

--- a/frontend/src/components/CustomApproval/Settings/components/common/RiskFilter/RiskFilter.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/common/RiskFilter/RiskFilter.vue
@@ -1,45 +1,26 @@
 <template>
-  <div class="flex flex-col gap-y-4">
-    <div
-      class="flex flex-col md:flex-row md:items-center justify-between gap-y-2"
+  <div class="flex items-center justify-between gap-x-2">
+    <NInput
+      v-if="!hideSearch"
+      v-model:value="search"
+      class="flex-1"
+      :clearable="true"
+      :placeholder="$t('custom-approval.risk-rule.search')"
     >
-      <div>
-        <LevelFilter v-if="!hideLevelFilter" />
-      </div>
+      <template #prefix>
+        <heroicons:magnifying-glass class="w-4 h-4" />
+      </template>
+    </NInput>
 
-      <div class="flex items-center justify-end gap-x-2">
-        <NInput
-          v-if="!hideSearch"
-          v-model:value="search"
-          :clearable="true"
-          :placeholder="$t('custom-approval.risk-rule.search')"
-        >
-          <template #prefix>
-            <heroicons:magnifying-glass class="w-4 h-4" />
-          </template>
-        </NInput>
-
-        <slot name="suffix" />
-      </div>
-    </div>
-
-    <hr v-if="!hideSourceFilter" />
-
-    <div v-if="!hideSourceFilter" class="flex items-center justify-start">
-      <SourceFilter />
-    </div>
+    <slot name="suffix" />
   </div>
 </template>
 
 <script lang="ts" setup>
 import { NInput } from "naive-ui";
-import LevelFilter from "./LevelFilter.vue";
-import SourceFilter from "./SourceFilter.vue";
 import { useRiskFilter } from "./context";
 
 defineProps<{
-  hideLevelFilter?: boolean;
-  hideSourceFilter?: boolean;
   hideSearch?: boolean;
 }>();
 


### PR DESCRIPTION
## Summary
Simplified the Risk Center page by removing the Level filter (High/Moderate/Low checkboxes) and Source filter (All/DDL/DML tabs), keeping only the search functionality. This reduces UI complexity when there are few risk entries.

## Changes
- **RiskCenter.vue**: 
  - Removed level and source filtering logic
  - Simplified to only filter by search text
  - Removed unused imports (`watch`, `Risk_Source`)
  - Removed filter synchronization watch effect
  
- **RiskFilter.vue**:
  - Removed `LevelFilter` and `SourceFilter` components
  - Removed `hideLevelFilter` and `hideSourceFilter` props
  - Simplified to just search input with flexible width
  - Updated to use `flex-1` for consistency with Instance/Database dashboards

## Test Plan
- [x] Search functionality works correctly
- [x] All risk sources are displayed
- [x] Layout is consistent with Instance/Database dashboards
- [x] Code passes linting and type checking

## Notes
- The filter context (`useRiskFilter`) is preserved for the CustomApproval component which still uses level filtering
- Net reduction of 50 lines of code

🤖 Generated with [Claude Code](https://claude.com/claude-code)