### PR TITLE
chore(grpc-gateway): use incoming header matcher

### DIFF
--- a/backend/api/auth/auth.go
+++ b/backend/api/auth/auth.go
@@ -277,7 +277,7 @@ func GetTokenFromHeaders(headers http.Header) (string, error) {
 
 	// Check HTTP cookies
 	var accessToken string
-	for _, cookieHeader := range append(headers.Values("cookie"), headers.Values("grpcgateway-cookie")...) {
+	for _, cookieHeader := range headers.Values("cookie") {
 		header := http.Header{}
 		header.Add("Cookie", cookieHeader)
 		request := http.Request{Header: header}

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -204,10 +204,6 @@ func (s *AuthService) Login(ctx context.Context, req *connect.Request[v1pb.Login
 		}
 
 		origin := req.Header().Get("Origin")
-		if origin == "" {
-			origin = req.Header().Get("grpcgateway-origin")
-		}
-
 		cookie := auth.GetTokenCookie(ctx, s.store, s.licenseService, origin, response.Token)
 		resp.Header().Add("Set-Cookie", cookie.String())
 	}
@@ -279,9 +275,6 @@ func (s *AuthService) Logout(ctx context.Context, req *connect.Request[v1pb.Logo
 	resp := connect.NewResponse(&emptypb.Empty{})
 
 	origin := req.Header().Get("Origin")
-	if origin == "" {
-		origin = req.Header().Get("grpcgateway-origin")
-	}
 	cookie := auth.GetTokenCookie(ctx, s.store, s.licenseService, origin, "")
 	resp.Header().Add("Set-Cookie", cookie.String())
 	return resp, nil


### PR DESCRIPTION
pass through the headers we need.

also updated the outgoing header matcher. no more grpcgateway-xxxx headers in the response