### PR TITLE
refactor: remove columns field from ExternalTableMetadata

### DIFF
--- a/backend/store/model/database.go
+++ b/backend/store/model/database.go
@@ -71,7 +71,6 @@ type TableConfig struct {
 type ExternalTableMetadata struct {
 	isDetailCaseSensitive bool
 	internal              map[string]*storepb.ColumnMetadata
-	columns               []*storepb.ColumnMetadata
 	proto                 *storepb.ExternalTableMetadata
 }
 
@@ -139,7 +138,6 @@ func NewDatabaseMetadata(
 			for _, column := range externalTable.Columns {
 				columnID := normalizeNameByCaseSensitivity(column.Name, isDetailCaseSensitive)
 				externalTableMetadata.internal[columnID] = column
-				externalTableMetadata.columns = append(externalTableMetadata.columns, column)
 			}
 			tableID := normalizeNameByCaseSensitivity(externalTable.Name, isObjectCaseSensitive)
 			schemaMetadata.internalExternalTable[tableID] = externalTableMetadata
@@ -1097,11 +1095,6 @@ func (t *ExternalTableMetadata) GetProto() *storepb.ExternalTableMetadata {
 func (t *ExternalTableMetadata) GetColumn(name string) *storepb.ColumnMetadata {
 	nameID := normalizeNameByCaseSensitivity(name, t.isDetailCaseSensitive)
 	return t.internal[nameID]
-}
-
-// GetColumns gets the columns.
-func (t *ExternalTableMetadata) GetColumns() []*storepb.ColumnMetadata {
-	return t.columns
 }
 
 func (i *IndexMetadata) GetProto() *storepb.IndexMetadata {


### PR DESCRIPTION
## Summary

Remove redundant `columns` field from `ExternalTableMetadata` struct, following the same refactoring pattern applied to `TableMetadata` in #18148.

This eliminates duplicate data storage while maintaining all necessary functionality.

## Changes

- Removed `columns` field from `ExternalTableMetadata` struct
- Removed `GetColumns()` wrapper method
- Updated initialization code to skip columns slice population
- Retained `internal` map for fast lookups
- Retained `GetProto()` method for accessing column data

## Benefits

- **Simpler code**: Single source of truth for column data (stored only in proto)
- **Reduced memory usage**: Eliminates duplicate slice for every external table
- **Consistency**: Matches the pattern used by `TableMetadata`
- **No breaking changes**: No external callers affected

## Migration Path

Callers can use `externalTable.GetProto().GetColumns()` instead (pattern already used throughout codebase).

## Testing

- ✅ All store/model tests pass
- ✅ PostgreSQL parser tests pass (including external table handling)
- ✅ Backend builds successfully
- ✅ No breaking changes to existing code

## Related

- Follows the same pattern as #18148 (TableMetadata refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)