### PR TITLE
refactor: use storepb types directly for View, MaterializedView, Package, and Sequence metadata

### DIFF
--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -1158,11 +1158,7 @@ func (s *DatabaseService) GetSchemaString(ctx context.Context, req *connect.Requ
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("table %q not found", req.Msg.Object))
 		}
 		sequences := schemaMetadata.GetSequencesByOwnerTable(req.Msg.Object)
-		var sequencesProto []*storepb.SequenceMetadata
-		for _, sequence := range sequences {
-			sequencesProto = append(sequencesProto, sequence.GetProto())
-		}
-		s, err := schema.GetTableDefinition(instance.Metadata.Engine, req.Msg.Schema, tableMetadata.GetProto(), sequencesProto)
+		s, err := schema.GetTableDefinition(instance.Metadata.Engine, req.Msg.Schema, tableMetadata.GetProto(), sequences)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("Failed to get table schema: %v", err))
 		}
@@ -1176,7 +1172,7 @@ func (s *DatabaseService) GetSchemaString(ctx context.Context, req *connect.Requ
 		if viewMetadata == nil {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("view %q not found", req.Msg.Object))
 		}
-		s, err := schema.GetViewDefinition(instance.Metadata.Engine, req.Msg.Schema, viewMetadata.GetProto())
+		s, err := schema.GetViewDefinition(instance.Metadata.Engine, req.Msg.Schema, viewMetadata)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("Failed to get view schema: %v", err))
 		}
@@ -1190,7 +1186,7 @@ func (s *DatabaseService) GetSchemaString(ctx context.Context, req *connect.Requ
 		if materializedViewMetadata == nil {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("materialized view %q not found", req.Msg.Object))
 		}
-		s, err := schema.GetMaterializedViewDefinition(instance.Metadata.Engine, req.Msg.Schema, materializedViewMetadata.GetProto())
+		s, err := schema.GetMaterializedViewDefinition(instance.Metadata.Engine, req.Msg.Schema, materializedViewMetadata)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("Failed to get materialized view schema: %v", err))
 		}
@@ -1218,7 +1214,7 @@ func (s *DatabaseService) GetSchemaString(ctx context.Context, req *connect.Requ
 		if procedureMetadata == nil {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("procedure %q not found", req.Msg.Object))
 		}
-		s, err := schema.GetProcedureDefinition(instance.Metadata.Engine, req.Msg.Schema, procedureMetadata.GetProto())
+		s, err := schema.GetProcedureDefinition(instance.Metadata.Engine, req.Msg.Schema, procedureMetadata)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("Failed to get procedure schema: %v", err))
 		}
@@ -1232,7 +1228,7 @@ func (s *DatabaseService) GetSchemaString(ctx context.Context, req *connect.Requ
 		if sequenceMetadata == nil {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("sequence %q not found", req.Msg.Object))
 		}
-		s, err := schema.GetSequenceDefinition(instance.Metadata.Engine, req.Msg.Schema, sequenceMetadata.GetProto())
+		s, err := schema.GetSequenceDefinition(instance.Metadata.Engine, req.Msg.Schema, sequenceMetadata)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("Failed to get sequence schema: %v", err))
 		}

--- a/backend/plugin/parser/mysql/query_span_extractor.go
+++ b/backend/plugin/parser/mysql/query_span_extractor.go
@@ -1385,7 +1385,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 		}, nil
 	}
 
