### PR TITLE
fix: rename approval approver principalId to principal and migrate to email format

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -746,8 +746,8 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 	}
 
 	payload.Approval.Approvers = append(payload.Approval.Approvers, &storepb.IssuePayloadApproval_Approver{
-		Status:      storepb.IssuePayloadApproval_Approver_APPROVED,
-		PrincipalId: int32(user.ID),
+		Status:    storepb.IssuePayloadApproval_Approver_APPROVED,
+		Principal: common.FormatUserEmail(user.Email),
 	})
 
 	approved, err := utils.CheckApprovalApproved(payload.Approval)
@@ -929,8 +929,8 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("cannot reject because the user does not have the required permission"))
 	}
 	payload.Approval.Approvers = append(payload.Approval.Approvers, &storepb.IssuePayloadApproval_Approver{
-		Status:      storepb.IssuePayloadApproval_Approver_REJECTED,
-		PrincipalId: int32(user.ID),
+		Status:    storepb.IssuePayloadApproval_Approver_REJECTED,
+		Principal: common.FormatUserEmail(user.Email),
 	})
 
 	issue, err = s.store.UpdateIssue(ctx, issue.UID, &store.UpdateIssueMessage{

--- a/backend/api/v1/issue_service_converter.go
+++ b/backend/api/v1/issue_service_converter.go
@@ -117,12 +117,10 @@ func (s *IssueService) convertToIssue(ctx context.Context, issue *store.IssueMes
 		issueV1.ApprovalTemplate = convertToApprovalTemplate(template)
 	}
 	for _, approver := range approval.GetApprovers() {
-		convertedApprover := &v1pb.Issue_Approver{Status: v1pb.Issue_Approver_Status(approver.GetStatus())}
-		user, err := s.store.GetUserByID(ctx, int(approver.GetPrincipalId()))
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to find user by id %v", approver.GetPrincipalId())
+		convertedApprover := &v1pb.Issue_Approver{
+			Status:    v1pb.Issue_Approver_Status(approver.GetStatus()),
+			Principal: approver.GetPrincipal(),
 		}
-		convertedApprover.Principal = fmt.Sprintf("users/%s", user.Email)
 		issueV1.Approvers = append(issueV1.Approvers, convertedApprover)
 	}
 	issueV1.ApprovalStatus = computeApprovalStatus(approval)

--- a/backend/generated-go/store/approval.pb.go
+++ b/backend/generated-go/store/approval.pb.go
@@ -266,8 +266,9 @@ type IssuePayloadApproval_Approver struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The current approval status.
 	Status IssuePayloadApproval_Approver_Status `protobuf:"varint,1,opt,name=status,proto3,enum=bytebase.store.IssuePayloadApproval_Approver_Status" json:"status,omitempty"`
-	// The ID of the principal who is the approver.
-	PrincipalId   int32 `protobuf:"varint,2,opt,name=principal_id,json=principalId,proto3" json:"principal_id,omitempty"`
+	// The principal who is the approver.
+	// Format: users/{email}.
+	Principal     string `protobuf:"bytes,2,opt,name=principal,proto3" json:"principal,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -309,26 +310,26 @@ func (x *IssuePayloadApproval_Approver) GetStatus() IssuePayloadApproval_Approve
 	return IssuePayloadApproval_Approver_STATUS_UNSPECIFIED
 }
 
-func (x *IssuePayloadApproval_Approver) GetPrincipalId() int32 {
+func (x *IssuePayloadApproval_Approver) GetPrincipal() string {
 	if x != nil {
-		return x.PrincipalId
+		return x.Principal
 	}
-	return 0
+	return ""
 }
 
 var File_store_approval_proto protoreflect.FileDescriptor
 
 const file_store_approval_proto_rawDesc = "" +
 	"\n" +
-	"\x14store/approval.proto\x12\x0ebytebase.store\"\xf7\x03\n" +
+	"\x14store/approval.proto\x12\x0ebytebase.store\"\xf2\x03\n" +
 	"\x14IssuePayloadApproval\x12M\n" +
 	"\x11approval_template\x18\x01 \x01(\v2 .bytebase.store.ApprovalTemplateR\x10approvalTemplate\x12K\n" +
 	"\tapprovers\x18\x02 \x03(\v2-.bytebase.store.IssuePayloadApproval.ApproverR\tapprovers\x122\n" +
 	"\x15approval_finding_done\x18\x03 \x01(\bR\x13approvalFindingDone\x124\n" +
-	"\x16approval_finding_error\x18\x04 \x01(\tR\x14approvalFindingError\x1a\xc6\x01\n" +
+	"\x16approval_finding_error\x18\x04 \x01(\tR\x14approvalFindingError\x1a\xc1\x01\n" +
 	"\bApprover\x12L\n" +
-	"\x06status\x18\x01 \x01(\x0e24.bytebase.store.IssuePayloadApproval.Approver.StatusR\x06status\x12!\n" +
-	"\fprincipal_id\x18\x02 \x01(\x05R\vprincipalId\"I\n" +
+	"\x06status\x18\x01 \x01(\x0e24.bytebase.store.IssuePayloadApproval.Approver.StatusR\x06status\x12\x1c\n" +
+	"\tprincipal\x18\x02 \x01(\tR\tprincipal\"I\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\v\n" +
 	"\aPENDING\x10\x01\x12\f\n" +

--- a/backend/generated-go/store/approval_equal.pb.go
+++ b/backend/generated-go/store/approval_equal.pb.go
@@ -13,7 +13,7 @@ func (x *IssuePayloadApproval_Approver) Equal(y *IssuePayloadApproval_Approver) 
 	if x.Status != y.Status {
 		return false
 	}
-	if x.PrincipalId != y.PrincipalId {
+	if x.Principal != y.Principal {
 		return false
 	}
 	return true

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -654,7 +654,7 @@ Approver represents a user who can approve or reject an issue.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | status | [IssuePayloadApproval.Approver.Status](#bytebase-store-IssuePayloadApproval-Approver-Status) |  | The current approval status. |
-| principal_id | [int32](#int32) |  | The ID of the principal who is the approver. |
+| principal | [string](#string) |  | The principal who is the approver. Format: users/{email}. |
 
 
 

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -2294,10 +2294,11 @@ False means the backend is still searching for matching templates. </p></td>
                 </tr>
               
                 <tr>
-                  <td>principal_id</td>
-                  <td><a href="#int32">int32</a></td>
+                  <td>principal</td>
+                  <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>The ID of the principal who is the approver. </p></td>
+                  <td><p>The principal who is the approver.
+Format: users/{email}. </p></td>
                 </tr>
               
             </tbody>

--- a/proto/store/store/approval.proto
+++ b/proto/store/store/approval.proto
@@ -21,8 +21,9 @@ message IssuePayloadApproval {
     // The current approval status.
     Status status = 1;
 
-    // The ID of the principal who is the approver.
-    int32 principal_id = 2;
+    // The principal who is the approver.
+    // Format: users/{email}.
+    string principal = 2;
   }
 
   // The approval template being used for this issue.


### PR DESCRIPTION
## Summary

Fixes the proto unmarshaling error that causes startup failures after the user migration in #18425.

**Error:**
```
proto: invalid value for int32 field principalId: "users/a@a.com"
```

**Root cause:** The user migration commit converted `principalId` values from numeric IDs to email format in the database, but forgot to update the proto definition from `int32` to `string` and rename the field.

## Changes

### Proto Definition
- Renamed field from `principal_id` (int32) to `principal` (string)
- Added format comment: `Format: users/{email}`

### Migration SQL Enhancement
Enhanced `0021##migrate_user_id_to_email.sql` to handle three cases:
1. **Numeric principal IDs** → Convert to `users/{email}` format AND rename key
2. **Already email format** → Just rename key from `principalId` to `principal`
3. **Already has principal field** → Keep unchanged

### UpdateUserEmail() 
Added section to update approval approvers when user emails change, following the same pattern as GrantRequest, IAM policies, and user groups.

### Go Code
- Updated `issue_service.go` - Use `Principal` field with email format when approving/rejecting
- Updated `issue_service_converter.go` - Simplified to use `GetPrincipal()` directly
- Regenerated proto code

## Test Plan

- [x] Backend builds successfully
- [x] golangci-lint passes (0 issues)
- [x] Migration SQL handles all three data states correctly
- [ ] Verify startup succeeds with existing data
- [ ] Test approval flow creates correct format
- [ ] Test user email update cascades to approvers

## Migration Safety

The migration SQL is idempotent and safe to run multiple times. It uses `jsonb_build_object` to rebuild approver objects, ensuring clean field renaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)