### PR TITLE
refactor(frontend): remove unused requiredClassification field from SQL review

### DIFF
--- a/frontend/src/locales/sql-review/en-US.json
+++ b/frontend/src/locales/sql-review/en-US.json
@@ -70,10 +70,6 @@
         "required": {
           "title": "Require comment"
         },
-        "requiredClassification": {
-          "title": "Require classification",
-          "tooltip": "The comment should follow {'{'}classification id{'}'}-{'{'}comment{'}'} format."
-        },
         "maxLength": {
           "title": "Max length"
         }
@@ -619,10 +615,6 @@
       "component": {
         "required": {
           "title": "Require comment"
-        },
-        "requiredClassification": {
-          "title": "Require classification",
-          "tooltip": "The comment should follow {'{'}classification id{'}'}-{'{'}comment{'}'} format."
         },
         "maxLength": {
           "title": "Max length"

--- a/frontend/src/locales/sql-review/es-ES.json
+++ b/frontend/src/locales/sql-review/es-ES.json
@@ -70,10 +70,6 @@
         "required": {
           "title": "Comentario obligatorio"
         },
-        "requiredClassification": {
-          "title": "Requerir clasificación",
-          "tooltip": "El comentario debe seguir el formato {'{'}identificación de clasificación{'}'}-{'{'}comentario{'}'}."
-        },
         "maxLength": {
           "title": "Longitud máxima"
         }
@@ -619,10 +615,6 @@
       "component": {
         "required": {
           "title": "Requerir comentario"
-        },
-        "requiredClassification": {
-          "title": "Requerir clasificación",
-          "tooltip": "El comentario debe seguir el formato {'{'}identificación de clasificación{'}'}-{'{'}comentario{'}'}."
         },
         "maxLength": {
           "title": "Longitud máxima"

--- a/frontend/src/locales/sql-review/ja-JP.json
+++ b/frontend/src/locales/sql-review/ja-JP.json
@@ -70,10 +70,6 @@
         "required": {
           "title": "コメントの必須化"
         },
-        "requiredClassification": {
-          "title": "分類が必要",
-          "tooltip": "コメントは、{'{'}分類 ID{'}'}-{'{'}コメント{'}'} の形式に従う必要があります。"
-        },
         "maxLength": {
           "title": "最大長"
         }
@@ -619,10 +615,6 @@
       "component": {
         "required": {
           "title": "コメントの必須化"
-        },
-        "requiredClassification": {
-          "title": "分類が必要",
-          "tooltip": "コメントは、{'{'}分類 ID{'}'}-{'{'}コメント{'}'} の形式に従う必要があります。"
         },
         "maxLength": {
           "title": "最大長"

--- a/frontend/src/locales/sql-review/vi-VN.json
+++ b/frontend/src/locales/sql-review/vi-VN.json
@@ -70,10 +70,6 @@
         "required": {
           "title": "Yêu cầu bình luận"
         },
-        "requiredClassification": {
-          "title": "Yêu cầu phân loại",
-          "tooltip": "Bình luận phải tuân theo định dạng {'{'}id phân loại{'}'}-{'{'}bình luận{'}'}."
-        },
         "maxLength": {
           "title": "Độ dài tối đa"
         }
@@ -619,10 +615,6 @@
       "component": {
         "required": {
           "title": "Yêu cầu bình luận"
-        },
-        "requiredClassification": {
-          "title": "Yêu cầu phân loại",
-          "tooltip": "Bình luận phải tuân theo định dạng {'{'}id phân loại{'}'}-{'{'}bình luận{'}'}."
         },
         "maxLength": {
           "title": "Độ dài tối đa"

--- a/frontend/src/locales/sql-review/zh-CN.json
+++ b/frontend/src/locales/sql-review/zh-CN.json
@@ -70,10 +70,6 @@
         "required": {
           "title": "必须注释"
         },
-        "requiredClassification": {
-          "title": "需要分类",
-          "tooltip": "评论应遵循{'{'}分类 ID{'}'}-{'{'}评论{'}'}格式。"
-        },
         "maxLength": {
           "title": "长度限制"
         }
@@ -619,10 +615,6 @@
       "component": {
         "required": {
           "title": "必须注释"
-        },
-        "requiredClassification": {
-          "title": "需要分类",
-          "tooltip": "评论应遵循{'{'}分类 ID{'}'}-{'{'}评论{'}'}格式。"
         },
         "maxLength": {
           "title": "长度限制"

--- a/frontend/src/types/sql-review-schema.yaml
+++ b/frontend/src/types/sql-review-schema.yaml
@@ -123,10 +123,6 @@
       payload:
         type: BOOLEAN
         default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
     - key: maxLength
       payload:
         type: NUMBER
@@ -136,10 +132,6 @@
   category: TABLE
   componentList:
     - key: required
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: requiredClassification
       payload:
         type: BOOLEAN
         default: false
@@ -155,10 +147,6 @@
       payload:
         type: BOOLEAN
         default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
     - key: maxLength
       payload:
         type: NUMBER
@@ -171,10 +159,6 @@
       payload:
         type: BOOLEAN
         default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
     - key: maxLength
       payload:
         type: NUMBER
@@ -184,10 +168,6 @@
   category: TABLE
   componentList:
     - key: required
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: requiredClassification
       payload:
         type: BOOLEAN
         default: false
@@ -1375,10 +1355,6 @@
       payload:
         type: BOOLEAN
         default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
     - key: maxLength
       payload:
         type: NUMBER
@@ -1388,10 +1364,6 @@
   category: COLUMN
   componentList:
     - key: required
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: requiredClassification
       payload:
         type: BOOLEAN
         default: false
@@ -1407,10 +1379,6 @@
       payload:
         type: BOOLEAN
         default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
     - key: maxLength
       payload:
         type: NUMBER
@@ -1423,10 +1391,6 @@
       payload:
         type: BOOLEAN
         default: false
-    - key: requiredClassification
-      payload:
-        type: BOOLEAN
-        default: false
     - key: maxLength
       payload:
         type: NUMBER
@@ -1436,10 +1400,6 @@
   category: COLUMN
   componentList:
     - key: required
-      payload:
-        type: BOOLEAN
-        default: false
-    - key: requiredClassification
       payload:
         type: BOOLEAN
         default: false

--- a/frontend/src/types/sqlReview.ts
+++ b/frontend/src/types/sqlReview.ts
@@ -79,7 +79,6 @@ interface StringArrayLimitPayload {
 // Used by the backend.
 interface CommentFormatPayload {
   required: boolean;
-  requiredClassification: boolean;
   maxLength: number;
 }
 
@@ -520,15 +519,8 @@ export const convertPolicyRuleToRuleTemplate = (
     case SQLReviewRule_Type.COLUMN_COMMENT:
     case SQLReviewRule_Type.TABLE_COMMENT: {
       const requireComponent = componentList.find((c) => c.key === "required");
-      const requiredClassificationComponent = componentList.find(
-        (c) => c.key === "requiredClassification"
-      );
 
-      if (
-        !requireComponent ||
-        !requiredClassificationComponent ||
-        !numberComponent
-      ) {
+      if (!requireComponent || !numberComponent) {
         throw new Error(`Invalid rule ${ruleTypeToString(ruleTemplate.type)}`);
       }
 
@@ -540,13 +532,6 @@ export const convertPolicyRuleToRuleTemplate = (
             payload: {
               ...requireComponent.payload,
               value: (payload as CommentFormatPayload).required,
-            } as BooleanPayload,
-          },
-          {
-            ...requiredClassificationComponent,
-            payload: {
-              ...requiredClassificationComponent.payload,
-              value: (payload as CommentFormatPayload).requiredClassification,
             } as BooleanPayload,
           },
           {
@@ -714,9 +699,6 @@ const mergeIndividualConfigAsRule = (
     case SQLReviewRule_Type.TABLE_COMMENT: {
       const requirePayload = componentList.find((c) => c.key === "required")
         ?.payload as BooleanPayload | undefined;
-      const requiredClassificationPayload = componentList.find(
-        (c) => c.key === "requiredClassification"
-      )?.payload as BooleanPayload | undefined;
 
       if (!requirePayload || !numberPayload) {
         throw new Error(`Invalid rule ${ruleTypeToString(template.type)}`);
@@ -726,10 +708,6 @@ const mergeIndividualConfigAsRule = (
         payload: {
           required: requirePayload.value ?? requirePayload.default,
           maxLength: numberPayload.value ?? numberPayload.default,
-          requiredClassification:
-            requiredClassificationPayload?.value ??
-            requiredClassificationPayload?.default ??
-            false,
         },
       };
     }


### PR DESCRIPTION
## Summary

- Removed the unused `requiredClassification` field from TABLE_COMMENT and COLUMN_COMMENT rules
- The field was defined in the schema but never used in the UI or backend logic
- Cleaned up all related code and i18n translations across 5 locales

## Changes

- **Schema**: Removed `requiredClassification` component from `TABLE_COMMENT` and `COLUMN_COMMENT` rules in `sql-review-schema.yaml`
- **TypeScript**: Removed `requiredClassification` from `CommentFormatPayload` interface and handling functions
- **i18n**: Removed translations from en-US, zh-CN, es-ES, ja-JP, and vi-VN locale files

## Test plan

- [x] Type check passed
- [x] Biome format/lint check passed
- [ ] Manual testing: Verify SQL review comment rules still work correctly in the UI
  - [ ] Create/edit a review policy with TABLE_COMMENT rule
  - [ ] Create/edit a review policy with COLUMN_COMMENT rule
  - [ ] Verify only "required" and "maxLength" options are shown
  - [ ] Verify rules apply correctly to SQL statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)