### PR TITLE
refactor: simplify refresh token design with frontend coordination

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -55,8 +55,6 @@ const (
 	errMsgInvalidRecoveryCode = "invalid recovery code"
 	errMsgTooManyPassword     = "too many failed login attempts, please try again later" // Will be used for password rate limiting
 	errMsgTooManyMFA          = "too many failed MFA attempts, please try again later"
-
-	refreshTokenGracePeriod = 30 * time.Second
 )
 
 var (
@@ -186,9 +184,9 @@ func (s *AuthService) Refresh(ctx context.Context, req *connect.Request[v1pb.Ref
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("refresh token not found"))
 	}
 
-	// 2. Look up in database
+	// 2. Look up and delete atomically
 	tokenHash := auth.HashToken(refreshToken)
-	stored, err := s.store.GetWebRefreshToken(ctx, tokenHash)
+	stored, err := s.store.GetAndDeleteWebRefreshToken(ctx, tokenHash)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get refresh token"))
 	}
@@ -198,25 +196,10 @@ func (s *AuthService) Refresh(ctx context.Context, req *connect.Request[v1pb.Ref
 
 	// 3. Check expiration
 	if time.Now().After(stored.ExpiresAt) {
-		if err := s.store.DeleteWebRefreshToken(ctx, tokenHash); err != nil {
-			slog.Error("failed to delete expired refresh token", log.BBError(err))
-		}
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("refresh token expired"))
 	}
 
-	// 4. Check if already rotated (grace period)
-	if stored.RotatedAt != nil {
-		if time.Since(*stored.RotatedAt) > refreshTokenGracePeriod {
-			if err := s.store.DeleteWebRefreshToken(ctx, tokenHash); err != nil {
-				slog.Error("failed to delete rotated refresh token", log.BBError(err))
-			}
-			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("refresh token already used"))
-		}
-		// Within grace period - return success but don't issue new tokens
-		return connect.NewResponse(&v1pb.RefreshResponse{}), nil
-	}
-
-	// 5. Get user
+	// 4. Get user
 	user, err := s.store.GetUserByEmail(ctx, stored.UserEmail)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get user"))
