### PR TITLE
fix: correct field path in SQL review rules migration

### DIFF
--- a/backend/migrator/migration/3.13/0007##plan_check_ddl_dml_consolidation.sql
+++ b/backend/migrator/migration/3.13/0007##plan_check_ddl_dml_consolidation.sql
@@ -16,10 +16,10 @@ WHERE config ? 'changeDatabaseType';
 UPDATE review_config
 SET payload = jsonb_set(
   payload,
-  '{rules}',
+  '{sqlReviewRules}',
   COALESCE(
     (SELECT jsonb_agg(r)
-     FROM jsonb_array_elements(payload->'rules') r
+     FROM jsonb_array_elements(payload->'sqlReviewRules') r
      WHERE r->>'type' NOT IN (
        'statement.disallow-mix-in-ddl',
        'statement.disallow-mix-in-dml'
@@ -27,5 +27,5 @@ SET payload = jsonb_set(
     '[]'::jsonb
   )
 )
-WHERE payload->'rules' IS NOT NULL
-  AND jsonb_array_length(payload->'rules') > 0;
+WHERE payload->'sqlReviewRules' IS NOT NULL
+  AND jsonb_array_length(payload->'sqlReviewRules') > 0;


### PR DESCRIPTION
## Summary

This PR fixes a bug in migration `3.13/0007` where it used the wrong field path causing deprecated SQL review rule types to not be removed, which leads to `TYPE_UNSPECIFIED` errors.

## Root Cause

Migration `0007##plan_check_ddl_dml_consolidation.sql` attempted to remove deprecated rules:
- `statement.disallow-mix-in-ddl`
- `statement.disallow-mix-in-dml`

However, it used incorrect field path `payload->'rules'` instead of `payload->'sqlReviewRules'`. This caused:

1. The migration silently failed (WHERE clause never matched)
2. Deprecated rules remained in the database
3. These old rule types use lowercase-with-dots naming which doesn't match proto enum format (UPPER_SNAKE_CASE)
4. When protojson unmarshals these invalid types, they default to `TYPE_UNSPECIFIED` (enum value 0)
5. Advisor system has no registered advisor for `TYPE_UNSPECIFIED`
6. Result: **"advisor: unknown advisor TYPE_UNSPECIFIED for MYSQL" errors**

## Fix

Changed all occurrences of `'rules'` to `'sqlReviewRules'` in the migration (4 places):
- `'{rules}'` → `'{sqlReviewRules}'`
- `payload->'rules'` → `payload->'sqlReviewRules'` (3 places)

## Impact

**Fresh installations:** Will not have the bad data ✅

**Existing databases:** Already ran this migration with the bug, so they still have the bad data. These databases will need manual cleanup:

```sql
UPDATE review_config
SET payload = jsonb_set(
  payload,
  '{sqlReviewRules}',
  COALESCE(
    (SELECT jsonb_agg(r)
     FROM jsonb_array_elements(payload->'sqlReviewRules') r
     WHERE r->>'type' NOT IN (
       'statement.disallow-mix-in-ddl',
       'statement.disallow-mix-in-dml'
     )),
    '[]'::jsonb
  )
)
WHERE payload->'sqlReviewRules' IS NOT NULL
  AND jsonb_array_length(payload->'sqlReviewRules') > 0;
```

## Test Plan

- ✅ Verified migration syntax is correct
- ✅ Tested on local database - removes 10 invalid rules (362 → 352)
- ✅ Confirmed `TestLatestVersion` passes
- ✅ Verified TYPE_UNSPECIFIED error is resolved after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)