### PR TITLE
fix(frontend): prevent infinite BatchGetProjects API calls

### DIFF
--- a/frontend/src/components/Project/useRecentProjects.ts
+++ b/frontend/src/components/Project/useRecentProjects.ts
@@ -1,6 +1,10 @@
 import { computedAsync } from "@vueuse/core";
 import { computed } from "vue";
-import { useCurrentUserV1, useProjectV1Store } from "@/store";
+import {
+  batchGetOrFetchProjects,
+  useCurrentUserV1,
+  useProjectV1Store,
+} from "@/store";
 import { isValidProjectName } from "@/types";
 import { hasProjectPermissionV2, useDynamicLocalStorage } from "@/utils";
 
@@ -36,7 +40,7 @@ export const useRecentProjects = () => {
     const projects = [];
     const invalidProjects: string[] = [];
 
-    await projectV1Store.batchGetProjects(recentViewProjectNames.value);
+    await batchGetOrFetchProjects(recentViewProjectNames.value);
 
     for (const projectName of recentViewProjectNames.value) {
       try {


### PR DESCRIPTION
Use batchGetOrFetchProjects instead of batchGetProjects in useRecentProjects to avoid infinite loop. The computedAsync was triggering repeated API calls because batchGetProjects always updates the reactive store, which re-triggers the computedAsync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)