### PR TITLE
refactor: use hierarchical access pattern for DatabaseMetadata

### DIFF
--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
@@ -63,18 +63,18 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 // ColumnDisallowChangingTypeRule checks for disallow changing column type.
 type ColumnDisallowChangingTypeRule struct {
 	BaseRule
-	text          string
-	originCatalog *model.DatabaseMetadata
+	text             string
+	originalMetadata *model.DatabaseMetadata
 }
 
 // NewColumnDisallowChangingTypeRule creates a new ColumnDisallowChangingTypeRule.
-func NewColumnDisallowChangingTypeRule(level storepb.Advice_Status, title string, originCatalog *model.DatabaseMetadata) *ColumnDisallowChangingTypeRule {
+func NewColumnDisallowChangingTypeRule(level storepb.Advice_Status, title string, originalMetadata *model.DatabaseMetadata) *ColumnDisallowChangingTypeRule {
 	return &ColumnDisallowChangingTypeRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		originCatalog: originCatalog,
+		originalMetadata: originalMetadata,
 	}
 }
 
@@ -170,8 +170,7 @@ func normalizeColumnType(tp string) string {
 
 func (r *ColumnDisallowChangingTypeRule) changeColumnType(tableName, columnName string, dataType mysql.IDataTypeContext) {
 	tp := dataType.GetParser().GetTokenStream().GetTextFromRuleContext(dataType)
-	column := r.originCatalog.GetColumn("", tableName, columnName)
-
+	column := r.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
 	if column == nil {
 		return
 	}

--- a/backend/plugin/advisor/mysql/rule_column_no_null.go
+++ b/backend/plugin/advisor/mysql/rule_column_no_null.go
@@ -135,8 +135,15 @@ func (r *ColumnNoNullRule) generateAdvice() {
 	})
 
 	for _, column := range columnList {
-		dbState := r.finalCatalog
-		col := dbState.GetColumn("", column.tableName, column.columnName)
+		schema, _ := r.finalCatalog.GetSchema("")
+		if schema == nil {
+			continue
+		}
+		table, _ := schema.GetTable(column.tableName)
+		if table == nil {
+			continue
+		}
+		col, _ := table.GetColumn(column.columnName)
 		if col != nil && col.Nullable() {
 			r.AddAdvice(&storepb.Advice{
 				Status:        r.level,

--- a/backend/plugin/advisor/mysql/rule_index_pk_type.go
+++ b/backend/plugin/advisor/mysql/rule_index_pk_type.go
@@ -63,19 +63,19 @@ func (*IndexPkTypeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 type IndexPkTypeRule struct {
 	BaseRule
 	line             map[string]int
-	originCatalog    *model.DatabaseMetadata
+	originalMetadata *model.DatabaseMetadata
 	tablesNewColumns tableColumnTypes
 }
 
 // NewIndexPkTypeRule creates a new IndexPkTypeRule.
-func NewIndexPkTypeRule(level storepb.Advice_Status, title string, originCatalog *model.DatabaseMetadata) *IndexPkTypeRule {
+func NewIndexPkTypeRule(level storepb.Advice_Status, title string, originalMetadata *model.DatabaseMetadata) *IndexPkTypeRule {
 	return &IndexPkTypeRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
 		line:             make(map[string]int),
-		originCatalog:    originCatalog,
+		originalMetadata: originalMetadata,
 		tablesNewColumns: make(tableColumnTypes),
 	}
 }
@@ -238,7 +238,7 @@ func (r *IndexPkTypeRule) getPKColumnType(tableName string, columnName string) (
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.originCatalog.GetColumn("", tableName, columnName)
+	column := r.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
 	if column != nil {
 		return column.Type, nil
 	}

--- a/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
@@ -70,19 +70,19 @@ func (*IndexPrimaryKeyTypeAllowlistAdvisor) Check(_ context.Context, checkCtx ad
 type IndexPrimaryKeyTypeAllowlistRule struct {
 	BaseRule
 	allowlist        map[string]bool
-	originCatalog    *model.DatabaseMetadata
+	originalMetadata *model.DatabaseMetadata
 	tablesNewColumns tableColumnTypes
 }
 
 // NewIndexPrimaryKeyTypeAllowlistRule creates a new IndexPrimaryKeyTypeAllowlistRule.
-func NewIndexPrimaryKeyTypeAllowlistRule(level storepb.Advice_Status, title string, allowlist map[string]bool, originCatalog *model.DatabaseMetadata) *IndexPrimaryKeyTypeAllowlistRule {
+func NewIndexPrimaryKeyTypeAllowlistRule(level storepb.Advice_Status, title string, allowlist map[string]bool, originalMetadata *model.DatabaseMetadata) *IndexPrimaryKeyTypeAllowlistRule {
 	return &IndexPrimaryKeyTypeAllowlistRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
 		allowlist:        allowlist,
-		originCatalog:    originCatalog,
+		originalMetadata: originalMetadata,
 		tablesNewColumns: make(tableColumnTypes),
 	}
 }
@@ -252,7 +252,7 @@ func (r *IndexPrimaryKeyTypeAllowlistRule) getPKColumnType(tableName string, col
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.originCatalog.GetColumn("", tableName, columnName)
+	column := r.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
 	if column != nil {
 		return column.Type, nil
 	}

--- a/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
+++ b/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
@@ -62,18 +62,18 @@ func (*IndexTypeNoBlobAdvisor) Check(_ context.Context, checkCtx advisor.Context
 // IndexTypeNoBlobRule checks for index type no blob.
 type IndexTypeNoBlobRule struct {
 	BaseRule
-	originCatalog    *model.DatabaseMetadata
+	originalMetadata *model.DatabaseMetadata
 	tablesNewColumns tableColumnTypes
 }
 
 // NewIndexTypeNoBlobRule creates a new IndexTypeNoBlobRule.
-func NewIndexTypeNoBlobRule(level storepb.Advice_Status, title string, originCatalog *model.DatabaseMetadata) *IndexTypeNoBlobRule {
+func NewIndexTypeNoBlobRule(level storepb.Advice_Status, title string, originalMetadata *model.DatabaseMetadata) *IndexTypeNoBlobRule {
 	return &IndexTypeNoBlobRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		originCatalog:    originCatalog,
+		originalMetadata: originalMetadata,
 		tablesNewColumns: make(tableColumnTypes),
 	}
 }
@@ -295,7 +295,7 @@ func (r *IndexTypeNoBlobRule) getColumnType(tableName string, columnName string)
 	if columnType, ok := r.tablesNewColumns.get(tableName, columnName); ok {
 		return columnType, nil
 	}
-	column := r.originCatalog.GetColumn("", tableName, columnName)
+	column := r.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
 	if column != nil {
 		return column.Type, nil
 	}

--- a/backend/plugin/advisor/mysql/rule_naming_index_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_index_convention.go
@@ -74,24 +74,24 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 // NamingIndexConventionRule checks for index naming convention.
 type NamingIndexConventionRule struct {
 	BaseRule
-	text          string
-	format        string
-	maxLength     int
-	templateList  []string
-	originCatalog *model.DatabaseMetadata
+	text             string
+	format           string
+	maxLength        int
+	templateList     []string
+	originalMetadata *model.DatabaseMetadata
 }
 
 // NewNamingIndexConventionRule creates a new NamingIndexConventionRule.
-func NewNamingIndexConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, originCatalog *model.DatabaseMetadata) *NamingIndexConventionRule {
+func NewNamingIndexConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, originalMetadata *model.DatabaseMetadata) *NamingIndexConventionRule {
 	return &NamingIndexConventionRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		format:        format,
-		maxLength:     maxLength,
-		templateList:  templateList,
-		originCatalog: originCatalog,
+		format:           format,
+		maxLength:        maxLength,
+		templateList:     templateList,
+		originalMetadata: originalMetadata,
 	}
 }
 
@@ -187,7 +187,7 @@ func (r *NamingIndexConventionRule) checkAlterTable(ctx *mysql.AlterTableContext
 		case alterListItem.RENAME_SYMBOL() != nil && alterListItem.KeyOrIndex() != nil && alterListItem.IndexRef() != nil && alterListItem.IndexName() != nil:
 			_, _, oldIndexName := mysqlparser.NormalizeIndexRef(alterListItem.IndexRef())
 			newIndexName := mysqlparser.NormalizeIndexName(alterListItem.IndexName())
-			_, indexState := r.originCatalog.GetIndex("", tableName, oldIndexName)
+			indexState := r.originalMetadata.GetSchema("").GetTable(tableName).GetIndex(oldIndexName)
 			if indexState == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
@@ -74,24 +74,24 @@ type ukIndexMetaData struct {
 // NamingUKConventionRule checks for unique key naming convention.
 type NamingUKConventionRule struct {
 	BaseRule
-	text          string
-	format        string
-	maxLength     int
-	templateList  []string
-	originCatalog *model.DatabaseMetadata
+	text             string
+	format           string
+	maxLength        int
+	templateList     []string
+	originalMetadata *model.DatabaseMetadata
 }
 
 // NewNamingUKConventionRule creates a new NamingUKConventionRule.
-func NewNamingUKConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, originCatalog *model.DatabaseMetadata) *NamingUKConventionRule {
+func NewNamingUKConventionRule(level storepb.Advice_Status, title string, format string, maxLength int, templateList []string, originalMetadata *model.DatabaseMetadata) *NamingUKConventionRule {
 	return &NamingUKConventionRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		format:        format,
-		maxLength:     maxLength,
-		templateList:  templateList,
-		originCatalog: originCatalog,
+		format:           format,
+		maxLength:        maxLength,
+		templateList:     templateList,
+		originalMetadata: originalMetadata,
 	}
 }
 
@@ -188,12 +188,8 @@ func (r *NamingUKConventionRule) checkAlterTable(ctx *mysql.AlterTableContext) {
 		case alterListItem.RENAME_SYMBOL() != nil && alterListItem.KeyOrIndex() != nil && alterListItem.IndexRef() != nil && alterListItem.IndexName() != nil:
 			_, _, oldIndexName := mysqlparser.NormalizeIndexRef(alterListItem.IndexRef())
 			newIndexName := mysqlparser.NormalizeIndexName(alterListItem.IndexName())
-			indexStateMap := r.originCatalog.Index("", tableName)
-			if indexStateMap == nil {
-				continue
-			}
-			indexState, ok := indexStateMap[oldIndexName]
-			if !ok {
+			indexState := r.originalMetadata.GetSchema("").GetTable(tableName).GetIndex(oldIndexName)
+			if indexState == nil {
 				continue
 			}
 			if !indexState.Unique() {

--- a/backend/plugin/advisor/mysql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_pk.go
@@ -69,21 +69,21 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 // TableRequirePKRule checks table requires PK.
 type TableRequirePKRule struct {
 	BaseRule
-	tables        map[string]columnSet
-	line          map[string]int
-	originCatalog *model.DatabaseMetadata
+	tables           map[string]columnSet
+	line             map[string]int
+	originalMetadata *model.DatabaseMetadata
 }
 
 // NewTableRequirePKRule creates a new TableRequirePKRule.
-func NewTableRequirePKRule(level storepb.Advice_Status, title string, originCatalog *model.DatabaseMetadata) *TableRequirePKRule {
+func NewTableRequirePKRule(level storepb.Advice_Status, title string, originalMetadata *model.DatabaseMetadata) *TableRequirePKRule {
 	return &TableRequirePKRule{
 		BaseRule: BaseRule{
 			level: level,
 			title: title,
 		},
-		tables:        make(map[string]columnSet),
-		line:          make(map[string]int),
-		originCatalog: originCatalog,
+		tables:           make(map[string]columnSet),
+		line:             make(map[string]int),
+		originalMetadata: originalMetadata,
 	}
 }
 
@@ -251,7 +251,7 @@ func (r *TableRequirePKRule) changeColumn(tableName string, oldColumn string, ne
 
 func (r *TableRequirePKRule) dropColumn(tableName string, columnName string) bool {
 	if _, ok := r.tables[tableName]; !ok {
-		_, pk := r.originCatalog.GetIndex("", tableName, primaryKeyName)
+		pk := r.originalMetadata.GetSchema("").GetTable(tableName).GetIndex(primaryKeyName)
 		if pk == nil {
 			return false
 		}

--- a/backend/plugin/advisor/pg/advisor_column_no_null.go
+++ b/backend/plugin/advisor/pg/advisor_column_no_null.go
@@ -45,8 +45,8 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 			level: level,
 			title: string(checkCtx.Rule.Type),
 		},
-		originCatalog:   checkCtx.OriginalMetadata,
-		nullableColumns: make(columnMap),
+		originalMetadata: checkCtx.OriginalMetadata,
+		nullableColumns:  make(columnMap),
 	}
 
 	checker := NewGenericChecker([]Rule{rule})
@@ -74,8 +74,8 @@ type columnMap map[columnName]int
 type columnNoNullRule struct {
 	BaseRule
 
-	originCatalog   *model.DatabaseMetadata
-	nullableColumns columnMap
+	originalMetadata *model.DatabaseMetadata
+	nullableColumns  columnMap
 }
 
 func (*columnNoNullRule) Name() string {
@@ -307,8 +307,15 @@ func (r *columnNoNullRule) removeColumnByTableConstraint(schema, table string, c
 		if existingIndex.Name() != nil {
 			indexName := pg.NormalizePostgreSQLName(existingIndex.Name())
 			// Try to find index in catalog
-			if r.originCatalog != nil {
-				_, index := r.originCatalog.GetIndex(schema, table, indexName)
+			if r.originalMetadata != nil {
+				dbSchema := r.originalMetadata.GetSchema(schema)
+				var index *model.IndexMetadata
+				if dbSchema != nil {
+					dbTable := dbSchema.GetTable(table)
+					if dbTable != nil {
+						index = dbTable.GetIndex(indexName)
+					}
+				}
 				if index != nil {
 					for _, expression := range index.ExpressionList() {
 						r.removeColumn(schema, table, expression)

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_changing_type.go
@@ -43,9 +43,9 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 		return nil, err
 	}
 	checker := &columnDisallowChangingTypeChecker{
-		level:         level,
-		title:         string(checkCtx.Rule.Type),
-		originCatalog: checkCtx.OriginalMetadata,
+		level:            level,
+		title:            string(checkCtx.Rule.Type),
+		originalMetadata: checkCtx.OriginalMetadata,
 	}
 
 	for _, stmt := range stmtList {
@@ -58,12 +58,12 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 }
 
 type columnDisallowChangingTypeChecker struct {
-	adviceList    []*storepb.Advice
-	level         storepb.Advice_Status
-	title         string
-	text          string
-	line          int
-	originCatalog *model.DatabaseMetadata
+	adviceList       []*storepb.Advice
+	level            storepb.Advice_Status
+	title            string
+	text             string
+	line             int
+	originalMetadata *model.DatabaseMetadata
 }
 
 // Enter implements the ast.Visitor interface.
@@ -131,8 +131,7 @@ func normalizeColumnType(tp string) string {
 }
 
 func (checker *columnDisallowChangingTypeChecker) changeColumnType(tableName string, columName string, newType string) bool {
-	column := checker.originCatalog.GetColumn("", tableName, columName)
-
+	column := checker.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columName)
 	if column == nil {
 		return false
 	}

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
@@ -43,10 +43,10 @@ func (*ColumnDisallowDropInIndexAdvisor) Check(_ context.Context, checkCtx advis
 	}
 
 	checker := &columnDisallowDropInIndexChecker{
-		level:         level,
-		title:         string(checkCtx.Rule.Type),
-		tables:        make(tableState),
-		originCatalog: checkCtx.OriginalMetadata,
+		level:            level,
+		title:            string(checkCtx.Rule.Type),
+		tables:           make(tableState),
+		originalMetadata: checkCtx.OriginalMetadata,
 	}
 
 	for _, stmt := range stmtList {
@@ -59,13 +59,13 @@ func (*ColumnDisallowDropInIndexAdvisor) Check(_ context.Context, checkCtx advis
 }
 
 type columnDisallowDropInIndexChecker struct {
-	adviceList    []*storepb.Advice
-	level         storepb.Advice_Status
-	title         string
-	text          string
-	tables        tableState // the variable mean whether the column in index.
-	originCatalog *model.DatabaseMetadata
-	line          int
+	adviceList       []*storepb.Advice
+	level            storepb.Advice_Status
+	title            string
+	text             string
+	tables           tableState // the variable mean whether the column in index.
+	originalMetadata *model.DatabaseMetadata
+	line             int
 }
 
 func (checker *columnDisallowDropInIndexChecker) Enter(in ast.Node) (ast.Node, bool) {
@@ -88,8 +88,7 @@ func (checker *columnDisallowDropInIndexChecker) dropColumn(in ast.Node) (ast.No
 			if spec.Tp == ast.AlterTableDropColumn {
 				table := node.Table.Name.O
 
-				tableMetadata := checker.originCatalog.GetTable("", table)
-
+				tableMetadata := checker.originalMetadata.GetSchema("").GetTable(table)
 				if tableMetadata != nil {
 					if checker.tables[table] == nil {
 						checker.tables[table] = make(columnSet)

--- a/backend/plugin/advisor/tidb/advisor_column_no_null.go
+++ b/backend/plugin/advisor/tidb/advisor_column_no_null.go
@@ -83,7 +83,15 @@ func (checker *columnNoNullChecker) generateAdvice() []*storepb.Advice {
 	})
 
 	for _, column := range columnList {
-		col := checker.finalCatalog.GetColumn("", column.tableName, column.columnName)
+		schema, _ := checker.finalCatalog.GetSchema("")
+		if schema == nil {
+			continue
+		}
+		table, _ := schema.GetTable(column.tableName)
+		if table == nil {
+			continue
+		}
+		col, _ := table.GetColumn(column.columnName)
 		if col != nil && col.Nullable() {
 			checker.adviceList = append(checker.adviceList, &storepb.Advice{
 				Status:        checker.level,

--- a/backend/plugin/advisor/tidb/advisor_index_pk_type.go
+++ b/backend/plugin/advisor/tidb/advisor_index_pk_type.go
@@ -47,7 +47,7 @@ func (*IndexPkTypeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 		level:            level,
 		title:            string(checkCtx.Rule.Type),
 		line:             make(map[string]int),
-		originCatalog:    checkCtx.OriginalMetadata,
+		originalMetadata: checkCtx.OriginalMetadata,
 		tablesNewColumns: make(map[string]columnNameToColumnDef),
 	}
 
@@ -88,7 +88,7 @@ type indexPkTypeChecker struct {
 	level            storepb.Advice_Status
 	title            string
 	line             map[string]int
-	originCatalog    *model.DatabaseMetadata
+	originalMetadata *model.DatabaseMetadata
 	tablesNewColumns tableNewColumn
 }
 
@@ -220,7 +220,7 @@ func (v *indexPkTypeChecker) getPKColumnType(tableName string, columnName string
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return v.getIntOrBigIntStr(colDef.Tp), nil
 	}
-	column := v.originCatalog.GetColumn("", tableName, columnName)
+	column := v.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
 	if column != nil {
 		return column.Type, nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
@@ -55,7 +55,7 @@ func (*IndexPrimaryKeyTypeAllowlistAdvisor) Check(_ context.Context, checkCtx ad
 		level:            level,
 		title:            string(checkCtx.Rule.Type),
 		allowlist:        allowlist,
-		originCatalog:    checkCtx.OriginalMetadata,
+		originalMetadata: checkCtx.OriginalMetadata,
 		tablesNewColumns: make(map[string]columnNameToColumnDef),
 	}
 
@@ -75,7 +75,7 @@ type indexPrimaryKeyTypeAllowlistChecker struct {
 	text             string
 	line             int
 	allowlist        map[string]bool
-	originCatalog    *model.DatabaseMetadata
+	originalMetadata *model.DatabaseMetadata
 	tablesNewColumns tableNewColumn
 }
 
@@ -201,7 +201,7 @@ func (v *indexPrimaryKeyTypeAllowlistChecker) getPKColumnType(tableName string, 
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return tidbparser.TypeString(colDef.Tp.GetType()), nil
 	}
-	column := v.originCatalog.GetColumn("", tableName, columnName)
+	column := v.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
 	if column != nil {
 		return column.Type, nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
+++ b/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
@@ -47,7 +47,7 @@ func (*IndexTypeNoBlobAdvisor) Check(_ context.Context, checkCtx advisor.Context
 	checker := &indexTypeNoBlobChecker{
 		level:            level,
 		title:            string(checkCtx.Rule.Type),
-		originCatalog:    checkCtx.OriginalMetadata,
+		originalMetadata: checkCtx.OriginalMetadata,
 		tablesNewColumns: make(map[string]columnNameToColumnDef),
 	}
 
@@ -66,7 +66,7 @@ type indexTypeNoBlobChecker struct {
 	title            string
 	text             string
 	line             int
-	originCatalog    *model.DatabaseMetadata
+	originalMetadata *model.DatabaseMetadata
 	tablesNewColumns tableNewColumn
 }
 
@@ -223,7 +223,7 @@ func (v *indexTypeNoBlobChecker) getColumnType(tableName string, columnName stri
 	if colDef, ok := v.tablesNewColumns.get(tableName, columnName); ok {
 		return v.getBlobStr(colDef.Tp), nil
 	}
-	column := v.originCatalog.GetColumn("", tableName, columnName)
+	column := v.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
 	if column != nil {
 		return column.Type, nil
 	}

--- a/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
@@ -45,12 +45,12 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		return nil, err
 	}
 	checker := &namingUKConventionChecker{
-		level:         level,
-		title:         string(checkCtx.Rule.Type),
-		format:        format,
-		maxLength:     maxLength,
-		templateList:  templateList,
-		originCatalog: checkCtx.OriginalMetadata,
+		level:            level,
+		title:            string(checkCtx.Rule.Type),
+		format:           format,
+		maxLength:        maxLength,
+		templateList:     templateList,
+		originalMetadata: checkCtx.OriginalMetadata,
 	}
 	for _, stmtNode := range root {
 		(stmtNode).Accept(checker)
@@ -60,13 +60,13 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 }
 
 type namingUKConventionChecker struct {
-	adviceList    []*storepb.Advice
-	level         storepb.Advice_Status
-	title         string
-	format        string
-	maxLength     int
-	templateList  []string
-	originCatalog *model.DatabaseMetadata
+	adviceList       []*storepb.Advice
+	level            storepb.Advice_Status
+	title            string
+	format           string
+	maxLength        int
+	templateList     []string
+	originalMetadata *model.DatabaseMetadata
 }
 
 // Enter implements the ast.Visitor interface.
@@ -142,7 +142,11 @@ func (checker *namingUKConventionChecker) getMetaDataList(in ast.Node) []*indexM
 		for _, spec := range node.Specs {
 			switch spec.Tp {
 			case ast.AlterTableRenameIndex:
-				_, index := checker.originCatalog.GetIndex("", node.Table.Name.String(), spec.FromKey.String())
+				schema := checker.originalMetadata.GetSchema("")
+				var index *model.IndexMetadata
+				if schema != nil {
+					index = schema.GetIndex(spec.FromKey.String())
+				}
 				if index == nil {
 					continue
 				}

--- a/backend/plugin/parser/plsql/resource_change.go
+++ b/backend/plugin/parser/plsql/resource_change.go
@@ -202,11 +202,11 @@ func (l *plsqlChangedResourceExtractListener) EnterDrop_index(ctx *parser.Drop_i
 	if foundSchema == nil {
 		return
 	}
-	indexes := foundSchema.GetIndexes(index)
-	if len(indexes) == 0 {
+	foundIndex := foundSchema.GetIndex(index)
+	if foundIndex == nil {
 		return
 	}
-	foundTable := indexes[0].GetTableProto().GetName()
+	foundTable := foundIndex.GetTableProto().GetName()
 
 	l.changedResources.AddTable(
 		schema,


### PR DESCRIPTION
## Summary

This PR refactors the `DatabaseMetadata` API to use a hierarchical access pattern with nil-safe method chaining, making the code cleaner and more maintainable.

## Changes

### 1. Removed Convenience Methods
Removed 4 convenience methods from `DatabaseMetadata` that mixed schema/table concerns:
- `GetTable(schemaName, tableName)`
- `GetColumn(schemaName, tableName, columnName)`
- `GetIndex(schemaName, tableName, indexName)`
- `Index(schemaName, tableName)`

### 2. Nil-Safe Method Chaining
Updated methods to handle `nil` receivers safely, enabling clean method chaining:
- `SchemaMetadata.GetTable(name)` - returns `nil` if receiver is `nil`
- `SchemaMetadata.GetIndex(name)` - returns `nil` if receiver is `nil`
- `TableMetadata.GetColumn(name)` - returns `nil` if receiver is `nil`
- `TableMetadata.GetIndex(name)` - returns `nil` if receiver is `nil`

### 3. Clean Chaining Pattern
**Before (verbose with intermediate nil checks):**
```go
schema := r.originalMetadata.GetSchema("")
if schema == nil {
    return false
}
table := schema.GetTable(tableName)
if table == nil {
    return false
}
column := table.GetColumn(columnName)
if column == nil {
    return false
}
// use column
```

**After (clean chaining):**
```go
column := r.originalMetadata.GetSchema("").GetTable(tableName).GetColumn(columnName)
if column == nil {
    return false
}
// use column
```

### 4. Schema-Level Index Access
- Added `SchemaMetadata.GetIndex(name)` since index names are unique within a schema
- Removed unused `SchemaMetadata.GetIndexes(name)` method
- Updated 6 files to use the new schema-level index access

### 5. Consistent Naming
Renamed `originCatalog` → `originalMetadata` in 21 advisor files where the type is `*model.DatabaseMetadata` for consistency.

## Files Changed
- **25 files** total
- `backend/store/model/database.go` - Core model changes
- 9 MySQL advisor files
- 9 TiDB advisor files
- 6 PostgreSQL advisor files
- 1 PLSQL parser file

## Benefits
✅ **Cleaner code** - Single-line chaining instead of verbose nil checks  
✅ **Nil-safe** - No panics when calling methods on `nil` receivers  
✅ **Better structure** - Clear hierarchical access: Database → Schema → Table → Column/Index  
✅ **Consistent naming** - `originalMetadata` for `*model.DatabaseMetadata` throughout

## Testing
- ✅ All tests pass (`go test` for model, tidb, mysql, pg advisor packages)
- ✅ No linting issues (`golangci-lint` shows 0 issues)
- ✅ All files formatted with `gofmt`

## Migration Guide
For any external code using the old convenience methods:

**Old:**
```go
table := db.GetTable(schemaName, tableName)
column := db.GetColumn(schemaName, tableName, columnName)
```

**New:**
```go
table := db.GetSchema(schemaName).GetTable(tableName)
column := db.GetSchema(schemaName).GetTable(tableName).GetColumn(columnName)
```

The new pattern is nil-safe, so intermediate nil checks are not needed.