### PR TITLE
refactor(taskrun): optimize pending scheduler with pre-fetched context

### DIFF
--- a/backend/runner/taskrun/pending_scheduler.go
+++ b/backend/runner/taskrun/pending_scheduler.go
@@ -182,8 +182,7 @@ func (s *Scheduler) promoteTaskRun(ctx context.Context, taskRun *store.TaskRunMe
 	return nil
 }
 
-// schedulingContext holds pre-fetched data for a scheduling cycle.
-// Reduces O(N) database queries to O(1) by fetching all active task runs once.
+// schedulingContext holds pre-fetched and indexed active task run data for a scheduling cycle.
 type schedulingContext struct {
 	// Pre-indexed active task runs (AVAILABLE + RUNNING)
 	activeByDatabase  map[string]int // dbKey -> blocking taskID (first found)


### PR DESCRIPTION
## Summary
- Reduce database queries from O(N×pending) to O(1)+O(pending) per scheduling cycle
- Create `schedulingContext` struct that pre-fetches and indexes all active task runs once
- Batch fetch tasks using `ListTasks` with IDs filter instead of individual `GetTaskByID` calls
- Encapsulate promotion tracking (`promotedDBs`, `promotedCounts`) in the context
- Extract helper functions for cleaner main scheduling logic

## Test plan
- [ ] Verify pending task runs are promoted to AVAILABLE correctly
- [ ] Verify database mutual exclusion still works (one task per database at a time)
- [ ] Verify parallel task limits are respected per rollout
- [ ] Verify version ordering blocks are correctly applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)