### PR TITLE
fix(frontend): show Create Rollout as primary button when issue approved

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/rollout.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/rollout.ts
@@ -6,18 +6,7 @@ export const ROLLOUT_CREATE: ActionDefinition = {
   id: "ROLLOUT_CREATE",
   label: () => t("issue.create-rollout"),
   buttonType: "default",
-  category: (ctx) => {
-    // Show as primary only when issue approved and plan checks done without errors
-    if (
-      ctx.issueApproved &&
-      !ctx.validation.planChecksRunning &&
-      !ctx.validation.planChecksFailed
-    ) {
-      return "primary";
-    }
-    // For force creating rollout, show as secondary
-    return "secondary";
-  },
+  category: (ctx) => (ctx.issueApproved ? "primary" : "secondary"),
   priority: 55,
 
   isVisible: (ctx) => {


### PR DESCRIPTION
Previously the Create Rollout button only showed as primary when issue was approved AND plan checks were complete without errors. Now it shows as primary whenever the issue is approved or skipped, regardless of plan check status.

Part of BYT-8643