### PR TITLE
refactor: webhook message

### DIFF
--- a/backend/plugin/webhook/slack/slack.go
+++ b/backend/plugin/webhook/slack/slack.go
@@ -145,6 +145,7 @@ func (*Receiver) Post(context webhook.Context) error {
 		if postDirectMessage(context) {
 			return nil
 		}
+		slog.Warn("failed to send direct messages for slack users, fallback to normal webhook", slog.String("event", context.EventType))
 	}
 	return postMessage(context)
 }
@@ -196,6 +197,7 @@ func postDirectMessage(webhookCtx webhook.Context) bool {
 	ctx := context.Background()
 	t := getSlackToken(webhookCtx.IMSetting)
 	if t == "" {
+		slog.Warn("failed to found valid slack im token", slog.String("event", webhookCtx.EventType))
 		return false
 	}
 	p := newProvider(t)
@@ -228,7 +230,7 @@ func postDirectMessage(webhookCtx webhook.Context) bool {
 		}
 		return errs
 	}); err != nil {
-		slog.Warn("failed to send direct message to slack user", log.BBError(err))
+		slog.Warn("failed to send direct message to slack user", log.BBError(err), slog.String("event", webhookCtx.EventType))
 		return false
 	}
 

--- a/backend/plugin/webhook/webhook.go
+++ b/backend/plugin/webhook/webhook.go
@@ -95,8 +95,7 @@ type Context struct {
 	Project     *Project
 	TaskResult  *TaskResult
 	// End users that should be mentioned.
-	MentionEndUsers     []*store.UserMessage
-	MentionUsersByPhone []string
+	MentionEndUsers []*store.UserMessage
 
 	DirectMessage bool
 	IMSetting     *storepb.AppIMSetting

--- a/frontend/src/components/ProjectWebhookForm.vue
+++ b/frontend/src/components/ProjectWebhookForm.vue
@@ -87,6 +87,40 @@
             :disabled="!allowEdit"
           />
         </div>
+        <div>
+          <div class="text-md leading-6 font-medium text-main">
+            {{ $t("project.webhook.triggering-activity") }}
+            <RequiredStar />
+          </div>
+          <div class="flex flex-col gap-y-4 mt-2">
+            <div v-for="(item, index) in webhookActivityItemList" :key="index">
+              <div>
+                <div class="flex items-center">
+                  <NCheckbox
+                    :label="item.title"
+                    :checked="isEventOn(item.activity)"
+                    @update:checked="
+                      (on: boolean) => {
+                        toggleEvent(item.activity, on);
+                      }
+                    "
+                  />
+                  <NTooltip
+                    v-if="
+                      webhookSupportDirectMessage && item.supportDirectMessage
+                    "
+                  >
+                    <template #trigger>
+                      <InfoIcon class="w-4 h-auto text-gray-500" />
+                    </template>
+                    {{ $t("project.webhook.activity-support-direct-message") }}
+                  </NTooltip>
+                </div>
+                <div class="textinfolabel">{{ item.label }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
         <div v-if="webhookSupportDirectMessage">
           <div class="text-md leading-6 font-medium text-main">
             {{ $t("project.webhook.direct-messages") }}
@@ -141,44 +175,10 @@
             />
           </div>
         </div>
-        <div>
-          <div class="text-md leading-6 font-medium text-main">
-            {{ $t("project.webhook.triggering-activity") }}
-            <RequiredStar />
-          </div>
-          <div class="flex flex-col gap-y-4 mt-2">
-            <div v-for="(item, index) in webhookActivityItemList" :key="index">
-              <div>
-                <div class="flex items-center">
-                  <NCheckbox
-                    :label="item.title"
-                    :checked="isEventOn(item.activity)"
-                    @update:checked="
-                      (on: boolean) => {
-                        toggleEvent(item.activity, on);
-                      }
-                    "
-                  />
-                  <NTooltip
-                    v-if="
-                      webhookSupportDirectMessage && item.supportDirectMessage
-                    "
-                  >
-                    <template #trigger>
-                      <InfoIcon class="w-4 h-auto text-gray-500" />
-                    </template>
-                    {{ $t("project.webhook.activity-support-direct-message") }}
-                  </NTooltip>
-                </div>
-                <div class="textinfolabel">{{ item.label }}</div>
-              </div>
-            </div>
-          </div>
-          <div class="mt-4">
-            <NButton @click.prevent="testWebhook">
-              {{ $t("project.webhook.test-webhook") }}
-            </NButton>
-          </div>
+        <div class="mt-4">
+          <NButton @click.prevent="testWebhook">
+            {{ $t("project.webhook.test-webhook") }}
+          </NButton>
         </div>
       </div>
     </template>
@@ -201,7 +201,7 @@
           :require-confirm="true"
           @confirm="deleteWebhook"
         />
-        <div class="gap-x-3">
+        <div class="flex items-center gap-x-3">
           <NButton v-if="create" @click.prevent="cancel">
             {{ $t("common.cancel") }}
           </NButton>


### PR DESCRIPTION
We used to return errors when failed to get users https://github.com/bytebase/bytebase/blob/main/backend/component/webhook/manager.go#L201, I'm not sure if it's the reason for BYT-8390. In this PR I add log and change it to `continue` https://github.com/bytebase/bytebase/pull/18200/files#diff-20b165960aae41a7a319056723a078c647f1d2b426045d9381c9ffd9b8fe1820R275

- Code refactor, and move the user phone logic into the dingtalk
- Add more logs
- UI fix for the webhook form: 1. The gap for buttons doesn't work 2. Move the "Direct messages" section under the "Triggering activities" section

<img width="1932" height="1718" alt="CleanShot 2025-11-26 at 10 27 37@2x" src="https://github.com/user-attachments/assets/ef7198b2-d6a1-4539-a629-06cbe297faff" />
