### PR TITLE
refactor: clean up redundant error message patterns

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -453,7 +453,7 @@ func (s *AuthService) getOrCreateUserWithIDP(ctx context.Context, request *v1pb.
 		PasswordHash: string(passwordHash),
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create user, error"))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create user"))
 	}
 	if userInfo.HasGroups {
 		// Sync user groups with the identity provider.
@@ -672,7 +672,7 @@ func (s *AuthService) completeMFALogin(ctx context.Context, request *v1pb.LoginR
 	}
 	user, err := s.store.GetUserByEmail(ctx, userEmail)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find user, error"))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find user"))
 	}
 	if user == nil {
 		return nil, invalidCredentialsError
@@ -704,7 +704,7 @@ func (s *AuthService) validateLoginPermissions(ctx context.Context, user *store.
 
 	isWorkspaceAdmin, err := isUserWorkspaceAdmin(ctx, s.store, user)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check user roles, error"))
+		return connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check user roles"))
 	}
 
 	// Skip restrictions for workspace admins and service accounts
@@ -724,7 +724,7 @@ func (s *AuthService) validateLoginPermissions(ctx context.Context, user *store.
 	if err := s.licenseService.IsFeatureEnabled(v1pb.PlanFeature_FEATURE_DISALLOW_PASSWORD_SIGNIN); err == nil {
 		setting, err := s.store.GetWorkspaceProfileSetting(ctx)
 		if err != nil {
-			return connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find workspace setting, error"))
+			return connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find workspace setting"))
 		}
 		if setting.DisallowPasswordSignin && !loginViaIDP {
 			return connect.NewError(connect.CodePermissionDenied, errors.Errorf("password signin is disallowed"))

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -63,7 +63,7 @@ func (s *DatabaseService) GetDatabase(ctx context.Context, req *connect.Request[
 	}
 	database, err := s.convertToDatabase(ctx, databaseMessage)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert database, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert database"))
 	}
 	return connect.NewResponse(database), nil
 }
@@ -116,7 +116,7 @@ func (s *DatabaseService) BatchGetDatabases(ctx context.Context, req *connect.Re
 		}
 		database, err := s.convertToDatabase(ctx, databaseMessage)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert database, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert database"))
 		}
 		databases = append(databases, database)
 	}
@@ -248,7 +248,7 @@ func (s *DatabaseService) ListDatabases(ctx context.Context, req *connect.Reques
 	if len(databaseMessages) == limitPlusOne {
 		databaseMessages = databaseMessages[:offset.limit]
 		if nextPageToken, err = offset.getNextPageToken(); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to marshal next page token, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to marshal next page token"))
 		}
 	}
 
@@ -258,7 +258,7 @@ func (s *DatabaseService) ListDatabases(ctx context.Context, req *connect.Reques
 	for _, databaseMessage := range databaseMessages {
 		database, err := s.convertToDatabase(ctx, databaseMessage)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert database, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert database"))
 		}
 		response.Databases = append(response.Databases, database)
 	}
@@ -382,7 +382,7 @@ func (s *DatabaseService) UpdateDatabase(ctx context.Context, req *connect.Reque
 
 	database, err := s.convertToDatabase(ctx, updatedDatabase)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert database, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert database"))
 	}
 	return connect.NewResponse(database), nil
 }
@@ -691,22 +691,22 @@ func (s *DatabaseService) DiffSchema(ctx context.Context, req *connect.Request[v
 	// Use unified SDL-based approach for all scenarios
 	sourceDBSchema, err := s.getSourceDBMetadata(ctx, req.Msg)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get source schema, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get source schema"))
 	}
 
 	targetDBSchema, err := s.getTargetDBMetadata(ctx, req.Msg)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get target schema, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get target schema"))
 	}
 
 	engine, err := s.getParserEngine(ctx, req.Msg)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get parser engine, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get parser engine"))
 	}
 
 	schemaDiff, err := schema.GetDatabaseSchemaDiff(engine, sourceDBSchema, targetDBSchema)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to compute schema diff, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to compute schema diff"))
 	}
 
 	// Filter out bbdataarchive schema changes for Postgres
