### PR TITLE
feat(frontend): add required field indicators in approval flow modal

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
@@ -21,7 +21,7 @@
       <div class="flex-1 flex flex-col px-6 py-4 overflow-hidden gap-y-4">
         <div class="flex flex-col gap-y-2">
           <h3 class="font-medium text-sm text-control">
-            {{ $t("common.title") }}
+            {{ $t("common.title") }} <RequiredStar />
           </h3>
           <NInput
             v-model:value="state.title"
@@ -45,7 +45,7 @@
 
         <div class="flex-1 flex flex-col gap-y-2 overflow-y-auto">
           <h3 class="font-medium text-sm text-control">
-            {{ $t("cel.condition.self") }}
+            {{ $t("cel.condition.self") }} <RequiredStar />
           </h3>
           <div class="text-sm text-control-light">
             {{ $t("cel.condition.description-tips") }}
@@ -62,7 +62,7 @@
 
         <div class="flex flex-col gap-y-2">
           <h3 class="font-medium text-sm text-control">
-            {{ $t("custom-approval.approval-flow.node.nodes") }}
+            {{ $t("custom-approval.approval-flow.node.nodes") }} <RequiredStar />
           </h3>
           <div class="text-sm text-control-light">
             {{ $t("custom-approval.approval-flow.node.description") }}
@@ -99,6 +99,7 @@ import { cloneDeep, head } from "lodash-es";
 import { NButton, NInput, NModal } from "naive-ui";
 import { computed, reactive, watch } from "vue";
 import ExprEditor from "@/components/ExprEditor";
+import RequiredStar from "@/components/RequiredStar.vue";
 import type { ConditionGroupExpr } from "@/plugins/cel";
 import {
   buildCELExpr,
@@ -157,6 +158,7 @@ const optionConfigMap = computed(() =>
 );
 
 const allowSave = computed(() => {
+  if (!state.title.trim()) return false;
   if (!state.conditionExpr) return false;
   if (!validateSimpleExpr(state.conditionExpr)) return false;
   if (state.flow.roles.length === 0) return false;


### PR DESCRIPTION
## Summary
- Add red asterisk (*) indicators to required fields: Title, Condition, and Approval nodes
- Make title a required field (save button disabled when title is empty)

## Test plan
- [x] Open approval flow create/edit modal
- [x] Verify asterisks appear next to Title, Condition, and Approval nodes labels
- [x] Verify Create/Update button is disabled when title is empty
- [x] Verify button enables when all required fields are filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)