### PR TITLE
fix(frontend): improve approval rule modal UX with better close behavior

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
@@ -1,7 +1,8 @@
 <template>
   <NModal
     :show="show"
-    :mask-closable="false"
+    :mask-closable="true"
+    :close-on-esc="true"
     @update:show="$emit('update:show', $event)"
   >
     <div

--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
@@ -164,6 +164,7 @@ const handleSaveRule = async (ruleData: Partial<LocalApprovalRule>) => {
     } else if (editingRule.value && ruleData.uid) {
       await store.updateRule(ruleData.uid, ruleData);
     }
+    showModal.value = false;
     pushNotification({
       module: "bytebase",
       style: "SUCCESS",


### PR DESCRIPTION
## Summary
- Enable closing modal by clicking outside (mask-closable)
- Enable closing modal with Escape key
- Close modal automatically after successful save (Update button)

## Test plan
- [ ] Open edit rule modal, click Update - modal should close after save
- [ ] Open edit rule modal, click outside the modal - modal should close
- [ ] Open edit rule modal, press Escape - modal should close
- [ ] Open edit rule modal, click Cancel - modal should close

🤖 Generated with [Claude Code](https://claude.com/claude-code)