### PR TITLE
fix: remove unnecessary horizontal negative margin causing horizontal…

### DIFF
--- a/frontend/src/views/ProfileDashboard.vue
+++ b/frontend/src/views/ProfileDashboard.vue
@@ -10,7 +10,7 @@
     <div v-else>
       <!-- Profile header -->
       <div>
-        <div class="-m-6 h-32 bg-accent lg:h-48"></div>
+        <div class="-mt-4 h-32 bg-accent lg:h-48"></div>
         <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div class="-mt-20 sm:flex sm:items-end sm:gap-x-5">
             <UserAvatar :user="user" size="HUGE" />


### PR DESCRIPTION
… scroll on user profile page

The -m-6 class was applying negative margins in all directions, but the parent container has no horizontal padding. Only vertical negative margin (-mt-4) is needed to compensate for the py-4 padding on the layout container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)