### PR TITLE
feat(frontend): add description field to approval rules

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
@@ -30,6 +30,19 @@
           />
         </div>
 
+        <div class="flex flex-col gap-y-2">
+          <h3 class="font-medium text-sm text-control">
+            {{ $t("common.description") }}
+          </h3>
+          <NInput
+            v-model:value="state.description"
+            type="textarea"
+            :placeholder="$t('common.description')"
+            :disabled="!allowAdmin"
+            :rows="2"
+          />
+        </div>
+
         <div class="flex-1 flex flex-col gap-y-2 overflow-y-auto">
           <h3 class="font-medium text-sm text-control">
             {{ $t("cel.condition.self") }}
@@ -111,6 +124,7 @@ import { useCustomApprovalContext } from "../context";
 
 type LocalState = {
   title: string;
+  description: string;
   conditionExpr: ConditionGroupExpr;
   flow: ApprovalFlow;
 };
@@ -132,6 +146,7 @@ const { allowAdmin } = context;
 
 const state = reactive<LocalState>({
   title: "",
+  description: "",
   conditionExpr: wrapAsGroup(emptySimpleExpr()),
   flow: createProto(ApprovalFlowSchema, { roles: [] }),
 });
@@ -153,11 +168,13 @@ const resolveLocalState = async () => {
   // This prevents component reuse issues when switching between rules,
   // where the ValueInput watch would reset values when factor/operator changes.
   state.title = "";
+  state.description = "";
   state.conditionExpr = wrapAsGroup(emptySimpleExpr());
   state.flow = createProto(ApprovalFlowSchema, { roles: [] });
 
   if (props.rule) {
     state.title = props.rule.title || "";
+    state.description = props.rule.description || "";
     if (props.rule.condition) {
       const parsedExprs = await batchConvertCELStringToParsedExpr([
         props.rule.condition,
@@ -191,6 +208,7 @@ const handleSave = async () => {
 
   const ruleData: Partial<LocalApprovalRule> = {
     title: state.title,
+    description: state.description,
     condition,
     conditionExpr: cloneDeep(state.conditionExpr),
     flow: cloneDeep(state.flow),

--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/logic/utils.ts
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/logic/utils.ts
@@ -9,6 +9,7 @@ export const emptyLocalApprovalRule = (): LocalApprovalRule => {
     uid: uuidv4(),
     source: WorkspaceApprovalSetting_Rule_Source.SOURCE_UNSPECIFIED,
     title: "",
+    description: "",
     condition: "",
     flow: createProto(ApprovalFlowSchema, { roles: [] }),
   };

--- a/frontend/src/types/workspaceApprovalSetting.ts
+++ b/frontend/src/types/workspaceApprovalSetting.ts
@@ -7,6 +7,7 @@ export type LocalApprovalRule = {
   uid: string; // Local unique identifier for UI tracking
   source: WorkspaceApprovalSetting_Rule_Source;
   title: string; // Human-readable title
+  description: string; // Description of the rule
   condition: string; // CEL expression string
   conditionExpr?: ConditionGroupExpr; // Parsed CEL for editor
   flow: ApprovalFlow; // Inline approval flow (roles array)

--- a/frontend/src/utils/workspaceApprovalSetting.ts
+++ b/frontend/src/utils/workspaceApprovalSetting.ts
@@ -37,6 +37,7 @@ export const resolveLocalApprovalConfig = async (
         protoRule.source ||
         WorkspaceApprovalSetting_Rule_Source.SOURCE_UNSPECIFIED,
       title: protoRule.template?.title || "",
+      description: protoRule.template?.description || "",
       condition,
       flow:
         protoRule.template?.flow || create(ApprovalFlowSchema, { roles: [] }),
@@ -79,6 +80,7 @@ export const buildWorkspaceApprovalSetting = async (
       template: {
         flow: rule.flow,
         title: rule.title,
+        description: rule.description,
       },
     });
     protoRules.push(protoRule);


### PR DESCRIPTION
## Summary
- Add a description field to approval rules in the edit modal
- Description is persisted via the existing `ApprovalTemplate.description` field in the proto
- Description is not shown in the table (as requested)

## Test plan
- [x] Open Custom Approval settings page
- [x] Click Add rule or edit existing rule
- [x] Verify description textarea appears below the title input
- [x] Enter a description and save - verify it persists when re-editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)