### PR TITLE
perf(mssql): remove redundant TSQL parsing from unit tests

### DIFF
--- a/backend/plugin/schema/mssql/generate_migration_test.go
+++ b/backend/plugin/schema/mssql/generate_migration_test.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
@@ -88,12 +87,6 @@ func runMigrationTest(t *testing.T, file string) {
 			// Generate migration
 			migration, err := generateMigration(diff)
 			require.NoErrorf(t, err, "Failed to generate migration for test case [%02d]: %s", i+1, test.Description)
-
-			// Parse the generated migration to ensure it's valid SQL
-			if migration != "" {
-				_, err := tsql.ParseTSQL(migration)
-				require.NoErrorf(t, err, "Failed to parse generated SQL for test case [%02d]: %s\nSQL: %s", i+1, test.Description, migration)
-			}
 
 			require.Equalf(t, test.Expected, migration, "Test case [%02d] failed: %s", i+1, test.Description)
 		})

--- a/backend/plugin/schema/mssql/get_database_definition_test.go
+++ b/backend/plugin/schema/mssql/get_database_definition_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
 
@@ -44,13 +43,6 @@ func TestGetDatabaseDefinition(t *testing.T) {
 
 		result, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, &metadata)
 		a.NoError(err)
-
-		// Parse the output to ensure it's valid TSQL
-		_, err = tsql.ParseTSQL(result)
-		if err != nil {
-			t.Logf("Test case %d SQL:\n%s", i, result)
-		}
-		a.NoError(err, "Test case %d: Failed to parse generated SQL", i)
 
 		if record {
 			tests[i].Output = result


### PR DESCRIPTION
## Summary
- Remove `tsql.ParseTSQL()` validation from MSSQL unit tests
- The TSQL parser has **244K lines** of ANTLR-generated code, causing severe CI slowdown
- `TestGetDatabaseDefinition` was taking **163s on CI** vs <1s locally due to parser init contention with parallel tests (`-p=8`)

## Why this is safe
1. Output is already compared with expected output (golden test pattern)
2. Testcontainer tests validate by executing SQL against a real database
3. The parser validation only catches syntax errors, which are already caught by the golden test comparison

## Test plan
- [x] All MSSQL unit tests pass locally
- [x] Linter passes
- [ ] CI backend tests complete faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)