### PR TITLE
refactor: standardize Snowflake parser to return list of ParseResults

### DIFF
--- a/backend/plugin/advisor/snowflake/rule_column_no_null.go
+++ b/backend/plugin/advisor/snowflake/rule_column_no_null.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
-	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -29,9 +28,9 @@ type ColumnNoNullAdvisor struct {
 
 // Check checks for column no NULL value.
 func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	tree, ok := checkCtx.AST.(antlr.Tree)
-	if !ok {
-		return nil, errors.Errorf("failed to convert to Tree")
+	parseResults, err := getANTLRTree(checkCtx)
+	if err != nil {
+		return nil, err
 	}
 
 	level, err := advisor.NewStatusBySQLReviewRuleLevel(checkCtx.Rule.Level)
@@ -45,7 +44,11 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 	// Create the generic checker with the rule
 	checker := NewGenericChecker([]Rule{rule})
 
-	antlr.ParseTreeWalkerDefault.Walk(checker, tree)
+	for _, parseResult := range parseResults {
+		rule.SetBaseLine(parseResult.BaseLine)
+		checker.SetBaseLine(parseResult.BaseLine)
+		antlr.ParseTreeWalkerDefault.Walk(checker, parseResult.Tree)
+	}
 
 	return checker.GetAdviceList(), nil
 }

--- a/backend/plugin/advisor/snowflake/rule_naming_identifier_case.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_identifier_case.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
-	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -31,9 +30,9 @@ type NamingIdentifierCaseAdvisor struct {
 
 // Check checks for identifier case.
 func (*NamingIdentifierCaseAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	tree, ok := checkCtx.AST.(antlr.Tree)
-	if !ok {
-		return nil, errors.Errorf("failed to convert to Tree")
+	parseResults, err := getANTLRTree(checkCtx)
+	if err != nil {
+		return nil, err
 	}
 
 	level, err := advisor.NewStatusBySQLReviewRuleLevel(checkCtx.Rule.Level)
@@ -44,7 +43,11 @@ func (*NamingIdentifierCaseAdvisor) Check(_ context.Context, checkCtx advisor.Co
 	rule := NewNamingIdentifierCaseRule(level, string(checkCtx.Rule.Type))
 	checker := NewGenericChecker([]Rule{rule})
 
-	antlr.ParseTreeWalkerDefault.Walk(checker, tree)
+	for _, parseResult := range parseResults {
+		rule.SetBaseLine(parseResult.BaseLine)
+		checker.SetBaseLine(parseResult.BaseLine)
+		antlr.ParseTreeWalkerDefault.Walk(checker, parseResult.Tree)
+	}
 
 	return checker.GetAdviceList(), nil
 }
@@ -119,7 +122,7 @@ func (r *NamingIdentifierCaseRule) enterColumnDeclItemList(ctx *parser.Column_de
 					Code:          code.NamingCaseMismatch.Int32(),
 					Title:         r.title,
 					Content:       fmt.Sprintf("Identifier %q should be upper case", originalColName),
-					StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
+					StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
 				})
 			}
 		}
@@ -139,7 +142,7 @@ func (r *NamingIdentifierCaseRule) enterAlterTable(ctx *parser.Alter_tableContex
 			Code:          code.NamingCaseMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("Identifier %q should be upper case", renameToColName),
-			StartPosition: common.ConvertANTLRLineToPosition(renameToID.GetStart().GetLine()),
+			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + renameToID.GetStart().GetLine()),
 		})
 	}
 }

--- a/backend/plugin/advisor/snowflake/rule_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/snowflake/rule_table_drop_naming_convention.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
-	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -32,9 +31,9 @@ type TableDropNamingConventionAdvisor struct {
 
 // Check checks for table drop with naming convention.
 func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	tree, ok := checkCtx.AST.(antlr.Tree)
-	if !ok {
-		return nil, errors.Errorf("failed to convert to Tree")
+	parseResults, err := getANTLRTree(checkCtx)
+	if err != nil {
+		return nil, err
 	}
 
 	level, err := advisor.NewStatusBySQLReviewRuleLevel(checkCtx.Rule.Level)
@@ -50,7 +49,11 @@ func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advis
 	rule := NewTableDropNamingConventionRule(level, string(checkCtx.Rule.Type), format)
 	checker := NewGenericChecker([]Rule{rule})
 
-	antlr.ParseTreeWalkerDefault.Walk(checker, tree)
+	for _, parseResult := range parseResults {
+		rule.SetBaseLine(parseResult.BaseLine)
+		checker.SetBaseLine(parseResult.BaseLine)
+		antlr.ParseTreeWalkerDefault.Walk(checker, parseResult.Tree)
+	}
 
 	return checker.GetAdviceList(), nil
 }
@@ -99,7 +102,7 @@ func (r *TableDropNamingConventionRule) enterDropTable(ctx *parser.Drop_tableCon
 			Code:          code.TableDropNamingConventionMismatch.Int32(),
 			Title:         r.title,
 			Content:       fmt.Sprintf("%q mismatches drop table naming convention, naming format should be %q", normalizedObjectName, r.format),
-			StartPosition: common.ConvertANTLRLineToPosition(ctx.Object_name().GetO().GetStart().GetLine()),
+			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.Object_name().GetO().GetStart().GetLine()),
 		})
 	}
 }

