### PR TITLE
chore: remove unused state fields

### DIFF
--- a/backend/component/state/state.go
+++ b/backend/component/state/state.go
@@ -14,11 +14,6 @@ type State struct {
 	// ApprovalFinding is the set of issues for finding the approval template.
 	ApprovalFinding sync.Map // map[issue.ID]*store.IssueMessage
 
-	// TaskProgress is the map from task ID to task progress.
-	TaskProgress sync.Map // map[taskID]api.Progress
-	// GhostTaskState is the map from task ID to gh-ost state.
-	GhostTaskState sync.Map // map[taskID]sharedGhostState
-
 	TaskRunSchedulerInfo sync.Map // map[taskRunID]*storepb.SchedulerInfo
 
 	// TaskRunConnectionID is the map from task run ID to the connection id of the connection to the database.


### PR DESCRIPTION
## Summary
- Removed `TaskProgress` field from State struct (unused)
- Removed `GhostTaskState` field from State struct (unused)

These fields were declared but had no references in the codebase outside of the state.go file itself.

## Test plan
- [x] Verified no usage of these fields in the codebase via grep
- [x] Compilation check (fields were never used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)