@@ -716,7 +716,7 @@ func (s *DatabaseService) DiffSchema(ctx context.Context, req *connect.Request[v
 
 	migrationSQL, err := schema.GenerateMigration(engine, schemaDiff)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to generate migration SQL, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to generate migration SQL"))
 	}
 
 	return connect.NewResponse(&v1pb.DiffSchemaResponse{

--- a/backend/api/v1/group_service.go
+++ b/backend/api/v1/group_service.go
@@ -98,7 +98,7 @@ func (s *GroupService) ListGroups(ctx context.Context, request *connect.Request[
 	if len(groups) == limitPlusOne {
 		groups = groups[:offset.limit]
 		if nextPageToken, err = offset.getNextPageToken(); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to marshal next page token, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to marshal next page token"))
 		}
 	}
 

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -69,7 +69,7 @@ func (s *IssueService) GetIssue(ctx context.Context, req *connect.Request[v1pb.G
 	}
 	issueV1, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 	return connect.NewResponse(issueV1), nil
 }
@@ -259,7 +259,7 @@ func (s *IssueService) getIssueFind(
 	}
 
 	if _, err := parseFilter(ast.NativeRep().Expr()); err != nil {
-		return nil, nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("failed to parse filter, error: %v", err))
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to parse filter"))
 	}
 	return issueFind, filterIssue, nil
 }
@@ -292,20 +292,20 @@ func (s *IssueService) ListIssues(ctx context.Context, req *connect.Request[v1pb
 
 	issues, err := s.store.ListIssues(ctx, issueFind)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to search issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to search issue"))
 	}
 
 	var nextPageToken string
 	if len(issues) == limitPlusOne {
 		if nextPageToken, err = offset.getNextPageToken(); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get next page token, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get next page token"))
 		}
 		issues = issues[:offset.limit]
 	}
 
 	converted, err := s.convertToIssues(ctx, issues, issueFilter)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 	return connect.NewResponse(&v1pb.ListIssuesResponse{
 		Issues:        converted,
@@ -347,27 +347,27 @@ func (s *IssueService) SearchIssues(ctx context.Context, req *connect.Request[v1
 		}
 		projectIDsFilter, err := getProjectIDsSearchFilter(ctx, user, iam.PermissionIssuesGet, s.iamManager, s.store)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get projectIDs, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get projectIDs"))
 		}
 		issueFind.ProjectIDs = projectIDsFilter
 	}
 
 	issues, err := s.store.ListIssues(ctx, issueFind)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to search issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to search issue"))
 	}
 
 	var nextPageToken string
 	if len(issues) == limitPlusOne {
 		if nextPageToken, err = offset.getNextPageToken(); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get next page token, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get next page token"))
 		}
 		issues = issues[:offset.limit]
 	}
 
 	converted, err := s.convertToIssues(ctx, issues, issueFilter)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 	return connect.NewResponse(&v1pb.SearchIssuesResponse{
 		Issues:        converted,
@@ -400,7 +400,7 @@ func (s *IssueService) CreateIssue(ctx context.Context, req *connect.Request[v1p
 		ResourceID: &projectID,
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get project, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project"))
 	}
 	if project == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project not found for id: %v", projectID))
@@ -441,7 +441,7 @@ func (s *IssueService) createIssueDatabaseChange(ctx context.Context, project *s
 	}
 	plan, err := s.store.GetPlan(ctx, &store.FindPlanMessage{UID: &planID, ProjectID: &project.ResourceID})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get plan, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan"))
 	}
 	if plan == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("plan %d not found in project %s", planID, project.ResourceID))
@@ -468,7 +468,7 @@ func (s *IssueService) createIssueDatabaseChange(ctx context.Context, project *s
 
 	issue, err := s.store.CreateIssue(ctx, issueCreateMessage)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create issue"))
 	}
 	s.stateCfg.ApprovalFinding.Store(issue.UID, issue)
 
@@ -482,7 +482,7 @@ func (s *IssueService) createIssueDatabaseChange(ctx context.Context, project *s
 
 	converted, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 
 	return connect.NewResponse(converted), nil
@@ -511,7 +511,7 @@ func (s *IssueService) createIssueGrantRequest(ctx context.Context, project *sto
 	if expression := request.Issue.GrantRequest.GetCondition().GetExpression(); expression != "" {
 		e, err := cel.NewEnv(common.IAMPolicyConditionCELAttributes...)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create cel environment, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create cel environment"))
 		}
 		if _, issues := e.Compile(expression); issues != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("found issues in grant request condition expression, issues: %v", issues.String()))
@@ -520,7 +520,7 @@ func (s *IssueService) createIssueGrantRequest(ctx context.Context, project *sto
 
 	convertedGrantRequest, err := convertGrantRequest(ctx, s.store, request.Issue.GrantRequest)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert GrantRequest, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert GrantRequest"))
 	}
 	issueCreateMessage := &store.IssueMessage{
 		ProjectID:    project.ResourceID,
@@ -543,7 +543,7 @@ func (s *IssueService) createIssueGrantRequest(ctx context.Context, project *sto
 
 	issue, err := s.store.CreateIssue(ctx, issueCreateMessage)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create issue"))
 	}
 	s.stateCfg.ApprovalFinding.Store(issue.UID, issue)
 
@@ -557,7 +557,7 @@ func (s *IssueService) createIssueGrantRequest(ctx context.Context, project *sto
 
 	converted, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 
 	return connect.NewResponse(converted), nil
@@ -580,7 +580,7 @@ func (s *IssueService) createIssueDatabaseDataExport(ctx context.Context, projec
 	}
 	plan, err := s.store.GetPlan(ctx, &store.FindPlanMessage{UID: &planID, ProjectID: &project.ResourceID})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get plan, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan"))
 	}
 	if plan == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("plan %d not found in project %s", planID, project.ResourceID))
@@ -607,7 +607,7 @@ func (s *IssueService) createIssueDatabaseDataExport(ctx context.Context, projec
 
 	issue, err := s.store.CreateIssue(ctx, issueCreateMessage)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create issue"))
 	}
 	s.stateCfg.ApprovalFinding.Store(issue.UID, issue)
 
@@ -621,7 +621,7 @@ func (s *IssueService) createIssueDatabaseDataExport(ctx context.Context, projec
 
 	converted, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 
 	return connect.NewResponse(converted), nil
@@ -635,7 +635,7 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 	}
 	project, err := s.store.GetProject(ctx, &store.FindProjectMessage{ResourceID: &issue.ProjectID})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get project, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project"))
 	}
 	if project == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %s not found", issue.ProjectID))
@@ -681,7 +681,7 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 
 	approved, err := utils.CheckApprovalApproved(payload.Approval)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to check if the approval is approved, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check if the approval is approved"))
 	}
 
 	issue, err = s.store.UpdateIssue(ctx, issue.UID, &store.UpdateIssueMessage{
@@ -690,7 +690,7 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		},
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 	}
 
 	// Grant the privilege if the issue is approved.
@@ -813,7 +813,7 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 
 	issueV1, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 
 	// Auto-create rollout if this approval completes the approval flow
@@ -876,7 +876,7 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		},
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 	}
 
 	if err := func() error {
@@ -899,7 +899,7 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 
 	issueV1, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 	return connect.NewResponse(issueV1), nil
 }
