### PR TITLE
refactor: clean up unused methods in store package

### DIFF
--- a/backend/store/setting.go
+++ b/backend/store/setting.go
@@ -142,20 +142,6 @@ func (s *Store) GetDataClassificationSetting(ctx context.Context) (*storepb.Data
 	return payload, nil
 }
 
-// GetDataClassificationConfigByID gets the classification config by the id.
-func (s *Store) GetDataClassificationConfigByID(ctx context.Context, classificationConfigID string) (*storepb.DataClassificationSetting_DataClassificationConfig, error) {
-	setting, err := s.GetDataClassificationSetting(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, config := range setting.Configs {
-		if config.Id == classificationConfigID {
-			return config, nil
-		}
-	}
-	return &storepb.DataClassificationSetting_DataClassificationConfig{}, nil
-}
-
 func (s *Store) GetAISetting(ctx context.Context) (*storepb.AISetting, error) {
 	aiSetting := &storepb.AISetting{}
 	setting, err := s.GetSettingV2(ctx, storepb.SettingName_AI)
@@ -186,14 +172,6 @@ func (s *Store) GetEnvironmentSetting(ctx context.Context) (*storepb.Environment
 		return nil, err
 	}
 	return envSetting, nil
-}
-
-// DeleteCache deletes the cache.
-func (s *Store) DeleteCache() {
-	s.settingCache.Purge()
-	s.policyCache.Purge()
-	s.userEmailCache.Purge()
-	s.userIDCache.Purge()
 }
 
 // GetSettingV2 returns the setting by name.

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -154,6 +154,14 @@ func (s *Store) GetDB() *sql.DB {
 	return s.dbConnManager.GetDB()
 }
 
+// DeleteCache deletes the cache.
+func (s *Store) DeleteCache() {
+	s.settingCache.Purge()
+	s.policyCache.Purge()
+	s.userEmailCache.Purge()
+	s.userIDCache.Purge()
+}
+
 func getInstanceCacheKey(instanceID string) string {
 	return instanceID
 }


### PR DESCRIPTION
## Summary
- Removed unused `GetDataClassificationConfigByID` method from `backend/store/setting.go`
- Moved `DeleteCache` method from `backend/store/setting.go` to `backend/store/store.go` for better organization since it manages all Store caches

## Test plan
- Verified `GetDataClassificationConfigByID` is unused in the codebase
- All other methods in `setting.go` are actively used
- Code formatted with `gofmt`
- Passed `golangci-lint` with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)