### PR TITLE
fix(frontend): prevent duplicate SearchIssues requests on project issues page

### DIFF
--- a/frontend/src/views/project/ProjectIssueDashboard.vue
+++ b/frontend/src/views/project/ProjectIssueDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProjectIssuesPanel :project="project" />
+  <ProjectIssuesPanel v-if="ready" :project="project" />
 </template>
 
 <script lang="ts" setup>
@@ -12,7 +12,7 @@ const props = defineProps<{
   projectId: string;
 }>();
 
-const { project } = useProjectByName(
+const { project, ready } = useProjectByName(
   computed(() => `${projectNamePrefix}${props.projectId}`)
 );
 </script>


### PR DESCRIPTION
Initialize search params from URL query at setup time instead of onMounted, and skip the first watch trigger since PagedTable already fetches on mount. Also wait for project to be ready before rendering the panel.
