### PR TITLE
fix: use UI-provided AWS credentials in OpenSearch and DynamoDB drivers

### DIFF
--- a/backend/plugin/db/dynamodb/dynamodb.go
+++ b/backend/plugin/db/dynamodb/dynamodb.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/pkg/errors"
@@ -19,6 +18,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/plugin/db"
+	"github.com/bytebase/bytebase/backend/plugin/db/util"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
@@ -42,13 +42,13 @@ func newDriver() db.Driver {
 	return &Driver{}
 }
 
-// Open opens a BigQuery driver. It must connect to a specific database.
+// Open opens a DynamoDB driver. It must connect to a specific database.
 // If database isn't provided, part of the driver cannot function.
 func (d *Driver) Open(ctx context.Context, _ storepb.Engine, conf db.ConnectionConfig) (db.Driver, error) {
 	d.config = conf
 	d.connCtx = conf.ConnectionContext
 
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := util.GetAWSConnectionConfig(ctx, conf)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load AWS config")
 	}

--- a/backend/plugin/db/elasticsearch/elasticsearch.go
+++ b/backend/plugin/db/elasticsearch/elasticsearch.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/elastic/go-elasticsearch/v7"
 	opensearch "github.com/opensearch-project/opensearch-go/v4"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
@@ -243,10 +242,8 @@ func openWithOpenSearchClient(ctx context.Context, config db.ConnectionConfig, a
 			return nil, errors.New("region is required for AWS IAM authentication")
 		}
 
-		// Load AWS configuration
-		awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
-			awsconfig.WithRegion(config.DataSource.GetRegion()),
-		)
+		// Load AWS configuration (uses specific credentials from UI if provided, otherwise default chain)
+		awsCfg, err := util.GetAWSConnectionConfig(ctx, config)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to load AWS config")
 		}


### PR DESCRIPTION
## Summary
- Fix OpenSearch driver to use `util.GetAWSConnectionConfig()` instead of `awsconfig.LoadDefaultConfig()`
- Fix DynamoDB driver to use `util.GetAWSConnectionConfig()` instead of `config.LoadDefaultConfig()`

Both drivers were ignoring user-provided AWS credentials from the UI ("Specific Credential" option) and always using the default credential chain (environment variables, ~/.aws/credentials, EC2 instance role).

This change makes them consistent with PostgreSQL and MySQL drivers which already use the utility function.

## Test plan
- [x] Tested OpenSearch connection with specific AWS credentials in UI
- [x] Verified connection works after fix
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)