### PR TITLE
perf: use cached instance metadata instead of querying lower_case_table_names

### DIFF
--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -232,7 +232,7 @@ func (s *RolloutService) CreateRollout(ctx context.Context, req *connect.Request
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("plan %d not found in project %s", planID, projectID))
 	}
 
-	pipelineCreate, err := GetPipelineCreate(ctx, s.store, s.dbFactory, plan.Config.GetSpecs(), project.ResourceID)
+	pipelineCreate, err := GetPipelineCreate(ctx, s.store, plan.Config.GetSpecs(), project.ResourceID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("failed to get pipeline create, error: %v", err))
 	}
@@ -1010,7 +1010,7 @@ func isChangeDatabasePlan(specs []*storepb.PlanConfig_Spec) bool {
 }
 
 // GetPipelineCreate gets a pipeline create message from a plan.
-func GetPipelineCreate(ctx context.Context, s *store.Store, dbFactory *dbfactory.DBFactory, specs []*storepb.PlanConfig_Spec, projectID string) (*store.PipelineMessage, error) {
+func GetPipelineCreate(ctx context.Context, s *store.Store, specs []*storepb.PlanConfig_Spec, projectID string) (*store.PipelineMessage, error) {
 	// Step 1 - transform database group specs.
 	// Re-evaluate database groups live to pick up newly created databases.
 	transformedSpecs, err := applyDatabaseGroupSpecTransformations(ctx, s, specs, projectID)
@@ -1021,7 +1021,7 @@ func GetPipelineCreate(ctx context.Context, s *store.Store, dbFactory *dbfactory
 	// Step 2 - convert all task creates.
 	var taskCreates []*store.TaskMessage
 	for _, spec := range transformedSpecs {
-		tcs, err := getTaskCreatesFromSpec(ctx, s, dbFactory, spec)
+		tcs, err := getTaskCreatesFromSpec(ctx, s, spec)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get task creates from spec")
 		}

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -487,7 +487,7 @@ func (r *Runner) buildCELVariablesForDatabaseChange(ctx context.Context, issue *
 	}
 
 	// Build CEL variables for each task
-	pipelineCreate, err := apiv1.GetPipelineCreate(ctx, r.store, r.dbFactory, plan.Config.GetSpecs(), issue.ProjectID)
+	pipelineCreate, err := apiv1.GetPipelineCreate(ctx, r.store, plan.Config.GetSpecs(), issue.ProjectID)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to get pipeline create")
 	}
@@ -601,7 +601,7 @@ func (r *Runner) buildCELVariablesForDataExport(ctx context.Context, issue *stor
 		return nil, false, errors.Errorf("plan %v not found", *issue.PlanUID)
 	}
 
-	pipelineCreate, err := apiv1.GetPipelineCreate(ctx, r.store, r.dbFactory, plan.Config.GetSpecs(), issue.ProjectID)
+	pipelineCreate, err := apiv1.GetPipelineCreate(ctx, r.store, plan.Config.GetSpecs(), issue.ProjectID)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to get pipeline create")
 	}

--- a/backend/runner/taskrun/rollout_creator.go
+++ b/backend/runner/taskrun/rollout_creator.go
@@ -10,7 +10,6 @@ import (
 
 	apiv1 "github.com/bytebase/bytebase/backend/api/v1"
 	"github.com/bytebase/bytebase/backend/common/log"
-	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	"github.com/bytebase/bytebase/backend/component/state"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/store"
@@ -20,17 +19,15 @@ import (
 // RolloutCreator handles automatic rollout creation.
 // nolint:revive
 type RolloutCreator struct {
-	store     *store.Store
-	stateCfg  *state.State
-	dbFactory *dbfactory.DBFactory
+	store    *store.Store
+	stateCfg *state.State
 }
 
 // NewRolloutCreator creates a new rollout creator.
-func NewRolloutCreator(store *store.Store, stateCfg *state.State, dbFactory *dbfactory.DBFactory) *RolloutCreator {
+func NewRolloutCreator(store *store.Store, stateCfg *state.State) *RolloutCreator {
 	return &RolloutCreator{
-		store:     store,
-		stateCfg:  stateCfg,
-		dbFactory: dbFactory,
+		store:    store,
+		stateCfg: stateCfg,
 	}
 }
 
@@ -148,7 +145,7 @@ func (rc *RolloutCreator) tryCreateRollout(_ context.Context, planID int64) {
 	slog.Info("auto-creating rollout", slog.Int("plan_id", int(planID)))
 
 	// Get pipeline create (tasks to create)
-	pipelineCreate, err := apiv1.GetPipelineCreate(rolloutCtx, rc.store, rc.dbFactory, plan.Config.GetSpecs(), project.ResourceID)
+	pipelineCreate, err := apiv1.GetPipelineCreate(rolloutCtx, rc.store, plan.Config.GetSpecs(), project.ResourceID)
 	if err != nil {
 		slog.Error("failed to get pipeline create for rollout creation",
 			slog.Int("plan_id", int(planID)),

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -76,7 +76,7 @@ func (s *Scheduler) Run(ctx context.Context, wg *sync.WaitGroup) {
 	go s.ListenTaskSkippedOrDone(ctx)
 
 	// Start rollout creator component
-	rolloutCreator := NewRolloutCreator(s.store, s.stateCfg, s.dbFactory)
+	rolloutCreator := NewRolloutCreator(s.store, s.stateCfg)
 	wg.Add(1)
 	go rolloutCreator.Run(ctx, wg, s.stateCfg.RolloutCreationChan)
 


### PR DESCRIPTION
## Summary

- Replace inefficient database query with cached instance metadata in rollout task creation
- Use `store.IsObjectCaseSensitive(instance)` helper instead of directly querying `SHOW VARIABLES LIKE 'lower_case_table_names'`
- Remove unused `dbFactory` parameter from `getTaskCreatesFromSpec` and `GetPipelineCreate`

## Changes

**Performance improvements:**
- Avoid opening database connections during task creation by using cached `instance.Metadata.MysqlLowerCaseTableNames` value
- Instance metadata is synced during instance sync and already cached

**Correctness:**
- Correctly handles all `lower_case_table_names` values (0, 1, 2), not just 1
- Consistent with 15+ other call sites that already use `store.IsObjectCaseSensitive(instance)`

**Cleanup:**
- Remove unused imports (log/slog, backend/common/log, backend/plugin/db, backend/component/dbfactory)

## Test plan

- [x] All linting passes (0 issues)
- [x] Code formatted with gofmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)