### PR TITLE
fix(frontend): use proper i18n binding for BBAttention props

### DIFF
--- a/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
@@ -52,9 +52,9 @@
       <BBAttention
         v-if="reviewPolicy.resources.length === 0"
         type="warning"
-        title="sql-review.attach-resource.no-linked-resources"
-        description="sql-review.attach-resource.label"
-        action-text="sql-review.attach-resource.self"
+        :title="$t('sql-review.attach-resource.no-linked-resources')"
+        :description="$t('sql-review.attach-resource.label')"
+        :action-text="$t('sql-review.attach-resource.self')"
         @click="state.showResourcePanel = true"
       />
       <div class="flex flex-col gap-y-2 gap-x-2">


### PR DESCRIPTION
The title, description, and action-text props were missing v-bind and $t() wrapper, causing raw i18n keys to be displayed instead of translated strings. fix from #18364 

🤖 Generated with [Claude Code](https://claude.com/claude-code)