### PR TITLE
refactor: make TaskRunResult.detail error-only

### DIFF
--- a/backend/generated-go/store/task_run.pb.go
+++ b/backend/generated-go/store/task_run.pb.go
@@ -138,7 +138,7 @@ func (*TaskRun) Descriptor() ([]byte, []int) {
 // TaskRunResult contains the outcome and metadata from a task run execution.
 type TaskRunResult struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Detailed execution information or error message.
+	// Error message for failed task runs. Empty for successful or canceled runs.
 	Detail string `protobuf:"bytes,1,opt,name=detail,proto3" json:"detail,omitempty"`
 	// UID of the export archive generated for export tasks.
 	ExportArchiveUid int32 `protobuf:"varint,5,opt,name=export_archive_uid,json=exportArchiveUid,proto3" json:"export_archive_uid,omitempty"`

--- a/backend/runner/taskrun/data_export_executor.go
+++ b/backend/runner/taskrun/data_export_executor.go
@@ -101,7 +101,6 @@ func (exec *DataExportExecutor) RunOnce(ctx context.Context, _ context.Context, 
 	}
 
 	return &storepb.TaskRunResult{
-		Detail:           "Data export succeeded",
 		ExportArchiveUid: int32(exportArchive.UID),
 	}, nil
 }

--- a/backend/runner/taskrun/database_create_executor.go
+++ b/backend/runner/taskrun/database_create_executor.go
@@ -2,7 +2,6 @@ package taskrun
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 
@@ -118,7 +117,5 @@ func (exec *DatabaseCreateExecutor) RunOnce(ctx context.Context, driverCtx conte
 		)
 	}
 
-	return &storepb.TaskRunResult{
-		Detail: fmt.Sprintf("Created database %q", task.Payload.GetDatabaseName()),
-	}, nil
+	return &storepb.TaskRunResult{}, nil
 }

--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -320,9 +320,7 @@ func (exec *DatabaseMigrateExecutor) runVersionedRelease(ctx context.Context, dr
 		}
 	}
 
-	return &storepb.TaskRunResult{
-		Detail: "Versioned release executed successfully",
-	}, nil
+	return &storepb.TaskRunResult{}, nil
 }
 
 func (exec *DatabaseMigrateExecutor) runDeclarativeRelease(ctx context.Context, driverCtx context.Context, task *store.TaskMessage, taskRunUID int, release *store.ReleaseMessage) (*storepb.TaskRunResult, error) {
@@ -395,9 +393,7 @@ func (exec *DatabaseMigrateExecutor) runDeclarativeRelease(ctx context.Context, 
 		return nil, errors.Wrapf(err, "failed to execute declarative release (version %s)", file.Version)
 	}
 
-	return &storepb.TaskRunResult{
-		Detail: "Declarative release executed successfully",
-	}, nil
+	return &storepb.TaskRunResult{}, nil
 }
 
 func (exec *DatabaseMigrateExecutor) shouldSkipBackupError(ctx context.Context, task *store.TaskMessage) (bool, error) {

--- a/backend/runner/taskrun/executor.go
+++ b/backend/runner/taskrun/executor.go
@@ -259,16 +259,7 @@ func postMigration(ctx context.Context, stores *store.Store, mc *migrateContext,
 		return nil, errors.Wrapf(err, "failed to update database %q for instance %q", database.DatabaseName, database.InstanceID)
 	}
 
-	var detail string
-	if mc.version == "" {
-		detail = fmt.Sprintf("Applied migration to database %q.", database.DatabaseName)
-	} else {
-		detail = fmt.Sprintf("Applied migration version %s to database %q.", mc.version, database.DatabaseName)
-	}
-
-	return &storepb.TaskRunResult{
-		Detail: detail,
-	}, nil
+	return &storepb.TaskRunResult{}, nil
 }
 
 // executeMigrationWithFunc executes the migration with custom migration function.

