### PR TITLE
fix: prevent SQL syntax error when searching issues without filters

### DIFF
--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -387,8 +387,10 @@ func (s *Store) ListIssueV2(ctx context.Context, find *FindIssueMessage) ([]*Iss
 				GROUP BY t.status
 			) AS t
 		) AS task_run_status_count ON TRUE
-		WHERE ?
-	`, from, where)
+	`, from)
+	if where.Len() > 0 {
+		q.Space("WHERE ?", where)
+	}
 	q.Space(orderByClause)
 
 	if v := find.Limit; v != nil {


### PR DESCRIPTION
## Summary

- Fixed SQL syntax error that occurred when searching issues without any filter conditions
- The bug caused `ERROR: syntax error at or near "ORDER" (SQLSTATE 42601)` in frontend when page changed
- Only add WHERE clause when there are actual conditions to prevent generating invalid SQL

## Problem

The `ListIssueV2` function was generating malformed SQL when the WHERE clause had no conditions:

```sql
SELECT ... FROM ... WHERE ORDER BY ...
```

This happened when:
1. User has full permissions (`getProjectIDsSearchFilter` returns `nil`)
2. `projectID == "-"` (search across all projects)
3. No other filters are applied

## Solution

Modified `backend/store/issue.go` to conditionally add the WHERE clause only when conditions exist:

```go
// Before
WHERE ?
`, from, where)

// After
`, from)
if where.Len() > 0 {
    q.Space("WHERE ?", where)
}
```

This follows the same pattern used in `database.go` and `instance.go` for handling optional WHERE clauses.

## Test plan

- [x] Code formatted with `gofmt`
- [x] Linting passed with `golangci-lint` (0 issues)
- [x] Backend builds successfully
- [x] Manual testing: searching issues without filters no longer produces SQL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)