### PR TITLE
feat(frontend): add tooltip and wider sidebar for run history

### DIFF
--- a/frontend/src/components/Plan/components/RolloutView/v2/StageContentSidebar.vue
+++ b/frontend/src/components/Plan/components/RolloutView/v2/StageContentSidebar.vue
@@ -2,7 +2,7 @@
   <!-- Desktop: Sticky sidebar -->
   <div
     v-if="isWideScreen"
-    class="shrink-0 pr-4 self-start sticky top-0 w-64"
+    class="shrink-0 pr-4 self-start sticky top-0 w-72 xl:w-80"
   >
     <!-- Rollback action at top -->
     <StageTaskRunsRollback class="px-3 pt-1 pb-2" :stage="stage" />


### PR DESCRIPTION
- Add NTooltip to truncated database/instance names in StageTimeline
- Increase sidebar width from w-64 to w-72 (xl:w-80) for better readability
- Add TaskTargetDisplay interface with pre-computed fullPath for DRY

🤖 Generated with [Claude Code](https://claude.com/claude-code)