-	var viewSchema *model.ViewMetadata
+	var viewSchema *storepb.ViewMetadata
 	if q.ignoreCaseSensitive {
 		for _, view := range schema.ListViewNames() {
 			if strings.EqualFold(view, tableName) {
@@ -1402,7 +1402,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 			return nil, errors.Wrapf(err, "failed to get columns for view %q", tableName)
 		}
 		return &base.PhysicalView{
-			Name:     viewSchema.GetProto().Name,
+			Name:     viewSchema.Name,
 			Schema:   emptySchema,
 			Database: dbMetadata.GetProto().GetName(),
 			Server:   "",

--- a/backend/plugin/parser/pg/query_span_extractor.go
+++ b/backend/plugin/parser/pg/query_span_extractor.go
@@ -1254,7 +1254,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   viewSchemaName,
-			Name:     view.GetProto().Name,
+			Name:     view.Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1268,7 +1268,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   materializedViewSchemaName,
-			Name:     materializedView.GetProto().Name,
+			Name:     materializedView.Name,
 			Columns:  columns,
 		}, nil
 	}
@@ -1280,7 +1280,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 			Server:   "",
 			Database: q.defaultDatabase,
 			Schema:   sequenceSchemaName,
-			Name:     sequence.GetProto().Name,
+			Name:     sequence.Name,
 			Columns:  columns,
 		}, nil
 	}

--- a/backend/plugin/parser/plsql/query_span_extractor.go
+++ b/backend/plugin/parser/plsql/query_span_extractor.go
@@ -1365,7 +1365,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbMeta
 			return nil, err
 		}
 		return &base.PseudoTable{
-			Name:    view.GetProto().Name,
+			Name:    view.Name,
 			Columns: columns,
 		}, nil
 	}
@@ -1377,7 +1377,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbMeta
 			return nil, err
 		}
 		return &base.PseudoTable{
-			Name:    materializedView.GetProto().Name,
+			Name:    materializedView.Name,
 			Columns: columns,
 		}, nil
 	}

--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -842,7 +842,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName string, tableName stri
 				}
 				return &base.PhysicalView{
 					Database: databaseName,
-					Name:     viewMeta.GetProto().Name,
+					Name:     viewMeta.Name,
 					Columns:  columns,
 				}, nil
 			}

