### PR TITLE
fix(frontend): differentiate tags and actions between plan and issue …

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/rollout.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/rollout.ts
@@ -1,4 +1,5 @@
 import { t } from "@/plugins/i18n";
+import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import type { ActionDefinition } from "../types";
 
 export const ROLLOUT_CREATE: ActionDefinition = {
@@ -14,6 +15,8 @@ export const ROLLOUT_CREATE: ActionDefinition = {
     if (ctx.isIssueOnly) return false;
     if (ctx.plan.hasRollout) return false;
     if (!ctx.issue) return false;
+    // Don't show create rollout when issue is closed
+    if (ctx.issueStatus === IssueStatus.CANCELED) return false;
     if (!ctx.permissions.createRollout) return false;
 
     // Project setting validations are handled in RolloutCreatePanel

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseChangeView/SpecTabs.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseChangeView/SpecTabs.vue
@@ -71,6 +71,7 @@ import {
   useCurrentProjectV1,
   useSheetV1Store,
 } from "@/store";
+import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import { UpdatePlanRequestSchema } from "@/types/proto-es/v1/plan_service_pb";
 import { extractSheetUID } from "@/utils";
@@ -84,7 +85,7 @@ const emit = defineEmits<{ "update:selectedSpecId": [specId: string] }>();
 
 const dialog = useDialog();
 const { t } = useI18n();
-const { plan, isCreating } = usePlanContext();
+const { plan, issue, isCreating } = usePlanContext();
 const sheetStore = useSheetV1Store();
 const { project } = useCurrentProjectV1();
 
@@ -92,7 +93,10 @@ const specs = computed(() => plan.value.specs);
 const { isSpecEmpty } = useSpecsValidation(specs);
 const showAddSpecDrawer = ref(false);
 const canModifySpecs = computed(
-  () => isCreating.value || !plan.value.hasRollout
+  () =>
+    (isCreating.value || !plan.value.hasRollout) &&
+    issue.value?.status !== IssueStatus.CANCELED &&
+    issue.value?.status !== IssueStatus.DONE
 );
 
 const getDropdownOptions = (): DropdownOption[] =>


### PR DESCRIPTION
…pages

Part of BYT-8609

- Show different status tags based on page context:
  - Plan detail page: closed, draft, or none
  - Issue detail page: closed, done, or none
- Hide "Create Rollout" action when issue is closed
- Prevent spec modifications when issue is closed or done

🤖 Generated with [Claude Code](https://claude.com/claude-code)