### PR TITLE
refactor: remove WalkThroughError.Payload field and centralize error codes

### DIFF
--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -13,6 +13,7 @@ import (
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	advisorpg "github.com/bytebase/bytebase/backend/plugin/advisor/pg"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/parser/pg"
@@ -220,7 +221,7 @@ loop:
 						Advices: []*v1pb.Advice{
 							{
 								Status:  v1pb.Advice_WARNING,
-								Code:    advisor.Internal.Int32(),
+								Code:    code.Internal.Int32(),
 								Title:   "Applied file has been modified",
 								Content: fmt.Sprintf("The file %q with version %q has already been applied to the database, but its content has been modified. Applied SHA256: %s, Release SHA256: %s", file.Path, file.Version, appliedRevision.Payload.SheetSha256, file.SheetSha256),
 							},
@@ -328,7 +329,7 @@ loop:
 					Advices: []*v1pb.Advice{
 						{
 							Status:  v1pb.Advice_ERROR,
-							Code:    advisor.Internal.Int32(),
+							Code:    code.Internal.Int32(),
 							Title:   "Failed to check",
 							Content: err.Error(),
 						},
@@ -409,7 +410,7 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 						Advices: []*v1pb.Advice{
 							{
 								Status:  v1pb.Advice_WARNING,
-								Code:    advisor.Internal.Int32(),
+								Code:    code.Internal.Int32(),
 								Title:   "Applied file has been modified",
 								Content: fmt.Sprintf("The file %q has version %q, but there is an equal or higher version %q applied", file.Path, file.Version, revisions[0].Version),
 							},
@@ -438,7 +439,7 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 					// Continue with other checks even if style check fails
 					sdlStyleAdvices[filePath] = []*storepb.Advice{{
 						Status:  storepb.Advice_ERROR,
-						Code:    advisor.Internal.Int32(),
+						Code:    code.Internal.Int32(),
 						Title:   "Failed to check SDL style",
 						Content: err.Error(),
 					}}
@@ -501,7 +502,7 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 					if err != nil {
 						checkResult.Advices = append(checkResult.Advices, &v1pb.Advice{
 							Status:  v1pb.Advice_ERROR,
-							Code:    advisor.Internal.Int32(),
+							Code:    code.Internal.Int32(),
 							Title:   "Failed to parse statement types",
 							Content: err.Error(),
 						})
@@ -512,7 +513,7 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 								// Create a separate advice for each disallowed statement with position
 								advice := &v1pb.Advice{
 									Status: v1pb.Advice_ERROR,
-									Code:   advisor.StatementDisallowedInSDL.Int32(),
+									Code:   code.StatementDisallowedInSDL.Int32(),
 									Title:  "Disallowed statement in SDL file",
 									Content: fmt.Sprintf(
 										"Statement type '%s' is not allowed in SDL files.\n\n"+

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -29,7 +29,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/generated-go/v1/v1connect"
-	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
@@ -1560,7 +1560,7 @@ func validateQueryRequest(instance *store.InstanceMessage, statement string) err
 		if syntaxErr, ok := err.(*parserbase.SyntaxError); ok {
 			err := connect.NewError(connect.CodeInvalidArgument, syntaxErr)
 			if detail, detailErr := connect.NewErrorDetail(&v1pb.PlanCheckRun_Result{
-				Code:    int32(advisor.StatementSyntaxError),
+				Code:    int32(code.StatementSyntaxError),
 				Content: syntaxErr.Message,
 				Title:   "Syntax error",
 				Status:  v1pb.Advice_ERROR,

--- a/backend/plugin/advisor/catalog/test/mysql_walk_through.yaml
+++ b/backend/plugin/advisor/catalog/test/mysql_walk_through.yaml
@@ -1,995 +1,419 @@
-- statement: |-
-    CREATE TABLE `test`.`t1` (a INT);
+- statement: 'CREATE TABLE `test`.`t1` (a INT);
+
     CREATE TABLE `other`.`t1` (a INT);
-    RENAME TABLE `other`.`t1` TO `other`.`t2`;
+
+    RENAME TABLE `other`.`t1` TO `other`.`t2`;'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 201
+    code: 702
     content: Database `other` is not the current database `test`
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE `test`.`t1` (a INT);
-    RENAME TABLE `test`.`t1` TO `other`.`t1`;
+- statement: 'CREATE TABLE `test`.`t1` (a INT);
+
+    RENAME TABLE `test`.`t1` TO `other`.`t1`;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {}
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {}\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(a INT);
+- statement: 'CREATE TABLE t1(a INT);
+
     CREATE TABLE t2(a INT);
-    RENAME TABLE t2 TO t1;
+
+    RENAME TABLE t2 TO t1;'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 301
+    code: 607
     content: Table `t1` already exists
     line: 3
-    payload: null
-- statement: |-
-    CREATE TABLE t1(a INT);
-    RENAME TABLE t2 TO t3;
+- statement: 'CREATE TABLE t1(a INT);
+
+    RENAME TABLE t2 TO t3;'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 302
+    code: 604
     content: Table `t2` does not exist
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE t1 (a INT);
-    RENAME TABLE t1 TO t2;
+- statement: 'CREATE TABLE t1 (a INT);
+
+    RENAME TABLE t1 TO t2;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t2",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t2\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"int\"\n            }\n\
+    \          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
 - statement: CREATE DATABASE another;
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 201
+    code: 702
     content: Database `another` is not the current database `test`
     line: 1
-    payload: null
-- statement: |-
-    -- this is comment
+- statement: '-- this is comment
+
     DROP DATABASE test;
-    CREATE TABLE t(a int);
+
+    CREATE TABLE t(a int);'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 202
+    code: 703
     content: Database `test` is deleted
     line: 1
-    payload: null
-- statement: |-
-    ALTER DATABASE CHARACTER SET = utf8mb4;
-    ALTER DATABASE test COLLATE utf8mb4_polish_ci;
+- statement: 'ALTER DATABASE CHARACTER SET = utf8mb4;
+
+    ALTER DATABASE test COLLATE utf8mb4_polish_ci;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {}
-      ],
-      "characterSet": "utf8mb4",
-      "collation": "utf8mb4_polish_ci"
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {}\n  ],\n  \"characterSet\"\
+    : \"utf8mb4\",\n  \"collation\": \"utf8mb4_polish_ci\"\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT PRIMARY KEY,
-      c VARCHAR(255) NOT NULL
-    );
-    ALTER TABLE t1 ADD INDEX idx1 (c);
-    CREATE FULLTEXT INDEX ftk1 ON t1 (c);
-    DROP INDEX `PRIMARY` ON t1;
-    DROP INDEX idx1 ON t1;
-    DROP INDEX ftk1 ON t1;
+- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  c VARCHAR(255) NOT NULL\n\
+    );\nALTER TABLE t1 ADD INDEX idx1 (c);\nCREATE FULLTEXT INDEX ftk1 ON t1 (c);\n\
+    DROP INDEX `PRIMARY` ON t1;\nDROP INDEX idx1 ON t1;\nDROP INDEX ftk1 ON t1;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "c",
-                  "position": 2,
-                  "type": "varchar"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
+    : \"c\",\n              \"position\": 2,\n              \"type\": \"varchar\"\n\
+    \            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT,
-      b INT,
-      c VARCHAR(255) NOT NULL,
-      d GEOMETRY NOT NULL
-    );
-    CREATE INDEX idx1 ON t1 (a) INVISIBLE;
-    CREATE UNIQUE INDEX uk1 ON t1 (b);
-    CREATE FULLTEXT INDEX ftk1 ON t1 (c);
-    CREATE SPATIAL INDEX sk1 ON t1 (d);
+- statement: "CREATE TABLE t1(\n  a INT,\n  b INT,\n  c VARCHAR(255) NOT NULL,\n \
+    \ d GEOMETRY NOT NULL\n);\nCREATE INDEX idx1 ON t1 (a) INVISIBLE;\nCREATE UNIQUE\
+    \ INDEX uk1 ON t1 (b);\nCREATE FULLTEXT INDEX ftk1 ON t1 (c);\nCREATE SPATIAL\
+    \ INDEX sk1 ON t1 (d);"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "type": "varchar"
-                },
-                {
-                  "name": "d",
-                  "position": 4,
-                  "type": "geometry"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "ftk1",
-                  "expressions": [
-                    "c"
-                  ],
-                  "type": "FULLTEXT",
-                  "visible": true
-                },
-                {
-                  "name": "idx1",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE"
-                },
-                {
-                  "name": "sk1",
-                  "expressions": [
-                    "d"
-                  ],
-                  "type": "SPATIAL",
-                  "visible": true
-                },
-                {
-                  "name": "uk1",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"nullable\": true,\n              \"type\": \"int\"\n        \
+    \    },\n            {\n              \"name\": \"c\",\n              \"position\"\
+    : 3,\n              \"type\": \"varchar\"\n            },\n            {\n   \
+    \           \"name\": \"d\",\n              \"position\": 4,\n              \"\
+    type\": \"geometry\"\n            }\n          ],\n          \"indexes\": [\n\
+    \            {\n              \"name\": \"ftk1\",\n              \"expressions\"\
+    : [\n                \"c\"\n              ],\n              \"type\": \"FULLTEXT\"\
+    ,\n              \"visible\": true\n            },\n            {\n          \
+    \    \"name\": \"idx1\",\n              \"expressions\": [\n                \"\
+    a\"\n              ],\n              \"type\": \"BTREE\"\n            },\n   \
+    \         {\n              \"name\": \"sk1\",\n              \"expressions\":\
+    \ [\n                \"d\"\n              ],\n              \"type\": \"SPATIAL\"\
+    ,\n              \"visible\": true\n            },\n            {\n          \
+    \    \"name\": \"uk1\",\n              \"expressions\": [\n                \"\
+    b\"\n              ],\n              \"type\": \"BTREE\",\n              \"unique\"\
+    : true,\n              \"visible\": true\n            }\n          ]\n       \
+    \ }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(a GEOMETRY);
-    CREATE SPATIAL INDEX sk1 ON t1 (a);
+- statement: 'CREATE TABLE t1(a GEOMETRY);
+
+    CREATE SPATIAL INDEX sk1 ON t1 (a);'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 507
+    code: 811
     content: All parts of a SPATIAL index must be NOT NULL, but `a` is nullable
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT PRIMARY KEY,
-      b INT,
-      UNIQUE uk1 (b)
-    );
-    ALTER TABLE t1 ENGINE = MyISAM;
-    ALTER TABLE t1 COMMENT = 't1 table';
-    ALTER TABLE t1 COLLATE utf8mb4_unicode_ci;
+- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  b INT,\n  UNIQUE uk1 (b)\n\
+    );\nALTER TABLE t1 ENGINE = MyISAM;\nALTER TABLE t1 COMMENT = 't1 table';\nALTER\
+    \ TABLE t1 COLLATE utf8mb4_unicode_ci;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                },
-                {
-                  "name": "uk1",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                }
-              ],
-              "engine": "MyISAM",
-              "collation": "utf8mb4_unicode_ci",
-              "comment": "t1 table"
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
+    : \"b\",\n              \"position\": 2,\n              \"nullable\": true,\n\
+    \              \"type\": \"int\"\n            }\n          ],\n          \"indexes\"\
+    : [\n            {\n              \"name\": \"PRIMARY\",\n              \"expressions\"\
+    : [\n                \"a\"\n              ],\n              \"type\": \"BTREE\"\
+    ,\n              \"unique\": true,\n              \"primary\": true,\n       \
+    \       \"visible\": true\n            },\n            {\n              \"name\"\
+    : \"uk1\",\n              \"expressions\": [\n                \"b\"\n        \
+    \      ],\n              \"type\": \"BTREE\",\n              \"unique\": true,\n\
+    \              \"visible\": true\n            }\n          ],\n          \"engine\"\
+    : \"MyISAM\",\n          \"collation\": \"utf8mb4_unicode_ci\",\n          \"\
+    comment\": \"t1 table\"\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT PRIMARY KEY,
-      b INT,
-      UNIQUE uk1 (b)
-    );
-    ALTER TABLE t1 DROP PRIMARY KEY;
-    ALTER TABLE t1 DROP INDEX uk1;
+- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  b INT,\n  UNIQUE uk1 (b)\n\
+    );\nALTER TABLE t1 DROP PRIMARY KEY;\nALTER TABLE t1 DROP INDEX uk1;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
+    : \"b\",\n              \"position\": 2,\n              \"nullable\": true,\n\
+    \              \"type\": \"int\"\n            }\n          ]\n        }\n    \
+    \  ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT,
-      b INT,
-      UNIQUE uk1 (b)
-    );
-    ALTER TABLE t1 RENAME INDEX uk1 TO uk_b;
-    ALTER TABLE t1 ADD INDEX idx1 (b);
-    ALTER TABLE t1 RENAME INDEX idx1 TO idx2;
-    ALTER TABLE t1 ALTER INDEX idx2 INVISIBLE;
-    ALTER TABLE t1 RENAME TO t2;
+- statement: "CREATE TABLE t1(\n  a INT,\n  b INT,\n  UNIQUE uk1 (b)\n);\nALTER TABLE\
+    \ t1 RENAME INDEX uk1 TO uk_b;\nALTER TABLE t1 ADD INDEX idx1 (b);\nALTER TABLE\
+    \ t1 RENAME INDEX idx1 TO idx2;\nALTER TABLE t1 ALTER INDEX idx2 INVISIBLE;\n\
+    ALTER TABLE t1 RENAME TO t2;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t2",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "idx2",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE"
-                },
-                {
-                  "name": "uk_b",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t2\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"nullable\": true,\n              \"type\": \"int\"\n        \
+    \    }\n          ],\n          \"indexes\": [\n            {\n              \"\
+    name\": \"idx2\",\n              \"expressions\": [\n                \"b\"\n \
+    \             ],\n              \"type\": \"BTREE\"\n            },\n        \
+    \    {\n              \"name\": \"uk_b\",\n              \"expressions\": [\n\
+    \                \"b\"\n              ],\n              \"type\": \"BTREE\",\n\
+    \              \"unique\": true,\n              \"visible\": true\n          \
+    \  }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(a INT NOT NULL);
-    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;
+- statement: 'CREATE TABLE t1(a INT NOT NULL);
+
+    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 406
+    code: 428
     content: Invalid default value for column `a`
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE t1(a INT);
+- statement: 'CREATE TABLE t1(a INT);
+
     ALTER TABLE t1 CHANGE COLUMN a a BLOB;
-    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT 'default value';
+
+    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT ''default value'';'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 407
+    code: 423
     content: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
     line: 3
-    payload: null
-- statement: |-
-    CREATE TABLE t1(a INT);
+- statement: 'CREATE TABLE t1(a INT);
+
     ALTER TABLE t1 CHANGE COLUMN a a BLOB;
-    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;
+
+    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "blob"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"blob\"\n            }\n\
+    \          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT
-    );
-    ALTER TABLE t1 ADD COLUMN b INT AFTER a;
-    ALTER TABLE t1 ADD COLUMN c INT NOT NULL DEFAULT 1 AFTER a;
-    ALTER TABLE t1 CHANGE COLUMN b d TEXT AFTER a;
-    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT 1;
-    ALTER TABLE t1 ALTER COLUMN a SET INVISIBLE;
-    ALTER TABLE t1 ALTER COLUMN c DROP DEFAULT;
+- statement: "CREATE TABLE t1(\n  a INT\n);\nALTER TABLE t1 ADD COLUMN b INT AFTER\
+    \ a;\nALTER TABLE t1 ADD COLUMN c INT NOT NULL DEFAULT 1 AFTER a;\nALTER TABLE\
+    \ t1 CHANGE COLUMN b d TEXT AFTER a;\nALTER TABLE t1 ALTER COLUMN a SET DEFAULT\
+    \ 1;\nALTER TABLE t1 ALTER COLUMN a SET INVISIBLE;\nALTER TABLE t1 ALTER COLUMN\
+    \ c DROP DEFAULT;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "default": "1",
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "d",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "text"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "type": "int"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"default\": \"1\",\n              \"nullable\": true,\n             \
+    \ \"type\": \"int\"\n            },\n            {\n              \"name\": \"\
+    d\",\n              \"position\": 2,\n              \"nullable\": true,\n    \
+    \          \"type\": \"text\"\n            },\n            {\n              \"\
+    name\": \"c\",\n              \"position\": 3,\n              \"type\": \"int\"\
+    \n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT
-    );
-    ALTER TABLE t1 ADD COLUMN b VARCHAR(255) FIRST;
-    ALTER TABLE t1 ADD COLUMN (c INT, d BLOB);
-    ALTER TABLE t1 MODIFY COLUMN b INT AFTER a;
-    ALTER TABLE t1 RENAME COLUMN b TO e;
-    ALTER TABLE t1 CHANGE COLUMN d f TEXT AFTER e;
-    ALTER TABLE t1 DROP COLUMN a;
+- statement: "CREATE TABLE t1(\n  a INT\n);\nALTER TABLE t1 ADD COLUMN b VARCHAR(255)\
+    \ FIRST;\nALTER TABLE t1 ADD COLUMN (c INT, d BLOB);\nALTER TABLE t1 MODIFY COLUMN\
+    \ b INT AFTER a;\nALTER TABLE t1 RENAME COLUMN b TO e;\nALTER TABLE t1 CHANGE\
+    \ COLUMN d f TEXT AFTER e;\nALTER TABLE t1 DROP COLUMN a;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "e",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "f",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "text"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"e\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"f\",\n              \"position\": 2,\n\
+    \              \"nullable\": true,\n              \"type\": \"text\"\n       \
+    \     },\n            {\n              \"name\": \"c\",\n              \"position\"\
+    : 3,\n              \"nullable\": true,\n              \"type\": \"int\"\n   \
+    \         }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(a INT);
+- statement: 'CREATE TABLE t1(a INT);
+
     CREATE TABLE t2(a INT);
+
     DROP TABLE t1, t2;
-    CREATE TABLE t3(a INT);
+
+    CREATE TABLE t3(a INT);'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t3",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t3\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"int\"\n            }\n\
+    \          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT AUTO_INCREMENT,
-      b INT AUTO_INCREMENT
-    );
+- statement: "CREATE TABLE t1(\n  a INT AUTO_INCREMENT,\n  b INT AUTO_INCREMENT\n\
+    );"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 404
+    code: 426
     content: There can be only one auto column for table `t1`
     line: 1
-    payload: null
-- statement: CREATE TABLE tvx SELECT (x,z) FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);
+- statement: CREATE TABLE tvx SELECT (x,z) FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS
+    v(x,y,z);
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 303
-    content: Disallow the CREATE TABLE AS statement but "CREATE TABLE tvx SELECT (x,z) FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);" uses
+    code: 205
+    content: Disallow the CREATE TABLE AS statement but "CREATE TABLE tvx SELECT (x,z)
+      FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);" uses
     line: 1
-    payload: null
-- statement: |-
-    CREATE TABLE t1(a int);
-    CREATE TABLE t2 (b INT) SELECT a FROM t1;
+- statement: 'CREATE TABLE t1(a int);
+
+    CREATE TABLE t2 (b INT) SELECT a FROM t1;'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 303
-    content: Disallow the CREATE TABLE AS statement but "CREATE TABLE t2 (b INT) SELECT a FROM t1;" uses
+    code: 205
+    content: Disallow the CREATE TABLE AS statement but "CREATE TABLE t2 (b INT) SELECT
+      a FROM t1;" uses
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE t1(
-      a int
-    );
-    CREATE TABLE t2 LIKE t1;
+- statement: "CREATE TABLE t1(\n  a int\n);\nCREATE TABLE t2 LIKE t1;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ]
-            },
-            {
-              "name": "t2",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"int\"\n            }\n\
+    \          ]\n        },\n        {\n          \"name\": \"t2\",\n          \"\
+    columns\": [\n            {\n              \"name\": \"a\",\n              \"\
+    position\": 1,\n              \"nullable\": true,\n              \"type\": \"\
+    int\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT PRIMARY KEY,
-      b INT NOT NULL DEFAULT 1,
-      c INT,
-      d VARCHAR(255) NOT NULL,
-      e VARCHAR(255),
-      UNIQUE KEY uk1 (b, c),
-      KEY idx1 (c),
-      FULLTEXT(d, e) WITH PARSER ngram INVISIBLE
-    );
+- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  b INT NOT NULL DEFAULT 1,\n\
+    \  c INT,\n  d VARCHAR(255) NOT NULL,\n  e VARCHAR(255),\n  UNIQUE KEY uk1 (b,\
+    \ c),\n  KEY idx1 (c),\n  FULLTEXT(d, e) WITH PARSER ngram INVISIBLE\n);"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "default": "1",
-                  "type": "int"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "d",
-                  "position": 4,
-                  "type": "varchar"
-                },
-                {
-                  "name": "e",
-                  "position": 5,
-                  "nullable": true,
-                  "type": "varchar"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                },
-                {
-                  "name": "d",
-                  "expressions": [
-                    "d",
-                    "e"
-                  ],
-                  "type": "FULLTEXT"
-                },
-                {
-                  "name": "idx1",
-                  "expressions": [
-                    "c"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                },
-                {
-                  "name": "uk1",
-                  "expressions": [
-                    "b",
-                    "c"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
+    : \"b\",\n              \"position\": 2,\n              \"default\": \"1\",\n\
+    \              \"type\": \"int\"\n            },\n            {\n            \
+    \  \"name\": \"c\",\n              \"position\": 3,\n              \"nullable\"\
+    : true,\n              \"type\": \"int\"\n            },\n            {\n    \
+    \          \"name\": \"d\",\n              \"position\": 4,\n              \"\
+    type\": \"varchar\"\n            },\n            {\n              \"name\": \"\
+    e\",\n              \"position\": 5,\n              \"nullable\": true,\n    \
+    \          \"type\": \"varchar\"\n            }\n          ],\n          \"indexes\"\
+    : [\n            {\n              \"name\": \"PRIMARY\",\n              \"expressions\"\
+    : [\n                \"a\"\n              ],\n              \"type\": \"BTREE\"\
+    ,\n              \"unique\": true,\n              \"primary\": true,\n       \
+    \       \"visible\": true\n            },\n            {\n              \"name\"\
+    : \"d\",\n              \"expressions\": [\n                \"d\",\n         \
+    \       \"e\"\n              ],\n              \"type\": \"FULLTEXT\"\n      \
+    \      },\n            {\n              \"name\": \"idx1\",\n              \"\
+    expressions\": [\n                \"c\"\n              ],\n              \"type\"\
+    : \"BTREE\",\n              \"visible\": true\n            },\n            {\n\
+    \              \"name\": \"uk1\",\n              \"expressions\": [\n        \
+    \        \"b\",\n                \"c\"\n              ],\n              \"type\"\
+    : \"BTREE\",\n              \"unique\": true,\n              \"visible\": true\n\
+    \            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT NOT NULL DEFAULT NULL
-    );
+- statement: "CREATE TABLE t1(\n  a INT NOT NULL DEFAULT NULL\n);"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 406
+    code: 428
     content: Invalid default value for column `a`
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE t1(
-      a BLOB DEFAULT 'this is a default value'
-    );
+- statement: "CREATE TABLE t1(\n  a BLOB DEFAULT 'this is a default value'\n);"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 407
+    code: 423
     content: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT ON UPDATE NOW()
-    );
+- statement: "CREATE TABLE t1(\n  a INT ON UPDATE NOW()\n);"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 405
+    code: 427
     content: Column `a` use ON UPDATE but is not DATETIME or TIMESTAMP
     line: 2
-    payload: null
-- statement: |-
-    CREATE TABLE t1(
-      a INT NOT NULL DEFAULT 1 PRIMARY KEY,
-      b INT UNIQUE,
-      c VARCHAR(255) NOT NULL DEFAULT 'NULL' COMMENT 'column c',
-      e INT NULL DEFAULT NULL,
-      f VARCHAR(10) NOT NULL COLLATE utf8mb4_polish_ci,
-      g VARCHAR(200) CHARACTER SET utf8mb4 NOT NULL
-    );
+- statement: "CREATE TABLE t1(\n  a INT NOT NULL DEFAULT 1 PRIMARY KEY,\n  b INT UNIQUE,\n\
+    \  c VARCHAR(255) NOT NULL DEFAULT 'NULL' COMMENT 'column c',\n  e INT NULL DEFAULT\
+    \ NULL,\n  f VARCHAR(10) NOT NULL COLLATE utf8mb4_polish_ci,\n  g VARCHAR(200)\
+    \ CHARACTER SET utf8mb4 NOT NULL\n);"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "default": "1",
-                  "type": "int"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "default": "NULL",
-                  "type": "varchar",
-                  "comment": "column c"
-                },
-                {
-                  "name": "e",
-                  "position": 4,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "f",
-                  "position": 5,
-                  "type": "varchar",
-                  "collation": "utf8mb4_polish_ci"
-                },
-                {
-                  "name": "g",
-                  "position": 6,
-                  "type": "varchar",
-                  "characterSet": "utf8mb4"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                },
-                {
-                  "name": "b",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"default\": \"1\",\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"nullable\": true,\n              \"type\": \"int\"\n        \
+    \    },\n            {\n              \"name\": \"c\",\n              \"position\"\
+    : 3,\n              \"default\": \"NULL\",\n              \"type\": \"varchar\"\
+    ,\n              \"comment\": \"column c\"\n            },\n            {\n  \
+    \            \"name\": \"e\",\n              \"position\": 4,\n              \"\
+    nullable\": true,\n              \"type\": \"int\"\n            },\n         \
+    \   {\n              \"name\": \"f\",\n              \"position\": 5,\n      \
+    \        \"type\": \"varchar\",\n              \"collation\": \"utf8mb4_polish_ci\"\
+    \n            },\n            {\n              \"name\": \"g\",\n            \
+    \  \"position\": 6,\n              \"type\": \"varchar\",\n              \"characterSet\"\
+    : \"utf8mb4\"\n            }\n          ],\n          \"indexes\": [\n       \
+    \     {\n              \"name\": \"PRIMARY\",\n              \"expressions\":\
+    \ [\n                \"a\"\n              ],\n              \"type\": \"BTREE\"\
+    ,\n              \"unique\": true,\n              \"primary\": true,\n       \
+    \       \"visible\": true\n            },\n            {\n              \"name\"\
+    : \"b\",\n              \"expressions\": [\n                \"b\"\n          \
+    \    ],\n              \"type\": \"BTREE\",\n              \"unique\": true,\n\
+    \              \"visible\": true\n            }\n          ]\n        }\n    \
+    \  ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(
-      id int,
-      name varchar(255),
-      key idx_name(name)
-    );
-    create table t2 (
-      id int,
-      t1_name varchar(255),
-      constraint fk_t1_name foreign key (t1_name) references t1 (name)
-    );
-    alter table t2 drop foreign key fk_t1_name;
+- statement: "CREATE TABLE t1(\n  id int,\n  name varchar(255),\n  key idx_name(name)\n\
+    );\ncreate table t2 (\n  id int,\n  t1_name varchar(255),\n  constraint fk_t1_name\
+    \ foreign key (t1_name) references t1 (name)\n);\nalter table t2 drop foreign\
+    \ key fk_t1_name;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "idx_name",
-                  "expressions": [
-                    "name"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                }
-              ]
-            },
-            {
-              "name": "t2",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int"
-                },
-                {
-                  "name": "t1_name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"id\",\n              \"position\": 1,\n      \
+    \        \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"name\",\n              \"position\"\
+    : 2,\n              \"nullable\": true,\n              \"type\": \"varchar\"\n\
+    \            }\n          ],\n          \"indexes\": [\n            {\n      \
+    \        \"name\": \"idx_name\",\n              \"expressions\": [\n         \
+    \       \"name\"\n              ],\n              \"type\": \"BTREE\",\n     \
+    \         \"visible\": true\n            }\n          ]\n        },\n        {\n\
+    \          \"name\": \"t2\",\n          \"columns\": [\n            {\n      \
+    \        \"name\": \"id\",\n              \"position\": 1,\n              \"nullable\"\
+    : true,\n              \"type\": \"int\"\n            },\n            {\n    \
+    \          \"name\": \"t1_name\",\n              \"position\": 2,\n          \
+    \    \"nullable\": true,\n              \"type\": \"varchar\"\n            }\n\
+    \          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    create table all_types(
-      c1 tinyblob not null,
-      c2 blob not null,
-      c3 mediumblob not null,
-      c4 longblob not null,
-      c5 tinytext not null,
-      c6 text not null,
-      c7 mediumtext not null,
-      c8 longtext not null,
-      c9 json not null,
-      c10 serial not null,
-      c11 long varbinary not null,
-      c12 long varchar not null 
-    );
+- statement: "create table all_types(\n  c1 tinyblob not null,\n  c2 blob not null,\n\
+    \  c3 mediumblob not null,\n  c4 longblob not null,\n  c5 tinytext not null,\n\
+    \  c6 text not null,\n  c7 mediumtext not null,\n  c8 longtext not null,\n  c9\
+    \ json not null,\n  c10 serial not null,\n  c11 long varbinary not null,\n  c12\
+    \ long varchar not null \n);"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "all_types",
-              "columns": [
-                {
-                  "name": "c1",
-                  "position": 1,
-                  "type": "tinyblob"
-                },
-                {
-                  "name": "c2",
-                  "position": 2,
-                  "type": "blob"
-                },
-                {
-                  "name": "c3",
-                  "position": 3,
-                  "type": "mediumblob"
-                },
-                {
-                  "name": "c4",
-                  "position": 4,
-                  "type": "longblob"
-                },
-                {
-                  "name": "c5",
-                  "position": 5,
-                  "type": "tinytext"
-                },
-                {
-                  "name": "c6",
-                  "position": 6,
-                  "type": "text"
-                },
-                {
-                  "name": "c7",
-                  "position": 7,
-                  "type": "mediumtext"
-                },
-                {
-                  "name": "c8",
-                  "position": 8,
-                  "type": "longtext"
-                },
-                {
-                  "name": "c9",
-                  "position": 9,
-                  "type": "json"
-                },
-                {
-                  "name": "c10",
-                  "position": 10,
-                  "type": "serial"
-                },
-                {
-                  "name": "c11",
-                  "position": 11,
-                  "type": "long"
-                },
-                {
-                  "name": "c12",
-                  "position": 12,
-                  "type": "long"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"all_types\",\n          \"columns\": [\n   \
+    \         {\n              \"name\": \"c1\",\n              \"position\": 1,\n\
+    \              \"type\": \"tinyblob\"\n            },\n            {\n       \
+    \       \"name\": \"c2\",\n              \"position\": 2,\n              \"type\"\
+    : \"blob\"\n            },\n            {\n              \"name\": \"c3\",\n \
+    \             \"position\": 3,\n              \"type\": \"mediumblob\"\n     \
+    \       },\n            {\n              \"name\": \"c4\",\n              \"position\"\
+    : 4,\n              \"type\": \"longblob\"\n            },\n            {\n  \
+    \            \"name\": \"c5\",\n              \"position\": 5,\n             \
+    \ \"type\": \"tinytext\"\n            },\n            {\n              \"name\"\
+    : \"c6\",\n              \"position\": 6,\n              \"type\": \"text\"\n\
+    \            },\n            {\n              \"name\": \"c7\",\n            \
+    \  \"position\": 7,\n              \"type\": \"mediumtext\"\n            },\n\
+    \            {\n              \"name\": \"c8\",\n              \"position\": 8,\n\
+    \              \"type\": \"longtext\"\n            },\n            {\n       \
+    \       \"name\": \"c9\",\n              \"position\": 9,\n              \"type\"\
+    : \"json\"\n            },\n            {\n              \"name\": \"c10\",\n\
+    \              \"position\": 10,\n              \"type\": \"serial\"\n       \
+    \     },\n            {\n              \"name\": \"c11\",\n              \"position\"\
+    : 11,\n              \"type\": \"long\"\n            },\n            {\n     \
+    \         \"name\": \"c12\",\n              \"position\": 12,\n              \"\
+    type\": \"long\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n\
+    }"
   err: null

--- a/backend/plugin/advisor/catalog/test/pg_walk_through.yaml
+++ b/backend/plugin/advisor/catalog/test/pg_walk_through.yaml
@@ -1,639 +1,238 @@
 - statement: CREATE TABLE t(a int, b int);
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "integer"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "integer"
-                }
-              ]
-            },
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"t\",\n      \
+    \    \"columns\": [\n            {\n              \"name\": \"a\",\n         \
+    \     \"position\": 1,\n              \"nullable\": true,\n              \"type\"\
+    : \"integer\"\n            },\n            {\n              \"name\": \"b\",\n\
+    \              \"position\": 2,\n              \"nullable\": true,\n         \
+    \     \"type\": \"integer\"\n            }\n          ]\n        },\n        {\n\
+    \          \"name\": \"test\",\n          \"columns\": [\n            {\n    \
+    \          \"name\": \"id\",\n              \"position\": 1,\n              \"\
+    type\": \"int\"\n            },\n            {\n              \"name\": \"name\"\
+    ,\n              \"position\": 2,\n              \"nullable\": true,\n       \
+    \       \"type\": \"varchar(20)\"\n            }\n          ]\n        }\n   \
+    \   ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE public.t(a int, "B" int);
+- statement: 'CREATE TABLE public.t(a int, "B" int);
+
     CREATE INDEX ON t(a, "B");
+
     CREATE UNIQUE INDEX ON t(a, "B");
-    DROP INDEX IF EXISTS t_a_B_idx_11111;
+
+    DROP INDEX IF EXISTS t_a_B_idx_11111;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "integer"
-                },
-                {
-                  "name": "B",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "integer"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "t_a_B_idx",
-                  "expressions": [
-                    "a",
-                    "B"
-                  ],
-                  "type": "btree"
-                },
-                {
-                  "name": "t_a_B_idx1",
-                  "expressions": [
-                    "a",
-                    "B"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                }
-              ]
-            },
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"t\",\n      \
+    \    \"columns\": [\n            {\n              \"name\": \"a\",\n         \
+    \     \"position\": 1,\n              \"nullable\": true,\n              \"type\"\
+    : \"integer\"\n            },\n            {\n              \"name\": \"B\",\n\
+    \              \"position\": 2,\n              \"nullable\": true,\n         \
+    \     \"type\": \"integer\"\n            }\n          ],\n          \"indexes\"\
+    : [\n            {\n              \"name\": \"t_a_B_idx\",\n              \"expressions\"\
+    : [\n                \"a\",\n                \"B\"\n              ],\n       \
+    \       \"type\": \"btree\"\n            },\n            {\n              \"name\"\
+    : \"t_a_B_idx1\",\n              \"expressions\": [\n                \"a\",\n\
+    \                \"B\"\n              ],\n              \"type\": \"btree\",\n\
+    \              \"unique\": true\n            }\n          ]\n        },\n    \
+    \    {\n          \"name\": \"test\",\n          \"columns\": [\n            {\n\
+    \              \"name\": \"id\",\n              \"position\": 1,\n           \
+    \   \"type\": \"int\"\n            },\n            {\n              \"name\":\
+    \ \"name\",\n              \"position\": 2,\n              \"nullable\": true,\n\
+    \              \"type\": \"varchar(20)\"\n            }\n          ]\n       \
+    \ }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE public.t(
-      a int primary key,
-      b int NOT NULL DEFAULT 1,
-      c int UNIQUE,
-      UNIQUE (a, b, c),
-      CONSTRAINT uk_a_b UNIQUE (a, b)
-    )
+- statement: "CREATE TABLE public.t(\n  a int primary key,\n  b int NOT NULL DEFAULT\
+    \ 1,\n  c int UNIQUE,\n  UNIQUE (a, b, c),\n  CONSTRAINT uk_a_b UNIQUE (a, b)\n\
+    )"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "integer"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "default": "1",
-                  "type": "integer"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "integer"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "t_a_b_c_idx",
-                  "expressions": [
-                    "a",
-                    "b",
-                    "c"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                },
-                {
-                  "name": "t_c_idx",
-                  "expressions": [
-                    "c"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                },
-                {
-                  "name": "t_pkey",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "btree",
-                  "unique": true,
-                  "primary": true
-                },
-                {
-                  "name": "uk_a_b",
-                  "expressions": [
-                    "a",
-                    "b"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                }
-              ]
-            },
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"t\",\n      \
+    \    \"columns\": [\n            {\n              \"name\": \"a\",\n         \
+    \     \"position\": 1,\n              \"type\": \"integer\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"default\": \"1\",\n              \"type\": \"integer\"\n    \
+    \        },\n            {\n              \"name\": \"c\",\n              \"position\"\
+    : 3,\n              \"nullable\": true,\n              \"type\": \"integer\"\n\
+    \            }\n          ],\n          \"indexes\": [\n            {\n      \
+    \        \"name\": \"t_a_b_c_idx\",\n              \"expressions\": [\n      \
+    \          \"a\",\n                \"b\",\n                \"c\"\n           \
+    \   ],\n              \"type\": \"btree\",\n              \"unique\": true\n \
+    \           },\n            {\n              \"name\": \"t_c_idx\",\n        \
+    \      \"expressions\": [\n                \"c\"\n              ],\n         \
+    \     \"type\": \"btree\",\n              \"unique\": true\n            },\n \
+    \           {\n              \"name\": \"t_pkey\",\n              \"expressions\"\
+    : [\n                \"a\"\n              ],\n              \"type\": \"btree\"\
+    ,\n              \"unique\": true,\n              \"primary\": true\n        \
+    \    },\n            {\n              \"name\": \"uk_a_b\",\n              \"\
+    expressions\": [\n                \"a\",\n                \"b\"\n            \
+    \  ],\n              \"type\": \"btree\",\n              \"unique\": true\n  \
+    \          }\n          ]\n        },\n        {\n          \"name\": \"test\"\
+    ,\n          \"columns\": [\n            {\n              \"name\": \"id\",\n\
+    \              \"position\": 1,\n              \"type\": \"int\"\n           \
+    \ },\n            {\n              \"name\": \"name\",\n              \"position\"\
+    : 2,\n              \"nullable\": true,\n              \"type\": \"varchar(20)\"\
+    \n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE public.t(
-      a int primary key,
-      b int NOT NULL DEFAULT 1,
-      c int UNIQUE,
-      UNIQUE (a, b, c),
-      CONSTRAINT uk_a_b UNIQUE (a, b)
-    );
-    ALTER TABLE t rename to t1;
-    ALTER TABLE t1 rename column a to a1;
-    alter table t1 rename constraint uk_a_b to ukk_a_b;
-    alter table t1 add column d int;
-    alter table t1 drop column c;
-    alter table t1 alter column b set data type bigint;
-    alter table t1 alter column a1 set default 1;
-    alter table t1 alter column b drop default;
-    alter table t1 alter column d set not null;
-    alter table t1 add constraint uk_d unique (d);
-    alter table t1 add constraint ukk_d unique (d);
-    alter table t1 drop constraint ukk_d;
+- statement: "CREATE TABLE public.t(\n  a int primary key,\n  b int NOT NULL DEFAULT\
+    \ 1,\n  c int UNIQUE,\n  UNIQUE (a, b, c),\n  CONSTRAINT uk_a_b UNIQUE (a, b)\n\
+    );\nALTER TABLE t rename to t1;\nALTER TABLE t1 rename column a to a1;\nalter\
+    \ table t1 rename constraint uk_a_b to ukk_a_b;\nalter table t1 add column d int;\n\
+    alter table t1 drop column c;\nalter table t1 alter column b set data type bigint;\n\
+    alter table t1 alter column a1 set default 1;\nalter table t1 alter column b drop\
+    \ default;\nalter table t1 alter column d set not null;\nalter table t1 add constraint\
+    \ uk_d unique (d);\nalter table t1 add constraint ukk_d unique (d);\nalter table\
+    \ t1 drop constraint ukk_d;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a1",
-                  "position": 1,
-                  "default": "1",
-                  "type": "integer"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "type": "bigint"
-                },
-                {
-                  "name": "d",
-                  "position": 4,
-                  "type": "integer"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "t_pkey",
-                  "expressions": [
-                    "a1"
-                  ],
-                  "type": "btree",
-                  "unique": true,
-                  "primary": true
-                },
-                {
-                  "name": "uk_d",
-                  "expressions": [
-                    "d"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                },
-                {
-                  "name": "ukk_a_b",
-                  "expressions": [
-                    "a1",
-                    "b"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                }
-              ]
-            },
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"t1\",\n     \
+    \     \"columns\": [\n            {\n              \"name\": \"a1\",\n       \
+    \       \"position\": 1,\n              \"default\": \"1\",\n              \"\
+    type\": \"integer\"\n            },\n            {\n              \"name\": \"\
+    b\",\n              \"position\": 2,\n              \"type\": \"bigint\"\n   \
+    \         },\n            {\n              \"name\": \"d\",\n              \"\
+    position\": 4,\n              \"type\": \"integer\"\n            }\n         \
+    \ ],\n          \"indexes\": [\n            {\n              \"name\": \"t_pkey\"\
+    ,\n              \"expressions\": [\n                \"a1\"\n              ],\n\
+    \              \"type\": \"btree\",\n              \"unique\": true,\n       \
+    \       \"primary\": true\n            },\n            {\n              \"name\"\
+    : \"uk_d\",\n              \"expressions\": [\n                \"d\"\n       \
+    \       ],\n              \"type\": \"btree\",\n              \"unique\": true\n\
+    \            },\n            {\n              \"name\": \"ukk_a_b\",\n       \
+    \       \"expressions\": [\n                \"a1\",\n                \"b\"\n \
+    \             ],\n              \"type\": \"btree\",\n              \"unique\"\
+    : true\n            }\n          ]\n        },\n        {\n          \"name\"\
+    : \"test\",\n          \"columns\": [\n            {\n              \"name\":\
+    \ \"id\",\n              \"position\": 1,\n              \"type\": \"int\"\n \
+    \           },\n            {\n              \"name\": \"name\",\n           \
+    \   \"position\": 2,\n              \"nullable\": true,\n              \"type\"\
+    : \"varchar(20)\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n\
+    }"
   err: null
