### PR TITLE
refactor: remove unused setting utils and use proto getters

### DIFF
--- a/backend/api/auth/header.go
+++ b/backend/api/auth/header.go
@@ -78,21 +78,18 @@ func GetTokenDuration(ctx context.Context, store *store.Store, licenseService *e
 	if err != nil {
 		return tokenDuration
 	}
-	passwordRestriction, err := store.GetPasswordRestriction(ctx)
-	if err != nil {
-		return tokenDuration
-	}
 
-	if workspaceProfile.TokenDuration != nil && workspaceProfile.TokenDuration.GetSeconds() > 0 {
-		tokenDuration = workspaceProfile.TokenDuration.AsDuration()
+	if workspaceProfile.GetTokenDuration().GetSeconds() > 0 {
+		tokenDuration = workspaceProfile.GetTokenDuration().AsDuration()
 	}
 	// Currently we implement the password rotation restriction in a simple way:
 	// 1. Only check if users need to reset their password during login.
 	// 2. For the 1st time login, if `RequireResetPasswordForFirstLogin` is true, `require_reset_password` in the response will be true
 	// 3. Otherwise if the `PasswordRotation` exists, check the password last updated time to decide if the `require_reset_password` is true.
 	// So we will use the minimum value between (`workspaceProfile.TokenDuration`, `passwordRestriction.PasswordRotation`) to force to expire the token.
-	if passwordRestriction.PasswordRotation != nil && passwordRestriction.PasswordRotation.GetSeconds() > 0 {
-		passwordRotation := passwordRestriction.PasswordRotation.AsDuration()
+	passwordRestriction := workspaceProfile.GetPasswordRestriction()
+	if passwordRestriction.GetPasswordRotation().GetSeconds() > 0 {
+		passwordRotation := passwordRestriction.GetPasswordRotation().AsDuration()
 		if passwordRotation.Seconds() < tokenDuration.Seconds() {
 			tokenDuration = passwordRotation
 		}

--- a/backend/api/directory-sync/webhook.go
+++ b/backend/api/directory-sync/webhook.go
@@ -617,10 +617,11 @@ func (s *Service) validRequestURL(ctx context.Context, c echo.Context) error {
 
 	workspaceID := c.Param("workspaceID")
 
-	myWorkspaceID, err := s.store.GetWorkspaceID(ctx)
+	systemSetting, err := s.store.GetSystemSetting(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get system setting")
 	}
+	myWorkspaceID := systemSetting.WorkspaceId
 	if myWorkspaceID != workspaceID {
 		return errors.Errorf("invalid workspace id %q, my ID %q", workspaceID, myWorkspaceID)
 	}

--- a/backend/api/v1/actuator_service.go
+++ b/backend/api/v1/actuator_service.go
@@ -143,16 +143,13 @@ func (s *ActuatorService) getServerInfo(ctx context.Context) (*v1pb.ActuatorInfo
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find workspace setting"))
 	}
 
-	passwordRestrictionSetting, err := s.store.GetPasswordRestriction(ctx)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find password restriction setting"))
-	}
-	passwordSetting := convertToPasswordRestrictionSetting(passwordRestrictionSetting)
+	passwordSetting := convertToPasswordRestrictionSetting(setting.GetPasswordRestriction())
 
-	workspaceID, err := s.store.GetWorkspaceID(ctx)
+	systemSetting, err := s.store.GetSystemSetting(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get system setting"))
 	}
+	workspaceID := systemSetting.WorkspaceId
 
 	usedFeatures, err := s.getUsedFeatures(ctx)
 	if err != nil {

--- a/backend/api/v1/audit.go
+++ b/backend/api/v1/audit.go
@@ -169,10 +169,11 @@ func createAuditLogConnect(ctx context.Context, request, response any, method st
 
 	var parents []string
 	if authContext.HasWorkspaceResource() {
-		workspaceID, err := storage.GetWorkspaceID(ctx)
+		systemSetting, err := storage.GetSystemSetting(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get workspace id")
+			return errors.Wrapf(err, "failed to get system setting")
 		}
+		workspaceID := systemSetting.WorkspaceId
 		parents = append(parents, common.FormatWorkspace(workspaceID))
 	} else {
 		for _, projectID := range authContext.GetProjectResources() {

--- a/backend/api/v1/user_service.go
+++ b/backend/api/v1/user_service.go
@@ -303,23 +303,25 @@ func (s *UserService) CreateUser(ctx context.Context, request *connect.Request[v
 }
 
 func (s *UserService) validatePassword(ctx context.Context, password string) error {
-	passwordRestriction, err := s.store.GetPasswordRestriction(ctx)
+	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, errors.Errorf("failed to get password restriction with error: %v", err))
 	}
-	if len(password) < int(passwordRestriction.MinLength) {
-		return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("password length should no less than %v characters", passwordRestriction.MinLength))
+	passwordRestriction := setting.GetPasswordRestriction()
+
+	if len(password) < int(passwordRestriction.GetMinLength()) {
+		return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("password length should no less than %v characters", passwordRestriction.GetMinLength()))
 	}
-	if passwordRestriction.RequireNumber && !regexp.MustCompile("[0-9]+").MatchString(password) {
+	if passwordRestriction.GetRequireNumber() && !regexp.MustCompile("[0-9]+").MatchString(password) {
 		return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("password must contains at least 1 number"))
 	}
-	if passwordRestriction.RequireLetter && !regexp.MustCompile("[a-zA-Z]+").MatchString(password) {
+	if passwordRestriction.GetRequireLetter() && !regexp.MustCompile("[a-zA-Z]+").MatchString(password) {
 		return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("password must contains at least 1 lower case letter"))
 	}
-	if passwordRestriction.RequireUppercaseLetter && !regexp.MustCompile("[A-Z]+").MatchString(password) {
+	if passwordRestriction.GetRequireUppercaseLetter() && !regexp.MustCompile("[A-Z]+").MatchString(password) {
 		return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("password must contains at least 1 upper case letter"))
 	}
-	if passwordRestriction.RequireSpecialCharacter && !regexp.MustCompile(`[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+`).MatchString(password) {
+	if passwordRestriction.GetRequireSpecialCharacter() && !regexp.MustCompile(`[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+`).MatchString(password) {
 		return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("password must contains at least 1 special character"))
 	}
 	return nil

--- a/backend/enterprise/plugin/hub/hub.go
+++ b/backend/enterprise/plugin/hub/hub.go
@@ -112,10 +112,11 @@ func (p *Provider) parseLicense(ctx context.Context, license string) (*v1pb.Subs
 
 func (p *Provider) findEnterpriseLicense(ctx context.Context) (*v1pb.Subscription, error) {
 	// Find enterprise license.
-	licenseStr, err := p.store.GetEnterpriseLicense(ctx)
+	systemSetting, err := p.store.GetSystemSetting(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load enterprise license from settings")
+		return nil, errors.Wrapf(err, "failed to get system setting")
 	}
+	licenseStr := systemSetting.License
 	if licenseStr != "" {
 		license, err := p.parseLicense(ctx, licenseStr)
 		if err != nil {
@@ -153,10 +154,11 @@ func (p *Provider) parseClaims(ctx context.Context, claim *claims) (*v1pb.Subscr
 	planType := v1pb.PlanType(v)
 
 	if claim.WorkspaceID != "" && planType == v1pb.PlanType_ENTERPRISE && !claim.Trialing {
-		workspaceID, err := p.store.GetWorkspaceID(ctx)
+		systemSetting, err := p.store.GetSystemSetting(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get workspace id from setting")
+			return nil, errors.Wrapf(err, "failed to get system setting")
 		}
+		workspaceID := systemSetting.WorkspaceId
 		if workspaceID != claim.WorkspaceID {
 			return nil, common.Errorf(common.Invalid, "the workspace id not match")
 		}

--- a/backend/plugin/schema/mssql/get_database_metadata.go
+++ b/backend/plugin/schema/mssql/get_database_metadata.go
@@ -715,11 +715,7 @@ func (e *metadataExtractor) extractColumn(ctx parser.IColumn_definitionContext, 
 
 				// Handle nullability
 				if nullNotNull := constraint.Null_notnull(); nullNotNull != nil {
-					if nullNotNull.NOT() != nil {
-						column.Nullable = false
-					} else {
-						column.Nullable = true
-					}
+					column.Nullable = nullNotNull.NOT() == nil
 				}
 
 				// Handle PRIMARY KEY

--- a/backend/plugin/schema/mysql/get_database_metadata.go
+++ b/backend/plugin/schema/mysql/get_database_metadata.go
@@ -374,11 +374,7 @@ func (e *metadataExtractor) extractFieldAttributes(ctx mysql.IFieldDefinitionCon
 
 		// Check for NULL/NOT NULL
 		if attr.NullLiteral() != nil {
-			if attr.NOT_SYMBOL() != nil {
-				column.Nullable = false
-			} else {
-				column.Nullable = true
-			}
+			column.Nullable = attr.NOT_SYMBOL() == nil
 		}
 
 		// Check for DEFAULT value


### PR DESCRIPTION
Removes GetPasswordRestriction, CreateSettingIfNotExistV2, GetWorkspaceID, GetEnterpriseLicense and updates callers to use GetWorkspaceGeneralSetting or GetSystemSetting with proto getters.

Also addressed some minor linter issues:
- Removed redundant flag.Parse() in ldap_test.go
- Simplified boolean expressions in database metadata fetching.