### PR TITLE
refactor: remove functions field from SchemaMetadata

### DIFF
--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -1196,7 +1196,13 @@ func (s *DatabaseService) GetSchemaString(ctx context.Context, req *connect.Requ
 		if schemaMetadata == nil {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("schema %q not found", req.Msg.Schema))
 		}
-		functionMetadata := schemaMetadata.GetFunction(req.Msg.Object)
+		var functionMetadata *storepb.FunctionMetadata
+		for _, fn := range schemaMetadata.GetProto().GetFunctions() {
+			if fn.Name == req.Msg.Object {
+				functionMetadata = fn
+				break
+			}
+		}
 		if functionMetadata == nil {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("function %q not found", req.Msg.Object))
 		}

--- a/backend/plugin/schema/differ.go
+++ b/backend/plugin/schema/differ.go
@@ -418,7 +418,7 @@ func addNewSchemaObjects(diff *MetadataDiff, schemaName string, schema *model.Sc
 	}
 
 	// Add all functions
-	for _, function := range schema.ListFunctions() {
+	for _, function := range schema.GetProto().GetFunctions() {
 		if !function.GetSkipDump() {
 			// Use signature if available, otherwise fall back to name
 			functionName := function.Signature
@@ -1678,7 +1678,7 @@ func compareFunctions(engine storepb.Engine, diff *MetadataDiff, schemaName stri
 	// Group functions by signature to properly match overloaded functions
 	// Build map of old functions by signature
 	oldFuncsBySignature := make(map[string]*storepb.FunctionMetadata)
-	for _, fn := range oldSchema.ListFunctions() {
+	for _, fn := range oldSchema.GetProto().GetFunctions() {
 		if !fn.GetSkipDump() {
 			sig := fn.Signature
 			if sig == "" {
@@ -1690,7 +1690,7 @@ func compareFunctions(engine storepb.Engine, diff *MetadataDiff, schemaName stri
 
 	// Build map of new functions by signature
 	newFuncsBySignature := make(map[string]*storepb.FunctionMetadata)
-	for _, fn := range newSchema.ListFunctions() {
+	for _, fn := range newSchema.GetProto().GetFunctions() {
 		if !fn.GetSkipDump() {
 			sig := fn.Signature
 			if sig == "" {

--- a/backend/store/model/pg_searcher.go
+++ b/backend/store/model/pg_searcher.go
@@ -138,7 +138,7 @@ func (s *DatabaseSearcher) SearchFunctions(name string) ([]string, []*storepb.Fu
 		if schema == nil {
 			continue
 		}
-		for _, function := range schema.functions {
+		for _, function := range schema.GetProto().GetFunctions() {
 			if s.db.isDetailCaseSensitive {
 				if function.Name == name {
 					schemas = append(schemas, schema.proto.Name)
@@ -276,7 +276,7 @@ func (d *DatabaseMetadata) SearchFunctions(searchPath []string, name string) ([]
 		if schema == nil {
 			continue
 		}
-		for _, function := range schema.functions {
+		for _, function := range schema.GetProto().GetFunctions() {
 			if d.isDetailCaseSensitive {
 				if function.Name == name {
 					schemas = append(schemas, schema.proto.Name)


### PR DESCRIPTION
## Summary

Remove redundant `functions` field from `SchemaMetadata` struct, following the same refactoring pattern applied to `TableMetadata` (#18148) and `ExternalTableMetadata` (#18151).

This eliminates duplicate data storage while maintaining all necessary functionality.

## Changes

- **Removed** `functions []*storepb.FunctionMetadata` field from `SchemaMetadata` struct
- **Removed** `ListFunctions()` wrapper method (3 callers updated to use `GetProto().GetFunctions()`)
- **Removed** `ListFunctionNames()` method (was unused, 0 callers)
- **Updated** `GetFunction(name)` to iterate through `proto.GetFunctions()` instead of the removed field
- **Updated** all callers:
  - `backend/plugin/schema/differ.go` - schema diff generation (3 call sites)
  - `backend/store/model/pg_searcher.go` - PostgreSQL search path lookup (2 call sites)
  - `backend/api/v1/database_service.go` - function schema retrieval (1 call site)

## Benefits

- **Simpler code**: Single source of truth for function data (stored only in proto)
- **Reduced memory usage**: Eliminates duplicate slice for every schema
- **Consistency**: Matches the pattern used by `TableMetadata` and `ExternalTableMetadata`
- **No breaking changes**: `GetFunction()` method preserved for backward compatibility

## Note on "Overloading" Comment

The original comment stated: *"Store internal functions by list to take care of the overloadings"*

However, the implementation was incorrect:
- `GetFunction(name)` returned only the **first** match by name, ignoring signatures
- The proper way to handle overloaded functions is via the `signature` field (e.g., `myFunc(int, text)`)
- The schema differ **already does this correctly** by using signatures as unique keys

The updated `GetFunction()` maintains the same behavior (first match by name) while now using the proto field.

## Migration Path

Callers can use:
- `schema.GetProto().GetFunctions()` instead of `schema.ListFunctions()`
- `schema.GetFunction(name)` continues to work (now uses proto internally)

## Testing

- ✅ All store/model tests pass
- ✅ Backend builds successfully
- ✅ No breaking changes to existing code

## Related

- Follows the same pattern as #18148 (TableMetadata refactoring)
- Follows the same pattern as #18151 (ExternalTableMetadata refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)