--- a/backend/plugin/advisor/snowflake/rule_table_require_pk.go
+++ b/backend/plugin/advisor/snowflake/rule_table_require_pk.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
-	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -30,9 +29,9 @@ type TableRequirePkAdvisor struct {
 
 // Check checks for table require primary key.
 func (*TableRequirePkAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	tree, ok := checkCtx.AST.(antlr.Tree)
-	if !ok {
-		return nil, errors.Errorf("failed to convert to Tree")
+	parseResults, err := getANTLRTree(checkCtx)
+	if err != nil {
+		return nil, err
 	}
 
 	level, err := advisor.NewStatusBySQLReviewRuleLevel(checkCtx.Rule.Level)
@@ -43,7 +42,11 @@ func (*TableRequirePkAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 	rule := NewTableRequirePkRule(level, string(checkCtx.Rule.Type))
 	checker := NewGenericChecker([]Rule{rule})
 
-	antlr.ParseTreeWalkerDefault.Walk(checker, tree)
+	for _, parseResult := range parseResults {
+		rule.SetBaseLine(parseResult.BaseLine)
+		checker.SetBaseLine(parseResult.BaseLine)
+		antlr.ParseTreeWalkerDefault.Walk(checker, parseResult.Tree)
+	}
 
 	return checker.GetAdviceList(), nil
 }
@@ -130,7 +133,7 @@ func (r *TableRequirePkRule) GetAdviceList() []*storepb.Advice {
 				Code:          code.TableNoPK.Int32(),
 				Title:         r.title,
 				Content:       fmt.Sprintf("Table %s requires PRIMARY KEY.", r.tableOriginalName[tableName]),
-				StartPosition: common.ConvertANTLRLineToPosition(r.tableLine[tableName]),
+				StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + r.tableLine[tableName]),
 			})
 		}
 	}

--- a/backend/plugin/advisor/snowflake/rule_where_require_select.go
+++ b/backend/plugin/advisor/snowflake/rule_where_require_select.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 	parser "github.com/bytebase/parser/snowflake"
-	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -28,9 +27,9 @@ type WhereRequireForSelectAdvisor struct {
 
 // Check checks for WHERE clause requirement.
 func (*WhereRequireForSelectAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	tree, ok := checkCtx.AST.(antlr.Tree)
-	if !ok {
-		return nil, errors.Errorf("failed to convert to Tree")
+	parseResults, err := getANTLRTree(checkCtx)
+	if err != nil {
+		return nil, err
 	}
 
 	level, err := advisor.NewStatusBySQLReviewRuleLevel(checkCtx.Rule.Level)
@@ -41,7 +40,11 @@ func (*WhereRequireForSelectAdvisor) Check(_ context.Context, checkCtx advisor.C
 	rule := NewWhereRequireForSelectRule(level, string(checkCtx.Rule.Type))
 	checker := NewGenericChecker([]Rule{rule})
 
-	antlr.ParseTreeWalkerDefault.Walk(checker, tree)
+	for _, parseResult := range parseResults {
+		rule.SetBaseLine(parseResult.BaseLine)
+		checker.SetBaseLine(parseResult.BaseLine)
+		antlr.ParseTreeWalkerDefault.Walk(checker, parseResult.Tree)
+	}
 
 	return checker.GetAdviceList(), nil
 }
@@ -95,7 +98,7 @@ func (r *WhereRequireForSelectRule) enterQueryStatement(ctx *parser.Query_statem
 			Code:          code.StatementNoWhere.Int32(),
 			Title:         r.title,
 			Content:       "WHERE clause is required for SELECT statement.",
-			StartPosition: common.ConvertANTLRLineToPosition(ctx.GetStart().GetLine()),
+			StartPosition: common.ConvertANTLRLineToPosition(r.baseLine + ctx.GetStart().GetLine()),
 		})
 	}
 }

