### PR TITLE
feat: add unique index on principal email

### DIFF
--- a/backend/migrator/migration/3.13/0019##add_unique_index_on_principal_email.sql
+++ b/backend/migrator/migration/3.13/0019##add_unique_index_on_principal_email.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX idx_principal_unique_email ON principal(email);

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -30,6 +30,8 @@ CREATE TABLE principal (
     profile jsonb NOT NULL DEFAULT '{}'
 );
 
+CREATE UNIQUE INDEX idx_principal_unique_email ON principal(email);
+
 -- Setting
 CREATE TABLE setting (
     id serial PRIMARY KEY,

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.13.18"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.13.19"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add unique constraint on `principal.email` to prevent duplicate email addresses
- Constraint applies to all principals regardless of deletion status
- Migration will fail if duplicates exist in production, requiring manual cleanup before upgrade

## Changes
- Created migration file `backend/migrator/migration/3.13/0019##add_unique_index_on_principal_email.sql`
- Updated `backend/migrator/migration/LATEST.sql` with the unique index
- Updated `TestLatestVersion` in `backend/migrator/migrator_test.go` to expect version 3.13.19

## Test plan
- [x] Verified `TestLatestVersion` test passes
- [x] Verified `TestVersionUnique` test passes
- [ ] Test migration on a database with duplicate emails to ensure it fails appropriately
- [ ] Test migration on a database without duplicate emails to ensure it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)