### PR TITLE
refactor(frontend): extract ScheduledTimeIndicator component for consistency

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/v2/ScheduledTimeIndicator.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/ScheduledTimeIndicator.vue
@@ -1,0 +1,58 @@
+<template>
+  <span class="scheduled-time-indicator flex items-center gap-x-1 text-blue-600" :class="sizeClass">
+    <ClockIcon :class="iconClass" />
+    <span v-if="label">{{ label }}:</span>
+    <slot>
+      <span>{{ formattedTime }}</span>
+    </slot>
+  </span>
+</template>
+
+<script lang="ts" setup>
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
+import { ClockIcon } from "lucide-vue-next";
+import { computed } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    time?: Date | Timestamp;
+    label?: string;
+    size?: "small" | "medium";
+    format?: "time" | "datetime";
+  }>(),
+  {
+    size: "small",
+    format: "time",
+  }
+);
+
+const sizeClass = computed(() => {
+  return props.size === "small" ? "text-xs" : "text-sm";
+});
+
+const iconClass = computed(() => {
+  return props.size === "small" ? "w-3 h-3" : "w-4 h-4";
+});
+
+const formattedTime = computed(() => {
+  if (!props.time) return "";
+
+  let date: Date;
+  if (props.time instanceof Date) {
+    date = props.time;
+  } else {
+    // Handle protobuf Timestamp
+    const seconds = props.time.seconds;
+    date = new Date(Number(seconds) * 1000);
+  }
+
+  if (props.format === "time") {
+    return date.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  return date.toLocaleString();
+});
+</script>

--- a/frontend/src/components/Plan/components/RolloutView/v2/StageTimeline.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageTimeline.vue
@@ -83,18 +83,13 @@
               {{ taskRun.detail }}
             </div>
             <!-- Scheduled run time for pending -->
-            <div
-              v-if="
-                taskRun.status === TaskRun_Status.PENDING && taskRun.runTime
-              "
-              class="text-xs text-gray-500 mt-0.5 flex items-center gap-1"
-            >
-              {{ $t("task.scheduled-at") }}
-              <TimestampDisplay
-                :timestamp="taskRun.runTime"
-                custom-class="!text-xs !text-gray-500"
-              />
-            </div>
+            <ScheduledTimeIndicator
+              v-if="taskRun.status === TaskRun_Status.PENDING && taskRun.runTime"
+              :time="taskRun.runTime"
+              :label="$t('task.scheduled-at')"
+              format="datetime"
+              class="mt-0.5"
+            />
             <!-- Duration and Timestamp -->
             <div class="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
               <NTooltip v-if="getTaskRunDuration(taskRun)">
@@ -162,6 +157,7 @@ import {
   getTimelineType,
   mapTaskRunStatusToTaskStatus,
 } from "./composables/useTaskRunUtils";
+import ScheduledTimeIndicator from "./ScheduledTimeIndicator.vue";
 import StageTaskRunsRollback from "./StageTaskRunsRollback.vue";
 
 const props = withDefaults(

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskItem.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskItem.vue
@@ -52,14 +52,11 @@
               {{ taskTypeDisplay }}
             </NTag>
             <!-- Scheduled time indicator -->
-            <span
+            <ScheduledTimeIndicator
               v-if="timingType === 'scheduled'"
-              class="flex items-center gap-x-1 text-xs text-blue-600"
+              :time="scheduledTime"
               :title="t('task.scheduled-time')"
-            >
-              <ClockIcon class="w-3 h-3" />
-              {{ timingDisplay }}
-            </span>
+            />
             <!-- Running indicator -->
             <span
               v-else-if="timingType === 'running'"
@@ -112,8 +109,17 @@
             <span>{{ t("common.type") }}: {{ taskTypeDisplay }}</span>
             <span v-if="executorEmail" class="text-gray-400">·</span>
             <span v-if="executorEmail">{{ t("task.executed-by") }}: {{ executorEmail }}</span>
-            <span v-if="timingDisplay" class="text-gray-400">·</span>
-            <span v-if="timingDisplay">{{ t("common.duration") }}: {{ timingDisplay }}</span>
+            <template v-if="timingType === 'scheduled'">
+              <span class="text-gray-400">·</span>
+              <ScheduledTimeIndicator
+                :time="scheduledTime"
+                :label="t('task.scheduled-time')"
+              />
+            </template>
+            <template v-else-if="timingDisplay">
+              <span class="text-gray-400">·</span>
+              <span>{{ t("common.duration") }}: {{ timingDisplay }}</span>
+            </template>
             <span v-if="affectedRowsDisplay" class="text-gray-400">·</span>
             <span v-if="affectedRowsDisplay">{{ t("task.affected-rows") }}: {{ affectedRowsDisplay }}</span>
           </div>
@@ -239,7 +245,6 @@ import { last } from "lodash-es";
 import {
   ChevronDownIcon,
   ChevronRightIcon,
-  ClockIcon,
   LoaderCircleIcon,
   PlayIcon,
   SkipForwardIcon,
@@ -264,6 +269,7 @@ import { useTaskActions } from "./composables/useTaskActions";
 import { useTaskRunSummary } from "./composables/useTaskRunSummary";
 import { useTaskStatement } from "./composables/useTaskStatement";
 import { useTaskTiming } from "./composables/useTaskTiming";
+import ScheduledTimeIndicator from "./ScheduledTimeIndicator.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -338,7 +344,7 @@ const latestTaskRun = computed(() => {
   return last(taskRunsForTask);
 });
 
-const { timingDisplay, timingType } = useTaskTiming(
+const { timingDisplay, timingType, scheduledTime } = useTaskTiming(
   () => props.task,
   () => latestTaskRun.value
 );


### PR DESCRIPTION
Create a reusable ScheduledTimeIndicator component to standardize the display of scheduled task times across TaskItem and StageTimeline views. This fixes the inconsistency where expanded TaskItem view was showing scheduled time as "Duration" instead of "Scheduled Time".
