### PR TITLE
refactor: use Config field in UpdatePlanMessage to follow store pattern

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -7,6 +7,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -366,7 +367,9 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 
 			// Convert and store new specs.
 			allSpecs := convertPlanSpecs(req.GetPlan().GetSpecs())
-			planUpdate.Specs = &allSpecs
+			config := proto.CloneOf(oldPlan.Config)
+			config.Specs = allSpecs
+			planUpdate.Config = config
 
 			// Trigger plan check runs.
 			planCheckRunsTrigger = true

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -10,6 +10,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/jackc/pgtype"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -300,10 +301,11 @@ func (s *RolloutService) CreateRollout(ctx context.Context, req *connect.Request
 	}
 
 	// Update plan to set hasRollout to true
-	hasRollout := true
+	config := proto.CloneOf(plan.Config)
+	config.HasRollout = true
 	if err := s.store.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:        planID,
-		HasRollout: &hasRollout,
+		UID:    planID,
+		Config: config,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan hasRollout, error: %v", err))
 	}


### PR DESCRIPTION
## Summary

Refactor `UpdatePlanMessage` to use a single `Config *storepb.PlanConfig` field instead of individual `Specs` and `HasRollout` fields. This follows the pattern used in other store updates like `UpdateReleaseMessage`.

## Changes

- **backend/store/plan.go**: Replace individual fields with `Config` field that replaces the entire config
- **backend/api/v1/plan_service.go**: Clone existing config and update only `Specs` field
- **backend/api/v1/rollout_service.go**: Clone existing config and update only `HasRollout` field

## Pattern

Callers now use `proto.CloneOf()` to clone the existing config, modify only the fields they need to change, then pass the complete config to the store. This ensures all other fields are preserved and follows the established pattern in the codebase.

```go
// Example usage:
config := proto.CloneOf(plan.Config)
config.HasRollout = true
store.UpdatePlan(ctx, &store.UpdatePlanMessage{
    UID: planID,
    Config: config,
})
```

## Test plan

- ✅ All linting passed (0 issues)
- ✅ Tests passed
- ✅ Backend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)