### PR TITLE
feat(frontend): add expand/collapse all button to task run log viewer

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/TaskRunLogViewer.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/TaskRunLogViewer/TaskRunLogViewer.vue
@@ -3,6 +3,40 @@
     v-if="sections.length > 0"
     class="w-full font-mono text-xs bg-gray-50 border border-gray-200 overflow-hidden rounded"
   >
+    <!-- Toolbar with summary stats and expand/collapse buttons -->
+    <div
+      class="flex items-center justify-between px-2 py-1 bg-gray-100 border-b border-gray-200"
+    >
+      <!-- Left: Summary stats -->
+      <div class="flex items-center gap-x-2 text-gray-500">
+        <ListIcon class="w-3.5 h-3.5" />
+        <span>
+          {{
+            $t("task-run.log-viewer.summary", {
+              sections: totalSections,
+              entries: totalEntries,
+            })
+          }}
+        </span>
+      </div>
+
+      <!-- Right: Expand/Collapse toggle button -->
+      <button
+        class="flex items-center gap-x-1 px-1.5 py-0.5 text-gray-600 hover:text-gray-900 hover:bg-gray-200 rounded transition-colors"
+        @click="toggleExpandAll"
+      >
+        <component
+          :is="areAllExpanded ? ChevronsDownUpIcon : ChevronsUpDownIcon"
+          class="w-3.5 h-3.5"
+        />
+        <span>{{
+          areAllExpanded
+            ? $t("task-run.log-viewer.collapse-all")
+            : $t("task-run.log-viewer.expand-all")
+        }}</span>
+      </button>
+    </div>
+
     <!-- Multi-deploy view: show deploy groups when server restarts detected -->
     <template v-if="hasMultipleDeploys">
       <!-- Server restart notice -->
@@ -86,6 +120,9 @@ import {
   AlertTriangleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  ListIcon,
   ServerIcon,
 } from "lucide-vue-next";
 import type { TaskRunLogEntry } from "@/types/proto-es/v1/rollout_service_pb";
@@ -107,8 +144,21 @@ const {
   toggleDeploy,
   isSectionExpanded,
   isDeployExpanded,
+  expandAll,
+  collapseAll,
+  areAllExpanded,
+  totalSections,
+  totalEntries,
 } = useTaskRunLogSections(
   () => props.entries,
   () => props.sheet
 );
+
+const toggleExpandAll = () => {
+  if (areAllExpanded.value) {
+    collapseAll();
+  } else {
+    expandAll();
+  }
+};
 </script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -394,7 +394,10 @@
     },
     "log-viewer": {
       "multiple-deploys-notice": "Server restart detected during execution. Logs are grouped by deployment.",
-      "deployment-n": "Deployment #{n}"
+      "deployment-n": "Deployment #{n}",
+      "expand-all": "Expand all",
+      "collapse-all": "Collapse all",
+      "summary": "{sections} sections · {entries} entries"
     }
   },
   "banner": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -394,7 +394,10 @@
     },
     "log-viewer": {
       "multiple-deploys-notice": "Se detectó un reinicio del servidor durante la ejecución. Los registros están agrupados por despliegue.",
-      "deployment-n": "Despliegue #{n}"
+      "deployment-n": "Despliegue #{n}",
+      "expand-all": "Expandir todo",
+      "collapse-all": "Contraer todo",
+      "summary": "{sections} secciones · {entries} entradas"
     }
   },
   "banner": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -394,7 +394,10 @@
     },
     "log-viewer": {
       "multiple-deploys-notice": "実行中にサーバーの再起動が検出されました。ログはデプロイごとにグループ化されています。",
-      "deployment-n": "デプロイ #{n}"
+      "deployment-n": "デプロイ #{n}",
+      "expand-all": "すべて展開",
+      "collapse-all": "すべて折りたたむ",
+      "summary": "{sections} セクション · {entries} エントリ"
     }
   },
   "banner": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -394,7 +394,10 @@
     },
     "log-viewer": {
       "multiple-deploys-notice": "Phát hiện khởi động lại máy chủ trong quá trình thực thi. Nhật ký được nhóm theo triển khai.",
-      "deployment-n": "Triển khai #{n}"
+      "deployment-n": "Triển khai #{n}",
+      "expand-all": "Mở rộng tất cả",
+      "collapse-all": "Thu gọn tất cả",
+      "summary": "{sections} phần · {entries} mục"
     }
   },
   "banner": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -394,7 +394,10 @@
     },
     "log-viewer": {
       "multiple-deploys-notice": "检测到执行期间服务重启，日志按部署分组显示。",
-      "deployment-n": "部署 #{n}"
+      "deployment-n": "部署 #{n}",
+      "expand-all": "全部展开",
+      "collapse-all": "全部收起",
+      "summary": "{sections} 个分组 · {entries} 条记录"
     }
   },
   "banner": {


### PR DESCRIPTION
Add a toolbar to the TaskRunLogViewer component with:
- Summary stats showing section and entry counts on the left
- Expand all / Collapse all toggle button on the right

This follows the common UX pattern seen in GitHub Actions, Datadog, and AWS CloudWatch for log viewers with collapsible sections.

<img width="1308" height="528" alt="image" src="https://github.com/user-attachments/assets/722f5e53-ff71-438c-8e96-f0c84df493a5" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)