### PR TITLE
fix(i18n): add missing translations for issue approval and plan check settings

### DIFF
--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1966,12 +1966,12 @@
           "description": "Controle el número de tareas paralelas por despliegue. \nEstablecer esto en cero deshabilita cualquier estrangulamiento."
         },
         "require-issue-approval": {
-          "self": "Require issue approval",
-          "description": "Issue must be approved before rollout."
+          "self": "Requiere aprobación de issue",
+          "description": "El issue debe ser aprobado antes del despliegue."
         },
         "require-plan-check-no-error": {
-          "self": "Require plan check no error",
-          "description": "Block rollout if plan check has errors."
+          "self": "Requiere verificación de plan sin errores",
+          "description": "Bloquear despliegue si la verificación del plan tiene errores."
         }
       },
       "project-labels": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1966,12 +1966,12 @@
           "description": "ロールアウトあたりの並列タスクの数を制御します。\nこれをゼロに設定すると、スロットリングが無効になります。"
         },
         "require-issue-approval": {
-          "self": "Require issue approval",
-          "description": "Issue must be approved before rollout."
+          "self": "イシュー承認が必要",
+          "description": "ロールアウト前にイシューの承認が必要です。"
         },
         "require-plan-check-no-error": {
-          "self": "Require plan check no error",
-          "description": "Block rollout if plan check has errors."
+          "self": "プランチェックエラーなしが必要",
+          "description": "プランチェックにエラーがある場合、ロールアウトをブロックします。"
         }
       },
       "project-labels": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1966,12 +1966,12 @@
           "description": "Kiểm soát số lượng các tác vụ song song cho mỗi lần triển khai. \nĐặt điều này thành 0 vô hiệu hóa bất kỳ điều chỉnh."
         },
         "require-issue-approval": {
-          "self": "Require issue approval",
-          "description": "Issue must be approved before rollout."
+          "self": "Yêu cầu phê duyệt issue",
+          "description": "Issue phải được phê duyệt trước khi triển khai."
         },
         "require-plan-check-no-error": {
-          "self": "Require plan check no error",
-          "description": "Block rollout if plan check has errors."
+          "self": "Yêu cầu kiểm tra kế hoạch không có lỗi",
+          "description": "Chặn triển khai nếu kiểm tra kế hoạch có lỗi."
         }
       },
       "project-labels": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1966,12 +1966,12 @@
           "description": "控制每个发布的并行任务数量。\n将其设置为零，可以禁用任何节流。"
         },
         "require-issue-approval": {
-          "self": "Require issue approval",
-          "description": "Issue must be approved before rollout."
+          "self": "需要工单审批",
+          "description": "工单必须在上线前获得批准。"
         },
         "require-plan-check-no-error": {
-          "self": "Require plan check no error",
-          "description": "Block rollout if plan check has errors."
+          "self": "要求计划检查无错误",
+          "description": "如果计划检查有错误则阻止上线。"
         }
       },
       "project-labels": {


### PR DESCRIPTION
## Summary
- Add Chinese translations: 需要工单审批 / 要求计划检查无错误
- Add Japanese translations: イシュー承認が必要 / プランチェックエラーなしが必要
- Add Spanish translations: Requiere aprobación de issue / Requiere verificación de plan sin errores
- Add Vietnamese translations: Yêu cầu phê duyệt issue / Yêu cầu kiểm tra kế hoạch không có lỗi

## Test plan
- [ ] Verify Chinese locale displays translated text for these settings
- [ ] Verify Japanese locale displays translated text for these settings
- [ ] Verify Spanish locale displays translated text for these settings
- [ ] Verify Vietnamese locale displays translated text for these settings
- [ ] Verify English locale remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)