### PR TITLE
chore(frontend): clarify run tasks button and drawer text

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskRolloutActionPanel.vue
@@ -221,7 +221,7 @@
                 type="primary"
                 @click="handleConfirm"
               >
-                {{ title }}
+                {{ action === "RUN" ? $t("common.run") : action === "SKIP" ? $t("common.skip") : $t("common.cancel") }}
               </NButton>
             </template>
             <template #default>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1234,7 +1234,7 @@
     },
     "stage": {
       "self": "Stage | Stages",
-      "run-stage": "Run Stage",
+      "run-stage": "Run Tasks",
       "confirm-create": "Confirm to create tasks for this stage?",
       "back-to-stage": "Back to Stage {stage}"
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1234,7 +1234,7 @@
     },
     "stage": {
       "self": "Escenario | Escenarios",
-      "run-stage": "Etapa de ejecución",
+      "run-stage": "Ejecutar tareas",
       "confirm-create": "¿Está seguro de que desea crear tareas para esta etapa?",
       "back-to-stage": "Volver a la etapa {stage}"
     },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1234,7 +1234,7 @@
     },
     "stage": {
       "self": "ステージ | ステージ",
-      "run-stage": "ランステージ",
+      "run-stage": "タスクを実行",
       "confirm-create": "このステージのタスクを作成してもよろしいですか？",
       "back-to-stage": "ステージに戻る {stage}"
     },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1234,7 +1234,7 @@
     },
     "stage": {
       "self": "Giai đoạn | Các giai đoạn",
-      "run-stage": "Chạy sân khấu",
+      "run-stage": "Chạy tác vụ",
       "confirm-create": "Bạn có chắc chắn muốn tạo tác vụ cho giai đoạn này không?",
       "back-to-stage": "Trở lại sân khấu {stage}"
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1234,7 +1234,7 @@
     },
     "stage": {
       "self": "阶段 | 阶段",
-      "run-stage": "运行阶段",
+      "run-stage": "运行任务",
       "confirm-create": "确定要为此阶段创建任务吗？",
       "back-to-stage": "返回阶段 {stage}"
     },


### PR DESCRIPTION
Change "Run Stage" to "Run Tasks" for consistency with the action being performed. Simplify confirm button to just "Run", "Skip", or "Cancel" based on the action type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)