### PR TITLE
refactor: standardize DatabaseState.deleted field handling across engines

### DIFF
--- a/backend/plugin/advisor/catalog/walk_through_for_mysql.go
+++ b/backend/plugin/advisor/catalog/walk_through_for_mysql.go
@@ -58,7 +58,7 @@ func (d *DatabaseState) mysqlChangeState(in *mysqlparser.ParseResult) (err *Walk
 		}
 	}()
 
-	if d.deleted {
+	if d.IsDeleted() {
 		return &WalkThroughError{
 			Type:    ErrorTypeDatabaseIsDeleted,
 			Content: fmt.Sprintf("Database `%s` is deleted", d.name),

--- a/backend/plugin/advisor/catalog/walk_through_for_tidb.go
+++ b/backend/plugin/advisor/catalog/walk_through_for_tidb.go
@@ -41,7 +41,7 @@ func (d *DatabaseState) changeState(in tidbast.StmtNode) (err *WalkThroughError)
 			err.Line = in.OriginTextPosition()
 		}
 	}()
-	if d.deleted {
+	if d.IsDeleted() {
 		return &WalkThroughError{
 			Type:    ErrorTypeDatabaseIsDeleted,
 			Content: fmt.Sprintf("Database `%s` is deleted", d.name),
@@ -135,7 +135,7 @@ func (d *DatabaseState) dropDatabase(node *tidbast.DropDatabaseStmt) *WalkThroug
 		return NewAccessOtherDatabaseError(d.name, node.Name.O)
 	}
 
-	d.deleted = true
+	d.MarkDeleted()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

The `deleted` field in `DatabaseState` was inconsistently accessed and mutated across different database engines. This change standardizes the usage to always use the public methods `MarkDeleted()` and `IsDeleted()`, and removes dead code in PostgreSQL that could never be executed.

## Changes

### MySQL (walk_through_for_mysql.go:61)
- Changed `if d.deleted` → `if d.IsDeleted()`
- Already using `MarkDeleted()` correctly

### TiDB (walk_through_for_tidb.go)
- Line 44: Changed `if d.deleted` → `if d.IsDeleted()`
- Line 138: Changed `d.deleted = true` → `d.MarkDeleted()`

### PostgreSQL (walk_through_for_pg.go)
- Added `EnterDropdbstmt()` handler for DROP DATABASE statements
- PostgreSQL does NOT allow dropping the currently open database (matches real behavior)
- Returns appropriate error when attempting to DROP current or other databases
- **Removed dead code**: `checkDatabaseNotDeleted()` function and all its call sites
  - This code could never be true for PostgreSQL since the database can never be marked as deleted
  - Removed from 5 different handlers to clean up the codebase

## Behavior by Engine

| Engine | Can DROP current DB? | Walk-through behavior |
|--------|---------------------|----------------------|
| **MySQL** | ✅ Yes | Marks as deleted, subsequent statements fail |
| **TiDB** | ✅ Yes | Marks as deleted, subsequent statements fail |
| **PostgreSQL** | ❌ No | Returns error immediately (mimics `ERROR: cannot drop the currently open database`) |

## Test Plan

- ✅ All existing tests pass
- ✅ `TestTiDBWalkThrough`
- ✅ `TestMySQLWalkThrough`
- ✅ `TestPostgreSQLWalkThrough`
- ✅ `TestPostgreSQLANTLRWalkThrough`
- ✅ Linter passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)