### PR TITLE
refactor(issue): simplify Issue creator storage and enrich webhook payload

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -997,7 +997,7 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("user not found"))
 	}
 
-	canRequest := canRequestIssue(issue.Creator, user)
+	canRequest := canRequestIssue(issue.CreatorEmail, user)
 	if !canRequest {
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("cannot request issues because you are not the issue creator"))
 	}
@@ -1529,6 +1529,6 @@ func (s *IssueService) isUserReviewer(ctx context.Context, issue *store.IssueMes
 	return roles[role]
 }
 
-func canRequestIssue(issueCreator *store.UserMessage, user *store.UserMessage) bool {
-	return issueCreator.ID == user.ID
+func canRequestIssue(issueCreatorEmail string, user *store.UserMessage) bool {
+	return issueCreatorEmail == user.Email
 }

--- a/backend/api/v1/issue_service_converter.go
+++ b/backend/api/v1/issue_service_converter.go
@@ -95,7 +95,7 @@ func (s *IssueService) convertToIssue(ctx context.Context, issue *store.IssueMes
 		Description:     issue.Description,
 		Type:            convertToIssueType(issue.Type),
 		Status:          convertToIssueStatus(issue.Status),
-		Creator:         common.FormatUserEmail(issue.Creator.Email),
+		Creator:         common.FormatUserEmail(issue.CreatorEmail),
 		CreateTime:      timestamppb.New(issue.CreatedAt),
 		UpdateTime:      timestamppb.New(issue.UpdatedAt),
 		GrantRequest:    convertedGrantRequest,
@@ -352,7 +352,7 @@ func convertToIssueComment(issueName string, ic *store.IssueCommentMessage) *v1p
 		CreateTime: timestamppb.New(ic.CreatedAt),
 		UpdateTime: timestamppb.New(ic.UpdatedAt),
 		Name:       fmt.Sprintf("%s/%s%d", issueName, common.IssueCommentNamePrefix, ic.UID),
-		Creator:    common.FormatUserEmail(ic.Creator.Email),
+		Creator:    common.FormatUserEmail(ic.CreatorEmail),
 	}
 
 	switch e := ic.Payload.Event.(type) {

--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -1009,7 +1009,7 @@ func (s *ProjectService) TestWebhook(ctx context.Context, req *connect.Request[v
 			Link:        fmt.Sprintf("%s/projects/%s/webhooks/%s", externalURL, project.ResourceID, fmt.Sprintf("%s-%d", slug.Make(webhook.Payload.GetTitle()), webhook.ID)),
 			ActorID:     common.SystemBotID,
 			ActorName:   "Bytebase",
-			ActorEmail:  s.store.GetSystemBotUser(ctx).Email,
+			ActorEmail:  common.SystemBotEmail,
 			CreatedTS:   time.Now().Unix(),
 			Issue: &webhookplugin.Issue{
 				ID:          1,
@@ -1017,7 +1017,10 @@ func (s *ProjectService) TestWebhook(ctx context.Context, req *connect.Request[v
 				Status:      "OPEN",
 				Type:        "bb.issue.database.create",
 				Description: "This is a test issue",
-				Creator:     s.store.GetSystemBotUser(ctx),
+				Creator: webhookplugin.Creator{
+					Name:  "Bytebase",
+					Email: common.SystemBotEmail,
+				},
 			},
 
 			Project: &webhookplugin.Project{

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -1053,7 +1053,7 @@ func GetValidRolloutPolicyForEnvironment(ctx context.Context, stores *store.Stor
 func (s *RolloutService) canUserRunEnvironmentTasks(ctx context.Context, user *store.UserMessage, project *store.ProjectMessage, issue *store.IssueMessage, environment string, _ string) (bool, error) {
 	// For data export issues, only the creator can run tasks.
 	if issue != nil && issue.Type == storepb.Issue_DATABASE_EXPORT {
-		return issue.Creator.Email == user.Email, nil
+		return issue.CreatorEmail == user.Email, nil
 	}
 
 	// Users with bb.taskRuns.create can always create task runs.

--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -39,7 +39,7 @@ func convertToTaskRun(ctx context.Context, s *store.Store, stateCfg *state.State
 	stageID := common.FormatStageID(taskRun.Environment)
 	t := &v1pb.TaskRun{
 		Name:          common.FormatTaskRun(taskRun.ProjectID, taskRun.PipelineUID, stageID, taskRun.TaskUID, taskRun.ID),
-		Creator:       common.FormatUserEmail(taskRun.Creator.Email),
+		Creator:       common.FormatUserEmail(taskRun.CreatorEmail),
 		CreateTime:    timestamppb.New(taskRun.CreatedAt),
 		UpdateTime:    timestamppb.New(taskRun.UpdatedAt),
 		Status:        convertToTaskRunStatus(taskRun.Status),

--- a/backend/component/webhook/event.go
+++ b/backend/component/webhook/event.go
@@ -26,13 +26,13 @@ func NewIssue(i *store.IssueMessage) *Issue {
 		return nil
 	}
 	return &Issue{
-		UID:         i.UID,
-		Status:      i.Status.String(),
-		Type:        i.Type.String(),
-		Title:       i.Title,
-		Description: i.Description,
-		Creator:     i.Creator,
-		Approval:    i.Payload.GetApproval(),
+		UID:          i.UID,
+		Status:       i.Status.String(),
+		Type:         i.Type.String(),
+		Title:        i.Title,
+		Description:  i.Description,
+		CreatorEmail: i.CreatorEmail,
+		Approval:     i.Payload.GetApproval(),
 	}
 }
 
@@ -50,13 +50,13 @@ func NewRollout(r *store.PipelineMessage) *Rollout {
 }
 
 type Issue struct {
-	UID         int
-	Status      string
-	Type        string
-	Title       string
-	Description string
-	Creator     *store.UserMessage
-	Approval    *storepb.IssuePayloadApproval
+	UID          int
+	Status       string
+	Type         string
+	Title        string
+	Description  string
+	CreatorEmail string
+	Approval     *storepb.IssuePayloadApproval
 }
 
 type Project struct {

--- a/backend/plugin/webhook/webhook.go
+++ b/backend/plugin/webhook/webhook.go
@@ -48,7 +48,12 @@ type Issue struct {
 	Status      string
 	Type        string
 	Description string
-	Creator     *store.UserMessage
+	Creator     Creator
+}
+
+type Creator struct {
+	Name  string
+	Email string
 }
 
 type Rollout struct {

--- a/backend/plugin/webhook/webhook_test.go
+++ b/backend/plugin/webhook/webhook_test.go
@@ -121,4 +121,61 @@ func TestContext_getMetaList(t *testing.T) {
 		}
 		a.Equal(want, context.GetMetaList())
 	})
+	t.Run("Issue with Creator", func(t *testing.T) {
+		a := require.New(t)
+		context := Context{
+			Issue: &Issue{
+				Name:        "Issue 101",
+				Description: "Fix critical bug",
+				Creator: Creator{
+					Name:  "Alice",
+					Email: "alice@example.com",
+				},
+			},
+		}
+		want := []Meta{
+			{
+				Name:  "Issue",
+				Value: "Issue 101",
+			},
+			{
+				Name:  "Issue Creator",
+				Value: "Alice (alice@example.com)",
+			},
+			{
+				Name:  "Issue Description",
+				Value: "Fix critical bug",
+			},
+		}
+		a.Equal(want, context.GetMetaList())
+	})
+
+	t.Run("Issue with Creator Zh", func(t *testing.T) {
+		a := require.New(t)
+		context := Context{
+			Issue: &Issue{
+				Name:        "Issue 101",
+				Description: "Fix critical bug",
+				Creator: Creator{
+					Name:  "Alice",
+					Email: "alice@example.com",
+				},
+			},
+		}
+		want := []Meta{
+			{
+				Name:  "工单",
+				Value: "Issue 101",
+			},
+			{
+				Name:  "工单创建者",
+				Value: "Alice (alice@example.com)",
+			},
+			{
+				Name:  "工单描述",
+				Value: "Fix critical bug",
+			},
+		}
+		a.Equal(want, context.GetMetaListZh())
+	})
 }

--- a/backend/runner/taskrun/data_export_executor.go
+++ b/backend/runner/taskrun/data_export_executor.go
@@ -74,7 +74,14 @@ func (exec *DataExportExecutor) RunOnce(ctx context.Context, _ context.Context, 
 		Format:    v1pb.ExportFormat(task.Payload.GetFormat()),
 		Password:  "", /* do not pass the password, we will encrypt the files will password when users download them */
 	}
-	bytes, _, exportErr := apiv1.DoExport(ctx, exec.store, exec.dbFactory, exec.license, exportRequest, issue.Creator /* user */, instance, database, nil /* access check */, exec.schemaSyncer, dataSource)
+	creatorUser, err := exec.store.GetUserByEmail(ctx, issue.CreatorEmail)
+	if err != nil {
+		return true, nil, errors.Wrapf(err, "failed to get creator user for issue %d", issue.UID)
+	}
+	if creatorUser == nil {
+		return true, nil, errors.Errorf("creator user not found for issue %d", issue.UID)
+	}
+	bytes, _, exportErr := apiv1.DoExport(ctx, exec.store, exec.dbFactory, exec.license, exportRequest, creatorUser /* user */, instance, database, nil /* access check */, exec.schemaSyncer, dataSource)
 	if exportErr != nil {
 		return true, nil, errors.Wrap(exportErr, "failed to export data")
 	}

--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -45,13 +45,12 @@ type IssueMessage struct {
 
 	// The following fields are output only and not used for create().
 	UID       int
-	Creator   *UserMessage
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
 	// Internal fields.
 	projectID    string
-	creatorEmail string
+	CreatorEmail string
 }
 
 // UpdateIssueMessage is the message for updating an issue.
@@ -418,7 +417,7 @@ func (s *Store) ListIssues(ctx context.Context, find *FindIssueMessage) ([]*Issu
 		var typeString string
 		if err := rows.Scan(
 			&issue.UID,
-			&issue.creatorEmail,
+			&issue.CreatorEmail,
 			&issue.CreatedAt,
 			&issue.UpdatedAt,
 			&issue.projectID,
@@ -466,11 +465,6 @@ func (s *Store) ListIssues(ctx context.Context, find *FindIssueMessage) ([]*Issu
 			return nil, err
 		}
 		issue.Project = project
-		creator, err := s.GetUserByEmail(ctx, issue.creatorEmail)
-		if err != nil {
-			return nil, err
-		}
-		issue.Creator = creator
 
 		s.issueCache.Add(issue.UID, issue)
 		if issue.PipelineUID != nil {

--- a/backend/store/issue_comment.go
+++ b/backend/store/issue_comment.go
@@ -13,14 +13,12 @@ import (
 )
 
 type IssueCommentMessage struct {
-	UID       int
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	IssueUID  int
-	Payload   *storepb.IssueCommentPayload
-	Creator   *UserMessage
-
-	creatorEmail string
+	UID          int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	IssueUID     int
+	Payload      *storepb.IssueCommentPayload
+	CreatorEmail string
 }
 
 type FindIssueCommentMessage struct {
@@ -99,7 +97,7 @@ func (s *Store) ListIssueComment(ctx context.Context, find *FindIssueCommentMess
 		var p []byte
 		if err := rows.Scan(
 			&ic.UID,
-			&ic.creatorEmail,
+			&ic.CreatorEmail,
 			&ic.CreatedAt,
 			&ic.UpdatedAt,
 			&ic.IssueUID,
@@ -115,14 +113,6 @@ func (s *Store) ListIssueComment(ctx context.Context, find *FindIssueCommentMess
 
 	if err := rows.Err(); err != nil {
 		return nil, errors.Wrapf(err, "rows err")
-	}
-
-	for _, ic := range issueComments {
-		creator, err := s.GetUserByEmail(ctx, ic.creatorEmail)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get creator")
-		}
-		ic.Creator = creator
 	}
 
 	return issueComments, nil
@@ -173,12 +163,7 @@ func (s *Store) CreateIssueComment(ctx context.Context, create *IssueCommentMess
 		return nil, errors.Wrapf(err, "failed to insert")
 	}
 
-	c, err := s.GetUserByEmail(ctx, creator)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get creator")
-	}
-	create.Creator = c
-	create.creatorEmail = creator
+	create.CreatorEmail = creator
 
 	return create, nil
 }

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -26,7 +26,6 @@ type TaskRunMessage struct {
 	// Output only.
 	ID           int
 	CreatorEmail string
-	Creator      *UserMessage
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	ProjectID    string
@@ -164,15 +163,6 @@ func (s *Store) ListTaskRuns(ctx context.Context, find *FindTaskRunMessage) ([]*
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-
-	for _, taskRun := range taskRuns {
-		creator, err := s.GetUserByEmail(ctx, taskRun.CreatorEmail)
-		if err != nil {
-			return nil, err
-		}
-		taskRun.Creator = creator
-	}
-
 	return taskRuns, nil
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the internal `Issue` representation to store the creator's email string instead of the full User object. Additionally, it enhances the webhook payload to include both the creator's name and email.

## Changes
- **Store**: `IssueMessage` now stores `CreatorEmail` (string) instead of `Creator` (*UserMessage).
- **Webhook**:
    - `webhook.Issue` struct updated to include a nested `Creator` struct with `Name` and `Email`.
    - `manager.go` updated to fetch the creator's user profile on-demand to populate the `Creator` struct.
    - Webhook messages now display the creator as "Name (Email)".
- **Refactor**: Updated various services (`issue_service`, `rollout_service`, `project_service`) and `event.go` to rely on `CreatorEmail`.