### PR TITLE
fix: prevent null values in migration results aggregation

### DIFF
--- a/backend/migrator/migration/3.14/0006##consolidate_plan_check_runs.sql
+++ b/backend/migrator/migration/3.14/0006##consolidate_plan_check_runs.sql
@@ -73,8 +73,8 @@ SELECT
                     END
                 )
             ), '[]'::jsonb)
-            FROM plan_check_run_deduped d3
-            LEFT JOIN LATERAL jsonb_array_elements(d3.result->'results') r ON true
+            FROM plan_check_run_deduped d3,
+            LATERAL jsonb_array_elements(d3.result->'results') r
             WHERE d3.plan_id = d.plan_id
         ))
     END,


### PR DESCRIPTION
## Summary
- Fix null values appearing in `results` array after running the plan_check_run consolidation migration
- Change `LEFT JOIN LATERAL jsonb_array_elements(...)` to implicit `LATERAL` join
- `LEFT JOIN` produces null rows when the array is empty; implicit join produces no rows, preventing nulls in `jsonb_agg`

## Data Fix
For existing data with nulls, run:
```sql
UPDATE plan_check_run
SET result = jsonb_set(
    result,
    '{results}',
    (
        SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)
        FROM jsonb_array_elements(result->'results') elem
        WHERE elem IS NOT NULL AND elem != 'null'::jsonb
    )
)
WHERE result->'results' IS NOT NULL
  AND EXISTS (
    SELECT 1
    FROM jsonb_array_elements(result->'results') elem
    WHERE elem IS NULL OR elem = 'null'::jsonb
  );
```

## Test plan
- [ ] Run migration on test database with existing plan_check_run data
- [ ] Verify no null values in results arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)