### PR TITLE
feat(frontend): group task run logs by deployment when server restarts

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/SectionContent.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/SectionContent.vue
@@ -1,0 +1,54 @@
+<template>
+  <NVirtualList
+    :items="section.items"
+    :item-size="ITEM_HEIGHT"
+    item-resizable
+    :style="{ maxHeight: `${MAX_VISIBLE_ITEMS * ITEM_HEIGHT}px` }"
+    class="bg-gray-50 border-t border-gray-100"
+  >
+    <template #default="{ item, index }">
+      <div
+        class="flex items-start gap-x-2 py-0.5 hover:bg-gray-100"
+        :class="[indent ? 'px-6' : 'px-3', { 'border-t border-gray-100': index > 0 }]"
+      >
+        <span class="text-gray-300 w-6 text-right shrink-0 tabular-nums">
+          {{ index + 1 }}
+        </span>
+        <span class="text-gray-400 shrink-0 tabular-nums">
+          {{ item.time }}
+        </span>
+        <span
+          v-if="item.relativeTime"
+          class="text-gray-300 shrink-0 tabular-nums"
+        >
+          {{ item.relativeTime }}
+        </span>
+        <span :class="item.levelClass" class="shrink-0">
+          {{ item.levelIndicator }}
+        </span>
+        <span :class="item.detailClass" class="break-all">
+          {{ item.detail }}
+        </span>
+        <span
+          v-if="item.affectedRows !== undefined"
+          class="text-gray-400 shrink-0 ml-auto"
+        >
+          {{ item.affectedRows }} rows
+        </span>
+      </div>
+    </template>
+  </NVirtualList>
+</template>
+
+<script lang="ts" setup>
+import { NVirtualList } from "naive-ui";
+import type { Section } from "./types";
+
+const ITEM_HEIGHT = 20;
+const MAX_VISIBLE_ITEMS = 10;
+
+defineProps<{
+  section: Section;
+  indent?: boolean;
+}>();
+</script>

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/SectionHeader.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/SectionHeader.vue
@@ -1,0 +1,40 @@
+<template>
+  <div
+    class="flex items-center gap-x-2 py-1.5 bg-white hover:bg-gray-50 cursor-pointer select-none"
+    :class="indent ? 'px-6' : 'px-3'"
+    @click="$emit('toggle')"
+  >
+    <component
+      :is="isExpanded ? ChevronDownIcon : ChevronRightIcon"
+      class="w-3.5 h-3.5 text-gray-400 shrink-0"
+    />
+    <component
+      :is="section.statusIcon"
+      class="w-3.5 h-3.5 shrink-0"
+      :class="[section.statusClass, { 'animate-spin': section.status === 'running' }]"
+    />
+    <span class="text-gray-700">{{ section.label }}</span>
+    <span v-if="section.entryCount > 1" class="text-gray-400">
+      ({{ section.entryCount }})
+    </span>
+    <span class="flex-1" />
+    <span v-if="section.duration" class="text-gray-500 tabular-nums">
+      {{ section.duration }}
+    </span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-vue-next";
+import type { Section } from "./types";
+
+defineProps<{
+  section: Section;
+  isExpanded: boolean;
+  indent?: boolean;
+}>();
+
+defineEmits<{
+  toggle: [];
+}>();
+</script>

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/types.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/types.ts
@@ -30,3 +30,8 @@ export interface EntryGroup {
   type: TaskRunLogEntry_Type;
   entries: import("@/types/proto-es/v1/rollout_service_pb").TaskRunLogEntry[];
 }
+
+export interface DeployGroup {
+  deployId: string;
+  sections: Section[];
+}

--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/utils.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/utils.ts
@@ -104,3 +104,42 @@ export const groupEntriesByType = (
 
   return groups;
 };
+
+// Get unique deploy IDs from entries, preserving order of first appearance
+export const getUniqueDeployIds = (entries: TaskRunLogEntry[]): string[] => {
+  if (!entries.length) return [];
+
+  const sortedEntries = [...entries].sort((a, b) => {
+    return getTimestampMs(a.logTime) - getTimestampMs(b.logTime);
+  });
+
+  const seen = new Set<string>();
+  const deployIds: string[] = [];
+
+  for (const entry of sortedEntries) {
+    const deployId = entry.deployId || "";
+    if (deployId && !seen.has(deployId)) {
+      seen.add(deployId);
+      deployIds.push(deployId);
+    }
+  }
+
+  return deployIds;
+};
+
+// Group entries by deploy ID, maintaining time order within each group
+export const groupEntriesByDeploy = (
+  entries: TaskRunLogEntry[]
+): Map<string, TaskRunLogEntry[]> => {
+  const result = new Map<string, TaskRunLogEntry[]>();
+
+  for (const entry of entries) {
+    const deployId = entry.deployId || "unknown";
+    if (!result.has(deployId)) {
+      result.set(deployId, []);
+    }
+    result.get(deployId)!.push(entry);
+  }
+
+  return result;
+};

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -387,6 +387,10 @@
       "backing-up": "backing up...",
       "retry-attempt": "attempt {current}/{max}",
       "computing": "computing..."
+    },
+    "log-viewer": {
+      "multiple-deploys-notice": "Server restart detected during execution. Logs are grouped by deployment.",
+      "deployment-n": "Deployment #{n}"
     }
   },
   "banner": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -387,6 +387,10 @@
       "backing-up": "haciendo copia de seguridad...",
       "retry-attempt": "intento {current}/{max}",
       "computing": "computación..."
+    },
+    "log-viewer": {
+      "multiple-deploys-notice": "Se detectó un reinicio del servidor durante la ejecución. Los registros están agrupados por despliegue.",
+      "deployment-n": "Despliegue #{n}"
     }
   },
   "banner": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -387,6 +387,10 @@
       "backing-up": "バックアップ中...",
       "retry-attempt": "試行 {current}/{max}",
       "computing": "コンピューティング..."
+    },
+    "log-viewer": {
+      "multiple-deploys-notice": "実行中にサーバーの再起動が検出されました。ログはデプロイごとにグループ化されています。",
+      "deployment-n": "デプロイ #{n}"
     }
   },
   "banner": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -387,6 +387,10 @@
       "backing-up": "đang sao lưu...",
       "retry-attempt": "nỗ lực {current}/{max}",
       "computing": "tính toán..."
+    },
+    "log-viewer": {
+      "multiple-deploys-notice": "Phát hiện khởi động lại máy chủ trong quá trình thực thi. Nhật ký được nhóm theo triển khai.",
+      "deployment-n": "Triển khai #{n}"
     }
   },
   "banner": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -387,6 +387,10 @@
       "backing-up": "备份中...",
       "retry-attempt": "第 {current}/{max} 次尝试",
       "computing": "计算中..."
+    },
+    "log-viewer": {
+      "multiple-deploys-notice": "检测到执行期间服务重启，日志按部署分组显示。",
+      "deployment-n": "部署 #{n}"
     }
   },
   "banner": {


### PR DESCRIPTION
When a task run spans multiple server deployments (e.g., server restart during execution), logs are now grouped by deployment ID with a visual indicator. Earlier deployments show error status since they were interrupted.

- Add DeployGroup type and deploy grouping utilities
- Extract SectionHeader and SectionContent into reusable components
- Show warning banner when multiple deployments detected
- Mark interrupted (non-latest) deployments as error status

<img width="2240" height="1106" alt="image" src="https://github.com/user-attachments/assets/eea71e3e-72d7-4f27-82f7-684209dfafec" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)