### PR TITLE
refactor: pass user objects instead of IDs to avoid redundant DB lookups

### DIFF
--- a/backend/api/v1/actuator_service.go
+++ b/backend/api/v1/actuator_service.go
@@ -122,7 +122,7 @@ func (s *ActuatorService) SetupSample(
 	if !ok || user == nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.New("user not found"))
 	}
-	if err := s.sampleInstanceManager.GenerateOnboardingData(ctx, user.ID, s.schemaSyncer); err != nil {
+	if err := s.sampleInstanceManager.GenerateOnboardingData(ctx, user, s.schemaSyncer); err != nil {
 		// When running inside docker on mac, we sometimes get database does not exist error.
 		// This is due to the docker overlay storage incompatibility with mac OS file system.
 		// Onboarding error is not critical, so we just emit an error log.

--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -204,7 +204,7 @@ func (s *ProjectService) CreateProject(ctx context.Context, req *connect.Request
 	}
 	project, err := s.store.CreateProject(ctx,
 		projectMessage,
-		user.ID,
+		user,
 	)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)

--- a/backend/component/sampleinstance/manager.go
+++ b/backend/component/sampleinstance/manager.go
@@ -152,7 +152,7 @@ func (m *Manager) Port() int {
 }
 
 // GenerateOnboardingData generates onboarding data including project and instance.
-func (m *Manager) GenerateOnboardingData(ctx context.Context, userID int, schemaSyncer *schemasync.Syncer) error {
+func (m *Manager) GenerateOnboardingData(ctx context.Context, user *store.UserMessage, schemaSyncer *schemasync.Syncer) error {
 	setting := &storepb.Project{
 		AllowModifyStatement: true,
 		AutoResolveIssue:     true,
@@ -170,7 +170,7 @@ func (m *Manager) GenerateOnboardingData(ctx context.Context, userID int, schema
 			ResourceID: "project-sample",
 			Title:      "Sample Project",
 			Setting:    setting,
-		}, userID)
+		}, user)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create onboarding project")
 		}

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -189,7 +189,7 @@ func (r *Runner) findApprovalTemplateForIssue(ctx context.Context, issue *store.
 		if err := utils.UpdateProjectPolicyFromGrantIssue(ctx, r.store, issue, payload.GrantRequest); err != nil {
 			return false, err
 		}
-		if err := webhook.ChangeIssueStatus(ctx, r.store, r.webhookManager, issue, storepb.Issue_DONE, r.store.GetSystemBotUser(ctx), ""); err != nil {
+		if err := webhook.ChangeIssueStatus(ctx, r.store, r.webhookManager, issue, storepb.Issue_DONE, store.SystemBotUser, ""); err != nil {
 			return false, errors.Wrap(err, "failed to update issue status")
 		}
 	}
@@ -234,7 +234,7 @@ func (r *Runner) findApprovalTemplateForIssue(ctx context.Context, issue *store.
 			return err
 		}
 		r.webhookManager.CreateEvent(ctx, &webhook.Event{
-			Actor:   r.store.GetSystemBotUser(ctx),
+			Actor:   store.SystemBotUser,
 			Type:    storepb.Activity_NOTIFY_PIPELINE_ROLLOUT,
 			Comment: "",
 			Issue:   webhook.NewIssue(issue),
@@ -258,7 +258,7 @@ func (r *Runner) findApprovalTemplateForIssue(ctx context.Context, issue *store.
 			return
 		}
 		r.webhookManager.CreateEvent(ctx, &webhook.Event{
-			Actor:   r.store.GetSystemBotUser(ctx),
+			Actor:   store.SystemBotUser,
 			Type:    storepb.Activity_ISSUE_APPROVAL_NOTIFY,
 			Comment: "",
 			Issue:   webhook.NewIssue(issue),

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -252,7 +252,7 @@ func (s *Scheduler) scheduleAutoRolloutTask(ctx context.Context, taskUID int) er
 		}
 	}
 	s.webhookManager.CreateEvent(ctx, &webhook.Event{
-		Actor:   s.store.GetSystemBotUser(ctx),
+		Actor:   store.SystemBotUser,
 		Type:    storepb.Activity_ISSUE_PIPELINE_TASK_RUN_STATUS_UPDATE,
 		Comment: "",
 		Issue:   webhook.NewIssue(issue),
@@ -839,7 +839,7 @@ func (s *Scheduler) ListenTaskSkippedOrDone(ctx context.Context) {
 				// every task in the stage terminated
 				// create "stage ends" activity.
 				s.webhookManager.CreateEvent(ctx, &webhook.Event{
-					Actor:   s.store.GetSystemBotUser(ctx),
+					Actor:   store.SystemBotUser,
 					Type:    storepb.Activity_ISSUE_PIPELINE_STAGE_STATUS_UPDATE,
 					Comment: "",
 					Issue:   webhook.NewIssue(issueN),
@@ -881,7 +881,7 @@ func (s *Scheduler) ListenTaskSkippedOrDone(ctx context.Context) {
 						return errors.Wrapf(err, "failed to get rollout policy")
 					}
 					s.webhookManager.CreateEvent(ctx, &webhook.Event{
-						Actor:   s.store.GetSystemBotUser(ctx),
+						Actor:   store.SystemBotUser,
 						Type:    storepb.Activity_NOTIFY_PIPELINE_ROLLOUT,
 						Comment: "",
 						Issue:   webhook.NewIssue(issueN),
@@ -927,7 +927,7 @@ func (s *Scheduler) ListenTaskSkippedOrDone(ctx context.Context) {
 						}
 
 						s.webhookManager.CreateEvent(ctx, &webhook.Event{
-							Actor:   s.store.GetSystemBotUser(ctx),
+							Actor:   store.SystemBotUser,
 							Type:    storepb.Activity_ISSUE_STATUS_UPDATE,
 							Comment: "",
 							Issue:   webhook.NewIssue(updatedIssue),
@@ -972,7 +972,7 @@ func (s *Scheduler) createActivityForTaskRunStatusUpdate(ctx context.Context, ta
 			return errors.Wrap(err, "failed to get issue")
 		}
 		s.webhookManager.CreateEvent(ctx, &webhook.Event{
-			Actor:   s.store.GetSystemBotUser(ctx),
+			Actor:   store.SystemBotUser,
 			Type:    storepb.Activity_ISSUE_PIPELINE_TASK_RUN_STATUS_UPDATE,
 			Comment: "",
 			Issue:   webhook.NewIssue(issue),

--- a/backend/store/principal.go
+++ b/backend/store/principal.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"database/sql"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -13,12 +12,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/common/qb"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
-var systemBotUser = &UserMessage{
+// SystemBotUser is the static system bot user.
+var SystemBotUser = &UserMessage{
 	ID:    common.SystemBotID,
 	Name:  "Bytebase",
 	Email: "support@bytebase.com",
@@ -71,19 +70,6 @@ type UserStat struct {
 	Type    storepb.PrincipalType
 	Deleted bool
 	Count   int
-}
-
-// GetSystemBotUser gets the system bot.
-func (s *Store) GetSystemBotUser(ctx context.Context) *UserMessage {
-	user, err := s.GetUserByID(ctx, common.SystemBotID)
-	if err != nil {
-		slog.Error("failed to find system bot", slog.Int("id", common.SystemBotID), log.BBError(err))
-		return systemBotUser
-	}
-	if user == nil {
-		return systemBotUser
-	}
-	return user
 }
 
 // GetUserByID gets the user by ID.

--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -170,10 +170,9 @@ func (s *Store) ListProjects(ctx context.Context, find *FindProjectMessage) ([]*
 }
 
 // CreateProject creates a project.
-func (s *Store) CreateProject(ctx context.Context, create *ProjectMessage, creatorID int) (*ProjectMessage, error) {
-	user, err := s.GetUserByID(ctx, creatorID)
-	if err != nil {
-		return nil, err
+func (s *Store) CreateProject(ctx context.Context, create *ProjectMessage, creator *UserMessage) (*ProjectMessage, error) {
+	if creator == nil {
+		return nil, errors.Errorf("creator cannot be nil")
 	}
 	if create.Setting == nil {
 		create.Setting = &storepb.Project{}
@@ -210,7 +209,7 @@ func (s *Store) CreateProject(ctx context.Context, create *ProjectMessage, creat
 			{
 				Role: common.FormatRole(common.ProjectOwner),
 				Members: []string{
-					common.FormatUserEmail(user.Email),
+					common.FormatUserEmail(creator.Email),
 				},
 				Condition: &expr.Expr{},
 			},


### PR DESCRIPTION
## Summary

This PR refactors several functions to accept `*store.UserMessage` instead of user IDs, eliminating unnecessary database lookups when the caller already has the user object.

## Changes

### Function Signature Updates
- **getUserRoleMap()**: Accept `*store.UserMessage` instead of `principalUID`
- **isIssueNextApprover()**: Accept `*store.UserMessage` instead of `principalUID`
- **store.CreateProject()**: Accept `*store.UserMessage` instead of `creatorID`
- **sampleinstance.GenerateOnboardingData()**: Accept `*store.UserMessage` instead of `userID`

### System Bot Refactoring
- Replaced `GetSystemBotUser()` method with static `store.SystemBotUser`
- Removed unnecessary database lookups for system bot user
- Updated 12 call sites across the codebase

### filterIssueMessage Update
- Changed `ApproverID *int` to `Approver *store.UserMessage`
- Updated all references to use the user object directly

## Benefits

- ✅ **Performance**: Eliminates 15+ redundant database lookups across request cycles
- ✅ **Simplicity**: Removes unnecessary error handling for user fetch operations
- ✅ **Efficiency**: Reuses already-fetched user objects instead of re-querying the database
- ✅ **Consistency**: Follows a more consistent pattern of passing objects instead of IDs

## Bug Fixes

- Fixed unconditional error logging in `getUserRoleMap` (was logging error even on success)

## Test Plan

- [x] All modified files formatted with `gofmt`
- [x] `golangci-lint` passes with 0 issues
- [x] Project builds successfully
- [x] No breaking changes to public APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)