### PR TITLE
fix: correct SQL review payload migration for STATEMENT_QUERY_MINIMUM_PLAN_LEVEL and COLUMN_CURRENT_TIME_COUNT_LIMIT

### DIFF
--- a/frontend/src/types/sql-review.dev.yaml
+++ b/frontend/src/types/sql-review.dev.yaml
@@ -419,8 +419,7 @@ ruleList:
   - type: STATEMENT_QUERY_MINIMUM_PLAN_LEVEL
     level: WARNING
     payload:
-      required: true
-      maxLength: 64
+      level: INDEX
     engine: MYSQL
   - type: STATEMENT_WHERE_MAXIMUM_LOGICAL_OPERATOR_COUNT
     level: WARNING
@@ -1063,23 +1062,15 @@ ruleList:
     engine: MARIADB
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: MYSQL
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: TIDB
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: OCEANBASE
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: MARIADB
   - type: COLUMN_REQUIRE_DEFAULT
     level: WARNING

--- a/frontend/src/types/sql-review.prod.yaml
+++ b/frontend/src/types/sql-review.prod.yaml
@@ -460,8 +460,7 @@ ruleList:
   - type: STATEMENT_QUERY_MINIMUM_PLAN_LEVEL
     level: WARNING
     payload:
-      required: true
-      maxLength: 64
+      level: INDEX
     engine: MYSQL
   - type: STATEMENT_WHERE_MAXIMUM_LOGICAL_OPERATOR_COUNT
     level: WARNING
@@ -1143,23 +1142,15 @@ ruleList:
     engine: MARIADB
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: MYSQL
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: TIDB
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: OCEANBASE
   - type: COLUMN_CURRENT_TIME_COUNT_LIMIT
     level: WARNING
-    payload:
-      number: 1000
     engine: MARIADB
   - type: COLUMN_REQUIRE_DEFAULT
     level: WARNING


### PR DESCRIPTION
## Summary

This PR fixes critical bugs in the SQL review rule payload migration (`0018##migrate_review_config_payload_to_proto.sql`) where several rules had incorrect payload types that didn't match their advisor implementations.

## Background

The migration `3.13/0018##migrate_review_config_payload_to_proto.sql` was created to migrate SQL review rule payloads from flat JSON strings to typed proto format. However, the migration contained several errors where rules were being migrated to the wrong payload types (e.g., `numberPayload` vs `stringPayload`) or being migrated when they should have no payload at all.

These errors occurred because:
1. The migration was written based on assumptions about payload types without verifying against actual advisor implementations
2. Some frontend YAML files had incorrect payload structures that were never valid (e.g., `STATEMENT_QUERY_MINIMUM_PLAN_LEVEL` using comment convention structure)
3. No systematic verification was done to compare migration logic against advisor code

## Issues Fixed

### 1. STATEMENT_QUERY_MINIMUM_PLAN_LEVEL ❌ CRITICAL

