### PR TITLE
refactor(frontend): consolidate DDL/DML into unified Database Change

### DIFF
--- a/frontend/src/components/IssueV1/components/Sidebar/PreBackupSection/TaskRollbackButton.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/PreBackupSection/TaskRollbackButton.vue
@@ -80,7 +80,7 @@ const createRestoreIssue = async () => {
   const sqlStorageKey = `bb.issues.sql.${uuidv4()}`;
   useStorageStore().put(sqlStorageKey, statement);
   const query: LocationQueryRaw = {
-    template: "bb.issue.database.data.update",
+    template: "bb.issue.database.update",
     name: `Rollback ${selectedTask.value.target} in issue#${extractIssueUID(issue.value.name)}`,
     databaseList: selectedTask.value.target,
     description: `This issue is created to rollback the data of ${selectedTask.value.target} in issue #${extractIssueUID(issue.value.name)}`,

--- a/frontend/src/components/Plan/logic/initialize/create.ts
+++ b/frontend/src/components/Plan/logic/initialize/create.ts
@@ -68,11 +68,7 @@ export const createPlanSkeleton = async (
 export const buildPlan = async (params: CreatePlanParams) => {
   if (
     !includes(
-      [
-        "bb.issue.database.data.update",
-        "bb.issue.database.schema.update",
-        "bb.issue.database.data.export",
-      ],
+      ["bb.issue.database.update", "bb.issue.database.data.export"],
       params.template
     )
   ) {
@@ -139,8 +135,7 @@ const buildSpecForTargetsV1 = async (
     id: uuidv4(),
   });
   switch (template) {
-    case "bb.issue.database.data.update":
-    case "bb.issue.database.schema.update": {
+    case "bb.issue.database.update": {
       spec.config = {
         case: "changeDatabaseConfig",
         value: createProto(Plan_ChangeDatabaseConfigSchema, {
@@ -148,9 +143,7 @@ const buildSpecForTargetsV1 = async (
           sheet,
           type: DatabaseChangeType.MIGRATE,
           enableGhost: false,
-          enablePriorBackup:
-            template === "bb.issue.database.data.update" &&
-            project.autoEnableBackup,
+          enablePriorBackup: project.autoEnableBackup,
         }),
       };
       break;

--- a/frontend/src/components/Plan/logic/issue.ts
+++ b/frontend/src/components/Plan/logic/issue.ts
@@ -29,7 +29,7 @@ const showDatabaseDriftedWarningDialog = () => {
 };
 
 export const preCreateIssue = async (project: string, targets: string[]) => {
-  const type = "bb.issue.database.schema.update";
+  const type = "bb.issue.database.update";
   const databaseStore = useDatabaseV1Store();
   const dbGroupStore = useDBGroupStore();
 

--- a/frontend/src/components/Release/ReleaseDetail/NavBar/ApplyToDatabasePanel.vue
+++ b/frontend/src/components/Release/ReleaseDetail/NavBar/ApplyToDatabasePanel.vue
@@ -152,7 +152,7 @@ const handleCreate = async () => {
     ...response,
     // Override title and description.
     title: generateIssueTitle(
-      "bb.issue.database.schema.update",
+      "bb.issue.database.update",
       state.targetSelectState.changeSource === "DATABASE"
         ? databaseList.map((db) => db.databaseName)
         : [databaseGroup?.title]

--- a/frontend/src/components/SyncDatabaseSchemaV1/index.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/index.vue
@@ -307,7 +307,7 @@ const tryFinishSetup = async () => {
 
   const targetDatabaseList = targetDatabaseViewRef.value.targetDatabaseList;
   const query: LocationQueryRaw = {
-    template: "bb.issue.database.schema.update",
+    template: "bb.issue.database.update",
     mode: "normal",
   };
   const sqlMap: Record<string, string> = {};
@@ -323,7 +323,7 @@ const tryFinishSetup = async () => {
   useStorageStore().put(sqlMapStorageKey, sqlMap);
   query.sqlMapStorageKey = sqlMapStorageKey;
   query.name = generateIssueTitle(
-    "bb.issue.database.schema.update",
+    "bb.issue.database.update",
     targetDatabaseList.map((db) => db.databaseName)
   );
 

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
@@ -294,10 +294,7 @@ const showDatabaseDriftedWarningDialog = () => {
 };
 
 const generateMultiDb = async (
-  type:
-    | "bb.issue.database.schema.update"
-    | "bb.issue.database.data.update"
-    | "bb.issue.database.data.export"
+  type: "bb.issue.database.update" | "bb.issue.database.data.export"
 ) => {
   // Check if any database is drifted.
   if (props.databases.some((d) => d.drifted)) {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1662,7 +1662,6 @@
     "edit-environment": "Edit Environment",
     "mixed-values-for-label": "This selected label have mixed values",
     "mixed-label-values-warning": "Some of the selected resources have mixed values for the same key",
-    "change-data": "Change Data",
     "table-detail": "Table detail",
     "batch-action-permission-denied": "Don't have permission to {action} for databases",
     "batch-action-disabled": "Can not {action} for the databases from different projects",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1662,7 +1662,6 @@
     "edit-environment": "Editar entorno",
     "mixed-values-for-label": "Esta etiqueta seleccionada tiene valores mixtos.",
     "mixed-label-values-warning": "Algunos de los recursos seleccionados tienen valores mixtos para la misma clave",
-    "change-data": "Cambiar datos",
     "table-detail": "Detalle de la tabla",
     "batch-action-permission-denied": "No tengo permiso para {action} para bases de datos",
     "batch-action-disabled": "No se puede {action} para las bases de datos de diferentes proyectos",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1662,7 +1662,6 @@
     "edit-environment": "環境の編集",
     "mixed-values-for-label": "タグの値が異なります",
     "mixed-label-values-warning": "一部のタグには異なる値があり、タグの編集はバッチで適用されます",
-    "change-data": "データ変更",
     "table-detail": "テーブルの詳細",
     "batch-action-permission-denied": "データベース {action} に対する権限がありません",
     "batch-action-disabled": "異なるプロジェクトのデータベース {action} を比較できません",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1662,7 +1662,6 @@
     "edit-environment": "Chỉnh sửa Môi trường",
     "mixed-values-for-label": "Nhãn đã chọn này có các giá trị hỗn hợp",
     "mixed-label-values-warning": "Một số tài nguyên đã chọn có các giá trị hỗn hợp cho cùng một khóa",
-    "change-data": "Thay đổi dữ liệu",
     "table-detail": "Chi tiết bảng",
     "batch-action-permission-denied": "Không có quyền {action} đối với cơ sở dữ liệu",
     "batch-action-disabled": "Không thể {action} đối với các cơ sở dữ liệu từ các dự án khác nhau",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1662,7 +1662,6 @@
     "edit-environment": "编辑环境",
     "mixed-values-for-label": "该标签拥有不同的值",
     "mixed-label-values-warning": "部分标签拥有不同的值，编辑标签将会批量应用",
-    "change-data": "变更数据",
     "table-detail": "表详情",
     "batch-action-permission-denied": "没有权限对数据库{action}",
     "batch-action-disabled": "无法对来自不同项目的数据库{action}",

--- a/frontend/src/types/issue.ts
+++ b/frontend/src/types/issue.ts
@@ -1,8 +1,7 @@
 type IssueTypeDatabase =
   | "bb.issue.database.create"
   | "bb.issue.database.grant"
-  | "bb.issue.database.schema.update"
-  | "bb.issue.database.data.update"
+  | "bb.issue.database.update"
   | "bb.issue.database.data.export";
 
 type IssueTypeGrantRequest = "bb.issue.grant.request";

--- a/frontend/src/utils/databaseGroup/issue.ts
+++ b/frontend/src/utils/databaseGroup/issue.ts
@@ -6,7 +6,7 @@ import type { DatabaseGroup } from "@/types/proto-es/v1/database_group_service_p
 import { extractProjectResourceName } from "../v1";
 
 export const generateDatabaseGroupIssueRoute = (
-  type: "bb.issue.database.schema.update" | "bb.issue.database.data.update",
+  type: "bb.issue.database.update",
   databaseGroup: DatabaseGroup,
   sql = ""
 ) => {

--- a/frontend/src/utils/v1/issue/issue.ts
+++ b/frontend/src/utils/v1/issue/issue.ts
@@ -59,8 +59,7 @@ export const isDatabaseDataExportIssue = (issue: ComposedIssue): boolean => {
 
 export const generateIssueTitle = (
   type:
-    | "bb.issue.database.schema.update"
-    | "bb.issue.database.data.update"
+    | "bb.issue.database.update"
     | "bb.issue.database.data.export"
     | "bb.issue.grant.request",
   databaseNameList?: string[],
@@ -84,8 +83,7 @@ export const generateIssueTitle = (
   } else {
     if (type.startsWith("bb.issue.database")) {
       parts.push(
-        type === "bb.issue.database.schema.update" ||
-          type === "bb.issue.database.data.update"
+        type === "bb.issue.database.update"
           ? t("issue.title.change-database")
           : t("issue.title.export-data")
       );

--- a/frontend/src/views/project/ProjectPlanDashboard.vue
+++ b/frontend/src/views/project/ProjectPlanDashboard.vue
@@ -284,8 +284,7 @@ const allowToCreatePlan = computed(() => {
 });
 
 const handleSpecCreated = async (spec: Plan_Spec) => {
-  // Always use schema update template since we no longer distinguish DML from DDL
-  const template = "bb.issue.database.schema.update";
+  const template = "bb.issue.database.update";
   const targets = targetsForSpec(spec);
   const isDatabaseGroup = targets.every((target) =>
     isValidDatabaseGroupName(target)

--- a/frontend/src/views/sql-editor/EditorCommon/ExecuteHint.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ExecuteHint.vue
@@ -95,13 +95,13 @@ const actions = computed(() => {
 
 const descriptions = computed(() => {
   const descriptions = {
-    want: t("database.change-data").toLowerCase(),
+    want: t("database.change-database").toLowerCase(),
     action: "",
     reaction: "",
   };
   const { admin, issue } = actions.value;
   if (issue) {
-    descriptions.action = t("database.change-data");
+    descriptions.action = t("database.change-database");
     descriptions.reaction = t("sql-editor.and-submit-an-issue");
   } else if (admin) {
     descriptions.action = t("sql-editor.admin-mode.self");
@@ -137,8 +137,8 @@ const gotoCreateIssue = async () => {
       issueSlug: "create",
     },
     query: {
-      template: "bb.issue.database.data.update", // Default to DML issue template.
-      name: `[${db.databaseName}] Update from SQL Editor`,
+      template: "bb.issue.database.update",
+      name: `[${db.databaseName}] Change from SQL Editor`,
       databaseList: db.name,
       sqlStorageKey,
     },

--- a/frontend/src/views/sql-editor/SQLEditorHomePage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorHomePage.vue
@@ -127,7 +127,7 @@ useEmitteryEventListener(
       }
     }
     const query = {
-      template: "bb.issue.database.schema.update",
+      template: "bb.issue.database.update",
       name: `[${database.databaseName}] Edit schema`,
       databaseList: database.name,
       sql: exampleSQL.join(" "),


### PR DESCRIPTION
## Summary

- Replace separate `bb.issue.database.schema.update` and `bb.issue.database.data.update` templates with unified `bb.issue.database.update`
- Update ExecuteHint to use "Change Database" wording instead of "Change Data"
- Remove unused `change-data` locale key from all language files (en-US, zh-CN, ja-JP, es-ES, vi-VN)
- Simplify `enablePriorBackup` logic to use `project.autoEnableBackup` directly

## Test plan

- [ ] Verify SQL Editor shows "Change Database" button when executing non-SELECT statements
- [ ] Verify clicking the button creates an issue with the correct template
- [ ] Verify database change issues work correctly from various entry points (database list, sync schema, releases)
- [ ] Verify rollback issue creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)