### PR TITLE
fix: modal width

### DIFF
--- a/frontend/src/components/Plan/components/StatementSection/SchemaEditorDrawer.vue
+++ b/frontend/src/components/Plan/components/StatementSection/SchemaEditorDrawer.vue
@@ -1,13 +1,9 @@
 <template>
-  <Drawer
-    v-model:show="show"
-    placement="right"
-    :resizable="true"
-    :default-width="'50%'"
-    :width="undefined"
-    class="max-w-[90vw]!"
-  >
-    <DrawerContent :title="$t('schema-editor.self')">
+  <Drawer v-model:show="show" placement="right" :resizable="true">
+    <DrawerContent
+      :title="$t('schema-editor.self')"
+      class="w-[70vw] min-w-4xl max-w-[100vw]"
+    >
       <div class="flex flex-col gap-y-4 h-full">
         <!-- Database selector for multi-database scenarios -->
         <div v-if="databases.length > 1" class="flex items-center gap-x-2">

--- a/frontend/src/components/ReleaseRemindModal.vue
+++ b/frontend/src/components/ReleaseRemindModal.vue
@@ -1,6 +1,6 @@
 <template>
   <BBModal :title="$t('remind.release.new-version-available')" @close="onClose">
-    <div class="min-w-0 md:min-w-400">
+    <div class="w-xl max-w-[calc(100vw-4rem)]">
       <div>
         <p class="whitespace-pre-wrap">
           <i18n-t keypath="remind.release.new-version-content">


### PR DESCRIPTION
The modal width is strange
<img width="3414" height="456" alt="CleanShot 2025-11-08 at 11 17 55@2x" src="https://github.com/user-attachments/assets/4b8bbcd4-3179-4c2d-a499-714a970d56c4" />

I guess it's also related to the tailwindcss v4