-- statement: |-
-    CREATE TABLE public.t(
-      a int primary key,
-      b int NOT NULL DEFAULT 1,
-      c int UNIQUE,
-      UNIQUE (a, b, c),
-      CONSTRAINT uk_a_b UNIQUE (a, b)
-    );
-    alter index uk_a_b rename to ukk_a_b;
+- statement: "CREATE TABLE public.t(\n  a int primary key,\n  b int NOT NULL DEFAULT\
+    \ 1,\n  c int UNIQUE,\n  UNIQUE (a, b, c),\n  CONSTRAINT uk_a_b UNIQUE (a, b)\n\
+    );\nalter index uk_a_b rename to ukk_a_b;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "integer"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "default": "1",
-                  "type": "integer"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "integer"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "t_a_b_c_idx",
-                  "expressions": [
-                    "a",
-                    "b",
-                    "c"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                },
-                {
-                  "name": "t_c_idx",
-                  "expressions": [
-                    "c"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                },
-                {
-                  "name": "t_pkey",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "btree",
-                  "unique": true,
-                  "primary": true
-                },
-                {
-                  "name": "ukk_a_b",
-                  "expressions": [
-                    "a",
-                    "b"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                }
-              ]
-            },
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"t\",\n      \
+    \    \"columns\": [\n            {\n              \"name\": \"a\",\n         \
+    \     \"position\": 1,\n              \"type\": \"integer\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"default\": \"1\",\n              \"type\": \"integer\"\n    \
+    \        },\n            {\n              \"name\": \"c\",\n              \"position\"\
+    : 3,\n              \"nullable\": true,\n              \"type\": \"integer\"\n\
+    \            }\n          ],\n          \"indexes\": [\n            {\n      \
+    \        \"name\": \"t_a_b_c_idx\",\n              \"expressions\": [\n      \
+    \          \"a\",\n                \"b\",\n                \"c\"\n           \
+    \   ],\n              \"type\": \"btree\",\n              \"unique\": true\n \
+    \           },\n            {\n              \"name\": \"t_c_idx\",\n        \
+    \      \"expressions\": [\n                \"c\"\n              ],\n         \
+    \     \"type\": \"btree\",\n              \"unique\": true\n            },\n \
+    \           {\n              \"name\": \"t_pkey\",\n              \"expressions\"\
+    : [\n                \"a\"\n              ],\n              \"type\": \"btree\"\
+    ,\n              \"unique\": true,\n              \"primary\": true\n        \
+    \    },\n            {\n              \"name\": \"ukk_a_b\",\n              \"\
+    expressions\": [\n                \"a\",\n                \"b\"\n            \
+    \  ],\n              \"type\": \"btree\",\n              \"unique\": true\n  \
+    \          }\n          ]\n        },\n        {\n          \"name\": \"test\"\
+    ,\n          \"columns\": [\n            {\n              \"name\": \"id\",\n\
+    \              \"position\": 1,\n              \"type\": \"int\"\n           \
+    \ },\n            {\n              \"name\": \"name\",\n              \"position\"\
+    : 2,\n              \"nullable\": true,\n              \"type\": \"varchar(20)\"\
+    \n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE public.t(
-      a int primary key,
-      b int NOT NULL DEFAULT 1,
-      c int UNIQUE,
-      UNIQUE (a, b, c),
-      CONSTRAINT uk_a_b UNIQUE (a, b)
-    );
-    drop index uk_a_b;
+- statement: "CREATE TABLE public.t(\n  a int primary key,\n  b int NOT NULL DEFAULT\
+    \ 1,\n  c int UNIQUE,\n  UNIQUE (a, b, c),\n  CONSTRAINT uk_a_b UNIQUE (a, b)\n\
+    );\ndrop index uk_a_b;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "integer"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "default": "1",
-                  "type": "integer"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "integer"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "t_a_b_c_idx",
-                  "expressions": [
-                    "a",
-                    "b",
-                    "c"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                },
-                {
-                  "name": "t_c_idx",
-                  "expressions": [
-                    "c"
-                  ],
-                  "type": "btree",
-                  "unique": true
-                },
-                {
-                  "name": "t_pkey",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "btree",
-                  "unique": true,
-                  "primary": true
-                }
-              ]
-            },
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"t\",\n      \
+    \    \"columns\": [\n            {\n              \"name\": \"a\",\n         \
+    \     \"position\": 1,\n              \"type\": \"integer\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"default\": \"1\",\n              \"type\": \"integer\"\n    \
+    \        },\n            {\n              \"name\": \"c\",\n              \"position\"\
+    : 3,\n              \"nullable\": true,\n              \"type\": \"integer\"\n\
+    \            }\n          ],\n          \"indexes\": [\n            {\n      \
+    \        \"name\": \"t_a_b_c_idx\",\n              \"expressions\": [\n      \
+    \          \"a\",\n                \"b\",\n                \"c\"\n           \
+    \   ],\n              \"type\": \"btree\",\n              \"unique\": true\n \
+    \           },\n            {\n              \"name\": \"t_c_idx\",\n        \
+    \      \"expressions\": [\n                \"c\"\n              ],\n         \
+    \     \"type\": \"btree\",\n              \"unique\": true\n            },\n \
+    \           {\n              \"name\": \"t_pkey\",\n              \"expressions\"\
+    : [\n                \"a\"\n              ],\n              \"type\": \"btree\"\
+    ,\n              \"unique\": true,\n              \"primary\": true\n        \
+    \    }\n          ]\n        },\n        {\n          \"name\": \"test\",\n  \
+    \        \"columns\": [\n            {\n              \"name\": \"id\",\n    \
+    \          \"position\": 1,\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"name\",\n              \"position\"\
+    : 2,\n              \"nullable\": true,\n              \"type\": \"varchar(20)\"\
+    \n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE public.t(
-      a int primary key,
-      b int NOT NULL DEFAULT 1,
-      c int UNIQUE,
-      UNIQUE (a, b, c),
-      CONSTRAINT uk_a_b UNIQUE (a, b)
-    );
-    drop table t;
+- statement: "CREATE TABLE public.t(\n  a int primary key,\n  b int NOT NULL DEFAULT\
+    \ 1,\n  c int UNIQUE,\n  UNIQUE (a, b, c),\n  CONSTRAINT uk_a_b UNIQUE (a, b)\n\
+    );\ndrop table t;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"test\",\n   \
+    \       \"columns\": [\n            {\n              \"name\": \"id\",\n     \
+    \         \"position\": 1,\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"name\",\n              \"position\"\
+    : 2,\n              \"nullable\": true,\n              \"type\": \"varchar(20)\"\
+    \n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE public.t(
-      a int primary key,
-      b int NOT NULL DEFAULT 1,
-      c int UNIQUE,
-      UNIQUE (a, b, c),
-      CONSTRAINT uk_a_b UNIQUE (a, b)
-    );
-    drop schema public;
+- statement: "CREATE TABLE public.t(\n  a int primary key,\n  b int NOT NULL DEFAULT\
+    \ 1,\n  c int UNIQUE,\n  UNIQUE (a, b, c),\n  CONSTRAINT uk_a_b UNIQUE (a, b)\n\
+    );\ndrop schema public;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres"
-    }
+  want: "{\n  \"name\": \"postgres\"\n}"
   err: null
 - statement: ALTER TABLE test DROP COLUMN id;
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 408
-    content: 'Cannot drop column "id" in table "public"."test", it''s referenced by view: "public"."v1"'
+    code: 421
+    content: 'Cannot drop column "id" in table "public"."test", it''s referenced by
+      view: "public"."v1"'
     line: 1
-    payload:
-      - '"public"."v1"'
 - statement: ALTER TABLE test ALTER COLUMN id TYPE varchar(20);
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 408
-    content: 'Cannot alter type of column "id" in table "public"."test", it''s referenced by view: "public"."v1"'
+    code: 421
+    content: 'Cannot alter type of column "id" in table "public"."test", it''s referenced
+      by view: "public"."v1"'
     line: 1
-    payload:
-      - '"public"."v1"'
 - statement: DROP TABLE test;
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 304
+    code: 609
     content: 'Cannot drop table "public"."test", it''s referenced by view: "public"."v1"'
     line: 1
-    payload:
-      - '"public"."v1"'
-- statement: |-
-    DROP VIEW v1;
-    ALTER TABLE test DROP COLUMN id;
+- statement: 'DROP VIEW v1;
+
+    ALTER TABLE test DROP COLUMN id;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"test\",\n   \
+    \       \"columns\": [\n            {\n              \"name\": \"name\",\n   \
+    \           \"position\": 2,\n              \"nullable\": true,\n            \
+    \  \"type\": \"varchar(20)\"\n            }\n          ]\n        }\n      ]\n\
+    \    }\n  ]\n}"
   err: null
-- statement: |-
-    create view v1 as select * from t;
+- statement: 'create view v1 as select * from t;
+
     alter view v1 rename to this_is_view_del;
