### PR TITLE
fix: exclude store package from OpenAPI generation to fix Issue schema

### DIFF
--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -36,3 +36,5 @@ plugins:
   - remote: buf.build/community/google-gnostic-openapi:v0.7.0
     out: gen/grpc-doc
     opt: paths=source_relative,enum_type=string
+    types:
+      - bytebase.v1

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -8044,12 +8044,12 @@ components:
             properties:
                 status:
                     enum:
-                        - STATUS_UNSPECIFIED
+                        - ADVICE_LEVEL_UNSPECIFIED
                         - SUCCESS
                         - WARNING
                         - ERROR
                     type: string
-                    description: The advice status.
+                    description: The advice level.
                     format: enum
                 code:
                     type: integer
@@ -8066,9 +8066,17 @@ components:
                         - $ref: '#/components/schemas/Position'
                     description: |-
                         The start_position is inclusive and the end_position is exclusive.
-                         TODO: use range instead.
+                         TODO: use range instead
                 endPosition:
                     $ref: '#/components/schemas/Position'
+                ruleType:
+                    enum:
+                        - RULE_TYPE_UNSPECIFIED
+                        - PARSER_BASED
+                        - AI_POWERED
+                    type: string
+                    description: The type of linting rule that generated this advice.
+                    format: enum
         Algorithm:
             type: object
             properties:
@@ -8244,22 +8252,20 @@ components:
                     type: array
                     items:
                         type: string
-                    description: List of role names that must approve, in order.
-            description: ApprovalFlow defines the sequence of approvals required.
+                    description: The roles required for approval in order.
         ApprovalTemplate:
             type: object
             properties:
                 flow:
                     allOf:
                         - $ref: '#/components/schemas/ApprovalFlow'
-                    description: The approval workflow specification.
+                    description: The approval flow definition.
                 title:
                     type: string
-                    description: Human-readable title of the approval template.
+                    description: The title of the approval template.
                 description:
                     type: string
-                    description: Detailed description of when this template applies.
-            description: ApprovalTemplate defines the approval workflow and requirements for an issue.
+                    description: The description of the approval template.
         ApproveIssueRequest:
             required:
                 - name
@@ -8746,6 +8752,26 @@ components:
                         - $ref: '#/components/schemas/Expr'
                     description: The parsed expression of the condition.
             description: Binding associates members with a role and optional conditions.
+        BoundingBox:
+            type: object
+            properties:
+                xmin:
+                    type: number
+                    description: Minimum X coordinate
+                    format: double
+                ymin:
+                    type: number
+                    description: Minimum Y coordinate
+                    format: double
+                xmax:
+                    type: number
+                    description: Maximum X coordinate
+                    format: double
+                ymax:
+                    type: number
+                    description: Maximum Y coordinate
+                    format: double
+            description: BoundingBox defines the spatial bounds for GEOMETRY spatial indexes.
         Candidate_Content:
             type: object
             properties:
@@ -8772,7 +8798,7 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/Range'
-                    description: The ranges of substrings correspond to the statements on the sheet.
+                    description: The ranges of sub-strings correspond to the statements on the sheet.
         ChangedResourceProcedure:
             type: object
             properties:
@@ -8782,7 +8808,7 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/Range'
-                    description: The ranges of substrings correspond to the statements on the sheet.
+                    description: The ranges of sub-strings correspond to the statements on the sheet.
         ChangedResourceSchema:
             type: object
             properties:
@@ -8809,14 +8835,11 @@ components:
             properties:
                 name:
                     type: string
-                tableRows:
-                    type: string
-                    description: The estimated row count of the table.
                 ranges:
                     type: array
                     items:
                         $ref: '#/components/schemas/Range'
-                    description: The ranges of substrings correspond to the statements on the sheet.
+                    description: The ranges of sub-strings correspond to the statements on the sheet.
         ChangedResourceView:
             type: object
             properties:
@@ -8826,7 +8849,7 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/Range'
-                    description: The ranges of substrings correspond to the statements on the sheet.
+                    description: The ranges of sub-strings correspond to the statements on the sheet.
         ChangedResources:
             type: object
             properties:
@@ -8898,6 +8921,16 @@ components:
                     description: |-
                         True if this changelog's dump version differs from current engine dump version.
                          When true and drift is detected, the drift may be a false positive from Bytebase upgrade.
+        CheckConstraintMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a check constraint.
+                expression:
+                    type: string
+                    description: The expression is the expression of a check constraint.
+            description: CheckConstraintMetadata is the metadata for check constraints.
         CheckReleaseRequest:
             required:
                 - parent
@@ -8977,6 +9010,17 @@ components:
                     description: The risk level of the statement on the target.
                     format: enum
             description: Check result for a single release file on a target database.
+        Checkers_RequiredStatusChecks:
+            type: object
+            properties:
+                planCheckEnforcement:
+                    enum:
+                        - PLAN_CHECK_ENFORCEMENT_UNSPECIFIED
+                        - ERROR_ONLY
+                        - STRICT
+                    type: string
+                    description: Enforcement level for plan check results during rollout validation.
+                    format: enum
         ColumnCatalog:
             type: object
             properties:
@@ -8999,6 +9043,112 @@ components:
                         - $ref: '#/components/schemas/ObjectSchema'
                     description: Object schema for complex column types like JSON.
             description: Column metadata within a table.
+        ColumnMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a column.
+                position:
+                    type: integer
+                    description: The position is the position in columns.
+                    format: int32
+                hasDefault:
+                    type: boolean
+                default:
+                    type: string
+                    description: The default value of column.
+                defaultOnNull:
+                    type: boolean
+                    description: |-
+                        Oracle specific metadata.
+                         The default_on_null is the default on null of a column.
+                onUpdate:
+                    type: string
+                    description: |-
+                        The on_update is the on update action of a column.
+                         For MySQL like databases, it's only supported for TIMESTAMP columns with
+                         CURRENT_TIMESTAMP as on update value.
+                nullable:
+                    type: boolean
+                    description: The nullable is the nullable of a column.
+                type:
+                    type: string
+                    description: The type is the type of a column.
+                characterSet:
+                    type: string
+                    description: The character_set is the character_set of a column.
+                collation:
+                    type: string
+                    description: The collation is the collation of a column.
+                comment:
+                    type: string
+                    description: The comment is the comment of a column.
+                generation:
+                    allOf:
+                        - $ref: '#/components/schemas/GenerationMetadata'
+                    description: The generation is the generation of a column.
+                isIdentity:
+                    type: boolean
+                identityGeneration:
+                    enum:
+                        - IDENTITY_GENERATION_UNSPECIFIED
+                        - ALWAYS
+                        - BY_DEFAULT
+                    type: string
+                    description: The identity_generation is for identity columns, PG only.
+                    format: enum
+                identitySeed:
+                    type: string
+                    description: The identity_seed is for identity columns, MSSQL only.
+                identityIncrement:
+                    type: string
+                    description: The identity_increment is for identity columns, MSSQL only.
+                defaultConstraintName:
+                    type: string
+                    description: |-
+                        The default_constraint_name is the name of the default constraint, MSSQL only.
+                         In MSSQL, default values are implemented as named constraints. When modifying or
+                         dropping a column's default value, you must reference the constraint by name.
+                         This field stores the actual constraint name from the database.
+
+                         Example: A column definition like:
+                           CREATE TABLE employees (
+                             status NVARCHAR(20) DEFAULT 'active'
+                           )
+
+                         Will create a constraint with an auto-generated name like 'DF__employees__statu__3B75D760'
+                         or a user-defined name if specified:
+                           ALTER TABLE employees ADD CONSTRAINT DF_employees_status DEFAULT 'active' FOR status
+
+                         To modify the default, you must first drop the existing constraint by name:
+                           ALTER TABLE employees DROP CONSTRAINT DF__employees__statu__3B75D760
+                           ALTER TABLE employees ADD CONSTRAINT DF_employees_status DEFAULT 'inactive' FOR status
+
+                         This field is populated when syncing from the database. When empty (e.g., when parsing
+                         from SQL files), the system cannot automatically drop the constraint.
+            description: ColumnMetadata is the metadata for columns.
+        CommandExecute_CommandResponse:
+            type: object
+            properties:
+                logTime:
+                    type: string
+                    description: When the response was logged.
+                    format: date-time
+                error:
+                    type: string
+                    description: Error message if command execution failed.
+                affectedRows:
+                    type: string
+                    description: Total affected rows.
+                allAffectedRows:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        `all_affected_rows` is the affected rows of each command.
+                         `all_affected_rows` may be unavailable if the database driver doesn't support it. Caller should fallback to `affected_rows` in that case.
+            description: Command execution response.
         Constant:
             type: object
             properties:
@@ -9152,9 +9302,7 @@ components:
             properties:
                 id:
                     type: string
-                    description: |-
-                        id is the uuid for classification. Each project can chose one
-                         classification config.
+                    description: id is the uuid for classification. Each project can chose one classification config.
                 title:
                     type: string
                 levels:
@@ -9176,34 +9324,37 @@ components:
             properties:
                 id:
                     type: string
+                    description: The unique identifier for this data source.
                 type:
                     enum:
                         - DATA_SOURCE_UNSPECIFIED
                         - ADMIN
                         - READ_ONLY
                     type: string
+                    description: The type of data source (ADMIN or READ_ONLY).
                     format: enum
                 username:
                     type: string
+                    description: The username for database authentication.
                 password:
+                    writeOnly: true
                     type: string
-                obfuscatedPassword:
-                    type: string
+                    description: The password for database authentication.
                 useSsl:
                     type: boolean
-                    description: Use SSL to connect to the data source. By default, we use the system's SSL configuration.
+                    description: Use SSL to connect to the data source. By default, we use system default SSL configuration.
                 sslCa:
+                    writeOnly: true
                     type: string
-                obfuscatedSslCa:
-                    type: string
+                    description: The SSL certificate authority certificate.
                 sslCert:
+                    writeOnly: true
                     type: string
-                obfuscatedSslCert:
-                    type: string
+                    description: The SSL client certificate.
                 sslKey:
+                    writeOnly: true
                     type: string
-                obfuscatedSslKey:
-                    type: string
+                    description: The SSL client private key.
                 verifyTlsCertificate:
                     type: boolean
                     description: |-
@@ -9214,14 +9365,17 @@ components:
                          validated (e.g., self-signed certs, VPN environments).
                 host:
                     type: string
+                    description: The hostname or IP address of the database server.
                 port:
                     type: string
