### PR TITLE
chore: upgrade parser dependency

### DIFF
--- a/backend/plugin/parser/pg/pg.go
+++ b/backend/plugin/parser/pg/pg.go
@@ -317,11 +317,6 @@ func NormalizePostgreSQLFuncName(ctx parser.IFunc_nameContext) []string {
 		}
 	}
 
-	// Handle builtin function names
-	if ctx.Builtin_function_name() != nil {
-		result = append(result, ctx.Builtin_function_name().GetText())
-	}
-
 	// Handle special keywords LEFT/RIGHT
 	if len(result) == 0 && ctx.GetText() != "" {
 		// Fallback for special cases like LEFT, RIGHT keywords

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -98,7 +98,6 @@ func newPreferredRules() map[int]bool {
 		plsql.PlSqlParserRULE_attribute_name:           true,
 		plsql.PlSqlParserRULE_savepoint_name:           true,
 		plsql.PlSqlParserRULE_rollback_segment_name:    true,
-		plsql.PlSqlParserRULE_table_var_name:           true,
 		plsql.PlSqlParserRULE_schema_name:              true,
 		plsql.PlSqlParserRULE_package_name:             true,
 		plsql.PlSqlParserRULE_implementation_type_name: true,

--- a/go.mod
+++ b/go.mod
@@ -293,7 +293,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.39.0
 	github.com/aws/smithy-go v1.23.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bytebase/parser v0.0.0-20251110095732-1f0027a46f16
+	github.com/bytebase/parser v0.0.0-20251113094200-734ef85da6ad
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/cockroachdb/cockroach-go/v2 v2.4.2

--- a/go.sum
+++ b/go.sum
@@ -853,8 +853,8 @@ github.com/bytebase/gosasl v0.0.0-20240422091407-6b7481e86f08 h1:S1GgjJLspz4E4z4
 github.com/bytebase/gosasl v0.0.0-20240422091407-6b7481e86f08/go.mod h1:Qx8cW6jkI8riyzmklj80kAIkv+iezFUTBiGU0qHhHes=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/parser v0.0.0-20251110095732-1f0027a46f16 h1:sjth6iocuBUU/Afu2/Hfhmz8nCiyXBBS34Zoj5FclT4=
-github.com/bytebase/parser v0.0.0-20251110095732-1f0027a46f16/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
+github.com/bytebase/parser v0.0.0-20251113094200-734ef85da6ad h1:cemWTRG6+M3LPA4h4Dl0wJIG90KX4OmV+BFrSDvCiDk=
+github.com/bytebase/parser v0.0.0-20251113094200-734ef85da6ad/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
Introducing:
https://github.com/bytebase/parser/pull/41
https://github.com/bytebase/parser/pull/40
https://github.com/bytebase/parser/pull/39