### PR TITLE
refactor(frontend): clean up Plan Configuration options

### DIFF
--- a/frontend/src/components/Plan/components/Configuration/GhostSection/common.ts
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/common.ts
@@ -28,16 +28,6 @@ export const allowGhostForDatabase = (database: ComposedDatabase) => {
   );
 };
 
-export const allowGhostForSpec = (spec: Plan_Spec | undefined) => {
-  const config =
-    spec?.config?.case === "changeDatabaseConfig"
-      ? spec.config.value
-      : undefined;
-  if (!config) return false;
-
-  return config.type === DatabaseChangeType.MIGRATE;
-};
-
 export const getGhostEnabledForSpec = (
   spec: Plan_Spec
 ): boolean | undefined => {

--- a/frontend/src/components/Plan/components/Configuration/GhostSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/context.ts
@@ -15,11 +15,7 @@ import {
   hasProjectPermissionV2,
   isNullOrUndefined,
 } from "@/utils";
-import {
-  allowGhostForSpec,
-  GHOST_AVAILABLE_ENGINES,
-  getGhostEnabledForSpec,
-} from "./common";
+import { GHOST_AVAILABLE_ENGINES, getGhostEnabledForSpec } from "./common";
 
 export const KEY = Symbol(
   "bb.plan.setting.gh-ost"
@@ -69,7 +65,6 @@ export const provideGhostSettingContext = (refs: {
   const shouldShow = computed(() => {
     return (
       selectedSpec.value &&
-      allowGhostForSpec(selectedSpec.value) &&
       databases.value.every((db) =>
         GHOST_AVAILABLE_ENGINES.includes(db.instanceResource.engine)
       ) &&

--- a/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/context.ts
@@ -58,12 +58,12 @@ export const provideInstanceRoleSettingContext = (refs: {
     );
     if (!allDatabasesArePostgres) return false;
 
-    // Check if this is a DDL or DML change
+    // Check if this is a database change spec.
     if (selectedSpec.value.config?.case !== "changeDatabaseConfig") {
       return false;
     }
     const config = selectedSpec.value.config.value;
-    // Show for all MIGRATE types (DDL, DML, Ghost), but not SDL
+    // Show for MIGRATE type, but not SDL.
     return config.type === DatabaseChangeType.MIGRATE;
   });
 

--- a/frontend/src/components/Plan/components/Configuration/PreBackupSection/PreBackupSwitch.vue
+++ b/frontend/src/components/Plan/components/Configuration/PreBackupSection/PreBackupSwitch.vue
@@ -34,10 +34,8 @@ import type { ErrorItem } from "@/components/misc/ErrorList.vue";
 import ErrorList from "@/components/misc/ErrorList.vue";
 import { targetsForSpec } from "@/components/Plan/logic";
 import { pushNotification } from "@/store";
-import {
-  PRE_BACKUP_AVAILABLE_ENGINES,
-  usePreBackupSettingContext,
-} from "./context";
+import { BACKUP_AVAILABLE_ENGINES } from "./common";
+import { usePreBackupSettingContext } from "./context";
 
 const { t } = useI18n();
 const { enabled, allowChange, databases, toggle, selectedSpec } =
@@ -49,7 +47,7 @@ const errors = computed(() => {
 
   // Check for unsupported database engines
   const unsupportedEngineDatabases = databases.value.filter(
-    (db) => !PRE_BACKUP_AVAILABLE_ENGINES.includes(db.instanceResource.engine)
+    (db) => !BACKUP_AVAILABLE_ENGINES.includes(db.instanceResource.engine)
   );
   if (unsupportedEngineDatabases.length > 0) {
     errors.push(
@@ -83,7 +81,7 @@ const databasesNotMeetingRequirements = computed(() => {
     // Check if database doesn't have backup available
     if (!db.backupAvailable) return true;
     // Check if database engine is not supported
-    if (!PRE_BACKUP_AVAILABLE_ENGINES.includes(db.instanceResource.engine)) {
+    if (!BACKUP_AVAILABLE_ENGINES.includes(db.instanceResource.engine)) {
       return true;
     }
     return false;

--- a/frontend/src/components/Plan/components/Configuration/PreBackupSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/PreBackupSection/context.ts
@@ -13,7 +13,6 @@ import { isDatabaseChangeSpec, targetsForSpec } from "@/components/Plan/logic";
 import { planServiceClientConnect } from "@/grpcweb";
 import { extractUserId, useCurrentUserV1, useDatabaseV1Store } from "@/store";
 import { isValidDatabaseName } from "@/types";
-import { Engine } from "@/types/proto-es/v1/common_pb";
 import { type Issue, IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import {
   type Plan,
@@ -25,14 +24,6 @@ import type { Rollout, Task } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { flattenTaskV1List, hasProjectPermissionV2 } from "@/utils";
 import { BACKUP_AVAILABLE_ENGINES } from "./common";
-
-export const PRE_BACKUP_AVAILABLE_ENGINES = [
-  Engine.MYSQL,
-  Engine.TIDB,
-  Engine.MSSQL,
-  Engine.ORACLE,
-  Engine.POSTGRES,
-];
 
 const KEY = Symbol(
   "bb.plan.setting.pre-backup"


### PR DESCRIPTION
- Remove redundant `allowGhostForSpec` check in GhostSection (already covered by `getGhostEnabledForSpec`)
- Remove unused `allowGhostForSpec` function from GhostSection/common.ts
- Remove duplicate `PRE_BACKUP_AVAILABLE_ENGINES` constant from PreBackupSection/context.ts
- Consolidate to use `BACKUP_AVAILABLE_ENGINES` from common.ts
- Update comments in InstanceRoleSection

🤖 Generated with [Claude Code](https://claude.com/claude-code)