### PR TITLE
fix: remove built-in prior backup check rules from review config

### DIFF
--- a/backend/migrator/migration/3.13/0007##plan_check_ddl_dml_consolidation.sql
+++ b/backend/migrator/migration/3.13/0007##plan_check_ddl_dml_consolidation.sql
@@ -12,7 +12,9 @@ UPDATE plan_check_run
 SET config = config - 'changeDatabaseType'
 WHERE config ? 'changeDatabaseType';
 
--- Remove disallow-mix rules from review_config if they exist
+-- Remove disallow-mix rules and built-in rules from review_config if they exist.
+-- Built-in rules (like prior-backup-check) are automatically injected by GetBuiltinRules()
+-- and should never be stored in the database.
 UPDATE review_config
 SET payload = jsonb_set(
   payload,
@@ -22,7 +24,9 @@ SET payload = jsonb_set(
      FROM jsonb_array_elements(payload->'sqlReviewRules') r
      WHERE r->>'type' NOT IN (
        'statement.disallow-mix-in-ddl',
-       'statement.disallow-mix-in-dml'
+       'statement.disallow-mix-in-dml',
+       'statement.prior-backup-check',
+       'builtin.prior-backup-check'
      )),
     '[]'::jsonb
   )

--- a/backend/migrator/migration/3.13/0017##update_review_config_rule_type.sql
+++ b/backend/migrator/migration/3.13/0017##update_review_config_rule_type.sql
@@ -65,7 +65,6 @@ BEGIN
                 WHEN 'statement.maximum-join-table-count' THEN jsonb_set(rule, '{type}', to_jsonb('STATEMENT_MAXIMUM_JOIN_TABLE_COUNT'::text))
                 WHEN 'statement.maximum-statements-in-transaction' THEN jsonb_set(rule, '{type}', to_jsonb('STATEMENT_MAXIMUM_STATEMENTS_IN_TRANSACTION'::text))
                 WHEN 'statement.join-strict-column-attrs' THEN jsonb_set(rule, '{type}', to_jsonb('STATEMENT_JOIN_STRICT_COLUMN_ATTRS'::text))
-                WHEN 'statement.prior-backup-check' THEN jsonb_set(rule, '{type}', to_jsonb('BUILTIN_PRIOR_BACKUP_CHECK'::text))
                 WHEN 'statement.non-transactional' THEN jsonb_set(rule, '{type}', to_jsonb('STATEMENT_NON_TRANSACTIONAL'::text))
                 WHEN 'statement.add-column-without-position' THEN jsonb_set(rule, '{type}', to_jsonb('STATEMENT_ADD_COLUMN_WITHOUT_POSITION'::text))
                 WHEN 'statement.disallow-offline-ddl' THEN jsonb_set(rule, '{type}', to_jsonb('STATEMENT_DISALLOW_OFFLINE_DDL'::text))
@@ -140,7 +139,6 @@ BEGIN
                 WHEN 'system.function-disallowed-list' THEN jsonb_set(rule, '{type}', to_jsonb('SYSTEM_FUNCTION_DISALLOWED_LIST'::text))
                 WHEN 'system.function.disallowed-list' THEN jsonb_set(rule, '{type}', to_jsonb('SYSTEM_FUNCTION_DISALLOWED_LIST'::text))
                 WHEN 'advice.online-migration' THEN jsonb_set(rule, '{type}', to_jsonb('ADVICE_ONLINE_MIGRATION'::text))
-                WHEN 'builtin.prior-backup-check' THEN jsonb_set(rule, '{type}', to_jsonb('BUILTIN_PRIOR_BACKUP_CHECK'::text))
                 WHEN 'engine.mysql.use-innodb' THEN jsonb_set(rule, '{type}', to_jsonb('ENGINE_MYSQL_USE_INNODB'::text))
                         ELSE rule
                     END


### PR DESCRIPTION
## Summary

Fixes the "unknown advisor statement.prior-backup-check" error by ensuring built-in SQL review rules are never stored in the database.

## Problem

Built-in SQL review rules (like `BUILTIN_PRIOR_BACKUP_CHECK`) are automatically injected by `GetBuiltinRules()` in `backend/plugin/advisor/builtin_rules.go` and should **never** be stored in the `review_config` database table.

However, migration `0017##update_review_config_rule_type.sql` was **converting** these rules from old string format to new enum format, causing:
1. Duplicate rules (one from database, one from code)
2. "unknown advisor statement.prior-backup-check" errors when old string formats remained in the database

## Changes

### Migration 0007 (`plan_check_ddl_dml_consolidation.sql`)
- Added removal of built-in prior backup check rules in old string format:
  - `statement.prior-backup-check`
  - `builtin.prior-backup-check`
- These are removed along with the existing `disallow-mix` rules

### Migration 0017 (`update_review_config_rule_type.sql`)
- Removed conversion logic for built-in prior backup check rules (lines 68 and 141)
- Since these rules are already filtered out in migration 0007, they never reach 0017 for conversion

## Why This Approach

- Migration 0007 runs **before** 0017, when rule types are still in old string format
- Migration 0017 converts remaining rules from old string format to enum format
- Since built-in rules are removed in 0007, they never get converted to the new format

## Impact

After these migrations run:
- Users will no longer see "unknown advisor statement.prior-backup-check" errors
- Built-in rules will work correctly (injected by code, not stored in DB)
- Review configs will be clean of built-in rules
- No duplicate rule warnings

## Test Plan

- [x] Migration test passes (`TestLatestVersion`)
- [x] SQL tested with sample data confirms correct removal of built-in rules
- [x] Other user-defined rules remain intact