+                    description: The port number of the database server.
                 database:
                     type: string
+                    description: The name of the database to connect to.
                 srv:
                     type: boolean
                     description: |-
-                        srv, authentication_database, and replica_set are used for MongoDB.
+                        srv, authentication_database and replica_set are used for MongoDB.
                          srv is a boolean flag that indicates whether the host is a DNS SRV record.
                 authenticationDatabase:
                     type: string
@@ -9237,36 +9391,37 @@ components:
                 sshHost:
                     type: string
                     description: |-
-                        SSH related
+                        Connection over SSH.
                          The hostname of the SSH server agent.
+                         Required.
                 sshPort:
                     type: string
-                    description: The port of the SSH server agent. It's 22 typically.
+                    description: |-
+                        The port of the SSH server agent. It's 22 typically.
+                         Required.
                 sshUser:
                     type: string
-                    description: The user to login the server.
+                    description: |-
+                        The user to login the server.
+                         Required.
                 sshPassword:
+                    writeOnly: true
                     type: string
                     description: The password to login the server. If it's empty string, no password is required.
-                obfuscatedSshPassword:
-                    type: string
                 sshPrivateKey:
+                    writeOnly: true
                     type: string
                     description: The private key to login the server. If it's empty string, we will use the system default private key from os.Getenv("SSH_AUTH_SOCK").
-                obfuscatedSshPrivateKey:
-                    type: string
                 authenticationPrivateKey:
+                    writeOnly: true
                     type: string
                     description: |-
                         PKCS#8 private key in PEM format. If it's empty string, no private key is required.
                          Used for authentication when connecting to the data source.
-                obfuscatedAuthenticationPrivateKey:
-                    type: string
                 authenticationPrivateKeyPassphrase:
+                    writeOnly: true
                     type: string
                     description: Passphrase for the encrypted PKCS#8 private key. Only used when the private key is encrypted.
-                obfuscatedAuthenticationPrivateKeyPassphrase:
-                    type: string
                 externalSecret:
                     $ref: '#/components/schemas/DataSourceExternalSecret'
                 authenticationType:
@@ -9296,7 +9451,7 @@ components:
                     description: direct_connection is used for MongoDB to dispatch all the operations to the node specified in the connection string.
                 region:
                     type: string
-                    description: Region is the location of the database, used for AWS RDS. For example, us-east-1.
+                    description: region is the location of where the DB is, works for AWS RDS. For example, us-east-1.
                 warehouseId:
                     type: string
                     description: warehouse_id is used by Databricks.
@@ -9305,10 +9460,8 @@ components:
                     description: master_name is the master name used by connecting redis-master via redis sentinel.
                 masterUsername:
                     type: string
-                    description: master_username and master_obfuscated_password are master credentials used by redis sentinel mode.
+                    description: master_username and master_password are master credentials used by redis sentinel mode.
                 masterPassword:
-                    type: string
-                obfuscatedMasterPassword:
                     type: string
                 redisType:
                     enum:
@@ -9338,20 +9491,27 @@ components:
                         - AWS_SECRETS_MANAGER
                         - GCP_SECRET_MANAGER
                     type: string
+                    description: The type of external secret store.
                     format: enum
                 url:
                     type: string
+                    description: The URL of the external secret store.
                 authType:
                     enum:
                         - AUTH_TYPE_UNSPECIFIED
                         - TOKEN
                         - VAULT_APP_ROLE
                     type: string
+                    description: The authentication method for accessing the secret store.
                     format: enum
                 appRole:
-                    $ref: '#/components/schemas/DataSourceExternalSecret_AppRoleAuthOption'
+                    allOf:
+                        - $ref: '#/components/schemas/DataSourceExternalSecret_AppRoleAuthOption'
+                    description: AppRole authentication configuration.
                 token:
+                    writeOnly: true
                     type: string
+                    description: Token for direct authentication.
                 engineName:
                     type: string
                     description: engine name is the name for secret engine.
@@ -9370,20 +9530,17 @@ components:
                          Default is false (verification enabled) for security.
                          Only set to true for development or when certificates cannot be properly validated.
                 vaultSslCa:
+                    writeOnly: true
                     type: string
                     description: CA certificate for Vault server verification.
-                obfuscatedVaultSslCa:
-                    type: string
                 vaultSslCert:
+                    writeOnly: true
                     type: string
                     description: Client certificate for mutual TLS authentication with Vault.
-                obfuscatedVaultSslCert:
-                    type: string
                 vaultSslKey:
+                    writeOnly: true
                     type: string
                     description: Client private key for mutual TLS authentication with Vault.
-                obfuscatedVaultSslKey:
-                    type: string
         DataSourceExternalSecret_AppRoleAuthOption:
             type: object
             properties:
@@ -9406,6 +9563,24 @@ components:
                 mountPath:
                     type: string
                     description: The path where the approle auth method is mounted.
+        DataSourceQueryPolicy:
+            type: object
+            properties:
+                adminDataSourceRestriction:
+                    enum:
+                        - RESTRICTION_UNSPECIFIED
+                        - FALLBACK
+                        - DISALLOW
+                    type: string
+                    description: Restriction for admin data source queries.
+                    format: enum
+                disallowDdl:
+                    type: boolean
+                    description: Disallow running DDL statements in the SQL editor.
+                disallowDml:
+                    type: boolean
+                    description: Disallow running DML statements in the SQL editor.
+            description: Policy for controlling which data sources can be queried in the SQL editor.
         DataSource_AWSCredential:
             type: object
             properties:
@@ -9578,23 +9753,34 @@ components:
         DatabaseMetadata:
             type: object
             properties:
-                labels:
-                    type: object
-                    additionalProperties:
-                        type: string
-                lastSyncTime:
+                name:
                     type: string
-                    format: date-time
-                backupAvailable:
-                    type: boolean
-                datashare:
-                    type: boolean
-                drifted:
-                    type: boolean
-                    description: The schema has drifted from the source of truth.
-                version:
+                    description: |-
+                        The database metadata name.
+
+                         Format: instances/{instance}/databases/{database}/metadata
+                schemas:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SchemaMetadata'
+                    description: The schemas is the list of schemas in a database.
+                characterSet:
                     type: string
-                    description: The version of database schema.
+                    description: The character_set is the character set of a database.
+                collation:
+                    type: string
+                    description: The collation is the collation of a database.
+                extensions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExtensionMetadata'
+                    description: The extensions is the list of extensions in a database.
+                owner:
+                    type: string
+                    description: The owner of the database.
+                searchPath:
+                    type: string
+                    description: The search_path is the search path of a PostgreSQL database.
             description: DatabaseMetadata is the metadata for databases.
         DatabaseSDLSchema:
             type: object
@@ -9623,6 +9809,28 @@ components:
                     type: string
                     description: The schema dump from database.
             description: DatabaseSchema is the metadata for databases.
+        DependencyColumn:
+            type: object
+            properties:
+                schema:
+                    type: string
+                    description: The schema is the schema of a reference column.
+                table:
+                    type: string
+                    description: The table is the table of a reference column.
+                column:
+                    type: string
+                    description: The column is the name of a reference column.
+            description: DependencyColumn is the metadata for dependency columns.
+        DependencyTable:
+            type: object
+            properties:
+                schema:
+                    type: string
+                    description: The schema is the schema of a reference table.
+                table:
+                    type: string
+                    description: The table is the name of a reference table.
         Deployment_DatabaseGroupMapping:
             type: object
             properties:
@@ -9715,6 +9923,62 @@ components:
             properties:
                 diff:
                     type: string
+        DimensionConstraint:
+            type: object
+            properties:
+                dimension:
+                    type: string
+                    description: Dimension name/type (X, Y, Z, M, etc.)
+                minValue:
+                    type: number
+                    description: Minimum value for this dimension
+                    format: double
+                maxValue:
+                    type: number
+                    description: Maximum value for this dimension
+                    format: double
+                tolerance:
+                    type: number
+                    description: Tolerance for this dimension
+                    format: double
+            description: DimensionConstraint defines constraints for a spatial dimension.
+        DimensionalConfig:
+            type: object
+            properties:
+                dimensions:
+                    type: integer
+                    description: Number of dimensions (2-4, default 2)
+                    format: int32
+                dataType:
+                    type: string
+                    description: Spatial data type (GEOMETRY, GEOGRAPHY, POINT, POLYGON, etc.)
+                srid:
+                    type: integer
+                    description: Spatial reference system identifier (SRID)
+                    format: int32
+                constraints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DimensionConstraint'
+                    description: Coordinate system constraints
+            description: DimensionalConfig defines dimensional and constraint parameters for spatial indexes.
+        EnumTypeMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name of a type.
+                values:
+                    type: array
+                    items:
+                        type: string
+                    description: The enum values of a type.
+                comment:
+                    type: string
+                    description: The comment describing the enum type.
+                skipDump:
+                    type: boolean
+                    description: Whether to skip this enum type during schema dump operations.
         EnvironmentSetting:
             type: object
             properties:
@@ -9725,6 +9989,13 @@ components:
         EnvironmentSetting_Environment:
             type: object
             properties:
+                name:
+                    readOnly: true
+                    type: string
+                    description: |-
+                        The resource name of the environment.
+                         Format: environments/{environment}.
+                         Output only.
                 id:
                     type: string
                     description: |-
@@ -9740,6 +10011,30 @@ components:
                         type: string
                 color:
                     type: string
+        EventMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name of the event.
+                definition:
+                    type: string
+                    description: The schedule of the event.
+                timeZone:
+                    type: string
+                    description: The time zone of the event.
+                sqlMode:
+                    type: string
+                    description: The SQL mode setting for the event.
+                characterSetClient:
+                    type: string
+                    description: The character set used by the client creating the event.
+                collationConnection:
+                    type: string
+                    description: The collation used for the connection when creating the event.
+                comment:
+                    type: string
+                    description: The comment is the comment of an event.
         ExportAuditLogsRequest:
             required:
                 - parent
@@ -10118,6 +10413,41 @@ components:
 
                          This results from the macro `has(request.auth)`.
             description: A field selection expression. e.g. `request.auth`.
