### PR TITLE
refactor: use storepb.LinkedDatabaseMetadata

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -1334,7 +1334,7 @@ func BuildGetLinkedDatabaseMetadataFunc(storeInstance *store.Store, engine store
 		if err != nil {
 			return "", "", nil, err
 		}
-		var linkedMeta *model.LinkedDatabaseMetadata
+		var linkedMeta *storepb.LinkedDatabaseMetadata
 		for _, database := range databases {
 			meta, err := storeInstance.GetDBSchema(ctx, &store.FindDBSchemaMessage{
 				InstanceID:   database.InstanceID,

--- a/backend/store/model/database.go
+++ b/backend/store/model/database.go
@@ -26,7 +26,7 @@ type DatabaseMetadata struct {
 	owner          string
 	searchPath     []string
 	internal       map[string]*SchemaMetadata
-	linkedDatabase map[string]*LinkedDatabaseMetadata
+	linkedDatabase map[string]*storepb.LinkedDatabaseMetadata
 
 	// Config fields (formerly in DatabaseConfig)
 	configName     string
@@ -51,7 +51,7 @@ func NewDatabaseMetadata(
 		owner:                 metadata.Owner,
 		searchPath:            normalizeSearchPath(metadata.SearchPath),
 		internal:              make(map[string]*SchemaMetadata),
-		linkedDatabase:        make(map[string]*LinkedDatabaseMetadata),
+		linkedDatabase:        make(map[string]*storepb.LinkedDatabaseMetadata),
 		configInternal:        make(map[string]*SchemaConfig),
 	}
 
@@ -191,11 +191,7 @@ func NewDatabaseMetadata(
 		} else {
 			dbLinkID = strings.ToLower(dbLink.Name)
 		}
-		dbMetadata.linkedDatabase[dbLinkID] = &LinkedDatabaseMetadata{
-			name:     dbLink.Name,
-			username: dbLink.Username,
-			host:     dbLink.Host,
-		}
+		dbMetadata.linkedDatabase[dbLinkID] = dbLink
 	}
 
 	// Build config maps
@@ -281,7 +277,7 @@ func (d *DatabaseMetadata) ListSchemaNames() []string {
 	return result
 }
 
-func (d *DatabaseMetadata) GetLinkedDatabase(name string) *LinkedDatabaseMetadata {
+func (d *DatabaseMetadata) GetLinkedDatabase(name string) *storepb.LinkedDatabaseMetadata {
 	var nameID string
 	if d.isObjectCaseSensitive {
 		nameID = name
@@ -485,25 +481,6 @@ func (t *TableConfig) GetColumnConfig(name string) *storepb.ColumnCatalog {
 	return &storepb.ColumnCatalog{
 		Name: name,
 	}
-}
-
-// LinkedDatabaseMetadata is the metadata for a linked database.
-type LinkedDatabaseMetadata struct {
-	name     string
-	username string
-	host     string
-}
-
-func (l *LinkedDatabaseMetadata) GetName() string {
-	return l.name
-}
-
-func (l *LinkedDatabaseMetadata) GetUsername() string {
-	return l.username
-}
-
-func (l *LinkedDatabaseMetadata) GetHost() string {
-	return l.host
 }
 
 // SchemaMetadata is the metadata for a schema.


### PR DESCRIPTION
Refactors  to use the auto-generated  from  instead of a custom struct. This simplifies the codebase and removes redundancy.

## Changes
- Replaced  with  in .
- Removed custom  struct and methods.
- Updated  and .
- Updated  in .

## Verification
- Ran ok  	github.com/bytebase/bytebase/backend/store/model	0.920s - PASS
- Ran ok  	github.com/bytebase/bytebase/backend/plugin/parser/plsql	2.621s - PASS
- Built server successfully.