### PR TITLE
feat: restrict email update to admin-only in UI

### DIFF
--- a/frontend/src/views/ProfileDashboard.vue
+++ b/frontend/src/views/ProfileDashboard.vue
@@ -95,7 +95,7 @@
             </dt>
             <dd class="mt-1 text-sm text-main">
               <EmailInput
-                v-if="state.editing"
+                v-if="state.editing && allowEditEmail"
                 v-model:value="state.editingUser!.email"
               />
               <template v-else>
@@ -359,6 +359,11 @@ const allowEdit = computed(() => {
     return false;
   }
   return isSelf.value || hasWorkspacePermissionV2("bb.policies.update");
+});
+
+// Only admins can change email.
+const allowEditEmail = computed(() => {
+  return hasWorkspacePermissionV2("bb.policies.update");
 });
 
 const allowSaveEdit = computed(() => {


### PR DESCRIPTION
## Summary

- Restrict user email updates to admin-only in the profile dashboard
- Regular users can no longer edit their own email addresses
- Only users with `bb.policies.update` permission (admins) can modify email addresses

## Motivation

Allowing users to update their email creates complexity in the data model:
- Requires maintaining user ID to email mappings
- Adds latency from metadata store lookups
- Complicates HA architecture design

Making email immutable (admin-only updates) simplifies the architecture while still allowing admins to handle legitimate email change requests through support.

## Changes

**File modified:** `frontend/src/views/ProfileDashboard.vue`

1. Added `allowEditEmail` computed property checking `bb.policies.update` permission
2. Email input field now only shows when both editing mode AND `allowEditEmail` are true
3. Regular users see email as read-only text even when editing their profile

## Test Plan

- [ ] Verify regular users cannot edit email field when editing their profile
- [ ] Verify admins can still edit email field when editing any user profile
- [ ] Verify other profile fields (name, phone, password) remain editable for regular users
- [ ] Verify email updates by admins still work correctly

## Future Work

A dedicated admin API for email updates will be implemented separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)