### PR TITLE
feat(frontend): make plan title/description readonly for rollout-only plans

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/DescriptionSection.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/DescriptionSection.vue
@@ -86,7 +86,7 @@ import { usePlanContext } from "../../logic";
 
 const currentUser = useCurrentUserV1();
 const { project } = useCurrentProjectV1();
-const { isCreating, plan, readonly } = usePlanContext();
+const { isCreating, plan, readonly, issue } = usePlanContext();
 const { refreshResources } = useResourcePoller();
 
 const state = reactive({
@@ -103,6 +103,10 @@ const allowEdit = computed(() => {
   }
   if (isCreating.value) {
     return true;
+  }
+  // Plans with rollout should have readonly description
+  if (!issue.value && plan.value.hasRollout) {
+    return false;
   }
   if (extractUserId(plan.value.creator) === currentUser.value.email) {
     return true;

--- a/frontend/src/components/Plan/components/HeaderSection/TitleInput.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/TitleInput.vue
@@ -99,6 +99,10 @@ const allowEdit = computed(() => {
   if (isCreating.value) {
     return true;
   }
+  // Plans with rollout should have readonly title
+  if (!issue.value && plan.value.hasRollout) {
+    return false;
+  }
 
   // For grant requests, check issue permissions
   if (isGrantRequest.value && issue.value) {

--- a/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
@@ -89,11 +89,6 @@ const shouldShowSidebar = computed(() => {
 });
 
 const shouldShowSpecList = computed(() => {
-  return (
-    (isCreating.value ||
-      plan.value.specs.length > 1 ||
-      !plan.value.hasRollout) &&
-    !isDataExportPlan.value
-  );
+  return !isDataExportPlan.value;
 });
 </script>

--- a/frontend/src/components/Plan/components/SpecDetailView/SpecListSection.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/SpecListSection.vue
@@ -9,8 +9,7 @@
       @update:value="handleTabChange"
     >
       <template #prefix>
-        <div class=""></div>
-        <div v-if="!plan.issue && !plan.hasRollout" class="pl-4 text-base font-medium">
+        <div class="pl-4 text-base font-medium">
           {{ $t("plan.navigator.changes") }}
         </div>
       </template>

--- a/frontend/src/components/Plan/components/common/validateSpec.ts
+++ b/frontend/src/components/Plan/components/common/validateSpec.ts
@@ -18,6 +18,14 @@ export const useSpecsValidation = (specs: Plan_Spec[] | Ref<Plan_Spec[]>) => {
       return false;
     }
 
+    // Released specs are not editable
+    if (
+      spec.config?.case === "changeDatabaseConfig" &&
+      spec.config.value.release
+    ) {
+      return false;
+    }
+
     const sheetName = sheetNameOfSpec(spec);
     // If there's no sheet reference, it's definitely empty
     if (!sheetName) {

--- a/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
+++ b/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
@@ -30,29 +30,21 @@ const ACTIONABLE_TASK_STATUSES = new Set([
 /**
  * Composable that determines whether the "Ready for Rollout" link should be shown.
  * This link appears when:
- * - Issue is a database change (not export/create)
  * - User is not already on the rollout tab
  * - Rollout exists
- * - Issue is DONE, OR issue is OPEN and approved with actionable tasks
+ * - For plans without issue: always show when rollout exists
+ * - For plans with issue: issue is a database change AND
+ *   (issue is DONE, OR issue is OPEN and approved with actionable tasks)
  */
 export const useRolloutReadyLink = () => {
   const route = useRoute();
-  const { issue, rollout } = usePlanContext();
+  const { plan, issue, rollout } = usePlanContext();
 
   const isOnRolloutTab = computed(() => {
     return ROLLOUT_ROUTES.has(route.name as string);
   });
 
   const shouldShow = computed(() => {
-    if (!issue.value) {
-      return false;
-    }
-
-    // Only show for database change issues
-    if (issue.value.type !== Issue_Type.DATABASE_CHANGE) {
-      return false;
-    }
-
     // Hide if on rollout tab
     if (isOnRolloutTab.value) {
       return false;
@@ -71,6 +63,20 @@ export const useRolloutReadyLink = () => {
       )
     );
     if (hasDatabaseCreateOrExportTasks) {
+      return false;
+    }
+
+    // For plans without issue but with rollout, show the link
+    if (!issue.value && plan.value.hasRollout) {
+      return true;
+    }
+
+    if (!issue.value) {
+      return false;
+    }
+
+    // Only show for database change issues
+    if (issue.value.type !== Issue_Type.DATABASE_CHANGE) {
       return false;
     }
 


### PR DESCRIPTION

- Make title and description readonly when plan has rollout but no issue
- Show rollout ready link for plans without issue but with rollout
- Simplify spec list display logic
- Skip validation for release-based specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)