### PR TITLE
refactor(frontend): extract shared SpecLink component for plan spec updates

### DIFF
--- a/frontend/src/components/v2/Model/Plan/SpecLink.vue
+++ b/frontend/src/components/v2/Model/Plan/SpecLink.vue
@@ -1,0 +1,36 @@
+<template>
+  <RouterLink
+    v-if="canLink"
+    :to="{
+      name: PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+      params: {
+        projectId: projectName,
+        planId: planUID,
+        specId: specId,
+      },
+    }"
+    class="inline-flex items-center gap-1 hover:underline"
+  >
+    {{ $t("plan.spec.change") }}
+    <NTag size="tiny" round> #{{ displayIndex }} </NTag>
+  </RouterLink>
+  <span v-else>{{ $t("plan.spec.change") }}</span>
+</template>
+
+<script lang="ts" setup>
+import { NTag } from "naive-ui";
+import { computed } from "vue";
+import { RouterLink } from "vue-router";
+import { PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL } from "@/router/dashboard/projectV1";
+
+const props = defineProps<{
+  projectName: string;
+  planUID: string;
+  specId: string;
+  displayIndex: number;
+}>();
+
+const canLink = computed(() => {
+  return props.projectName && props.planUID && props.specId;
+});
+</script>

--- a/frontend/src/components/v2/Model/Plan/index.ts
+++ b/frontend/src/components/v2/Model/Plan/index.ts
@@ -1,0 +1,1 @@
+export { default as SpecLink } from "./SpecLink.vue";

--- a/frontend/src/components/v2/Model/index.ts
+++ b/frontend/src/components/v2/Model/index.ts
@@ -11,6 +11,7 @@ import ProjectV1Table from "./ProjectV1Table.vue";
 import RichDatabaseName from "./RichDatabaseName.vue";
 
 export * from "./Instance";
+export * from "./Plan";
 export * from "./User";
 export * from "./DatabaseV1Table";
 export * from "./Project";

--- a/frontend/src/locales/dynamic/en-US.json
+++ b/frontend/src/locales/dynamic/en-US.json
@@ -23,7 +23,8 @@
     "sentence": {
       "verb-type-target-by-people": "{verb} {type} {target}",
       "verb-type-target-by-system-bot": "{type} {target} {verb}",
-      "changed-x-link": "changed {name}. {link}"
+      "changed-x-link": "changed {name}. {link}",
+      "modified-sql-of-spec-link": "Modified SQL of {spec}. {link}"
     }
   },
   "settings": {

--- a/frontend/src/locales/dynamic/es-ES.json
+++ b/frontend/src/locales/dynamic/es-ES.json
@@ -23,7 +23,8 @@
     "sentence": {
       "verb-type-target-by-people": "{verb} {type} {target}",
       "verb-type-target-by-system-bot": "{type} {target} {verb}",
-      "changed-x-link": "cambiado {name}. \n{link}"
+      "changed-x-link": "cambiado {name}. \n{link}",
+      "modified-sql-of-spec-link": "SQL modificado de {spec}. {link}"
     }
   },
   "settings": {

--- a/frontend/src/locales/dynamic/ja-JP.json
+++ b/frontend/src/locales/dynamic/ja-JP.json
@@ -23,7 +23,8 @@
     "sentence": {
       "verb-type-target-by-people": "{verb} {type} {target}",
       "verb-type-target-by-system-bot": "{type} {target} {verb}",
-      "changed-x-link": "{name} が変更されました。 {link}"
+      "changed-x-link": "{name} が変更されました。 {link}",
+      "modified-sql-of-spec-link": "{spec} の SQL が変更されました。{link}"
     }
   },
   "settings": {

--- a/frontend/src/locales/dynamic/vi-VN.json
+++ b/frontend/src/locales/dynamic/vi-VN.json
@@ -23,7 +23,8 @@
     "sentence": {
       "verb-type-target-by-people": "{verb} {type} {target}",
       "verb-type-target-by-system-bot": "{type} {target} {verb}",
-      "changed-x-link": "đã thay đổi {name}. {link}"
+      "changed-x-link": "đã thay đổi {name}. {link}",
+      "modified-sql-of-spec-link": "Đã sửa đổi SQL của {spec}. {link}"
     }
   },
   "settings": {

--- a/frontend/src/locales/dynamic/zh-CN.json
+++ b/frontend/src/locales/dynamic/zh-CN.json
@@ -23,7 +23,8 @@
     "sentence": {
       "verb-type-target-by-people": "{verb} {type} {target}",
       "verb-type-target-by-system-bot": "{type} {target} {verb}",
-      "changed-x-link": "修改了 {name}。{link}"
+      "changed-x-link": "修改了 {name}。{link}",
+      "modified-sql-of-spec-link": "修改了 {spec} 的 SQL。{link}"
     }
   },
   "settings": {

--- a/frontend/src/utils/v1/issue/plan.ts
+++ b/frontend/src/utils/v1/issue/plan.ts
@@ -32,3 +32,27 @@ export const extractPlanCheckRunUID = (name: string) => {
   const matches = name.match(pattern);
   return matches?.[1] ?? "";
 };
+
+export const extractSpecId = (name: string) => {
+  const pattern = /(?:^|\/)specs\/([^/]+)(?:$|\/)/;
+  const matches = name.match(pattern);
+  return matches?.[1] ?? "";
+};
+
+/**
+ * Get spec display info from spec resource name.
+ * Returns specId and 1-based display index, or null if not found.
+ */
+export const getSpecDisplayInfo = (
+  specs: Plan_Spec[],
+  specResourceName: string
+): { specId: string; displayIndex: number } | null => {
+  const specId = extractSpecId(specResourceName);
+  if (!specId) return null;
+
+  const index = specs.findIndex((spec) => spec.id === specId);
+  if (index >= 0) {
+    return { specId, displayIndex: index + 1 };
+  }
+  return null;
+};


### PR DESCRIPTION

- Create reusable SpecLink component in components/v2/Model/Plan
- Extract getSpecDisplayInfo utility function to utils/v1/issue/plan.ts
- Update both ActionSentence.vue files to use shared code

This reduces code duplication between IssueV1 and Plan comment views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)