### PR TITLE
fix: pre-select database group in change database drawer

### DIFF
--- a/frontend/src/views/project/ProjectDatabaseGroupDetail.vue
+++ b/frontend/src/views/project/ProjectDatabaseGroupDetail.vue
@@ -47,6 +47,7 @@
       v-model:show="state.showChangeDatabaseDrawer"
       :title="$t('database.change-database')"
       :project-name="project.name"
+      :pre-selected-database-group="databaseGroupResourceName"
       :use-legacy-issue-flow="true"
     />
   </div>


### PR DESCRIPTION
When clicking "Change Database" on a database group detail page, the drawer now automatically pre-selects the database group instead of requiring users to manually select targets. The issue title also correctly displays the database group's display name.

Changes:
- Add preSelectedDatabaseGroup prop to AddSpecDrawer component
- Initialize drawer with GROUP change source when database group is pre-selected
- Pass database group resource name from ProjectDatabaseGroupDetail to drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)