+        ExtensionMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of an extension.
+                schema:
+                    type: string
+                    description: |-
+                        The schema is the extension that is installed to. But the extension usage
+                         is not limited to the schema.
+                version:
+                    type: string
+                    description: The version is the version of an extension.
+                description:
+                    type: string
+                    description: The description is the description of an extension.
+            description: ExtensionMetadata is the metadata for extensions.
+        ExternalTableMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a external table.
+                externalServerName:
+                    type: string
+                    description: The external_server_name is the name of the external server.
+                externalDatabaseName:
+                    type: string
+                    description: The external_database_name is the name of the external database.
+                columns:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ColumnMetadata'
+                    description: The columns is the ordered list of columns in a foreign table.
         FieldMapping:
             type: object
             properties:
@@ -10139,6 +10469,90 @@ components:
                 FieldMapping saves the field names from user info API of identity provider.
                  As we save all raw json string of user info response data into `principal.idp_user_info`,
                  we can extract the relevant data based with `FieldMapping`.
+        ForeignKeyMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a foreign key.
+                columns:
+                    type: array
+                    items:
+                        type: string
+                    description: The columns are the ordered referencing columns of a foreign key.
+                referencedSchema:
+                    type: string
+                    description: |-
+                        The referenced_schema is the referenced schema name of a foreign key.
+                         It is an empty string for databases without such concept such as MySQL.
+                referencedTable:
+                    type: string
+                    description: The referenced_table is the referenced table name of a foreign key.
+                referencedColumns:
+                    type: array
+                    items:
+                        type: string
+                    description: The referenced_columns are the ordered referenced columns of a foreign key.
+                onDelete:
+                    type: string
+                    description: The on_delete is the on delete action of a foreign key.
+                onUpdate:
+                    type: string
+                    description: The on_update is the on update action of a foreign key.
+                matchType:
+                    type: string
+                    description: |-
+                        The match_type is the match type of a foreign key.
+                         The match_type is the PostgreSQL specific field.
+                         It's empty string for other databases.
+            description: ForeignKeyMetadata is the metadata for foreign keys.
+        FunctionMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a function.
+                definition:
+                    type: string
+                    description: The definition is the definition of a function.
+                signature:
+                    type: string
+                    description: |-
+                        The signature is the name with the number and type of input arguments the
+                         function takes.
+                characterSetClient:
+                    type: string
+                    description: MySQL specific metadata.
+                collationConnection:
+                    type: string
+                databaseCollation:
+                    type: string
+                sqlMode:
+                    type: string
+                comment:
+                    type: string
+                dependencyTables:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DependencyTable'
+                    description: |-
+                        The dependency_tables is the list of dependency tables of a function.
+                         For PostgreSQL, it's the list of tables that the function depends on the return type definition.
+                skipDump:
+                    type: boolean
+            description: FunctionMetadata is the metadata for functions.
+        GenerationMetadata:
+            type: object
+            properties:
+                type:
+                    enum:
+                        - TYPE_UNSPECIFIED
+                        - VIRTUAL
+                        - STORED
+                    type: string
+                    format: enum
+                expression:
+                    type: string
         GetSchemaStringResponse:
             type: object
             properties:
@@ -10160,22 +10574,32 @@ components:
                 role:
                     type: string
                     description: |-
-                        The role being requested for the user.
+                        The requested role.
                          Format: roles/EXPORTER.
                 user:
                     type: string
                     description: |-
-                        The user who will receive the role.
-                         Format: users/{userUID}.
+                        The user to be granted.
+                         Format: users/{email}.
                 condition:
                     allOf:
                         - $ref: '#/components/schemas/Expr'
-                    description: Optional conditional expression that limits when the grant applies.
+                    description: The condition for the role. Same as the condition in IAM Binding message.
                 expiration:
                     pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
                     type: string
-                    description: Duration after which the grant automatically expires.
-            description: GrantRequest contains details for requesting database access permissions.
+                    description: The duration for which the grant is valid.
+        GridLevel:
+            type: object
+            properties:
+                level:
+                    type: integer
+                    description: Grid level number (1-4 for SQL Server)
+                    format: int32
+                density:
+                    type: string
+                    description: Grid density (LOW, MEDIUM, HIGH)
+            description: GridLevel defines a tessellation grid level with its density.
         Group:
             type: object
             properties:
@@ -10209,16 +10633,18 @@ components:
                 member:
                     type: string
                     description: |-
-                        Member is the principal who belongs to this group.
+                        Member is the principal who belong to this group.
 
-                         Format: users/{userUID}.
+                         Format: users/hello@world.com
                 role:
                     enum:
                         - ROLE_UNSPECIFIED
                         - OWNER
                         - MEMBER
                     type: string
+                    description: The member's role in the group.
                     format: enum
+            description: A member of a group with a role.
         IamPolicy:
             type: object
             properties:
@@ -10228,7 +10654,14 @@ components:
                         $ref: '#/components/schemas/Binding'
                     description: |-
                         Collection of binding.
-                         A binding binds one or more members or groups to a single role.
+                         A binding binds one or more project members to a single project role.
+                etag:
+                    type: string
+                    description: |-
+                        The current etag of the policy.
+                         If an etag is provided and does not match the current etag of the policy,
+                         the call will be blocked and an ABORTED error will be returned.
+            description: IAM policy that binds members to roles.
         IdentityProvider:
             type: object
             properties:
@@ -10283,11 +10716,99 @@ components:
                         - $ref: '#/components/schemas/OIDCIdentityProviderContext'
                     description: OpenID Connect authentication context.
             description: Context for identity provider authentication.
+        IndexMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of an index.
+                expressions:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The expressions are the ordered columns or expressions of an index.
+                         This could refer to a column or an expression.
+                keyLength:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The key_lengths are the ordered key lengths of an index.
+                         If the key length is not specified, it's -1.
+                descending:
+                    type: array
+                    items:
+                        type: boolean
+                    description: The descending is the ordered descending of an index.
+                type:
+                    type: string
+                    description: The type is the type of an index.
+                unique:
+                    type: boolean
+                    description: The unique is whether the index is unique.
+                primary:
+                    type: boolean
+                    description: The primary is whether the index is a primary key index.
+                visible:
+                    type: boolean
+                    description: The visible is whether the index is visible.
+                comment:
+                    type: string
+                    description: The comment is the comment of an index.
+                definition:
+                    type: string
+                    description: The definition of an index.
+                parentIndexSchema:
+                    type: string
+                    description: The schema name of the parent index.
+                parentIndexName:
+                    type: string
+                    description: The index name of the parent index.
+                granularity:
+                    type: string
+                    description: The number of granules in the block. It's a ClickHouse specific field.
+                isConstraint:
+                    type: boolean
+                    description: |-
+                        It's a PostgreSQL specific field.
+                         The unique constraint and unique index are not the same thing in PostgreSQL.
+                spatialConfig:
+                    allOf:
+                        - $ref: '#/components/schemas/SpatialIndexConfig'
+                    description: Spatial index configuration for spatial databases like SQL Server, PostgreSQL with PostGIS, etc.
+                opclassNames:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        https://www.postgresql.org/docs/current/catalog-pg-opclass.html
+                         Name of the operator class for each column. (PostgreSQL specific).
+                opclassDefaults:
+                    type: array
+                    items:
+                        type: boolean
+                    description: True if the operator class is the default. (PostgreSQL specific).
+            description: IndexMetadata is the metadata for indexes.
         Instance:
             type: object
             properties:
+                name:
+                    type: string
+                    description: |-
+                        The name of the instance.
+                         Format: instances/{instance}
+                state:
+                    enum:
+                        - STATE_UNSPECIFIED
+                        - ACTIVE
+                        - DELETED
+                    type: string
+                    description: The lifecycle state of the instance.
+                    format: enum
                 title:
                     type: string
+                    description: The display title of the instance.
                 engine:
                     enum:
                         - ENGINE_UNSPECIFIED
@@ -10317,21 +10838,38 @@ components:
                         - TRINO
                         - CASSANDRA
                     type: string
+                    description: The database engine type.
                     format: enum
-                activation:
-                    type: boolean
-                version:
+                engineVersion:
+                    readOnly: true
                     type: string
+                    description: The version of the database engine.
                 externalLink:
                     type: string
+                    description: External URL to the database instance console.
                 dataSources:
                     type: array
                     items:
                         $ref: '#/components/schemas/DataSource'
+                    description: Data source configurations for connecting to the instance.
+                environment:
+                    type: string
+                    description: |-
+                        The environment resource.
+                         Format: environments/prod where prod is the environment resource ID.
+                activation:
+                    type: boolean
+                    description: Whether the instance is activated for use.
+                roles:
+                    readOnly: true
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/InstanceRole'
+                    description: Database roles available in this instance.
                 syncInterval:
                     pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
                     type: string
-                    description: The interval between automatic instance synchronizations.
+                    description: How often the instance is synced.
                 maximumConnections:
                     type: integer
                     description: |-
@@ -10343,21 +10881,13 @@ components:
                     items:
                         type: string
                     description: |-
-                        Enable sync for the following databases.
+                        Enable sync for following databases.
                          Default empty, means sync all schemas & databases.
-                mysqlLowerCaseTableNames:
-                    type: integer
-                    description: |-
-                        The lower_case_table_names config for MySQL instances.
-                         It is used to determine whether the table names and database names are case sensitive.
-                    format: int32
                 lastSyncTime:
+                    readOnly: true
                     type: string
+                    description: The last time the instance was synced.
                     format: date-time
-                roles:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/InstanceRole'
                 labels:
                     type: object
                     additionalProperties:
@@ -10365,7 +10895,6 @@ components:
                     description: |-
                         Labels are key-value pairs that can be attached to the instance.
                          For example, { "org_group": "infrastructure", "environment": "production" }
-            description: Instance is the proto for instances.
         InstanceResource:
             type: object
             properties:
@@ -10430,7 +10959,17 @@ components:
             properties:
                 name:
                     type: string
-                    description: The role name.
+                    description: |-
+                        The name of the role.
+                         Format: instances/{instance}/roles/{role}
+                         The role name is the unique name for the role.
+                roleName:
+                    type: string
+                    description: The role name. It's unique within the instance.
+                password:
+                    writeOnly: true
+                    type: string
+                    description: The role password.
                 connectionLimit:
                     type: integer
                     description: The connection count limit for this role.
@@ -10442,25 +10981,88 @@ components:
                     type: string
                     description: |-
                         The role attribute.
