### PR TITLE
refactor: simplify catalog state API by removing Find structs

### DIFF
--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
@@ -168,10 +168,7 @@ func normalizeColumnType(tp string) string {
 
 func (r *ColumnDisallowChangingTypeRule) changeColumnType(tableName, columnName string, dataType mysql.IDataTypeContext) {
 	tp := dataType.GetParser().GetTokenStream().GetTextFromRuleContext(dataType)
-	column := r.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columnName,
-	})
+	column := r.catalog.Origin.GetColumn("", tableName, columnName)
 
 	if column == nil {
 		return

--- a/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
@@ -156,11 +156,7 @@ func (r *ColumnDisallowDropInIndexRule) checkAlterTable(ctx *mysql.AlterTableCon
 			continue
 		}
 
-		index := r.catalog.Origin.Index(&catalog.TableIndexFind{
-			// In MySQL, the SchemaName is "".
-			SchemaName: "",
-			TableName:  tableName,
-		})
+		index := r.catalog.Origin.Index("", tableName)
 
 		if index != nil {
 			if r.tables[tableName] == nil {

--- a/backend/plugin/advisor/mysql/rule_column_no_null.go
+++ b/backend/plugin/advisor/mysql/rule_column_no_null.go
@@ -134,10 +134,7 @@ func (r *ColumnNoNullRule) generateAdvice() {
 	})
 
 	for _, column := range columnList {
-		col := r.catalog.Final.FindColumn(&catalog.ColumnFind{
-			TableName:  column.tableName,
-			ColumnName: column.columnName,
-		})
+		col := r.catalog.Final.GetColumn("", column.tableName, column.columnName)
 		if col != nil && col.Nullable() {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,

--- a/backend/plugin/advisor/mysql/rule_index_pk_type.go
+++ b/backend/plugin/advisor/mysql/rule_index_pk_type.go
@@ -236,10 +236,7 @@ func (r *IndexPkTypeRule) getPKColumnType(tableName string, columnName string) (
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columnName,
-	})
+	column := r.catalog.Origin.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
@@ -250,10 +250,7 @@ func (r *IndexPrimaryKeyTypeAllowlistRule) getPKColumnType(tableName string, col
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columnName,
-	})
+	column := r.catalog.Origin.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
+++ b/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
@@ -130,7 +130,7 @@ func (r *IndexTotalNumberLimitRule) generateAdvice() []*storepb.Advice {
 	})
 
 	for _, table := range tableList {
-		tableInfo := r.catalog.Final.FindTable(&catalog.TableFind{TableName: table.name})
+		tableInfo := r.catalog.Final.GetTable("", table.name)
 		if tableInfo != nil && tableInfo.CountIndex() > r.max {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,

--- a/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
+++ b/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
@@ -293,10 +293,7 @@ func (r *IndexTypeNoBlobRule) getColumnType(tableName string, columnName string)
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columnName,
-	})
+	column := r.catalog.Origin.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/mysql/rule_naming_index_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_index_convention.go
@@ -186,10 +186,7 @@ func (r *NamingIndexConventionRule) checkAlterTable(ctx *mysql.AlterTableContext
 		case alterListItem.RENAME_SYMBOL() != nil && alterListItem.KeyOrIndex() != nil && alterListItem.IndexRef() != nil && alterListItem.IndexName() != nil:
 			_, _, oldIndexName := mysqlparser.NormalizeIndexRef(alterListItem.IndexRef())
 			newIndexName := mysqlparser.NormalizeIndexName(alterListItem.IndexName())
-			_, indexState := r.catalog.Origin.FindIndex(&catalog.IndexFind{
-				TableName: tableName,
-				IndexName: oldIndexName,
-			})
+			_, indexState := r.catalog.Origin.GetIndex("", tableName, oldIndexName)
 			if indexState == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
@@ -187,10 +187,7 @@ func (r *NamingUKConventionRule) checkAlterTable(ctx *mysql.AlterTableContext) {
 		case alterListItem.RENAME_SYMBOL() != nil && alterListItem.KeyOrIndex() != nil && alterListItem.IndexRef() != nil && alterListItem.IndexName() != nil:
 			_, _, oldIndexName := mysqlparser.NormalizeIndexRef(alterListItem.IndexRef())
 			newIndexName := mysqlparser.NormalizeIndexName(alterListItem.IndexName())
-			indexStateMap := r.catalog.Origin.Index(&catalog.TableIndexFind{
-				SchemaName: "",
-				TableName:  tableName,
-			})
+			indexStateMap := r.catalog.Origin.Index("", tableName)
 			if indexStateMap == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_pk.go
@@ -250,10 +250,7 @@ func (r *TableRequirePKRule) changeColumn(tableName string, oldColumn string, ne
 
 func (r *TableRequirePKRule) dropColumn(tableName string, columnName string) bool {
 	if _, ok := r.tables[tableName]; !ok {
-		_, pk := r.catalog.Origin.FindIndex(&catalog.IndexFind{
-			TableName: tableName,
-			IndexName: primaryKeyName,
-		})
+		_, pk := r.catalog.Origin.GetIndex("", tableName, primaryKeyName)
 		if pk == nil {
 			return false
 		}

--- a/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
+++ b/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
@@ -114,7 +114,7 @@ func (r *TableTextFieldsTotalLengthRule) checkCreateTable(ctx *mysql.CreateTable
 	if tableName == "" {
 		return
 	}
-	tableInfo := r.catalog.Final.FindTable(&catalog.TableFind{TableName: tableName})
+	tableInfo := r.catalog.Final.GetTable("", tableName)
 	if tableInfo == nil {
 		return
 	}
@@ -148,7 +148,7 @@ func (r *TableTextFieldsTotalLengthRule) checkAlterTable(ctx *mysql.AlterTableCo
 	if tableName == "" {
 		return
 	}
-	tableInfo := r.catalog.Final.FindTable(&catalog.TableFind{TableName: tableName})
+	tableInfo := r.catalog.Final.GetTable("", tableName)
 	if tableInfo == nil {
 		return
 	}

--- a/backend/plugin/advisor/pg/advisor_column_no_null.go
+++ b/backend/plugin/advisor/pg/advisor_column_no_null.go
@@ -307,11 +307,7 @@ func (r *columnNoNullRule) removeColumnByTableConstraint(schema, table string, c
 			indexName := pg.NormalizePostgreSQLName(existingIndex.Name())
 			// Try to find index in catalog
 			if r.catalog != nil {
-				_, index := r.catalog.Origin.FindIndex(&catalog.IndexFind{
-					SchemaName: schema,
-					TableName:  table,
-					IndexName:  indexName,
-				})
+				_, index := r.catalog.Origin.GetIndex(schema, table, indexName)
 				if index != nil {
 					for _, expression := range index.ExpressionList() {
 						r.removeColumn(schema, table, expression)

--- a/backend/plugin/advisor/pg/advisor_index_total_number_limit.go
+++ b/backend/plugin/advisor/pg/advisor_index_total_number_limit.go
@@ -124,10 +124,7 @@ func (r *indexTotalNumberLimitRule) generateAdvice() {
 	})
 
 	for _, table := range tableList {
-		tableInfo := r.catalog.Final.FindTable(&catalog.TableFind{
-			SchemaName: table.schema,
-			TableName:  table.table,
-		})
+		tableInfo := r.catalog.Final.GetTable(table.schema, table.table)
 		if tableInfo != nil && tableInfo.CountIndex() > r.max {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,

--- a/backend/plugin/advisor/pg/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_index_convention.go
@@ -236,9 +236,5 @@ func (r *namingIndexConventionRule) findIndex(schemaName string, tableName strin
 	if r.catalog == nil {
 		return "", nil
 	}
-	return r.catalog.Origin.FindIndex(&catalog.IndexFind{
-		SchemaName: normalizeSchemaName(schemaName),
-		TableName:  tableName,
-		IndexName:  indexName,
-	})
+	return r.catalog.Origin.GetIndex(normalizeSchemaName(schemaName), tableName, indexName)
 }

--- a/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
@@ -195,11 +195,7 @@ func (r *namingPKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 				if normalizedSchema == "" {
 					normalizedSchema = "public"
 				}
-				_, index := r.catalog.Origin.FindIndex(&catalog.IndexFind{
-					SchemaName: normalizedSchema,
-					TableName:  tableName,
-					IndexName:  oldName,
-				})
+				_, index := r.catalog.Origin.GetIndex(normalizedSchema, tableName, oldName)
 				if index != nil && index.Primary() {
 					metaData := map[string]string{
 						advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
@@ -243,11 +239,8 @@ func (r *namingPKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 					normalizedSchema = "public"
 				}
 				// "ALTER INDEX name RENAME TO new_name" doesn't specify table name
-				tableName, index := r.catalog.Origin.FindIndex(&catalog.IndexFind{
-					SchemaName: normalizedSchema,
-					TableName:  "", // Empty table name for ALTER INDEX
-					IndexName:  oldIndexName,
-				})
+				// Empty table name for ALTER INDEX
+				tableName, index := r.catalog.Origin.GetIndex(normalizedSchema, "", oldIndexName)
 				if index != nil && index.Primary() {
 					metaData := map[string]string{
 						advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
@@ -318,11 +311,7 @@ func (r *namingPKConventionRule) getPKMetaDataFromTableConstraint(constraint par
 				if normalizedSchema == "" {
 					normalizedSchema = "public"
 				}
-				_, index := r.catalog.Origin.FindIndex(&catalog.IndexFind{
-					SchemaName: normalizedSchema,
-					TableName:  tableName,
-					IndexName:  indexName,
-				})
+				_, index := r.catalog.Origin.GetIndex(normalizedSchema, tableName, indexName)
 				if index != nil {
 					columnList = index.ExpressionList()
 				}

--- a/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
@@ -410,9 +410,5 @@ func (r *namingUKConventionRule) findIndex(schemaName string, tableName string, 
 	if r.catalog == nil {
 		return "", nil
 	}
-	return r.catalog.Origin.FindIndex(&catalog.IndexFind{
-		SchemaName: normalizeSchemaName(schemaName),
-		TableName:  tableName,
-		IndexName:  indexName,
-	})
+	return r.catalog.Origin.GetIndex(normalizeSchemaName(schemaName), tableName, indexName)
 }

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -179,10 +179,7 @@ func (r *tableRequirePKRule) validateFinalState() {
 		schemaName, tableName := parseTableKey(tableKey)
 
 		// Check catalog.Final for PRIMARY KEY
-		hasPK := r.catalog.Final.HasPrimaryKey(&catalog.PrimaryKeyFind{
-			SchemaName: schemaName,
-			TableName:  tableName,
-		})
+		hasPK := r.catalog.Final.HasPrimaryKey(schemaName, tableName)
 
 		if !hasPK {
 			content := fmt.Sprintf("Table %q.%q requires PRIMARY KEY", schemaName, tableName)

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
@@ -129,10 +129,7 @@ func normalizeColumnType(tp string) string {
 }
 
 func (checker *columnDisallowChangingTypeChecker) changeColumnType(tableName string, columName string, newType string) bool {
-	column := checker.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columName,
-	})
+	column := checker.catalog.Origin.GetColumn("", tableName, columName)
 
 	if column == nil {
 		return false

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
@@ -86,11 +86,7 @@ func (checker *columnDisallowDropInIndexChecker) dropColumn(in ast.Node) (ast.No
 			if spec.Tp == ast.AlterTableDropColumn {
 				table := node.Table.Name.O
 
-				index := checker.catalog.Origin.Index(&catalog.TableIndexFind{
-					// In MySQL, the SchemaName is "".
-					SchemaName: "",
-					TableName:  table,
-				})
+				index := checker.catalog.Origin.Index("", table)
 
 				if index != nil {
 					if checker.tables[table] == nil {

--- a/backend/plugin/advisor/tidb/advisor_column_no_null.go
+++ b/backend/plugin/advisor/tidb/advisor_column_no_null.go
@@ -82,10 +82,7 @@ func (checker *columnNoNullChecker) generateAdvice() []*storepb.Advice {
 	})
 
 	for _, column := range columnList {
-		col := checker.catalog.Final.FindColumn(&catalog.ColumnFind{
-			TableName:  column.tableName,
-			ColumnName: column.columnName,
-		})
+		col := checker.catalog.Final.GetColumn("", column.tableName, column.columnName)
 		if col != nil && col.Nullable() {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,

--- a/backend/plugin/advisor/tidb/advisor_index_pk_type.go
+++ b/backend/plugin/advisor/tidb/advisor_index_pk_type.go
@@ -218,10 +218,7 @@ func (v *indexPkTypeChecker) getPKColumnType(tableName string, columnName string
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return v.getIntOrBigIntStr(colDef.Tp), nil
 	}
-	column := v.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columnName,
-	})
+	column := v.catalog.Origin.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
@@ -199,10 +199,7 @@ func (v *indexPrimaryKeyTypeAllowlistChecker) getPKColumnType(tableName string, 
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return tidbparser.TypeString(colDef.Tp.GetType()), nil
 	}
-	column := v.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columnName,
-	})
+	column := v.catalog.Origin.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_total_number_limit.go
+++ b/backend/plugin/advisor/tidb/advisor_index_total_number_limit.go
@@ -96,7 +96,7 @@ func (checker *indexTotalNumberLimitChecker) generateAdvice() []*storepb.Advice 
 	})
 
 	for _, table := range tableList {
-		tableInfo := checker.catalog.Final.FindTable(&catalog.TableFind{TableName: table.name})
+		tableInfo := checker.catalog.Final.GetTable("", table.name)
 		if tableInfo != nil && tableInfo.CountIndex() > checker.max {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,

--- a/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
+++ b/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
@@ -221,10 +221,7 @@ func (v *indexTypeNoBlobChecker) getColumnType(tableName string, columnName stri
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return v.getBlobStr(colDef.Tp), nil
 	}
-	column := v.catalog.Origin.FindColumn(&catalog.ColumnFind{
-		TableName:  tableName,
-		ColumnName: columnName,
-	})
+	column := v.catalog.Origin.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
@@ -150,10 +150,7 @@ func (checker *namingIndexConventionChecker) getMetaDataList(in ast.Node) []*ind
 		for _, spec := range node.Specs {
 			switch spec.Tp {
 			case ast.AlterTableRenameIndex:
-				_, index := checker.catalog.Origin.FindIndex(&catalog.IndexFind{
-					TableName: node.Table.Name.String(),
-					IndexName: spec.FromKey.String(),
-				})
+				_, index := checker.catalog.Origin.GetIndex("", node.Table.Name.String(), spec.FromKey.String())
 				if index == nil {
 					continue
 				}

--- a/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
@@ -141,10 +141,7 @@ func (checker *namingUKConventionChecker) getMetaDataList(in ast.Node) []*indexM
 		for _, spec := range node.Specs {
 			switch spec.Tp {
 			case ast.AlterTableRenameIndex:
-				_, index := checker.catalog.Origin.FindIndex(&catalog.IndexFind{
-					TableName: node.Table.Name.String(),
-					IndexName: spec.FromKey.String(),
-				})
+				_, index := checker.catalog.Origin.GetIndex("", node.Table.Name.String(), spec.FromKey.String())
 				if index == nil {
 					continue
 				}

--- a/backend/plugin/advisor/tidb/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/tidb/advisor_table_require_pk.go
@@ -179,11 +179,9 @@ func (v *tableRequirePKChecker) createTableLike(node *ast.CreateTableStmt) {
 		}
 		v.tables[table] = newColumnSet(columns)
 	} else {
-		referTableState := v.catalog.Origin.FindTable(&catalog.TableFind{
-			TableName: referTableName,
-		})
+		referTableState := v.catalog.Origin.GetTable("", referTableName)
 		if referTableState != nil {
-			indexSet := referTableState.Index(&catalog.TableIndexFind{})
+			indexSet := referTableState.Index()
 			for _, index := range *indexSet {
 				if index.Primary() {
 					v.tables[table] = newColumnSet(index.ExpressionList())
@@ -195,10 +193,7 @@ func (v *tableRequirePKChecker) createTableLike(node *ast.CreateTableStmt) {
 
 func (v *tableRequirePKChecker) dropColumn(table string, column string) bool {
 	if _, ok := v.tables[table]; !ok {
-		_, pk := v.catalog.Origin.FindIndex(&catalog.IndexFind{
-			TableName: table,
-			IndexName: primaryKeyName,
-		})
+		_, pk := v.catalog.Origin.GetIndex("", table, primaryKeyName)
 		if pk == nil {
 			return false
 		}


### PR DESCRIPTION
## Summary

This PR simplifies the catalog state API by removing unnecessary struct wrappers and renaming methods for consistency.

### Changes

**Removed structs:**
- `TableIndexFind`
- `IndexFind` 
- `PrimaryKeyFind`
- `ColumnFind`
- `TableFind`
- `ColumnCount`

**Method changes:**
- Replaced struct parameters with simple string arguments
- Renamed `Find*` methods to `Get*` for consistency:
  - `FindTable` → `GetTable`
  - `FindColumn` → `GetColumn`
  - `FindIndex` → `GetIndex`
  - `FindPrimaryKey` → `GetPrimaryKey`

**New method signatures:**
- `Index(schemaName, tableName string)` 
- `GetIndex(schemaName, tableName, indexName string)`
- `GetPrimaryKey(schemaName, tableName string)`
- `HasPrimaryKey(schemaName, tableName string)`
- `CountColumn(schemaName, tableName, columnType string)`
- `GetColumn(schemaName, tableName, columnName string)`
- `GetTable(schemaName, tableName string)`

### Benefits

- **Simpler API**: No need to create struct instances for simple parameter passing
- **Consistent naming**: Using `Get*` prefix aligns with Go conventions
- **Less boilerplate**: Cleaner and more straightforward method calls
- **Better readability**: Intent is clearer with direct string parameters

### Files Modified

- 1 core file: `backend/plugin/advisor/catalog/state.go`
- 27 caller files across mysql/, tidb/, and pg/ advisor packages

### Test plan

- [x] All catalog package tests pass
- [x] All MySQL advisor tests pass
- [x] All PostgreSQL advisor tests pass
- [x] All TiDB advisor tests pass
- [x] Code formatted with `gofmt`
- [x] Passed `golangci-lint` with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)