### PR TITLE
fix(frontend): fix condition values not showing in Custom Approval edit modal

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
@@ -135,22 +135,23 @@ const allowSave = computed(() => {
 });
 
 const resolveLocalState = async () => {
+  // Reset to empty state immediately to unmount old Condition components.
+  // This prevents component reuse issues when switching between rules,
+  // where the ValueInput watch would reset values when factor/operator changes.
+  state.conditionExpr = wrapAsGroup(emptySimpleExpr());
+  state.flow = createProto(ApprovalFlowSchema, { roles: [] });
+
   if (props.rule) {
-    let expr: ConditionGroupExpr = wrapAsGroup(emptySimpleExpr());
     if (props.rule.condition) {
       const parsedExprs = await batchConvertCELStringToParsedExpr([
         props.rule.condition,
       ]);
       const celExpr = head(parsedExprs);
       if (celExpr) {
-        expr = wrapAsGroup(resolveCELExpr(celExpr));
+        state.conditionExpr = wrapAsGroup(resolveCELExpr(celExpr));
       }
     }
-    state.conditionExpr = expr;
     state.flow = cloneDeep(props.rule.flow);
-  } else {
-    state.conditionExpr = wrapAsGroup(emptySimpleExpr());
-    state.flow = createProto(ApprovalFlowSchema, { roles: [] });
   }
 };
 

--- a/frontend/src/components/ExprEditor/components/MultiSelect.vue
+++ b/frontend/src/components/ExprEditor/components/MultiSelect.vue
@@ -84,7 +84,8 @@ const toggleCheckAll = (on: boolean) => {
   }
 };
 
-const handleSearch = useDebounceFn(async (search: string) => {
+// Non-debounced function for initial load
+const loadOptions = async (search: string) => {
   if (!optionConfig.value.search) {
     state.rawOptionList = [...optionConfig.value.options];
     return;
@@ -97,12 +98,17 @@ const handleSearch = useDebounceFn(async (search: string) => {
   } finally {
     state.loading = false;
   }
-}, DEBOUNCE_SEARCH_DELAY);
+};
+
+// Debounced version for user-typed searches
+const handleSearch = useDebounceFn(loadOptions, DEBOUNCE_SEARCH_DELAY);
 
 watch(
   () => factor.value,
   async () => {
-    await handleSearch("");
+    // Use non-debounced loadOptions for initial load to ensure options
+    // are available immediately when the component renders
+    await loadOptions("");
     // valid initial value.
     const search = optionConfig.value.search;
     if (!search) {

--- a/frontend/src/components/ExprEditor/components/SingleSelect.vue
+++ b/frontend/src/components/ExprEditor/components/SingleSelect.vue
@@ -48,7 +48,8 @@ const state = reactive<LocalState>({
 
 const { optionConfig, factor } = useSelectOptionConfig(toRef(props, "expr"));
 
-const handleSearch = useDebounceFn(async (search: string) => {
+// Non-debounced function for initial load
+const loadOptions = async (search: string) => {
   if (!optionConfig.value.search) {
     state.rawOptionList = [...optionConfig.value.options];
     return;
@@ -61,12 +62,17 @@ const handleSearch = useDebounceFn(async (search: string) => {
   } finally {
     state.loading = false;
   }
-}, DEBOUNCE_SEARCH_DELAY);
+};
+
+// Debounced version for user-typed searches
+const handleSearch = useDebounceFn(loadOptions, DEBOUNCE_SEARCH_DELAY);
 
 watch(
   () => factor.value,
   async () => {
-    await handleSearch("");
+    // Use non-debounced loadOptions for initial load to ensure options
+    // are available immediately when the component renders
+    await loadOptions("");
     const search = optionConfig.value.search;
     if (!search) {
       return;


### PR DESCRIPTION
## Summary

- Fix condition values appearing empty when first opening the Edit rule modal in Custom Approval settings
- Values now display correctly on first click instead of requiring a second click

## Root Cause

Two issues were causing this bug:

1. **Debounced initial load**: `SingleSelect` and `MultiSelect` used a debounced `handleSearch` for initial option loading. However, `await` on a debounced function doesn't actually wait for execution, so options weren't loaded on first render.

2. **Component reuse issue**: When switching between rules, old `Condition` components were reused (due to `:key="i"` index-based keying). When new expression data arrived, the factor/operator changes triggered a watch in `ValueInput.vue` that reset values to 0/"".

## Changes

- **SingleSelect.vue / MultiSelect.vue**: Split into non-debounced `loadOptions()` for initial load and debounced `handleSearch()` for user searches
- **RuleEditModal.vue**: Reset state to empty immediately before async CEL parsing, ensuring old components unmount before new ones are created

## Test plan

- [x] Open Custom Approval settings page
- [x] Click edit on a DDL rule - verify all condition values display correctly on first click
- [x] Close and open a different rule - verify values still display correctly
- [x] Test rules with nested condition groups (AND/OR)
- [x] Test rules with number values, string values, and select values

🤖 Generated with [Claude Code](https://claude.com/claude-code)