### PR TITLE
refactor: make UpdatePlan() return the updated plan

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -397,19 +397,9 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		}
 	}
 
-	if err := s.store.UpdatePlan(ctx, planUpdate); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
-	}
-
-	updatedPlan, err := s.store.GetPlan(ctx, &store.FindPlanMessage{
-		UID:       &oldPlan.UID,
-		ProjectID: &oldPlan.ProjectID,
-	})
+	updatedPlan, err := s.store.UpdatePlan(ctx, planUpdate)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get updated plan %q: %v", req.Plan.Name, err))
-	}
-	if updatedPlan == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("updated plan %q not found", req.Plan.Name))
+		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
 	}
 
 	if planCheckRunsTrigger {

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -307,25 +307,12 @@ func (s *RolloutService) CreateRollout(ctx context.Context, req *connect.Request
 	// Update plan to set hasRollout to true
 	config := proto.CloneOf(plan.Config)
 	config.HasRollout = true
-	if err := s.store.UpdatePlan(ctx, &store.UpdatePlanMessage{
+	rollout, err := s.store.UpdatePlan(ctx, &store.UpdatePlanMessage{
 		UID:    planID,
 		Config: config,
-	}); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan hasRollout, error: %v", err))
-	}
-
-	// getRolloutWithTasks inlined
-	// re-fetch plan to get latest state (e.g. hasRollout config)
-	rollout, err := s.store.GetPlan(ctx, &store.FindPlanMessage{
-		UID:       &planID, // planID is already int64
-		ProjectID: &projectID,
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get plan, error: %v", err))
-	}
-	if rollout == nil {
-		// Should not happen as we just created tasks for it
-		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("rollout %d not found in project %s", planID, projectID))
+		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan hasRollout, error: %v", err))
 	}
 
 	tasks, err := s.store.ListTasks(ctx, &store.TaskFind{PlanID: &planID})


### PR DESCRIPTION
## Summary
- Modified `UpdatePlan()` in `backend/store/plan.go` to return the updated plan instead of requiring callers to re-fetch it
- Updated callers in `backend/api/v1/plan_service.go` and `backend/api/v1/rollout_service.go` to use the returned plan
- Eliminates redundant database queries and simplifies the API

## Changes
- **backend/store/plan.go**: Changed `UpdatePlan()` signature to return `(*PlanMessage, error)` and use `RETURNING` clause in the UPDATE query
- **backend/api/v1/plan_service.go**: Use the returned plan from `UpdatePlan()` instead of calling `GetPlan()`
- **backend/api/v1/rollout_service.go**: Use the returned plan from `UpdatePlan()` instead of calling `GetPlan()`

## Benefits
- Reduces database round-trips by eliminating the need to re-fetch plans after updates
- Simplifies caller code by removing boilerplate GetPlan calls
- Follows the pattern established by `CreatePlan()` which already returns the created plan

## Test plan
- [ ] Verify existing tests pass
- [ ] Manually test plan updates in the UI
- [ ] Verify rollout creation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)