### PR TITLE
refactor(frontend): improve RolloutView v2 components

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
@@ -96,38 +96,13 @@
                 <template #default="{ item: task }">
                   <div
                     :key="task.name"
-                    class="flex items-center text-sm"
+                    class="flex items-center text-sm gap-2"
                     :style="{ height: `${itemHeight}px` }"
                   >
-                    <NTag
-                      v-if="
-                        semanticTaskType(
-                          task.type,
-                          task.payload?.case === 'databaseUpdate'
-                            ? task.payload.value.databaseChangeType
-                            : undefined,
-                          task.payload?.case === 'databaseUpdate'
-                            ? task.payload.value.migrationType
-                            : undefined
-                        )
-                      "
-                      class="mr-2"
+                    <TaskStatus
+                      :status="task.status"
                       size="small"
-                    >
-                      <span class="inline-block text-center">
-                        {{
-                          semanticTaskType(
-                            task.type,
-                            task.payload?.case === "databaseUpdate"
-                              ? task.payload.value.databaseChangeType
-                              : undefined,
-                            task.payload?.case === "databaseUpdate"
-                              ? task.payload.value.migrationType
-                              : undefined
-                          )
-                        }}
-                      </span>
-                    </NTag>
+                    />
                     <TaskDatabaseName :task="task" />
                   </div>
                 </template>
@@ -139,37 +114,12 @@
                   <li
                     v-for="task in eligibleTasks"
                     :key="task.name"
-                    class="flex items-center"
+                    class="flex items-center gap-2"
                   >
-                    <NTag
-                      v-if="
-                        semanticTaskType(
-                          task.type,
-                          task.payload?.case === 'databaseUpdate'
-                            ? task.payload.value.databaseChangeType
-                            : undefined,
-                          task.payload?.case === 'databaseUpdate'
-                            ? task.payload.value.migrationType
-                            : undefined
-                        )
-                      "
-                      class="mr-2"
+                    <TaskStatus
+                      :status="task.status"
                       size="small"
-                    >
-                      <span class="inline-block text-center">
-                        {{
-                          semanticTaskType(
-                            task.type,
-                            task.payload?.case === "databaseUpdate"
-                              ? task.payload.value.databaseChangeType
-                              : undefined,
-                            task.payload?.case === "databaseUpdate"
-                              ? task.payload.value.migrationType
-                              : undefined
-                          )
-                        }}
-                      </span>
-                    </NTag>
+                    />
                     <TaskDatabaseName :task="task" />
                   </li>
                 </ul>
