### PR TITLE
fix(migrator): delete task_run_log before task_run to respect FK constraint

### DIFF
--- a/backend/migrator/migration/3.14/0010##remove_pipeline.sql
+++ b/backend/migrator/migration/3.14/0010##remove_pipeline.sql
@@ -7,7 +7,12 @@ WHERE task.pipeline_id = pipeline.id;
 
 -- Remove any orphaned tasks that don't belong to a plan (i.e. not linked to a pipeline).
 -- This is required to satisfy the NOT NULL constraint on plan_id.
-DELETE FROM task_run WHERE task_id IN (SELECT id FROM task WHERE plan_id IS NULL);
+DELETE FROM task_run_log USING task_run, task
+WHERE task_run_log.task_run_id = task_run.id AND task_run.task_id = task.id AND task.plan_id IS NULL;
+
+DELETE FROM task_run USING task
+WHERE task_run.task_id = task.id AND task.plan_id IS NULL;
+
 DELETE FROM task WHERE plan_id IS NULL;
 
 ALTER TABLE task ALTER COLUMN plan_id SET NOT NULL;


### PR DESCRIPTION
## Summary
- Fix migration 3.14.10 failing due to foreign key constraint violation
- Delete from `task_run_log` before `task_run` since `task_run_log` references `task_run`
- Refactor nested `IN` subqueries to cleaner `DELETE ... USING` syntax

## Test plan
- [ ] Run migration on a database with existing task_run_log data

🤖 Generated with [Claude Code](https://claude.ai/code)