-                         For PostgreSQL, it contains super_user, no_inherit, create_role, create_db, can_login, replication and bypass_rls. Docs: https://www.postgresql.org/docs/current/role-attributes.html
-                         For MySQL, it is the global privileges as GRANT statements, which means it only contains "GRANT ... ON *.* TO ...". Docs: https://dev.mysql.com/doc/refman/8.0/en/grant.html
+                         For PostgreSQL, it contains super_user, no_inherit, create_role, create_db, can_login, replication, and bypass_rls. Docs: https://www.postgresql.org/docs/current/role-attributes.html
+                         For MySQL, it's the global privileges as GRANT statements, which means it only contains "GRANT ... ON *.* TO ...". Docs: https://dev.mysql.com/doc/refman/8.0/en/grant.html
             description: InstanceRole is the API message for instance role.
         Issue:
             type: object
             properties:
-                approval:
+                name:
+                    type: string
+                    description: |-
+                        The name of the issue.
+                         Format: projects/{project}/issues/{issue}
+                title:
+                    type: string
+                    description: The title of the issue.
+                description:
+                    type: string
+                    description: The description of the issue.
+                type:
+                    enum:
+                        - TYPE_UNSPECIFIED
+                        - DATABASE_CHANGE
+                        - GRANT_REQUEST
+                        - DATABASE_EXPORT
+                    type: string
+                    format: enum
+                status:
+                    enum:
+                        - ISSUE_STATUS_UNSPECIFIED
+                        - OPEN
+                        - DONE
+                        - CANCELED
+                    type: string
+                    description: The status of the issue.
+                    format: enum
+                approvers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Issue_Approver'
+                approvalTemplate:
                     allOf:
-                        - $ref: '#/components/schemas/IssuePayloadApproval'
-                    description: Approval information for the issue workflow.
+                        - $ref: '#/components/schemas/ApprovalTemplate'
+                    description: The approval template for the issue.
+                creator:
+                    readOnly: true
+                    type: string
+                    description: 'Format: users/hello@world.com'
+                createTime:
+                    readOnly: true
+                    type: string
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    format: date-time
+                plan:
+                    type: string
+                    description: |-
+                        The plan associated with the issue.
+                         Can be empty.
+                         Format: projects/{project}/plans/{plan}
+                rollout:
+                    type: string
+                    description: |-
+                        The rollout associated with the issue.
+                         Can be empty.
+                         Format: projects/{project}/rollouts/{rollout}
                 grantRequest:
                     allOf:
                         - $ref: '#/components/schemas/GrantRequest'
-                    description: Access grant request details if this is a grant request issue.
-                labels:
+                    description: Used if the issue type is GRANT_REQUEST.
+                releasers:
                     type: array
                     items:
                         type: string
-                    description: Labels attached to categorize and filter the issue.
+                    description: |-
+                        The releasers of the pending stage of the issue rollout, judging
+                         from the rollout policy.
+                         Format:
+                         - roles/workspaceOwner
+                         - roles/workspaceDBA
+                         - roles/projectOwner
+                         - roles/projectReleaser
                 riskLevel:
                     enum:
                         - RISK_LEVEL_UNSPECIFIED
@@ -10468,9 +11070,44 @@ components:
                         - MODERATE
                         - HIGH
                     type: string
-                    description: Risk level for the issue, calculated from statement types.
+                    description: The risk level of the issue.
                     format: enum
-            description: Issue is the metadata for issues that track database operations and access requests.
+                taskStatusCount:
+                    type: object
+                    additionalProperties:
+                        type: integer
+                        format: int32
+                    description: |-
+                        The status count of the issue.
+                         Keys are the following:
+                         - NOT_STARTED
+                         - SKIPPED
+                         - PENDING
+                         - RUNNING
+                         - DONE
+                         - FAILED
+                         - CANCELED
+                labels:
+                    type: array
+                    items:
+                        type: string
+                    description: Labels attached to the issue for categorization and filtering.
+                approvalStatus:
+                    readOnly: true
+                    enum:
+                        - APPROVAL_STATUS_UNSPECIFIED
+                        - CHECKING
+                        - PENDING
+                        - APPROVED
+                        - REJECTED
+                        - SKIPPED
+                        - ERROR
+                    type: string
+                    format: enum
+                approvalStatusError:
+                    readOnly: true
+                    type: string
+                    description: Only populated when approval_status == ERROR
         IssueComment:
             type: object
             properties:
@@ -10620,28 +11257,7 @@ components:
                     type: string
                     format: enum
             description: Task update event information.
-        IssuePayloadApproval:
-            type: object
-            properties:
-                approvalTemplate:
-                    allOf:
-                        - $ref: '#/components/schemas/ApprovalTemplate'
-                    description: The approval template being used for this issue.
-                approvers:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/IssuePayloadApproval_Approver'
-                    description: List of approvers and their current status.
-                approvalFindingDone:
-                    type: boolean
-                    description: |-
-                        Whether the system has finished finding a matching approval template.
-                         False means the backend is still searching for matching templates.
-                approvalFindingError:
-                    type: string
-                    description: Error message if approval template finding failed.
-            description: IssuePayloadApproval records the approval template used and approval history for an issue.
-        IssuePayloadApproval_Approver:
+        Issue_Approver:
             type: object
             properties:
                 status:
@@ -10651,46 +11267,52 @@ components:
                         - APPROVED
                         - REJECTED
                     type: string
-                    description: The current approval status.
+                    description: The new status.
                     format: enum
-                principalId:
-                    type: integer
-                    description: The ID of the principal who is the approver.
-                    format: int32
-            description: Approver represents a user who can approve or reject an issue.
+                principal:
+                    type: string
+                    description: 'Format: users/hello@world.com'
+            description: Approvers and their approval status for the issue.
         Item_Table:
             type: object
             properties:
                 database:
                     type: string
                     description: |-
-                        The database containing the table.
+                        The database information.
                          Format: instances/{instance}/databases/{database}
                 schema:
                     type: string
-                    description: Schema name (for databases that support schemas).
+                    description: The schema name.
                 table:
                     type: string
-                    description: Table name.
-            description: Table identifies a database table.
+                    description: The table name.
+            description: Table information.
         KerberosConfig:
             type: object
             properties:
                 primary:
                     type: string
+                    description: The primary component of the Kerberos principal.
                 instance:
                     type: string
+                    description: The instance component of the Kerberos principal.
                 realm:
                     type: string
+                    description: The Kerberos realm.
                 keytab:
                     type: string
+                    description: The keytab file contents for authentication.
                     format: bytes
                 kdcHost:
                     type: string
+                    description: The hostname of the Key Distribution Center (KDC).
                 kdcPort:
                     type: string
+                    description: The port of the Key Distribution Center (KDC).
                 kdcTransportProtocol:
                     type: string
+                    description: The transport protocol for KDC communication (tcp or udp).
         LDAPIdentityProviderConfig:
             type: object
             properties:
@@ -11061,6 +11683,54 @@ components:
             type: object
             properties: {}
             description: Request to logout current user session.
+        MaskingExceptionPolicy:
+            type: object
+            properties:
+                maskingExceptions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/MaskingExceptionPolicy_MaskingException'
+                    description: The list of masking exceptions.
+            description: MaskingExceptionPolicy is the allowlist of users who can access sensitive data.
+        MaskingExceptionPolicy_MaskingException:
+            type: object
+            properties:
+                action:
+                    enum:
+                        - ACTION_UNSPECIFIED
+                        - QUERY
+                        - EXPORT
+                    type: string
+                    description: The action that the user can perform on sensitive data.
+                    format: enum
+                member:
+                    type: string
+                    description: |-
+                        Member is the principal who bind to this exception policy instance.
+
+                         - `user:{email}`: An email address that represents a specific Bytebase account. For example, `alice@example.com`.
+                         - `group:{email}`: An email address for group.
+                condition:
+                    allOf:
+                        - $ref: '#/components/schemas/Expr'
+                    description: |-
+                        The condition that is associated with this exception policy instance.
+                         The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
+                         If the condition is empty, means the user can access all databases without expiration.
+
+                         Support variables:
+                         resource.instance_id: the instance resource id. Only support "==" operation.
+                         resource.database_name: the database name. Only support "==" operation.
+                         resource.schema_name: the schema name. Only support "==" operation.
+                         resource.table_name: the table name. Only support "==" operation.
+                         resource.column_name: the column name. Only support "==" operation.
+                         request.time: the expiration. Only support "<" operation in `request.time < timestamp("{ISO datetime string format}")`
+                         All variables should join with "&&" condition.
+
+                         For example:
+                         resource.instance_id == "local" && resource.database_name == "employee" && request.time < timestamp("2025-04-30T11:10:39.000Z")
+                         resource.instance_id == "local" && resource.database_name == "employee"
+            description: An exception allowing specific users to access masked data.
         MaskingReason:
             type: object
             properties:
@@ -11085,6 +11755,84 @@ components:
                 semanticTypeIcon:
                     type: string
                     description: Icon associated with the semantic type (if any).
+        MaskingRulePolicy:
+            type: object
+            properties:
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/MaskingRulePolicy_MaskingRule'
+                    description: The list of masking rules.
+            description: Policy for configuring data masking rules.
+        MaskingRulePolicy_MaskingRule:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the rule in UUID format.
+                condition:
+                    allOf:
+                        - $ref: '#/components/schemas/Expr'
+                    description: |-
+                        The condition for the masking rule.
+                         The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
+
+                         Support variables:
+                         resource.environment_id: the environment resource id.
+                         resource.project_id: the project resource id.
+                         resource.instance_id: the instance resource id.
+                         resource.database_name: the database name.
+                         resource.table_name: the table name.
+                         resource.column_name: the column name.
+                         resource.classification_level: the classification level.
+
+                         Each variable support following operations:
+                         ==: the value equals the target.
+                         !=: the value not equals the target.
+                         in: the value matches one of the targets.
+                         !(in): the value not matches any of the targets.
+
+                         For example:
+                         resource.environment_id == "test" && resource.project_id == "sample-project"
+                         resource.instance_id == "sample-instance" && resource.database_name == "employee" && resource.table_name in ["table1", "table2"]
+                         resource.environment_id != "test" || !(resource.project_id in ["poject1", "prject2"])
+                         resource.instance_id == "sample-instance" && (resource.database_name == "db1" || resource.database_name == "db2")
+                semanticType:
+                    type: string
+                    description: The semantic type of data to mask (e.g., "SSN", "EMAIL").
+            description: A rule that defines when and how to mask data.
+        MaterializedViewMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a materialized view.
+                definition:
+                    type: string
+                    description: The definition is the definition of a materialized view.
+                comment:
+                    type: string
+                    description: The comment is the comment of a materialized view.
+                dependencyColumns:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DependencyColumn'
+                    description: |-
+                        The dependency_columns is the list of dependency columns of a materialized
+                         view.
+                triggers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TriggerMetadata'
+                    description: The columns is the ordered list of columns in a table.
+                indexes:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/IndexMetadata'
+                    description: The indexes is the list of indexes in a table.
+                skipDump:
+                    type: boolean
+            description: MaterializedViewMetadata is the metadata for materialized views.
         OAuth2IdentityProviderConfig:
             type: object
             properties:
