### PR TITLE
fix: use correct stage ID placeholder in issue comment task names

### DIFF
--- a/backend/common/resource_name.go
+++ b/backend/common/resource_name.go
@@ -560,6 +560,17 @@ func FormatRollout(projectID string, pipelineUID int) string {
 	return fmt.Sprintf("%s/%s%d", FormatProject(projectID), RolloutPrefix, pipelineUID)
 }
 
+// EmptyStageID is the placeholder used for stages without environment or with deleted environments.
+const EmptyStageID = "-"
+
+// FormatStageID returns the stage ID, using EmptyStageID placeholder if environment is empty.
+func FormatStageID(environment string) string {
+	if environment == "" {
+		return EmptyStageID
+	}
+	return environment
+}
+
 // stageID is task environmentID.
 func FormatStage(projectID string, pipelineUID int, stageID string) string {
 	return fmt.Sprintf("%s/%s%s", FormatRollout(projectID, pipelineUID), StagePrefix, stageID)

--- a/backend/runner/taskrun/schedulerv2.go
+++ b/backend/runner/taskrun/schedulerv2.go
@@ -260,7 +260,7 @@ func (s *SchedulerV2) scheduleAutoRolloutTask(ctx context.Context, taskUID int) 
 	}
 
 	if issue != nil {
-		tasks := []string{common.FormatTask(issue.Project.ResourceID, task.PipelineID, task.Environment, taskUID)}
+		tasks := []string{common.FormatTask(issue.Project.ResourceID, task.PipelineID, common.FormatStageID(task.Environment), taskUID)}
 		if err := s.store.CreateIssueCommentTaskUpdateStatus(ctx, issue.UID, tasks, storepb.TaskRun_PENDING, common.SystemBotID, ""); err != nil {
 			slog.Warn("failed to create issue comment", "issueUID", issue.UID, log.BBError(err))
 		}
@@ -672,7 +672,7 @@ func (s *SchedulerV2) runTaskRunOnce(ctx context.Context, taskRun *store.TaskRun
 			if issue == nil {
 				return nil
 			}
-			tasks := []string{common.FormatTask(issue.Project.ResourceID, task.PipelineID, task.Environment, task.ID)}
+			tasks := []string{common.FormatTask(issue.Project.ResourceID, task.PipelineID, common.FormatStageID(task.Environment), task.ID)}
 			return s.store.CreateIssueCommentTaskUpdateStatus(ctx, issue.UID, tasks, storepb.TaskRun_FAILED, common.SystemBotID, "")
 		}(); err != nil {
 			slog.Warn("failed to create issue comment", log.BBError(err))
@@ -716,7 +716,7 @@ func (s *SchedulerV2) runTaskRunOnce(ctx context.Context, taskRun *store.TaskRun
 			if issue == nil {
 				return nil
 			}
-			tasks := []string{common.FormatTask(issue.Project.ResourceID, task.PipelineID, task.Environment, task.ID)}
+			tasks := []string{common.FormatTask(issue.Project.ResourceID, task.PipelineID, common.FormatStageID(task.Environment), task.ID)}
 			return s.store.CreateIssueCommentTaskUpdateStatus(ctx, issue.UID, tasks, storepb.TaskRun_DONE, common.SystemBotID, "")
 		}(); err != nil {
 			slog.Warn("failed to create issue comment", log.BBError(err))
@@ -869,7 +869,7 @@ func (s *SchedulerV2) ListenTaskSkippedOrDone(ctx context.Context) {
 					p := &storepb.IssueCommentPayload{
 						Event: &storepb.IssueCommentPayload_StageEnd_{
 							StageEnd: &storepb.IssueCommentPayload_StageEnd{
-								Stage: common.FormatStage(project.ResourceID, task.PipelineID, task.Environment),
+								Stage: common.FormatStage(project.ResourceID, task.PipelineID, common.FormatStageID(task.Environment)),
 							},
 						},
 					}

--- a/frontend/src/utils/v1/issue/rollout.ts
+++ b/frontend/src/utils/v1/issue/rollout.ts
@@ -145,9 +145,14 @@ export const findTaskByName = (
   rollout: Rollout | undefined,
   name: string
 ): Task => {
+  // Use task ID for comparison to handle legacy data with malformed stage IDs.
+  const targetTaskUID = extractTaskUID(name);
+  if (!targetTaskUID) {
+    return unknownTask();
+  }
   for (const stage of rollout?.stages ?? []) {
     for (const task of stage.tasks) {
-      if (task.name === name) {
+      if (extractTaskUID(task.name) === targetTaskUID) {
         return task;
       }
     }
@@ -159,7 +164,16 @@ export const findStageByName = (
   rollout: Rollout | undefined,
   name: string
 ): Stage => {
-  return (rollout?.stages ?? []).find((s) => s.name === name) ?? unknownStage();
+  // Use stage ID for comparison to handle legacy data with malformed stage IDs.
+  const targetStageUID = extractStageUID(name);
+  if (!targetStageUID) {
+    return unknownStage();
+  }
+  return (
+    (rollout?.stages ?? []).find(
+      (s) => extractStageUID(s.name) === targetStageUID
+    ) ?? unknownStage()
+  );
 };
 
 export const extractSchemaVersionFromTask = (task: Task): string => {


### PR DESCRIPTION
When creating issue comments for task status updates (PENDING, FAILED, DONE) and stage end events, the scheduler was passing empty string for stage ID instead of "-" placeholder. This caused task names like "stages//tasks/10040" instead of "stages/-/tasks/10040".

Changes:
- Add common.EmptyStageID constant and FormatStageID helper function
- Update schedulerv2.go to use FormatStageID for all task/stage names
- Refactor rollout_service_converter.go to use common.FormatStageID
- Update frontend findTaskByName/findStageByName to use ID-based comparison for handling legacy malformed data
