### PR TITLE
feat(frontend): add more approval rule presets with source filtering

### DIFF
--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/RuleEditModal.vue
@@ -150,6 +150,7 @@ import { useCustomApprovalContext } from "../context";
 import {
   type ApprovalRuleTemplate,
   applyTemplateToState,
+  filterTemplatesBySource,
   useApprovalRuleTemplates,
 } from "./template";
 
@@ -174,7 +175,10 @@ const emit = defineEmits<{
 
 const context = useCustomApprovalContext();
 const { allowAdmin } = context;
-const templates = useApprovalRuleTemplates();
+const allTemplates = useApprovalRuleTemplates();
+const templates = computed(() =>
+  filterTemplatesBySource(allTemplates.value, props.source)
+);
 
 const state = reactive<LocalState>({
   title: "",

--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/template.ts
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/RulesPanel/template.ts
@@ -5,17 +5,65 @@ import { ExprType, wrapAsGroup } from "@/plugins/cel";
 import { t } from "@/plugins/i18n";
 import { PresetRoleType } from "@/types";
 import { ApprovalFlowSchema } from "@/types/proto-es/v1/issue_service_pb";
+import { WorkspaceApprovalSetting_Rule_Source } from "@/types/proto-es/v1/setting_service_pb";
+import {
+  CEL_ATTRIBUTE_STATEMENT_AFFECTED_ROWS,
+  CEL_ATTRIBUTE_STATEMENT_SQL_TYPE,
+} from "@/utils/cel-attributes";
 
 export type ApprovalRuleTemplate = {
   title: () => string;
   description: () => string;
   expr: ConditionGroupExpr;
   roles: string[];
+  // If undefined, the template applies to all sources.
+  // If specified, the template only applies to the listed sources.
+  sources?: WorkspaceApprovalSetting_Rule_Source[];
 };
 
 export const useApprovalRuleTemplates = () => {
   const templates = computed((): ApprovalRuleTemplate[] => {
     return [
+      {
+        title: () =>
+          t("custom-approval.approval-flow.template.presets.drop-or-truncate"),
+        description: () =>
+          t(
+            "custom-approval.approval-flow.template.preset-descriptions.drop-or-truncate"
+          ),
+        // statement.sql_type in ["DROP_TABLE", "TRUNCATE"]
+        expr: wrapAsGroup({
+          type: ExprType.Condition,
+          operator: "@in",
+          args: [CEL_ATTRIBUTE_STATEMENT_SQL_TYPE, ["DROP_TABLE", "TRUNCATE"]],
+        }),
+        roles: [PresetRoleType.PROJECT_OWNER, PresetRoleType.WORKSPACE_DBA],
+        sources: [
+          WorkspaceApprovalSetting_Rule_Source.DDL,
+          WorkspaceApprovalSetting_Rule_Source.DML,
+        ],
+      },
+      {
+        title: () =>
+          t(
+            "custom-approval.approval-flow.template.presets.high-affected-rows"
+          ),
+        description: () =>
+          t(
+            "custom-approval.approval-flow.template.preset-descriptions.high-affected-rows"
+          ),
+        // statement.affected_rows > 100
+        expr: wrapAsGroup({
+          type: ExprType.Condition,
+          operator: "_>_",
+          args: [CEL_ATTRIBUTE_STATEMENT_AFFECTED_ROWS, 100],
+        }),
+        roles: [PresetRoleType.PROJECT_OWNER, PresetRoleType.WORKSPACE_DBA],
+        sources: [
+          WorkspaceApprovalSetting_Rule_Source.DDL,
+          WorkspaceApprovalSetting_Rule_Source.DML,
+        ],
+      },
       {
         title: () =>
           t("custom-approval.approval-flow.template.presets.fallback"),
@@ -29,11 +77,25 @@ export const useApprovalRuleTemplates = () => {
           content: "true",
         }),
         roles: [PresetRoleType.PROJECT_OWNER],
+        // No sources specified - applies to all sources
       },
     ];
   });
 
   return templates;
+};
+
+export const filterTemplatesBySource = (
+  templates: ApprovalRuleTemplate[],
+  source: WorkspaceApprovalSetting_Rule_Source
+): ApprovalRuleTemplate[] => {
+  return templates.filter((template) => {
+    // If no sources specified, the template applies to all sources
+    if (!template.sources) {
+      return true;
+    }
+    return template.sources.includes(source);
+  });
 };
 
 export const applyTemplateToState = (

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2692,9 +2692,13 @@
       "template": {
         "presets-title": "Presets",
         "presets": {
+          "drop-or-truncate": "Drop/Truncate Table",
+          "high-affected-rows": "High Affected Rows",
           "fallback": "Fallback Rule"
         },
         "preset-descriptions": {
+          "drop-or-truncate": "Require approval for DROP TABLE or TRUNCATE statements.",
+          "high-affected-rows": "Require approval when affected rows exceed 100.",
           "fallback": "A catch-all rule that matches all requests. Place at the end of your rules list."
         }
       }

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2692,9 +2692,13 @@
       "template": {
         "presets-title": "Plantillas",
         "presets": {
+          "drop-or-truncate": "Eliminar/Truncar Tabla",
+          "high-affected-rows": "Alto Número de Filas",
           "fallback": "Regla de respaldo"
         },
         "preset-descriptions": {
+          "drop-or-truncate": "Requerir aprobación para sentencias DROP TABLE o TRUNCATE.",
+          "high-affected-rows": "Requerir aprobación cuando las filas afectadas excedan 100.",
           "fallback": "Una regla general que coincide con todas las solicitudes. Colóquela al final de su lista de reglas."
         }
       }

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2692,9 +2692,13 @@
       "template": {
         "presets-title": "プリセット",
         "presets": {
+          "drop-or-truncate": "テーブル削除/切り捨て",
+          "high-affected-rows": "高影響行数",
           "fallback": "フォールバックルール"
         },
         "preset-descriptions": {
+          "drop-or-truncate": "DROP TABLEまたはTRUNCATEステートメントには承認が必要です。",
+          "high-affected-rows": "影響行数が100を超える場合は承認が必要です。",
           "fallback": "すべてのリクエストに一致するキャッチオールルール。ルールリストの最後に配置してください。"
         }
       }

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2692,9 +2692,13 @@
       "template": {
         "presets-title": "Mẫu có sẵn",
         "presets": {
+          "drop-or-truncate": "Xóa/Truncate Bảng",
+          "high-affected-rows": "Số Hàng Ảnh Hưởng Cao",
           "fallback": "Quy tắc dự phòng"
         },
         "preset-descriptions": {
+          "drop-or-truncate": "Yêu cầu phê duyệt cho các câu lệnh DROP TABLE hoặc TRUNCATE.",
+          "high-affected-rows": "Yêu cầu phê duyệt khi số hàng bị ảnh hưởng vượt quá 100.",
           "fallback": "Quy tắc bắt tất cả khớp với mọi yêu cầu. Đặt ở cuối danh sách quy tắc của bạn."
         }
       }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2692,9 +2692,13 @@
       "template": {
         "presets-title": "预设模板",
         "presets": {
+          "drop-or-truncate": "删除/清空表",
+          "high-affected-rows": "高影响行数",
           "fallback": "兜底规则"
         },
         "preset-descriptions": {
+          "drop-or-truncate": "DROP TABLE 或 TRUNCATE 语句需要审批。",
+          "high-affected-rows": "影响行数超过 100 时需要审批。",
           "fallback": "匹配所有请求的兜底规则，请将其放在规则列表的末尾。"
         }
       }


### PR DESCRIPTION
## Summary
- Add two new presets for DDL/DML rules:
  - **Drop/Truncate Table**: requires approval for `DROP_TABLE` or `TRUNCATE` statements
  - **High Affected Rows**: requires approval when `affected_rows > 100`
- Both presets require Project Owner and DBA approval (two-step approval flow)
- Add source filtering so presets only appear for applicable rule sources
  - Statement-based presets (Drop/Truncate, High Affected Rows) only show for DDL/DML sources
  - Fallback preset shows for all sources

## Test plan
- [ ] Open approval rule create modal for DDL source → should see all 3 presets
- [ ] Open approval rule create modal for DML source → should see all 3 presets  
- [ ] Open approval rule create modal for CREATE_DATABASE source → should only see Fallback preset
- [ ] Open approval rule create modal for EXPORT_DATA source → should only see Fallback preset
- [ ] Open approval rule create modal for REQUEST_ROLE source → should only see Fallback preset
- [ ] Click each preset and verify the condition and approval nodes are populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)