### PR TITLE
chore: remove legacy migration comments from pgantlr_test.go

### DIFF
--- a/backend/plugin/advisor/pg/pgantlr_test.go
+++ b/backend/plugin/advisor/pg/pgantlr_test.go
@@ -9,60 +9,60 @@ import (
 
 func TestPostgreSQLANTLRRules(t *testing.T) {
 	antlrRules := []advisor.SQLReviewRuleType{
-		advisor.BuiltinRulePriorBackupCheck,                     // Migrated from legacy
-		advisor.SchemaRuleCharsetAllowlist,                      // Migrated from legacy
-		advisor.SchemaRuleCollationAllowlist,                    // Migrated from legacy
-		advisor.SchemaRuleColumnCommentConvention,               // Migrated from legacy
-		advisor.SchemaRuleColumnDefaultDisallowVolatile,         // Migrated from legacy
-		advisor.SchemaRuleColumnDisallowChangeType,              // Migrated from legacy
-		advisor.SchemaRuleColumnMaximumCharacterLength,          // Migrated from legacy
-		advisor.SchemaRuleColumnNotNull,                         // Migrated from legacy
-		advisor.SchemaRuleColumnRequireDefault,                  // Migrated from legacy
-		advisor.SchemaRuleColumnTypeDisallowList,                // Migrated from legacy
-		advisor.SchemaRuleCommentLength,                         // Migrated from legacy
-		advisor.SchemaRuleCreateIndexConcurrently,               // Migrated from legacy
-		advisor.SchemaRuleFKNaming,                              // Migrated from legacy
-		advisor.SchemaRuleFullyQualifiedObjectName,              // Migrated from legacy
-		advisor.SchemaRuleIDXNaming,                             // Migrated from legacy
-		advisor.SchemaRuleIndexKeyNumberLimit,                   // Migrated from legacy
-		advisor.SchemaRuleIndexNoDuplicateColumn,                // Migrated from legacy
-		advisor.SchemaRuleIndexPrimaryKeyTypeAllowlist,          // Migrated from legacy
-		advisor.SchemaRuleIndexTotalNumberLimit,                 // Migrated from legacy
-		advisor.SchemaRulePKNaming,                              // Migrated from legacy
-		advisor.SchemaRuleRequiredColumn,                        // Migrated from legacy
-		advisor.SchemaRuleStatementInsertDisallowOrderByRand,    // Migrated from legacy
-		advisor.SchemaRuleStatementInsertMustSpecifyColumn,      // Migrated from legacy
-		advisor.SchemaRuleStatementInsertRowLimit,               // Migrated from legacy
-		advisor.SchemaRuleStatementMaximumLimitValue,            // Migrated from legacy
-		advisor.SchemaRuleStatementMergeAlterTable,              // Migrated from legacy
-		advisor.SchemaRuleStatementNoLeadingWildcardLike,        // Migrated from legacy
-		advisor.SchemaRuleStatementNoSelectAll,                  // Migrated from legacy
-		advisor.SchemaRuleStatementObjectOwnerCheck,             // Migrated from legacy
-		advisor.SchemaRuleStatementRequireWhereForSelect,        // Migrated from legacy
-		advisor.SchemaRuleStatementRequireWhereForUpdateDelete,  // Migrated from legacy
-		advisor.SchemaRuleColumnNaming,                          // Migrated from legacy
-		advisor.SchemaRuleSchemaBackwardCompatibility,           // Migrated from legacy
-		advisor.SchemaRuleStatementAddCheckNotValid,             // Migrated from legacy
-		advisor.SchemaRuleStatementAddFKNotValid,                // Migrated from legacy
-		advisor.SchemaRuleStatementAffectedRowLimit,             // Migrated from legacy
-		advisor.SchemaRuleStatementCheckSetRoleVariable,         // Migrated from legacy
-		advisor.SchemaRuleStatementCreateSpecifySchema,          // Migrated from legacy
-		advisor.SchemaRuleStatementDisallowAddColumnWithDefault, // Migrated from legacy
-		advisor.SchemaRuleStatementDisallowAddNotNull,           // Migrated from legacy
-		advisor.SchemaRuleStatementDisallowCommit,               // Migrated from legacy
-		advisor.SchemaRuleStatementDisallowMixInDDL,             // Migrated from legacy
-		advisor.SchemaRuleStatementDisallowMixInDML,             // Migrated from legacy
-		advisor.SchemaRuleStatementDisallowOnDelCascade,         // Migrated from legacy
-		advisor.SchemaRuleStatementDisallowRemoveTblCascade,     // Migrated from legacy
-		advisor.SchemaRuleStatementDMLDryRun,                    // Migrated from legacy
-		advisor.SchemaRuleStatementNonTransactional,             // Migrated from legacy
-		advisor.SchemaRuleTableCommentConvention,                // Migrated from legacy
-		advisor.SchemaRuleTableDisallowPartition,                // Migrated from legacy
-		advisor.SchemaRuleTableDropNamingConvention,             // Migrated from legacy
-		advisor.SchemaRuleTableNaming,                           // Migrated from legacy
-		advisor.SchemaRuleTableNoFK,                             // Migrated from legacy
-		advisor.SchemaRuleTableRequirePK,                        // Migrated from legacy - BYT-7917 fix
-		advisor.SchemaRuleUKNaming,                              // Migrated from legacy
+		advisor.BuiltinRulePriorBackupCheck,
+		advisor.SchemaRuleCharsetAllowlist,
+		advisor.SchemaRuleCollationAllowlist,
+		advisor.SchemaRuleColumnCommentConvention,
+		advisor.SchemaRuleColumnDefaultDisallowVolatile,
+		advisor.SchemaRuleColumnDisallowChangeType,
+		advisor.SchemaRuleColumnMaximumCharacterLength,
+		advisor.SchemaRuleColumnNotNull,
+		advisor.SchemaRuleColumnRequireDefault,
+		advisor.SchemaRuleColumnTypeDisallowList,
+		advisor.SchemaRuleCommentLength,
+		advisor.SchemaRuleCreateIndexConcurrently,
+		advisor.SchemaRuleFKNaming,
+		advisor.SchemaRuleFullyQualifiedObjectName,
+		advisor.SchemaRuleIDXNaming,
+		advisor.SchemaRuleIndexKeyNumberLimit,
+		advisor.SchemaRuleIndexNoDuplicateColumn,
+		advisor.SchemaRuleIndexPrimaryKeyTypeAllowlist,
+		advisor.SchemaRuleIndexTotalNumberLimit,
+		advisor.SchemaRulePKNaming,
+		advisor.SchemaRuleRequiredColumn,
+		advisor.SchemaRuleStatementInsertDisallowOrderByRand,
+		advisor.SchemaRuleStatementInsertMustSpecifyColumn,
+		advisor.SchemaRuleStatementInsertRowLimit,
+		advisor.SchemaRuleStatementMaximumLimitValue,
+		advisor.SchemaRuleStatementMergeAlterTable,
+		advisor.SchemaRuleStatementNoLeadingWildcardLike,
+		advisor.SchemaRuleStatementNoSelectAll,
+		advisor.SchemaRuleStatementObjectOwnerCheck,
+		advisor.SchemaRuleStatementRequireWhereForSelect,
+		advisor.SchemaRuleStatementRequireWhereForUpdateDelete,
+		advisor.SchemaRuleColumnNaming,
+		advisor.SchemaRuleSchemaBackwardCompatibility,
+		advisor.SchemaRuleStatementAddCheckNotValid,
+		advisor.SchemaRuleStatementAddFKNotValid,
+		advisor.SchemaRuleStatementAffectedRowLimit,
+		advisor.SchemaRuleStatementCheckSetRoleVariable,
+		advisor.SchemaRuleStatementCreateSpecifySchema,
+		advisor.SchemaRuleStatementDisallowAddColumnWithDefault,
+		advisor.SchemaRuleStatementDisallowAddNotNull,
+		advisor.SchemaRuleStatementDisallowCommit,
+		advisor.SchemaRuleStatementDisallowMixInDDL,
+		advisor.SchemaRuleStatementDisallowMixInDML,
+		advisor.SchemaRuleStatementDisallowOnDelCascade,
+		advisor.SchemaRuleStatementDisallowRemoveTblCascade,
+		advisor.SchemaRuleStatementDMLDryRun,
+		advisor.SchemaRuleStatementNonTransactional,
+		advisor.SchemaRuleTableCommentConvention,
+		advisor.SchemaRuleTableDisallowPartition,
+		advisor.SchemaRuleTableDropNamingConvention,
+		advisor.SchemaRuleTableNaming,
+		advisor.SchemaRuleTableNoFK,
+		advisor.SchemaRuleTableRequirePK,
+		advisor.SchemaRuleUKNaming,
 	}
 
 	for _, rule := range antlrRules {


### PR DESCRIPTION
## Summary
- Removed outdated "Migrated from legacy" comments from PostgreSQL ANTLR rules test file
- These comments no longer provide value as the migration is now complete
- Improves code readability by removing noise

## Test plan
- No functional changes, only comment removal
- Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)