### PR TITLE
refactor(frontend): add proper i18n for changelog MIGRATE type

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1622,6 +1622,9 @@
     "self": "Changelog",
     "select": "Schema version is recorded each time a schema change is applied via Bytebase",
     "change-type": "Type",
+    "type": {
+      "migrate": "Migrate"
+    },
     "no-schema-change": "this migration has no schema change",
     "show-diff": "Show diff",
     "schema-snapshot-after-change": "The schema snapshot recorded after applying this change",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1622,6 +1622,9 @@
     "self": "Historial de cambios",
     "select": "La versión del esquema se registra cada vez que se aplica un cambio de esquema a través de Bytebase",
     "change-type": "Tipo",
+    "type": {
+      "migrate": "Migrar"
+    },
     "no-schema-change": "esta migración no tiene cambios de esquema",
     "show-diff": "Mostrar diferencias",
     "schema-snapshot-after-change": "La instantánea de esquema registrada después de aplicar este cambio",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1622,6 +1622,9 @@
     "self": "変更履歴",
     "select": "スキーマのバージョンは、Bytebase を通じてスキーマの変更が実行されるたびに記録されます。",
     "change-type": "タイプ",
+    "type": {
+      "migrate": "マイグレート"
+    },
     "no-schema-change": "この変更ではスキーマの変更はありません",
     "show-diff": "違いを表示",
     "schema-snapshot-after-change": "この変更を完了した後のスキーマのスナップショット",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1622,6 +1622,9 @@
     "self": "Nhật ký thay đổi",
     "select": "Phiên bản lược đồ được ghi lại mỗi khi thay đổi lược đồ được áp dụng qua Bytebase",
     "change-type": "Loại thay đổi",
+    "type": {
+      "migrate": "Di chuyển"
+    },
     "no-schema-change": "di chuyển này không có thay đổi lược đồ",
     "show-diff": "Hiển thị khác biệt",
     "schema-snapshot-after-change": "Ảnh chụp nhanh lược đồ được ghi lại sau khi áp dụng thay đổi này",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1622,6 +1622,9 @@
     "self": "变更历史",
     "select": "Schema 版本是在每次通过 Bytebase 执行 Schema 变更后被记录下来的",
     "change-type": "类型",
+    "type": {
+      "migrate": "变更"
+    },
     "no-schema-change": "本次变更没有任何 Schema 的改动",
     "show-diff": "显示差异",
     "schema-snapshot-after-change": "完成这次变更后的 schema 快照",

--- a/frontend/src/utils/v1/changelog.ts
+++ b/frontend/src/utils/v1/changelog.ts
@@ -60,7 +60,7 @@ export const getChangelogChangeType = (type: Changelog_Type) => {
     case Changelog_Type.SDL:
       return "SDL";
     case Changelog_Type.MIGRATE:
-      return t("issue.title.change-database");
+      return t("changelog.type.migrate");
     case Changelog_Type.BASELINE:
       return t("common.baseline");
     default:


### PR DESCRIPTION
## Summary
- Add dedicated i18n key `changelog.type.migrate` for MIGRATE changelog type display
- Replace hardcoded `issue.title.change-database` with proper changelog-specific translation
- Add translations for all supported locales (en, zh, ja, es, vi)

## Test plan
- [ ] Verify changelog table displays "Migrate" (or localized equivalent) for MIGRATE type entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)