### PR TITLE
chore: remove unused IssueExternalApprovalRelayCancelChan

### DIFF
--- a/backend/component/state/state.go
+++ b/backend/component/state/state.go
@@ -40,9 +40,6 @@ type State struct {
 	// RolloutOutstandingTasks is the maximum number of tasks per rollout.
 	RolloutOutstandingTasks *resourceLimiter
 
-	// IssueExternalApprovalRelayCancelChan cancels the external approval from relay for issue issueUID.
-	IssueExternalApprovalRelayCancelChan chan int
-
 	// TaskSkippedOrDoneChan is the channel for notifying the task is skipped or done.
 	TaskSkippedOrDoneChan chan int
 
@@ -60,13 +57,12 @@ func New() (*State, error) {
 		return nil, errors.Wrapf(err, "failed to create auth expire cache")
 	}
 	return &State{
-		InstanceOutstandingConnections:       &resourceLimiter{connections: map[string]int{}},
-		RolloutOutstandingTasks:              &resourceLimiter{connections: map[string]int{}},
-		IssueExternalApprovalRelayCancelChan: make(chan int, 1),
-		TaskSkippedOrDoneChan:                make(chan int, 1000),
-		PlanCheckTickleChan:                  make(chan int, 1000),
-		TaskRunTickleChan:                    make(chan int, 1000),
-		ExpireCache:                          expireCache,
+		InstanceOutstandingConnections: &resourceLimiter{connections: map[string]int{}},
+		RolloutOutstandingTasks:        &resourceLimiter{connections: map[string]int{}},
+		TaskSkippedOrDoneChan:          make(chan int, 1000),
+		PlanCheckTickleChan:            make(chan int, 1000),
+		TaskRunTickleChan:              make(chan int, 1000),
+		ExpireCache:                    expireCache,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Remove dead code left over from external approval feature removal.

## Changes

- Removed `IssueExternalApprovalRelayCancelChan` field from `State` struct
- Removed channel initialization in `New()` function

## Background

The `IssueExternalApprovalRelayCancelChan` was only used by the relay runner (`backend/runner/relay/runner.go`), which was deleted in commit 246eeddd94 as part of removing external approval functionality in #15258. The channel declaration and initialization were left behind as dead code with no send or receive operations anywhere in the codebase.

## Testing

- ✓ Code formatted with `gofmt`
- ✓ Linting passed with `golangci-lint` (0 issues)
- ✓ Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)