### PR TITLE
feat(frontend): unify rollout creation warning behavior

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/create/RolloutCreatePanel.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/create/RolloutCreatePanel.vue
@@ -1,0 +1,184 @@
+<template>
+  <CommonDrawer
+    :show="show"
+    :title="$t('issue.create-rollout')"
+    :loading="loading"
+    @show="resetState"
+    @close="$emit('close')"
+  >
+    <template #default>
+      <div class="flex flex-col gap-y-4 h-full px-1">
+        <!-- Warning alert with messages -->
+        <NAlert
+          v-if="warningMessages.length > 0"
+          type="warning"
+          :title="$t('common.notices')"
+        >
+          <ul class="list-disc list-inside flex flex-col gap-y-1">
+            <li
+              v-for="(warning, index) in warningMessages"
+              :key="index"
+              class="text-sm"
+            >
+              {{ warning }}
+            </li>
+          </ul>
+        </NAlert>
+
+        <!-- Approval Flow Section -->
+        <ApprovalFlowSection v-if="issue" :issue="issue" />
+
+        <!-- Plan Check Status -->
+        <div class="w-full flex flex-col gap-2">
+          <span class="font-medium text-control shrink-0">{{
+            $t("plan.navigator.checks")
+          }}</span>
+          <PlanCheckStatusCount :plan="plan" />
+        </div>
+      </div>
+    </template>
+    <template #footer>
+      <div class="w-full flex flex-row justify-between items-center gap-x-2">
+        <!-- Bypass checkbox -->
+        <div v-if="hasWarnings" class="flex items-center">
+          <NCheckbox v-model:checked="bypassWarnings" :disabled="loading">
+            {{ $t("rollout.bypass-stage-requirements") }}
+          </NCheckbox>
+        </div>
+        <div v-else />
+
+        <div class="flex justify-end gap-x-2">
+          <NButton quaternary @click="$emit('close')">
+            {{ $t("common.close") }}
+          </NButton>
+
+          <NButton
+            :disabled="hasWarnings && !bypassWarnings"
+            type="primary"
+            :loading="loading"
+            @click="handleConfirm"
+          >
+            {{ $t("issue.create-rollout") }}
+          </NButton>
+        </div>
+      </div>
+    </template>
+  </CommonDrawer>
+</template>
+
+<script setup lang="ts">
+import { create } from "@bufbuild/protobuf";
+import { NAlert, NButton, NCheckbox } from "naive-ui";
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import CommonDrawer from "@/components/IssueV1/components/Panel/CommonDrawer.vue";
+import { ApprovalFlowSection } from "@/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection";
+import PlanCheckStatusCount from "@/components/Plan/components/PlanCheckStatusCount.vue";
+import { usePlanContext } from "@/components/Plan/logic";
+import { rolloutServiceClientConnect } from "@/grpcweb";
+import { PROJECT_V1_ROUTE_ROLLOUT_DETAIL } from "@/router/dashboard/projectV1";
+import { pushNotification } from "@/store";
+import { CreateRolloutRequestSchema } from "@/types/proto-es/v1/rollout_service_pb";
+import { extractProjectResourceName, extractRolloutUID } from "@/utils";
+import type { ActionContext } from "../registry/types";
+
+const props = defineProps<{
+  show: boolean;
+  context: ActionContext;
+}>();
+
+const emit = defineEmits<{
+  (event: "close"): void;
+  (event: "confirm"): void;
+}>();
+
+const { t } = useI18n();
+const router = useRouter();
+const { events } = usePlanContext();
+
+// Use context from props for consistency
+const plan = computed(() => props.context.plan);
+const issue = computed(() => props.context.issue);
+const project = computed(() => props.context.project);
+const warnings = computed(() => props.context.rolloutCreationWarnings);
+
+const loading = ref(false);
+const bypassWarnings = ref(false);
+
+// Build warning messages based on current state
+const warningMessages = computed(() => {
+  const messages: string[] = [];
+
+  if (warnings.value.approvalNotReady) {
+    messages.push(
+      t("project.settings.issue-related.require-issue-approval.description")
+    );
+  }
+
+  if (warnings.value.planChecksRunning) {
+    messages.push(
+      t(
+        "custom-approval.issue-review.disallow-approve-reason.some-task-checks-are-still-running"
+      )
+    );
+  } else if (warnings.value.planChecksFailed) {
+    messages.push(
+      t(
+        "project.settings.issue-related.require-plan-check-no-error.description"
+      )
+    );
+  }
+
+  return messages;
+});
+
+const hasWarnings = computed(() => warnings.value.hasAny);
+
+const resetState = () => {
+  bypassWarnings.value = false;
+};
+
+const handleConfirm = async () => {
+  if (loading.value) return;
+
+  loading.value = true;
+  try {
+    const request = create(CreateRolloutRequestSchema, {
+      parent: project.value.name,
+      rollout: {
+        plan: plan.value.name,
+      },
+    });
+    const createdRollout =
+      await rolloutServiceClientConnect.createRollout(request);
+
+    pushNotification({
+      module: "bytebase",
+      style: "SUCCESS",
+      title: t("common.created"),
+    });
+
+    events.emit("status-changed", { eager: true });
+    emit("confirm");
+
+    router.push({
+      name: PROJECT_V1_ROUTE_ROLLOUT_DETAIL,
+      params: {
+        projectId: extractProjectResourceName(project.value.name),
+        rolloutId: extractRolloutUID(createdRollout.name),
+      },
+    });
+  } catch (error) {
+    pushNotification({
+      module: "bytebase",
+      style: "CRITICAL",
+      title: t("common.failed"),
+      description: String(error),
+    });
+  } finally {
+    loading.value = false;
+    emit("close");
+  }
+};
+</script>

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/create/index.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/create/index.ts
@@ -1,4 +1,5 @@
 import CreateButton from "./CreateButton.vue";
 import CreateIssueButton from "./CreateIssueButton.vue";
