### PR TITLE
docs: allow input mongodb password interactively instead of using clear text

### DIFF
--- a/frontend/src/components/InstanceForm/DataSourceSection/CreateDataSourceExample.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/CreateDataSourceExample.vue
@@ -557,7 +557,7 @@ GRANT ALL PRIVILEGES ON PIPE {{PIPE_NAME}} IN DATABASE {{YOUR_DB_NAME}} TO ROLE 
         return `use admin;
 db.createUser({
   user: "${DATASOURCE_READONLY_USER_NAME}",
-  pwd: "YOUR_DB_PWD",
+  pwd: passwordPrompt(),
   roles: [
     {role: "readAnyDatabase", db: "admin"}
   ]


### PR DESCRIPTION
In the MongoDB CLI, every entered command is recorded similarly to a Bash history. By entering passwords interactively, we can prevent them from being exposed to others.

<img width="1076" height="868" alt="CleanShot 2026-01-08 at 14 04 54@2x" src="https://github.com/user-attachments/assets/2afe290f-ef97-4798-b186-adc5268f416b" />
