### PR TITLE
refactor: rename GetSheetMetadata to GetSheetTruncated

### DIFF
--- a/backend/api/v1/release_service.go
+++ b/backend/api/v1/release_service.go
@@ -437,7 +437,7 @@ func convertToRelease(ctx context.Context, s *store.Store, release *store.Releas
 	}
 
 	for _, f := range release.Payload.Files {
-		sheet, err := s.GetSheetMetadata(ctx, f.SheetSha256)
+		sheet, err := s.GetSheetTruncated(ctx, f.SheetSha256)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get sheet %q", f.SheetSha256)
 		}

--- a/backend/api/v1/revision_service.go
+++ b/backend/api/v1/revision_service.go
@@ -278,7 +278,7 @@ func convertToRevisions(ctx context.Context, s *store.Store, parent string, revi
 
 func convertToRevision(ctx context.Context, s *store.Store, parent string, revision *store.RevisionMessage) (*v1pb.Revision, error) {
 	sheetSha256 := revision.Payload.SheetSha256
-	sheet, err := s.GetSheetMetadata(ctx, sheetSha256)
+	sheet, err := s.GetSheetTruncated(ctx, sheetSha256)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get sheet %q", sheetSha256)
 	}

--- a/backend/api/v1/sheet_service.go
+++ b/backend/api/v1/sheet_service.go
@@ -149,7 +149,7 @@ func (s *SheetService) GetSheet(ctx context.Context, request *connect.Request[v1
 	if request.Msg.Raw {
 		sheet, sheetErr = s.store.GetSheetFull(ctx, sheetSha256)
 	} else {
-		sheet, sheetErr = s.store.GetSheetMetadata(ctx, sheetSha256)
+		sheet, sheetErr = s.store.GetSheetTruncated(ctx, sheetSha256)
 	}
 	if sheetErr != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(sheetErr, "failed to get sheet"))

--- a/backend/store/sheet.go
+++ b/backend/store/sheet.go
@@ -24,10 +24,10 @@ type SheetMessage struct {
 	Size int64
 }
 
-// GetSheetMetadata gets a sheet by SHA256 hash with truncated statement (max 2MB).
+// GetSheetTruncated gets a sheet by SHA256 hash with truncated statement (max 2MB).
 // Statement field will be truncated to MaxSheetSize (2MB).
 // Results are cached by SHA256 hex string.
-func (s *Store) GetSheetMetadata(ctx context.Context, sha256Hex string) (*SheetMessage, error) {
+func (s *Store) GetSheetTruncated(ctx context.Context, sha256Hex string) (*SheetMessage, error) {
 	if v, ok := s.sheetMetadataCache.Get(sha256Hex); ok && s.enableCache {
 		return v, nil
 	}


### PR DESCRIPTION
Renamed `GetSheetMetadata` to `GetSheetTruncated` to better reflect that it returns a truncated statement from the sheet blob.

This follows up on the sheet metadata optimization work.