### PR TITLE
feat: add UI for audit log stdout setting

### DIFF
--- a/backend/api/v1/setting_service_converter.go
+++ b/backend/api/v1/setting_service_converter.go
@@ -424,6 +424,7 @@ func convertWorkspaceProfileSetting(v1Setting *v1pb.WorkspaceProfileSetting) *st
 		DatabaseChangeMode:     storepb.DatabaseChangeMode(v1Setting.DatabaseChangeMode),
 		DisallowPasswordSignin: v1Setting.DisallowPasswordSignin,
 		EnableMetricCollection: v1Setting.EnableMetricCollection,
+		EnableAuditLogStdout:   v1Setting.EnableAuditLogStdout,
 	}
 
 	// Convert announcement if present
@@ -466,6 +467,7 @@ func convertToWorkspaceProfileSetting(storeSetting *storepb.WorkspaceProfileSett
 		DatabaseChangeMode:     v1pb.DatabaseChangeMode(storeSetting.DatabaseChangeMode),
 		DisallowPasswordSignin: storeSetting.DisallowPasswordSignin,
 		EnableMetricCollection: storeSetting.EnableMetricCollection,
+		EnableAuditLogStdout:   storeSetting.EnableAuditLogStdout,
 	}
 
 	if storeSetting.Announcement != nil {

--- a/frontend/src/components/GeneralSetting/AuditLogStdoutSetting.vue
+++ b/frontend/src/components/GeneralSetting/AuditLogStdoutSetting.vue
@@ -1,0 +1,84 @@
+<template>
+  <div id="audit-log-stdout" class="py-6 lg:flex">
+    <div class="text-left lg:w-1/4">
+      <h1 class="text-2xl font-bold">
+        {{ $t("settings.general.workspace.audit-log-stdout.self") }}
+      </h1>
+    </div>
+    <div class="flex-1 lg:px-4">
+      <div class="flex items-center gap-x-2">
+        <Switch
+          v-model:value="state.enableAuditLogStdout"
+          :text="true"
+          :disabled="!allowEdit"
+        />
+        <span class="text-sm">
+          {{ $t("settings.general.workspace.audit-log-stdout.enable") }}
+        </span>
+      </div>
+      <div class="mt-1 text-sm text-gray-400">
+        {{ $t("settings.general.workspace.audit-log-stdout.description") }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { create } from "@bufbuild/protobuf";
+import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
+import { isEqual } from "lodash-es";
+import { computed, reactive } from "vue";
+import { Switch } from "@/components/v2";
+import { useSettingV1Store } from "@/store";
+import type { WorkspaceProfileSetting } from "@/types/proto-es/v1/setting_service_pb";
+
+interface LocalState {
+  enableAuditLogStdout: boolean;
+}
+
+defineProps<{
+  allowEdit: boolean;
+}>();
+
+const settingV1Store = useSettingV1Store();
+
+const getInitialState = (): LocalState => {
+  return {
+    enableAuditLogStdout:
+      settingV1Store.workspaceProfileSetting?.enableAuditLogStdout ?? false,
+  };
+};
+
+const state = reactive(getInitialState());
+const originalState = reactive(getInitialState());
+
+const isDirty = computed(() => {
+  return !isEqual(state, originalState);
+});
+
+const revert = () => {
+  Object.assign(state, originalState);
+};
+
+const update = async () => {
+  const payload: Partial<WorkspaceProfileSetting> = {
+    enableAuditLogStdout: state.enableAuditLogStdout,
+  };
+
+  await settingV1Store.updateWorkspaceProfile({
+    payload,
+    updateMask: create(FieldMaskSchema, {
+      paths: ["value.workspace_profile_setting_value.enable_audit_log_stdout"],
+    }),
+  });
+
+  Object.assign(originalState, state);
+};
+
+defineExpose({
+  isDirty,
+  revert,
+  update,
+  title: "Audit Log Stdout",
+});
+</script>

--- a/frontend/src/components/GeneralSetting/index.ts
+++ b/frontend/src/components/GeneralSetting/index.ts
@@ -1,6 +1,7 @@
 import AIAugmentationSetting from "./AIAugmentationSetting.vue";
 import AccountSetting from "./AccountSetting.vue";
 import AnnouncementSetting from "./AnnouncementSetting.vue";
+import AuditLogStdoutSetting from "./AuditLogStdoutSetting.vue";
 import BrandingSetting from "./BrandingSetting.vue";
 import GeneralSetting from "./GeneralSetting.vue";
 import MaximumSQLResultSizeSetting from "./MaximumSQLResultSizeSetting.vue";
@@ -14,6 +15,7 @@ export {
   MaximumSQLResultSizeSetting,
   AIAugmentationSetting,
   AnnouncementSetting,
+  AuditLogStdoutSetting,
   GeneralSetting,
   ProductImprovementSetting,
 };

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -589,6 +589,11 @@
           "participate": "Participate in improvement program",
           "description": "Help improve Bytebase by sharing anonymous usage data"
         },
+        "audit-log-stdout": {
+          "self": "Audit Log Export",
+          "enable": "Enable audit logging to stdout",
+          "description": "Output structured JSON audit logs to stdout for ingestion by log aggregators (Splunk, ELK, Datadog, Loki). Requires TEAM or ENTERPRISE license."
+        },
         "disallow-signup": {
           "enable": "Disallow self-service signup",
           "description": "Users cannot self-service signup and can only be invited by the workspace admin."

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -589,6 +589,11 @@
           "participate": "Participar en el programa de mejora",
           "description": "Ayuda a mejorar Bytebase compartiendo datos de uso anónimos"
         },
+        "audit-log-stdout": {
+          "self": "Exportación de Registros de Auditoría",
+          "enable": "Habilitar el registro de auditoría en la salida estándar",
+          "description": "Generar registros de auditoría JSON estructurados en la salida estándar para su ingesta por agregadores de registros (Splunk, ELK, Datadog, Loki). Requiere licencia TEAM o ENTERPRISE."
+        },
         "disallow-signup": {
           "enable": "Deshabilitar el registro de autoservicio",
           "description": "Una vez deshabilitado, los usuarios no pueden registrarse por sí mismos y solo pueden ser invitados por el administrador del espacio de trabajo."

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -589,6 +589,11 @@
           "participate": "改善プログラムに参加",
           "description": "匿名の使用データを共有してBytebaseの改善に協力する"
         },
+        "audit-log-stdout": {
+          "self": "監査ログエクスポート",
+          "enable": "監査ログの標準出力への出力を有効にする",
+          "description": "構造化されたJSON監査ログを標準出力に出力し、ログアグリゲーター（Splunk、ELK、Datadog、Loki）で取り込めるようにします。TEAMまたはENTERPRISEライセンスが必要です。"
+        },
         "disallow-signup": {
           "enable": "セルフサービス登録を無効にする",
           "description": "無効化されると、新しいユーザーは自己登録できなくなり、管理者の招待を通じてのみアカウントを作成できます。"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -589,6 +589,11 @@
           "participate": "Tham gia chương trình cải thiện",
           "description": "Giúp cải thiện Bytebase bằng cách chia sẻ dữ liệu sử dụng ẩn danh"
         },
+        "audit-log-stdout": {
+          "self": "Xuất Nhật ký Kiểm toán",
+          "enable": "Bật ghi nhật ký kiểm toán vào đầu ra chuẩn",
+          "description": "Xuất nhật ký kiểm toán JSON có cấu trúc vào đầu ra chuẩn để thu thập bởi các bộ tổng hợp nhật ký (Splunk, ELK, Datadog, Loki). Yêu cầu giấy phép TEAM hoặc ENTERPRISE."
+        },
         "disallow-signup": {
           "enable": "Không cho phép đăng ký tự phục vụ",
           "description": "Người dùng không thể tự đăng ký và chỉ có thể được mời bởi quản trị viên không gian làm việc."

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -589,6 +589,11 @@
           "participate": "参与改进计划",
           "description": "通过分享匿名使用数据帮助改进 Bytebase"
         },
+        "audit-log-stdout": {
+          "self": "审计日志导出",
+          "enable": "启用审计日志输出到标准输出",
+          "description": "将结构化的 JSON 审计日志输出到标准输出，以便日志聚合器（Splunk、ELK、Datadog、Loki）摄取。需要 TEAM 或 ENTERPRISE 许可证。"
+        },
         "disallow-signup": {
           "enable": "禁用自助注册",
           "description": "禁用之后，新用户将无法自助注册，只能通过管理员邀请来创建账户。"

--- a/frontend/src/views/SettingWorkspaceGeneral.vue
+++ b/frontend/src/views/SettingWorkspaceGeneral.vue
@@ -34,6 +34,10 @@
       ref="productImprovementSettingRef"
       :allow-edit="allowEdit"
     />
+    <AuditLogStdoutSetting
+      ref="auditLogStdoutSettingRef"
+      :allow-edit="allowEdit"
+    />
 
     <div v-if="allowEdit && isDirty" class="sticky -bottom-4 z-10">
       <div
@@ -61,6 +65,7 @@ import {
   AccountSetting,
   AIAugmentationSetting,
   AnnouncementSetting,
+  AuditLogStdoutSetting,
   GeneralSetting,
   ProductImprovementSetting,
 } from "@/components/GeneralSetting";
@@ -84,6 +89,8 @@ const aiAugmentationSettingRef =
 const announcementSettingRef = ref<InstanceType<typeof AnnouncementSetting>>();
 const productImprovementSettingRef =
   ref<InstanceType<typeof ProductImprovementSetting>>();
+const auditLogStdoutSettingRef =
+  ref<InstanceType<typeof AuditLogStdoutSetting>>();
 
 const settingRefList = computed(() => {
   return [
@@ -94,6 +101,7 @@ const settingRefList = computed(() => {
     aiAugmentationSettingRef,
     announcementSettingRef,
     productImprovementSettingRef,
+    auditLogStdoutSettingRef,
   ];
 });
 


### PR DESCRIPTION
Completes the audit log stdout feature started in #17914 by adding frontend UI for configuration.

  ## Changes

  **Frontend**
  - Added `AuditLogStdoutSetting.vue` component with toggle control
  - Integrated into workspace settings page (Settings → Workspace → General)
  - Added i18n translations (EN, CN, JP, VN, ES)

  **Backend Bug Fix**
  - Fixed `convertWorkspaceProfileSetting` and `convertToWorkspaceProfileSetting` to include `EnableAuditLogStdout` field (missing from #17914)
  - Without this fix, the frontend would send `true` but backend converters would drop the value

  ## Result

  Users can now enable/disable audit logging to stdout through the Bytebase UI. Requires TEAM or ENTERPRISE license.