### PR TITLE
chore: upgrade pnpm to 10.26.1 and remove packageManager field

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
-          version: '10.24.0'
+          version: '10.26.1'
       - uses: actions/setup-node@v6
         with:
           node-version: '24.11.1'
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
-          version: '10.24.0'
+          version: '10.26.1'
       - uses: actions/setup-node@v6
         with:
           node-version: '24.11.1'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -148,6 +148,5 @@
   },
   "browserslist": [
     "> 0.08%, not dead"
-  ],
-  "packageManager": "pnpm@10.24.0"
+  ]
 }

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24.11.1-slim AS frontend
 ARG GIT_COMMIT
 
-RUN npm i -g pnpm@10.24.0
+RUN npm i -g pnpm@10.26.1
 
 WORKDIR /frontend-build
 


### PR DESCRIPTION
- Upgrade pnpm from 10.24.0 to 10.26.1 in CI and Dockerfile
- Remove redundant packageManager field from package.json since version is already pinned in CI workflow and Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)