### PR TITLE
feat: add 'no approval required' option for approval rules

### DIFF
--- a/backend/api/v1/setting_service.go
+++ b/backend/api/v1/setting_service.go
@@ -683,9 +683,7 @@ func validateApprovalTemplate(template *v1pb.ApprovalTemplate) error {
 	if template.Flow == nil {
 		return errors.Errorf("approval template cannot be nil")
 	}
-	if len(template.Flow.Roles) == 0 {
-		return errors.Errorf("approval template cannot have 0 role")
-	}
+	// Empty roles means "no approval required" - issue will be auto-approved
 	return nil
 }
 

--- a/frontend/src/components/CustomApproval/Settings/components/CustomApproval/logic/validate.ts
+++ b/frontend/src/components/CustomApproval/Settings/components/CustomApproval/logic/validate.ts
@@ -4,10 +4,7 @@ import type {
 } from "@/types/proto-es/v1/issue_service_pb";
 
 const validateApprovalFlow = (flow: ApprovalFlow) => {
-  if (flow.roles.length === 0) {
-    return false;
-  }
-
+  // Empty roles means "no approval required" - issue will be auto-approved
   return flow.roles.every((role) => !!role);
 };
 


### PR DESCRIPTION
Close BYT-8669

## Summary

- Allow users to create approval rules with zero approval nodes
- When "No approval required" is enabled, matched issues are auto-approved
- Enables skipping approval for specific conditions (e.g., dev/staging environments)

## Changes

- Remove backend validation requiring at least 1 role in approval flow
- Remove frontend validation for empty roles  
- Add toggle in approval rule editor to enable "No approval required"

## Screenshot

<img width="2984" height="1444" alt="CleanShot 2026-01-09 at 16 59 36@2x" src="https://github.com/user-attachments/assets/6d5a24d4-d352-4346-be23-d71d20f66023" />


## Test plan

- [ ] Create a new approval rule with "No approval required" enabled
- [ ] Verify the rule saves successfully with empty roles
- [ ] Create an issue matching the rule condition
- [ ] Verify issue is auto-approved (no approval steps required)
- [ ] Edit existing rule, toggle on "No approval required", verify roles are cleared
- [ ] Toggle off, verify approval nodes section reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)