### PR TITLE
refactor: rename state package to bus and stateCfg to bus

### DIFF
--- a/backend/api/auth/auth.go
+++ b/backend/api/auth/auth.go
@@ -19,8 +19,8 @@ import (
 	errs "github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/component/config"
-	"github.com/bytebase/bytebase/backend/component/state"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/store"
@@ -54,7 +54,7 @@ type APIAuthInterceptor struct {
 	store          *store.Store
 	secret         string
 	licenseService *enterprise.LicenseService
-	stateCfg       *state.State
+	bus            *bus.Bus
 	profile        *config.Profile
 }
 
@@ -63,14 +63,14 @@ func New(
 	store *store.Store,
 	secret string,
 	licenseService *enterprise.LicenseService,
-	stateCfg *state.State,
+	bus *bus.Bus,
 	profile *config.Profile,
 ) *APIAuthInterceptor {
 	return &APIAuthInterceptor{
 		store:          store,
 		secret:         secret,
 		licenseService: licenseService,
-		stateCfg:       stateCfg,
+		bus:            bus,
 		profile:        profile,
 	}
 }

--- a/backend/api/lsp/server.go
+++ b/backend/api/lsp/server.go
@@ -4,9 +4,9 @@ import (
 	"sync/atomic"
 
 	"github.com/bytebase/bytebase/backend/api/auth"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/iam"
-	"github.com/bytebase/bytebase/backend/component/state"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -18,7 +18,7 @@ type Server struct {
 	store           *store.Store
 	profile         *config.Profile
 	secret          string
-	stateCfg        *state.State
+	bus             *bus.Bus
 	iamManager      *iam.Manager
 	licenseService  *enterprise.LicenseService
 	authInterceptor *auth.APIAuthInterceptor
@@ -29,7 +29,7 @@ func NewServer(
 	store *store.Store,
 	profile *config.Profile,
 	secret string,
-	stateCfg *state.State,
+	bus *bus.Bus,
 	iamManager *iam.Manager,
 	licenseService *enterprise.LicenseService,
 ) *Server {
@@ -37,9 +37,9 @@ func NewServer(
 		store:           store,
 		profile:         profile,
 		secret:          secret,
-		stateCfg:        stateCfg,
+		bus:             bus,
 		iamManager:      iamManager,
 		licenseService:  licenseService,
-		authInterceptor: auth.New(store, secret, licenseService, stateCfg, profile),
+		authInterceptor: auth.New(store, secret, licenseService, bus, profile),
 	}
 }

--- a/backend/component/bus/bus.go
+++ b/backend/component/bus/bus.go
@@ -1,12 +1,12 @@
-// Package state contains the synchronization state shared within the server.
-package state
+// Package bus contains the message bus for synchronization within the server.
+package bus
 
 import (
 	"sync"
 )
 
-// State is the state for all in-memory states within the server.
-type State struct {
+// Bus is the message bus for all in-memory communication within the server.
+type Bus struct {
 	// ApprovalCheckChan signals when an issue needs approval template finding.
 	// Triggered by plan check completion, issue creation (if checks already done).
 	ApprovalCheckChan chan int64 // issue UID
@@ -33,8 +33,8 @@ type State struct {
 	PlanCompletionCheckChan chan int64
 }
 
-func New() (*State, error) {
-	return &State{
+func New() (*Bus, error) {
+	return &Bus{
 		ApprovalCheckChan:       make(chan int64, 1000),
 		PlanCheckTickleChan:     make(chan int, 1000),
 		TaskRunTickleChan:       make(chan int, 1000),

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -16,7 +16,7 @@ import (
 	apiv1 "github.com/bytebase/bytebase/backend/api/v1"
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
-	"github.com/bytebase/bytebase/backend/component/state"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/component/webhook"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -28,16 +28,16 @@ import (
 // Runner is the runner for finding approval templates for issues.
 type Runner struct {
 	store          *store.Store
-	stateCfg       *state.State
+	bus            *bus.Bus
 	webhookManager *webhook.Manager
 	licenseService *enterprise.LicenseService
 }
 
 // NewRunner creates a new runner.
-func NewRunner(store *store.Store, stateCfg *state.State, webhookManager *webhook.Manager, licenseService *enterprise.LicenseService) *Runner {
+func NewRunner(store *store.Store, bus *bus.Bus, webhookManager *webhook.Manager, licenseService *enterprise.LicenseService) *Runner {
 	return &Runner{
 		store:          store,
-		stateCfg:       stateCfg,
+		bus:            bus,
 		webhookManager: webhookManager,
 		licenseService: licenseService,
 	}
@@ -50,7 +50,7 @@ func (r *Runner) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 	for {
 		select {
-		case issueUID := <-r.stateCfg.ApprovalCheckChan:
+		case issueUID := <-r.bus.ApprovalCheckChan:
 			r.processIssue(ctx, issueUID)
 		case <-ctx.Done():
 			return

--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	"github.com/bytebase/bytebase/backend/component/ghost"
-	"github.com/bytebase/bytebase/backend/component/state"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/db/oracle"
@@ -31,11 +31,11 @@ import (
 )
 
 // NewDatabaseMigrateExecutor creates a database migration task executor.
-func NewDatabaseMigrateExecutor(store *store.Store, dbFactory *dbfactory.DBFactory, stateCfg *state.State, schemaSyncer *schemasync.Syncer, profile *config.Profile) Executor {
+func NewDatabaseMigrateExecutor(store *store.Store, dbFactory *dbfactory.DBFactory, bus *bus.Bus, schemaSyncer *schemasync.Syncer, profile *config.Profile) Executor {
 	return &DatabaseMigrateExecutor{
 		store:        store,
 		dbFactory:    dbFactory,
-		stateCfg:     stateCfg,
+		bus:          bus,
 		schemaSyncer: schemaSyncer,
 		profile:      profile,
 	}
@@ -45,7 +45,7 @@ func NewDatabaseMigrateExecutor(store *store.Store, dbFactory *dbfactory.DBFacto
 type DatabaseMigrateExecutor struct {
 	store        *store.Store
 	dbFactory    *dbfactory.DBFactory
-	stateCfg     *state.State
+	bus          *bus.Bus
 	schemaSyncer *schemasync.Syncer
 	profile      *config.Profile
 }

--- a/backend/runner/taskrun/rollout_creator.go
+++ b/backend/runner/taskrun/rollout_creator.go
@@ -7,7 +7,7 @@ import (
 
 	apiv1 "github.com/bytebase/bytebase/backend/api/v1"
 	"github.com/bytebase/bytebase/backend/common/log"
-	"github.com/bytebase/bytebase/backend/component/state"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/component/webhook"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/store"
@@ -18,15 +18,15 @@ import (
 // nolint:revive
 type RolloutCreator struct {
 	store          *store.Store
-	stateCfg       *state.State
+	bus            *bus.Bus
 	webhookManager *webhook.Manager
 }
 
 // NewRolloutCreator creates a new rollout creator.
-func NewRolloutCreator(store *store.Store, stateCfg *state.State, webhookManager *webhook.Manager) *RolloutCreator {
+func NewRolloutCreator(store *store.Store, bus *bus.Bus, webhookManager *webhook.Manager) *RolloutCreator {
 	return &RolloutCreator{
 		store:          store,
-		stateCfg:       stateCfg,
+		bus:            bus,
 		webhookManager: webhookManager,
 	}
 }
@@ -149,7 +149,7 @@ func (rc *RolloutCreator) tryCreateRollout(ctx context.Context, planID int64) {
 	}
 
 	// Tickle task run scheduler
-	rc.stateCfg.TaskRunTickleChan <- 0
+	rc.bus.TaskRunTickleChan <- 0
 
 	slog.Info("successfully auto-created rollout", slog.Int("plan_id", int(planID)))
 }

--- a/backend/runner/taskrun/schema_update_sdl_executor.go
+++ b/backend/runner/taskrun/schema_update_sdl_executor.go
@@ -6,9 +6,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
-	"github.com/bytebase/bytebase/backend/component/state"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
@@ -18,11 +18,11 @@ import (
 )
 
 // NewSchemaDeclareExecutor creates a schema declare (SDL) task executor.
-func NewSchemaDeclareExecutor(store *store.Store, dbFactory *dbfactory.DBFactory, stateCfg *state.State, schemaSyncer *schemasync.Syncer, profile *config.Profile) Executor {
+func NewSchemaDeclareExecutor(store *store.Store, dbFactory *dbfactory.DBFactory, bus *bus.Bus, schemaSyncer *schemasync.Syncer, profile *config.Profile) Executor {
 	return &SchemaDeclareExecutor{
 		store:        store,
 		dbFactory:    dbFactory,
-		stateCfg:     stateCfg,
+		bus:          bus,
 		schemaSyncer: schemaSyncer,
 		profile:      profile,
 	}
@@ -32,7 +32,7 @@ func NewSchemaDeclareExecutor(store *store.Store, dbFactory *dbfactory.DBFactory
 type SchemaDeclareExecutor struct {
 	store        *store.Store
 	dbFactory    *dbfactory.DBFactory
-	stateCfg     *state.State
+	bus          *bus.Bus
 	schemaSyncer *schemasync.Syncer
 	profile      *config.Profile
 }


### PR DESCRIPTION
## Summary

Renamed the `state` package to `bus` to better reflect its purpose as a message bus for inter-component communication. Also renamed all `stateCfg` variables to `bus` for consistency with the new package and type names.

## Changes

### Package and Type Renaming
- Renamed `backend/component/state/state.go` → `backend/component/bus/bus.go`
- Renamed `State` struct to `Bus`
- Updated package from `state` to `bus`
- Updated all imports from `component/state` to `component/bus`

### Variable Renaming
Renamed `stateCfg` variable to `bus` in **17 files** across the codebase:

**Server Layer:**
- backend/server/server.go
- backend/server/grpc_routes.go

**API Layer:**
- backend/api/v1/rollout_service.go
- backend/api/v1/rollout_service_converter.go
- backend/api/v1/plan_service.go
- backend/api/v1/issue_service.go
- backend/api/auth/auth.go
- backend/api/lsp/server.go

**Runner Layer:**
- backend/runner/plancheck/scheduler.go
- backend/runner/taskrun/scheduler.go
- backend/runner/taskrun/rollout_creator.go
- backend/runner/taskrun/running_scheduler.go
- backend/runner/taskrun/pending_scheduler.go
- backend/runner/approval/runner.go
- backend/runner/taskrun/schema_update_sdl_executor.go
- backend/runner/taskrun/database_migrate_executor.go

### Documentation Updates
- Updated comments to use "message bus" terminology instead of "state"
- Clarified that the bus is for inter-component communication

## Rationale

The previous naming (`state` package with `State` type and `stateCfg` variable) was misleading because:
1. It's not actually managing application state - it's a message bus with channels and sync maps
2. The name "state" suggests persistent data, but it only contains communication primitives
3. The name `stateCfg` (state config) was confusing given it wasn't configuration

The new naming (`bus` package with `Bus` type and `bus` variable) is more accurate because:
1. It clearly conveys this is a message bus for inter-component signaling
2. The channels (ApprovalCheckChan, TaskRunTickleChan, etc.) and sync maps are bus communication primitives
3. Simpler variable name `bus` is more concise than `stateCfg`

## Test Plan

- ✅ All files formatted with `gofmt`
- ✅ `golangci-lint run --allow-parallel-runners` passes with 0 issues
- ✅ Project builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)