--- a/backend/plugin/parser/trino/query_span_extractor.go
+++ b/backend/plugin/parser/trino/query_span_extractor.go
@@ -8,6 +8,7 @@ import (
 	parser "github.com/bytebase/parser/trino"
 	"github.com/pkg/errors"
 
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	parsererror "github.com/bytebase/bytebase/backend/plugin/parser/errors"
 	"github.com/bytebase/bytebase/backend/store/model"
@@ -314,7 +315,7 @@ func (q *querySpanExtractor) findTableSchema(db, schema, name string) (*model.Ta
 	}
 
 	// Look for view
-	var viewMeta *model.ViewMetadata
+	var viewMeta *storepb.ViewMetadata
 	if q.ignoreCaseSensitive {
 		for _, viewName := range schemaMeta.ListViewNames() {
 			if strings.EqualFold(viewName, name) {

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -732,7 +732,7 @@ func (q *querySpanExtractor) tsqlFindTableSchema(fullTableName parser.IFull_tabl
 					Server:   "",
 					Database: databaseName,
 					Schema:   schemaName,
-					Name:     view.GetProto().Name,
+					Name:     view.Name,
 					Columns:  columns,
 				}
 				return tableSource, nil

--- a/backend/plugin/schema/differ.go
+++ b/backend/plugin/schema/differ.go
@@ -392,12 +392,12 @@ func addNewSchemaObjects(diff *MetadataDiff, schemaName string, schema *model.Sc
 	// Add all views
 	for _, viewName := range schema.ListViewNames() {
 		view := schema.GetView(viewName)
-		if view != nil && !view.GetProto().GetSkipDump() {
+		if view != nil && !view.SkipDump {
 			diff.ViewChanges = append(diff.ViewChanges, &ViewDiff{
 				Action:     MetadataDiffActionCreate,
 				SchemaName: schemaName,
 				ViewName:   viewName,
-				NewView:    view.GetProto(),
+				NewView:    view,
 				OldASTNode: nil,
 				NewASTNode: nil,
 			})
@@ -407,12 +407,12 @@ func addNewSchemaObjects(diff *MetadataDiff, schemaName string, schema *model.Sc
 	// Add all materialized views
 	for _, mvName := range schema.ListMaterializedViewNames() {
 		mv := schema.GetMaterializedView(mvName)
-		if mv != nil && !mv.GetProto().GetSkipDump() {
+		if mv != nil && !mv.SkipDump {
 			diff.MaterializedViewChanges = append(diff.MaterializedViewChanges, &MaterializedViewDiff{
 				Action:               MetadataDiffActionCreate,
 				SchemaName:           schemaName,
 				MaterializedViewName: mvName,
-				NewMaterializedView:  mv.GetProto(),
+				NewMaterializedView:  mv,
 			})
 		}
 	}
@@ -437,12 +437,12 @@ func addNewSchemaObjects(diff *MetadataDiff, schemaName string, schema *model.Sc
 	// Add all procedures
 	for _, procName := range schema.ListProcedureNames() {
 		proc := schema.GetProcedure(procName)
-		if proc != nil && !proc.GetProto().GetSkipDump() {
+		if proc != nil && !proc.SkipDump {
 			diff.ProcedureChanges = append(diff.ProcedureChanges, &ProcedureDiff{
 				Action:        MetadataDiffActionCreate,
 				SchemaName:    schemaName,
 				ProcedureName: procName,
-				NewProcedure:  proc.GetProto(),
+				NewProcedure:  proc,
 			})
 		}
 	}
@@ -1523,12 +1523,12 @@ func compareViews(engine storepb.Engine, diff *MetadataDiff, schemaName string, 
 	for _, viewName := range oldSchema.ListViewNames() {
 		if newSchema.GetView(viewName) == nil {
 			oldView := oldSchema.GetView(viewName)
-			if oldView != nil && !oldView.GetProto().GetSkipDump() {
+			if oldView != nil && !oldView.SkipDump {
 				diff.ViewChanges = append(diff.ViewChanges, &ViewDiff{
 					Action:     MetadataDiffActionDrop,
 					SchemaName: schemaName,
 					ViewName:   viewName,
-					OldView:    oldView.GetProto(),
+					OldView:    oldView,
 					OldASTNode: nil,
 					NewASTNode: nil,
 				})
@@ -1539,7 +1539,7 @@ func compareViews(engine storepb.Engine, diff *MetadataDiff, schemaName string, 
 	// Check for new and modified views
 	for _, viewName := range newSchema.ListViewNames() {
 		newView := newSchema.GetView(viewName)
-		if newView == nil || newView.GetProto().GetSkipDump() {
+		if newView == nil || newView.SkipDump {
 			continue
 		}
 
@@ -1549,11 +1549,11 @@ func compareViews(engine storepb.Engine, diff *MetadataDiff, schemaName string, 
 				Action:     MetadataDiffActionCreate,
 				SchemaName: schemaName,
 				ViewName:   viewName,
-				NewView:    newView.GetProto(),
+				NewView:    newView,
 				OldASTNode: nil,
 				NewASTNode: nil,
 			})
-		} else if !oldView.GetProto().GetSkipDump() {
+		} else if !oldView.SkipDump {
 			// Use engine-specific comparison
 			changes, err := comparer.CompareView(oldView, newView)
 			if err != nil {
@@ -1563,8 +1563,8 @@ func compareViews(engine storepb.Engine, diff *MetadataDiff, schemaName string, 
 						Action:     MetadataDiffActionAlter,
 						SchemaName: schemaName,
 						ViewName:   viewName,
-						OldView:    oldView.GetProto(),
-						NewView:    newView.GetProto(),
+						OldView:    oldView,
+						NewView:    newView,
 						OldASTNode: nil,
 						NewASTNode: nil,
 					})
@@ -1584,8 +1584,8 @@ func compareViews(engine storepb.Engine, diff *MetadataDiff, schemaName string, 
 						Action:     MetadataDiffActionAlter,
 						SchemaName: schemaName,
 						ViewName:   viewName,
-						OldView:    oldView.GetProto(),
-						NewView:    newView.GetProto(),
+						OldView:    oldView,
+						NewView:    newView,
 						OldASTNode: nil,
 						NewASTNode: nil,
 					})
@@ -1604,12 +1604,12 @@ func compareMaterializedViews(engine storepb.Engine, diff *MetadataDiff, schemaN
 	for _, mvName := range oldSchema.ListMaterializedViewNames() {
 		if newSchema.GetMaterializedView(mvName) == nil {
 			oldMV := oldSchema.GetMaterializedView(mvName)
-			if oldMV != nil && !oldMV.GetProto().GetSkipDump() {
+			if oldMV != nil && !oldMV.SkipDump {
 				diff.MaterializedViewChanges = append(diff.MaterializedViewChanges, &MaterializedViewDiff{
 					Action:               MetadataDiffActionDrop,
 					SchemaName:           schemaName,
 					MaterializedViewName: mvName,
-					OldMaterializedView:  oldMV.GetProto(),
+					OldMaterializedView:  oldMV,
 				})
 			}
 		}
@@ -1618,7 +1618,7 @@ func compareMaterializedViews(engine storepb.Engine, diff *MetadataDiff, schemaN
 	// Check for new and modified materialized views
 	for _, mvName := range newSchema.ListMaterializedViewNames() {
 		newMV := newSchema.GetMaterializedView(mvName)
-		if newMV == nil || newMV.GetProto().GetSkipDump() {
+		if newMV == nil || newMV.SkipDump {
 			continue
 		}
 
@@ -1628,9 +1628,9 @@ func compareMaterializedViews(engine storepb.Engine, diff *MetadataDiff, schemaN
 				Action:               MetadataDiffActionCreate,
 				SchemaName:           schemaName,
 				MaterializedViewName: mvName,
-				NewMaterializedView:  newMV.GetProto(),
+				NewMaterializedView:  newMV,
 			})
-		} else if !oldMV.GetProto().GetSkipDump() {
+		} else if !oldMV.SkipDump {
 			// Use engine-specific comparison
 			changes, err := comparer.CompareMaterializedView(oldMV, newMV)
 			if err != nil {
@@ -1640,8 +1640,8 @@ func compareMaterializedViews(engine storepb.Engine, diff *MetadataDiff, schemaN
 						Action:               MetadataDiffActionAlter,
 						SchemaName:           schemaName,
 						MaterializedViewName: mvName,
-						OldMaterializedView:  oldMV.GetProto(),
-						NewMaterializedView:  newMV.GetProto(),
+						OldMaterializedView:  oldMV,
+						NewMaterializedView:  newMV,
 					})
 				}
 			} else if len(changes) > 0 {
@@ -1659,8 +1659,8 @@ func compareMaterializedViews(engine storepb.Engine, diff *MetadataDiff, schemaN
 						Action:               MetadataDiffActionAlter,
 						SchemaName:           schemaName,
 						MaterializedViewName: mvName,
-						OldMaterializedView:  oldMV.GetProto(),
-						NewMaterializedView:  newMV.GetProto(),
+						OldMaterializedView:  oldMV,
+						NewMaterializedView:  newMV,
 					})
 				}
 				// TODO: Handle non-recreating changes like comment updates or index-only changes
@@ -1833,12 +1833,12 @@ func compareProcedures(diff *MetadataDiff, schemaName string, oldSchema, newSche
 	for _, procName := range oldSchema.ListProcedureNames() {
 		if newSchema.GetProcedure(procName) == nil {
 			oldProc := oldSchema.GetProcedure(procName)
-			if oldProc != nil && !oldProc.GetProto().GetSkipDump() {
+			if oldProc != nil && !oldProc.SkipDump {
 				diff.ProcedureChanges = append(diff.ProcedureChanges, &ProcedureDiff{
 					Action:        MetadataDiffActionDrop,
 					SchemaName:    schemaName,
 					ProcedureName: procName,
-					OldProcedure:  oldProc.GetProto(),
+					OldProcedure:  oldProc,
 				})
 			}
 		}
@@ -1847,7 +1847,7 @@ func compareProcedures(diff *MetadataDiff, schemaName string, oldSchema, newSche
 	// Check for new and modified procedures
 	for _, procName := range newSchema.ListProcedureNames() {
 		newProc := newSchema.GetProcedure(procName)
-		if newProc == nil || newProc.GetProto().GetSkipDump() {
+		if newProc == nil || newProc.SkipDump {
 			continue
 		}
 
@@ -1857,15 +1857,15 @@ func compareProcedures(diff *MetadataDiff, schemaName string, oldSchema, newSche
 				Action:        MetadataDiffActionCreate,
 				SchemaName:    schemaName,
 				ProcedureName: procName,
-				NewProcedure:  newProc.GetProto(),
+				NewProcedure:  newProc,
 			})
-		} else if !oldProc.GetProto().GetSkipDump() && !procedureDefinitionsEqual(oldProc.Definition, newProc.Definition, procName) {
+		} else if !oldProc.SkipDump && !procedureDefinitionsEqual(oldProc.Definition, newProc.Definition, procName) {
 			diff.ProcedureChanges = append(diff.ProcedureChanges, &ProcedureDiff{
 				Action:        MetadataDiffActionAlter,
 				SchemaName:    schemaName,
 				ProcedureName: procName,
-				OldProcedure:  oldProc.GetProto(),
-				NewProcedure:  newProc.GetProto(),
+				OldProcedure:  oldProc,
+				NewProcedure:  newProc,
 			})
 		}
 	}

--- a/backend/store/model/pg_searcher.go
+++ b/backend/store/model/pg_searcher.go
@@ -66,7 +66,7 @@ func (s *DatabaseSearcher) SearchIndex(name string) (string, *IndexMetadata) {
 
 // SearchView searches for a view in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (s *DatabaseSearcher) SearchView(name string) (string, *ViewMetadata) {
+func (s *DatabaseSearcher) SearchView(name string) (string, *storepb.ViewMetadata) {
 	for _, schemaName := range s.searchPath {
 		schema := s.db.GetSchemaMetadata(schemaName)
 		if schema == nil {
@@ -98,7 +98,7 @@ func (s *DatabaseSearcher) SearchExternalTable(name string) (string, *ExternalTa
 
 // SearchSequence searches for a sequence in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (s *DatabaseSearcher) SearchSequence(name string) (string, *SequenceMetadata) {
+func (s *DatabaseSearcher) SearchSequence(name string) (string, *storepb.SequenceMetadata) {
 	for _, schemaName := range s.searchPath {
 		schema := s.db.GetSchemaMetadata(schemaName)
 		if schema == nil {
@@ -114,7 +114,7 @@ func (s *DatabaseSearcher) SearchSequence(name string) (string, *SequenceMetadat
 
 // SearchMaterializedView searches for a materialized view in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (s *DatabaseSearcher) SearchMaterializedView(name string) (string, *MaterializedViewMetadata) {
+func (s *DatabaseSearcher) SearchMaterializedView(name string) (string, *storepb.MaterializedViewMetadata) {
 	for _, schemaName := range s.searchPath {
 		schema := s.db.GetSchemaMetadata(schemaName)
 		if schema == nil {
@@ -204,7 +204,7 @@ func (d *DatabaseMetadata) SearchIndex(searchPath []string, name string) (string
 
 // SearchView searches for a view in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (d *DatabaseMetadata) SearchView(searchPath []string, name string) (string, *ViewMetadata) {
+func (d *DatabaseMetadata) SearchView(searchPath []string, name string) (string, *storepb.ViewMetadata) {
 	for _, schemaName := range searchPath {
 		schema := d.GetSchemaMetadata(schemaName)
 		if schema == nil {
@@ -236,7 +236,7 @@ func (d *DatabaseMetadata) SearchExternalTable(searchPath []string, name string)
 
 // SearchSequence searches for a sequence in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (d *DatabaseMetadata) SearchSequence(searchPath []string, name string) (string, *SequenceMetadata) {
+func (d *DatabaseMetadata) SearchSequence(searchPath []string, name string) (string, *storepb.SequenceMetadata) {
 	for _, schemaName := range searchPath {
 		schema := d.GetSchemaMetadata(schemaName)
 		if schema == nil {
@@ -252,7 +252,7 @@ func (d *DatabaseMetadata) SearchSequence(searchPath []string, name string) (str
 
 // SearchMaterializedView searches for a materialized view in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (d *DatabaseMetadata) SearchMaterializedView(searchPath []string, name string) (string, *MaterializedViewMetadata) {
+func (d *DatabaseMetadata) SearchMaterializedView(searchPath []string, name string) (string, *storepb.MaterializedViewMetadata) {
 	for _, schemaName := range searchPath {
 		schema := d.GetSchemaMetadata(schemaName)
 		if schema == nil {


### PR DESCRIPTION
## Summary

This PR refactors the metadata handling for `ViewMetadata`, `MaterializedViewMetadata`, `PackageMetadata`, and `SequenceMetadata` to use auto-generated `*storepb` types directly, removing custom wrapper structs. This continues the refactoring pattern established in previous work with `ProcedureMetadata`.

## Motivation

The codebase previously used custom wrapper structs in `backend/store/model/database.go` that wrapped the auto-generated protobuf types. This created unnecessary indirection and required `GetProto()` methods to convert between the wrapper and the underlying protobuf type.

By using `*storepb` types directly, we:
- Eliminate boilerplate code
- Simplify the data model
- Reduce potential for bugs from wrapper/proto conversions
- Improve consistency across the codebase

## Changes

### Removed Custom Wrapper Structs

Deleted the following structs from `backend/store/model/database.go`:
- `ViewMetadata`
- `MaterializedViewMetadata`
- `PackageMetadata`
- `SequenceMetadata`

### Updated `backend/store/model/database.go`

**Internal storage maps:**
- `internalViews`: `map[string]*storepb.ViewMetadata`
- `internalMaterializedView`: `map[string]*storepb.MaterializedViewMetadata`
- `internalPackages`: `map[string]*storepb.PackageMetadata`
- `internalSequences`: `map[string]*storepb.SequenceMetadata`

**Method signature updates:**
- `GetView()` → returns `*storepb.ViewMetadata`
- `GetMaterializedView()` → returns `*storepb.MaterializedViewMetadata`
- `GetPackage()` → returns `*storepb.PackageMetadata`
- `GetSequence()` → returns `*storepb.SequenceMetadata`
- `GetSequencesByOwnerTable()` → returns `[]*storepb.SequenceMetadata`
- `CreateView()` → returns `*storepb.ViewMetadata`

**Removed methods:**
- `ViewMetadata.GetProto()`
- `MaterializedViewMetadata.GetProto()`
- `PackageMetadata.GetProto()`
- `SequenceMetadata.GetProto()`

### Updated Call Sites

**Store layer:**
- `backend/store/model/pg_searcher.go`: Updated search method return types to use `*storepb` types

**Schema layer:**
- `backend/plugin/schema/differ.go`: Removed all `GetProto()` calls in diff logic
- `backend/plugin/schema/view_comparer.go`: Updated `ViewComparer` interface to accept `*storepb` types
- `backend/plugin/schema/pg/view_comparer.go`: Updated PostgreSQL-specific view comparer implementation

**API layer:**
- `backend/api/v1/database_service.go`: Removed `GetProto()` calls in `GetSchemaString()` for VIEW, MATERIALIZED_VIEW, and SEQUENCE types

**Parser layer:**
- `backend/plugin/parser/mysql/query_span_extractor.go`
- `backend/plugin/parser/pg/query_span_extractor.go`
- `backend/plugin/parser/plsql/query_span_extractor.go`
- `backend/plugin/parser/tidb/query_span_extractor.go`
- `backend/plugin/parser/trino/query_span_extractor.go`
- `backend/plugin/parser/tsql/query_span_extractor.go`

All parser files updated to use `*storepb` types directly and removed `GetProto()` calls.

## Testing

✅ **Build**: `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`  
✅ **Tests**: `go test -v -count=1 github.com/bytebase/bytebase/backend/store/model github.com/bytebase/bytebase/backend/plugin/schema`

All existing tests pass without modification.

## Impact

- **12 files changed**
- **142 insertions(+), 223 deletions(-)**
- **Net reduction of 81 lines**

## Migration Notes

This is a refactoring change with no breaking changes to external APIs. All changes are internal to the backend implementation.
