### PR TITLE
fix(auth): don't return access token in response body for web login

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -12131,7 +12131,9 @@ components:
         web:
           type: boolean
           title: web
-          description: If web is set, we will set access token, refresh token, and user to the cookie.
+          description: |-
+            If true, sets access token and refresh token as HTTP-only cookies instead of
+             returning the token in the response body. Use for browser-based clients.
         idpName:
           type: string
           title: idp_name
@@ -12165,7 +12167,9 @@ components:
         token:
           type: string
           title: token
-          description: Access token for authenticated requests.
+          description: |-
+            Access token for authenticated requests.
+             Only returned when web=false. For web=true, the token is set as an HTTP-only cookie.
         mfaTempToken:
           type: string
           title: mfa_temp_token

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -793,7 +793,6 @@ func (s *AuthService) generateLoginToken(ctx context.Context, user *store.UserMe
 // finalizeLogin builds the response, sets cookies if needed, and updates the user profile.
 func (s *AuthService) finalizeLogin(ctx context.Context, req *connect.Request[v1pb.LoginRequest], user *store.UserMessage, token string, requireResetPassword bool) (*connect.Response[v1pb.LoginResponse], error) {
 	response := &v1pb.LoginResponse{
-		Token:                token,
 		RequireResetPassword: requireResetPassword,
 	}
 	resp := connect.NewResponse(response)
@@ -821,6 +820,9 @@ func (s *AuthService) finalizeLogin(ctx context.Context, req *connect.Request[v1
 		}
 		refreshCookie := auth.GetRefreshTokenCookie(origin, refreshToken, refreshTokenDuration)
 		resp.Header().Add("Set-Cookie", refreshCookie.String())
+	} else {
+		// For non-web clients (CLI, API), return the token in the response body.
+		response.Token = token
 	}
 
 	if _, err := s.store.UpdateUser(ctx, user, &store.UpdateUserMessage{

--- a/backend/generated-go/v1/auth_service.pb.go
+++ b/backend/generated-go/v1/auth_service.pb.go
@@ -29,7 +29,8 @@ type LoginRequest struct {
 	Email string `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
 	// User's password for authentication.
 	Password string `protobuf:"bytes,2,opt,name=password,proto3" json:"password,omitempty"`
-	// If web is set, we will set access token, refresh token, and user to the cookie.
+	// If true, sets access token and refresh token as HTTP-only cookies instead of
+	// returning the token in the response body. Use for browser-based clients.
 	Web bool `protobuf:"varint,3,opt,name=web,proto3" json:"web,omitempty"`
 	// The name of the identity provider.
 	// Format: idps/{idp}
@@ -312,6 +313,7 @@ func (x *OIDCIdentityProviderContext) GetCode() string {
 type LoginResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Access token for authenticated requests.
+	// Only returned when web=false. For web=true, the token is set as an HTTP-only cookie.
 	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
 	// Temporary token for MFA verification.
 	MfaTempToken *string `protobuf:"bytes,2,opt,name=mfa_temp_token,json=mfaTempToken,proto3,oneof" json:"mfa_temp_token,omitempty"`

--- a/frontend/src/types/proto-es/v1/auth_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/auth_service_pb.d.ts
@@ -31,7 +31,8 @@ export declare type LoginRequest = Message<"bytebase.v1.LoginRequest"> & {
   password: string;
 
   /**
-   * If web is set, we will set access token, refresh token, and user to the cookie.
+   * If true, sets access token and refresh token as HTTP-only cookies instead of
+   * returning the token in the response body. Use for browser-based clients.
    *
    * @generated from field: bool web = 3;
    */
@@ -160,6 +161,7 @@ export declare const OIDCIdentityProviderContextSchema: GenMessage<OIDCIdentityP
 export declare type LoginResponse = Message<"bytebase.v1.LoginResponse"> & {
   /**
    * Access token for authenticated requests.
+   * Only returned when web=false. For web=true, the token is set as an HTTP-only cookie.
    *
    * @generated from field: string token = 1;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -11355,7 +11355,9 @@ components:
                     description: User's password for authentication.
                 web:
                     type: boolean
-                    description: If web is set, we will set access token, refresh token, and user to the cookie.
+                    description: |-
+                        If true, sets access token and refresh token as HTTP-only cookies instead of
+                         returning the token in the response body. Use for browser-based clients.
                 idpName:
                     type: string
                     description: |-
@@ -11379,7 +11381,9 @@ components:
             properties:
                 token:
                     type: string
-                    description: Access token for authenticated requests.
+                    description: |-
+                        Access token for authenticated requests.
+                         Only returned when web=false. For web=true, the token is set as an HTTP-only cookie.
                 mfaTempToken:
                     type: string
                     description: Temporary token for MFA verification.

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -3040,7 +3040,7 @@ Context for identity provider authentication.
 | ----- | ---- | ----- | ----------- |
 | email | [string](#string) |  | User&#39;s email address. |
 | password | [string](#string) |  | User&#39;s password for authentication. |
-| web | [bool](#bool) |  | If web is set, we will set access token, refresh token, and user to the cookie. |
+| web | [bool](#bool) |  | If true, sets access token and refresh token as HTTP-only cookies instead of returning the token in the response body. Use for browser-based clients. |
 | idp_name | [string](#string) |  | The name of the identity provider. Format: idps/{idp} |
 | idp_context | [IdentityProviderContext](#bytebase-v1-IdentityProviderContext) |  | The idp_context is used to get the user information from identity provider. |
 | otp_code | [string](#string) | optional | The otp_code is used to verify the user&#39;s identity by MFA. |
@@ -3060,7 +3060,7 @@ Context for identity provider authentication.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| token | [string](#string) |  | Access token for authenticated requests. |
+| token | [string](#string) |  | Access token for authenticated requests. Only returned when web=false. For web=true, the token is set as an HTTP-only cookie. |
 | mfa_temp_token | [string](#string) | optional | Temporary token for MFA verification. |
 | require_reset_password | [bool](#bool) |  | Whether user must reset password before continuing. |
 | user | [User](#bytebase-v1-User) |  | The user from the successful login. |

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -8895,7 +8895,8 @@ Format: {name}@workload.bytebase.com </p></td>
                   <td>web</td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
-                  <td><p>If web is set, we will set access token, refresh token, and user to the cookie. </p></td>
+                  <td><p>If true, sets access token and refresh token as HTTP-only cookies instead of
+returning the token in the response body. Use for browser-based clients. </p></td>
                 </tr>
               
                 <tr>
@@ -8955,7 +8956,8 @@ Format: idps/{idp} </p></td>
                   <td>token</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Access token for authenticated requests. </p></td>
+                  <td><p>Access token for authenticated requests.
+Only returned when web=false. For web=true, the token is set as an HTTP-only cookie. </p></td>
                 </tr>
               
                 <tr>

--- a/proto/v1/v1/auth_service.proto
+++ b/proto/v1/v1/auth_service.proto
@@ -63,7 +63,8 @@ message LoginRequest {
   // User's password for authentication.
   string password = 2;
 
-  // If web is set, we will set access token, refresh token, and user to the cookie.
+  // If true, sets access token and refresh token as HTTP-only cookies instead of
+  // returning the token in the response body. Use for browser-based clients.
   bool web = 3;
 
   // The name of the identity provider.
@@ -107,6 +108,7 @@ message OIDCIdentityProviderContext {
 
 message LoginResponse {
   // Access token for authenticated requests.
+  // Only returned when web=false. For web=true, the token is set as an HTTP-only cookie.
   string token = 1;
 
   // Temporary token for MFA verification.


### PR DESCRIPTION
## Summary
- When `web=true`, the login response no longer includes the access token in the body
- Access token is only set via HTTP-only cookie for web clients
- Added documentation comments in proto explaining the behavior

## Test plan
- [x] Test web login: verify token is NOT in response body, only in cookie
- [x] Test non-web login (CLI/API): verify token IS in response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)