@@ -299,15 +249,14 @@ import {
   NRadio,
   NRadioGroup,
   NScrollbar,
-  NTag,
   NTooltip,
   NVirtualList,
 } from "naive-ui";
 import { computed, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
-import { semanticTaskType } from "@/components/IssueV1";
 import { ErrorList } from "@/components/IssueV1/components/common";
 import CommonDrawer from "@/components/IssueV1/components/Panel/CommonDrawer.vue";
+import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
 import { EnvironmentV1Name } from "@/components/v2";
 import { rolloutServiceClientConnect } from "@/grpcweb";
 import {

--- a/frontend/src/components/Plan/components/RolloutView/context.ts
+++ b/frontend/src/components/Plan/components/RolloutView/context.ts
@@ -1,7 +1,7 @@
 import { create } from "@bufbuild/protobuf";
 import { createContextValues } from "@connectrpc/connect";
 import type { InjectionKey } from "vue";
-import { computed, inject, onUnmounted, provide, ref } from "vue";
+import { computed, inject, nextTick, onUnmounted, provide, ref } from "vue";
 import { rolloutServiceClientConnect } from "@/grpcweb";
 import { silentContextKey } from "@/grpcweb/context-key";
 import { useCurrentProjectV1 } from "@/store";
@@ -72,7 +72,9 @@ export const provideRolloutViewContext = () => {
       console.error("Failed to fetch rollout preview:", error);
       rolloutPreview.value = create(RolloutSchema, {});
     } finally {
-      ready.value = true;
+      nextTick(() => {
+        ready.value = true;
+      });
     }
   };
 

--- a/frontend/src/components/Plan/components/RolloutView/v2/RolloutView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/RolloutView.vue
@@ -61,15 +61,17 @@ const { events } = usePlanContextWithRollout();
 
 const { rollout, mergedStages, ready } = useRolloutViewContext();
 
-// Preload instances for all tasks to ensure engine icons display
-useTaskInstancePreload(() => mergedStages.value);
-
 const routeStageId = computed(() => route.params.stageId as string | undefined);
 
 const { selectedStage, isStageCreated } = useStageSelection(
   mergedStages,
   routeStageId,
   rollout
+);
+
+// Preload instances for tasks in the selected stage to ensure engine icons display
+useTaskInstancePreload(() =>
+  selectedStage.value ? [selectedStage.value] : []
 );
 
 // Stage action panel state

--- a/frontend/src/components/Plan/components/RolloutView/v2/StageContentView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageContentView.vue
@@ -39,17 +39,20 @@
             </template>
             {{ $t("rollout.stage.run-stage") }}
           </NButton>
-          <NButton
+          <NPopconfirm
             v-else
-            type="primary"
-            :size="'small'"
-            @click="$emit('create-stage', selectedStage)"
+            @positive-click="$emit('create-stage', selectedStage)"
           >
-            <template #icon>
-              <PlusIcon :size="16" />
+            <template #trigger>
+              <NButton type="primary" :size="'small'">
+                <template #icon>
+                  <PlusIcon :size="16" />
+                </template>
+                {{ $t("common.create") }}
+              </NButton>
             </template>
-            {{ $t("rollout.stage.create-stage") }}
-          </NButton>
+            {{ $t("rollout.stage.confirm-create") }}
+          </NPopconfirm>
         </div>
       </div>
     </div>
@@ -102,7 +105,7 @@
 <script lang="ts" setup>
 import { useMediaQuery } from "@vueuse/core";
 import { PlayIcon, PlusIcon } from "lucide-vue-next";
-import { NButton, NTag } from "naive-ui";
+import { NButton, NPopconfirm, NTag } from "naive-ui";
 import { computed, ref } from "vue";
 import { EnvironmentV1Name } from "@/components/v2";
 import { useEnvironmentV1Store } from "@/store";

--- a/frontend/src/components/Plan/components/RolloutView/v2/StageTimeline.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageTimeline.vue
@@ -27,17 +27,15 @@
       class="overflow-y-auto px-3 pt-1 pb-3"
       :class="isInline ? 'max-h-48' : 'max-h-[calc(100vh-300px)]'"
     >
-      <div
-        v-if="isLoading"
-        class="py-4 text-sm text-gray-400 text-center"
-      >
-        {{ $t("common.loading") }}
+      <div v-if="isLoading" class="py-4 flex justify-center">
+        <BBSpin />
       </div>
       <div
         v-else-if="stageTaskRuns.length === 0"
-        class="py-4 text-sm text-gray-500 text-center"
+        class="py-4 text-sm text-gray-500 flex flex-col justify-center items-center gap-1"
       >
-        {{ $t("common.no-data") }}
+        <SquareChartGanttIcon :stroke-width="1" :size="36" />
+        <span>{{ $t("common.no-data") }}</span>
       </div>
       <NTimeline v-else size="medium">
         <NTimelineItem
@@ -134,9 +132,14 @@
 </template>
 
 <script lang="ts" setup>
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-vue-next";
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  SquareChartGanttIcon,
+} from "lucide-vue-next";
 import { NTimeline, NTimelineItem, NTooltip } from "naive-ui";
 import { computed, ref } from "vue";
+import BBSpin from "@/bbkit/BBSpin.vue";
 import TaskRunDetail from "@/components/IssueV1/components/TaskRunSection/TaskRunDetail.vue";
 import TimestampDisplay from "@/components/misc/Timestamp.vue";
 import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskList.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskList.vue
@@ -16,6 +16,7 @@
         v-for="task in visibleTasks"
         :key="task.name"
         :task="task"
+        :stage="stage"
         :is-expanded="isTaskExpanded(task)"
         :is-selected="isTaskSelected(task)"
         :is-selectable="!readonly && isTaskSelectable(task)"

--- a/frontend/src/components/Plan/components/RolloutView/v2/composables/useStageSelection.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/composables/useStageSelection.ts
@@ -1,4 +1,3 @@
-import { head } from "lodash-es";
 import { type ComputedRef, computed, type Ref } from "vue";
 import type { Rollout, Stage } from "@/types/proto-es/v1/rollout_service_pb";
 import { isTaskRunning, isTaskUnfinished } from "../utils/taskStatus";
