### PR TITLE
feat(frontend): add presets to approval rule edit modal

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/template.ts
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/template.ts
@@ -1,0 +1,51 @@
+import { create } from "@bufbuild/protobuf";
+import { computed } from "vue";
+import type { ConditionGroupExpr } from "@/plugins/cel";
+import { ExprType, wrapAsGroup } from "@/plugins/cel";
+import { t } from "@/plugins/i18n";
+import { PresetRoleType } from "@/types";
+import { ApprovalFlowSchema } from "@/types/proto-es/v1/issue_service_pb";
+
+export type ApprovalRuleTemplate = {
+  title: () => string;
+  description: () => string;
+  expr: ConditionGroupExpr;
+  roles: string[];
+};
+
+export const useApprovalRuleTemplates = () => {
+  const templates = computed((): ApprovalRuleTemplate[] => {
+    return [
+      {
+        title: () =>
+          t("custom-approval.approval-flow.template.presets.fallback"),
+        description: () =>
+          t(
+            "custom-approval.approval-flow.template.preset-descriptions.fallback"
+          ),
+        // The condition "true" matches all requests not matched by other rules.
+        expr: wrapAsGroup({
+          type: ExprType.RawString,
+          content: "true",
+        }),
+        roles: [PresetRoleType.PROJECT_OWNER],
+      },
+    ];
+  });
+
+  return templates;
+};
+
+export const applyTemplateToState = (
+  template: ApprovalRuleTemplate
+): {
+  title: string;
+  conditionExpr: ConditionGroupExpr;
+  flow: ReturnType<typeof create<typeof ApprovalFlowSchema>>;
+} => {
+  return {
+    title: template.title(),
+    conditionExpr: template.expr,
+    flow: create(ApprovalFlowSchema, { roles: [...template.roles] }),
+  };
+};

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2687,7 +2687,16 @@
         "review-sent-back-by": "Review sent back by {user}"
       },
       "add-rule": "Add rule",
-      "edit-rule": "Edit rule"
+      "edit-rule": "Edit rule",
+      "template": {
+        "presets-title": "Presets",
+        "presets": {
+          "fallback": "Fallback Rule"
+        },
+        "preset-descriptions": {
+          "fallback": "A catch-all rule that matches all requests. Place at the end of your rules list."
+        }
+      }
     },
     "risk": {
       "risks": "Risks",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2687,7 +2687,16 @@
         "review-sent-back-by": "Reseña enviada por {user}"
       },
       "add-rule": "Agregar regla",
-      "edit-rule": "Editar regla"
+      "edit-rule": "Editar regla",
+      "template": {
+        "presets-title": "Plantillas",
+        "presets": {
+          "fallback": "Regla de respaldo"
+        },
+        "preset-descriptions": {
+          "fallback": "Una regla general que coincide con todas las solicitudes. Colóquela al final de su lista de reglas."
+        }
+      }
     },
     "risk": {
       "risks": "Riesgo",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2687,7 +2687,16 @@
         "review-sent-back-by": "{user} から承認が返されました"
       },
       "add-rule": "ルールを追加",
-      "edit-rule": "ルールを編集"
+      "edit-rule": "ルールを編集",
+      "template": {
+        "presets-title": "プリセット",
+        "presets": {
+          "fallback": "フォールバックルール"
+        },
+        "preset-descriptions": {
+          "fallback": "すべてのリクエストに一致するキャッチオールルール。ルールリストの最後に配置してください。"
+        }
+      }
     },
     "risk": {
       "risks": "リスク",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2687,7 +2687,16 @@
         "review-sent-back-by": "Đánh giá đã gửi lại bởi {user}"
       },
       "add-rule": "Thêm quy tắc",
-      "edit-rule": "Chỉnh sửa quy tắc"
+      "edit-rule": "Chỉnh sửa quy tắc",
+      "template": {
+        "presets-title": "Mẫu có sẵn",
+        "presets": {
+          "fallback": "Quy tắc dự phòng"
+        },
+        "preset-descriptions": {
+          "fallback": "Quy tắc bắt tất cả khớp với mọi yêu cầu. Đặt ở cuối danh sách quy tắc của bạn."
+        }
+      }
     },
     "risk": {
       "risks": "Rủi ro",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2687,7 +2687,16 @@
         "review-sent-back-by": "审批被 {user} 退回"
       },
       "add-rule": "添加规则",
-      "edit-rule": "编辑规则"
+      "edit-rule": "编辑规则",
+      "template": {
+        "presets-title": "预设模板",
+        "presets": {
+          "fallback": "兜底规则"
+        },
+        "preset-descriptions": {
+          "fallback": "匹配所有请求的兜底规则，请将其放在规则列表的末尾。"
+        }
+      }
     },
     "risk": {
       "risks": "风险",


### PR DESCRIPTION
## Summary
- Add a "Presets" section to the approval rule create modal
- Include a "Fallback Rule" preset with condition `true` that matches all requests
- Users can click the preset to quickly populate the form with a catch-all rule template

<img width="2136" height="1866" alt="CleanShot 2025-11-27 at 18 00 25@2x" src="https://github.com/user-attachments/assets/6164d6f6-6839-49ff-a1c0-c695a8436c24" />


## Test plan
- [ ] Open the approval rule create modal (Settings → Custom Approval → Add rule)
- [ ] Verify the "Presets" section appears at the top with "Fallback Rule" button
- [ ] Click the button and verify it populates:
  - Title: "Fallback Rule"
  - Condition: `true`
  - Approval nodes: Workspace Admin
- [ ] Verify tooltip appears on hover with description
- [ ] Test in different locales (en, zh, es, ja, vi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)