### PR TITLE
refactor: remove unnecessary pointer usage in catalog state structures

### DIFF
--- a/backend/plugin/advisor/catalog/walk_through_test.go
+++ b/backend/plugin/advisor/catalog/walk_through_test.go
@@ -303,17 +303,9 @@ func (s *SchemaState) convertToTableMetadataList() []*storepb.TableMetadata {
 			ForeignKeys: []*storepb.ForeignKeyMetadata{},
 		}
 
-		if table.engine != nil {
-			tableMeta.Engine = *table.engine
-		}
-
-		if table.collation != nil {
-			tableMeta.Collation = *table.collation
-		}
-
-		if table.comment != nil {
-			tableMeta.Comment = *table.comment
-		}
+		tableMeta.Engine = table.engine
+		tableMeta.Collation = table.collation
+		tableMeta.Comment = table.comment
 
 		result = append(result, tableMeta)
 	}
@@ -342,17 +334,9 @@ func (t *TableState) convertToIndexMetadataList() []*storepb.IndexMetadata {
 			Primary:     index.Primary(),
 		}
 
-		if index.indexType != nil {
-			indexMeta.Type = *index.indexType
-		}
-
-		if index.visible != nil {
-			indexMeta.Visible = *index.visible
-		}
-
-		if index.comment != nil {
-			indexMeta.Comment = *index.comment
-		}
+		indexMeta.Type = index.indexType
+		indexMeta.Visible = index.visible
+		indexMeta.Comment = index.comment
 
 		result = append(result, indexMeta)
 	}
@@ -380,25 +364,11 @@ func (t *TableState) convertToColumnMetadataList() []*storepb.ColumnMetadata {
 			Type:     column.Type(),
 		}
 
-		if column.defaultValue != nil {
-			columnMeta.Default = *column.defaultValue
-		}
-
-		if column.characterSet != nil {
-			columnMeta.CharacterSet = *column.characterSet
-		}
-
-		if column.collation != nil {
-			columnMeta.Collation = *column.collation
-		}
-
-		if column.comment != nil {
-			columnMeta.Comment = *column.comment
-		}
-
-		if column.position != nil {
-			columnMeta.Position = int32(*column.position)
-		}
+		columnMeta.Default = column.defaultValue
+		columnMeta.CharacterSet = column.characterSet
+		columnMeta.Collation = column.collation
+		columnMeta.Comment = column.comment
+		columnMeta.Position = int32(column.position)
 
 		result = append(result, columnMeta)
 	}


### PR DESCRIPTION
## Summary

This PR refactors the catalog state structures to remove unnecessary pointer usage for primitive types, simplifies the codebase by removing duplicate helper methods, and improves code organization by converting engine-specific methods to standalone functions.

### Key Changes

**1. Remove Pointer Types for Primitives**
- Changed all primitive type fields from pointers to values in:
  - `TableState`: `engine`, `collation`, `comment` (string* → string)
  - `IndexState`: `indexType`, `comment` (string* → string), `visible` (bool* → bool)
  - `ColumnState`: `defaultValue`, `columnType`, `characterSet`, `collation`, `comment` (string* → string), `nullable` (bool* → bool), `position` (int* → int)
  - `ViewState`: `definition`, `comment` (string* → string)
- Deleted 9 pointer helper functions: `copyStringPointer`, `copyBoolPointer`, `copyIntPointer`, `newEmptyStringPointer`, `newStringPointer`, `newIntPointer`, `newTruePointer`, `newFalsePointer`, `newBoolPointer`
- Kept `copyStringSlice` as it's still useful for slice copying
- Simplified all accessors by removing nil checks and pointer dereferences
- Updated constructors to use direct value assignment

**2. Remove Duplicate Helper Methods**
- Deleted `createDefaultSchema()` - replaced with public `CreateSchema("")`
- Deleted `pgGetColumn()` - replaced with public `GetColumn()` (both use normalized lowercase keys)
- Deleted `pgGetTable()` - replaced with public `GetTable()` (both use normalized lowercase keys)
- Refactored `pgGetOrCreateSchema()` to use public `GetSchema()` and `CreateSchema()` instead of duplicating logic

**3. Refactor Engine-Specific Methods to Standalone Functions**
- Changed `mysqlGetTable` and `mysqlRenameTable` from `SchemaState` methods to standalone functions
- Better separation of concerns - MySQL/TiDB-specific logic no longer pollutes the generic `SchemaState` type
- More flexible and clearer intent

**4. Resolve Naming Conflicts**
- Renamed internal methods with engine-specific prefixes to avoid revive linting errors
- Examples: `createColumn` → `tidbCreateColumn`, `createIndex` → `tidbCreateIndex`

### Benefits

- **Simpler code**: Removed 162 net lines of code (516 deletions, 354 insertions)
- **Better alignment with proto3**: Proto3 doesn't distinguish between nil and zero values, so pointers were adding unnecessary complexity
- **Improved type safety**: No more nil pointer dereferences
- **Cleaner API**: Removed duplicate methods, better separation of concerns
- **No linting issues**: Resolved all revive naming conflicts

### Testing

- ✅ All catalog package tests pass
- ✅ All backend/plugin/advisor tests pass
- ✅ No golangci-lint issues

## Test plan

- [x] Run `go test github.com/bytebase/bytebase/backend/plugin/advisor/catalog`
- [x] Run `go test ./backend/plugin/advisor/...`
- [x] Run `golangci-lint run --allow-parallel-runners`