### PR TITLE
fix: online migration rule check failure

### DIFF
--- a/backend/api/v1/review_config_service.go
+++ b/backend/api/v1/review_config_service.go
@@ -371,7 +371,8 @@ func validateSQLReviewRule(rule *v1pb.SQLReviewRule) error {
 		storepb.SQLReviewRule_INDEX_TOTAL_NUMBER_LIMIT,
 		storepb.SQLReviewRule_TABLE_TEXT_FIELDS_TOTAL_LENGTH,
 		storepb.SQLReviewRule_TABLE_LIMIT_SIZE,
-		storepb.SQLReviewRule_SYSTEM_COMMENT_LENGTH:
+		storepb.SQLReviewRule_SYSTEM_COMMENT_LENGTH,
+		storepb.SQLReviewRule_ADVICE_ONLINE_MIGRATION:
 		payload := rule.GetNumberPayload()
 		if payload == nil {
 			return errors.Errorf("rule %s requires number payload", ruleType)
@@ -504,7 +505,6 @@ func validateSQLReviewRule(rule *v1pb.SQLReviewRule) error {
 		storepb.SQLReviewRule_SYSTEM_EVENT_DISALLOW_CREATE,
 		storepb.SQLReviewRule_SYSTEM_VIEW_DISALLOW_CREATE,
 		storepb.SQLReviewRule_SYSTEM_FUNCTION_DISALLOW_CREATE,
-		storepb.SQLReviewRule_ADVICE_ONLINE_MIGRATION,
 		storepb.SQLReviewRule_BUILTIN_PRIOR_BACKUP_CHECK:
 		// These rules should not have any payload
 		if rule.Payload != nil {

--- a/backend/migrator/migration/3.13/0018##migrate_review_config_payload_to_proto.sql
+++ b/backend/migrator/migration/3.13/0018##migrate_review_config_payload_to_proto.sql
@@ -33,7 +33,8 @@ BEGIN
                             'COLUMN_MAXIMUM_CHARACTER_LENGTH', 'COLUMN_MAXIMUM_VARCHAR_LENGTH',
                             'COLUMN_AUTO_INCREMENT_INITIAL_VALUE',
                             'INDEX_KEY_NUMBER_LIMIT', 'INDEX_TOTAL_NUMBER_LIMIT',
-                            'TABLE_TEXT_FIELDS_TOTAL_LENGTH', 'TABLE_LIMIT_SIZE', 'SYSTEM_COMMENT_LENGTH'
+                            'TABLE_TEXT_FIELDS_TOTAL_LENGTH', 'TABLE_LIMIT_SIZE', 'SYSTEM_COMMENT_LENGTH',
+                            'ADVICE_ONLINE_MIGRATION'
                         ) AND rule->>'payload' IS NOT NULL AND rule->>'payload' != '' AND rule->>'payload' != 'null' AND rule->>'payload' != '{}'
                         THEN jsonb_set(rule, '{numberPayload}', (rule->>'payload')::jsonb) - 'payload'
 
@@ -65,8 +66,83 @@ BEGIN
                             jsonb_build_object('value', COALESCE((rule->>'payload')::jsonb->>'level', 'INDEX'))
                         ) - 'payload'
 
-                        -- Rules with empty/null payload or no payload (like NAMING_FULLY_QUALIFIED,
-                        -- STATEMENT_MAX_EXECUTION_TIME, COLUMN_CURRENT_TIME_COUNT_LIMIT) - just remove payload field
+                        -- Rules with empty/null payload or no payload.
+                        -- Full list:
+                        -- TYPE_UNSPECIFIED
+                        -- ENGINE_MYSQL_USE_INNODB
+                        -- NAMING_FULLY_QUALIFIED
+                        -- NAMING_TABLE_NO_KEYWORD
+                        -- NAMING_IDENTIFIER_NO_KEYWORD
+                        -- STATEMENT_SELECT_NO_SELECT_ALL
+                        -- STATEMENT_WHERE_REQUIRE_SELECT
+                        -- STATEMENT_WHERE_REQUIRE_UPDATE_DELETE
+                        -- STATEMENT_WHERE_NO_LEADING_WILDCARD_LIKE
+                        -- STATEMENT_DISALLOW_ON_DEL_CASCADE
+                        -- STATEMENT_DISALLOW_RM_TBL_CASCADE
+                        -- STATEMENT_DISALLOW_COMMIT
+                        -- STATEMENT_DISALLOW_LIMIT
+                        -- STATEMENT_DISALLOW_ORDER_BY
+                        -- STATEMENT_MERGE_ALTER_TABLE
+                        -- STATEMENT_INSERT_MUST_SPECIFY_COLUMN
+                        -- STATEMENT_INSERT_DISALLOW_ORDER_BY_RAND
+                        -- STATEMENT_DML_DRY_RUN
+                        -- STATEMENT_DISALLOW_ADD_COLUMN_WITH_DEFAULT
+                        -- STATEMENT_ADD_CHECK_NOT_VALID
+                        -- STATEMENT_ADD_FOREIGN_KEY_NOT_VALID
+                        -- STATEMENT_DISALLOW_ADD_NOT_NULL
+                        -- STATEMENT_SELECT_FULL_TABLE_SCAN
+                        -- STATEMENT_CREATE_SPECIFY_SCHEMA
+                        -- STATEMENT_CHECK_SET_ROLE_VARIABLE
+                        -- STATEMENT_DISALLOW_USING_FILESORT
+                        -- STATEMENT_DISALLOW_USING_TEMPORARY
+                        -- STATEMENT_WHERE_NO_EQUAL_NULL
+                        -- STATEMENT_WHERE_DISALLOW_FUNCTIONS_AND_CALCULATIONS
+                        -- STATEMENT_JOIN_STRICT_COLUMN_ATTRS
+                        -- STATEMENT_NON_TRANSACTIONAL
+                        -- STATEMENT_ADD_COLUMN_WITHOUT_POSITION
+                        -- STATEMENT_DISALLOW_OFFLINE_DDL
+                        -- STATEMENT_DISALLOW_CROSS_DB_QUERIES
+                        -- STATEMENT_MAX_EXECUTION_TIME
+                        -- STATEMENT_REQUIRE_ALGORITHM_OPTION
+                        -- STATEMENT_REQUIRE_LOCK_OPTION
+                        -- STATEMENT_OBJECT_OWNER_CHECK
+                        -- TABLE_REQUIRE_PK
+                        -- TABLE_NO_FOREIGN_KEY
+                        -- TABLE_DISALLOW_PARTITION
+                        -- TABLE_DISALLOW_TRIGGER
+                        -- TABLE_NO_DUPLICATE_INDEX
+                        -- TABLE_DISALLOW_SET_CHARSET
+                        -- TABLE_REQUIRE_CHARSET
+                        -- TABLE_REQUIRE_COLLATION
+                        -- COLUMN_NO_NULL
+                        -- COLUMN_DISALLOW_CHANGE_TYPE
+                        -- COLUMN_SET_DEFAULT_FOR_NOT_NULL
+                        -- COLUMN_DISALLOW_CHANGE
+                        -- COLUMN_DISALLOW_CHANGING_ORDER
+                        -- COLUMN_DISALLOW_DROP
+                        -- COLUMN_DISALLOW_DROP_IN_INDEX
+                        -- COLUMN_AUTO_INCREMENT_MUST_INTEGER
+                        -- COLUMN_DISALLOW_SET_CHARSET
+                        -- COLUMN_AUTO_INCREMENT_MUST_UNSIGNED
+                        -- COLUMN_CURRENT_TIME_COUNT_LIMIT
+                        -- COLUMN_REQUIRE_DEFAULT
+                        -- COLUMN_DEFAULT_DISALLOW_VOLATILE
+                        -- COLUMN_ADD_NOT_NULL_REQUIRE_DEFAULT
+                        -- COLUMN_REQUIRE_CHARSET
+                        -- COLUMN_REQUIRE_COLLATION
+                        -- SCHEMA_BACKWARD_COMPATIBILITY
+                        -- DATABASE_DROP_EMPTY_DATABASE
+                        -- INDEX_NO_DUPLICATE_COLUMN
+                        -- INDEX_PK_TYPE_LIMIT
+                        -- INDEX_TYPE_NO_BLOB
+                        -- INDEX_CREATE_CONCURRENTLY
+                        -- INDEX_NOT_REDUNDANT
+                        -- SYSTEM_PROCEDURE_DISALLOW_CREATE
+                        -- SYSTEM_EVENT_DISALLOW_CREATE
+                        -- SYSTEM_VIEW_DISALLOW_CREATE
+                        -- SYSTEM_FUNCTION_DISALLOW_CREATE
+                        -- SYSTEM_FUNCTION_DISALLOWED_LIST
+                        -- BUILTIN_PRIOR_BACKUP_CHECK
                         ELSE rule - 'payload'
                     END
                 )

--- a/backend/plugin/advisor/sql_review.go
+++ b/backend/plugin/advisor/sql_review.go
@@ -2,13 +2,13 @@ package advisor
 
 import (
 	"context"
+	"fmt"
 	"regexp"
-
-	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/component/sheet"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 
@@ -142,7 +142,13 @@ func SQLReviewCheck(
 			checkContext,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to check statement")
+			errorAdvices = append(errorAdvices, &storepb.Advice{
+				Status:  storepb.Advice_ERROR,
+				Code:    code.Internal.Int32(),
+				Title:   ruleType.String(),
+				Content: fmt.Sprintf("Rule check failed: %v", err),
+			})
+			continue
 		}
 
 		for _, advice := range adviceList {


### PR DESCRIPTION
This commit fixes the 'number_payload is required for this rule' error for the ADVICE_ONLINE_MIGRATION rule.
1. Added graceful error handling in SQLReviewCheck.
2. Updated ReviewConfigService validation to enforce number payload for ADVICE_ONLINE_MIGRATION.
3. Updated migration script to correctly migrate ADVICE_ONLINE_MIGRATION payload.