### PR TITLE
docs: add recommended location for git worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ psql -U bbdev bbdev
 ### Git
 
 - Follow conventional commit format
+- **Worktrees** — Place git worktrees in `../bytebase-worktrees/` (sibling directory to the main repo) to keep them organized and separate from the main working directory
 
 ### Imports
 


### PR DESCRIPTION
## Summary

Add instruction to CLAUDE.md recommending that git worktrees be placed in `../bytebase-worktrees/` (a sibling directory to the main repo).

## Changes

- Added worktree location guideline to the Git section under Code Style

## Rationale

This keeps worktrees organized and separated from the primary working directory, which:
- Reduces clutter in the main repository
- Prevents accidental changes to the main repo when using additional worktrees
- Makes it easier to manage multiple worktrees
- Follows common best practices for worktree organization

## Test plan

- [x] Documentation change only - no code changes to test
- [x] Verified the instruction is clear and follows existing CLAUDE.md formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)