### PR TITLE
fix(frontend): teleport RoleSelect dropdown to body to prevent clipping

### DIFF
--- a/frontend/src/components/v2/Select/RoleSelect.vue
+++ b/frontend/src/components/v2/Select/RoleSelect.vue
@@ -10,6 +10,7 @@
     :filterable="true"
     :render-label="renderLabel"
     :placeholder="$t('settings.members.select-role', multiple ? 2 : 1)"
+    to="body"
     @update:value="onValueUpdate"
   />
   <FeatureModal


### PR DESCRIPTION
## Summary
- Add `to="body"` to RoleSelect's NSelect to teleport the dropdown menu outside modals
- Fixes dropdown being clipped in the approval flow edit modal

## Test plan
- [x] Open approval flow edit modal
- [x] Click on the approver dropdown
- [x] Verify dropdown is not clipped by the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)