### PR TITLE
feat: show release info in rollout UI for release-based tasks

### DIFF
--- a/frontend/src/components/RolloutV1/components/TaskItem.vue
+++ b/frontend/src/components/RolloutV1/components/TaskItem.vue
@@ -148,7 +148,7 @@
         </div>
 
         <!-- SQL Statement section -->
-        <div>
+        <div v-if="!isReleaseTask">
           <div class="flex items-center justify-between mb-1">
             <span class="text-sm font-medium text-gray-700">{{ t("common.statement") }}</span>
             <RouterLink
@@ -240,6 +240,7 @@ import {
   extractStageNameFromTaskName,
   extractStageUID,
   extractTaskUID,
+  isReleaseBasedTask,
   sheetNameOfTaskV1,
 } from "@/utils";
 import { useTaskActions } from "./composables/useTaskActions";
@@ -314,6 +315,8 @@ const taskDetailRoute = computed(() => {
     },
   };
 });
+
+const isReleaseTask = computed(() => isReleaseBasedTask(props.task));
 
 const { loading, displayedStatement, isStatementTruncated } = useTaskStatement(
   () => props.task,

--- a/frontend/src/components/RolloutV1/components/TaskView.vue
+++ b/frontend/src/components/RolloutV1/components/TaskView.vue
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Sheet Statement -->
-    <div class="w-full flex-1 min-h-0">
+    <div v-if="!isReleaseTask" class="w-full flex-1 min-h-0">
       <div class="flex items-center justify-between mb-2">
         <span class="text-base font-medium">{{ $t("common.statement") }}</span>
         <div>
@@ -161,6 +161,7 @@ import {
   extractProjectResourceName,
   extractSchemaVersionFromTask,
   getSheetStatement,
+  isReleaseBasedTask,
   sheetNameOfTaskV1,
 } from "@/utils";
 import TaskRollbackButton from "./TaskRollbackButton.vue";
@@ -211,6 +212,8 @@ const task = computed(() => {
     ) || unknownTask()
   );
 });
+
+const isReleaseTask = computed(() => isReleaseBasedTask(task.value));
 
 const taskRuns = computed(() => {
   return allTaskRuns.value.filter((run) =>

--- a/frontend/src/utils/v1/index.ts
+++ b/frontend/src/utils/v1/index.ts
@@ -16,3 +16,4 @@ export * from "./cel";
 export * from "./advanced-search";
 export * from "./iam";
 export * from "./dbSchema";
+export * from "./release";

--- a/frontend/src/utils/v1/issue/rollout.ts
+++ b/frontend/src/utils/v1/issue/rollout.ts
@@ -15,6 +15,7 @@ import {
   unknownStage,
   unknownTask,
 } from "@/types";
+import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
   type Rollout,
@@ -305,4 +306,24 @@ export const databaseForTask = (project: Project, task: Task) => {
     default:
       return unknownDatabase();
   }
+};
+
+export const isReleaseBasedTask = (task: Task): boolean => {
+  if (task.payload?.case === "databaseUpdate") {
+    return task.payload.value.source?.case === "release";
+  }
+
+  return false;
+};
+
+export const releaseNameOfPlan = (plan: Plan): string | undefined => {
+  for (const spec of plan.specs) {
+    if (spec.config.case === "changeDatabaseConfig") {
+      const release = spec.config.value.release;
+      if (release) {
+        return release;
+      }
+    }
+  }
+  return undefined;
 };

--- a/frontend/src/utils/v1/release.ts
+++ b/frontend/src/utils/v1/release.ts
@@ -1,0 +1,5 @@
+export const extractReleaseUID = (name: string) => {
+  const pattern = /(?:^|\/)releases\/([^/]+)(?:$|\/)/;
+  const matches = name.match(pattern);
+  return matches?.[1] ?? "";
+};

--- a/frontend/src/views/project/RolloutLayout.vue
+++ b/frontend/src/views/project/RolloutLayout.vue
@@ -12,6 +12,16 @@
             {{ title }}
           </h1>
 
+          <div v-if="releaseRoute" class="px-3 sm:px-4 pb-2">
+            <router-link
+              :to="releaseRoute"
+              class="inline-flex items-center gap-x-2 text-sm text-accent hover:underline"
+            >
+              <span>{{ $t("release.title") }}: {{ release.title }}</span>
+              <ExternalLinkIcon class="w-4 h-4" />
+            </router-link>
+          </div>
+
           <router-view v-slot="{ Component }">
             <keep-alive :max="3">
               <component :is="Component" />
@@ -28,6 +38,7 @@
 
 <script lang="ts" setup>
 import { useTitle } from "@vueuse/core";
+import { ExternalLinkIcon } from "lucide-vue-next";
 import { NSpin } from "naive-ui";
 import { computed, ref, toRef, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
@@ -41,8 +52,10 @@ import { provideSidebarContext } from "@/components/Plan/logic/sidebar";
 import PollerProvider from "@/components/Plan/PollerProvider.vue";
 import RolloutBreadcrumb from "@/components/RolloutV1/components/RolloutBreadcrumb.vue";
 import { useBodyLayoutContext } from "@/layouts/common";
-import { usePolicyV1Store } from "@/store";
+import { PROJECT_V1_ROUTE_RELEASE_DETAIL } from "@/router/dashboard/projectV1";
+import { usePolicyV1Store, useReleaseByName } from "@/store";
 import { PolicyType } from "@/types/proto-es/v1/org_policy_service_pb";
+import { extractReleaseUID, releaseNameOfPlan } from "@/utils";
 
 const props = defineProps<{
   projectId: string;
@@ -84,6 +97,25 @@ watchEffect(() => {
   }
 });
 const title = computed(() => issue.value?.title || plan.value?.title || "");
+
+const releaseName = computed(() => {
+  if (!plan.value) return undefined;
+  return releaseNameOfPlan(plan.value);
+});
+
+const { release } = useReleaseByName(computed(() => releaseName.value || ""));
+
+const releaseRoute = computed(() => {
+  if (!releaseName.value) return undefined;
+
+  return {
+    name: PROJECT_V1_ROUTE_RELEASE_DETAIL,
+    params: {
+      projectId: props.projectId,
+      releaseId: extractReleaseUID(releaseName.value),
+    },
+  };
+});
 
 providePlanContext({
   isCreating,


### PR DESCRIPTION
## Summary
- Hide "No SQL statement" section for release-based tasks in rollout UI
- Display release title with clickable link in rollout header
- Add utilities to detect release-based tasks and extract release information from plans

## Changes
- **Utilities**: Add `isReleaseBasedTask()`, `releaseNameOfPlan()`, and `extractReleaseUID()` helper functions
- **TaskItem.vue & TaskView.vue**: Conditionally hide Statement section when task is release-based
- **RolloutLayout.vue**: Fetch and display release title with navigation link to release detail page

## Screenshots
Before: Tasks showed "No SQL statement" for release-based rollouts
After: Release title displayed prominently at rollout level, no redundant "No SQL statement" messages

## Test plan
- [x] Frontend linting passed (ESLint, Biome)
- [x] TypeScript type checking passed
- [ ] Tested with release-based rollout
- [ ] Tested with sheet-based rollout (should show Statement as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)