### PR TITLE
refactor: decouple issue status from rollout execution

### DIFF
--- a/backend/component/webhook/manager.go
+++ b/backend/component/webhook/manager.go
@@ -372,29 +372,3 @@ func getUsersFromUsers(users ...*store.UserMessage) UsersGetter {
 		return users, nil
 	}
 }
-
-// ChangeIssueStatus changes the status of an issue.
-func ChangeIssueStatus(ctx context.Context, stores *store.Store, webhookManager *Manager, issue *store.IssueMessage, newStatus storepb.Issue_Status, updater *store.UserMessage, comment string) error {
-	updateIssueMessage := &store.UpdateIssueMessage{Status: &newStatus}
-	updatedIssue, err := stores.UpdateIssue(ctx, issue.UID, updateIssueMessage)
-	if err != nil {
-		return errors.Wrapf(err, "failed to update issue %q's status", issue.Title)
-	}
-
-	project, err := stores.GetProject(ctx, &store.FindProjectMessage{ResourceID: &updatedIssue.ProjectID})
-	if err != nil {
-		return errors.Wrapf(err, "failed to get project")
-	}
-	if project == nil {
-		return errors.Errorf("project %s not found", updatedIssue.ProjectID)
-	}
-
-	webhookManager.CreateEvent(ctx, &Event{
-		Actor:   updater,
-		Type:    storepb.Activity_ISSUE_STATUS_UPDATE,
-		Comment: comment,
-		Issue:   NewIssue(updatedIssue),
-		Project: NewProject(project),
-	})
-	return nil
-}

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/state"
@@ -149,14 +148,10 @@ func (s *Scheduler) ListenTaskSkippedOrDone(ctx context.Context) {
 
 				currentEnvironment := task.Environment
 				var nextEnvironment string
-				var planDone bool
 				for i, env := range filteredEnvironmentOrder {
 					if env == currentEnvironment {
 						if i < len(filteredEnvironmentOrder)-1 {
 							nextEnvironment = filteredEnvironmentOrder[i+1]
-						}
-						if i == len(filteredEnvironmentOrder)-1 {
-							planDone = true
 						}
 						break
 					}
@@ -221,49 +216,6 @@ func (s *Scheduler) ListenTaskSkippedOrDone(ctx context.Context) {
 					slog.Error("failed to create rollout release notification activity", log.BBError(err))
 				}
 
-				// After all tasks in the pipeline are done, we will resolve the issue.
-				if issueN != nil && planDone {
-					if err := func() error {
-						// For those database data export issues, we don't resolve them automatically.
-						if issueN.Type == storepb.Issue_DATABASE_EXPORT {
-							return nil
-						}
-
-						newStatus := storepb.Issue_DONE
-						updatedIssue, err := s.store.UpdateIssue(ctx, issueN.UID, &store.UpdateIssueMessage{Status: &newStatus})
-						if err != nil {
-							return errors.Wrapf(err, "failed to update issue status")
-						}
-
-						fromStatus := storepb.Issue_Status(storepb.Issue_Status_value[issueN.Status.String()])
-						toStatus := storepb.Issue_Status(storepb.Issue_Status_value[updatedIssue.Status.String()])
-						if _, err := s.store.CreateIssueComments(ctx, common.SystemBotEmail, &store.IssueCommentMessage{
-							IssueUID: issueN.UID,
-							Payload: &storepb.IssueCommentPayload{
-								Event: &storepb.IssueCommentPayload_IssueUpdate_{
-									IssueUpdate: &storepb.IssueCommentPayload_IssueUpdate{
-										FromStatus: &fromStatus,
-										ToStatus:   &toStatus,
-									},
-								},
-							},
-						}); err != nil {
-							return errors.Wrapf(err, "failed to create issue comment after changing the issue status")
-						}
-
-						s.webhookManager.CreateEvent(ctx, &webhook.Event{
-							Actor:   store.SystemBotUser,
-							Type:    storepb.Activity_ISSUE_STATUS_UPDATE,
-							Comment: "",
-							Issue:   webhook.NewIssue(updatedIssue),
-							Project: webhook.NewProject(project),
-						})
-
-						return nil
-					}(); err != nil {
-						slog.Error("failed to update issue status", log.BBError(err))
-					}
-				}
 				return nil
 			}(); err != nil {
 				slog.Error("failed to handle task skipped or done", log.BBError(err))


### PR DESCRIPTION
## Summary

This PR decouples issue status from rollout/deployment execution. Issue status now transitions to DONE when rollout is created (HasRollout=true), not when tasks finish executing.

## Changes

### 1. Removed Auto-DONE from Task Scheduler
- **File**: `backend/runner/taskrun/scheduler.go`
- Removed automatic issue status change when all tasks complete
- Cleaned up unused imports and variables
- **Rationale**: Issue status should not depend on deployment completion

### 2. Inlined `ChangeIssueStatus` Function
- **Files**: 
  - `backend/component/webhook/manager.go` - Removed shared function
  - `backend/runner/approval/runner.go` - Inlined with issue comment
  - `backend/api/v1/issue_service.go` - Inlined with issue comment
- **Rationale**: Let callers control status update flow directly

### 3. Set Issue Status to DONE on Rollout Creation
- **File**: `backend/api/v1/rollout_service.go`
- Sets issue status to DONE when `CreateRolloutAndPendingTasks` sets `HasRollout=true`
- Creates issue comment documenting the status change
- Emits webhook event
- **Rationale**: Issue/PR phase completes when rollout starts, not when deployment finishes

### 4. Added Issue Comments for All Status Changes
- Grant request approval (both locations)
- Rollout creation
- **Rationale**: Audit trail for status changes

### 5. Code Cleanup
- Removed redundant project fetches (reuse existing variables)
- Removed unnecessary type conversions
- Inlined single-use variables

## Current Flow for Issue Status → DONE

Issues now transition to DONE through:
1. **Manual user action** - via `BatchUpdateIssuesStatus` API
2. **Grant request approval** - when approved
3. **Rollout creation** - when `HasRollout=true` is set ✨ **NEW**

## Testing
- [x] All code formatted with `gofmt`
- [x] `golangci-lint` passed with 0 issues
- [x] Backend build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)