### PR TITLE
refactor: inline task type display logic and add i18n keys

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskItem.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskItem.vue
@@ -275,8 +275,7 @@ import TaskRolloutActionPanel from "@/components/Plan/components/RolloutView/Tas
 import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
 import { taskRunNamePrefix } from "@/store";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
-import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
-import { getTaskTypeI18nKey } from "@/utils";
+import { Task_Status, Task_Type } from "@/types/proto-es/v1/rollout_service_pb";
 import { useTaskActions } from "./composables/useTaskActions";
 import { useTaskRunSummary } from "./composables/useTaskRunSummary";
 import { useTaskStatement } from "./composables/useTaskStatement";
@@ -364,8 +363,20 @@ const affectedRowsDisplay = computed(() => {
 });
 
 const taskTypeDisplay = computed(() => {
-  const i18nKey = getTaskTypeI18nKey(props.task);
-  return i18nKey ? t(i18nKey) : "";
+  switch (props.task.type) {
+    case Task_Type.DATABASE_CREATE:
+      return t("task.type.database-create");
+    case Task_Type.DATABASE_MIGRATE:
+      return t("task.type.migrate");
+    case Task_Type.DATABASE_SDL:
+      return t("task.type.database-sdl");
+    case Task_Type.DATABASE_EXPORT:
+      return t("task.type.database-export");
+    case Task_Type.GENERAL:
+      return t("task.type.general");
+    default:
+      return "";
+  }
 });
 
 const errorPreview = computed(() => {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -352,6 +352,13 @@
       "connection-limit": "Waiting for available connections",
       "parallel-tasks-limit": "Waiting for other tasks to complete",
       "blocking-task": "Waiting for another task"
+    },
+    "type": {
+      "database-create": "Create Database",
+      "migrate": "Migrate",
+      "database-sdl": "SDL",
+      "database-export": "Data Export",
+      "general": "General"
     }
   },
   "task-run": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -352,6 +352,13 @@
       "connection-limit": "Esperando conexiones disponibles",
       "parallel-tasks-limit": "Esperando a que se completen otras tareas",
       "blocking-task": "Esperando otra tarea"
+    },
+    "type": {
+      "database-create": "Crear base de datos",
+      "migrate": "Migrar",
+      "database-sdl": "SDL",
+      "database-export": "Exportar datos",
+      "general": "General"
     }
   },
   "task-run": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -352,6 +352,13 @@
       "connection-limit": "利用可能な接続を待機しています",
       "parallel-tasks-limit": "他のタスクが完了するのを待っています",
       "blocking-task": "別のタスクを待っています"
+    },
+    "type": {
+      "database-create": "データベース作成",
+      "migrate": "マイグレーション",
+      "database-sdl": "SDL",
+      "database-export": "データエクスポート",
+      "general": "一般"
     }
   },
   "task-run": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -352,6 +352,13 @@
       "connection-limit": "Đang chờ kết nối khả dụng",
       "parallel-tasks-limit": "Đang chờ các tác vụ khác hoàn thành",
       "blocking-task": "Đang chờ nhiệm vụ khác"
+    },
+    "type": {
+      "database-create": "Tạo cơ sở dữ liệu",
+      "migrate": "Di chuyển",
+      "database-sdl": "SDL",
+      "database-export": "Xuất dữ liệu",
+      "general": "Chung"
     }
   },
   "task-run": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -352,6 +352,13 @@
       "connection-limit": "等待可用连接",
       "parallel-tasks-limit": "等待其他任务完成",
       "blocking-task": "等待另一个任务"
+    },
+    "type": {
+      "database-create": "创建数据库",
+      "migrate": "变更",
+      "database-sdl": "SDL",
+      "database-export": "导出数据",
+      "general": "通用"
     }
   },
   "task-run": {

--- a/frontend/src/utils/v1/issue/rollout.ts
+++ b/frontend/src/utils/v1/issue/rollout.ts
@@ -232,24 +232,6 @@ export const stringifyTaskStatus = (
   }
 };
 
-export const getTaskTypeI18nKey = (task: Task): string => {
-  switch (task.type) {
-    case Task_Type.DATABASE_CREATE:
-      return "task.type.database-create";
-    case Task_Type.DATABASE_MIGRATE:
-      // Ghost mode is indicated via spec.enableGhost, shown separately as a tag
-      return "release.change-type.ddl";
-    case Task_Type.DATABASE_SDL:
-      return "task.type.database-sdl";
-    case Task_Type.DATABASE_EXPORT:
-      return "task.type.database-export";
-    case Task_Type.GENERAL:
-      return "task.type.general";
-    default:
-      return "";
-  }
-};
-
 export const getStageStatus = (stage: Stage): Task_Status => {
   const tasks = stage.tasks;
   if (tasks.length === 0) return Task_Status.NOT_STARTED;


### PR DESCRIPTION
Remove getTaskTypeI18nKey utility function and inline the logic directly in TaskItem.vue. Add proper task.type i18n keys to all locale files instead of relying on release.change-type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)