### PR TITLE
chore: correct err handle

### DIFF
--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -234,11 +233,9 @@ func start() {
 
 	// Execute program.
 	if err := s.Run(ctx, flags.port); err != nil {
-		if err != http.ErrServerClosed {
-			slog.Error(err.Error())
-			_ = s.Shutdown(ctx)
-			cancel()
-		}
+		slog.Error(err.Error())
+		_ = s.Shutdown(ctx)
+		cancel()
 	}
 
 	// Wait for CTRL-C.

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"path"
 	"sync"
 	"time"
@@ -272,7 +273,9 @@ func (s *Server) Run(ctx context.Context, port int) error {
 
 	go func() {
 		if err := s.echoServer.StartH2CServer(address, &http2.Server{}); err != nil {
-			slog.Error("http server listen error", log.BBError(err))
+			if !errors.Is(err, http.ErrServerClosed) {
+				slog.Error("http server listen error", log.BBError(err))
+			}
 		}
 	}()
 


### PR DESCRIPTION
root.go would never hit `ErrServerClosed`