### PR TITLE
fix(frontend): show issue creator instead of plan creator in IssueDes…

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueDescriptionComment.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueDescriptionComment.vue
@@ -117,11 +117,11 @@ const createdSentence = computed(() => {
 });
 
 const creatorName = computed(() => {
-  return hasPlan.value ? plan.value.creator : (issue.value?.creator ?? "");
+  return issue.value?.creator || plan.value?.creator || "";
 });
 
 const createTime = computed((): Timestamp | undefined => {
-  return hasPlan.value ? plan.value.createTime : issue.value?.createTime;
+  return issue.value?.createTime || plan.value?.createTime;
 });
 
 const creator = computed(() => {


### PR DESCRIPTION
…criptionComment

When an issue is created from a plan by a different user (e.g., clicking "ready for review"), the UI was showing the plan creator instead of the issue creator. This was confusing because the text said "created issue" but showed the wrong person.

Now both creatorName and createTime prefer issue data and fall back to plan data only when no issue exists.

Fixes BYT-8569

🤖 Generated with [Claude Code](https://claude.com/claude-code)