-    drop view this_is_view_del;
+
+    drop view this_is_view_del;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "postgres",
-      "schemas": [
-        {
-          "name": "public",
-          "tables": [
-            {
-              "name": "test",
-              "columns": [
-                {
-                  "name": "id",
-                  "position": 1,
-                  "type": "int"
-                },
-                {
-                  "name": "name",
-                  "position": 2,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"postgres\",\n  \"schemas\": [\n    {\n      \"name\": \"\
+    public\",\n      \"tables\": [\n        {\n          \"name\": \"test\",\n   \
+    \       \"columns\": [\n            {\n              \"name\": \"id\",\n     \
+    \         \"position\": 1,\n              \"type\": \"int\"\n            },\n\
+    \            {\n              \"name\": \"name\",\n              \"position\"\
+    : 2,\n              \"nullable\": true,\n              \"type\": \"varchar(20)\"\
+    \n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null

--- a/backend/plugin/advisor/catalog/test/tidb_walk_through.yaml
+++ b/backend/plugin/advisor/catalog/test/tidb_walk_through.yaml
@@ -1,843 +1,386 @@
 - statement: CREATE TABLE t(a date default '');
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 407
+    code: 423
     content: '[types:1292]Incorrect datetime value: '''''
     line: 1
-    payload: null
-- statement: |-
-    CREATE TABLE t(a TEXT);
-    ALTER TABLE T ALTER COLUMN a SET DEFAULT '1';
+- statement: 'CREATE TABLE t(a TEXT);
+
+    ALTER TABLE T ALTER COLUMN a SET DEFAULT ''1'';'
   ignore_case_sensitive: true
-  want: ""
+  want: ''
   err:
-    type: 407
+    code: 423
     content: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
     line: 2
-    payload: null
 - statement: '      CREATE TABLE t(a TEXT DEFAULT ''1'')'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 407
+    code: 423
     content: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
     line: 1
-    payload: null
-- statement: |-
-    CREATE TABLE t(a INT NOT NULL);
-    ALTER TABLE t ALTER COLUMN a SET DEFAULT NULL;
+- statement: 'CREATE TABLE t(a INT NOT NULL);
+
+    ALTER TABLE t ALTER COLUMN a SET DEFAULT NULL;'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 406
+    code: 428
     content: Invalid default value for column `a`
     line: 2
-    payload: null
 - statement: '      CREATE TABLE t(a INT NOT NULL DEFAULT NULL)'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 406
+    code: 428
     content: Invalid default value for column `a`
     line: 1
-    payload: null
 - statement: '      CREATE TABLE t(a int ON UPDATE NOW())'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 405
+    code: 427
     content: Column `a` use ON UPDATE but is not DATETIME or TIMESTAMP
     line: 1
-    payload: null
 - statement: '      CREATE TABLE t(a int auto_increment, b int auto_increment);'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 404
+    code: 426
     content: There can be only one auto column for table `t`
     line: 1
-    payload: null
 - statement: '      CREATE TABLE t as select * from t1;'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 303
-    content: Disallow the CREATE TABLE AS statement but "CREATE TABLE t as select * from t1;" uses
+    code: 205
+    content: Disallow the CREATE TABLE AS statement but "CREATE TABLE t as select
+      * from t1;" uses
     line: 1
-    payload: null
-- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tCREATE INDEX idx_c on t(c);\n\t\t\t"
+- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tCREATE INDEX idx_c\
+    \ on t(c);\n\t\t\t"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 402
+    code: 405
     content: Column `c` does not exist in table `t`
     line: 3
-    payload: null
-- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t MODIFY COLUMN c int;\n\t\t\t"
+- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t MODIFY\
+    \ COLUMN c int;\n\t\t\t"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 402
+    code: 405
     content: Column `c` does not exist in table `t`
     line: 3
-    payload: null
-- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t CHANGE COLUMN c aa int;\n\t\t\t"
+- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t CHANGE\
+    \ COLUMN c aa int;\n\t\t\t"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 402
+    code: 405
     content: Column `c` does not exist in table `t`
     line: 3
-    payload: null
-- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t DROP COLUMN c;\n\t\t\t"
+- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t DROP\
+    \ COLUMN c;\n\t\t\t"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 402
+    code: 405
     content: Column `c` does not exist in table `t`
     line: 3
-    payload: null
-- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t RENAME COLUMN c TO cc;\n\t\t\t"
+- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t RENAME\
+    \ COLUMN c TO cc;\n\t\t\t"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 402
+    code: 405
     content: Column `c` does not exist in table `t`
     line: 3
-    payload: null
-- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t RENAME COLUMN c TO cc;\n\t\t\t"
+- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t RENAME\
+    \ COLUMN c TO cc;\n\t\t\t"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 402
+    code: 405
     content: Column `c` does not exist in table `t`
     line: 3
-    payload: null
-- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t ALTER COLUMN c DROP DEFAULT;\n\t\t\t"
+- statement: "\n\t\t\t\tCREATE TABLE t(a int, b int); \n\t\t\t\tALTER TABLE t ALTER\
+    \ COLUMN c DROP DEFAULT;\n\t\t\t"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 402
+    code: 405
     content: Column `c` does not exist in table `t`
     line: 3
-    payload: null
-- statement: |-
-    ALTER DATABASE CHARACTER SET = utf8mb4;
-    ALTER DATABASE test COLLATE utf8mb4_polish_ci;
+- statement: 'ALTER DATABASE CHARACTER SET = utf8mb4;
+
+    ALTER DATABASE test COLLATE utf8mb4_polish_ci;'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {}
-      ],
-      "characterSet": "utf8mb4",
-      "collation": "utf8mb4_polish_ci"
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {}\n  ],\n  \"characterSet\"\
+    : \"utf8mb4\",\n  \"collation\": \"utf8mb4_polish_ci\"\n}"
   err: null
-- statement: |-
-    CREATE TABLE t(
-      a int PRIMARY KEY DEFAULT 1,
-      b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE,
-      c int auto_increment NULL COMMENT 'This is a comment' DEFAULT NULL,
-      d varchar(10) COLLATE utf8mb4_polish_ci,
-      KEY idx_a (a),
-      INDEX (b, a),
-      UNIQUE (b, c, d),
-      FULLTEXT (b, d) WITH PARSER ngram INVISIBLE
-    );
-    CREATE TABLE t_copy like t;
+- statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
+    \ SET utf8mb4 NOT NULL UNIQUE,\n  c int auto_increment NULL COMMENT 'This is a\
+    \ comment' DEFAULT NULL,\n  d varchar(10) COLLATE utf8mb4_polish_ci,\n  KEY idx_a\
+    \ (a),\n  INDEX (b, a),\n  UNIQUE (b, c, d),\n  FULLTEXT (b, d) WITH PARSER ngram\
+    \ INVISIBLE\n);\nCREATE TABLE t_copy like t;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "default": "1",
-                  "type": "int(11)"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "type": "varchar(200)",
-                  "characterSet": "utf8mb4"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "int(11)",
-                  "comment": "This is a comment"
-                },
-                {
-                  "name": "d",
-                  "position": 4,
-                  "nullable": true,
-                  "type": "varchar(10)",
-                  "collation": "utf8mb4_polish_ci"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                },
-                {
-                  "name": "b",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_2",
-                  "expressions": [
-                    "b",
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                },
-                {
-                  "name": "b_3",
-                  "expressions": [
-                    "b",
-                    "c",
-                    "d"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_4",
-                  "expressions": [
-                    "b",
-                    "d"
-                  ],
-                  "type": "FULLTEXT"
-                },
-                {
-                  "name": "idx_a",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                }
-              ]
-            },
-            {
-              "name": "t_copy",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "default": "1",
-                  "type": "int(11)"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "type": "varchar(200)",
-                  "characterSet": "utf8mb4"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "int(11)",
-                  "comment": "This is a comment"
-                },
-                {
-                  "name": "d",
-                  "position": 4,
-                  "nullable": true,
-                  "type": "varchar(10)",
-                  "collation": "utf8mb4_polish_ci"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                },
-                {
-                  "name": "b",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_2",
-                  "expressions": [
-                    "b",
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                },
-                {
-                  "name": "b_3",
-                  "expressions": [
-                    "b",
-                    "c",
-                    "d"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_4",
-                  "expressions": [
-                    "b",
-                    "d"
-                  ],
-                  "type": "FULLTEXT"
-                },
-                {
-                  "name": "idx_a",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t\",\n          \"columns\": [\n           \
+    \ {\n              \"name\": \"a\",\n              \"position\": 1,\n        \
+    \      \"default\": \"1\",\n              \"type\": \"int(11)\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"type\": \"varchar(200)\",\n              \"characterSet\": \"\
+    utf8mb4\"\n            },\n            {\n              \"name\": \"c\",\n   \
+    \           \"position\": 3,\n              \"nullable\": true,\n            \
+    \  \"type\": \"int(11)\",\n              \"comment\": \"This is a comment\"\n\
+    \            },\n            {\n              \"name\": \"d\",\n             \
+    \ \"position\": 4,\n              \"nullable\": true,\n              \"type\"\
+    : \"varchar(10)\",\n              \"collation\": \"utf8mb4_polish_ci\"\n     \
+    \       }\n          ],\n          \"indexes\": [\n            {\n           \
+    \   \"name\": \"PRIMARY\",\n              \"expressions\": [\n               \
+    \ \"a\"\n              ],\n              \"type\": \"BTREE\",\n              \"\
+    unique\": true,\n              \"primary\": true,\n              \"visible\":\
+    \ true\n            },\n            {\n              \"name\": \"b\",\n      \
+    \        \"expressions\": [\n                \"b\"\n              ],\n       \
+    \       \"type\": \"BTREE\",\n              \"unique\": true,\n              \"\
+    visible\": true\n            },\n            {\n              \"name\": \"b_2\"\
+    ,\n              \"expressions\": [\n                \"b\",\n                \"\
+    a\"\n              ],\n              \"type\": \"BTREE\",\n              \"visible\"\
+    : true\n            },\n            {\n              \"name\": \"b_3\",\n    \
+    \          \"expressions\": [\n                \"b\",\n                \"c\",\n\
+    \                \"d\"\n              ],\n              \"type\": \"BTREE\",\n\
+    \              \"unique\": true,\n              \"visible\": true\n          \
+    \  },\n            {\n              \"name\": \"b_4\",\n              \"expressions\"\
+    : [\n                \"b\",\n                \"d\"\n              ],\n       \
+    \       \"type\": \"FULLTEXT\"\n            },\n            {\n              \"\
+    name\": \"idx_a\",\n              \"expressions\": [\n                \"a\"\n\
+    \              ],\n              \"type\": \"BTREE\",\n              \"visible\"\
+    : true\n            }\n          ]\n        },\n        {\n          \"name\"\
+    : \"t_copy\",\n          \"columns\": [\n            {\n              \"name\"\
+    : \"a\",\n              \"position\": 1,\n              \"default\": \"1\",\n\
+    \              \"type\": \"int(11)\"\n            },\n            {\n        \
+    \      \"name\": \"b\",\n              \"position\": 2,\n              \"type\"\
+    : \"varchar(200)\",\n              \"characterSet\": \"utf8mb4\"\n           \
+    \ },\n            {\n              \"name\": \"c\",\n              \"position\"\
+    : 3,\n              \"nullable\": true,\n              \"type\": \"int(11)\",\n\
+    \              \"comment\": \"This is a comment\"\n            },\n          \
+    \  {\n              \"name\": \"d\",\n              \"position\": 4,\n       \
+    \       \"nullable\": true,\n              \"type\": \"varchar(10)\",\n      \
+    \        \"collation\": \"utf8mb4_polish_ci\"\n            }\n          ],\n \
+    \         \"indexes\": [\n            {\n              \"name\": \"PRIMARY\",\n\
+    \              \"expressions\": [\n                \"a\"\n              ],\n \
+    \             \"type\": \"BTREE\",\n              \"unique\": true,\n        \
+    \      \"primary\": true,\n              \"visible\": true\n            },\n \
+    \           {\n              \"name\": \"b\",\n              \"expressions\":\
+    \ [\n                \"b\"\n              ],\n              \"type\": \"BTREE\"\
+    ,\n              \"unique\": true,\n              \"visible\": true\n        \
+    \    },\n            {\n              \"name\": \"b_2\",\n              \"expressions\"\
+    : [\n                \"b\",\n                \"a\"\n              ],\n       \
+    \       \"type\": \"BTREE\",\n              \"visible\": true\n            },\n\
+    \            {\n              \"name\": \"b_3\",\n              \"expressions\"\
+    : [\n                \"b\",\n                \"c\",\n                \"d\"\n \
+    \             ],\n              \"type\": \"BTREE\",\n              \"unique\"\
+    : true,\n              \"visible\": true\n            },\n            {\n    \
+    \          \"name\": \"b_4\",\n              \"expressions\": [\n            \
+    \    \"b\",\n                \"d\"\n              ],\n              \"type\":\
+    \ \"FULLTEXT\"\n            },\n            {\n              \"name\": \"idx_a\"\
+    ,\n              \"expressions\": [\n                \"a\"\n              ],\n\
+    \              \"type\": \"BTREE\",\n              \"visible\": true\n       \
+    \     }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t(
-      a int PRIMARY KEY DEFAULT 1,
-      b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE,
-      c int auto_increment NULL COMMENT 'This is a comment',
-      d varchar(10) COLLATE utf8mb4_polish_ci,
-      KEY idx_a (a),
-      INDEX (b, a),
-      UNIQUE (b, c, d),
-      FULLTEXT (b, d) WITH PARSER ngram INVISIBLE
-    )
+- statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
+    \ SET utf8mb4 NOT NULL UNIQUE,\n  c int auto_increment NULL COMMENT 'This is a\
+    \ comment',\n  d varchar(10) COLLATE utf8mb4_polish_ci,\n  KEY idx_a (a),\n  INDEX\
+    \ (b, a),\n  UNIQUE (b, c, d),\n  FULLTEXT (b, d) WITH PARSER ngram INVISIBLE\n\
+    )"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "default": "1",
-                  "type": "int(11)"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "type": "varchar(200)",
-                  "characterSet": "utf8mb4"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "int(11)",
-                  "comment": "This is a comment"
-                },
-                {
-                  "name": "d",
-                  "position": 4,
-                  "nullable": true,
-                  "type": "varchar(10)",
-                  "collation": "utf8mb4_polish_ci"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                },
-                {
-                  "name": "b",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_2",
-                  "expressions": [
-                    "b",
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                },
-                {
-                  "name": "b_3",
-                  "expressions": [
-                    "b",
-                    "c",
-                    "d"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_4",
-                  "expressions": [
-                    "b",
-                    "d"
-                  ],
-                  "type": "FULLTEXT"
-                },
-                {
-                  "name": "idx_a",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t\",\n          \"columns\": [\n           \
+    \ {\n              \"name\": \"a\",\n              \"position\": 1,\n        \
+    \      \"default\": \"1\",\n              \"type\": \"int(11)\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"type\": \"varchar(200)\",\n              \"characterSet\": \"\
+    utf8mb4\"\n            },\n            {\n              \"name\": \"c\",\n   \
+    \           \"position\": 3,\n              \"nullable\": true,\n            \
+    \  \"type\": \"int(11)\",\n              \"comment\": \"This is a comment\"\n\
+    \            },\n            {\n              \"name\": \"d\",\n             \
+    \ \"position\": 4,\n              \"nullable\": true,\n              \"type\"\
+    : \"varchar(10)\",\n              \"collation\": \"utf8mb4_polish_ci\"\n     \
+    \       }\n          ],\n          \"indexes\": [\n            {\n           \
+    \   \"name\": \"PRIMARY\",\n              \"expressions\": [\n               \
+    \ \"a\"\n              ],\n              \"type\": \"BTREE\",\n              \"\
+    unique\": true,\n              \"primary\": true,\n              \"visible\":\
+    \ true\n            },\n            {\n              \"name\": \"b\",\n      \
+    \        \"expressions\": [\n                \"b\"\n              ],\n       \
+    \       \"type\": \"BTREE\",\n              \"unique\": true,\n              \"\
+    visible\": true\n            },\n            {\n              \"name\": \"b_2\"\
+    ,\n              \"expressions\": [\n                \"b\",\n                \"\
+    a\"\n              ],\n              \"type\": \"BTREE\",\n              \"visible\"\
+    : true\n            },\n            {\n              \"name\": \"b_3\",\n    \
+    \          \"expressions\": [\n                \"b\",\n                \"c\",\n\
+    \                \"d\"\n              ],\n              \"type\": \"BTREE\",\n\
+    \              \"unique\": true,\n              \"visible\": true\n          \
+    \  },\n            {\n              \"name\": \"b_4\",\n              \"expressions\"\
+    : [\n                \"b\",\n                \"d\"\n              ],\n       \
+    \       \"type\": \"FULLTEXT\"\n            },\n            {\n              \"\
+    name\": \"idx_a\",\n              \"expressions\": [\n                \"a\"\n\
+    \              ],\n              \"type\": \"BTREE\",\n              \"visible\"\
+    : true\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t(
-      a int,
-      b int,
-      PRIMARY KEY (a, b)
-    )
+- statement: "CREATE TABLE t(\n  a int,\n  b int,\n  PRIMARY KEY (a, b)\n)"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "type": "int(11)"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "type": "int(11)"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a",
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t\",\n          \"columns\": [\n           \
+    \ {\n              \"name\": \"a\",\n              \"position\": 1,\n        \
+    \      \"type\": \"int(11)\"\n            },\n            {\n              \"\
+    name\": \"b\",\n              \"position\": 2,\n              \"type\": \"int(11)\"\
+    \n            }\n          ],\n          \"indexes\": [\n            {\n     \
+    \         \"name\": \"PRIMARY\",\n              \"expressions\": [\n         \
+    \       \"a\",\n                \"b\"\n              ],\n              \"type\"\
+    : \"BTREE\",\n              \"unique\": true,\n              \"primary\": true,\n\
+    \              \"visible\": true\n            }\n          ]\n        }\n    \
+    \  ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t1(a int, b int, c int);
+- statement: 'CREATE TABLE t1(a int, b int, c int);
+
     CREATE TABLE t2(a int);
-    DROP TABLE t1, t2
+
+    DROP TABLE t1, t2'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {}
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {}\n  ]\n}"
   err: null
 - statement: '      DROP TABLE t1, t2'
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 302
+    code: 604
     content: Table `t1` does not exist
     line: 1
-    payload: null
-- statement: |-
-    CREATE TABLE t(a int);
-    RENAME TABLE t to other_db.t1
+- statement: 'CREATE TABLE t(a int);
+
+    RENAME TABLE t to other_db.t1'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {}
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {}\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t(a int);
-    RENAME TABLE t to test.t1
+- statement: 'CREATE TABLE t(a int);
+
+    RENAME TABLE t to test.t1'
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t1",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "int(11)"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
+    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
+    \       \"nullable\": true,\n              \"type\": \"int(11)\"\n           \
+    \ }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    -- this is comment
-            DROP DATABASE test;
-            CREATE TABLE t(a int);
+- statement: "-- this is comment\n        DROP DATABASE test;\n        CREATE TABLE\
+    \ t(a int);"
   ignore_case_sensitive: false
-  want: ""
+  want: ''
   err:
-    type: 202
+    code: 703
     content: Database `test` is deleted
     line: 3
-    payload: null
-- statement: |-
-    CREATE TABLE t(
-      a int PRIMARY KEY DEFAULT 1,
-      b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE,
-      c int auto_increment NULL COMMENT 'This is a comment',
-      d varchar(10) COLLATE utf8mb4_polish_ci,
-      e int,
-      KEY idx_a (a),
-      INDEX (b, a),
-      UNIQUE (b, c, d),
-      FULLTEXT (b, d) WITH PARSER ngram INVISIBLE
-    );
-    ALTER TABLE t COLLATE utf8mb4_0900_ai_ci, ENGINE = INNODB, COMMENT 'This is a table comment';
-    ALTER TABLE t ADD COLUMN a1 int AFTER a;
-    ALTER TABLE t ADD INDEX idx_a_b (a, b);
-    ALTER TABLE t DROP COLUMN c;
-    ALTER TABLE t DROP PRIMARY KEY;
-    ALTER TABLE t DROP INDEX b_2;
-    ALTER TABLE t MODIFY COLUMN b varchar(20) FIRST;
-    ALTER TABLE t CHANGE COLUMN d d_copy varchar(10) COLLATE utf8mb4_polish_ci;
-    ALTER TABLE t RENAME COLUMN a to a_copy;
-    ALTER TABLE t RENAME TO t_copy;
-    ALTER TABLE t_copy ALTER COLUMN a_copy DROP DEFAULT;
-    ALTER TABLE t_copy RENAME INDEX b TO idx_b;
-    ALTER TABLE t_copy ALTER INDEX b_3 INVISIBLE;
+- statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
+    \ SET utf8mb4 NOT NULL UNIQUE,\n  c int auto_increment NULL COMMENT 'This is a\
+    \ comment',\n  d varchar(10) COLLATE utf8mb4_polish_ci,\n  e int,\n  KEY idx_a\
+    \ (a),\n  INDEX (b, a),\n  UNIQUE (b, c, d),\n  FULLTEXT (b, d) WITH PARSER ngram\
+    \ INVISIBLE\n);\nALTER TABLE t COLLATE utf8mb4_0900_ai_ci, ENGINE = INNODB, COMMENT\
+    \ 'This is a table comment';\nALTER TABLE t ADD COLUMN a1 int AFTER a;\nALTER\
+    \ TABLE t ADD INDEX idx_a_b (a, b);\nALTER TABLE t DROP COLUMN c;\nALTER TABLE\
+    \ t DROP PRIMARY KEY;\nALTER TABLE t DROP INDEX b_2;\nALTER TABLE t MODIFY COLUMN\
+    \ b varchar(20) FIRST;\nALTER TABLE t CHANGE COLUMN d d_copy varchar(10) COLLATE\
+    \ utf8mb4_polish_ci;\nALTER TABLE t RENAME COLUMN a to a_copy;\nALTER TABLE t\
+    \ RENAME TO t_copy;\nALTER TABLE t_copy ALTER COLUMN a_copy DROP DEFAULT;\nALTER\
+    \ TABLE t_copy RENAME INDEX b TO idx_b;\nALTER TABLE t_copy ALTER INDEX b_3 INVISIBLE;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t_copy",
-              "columns": [
-                {
-                  "name": "b",
-                  "position": 1,
-                  "nullable": true,
-                  "type": "varchar(20)"
-                },
-                {
-                  "name": "a_copy",
-                  "position": 2,
-                  "type": "int(11)"
-                },
-                {
-                  "name": "a1",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "int(11)"
-                },
-                {
-                  "name": "d_copy",
-                  "position": 4,
-                  "nullable": true,
-                  "type": "varchar(10)",
-                  "collation": "utf8mb4_polish_ci"
-                },
-                {
-                  "name": "e",
-                  "position": 5,
-                  "nullable": true,
-                  "type": "int(11)"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "b_3",
-                  "expressions": [
-                    "b",
-                    "d_copy"
-                  ],
-                  "type": "BTREE",
-                  "unique": true
-                },
-                {
-                  "name": "b_4",
-                  "expressions": [
-                    "b",
-                    "d_copy"
-                  ],
-                  "type": "FULLTEXT"
-                },
-                {
-                  "name": "idx_a",
-                  "expressions": [
-                    "a_copy"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                },
-                {
-                  "name": "idx_a_b",
-                  "expressions": [
-                    "a_copy",
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                },
-                {
-                  "name": "idx_b",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                }
-              ],
-              "engine": "INNODB",
-              "collation": "utf8mb4_0900_ai_ci",
-              "comment": "This is a table comment"
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t_copy\",\n          \"columns\": [\n      \
+    \      {\n              \"name\": \"b\",\n              \"position\": 1,\n   \
+    \           \"nullable\": true,\n              \"type\": \"varchar(20)\"\n   \
+    \         },\n            {\n              \"name\": \"a_copy\",\n           \
+    \   \"position\": 2,\n              \"type\": \"int(11)\"\n            },\n  \
+    \          {\n              \"name\": \"a1\",\n              \"position\": 3,\n\
+    \              \"nullable\": true,\n              \"type\": \"int(11)\"\n    \
+    \        },\n            {\n              \"name\": \"d_copy\",\n            \
+    \  \"position\": 4,\n              \"nullable\": true,\n              \"type\"\
+    : \"varchar(10)\",\n              \"collation\": \"utf8mb4_polish_ci\"\n     \
+    \       },\n            {\n              \"name\": \"e\",\n              \"position\"\
+    : 5,\n              \"nullable\": true,\n              \"type\": \"int(11)\"\n\
+    \            }\n          ],\n          \"indexes\": [\n            {\n      \
+    \        \"name\": \"b_3\",\n              \"expressions\": [\n              \
+    \  \"b\",\n                \"d_copy\"\n              ],\n              \"type\"\
+    : \"BTREE\",\n              \"unique\": true\n            },\n            {\n\
+    \              \"name\": \"b_4\",\n              \"expressions\": [\n        \
+    \        \"b\",\n                \"d_copy\"\n              ],\n              \"\
+    type\": \"FULLTEXT\"\n            },\n            {\n              \"name\": \"\
+    idx_a\",\n              \"expressions\": [\n                \"a_copy\"\n     \
+    \         ],\n              \"type\": \"BTREE\",\n              \"visible\": true\n\
+    \            },\n            {\n              \"name\": \"idx_a_b\",\n       \
+    \       \"expressions\": [\n                \"a_copy\",\n                \"b\"\
+    \n              ],\n              \"type\": \"BTREE\",\n              \"visible\"\
+    : true\n            },\n            {\n              \"name\": \"idx_b\",\n  \
+    \            \"expressions\": [\n                \"b\"\n              ],\n   \
+    \           \"type\": \"BTREE\",\n              \"unique\": true,\n          \
+    \    \"visible\": true\n            }\n          ],\n          \"engine\": \"\
+    INNODB\",\n          \"collation\": \"utf8mb4_0900_ai_ci\",\n          \"comment\"\
+    : \"This is a table comment\"\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t(
-      a int PRIMARY KEY DEFAULT 1,
-      b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE,
-      c int auto_increment NULL COMMENT 'This is a comment',
-      d varchar(10) COLLATE utf8mb4_polish_ci
-    );
-    CREATE INDEX idx_a on t(a);
-    CREATE INDEX b_2 on t(b, a);
-    CREATE UNIQUE INDEX b_3 on t(b, c, d);
-    CREATE FULLTEXT INDEX b_4 on t(b, d) WITH PARSER ngram INVISIBLE;
+- statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
+    \ SET utf8mb4 NOT NULL UNIQUE,\n  c int auto_increment NULL COMMENT 'This is a\
+    \ comment',\n  d varchar(10) COLLATE utf8mb4_polish_ci\n);\nCREATE INDEX idx_a\
+    \ on t(a);\nCREATE INDEX b_2 on t(b, a);\nCREATE UNIQUE INDEX b_3 on t(b, c, d);\n\
+    CREATE FULLTEXT INDEX b_4 on t(b, d) WITH PARSER ngram INVISIBLE;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "default": "1",
-                  "type": "int(11)"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "type": "varchar(200)",
-                  "characterSet": "utf8mb4"
-                },
-                {
-                  "name": "c",
-                  "position": 3,
-                  "nullable": true,
-                  "type": "int(11)",
-                  "comment": "This is a comment"
-                },
-                {
-                  "name": "d",
-                  "position": 4,
-                  "nullable": true,
-                  "type": "varchar(10)",
-                  "collation": "utf8mb4_polish_ci"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                },
-                {
-                  "name": "b",
-                  "expressions": [
-                    "b"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_2",
-                  "expressions": [
-                    "b",
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                },
-                {
-                  "name": "b_3",
-                  "expressions": [
-                    "b",
-                    "c",
-                    "d"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "visible": true
-                },
-                {
-                  "name": "b_4",
-                  "expressions": [
-                    "b",
-                    "d"
-                  ],
-                  "type": "FULLTEXT"
-                },
-                {
-                  "name": "idx_a",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t\",\n          \"columns\": [\n           \
+    \ {\n              \"name\": \"a\",\n              \"position\": 1,\n        \
+    \      \"default\": \"1\",\n              \"type\": \"int(11)\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"type\": \"varchar(200)\",\n              \"characterSet\": \"\
+    utf8mb4\"\n            },\n            {\n              \"name\": \"c\",\n   \
+    \           \"position\": 3,\n              \"nullable\": true,\n            \
+    \  \"type\": \"int(11)\",\n              \"comment\": \"This is a comment\"\n\
+    \            },\n            {\n              \"name\": \"d\",\n             \
+    \ \"position\": 4,\n              \"nullable\": true,\n              \"type\"\
+    : \"varchar(10)\",\n              \"collation\": \"utf8mb4_polish_ci\"\n     \
+    \       }\n          ],\n          \"indexes\": [\n            {\n           \
+    \   \"name\": \"PRIMARY\",\n              \"expressions\": [\n               \
+    \ \"a\"\n              ],\n              \"type\": \"BTREE\",\n              \"\
+    unique\": true,\n              \"primary\": true,\n              \"visible\":\
+    \ true\n            },\n            {\n              \"name\": \"b\",\n      \
+    \        \"expressions\": [\n                \"b\"\n              ],\n       \
+    \       \"type\": \"BTREE\",\n              \"unique\": true,\n              \"\
+    visible\": true\n            },\n            {\n              \"name\": \"b_2\"\
+    ,\n              \"expressions\": [\n                \"b\",\n                \"\
+    a\"\n              ],\n              \"type\": \"BTREE\",\n              \"visible\"\
+    : true\n            },\n            {\n              \"name\": \"b_3\",\n    \
+    \          \"expressions\": [\n                \"b\",\n                \"c\",\n\
+    \                \"d\"\n              ],\n              \"type\": \"BTREE\",\n\
+    \              \"unique\": true,\n              \"visible\": true\n          \
+    \  },\n            {\n              \"name\": \"b_4\",\n              \"expressions\"\
+    : [\n                \"b\",\n                \"d\"\n              ],\n       \
+    \       \"type\": \"FULLTEXT\"\n            },\n            {\n              \"\
+    name\": \"idx_a\",\n              \"expressions\": [\n                \"a\"\n\
+    \              ],\n              \"type\": \"BTREE\",\n              \"visible\"\
+    : true\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   err: null
-- statement: |-
-    CREATE TABLE t(
-      a int PRIMARY KEY DEFAULT 1,
-      b varchar(200) CHARACTER SET utf8mb4 NOT NULL UNIQUE
-    );
-    DROP INDEX b on t;
+- statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
+    \ SET utf8mb4 NOT NULL UNIQUE\n);\nDROP INDEX b on t;"
   ignore_case_sensitive: false
-  want: |-
-    {
-      "name": "test",
-      "schemas": [
-        {
-          "tables": [
-            {
-              "name": "t",
-              "columns": [
-                {
-                  "name": "a",
-                  "position": 1,
-                  "default": "1",
-                  "type": "int(11)"
-                },
-                {
-                  "name": "b",
-                  "position": 2,
-                  "type": "varchar(200)",
-                  "characterSet": "utf8mb4"
-                }
-              ],
-              "indexes": [
-                {
-                  "name": "PRIMARY",
-                  "expressions": [
-                    "a"
-                  ],
-                  "type": "BTREE",
-                  "unique": true,
-                  "primary": true,
-                  "visible": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t\",\n          \"columns\": [\n           \
+    \ {\n              \"name\": \"a\",\n              \"position\": 1,\n        \
+    \      \"default\": \"1\",\n              \"type\": \"int(11)\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"type\": \"varchar(200)\",\n              \"characterSet\": \"\
+    utf8mb4\"\n            }\n          ],\n          \"indexes\": [\n           \
+    \ {\n              \"name\": \"PRIMARY\",\n              \"expressions\": [\n\
+    \                \"a\"\n              ],\n              \"type\": \"BTREE\",\n\
+    \              \"unique\": true,\n              \"primary\": true,\n         \
+    \     \"visible\": true\n            }\n          ]\n        }\n      ]\n    }\n\
+    \  ]\n}"
   err: null

--- a/backend/plugin/advisor/catalog/walk_through.go
+++ b/backend/plugin/advisor/catalog/walk_through.go
@@ -8,10 +8,8 @@ import (
 	"github.com/pkg/errors"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
-
-// WalkThroughErrorType is the type of WalkThroughError.
-type WalkThroughErrorType int
 
 const (
 	// PrimaryKeyName is the string for PK.
@@ -22,153 +20,69 @@ const (
 	SpatialName string = "SPATIAL"
 
 	publicSchemaName = "public"
-
-	// ErrorTypeUnsupported is the error for unsupported cases.
-	ErrorTypeUnsupported WalkThroughErrorType = 1
-	// ErrorTypeInternal is the error for internal errors.
-	ErrorTypeInternal WalkThroughErrorType = 2
-
-	// 101 parse error type.
-
-	// ErrorTypeParseError is the error in parsing.
-	ErrorTypeParseError WalkThroughErrorType = 101
-	// ErrorTypeDeparseError is the error in deparsing.
-	ErrorTypeDeparseError WalkThroughErrorType = 102
-
-	// 201 ~ 299 database error type.
-
-	// ErrorTypeAccessOtherDatabase is the error that try to access other database.
-	ErrorTypeAccessOtherDatabase = 201
-	// ErrorTypeDatabaseIsDeleted is the error that try to access the deleted database.
-	ErrorTypeDatabaseIsDeleted = 202
-	// ErrorTypeReferenceOtherDatabase is the error that try to reference other database.
-	ErrorTypeReferenceOtherDatabase = 203
-
-	// 301 ~ 399 table error type.
-
-	// ErrorTypeTableExists is the error that table exists.
-	ErrorTypeTableExists = 301
-	// ErrorTypeTableNotExists is the error that table not exists.
-	ErrorTypeTableNotExists = 302
-	// ErrorTypeUseCreateTableAs is the error that using CREATE TABLE AS statements.
-	ErrorTypeUseCreateTableAs = 303
-	// ErrorTypeTableIsReferencedByView is the error that table is referenced by view.
-	ErrorTypeTableIsReferencedByView = 304
-
-	// 401 ~ 499 column error type.
-
-	// ErrorTypeColumnExists is the error that column exists.
-	ErrorTypeColumnExists = 401
-	// ErrorTypeColumnNotExists is the error that column not exists.
-	ErrorTypeColumnNotExists = 402
-	// ErrorTypeDropAllColumns is the error that dropping all columns in a table.
-	ErrorTypeDropAllColumns = 403
-	// ErrorTypeAutoIncrementExists is the error that auto_increment exists.
-	ErrorTypeAutoIncrementExists = 404
-	// ErrorTypeOnUpdateColumnNotDatetimeOrTimestamp is the error that the ON UPDATE column is not datetime or timestamp.
-	ErrorTypeOnUpdateColumnNotDatetimeOrTimestamp = 405
-	// ErrorTypeSetNullDefaultForNotNullColumn is the error that setting NULL default value for the NOT NULL column.
-	ErrorTypeSetNullDefaultForNotNullColumn = 406
-	// ErrorTypeInvalidColumnTypeForDefaultValue is the error that invalid column type for default value.
-	ErrorTypeInvalidColumnTypeForDefaultValue = 407
-	// ErrorTypeColumnIsReferencedByView is the error that column is referenced by view.
-	ErrorTypeColumnIsReferencedByView = 408
-
-	// 501 ~ 599 index error type.
-
-	// ErrorTypePrimaryKeyExists is the error that PK exists.
-	ErrorTypePrimaryKeyExists = 501
-	// ErrorTypeIndexExists is the error that index exists.
-	ErrorTypeIndexExists = 502
-	// ErrorTypeIndexEmptyKeys is the error that index has empty keys.
-	ErrorTypeIndexEmptyKeys = 503
-	// ErrorTypePrimaryKeyNotExists is the error that PK does not exist.
-	ErrorTypePrimaryKeyNotExists = 504
-	// ErrorTypeIndexNotExists is the error that index does not exist.
-	ErrorTypeIndexNotExists = 505
-	// ErrorTypeIncorrectIndexName is the incorrect index name error.
-	ErrorTypeIncorrectIndexName = 506
-	// ErrorTypeSpatialIndexKeyNullable is the error that keys in spatial index are nullable.
-	ErrorTypeSpatialIndexKeyNullable = 507
-
-	// 701 ~ 799 schema error type.
-
-	// ErrorTypeSchemaNotExists is the error that schema does not exist.
-	ErrorTypeSchemaNotExists = 701
-
-	// 801 ~ 899 relation error type.
-
-	// ErrorTypeRelationExists is the error that relation already exists.
-	ErrorTypeRelationExists = 801
-
-	// 901 ~ 999 constraint error type.
-
-	// ErrorTypeConstraintNotExists is the error that constraint doesn't exist.
-	ErrorTypeConstraintNotExists = 901
 )
 
 // WalkThroughError is the error for walking-through.
+// It represents SQL review errors that should be converted to advisor codes.
 type WalkThroughError struct {
-	Type    WalkThroughErrorType
+	Code    code.Code
 	Content string
 	// TODO(zp): position
 	Line int
-
-	Payload any
 }
 
-// NewRelationExistsError returns a new ErrorTypeRelationExists.
+// NewRelationExistsError returns a new RelationExists error.
 func NewRelationExistsError(relationName string, schemaName string) *WalkThroughError {
 	return &WalkThroughError{
-		Type:    ErrorTypeRelationExists,
+		Code:    code.RelationExists,
 		Content: fmt.Sprintf("Relation %q already exists in schema %q", relationName, schemaName),
 	}
 }
 
-// NewColumnNotExistsError returns a new ErrorTypeColumnNotExists.
+// NewColumnNotExistsError returns a new ColumnNotExists error.
 func NewColumnNotExistsError(tableName string, columnName string) *WalkThroughError {
 	return &WalkThroughError{
-		Type:    ErrorTypeColumnNotExists,
+		Code:    code.ColumnNotExists,
 		Content: fmt.Sprintf("Column `%s` does not exist in table `%s`", columnName, tableName),
 	}
 }
 
-// NewIndexNotExistsError returns a new ErrorTypeIndexNotExists.
+// NewIndexNotExistsError returns a new IndexNotExists error.
 func NewIndexNotExistsError(tableName string, indexName string) *WalkThroughError {
 	return &WalkThroughError{
-		Type:    ErrorTypeIndexNotExists,
+		Code:    code.IndexNotExists,
 		Content: fmt.Sprintf("Index `%s` does not exist in table `%s`", indexName, tableName),
 	}
 }
 
-// NewIndexExistsError returns a new ErrorTypeIndexExists.
+// NewIndexExistsError returns a new IndexExists error.
 func NewIndexExistsError(tableName string, indexName string) *WalkThroughError {
 	return &WalkThroughError{
-		Type:    ErrorTypeIndexExists,
+		Code:    code.IndexExists,
 		Content: fmt.Sprintf("Index `%s` already exists in table `%s`", indexName, tableName),
 	}
 }
 
-// NewAccessOtherDatabaseError returns a new ErrorTypeAccessOtherDatabase.
+// NewAccessOtherDatabaseError returns a new NotCurrentDatabase error.
 func NewAccessOtherDatabaseError(current string, target string) *WalkThroughError {
 	return &WalkThroughError{
-		Type:    ErrorTypeAccessOtherDatabase,
+		Code:    code.NotCurrentDatabase,
 		Content: fmt.Sprintf("Database `%s` is not the current database `%s`", target, current),
 	}
 }
 
-// NewTableNotExistsError returns a new ErrorTypeTableNotExists.
+// NewTableNotExistsError returns a new TableNotExists error.
 func NewTableNotExistsError(tableName string) *WalkThroughError {
 	return &WalkThroughError{
-		Type:    ErrorTypeTableNotExists,
+		Code:    code.TableNotExists,
 		Content: fmt.Sprintf("Table `%s` does not exist", tableName),
 	}
 }
 
-// NewTableExistsError returns a new ErrorTypeTableExists.
+// NewTableExistsError returns a new TableExists error.
 func NewTableExistsError(tableName string) *WalkThroughError {
 	return &WalkThroughError{
-		Type:    ErrorTypeTableExists,
+		Code:    code.TableExists,
 		Content: fmt.Sprintf("Table `%s` already exists", tableName),
 	}
 }
@@ -188,10 +102,7 @@ func WalkThrough(d *DatabaseState, ast any) error {
 	case storepb.Engine_POSTGRES:
 		return PgWalkThrough(d, ast)
 	default:
-		return &WalkThroughError{
-			Type:    ErrorTypeUnsupported,
-			Content: fmt.Sprintf("Walk-through doesn't support engine type: %s", d.dbType),
-		}
+		return errors.Errorf("Walk-through doesn't support engine type: %s", d.dbType)
 	}
 }
 
@@ -231,14 +142,14 @@ func (s *SchemaState) renameTable(oldName string, newName string) *WalkThroughEr
 	table, exists := s.getTable(oldName)
 	if !exists {
 		return &WalkThroughError{
-			Type:    ErrorTypeTableNotExists,
+			Code:    code.TableNotExists,
 			Content: fmt.Sprintf("Table `%s` does not exist", oldName),
 		}
 	}
 
 	if _, exists := s.getTable(newName); exists {
 		return &WalkThroughError{
-			Type:    ErrorTypeTableExists,
+			Code:    code.TableExists,
 			Content: fmt.Sprintf("Table `%s` already exists", newName),
 		}
 	}
@@ -277,15 +188,12 @@ func parseViewName(viewName string) (string, string, error) {
 	return match[1], match[2], nil
 }
 
-func (d *DatabaseState) existedViewList(viewMap map[string]bool) ([]string, *WalkThroughError) {
+func (d *DatabaseState) existedViewList(viewMap map[string]bool) ([]string, error) {
 	var result []string
 	for viewName := range viewMap {
 		schemaName, viewName, err := parseViewName(viewName)
 		if err != nil {
-			return nil, &WalkThroughError{
-				Type:    ErrorTypeInternal,
-				Content: fmt.Sprintf("failed to check view dependency: %s", err.Error()),
-			}
+			return nil, errors.Wrapf(err, "failed to check view dependency")
 		}
 		schemaMeta, exists := d.schemaSet[schemaName]
 		if !exists {
@@ -323,7 +231,7 @@ func (d *DatabaseState) getSchema(schemaName string) (*SchemaState, *WalkThrough
 	if !exists {
 		if schemaName != publicSchemaName {
 			return nil, &WalkThroughError{
-				Type:    ErrorTypeSchemaNotExists,
+				Code:    code.SchemaNotExists,
 				Content: fmt.Sprintf("The schema %q doesn't exist", schemaName),
 			}
 		}
@@ -344,7 +252,7 @@ func (t *TableState) getColumn(columnName string) (*ColumnState, *WalkThroughErr
 	column, exists := t.columnSet[columnName]
 	if !exists {
 		return nil, &WalkThroughError{
-			Type:    ErrorTypeColumnNotExists,
+			Code:    code.ColumnNotExists,
 			Content: fmt.Sprintf("The column %q does not exist in the table %q", columnName, t.name),
 		}
 	}
@@ -355,7 +263,7 @@ func (s *SchemaState) pgGetTable(tableName string) (*TableState, *WalkThroughErr
 	table, exists := s.tableSet[tableName]
 	if !exists {
 		return nil, &WalkThroughError{
-			Type:    ErrorTypeTableNotExists,
+			Code:    code.TableNotExists,
 			Content: fmt.Sprintf("The table %q does not exist in schema %q", tableName, s.name),
 		}
 	}
@@ -370,7 +278,7 @@ func (s *SchemaState) getIndex(indexName string) (*TableState, *IndexState, *Wal
 	}
 
 	return nil, nil, &WalkThroughError{
-		Type:    ErrorTypeIndexNotExists,
+		Code:    code.IndexNotExists,
 		Content: fmt.Sprintf("Index %q does not exists in schema %q", indexName, s.name),
 	}
 }

--- a/backend/plugin/advisor/catalog/walk_through_test.go
+++ b/backend/plugin/advisor/catalog/walk_through_test.go
@@ -162,14 +162,6 @@ func TestPostgreSQLANTLRWalkThrough(t *testing.T) {
 	}
 }
 
-func convertInterfaceSliceToStringSlice(slice []any) []string {
-	var res []string
-	for _, item := range slice {
-		res = append(res, item.(string))
-	}
-	return res
-}
-
 func runWalkThroughTest(t *testing.T, file string, engineType storepb.Engine, originDatabase *storepb.DatabaseSchemaMetadata) {
 	tests := []testData{}
 	filepath := filepath.Join("test", file+".yaml")
@@ -196,17 +188,7 @@ func runWalkThroughTest(t *testing.T, file string, engineType storepb.Engine, or
 		if err != nil {
 			err, yes := err.(*WalkThroughError)
 			require.True(t, yes)
-			if err.Payload != nil {
-				actualPayloadText, yes := err.Payload.([]string)
-				require.True(t, yes)
-				expectedPayloadText := convertInterfaceSliceToStringSlice(test.Err.Payload.([]any))
-				err.Payload = nil
-				test.Err.Payload = nil
-				require.Equal(t, test.Err, err)
-				require.Equal(t, expectedPayloadText, actualPayloadText)
-			} else {
-				require.Equal(t, test.Err, err)
-			}
+			require.Equal(t, test.Err, err)
 			continue
 		}
 		require.NoError(t, err, test.Statement)
@@ -251,17 +233,7 @@ func runANTLRWalkThroughTest(t *testing.T, file string, engineType storepb.Engin
 		if err != nil {
 			err, yes := err.(*WalkThroughError)
 			require.True(t, yes)
-			if err.Payload != nil {
-				actualPayloadText, yes := err.Payload.([]string)
-				require.True(t, yes)
-				expectedPayloadText := convertInterfaceSliceToStringSlice(test.Err.Payload.([]any))
-				err.Payload = nil
-				test.Err.Payload = nil
-				require.Equal(t, test.Err, err)
-				require.Equal(t, expectedPayloadText, actualPayloadText)
-			} else {
-				require.Equal(t, test.Err, err)
-			}
+			require.Equal(t, test.Err, err)
 			continue
 		}
 		require.NoError(t, err, test.Statement)

--- a/backend/plugin/advisor/code/code.go
+++ b/backend/plugin/advisor/code/code.go
@@ -1,4 +1,4 @@
-package advisor
+package code
 
 // Code is the error code.
 type Code int
@@ -126,6 +126,9 @@ const (
 	InvalidColumnDefault                       Code = 423
 	DropIndexColumn                            Code = 424
 	DropColumn                                 Code = 425
+	AutoIncrementExists                        Code = 426
+	OnUpdateColumnNotDatetimeOrTimestamp       Code = 427
+	SetNullDefaultForNotNullColumn             Code = 428
 
 	// 501 engine error code.
 	NotInnoDBEngine Code = 501
@@ -218,9 +221,13 @@ const (
 
 	// 1901 ~ 1999 schema error code.
 	SchemaNotExists Code = 1901
+	RelationExists  Code = 1902
 
 	// 2001 ~ 2099 builtin error code.
 	BuiltinPriorBackupCheck Code = 2001
+
+	// 2101 ~ 2199 constraint error code.
+	ConstraintNotExists Code = 2101
 )
 
 // Int returns the int type of code.

--- a/backend/plugin/advisor/mssql/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/mssql/rule_builtin_prior_backup_check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	tsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )
 
@@ -54,7 +55,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 			Status:        level,
 			Title:         title,
 			Content:       fmt.Sprintf("The size of statements in the sheet exceeds the limit of %d", common.MaxSheetCheckSize),
-			Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+			Code:          code.BuiltinPriorBackupCheck.Int32(),
 			StartPosition: common.ConvertANTLRLineToPosition(1),
 		})
 	}
@@ -65,7 +66,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 			Status:        level,
 			Title:         title,
 			Content:       fmt.Sprintf("Need database %q to do prior backup but it does not exist", databaseName),
-			Code:          advisor.DatabaseNotExists.Int32(),
+			Code:          code.DatabaseNotExists.Int32(),
 			StartPosition: common.ConvertANTLRLineToPosition(1),
 		})
 		return adviceList, nil
@@ -81,7 +82,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 			Status:        level,
 			Title:         title,
 			Content:       "Prior backup cannot deal with mixed DDL and DML statements",
-			Code:          int32(advisor.BuiltinPriorBackupCheck),
+			Code:          int32(code.BuiltinPriorBackupCheck),
 			StartPosition: common.ConvertANTLRLineToPosition(1),
 		})
 	}
@@ -109,7 +110,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 					Status:        level,
 					Title:         title,
 					Content:       fmt.Sprintf("The statement type is not the same for all statements on the same table %q", key),
-					Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+					Code:          code.BuiltinPriorBackupCheck.Int32(),
 					StartPosition: common.ConvertANTLRLineToPosition(1),
 				})
 				break

--- a/backend/plugin/advisor/mssql/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/mssql/rule_column_maximum_varchar_length.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -133,7 +135,7 @@ func (r *ColumnMaximumVarcharLengthRule) enterDataType(ctx *parser.Data_typeCont
 	if currentLength > r.maximum {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.VarcharLengthExceedsLimit.Int32(),
+			Code:          code.VarcharLengthExceedsLimit.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("The maximum varchar length is %d.", r.maximum),
 			StartPosition: common.ConvertANTLRLineToPosition(line),

--- a/backend/plugin/advisor/mssql/rule_column_no_null.go
+++ b/backend/plugin/advisor/mssql/rule_column_no_null.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	tsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )
 
@@ -123,7 +124,7 @@ func (r *ColumnNoNullRule) exitCreateTable(_ *parser.Create_tableContext) {
 		}
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.ColumnCannotNull.Int32(),
+			Code:          code.ColumnCannotNull.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Column [%s] is nullable, which is not allowed.", columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.currentTableColumnIsNullableLine[columnName]),
@@ -195,7 +196,7 @@ func (r *ColumnNoNullRule) exitAlterTable(_ *parser.Alter_tableContext) {
 		}
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.ColumnCannotNull.Int32(),
+			Code:          code.ColumnCannotNull.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Column [%s] is nullable, which is not allowed.", columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.currentTableColumnIsNullableLine[columnName]),

--- a/backend/plugin/advisor/mssql/rule_column_require.go
+++ b/backend/plugin/advisor/mssql/rule_column_require.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -152,7 +154,7 @@ func (r *ColumnRequireRule) exitCreateTable(ctx *parser.Create_tableContext) {
 		for _, column := range missingColumns {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NoRequiredColumn.Int32(),
+				Code:          code.NoRequiredColumn.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table %s missing required column \"%s\"", r.currentOriginalTableName, column),
 				StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -173,7 +175,7 @@ func (r *ColumnRequireRule) enterAlterTable(ctx *parser.Alter_tableContext) {
 		if _, ok := r.requireColumns[normalizedColumnName]; ok {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NoRequiredColumn.Int32(),
+				Code:          code.NoRequiredColumn.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table %s missing required column \"%s\"", tableName, normalizedColumnName),
 				StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_column_type_disallow_list.go
+++ b/backend/plugin/advisor/mssql/rule_column_type_disallow_list.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -98,7 +100,7 @@ func (r *ColumnTypeDisallowListRule) enterDataType(ctx *parser.Data_typeContext)
 	if slices.Contains(r.disallowTypes, formatedDataType) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DisabledColumnType.Int32(),
+			Code:          code.DisabledColumnType.Int32(),
 			Title:         r.title,
 			Content:       "Column type " + formatedDataType + " is disallowed",
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_function_disallow_create_or_alter.go
+++ b/backend/plugin/advisor/mssql/rule_function_disallow_create_or_alter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 func init() {
@@ -78,7 +79,7 @@ func (*FunctionDisallowCreateOrAlterRule) OnExit(_ antlr.ParserRuleContext, _ st
 func (r *FunctionDisallowCreateOrAlterRule) enterCreateOrAlterFunction(ctx *parser.Create_or_alter_functionContext) {
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.DisallowCreateFunction.Int32(),
+		Code:          code.DisallowCreateFunction.Int32(),
 		Title:         r.title,
 		Content:       "Creating or altering functions is prohibited",
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_index_not_redundant.go
+++ b/backend/plugin/advisor/mssql/rule_index_not_redundant.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -126,7 +128,7 @@ func (r *IndexNotRedundantRule) enterCreateIndex(ctx *parser.Create_indexContext
 		r.AddAdvice(&storepb.Advice{
 			Status: r.level,
 			Title:  r.title,
-			Code:   advisor.RedundantIndex.Int32(),
+			Code:   code.RedundantIndex.Int32(),
 			Content: fmt.Sprintf("Redundant indexes with the same prefix ('%s' and '%s') in '%s.%s' is not allowed",
 				metaIdxName, statIdxName, findIdxKey.schemaName, findIdxKey.tblName),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/mssql/rule_naming_identifier_no_keyword.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -107,7 +109,7 @@ func (r *NamingIdentifierNoKeywordRule) enterID(ctx *parser.Id_Context) {
 	if tsqlparser.IsTSQLReservedKeyword(normalizedID, false) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NameIsKeywordIdentifier.Int32(),
+			Code:          code.NameIsKeywordIdentifier.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Identifier [%s] is a keyword identifier and should be avoided.", normalizedID),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_naming_table.go
+++ b/backend/plugin/advisor/mssql/rule_naming_table.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	tsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )
 
@@ -104,7 +105,7 @@ func (r *NamingTableRule) enterCreateTable(ctx *parser.Create_tableContext) {
 	if !r.format.MatchString(tableName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf(`%s mismatches table naming convention, naming format should be %q`, tableName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -113,7 +114,7 @@ func (r *NamingTableRule) enterCreateTable(ctx *parser.Create_tableContext) {
 	if r.maxLength > 0 && len(tableName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf(`%s mismatches table naming convention, its length should be within %d characters`, tableName, r.maxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -186,7 +187,7 @@ func (r *NamingTableRule) enterExecuteBody(ctx *parser.Execute_bodyContext) {
 	if !r.format.MatchString(newTableName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf(`%s mismatches table naming convention, naming format should be %q`, newTableName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -195,7 +196,7 @@ func (r *NamingTableRule) enterExecuteBody(ctx *parser.Execute_bodyContext) {
 	if r.maxLength > 0 && len(newTableName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf(`%s mismatches table naming convention, its length should be within %d characters`, newTableName, r.maxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_naming_table_no_keyword.go
+++ b/backend/plugin/advisor/mssql/rule_naming_table_no_keyword.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -89,7 +91,7 @@ func (r *NamingTableNoKeywordRule) enterCreateTable(ctx *parser.Create_tableCont
 	if tsqlparser.IsTSQLReservedKeyword(normalizedTableName, false) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NameIsKeywordIdentifier.Int32(),
+			Code:          code.NameIsKeywordIdentifier.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table name [%s] is a reserved keyword and should be avoided.", normalizedTableName),
 			StartPosition: common.ConvertANTLRLineToPosition(tableName.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_procedure_disallow_create_or_alter.go
+++ b/backend/plugin/advisor/mssql/rule_procedure_disallow_create_or_alter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 func init() {
@@ -77,7 +78,7 @@ func (*ProcedureDisallowCreateOrAlterRule) OnExit(_ antlr.ParserRuleContext, _ s
 func (r *ProcedureDisallowCreateOrAlterRule) enterCreateOrAlterProcedure(ctx *parser.Create_or_alter_procedureContext) {
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.DisallowCreateProcedure.Int32(),
+		Code:          code.DisallowCreateProcedure.Int32(),
 		Title:         r.title,
 		Content:       "Creating or altering procedures is prohibited",
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_select_no_select_all.go
+++ b/backend/plugin/advisor/mssql/rule_select_no_select_all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -86,7 +87,7 @@ func (r *SelectNoSelectAllRule) enterSelectListElem(ctx *parser.Select_list_elem
 		if v.STAR() != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementSelectAll.Int32(),
+				Code:          code.StatementSelectAll.Int32(),
 				Title:         r.title,
 				Content:       "Avoid using SELECT *.",
 				StartPosition: common.ConvertANTLRLineToPosition(v.STAR().GetSymbol().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_statement_disallow_cross_db_queries.go
+++ b/backend/plugin/advisor/mssql/rule_statement_disallow_cross_db_queries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )
 
@@ -90,7 +91,7 @@ func (r *DisallowCrossDBQueriesRule) enterTableSourceItem(ctx *parser.Table_sour
 		if fullTblName, err := tsql.NormalizeFullTableName(fullTblnameCtx); err == nil && fullTblName.Database != "" && !strings.EqualFold(fullTblName.Database, r.curDB) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementDisallowCrossDBQueries.Int32(),
+				Code:          code.StatementDisallowCrossDBQueries.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Cross database queries (target databse: '%s', current database: '%s') are prohibited", fullTblName.Database, r.curDB),
 				StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_statement_disallow_mix_in_ddl.go
+++ b/backend/plugin/advisor/mssql/rule_statement_disallow_mix_in_ddl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	tsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )
 
@@ -103,7 +104,7 @@ func (r *StatementDisallowMixInDDLRule) enterSQLClauses(ctx *parser.Sql_clausesC
 			Status:        r.level,
 			Title:         r.title,
 			Content:       "Alter schema can only run DDL",
-			Code:          advisor.StatementDisallowMixDDLDML.Int32(),
+			Code:          code.StatementDisallowMixDDLDML.Int32(),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
 		})
 	}

--- a/backend/plugin/advisor/mssql/rule_statement_disallow_mix_in_dml.go
+++ b/backend/plugin/advisor/mssql/rule_statement_disallow_mix_in_dml.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	tsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )
 
@@ -103,7 +104,7 @@ func (r *StatementDisallowMixInDMLRule) enterSQLClauses(ctx *parser.Sql_clausesC
 			Status:        r.level,
 			Title:         r.title,
 			Content:       "Data change can only run DML",
-			Code:          advisor.StatementDisallowMixDDLDML.Int32(),
+			Code:          code.StatementDisallowMixDDLDML.Int32(),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
 		})
 	}

--- a/backend/plugin/advisor/mssql/rule_statement_where_disallow_functions_and_calculations.go
+++ b/backend/plugin/advisor/mssql/rule_statement_where_disallow_functions_and_calculations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 func init() {
@@ -131,7 +132,7 @@ func (r *DisallowFuncAndCalculationsRule) generateAdviceOnFunctionUsing(ctx antl
 	r.hasTriggeredRule = true
 	return &storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.StatementDisallowFunctionsAndCalculations.Int32(),
+		Code:          code.StatementDisallowFunctionsAndCalculations.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("Calling function '%s' in 'WHERE' clause is not allowed", ctx.GetText()),
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -145,7 +146,7 @@ func (r *DisallowFuncAndCalculationsRule) generateAdviceOnPerformingCalculations
 	r.hasTriggeredRule = true
 	return &storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.StatementDisallowFunctionsAndCalculations.Int32(),
+		Code:          code.StatementDisallowFunctionsAndCalculations.Int32(),
 		Title:         r.title,
 		Content:       "Performing calculations in 'WHERE' clause is not allowed",
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_select.go
+++ b/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_select.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -86,7 +87,7 @@ func (r *WhereRequirementForSelectRule) enterQuerySpecification(ctx *parser.Quer
 	if ctx.WHERE() == nil && ctx.From_table_sources() != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementNoWhere.Int32(),
+			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       "WHERE clause is required for SELETE statement.",
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_update_delete.go
+++ b/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_update_delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -90,7 +91,7 @@ func (r *WhereRequirementForUpdateDeleteRule) enterDeleteStatement(ctx *parser.D
 	if ctx.WHERE() == nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementNoWhere.Int32(),
+			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       "WHERE clause is required for DELETE statement.",
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -102,7 +103,7 @@ func (r *WhereRequirementForUpdateDeleteRule) enterUpdateStatement(ctx *parser.U
 	if ctx.WHERE() == nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementNoWhere.Int32(),
+			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       "WHERE clause is required for UPDATE statement.",
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_table_disallow_ddl.go
+++ b/backend/plugin/advisor/mssql/rule_table_disallow_ddl.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -139,7 +141,7 @@ func (r *TableDisallowDDLRule) checkTableName(normalizedTableName string, line i
 		if normalizedTableName == disallow {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableDisallowDDL.Int32(),
+				Code:          code.TableDisallowDDL.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("DDL is disallowed on table %s.", normalizedTableName),
 				StartPosition: common.ConvertANTLRLineToPosition(line),

--- a/backend/plugin/advisor/mssql/rule_table_disallow_dml.go
+++ b/backend/plugin/advisor/mssql/rule_table_disallow_dml.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -149,7 +151,7 @@ func (r *TableDisallowDMLRule) checkTableName(normalizedTableName string, line i
 		if normalizedTableName == disallow {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableDisallowDML.Int32(),
+				Code:          code.TableDisallowDML.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("DML is disallowed on table %s.", normalizedTableName),
 				StartPosition: common.ConvertANTLRLineToPosition(line),

--- a/backend/plugin/advisor/mssql/rule_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/mssql/rule_table_drop_naming_convention.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -101,7 +103,7 @@ func (r *TableDropNamingConventionRule) enterDropTable(ctx *parser.Drop_tableCon
 		if !r.format.MatchString(normalizedTableName) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableDropNamingConventionMismatch.Int32(),
+				Code:          code.TableDropNamingConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("[%s] mismatches drop table naming convention, naming format should be %q", normalizedTableName, r.format),
 				StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mssql/rule_table_no_foreign_key.go
+++ b/backend/plugin/advisor/mssql/rule_table_no_foreign_key.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/tsql"
 	"github.com/pkg/errors"
@@ -190,7 +192,7 @@ func (r *TableNoForeignKeyRule) generateFinalAdvice() {
 		if hasForeignKey {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableHasFK.Int32(),
+				Code:          code.TableHasFK.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("FOREIGN KEY is not allowed in the table %s.", r.tableOriginalName[tableName]),
 				StartPosition: common.ConvertANTLRLineToPosition(r.tableLine[tableName]),

--- a/backend/plugin/advisor/mssql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mssql/rule_table_require_pk.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	tsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )
 
@@ -188,7 +189,7 @@ func (r *TableRequirePkRule) generateFinalAdvice() {
 		if !hasPK {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableNoPK.Int32(),
+				Code:          code.TableNoPK.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table %s requires PRIMARY KEY.", r.tableOriginalName[tableName]),
 				StartPosition: common.ConvertANTLRLineToPosition(r.tableLine[tableName]),

--- a/backend/plugin/advisor/mysql/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/mysql/rule_builtin_prior_backup_check.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -46,7 +47,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 			Status:        level,
 			Title:         title,
 			Content:       fmt.Sprintf("The size of the SQL statements exceeds the maximum limit of %d bytes for backup", common.MaxSheetCheckSize),
-			Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+			Code:          code.BuiltinPriorBackupCheck.Int32(),
 			StartPosition: nil,
 		})
 	}
@@ -60,7 +61,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 				Status:        level,
 				Title:         title,
 				Content:       "Prior backup cannot deal with mixed DDL and DML statements",
-				Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+				Code:          code.BuiltinPriorBackupCheck.Int32(),
 				StartPosition: common.ConvertANTLRLineToPosition(stmt.BaseLine),
 			})
 		}
@@ -72,7 +73,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 			Status:        level,
 			Title:         title,
 			Content:       fmt.Sprintf("Need database %q to do prior backup but it does not exist", databaseName),
-			Code:          advisor.DatabaseNotExists.Int32(),
+			Code:          code.DatabaseNotExists.Int32(),
 			StartPosition: nil,
 		})
 	}
@@ -98,7 +99,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 					Status:        level,
 					Title:         title,
 					Content:       fmt.Sprintf("Prior backup cannot handle mixed DML statements on the same table %q", key),
-					Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+					Code:          code.BuiltinPriorBackupCheck.Int32(),
 					StartPosition: nil,
 				})
 				break

--- a/backend/plugin/advisor/mysql/rule_charset_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_charset_allowlist.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -130,7 +131,7 @@ func (r *CharsetAllowlistRule) checkCharset(charset string, lineNumber int) {
 	if _, exists := r.allowList[charset]; charset != "" && !exists {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DisabledCharset.Int32(),
+			Code:          code.DisabledCharset.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" used disabled charset '%s'", r.text, charset),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + lineNumber),

--- a/backend/plugin/advisor/mysql/rule_collation_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_collation_allowlist.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -229,7 +230,7 @@ func (r *CollationAllowlistRule) checkCollation(collation string, lineNumber int
 	if _, exists := r.allowList[collation]; collation != "" && !exists {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DisabledCollation.Int32(),
+			Code:          code.DisabledCollation.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" used disabled collation '%s'", r.text, collation),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + lineNumber),

--- a/backend/plugin/advisor/mysql/rule_column_auto_increment_initial_value.go
+++ b/backend/plugin/advisor/mysql/rule_column_auto_increment_initial_value.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -124,7 +126,7 @@ func (r *ColumnAutoIncrementInitialValueRule) checkCreateTable(ctx *mysql.Create
 		if value != uint64(r.value) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.AutoIncrementColumnInitialValueNotMatch.Int32(),
+				Code:          code.AutoIncrementColumnInitialValueNotMatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("The initial auto-increment value in table `%s` is %v, which doesn't equal %v", tableName, value, r.value),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -171,7 +173,7 @@ func (r *ColumnAutoIncrementInitialValueRule) checkAlterTable(ctx *mysql.AlterTa
 			if value != uint64(r.value) {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.AutoIncrementColumnInitialValueNotMatch.Int32(),
+					Code:          code.AutoIncrementColumnInitialValueNotMatch.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("The initial auto-increment value in table `%s` is %v, which doesn't equal %v", tableName, value, r.value),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_auto_increment_must_integer.go
+++ b/backend/plugin/advisor/mysql/rule_column_auto_increment_must_integer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -174,7 +176,7 @@ func (r *ColumnAutoIncrementMustIntegerRule) checkFieldDefinition(tableName, col
 	if !r.isAutoIncrementColumnIsInteger(ctx) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.AutoIncrementColumnNotInteger.Int32(),
+			Code:          code.AutoIncrementColumnNotInteger.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Auto-increment column `%s`.`%s` requires integer type", tableName, columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_auto_increment_must_unsigned.go
+++ b/backend/plugin/advisor/mysql/rule_column_auto_increment_must_unsigned.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -168,7 +170,7 @@ func (r *ColumnAutoIncrementMustUnsignedRule) checkFieldDefinition(tableName, co
 	if !r.isAutoIncrementColumnIsUnsigned(ctx) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.AutoIncrementColumnSigned.Int32(),
+			Code:          code.AutoIncrementColumnSigned.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Auto-increment column `%s`.`%s` is not UNSIGNED type", tableName, columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_comment_convention.go
+++ b/backend/plugin/advisor/mysql/rule_column_comment_convention.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -196,7 +197,7 @@ func (r *ColumnCommentConventionRule) checkFieldDefinition(tableName, columnName
 		if r.payload.MaxLength >= 0 && len(comment) > r.payload.MaxLength {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.CommentTooLong.Int32(),
+				Code:          code.CommentTooLong.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("The length of column `%s`.`%s` comment should be within %d characters", tableName, columnName, r.payload.MaxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -207,7 +208,7 @@ func (r *ColumnCommentConventionRule) checkFieldDefinition(tableName, columnName
 			if classification, _ := common.GetClassificationAndUserComment(comment, r.classificationConfig); classification == "" {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.CommentMissingClassification.Int32(),
+					Code:          code.CommentMissingClassification.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Column `%s`.`%s` comment requires classification", tableName, columnName),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -221,7 +222,7 @@ func (r *ColumnCommentConventionRule) checkFieldDefinition(tableName, columnName
 	if len(comment) == 0 && r.payload.Required {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.CommentEmpty.Int32(),
+			Code:          code.CommentEmpty.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Column `%s`.`%s` requires comments", tableName, columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_current_time_count_limit.go
+++ b/backend/plugin/advisor/mysql/rule_column_current_time_count_limit.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -268,7 +270,7 @@ func (r *ColumnCurrentTimeCountLimitRule) generateAdvice() {
 		if table.defaultCurrentTimeCount > maxDefaultCurrentTimeColumCount {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.DefaultCurrentTimeColumnCountExceedsLimit.Int32(),
+				Code:          code.DefaultCurrentTimeColumnCountExceedsLimit.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table `%s` has %d DEFAULT CURRENT_TIMESTAMP() columns. The count greater than %d.", table.tableName, table.defaultCurrentTimeCount, maxDefaultCurrentTimeColumCount),
 				StartPosition: common.ConvertANTLRLineToPosition(table.line),
@@ -277,7 +279,7 @@ func (r *ColumnCurrentTimeCountLimitRule) generateAdvice() {
 		if table.onUpdateCurrentTimeCount > maxOnUpdateCurrentTimeColumnCount {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.OnUpdateCurrentTimeColumnCountExceedsLimit.Int32(),
+				Code:          code.OnUpdateCurrentTimeColumnCountExceedsLimit.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table `%s` has %d ON UPDATE CURRENT_TIMESTAMP() columns. The count greater than %d.", table.tableName, table.onUpdateCurrentTimeCount, maxOnUpdateCurrentTimeColumnCount),
 				StartPosition: common.ConvertANTLRLineToPosition(table.line),

--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -119,7 +121,7 @@ func (r *ColumnDisallowChangingRule) checkAlterTable(ctx *mysql.AlterTableContex
 		if item.CHANGE_SYMBOL() != nil && item.ColumnInternalRef() != nil && item.Identifier() != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.UseChangeColumnStatement.Int32(),
+				Code:          code.UseChangeColumnStatement.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("\"%s\" contains CHANGE COLUMN statement", r.text),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing_order.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing_order.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -129,7 +131,7 @@ func (r *ColumnDisallowChangingOrderRule) checkAlterTable(ctx *mysql.AlterTableC
 		if item.Place() != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.ChangeColumnOrder.Int32(),
+				Code:          code.ChangeColumnOrder.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("\"%s\" changes column order", r.text),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -177,7 +179,7 @@ func (r *ColumnDisallowChangingTypeRule) changeColumnType(tableName, columnName 
 	if normalizeColumnType(column.Type()) != normalizeColumnType(tp) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.ChangeColumnType.Int32(),
+			Code:          code.ChangeColumnType.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" changes column type", r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + dataType.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_disallow_drop.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_drop.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -107,7 +109,7 @@ func (r *ColumnDisallowDropRule) checkAlterTable(ctx *mysql.AlterTableContext) {
 		columnName := mysqlparser.NormalizeMySQLColumnInternalRef(item.ColumnInternalRef())
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DropColumn.Int32(),
+			Code:          code.DropColumn.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("drops column \"%s\" of table \"%s\"", columnName, tableName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + item.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -173,7 +175,7 @@ func (r *ColumnDisallowDropInIndexRule) checkAlterTable(ctx *mysql.AlterTableCon
 		if !r.canDrop(tableName, columnName) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.DropIndexColumn.Int32(),
+				Code:          code.DropIndexColumn.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("`%s`.`%s` cannot drop index column", tableName, columnName),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + item.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_disallow_set_charset.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_set_charset.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -122,7 +124,7 @@ func (r *ColumnDisallowSetCharsetRule) checkCreateTable(ctx *mysql.CreateTableCo
 		if !r.checkCharset(charset) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.SetColumnCharset.Int32(),
+				Code:          code.SetColumnCharset.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Disallow set column charset but \"%s\" does", r.text),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -201,7 +203,7 @@ func (r *ColumnDisallowSetCharsetRule) checkAlterTable(ctx *mysql.AlterTableCont
 			if !r.checkCharset(charsetName) {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.SetColumnCharset.Int32(),
+					Code:          code.SetColumnCharset.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Disallow set column charset but \"%s\" does", r.text),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_maximum_character_length.go
+++ b/backend/plugin/advisor/mysql/rule_column_maximum_character_length.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -127,7 +129,7 @@ func (r *ColumnMaximumCharacterLengthRule) checkCreateTable(ctx *mysql.CreateTab
 		if r.maximum > 0 && charLength > r.maximum {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.CharLengthExceedsLimit.Int32(),
+				Code:          code.CharLengthExceedsLimit.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("The length of the CHAR column `%s.%s` is bigger than %d, please use VARCHAR instead", tableName, columnName, r.maximum),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + tableElement.ColumnDefinition().GetStart().GetLine()),
@@ -214,7 +216,7 @@ func (r *ColumnMaximumCharacterLengthRule) checkAlterTable(ctx *mysql.AlterTable
 			if charLength, ok := charLengthMap[columnName]; ok && r.maximum > 0 && charLength > r.maximum {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.CharLengthExceedsLimit.Int32(),
+					Code:          code.CharLengthExceedsLimit.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("The length of the CHAR column `%s.%s` is bigger than %d, please use VARCHAR instead", tableName, columnName, r.maximum),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/mysql/rule_column_maximum_varchar_length.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -125,7 +127,7 @@ func (r *VarcharLengthRule) checkCreateTable(ctx *mysql.CreateTableContext) {
 		if r.maximum > 0 && length > r.maximum {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.VarcharLengthExceedsLimit.Int32(),
+				Code:          code.VarcharLengthExceedsLimit.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("The length of the VARCHAR column `%s.%s` is bigger than %d", tableName, columnName, r.maximum),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + tableElement.ColumnDefinition().GetStart().GetLine()),
@@ -209,7 +211,7 @@ func (r *VarcharLengthRule) checkAlterTable(ctx *mysql.AlterTableContext) {
 			if length, ok := varcharLengthMap[columnName]; ok && r.maximum > 0 && length > r.maximum {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.VarcharLengthExceedsLimit.Int32(),
+					Code:          code.VarcharLengthExceedsLimit.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("The length of the VARCHAR column `%s.%s` is bigger than %d", tableName, columnName, r.maximum),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_no_null.go
+++ b/backend/plugin/advisor/mysql/rule_column_no_null.go
@@ -13,6 +13,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -138,7 +139,7 @@ func (r *ColumnNoNullRule) generateAdvice() {
 		if col != nil && col.Nullable() {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.ColumnCannotNull.Int32(),
+				Code:          code.ColumnCannotNull.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("`%s`.`%s` cannot have NULL value", column.tableName, column.columnName),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/mysql/rule_column_require_charset.go
+++ b/backend/plugin/advisor/mysql/rule_column_require_charset.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -114,7 +116,7 @@ func (r *ColumnRequireCharsetRule) checkCreateTable(ctx *mysql.CreateTableContex
 			if dataType.CharsetWithOptBinary() == nil {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.NoCharset.Int32(),
+					Code:          code.NoCharset.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Column %s does not have a character set specified", columnName),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + columnDefinition.GetStart().GetLine()),
@@ -140,7 +142,7 @@ func (r *ColumnRequireCharsetRule) checkAlterTable(ctx *mysql.AlterTableContext)
 			if dataType.CharsetWithOptBinary() == nil {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.NoCharset.Int32(),
+					Code:          code.NoCharset.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Column %s does not have a character set specified", columnName),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + alterListItem.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_require_collation.go
+++ b/backend/plugin/advisor/mysql/rule_column_require_collation.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -113,7 +115,7 @@ func (r *ColumnRequireCollationRule) checkCreateTable(ctx *mysql.CreateTableCont
 			if columnDefinition.FieldDefinition().Collate() == nil {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.NoCollation.Int32(),
+					Code:          code.NoCollation.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Column %s does not have a collation specified", columnName),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + columnDefinition.GetStart().GetLine()),
@@ -139,7 +141,7 @@ func (r *ColumnRequireCollationRule) checkAlterTable(ctx *mysql.AlterTableContex
 			if alterListItem.FieldDefinition().Collate() == nil {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.NoCollation.Int32(),
+					Code:          code.NoCollation.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Column %s does not have a collation specified", columnName),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + alterListItem.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_require_default.go
+++ b/backend/plugin/advisor/mysql/rule_column_require_default.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -175,7 +177,7 @@ func (r *ColumnRequireDefaultRule) checkFieldDefinition(tableName, columnName st
 	if !r.hasDefault(ctx) && r.columnNeedDefault(ctx) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NoDefault.Int32(),
+			Code:          code.NoDefault.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Column `%s`.`%s` doesn't have DEFAULT.", tableName, columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_required.go
+++ b/backend/plugin/advisor/mysql/rule_column_required.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -212,7 +214,7 @@ func (r *ColumnRequiredRule) generateAdviceList() []*storepb.Advice {
 			slices.Sort(missingColumns)
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NoRequiredColumn.Int32(),
+				Code:          code.NoRequiredColumn.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table `%s` requires columns: %s", tableName, strings.Join(missingColumns, ", ")),
 				StartPosition: common.ConvertANTLRLineToPosition(r.line[tableName]),

--- a/backend/plugin/advisor/mysql/rule_column_set_default_for_not_null.go
+++ b/backend/plugin/advisor/mysql/rule_column_set_default_for_not_null.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -150,7 +152,7 @@ func (r *ColumnSetDefaultForNotNullRule) checkCreateTable(ctx *mysql.CreateTable
 		if !r.canNull(field) && !r.hasDefault(field) && r.columnNeedDefault(field) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NotNullColumnWithNoDefault.Int32(),
+				Code:          code.NotNullColumnWithNoDefault.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Column `%s`.`%s` is NOT NULL but doesn't have DEFAULT", tableName, columnName),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + tableElement.ColumnDefinition().GetStart().GetLine()),
@@ -163,7 +165,7 @@ func (r *ColumnSetDefaultForNotNullRule) checkFieldDefinition(tableName, columnN
 	if !r.canNull(ctx) && !r.hasDefault(ctx) && r.columnNeedDefault(ctx) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NotNullColumnWithNoDefault.Int32(),
+			Code:          code.NotNullColumnWithNoDefault.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Column `%s`.`%s` is NOT NULL but doesn't have DEFAULT", tableName, columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_column_type_disallow_list.go
+++ b/backend/plugin/advisor/mysql/rule_column_type_disallow_list.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -142,7 +144,7 @@ func (r *ColumnTypeDisallowListRule) checkFieldDefinition(tableName, columnName 
 	if _, exists := r.typeRestriction[columnType]; exists {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DisabledColumnType.Int32(),
+			Code:          code.DisabledColumnType.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Disallow column type %s but column `%s`.`%s` is", columnType, tableName, columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_database_drop_empty_db.go
+++ b/backend/plugin/advisor/mysql/rule_database_drop_empty_db.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -103,7 +105,7 @@ func (r *DatabaseDropEmptyDBRule) checkDropDatabase(ctx *mysql.DropDatabaseConte
 	if r.originCatalog.DatabaseName() != dbName {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NotCurrentDatabase.Int32(),
+			Code:          code.NotCurrentDatabase.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Database `%s` that is trying to be deleted is not the current database `%s`", dbName, r.originCatalog.DatabaseName()),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -111,7 +113,7 @@ func (r *DatabaseDropEmptyDBRule) checkDropDatabase(ctx *mysql.DropDatabaseConte
 	} else if !r.originCatalog.HasNoTable() {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DatabaseNotEmpty.Int32(),
+			Code:          code.DatabaseNotEmpty.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Database `%s` is not allowed to drop if not empty", dbName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_disallow_procedure.go
+++ b/backend/plugin/advisor/mysql/rule_disallow_procedure.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -99,12 +100,12 @@ func (r *ProcedureDisallowCreateRule) checkCreateProcedure(ctx *mysql.CreateProc
 	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
 		return
 	}
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if ctx.ProcedureName() != nil {
-		code = advisor.DisallowCreateProcedure
+		code = advisorcode.DisallowCreateProcedure
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/mysql/rule_event_disallow_create.go
+++ b/backend/plugin/advisor/mysql/rule_event_disallow_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -98,12 +99,12 @@ func (r *EventDisallowCreateRule) checkCreateEvent(ctx *mysql.CreateEventContext
 	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
 		return
 	}
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if ctx.EventName() != nil {
-		code = advisor.DisallowCreateEvent
+		code = advisorcode.DisallowCreateEvent
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/mysql/rule_function_disallow_create.go
+++ b/backend/plugin/advisor/mysql/rule_function_disallow_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -98,12 +99,12 @@ func (r *FunctionDisallowCreateRule) checkCreateFunction(ctx *mysql.CreateFuncti
 	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
 		return
 	}
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if ctx.FunctionName() != nil {
-		code = advisor.DisallowCreateFunction
+		code = advisorcode.DisallowCreateFunction
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/mysql/rule_function_disallowed_list.go
+++ b/backend/plugin/advisor/mysql/rule_function_disallowed_list.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -114,7 +116,7 @@ func (r *FunctionDisallowedListRule) checkFunctionCall(ctx *mysql.FunctionCallCo
 		if slices.Contains(r.disallowList, strings.ToUpper(functionName)) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.DisabledFunction.Int32(),
+				Code:          code.DisabledFunction.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Function \"%s\" is disallowed, but \"%s\" uses", functionName, r.text),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_index_key_number_limit.go
+++ b/backend/plugin/advisor/mysql/rule_index_key_number_limit.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -151,7 +153,7 @@ func (r *IndexKeyNumberLimitRule) handleConstraintDef(tableName string, ctx mysq
 	if r.max > 0 && len(columnList) > r.max {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.IndexKeyNumberExceedsLimit.Int32(),
+			Code:          code.IndexKeyNumberExceedsLimit.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("The number of index `%s` in table `%s` should be not greater than %d", indexName, tableName, r.max),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -185,7 +187,7 @@ func (r *IndexKeyNumberLimitRule) checkCreateIndex(ctx *mysql.CreateIndexContext
 	if r.max > 0 && len(columnList) > r.max {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.IndexKeyNumberExceedsLimit.Int32(),
+			Code:          code.IndexKeyNumberExceedsLimit.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("The number of index `%s` in table `%s` should be not greater than %d", indexName, tableName, r.max),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_index_no_duplicate_column.go
+++ b/backend/plugin/advisor/mysql/rule_index_no_duplicate_column.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -189,7 +191,7 @@ func (r *IndexNoDuplicateColumnRule) checkCreateIndex(ctx *mysql.CreateIndexCont
 	if column, duplicate := r.hasDuplicateColumn(columnList); duplicate {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DuplicateColumnInIndex.Int32(),
+			Code:          code.DuplicateColumnInIndex.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("%s`%s` has duplicate column `%s`.`%s`", indexType, indexName, tableName, column),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -241,7 +243,7 @@ func (r *IndexNoDuplicateColumnRule) handleConstraintDef(tableName string, ctx m
 	if column, duplicate := r.hasDuplicateColumn(columnList); duplicate {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DuplicateColumnInIndex.Int32(),
+			Code:          code.DuplicateColumnInIndex.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("%s`%s` has duplicate column `%s`.`%s`", indexType, indexName, tableName, column),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_index_pk_type.go
+++ b/backend/plugin/advisor/mysql/rule_index_pk_type.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -223,7 +225,7 @@ func (r *IndexPkTypeRule) addAdvice(tableName, columnName, columnType string, li
 	if !strings.EqualFold(columnType, "INT") && !strings.EqualFold(columnType, "BIGINT") {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.IndexPKType.Int32(),
+			Code:          code.IndexPKType.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Columns in primary key must be INT/BIGINT but `%s`.`%s` is %s", tableName, columnName, columnType),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),

--- a/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -207,7 +209,7 @@ func (r *IndexPrimaryKeyTypeAllowlistRule) checkFieldDefinition(tableName, colum
 			if _, exists := r.allowlist[columnType]; !exists {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.IndexPKType.Int32(),
+					Code:          code.IndexPKType.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("The column `%s` in table `%s` is one of the primary key, but its type \"%s\" is not in allowlist", columnName, tableName, columnType),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -236,7 +238,7 @@ func (r *IndexPrimaryKeyTypeAllowlistRule) checkConstraintDef(tableName string, 
 		if _, exists := r.allowlist[columnType]; !exists {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.IndexPKType.Int32(),
+				Code:          code.IndexPKType.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("The column `%s` in table `%s` is one of the primary key, but its type \"%s\" is not in allowlist", columnName, tableName, columnType),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
+++ b/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -134,7 +136,7 @@ func (r *IndexTotalNumberLimitRule) generateAdvice() []*storepb.Advice {
 		if tableInfo != nil && tableInfo.CountIndex() > r.max {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.IndexCountExceedsLimit.Int32(),
+				Code:          code.IndexCountExceedsLimit.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("The count of index in table `%s` should be no more than %d, but found %d", table.name, r.max, tableInfo.CountIndex()),
 				StartPosition: common.ConvertANTLRLineToPosition(table.line),

--- a/backend/plugin/advisor/mysql/rule_index_type_allow_list.go
+++ b/backend/plugin/advisor/mysql/rule_index_type_allow_list.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -189,7 +191,7 @@ func (r *IndexTypeAllowListRule) validateIndexType(indexType string, line int) {
 
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.IndexTypeNotAllowed.Int32(),
+		Code:          code.IndexTypeNotAllowed.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("Index type `%s` is not allowed", indexType),
 		StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + line),

--- a/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
+++ b/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -272,7 +274,7 @@ func (r *IndexTypeNoBlobRule) addAdvice(tableName, columnName, columnType string
 	if r.isBlob(columnType) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.IndexTypeNoBlob.Int32(),
+			Code:          code.IndexTypeNoBlob.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Columns in index must not be BLOB but `%s`.`%s` is %s", tableName, columnName, columnType),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + lineNumber),

--- a/backend/plugin/advisor/mysql/rule_insert_disallow_order_by_rand.go
+++ b/backend/plugin/advisor/mysql/rule_insert_disallow_order_by_rand.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -129,7 +130,7 @@ func (r *InsertDisallowOrderByRandRule) checkQueryExpression(ctx *mysql.QueryExp
 		if strings.EqualFold(text, RandFn) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.InsertUseOrderByRand.Int32(),
+				Code:          code.InsertUseOrderByRand.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("\"%s\" uses ORDER BY RAND in the INSERT statement", r.text),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_insert_must_specify_column.go
+++ b/backend/plugin/advisor/mysql/rule_insert_must_specify_column.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -119,7 +120,7 @@ func (r *InsertMustSpecifyColumnRule) checkInsertStatement(ctx *mysql.InsertStat
 	}
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.InsertNotSpecifyColumn.Int32(),
+		Code:          code.InsertNotSpecifyColumn.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("The INSERT statement must specify columns but \"%s\" does not", r.text),
 		StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -130,7 +131,7 @@ func (r *InsertMustSpecifyColumnRule) checkSelectItemList(ctx *mysql.SelectItemL
 	if r.hasSelect && ctx.MULT_OPERATOR() != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.InsertNotSpecifyColumn.Int32(),
+			Code:          code.InsertNotSpecifyColumn.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("The INSERT statement must specify columns but \"%s\" does not", r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_insert_row_limit.go
+++ b/backend/plugin/advisor/mysql/rule_insert_row_limit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -140,7 +141,7 @@ func (r *InsertRowLimitRule) handleInsertQueryExpression(ctx mysql.IInsertQueryE
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.InsertTooManyRows.Int32(),
+			Code:          code.InsertTooManyRows.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", r.text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(r.line),
@@ -151,7 +152,7 @@ func (r *InsertRowLimitRule) handleInsertQueryExpression(ctx mysql.IInsertQueryE
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.Internal.Int32(),
+			Code:          code.Internal.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", r.text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(r.line),
@@ -159,7 +160,7 @@ func (r *InsertRowLimitRule) handleInsertQueryExpression(ctx mysql.IInsertQueryE
 	} else if rowCount > int64(r.maxRow) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.InsertTooManyRows.Int32(),
+			Code:          code.InsertTooManyRows.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", r.text, rowCount, r.maxRow),
 			StartPosition: common.ConvertANTLRLineToPosition(r.line),
@@ -182,7 +183,7 @@ func (r *InsertRowLimitRule) handleNoInsertQueryExpression(ctx mysql.IInsertStat
 	if len(allValues) > r.maxRow {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.InsertTooManyRows.Int32(),
+			Code:          code.InsertTooManyRows.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", r.text, len(allValues), r.maxRow),
 			StartPosition: common.ConvertANTLRLineToPosition(r.line),

--- a/backend/plugin/advisor/mysql/rule_naming_auto_increment_column.go
+++ b/backend/plugin/advisor/mysql/rule_naming_auto_increment_column.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -185,7 +186,7 @@ func (r *NamingAutoIncrementColumnRule) checkFieldDefinition(tableName, columnNa
 	if !r.format.MatchString(columnName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingAutoIncrementColumnConventionMismatch.Int32(),
+			Code:          code.NamingAutoIncrementColumnConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s`.`%s` mismatches auto_increment column naming convention, naming format should be %q", tableName, columnName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -194,7 +195,7 @@ func (r *NamingAutoIncrementColumnRule) checkFieldDefinition(tableName, columnNa
 	if r.maxLength > 0 && len(columnName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingAutoIncrementColumnConventionMismatch.Int32(),
+			Code:          code.NamingAutoIncrementColumnConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s`.`%s` mismatches auto_increment column naming convention, its length should be within %d characters", tableName, columnName, r.maxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_naming_column.go
+++ b/backend/plugin/advisor/mysql/rule_naming_column.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -187,7 +188,7 @@ func (r *NamingColumnRule) handleColumn(tableName string, columnName string, lin
 	if !r.format.MatchString(columnName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingColumnConventionMismatch.Int32(),
+			Code:          code.NamingColumnConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, naming format should be %q", tableName, columnName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
@@ -196,7 +197,7 @@ func (r *NamingColumnRule) handleColumn(tableName string, columnName string, lin
 	if r.maxLength > 0 && len(columnName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingColumnConventionMismatch.Int32(),
+			Code:          code.NamingColumnConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, its length should be within %d characters", tableName, columnName, r.maxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),

--- a/backend/plugin/advisor/mysql/rule_naming_foreign_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_foreign_key_convention.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -187,7 +188,7 @@ func (r *NamingFKConventionRule) handleIndexList(indexDataList []*fkIndexMetaDat
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.Internal.Int32(),
+				Code:    code.Internal.Int32(),
 				Title:   "Internal error for foreign key naming convention rule",
 				Content: fmt.Sprintf("%q meet internal error %q", r.text, err.Error()),
 			})
@@ -196,7 +197,7 @@ func (r *NamingFKConventionRule) handleIndexList(indexDataList []*fkIndexMetaDat
 		if !regex.MatchString(indexData.indexName) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NamingFKConventionMismatch.Int32(),
+				Code:          code.NamingFKConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Foreign key in table `%s` mismatches the naming convention, expect %q but found `%s`", indexData.tableName, regex, indexData.indexName),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),
@@ -205,7 +206,7 @@ func (r *NamingFKConventionRule) handleIndexList(indexDataList []*fkIndexMetaDat
 		if r.maxLength > 0 && len(indexData.indexName) > r.maxLength {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NamingFKConventionMismatch.Int32(),
+				Code:          code.NamingFKConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Foreign key `%s` in table `%s` mismatches the naming convention, its length should be within %d characters", indexData.indexName, indexData.tableName, r.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),

--- a/backend/plugin/advisor/mysql/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/mysql/rule_naming_identifier_no_keyword.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -119,7 +121,7 @@ func (r *NamingIdentifierNoKeywordRule) checkIdentifier(identifier string) *stor
 	if isKeyword(identifier) {
 		return &storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NameIsKeywordIdentifier.Int32(),
+			Code:    code.NameIsKeywordIdentifier.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Identifier %q is a keyword and should be avoided", identifier),
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_index_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_index_convention.go
@@ -13,6 +13,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -258,7 +259,7 @@ func (r *NamingIndexConventionRule) handleIndexList(indexDataList []*indexMetaDa
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.Internal.Int32(),
+				Code:    code.Internal.Int32(),
 				Title:   "Internal error for unique key naming convention rule",
 				Content: fmt.Sprintf("%q meet internal error %q", r.text, err.Error()),
 			})
@@ -267,7 +268,7 @@ func (r *NamingIndexConventionRule) handleIndexList(indexDataList []*indexMetaDa
 		if !regex.MatchString(indexData.indexName) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NamingIndexConventionMismatch.Int32(),
+				Code:          code.NamingIndexConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Index in table `%s` mismatches the naming convention, expect %q but found `%s`", indexData.tableName, regex, indexData.indexName),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),
@@ -276,7 +277,7 @@ func (r *NamingIndexConventionRule) handleIndexList(indexDataList []*indexMetaDa
 		if r.maxLength > 0 && len(indexData.indexName) > r.maxLength {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NamingIndexConventionMismatch.Int32(),
+				Code:          code.NamingIndexConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Index `%s` in table `%s` mismatches the naming convention, its length should be within %d characters", indexData.indexName, indexData.tableName, r.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),

--- a/backend/plugin/advisor/mysql/rule_naming_table.go
+++ b/backend/plugin/advisor/mysql/rule_naming_table.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -150,7 +151,7 @@ func (r *NamingTableRule) handleTableName(tableName string, lineNumber int) {
 	if !r.format.MatchString(tableName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s` mismatches table naming convention, naming format should be %q", tableName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
@@ -159,7 +160,7 @@ func (r *NamingTableRule) handleTableName(tableName string, lineNumber int) {
 	if r.maxLength > 0 && len(tableName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s` mismatches table naming convention, its length should be within %d characters", tableName, r.maxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),

--- a/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
@@ -13,6 +13,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -257,7 +258,7 @@ func (r *NamingUKConventionRule) handleIndexList(indexDataList []*ukIndexMetaDat
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.Internal.Int32(),
+				Code:    code.Internal.Int32(),
 				Title:   "Internal error for unique key naming convention rule",
 				Content: fmt.Sprintf("%q meet internal error %q", r.text, err.Error()),
 			})
@@ -266,7 +267,7 @@ func (r *NamingUKConventionRule) handleIndexList(indexDataList []*ukIndexMetaDat
 		if !regex.MatchString(indexData.indexName) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NamingUKConventionMismatch.Int32(),
+				Code:          code.NamingUKConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Unique key in table `%s` mismatches the naming convention, expect %q but found `%s`", indexData.tableName, regex, indexData.indexName),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),
@@ -275,7 +276,7 @@ func (r *NamingUKConventionRule) handleIndexList(indexDataList []*ukIndexMetaDat
 		if r.maxLength > 0 && len(indexData.indexName) > r.maxLength {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.NamingUKConventionMismatch.Int32(),
+				Code:          code.NamingUKConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Unique key `%s` in table `%s` mismatches the naming convention, its length should be within %d characters", indexData.indexName, indexData.tableName, r.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),

--- a/backend/plugin/advisor/mysql/rule_online_migration.go
+++ b/backend/plugin/advisor/mysql/rule_online_migration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	"github.com/bytebase/bytebase/backend/store/model"
@@ -61,7 +62,7 @@ func (*OnlineMigrationAdvisor) Check(ctx context.Context, checkCtx advisor.Conte
 					Status:        level,
 					Title:         title,
 					Content:       fmt.Sprintf("Needs database %q to save temporary data for online migration but it does not exist", ghostDatabaseName),
-					Code:          advisor.DatabaseNotExists.Int32(),
+					Code:          code.DatabaseNotExists.Int32(),
 					StartPosition: nil,
 				},
 			}, nil
@@ -101,7 +102,7 @@ func (*OnlineMigrationAdvisor) Check(ctx context.Context, checkCtx advisor.Conte
 			return nil, nil
 		}
 
-		adviceList[0].Code = advisor.AdviseOnlineMigration.Int32()
+		adviceList[0].Code = code.AdviseOnlineMigration.Int32()
 		return adviceList, nil
 	}
 
@@ -111,7 +112,7 @@ func (*OnlineMigrationAdvisor) Check(ctx context.Context, checkCtx advisor.Conte
 		if checkCtx.ChangeType == storepb.PlanCheckRunConfig_DDL_GHOST {
 			return []*storepb.Advice{{
 				Status:  level,
-				Code:    advisor.AdviseNoOnlineMigration.Int32(),
+				Code:    code.AdviseNoOnlineMigration.Int32(),
 				Title:   title,
 				Content: "Advise to disable online migration because found no statements that need online migration",
 			}}, nil
@@ -212,7 +213,7 @@ func (r *OnlineMigrationRule) exitAlterStatement(ctx *mysql.AlterStatementContex
 		if tableRows >= r.minRows {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.AdviseOnlineMigrationForStatement.Int32(),
+				Code:          code.AdviseOnlineMigrationForStatement.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Estimated table row count of %q is %d exceeding the set value %d. Consider using online migration for this statement", fmt.Sprintf("%s.%s", resource.Schema, resource.Table), tableRows, r.minRows),
 				StartPosition: r.start,

--- a/backend/plugin/advisor/mysql/rule_statement_add_column_without_position.go
+++ b/backend/plugin/advisor/mysql/rule_statement_add_column_without_position.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -138,7 +139,7 @@ func (r *StatementAddColumnWithoutPositionRule) checkAlterTable(ctx *mysql.Alter
 		if len(position) != 0 {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementAddColumnWithPosition.Int32(),
+				Code:          code.StatementAddColumnWithPosition.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("add column with position \"%s\"", position),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/mysql/rule_statement_affected_row_limit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -127,7 +128,7 @@ func (r *StatementAffectedRowLimitRule) handleStmt(lineNumber int) {
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementAffectedRowExceedsLimit.Int32(),
+			Code:          code.StatementAffectedRowExceedsLimit.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", r.text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
@@ -137,7 +138,7 @@ func (r *StatementAffectedRowLimitRule) handleStmt(lineNumber int) {
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.Internal.Int32(),
+				Code:          code.Internal.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", r.text, err.Error()),
 				StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
@@ -145,7 +146,7 @@ func (r *StatementAffectedRowLimitRule) handleStmt(lineNumber int) {
 		} else if rowCount > int64(r.maxRow) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementAffectedRowExceedsLimit.Int32(),
+				Code:          code.StatementAffectedRowExceedsLimit.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("\"%s\" affected %d rows (estimated). The count exceeds %d.", r.text, rowCount, r.maxRow),
 				StartPosition: common.ConvertANTLRLineToPosition(lineNumber),

--- a/backend/plugin/advisor/mysql/rule_statement_disallow_mix_in_ddl.go
+++ b/backend/plugin/advisor/mysql/rule_statement_disallow_mix_in_ddl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -52,7 +53,7 @@ func (*StatementDisallowMixInDDLAdvisor) Check(_ context.Context, checkCtx advis
 				Status:        level,
 				Title:         title,
 				Content:       fmt.Sprintf("Alter schema can only run DDL, \"%s\" is not DDL", checker.Text),
-				Code:          advisor.StatementDisallowMixDDLDML.Int32(),
+				Code:          code.StatementDisallowMixDDLDML.Int32(),
 				StartPosition: common.ConvertANTLRLineToPosition(stmt.BaseLine),
 			})
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_disallow_mix_in_dml.go
+++ b/backend/plugin/advisor/mysql/rule_statement_disallow_mix_in_dml.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -52,7 +53,7 @@ func (*StatementDisallowMixInDMLAdvisor) Check(_ context.Context, checkCtx advis
 				Status:        level,
 				Title:         title,
 				Content:       fmt.Sprintf("Data change can only run DML, \"%s\" is not DML", checker.Text),
-				Code:          advisor.StatementDisallowMixDDLDML.Int32(),
+				Code:          code.StatementDisallowMixDDLDML.Int32(),
 				StartPosition: common.ConvertANTLRLineToPosition(stmt.BaseLine),
 			})
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_disallow_using_filesort.go
+++ b/backend/plugin/advisor/mysql/rule_statement_disallow_using_filesort.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -116,7 +117,7 @@ func (r *StatementDisallowUsingFilesortRule) checkSelectStatement(ctx *mysql.Sel
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementExplainQueryFailed.Int32(),
+			Code:          code.StatementExplainQueryFailed.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Failed to explain query: %s, with error: %s", query, err),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -126,7 +127,7 @@ func (r *StatementDisallowUsingFilesortRule) checkSelectStatement(ctx *mysql.Sel
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.Internal.Int32(),
+				Code:          code.Internal.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Failed to check extra column: %s, with error: %s", query, err),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -134,7 +135,7 @@ func (r *StatementDisallowUsingFilesortRule) checkSelectStatement(ctx *mysql.Sel
 		} else if hasUsingFilesort {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementHasUsingFilesort.Int32(),
+				Code:          code.StatementHasUsingFilesort.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Using filesort detected on table(s): %s", tables),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_disallow_using_temporary.go
+++ b/backend/plugin/advisor/mysql/rule_statement_disallow_using_temporary.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -116,7 +117,7 @@ func (r *StatementDisallowUsingTemporaryRule) checkSelectStatement(ctx *mysql.Se
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementExplainQueryFailed.Int32(),
+			Code:          code.StatementExplainQueryFailed.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Failed to explain query: %s, with error: %s", query, err),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -126,7 +127,7 @@ func (r *StatementDisallowUsingTemporaryRule) checkSelectStatement(ctx *mysql.Se
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.Internal.Int32(),
+				Code:          code.Internal.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Failed to check extra column: %s, with error: %s", query, err),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -134,7 +135,7 @@ func (r *StatementDisallowUsingTemporaryRule) checkSelectStatement(ctx *mysql.Se
 		} else if hasUsingTemporary {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementHasUsingTemporary.Int32(),
+				Code:          code.StatementHasUsingTemporary.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Using temporary detected on table(s): %s", tables),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/mysql/rule_statement_dml_dry_run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -129,7 +130,7 @@ func (r *StatementDmlDryRunRule) handleStmt(text string, lineNumber int) {
 	if _, err := advisor.Query(r.ctx, advisor.QueryContext{}, r.driver, storepb.Engine_MYSQL, fmt.Sprintf("EXPLAIN %s", text)); err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementDMLDryRunFailed.Int32(),
+			Code:          code.StatementDMLDryRunFailed.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + lineNumber),

--- a/backend/plugin/advisor/mysql/rule_statement_join_strict_column_attrs.go
+++ b/backend/plugin/advisor/mysql/rule_statement_join_strict_column_attrs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
@@ -232,7 +233,7 @@ func (r *StatementJoinStrictColumnAttrsRule) checkColumnAttrs(leftColumnAttr *Co
 	if leftColumn.Type != rightColumn.Type || leftColumn.CharacterSet != rightColumn.CharacterSet || leftColumn.Collation != rightColumn.Collation {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementJoinColumnAttrsNotMatch.Int32(),
+			Code:          code.StatementJoinColumnAttrsNotMatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("%s.%s and %s.%s column fields do not match", leftColumnAttr.Table, leftColumnAttr.Column, rightColumnAttr.Table, rightColumnAttr.Column),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine),

--- a/backend/plugin/advisor/mysql/rule_statement_maximum_join_table_count.go
+++ b/backend/plugin/advisor/mysql/rule_statement_maximum_join_table_count.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -107,7 +108,7 @@ func (r *StatementMaximumJoinTableCountRule) checkJoinedTable(ctx *mysql.JoinedT
 	if r.count == r.limitMaxValue {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementMaximumJoinTableCount.Int32(),
+			Code:          code.StatementMaximumJoinTableCount.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" exceeds the maximum number of joins %d.", r.text, r.limitMaxValue),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_maximum_limit_value.go
+++ b/backend/plugin/advisor/mysql/rule_statement_maximum_limit_value.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -131,7 +132,7 @@ func (r *StatementMaximumLimitValueRule) checkLimitClause(ctx *mysql.LimitClause
 		if limitValue > r.limitMaxValue {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementExceedMaximumLimitValue.Int32(),
+				Code:          code.StatementExceedMaximumLimitValue.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("The limit value %d exceeds the maximum allowed value %d", limitValue, r.limitMaxValue),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_merge_alter_table.go
+++ b/backend/plugin/advisor/mysql/rule_statement_merge_alter_table.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -167,7 +168,7 @@ func (r *StatementMergeAlterTableRule) generateAdvice() {
 		if table.count > 1 {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementRedundantAlterTable.Int32(),
+				Code:          code.StatementRedundantAlterTable.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("There are %d statements to modify table `%s`", table.count, table.name),
 				StartPosition: common.ConvertANTLRLineToPosition(table.lastLine),

--- a/backend/plugin/advisor/mysql/rule_statement_query_minimum_plan_level.go
+++ b/backend/plugin/advisor/mysql/rule_statement_query_minimum_plan_level.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -182,7 +183,7 @@ func (r *StatementQueryMinumumPlanLevelRule) checkSelectStatement(ctx *mysql.Sel
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementExplainQueryFailed.Int32(),
+			Code:          code.StatementExplainQueryFailed.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Failed to explain query: %s, with error: %s", query, err),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -192,7 +193,7 @@ func (r *StatementQueryMinumumPlanLevelRule) checkSelectStatement(ctx *mysql.Sel
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.Internal.Int32(),
+				Code:          code.Internal.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Failed to check explain type column: %s, with error: %s", query, err),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -209,7 +210,7 @@ func (r *StatementQueryMinumumPlanLevelRule) checkSelectStatement(ctx *mysql.Sel
 			if overused {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.StatementUnwantedQueryPlanLevel.Int32(),
+					Code:          code.StatementUnwantedQueryPlanLevel.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Overused query plan level detected %s, minimum plan level: %s", overusedType.String(), r.explainType.String()),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_select_full_table_scan.go
+++ b/backend/plugin/advisor/mysql/rule_statement_select_full_table_scan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -118,7 +119,7 @@ func (r *StatementSelectFullTableScanRule) checkSelectStatement(ctx *mysql.Selec
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementCheckSelectFullTableScanFailed.Int32(),
+			Code:          code.StatementCheckSelectFullTableScanFailed.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Failed to check full table scan: %s, with error: %s", query, err),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -128,7 +129,7 @@ func (r *StatementSelectFullTableScanRule) checkSelectStatement(ctx *mysql.Selec
 		if err != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.Internal.Int32(),
+				Code:          code.Internal.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Failed to check full table scan: %s, with error: %s", query, err),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -136,7 +137,7 @@ func (r *StatementSelectFullTableScanRule) checkSelectStatement(ctx *mysql.Selec
 		} else if hasFullScan {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementHasTableFullScan.Int32(),
+				Code:          code.StatementHasTableFullScan.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Full table scan detected on table(s): %s", tables),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_where_disallow_using_function.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_disallow_using_function.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -115,7 +117,7 @@ func (r *StatementWhereDisallowUsingFunctionRule) checkFunctionCall(ctx *mysql.F
 	if pi != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DisabledFunction.Int32(),
+			Code:          code.DisabledFunction.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Function is disallowed in where clause, but \"%s\" uses", r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_statement_where_maximum_logical_operator_count.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_maximum_logical_operator_count.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -143,7 +144,7 @@ func (r *StatementWhereMaximumLogicalOperatorCountRule) checkExprList(ctx *mysql
 	if count > r.maximum {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementWhereMaximumLogicalOperatorCount.Int32(),
+			Code:          code.StatementWhereMaximumLogicalOperatorCount.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Number of tokens (%d) in IN predicate operation exceeds limit (%d) in statement %q.", count, r.maximum, r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -164,7 +165,7 @@ func (r *StatementWhereMaximumLogicalOperatorCountRule) checkOrConditions() {
 	if r.maxOrCount > r.maximum {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementWhereMaximumLogicalOperatorCount.Int32(),
+			Code:          code.StatementWhereMaximumLogicalOperatorCount.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Number of tokens (%d) in the OR predicate operation exceeds limit (%d) in statement %q.", r.maxOrCount, r.maximum, r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.maxOrCountLine),

--- a/backend/plugin/advisor/mysql/rule_statement_where_no_equal_null.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_no_equal_null.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -112,7 +113,7 @@ func (r *StatementWhereNoEqualNullRule) checkPrimaryExprCompare(ctx *mysql.Prima
 	if ctx.Predicate() != nil && ctx.Predicate().GetText() == "NULL" {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementWhereNoEqualNull.Int32(),
+			Code:          code.StatementWhereNoEqualNull.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("WHERE clause contains equal null: %s", r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_stmt_disallow_commit.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_disallow_commit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -107,7 +108,7 @@ func (r *StatementDisallowCommitRule) checkTransactionStatement(ctx *mysql.Trans
 
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.StatementDisallowCommit.Int32(),
+		Code:          code.StatementDisallowCommit.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("Commit is not allowed, related statement: \"%s\"", r.text),
 		StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_stmt_disallow_limit.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_disallow_limit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -109,13 +110,13 @@ func (r *StatementDisallowLimitRule) OnExit(_ antlr.ParserRuleContext, nodeType 
 
 func (r *StatementDisallowLimitRule) checkDeleteStatement(ctx *mysql.DeleteStatementContext) {
 	if ctx.SimpleLimitClause() != nil && ctx.SimpleLimitClause().LIMIT_SYMBOL() != nil {
-		r.handleLimitClause(advisor.DeleteUseLimit, ctx.GetStart().GetLine())
+		r.handleLimitClause(code.DeleteUseLimit, ctx.GetStart().GetLine())
 	}
 }
 
 func (r *StatementDisallowLimitRule) checkUpdateStatement(ctx *mysql.UpdateStatementContext) {
 	if ctx.SimpleLimitClause() != nil && ctx.SimpleLimitClause().LIMIT_SYMBOL() != nil {
-		r.handleLimitClause(advisor.UpdateUseLimit, ctx.GetStart().GetLine())
+		r.handleLimitClause(code.UpdateUseLimit, ctx.GetStart().GetLine())
 	}
 }
 
@@ -124,11 +125,11 @@ func (r *StatementDisallowLimitRule) checkQueryExpression(ctx *mysql.QueryExpres
 		return
 	}
 	if ctx.LimitClause() != nil && ctx.LimitClause().LIMIT_SYMBOL() != nil {
-		r.handleLimitClause(advisor.InsertUseLimit, ctx.GetStart().GetLine())
+		r.handleLimitClause(code.InsertUseLimit, ctx.GetStart().GetLine())
 	}
 }
 
-func (r *StatementDisallowLimitRule) handleLimitClause(code advisor.Code, lineNumber int) {
+func (r *StatementDisallowLimitRule) handleLimitClause(code code.Code, lineNumber int) {
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
 		Code:          code.Int32(),

--- a/backend/plugin/advisor/mysql/rule_stmt_disallow_order_by.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_disallow_order_by.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -101,17 +102,17 @@ func (*DisallowOrderByRule) OnExit(_ antlr.ParserRuleContext, _ string) error {
 
 func (r *DisallowOrderByRule) checkDeleteStatement(ctx *mysql.DeleteStatementContext) {
 	if ctx.OrderClause() != nil && ctx.OrderClause().ORDER_SYMBOL() != nil {
-		r.handleOrderByClause(advisor.DeleteUseOrderBy, ctx.GetStart().GetLine())
+		r.handleOrderByClause(code.DeleteUseOrderBy, ctx.GetStart().GetLine())
 	}
 }
 
 func (r *DisallowOrderByRule) checkUpdateStatement(ctx *mysql.UpdateStatementContext) {
 	if ctx.OrderClause() != nil && ctx.OrderClause().ORDER_SYMBOL() != nil {
-		r.handleOrderByClause(advisor.UpdateUseOrderBy, ctx.GetStart().GetLine())
+		r.handleOrderByClause(code.UpdateUseOrderBy, ctx.GetStart().GetLine())
 	}
 }
 
-func (r *DisallowOrderByRule) handleOrderByClause(code advisor.Code, lineNumber int) {
+func (r *DisallowOrderByRule) handleOrderByClause(code code.Code, lineNumber int) {
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
 		Code:          code.Int32(),

--- a/backend/plugin/advisor/mysql/rule_stmt_max_execution_time.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_max_execution_time.go
@@ -12,6 +12,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -152,7 +153,7 @@ func (r *MaxExecutionTimeRule) checkSetStatement(ctx *mysql.SetStatementContext)
 func (r *MaxExecutionTimeRule) setAdvice() {
 	r.adviceList = append(r.adviceList, &storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.StatementNoMaxExecutionTime.Int32(),
+		Code:    code.StatementNoMaxExecutionTime.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("The %s is not set", r.systemVariable),
 	})

--- a/backend/plugin/advisor/mysql/rule_stmt_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_no_leading_wildcard_like.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -108,7 +109,7 @@ func (r *NoLeadingWildcardLikeRule) checkPredicateExprLike(ctx *mysql.PredicateE
 		if (strings.HasPrefix(pattern, "'%") && strings.HasSuffix(pattern, "'")) || (strings.HasPrefix(pattern, "\"%") && strings.HasSuffix(pattern, "\"")) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementLeadingWildcardLike.Int32(),
+				Code:          code.StatementLeadingWildcardLike.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("\"%s\" uses leading wildcard LIKE", r.text),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_stmt_no_select_all.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_no_select_all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -102,7 +103,7 @@ func (r *NoSelectAllRule) checkSelectItemList(ctx *mysql.SelectItemListContext) 
 	if ctx.MULT_OPERATOR() != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementSelectAll.Int32(),
+			Code:          code.StatementSelectAll.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" uses SELECT all", r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_stmt_require_algorithm_or_lock_options.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_require_algorithm_or_lock_options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -40,9 +41,9 @@ func (*RequireAlgorithmOrLockOptionAdvisor) Check(_ context.Context, checkCtx ad
 		return nil, err
 	}
 
-	requiredOption, errorCode := "ALGORITHM", advisor.StatementNoAlgorithmOption
+	requiredOption, errorCode := "ALGORITHM", code.StatementNoAlgorithmOption
 	if checkCtx.Rule.Type == string(advisor.SchemaRuleStatementRequireLockOption) {
-		requiredOption, errorCode = "LOCK", advisor.StatementNoLockOption
+		requiredOption, errorCode = "LOCK", code.StatementNoLockOption
 	}
 
 	// Create the rule
@@ -66,13 +67,13 @@ type RequireAlgorithmOrLockOptionRule struct {
 	requiredOption        string
 	hasOption             bool
 	inAlterTableStatement bool
-	errorCode             advisor.Code
+	errorCode             code.Code
 	text                  string
 	line                  int
 }
 
 // NewRequireAlgorithmOrLockOptionRule creates a new RequireAlgorithmOrLockOptionRule.
-func NewRequireAlgorithmOrLockOptionRule(level storepb.Advice_Status, title string, requiredOption string, errorCode advisor.Code) *RequireAlgorithmOrLockOptionRule {
+func NewRequireAlgorithmOrLockOptionRule(level storepb.Advice_Status, title string, requiredOption string, errorCode code.Code) *RequireAlgorithmOrLockOptionRule {
 	return &RequireAlgorithmOrLockOptionRule{
 		BaseRule: BaseRule{
 			level: level,

--- a/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_select.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_select.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -105,7 +106,7 @@ func (r *WhereRequirementForSelectRule) checkQuerySpecification(ctx *mysql.Query
 	if ctx.WhereClause() == nil || ctx.WhereClause().WHERE_SYMBOL() == nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementNoWhere.Int32(),
+			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" requires WHERE clause", r.text),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_update_delete.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_update_delete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -120,7 +121,7 @@ func (r *WhereRequirementForUpdateDeleteRule) checkUpdateStatement(ctx *mysql.Up
 func (r *WhereRequirementForUpdateDeleteRule) handleWhereClause(lineNumber int) {
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.StatementNoWhere.Int32(),
+		Code:          code.StatementNoWhere.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("\"%s\" requires WHERE clause", r.text),
 		StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + lineNumber),

--- a/backend/plugin/advisor/mysql/rule_table_comment_convention.go
+++ b/backend/plugin/advisor/mysql/rule_table_comment_convention.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -111,7 +112,7 @@ func (r *TableCommentConventionRule) checkCreateTable(ctx *mysql.CreateTableCont
 	if r.payload.Required && !exists {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.CommentEmpty.Int32(),
+			Code:          code.CommentEmpty.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table `%s` requires comments", tableName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -120,7 +121,7 @@ func (r *TableCommentConventionRule) checkCreateTable(ctx *mysql.CreateTableCont
 	if r.payload.MaxLength >= 0 && len(comment) > r.payload.MaxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.CommentTooLong.Int32(),
+			Code:          code.CommentTooLong.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("The length of table `%s` comment should be within %d characters", tableName, r.payload.MaxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -130,7 +131,7 @@ func (r *TableCommentConventionRule) checkCreateTable(ctx *mysql.CreateTableCont
 		if classification, _ := common.GetClassificationAndUserComment(comment, r.classificationConfig); classification == "" {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.CommentMissingClassification.Int32(),
+				Code:          code.CommentMissingClassification.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table `%s` comment requires classification", tableName),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_table_disallow_ddl.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_ddl.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -150,7 +152,7 @@ func (r *TableDisallowDDLRule) checkTableName(tableName string, line int) {
 		if tableName == disallow {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableDisallowDDL.Int32(),
+				Code:          code.TableDisallowDDL.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("DDL is disallowed on table %s.", tableName),
 				StartPosition: common.ConvertANTLRLineToPosition(line),

--- a/backend/plugin/advisor/mysql/rule_table_disallow_dml.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_dml.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -142,7 +144,7 @@ func (r *TableDisallowDMLRule) checkTableName(tableName string, line int) {
 		if tableName == disallow {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableDisallowDML.Int32(),
+				Code:          code.TableDisallowDML.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("DML is disallowed on table %s.", tableName),
 				StartPosition: common.ConvertANTLRLineToPosition(line),

--- a/backend/plugin/advisor/mysql/rule_table_disallow_partition.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_partition.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -103,12 +105,12 @@ func (r *TableDisallowPartitionRule) checkCreateTable(ctx *mysql.CreateTableCont
 	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
 		return
 	}
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if ctx.PartitionClause() != nil && ctx.PartitionClause().PartitionTypeDef() != nil {
-		code = advisor.CreateTablePartition
+		code = advisorcode.CreateTablePartition
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
 			Code:          code.Int32(),
@@ -123,11 +125,11 @@ func (r *TableDisallowPartitionRule) checkAlterTable(ctx *mysql.AlterTableContex
 	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
 		return
 	}
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if ctx.AlterTableActions() != nil && ctx.AlterTableActions().PartitionClause() != nil && ctx.AlterTableActions().PartitionClause().PartitionTypeDef() != nil {
-		code = advisor.CreateTablePartition
+		code = advisorcode.CreateTablePartition
 	}
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/mysql/rule_table_disallow_set_charset.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_set_charset.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -105,7 +106,7 @@ func (r *TableDisallowSetCharsetRule) checkCreateTable(ctx *mysql.CreateTableCon
 			if option.DefaultCharset() != nil {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.DisallowSetCharset.Int32(),
+					Code:          code.DisallowSetCharset.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Set charset on tables is disallowed, but \"%s\" uses", r.text),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -135,7 +136,7 @@ func (r *TableDisallowSetCharsetRule) checkAlterTable(ctx *mysql.AlterTableConte
 		if alterListItem.Charset() != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.DisallowSetCharset.Int32(),
+				Code:          code.DisallowSetCharset.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Set charset on tables is disallowed, but \"%s\" uses", r.text),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_table_disallow_trigger.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_trigger.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -100,12 +102,12 @@ func (r *TableDisallowTriggerRule) checkCreateTrigger(ctx *mysql.CreateTriggerCo
 	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
 		return
 	}
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if ctx.TriggerName() != nil {
-		code = advisor.CreateTableTrigger
+		code = advisorcode.CreateTableTrigger
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/mysql/rule_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/mysql/rule_table_drop_naming_convention.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -107,7 +109,7 @@ func (r *TableDropNamingConventionRule) checkDropTable(ctx *mysql.DropTableConte
 		if !r.format.MatchString(tableName) {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableDropNamingConventionMismatch.Int32(),
+				Code:          code.TableDropNamingConventionMismatch.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("`%s` mismatches drop table naming convention, naming format should be %q", tableName, r.format),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_table_limit_size.go
+++ b/backend/plugin/advisor/mysql/rule_table_limit_size.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -145,7 +147,7 @@ func (r *TableLimitSizeRule) generateAdvice() {
 			if tableRows >= int64(r.maxRows) {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.TableExceedLimitSize.Int32(),
+					Code:          code.TableExceedLimitSize.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Apply DDL on large table '%s' ( %d rows ) will lock table for a long time", tabName, tableRows),
 					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + r.statementBaseLine),

--- a/backend/plugin/advisor/mysql/rule_table_no_duplicate_index.go
+++ b/backend/plugin/advisor/mysql/rule_table_no_duplicate_index.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -134,7 +136,7 @@ func (r *TableNoDuplicateIndexRule) checkCreateTable(ctx *mysql.CreateTableConte
 	if index := hasDuplicateIndexes(r.indexList); index != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DuplicateIndexInTable.Int32(),
+			Code:          code.DuplicateIndexInTable.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s` has duplicate index `%s`", tableName, index.indexName),
 			StartPosition: common.ConvertANTLRLineToPosition(index.line),
@@ -165,7 +167,7 @@ func (r *TableNoDuplicateIndexRule) checkAlterTable(ctx *mysql.AlterTableContext
 	if index := hasDuplicateIndexes(r.indexList); index != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DuplicateIndexInTable.Int32(),
+			Code:          code.DuplicateIndexInTable.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s` has duplicate index `%s`", tableName, index.indexName),
 			StartPosition: common.ConvertANTLRLineToPosition(index.line),
@@ -247,7 +249,7 @@ func (r *TableNoDuplicateIndexRule) checkCreateIndex(ctx *mysql.CreateIndexConte
 	if index := hasDuplicateIndexes(r.indexList); index != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.DuplicateIndexInTable.Int32(),
+			Code:          code.DuplicateIndexInTable.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("`%s` has duplicate index `%s`", tableName, index.indexName),
 			StartPosition: common.ConvertANTLRLineToPosition(index.line),

--- a/backend/plugin/advisor/mysql/rule_table_no_fk.go
+++ b/backend/plugin/advisor/mysql/rule_table_no_fk.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -137,7 +139,7 @@ func (r *TableNoFKRule) handleTableConstraintDef(tableName string, ctx mysql.ITa
 		case "FOREIGN":
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableHasFK.Int32(),
+				Code:          code.TableHasFK.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Foreign key is not allowed in the table `%s`", tableName),
 				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_table_require_charset.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_charset.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -106,7 +108,7 @@ func (r *TableRequireCharsetRule) checkCreateTable(ctx *mysql.CreateTableContext
 	if !hasCharset {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NoCharset.Int32(),
+			Code:          code.NoCharset.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table %s does not have a character set specified", tableName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_table_require_collation.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_collation.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/parser/mysql"
 	"github.com/pkg/errors"
@@ -106,7 +108,7 @@ func (r *TableRequireCollationRule) checkCreateTable(ctx *mysql.CreateTableConte
 	if !hasCollation {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NoCollation.Int32(),
+			Code:          code.NoCollation.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table %s does not have a collation specified", tableName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_pk.go
@@ -14,6 +14,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -230,7 +231,7 @@ func (r *TableRequirePKRule) generateAdviceList() {
 		if len(r.tables[tableName]) == 0 {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableNoPK.Int32(),
+				Code:          code.TableNoPK.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table `%s` requires PRIMARY KEY", tableName),
 				StartPosition: common.ConvertANTLRLineToPosition(r.line[tableName]),

--- a/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
+++ b/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
@@ -122,7 +124,7 @@ func (r *TableTextFieldsTotalLengthRule) checkCreateTable(ctx *mysql.CreateTable
 	if total > int64(r.maximum) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.IndexCountExceedsLimit.Int32(),
+			Code:          code.IndexCountExceedsLimit.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table %q total text column length (%d) exceeds the limit (%d).", tableName, total, r.maximum),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
@@ -156,7 +158,7 @@ func (r *TableTextFieldsTotalLengthRule) checkAlterTable(ctx *mysql.AlterTableCo
 	if total > int64(r.maximum) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.TotalTextLengthExceedsLimit.Int32(),
+			Code:          code.TotalTextLengthExceedsLimit.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table %q total text column length (%d) exceeds the limit (%d).", tableName, total, r.maximum),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/mysql/rule_view_disallow_create.go
+++ b/backend/plugin/advisor/mysql/rule_view_disallow_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -99,12 +100,12 @@ func (r *ViewDisallowCreateRule) checkCreateView(ctx *mysql.CreateViewContext) {
 	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
 		return
 	}
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if ctx.ViewName() != nil {
-		code = advisor.DisallowCreateView
+		code = advisorcode.DisallowCreateView
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/oceanbase/advisor_disallow_offline_ddl.go
+++ b/backend/plugin/advisor/oceanbase/advisor_disallow_offline_ddl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -252,7 +253,7 @@ func (*disallowOfflineDdlChecker) isPrimaryKeyColumn(ctx mysql.IFieldDefinitionC
 func (checker *disallowOfflineDdlChecker) advice(ctx antlr.ParserRuleContext, operation string) {
 	checker.adviceList = append(checker.adviceList, &storepb.Advice{
 		Status:        checker.level,
-		Code:          advisor.StatementOfflineDDL.Int32(),
+		Code:          code.StatementOfflineDDL.Int32(),
 		Title:         checker.title,
 		Content:       fmt.Sprintf("%s is an offline DDL operation.", operation),
 		StartPosition: common.ConvertANTLRLineToPosition(checker.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/oceanbase/advisor_insert_row_limit.go
+++ b/backend/plugin/advisor/oceanbase/advisor_insert_row_limit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -107,7 +108,7 @@ func (checker *insertRowLimitChecker) handleInsertQueryExpression(ctx mysql.IIns
 	if err != nil {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.InsertTooManyRows.Int32(),
+			Code:          code.InsertTooManyRows.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", checker.text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),
@@ -118,7 +119,7 @@ func (checker *insertRowLimitChecker) handleInsertQueryExpression(ctx mysql.IIns
 	if err != nil {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.Internal.Int32(),
+			Code:          code.Internal.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", checker.text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),
@@ -126,7 +127,7 @@ func (checker *insertRowLimitChecker) handleInsertQueryExpression(ctx mysql.IIns
 	} else if rowCount > int64(checker.maxRow) {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.InsertTooManyRows.Int32(),
+			Code:          code.InsertTooManyRows.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", checker.text, rowCount, checker.maxRow),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),
@@ -149,7 +150,7 @@ func (checker *insertRowLimitChecker) handleNoInsertQueryExpression(ctx mysql.II
 	if len(allValues) > checker.maxRow {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.InsertTooManyRows.Int32(),
+			Code:          code.InsertTooManyRows.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", checker.text, len(allValues), checker.maxRow),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/oceanbase/advisor_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/oceanbase/advisor_statement_affected_row_limit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -105,7 +106,7 @@ func (checker *statementAffectedRowLimitChecker) handleStmt(lineNumber int) {
 	if err != nil {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.StatementAffectedRowExceedsLimit.Int32(),
+			Code:          code.StatementAffectedRowExceedsLimit.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", checker.text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
@@ -115,7 +116,7 @@ func (checker *statementAffectedRowLimitChecker) handleStmt(lineNumber int) {
 		if err != nil {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.Internal.Int32(),
+				Code:          code.Internal.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", checker.text, err.Error()),
 				StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
@@ -123,7 +124,7 @@ func (checker *statementAffectedRowLimitChecker) handleStmt(lineNumber int) {
 		} else if rowCount > int64(checker.maxRow) {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.StatementAffectedRowExceedsLimit.Int32(),
+				Code:          code.StatementAffectedRowExceedsLimit.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("\"%s\" affected %d rows (estimated). The count exceeds %d.", checker.text, rowCount, checker.maxRow),
 				StartPosition: common.ConvertANTLRLineToPosition(lineNumber),

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -252,7 +253,7 @@ func (r *StatementPriorBackupCheckRule) handleSQLScriptExit() {
 			Status:        r.level,
 			Title:         r.title,
 			Content:       fmt.Sprintf("The size of the SQL statements exceeds the maximum limit of %d bytes for backup", common.MaxSheetCheckSize),
-			Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+			Code:          code.BuiltinPriorBackupCheck.Int32(),
 			StartPosition: nil,
 		})
 	}
@@ -263,7 +264,7 @@ func (r *StatementPriorBackupCheckRule) handleSQLScriptExit() {
 			Status:        r.level,
 			Title:         r.title,
 			Content:       fmt.Sprintf("Need database %q to do prior backup but it does not exist", databaseName),
-			Code:          advisor.DatabaseNotExists.Int32(),
+			Code:          code.DatabaseNotExists.Int32(),
 			StartPosition: nil,
 		})
 		r.adviceList = append(r.adviceList, adviceList...)
@@ -275,7 +276,7 @@ func (r *StatementPriorBackupCheckRule) handleSQLScriptExit() {
 			Status:        r.level,
 			Title:         r.title,
 			Content:       "Prior backup cannot deal with mixed DDL and DML statements",
-			Code:          int32(advisor.BuiltinPriorBackupCheck),
+			Code:          int32(code.BuiltinPriorBackupCheck),
 			StartPosition: nil,
 		})
 	}
@@ -303,7 +304,7 @@ func (r *StatementPriorBackupCheckRule) handleSQLScriptExit() {
 					Status:        r.level,
 					Title:         r.title,
 					Content:       fmt.Sprintf("Prior backup cannot handle mixed DML statements on the same table %q", key),
-					Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+					Code:          code.BuiltinPriorBackupCheck.Int32(),
 					StartPosition: nil,
 				})
 				break

--- a/backend/plugin/advisor/oracle/rule_column_add_not_null_column_require_default.go
+++ b/backend/plugin/advisor/oracle/rule_column_add_not_null_column_require_default.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -125,7 +127,7 @@ func (r *ColumnAddNotNullColumnRequireDefaultRule) handleColumnDefinitionExit(ct
 	if ctx.DEFAULT() == nil {
 		r.AddAdvice(
 			r.level,
-			advisor.NotNullColumnWithNoDefault.Int32(),
+			code.NotNullColumnWithNoDefault.Int32(),
 			fmt.Sprintf("Adding not null column %q requires default.", normalizeIdentifier(ctx.Column_name(), r.currentDatabase)),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_column_comment_convention.go
+++ b/backend/plugin/advisor/oracle/rule_column_comment_convention.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -161,7 +162,7 @@ func (r *ColumnCommentConventionRule) GetAdviceList() ([]*storepb.Advice, error)
 			if r.payload.Required {
 				r.AddAdvice(
 					r.level,
-					advisor.CommentEmpty.Int32(),
+					code.CommentEmpty.Int32(),
 					fmt.Sprintf("Comment is required for column %s", normalizeIdentifierName(columnName)),
 					common.ConvertANTLRLineToPosition(r.columnLine[columnName]),
 				)
@@ -170,7 +171,7 @@ func (r *ColumnCommentConventionRule) GetAdviceList() ([]*storepb.Advice, error)
 			if r.payload.MaxLength > 0 && len(comment) > r.payload.MaxLength {
 				r.AddAdvice(
 					r.level,
-					advisor.CommentTooLong.Int32(),
+					code.CommentTooLong.Int32(),
 					fmt.Sprintf("Column %s comment is too long. The length of comment should be within %d characters", normalizeIdentifierName(columnName), r.payload.MaxLength),
 					common.ConvertANTLRLineToPosition(r.columnLine[columnName]),
 				)
@@ -179,7 +180,7 @@ func (r *ColumnCommentConventionRule) GetAdviceList() ([]*storepb.Advice, error)
 				if classification, _ := common.GetClassificationAndUserComment(comment, r.classificationConfig); classification == "" {
 					r.AddAdvice(
 						r.level,
-						advisor.CommentMissingClassification.Int32(),
+						code.CommentMissingClassification.Int32(),
 						fmt.Sprintf("Column %s comment requires classification", normalizeIdentifierName(columnName)),
 						common.ConvertANTLRLineToPosition(r.columnLine[columnName]),
 					)

--- a/backend/plugin/advisor/oracle/rule_column_maximum_character_length.go
+++ b/backend/plugin/advisor/oracle/rule_column_maximum_character_length.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -116,7 +118,7 @@ func (r *ColumnMaximumCharacterLengthRule) handleDatatype(ctx *parser.DatatypeCo
 
 	r.AddAdvice(
 		r.level,
-		advisor.CharLengthExceedsLimit.Int32(),
+		code.CharLengthExceedsLimit.Int32(),
 		fmt.Sprintf("The maximum character length is %d.", r.maximum),
 		common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 	)

--- a/backend/plugin/advisor/oracle/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/oracle/rule_column_maximum_varchar_length.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -116,7 +118,7 @@ func (r *ColumnMaximumVarcharLengthRule) handleDatatype(ctx *parser.DatatypeCont
 
 	r.AddAdvice(
 		r.level,
-		advisor.VarcharLengthExceedsLimit.Int32(),
+		code.VarcharLengthExceedsLimit.Int32(),
 		fmt.Sprintf("The maximum varchar length is %d.", r.maximum),
 		common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 	)

--- a/backend/plugin/advisor/oracle/rule_column_no_null.go
+++ b/backend/plugin/advisor/oracle/rule_column_no_null.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -125,7 +126,7 @@ func (r *ColumnNoNullRule) GetAdviceList() ([]*storepb.Advice, error) {
 		line := r.nullableColumns[columnID]
 		r.AddAdvice(
 			r.level,
-			advisor.ColumnCannotNull.Int32(),
+			code.ColumnCannotNull.Int32(),
 			fmt.Sprintf("Column %q is nullable, which is not allowed.", lastIdentifier(columnID)),
 			common.ConvertANTLRLineToPosition(line),
 		)

--- a/backend/plugin/advisor/oracle/rule_column_require.go
+++ b/backend/plugin/advisor/oracle/rule_column_require.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -140,7 +142,7 @@ func (r *ColumnRequireRule) handleCreateTableExit(ctx *parser.Create_tableContex
 	tableName := normalizeIdentifier(ctx.Table_name(), r.currentDatabase)
 	r.AddAdvice(
 		r.level,
-		advisor.NoRequiredColumn.Int32(),
+		code.NoRequiredColumn.Int32(),
 		fmt.Sprintf("Table %q requires columns: %s", tableName, strings.Join(missingColumns, ", ")),
 		common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStop().GetLine()),
 	)
@@ -173,7 +175,7 @@ func (r *ColumnRequireRule) handleAlterTableExit(ctx *parser.Alter_tableContext)
 	tableName := lastIdentifier(normalizeIdentifier(ctx.Tableview_name(), r.currentDatabase))
 	r.AddAdvice(
 		r.level,
-		advisor.NoRequiredColumn.Int32(),
+		code.NoRequiredColumn.Int32(),
 		fmt.Sprintf("Table %q requires columns: %s", tableName, strings.Join(missingColumns, ", ")),
 		common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStop().GetLine()),
 	)

--- a/backend/plugin/advisor/oracle/rule_column_require_default.go
+++ b/backend/plugin/advisor/oracle/rule_column_require_default.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -116,7 +118,7 @@ func (r *ColumnRequireDefaultRule) GetAdviceList() ([]*storepb.Advice, error) {
 		line := r.noDefaultColumns[columnID]
 		r.AddAdvice(
 			r.level,
-			advisor.NoDefault.Int32(),
+			code.NoDefault.Int32(),
 			fmt.Sprintf("Column %q doesn't have default value", lastIdentifier(columnID)),
 			common.ConvertANTLRLineToPosition(line),
 		)

--- a/backend/plugin/advisor/oracle/rule_column_type_disallow_list.go
+++ b/backend/plugin/advisor/oracle/rule_column_type_disallow_list.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -112,7 +114,7 @@ func (r *ColumnTypeDisallowListRule) handleColumnDefinition(ctx *parser.Column_d
 	if r.isDisallowType(ctx.Datatype()) {
 		r.AddAdvice(
 			r.level,
-			advisor.DisabledColumnType.Int32(),
+			code.DisabledColumnType.Int32(),
 			fmt.Sprintf("Disallow column type %s but column \"%s\" is", ctx.Datatype().GetText(), normalizeIdentifier(ctx.Column_name(), r.currentDatabase)),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.Datatype().GetStart().GetLine()),
 		)
@@ -122,7 +124,7 @@ func (r *ColumnTypeDisallowListRule) handleColumnDefinition(ctx *parser.Column_d
 			if ctx.Regular_id().GetText() == tp {
 				r.AddAdvice(
 					r.level,
-					advisor.DisabledColumnType.Int32(),
+					code.DisabledColumnType.Int32(),
 					fmt.Sprintf("Disallow column type %s but column \"%s\" is", ctx.Regular_id().GetText(), normalizeIdentifier(ctx.Column_name(), r.currentDatabase)),
 					common.ConvertANTLRLineToPosition(r.baseLine+ctx.Regular_id().GetStart().GetLine()),
 				)
@@ -136,7 +138,7 @@ func (r *ColumnTypeDisallowListRule) handleModifyColProperties(ctx *parser.Modif
 	if r.isDisallowType(ctx.Datatype()) {
 		r.AddAdvice(
 			r.level,
-			advisor.DisabledColumnType.Int32(),
+			code.DisabledColumnType.Int32(),
 			fmt.Sprintf("Disallow column type %s but column \"%s\" is", ctx.Datatype().GetText(), normalizeIdentifier(ctx.Column_name(), r.currentDatabase)),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.Datatype().GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_index_key_number_limit.go
+++ b/backend/plugin/advisor/oracle/rule_index_key_number_limit.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -103,7 +105,7 @@ func (r *IndexKeyNumberLimitRule) handleTableIndexClause(ctx *parser.Table_index
 	if keys > r.max {
 		r.AddAdvice(
 			r.level,
-			advisor.IndexKeyNumberExceedsLimit.Int32(),
+			code.IndexKeyNumberExceedsLimit.Int32(),
 			fmt.Sprintf("Index key number should be less than or equal to %d", r.max),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)
@@ -115,7 +117,7 @@ func (r *IndexKeyNumberLimitRule) handleOutOfLineConstraint(ctx *parser.Out_of_l
 	if keys > r.max {
 		r.AddAdvice(
 			r.level,
-			advisor.IndexKeyNumberExceedsLimit.Int32(),
+			code.IndexKeyNumberExceedsLimit.Int32(),
 			fmt.Sprintf("Index key number should be less than or equal to %d", r.max),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_insert_must_specify_column.go
+++ b/backend/plugin/advisor/oracle/rule_insert_must_specify_column.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -87,7 +88,7 @@ func (r *InsertMustSpecifyColumnRule) handleInsertIntoClause(ctx *parser.Insert_
 	if ctx.Paren_column_list() == nil {
 		r.AddAdvice(
 			r.level,
-			advisor.InsertNotSpecifyColumn.Int32(),
+			code.InsertNotSpecifyColumn.Int32(),
 			"INSERT statement should specify column name.",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_naming_identifier_case.go
+++ b/backend/plugin/advisor/oracle/rule_naming_identifier_case.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -97,7 +98,7 @@ func (r *NamingIdentifierCaseRule) handleIDExpression(ctx *parser.Id_expressionC
 		if identifier != strings.ToUpper(identifier) {
 			r.AddAdvice(
 				r.level,
-				advisor.NamingCaseMismatch.Int32(),
+				code.NamingCaseMismatch.Int32(),
 				fmt.Sprintf("Identifier %q should be upper case", identifier),
 				common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 			)
@@ -106,7 +107,7 @@ func (r *NamingIdentifierCaseRule) handleIDExpression(ctx *parser.Id_expressionC
 		if identifier != strings.ToLower(identifier) {
 			r.AddAdvice(
 				r.level,
-				advisor.NamingCaseMismatch.Int32(),
+				code.NamingCaseMismatch.Int32(),
 				fmt.Sprintf("Identifier %q should be lower case", identifier),
 				common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 			)

--- a/backend/plugin/advisor/oracle/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/oracle/rule_naming_identifier_no_keyword.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -89,7 +91,7 @@ func (r *NamingIdentifierNoKeywordRule) handleIDExpression(ctx *parser.Id_expres
 	if plsqlparser.IsOracleKeyword(identifier) {
 		r.AddAdvice(
 			r.level,
-			advisor.NameIsKeywordIdentifier.Int32(),
+			code.NameIsKeywordIdentifier.Int32(),
 			fmt.Sprintf("Identifier %q is a keyword and should be avoided", identifier),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_naming_table.go
+++ b/backend/plugin/advisor/oracle/rule_naming_table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -102,7 +103,7 @@ func (r *NamingTableRule) handleCreateTable(ctx *parser.Create_tableContext) {
 	if !r.format.MatchString(tableName) {
 		r.AddAdvice(
 			r.level,
-			advisor.NamingTableConventionMismatch.Int32(),
+			code.NamingTableConventionMismatch.Int32(),
 			fmt.Sprintf(`"%s" mismatches table naming convention, naming format should be %q`, tableName, r.format),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)
@@ -110,7 +111,7 @@ func (r *NamingTableRule) handleCreateTable(ctx *parser.Create_tableContext) {
 	if r.maxLength > 0 && len(tableName) > r.maxLength {
 		r.AddAdvice(
 			r.level,
-			advisor.NamingTableConventionMismatch.Int32(),
+			code.NamingTableConventionMismatch.Int32(),
 			fmt.Sprintf("\"%s\" mismatches table naming convention, its length should be within %d characters", tableName, r.maxLength),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)
@@ -128,7 +129,7 @@ func (r *NamingTableRule) handleAlterTableProperties(ctx *parser.Alter_table_pro
 	if !r.format.MatchString(tableName) {
 		r.AddAdvice(
 			r.level,
-			advisor.NamingTableConventionMismatch.Int32(),
+			code.NamingTableConventionMismatch.Int32(),
 			fmt.Sprintf(`"%s" mismatches table naming convention, naming format should be %q`, tableName, r.format),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)
@@ -136,7 +137,7 @@ func (r *NamingTableRule) handleAlterTableProperties(ctx *parser.Alter_table_pro
 	if r.maxLength > 0 && len(tableName) > r.maxLength {
 		r.AddAdvice(
 			r.level,
-			advisor.NamingTableConventionMismatch.Int32(),
+			code.NamingTableConventionMismatch.Int32(),
 			fmt.Sprintf("\"%s\" mismatches table naming convention, its length should be within %d characters", tableName, r.maxLength),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_naming_table_no_keyword.go
+++ b/backend/plugin/advisor/oracle/rule_naming_table_no_keyword.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -93,7 +95,7 @@ func (r *NamingTableNoKeywordRule) handleCreateTable(ctx *parser.Create_tableCon
 	if plsqlparser.IsOracleKeyword(tableName) {
 		r.AddAdvice(
 			r.level,
-			advisor.NameIsKeywordIdentifier.Int32(),
+			code.NameIsKeywordIdentifier.Int32(),
 			fmt.Sprintf("Table name %q is a keyword identifier and should be avoided.", tableName),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)
@@ -108,7 +110,7 @@ func (r *NamingTableNoKeywordRule) handleAlterTableProperties(ctx *parser.Alter_
 	if plsqlparser.IsOracleKeyword(tableName) {
 		r.AddAdvice(
 			r.level,
-			advisor.NameIsKeywordIdentifier.Int32(),
+			code.NameIsKeywordIdentifier.Int32(),
 			fmt.Sprintf("Table name %q is a keyword identifier and should be avoided.", tableName),
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_select_no_select_all.go
+++ b/backend/plugin/advisor/oracle/rule_select_no_select_all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -87,7 +88,7 @@ func (r *SelectNoSelectAllRule) handleSelectedList(ctx *parser.Selected_listCont
 	if ctx.ASTERISK() != nil {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementSelectAll.Int32(),
+			code.StatementSelectAll.Int32(),
 			"Avoid using SELECT *.",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_statement_disallow_mix_in_ddl.go
+++ b/backend/plugin/advisor/oracle/rule_statement_disallow_mix_in_ddl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -87,7 +88,7 @@ func (r *StatementDisallowMixInDDLRule) handleUnitStatement(ctx *parser.Unit_sta
 	if ctx.Data_manipulation_language_statements() != nil {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementDisallowMixDDLDML.Int32(),
+			code.StatementDisallowMixDDLDML.Int32(),
 			"Alter schema can only run DDL",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_statement_disallow_mix_in_dml.go
+++ b/backend/plugin/advisor/oracle/rule_statement_disallow_mix_in_dml.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -88,7 +89,7 @@ func (r *StatementDisallowMixInDMLRule) handleUnitStatement(ctx *parser.Unit_sta
 	if ctx.Data_manipulation_language_statements() == nil {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementDisallowMixDDLDML.Int32(),
+			code.StatementDisallowMixDDLDML.Int32(),
 			"Data change can only run DML",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/oracle/rule_statement_dml_dry_run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -128,7 +129,7 @@ func (r *StatementDmlDryRunRule) handleStmt(text string, lineNumber int) {
 	if _, err := advisor.Query(r.ctx, advisor.QueryContext{}, r.driver, storepb.Engine_ORACLE, fmt.Sprintf("EXPLAIN PLAN FOR %s", text)); err != nil {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementDMLDryRunFailed.Int32(),
+			code.StatementDMLDryRunFailed.Int32(),
 			fmt.Sprintf("Failed to dry run statement at line %d: %v", lineNumber, err),
 			common.ConvertANTLRLineToPosition(lineNumber),
 		)

--- a/backend/plugin/advisor/oracle/rule_table_comment_convention.go
+++ b/backend/plugin/advisor/oracle/rule_table_comment_convention.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -130,7 +131,7 @@ func (r *TableCommentConventionRule) GetAdviceList() ([]*storepb.Advice, error) 
 			if r.payload.Required {
 				r.AddAdvice(
 					r.level,
-					advisor.CommentEmpty.Int32(),
+					code.CommentEmpty.Int32(),
 					fmt.Sprintf("Comment is required for table %s", normalizeIdentifierName(tableName)),
 					common.ConvertANTLRLineToPosition(r.tableLine[tableName]),
 				)
@@ -139,7 +140,7 @@ func (r *TableCommentConventionRule) GetAdviceList() ([]*storepb.Advice, error) 
 			if r.payload.MaxLength > 0 && len(comment) > r.payload.MaxLength {
 				r.AddAdvice(
 					r.level,
-					advisor.CommentTooLong.Int32(),
+					code.CommentTooLong.Int32(),
 					fmt.Sprintf("Table %s comment is too long. The length of comment should be within %d characters", normalizeIdentifierName(tableName), r.payload.MaxLength),
 					common.ConvertANTLRLineToPosition(r.tableLine[tableName]),
 				)
@@ -148,7 +149,7 @@ func (r *TableCommentConventionRule) GetAdviceList() ([]*storepb.Advice, error) 
 				if classification, _ := common.GetClassificationAndUserComment(comment, r.classificationConfig); classification == "" {
 					r.AddAdvice(
 						r.level,
-						advisor.CommentMissingClassification.Int32(),
+						code.CommentMissingClassification.Int32(),
 						fmt.Sprintf("Table %s comment requires classification", normalizeIdentifierName(tableName)),
 						common.ConvertANTLRLineToPosition(r.tableLine[tableName]),
 					)

--- a/backend/plugin/advisor/oracle/rule_table_no_foreign_key.go
+++ b/backend/plugin/advisor/oracle/rule_table_no_foreign_key.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
@@ -108,7 +110,7 @@ func (r *TableNoForeignKeyRule) GetAdviceList() ([]*storepb.Advice, error) {
 		if hasFK {
 			r.AddAdvice(
 				r.level,
-				advisor.TableHasFK.Int32(),
+				code.TableHasFK.Int32(),
 				fmt.Sprintf("Foreign key is not allowed in the table %s.", normalizeIdentifierName(tableName)),
 				common.ConvertANTLRLineToPosition(r.tableLine[tableName]),
 			)

--- a/backend/plugin/advisor/oracle/rule_table_require_pk.go
+++ b/backend/plugin/advisor/oracle/rule_table_require_pk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -116,7 +117,7 @@ func (r *TableRequirePKRule) GetAdviceList() ([]*storepb.Advice, error) {
 		if !hasPK {
 			r.AddAdvice(
 				r.level,
-				advisor.TableNoPK.Int32(),
+				code.TableNoPK.Int32(),
 				fmt.Sprintf("Table %s requires PRIMARY KEY.", normalizeIdentifierName(tableName)),
 				common.ConvertANTLRLineToPosition(r.tableLine[tableName]),
 			)

--- a/backend/plugin/advisor/oracle/rule_where_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/oracle/rule_where_no_leading_wildcard_like.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -97,7 +98,7 @@ func (r *WhereNoLeadingWildcardLikeRule) handleCompoundExpression(ctx *parser.Co
 	if strings.HasPrefix(text, "'%") && strings.HasSuffix(text, "'") {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementLeadingWildcardLike.Int32(),
+			code.StatementLeadingWildcardLike.Int32(),
 			"Avoid using leading wildcard LIKE.",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStart().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_where_require_for_select.go
+++ b/backend/plugin/advisor/oracle/rule_where_require_for_select.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -95,7 +96,7 @@ func (r *WhereRequireForSelectRule) handleQueryBlock(ctx *parser.Query_blockCont
 	if ctx.Where_clause() == nil {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementNoWhere.Int32(),
+			code.StatementNoWhere.Int32(),
 			"WHERE clause is required for SELECT statement.",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStop().GetLine()),
 		)

--- a/backend/plugin/advisor/oracle/rule_where_require_for_update_delete.go
+++ b/backend/plugin/advisor/oracle/rule_where_require_for_update_delete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 )
 
@@ -92,7 +93,7 @@ func (r *WhereRequireForUpdateDeleteRule) handleUpdateStatement(ctx *parser.Upda
 	if ctx.Where_clause() == nil {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementNoWhere.Int32(),
+			code.StatementNoWhere.Int32(),
 			"WHERE clause is required for UPDATE statement.",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStop().GetLine()),
 		)
@@ -103,7 +104,7 @@ func (r *WhereRequireForUpdateDeleteRule) handleDeleteStatement(ctx *parser.Dele
 	if ctx.Where_clause() == nil {
 		r.AddAdvice(
 			r.level,
-			advisor.StatementNoWhere.Int32(),
+			code.StatementNoWhere.Int32(),
 			"WHERE clause is required for DELETE statement.",
 			common.ConvertANTLRLineToPosition(r.baseLine+ctx.GetStop().GetLine()),
 		)

--- a/backend/plugin/advisor/pg/advisor_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/pg/advisor_builtin_prior_backup_check.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common/log"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -71,7 +72,7 @@ func (*BuiltinPriorBackupCheckAdvisor) Check(_ context.Context, checkCtx advisor
 			Status:        level,
 			Title:         title,
 			Content:       fmt.Sprintf("Need schema %q to do prior backup but it does not exist", schemaName),
-			Code:          advisor.SchemaNotExists.Int32(),
+			Code:          code.SchemaNotExists.Int32(),
 			StartPosition: nil,
 		})
 	}
@@ -100,7 +101,7 @@ func (*BuiltinPriorBackupCheckAdvisor) Check(_ context.Context, checkCtx advisor
 					Status:        level,
 					Title:         title,
 					Content:       fmt.Sprintf("The statement type is not the same for all statements on the same table %q", key),
-					Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+					Code:          code.BuiltinPriorBackupCheck.Int32(),
 					StartPosition: nil,
 				})
 				break
@@ -247,7 +248,7 @@ func (r *ddlRule) handleEveryRule(ctx antlr.ParserRuleContext) error {
 			Status:  r.level,
 			Title:   r.title,
 			Content: fmt.Sprintf("Data change can only run DML, \"%s\" is not DML", r.getStatementText(ctx)),
-			Code:    advisor.BuiltinPriorBackupCheck.Int32(),
+			Code:    code.BuiltinPriorBackupCheck.Int32(),
 			StartPosition: &storepb.Position{
 				Line:   int32(ctx.GetStart().GetLine()),
 				Column: 0,

--- a/backend/plugin/advisor/pg/advisor_collation_allowlist.go
+++ b/backend/plugin/advisor/pg/advisor_collation_allowlist.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -192,7 +193,7 @@ func (r *collationAllowlistRule) addAdvice(collation string, ctx antlr.ParserRul
 
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.DisabledCollation.Int32(),
+		Code:    code.DisabledCollation.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("Use disabled collation \"%s\", related statement \"%s\"", collation, text),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_comment_convention.go
+++ b/backend/plugin/advisor/pg/advisor_column_comment_convention.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -228,7 +229,7 @@ func (r *columnCommentConventionRule) generateAdvice() []*storepb.Advice {
 			if r.payload.Required {
 				adviceList = append(adviceList, &storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.CommentEmpty.Int32(),
+					Code:    code.CommentEmpty.Int32(),
 					Title:   r.title,
 					Content: fmt.Sprintf("Comment is required for column `%s.%s`", col.table, col.column),
 					StartPosition: &storepb.Position{
@@ -244,7 +245,7 @@ func (r *columnCommentConventionRule) generateAdvice() []*storepb.Advice {
 			if r.payload.MaxLength > 0 && len(comment) > r.payload.MaxLength {
 				adviceList = append(adviceList, &storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.CommentTooLong.Int32(),
+					Code:    code.CommentTooLong.Int32(),
 					Title:   r.title,
 					Content: fmt.Sprintf("Column `%s.%s` comment is too long. The length of comment should be within %d characters", col.table, col.column, r.payload.MaxLength),
 					StartPosition: &storepb.Position{
@@ -259,7 +260,7 @@ func (r *columnCommentConventionRule) generateAdvice() []*storepb.Advice {
 				if classification, _ := common.GetClassificationAndUserComment(comment, r.classificationConfig); classification == "" {
 					adviceList = append(adviceList, &storepb.Advice{
 						Status:  r.level,
-						Code:    advisor.CommentMissingClassification.Int32(),
+						Code:    code.CommentMissingClassification.Int32(),
 						Title:   r.title,
 						Content: fmt.Sprintf("Column `%s.%s` comment requires classification", col.table, col.column),
 						StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_default_disallow_volatile.go
+++ b/backend/plugin/advisor/pg/advisor_column_default_disallow_volatile.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -213,7 +215,7 @@ func (r *columnDefaultDisallowVolatileRule) generateAdvice() {
 	for _, column := range columnList {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NoDefault.Int32(),
+			Code:    code.NoDefault.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Column %q.%q in schema %q has volatile DEFAULT", column.table, column.name, column.schema),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/pg/advisor_column_disallow_changing_type.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -93,7 +95,7 @@ func (r *columnDisallowChangingTypeRule) handleAltertablestmt(ctx *parser.Altert
 
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.ChangeColumnType.Int32(),
+				Code:    code.ChangeColumnType.Int32(),
 				Title:   r.title,
 				Content: fmt.Sprintf("The statement \"%s\" changes column type", text),
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_maximum_character_length.go
+++ b/backend/plugin/advisor/pg/advisor_column_maximum_character_length.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -235,7 +237,7 @@ func (*columnMaximumCharacterLengthRule) getCharLength(typename parser.ITypename
 func (r *columnMaximumCharacterLengthRule) addAdvice(tableName, columnName string, line int) {
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.CharLengthExceedsLimit.Int32(),
+		Code:    code.CharLengthExceedsLimit.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("The length of the CHAR column %q in table %s is bigger than %d, please use VARCHAR instead", columnName, tableName, r.maximum),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_no_null.go
+++ b/backend/plugin/advisor/pg/advisor_column_no_null.go
@@ -12,6 +12,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -133,7 +134,7 @@ func (r *columnNoNullRule) OnExit(ctx antlr.ParserRuleContext, _ string) error {
 		for _, column := range columnList {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.ColumnCannotNull.Int32(),
+				Code:    code.ColumnCannotNull.Int32(),
 				Title:   r.title,
 				Content: fmt.Sprintf("Column %q in %s cannot have NULL value", column.column, column.normalizeTableName()),
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_require_default.go
+++ b/backend/plugin/advisor/pg/advisor_column_require_default.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -106,7 +108,7 @@ func (r *columnRequireDefaultRule) handleCreatestmt(ctx *parser.CreatestmtContex
 					if !r.hasDefault(colDef) {
 						r.AddAdvice(&storepb.Advice{
 							Status:  r.level,
-							Code:    advisor.NoDefault.Int32(),
+							Code:    code.NoDefault.Int32(),
 							Title:   r.title,
 							Content: fmt.Sprintf("Column %q.%q in schema %q doesn't have DEFAULT", tableName, columnName, "public"),
 							StartPosition: &storepb.Position{
@@ -148,7 +150,7 @@ func (r *columnRequireDefaultRule) handleAltertablestmt(ctx *parser.Altertablest
 					if !r.hasDefault(colDef) {
 						r.AddAdvice(&storepb.Advice{
 							Status:  r.level,
-							Code:    advisor.NoDefault.Int32(),
+							Code:    code.NoDefault.Int32(),
 							Title:   r.title,
 							Content: fmt.Sprintf("Column %q.%q in schema %q doesn't have DEFAULT", tableName, columnName, "public"),
 							StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_required.go
+++ b/backend/plugin/advisor/pg/advisor_column_required.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -142,7 +144,7 @@ func (r *columnRequirementRule) handleCreatestmt(ctx antlr.ParserRuleContext) {
 
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NoRequiredColumn.Int32(),
+			Code:    code.NoRequiredColumn.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Table %q requires columns: %s", tableName, strings.Join(missingColumns, ", ")),
 			StartPosition: &storepb.Position{
@@ -184,7 +186,7 @@ func (r *columnRequirementRule) handleAltertablestmt(ctx antlr.ParserRuleContext
 					if r.requiredColumnsMap[columnName] {
 						r.AddAdvice(&storepb.Advice{
 							Status:  r.level,
-							Code:    advisor.NoRequiredColumn.Int32(),
+							Code:    code.NoRequiredColumn.Int32(),
 							Title:   r.title,
 							Content: fmt.Sprintf("Table %q requires columns: %s", tableName, columnName),
 							StartPosition: &storepb.Position{
@@ -235,7 +237,7 @@ func (r *columnRequirementRule) handleRenamestmt(ctx antlr.ParserRuleContext) {
 	if r.requiredColumnsMap[oldName] && oldName != newName {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NoRequiredColumn.Int32(),
+			Code:    code.NoRequiredColumn.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Table %q requires columns: %s", tableName, oldName),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_column_type_disallow_list.go
+++ b/backend/plugin/advisor/pg/advisor_column_type_disallow_list.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -182,7 +184,7 @@ func (r *columnTypeDisallowListRule) checkType(tableName, columnName string, typ
 	if matchedDisallowedType != "" {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.DisabledColumnType.Int32(),
+			Code:    code.DisabledColumnType.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Disallow column type %s but column %q.%q is", strings.ToUpper(matchedDisallowedType), tableName, columnName),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_comment_convention.go
+++ b/backend/plugin/advisor/pg/advisor_comment_convention.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -97,7 +98,7 @@ func (r *commentConventionRule) handleCommentstmt(ctx antlr.ParserRuleContext) {
 		if r.maxLength > 0 && len(comment) > r.maxLength {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.CommentTooLong.Int32(),
+				Code:    code.CommentTooLong.Int32(),
 				Title:   r.title,
 				Content: fmt.Sprintf("The length of comment should be within %d characters", r.maxLength),
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_encoding_allowlist.go
+++ b/backend/plugin/advisor/pg/advisor_encoding_allowlist.go
@@ -11,6 +11,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -103,7 +104,7 @@ func (r *encodingAllowlistRule) handleCreatedbstmt(ctx *parser.CreatedbstmtConte
 		if !r.allowlist[strings.ToLower(encoding)] {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.DisabledCharset.Int32(),
+				Code:    code.DisabledCharset.Int32(),
 				Title:   r.title,
 				Content: fmt.Sprintf("\"\" used disabled encoding '%s'", strings.ToLower(encoding)),
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_hello_world.go
+++ b/backend/plugin/advisor/pg/advisor_hello_world.go
@@ -3,6 +3,8 @@ package pg
 import (
 	"context"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 )
@@ -29,7 +31,7 @@ func (*HelloWorldAdvisor) Check(_ context.Context, _ advisor.Context) ([]*storep
 	return []*storepb.Advice{
 		{
 			Status:  storepb.Advice_WARNING,
-			Code:    advisor.Ok.Int32(),
+			Code:    code.Ok.Int32(),
 			Title:   "Hello World Test",
 			Content: "hello world",
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
+++ b/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
@@ -3,6 +3,8 @@ package pg
 import (
 	"context"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -120,7 +122,7 @@ func (r *indexCreateConcurrentlyRule) handleIndexstmt(ctx *parser.IndexstmtConte
 
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.CreateIndexUnconcurrently.Int32(),
+			Code:    code.CreateIndexUnconcurrently.Int32(),
 			Title:   r.title,
 			Content: "Creating indexes will block writes on the table, unless use CONCURRENTLY",
 			StartPosition: &storepb.Position{
@@ -143,7 +145,7 @@ func (r *indexCreateConcurrentlyRule) handleDropstmt(ctx *parser.DropstmtContext
 		if ctx.CONCURRENTLY() == nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.DropIndexUnconcurrently.Int32(),
+				Code:    code.DropIndexUnconcurrently.Int32(),
 				Title:   r.title,
 				Content: "Droping indexes will block writes on the table, unless use CONCURRENTLY",
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_index_key_number_limit.go
+++ b/backend/plugin/advisor/pg/advisor_index_key_number_limit.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -111,7 +113,7 @@ func (r *indexKeyNumberLimitRule) handleIndexstmt(ctx antlr.ParserRuleContext) {
 
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.IndexKeyNumberExceedsLimit.Int32(),
+				Code:    code.IndexKeyNumberExceedsLimit.Int32(),
 				Title:   r.title,
 				Content: fmt.Sprintf("The number of keys of index %q in table %q should be not greater than %d", indexName, tableName, r.max),
 				StartPosition: &storepb.Position{
@@ -225,7 +227,7 @@ func (r *indexKeyNumberLimitRule) checkTableConstraint(constraint parser.ITablec
 	if r.max > 0 && keyCount > r.max {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.IndexKeyNumberExceedsLimit.Int32(),
+			Code:    code.IndexKeyNumberExceedsLimit.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("The number of keys of index %q in table %q should be not greater than %d", constraintName, tableName, r.max),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_index_no_duplicate_column.go
+++ b/backend/plugin/advisor/pg/advisor_index_no_duplicate_column.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -262,7 +264,7 @@ func findDuplicate(columns []string) string {
 func (r *indexNoDuplicateColumnRule) addAdvice(constraintType, constraintName, tableName, duplicateColumn string, line int) {
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.DuplicateColumnInIndex.Int32(),
+		Code:    code.DuplicateColumnInIndex.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("%s %q has duplicate column %q.%q", constraintType, constraintName, tableName, duplicateColumn),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/pg/advisor_index_primary_key_type_allowlist.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -180,7 +182,7 @@ func (r *indexPrimaryKeyTypeAllowlistRule) isTypeAllowed(columnType string) bool
 func (r *indexPrimaryKeyTypeAllowlistRule) addAdvice(columnName, columnType string, line int) {
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.IndexPKType.Int32(),
+		Code:    code.IndexPKType.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("The column %q is one of the primary key, but its type %q is not in allowlist", columnName, columnType),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_index_total_number_limit.go
+++ b/backend/plugin/advisor/pg/advisor_index_total_number_limit.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -124,7 +126,7 @@ func (r *indexTotalNumberLimitRule) generateAdvice() {
 		if tableInfo != nil && tableInfo.CountIndex() > r.max {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.IndexCountExceedsLimit.Int32(),
+				Code:    code.IndexCountExceedsLimit.Int32(),
 				Title:   r.title,
 				Content: fmt.Sprintf("The count of index in table %q.%q should be no more than %d, but found %d", table.schema, table.table, r.max, tableInfo.CountIndex()),
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_insert_disallow_order_by_rand.go
+++ b/backend/plugin/advisor/pg/advisor_insert_disallow_order_by_rand.go
@@ -11,6 +11,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -97,7 +98,7 @@ func (r *insertDisallowOrderByRandRule) handleInsertstmt(ctx antlr.ParserRuleCon
 
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.InsertUseOrderByRand.Int32(),
+			Code:    code.InsertUseOrderByRand.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("The INSERT statement uses ORDER BY random() or random_between(), related statement \"%s\"", stmtText),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_insert_must_specify_column.go
+++ b/backend/plugin/advisor/pg/advisor_insert_must_specify_column.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -101,7 +102,7 @@ func (r *insertMustSpecifyColumnRule) handleInsertstmt(ctx antlr.ParserRuleConte
 
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.InsertNotSpecifyColumn.Int32(),
+			Code:    code.InsertNotSpecifyColumn.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("The INSERT statement must specify columns but \"%s\" does not", stmtText),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_insert_row_limit.go
+++ b/backend/plugin/advisor/pg/advisor_insert_row_limit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -122,7 +123,7 @@ func (r *insertRowLimitRule) handleInsertstmt(ctx *parser.InsertstmtContext) {
 		return
 	}
 
-	code := advisor.Ok
+	code := advisorcode.Ok
 	rows := int64(0)
 
 	// Check if this is INSERT ... VALUES or INSERT ... SELECT
@@ -132,7 +133,7 @@ func (r *insertRowLimitRule) handleInsertstmt(ctx *parser.InsertstmtContext) {
 		if rowCount > 0 {
 			// This is INSERT ... VALUES
 			if rowCount > r.maxRow {
-				code = advisor.InsertTooManyRows
+				code = advisorcode.InsertTooManyRows
 				rows = int64(rowCount)
 			}
 		} else if r.driver != nil {
@@ -151,7 +152,7 @@ func (r *insertRowLimitRule) handleInsertstmt(ctx *parser.InsertstmtContext) {
 			if err != nil {
 				r.AddAdvice(&storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.InsertTooManyRows.Int32(),
+					Code:    advisorcode.InsertTooManyRows.Int32(),
 					Title:   r.title,
 					Content: fmt.Sprintf("\"%s\" dry runs failed: %s", stmtText, err.Error()),
 					StartPosition: &storepb.Position{
@@ -166,7 +167,7 @@ func (r *insertRowLimitRule) handleInsertstmt(ctx *parser.InsertstmtContext) {
 			if err != nil {
 				r.AddAdvice(&storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.Internal.Int32(),
+					Code:    advisorcode.Internal.Int32(),
 					Title:   r.title,
 					Content: fmt.Sprintf("failed to get row count for \"%s\": %s", stmtText, err.Error()),
 					StartPosition: &storepb.Position{
@@ -178,13 +179,13 @@ func (r *insertRowLimitRule) handleInsertstmt(ctx *parser.InsertstmtContext) {
 			}
 
 			if rowCount > int64(r.maxRow) {
-				code = advisor.InsertTooManyRows
+				code = advisorcode.InsertTooManyRows
 				rows = rowCount
 			}
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		stmtText := extractStatementText(r.statementsText, ctx.GetStart().GetLine(), ctx.GetStop().GetLine())
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,

--- a/backend/plugin/advisor/pg/advisor_naming_column.go
+++ b/backend/plugin/advisor/pg/advisor_naming_column.go
@@ -11,6 +11,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -193,7 +194,7 @@ func (r *namingColumnConventionRule) checkColumnName(tableName, columnName strin
 	if !r.format.MatchString(columnName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingColumnConventionMismatch.Int32(),
+			Code:    code.NamingColumnConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\".\"%s\" mismatches column naming convention, naming format should be %q", tableName, columnName, r.format),
 			StartPosition: &storepb.Position{
@@ -206,7 +207,7 @@ func (r *namingColumnConventionRule) checkColumnName(tableName, columnName strin
 	if r.maxLength > 0 && len(columnName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingColumnConventionMismatch.Int32(),
+			Code:    code.NamingColumnConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\".\"%s\" mismatches column naming convention, its length should be within %d characters", tableName, columnName, r.maxLength),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_naming_foreign_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_foreign_key_convention.go
@@ -12,6 +12,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -298,7 +299,7 @@ func (r *namingFKConventionRule) checkFKMetadata(fkData *fkMetaData) {
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.Internal.Int32(),
+			Code:    code.Internal.Int32(),
 			Title:   "Internal error for foreign key naming convention rule",
 			Content: fmt.Sprintf("Failed to compile regex: %s", err.Error()),
 			StartPosition: &storepb.Position{
@@ -312,7 +313,7 @@ func (r *namingFKConventionRule) checkFKMetadata(fkData *fkMetaData) {
 	if !regex.MatchString(fkData.indexName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingFKConventionMismatch.Int32(),
+			Code:    code.NamingFKConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf(`Foreign key in table "%s" mismatches the naming convention, expect %q but found "%s"`, fkData.tableName, regex, fkData.indexName),
 			StartPosition: &storepb.Position{
@@ -325,7 +326,7 @@ func (r *namingFKConventionRule) checkFKMetadata(fkData *fkMetaData) {
 	if r.maxLength > 0 && len(fkData.indexName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingFKConventionMismatch.Int32(),
+			Code:    code.NamingFKConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf(`Foreign key "%s" in table "%s" mismatches the naming convention, its length should be within %d characters`, fkData.indexName, fkData.tableName, r.maxLength),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_naming_fully_qualified.go
+++ b/backend/plugin/advisor/pg/advisor_naming_fully_qualified.go
@@ -11,6 +11,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
@@ -266,7 +267,7 @@ func (r *fullyQualifiedObjectNameRule) handleSelectstmt(ctx *parser.SelectstmtCo
 		if !r.isFullyQualified(objName) {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    int32(advisor.NamingNotFullyQualifiedName),
+				Code:    int32(code.NamingNotFullyQualifiedName),
 				Title:   r.title,
 				Content: fmt.Sprintf("unqualified object name: '%s'", objName),
 				StartPosition: &storepb.Position{
@@ -290,7 +291,7 @@ func (r *fullyQualifiedObjectNameRule) checkQualifiedName(ctx parser.IQualified_
 	if !r.isFullyQualified(objName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    int32(advisor.NamingNotFullyQualifiedName),
+			Code:    int32(code.NamingNotFullyQualifiedName),
 			Title:   r.title,
 			Content: fmt.Sprintf("unqualified object name: '%s'", objName),
 			StartPosition: &storepb.Position{
@@ -314,7 +315,7 @@ func (r *fullyQualifiedObjectNameRule) checkAnyName(ctx parser.IAny_nameContext,
 	if !r.isFullyQualified(objName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    int32(advisor.NamingNotFullyQualifiedName),
+			Code:    int32(code.NamingNotFullyQualifiedName),
 			Title:   r.title,
 			Content: fmt.Sprintf("unqualified object name: '%s'", objName),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_index_convention.go
@@ -12,6 +12,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -193,7 +194,7 @@ func (r *namingIndexConventionRule) checkIndexName(indexName, tableName string, 
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.Internal.Int32(),
+			Code:    code.Internal.Int32(),
 			Title:   "Internal error for index naming convention rule",
 			Content: fmt.Sprintf("Failed to compile regex: %v", err),
 			StartPosition: &storepb.Position{
@@ -207,7 +208,7 @@ func (r *namingIndexConventionRule) checkIndexName(indexName, tableName string, 
 	if !regex.MatchString(indexName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingIndexConventionMismatch.Int32(),
+			Code:    code.NamingIndexConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Index in table %q mismatches the naming convention, expect %q but found %q", tableName, regex, indexName),
 			StartPosition: &storepb.Position{
@@ -220,7 +221,7 @@ func (r *namingIndexConventionRule) checkIndexName(indexName, tableName string, 
 	if r.maxLength > 0 && len(indexName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingIndexConventionMismatch.Int32(),
+			Code:    code.NamingIndexConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Index %q in table %q mismatches the naming convention, its length should be within %d characters", indexName, tableName, r.maxLength),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
@@ -12,6 +12,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -341,7 +342,7 @@ func (r *namingPKConventionRule) checkPKName(pkData *pkMetaData) {
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.Internal.Int32(),
+			Code:    code.Internal.Int32(),
 			Title:   "Internal error for primary key naming convention rule",
 			Content: fmt.Sprintf("Failed to compile regex: %v", err),
 			StartPosition: &storepb.Position{
@@ -355,7 +356,7 @@ func (r *namingPKConventionRule) checkPKName(pkData *pkMetaData) {
 	if !regex.MatchString(pkData.pkName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingPKConventionMismatch.Int32(),
+			Code:    code.NamingPKConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf(`Primary key in table "%s" mismatches the naming convention, expect %q but found "%s"`, pkData.tableName, regex, pkData.pkName),
 			StartPosition: &storepb.Position{
@@ -368,7 +369,7 @@ func (r *namingPKConventionRule) checkPKName(pkData *pkMetaData) {
 	if r.maxLength > 0 && len(pkData.pkName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingPKConventionMismatch.Int32(),
+			Code:    code.NamingPKConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf(`Primary key "%s" in table "%s" mismatches the naming convention, its length should be within %d characters`, pkData.pkName, pkData.tableName, r.maxLength),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_naming_table.go
+++ b/backend/plugin/advisor/pg/advisor_naming_table.go
@@ -11,6 +11,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -119,7 +120,7 @@ func (r *namingTableConventionRule) checkTableName(tableName string, ctx antlr.P
 	if !r.format.MatchString(tableName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingTableConventionMismatch.Int32(),
+			Code:    code.NamingTableConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf(`"%s" mismatches table naming convention, naming format should be %q`, tableName, r.format),
 			StartPosition: &storepb.Position{
@@ -131,7 +132,7 @@ func (r *namingTableConventionRule) checkTableName(tableName string, ctx antlr.P
 	if r.maxLength > 0 && len(tableName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingTableConventionMismatch.Int32(),
+			Code:    code.NamingTableConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\" mismatches table naming convention, its length should be within %d characters", tableName, r.maxLength),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
@@ -12,6 +12,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -361,7 +362,7 @@ func (r *namingUKConventionRule) checkUniqueKeyName(indexName, tableName string,
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.Internal.Int32(),
+			Code:    code.Internal.Int32(),
 			Title:   "Internal error for unique key naming convention rule",
 			Content: fmt.Sprintf("Failed to compile regex for unique key naming convention: %v", err),
 		})
@@ -371,7 +372,7 @@ func (r *namingUKConventionRule) checkUniqueKeyName(indexName, tableName string,
 	if !regex.MatchString(indexName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingUKConventionMismatch.Int32(),
+			Code:    code.NamingUKConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf(`Unique key in table "%s" mismatches the naming convention, expect %q but found "%s"`, tableName, regex, indexName),
 			StartPosition: &storepb.Position{
@@ -384,7 +385,7 @@ func (r *namingUKConventionRule) checkUniqueKeyName(indexName, tableName string,
 	if r.maxLength > 0 && len(indexName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NamingUKConventionMismatch.Int32(),
+			Code:    code.NamingUKConventionMismatch.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf(`Unique key "%s" in table "%s" mismatches the naming convention, its length should be within %d characters`, indexName, tableName, r.maxLength),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_add_check_not_valid.go
+++ b/backend/plugin/advisor/pg/advisor_statement_add_check_not_valid.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -108,7 +109,7 @@ func (r *statementAddCheckNotValidRule) handleColconstraint(ctx antlr.ParserRule
 			// (when NOT VALID is present, it's parsed as a table constraint)
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.StatementAddCheckWithValidation.Int32(),
+				Code:    code.StatementAddCheckWithValidation.Int32(),
 				Title:   r.title,
 				Content: "Adding check constraints with validation will block reads and writes. You can add check constraints not valid and then validate separately",
 				StartPosition: &storepb.Position{
@@ -167,7 +168,7 @@ func (r *statementAddCheckNotValidRule) handleTableconstraint(ctx antlr.ParserRu
 			if !hasNotValid {
 				r.AddAdvice(&storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.StatementAddCheckWithValidation.Int32(),
+					Code:    code.StatementAddCheckWithValidation.Int32(),
 					Title:   r.title,
 					Content: "Adding check constraints with validation will block reads and writes. You can add check constraints not valid and then validate separately",
 					StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_add_fk_not_valid.go
+++ b/backend/plugin/advisor/pg/advisor_statement_add_fk_not_valid.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -124,7 +125,7 @@ func (r *statementAddFKNotValidRule) handleAltertablestmt(ctx antlr.ParserRuleCo
 		if !hasNotValid {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.StatementAddFKWithValidation.Int32(),
+				Code:    code.StatementAddFKWithValidation.Int32(),
 				Title:   r.title,
 				Content: "Adding foreign keys with validation will block reads and writes. You can add check foreign keys not valid and then validate separately",
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/pg/advisor_statement_affected_row_limit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -157,7 +158,7 @@ func (r *statementAffectedRowLimitRule) checkAffectedRows(ctx antlr.ParserRuleCo
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.InsertTooManyRows.Int32(),
+			Code:    code.InsertTooManyRows.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\" dry runs failed: %s", normalizedStmt, err.Error()),
 			StartPosition: &storepb.Position{
@@ -172,7 +173,7 @@ func (r *statementAffectedRowLimitRule) checkAffectedRows(ctx antlr.ParserRuleCo
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.Internal.Int32(),
+			Code:    code.Internal.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("failed to get row count for \"%s\": %s", normalizedStmt, err.Error()),
 			StartPosition: &storepb.Position{
@@ -186,7 +187,7 @@ func (r *statementAffectedRowLimitRule) checkAffectedRows(ctx antlr.ParserRuleCo
 	if rowCount > int64(r.maxRow) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementAffectedRowExceedsLimit.Int32(),
+			Code:    code.StatementAffectedRowExceedsLimit.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("The statement \"%s\" affected %d rows (estimated). The count exceeds %d.", normalizedStmt, rowCount, r.maxRow),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_check_set_role_variable.go
+++ b/backend/plugin/advisor/pg/advisor_statement_check_set_role_variable.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -46,7 +47,7 @@ func (*StatementCheckSetRoleVariable) Check(_ context.Context, checkCtx advisor.
 	if !rule.hasSetRole {
 		rule.AddAdvice(&storepb.Advice{
 			Status:        level,
-			Code:          advisor.StatementCheckSetRoleVariable.Int32(),
+			Code:          code.StatementCheckSetRoleVariable.Int32(),
 			Title:         rule.title,
 			Content:       "No SET ROLE statement found.",
 			StartPosition: nil,

--- a/backend/plugin/advisor/pg/advisor_statement_create_specify_schema.go
+++ b/backend/plugin/advisor/pg/advisor_statement_create_specify_schema.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -85,7 +86,7 @@ func (r *statementCreateSpecifySchemaRule) handleCreatestmt(ctx antlr.ParserRule
 		if schemaName == "" {
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.StatementCreateWithoutSchemaName.Int32(),
+				Code:    code.StatementCreateWithoutSchemaName.Int32(),
 				Title:   r.title,
 				Content: "Table schema should be specified.",
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_add_column_with_default.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_add_column_with_default.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -95,7 +96,7 @@ func (r *statementDisallowAddColumnWithDefaultRule) handleAltertablestmt(ctx *pa
 							if constraintElem.DEFAULT() != nil {
 								r.AddAdvice(&storepb.Advice{
 									Status:  r.level,
-									Code:    advisor.StatementAddColumnWithDefault.Int32(),
+									Code:    code.StatementAddColumnWithDefault.Int32(),
 									Title:   r.title,
 									Content: "Adding column with DEFAULT will locked the whole table and rewriting each rows",
 									StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_add_not_null.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_add_not_null.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -95,7 +96,7 @@ func (r *statementDisallowAddNotNullRule) handleAltertablestmt(ctx antlr.ParserR
 					columnName := pgparser.NormalizePostgreSQLColid(allColIDs[0])
 					r.AddAdvice(&storepb.Advice{
 						Status:  r.level,
-						Code:    advisor.StatementAddNotNull.Int32(),
+						Code:    code.StatementAddNotNull.Int32(),
 						Title:   r.title,
 						Content: fmt.Sprintf("Setting NOT NULL will block reads and writes. You can use CHECK (%q IS NOT NULL) instead", columnName),
 						StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_commit.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_commit.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -81,7 +82,7 @@ func (r *statementDisallowCommitRule) OnEnter(ctx antlr.ParserRuleContext, nodeT
 	stmtText := extractStatementText(r.statementsText, transactionCtx.GetStart().GetLine(), transactionCtx.GetStop().GetLine())
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.StatementDisallowCommit.Int32(),
+		Code:    code.StatementDisallowCommit.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("Commit is not allowed, related statement: \"%s\"", stmtText),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_mix_in_ddl.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_mix_in_ddl.go
@@ -8,6 +8,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -144,7 +145,7 @@ func (r *statementDisallowMixInDDLRule) addDMLAdvice(ctx antlr.ParserRuleContext
 
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.StatementDisallowMixDDLDML.Int32(),
+		Code:    code.StatementDisallowMixDDLDML.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("Alter schema can only run DDL, %q is not DDL", stmtText),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_mix_in_dml.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_mix_in_dml.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -342,7 +343,7 @@ func (r *statementDisallowMixInDMLRule) addDDLAdvice(ctx antlr.ParserRuleContext
 
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.StatementDisallowMixDDLDML.Int32(),
+		Code:    code.StatementDisallowMixDDLDML.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("Data change can only run DML, %q is not DML", stmtText),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_on_del_cascade.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_on_del_cascade.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -107,7 +108,7 @@ func (r *statementDisallowOnDelCascadeRule) handleKeyDelete(ctx *parser.Key_dele
 				}
 				r.AddAdvice(&storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.StatementDisallowCascade.Int32(),
+					Code:    code.StatementDisallowCascade.Int32(),
 					Title:   r.title,
 					Content: "The CASCADE option is not permitted for ON DELETE clauses",
 					StartPosition: common.ConvertANTLRPositionToPosition(&common.ANTLRPosition{

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_rm_tbl_cascade.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_rm_tbl_cascade.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -89,7 +90,7 @@ func (r *statementDisallowRemoveTblCascadeRule) handleDropstmt(ctx *parser.Drops
 	if r.hasCascadeOption(ctx.Opt_drop_behavior()) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementDisallowCascade.Int32(),
+			Code:    code.StatementDisallowCascade.Int32(),
 			Title:   r.title,
 			Content: "The use of CASCADE is not permitted when removing a table",
 			StartPosition: &storepb.Position{
@@ -109,7 +110,7 @@ func (r *statementDisallowRemoveTblCascadeRule) handleTruncatestmt(ctx *parser.T
 	if r.hasCascadeOption(ctx.Opt_drop_behavior()) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementDisallowCascade.Int32(),
+			Code:    code.StatementDisallowCascade.Int32(),
 			Title:   r.title,
 			Content: "The use of CASCADE is not permitted when removing a table",
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/pg/advisor_statement_dml_dry_run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -156,7 +157,7 @@ func (r *statementDMLDryRunRule) checkDMLDryRun(ctx antlr.ParserRuleContext) {
 	if err != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementDMLDryRunFailed.Int32(),
+			Code:    code.StatementDMLDryRunFailed.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\" dry runs failed: %s", normalizedStmt, err.Error()),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_maximum_limit_value.go
+++ b/backend/plugin/advisor/pg/advisor_statement_maximum_limit_value.go
@@ -11,6 +11,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -85,7 +86,7 @@ func (r *statementMaximumLimitValueRule) OnEnter(ctx antlr.ParserRuleContext, no
 	if limitValue > 0 && limitValue > r.limitMaxValue {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementExceedMaximumLimitValue.Int32(),
+			Code:    code.StatementExceedMaximumLimitValue.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("The limit value %d exceeds the maximum allowed value %d", limitValue, r.limitMaxValue),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_merge_alter_table.go
+++ b/backend/plugin/advisor/pg/advisor_statement_merge_alter_table.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -180,7 +181,7 @@ func (r *statementMergeAlterTableRule) generateAdvice() []*storepb.Advice {
 		if table.count > 1 {
 			adviceList = append(adviceList, &storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.StatementRedundantAlterTable.Int32(),
+				Code:    code.StatementRedundantAlterTable.Int32(),
 				Title:   r.title,
 				Content: fmt.Sprintf("There are %d statements to modify table `%s`", table.count, table.name),
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/pg/advisor_statement_no_leading_wildcard_like.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -110,7 +111,7 @@ func (r *statementNoLeadingWildcardLikeRule) handleAExprLike(ctx *parser.A_expr_
 		stmtText := extractStatementText(r.statementsText, stmtCtx.GetStart().GetLine(), stmtCtx.GetStop().GetLine())
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementLeadingWildcardLike.Int32(),
+			Code:    code.StatementLeadingWildcardLike.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\" uses leading wildcard LIKE", stmtText),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_no_select_all.go
+++ b/backend/plugin/advisor/pg/advisor_statement_no_select_all.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -125,7 +126,7 @@ func (r *noSelectAllRule) handleSimpleSelectPramary(ctx *parser.Simple_select_pr
 
 				r.AddAdvice(&storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.StatementSelectAll.Int32(),
+					Code:    code.StatementSelectAll.Int32(),
 					Title:   r.title,
 					Content: fmt.Sprintf("\"%s\" uses SELECT all", stmtText),
 					StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_non_transactional.go
+++ b/backend/plugin/advisor/pg/advisor_statement_non_transactional.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/db/pg"
 )
 
@@ -108,7 +109,7 @@ func (r *nonTransactionalRule) checkStatement(ctx antlr.ParserRuleContext) {
 	if pg.IsNonTransactionStatement(stmtText) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementNonTransactional.Int32(),
+			Code:    code.StatementNonTransactional.Int32(),
 			Title:   r.title,
 			Content: "This statement is non-transactional",
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_object_owner_check.go
+++ b/backend/plugin/advisor/pg/advisor_statement_object_owner_check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common/log"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/pg"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
@@ -155,7 +156,7 @@ func (r *statementObjectOwnerCheckRule) checkSchemaOwnership(schemaName string, 
 			Status:  r.level,
 			Title:   r.title,
 			Content: fmt.Sprintf("Schema \"%s\" is owned by \"%s\", but the current role is \"%s\".", schemaName, owner, r.currentRole),
-			Code:    advisor.StatementObjectOwnerCheck.Int32(),
+			Code:    code.StatementObjectOwnerCheck.Int32(),
 			StartPosition: &storepb.Position{
 				Line:   int32(line),
 				Column: 0,
@@ -188,7 +189,7 @@ func (r *statementObjectOwnerCheckRule) checkTableOwnership(schemaName, tableNam
 			Status:  r.level,
 			Title:   r.title,
 			Content: fmt.Sprintf("Table \"%s\" is owned by \"%s\", but the current role is \"%s\".", tableName, owner, r.currentRole),
-			Code:    advisor.StatementObjectOwnerCheck.Int32(),
+			Code:    code.StatementObjectOwnerCheck.Int32(),
 			StartPosition: &storepb.Position{
 				Line:   int32(line),
 				Column: 0,
@@ -312,7 +313,7 @@ func (r *statementObjectOwnerCheckRule) handleCreateschemastmt(ctx *parser.Creat
 			Status:  r.level,
 			Title:   r.title,
 			Content: fmt.Sprintf("Database \"%s\" is owned by \"%s\", but the current role is \"%s\".", r.dbMetadata.GetName(), owner, r.currentRole),
-			Code:    advisor.StatementObjectOwnerCheck.Int32(),
+			Code:    code.StatementObjectOwnerCheck.Int32(),
 			StartPosition: &storepb.Position{
 				Line:   int32(ctx.GetStart().GetLine()),
 				Column: 0,

--- a/backend/plugin/advisor/pg/advisor_statement_where_required_select.go
+++ b/backend/plugin/advisor/pg/advisor_statement_where_required_select.go
@@ -9,6 +9,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -122,7 +123,7 @@ func (r *statementWhereRequiredSelectRule) checkSelect(
 
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.StatementNoWhere.Int32(),
+		Code:    code.StatementNoWhere.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("\"%s\" requires WHERE clause", stmtText),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_statement_where_required_update_delete.go
+++ b/backend/plugin/advisor/pg/advisor_statement_where_required_update_delete.go
@@ -10,6 +10,7 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -88,7 +89,7 @@ func (r *statementWhereRequiredRule) handleUpdatestmt(ctx *parser.UpdatestmtCont
 		stmtText := extractStatementText(r.statementsText, ctx.GetStart().GetLine(), ctx.GetStop().GetLine())
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementNoWhere.Int32(),
+			Code:    code.StatementNoWhere.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\" requires WHERE clause", stmtText),
 			StartPosition: &storepb.Position{
@@ -109,7 +110,7 @@ func (r *statementWhereRequiredRule) handleDeletestmt(ctx *parser.DeletestmtCont
 		stmtText := extractStatementText(r.statementsText, ctx.GetStart().GetLine(), ctx.GetStop().GetLine())
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.StatementNoWhere.Int32(),
+			Code:    code.StatementNoWhere.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("\"%s\" requires WHERE clause", stmtText),
 			StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_table_comment_convention.go
+++ b/backend/plugin/advisor/pg/advisor_table_comment_convention.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -65,7 +66,7 @@ func (*TableCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 			if rule.payload.Required {
 				rule.AddAdvice(&storepb.Advice{
 					Status:  rule.level,
-					Code:    advisor.CommentEmpty.Int32(),
+					Code:    code.CommentEmpty.Int32(),
 					Title:   rule.title,
 					Content: fmt.Sprintf("Comment is required for table `%s`", tableInfo.displayName),
 					StartPosition: &storepb.Position{
@@ -79,7 +80,7 @@ func (*TableCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 			if rule.payload.MaxLength > 0 && len(comment) > rule.payload.MaxLength {
 				rule.AddAdvice(&storepb.Advice{
 					Status:  rule.level,
-					Code:    advisor.CommentTooLong.Int32(),
+					Code:    code.CommentTooLong.Int32(),
 					Title:   rule.title,
 					Content: fmt.Sprintf("Table `%s` comment is too long. The length of comment should be within %d characters", tableInfo.displayName, rule.payload.MaxLength),
 					StartPosition: &storepb.Position{
@@ -92,7 +93,7 @@ func (*TableCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 				if classification, _ := common.GetClassificationAndUserComment(comment, rule.classificationConfig); classification == "" {
 					rule.AddAdvice(&storepb.Advice{
 						Status:  rule.level,
-						Code:    advisor.CommentMissingClassification.Int32(),
+						Code:    code.CommentMissingClassification.Int32(),
 						Title:   rule.title,
 						Content: fmt.Sprintf("Table `%s` comment requires classification", tableInfo.displayName),
 						StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_table_disallow_partition.go
+++ b/backend/plugin/advisor/pg/advisor_table_disallow_partition.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -89,7 +91,7 @@ func (r *tableDisallowPartitionRule) handleCreatestmt(ctx *parser.CreatestmtCont
 
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.CreateTablePartition.Int32(),
+			Code:    code.CreateTablePartition.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Table partition is forbidden, but %q creates", stmtText),
 			StartPosition: &storepb.Position{
@@ -115,7 +117,7 @@ func (r *tableDisallowPartitionRule) handlePartitionCmd(ctx *parser.Partition_cm
 				stmtText := extractStatementText(r.statementsText, alterTableCtx.GetStart().GetLine(), alterTableCtx.GetStop().GetLine())
 				r.AddAdvice(&storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.CreateTablePartition.Int32(),
+					Code:    code.CreateTablePartition.Int32(),
 					Title:   r.title,
 					Content: fmt.Sprintf("Table partition is forbidden, but %q creates", stmtText),
 					StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/pg/advisor_table_drop_naming_convention.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -101,7 +103,7 @@ func (r *tableDropNamingConventionRule) handleDropstmt(ctx *parser.DropstmtConte
 			if tableName != "" && !r.format.MatchString(tableName) {
 				r.AddAdvice(&storepb.Advice{
 					Status:  r.level,
-					Code:    advisor.TableDropNamingConventionMismatch.Int32(),
+					Code:    code.TableDropNamingConventionMismatch.Int32(),
 					Title:   r.title,
 					Content: fmt.Sprintf("`%s` mismatches drop table naming convention, naming format should be %q", tableName, r.format),
 					StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_table_no_fk.go
+++ b/backend/plugin/advisor/pg/advisor_table_no_fk.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	parser "github.com/bytebase/parser/postgresql"
@@ -178,7 +180,7 @@ func (r *tableNoFKRule) addFKAdvice(schemaName, tableName string, ctx antlr.Pars
 	stmtText := extractStatementText(r.statementsText, ctx.GetStart().GetLine(), ctx.GetStop().GetLine())
 	r.AddAdvice(&storepb.Advice{
 		Status:  r.level,
-		Code:    advisor.TableHasFK.Int32(),
+		Code:    code.TableHasFK.Int32(),
 		Title:   r.title,
 		Content: fmt.Sprintf("Foreign key is not allowed in the table %q.%q, related statement: \"%s\"", schemaName, tableName, stmtText),
 		StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -11,6 +11,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -192,7 +193,7 @@ func (r *tableRequirePKRule) validateFinalState() {
 
 			r.AddAdvice(&storepb.Advice{
 				Status:  r.level,
-				Code:    advisor.TableNoPK.Int32(),
+				Code:    code.TableNoPK.Int32(),
 				Title:   r.title,
 				Content: content,
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/pg/sdl_check.go
+++ b/backend/plugin/advisor/pg/sdl_check.go
@@ -3,11 +3,12 @@ package pg
 import (
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/postgresql"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
@@ -58,7 +59,7 @@ func (c *sdlChecker) EnterCreatestmt(ctx *parser.CreatestmtContext) {
 	if schemaName == "" {
 		c.adviceList = append(c.adviceList, &storepb.Advice{
 			Status: storepb.Advice_ERROR,
-			Code:   advisor.SDLRequireSchemaName.Int32(),
+			Code:   code.SDLRequireSchemaName.Int32(),
 			Title:  "sdl.require-schema-name",
 			Content: fmt.Sprintf(
 				"Table '%s' is created without explicit schema name.\n\n"+
@@ -110,7 +111,7 @@ func (c *sdlChecker) EnterIndexstmt(ctx *parser.IndexstmtContext) {
 	if indexName == "" {
 		c.adviceList = append(c.adviceList, &storepb.Advice{
 			Status: storepb.Advice_ERROR,
-			Code:   advisor.SDLRequireIndexName.Int32(),
+			Code:   code.SDLRequireIndexName.Int32(),
 			Title:  "sdl.require-index-name",
 			Content: "Index is created without an explicit name.\n\n" +
 				"SDL requires all indexes to have explicit names.\n\n" +
@@ -158,7 +159,7 @@ func (c *sdlChecker) EnterIndexstmt(ctx *parser.IndexstmtContext) {
 
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status:  storepb.Advice_ERROR,
-				Code:    advisor.SDLRequireSchemaName.Int32(),
+				Code:    code.SDLRequireSchemaName.Int32(),
 				Title:   "sdl.require-schema-name",
 				Content: content,
 				StartPosition: &storepb.Position{
@@ -182,7 +183,7 @@ func (c *sdlChecker) EnterViewstmt(ctx *parser.ViewstmtContext) {
 		if schemaName == "" {
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status: storepb.Advice_ERROR,
-				Code:   advisor.SDLRequireSchemaName.Int32(),
+				Code:   code.SDLRequireSchemaName.Int32(),
 				Title:  "sdl.require-schema-name",
 				Content: fmt.Sprintf(
 					"View '%s' is created without explicit schema name.\n\n"+
@@ -214,7 +215,7 @@ func (c *sdlChecker) EnterCreateseqstmt(ctx *parser.CreateseqstmtContext) {
 		if schemaName == "" {
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status: storepb.Advice_ERROR,
-				Code:   advisor.SDLRequireSchemaName.Int32(),
+				Code:   code.SDLRequireSchemaName.Int32(),
 				Title:  "sdl.require-schema-name",
 				Content: fmt.Sprintf(
 					"Sequence '%s' is created without explicit schema name.\n\n"+
@@ -245,7 +246,7 @@ func (c *sdlChecker) EnterCreatefunctionstmt(ctx *parser.CreatefunctionstmtConte
 		if schemaName == "" {
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status: storepb.Advice_ERROR,
-				Code:   advisor.SDLRequireSchemaName.Int32(),
+				Code:   code.SDLRequireSchemaName.Int32(),
 				Title:  "sdl.require-schema-name",
 				Content: fmt.Sprintf(
 					"Function '%s' is created without explicit schema name.\n\n"+
@@ -277,7 +278,7 @@ func (c *sdlChecker) EnterAlterseqstmt(ctx *parser.AlterseqstmtContext) {
 		if schemaName == "" {
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status: storepb.Advice_ERROR,
-				Code:   advisor.SDLRequireSchemaName.Int32(),
+				Code:   code.SDLRequireSchemaName.Int32(),
 				Title:  "sdl.require-schema-name",
 				Content: fmt.Sprintf(
 					"Sequence '%s' is altered without explicit schema name.\n\n"+
@@ -354,7 +355,7 @@ func (c *sdlChecker) checkColumnConstraints(columnDef parser.IColumnDefContext, 
 
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status:  storepb.Advice_ERROR,
-				Code:    advisor.SDLDisallowColumnConstraint.Int32(),
+				Code:    code.SDLDisallowColumnConstraint.Int32(),
 				Title:   "sdl.disallow-column-constraint",
 				Content: content,
 				StartPosition: &storepb.Position{
@@ -427,7 +428,7 @@ func (c *sdlChecker) checkTableConstraintName(constraint parser.ITableconstraint
 
 		c.adviceList = append(c.adviceList, &storepb.Advice{
 			Status:  storepb.Advice_ERROR,
-			Code:    advisor.SDLRequireConstraintName.Int32(),
+			Code:    code.SDLRequireConstraintName.Int32(),
 			Title:   "sdl.require-constraint-name",
 			Content: content,
 			StartPosition: &storepb.Position{
@@ -476,7 +477,7 @@ func (c *sdlChecker) checkForeignKeyReferenceSchema(constraint parser.ITablecons
 
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status:  storepb.Advice_ERROR,
-				Code:    advisor.SDLRequireSchemaName.Int32(),
+				Code:    code.SDLRequireSchemaName.Int32(),
 				Title:   "sdl.require-schema-name",
 				Content: content,
 				StartPosition: &storepb.Position{
@@ -525,7 +526,7 @@ func (c *sdlChecker) checkColumnForeignKeyReferenceSchema(elem parser.IColconstr
 
 			c.adviceList = append(c.adviceList, &storepb.Advice{
 				Status:  storepb.Advice_ERROR,
-				Code:    advisor.SDLRequireSchemaName.Int32(),
+				Code:    code.SDLRequireSchemaName.Int32(),
 				Title:   "sdl.require-schema-name",
 				Content: content,
 				StartPosition: &storepb.Position{

--- a/backend/plugin/advisor/redshift/advisor_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/redshift/advisor_table_drop_naming_convention.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/redshift"
 	"github.com/pkg/errors"
@@ -79,7 +81,7 @@ func (l *tableDropNamingConventionListener) EnterDropstmt(ctx *parser.DropstmtCo
 				if tableName != "" && !l.format.MatchString(tableName) {
 					l.adviceList = append(l.adviceList, &storepb.Advice{
 						Status:  l.level,
-						Code:    advisor.TableDropNamingConventionMismatch.Int32(),
+						Code:    code.TableDropNamingConventionMismatch.Int32(),
 						Title:   l.title,
 						Content: fmt.Sprintf("`%s` mismatches drop table naming convention, naming format should be %q", tableName, l.format),
 						StartPosition: common.ConvertANTLRPositionToPosition(&common.ANTLRPosition{

--- a/backend/plugin/advisor/snowflake/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/snowflake/rule_column_maximum_varchar_length.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
 	"github.com/pkg/errors"
@@ -116,7 +118,7 @@ func (r *ColumnMaximumVarcharLengthRule) checkDataType(ctx *parser.Data_typeCont
 	if length > r.maximum {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.VarcharLengthExceedsLimit.Int32(),
+			Code:          code.VarcharLengthExceedsLimit.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("The maximum varchar length is %d.", r.maximum),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_column_no_null.go
+++ b/backend/plugin/advisor/snowflake/rule_column_no_null.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	snowsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/snowflake"
 )
 
@@ -121,7 +122,7 @@ func (r *ColumnNoNullRule) exitCreateTable() {
 	for normalizedColumnName, columnNullableLine := range r.columnNullable {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.ColumnCannotNull.Int32(),
+			Code:          code.ColumnCannotNull.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Column %s is nullable, which is not allowed.", normalizedColumnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + columnNullableLine),
@@ -173,7 +174,7 @@ func (r *ColumnNoNullRule) exitAlterTable() {
 	for normalizedColumnName, columnNullableLine := range r.columnNullable {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.ColumnCannotNull.Int32(),
+			Code:          code.ColumnCannotNull.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Column %s is nullable, which is not allowed.", normalizedColumnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + columnNullableLine),
@@ -215,7 +216,7 @@ func (r *ColumnNoNullRule) exitAlterTableAlterColumn() {
 	for normalizedColumnName, columnNullableLine := range r.columnNullable {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.ColumnCannotNull.Int32(),
+			Code:          code.ColumnCannotNull.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("After dropping NOT NULL of column %s, it will be nullable, which is not allowed.", normalizedColumnName),
 			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + columnNullableLine),

--- a/backend/plugin/advisor/snowflake/rule_column_require.go
+++ b/backend/plugin/advisor/snowflake/rule_column_require.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
 	"github.com/pkg/errors"
@@ -151,7 +153,7 @@ func (r *ColumnRequireRule) exitCreateTable(ctx *parser.Create_tableContext) {
 	for _, column := range columnNames {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NoRequiredColumn.Int32(),
+			Code:          code.NoRequiredColumn.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table %s missing required column %q", r.currentOriginalTableName, column),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.Column_decl_item_list().GetStop().GetLine()),
@@ -193,7 +195,7 @@ func (r *ColumnRequireRule) exitAlterTable(ctx *parser.Alter_tableContext) {
 	for _, column := range columnNames {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NoRequiredColumn.Int32(),
+			Code:          code.NoRequiredColumn.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Table %s missing required column %q", r.currentOriginalTableName, column),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.Table_column_action().GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_migration_compatibility.go
+++ b/backend/plugin/advisor/snowflake/rule_migration_compatibility.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	snowsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/snowflake"
 )
 
@@ -144,7 +145,7 @@ func (r *MigrationCompatibilityRule) enterDropTable(ctx *parser.Drop_tableContex
 	}
 	r.AddAdvice(&storepb.Advice{
 		Status:        level,
-		Code:          advisor.CompatibilityDropTable.Int32(),
+		Code:          code.CompatibilityDropTable.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("Drop table %q may cause incompatibility with the existing data and code", normalizedFullDropTableName),
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -163,7 +164,7 @@ func (r *MigrationCompatibilityRule) enterDropSchema(ctx *parser.Drop_schemaCont
 	}
 	r.AddAdvice(&storepb.Advice{
 		Status:        level,
-		Code:          advisor.CompatibilityDropSchema.Int32(),
+		Code:          code.CompatibilityDropSchema.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("Drop schema %q may cause incompatibility with the existing data and code", normalizedFullDropSchemaName),
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -182,7 +183,7 @@ func (r *MigrationCompatibilityRule) enterDropDatabase(ctx *parser.Drop_database
 	}
 	r.AddAdvice(&storepb.Advice{
 		Status:        level,
-		Code:          advisor.CompatibilityDropDatabase.Int32(),
+		Code:          code.CompatibilityDropDatabase.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("Drop database %q may cause incompatibility with the existing data and code", normalizedFullDropDatabaseName),
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -205,7 +206,7 @@ func (r *MigrationCompatibilityRule) enterAlterTable(ctx *parser.Alter_tableCont
 	}
 	r.AddAdvice(&storepb.Advice{
 		Status:        r.level,
-		Code:          advisor.CompatibilityDropColumn.Int32(),
+		Code:          code.CompatibilityDropColumn.Int32(),
 		Title:         r.title,
 		Content:       fmt.Sprintf("Drop column %s may cause incompatibility with the existing data and code", strings.Join(normalizedAllColumnNames, ",")),
 		StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_naming_identifier_case.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_identifier_case.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	snowsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/snowflake"
 )
 
@@ -115,7 +116,7 @@ func (r *NamingIdentifierCaseRule) enterColumnDeclItemList(ctx *parser.Column_de
 			if strings.ToUpper(originalColName) != originalColName {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.NamingCaseMismatch.Int32(),
+					Code:          code.NamingCaseMismatch.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Identifier %q should be upper case", originalColName),
 					StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -135,7 +136,7 @@ func (r *NamingIdentifierCaseRule) enterAlterTable(ctx *parser.Alter_tableContex
 	if strings.ToUpper(renameToColName) != renameToColName {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingCaseMismatch.Int32(),
+			Code:          code.NamingCaseMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Identifier %q should be upper case", renameToColName),
 			StartPosition: common.ConvertANTLRLineToPosition(renameToID.GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_identifier_no_keyword.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
 	"github.com/pkg/errors"
@@ -114,7 +116,7 @@ func (r *NamingIdentifierNoKeywordRule) enterColumnDeclItemList(ctx *parser.Colu
 			if snowsqlparser.IsSnowflakeKeyword(originalColName, false) {
 				r.AddAdvice(&storepb.Advice{
 					Status:        r.level,
-					Code:          advisor.NameIsKeywordIdentifier.Int32(),
+					Code:          code.NameIsKeywordIdentifier.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Identifier %s is a keyword and should be avoided", originalID.GetText()),
 					StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -134,7 +136,7 @@ func (r *NamingIdentifierNoKeywordRule) enterAlterTable(ctx *parser.Alter_tableC
 	if snowsqlparser.IsSnowflakeKeyword(renameToColName, false) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NameIsKeywordIdentifier.Int32(),
+			Code:          code.NameIsKeywordIdentifier.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Identifier %s is a keyword and should be avoided", renameToID.GetText()),
 			StartPosition: common.ConvertANTLRLineToPosition(renameToID.GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_naming_table.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_table.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -103,7 +104,7 @@ func (r *NamingTableRule) enterCreateTable(ctx *parser.Create_tableContext) {
 	if !r.format.MatchString(tableName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf(`"%s" mismatches table naming convention, naming format should be %q`, tableName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -112,7 +113,7 @@ func (r *NamingTableRule) enterCreateTable(ctx *parser.Create_tableContext) {
 	if r.maxLength > 0 && len(tableName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" mismatches table naming convention, its length should be within %d characters", tableName, r.maxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -137,7 +138,7 @@ func (r *NamingTableRule) enterAlterTable(ctx *parser.Alter_tableContext) {
 	if !r.format.MatchString(tableName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf(`"%s" mismatches table naming convention, naming format should be %q`, tableName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -146,7 +147,7 @@ func (r *NamingTableRule) enterAlterTable(ctx *parser.Alter_tableContext) {
 	if r.maxLength > 0 && len(tableName) > r.maxLength {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.NamingTableConventionMismatch.Int32(),
+			Code:          code.NamingTableConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("\"%s\" mismatches table naming convention, its length should be within %d characters", tableName, r.maxLength),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_naming_table_no_keyword.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_table_no_keyword.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
 	"github.com/pkg/errors"
@@ -90,7 +92,7 @@ func (r *NamingTableNoKeywordRule) enterCreateTable(ctx *parser.Create_tableCont
 	if snowsqlparser.IsSnowflakeKeyword(tableName, false) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NameIsKeywordIdentifier.Int32(),
+			Code:    code.NameIsKeywordIdentifier.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Table name %q is a keyword identifier and should be avoided.", tableName),
 		})
@@ -106,7 +108,7 @@ func (r *NamingTableNoKeywordRule) enterAlterTable(ctx *parser.Alter_tableContex
 	if snowsqlparser.IsSnowflakeKeyword(tableName, false) {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
-			Code:    advisor.NameIsKeywordIdentifier.Int32(),
+			Code:    code.NameIsKeywordIdentifier.Int32(),
 			Title:   r.title,
 			Content: fmt.Sprintf("Table name %q is a keyword identifier and should be avoided.", tableName),
 		})

--- a/backend/plugin/advisor/snowflake/rule_select_no_select_all.go
+++ b/backend/plugin/advisor/snowflake/rule_select_no_select_all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -84,7 +85,7 @@ func (r *SelectNoSelectAllRule) enterSelectListElem(ctx *parser.Select_list_elem
 		if v.STAR() != nil {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.StatementSelectAll.Int32(),
+				Code:          code.StatementSelectAll.Int32(),
 				Title:         r.title,
 				Content:       "Avoid using SELECT *.",
 				StartPosition: common.ConvertANTLRLineToPosition(v.STAR().GetSymbol().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/snowflake/rule_table_drop_naming_convention.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
 	"github.com/pkg/errors"
@@ -94,7 +96,7 @@ func (r *TableDropNamingConventionRule) enterDropTable(ctx *parser.Drop_tableCon
 	if !r.format.MatchString(normalizedObjectName) {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.TableDropNamingConventionMismatch.Int32(),
+			Code:          code.TableDropNamingConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("%q mismatches drop table naming convention, naming format should be %q", normalizedObjectName, r.format),
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.Object_name().GetO().GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_table_no_foreign_key.go
+++ b/backend/plugin/advisor/snowflake/rule_table_no_foreign_key.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
 	"github.com/pkg/errors"
@@ -124,7 +126,7 @@ func (r *TableNoForeignKeyRule) GetAdviceList() []*storepb.Advice {
 		if times > 0 {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableHasFK.Int32(),
+				Code:          code.TableHasFK.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("FOREIGN KEY is not allowed in the table %s.", r.tableOriginalName[tableName]),
 				StartPosition: common.ConvertANTLRLineToPosition(r.tableLine[tableName]),

--- a/backend/plugin/advisor/snowflake/rule_table_require_pk.go
+++ b/backend/plugin/advisor/snowflake/rule_table_require_pk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	snowsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/snowflake"
 )
 
@@ -126,7 +127,7 @@ func (r *TableRequirePkRule) GetAdviceList() []*storepb.Advice {
 		if !has {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,
-				Code:          advisor.TableNoPK.Int32(),
+				Code:          code.TableNoPK.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table %s requires PRIMARY KEY.", r.tableOriginalName[tableName]),
 				StartPosition: common.ConvertANTLRLineToPosition(r.tableLine[tableName]),

--- a/backend/plugin/advisor/snowflake/rule_where_require_select.go
+++ b/backend/plugin/advisor/snowflake/rule_where_require_select.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -91,7 +92,7 @@ func (r *WhereRequireForSelectRule) enterQueryStatement(ctx *parser.Query_statem
 	if optional.Where_clause() == nil && optional.From_clause() != nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementNoWhere.Int32(),
+			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       "WHERE clause is required for SELECT statement.",
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/snowflake/rule_where_require_update_delete.go
+++ b/backend/plugin/advisor/snowflake/rule_where_require_update_delete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -88,7 +89,7 @@ func (r *WhereRequireForUpdateDeleteRule) enterUpdateStatement(ctx *parser.Updat
 	if ctx.WHERE() == nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementNoWhere.Int32(),
+			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       "WHERE clause is required for UPDATE statement.",
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
@@ -100,7 +101,7 @@ func (r *WhereRequireForUpdateDeleteRule) enterDeleteStatement(ctx *parser.Delet
 	if ctx.WHERE() == nil {
 		r.AddAdvice(&storepb.Advice{
 			Status:        r.level,
-			Code:          advisor.StatementNoWhere.Int32(),
+			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       "WHERE clause is required for DELETE statement.",
 			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),

--- a/backend/plugin/advisor/tidb/advisor_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/tidb/advisor_builtin_prior_backup_check.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common/log"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 const (
@@ -72,7 +73,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 				Status:        level,
 				Title:         title,
 				Content:       "Prior backup cannot deal with mixed DDL and DML statements",
-				Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+				Code:          code.BuiltinPriorBackupCheck.Int32(),
 				StartPosition: common.ConvertANTLRLineToPosition(stmtNode.OriginTextPosition()),
 			})
 		}
@@ -84,7 +85,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 			Status:        level,
 			Title:         title,
 			Content:       fmt.Sprintf("Need database %q to do prior backup but it does not exist", databaseName),
-			Code:          advisor.DatabaseNotExists.Int32(),
+			Code:          code.DatabaseNotExists.Int32(),
 			StartPosition: nil,
 		})
 	}
@@ -94,7 +95,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 			Status:        level,
 			Title:         title,
 			Content:       fmt.Sprintf("Prior backup is feasible only with up to %d statements that are either UPDATE or DELETE, or if all UPDATEs target the same table with a PRIMARY or UNIQUE KEY in the WHERE clause", maxMixedDMLCount),
-			Code:          advisor.BuiltinPriorBackupCheck.Int32(),
+			Code:          code.BuiltinPriorBackupCheck.Int32(),
 			StartPosition: nil,
 		})
 	}

--- a/backend/plugin/advisor/tidb/advisor_column_auto_increment_initial_value.go
+++ b/backend/plugin/advisor/tidb/advisor_column_auto_increment_initial_value.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -74,7 +76,7 @@ func (checker *columnAutoIncrementInitialValueChecker) Enter(in ast.Node) (ast.N
 				if option.UintValue != uint64(checker.value) {
 					checker.adviceList = append(checker.adviceList, &storepb.Advice{
 						Status:        checker.level,
-						Code:          advisor.AutoIncrementColumnInitialValueNotMatch.Int32(),
+						Code:          code.AutoIncrementColumnInitialValueNotMatch.Int32(),
 						Title:         checker.title,
 						Content:       fmt.Sprintf("The initial auto-increment value in table `%s` is %v, which doesn't equal %v", createTable.Table.Name.O, option.UintValue, checker.value),
 						StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_auto_increment_must_integer.go
+++ b/backend/plugin/advisor/tidb/advisor_column_auto_increment_must_integer.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
@@ -112,7 +114,7 @@ func (checker *columnAutoIncrementMustIntegerChecker) Enter(in ast.Node) (ast.No
 	for _, column := range columnList {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.AutoIncrementColumnNotInteger.Int32(),
+			Code:          code.AutoIncrementColumnNotInteger.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("Auto-increment column `%s`.`%s` requires integer type", column.table, column.column),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_auto_increment_must_unsigned.go
+++ b/backend/plugin/advisor/tidb/advisor_column_auto_increment_must_unsigned.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pkg/errors"
@@ -104,7 +106,7 @@ func (checker *columnAutoIncrementMustUnsignedChecker) Enter(in ast.Node) (ast.N
 	for _, column := range columnList {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.AutoIncrementColumnSigned.Int32(),
+			Code:          code.AutoIncrementColumnSigned.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("Auto-increment column `%s`.`%s` is not UNSIGNED type", column.table, column.column),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_comment_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_column_comment_convention.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -125,7 +126,7 @@ func (checker *columnCommentConventionChecker) Enter(in ast.Node) (ast.Node, boo
 		if checker.payload.Required && !column.exist {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.CommentEmpty.Int32(),
+				Code:          code.CommentEmpty.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Column `%s`.`%s` requires comments", column.table, column.column),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),
@@ -134,7 +135,7 @@ func (checker *columnCommentConventionChecker) Enter(in ast.Node) (ast.Node, boo
 		if checker.payload.MaxLength >= 0 && len(column.comment) > checker.payload.MaxLength {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.CommentTooLong.Int32(),
+				Code:          code.CommentTooLong.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("The length of column `%s`.`%s` comment should be within %d characters", column.table, column.column, checker.payload.MaxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),
@@ -144,7 +145,7 @@ func (checker *columnCommentConventionChecker) Enter(in ast.Node) (ast.Node, boo
 			if classification, _ := common.GetClassificationAndUserComment(column.comment, checker.classificationConfig); classification == "" {
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:        checker.level,
-					Code:          advisor.CommentMissingClassification.Int32(),
+					Code:          code.CommentMissingClassification.Int32(),
 					Title:         checker.title,
 					Content:       fmt.Sprintf("Column `%s`.`%s` comment requires classification", column.table, column.column),
 					StartPosition: common.ConvertANTLRLineToPosition(column.line),
@@ -169,7 +170,7 @@ func (checker *columnCommentConventionChecker) columnComment(column *ast.ColumnD
 				comment = ""
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:  checker.level,
-					Code:    advisor.Internal.Int32(),
+					Code:    code.Internal.Int32(),
 					Title:   "Internal error for parsing column comment",
 					Content: fmt.Sprintf("\"%q\" meet internal error %s", checker.text, err),
 				})

--- a/backend/plugin/advisor/tidb/advisor_column_current_time_count_limit.go
+++ b/backend/plugin/advisor/tidb/advisor_column_current_time_count_limit.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pkg/errors"
@@ -95,7 +97,7 @@ func (checker *columnCurrentTimeCountLimitChecker) generateAdvice() []*storepb.A
 		if table.defaultCurrentTimeCount > maxDefaultCurrentTimeColumCount {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.DefaultCurrentTimeColumnCountExceedsLimit.Int32(),
+				Code:          code.DefaultCurrentTimeColumnCountExceedsLimit.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Table `%s` has %d DEFAULT CURRENT_TIMESTAMP() columns. The count greater than %d.", table.tableName, table.defaultCurrentTimeCount, maxDefaultCurrentTimeColumCount),
 				StartPosition: common.ConvertANTLRLineToPosition(table.line),
@@ -104,7 +106,7 @@ func (checker *columnCurrentTimeCountLimitChecker) generateAdvice() []*storepb.A
 		if table.onUpdateCurrentTimeCount > maxOnUpdateCurrentTimeColumnCount {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.OnUpdateCurrentTimeColumnCountExceedsLimit.Int32(),
+				Code:          code.OnUpdateCurrentTimeColumnCountExceedsLimit.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Table `%s` has %d ON UPDATE CURRENT_TIMESTAMP() columns. The count greater than %d.", table.tableName, table.onUpdateCurrentTimeCount, maxOnUpdateCurrentTimeColumnCount),
 				StartPosition: common.ConvertANTLRLineToPosition(table.line),

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_changing.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_changing.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -67,7 +69,7 @@ func (checker *columnDisallowChangingChecker) Enter(in ast.Node) (ast.Node, bool
 			if spec.Tp == ast.AlterTableChangeColumn {
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:        checker.level,
-					Code:          advisor.UseChangeColumnStatement.Int32(),
+					Code:          code.UseChangeColumnStatement.Int32(),
 					Title:         checker.title,
 					Content:       fmt.Sprintf("\"%s\" contains CHANGE COLUMN statement", checker.text),
 					StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_changing_order.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_changing_order.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -68,7 +70,7 @@ func (checker *columnDisallowChangingOrderChecker) Enter(in ast.Node) (ast.Node,
 				spec.Position.Tp != ast.ColumnPositionNone {
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:        checker.level,
-					Code:          advisor.ChangeColumnOrder.Int32(),
+					Code:          code.ChangeColumnOrder.Int32(),
 					Title:         checker.title,
 					Content:       fmt.Sprintf("\"%s\" changes column order", checker.text),
 					StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -86,7 +88,7 @@ func (checker *columnDisallowChangingTypeChecker) Enter(in ast.Node) (ast.Node, 
 	if changeType {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.ChangeColumnType.Int32(),
+			Code:          code.ChangeColumnType.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("\"%s\" changes column type", checker.text),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -103,7 +105,7 @@ func (checker *columnDisallowDropInIndexChecker) dropColumn(in ast.Node) (ast.No
 				if !checker.canDrop(table, colName) {
 					checker.adviceList = append(checker.adviceList, &storepb.Advice{
 						Status:        checker.level,
-						Code:          advisor.DropIndexColumn.Int32(),
+						Code:          code.DropIndexColumn.Int32(),
 						Title:         checker.title,
 						Content:       fmt.Sprintf("`%s`.`%s` cannot drop index column", table, colName),
 						StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_set_charset.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_set_charset.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -62,13 +64,13 @@ type columnDisallowSetCharsetChecker struct {
 
 // Enter implements the ast.Visitor interface.
 func (checker *columnDisallowSetCharsetChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisor.Ok
+	code := advisorcode.Ok
 	switch node := in.(type) {
 	case *ast.CreateTableStmt:
 		for _, column := range node.Cols {
 			charset := getColumnCharset(column)
 			if !checkCharset(charset) {
-				code = advisor.SetColumnCharset
+				code = advisorcode.SetColumnCharset
 				break
 			}
 		}
@@ -79,27 +81,27 @@ func (checker *columnDisallowSetCharsetChecker) Enter(in ast.Node) (ast.Node, bo
 				for _, column := range spec.NewColumns {
 					charset := getColumnCharset(column)
 					if !checkCharset(charset) {
-						code = advisor.SetColumnCharset
+						code = advisorcode.SetColumnCharset
 					}
 				}
 			case ast.AlterTableChangeColumn, ast.AlterTableModifyColumn:
 				charset := getColumnCharset(spec.NewColumns[0])
 				if !checkCharset(charset) {
-					code = advisor.SetColumnCharset
+					code = advisorcode.SetColumnCharset
 				}
 			default:
 				// Other alter table types
 			}
-			if code != advisor.Ok {
+			if code != advisorcode.Ok {
 				break
 			}
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.SetColumnCharset.Int32(),
+			Code:          advisorcode.SetColumnCharset.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("Disallow set column charset but \"%s\" does", checker.text),
 			StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_column_maximum_character_length.go
+++ b/backend/plugin/advisor/tidb/advisor_column_maximum_character_length.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pkg/errors"
@@ -112,7 +114,7 @@ func (checker *columnMaximumCharacterLengthChecker) Enter(in ast.Node) (ast.Node
 	if tableName != "" {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.CharLengthExceedsLimit.Int32(),
+			Code:          code.CharLengthExceedsLimit.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("The length of the CHAR column `%s` is bigger than %d, please use VARCHAR instead", columnName, checker.maximum),
 			StartPosition: common.ConvertANTLRLineToPosition(line),

--- a/backend/plugin/advisor/tidb/advisor_column_no_null.go
+++ b/backend/plugin/advisor/tidb/advisor_column_no_null.go
@@ -12,6 +12,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -86,7 +87,7 @@ func (checker *columnNoNullChecker) generateAdvice() []*storepb.Advice {
 		if col != nil && col.Nullable() {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.ColumnCannotNull.Int32(),
+				Code:          code.ColumnCannotNull.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("`%s`.`%s` cannot have NULL value", column.tableName, column.columnName),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/tidb/advisor_column_require_default.go
+++ b/backend/plugin/advisor/tidb/advisor_column_require_default.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -123,7 +125,7 @@ func (checker *columRequireDefaultChecker) Enter(in ast.Node) (ast.Node, bool) {
 	for _, column := range columnList {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.NoDefault.Int32(),
+			Code:          code.NoDefault.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("Column `%s`.`%s` doesn't have DEFAULT.", column.table, column.column),
 			StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/tidb/advisor_column_required.go
+++ b/backend/plugin/advisor/tidb/advisor_column_required.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -133,7 +135,7 @@ func (v *columnRequirementChecker) generateAdviceList() []*storepb.Advice {
 			slices.Sort(missingColumns)
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.NoRequiredColumn.Int32(),
+				Code:          code.NoRequiredColumn.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("Table `%s` requires columns: %s", tableName, strings.Join(missingColumns, ", ")),
 				StartPosition: common.ConvertANTLRLineToPosition(v.line[tableName]),

--- a/backend/plugin/advisor/tidb/advisor_column_set_default_for_not_null.go
+++ b/backend/plugin/advisor/tidb/advisor_column_set_default_for_not_null.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -119,7 +121,7 @@ func (checker *columnSetDefaultForNotNullChecker) Enter(in ast.Node) (ast.Node, 
 	for _, column := range notNullColumnWithNoDefault {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.NotNullColumnWithNoDefault.Int32(),
+			Code:          code.NotNullColumnWithNoDefault.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("Column `%s`.`%s` is NOT NULL but doesn't have DEFAULT", column.tableName, column.columnName),
 			StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/tidb/advisor_column_type_disallow_list.go
+++ b/backend/plugin/advisor/tidb/advisor_column_type_disallow_list.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -124,7 +126,7 @@ func (checker *columnTypeDisallowListChecker) Enter(in ast.Node) (ast.Node, bool
 	for _, column := range columnList {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.DisabledColumnType.Int32(),
+			Code:          code.DisabledColumnType.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("Disallow column type %s but column `%s`.`%s` is", column.tp, column.table, column.column),
 			StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/tidb/advisor_database_drop_empty_db.go
+++ b/backend/plugin/advisor/tidb/advisor_database_drop_empty_db.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -63,7 +65,7 @@ func (v *allowDropEmptyDBChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if v.originCatalog.DatabaseName() != node.Name.O {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.NotCurrentDatabase.Int32(),
+				Code:          code.NotCurrentDatabase.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("Database `%s` that is trying to be deleted is not the current database `%s`", node.Name, v.originCatalog.DatabaseName()),
 				StartPosition: common.ConvertANTLRLineToPosition(node.OriginTextPosition()),
@@ -71,7 +73,7 @@ func (v *allowDropEmptyDBChecker) Enter(in ast.Node) (ast.Node, bool) {
 		} else if !v.originCatalog.HasNoTable() {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.DatabaseNotEmpty.Int32(),
+				Code:          code.DatabaseNotEmpty.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("Database `%s` is not allowed to drop if not empty", node.Name),
 				StartPosition: common.ConvertANTLRLineToPosition(node.OriginTextPosition()),

--- a/backend/plugin/advisor/tidb/advisor_index_key_number_limit.go
+++ b/backend/plugin/advisor/tidb/advisor_index_key_number_limit.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -108,7 +110,7 @@ func (checker *indexKeyNumberLimitChecker) Enter(in ast.Node) (ast.Node, bool) {
 	for _, index := range indexList {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.IndexKeyNumberExceedsLimit.Int32(),
+			Code:          code.IndexKeyNumberExceedsLimit.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("The number of index `%s` in table `%s` should be not greater than %d", index.index, index.table, checker.max),
 			StartPosition: common.ConvertANTLRLineToPosition(index.line),

--- a/backend/plugin/advisor/tidb/advisor_index_no_duplicate_column.go
+++ b/backend/plugin/advisor/tidb/advisor_index_no_duplicate_column.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -129,7 +131,7 @@ func (checker *indexNoDuplicateColumnChecker) Enter(in ast.Node) (ast.Node, bool
 	for _, column := range columnList {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
-			Code:          advisor.DuplicateColumnInIndex.Int32(),
+			Code:          code.DuplicateColumnInIndex.Int32(),
 			Title:         checker.title,
 			Content:       fmt.Sprintf("%s `%s` has duplicate column `%s`.`%s`", column.tp, column.index, column.table, column.column),
 			StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/tidb/advisor_index_pk_type.go
+++ b/backend/plugin/advisor/tidb/advisor_index_pk_type.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
@@ -138,7 +140,7 @@ func (v *indexPkTypeChecker) Enter(in ast.Node) (ast.Node, bool) {
 	for _, pd := range pkDataList {
 		v.adviceList = append(v.adviceList, &storepb.Advice{
 			Status:        v.level,
-			Code:          advisor.IndexPKType.Int32(),
+			Code:          code.IndexPKType.Int32(),
 			Title:         v.title,
 			Content:       fmt.Sprintf("Columns in primary key must be INT/BIGINT but `%s`.`%s` is %s", pd.table, pd.column, pd.columnType),
 			StartPosition: common.ConvertANTLRLineToPosition(pd.line),

--- a/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -119,7 +121,7 @@ func (v *indexPrimaryKeyTypeAllowlistChecker) Enter(in ast.Node) (ast.Node, bool
 	for _, pd := range pkDataList {
 		v.adviceList = append(v.adviceList, &storepb.Advice{
 			Status:        v.level,
-			Code:          advisor.IndexPKType.Int32(),
+			Code:          code.IndexPKType.Int32(),
 			Title:         v.title,
 			Content:       fmt.Sprintf("The column `%s` in table `%s` is one of the primary key, but its type \"%s\" is not in allowlist", pd.column, pd.table, pd.columnType),
 			StartPosition: common.ConvertANTLRLineToPosition(pd.line),

--- a/backend/plugin/advisor/tidb/advisor_index_total_number_limit.go
+++ b/backend/plugin/advisor/tidb/advisor_index_total_number_limit.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -100,7 +102,7 @@ func (checker *indexTotalNumberLimitChecker) generateAdvice() []*storepb.Advice 
 		if tableInfo != nil && tableInfo.CountIndex() > checker.max {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.IndexCountExceedsLimit.Int32(),
+				Code:          code.IndexCountExceedsLimit.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("The count of index in table `%s` should be no more than %d, but found %d", table.name, checker.max, tableInfo.CountIndex()),
 				StartPosition: common.ConvertANTLRLineToPosition(table.line),

--- a/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
+++ b/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
@@ -116,7 +118,7 @@ func (v *indexTypeNoBlobChecker) Enter(in ast.Node) (ast.Node, bool) {
 	for _, pd := range pkDataList {
 		v.adviceList = append(v.adviceList, &storepb.Advice{
 			Status:        v.level,
-			Code:          advisor.IndexTypeNoBlob.Int32(),
+			Code:          code.IndexTypeNoBlob.Int32(),
 			Title:         v.title,
 			Content:       fmt.Sprintf("Columns in index must not be BLOB but `%s`.`%s` is %s", pd.table, pd.column, pd.columnType),
 			StartPosition: common.ConvertANTLRLineToPosition(pd.line),

--- a/backend/plugin/advisor/tidb/advisor_insert_disallow_order_by_rand.go
+++ b/backend/plugin/advisor/tidb/advisor_insert_disallow_order_by_rand.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -62,7 +63,7 @@ type insertDisallowOrderByRandChecker struct {
 
 // Enter implements the ast.Visitor interface.
 func (checker *insertDisallowOrderByRandChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if insert, ok := in.(*ast.InsertStmt); ok {
 		if insert.Select != nil {
 			if selectNode, ok := insert.Select.(*ast.SelectStmt); ok {
@@ -70,7 +71,7 @@ func (checker *insertDisallowOrderByRandChecker) Enter(in ast.Node) (ast.Node, b
 					for _, item := range selectNode.OrderBy.Items {
 						if f, ok := item.Expr.(*ast.FuncCallExpr); ok {
 							if f.FnName.L == ast.Rand {
-								code = advisor.InsertUseOrderByRand
+								code = advisorcode.InsertUseOrderByRand
 								break
 							}
 						}
@@ -80,7 +81,7 @@ func (checker *insertDisallowOrderByRandChecker) Enter(in ast.Node) (ast.Node, b
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/tidb/advisor_insert_must_specify_column.go
+++ b/backend/plugin/advisor/tidb/advisor_insert_must_specify_column.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -66,7 +67,7 @@ func (checker *insertMustSpecifyColumnChecker) Enter(in ast.Node) (ast.Node, boo
 		if node.Columns == nil {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.InsertNotSpecifyColumn.Int32(),
+				Code:          code.InsertNotSpecifyColumn.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("The INSERT statement must specify columns but \"%s\" does not", checker.text),
 				StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_naming_auto_increment_column.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_auto_increment_column.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -121,7 +122,7 @@ func (checker *namingAutoIncrementColumnChecker) Enter(in ast.Node) (ast.Node, b
 		if !checker.format.MatchString(column.name) {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingAutoIncrementColumnConventionMismatch.Int32(),
+				Code:          code.NamingAutoIncrementColumnConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("`%s`.`%s` mismatches auto_increment column naming convention, naming format should be %q", tableName, column.name, checker.format),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),
@@ -130,7 +131,7 @@ func (checker *namingAutoIncrementColumnChecker) Enter(in ast.Node) (ast.Node, b
 		if checker.maxLength > 0 && len(column.name) > checker.maxLength {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingAutoIncrementColumnConventionMismatch.Int32(),
+				Code:          code.NamingAutoIncrementColumnConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("`%s`.`%s` mismatches auto_increment column naming convention, its length should be within %d characters", tableName, column.name, checker.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/tidb/advisor_naming_column.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_column.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -116,7 +117,7 @@ func (v *namingColumnConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if !v.format.MatchString(column.name) {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.NamingColumnConventionMismatch.Int32(),
+				Code:          code.NamingColumnConventionMismatch.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, naming format should be %q", tableName, column.name, v.format),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),
@@ -125,7 +126,7 @@ func (v *namingColumnConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if v.maxLength > 0 && len(column.name) > v.maxLength {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.NamingColumnConventionMismatch.Int32(),
+				Code:          code.NamingColumnConventionMismatch.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, its length should be within %d characters", tableName, column.name, v.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),

--- a/backend/plugin/advisor/tidb/advisor_naming_foreign_key_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_foreign_key_convention.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -74,7 +75,7 @@ func (checker *namingFKConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if err != nil {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:  checker.level,
-				Code:    advisor.Internal.Int32(),
+				Code:    code.Internal.Int32(),
 				Title:   "Internal error for foreign key naming convention rule",
 				Content: fmt.Sprintf("%q meet internal error %q", in.Text(), err.Error()),
 			})
@@ -83,7 +84,7 @@ func (checker *namingFKConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if !regex.MatchString(indexData.indexName) {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingFKConventionMismatch.Int32(),
+				Code:          code.NamingFKConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Foreign key in table `%s` mismatches the naming convention, expect %q but found `%s`", indexData.tableName, regex, indexData.indexName),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),
@@ -92,7 +93,7 @@ func (checker *namingFKConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if checker.maxLength > 0 && len(indexData.indexName) > checker.maxLength {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingFKConventionMismatch.Int32(),
+				Code:          code.NamingFKConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Foreign key `%s` in table `%s` mismatches the naming convention, its length should be within %d characters", indexData.indexName, indexData.tableName, checker.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),

--- a/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
@@ -13,6 +13,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -78,7 +79,7 @@ func (checker *namingIndexConventionChecker) Enter(in ast.Node) (ast.Node, bool)
 		if err != nil {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:  checker.level,
-				Code:    advisor.Internal.Int32(),
+				Code:    code.Internal.Int32(),
 				Title:   "Internal error for index naming convention rule",
 				Content: fmt.Sprintf("%q meet internal error %q", in.Text(), err.Error()),
 			})
@@ -87,7 +88,7 @@ func (checker *namingIndexConventionChecker) Enter(in ast.Node) (ast.Node, bool)
 		if !regex.MatchString(indexData.indexName) {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingIndexConventionMismatch.Int32(),
+				Code:          code.NamingIndexConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Index in table `%s` mismatches the naming convention, expect %q but found `%s`", indexData.tableName, regex, indexData.indexName),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),
@@ -96,7 +97,7 @@ func (checker *namingIndexConventionChecker) Enter(in ast.Node) (ast.Node, bool)
 		if checker.maxLength > 0 && len(indexData.indexName) > checker.maxLength {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingIndexConventionMismatch.Int32(),
+				Code:          code.NamingIndexConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Index `%s` in table `%s` mismatches the naming convention, its length should be within %d characters", indexData.indexName, indexData.tableName, checker.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),

--- a/backend/plugin/advisor/tidb/advisor_naming_table.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -89,7 +90,7 @@ func (v *namingTableConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if !v.format.MatchString(tableName) {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.NamingTableConventionMismatch.Int32(),
+				Code:          code.NamingTableConventionMismatch.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("`%s` mismatches table naming convention, naming format should be %q", tableName, v.format),
 				StartPosition: common.ConvertANTLRLineToPosition(in.OriginTextPosition()),
@@ -98,7 +99,7 @@ func (v *namingTableConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if v.maxLength > 0 && len(tableName) > v.maxLength {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.NamingTableConventionMismatch.Int32(),
+				Code:          code.NamingTableConventionMismatch.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("`%s` mismatches table naming convention, its length should be within %d characters", tableName, v.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(in.OriginTextPosition()),

--- a/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
@@ -12,6 +12,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -77,7 +78,7 @@ func (checker *namingUKConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if err != nil {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:  checker.level,
-				Code:    advisor.Internal.Int32(),
+				Code:    code.Internal.Int32(),
 				Title:   "Internal error for unique key naming convention rule",
 				Content: fmt.Sprintf("%q meet internal error %q", in.Text(), err.Error()),
 			})
@@ -86,7 +87,7 @@ func (checker *namingUKConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if !regex.MatchString(indexData.indexName) {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingUKConventionMismatch.Int32(),
+				Code:          code.NamingUKConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Unique key in table `%s` mismatches the naming convention, expect %q but found `%s`", indexData.tableName, regex, indexData.indexName),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),
@@ -95,7 +96,7 @@ func (checker *namingUKConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if checker.maxLength > 0 && len(indexData.indexName) > checker.maxLength {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.NamingUKConventionMismatch.Int32(),
+				Code:          code.NamingUKConventionMismatch.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Unique key `%s` in table `%s` mismatches the naming convention, its length should be within %d characters", indexData.indexName, indexData.tableName, checker.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(indexData.line),

--- a/backend/plugin/advisor/tidb/advisor_statement_disallow_mix_in_ddl.go
+++ b/backend/plugin/advisor/tidb/advisor_statement_disallow_mix_in_ddl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -49,7 +50,7 @@ func (*StatementDisallowMixInDDLAdvisor) Check(_ context.Context, checkCtx advis
 				Status:        level,
 				Title:         title,
 				Content:       fmt.Sprintf("Alter schema can only run DDL, \"%s\" is not DDL", stmtNode.Text()),
-				Code:          advisor.StatementDisallowMixDDLDML.Int32(),
+				Code:          code.StatementDisallowMixDDLDML.Int32(),
 				StartPosition: common.ConvertANTLRLineToPosition(stmtNode.OriginTextPosition()),
 			})
 		}

--- a/backend/plugin/advisor/tidb/advisor_statement_disallow_mix_in_dml.go
+++ b/backend/plugin/advisor/tidb/advisor_statement_disallow_mix_in_dml.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -49,7 +50,7 @@ func (*StatementDisallowMixInDMLAdvisor) Check(_ context.Context, checkCtx advis
 				Status:        level,
 				Title:         title,
 				Content:       fmt.Sprintf("Data change can only run DML, \"%s\" is not DML", stmtNode.Text()),
-				Code:          advisor.StatementDisallowMixDDLDML.Int32(),
+				Code:          code.StatementDisallowMixDDLDML.Int32(),
 				StartPosition: common.ConvertANTLRLineToPosition(stmtNode.OriginTextPosition()),
 			})
 		}

--- a/backend/plugin/advisor/tidb/advisor_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/tidb/advisor_statement_dml_dry_run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -79,7 +80,7 @@ func (checker *statementDmlDryRunChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if _, err := advisor.Query(checker.ctx, advisor.QueryContext{}, checker.driver, storepb.Engine_TIDB, fmt.Sprintf("EXPLAIN %s", node.Text())); err != nil {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.StatementDMLDryRunFailed.Int32(),
+				Code:          code.StatementDMLDryRunFailed.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", node.Text(), err.Error()),
 				StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_statement_maximum_limit_value.go
+++ b/backend/plugin/advisor/tidb/advisor_statement_maximum_limit_value.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -77,7 +78,7 @@ func (checker *statementMaximumLimitValueChecker) Enter(in ast.Node) (ast.Node, 
 			if limitVal > int64(checker.limitMaxValue) {
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:        checker.level,
-					Code:          advisor.StatementExceedMaximumLimitValue.Int32(),
+					Code:          code.StatementExceedMaximumLimitValue.Int32(),
 					Title:         checker.title,
 					Content:       fmt.Sprintf("The limit value %d exceeds the maximum allowed value %d", limitVal, checker.limitMaxValue),
 					StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_statement_merge_alter_table.go
+++ b/backend/plugin/advisor/tidb/advisor_statement_merge_alter_table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -119,7 +120,7 @@ func (checker *statementMergeAlterTableChecker) generateAdvice() []*storepb.Advi
 		if table.count > 1 {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.StatementRedundantAlterTable.Int32(),
+				Code:          code.StatementRedundantAlterTable.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("There are %d statements to modify table `%s`", table.count, table.name),
 				StartPosition: common.ConvertANTLRLineToPosition(table.lastLine),

--- a/backend/plugin/advisor/tidb/advisor_stmt_disallow_commit.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_disallow_commit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -65,7 +66,7 @@ func (c *statementDisallowCommitChecker) Enter(in ast.Node) (ast.Node, bool) {
 	if _, ok := in.(*ast.CommitStmt); ok {
 		c.adviceList = append(c.adviceList, &storepb.Advice{
 			Status:        c.level,
-			Code:          advisor.StatementDisallowCommit.Int32(),
+			Code:          code.StatementDisallowCommit.Int32(),
 			Title:         c.title,
 			Content:       fmt.Sprintf("Commit is not allowed, related statement: \"%s\"", c.text),
 			StartPosition: common.ConvertANTLRLineToPosition(c.line),

--- a/backend/plugin/advisor/tidb/advisor_stmt_disallow_limit.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_disallow_limit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -62,23 +63,23 @@ type statementDisallowLimitChecker struct {
 
 // Enter implements the ast.Visitor interface.
 func (checker *statementDisallowLimitChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisor.Ok
+	code := advisorcode.Ok
 	switch node := in.(type) {
 	case *ast.UpdateStmt:
 		if node.Limit != nil {
-			code = advisor.UpdateUseLimit
+			code = advisorcode.UpdateUseLimit
 		}
 	case *ast.DeleteStmt:
 		if node.Limit != nil {
-			code = advisor.DeleteUseLimit
+			code = advisorcode.DeleteUseLimit
 		}
 	case *ast.InsertStmt:
 		if useLimit(node) {
-			code = advisor.InsertUseLimit
+			code = advisorcode.InsertUseLimit
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/tidb/advisor_stmt_disallow_order_by.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_disallow_order_by.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -62,19 +63,19 @@ type disallowOrderByChecker struct {
 
 // Enter implements the ast.Visitor interface.
 func (checker *disallowOrderByChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisor.Ok
+	code := advisorcode.Ok
 	switch node := in.(type) {
 	case *ast.UpdateStmt:
 		if node.Order != nil {
-			code = advisor.UpdateUseOrderBy
+			code = advisorcode.UpdateUseOrderBy
 		}
 	case *ast.DeleteStmt:
 		if node.Order != nil {
-			code = advisor.DeleteUseOrderBy
+			code = advisorcode.DeleteUseOrderBy
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/tidb/advisor_stmt_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_no_leading_wildcard_like.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 const (
@@ -51,7 +52,7 @@ func (*NoLeadingWildcardLikeAdvisor) Check(_ context.Context, checkCtx advisor.C
 		if checker.leadingWildcardLike {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.StatementLeadingWildcardLike.Int32(),
+				Code:          code.StatementLeadingWildcardLike.Int32(),
 				Title:         string(checkCtx.Rule.Type),
 				Content:       fmt.Sprintf("\"%s\" uses leading wildcard LIKE", checker.text),
 				StartPosition: common.ConvertANTLRLineToPosition(stmtNode.OriginTextPosition()),
@@ -76,7 +77,7 @@ func (v *noLeadingWildcardLikeChecker) Enter(in ast.Node) (ast.Node, bool) {
 		if err != nil {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:  v.level,
-				Code:    advisor.Internal.Int32(),
+				Code:    code.Internal.Int32(),
 				Title:   "Internal error for no leading wildcard LIKE rule",
 				Content: fmt.Sprintf("\"%s\" meet internal error %q", v.text, err.Error()),
 			})

--- a/backend/plugin/advisor/tidb/advisor_stmt_no_select_all.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_no_select_all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -64,7 +65,7 @@ func (v *noSelectAllChecker) Enter(in ast.Node) (ast.Node, bool) {
 			if field.WildCard != nil {
 				v.adviceList = append(v.adviceList, &storepb.Advice{
 					Status:        v.level,
-					Code:          advisor.StatementSelectAll.Int32(),
+					Code:          code.StatementSelectAll.Int32(),
 					Title:         v.title,
 					Content:       fmt.Sprintf("\"%s\" uses SELECT all", v.text),
 					StartPosition: common.ConvertANTLRLineToPosition(v.line),

--- a/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_select.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_select.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
 )
@@ -60,15 +61,15 @@ type whereRequirementForSelectChecker struct {
 
 // Enter implements the ast.Visitor interface.
 func (v *whereRequirementForSelectChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisor.Ok
+	code := advisorcode.Ok
 	if node, ok := in.(*ast.SelectStmt); ok {
 		// Allow SELECT queries without a FROM clause to proceed, e.g. SELECT 1.
 		if node.Where == nil && node.From != nil {
-			code = advisor.StatementNoWhere
+			code = advisorcode.StatementNoWhere
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		v.adviceList = append(v.adviceList, &storepb.Advice{
 			Status:        v.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_update_delete.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_update_delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
 )
@@ -60,21 +61,21 @@ type whereRequirementForUpdateDeleteChecker struct {
 
 // Enter implements the ast.Visitor interface.
 func (v *whereRequirementForUpdateDeleteChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisor.Ok
+	code := advisorcode.Ok
 	switch node := in.(type) {
 	// DELETE
 	case *ast.DeleteStmt:
 		if node.Where == nil {
-			code = advisor.StatementNoWhere
+			code = advisorcode.StatementNoWhere
 		}
 	// UPDATE
 	case *ast.UpdateStmt:
 		if node.Where == nil {
-			code = advisor.StatementNoWhere
+			code = advisorcode.StatementNoWhere
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		v.adviceList = append(v.adviceList, &storepb.Advice{
 			Status:        v.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/tidb/advisor_table_comment_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_table_comment_convention.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
@@ -75,7 +76,7 @@ func (checker *tableCommentConventionChecker) Enter(in ast.Node) (ast.Node, bool
 		if checker.payload.Required && !exist {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.CommentEmpty.Int32(),
+				Code:          code.CommentEmpty.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("Table `%s` requires comments", node.Table.Name.O),
 				StartPosition: common.ConvertANTLRLineToPosition(checker.line),
@@ -84,7 +85,7 @@ func (checker *tableCommentConventionChecker) Enter(in ast.Node) (ast.Node, bool
 		if checker.payload.MaxLength >= 0 && len(comment) > checker.payload.MaxLength {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,
-				Code:          advisor.CommentTooLong.Int32(),
+				Code:          code.CommentTooLong.Int32(),
 				Title:         checker.title,
 				Content:       fmt.Sprintf("The length of table `%s` comment should be within %d characters", node.Table.Name.O, checker.payload.MaxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(checker.line),
@@ -94,7 +95,7 @@ func (checker *tableCommentConventionChecker) Enter(in ast.Node) (ast.Node, bool
 			if classification, _ := common.GetClassificationAndUserComment(comment, checker.classificationConfig); classification == "" {
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:        checker.level,
-					Code:          advisor.CommentMissingClassification.Int32(),
+					Code:          code.CommentMissingClassification.Int32(),
 					Title:         checker.title,
 					Content:       fmt.Sprintf("Table `%s` comment requires classification", node.Table.Name.O),
 					StartPosition: common.ConvertANTLRLineToPosition(checker.line),

--- a/backend/plugin/advisor/tidb/advisor_table_disallow_partition.go
+++ b/backend/plugin/advisor/tidb/advisor_table_disallow_partition.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -62,22 +64,22 @@ type tableDisallowPartitionChecker struct {
 
 // Enter implements the ast.Visitor interface.
 func (checker *tableDisallowPartitionChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisor.Ok
+	code := advisorcode.Ok
 	switch node := in.(type) {
 	case *ast.CreateTableStmt:
 		if node.Partition != nil {
-			code = advisor.CreateTablePartition
+			code = advisorcode.CreateTablePartition
 		}
 	case *ast.AlterTableStmt:
 		for _, spec := range node.Specs {
 			if spec.Tp == ast.AlterTablePartition {
-				code = advisor.CreateTablePartition
+				code = advisorcode.CreateTablePartition
 				break
 			}
 		}
 	}
 
-	if code != advisor.Ok {
+	if code != advisorcode.Ok {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.Int32(),

--- a/backend/plugin/advisor/tidb/advisor_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_table_drop_naming_convention.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -68,7 +70,7 @@ func (v *namingDropTableConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
 			if !v.format.MatchString(table.Name.O) {
 				v.adviceList = append(v.adviceList, &storepb.Advice{
 					Status:        v.level,
-					Code:          advisor.TableDropNamingConventionMismatch.Int32(),
+					Code:          code.TableDropNamingConventionMismatch.Int32(),
 					Title:         v.title,
 					Content:       fmt.Sprintf("`%s` mismatches drop table naming convention, naming format should be %q", table.Name.O, v.format),
 					StartPosition: common.ConvertANTLRLineToPosition(node.OriginTextPosition()),

--- a/backend/plugin/advisor/tidb/advisor_table_no_fk.go
+++ b/backend/plugin/advisor/tidb/advisor_table_no_fk.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pkg/errors"
 
@@ -61,7 +63,7 @@ func (checker *tableNoFKChecker) Enter(in ast.Node) (ast.Node, bool) {
 			if constraint.Tp == ast.ConstraintForeignKey {
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:        checker.level,
-					Code:          advisor.TableHasFK.Int32(),
+					Code:          code.TableHasFK.Int32(),
 					Title:         checker.title,
 					Content:       fmt.Sprintf("Foreign key is not allowed in the table `%s`", node.Table.Name),
 					StartPosition: common.ConvertANTLRLineToPosition(constraint.OriginTextPosition()),
@@ -73,7 +75,7 @@ func (checker *tableNoFKChecker) Enter(in ast.Node) (ast.Node, bool) {
 			if spec.Tp == ast.AlterTableAddConstraint && spec.Constraint.Tp == ast.ConstraintForeignKey {
 				checker.adviceList = append(checker.adviceList, &storepb.Advice{
 					Status:        checker.level,
-					Code:          advisor.TableHasFK.Int32(),
+					Code:          code.TableHasFK.Int32(),
 					Title:         checker.title,
 					Content:       fmt.Sprintf("Foreign key is not allowed in the table `%s`", node.Table.Name),
 					StartPosition: common.ConvertANTLRLineToPosition(in.OriginTextPosition()),

--- a/backend/plugin/advisor/tidb/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/tidb/advisor_table_require_pk.go
@@ -12,6 +12,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/catalog"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 const (
@@ -141,7 +142,7 @@ func (v *tableRequirePKChecker) generateAdviceList() []*storepb.Advice {
 		if len(v.tables[tableName]) == 0 {
 			v.adviceList = append(v.adviceList, &storepb.Advice{
 				Status:        v.level,
-				Code:          advisor.TableNoPK.Int32(),
+				Code:          code.TableNoPK.Int32(),
 				Title:         v.title,
 				Content:       fmt.Sprintf("Table `%s` requires PRIMARY KEY", tableName),
 				StartPosition: common.ConvertANTLRLineToPosition(v.line[tableName]),


### PR DESCRIPTION
## Summary

This PR contains two main refactorings to clean up the advisor error code architecture:

### 1. Centralize error codes
- Move `backend/plugin/advisor/code.go` to `backend/plugin/advisor/code/code.go`
- Update ~200 advisor files to use the new code package
- Eliminates import cycle between advisor and catalog packages

### 2. Remove unused Payload field
- Remove `Payload` field from `WalkThroughError` struct
- The field only stored view lists already included in the error `Content` string
- Provided no value in production code, only used for redundant test validation
- Simplifies error handling and test code

## Changes

- Move error codes to `backend/plugin/advisor/code/code.go` package
- Update `WalkThroughError` struct to use `code.Code` instead of `Type` enum
- Remove `Payload` field from `WalkThroughError` struct
- Remove `Payload` assignments from error constructions (5 locations)
- Simplify test error comparison logic
- Remove `payload:` fields from YAML test files
- Update ~200 advisor files to import and use code package

## Test plan

- [x] All walk-through tests pass: `TestTiDBWalkThrough`, `TestMySQLWalkThrough`, `TestPostgreSQLWalkThrough`, `TestPostgreSQLANTLRWalkThrough`
- [x] No linting issues: `golangci-lint run --allow-parallel-runners`
- [x] Code properly formatted with `gofmt`

## Statistics

- 280 files changed
- 1,991 insertions(+)
- 3,316 deletions(-)
- Net reduction: 1,325 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)