--- a/backend/runner/taskrun/running_scheduler.go
+++ b/backend/runner/taskrun/running_scheduler.go
@@ -116,12 +116,10 @@ func (s *Scheduler) runTaskRunOnce(ctx context.Context, taskRunUID int, task *st
 			log.BBError(err),
 		)
 		taskRunStatusPatch := &store.TaskRunStatusPatch{
-			ID:      taskRunUID,
-			Updater: common.SystemBotEmail,
-			Status:  storepb.TaskRun_CANCELED,
-			ResultProto: &storepb.TaskRunResult{
-				Detail: "The task run is canceled",
-			},
+			ID:          taskRunUID,
+			Updater:     common.SystemBotEmail,
+			Status:      storepb.TaskRun_CANCELED,
+			ResultProto: &storepb.TaskRunResult{},
 		}
 		if _, err := s.store.UpdateTaskRunStatus(ctx, taskRunStatusPatch); err != nil {
 			slog.Error("Failed to mark task as CANCELED",

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -4816,7 +4816,7 @@ TaskRunResult contains the outcome and metadata from a task run execution.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| detail | [string](#string) |  | Detailed execution information or error message. |
+| detail | [string](#string) |  | Error message for failed task runs. Empty for successful or canceled runs. |
 | export_archive_uid | [int32](#int32) |  | UID of the export archive generated for export tasks. |
 | prior_backup_detail | [PriorBackupDetail](#bytebase-store-PriorBackupDetail) |  | Backup details that can be used to rollback changes. |
 

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -13027,7 +13027,7 @@ Format: instances/{instance}/databases/{database} </p></td>
                   <td>detail</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Detailed execution information or error message. </p></td>
+                  <td><p>Error message for failed task runs. Empty for successful or canceled runs. </p></td>
                 </tr>
               
                 <tr>

--- a/proto/store/store/task_run.proto
+++ b/proto/store/store/task_run.proto
@@ -33,7 +33,7 @@ message TaskRun {
 
 // TaskRunResult contains the outcome and metadata from a task run execution.
 message TaskRunResult {
-  // Detailed execution information or error message.
+  // Error message for failed task runs. Empty for successful or canceled runs.
   string detail = 1;
 
   // UID of the export archive generated for export tasks.


### PR DESCRIPTION
## Summary

Refactors `TaskRunResult.detail` field to be error-only, removing success and canceled messages to reduce UI noise and make errors more prominent.

### Changes

- Updated proto comment to specify "Error message for failed task runs. Empty for successful or canceled runs"
- Removed success detail messages from all executors:
  - `executor.go`: Removed "Applied migration version X to database Y"
  - `database_migrate_executor.go`: Removed "Versioned/Declarative release executed successfully"
  - `database_create_executor.go`: Removed "Created database X"
  - `data_export_executor.go`: Removed "Data export succeeded"
- Removed canceled message "The task run is canceled" from `running_scheduler.go`
- Kept "Task skipped because version X has been applied" message (users need to know why)
- Removed unused `fmt` import from `database_create_executor.go`

### Frontend Impact

Frontend already handles empty detail correctly:
- Collapsed task view only shows detail when present (errors)
- Status badges and icons convey success/canceled state
- Detail field only displayed for failed tasks with red styling

### UI Before/After

**Before:**
- Successful: Shows "Applied migration version 1.0.0 to database mydb" in gray
- Failed: Shows error message in red
- Canceled: Shows "The task run is canceled" in gray

**After:**
- Successful: No detail shown (status badge indicates success)
- Failed: Shows error message in red (unchanged)
- Canceled: No detail shown (user knows why they canceled)

### Performance Benefit

Keeps detail field for performance reasons:
- Task run logs are only fetched when task is expanded (expensive)
- Detail provides immediate error visibility in collapsed task list
- Avoids N+1 query problem for large rollouts

## Test Plan

- [x] Verified proto changes generate correctly
- [x] Verified all backend tests pass (taskrun package)
- [x] Verified golangci-lint passes
- [x] Verified frontend components handle empty detail correctly
- [ ] Manual testing: Create successful task run, verify no detail shown
- [ ] Manual testing: Create failed task run, verify error shown in collapsed view
- [ ] Manual testing: Cancel task run, verify no detail shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)