### PR TITLE
fix: update grant request to use email-based user lookup

### DIFF
--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 	"unicode"
 
@@ -88,16 +87,16 @@ func UpdateProjectPolicyFromGrantIssue(ctx context.Context, stores *store.Store,
 	}
 	updated := false
 
-	userID, err := strconv.Atoi(strings.TrimPrefix(grantRequest.User, "users/"))
-	if err != nil {
-		return err
+	email := strings.TrimPrefix(grantRequest.User, "users/")
+	if email == "" {
+		return errors.New("invalid empty user identifier")
 	}
-	newUser, err := stores.GetUserByID(ctx, userID)
+	newUser, err := stores.GetUserByEmail(ctx, email)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to find user %s", email)
 	}
 	if newUser == nil {
-		return connect.NewError(connect.CodeInternal, errors.Errorf("user %v not found", userID))
+		return connect.NewError(connect.CodeInternal, errors.Errorf("user %s not found", email))
 	}
 	for _, binding := range policyMessage.Policy.Bindings {
 		if binding.Role != grantRequest.Role {


### PR DESCRIPTION
## Summary

Fixes the `strconv.Atoi: parsing "c@c.com": invalid syntax` error in the approval runner when processing grant requests.

After the user migration to email format in commit 128cc62870, the `UpdateProjectPolicyFromGrantIssue` function was still trying to parse `grantRequest.User` as an integer ID, but it now contains email addresses in `users/{email}` format.

## Changes

- Updated `backend/utils/utils.go` to use `GetUserByEmail()` instead of `GetUserByID()`
- Extract email directly from `users/{email}` format without attempting integer parsing
- Removed unused `strconv` import
- Aligned with existing patterns used in `backend/store/plan.go:434` and `backend/api/v1/issue_service.go:387`

## Test plan

- [x] Code formatted with `gofmt`
- [x] Linter passes with 0 issues
- [ ] Verify approval runner no longer throws parsing errors for grant requests
- [ ] Test grant request approval flow with email-based user identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)