### PR TITLE
refactor: change SettingMessage.Value from string to proto.Message

### DIFF
--- a/backend/api/auth/header.go
+++ b/backend/api/auth/header.go
@@ -74,7 +74,7 @@ func GetTokenDuration(ctx context.Context, store *store.Store, licenseService *e
 		return tokenDuration
 	}
 
-	workspaceProfile, err := store.GetWorkspaceGeneralSetting(ctx)
+	workspaceProfile, err := store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return tokenDuration
 	}

--- a/backend/api/directory-sync/webhook.go
+++ b/backend/api/directory-sync/webhook.go
@@ -605,7 +605,7 @@ func (s *Service) validRequestURL(ctx context.Context, c echo.Context) error {
 		return errors.Errorf("missing authorization token")
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return err
 	}
@@ -626,7 +626,7 @@ func (s *Service) validRequestURL(ctx context.Context, c echo.Context) error {
 		return errors.Errorf("invalid workspace id %q, my ID %q", workspaceID, myWorkspaceID)
 	}
 
-	workspaceProfileSetting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	workspaceProfileSetting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get workspace profile setting")
 	}

--- a/backend/api/v1/actuator_service.go
+++ b/backend/api/v1/actuator_service.go
@@ -103,7 +103,7 @@ func (s *ActuatorService) GetResourcePackage(
 	ctx context.Context,
 	_ *connect.Request[v1pb.GetResourcePackageRequest],
 ) (*connect.Response[v1pb.ResourcePackage], error) {
-	workspaceProfileSetting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	workspaceProfileSetting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find workspace profile setting"))
 	}
@@ -138,7 +138,7 @@ func (s *ActuatorService) getServerInfo(ctx context.Context) (*v1pb.ActuatorInfo
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find workspace setting"))
 	}
@@ -230,7 +230,7 @@ func (s *ActuatorService) getUsedFeatures(ctx context.Context) ([]v1pb.PlanFeatu
 		features = append(features, v1pb.PlanFeature_FEATURE_ENTERPRISE_SSO)
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get workspace general setting")
 	}

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -149,7 +149,7 @@ func (s *AuthService) Login(ctx context.Context, req *connect.Request[v1pb.Login
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.Errorf("user has been deactivated by administrators"))
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find workspace setting, error"))
 	}
@@ -247,7 +247,7 @@ func (s *AuthService) needResetPassword(ctx context.Context, user *store.UserMes
 		return false
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		slog.Error("failed to get workspace setting", log.BBError(err))
 		return false
@@ -335,7 +335,7 @@ func (s *AuthService) getOrCreateUserWithIDP(ctx context.Context, request *v1pb.
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("identity provider not found"))
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get workspace setting"))
 	}

--- a/backend/api/v1/idp_service.go
+++ b/backend/api/v1/idp_service.go
@@ -70,7 +70,7 @@ func (s *IdentityProviderService) CreateIdentityProvider(ctx context.Context, re
 		return nil, err
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get workspace setting"))
 	}
@@ -229,7 +229,7 @@ func (s *IdentityProviderService) TestIdentityProvider(ctx context.Context, req 
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("identity provider not found"))
 	}
 
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get workspace setting"))
 	}

--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -959,7 +959,7 @@ func (s *ProjectService) RemoveWebhook(ctx context.Context, req *connect.Request
 
 // TestWebhook tests a webhook.
 func (s *ProjectService) TestWebhook(ctx context.Context, req *connect.Request[v1pb.TestWebhookRequest]) (*connect.Response[v1pb.TestWebhookResponse], error) {
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get workspace setting"))
 	}
@@ -1083,13 +1083,13 @@ func validateIAMPolicy(
 		return false, connect.NewError(connect.CodeInvalidArgument, errors.New("IAM Binding is empty"))
 	}
 
-	generalSetting, err := stores.GetWorkspaceGeneralSetting(ctx)
+	workspaceProfileSetting, err := stores.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
-		return false, connect.NewError(connect.CodeInternal, errors.New("failed to get workspace general setting"))
+		return false, connect.NewError(connect.CodeInternal, errors.New("failed to get workspace profile setting"))
 	}
 	var maximumRoleExpiration *durationpb.Duration
