### PR TITLE
fix(store): prevent HasSheets from modifying caller's slice

### DIFF
--- a/backend/store/sheet.go
+++ b/backend/store/sheet.go
@@ -159,6 +159,9 @@ func (s *Store) HasSheets(ctx context.Context, sha256Hexes ...string) (bool, err
 		return true, nil
 	}
 
+	// Make a copy before sorting to avoid modifying the caller's slice
+	sha256Hexes = slices.Clone(sha256Hexes)
+
 	// Remove duplicates
 	slices.Sort(sha256Hexes)
 	sha256Hexes = slices.Compact(sha256Hexes)


### PR DESCRIPTION
## Summary

- Fixed bug where `HasSheets` was sorting its input slice in-place via `slices.Sort(sha256Hexes)`
- When called with variadic argument (`sheetSha256s...`), the underlying slice got sorted, corrupting the mapping between release files and their sheet hashes
- This caused file versions and contents to become mismatched when lexicographical order differed from version order (e.g., v1, v10, v2)

## Root Cause

`slices.Sort` modifies slices in-place. When `CreateRelease` called `HasSheets(ctx, sheetSha256s...)`, the variadic argument passed the underlying slice which got sorted, destroying the original order needed for mapping files to their sheets.

## Fix

Added `sha256Hexes = slices.Clone(sha256Hexes)` before sorting to preserve the caller's slice order.

## Test plan

- [x] Added `FileContentVersionMatch` test case that uses files where lexicographical order differs from version order (v1, v10, v2 vs 1, 2, 10)
- [x] All existing tests pass
- [x] `golangci-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)