### PR TITLE
fix: make task run creation idempotent to prevent double-click errors

### DIFF
--- a/action/command/rollout.go
+++ b/action/command/rollout.go
@@ -358,10 +358,7 @@ func waitForRollout(ctx context.Context, w *world.World, client *Client, pending
 				Parent: stage.Name,
 				Tasks:  notStartedTasks,
 			}); err != nil {
-				// Check for specific error indicating task runs already exist (retryable)
-				if !strings.Contains(err.Error(), "cannot create pending task runs because there are pending/running/done task runs") {
-					return errors.Wrapf(err, "failed to batch create tasks")
-				}
+				return errors.Wrapf(err, "failed to batch create tasks")
 			}
 		}
 		time.Sleep(5 * time.Second)

--- a/backend/tests/task_run_idempotent_test.go
+++ b/backend/tests/task_run_idempotent_test.go
@@ -1,0 +1,152 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+// TestBatchRunTasks_Idempotent verifies that BatchRunTasks is idempotent and safe for concurrent calls.
+// This test covers both sequential double-clicks and concurrent requests scenarios.
+func TestBatchRunTasks_Idempotent(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	// Provision an instance
+	instanceRootDir := t.TempDir()
+	instanceName := "testInstanceIdempotent"
+	instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, instanceName)
+	a.NoError(err)
+
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       instanceName,
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: stringPtr("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{Type: v1pb.DataSourceType_ADMIN, Host: instanceDir, Id: "admin"}},
+		},
+	}))
+	a.NoError(err)
+	instance := instanceResp.Msg
+
+	// Create a database
+	databaseName := "testIdempotentDb"
+	err = ctl.createDatabaseV2(ctx, ctl.project, instance, nil /* environment */, databaseName, "")
+	a.NoError(err)
+
+	databaseResp, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{
+		Name: fmt.Sprintf("%s/databases/%s", instance.Name, databaseName),
+	}))
+	a.NoError(err)
+	database := databaseResp.Msg
+
+	// Create a sheet with SQL
+	sheetResp, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet: &v1pb.Sheet{
+			Title:   "Test Sheet",
+			Content: []byte("SELECT 1;"),
+		},
+	}))
+	a.NoError(err)
+	sheet := sheetResp.Msg
+
+	// Create a plan with change database config
+	spec := &v1pb.Plan_Spec{
+		Id: uuid.NewString(),
+		Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+			ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+				Targets: []string{database.Name},
+				Sheet:   sheet.Name,
+				Type:    v1pb.DatabaseChangeType_MIGRATE,
+			},
+		},
+	}
+
+	planResp, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan: &v1pb.Plan{
+			Specs: []*v1pb.Plan_Spec{spec},
+		},
+	}))
+	a.NoError(err)
+	plan := planResp.Msg
+
+	// Create a rollout
+	rolloutResp, err := ctl.rolloutServiceClient.CreateRollout(ctx, connect.NewRequest(&v1pb.CreateRolloutRequest{
+		Parent:  ctl.project.Name,
+		Rollout: &v1pb.Rollout{Plan: plan.Name},
+	}))
+	a.NoError(err)
+	rollout := rolloutResp.Msg
+
+	// Get the tasks from the rollout
+	a.GreaterOrEqual(len(rollout.Stages), 1, "rollout should have at least one stage")
+	stage := rollout.Stages[0]
+	a.GreaterOrEqual(len(stage.Tasks), 1, "stage should have at least one task")
+
+	var taskNames []string
+	for _, task := range stage.Tasks {
+		taskNames = append(taskNames, task.Name)
+	}
+
+	// Test 1: Concurrent calls (hardest case - simulates rapid multiple clicks)
+	// Make 5 concurrent BatchRunTasks calls
+	type result struct {
+		err error
+	}
+	results := make(chan result, 5)
+
+	for range 5 {
+		go func() {
+			_, err := ctl.rolloutServiceClient.BatchRunTasks(ctx, connect.NewRequest(&v1pb.BatchRunTasksRequest{
+				Parent: stage.Name,
+				Tasks:  taskNames,
+			}))
+			results <- result{err: err}
+		}()
+	}
+
+	// Collect results - all should succeed
+	for i := range 5 {
+		res := <-results
+		a.NoError(res.err, "concurrent BatchRunTasks call %d should succeed", i+1)
+	}
+
+	// Verify no duplicate task runs were created despite concurrent requests
+	for _, taskName := range taskNames {
+		taskRunsResp, err := ctl.rolloutServiceClient.ListTaskRuns(ctx, connect.NewRequest(&v1pb.ListTaskRunsRequest{
+			Parent: taskName,
+		}))
+		a.NoError(err)
+		a.Equal(1, len(taskRunsResp.Msg.TaskRuns), "task %s should have exactly one task run after concurrent calls", taskName)
+	}
+
+	// Test 2: Sequential double-click (simulates user accidentally clicking twice)
+	_, err = ctl.rolloutServiceClient.BatchRunTasks(ctx, connect.NewRequest(&v1pb.BatchRunTasksRequest{
+		Parent: stage.Name,
+		Tasks:  taskNames,
+	}))
+	a.NoError(err, "sequential BatchRunTasks call should succeed")
+
+	// Verify still exactly one task run per task
+	for _, taskName := range taskNames {
+		taskRunsResp, err := ctl.rolloutServiceClient.ListTaskRuns(ctx, connect.NewRequest(&v1pb.ListTaskRunsRequest{
+			Parent: taskName,
+		}))
+		a.NoError(err)
+		a.Equal(1, len(taskRunsResp.Msg.TaskRuns), "task %s should still have exactly one task run after sequential call", taskName)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the issue where users clicking the "Rollout" button multiple times would encounter the error: `cannot create pending task runs because there are pending/running/done task runs`.

This PR makes the task run creation operation idempotent and safe for concurrent requests, providing a better user experience.

## Changes

### backend/store/task_run.go
- **Simplified `CreatePendingTaskRuns`** to use a single SQL query instead of complex multi-step approach
- Uses `WHERE NOT EXISTS` to filter out tasks that already have active (PENDING/RUNNING/DONE) task runs
- Uses `ON CONFLICT (task_id, attempt) DO NOTHING` to handle race conditions
- **Removed 5 helper functions** that are no longer needed:
  - `lockTasksForUpdate`
  - `getTaskIDsWithExistingRuns`
  - `getTaskNextAttempt`
  - `createPendingTaskRunsTx`
  - `checkTaskRunsExist`
- Removed unused `slices` import

### action/command/rollout.go
- Removed workaround error handling that was catching and ignoring the specific error
- Now relies on idempotent behavior at the store level

### backend/tests/task_run_idempotent_test.go (new)
- Added comprehensive integration test `TestBatchRunTasks_Idempotent`
- Tests both concurrent requests (5 simultaneous calls) and sequential double-clicks
- Verifies no duplicate task runs are created in either scenario

## Technical Details

The implementation leverages PostgreSQL's unique constraint on `(task_id, attempt)` to safely handle duplicate requests:
- **Idempotency**: `WHERE NOT EXISTS` ensures tasks with existing active runs are skipped
- **Race condition safety**: `ON CONFLICT DO NOTHING` silently ignores duplicate attempts from concurrent requests
- **Simplicity**: Single SQL statement (60 lines) vs. complex multi-query approach (200+ lines)

## Test Plan

All tests passing:
- ✅ `TestBatchRunTasks_Idempotent` - New comprehensive test
- ✅ `TestArchiveProject` - Existing integration test
- ✅ `TestSchemaAndDataUpdate` - Existing integration test

## Code Quality

- Code reduction: 93 lines removed from test file, 60+ lines removed from store implementation
- Linter: All issues resolved (modernized for loops to use `range` over int)
- Follows conventional commit format

🤖 Generated with [Claude Code](https://claude.com/claude-code)