### PR TITLE
perf: optimize ListRollouts to fix N+1 query for task loading

### DIFF
--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -56,6 +56,7 @@ type TaskFind struct {
 
 	// Related fields
 	PlanID       *int64
+	PlanIDs      *[]int64
 	Environment  *string
 	InstanceID   *string
 	DatabaseName *string
@@ -290,6 +291,9 @@ func (*Store) listTasksTx(ctx context.Context, txn *sql.Tx, find *TaskFind) ([]*
 	}
 	if v := find.PlanID; v != nil {
 		q.Space("AND task.plan_id = ?", *v)
+	}
+	if v := find.PlanIDs; v != nil {
+		q.Space("AND task.plan_id = ANY(?)", *v)
 	}
 	if v := find.Environment; v != nil {
 		q.Space("AND task.environment = ?", *v)


### PR DESCRIPTION
## Summary

Fixes a performance issue in the `ListRollouts` endpoint where tasks were loaded using an N+1 query pattern.

## Problem

The `ListRollouts` method was making a separate database query for each plan in a loop:

```go
for _, plan := range plans {
    tasks, err := s.store.ListTasks(ctx, &store.TaskFind{PlanID: &plan.UID})
    // ...
}
```

This caused poor performance when listing many rollouts, especially when the database is under load.

## Solution

Implemented batch loading of tasks:
1. Added `PlanIDs *[]int64` field to `store.TaskFind` to support filtering by multiple plan IDs
2. Updated the SQL query in `listTasksTx` to use `task.plan_id = ANY(?)` for batch loading
3. Refactored `ListRollouts` to:
   - Collect all plan IDs upfront
   - Load ALL tasks for ALL plans in a single query
   - Group tasks by plan ID in memory
   - Convert to rollouts with pre-loaded tasks

## Performance Impact

- **Before**: 1 + N queries (1 for plans, N for each plan's tasks)
- **After**: 2 queries total (1 for plans, 1 for all tasks)
- **Example**: Listing 100 rollouts went from **101 queries → 2 queries** (50x reduction!)

## Test Plan

- [x] All existing tests pass
- [x] Linting passes with no issues
- [x] Code formatted with `gofmt`
- [x] Backward compatible (both `PlanID` and `PlanIDs` fields supported)

## Files Changed

- `backend/store/task.go` - Added `PlanIDs` field and query support
- `backend/api/v1/rollout_service.go` - Refactored to use batch loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)