### PR TITLE
refactor: replace GetPipeline with GetPlan in rollout service

### DIFF
--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -125,18 +125,20 @@ func convertToSchedulerInfoWaitingCause(ctx context.Context, s *store.Store, c *
 		if task == nil {
 			return nil, errors.Errorf("task %v not found", taskUID)
 		}
-		pipeline, err := s.GetPipelineByID(ctx, int(task.PlanID))
+		plan, err := s.GetPlan(ctx, &store.FindPlanMessage{
+			UID: &task.PlanID,
+		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get pipeline %v", task.PlanID)
+			return nil, errors.Wrapf(err, "failed to get plan %v", task.PlanID)
 		}
-		if pipeline == nil {
-			return nil, errors.Errorf("pipeline %d not found", task.PlanID)
+		if plan == nil {
+			return nil, errors.Errorf("plan %d not found", task.PlanID)
 		}
 		stageID := common.FormatStageID(task.Environment)
 		return &v1pb.TaskRun_SchedulerInfo_WaitingCause{
 			Cause: &v1pb.TaskRun_SchedulerInfo_WaitingCause_Task_{
 				Task: &v1pb.TaskRun_SchedulerInfo_WaitingCause_Task{
-					Task: common.FormatTask(pipeline.ProjectID, int(task.PlanID), stageID, task.ID),
+					Task: common.FormatTask(plan.ProjectID, int(task.PlanID), stageID, task.ID),
 				},
 			},
 		}, nil

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -487,13 +487,13 @@ func (r *Runner) buildCELVariablesForDatabaseChange(ctx context.Context, issue *
 	}
 
 	// Build CEL variables for each task
-	pipelineCreate, err := apiv1.GetPipelineCreate(ctx, r.store, plan.Config.GetSpecs(), issue.ProjectID)
+	tasks, err := apiv1.GetPipelineCreate(ctx, r.store, plan.Config.GetSpecs(), issue.ProjectID)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to get pipeline create")
 	}
 
 	var celVarsList []map[string]any
-	for _, task := range pipelineCreate.Tasks {
+	for _, task := range tasks {
 		instance, err := r.store.GetInstance(ctx, &store.FindInstanceMessage{
 			ResourceID: &task.InstanceID,
 		})
@@ -601,13 +601,13 @@ func (r *Runner) buildCELVariablesForDataExport(ctx context.Context, issue *stor
 		return nil, false, errors.Errorf("plan %v not found", *issue.PlanUID)
 	}
 
-	pipelineCreate, err := apiv1.GetPipelineCreate(ctx, r.store, plan.Config.GetSpecs(), issue.ProjectID)
+	tasks, err := apiv1.GetPipelineCreate(ctx, r.store, plan.Config.GetSpecs(), issue.ProjectID)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to get pipeline create")
 	}
 
 	var celVarsList []map[string]any
-	for _, task := range pipelineCreate.Tasks {
+	for _, task := range tasks {
 		if task.Type != storepb.Task_DATABASE_EXPORT {
 			continue
 		}


### PR DESCRIPTION
Replaced GetPipeline with GetPlan in rollout service and converter to deprecate GetPipeline usage.