### PR TITLE
fix: re-run approval finding for DATABASE_EXPORT issues on plan update

### DIFF
--- a/backend/server/grpc_routes.go
+++ b/backend/server/grpc_routes.go
@@ -100,7 +100,7 @@ func configureGrpcRouters(
 	instanceService := apiv1.NewInstanceService(stores, profile, licenseService, dbFactory, schemaSyncer, sampleInstanceManager)
 	issueService := apiv1.NewIssueService(stores, webhookManager, bus, licenseService, iamManager)
 	orgPolicyService := apiv1.NewOrgPolicyService(stores, licenseService)
-	planService := apiv1.NewPlanService(stores, bus, iamManager)
+	planService := apiv1.NewPlanService(stores, bus, iamManager, webhookManager, licenseService)
 	projectService := apiv1.NewProjectService(stores, profile, iamManager)
 	releaseService := apiv1.NewReleaseService(stores, sheetManager, dbFactory)
 	reviewConfigService := apiv1.NewReviewConfigService(stores)


### PR DESCRIPTION
## Summary

Fixes approval flow for DATABASE_EXPORT issues when plan specs are updated. Previously, updating the plan would reset approval status but never re-trigger approval finding, leaving the issue in a broken state.

## Root Cause

When `UpdatePlan()` updates specs for a DATABASE_EXPORT issue:
1. It resets `ApprovalFindingDone` to `false` 
2. Comment assumed plan checks would trigger approval re-evaluation
3. **But DATABASE_EXPORT issues don't have plan checks** (line 703-704 in plan_service.go)
4. Approval finding was never re-triggered

This is because `ExportDataConfig` specs don't require plan checks (no SQL validation needed for data export).

## Solution

After resetting approval status in `UpdatePlan()`:
- Check if issue type is `DATABASE_EXPORT`
- Call `approval.FindAndApplyApprovalTemplate()` synchronously
- Matches the pattern used in `CreateIssue()` (from #18712)

DATABASE_CHANGE issues continue using async approval (triggered when plan checks complete).

## Changes

- **backend/api/v1/plan_service.go**
  - Add `webhookManager` and `licenseService` to PlanService struct
  - Add approval finding logic for DATABASE_EXPORT issues in UpdatePlan()
  
- **backend/server/grpc_routes.go**
  - Update NewPlanService constructor call with new parameters

## Testing

- [x] Code formatted with gofmt
- [x] golangci-lint passed with 0 issues

## Related

- Aligns with #18712 optimization where DATABASE_EXPORT/GRANT_REQUEST issues can determine approval immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)