### PR TITLE
refactor(parser): eliminate BaseLine field from Statement struct

### DIFF
--- a/backend/plugin/advisor/mssql/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/mssql/rule_builtin_prior_backup_check.go
@@ -78,7 +78,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/mssql/rule_column_maximum_varchar_length.go
@@ -63,7 +63,7 @@ func (*ColumnMaximumVarcharLengthAdvisor) Check(_ context.Context, checkCtx advi
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_column_no_null.go
+++ b/backend/plugin/advisor/mssql/rule_column_no_null.go
@@ -48,7 +48,7 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_column_require.go
+++ b/backend/plugin/advisor/mssql/rule_column_require.go
@@ -57,7 +57,7 @@ func (*ColumnRequireAdvisor) Check(_ context.Context, checkCtx advisor.Context) 
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_column_type_disallow_list.go
+++ b/backend/plugin/advisor/mssql/rule_column_type_disallow_list.go
@@ -59,7 +59,7 @@ func (*ColumnTypeDisallowListAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_function_disallow_create_or_alter.go
+++ b/backend/plugin/advisor/mssql/rule_function_disallow_create_or_alter.go
@@ -40,7 +40,7 @@ func (*FunctionDisallowCreateOrAlterAdvisor) Check(_ context.Context, checkCtx a
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_index_not_redundant.go
+++ b/backend/plugin/advisor/mssql/rule_index_not_redundant.go
@@ -50,7 +50,7 @@ func (IndexNotRedundantAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_migration_compatibility.go
+++ b/backend/plugin/advisor/mssql/rule_migration_compatibility.go
@@ -49,7 +49,7 @@ func (*MigrationCompatibilityAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/mssql/rule_naming_identifier_no_keyword.go
@@ -49,7 +49,7 @@ func (*NamingIdentifierNoKeywordAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_naming_table.go
+++ b/backend/plugin/advisor/mssql/rule_naming_table.go
@@ -65,7 +65,7 @@ func (*NamingTableAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_naming_table_no_keyword.go
+++ b/backend/plugin/advisor/mssql/rule_naming_table_no_keyword.go
@@ -49,7 +49,7 @@ func (*NamingTableNoKeywordAdvisor) Check(_ context.Context, checkCtx advisor.Co
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_procedure_disallow_create_or_alter.go
+++ b/backend/plugin/advisor/mssql/rule_procedure_disallow_create_or_alter.go
@@ -39,7 +39,7 @@ func (*ProcedureDisallowCreateOrAlterAdvisor) Check(_ context.Context, checkCtx 
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_select_no_select_all.go
+++ b/backend/plugin/advisor/mssql/rule_select_no_select_all.go
@@ -46,7 +46,7 @@ func (*SelectNoSelectAllAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_statement_disallow_cross_db_queries.go
+++ b/backend/plugin/advisor/mssql/rule_statement_disallow_cross_db_queries.go
@@ -42,7 +42,7 @@ func (*DisallowCrossDBQueriesAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_statement_where_disallow_functions_and_calculations.go
+++ b/backend/plugin/advisor/mssql/rule_statement_where_disallow_functions_and_calculations.go
@@ -42,7 +42,7 @@ func (*DisallowFuncAndCalculationsAdvisor) Check(_ context.Context, checkCtx adv
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_select.go
+++ b/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_select.go
@@ -46,7 +46,7 @@ func (*WhereRequirementForSelectAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_update_delete.go
+++ b/backend/plugin/advisor/mssql/rule_statement_where_requirement_for_update_delete.go
@@ -46,7 +46,7 @@ func (*WhereRequirementForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_table_disallow_ddl.go
+++ b/backend/plugin/advisor/mssql/rule_table_disallow_ddl.go
@@ -54,7 +54,7 @@ func (*TableDisallowDDLAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_table_disallow_dml.go
+++ b/backend/plugin/advisor/mssql/rule_table_disallow_dml.go
@@ -54,7 +54,7 @@ func (*TableDisallowDMLAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/mssql/rule_table_drop_naming_convention.go
@@ -60,7 +60,7 @@ func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_table_no_foreign_key.go
+++ b/backend/plugin/advisor/mssql/rule_table_no_foreign_key.go
@@ -49,7 +49,7 @@ func (*TableNoForeignKeyAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mssql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mssql/rule_table_require_pk.go
@@ -48,7 +48,7 @@ func (*TableRequirePkAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/mysql/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/mysql/rule_builtin_prior_backup_check.go
@@ -65,7 +65,7 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 				Title:         title,
 				Content:       "Prior backup cannot deal with mixed DDL and DML statements",
 				Code:          code.BuiltinPriorBackupCheck.Int32(),
-				StartPosition: common.ConvertANTLRLineToPosition(stmt.BaseLine),
+				StartPosition: common.ConvertANTLRLineToPosition(stmt.BaseLine()),
 			})
 		}
 	}

--- a/backend/plugin/advisor/mysql/rule_charset_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_charset_allowlist.go
@@ -50,8 +50,8 @@ func (*CharsetAllowlistAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_collation_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_collation_allowlist.go
@@ -45,8 +45,8 @@ func (*CollationAllowlistAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		// Set text will be handled in the Query node
 		if stmt.AST == nil {
 			continue

--- a/backend/plugin/advisor/mysql/rule_column_auto_increment_initial_value.go
+++ b/backend/plugin/advisor/mysql/rule_column_auto_increment_initial_value.go
@@ -52,8 +52,8 @@ func (*ColumnAutoIncrementInitialValueAdvisor) Check(_ context.Context, checkCtx
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_auto_increment_must_integer.go
+++ b/backend/plugin/advisor/mysql/rule_column_auto_increment_must_integer.go
@@ -46,8 +46,8 @@ func (*ColumnAutoIncrementMustIntegerAdvisor) Check(_ context.Context, checkCtx 
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_auto_increment_must_unsigned.go
+++ b/backend/plugin/advisor/mysql/rule_column_auto_increment_must_unsigned.go
@@ -46,8 +46,8 @@ func (*ColumnAutoIncrementMustUnsignedAdvisor) Check(_ context.Context, checkCtx
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_comment_convention.go
+++ b/backend/plugin/advisor/mysql/rule_column_comment_convention.go
@@ -44,8 +44,8 @@ func (*ColumnCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_current_time_count_limit.go
+++ b/backend/plugin/advisor/mysql/rule_column_current_time_count_limit.go
@@ -51,8 +51,8 @@ func (*ColumnCurrentTimeCountLimitAdvisor) Check(_ context.Context, checkCtx adv
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing.go
@@ -45,8 +45,8 @@ func (*ColumnDisallowChangingAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing_order.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing_order.go
@@ -45,8 +45,8 @@ func (*ColumnDisallowChangingOrderAdvisor) Check(_ context.Context, checkCtx adv
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_changing_type.go
@@ -47,8 +47,8 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_disallow_drop.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_drop.go
@@ -43,8 +43,8 @@ func (*ColumnDisallowDropAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_drop_in_index.go
@@ -45,8 +45,8 @@ func (*ColumnDisallowDropInIndexAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_disallow_set_charset.go
+++ b/backend/plugin/advisor/mysql/rule_column_disallow_set_charset.go
@@ -44,8 +44,8 @@ func (*ColumnDisallowSetCharsetAdvisor) Check(_ context.Context, checkCtx adviso
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_maximum_character_length.go
+++ b/backend/plugin/advisor/mysql/rule_column_maximum_character_length.go
@@ -51,8 +51,8 @@ func (*ColumnMaximumCharacterLengthAdvisor) Check(_ context.Context, checkCtx ad
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/mysql/rule_column_maximum_varchar_length.go
@@ -50,8 +50,8 @@ func (*ColumnMaximumVarcharLengthAdvisor) Check(_ context.Context, checkCtx advi
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_no_null.go
+++ b/backend/plugin/advisor/mysql/rule_column_no_null.go
@@ -45,8 +45,8 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_require_charset.go
+++ b/backend/plugin/advisor/mysql/rule_column_require_charset.go
@@ -42,8 +42,8 @@ func (*ColumnRequireCharsetAdvisor) Check(_ context.Context, checkCtx advisor.Co
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_require_collation.go
+++ b/backend/plugin/advisor/mysql/rule_column_require_collation.go
@@ -41,8 +41,8 @@ func (*ColumnRequireCollationAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_require_default.go
+++ b/backend/plugin/advisor/mysql/rule_column_require_default.go
@@ -44,8 +44,8 @@ func (*ColumnRequireDefaultAdvisor) Check(_ context.Context, checkCtx advisor.Co
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_required.go
+++ b/backend/plugin/advisor/mysql/rule_column_required.go
@@ -56,8 +56,8 @@ func (*ColumnRequirementAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_set_default_for_not_null.go
+++ b/backend/plugin/advisor/mysql/rule_column_set_default_for_not_null.go
@@ -45,8 +45,8 @@ func (*ColumnSetDefaultForNotNullAdvisor) Check(_ context.Context, checkCtx advi
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_column_type_disallow_list.go
+++ b/backend/plugin/advisor/mysql/rule_column_type_disallow_list.go
@@ -52,8 +52,8 @@ func (*ColumnTypeDisallowListAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_database_drop_empty_db.go
+++ b/backend/plugin/advisor/mysql/rule_database_drop_empty_db.go
@@ -45,8 +45,8 @@ func (*DatabaseAllowDropIfEmptyAdvisor) Check(_ context.Context, checkCtx adviso
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_disallow_procedure.go
+++ b/backend/plugin/advisor/mysql/rule_disallow_procedure.go
@@ -42,8 +42,8 @@ func (*ProcedureDisallowCreateAdvisor) Check(_ context.Context, checkCtx advisor
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_event_disallow_create.go
+++ b/backend/plugin/advisor/mysql/rule_event_disallow_create.go
@@ -42,8 +42,8 @@ func (*EventDisallowCreateAdvisor) Check(_ context.Context, checkCtx advisor.Con
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_function_disallow_create.go
+++ b/backend/plugin/advisor/mysql/rule_function_disallow_create.go
@@ -42,8 +42,8 @@ func (*FunctionDisallowCreateAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_function_disallowed_list.go
+++ b/backend/plugin/advisor/mysql/rule_function_disallowed_list.go
@@ -49,8 +49,8 @@ func (*FunctionDisallowedListAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_index_key_number_limit.go
+++ b/backend/plugin/advisor/mysql/rule_index_key_number_limit.go
@@ -49,8 +49,8 @@ func (*IndexKeyNumberLimitAdvisor) Check(_ context.Context, checkCtx advisor.Con
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_index_no_duplicate_column.go
+++ b/backend/plugin/advisor/mysql/rule_index_no_duplicate_column.go
@@ -45,8 +45,8 @@ func (*IndexNoDuplicateColumnAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_index_pk_type.go
+++ b/backend/plugin/advisor/mysql/rule_index_pk_type.go
@@ -47,8 +47,8 @@ func (*IndexPkTypeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/mysql/rule_index_primary_key_type_allowlist.go
@@ -51,8 +51,8 @@ func (*IndexPrimaryKeyTypeAllowlistAdvisor) Check(_ context.Context, checkCtx ad
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
+++ b/backend/plugin/advisor/mysql/rule_index_total_number_limit.go
@@ -51,8 +51,8 @@ func (*IndexTotalNumberLimitAdvisor) Check(_ context.Context, checkCtx advisor.C
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_index_type_allow_list.go
+++ b/backend/plugin/advisor/mysql/rule_index_type_allow_list.go
@@ -44,8 +44,8 @@ func (*IndexTypeAllowListAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
+++ b/backend/plugin/advisor/mysql/rule_index_type_no_blob.go
@@ -47,8 +47,8 @@ func (*IndexTypeNoBlobAdvisor) Check(_ context.Context, checkCtx advisor.Context
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_insert_disallow_order_by_rand.go
+++ b/backend/plugin/advisor/mysql/rule_insert_disallow_order_by_rand.go
@@ -46,8 +46,8 @@ func (*InsertDisallowOrderByRandAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_insert_must_specify_column.go
+++ b/backend/plugin/advisor/mysql/rule_insert_must_specify_column.go
@@ -43,8 +43,8 @@ func (*InsertMustSpecifyColumnAdvisor) Check(_ context.Context, checkCtx advisor
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_insert_row_limit.go
+++ b/backend/plugin/advisor/mysql/rule_insert_row_limit.go
@@ -50,8 +50,8 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_migration_compatibility.go
+++ b/backend/plugin/advisor/mysql/rule_migration_compatibility.go
@@ -44,8 +44,8 @@ func (*CompatibilityAdvisor) Check(_ context.Context, checkCtx advisor.Context) 
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_auto_increment_column.go
+++ b/backend/plugin/advisor/mysql/rule_naming_auto_increment_column.go
@@ -59,8 +59,8 @@ func (*NamingAutoIncrementColumnAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_column.go
+++ b/backend/plugin/advisor/mysql/rule_naming_column.go
@@ -58,8 +58,8 @@ func (*NamingColumnConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_foreign_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_foreign_key_convention.go
@@ -64,8 +64,8 @@ func (*NamingFKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/mysql/rule_naming_identifier_no_keyword.go
@@ -41,8 +41,8 @@ func (*NamingIdentifierNoKeywordAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_index_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_index_convention.go
@@ -73,8 +73,8 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_table.go
+++ b/backend/plugin/advisor/mysql/rule_naming_table.go
@@ -60,8 +60,8 @@ func (*NamingTableConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/mysql/rule_naming_unique_key_convention.go
@@ -65,8 +65,8 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_online_migration.go
+++ b/backend/plugin/advisor/mysql/rule_online_migration.go
@@ -71,8 +71,8 @@ func (*OnlineMigrationAdvisor) Check(ctx context.Context, checkCtx advisor.Conte
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_add_column_without_position.go
+++ b/backend/plugin/advisor/mysql/rule_statement_add_column_without_position.go
@@ -41,8 +41,8 @@ func (*StatementAddColumnWithoutPositionAdvisor) Check(_ context.Context, checkC
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/mysql/rule_statement_affected_row_limit.go
@@ -50,8 +50,8 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 
 	if checkCtx.Driver != nil {
 		for _, stmt := range checkCtx.ParsedStatements {
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			if stmt.AST == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_statement_disallow_using_filesort.go
+++ b/backend/plugin/advisor/mysql/rule_statement_disallow_using_filesort.go
@@ -44,8 +44,8 @@ func (*StatementDisallowUsingFilesortAdvisor) Check(ctx context.Context, checkCt
 
 	if rule.driver != nil {
 		for _, stmt := range checkCtx.ParsedStatements {
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			if stmt.AST == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_statement_disallow_using_temporary.go
+++ b/backend/plugin/advisor/mysql/rule_statement_disallow_using_temporary.go
@@ -44,8 +44,8 @@ func (*StatementDisallowUsingTemporaryAdvisor) Check(ctx context.Context, checkC
 
 	if rule.driver != nil {
 		for _, stmt := range checkCtx.ParsedStatements {
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			if stmt.AST == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/mysql/rule_statement_dml_dry_run.go
@@ -45,8 +45,8 @@ func (*StatementDmlDryRunAdvisor) Check(ctx context.Context, checkCtx advisor.Co
 
 	if checkCtx.Driver != nil {
 		for _, stmt := range checkCtx.ParsedStatements {
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			if stmt.AST == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_statement_join_strict_column_attrs.go
+++ b/backend/plugin/advisor/mysql/rule_statement_join_strict_column_attrs.go
@@ -45,8 +45,8 @@ func (*StatementJoinStrictColumnAttrsAdvisor) Check(_ context.Context, checkCtx 
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_maximum_join_table_count.go
+++ b/backend/plugin/advisor/mysql/rule_statement_maximum_join_table_count.go
@@ -43,8 +43,8 @@ func (*StatementMaximumJoinTableCountAdvisor) Check(_ context.Context, checkCtx 
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_maximum_limit_value.go
+++ b/backend/plugin/advisor/mysql/rule_statement_maximum_limit_value.go
@@ -47,8 +47,8 @@ func (*StatementMaximumLimitValueAdvisor) Check(_ context.Context, checkCtx advi
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_maximum_statements_in_transaction.go
+++ b/backend/plugin/advisor/mysql/rule_statement_maximum_statements_in_transaction.go
@@ -40,8 +40,8 @@ func (*StatementMaximumStatementsInTransactionAdvisor) Check(_ context.Context, 
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_merge_alter_table.go
+++ b/backend/plugin/advisor/mysql/rule_statement_merge_alter_table.go
@@ -44,8 +44,8 @@ func (*StatementMergeAlterTableAdvisor) Check(_ context.Context, checkCtx adviso
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_query_minimum_plan_level.go
+++ b/backend/plugin/advisor/mysql/rule_statement_query_minimum_plan_level.go
@@ -48,8 +48,8 @@ func (*StatementQueryMinumumPlanLevelAdvisor) Check(ctx context.Context, checkCt
 
 	if rule.driver != nil {
 		for _, stmt := range checkCtx.ParsedStatements {
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			if stmt.AST == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_statement_select_full_table_scan.go
+++ b/backend/plugin/advisor/mysql/rule_statement_select_full_table_scan.go
@@ -46,8 +46,8 @@ func (*StatementSelectFullTableScanAdvisor) Check(ctx context.Context, checkCtx 
 
 	if rule.driver != nil {
 		for _, stmt := range checkCtx.ParsedStatements {
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			if stmt.AST == nil {
 				continue
 			}

--- a/backend/plugin/advisor/mysql/rule_statement_where_disallow_using_function.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_disallow_using_function.go
@@ -39,8 +39,8 @@ func (*StatementWhereDisallowUsingFunctionAdvisor) Check(_ context.Context, chec
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_statement_where_maximum_logical_operator_count.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_maximum_logical_operator_count.go
@@ -44,8 +44,8 @@ func (*StatementWhereMaximumLogicalOperatorCountAdvisor) Check(_ context.Context
 		// Create the generic checker with the rule
 		checker := NewGenericChecker([]Rule{rule})
 
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		rule.resetForStatement()
 		if stmt.AST == nil {
 			continue

--- a/backend/plugin/advisor/mysql/rule_statement_where_no_equal_null.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_no_equal_null.go
@@ -38,8 +38,8 @@ func (*StatementWhereNoEqualNullAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_disallow_commit.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_disallow_commit.go
@@ -43,8 +43,8 @@ func (*StatementDisallowCommitAdvisor) Check(_ context.Context, checkCtx advisor
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_disallow_limit.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_disallow_limit.go
@@ -42,8 +42,8 @@ func (*StatementDisallowLimitAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_disallow_order_by.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_disallow_order_by.go
@@ -42,8 +42,8 @@ func (*DisallowOrderByAdvisor) Check(_ context.Context, checkCtx advisor.Context
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_max_execution_time.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_max_execution_time.go
@@ -47,8 +47,8 @@ func (*MaxExecutionTimeAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_no_leading_wildcard_like.go
@@ -43,8 +43,8 @@ func (*NoLeadingWildcardLikeAdvisor) Check(_ context.Context, checkCtx advisor.C
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_no_select_all.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_no_select_all.go
@@ -42,8 +42,8 @@ func (*NoSelectAllAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_require_algorithm_or_lock_options.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_require_algorithm_or_lock_options.go
@@ -48,8 +48,8 @@ func (*RequireAlgorithmOrLockOptionAdvisor) Check(_ context.Context, checkCtx ad
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_select.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_select.go
@@ -42,8 +42,8 @@ func (*WhereRequirementForSelectAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_update_delete.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_update_delete.go
@@ -43,8 +43,8 @@ func (*WhereRequirementForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_comment_convention.go
+++ b/backend/plugin/advisor/mysql/rule_table_comment_convention.go
@@ -44,8 +44,8 @@ func (*TableCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_disallow_ddl.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_ddl.go
@@ -42,8 +42,8 @@ func (*TableDisallowDDLAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_disallow_dml.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_dml.go
@@ -42,8 +42,8 @@ func (*TableDisallowDMLAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_disallow_partition.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_partition.go
@@ -44,8 +44,8 @@ func (*TableDisallowPartitionAdvisor) Check(_ context.Context, checkCtx advisor.
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_disallow_set_charset.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_set_charset.go
@@ -40,8 +40,8 @@ func (*TableDisallowSetCharsetAdvisor) Check(_ context.Context, checkCtx advisor
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_disallow_trigger.go
+++ b/backend/plugin/advisor/mysql/rule_table_disallow_trigger.go
@@ -42,8 +42,8 @@ func (*TableDisallowTriggerAdvisor) Check(_ context.Context, checkCtx advisor.Co
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/mysql/rule_table_drop_naming_convention.go
@@ -55,8 +55,8 @@ func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_limit_size.go
+++ b/backend/plugin/advisor/mysql/rule_table_limit_size.go
@@ -64,8 +64,8 @@ func (*MaximumTableSizeAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 			// Create the generic checker with the rule
 			checker := NewGenericChecker([]Rule{rule})
 
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 
 			// Generate advice based on collected table information

--- a/backend/plugin/advisor/mysql/rule_table_no_duplicate_index.go
+++ b/backend/plugin/advisor/mysql/rule_table_no_duplicate_index.go
@@ -46,8 +46,8 @@ func (*TableNoDuplicateIndexAdvisor) Check(_ context.Context, checkCtx advisor.C
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_no_fk.go
+++ b/backend/plugin/advisor/mysql/rule_table_no_fk.go
@@ -46,8 +46,8 @@ func (*TableNoFKAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_require_charset.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_charset.go
@@ -41,8 +41,8 @@ func (*TableRequireCharsetAdvisor) Check(_ context.Context, checkCtx advisor.Con
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_require_collation.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_collation.go
@@ -41,8 +41,8 @@ func (*TableRequireCollationAdvisor) Check(_ context.Context, checkCtx advisor.C
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_require_pk.go
+++ b/backend/plugin/advisor/mysql/rule_table_require_pk.go
@@ -50,8 +50,8 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
+++ b/backend/plugin/advisor/mysql/rule_table_text_fields_total_length.go
@@ -50,8 +50,8 @@ func (*TableMaximumVarcharLengthAdvisor) Check(_ context.Context, checkCtx advis
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_use_innodb.go
+++ b/backend/plugin/advisor/mysql/rule_use_innodb.go
@@ -47,8 +47,8 @@ func (*UseInnoDBAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/mysql/rule_view_disallow_create.go
+++ b/backend/plugin/advisor/mysql/rule_view_disallow_create.go
@@ -42,8 +42,8 @@ func (*ViewDisallowCreateAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 	checker := NewGenericChecker([]Rule{rule})
 
 	for _, stmt := range checkCtx.ParsedStatements {
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		if stmt.AST == nil {
 			continue
 		}

--- a/backend/plugin/advisor/oceanbase/advisor_disallow_offline_ddl.go
+++ b/backend/plugin/advisor/oceanbase/advisor_disallow_offline_ddl.go
@@ -54,7 +54,7 @@ func (*DisallowOfflineDdlAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		if !ok {
 			continue
 		}
-		checker.baseLine = stmt.BaseLine
+		checker.baseLine = stmt.BaseLine()
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oceanbase/advisor_insert_row_limit.go
+++ b/backend/plugin/advisor/oceanbase/advisor_insert_row_limit.go
@@ -58,7 +58,7 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 		if !ok {
 			continue
 		}
-		checker.baseLine = stmt.BaseLine
+		checker.baseLine = stmt.BaseLine()
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		if checker.explainCount >= common.MaximumLintExplainSize {
 			break

--- a/backend/plugin/advisor/oceanbase/advisor_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/oceanbase/advisor_statement_affected_row_limit.go
@@ -58,7 +58,7 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 			if !ok {
 				continue
 			}
-			checker.baseLine = stmt.BaseLine
+			checker.baseLine = stmt.BaseLine()
 			antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 			if checker.explainCount >= common.MaximumLintExplainSize {
 				break

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
@@ -48,8 +48,8 @@ func (*StatementPriorBackupCheckAdvisor) Check(ctx context.Context, checkCtx adv
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_add_not_null_column_require_default.go
+++ b/backend/plugin/advisor/oracle/rule_column_add_not_null_column_require_default.go
@@ -45,8 +45,8 @@ func (*ColumnAddNotNullColumnRequireDefaultAdvisor) Check(_ context.Context, che
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_comment_convention.go
+++ b/backend/plugin/advisor/oracle/rule_column_comment_convention.go
@@ -46,8 +46,8 @@ func (*ColumnCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_maximum_character_length.go
+++ b/backend/plugin/advisor/oracle/rule_column_maximum_character_length.go
@@ -56,8 +56,8 @@ func (*ColumnMaximumCharacterLengthAdvisor) Check(_ context.Context, checkCtx ad
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/oracle/rule_column_maximum_varchar_length.go
@@ -56,8 +56,8 @@ func (*ColumnMaximumVarcharLengthAdvisor) Check(_ context.Context, checkCtx advi
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_no_null.go
+++ b/backend/plugin/advisor/oracle/rule_column_no_null.go
@@ -48,8 +48,8 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_require.go
+++ b/backend/plugin/advisor/oracle/rule_column_require.go
@@ -53,8 +53,8 @@ func (*ColumnRequireAdvisor) Check(_ context.Context, checkCtx advisor.Context) 
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_require_default.go
+++ b/backend/plugin/advisor/oracle/rule_column_require_default.go
@@ -46,8 +46,8 @@ func (*ColumnRequireDefaultAdvisor) Check(_ context.Context, checkCtx advisor.Co
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_column_type_disallow_list.go
+++ b/backend/plugin/advisor/oracle/rule_column_type_disallow_list.go
@@ -48,8 +48,8 @@ func (*ColumnTypeDisallowListAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_index_key_number_limit.go
+++ b/backend/plugin/advisor/oracle/rule_index_key_number_limit.go
@@ -55,8 +55,8 @@ func (*IndexKeyNumberLimitAdvisor) Check(_ context.Context, checkCtx advisor.Con
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_insert_must_specify_column.go
+++ b/backend/plugin/advisor/oracle/rule_insert_must_specify_column.go
@@ -44,8 +44,8 @@ func (*InsertMustSpecifyColumnAdvisor) Check(_ context.Context, checkCtx advisor
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_naming_identifier_case.go
+++ b/backend/plugin/advisor/oracle/rule_naming_identifier_case.go
@@ -47,8 +47,8 @@ func (*NamingIdentifierCaseAdvisor) Check(_ context.Context, checkCtx advisor.Co
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/oracle/rule_naming_identifier_no_keyword.go
@@ -46,8 +46,8 @@ func (*NamingIdentifierNoKeywordAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_naming_table.go
+++ b/backend/plugin/advisor/oracle/rule_naming_table.go
@@ -61,8 +61,8 @@ func (*NamingTableAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_naming_table_no_keyword.go
+++ b/backend/plugin/advisor/oracle/rule_naming_table_no_keyword.go
@@ -46,8 +46,8 @@ func (*NamingTableNoKeywordAdvisor) Check(_ context.Context, checkCtx advisor.Co
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_select_no_select_all.go
+++ b/backend/plugin/advisor/oracle/rule_select_no_select_all.go
@@ -44,8 +44,8 @@ func (*SelectNoSelectAllAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/oracle/rule_statement_dml_dry_run.go
@@ -46,8 +46,8 @@ func (*StatementDmlDryRunAdvisor) Check(ctx context.Context, checkCtx advisor.Co
 			if !ok {
 				continue
 			}
-			rule.SetBaseLine(stmt.BaseLine)
-			checker.SetBaseLine(stmt.BaseLine)
+			rule.SetBaseLine(stmt.BaseLine())
+			checker.SetBaseLine(stmt.BaseLine())
 			antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		}
 	}

--- a/backend/plugin/advisor/oracle/rule_table_comment_convention.go
+++ b/backend/plugin/advisor/oracle/rule_table_comment_convention.go
@@ -46,8 +46,8 @@ func (*TableCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_table_no_foreign_key.go
+++ b/backend/plugin/advisor/oracle/rule_table_no_foreign_key.go
@@ -45,8 +45,8 @@ func (*TableNoForeignKeyAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_table_require_pk.go
+++ b/backend/plugin/advisor/oracle/rule_table_require_pk.go
@@ -45,8 +45,8 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_where_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/oracle/rule_where_no_leading_wildcard_like.go
@@ -45,8 +45,8 @@ func (*WhereNoLeadingWildcardLikeAdvisor) Check(_ context.Context, checkCtx advi
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_where_require_for_select.go
+++ b/backend/plugin/advisor/oracle/rule_where_require_for_select.go
@@ -45,8 +45,8 @@ func (*WhereRequireForSelectAdvisor) Check(_ context.Context, checkCtx advisor.C
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/oracle/rule_where_require_for_update_delete.go
+++ b/backend/plugin/advisor/oracle/rule_where_require_for_update_delete.go
@@ -44,8 +44,8 @@ func (*WhereRequireForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx adv
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/pg/advisor_builtin_prior_backup_check.go
@@ -65,7 +65,7 @@ func (*BuiltinPriorBackupCheckAdvisor) Check(_ context.Context, checkCtx advisor
 			},
 			tokens: antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_collation_allowlist.go
+++ b/backend/plugin/advisor/pg/advisor_collation_allowlist.go
@@ -57,8 +57,8 @@ func (*CollationAllowlistAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		rule.tokens = antlrAST.Tokens
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}

--- a/backend/plugin/advisor/pg/advisor_column_comment_convention.go
+++ b/backend/plugin/advisor/pg/advisor_column_comment_convention.go
@@ -50,8 +50,8 @@ func (*ColumnCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_column_default_disallow_volatile.go
+++ b/backend/plugin/advisor/pg/advisor_column_default_disallow_volatile.go
@@ -54,8 +54,8 @@ func (*ColumnDefaultDisallowVolatileAdvisor) Check(_ context.Context, checkCtx a
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_column_disallow_changing_type.go
+++ b/backend/plugin/advisor/pg/advisor_column_disallow_changing_type.go
@@ -51,8 +51,8 @@ func (*ColumnDisallowChangingTypeAdvisor) Check(_ context.Context, checkCtx advi
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		rule.tokens = antlrAST.Tokens
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}

--- a/backend/plugin/advisor/pg/advisor_column_maximum_character_length.go
+++ b/backend/plugin/advisor/pg/advisor_column_maximum_character_length.go
@@ -63,8 +63,8 @@ func (*ColumnMaximumCharacterLengthAdvisor) Check(_ context.Context, checkCtx ad
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_column_no_null.go
+++ b/backend/plugin/advisor/pg/advisor_column_no_null.go
@@ -55,8 +55,8 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_column_require_default.go
+++ b/backend/plugin/advisor/pg/advisor_column_require_default.go
@@ -53,8 +53,8 @@ func (*ColumnRequireDefaultAdvisor) Check(_ context.Context, checkCtx advisor.Co
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_column_required.go
+++ b/backend/plugin/advisor/pg/advisor_column_required.go
@@ -70,8 +70,8 @@ func (*ColumnRequirementAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_column_type_disallow_list.go
+++ b/backend/plugin/advisor/pg/advisor_column_type_disallow_list.go
@@ -62,8 +62,8 @@ func (*ColumnTypeDisallowListAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_comment_convention.go
+++ b/backend/plugin/advisor/pg/advisor_comment_convention.go
@@ -58,8 +58,8 @@ func (*CommentConventionAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_encoding_allowlist.go
+++ b/backend/plugin/advisor/pg/advisor_encoding_allowlist.go
@@ -60,8 +60,8 @@ func (*EncodingAllowlistAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
+++ b/backend/plugin/advisor/pg/advisor_index_create_concurrently.go
@@ -51,8 +51,8 @@ func (*IndexConcurrentlyAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_index_key_number_limit.go
+++ b/backend/plugin/advisor/pg/advisor_index_key_number_limit.go
@@ -60,8 +60,8 @@ func (*IndexKeyNumberLimitAdvisor) Check(_ context.Context, checkCtx advisor.Con
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_index_no_duplicate_column.go
+++ b/backend/plugin/advisor/pg/advisor_index_no_duplicate_column.go
@@ -52,8 +52,8 @@ func (*IndexNoDuplicateColumnAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/pg/advisor_index_primary_key_type_allowlist.go
@@ -52,8 +52,8 @@ func (*IndexPrimaryKeyTypeAllowlistAdvisor) Check(_ context.Context, checkCtx ad
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_index_total_number_limit.go
+++ b/backend/plugin/advisor/pg/advisor_index_total_number_limit.go
@@ -59,8 +59,8 @@ func (*IndexTotalNumberLimitAdvisor) Check(_ context.Context, checkCtx advisor.C
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_insert_disallow_order_by_rand.go
+++ b/backend/plugin/advisor/pg/advisor_insert_disallow_order_by_rand.go
@@ -50,7 +50,7 @@ func (*InsertDisallowOrderByRandAdvisor) Check(_ context.Context, checkCtx advis
 			},
 			tokens: antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_insert_must_specify_column.go
+++ b/backend/plugin/advisor/pg/advisor_insert_must_specify_column.go
@@ -49,7 +49,7 @@ func (*InsertMustSpecifyColumnAdvisor) Check(_ context.Context, checkCtx advisor
 			},
 			tokens: antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_insert_row_limit.go
+++ b/backend/plugin/advisor/pg/advisor_insert_row_limit.go
@@ -66,7 +66,7 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 			tokens:     antlrAST.Tokens,
 			TenantMode: checkCtx.TenantMode,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_migration_compatibility.go
+++ b/backend/plugin/advisor/pg/advisor_migration_compatibility.go
@@ -54,8 +54,8 @@ func (*CompatibilityAdvisor) Check(_ context.Context, checkCtx advisor.Context) 
 		}
 
 		checker := NewGenericChecker([]Rule{rule})
-		rule.SetBaseLine(stmtInfo.BaseLine)
-		checker.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
+		checker.SetBaseLine(stmtInfo.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 
 		adviceList = append(adviceList, checker.GetAdviceList()...)

--- a/backend/plugin/advisor/pg/advisor_naming_column.go
+++ b/backend/plugin/advisor/pg/advisor_naming_column.go
@@ -71,8 +71,8 @@ func (*NamingColumnConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_naming_foreign_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_foreign_key_convention.go
@@ -77,8 +77,8 @@ func (*NamingFKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_naming_fully_qualified.go
+++ b/backend/plugin/advisor/pg/advisor_naming_fully_qualified.go
@@ -52,7 +52,7 @@ func (*FullyQualifiedObjectNameAdvisor) Check(_ context.Context, checkCtx adviso
 			dbMetadata: checkCtx.DBSchema,
 			tokens:     antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_naming_index_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_index_convention.go
@@ -76,8 +76,8 @@ func (*NamingIndexConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_primary_key_convention.go
@@ -76,8 +76,8 @@ func (*NamingPKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		}
 
 		checker := NewGenericChecker([]Rule{rule})
-		rule.SetBaseLine(stmtInfo.BaseLine)
-		checker.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
+		checker.SetBaseLine(stmtInfo.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		adviceList = append(adviceList, checker.GetAdviceList()...)
 	}

--- a/backend/plugin/advisor/pg/advisor_naming_table.go
+++ b/backend/plugin/advisor/pg/advisor_naming_table.go
@@ -70,8 +70,8 @@ func (*NamingTableConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
+++ b/backend/plugin/advisor/pg/advisor_naming_unique_key_convention.go
@@ -77,8 +77,8 @@ func (*NamingUKConventionAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_add_check_not_valid.go
+++ b/backend/plugin/advisor/pg/advisor_statement_add_check_not_valid.go
@@ -49,8 +49,8 @@ func (*StatementAddCheckNotValidAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_add_fk_not_valid.go
+++ b/backend/plugin/advisor/pg/advisor_statement_add_fk_not_valid.go
@@ -49,8 +49,8 @@ func (*StatementAddFKNotValidAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/pg/advisor_statement_affected_row_limit.go
@@ -66,7 +66,7 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 			tenantMode: checkCtx.TenantMode,
 			tokens:     antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_statement_check_set_role_variable.go
+++ b/backend/plugin/advisor/pg/advisor_statement_check_set_role_variable.go
@@ -47,8 +47,8 @@ func (*StatementCheckSetRoleVariable) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_create_specify_schema.go
+++ b/backend/plugin/advisor/pg/advisor_statement_create_specify_schema.go
@@ -47,8 +47,8 @@ func (*StatementCreateSpecifySchema) Check(_ context.Context, checkCtx advisor.C
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_add_column_with_default.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_add_column_with_default.go
@@ -49,8 +49,8 @@ func (*StatementDisallowAddColumnWithDefaultAdvisor) Check(_ context.Context, ch
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_add_not_null.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_add_not_null.go
@@ -51,8 +51,8 @@ func (*StatementDisallowAddNotNullAdvisor) Check(_ context.Context, checkCtx adv
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_commit.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_commit.go
@@ -46,7 +46,7 @@ func (*StatementDisallowCommitAdvisor) Check(_ context.Context, checkCtx advisor
 			BaseRule: BaseRule{level: level, title: checkCtx.Rule.Type.String()},
 			tokens:   antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_on_del_cascade.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_on_del_cascade.go
@@ -51,8 +51,8 @@ func (*StatementDisallowOnDelCascadeAdvisor) Check(_ context.Context, checkCtx a
 		}
 
 		checker := NewGenericChecker([]Rule{rule})
-		rule.SetBaseLine(stmtInfo.BaseLine)
-		checker.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
+		checker.SetBaseLine(stmtInfo.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 
 		adviceList = append(adviceList, checker.GetAdviceList()...)

--- a/backend/plugin/advisor/pg/advisor_statement_disallow_rm_tbl_cascade.go
+++ b/backend/plugin/advisor/pg/advisor_statement_disallow_rm_tbl_cascade.go
@@ -49,8 +49,8 @@ func (*StatementDisallowRemoveTblCascadeAdvisor) Check(_ context.Context, checkC
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/pg/advisor_statement_dml_dry_run.go
@@ -58,7 +58,7 @@ func (*StatementDMLDryRunAdvisor) Check(ctx context.Context, checkCtx advisor.Co
 			tenantMode: checkCtx.TenantMode,
 			tokens:     antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_statement_maximum_limit_value.go
+++ b/backend/plugin/advisor/pg/advisor_statement_maximum_limit_value.go
@@ -58,8 +58,8 @@ func (*StatementMaximumLimitValueAdvisor) Check(_ context.Context, checkCtx advi
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_merge_alter_table.go
+++ b/backend/plugin/advisor/pg/advisor_statement_merge_alter_table.go
@@ -51,8 +51,8 @@ func (*StatementMergeAlterTableAdvisor) Check(_ context.Context, checkCtx adviso
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/pg/advisor_statement_no_leading_wildcard_like.go
@@ -52,7 +52,7 @@ func (*StatementNoLeadingWildcardLikeAdvisor) Check(_ context.Context, checkCtx 
 			tokens:             antlrAST.Tokens,
 			reportedStatements: make(map[antlr.ParserRuleContext]bool),
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_statement_no_select_all.go
+++ b/backend/plugin/advisor/pg/advisor_statement_no_select_all.go
@@ -49,7 +49,7 @@ func (*NoSelectAllAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 			},
 			tokens: antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_statement_non_transactional.go
+++ b/backend/plugin/advisor/pg/advisor_statement_non_transactional.go
@@ -50,8 +50,8 @@ func (*NonTransactionalAdvisor) Check(_ context.Context, checkCtx advisor.Contex
 			tokens: antlrAST.Tokens,
 		}
 		checker := NewGenericChecker([]Rule{rule})
-		rule.SetBaseLine(stmtInfo.BaseLine)
-		checker.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
+		checker.SetBaseLine(stmtInfo.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		adviceList = append(adviceList, checker.GetAdviceList()...)
 	}

--- a/backend/plugin/advisor/pg/advisor_statement_object_owner_check.go
+++ b/backend/plugin/advisor/pg/advisor_statement_object_owner_check.go
@@ -68,8 +68,8 @@ func (*StatementObjectOwnerCheckAdvisor) Check(ctx context.Context, checkCtx adv
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_statement_where_required_select.go
+++ b/backend/plugin/advisor/pg/advisor_statement_where_required_select.go
@@ -48,7 +48,7 @@ func (*StatementWhereRequiredSelectAdvisor) Check(_ context.Context, checkCtx ad
 			},
 			tokens: antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_statement_where_required_update_delete.go
+++ b/backend/plugin/advisor/pg/advisor_statement_where_required_update_delete.go
@@ -48,7 +48,7 @@ func (*StatementWhereRequiredUpdateDeleteAdvisor) Check(_ context.Context, check
 			},
 			tokens: antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_table_comment_convention.go
+++ b/backend/plugin/advisor/pg/advisor_table_comment_convention.go
@@ -55,8 +55,8 @@ func (*TableCommentConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_table_disallow_partition.go
+++ b/backend/plugin/advisor/pg/advisor_table_disallow_partition.go
@@ -50,7 +50,7 @@ func (*TableDisallowPartitionAdvisor) Check(_ context.Context, checkCtx advisor.
 			},
 			tokens: antlrAST.Tokens,
 		}
-		rule.SetBaseLine(stmtInfo.BaseLine)
+		rule.SetBaseLine(stmtInfo.BaseLine())
 
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)

--- a/backend/plugin/advisor/pg/advisor_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/pg/advisor_table_drop_naming_convention.go
@@ -66,8 +66,8 @@ func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/pg/advisor_table_no_fk.go
+++ b/backend/plugin/advisor/pg/advisor_table_no_fk.go
@@ -52,7 +52,7 @@ func (*TableNoFKAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*
 		}
 
 		checker := NewGenericChecker([]Rule{rule})
-		checker.SetBaseLine(stmtInfo.BaseLine)
+		checker.SetBaseLine(stmtInfo.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		adviceList = append(adviceList, checker.GetAdviceList()...)
 	}

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -54,9 +54,9 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
 		rule.tokens = antlrAST.Tokens
-		checker.SetBaseLine(stmt.BaseLine)
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_column_maximum_varchar_length.go
+++ b/backend/plugin/advisor/snowflake/rule_column_maximum_varchar_length.go
@@ -65,8 +65,8 @@ func (*ColumnMaximumVarcharLengthAdvisor) Check(_ context.Context, checkCtx advi
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_column_no_null.go
+++ b/backend/plugin/advisor/snowflake/rule_column_no_null.go
@@ -48,8 +48,8 @@ func (*ColumnNoNullAdvisor) Check(_ context.Context, checkCtx advisor.Context) (
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_column_require.go
+++ b/backend/plugin/advisor/snowflake/rule_column_require.go
@@ -59,8 +59,8 @@ func (*ColumnRequireAdvisor) Check(_ context.Context, checkCtx advisor.Context) 
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_migration_compatibility.go
+++ b/backend/plugin/advisor/snowflake/rule_migration_compatibility.go
@@ -47,8 +47,8 @@ func (*MigrationCompatibilityAdvisor) Check(_ context.Context, checkCtx advisor.
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_naming_identifier_case.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_identifier_case.go
@@ -47,8 +47,8 @@ func (*NamingIdentifierCaseAdvisor) Check(_ context.Context, checkCtx advisor.Co
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_identifier_no_keyword.go
@@ -47,8 +47,8 @@ func (*NamingIdentifierNoKeywordAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_naming_table.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_table.go
@@ -63,8 +63,8 @@ func (*NamingTableAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_naming_table_no_keyword.go
+++ b/backend/plugin/advisor/snowflake/rule_naming_table_no_keyword.go
@@ -46,8 +46,8 @@ func (*NamingTableNoKeywordAdvisor) Check(_ context.Context, checkCtx advisor.Co
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_select_no_select_all.go
+++ b/backend/plugin/advisor/snowflake/rule_select_no_select_all.go
@@ -44,8 +44,8 @@ func (*SelectNoSelectAllAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/snowflake/rule_table_drop_naming_convention.go
@@ -58,8 +58,8 @@ func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advis
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_table_no_foreign_key.go
+++ b/backend/plugin/advisor/snowflake/rule_table_no_foreign_key.go
@@ -46,8 +46,8 @@ func (*TableNoForeignKeyAdvisor) Check(_ context.Context, checkCtx advisor.Conte
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_table_require_pk.go
+++ b/backend/plugin/advisor/snowflake/rule_table_require_pk.go
@@ -46,8 +46,8 @@ func (*TableRequirePkAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_where_require_select.go
+++ b/backend/plugin/advisor/snowflake/rule_where_require_select.go
@@ -44,8 +44,8 @@ func (*WhereRequireForSelectAdvisor) Check(_ context.Context, checkCtx advisor.C
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/advisor/snowflake/rule_where_require_update_delete.go
+++ b/backend/plugin/advisor/snowflake/rule_where_require_update_delete.go
@@ -44,8 +44,8 @@ func (*WhereRequireForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx adv
 		if !ok {
 			continue
 		}
-		rule.SetBaseLine(stmt.BaseLine)
-		checker.SetBaseLine(stmt.BaseLine)
+		rule.SetBaseLine(stmt.BaseLine())
+		checker.SetBaseLine(stmt.BaseLine())
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 	}
 

--- a/backend/plugin/parser/base/lexer.go
+++ b/backend/plugin/parser/base/lexer.go
@@ -112,8 +112,7 @@ func SplitSQLByLexer(stream *antlr.CommonTokenStream, semiTokenType int) ([]Stat
 			lastToken := buf[len(buf)-1]
 			// Use buf[0]'s position directly since GetAllTokens() includes hidden channel tokens (whitespace/comments)
 			sqls = append(sqls, Statement{
-				Text:     stmtText,
-				BaseLine: buf[0].GetLine() - 1, // BaseLine is the offset of the first token
+				Text: stmtText,
 				Range: &storepb.Range{
 					Start: int32(byteOffset),
 					End:   int32(byteOffset + stmtByteLength),

--- a/backend/plugin/parser/base/split_test_runner.go
+++ b/backend/plugin/parser/base/split_test_runner.go
@@ -89,7 +89,7 @@ func assertStatementsEqual(t *testing.T, expected []StatementResult, actual []St
 		msg := append([]any{"statement %d mismatch", i}, msgAndArgs...)
 
 		require.Equal(t, exp.Text, act.Text, msg...)
-		require.Equal(t, exp.BaseLine, act.BaseLine, msg...)
+		require.Equal(t, exp.BaseLine, act.BaseLine(), msg...)
 		require.Equal(t, exp.Empty, act.Empty, msg...)
 
 		require.NotNil(t, act.Start, msg...)
@@ -162,7 +162,7 @@ func recordTestResults(t *testing.T, fullPath string, testCases []SplitTestCase,
 		for j, stmt := range result {
 			updated[i].Result[j] = StatementResult{
 				Text:     stmt.Text,
-				BaseLine: stmt.BaseLine,
+				BaseLine: stmt.BaseLine(),
 				Empty:    stmt.Empty,
 			}
 			if stmt.Start != nil {

--- a/backend/plugin/parser/base/statement.go
+++ b/backend/plugin/parser/base/statement.go
@@ -11,10 +11,6 @@ type Statement struct {
 	// Empty indicates if the sql is empty, such as `/* comments */;` or just `;`.
 	Empty bool
 
-	// BaseLine is the line number of the first line of the SQL in the original SQL.
-	// HINT: ZERO based. This is kept for backward compatibility with advisor code.
-	BaseLine int
-
 	// Start is the inclusive start position of the SQL in the original SQL (1-based).
 	Start *storepb.Position
 	// End is the exclusive end position of the SQL in the original SQL (1-based).
@@ -25,6 +21,15 @@ type Statement struct {
 	// This field may not be present for every engine.
 	// Range is intended for sql execution log display. It may not represent the actual sql that is sent to the database.
 	Range *storepb.Range
+}
+
+// BaseLine returns the 0-based line number of the first line of the SQL.
+// This is derived from Start.Line - 1 and is used for advisor code compatibility.
+func (s *Statement) BaseLine() int {
+	if s.Start == nil {
+		return 0
+	}
+	return int(s.Start.Line) - 1
 }
 
 // ParsedStatement is the result of parsing SQL (Statement + AST).

--- a/backend/plugin/parser/base/statement_test.go
+++ b/backend/plugin/parser/base/statement_test.go
@@ -44,16 +44,15 @@ func TestParsedStatementEmbedding(t *testing.T) {
 	// Fields should be accessible directly
 	ps := ParsedStatement{
 		Statement: Statement{
-			Text:     "SELECT 1",
-			BaseLine: 5,
-			Start:    &storepb.Position{Line: 6, Column: 1},
+			Text:  "SELECT 1",
+			Start: &storepb.Position{Line: 6, Column: 1},
 		},
 		AST: &ANTLRAST{StartPosition: &storepb.Position{Line: 6}},
 	}
 
 	// Direct access to embedded fields
 	require.Equal(t, "SELECT 1", ps.Text)
-	require.Equal(t, 5, ps.BaseLine)
+	require.Equal(t, 5, ps.BaseLine()) // BaseLine() = Start.Line - 1 = 6 - 1 = 5
 	require.Equal(t, int32(6), ps.Start.Line)
 	require.NotNil(t, ps.AST)
 }

--- a/backend/plugin/parser/bigquery/bigquery.go
+++ b/backend/plugin/parser/bigquery/bigquery.go
@@ -25,7 +25,7 @@ func ParseBigQuerySQL(statement string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		ast, err := parseSingleBigQuerySQL(stmt.Text, stmt.BaseLine)
+		ast, err := parseSingleBigQuerySQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/cassandra/cassandra.go
+++ b/backend/plugin/parser/cassandra/cassandra.go
@@ -75,7 +75,7 @@ func ParseCassandraSQL(statement string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSingleCassandraSQL(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSingleCassandraSQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/cosmosdb/cosmosdb.go
+++ b/backend/plugin/parser/cosmosdb/cosmosdb.go
@@ -25,7 +25,7 @@ func ParseCosmosDBQuery(statement string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSingleCosmosDBQuery(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSingleCosmosDBQuery(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/cosmosdb/split.go
+++ b/backend/plugin/parser/cosmosdb/split.go
@@ -64,8 +64,7 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 	// Start should point to the first character (position 1,1)
 	return []base.Statement{
 		{
-			Text:     statement,
-			BaseLine: 0,
+			Text: statement,
 			Range: &storepb.Range{
 				Start: 0,
 				End:   int32(len(statement)),

--- a/backend/plugin/parser/doris/doris.go
+++ b/backend/plugin/parser/doris/doris.go
@@ -72,7 +72,7 @@ func ParseDorisSQL(statement string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		antlrAST, err := parseSingleDorisSQL(stmt.Text, stmt.BaseLine)
+		antlrAST, err := parseSingleDorisSQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/mysql/mysql.go
+++ b/backend/plugin/parser/mysql/mysql.go
@@ -220,7 +220,7 @@ func parseInputStream(input *antlr.InputStream, statement string) ([]*base.ANTLR
 		}
 
 		result = append(result, &base.ANTLRAST{
-			StartPosition: &storepb.Position{Line: int32(s.BaseLine) + 1},
+			StartPosition: &storepb.Position{Line: int32(s.BaseLine()) + 1},
 			Tree:          tree,
 			Tokens:        tokens,
 		})

--- a/backend/plugin/parser/mysql/split.go
+++ b/backend/plugin/parser/mysql/split.go
@@ -71,8 +71,7 @@ func splitDelimiterModeSQL(stream *antlr.CommonTokenStream, statement string) ([
 			// From antlr4, the line is ONE based, and the column is ZERO based.
 			// So we should minus 1 for the line.
 			result = append(result, base.Statement{
-				Text:     stmtText,
-				BaseLine: tokens[start].GetLine() - 1,
+				Text: stmtText,
 				Range: &storepb.Range{
 					Start: int32(stmtStartByte),
 					End:   int32(stmtEndByte),
@@ -113,8 +112,7 @@ func splitDelimiterModeSQL(stream *antlr.CommonTokenStream, statement string) ([
 			// So we should minus 1 for the line.
 			result = append(result, base.Statement{
 				// Use a single semicolon instead of the user defined delimiter.
-				Text:     stmtText,
-				BaseLine: tokens[start].GetLine() - 1,
+				Text: stmtText,
 				Range: &storepb.Range{
 					Start: int32(stmtStartByte),
 					End:   int32(stmtEndByte),
@@ -153,8 +151,7 @@ func splitDelimiterModeSQL(stream *antlr.CommonTokenStream, statement string) ([
 		// From antlr4, the line is ONE based, and the column is ZERO based.
 		// So we should minus 1 for the line.
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(stmtStartByte),
 				End:   int32(stmtEndByte),
@@ -258,8 +255,7 @@ func splitByParser(statement string, lexer *parser.MySQLLexer, stream *antlr.Com
 		// From antlr4, the line is ONE based, and the column is ZERO based.
 		// So we should minus 1 for the line.
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -289,8 +285,7 @@ func splitByParser(statement string, lexer *parser.MySQLLexer, stream *antlr.Com
 		// From antlr4, the line is ONE based, and the column is ZERO based.
 		// So we should minus 1 for the line.
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -462,8 +457,7 @@ func splitMySQLStatement(stream *antlr.CommonTokenStream, statement string) ([]b
 		// From antlr4, the line is ONE based, and the column is ZERO based.
 		// So we should minus 1 for the line.
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -493,8 +487,7 @@ func splitMySQLStatement(stream *antlr.CommonTokenStream, statement string) ([]b
 		// From antlr4, the line is ONE based, and the column is ZERO based.
 		// So we should minus 1 for the line.
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),

--- a/backend/plugin/parser/partiql/partiql.go
+++ b/backend/plugin/parser/partiql/partiql.go
@@ -76,7 +76,7 @@ func ParsePartiQL(statement string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSinglePartiQL(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSinglePartiQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/pg/pg.go
+++ b/backend/plugin/parser/pg/pg.go
@@ -76,7 +76,7 @@ func ParsePostgreSQL(sql string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSinglePostgreSQL(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSinglePostgreSQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/pg/split.go
+++ b/backend/plugin/parser/pg/split.go
@@ -73,8 +73,7 @@ func splitByParser(statement string, lexer *parser.PostgreSQLLexer, stream *antl
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -102,8 +101,7 @@ func splitByParser(statement string, lexer *parser.PostgreSQLLexer, stream *antl
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -214,8 +212,7 @@ func splitSQLImpl(stream *antlr.CommonTokenStream, statement string) ([]base.Sta
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -243,8 +240,7 @@ func splitSQLImpl(stream *antlr.CommonTokenStream, statement string) ([]base.Sta
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),

--- a/backend/plugin/parser/plsql/split.go
+++ b/backend/plugin/parser/plsql/split.go
@@ -86,8 +86,6 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 
 			result = append(result, base.Statement{
 				Text: text,
-				// BaseLine is 0-based line offset of this statement in the original SQL
-				BaseLine: startLine,
 				Start: &storepb.Position{
 					Line:   int32(startLine + 1),
 					Column: int32(startColumn + 1),

--- a/backend/plugin/parser/redshift/redshift.go
+++ b/backend/plugin/parser/redshift/redshift.go
@@ -78,7 +78,7 @@ func ParseRedshift(sql string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSingleRedshift(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSingleRedshift(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/redshift/split.go
+++ b/backend/plugin/parser/redshift/split.go
@@ -74,8 +74,7 @@ func splitByParser(statement string, lexer *parser.RedshiftLexer, stream *antlr.
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -103,8 +102,7 @@ func splitByParser(statement string, lexer *parser.RedshiftLexer, stream *antlr.
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -214,8 +212,7 @@ func splitSQLImpl(stream *antlr.CommonTokenStream, statement string) ([]base.Sta
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -243,8 +240,7 @@ func splitSQLImpl(stream *antlr.CommonTokenStream, statement string) ([]base.Sta
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),

--- a/backend/plugin/parser/snowflake/snowflake.go
+++ b/backend/plugin/parser/snowflake/snowflake.go
@@ -77,7 +77,7 @@ func ParseSnowSQL(sql string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSingleSnowSQL(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSingleSnowSQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/spanner/spanner.go
+++ b/backend/plugin/parser/spanner/spanner.go
@@ -26,7 +26,7 @@ func ParseSpannerGoogleSQL(sql string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSingleSpannerGoogleSQL(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSingleSpannerGoogleSQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/spanner/split.go
+++ b/backend/plugin/parser/spanner/split.go
@@ -95,8 +95,7 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),

--- a/backend/plugin/parser/standard/split.go
+++ b/backend/plugin/parser/standard/split.go
@@ -48,8 +48,7 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 		endLine, endColumn := base.CalculateLineAndColumn(statement, endPos)
 
 		list = append(list, base.Statement{
-			Text:     text,
-			BaseLine: startLine,
+			Text: text,
 			Start: &storepb.Position{
 				Line:   int32(startLine + 1),   // 1-based
 				Column: int32(startColumn + 1), // 1-based per proto spec

--- a/backend/plugin/parser/tidb/tidb.go
+++ b/backend/plugin/parser/tidb/tidb.go
@@ -45,9 +45,9 @@ func ParseTiDBForSyntaxCheck(statement string) ([]base.AST, error) {
 			// We need to add the offset to get the absolute line number
 			if se, ok := syntaxErr.(*base.SyntaxError); ok && se.Position != nil {
 				// errorLine is 1-based relative to singleSQL.Text
-				// singleSQL.BaseLine is 0-based line number of the first line in the original statement
+				// singleSQL.BaseLine() is 0-based line number of the first line in the original statement
 				// Absolute line (1-based) = BaseLine (0-based) + errorLine (1-based)
-				se.Position.Line = int32(singleSQL.BaseLine) + se.Position.Line
+				se.Position.Line = int32(singleSQL.BaseLine()) + se.Position.Line
 			}
 			return nil, syntaxErr
 		}
@@ -66,7 +66,7 @@ func ParseTiDBForSyntaxCheck(statement string) ([]base.AST, error) {
 		// from its internal Text(), so we count how many were stripped.
 		nativeText := node.Text()
 		leadingNewlinesStripped := strings.Count(singleSQL.Text, "\n") - strings.Count(nativeText, "\n")
-		actualStartLine := singleSQL.BaseLine + leadingNewlinesStripped + 1
+		actualStartLine := singleSQL.BaseLine() + leadingNewlinesStripped + 1
 
 		node.SetOriginTextPosition(actualStartLine)
 		if n, ok := node.(*ast.CreateTableStmt); ok {

--- a/backend/plugin/parser/tokenizer/tokenizer.go
+++ b/backend/plugin/parser/tokenizer/tokenizer.go
@@ -232,8 +232,6 @@ func (t *Tokenizer) SplitTiDBMultiSQL() ([]base.Statement, error) {
 				if t.f == nil {
 					res = append(res, base.Statement{
 						Text: s,
-						// BaseLine is 0-based line number, so subtract 1 from 1-based startLine
-						BaseLine: startLine - 1,
 						Start: &store.Position{
 							Line:   int32(startLine),
 							Column: int32(startColumn),
@@ -273,8 +271,6 @@ func (t *Tokenizer) SplitTiDBMultiSQL() ([]base.Statement, error) {
 			if t.f == nil {
 				res = append(res, base.Statement{
 					Text: text,
-					// BaseLine is 0-based line number, so subtract 1 from 1-based startLine
-					BaseLine: startLine - 1,
 					Start: &store.Position{
 						Line:   int32(startLine),
 						Column: int32(startColumn),
@@ -310,8 +306,6 @@ func (t *Tokenizer) SplitTiDBMultiSQL() ([]base.Statement, error) {
 			if t.f == nil {
 				res = append(res, base.Statement{
 					Text: text,
-					// BaseLine is 0-based line number, so subtract 1 from 1-based startLine
-					BaseLine: startLine - 1,
 					Start: &store.Position{
 						Line:   int32(startLine),
 						Column: int32(startColumn),
@@ -420,8 +414,7 @@ func (t *Tokenizer) SplitStandardMultiSQL() ([]base.Statement, error) {
 			text := t.getString(startPos, t.pos()-startPos)
 			if t.f == nil {
 				res = append(res, base.Statement{
-					Text:     text,
-					BaseLine: firstStatementLine - 1, // 0-based line of first token
+					Text: text,
 					Start: &store.Position{
 						Line:   int32(firstStatementLine), // 1-based per proto spec
 						Column: int32(firstStatementColumn),
@@ -454,8 +447,7 @@ func (t *Tokenizer) SplitStandardMultiSQL() ([]base.Statement, error) {
 					// The cursor might be past all content (on blank lines or at EOF).
 					endLine := t.line - t.aboveNonBlankLineDistance()
 					res = append(res, base.Statement{
-						Text:     s,
-						BaseLine: firstStatementLine - 1, // 0-based line of first token
+						Text: s,
 						Start: &store.Position{
 							Line:   int32(firstStatementLine), // 1-based per proto spec
 							Column: int32(firstStatementColumn),

--- a/backend/plugin/parser/trino/split.go
+++ b/backend/plugin/parser/trino/split.go
@@ -104,8 +104,7 @@ func splitByParser(statement string) ([]base.Statement, error) {
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffsetStart)
 
 		result = append(result, base.Statement{
-			Text:     text,
-			BaseLine: startLine,
+			Text: text,
 			Range: &storepb.Range{
 				Start: int32(byteOffsetStart),
 				End:   int32(rangeEnd),

--- a/backend/plugin/parser/trino/trino.go
+++ b/backend/plugin/parser/trino/trino.go
@@ -27,7 +27,7 @@ func ParseTrino(sql string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		parseResult, err := parseSingleTrino(stmt.Text, stmt.BaseLine)
+		parseResult, err := parseSingleTrino(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/plugin/parser/tsql/split.go
+++ b/backend/plugin/parser/tsql/split.go
@@ -78,8 +78,7 @@ func splitByParser(statement string) ([]base.Statement, error) {
 			// Calculate start position from byte offset (first character of Text)
 			startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 			result = append(result, base.Statement{
-				Text:     stmtText,
-				BaseLine: tokens[start].GetLine() - 1,
+				Text: stmtText,
 				Range: &storepb.Range{
 					Start: int32(byteOffset),
 					End:   int32(byteOffset + stmtByteLength),
@@ -129,8 +128,7 @@ func splitByParser(statement string) ([]base.Statement, error) {
 				// Calculate start position from byte offset (first character of Text)
 				startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 				result = append(result, base.Statement{
-					Text:     stmtText,
-					BaseLine: tokens[start].GetLine() - 1,
+					Text: stmtText,
 					Range: &storepb.Range{
 						Start: int32(byteOffset),
 						End:   int32(byteOffset + stmtByteLength),
@@ -164,8 +162,7 @@ func splitByParser(statement string) ([]base.Statement, error) {
 			// Calculate start position from byte offset (first character of Text)
 			startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 			result = append(result, base.Statement{
-				Text:     stmtText,
-				BaseLine: tokens[start].GetLine() - 1,
+				Text: stmtText,
 				Range: &storepb.Range{
 					Start: int32(byteOffset),
 					End:   int32(byteOffset + stmtByteLength),
@@ -201,8 +198,7 @@ func splitBatchWithoutGo(b parser.IBatch_without_goContext, tokens []antlr.Token
 			// Calculate start position from byte offset (first character of Text)
 			startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 			result = append(result, base.Statement{
-				Text:     stmtText,
-				BaseLine: tokens[start].GetLine() - 1,
+				Text: stmtText,
 				Range: &storepb.Range{
 					Start: int32(byteOffset),
 					End:   int32(byteOffset + stmtByteLength),
@@ -228,8 +224,7 @@ func splitBatchWithoutGo(b parser.IBatch_without_goContext, tokens []antlr.Token
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -254,8 +249,7 @@ func splitBatchWithoutGo(b parser.IBatch_without_goContext, tokens []antlr.Token
 		// Calculate start position from byte offset (first character of Text)
 		startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 		result = append(result, base.Statement{
-			Text:     stmtText,
-			BaseLine: tokens[start].GetLine() - 1,
+			Text: stmtText,
 			Range: &storepb.Range{
 				Start: int32(byteOffset),
 				End:   int32(byteOffset + stmtByteLength),
@@ -280,8 +274,7 @@ func splitBatchWithoutGo(b parser.IBatch_without_goContext, tokens []antlr.Token
 			// Calculate start position from byte offset (first character of Text)
 			startLine, startColumn := base.CalculateLineAndColumn(statement, byteOffset)
 			result = append(result, base.Statement{
-				Text:     stmtText,
-				BaseLine: tokens[start].GetLine() - 1,
+				Text: stmtText,
 				Range: &storepb.Range{
 					Start: int32(byteOffset),
 					End:   int32(byteOffset + stmtByteLength),

--- a/backend/plugin/parser/tsql/tsql.go
+++ b/backend/plugin/parser/tsql/tsql.go
@@ -79,7 +79,7 @@ func ParseTSQL(sql string) ([]*base.ANTLRAST, error) {
 			continue
 		}
 
-		antlrAST, err := parseSingleTSQL(stmt.Text, stmt.BaseLine)
+		antlrAST, err := parseSingleTSQL(stmt.Text, stmt.BaseLine())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- Remove `BaseLine` field from `Statement` struct and replace it with a `BaseLine()` method that computes the value from `Start.Line - 1`
- This eliminates redundant data storage since `BaseLine` was always equal to `Start.Line - 1`
- The error line formula in advisor code remains functionally identical:
  - **Before**: `BaseLine + token.GetLine()` where `BaseLine` was stored as `Start.Line - 1`
  - **After**: `Start.GetLine() - 1 + token.GetLine()` (now computed via `BaseLine()` method)

## Changes
1. **`backend/plugin/parser/base/statement.go`**: Removed `BaseLine int` field, added `BaseLine()` method
2. **Parser split files**: Removed `BaseLine:` field initialization from all Statement struct literals
3. **All advisor and parser files**: Changed `.BaseLine` field access to `.BaseLine()` method call

## Test plan
- [x] Existing tests pass (`TestParsedStatementEmbedding`, `TestSplitMySQLStatements`)
- [x] Build succeeds
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)