### PR TITLE
feat(frontend): add revision routes and polish UI to match changelog

### DIFF
--- a/frontend/src/components/Database/DatabaseRevisionPanel.vue
+++ b/frontend/src/components/Database/DatabaseRevisionPanel.vue
@@ -17,8 +17,7 @@
           :loading="loading"
           :revisions="list"
           :show-selection="true"
-          :custom-click="true"
-          @row-click="(name) => (selectedRevisionName = name)"
+          @delete="refreshList"
         />
       </template>
     </PagedTable>
@@ -30,31 +29,14 @@
     :database="database.name"
     @created="handleRevisionCreated"
   />
-
-  <Drawer
-    :show="!!selectedRevisionName"
-    @close="selectedRevisionName = undefined"
-  >
-    <DrawerContent
-      style="width: 75vw; max-width: calc(100vw - 8rem)"
-      :title="$t('common.detail')"
-    >
-      <RevisionDetailPanel
-        v-if="selectedRevisionName"
-        :database="database"
-        :revision-name="selectedRevisionName"
-      />
-    </DrawerContent>
-  </Drawer>
 </template>
 
 <script lang="ts" setup>
 import { create } from "@bufbuild/protobuf";
 import { NButton } from "naive-ui";
 import { ref } from "vue";
-import { RevisionDataTable, RevisionDetailPanel } from "@/components/Revision";
+import { RevisionDataTable } from "@/components/Revision";
 import CreateRevisionDrawer from "@/components/Revision/CreateRevisionDrawer.vue";
-import { Drawer, DrawerContent } from "@/components/v2";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
 import { revisionServiceClientConnect } from "@/connect";
 import type { ComposedDatabase } from "@/types";
