### PR TITLE
refactor: batch get or fetch

### DIFF
--- a/frontend/src/AuthContext.vue
+++ b/frontend/src/AuthContext.vue
@@ -16,10 +16,10 @@ import SigninModal from "@/views/auth/SigninModal.vue";
 import { t } from "./plugins/i18n";
 import { WORKSPACE_ROOT_MODULE } from "./router/dashboard/workspaceRoutes";
 import {
-  batchGetOrFetchGroups,
   pushNotification,
   useAuthStore,
   useCurrentUserV1,
+  useGroupStore,
   useRoleStore,
   useWorkspaceV1Store,
 } from "./store";
@@ -34,6 +34,7 @@ const authStore = useAuthStore();
 const currentUser = useCurrentUserV1();
 const workspaceStore = useWorkspaceV1Store();
 const roleStore = useRoleStore();
+const groupStore = useGroupStore();
 
 const authCheckIntervalId = ref<NodeJS.Timeout>();
 
@@ -101,7 +102,7 @@ watch(
       workspaceStore.fetchIamPolicy(),
       roleStore.fetchRoleList(),
       // we only care about the groups for the current user.
-      batchGetOrFetchGroups(currentUser.value.groups),
+      groupStore.batchGetOrFetchGroups(currentUser.value.groups),
     ]);
   },
   {

--- a/frontend/src/components/DatabaseGroup/MatchedDatabaseView.vue
+++ b/frontend/src/components/DatabaseGroup/MatchedDatabaseView.vue
@@ -72,11 +72,7 @@ import {
 } from "@/components/v2";
 import type { ConditionGroupExpr } from "@/plugins/cel";
 import { validateSimpleExpr } from "@/plugins/cel";
-import {
-  batchGetOrFetchDatabases,
-  useDatabaseV1Store,
-  useDBGroupStore,
-} from "@/store";
+import { useDatabaseV1Store, useDBGroupStore } from "@/store";
 import {
   type ComposedDatabase,
   DEBOUNCE_SEARCH_DELAY,
@@ -125,7 +121,7 @@ const loadMoreMatched = async (index: number) => {
   const previous = index;
   const next = previous + pageSize.value;
   const databaseNames = matchedDatabaseNameList.value.slice(previous, next);
-  await batchGetOrFetchDatabases(databaseNames);
+  await databaseStore.batchGetOrFetchDatabases(databaseNames);
 
   return {
     databases: databaseNames.map(databaseStore.getDatabaseByName),

--- a/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
+++ b/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
@@ -36,7 +36,6 @@ import { BBSpin } from "@/bbkit";
 import AdvancedSearch from "@/components/AdvancedSearch";
 import { useCommonSearchScopeOptions } from "@/components/AdvancedSearch/useCommonSearchScopeOptions";
 import {
-  batchGetOrFetchDatabases,
   type DatabaseFilter,
   useDatabaseV1Store,
   useDBSchemaV1Store,
@@ -300,7 +299,7 @@ watch(
 );
 
 onMounted(async () => {
-  await batchGetOrFetchDatabases(
+  await databaseStore.batchGetOrFetchDatabases(
     props.databaseResources.map((resource) => resource.databaseFullName)
   );
   await refreshData();

--- a/frontend/src/components/IssueV1/components/GrantRequest/DatabaseResourceTable.vue
+++ b/frontend/src/components/IssueV1/components/GrantRequest/DatabaseResourceTable.vue
@@ -9,13 +9,12 @@
 </template>
 
 <script lang="tsx" setup>
-import { uniq } from "lodash-es";
 import type { DataTableColumn } from "naive-ui";
 import { NDataTable } from "naive-ui";
 import { computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { EnvironmentV1Name, InstanceV1Name } from "@/components/v2";
-import { batchGetOrFetchDatabases, useDatabaseV1Store } from "@/store";
+import { useDatabaseV1Store } from "@/store";
 import type { DatabaseResource } from "@/types";
 import type { DatabaseGroup } from "@/types/proto-es/v1/database_group_service_pb";
 
@@ -59,11 +58,9 @@ const extractComposedDatabase = (databaseResource: DatabaseResource) => {
 watch(
   () => props.databaseResourceList,
   async () => {
-    await batchGetOrFetchDatabases(
-      uniq(
-        props.databaseResourceList.map(
-          (databaseResource) => databaseResource.databaseFullName
-        )
+    await databaseStore.batchGetOrFetchDatabases(
+      props.databaseResourceList.map(
+        (databaseResource) => databaseResource.databaseFullName
       )
     );
   },

--- a/frontend/src/components/IssueV1/components/TaskListSection/TaskListSection.vue
+++ b/frontend/src/components/IssueV1/components/TaskListSection/TaskListSection.vue
@@ -66,7 +66,7 @@ import { computed, reactive, ref, watch } from "vue";
 import { BBSpin } from "@/bbkit";
 import { usePlanSQLCheckContext } from "@/components/Plan/components/SQLCheckSection/context";
 import { useVerticalScrollState } from "@/composables/useScrollState";
-import { batchGetOrFetchDatabases, useCurrentProjectV1 } from "@/store";
+import { useCurrentProjectV1, useDatabaseV1Store } from "@/store";
 import { DEBOUNCE_SEARCH_DELAY } from "@/types";
 import type { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import type { Advice_Level } from "@/types/proto-es/v1/sql_service_pb";
@@ -106,6 +106,7 @@ const { project } = useCurrentProjectV1();
 const { resultMap } = usePlanSQLCheckContext();
 const taskBar = ref<HTMLDivElement>();
 const taskBarScrollState = useVerticalScrollState(taskBar, MAX_LIST_HEIGHT);
+const dbStore = useDatabaseV1Store();
 
 const taskList = computed(() => {
   return selectedStage.value.tasks;
@@ -173,7 +174,7 @@ const loadMore = useDebounceFn(async () => {
     .map((task) => databaseForTask(project.value, task).name);
 
   try {
-    await batchGetOrFetchDatabases(databaseNames);
+    await dbStore.batchGetOrFetchDatabases(databaseNames);
   } catch {
     // Ignore errors
     // If the issue type is create database,

--- a/frontend/src/components/Member/MemberDataTable/index.vue
+++ b/frontend/src/components/Member/MemberDataTable/index.vue
@@ -86,10 +86,9 @@ const onGroupLoad = async (row: DataTableRowData) => {
     return;
   }
 
-  const memberUserIds = binding.group.members.map((m) => m.member);
-  if (memberUserIds.length > 0) {
-    await userStore.batchGetUsers(memberUserIds);
-  }
+  await userStore.batchGetOrFetchUsers(
+    binding.group.members.map((m) => m.member)
+  );
 
   const children: UserRoleData[] = [];
   for (const member of binding.group.members) {

--- a/frontend/src/components/Plan/components/AddSpecDrawer.vue
+++ b/frontend/src/components/Plan/components/AddSpecDrawer.vue
@@ -53,9 +53,9 @@ import DatabaseAndGroupSelector from "@/components/DatabaseAndGroupSelector";
 import { getLocalSheetByName, getNextLocalSheetUID } from "@/components/Plan";
 import { Drawer, DrawerContent } from "@/components/v2";
 import {
-  batchGetOrFetchDatabases,
   pushNotification,
   useCurrentProjectV1,
+  useDatabaseV1Store,
 } from "@/store";
 import type { ComposedDatabase } from "@/types";
 import { DatabaseChangeType } from "@/types/proto-es/v1/common_pb";
@@ -77,6 +77,7 @@ const emit = defineEmits<{
 
 const { project } = useCurrentProjectV1();
 const { t } = useI18n();
+const dbStore = useDatabaseV1Store();
 const show = defineModel<boolean>("show", { default: false });
 
 const isCreating = ref(false);
@@ -127,7 +128,7 @@ const handleUpdateSelection = async (newState: DatabaseSelectState) => {
     newState.changeSource === "DATABASE" &&
     newState.selectedDatabaseNameList?.length > 0
   ) {
-    await batchGetOrFetchDatabases(newState.selectedDatabaseNameList);
+    await dbStore.batchGetOrFetchDatabases(newState.selectedDatabaseNameList);
   }
 };
 

--- a/frontend/src/components/Plan/components/RolloutView/TaskTable.vue
+++ b/frontend/src/components/Plan/components/RolloutView/TaskTable.vue
@@ -30,7 +30,7 @@ import Timestamp from "@/components/misc/Timestamp.vue";
 import DatabaseDisplay from "@/components/Plan/components/common/DatabaseDisplay.vue";
 import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
 import { PROJECT_V1_ROUTE_ROLLOUT_DETAIL_TASK_DETAIL } from "@/router/dashboard/projectV1";
-import { batchGetOrFetchDatabases, useCurrentProjectV1 } from "@/store";
+import { useCurrentProjectV1, useDatabaseV1Store } from "@/store";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
@@ -64,6 +64,7 @@ const router = useRouter();
 const { project } = useCurrentProjectV1();
 const { rollout, mergedStages } = useRolloutViewContext();
 const { taskRuns } = usePlanContextWithRollout();
+const dbStore = useDatabaseV1Store();
 
 const taskList = computed(() => {
   if (props.taskStatusFilter.length === 0) {
@@ -105,7 +106,9 @@ const stageMap = computed(() => {
 const prepareDatabases = async () => {
   if (taskList.value.length > 0) {
     try {
-      await batchGetOrFetchDatabases(taskList.value.map((task) => task.target));
+      await dbStore.batchGetOrFetchDatabases(
+        taskList.value.map((task) => task.target)
+      );
     } catch {
       // Ignore errors - this is just for pre-loading data
     }

--- a/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskInstancePreload.ts
+++ b/frontend/src/components/Plan/components/RolloutView/v2/composables/useTaskInstancePreload.ts
@@ -1,5 +1,5 @@
 import { ref, watch } from "vue";
-import { batchGetOrFetchDatabases } from "@/store";
+import { useDatabaseV1Store } from "@/store";
 import type { Stage } from "@/types/proto-es/v1/rollout_service_pb";
 
 /**
@@ -8,6 +8,7 @@ import type { Stage } from "@/types/proto-es/v1/rollout_service_pb";
  */
 export const useTaskInstancePreload = (stages: () => Stage[]) => {
   const fetchedDatabases = ref(new Set<string>());
+  const dbStore = useDatabaseV1Store();
 
   watch(
     stages,
@@ -31,7 +32,7 @@ export const useTaskInstancePreload = (stages: () => Stage[]) => {
       if (newDatabases.length > 0) {
         // Batch fetch databases (which also fetches their instances)
         try {
-          await batchGetOrFetchDatabases(newDatabases);
+          await dbStore.batchGetOrFetchDatabases(newDatabases);
           // Mark these databases as fetched
           newDatabases.forEach((name) => fetchedDatabases.value.add(name));
         } catch {

--- a/frontend/src/components/Plan/components/SpecDetailView/AllTargetsDrawer.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/AllTargetsDrawer.vue
@@ -63,11 +63,7 @@
 import { computed, reactive, watch } from "vue";
 import { BBSpin } from "@/bbkit";
 import { Drawer, DrawerContent, SearchBox } from "@/components/v2";
-import {
-  batchGetOrFetchDatabases,
-  useDatabaseV1Store,
-  useDBGroupStore,
-} from "@/store";
+import { useDatabaseV1Store, useDBGroupStore } from "@/store";
 import { isValidDatabaseGroupName, isValidDatabaseName } from "@/types";
 import DatabaseDisplay from "../common/DatabaseDisplay.vue";
 import { useSelectedSpec } from "./context";
@@ -129,7 +125,9 @@ const loadAllTargets = async () => {
     const fetchPromises: Promise<unknown>[] = [];
 
     if (databaseTargets.length > 0) {
-      fetchPromises.push(batchGetOrFetchDatabases(databaseTargets));
+      fetchPromises.push(
+        databaseStore.batchGetOrFetchDatabases(databaseTargets)
+      );
     }
 
     const dbGroupPromises = dbGroupTargets.map((target) =>

--- a/frontend/src/components/Plan/components/StatementSection/SchemaEditorDrawer.vue
+++ b/frontend/src/components/Plan/components/StatementSection/SchemaEditorDrawer.vue
@@ -68,11 +68,7 @@ import SchemaEditorLite, {
   generateDiffDDL,
 } from "@/components/SchemaEditorLite";
 import { Drawer, DrawerContent } from "@/components/v2";
-import {
-  batchGetOrFetchDatabases,
-  useDatabaseV1Store,
-  useDBSchemaV1Store,
-} from "@/store";
+import { useDatabaseV1Store, useDBSchemaV1Store } from "@/store";
 import { DEBOUNCE_SEARCH_DELAY } from "@/types";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import { engineSupportsSchemaEditor } from "@/utils/schemaEditor";
@@ -117,7 +113,7 @@ watchDebounced(
   () => state.databaseSelectorPageIndex,
   async (index) => {
     try {
-      await batchGetOrFetchDatabases(
+      await databaseStore.batchGetOrFetchDatabases(
         props.databaseNames.slice(
           DEFAULT_VISIBLE_TARGETS * index,
           DEFAULT_VISIBLE_TARGETS * (index + 1)

--- a/frontend/src/components/Plan/logic/rolloutPreview.ts
+++ b/frontend/src/components/Plan/logic/rolloutPreview.ts
@@ -4,7 +4,6 @@ import {
   useDBGroupStore,
   useEnvironmentV1Store,
 } from "@/store";
-import { batchGetOrFetchDatabases } from "@/store/modules/v1/database";
 import { isValidDatabaseGroupName, isValidDatabaseName } from "@/types";
 import { DatabaseChangeType } from "@/types/proto-es/v1/common_pb";
 import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
@@ -47,11 +46,10 @@ export async function generateRolloutPreview(
 ): Promise<Rollout> {
   // Step 1: Extract all database targets from specs and expand database groups
   const allDatabaseNames = await extractAndExpandDatabaseTargets(plan.specs);
+  const dbStore = useDatabaseV1Store();
 
   // Step 2: Fetch databases that are not cached
-  if (allDatabaseNames.length > 0) {
-    await batchGetOrFetchDatabases(allDatabaseNames);
-  }
+  await dbStore.batchGetOrFetchDatabases(allDatabaseNames);
 
   // Step 3: Generate tasks from specs
   const tasks = await generateTasksFromSpecs(plan.specs);

--- a/frontend/src/components/Project/useRecentProjects.ts
+++ b/frontend/src/components/Project/useRecentProjects.ts
@@ -1,10 +1,6 @@
 import { computedAsync } from "@vueuse/core";
 import { computed } from "vue";
-import {
-  batchGetOrFetchProjects,
-  useCurrentUserV1,
-  useProjectV1Store,
-} from "@/store";
+import { useCurrentUserV1, useProjectV1Store } from "@/store";
 import { isValidProjectName } from "@/types";
 import { hasProjectPermissionV2, useDynamicLocalStorage } from "@/utils";
 
@@ -40,7 +36,7 @@ export const useRecentProjects = () => {
     const projects = [];
     const invalidProjects: string[] = [];
 
-    await batchGetOrFetchProjects(recentViewProjectNames.value);
+    await projectV1Store.batchGetOrFetchProjects(recentViewProjectNames.value);
 
     for (const projectName of recentViewProjectNames.value) {
       try {

--- a/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
@@ -151,7 +151,6 @@ import {
   MiniActionButton,
 } from "@/components/v2";
 import {
-  batchGetOrFetchDatabases,
   extractGroupEmail,
   extractUserId,
   pushNotification,
@@ -588,7 +587,7 @@ watch(
           Array.isArray(conditionExpr.databaseResources) &&
           conditionExpr.databaseResources.length > 0
         ) {
-          await batchGetOrFetchDatabases(
+          await databaseStore.batchGetOrFetchDatabases(
             conditionExpr.databaseResources.map(
               (resource) => resource.databaseFullName
             )
@@ -638,10 +637,7 @@ const groupMembers = computedAsync(async () => {
 
   // Fetch user data for group members
   const members = props.binding.group?.members ?? [];
-  if (members.length > 0) {
-    const memberUserIds = members.map((m) => m.member);
-    await userStore.batchGetUsers(memberUserIds);
-  }
+  await userStore.batchGetOrFetchUsers(members.map((m) => m.member));
 
   const resp = [];
   for (const member of members) {

--- a/frontend/src/components/User/Settings/UserDataTable/index.vue
+++ b/frontend/src/components/User/Settings/UserDataTable/index.vue
@@ -31,8 +31,8 @@ import { useI18n } from "vue-i18n";
 import { BBAlert } from "@/bbkit";
 import { UserNameCell } from "@/components/v2/Model/cells";
 import {
-  batchGetOrFetchGroups,
   pushNotification,
+  useGroupStore,
   useUserStore,
   useWorkspaceV1Store,
 } from "@/store";
@@ -69,6 +69,7 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const userStore = useUserStore();
 const workspaceStore = useWorkspaceV1Store();
+const groupStore = useGroupStore();
 
 const { copy: copyTextToClipboard, isSupported } = useClipboard({
   legacy: true,
@@ -79,7 +80,7 @@ watchEffect(async () => {
   for (const user of props.userList) {
     groupNames.push(...user.groups);
   }
-  await batchGetOrFetchGroups(groupNames);
+  await groupStore.batchGetOrFetchGroups(groupNames);
 });
 
 const state = reactive<LocalState>({

--- a/frontend/src/components/User/Settings/UserDataTableByGroup/index.vue
+++ b/frontend/src/components/User/Settings/UserDataTableByGroup/index.vue
@@ -72,7 +72,7 @@ const onGroupLoad = async (row: DataTableRowData) => {
   const group = (row as GroupRowData).group;
   const memberUserIds = group.members.map((m) => m.member);
   if (memberUserIds.length > 0) {
-    await userStore.batchGetUsers(memberUserIds);
+    await userStore.batchGetOrFetchUsers(memberUserIds);
   }
 
   const members: UserRowData[] = [];

--- a/frontend/src/components/v2/Select/DatabaseSelect.vue
+++ b/frontend/src/components/v2/Select/DatabaseSelect.vue
@@ -76,7 +76,7 @@ const additionalOptions = computedAsync(async () => {
     databaseNames = [props.value];
   }
 
-  const databases = await databaseStore.batchGetDatabases(databaseNames);
+  const databases = await databaseStore.batchGetOrFetchDatabases(databaseNames);
   options.push(...databases.map(getOption));
 
   return options;

--- a/frontend/src/components/v2/Select/GroupSelect.vue
+++ b/frontend/src/components/v2/Select/GroupSelect.vue
@@ -59,9 +59,11 @@ const additionalOptions = computedAsync(async () => {
     groupNames = [props.value];
   }
 
-  const groups = await groupStore.batchFetchGroups(groupNames);
+  const groups = await groupStore.batchGetOrFetchGroups(groupNames);
   for (const group of groups) {
-    options.push(getOption(group));
+    if (group) {
+      options.push(getOption(group));
+    }
   }
 
   return options;

--- a/frontend/src/components/v2/Select/ProjectSelect.vue
+++ b/frontend/src/components/v2/Select/ProjectSelect.vue
@@ -118,7 +118,7 @@ const additionalOptions = computedAsync(async () => {
     options.unshift(getOption(dummyAll));
   }
 
-  const projects = await projectStore.batchGetProjects(projectNames);
+  const projects = await projectStore.batchGetOrFetchProjects(projectNames);
   options.push(...projects.map(getOption));
 
   return options;

--- a/frontend/src/components/v2/Select/UserSelect.vue
+++ b/frontend/src/components/v2/Select/UserSelect.vue
@@ -95,7 +95,7 @@ const additionalOptions = computedAsync(async () => {
   }
 
   // Ensure users are fetched into store
-  await userStore.batchGetUsers(
+  await userStore.batchGetOrFetchUsers(
     userEmails.map((email) => `${userNamePrefix}${email}`)
   );
 

--- a/frontend/src/composables/useExecuteSQL.ts
+++ b/frontend/src/composables/useExecuteSQL.ts
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from "uuid";
 import { markRaw, reactive } from "vue";
 import { t } from "@/plugins/i18n";
 import {
-  batchGetOrFetchDatabases,
   hasFeature,
   pushNotification,
   useDatabaseV1Store,
@@ -205,7 +204,7 @@ const useExecuteSQL = () => {
     }
 
     const isBatch = batchQueryDatabaseSet.size > 1;
-    await batchGetOrFetchDatabases([...batchQueryDatabaseSet.keys()]);
+    await dbStore.batchGetOrFetchDatabases([...batchQueryDatabaseSet.keys()]);
 
     for (const databaseName of batchQueryDatabaseSet.values()) {
       if (!databaseQueryContexts.has(databaseName)) {

--- a/frontend/src/store/modules/user.ts
+++ b/frontend/src/store/modules/user.ts
@@ -174,7 +174,7 @@ export const useUserStore = defineStore("user", () => {
     return setUser(response);
   };
 
-  const batchGetUsers = async (userNameList: string[]) => {
+  const batchGetOrFetchUsers = async (userNameList: string[]) => {
     const distinctList = uniq(userNameList)
       .filter(
         (name) =>
@@ -197,7 +197,7 @@ export const useUserStore = defineStore("user", () => {
     for (const user of response.users) {
       setUser(user);
     }
-    return response.users;
+    return distinctList.map((name) => getUserByIdentifier(name));
   };
 
   const getOrFetchUserByIdentifier = async (
@@ -245,7 +245,7 @@ export const useUserStore = defineStore("user", () => {
     createUser,
     updateUser,
     updateEmail,
-    batchGetUsers,
+    batchGetOrFetchUsers,
     getOrFetchUserByIdentifier,
     getUserByIdentifier,
     archiveUser,

--- a/frontend/src/store/modules/v1/group.ts
+++ b/frontend/src/store/modules/v1/group.ts
@@ -102,6 +102,21 @@ export const useGroupStore = defineStore("group", () => {
     return groups;
   };
 
+  const batchGetOrFetchGroups = async (groupNames: string[]) => {
+    const distinctGroupList = uniq(groupNames).filter((groupName) => {
+      if (!groupName) {
+        return false;
+      }
+      const group = getGroupByIdentifier(groupName);
+      if (group) {
+        return false;
+      }
+      return true;
+    });
+    await batchFetchGroups(distinctGroupList);
+    return distinctGroupList.map(getGroupByIdentifier);
+  };
+
   const getOrFetchGroupByIdentifier = async (id: string) => {
     if (!hasWorkspacePermissionV2("bb.groups.get")) {
       return;
@@ -152,7 +167,7 @@ export const useGroupStore = defineStore("group", () => {
   return {
     groupList,
     fetchGroupList,
-    batchFetchGroups,
+    batchGetOrFetchGroups,
     getGroupByIdentifier,
     getOrFetchGroupByIdentifier,
     deleteGroup,
@@ -160,21 +175,3 @@ export const useGroupStore = defineStore("group", () => {
     createGroup,
   };
 });
-
-export const batchGetOrFetchGroups = async (groupNames: string[]) => {
-  const store = useGroupStore();
-
-  const distinctGroupList = uniq(groupNames).filter((groupName) => {
-    if (!groupName) {
-      return false;
-    }
-    const group = store.getGroupByIdentifier(groupName);
-    if (group) {
-      return false;
-    }
-    return true;
-  });
-  if (distinctGroupList.length > 0) {
-    return store.batchFetchGroups(distinctGroupList);
-  }
-};

--- a/frontend/src/store/modules/v1/issue.ts
+++ b/frontend/src/store/modules/v1/issue.ts
@@ -28,7 +28,7 @@ import {
   type ComposeIssueConfig,
   shallowComposeIssue,
 } from "./experimental-issue";
-import { batchGetOrFetchProjects, useProjectV1Store } from "./project";
+import { useProjectV1Store } from "./project";
 import { useProjectIamPolicyStore } from "./projectIamPolicy";
 
 export type ListIssueParams = {
@@ -114,13 +114,13 @@ export const useIssueV1Store = defineStore("issue_v1", () => {
     const projects = issues.map((issue) => {
       return `projects/${extractProjectResourceName(issue.name)}`;
     });
-    await batchGetOrFetchProjects(projects);
+    await projectStore.batchGetOrFetchProjects(projects);
     const composedIssues = await Promise.all(
       issues.map((issue) => shallowComposeIssue(issue, composeIssueConfig))
     );
     // Preprare creator for the issues.
     const users = uniq(composedIssues.map((issue) => issue.creator));
-    await useUserStore().batchGetUsers(users);
+    await useUserStore().batchGetOrFetchUsers(users);
     return {
       nextPageToken: resp.nextPageToken,
       issues: composedIssues,

--- a/frontend/src/store/modules/v1/plan.ts
+++ b/frontend/src/store/modules/v1/plan.ts
@@ -103,7 +103,7 @@ export const usePlanStore = defineStore("plan", () => {
       await planServiceClientConnect.searchPlans(request);
     // Prepare creator for the plans.
     const users = uniq(plans.map((plan) => plan.creator));
-    await useUserStore().batchGetUsers(users);
+    await useUserStore().batchGetOrFetchUsers(users);
     return {
       nextPageToken: nextPageToken,
       plans,

--- a/frontend/src/store/modules/v1/project.ts
+++ b/frontend/src/store/modules/v1/project.ts
@@ -204,6 +204,25 @@ export const useProjectV1Store = defineStore("project_v1", () => {
     return composedProjects;
   };
 
+  const batchGetOrFetchProjects = async (projectNames: string[]) => {
+    const distinctProjectList = uniq(projectNames).filter((projectName) => {
+      if (
+        !projectName ||
+        !isValidProjectName(projectName) ||
+        projectName === DEFAULT_PROJECT_NAME
+      ) {
+        return false;
+      }
+      const project = getProjectByName(projectName);
+      if (isValidProjectName(project.name)) {
+        return false;
+      }
+      return true;
+    });
+    await batchGetProjects(distinctProjectList, true /* silent */);
+    return distinctProjectList.map(getProjectByName);
+  };
+
   const getOrFetchProjectByName = async (name: string, silent = true) => {
     const cachedData = getProjectByName(name);
     if (cachedData && cachedData.name !== UNKNOWN_PROJECT_NAME) {
@@ -296,7 +315,7 @@ export const useProjectV1Store = defineStore("project_v1", () => {
     restoreProject,
     updateProjectCache,
     fetchProjectList,
-    batchGetProjects,
+    batchGetOrFetchProjects,
   };
 });
 
@@ -323,26 +342,4 @@ export const useCurrentProjectV1 = () => {
       : unknownProject().name
   );
   return useProjectByName(projectName);
-};
-
-export const batchGetOrFetchProjects = async (projectNames: string[]) => {
-  const store = useProjectV1Store();
-
-  const distinctProjectList = uniq(projectNames).filter((projectName) => {
-    if (
-      !projectName ||
-      !isValidProjectName(projectName) ||
-      projectName === DEFAULT_PROJECT_NAME
-    ) {
-      return false;
-    }
-    const project = store.getProjectByName(projectName);
-    if (isValidProjectName(project.name)) {
-      return false;
-    }
-    return true;
-  });
-  if (distinctProjectList.length > 0) {
-    return store.batchGetProjects(distinctProjectList, true /* silent */);
-  }
 };

--- a/frontend/src/store/modules/v1/projectIamPolicy.ts
+++ b/frontend/src/store/modules/v1/projectIamPolicy.ts
@@ -44,8 +44,8 @@ export const composePolicyBindings = async (
     }
   }
   await Promise.all([
-    useUserStore().batchGetUsers(users),
-    useGroupStore().batchFetchGroups(groups),
+    useUserStore().batchGetOrFetchUsers(users),
+    useGroupStore().batchGetOrFetchGroups(groups),
   ]);
 };
 

--- a/frontend/src/store/modules/v1/worksheet.ts
+++ b/frontend/src/store/modules/v1/worksheet.ts
@@ -31,8 +31,8 @@ import { useSQLEditorTabStore } from "../sqlEditor";
 import { useUserStore } from "../user";
 import { useCurrentUserV1 } from "./auth";
 import { extractUserId } from "./common";
-import { batchGetOrFetchDatabases, useDatabaseV1Store } from "./database";
-import { batchGetOrFetchProjects, useProjectV1Store } from "./project";
+import { useDatabaseV1Store } from "./database";
+import { useProjectV1Store } from "./project";
 
 type WorksheetView = "FULL" | "BASIC";
 type WorksheetCacheKey = [string /* uid */, WorksheetView];
@@ -90,11 +90,15 @@ export const useWorkSheetStore = defineStore("worksheet_v1", () => {
 
   const setListCache = async (worksheets: Worksheet[]) => {
     await Promise.all([
-      batchGetOrFetchProjects(worksheets.map((worksheet) => worksheet.project)),
-      batchGetOrFetchDatabases(
+      projectStore.batchGetOrFetchProjects(
+        worksheets.map((worksheet) => worksheet.project)
+      ),
+      databaseStore.batchGetOrFetchDatabases(
         worksheets.map((worksheet) => worksheet.database)
       ),
-      userStore.batchGetUsers(worksheets.map((worksheet) => worksheet.creator)),
+      userStore.batchGetOrFetchUsers(
+        worksheets.map((worksheet) => worksheet.creator)
+      ),
     ]);
     for (const worksheet of worksheets) {
       setCacheEntry(worksheet, "BASIC");

--- a/frontend/src/utils/expr.ts
+++ b/frontend/src/utils/expr.ts
@@ -137,7 +137,7 @@ export const getProjectIdOptionConfig = (): OptionConfig => {
   return {
     options: [],
     fetch: async (projectIds: string[]) => {
-      const projects = await projectStore.batchGetProjects(
+      const projects = await projectStore.batchGetOrFetchProjects(
         projectIds.map((projectId) => `${projectNamePrefix}${projectId}`)
       );
       return projects.map(getProjectIdOption);
@@ -245,7 +245,7 @@ export const getDatabaseNameOptionConfig = (parent: string): OptionConfig => {
   return {
     options: [],
     fetch: async (names: string[]) => {
-      const databases = await dbStore.batchGetDatabases(names);
+      const databases = await dbStore.batchGetOrFetchDatabases(names);
       return databases.map(getDatabasFullNameOption);
     },
     search: async (params: {

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -53,9 +53,9 @@ import DataExportButton from "@/components/DataExportButton.vue";
 import { FeatureAttention } from "@/components/FeatureGuard";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
 import {
-  batchGetOrFetchProjects,
   featureToRef,
   useAuditLogStore,
+  useProjectV1Store,
   useUserStore,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
@@ -89,6 +89,7 @@ const state = reactive<LocalState>({
 });
 const { t } = useI18n();
 const auditLogStore = useAuditLogStore();
+const projectStore = useProjectV1Store();
 const auditLogPagedTable = ref<ComponentExposed<typeof PagedTable<AuditLog>>>();
 const hasAuditLogFeature = featureToRef(PlanFeature.FEATURE_AUDIT_LOG);
 
@@ -111,7 +112,7 @@ const fetchAuditLog = async ({
     pageToken,
     pageSize,
   });
-  await batchGetOrFetchProjects(
+  await projectStore.batchGetOrFetchProjects(
     auditLogs.map((auditLog) => {
       const projectResourceId = extractProjectResourceName(auditLog.name);
       if (!projectResourceId) {
@@ -120,7 +121,7 @@ const fetchAuditLog = async ({
       return `${projectNamePrefix}${projectResourceId}`;
     })
   );
-  await useUserStore().batchGetUsers(auditLogs.map((log) => log.user));
+  await useUserStore().batchGetOrFetchUsers(auditLogs.map((log) => log.user));
   return { nextPageToken, list: auditLogs };
 };
 

--- a/frontend/src/views/project/ProjectAuditLogDashboard.vue
+++ b/frontend/src/views/project/ProjectAuditLogDashboard.vue
@@ -122,7 +122,7 @@ const fetchAuditLog = async ({
     pageToken,
     pageSize,
   });
-  await useUserStore().batchGetUsers(auditLogs.map((log) => log.user));
+  await useUserStore().batchGetOrFetchUsers(auditLogs.map((log) => log.user));
   return { nextPageToken, list: auditLogs };
 };
 

--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/ConnectionPane.vue
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/ConnectionPane.vue
@@ -218,7 +218,6 @@ import MaskSpinner from "@/components/misc/MaskSpinner.vue";
 import { RichDatabaseName } from "@/components/v2";
 import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
 import {
-  batchGetOrFetchDatabases,
   type DatabaseFilter,
   featureToRef,
   idForSQLEditorTreeNodeTarget,
@@ -409,7 +408,7 @@ const getQueryableDatabase = async (batchQueryContext: BatchQueryContext) => {
 
   for (const databaseGroupName of batchQueryContext.databaseGroups ?? []) {
     const databaseGroup = dbGroupStore.getDBGroupByName(databaseGroupName);
-    await batchGetOrFetchDatabases(
+    await databaseStore.batchGetOrFetchDatabases(
       databaseGroup.matchedDatabases.map((db) => db.name)
     );
     for (const matchedDatabase of databaseGroup.matchedDatabases) {
@@ -507,7 +506,7 @@ watch(
       return;
     }
     const databases = tabStore.currentTab.batchQueryContext.databases ?? [];
-    await batchGetOrFetchDatabases(databases);
+    await databaseStore.batchGetOrFetchDatabases(databases);
   },
   {
     immediate: true,

--- a/frontend/src/views/sql-editor/EditorPanel/TerminalPanel/TerminalPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/TerminalPanel/TerminalPanel.vue
@@ -90,7 +90,6 @@ import {
 import { BBSpin } from "@/bbkit";
 import type { IStandaloneCodeEditor } from "@/components/MonacoEditor";
 import {
-  batchGetOrFetchDatabases,
   useDatabaseV1Store,
   useSQLEditorTabStore,
   useWebTerminalStore,
@@ -120,7 +119,7 @@ const queryList = computed(() => {
 });
 
 watchEffect(async () => {
-  await batchGetOrFetchDatabases(
+  await databaseStore.batchGetOrFetchDatabases(
     queryList.value.map((query) => query?.params?.connection.database ?? "")
   );
 });


### PR DESCRIPTION
Do not expose the `BatchGetXXX` in the store, expose the `BatchGetOrFetchXXX` instead.
It's too easy to use the wrong method, like https://github.com/bytebase/bytebase/pull/18591.
Besides, the `BatchGetOrFetchXXX` will filter existing resources so that it saves efforts.