### PR TITLE
refactor: remove redundant IAM permission checks in allow_missing scenarios

### DIFF
--- a/backend/api/v1/database_group_service.go
+++ b/backend/api/v1/database_group_service.go
@@ -119,11 +119,6 @@ func (s *DatabaseGroupService) UpdateDatabaseGroup(ctx context.Context, req *con
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q has been deleted", projectResourceID))
 	}
 
-	user, ok := GetUserFromContext(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("user not found"))
-	}
-
 	existedDatabaseGroup, err := s.store.GetDatabaseGroup(ctx, &store.FindDatabaseGroupMessage{
 		ProjectID:  &project.ResourceID,
 		ResourceID: &databaseGroupResourceID,
@@ -133,13 +128,6 @@ func (s *DatabaseGroupService) UpdateDatabaseGroup(ctx context.Context, req *con
 	}
 	if existedDatabaseGroup == nil {
 		if req.Msg.AllowMissing {
-			ok, err := s.iamManager.CheckPermission(ctx, iam.PermissionDatabaseGroupsCreate, user, project.ResourceID)
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to check permission"))
-			}
-			if !ok {
-				return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("user does not have permission %q", iam.PermissionDatabaseGroupsCreate))
-			}
 			return s.CreateDatabaseGroup(ctx, connect.NewRequest(&v1pb.CreateDatabaseGroupRequest{
 				Parent:          common.FormatProject(project.ResourceID),
 				DatabaseGroupId: databaseGroupResourceID,

--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -225,23 +225,11 @@ func (s *ProjectService) UpdateProject(ctx context.Context, req *connect.Request
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound && req.Msg.AllowMissing {
 			// When allow_missing is true and project doesn't exist, create a new one
-			user, ok := GetUserFromContext(ctx)
-			if !ok {
-				return nil, connect.NewError(connect.CodeInternal, errors.New("user not found"))
-			}
-
 			projectID, perr := common.GetProjectID(req.Msg.Project.Name)
 			if perr != nil {
 				return nil, connect.NewError(connect.CodeInvalidArgument, perr)
 			}
 
-			ok, err = s.iamManager.CheckPermission(ctx, iam.PermissionProjectsCreate, user)
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to check permission"))
-			}
-			if !ok {
-				return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("user does not have permission %q", iam.PermissionProjectsCreate))
-			}
 			return s.CreateProject(ctx, connect.NewRequest(&v1pb.CreateProjectRequest{
 				Project:   req.Msg.Project,
 				ProjectId: projectID,
@@ -863,18 +851,6 @@ func (s *ProjectService) UpdateWebhook(ctx context.Context, req *connect.Request
 	if webhook == nil {
 		if req.Msg.AllowMissing {
 			// When allow_missing is true and webhook doesn't exist, create a new one
-			user, ok := GetUserFromContext(ctx)
-			if !ok {
-				return nil, connect.NewError(connect.CodeInternal, errors.New("user not found"))
-			}
-			// Check if user has permission to update project (which includes adding webhooks)
-			ok, err := s.iamManager.CheckPermission(ctx, iam.PermissionProjectsUpdate, user, project.ResourceID)
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to check permission"))
-			}
-			if !ok {
-				return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("user does not have permission %q", iam.PermissionProjectsUpdate))
-			}
 			// Call AddWebhook instead since we're creating a new webhook
 			return s.AddWebhook(ctx, connect.NewRequest(&v1pb.AddWebhookRequest{
 				Project: fmt.Sprintf("projects/%s", project.ResourceID),


### PR DESCRIPTION
## Summary
Remove redundant manual IAM permission checks from Update* methods that already use IAM authentication via proto annotations.

## Background
The ACL interceptor (`backend/api/v1/acl.go:154-175`) automatically handles permission checking for all methods annotated with `option (bytebase.v1.auth_method) = IAM;`. This includes:

1. **Primary permission validation** - Checks the declared permission (e.g., `bb.releases.update`)
2. **Allow-missing permission validation** - When `allow_missing=true` is detected via proto reflection, automatically derives and checks the corresponding `.create` permission

Since the interceptor runs before service methods are invoked, manual permission checks within the methods are redundant.

## Changes

### Files Modified (72 lines removed)

#### `database_group_service.go` - UpdateDatabaseGroup (12 lines)
- Removed manual check for `PermissionDatabaseGroupsCreate` when `allow_missing=true`

#### `release_service.go` - UpdateRelease (12 lines)
- Removed manual check for `PermissionReleasesCreate` when `allow_missing=true`

#### `project_service.go` - UpdateProject (13 lines)
- Removed manual check for `PermissionProjectsCreate` when `allow_missing=true`

#### `project_service.go` - UpdateWebhook (11 lines)
- Removed manual check for `PermissionProjectsUpdate` when `allow_missing=true`
- Note: This was checking the SAME permission already enforced by the interceptor

#### `instance_service.go` - UpdateInstance (13 lines)
- Removed manual check for `PermissionInstancesCreate` when `allow_missing=true`

#### `instance_service.go` - UpdateDataSource (11 lines)
- Removed manual check for `PermissionInstancesCreate` when `allow_missing=true`

## Testing
- ✅ Code builds successfully
- ✅ All files formatted with `gofmt`
- ✅ No new lint issues introduced

## Benefits
- **Cleaner code** - 72 lines of redundant code removed
- **Consistency** - All IAM-protected methods now rely solely on the interceptor
- **Maintainability** - Single source of truth for permission checking logic
- **Less error-prone** - Eliminates risk of checking wrong permissions (as seen in UpdateDataSource)

🤖 Generated with [Claude Code](https://claude.com/claude-code)