### PR TITLE
feat: handle multi-statement SQL execution gracefully

### DIFF
--- a/backend/tests/sql_multi_statement_test.go
+++ b/backend/tests/sql_multi_statement_test.go
@@ -18,6 +18,7 @@ import (
 // TestMultiStatementSQLExecution tests that multiple SQL statements can be executed
 // and returns results for all statements, even if some fail.
 func TestMultiStatementSQLExecution(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		databaseName      string
@@ -130,19 +131,15 @@ func TestMultiStatementSQLExecution(t *testing.T) {
 	ctl := &controller{}
 	ctx, err := ctl.StartServerWithExternalPg(ctx)
 	a.NoError(err)
-	defer ctl.Close(ctx)
+	t.Cleanup(func() { ctl.Close(ctx) })
 
 	mysqlContainer, err := getMySQLContainer(ctx)
-	defer func() {
-		mysqlContainer.Close(ctx)
-	}()
 	a.NoError(err)
+	t.Cleanup(func() { mysqlContainer.Close(ctx) })
 
 	pgContainer, err := getPgContainer(ctx)
-	defer func() {
-		pgContainer.Close(ctx)
-	}()
 	a.NoError(err)
+	t.Cleanup(func() { pgContainer.Close(ctx) })
 
 	mysqlInstanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
 		InstanceId: generateRandomString("instance"),
@@ -172,6 +169,7 @@ func TestMultiStatementSQLExecution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			a := require.New(t)
 
 			var instance *v1pb.Instance
@@ -344,19 +342,15 @@ func TestMultiStatementSQLWithErrors(t *testing.T) {
 	ctl := &controller{}
 	ctx, err := ctl.StartServerWithExternalPg(ctx)
 	a.NoError(err)
-	defer ctl.Close(ctx)
+	t.Cleanup(func() { ctl.Close(ctx) })
 
 	mysqlContainer, err := getMySQLContainer(ctx)
-	defer func() {
-		mysqlContainer.Close(ctx)
-	}()
 	a.NoError(err)
+	t.Cleanup(func() { mysqlContainer.Close(ctx) })
 
 	pgContainer, err := getPgContainer(ctx)
-	defer func() {
-		pgContainer.Close(ctx)
-	}()
 	a.NoError(err)
+	t.Cleanup(func() { pgContainer.Close(ctx) })
 
 	mysqlInstanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
 		InstanceId: generateRandomString("instance"),
@@ -386,6 +380,7 @@ func TestMultiStatementSQLWithErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			a := require.New(t)
 
 			var instance *v1pb.Instance


### PR DESCRIPTION
## Summary

This PR improves multi-statement SQL execution by handling each statement individually instead of failing all statements when one encounters an error.

### Changes

- **Refactored `queryRetry` function** to split multi-statement SQL using `SplitMultiSQL`
- **Created `querySingleSQL` helper function** to encapsulate single SQL execution logic (~260 lines)
- **Execute each statement independently** and aggregate results
- **Isolate errors per statement** - errors are recorded in `QueryResult.Error` field instead of failing the entire batch

### Key Improvements

1. **Better error isolation**: If statement 2 fails, statements 1 and 3 still execute successfully
2. **Cleaner code**: Extracted helper function reduces duplication and improves maintainability
3. **Backwards compatible**: Falls back to single-statement execution if splitting fails

### Testing

Added comprehensive integration tests in `backend/tests/sql_multi_statement_test.go`:

- ✅ Successful multi-statement execution (MySQL and PostgreSQL)
- ✅ Handling duplicate key errors in middle of batch
- ✅ Handling syntax errors without stopping other statements
- ✅ All 4 test scenarios pass for both MySQL and PostgreSQL

## Test Plan

- [x] Integration tests pass for MySQL and PostgreSQL
- [x] Code builds successfully
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Close BYT-8248