### PR TITLE
refactor: remove redundant position fields from TaskRunResult

### DIFF
--- a/backend/generated-go/store/task_run.pb.go
+++ b/backend/generated-go/store/task_run.pb.go
@@ -140,10 +140,6 @@ type TaskRunResult struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Detailed execution information or error message.
 	Detail string `protobuf:"bytes,1,opt,name=detail,proto3" json:"detail,omitempty"`
-	// Starting position in the SQL statement where an error occurred.
-	StartPosition *Position `protobuf:"bytes,3,opt,name=start_position,json=startPosition,proto3" json:"start_position,omitempty"`
-	// Ending position in the SQL statement where an error occurred.
-	EndPosition *Position `protobuf:"bytes,4,opt,name=end_position,json=endPosition,proto3" json:"end_position,omitempty"`
 	// UID of the export archive generated for export tasks.
 	ExportArchiveUid int32 `protobuf:"varint,5,opt,name=export_archive_uid,json=exportArchiveUid,proto3" json:"export_archive_uid,omitempty"`
 	// Backup details that can be used to rollback changes.
@@ -190,20 +186,6 @@ func (x *TaskRunResult) GetDetail() string {
 		return x.Detail
 	}
 	return ""
-}
-
-func (x *TaskRunResult) GetStartPosition() *Position {
-	if x != nil {
-		return x.StartPosition
-	}
-	return nil
-}
-
-func (x *TaskRunResult) GetEndPosition() *Position {
-	if x != nil {
-		return x.EndPosition
-	}
-	return nil
 }
 
 func (x *TaskRunResult) GetExportArchiveUid() int32 {
@@ -584,11 +566,9 @@ const file_store_task_run_proto_rawDesc = "" +
 	"\bCANCELED\x10\x05\x12\x0f\n" +
 	"\vNOT_STARTED\x10\x06\x12\v\n" +
 	"\aSKIPPED\x10\a\x12\r\n" +
-	"\tAVAILABLE\x10\b\"\xc4\x02\n" +
+	"\tAVAILABLE\x10\b\"\xc6\x01\n" +
 	"\rTaskRunResult\x12\x16\n" +
-	"\x06detail\x18\x01 \x01(\tR\x06detail\x12?\n" +
-	"\x0estart_position\x18\x03 \x01(\v2\x18.bytebase.store.PositionR\rstartPosition\x12;\n" +
-	"\fend_position\x18\x04 \x01(\v2\x18.bytebase.store.PositionR\vendPosition\x12,\n" +
+	"\x06detail\x18\x01 \x01(\tR\x06detail\x12,\n" +
 	"\x12export_archive_uid\x18\x05 \x01(\x05R\x10exportArchiveUid\x12Q\n" +
 	"\x13prior_backup_detail\x18\x06 \x01(\v2!.bytebase.store.PriorBackupDetailR\x11priorBackupDetail\x12\x1c\n" +
 	"\tchangelog\x18\a \x01(\tR\tchangelog\"\xcd\x03\n" +
@@ -637,25 +617,23 @@ var file_store_task_run_proto_goTypes = []any{
 	(*PriorBackupDetail_Item)(nil),       // 5: bytebase.store.PriorBackupDetail.Item
 	(*PriorBackupDetail_Item_Table)(nil), // 6: bytebase.store.PriorBackupDetail.Item.Table
 	(*SchedulerInfo_WaitingCause)(nil),   // 7: bytebase.store.SchedulerInfo.WaitingCause
-	(*Position)(nil),                     // 8: bytebase.store.Position
-	(*timestamppb.Timestamp)(nil),        // 9: google.protobuf.Timestamp
+	(*timestamppb.Timestamp)(nil),        // 8: google.protobuf.Timestamp
+	(*Position)(nil),                     // 9: bytebase.store.Position
 }
 var file_store_task_run_proto_depIdxs = []int32{
-	8,  // 0: bytebase.store.TaskRunResult.start_position:type_name -> bytebase.store.Position
-	8,  // 1: bytebase.store.TaskRunResult.end_position:type_name -> bytebase.store.Position
-	3,  // 2: bytebase.store.TaskRunResult.prior_backup_detail:type_name -> bytebase.store.PriorBackupDetail
-	5,  // 3: bytebase.store.PriorBackupDetail.items:type_name -> bytebase.store.PriorBackupDetail.Item
-	9,  // 4: bytebase.store.SchedulerInfo.report_time:type_name -> google.protobuf.Timestamp
-	7,  // 5: bytebase.store.SchedulerInfo.waiting_cause:type_name -> bytebase.store.SchedulerInfo.WaitingCause
-	6,  // 6: bytebase.store.PriorBackupDetail.Item.source_table:type_name -> bytebase.store.PriorBackupDetail.Item.Table
-	6,  // 7: bytebase.store.PriorBackupDetail.Item.target_table:type_name -> bytebase.store.PriorBackupDetail.Item.Table
-	8,  // 8: bytebase.store.PriorBackupDetail.Item.start_position:type_name -> bytebase.store.Position
-	8,  // 9: bytebase.store.PriorBackupDetail.Item.end_position:type_name -> bytebase.store.Position
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	3, // 0: bytebase.store.TaskRunResult.prior_backup_detail:type_name -> bytebase.store.PriorBackupDetail
+	5, // 1: bytebase.store.PriorBackupDetail.items:type_name -> bytebase.store.PriorBackupDetail.Item
+	8, // 2: bytebase.store.SchedulerInfo.report_time:type_name -> google.protobuf.Timestamp
+	7, // 3: bytebase.store.SchedulerInfo.waiting_cause:type_name -> bytebase.store.SchedulerInfo.WaitingCause
+	6, // 4: bytebase.store.PriorBackupDetail.Item.source_table:type_name -> bytebase.store.PriorBackupDetail.Item.Table
+	6, // 5: bytebase.store.PriorBackupDetail.Item.target_table:type_name -> bytebase.store.PriorBackupDetail.Item.Table
+	9, // 6: bytebase.store.PriorBackupDetail.Item.start_position:type_name -> bytebase.store.Position
+	9, // 7: bytebase.store.PriorBackupDetail.Item.end_position:type_name -> bytebase.store.Position
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_store_task_run_proto_init() }

--- a/backend/generated-go/store/task_run_equal.pb.go
+++ b/backend/generated-go/store/task_run_equal.pb.go
@@ -23,12 +23,6 @@ func (x *TaskRunResult) Equal(y *TaskRunResult) bool {
 	if x.Detail != y.Detail {
 		return false
 	}
-	if !x.StartPosition.Equal(y.StartPosition) {
-		return false
-	}
-	if !x.EndPosition.Equal(y.EndPosition) {
-		return false
-	}
 	if x.ExportArchiveUid != y.ExportArchiveUid {
 		return false
 	}

--- a/backend/plugin/db/clickhouse/clickhouse.go
+++ b/backend/plugin/db/clickhouse/clickhouse.go
@@ -177,11 +177,7 @@ func (d *Driver) executeInTransactionMode(ctx context.Context, singleSQLs []base
 		sqlResult, err := tx.ExecContext(ctx, singleSQL.Text)
 		if err != nil {
 			opts.LogCommandResponse(0, nil, err.Error())
-			return 0, &db.ErrorWithPosition{
-				Err:   errors.Wrapf(err, "failed to execute context in a transaction"),
-				Start: singleSQL.Start,
-				End:   singleSQL.End,
-			}
+			return 0, err
 		}
 		rowsAffected, err := sqlResult.RowsAffected()
 		if err != nil {

--- a/backend/plugin/db/cockroachdb/cockroachdb.go
+++ b/backend/plugin/db/cockroachdb/cockroachdb.go
@@ -382,11 +382,7 @@ func (d *Driver) executeInTransactionMode(
 				if err != nil {
 					opts.LogCommandResponse(0, nil, err.Error())
 
-					return &db.ErrorWithPosition{
-						Err:   errors.Wrapf(err, "failed to execute context in a transaction"),
-						Start: command.Start,
-						End:   command.End,
-					}
+					return err
 				}
 
 				var rowsAffected int64

--- a/backend/plugin/db/driver.go
+++ b/backend/plugin/db/driver.go
@@ -352,18 +352,3 @@ func (o *ExecuteOptions) LogTransactionControl(t storepb.TaskRunLog_TransactionC
 		slog.Warn("failed to log command transaction control", log.BBError(err))
 	}
 }
-
-// ErrorWithPosition is the error with the position information.
-type ErrorWithPosition struct {
-	Err   error
-	Start *storepb.Position
-	End   *storepb.Position
-}
-
-func (e *ErrorWithPosition) Error() string {
-	return e.Err.Error()
-}
-
-func (e *ErrorWithPosition) Unwrap() error {
-	return e.Err
-}

--- a/backend/plugin/db/dynamodb/dynamodb.go
+++ b/backend/plugin/db/dynamodb/dynamodb.go
@@ -114,11 +114,7 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		})
 		if err != nil {
 			opts.LogCommandResponse(0, []int64{0}, err.Error())
-			return 0, &db.ErrorWithPosition{
-				Err:   errors.Wrap(err, "failed to execute statement"),
-				Start: statement.Start,
-				End:   statement.End,
-			}
+			return 0, err
 		}
 		opts.LogCommandResponse(0, []int64{0}, "")
 	}

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -433,11 +433,7 @@ func (d *Driver) executeInTransactionMode(ctx context.Context, conn *sql.Conn, c
 
 				opts.LogCommandResponse(0, nil, err.Error())
 
-				return &db.ErrorWithPosition{
-					Err:   errors.Wrapf(err, "failed to execute context in a transaction"),
-					Start: command.Start,
-					End:   command.End,
-				}
+				return err
 			}
 
 			allRowsAffected := sqlResult.(mysql.Result).AllRowsAffected()
@@ -475,7 +471,7 @@ func (d *Driver) executeInAutoCommitMode(ctx context.Context, conn *sql.Conn, co
 		//nolint
 		exer := driverConn.(driver.ExecerContext)
 
-		for i, command := range commands {
+		for _, command := range commands {
 			opts.LogCommandExecute(command.Range, command.Text)
 
 			sqlWithBytebaseAppComment := util.MySQLPrependBytebaseAppComment(command.Text)
@@ -491,11 +487,7 @@ func (d *Driver) executeInAutoCommitMode(ctx context.Context, conn *sql.Conn, co
 				opts.LogCommandResponse(0, nil, err.Error())
 				// In auto-commit mode, we stop at the first error
 				// The database is left in a partially migrated state
-				return &db.ErrorWithPosition{
-					Err:   errors.Wrapf(err, "failed to execute statement %d in auto-commit mode", i+1),
-					Start: command.Start,
-					End:   command.End,
-				}
+				return err
 			}
 
 			allRowsAffected := sqlResult.(mysql.Result).AllRowsAffected()

--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -179,11 +179,7 @@ func (*Driver) executeInTransactionMode(ctx context.Context, conn *sql.Conn, com
 		sqlResult, err := tx.ExecContext(ctx, command.Text)
 		if err != nil {
 			opts.LogCommandResponse(0, nil, err.Error())
-			return 0, &db.ErrorWithPosition{
-				Err:   errors.Wrapf(err, "failed to execute context in a transaction"),
-				Start: command.Start,
-				End:   command.End,
-			}
+			return 0, err
 		}
 		rowsAffected, err := sqlResult.RowsAffected()
 		if err != nil {
@@ -207,7 +203,7 @@ func (*Driver) executeInTransactionMode(ctx context.Context, conn *sql.Conn, com
 // executeInAutoCommitMode executes statements sequentially in auto-commit mode
 func (*Driver) executeInAutoCommitMode(ctx context.Context, conn *sql.Conn, commands []base.Statement, opts db.ExecuteOptions) (int64, error) {
 	totalRowsAffected := int64(0)
-	for i, command := range commands {
+	for _, command := range commands {
 		opts.LogCommandExecute(command.Range, command.Text)
 
 		sqlResult, err := conn.ExecContext(ctx, command.Text)
@@ -215,11 +211,7 @@ func (*Driver) executeInAutoCommitMode(ctx context.Context, conn *sql.Conn, comm
 			opts.LogCommandResponse(0, nil, err.Error())
 			// In auto-commit mode, we stop at the first error
 			// The database is left in a partially migrated state
-			return totalRowsAffected, &db.ErrorWithPosition{
-				Err:   errors.Wrapf(err, "failed to execute statement %d in auto-commit mode", i+1),
-				Start: command.Start,
-				End:   command.End,
-			}
+			return totalRowsAffected, err
 		}
 		rowsAffected, err := sqlResult.RowsAffected()
 		if err != nil {

--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -552,11 +552,7 @@ func (d *Driver) executeInTransactionMode(
 				if err != nil {
 					opts.LogCommandResponse(0, nil, err.Error())
 
-					return &db.ErrorWithPosition{
-						Err:   errors.Wrapf(err, "failed to execute context in a transaction"),
-						Start: command.Start,
-						End:   command.End,
-					}
+					return err
 				}
 
 				var rowsAffected int64

--- a/backend/plugin/db/redshift/redshift.go
+++ b/backend/plugin/db/redshift/redshift.go
@@ -266,11 +266,7 @@ func (d *Driver) executeInTransactionMode(ctx context.Context, commands []base.S
 		sqlResult, err := tx.ExecContext(ctx, command.Text)
 		if err != nil {
 			opts.LogCommandResponse(0, nil, err.Error())
-			return 0, &db.ErrorWithPosition{
-				Err:   errors.Wrapf(err, "failed to execute context in a transaction"),
-				Start: command.Start,
-				End:   command.End,
-			}
+			return 0, err
 		}
 		rowsAffected, err := sqlResult.RowsAffected()
 		if err != nil {
@@ -308,11 +304,7 @@ func (d *Driver) executeInAutoCommitMode(ctx context.Context, commands []base.St
 			opts.LogCommandResponse(0, nil, err.Error())
 			// In auto-commit mode, we stop at the first error
 			// The database is left in a partially migrated state
-			return totalRowsAffected, &db.ErrorWithPosition{
-				Err:   errors.Wrapf(err, "failed to execute statement %d in auto-commit mode", i+1),
-				Start: command.Start,
-				End:   command.End,
-			}
+			return totalRowsAffected, err
 		}
 		rowsAffected, err := sqlResult.RowsAffected()
 		if err != nil {

--- a/backend/plugin/db/tidb/tidb.go
+++ b/backend/plugin/db/tidb/tidb.go
@@ -272,11 +272,7 @@ func (d *Driver) executeInTransactionMode(ctx context.Context, conn *sql.Conn, c
 
 				opts.LogCommandResponse(0, nil, err.Error())
 
-				return &db.ErrorWithPosition{
-					Err:   errors.Wrapf(err, "failed to execute context in a transaction"),
-					Start: command.Start,
-					End:   command.End,
-				}
+				return err
 			}
 
 			allRowsAffected := sqlResult.(mysql.Result).AllRowsAffected()
@@ -329,7 +325,7 @@ func (d *Driver) executeInAutoCommitMode(ctx context.Context, conn *sql.Conn, co
 		//nolint
 		exer := driverConn.(driver.ExecerContext)
 
-		for i, command := range allCommands {
+		for _, command := range allCommands {
 			opts.LogCommandExecute(command.Range, command.Text)
 
 			sqlWithBytebaseAppComment := util.MySQLPrependBytebaseAppComment(command.Text)
@@ -345,11 +341,7 @@ func (d *Driver) executeInAutoCommitMode(ctx context.Context, conn *sql.Conn, co
 				opts.LogCommandResponse(0, nil, err.Error())
 				// In auto-commit mode, we stop at the first error
 				// The database is left in a partially migrated state
-				return &db.ErrorWithPosition{
-					Err:   errors.Wrapf(err, "failed to execute statement %d in auto-commit mode", i+1),
-					Start: command.Start,
-					End:   command.End,
-				}
+				return err
 			}
 
 			allRowsAffected := sqlResult.(mysql.Result).AllRowsAffected()

--- a/backend/runner/taskrun/running_scheduler.go
+++ b/backend/runner/taskrun/running_scheduler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/component/webhook"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -165,11 +164,6 @@ func (s *Scheduler) runTaskRunOnce(ctx context.Context, taskRunUID int, task *st
 		taskRunResult := &storepb.TaskRunResult{
 			Detail:    err.Error(),
 			Changelog: "",
-		}
-		var errWithPosition *db.ErrorWithPosition
-		if errors.As(err, &errWithPosition) {
-			taskRunResult.StartPosition = errWithPosition.Start
-			taskRunResult.EndPosition = errWithPosition.End
 		}
 		resultBytes, marshalErr := protojson.Marshal(taskRunResult)
 		if marshalErr != nil {

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -4834,8 +4834,6 @@ TaskRunResult contains the outcome and metadata from a task run execution.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | detail | [string](#string) |  | Detailed execution information or error message. |
-| start_position | [Position](#bytebase-store-Position) |  | Starting position in the SQL statement where an error occurred. |
-| end_position | [Position](#bytebase-store-Position) |  | Ending position in the SQL statement where an error occurred. |
 | export_archive_uid | [int32](#int32) |  | UID of the export archive generated for export tasks. |
 | prior_backup_detail | [PriorBackupDetail](#bytebase-store-PriorBackupDetail) |  | Backup details that can be used to rollback changes. |
 | changelog | [string](#string) |  | Resource name of the changelog entry created by this run. Format: instances/{instance}/databases/{database}/changelogs/{changelog} |

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -13078,20 +13078,6 @@ Format: instances/{instance}/databases/{database} </p></td>
                 </tr>
               
                 <tr>
-                  <td>start_position</td>
-                  <td><a href="#bytebase.store.Position">Position</a></td>
-                  <td></td>
-                  <td><p>Starting position in the SQL statement where an error occurred. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>end_position</td>
-                  <td><a href="#bytebase.store.Position">Position</a></td>
-                  <td></td>
-                  <td><p>Ending position in the SQL statement where an error occurred. </p></td>
-                </tr>
-              
-                <tr>
                   <td>export_archive_uid</td>
                   <td><a href="#int32">int32</a></td>
                   <td></td>

--- a/proto/store/store/task_run.proto
+++ b/proto/store/store/task_run.proto
@@ -36,11 +36,6 @@ message TaskRunResult {
   // Detailed execution information or error message.
   string detail = 1;
 
-  // Starting position in the SQL statement where an error occurred.
-  Position start_position = 3;
-  // Ending position in the SQL statement where an error occurred.
-  Position end_position = 4;
-
   // UID of the export archive generated for export tasks.
   int32 export_archive_uid = 5;
 


### PR DESCRIPTION
## Summary
Remove redundant `start_position` and `end_position` fields from `TaskRunResult` proto message and the associated `ErrorWithPosition` type.

## Context
The `TaskRunResult.start_position/end_position` fields stored line/column positions of failed SQL commands. However, this information is redundant with `CommandExecute.range` (byte offsets) already available in `TaskRunLog`.

Analysis showed:
- Position fields were only set in one place (`running_scheduler.go`) when tasks failed
- They were never exposed in the v1 API
- Frontend can determine failed command positions using `CommandResponse.error` + `CommandExecute.range` from task run logs
- `ErrorWithPosition` was created by 12 database drivers but never consumed by any code

## Changes
- Remove `start_position` and `end_position` from `TaskRunResult` proto
- Remove `ErrorWithPosition` type from `backend/plugin/db/driver.go`
- Update all database drivers to return plain errors instead of wrapped `ErrorWithPosition`
  - MySQL, PostgreSQL, TiDB, Oracle, Redshift, ClickHouse, CockroachDB, DynamoDB
- Remove code in `running_scheduler.go` that populated these fields
- Regenerate proto files

## Impact
- Simplifies error handling in database drivers
- Reduces code complexity (118 lines removed)
- Error position information remains fully available via `TaskRunLog.CommandExecute.range`

## Test plan
- [x] Backend builds successfully
- [x] golangci-lint passes with 0 issues
- [ ] Verify task run logs still show command positions correctly in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)