### PR TITLE
refactor: copy plan title/description to issues instead of using COALESCE

### DIFF
--- a/backend/migrator/migration/3.14/0017##backfill_issue_titles.sql
+++ b/backend/migrator/migration/3.14/0017##backfill_issue_titles.sql
@@ -1,0 +1,10 @@
+-- Backfill issue titles and descriptions from their associated plans.
+-- Issues created from plans previously had empty titles/descriptions and relied on COALESCE.
+-- This migration makes the relationship explicit by copying plan data into issue records.
+UPDATE issue
+SET
+    name = plan.name,
+    description = plan.description
+FROM plan
+WHERE issue.plan_id = plan.id
+  AND issue.name = '';

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,8 +12,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.14.16"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.14/0016##plan_webhook_delivery.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.14.17"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.14/0017##backfill_issue_titles.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
## Summary

- Issues created from plans now explicitly store their own title and description instead of relying on `COALESCE` magic at query time
- Backend copies plan values to issue fields at creation time (respects frontend-provided values if present)
- Removed `COALESCE(plan.name, issue.name)` and `COALESCE(plan.description, issue.description)` from queries
- Removed `LEFT JOIN plan` from `ListIssues` query for better performance
- Added migration `0017##backfill_issue_titles.sql` to backfill existing issues with empty titles

## Benefits

- **No more "magic"**: Issue titles are explicit in the database, not computed at query time
- **Better performance**: One less table join in `ListIssues`
- **Simpler queries**: No COALESCE logic
- **Clearer data model**: Follows the GitHub PR/branch analogy where issue and plan are independent
- **Future-proof**: Allows users to customize titles at creation if needed

## Changes

### Backend
- `backend/api/v1/issue_service.go`: Copy plan title/description to issue at creation
- `backend/store/issue.go`: Remove COALESCE and plan JOIN from queries
- `backend/migrator/migration/3.14/0017##backfill_issue_titles.sql`: Backfill migration
- `backend/migrator/migrator_test.go`: Update test to expect version 3.14.17

## Test Plan

- [ ] Existing issues with plans should continue to display correctly after migration
- [ ] New issues created from plans should have explicit titles
- [ ] Search functionality should work correctly without plan JOIN
- [ ] All existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)