@@ -912,7 +912,7 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 	}
 	project, err := s.store.GetProject(ctx, &store.FindProjectMessage{ResourceID: &issue.ProjectID})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get project, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project"))
 	}
 	if project == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %s not found", issue.ProjectID))
@@ -961,7 +961,7 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		},
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 	}
 
 	func() {
@@ -1007,7 +1007,7 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 
 	issueV1, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 	return connect.NewResponse(issueV1), nil
 }
@@ -1050,7 +1050,7 @@ func (s *IssueService) UpdateIssue(ctx context.Context, req *connect.Request[v1p
 	}
 	project, err := s.store.GetProject(ctx, &store.FindProjectMessage{ResourceID: &issue.ProjectID})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get project, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project"))
 	}
 	if project == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %s not found", issue.ProjectID))
@@ -1174,7 +1174,7 @@ func (s *IssueService) UpdateIssue(ctx context.Context, req *connect.Request[v1p
 
 	issue, err = s.store.UpdateIssue(ctx, issue.UID, patch)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 	}
 
 	if updateMasks["approval_finding_done"] {
@@ -1192,7 +1192,7 @@ func (s *IssueService) UpdateIssue(ctx context.Context, req *connect.Request[v1p
 
 	issueV1, err := s.convertToIssue(issue)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert to issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 	return connect.NewResponse(issueV1), nil
 }
@@ -1338,7 +1338,7 @@ func (s *IssueService) ListIssueComments(ctx context.Context, req *connect.Reque
 	var nextPageToken string
 	if len(issueComments) == limitPlusOne {
 		if nextPageToken, err = offset.getNextPageToken(); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get next page token, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get next page token"))
 		}
 		issueComments = issueComments[:offset.limit]
 	}
@@ -1365,7 +1365,7 @@ func (s *IssueService) CreateIssueComment(ctx context.Context, req *connect.Requ
 	}
 	project, err := s.store.GetProject(ctx, &store.FindProjectMessage{ResourceID: &issue.ProjectID})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get project, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project"))
 	}
 	if project == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %s not found", issue.ProjectID))
@@ -1464,7 +1464,7 @@ func (s *IssueService) getIssueMessage(ctx context.Context, name string) (*store
 		ProjectID: &projectID,
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get issue, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get issue"))
 	}
 	if issue == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("issue %d not found in project %s", issueUID, projectID))

--- a/backend/api/v1/revision_service.go
+++ b/backend/api/v1/revision_service.go
@@ -78,7 +78,7 @@ func (s *RevisionService) ListRevisions(
 	var nextPageToken string
 	if len(revisions) == limitPlusOne {
 		if nextPageToken, err = offset.getNextPageToken(); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get next page token, error"))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get next page token"))
 		}
 		revisions = revisions[:offset.limit]
 	}

