### PR TITLE
fix(i18n): change 'Skip manual approval' to 'No approval required'

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2649,7 +2649,7 @@
         "add": "Add node",
         "delete": "Delete approval node"
       },
-      "skip": "Skip manual approval",
+      "skip": "No approval required",
       "issue-review": {
         "sent-back": "Sent back",
         "review-sent-back-by": "Review sent back by {user}"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2649,7 +2649,7 @@
         "add": "Agregar nodo",
         "delete": "Eliminar nodo de aprobación"
       },
-      "skip": "Omitir aprobación manual",
+      "skip": "No se requiere aprobación",
       "issue-review": {
         "sent-back": "Devuelto",
         "review-sent-back-by": "Reseña enviada por {user}"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2649,7 +2649,7 @@
         "add": "ノードの追加",
         "delete": "承認ノードの削除"
       },
-      "skip": "手動承認をスキップする",
+      "skip": "承認不要",
       "issue-review": {
         "sent-back": "戻ってきた",
         "review-sent-back-by": "{user} から承認が返されました"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2649,7 +2649,7 @@
         "add": "Thêm nút",
         "delete": "Xóa nút phê duyệt"
       },
-      "skip": "Bỏ qua phê duyệt thủ công",
+      "skip": "Không cần phê duyệt",
       "issue-review": {
         "sent-back": "Đã gửi lại",
         "review-sent-back-by": "Đánh giá đã gửi lại bởi {user}"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2649,7 +2649,7 @@
         "add": "增加节点",
         "delete": "删除审批节点"
       },
-      "skip": "跳过人工审批",
+      "skip": "无需审批",
       "issue-review": {
         "sent-back": "被退回",
         "review-sent-back-by": "审批被 {user} 退回"


### PR DESCRIPTION
## Summary

- Changed approval status wording from "Skip manual approval" to "No approval required" across all locales
- Resolves confusing messaging where the policy "Require Issue Approval" conflicted with "Skip manual approval"

## Changes

| Locale | Before | After |
|--------|--------|-------|
| en-US | Skip manual approval | No approval required |
| zh-CN | 跳过人工审批 | 无需审批 |
| ja-JP | 手動承認をスキップする | 承認不要 |
| es-ES | Omitir aprobación manual | No se requiere aprobación |
| vi-VN | Bỏ qua phê duyệt thủ công | Không cần phê duyệt |

## Rationale

The word "skip" implied something was being bypassed, which conflicted with the policy name. "No approval required" clearly indicates the system evaluated the issue and determined approval isn't needed for this particular case.

This aligns with industry terminology (ServiceNow uses "Not Required", GitLab/Azure DevOps use "Optional").

Fixes BYT-8203

🤖 Generated with [Claude Code](https://claude.com/claude-code)