### PR TITLE
fix: ensure API client Close is called to clean up idle connections

### DIFF
--- a/action/command/check.go
+++ b/action/command/check.go
@@ -57,6 +57,7 @@ func runCheck(w *world.World) func(*cobra.Command, []string) error {
 		if err != nil {
 			return err
 		}
+		defer client.Close()
 
 		// Check version compatibility
 		CheckVersionCompatibility(w, client, args.Version)

--- a/action/command/rollout.go
+++ b/action/command/rollout.go
@@ -61,6 +61,7 @@ func runRollout(w *world.World) func(command *cobra.Command, _ []string) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to create client")
 		}
+		defer client.Close()
 
 		// Check version compatibility
 		CheckVersionCompatibility(w, client, args.Version)


### PR DESCRIPTION
## Summary
- Add `defer client.Close()` in `check.go` and `rollout.go` after creating the API client
- Ensures proper cleanup of HTTP client idle connections when commands complete

## Test plan
- [ ] Build passes
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)