### PR TITLE
fix(i18n): change translation of "close" to more natural Japanese

### DIFF
--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1058,7 +1058,7 @@
       "reopened": "再開",
       "action-n-issues": "{action} {n} 個のイシュー",
       "closed": "閉まっている",
-      "close": "近い"
+      "close": "閉じる"
     },
     "approval-flow": {
       "self": "承認の流れ",


### PR DESCRIPTION
## About

- "近い" has the meaning of "near" (like physical proximity)