+import RolloutCreatePanel from "./RolloutCreatePanel.vue";
 
-export { CreateButton, CreateIssueButton };
+export { CreateButton, CreateIssueButton, RolloutCreatePanel };

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/types.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/types.ts
@@ -63,23 +63,34 @@ export interface ActionContext {
   isIssueOnly: boolean;
   isExportPlan: boolean;
   isCreator: boolean;
+  issueApproved: boolean; // approval is APPROVED or SKIPPED
   exportArchiveReady: boolean;
   allTasksFinished: boolean;
   hasDatabaseCreateOrExportTasks: boolean;
   hasStartableTasks: boolean;
   hasRunningTasks: boolean;
-  rolloutPreconditionsMet: boolean;
+
+  // Warning flags for rollout creation (button moves to dropdown when hasAny=true)
+  // Note: When require_*=true and condition not met, button is HIDDEN (not a warning)
+  rolloutCreationWarnings: {
+    approvalNotReady: boolean; // require_issue_approval=false AND not approved
+    planChecksRunning: boolean; // plan checks currently running
+    planChecksFailed: boolean; // require_plan_check_no_error=false AND checks failed
+    hasAny: boolean; // convenience: true if any warning is active
+  };
 
   // Grouped
   permissions: ActionPermissions;
   validation: ActionValidation;
 }
 
+export type ActionCategory = "primary" | "secondary";
+
 export interface ActionDefinition {
   id: UnifiedAction;
   label: (ctx: ActionContext) => string;
   buttonType: "primary" | "success" | "default";
-  category: "primary" | "secondary";
+  category: ActionCategory | ((ctx: ActionContext) => ActionCategory);
   priority: number;
 
   isVisible: (ctx: ActionContext) => boolean;

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/useActionRegistry.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/useActionRegistry.ts
@@ -44,6 +44,12 @@ export function useActionRegistry(): ActionRegistryReturn {
       : undefined
   );
 
+  // Helper to resolve category (static or dynamic)
+  const getCategory = (action: ActionDefinition) =>
+    typeof action.category === "function"
+      ? action.category(context.value)
+      : action.category;
+
   // Filter visible actions (no actions during plan creation)
   const visibleActions = computed(() => {
     if (isCreating.value) return [];
@@ -52,15 +58,15 @@ export function useActionRegistry(): ActionRegistryReturn {
 
   // Primary action (first visible by priority, category=primary)
   const primaryAction = computed(() =>
-    visibleActions.value.find((a) => a.category === "primary")
+    visibleActions.value.find((a) => getCategory(a) === "primary")
   );
 
   // Secondary actions: all secondary-category actions + remaining primary actions (excluding the chosen primary)
   const secondaryActions = computed(() =>
     visibleActions.value.filter(
       (a) =>
-        a.category === "secondary" ||
-        (a.category === "primary" && a.id !== primaryAction.value?.id)
+        getCategory(a) === "secondary" ||
+        (getCategory(a) === "primary" && a.id !== primaryAction.value?.id)
     )
   );
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -139,6 +139,7 @@
     "search": "Search",
     "search-for-more": "Search for more",
     "warning": "Warning",
+    "notices": "Notices",
     "edited": "edited",
     "preview": "Preview",
     "file-selector": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -139,6 +139,7 @@
     "search": "Buscar",
     "search-for-more": "Buscar más",
     "warning": "Advertencia",
+    "notices": "Avisos",
     "edited": "editado",
     "preview": "Previsualización",
     "file-selector": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -139,6 +139,7 @@
     "search": "検索",
     "search-for-more": "さらに検索",
     "warning": "警告する",
+    "notices": "注意事項",
     "edited": "編集日時",
     "preview": "プレビュー",
     "file-selector": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -139,6 +139,7 @@
     "search": "Tìm kiếm",
     "search-for-more": "Tìm kiếm thêm",
     "warning": "Cảnh báo",
+    "notices": "Thông báo",
     "edited": "đã chỉnh sửa",
     "preview": "Xem trước",
     "file-selector": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -139,6 +139,7 @@
     "search": "搜索",
     "search-for-more": "搜索更多",
     "warning": "警告",
+    "notices": "注意事项",
     "edited": "编辑于",
     "preview": "预览",
     "file-selector": {


### PR DESCRIPTION
Implement unified warning behavior for ROLLOUT_CREATE action:
- Hide button when require_issue_approval=true and issue not approved
- Hide button when require_plan_check_no_error=true and plan checks failed
- Show in dropdown with warnings when require_*=false but conditions not met
- Add RolloutCreatePanel with NAlert for warning messages and bypass checkbox
- Add issueApproved flag to ActionContext for consistent usage across actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>