### PR TITLE
feat: auto-tag latest Docker image when building latest release version

### DIFF
--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      actions: write
     steps:
       - uses: actions/checkout@v5
       - name: Extract build args
@@ -44,3 +45,41 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
             GIT_COMMIT=${{ env.GIT_COMMIT }}
+      - name: Check if version is latest
+        id: check_latest
+        run: |
+          # Fetch all branches to get release branches
+          git fetch --all
+
+          # Get all release branch versions
+          VERSIONS=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9]*' | sed 's/release\///' | sort -V)
+
+          # Get the latest version
+          LATEST_VERSION=$(echo "$VERSIONS" | tail -n 1)
+
+          echo "Current version: ${{ env.VERSION }}"
+          echo "Latest version: $LATEST_VERSION"
+
+          # Check if current version is the latest
+          if [ "${{ env.VERSION }}" = "$LATEST_VERSION" ]; then
+            echo "is_latest=true" >> $GITHUB_OUTPUT
+            echo "✅ This is the latest version"
+          else
+            echo "is_latest=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ This is not the latest version"
+          fi
+      - name: Trigger docker-tag-latest workflow
+        if: steps.check_latest.outputs.is_latest == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docker-tag-latest.yml',
+              ref: 'main',
+              inputs: {
+                version: '${{ env.VERSION }}'
+              }
+            });
+            console.log('✅ Triggered docker-tag-latest workflow for version ${{ env.VERSION }}');

--- a/.github/workflows/docker-tag-latest.yml
+++ b/.github/workflows/docker-tag-latest.yml
@@ -2,6 +2,17 @@ name: Docker tag latest
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag as latest (e.g., 1.0.0)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to tag as latest (e.g., 1.0.0)'
+        required: true
+        type: string
 
 jobs:
   docker:
@@ -14,7 +25,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Tag latest image in DockerHub
         run: |
-          RELEASE_VERSION=${GITHUB_REF_NAME#release/}
+          # Use input version if provided, otherwise extract from branch name
+          if [ -n "${{ inputs.version }}" ]; then
+            RELEASE_VERSION="${{ inputs.version }}"
+          else
+            RELEASE_VERSION=${GITHUB_REF_NAME#release/}
+          fi
           echo version: ${RELEASE_VERSION}
           docker buildx imagetools create -t bytebase/bytebase:latest bytebase/bytebase:${RELEASE_VERSION}
           docker buildx imagetools create -t bytebase/bytebase-action:latest bytebase/bytebase-action:${RELEASE_VERSION}


### PR DESCRIPTION
## Summary
- Automatically tag Docker images as 'latest' when a release is determined to be the latest version
- Eliminates the need to manually trigger the docker-tag-latest workflow after each release

## Changes
- Modified `docker-tag-latest.yml` to accept version input via `workflow_call` and `workflow_dispatch`
- Added version comparison logic to `build-push-release-image.yml` to detect if current version is latest
- Automatically trigger `docker-tag-latest` workflow when building the latest version
- Added `actions: write` permission to build workflow

## How It Works
1. When pushing to a release branch (e.g., `release/2.3.0`), the build workflow runs
2. After building and pushing the versioned image, it checks all release branches
3. Compares current version with all release versions using semantic versioning
4. If current version is the latest, automatically triggers the docker-tag-latest workflow
5. The docker-tag-latest workflow tags the images as `latest`

## Test plan
- Push to a release branch that is the latest version and verify latest tag is applied
- Push to an older release branch and verify latest tag is NOT applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)