### PR TITLE
feat: show ROLLOUT_CREATE as secondary action when conditions not met

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/rollout.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/rollout.ts
@@ -6,7 +6,18 @@ export const ROLLOUT_CREATE: ActionDefinition = {
   id: "ROLLOUT_CREATE",
   label: () => t("issue.create-rollout"),
   buttonType: "default",
-  category: "primary",
+  category: (ctx) => {
+    // Show as primary only when issue approved and plan checks done without errors
+    if (
+      ctx.issueApproved &&
+      !ctx.validation.planChecksRunning &&
+      !ctx.validation.planChecksFailed
+    ) {
+      return "primary";
+    }
+    // For force creating rollout, show as secondary
+    return "secondary";
+  },
   priority: 55,
 
   isVisible: (ctx) => {


### PR DESCRIPTION
Show the create rollout action as primary only when issue is approved and plan checks are done without errors. Otherwise show it in the dropdown as a secondary action for force creating rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)