### PR TITLE
refactor: standardize PostgreSQL parser to return list of ParseResults

### DIFF
--- a/backend/plugin/parser/pg/extract_params_test.go
+++ b/backend/plugin/parser/pg/extract_params_test.go
@@ -73,10 +73,11 @@ $$ LANGUAGE SQL;`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := ParsePostgreSQL(tt.definition)
+			results, err := ParsePostgreSQL(tt.definition)
 			require.NoError(t, err, "failed to parse function definition")
+			require.Len(t, results, 1, "expected exactly one statement")
 
-			root, ok := res.Tree.(*postgresql.RootContext)
+			root, ok := results[0].Tree.(*postgresql.RootContext)
 			require.True(t, ok, "expected RootContext")
 			stmtblock := root.Stmtblock()
 			stmtmulti := stmtblock.Stmtmulti()

--- a/backend/plugin/parser/pg/pg_parse_test.go
+++ b/backend/plugin/parser/pg/pg_parse_test.go
@@ -1,0 +1,195 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePostgreSQL(t *testing.T) {
+	tests := []struct {
+		name          string
+		statement     string
+		wantStatCount int
+		wantErr       bool
+	}{
+		{
+			name:          "Single SELECT statement",
+			statement:     "SELECT * FROM users",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "SELECT with WHERE clause",
+			statement:     "SELECT id, name FROM users WHERE age > 18",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "Multiple statements with semicolon",
+			statement:     "SELECT * FROM t1; SELECT * FROM t2;",
+			wantStatCount: 2,
+			wantErr:       false,
+		},
+		{
+			name:          "INSERT statement",
+			statement:     "INSERT INTO users (id, name) VALUES (1, 'John')",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "UPDATE statement",
+			statement:     "UPDATE users SET name = 'Jane' WHERE id = 1",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "DELETE statement",
+			statement:     "DELETE FROM users WHERE id = 1",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "CREATE TABLE statement",
+			statement:     "CREATE TABLE users (id INT PRIMARY KEY, name TEXT)",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "Empty string",
+			statement:     "",
+			wantStatCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "Only whitespace",
+			statement:     "   \n  \t  ",
+			wantStatCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "Only semicolon",
+			statement:     ";",
+			wantStatCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "Multiple semicolons",
+			statement:     ";;",
+			wantStatCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "Statement with trailing semicolon",
+			statement:     "SELECT * FROM users;",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "Statement without trailing semicolon",
+			statement:     "SELECT * FROM users",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "Comment only",
+			statement:     "-- This is a comment",
+			wantStatCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "Statement with comment",
+			statement:     "SELECT * FROM users -- Get all users",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "Block comment",
+			statement:     "/* This is a block comment */",
+			wantStatCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "Statement with block comment",
+			statement:     "SELECT /* comment */ * FROM users",
+			wantStatCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:      "Invalid SQL syntax",
+			statement: "SELCT * FRM users",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := ParsePostgreSQL(tt.statement)
+			if tt.wantErr {
+				require.Error(t, err, "Expected error for invalid PostgreSQL SQL")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatCount, len(results))
+
+			// Verify each result has the required fields
+			for i, result := range results {
+				assert.NotNil(t, result.Tree, "Result %d should have a Tree", i)
+				assert.NotNil(t, result.Tokens, "Result %d should have Tokens", i)
+				assert.GreaterOrEqual(t, result.BaseLine, 0, "Result %d should have non-negative BaseLine", i)
+			}
+		})
+	}
+}
+
+func TestParsePostgreSQLBaseLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		wantLines []int
+	}{
+		{
+			name:      "Single statement",
+			statement: "SELECT * FROM users",
+			wantLines: []int{0},
+		},
+		{
+			name:      "Two statements on same line",
+			statement: "SELECT * FROM t1; SELECT * FROM t2;",
+			wantLines: []int{0, 0},
+		},
+		{
+			name: "Two statements on different lines",
+			statement: `SELECT * FROM t1;
+SELECT * FROM t2;`,
+			wantLines: []int{0, 1},
+		},
+		{
+			name: "Three statements on different lines",
+			statement: `SELECT * FROM t1;
+SELECT * FROM t2;
+SELECT * FROM t3;`,
+			wantLines: []int{0, 1, 2},
+		},
+		{
+			name: "Statements with empty lines",
+			statement: `SELECT * FROM t1;
+
+SELECT * FROM t2;`,
+			wantLines: []int{0, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := ParsePostgreSQL(tt.statement)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.wantLines), len(results))
+
+			for i, result := range results {
+				assert.Equal(t, tt.wantLines[i], result.BaseLine, "Statement %d BaseLine mismatch", i)
+			}
+		})
+	}
+}

--- a/backend/plugin/parser/pg/pg_test.go
+++ b/backend/plugin/parser/pg/pg_test.go
@@ -24,14 +24,14 @@ func TestPostgreSQLParser(t *testing.T) {
 		},
 		{
 			statement:    "SELECT 1;\n   SELEC 5;\nSELECT 6;",
-			errorMessage: "Syntax error at line 2:4 \nrelated text: SELECT 1;\n   SELEC",
+			errorMessage: "Syntax error at line 2:4 \nrelated text: \n   SELEC",
 		},
 	}
 
 	for _, test := range tests {
-		res, err := ParsePostgreSQL(test.statement)
-		if res != nil {
-			_, ok := res.Tree.(*parser.RootContext)
+		results, err := ParsePostgreSQL(test.statement)
+		if len(results) > 0 {
+			_, ok := results[0].Tree.(*parser.RootContext)
 			require.True(t, ok)
 		}
 		if test.errorMessage == "" {

--- a/backend/plugin/parser/pg/plsql.go
+++ b/backend/plugin/parser/pg/plsql.go
@@ -8,13 +8,17 @@ import (
 // Returns true if the statement is a DO block only, false otherwise.
 func IsPlSQLBlock(stmt string) bool {
 	// Parse using the existing ANTLR-based parser
-	result, err := ParsePostgreSQL(stmt)
+	results, err := ParsePostgreSQL(stmt)
 	if err != nil {
 		return false
 	}
 
+	if len(results) != 1 {
+		return false
+	}
+
 	// Check if the parsed tree is a single DO statement
-	root, ok := result.Tree.(*parser.RootContext)
+	root, ok := results[0].Tree.(*parser.RootContext)
 	if !ok || root == nil {
 		return false
 	}

--- a/backend/plugin/parser/pg/query_antlr.go
+++ b/backend/plugin/parser/pg/query_antlr.go
@@ -18,7 +18,7 @@ import (
 // 5. Reject: All other statements (DDL, DML except SELECT)
 func validateQueryANTLR(statement string) (bool, bool, error) {
 	// Parse with ANTLR
-	result, err := ParsePostgreSQL(statement)
+	results, err := ParsePostgreSQL(statement)
 	if err != nil {
 		// Return syntax error
 		if syntaxErr, ok := err.(*base.SyntaxError); ok {
@@ -27,8 +27,16 @@ func validateQueryANTLR(statement string) (bool, bool, error) {
 		return false, false, err
 	}
 
+	if len(results) == 0 {
+		return false, false, nil
+	}
+
+	if len(results) != 1 {
+		return false, false, nil
+	}
+
 	// Analyze the parse tree
-	tree := result.Tree
+	tree := results[0].Tree
 	listener := &queryValidatorListener{
 		hasExecute:     false,
 		explainAnalyze: false,

--- a/backend/plugin/parser/pg/resource_change_test.go
+++ b/backend/plugin/parser/pg/resource_change_test.go
@@ -65,9 +65,10 @@ func TestExtractChangedResources(t *testing.T) {
 		InsertCount:      2,
 	}
 
-	parseResult, err := ParsePostgreSQL(statement)
+	parseResults, err := ParsePostgreSQL(statement)
 	require.NoError(t, err)
-	got, err := extractChangedResources("db", "public", dbSchema, parseResult, statement)
+	require.Len(t, parseResults, 1, "expected exactly one statement")
+	got, err := extractChangedResources("db", "public", dbSchema, parseResults[0], statement)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }

--- a/backend/plugin/parser/pg/statement_type_antlr_test.go
+++ b/backend/plugin/parser/pg/statement_type_antlr_test.go
@@ -218,10 +218,11 @@ func TestGetStatementTypesANTLR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parseResult, err := ParsePostgreSQL(tt.sql)
+			parseResults, err := ParsePostgreSQL(tt.sql)
 			require.NoError(t, err)
+			require.Len(t, parseResults, 1, "expected exactly one statement")
 
-			stmtsWithPos, err := GetStatementTypes(parseResult)
+			stmtsWithPos, err := GetStatementTypes(parseResults[0])
 			require.NoError(t, err)
 
 			// Extract types from statements with positions
@@ -275,10 +276,11 @@ INSERT INTO t1 VALUES (1);`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parseResult, err := ParsePostgreSQL(tt.sql)
+			parseResults, err := ParsePostgreSQL(tt.sql)
 			require.NoError(t, err)
