### PR TITLE
refactor(frontend): extract StageContentSidebar for responsive rollout view

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/v2/StageContentSidebar.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageContentSidebar.vue
@@ -1,0 +1,74 @@
+<template>
+  <!-- Desktop: Sticky sidebar -->
+  <div
+    v-if="isWideScreen"
+    class="shrink-0 pr-4 self-start sticky top-0 w-64"
+  >
+    <!-- Rollback action at top -->
+    <StageTaskRunsRollback class="px-3 pt-1 pb-2" :stage="stage" />
+    <!-- Run history section with border -->
+    <div class="border rounded-lg">
+      <StageTimeline
+        :stage="stage"
+        :task-runs="taskRuns"
+        mode="sidebar"
+      />
+    </div>
+  </div>
+
+  <!-- Mobile: Drawer trigger button -->
+  <template v-else>
+    <NButton
+      size="small"
+      quaternary
+      class="!px-2"
+      @click="showDrawer = true"
+    >
+      <template #icon>
+        <MenuIcon :size="16" />
+      </template>
+    </NButton>
+
+    <!-- Mobile drawer -->
+    <Drawer v-model:show="showDrawer" placement="right">
+      <DrawerContent :title="environment?.title" style="width: 20rem">
+        <!-- Rollback action at top -->
+        <StageTaskRunsRollback class="pb-3" :stage="stage" />
+        <StageTimeline
+          :stage="stage"
+          :task-runs="taskRuns"
+          mode="drawer"
+        />
+      </DrawerContent>
+    </Drawer>
+  </template>
+</template>
+
+<script lang="ts" setup>
+import { useWindowSize } from "@vueuse/core";
+import { MenuIcon } from "lucide-vue-next";
+import { NButton } from "naive-ui";
+import { computed, ref } from "vue";
+import { Drawer, DrawerContent } from "@/components/v2";
+import { useEnvironmentV1Store } from "@/store";
+import type { Stage, TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
+import StageTaskRunsRollback from "./StageTaskRunsRollback.vue";
+import StageTimeline from "./StageTimeline.vue";
+
+const props = defineProps<{
+  stage: Stage | null | undefined;
+  taskRuns: TaskRun[];
+}>();
+
+const environmentStore = useEnvironmentV1Store();
+const { width: windowWidth } = useWindowSize();
+const isWideScreen = computed(() => windowWidth.value >= 768);
+const showDrawer = ref(false);
+
+const environment = computed(() => {
+  if (!props.stage) {
+    return null;
+  }
+  return environmentStore.getEnvironmentByName(props.stage.environment);
+});
+</script>

--- a/frontend/src/components/Plan/components/RolloutView/v2/StageContentView.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageContentView.vue
@@ -53,22 +53,18 @@
             </template>
             {{ $t("rollout.stage.confirm-create") }}
           </NPopconfirm>
+          <!-- Mobile: Timeline drawer trigger (rightmost) -->
+          <StageContentSidebar
+            v-if="!isWideScreen && isStageCreated(selectedStage)"
+            :stage="selectedStage"
+            :task-runs="taskRuns"
+          />
         </div>
       </div>
     </div>
 
     <!-- Main content area: responsive layout -->
-    <div class="flex" :class="isWideScreen ? 'flex-row' : 'flex-col'">
-      <!-- Timeline: inline above on narrow screen -->
-      <div v-if="!isWideScreen && isStageCreated(selectedStage)" class="mb-4">
-        <StageTimeline
-          :stage="selectedStage"
-          :task-runs="taskRuns"
-          :is-inline="true"
-          class="border-y"
-        />
-      </div>
-
+    <div class="flex flex-row">
       <!-- Task list content -->
       <div class="flex-1 min-w-0">
         <TaskList
@@ -79,19 +75,12 @@
         />
       </div>
 
-      <!-- Timeline: sidebar on wide screen (sticky) -->
-      <div
+      <!-- Desktop: Timeline sidebar -->
+      <StageContentSidebar
         v-if="isWideScreen && isStageCreated(selectedStage)"
-        class="shrink-0 pr-4 self-start sticky top-0"
-      >
-        <div class="w-64 border rounded-lg">
-          <StageTimeline
-            :stage="selectedStage"
-            :task-runs="taskRuns"
-            :is-inline="false"
-          />
-        </div>
-      </div>
+        :stage="selectedStage"
+        :task-runs="taskRuns"
+      />
     </div>
   </div>
 
@@ -103,7 +92,7 @@
 </template>
 
 <script lang="ts" setup>
-import { useMediaQuery } from "@vueuse/core";
+import { useWindowSize } from "@vueuse/core";
 import { PlayIcon, PlusIcon } from "lucide-vue-next";
 import { NButton, NPopconfirm, NTag } from "naive-ui";
 import { computed, ref } from "vue";
@@ -112,7 +101,7 @@ import { useEnvironmentV1Store } from "@/store";
 import type { Rollout, Stage } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { usePlanContextWithRollout } from "../../../logic";
-import StageTimeline from "./StageTimeline.vue";
+import StageContentSidebar from "./StageContentSidebar.vue";
 import TaskFilter from "./TaskFilter.vue";
 import TaskList from "./TaskList.vue";
 
@@ -130,8 +119,9 @@ defineEmits<{
 const environmentStore = useEnvironmentV1Store();
 const filterStatuses = ref<Task_Status[]>([]);
 
-// Responsive layout: sidebar on wide screen, inline on narrow
-const isWideScreen = useMediaQuery("(min-width: 1024px)");
+// Responsive layout: sidebar on wide screen (>= 768px), drawer on narrow
+const { width: windowWidth } = useWindowSize();
+const isWideScreen = computed(() => windowWidth.value >= 768);
 
 const { taskRuns } = usePlanContextWithRollout();
 

--- a/frontend/src/components/Plan/components/RolloutView/v2/StageTaskRunsRollback.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageTaskRunsRollback.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="rollbackableTaskRuns.length > 0" class="px-3 pb-3">
+  <div v-if="rollbackableTaskRuns.length > 0">
     <NButton size="small" text @click="showRollbackDrawer = true">
       <template #icon>
         <DatabaseBackupIcon :size="16" />


### PR DESCRIPTION
- Create StageContentSidebar.vue to wrap timeline with responsive behavior
  - Desktop (>=768px): sticky sidebar with rollback action and run history
  - Mobile (<768px): menu icon button that opens drawer