### PR TITLE
fix(frontend): update broken GitOps release documentation link

### DIFF
--- a/frontend/src/components/Project/ProjectReleasesPanel.vue
+++ b/frontend/src/components/Project/ProjectReleasesPanel.vue
@@ -3,7 +3,7 @@
     <NAlert type="info">
       <span>{{ $t("release.usage-description") }}</span>
       <LearnMoreLink
-        url="https://docs.bytebase.com/gitops/release/?source=console"
+        url="https://docs.bytebase.com/gitops/migration-based-workflow/release/?source=console"
         class="ml-1"
       />
     </NAlert>


### PR DESCRIPTION
The doc link pointed to /gitops/release/ which no longer exists. Updated to the correct path /gitops/migration-based-workflow/release/.
