### PR TITLE
fix: change MySQL validation rules from ERROR to WARNING

### DIFF
--- a/backend/plugin/schema/mysql/walk_through.go
+++ b/backend/plugin/schema/mysql/walk_through.go
@@ -105,7 +105,7 @@ func (l *mysqlListener) EnterCreateTable(ctx *mysql.CreateTableContext) {
 	databaseName, tableName := mysqlparser.NormalizeMySQLTableName(ctx.TableName())
 	if databaseName != "" && !isCurrentDatabase(l.databaseMetadata, databaseName) {
 		l.advice = &storepb.Advice{
-			Status:        storepb.Advice_ERROR,
+			Status:        storepb.Advice_WARNING,
 			Code:          code.NotCurrentDatabase.Int32(),
 			Title:         fmt.Sprintf("Database `%s` is not the current database `%s`", databaseName, l.databaseMetadata.DatabaseName()),
 			Content:       fmt.Sprintf("Database `%s` is not the current database `%s`", databaseName, l.databaseMetadata.DatabaseName()),
@@ -141,7 +141,7 @@ func (l *mysqlListener) EnterCreateTable(ctx *mysql.CreateTableContext) {
 
 	if ctx.DuplicateAsQueryExpression() != nil {
 		l.advice = &storepb.Advice{
-			Status:        storepb.Advice_ERROR,
+			Status:        storepb.Advice_WARNING,
 			Code:          code.StatementCreateTableAs.Int32(),
 			Title:         fmt.Sprintf("Disallow the CREATE TABLE AS statement but \"%s\" uses", l.text),
 			Content:       fmt.Sprintf("Disallow the CREATE TABLE AS statement but \"%s\" uses", l.text),
@@ -229,7 +229,7 @@ func (l *mysqlListener) EnterDropTable(ctx *mysql.DropTableContext) {
 		databaseName, tableName := mysqlparser.NormalizeMySQLTableRef(tableRef)
 		if databaseName != "" && !isCurrentDatabase(l.databaseMetadata, databaseName) {
 			l.advice = &storepb.Advice{
-				Status:        storepb.Advice_ERROR,
+				Status:        storepb.Advice_WARNING,
 				Code:          code.NotCurrentDatabase.Int32(),
 				Title:         fmt.Sprintf("Database `%s` is not the current database `%s`", databaseName, tableName),
 				Content:       fmt.Sprintf("Database `%s` is not the current database `%s`", databaseName, tableName),


### PR DESCRIPTION
## Summary

- Change the status of certain MySQL schema validation rules from ERROR to WARNING
- Affects `NotCurrentDatabase` validation for CREATE TABLE and DROP TABLE operations
- Affects `StatementCreateTableAs` validation

This allows users to proceed with these operations while still being notified of potential issues through warnings instead of blocking with errors.

## Changes

Modified `backend/plugin/schema/mysql/walk_through.go`:
- Line 108: Changed NotCurrentDatabase status from ERROR to WARNING for CREATE TABLE
- Line 144: Changed StatementCreateTableAs status from ERROR to WARNING
- Line 232: Changed NotCurrentDatabase status from ERROR to WARNING for DROP TABLE

## Test plan

- [ ] Verify that CREATE TABLE with non-current database now shows WARNING instead of ERROR
- [ ] Verify that CREATE TABLE AS statement now shows WARNING instead of ERROR
- [ ] Verify that DROP TABLE with non-current database now shows WARNING instead of ERROR
- [ ] Ensure validation still triggers and displays appropriate messages
- [ ] Run existing MySQL schema validation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)