### PR TITLE
fix(frontend): move Add rule button to top right of each section

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
@@ -4,12 +4,20 @@
       <div class="font-medium text-base">
         {{ sourceDisplayText }}
       </div>
-      <NTooltip>
-        <template #trigger>
-          <HelpCircleIcon class="w-4 h-4 text-control-light cursor-help" />
-        </template>
-        {{ $t("custom-approval.rule.first-match-wins") }}
-      </NTooltip>
+      <div class="flex items-center gap-x-2">
+        <NButton size="small" @click="handleAddRule">
+          <template #icon>
+            <PlusIcon class="w-4" />
+          </template>
+          {{ $t("custom-approval.approval-flow.add-rule") }}
+        </NButton>
+        <NTooltip>
+          <template #trigger>
+            <HelpCircleIcon class="w-4 h-4 text-control-light cursor-help" />
+          </template>
+          {{ $t("custom-approval.rule.first-match-wins") }}
+        </NTooltip>
+      </div>
     </div>
 
     <NDataTable
@@ -20,15 +28,6 @@
       :bordered="true"
       :row-key="(row: LocalApprovalRule) => row.uid"
     />
-
-    <div class="mt-2">
-      <NButton size="small" @click="handleAddRule">
-        <template #icon>
-          <PlusIcon class="w-4" />
-        </template>
-        {{ $t("custom-approval.approval-flow.add-rule") }}
-      </NButton>
-    </div>
 
     <RuleEditModal
       v-model:show="showModal"


### PR DESCRIPTION
## Summary
- Move the "Add rule" button from below the table to the top right header of each approval rule section (DDL, DML, Create Database, Export Data, Request Role)
- Button is now positioned next to the help tooltip for better discoverability

## Test plan
- [ ] Verify "Add rule" button appears in top right of each section header
- [ ] Click button to confirm it still opens the rule creation modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)