### PR TITLE
chore: change skip task comment label to reason

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
@@ -176,7 +176,6 @@
           </div>
         </div>
 
-        <!-- shouldShowComment: only show if issue is available -->
         <div
           v-if="shouldShowComment"
           class="flex flex-col gap-y-1 shrink-0"


### PR DESCRIPTION
Update the task rollout action panel to use "Reason" instead of "Comment" for the input field label, and adjust styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)