### PR TITLE
refactor(frontend): move rollout ready link from banner to header actions

### DIFF
--- a/frontend/src/components/Plan/components/BannerSection/BannerSection.vue
+++ b/frontend/src/components/Plan/components/BannerSection/BannerSection.vue
@@ -12,53 +12,16 @@
     >
       {{ $t("common.done") }}
     </div>
-    <div
-      v-show="showReadyForRollout"
-      class="h-8 w-full text-base font-medium bg-accent text-white flex justify-center items-center shrink-0"
-    >
-      <NButton
-        text
-        class="text-white! hover:opacity-80"
-        :icon-placement="'right'"
-        @click="handleGoToRollout"
-      >
-        {{ t("issue.approval.ready-for-rollout") }}
-        <template #icon>
-          <ArrowRightIcon class="w-4 h-4" />
-        </template>
-      </NButton>
-    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { ArrowRightIcon } from "lucide-vue-next";
-import { NButton } from "naive-ui";
 import { computed } from "vue";
-import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
 import { usePlanContext } from "@/components/Plan";
-import { PROJECT_V1_ROUTE_ROLLOUT_DETAIL } from "@/router/dashboard/projectV1";
 import { State } from "@/types/proto-es/v1/common_pb";
-import {
-  Issue_ApprovalStatus,
-  Issue_Type,
-  IssueStatus,
-} from "@/types/proto-es/v1/issue_service_pb";
-import { Task_Status, Task_Type } from "@/types/proto-es/v1/rollout_service_pb";
-import {
-  activeTaskInRollout,
-  extractProjectResourceName,
-  extractRolloutUID,
-} from "@/utils";
+import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 
-const props = defineProps<{
-  currentTab: string;
-}>();
-
-const { t } = useI18n();
-const router = useRouter();
-const { plan, issue, rollout } = usePlanContext();
+const { plan, issue } = usePlanContext();
 
 const showClosedBanner = computed(() => {
   return (
@@ -70,63 +33,4 @@ const showClosedBanner = computed(() => {
 const showSuccessBanner = computed(() => {
   return issue.value && issue.value.status === IssueStatus.DONE;
 });
-
-const showReadyForRollout = computed(() => {
-  // Only show for OPEN issues
-  if (!issue.value || issue.value.status !== IssueStatus.OPEN) return false;
-
-  // Only show for database change issues
-  if (issue.value.type !== Issue_Type.DATABASE_CHANGE) return false;
-
-  // Check if issue is approved
-  if (
-    issue.value.approvalStatus !== Issue_ApprovalStatus.APPROVED &&
-    issue.value.approvalStatus !== Issue_ApprovalStatus.SKIPPED
-  ) {
-    return false;
-  }
-
-  // Hide if on rollout tab
-  if (props.currentTab === "rollout") {
-    return false;
-  }
-
-  if (!rollout.value) {
-    return false;
-  }
-
-  // Don't show for rollouts with database creation/export tasks
-  const hasDatabaseCreateOrExportTasks = rollout.value.stages.some((stage) =>
-    stage.tasks.some(
-      (task) =>
-        task.type === Task_Type.DATABASE_CREATE ||
-        task.type === Task_Type.DATABASE_EXPORT
-    )
-  );
-  if (hasDatabaseCreateOrExportTasks) {
-    return false;
-  }
-
-  // Check if there's an active task that needs action
-  const activeTask = activeTaskInRollout(rollout.value);
-  return (
-    activeTask.status === Task_Status.NOT_STARTED ||
-    activeTask.status === Task_Status.PENDING ||
-    activeTask.status === Task_Status.RUNNING ||
-    activeTask.status === Task_Status.FAILED ||
-    activeTask.status === Task_Status.CANCELED
-  );
-});
-
-const handleGoToRollout = () => {
-  if (!rollout.value) return;
-
-  router.push({
-    name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
-    params: {
-      projectId: extractProjectResourceName(plan.value.name),
-      rolloutId: extractRolloutUID(rollout.value.name),
-    },
-  });
-};
 </script>

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/RolloutReadyLink.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/RolloutReadyLink.vue
@@ -1,0 +1,29 @@
+<template>
+  <RouterLink v-if="rollout" :to="rolloutRoute">
+    <NButton icon-placement="right" size="small" text type="info">
+      {{ $t("issue.approval.ready-for-rollout") }}
+      <template #icon>
+        <ArrowRightIcon class="w-4 h-4" />
+      </template>
+    </NButton>
+  </RouterLink>
+</template>
+
+<script lang="ts" setup>
+import { ArrowRightIcon } from "lucide-vue-next";
+import { NButton } from "naive-ui";
+import { computed } from "vue";
+import { usePlanContext } from "@/components/Plan/logic";
+import { PROJECT_V1_ROUTE_ROLLOUT_DETAIL } from "@/router/dashboard/projectV1";
+import { extractProjectResourceName, extractRolloutUID } from "@/utils";
+
+const { plan, rollout } = usePlanContext();
+
+const rolloutRoute = computed(() => ({
+  name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
+  params: {
+    projectId: extractProjectResourceName(plan.value.name),
+    rolloutId: extractRolloutUID(rollout.value?.name ?? ""),
+  },
+}));
+</script>

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/unified/UnifiedActionButton.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/unified/UnifiedActionButton.vue
@@ -8,9 +8,6 @@
         :disabled="disabled"
         @click="$emit('perform-action', action)"
       >
-        <template v-if="action === 'EXPORT_DOWNLOAD'" #icon>
-          <DownloadIcon class="w-5 h-5" />
-        </template>
         {{ actionDisplayName(action) }}
       </NButton>
     </template>
@@ -21,7 +18,6 @@
 </template>
 
 <script setup lang="ts">
-import { DownloadIcon } from "lucide-vue-next";
 import { NButton, NTooltip } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -72,8 +68,6 @@ const actionDisplayName = (action: UnifiedAction): string => {
       return isExportPlan.value ? t("common.export") : t("common.rollout");
     case "ROLLOUT_CANCEL":
       return t("common.cancel");
-    case "EXPORT_DOWNLOAD":
-      return t("common.download");
   }
 };
 
@@ -82,7 +76,6 @@ const actionButtonProps = (action: UnifiedAction) => {
     case "ISSUE_REVIEW_APPROVE":
     case "ISSUE_CREATE":
     case "ROLLOUT_START":
-    case "EXPORT_DOWNLOAD":
       return {
         type: "primary" as const,
       };

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/unified/UnifiedActionGroup.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/unified/UnifiedActionGroup.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="flex items-center gap-x-2">
+    <!-- Rollout ready link for database change issues -->
+    <RolloutReadyLink v-if="shouldShowRolloutReadyLink" />
+
     <!-- Export Archive Download Action for export data issues (replaces primary action) -->
-    <ExportArchiveDownloadAction v-if="shouldShowExportDownload" />
+    <ExportArchiveDownloadAction v-else-if="shouldShowExportDownload" />
 
     <!-- Primary action button (hidden when export download is shown) -->
     <UnifiedActionButton
-      v-else-if="primaryAction && primaryAction.action !== 'EXPORT_DOWNLOAD'"
+      v-else-if="primaryAction"
       :action="primaryAction.action"
       :disabled="disabled || primaryAction.disabled"
       :disabled-tooltip="disabled ? disabledTooltip : primaryAction.description"
@@ -53,8 +56,9 @@ import {
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
 import { extractTaskRunUID, extractTaskUID } from "@/utils";
-import { usePlanContext } from "../../../../logic";
+import { usePlanContext, useRolloutReadyLink } from "../../../../logic";
 import { ExportArchiveDownloadAction } from "../export";
+import RolloutReadyLink from "../RolloutReadyLink.vue";
 import type { ActionConfig, UnifiedAction } from "./types";
 import UnifiedActionButton from "./UnifiedActionButton.vue";
 
@@ -72,6 +76,7 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const { plan, issue, rollout, taskRuns } = usePlanContext();
 const currentUser = useCurrentUserV1();
+const { shouldShow: shouldShowRolloutReadyLink } = useRolloutReadyLink();
 
 // Check if this is a database export plan
 const isExportPlan = computed(() => {
@@ -169,8 +174,6 @@ const actionDisplayName = (action: UnifiedAction): string => {
       return isExportPlan.value ? t("common.export") : t("common.rollout");
     case "ROLLOUT_CANCEL":
       return t("common.cancel");
-    case "EXPORT_DOWNLOAD":
-      return t("common.download");
   }
 };
 

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/unified/types.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/unified/types.ts
@@ -17,14 +17,8 @@ export type PlanAction = "PLAN_CLOSE" | "PLAN_REOPEN";
 
 export type RolloutAction = "ROLLOUT_START" | "ROLLOUT_CANCEL";
 
-export type ExportAction = "EXPORT_DOWNLOAD";
-
 // All unified actions
-export type UnifiedAction =
-  | IssueAction
-  | PlanAction
-  | RolloutAction
-  | ExportAction;
+export type UnifiedAction = IssueAction | PlanAction | RolloutAction;
 
 export interface ActionConfig {
   action: UnifiedAction;

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/OptionsSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/OptionsSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="gap-y-2">
+  <div class="flex flex-col gap-y-2">
     <div class="flex items-center justify-between">
       <h3 class="text-base">
         {{ $t("issue.data-export.options") }}
@@ -24,7 +24,7 @@
       </div>
     </div>
 
-    <div class="p-3 border rounded-sm gap-y-3">
+    <div class="p-3 border rounded-sm flex flex-col gap-y-3">
       <!-- Format Display/Edit -->
       <div class="flex items-center gap-4">
         <span class="text-sm">

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/TasksSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/TasksSection.vue
@@ -1,49 +1,47 @@
 <template>
-  <div class="gap-y-2">
-    <!-- Tasks Display -->
-    <div class="gap-y-3">
-      <!-- Task status summary with title -->
+  <!-- Tasks Display -->
+  <div class="flex flex-col gap-y-2">
+    <!-- Task status summary with title -->
+    <div
+      v-if="exportTasks.length > 0"
+      class="flex items-center justify-between"
+    >
+      <div class="flex items-center gap-2">
+        <h3 class="text-base font-medium">
+          {{ $t("common.task", exportTasks.length) }}
+        </h3>
+      </div>
+    </div>
+
+    <!-- Task status display -->
+    <div v-if="exportTasks.length > 0" class="flex flex-wrap gap-2">
       <div
-        v-if="exportTasks.length > 0"
-        class="flex items-center justify-between"
+        v-for="task in exportTasks"
+        :key="task.name"
+        class="inline-flex items-center gap-2 px-2 py-1.5 border rounded-sm transition-colors min-w-0"
       >
-        <div class="flex items-center gap-2">
-          <h3 class="text-base font-medium">
-            {{ $t("common.task", exportTasks.length) }}
-          </h3>
+        <!-- Task Status -->
+        <div class="shrink-0">
+          <TaskStatus :status="task.status" size="tiny" />
+        </div>
+
+        <!-- Database Display -->
+        <div class="flex-1 min-w-0">
+          <DatabaseDisplay
+            :database="task.target"
+            :show-environment="true"
+            size="medium"
+          />
         </div>
       </div>
+    </div>
 
-      <!-- Task status display -->
-      <div v-if="exportTasks.length > 0" class="flex flex-wrap gap-2">
-        <div
-          v-for="task in exportTasks"
-          :key="task.name"
-          class="inline-flex items-center gap-2 px-2 py-1.5 border rounded-sm transition-colors min-w-0"
-        >
-          <!-- Task Status -->
-          <div class="shrink-0">
-            <TaskStatus :status="task.status" size="tiny" />
-          </div>
-
-          <!-- Database Display -->
-          <div class="flex-1 min-w-0">
-            <DatabaseDisplay
-              :database="task.target"
-              :show-environment="true"
-              size="medium"
-            />
-          </div>
-        </div>
-      </div>
-
-      <!-- No tasks message -->
-      <div
-        v-else-if="exportTasks.length === 0"
-        class="text-center text-control-light py-8"
-      >
-        {{ $t("common.no-data") }}
-      </div>
+    <!-- No tasks message -->
+    <div
+      v-else-if="exportTasks.length === 0"
+      class="text-center text-control-light py-8"
+    >
+      {{ $t("common.no-data") }}
     </div>
   </div>
 </template>

--- a/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
@@ -15,6 +15,7 @@
       </div>
       <!-- Right: Checks + Options -->
       <div
+        v-if="shouldShowSidebar"
         class="lg:w-80 shrink-0 flex flex-col divide-y lg:border-l lg:pl-4 overflow-y-auto"
       >
         <template v-if="!specHasRelease">
@@ -31,6 +32,7 @@
 import { computed, type Ref } from "vue";
 import { useCurrentProjectV1 } from "@/store";
 import { isValidReleaseName } from "@/types";
+import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
 import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import { usePlanContext } from "../../logic/context";
 import Configuration from "../Configuration";
@@ -45,7 +47,7 @@ import SpecListSection from "./SpecListSection.vue";
 import TargetListSection from "./TargetListSection.vue";
 
 const { project } = useCurrentProjectV1();
-const { isCreating, plan, rollout } = usePlanContext();
+const { isCreating, plan, issue, rollout } = usePlanContext();
 
 const selectedSpec = useSelectedSpec();
 
@@ -65,6 +67,24 @@ const specHasRelease = computed(() => {
 const isDataExportPlan = computed(() => {
   return plan.value.specs.every(
     (spec) => spec.config.case === "exportDataConfig"
+  );
+});
+
+const isCreateDatabasePlan = computed(() => {
+  return plan.value.specs.every(
+    (spec) => spec.config.case === "createDatabaseConfig"
+  );
+});
+
+const isGrantRequestIssue = computed(() => {
+  return issue.value?.type === Issue_Type.GRANT_REQUEST;
+});
+
+const shouldShowSidebar = computed(() => {
+  return (
+    !isDataExportPlan.value &&
+    !isCreateDatabasePlan.value &&
+    !isGrantRequestIssue.value
   );
 });
 

--- a/frontend/src/components/Plan/logic/index.ts
+++ b/frontend/src/components/Plan/logic/index.ts
@@ -7,3 +7,4 @@ export * from "./plan-check";
 export * from "./utils";
 export * from "./sidebar";
 export * from "./usePlanCheckStatus";
+export * from "./useRolloutReadyLink";

--- a/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
+++ b/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
@@ -1,0 +1,94 @@
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+import {
+  PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
+  PROJECT_V1_ROUTE_ROLLOUT_DETAIL_STAGE_DETAIL,
+  PROJECT_V1_ROUTE_ROLLOUT_DETAIL_TASK_DETAIL,
+} from "@/router/dashboard/projectV1";
+import {
+  Issue_ApprovalStatus,
+  Issue_Type,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { Task_Status, Task_Type } from "@/types/proto-es/v1/rollout_service_pb";
+import { usePlanContext } from "./context";
+
+const ROLLOUT_ROUTES = new Set([
+  PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
+  PROJECT_V1_ROUTE_ROLLOUT_DETAIL_STAGE_DETAIL,
+  PROJECT_V1_ROUTE_ROLLOUT_DETAIL_TASK_DETAIL,
+]);
+
+const ACTIONABLE_TASK_STATUSES = new Set([
+  Task_Status.NOT_STARTED,
+  Task_Status.PENDING,
+  Task_Status.RUNNING,
+  Task_Status.FAILED,
+  Task_Status.CANCELED,
+]);
+
+/**
+ * Composable that determines whether the "Ready for Rollout" link should be shown.
+ * This link appears when:
+ * - Issue is open and approved
+ * - Issue is a database change (not export/create)
+ * - User is not already on the rollout tab
+ * - There are actionable tasks in the rollout
+ */
+export const useRolloutReadyLink = () => {
+  const route = useRoute();
+  const { issue, rollout } = usePlanContext();
+
+  const isOnRolloutTab = computed(() => {
+    return ROLLOUT_ROUTES.has(route.name as string);
+  });
+
+  const shouldShow = computed(() => {
+    // Only show for OPEN issues
+    if (!issue.value || issue.value.status !== IssueStatus.OPEN) {
+      return false;
+    }
+
+    // Only show for database change issues
+    if (issue.value.type !== Issue_Type.DATABASE_CHANGE) {
+      return false;
+    }
+
+    // Check if issue is approved
+    if (
+      issue.value.approvalStatus !== Issue_ApprovalStatus.APPROVED &&
+      issue.value.approvalStatus !== Issue_ApprovalStatus.SKIPPED
+    ) {
+      return false;
+    }
+
+    // Hide if on rollout tab
+    if (isOnRolloutTab.value) {
+      return false;
+    }
+
+    if (!rollout.value) {
+      return false;
+    }
+
+    // Don't show for rollouts with database creation/export tasks
+    const hasDatabaseCreateOrExportTasks = rollout.value.stages.some((stage) =>
+      stage.tasks.some(
+        (task) =>
+          task.type === Task_Type.DATABASE_CREATE ||
+          task.type === Task_Type.DATABASE_EXPORT
+      )
+    );
+    if (hasDatabaseCreateOrExportTasks) {
+      return false;
+    }
+
+    // Check if there's any task that needs action
+    const allTasks = rollout.value.stages.flatMap((stage) => stage.tasks);
+    return allTasks.some((task) => ACTIONABLE_TASK_STATUSES.has(task.status));
+  });
+
+  return {
+    shouldShow,
+  };
+};

--- a/frontend/src/views/project/CICDLayout.vue
+++ b/frontend/src/views/project/CICDLayout.vue
@@ -3,7 +3,7 @@
     <template v-if="ready">
       <PollerProvider>
         <div class="h-full flex flex-col">
-          <BannerSection :current-tab="tabKey" />
+          <BannerSection />
 
           <HeaderSection />
 


### PR DESCRIPTION
Move the "Ready for Rollout" link from BannerSection to UnifiedActionGroup in the header, improving UX by placing the action near other action buttons.

- Extract visibility logic into useRolloutReadyLink composable for maintainability
- Create dedicated RolloutReadyLink component
- Fix CSS gap-y classes by adding flex containers
