### PR TITLE
refactor: remove catalog wrapper structs and use direct DatabaseState references

### DIFF
--- a/backend/plugin/advisor/advisor.go
+++ b/backend/plugin/advisor/advisor.go
@@ -45,10 +45,11 @@ type Context struct {
 	IsObjectCaseSensitive bool
 
 	// SQL review rule special fields.
-	AST     any
-	Rule    *storepb.SQLReviewRule
-	Catalog *catalog.Finder
-	Driver  *sql.DB
+	AST           any
+	Rule          *storepb.SQLReviewRule
+	OriginCatalog *catalog.DatabaseState
+	FinalCatalog  *catalog.DatabaseState
+	Driver        *sql.DB
 
 	// CurrentDatabase is the current database.
 	CurrentDatabase string

--- a/backend/plugin/advisor/catalog/finder.go
+++ b/backend/plugin/advisor/catalog/finder.go
@@ -31,33 +31,3 @@ type FinderContext struct {
 	// Database, Table
 	IgnoreCaseSensitive bool
 }
-
-// Copy returns the deep copy.
-func (ctx *FinderContext) Copy() *FinderContext {
-	return &FinderContext{
-		CheckIntegrity:      ctx.CheckIntegrity,
-		EngineType:          ctx.EngineType,
-		IgnoreCaseSensitive: ctx.IgnoreCaseSensitive,
-	}
-}
-
-// Finder is the service for finding schema information in database.
-type Finder struct {
-	Origin *DatabaseState
-	Final  *DatabaseState
-}
-
-// NewFinder creates a new finder.
-func NewFinder(database *storepb.DatabaseSchemaMetadata, ctx *FinderContext) *Finder {
-	return &Finder{Origin: newDatabaseState(database, ctx), Final: newDatabaseState(database, ctx)}
-}
-
-// NewEmptyFinder creates a finder with empty database.
-func NewEmptyFinder(ctx *FinderContext) *Finder {
-	return &Finder{Origin: newDatabaseState(&storepb.DatabaseSchemaMetadata{}, ctx), Final: newDatabaseState(&storepb.DatabaseSchemaMetadata{}, ctx)}
-}
-
-// WalkThrough does the walk through.
-func (f *Finder) WalkThrough(ast any) error {
-	return f.Final.WalkThrough(ast)
-}

--- a/backend/plugin/advisor/catalog/state.go
+++ b/backend/plugin/advisor/catalog/state.go
@@ -11,9 +11,10 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
-func newDatabaseState(d *storepb.DatabaseSchemaMetadata, context *FinderContext) *DatabaseState {
+// NewDatabaseState creates a new database state from schema metadata and context.
+func NewDatabaseState(d *storepb.DatabaseSchemaMetadata, context *FinderContext) *DatabaseState {
 	database := &DatabaseState{
-		ctx:          context.Copy(),
+		ctx:          context,
 		name:         d.Name,
 		characterSet: d.CharacterSet,
 		collation:    d.Collation,
@@ -46,7 +47,7 @@ func newDatabaseState(d *storepb.DatabaseSchemaMetadata, context *FinderContext)
 
 func newSchemaState(s *storepb.SchemaMetadata, context *FinderContext) *SchemaState {
 	schema := &SchemaState{
-		ctx:           context.Copy(),
+		ctx:           context,
 		name:          s.Name,
 		tableSet:      make(tableStateMap),
 		viewSet:       make(viewStateMap),
@@ -598,7 +599,7 @@ func newBoolPointer(v bool) *bool {
 // createSchemaState creates a new schema state with the given name.
 func (d *DatabaseState) createSchemaState(schemaName string) *SchemaState {
 	schema := &SchemaState{
-		ctx:           d.ctx.Copy(),
+		ctx:           d.ctx,
 		name:          schemaName,
 		tableSet:      make(tableStateMap),
 		viewSet:       make(viewStateMap),

--- a/backend/plugin/advisor/catalog/walk_through.go
+++ b/backend/plugin/advisor/catalog/walk_through.go
@@ -286,7 +286,7 @@ func (t *TableState) createIncompleteColumn(name string) *ColumnState {
 
 func (d *DatabaseState) createSchema() *SchemaState {
 	schema := &SchemaState{
-		ctx:      d.ctx.Copy(),
+		ctx:      d.ctx,
 		name:     "",
 		tableSet: make(tableStateMap),
 		viewSet:  make(viewStateMap),
@@ -363,7 +363,7 @@ func (d *DatabaseState) getSchema(schemaName string) (*SchemaState, *WalkThrough
 			}
 		}
 		schema = &SchemaState{
-			ctx:           d.ctx.Copy(),
+			ctx:           d.ctx,
 			name:          publicSchemaName,
 			tableSet:      make(tableStateMap),
 			viewSet:       make(viewStateMap),

--- a/backend/plugin/advisor/catalog/walk_through_test.go
+++ b/backend/plugin/advisor/catalog/walk_through_test.go
@@ -196,10 +196,9 @@ func runWalkThroughTest(t *testing.T, file string, engineType storepb.Engine, or
 	for _, test := range tests {
 		var state *DatabaseState
 		if originDatabase != nil {
-			state = newDatabaseState(originDatabase, &FinderContext{CheckIntegrity: true, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
+			state = NewDatabaseState(originDatabase, &FinderContext{CheckIntegrity: true, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		} else {
-			finder := NewEmptyFinder(&FinderContext{CheckIntegrity: false, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
-			state = finder.Origin
+			state = NewDatabaseState(&storepb.DatabaseSchemaMetadata{}, &FinderContext{CheckIntegrity: false, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		}
 
 		asts, _ := sm.GetASTsForChecks(engineType, test.Statement)
@@ -246,10 +245,9 @@ func runANTLRWalkThroughTest(t *testing.T, file string, engineType storepb.Engin
 	for _, test := range tests {
 		var state *DatabaseState
 		if originDatabase != nil {
-			state = newDatabaseState(originDatabase, &FinderContext{CheckIntegrity: true, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
+			state = NewDatabaseState(originDatabase, &FinderContext{CheckIntegrity: true, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		} else {
-			finder := NewEmptyFinder(&FinderContext{CheckIntegrity: false, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
-			state = finder.Origin
+			state = NewDatabaseState(&storepb.DatabaseSchemaMetadata{}, &FinderContext{CheckIntegrity: false, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		}
 
 		// Parse using ANTLR parser instead of legacy parser

--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
@@ -44,7 +44,7 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 	}
 
 	// Create the rule
-	rule := NewColumnDisallowChangingTypeRule(level, string(checkCtx.Rule.Type), checkCtx.Catalog)
+	rule := NewColumnDisallowChangingTypeRule(level, string(checkCtx.Rule.Type), checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -61,18 +61,18 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 // ColumnDisallowChangingTypeRule checks for disallow changing column type.
 type ColumnDisallowChangingTypeRule struct {
 	BaseRule
-	text    string
-	catalog *catalog.Finder
+	text          string
+	originCatalog *catalog.DatabaseState
 }
 
 // NewColumnDisallowChangingTypeRule creates a new ColumnDisallowChangingTypeRule.
-func NewColumnDisallowChangingTypeRule(level storepb.Advice_Status, title string, catalog *catalog.Finder) *ColumnDisallowChangingTypeRule {
+func NewColumnDisallowChangingTypeRule(level storepb.Advice_Status, title string, originCatalog *catalog.DatabaseState) *ColumnDisallowChangingTypeRule {
 	return &ColumnDisallowChangingTypeRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		catalog: catalog,
+		originCatalog: originCatalog,
 	}
 }
 
@@ -168,7 +168,7 @@ func normalizeColumnType(tp string) string {
 
 func (r *ColumnDisallowChangingTypeRule) changeColumnType(tableName, columnName string, dataType mysql.IDataTypeContext) {
 	tp := dataType.GetParser().GetTokenStream().GetTextFromRuleContext(dataType)
-	column := r.catalog.Origin.GetColumn("", tableName, columnName)
+	column := r.originCatalog.GetColumn("", tableName, columnName)
 
 	if column == nil {
 		return

--- a/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
@@ -42,7 +42,7 @@ func (*ColumnDisallowDropInIndexAdvisor) Check(_ context.Context, checkCtx advis
 	}
 
 	// Create the rule
-	rule := NewColumnDisallowDropInIndexRule(level, string(checkCtx.Rule.Type), checkCtx.Catalog)
+	rule := NewColumnDisallowDropInIndexRule(level, string(checkCtx.Rule.Type), checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -59,19 +59,19 @@ func (*ColumnDisallowDropInIndexAdvisor) Check(_ context.Context, checkCtx advis
 // ColumnDisallowDropInIndexRule checks for disallow DROP COLUMN in index.
 type ColumnDisallowDropInIndexRule struct {
 	BaseRule
-	tables  tableState
-	catalog *catalog.Finder
+	tables        tableState
+	originCatalog *catalog.DatabaseState
 }
 
 // NewColumnDisallowDropInIndexRule creates a new ColumnDisallowDropInIndexRule.
-func NewColumnDisallowDropInIndexRule(level storepb.Advice_Status, title string, catalog *catalog.Finder) *ColumnDisallowDropInIndexRule {
+func NewColumnDisallowDropInIndexRule(level storepb.Advice_Status, title string, originCatalog *catalog.DatabaseState) *ColumnDisallowDropInIndexRule {
 	return &ColumnDisallowDropInIndexRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		tables:  make(tableState),
-		catalog: catalog,
+		tables:        make(tableState),
+		originCatalog: originCatalog,
 	}
 }
 
@@ -156,7 +156,7 @@ func (r *ColumnDisallowDropInIndexRule) checkAlterTable(ctx *mysql.AlterTableCon
 			continue
 		}
 
-		index := r.catalog.Origin.Index("", tableName)
+		index := r.originCatalog.Index("", tableName)
 
 		if index != nil {
 			if r.tables[tableName] == nil {

--- a/backend/plugin/advisor/mysql/rule_index_pk_type.go
+++ b/backend/plugin/advisor/mysql/rule_index_pk_type.go
@@ -43,7 +43,7 @@ func (*IndexPkTypeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 	}
 
 	// Create the rule
-	rule := NewIndexPkTypeRule(level, string(checkCtx.Rule.Type), checkCtx.Catalog)
+	rule := NewIndexPkTypeRule(level, string(checkCtx.Rule.Type), checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -61,19 +61,19 @@ func (*IndexPkTypeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 type IndexPkTypeRule struct {
 	BaseRule
 	line             map[string]int
-	catalog          *catalog.Finder
+	originCatalog    *catalog.DatabaseState
 	tablesNewColumns tableColumnTypes
 }
 
 // NewIndexPkTypeRule creates a new IndexPkTypeRule.
-func NewIndexPkTypeRule(level storepb.Advice_Status, title string, catalog *catalog.Finder) *IndexPkTypeRule {
+func NewIndexPkTypeRule(level storepb.Advice_Status, title string, originCatalog *catalog.DatabaseState) *IndexPkTypeRule {
 	return &IndexPkTypeRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
 		line:             make(map[string]int),
-		catalog:          catalog,
+		originCatalog:    originCatalog,
 		tablesNewColumns: make(tableColumnTypes),
 	}
 }
@@ -236,7 +236,7 @@ func (r *IndexPkTypeRule) getPKColumnType(tableName string, columnName string) (
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.catalog.Origin.GetColumn("", tableName, columnName)
+	column := r.originCatalog.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
@@ -50,7 +50,7 @@ func (*IndexPrimaryKeyTypeAllowlistAdvisor) Check(_ context.Context, checkCtx ad
 	}
 
 	// Create the rule
-	rule := NewIndexPrimaryKeyTypeAllowlistRule(level, string(checkCtx.Rule.Type), allowlist, checkCtx.Catalog)
+	rule := NewIndexPrimaryKeyTypeAllowlistRule(level, string(checkCtx.Rule.Type), allowlist, checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -68,19 +68,19 @@ func (*IndexPrimaryKeyTypeAllowlistAdvisor) Check(_ context.Context, checkCtx ad
 type IndexPrimaryKeyTypeAllowlistRule struct {
 	BaseRule
 	allowlist        map[string]bool
-	catalog          *catalog.Finder
+	originCatalog    *catalog.DatabaseState
 	tablesNewColumns tableColumnTypes
 }
 
 // NewIndexPrimaryKeyTypeAllowlistRule creates a new IndexPrimaryKeyTypeAllowlistRule.
-func NewIndexPrimaryKeyTypeAllowlistRule(level storepb.Advice_Status, title string, allowlist map[string]bool, catalog *catalog.Finder) *IndexPrimaryKeyTypeAllowlistRule {
+func NewIndexPrimaryKeyTypeAllowlistRule(level storepb.Advice_Status, title string, allowlist map[string]bool, originCatalog *catalog.DatabaseState) *IndexPrimaryKeyTypeAllowlistRule {
 	return &IndexPrimaryKeyTypeAllowlistRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
 		allowlist:        allowlist,
-		catalog:          catalog,
+		originCatalog:    originCatalog,
 		tablesNewColumns: make(tableColumnTypes),
 	}
 }
@@ -250,7 +250,7 @@ func (r *IndexPrimaryKeyTypeAllowlistRule) getPKColumnType(tableName string, col
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.catalog.Origin.GetColumn("", tableName, columnName)
+	column := r.originCatalog.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
+++ b/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
@@ -47,7 +47,7 @@ func (*IndexTotalNumberLimitAdvisor) Check(_ context.Context, checkCtx advisor.C
 	}
 
 	// Create the rule
-	rule := NewIndexTotalNumberLimitRule(level, string(checkCtx.Rule.Type), payload.Number, checkCtx.Catalog)
+	rule := NewIndexTotalNumberLimitRule(level, string(checkCtx.Rule.Type), payload.Number, checkCtx.FinalCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -66,11 +66,11 @@ type IndexTotalNumberLimitRule struct {
 	BaseRule
 	max          int
 	lineForTable map[string]int
-	catalog      *catalog.Finder
+	finalCatalog *catalog.DatabaseState
 }
 
 // NewIndexTotalNumberLimitRule creates a new IndexTotalNumberLimitRule.
-func NewIndexTotalNumberLimitRule(level storepb.Advice_Status, title string, maxIndexes int, catalog *catalog.Finder) *IndexTotalNumberLimitRule {
+func NewIndexTotalNumberLimitRule(level storepb.Advice_Status, title string, maxIndexes int, finalCatalog *catalog.DatabaseState) *IndexTotalNumberLimitRule {
 	return &IndexTotalNumberLimitRule{
 		BaseRule: BaseRule{
 			level: level,
@@ -78,7 +78,7 @@ func NewIndexTotalNumberLimitRule(level storepb.Advice_Status, title string, max
 		},
 		max:          maxIndexes,
 		lineForTable: make(map[string]int),
-		catalog:      catalog,
+		finalCatalog: finalCatalog,
 	}
 }
 
@@ -130,7 +130,7 @@ func (r *IndexTotalNumberLimitRule) generateAdvice() []*storepb.Advice {
 	})
 
 	for _, table := range tableList {
-		tableInfo := r.catalog.Final.GetTable("", table.name)
+		tableInfo := r.finalCatalog.GetTable("", table.name)
 		if tableInfo != nil && tableInfo.CountIndex() > r.max {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,

--- a/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
+++ b/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
@@ -43,7 +43,7 @@ func (*IndexTypeNoBlobAdvisor) Check(_ context.Context, checkCtx advisor.Context
 	}
 
 	// Create the rule
-	rule := NewIndexTypeNoBlobRule(level, string(checkCtx.Rule.Type), checkCtx.Catalog)
+	rule := NewIndexTypeNoBlobRule(level, string(checkCtx.Rule.Type), checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -60,18 +60,18 @@ func (*IndexTypeNoBlobAdvisor) Check(_ context.Context, checkCtx advisor.Context
 // IndexTypeNoBlobRule checks for index type no blob.
 type IndexTypeNoBlobRule struct {
 	BaseRule
-	catalog          *catalog.Finder
+	originCatalog    *catalog.DatabaseState
 	tablesNewColumns tableColumnTypes
 }
 
 // NewIndexTypeNoBlobRule creates a new IndexTypeNoBlobRule.
-func NewIndexTypeNoBlobRule(level storepb.Advice_Status, title string, catalog *catalog.Finder) *IndexTypeNoBlobRule {
+func NewIndexTypeNoBlobRule(level storepb.Advice_Status, title string, originCatalog *catalog.DatabaseState) *IndexTypeNoBlobRule {
 	return &IndexTypeNoBlobRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		catalog:          catalog,
+		originCatalog:    originCatalog,
 		tablesNewColumns: make(tableColumnTypes),
 	}
 }
@@ -293,7 +293,7 @@ func (r *IndexTypeNoBlobRule) getColumnType(tableName string, columnName string)
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.catalog.Origin.GetColumn("", tableName, columnName)
+	column := r.originCatalog.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/mysql/rule_naming_index_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_index_convention.go
@@ -56,7 +56,7 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 	}
 
 	// Create the rule
-	rule := NewNamingIndexConventionRule(level, string(checkCtx.Rule.Type), format, maxLength, templateList, checkCtx.Catalog)
+	rule := NewNamingIndexConventionRule(level, string(checkCtx.Rule.Type), format, maxLength, templateList, checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -73,24 +73,24 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 // NamingIndexConventionRule checks for index naming convention.
 type NamingIndexConventionRule struct {
 	BaseRule
-	text         string
-	format       string
-	maxLength    int
-	templateList []string
-	catalog      *catalog.Finder
+	text          string
+	format        string
+	maxLength     int
+	templateList  []string
+	originCatalog *catalog.DatabaseState
 }
 
 // NewNamingIndexConventionRule creates a new NamingIndexConventionRule.
-func NewNamingIndexConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, catalog *catalog.Finder) *NamingIndexConventionRule {
+func NewNamingIndexConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, originCatalog *catalog.DatabaseState) *NamingIndexConventionRule {
 	return &NamingIndexConventionRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		format:       format,
-		maxLength:    maxLength,
-		templateList: templateList,
-		catalog:      catalog,
+		format:        format,
+		maxLength:     maxLength,
+		templateList:  templateList,
+		originCatalog: originCatalog,
 	}
 }
 
@@ -186,7 +186,7 @@ func (r *NamingIndexConventionRule) checkAlterTable(ctx *mysql.AlterTableContext
 		case alterListItem.RENAME_SYMBOL() != nil && alterListItem.KeyOrIndex() != nil && alterListItem.IndexRef() != nil && alterListItem.IndexName() != nil:
 			_, _, oldIndexName := mysqlparser.NormalizeIndexRef(alterListItem.IndexRef())
 			newIndexName := mysqlparser.NormalizeIndexName(alterListItem.IndexName())
-			_, indexState := r.catalog.Origin.GetIndex("", tableName, oldIndexName)
+			_, indexState := r.originCatalog.GetIndex("", tableName, oldIndexName)
 			if indexState == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
@@ -48,7 +48,7 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 	}
 
 	// Create the rule
-	rule := NewNamingUKConventionRule(level, string(checkCtx.Rule.Type), format, maxLength, templateList, checkCtx.Catalog)
+	rule := NewNamingUKConventionRule(level, string(checkCtx.Rule.Type), format, maxLength, templateList, checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -73,24 +73,24 @@ type ukIndexMetaData struct {
 // NamingUKConventionRule checks for unique key naming convention.
 type NamingUKConventionRule struct {
 	BaseRule
-	text         string
-	format       string
-	maxLength    int
-	templateList []string
-	catalog      *catalog.Finder
+	text          string
+	format        string
+	maxLength     int
+	templateList  []string
+	originCatalog *catalog.DatabaseState
 }
 
 // NewNamingUKConventionRule creates a new NamingUKConventionRule.
-func NewNamingUKConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, catalog *catalog.Finder) *NamingUKConventionRule {
+func NewNamingUKConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, originCatalog *catalog.DatabaseState) *NamingUKConventionRule {
 	return &NamingUKConventionRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		format:       format,
-		maxLength:    maxLength,
-		templateList: templateList,
-		catalog:      catalog,
+		format:        format,
+		maxLength:     maxLength,
+		templateList:  templateList,
+		originCatalog: originCatalog,
 	}
 }
 
@@ -187,7 +187,7 @@ func (r *NamingUKConventionRule) checkAlterTable(ctx *mysql.AlterTableContext) {
 		case alterListItem.RENAME_SYMBOL() != nil && alterListItem.KeyOrIndex() != nil && alterListItem.IndexRef() != nil && alterListItem.IndexName() != nil:
 			_, _, oldIndexName := mysqlparser.NormalizeIndexRef(alterListItem.IndexRef())
 			newIndexName := mysqlparser.NormalizeIndexName(alterListItem.IndexName())
-			indexStateMap := r.catalog.Origin.Index("", tableName)
+			indexStateMap := r.originCatalog.Index("", tableName)
 			if indexStateMap == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_pk.go
@@ -48,7 +48,7 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 	}
 
 	// Create the rule
-	rule := NewTableRequirePKRule(level, string(checkCtx.Rule.Type), checkCtx.Catalog)
+	rule := NewTableRequirePKRule(level, string(checkCtx.Rule.Type), checkCtx.OriginCatalog)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -68,21 +68,21 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 // TableRequirePKRule checks table requires PK.
 type TableRequirePKRule struct {
 	BaseRule
-	tables  map[string]columnSet
-	line    map[string]int
-	catalog *catalog.Finder
+	tables        map[string]columnSet
+	line          map[string]int
+	originCatalog *catalog.DatabaseState
 }
 
 // NewTableRequirePKRule creates a new TableRequirePKRule.
-func NewTableRequirePKRule(level storepb.Advice_Status, title string, catalog *catalog.Finder) *TableRequirePKRule {
+func NewTableRequirePKRule(level storepb.Advice_Status, title string, originCatalog *catalog.DatabaseState) *TableRequirePKRule {
 	return &TableRequirePKRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		tables:  make(map[string]columnSet),
-		line:    make(map[string]int),
-		catalog: catalog,
+		tables:        make(map[string]columnSet),
+		line:          make(map[string]int),
+		originCatalog: originCatalog,
 	}
 }
 
@@ -250,7 +250,7 @@ func (r *TableRequirePKRule) changeColumn(tableName string, oldColumn string, ne
 
 func (r *TableRequirePKRule) dropColumn(tableName string, columnName string) bool {
 	if _, ok := r.tables[tableName]; !ok {
-		_, pk := r.catalog.Origin.GetIndex("", tableName, primaryKeyName)
+		_, pk := r.originCatalog.GetIndex("", tableName, primaryKeyName)
 		if pk == nil {
 			return false
 		}

--- a/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
+++ b/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
@@ -46,7 +46,7 @@ func (*TableMaximumVarcharLengthAdvisor) Check(_ context.Context, checkCtx advis
 	}
 
 	// Create the rule
-	rule := NewTableTextFieldsTotalLengthRule(level, string(checkCtx.Rule.Type), checkCtx.Catalog, payload.Number)
+	rule := NewTableTextFieldsTotalLengthRule(level, string(checkCtx.Rule.Type), checkCtx.FinalCatalog, payload.Number)
 
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
@@ -63,19 +63,19 @@ func (*TableMaximumVarcharLengthAdvisor) Check(_ context.Context, checkCtx advis
 // TableTextFieldsTotalLengthRule checks for table text fields total length.
 type TableTextFieldsTotalLengthRule struct {
 	BaseRule
-	catalog *catalog.Finder
-	maximum int
+	finalCatalog *catalog.DatabaseState
+	maximum      int
 }
 
 // NewTableTextFieldsTotalLengthRule creates a new TableTextFieldsTotalLengthRule.
-func NewTableTextFieldsTotalLengthRule(level storepb.Advice_Status, title string, catalog *catalog.Finder, maximum int) *TableTextFieldsTotalLengthRule {
+func NewTableTextFieldsTotalLengthRule(level storepb.Advice_Status, title string, finalCatalog *catalog.DatabaseState, maximum int) *TableTextFieldsTotalLengthRule {
 	return &TableTextFieldsTotalLengthRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		catalog: catalog,
-		maximum: maximum,
+		finalCatalog: finalCatalog,
+		maximum:      maximum,
 	}
 }
 
@@ -114,7 +114,7 @@ func (r *TableTextFieldsTotalLengthRule) checkCreateTable(ctx *mysql.CreateTable
 	if tableName == "" {
 		return
 	}
-	tableInfo := r.catalog.Final.GetTable("", tableName)
+	tableInfo := r.finalCatalog.GetTable("", tableName)
 	if tableInfo == nil {
 		return
 	}
@@ -148,7 +148,7 @@ func (r *TableTextFieldsTotalLengthRule) checkAlterTable(ctx *mysql.AlterTableCo
 	if tableName == "" {
 		return
 	}
-	tableInfo := r.catalog.Final.GetTable("", tableName)
+	tableInfo := r.finalCatalog.GetTable("", tableName)
 	if tableInfo == nil {
 		return
 	}

--- a/backend/plugin/advisor/pg/advisor_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/pg/advisor_builtin_prior_backup_check.go
@@ -66,7 +66,7 @@ func (*BuiltinPriorBackupCheckAdvisor) Check(_ context.Context, checkCtx advisor
 
 	// Check if backup schema exists
 	schemaName := common.BackupDatabaseNameOfEngine(storepb.Engine_POSTGRES)
-	if !checkCtx.Catalog.Origin.HasSchema(schemaName) {
+	if !checkCtx.OriginCatalog.HasSchema(schemaName) {
 		adviceList = append(adviceList, &storepb.Advice{
 			Status:        level,
 			Title:         title,

--- a/backend/plugin/advisor/pg/advisor_column_no_null.go
+++ b/backend/plugin/advisor/pg/advisor_column_no_null.go
@@ -44,7 +44,7 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 			level: level,
 			title: string(checkCtx.Rule.Type),
 		},
-		catalog:         checkCtx.Catalog,
+		originCatalog:   checkCtx.OriginCatalog,
 		nullableColumns: make(columnMap),
 	}
 
@@ -73,7 +73,7 @@ type columnMap map[columnName]int
 type columnNoNullRule struct {
 	BaseRule
 
-	catalog         *catalog.Finder
+	originCatalog   *catalog.DatabaseState
 	nullableColumns columnMap
 }
 
@@ -306,8 +306,8 @@ func (r *columnNoNullRule) removeColumnByTableConstraint(schema, table string, c
 		if existingIndex.Name() != nil {
 			indexName := pg.NormalizePostgreSQLName(existingIndex.Name())
 			// Try to find index in catalog
-			if r.catalog != nil {
-				_, index := r.catalog.Origin.GetIndex(schema, table, indexName)
+			if r.originCatalog != nil {
+				_, index := r.originCatalog.GetIndex(schema, table, indexName)
 				if index != nil {
 					for _, expression := range index.ExpressionList() {
 						r.removeColumn(schema, table, expression)

--- a/backend/plugin/advisor/pg/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_index_convention.go
@@ -49,10 +49,10 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 			level: level,
 			title: string(checkCtx.Rule.Type),
 		},
-		format:       format,
-		maxLength:    maxLength,
-		templateList: templateList,
-		catalog:      checkCtx.Catalog,
+		format:        format,
+		maxLength:     maxLength,
+		templateList:  templateList,
+		originCatalog: checkCtx.OriginCatalog,
 	}
 
 	checker := NewGenericChecker([]Rule{rule})
@@ -64,10 +64,10 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 type namingIndexConventionRule struct {
 	BaseRule
 
-	format       string
-	maxLength    int
-	templateList []string
-	catalog      *catalog.Finder
+	format        string
+	maxLength     int
+	templateList  []string
+	originCatalog *catalog.DatabaseState
 }
 
 // Name returns the rule name.
@@ -171,7 +171,7 @@ func (r *namingIndexConventionRule) handleRenamestmt(ctx antlr.ParserRuleContext
 		newIndexName := pgparser.NormalizePostgreSQLName(allNames[0])
 
 		// Look up the index in catalog to determine if it's a regular index (not unique, not PK)
-		if r.catalog != nil && oldIndexName != "" {
+		if r.originCatalog != nil && oldIndexName != "" {
 			tableName, index := r.findIndex("", "", oldIndexName)
 			if index != nil {
 				// Only check if it's a regular index (not unique, not primary)
@@ -233,8 +233,8 @@ func (r *namingIndexConventionRule) checkIndexName(indexName, tableName string, 
 
 // findIndex returns index found in catalogs, nil if not found.
 func (r *namingIndexConventionRule) findIndex(schemaName string, tableName string, indexName string) (string, *catalog.IndexState) {
-	if r.catalog == nil {
+	if r.originCatalog == nil {
 		return "", nil
 	}
-	return r.catalog.Origin.GetIndex(normalizeSchemaName(schemaName), tableName, indexName)
+	return r.originCatalog.GetIndex(normalizeSchemaName(schemaName), tableName, indexName)
 }

--- a/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
@@ -52,7 +52,7 @@ func (*NamingPKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		format:         format,
 		maxLength:      maxLength,
 		templateList:   templateList,
-		catalog:        checkCtx.Catalog,
+		originCatalog:  checkCtx.OriginCatalog,
 		statementsText: checkCtx.Statements,
 	}
 
@@ -69,7 +69,7 @@ type namingPKConventionRule struct {
 	format         string
 	maxLength      int
 	templateList   []string
-	catalog        *catalog.Finder
+	originCatalog  *catalog.DatabaseState
 	statementsText string
 }
 
@@ -190,12 +190,12 @@ func (r *namingPKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 			newName := pgparser.NormalizePostgreSQLName(allNames[len(allNames)-1])
 
 			// Check if old constraint is a primary key using catalog
-			if r.catalog != nil {
+			if r.originCatalog != nil {
 				normalizedSchema := schemaName
 				if normalizedSchema == "" {
 					normalizedSchema = "public"
 				}
-				_, index := r.catalog.Origin.GetIndex(normalizedSchema, tableName, oldName)
+				_, index := r.originCatalog.GetIndex(normalizedSchema, tableName, oldName)
 				if index != nil && index.Primary() {
 					metaData := map[string]string{
 						advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
@@ -233,14 +233,14 @@ func (r *namingPKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 			newIndexName := pgparser.NormalizePostgreSQLName(allNames[len(allNames)-1])
 
 			// Check if this index is a primary key using catalog
-			if r.catalog != nil {
+			if r.originCatalog != nil {
 				normalizedSchema := schemaName
 				if normalizedSchema == "" {
 					normalizedSchema = "public"
 				}
 				// "ALTER INDEX name RENAME TO new_name" doesn't specify table name
 				// Empty table name for ALTER INDEX
-				tableName, index := r.catalog.Origin.GetIndex(normalizedSchema, "", oldIndexName)
+				tableName, index := r.originCatalog.GetIndex(normalizedSchema, "", oldIndexName)
 				if index != nil && index.Primary() {
 					metaData := map[string]string{
 						advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
@@ -306,12 +306,12 @@ func (r *namingPKConventionRule) getPKMetaDataFromTableConstraint(constraint par
 			// Extract index name properly
 			indexName := pgparser.NormalizePostgreSQLName(elem.Existingindex().Name())
 			// Find the index in catalog to get column list
-			if r.catalog != nil && indexName != "" {
+			if r.originCatalog != nil && indexName != "" {
 				normalizedSchema := schemaName
 				if normalizedSchema == "" {
 					normalizedSchema = "public"
 				}
-				_, index := r.catalog.Origin.GetIndex(normalizedSchema, tableName, indexName)
+				_, index := r.originCatalog.GetIndex(normalizedSchema, tableName, indexName)
 				if index != nil {
 					columnList = index.ExpressionList()
 				}

--- a/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
@@ -49,10 +49,10 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 			level: level,
 			title: string(checkCtx.Rule.Type),
 		},
-		format:       format,
-		maxLength:    maxLength,
-		templateList: templateList,
-		catalog:      checkCtx.Catalog,
+		format:        format,
+		maxLength:     maxLength,
+		templateList:  templateList,
+		originCatalog: checkCtx.OriginCatalog,
 	}
 
 	checker := NewGenericChecker([]Rule{rule})
@@ -64,10 +64,10 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 type namingUKConventionRule struct {
 	BaseRule
 
-	format       string
-	maxLength    int
-	templateList []string
-	catalog      *catalog.Finder
+	format        string
+	maxLength     int
+	templateList  []string
+	originCatalog *catalog.DatabaseState
 }
 
 //nolint:unused
@@ -234,7 +234,7 @@ func (r *namingUKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 		newIndexName := pgparser.NormalizePostgreSQLName(allNames[0])
 
 		// Look up the index in catalog to determine if it's a unique key
-		if r.catalog != nil && oldIndexName != "" {
+		if r.originCatalog != nil && oldIndexName != "" {
 			tableName, index := r.findIndex("", "", oldIndexName)
 			if index != nil && index.Unique() && !index.Primary() {
 				r.checkUniqueKeyName(newIndexName, tableName, map[string]string{
@@ -246,7 +246,7 @@ func (r *namingUKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 	}
 
 	// Check for ALTER TABLE ... RENAME CONSTRAINT
-	if ctx.CONSTRAINT() != nil && ctx.TO() != nil && r.catalog != nil {
+	if ctx.CONSTRAINT() != nil && ctx.TO() != nil && r.originCatalog != nil {
 		allNames := ctx.AllName()
 		if len(allNames) >= 2 {
 			oldConstraintName := pgparser.NormalizePostgreSQLName(allNames[0])
@@ -407,8 +407,8 @@ func (r *namingUKConventionRule) getTemplateRegexp(tokens map[string]string) (*r
 
 // findIndex returns index found in catalogs, nil if not found.
 func (r *namingUKConventionRule) findIndex(schemaName string, tableName string, indexName string) (string, *catalog.IndexState) {
-	if r.catalog == nil {
+	if r.originCatalog == nil {
 		return "", nil
 	}
-	return r.catalog.Origin.GetIndex(normalizeSchemaName(schemaName), tableName, indexName)
+	return r.originCatalog.GetIndex(normalizeSchemaName(schemaName), tableName, indexName)
 }

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -44,7 +44,7 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 			title: string(checkCtx.Rule.Type),
 		},
 		statementsText: checkCtx.Statements,
-		catalog:        checkCtx.Catalog,
+		finalCatalog:   checkCtx.FinalCatalog,
 		tableMentions:  make(map[string]*tableMention),
 	}
 
@@ -65,7 +65,7 @@ type tableMention struct {
 type tableRequirePKRule struct {
 	BaseRule
 	statementsText string
-	catalog        *catalog.Finder
+	finalCatalog   *catalog.DatabaseState
 
 	// Simple Solution: Track last mention of each table
 	tableMentions map[string]*tableMention // key: "schema.table", value: last mention info
@@ -179,7 +179,7 @@ func (r *tableRequirePKRule) validateFinalState() {
 		schemaName, tableName := parseTableKey(tableKey)
 
 		// Check catalog.Final for PRIMARY KEY
-		hasPK := r.catalog.Final.HasPrimaryKey(schemaName, tableName)
+		hasPK := r.finalCatalog.HasPrimaryKey(schemaName, tableName)
 
 		if !hasPK {
 			content := fmt.Sprintf("Table %q.%q requires PRIMARY KEY", schemaName, tableName)

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
@@ -41,9 +41,9 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 		return nil, err
 	}
 	checker := &columnDisallowChangingTypeChecker{
-		level:   level,
-		title:   string(checkCtx.Rule.Type),
-		catalog: checkCtx.Catalog,
+		level:         level,
+		title:         string(checkCtx.Rule.Type),
+		originCatalog: checkCtx.OriginCatalog,
 	}
 
 	for _, stmt := range stmtList {
@@ -56,12 +56,12 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 }
 
 type columnDisallowChangingTypeChecker struct {
-	adviceList []*storepb.Advice
-	level      storepb.Advice_Status
-	title      string
-	text       string
-	line       int
-	catalog    *catalog.Finder
+	adviceList    []*storepb.Advice
+	level         storepb.Advice_Status
+	title         string
+	text          string
+	line          int
+	originCatalog *catalog.DatabaseState
 }
 
 // Enter implements the ast.Visitor interface.
@@ -129,7 +129,7 @@ func normalizeColumnType(tp string) string {
 }
 
 func (checker *columnDisallowChangingTypeChecker) changeColumnType(tableName string, columName string, newType string) bool {
-	column := checker.catalog.Origin.GetColumn("", tableName, columName)
+	column := checker.originCatalog.GetColumn("", tableName, columName)
 
 	if column == nil {
 		return false

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
@@ -41,10 +41,10 @@ func (*ColumnDisallowDropInIndexAdvisor) Check(_ context.Context, checkCtx advis
 	}
 
 	checker := &columnDisallowDropInIndexChecker{
-		level:   level,
-		title:   string(checkCtx.Rule.Type),
-		tables:  make(tableState),
-		catalog: checkCtx.Catalog,
+		level:         level,
+		title:         string(checkCtx.Rule.Type),
+		tables:        make(tableState),
+		originCatalog: checkCtx.OriginCatalog,
 	}
 
 	for _, stmt := range stmtList {
@@ -57,13 +57,13 @@ func (*ColumnDisallowDropInIndexAdvisor) Check(_ context.Context, checkCtx advis
 }
 
 type columnDisallowDropInIndexChecker struct {
-	adviceList []*storepb.Advice
-	level      storepb.Advice_Status
-	title      string
-	text       string
-	tables     tableState // the variable mean whether the column in index.
-	catalog    *catalog.Finder
-	line       int
+	adviceList    []*storepb.Advice
+	level         storepb.Advice_Status
+	title         string
+	text          string
+	tables        tableState // the variable mean whether the column in index.
+	originCatalog *catalog.DatabaseState
+	line          int
 }
 
 func (checker *columnDisallowDropInIndexChecker) Enter(in ast.Node) (ast.Node, bool) {
@@ -86,7 +86,7 @@ func (checker *columnDisallowDropInIndexChecker) dropColumn(in ast.Node) (ast.No
 			if spec.Tp == ast.AlterTableDropColumn {
 				table := node.Table.Name.O
 
-				index := checker.catalog.Origin.Index("", table)
+				index := checker.originCatalog.Index("", table)
 
 				if index != nil {
 					if checker.tables[table] == nil {

--- a/backend/plugin/advisor/tidb/advisor_column_no_null.go
+++ b/backend/plugin/advisor/tidb/advisor_column_no_null.go
@@ -39,10 +39,10 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 		return nil, err
 	}
 	checker := &columnNoNullChecker{
-		level:     level,
-		title:     string(checkCtx.Rule.Type),
-		columnSet: make(map[string]columnName),
-		catalog:   checkCtx.Catalog,
+		level:        level,
+		title:        string(checkCtx.Rule.Type),
+		columnSet:    make(map[string]columnName),
+		finalCatalog: checkCtx.FinalCatalog,
 	}
 
 	for _, stmtNode := range root {
@@ -53,11 +53,11 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 }
 
 type columnNoNullChecker struct {
-	adviceList []*storepb.Advice
-	level      storepb.Advice_Status
-	title      string
-	columnSet  map[string]columnName
-	catalog    *catalog.Finder
+	adviceList   []*storepb.Advice
+	level        storepb.Advice_Status
+	title        string
+	columnSet    map[string]columnName
+	finalCatalog *catalog.DatabaseState
 }
 
 func (checker *columnNoNullChecker) generateAdvice() []*storepb.Advice {
@@ -82,7 +82,7 @@ func (checker *columnNoNullChecker) generateAdvice() []*storepb.Advice {
 	})
 
 	for _, column := range columnList {
-		col := checker.catalog.Final.GetColumn("", column.tableName, column.columnName)
+		col := checker.finalCatalog.GetColumn("", column.tableName, column.columnName)
 		if col != nil && col.Nullable() {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,

--- a/backend/plugin/advisor/tidb/advisor_index_pk_type.go
+++ b/backend/plugin/advisor/tidb/advisor_index_pk_type.go
@@ -45,7 +45,7 @@ func (*IndexPkTypeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 		level:            level,
 		title:            string(checkCtx.Rule.Type),
 		line:             make(map[string]int),
-		catalog:          checkCtx.Catalog,
+		originCatalog:    checkCtx.OriginCatalog,
 		tablesNewColumns: make(map[string]columnNameToColumnDef),
 	}
 
@@ -86,7 +86,7 @@ type indexPkTypeChecker struct {
 	level            storepb.Advice_Status
 	title            string
 	line             map[string]int
-	catalog          *catalog.Finder
+	originCatalog    *catalog.DatabaseState
 	tablesNewColumns tableNewColumn
 }
 
@@ -218,7 +218,7 @@ func (v *indexPkTypeChecker) getPKColumnType(tableName string, columnName string
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return v.getIntOrBigIntStr(colDef.Tp), nil
 	}
-	column := v.catalog.Origin.GetColumn("", tableName, columnName)
+	column := v.originCatalog.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
@@ -53,7 +53,7 @@ func (*IndexPrimaryKeyTypeAllowlistAdvisor) Check(_ context.Context, checkCtx ad
 		level:            level,
 		title:            string(checkCtx.Rule.Type),
 		allowlist:        allowlist,
-		catalog:          checkCtx.Catalog,
+		originCatalog:    checkCtx.OriginCatalog,
 		tablesNewColumns: make(map[string]columnNameToColumnDef),
 	}
 
@@ -73,7 +73,7 @@ type indexPrimaryKeyTypeAllowlistChecker struct {
 	text             string
 	line             int
 	allowlist        map[string]bool
-	catalog          *catalog.Finder
+	originCatalog    *catalog.DatabaseState
 	tablesNewColumns tableNewColumn
 }
 
@@ -199,7 +199,7 @@ func (v *indexPrimaryKeyTypeAllowlistChecker) getPKColumnType(tableName string, 
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return tidbparser.TypeString(colDef.Tp.GetType()), nil
 	}
-	column := v.catalog.Origin.GetColumn("", tableName, columnName)
+	column := v.originCatalog.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_total_number_limit.go
+++ b/backend/plugin/advisor/tidb/advisor_index_total_number_limit.go
@@ -49,7 +49,7 @@ func (*IndexTotalNumberLimitAdvisor) Check(_ context.Context, checkCtx advisor.C
 		title:        string(checkCtx.Rule.Type),
 		max:          payload.Number,
 		lineForTable: make(map[string]int),
-		catalog:      checkCtx.Catalog,
+		finalCatalog: checkCtx.FinalCatalog,
 	}
 
 	for _, stmt := range stmtList {
@@ -69,7 +69,7 @@ type indexTotalNumberLimitChecker struct {
 	line         int
 	max          int
 	lineForTable map[string]int
-	catalog      *catalog.Finder
+	finalCatalog *catalog.DatabaseState
 }
 
 func (checker *indexTotalNumberLimitChecker) generateAdvice() []*storepb.Advice {
@@ -96,7 +96,7 @@ func (checker *indexTotalNumberLimitChecker) generateAdvice() []*storepb.Advice 
 	})
 
 	for _, table := range tableList {
-		tableInfo := checker.catalog.Final.GetTable("", table.name)
+		tableInfo := checker.finalCatalog.GetTable("", table.name)
 		if tableInfo != nil && tableInfo.CountIndex() > checker.max {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,

--- a/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
+++ b/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
@@ -45,7 +45,7 @@ func (*IndexTypeNoBlobAdvisor) Check(_ context.Context, checkCtx advisor.Context
 	checker := &indexTypeNoBlobChecker{
 		level:            level,
 		title:            string(checkCtx.Rule.Type),
-		catalog:          checkCtx.Catalog,
+		originCatalog:    checkCtx.OriginCatalog,
 		tablesNewColumns: make(map[string]columnNameToColumnDef),
 	}
 
@@ -64,7 +64,7 @@ type indexTypeNoBlobChecker struct {
 	title            string
 	text             string
 	line             int
-	catalog          *catalog.Finder
+	originCatalog    *catalog.DatabaseState
 	tablesNewColumns tableNewColumn
 }
 
@@ -221,7 +221,7 @@ func (v *indexTypeNoBlobChecker) getColumnType(tableName string, columnName stri
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return v.getBlobStr(colDef.Tp), nil
 	}
-	column := v.catalog.Origin.GetColumn("", tableName, columnName)
+	column := v.originCatalog.GetColumn("", tableName, columnName)
 	if column != nil {
 		return column.Type(), nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
@@ -45,12 +45,12 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 		return nil, err
 	}
 	checker := &namingIndexConventionChecker{
-		level:        level,
-		title:        string(checkCtx.Rule.Type),
-		format:       format,
-		maxLength:    maxLength,
-		templateList: templateList,
-		catalog:      checkCtx.Catalog,
+		level:         level,
+		title:         string(checkCtx.Rule.Type),
+		format:        format,
+		maxLength:     maxLength,
+		templateList:  templateList,
+		originCatalog: checkCtx.OriginCatalog,
 	}
 	for _, stmtNode := range root {
 		(stmtNode).Accept(checker)
@@ -60,13 +60,13 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 }
 
 type namingIndexConventionChecker struct {
-	adviceList   []*storepb.Advice
-	level        storepb.Advice_Status
-	title        string
-	format       string
-	maxLength    int
-	templateList []string
-	catalog      *catalog.Finder
+	adviceList    []*storepb.Advice
+	level         storepb.Advice_Status
+	title         string
+	format        string
+	maxLength     int
+	templateList  []string
+	originCatalog *catalog.DatabaseState
 }
 
 // Enter implements the ast.Visitor interface.
@@ -150,7 +150,7 @@ func (checker *namingIndexConventionChecker) getMetaDataList(in ast.Node) []*ind
 		for _, spec := range node.Specs {
 			switch spec.Tp {
 			case ast.AlterTableRenameIndex:
-				_, index := checker.catalog.Origin.GetIndex("", node.Table.Name.String(), spec.FromKey.String())
+				_, index := checker.originCatalog.GetIndex("", node.Table.Name.String(), spec.FromKey.String())
 				if index == nil {
 					continue
 				}

--- a/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
@@ -44,12 +44,12 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		return nil, err
 	}
 	checker := &namingUKConventionChecker{
-		level:        level,
-		title:        string(checkCtx.Rule.Type),
-		format:       format,
-		maxLength:    maxLength,
-		templateList: templateList,
-		catalog:      checkCtx.Catalog,
+		level:         level,
+		title:         string(checkCtx.Rule.Type),
+		format:        format,
+		maxLength:     maxLength,
+		templateList:  templateList,
+		originCatalog: checkCtx.OriginCatalog,
 	}
 	for _, stmtNode := range root {
 		(stmtNode).Accept(checker)
@@ -59,13 +59,13 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 }
 
 type namingUKConventionChecker struct {
-	adviceList   []*storepb.Advice
-	level        storepb.Advice_Status
-	title        string
-	format       string
-	maxLength    int
-	templateList []string
-	catalog      *catalog.Finder
+	adviceList    []*storepb.Advice
+	level         storepb.Advice_Status
+	title         string
+	format        string
+	maxLength     int
+	templateList  []string
+	originCatalog *catalog.DatabaseState
 }
 
 // Enter implements the ast.Visitor interface.
@@ -141,7 +141,7 @@ func (checker *namingUKConventionChecker) getMetaDataList(in ast.Node) []*indexM
 		for _, spec := range node.Specs {
 			switch spec.Tp {
 			case ast.AlterTableRenameIndex:
-				_, index := checker.catalog.Origin.GetIndex("", node.Table.Name.String(), spec.FromKey.String())
+				_, index := checker.originCatalog.GetIndex("", node.Table.Name.String(), spec.FromKey.String())
 				if index == nil {
 					continue
 				}

--- a/backend/plugin/advisor/tidb/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/tidb/advisor_table_require_pk.go
@@ -43,11 +43,12 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 		return nil, err
 	}
 	checker := &tableRequirePKChecker{
-		level:   level,
-		title:   string(checkCtx.Rule.Type),
-		tables:  make(tablePK),
-		line:    make(map[string]int),
-		catalog: checkCtx.Catalog,
+		level:         level,
+		title:         string(checkCtx.Rule.Type),
+		tables:        make(tablePK),
+		line:          make(map[string]int),
+		originCatalog: checkCtx.OriginCatalog,
+		finalCatalog:  checkCtx.FinalCatalog,
 	}
 
 	for _, stmtNode := range root {
@@ -58,12 +59,13 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 }
 
 type tableRequirePKChecker struct {
-	adviceList []*storepb.Advice
-	level      storepb.Advice_Status
-	title      string
-	tables     tablePK
-	line       map[string]int
-	catalog    *catalog.Finder
+	adviceList    []*storepb.Advice
+	level         storepb.Advice_Status
+	title         string
+	tables        tablePK
+	line          map[string]int
+	originCatalog *catalog.DatabaseState
+	finalCatalog  *catalog.DatabaseState
 }
 
 // Enter implements the ast.Visitor interface.
@@ -179,7 +181,7 @@ func (v *tableRequirePKChecker) createTableLike(node *ast.CreateTableStmt) {
 		}
 		v.tables[table] = newColumnSet(columns)
 	} else {
-		referTableState := v.catalog.Origin.GetTable("", referTableName)
+		referTableState := v.originCatalog.GetTable("", referTableName)
 		if referTableState != nil {
 			indexSet := referTableState.Index()
 			for _, index := range *indexSet {
@@ -193,7 +195,7 @@ func (v *tableRequirePKChecker) createTableLike(node *ast.CreateTableStmt) {
 
 func (v *tableRequirePKChecker) dropColumn(table string, column string) bool {
 	if _, ok := v.tables[table]; !ok {
-		_, pk := v.catalog.Origin.GetIndex("", table, primaryKeyName)
+		_, pk := v.originCatalog.GetIndex("", table, primaryKeyName)
 		if pk == nil {
 			return false
 		}

--- a/backend/runner/plancheck/statement_advise_executor.go
+++ b/backend/runner/plancheck/statement_advise_executor.go
@@ -149,7 +149,7 @@ func (e *StatementAdviseExecutor) runReview(
 		}
 	}
 
-	catalog, err := catalog.NewCatalog(ctx, e.store, database.InstanceID, database.DatabaseName, instance.Metadata.GetEngine(), store.IsObjectCaseSensitive(instance), nil /* Override Metadata */)
+	originCatalog, finalCatalog, err := catalog.NewCatalog(ctx, e.store, database.InstanceID, database.DatabaseName, instance.Metadata.GetEngine(), store.IsObjectCaseSensitive(instance), nil /* Override Metadata */)
 	if err != nil {
 		return nil, common.Wrapf(err, common.Internal, "failed to create a catalog")
 	}
@@ -176,7 +176,8 @@ func (e *StatementAdviseExecutor) runReview(
 		DBSchema:                 dbSchema.GetMetadata(),
 		ChangeType:               changeType,
 		DBType:                   instance.Metadata.GetEngine(),
-		Catalog:                  catalog,
+		OriginCatalog:            originCatalog,
+		FinalCatalog:             finalCatalog,
 		Driver:                   connection,
 		EnablePriorBackup:        enablePriorBackup,
 		ClassificationConfig:     classificationConfig,


### PR DESCRIPTION
## Summary

This PR refactors the advisor catalog system by eliminating unnecessary wrapper structs (`Finder` and `Catalog`) and providing direct access to `OriginCatalog` and `FinalCatalog` throughout the codebase.

## Motivation

The original design used two layers of wrappers:
```go
// Old pattern - unnecessary indirection
catalog.Catalog → catalog.Finder → DatabaseState (Origin/Final)
```

This refactoring simplifies to:
```go
// New pattern - direct access
OriginCatalog *catalog.DatabaseState
FinalCatalog  *catalog.DatabaseState
```

## Key Changes

### Core Refactoring
- ✅ Remove `Finder` and `Catalog` wrapper structs from catalog package
- ✅ Update `advisor.Context` to have separate `OriginCatalog` and `FinalCatalog` fields
- ✅ Remove `FinderContext.Copy()` method (unnecessary defensive copying of primitives)
- ✅ Export `newDatabaseState` → `NewDatabaseState` for direct construction
- ✅ Update `NewCatalog()` to return `(origin, final, error)` instead of wrapper

### Optimized Catalog Usage
Each advisor rule now only receives the catalog it actually uses:
- **18 rules** use only `originCatalog` (checking existing schema before changes)
- **6 rules** use only `finalCatalog` (validating post-walkthrough state)
- **1 rule** (TiDB table require PK) uses both catalogs

### Bug Fixes Discovered During Testing

#### 1. PostgreSQL Naming Conventions
**Files:** `advisor_naming_index_convention.go`, `advisor_naming_unique_key_convention.go`

**Issue:** During refactoring, the `originCatalog` field initialization was accidentally removed, causing `ALTER INDEX old_name RENAME TO new_name` validation to fail.

**Fix:** Restored `originCatalog: checkCtx.OriginCatalog` in struct initialization.

#### 2. TiDB Table Require PK  
**File:** `advisor_table_require_pk.go`

**Issue:** Initially changed to use only `finalCatalog`, but this was incorrect. Since walk-through happens BEFORE advisors run, the final catalog already reflects all changes. When checking `DROP COLUMN id` where `id` is in PK, the final catalog shows no PK (already dropped), so the advisor incorrectly allows it.

**Fix:** Use `originCatalog` for PK lookups (original state) and keep `finalCatalog` for future use.

## Impact

### Statistics
- 41 files changed
- +278 insertions, -319 deletions
- **Net: -41 lines** (code reduction)

### Benefits
- ✅ Simplified architecture with clearer intent
- ✅ Improved code maintainability
- ✅ Reduced memory usage (no defensive copying)
- ✅ Better performance (fewer indirections)
- ✅ More explicit about catalog usage (origin vs final)

## Testing

### Test Results
All tests pass:
```
✅ backend/plugin/advisor (4.5s)
✅ backend/plugin/advisor/catalog (2.7s)  
✅ backend/plugin/advisor/mssql (8.2s)
✅ backend/plugin/advisor/mysql (6.1s)
✅ backend/plugin/advisor/oracle (9.6s)
✅ backend/plugin/advisor/pg (10.9s)
✅ backend/plugin/advisor/snowflake (12.6s)
✅ backend/plugin/advisor/tidb (13.9s)
```

**Total: 8/8 test suites passing (100% pass rate)**

### Regression Testing
Both bugs were caught by existing tests:
1. `TestPostgreSQLANTLRRules` - PG naming convention validation
2. `TestTiDBRules` - TiDB table require PK validation

## Breaking Changes

None. This is a pure internal refactoring with no API changes.

## Migration Guide

Not applicable - internal refactoring only.

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass locally
- [x] No new warnings from linters
- [x] Commits follow conventional commit format
- [x] Self-review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>