### PR TITLE
refactor: convert WalkThrough methods to public functions

### DIFF
--- a/backend/plugin/advisor/catalog/walk_through.go
+++ b/backend/plugin/advisor/catalog/walk_through.go
@@ -179,14 +179,14 @@ func (e *WalkThroughError) Error() string {
 }
 
 // WalkThrough will collect the catalog schema in the databaseState as it walks through the stmt.
-func (d *DatabaseState) WalkThrough(ast any) error {
+func WalkThrough(d *DatabaseState, ast any) error {
 	switch d.dbType {
 	case storepb.Engine_TIDB:
-		return d.tidbWalkThrough(ast)
+		return TiDBWalkThrough(d, ast)
 	case storepb.Engine_MYSQL, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE:
-		return d.mysqlWalkThrough(ast)
+		return MySQLWalkThrough(d, ast)
 	case storepb.Engine_POSTGRES:
-		if err := d.pgWalkThrough(ast); err != nil {
+		if err := PgWalkThrough(d, ast); err != nil {
 			if d.ctx.CheckIntegrity {
 				return err
 			}

--- a/backend/plugin/advisor/catalog/walk_through_for_mysql.go
+++ b/backend/plugin/advisor/catalog/walk_through_for_mysql.go
@@ -13,7 +13,8 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/parser/tidb"
 )
 
-func (d *DatabaseState) mysqlWalkThrough(ast any) error {
+// MySQLWalkThrough walks through MySQL AST and updates the database state.
+func MySQLWalkThrough(d *DatabaseState, ast any) error {
 	// We define the Catalog as Database -> Schema -> Table. The Schema is only for PostgreSQL.
 	// So we use a Schema whose name is empty for other engines, such as MySQL.
 	// If there is no empty-string-name schema, create it to avoid corner cases.

--- a/backend/plugin/advisor/catalog/walk_through_for_pg.go
+++ b/backend/plugin/advisor/catalog/walk_through_for_pg.go
@@ -12,8 +12,8 @@ import (
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
-// pgWalkThrough walks through the ANTLR parse tree and builds catalog state.
-func (d *DatabaseState) pgWalkThrough(ast any) error {
+// PgWalkThrough walks through the PostgreSQL ANTLR parse tree and builds catalog state.
+func PgWalkThrough(d *DatabaseState, ast any) error {
 	// ANTLR-based walkthrough
 	parseResult, ok := ast.(*pgparser.ParseResult)
 	if !ok {

--- a/backend/plugin/advisor/catalog/walk_through_for_tidb.go
+++ b/backend/plugin/advisor/catalog/walk_through_for_tidb.go
@@ -11,7 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (d *DatabaseState) tidbWalkThrough(ast any) error {
+// TiDBWalkThrough walks through TiDB AST and updates the database state.
+func TiDBWalkThrough(d *DatabaseState, ast any) error {
 	// We define the Catalog as Database -> Schema -> Table. The Schema is only for PostgreSQL.
 	// So we use a Schema whose name is empty for other engines, such as MySQL.
 	// If there is no empty-string-name schema, create it to avoid corner cases.

--- a/backend/plugin/advisor/catalog/walk_through_test.go
+++ b/backend/plugin/advisor/catalog/walk_through_test.go
@@ -202,7 +202,7 @@ func runWalkThroughTest(t *testing.T, file string, engineType storepb.Engine, or
 		}
 
 		asts, _ := sm.GetASTsForChecks(engineType, test.Statement)
-		err := state.WalkThrough(asts)
+		err := WalkThrough(state, asts)
 		if err != nil {
 			err, yes := err.(*WalkThroughError)
 			require.True(t, yes)
@@ -257,7 +257,7 @@ func runANTLRWalkThroughTest(t *testing.T, file string, engineType storepb.Engin
 		}
 
 		// Call WalkThrough with ANTLR tree
-		err := state.WalkThrough(parseResult)
+		err := WalkThrough(state, parseResult)
 		if err != nil {
 			err, yes := err.(*WalkThroughError)
 			require.True(t, yes)

--- a/backend/plugin/advisor/pg/pgantlr_test.go
+++ b/backend/plugin/advisor/pg/pgantlr_test.go
@@ -67,20 +67,6 @@ func TestPostgreSQLANTLRRules(t *testing.T) {
 	}
 
 	for _, rule := range antlrRules {
-		needMetaData := advisorNeedMockData[rule]
-		RunANTLRAdvisorRuleTest(t, rule, storepb.Engine_POSTGRES, needMetaData, false /* record */)
+		RunANTLRAdvisorRuleTest(t, rule, storepb.Engine_POSTGRES, false /* record */)
 	}
-}
-
-// Add SQL review type here if you need metadata for test.
-var advisorNeedMockData = map[advisor.SQLReviewRuleType]bool{
-	advisor.BuiltinRulePriorBackupCheck:         true,
-	advisor.SchemaRuleColumnNotNull:             true, // Needs metadata for PRIMARY KEY USING INDEX case
-	advisor.SchemaRuleFullyQualifiedObjectName:  true, // Needs metadata for SELECT statement checks
-	advisor.SchemaRuleIDXNaming:                 true, // Needs catalog for ALTER INDEX RENAME
-	advisor.SchemaRuleIndexTotalNumberLimit:     true, // Needs catalog to count indexes
-	advisor.SchemaRulePKNaming:                  true, // Needs catalog for PRIMARY KEY USING INDEX
-	advisor.SchemaRuleStatementObjectOwnerCheck: true, // Needs catalog for ownership checks
-	advisor.SchemaRuleTableRequirePK:            true, // Needs catalog for DROP CONSTRAINT/COLUMN checks
-	advisor.SchemaRuleUKNaming:                  true, // Needs catalog for UNIQUE USING INDEX
 }

--- a/backend/plugin/advisor/sql_review.go
+++ b/backend/plugin/advisor/sql_review.go
@@ -534,7 +534,7 @@ func SQLReviewCheck(
 	if !builtinOnly && checkContext.FinalCatalog != nil {
 		switch checkContext.DBType {
 		case storepb.Engine_TIDB, storepb.Engine_MYSQL, storepb.Engine_MARIADB, storepb.Engine_POSTGRES, storepb.Engine_OCEANBASE:
-			if err := checkContext.FinalCatalog.WalkThrough(asts); err != nil {
+			if err := catalog.WalkThrough(checkContext.FinalCatalog, asts); err != nil {
 				return convertWalkThroughErrorToAdvice(err)
 			}
 		default:


### PR DESCRIPTION
## Summary

Convert `DatabaseState` walk-through methods to public utility functions for better API design and clearer dependency handling.

## Changes

### Refactored Functions

1. **`WalkThrough`** - Main dispatcher function
   - Before: `func (d *DatabaseState) WalkThrough(ast any) error`
   - After: `func WalkThrough(d *DatabaseState, ast any) error`

2. **`MySQLWalkThrough`** - MySQL AST processing
   - Before: `func (d *DatabaseState) mysqlWalkThrough(ast any) error` (private)
   - After: `func MySQLWalkThrough(d *DatabaseState, ast any) error` (public)

3. **`PgWalkThrough`** - PostgreSQL AST processing
   - Before: `func (d *DatabaseState) pgWalkThrough(ast any) error` (private)
   - After: `func PgWalkThrough(d *DatabaseState, ast any) error` (public)

4. **`TiDBWalkThrough`** - TiDB AST processing
   - Before: `func (d *DatabaseState) tidbWalkThrough(ast any) error` (private)
   - After: `func TiDBWalkThrough(d *DatabaseState, ast any) error` (public)

### Updated Callers

All callers updated to use new function signatures:
- `backend/plugin/advisor/sql_review.go`: `catalog.WalkThrough(checkContext.FinalCatalog, asts)`
- `backend/plugin/advisor/pg/test_helper.go`: `catalog.WalkThrough(finalCatalog, tree)`
- `backend/plugin/advisor/catalog/walk_through_test.go`: `WalkThrough(state, asts)` (2 instances)

### Additional Cleanup

- Removed `needMetaData` parameter from `RunANTLRAdvisorRuleTest`
- Always run catalog walk-through in tests (simpler, negligible performance impact)
- Removed `advisorNeedMockData` map (no longer needed)
- Net reduction: **16 lines of code removed**

## Benefits

✅ **Better API design** - Explicit dependency passing instead of method calls  
✅ **More functional** - Follows functional programming style  
✅ **Simpler tests** - Removed unnecessary conditional logic  
✅ **Less error-prone** - No risk of forgetting to update metadata map  
✅ **Public interface** - Engine-specific functions can now be called directly if needed

## Test Plan

All existing tests pass:
- `TestTiDBWalkThrough` ✓
- `TestMySQLWalkThrough` ✓
- `TestMySQLWalkThroughForIncomplete` ✓
- `TestPostgreSQLWalkThrough` ✓
- `TestPostgreSQLANTLRWalkThrough` ✓
- `TestPostgreSQLANTLRRules` ✓
- All pg advisor tests ✓

Linting: 0 issues with `golangci-lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)