@@ -11221,7 +11969,10 @@ components:
             type: object
             properties:
                 kind:
-                    $ref: '#/components/schemas/ObjectSchema'
+                    allOf:
+                        - $ref: '#/components/schemas/ObjectSchema'
+                    description: The schema of array elements.
+            description: Array type with element schema.
         ObjectSchema_StructKind:
             type: object
             properties:
@@ -11229,6 +11980,18 @@ components:
                     type: object
                     additionalProperties:
                         $ref: '#/components/schemas/ObjectSchema'
+                    description: Properties of the struct.
+            description: Structure type with named properties.
+        PackageMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a package.
+                definition:
+                    type: string
+                    description: The definition is the definition of a package.
+            description: PackageMetadata is the metadata for packages.
         PasswordRestrictionSetting:
             type: object
             properties:
@@ -11521,7 +12284,56 @@ components:
                     $ref: '#/components/schemas/Plan_ExportDataConfig'
         Policy:
             type: object
-            properties: {}
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The name of the policy.
+                         Format: {resource name}/policies/{policy type}
+                         Workspace resource name: "".
+                         Environment resource name: environments/environment-id.
+                         Instance resource name: instances/instance-id.
+                         Database resource name: instances/instance-id/databases/database-name.
+                inheritFromParent:
+                    type: boolean
+                    description: Whether this policy inherits from its parent resource.
+                type:
+                    enum:
+                        - POLICY_TYPE_UNSPECIFIED
+                        - ROLLOUT_POLICY
+                        - MASKING_RULE
+                        - MASKING_EXCEPTION
+                        - TAG
+                        - DATA_SOURCE_QUERY
+                        - DATA_QUERY
+                    type: string
+                    description: The type of policy.
+                    format: enum
+                rolloutPolicy:
+                    $ref: '#/components/schemas/RolloutPolicy'
+                maskingRulePolicy:
+                    $ref: '#/components/schemas/MaskingRulePolicy'
+                maskingExceptionPolicy:
+                    $ref: '#/components/schemas/MaskingExceptionPolicy'
+                tagPolicy:
+                    $ref: '#/components/schemas/TagPolicy'
+                dataSourceQueryPolicy:
+                    $ref: '#/components/schemas/DataSourceQueryPolicy'
+                queryDataPolicy:
+                    $ref: '#/components/schemas/QueryDataPolicy'
+                enforce:
+                    type: boolean
+                    description: Whether the policy is enforced.
+                resourceType:
+                    readOnly: true
+                    enum:
+                        - RESOURCE_TYPE_UNSPECIFIED
+                        - WORKSPACE
+                        - ENVIRONMENT
+                        - PROJECT
+                    type: string
+                    description: The resource type for the policy.
+                    format: enum
         Position:
             type: object
             properties:
@@ -11629,15 +12441,6 @@ components:
                 statement:
                     type: string
                     description: The rollback SQL statement that would undo the task run.
-        PriorBackupDetail:
-            type: object
-            properties:
-                items:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/PriorBackupDetail_Item'
-                    description: List of backup operations performed.
-            description: PriorBackupDetail contains information about automatic backups created before migration.
         PriorBackupDetail_Item:
             type: object
             properties:
@@ -11658,53 +12461,106 @@ components:
                         - $ref: '#/components/schemas/Position'
                     description: The end position in the SQL statement.
             description: A single backup table mapping.
+        ProcedureMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a procedure.
+                definition:
+                    type: string
+                    description: The definition is the definition of a procedure.
+                signature:
+                    type: string
+                    description: |-
+                        The signature is the name with the number and type of input arguments the
+                         procedure takes.
+                characterSetClient:
+                    type: string
+                    description: MySQL specific metadata.
+                collationConnection:
+                    type: string
+                databaseCollation:
+                    type: string
+                sqlMode:
+                    type: string
+                comment:
+                    type: string
+                    description: The comment is the comment of a procedure.
+                skipDump:
+                    type: boolean
+            description: ProcedureMetadata is the metadata for procedures.
         Project:
             type: object
             properties:
+                name:
+                    type: string
+                    description: |-
+                        The name of the project.
+                         Format: projects/{project}
+                state:
+                    enum:
+                        - STATE_UNSPECIFIED
+                        - ACTIVE
+                        - DELETED
+                    type: string
+                    description: The lifecycle state of the project.
+                    format: enum
+                title:
+                    type: string
+                    description: The title or name of a project. It's not unique within the workspace.
+                webhooks:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Webhook'
+                    description: The list of webhooks configured for the project.
+                dataClassificationConfigId:
+                    type: string
+                    description: The data classification configuration ID for the project.
                 issueLabels:
                     type: array
                     items:
                         $ref: '#/components/schemas/Label'
-                    description: Available labels that can be applied to issues in this project.
+                    description: Labels available for tagging issues in this project.
                 forceIssueLabels:
                     type: boolean
                     description: Force issue labels to be used when creating an issue.
                 allowModifyStatement:
                     type: boolean
-                    description: Allow modifying statement after issue is created.
+                    description: Allow modifying SQL statements after issue is created.
                 autoResolveIssue:
                     type: boolean
-                    description: Enable auto resolve issue.
+                    description: Enable automatic issue resolution when tasks complete.
                 enforceIssueTitle:
                     type: boolean
-                    description: Enforce issue title created by user instead of generated by Bytebase.
+                    description: Enforce issue title to be created by user instead of generated by Bytebase.
                 autoEnableBackup:
                     type: boolean
-                    description: Whether to automatically enable backup.
+                    description: Whether to automatically enable backup for database changes.
                 skipBackupErrors:
                     type: boolean
-                    description: Whether to skip backup errors and continue the data migration.
+                    description: Whether to skip backup errors and continue with data migration.
                 postgresDatabaseTenantMode:
                     type: boolean
                     description: |-
-                        Whether to enable the database tenant mode for PostgreSQL.
-                         If enabled, the issue will be created with the prepend "set role <db_owner>" statement.
+                        Whether to enable database tenant mode for PostgreSQL.
+                         If enabled, issues will include "set role <db_owner>" statement.
                 allowSelfApproval:
                     type: boolean
-                    description: Whether to allow the issue creator to self-approve the issue.
+                    description: Whether to allow issue creators to self-approve their own issues.
                 executionRetryPolicy:
                     allOf:
                         - $ref: '#/components/schemas/Project_ExecutionRetryPolicy'
-                    description: Configuration for automatic retry on task execution failures.
+                    description: Execution retry policy for task runs.
                 ciSamplingSize:
                     type: integer
                     description: |-
-                        The maximum number of databases to sample during CI data validation.
-                         If not specified, sampling is disabled, resulting in a full validation.
+                        The maximum number of database rows to sample during CI data validation.
+                         Without specification, sampling is disabled, resulting in full validation.
                     format: int32
                 parallelTasksPerRollout:
                     type: integer
-                    description: The maximum number of parallel tasks to run during the rollout.
+                    description: The maximum number of parallel tasks allowed during rollout execution.
                     format: int32
                 labels:
                     type: object
@@ -11718,7 +12574,6 @@ components:
                     description: |-
                         Whether to enforce SQL review checks to pass before issue creation.
                          If enabled, issues cannot be created when SQL review finds errors.
-            description: Project contains settings and configuration for a Bytebase project.
         Project_ExecutionRetryPolicy:
             type: object
             properties:
@@ -11727,6 +12582,31 @@ components:
                     description: The maximum number of retries for lock timeout errors.
                     format: int32
             description: Execution retry policy configuration.
+        QueryDataPolicy:
+            type: object
+            properties:
+                timeout:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                    description: The query timeout duration.
+                disableExport:
+                    type: boolean
+                    description: Disable data export in the SQL editor.
+                maximumResultSize:
+                    type: string
+                    description: |-
+                        The maximum result size limit in bytes.
+                         The default value is 100MB, we will use the default value if the setting not exists, or the limit <= 0.
+                maximumResultRows:
+                    type: integer
+                    description: |-
+                        The maximum number of rows to return.
+                         The default value is -1, means no limit.
+                    format: int32
+                disableCopyData:
+                    type: boolean
+                    description: Disable copying query results.
+            description: QueryDataPolicy is the policy configuration for querying data.
         QueryHistory:
             type: object
             properties:
@@ -12007,7 +12887,7 @@ components:
                     format: int32
                 substitution:
                     type: string
-                    description: OriginalValue[start:end) would be replaced with replace_with.
+                    description: substitution is the string used to replace the OriginalValue[start:end).
         RejectIssueRequest:
             required:
                 - name
@@ -12200,7 +13080,7 @@ components:
                     type: array
                     items:
                         type: string
-                    description: statement_types are the types of statements found in the SQL.
+                    description: statement_types are the types of statements that are found in the sql.
                 affectedRows:
                     type: string
                 changedResources:
@@ -12374,6 +13254,34 @@ components:
                     description: |-
                         The issue associated with the rollout. Could be empty.
                          Format: projects/{project}/issues/{issue}
+        RolloutPolicy:
+            type: object
+            properties:
+                automatic:
+                    type: boolean
+                    description: Whether rollout is automatic without manual approval.
+                roles:
+                    type: array
+                    items:
+                        type: string
+                    description: The roles that can approve rollout execution.
+                checkers:
+                    allOf:
+                        - $ref: '#/components/schemas/RolloutPolicy_Checkers'
+                    description: |-
+                        Checkers that must pass before rollout execution.
+                         These checks are performed in UI workflows only.
+            description: Rollout policy configuration.
+        RolloutPolicy_Checkers:
+            type: object
+            properties:
+                requiredIssueApproval:
+                    type: boolean
+                    description: Whether issue approval is required before proceeding with rollout.
+                requiredStatusChecks:
+                    allOf:
+                        - $ref: '#/components/schemas/Checkers_RequiredStatusChecks'
+                    description: Status checks that must pass before rollout can be executed.
         RowValue:
             type: object
             properties:
