### PR TITLE
fix: display spatial types (geometry/geography) as hex

### DIFF
--- a/backend/plugin/db/mssql/query.go
+++ b/backend/plugin/db/mssql/query.go
@@ -58,6 +58,8 @@ func makeValueByTypeName(typeName string, _ *sql.ColumnType) any {
 		return new([]byte)
 	case "SQL_VARIANT":
 		return new([]byte)
+	case "GEOMETRY", "GEOGRAPHY":
+		return new([]byte)
 	default:
 		// For unknown types, default to sql.NullString which can handle most values
 		return new(sql.NullString)

--- a/backend/plugin/db/mysql/query.go
+++ b/backend/plugin/db/mysql/query.go
@@ -31,6 +31,8 @@ func makeValueByTypeName(typeName string, _ *sql.ColumnType) any {
 		return new(sql.NullFloat64)
 	case "BIT", "VARBIT", "BINARY", "VARBINARY":
 		return new([]byte)
+	case "GEOMETRY", "POINT", "LINESTRING", "POLYGON", "MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON", "GEOMETRYCOLLECTION":
+		return new([]byte)
 	default:
 		return new(sql.NullString)
 	}

--- a/backend/plugin/db/pg/query.go
+++ b/backend/plugin/db/pg/query.go
@@ -37,6 +37,8 @@ func makeValueByTypeName(typeName string, _ *sql.ColumnType) any {
 		return new(pgtype.Timestamptz)
 	case "BIT", "VARBIT", "BYTEA":
 		return new([]byte)
+	case "GEOMETRY", "GEOGRAPHY":
+		return new([]byte)
 	default:
 		return new(sql.NullString)
 	}

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/common/binary-format-store.ts
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/common/binary-format-store.ts
@@ -227,7 +227,17 @@ export const getBinaryFormatByColumnType = (
     columnType === "varbinary(max)" ||
     // Oracle binary types
     columnType === "raw" ||
-    columnType === "long raw";
+    columnType === "long raw" ||
+    // Spatial types (SQL Server, PostgreSQL/PostGIS, MySQL)
+    columnType === "geometry" ||
+    columnType === "geography" ||
+    columnType === "point" ||
+    columnType === "linestring" ||
+    columnType === "polygon" ||
+    columnType === "multipoint" ||
+    columnType === "multilinestring" ||
+    columnType === "multipolygon" ||
+    columnType === "geometrycollection";
 
   // BINARY/VARBINARY/BLOB columns default to HEX format
   if (isBinaryColumn) {


### PR DESCRIPTION
## Summary
Spatial columns (geometry/geography) were displaying as raw binary digits (`100000100...`) instead of hex format (`0x...`).

**Changes:**

| Database | Types Added |
|----------|------------|
| MSSQL | `GEOMETRY`, `GEOGRAPHY` |
| PostgreSQL | `GEOMETRY`, `GEOGRAPHY` (PostGIS) |
| MySQL | `GEOMETRY`, `POINT`, `LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`, `GEOMETRYCOLLECTION` |

Frontend updated to default all spatial types to HEX format display.

Now matches Azure Data Studio and DataGrip behavior.

**Before:**
Raw binary: `100000100000000011000000...`

**After:**
Hex format: `0x00000000010403000000...`

## Test plan
- [x] Created SQL Server database with geometry/geography columns
- [x] Verified columns display as hex (`0x...`) instead of raw binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)