### PR TITLE
fix(pg): treat COMMENT ON EXTENSION as superuser statement

### DIFF
--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -769,7 +769,7 @@ func IsNonTransactionStatement(stmt string) bool {
 
 func isSuperuserStatement(stmt string) bool {
 	upperCaseStmt := strings.ToUpper(strings.TrimLeftFunc(stmt, unicode.IsSpace))
-	if strings.HasPrefix(upperCaseStmt, "GRANT") || strings.HasPrefix(upperCaseStmt, "CREATE EXTENSION") || strings.HasPrefix(upperCaseStmt, "CREATE EVENT TRIGGER") || strings.HasPrefix(upperCaseStmt, "COMMENT ON EVENT TRIGGER") {
+	if strings.HasPrefix(upperCaseStmt, "GRANT") || strings.HasPrefix(upperCaseStmt, "CREATE EXTENSION") || strings.HasPrefix(upperCaseStmt, "CREATE EVENT TRIGGER") || strings.HasPrefix(upperCaseStmt, "COMMENT ON EVENT TRIGGER") || strings.HasPrefix(upperCaseStmt, "COMMENT ON EXTENSION") {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

- Add `COMMENT ON EXTENSION` to the `isSuperuserStatement()` check so it gets executed with elevated privileges when `UseDatabaseOwner` is enabled

## Problem

After the extension SDL support was added (commit cc1c99d651), DDL tickets involving PostgreSQL extensions started failing with:

```
ERROR: must be owner of extension hstore (SQLSTATE 42501)
```

When users submit a simple extension creation like:
```sql
CREATE EXTENSION IF NOT EXISTS "hstore" WITH SCHEMA "public"
```

Bytebase now generates:
```sql
CREATE EXTENSION IF NOT EXISTS "hstore" WITH SCHEMA "public" VERSION '1.8';
COMMENT ON EXTENSION "hstore" IS 'data type for storing sets of (key, value) pairs';
```

The `COMMENT ON EXTENSION` statement requires extension ownership, which the application user typically doesn't have for built-in extensions.

## Solution

Follow the existing pattern used for similar privileged statements (`CREATE EXTENSION`, `CREATE EVENT TRIGGER`, `COMMENT ON EVENT TRIGGER`). When `UseDatabaseOwner` is enabled (e.g., AWS RDS environments), statements identified by `isSuperuserStatement()` are wrapped with `SET LOCAL ROLE NONE` to temporarily elevate privileges.

## Test plan

- [x] Linter passes (no new issues)
- [x] Build succeeds
- [x] All pg package tests pass
- [x] All extension tests pass

Fixes BYT-8499

🤖 Generated with [Claude Code](https://claude.com/claude-code)