@@ -12478,21 +13386,26 @@ components:
             type: object
             properties:
                 krbConfig:
-                    $ref: '#/components/schemas/KerberosConfig'
+                    allOf:
+                        - $ref: '#/components/schemas/KerberosConfig'
+                    description: Kerberos authentication configuration.
         SQLReviewRule:
             type: object
             properties:
                 type:
                     type: string
+                    description: The type of SQL review rule.
                 level:
                     enum:
                         - LEVEL_UNSPECIFIED
                         - ERROR
                         - WARNING
                     type: string
+                    description: The severity level of the rule.
                     format: enum
                 payload:
                     type: string
+                    description: The payload is a JSON string that varies by rule type.
                 engine:
                     enum:
                         - ENGINE_UNSPECIFIED
@@ -12522,9 +13435,26 @@ components:
                         - TRINO
                         - CASSANDRA
                     type: string
+                    description: The database engine this rule applies to.
                     format: enum
                 comment:
                     type: string
+                    description: Additional comment for the rule.
+            description: SQL review rule configuration. Check the SQL_REVIEW_RULES_DOCUMENTATION.md for details.
+        SchedulerInfo_WaitingCause:
+            type: object
+            properties:
+                connectionLimit:
+                    type: boolean
+                    description: Waiting due to connection limit reached.
+                task:
+                    allOf:
+                        - $ref: '#/components/schemas/WaitingCause_Task'
+                    description: Waiting for another task to complete.
+                parallelTasksLimit:
+                    type: boolean
+                    description: Waiting due to parallel tasks limit.
+            description: Information about why a task run is waiting.
         SchemaCatalog:
             type: object
             properties:
@@ -12537,6 +13467,90 @@ components:
                         $ref: '#/components/schemas/TableCatalog'
                     description: The tables in the schema.
             description: Schema metadata within a database.
+        SchemaMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The name is the schema name.
+                         It is an empty string for databases without such concept such as MySQL.
+                tables:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TableMetadata'
+                    description: The tables is the list of tables in a schema.
+                externalTables:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExternalTableMetadata'
+                    description: The external_tables is the list of external tables in a schema.
+                views:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ViewMetadata'
+                    description: The views is the list of views in a schema.
+                functions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/FunctionMetadata'
+                    description: The functions is the list of functions in a schema.
+                procedures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ProcedureMetadata'
+                    description: The procedures is the list of procedures in a schema.
+                streams:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/StreamMetadata'
+                    description: |-
+                        The streams is the list of streams in a schema, currently, only used for
+                         Snowflake.
+                tasks:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaskMetadata'
+                    description: |-
+                        The routines is the list of routines in a schema, currently, only used for
+                         Snowflake.
+                materializedViews:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/MaterializedViewMetadata'
+                    description: The materialized_views is the list of materialized views in a schema.
+                packages:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/PackageMetadata'
+                    description: The packages is the list of packages in a schema.
+                owner:
+                    type: string
+                    description: The owner of the schema.
+                sequences:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SequenceMetadata'
+                    description: The sequences is the list of sequences in a schema, sorted by name.
+                events:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EventMetadata'
+                    description: The events is the list of scheduled events in a schema.
+                enumTypes:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EnumTypeMetadata'
+                    description: The enum_types is the list of user-defined enum types in a schema.
+                skipDump:
+                    type: boolean
+                    description: Whether to skip this schema during schema dump operations.
+                comment:
+                    type: string
+                    description: The comment is the comment of a schema.
+            description: |-
+                SchemaMetadata is the metadata for schemas.
+                 This is the concept of schema in Postgres, but it's a no-op for MySQL.
         SearchAuditLogsRequest:
             required:
                 - parent
@@ -12889,6 +13903,48 @@ components:
                 icon:
                     type: string
                     description: icon is the icon for semantic type, it can be emoji or base64 encoded image.
+        SequenceMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name of a sequence.
+                dataType:
+                    type: string
+                    description: The data type of a sequence.
+                start:
+                    type: string
+                    description: The start value of a sequence.
+                minValue:
+                    type: string
+                    description: The minimum value of a sequence.
+                maxValue:
+                    type: string
+                    description: The maximum value of a sequence.
+                increment:
+                    type: string
+                    description: Increment value of a sequence.
+                cycle:
+                    type: boolean
+                    description: Cycle is whether the sequence cycles.
+                cacheSize:
+                    type: string
+                    description: Cache size of a sequence.
+                lastValue:
+                    type: string
+                    description: Last value of a sequence.
+                ownerTable:
+                    type: string
+                    description: The owner table of the sequence.
+                ownerColumn:
+                    type: string
+                    description: The owner column of the sequence.
+                comment:
+                    type: string
+                    description: The comment describing the sequence.
+                skipDump:
+                    type: boolean
+                    description: Whether to skip this sequence during schema dump operations.
         SetIamPolicyRequest:
             required:
                 - resource
@@ -13040,6 +14096,25 @@ components:
                     items:
                         $ref: '#/components/schemas/SheetCommand'
                     description: The start and end position of each command in the sheet statement.
+        SpatialIndexConfig:
+            type: object
+            properties:
+                method:
+                    type: string
+                    description: Spatial indexing method (e.g., "SPATIAL", "R-TREE", "GIST")
+                tessellation:
+                    allOf:
+                        - $ref: '#/components/schemas/TessellationConfig'
+                    description: Tessellation configuration for grid-based spatial indexes
+                storage:
+                    allOf:
+                        - $ref: '#/components/schemas/StorageConfig'
+                    description: Storage and performance configuration
+                dimensional:
+                    allOf:
+                        - $ref: '#/components/schemas/DimensionalConfig'
+                    description: Dimensional configuration
+            description: SpatialIndexConfig defines the spatial index configuration for spatial databases.
         Stage:
             type: object
             properties:
@@ -13081,6 +14156,83 @@ components:
                         $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        StorageConfig:
+            type: object
+            properties:
+                fillfactor:
+                    type: integer
+                    description: Fill factor percentage (1-100)
+                    format: int32
+                buffering:
+                    type: string
+                    description: Buffering mode for PostgreSQL (auto, on, off)
+                tablespace:
+                    type: string
+                    description: Tablespace configuration for Oracle
+                workTablespace:
+                    type: string
+                sdoLevel:
+                    type: integer
+                    format: int32
+                commitInterval:
+                    type: integer
+                    format: int32
+                padIndex:
+                    type: boolean
+                    description: SQL Server specific parameters
+                sortInTempdb:
+                    type: string
+                dropExisting:
+                    type: boolean
+                online:
+                    type: boolean
+                allowRowLocks:
+                    type: boolean
+                allowPageLocks:
+                    type: boolean
+                maxdop:
+                    type: integer
+                    format: int32
+                dataCompression:
+                    type: string
+            description: StorageConfig defines storage and performance parameters for spatial indexes.
+        StreamMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a stream.
+                tableName:
+                    type: string
+                    description: The table_name is the name of the table/view that the stream is created on.
+                owner:
+                    type: string
+                    description: The owner of the stream.
+                comment:
+                    type: string
+                    description: The comment of the stream.
+                type:
+                    enum:
+                        - TYPE_UNSPECIFIED
+                        - DELTA
+                    type: string
+                    description: The type of the stream.
+                    format: enum
+                stale:
+                    type: boolean
+                    description: Indicates whether the stream was last read before the `stale_after` time.
+                mode:
+                    enum:
+                        - MODE_UNSPECIFIED
+                        - DEFAULT
+                        - APPEND_ONLY
+                        - INSERT_ONLY
+                    type: string
+                    description: The mode of the stream.
+                    format: enum
+                definition:
+                    type: string
+                    description: The definition of the stream.
         Subscription:
             type: object
             properties:
@@ -13178,6 +14330,167 @@ components:
                         $ref: '#/components/schemas/ColumnCatalog'
                     description: The columns in the table.
             description: Column list for regular tables.
+        TableMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a table.
+                columns:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ColumnMetadata'
+                    description: The columns is the ordered list of columns in a table.
+                indexes:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/IndexMetadata'
+                    description: The indexes is the list of indexes in a table.
+                engine:
+                    type: string
+                    description: The engine is the engine of a table.
+                collation:
+                    type: string
+                    description: The collation is the collation of a table.
+                charset:
+                    type: string
+                    description: The character set of table.
+                rowCount:
+                    type: string
+                    description: The row_count is the estimated number of rows of a table.
+                dataSize:
+                    type: string
+                    description: The data_size is the estimated data size of a table.
+                indexSize:
+                    type: string
+                    description: The index_size is the estimated index size of a table.
+                dataFree:
+                    type: string
+                    description: The data_free is the estimated free data size of a table.
+                createOptions:
+                    type: string
+                    description: The create_options is the create option of a table.
+                comment:
+                    type: string
+                    description: The comment is the comment of a table.
+                foreignKeys:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ForeignKeyMetadata'
+                    description: The foreign_keys is the list of foreign keys in a table.
+                partitions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TablePartitionMetadata'
+                    description: The partitions is the list of partitions in a table.
+                checkConstraints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CheckConstraintMetadata'
+                    description: The check_constraints is the list of check constraints in a table.
+                owner:
+                    type: string
+                    description: The owner of the table.
+                sortingKeys:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The sorting_keys is a tuple of column names or arbitrary expressions. ClickHouse specific field.
+                         Reference: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#order_by
+                triggers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TriggerMetadata'
+                    description: The triggers is the list of triggers associated with the table.
+                skipDump:
+                    type: boolean
+                    description: Whether to skip this table during schema dump operations.
+                shardingInfo:
+                    type: string
+                    description: https://docs.pingcap.com/tidb/stable/information-schema-tables/
+                primaryKeyType:
+                    type: string
+                    description: |-
+                        https://docs.pingcap.com/tidb/stable/clustered-indexes/#clustered-indexes
+                         CLUSTERED or NONCLUSTERED.
+            description: TableMetadata is the metadata for tables.
+        TablePartitionMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a table partition.
+                type:
+                    enum:
+                        - TYPE_UNSPECIFIED
+                        - RANGE
+                        - RANGE_COLUMNS
+                        - LIST
+                        - LIST_COLUMNS
+                        - HASH
+                        - LINEAR_HASH
+                        - KEY
+                        - LINEAR_KEY
+                    type: string
+                    description: The type of a table partition.
+                    format: enum
+                expression:
+                    type: string
+                    description: |-
+                        The expression is the expression of a table partition.
+                         For PostgreSQL, the expression is the text of {FOR VALUES
+                         partition_bound_spec}, see
+                         https://www.postgresql.org/docs/current/sql-createtable.html. For MySQL,
+                         the expression is the `expr` or `column_list` of the following syntax.
+                         PARTITION BY
+                            { [LINEAR] HASH(expr)
+                            | [LINEAR] KEY [ALGORITHM={1 | 2}] (column_list)
+                            | RANGE{(expr) | COLUMNS(column_list)}
+                            | LIST{(expr) | COLUMNS(column_list)} }.
+                value:
+                    type: string
+                    description: |-
+                        The value is the value of a table partition.
+                         For MySQL, the value is for RANGE and LIST partition types,
+                         - For a RANGE partition, it contains the value set in the partition's
+                         VALUES LESS THAN clause, which can be either an integer or MAXVALUE.
+                         - For a LIST partition, this column contains the values defined in the
+                         partition's VALUES IN clause, which is a list of comma-separated integer
+                         values.
+                         - For others, it's an empty string.
+                useDefault:
+                    type: string
+                    description: |-
+                        The use_default is whether the users use the default partition, it stores
+                         the different value for different database engines. For MySQL, it's [INT]
+                         type, 0 means not use default partition, otherwise, it's equals to number
+                         in syntax [SUB]PARTITION {number}.
+                subpartitions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TablePartitionMetadata'
+                    description: The subpartitions is the list of subpartitions in a table partition.
+                indexes:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/IndexMetadata'
+                checkConstraints:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CheckConstraintMetadata'
+            description: TablePartitionMetadata is the metadata for table partitions.
+        TagPolicy:
+            type: object
+            properties:
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: |-
+                        tags is the key - value map for resources.
+                         for example, the environment resource can have the sql review config tag, like "bb.tag.review_config": "reviewConfigs/{review config resource id}"
+            description: Policy for tagging resources with metadata.
         Task:
             type: object
             properties:
