### PR TITLE
feat(helm-chart): add service account option

### DIFF
--- a/helm-charts/bytebase/templates/_helpers.tpl
+++ b/helm-charts/bytebase/templates/_helpers.tpl
@@ -24,3 +24,14 @@ Selector labels
 {{- define "bytebase.selectorLabels" -}}
 app: bytebase
 {{- end }}
+
+{{/*
+Create the name of the general service account
+*/}}
+{{- define "bytebase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default ("bytebase") .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/bytebase/templates/serviceaccount.yaml
+++ b/helm-charts/bytebase/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "bytebase.serviceAccountName" . }}
+  labels:
+    {{- include "bytebase.labels" . | nindent 4}}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm-charts/bytebase/templates/statefulset.yaml
+++ b/helm-charts/bytebase/templates/statefulset.yaml
@@ -45,6 +45,7 @@ spec:
       labels:
         app: bytebase
     spec:
+      serviceAccountName: {{ template "bytebase.serviceAccountName" . }}
       {{- if $externalPgEscapePgPassword }}
       # If user specify the externalPgEscapePgPassword, we should escape the password in the PG_URL in the shell,
       # because the password may comes from a secret, which is invisible in helm.

--- a/helm-charts/bytebase/values.yaml
+++ b/helm-charts/bytebase/values.yaml
@@ -93,3 +93,13 @@ bytebase:
   #   operator: "Equal"
   #   value: "value"
   #   effect: "NoSchedule"
+
+# Service account configuration
+# ref: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # -- Whether to create a service account or not. In case 'create' is false, do set 'name' to an existing service account name.
+  create: true
+  # -- Override for the generated service account name.
+  name:
+  annotations: {}
+  labels: {}


### PR DESCRIPTION
Improves security of system by allowing use of service accounts within kubernetes.

The current way that a RDS - IAM works is very challenging to operate securely without a service account on the charts. 

This PR adds a bog-standard serviceaccount implementation. 