### PR TITLE
refactor: Use storepb.FunctionMetadata and improve PG function comparison

### DIFF
--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -174,10 +174,10 @@ loop:
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database schema not found for %s", database.DatabaseName))
 		}
 		// Create original metadata as read-only
-		originMetadata := model.NewDatabaseMetadata(dbMetadata.GetMetadata(), nil, nil, engine, store.IsObjectCaseSensitive(instance))
+		originMetadata := model.NewDatabaseMetadata(dbMetadata.GetProto(), nil, nil, engine, store.IsObjectCaseSensitive(instance))
 
 		// Clone metadata for final to avoid modifying the original
-		clonedMetadata, ok := proto.Clone(dbMetadata.GetMetadata()).(*storepb.DatabaseSchemaMetadata)
+		clonedMetadata, ok := proto.Clone(dbMetadata.GetProto()).(*storepb.DatabaseSchemaMetadata)
 		if !ok {
 			return nil, connect.NewError(connect.CodeInternal, errors.New("failed to clone database schema metadata"))
 		}
@@ -650,7 +650,7 @@ func (s *ReleaseService) runSQLReviewCheckForFile(
 		}
 	}
 
-	dbMetadataProto := dbMetadata.GetMetadata()
+	dbMetadataProto := dbMetadata.GetProto()
 	useDatabaseOwner, err := getUseDatabaseOwner(ctx, s.store, instance, database)
 	if err != nil {
 		return storepb.Advice_ERROR, nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get use database owner"))

--- a/backend/component/export/resources.go
+++ b/backend/component/export/resources.go
@@ -112,7 +112,7 @@ func getResourcesForMySQL(
 				Table:        sourceColumn.Table,
 				LinkedServer: sourceColumn.Server,
 			}
-			if sourceColumn.Database != dbMetadata.GetMetadata().Name {
+			if sourceColumn.Database != dbMetadata.GetProto().Name {
 				resourceDB, err := storeInstance.GetDatabaseV2(ctx, &store.FindDatabaseMessage{
 					InstanceID:      &instance.ResourceID,
 					DatabaseName:    &sourceColumn.Database,
@@ -198,7 +198,7 @@ func getResourcesForPostgres(
 				LinkedServer: sourceColumn.Server,
 			}
 
-			if sourceColumn.Database != dbMetadata.GetMetadata().Name {
+			if sourceColumn.Database != dbMetadata.GetProto().Name {
 				continue
 			}
 

--- a/backend/plugin/advisor/mysql/rule_online_migration.go
+++ b/backend/plugin/advisor/mysql/rule_online_migration.go
@@ -204,7 +204,7 @@ func (r *OnlineMigrationRule) exitAlterStatement(ctx *mysql.AlterStatementContex
 
 	for _, resource := range r.changedResources {
 		var tableRows int64
-		for _, table := range r.dbMetadata.GetMetadata().GetSchemas()[0].GetTables() {
+		for _, table := range r.dbMetadata.GetProto().GetSchemas()[0].GetTables() {
 			if table.GetName() == resource.Table {
 				tableRows = table.GetRowCount()
 				break

--- a/backend/plugin/advisor/pg/advisor_statement_object_owner_check.go
+++ b/backend/plugin/advisor/pg/advisor_statement_object_owner_check.go
@@ -149,7 +149,7 @@ func (r *statementObjectOwnerCheckRule) checkSchemaOwnership(schemaName string, 
 
 	owner := schemaMeta.GetOwner()
 	if owner == pgDatabaseOwner {
-		owner = r.dbMetadata.GetOwner()
+		owner = r.dbMetadata.GetProto().GetOwner()
 	}
 	if owner != r.currentRole {
 		r.AddAdvice(&storepb.Advice{
@@ -182,7 +182,7 @@ func (r *statementObjectOwnerCheckRule) checkTableOwnership(schemaName, tableNam
 
 	owner := tableMeta.GetOwner()
 	if owner == pgDatabaseOwner {
-		owner = r.dbMetadata.GetOwner()
+		owner = r.dbMetadata.GetProto().GetOwner()
 	}
 	if owner != r.currentRole {
 		r.AddAdvice(&storepb.Advice{
@@ -307,12 +307,12 @@ func (r *statementObjectOwnerCheckRule) handleCreateschemastmt(ctx *parser.Creat
 		return
 	}
 
-	owner := r.dbMetadata.GetOwner()
+	owner := r.dbMetadata.GetProto().GetOwner()
 	if owner != r.currentRole {
 		r.AddAdvice(&storepb.Advice{
 			Status:  r.level,
 			Title:   r.title,
-			Content: fmt.Sprintf("Database \"%s\" is owned by \"%s\", but the current role is \"%s\".", r.dbMetadata.GetName(), owner, r.currentRole),
+			Content: fmt.Sprintf("Database \"%s\" is owned by \"%s\", but the current role is \"%s\".", r.dbMetadata.GetProto().GetName(), owner, r.currentRole),
 			Code:    code.StatementObjectOwnerCheck.Int32(),
 			StartPosition: &storepb.Position{
 				Line:   int32(ctx.GetStart().GetLine()),

--- a/backend/plugin/parser/mysql/query_span_extractor.go
+++ b/backend/plugin/parser/mysql/query_span_extractor.go
@@ -1379,7 +1379,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 		return &base.PhysicalTable{
 			Name:     tableSchema.GetProto().Name,
 			Schema:   emptySchema,
-			Database: dbMetadata.GetName(),
+			Database: dbMetadata.GetProto().GetName(),
 			Server:   "",
 			Columns:  columnNames,
 		}, nil
@@ -1404,7 +1404,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 		return &base.PhysicalView{
 			Name:     viewSchema.GetProto().Name,
 			Schema:   emptySchema,
-			Database: dbMetadata.GetName(),
+			Database: dbMetadata.GetProto().GetName(),
 			Server:   "",
 			Columns:  columns,
 		}, nil

--- a/backend/plugin/parser/pg/query_span_extractor.go
+++ b/backend/plugin/parser/pg/query_span_extractor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
 
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	parsererror "github.com/bytebase/bytebase/backend/plugin/parser/errors"
 
 	"github.com/bytebase/parser/postgresql"
@@ -235,7 +236,7 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, stmt string) (*ba
 
 type functionDefinition struct {
 	schemaName string
-	metadata   *model.FunctionMetadata
+	metadata   *storepb.FunctionMetadata
 }
 
 func (q *querySpanExtractor) findFunctionDefine(schemaName, funcName string, nArgs int) (base.TableSource, error) {
@@ -300,7 +301,7 @@ type functionDefinitionDetail struct {
 
 func buildFunctionDefinitionDetail(funcDef *functionDefinition) (*functionDefinitionDetail, error) {
 	function := funcDef.metadata
-	definition := function.GetProto().GetDefinition()
+	definition := function.GetDefinition()
 	res, err := ParsePostgreSQL(definition)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse function definition: %s", definition)
@@ -365,7 +366,7 @@ func getFunctionCandidates(functions []*functionDefinition, nArgs int, funcName 
 	// Filter by name only.
 	var nameFiltered []*functionDefinition
 	for _, function := range functions {
-		if function.metadata.GetProto().GetName() != funcName {
+		if function.metadata.GetName() != funcName {
 			continue
 		}
 		nameFiltered = append(nameFiltered, function)

--- a/backend/plugin/schema/pg/get_database_metadata_testcontainer_test.go
+++ b/backend/plugin/schema/pg/get_database_metadata_testcontainer_test.go
@@ -1393,8 +1393,8 @@ func compareFunctions(t *testing.T, syncFuncs, parseFuncs []*storepb.FunctionMet
 
 		// Compare function definitions using PostgreSQL function comparer
 		comparer := &PostgreSQLFunctionComparer{}
-		syncFunc := &model.FunctionMetadata{Definition: syncFn.Definition}
-		parseFunc := &model.FunctionMetadata{Definition: parseFn.Definition}
+		syncFunc := &storepb.FunctionMetadata{Definition: syncFn.Definition}
+		parseFunc := &storepb.FunctionMetadata{Definition: parseFn.Definition}
 
 		// Use function comparer to check if they are equal
 		if !comparer.Equal(syncFunc, parseFunc) {

--- a/backend/plugin/schema/pg/get_sdl_diff.go
+++ b/backend/plugin/schema/pg/get_sdl_diff.go
@@ -2715,8 +2715,8 @@ func applyMinimalChangesToChunks(previousChunks *schema.SDLChunks, currentSchema
 	}
 
 	// Get table differences between schemas
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -3730,7 +3730,7 @@ func convertDatabaseSchemaToSDL(dbMetadata *model.DatabaseMetadata) (string, err
 		return "", nil
 	}
 
-	metadata := dbMetadata.GetMetadata()
+	metadata := dbMetadata.GetProto()
 	if metadata == nil {
 		return "", nil
 	}
@@ -4242,8 +4242,8 @@ func applyStandaloneIndexChangesToChunks(previousChunks *schema.SDLChunks, curre
 	}
 
 	// Get index differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -4578,8 +4578,8 @@ func applyFunctionChangesToChunks(previousChunks *schema.SDLChunks, currentSchem
 	}
 
 	// Get function differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -4950,8 +4950,8 @@ func applySequenceChangesToChunks(previousChunks *schema.SDLChunks, currentSchem
 	}
 
 	// Get sequence differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -5744,8 +5744,8 @@ func applyViewChangesToChunks(previousChunks *schema.SDLChunks, currentSchema, p
 	}
 
 	// Get view differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -5996,8 +5996,8 @@ func applyMaterializedViewChangesToChunks(previousChunks *schema.SDLChunks, curr
 	}
 
 	// Get materialized view differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -6226,8 +6226,8 @@ func applyEnumTypeChangesToChunks(previousChunks *schema.SDLChunks, currentSchem
 	}
 
 	// Get enum type differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -6488,8 +6488,8 @@ func applyColumnCommentChanges(previousChunks *schema.SDLChunks, currentSchema, 
 	}
 
 	// Get table metadata from schemas
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -6964,8 +6964,8 @@ func applyExtensionChangesToChunks(previousChunks *schema.SDLChunks, currentSche
 	}
 
 	// Get extension differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}
@@ -7251,8 +7251,8 @@ func applyTriggerChangesToChunks(previousChunks *schema.SDLChunks, currentSchema
 	}
 
 	// Get trigger differences by comparing schema metadata
-	currentMetadata := currentSchema.GetMetadata()
-	previousMetadata := previousSchema.GetMetadata()
+	currentMetadata := currentSchema.GetProto()
+	previousMetadata := previousSchema.GetProto()
 	if currentMetadata == nil || previousMetadata == nil {
 		return nil
 	}

--- a/backend/runner/plancheck/statement_advise_executor.go
+++ b/backend/runner/plancheck/statement_advise_executor.go
@@ -136,7 +136,7 @@ func (e *StatementAdviseExecutor) runReview(
 	if dbMetadata == nil {
 		return nil, errors.Errorf("database schema %s not found", database.String())
 	}
-	if dbMetadata.GetMetadata() == nil {
+	if dbMetadata.GetProto() == nil {
 		return nil, errors.Errorf("database schema metadata %s not found", database.String())
 	}
 
@@ -151,10 +151,10 @@ func (e *StatementAdviseExecutor) runReview(
 	}
 
 	// Create original metadata as read-only
-	originMetadata := model.NewDatabaseMetadata(dbMetadata.GetMetadata(), nil, nil, instance.Metadata.GetEngine(), store.IsObjectCaseSensitive(instance))
+	originMetadata := model.NewDatabaseMetadata(dbMetadata.GetProto(), nil, nil, instance.Metadata.GetEngine(), store.IsObjectCaseSensitive(instance))
 
 	// Clone metadata for final to avoid modifying the original
-	clonedMetadata, ok := proto.Clone(dbMetadata.GetMetadata()).(*storepb.DatabaseSchemaMetadata)
+	clonedMetadata, ok := proto.Clone(dbMetadata.GetProto()).(*storepb.DatabaseSchemaMetadata)
 	if !ok {
 		return nil, common.Wrapf(errors.New("failed to clone database schema metadata"), common.Internal, "failed to create a catalog")
 	}
@@ -177,9 +177,9 @@ func (e *StatementAdviseExecutor) runReview(
 	classificationConfig := getClassificationByProject(ctx, e.store, database.ProjectID)
 
 	adviceList, err := advisor.SQLReviewCheck(ctx, e.sheetManager, statement, reviewConfig.SqlReviewRules, advisor.SQLReviewCheckContext{
-		Charset:                  dbMetadata.GetMetadata().CharacterSet,
-		Collation:                dbMetadata.GetMetadata().Collation,
-		DBSchema:                 dbMetadata.GetMetadata(),
+		Charset:                  dbMetadata.GetProto().CharacterSet,
+		Collation:                dbMetadata.GetProto().Collation,
+		DBSchema:                 dbMetadata.GetProto(),
 		ChangeType:               changeType,
 		DBType:                   instance.Metadata.GetEngine(),
 		OriginalMetadata:         originMetadata,

--- a/backend/runner/plancheck/statement_report_executor.go
+++ b/backend/runner/plancheck/statement_report_executor.go
@@ -146,7 +146,7 @@ func GetSQLSummaryReport(ctx context.Context, stores *store.Store, sheetManager 
 	if databaseSchema == nil {
 		return nil, errors.Errorf("database schema %s not found", database.String())
 	}
-	if databaseSchema.GetMetadata() == nil {
+	if databaseSchema.GetProto() == nil {
 		return nil, errors.Errorf("database schema metadata %s not found", database.String())
 	}
 	instance, err := stores.GetInstanceV2(ctx, &store.FindInstanceMessage{ResourceID: &database.InstanceID})

--- a/backend/store/model/pg_searcher.go
+++ b/backend/store/model/pg_searcher.go
@@ -1,6 +1,10 @@
 package model
 
-import "strings"
+import (
+	"strings"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
 
 // DatabaseSearcher provides a fluent interface for searching database objects with a specific search path.
 // This helper avoids repetitive searchPath parameter passing when performing multiple searches.
@@ -126,22 +130,22 @@ func (s *DatabaseSearcher) SearchMaterializedView(name string) (string, *Materia
 
 // SearchFunctions searches for functions in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (s *DatabaseSearcher) SearchFunctions(name string) ([]string, []*FunctionMetadata) {
+func (s *DatabaseSearcher) SearchFunctions(name string) ([]string, []*storepb.FunctionMetadata) {
 	var schemas []string
-	var funcs []*FunctionMetadata
+	var funcs []*storepb.FunctionMetadata
 	for _, schemaName := range s.searchPath {
 		schema := s.db.GetSchemaMetadata(schemaName)
 		if schema == nil {
 			continue
 		}
-		for _, function := range schema.ListFunctions() {
+		for _, function := range schema.functions {
 			if s.db.isDetailCaseSensitive {
-				if function.proto.Name == name {
+				if function.Name == name {
 					schemas = append(schemas, schema.proto.Name)
 					funcs = append(funcs, function)
 				}
 			} else {
-				if strings.EqualFold(function.proto.Name, name) {
+				if strings.EqualFold(function.Name, name) {
 					schemas = append(schemas, schema.proto.Name)
 					funcs = append(funcs, function)
 				}
@@ -264,22 +268,22 @@ func (d *DatabaseMetadata) SearchMaterializedView(searchPath []string, name stri
 
 // SearchFunctions searches for functions in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (d *DatabaseMetadata) SearchFunctions(searchPath []string, name string) ([]string, []*FunctionMetadata) {
+func (d *DatabaseMetadata) SearchFunctions(searchPath []string, name string) ([]string, []*storepb.FunctionMetadata) {
 	var schemas []string
-	var funcs []*FunctionMetadata
+	var funcs []*storepb.FunctionMetadata
 	for _, schemaName := range searchPath {
 		schema := d.GetSchemaMetadata(schemaName)
 		if schema == nil {
 			continue
 		}
-		for _, function := range schema.ListFunctions() {
+		for _, function := range schema.functions {
 			if d.isDetailCaseSensitive {
-				if function.proto.Name == name {
+				if function.Name == name {
 					schemas = append(schemas, schema.proto.Name)
 					funcs = append(funcs, function)
 				}
 			} else {
-				if strings.EqualFold(function.proto.Name, name) {
+				if strings.EqualFold(function.Name, name) {
 					schemas = append(schemas, schema.proto.Name)
 					funcs = append(funcs, function)
 				}


### PR DESCRIPTION
This PR refactors the codebase to use  instead of the custom  struct. It also improves the PostgreSQL function comparer to be more robust and safer against nil pointers.

Changes:
- Replaced  with  in  and related files.
- Removed unused  struct and  method.
- Updated  to handle nil inputs safely in  and .
- Fixed a test case in  that incorrectly expected equality for nil functions.
- Updated  to use the new metadata types.

Verified with existing tests.