@@ -13240,69 +14553,207 @@ components:
                         The run_time is the scheduled run time of latest task run.
                          If there are no task runs or the task run is not scheduled, it will be empty.
                     format: date-time
+        TaskMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a task.
+                id:
+                    type: string
+                    description: |-
+                        The id is the snowflake-generated id of a task.
+                         Example: 01ad32a0-1bb6-5e93-0000-000000000001
+                owner:
+                    type: string
+                    description: The owner of the task.
+                comment:
+                    type: string
+                    description: The comment of the task.
+                warehouse:
+                    type: string
+                    description: The warehouse of the task.
+                schedule:
+                    type: string
+                    description: The schedule interval of the task.
+                predecessors:
+                    type: array
+                    items:
+                        type: string
+                    description: The predecessor tasks of the task.
+                state:
+                    enum:
+                        - STATE_UNSPECIFIED
+                        - STARTED
+                        - SUSPENDED
+                    type: string
+                    description: The state of the task.
+                    format: enum
+                condition:
+                    type: string
+                    description: The condition of the task.
+                definition:
+                    type: string
+                    description: The definition of the task.
         TaskPriorBackup_Table:
             type: object
             properties:
                 schema:
                     type: string
+                    description: The schema name.
                 table:
                     type: string
+                    description: The table name.
+            description: Table identification.
         TaskRun:
             type: object
-            properties: {}
-            description: TaskRun represents an execution attempt of a task.
+            properties:
+                name:
+                    type: string
+                    description: 'Format: projects/{project}/rollouts/{rollout}/stages/{stage}/tasks/{task}/taskRuns/{taskRun}'
+                creator:
+                    type: string
+                    description: 'Format: users/hello@world.com'
+                createTime:
+                    readOnly: true
+                    type: string
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    format: date-time
+                status:
+                    enum:
+                        - STATUS_UNSPECIFIED
+                        - PENDING
+                        - RUNNING
+                        - DONE
+                        - FAILED
+                        - CANCELED
+                    type: string
+                    description: The current execution status of the task run.
+                    format: enum
+                detail:
+                    type: string
+                    description: |-
+                        Below are the results of a task run.
+                         Detailed information about the task run result.
+                changelog:
+                    readOnly: true
+                    type: string
+                    description: |-
+                        The resource name of the changelog.
+                         Format: instances/{instance}/databases/{database}/changelogs/{changelog}
+                schemaVersion:
+                    type: string
+                    description: The schema version after this task run completes.
+                startTime:
+                    readOnly: true
+                    type: string
+                    description: The time when the task run started execution.
+                    format: date-time
+                exportArchiveStatus:
+                    enum:
+                        - EXPORT_ARCHIVE_STATUS_UNSPECIFIED
+                        - READY
+                        - EXPORTED
+                    type: string
+                    description: The export archive status for data export tasks.
+                    format: enum
+                priorBackupDetail:
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRun_PriorBackupDetail'
+                    description: The prior backup detail that will be used to rollback the task run.
+                schedulerInfo:
+                    readOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRun_SchedulerInfo'
+                    description: Scheduling information about the task run.
+                sheet:
+                    readOnly: true
+                    type: string
+                    description: 'Format: projects/{project}/sheets/{sheet}'
+                runTime:
+                    readOnly: true
+                    type: string
+                    description: |-
+                        The task run should run after run_time.
+                         This can only be set when creating the task run calling BatchRunTasks.
+                    format: date-time
         TaskRunLog:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: 'Format: projects/{project}/rollouts/{rollout}/stages/{stage}/tasks/{task}/taskRuns/{taskRun}/log'
+                entries:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaskRunLogEntry'
+                    description: The log entries for this task run.
+        TaskRunLogEntry:
             type: object
             properties:
                 type:
                     enum:
                         - TYPE_UNSPECIFIED
-                        - SCHEMA_DUMP_START
-                        - SCHEMA_DUMP_END
+                        - SCHEMA_DUMP
                         - COMMAND_EXECUTE
-                        - COMMAND_RESPONSE
-                        - DATABASE_SYNC_START
-                        - DATABASE_SYNC_END
+                        - DATABASE_SYNC
                         - TASK_RUN_STATUS_UPDATE
                         - TRANSACTION_CONTROL
-                        - PRIOR_BACKUP_START
-                        - PRIOR_BACKUP_END
+                        - PRIOR_BACKUP
                         - RETRY_INFO
-                        - COMPUTE_DIFF_START
-                        - COMPUTE_DIFF_END
+                        - COMPUTE_DIFF
                     type: string
+                    description: The type of this log entry.
                     format: enum
+                logTime:
+                    type: string
+                    description: The time when the log was recorded.
+                    format: date-time
                 deployId:
                     type: string
-                schemaDumpStart:
-                    $ref: '#/components/schemas/TaskRunLog_SchemaDumpStart'
-                schemaDumpEnd:
-                    $ref: '#/components/schemas/TaskRunLog_SchemaDumpEnd'
+                    description: The deployment ID for this log entry.
+                schemaDump:
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_SchemaDump'
+                    description: Schema dump details (if type is SCHEMA_DUMP).
                 commandExecute:
-                    $ref: '#/components/schemas/TaskRunLog_CommandExecute'
-                commandResponse:
-                    $ref: '#/components/schemas/TaskRunLog_CommandResponse'
-                databaseSyncStart:
-                    $ref: '#/components/schemas/TaskRunLog_DatabaseSyncStart'
-                databaseSyncEnd:
-                    $ref: '#/components/schemas/TaskRunLog_DatabaseSyncEnd'
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_CommandExecute'
+                    description: Command execution details (if type is COMMAND_EXECUTE).
+                databaseSync:
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_DatabaseSync'
+                    description: Database sync details (if type is DATABASE_SYNC).
                 taskRunStatusUpdate:
-                    $ref: '#/components/schemas/TaskRunLog_TaskRunStatusUpdate'
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_TaskRunStatusUpdate'
+                    description: Task run status update details (if type is TASK_RUN_STATUS_UPDATE).
                 transactionControl:
-                    $ref: '#/components/schemas/TaskRunLog_TransactionControl'
-                priorBackupStart:
-                    $ref: '#/components/schemas/TaskRunLog_PriorBackupStart'
-                priorBackupEnd:
-                    $ref: '#/components/schemas/TaskRunLog_PriorBackupEnd'
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_TransactionControl'
+                    description: Transaction control details (if type is TRANSACTION_CONTROL).
+                priorBackup:
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_PriorBackup'
+                    description: Prior backup details (if type is PRIOR_BACKUP).
                 retryInfo:
-                    $ref: '#/components/schemas/TaskRunLog_RetryInfo'
-                computeDiffStart:
-                    $ref: '#/components/schemas/TaskRunLog_ComputeDiffStart'
-                computeDiffEnd:
-                    $ref: '#/components/schemas/TaskRunLog_ComputeDiffEnd'
-        TaskRunLog_CommandExecute:
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_RetryInfo'
+                    description: Retry information details (if type is RETRY_INFO).
+                computeDiff:
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRunLogEntry_ComputeDiff'
+                    description: Compute diff details (if type is COMPUTE_DIFF).
+        TaskRunLogEntry_CommandExecute:
             type: object
             properties:
+                logTime:
+                    type: string
+                    description: When the command was logged.
+                    format: date-time
                 commandIndexes:
                     type: array
                     items:
@@ -13313,67 +14764,92 @@ components:
                          The indexes of the executed commands.
                 statement:
                     type: string
-                    description: The statement to be executed.
-        TaskRunLog_CommandResponse:
+                    description: The executed statement.
+                response:
+                    allOf:
+                        - $ref: '#/components/schemas/CommandExecute_CommandResponse'
+                    description: The response from executing the command.
+            description: Command execution details.
+        TaskRunLogEntry_ComputeDiff:
             type: object
             properties:
+                startTime:
+                    type: string
+                    description: When diff computation started.
+                    format: date-time
+                endTime:
+                    type: string
+                    description: When diff computation ended.
+                    format: date-time
                 error:
                     type: string
-                affectedRows:
-                    type: string
-                allAffectedRows:
-                    type: array
-                    items:
-                        type: string
-                    description: |-
-                        `all_affected_rows` is the affected rows of each command.
-                         `all_affected_rows` may be unavailable if the database driver doesn't support it. Caller should fallback to `affected_rows` in that case.
-        TaskRunLog_ComputeDiffEnd:
+                    description: Error message if computation failed.
+            description: Schema diff computation details.
+        TaskRunLogEntry_DatabaseSync:
             type: object
             properties:
