### PR TITLE
refactor(taskrun): simplify scheduler with atomic claim

### DIFF
--- a/backend/component/state/state.go
+++ b/backend/component/state/state.go
@@ -15,8 +15,6 @@ type State struct {
 	// TaskRunConnectionID is the map from task run ID to the connection id of the connection to the database.
 	TaskRunConnectionID sync.Map // map[taskRunID]string
 
-	// RunningTaskRuns is the set of running taskruns.
-	RunningTaskRuns sync.Map // map[taskRunID]bool
 	// RunningTaskRunsCancelFunc is the cancelFunc of running taskruns.
 	RunningTaskRunsCancelFunc sync.Map // map[taskRunID]context.CancelFunc
 


### PR DESCRIPTION
## Summary
- Replace separate list + claim with atomic `ClaimAvailableTaskRuns` using `UPDATE ... RETURNING` with `FOR UPDATE SKIP LOCKED` for HA support
- Remove auto-restart of orphaned RUNNING tasks
- Remove unused `RunningTaskRuns` state field
- Simplify `executeTaskRun` to take `taskRunUID` and `taskUID` directly

## Test plan
- [ ] Verify task runs are claimed and executed correctly
- [ ] Test concurrent schedulers don't claim the same tasks (HA scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)