### PR TITLE
chore: remove redundant 'consolidated model' comments

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -252,7 +252,6 @@ func (s *PlanService) CreatePlan(ctx context.Context, request *connect.Request[v
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create plan, error: %v", err))
 	}
 
-	// Create consolidated plan check run if applicable.
 	planCheckRun, err := getPlanCheckRunFromPlan(project, plan, databaseGroup)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get plan check run for plan, error: %v", err))
@@ -759,7 +758,7 @@ func storePlanConfigHasRelease(plan *storepb.PlanConfig) bool {
 
 // Converters section - ordered with callers before callees.
 
-// getPlanCheckRunFromPlan returns a single consolidated plan check run for a plan.
+// getPlanCheckRunFromPlan returns the plan check run for a plan.
 func getPlanCheckRunFromPlan(project *store.ProjectMessage, plan *store.PlanMessage, databaseGroup *v1pb.DatabaseGroup) (*store.PlanCheckRunMessage, error) {
 	var targets []*storepb.PlanCheckRunConfig_CheckTarget
 

--- a/backend/migrator/migration/3.14/0009##plan_check_run_unique_plan_id.sql
+++ b/backend/migrator/migration/3.14/0009##plan_check_run_unique_plan_id.sql
@@ -1,4 +1,3 @@
--- Drop the non-unique index and add a unique index on plan_id.
--- This enforces the consolidated model (one record per plan) and enables UPSERT.
+-- Replace non-unique index with unique index to enable UPSERT.
 DROP INDEX IF EXISTS idx_plan_check_run_plan_id;
 CREATE UNIQUE INDEX idx_plan_check_run_unique_plan_id ON plan_check_run(plan_id);

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -452,7 +452,6 @@ func (r *Runner) buildCELVariablesForDatabaseChange(ctx context.Context, issue *
 		return nil, false, errors.Errorf("plan %v not found", *issue.PlanUID)
 	}
 
-	// Check plan check run status (consolidated model: one run per plan)
 	planCheckRun, err := r.store.GetPlanCheckRun(ctx, plan.UID)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "failed to get plan check run for plan %v", plan.UID)

--- a/backend/runner/plancheck/executor_combined.go
+++ b/backend/runner/plancheck/executor_combined.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bytebase/bytebase/backend/store"
 )
 
-// CombinedExecutor processes all plan check types for a consolidated plan check run.
+// CombinedExecutor processes all plan check types.
 type CombinedExecutor struct {
 	store          *store.Store
 	sheetManager   *sheet.Manager
@@ -34,7 +34,7 @@ func NewCombinedExecutor(
 	}
 }
 
-// Run runs all checks for a consolidated config.
+// Run runs all checks for the given config.
 func (e *CombinedExecutor) Run(ctx context.Context, config *storepb.PlanCheckRunConfig) ([]*storepb.PlanCheckRunResult_Result, error) {
 	var allResults []*storepb.PlanCheckRunResult_Result
 

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -48,7 +48,6 @@ type FindPlanCheckRunMessage struct {
 }
 
 // CreatePlanCheckRun creates or replaces the plan check run for a plan.
-// With the consolidated model, there is only one record per plan.
 func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMessage) error {
 	config, err := protojson.Marshal(create.Config)
 	if err != nil {
@@ -157,7 +156,6 @@ func (s *Store) GetPlanCheckRun(ctx context.Context, planUID int64) (*PlanCheckR
 	if len(runs) == 0 {
 		return nil, nil
 	}
-	// With consolidated model, there should be only one record per plan
 	return runs[0], nil
 }
 

--- a/backend/tests/sql.go
+++ b/backend/tests/sql.go
@@ -41,7 +41,6 @@ func (ctl *controller) GetSQLReviewResult(ctx context.Context, plan *v1pb.Plan) 
 			return nil, err
 		}
 		check := resp.Msg
-		// With consolidated model, check if any result has STATEMENT_ADVISE type
 		hasStatementAdvise := false
 		for _, result := range check.Results {
 			if result.Type == v1pb.PlanCheckRun_Result_STATEMENT_ADVISE {

--- a/backend/tests/sql_review_test.go
+++ b/backend/tests/sql_review_test.go
@@ -486,7 +486,6 @@ func createIssueAndReturnSQLReviewResult(ctx context.Context, a *require.Asserti
 	result, err := ctl.GetSQLReviewResult(ctx, plan.Msg)
 	a.NoError(err)
 
-	// With consolidated model, filter to only STATEMENT_ADVISE results
 	var statementAdviseResults []*v1pb.PlanCheckRun_Result
 	for _, r := range result.Results {
 		if r.Type == v1pb.PlanCheckRun_Result_STATEMENT_ADVISE {


### PR DESCRIPTION
## Summary

Remove redundant comments that mention "consolidated model" throughout the codebase. The consolidation is now the established model - no need to keep explaining it everywhere.

## Files changed

- `backend/store/plan_check_run.go`
- `backend/api/v1/plan_service.go`
- `backend/runner/approval/runner.go`
- `backend/runner/plancheck/executor_combined.go`
- `backend/tests/sql.go`
- `backend/tests/sql_review_test.go`
- `backend/migrator/migration/3.14/0009##plan_check_run_unique_plan_id.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)