### PR TITLE
refactor: remove columns and rowCount fields from TableMetadata

### DIFF
--- a/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
@@ -164,7 +164,7 @@ func (r *ColumnDisallowDropInIndexRule) checkAlterTable(ctx *mysql.AlterTableCon
 				r.tables[tableName] = make(columnSet)
 			}
 			for _, indexColumn := range table.ListIndexes() {
-				for _, column := range indexColumn.ExpressionList() {
+				for _, column := range indexColumn.GetProto().GetExpressions() {
 					r.tables[tableName][column] = true
 				}
 			}

--- a/backend/plugin/advisor/mysql/rule_naming_index_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_index_convention.go
@@ -191,12 +191,12 @@ func (r *NamingIndexConventionRule) checkAlterTable(ctx *mysql.AlterTableContext
 			if indexState == nil {
 				continue
 			}
-			if indexState.Unique() {
+			if indexState.GetProto().GetUnique() {
 				// Unique index naming convention should in advisor_naming_unique_key_convention.go
 				continue
 			}
 			metaData := map[string]string{
-				advisor.ColumnListTemplateToken: strings.Join(indexState.ExpressionList(), "_"),
+				advisor.ColumnListTemplateToken: strings.Join(indexState.GetProto().GetExpressions(), "_"),
 				advisor.TableNameTemplateToken:  tableName,
 			}
 			indexData := &indexMetaData{

--- a/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
@@ -192,10 +192,10 @@ func (r *NamingUKConventionRule) checkAlterTable(ctx *mysql.AlterTableContext) {
 			if indexState == nil {
 				continue
 			}
-			if !indexState.Unique() {
+			if !indexState.GetProto().GetUnique() {
 				continue
 			}
-			columnList := indexState.ExpressionList()
+			columnList := indexState.GetProto().GetExpressions()
 			metaData := map[string]string{
 				advisor.ColumnListTemplateToken: strings.Join(columnList, "_"),
 				advisor.TableNameTemplateToken:  tableName,

--- a/backend/plugin/advisor/mysql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_pk.go
@@ -255,7 +255,7 @@ func (r *TableRequirePKRule) dropColumn(tableName string, columnName string) boo
 		if pk == nil {
 			return false
 		}
-		r.tables[tableName] = newColumnSet(pk.ExpressionList())
+		r.tables[tableName] = newColumnSet(pk.GetProto().GetExpressions())
 	}
 
 	pk := r.tables[tableName]

--- a/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
+++ b/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
@@ -176,7 +176,7 @@ func (r *TableTextFieldsTotalLengthRule) checkAlterTable(ctx *mysql.AlterTableCo
 
 func getTotalTextLength(tableInfo *model.TableMetadata) int64 {
 	var total int64
-	columns := tableInfo.GetColumns()
+	columns := tableInfo.GetProto().GetColumns()
 	for _, column := range columns {
 		total += getTextLength(column.Type)
 	}

--- a/backend/plugin/advisor/pg/advisor_column_no_null.go
+++ b/backend/plugin/advisor/pg/advisor_column_no_null.go
@@ -317,7 +317,7 @@ func (r *columnNoNullRule) removeColumnByTableConstraint(schema, table string, c
 					}
 				}
 				if index != nil {
-					for _, expression := range index.ExpressionList() {
+					for _, expression := range index.GetProto().GetExpressions() {
 						r.removeColumn(schema, table, expression)
 					}
 				}

--- a/backend/plugin/advisor/pg/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_index_convention.go
@@ -176,8 +176,8 @@ func (r *namingIndexConventionRule) handleRenamestmt(ctx antlr.ParserRuleContext
 			tableName, index := r.findIndex("", "", oldIndexName)
 			if index != nil {
 				// Only check if it's a regular index (not unique, not primary)
-				if !index.Unique() && !index.Primary() {
-					r.checkIndexName(newIndexName, tableName, index.ExpressionList(), renamestmtCtx.GetStart().GetLine())
+				if !index.GetProto().GetUnique() && !index.GetProto().GetPrimary() {
+					r.checkIndexName(newIndexName, tableName, index.GetProto().GetExpressions(), renamestmtCtx.GetStart().GetLine())
 				}
 			}
 		}

--- a/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
@@ -197,9 +197,9 @@ func (r *namingPKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 					normalizedSchema = "public"
 				}
 				index := r.originalMetadata.GetSchemaMetadata(normalizedSchema).GetTable(tableName).GetIndex(oldName)
-				if index != nil && index.Primary() {
+				if index != nil && index.GetProto().GetPrimary() {
 					metaData := map[string]string{
-						advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
+						advisor.ColumnListTemplateToken: strings.Join(index.GetProto().GetExpressions(), "_"),
 						advisor.TableNameTemplateToken:  tableName,
 					}
 					pkData := &pkMetaData{
@@ -250,9 +250,9 @@ func (r *namingPKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 						tableName = index.GetTableProto().Name
 					}
 				}
-				if index != nil && index.Primary() {
+				if index != nil && index.GetProto().GetPrimary() {
 					metaData := map[string]string{
-						advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
+						advisor.ColumnListTemplateToken: strings.Join(index.GetProto().GetExpressions(), "_"),
 						advisor.TableNameTemplateToken:  tableName,
 					}
 					pkData := &pkMetaData{
@@ -329,7 +329,7 @@ func (r *namingPKConventionRule) getPKMetaDataFromTableConstraint(constraint par
 					}
 				}
 				if index != nil {
-					columnList = index.ExpressionList()
+					columnList = index.GetProto().GetExpressions()
 				}
 			}
 		}

--- a/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
@@ -237,9 +237,9 @@ func (r *namingUKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 		// Look up the index in catalog to determine if it's a unique key
 		if r.originalMetadata != nil && oldIndexName != "" {
 			tableName, index := r.findIndex("", "", oldIndexName)
-			if index != nil && index.Unique() && !index.Primary() {
+			if index != nil && index.GetProto().GetUnique() && !index.GetProto().GetPrimary() {
 				r.checkUniqueKeyName(newIndexName, tableName, map[string]string{
-					advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
+					advisor.ColumnListTemplateToken: strings.Join(index.GetProto().GetExpressions(), "_"),
 					advisor.TableNameTemplateToken:  tableName,
 				}, ctx.GetStart().GetLine())
 			}
@@ -262,9 +262,9 @@ func (r *namingUKConventionRule) handleRenamestmt(ctx *parser.RenamestmtContext)
 
 			// Check if this is a unique key constraint in catalog
 			foundTableName, index := r.findIndex(schemaName, tableName, oldConstraintName)
-			if index != nil && index.Unique() && !index.Primary() {
+			if index != nil && index.GetProto().GetUnique() && !index.GetProto().GetPrimary() {
 				metaData := map[string]string{
-					advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
+					advisor.ColumnListTemplateToken: strings.Join(index.GetProto().GetExpressions(), "_"),
 					advisor.TableNameTemplateToken:  foundTableName,
 				}
 				r.checkUniqueKeyName(newConstraintName, foundTableName, metaData, ctx.GetStart().GetLine())
@@ -309,7 +309,7 @@ func (r *namingUKConventionRule) checkTableConstraint(constraint parser.ITableco
 					}
 				}
 				if index != nil {
-					columnList = index.ExpressionList()
+					columnList = index.GetProto().GetExpressions()
 				}
 			}
 

--- a/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/tidb/advisor_column_disallow_drop_in_index.go
@@ -94,7 +94,7 @@ func (checker *columnDisallowDropInIndexChecker) dropColumn(in ast.Node) (ast.No
 						checker.tables[table] = make(columnSet)
 					}
 					for _, indexColumn := range tableMetadata.ListIndexes() {
-						for _, column := range indexColumn.ExpressionList() {
+						for _, column := range indexColumn.GetProto().GetExpressions() {
 							checker.tables[table][column] = true
 						}
 					}

--- a/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_index_convention.go
@@ -159,12 +159,12 @@ func (checker *namingIndexConventionChecker) getMetaDataList(in ast.Node) []*ind
 				if index == nil {
 					continue
 				}
-				if index.Unique() {
+				if index.GetProto().GetUnique() {
 					// Unique index naming convention should in advisor_naming_unique_key_convention.go
 					continue
 				}
 				metaData := map[string]string{
-					advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
+					advisor.ColumnListTemplateToken: strings.Join(index.GetProto().GetExpressions(), "_"),
 					advisor.TableNameTemplateToken:  node.Table.Name.String(),
 				}
 				res = append(res, &indexMetaData{

--- a/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_unique_key_convention.go
@@ -150,12 +150,12 @@ func (checker *namingUKConventionChecker) getMetaDataList(in ast.Node) []*indexM
 				if index == nil {
 					continue
 				}
-				if !index.Unique() {
+				if !index.GetProto().GetUnique() {
 					// Index naming convention should in advisor_naming_index_convention.go
 					continue
 				}
 				metaData := map[string]string{
-					advisor.ColumnListTemplateToken: strings.Join(index.ExpressionList(), "_"),
+					advisor.ColumnListTemplateToken: strings.Join(index.GetProto().GetExpressions(), "_"),
 					advisor.TableNameTemplateToken:  node.Table.Name.String(),
 				}
 				res = append(res, &indexMetaData{

--- a/backend/plugin/advisor/tidb/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/tidb/advisor_table_require_pk.go
@@ -188,7 +188,7 @@ func (v *tableRequirePKChecker) createTableLike(node *ast.CreateTableStmt) {
 			if referTableMetadata != nil {
 				primaryKey := referTableMetadata.GetPrimaryKey()
 				if primaryKey != nil {
-					v.tables[table] = newColumnSet(primaryKey.ExpressionList())
+					v.tables[table] = newColumnSet(primaryKey.GetProto().GetExpressions())
 				}
 			}
 		}
@@ -201,7 +201,7 @@ func (v *tableRequirePKChecker) dropColumn(table string, column string) bool {
 		if pk == nil {
 			return false
 		}
-		v.tables[table] = newColumnSet(pk.ExpressionList())
+		v.tables[table] = newColumnSet(pk.GetProto().GetExpressions())
 	}
 
 	pk := v.tables[table]

--- a/backend/plugin/parser/bigquery/query_span_extractor.go
+++ b/backend/plugin/parser/bigquery/query_span_extractor.go
@@ -1145,7 +1145,7 @@ func (q *querySpanExtractor) findTableSchema(datasetName string, tableName strin
 	}
 
 	var columns []string
-	for _, column := range table.GetColumns() {
+	for _, column := range table.GetProto().GetColumns() {
 		columns = append(columns, column.Name)
 	}
 	return &base.PhysicalTable{

--- a/backend/plugin/parser/cassandra/query_span_extractor.go
+++ b/backend/plugin/parser/cassandra/query_span_extractor.go
@@ -203,7 +203,7 @@ func (e *querySpanExtractor) expandSelectAsterisk(keyspace, table string) []base
 
 		tbl := schema.GetTable(table)
 		if tbl != nil {
-			for _, col := range tbl.GetColumns() {
+			for _, col := range tbl.GetProto().GetColumns() {
 				sourceColumn := base.SourceColumnSet{}
 				sourceColumn[base.ColumnResource{
 					Database: keyspace,

--- a/backend/plugin/parser/mysql/backup.go
+++ b/backend/plugin/parser/mysql/backup.go
@@ -326,7 +326,7 @@ func classifyColumns(ctx context.Context, getDatabaseMetadataFunc base.GetDataba
 	}
 
 	var generatedColumns, normalColumns []string
-	for _, column := range tableSchema.GetColumns() {
+	for _, column := range tableSchema.GetProto().GetColumns() {
 		if column.GetGeneration() != nil {
 			generatedColumns = append(generatedColumns, column.GetName())
 		} else {

--- a/backend/plugin/parser/mysql/completion.go
+++ b/backend/plugin/parser/mysql/completion.go
@@ -1417,7 +1417,7 @@ func (m CompletionMap) insertColumns(c *Completer, databases, tables map[string]
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s | %s", table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"
@@ -1454,7 +1454,7 @@ func (m CompletionMap) insertAllColumns(c *Completer) {
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s | %s", table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"

--- a/backend/plugin/parser/mysql/query_span_extractor.go
+++ b/backend/plugin/parser/mysql/query_span_extractor.go
@@ -1372,8 +1372,8 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 		tableSchema = schema.GetTable(tableName)
 	}
 	if tableSchema != nil {
-		columnNames := make([]string, 0, len(tableSchema.GetColumns()))
-		for _, column := range tableSchema.GetColumns() {
+		columnNames := make([]string, 0, len(tableSchema.GetProto().GetColumns()))
+		for _, column := range tableSchema.GetProto().GetColumns() {
 			columnNames = append(columnNames, column.Name)
 		}
 		return &base.PhysicalTable{

--- a/backend/plugin/parser/partiql/completion.go
+++ b/backend/plugin/parser/partiql/completion.go
@@ -136,7 +136,7 @@ func (m CompletionMap) insertMetadataColumns(c *Completer) {
 			if table == nil {
 				return
 			}
-			for _, column := range table.GetColumns() {
+			for _, column := range table.GetProto().GetColumns() {
 				if _, ok := m[column.Name]; !ok {
 					m.Insert(base.Candidate{
 						Type: base.CandidateTypeColumn,

--- a/backend/plugin/parser/pg/completion.go
+++ b/backend/plugin/parser/pg/completion.go
@@ -409,7 +409,7 @@ func (m CompletionMap) insertColumns(c *Completer, schemas, tables map[string]bo
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"
@@ -446,7 +446,7 @@ func (m CompletionMap) insertAllColumns(c *Completer) {
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"

--- a/backend/plugin/parser/pg/query_span_extractor.go
+++ b/backend/plugin/parser/pg/query_span_extractor.go
@@ -1219,7 +1219,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 
 	if table != nil {
 		var columns []string
-		for _, column := range table.GetColumns() {
+		for _, column := range table.GetProto().GetColumns() {
 			columns = append(columns, column.Name)
 		}
 		return &base.PhysicalTable{
@@ -1233,7 +1233,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 
 	if foreignTable != nil {
 		var columns []string
-		for _, column := range foreignTable.GetColumns() {
+		for _, column := range foreignTable.GetProto().GetColumns() {
 			columns = append(columns, column.Name)
 		}
 		return &base.PhysicalTable{

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -360,7 +360,7 @@ func (m CompletionMap) insertAllColumns(c *Completer) {
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"
@@ -406,7 +406,7 @@ func (m CompletionMap) insertColumns(c *Completer, schemas, tables map[string]bo
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"

--- a/backend/plugin/parser/plsql/query_span_extractor.go
+++ b/backend/plugin/parser/plsql/query_span_extractor.go
@@ -1334,7 +1334,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbMeta
 
 	if table != nil {
 		var columns []string
-		for _, column := range table.GetColumns() {
+		for _, column := range table.GetProto().GetColumns() {
 			columns = append(columns, column.Name)
 		}
 		return &base.PhysicalTable{
@@ -1347,7 +1347,7 @@ func (q *querySpanExtractor) findTableSchemaInMetadata(instanceID string, dbMeta
 
 	if foreignTable != nil {
 		var columns []string
-		for _, column := range foreignTable.GetColumns() {
+		for _, column := range foreignTable.GetProto().GetColumns() {
 			columns = append(columns, column.Name)
 		}
 		return &base.PhysicalTable{

--- a/backend/plugin/parser/plsql/restore.go
+++ b/backend/plugin/parser/plsql/restore.go
@@ -224,7 +224,7 @@ func (g *generator) EnterUpdate_statement(ctx *parser.Update_statementContext) {
 		g.err = err
 		return
 	}
-	for i, column := range g.table.GetColumns() {
+	for i, column := range g.table.GetProto().GetColumns() {
 		if i > 0 {
 			if _, err := fmt.Fprint(&buf, ", "); err != nil {
 				g.err = err
@@ -240,7 +240,7 @@ func (g *generator) EnterUpdate_statement(ctx *parser.Update_statementContext) {
 		g.err = err
 		return
 	}
-	for i, column := range g.table.GetColumns() {
+	for i, column := range g.table.GetProto().GetColumns() {
 		if i > 0 {
 			if _, err := fmt.Fprint(&buf, ", "); err != nil {
 				g.err = err

--- a/backend/plugin/parser/redshift/completion.go
+++ b/backend/plugin/parser/redshift/completion.go
@@ -418,7 +418,7 @@ func (m CompletionMap) insertColumns(c *Completer, schemas, tables map[string]bo
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"
@@ -455,7 +455,7 @@ func (m CompletionMap) insertAllColumns(c *Completer) {
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
 				if !column.Nullable {
 					definition += ", NOT NULL"

--- a/backend/plugin/parser/snowflake/query_span_extractor.go
+++ b/backend/plugin/parser/snowflake/query_span_extractor.go
@@ -1118,7 +1118,7 @@ func (q *querySpanExtractor) findTableSchema(objectName parser.IObject_nameConte
 				if tableSchema == nil {
 					return "", nil, errors.Errorf(`table %s.%s.%s is not found`, normalizedDatabaseName, normalizedSchemaName, normalizedTableName)
 				}
-				columns := tableSchema.GetColumns()
+				columns := tableSchema.GetProto().GetColumns()
 				return normalizedDatabaseName, &base.PhysicalTable{
 					Name:     tableSchema.GetProto().Name,
 					Database: normalizedDatabaseName,

--- a/backend/plugin/parser/spanner/query_span_extractor.go
+++ b/backend/plugin/parser/spanner/query_span_extractor.go
@@ -1130,7 +1130,7 @@ func (q *querySpanExtractor) findTableSchema(schemaName string, tableName string
 	}
 
 	var columns []string
-	for _, column := range table.GetColumns() {
+	for _, column := range table.GetProto().GetColumns() {
 		columns = append(columns, column.Name)
 	}
 	return &base.PhysicalTable{

--- a/backend/plugin/parser/tidb/backup.go
+++ b/backend/plugin/parser/tidb/backup.go
@@ -321,7 +321,7 @@ func classifyColumns(ctx context.Context, getDatabaseMetadataFunc base.GetDataba
 	}
 
 	var generatedColumns, normalColumns []string
-	for _, column := range tableSchema.GetColumns() {
+	for _, column := range tableSchema.GetProto().GetColumns() {
 		if column.GetGeneration() != nil {
 			generatedColumns = append(generatedColumns, column.GetName())
 		} else {

--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -820,7 +820,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName string, tableName stri
 			var columns []string
 			tableMeta := schema.GetTable(table)
 			if tableMeta != nil {
-				for _, column := range tableMeta.GetColumns() {
+				for _, column := range tableMeta.GetProto().GetColumns() {
 					columns = append(columns, column.Name)
 				}
 				return &base.PhysicalTable{

--- a/backend/plugin/parser/trino/completion.go
+++ b/backend/plugin/parser/trino/completion.go
@@ -233,7 +233,7 @@ func (m CompletionMap) insertAllColumns(c *Completer) {
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				columnID := getColumnID(c.defaultCatalog, schema, table, column.Name)
 				if _, ok := m[columnID]; !ok {
 					definition := fmt.Sprintf("%s.%s.%s | %s", c.defaultCatalog, schema, table, column.Type)
@@ -323,7 +323,7 @@ func (m CompletionMap) insertMetadataColumns(c *Completer, catalog string, schem
 	}
 	for _, table := range tableNames {
 		tableMetadata := schemaMetadata.GetTable(table)
-		for _, column := range tableMetadata.GetColumns() {
+		for _, column := range tableMetadata.GetProto().GetColumns() {
 			columnID := getColumnID(catalogName, schemaName, table, column.Name)
 			if _, ok := m[columnID]; !ok {
 				definition := fmt.Sprintf("%s.%s.%s | %s", catalogName, schemaName, table, column.Type)

--- a/backend/plugin/parser/trino/query_span_extractor.go
+++ b/backend/plugin/parser/trino/query_span_extractor.go
@@ -206,7 +206,7 @@ func (q *querySpanExtractor) expandTableReferencesToColumns(accessTables base.So
 			tableMeta, err := q.findTableSchema(db, schema, table)
 			if err == nil && tableMeta != nil {
 				// Add each column from the table as a source column with full path
-				for _, col := range tableMeta.GetColumns() {
+				for _, col := range tableMeta.GetProto().GetColumns() {
 					colResource := base.ColumnResource{
 						Database: db,
 						Schema:   schema,

--- a/backend/plugin/parser/trino/query_span_listener.go
+++ b/backend/plugin/parser/trino/query_span_listener.go
@@ -115,7 +115,7 @@ func (l *trinoQuerySpanListener) EnterTableName(ctx *parser.TableNameContext) {
 
 	// Create physical table with column names from metadata
 	var columnNames []string
-	for _, col := range tableMeta.GetColumns() {
+	for _, col := range tableMeta.GetProto().GetColumns() {
 		columnNames = append(columnNames, col.Name)
 	}
 
@@ -128,7 +128,7 @@ func (l *trinoQuerySpanListener) EnterTableName(ctx *parser.TableNameContext) {
 	l.extractor.tableSourcesFrom = append(l.extractor.tableSourcesFrom, physicalTable)
 
 	// Add each column from the table as a source column
-	for _, col := range tableMeta.GetColumns() {
+	for _, col := range tableMeta.GetProto().GetColumns() {
 		colResource := base.ColumnResource{
 			Database: db,
 			Schema:   schema,

--- a/backend/plugin/parser/tsql/completion.go
+++ b/backend/plugin/parser/tsql/completion.go
@@ -291,7 +291,7 @@ func (m CompletionMap) insertAllColumns(c *Completer) {
 			if tableMeta == nil {
 				continue
 			}
-			for _, column := range tableMeta.GetColumns() {
+			for _, column := range tableMeta.GetProto().GetColumns() {
 				columnID := getColumnID(c.defaultDatabase, schema, table, column.Name)
 				if _, ok := m[columnID]; !ok {
 					definition := fmt.Sprintf("%s.%s.%s | %s", c.defaultDatabase, schema, table, column.Type)
@@ -384,7 +384,7 @@ func (m CompletionMap) insertMetadataColumns(c *Completer, linkedServer string, 
 	}
 	for _, table := range tableNames {
 		tableMetadata := schemaMetadata.GetTable(table)
-		for _, column := range tableMetadata.GetColumns() {
+		for _, column := range tableMetadata.GetProto().GetColumns() {
 			columnID := getColumnID(databaseName, schemaName, table, column.Name)
 			if _, ok := m[columnID]; !ok {
 				definition := fmt.Sprintf("%s.%s.%s | %s", databaseName, schemaName, table, column.Type)

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -709,7 +709,7 @@ func (q *querySpanExtractor) tsqlFindTableSchema(fullTableName parser.IFull_tabl
 					Name:     table.GetProto().Name,
 					Columns: func() []string {
 						var result []string
-						for _, column := range table.GetColumns() {
+						for _, column := range table.GetProto().GetColumns() {
 							result = append(result, column.Name)
 						}
 						return result

--- a/backend/plugin/parser/tsql/restore.go
+++ b/backend/plugin/parser/tsql/restore.go
@@ -126,7 +126,7 @@ func (g *generator) hasIdentityColumn() bool {
 	if g.table == nil {
 		return false
 	}
-	for _, col := range g.table.GetColumns() {
+	for _, col := range g.table.GetProto().GetColumns() {
 		if col.IsIdentity {
 			return true
 		}
@@ -148,7 +148,7 @@ func (g *generator) EnterDelete_statement(ctx *parser.Delete_statementContext) {
 
 			// Build column list
 			var columnList strings.Builder
-			for i, column := range g.table.GetColumns() {
+			for i, column := range g.table.GetProto().GetColumns() {
 				if i > 0 {
 					columnList.WriteString(", ")
 				}
@@ -277,7 +277,7 @@ func (g *generator) EnterUpdate_statement(ctx *parser.Update_statementContext) {
 			g.err = err
 			return
 		}
-		for i, column := range g.table.GetColumns() {
+		for i, column := range g.table.GetProto().GetColumns() {
 			if i > 0 {
 				if _, err := fmt.Fprint(&buf, ", "); err != nil {
 					g.err = err
@@ -293,7 +293,7 @@ func (g *generator) EnterUpdate_statement(ctx *parser.Update_statementContext) {
 			g.err = err
 			return
 		}
-		for i, column := range g.table.GetColumns() {
+		for i, column := range g.table.GetProto().GetColumns() {
 			if i > 0 {
 				if _, err := fmt.Fprint(&buf, ", "); err != nil {
 					g.err = err

--- a/backend/plugin/schema/differ.go
+++ b/backend/plugin/schema/differ.go
@@ -618,8 +618,8 @@ func compareTableDetails(engine storepb.Engine, schemaName, tableName string, ol
 func compareColumns(engine storepb.Engine, oldTable, newTable *model.TableMetadata) []*ColumnDiff {
 	var changes []*ColumnDiff
 
-	oldColumns := oldTable.GetColumns()
-	newColumns := newTable.GetColumns()
+	oldColumns := oldTable.GetProto().GetColumns()
+	newColumns := newTable.GetProto().GetColumns()
 
 	// Check for dropped columns
 	for _, oldCol := range oldColumns {

--- a/backend/plugin/schema/mysql/walk_through.go
+++ b/backend/plugin/schema/mysql/walk_through.go
@@ -1155,7 +1155,7 @@ func mysqlCopyTable(d *model.DatabaseMetadata, databaseName, tableName, referTab
 	newTableProto.Comment = targetProto.Comment
 
 	// Copy columns
-	for _, col := range targetTable.GetColumns() {
+	for _, col := range targetTable.GetProto().GetColumns() {
 		colCopy, ok := proto.Clone(col).(*storepb.ColumnMetadata)
 		if !ok {
 			return &storepb.Advice{
@@ -1456,7 +1456,7 @@ func mysqlCreateColumn(table *model.TableMetadata, columnName string, fieldDef m
 
 	col := &storepb.ColumnMetadata{
 		Name:         columnName,
-		Position:     int32(len(table.GetColumns()) + 1),
+		Position:     int32(len(table.GetProto().GetColumns()) + 1),
 		Default:      "",
 		Nullable:     true,
 		Type:         columnType,

--- a/backend/plugin/schema/pg/walk_through.go
+++ b/backend/plugin/schema/pg/walk_through.go
@@ -195,7 +195,7 @@ func pgCreateColumn(schema *model.SchemaMetadata, table *model.TableMetadata, co
 	// Create column metadata
 	col := &storepb.ColumnMetadata{
 		Name:     columnName,
-		Position: int32(len(table.GetColumns()) + 1),
+		Position: int32(len(table.GetProto().GetColumns()) + 1),
 		Default:  "",
 		Nullable: true,
 		Type:     columnType,
@@ -847,7 +847,7 @@ func (l *pgCatalogListener) alterTableAddColumn(schema *model.SchemaMetadata, ta
 	// Create column metadata
 	col := &storepb.ColumnMetadata{
 		Name:     columnName,
-		Position: int32(len(table.GetColumns()) + 1),
+		Position: int32(len(table.GetProto().GetColumns()) + 1),
 		Nullable: true,
 		Type:     typeString,
 		Default:  "",

--- a/backend/plugin/schema/tidb/walk_through.go
+++ b/backend/plugin/schema/tidb/walk_through.go
@@ -735,9 +735,9 @@ func tidbChangeColumn(t *model.TableMetadata, oldName string, newColumn *tidbast
 func tidbReorderColumn(t *model.TableMetadata, position *tidbast.ColumnPosition) (int, *storepb.Advice) {
 	switch position.Tp {
 	case tidbast.ColumnPositionNone:
-		return len(t.GetColumns()) + 1, nil
+		return len(t.GetProto().GetColumns()) + 1, nil
 	case tidbast.ColumnPositionFirst:
-		for _, column := range t.GetColumns() {
+		for _, column := range t.GetProto().GetColumns() {
 			column.Position++
 		}
 		return 1, nil
@@ -754,7 +754,7 @@ func tidbReorderColumn(t *model.TableMetadata, position *tidbast.ColumnPosition)
 				StartPosition: &storepb.Position{Line: 0},
 			}
 		}
-		for _, col := range t.GetColumns() {
+		for _, col := range t.GetProto().GetColumns() {
 			if col.Position > column.Position {
 				col.Position++
 			}
@@ -851,7 +851,7 @@ func tidbCopyTable(d *model.DatabaseMetadata, node *tidbast.CreateTableStmt) *st
 	}
 
 	// Copy columns and indexes from the target table
-	for _, col := range targetTable.GetColumns() {
+	for _, col := range targetTable.GetProto().GetColumns() {
 		colCopy, ok := proto.Clone(col).(*storepb.ColumnMetadata)
 		if !ok {
 			return &storepb.Advice{
@@ -1133,7 +1133,7 @@ func tidbCreateColumnHelper(t *model.TableMetadata, column *tidbast.ColumnDef, p
 		}
 	}
 
-	pos := len(t.GetColumns()) + 1
+	pos := len(t.GetProto().GetColumns()) + 1
 	if position != nil {
 		var err *storepb.Advice
 		pos, err = tidbReorderColumn(t, position)

--- a/backend/store/model/changed_resources.go
+++ b/backend/store/model/changed_resources.go
@@ -51,7 +51,7 @@ func (r *ChangedResources) Build() *storepb.ChangedResources {
 				}
 				tableMetadata := schemaMetadata.GetTable(table.GetName())
 				if tableMetadata != nil {
-					table.TableRows = tableMetadata.GetRowCount()
+					table.TableRows = tableMetadata.GetProto().GetRowCount()
 				}
 			}
 		}
@@ -248,7 +248,7 @@ func (r *ChangedResources) CountAffectedTableRows() int64 {
 				if tableMeta == nil {
 					continue
 				}
-				totalAffectedRows += tableMeta.GetRowCount()
+				totalAffectedRows += tableMeta.GetProto().GetRowCount()
 			}
 		}
 	}

--- a/backend/store/model/database_test.go
+++ b/backend/store/model/database_test.go
@@ -87,7 +87,7 @@ func TestBuildTablesMetadata(t *testing.T) {
 
 		// Each table should have the same columns as the input.
 		for _, table := range tables {
-			a.Equal(len(table.GetColumns()), len(tc.wantColumns))
+			a.Equal(len(table.GetProto().GetColumns()), len(tc.wantColumns))
 			for _, column := range tc.wantColumns {
 				a.NotNil(table.GetColumn(column.Name))
 			}


### PR DESCRIPTION
## Summary

Remove redundant wrapper fields from `TableMetadata` struct and update all callers to use proto getters directly. This simplifies the code by storing data only in the proto field rather than duplicating it in separate wrapper fields.

## Changes

### 1. Removed wrapper fields from TableMetadata
- Removed `columns []*storepb.ColumnMetadata` field
- Removed `rowCount int64` field  
- Removed `GetColumns()` and `GetRowCount()` wrapper methods
- Kept only `proto *storepb.TableMetadata` which contains all the data

### 2. Removed IndexMetadata wrapper methods (from previous commit)
- Removed `Primary() bool`
- Removed `Unique() bool`
- Removed `ExpressionList() []string`

### 3. Updated all callers
Changed callers to use proto getters:
- `tableMetadata.GetColumns()` → `tableMetadata.GetProto().GetColumns()`
- `tableMetadata.GetRowCount()` → `tableMetadata.GetProto().GetRowCount()`
- `index.Primary()` → `index.GetProto().GetPrimary()`
- `index.Unique()` → `index.GetProto().GetUnique()`
- `index.ExpressionList()` → `index.GetProto().GetExpressions()`

### Files Modified
- 42 files changed
- 77 insertions(+), 125 deletions(-)

### Testing
- ✅ All store/model tests pass (9 tests)
- ✅ All plugin tests pass (77 packages)
- ✅ Build successful
- ✅ golangci-lint passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)