### PR TITLE
feat: remove "All" option from issue status filter

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/Status.vue
+++ b/frontend/src/components/IssueV1/components/IssueSearch/Status.vue
@@ -38,10 +38,6 @@ const tabItemList = computed(() => {
       value: "CLOSED",
       label: t("issue.table.closed"),
     },
-    {
-      value: "",
-      label: t("common.all"),
-    },
   ] as {
     value: SemanticIssueStatus;
     label: string;


### PR DESCRIPTION
## Summary

- Remove the "All" option from the Open/Closed status filter in the issue dashboard
- Users must now choose either "Open" or "Closed" status when viewing issues
- Top-level tabs (Waiting for Approval, Created, All) remain unchanged

## Motivation

This change aligns with common patterns in code review tools like GitHub, where status filters are binary (open or closed) rather than offering an "all" option. 

Mixing open and closed issues in the same view:
- Creates a confusing UX where actionable items (open) are mixed with historical items (closed)
- Is rarely needed in practice - users typically want to see either open OR closed issues
- Doesn't match industry standards (GitHub, GitLab, etc. don't offer "All" for PR status)

## Changes

**Modified file:**
- `frontend/src/components/IssueV1/components/IssueSearch/Status.vue`

**What changed:**
- Removed the "All" option from the status filter tab list
- Status filter now only shows "Open" and "Closed"

## Test plan

- [ ] Verify issue dashboard shows only "Open" and "Closed" status filters (no "All")
- [ ] Verify top-level tabs still show "Waiting for Approval", "Created", and "All"
- [ ] Verify switching between "Open" and "Closed" filters correctly
- [ ] Verify Advanced Search still works correctly
- [ ] Run frontend linting: `pnpm --dir frontend lint`
- [ ] Run frontend type checking: `pnpm --dir frontend type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)