### PR TITLE
fix(frontend): prevent /auth/admin redirect to /auth

### DIFF
--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -5,6 +5,7 @@ import {
   AUTH_OIDC_CALLBACK_MODULE,
   AUTH_PASSWORD_FORGOT_MODULE,
   AUTH_PASSWORD_RESET_MODULE,
+  AUTH_SIGNIN_ADMIN_MODULE,
   AUTH_SIGNIN_MODULE,
   AUTH_SIGNUP_MODULE,
 } from "@/router/auth";
@@ -12,6 +13,7 @@ import {
 export const isAuthRelatedRoute = (routeName: string) => {
   return [
     AUTH_SIGNIN_MODULE,
+    AUTH_SIGNIN_ADMIN_MODULE,
     AUTH_SIGNUP_MODULE,
     AUTH_MFA_MODULE,
     AUTH_PASSWORD_RESET_MODULE,


### PR DESCRIPTION
Add AUTH_SIGNIN_ADMIN_MODULE to isAuthRelatedRoute() so the admin signin page is recognized as an auth route and doesn't redirect unauthenticated users to /auth?redirect=/auth/admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)