### PR TITLE
fix(frontend): issue preset buttons not working on first click

### DIFF
--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -135,15 +135,9 @@ const fetchIssueList = async ({
   };
 };
 
-// Skip the first watch trigger since PagedTable already fetches on mount
-let isFirstFilterWatch = true;
 watch(
   () => JSON.stringify(mergedIssueFilter.value),
   () => {
-    if (isFirstFilterWatch) {
-      isFirstFilterWatch = false;
-      return;
-    }
     issuePagedTable.value?.refresh();
   }
 );


### PR DESCRIPTION
Close BYT-8661

The isFirstFilterWatch flag was intended to skip a "mount trigger" to prevent double-fetching, but Vue's watch() without immediate:true doesn't trigger on mount. The flag was actually skipping the first real user interaction, causing preset buttons like "All" to not work on first click.