--- a/backend/api/v1/setting_service.go
+++ b/backend/api/v1/setting_service.go
@@ -373,7 +373,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 					return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot found slack setting"))
 				}
 				if err := slack.ValidateToken(ctx, slackSetting.GetSlack().GetToken()); err != nil {
-					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("validation failed, error: %v", err))
+					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "validation failed"))
 				}
 
 			case "value.app_im.feishu":
@@ -382,7 +382,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 					return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot found feishu setting"))
 				}
 				if err := feishu.Validate(ctx, feishuSetting.GetFeishu().GetAppId(), feishuSetting.GetFeishu().GetAppSecret(), user.Email); err != nil {
-					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("validation failed, error: %v", err))
+					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "validation failed"))
 				}
 
 			case "value.app_im.wecom":
@@ -391,7 +391,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 					return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot found wecom setting"))
 				}
 				if err := wecom.Validate(ctx, wecomSetting.GetWecom().GetCorpId(), wecomSetting.GetWecom().GetAgentId(), wecomSetting.GetWecom().GetSecret()); err != nil {
-					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("validation failed, error: %v", err))
+					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "validation failed"))
 				}
 
 			case "value.app_im.lark":
@@ -400,7 +400,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 					return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot found lark setting"))
 				}
 				if err := lark.Validate(ctx, larkSetting.GetLark().GetAppId(), larkSetting.GetLark().GetAppSecret(), user.Email); err != nil {
-					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("validation failed, error: %v", err))
+					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "validation failed"))
 				}
 
 			case "value.app_im.dingtalk":
