### PR TITLE
fix(oracle): fix schema sync generating DROP+CREATE for identical tables

### DIFF
--- a/backend/plugin/schema/oracle/get_database_metadata.go
+++ b/backend/plugin/schema/oracle/get_database_metadata.go
@@ -62,10 +62,9 @@ func GetDatabaseMetadata(schemaText string) (*storepb.DatabaseSchemaMetadata, er
 	}
 
 	// Create single schema for Oracle (Oracle uses schemas, not separate databases)
+	// Keep schema name empty if not specified - this matches sync.go behavior
+	// and allows proper schema diff comparison
 	schemaName := extractor.currentSchema
-	if schemaName == "" {
-		schemaName = "PUBLIC"
-	}
 
 	schema := &storepb.SchemaMetadata{
 		Name:              schemaName,


### PR DESCRIPTION
## Summary

- Fix Oracle schema sync incorrectly generating `DROP TABLE` + `CREATE TABLE` for identical tables
- Root cause: schema name mismatch between live DB sync (`""`) and SDL parser (`"PUBLIC"`)
- The differ saw these as different schemas, resulting in drop/recreate instead of no-op or ALTER

## Problem

Customer reported that Oracle schema sync generates incorrect DDL:
```sql
-- Generated (wrong):
DROP TABLE "表1";
CREATE TABLE "PUBLIC"."表1" (...);

-- Expected (for identical tables):
(no DDL)

-- Expected (for changes):
ALTER TABLE "表1" ADD/MODIFY xxx
```

## Root Cause

```
Source (sync.go:132)     →  Schema.Name = ""
Target (SDL parser)      →  Schema.Name = "PUBLIC"  (converted from "")

differ.go comparison:
  - Schema "" not in target → DROP all tables
  - Schema "PUBLIC" not in source → CREATE all tables
```

## Fix

Remove the `"PUBLIC"` fallback in `get_database_metadata.go`. The DDL generation already handles empty schema names correctly (25+ places with `if schema != ""` checks).

## Test plan

- [x] All 50+ Oracle schema tests pass
- [x] Lint passes
- [ ] Manual verification with Oracle database

🤖 Generated with [Claude Code](https://claude.com/claude-code)