### PR TITLE
refactor(parser/doris): change ParseDorisSQL to return list of AST nodes

### DIFF
--- a/backend/plugin/parser/doris/doris_test.go
+++ b/backend/plugin/parser/doris/doris_test.go
@@ -26,8 +26,8 @@ func TestDorisSQLParser(t *testing.T) {
 
 	for _, test := range tests {
 		res, err := ParseDorisSQL(test.statement)
-		if res != nil {
-			_, ok := res.Tree.(*parser.SqlStatementsContext)
+		if len(res) > 0 {
+			_, ok := res[0].Tree.(*parser.SqlStatementsContext)
 			require.True(t, ok)
 		}
 		if test.errorMessage == "" {

--- a/backend/plugin/parser/doris/query.go
+++ b/backend/plugin/parser/doris/query.go
@@ -15,16 +15,18 @@ func init() {
 
 func validateQuery(statement string) (bool, bool, error) {
 	// TODO: support other readonly statements like SHOW TABLES, SHOW CREATE TABLE, etc.
-	result, err := ParseDorisSQL(statement)
+	results, err := ParseDorisSQL(statement)
 	if err != nil {
 		return false, false, err
 	}
-	l := &queryValidateListener{
-		valid: true,
-	}
-	antlr.ParseTreeWalkerDefault.Walk(l, result.Tree)
-	if !l.valid {
-		return false, false, nil
+	for _, result := range results {
+		l := &queryValidateListener{
+			valid: true,
+		}
+		antlr.ParseTreeWalkerDefault.Walk(l, result.Tree)
+		if !l.valid {
+			return false, false, nil
+		}
 	}
 	return true, true, nil
 }


### PR DESCRIPTION
## Summary
Standardize Doris parser to return `[]*ParseResult` instead of `*ParseResult`, with one AST per statement.

## Changes

### Key Implementation Details:

1. **backend/plugin/parser/doris/split.go**:
   - **Refactored `SplitSQL` to be lexer-based** (avoiding circular dependency)
   - Changed from parse-then-split approach to direct lexer token scanning
   - Uses `SEMICOLON` token from Doris lexer as statement delimiter
   - Follows BigQuery's lexer-based pattern

2. **backend/plugin/parser/doris/doris.go**:
   - Modified `ParseDorisSQL` to return `[]*ParseResult`
   - Created `parseSingleDorisSQL` helper function
   - Added `BaseLine` field to `ParseResult` for line tracking
   - Uses refactored `SplitSQL` for statement splitting

3. **backend/plugin/parser/doris/query_span_extractor.go**:
   - Updated to validate exactly 1 statement (like MySQL pattern)
   - Returns empty QuerySpan for zero statements
   - Returns error for multiple statements

4. **backend/plugin/parser/doris/query.go**:
   - Updated `validateQuery` to **iterate through multiple statements**
   - Important: Query validation handles multiple statements, unlike query span extraction
   - Follows MySQL validation pattern

5. **backend/plugin/parser/doris/doris_test.go**:
   - Updated test to handle list return type

### Safety Notes:
- ✅ Doris doesn't use WalkThrough (not in the switch case in `sql_review.go:541`)
- ✅ Doris has no specific advisors that access the AST structure
- ✅ Return type is `any` so the change is transparent at the interface level

### Pattern Differences from BigQuery:
- **BigQuery**: Already had lexer-based `SplitSQL`
- **Doris**: Needed to refactor `SplitSQL` from parse-based to lexer-based to avoid circular dependency

## Testing
- ✅ All existing tests pass
- ✅ Linting passes with 0 issues
- ✅ Query span validation properly enforces single statement
- ✅ Query validation properly handles multiple statements

## Related
- Follows pattern from #18039 (BigQuery implementation)
- Part of standardizing all engine parsers per Linear issue BYT-8330

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>