-	if generalSetting != nil {
-		maximumRoleExpiration = generalSetting.MaximumRoleExpiration
+	if workspaceProfileSetting != nil {
+		maximumRoleExpiration = workspaceProfileSetting.MaximumRoleExpiration
 	}
 
 	roleMessages, err := stores.ListRoles(ctx)

--- a/backend/api/v1/user_service.go
+++ b/backend/api/v1/user_service.go
@@ -169,7 +169,7 @@ func (s *UserService) ListUsers(ctx context.Context, request *connect.Request[v1
 // CreateUser creates a user.
 func (s *UserService) CreateUser(ctx context.Context, request *connect.Request[v1pb.CreateUserRequest]) (*connect.Response[v1pb.User], error) {
 	if err := s.licenseService.IsFeatureEnabled(v1pb.PlanFeature_FEATURE_DISALLOW_SELF_SERVICE_SIGNUP); err == nil {
-		setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+		setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to find workspace setting, error: %v", err))
 		}
@@ -303,7 +303,7 @@ func (s *UserService) CreateUser(ctx context.Context, request *connect.Request[v
 }
 
 func (s *UserService) validatePassword(ctx context.Context, password string) error {
-	setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, errors.Errorf("failed to get password restriction with error: %v", err))
 	}
@@ -430,7 +430,7 @@ func (s *UserService) UpdateUser(ctx context.Context, request *connect.Request[v
 					TempOtpSecretCreatedTime: nil,
 				}
 			} else {
-				setting, err := s.store.GetWorkspaceGeneralSetting(ctx)
+				setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 				if err != nil {
 					return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to find workspace setting, error: %v", err))
 				}
@@ -730,7 +730,7 @@ func validateEmailWithDomains(ctx context.Context, licenseService *enterprise.Li
 		}
 		return nil
 	}
-	setting, err := stores.GetWorkspaceGeneralSetting(ctx)
+	setting, err := stores.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, errors.Errorf("failed to find workspace setting, error: %v", err))
 	}

--- a/backend/component/webhook/manager.go
+++ b/backend/component/webhook/manager.go
@@ -73,7 +73,7 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 	var webhookCtx webhook.Context
 	var mentionUsers []*store.UserMessage
 
-	setting, err := m.store.GetWorkspaceGeneralSetting(ctx)
+	setting, err := m.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get workspace setting")
 	}

--- a/backend/runner/metricreport/reporter.go
+++ b/backend/runner/metricreport/reporter.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/enterprise"
-	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/plugin/metric"
 	"github.com/bytebase/bytebase/backend/plugin/metric/segment"
@@ -167,22 +167,10 @@ func (m *Reporter) isMetricCollectionEnabled(ctx context.Context) bool {
 	}
 
 	// Get workspace profile setting
-	setting, err := m.store.GetSettingV2(ctx, storepb.SettingName_WORKSPACE_PROFILE)
+	workspaceProfile, err := m.store.GetWorkspaceProfileSetting(ctx)
 	if err != nil {
 		// If we can't get the setting, default to enabled for backward compatibility
 		slog.Debug("Failed to get workspace profile setting for metric collection", log.BBError(err))
-		return true
-	}
-
-	if setting == nil {
-		// Default to enabled if setting is not found
-		return true
-	}
-
-	var workspaceProfile storepb.WorkspaceProfileSetting
-	if err := common.ProtojsonUnmarshaler.Unmarshal([]byte(setting.Value), &workspaceProfile); err != nil {
-		slog.Debug("Failed to unmarshal workspace profile setting", log.BBError(err))
-		// Default to enabled if we can't parse the setting
 		return true
 	}
 

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -251,7 +251,7 @@ func (s *Server) Run(ctx context.Context, port int) error {
 	go mmm.Run(ctx, &s.runnerWG)
 
 	// Check workspace setting and set audit logger runtime flag
-	workspaceProfile, err := s.store.GetWorkspaceGeneralSetting(ctx)
+	workspaceProfile, err := s.store.GetWorkspaceProfileSetting(ctx)
 	if err == nil && workspaceProfile.GetEnableAuditLogStdout() {
 		// Validate license before enabling (prevents usage after license downgrade/expiry)
 		if err := s.licenseService.IsFeatureEnabled(v1pb.PlanFeature_FEATURE_AUDIT_LOG); err != nil {


### PR DESCRIPTION
This PR changes the `Value` field in `SettingMessage` from `string` (JSON) to `proto.Message` for better type safety and performance. It also renames `GetWorkspaceGeneralSetting` to `GetWorkspaceProfileSetting` to match the proto enum name and removes the unused `FindSettingMessage` struct.