### PR TITLE
fix(frontend): fix InstanceSyncButton dropdown not opening

### DIFF
--- a/frontend/src/components/Instance/InstanceSyncButton.vue
+++ b/frontend/src/components/Instance/InstanceSyncButton.vue
@@ -1,14 +1,14 @@
 <template>
-  <NDropdown
-    :trigger="'click'"
-    :options="syncInstnceOptions"
-    :render-label="renderDropdownLabel"
-    :disabled="disabled || syncingSchema"
-    @select="syncSchema"
+  <PermissionGuardWrapper
+    v-slot="slotProps"
+    :permissions="['bb.instances.sync']"
   >
-    <PermissionGuardWrapper
-      v-slot="slotProps"
-      :permissions="['bb.instances.sync']"
+    <NDropdown
+      :trigger="'click'"
+      :options="syncInstnceOptions"
+      :render-label="renderDropdownLabel"
+      :disabled="slotProps.disabled || disabled || syncingSchema"
+      @select="syncSchema"
     >
       <NButton
         icon-placement="right"
@@ -28,8 +28,8 @@
           {{ $t("instance.sync.self") }}
         </template>
       </NButton>
-    </PermissionGuardWrapper>
-  </NDropdown>
+    </NDropdown>
+  </PermissionGuardWrapper>
 </template>
 
 <script lang="tsx" setup>


### PR DESCRIPTION
Move PermissionGuardWrapper outside NDropdown to prevent NTooltip from intercepting click events that trigger the dropdown menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)