### PR TITLE
refactor(common): move Uniq to common package to reduce import cycles

### DIFF
--- a/backend/api/v1/project_service_converter.go
+++ b/backend/api/v1/project_service_converter.go
@@ -14,7 +14,6 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/store"
-	"github.com/bytebase/bytebase/backend/utils"
 )
 
 func convertToProtoAny(i any) (*anypb.Any, error) {
@@ -202,7 +201,7 @@ func convertToStoreIamPolicy(iamPolicy *v1pb.IamPolicy) (*storepb.IamPolicy, err
 
 	for _, binding := range iamPolicy.Bindings {
 		var members []string
-		for _, member := range utils.Uniq(binding.Members) {
+		for _, member := range common.Uniq(binding.Members) {
 			storeMember, err := convertToStoreIamPolicyMember(member)
 			if err != nil {
 				return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert iam member with error"))

--- a/backend/common/util.go
+++ b/backend/common/util.go
@@ -232,3 +232,19 @@ func IsNil(val any) bool {
 func NewP[T any](x T) *T {
 	return &x
 }
+
+// Uniq returns a new slice with duplicate elements removed, preserving order.
+func Uniq[T comparable](array []T) []T {
+	res := make([]T, 0, len(array))
+	seen := make(map[T]struct{}, len(array))
+
+	for _, e := range array {
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		res = append(res, e)
+	}
+
+	return res
+}

--- a/backend/store/sheet.go
+++ b/backend/store/sheet.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"slices"
 
 	"github.com/pkg/errors"
 
@@ -159,12 +158,8 @@ func (s *Store) HasSheets(ctx context.Context, sha256Hexes ...string) (bool, err
 		return true, nil
 	}
 
-	// Make a copy before sorting to avoid modifying the caller's slice
-	sha256Hexes = slices.Clone(sha256Hexes)
-
 	// Remove duplicates
-	slices.Sort(sha256Hexes)
-	sha256Hexes = slices.Compact(sha256Hexes)
+	sha256Hexes = common.Uniq(sha256Hexes)
 
 	q := qb.Q().Space(`
 		SELECT COUNT(*)

--- a/backend/utils/member.go
+++ b/backend/utils/member.go
@@ -246,7 +246,7 @@ func GetUserRolesInIamPolicy(ctx context.Context, stores *store.Store, user *sto
 			roles = append(roles, binding.Role)
 		}
 	}
-	roles = Uniq(roles)
+	roles = common.Uniq(roles)
 
 	return roles
 }

--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -197,21 +197,6 @@ func CheckDatabaseGroupMatch(ctx context.Context, expression string, database *s
 	return false, nil
 }
 
-func Uniq[T comparable](array []T) []T {
-	res := make([]T, 0, len(array))
-	seen := make(map[T]struct{}, len(array))
-
-	for _, e := range array {
-		if _, ok := seen[e]; ok {
-			continue
-		}
-		seen[e] = struct{}{}
-		res = append(res, e)
-	}
-
-	return res
-}
-
 // IsSpaceOrSemicolon checks if the rune is a space or a semicolon.
 func IsSpaceOrSemicolon(r rune) bool {
 	if ok := unicode.IsSpace(r); ok {


### PR DESCRIPTION
## Summary
- Move `Uniq` generic function from `backend/utils` to `backend/common` package
- `common` has fewer dependencies and is lower in the import hierarchy, reducing likelihood of import cycles
- Update `HasSheets` to use `common.Uniq` instead of `slices.Clone + slices.Sort + slices.Compact`

## Test plan
- [x] `golangci-lint run --allow-parallel-runners` passes
- [ ] Verify build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)