--- a/backend/plugin/advisor/snowflake/test/table_require_pk.yaml
+++ b/backend/plugin/advisor/snowflake/test/table_require_pk.yaml
@@ -126,7 +126,7 @@
       title: table.require-pk
       content: Table CUSTOMER requires PRIMARY KEY.
       startposition:
-        line: 24
+        line: 25
         column: 0
       endposition: null
     - status: 2

--- a/backend/plugin/advisor/snowflake/utils.go
+++ b/backend/plugin/advisor/snowflake/utils.go
@@ -1,0 +1,25 @@
+package snowflake
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	snowsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/snowflake"
+)
+
+// getANTLRTree extracts the ANTLR parse trees from the advisor context.
+// The AST must be pre-parsed and passed via checkCtx.AST (e.g., in tests or by the framework).
+// This enforces proper AST caching and makes any missing cache obvious.
+// Returns all parse results for multi-statement SQL review.
+func getANTLRTree(checkCtx advisor.Context) ([]*snowsqlparser.ParseResult, error) {
+	if checkCtx.AST == nil {
+		return nil, errors.New("AST is not provided in context - must be parsed before calling advisor")
+	}
+
+	parseResults, ok := checkCtx.AST.([]*snowsqlparser.ParseResult)
+	if !ok {
+		return nil, errors.Errorf("AST type mismatch: expected []*snowsqlparser.ParseResult, got %T", checkCtx.AST)
+	}
+
+	return parseResults, nil
+}

