### PR TITLE
fix: align Snowflake BaseLine calculation with Cassandra approach

### DIFF
--- a/backend/plugin/parser/snowflake/snowflake.go
+++ b/backend/plugin/parser/snowflake/snowflake.go
@@ -54,11 +54,6 @@ func ParseSnowSQL(sql string) ([]*ParseResult, error) {
 
 // parseSingleSnowSQL parses a single Snowflake statement and returns the ParseResult.
 func parseSingleSnowSQL(statement string, baseLine int) (*ParseResult, error) {
-	// Trim leading newlines to ensure the first token starts at line 1 in ANTLR
-	// This makes baseLine calculations simpler: baseLine + line = original line
-	statement = strings.TrimLeftFunc(statement, func(r rune) bool {
-		return r == '\n' || r == '\r'
-	})
 	statement = strings.TrimRightFunc(statement, utils.IsSpaceOrSemicolon) + "\n;"
 	inputStream := antlr.NewInputStream(statement)
 	lexer := parser.NewSnowflakeLexer(inputStream)

--- a/backend/plugin/parser/snowflake/snowflake_test.go
+++ b/backend/plugin/parser/snowflake/snowflake_test.go
@@ -54,8 +54,7 @@ func TestParseSnowSQL(t *testing.T) {
 			sql: "SELECT 1;\n   SELEC 5;\nSELECT 6;",
 			// After standardization, each statement is parsed separately, so the error context
 			// only includes the current statement being parsed (not previous statements).
-			// Leading newlines are trimmed, so the error context shows the trimmed text.
-			err: "Syntax error at line 2:4 \nrelated text:    SELEC",
+			err: "Syntax error at line 2:4 \nrelated text: \n   SELEC",
 		},
 	}
 

--- a/backend/plugin/parser/snowflake/split.go
+++ b/backend/plugin/parser/snowflake/split.go
@@ -15,13 +15,6 @@ func init() {
 	base.RegisterSplitterFunc(storepb.Engine_SNOWFLAKE, SplitSQL)
 }
 
-// calculateBaseLine calculates the base line offset for a split statement.
-// Since we trim leading newlines before parsing, the first token will be on line 1
-// in the parsed result. Therefore, baseLine = original line - 1.
-func calculateBaseLine(_ []antlr.Token, antlrPosition *common.ANTLRPosition) int {
-	return int(antlrPosition.Line) - 1
-}
-
 // SplitSQL splits the given SQL statement into multiple SQL statements using ANTLR lexer.
 func SplitSQL(statement string) ([]base.SingleSQL, error) {
 	lexer := parser.NewSnowflakeLexer(antlr.NewInputStream(statement))
@@ -54,7 +47,7 @@ func SplitSQL(statement string) ([]base.SingleSQL, error) {
 			// instead of the last token in buf
 			sqls = append(sqls, base.SingleSQL{
 				Text:     bufStr.String(),
-				BaseLine: calculateBaseLine(buf, antlrPosition),
+				BaseLine: buf[0].GetLine() - 1,
 				End: common.ConvertANTLRPositionToPosition(&common.ANTLRPosition{
 					Line:   int32(token.GetLine()),
 					Column: int32(token.GetColumn()),

--- a/backend/plugin/parser/snowflake/split_test.go
+++ b/backend/plugin/parser/snowflake/split_test.go
@@ -23,14 +23,14 @@ func TestSplitSQL(t *testing.T) {
 		},
 		{
 			Text:     "\n\tSELECT * FROM orders;",
-			BaseLine: 1, // Corrected: first token is on line 2 of original SQL
+			BaseLine: 0,
 			Start:    &storepb.Position{Line: 2, Column: 2},
 			End:      &storepb.Position{Line: 2, Column: 22},
 			Empty:    false,
 		},
 		{
 			Text:     "\n\tSELECT * FROM products;",
-			BaseLine: 2, // Corrected: first token is on line 3 of original SQL
+			BaseLine: 1,
 			Start:    &storepb.Position{Line: 3, Column: 2},
 			End:      &storepb.Position{Line: 3, Column: 24},
 			Empty:    false,


### PR DESCRIPTION
## Problem

The previous Snowflake BaseLine calculation had a critical flaw that would cause incorrect line number reporting when multi-line comments are present in the SQL.

### The Bug

The implementation used `FirstDefaultChannelTokenPosition()` (which skips hidden channel tokens like comments) to calculate BaseLine, but only trimmed leading newlines (not comments) from the text before parsing. This creates a mismatch:

**Example SQL:**
```sql
SELECT 1;
/* multi-line
   comment */
SELECT 2;
```

After splitting, statement 2 text would be:
```
"\n/* multi-line\n   comment */\nSELECT 2;"
```

**With old approach:**
- `FirstDefaultChannelTokenPosition(buf)` finds SELECT at line 4
- BaseLine = 4 - 1 = 3
- Text passed to parser: `"/* multi-line\n   comment */\nSELECT 2;"` (only newlines trimmed, comment remains)
- Parser sees SELECT at line 3 (relative)
- Final error line: 3 + 3 = 6 ❌ **Wrong! Should be 4**

The mismatch occurs because we calculate BaseLine by skipping hidden tokens, but don't actually remove those tokens from the text.

## Solution

Align with Cassandra's simpler and correct approach: use `buf[0].GetLine() - 1` for BaseLine calculation.

### Changes

1. **Remove leading newline trimming** in `parseSingleSnowSQL()` 
   - Previously: `TrimLeftFunc()` to remove `\n` and `\r`
   - Now: No trimming of leading content

2. **Change BaseLine calculation** in `split.go`
   - Previously: `calculateBaseLine(FirstDefaultChannelTokenPosition(buf))`
   - Now: `buf[0].GetLine() - 1` (same as Cassandra)

3. **Update test expectations** to match new behavior

### Why This Works

- `buf[0]` is the very first token in the split text (newline, comment, or code)
- The parser receives the text starting from that first token
- No mismatch between what we calculate and what the parser sees
- Follows the same pattern as Cassandra (another lexer-based engine)

## Test Results

```
✅ Parser tests: backend/plugin/parser/snowflake
✅ Advisor tests: backend/plugin/advisor/snowflake (all 14 rules)
✅ No linting issues
```

## Related

- Fixes a bug introduced in #18155
- Aligns with Cassandra's approach (lexer-based splitting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)