### PR TITLE
feat(frontend): add StageTimeline component for task run history

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/v2/StageContentView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageContentView.vue
@@ -70,13 +70,43 @@
       </div>
     </div>
 
-    <!-- Task list content -->
-    <TaskList
-      :stage="selectedStage"
-      :rollout="rollout"
-      :filter-statuses="filterStatuses"
-      :readonly="!isStageCreated(selectedStage)"
-    />
+    <!-- Main content area: responsive layout -->
+    <div class="flex" :class="isWideScreen ? 'flex-row' : 'flex-col'">
+      <!-- Timeline: inline above on narrow screen -->
+       <div v-if="!isWideScreen && isStageCreated(selectedStage)" class="mb-4">
+         <StageTimeline
+           :stage="selectedStage"
+           :task-runs="taskRuns"
+           :is-inline="true"
+           class="border-y"
+         />
+
+       </div>
+
+      <!-- Task list content -->
+      <div class="flex-1 min-w-0">
+        <TaskList
+          :stage="selectedStage"
+          :rollout="rollout"
+          :filter-statuses="filterStatuses"
+          :readonly="!isStageCreated(selectedStage)"
+        />
+      </div>
+
+      <!-- Timeline: sidebar on wide screen (sticky) -->
+      <div
+        v-if="isWideScreen && isStageCreated(selectedStage)"
+        class="shrink-0 pr-4 self-start sticky top-0"
+      >
+        <div class="w-64 border rounded-lg">
+          <StageTimeline
+            :stage="selectedStage"
+            :task-runs="taskRuns"
+            :is-inline="false"
+          />
+        </div>
+      </div>
+    </div>
 
     <!-- Rollback drawer -->
     <TaskRunRollbackDrawer
@@ -95,6 +125,7 @@
 </template>
 
 <script lang="ts" setup>
+import { useMediaQuery } from "@vueuse/core";
 import { DatabaseBackupIcon, PlayIcon, PlusIcon } from "lucide-vue-next";
 import { NButton, NTag } from "naive-ui";
 import { computed, ref, toRef } from "vue";
@@ -105,6 +136,7 @@ import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { usePlanContextWithRollout } from "../../../logic";
 import TaskRunRollbackDrawer from "../TaskRunRollbackDrawer.vue";
 import { useRollbackableTasks } from "./composables/useRollbackableTasks";
+import StageTimeline from "./StageTimeline.vue";
 import TaskFilter from "./TaskFilter.vue";
 import TaskList from "./TaskList.vue";
 
