### PR TITLE
fix(frontend): add events package for pouchdb runtime dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "downloadjs": "1.4.7",
     "elkjs": "^0.11.0",
     "emittery": "^1.2.0",
+    "events": "^3.3.0",
     "file-saver": "^2.0.5",
     "highlight.js": "11.11.1",
     "html-query-plan": "^2.6.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       emittery:
         specifier: ^1.2.0
         version: 1.2.0
+      events:
+        specifier: ^3.3.0
+        version: 3.3.0
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -3575,6 +3578,10 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   evtd@0.2.4:
     resolution: {integrity: sha512-qaeGN5bx63s/AXgQo8gj6fBkxge+OoLddLniox5qtLAEY5HSnuSlISXVPxnSae1dWblvTh4/HoMIB+mbMsvZzw==}
@@ -9714,6 +9721,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  events@3.3.0: {}
 
   evtd@0.2.4: {}
 


### PR DESCRIPTION
The events package provides the Node.js EventEmitter polyfill needed by PouchDB in browser environments. It was incorrectly removed in commit 4f329e04d9 as it was listed as devDependency/peerDependency, but it's actually required at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)