### PR TITLE
fix: remove background color from condition code element to fix tooltip style

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RulesSection.vue
@@ -86,11 +86,7 @@ const columns = computed((): DataTableColumn<LocalApprovalRule>[] => [
     title: t("cel.condition.self"),
     key: "condition",
     ellipsis: { tooltip: true },
-    render: (row) => (
-      <code class="text-xs bg-control-bg px-1 py-0.5 rounded">
-        {row.condition || "true"}
-      </code>
-    ),
+    render: (row) => <code class="text-xs">{row.condition || "true"}</code>,
   },
   {
     title: t("custom-approval.approval-flow.self"),


### PR DESCRIPTION
## Summary
- Remove `bg-control-bg` background styling from the condition code element in the approval rules table
- The light background was conflicting with the dark tooltip background, making the tooltip unreadable

## Test plan
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)