### PR TITLE
fix(elasticsearch): skip role fetching for OpenSearch with AWS IAM auth

### DIFF
--- a/backend/plugin/db/elasticsearch/role.go
+++ b/backend/plugin/db/elasticsearch/role.go
@@ -21,6 +21,11 @@ type UserResult struct {
 }
 
 func (d *Driver) getInstanceRoles() ([]*storepb.InstanceRole, error) {
+	// AWS IAM authentication doesn't use internal users - skip role fetching
+	if d.config.DataSource.GetAuthenticationType() == storepb.DataSource_AWS_RDS_IAM {
+		return nil, nil
+	}
+
 	var bytes []byte
 
 	if d.isOpenSearch && d.opensearchClient != nil {


### PR DESCRIPTION
## Summary
- Skip internal user/role fetching for OpenSearch when using AWS IAM authentication
- The `getInstanceRoles()` function was using `basicAuthClient` which makes unsigned HTTP requests, causing "User: anonymous" errors during database sync

## Background
When using AWS IAM authentication with OpenSearch, the `getInstanceRoles()` function attempted to fetch internal users via `/_plugins/_security/api/internalusers`. However, this request was made using `basicAuthClient` which doesn't sign requests with AWS credentials, resulting in:

```
User: anonymous is not authorized to perform: es:ESHttpGet because no resource-based policy allows the es:ESHttpGet action
```

Since AWS IAM-authenticated OpenSearch doesn't use internal users (authentication is handled by IAM, not OpenSearch's internal user database), we skip role fetching entirely for this authentication type.

## Test plan
- [x] Tested with AWS OpenSearch domain using IAM authentication
- [x] Verified connection test succeeds
- [x] Verified database sync completes without "anonymous" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)