### PR TITLE
fix: issue comment shows unknown user and comment button not working

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueDescriptionComment.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueDescriptionComment.vue
@@ -87,7 +87,7 @@ import {
   PlanSchema,
   UpdatePlanRequestSchema,
 } from "@/types/proto-es/v1/plan_service_pb";
-import { hasProjectPermissionV2 } from "@/utils";
+import { hasProjectPermissionV2, isValidPlanName } from "@/utils";
 import ActionCreator from "./ActionCreator.vue";
 import type { DistinctIssueComment } from "./common";
 import EditableMarkdownContent from "./EditableMarkdownContent.vue";
@@ -108,7 +108,7 @@ const state = reactive({
   isSaving: false,
 });
 
-const hasPlan = computed(() => !!plan.value.name);
+const hasPlan = computed(() => isValidPlanName(plan.value.name));
 
 const createdSentence = computed(() => {
   // In IssueReviewView context, we always show "created issue"

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/useCommentEdit.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/useCommentEdit.ts
@@ -15,11 +15,11 @@ interface CommentEditState {
 }
 
 export function useCommentEdit(project: Ref<Project> | ComputedRef<Project>) {
-  const { plan } = usePlanContext();
+  const { plan, issue } = usePlanContext();
   const currentUser = useCurrentUserV1();
   const issueCommentStore = useIssueCommentStore();
 
-  const issueName = computed(() => plan.value.issue);
+  const issueName = computed(() => issue.value?.name || plan.value.issue);
 
   const state = reactive<CommentEditState>({
     editMode: false,


### PR DESCRIPTION

- Use isValidPlanName() instead of checking plan.value.name truthiness to properly detect empty plans for grant request issues
- Get issue name from issue context first, falling back to plan reference, to enable commenting on issues without associated plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)