### PR TITLE
fix: improve pending task handling in rollout view

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/StageCard.vue
+++ b/frontend/src/components/Plan/components/RolloutView/StageCard.vue
@@ -114,7 +114,7 @@
               </template>
               <div class="flex items-center flex-nowrap gap-2">
                 <DatabaseDisplay :database="task.target" />
-                <template v-if="task.runTime">
+                <template v-if="task.runTime && task.status === Task_Status.PENDING">
                   <span class="font-mono text-control-light opacity-80">/</span>
                   <NTooltip>
                     <template #trigger>
@@ -284,7 +284,6 @@ const runableTasks = computed(() => {
   return filteredTasks.value.filter(
     (task) =>
       task.status === Task_Status.NOT_STARTED ||
-      task.status === Task_Status.PENDING ||
       task.status === Task_Status.FAILED ||
       task.status === Task_Status.CANCELED
   );

--- a/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
@@ -316,7 +316,13 @@ import {
   useEnvironmentV1Store,
   usePolicyByParentAndType,
 } from "@/store";
-import { userNamePrefix } from "@/store/modules/v1/common";
+import {
+  getProjectIdRolloutUidStageUidTaskUid,
+  projectNamePrefix,
+  rolloutNamePrefix,
+  stageNamePrefix,
+  userNamePrefix,
+} from "@/store/modules/v1/common";
 import {
   Issue_ApprovalStatus,
   Issue_Approver_Status,
@@ -424,7 +430,6 @@ const planCheckError = computed(() => {
       ? rolloutPolicy.value.policy.value.checkers?.requiredStatusChecks
           ?.planCheckEnforcement
       : undefined;
-
   // If no enforcement is specified, default to no validation
   if (!planCheckEnforcement) {
     return undefined;
@@ -534,6 +539,19 @@ const validationErrors = computed(() => {
   }
 
   if (props.action === "RUN") {
+    // No runnable tasks - blocking error
+    if (
+      eligibleTasks.value.length > 0 &&
+      !eligibleTasks.value.some(
+        (task) =>
+          task.status === Task_Status.NOT_STARTED ||
+          task.status === Task_Status.FAILED ||
+          task.status === Task_Status.CANCELED
+      )
+    ) {
+      errors.push(t("rollout.no-runnable-task"));
+    }
+
     // Issue approval errors (only if policy requires it) - HARD BLOCK
     const requiresIssueApproval =
       rolloutPolicy.value?.policy?.case === "rolloutPolicy"
@@ -721,8 +739,8 @@ const eligibleTasks = computed(() => {
     return stageTasks.filter(
       (task) =>
         task.status === Task_Status.NOT_STARTED ||
-        task.status === Task_Status.PENDING ||
-        task.status === Task_Status.FAILED
+        task.status === Task_Status.FAILED ||
+        task.status === Task_Status.CANCELED
     );
   } else if (props.action === "SKIP") {
     return stageTasks.filter(
@@ -813,7 +831,6 @@ const handleConfirm = async () => {
   loading.value = true;
   try {
     if (props.action === "RUN") {
-      await cancelTasks();
       // For export tasks, group by stage/environment and make separate batch calls
       if (isDatabaseExportTask.value) {
         const tasksByStage = groupTasksByStage(eligibleTasks.value);
@@ -904,67 +921,60 @@ watchEffect(() => {
 });
 
 const cancelTasks = async () => {
-  // Fetch task runs for the tasks to be canceled.
-  const taskRuns = (
-    await Promise.all(
-      eligibleTasks.value.map(async (task) => {
-        const request = create(ListTaskRunsRequestSchema, {
-          parent: task.name,
-        });
-        return rolloutServiceClientConnect
-          .listTaskRuns(request)
-          .then((response) => response.taskRuns || []);
-      })
-    )
-  ).flat();
-  const cancelableTaskRuns = taskRuns.filter(
-    (taskRun) =>
-      taskRun.status === TaskRun_Status.PENDING ||
-      taskRun.status === TaskRun_Status.RUNNING
-  );
-
-  if (isDatabaseCreationOrExportTask.value) {
-    // For database creation/export tasks, group task runs by stage and cancel them per stage
-    const taskRunsByStage = new Map<string, typeof cancelableTaskRuns>();
-
-    for (const taskRun of cancelableTaskRuns) {
-      // Extract stage name from task run path: projects/.../rollouts/.../stages/{stage}/tasks/.../taskRuns/...
-      const pathParts = taskRun.name.split("/");
-      const stageIndex = pathParts.findIndex((part) => part === "stages");
-      if (stageIndex >= 0 && stageIndex + 1 < pathParts.length) {
-        const stageName = pathParts.slice(0, stageIndex + 2).join("/"); // projects/.../rollouts/.../stages/{stage}
-        if (!taskRunsByStage.has(stageName)) {
-          taskRunsByStage.set(stageName, []);
-        }
-        taskRunsByStage.get(stageName)!.push(taskRun);
+  // Group tasks by stage first
+  const tasksByStage = new Map<string, Task[]>();
+  for (const task of eligibleTasks.value) {
+    // Extract stage name from task path: projects/{projectId}/rollouts/{rolloutId}/stages/{stageId}/tasks/...
+    const [projectId, rolloutId, stageId] =
+      getProjectIdRolloutUidStageUidTaskUid(task.name);
+    if (projectId && rolloutId && stageId) {
+      const stageName = `${projectNamePrefix}${projectId}/${rolloutNamePrefix}${rolloutId}/${stageNamePrefix}${stageId}`;
+      if (!tasksByStage.has(stageName)) {
+        tasksByStage.set(stageName, []);
       }
-    }
-
-    // Cancel task runs for each stage separately
-    await Promise.all(
-      Array.from(taskRunsByStage.entries()).map(
-        ([stageName, stageTaskRuns]) => {
-          const request = create(BatchCancelTaskRunsRequestSchema, {
-            parent: `${stageName}/tasks/-`,
-            taskRuns: stageTaskRuns.map((taskRun) => taskRun.name),
-            reason: comment.value,
-          });
-          if (request.taskRuns.length > 0) {
-            return rolloutServiceClientConnect.batchCancelTaskRuns(request);
-          }
-        }
-      )
-    );
-  } else {
-    // For regular stage-level tasks
-    const request = create(BatchCancelTaskRunsRequestSchema, {
-      parent: `${targetStage.value.name}/tasks/-`,
-      taskRuns: cancelableTaskRuns.map((taskRun) => taskRun.name),
-      reason: comment.value,
-    });
-    if (request.taskRuns.length > 0) {
-      await rolloutServiceClientConnect.batchCancelTaskRuns(request);
+      tasksByStage.get(stageName)!.push(task);
     }
   }
+
+  // Fetch task runs at stage level and filter by eligible tasks
+  const cancelableTaskRunsByStage = new Map<string, string[]>();
+
+  for (const [stageName, tasks] of tasksByStage) {
+    const taskNames = new Set(tasks.map((t) => t.name));
+    const request = create(ListTaskRunsRequestSchema, {
+      parent: `${stageName}/tasks/-`,
+    });
+
+    const response = await rolloutServiceClientConnect.listTaskRuns(request);
+    const stageTaskRuns = (response.taskRuns || [])
+      .filter((taskRun) => {
+        // Only include task runs for our eligible tasks
+        const taskName = taskRun.name.split("/taskRuns/")[0];
+        return (
+          taskNames.has(taskName) &&
+          (taskRun.status === TaskRun_Status.PENDING ||
+            taskRun.status === TaskRun_Status.RUNNING)
+        );
+      })
+      .map((taskRun) => taskRun.name);
+
+    if (stageTaskRuns.length > 0) {
+      cancelableTaskRunsByStage.set(stageName, stageTaskRuns);
+    }
+  }
+
+  // Cancel task runs for each stage
+  await Promise.all(
+    Array.from(cancelableTaskRunsByStage.entries()).map(
+      ([stageName, taskRunNames]) => {
+        const request = create(BatchCancelTaskRunsRequestSchema, {
+          parent: `${stageName}/tasks/-`,
+          taskRuns: taskRunNames,
+          reason: comment.value,
+        });
+        return rolloutServiceClientConnect.batchCancelTaskRuns(request);
+      }
+    )
+  );
 };
 </script>

--- a/frontend/src/components/Plan/components/RolloutView/TaskTable.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskTable.vue
@@ -218,7 +218,7 @@ const columnList = computed((): DataTableColumn<Task>[] => {
                 {schemaVersion}
               </NTag>
             )}
-            {task.runTime && (
+            {task.runTime && task.status === Task_Status.PENDING && (
               <NTooltip>
                 {{
                   trigger: () => (

--- a/frontend/src/components/Plan/components/RolloutView/TaskView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskView.vue
@@ -30,7 +30,7 @@
               </template>
               {{ $t("common.version") }}
             </NTooltip>
-            <NTooltip v-if="task.runTime">
+            <NTooltip v-if="task.runTime && task.status === Task_Status.PENDING">
               <template #trigger>
                 <NTag round>
                   <div class="flex items-center gap-1">
@@ -155,7 +155,10 @@ import {
   useSheetV1Store,
 } from "@/store";
 import { getTimeForPbTimestampProtoEs, unknownTask } from "@/types";
-import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  Task_Status,
+  TaskRun_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
 import {
   databaseForTask,
   extractPlanUID,

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1189,6 +1189,7 @@
     "task-execution-notices": "Task execution notices",
     "task-execution-errors": "Task execution errors",
     "no-active-task-to-cancel": "No active task to cancel.",
+    "no-runnable-task": "No runnable task available.",
     "automatic-rollout": {
       "description": "This environment has automatic rollout enabled."
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1189,6 +1189,7 @@
     "task-execution-notices": "Avisos de ejecución de tareas",
     "task-execution-errors": "Errores de ejecución de tareas",
     "no-active-task-to-cancel": "No hay ninguna tarea activa para cancelar.",
+    "no-runnable-task": "No hay ninguna tarea ejecutable disponible.",
     "automatic-rollout": {
       "description": "Este entorno tiene habilitada la implementación automática."
     },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1189,6 +1189,7 @@
     "task-execution-notices": "タスク実行通知",
     "task-execution-errors": "タスク実行エラー",
     "no-active-task-to-cancel": "キャンセルするアクティブなタスクはありません。",
+    "no-runnable-task": "実行可能なタスクがありません。",
     "automatic-rollout": {
       "description": "この環境では自動ロールアウトが有効になっています。"
     },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1189,6 +1189,7 @@
     "task-execution-notices": "Thông báo thực hiện nhiệm vụ",
     "task-execution-errors": "Lỗi thực hiện tác vụ",
     "no-active-task-to-cancel": "Không có tác vụ nào đang hoạt động để hủy.",
+    "no-runnable-task": "Không có tác vụ nào có thể chạy được.",
     "automatic-rollout": {
       "description": "Môi trường này đã bật tính năng triển khai tự động."
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1189,6 +1189,7 @@
     "task-execution-notices": "任务执行提醒",
     "task-execution-errors": "任务执行警告",
     "no-active-task-to-cancel": "没有要取消的任务。",
+    "no-runnable-task": "没有可运行的任务。",
     "automatic-rollout": {
       "description": "此环境已启用自动部署。"
     },


### PR DESCRIPTION
## Summary
- Remove PENDING tasks from runnable task list to prevent re-running already queued tasks
- Show runtime indicator only for PENDING tasks in stage card  
- Add validation error message when no runnable tasks are available
- Refactor `cancelTasks()` function to group tasks by stage first for better performance
- Remove preemptive task cancellation before running tasks

## Changes
### Frontend Components
- **StageCard.vue**: Only display runtime indicator for tasks with PENDING status
- **TaskRolloutActionPanel.vue**: 
  - Exclude PENDING tasks from eligible tasks for RUN action
  - Add "no runnable task" validation error
  - Refactor `cancelTasks()` to fetch task runs at stage level (more efficient)
  - Remove automatic task cancellation before running new tasks
- **Locale files**: Add "no-runnable-task" translation in all 5 languages

## Test Plan
- [ ] Verify PENDING tasks cannot be manually run again
- [ ] Verify runtime indicator only shows for PENDING tasks
- [ ] Verify "no runnable task" error displays appropriately
- [ ] Test task cancellation works correctly across different task types
- [ ] Test rollout execution flow for various task states

🤖 Generated with [Claude Code](https://claude.com/claude-code)