### PR TITLE
fix(migrator): add explicit type casts in migration 3.13.21 VALUES clause

### DIFF
--- a/backend/migrator/migrator.go
+++ b/backend/migrator/migrator.go
@@ -309,7 +309,7 @@ func migrateAuditLogBatch(ctx context.Context, conn *sql.Conn, userMap map[int]s
 		}
 
 		newUserRef := convertUserIDToEmail(userRef, userMap)
-		valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d)", argPos, argPos+1))
+		valueStrings = append(valueStrings, fmt.Sprintf("($%d::bigint, $%d::text)", argPos, argPos+1))
 		valueArgs = append(valueArgs, id, newUserRef)
 		argPos += 2
 		maxID = id


### PR DESCRIPTION
## Summary

- Fixed PostgreSQL type inference issue in migration 3.13.21
- Added explicit `::bigint` and `::text` type casts in VALUES clause to prevent encoding errors

## Context

Users were encountering migration failures with errors:
- `ERROR: operator does not exist: bigint = text (SQLSTATE 42883)`
- `unable to encode into text format for text (OID 25): cannot find encode plan`

Root cause: PostgreSQL was inferring all columns in the parameterized VALUES clause as TEXT type, causing the Go database driver to fail when binding int64 values.

## Changes

Modified `migrateAuditLogBatch` to generate VALUES clause with explicit type casts:
```go
// Before
valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d)", argPos, argPos+1))

// After  
valueStrings = append(valueStrings, fmt.Sprintf("($%d::bigint, $%d::text)", argPos, argPos+1))
```

This ensures PostgreSQL correctly binds:
- `int64` audit log IDs to `bigint` parameters
- `string` user references to `text` parameters

## Test Plan

- [x] Verified existing migrator tests pass
- [x] Verified golangci-lint passes with 0 issues
- [ ] Manual verification: Run migration on database with audit_log records

🤖 Generated with [Claude Code](https://claude.com/claude-code)