### PR TITLE
feat: add GitOps Service Agent role for automated CI/CD workflows

### DIFF
--- a/backend/component/iam/acl.yaml
+++ b/backend/component/iam/acl.yaml
@@ -378,8 +378,8 @@ roles:
       - bb.sheets.get
       - bb.taskRuns.create
       - bb.taskRuns.list
-  - name: roles/gitopsAgent
-    title: GitOps Agent
+  - name: roles/gitopsServiceAgent
+    title: GitOps Service Agent
     permissions:
       - bb.plans.create
       - bb.plans.get

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2775,8 +2775,8 @@
       "self": "SQL Editor User",
       "description": "Permissions for querying database data."
     },
-    "gitops-agent": {
-      "self": "GitOps Agent",
+    "gitops-service-agent": {
+      "self": "GitOps Service Agent",
       "description": "Permissions for automated CI/CD workflows to create and execute database changes via GitOps."
     },
     "project-viewer": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2775,8 +2775,8 @@
       "self": "Usuario del editor SQL",
       "description": "El consultor del proyecto tiene todos los permisos dentro del proyecto, excepto la gestión de miembros del proyecto."
     },
-    "gitops-agent": {
-      "self": "Agente GitOps",
+    "gitops-service-agent": {
+      "self": "Agente de Servicio GitOps",
       "description": "Permisos para flujos de trabajo automatizados de CI/CD para crear y ejecutar cambios de base de datos a través de GitOps."
     },
     "project-viewer": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2775,8 +2775,8 @@
       "self": "SQLエディタのユーザー",
       "description": "指定した範囲内のデータをクエリできます。"
     },
-    "gitops-agent": {
-      "self": "GitOps エージェント",
+    "gitops-service-agent": {
+      "self": "GitOps サービスエージェント",
       "description": "GitOps を介して自動化された CI/CD ワークフローでデータベース変更を作成および実行するための権限。"
     },
     "project-viewer": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2775,8 +2775,8 @@
       "self": "Người dùng Trình soạn thảo SQL",
       "description": "Quyền truy vấn dữ liệu cơ sở dữ liệu."
     },
-    "gitops-agent": {
-      "self": "Tác nhân GitOps",
+    "gitops-service-agent": {
+      "self": "Tác nhân Dịch vụ GitOps",
       "description": "Quyền cho quy trình CI/CD tự động để tạo và thực thi các thay đổi cơ sở dữ liệu qua GitOps."
     },
     "project-viewer": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2775,8 +2775,8 @@
       "self": "SQL 编辑器用户",
       "description": "可查询指定范围的数据。"
     },
-    "gitops-agent": {
-      "self": "GitOps 代理",
+    "gitops-service-agent": {
+      "self": "GitOps 服务代理",
       "description": "通过 GitOps 自动化 CI/CD 工作流创建和执行数据库变更的权限。"
     },
     "project-viewer": {

--- a/frontend/src/types/iam/role.ts
+++ b/frontend/src/types/iam/role.ts
@@ -8,7 +8,7 @@ export enum PresetRoleType {
   PROJECT_DEVELOPER = `${roleNamePrefix}projectDeveloper`,
   SQL_EDITOR_USER = `${roleNamePrefix}sqlEditorUser`,
   PROJECT_RELEASER = `${roleNamePrefix}projectReleaser`,
-  GITOPS_AGENT = `${roleNamePrefix}gitopsAgent`,
+  GITOPS_SERVICE_AGENT = `${roleNamePrefix}gitopsServiceAgent`,
   PROJECT_VIEWER = `${roleNamePrefix}projectViewer`,
 }
 
@@ -25,6 +25,6 @@ export const PRESET_PROJECT_ROLES: string[] = [
   PresetRoleType.PROJECT_DEVELOPER,
   PresetRoleType.SQL_EDITOR_USER,
   PresetRoleType.PROJECT_RELEASER,
-  PresetRoleType.GITOPS_AGENT,
+  PresetRoleType.GITOPS_SERVICE_AGENT,
   PresetRoleType.PROJECT_VIEWER,
 ];

--- a/frontend/src/utils/role.ts
+++ b/frontend/src/utils/role.ts
@@ -35,8 +35,8 @@ export const displayRoleTitle = (role: string): string => {
       return t("role.project-releaser.self");
     case PresetRoleType.SQL_EDITOR_USER:
       return t("role.sql-editor-user.self");
-    case PresetRoleType.GITOPS_AGENT:
-      return t("role.gitops-agent.self");
+    case PresetRoleType.GITOPS_SERVICE_AGENT:
+      return t("role.gitops-service-agent.self");
     case PresetRoleType.PROJECT_VIEWER:
       return t("role.project-viewer.self");
   }
@@ -62,8 +62,8 @@ export const displayRoleDescription = (role: string): string => {
       return t("role.project-releaser.description");
     case PresetRoleType.SQL_EDITOR_USER:
       return t("role.sql-editor-user.description");
-    case PresetRoleType.GITOPS_AGENT:
-      return t("role.gitops-agent.description");
+    case PresetRoleType.GITOPS_SERVICE_AGENT:
+      return t("role.gitops-service-agent.description");
     case PresetRoleType.PROJECT_VIEWER:
       return t("role.project-viewer.description");
   }


### PR DESCRIPTION
## Summary
- Add new built-in role `roles/gitopsAgent` for service accounts used in automated CI/CD workflows
- This role has the minimum permissions required for bytebase-action in GitHub Actions/GitLab CI

## Permissions
The GitOps Agent role includes:
- `bb.plans.create`, `bb.plans.get`
- `bb.releases.check`, `bb.releases.create`, `bb.releases.get`
- `bb.rollouts.create`, `bb.rollouts.get`, `bb.rollouts.list`
- `bb.taskRuns.create`, `bb.taskRuns.list`

## Changes
- Add role definition in `backend/component/iam/acl.yaml`
- Add `GITOPS_AGENT` to `PresetRoleType` enum in `frontend/src/types/iam/role.ts`
- Add i18n translations (EN, ZH-CN, JA-JP, ES-ES, VI-VN)

## Test plan
- [x] Backend build successful
- [x] Frontend type-check passed
- [x] Frontend lint passed
- [ ] Manual testing: Assign gitopsAgent role to service account and verify bytebase-action workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)