### PR TITLE
feat(approval): add default fallback rule requiring project owner approval

### DIFF
--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -554,7 +554,7 @@ INSERT INTO setting (name, value) VALUES ('ENTERPRISE_LICENSE', '');
 INSERT INTO setting (name, value) VALUES ('APP_IM', '{}');
 INSERT INTO setting (name, value) VALUES ('WATERMARK', '0');
 INSERT INTO setting (name, value) VALUES ('DATA_CLASSIFICATION', '{}');
-INSERT INTO setting (name, value) VALUES ('WORKSPACE_APPROVAL', '{}');
+INSERT INTO setting (name, value) VALUES ('WORKSPACE_APPROVAL', '{"rules":[{"template":{"flow":{"roles":["roles/projectOwner"]},"title":"Fallback Rule","description":"Requires project owner approval when no other rules match."},"condition":{"expression":"true"}}]}');
 INSERT INTO setting (name, value) VALUES ('PASSWORD_RESTRICTION', '{"minLength":8}');
 INSERT INTO setting (name, value) VALUES ('WORKSPACE_PROFILE', '{"enableMetricCollection":true}');
 INSERT INTO setting (name, value) VALUES ('ENVIRONMENT', '{"environments":[{"title":"Test","id":"test"},{"title":"Prod","id":"prod"}]}');

--- a/backend/tests/rollout.go
+++ b/backend/tests/rollout.go
@@ -99,6 +99,15 @@ waitApproval:
 			if issue.ApprovalStatus == v1pb.Issue_APPROVED || issue.ApprovalStatus == v1pb.Issue_SKIPPED {
 				break waitApproval
 			}
+			// If the issue is pending approval, approve it (test user should be project owner)
+			if issue.ApprovalStatus == v1pb.Issue_PENDING {
+				_, err := ctl.issueServiceClient.ApproveIssue(ctx, connect.NewRequest(&v1pb.ApproveIssueRequest{
+					Name: issueName,
+				}))
+				if err != nil {
+					return errors.Wrapf(err, "failed to approve issue")
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Initialize WORKSPACE_APPROVAL setting with a default fallback rule
- Fallback rule requires project owner approval when no other rules match
- Condition: `true` (matches all requests that don't match source-specific rules)

This provides a sensible default for new installations - all approval requests will require project owner approval.

**Note:** This PR should be merged after #18296 (fallback rules implementation).

## Test plan

- [x] Verified JSON format matches expected structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)