### PR TITLE
feat: make enforce_issue_title default for all projects

### DIFF
--- a/backend/migrator/migration/3.14/0007##enforce_issue_title_default.sql
+++ b/backend/migrator/migration/3.14/0007##enforce_issue_title_default.sql
@@ -1,0 +1,7 @@
+-- Enable enforce_issue_title for all existing projects.
+UPDATE project
+SET setting = jsonb_set(
+    setting,
+    '{enforceIssueTitle}',
+    'true'::jsonb
+);

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.14.6"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.14.7"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/frontend/src/types/v1/project.ts
+++ b/frontend/src/types/v1/project.ts
@@ -14,6 +14,7 @@ export const emptyProject = (): Project => {
     name: EMPTY_PROJECT_NAME,
     title: "",
     state: State.ACTIVE,
+    enforceIssueTitle: true,
   });
 };
 


### PR DESCRIPTION
## Summary

Make `enforce_issue_title` the default setting for all projects (both new and existing). This ensures users provide meaningful, manually-entered titles for issues and plans instead of relying on auto-generated ones.

## Changes

- **Frontend:** Modified `emptyProject()` to default `enforceIssueTitle` to `true` for all new projects
- **Backend:** Added migration (3.14.7) to enable `enforce_issue_title` for all existing projects
- **Tests:** Updated `TestLatestVersion` to expect version 3.14.7

## Impact

- **New projects:** Will require manual title entry by default
- **Existing projects:** Migration will enable this setting on next deployment
- **User experience:** Users must enter titles manually instead of accepting auto-generated ones

## Test Plan

- [x] Migration test passes (`TestLatestVersion`)
- [x] Frontend code formatted and type-checked
- [ ] Manual testing: Create new project and verify enforceIssueTitle is true
- [ ] Manual testing: Verify existing projects get updated after migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)