### PR TITLE
refactor(frontend): simplify TaskRunLogViewer API and improve data fetching

### DIFF
--- a/frontend/src/components/RolloutV1/components/LatestTaskRunInfo.vue
+++ b/frontend/src/components/RolloutV1/components/LatestTaskRunInfo.vue
@@ -50,9 +50,8 @@
 
     <!-- Line 2: Task run logs -->
     <TaskRunLogViewer
-      v-if="summary.entries.length > 0"
-      :entries="summary.entries"
-      :sheet="sheet"
+      v-if="taskRunName && summary.entries.length > 0"
+      :task-run-name="taskRunName"
     />
   </div>
 </template>
@@ -74,7 +73,6 @@ import { computed, h } from "vue";
 import { useI18n } from "vue-i18n";
 import Timestamp from "@/components/misc/Timestamp.vue";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
-import type { Sheet } from "@/types/proto-es/v1/sheet_service_pb";
 import type { TaskRunLogSummary } from "./composables/useTaskRunLogSummary";
 import { TaskRunLogViewer } from "./TaskRunLogViewer";
 
@@ -154,12 +152,11 @@ const STATUS_CONFIG: Record<Task_Status, StatusConfig> = {
 const props = defineProps<{
   status: Task_Status;
   updateTime?: TimestampType;
-  sheet?: Sheet;
+  taskRunName?: string;
   executorEmail?: string;
   duration?: string;
   affectedRowsDisplay?: string;
   summary: TaskRunLogSummary;
-  taskName?: string;
 }>();
 
 const { t } = useI18n();

--- a/frontend/src/components/RolloutV1/components/TaskItem.vue
+++ b/frontend/src/components/RolloutV1/components/TaskItem.vue
@@ -194,12 +194,11 @@
           v-if="latestTaskRun"
           :status="task.status"
           :update-time="latestTaskRun.updateTime"
-          :sheet="taskSheet"
+          :task-run-name="latestTaskRun.name"
           :executor-email="executorEmail"
           :duration="timingType !== 'scheduled' ? timingDisplay : undefined"
           :affected-rows-display="affectedRowsDisplay"
           :summary="taskRunLogSummary"
-          :task-name="task.name"
         />
       </div>
     </div>
@@ -238,7 +237,7 @@ import { usePlanContextWithRollout } from "@/components/Plan";
 import DatabaseDisplay from "@/components/Plan/components/common/DatabaseDisplay.vue";
 import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
 import { PROJECT_V1_ROUTE_PLAN_ROLLOUT_TASK } from "@/router/dashboard/projectV1";
-import { taskRunNamePrefix, useSheetV1Store } from "@/store";
+import { taskRunNamePrefix } from "@/store";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import {
@@ -249,7 +248,6 @@ import {
   extractTaskUID,
   isReleaseBasedTask,
   releaseNameOfTaskV1,
-  sheetNameOfTaskV1,
 } from "@/utils";
 import { useTaskActions } from "./composables/useTaskActions";
 import { useTaskDisplay } from "./composables/useTaskDisplay";
@@ -334,14 +332,6 @@ const { loading, displayedStatement, isStatementTruncated } = useTaskStatement(
   () => props.task,
   () => props.isExpanded
 );
-
-// Get sheet for extracting individual commands in log display
-const sheetStore = useSheetV1Store();
-const taskSheet = computed(() => {
-  const sheetName = sheetNameOfTaskV1(props.task);
-  if (!sheetName) return undefined;
-  return sheetStore.getSheetByName(sheetName);
-});
 
 const latestTaskRun = computed(() => {
   const taskRunsForTask = allTaskRuns.value.filter((run) =>

--- a/frontend/src/components/RolloutV1/components/TaskRunLogViewer/TaskRunLogViewer.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRunLogViewer/TaskRunLogViewer.vue
@@ -215,16 +215,19 @@ import {
   ListIcon,
   ServerIcon,
 } from "lucide-vue-next";
-import type { TaskRunLogEntry } from "@/types/proto-es/v1/rollout_service_pb";
-import type { Sheet } from "@/types/proto-es/v1/sheet_service_pb";
 import SectionContent from "./SectionContent.vue";
 import SectionHeader from "./SectionHeader.vue";
+import { useTaskRunLogData } from "./useTaskRunLogData";
 import { useTaskRunLogSections } from "./useTaskRunLogSections";
 
 const props = defineProps<{
-  entries: TaskRunLogEntry[];
-  sheet?: Sheet;
+  taskRunName: string;
 }>();
+
+// Fetch task run log entries and sheets internally
+const { entries, sheet, sheetsMap } = useTaskRunLogData(
+  () => props.taskRunName
+);
 
 const {
   sections,
@@ -244,8 +247,9 @@ const {
   totalSections,
   totalEntries,
 } = useTaskRunLogSections(
-  () => props.entries,
-  () => props.sheet
+  () => entries.value,
+  () => sheet.value,
+  () => sheetsMap.value
 );
 
 const toggleExpandAll = () => {

--- a/frontend/src/components/RolloutV1/components/TaskRunLogViewer/index.ts
+++ b/frontend/src/components/RolloutV1/components/TaskRunLogViewer/index.ts
@@ -1,3 +1,2 @@
 export { default as TaskRunLogViewer } from "./TaskRunLogViewer.vue";
 export * from "./types";
-export * from "./useTaskRunLogSections";

--- a/frontend/src/components/RolloutV1/components/TaskRunLogViewer/useTaskRunLogData.ts
+++ b/frontend/src/components/RolloutV1/components/TaskRunLogViewer/useTaskRunLogData.ts
@@ -1,0 +1,165 @@
+import { create } from "@bufbuild/protobuf";
+import { computedAsync } from "@vueuse/core";
+import type { MaybeRefOrGetter, Ref } from "vue";
+import { computed, ref, toValue, watch } from "vue";
+import {
+  rolloutServiceClientConnect,
+  sheetServiceClientConnect,
+} from "@/connect";
+import { useReleaseStore, useRolloutByName } from "@/store";
+import {
+  GetTaskRunLogRequestSchema,
+  type TaskRunLogEntry,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import type { Sheet } from "@/types/proto-es/v1/sheet_service_pb";
+import {
+  extractRolloutNameFromTaskRunName,
+  extractTaskNameFromTaskRunName,
+  isReleaseBasedTask,
+  releaseNameOfTaskV1,
+  sheetNameOfTaskV1,
+} from "@/utils";
+
+export interface UseTaskRunLogDataReturn {
+  entries: Ref<TaskRunLogEntry[]>;
+  sheet: Ref<Sheet | undefined>;
+  sheetsMap: Ref<Map<string, Sheet>>;
+}
+
+/**
+ * Composable that fetches task run log entries and associated sheets.
+ * Handles both regular tasks (single sheet) and release tasks (multiple sheets by version).
+ */
+export const useTaskRunLogData = (
+  taskRunName: MaybeRefOrGetter<string | undefined>
+): UseTaskRunLogDataReturn => {
+  const releaseStore = useReleaseStore();
+
+  // Sheet for non-release tasks
+  const sheet = ref<Sheet | undefined>(undefined);
+  // Map of version -> Sheet for release tasks
+  const sheetsMap = ref<Map<string, Sheet>>(new Map());
+
+  // Fetch task run log entries
+  const taskRunLog = computedAsync(async () => {
+    const name = toValue(taskRunName);
+    if (!name) return undefined;
+    const request = create(GetTaskRunLogRequestSchema, {
+      parent: name,
+    });
+    return await rolloutServiceClientConnect.getTaskRunLog(request);
+  }, undefined);
+
+  const entries = computed(() => taskRunLog.value?.entries ?? []);
+
+  // Extract rollout name from task run name to get the task
+  const rolloutName = computed(() => {
+    const name = toValue(taskRunName);
+    if (!name) return "";
+    return extractRolloutNameFromTaskRunName(name);
+  });
+
+  const { rollout } = useRolloutByName(rolloutName);
+
+  // Find the task from the rollout
+  const task = computed(() => {
+    const name = toValue(taskRunName);
+    if (!name || !rollout.value) return undefined;
+
+    const taskName = extractTaskNameFromTaskRunName(name);
+    if (!taskName) return undefined;
+
+    for (const stage of rollout.value.stages) {
+      const foundTask = stage.tasks.find((t) => t.name === taskName);
+      if (foundTask) return foundTask;
+    }
+    return undefined;
+  });
+
+  // Track fetch version to handle race conditions
+  let fetchVersion = 0;
+
+  // Fetch sheet(s) based on task type
+  watch(
+    task,
+    async (currentTask) => {
+      const currentFetchVersion = ++fetchVersion;
+
+      if (!currentTask) {
+        sheet.value = undefined;
+        sheetsMap.value = new Map();
+        return;
+      }
+
+      if (isReleaseBasedTask(currentTask)) {
+        // Release task: fetch release and build sheets map by version
+        const releaseName = releaseNameOfTaskV1(currentTask);
+        if (!releaseName) return;
+
+        try {
+          const release = await releaseStore.fetchReleaseByName(
+            releaseName,
+            true
+          );
+          // Abort if a newer fetch has started
+          if (currentFetchVersion !== fetchVersion) return;
+
+          // Fetch all sheets in parallel
+          const filesToFetch = release.files.filter(
+            (f) => f.sheet && f.version
+          );
+          const sheetPromises = filesToFetch.map(async (file) => {
+            try {
+              const fetchedSheet = await sheetServiceClientConnect.getSheet({
+                name: file.sheet,
+                raw: true,
+              });
+              return { version: file.version, sheet: fetchedSheet };
+            } catch {
+              return null;
+            }
+          });
+
+          const results = await Promise.all(sheetPromises);
+          // Abort if a newer fetch has started
+          if (currentFetchVersion !== fetchVersion) return;
+
+          const newSheetsMap = new Map<string, Sheet>();
+          for (const result of results) {
+            if (result?.sheet) {
+              newSheetsMap.set(result.version, result.sheet);
+            }
+          }
+          sheetsMap.value = newSheetsMap;
+        } catch {
+          // Ignore release fetch errors
+        }
+      } else {
+        // Non-release task: fetch single sheet
+        const sheetName = sheetNameOfTaskV1(currentTask);
+        if (!sheetName) return;
+
+        try {
+          const fetchedSheet = await sheetServiceClientConnect.getSheet({
+            name: sheetName,
+            raw: true,
+          });
+          // Abort if a newer fetch has started
+          if (currentFetchVersion !== fetchVersion) return;
+          sheet.value = fetchedSheet;
+        } catch {
+          if (currentFetchVersion === fetchVersion) {
+            sheet.value = undefined;
+          }
+        }
+      }
+    },
+    { immediate: true }
+  );
+
+  return {
+    entries,
+    sheet,
+    sheetsMap,
+  };
+};

--- a/frontend/src/utils/v1/issue/rollout.ts
+++ b/frontend/src/utils/v1/issue/rollout.ts
@@ -79,6 +79,30 @@ export const extractTaskRunUID = (name: string) => {
   return matches?.[1] ?? "";
 };
 
+/**
+ * Extracts the rollout resource name from a task run resource name.
+ * Task run name format: projects/{project}/plans/{plan}/rollout/stages/{stage}/tasks/{task}/taskRuns/{taskRun}
+ * Returns: projects/{project}/plans/{plan}/rollout
+ */
+export const extractRolloutNameFromTaskRunName = (
+  taskRunName: string
+): string => {
+  const pattern = /^(projects\/[^/]+\/plans\/[^/]+\/rollout)\/stages\//;
+  const matches = taskRunName.match(pattern);
+  return matches?.[1] ?? "";
+};
+
+/**
+ * Extracts the task resource name from a task run resource name.
+ * Task run name format: projects/{project}/plans/{plan}/rollout/stages/{stage}/tasks/{task}/taskRuns/{taskRun}
+ * Returns: projects/{project}/plans/{plan}/rollout/stages/{stage}/tasks/{task}
+ */
+export const extractTaskNameFromTaskRunName = (taskRunName: string): string => {
+  const idx = taskRunName.lastIndexOf("/taskRuns/");
+  if (idx === -1) return "";
+  return taskRunName.substring(0, idx);
+};
+
 export const stageV1Slug = (stage: Stage): string => {
   // Stage UID is now the environment ID
   return extractStageUID(stage.name);


### PR DESCRIPTION
Close BYT-8653

- TaskRunLogViewer now only accepts taskRunName prop and fetches data internally
- Add useTaskRunLogData composable for centralized data fetching with:
  - Parallel sheet fetching for release tasks (performance improvement)
  - Race condition handling to prevent stale data
- Improve useTaskRunLogSections with explicit data flow instead of closure-based access
- Add extractRolloutNameFromTaskRunName/extractTaskNameFromTaskRunName utilities
- Simplify consumers (ChangelogDetail, RevisionDetailPanel, LatestTaskRunInfo)