### PR TITLE
feat: add CREATE_DATABASE plan immutability and optional title for export issues

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -445,16 +445,17 @@ func (s *IssueService) CreateIssue(ctx context.Context, req *connect.Request[v1p
 }
 
 func (s *IssueService) buildIssueMessage(ctx context.Context, project *store.ProjectMessage, userEmail string, request *v1pb.CreateIssueRequest) (*store.IssueMessage, error) {
-	if request.Issue.Title == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("issue title is required"))
-	}
-
 	var planUID *int64
 	var grantRequest *storepb.GrantRequest
 
 	// Type-specific validation and preparation
 	switch request.Issue.Type {
 	case v1pb.Issue_GRANT_REQUEST:
+		// Title is required for grant requests
+		if request.Issue.Title == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("issue title is required"))
+		}
+
 		// Check if grant request feature is enabled
 		if err := s.licenseService.IsFeatureEnabled(v1pb.PlanFeature_FEATURE_REQUEST_ROLE_WORKFLOW); err != nil {
 			return nil, connect.NewError(connect.CodePermissionDenied,


### PR DESCRIPTION
## Summary
- Prevent updating plan specs for CREATE_DATABASE plans to maintain data integrity
- Make issue title optional for DATABASE_EXPORT issues (only required for GRANT_REQUEST)
- Add `storePlanConfigHasCreateDatabase` helper function for plan type detection

## Test Plan
- [x] Verified backend API tests pass
- [ ] Test CREATE_DATABASE plan spec update returns error
- [ ] Test DATABASE_EXPORT issue creation without title succeeds
- [ ] Test GRANT_REQUEST issue creation without title fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)