### PR TITLE
chore: update masking exemption member format to match IAM policy

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -12339,9 +12339,9 @@ components:
             type: string
           title: members
           description: |-
-            Members who bind to this exemption.
-
-             Format: users/{email} or groups/{group email}
+            Specifies the principals who are exempt from masking.
+             For users, the member should be: user:{email}
+             For groups, the member should be: group:{email}
         condition:
           title: condition
           description: |-

--- a/backend/generated-go/v1/org_policy_service.pb.go
+++ b/backend/generated-go/v1/org_policy_service.pb.go
@@ -1089,9 +1089,9 @@ func (x *DataSourceQueryPolicy) GetDisallowDml() bool {
 
 type MaskingExemptionPolicy_Exemption struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Members who bind to this exemption.
-	//
-	// Format: users/{email} or groups/{group email}
+	// Specifies the principals who are exempt from masking.
+	// For users, the member should be: user:{email}
+	// For groups, the member should be: group:{email}
 	Members []string `protobuf:"bytes,1,rep,name=members,proto3" json:"members,omitempty"`
 	// The condition that is associated with this exception policy instance.
 	// The syntax and semantics of CEL are documented at https://github.com/google/cel-spec

--- a/frontend/src/components/Member/MembersBindingSelect.vue
+++ b/frontend/src/components/Member/MembersBindingSelect.vue
@@ -89,7 +89,7 @@ type MemberType = "USERS" | "GROUPS";
 
 const props = withDefaults(
   defineProps<{
-    // member binding list, for users, should be user:{email}, for groups, shoud be groups:{email}
+    // member binding list, for users, should be user:{email}, for groups, should be group:{email}
     // We don't support mixed data.
     value: string[];
     required: boolean;

--- a/frontend/src/types/proto-es/v1/org_policy_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/org_policy_service_pb.d.ts
@@ -375,9 +375,9 @@ export declare const MaskingExemptionPolicySchema: GenMessage<MaskingExemptionPo
  */
 export declare type MaskingExemptionPolicy_Exemption = Message<"bytebase.v1.MaskingExemptionPolicy.Exemption"> & {
   /**
-   * Members who bind to this exemption.
-   *
-   * Format: users/{email} or groups/{group email}
+   * Specifies the principals who are exempt from masking.
+   * For users, the member should be: user:{email}
+   * For groups, the member should be: group:{email}
    *
    * @generated from field: repeated string members = 1;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -11539,9 +11539,9 @@ components:
                     items:
                         type: string
                     description: |-
-                        Members who bind to this exemption.
-
-                         Format: users/{email} or groups/{group email}
+                        Specifies the principals who are exempt from masking.
+                         For users, the member should be: user:{email}
+                         For groups, the member should be: group:{email}
                 condition:
                     allOf:
                         - $ref: '#/components/schemas/Expr'

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -6522,9 +6522,7 @@ MaskingExemptionPolicy is the allowlist of users who can access sensitive data.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| members | [string](#string) | repeated | Members who bind to this exemption.
-
-Format: users/{email} or groups/{group email} |
+| members | [string](#string) | repeated | Specifies the principals who are exempt from masking. For users, the member should be: user:{email} For groups, the member should be: group:{email} |
 | condition | [google.type.Expr](#google-type-Expr) |  | The condition that is associated with this exception policy instance. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec If the condition is empty, means the user can access all databases without expiration.
 
 Support variables: resource.instance_id: the instance resource id. Only support &#34;==&#34; operation. resource.database_name: the database name. Only support &#34;==&#34; operation. resource.schema_name: the schema name. Only support &#34;==&#34; operation. resource.table_name: the table name. Only support &#34;==&#34; operation. resource.column_name: the column name. Only support &#34;==&#34; operation. request.time: the expiration. Only support &#34;&lt;&#34; operation in `request.time &lt; timestamp(&#34;{ISO datetime string format}&#34;)` All variables should join with &#34;&amp;&amp;&#34; condition.

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -18442,9 +18442,9 @@ Format: {resource type}/{resource id} </p></td>
                   <td>members</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>Members who bind to this exemption.
-
-Format: users/{email} or groups/{group email} </p></td>
+                  <td><p>Specifies the principals who are exempt from masking.
+For users, the member should be: user:{email}
+For groups, the member should be: group:{email} </p></td>
                 </tr>
               
                 <tr>

--- a/proto/v1/v1/org_policy_service.proto
+++ b/proto/v1/v1/org_policy_service.proto
@@ -307,9 +307,9 @@ message QueryDataPolicy {
 // MaskingExemptionPolicy is the allowlist of users who can access sensitive data.
 message MaskingExemptionPolicy {
   message Exemption {
-    // Members who bind to this exemption.
-    //
-    // Format: users/{email} or groups/{group email}
+    // Specifies the principals who are exempt from masking.
+    // For users, the member should be: user:{email}
+    // For groups, the member should be: group:{email}
     repeated string members = 1;
 
     // The condition that is associated with this exception policy instance.


### PR DESCRIPTION
## Summary

Update the format of `members` field in `MaskingExemptionPolicy.Exemption` to be consistent with IAM policy format:

- **Old format:** `users/{email}` or `groups/{group email}`
- **New format:** `user:{email}` or `group:{email}`

This change improves consistency across the codebase and aligns with the IAM policy member format used in `iam_policy.proto`.

## Changes

1. **Proto definition** (`proto/v1/v1/org_policy_service.proto`):
   - Updated comment for `Exemption.members` field to match IAM policy format
   - Changed from `users/{email}` to `user:{email}`
   - Changed from `groups/{group email}` to `group:{email}`
   - Improved clarity of the comment

2. **Frontend** (`frontend/src/components/Member/MembersBindingSelect.vue`):
   - Fixed comment typo from `groups:{email}` to `group:{email}`

3. **Generated files**:
   - Regenerated proto files and documentation

## Backend Compatibility

The backend already handles this format correctly through conversion functions:
- `convertToStoreIamPolicyMember` - converts API format (`user:{email}`) to internal storage format (`users/{email}`)
- `convertToV1MemberInBinding` - converts internal storage format back to API format

These functions are already used in the masking exemption policy converters, so no additional backend changes are needed.

## Test plan

- [ ] Verify proto generation completed successfully
- [ ] Test masking exemption policy creation/update with new format
- [ ] Verify frontend displays members correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)