+			require.Len(t, parseResults, 1, "expected exactly one statement")
 
-			results, err := GetStatementTypes(parseResult)
+			results, err := GetStatementTypes(parseResults[0])
 			require.NoError(t, err)
 			require.Len(t, results, len(tt.expected))
 


### PR DESCRIPTION
## Summary
Migrates the PostgreSQL parser to return a list of ParseResult objects (one per statement) instead of a single result, following the pattern established for other SQL engines (MySQL, BigQuery, Doris, PartiQL, PLSQL, Cassandra, CosmosDB).

Part of #8330 (Linear: BYT-8330)

## Changes
- Added `BaseLine` field to `ParseResult` struct for multi-statement error reporting
- Updated `ParsePostgreSQL()` to return `[]*ParseResult`
- Created `parseSinglePostgreSQL()` helper function
- Updated query span validation to require single statement input
- Updated all callers to handle list return type:
  - `query_antlr.go`, `access_tables.go`, `plsql.go`
  - `restore.go`, `backup.go`, `query_span_extractor.go`
  - All test files
- Added comprehensive tests for parser and `BaseLine` tracking

## Engines Affected
- POSTGRES
- COCKROACHDB (shares parser implementation)
- REDSHIFT (shares query span implementation)

## Test Plan
- [x] All existing tests pass with updated expectations
- [x] New comprehensive parser tests added (`TestParsePostgreSQL`, `TestParsePostgreSQLBaseLine`)
- [x] golangci-lint passes with no issues
- [x] Verified error line numbers are correctly reported for multi-statement input

🤖 Generated with [Claude Code](https://claude.com/claude-code)