### PR TITLE
fix(frontend): use proper protobuf JSON serialization for table catalog

### DIFF
--- a/frontend/src/components/TableDetailDrawer.vue
+++ b/frontend/src/components/TableDetailDrawer.vue
@@ -303,7 +303,7 @@
 </template>
 
 <script lang="ts" setup>
-import { create } from "@bufbuild/protobuf";
+import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
 import { computedAsync } from "@vueuse/core";
 import { cloneDeep } from "lodash-es";
 import { CodeIcon } from "lucide-vue-next";
@@ -331,7 +331,6 @@ import {
 } from "@/store";
 import { DEFAULT_PROJECT_NAME, defaultProject } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
-import type { TableCatalog } from "@/types/proto-es/v1/database_catalog_service_pb";
 import {
   SchemaCatalogSchema,
   TableCatalogSchema,
@@ -392,17 +391,18 @@ const tableCatalog = computed(() =>
 
 const initTableCatalog = computed(() => {
   if (!tableCatalog.value) {
-    return JSON.stringify(
+    return toJsonString(
+      TableCatalogSchema,
       create(TableCatalogSchema, {
         name: props.tableName,
       }),
-      null,
-      4
+      { prettySpaces: 2 }
     );
   }
 
-  const catalog = cloneDeep(tableCatalog.value);
-  return JSON.stringify(catalog, null, 4);
+  return toJsonString(TableCatalogSchema, tableCatalog.value, {
+    prettySpaces: 2,
+  });
 });
 
 const state = reactive<LocalState>({
@@ -448,7 +448,7 @@ watch(
 );
 
 const onCatalogUpload = async () => {
-  const catalog = JSON.parse(state.tableCatalog) as TableCatalog;
+  const catalog = fromJsonString(TableCatalogSchema, state.tableCatalog);
   if (catalog.name !== props.tableName) {
     pushNotification({
       module: "bytebase",


### PR DESCRIPTION
## Summary
- Fix table catalog upload by using proper protobuf JSON serialization functions
- Replace `JSON.parse`/`JSON.stringify` with `fromJsonString`/`toJsonString` from `@bufbuild/protobuf`
- Remove unused `TableCatalog` type import

## Problem
When uploading table catalog data with complex nested structures (like `objectSchema.structKind`), the previous implementation had two issues:

1. **Deserialization**: Using `JSON.parse()` + type cast created a plain JavaScript object instead of a proper protobuf message, causing the `kind` member to be undefined
2. **Serialization**: Using `JSON.stringify()` included internal metadata fields like `$typeName`, which caused errors when trying to upload the modified catalog

## Solution
- **Display**: Use `toJsonString(TableCatalogSchema, catalog)` to produce clean protobuf JSON without internal metadata
- **Upload**: Use `fromJsonString(TableCatalogSchema, jsonString)` to properly deserialize nested protobuf structures including `oneof` fields

## Test plan
- [ ] Verify table catalog upload works with simple schemas
- [ ] Verify table catalog upload works with complex nested `objectSchema.structKind` structures
- [ ] Verify editing and re-uploading catalog data works without errors
- [ ] Verify no TypeScript/ESLint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)