@@ -121,6 +153,9 @@ defineEmits<{
 
 const environmentStore = useEnvironmentV1Store();
 const filterStatuses = ref<Task_Status[]>([]);
+
+// Responsive layout: sidebar on wide screen, inline on narrow
+const isWideScreen = useMediaQuery("(min-width: 1024px)");
 
 // Rollback functionality
 const { taskRuns } = usePlanContextWithRollout();

--- a/frontend/src/components/Plan/components/RolloutView/v2/StageTimeline.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageTimeline.vue
@@ -1,0 +1,248 @@
+<template>
+  <div>
+    <!-- Header -->
+    <div
+      class="flex items-center justify-between px-3 py-2"
+      :class="[isExpanded && 'border-b']"
+      @click="isInline && (isCollapsed = !isCollapsed)"
+    >
+      <div class="flex items-center gap-2">
+        <!-- Only show toggle icon in inline mode -->
+        <component
+          :is="isCollapsed ? ChevronRightIcon : ChevronDownIcon"
+          v-if="isInline"
+          class="w-4 h-4 text-gray-500"
+        />
+        <span class="text-sm font-medium text-gray-700">
+          {{ $t("task.run-history") }}
+        </span>
+        <span v-if="stageTaskRuns.length > 0" class="text-gray-500">
+          ({{ stageTaskRuns.length }})
+        </span>
+      </div>
+    </div>
+
+    <!-- Timeline entries: always show in sidebar mode, toggle in inline mode -->
+    <div
+      v-if="isExpanded"
+      class="overflow-y-auto px-3 py-3"
+      :class="isInline ? 'max-h-48' : 'max-h-[calc(100vh-300px)]'"
+    >
+      <div
+        v-if="isLoading"
+        class="py-4 text-sm text-gray-400 text-center"
+      >
+        {{ $t("common.loading") }}
+      </div>
+      <div
+        v-else-if="stageTaskRuns.length === 0"
+        class="py-4 text-sm text-gray-500 text-center"
+      >
+        {{ $t("common.no-data") }}
+      </div>
+      <NTimeline v-else size="medium">
+        <NTimelineItem
+          v-for="taskRun in sortedTaskRuns"
+          :key="taskRun.name"
+          :type="getTimelineType(taskRun.status)"
+        >
+          <template #icon>
+            <TaskStatus
+              :status="mapTaskRunStatusToTaskStatus(taskRun.status)"
+              size="small"
+              :disabled="true"
+            />
+          </template>
+          <div
+            class="-ml-1 px-1 py-0.5 rounded -mt-0.5"
+            @click="handleClickTaskRun(taskRun)"
+          >
+            <div
+              class="text-sm leading-4 truncate cursor-pointer hover:underline"
+              @click.stop="handleClickTarget(taskRun)"
+            >
+              <span
+                v-if="getTaskTargetDisplay(taskRun).instance"
+                class="text-gray-500"
+              >
+                {{ getTaskTargetDisplay(taskRun).instance }}
+              </span>
+              <span
+                v-if="getTaskTargetDisplay(taskRun).instance"
+                class="text-gray-400 mx-0.5"
+                >/</span
+              >
+              <span>{{
+                getTaskTargetDisplay(taskRun).database
+              }}</span>
+            </div>
+            <!-- Error preview for failed -->
+            <div
+              v-if="taskRun.status === TaskRun_Status.FAILED && taskRun.detail"
+              class="text-xs text-red-600 truncate mt-0.5"
+            >
+              {{ getErrorPreview(taskRun.detail) }}
+            </div>
+            <!-- Scheduled run time for pending -->
+            <div
+              v-if="
+                taskRun.status === TaskRun_Status.PENDING && taskRun.runTime
+              "
+              class="text-xs text-gray-500 mt-0.5 flex items-center gap-1"
+            >
+{{ $t("task.scheduled-at") }}
+              <TimestampDisplay
+                :timestamp="taskRun.runTime"
+                custom-class="!text-xs !text-gray-500"
+              />
+            </div>
+            <!-- Duration and Timestamp -->
+            <div class="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+              <NTooltip v-if="getDuration(taskRun)">
+                <template #trigger>
+                  <span class="">{{ getDuration(taskRun) }}</span>
+                </template>
+                {{ $t("common.duration") }}
+              </NTooltip>
+              <span v-if="getDuration(taskRun)">·</span>
+              <TimestampDisplay
+                :timestamp="taskRun.updateTime"
+                custom-class="!text-xs !text-gray-400"
+              />
+            </div>
+          </div>
+        </NTimelineItem>
+      </NTimeline>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-vue-next";
+import { NTimeline, NTimelineItem, NTooltip } from "naive-ui";
+import { computed, ref } from "vue";
+import TimestampDisplay from "@/components/misc/Timestamp.vue";
+import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
+import type { Stage, TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
+import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  extractDatabaseResourceName,
+  extractInstanceResourceName,
+} from "@/utils";
+import { useResourcePoller } from "../../../logic/poller";
+import { useTaskNavigation } from "./composables/useTaskNavigation";
+import {
+  getErrorPreview,
+  getTaskNameFromTaskRun,
+  getTimelineType,
+  mapTaskRunStatusToTaskStatus,
+} from "./composables/useTaskRunUtils";
+import { formatDuration } from "./composables/useTaskTiming";
+
+const props = withDefaults(
+  defineProps<{
+    stage: Stage | null | undefined;
+    taskRuns: TaskRun[];
+    isInline?: boolean;
+  }>(),
+  {
+    isInline: false,
+  }
+);
+
+const emit = defineEmits<{
+  (event: "click-task-run", taskRun: TaskRun): void;
+}>();
+
+const isCollapsed = ref(false);
+const { navigateToTaskDetail } = useTaskNavigation();
+const { lastRefreshTime } = useResourcePoller();
+
+// In sidebar mode (not inline), always show expanded
+const isExpanded = computed(() => !props.isInline || !isCollapsed.value);
+
+// Filter task runs for this stage
+const stageTaskRuns = computed(() => {
+  if (!props.stage) return [];
+
+  const stageTaskNames = new Set(props.stage.tasks.map((t) => t.name));
+  return props.taskRuns.filter((run) =>
+    stageTaskNames.has(getTaskNameFromTaskRun(run.name))
+  );
+});
+
+// Check if we're still in initial loading state (never refreshed yet)
+const isLoading = computed(
+  () => lastRefreshTime.value === 0 && stageTaskRuns.value.length === 0
+);
+
+// Sort by updateTime descending (most recent first)
+const sortedTaskRuns = computed(() => {
+  return [...stageTaskRuns.value].sort((a, b) => {
+    const timeA = a.updateTime?.seconds ?? BigInt(0);
+    const timeB = b.updateTime?.seconds ?? BigInt(0);
+    return Number(timeB - timeA);
+  });
+});
+
+const getTaskFromTaskRun = (taskRun: TaskRun) => {
+  const taskName = getTaskNameFromTaskRun(taskRun.name);
+  return props.stage?.tasks.find((t) => t.name === taskName);
+};
+
+const getTaskTargetDisplay = (
+  taskRun: TaskRun
+): { instance: string; database: string } => {
+  const task = getTaskFromTaskRun(taskRun);
+  const target = task?.target;
+
+  if (!target) {
+    return {
+      instance: "",
+      database: taskRun.name.split("/").pop() || "unknown",
+    };
+  }
+
+  return {
+    instance: extractInstanceResourceName(target) || "",
+    database: extractDatabaseResourceName(target).databaseName || "unknown",
+  };
+};
+
+const getDuration = (taskRun: TaskRun): string => {
+  const startTime = taskRun.startTime;
+  const status = taskRun.status;
+
+  // PENDING tasks are scheduled/queued, not running - no duration to show
+  if (status === TaskRun_Status.PENDING) {
+    return "";
+  }
+
+  if (!startTime) return "";
+
+  if (status === TaskRun_Status.RUNNING) {
+    // Show elapsed time for running tasks
+    const elapsedMs = Date.now() - Number(startTime.seconds) * 1000;
+    return elapsedMs > 0 ? formatDuration(elapsedMs) : "";
+  }
+
+  // For completed tasks (DONE, FAILED, CANCELED), show total duration
+  const endTime = taskRun.updateTime;
+  if (!endTime) return "";
+
+  const durationMs =
+    (Number(endTime.seconds) - Number(startTime.seconds)) * 1000;
+  return durationMs > 0 ? formatDuration(durationMs) : "";
+};
+
+const handleClickTarget = (taskRun: TaskRun) => {
+  const task = getTaskFromTaskRun(taskRun);
+  if (task) {
+    navigateToTaskDetail(task);
+  }
+};
+
+const handleClickTaskRun = (taskRun: TaskRun) => {
+  emit("click-task-run", taskRun);
+};
+</script>

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskList.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskList.vue
@@ -11,7 +11,7 @@
       @action-complete="handleActionComplete"
     />
 
-    <div class="task-list px-4 py-4 space-y-3">
+    <div class="task-list px-4 py-3 space-y-3">
       <TaskItem
         v-for="task in visibleTasks"
         :key="task.name"

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskToolbar.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskToolbar.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="task-toolbar sticky top-0 z-10 px-4 py-3 transition-colors bg-blue-100"
+    class="task-toolbar sticky top-0 z-10 px-4"
   >
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-between border px-2 py-1 rounded-lg border-blue-200 bg-blue-100">
       <!-- Left section -->
       <div class="flex items-center gap-x-3">
         <!-- Select all checkbox -->

--- a/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskRunUtils.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskRunUtils.ts
@@ -1,0 +1,70 @@
+import { taskRunNamePrefix } from "@/store";
+import {
+  Task_Status,
+  TaskRun_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
+
+/**
+ * Extract task name from task run name.
+ * Format: projects/{project}/rollouts/{rollout}/stages/{stage}/tasks/{task}/taskRuns/{taskRun}
+ */
+export const getTaskNameFromTaskRun = (taskRunName: string): string => {
+  return taskRunName.replace(
+    `/${taskRunNamePrefix}${taskRunName.split("/").pop()}`,
+    ""
+  );
+};
+
+/**
+ * Map TaskRun_Status to Task_Status for TaskStatus component.
+ */
+export const mapTaskRunStatusToTaskStatus = (
+  status: TaskRun_Status
+): Task_Status => {
+  switch (status) {
+    case TaskRun_Status.PENDING:
+      return Task_Status.PENDING;
+    case TaskRun_Status.RUNNING:
+      return Task_Status.RUNNING;
+    case TaskRun_Status.DONE:
+      return Task_Status.DONE;
+    case TaskRun_Status.FAILED:
+      return Task_Status.FAILED;
+    case TaskRun_Status.CANCELED:
+      return Task_Status.CANCELED;
+    default:
+      return Task_Status.STATUS_UNSPECIFIED;
+  }
+};
+
+export type TimelineType = "success" | "error" | "warning" | "info" | "default";
+
+/**
+ * Get NTimeline type from TaskRun_Status.
+ */
+export const getTimelineType = (status: TaskRun_Status): TimelineType => {
+  switch (status) {
+    case TaskRun_Status.DONE:
+      return "success";
+    case TaskRun_Status.FAILED:
+      return "error";
+    case TaskRun_Status.RUNNING:
+      return "info";
+    case TaskRun_Status.PENDING:
+      return "warning";
+    case TaskRun_Status.CANCELED:
+      return "default";
+    default:
+      return "default";
+  }
+};
+
+/**
+ * Get first line preview of error detail, truncated to maxLength.
+ */
+export const getErrorPreview = (detail: string, maxLength = 50): string => {
+  const firstLine = detail.split("\n")[0];
+  return firstLine.length > maxLength
+    ? `${firstLine.substring(0, maxLength)}...`
+    : firstLine;
+};

--- a/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskTiming.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskTiming.ts
@@ -96,7 +96,7 @@ export const useTaskTiming = (
   };
 };
 
-const formatDuration = (durationMs: number): string => {
+export const formatDuration = (durationMs: number): string => {
   const seconds = Math.floor(durationMs / 1000);
   const minutes = Math.floor(seconds / 60);
   const hours = Math.floor(minutes / 60);

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -318,6 +318,8 @@
     "no-permission": "No permission to perform this action",
     "data-export-creator-only": "Only the issue creator can execute data export tasks",
     "scheduled-time": "Scheduled time",
+    "scheduled-at": "Scheduled at",
+    "run-history": "Run History",
     "select-scheduled-time": "Select scheduled time",
     "error": {
       "scheduled-time-must-be-in-the-future": "Scheduled time must be in the future"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -318,6 +318,8 @@
     "no-permission": "No hay permiso para realizar esta acción",
     "data-export-creator-only": "Sólo el creador del problema puede ejecutar tareas de exportación de datos",
     "scheduled-time": "Hora programada",
+    "scheduled-at": "Programado en",
+    "run-history": "Historial de ejecución",
     "select-scheduled-time": "Seleccionar hora programada",
     "error": {
       "scheduled-time-must-be-in-the-future": "La hora programada debe ser en el futuro"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -318,6 +318,8 @@
     "no-permission": "この操作を実行する権限がありません",
     "data-export-creator-only": "問題作成者のみがデータエクスポートタスクを実行できます",
     "scheduled-time": "予定時刻",
+    "scheduled-at": "予定日時",
+    "run-history": "実行履歴",
     "select-scheduled-time": "予定時刻を選択してください",
     "error": {
       "scheduled-time-must-be-in-the-future": "スケジュール時間は将来の時間である必要があります"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -318,6 +318,8 @@
     "no-permission": "Không có quyền thực hiện hành động này",
     "data-export-creator-only": "Chỉ người tạo sự cố mới có thể thực hiện tác vụ xuất dữ liệu",
     "scheduled-time": "Thời gian đã lên lịch",
+    "scheduled-at": "Đã lên lịch tại",
+    "run-history": "Lịch sử chạy",
     "select-scheduled-time": "Chọn thời gian đã lên lịch",
     "error": {
       "scheduled-time-must-be-in-the-future": "Thời gian dự kiến phải ở trong tương lai"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -318,6 +318,8 @@
     "no-permission": "无权限执行该操作",
     "data-export-creator-only": "只有工单创建者可以执行数据导出任务",
     "scheduled-time": "计划时间",
+    "scheduled-at": "计划于",
+    "run-history": "执行历史",
     "select-scheduled-time": "选择计划时间",
     "error": {
       "scheduled-time-must-be-in-the-future": "计划时间必须是将来的时间"


### PR DESCRIPTION
Part of BYT-8392

- Add StageTimeline.vue showing task run history with status, duration, and timestamps in a timeline view
- Support inline (collapsible) and sidebar (sticky) display modes
- Extract shared utilities to useTaskRunUtils.ts for better maintainability

<img width="2500" height="1584" alt="image" src="https://github.com/user-attachments/assets/aacbb890-78bc-4835-881c-2a254fafd90c" />

