### PR TITLE
fix: remove max height restriction on issue comments

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentList.vue
+++ b/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentList.vue
@@ -40,6 +40,7 @@
             :content="item.comment.comment"
             :project="project"
             :maxlength="65536"
+            :max-height="Number.MAX_SAFE_INTEGER"
             @change="(val: string) => (state.editComment = val)"
             @submit="doUpdateComment"
           />

--- a/frontend/src/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor/MarkdownEditor.vue
@@ -128,14 +128,20 @@ interface Toolbar {
 
 type EditorMode = "editor" | "preview";
 
-const props = defineProps<{
-  content: string;
-  mode: EditorMode;
-  project: Project;
-  placeholder?: string;
-  autofocus?: boolean;
-  maxlength?: number;
-}>();
+const props = withDefaults(
+  defineProps<{
+    content: string;
+    mode: EditorMode;
+    project: Project;
+    placeholder?: string;
+    autofocus?: boolean;
+    maxlength?: number;
+    maxHeight?: number;
+  }>(),
+  {
+    maxHeight: 192,
+  }
+);
 
 const emit = defineEmits<{
   (event: "change", value: string): void;
@@ -189,6 +195,7 @@ const { renderedContent } = useRenderMarkdown(
   toRef(props, "project"),
   {
     placeholder: `<span>${t("issue.comment-editor.nothing-to-preview")}</span>`,
+    maxHeight: props.maxHeight,
   }
 );
 


### PR DESCRIPTION
## Summary

- Added `maxHeight` prop to `MarkdownEditor` component with default value of 192px for backward compatibility
- Set `maxHeight` to unlimited (`Number.MAX_SAFE_INTEGER`) for issue comment displays
- Issue comments are no longer truncated at 192px height and will display their full content

## Test plan

- [ ] View issue comments with long markdown content and verify they display fully without height restriction
- [ ] Verify other uses of MarkdownEditor (e.g., comment editor preview) still work correctly with default 192px max height
- [ ] Test comment editing mode to ensure it still works properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)