### PR TITLE
refactor: remove CheckIntegrity flag and always enforce integrity checks

### DIFF
--- a/backend/plugin/advisor/catalog/catalog.go
+++ b/backend/plugin/advisor/catalog/catalog.go
@@ -24,7 +24,7 @@ func NewCatalog(ctx context.Context, s *store.Store, instanceID, databaseName st
 		}
 		dbMetadata = databaseMeta.GetMetadata()
 	}
-	finderCtx := &FinderContext{CheckIntegrity: true, EngineType: engineType, IgnoreCaseSensitive: !isCaseSensitive}
+	finderCtx := &FinderContext{EngineType: engineType, IgnoreCaseSensitive: !isCaseSensitive}
 	origin = NewDatabaseState(dbMetadata, finderCtx)
 	final = NewDatabaseState(dbMetadata, finderCtx)
 	return origin, final, nil

--- a/backend/plugin/advisor/catalog/finder.go
+++ b/backend/plugin/advisor/catalog/finder.go
@@ -6,21 +6,6 @@ import (
 
 // FinderContext is the context for finder.
 type FinderContext struct {
-	// CheckIntegrity defines the policy for integrity checking.
-	// There are two cases that will cause database to have an empty catalog:
-	//   1. we cannot fetch the catalog, such as GitHub App/Actions.
-	//   2. the database is indeed empty.
-	// We need different logic to deal with these two cases separately.
-	// If DROP TABLE t and t not exists:
-	//   1. For case one, just ignore this statement.
-	//   2. For case two, return the error that table t not exists.
-	// In addition, We need fine-grained CheckIntegrity.
-	// Consider the case one, and then create a table t by CREATE TABLE statement.
-	// After this, drop column a in table t, but column a not exists.
-	// In this case, we need return the error that column a does not exist in table t,
-	// instead of ignoring this drop-column statement.
-	CheckIntegrity bool
-
 	// EngineType is the engine type for database engine.
 	EngineType storepb.Engine
 

--- a/backend/plugin/advisor/catalog/walk_through_test.go
+++ b/backend/plugin/advisor/catalog/walk_through_test.go
@@ -54,16 +54,6 @@ func TestMySQLWalkThrough(t *testing.T) {
 	}
 }
 
-func TestMySQLWalkThroughForIncomplete(t *testing.T) {
-	tests := []string{
-		"mysql_walk_through_for_incomplete",
-	}
-
-	for _, test := range tests {
-		runWalkThroughTest(t, test, storepb.Engine_MYSQL, nil)
-	}
-}
-
 func TestPostgreSQLWalkThrough(t *testing.T) {
 	originDatabase := &storepb.DatabaseSchemaMetadata{
 		Name: "postgres",
@@ -196,9 +186,9 @@ func runWalkThroughTest(t *testing.T, file string, engineType storepb.Engine, or
 	for _, test := range tests {
 		var state *DatabaseState
 		if originDatabase != nil {
-			state = NewDatabaseState(originDatabase, &FinderContext{CheckIntegrity: true, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
+			state = NewDatabaseState(originDatabase, &FinderContext{EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		} else {
-			state = NewDatabaseState(&storepb.DatabaseSchemaMetadata{}, &FinderContext{CheckIntegrity: false, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
+			state = NewDatabaseState(&storepb.DatabaseSchemaMetadata{}, &FinderContext{EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		}
 
 		asts, _ := sm.GetASTsForChecks(engineType, test.Statement)
@@ -245,9 +235,9 @@ func runANTLRWalkThroughTest(t *testing.T, file string, engineType storepb.Engin
 	for _, test := range tests {
 		var state *DatabaseState
 		if originDatabase != nil {
-			state = NewDatabaseState(originDatabase, &FinderContext{CheckIntegrity: true, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
+			state = NewDatabaseState(originDatabase, &FinderContext{EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		} else {
-			state = NewDatabaseState(&storepb.DatabaseSchemaMetadata{}, &FinderContext{CheckIntegrity: false, EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
+			state = NewDatabaseState(&storepb.DatabaseSchemaMetadata{}, &FinderContext{EngineType: engineType, IgnoreCaseSensitive: test.IgnoreCaseSensitive})
 		}
 
 		// Parse using ANTLR parser instead of legacy parser

--- a/backend/plugin/advisor/pg/test_helper.go
+++ b/backend/plugin/advisor/pg/test_helper.go
@@ -59,7 +59,7 @@ func RunANTLRAdvisorRuleTest(t *testing.T, rule advisor.SQLReviewRuleType, dbTyp
 		}
 
 		database := advisor.MockPostgreSQLDatabase
-		ctx := &catalog.FinderContext{CheckIntegrity: true, EngineType: dbType}
+		ctx := &catalog.FinderContext{EngineType: dbType}
 		originCatalog := catalog.NewDatabaseState(database, ctx)
 		finalCatalog := catalog.NewDatabaseState(database, ctx)
 

--- a/backend/plugin/advisor/utils_for_tests.go
+++ b/backend/plugin/advisor/utils_for_tests.go
@@ -200,7 +200,7 @@ func RunSQLReviewRuleTest(t *testing.T, rule SQLReviewRuleType, dbType storepb.E
 		if dbType == storepb.Engine_POSTGRES {
 			database = MockPostgreSQLDatabase
 		}
-		ctx := &catalog.FinderContext{CheckIntegrity: true, EngineType: dbType}
+		ctx := &catalog.FinderContext{EngineType: dbType}
 		originCatalog := catalog.NewDatabaseState(database, ctx)
 		finalCatalog := catalog.NewDatabaseState(database, ctx)
 


### PR DESCRIPTION
## Summary

Remove the `CheckIntegrity` field from `FinderContext` and always treat it as `true`, simplifying the catalog codebase by eliminating the "incomplete" catalog mode.

## Background

The `CheckIntegrity` flag controlled two different behaviors:
- **`true` (strict mode)**: Validate that tables/columns/indexes exist before operations
- **`false` (incomplete mode)**: Allow operations on non-existent objects by creating incomplete placeholder entries

In production, this flag was **always set to `true`**. The `false` path only existed in some tests to handle cases where database schema wasn't available.

## Changes

### Core Changes
- Remove `CheckIntegrity` field from `FinderContext` struct
- Update all conditional checks to always validate object existence
- Remove `checkIntegrity` parameters from methods:
  - `DropColumn(columnName, checkViewDependency)`
  - `RenameColumn(oldName, newName)` 
  - `DropIndex(indexName, identifierMap)`
  - `RenameIndex(oldName, newName, identifierMap)`

### Cleanup
- Remove unused "incomplete" mode helper functions:
  - `createIncompleteIndex`, `createIncompleteTable`, `createIncompleteColumn`
  - `mysqlIncompleteTableChangeColumn`, `incompleteTableChangeColumn`
- Remove `TestMySQLWalkThroughForIncomplete` test
- Fix linter warnings by renaming unused `ctx` parameters to `_`

### Impact
- **137 lines removed**, 105 lines added (net reduction of 32 lines)
- Simpler, more predictable code with consistent validation behavior
- Better error detection - failures occur earlier when objects don't exist

## Test plan

- [x] All existing catalog tests pass
- [x] `golangci-lint` passes with no issues
- [x] Code properly formatted with `gofmt`

## Verification

```bash
# Run tests
go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/advisor/catalog

# Run linter
golangci-lint run --allow-parallel-runners backend/plugin/advisor/catalog/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)