### PR TITLE
fix: improve MongoDB query error handling and bracket notation support

### DIFF
--- a/backend/plugin/db/mongodb/mongodb.go
+++ b/backend/plugin/db/mongodb/mongodb.go
@@ -344,7 +344,6 @@ func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, q
 		strings.Join(mongoshArgs, " "),
 	}
 	shCmd := exec.CommandContext(ctx, "sh", shellArgs...)
-	slog.Info("MongoDB query command", slog.String("command", shCmd.String()))
 	var errContent bytes.Buffer
 	var outContent bytes.Buffer
 	shCmd.Stderr = &errContent


### PR DESCRIPTION
## Summary

Fixes MongoDB query errors when using bracket notation with single quotes (e.g., `db['collection'].find()`), which was introduced in PR #17282 to support collection names with special characters.

## Changes

1. **Improved error handling**: Capture mongosh stdout in addition to stderr to display detailed error messages (like BSONError) to users
2. **Fixed bracket notation detection**: Made `isMongoStatement()` recognize `db[` prefix regardless of quote type (single, double, or no quotes)
3. **Code cleanup**: Removed debug logging

## Root Cause

PR #17282 changed the frontend to generate MongoDB queries using single-quote bracket notation (`db['collection']`) instead of dot notation (`db.collection`) to support collection names with special characters. However, the backend's `isMongoStatement()` function only recognized double-quote bracket notation (`db["collection"]`), causing queries to fail with "Converting circular structure to EJSON" errors.

## Test Plan

- [x] Test double-clicking collections with special characters in the SQL editor
- [x] Verify error messages are properly displayed for invalid queries
- [x] Test all bracket notation variants: `db['collection']`, `db["collection"]`, `db[variable]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)