### PR TITLE
fix: simply fetch the databases

### DIFF
--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/tree.ts
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/tree.ts
@@ -18,7 +18,7 @@ import type {
   StatefulSQLEditorTreeFactor as StatefulFactor,
   SQLEditorTreeNode as TreeNode,
 } from "@/types";
-import { DEBOUNCE_SEARCH_DELAY, unknownEnvironment } from "@/types";
+import { DEBOUNCE_SEARCH_DELAY } from "@/types";
 import {
   getDefaultPagination,
   isDatabaseV1Queryable,
@@ -53,7 +53,6 @@ export const useSQLEditorTreeByEnvironment = (
   const { project } = storeToRefs(useSQLEditorStore());
   const currentUser = useCurrentUserV1();
   const environmentStore = useEnvironmentV1Store();
-  const unknownEnv = unknownEnvironment();
 
   const tree = ref<TreeNode[]>([]);
   const showMissingQueryDatabases = ref<boolean>(false);


### PR DESCRIPTION
Fix issue BYT-8520

Cause

The customer has many databases, but for normal users, they don't have the query permission for most databases, so we keep calling ListDatabase many times, it's the root cause for slow UX

It's a temporary but simple solution for this issue. In the future, we may want to support filtering databases by the query permission in the SQL Editor.