### PR TITLE
fix(frontend): increase title column width in approval rules table

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
@@ -78,7 +78,7 @@ const columns = computed((): DataTableColumn<LocalApprovalRule>[] => [
   {
     title: t("common.title"),
     key: "title",
-    width: 150,
+    width: 200,
     ellipsis: { tooltip: true },
     render: (row) => row.title || "-",
   },


### PR DESCRIPTION
## Summary
- Increase title column width from 150px to 200px for better readability

## Test plan
- [x] Open Custom Approval settings page
- [x] Verify title column has more space

🤖 Generated with [Claude Code](https://claude.com/claude-code)