@@ -67,7 +49,6 @@ const props = defineProps<{
 
 const { pagedRevisionTableSessionKey } = useDatabaseDetailContext();
 const showCreateRevisionDrawer = ref(false);
-const selectedRevisionName = ref<string>();
 
 const fetchRevisionList = async ({
   pageToken,
@@ -91,9 +72,10 @@ const fetchRevisionList = async ({
 
 const handleRevisionCreated = () => {
   showCreateRevisionDrawer.value = false;
+  refreshList();
+};
 
-  // Refresh the revision list to show the newly created revision
-  // The PagedTable component will automatically refresh when we trigger it
-  pagedRevisionTableSessionKey.value = `${pagedRevisionTableSessionKey.value}-refresh-${Date.now()}`;
+const refreshList = () => {
+  pagedRevisionTableSessionKey.value = `bb.paged-revision-table.${Date.now()}`;
 };
 </script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1764,7 +1764,6 @@
     "engine-not-supported-for-backup": "Prior backup is not supported for: {databases}",
     "revision": {
       "self": "Revision",
-      "applied-at": "Applied at",
       "filename": "Filename",
       "import-revision": "Import Revision",
       "select-source": "Select Source",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1764,7 +1764,6 @@
     "engine-not-supported-for-backup": "No se admite la copia de seguridad previa para: {databases}",
     "revision": {
       "self": "Revisión",
-      "applied-at": "Aplicado en",
       "filename": "Nombre del archivo",
       "import-revision": "Revisión de importación",
       "select-source": "Seleccionar fuente",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1764,7 +1764,6 @@
     "engine-not-supported-for-backup": "以前のバックアップはサポートされていません: {databases}",
     "revision": {
       "self": "リビジョン",
-      "applied-at": "申請先",
       "filename": "ファイル名",
       "import-revision": "インポートリビジョン",
       "select-source": "ソースを選択",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1764,7 +1764,6 @@
     "engine-not-supported-for-backup": "Sao lưu trước đó không được hỗ trợ cho: {databases}",
     "revision": {
       "self": "Bản sửa đổi",
-      "applied-at": "Đã áp dụng vào",
       "filename": "Tên tệp",
       "import-revision": "Nhập bản sửa đổi",
       "select-source": "Chọn nguồn",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1764,7 +1764,6 @@
     "engine-not-supported-for-backup": "引擎不支持预备份：{databases}",
     "revision": {
       "self": "版本",
-      "applied-at": "应用时间",
       "filename": "文件名",
       "import-revision": "导入版本",
       "select-source": "选择来源",

--- a/frontend/src/router/dashboard/projectV1.ts
+++ b/frontend/src/router/dashboard/projectV1.ts
@@ -9,6 +9,7 @@ export const PROJECT_V1_ROUTE_MASKING_EXEMPTION = `${PROJECT_V1_ROUTE_DASHBOARD}
 export const PROJECT_V1_ROUTE_MASKING_EXEMPTION_CREATE = `${PROJECT_V1_ROUTE_DASHBOARD}.masking-exemption.create`;
 export const PROJECT_V1_ROUTE_DATABASE_DETAIL = `${PROJECT_V1_ROUTE_DASHBOARD}.database.detail`;
 export const PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL = `${PROJECT_V1_ROUTE_DASHBOARD}.database.changelog.detail`;
+export const PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL = `${PROJECT_V1_ROUTE_DASHBOARD}.database.revision.detail`;
 export const PROJECT_V1_ROUTE_DATABASE_GROUPS = `${PROJECT_V1_ROUTE_DASHBOARD}.database-group`;
 export const PROJECT_V1_ROUTE_DATABASE_GROUPS_CREATE = `${PROJECT_V1_ROUTE_DASHBOARD}.database-group.create`;
 export const PROJECT_V1_ROUTE_DATABASE_GROUP_DETAIL = `${PROJECT_V1_ROUTE_DASHBOARD}.database-group.detail`;
@@ -390,6 +391,22 @@ const projectV1Routes: RouteRecordRaw[] = [
               instance: `instances/${route.params.instanceId}`,
               database: `instances/${route.params.instanceId}/databases/${route.params.databaseName}`,
               changelogId: route.params.changelogId,
+            }),
+          },
+          {
+            path: "revisions/:revisionId",
+            name: PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
+            meta: {
+              requiredPermissionList: () => ["bb.databases.get"],
+            },
+            component: () =>
+              import("@/views/DatabaseDetail/RevisionDetail.vue"),
+            props: (route) => ({
+              ...route.params,
+              project: `projects/${route.params.projectId}`,
+              instance: `instances/${route.params.instanceId}`,
+              database: `instances/${route.params.instanceId}/databases/${route.params.databaseName}`,
+              revisionId: route.params.revisionId,
             }),
           },
         ],

--- a/frontend/src/utils/v1/index.ts
+++ b/frontend/src/utils/v1/index.ts
@@ -12,6 +12,7 @@ export * from "./sheet";
 export * from "./worksheet";
 export * from "./issue";
 export * from "./changelog";
+export * from "./revision";
 export * from "./cel";
 export * from "./advanced-search";
 export * from "./iam";

--- a/frontend/src/utils/v1/revision.ts
+++ b/frontend/src/utils/v1/revision.ts
@@ -1,0 +1,42 @@
+import { t } from "@/plugins/i18n";
+import { useDatabaseV1Store } from "@/store";
+import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
+import { Revision_Type } from "@/types/proto-es/v1/revision_service_pb";
+import { databaseV1Url, extractDatabaseResourceName } from "./database";
+
+export const extractRevisionUID = (name: string): string => {
+  const pattern = /(?:^|\/)revisions\/([^/]+)(?:$|\/)/;
+  const matches = name.match(pattern);
+  return matches?.[1] ?? "";
+};
+
+export const revisionLink = (revision: Revision): string => {
+  const parts = revision.name.split("/revisions/");
+  if (parts.length !== 2) {
+    return "";
+  }
+  const { database } = extractDatabaseResourceName(revision.name);
+  const composedDatabase = useDatabaseV1Store().getDatabaseByName(database);
+  return `${databaseV1Url(composedDatabase)}/revisions/${parts[1]}`;
+};
+
+export const getRevisionType = (type: Revision_Type): string => {
+  switch (type) {
+    case Revision_Type.VERSIONED:
+      return t("database.revision.type-versioned");
+    case Revision_Type.DECLARATIVE:
+      return t("database.revision.type-declarative");
+    default:
+      return "-";
+  }
+};
+
+// Extract task link from taskRun resource name
+// e.g., "projects/xxx/rollouts/yyy/stages/zzz/tasks/aaa/taskRuns/bbb" -> "/projects/xxx/rollouts/yyy/stages/zzz/tasks/aaa"
+export const extractTaskLink = (taskRunName: string): string => {
+  const parts = taskRunName.split("/taskRuns/");
+  if (parts.length !== 2) {
+    return "";
+  }
+  return `/${parts[0]}`;
+};

--- a/frontend/src/views/DatabaseDetail/RevisionDetail.vue
+++ b/frontend/src/views/DatabaseDetail/RevisionDetail.vue
@@ -1,0 +1,46 @@
+<template>
+  <NBreadcrumb class="mb-4">
+    <NBreadcrumbItem @click="router.push(`/${props.project}/databases`)">
+      {{ $t("common.databases") }}
+    </NBreadcrumbItem>
+    <NBreadcrumbItem @click="router.push(databaseV1Url(database))">
+      {{ database.databaseName }}
+    </NBreadcrumbItem>
+    <NBreadcrumbItem
+      @click="router.push(`${databaseV1Url(database)}#revision`)"
+    >
+      {{ $t("database.revision.self") }}
+    </NBreadcrumbItem>
+    <NBreadcrumbItem :clickable="false">
+      {{ revisionId }}
+    </NBreadcrumbItem>
+  </NBreadcrumb>
+  <RevisionDetailView
+    v-if="ready"
+    :database="database"
+    :revision-name="`${database.name}/revisions/${revisionId}`"
+  />
+  <div v-else class="flex justify-center items-center py-10">
+    <BBSpin />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { NBreadcrumb, NBreadcrumbItem } from "naive-ui";
+import { useRouter } from "vue-router";
+import { BBSpin } from "@/bbkit";
+import { RevisionDetailPanel as RevisionDetailView } from "@/components/Revision";
+import { useDatabaseV1ByName } from "@/store";
+import { databaseV1Url } from "@/utils";
+
+const props = defineProps<{
+  project: string;
+  instance: string;
+  database: string;
+  revisionId: string;
+}>();
+
+const router = useRouter();
+
+const { database, ready } = useDatabaseV1ByName(props.database);
+</script>


### PR DESCRIPTION
- Add dedicated route for revision detail page (/revisions/:revisionId)
- Add revision utility functions (revisionLink, getRevisionType, extractTaskLink)
- Polish RevisionDetailPanel UI to match ChangelogDetail style:
  - Styled version title with metadata row
  - Task run logs section with "show more" link
  - Statement section with size display
- Update RevisionDataTable to use router navigation and emit selection changes

Closes BYT-8671