### PR TITLE
chore: do not cache the page count

### DIFF
--- a/frontend/src/components/AuditLog/AuditLogDataTable.vue
+++ b/frontend/src/components/AuditLog/AuditLogDataTable.vue
@@ -78,9 +78,6 @@ const columnList = computed((): AuditDataTableColumn[] => {
         title: t("audit-log.table.created-ts"),
         width: 220,
         resizable: true,
-        ellipsis: {
-          tooltip: true,
-        },
         render: (auditLog) =>
           dayjs(getDateForPbTimestampProtoEs(auditLog.createTime)).format(
             "YYYY-MM-DD HH:mm:ss Z"
@@ -116,9 +113,6 @@ const columnList = computed((): AuditDataTableColumn[] => {
         resizable: true,
         width: 256,
         title: t("audit-log.table.method"),
-        ellipsis: {
-          tooltip: true,
-        },
         render: (auditLog) => auditLog.method,
       },
       {


### PR DESCRIPTION
- Do not cache the page count

We used to cache how many pages were loaded, and when users refresh the page, we will request (pageSize * page) data.
It's probably not a good design, not only wastes the resource, but also could be a performance issue

- Fix the table connot horizontal scroll

When configuring the table with `ellipsis` enabled, it cannot support horizontal scrolling. Looks like a bug in the `NDataTable`