### PR TITLE
fix: prevent LDAP configuration disclosure in authentication errors

### DIFF
--- a/backend/plugin/idp/ldap/ldap.go
+++ b/backend/plugin/idp/ldap/ldap.go
@@ -4,6 +4,7 @@ package ldap
 import (
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/go-ldap/ldap/v3"
@@ -150,9 +151,26 @@ func (p *IdentityProvider) Authenticate(username, password string) (*storepb.Ide
 		return nil, errors.Errorf("search user DN: %v", err)
 	}
 	if len(sr.Entries) == 0 {
-		return nil, errors.Errorf("user filter matched no users; the filter may be too restrictive or the user does not exist in the directory (filter: %q, baseDN: %q)", p.config.UserFilter, p.config.BaseDN)
+		// Log detailed information for admin troubleshooting
+		slog.Error("LDAP authentication failed: user filter matched no users",
+			slog.String("username", username),
+			slog.String("filter", p.config.UserFilter),
+			slog.String("base_dn", p.config.BaseDN),
+			slog.String("hint", "filter may be too restrictive or user does not exist in the directory"),
+		)
+		// Return generic error to prevent information disclosure
+		return nil, errors.New("invalid credentials")
 	} else if len(sr.Entries) > 1 {
-		return nil, errors.Errorf("user filter matched %d users but must match exactly one; the filter is too broad and needs to be more specific (filter: %q, baseDN: %q)", len(sr.Entries), p.config.UserFilter, p.config.BaseDN)
+		// Log detailed information for admin troubleshooting
+		slog.Error("LDAP authentication failed: user filter matched multiple users",
+			slog.String("username", username),
+			slog.Int("matched_count", len(sr.Entries)),
+			slog.String("filter", p.config.UserFilter),
+			slog.String("base_dn", p.config.BaseDN),
+			slog.String("hint", "filter is too broad and needs to be more specific"),
+		)
+		// Return generic error to prevent information disclosure
+		return nil, errors.New("authentication configuration error, please contact your administrator")
 	}
 	entry := sr.Entries[0]
 


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability where LDAP configuration details (filter syntax and baseDN) were being exposed in API error messages displayed to users during authentication failures.

## Security Issue

**Before:** Error messages included sensitive configuration:
```
user filter matched no users (filter: "(uid=%s)", baseDN: "ou=users,dc=company,dc=com")
```

This exposed:
- LDAP filter structure → enables targeted attacks
- Directory structure (baseDN) → reduces attacker search space  
- User enumeration capability → attackers can determine if users exist
- Authentication mechanism details → aids reconnaissance

## Solution

**After:** Generic user-facing errors with detailed server logging:
- User sees: `"invalid credentials"` (prevents enumeration)
- Admin sees in logs: Full details including filter, baseDN, username, match count, and troubleshooting hints

## Changes

- Added structured logging with `slog.Error()` for admin troubleshooting
- Replaced detailed `errors.Errorf()` with generic error messages
- Logged username, filter, baseDN, match count, and hints server-side
- Prevented information disclosure in API responses

## Security Benefits

✅ Prevents user enumeration attacks  
✅ Hides LDAP configuration from unauthorized users  
✅ Maintains detailed logging for legitimate troubleshooting  
✅ Follows security best practices for authentication errors  

## Testing

- ✅ Code formatted with `gofmt`
- ✅ Linting passed: `golangci-lint run --allow-parallel-runners` (0 issues)
- Manual testing recommended: Verify error messages in UI and logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)