### PR TITLE
feat: add CREATE OR REPLACE warning for SDL schema changes

### DIFF
--- a/backend/plugin/advisor/code/code.go
+++ b/backend/plugin/advisor/code/code.go
@@ -79,6 +79,8 @@ const (
 	SDLDuplicateColumnName                    Code = 252
 	SDLMultiplePrimaryKey                     Code = 253
 	SDLViewDependencyNotFound                 Code = 254
+	SDLDropOperation                          Code = 255
+	SDLReplaceOperation                       Code = 256
 
 	// 301 ～ 399 naming error code
 	// 301 table naming advisor error code.

--- a/backend/plugin/advisor/pg/sdl_drop_check.go
+++ b/backend/plugin/advisor/pg/sdl_drop_check.go
@@ -1,0 +1,291 @@
+package pg
+
+import (
+	"fmt"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+)
+
+// CheckSDLDropOperations analyzes MetadataDiff for DROP and ALTER operations
+// and returns warnings for each DROP detected and info messages for ALTER (CREATE OR REPLACE) operations.
+func CheckSDLDropOperations(diff *schema.MetadataDiff) []*storepb.Advice {
+	if diff == nil {
+		return nil
+	}
+
+	var advices []*storepb.Advice
+
+	// Check schema drops
+	for _, schemaDiff := range diff.SchemaChanges {
+		if schemaDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping schema '%s' will result in data loss.\n\n"+
+						"This operation cannot be undone. Please ensure:\n"+
+						"- You have a backup of the data\n"+
+						"- This change is intentional\n"+
+						"- All dependent objects are handled",
+					schemaDiff.SchemaName,
+				),
+			})
+		}
+	}
+
+	// Check table drops
+	for _, tableDiff := range diff.TableChanges {
+		if tableDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping table '%s.%s' will result in data loss.\n\n"+
+						"This operation cannot be undone. Please ensure:\n"+
+						"- You have a backup of the data\n"+
+						"- This change is intentional\n"+
+						"- All dependent objects are handled",
+					tableDiff.SchemaName, tableDiff.TableName,
+				),
+			})
+		}
+
+		// Check column drops within table
+		for _, colDiff := range tableDiff.ColumnChanges {
+			if colDiff.Action == schema.MetadataDiffActionDrop {
+				columnName := ""
+				if colDiff.OldColumn != nil {
+					columnName = colDiff.OldColumn.Name
+				}
+				advices = append(advices, &storepb.Advice{
+					Status: storepb.Advice_WARNING,
+					Code:   code.SDLDropOperation.Int32(),
+					Title:  "DROP operation detected",
+					Content: fmt.Sprintf(
+						"Dropping column '%s' from table '%s.%s' will result in data loss.\n\n"+
+							"This operation cannot be undone. Please ensure:\n"+
+							"- You have a backup of the data\n"+
+							"- This change is intentional",
+						columnName, tableDiff.SchemaName, tableDiff.TableName,
+					),
+				})
+			}
+		}
+
+		// Check constraint drops within table
+		for _, fkDiff := range tableDiff.ForeignKeyChanges {
+			if fkDiff.Action == schema.MetadataDiffActionDrop {
+				fkName := ""
+				if fkDiff.OldForeignKey != nil {
+					fkName = fkDiff.OldForeignKey.Name
+				}
+				advices = append(advices, &storepb.Advice{
+					Status: storepb.Advice_WARNING,
+					Code:   code.SDLDropOperation.Int32(),
+					Title:  "DROP operation detected",
+					Content: fmt.Sprintf(
+						"Dropping foreign key constraint '%s' from table '%s.%s'.\n\n"+
+							"This change may affect referential integrity. Please ensure this is intentional.",
+						fkName, tableDiff.SchemaName, tableDiff.TableName,
+					),
+				})
+			}
+		}
+
+		for _, ckDiff := range tableDiff.CheckConstraintChanges {
+			if ckDiff.Action == schema.MetadataDiffActionDrop {
+				ckName := ""
+				if ckDiff.OldCheckConstraint != nil {
+					ckName = ckDiff.OldCheckConstraint.Name
+				}
+				advices = append(advices, &storepb.Advice{
+					Status: storepb.Advice_WARNING,
+					Code:   code.SDLDropOperation.Int32(),
+					Title:  "DROP operation detected",
+					Content: fmt.Sprintf(
+						"Dropping check constraint '%s' from table '%s.%s'.\n\n"+
+							"This change may allow previously invalid data. Please ensure this is intentional.",
+						ckName, tableDiff.SchemaName, tableDiff.TableName,
+					),
+				})
+			}
+		}
+	}
+
+	// Check view drops
+	for _, viewDiff := range diff.ViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping view '%s.%s' will affect dependent objects.\n\n"+
+						"Please ensure:\n"+
+						"- All dependent views, functions, and queries are updated\n"+
+						"- This change is intentional",
+					viewDiff.SchemaName, viewDiff.ViewName,
+				),
+			})
+		}
+	}
+
+	// Check materialized view drops
+	for _, mvDiff := range diff.MaterializedViewChanges {
+		if mvDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping materialized view '%s.%s' will result in data loss.\n\n"+
+						"This operation cannot be undone. Please ensure:\n"+
+						"- You have a backup of the data\n"+
+						"- This change is intentional\n"+
+						"- All dependent objects are handled",
+					mvDiff.SchemaName, mvDiff.MaterializedViewName,
+				),
+			})
+		}
+	}
+
+	// Check function drops
+	for _, funcDiff := range diff.FunctionChanges {
+		if funcDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping function '%s.%s' will affect dependent objects.\n\n"+
+						"Please ensure:\n"+
+						"- All dependent triggers, views, and functions are updated\n"+
+						"- This change is intentional",
+					funcDiff.SchemaName, funcDiff.FunctionName,
+				),
+			})
+		}
+	}
+
+	// Check procedure drops
+	for _, procDiff := range diff.ProcedureChanges {
+		if procDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping procedure '%s.%s' will affect dependent objects.\n\n"+
+						"Please ensure:\n"+
+						"- All dependent code and queries are updated\n"+
+						"- This change is intentional",
+					procDiff.SchemaName, procDiff.ProcedureName,
+				),
+			})
+		}
+	}
+
+	// Check sequence drops
+	for _, seqDiff := range diff.SequenceChanges {
+		if seqDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping sequence '%s.%s' may affect auto-increment columns.\n\n"+
+						"This operation cannot be undone. Please ensure:\n"+
+						"- No columns depend on this sequence\n"+
+						"- This change is intentional",
+					seqDiff.SchemaName, seqDiff.SequenceName,
+				),
+			})
+		}
+	}
+
+	// Check enum type drops
+	for _, enumDiff := range diff.EnumTypeChanges {
+		if enumDiff.Action == schema.MetadataDiffActionDrop {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLDropOperation.Int32(),
+				Title:  "DROP operation detected",
+				Content: fmt.Sprintf(
+					"Dropping enum type '%s.%s' will affect columns using this type.\n\n"+
+						"This operation cannot be undone. Please ensure:\n"+
+						"- No columns use this enum type\n"+
+						"- This change is intentional",
+					enumDiff.SchemaName, enumDiff.EnumTypeName,
+				),
+			})
+		}
+	}
+
+	// Check function ALTER operations (CREATE OR REPLACE)
+	for _, funcDiff := range diff.FunctionChanges {
+		if funcDiff.Action == schema.MetadataDiffActionAlter {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLReplaceOperation.Int32(),
+				Title:  "CREATE OR REPLACE operation detected",
+				Content: fmt.Sprintf(
+					"Function '%s.%s' definition will be replaced.\n\n"+
+						"The old function logic will be overwritten but dependent objects (triggers, views) will be preserved.\n\n"+
+						"Please ensure:\n"+
+						"- The new function logic is correct\n"+
+						"- Dependent triggers, views, and applications are compatible with the changes\n"+
+						"- You have tested the changes in a non-production environment",
+					funcDiff.SchemaName, funcDiff.FunctionName,
+				),
+			})
+		}
+	}
+
+	// Check procedure ALTER operations (CREATE OR REPLACE)
+	for _, procDiff := range diff.ProcedureChanges {
+		if procDiff.Action == schema.MetadataDiffActionAlter {
+			advices = append(advices, &storepb.Advice{
+				Status: storepb.Advice_WARNING,
+				Code:   code.SDLReplaceOperation.Int32(),
+				Title:  "CREATE OR REPLACE operation detected",
+				Content: fmt.Sprintf(
+					"Procedure '%s.%s' definition will be replaced.\n\n"+
+						"The old procedure logic will be overwritten but dependent objects will be preserved.\n\n"+
+						"Please ensure:\n"+
+						"- The new procedure logic is correct\n"+
+						"- Dependent code and applications are compatible with the changes\n"+
+						"- You have tested the changes in a non-production environment",
+					procDiff.SchemaName, procDiff.ProcedureName,
+				),
+			})
+		}
+	}
+
+	// Check trigger ALTER operations (CREATE OR REPLACE)
+	for _, tableDiff := range diff.TableChanges {
+		for _, triggerDiff := range tableDiff.TriggerChanges {
+			if triggerDiff.Action == schema.MetadataDiffActionAlter {
+				advices = append(advices, &storepb.Advice{
+					Status: storepb.Advice_WARNING,
+					Code:   code.SDLReplaceOperation.Int32(),
+					Title:  "CREATE OR REPLACE operation detected",
+					Content: fmt.Sprintf(
+						"Trigger '%s' on table '%s.%s' will be replaced.\n\n"+
+							"The old trigger logic will be overwritten.\n\n"+
+							"Please ensure:\n"+
+							"- The new trigger logic is correct\n"+
+							"- The trigger function reference is valid\n"+
+							"- You have tested the changes in a non-production environment",
+						triggerDiff.TriggerName, tableDiff.SchemaName, tableDiff.TableName,
+					),
+				})
+			}
+		}
+	}
+
+	return advices
+}

