### PR TITLE
fix: use upsert to prevent race condition in plan check run creation

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -258,7 +258,7 @@ func (s *PlanService) CreatePlan(ctx context.Context, request *connect.Request[v
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get plan check run for plan, error: %v", err))
 	}
 	if planCheckRun != nil {
-		if err := s.store.CreatePlanCheckRuns(ctx, plan, planCheckRun); err != nil {
+		if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create plan check run, error: %v", err))
 		}
 	}
@@ -416,7 +416,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get plan check run for plan, error: %v", err))
 		}
 		if planCheckRun != nil {
-			if err := s.store.CreatePlanCheckRuns(ctx, updatedPlan, planCheckRun); err != nil {
+			if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
 				return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create plan check run, error: %v", err))
 			}
 		}
@@ -503,7 +503,7 @@ func (s *PlanService) RunPlanChecks(ctx context.Context, request *connect.Reques
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get plan check run for plan, error: %v", err))
 	}
 	if planCheckRun != nil {
-		if err := s.store.CreatePlanCheckRuns(ctx, plan, planCheckRun); err != nil {
+		if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create plan check run, error: %v", err))
 		}
 	}

--- a/backend/migrator/migration/3.14/0009##plan_check_run_unique_plan_id.sql
+++ b/backend/migrator/migration/3.14/0009##plan_check_run_unique_plan_id.sql
@@ -1,0 +1,4 @@
+-- Drop the non-unique index and add a unique index on plan_id.
+-- This enforces the consolidated model (one record per plan) and enables UPSERT.
+DROP INDEX IF EXISTS idx_plan_check_run_plan_id;
+CREATE UNIQUE INDEX idx_plan_check_run_unique_plan_id ON plan_check_run(plan_id);

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -296,7 +296,7 @@ CREATE TABLE plan_check_run (
     payload jsonb NOT NULL DEFAULT '{}'
 );
 
-CREATE INDEX idx_plan_check_run_plan_id ON plan_check_run (plan_id);
+CREATE UNIQUE INDEX idx_plan_check_run_unique_plan_id ON plan_check_run(plan_id);
 
 CREATE INDEX idx_plan_check_run_active_status ON plan_check_run(status, id) WHERE status = 'RUNNING';
 

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.14.8"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.14.9"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -47,52 +47,31 @@ type FindPlanCheckRunMessage struct {
 	ResultStatus *[]storepb.Advice_Status
 }
 
-// CreatePlanCheckRuns creates new plan check runs.
-func (s *Store) CreatePlanCheckRuns(ctx context.Context, plan *PlanMessage, creates ...*PlanCheckRunMessage) error {
-	if len(creates) == 0 {
-		return nil
+// CreatePlanCheckRun creates or replaces the plan check run for a plan.
+// With the consolidated model, there is only one record per plan.
+func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMessage) error {
+	config, err := protojson.Marshal(create.Config)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal config")
+	}
+	result, err := protojson.Marshal(create.Result)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal result")
 	}
 
-	txn, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return err
+	query := `
+		INSERT INTO plan_check_run (plan_id, status, config, result)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (plan_id) DO UPDATE SET
+			status = EXCLUDED.status,
+			config = EXCLUDED.config,
+			result = EXCLUDED.result,
+			updated_at = now()
+	`
+	if _, err := s.GetDB().ExecContext(ctx, query, create.PlanUID, create.Status, config, result); err != nil {
+		return errors.Wrapf(err, "failed to upsert plan check run")
 	}
-	defer txn.Rollback()
-
-	// Delete existing plan check runs
-	q := qb.Q().Space("DELETE FROM plan_check_run WHERE plan_id = ?", plan.UID)
-	query, args, err := q.ToSQL()
-	if err != nil {
-		return errors.Wrapf(err, "failed to build delete sql")
-	}
-	if _, err := txn.ExecContext(ctx, query, args...); err != nil {
-		return errors.Wrapf(err, "failed to delete plan check run for plan %d", plan.UID)
-	}
-
-	// Insert new plan check runs
-	q = qb.Q().Space("INSERT INTO plan_check_run (plan_id, status, config, result) VALUES")
-	for i, create := range creates {
-		config, err := protojson.Marshal(create.Config)
-		if err != nil {
-			return errors.Wrapf(err, "failed to marshal create config")
-		}
-		result, err := protojson.Marshal(create.Result)
-		if err != nil {
-			return errors.Wrapf(err, "failed to marshal create result %v", create.Result)
-		}
-		if i > 0 {
-			q.Space(",")
-		}
-		q.Space("(?, ?, ?, ?)", create.PlanUID, create.Status, config, result)
-	}
-	query, args, err = q.ToSQL()
-	if err != nil {
-		return errors.Wrapf(err, "failed to build insert sql")
-	}
-	if _, err := txn.ExecContext(ctx, query, args...); err != nil {
-		return errors.Wrapf(err, "failed to execute insert")
-	}
-	return txn.Commit()
+	return nil
 }
 
 // ListPlanCheckRuns returns a list of plan check runs based on find.


### PR DESCRIPTION
## Summary

- Replace DELETE+INSERT pattern with `ON CONFLICT` upsert in `CreatePlanCheckRun` to prevent race condition
- Add unique index `idx_plan_check_run_unique_plan_id` on `plan_id` to enforce the one-record-per-plan invariant
- Rename `CreatePlanCheckRuns` → `CreatePlanCheckRun` (singular) to match consolidated model

## Problem

With READ COMMITTED isolation (PostgreSQL default), concurrent calls to `CreatePlanCheckRuns` could create duplicate records:

| Time | Transaction A | Transaction B |
|------|---------------|---------------|
| T1 | BEGIN | BEGIN |
| T2 | DELETE (removes 0 rows) | |
| T3 | | DELETE (removes 0 rows) |
| T4 | INSERT | |
| T5 | COMMIT | |
| T6 | | INSERT (duplicate!) |
| T7 | | COMMIT |

## Solution

Use atomic UPSERT which is safe under concurrent access:

```sql
INSERT INTO plan_check_run (plan_id, status, config, result)
VALUES ($1, $2, $3, $4)
ON CONFLICT (plan_id) DO UPDATE SET
    status = EXCLUDED.status,
    config = EXCLUDED.config,
    result = EXCLUDED.result,
    updated_at = now()
```

## Test plan

- [ ] Verify migration applies cleanly
- [ ] Verify plan check runs still work correctly
- [ ] Verify concurrent plan check creation doesn't create duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)