### PR TITLE
refactor: unify advisor Context by merging SQLReviewCheckContext

### DIFF
--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -663,7 +663,7 @@ func (s *ReleaseService) runSQLReviewCheckForFile(
 	connection := driver.GetDB()
 
 	classificationConfig := getClassificationByProject(ctx, s.store, database.ProjectID)
-	context := advisor.SQLReviewCheckContext{
+	context := advisor.Context{
 		Charset:                  dbMetadataProto.CharacterSet,
 		Collation:                dbMetadataProto.Collation,
 		ChangeType:               changeType,

--- a/backend/plugin/advisor/advisor.go
+++ b/backend/plugin/advisor/advisor.go
@@ -58,6 +58,17 @@ type Context struct {
 	Statements string
 	// UsePostgresDatabaseOwner is true if the advisor should use the database owner as default role.
 	UsePostgresDatabaseOwner bool
+
+	// SQL review level fields.
+	Charset   string
+	Collation string
+	DBType    storepb.Engine
+
+	// Snowflake specific fields (duplicates CurrentDatabase, kept for compatibility).
+	// CurrentDatabase string
+
+	// Used for test only.
+	NoAppendBuiltin bool
 }
 
 // Advisor is the interface for advisor.

--- a/backend/plugin/advisor/utils_for_tests.go
+++ b/backend/plugin/advisor/utils_for_tests.go
@@ -235,7 +235,7 @@ func RunSQLReviewRuleTest(t *testing.T, rule SQLReviewRuleType, dbType storepb.E
 			},
 		}
 
-		checkCtx := SQLReviewCheckContext{
+		checkCtx := Context{
 			Charset:                  "",
 			Collation:                "",
 			DBType:                   dbType,

--- a/backend/runner/plancheck/statement_advise_executor.go
+++ b/backend/runner/plancheck/statement_advise_executor.go
@@ -176,7 +176,7 @@ func (e *StatementAdviseExecutor) runReview(
 	// Database secrets feature removed - using original statement directly
 	classificationConfig := getClassificationByProject(ctx, e.store, database.ProjectID)
 
-	adviceList, err := advisor.SQLReviewCheck(ctx, e.sheetManager, statement, reviewConfig.SqlReviewRules, advisor.SQLReviewCheckContext{
+	adviceList, err := advisor.SQLReviewCheck(ctx, e.sheetManager, statement, reviewConfig.SqlReviewRules, advisor.Context{
 		Charset:                  dbMetadata.GetProto().CharacterSet,
 		Collation:                dbMetadata.GetProto().Collation,
 		DBSchema:                 dbMetadata.GetProto(),


### PR DESCRIPTION
## Summary

Consolidates `SQLReviewCheckContext` and `Context` into a single unified `Context` struct to eliminate field duplication and simplify the call pattern in the SQL review advisor system.

## Changes

### Core Refactoring
- **Merged contexts** (`backend/plugin/advisor/advisor.go`): Added `Charset`, `Collation`, `DBType`, and `NoAppendBuiltin` fields from `SQLReviewCheckContext` into the unified `Context` struct
- **Removed duplicate struct** (`backend/plugin/advisor/sql_review.go`): Deleted `SQLReviewCheckContext` struct definition entirely
- **Simplified SQLReviewCheck**: Changed function signature to accept unified `Context` instead of `SQLReviewCheckContext`
- **Eliminated manual field copying**: Reduced from copying 13 fields per rule check to setting only 3 per-rule fields (AST, Statements, Rule)
- **Cleaned up imports**: Removed unused imports from `sql_review.go`

### Updated Call Sites
- `backend/runner/plancheck/statement_advise_executor.go`
- `backend/api/v1/release_service_check.go`
- `backend/plugin/advisor/utils_for_tests.go`

## Benefits

✅ **Zero duplication** - All 13+ shared fields are defined in one place  
✅ **Simpler code** - Reduced manual field copying complexity  
✅ **Impossible to drift** - Fields can't get out of sync between two structs  
✅ **Cleaner codebase** - Net reduction of 29 lines of code

## Code Impact

**Before**: Manual copying of 13 fields for each rule check
```go
Context{
    DBSchema:                 checkContext.DBSchema,
    ChangeType:               checkContext.ChangeType,
    EnablePriorBackup:        checkContext.EnablePriorBackup,
    // ... 10 more fields manually copied
}
```

**After**: Direct context usage with 3 field updates
```go
checkContext.AST = asts
checkContext.Statements = statements
checkContext.Rule = rule
```

## Test plan

- [x] Go build succeeds
- [x] golangci-lint passes with no issues
- [x] All modified files formatted with gofmt
- [ ] Existing tests should pass (no behavior changes, pure refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)