### PR TITLE
chore: add `rollouts.create` permission to project releaser role

### DIFF
--- a/backend/component/iam/acl.yaml
+++ b/backend/component/iam/acl.yaml
@@ -380,6 +380,7 @@ roles:
       - bb.releases.list
       - bb.revisions.get
       - bb.revisions.list
+      - bb.rollouts.create
       - bb.rollouts.get
       - bb.rollouts.list
       - bb.sheets.get


### PR DESCRIPTION
Part of BYT-8641