@@ -225,19 +208,7 @@ func (s *AuthService) Refresh(ctx context.Context, req *connect.Request[v1pb.Ref
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not found"))
 	}
 
-	// 6. Atomically mark old token as rotated (grace period starts)
-	// If another request already rotated it, we're in a race - return success without new tokens
-	rotated, err := s.store.MarkWebRefreshTokenRotated(ctx, tokenHash)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to rotate refresh token"))
-	}
-	if !rotated {
-		// Another request already rotated this token - we're within grace period
-		// Return success but don't issue new tokens (the other request already did)
-		return connect.NewResponse(&v1pb.RefreshResponse{}), nil
-	}
-
-	// 7. Issue new tokens
+	// 5. Issue new tokens
 	accessTokenDuration := auth.GetAccessTokenDuration(ctx, s.store, s.licenseService)
 	accessToken, err := auth.GenerateAccessToken(user.Email, s.secret, accessTokenDuration)
 	if err != nil {
@@ -258,7 +229,7 @@ func (s *AuthService) Refresh(ctx context.Context, req *connect.Request[v1pb.Ref
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to create refresh token"))
 	}
 
-	// 8. Set cookies and return
+	// 6. Set cookies and return
 	resp := connect.NewResponse(&v1pb.RefreshResponse{})
 	origin := req.Header().Get("Origin")
 	resp.Header().Add("Set-Cookie", auth.GetTokenCookie(ctx, s.store, s.licenseService, origin, accessToken).String())

--- a/backend/migrator/migration/3.14/0011##web_refresh_token.sql
+++ b/backend/migrator/migration/3.14/0011##web_refresh_token.sql
@@ -1,10 +1,8 @@
 CREATE TABLE web_refresh_token (
     token_hash  TEXT PRIMARY KEY,
     user_email  TEXT NOT NULL REFERENCES principal(email) ON UPDATE CASCADE,
-    expires_at  TIMESTAMPTZ NOT NULL,
-    rotated_at  TIMESTAMPTZ
+    expires_at  TIMESTAMPTZ NOT NULL
 );
 
 CREATE INDEX idx_web_refresh_token_user_email ON web_refresh_token(user_email);
 CREATE INDEX idx_web_refresh_token_expires_at ON web_refresh_token(expires_at);
-CREATE INDEX idx_web_refresh_token_rotated_at ON web_refresh_token(rotated_at) WHERE rotated_at IS NOT NULL;

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -565,13 +565,11 @@ CREATE INDEX idx_oauth2_client_last_active_at ON oauth2_client(last_active_at);
 CREATE TABLE web_refresh_token (
     token_hash  TEXT PRIMARY KEY,
     user_email  TEXT NOT NULL REFERENCES principal(email) ON UPDATE CASCADE,
-    expires_at  TIMESTAMPTZ NOT NULL,
-    rotated_at  TIMESTAMPTZ
+    expires_at  TIMESTAMPTZ NOT NULL
 );
 
 CREATE INDEX idx_web_refresh_token_user_email ON web_refresh_token(user_email);
 CREATE INDEX idx_web_refresh_token_expires_at ON web_refresh_token(expires_at);
-CREATE INDEX idx_web_refresh_token_rotated_at ON web_refresh_token(rotated_at) WHERE rotated_at IS NOT NULL;
 
 -- Default bytebase system account id is 1.
 INSERT INTO principal (id, type, name, email, password_hash) VALUES (1, 'SYSTEM_BOT', 'Bytebase', 'support@bytebase.com', '');

--- a/backend/runner/cleaner/data_cleaner.go
+++ b/backend/runner/cleaner/data_cleaner.go
@@ -15,7 +15,6 @@ const (
 	cleanupInterval              = 1 * time.Hour
 	exportArchiveRetentionPeriod = 24 * time.Hour
 	oauth2ClientRetentionPeriod  = 30 * 24 * time.Hour // 30 days of inactivity
-	refreshTokenGracePeriod      = 30 * time.Second    // Grace period for rotated refresh tokens
 )
 
 // DataCleaner periodically cleans up expired data from the database.
@@ -92,17 +91,9 @@ func (c *DataCleaner) cleanupOAuth2Data(ctx context.Context) {
 }
 
 func (c *DataCleaner) cleanupWebRefreshTokens(ctx context.Context) {
-	// Clean up expired web refresh tokens
 	if rowsAffected, err := c.store.DeleteExpiredWebRefreshTokens(ctx); err != nil {
 		slog.Error("Failed to clean up expired web refresh tokens", log.BBError(err))
 	} else if rowsAffected > 0 {
 		slog.Info("Cleaned up expired web refresh tokens", slog.Int64("count", rowsAffected))
-	}
-
-	// Clean up rotated tokens past grace period
-	if rowsAffected, err := c.store.DeleteRotatedWebRefreshTokens(ctx, refreshTokenGracePeriod); err != nil {
-		slog.Error("Failed to clean up rotated web refresh tokens", log.BBError(err))
-	} else if rowsAffected > 0 {
-		slog.Info("Cleaned up rotated web refresh tokens", slog.Int64("count", rowsAffected))
 	}
 }


### PR DESCRIPTION
## Summary
- Remove server-side grace period for refresh token rotation
- Add localStorage-based cross-tab coordination in frontend
- Simplify backend to atomically get-and-delete tokens on refresh
- Remove `rotated_at` column from `web_refresh_token` table

## Changes
| File | Change |
|------|--------|
| `frontend/src/grpcweb/refreshToken.ts` | Added localStorage lock for cross-tab coordination |
| `backend/api/v1/auth_service.go` | Simplified `Refresh()` - removed grace period logic |
| `backend/store/web_refresh_token.go` | Removed `RotatedAt`, added `GetAndDeleteWebRefreshToken()` |
| `backend/runner/cleaner/data_cleaner.go` | Removed rotated token cleanup |
| `backend/migrator/...` | Removed `rotated_at` column and index |

## Test plan
- [ ] Login on web, verify access token cookie is set
- [ ] Wait for token expiry, verify refresh works
- [ ] Open multiple tabs, trigger refresh, verify only one tab refreshes
- [ ] Verify logout clears tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)