### PR TITLE
refactor(plan): show issue labels in two-step creation flow

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateIssueButton.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateIssueButton.vue
@@ -1,0 +1,238 @@
+<template>
+  <NPopover
+    trigger="click"
+    placement="bottom"
+    :show="showPopover"
+    @update:show="showPopover = $event"
+  >
+    <template #trigger>
+      <NTooltip :disabled="errors.length === 0" placement="top">
+        <template #trigger>
+          <NButton
+            type="primary"
+            size="medium"
+            tag="div"
+            :disabled="errors.length > 0 || loading"
+            :loading="loading"
+          >
+            {{ $t("plan.ready-for-review") }}
+          </NButton>
+        </template>
+        <template #default>
+          <ErrorList :errors="errors" />
+        </template>
+      </NTooltip>
+    </template>
+
+    <template #default>
+      <div class="w-72 flex flex-col gap-y-3 p-1">
+        <div class="flex flex-col gap-y-1">
+          <div class="font-medium text-control flex items-center gap-x-1">
+            {{ $t("issue.labels") }}
+            <RequiredStar v-if="project.forceIssueLabels" />
+          </div>
+          <IssueLabelSelector
+            :disabled="loading"
+            :selected="selectedLabels"
+            :project="project"
+            :size="'medium'"
+            @update:selected="selectedLabels = $event"
+          />
+        </div>
+        <div class="flex justify-end gap-x-2">
+          <NButton size="small" quaternary @click="showPopover = false">
+            {{ $t("common.cancel") }}
+          </NButton>
+          <NTooltip :disabled="confirmErrors.length === 0" placement="top">
+            <template #trigger>
+              <NButton
+                type="primary"
+                size="small"
+                :disabled="confirmErrors.length > 0 || loading"
+                :loading="loading"
+                @click="doCreateIssue"
+              >
+                {{ $t("common.confirm") }}
+              </NButton>
+            </template>
+            <template #default>
+              <ErrorList :errors="confirmErrors" />
+            </template>
+          </NTooltip>
+        </div>
+      </div>
+    </template>
+  </NPopover>
+</template>
+
+<script setup lang="ts">
+import { create } from "@bufbuild/protobuf";
+import { NButton, NPopover, NTooltip } from "naive-ui";
+import { computed, nextTick, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import IssueLabelSelector from "@/components/IssueV1/components/IssueLabelSelector.vue";
+import {
+  ErrorList,
+  useSpecsValidation,
+} from "@/components/Plan/components/common";
+import { usePlanCheckStatus, usePlanContext } from "@/components/Plan/logic";
+import RequiredStar from "@/components/RequiredStar.vue";
+import {
+  issueServiceClientConnect,
+  rolloutServiceClientConnect,
+} from "@/grpcweb";
+import { PROJECT_V1_ROUTE_ISSUE_DETAIL_V1 } from "@/router/dashboard/projectV1";
+import {
+  pushNotification,
+  useCurrentProjectV1,
+  useCurrentUserV1,
+} from "@/store";
+import {
+  CreateIssueRequestSchema,
+  Issue_Type,
+  IssueSchema,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import type { Plan, Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
+import { CreateRolloutRequestSchema } from "@/types/proto-es/v1/rollout_service_pb";
+import { Advice_Level } from "@/types/proto-es/v1/sql_service_pb";
+import { extractIssueUID, extractProjectResourceName } from "@/utils";
+
+const { t } = useI18n();
+const router = useRouter();
+const { project } = useCurrentProjectV1();
+const { plan, events } = usePlanContext();
+const currentUser = useCurrentUserV1();
+
+const loading = ref(false);
+const showPopover = ref(false);
+const selectedLabels = ref<string[]>([]);
+
+// Use the validation hook for all specs
+const { isSpecEmpty } = useSpecsValidation(computed(() => plan.value.specs));
+
+// Use plan check status for issue creation validation
+const {
+  getOverallStatus: planCheckSummaryStatus,
+  hasRunning: hasRunningPlanChecks,
+} = usePlanCheckStatus(plan);
+
+// Reset labels when popover opens
+watch(showPopover, (show) => {
+  if (show) {
+    selectedLabels.value = [];
+  }
+});
+
+// Errors that disable the main button
+const errors = computed(() => {
+  const list: string[] = [];
+
+  // Check if all specs have valid statements
+  if (plan.value.specs.some((spec) => isSpecEmpty(spec))) {
+    list.push(t("plan.navigator.statement-empty"));
+  }
+
+  // Check if plan checks are running
+  if (hasRunningPlanChecks.value) {
+    list.push(
+      t(
+        "custom-approval.issue-review.disallow-approve-reason.some-task-checks-are-still-running"
+      )
+    );
+  }
+
+  // Check if plan checks failed and policy restricts
+  const planChecksFailed = planCheckSummaryStatus.value === Advice_Level.ERROR;
+  if (planChecksFailed && project.value.enforceSqlReview) {
+    list.push(
+      t(
+        "custom-approval.issue-review.disallow-approve-reason.some-task-checks-didnt-pass"
+      )
+    );
+  }
+
+  return list;
+});
+
+// Errors that disable the confirm button in popover
+const confirmErrors = computed(() => {
+  const list: string[] = [];
+
+  if (project.value.forceIssueLabels && selectedLabels.value.length === 0) {
+    list.push(t("plan.labels-required-for-review"));
+  }
+
+  return list;
+});
+
+// Helper function to determine issue type from plan specs
+const getIssueTypeFromPlan = (planValue: Plan): Issue_Type => {
+  const hasExportDataSpec = planValue.specs.some(
+    (spec: Plan_Spec) => spec.config?.case === "exportDataConfig"
+  );
+
+  if (hasExportDataSpec) {
+    return Issue_Type.DATABASE_EXPORT;
+  }
+
+  return Issue_Type.DATABASE_CHANGE;
+};
+
+const doCreateIssue = async () => {
+  if (loading.value) return;
+  if (confirmErrors.value.length > 0) return;
+
+  loading.value = true;
+
+  try {
+    const createIssueRequest = create(CreateIssueRequestSchema, {
+      parent: project.value.name,
+      issue: create(IssueSchema, {
+        creator: `users/${currentUser.value.email}`,
+        labels: selectedLabels.value,
+        plan: plan.value.name,
+        status: IssueStatus.OPEN,
+        type: getIssueTypeFromPlan(plan.value),
+        rollout: "",
+      }),
+    });
+
+    const createdIssue =
+      await issueServiceClientConnect.createIssue(createIssueRequest);
+
+    const createRolloutRequest = create(CreateRolloutRequestSchema, {
+      parent: project.value.name,
+      rollout: {
+        plan: plan.value.name,
+      },
+    });
+
+    await rolloutServiceClientConnect.createRollout(createRolloutRequest);
+
+    events.emit("status-changed", { eager: true });
+
+    showPopover.value = false;
+
+    nextTick(() => {
+      router.push({
+        name: PROJECT_V1_ROUTE_ISSUE_DETAIL_V1,
+        params: {
+          projectId: extractProjectResourceName(plan.value.name),
+          issueId: extractIssueUID(createdIssue.name),
+        },
+      });
+    });
+  } catch (error) {
+    pushNotification({
+      module: "bytebase",
+      style: "CRITICAL",
+      title: t("common.failed"),
+      description: String(error),
+    });
+  } finally {
+    loading.value = false;
+  }
+};
+</script>

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/create/index.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/create/index.ts
@@ -1,3 +1,4 @@
 import CreateButton from "./CreateButton.vue";
+import CreateIssueButton from "./CreateIssueButton.vue";
 
-export { CreateButton };
+export { CreateButton, CreateIssueButton };

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/unified/index.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/unified/index.ts
@@ -1,3 +1,4 @@
+export { usePlanAction } from "./action";
 export { default as UnifiedActionButton } from "./UnifiedActionButton.vue";
 export { default as UnifiedActionGroup } from "./UnifiedActionGroup.vue";
 export * from "./types";

--- a/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
@@ -23,13 +23,6 @@
       </div>
     </div>
     <DescriptionSection v-if="showDescriptionSection" />
-    <div class=" max-w-120 my-4">
-      <IssueLabels
-        v-if="availableActions.includes('ISSUE_CREATE')"
-        :project="project"
-        v-model:value="issueLabels"
-      />
-    </div>
   </div>
 </template>
 
@@ -38,21 +31,16 @@ import { CircleDotDashedIcon, MenuIcon } from "lucide-vue-next";
 import { NButton, NTag } from "naive-ui";
 import { computed } from "vue";
 import { useRoute } from "vue-router";
-import IssueLabels from "@/components/IssueV1/components/Sidebar/IssueLabels.vue";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL_V1 } from "@/router/dashboard/projectV1";
-import { useCurrentProjectV1 } from "@/store";
 import { isValidPlanName } from "@/utils";
 import { usePlanContext } from "../../logic";
 import { useSidebarContext } from "../../logic/sidebar";
 import Actions from "./Actions";
-import { usePlanAction } from "./Actions/unified/action";
 import DescriptionSection from "./DescriptionSection.vue";
 import TitleInput from "./TitleInput.vue";
 
 const route = useRoute();
-const { isCreating, plan, issueLabels } = usePlanContext();
-const { project } = useCurrentProjectV1();
-const { availableActions } = usePlanAction();
+const { isCreating, plan } = usePlanContext();
 
 const hasSidebar = computed(() => {
   // Check if we're in a layout with sidebar (Issue overview tab only)

--- a/frontend/src/components/Plan/logic/context.ts
+++ b/frontend/src/components/Plan/logic/context.ts
@@ -30,7 +30,6 @@ export type PlanContext = {
   issue: Ref<Issue | undefined>;
   rollout: Ref<Rollout | undefined>;
   taskRuns: Ref<TaskRun[]>;
-  issueLabels: Ref<string[]>;
 
   readonly: ComputedRef<boolean>;
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1167,6 +1167,7 @@
     "add-spec": "Add Change",
     "select-targets": "Select Targets",
     "ready-for-review": "Ready for Review",
+    "labels-required-for-review": "Labels are required before requesting review",
     "overview": {
       "no-checks": "No checks"
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1167,6 +1167,7 @@
     "add-spec": "Agregar especificación",
     "select-targets": "Seleccionar objetivos",
     "ready-for-review": "Listo para revisión",
+    "labels-required-for-review": "Se requieren etiquetas antes de solicitar revisión",
     "overview": {
       "no-checks": "Sin controles"
     },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1167,6 +1167,7 @@
     "add-spec": "仕様を追加",
     "select-targets": "ターゲットを選択",
     "ready-for-review": "レビュー準備完了",
+    "labels-required-for-review": "レビューをリクエストする前にラベルが必要です",
     "overview": {
       "no-checks": "チェックなし"
     },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1167,6 +1167,7 @@
     "add-spec": "Thêm thông số kỹ thuật",
     "select-targets": "Chọn mục tiêu",
     "ready-for-review": "Sẵn sàng để xem xét",
+    "labels-required-for-review": "Cần có nhãn trước khi yêu cầu xem xét",
     "overview": {
       "no-checks": "Không kiểm tra"
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1167,6 +1167,7 @@
     "add-spec": "添加变更项",
     "select-targets": "选择目标库",
     "ready-for-review": "提交审批",
+    "labels-required-for-review": "提交审批前需要选择标签",
     "overview": {
       "no-checks": "没有检查"
     },

--- a/frontend/src/views/project/CICDLayout.vue
+++ b/frontend/src/views/project/CICDLayout.vue
@@ -131,7 +131,6 @@ providePlanContext({
   issue,
   rollout,
   taskRuns,
-  issueLabels: ref<string[]>(issue.value?.labels ?? []),
   ...planBaseContext,
 });
 


### PR DESCRIPTION
Follows https://github.com/bytebase/bytebase/pull/18582. 

Issue labels are properties of Issue, not Plan. Previously they were shown on the Plan page which was confusing. Now labels are selected in a popover when clicking "Ready for Review", making the two-step Plan → Issue creation flow clearer.

<img width="1948" height="916" alt="image" src="https://github.com/user-attachments/assets/be04f8c5-2bae-479f-8498-3544b6cd73e0" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)