### PR TITLE
fix: preserve task list pagination state on refresh

### DIFF
--- a/frontend/src/components/HighlightCodeBlock.ts
+++ b/frontend/src/components/HighlightCodeBlock.ts
@@ -1,5 +1,9 @@
+import { useVirtualizer } from "@tanstack/vue-virtual";
 import hljs from "highlight.js/lib/core";
-import { defineComponent, h } from "vue";
+import { computed, defineComponent, h, onMounted, ref, watch } from "vue";
+
+// Enable virtual scrolling for code with more lines than this
+const VIRTUAL_SCROLL_THRESHOLD = 100;
 
 export default defineComponent({
   name: "HighlightCodeBlock",
@@ -16,18 +20,189 @@ export default defineComponent({
       type: String,
       default: "pre",
     },
+    lazy: {
+      type: Boolean,
+      default: false,
+    },
+    virtual: {
+      type: Boolean,
+      default: false,
+    },
+    lineHeight: {
+      type: Number,
+      default: 20,
+    },
+  },
+  setup(props) {
+    const highlighted = ref(!props.lazy);
+    const highlightedCode = ref("");
+    const containerRef = ref<HTMLElement>();
+    const lineCache = ref<Map<number, string>>(new Map());
+
+    const lines = computed(() => props.code.split("\n"));
+    const shouldUseVirtual = computed(
+      () => props.virtual && lines.value.length > VIRTUAL_SCROLL_THRESHOLD
+    );
+
+    const highlightLine = (line: string): string => {
+      try {
+        const result = hljs.highlight(line, {
+          language: props.language,
+          ignoreIllegals: true,
+        });
+        return result.value;
+      } catch {
+        return line;
+      }
+    };
+
+    const doHighlight = () => {
+      if (shouldUseVirtual.value) {
+        // For virtual mode, highlighting happens per-line on demand
+        highlighted.value = true;
+        return;
+      }
+
+      const highlightFn = () => {
+        const result = hljs.highlight(props.code, {
+          language: props.language,
+        });
+        highlightedCode.value = result.value;
+        highlighted.value = true;
+      };
+
+      if (props.lazy) {
+        // Async highlighting
+        if (typeof requestIdleCallback !== "undefined") {
+          requestIdleCallback(highlightFn);
+        } else {
+          setTimeout(highlightFn, 0);
+        }
+      } else {
+        // Sync highlighting
+        highlightFn();
+      }
+    };
+
+    // Virtual scrolling setup
+    const virtualizer = useVirtualizer(
+      computed(() => ({
+        count: lines.value.length,
+        getScrollElement: () => containerRef.value ?? null,
+        estimateSize: () => props.lineHeight,
+        overscan: 10,
+      }))
+    );
+
+    const virtualItems = computed(() => virtualizer.value.getVirtualItems());
+
+    // Initialize highlighting
+    if (!props.lazy) {
+      doHighlight();
+    } else {
+      onMounted(() => {
+        doHighlight();
+      });
+    }
+
+    watch(
+      () => props.code,
+      () => {
+        highlighted.value = false;
+        lineCache.value.clear();
+        doHighlight();
+      }
+    );
+
+    return {
+      highlighted,
+      highlightedCode,
+      containerRef,
+      lines,
+      shouldUseVirtual,
+      virtualizer,
+      virtualItems,
+      highlightLine,
+      lineCache,
+    };
   },
   render() {
     const { code, language, tag } = this.$props;
     const { class: additionalClass } = this.$attrs;
 
-    const result = hljs.highlight(code, {
-      language: language,
-    });
+    // Virtual scrolling mode
+    if (this.shouldUseVirtual && this.highlighted) {
+      const virtualHeight = this.virtualizer.getTotalSize();
+      const virtualStart = this.virtualItems[0]?.start ?? 0;
 
+      return h(
+        "div",
+        {
+          ref: "containerRef",
+          class: ["overflow-auto", additionalClass],
+        },
+        [
+          h(
+            "div",
+            {
+              style: {
+                height: `${virtualHeight}px`,
+                position: "relative",
+              },
+            },
+            [
+              h(
+                tag,
+                {
+                  class: [language],
+                  style: {
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualStart}px)`,
+                    margin: 0,
+                  },
+                },
+                this.virtualItems.map((virtualRow) => {
+                  const lineIndex = virtualRow.index;
+                  const line = this.lines[lineIndex];
+
+                  // Check cache first
+                  if (!this.lineCache.has(lineIndex)) {
+                    this.lineCache.set(lineIndex, this.highlightLine(line));
+                  }
+
+                  return h("div", {
+                    key: String(virtualRow.key),
+                    style: {
+                      height: `${virtualRow.size}px`,
+                    },
+                    innerHTML: this.lineCache.get(lineIndex),
+                  });
+                })
+              ),
+            ]
+          ),
+        ]
+      );
+    }
+
+    // Non-virtual mode - show plain text while highlighting
+    if (!this.highlighted) {
+      return h(
+        tag,
+        {
+          class: [language, additionalClass],
+        },
+        code
+      );
+    }
+
+    // Highlighted content
     return h(tag, {
       class: [language, additionalClass],
-      innerHTML: result.value,
+      innerHTML: this.highlightedCode,
     });
   },
 });

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskItem.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskItem.vue
@@ -83,7 +83,9 @@
           v-else
           :code="displayedStatement"
           language="sql"
-          class="text-sm whitespace-pre-wrap wrap-break-word max-h-96 overflow-y-auto rounded p-2 bg-white border border-gray-200"
+          :lazy="true"
+          :virtual="true"
+          class="text-sm whitespace-pre-wrap wrap-break-word max-h-64 rounded p-2 bg-white border border-gray-200"
         />
       </div>
 

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskList.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskList.vue
@@ -125,11 +125,21 @@ const handleActionComplete = () => {
   events.emit("status-changed", { eager: true });
 };
 
-// Reset pagination when filters change or tasks change
+// Reset pagination when filters change, but preserve state on refresh
 watch(
-  () => [props.filterStatuses, props.stage.tasks.length],
+  () => props.filterStatuses,
   () => {
     displayedTaskCount.value = DEFAULT_PAGE_SIZE;
+  }
+);
+
+// Ensure displayedTaskCount doesn't exceed available tasks
+watch(
+  () => filteredTasks.value.length,
+  (newLength) => {
+    if (displayedTaskCount.value > newLength) {
+      displayedTaskCount.value = Math.max(DEFAULT_PAGE_SIZE, newLength);
+    }
   }
 );
 </script>

--- a/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskCollapse.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskCollapse.ts
@@ -1,5 +1,6 @@
-import { type Ref, ref } from "vue";
+import { type Ref, ref, watch } from "vue";
 import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
+import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { addToSet, deleteFromSet } from "../utils/reactivity";
 
 export interface UseTaskCollapseReturn {
@@ -8,8 +9,9 @@ export interface UseTaskCollapseReturn {
   toggleExpand: (task: Task) => void;
 }
 
-export const useTaskCollapse = (_tasks: Ref<Task[]>): UseTaskCollapseReturn => {
+export const useTaskCollapse = (tasks: Ref<Task[]>): UseTaskCollapseReturn => {
   const expandedTaskIds = ref<Set<string>>(new Set());
+  const lastTaskNames = ref<string>("");
 
   const isTaskExpanded = (task: Task): boolean => {
     return expandedTaskIds.value.has(task.name);
@@ -22,6 +24,37 @@ export const useTaskCollapse = (_tasks: Ref<Task[]>): UseTaskCollapseReturn => {
       addToSet(expandedTaskIds, task.name);
     }
   };
+
+  // Auto-expand first non-completed task when tasks change (initial load or stage switch)
+  watch(
+    tasks,
+    (newTasks) => {
+      if (newTasks.length === 0) {
+        return;
+      }
+
+      // Create a unique identifier for the current task set
+      const currentTaskNames = newTasks.map((t) => t.name).join(",");
+
+      // If tasks have changed (stage switch) or it's the first load, reset and auto-expand
+      if (currentTaskNames !== lastTaskNames.value) {
+        lastTaskNames.value = currentTaskNames;
+
+        // Clear expanded tasks from previous stage
+        expandedTaskIds.value.clear();
+
+        // Auto-expand first non-completed task
+        const firstActiveTask = newTasks.find(
+          (task) =>
+            task.status !== Task_Status.DONE &&
+            task.status !== Task_Status.CANCELED
+        );
+        const taskToExpand = firstActiveTask || newTasks[0];
+        addToSet(expandedTaskIds, taskToExpand.name);
+      }
+    },
+    { immediate: true }
+  );
 
   return {
     expandedTaskIds,

--- a/frontend/src/components/Plan/components/RolloutView/v2/constants.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/constants.ts
@@ -1,7 +1,7 @@
 /**
  * Number of tasks to display per page in the task list
  */
-export const DEFAULT_PAGE_SIZE = 20;
+export const DEFAULT_PAGE_SIZE = 10;
 
 /**
  * Maximum characters to show in collapsed SQL statement preview


### PR DESCRIPTION
Close BYT-7911

- Add virtual scrolling and lazy highlighting for large SQL statements (100+ lines)
- Enable lazy/virtual rendering for SQL code blocks in TaskItem
- Auto-expand first non-completed task on initial load for better UX
- Reduce initial page size from 20 to 10 tasks for faster rendering
