### PR TITLE
fix: improve LDAP user filter error messages for better troubleshooting

### DIFF
--- a/backend/plugin/idp/ldap/ldap.go
+++ b/backend/plugin/idp/ldap/ldap.go
@@ -148,8 +148,11 @@ func (p *IdentityProvider) Authenticate(username, password string) (*storepb.Ide
 	)
 	if err != nil {
 		return nil, errors.Errorf("search user DN: %v", err)
-	} else if len(sr.Entries) != 1 {
-		return nil, errors.Errorf("expect 1 user DN but got %d", len(sr.Entries))
+	}
+	if len(sr.Entries) == 0 {
+		return nil, errors.Errorf("user filter matched no users; the filter may be too restrictive or the user does not exist in the directory (filter: %q, baseDN: %q)", p.config.UserFilter, p.config.BaseDN)
+	} else if len(sr.Entries) > 1 {
+		return nil, errors.Errorf("user filter matched %d users but must match exactly one; the filter is too broad and needs to be more specific (filter: %q, baseDN: %q)", len(sr.Entries), p.config.UserFilter, p.config.BaseDN)
 	}
 	entry := sr.Entries[0]
 


### PR DESCRIPTION
Replace the confusing "expect 1 user DN but got N" error with more actionable messages that explain the problem and show the actual filter configuration being used.

- When no users match: explains the filter may be too restrictive
- When multiple users match: explains the filter is too broad
- Both cases now display the filter and baseDN for easier debugging

This addresses the issue found in BYT-8361 where users encountered "expect 1 user DN but got 4445" and had difficulty understanding that their user filter was incorrectly configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)