### PR TITLE
feat: link to related task from changelog detail view

### DIFF
--- a/frontend/src/components/Changelog/ChangelogDetail.vue
+++ b/frontend/src/components/Changelog/ChangelogDetail.vue
@@ -22,12 +22,16 @@
             <NTag v-if="changelog.version" round>
               {{ $t("common.version") }} {{ changelog.version }}
             </NTag>
-            <span class="text-xl">{{
-              getDateForPbTimestampProtoEs(
-                changelog.createTime
-              )?.toLocaleString()
-            }}</span>
           </div>
+
+          <dl v-if="taskFullLink" class="flex flex-col gap-y-1">
+            <dt class="sr-only">{{ $t("common.task") }}</dt>
+            <dd class="flex items-center text-sm md:mr-4">
+              <router-link :to="taskFullLink" class="normal-link">
+                {{ $t("changelog.task-at", { time: formattedCreateTime }) }}
+              </router-link>
+            </dd>
+          </dl>
         </div>
       </div>
 
@@ -149,6 +153,26 @@ const changelogName = computed(() => {
 
 const changelog = computed((): Changelog | undefined => {
   return changelogStore.getChangelogByName(changelogName.value);
+});
+
+const taskFullLink = computed(() => {
+  if (!changelog.value?.taskRun) {
+    return "";
+  }
+  const parts = changelog.value.taskRun.split("/taskRuns/");
+  if (parts.length !== 2) {
+    return "";
+  }
+  return `/${parts[0]}`;
+});
+
+const formattedCreateTime = computed(() => {
+  if (!changelog.value) {
+    return "";
+  }
+  return getDateForPbTimestampProtoEs(
+    changelog.value.createTime
+  )?.toLocaleString();
 });
 
 const changelogSchema = computed(() => {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1655,7 +1655,8 @@
     "establish-database-baseline": "Establish \"{name}\" baseline",
     "export": "Export Changelog",
     "need-to-select-first": "Need to select changelog first",
-    "rollback-tip": "Select a specific DDL changelog to rollback."
+    "rollback-tip": "Select a specific DDL changelog to rollback.",
+    "task-at": "Task at {time}"
   },
   "database": {
     "labels": "Database Labels",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1655,7 +1655,8 @@
     "establish-database-baseline": "Establecer línea base de \"{name}\"",
     "export": "Exportar historial de cambios",
     "need-to-select-first": "Necesita seleccionar primero el historial de cambios",
-    "rollback-tip": "Seleccione un historial de DDL específico para revertir."
+    "rollback-tip": "Seleccione un historial de DDL específico para revertir.",
+    "task-at": "Tarea el {time}"
   },
   "database": {
     "labels": "Etiquetas de base de datos",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1655,7 +1655,8 @@
     "establish-database-baseline": "ベースライン「{name}」を作成します",
     "export": "変更履歴のエクスポート",
     "need-to-select-first": "最初に変更履歴を選択する必要があります",
-    "rollback-tip": "ロールバックする特定の DDL 履歴を選択します。"
+    "rollback-tip": "ロールバックする特定の DDL 履歴を選択します。",
+    "task-at": "タスク日時 {time}"
   },
   "database": {
     "labels": "データベースラベル",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1655,7 +1655,8 @@
     "establish-database-baseline": "Thiết lập đường cơ sở \"{name}\"",
     "export": "Xuất Nhật ký thay đổi",
     "need-to-select-first": "Cần chọn nhật ký thay đổi trước",
-    "rollback-tip": "Chọn một nhật ký thay đổi DDL cụ thể để hoàn tác."
+    "rollback-tip": "Chọn một nhật ký thay đổi DDL cụ thể để hoàn tác.",
+    "task-at": "Task at {time}"
   },
   "database": {
     "labels": "Nhãn cơ sở dữ liệu",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1655,7 +1655,8 @@
     "establish-database-baseline": "建立「{name}」基线",
     "export": "导出变更历史",
     "need-to-select-first": "需要先选择变更历史",
-    "rollback-tip": "选择要回滚到的某个 DDL 历史记录。"
+    "rollback-tip": "选择要回滚到的某个 DDL 历史记录。",
+    "task-at": "任务于 {time}"
   },
   "database": {
     "labels": "数据库标签",


### PR DESCRIPTION
This PR adds a link to the related task in the changelog detail view. It displays "Task at {time}" where the time is the creation time of the changelog, and the link points to the task detail page.

Related to the issue where changelog entries created from task rollouts were difficult to trace back to the task.

Changes:
- Modified `ChangelogDetail.vue` to display the task link.
- Added translation keys to `en-US.json`, `zh-CN.json`, `es-ES.json`, `ja-JP.json`, `vi-VN.json`.