### PR TITLE
test: add integration tests for CheckRelease endpoint

### DIFF
--- a/backend/tests/gitops_test.go
+++ b/backend/tests/gitops_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/bytebase/backend/common"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 )
 
@@ -781,4 +782,571 @@ func TestGitOpsCheckAppliedButChanged(t *testing.T) {
 	a.Contains(advice.Content, "Release SHA256:", "Should include the SHA256 of the new release file")
 	a.Contains(advice.Content, "migrations/1.0.0__create_users_table.sql", "Should mention the specific file")
 	a.Contains(advice.Content, "version \"1.0.0\"", "Should mention the version")
+}
+
+// TestGitOpsCheckEmptyTargets tests that CheckRelease returns an error when targets are empty.
+func TestGitOpsCheckEmptyTargets(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	// Create a project.
+	projectID := generateRandomString("gitops-empty")
+	projectResp, err := ctl.projectServiceClient.CreateProject(ctx, connect.NewRequest(&v1pb.CreateProjectRequest{
+		Project: &v1pb.Project{
+			Name:  fmt.Sprintf("projects/%s", projectID),
+			Title: projectID,
+		},
+		ProjectId: projectID,
+	}))
+	a.NoError(err)
+	project := projectResp.Msg
+
+	// Create a release with a migration file.
+	release := &v1pb.Release{
+		Title: "Test Release",
+		Files: []*v1pb.Release_File{
+			{
+				Path:      "migrations/001__create_table.sql",
+				Type:      v1pb.Release_File_VERSIONED,
+				Version:   "001",
+				Statement: []byte(`CREATE TABLE test_table (id INT);`),
+			},
+		},
+	}
+
+	// Call CheckRelease with empty targets - should fail.
+	_, err = ctl.releaseServiceClient.CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+		Parent:  project.Name,
+		Release: release,
+		Targets: []string{}, // Empty targets
+	}))
+	a.Error(err, "CheckRelease should fail with empty targets")
+	a.Contains(err.Error(), "targets cannot be empty", "Error should mention empty targets")
+}
+
+// TestGitOpsCheckDeclarative tests CheckRelease with declarative (SDL) files using PostgreSQL.
+func TestGitOpsCheckDeclarative(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	// Create a project.
+	projectID := generateRandomString("gitops-decl")
+	projectResp, err := ctl.projectServiceClient.CreateProject(ctx, connect.NewRequest(&v1pb.CreateProjectRequest{
+		Project: &v1pb.Project{
+			Name:  fmt.Sprintf("projects/%s", projectID),
+			Title: projectID,
+		},
+		ProjectId: projectID,
+	}))
+	a.NoError(err)
+	project := projectResp.Msg
+
+	// Provision PostgreSQL instance.
+	pgContainer, err := getPgContainer(ctx)
+	a.NoError(err)
+	defer pgContainer.Close(ctx)
+
+	pgInstanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "gitops-decl-pg",
+			Engine:      v1pb.Engine_POSTGRES,
+			Environment: stringPtr("environments/test"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{
+				Type:     v1pb.DataSourceType_ADMIN,
+				Host:     pgContainer.host,
+				Port:     pgContainer.port,
+				Username: "postgres",
+				Password: "root-password",
+				Id:       "admin",
+			}},
+		},
+	}))
+	a.NoError(err)
+	pgInstance := pgInstanceResp.Msg
+
+	// Create database.
+	databaseName := "gitops_decl_db"
+	err = ctl.createDatabase(ctx, project, pgInstance, nil, databaseName, "postgres")
+	a.NoError(err)
+
+	// Create a release with declarative SDL files.
+	release := &v1pb.Release{
+		Title: "Declarative SDL Release",
+		Files: []*v1pb.Release_File{
+			{
+				Path:    "schema/users.sql",
+				Type:    v1pb.Release_File_DECLARATIVE,
+				Version: "1.0.0",
+				Statement: []byte(`CREATE TABLE public.users (
+    id SERIAL NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    email VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_users PRIMARY KEY (id),
+    CONSTRAINT uk_users_username UNIQUE (username)
+);`),
+			},
+		},
+	}
+
+	// Call CheckRelease with declarative files.
+	checkResp, err := ctl.releaseServiceClient.CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+		Parent:  project.Name,
+		Release: release,
+		Targets: []string{
+			fmt.Sprintf("%s/databases/%s", pgInstance.Name, databaseName),
+		},
+	}))
+	a.NoError(err)
+	a.NotNil(checkResp)
+
+	// For valid declarative SDL, there should be no error advices.
+	for _, result := range checkResp.Msg.Results {
+		for _, advice := range result.Advices {
+			a.NotEqual(v1pb.Advice_ERROR, advice.Status,
+				"Valid SDL should not produce error advices, got: %s - %s", advice.Title, advice.Content)
+		}
+	}
+}
+
+// TestGitOpsCheckDeclarativeDisallowedStatements tests that CheckRelease catches disallowed statements in SDL files.
+func TestGitOpsCheckDeclarativeDisallowedStatements(t *testing.T) {
+	t.Parallel()
+
+	// Test cases for disallowed statements in SDL files.
+	testCases := []struct {
+		name              string
+		statement         string
+		expectError       bool
+		expectedErrorType string
+	}{
+		{
+			name: "DROP TABLE is disallowed",
+			statement: `CREATE TABLE public.users (id SERIAL PRIMARY KEY);
+DROP TABLE public.old_table;`,
+			expectError:       true,
+			expectedErrorType: "DROP",
+		},
+		{
+			name: "INSERT is disallowed",
+			statement: `CREATE TABLE public.users (id SERIAL PRIMARY KEY);
+INSERT INTO public.users (id) VALUES (1);`,
+			expectError:       true,
+			expectedErrorType: "INSERT",
+		},
+		{
+			name: "UPDATE is disallowed",
+			statement: `CREATE TABLE public.users (id SERIAL PRIMARY KEY);
+UPDATE public.users SET id = 2 WHERE id = 1;`,
+			expectError:       true,
+			expectedErrorType: "UPDATE",
+		},
+		{
+			name: "DELETE is disallowed",
+			statement: `CREATE TABLE public.users (id SERIAL PRIMARY KEY);
+DELETE FROM public.users WHERE id = 1;`,
+			expectError:       true,
+			expectedErrorType: "DELETE",
+		},
+		{
+			name: "ALTER TABLE (non-sequence) is disallowed",
+			statement: `CREATE TABLE public.users (id SERIAL PRIMARY KEY);
+ALTER TABLE public.users ADD COLUMN name VARCHAR(255);`,
+			expectError:       true,
+			expectedErrorType: "ALTER",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := require.New(t)
+			ctx := context.Background()
+			ctl := &controller{}
+			ctx, err := ctl.StartServerWithExternalPg(ctx)
+			a.NoError(err)
+			defer ctl.Close(ctx)
+
+			// Create a project.
+			projectID := generateRandomString("gitops-disallow")
+			projectResp, err := ctl.projectServiceClient.CreateProject(ctx, connect.NewRequest(&v1pb.CreateProjectRequest{
+				Project: &v1pb.Project{
+					Name:  fmt.Sprintf("projects/%s", projectID),
+					Title: projectID,
+				},
+				ProjectId: projectID,
+			}))
+			a.NoError(err)
+			project := projectResp.Msg
+
+			// Provision PostgreSQL instance.
+			pgContainer, err := getPgContainer(ctx)
+			a.NoError(err)
+			defer pgContainer.Close(ctx)
+
+			pgInstanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+				InstanceId: generateRandomString("instance"),
+				Instance: &v1pb.Instance{
+					Title:       "gitops-disallow-pg",
+					Engine:      v1pb.Engine_POSTGRES,
+					Environment: stringPtr("environments/test"),
+					Activation:  true,
+					DataSources: []*v1pb.DataSource{{
+						Type:     v1pb.DataSourceType_ADMIN,
+						Host:     pgContainer.host,
+						Port:     pgContainer.port,
+						Username: "postgres",
+						Password: "root-password",
+						Id:       "admin",
+					}},
+				},
+			}))
+			a.NoError(err)
+			pgInstance := pgInstanceResp.Msg
+
+			// Create database.
+			databaseName := "gitops_disallow_db"
+			err = ctl.createDatabase(ctx, project, pgInstance, nil, databaseName, "postgres")
+			a.NoError(err)
+
+			release := &v1pb.Release{
+				Title: fmt.Sprintf("Test Release - %s", tc.name),
+				Files: []*v1pb.Release_File{
+					{
+						Path:      "schema/test.sql",
+						Type:      v1pb.Release_File_DECLARATIVE,
+						Version:   "1.0.0",
+						Statement: []byte(tc.statement),
+					},
+				},
+			}
+
+			checkResp, err := ctl.releaseServiceClient.CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+				Parent:  project.Name,
+				Release: release,
+				Targets: []string{
+					fmt.Sprintf("%s/databases/%s", pgInstance.Name, databaseName),
+				},
+			}))
+			a.NoError(err, "CheckRelease API call should succeed")
+			a.NotNil(checkResp)
+
+			if tc.expectError {
+				// Should have at least one result with error advice about disallowed statement.
+				foundDisallowedError := false
+				for _, result := range checkResp.Msg.Results {
+					for _, advice := range result.Advices {
+						if advice.Status == v1pb.Advice_ERROR &&
+							(advice.Title == "Disallowed statement in SDL file" ||
+								advice.Title == "Syntax error") {
+							foundDisallowedError = true
+							break
+						}
+					}
+				}
+				a.True(foundDisallowedError,
+					"Expected error advice for disallowed %s statement, but got none. Results: %v",
+					tc.expectedErrorType, checkResp.Msg.Results)
+			}
+		})
+	}
+}
+
+// TestGitOpsCheckVersionedDependency tests that CheckRelease SQL review handles dependencies
+// between migration files correctly.
+// Test case 1: Create table t1, then alter table t1 - should pass with no SQL review errors
+// Test case 2: Create table t1, then alter table t2 - should have SQL review error (t2 doesn't exist)
+func TestGitOpsCheckVersionedDependency(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		files       []*v1pb.Release_File
+		expectError bool
+	}{
+		{
+			name: "alter_same_table_should_pass",
+			files: []*v1pb.Release_File{
+				{
+					Path:    "migrations/001__create_t1.sql",
+					Type:    v1pb.Release_File_VERSIONED,
+					Version: "001",
+					Statement: []byte(`CREATE TABLE t1 (
+	id SERIAL PRIMARY KEY,
+	name VARCHAR(255) NOT NULL
+);`),
+				},
+				{
+					Path:      "migrations/002__alter_t1.sql",
+					Type:      v1pb.Release_File_VERSIONED,
+					Version:   "002",
+					Statement: []byte(`ALTER TABLE t1 ADD COLUMN email VARCHAR(255);`),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "alter_nonexistent_table_should_error",
+			files: []*v1pb.Release_File{
+				{
+					Path:    "migrations/001__create_t1.sql",
+					Type:    v1pb.Release_File_VERSIONED,
+					Version: "001",
+					Statement: []byte(`CREATE TABLE t1 (
+	id SERIAL PRIMARY KEY,
+	name VARCHAR(255) NOT NULL
+);`),
+				},
+				{
+					Path:      "migrations/002__alter_t2.sql",
+					Type:      v1pb.Release_File_VERSIONED,
+					Version:   "002",
+					Statement: []byte(`ALTER TABLE t2 ADD COLUMN email VARCHAR(255);`),
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := require.New(t)
+			ctx := context.Background()
+			ctl := &controller{}
+			ctx, err := ctl.StartServerWithExternalPg(ctx)
+			a.NoError(err)
+			defer ctl.Close(ctx)
+
+			// Create a project.
+			projectID := generateRandomString("gitops-dep")
+			projectResp, err := ctl.projectServiceClient.CreateProject(ctx, connect.NewRequest(&v1pb.CreateProjectRequest{
+				Project: &v1pb.Project{
+					Name:  fmt.Sprintf("projects/%s", projectID),
+					Title: projectID,
+				},
+				ProjectId: projectID,
+			}))
+			a.NoError(err)
+			project := projectResp.Msg
+
+			// Set up SQL review rules for the test environment.
+			reviewConfig := &v1pb.ReviewConfig{
+				Name:    common.FormatReviewConfig(generateRandomString("review")),
+				Title:   "Test Review Config",
+				Enabled: true,
+				Rules: []*v1pb.SQLReviewRule{
+					{
+						Type:   v1pb.SQLReviewRule_SCHEMA_BACKWARD_COMPATIBILITY,
+						Level:  v1pb.SQLReviewRule_WARNING,
+						Engine: v1pb.Engine_POSTGRES,
+					},
+				},
+			}
+			createdConfig, err := ctl.reviewConfigServiceClient.CreateReviewConfig(ctx, connect.NewRequest(&v1pb.CreateReviewConfigRequest{
+				ReviewConfig: reviewConfig,
+			}))
+			a.NoError(err)
+
+			// Create policy to attach review config to the test environment.
+			_, err = ctl.orgPolicyServiceClient.CreatePolicy(ctx, connect.NewRequest(&v1pb.CreatePolicyRequest{
+				Parent: "environments/test",
+				Policy: &v1pb.Policy{
+					Type: v1pb.PolicyType_TAG,
+					Policy: &v1pb.Policy_TagPolicy{
+						TagPolicy: &v1pb.TagPolicy{
+							Tags: map[string]string{
+								common.ReservedTagReviewConfig: createdConfig.Msg.Name,
+							},
+						},
+					},
+				},
+			}))
+			a.NoError(err)
+
+			// Provision PostgreSQL instance.
+			pgContainer, err := getPgContainer(ctx)
+			a.NoError(err)
+			defer pgContainer.Close(ctx)
+
+			pgInstanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+				InstanceId: generateRandomString("instance"),
+				Instance: &v1pb.Instance{
+					Title:       "gitops-dep-pg",
+					Engine:      v1pb.Engine_POSTGRES,
+					Environment: stringPtr("environments/test"),
+					Activation:  true,
+					DataSources: []*v1pb.DataSource{{
+						Type:     v1pb.DataSourceType_ADMIN,
+						Host:     pgContainer.host,
+						Port:     pgContainer.port,
+						Username: "postgres",
+						Password: "root-password",
+						Id:       "admin",
+					}},
+				},
+			}))
+			a.NoError(err)
+			pgInstance := pgInstanceResp.Msg
+
+			// Create database.
+			databaseName := "gitops_dep_db"
+			err = ctl.createDatabase(ctx, project, pgInstance, nil, databaseName, "postgres")
+			a.NoError(err)
+
+			release := &v1pb.Release{
+				Title: fmt.Sprintf("Test Release - %s", tc.name),
+				Files: tc.files,
+			}
+
+			checkResp, err := ctl.releaseServiceClient.CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+				Parent:  project.Name,
+				Release: release,
+				Targets: []string{
+					fmt.Sprintf("%s/databases/%s", pgInstance.Name, databaseName),
+				},
+			}))
+			a.NoError(err, "CheckRelease API call should succeed")
+			a.NotNil(checkResp)
+
+			// Check for SQL review errors in the results.
+			var errorAdvices []*v1pb.Advice
+			for _, result := range checkResp.Msg.Results {
+				for _, advice := range result.Advices {
+					if advice.Status == v1pb.Advice_ERROR || advice.Status == v1pb.Advice_WARNING {
+						errorAdvices = append(errorAdvices, advice)
+					}
+				}
+			}
+
+			if tc.expectError {
+				a.NotEmpty(errorAdvices, "Expected SQL review error for altering non-existent table t2")
+				// Validate the error message mentions the missing table.
+				foundTableError := false
+				for _, advice := range errorAdvices {
+					if advice.Title == "Table `t2` does not exist" {
+						foundTableError = true
+						a.Contains(advice.Content, "t2", "Error content should mention table t2")
+					}
+				}
+				a.True(foundTableError, "Expected error about table t2 not existing")
+			} else {
+				a.Empty(errorAdvices, "Expected no SQL review errors for valid migration sequence")
+			}
+		})
+	}
+}
+
+// TestGitOpsCheckDeclarativeMultipleFiles tests CheckRelease with multiple declarative SDL files.
+func TestGitOpsCheckDeclarativeMultipleFiles(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	// Create a project.
+	projectID := generateRandomString("gitops-multi-decl")
+	projectResp, err := ctl.projectServiceClient.CreateProject(ctx, connect.NewRequest(&v1pb.CreateProjectRequest{
+		Project: &v1pb.Project{
+			Name:  fmt.Sprintf("projects/%s", projectID),
+			Title: projectID,
+		},
+		ProjectId: projectID,
+	}))
+	a.NoError(err)
+	project := projectResp.Msg
+
+	// Provision PostgreSQL instance.
+	pgContainer, err := getPgContainer(ctx)
+	a.NoError(err)
+	defer pgContainer.Close(ctx)
+
+	pgInstanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "gitops-multi-decl-pg",
+			Engine:      v1pb.Engine_POSTGRES,
+			Environment: stringPtr("environments/test"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{
+				Type:     v1pb.DataSourceType_ADMIN,
+				Host:     pgContainer.host,
+				Port:     pgContainer.port,
+				Username: "postgres",
+				Password: "root-password",
+				Id:       "admin",
+			}},
+		},
+	}))
+	a.NoError(err)
+	pgInstance := pgInstanceResp.Msg
+
+	// Create database.
+	databaseName := "gitops_multi_decl_db"
+	err = ctl.createDatabase(ctx, project, pgInstance, nil, databaseName, "postgres")
+	a.NoError(err)
+
+	// Create a release with multiple declarative SDL files.
+	release := &v1pb.Release{
+		Title: "Multi-File Declarative SDL Release",
+		Files: []*v1pb.Release_File{
+			{
+				Path:    "schema/users.sql",
+				Type:    v1pb.Release_File_DECLARATIVE,
+				Version: "1.0.0",
+				Statement: []byte(`CREATE TABLE public.users (
+    id SERIAL NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_users PRIMARY KEY (id)
+);`),
+			},
+			{
+				Path:    "schema/products.sql",
+				Type:    v1pb.Release_File_DECLARATIVE,
+				Version: "1.0.0",
+				Statement: []byte(`CREATE TABLE public.products (
+    id SERIAL NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    price DECIMAL(10,2),
+    CONSTRAINT pk_products PRIMARY KEY (id)
+);`),
+			},
+		},
+	}
+
+	// Call CheckRelease with multiple declarative files.
+	checkResp, err := ctl.releaseServiceClient.CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+		Parent:  project.Name,
+		Release: release,
+		Targets: []string{
+			fmt.Sprintf("%s/databases/%s", pgInstance.Name, databaseName),
+		},
+	}))
+	a.NoError(err)
+	a.NotNil(checkResp)
+
+	// For valid declarative SDL, there should be no error advices.
+	for _, result := range checkResp.Msg.Results {
+		for _, advice := range result.Advices {
+			a.NotEqual(v1pb.Advice_ERROR, advice.Status,
+				"Valid multi-file SDL should not produce error advices, got: %s - %s", advice.Title, advice.Content)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add `TestGitOpsCheckEmptyTargets` to validate error when targets are empty
- Add `TestGitOpsCheckDeclarative` to test valid SDL files with PostgreSQL
- Add `TestGitOpsCheckDeclarativeDisallowedStatements` to test disallowed statement detection (DROP, INSERT, UPDATE, DELETE, ALTER TABLE)
- Add `TestGitOpsCheckDeclarativeMultipleFiles` to test multiple SDL files
- Add `TestGitOpsCheckVersionedDependency` to test SQL review handles cross-file dependencies correctly:
  - Create t1 → Alter t1: passes with no errors
  - Create t1 → Alter t2: fails with "Table `t2` does not exist" error

## Test plan
- [x] All new tests pass locally
- [x] Linter reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)