--- a/backend/plugin/db/snowflake/query.go
+++ b/backend/plugin/db/snowflake/query.go
@@ -25,10 +25,16 @@ func getStatementWithResultLimit(statement string, limit int) string {
 }
 
 func getStatementWithResultLimitInline(singleStatement string, limitCount int) (string, error) {
-	result, err := snowparser.ParseSnowSQL(singleStatement)
+	results, err := snowparser.ParseSnowSQL(singleStatement)
 	if err != nil {
 		return "", err
 	}
+
+	if len(results) != 1 {
+		return "", errors.Errorf("expected exactly 1 statement, got %d", len(results))
+	}
+
+	result := results[0]
 
 	listener := &snowsqlRewriter{
 		limitCount:     limitCount,

--- a/backend/plugin/parser/base/interface.go
+++ b/backend/plugin/parser/base/interface.go
@@ -271,7 +271,7 @@ func RegisterParseFunc(engine storepb.Engine, f ParseFunc) {
 //   - CockroachDB: statements.Statements (github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements)
 //   - Redshift: antlr.Tree
 //   - Oracle: antlr.Tree
-//   - Snowflake: antlr.Tree
+//   - Snowflake: []*ParseResult (github.com/bytebase/bytebase/backend/plugin/parser/snowflake) - ANTLR-based
 //   - MSSQL: antlr.Tree
 //   - DynamoDB (PartiQL): antlr.Tree
 //   - Doris: *ParseResult (github.com/bytebase/bytebase/backend/plugin/parser/doris)

--- a/backend/plugin/parser/snowflake/query.go
+++ b/backend/plugin/parser/snowflake/query.go
@@ -14,16 +14,18 @@ func init() {
 
 // validateQuery validates the SQL statement for SQL editor.
 func validateQuery(statement string) (bool, bool, error) {
-	parseResult, err := ParseSnowSQL(statement)
+	parseResults, err := ParseSnowSQL(statement)
 	if err != nil {
 		return false, false, err
 	}
 	l := &queryValidateListener{
 		valid: true,
 	}
-	antlr.ParseTreeWalkerDefault.Walk(l, parseResult.Tree)
-	if !l.valid {
-		return false, false, nil
+	for _, parseResult := range parseResults {
+		antlr.ParseTreeWalkerDefault.Walk(l, parseResult.Tree)
+		if !l.valid {
+			return false, false, nil
+		}
 	}
 	return true, !l.hasExecute, nil
 }

--- a/backend/plugin/parser/snowflake/query_span_extractor.go
+++ b/backend/plugin/parser/snowflake/query_span_extractor.go
@@ -48,13 +48,16 @@ func newQuerySpanExtractor(defaultDatabase, defaultSchema string, gCtx base.GetQ
 func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string) (*base.QuerySpan, error) {
 	q.ctx = ctx
 
-	parseResult, err := ParseSnowSQL(statement)
+	parseResults, err := ParseSnowSQL(statement)
 	if err != nil {
 		return nil, err
 	}
-	if parseResult == nil {
-		return nil, nil
+
+	if len(parseResults) != 1 {
+		return nil, errors.Errorf("expected exactly 1 statement, got %d", len(parseResults))
 	}
+
+	parseResult := parseResults[0]
 	tree := parseResult.Tree
 	if tree == nil {
 		return nil, nil

--- a/backend/plugin/parser/snowflake/snowflake_test.go
+++ b/backend/plugin/parser/snowflake/snowflake_test.go
@@ -52,7 +52,10 @@ func TestParseSnowSQL(t *testing.T) {
 		},
 		{
 			sql: "SELECT 1;\n   SELEC 5;\nSELECT 6;",
-			err: "Syntax error at line 2:4 \nrelated text: SELECT 1;\n   SELEC",
+			// After standardization, each statement is parsed separately, so the error context
+			// only includes the current statement being parsed (not previous statements).
+			// Leading newlines are trimmed, so the error context shows the trimmed text.
+			err: "Syntax error at line 2:4 \nrelated text:    SELEC",
 		},
 	}
 

--- a/backend/plugin/parser/snowflake/split.go
+++ b/backend/plugin/parser/snowflake/split.go
@@ -1,21 +1,70 @@
 package snowflake
 
 import (
+	"strings"
+
+	"github.com/antlr4-go/antlr/v4"
+	parser "github.com/bytebase/parser/snowflake"
+
+	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
-	"github.com/bytebase/bytebase/backend/plugin/parser/tokenizer"
 )
 
 func init() {
 	base.RegisterSplitterFunc(storepb.Engine_SNOWFLAKE, SplitSQL)
 }
 
-// SplitSQL splits the given SQL statement into multiple SQL statements.
+// calculateBaseLine calculates the base line offset for a split statement.
+// Since we trim leading newlines before parsing, the first token will be on line 1
+// in the parsed result. Therefore, baseLine = original line - 1.
+func calculateBaseLine(_ []antlr.Token, antlrPosition *common.ANTLRPosition) int {
+	return int(antlrPosition.Line) - 1
+}
+
+// SplitSQL splits the given SQL statement into multiple SQL statements using ANTLR lexer.
 func SplitSQL(statement string) ([]base.SingleSQL, error) {
-	t := tokenizer.NewTokenizer(statement)
-	list, err := t.SplitStandardMultiSQL()
-	if err != nil {
-		return nil, err
+	lexer := parser.NewSnowflakeLexer(antlr.NewInputStream(statement))
+	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	stream.Fill()
+
+	tokens := stream.GetAllTokens()
+	var buf []antlr.Token
+	var sqls []base.SingleSQL
+
+	for i, token := range tokens {
+		if i < len(tokens)-1 {
+			buf = append(buf, token)
+		}
+		if (token.GetTokenType() == parser.SnowflakeLexerSEMI || i == len(tokens)-1) && len(buf) > 0 {
+			bufStr := new(strings.Builder)
+			empty := true
+
+			for _, b := range buf {
+				if _, err := bufStr.WriteString(b.GetText()); err != nil {
+					return nil, err
+				}
+				if b.GetChannel() != antlr.TokenHiddenChannel {
+					empty = false
+				}
+			}
+			antlrPosition := base.FirstDefaultChannelTokenPosition(buf)
+
+			// For the End position, use the current token (semicolon or EOF)
+			// instead of the last token in buf
+			sqls = append(sqls, base.SingleSQL{
+				Text:     bufStr.String(),
+				BaseLine: calculateBaseLine(buf, antlrPosition),
+				End: common.ConvertANTLRPositionToPosition(&common.ANTLRPosition{
+					Line:   int32(token.GetLine()),
+					Column: int32(token.GetColumn()),
+				}, statement),
+				Start: common.ConvertANTLRPositionToPosition(antlrPosition, statement),
+				Empty: empty,
+			})
+			buf = nil
+			continue
+		}
 	}
-	return list, nil
+	return sqls, nil
 }

--- a/backend/plugin/parser/snowflake/split_test.go
+++ b/backend/plugin/parser/snowflake/split_test.go
@@ -1,0 +1,142 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestSplitSQL(t *testing.T) {
+	statement := `SELECT * FROM users;
+	SELECT * FROM orders;
+	SELECT * FROM products;`
+	want := []base.SingleSQL{
+		{
+			Text:     "SELECT * FROM users;",
+			BaseLine: 0,
+			Start:    &storepb.Position{Line: 1, Column: 1},
+			End:      &storepb.Position{Line: 1, Column: 20},
+			Empty:    false,
+		},
+		{
+			Text:     "\n\tSELECT * FROM orders;",
+			BaseLine: 1, // Corrected: first token is on line 2 of original SQL
+			Start:    &storepb.Position{Line: 2, Column: 2},
+			End:      &storepb.Position{Line: 2, Column: 22},
+			Empty:    false,
+		},
+		{
+			Text:     "\n\tSELECT * FROM products;",
+			BaseLine: 2, // Corrected: first token is on line 3 of original SQL
+			Start:    &storepb.Position{Line: 3, Column: 2},
+			End:      &storepb.Position{Line: 3, Column: 24},
+			Empty:    false,
+		},
+	}
+
+	list, err := SplitSQL(statement)
+	require.NoError(t, err)
+	require.Equal(t, want, list)
+}
+
+func TestSplitSQLSingleStatement(t *testing.T) {
+	statement := "SELECT * FROM users;"
+	list, err := SplitSQL(statement)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(list))
+	require.Equal(t, "SELECT * FROM users;", list[0].Text)
+	require.Equal(t, 0, list[0].BaseLine)
+	require.False(t, list[0].Empty)
+}
+
+func TestSplitSQLEmpty(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		wantCount int
+	}{
+		{
+			name:      "Empty string",
+			statement: "",
+			wantCount: 0,
+		},
+		{
+			name:      "Only whitespace",
+			statement: "   \n  \t  ",
+			wantCount: 0,
+		},
+		{
+			name:      "Only semicolon",
+			statement: ";",
+			wantCount: 1,
+		},
+		{
+			name:      "Only comments and semicolon",
+			statement: "-- comment\n;",
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := SplitSQL(tt.statement)
+			require.NoError(t, err)
+			nonEmpty := 0
+			for _, sql := range list {
+				if !sql.Empty {
+					nonEmpty++
+				}
+			}
+			require.Equal(t, tt.wantCount, nonEmpty)
+		})
+	}
+}
+
+func TestSplitSQLWithComments(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		wantCount int
+	}{
+		{
+			name:      "Statement with trailing comment",
+			statement: "SELECT * FROM users; -- This is a comment\nSELECT * FROM orders;",
+			wantCount: 2,
+		},
+		{
+			name:      "Statement with leading comment",
+			statement: "-- Comment at start\nSELECT * FROM users;",
+			wantCount: 1,
+		},
+		{
+			name:      "Only comment with semicolon",
+			statement: "-- comment only\n;",
+			wantCount: 1,
+		},
+		{
+			name:      "Multiple statements with comments",
+			statement: "-- First query\nSELECT * FROM users;\n-- Second query\nSELECT * FROM orders;",
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := SplitSQL(tt.statement)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCount, len(list))
+		})
+	}
+}
+
+func TestSplitSQLWithoutSemicolon(t *testing.T) {
+	statement := "SELECT * FROM users"
+	list, err := SplitSQL(statement)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(list))
+	require.Equal(t, "SELECT * FROM users", list[0].Text)
+	require.False(t, list[0].Empty)
+}


### PR DESCRIPTION
## Summary

Standardize the Snowflake parser interface to return a list of AST nodes (one per statement) instead of a single AST, aligning with the pattern used by other completed engines (PostgreSQL, Cassandra, PLSQL, etc.).

## Changes

### Parser Layer
- Implement ANTLR lexer-based SQL splitter in `split.go`
  - Properly handles multi-statement SQL with position tracking
  - Includes BaseLine calculation for accurate line number reporting
- Modify `ParseSnowSQL` to return `[]*ParseResult` instead of `*ParseResult`
- Add `BaseLine` field to `ParseResult` struct for multi-statement SQL support
- Trim leading newlines before parsing to ensure consistent line numbering

### Advisor Layer
- Update all 14 Snowflake SQL review advisors to handle list-based ASTs
- Create `utils.go` helper with `getANTLRTree()` for consistent AST extraction
- Fix critical bug: Store absolute line numbers (`baseLine + ctx.GetStart().GetLine()`) instead of relative ones
  - This ensures correct line reporting when `GetAdviceList()` is called after processing multiple statements

### Direct AST Consumers
- Update `query_span_extractor.go` to use `parseResults[0]`
- Update `query.go` to iterate through all parse results
- Update `db/snowflake/query.go` to validate single statement

### Tests
- Add comprehensive split tests in `split_test.go`
- Update advisor test expectations for corrected line numbers
- All tests passing (parser, advisor, db plugin)

## Test Results

```
✅ Parser tests: backend/plugin/parser/snowflake
✅ Advisor tests: backend/plugin/advisor/snowflake (all 14 rules)
✅ DB plugin tests: backend/plugin/db/snowflake
✅ No linting issues
```

## Related

- Addresses BYT-8330
- Follows pattern from PR #18137 (PostgreSQL standardization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)