### PR TITLE
refactor(frontend): improve ActivitySection component maintainability

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/ActivitySection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/ActivitySection.vue
@@ -8,5 +8,5 @@
 </template>
 
 <script setup lang="ts">
-import IssueCommentList from "@/components/IssueV1/components/IssueCommentSection/IssueCommentList.vue";
+import IssueCommentList from "./IssueCommentList.vue";
 </script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentList.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentList.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="flex flex-col">
+    <ul>
+      <IssueDescriptionComment :issue-comments="issueComments" />
+      <IssueCommentView
+        v-for="(item, index) in issueComments"
+        :key="item.comment.name"
+        class="group"
+        :is-last="index === issueComments.length - 1"
+        :issue-comment="item.comment"
+        :similar="item.similar"
+      >
+        <template v-if="allowEditComment(item.comment)" #subject-suffix>
+          <NButton
+            v-if="!commentEdit.state.editMode"
+            quaternary
+            size="tiny"
+            class="text-gray-500 hover:text-gray-700"
+            @click.prevent="commentEdit.startEditComment(item.comment)"
+          >
+            <PencilIcon class="w-3.5 h-3.5" />
+          </NButton>
+        </template>
+
+        <template v-if="item.comment.comment" #comment>
+          <EditableMarkdownContent
+            :content="item.comment.comment"
+            :edit-content="commentEdit.state.editContent"
+            :project="project"
+            :is-editing="isEditingComment(item.comment.name)"
+            :allow-save="commentEdit.allowUpdateComment.value"
+            @update:edit-content="commentEdit.state.editContent = $event"
+            @save="commentEdit.saveEditComment"
+            @cancel="commentEdit.cancelEditComment"
+          />
+        </template>
+      </IssueCommentView>
+    </ul>
+
+    <div
+      v-if="!commentEdit.state.editMode && commentEdit.allowCreateComment.value"
+      class="mt-2"
+    >
+      <div class="flex gap-3">
+        <div class="shrink-0 pt-1">
+          <UserAvatar :user="commentEdit.currentUser.value" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <h3 class="sr-only" id="issue-comment-editor"></h3>
+          <MarkdownEditor
+            mode="editor"
+            :content="commentEdit.state.newComment"
+            :project="project"
+            :maxlength="65536"
+            @change="(val: string) => (commentEdit.state.newComment = val)"
+            @submit="handleCreateComment"
+          />
+          <div class="mt-3 flex items-center justify-end">
+            <NButton
+              type="primary"
+              :disabled="commentEdit.state.newComment.length === 0"
+              @click.prevent="handleCreateComment"
+            >
+              {{ $t("common.comment") }}
+            </NButton>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { create } from "@bufbuild/protobuf";
+import { PencilIcon } from "lucide-vue-next";
+import { NButton } from "naive-ui";
+import { computed, onMounted, watch, watchEffect } from "vue";
+import { useRoute } from "vue-router";
+import MarkdownEditor from "@/components/MarkdownEditor";
+import UserAvatar from "@/components/User/UserAvatar.vue";
+import { useCurrentProjectV1, useIssueCommentStore } from "@/store";
+import { ListIssueCommentsRequestSchema } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  groupIssueComments,
+  IssueCommentView,
+  useCommentEdit,
+} from "./IssueCommentView";
+import EditableMarkdownContent from "./IssueCommentView/EditableMarkdownContent.vue";
+import IssueDescriptionComment from "./IssueCommentView/IssueDescriptionComment.vue";
+
+const route = useRoute();
+const { project } = useCurrentProjectV1();
+const issueCommentStore = useIssueCommentStore();
+
+const commentEdit = useCommentEdit(project);
+const { issueName, allowEditComment } = commentEdit;
+
+const isEditingComment = (commentName: string): boolean => {
+  return (
+    commentEdit.state.editMode &&
+    commentEdit.state.activeComment?.name === commentName
+  );
+};
+
+const fetchIssueComments = async () => {
+  if (!issueName.value) return;
+  await issueCommentStore.listIssueComments(
+    create(ListIssueCommentsRequestSchema, {
+      parent: issueName.value,
+      pageSize: 1000,
+    })
+  );
+};
+
+watchEffect(fetchIssueComments);
+
+const issueComments = computed(() => {
+  if (!issueName.value) return [];
+  const list = issueCommentStore.getIssueComments(issueName.value);
+  return groupIssueComments(list);
+});
+
+const handleCreateComment = async () => {
+  await commentEdit.createComment(commentEdit.state.newComment);
+  await fetchIssueComments();
+};
+
+onMounted(() => {
+  watch(
+    () => route.hash,
+    (hash) => {
+      if (hash.match(/^#activity(\d+)/)) {
+        const elem =
+          document.querySelector(hash) || document.querySelector("#activity");
+        setTimeout(() => elem?.scrollIntoView());
+      }
+    },
+    { immediate: true }
+  );
+});
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionCreator.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionCreator.vue
@@ -1,0 +1,49 @@
+<template>
+  <component
+    :is="'router-link'"
+    v-if="userEmail !== userStore.systemBotUser?.email"
+    v-bind="bindings"
+    class="font-semibold text-gray-900 whitespace-nowrap hover:underline"
+  >
+    {{ user?.title }}
+  </component>
+  <div v-else class="inline-flex items-center gap-1">
+    <span class="font-medium text-main whitespace-nowrap">
+      {{ user?.title }}
+    </span>
+    <SystemBotTag />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computedAsync } from "@vueuse/core";
+import { computed } from "vue";
+import SystemBotTag from "@/components/misc/SystemBotTag.vue";
+import { extractUserId, useUserStore } from "@/store";
+
+const props = defineProps<{
+  // Format: users/{email}
+  creator: string;
+}>();
+
+const userStore = useUserStore();
+
+const userEmail = computed(() => {
+  return extractUserId(props.creator);
+});
+
+const user = computedAsync(() => {
+  return userStore.getOrFetchUserByIdentifier(props.creator);
+});
+
+const bindings = computed(() => {
+  return {
+    to: `/users/${userEmail.value}`,
+    activeClass: "",
+    exactActiveClass: "",
+    onClick: (e: MouseEvent) => {
+      e.stopPropagation();
+    },
+  };
+});
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionIcon.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionIcon.vue
@@ -1,0 +1,260 @@
+<template>
+  <div class="relative">
+    <div v-if="iconConfig.type === 'system'" class="relative pl-0.5">
+      <div
+        class="w-7 h-7 bg-control-bg rounded-full ring-4 ring-white flex items-center justify-center"
+      >
+        <img class="mt-1" src="@/assets/logo-icon.svg" alt="Bytebase" />
+      </div>
+    </div>
+    <div v-else-if="iconConfig.type === 'avatar'" class="relative pl-0.5">
+      <div
+        class="w-7 h-7 bg-white rounded-full ring-4 ring-white flex items-center justify-center"
+      >
+        <PrincipalAvatar
+          :user="user"
+          override-class="w-7 h-7 font-medium"
+          override-text-size="0.8rem"
+        />
+      </div>
+    </div>
+    <div v-else class="relative" :class="iconConfig.wrapper">
+      <div
+        class="rounded-full ring-4 ring-white flex items-center justify-center"
+        :class="iconConfig.container"
+      >
+        <component :is="iconConfig.icon" :class="iconConfig.iconClass" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computedAsync } from "@vueuse/core";
+import {
+  CheckCircle2Icon,
+  CircleAlertIcon,
+  CodeIcon,
+  MinusIcon,
+  PencilIcon,
+  PlayCircleIcon,
+  PlayIcon,
+  PlusIcon,
+  ThumbsUpIcon,
+} from "lucide-vue-next";
+import type { Component } from "vue";
+import { computed } from "vue";
+import { SkipIcon } from "@/components/Icon";
+import PrincipalAvatar from "@/components/PrincipalAvatar.vue";
+import {
+  extractUserId,
+  getIssueCommentType,
+  IssueCommentType,
+  useUserStore,
+} from "@/store";
+import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  IssueComment_Approval_Status,
+  IssueComment_TaskUpdate_Status,
+} from "@/types/proto-es/v1/issue_service_pb";
+
+type ActionIconType =
+  | "avatar"
+  | "system"
+  | "create"
+  | "update"
+  | "run"
+  | "approve-review"
+  | "reject-review"
+  | "re-request-review"
+  | "rollout"
+  | "cancel"
+  | "fail"
+  | "complete"
+  | "skip"
+  | "commit";
+
+interface IconConfig {
+  type: "system" | "avatar" | "icon";
+  wrapper?: string;
+  container?: string;
+  icon?: Component;
+  iconClass?: string;
+}
+
+const ICON_CONFIGS: Record<
+  Exclude<ActionIconType, "system" | "avatar">,
+  Omit<IconConfig, "type">
+> = {
+  create: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-control-bg",
+    icon: PlusIcon,
+    iconClass: "w-5 h-5 text-control",
+  },
+  update: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-control-bg",
+    icon: PencilIcon,
+    iconClass: "w-4 h-4 text-control",
+  },
+  run: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-control-bg",
+    icon: PlayCircleIcon,
+    iconClass: "w-5 h-5 text-control",
+  },
+  rollout: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-control-bg",
+    icon: PlayCircleIcon,
+    iconClass: "w-5 h-5 text-control",
+  },
+  "approve-review": {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-success",
+    icon: ThumbsUpIcon,
+    iconClass: "w-4 h-4 text-white",
+  },
+  "reject-review": {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-warning",
+    icon: PencilIcon,
+    iconClass: "w-4 h-4 text-white",
+  },
+  "re-request-review": {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-control-bg icon-re-request-review",
+    icon: PlayIcon,
+    iconClass: "w-4 h-4 text-control ml-px",
+  },
+  cancel: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-control-bg",
+    icon: MinusIcon,
+    iconClass: "w-5 h-5 text-control",
+  },
+  fail: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-white",
+    icon: CircleAlertIcon,
+    iconClass: "w-5 h-5 text-error",
+  },
+  complete: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-white",
+    icon: CheckCircle2Icon,
+    iconClass: "w-6 h-6 text-success",
+  },
+  skip: {
+    wrapper: "pl-1",
+    container: "w-6 h-6 bg-gray-200",
+    icon: SkipIcon,
+    iconClass: "w-5 h-5 text-gray-500",
+  },
+  commit: {
+    wrapper: "pl-0.5",
+    container: "w-7 h-7 bg-control-bg",
+    icon: CodeIcon,
+    iconClass: "w-5 h-5 text-control",
+  },
+};
+
+const props = defineProps<{
+  issueComment: IssueComment;
+}>();
+
+const userStore = useUserStore();
+
+const user = computedAsync(() => {
+  return userStore.getOrFetchUserByIdentifier(props.issueComment.creator);
+});
+
+const iconType = computed((): ActionIconType => {
+  const { issueComment } = props;
+  const commentType = getIssueCommentType(issueComment);
+
+  if (
+    commentType === IssueCommentType.APPROVAL &&
+    issueComment.event?.case === "approval"
+  ) {
+    const { status } = issueComment.event.value;
+    switch (status) {
+      case IssueComment_Approval_Status.APPROVED:
+        return "approve-review";
+      case IssueComment_Approval_Status.REJECTED:
+        return "reject-review";
+      case IssueComment_Approval_Status.PENDING:
+        return "re-request-review";
+    }
+  }
+
+  if (commentType === IssueCommentType.STAGE_END) {
+    return "complete";
+  }
+
+  if (
+    commentType === IssueCommentType.TASK_UPDATE &&
+    issueComment.event?.case === "taskUpdate"
+  ) {
+    const { toStatus } = issueComment.event.value;
+    if (toStatus !== undefined) {
+      const statusToIcon: Record<
+        IssueComment_TaskUpdate_Status,
+        ActionIconType
+      > = {
+        [IssueComment_TaskUpdate_Status.STATUS_UNSPECIFIED]: "update",
+        [IssueComment_TaskUpdate_Status.PENDING]: "rollout",
+        [IssueComment_TaskUpdate_Status.RUNNING]: "run",
+        [IssueComment_TaskUpdate_Status.DONE]: "complete",
+        [IssueComment_TaskUpdate_Status.FAILED]: "fail",
+        [IssueComment_TaskUpdate_Status.SKIPPED]: "skip",
+        [IssueComment_TaskUpdate_Status.CANCELED]: "cancel",
+      };
+      return statusToIcon[toStatus] ?? "update";
+    }
+    return "update";
+  }
+
+  if (
+    commentType === IssueCommentType.ISSUE_UPDATE &&
+    issueComment.event?.case === "issueUpdate"
+  ) {
+    const { toTitle, toDescription, toLabels, fromLabels } =
+      issueComment.event.value;
+    if (
+      toTitle !== undefined ||
+      toDescription !== undefined ||
+      toLabels.length !== 0 ||
+      fromLabels.length !== 0
+    ) {
+      return "update";
+    }
+  }
+
+  if (
+    commentType === IssueCommentType.TASK_PRIOR_BACKUP &&
+    issueComment.event?.case === "taskPriorBackup"
+  ) {
+    return issueComment.event.value.error !== "" ? "fail" : "complete";
+  }
+
+  return extractUserId(issueComment.creator) === userStore.systemBotUser?.email
+    ? "system"
+    : "avatar";
+});
+
+const iconConfig = computed((): IconConfig => {
+  const type = iconType.value;
+  if (type === "system" || type === "avatar") {
+    return { type };
+  }
+  return { type: "icon", ...ICON_CONFIGS[type] };
+});
+</script>
+
+<style scoped>
+.icon-re-request-review :deep(path) {
+  stroke-width: 3 !important;
+}
+</style>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue
@@ -1,0 +1,253 @@
+<template>
+  <Renderer />
+</template>
+
+<script lang="tsx" setup>
+import type { h } from "vue";
+import { defineComponent } from "vue";
+import { Translation, useI18n } from "vue-i18n";
+import { usePlanContext } from "@/components/Plan/logic";
+import {
+  extractUserId,
+  getIssueCommentType,
+  IssueCommentType,
+  useUserStore,
+} from "@/store";
+import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  IssueComment_Approval_Status,
+  IssueComment_TaskUpdate_Status,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { findStageByName, findTaskByName } from "@/utils";
+import StageName from "./StageName.vue";
+import StatementUpdate from "./StatementUpdate.vue";
+import TaskName from "./TaskName.vue";
+
+type RenderedContent = string | ReturnType<typeof h>;
+
+const props = defineProps<{
+  issueComment: IssueComment;
+}>();
+
+const { plan, rollout } = usePlanContext();
+const { t } = useI18n();
+const userStore = useUserStore();
+
+const renderActionSentence = () => {
+  const { issueComment } = props;
+  const commentType = getIssueCommentType(issueComment);
+  if (
+    commentType === IssueCommentType.APPROVAL &&
+    issueComment.event?.case === "approval"
+  ) {
+    const { status } = issueComment.event.value;
+    let verb = "";
+    if (status === IssueComment_Approval_Status.APPROVED) {
+      verb = t("custom-approval.issue-review.approved-issue");
+    } else if (status === IssueComment_Approval_Status.REJECTED) {
+      verb = t("custom-approval.issue-review.sent-back-issue");
+    } else if (status === IssueComment_Approval_Status.PENDING) {
+      verb = t("custom-approval.issue-review.re-requested-review");
+    }
+    if (verb) {
+      return maybeAutomaticallyVerb(issueComment, verb);
+    }
+  } else if (
+    commentType === IssueCommentType.ISSUE_UPDATE &&
+    issueComment.event?.case === "issueUpdate"
+  ) {
+    const {
+      fromTitle,
+      toTitle,
+      fromDescription,
+      toDescription,
+      fromStatus,
+      toStatus,
+      fromLabels,
+      toLabels,
+    } = issueComment.event.value;
+    if (fromTitle !== undefined && toTitle !== undefined) {
+      return t("activity.sentence.changed-from-to", {
+        name: t("issue.issue-name").toLowerCase(),
+        oldValue: fromTitle,
+        newValue: toTitle,
+      });
+    } else if (fromDescription !== undefined && toDescription !== undefined) {
+      return t("activity.sentence.changed-description");
+    } else if (fromStatus !== undefined && toStatus !== undefined) {
+      if (toStatus === IssueStatus.DONE) {
+        return t("activity.sentence.resolved-issue");
+      } else if (toStatus === IssueStatus.CANCELED) {
+        return t("activity.sentence.canceled-issue");
+      } else if (toStatus === IssueStatus.OPEN) {
+        return t("activity.sentence.reopened-issue");
+      }
+    } else if (fromLabels.length !== 0 || toLabels.length !== 0) {
+      return t("activity.sentence.changed-labels");
+    }
+  } else if (
+    commentType === IssueCommentType.STAGE_END &&
+    issueComment.event?.case === "stageEnd"
+  ) {
+    const { stage } = issueComment.event.value;
+    const stageEntity = rollout.value
+      ? findStageByName(rollout.value, stage)
+      : undefined;
+    const params: VerbTypeTarget = {
+      issueComment,
+      type: t("common.stage"),
+      target: stageEntity ? <StageName stage={stageEntity} /> : "",
+      verb: t("activity.sentence.completed"),
+    };
+    return renderVerbTypeTarget(params);
+  } else if (
+    commentType === IssueCommentType.TASK_UPDATE &&
+    issueComment.event?.case === "taskUpdate"
+  ) {
+    const { tasks, fromSheet, toSheet, toStatus } = issueComment.event.value;
+
+    if (toStatus !== undefined) {
+      const params: VerbTypeTarget = {
+        issueComment,
+        verb: "",
+        type: t("common.task"),
+        target: "",
+      };
+      switch (toStatus) {
+        case IssueComment_TaskUpdate_Status.PENDING: {
+          params.verb = maybeAutomaticallyVerb(
+            issueComment,
+            t("activity.sentence.rolled-out")
+          );
+          break;
+        }
+        case IssueComment_TaskUpdate_Status.RUNNING: {
+          params.verb = t("activity.sentence.started");
+          break;
+        }
+        case IssueComment_TaskUpdate_Status.DONE: {
+          params.verb = t("activity.sentence.completed");
+          break;
+        }
+        case IssueComment_TaskUpdate_Status.FAILED: {
+          params.verb = t("activity.sentence.failed");
+          break;
+        }
+        case IssueComment_TaskUpdate_Status.CANCELED: {
+          params.verb = t("activity.sentence.canceled");
+          break;
+        }
+        case IssueComment_TaskUpdate_Status.SKIPPED: {
+          params.verb = t("activity.sentence.skipped");
+          break;
+        }
+        default:
+          params.verb = t("activity.sentence.changed");
+      }
+      const taskEntities = rollout.value
+        ? tasks.map((task) => findTaskByName(rollout.value!, task))
+        : [];
+      if (taskEntities.length > 0 && taskEntities[0]) {
+        params.target = <TaskName plan={plan.value} task={taskEntities[0]} />;
+      }
+      return renderVerbTypeTarget(params);
+    } else if (fromSheet !== undefined && toSheet !== undefined) {
+      return (
+        <Translation keypath="dynamic.activity.sentence.changed-x-link">
+          {{
+            name: () => "SQL",
+            link: () => (
+              <StatementUpdate oldSheet={fromSheet} newSheet={toSheet} />
+            ),
+          }}
+        </Translation>
+      );
+    }
+  } else if (
+    commentType === IssueCommentType.TASK_PRIOR_BACKUP &&
+    issueComment.event?.case === "taskPriorBackup"
+  ) {
+    const { task, tables, originalLine, database, error } =
+      issueComment.event.value;
+    if (error) {
+      return t("activity.sentence.failed-to-backup", { error });
+    }
+
+    const taskEntity = rollout.value
+      ? findTaskByName(rollout.value, task)
+      : undefined;
+    let verb = t("activity.sentence.prior-back-table", {
+      database: database.length > 0 ? database : "bbdataarchive",
+      tables: tables
+        .map((table) =>
+          table.schema ? `${table.schema}.${table.table}` : table.table
+        )
+        .join(", "),
+    });
+    if (originalLine) {
+      verb = t("activity.sentence.prior-back-table-for-line", {
+        database: database.length > 0 ? database : "bbdataarchive",
+        tables: tables
+          .map((table) =>
+            table.schema ? `${table.schema}.${table.table}` : table.table
+          )
+          .join(", "),
+        line: originalLine,
+      });
+    }
+    const params: VerbTypeTarget = {
+      issueComment,
+      verb: verb,
+      type: t("common.task"),
+      target: "",
+    };
+    if (task && taskEntity) {
+      params.target = <TaskName plan={plan.value} task={taskEntity} />;
+    }
+    return renderVerbTypeTarget(params);
+  }
+  return "";
+};
+
+const maybeAutomaticallyVerb = (
+  issueComment: IssueComment,
+  verb: string
+): string => {
+  if (extractUserId(issueComment.creator) !== userStore.systemBotUser?.email) {
+    return verb;
+  }
+  return t("activity.sentence.xxx-automatically", {
+    verb,
+  });
+};
+
+type VerbTypeTarget = {
+  issueComment: IssueComment;
+  verb: RenderedContent;
+  type: RenderedContent;
+  target?: RenderedContent;
+};
+
+const renderVerbTypeTarget = (params: VerbTypeTarget, props: object = {}) => {
+  const keypath =
+    extractUserId(params.issueComment.creator) ===
+    userStore.systemBotUser?.email
+      ? "dynamic.activity.sentence.verb-type-target-by-system-bot"
+      : "dynamic.activity.sentence.verb-type-target-by-people";
+  return (
+    <Translation {...props} keypath={keypath}>
+      {{
+        verb: () => params.verb,
+        type: () => params.type,
+        target: () => params.target,
+      }}
+    </Translation>
+  );
+};
+
+const Renderer = defineComponent({
+  name: "ActionSentenceRenderer",
+  render: () => <span>{renderActionSentence()}</span>,
+});
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/EditableMarkdownContent.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/EditableMarkdownContent.vue
@@ -1,0 +1,65 @@
+<template>
+  <div>
+    <p v-if="!isEditing && !content">
+      <i class="text-gray-400 italic">{{ placeholder }}</i>
+    </p>
+    <MarkdownEditor
+      v-else
+      :mode="isEditing ? 'editor' : 'preview'"
+      :content="isEditing ? editContent : content"
+      :project="project"
+      :maxlength="maxlength"
+      :max-height="maxHeight"
+      @change="(val: string) => emit('update:editContent', val)"
+      @submit="emit('save')"
+    />
+    <div
+      v-if="isEditing"
+      class="flex gap-x-2 mt-2 items-center justify-end"
+    >
+      <NButton quaternary size="small" @click.prevent="emit('cancel')">
+        {{ $t("common.cancel") }}
+      </NButton>
+      <NButton
+        size="small"
+        :disabled="!allowSave"
+        :loading="isSaving"
+        @click.prevent="emit('save')"
+      >
+        {{ $t("common.save") }}
+      </NButton>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { NButton } from "naive-ui";
+import MarkdownEditor from "@/components/MarkdownEditor";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+
+withDefaults(
+  defineProps<{
+    content: string;
+    editContent: string;
+    project: Project;
+    isEditing: boolean;
+    allowSave: boolean;
+    isSaving?: boolean;
+    placeholder?: string;
+    maxlength?: number;
+    maxHeight?: number;
+  }>(),
+  {
+    isSaving: false,
+    placeholder: "",
+    maxlength: 65536,
+    maxHeight: Number.MAX_SAFE_INTEGER,
+  }
+);
+
+const emit = defineEmits<{
+  (e: "update:editContent", value: string): void;
+  (e: "save"): void;
+  (e: "cancel"): void;
+}>();
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueCommentAction.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueCommentAction.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="min-w-0 flex-1">
+    <div
+      class="rounded-lg border overflow-hidden"
+      :class="
+        $slots.comment
+          ? 'ml-3 border-gray-200 bg-white'
+          : 'ml-1 border-transparent'
+      "
+    >
+      <div class="px-3 py-2" :class="$slots.comment ? 'bg-gray-50' : ''">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-x-2 text-sm min-w-0 flex-wrap">
+            <ActionCreator
+              v-if="
+                extractUserId(issueComment.creator) !==
+                  userStore.systemBotUser?.email ||
+                getIssueCommentType(issueComment) ===
+                  IssueCommentType.USER_COMMENT
+              "
+              :creator="issueComment.creator"
+            />
+
+            <ActionSentence
+              :issue-comment="issueComment"
+              class="text-gray-600 wrap-break-word min-w-0"
+            />
+
+            <HumanizeTs
+              :ts="
+                getTimeForPbTimestampProtoEs(issueComment.createTime, 0) / 1000
+              "
+              class="text-gray-500"
+            />
+
+            <span
+              v-if="
+                getTimeForPbTimestampProtoEs(issueComment.createTime) !==
+                  getTimeForPbTimestampProtoEs(issueComment.updateTime) &&
+                getIssueCommentType(issueComment) ===
+                  IssueCommentType.USER_COMMENT
+              "
+              class="text-gray-500 text-xs"
+            >
+              ({{ $t("common.edited") }})
+            </span>
+
+            <span v-if="similar.length > 0" class="text-xs text-gray-500">
+              {{
+                $t("activity.n-similar-activities", {
+                  count: similar.length + 1,
+                })
+              }}
+            </span>
+          </div>
+
+          <slot name="subject-suffix"></slot>
+        </div>
+      </div>
+      <div
+        v-if="$slots.comment"
+        class="px-4 py-3 border-t border-gray-200 text-sm text-gray-700 whitespace-pre-wrap wrap-break-word"
+      >
+        <slot name="comment" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import HumanizeTs from "@/components/misc/HumanizeTs.vue";
+import {
+  extractUserId,
+  getIssueCommentType,
+  IssueCommentType,
+  useUserStore,
+} from "@/store";
+import { getTimeForPbTimestampProtoEs } from "@/types";
+import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
+import ActionCreator from "./ActionCreator.vue";
+import ActionSentence from "./ActionSentence.vue";
+
+defineProps<{
+  issueComment: IssueComment;
+  similar: IssueComment[];
+}>();
+
+const userStore = useUserStore();
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueCommentView.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueCommentView.vue
@@ -1,0 +1,37 @@
+<template>
+  <li>
+    <div :id="issueComment.name" class="relative pb-4">
+      <span
+        v-if="!isLast"
+        class="absolute left-4 -ml-px h-full w-0.5 bg-gray-200"
+        aria-hidden="true"
+      ></span>
+      <div class="relative flex items-start">
+        <div class="pt-1.5">
+          <ActionIcon :issue-comment="issueComment" />
+        </div>
+
+        <IssueCommentAction
+          :issue-comment="issueComment"
+          :similar="similar"
+        >
+          <template v-for="(_, name) in $slots" :key="name" #[name]>
+            <slot :name="name" />
+          </template>
+        </IssueCommentAction>
+      </div>
+    </div>
+  </li>
+</template>
+
+<script lang="ts" setup>
+import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
+import ActionIcon from "./ActionIcon.vue";
+import IssueCommentAction from "./IssueCommentAction.vue";
+
+defineProps<{
+  isLast: boolean;
+  issueComment: IssueComment;
+  similar: IssueComment[];
+}>();
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueDescriptionComment.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueDescriptionComment.vue
@@ -1,0 +1,198 @@
+<template>
+  <li>
+    <div class="relative pb-4">
+      <span
+        v-if="issueComments.length > 0"
+        class="absolute left-4 -ml-px h-full w-0.5 bg-block-border"
+        aria-hidden="true"
+      ></span>
+      <div class="relative flex items-start">
+        <div class="relative">
+          <div class="pt-1.5 bg-white"></div>
+          <UserAvatar override-class="w-7 h-7 font-medium" :user="creator" />
+          <div
+            class="absolute -bottom-1 -right-1 w-4 h-4 bg-control-bg rounded-full ring-2 ring-white flex items-center justify-center"
+          >
+            <PlusIcon class="w-4 h-4 text-control" />
+          </div>
+        </div>
+
+        <div class="ml-3 min-w-0 flex-1">
+          <div class="rounded-lg border border-gray-200 bg-white overflow-hidden">
+            <div class="px-3 py-2 bg-gray-50">
+              <div class="flex items-center justify-between">
+                <div
+                  class="flex items-center gap-x-2 text-sm min-w-0 flex-wrap"
+                >
+                  <ActionCreator :creator="creatorName" />
+                  <span class="text-gray-600 wrap-break-word min-w-0">{{
+                    createdSentence
+                  }}</span>
+                  <HumanizeTs
+                    :ts="getTimeForPbTimestampProtoEs(createTime, 0) / 1000"
+                    class="text-gray-500"
+                  />
+                </div>
+                <NButton
+                  v-if="allowEdit && !state.isEditing"
+                  quaternary
+                  size="tiny"
+                  @click.prevent="startEdit"
+                >
+                  <PencilIcon class="w-3.5 h-3.5" />
+                </NButton>
+              </div>
+            </div>
+            <div
+              class="px-4 py-3 border-t border-gray-200 text-sm text-gray-700"
+            >
+              <EditableMarkdownContent
+                :content="description"
+                :edit-content="state.editContent"
+                :project="project"
+                :is-editing="state.isEditing"
+                :allow-save="allowSave"
+                :is-saving="state.isSaving"
+                :placeholder="$t('issue.no-description-provided')"
+                @update:edit-content="state.editContent = $event"
+                @save="saveEdit"
+                @cancel="cancelEdit"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+</template>
+
+<script lang="ts" setup>
+import { create } from "@bufbuild/protobuf";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
+import { PencilIcon, PlusIcon } from "lucide-vue-next";
+import { NButton } from "naive-ui";
+import { computed, reactive } from "vue";
+import { useI18n } from "vue-i18n";
+import HumanizeTs from "@/components/misc/HumanizeTs.vue";
+import { usePlanContext } from "@/components/Plan/logic";
+import UserAvatar from "@/components/User/UserAvatar.vue";
+import { issueServiceClientConnect, planServiceClientConnect } from "@/grpcweb";
+import { useCurrentProjectV1, useCurrentUserV1, useUserStore } from "@/store";
+import { getTimeForPbTimestampProtoEs } from "@/types";
+import {
+  IssueSchema,
+  UpdateIssueRequestSchema,
+} from "@/types/proto-es/v1/issue_service_pb";
+import {
+  PlanSchema,
+  UpdatePlanRequestSchema,
+} from "@/types/proto-es/v1/plan_service_pb";
+import { hasProjectPermissionV2 } from "@/utils";
+import ActionCreator from "./ActionCreator.vue";
+import type { DistinctIssueComment } from "./common";
+import EditableMarkdownContent from "./EditableMarkdownContent.vue";
+
+defineProps<{
+  issueComments: DistinctIssueComment[];
+}>();
+
+const { t } = useI18n();
+const { plan, issue } = usePlanContext();
+const currentUser = useCurrentUserV1();
+const userStore = useUserStore();
+const { project } = useCurrentProjectV1();
+
+const state = reactive({
+  isEditing: false,
+  editContent: "",
+  isSaving: false,
+});
+
+const hasPlan = computed(() => !!plan.value.name);
+
+const createdSentence = computed(() => {
+  // In IssueReviewView context, we always show "created issue"
+  // because this view is for managing issues (even though data may come from plan)
+  return t("activity.sentence.created-issue");
+});
+
+const creatorName = computed(() => {
+  return hasPlan.value ? plan.value.creator : (issue.value?.creator ?? "");
+});
+
+const createTime = computed((): Timestamp | undefined => {
+  return hasPlan.value ? plan.value.createTime : issue.value?.createTime;
+});
+
+const creator = computed(() => {
+  return userStore.getUserByIdentifier(creatorName.value);
+});
+
+const description = computed(() => {
+  return hasPlan.value
+    ? plan.value.description || ""
+    : issue.value?.description || "";
+});
+
+const allowEdit = computed(() => {
+  if (currentUser.value.name === creator.value?.name) {
+    return true;
+  }
+  if (hasPlan.value) {
+    return hasProjectPermissionV2(project.value, "bb.plans.update");
+  }
+  return hasProjectPermissionV2(project.value, "bb.issues.update");
+});
+
+const allowSave = computed(() => {
+  return state.editContent !== description.value;
+});
+
+const startEdit = () => {
+  state.editContent = description.value;
+  state.isEditing = true;
+};
+
+const cancelEdit = () => {
+  state.isEditing = false;
+  state.editContent = "";
+};
+
+const saveEdit = async () => {
+  if (!allowSave.value) return;
+
+  try {
+    state.isSaving = true;
+
+    if (hasPlan.value) {
+      const planPatch = create(PlanSchema, {
+        name: plan.value.name,
+        description: state.editContent,
+      });
+      const request = create(UpdatePlanRequestSchema, {
+        plan: planPatch,
+        updateMask: { paths: ["description"] },
+      });
+      const response = await planServiceClientConnect.updatePlan(request);
+      Object.assign(plan.value, response);
+    } else if (issue.value) {
+      const issuePatch = create(IssueSchema, {
+        name: issue.value.name,
+        description: state.editContent,
+      });
+      const request = create(UpdateIssueRequestSchema, {
+        issue: issuePatch,
+        updateMask: { paths: ["description"] },
+      });
+      const response = await issueServiceClientConnect.updateIssue(request);
+      Object.assign(issue.value, response);
+    }
+
+    cancelEdit();
+  } catch (error) {
+    console.error("Failed to update description:", error);
+  } finally {
+    state.isSaving = false;
+  }
+};
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/StageName.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/StageName.vue
@@ -1,0 +1,44 @@
+<template>
+  <router-link
+    :to="link"
+    exact-active-class=""
+    class="font-medium text-main hover:border-b hover:border-b-main"
+  >
+    <EnvironmentV1Name
+      :link="false"
+      :environment="environmentStore.getEnvironmentByName(stage.environment)"
+    />
+  </router-link>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { EnvironmentV1Name } from "@/components/v2";
+import { PROJECT_V1_ROUTE_ROLLOUT_DETAIL_STAGE_DETAIL } from "@/router/dashboard/projectV1";
+import { useEnvironmentV1Store } from "@/store";
+import type { Stage } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  extractProjectResourceName,
+  extractRolloutUID,
+  extractStageUID,
+} from "@/utils";
+
+const props = defineProps<{
+  stage: Stage;
+}>();
+
+const environmentStore = useEnvironmentV1Store();
+
+const link = computed(() => {
+  const { stage } = props;
+
+  return {
+    name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL_STAGE_DETAIL,
+    params: {
+      projectId: extractProjectResourceName(stage.name),
+      rolloutId: extractRolloutUID(stage.name),
+      stageId: extractStageUID(stage.name),
+    },
+  };
+});
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/StatementUpdate.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/StatementUpdate.vue
@@ -1,0 +1,85 @@
+<template>
+  <NButton text type="primary" v-bind="$attrs" @click="showPanel = true">
+    {{ $t("common.view-details") }}
+  </NButton>
+
+  <BBModal
+    v-if="showPanel"
+    :title="$t('common.detail')"
+    header-class="border-0!"
+    container-class="pt-0!"
+    @close="showPanel = false"
+  >
+    <div
+      style="width: calc(100vw - 9rem); height: calc(100vh - 10rem)"
+      class="relative"
+    >
+      <DiffEditor
+        v-if="!isPreparingOldStatement && !isPreparingNewStatement"
+        class="w-full h-full border rounded-md overflow-clip"
+        :original="oldStatement"
+        :modified="newStatement"
+        :readonly="true"
+      />
+      <div
+        v-else
+        class="absolute inset-0 flex flex-col items-center justify-center"
+      >
+        <BBSpin />
+      </div>
+    </div>
+  </BBModal>
+</template>
+
+<script setup lang="ts">
+import { asyncComputed } from "@vueuse/core";
+import { NButton } from "naive-ui";
+import { ref } from "vue";
+import { BBModal, BBSpin } from "@/bbkit";
+import { DiffEditor } from "@/components/MonacoEditor";
+import { useSheetV1Store } from "@/store";
+import { UNKNOWN_ID } from "@/types";
+import { extractSheetUID, getSheetStatement } from "@/utils";
+
+const props = defineProps<{
+  // Format: projects/{project}/sheets/{sheet}
+  oldSheet: string;
+  // Format: projects/{project}/sheets/{sheet}
+  newSheet: string;
+}>();
+
+const showPanel = ref(false);
+
+const prepareStatement = async (sheetName: string) => {
+  if (extractSheetUID(sheetName) === String(UNKNOWN_ID)) return "";
+  // Use any (basic or full) view of sheets here to save data size
+  const sheet = await useSheetV1Store().getOrFetchSheetByName(sheetName);
+  if (!sheet) return "";
+  return getSheetStatement(sheet);
+};
+
+const isPreparingOldStatement = ref(false);
+const isPreparingNewStatement = ref(false);
+
+const oldStatement = asyncComputed(
+  () => {
+    return prepareStatement(props.oldSheet);
+  },
+  "",
+  {
+    evaluating: isPreparingOldStatement,
+    lazy: true,
+  }
+);
+
+const newStatement = asyncComputed(
+  () => {
+    return prepareStatement(props.newSheet);
+  },
+  "",
+  {
+    evaluating: isPreparingNewStatement,
+    lazy: true,
+  }
+);
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/TaskName.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/TaskName.vue
@@ -1,0 +1,38 @@
+<template>
+  <router-link
+    :to="task.name"
+    exact-active-class=""
+    class="font-medium text-main hover:border-b hover:border-b-main"
+  >
+    <span>{{ databaseForTask(project, task).databaseName }}</span>
+    <span class="ml-1 text-control-placeholder">#{{ taskUID }}</span>
+  </router-link>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useProjectV1Store } from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
+import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  databaseForTask,
+  extractProjectResourceName,
+  extractTaskUID,
+} from "@/utils";
+
+const props = defineProps<{
+  plan: Plan;
+  task: Task;
+}>();
+
+const project = computed(() => {
+  return useProjectV1Store().getProjectByName(
+    `${projectNamePrefix}${extractProjectResourceName(props.plan.name)}`
+  );
+});
+
+const taskUID = computed(() => {
+  return extractTaskUID(props.task.name);
+});
+</script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/common.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/common.ts
@@ -1,0 +1,108 @@
+import { getIssueCommentType, IssueCommentType } from "@/store";
+import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
+import { isNullOrUndefined } from "@/utils";
+
+export interface DistinctIssueComment {
+  comment: IssueComment;
+  similar: IssueComment[];
+}
+
+const isSimilarTaskUpdate = (a: IssueComment, b: IssueComment): boolean => {
+  const fromTaskUpdate = a.event?.case === "taskUpdate" ? a.event.value : null;
+  const toTaskUpdate = b.event?.case === "taskUpdate" ? b.event.value : null;
+  if (!fromTaskUpdate || !toTaskUpdate) {
+    return false;
+  }
+  // Group task updates by status or sheet changes, regardless of specific task IDs
+  // This allows grouping of "completed Task d1", "completed Task d2", etc.
+  if (
+    fromTaskUpdate.toSheet &&
+    fromTaskUpdate.toSheet === toTaskUpdate.toSheet
+  ) {
+    return true;
+  }
+  if (
+    fromTaskUpdate.toStatus &&
+    fromTaskUpdate.toStatus === toTaskUpdate.toStatus
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const isSimilarIssueUpdate = (a: IssueComment, b: IssueComment): boolean => {
+  const aIssueUpdate = a.event?.case === "issueUpdate" ? a.event.value : null;
+  const bIssueUpdate = b.event?.case === "issueUpdate" ? b.event.value : null;
+  if (
+    !isNullOrUndefined(aIssueUpdate?.toTitle) &&
+    !isNullOrUndefined(bIssueUpdate?.toTitle)
+  ) {
+    return true;
+  }
+  if (
+    !isNullOrUndefined(aIssueUpdate?.toDescription) &&
+    !isNullOrUndefined(bIssueUpdate?.toDescription)
+  ) {
+    return true;
+  }
+  if (
+    !isNullOrUndefined(aIssueUpdate?.toLabels) &&
+    !isNullOrUndefined(bIssueUpdate?.toLabels)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const isSimilarIssueComment = (
+  a: IssueComment,
+  b: IssueComment
+): boolean => {
+  const aType = getIssueCommentType(a);
+  const bType = getIssueCommentType(b);
+  if (aType !== bType || a.creator !== b.creator) {
+    return false;
+  }
+
+  if (aType === IssueCommentType.TASK_UPDATE) {
+    return isSimilarTaskUpdate(a, b);
+  }
+  if (aType === IssueCommentType.ISSUE_UPDATE) {
+    return isSimilarIssueUpdate(a, b);
+  }
+
+  return false;
+};
+
+export const isUserEditableComment = (comment: IssueComment): boolean => {
+  const commentType = getIssueCommentType(comment);
+  // Always allow editing user comments.
+  if (commentType === IssueCommentType.USER_COMMENT) {
+    return true;
+  }
+  // For approval comments, we allow editing if the comment is not empty.
+  if (commentType === IssueCommentType.APPROVAL && comment.comment !== "") {
+    return true;
+  }
+  return false;
+};
+
+export const groupIssueComments = (
+  comments: IssueComment[]
+): DistinctIssueComment[] => {
+  const result: DistinctIssueComment[] = [];
+  for (const comment of comments) {
+    if (result.length === 0) {
+      result.push({ comment, similar: [] });
+      continue;
+    }
+
+    const prev = result[result.length - 1];
+    if (isSimilarIssueComment(prev.comment, comment)) {
+      prev.similar.push(comment);
+    } else {
+      result.push({ comment, similar: [] });
+    }
+  }
+  return result;
+};

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/index.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/index.ts
@@ -1,0 +1,5 @@
+import IssueCommentView from "./IssueCommentView.vue";
+
+export * from "./common";
+export * from "./useCommentEdit";
+export { IssueCommentView };

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/useCommentEdit.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/useCommentEdit.ts
@@ -1,0 +1,95 @@
+import type { ComputedRef, Ref } from "vue";
+import { computed, reactive } from "vue";
+import { usePlanContext } from "@/components/Plan/logic";
+import { extractUserId, useCurrentUserV1, useIssueCommentStore } from "@/store";
+import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import { hasProjectPermissionV2 } from "@/utils";
+import { isUserEditableComment } from "./common";
+
+interface CommentEditState {
+  editMode: boolean;
+  activeComment?: IssueComment;
+  editContent: string;
+  newComment: string;
+}
+
+export function useCommentEdit(project: Ref<Project> | ComputedRef<Project>) {
+  const { plan } = usePlanContext();
+  const currentUser = useCurrentUserV1();
+  const issueCommentStore = useIssueCommentStore();
+
+  const issueName = computed(() => plan.value.issue);
+
+  const state = reactive<CommentEditState>({
+    editMode: false,
+    editContent: "",
+    newComment: "",
+  });
+
+  const allowCreateComment = computed(() => {
+    return hasProjectPermissionV2(project.value, "bb.issueComments.create");
+  });
+
+  const allowEditComment = (comment: IssueComment): boolean => {
+    if (!isUserEditableComment(comment)) {
+      return false;
+    }
+    if (currentUser.value.email === extractUserId(comment.creator)) {
+      return true;
+    }
+    return hasProjectPermissionV2(project.value, "bb.issueComments.update");
+  };
+
+  const allowUpdateComment = computed(() => {
+    return (
+      !!state.editContent && state.editContent !== state.activeComment?.comment
+    );
+  });
+
+  const startEditComment = (comment: IssueComment) => {
+    state.activeComment = comment;
+    state.editMode = true;
+    state.editContent = comment.comment;
+  };
+
+  const cancelEditComment = () => {
+    state.activeComment = undefined;
+    state.editMode = false;
+    state.editContent = "";
+  };
+
+  const saveEditComment = async () => {
+    if (!state.activeComment || !state.editContent) {
+      return;
+    }
+
+    await issueCommentStore.updateIssueComment({
+      issueCommentName: state.activeComment.name,
+      comment: state.editContent,
+    });
+    cancelEditComment();
+  };
+
+  const createComment = async (comment: string) => {
+    if (!issueName.value) return;
+    await issueCommentStore.createIssueComment({
+      issueName: issueName.value,
+      comment,
+    });
+    state.newComment = "";
+  };
+
+  return {
+    state,
+    issueName,
+    currentUser,
+    allowCreateComment,
+    allowEditComment,
+    allowUpdateComment,
+    startEditComment,
+    cancelEditComment,
+    saveEditComment,
+    createComment,
+  };
+}


### PR DESCRIPTION
- Extract IssueCommentView components into separate files for better organization
- Create useCommentEdit composable for comment editing logic
- Make StageName and TaskName clickable links to their detail pages
- Add task UID display (`#123` format) after task name
- Replace prop drilling with usePlanContext() for cleaner component API
- Refactor ActionIcon with config-driven ICON_CONFIGS map

🤖 Generated with [Claude Code](https://claude.com/claude-code)