### PR TITLE
refactor: migrate Trino parser to return list of ParseResults

### DIFF
--- a/backend/plugin/parser/trino/query.go
+++ b/backend/plugin/parser/trino/query.go
@@ -11,32 +11,55 @@ func init() {
 
 // validateQuery validates if the given SQL statement is valid for SQL editor.
 // We only allow read-only queries in the SQL editor.
+// Returns (canRunInReadOnly, returnsData, error):
+// - canRunInReadOnly: whether all queries can run in read-only mode
+// - returnsData: whether all queries return data
+// - error: parsing error if the statement is invalid
 func validateQuery(statement string) (bool, bool, error) {
-	result, err := ParseTrino(statement)
+	parseResults, err := ParseTrino(statement)
 	if err != nil {
 		return false, false, err
 	}
 
-	queryType, isAnalyze := getQueryType(result.Tree)
+	allReadOnly := true
+	allReturnData := true
 
-	// If it's an EXPLAIN ANALYZE, the query will be executed
-	if isAnalyze {
-		// Only allow EXPLAIN ANALYZE for SELECT statements
-		if queryType == base.Select {
-			return true, true, nil
+	// Validate each statement
+	for _, result := range parseResults {
+		queryType, isAnalyze := getQueryType(result.Tree)
+
+		// If it's an EXPLAIN ANALYZE, the query will be executed
+		if isAnalyze {
+			// Only allow EXPLAIN ANALYZE for SELECT statements
+			if queryType != base.Select {
+				return false, false, nil
+			}
+			// EXPLAIN ANALYZE SELECT is read-only and returns data
+			continue
 		}
-		return false, false, nil
+
+		// Determine if the statement is read-only
+		readOnly := queryType == base.Select ||
+			queryType == base.Explain ||
+			queryType == base.SelectInfoSchema
+
+		// Determine if the statement returns data
+		returnsData := queryType == base.Select ||
+			queryType == base.Explain ||
+			queryType == base.SelectInfoSchema
+
+		if !readOnly {
+			allReadOnly = false
+		}
+		if !returnsData {
+			allReturnData = false
+		}
+
+		// If any statement fails validation, return immediately
+		if !allReadOnly {
+			break
+		}
 	}
 
-	// Determine if the statement is read-only
-	readOnly := queryType == base.Select ||
-		queryType == base.Explain ||
-		queryType == base.SelectInfoSchema
-
-	// Determine if the statement returns data
-	returnsData := queryType == base.Select ||
-		queryType == base.Explain ||
-		queryType == base.SelectInfoSchema
-
-	return readOnly, returnsData, nil
+	return allReadOnly, allReturnData, nil
 }

--- a/backend/plugin/parser/trino/query_span_extractor.go
+++ b/backend/plugin/parser/trino/query_span_extractor.go
@@ -66,10 +66,17 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 	q.ctes = []*base.PseudoTable{}
 
 	// Parse the statement
-	result, err := ParseTrino(statement)
+	parseResults, err := ParseTrino(statement)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse Trino statement")
 	}
+
+	// Query span extraction expects exactly one statement
+	if len(parseResults) != 1 {
+		return nil, errors.Errorf("expected exactly 1 statement, got %d", len(parseResults))
+	}
+
+	result := parseResults[0]
 
 	if result.Tree == nil {
 		return nil, errors.New("failed to parse Trino statement, no parse tree found")

--- a/backend/plugin/parser/trino/query_type_test.go
+++ b/backend/plugin/parser/trino/query_type_test.go
@@ -191,8 +191,11 @@ func TestGetStatementType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Parse the statement
-			result, err := ParseTrino(tt.sql)
+			results, err := ParseTrino(tt.sql)
 			require.NoError(t, err, "Parsing should not fail")
+			require.Len(t, results, 1, "Should parse exactly one statement")
+
+			result := results[0]
 
 			// Test GetStatementType
 			stmtType := GetStatementType(result.Tree)


### PR DESCRIPTION
## Summary
Migrates the Trino parser interface from returning a single unified AST to returning a list of AST nodes (one per statement), following the same pattern as PostgreSQL, T-SQL, and Redshift parsers.

## Changes

### Core Parser Changes
- **Add `BaseLine` field** to `ParseResult` struct for multi-statement SQL error position mapping
- **Update `ParseTrino`** to return `[]*ParseResult` instead of `*ParseResult`
- Split SQL into individual statements using `SplitSQL` before parsing
- Update `parseSingleTrino` helper to accept `baseLine` parameter

### BaseLine Calculation Fix (Critical)
- **Fix baseLine calculation in `split.go`** to use **first token of any channel** instead of first default channel token
- This is the same bug we fixed in T-SQL parser - when ANTLR reparses fragments, it sees ALL tokens including comments on hidden channels
- Formula: `originalLine = antlrLine + baseLine` requires baseLine from first token (any channel)

### Query Validation
- **Update `validateQuery`** to loop through all statements and validate each one (matching PostgreSQL/T-SQL/Redshift pattern)
- Returns `false` if any statement fails validation
- Properly tracks `allReadOnly` and `allReturnData` across all statements

### Query Span Extraction
- Update `query_span_extractor.go` to validate exactly 1 statement (matching T-SQL pattern)

### Test Updates
- Update `parser_test.go` to handle list of ParseResults
- Update `query_type_test.go` to handle list of ParseResults
- All existing tests pass without modification to test logic

## Benefits
- Standardizes the Trino parser interface with other database parsers (PostgreSQL, T-SQL, Redshift)
- Enables proper line number tracking for error reporting in multi-statement SQL
- Fixes baseLine calculation bug that would cause incorrect error positions when SQL contains comments

## Test Results
All existing Trino parser tests pass:
- `TestTrinoParser` ✅
- `TestTrinoQueryType` ✅  
- `TestGetQuerySpan` ✅
- `TestGetStatementType` ✅
- All other parser tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)