### PR TITLE
feat(frontend): show all workspace users/groups in masking exemption selector

### DIFF
--- a/frontend/src/components/SensitiveData/GrantAccessForm.vue
+++ b/frontend/src/components/SensitiveData/GrantAccessForm.vue
@@ -71,7 +71,6 @@
         <MembersBindingSelect
           v-model:value="state.memberList"
           :required="true"
-          :project-name="projectName"
           :include-all-users="false"
           :include-service-account="false"
         />


### PR DESCRIPTION
## Summary

- Remove project-based filtering from masking exemption user/group selector
- Show all workspace users and groups instead of only project members
- Follows GCP IAM model where admins can grant access to any principal

## Why

The original design proposed permission-based filtering (`bb.sql.select`), but this was rejected because:

1. **Anti-pattern to data model**: The relationship is `user ← role ← permission`. Filtering users BY permission inverts this hierarchy.
2. **GCP precedent**: GCP allows granting IAM roles to any principal, even those not currently in the project.

## Behavior

- Dropdown shows all workspace users/groups
- Admin can grant masking exemption to any user/group
- Exemption becomes effective when user gains project access

## Test plan

- [ ] Open masking exemption grant form
- [ ] Verify user dropdown shows all workspace users (not filtered by project)
- [ ] Verify group dropdown shows all workspace groups
- [ ] Grant exemption to a user not in the project
- [ ] Add user to project and verify exemption is effective

## References

- Design doc: https://docs.google.com/document/d/10fp-z0hm3tHyorfGXc3xko8TaZH0YtVhZneqKZgFi50/edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)