### PR TITLE
fix: set correct default data directory in Docker to prevent data loss appearance

### DIFF
--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -90,6 +90,15 @@ func Execute() error {
 }
 
 func init() {
+	// Set default data directory based on environment.
+	// In Docker, default to /var/opt/bytebase to match the Dockerfile's CMD.
+	// This ensures the data directory is correct even when users add other flags,
+	// which would otherwise cause Docker to replace the entire CMD and lose --data.
+	defaultDataDir := "."
+	if isDocker() {
+		defaultDataDir = "/var/opt/bytebase"
+	}
+
 	// In the release build, Bytebase bundles frontend and backend together and runs on a single port as a mono server.
 	// During development, Bytebase frontend runs on a separate port.
 	rootCmd.PersistentFlags().IntVar(&flags.port, "port", 8080, "port where Bytebase server runs. Default to 80")
@@ -97,7 +106,7 @@ func init() {
 	// Instead they would configure a gateway to forward the traffic to Bytebase. Users need to set --external-url to the address
 	// exposed on that gateway accordingly.
 	rootCmd.PersistentFlags().StringVar(&flags.externalURL, "external-url", "", "the external URL where user visits Bytebase, must start with http:// or https://")
-	rootCmd.PersistentFlags().StringVar(&flags.dataDir, "data", ".", "not recommended for production. Directory where Bytebase stores data if PG_URL is not specified. If relative path is supplied, then the path is relative to the directory where Bytebase is under")
+	rootCmd.PersistentFlags().StringVar(&flags.dataDir, "data", defaultDataDir, "not recommended for production. Directory where Bytebase stores data if PG_URL is not specified. If relative path is supplied, then the path is relative to the directory where Bytebase is under")
 	rootCmd.PersistentFlags().BoolVar(&flags.ha, "ha", false, "run in HA mode")
 	rootCmd.PersistentFlags().BoolVar(&flags.saas, "saas", false, "run in SaaS mode")
 	rootCmd.PersistentFlags().BoolVar(&flags.enableJSONLogging, "enable-json-logging", false, "enable output logs in bytebase in json format")


### PR DESCRIPTION
## Summary

Fixes #BYT-8505 - Docker users adding command-line flags (like `--enable-json-logging` or `--saas`) would see the admin registration screen as if their data was erased.

**Root Cause:** Docker's CMD replacement behavior. When users provide any arguments to `docker run`, Docker **replaces** the entire `CMD` instead of appending to it. This caused the `--data /var/opt/bytebase` argument to be lost, making the app default to `.` (current directory) where no data exists.

**The Fix:** Detect when running in Docker (via `/etc/bb.env` marker) and automatically set the default data directory to `/var/opt/bytebase`. This ensures data is found correctly regardless of which flags users add.

## Changes

- `backend/bin/server/cmd/root.go`: Added Docker-aware default for `--data` flag
  - Non-Docker: defaults to `.` (preserves existing behavior)
  - Docker: defaults to `/var/opt/bytebase` (matches Dockerfile CMD)

## Test Plan

### Manual Testing Scenarios

1. **Docker with no extra flags** (should still work)
   ```bash
   docker run bytebase/bytebase:latest
   # Expected: Uses /var/opt/bytebase, data found
   ```

2. **Docker with `--enable-json-logging`** (the bug scenario)
   ```bash
   docker run bytebase/bytebase:latest --enable-json-logging
   # Expected: Uses /var/opt/bytebase, data found (FIXED!)
   # Before: Would use ".", data not found
   ```

3. **Docker with explicit `--data` override** (should respect user choice)
   ```bash
   docker run bytebase/bytebase:latest --data /custom/path
   # Expected: Uses /custom/path as specified
   ```

4. **Non-Docker deployment** (should not be affected)
   ```bash
   ./bytebase
   # Expected: Uses "." as before (no /etc/bb.env, so isDocker() returns false)
   ```

### Build Verification

- [x] Code formatted with `gofmt`
- [x] Linted with `golangci-lint` (0 issues)
- [x] Successfully built backend binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)