+                startTime:
+                    type: string
+                    description: When the database sync started.
+                    format: date-time
+                endTime:
+                    type: string
+                    description: When the database sync ended.
+                    format: date-time
                 error:
                     type: string
-        TaskRunLog_ComputeDiffStart:
-            type: object
-            properties: {}
-        TaskRunLog_DatabaseSyncEnd:
+                    description: Error message if sync failed.
+            description: Database synchronization details.
+        TaskRunLogEntry_PriorBackup:
             type: object
             properties:
-                error:
+                startTime:
                     type: string
-        TaskRunLog_DatabaseSyncStart:
-            type: object
-            properties: {}
-        TaskRunLog_PriorBackupEnd:
-            type: object
-            properties:
+                    description: When the backup started.
+                    format: date-time
+                endTime:
+                    type: string
+                    description: When the backup ended.
+                    format: date-time
                 priorBackupDetail:
-                    $ref: '#/components/schemas/PriorBackupDetail'
+                    allOf:
+                        - $ref: '#/components/schemas/TaskRun_PriorBackupDetail'
+                    description: The backup details.
                 error:
                     type: string
-        TaskRunLog_PriorBackupStart:
-            type: object
-            properties: {}
-        TaskRunLog_RetryInfo:
+                    description: Error message if the backup failed.
+            description: Prior backup operation details.
+        TaskRunLogEntry_RetryInfo:
             type: object
             properties:
                 error:
                     type: string
+                    description: The error that triggered the retry.
                 retryCount:
                     type: integer
+                    description: Current retry attempt number.
                     format: int32
                 maximumRetries:
                     type: integer
+                    description: Maximum number of retries allowed.
                     format: int32
-        TaskRunLog_SchemaDumpEnd:
+            description: Retry information for failed operations.
+        TaskRunLogEntry_SchemaDump:
             type: object
             properties:
+                startTime:
+                    type: string
+                    description: When the schema dump started.
+                    format: date-time
+                endTime:
+                    type: string
+                    description: When the schema dump ended.
+                    format: date-time
                 error:
                     type: string
-        TaskRunLog_SchemaDumpStart:
-            type: object
-            properties: {}
-        TaskRunLog_TaskRunStatusUpdate:
+                    description: Error message if the schema dump failed.
+            description: Schema dump operation details.
+        TaskRunLogEntry_TaskRunStatusUpdate:
             type: object
             properties:
                 status:
@@ -13382,8 +14858,10 @@ components:
                         - RUNNING_WAITING
                         - RUNNING_RUNNING
                     type: string
+                    description: The new status.
                     format: enum
-        TaskRunLog_TransactionControl:
+            description: Task run status update details.
+        TaskRunLogEntry_TransactionControl:
             type: object
             properties:
                 type:
@@ -13393,9 +14871,12 @@ components:
                         - COMMIT
                         - ROLLBACK
                     type: string
+                    description: The type of transaction control.
                     format: enum
                 error:
                     type: string
+                    description: Error message if the operation failed.
+            description: Transaction control operation details.
         TaskRunSession:
             type: object
             properties:
@@ -13424,6 +14905,27 @@ components:
                         $ref: '#/components/schemas/Postgres_Session'
                     description: '`blocked_sessions` are blocked by `session`.'
             description: PostgreSQL session information.
+        TaskRun_PriorBackupDetail:
+            type: object
+            properties:
+                items:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/PriorBackupDetail_Item'
+                    description: The list of backed up tables.
+            description: Prior backup detail for rollback purposes.
+        TaskRun_SchedulerInfo:
+            type: object
+            properties:
+                reportTime:
+                    type: string
+                    description: The time when the scheduling info was reported.
+                    format: date-time
+                waitingCause:
+                    allOf:
+                        - $ref: '#/components/schemas/SchedulerInfo_WaitingCause'
+                    description: The cause for the task run waiting.
+            description: Information about task run scheduling.
         Task_DatabaseCreate:
             type: object
             properties:
@@ -13498,6 +15000,26 @@ components:
                     description: The type of database change (MIGRATE or SDL).
                     format: enum
             description: Payload for updating a database schema.
+        TessellationConfig:
+            type: object
+            properties:
+                scheme:
+                    type: string
+                    description: Tessellation scheme (e.g., "GEOMETRY_GRID", "GEOGRAPHY_GRID", "GEOMETRY_AUTO_GRID")
+                gridLevels:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GridLevel'
+                    description: Grid levels and densities for multi-level tessellation
+                cellsPerObject:
+                    type: integer
+                    description: Number of cells per object (1-8192 for SQL Server)
+                    format: int32
+                boundingBox:
+                    allOf:
+                        - $ref: '#/components/schemas/BoundingBox'
+                    description: Bounding box for GEOMETRY tessellation (not used for GEOGRAPHY)
+            description: TessellationConfig defines tessellation parameters for spatial indexes.
         TestIdentityProviderRequest:
             type: object
             properties:
@@ -13545,6 +15067,38 @@ components:
                 error:
                     type: string
                     description: The result of the test, empty if the test is successful.
+        TriggerMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of the trigger.
+                event:
+                    type: string
+                    description: |-
+                        The event is the event of the trigger, such as INSERT, UPDATE, DELETE,
+                         TRUNCATE.
+                timing:
+                    type: string
+                    description: The timing is the timing of the trigger, such as BEFORE, AFTER.
+                body:
+                    type: string
+                    description: The body is the body of the trigger.
+                sqlMode:
+                    type: string
+                    description: The SQL mode setting for the trigger.
+                characterSetClient:
+                    type: string
+                    description: The character set used by the client creating the trigger.
+                collationConnection:
+                    type: string
+                    description: The collation used for the connection when creating the trigger.
+                comment:
+                    type: string
+                    description: The comment describing the trigger.
+                skipDump:
+                    type: boolean
+                    description: Whether to skip this trigger during schema dump operations.
         UndeleteInstanceRequest:
             required:
                 - name
@@ -13731,6 +15285,46 @@ components:
                 source:
                     type: string
                     description: source means where the user comes from. For now we support Entra ID SCIM sync, so the source could be Entra ID.
+        ViewMetadata:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name is the name of a view.
+                definition:
+                    type: string
+                    description: The definition is the definition of a view.
+                comment:
+                    type: string
+                    description: The comment is the comment of a view.
+                dependencyColumns:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DependencyColumn'
+                    description: The dependency_columns is the list of dependency columns of a view.
+                columns:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ColumnMetadata'
+                    description: The columns is the ordered list of columns in a table.
+                triggers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TriggerMetadata'
+                    description: The triggers is the list of triggers in a view.
+                skipDump:
+                    type: boolean
+            description: ViewMetadata is the metadata for views.
+        WaitingCause_Task:
+            type: object
+            properties:
+                task:
+                    type: string
+                    description: 'Format: projects/{project}/rollouts/{rollout}/stages/{stage}/tasks/{task}'
+                issue:
+                    type: string
+                    description: 'Format: projects/{project}/issues/{issue}'
+            description: Information about a blocking task.
         Webhook:
             required:
                 - type
@@ -13900,7 +15494,36 @@ components:
                 template:
                     $ref: '#/components/schemas/ApprovalTemplate'
                 condition:
-                    $ref: '#/components/schemas/Expr'
+                    allOf:
+                        - $ref: '#/components/schemas/Expr'
+                    description: |-
+                        The condition that is associated with the rule.
+                         The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
+
+                         The `source` field filters which rules apply. The `condition` field then evaluates with full context.
+
+                         All supported variables:
+                         statement.affected_rows: affected row count in the DDL/DML, support "==", "!=", "<", "<=", ">", ">=" operations.
+                         statement.table_rows: table row count number, support "==", "!=", "<", "<=", ">", ">=" operations.
+                         resource.environment_id: the environment resource id, support "==", "!=", "in [xx]", "!(in [xx])" operations.
+                         resource.project_id: the project resource id, support "==", "!=", "in [xx]", "!(in [xx])", "contains()", "matches()", "startsWith()", "endsWith()" operations.
+                         resource.db_engine: the database engine type, support "==", "!=", "in [xx]", "!(in [xx])" operations. Check the Engine enum for values.
+                         statement.sql_type: the SQL type, support "==", "!=", "in [xx]", "!(in [xx])" operations.
+                         resource.database_name: the database name, support "==", "!=", "in [xx]", "!(in [xx])", "contains()", "matches()", "startsWith()", "endsWith()" operations.
+                         resource.schema_name: the schema name, support "==", "!=", "in [xx]", "!(in [xx])", "contains()", "matches()", "startsWith()", "endsWith()" operations.
+                         resource.table_name: the table name, support "==", "!=", "in [xx]", "!(in [xx])", "contains()", "matches()", "startsWith()", "endsWith()" operations.
+                         statement.text: the SQL statement, support "contains()", "matches()", "startsWith()", "endsWith()" operations.
+                         request.expiration_days: the role expiration days for the request, support "==", "!=", "<", "<=", ">", ">=" operations.
+                         request.role: the request role full name, support "==", "!=", "in [xx]", "!(in [xx])", "contains()", "matches()", "startsWith()", "endsWith()" operations.
+
+                         When source is CHANGE_DATABASE, support: statement.*, resource.* (excluding request.*)
+                         When source is CREATE_DATABASE, support: resource.environment_id, resource.project_id, resource.db_engine, resource.database_name
+                         When source is EXPORT_DATA, support: resource.environment_id, resource.project_id, resource.db_engine, resource.database_name, resource.schema_name, resource.table_name
+                         When source is REQUEST_ROLE, support: resource.project_id, request.expiration_days, request.role
+
+                         For examples:
+                         resource.environment_id == "prod" && statement.affected_rows >= 100
+                         resource.table_name.matches("sensitive_.*") && resource.db_engine == "MYSQL"
                 source:
                     enum:
                         - SOURCE_UNSPECIFIED


### PR DESCRIPTION
## Summary
- Fixed incomplete Issue schema in generated `openapi.yaml` by adding `types: [bytebase.v1]` filter to the OpenAPI generator plugin
- The issue was caused by a name collision between `bytebase.v1.Issue` (API message with all fields) and `bytebase.store.Issue` (internal store message with only 4 fields)
- The OpenAPI generator was using the store version, resulting in missing fields like `name`, `title`, `description`, `status`, `creator`, `createTime`, etc.

## Test plan
- [x] Run `buf generate` and verify `openapi.yaml` contains complete Issue schema with all v1 fields
- [x] Verify no `bytebase.store` types appear in the generated OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)