### PR TITLE
fix(frontend): make UserNameCell gap dynamic based on size prop

### DIFF
--- a/frontend/src/components/v2/Model/cells/UserNameCell.vue
+++ b/frontend/src/components/v2/Model/cells/UserNameCell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-row items-center gap-x-2">
+  <div class="flex flex-row items-center" :class="gapClass">
     <UserAvatar :user="user" :size="avatarSize" />
 
     <div class="flex flex-row items-center">
@@ -151,5 +151,12 @@ const avatarSize = computed(() => {
     default:
       return "NORMAL";
   }
+});
+
+const gapClass = computed(() => {
+  if (props.size === "tiny") {
+    return "gap-x-1";
+  }
+  return "gap-x-2";
 });
 </script>


### PR DESCRIPTION
Use gap-x-1 for tiny size and gap-x-2 for small/medium sizes, following the same pattern as tagSize and avatarSize computeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)