@@ -409,7 +409,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 					return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot found dingtalk setting"))
 				}
 				if err := dingtalk.Validate(ctx, dingtalkSetting.GetDingtalk().GetClientId(), dingtalkSetting.GetDingtalk().GetClientSecret(), dingtalkSetting.GetDingtalk().GetRobotCode(), user.Phone); err != nil {
-					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("validation failed, error: %v", err))
+					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "validation failed"))
 				}
 
 			case "value.app_im_setting_value.teams":
@@ -418,7 +418,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 					return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot found teams setting"))
 				}
 				if err := teams.Validate(ctx, teamsSetting.GetTeams().GetTenantId(), teamsSetting.GetTeams().GetClientId(), teamsSetting.GetTeams().GetClientSecret(), user.Email); err != nil {
-					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("validation failed, error: %v", err))
+					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "validation failed"))
 				}
 
 			default:

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -1278,7 +1278,7 @@ func (s *SQLService) SearchQueryHistories(ctx context.Context, req *connect.Requ
 	if len(historyList) == limitPlusOne {
 		historyList = historyList[:offset.limit]
 		if nextPageToken, err = offset.getNextPageToken(); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to marshal next page token, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to marshal next page token"))
 		}
 	}
 
@@ -1288,7 +1288,7 @@ func (s *SQLService) SearchQueryHistories(ctx context.Context, req *connect.Requ
 	for _, history := range historyList {
 		queryHistory, err := s.convertToV1QueryHistory(ctx, history)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to convert log entity, error: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert log entity"))
 		}
 		if queryHistory == nil {
 			continue
@@ -1426,7 +1426,7 @@ func (s *SQLService) accessCheck(
 
 	workspacePolicy, err := s.store.GetWorkspaceIamPolicy(ctx)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, errors.Errorf("failed to get workspace iam policy, error: %v", err))
+		return connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get workspace iam policy"))
 	}
 
 	projectPolicy, err := s.store.GetProjectIamPolicy(ctx, project.ResourceID)
@@ -1696,13 +1696,13 @@ func (*SQLService) DiffMetadata(_ context.Context, req *connect.Request[v1pb.Dif
 	// Get the metadata diff between source and target
 	metadataDiff, err := schema.GetDatabaseSchemaDiff(storepb.Engine(request.Engine), sourceDBSchema, targetDBSchema)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to compute diff between source and target schemas, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to compute diff between source and target schemas"))
 	}
 
 	// Generate migration SQL from the diff
 	diff, err := schema.GenerateMigration(storepb.Engine(request.Engine), metadataDiff)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to generate migration SQL, error: %v", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to generate migration SQL"))
 	}
 
 	return connect.NewResponse(&v1pb.DiffMetadataResponse{


### PR DESCRIPTION
## Summary
- Replace `errors.Errorf("message, error: %v", err)` with `errors.Wrapf(err, "message")`
- Replace `errors.Wrapf(err, "message, error")` with `errors.Wrapf(err, "message")`
- The redundant ", error" suffix is unnecessary when using `errors.Wrapf` which already wraps the error appropriately

## Files Modified
- `backend/api/v1/auth_service.go`
- `backend/api/v1/database_service.go`
- `backend/api/v1/group_service.go`
- `backend/api/v1/issue_service.go`
- `backend/api/v1/plan_service.go`
- `backend/api/v1/revision_service.go`
- `backend/api/v1/rollout_service.go`
- `backend/api/v1/setting_service.go`
- `backend/api/v1/sql_service.go`
- `backend/api/v1/user_service.go`

## Test plan
- [x] `golangci-lint run --allow-parallel-runners` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)