### PR TITLE
refactor: skip schema dump when all statements are DML

### DIFF
--- a/backend/plugin/parser/base/interface.go
+++ b/backend/plugin/parser/base/interface.go
@@ -29,6 +29,7 @@ var (
 	transformDMLToSelect    = make(map[storepb.Engine]TransformDMLToSelectFunc)
 	generateRestoreSQL      = make(map[storepb.Engine]GenerateRestoreSQLFunc)
 	parsers                 = make(map[storepb.Engine]ParseFunc)
+	statementTypeGetters    = make(map[storepb.Engine]GetStatementTypesFunc)
 )
 
 type ValidateSQLForEditorFunc func(string) (bool, bool, error)
@@ -50,6 +51,10 @@ type GenerateRestoreSQLFunc func(ctx context.Context, rCtx RestoreContext, state
 // Each parser package is responsible for creating AST instances with the appropriate data.
 // Parser packages can return *ANTLRAST for ANTLR-based parsers or their own concrete types.
 type ParseFunc func(statement string) ([]AST, error)
+
+// GetStatementTypesFunc returns the types of statements in the ASTs.
+// Statement types include: INSERT, UPDATE, DELETE (DML), CREATE_TABLE, ALTER_TABLE, DROP_TABLE, etc. (DDL).
+type GetStatementTypesFunc func([]AST) ([]string, error)
 
 func RegisterQueryValidator(engine storepb.Engine, f ValidateSQLForEditorFunc) {
 	mux.Lock()
@@ -271,6 +276,52 @@ func Parse(engine storepb.Engine, statement string) ([]AST, error) {
 		return nil, errors.Errorf("engine %s is not supported", engine)
 	}
 	return f(statement)
+}
+
+func RegisterGetStatementTypes(engine storepb.Engine, f GetStatementTypesFunc) {
+	mux.Lock()
+	defer mux.Unlock()
+	if _, dup := statementTypeGetters[engine]; dup {
+		panic(fmt.Sprintf("Register called twice %s", engine))
+	}
+	statementTypeGetters[engine] = f
+}
+
+// GetStatementTypes returns the types of statements in the ASTs.
+func GetStatementTypes(engine storepb.Engine, asts []AST) ([]string, error) {
+	f, ok := statementTypeGetters[engine]
+	if !ok {
+		return nil, errors.Errorf("engine %s is not supported", engine)
+	}
+	return f(asts)
+}
+
+// IsAllDML checks if all statements are DML (INSERT, UPDATE, DELETE).
+// Returns false for unsupported engines or parse errors (conservative approach).
+func IsAllDML(engine storepb.Engine, statement string) bool {
+	asts, err := Parse(engine, statement)
+	if err != nil {
+		return false
+	}
+	if len(asts) == 0 {
+		return false
+	}
+	types, err := GetStatementTypes(engine, asts)
+	if err != nil {
+		return false
+	}
+	if len(types) == 0 {
+		return false
+	}
+	for _, t := range types {
+		switch t {
+		case "INSERT", "UPDATE", "DELETE":
+			// DML statement, continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 type ChangeSummary struct {

--- a/backend/plugin/parser/mysql/mysql.go
+++ b/backend/plugin/parser/mysql/mysql.go
@@ -20,6 +20,9 @@ func init() {
 	base.RegisterParseFunc(storepb.Engine_MYSQL, parseMySQLForRegistry)
 	base.RegisterParseFunc(storepb.Engine_MARIADB, parseMySQLForRegistry)
 	base.RegisterParseFunc(storepb.Engine_OCEANBASE, parseMySQLForRegistry)
+	base.RegisterGetStatementTypes(storepb.Engine_MYSQL, GetStatementTypes)
+	base.RegisterGetStatementTypes(storepb.Engine_MARIADB, GetStatementTypes)
+	base.RegisterGetStatementTypes(storepb.Engine_OCEANBASE, GetStatementTypes)
 }
 
 // parseMySQLForRegistry is the ParseFunc for MySQL, MariaDB, and OceanBase.

--- a/backend/plugin/parser/pg/pg.go
+++ b/backend/plugin/parser/pg/pg.go
@@ -12,6 +12,7 @@ import (
 
 func init() {
 	base.RegisterParseFunc(storepb.Engine_POSTGRES, parsePostgreSQLForRegistry)
+	base.RegisterGetStatementTypes(storepb.Engine_POSTGRES, GetStatementTypesForRegistry)
 }
 
 // parsePostgreSQLForRegistry is the ParseFunc for PostgreSQL.

--- a/backend/plugin/parser/pg/statement_type.go
+++ b/backend/plugin/parser/pg/statement_type.go
@@ -43,3 +43,17 @@ func GetStatementTypes(asts []base.AST) ([]StatementTypeWithPosition, error) {
 
 	return allResults, nil
 }
+
+// GetStatementTypesForRegistry returns only the statement types as strings.
+// This is used for registration with base.RegisterGetStatementTypes.
+func GetStatementTypesForRegistry(asts []base.AST) ([]string, error) {
+	results, err := GetStatementTypes(asts)
+	if err != nil {
+		return nil, err
+	}
+	types := make([]string, len(results))
+	for i, r := range results {
+		types[i] = r.Type
+	}
+	return types, nil
+}

--- a/backend/plugin/parser/plsql/plsql.go
+++ b/backend/plugin/parser/plsql/plsql.go
@@ -16,6 +16,7 @@ import (
 
 func init() {
 	base.RegisterParseFunc(storepb.Engine_ORACLE, parsePLSQLForRegistry)
+	base.RegisterGetStatementTypes(storepb.Engine_ORACLE, GetStatementTypes)
 }
 
 // parsePLSQLForRegistry is the ParseFunc for PL/SQL.

--- a/backend/plugin/parser/redshift/redshift.go
+++ b/backend/plugin/parser/redshift/redshift.go
@@ -14,6 +14,7 @@ import (
 
 func init() {
 	base.RegisterParseFunc(storepb.Engine_REDSHIFT, parseRedshiftForRegistry)
+	base.RegisterGetStatementTypes(storepb.Engine_REDSHIFT, GetStatementTypes)
 }
 
 // parseRedshiftForRegistry is the ParseFunc for Redshift.

--- a/backend/plugin/parser/tidb/tidb.go
+++ b/backend/plugin/parser/tidb/tidb.go
@@ -26,6 +26,7 @@ import (
 
 func init() {
 	base.RegisterParseFunc(storepb.Engine_TIDB, ParseTiDBForSyntaxCheck)
+	base.RegisterGetStatementTypes(storepb.Engine_TIDB, GetStatementTypes)
 }
 
 // ParseTiDBForSyntaxCheck parses TiDB SQL for syntax checking purposes.

--- a/backend/plugin/parser/tsql/tsql.go
+++ b/backend/plugin/parser/tsql/tsql.go
@@ -15,6 +15,7 @@ import (
 
 func init() {
 	base.RegisterParseFunc(storepb.Engine_MSSQL, parseTSQLForRegistry)
+	base.RegisterGetStatementTypes(storepb.Engine_MSSQL, GetStatementTypes)
 }
 
 // parseTSQLForRegistry is the ParseFunc for T-SQL.


### PR DESCRIPTION
## Summary
- Add `RegisterGetStatementTypes` and `GetStatementTypes` to `base/interface.go`
- Add `IsAllDML` function to `base/interface.go` for centralized DML detection
- Register `GetStatementTypes` for MySQL, MariaDB, OceanBase, PostgreSQL, TiDB, MSSQL, Redshift, and Oracle
- Update `executor.go` to use `base.IsAllDML` instead of local implementation
- Remove unused parser imports from `executor.go`

Schema dumps are now skipped for pure DML statements (INSERT, UPDATE, DELETE) since they don't change the schema. This optimization applies across all supported database engines using the parser's registration pattern.

## Test plan
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual testing with DML and DDL statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)