### PR TITLE
fix(frontend): convert JSX to h() in StepsTable to fix invalid vnode error

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/common/StepsTable.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/common/StepsTable.vue
@@ -20,7 +20,7 @@
   </div>
 </template>
 
-<script lang="tsx" setup>
+<script lang="ts" setup>
 /* eslint-disable vue/no-mutating-props */
 import {
   ArrowDownIcon,
@@ -30,7 +30,7 @@ import {
 } from "lucide-vue-next";
 import type { DataTableColumn } from "naive-ui";
 import { NButton, NDataTable } from "naive-ui";
-import { computed } from "vue";
+import { computed, h } from "vue";
 import { useI18n } from "vue-i18n";
 import { RoleSelect } from "@/components/v2";
 import { SpinnerButton } from "@/components/v2/Form";
@@ -70,18 +70,16 @@ const columns = computed(
         resizable: true,
         render: (stepData) => {
           if (props.editable) {
-            return (
-              <RoleSelect
-                suffix=""
-                value={stepData.role}
-                style="width: 80%"
-                onUpdate:value={(val: string | string[]) => {
-                  const role = Array.isArray(val) ? val[0] : val;
-                  props.flow.roles[stepData.index] = role;
-                  emit("update");
-                }}
-              />
-            );
+            return h(RoleSelect, {
+              suffix: "",
+              value: stepData.role,
+              style: "width: 80%",
+              "onUpdate:value": (val: string | string[]) => {
+                const role = Array.isArray(val) ? val[0] : val;
+                props.flow.roles[stepData.index] = role;
+                emit("update");
+              },
+            });
           }
           return displayRoleTitle(stepData.role);
         },
@@ -92,33 +90,38 @@ const columns = computed(
       cols.push({
         title: t("common.operations"),
         key: "operations",
-        render: (stepData, index) => (
-          <div class="flex gap-x-1">
-            <NButton
-              disabled={index === 0 || !allowAdmin.value}
-              size="tiny"
-              onClick={() => reorder(stepData, -1)}
-            >
-              <ArrowUpIcon class={"w-4"} />
-            </NButton>
-            <NButton
-              disabled={index === steps.value.length - 1 || !allowAdmin.value}
-              size="tiny"
-              onClick={() => reorder(stepData, 1)}
-            >
-              <ArrowDownIcon class={"w-4"} />
-            </NButton>
-            {allowAdmin.value && (
-              <SpinnerButton
-                size="tiny"
-                tooltip={t("custom-approval.approval-flow.node.delete")}
-                onConfirm={() => removeStep(stepData)}
-              >
-                <TrashIcon class={"w-3"} />
-              </SpinnerButton>
-            )}
-          </div>
-        ),
+        render: (stepData, index) =>
+          h("div", { class: "flex gap-x-1" }, [
+            h(
+              NButton,
+              {
+                disabled: index === 0 || !allowAdmin.value,
+                size: "tiny",
+                onClick: () => reorder(stepData, -1),
+              },
+              () => h(ArrowUpIcon, { class: "w-4" })
+            ),
+            h(
+              NButton,
+              {
+                disabled: index === steps.value.length - 1 || !allowAdmin.value,
+                size: "tiny",
+                onClick: () => reorder(stepData, 1),
+              },
+              () => h(ArrowDownIcon, { class: "w-4" })
+            ),
+            allowAdmin.value
+              ? h(
+                  SpinnerButton,
+                  {
+                    size: "tiny",
+                    tooltip: t("custom-approval.approval-flow.node.delete"),
+                    onConfirm: () => removeStep(stepData),
+                  },
+                  () => h(TrashIcon, { class: "w-3" })
+                )
+              : null,
+          ]),
       });
     }
 


### PR DESCRIPTION
## Summary
- Fix "Invalid vnode type: undefined" Vue warning in StepsTable component
- Root cause: The component used `lang="tsx"` with BOTH template slots (`<template #icon>`) AND JSX in the script section, causing a conflict between Vue template compiler and JSX transformer
- Solution: Convert JSX render functions to use Vue's `h()` function and change from `lang="tsx"` to `lang="ts"`, which allows restoring the `<template #icon>` slot syntax

## Changes
- Changed `<script lang="tsx" setup>` to `<script lang="ts" setup>`
- Converted JSX in column render functions to use `h()` function calls
- Restored `<template #icon>` slot syntax for the Add button

## Test plan
- [ ] Open Custom Approval settings page
- [ ] Click to add/edit an approval rule  
- [ ] Verify no Vue warnings in console
- [ ] Verify the Add button displays correctly with icon
- [ ] Verify role select dropdown works in edit mode
- [ ] Verify operation buttons (up, down, delete) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)