### PR TITLE
chore: reorder project roles by permission hierarchy

### DIFF
--- a/frontend/src/types/iam/role.ts
+++ b/frontend/src/types/iam/role.ts
@@ -23,8 +23,8 @@ export const PRESET_WORKSPACE_ROLES: string[] = [
 export const PRESET_PROJECT_ROLES: string[] = [
   PresetRoleType.PROJECT_OWNER,
   PresetRoleType.PROJECT_DEVELOPER,
-  PresetRoleType.SQL_EDITOR_USER,
   PresetRoleType.PROJECT_RELEASER,
-  PresetRoleType.GITOPS_SERVICE_AGENT,
+  PresetRoleType.SQL_EDITOR_USER,
   PresetRoleType.PROJECT_VIEWER,
+  PresetRoleType.GITOPS_SERVICE_AGENT,
 ];


### PR DESCRIPTION
## Summary
- Reorganize `PRESET_PROJECT_ROLES` array to follow a logical order based on permission levels and workflow progression
- New order: Owner → Developer → Releaser → SQL Editor → Viewer → GitOps Agent

## Changes
Reordered the project roles in `frontend/src/types/iam/role.ts`:
1. Project Owner (highest permissions)
2. Project Developer
3. Project Releaser  
4. SQL Editor User
5. Project Viewer (read-only)
6. GitOps Service Agent (service role, placed last)

## Rationale
The previous ordering was inconsistent and didn't reflect permission hierarchy. This change provides better UX in role selection UIs by presenting roles in descending order of privileges, which is more intuitive for users.

## Test plan
- [x] Frontend lint passed
- [x] Frontend type-check passed
- [ ] Manual verification: role selection dropdowns show roles in the new logical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)