### PR TITLE
chore(frontend): force enable new CI/CD layout by default

### DIFF
--- a/frontend/src/composables/useIssueLayoutVersion.ts
+++ b/frontend/src/composables/useIssueLayoutVersion.ts
@@ -6,7 +6,7 @@ const STORAGE_KEY = "bb.issue.layout";
 
 // When releasing a new version as default, increment this number.
 // This helps to reset user preferences to the new default layout.
-const CURRENT_DEFAULT_VERSION = 1;
+const CURRENT_DEFAULT_VERSION = 2;
 
 // Send event to hub.bytebase.com when switching to legacy layout.
 async function trackLayoutSwitch() {


### PR DESCRIPTION
Increment CURRENT_DEFAULT_VERSION to reset users' layout preferences back to the new CI/CD layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)