### PR TITLE
fix(starrocks): removed transaction for db dump

### DIFF
--- a/backend/plugin/db/starrocks/dump.go
+++ b/backend/plugin/db/starrocks/dump.go
@@ -80,7 +80,7 @@ const (
 )
 
 // Dump dumps the database.
-func (d *Driver) Dump(ctx context.Context, out io.Writer, _ *storepb.DatabaseSchemaMetadata) error {
+func (d *Driver) Dump(_ context.Context, out io.Writer, _ *storepb.DatabaseSchemaMetadata) error {
 	// mysqldump -u root --databases dbName --no-data --routines --events --triggers --compact
 
 	slog.Debug("begin to dump database", slog.String("database", d.databaseName))


### PR DESCRIPTION
Fixes #17264 

This PR resolves the StarRocks rollout failure caused by an error in plugin/db/starrocks.dumpTxn. The issue occurred because StarRocks has a limitation where explicit transactions only support INSERT statements, but the dumpTxn function was attempting to execute other SQL commands (like schema introspection queries) within a transaction block.

## Problem
When attempting to rollout a plan to a StarRocks database, the schema dump process would fail with:
`Error 5305 (25P01): Explicit transaction only support insert statement`
This error was triggered during the database schema synchronization phase when Bytebase attempted to dump the database schema before executing migrations. The `dumpTxn` function in `backend/plugin/db/starrocks/dump.go` was wrapping schema introspection queries in a transaction, which StarRocks does not support for non-INSERT operations.

## Solution
As commented in the issue, I removed the transaction creation for the db dump operation on the starrocks db plugin.

## Testing
✅ Tested locally with StarRocks database
✅ Successfully completed rollouts that previously failed