### PR TITLE
fix: prevent GetRelease permission error when navigating to release page

### DIFF
--- a/frontend/src/components/Release/ReleaseDetail/context.ts
+++ b/frontend/src/components/Release/ReleaseDetail/context.ts
@@ -40,7 +40,7 @@ export const provideReleaseDetailContext = () => {
   }, unknownProject());
 
   const name = computed(() => {
-    return `${project.value.name}/releases/${route.params.releaseId}`;
+    return `${projectNamePrefix}${route.params.projectId}/releases/${route.params.releaseId}`;
   });
 
   watchEffect(async () => {


### PR DESCRIPTION
## Summary

Fixes a permission error that occurs when navigating to a release detail page.

## Problem

When navigating to `/projects/{projectId}/releases/{releaseId}`, users encountered the error:
```
[internal] failed to check permission for method "/bytebase.v1.ReleaseService/GetRelease", extra [-1], err: project "-1" not found
```

## Root Cause

The release name was constructed using `project.value.name` where `project` is loaded asynchronously via `computedAsync`. During initial render, the project value is `unknownProject()` with `name: "projects/-1"`, causing the release name to be `projects/-1/releases/{uid}`. The `watchEffect` immediately triggered with this invalid name, causing the backend permission check to fail.

## Solution

Changed the release name construction to use route params directly:
- **Before**: `${project.value.name}/releases/${route.params.releaseId}` (depends on async project load)
- **After**: `${projectNamePrefix}${route.params.projectId}/releases/${route.params.releaseId}` (uses sync route params)

Route params are synchronously available and are the authoritative source for resource IDs. This eliminates the race condition and simplifies the code.

## Test plan

- [x] Navigate to a release detail page and verify no permission error occurs
- [x] ESLint passes
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)