### PR TITLE
fix(frontend): check hasRollout in configuration sections to match backend API

### DIFF
--- a/frontend/src/components/IssueV1/components/Sidebar/PreBackupSection/PreBackupSection.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/PreBackupSection/PreBackupSection.vue
@@ -32,9 +32,7 @@ const {
   selectedSpec: computed(() =>
     specForTask(issue.value.planEntity as Plan, selectedTask.value)
   ),
-  selectedTask,
   issue,
-  rollout: computed(() => issue.value.rolloutEntity),
 });
 
 const database = computed(() =>

--- a/frontend/src/components/IssueV1/components/Sidebar/Sidebar.vue
+++ b/frontend/src/components/IssueV1/components/Sidebar/Sidebar.vue
@@ -111,7 +111,6 @@ const { shouldShow: shouldShowGhostSection, events: ghostEvents } =
     project,
     plan: computed(() => issue.value.planEntity as Plan),
     selectedSpec,
-    selectedTask: selectedTask,
     issue,
   });
 

--- a/frontend/src/components/Plan/components/Configuration/Configuration.vue
+++ b/frontend/src/components/Plan/components/Configuration/Configuration.vue
@@ -31,7 +31,7 @@ import TransactionModeSection from "./TransactionModeSection";
 import { provideTransactionModeSettingContext } from "./TransactionModeSection/context";
 
 const { project } = useCurrentProjectV1();
-const { isCreating, plan, events, issue, rollout, readonly } = usePlanContext();
+const { isCreating, plan, events, issue, readonly } = usePlanContext();
 const { selectedSpec } = useSelectedSpec();
 
 const {
@@ -43,7 +43,6 @@ const {
   selectedSpec,
   isCreating,
   issue,
-  rollout,
   readonly,
 });
 
@@ -56,7 +55,6 @@ const {
   selectedSpec,
   isCreating,
   issue,
-  rollout,
   readonly,
 });
 
@@ -69,7 +67,6 @@ const {
   selectedSpec,
   isCreating,
   issue,
-  rollout,
   readonly,
 });
 
@@ -80,7 +77,6 @@ const { shouldShow: shouldShowGhostSection, events: ghostEvents } =
     selectedSpec,
     isCreating,
     issue,
-    rollout,
     readonly,
   });
 
@@ -91,7 +87,6 @@ const { shouldShow: shouldShowPreBackupSection, events: preBackupEvents } =
     selectedSpec,
     isCreating,
     issue,
-    rollout,
     readonly,
   });
 

--- a/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/context.ts
@@ -9,9 +9,6 @@ import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import { type Plan, type Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import type { Rollout } from "@/types/proto-es/v1/rollout_service_pb";
-import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
-import { flattenTaskV1List } from "@/utils";
 
 export const KEY = Symbol(
   "bb.plan.setting.instance-role"
@@ -27,12 +24,11 @@ export const provideInstanceRoleSettingContext = (refs: {
   plan: Ref<Plan>;
   selectedSpec: Ref<Plan_Spec | undefined>;
   issue?: Ref<Issue | undefined>;
-  rollout?: Ref<Rollout | undefined>;
   readonly?: Ref<boolean>;
 }) => {
   const databaseStore = useDatabaseV1Store();
 
-  const { isCreating, plan, selectedSpec, issue, rollout, readonly } = refs;
+  const { isCreating, plan, selectedSpec, issue, readonly } = refs;
 
   const events = new Emittery<{
     update: never;
@@ -78,23 +74,13 @@ export const provideInstanceRoleSettingContext = (refs: {
       return true;
     }
 
-    // If issue is not open, disallow
-    if (issue?.value && issue.value.status !== IssueStatus.OPEN) {
+    // Disallow changes if the plan has started rollout.
+    if (plan.value.hasRollout) {
       return false;
     }
 
-    const tasks = flattenTaskV1List(rollout?.value) || [];
-    // If any task is running/done/etc, disallow
-    if (
-      tasks.some((task) => {
-        return [
-          Task_Status.PENDING,
-          Task_Status.RUNNING,
-          Task_Status.DONE,
-          Task_Status.SKIPPED,
-        ].includes(task.status);
-      })
-    ) {
+    // If issue is not open, disallow
+    if (issue?.value && issue.value.status !== IssueStatus.OPEN) {
       return false;
     }
 

--- a/frontend/src/components/Plan/components/Configuration/TransactionModeSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/TransactionModeSection/context.ts
@@ -9,9 +9,7 @@ import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import { type Plan, type Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import type { Rollout } from "@/types/proto-es/v1/rollout_service_pb";
-import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
-import { flattenTaskV1List, instanceV1SupportsTransactionMode } from "@/utils";
+import { instanceV1SupportsTransactionMode } from "@/utils";
 
 export const KEY = Symbol(
   "bb.plan.setting.transaction-mode"
@@ -27,12 +25,11 @@ export const provideTransactionModeSettingContext = (refs: {
   plan: Ref<Plan>;
   selectedSpec: Ref<Plan_Spec | undefined>;
   issue?: Ref<Issue | undefined>;
-  rollout?: Ref<Rollout | undefined>;
   readonly?: Ref<boolean>;
 }) => {
   const databaseStore = useDatabaseV1Store();
 
-  const { isCreating, plan, selectedSpec, issue, rollout, readonly } = refs;
+  const { isCreating, plan, selectedSpec, issue, readonly } = refs;
 
   const events = new Emittery<{
     update: never;
@@ -78,23 +75,13 @@ export const provideTransactionModeSettingContext = (refs: {
       return true;
     }
 
-    // If issue is not open, disallow
-    if (issue?.value && issue.value.status !== IssueStatus.OPEN) {
+    // Disallow changes if the plan has started rollout.
+    if (plan.value.hasRollout) {
       return false;
     }
 
-    const tasks = flattenTaskV1List(rollout?.value) || [];
-    // If any task is running/done/etc, disallow
-    if (
-      tasks.some((task) => {
-        return [
-          Task_Status.PENDING,
-          Task_Status.RUNNING,
-          Task_Status.DONE,
-          Task_Status.SKIPPED,
-        ].includes(task.status);
-      })
-    ) {
+    // If issue is not open, disallow
+    if (issue?.value && issue.value.status !== IssueStatus.OPEN) {
       return false;
     }
 


### PR DESCRIPTION
Configuration sections (PreBackup, Ghost, TransactionMode, InstanceRole, IsolationLevel) were checking task status to determine if changes are allowed. However, the backend API blocks ALL spec changes when plan.hasRollout is true, regardless of task status.

This change updates the frontend to check plan.hasRollout directly, ensuring consistency with the backend UpdatePlan API behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)