### PR TITLE
refactor: remove sheetMetadataCache

### DIFF
--- a/backend/store/sheet.go
+++ b/backend/store/sheet.go
@@ -28,10 +28,6 @@ type SheetMessage struct {
 // Statement field will be truncated to MaxSheetSize (2MB).
 // Results are cached by SHA256 hex string.
 func (s *Store) GetSheetTruncated(ctx context.Context, sha256Hex string) (*SheetMessage, error) {
-	if v, ok := s.sheetMetadataCache.Get(sha256Hex); ok && s.enableCache {
-		return v, nil
-	}
-
 	sheet, err := s.getSheet(ctx, sha256Hex, false)
 	if err != nil {
 		return nil, err
@@ -39,8 +35,6 @@ func (s *Store) GetSheetTruncated(ctx context.Context, sha256Hex string) (*Sheet
 	if sheet == nil {
 		return nil, nil
 	}
-
-	s.sheetMetadataCache.Add(sha256Hex, sheet)
 	return sheet, nil
 }
 

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -18,16 +18,15 @@ type Store struct {
 	enableCache   bool
 
 	// Cache.
-	Secret             string
-	userEmailCache     *lru.Cache[string, *UserMessage]
-	instanceCache      *lru.Cache[string, *InstanceMessage]
-	databaseCache      *lru.Cache[string, *DatabaseMessage]
-	projectCache       *lru.Cache[string, *ProjectMessage]
-	policyCache        *lru.Cache[string, *PolicyMessage]
-	settingCache       *lru.Cache[storepb.SettingName, *SettingMessage]
-	rolesCache         *lru.Cache[string, *RoleMessage]
-	groupCache         *lru.Cache[string, *GroupMessage]
-	sheetMetadataCache *lru.Cache[string, *SheetMessage]
+	Secret         string
+	userEmailCache *lru.Cache[string, *UserMessage]
+	instanceCache  *lru.Cache[string, *InstanceMessage]
+	databaseCache  *lru.Cache[string, *DatabaseMessage]
+	projectCache   *lru.Cache[string, *ProjectMessage]
+	policyCache    *lru.Cache[string, *PolicyMessage]
+	settingCache   *lru.Cache[storepb.SettingName, *SettingMessage]
+	rolesCache     *lru.Cache[string, *RoleMessage]
+	groupCache     *lru.Cache[string, *GroupMessage]
 
 	// Large objects.
 	sheetFullCache  *lru.Cache[string, *SheetMessage]
@@ -65,10 +64,6 @@ func New(ctx context.Context, pgURL string, enableCache bool) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	sheetMetadataCache, err := lru.New[string, *SheetMessage](64)
-	if err != nil {
-		return nil, err
-	}
 	sheetFullCache, err := lru.New[string, *SheetMessage](10)
 	if err != nil {
 		return nil, err
@@ -93,17 +88,16 @@ func New(ctx context.Context, pgURL string, enableCache bool) (*Store, error) {
 		enableCache:   enableCache,
 
 		// Cache.
-		userEmailCache:     userEmailCache,
-		instanceCache:      instanceCache,
-		databaseCache:      databaseCache,
-		projectCache:       projectCache,
-		policyCache:        policyCache,
-		settingCache:       settingCache,
-		rolesCache:         rolesCache,
-		sheetMetadataCache: sheetMetadataCache,
-		sheetFullCache:     sheetFullCache,
-		dbMetadataCache:    dbMetadataCache,
-		groupCache:         groupCache,
+		userEmailCache:  userEmailCache,
+		instanceCache:   instanceCache,
+		databaseCache:   databaseCache,
+		projectCache:    projectCache,
+		policyCache:     policyCache,
+		settingCache:    settingCache,
+		rolesCache:      rolesCache,
+		sheetFullCache:  sheetFullCache,
+		dbMetadataCache: dbMetadataCache,
+		groupCache:      groupCache,
 	}
 
 	return s, nil


### PR DESCRIPTION
Removes `sheetMetadataCache` as it is no longer needed. Verified with `go build` and `golangci-lint`.