### PR TITLE
fix(frontend): show drifted databases in project database list by default

### DIFF
--- a/frontend/src/components/ProjectDatabasesPanel.vue
+++ b/frontend/src/components/ProjectDatabasesPanel.vue
@@ -154,7 +154,9 @@ const selectedEngines = computed(() => {
 
 const selectedDriftedValue = computed(() => {
   const driftedValue = getValueFromSearchParams(state.params, "drifted");
-  return driftedValue === "true" ? true : false;
+  if (driftedValue === "true") return true;
+  if (driftedValue === "false") return false;
+  return undefined;
 });
 
 const filter = computed(() => ({


### PR DESCRIPTION
## Summary

Fix a bug where drifted databases were hidden from the project database list when no `drifted` filter was specified.

## Root Cause

```ts
// Before: returns false when no filter, hiding drifted databases
const selectedDriftedValue = computed(() => {
  const driftedValue = getValueFromSearchParams(state.params, "drifted");
  return driftedValue === "true" ? true : false;  // BUG: false when undefined
});
```

## Fix

```ts
// After: returns undefined when no filter, showing all databases
const selectedDriftedValue = computed(() => {
  const driftedValue = getValueFromSearchParams(state.params, "drifted");
  if (driftedValue === "true") return true;
  if (driftedValue === "false") return false;
  return undefined;  // No filter applied
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)