### PR TITLE
feat(frontend): show command duration in TaskRunLogViewer

### DIFF
--- a/frontend/src/components/RolloutV1/components/TaskRunLogViewer/SectionContent.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRunLogViewer/SectionContent.vue
@@ -29,11 +29,13 @@
         <span :class="item.detailClass" class="break-all">
           {{ item.detail }}
         </span>
-        <span
-          v-if="item.affectedRows !== undefined"
-          class="text-gray-400 shrink-0 ml-auto"
-        >
-          {{ item.affectedRows }} rows
+        <span class="shrink-0 ml-auto flex items-center gap-x-2">
+          <span v-if="item.duration" class="text-blue-500 tabular-nums">
+            {{ item.duration }}
+          </span>
+          <span v-if="item.affectedRows !== undefined" class="text-gray-400">
+            {{ item.affectedRows }} rows
+          </span>
         </span>
       </div>
     </template>

--- a/frontend/src/components/RolloutV1/components/TaskRunLogViewer/TaskRunLogViewer.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRunLogViewer/TaskRunLogViewer.vue
@@ -18,6 +18,9 @@
             })
           }}
         </span>
+        <span v-if="totalDuration" class="text-blue-500 tabular-nums">
+          {{ totalDuration }}
+        </span>
       </div>
 
       <!-- Right: Expand/Collapse toggle button -->
@@ -246,6 +249,7 @@ const {
   areAllExpanded,
   totalSections,
   totalEntries,
+  totalDuration,
 } = useTaskRunLogSections(
   () => entries.value,
   () => sheet.value,

--- a/frontend/src/components/RolloutV1/components/TaskRunLogViewer/types.ts
+++ b/frontend/src/components/RolloutV1/components/TaskRunLogViewer/types.ts
@@ -12,6 +12,7 @@ export interface DisplayItem {
   detail: string;
   detailClass: string;
   affectedRows?: number;
+  duration?: string;
 }
 
 export interface Section {

--- a/frontend/src/components/RolloutV1/components/TaskRunLogViewer/utils.ts
+++ b/frontend/src/components/RolloutV1/components/TaskRunLogViewer/utils.ts
@@ -26,6 +26,7 @@ export const formatTime = (ts: PbTimestamp | undefined): string => {
 };
 
 export const formatDuration = (ms: number): string => {
+  if (ms < 1) return "<1ms";
   if (ms < 1000) return `${ms.toFixed(0)}ms`;
   if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
   const mins = Math.floor(ms / 60000);


### PR DESCRIPTION
Close BYT-8649

- Add duration display for each command entry (using commandExecute.logTime to commandExecute.response.logTime)
- Add total duration in summary stats toolbar
- Add duration display in section headers
- Show "<1ms" for durations less than 1ms
- Use actual operation start/end times for accurate duration calculation

<img width="1470" height="558" alt="image" src="https://github.com/user-attachments/assets/a7692302-8784-4500-b9ef-826a423dbf7c" />
