### PR TITLE
chore(frontend): use JSON format for gRPC in development mode

### DIFF
--- a/frontend/src/connect/index.ts
+++ b/frontend/src/connect/index.ts
@@ -32,12 +32,13 @@ import {
   errorNotificationInterceptor,
   activeInterceptor,
 } from "./middlewares";
+import { isDev } from "@/utils";
 
 const address = import.meta.env.BB_GRPC_LOCAL || window.location.origin;
 
 const transport = createConnectTransport({
   baseUrl: address,
-  useBinaryFormat: true,
+  useBinaryFormat: isDev() ? false : true,
   interceptors: [
     authInterceptor,
     activeInterceptor,


### PR DESCRIPTION
Use JSON format instead of binary for Connect transport in development mode to make debugging easier with human-readable request/response data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)