--- a/backend/plugin/advisor/pg/sdl_drop_check_test.go
+++ b/backend/plugin/advisor/pg/sdl_drop_check_test.go
@@ -1,0 +1,442 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+)
+
+func TestCheckSDLDropOperations(t *testing.T) {
+	tests := []struct {
+		name         string
+		diff         *schema.MetadataDiff
+		wantWarnings int
+		wantMessages []string
+	}{
+		{
+			name:         "No DROP operations",
+			diff:         &schema.MetadataDiff{},
+			wantWarnings: 0,
+		},
+		{
+			name: "DROP TABLE",
+			diff: &schema.MetadataDiff{
+				TableChanges: []*schema.TableDiff{
+					{
+						Action:     schema.MetadataDiffActionDrop,
+						SchemaName: "public",
+						TableName:  "users",
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"table 'public.users'"},
+		},
+		{
+			name: "DROP COLUMN",
+			diff: &schema.MetadataDiff{
+				TableChanges: []*schema.TableDiff{
+					{
+						Action:     schema.MetadataDiffActionAlter,
+						SchemaName: "public",
+						TableName:  "users",
+						ColumnChanges: []*schema.ColumnDiff{
+							{
+								Action: schema.MetadataDiffActionDrop,
+								OldColumn: &storepb.ColumnMetadata{
+									Name: "email",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"column 'email'"},
+		},
+		{
+			name: "Multiple DROPs",
+			diff: &schema.MetadataDiff{
+				TableChanges: []*schema.TableDiff{
+					{
+						Action:     schema.MetadataDiffActionDrop,
+						SchemaName: "public",
+						TableName:  "orders",
+					},
+				},
+				ViewChanges: []*schema.ViewDiff{
+					{
+						Action:     schema.MetadataDiffActionDrop,
+						SchemaName: "public",
+						ViewName:   "active_users",
+					},
+				},
+			},
+			wantWarnings: 2,
+			wantMessages: []string{"table 'public.orders'", "view 'public.active_users'"},
+		},
+		{
+			name: "DROP MATERIALIZED VIEW",
+			diff: &schema.MetadataDiff{
+				MaterializedViewChanges: []*schema.MaterializedViewDiff{
+					{
+						Action:               schema.MetadataDiffActionDrop,
+						SchemaName:           "public",
+						MaterializedViewName: "sales_summary",
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"materialized view 'public.sales_summary'"},
+		},
+		{
+			name: "DROP CONSTRAINT",
+			diff: &schema.MetadataDiff{
+				TableChanges: []*schema.TableDiff{
+					{
+						Action:     schema.MetadataDiffActionAlter,
+						SchemaName: "public",
+						TableName:  "users",
+						ForeignKeyChanges: []*schema.ForeignKeyDiff{
+							{
+								Action: schema.MetadataDiffActionDrop,
+								OldForeignKey: &storepb.ForeignKeyMetadata{
+									Name: "fk_users_teams",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"foreign key constraint 'fk_users_teams'"},
+		},
+		{
+			name: "DROP SEQUENCE",
+			diff: &schema.MetadataDiff{
+				SequenceChanges: []*schema.SequenceDiff{
+					{
+						Action:       schema.MetadataDiffActionDrop,
+						SchemaName:   "public",
+						SequenceName: "order_id_seq",
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"sequence 'public.order_id_seq'"},
+		},
+		{
+			name: "DROP FUNCTION",
+			diff: &schema.MetadataDiff{
+				FunctionChanges: []*schema.FunctionDiff{
+					{
+						Action:       schema.MetadataDiffActionDrop,
+						SchemaName:   "public",
+						FunctionName: "calculate_total",
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"function 'public.calculate_total'"},
+		},
+		{
+			name: "DROP PROCEDURE",
+			diff: &schema.MetadataDiff{
+				ProcedureChanges: []*schema.ProcedureDiff{
+					{
+						Action:        schema.MetadataDiffActionDrop,
+						SchemaName:    "public",
+						ProcedureName: "log_message",
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"procedure 'public.log_message'"},
+		},
+		{
+			name: "DROP ENUM TYPE",
+			diff: &schema.MetadataDiff{
+				EnumTypeChanges: []*schema.EnumTypeDiff{
+					{
+						Action:       schema.MetadataDiffActionDrop,
+						SchemaName:   "public",
+						EnumTypeName: "status",
+					},
+				},
+			},
+			wantWarnings: 1,
+			wantMessages: []string{"enum type 'public.status'"},
+		},
+		{
+			name: "Complex diff with mix of CREATE and DROP",
+			diff: &schema.MetadataDiff{
+				TableChanges: []*schema.TableDiff{
+					{
+						Action:     schema.MetadataDiffActionCreate,
+						SchemaName: "public",
+						TableName:  "products",
+					},
+					{
+						Action:     schema.MetadataDiffActionDrop,
+						SchemaName: "public",
+						TableName:  "old_products",
+					},
+					{
+						Action:     schema.MetadataDiffActionAlter,
+						SchemaName: "public",
+						TableName:  "users",
+						ColumnChanges: []*schema.ColumnDiff{
+							{
+								Action: schema.MetadataDiffActionDrop,
+								OldColumn: &storepb.ColumnMetadata{
+									Name: "legacy_field",
+								},
+							},
+						},
+					},
+				},
+				ViewChanges: []*schema.ViewDiff{
+					{
+						Action:     schema.MetadataDiffActionCreate,
+						SchemaName: "public",
+						ViewName:   "active_products",
+					},
+					{
+						Action:     schema.MetadataDiffActionDrop,
+						SchemaName: "public",
+						ViewName:   "inactive_products",
+					},
+				},
+			},
+			wantWarnings: 3,
+			wantMessages: []string{"table 'public.old_products'", "column 'legacy_field'", "view 'public.inactive_products'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			advices := CheckSDLDropOperations(tt.diff)
+
+			// Check number of warnings
+			warningCount := 0
+			for _, advice := range advices {
+				if advice.Status == storepb.Advice_WARNING {
+					warningCount++
+					assert.Equal(t, code.SDLDropOperation.Int32(), advice.Code)
+					assert.Equal(t, "DROP operation detected", advice.Title)
+				}
+			}
+			assert.Equal(t, tt.wantWarnings, warningCount,
+				"Expected %d warnings, got %d", tt.wantWarnings, warningCount)
+
+			// Check messages mentioned in warnings
+			if len(tt.wantMessages) > 0 {
+				for i, advice := range advices {
+					if i < len(tt.wantMessages) {
+						assert.Contains(t, advice.Content, tt.wantMessages[i],
+							"Warning should mention '%s'", tt.wantMessages[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCheckSDLDropOperations_Nil(t *testing.T) {
+	advices := CheckSDLDropOperations(nil)
+	require.Nil(t, advices)
+}
+
+func TestCheckSDLDropOperations_EmptyDiff(t *testing.T) {
+	advices := CheckSDLDropOperations(&schema.MetadataDiff{})
+	assert.Empty(t, advices)
+}
+
+func TestCheckSDLDropOperations_AlterOperations(t *testing.T) {
+	tests := []struct {
+		name            string
+		diff            *schema.MetadataDiff
+		wantInfoCount   int
+		wantMessages    []string
+		wantCodeMatches []int32
+	}{
+		{
+			name: "ALTER FUNCTION (CREATE OR REPLACE)",
+			diff: &schema.MetadataDiff{
+				FunctionChanges: []*schema.FunctionDiff{
+					{
+						Action:       schema.MetadataDiffActionAlter,
+						SchemaName:   "public",
+						FunctionName: "calculate_total",
+					},
+				},
+			},
+			wantInfoCount:   1,
+			wantMessages:    []string{"Function 'public.calculate_total'"},
+			wantCodeMatches: []int32{code.SDLReplaceOperation.Int32()},
+		},
+		{
+			name: "ALTER PROCEDURE (CREATE OR REPLACE)",
+			diff: &schema.MetadataDiff{
+				ProcedureChanges: []*schema.ProcedureDiff{
+					{
+						Action:        schema.MetadataDiffActionAlter,
+						SchemaName:    "public",
+						ProcedureName: "process_orders",
+					},
+				},
+			},
+			wantInfoCount:   1,
+			wantMessages:    []string{"Procedure 'public.process_orders'"},
+			wantCodeMatches: []int32{code.SDLReplaceOperation.Int32()},
+		},
+		{
+			name: "ALTER TRIGGER (CREATE OR REPLACE)",
+			diff: &schema.MetadataDiff{
+				TableChanges: []*schema.TableDiff{
+					{
+						Action:     schema.MetadataDiffActionAlter,
+						SchemaName: "public",
+						TableName:  "users",
+						TriggerChanges: []*schema.TriggerDiff{
+							{
+								Action:      schema.MetadataDiffActionAlter,
+								TriggerName: "update_timestamp",
+							},
+						},
+					},
+				},
+			},
+			wantInfoCount:   1,
+			wantMessages:    []string{"Trigger 'update_timestamp'"},
+			wantCodeMatches: []int32{code.SDLReplaceOperation.Int32()},
+		},
+		{
+			name: "Multiple ALTER operations",
+			diff: &schema.MetadataDiff{
+				FunctionChanges: []*schema.FunctionDiff{
+					{
+						Action:       schema.MetadataDiffActionAlter,
+						SchemaName:   "public",
+						FunctionName: "func1",
+					},
+					{
+						Action:       schema.MetadataDiffActionAlter,
+						SchemaName:   "public",
+						FunctionName: "func2",
+					},
+				},
+				ProcedureChanges: []*schema.ProcedureDiff{
+					{
+						Action:        schema.MetadataDiffActionAlter,
+						SchemaName:    "public",
+						ProcedureName: "proc1",
+					},
+				},
+			},
+			wantInfoCount:   3,
+			wantMessages:    []string{"Function 'public.func1'", "Function 'public.func2'", "Procedure 'public.proc1'"},
+			wantCodeMatches: []int32{code.SDLReplaceOperation.Int32(), code.SDLReplaceOperation.Int32(), code.SDLReplaceOperation.Int32()},
+		},
+		{
+			name: "Mix of DROP and ALTER operations",
+			diff: &schema.MetadataDiff{
+				FunctionChanges: []*schema.FunctionDiff{
+					{
+						Action:       schema.MetadataDiffActionDrop,
+						SchemaName:   "public",
+						FunctionName: "old_func",
+					},
+					{
+						Action:       schema.MetadataDiffActionAlter,
+						SchemaName:   "public",
+						FunctionName: "modified_func",
+					},
+				},
+			},
+			wantInfoCount: 2, // 1 DROP (WARNING) + 1 ALTER (SUCCESS with info message)
+			wantMessages:  []string{"function 'public.old_func'", "Function 'public.modified_func'"},
+			wantCodeMatches: []int32{
+				code.SDLDropOperation.Int32(),
+				code.SDLReplaceOperation.Int32(),
+			},
+		},
+		{
+			name: "ALTER with CREATE - no info (CREATE doesn't trigger ALTER check)",
+			diff: &schema.MetadataDiff{
+				FunctionChanges: []*schema.FunctionDiff{
+					{
+						Action:       schema.MetadataDiffActionCreate,
+						SchemaName:   "public",
+						FunctionName: "new_func",
+					},
+				},
+			},
+			wantInfoCount: 0,
+			wantMessages:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			advices := CheckSDLDropOperations(tt.diff)
+
+			// Check total count
+			assert.Equal(t, tt.wantInfoCount, len(advices),
+				"Expected %d advices, got %d", tt.wantInfoCount, len(advices))
+
+			// Check messages are present
+			for i, expectedMsg := range tt.wantMessages {
+				if i < len(advices) {
+					assert.Contains(t, advices[i].Content, expectedMsg,
+						"Advice %d should mention '%s'", i, expectedMsg)
+				}
+			}
+
+			// Check codes match
+			for i, expectedCode := range tt.wantCodeMatches {
+				if i < len(advices) {
+					assert.Equal(t, expectedCode, advices[i].Code,
+						"Advice %d should have code %d", i, expectedCode)
+				}
+			}
+
+			// For ALTER operations specifically, verify they use WARNING status
+			for _, advice := range advices {
+				if advice.Code == code.SDLReplaceOperation.Int32() {
+					assert.Equal(t, storepb.Advice_WARNING, advice.Status,
+						"ALTER operations should use WARNING status")
+					assert.Equal(t, "CREATE OR REPLACE operation detected", advice.Title,
+						"ALTER operations should have correct title")
+				}
+			}
+		})
+	}
+}
+
+func TestCheckSDLDropOperations_OnlyAlterWarnings(t *testing.T) {
+	// Test that ALTER operations generate WARNINGs with appropriate messaging
+	diff := &schema.MetadataDiff{
+		FunctionChanges: []*schema.FunctionDiff{
+			{
+				Action:       schema.MetadataDiffActionAlter,
+				SchemaName:   "public",
+				FunctionName: "test_func",
+			},
+		},
+	}
+
+	advices := CheckSDLDropOperations(diff)
+
+	require.Len(t, advices, 1)
+	assert.Equal(t, storepb.Advice_WARNING, advices[0].Status,
+		"ALTER operations should generate WARNINGs")
+	assert.Equal(t, code.SDLReplaceOperation.Int32(), advices[0].Code)
+	assert.Contains(t, advices[0].Content, "will be replaced")
+	assert.Contains(t, advices[0].Content, "dependent objects")
+}


### PR DESCRIPTION
Add warnings for CREATE OR REPLACE operations (ALTER actions) in SDL mode to notify users when function, procedure, or trigger definitions are being replaced. This complements the existing DROP operation warnings.

Changes:
- Add SDLReplaceOperation error code (256)
- Extend CheckSDLDropOperations to detect ALTER operations
- Generate WARNING-level advices for CREATE OR REPLACE operations
- Add comprehensive test coverage for ALTER scenarios

The warnings inform users that:
- Old logic will be overwritten
- Dependent objects (triggers, views) will be preserved
- Changes should be tested before production deployment

Covered object types:
- Functions (CREATE OR REPLACE FUNCTION)
- Procedures (CREATE OR REPLACE PROCEDURE)
- Triggers (CREATE OR REPLACE TRIGGER)

🤖 Generated with [Claude Code](https://claude.com/claude-code)