**Problem:**
- Migration incorrectly categorized this as a **number rule** (line 33)
- Advisor expects **`stringPayload`** ([code](backend/plugin/advisor/mysql/rule_statement_query_minimum_plan_level.go#L43-L49))
- Frontend YAML files had wrong structure inherited from comment conventions:
  ```yaml
  # WRONG - Never valid
  payload:
    required: true
    maxLength: 64
  ```

**Fix:**
- Migration now correctly uses `stringPayload` with `COALESCE` to handle missing "level" field
- Updated YAML files to correct structure:
  ```yaml
  # CORRECT
  payload:
    level: INDEX  # Valid: ALL, INDEX, RANGE, REF, EQ_REF, CONST
  ```

**Evidence:**
```go
// backend/plugin/advisor/mysql/rule_statement_query_minimum_plan_level.go:43-49
stringPayload := checkCtx.Rule.GetStringPayload()
if stringPayload == nil {
    return nil, errors.New("string_payload is required for this rule")
}
rule := NewStatementQueryMinumumPlanLevelRule(ctx, level, checkCtx.Rule.Type.String(), 
    checkCtx.Driver, convertExplainTypeFromString(strings.ToUpper(stringPayload.Value)))
```

### 2. STATEMENT_MAX_EXECUTION_TIME ❌ WRONG PAYLOAD

**Problem:**
- Migration incorrectly included this in **number rules** (line 33)
- Advisor **doesn't use any payload** ([code](backend/plugin/advisor/mysql/rule_stmt_max_execution_time.go#L31-49))

**Fix:**
- Removed from number rules section
- Falls through to default case (removes payload field)

**Evidence:**
```go
// backend/plugin/advisor/mysql/rule_stmt_max_execution_time.go:31-49
func (*MaxExecutionTimeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
    // No GetNumberPayload() or any payload extraction
    rule := NewMaxExecutionTimeRule(level, checkCtx.Rule.Type.String(), systemVariable)
    // ...
}
```

### 3. COLUMN_CURRENT_TIME_COUNT_LIMIT ❌ WRONG PAYLOAD

**Problem:**
- Migration incorrectly included this in **number rules** (line 35)
- Advisor **doesn't use any payload** - uses hardcoded limits ([code](backend/plugin/advisor/mysql/rule_column_current_time_count_limit.go#L20-23,L40-53))
- Frontend YAML files incorrectly had `payload.number: 1000` for 4 engines

**Fix:**
- Removed from number rules section in migration
- Removed incorrect payload from `sql-review.prod.yaml` (4 occurrences)
- Removed incorrect payload from `sql-review.dev.yaml` (4 occurrences)

**Evidence:**
```go
// backend/plugin/advisor/mysql/rule_column_current_time_count_limit.go:20-23
const (
    maxDefaultCurrentTimeColumCount   = 2  // Hardcoded, not from payload
    maxOnUpdateCurrentTimeColumnCount = 1  // Hardcoded, not from payload
)

// Lines 40-53: No GetNumberPayload() call anywhere
func (*ColumnCurrentTimeCountLimitAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
    rule := NewColumnCurrentTimeCountLimitRule(level, checkCtx.Rule.Type.String())
    // No payload extraction
}
```

### 4. NAMING_FULLY_QUALIFIED ❌ UNNECESSARY HANDLING

**Problem:**
- Migration had special case for string handling (lines 60-67)
- Advisor **doesn't use any payload** ([code](backend/plugin/advisor/pg/advisor_naming_fully_qualified.go#L32-61))

**Fix:**
- Removed special case
- Falls through to default case (removes payload field)

**Evidence:**
```go
// backend/plugin/advisor/pg/advisor_naming_fully_qualified.go:32-61
func (*FullyQualifiedObjectNameAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
    // No payload extraction at all
    rule := &fullyQualifiedObjectNameRule{
        BaseRule: BaseRule{
            level: level,
            title: checkCtx.Rule.Type.String(),
        },
        // ...
    }
}
```

## Verification Process

A comprehensive audit was performed comparing the migration against **all advisor implementations**:

```bash
# Verified all rule types against their advisor code
grep -r "GetNumberPayload\|GetStringPayload\|GetStringArrayPayload\|..." backend/plugin/advisor
```

**Results:**
- ✅ **Naming rules** (8 rules): All use `GetNamingPayload()`
- ✅ **Number rules** (13 rules): All use `GetNumberPayload()`
- ✅ **String array rules** (9 rules): All use `GetStringArrayPayload()`
- ✅ **Comment convention rules** (2 rules): All use `GetCommentConventionPayload()`
- ✅ **Naming case rule** (1 rule): Uses `GetNamingCasePayload()`
- ✅ **String rule** (1 rule): `STATEMENT_QUERY_MINIMUM_PLAN_LEVEL` uses `GetStringPayload()`
- ✅ **No payload rules** (3 rules): `NAMING_FULLY_QUALIFIED`, `STATEMENT_MAX_EXECUTION_TIME`, `COLUMN_CURRENT_TIME_COUNT_LIMIT`

## Files Changed

### Migration
- `backend/migrator/migration/3.13/0018##migrate_review_config_payload_to_proto.sql`
  - Removed `STATEMENT_QUERY_MINIMUM_PLAN_LEVEL` from number rules
  - Added string rule section for `STATEMENT_QUERY_MINIMUM_PLAN_LEVEL` with COALESCE
  - Removed `STATEMENT_MAX_EXECUTION_TIME` from number rules
  - Removed `COLUMN_CURRENT_TIME_COUNT_LIMIT` from number rules
  - Removed `NAMING_FULLY_QUALIFIED` special case

### Frontend YAML
- `frontend/src/types/sql-review.prod.yaml`
  - Fixed `STATEMENT_QUERY_MINIMUM_PLAN_LEVEL` payload structure (line 460)
  - Removed payloads from 4 `COLUMN_CURRENT_TIME_COUNT_LIMIT` entries (lines 1144-1163)

- `frontend/src/types/sql-review.dev.yaml`
  - Fixed `STATEMENT_QUERY_MINIMUM_PLAN_LEVEL` payload structure (line 419)
  - Removed payloads from 4 `COLUMN_CURRENT_TIME_COUNT_LIMIT` entries (lines 1064-1082)

- `frontend/src/types/sql-review-schema.yaml` - Already correct, no changes needed
- `frontend/src/types/sql-review.sample.yaml` - Already correct, no changes needed

## Impact

**Without this fix:**
- `STATEMENT_QUERY_MINIMUM_PLAN_LEVEL` would fail at runtime with "number_payload is required" error
- `STATEMENT_MAX_EXECUTION_TIME` would have unnecessary payload data
- `COLUMN_CURRENT_TIME_COUNT_LIMIT` would have unnecessary payload data (ignoring configured values)
- `NAMING_FULLY_QUALIFIED` would have unnecessary payload data

**With this fix:**
- All rules now correctly align with their advisor implementations
- Migration properly handles legacy incorrect data
- Frontend configurations follow correct schemas

## Testing

Verified by:
1. Comparing migration logic against every advisor implementation
2. Checking schema definitions in `sql-review-schema.yaml`
3. Confirming frontend TypeScript code expectations in `sqlReview.ts`
4. Cross-referencing proto definitions in `review_config.proto`

## Related Files

For reference, the advisor implementations checked:
- `backend/plugin/advisor/mysql/rule_statement_query_minimum_plan_level.go`
- `backend/plugin/advisor/mysql/rule_stmt_max_execution_time.go`
- `backend/plugin/advisor/mysql/rule_column_current_time_count_limit.go`
- `backend/plugin/advisor/pg/advisor_naming_fully_qualified.go`