### PR TITLE
chore: use new CI/CD layout routes

### DIFF
--- a/frontend/src/components/IssueV1/components/Sidebar/PreBackupSection/TaskRollbackButton.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/PreBackupSection/TaskRollbackButton.vue
@@ -19,8 +19,12 @@ import {
   latestTaskRunForTask,
   useIssueContext,
 } from "@/components/IssueV1/logic";
+import { useIssueLayoutVersion } from "@/composables/useIssueLayoutVersion";
 import { rolloutServiceClientConnect } from "@/grpcweb";
-import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
+import {
+  PROJECT_V1_ROUTE_ISSUE_DETAIL,
+  PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+} from "@/router/dashboard/projectV1";
 import {
   pushNotification,
   useCurrentProjectV1,
@@ -77,6 +81,7 @@ const createRestoreIssue = async () => {
   const { statement } = response;
   isLoading.value = false;
 
+  const { enabledNewLayout } = useIssueLayoutVersion();
   const sqlStorageKey = `bb.issues.sql.${uuidv4()}`;
   useStorageStore().put(sqlStorageKey, statement);
   const query: LocationQueryRaw = {
@@ -86,13 +91,26 @@ const createRestoreIssue = async () => {
     description: `This issue is created to rollback the data of ${selectedTask.value.target} in issue #${extractIssueUID(issue.value.name)}`,
     sqlStorageKey,
   };
-  router.push({
-    name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
-    params: {
-      projectId: extractProjectResourceName(issue.value.name),
-      issueSlug: "create",
-    },
-    query,
-  });
+
+  if (enabledNewLayout.value) {
+    router.push({
+      name: PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+      params: {
+        projectId: extractProjectResourceName(issue.value.name),
+        planId: "create",
+        specId: "placeholder",
+      },
+      query,
+    });
+  } else {
+    router.push({
+      name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
+      params: {
+        projectId: extractProjectResourceName(issue.value.name),
+        issueSlug: "create",
+      },
+      query,
+    });
+  }
 };
 </script>

--- a/frontend/src/components/SyncDatabaseSchemaV1/index.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/index.vue
@@ -85,8 +85,12 @@ import { useI18n } from "vue-i18n";
 import { type LocationQueryRaw, useRoute, useRouter } from "vue-router";
 import { BBSpin } from "@/bbkit";
 import { StepTab } from "@/components/v2";
+import { useIssueLayoutVersion } from "@/composables/useIssueLayoutVersion";
 import { useRouteChangeGuard } from "@/composables/useRouteChangeGuard";
-import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
+import {
+  PROJECT_V1_ROUTE_ISSUE_DETAIL,
+  PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+} from "@/router/dashboard/projectV1";
 import { WORKSPACE_ROOT_MODULE } from "@/router/dashboard/workspaceRoutes";
 import {
   useChangelogStore,
@@ -305,6 +309,7 @@ const tryFinishSetup = async () => {
     return;
   }
 
+  const { enabledNewLayout } = useIssueLayoutVersion();
   const targetDatabaseList = targetDatabaseViewRef.value.targetDatabaseList;
   const query: LocationQueryRaw = {
     template: "bb.issue.database.update",
@@ -327,15 +332,26 @@ const tryFinishSetup = async () => {
     targetDatabaseList.map((db) => db.databaseName)
   );
 
-  const routeInfo = {
-    name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
-    params: {
-      projectId: extractProjectResourceName(props.project.name),
-      issueSlug: "create",
-    },
-    query,
-  };
-  router.push(routeInfo);
+  if (enabledNewLayout.value) {
+    router.push({
+      name: PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+      params: {
+        projectId: extractProjectResourceName(props.project.name),
+        planId: "create",
+        specId: "placeholder",
+      },
+      query,
+    });
+  } else {
+    router.push({
+      name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
+      params: {
+        projectId: extractProjectResourceName(props.project.name),
+        issueSlug: "create",
+      },
+      query,
+    });
+  }
 };
 
 const cancelSetup = () => {

--- a/frontend/src/views/sql-editor/SQLEditorHomePage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorHomePage.vue
@@ -70,7 +70,11 @@ import IAMRemindModal from "@/components/IAMRemindModal.vue";
 import Quickstart from "@/components/Quickstart.vue";
 import { Drawer } from "@/components/v2";
 import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
-import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
+import { useIssueLayoutVersion } from "@/composables/useIssueLayoutVersion";
+import {
+  PROJECT_V1_ROUTE_ISSUE_DETAIL,
+  PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+} from "@/router/dashboard/projectV1";
 import {
   useActuatorV1Store,
   useDatabaseV1Store,
@@ -117,6 +121,7 @@ useEmitteryEventListener(
   editorEvents,
   "alter-schema",
   async ({ databaseName, schema, table }) => {
+    const { enabledNewLayout } = useIssueLayoutVersion();
     const database = await databaseStore.getOrFetchDatabaseByName(databaseName);
     const exampleSQL = ["ALTER TABLE"];
     if (table) {
@@ -132,14 +137,24 @@ useEmitteryEventListener(
       databaseList: database.name,
       sql: exampleSQL.join(" "),
     };
-    const route = router.resolve({
-      name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
-      params: {
-        projectId: extractProjectResourceName(database.project),
-        issueSlug: "create",
-      },
-      query,
-    });
+    const route = enabledNewLayout.value
+      ? router.resolve({
+          name: PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+          params: {
+            projectId: extractProjectResourceName(database.project),
+            planId: "create",
+            specId: "placeholder",
+          },
+          query,
+        })
+      : router.resolve({
+          name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
+          params: {
+            projectId: extractProjectResourceName(database.project),
+            issueSlug: "create",
+          },
+          query,
+        });
     window.open(route.fullPath, "_blank");
   }
 );


### PR DESCRIPTION
- Update issue creation routes to check enabledNewLayout:
  - preCreateIssue in Plan/logic/issue.ts
  - SyncDatabaseSchemaV1/index.vue
  - ExecuteHint.vue (SQL Editor)
  - SQLEditorHomePage.vue (alter-schema)
  - TaskRollbackButton.vue
  - DatabaseOperations.vue (generateMultiDb)
- When new layout is enabled, navigate to PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL instead of PROJECT_V1_ROUTE_ISSUE_DETAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)