@@ -54,7 +53,9 @@ export const useStageSelection = (
 
   const selectedStage = computed(() => {
     const stages = mergedStages.value;
-    const createdStages = stages.filter(isStageCreated);
+    if (!routeStageId.value) {
+      return findSuitableStage(stages);
+    }
 
     // Always follow route params if stageId is provided (allow both created and uncreated)
     if (routeStageId.value) {
@@ -67,13 +68,7 @@ export const useStageSelection = (
       }
     }
 
-    // If no stageId in route, auto-select a suitable created stage
-    if (createdStages.length === 0) {
-      // If no created stages, fallback to the first uncreated stage
-      return head(stages);
-    }
-
-    return findSuitableStage(stages);
+    return undefined;
   });
 
   return {

--- a/frontend/src/components/Plan/components/RolloutView/v2/constants.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/constants.ts
@@ -7,3 +7,9 @@ export const DEFAULT_PAGE_SIZE = 10;
  * Maximum characters to show in collapsed SQL statement preview
  */
 export const STATEMENT_PREVIEW_LENGTH = 80;
+
+/**
+ * Maximum characters to display in expanded SQL statement view.
+ * Larger statements are truncated to avoid performance issues with syntax highlighting.
+ */
+export const MAX_STATEMENT_DISPLAY_SIZE = 10000;

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1225,7 +1225,7 @@
       "self": "Stage | Stages",
       "start-stage": "Start stage",
       "run-stage": "Run Stage",
-      "create-stage": "Create Stage",
+      "confirm-create": "Confirm to create tasks for this stage?",
       "back-to-stage": "Back to Stage {stage}",
       "no-stages": {
         "self": "No stages",
@@ -1236,7 +1236,8 @@
       "selected-count": "{count} task selected | {count} tasks selected",
       "no-tasks": "No tasks in this stage",
       "no-statement": "No SQL statement",
-      "view-full-details": "View Full Details"
+      "view-full-details": "View Details",
+      "statement-truncated-hint": "Statement truncated due to large size."
     },
     "no-stages": "No stages available"
   },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1225,7 +1225,7 @@
       "self": "Escenario | Escenarios",
       "start-stage": "Etapa de inicio",
       "run-stage": "Etapa de ejecución",
-      "create-stage": "Crear etapa",
+      "confirm-create": "¿Está seguro de que desea crear tareas para esta etapa?",
       "back-to-stage": "Volver a la etapa {stage}",
       "no-stages": {
         "self": "Sin etapas",
@@ -1236,7 +1236,8 @@
       "selected-count": "{count} tarea seleccionada | {count} tareas seleccionadas",
       "no-tasks": "No hay tareas en esta etapa",
       "no-statement": "Declaración sin SQL",
-      "view-full-details": "Ver detalles completos"
+      "view-full-details": "Ver detalles",
+      "statement-truncated-hint": "Declaración truncada debido al gran tamaño."
     },
     "no-stages": "No hay etapas disponibles"
   },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1225,7 +1225,7 @@
       "self": "ステージ | ステージ",
       "start-stage": "スタートステージ",
       "run-stage": "ランステージ",
-      "create-stage": "ステージを作成",
+      "confirm-create": "このステージのタスクを作成してもよろしいですか？",
       "back-to-stage": "ステージに戻る {stage}",
       "no-stages": {
         "self": "ステージなし",
@@ -1236,7 +1236,8 @@
       "selected-count": "{count} 個のタスクが選択されました | {count} 個のタスクが選択されました",
       "no-tasks": "このステージにはタスクはありません",
       "no-statement": "SQL文なし",
-      "view-full-details": "詳細を表示"
+      "view-full-details": "詳細を表示",
+      "statement-truncated-hint": "サイズが大きいため、ステートメントは切り捨てられました。"
     },
     "no-stages": "利用可能なステージはありません"
   },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1225,7 +1225,7 @@
       "self": "Giai đoạn | Các giai đoạn",
       "start-stage": "Giai đoạn bắt đầu",
       "run-stage": "Chạy sân khấu",
-      "create-stage": "Tạo sân khấu",
+      "confirm-create": "Bạn có chắc chắn muốn tạo tác vụ cho giai đoạn này không?",
       "back-to-stage": "Trở lại sân khấu {stage}",
       "no-stages": {
         "self": "Không có giai đoạn",
@@ -1236,7 +1236,8 @@
       "selected-count": "{count} nhiệm vụ đã chọn | {count} nhiệm vụ đã chọn",
       "no-tasks": "Không có nhiệm vụ nào ở giai đoạn này",
       "no-statement": "Không có câu lệnh SQL",
-      "view-full-details": "Xem chi tiết đầy đủ"
+      "view-full-details": "Xem chi tiết đầy đủ",
+      "statement-truncated-hint": "Câu lệnh bị cắt bớt do kích thước lớn."
     },
     "no-stages": "Không có giai đoạn nào có sẵn"
   },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1225,7 +1225,7 @@
       "self": "阶段 | 阶段",
       "start-stage": "开始该阶段",
       "run-stage": "运行阶段",
-      "create-stage": "创建阶段",
+      "confirm-create": "确定要为此阶段创建任务吗？",
       "back-to-stage": "返回阶段 {stage}",
       "no-stages": {
         "self": "没有阶段",
@@ -1236,7 +1236,8 @@
       "selected-count": "已选择 {count} 个任务",
       "no-tasks": "此阶段没有任务",
       "no-statement": "没有 SQL 语句",
-      "view-full-details": "查看完整详情"
+      "view-full-details": "查看详情",
+      "statement-truncated-hint": "由于语句过长，已被截断。"
     },
     "no-stages": "没有可用的阶段"
   },


### PR DESCRIPTION
- Replace semantic task type tags with TaskStatus component in TaskRolloutActionPanel
- Use spinner instead of loading text in StageTimeline
- Add empty state icon for StageTimeline
- Add confirmation popconfirm for stage creation
- Show statement truncation hint in TaskItem expanded view
- Optimize instance preloading to selected stage only
- Fix ready state timing with nextTick
