### PR TITLE
fix(advisor): support column comment check for MySQL generated columns

### DIFF
--- a/backend/plugin/advisor/mysql/test/column_comment.yaml
+++ b/backend/plugin/advisor/mysql/test/column_comment.yaml
@@ -181,3 +181,66 @@
         line: 2
         column: 0
       endposition: null
+# Test cases for virtual/generated columns (BYT-8503)
+- statement: |-
+    CREATE TABLE users (
+      id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'ID',
+      first_name VARCHAR(60) NOT NULL COMMENT 'First',
+      last_name VARCHAR(60) NOT NULL COMMENT 'Last',
+      full_name VARCHAR(120) GENERATED ALWAYS AS (CONCAT(first_name, ' ', last_name)) VIRTUAL COMMENT 'Full'
+    );
+  changeType: 1
+# Virtual column with comment - should pass
+- statement: |-
+    CREATE TABLE t(
+      a int COMMENT 'comment',
+      b int GENERATED ALWAYS AS (a * 2) VIRTUAL COMMENT 'comment'
+    );
+  changeType: 1
+# Stored generated column with comment - should pass
+- statement: |-
+    CREATE TABLE t(
+      a int COMMENT 'comment',
+      b int GENERATED ALWAYS AS (a * 2) STORED COMMENT 'comment'
+    );
+  changeType: 1
+# Virtual column without comment - should fail
+- statement: |-
+    CREATE TABLE t(
+      a int COMMENT 'comment',
+      b int GENERATED ALWAYS AS (a * 2) VIRTUAL
+    );
+  changeType: 1
+  want:
+    - status: 2
+      code: 1032
+      title: COLUMN_COMMENT
+      content: Column `t`.`b` requires comments
+      startposition:
+        line: 3
+        column: 0
+      endposition: null
+# Mixed regular and generated columns
+- statement: |-
+    CREATE TABLE t(
+      a int,
+      b int GENERATED ALWAYS AS (a * 2) VIRTUAL
+    );
+  changeType: 1
+  want:
+    - status: 2
+      code: 1032
+      title: COLUMN_COMMENT
+      content: Column `t`.`a` requires comments
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+    - status: 2
+      code: 1032
+      title: COLUMN_COMMENT
+      content: Column `t`.`b` requires comments
+      startposition:
+        line: 3
+        column: 0
+      endposition: null

--- a/backend/plugin/advisor/tidb/test/column_comment.yaml
+++ b/backend/plugin/advisor/tidb/test/column_comment.yaml
@@ -107,3 +107,66 @@
         line: 2
         column: 0
       endposition: null
+# Test cases for virtual/generated columns (BYT-8503)
+- statement: |-
+    CREATE TABLE users (
+      id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'ID',
+      first_name VARCHAR(60) NOT NULL COMMENT 'First',
+      last_name VARCHAR(60) NOT NULL COMMENT 'Last',
+      full_name VARCHAR(120) GENERATED ALWAYS AS (CONCAT(first_name, ' ', last_name)) VIRTUAL COMMENT 'Full'
+    )
+  changeType: 1
+# Virtual column with comment - should pass
+- statement: |-
+    CREATE TABLE t(
+      a int COMMENT 'comment',
+      b int GENERATED ALWAYS AS (a * 2) VIRTUAL COMMENT 'comment'
+    )
+  changeType: 1
+# Stored generated column with comment - should pass
+- statement: |-
+    CREATE TABLE t(
+      a int COMMENT 'comment',
+      b int GENERATED ALWAYS AS (a * 2) STORED COMMENT 'comment'
+    )
+  changeType: 1
+# Virtual column without comment - should fail
+- statement: |-
+    CREATE TABLE t(
+      a int COMMENT 'comment',
+      b int GENERATED ALWAYS AS (a * 2) VIRTUAL
+    )
+  changeType: 1
+  want:
+    - status: 2
+      code: 1032
+      title: COLUMN_COMMENT
+      content: Column `t`.`b` requires comments
+      startposition:
+        line: 3
+        column: 0
+      endposition: null
+# Mixed regular and generated columns
+- statement: |-
+    CREATE TABLE t(
+      a int,
+      b int GENERATED ALWAYS AS (a * 2) VIRTUAL
+    )
+  changeType: 1
+  want:
+    - status: 2
+      code: 1032
+      title: COLUMN_COMMENT
+      content: Column `t`.`a` requires comments
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+    - status: 2
+      code: 1032
+      title: COLUMN_COMMENT
+      content: Column `t`.`b` requires comments
+      startposition:
+        line: 3
+        column: 0
+      endposition: null


### PR DESCRIPTION
## Summary

- Fix MySQL column comment convention advisor to correctly handle generated/virtual columns
- Add test cases for MySQL and TiDB generated columns

## Root Cause

MySQL generated/virtual columns use `gcolAttribute` for the COMMENT clause instead of `columnAttribute`. The column comment convention advisor was only checking `columnAttribute`, causing false positives for generated columns that have comments.

**Grammar:**
```
fieldDefinition:
    dataType columnAttribute*  // Regular columns
    | ... AS expr (VIRTUAL|STORED)? (
        gcolAttribute*         // Generated columns use gcolAttribute
        | columnAttribute*     // MySQL 8.0+ may use columnAttribute
    )

gcolAttribute:
    UNIQUE KEY?
    | COMMENT textString       <-- COMMENT for generated columns
    | NOT? NULL
    | PRIMARY? KEY
```

## Changes

1. Updated `checkFieldDefinition()` in `rule_column_comment_convention.go` to also check `gcolAttribute` for generated columns
2. Added test cases for MySQL generated columns (virtual and stored)
3. Added test cases for TiDB generated columns

## Other Engines Checked

| Engine | Status |
|--------|--------|
| TiDB | Uses PingCAP parser which handles options uniformly - added tests to verify |
| PostgreSQL | Uses `COMMENT ON COLUMN` statements - no change needed |
| Oracle | Uses `COMMENT ON COLUMN` statements - no change needed |
| MSSQL | No column comment advisor (uses extended properties) |

## Test plan

- [x] MySQL advisor tests pass
- [x] TiDB advisor tests pass
- [x] Build succeeds

Fixes BYT-8503

🤖 Generated with [Claude Code](https://claude.com/claude-code)