### PR TITLE
fix: rollout date filter not working

### DIFF
--- a/backend/store/pipeline.go
+++ b/backend/store/pipeline.go
@@ -404,10 +404,12 @@ func (s *Store) GetListRolloutFilter(_ context.Context, filter string) (*qb.Quer
 				if err != nil {
 					return nil, errors.Errorf("failed to parse time %v, error: %v", value, err)
 				}
+				// Use the same subquery as in ListPipelines SELECT to compute updated_at
+				updatedAtSubquery := `COALESCE((SELECT MAX(task_run.updated_at) FROM task JOIN task_run ON task_run.task_id = task.id WHERE task.pipeline_id = pipeline.id), pipeline.created_at)`
 				if functionName == celoperators.GreaterEquals {
-					return qb.Q().Space("updated_at >= ?", t), nil
+					return qb.Q().Space(updatedAtSubquery+" >= ?", t), nil
 				}
-				return qb.Q().Space("updated_at <= ?", t), nil
+				return qb.Q().Space(updatedAtSubquery+" <= ?", t), nil
 			default:
 				return nil, errors.Errorf("unexpected function %v", functionName)
 			}

--- a/backend/store/pipeline_filter_test.go
+++ b/backend/store/pipeline_filter_test.go
@@ -1,0 +1,171 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetListRolloutFilter(t *testing.T) {
+	s := &Store{}
+	ctx := context.Background()
+
+	// The subquery used for update_time filtering
+	updatedAtSubquery := `COALESCE((SELECT MAX(task_run.updated_at) FROM task JOIN task_run ON task_run.task_id = task.id WHERE task.pipeline_id = pipeline.id), pipeline.created_at)`
+
+	tests := []struct {
+		name        string
+		filter      string
+		wantSQL     string
+		wantArgs    []any
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "empty filter",
+			filter:   "",
+			wantSQL:  "",
+			wantArgs: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "creator filter",
+			filter:   `creator == "users/test@example.com"`,
+			wantSQL:  "(pipeline.creator = $1)",
+			wantArgs: []any{"test@example.com"},
+			wantErr:  false,
+		},
+		{
+			name:     "task_type equals filter",
+			filter:   `task_type == "DATABASE_MIGRATE"`,
+			wantSQL:  "(EXISTS (SELECT 1 FROM task WHERE task.pipeline_id = pipeline.id AND task.type = $1))",
+			wantArgs: []any{"DATABASE_MIGRATE"},
+			wantErr:  false,
+		},
+		{
+			name:     "task_type in filter",
+			filter:   `task_type in ["DATABASE_MIGRATE", "DATABASE_SDL"]`,
+			wantSQL:  "(EXISTS (SELECT 1 FROM task WHERE task.pipeline_id = pipeline.id AND task.type = ANY($1)))",
+			wantArgs: []any{[]string{"DATABASE_MIGRATE", "DATABASE_SDL"}},
+			wantErr:  false,
+		},
+		{
+			name:    "update_time greater than or equal",
+			filter:  `update_time >= "2024-01-01T00:00:00Z"`,
+			wantSQL: "(" + updatedAtSubquery + " >= $1)",
+			wantArgs: []any{func() time.Time {
+				ts, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+				return ts
+			}()},
+			wantErr: false,
+		},
+		{
+			name:    "update_time less than or equal",
+			filter:  `update_time <= "2024-12-31T23:59:59Z"`,
+			wantSQL: "(" + updatedAtSubquery + " <= $1)",
+			wantArgs: []any{func() time.Time {
+				ts, _ := time.Parse(time.RFC3339, "2024-12-31T23:59:59Z")
+				return ts
+			}()},
+			wantErr: false,
+		},
+		{
+			name:    "update_time with ISO format including milliseconds",
+			filter:  `update_time >= "2024-01-01T00:00:00.000Z"`,
+			wantSQL: "(" + updatedAtSubquery + " >= $1)",
+			wantArgs: []any{func() time.Time {
+				ts, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00.000Z")
+				return ts
+			}()},
+			wantErr: false,
+		},
+		{
+			name:    "AND condition with task_type and update_time",
+			filter:  `task_type == "DATABASE_MIGRATE" && update_time >= "2024-01-01T00:00:00Z"`,
+			wantSQL: "((EXISTS (SELECT 1 FROM task WHERE task.pipeline_id = pipeline.id AND task.type = $1) AND " + updatedAtSubquery + " >= $2))",
+			wantArgs: []any{"DATABASE_MIGRATE", func() time.Time {
+				ts, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+				return ts
+			}()},
+			wantErr: false,
+		},
+		{
+			name:        "invalid filter syntax",
+			filter:      `invalid syntax {{`,
+			wantErr:     true,
+			errContains: "failed to parse filter",
+		},
+		{
+			name:        "unsupported variable",
+			filter:      `unsupported == "value"`,
+			wantErr:     true,
+			errContains: "unsupported variable",
+		},
+		{
+			name:        "invalid task_type value",
+			filter:      `task_type == "INVALID_TYPE"`,
+			wantErr:     true,
+			errContains: "invalid task_type value",
+		},
+		{
+			name:        "invalid time format",
+			filter:      `update_time >= "invalid-time"`,
+			wantErr:     true,
+			errContains: "failed to parse time",
+		},
+		{
+			name:        "comparison operator on unsupported field",
+			filter:      `creator >= "test"`,
+			wantErr:     true,
+			errContains: `">=" and "<=" are only supported for "update_time"`,
+		},
+		{
+			name:        "empty creator identifier",
+			filter:      `creator == "users/"`,
+			wantErr:     true,
+			errContains: "invalid empty creator identifier",
+		},
+		{
+			name:        "task_type with non-string value",
+			filter:      `task_type == 123`,
+			wantErr:     true,
+			errContains: "task_type value must be a string",
+		},
+		{
+			name:        "task_type in with empty list",
+			filter:      `task_type in []`,
+			wantErr:     true,
+			errContains: "empty list value for filter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := s.GetListRolloutFilter(ctx, tt.filter)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.filter == "" {
+				require.Nil(t, q)
+				return
+			}
+
+			require.NotNil(t, q)
+
+			sql, args, err := q.ToSQL()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantSQL, sql)
+			require.Equal(t, tt.wantArgs, args)
+		})
+	}
+}

--- a/frontend/src/store/modules/rollout.ts
+++ b/frontend/src/store/modules/rollout.ts
@@ -44,12 +44,12 @@ export const buildRolloutFilter = (find: RolloutFind): string => {
   }
   if (find.updatedTsAfter) {
     filter.push(
-      `update_time >= "${dayjs(find.updatedTsAfter).utc().format()}"`
+      `update_time >= "${dayjs(find.updatedTsAfter).utc().toISOString()}"`
     );
   }
   if (find.updatedTsBefore) {
     filter.push(
-      `update_time <= "${dayjs(find.updatedTsBefore).utc().format()}"`
+      `update_time <= "${dayjs(find.updatedTsBefore).utc().toISOString()}"`
     );
   }
   return filter.join(" && ");


### PR DESCRIPTION
The rollout list date filter was failing because the WHERE clause tried to reference `updated_at` which is a computed column alias in the SELECT clause. SQL doesn't allow referencing column aliases in the WHERE clause of the same query.

Fix by using the same COALESCE subquery expression in the filter instead of the column alias.

Also changed frontend to use toISOString() for more reliable RFC3339 date formatting.

Close BYT-8568

🤖 Generated with [Claude Code](https://claude.com/claude-code)