### PR TITLE
fix(migrator): append (DDL)/(DML) suffix to approval rule titles during consolidation

### DIFF
--- a/backend/migrator/migration/3.13/0006##approval_source_consolidation.sql
+++ b/backend/migrator/migration/3.13/0006##approval_source_consolidation.sql
@@ -7,10 +7,14 @@ SET value = (
     value::jsonb,
     '{rules}',
     (
-      -- DDL rules: rename to CHANGE_DATABASE and add DDL condition filter
+      -- DDL rules: rename to CHANGE_DATABASE, append (DDL) to title, and add DDL condition filter
       SELECT COALESCE(jsonb_agg(
         jsonb_set(
-          jsonb_set(rule, '{source}', '"CHANGE_DATABASE"'),
+          jsonb_set(
+            jsonb_set(rule, '{source}', '"CHANGE_DATABASE"'),
+            '{template,title}',
+            to_jsonb((rule->'template'->>'title') || ' (DDL)')
+          ),
           '{condition,expression}',
           to_jsonb(
             CASE
@@ -24,10 +28,14 @@ SET value = (
       FROM jsonb_array_elements(value::jsonb->'rules') AS rule
       WHERE rule->>'source' = 'DDL'
     ) || (
-      -- DML rules: rename to CHANGE_DATABASE and add DML condition filter (appended after DDL)
+      -- DML rules: rename to CHANGE_DATABASE, append (DML) to title, and add DML condition filter (appended after DDL)
       SELECT COALESCE(jsonb_agg(
         jsonb_set(
-          jsonb_set(rule, '{source}', '"CHANGE_DATABASE"'),
+          jsonb_set(
+            jsonb_set(rule, '{source}', '"CHANGE_DATABASE"'),
+            '{template,title}',
+            to_jsonb((rule->'template'->>'title') || ' (DML)')
+          ),
           '{condition,expression}',
           to_jsonb(
             CASE


### PR DESCRIPTION
## Summary
- Append `(DDL)` or `(DML)` suffix to approval rule titles when migrating DDL/DML sources to CHANGE_DATABASE
- Helps users identify the original source type after consolidation

## Test plan
- [ ] Run migration on existing approval settings with DDL/DML rules
- [ ] Verify titles are updated with correct suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)