### PR TITLE
refactor: remove unused HandleIncomingApprovalSteps function

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -764,12 +764,6 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to check if the approval is approved, error: %v", err))
 	}
 
-	newApprovers, err := utils.HandleIncomingApprovalSteps(payload.Approval)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to handle incoming approval steps, error: %v", err))
-	}
-	payload.Approval.Approvers = append(payload.Approval.Approvers, newApprovers...)
-
 	issue, err = s.store.UpdateIssueV2(ctx, issue.UID, &store.UpdateIssueMessage{
 		PayloadUpsert: &storepb.Issue{
 			Approval: payload.Approval,
@@ -1025,12 +1019,6 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		updatedApprovers = append(updatedApprovers, approver)
 	}
 	payload.Approval.Approvers = updatedApprovers
-
-	newApprovers, err := utils.HandleIncomingApprovalSteps(payload.Approval)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to handle incoming approval steps, error: %v", err))
-	}
-	payload.Approval.Approvers = append(payload.Approval.Approvers, newApprovers...)
 
 	issue, err = s.store.UpdateIssueV2(ctx, issue.UID, &store.UpdateIssueMessage{
 		PayloadUpsert: &storepb.Issue{

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -193,19 +193,6 @@ func (r *Runner) findApprovalTemplateForIssue(ctx context.Context, issue *store.
 		Approvers:           nil,
 	}
 
-	newApprovers, err := utils.HandleIncomingApprovalSteps(payload.Approval)
-	if err != nil {
-		err = errors.Wrapf(err, "failed to handle incoming approval steps")
-		if updateErr := updateIssueApprovalPayload(ctx, r.store, issue, &storepb.IssuePayloadApproval{
-			ApprovalFindingDone:  true,
-			ApprovalFindingError: err.Error(),
-		}); updateErr != nil {
-			return false, multierr.Append(errors.Wrap(updateErr, "failed to update issue payload"), err)
-		}
-		return false, err
-	}
-	payload.Approval.Approvers = append(payload.Approval.Approvers, newApprovers...)
-
 	if err := updateIssueApprovalPayload(ctx, r.store, issue, payload.Approval); err != nil {
 		return false, errors.Wrap(err, "failed to update issue payload")
 	}

--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -75,22 +75,6 @@ func CheckIssueApproved(issue *store.IssueMessage) (bool, error) {
 	return CheckApprovalApproved(issue.Payload.Approval)
 }
 
-// HandleIncomingApprovalSteps handles incoming approval steps.
-// - Blocks approval steps if no user can approve the step.
-func HandleIncomingApprovalSteps(approval *storepb.IssuePayloadApproval) ([]*storepb.IssuePayloadApproval_Approver, error) {
-	if approval.ApprovalTemplate == nil {
-		return nil, nil
-	}
-
-	var approvers []*storepb.IssuePayloadApproval_Approver
-
-	role := FindNextPendingRole(approval.ApprovalTemplate, approval.Approvers)
-	if role == "" {
-		return nil, nil
-	}
-	return approvers, nil
-}
-
 // UpdateProjectPolicyFromGrantIssue updates the project policy from grant issue.
 func UpdateProjectPolicyFromGrantIssue(ctx context.Context, stores *store.Store, issue *store.IssueMessage, grantRequest *storepb.GrantRequest) error {
 	policyMessage, err := stores.GetProjectIamPolicy(ctx, issue.Project.ResourceID)


### PR DESCRIPTION
## Summary
- Remove `HandleIncomingApprovalSteps` function from `backend/utils/utils.go`
- Remove 3 call sites in `issue_service.go` and `runner.go`

This function was used to handle external approval nodes, but that feature has been removed. The function was always returning nil/empty slice, so removing it has no functional impact.

## Test plan
- [x] `golangci-lint run --allow-parallel-runners` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)