### PR TITLE
feat(api): support create_time filter in changelogs API

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -10986,13 +10986,15 @@ components:
              The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
 
              Supported filter:
-             status: the changelog status, support "==" operation. check Changelog.Status for available values.
-             type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+             - status: the changelog status, support "==" operation. check Changelog.Status for available values.
+             - type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+             - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
 
              Example:
              status == "DONE"
              type in ["BASELINE", "MIGRATE"]
              status == "FAILED" && type == "SDL"
+             create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
       title: ListChangelogsRequest
       additionalProperties: false
     bytebase.v1.ListChangelogsResponse:

--- a/backend/api/v1/database_service_changelog_test.go
+++ b/backend/api/v1/database_service_changelog_test.go
@@ -1,0 +1,138 @@
+package v1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestParseChangelogFilter(t *testing.T) {
+	tests := []struct {
+		name         string
+		filter       string
+		wantStatus   *store.ChangelogStatus
+		wantTypeList []string
+		wantAfter    *time.Time
+		wantBefore   *time.Time
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name:   "empty filter",
+			filter: "",
+		},
+		{
+			name:       "status filter",
+			filter:     `status == "DONE"`,
+			wantStatus: ptr(store.ChangelogStatusDone),
+		},
+		{
+			name:         "type filter with equals",
+			filter:       `type == "MIGRATE"`,
+			wantTypeList: []string{"MIGRATE"},
+		},
+		{
+			name:         "type filter with in",
+			filter:       `type in ["BASELINE", "MIGRATE"]`,
+			wantTypeList: []string{"BASELINE", "MIGRATE"},
+		},
+		{
+			name:      "create_time greater than or equal",
+			filter:    `create_time >= "2024-01-01T00:00:00Z"`,
+			wantAfter: ptr(mustParseTime(t, "2024-01-01T00:00:00Z")),
+		},
+		{
+			name:       "create_time less than or equal",
+			filter:     `create_time <= "2024-12-31T23:59:59Z"`,
+			wantBefore: ptr(mustParseTime(t, "2024-12-31T23:59:59Z")),
+		},
+		{
+			name:       "create_time range",
+			filter:     `create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"`,
+			wantAfter:  ptr(mustParseTime(t, "2024-01-01T00:00:00Z")),
+			wantBefore: ptr(mustParseTime(t, "2024-01-02T00:00:00Z")),
+		},
+		{
+			name:       "combined status and time filter",
+			filter:     `status == "DONE" && create_time >= "2024-01-01T00:00:00Z"`,
+			wantStatus: ptr(store.ChangelogStatusDone),
+			wantAfter:  ptr(mustParseTime(t, "2024-01-01T00:00:00Z")),
+		},
+		{
+			name:         "combined type and time filter",
+			filter:       `type in ["BASELINE", "MIGRATE"] && create_time <= "2024-12-31T23:59:59Z"`,
+			wantTypeList: []string{"BASELINE", "MIGRATE"},
+			wantBefore:   ptr(mustParseTime(t, "2024-12-31T23:59:59Z")),
+		},
+		{
+			name:        "invalid time format",
+			filter:      `create_time >= "invalid-time"`,
+			wantErr:     true,
+			errContains: "failed to parse time",
+		},
+		{
+			name:        "time comparison on wrong field",
+			filter:      `status >= "2024-01-01T00:00:00Z"`,
+			wantErr:     true,
+			errContains: `">=" and "<=" are only supported for "create_time"`,
+		},
+		{
+			name:        "unsupported variable",
+			filter:      `unknown == "value"`,
+			wantErr:     true,
+			errContains: "unsupport variable",
+		},
+		{
+			name:      "create_time with timezone offset",
+			filter:    `create_time >= "2024-01-01T00:00:00+05:30"`,
+			wantAfter: ptr(mustParseTime(t, "2024-01-01T00:00:00+05:30")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			find := &store.FindChangelogMessage{}
+			err := parseChangelogFilter(tt.filter, find)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.wantStatus != nil {
+				require.NotNil(t, find.Status)
+				require.Equal(t, *tt.wantStatus, *find.Status)
+			}
+			if tt.wantTypeList != nil {
+				require.Equal(t, tt.wantTypeList, find.TypeList)
+			}
+			if tt.wantAfter != nil {
+				require.NotNil(t, find.CreatedAtAfter)
+				require.Equal(t, *tt.wantAfter, *find.CreatedAtAfter)
+			}
+			if tt.wantBefore != nil {
+				require.NotNil(t, find.CreatedAtBefore)
+				require.Equal(t, *tt.wantBefore, *find.CreatedAtBefore)
+			}
+		})
+	}
+}
+
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsedTime, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return parsedTime
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/backend/generated-go/v1/database_service.pb.go
+++ b/backend/generated-go/v1/database_service.pb.go
@@ -5168,13 +5168,15 @@ type ListChangelogsRequest struct {
 	// The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
 	//
 	// Supported filter:
-	// status: the changelog status, support "==" operation. check Changelog.Status for available values.
-	// type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+	// - status: the changelog status, support "==" operation. check Changelog.Status for available values.
+	// - type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+	// - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
 	//
 	// Example:
 	// status == "DONE"
 	// type in ["BASELINE", "MIGRATE"]
 	// status == "FAILED" && type == "SDL"
+	// create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
 	Filter        string `protobuf:"bytes,5,opt,name=filter,proto3" json:"filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/backend/store/changelog.go
+++ b/backend/store/changelog.go
@@ -43,8 +43,10 @@ type FindChangelogMessage struct {
 	InstanceID   *string
 	DatabaseName *string
 
-	TypeList []string
-	Status   *ChangelogStatus
+	TypeList        []string
+	Status          *ChangelogStatus
+	CreatedAtBefore *time.Time
+	CreatedAtAfter  *time.Time
 
 	Limit  *int
 	Offset *int
@@ -197,6 +199,12 @@ func (s *Store) ListChangelogs(ctx context.Context, find *FindChangelogMessage) 
 	}
 	if len(find.TypeList) > 0 {
 		q.And("changelog.payload->>'type' = ANY(?)", find.TypeList)
+	}
+	if v := find.CreatedAtBefore; v != nil {
+		q.And("changelog.created_at <= ?", *v)
+	}
+	if v := find.CreatedAtAfter; v != nil {
+		q.And("changelog.created_at >= ?", *v)
 	}
 
 	q.Space("ORDER BY changelog.id DESC")

--- a/frontend/src/types/proto-es/v1/database_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/database_service_pb.d.ts
@@ -2950,13 +2950,15 @@ export declare type ListChangelogsRequest = Message<"bytebase.v1.ListChangelogsR
    * The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
    *
    * Supported filter:
-   * status: the changelog status, support "==" operation. check Changelog.Status for available values.
-   * type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+   * - status: the changelog status, support "==" operation. check Changelog.Status for available values.
+   * - type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+   * - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
    *
    * Example:
    * status == "DONE"
    * type in ["BASELINE", "MIGRATE"]
    * status == "FAILED" && type == "SDL"
+   * create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
    *
    * @generated from field: string filter = 5;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -1500,13 +1500,15 @@ paths:
                      The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
 
                      Supported filter:
-                     status: the changelog status, support "==" operation. check Changelog.Status for available values.
-                     type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+                     - status: the changelog status, support "==" operation. check Changelog.Status for available values.
+                     - type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+                     - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
 
                      Example:
                      status == "DONE"
                      type in ["BASELINE", "MIGRATE"]
                      status == "FAILED" && type == "SDL"
+                     create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
                   schema:
                     type: string
             responses:

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -3805,9 +3805,9 @@ When paginating, all other parameters provided must match the call that provided
 | view | [ChangelogView](#bytebase-v1-ChangelogView) |  |  |
 | filter | [string](#string) |  | Filter is used to filter changelogs returned in the list. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
 
-Supported filter: status: the changelog status, support &#34;==&#34; operation. check Changelog.Status for available values. type: the changelog type, support &#34;in&#34; and &#34;==&#34; operation. check Changelog.Type for available values.
+Supported filter: - status: the changelog status, support &#34;==&#34; operation. check Changelog.Status for available values. - type: the changelog type, support &#34;in&#34; and &#34;==&#34; operation. check Changelog.Type for available values. - create_time: the changelog create time in &#34;2006-01-02T15:04:05Z07:00&#34; format, support &#34;&gt;=&#34; or &#34;&lt;=&#34; operator.
 
-Example: status == &#34;DONE&#34; type in [&#34;BASELINE&#34;, &#34;MIGRATE&#34;] status == &#34;FAILED&#34; &amp;&amp; type == &#34;SDL&#34; |
+Example: status == &#34;DONE&#34; type in [&#34;BASELINE&#34;, &#34;MIGRATE&#34;] status == &#34;FAILED&#34; &amp;&amp; type == &#34;SDL&#34; create_time &gt;= &#34;2024-01-01T00:00:00Z&#34; &amp;&amp; create_time &lt;= &#34;2024-01-02T00:00:00Z&#34; |
 
 
 

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -10921,13 +10921,15 @@ the call that provided the page token. </p></td>
 The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
 
 Supported filter:
-status: the changelog status, support &#34;==&#34; operation. check Changelog.Status for available values.
-type: the changelog type, support &#34;in&#34; and &#34;==&#34; operation. check Changelog.Type for available values.
+- status: the changelog status, support &#34;==&#34; operation. check Changelog.Status for available values.
+- type: the changelog type, support &#34;in&#34; and &#34;==&#34; operation. check Changelog.Type for available values.
+- create_time: the changelog create time in &#34;2006-01-02T15:04:05Z07:00&#34; format, support &#34;&gt;=&#34; or &#34;&lt;=&#34; operator.
 
 Example:
 status == &#34;DONE&#34;
 type in [&#34;BASELINE&#34;, &#34;MIGRATE&#34;]
-status == &#34;FAILED&#34; &amp;&amp; type == &#34;SDL&#34; </p></td>
+status == &#34;FAILED&#34; &amp;&amp; type == &#34;SDL&#34;
+create_time &gt;= &#34;2024-01-01T00:00:00Z&#34; &amp;&amp; create_time &lt;= &#34;2024-01-02T00:00:00Z&#34; </p></td>
                 </tr>
               
             </tbody>

--- a/proto/v1/v1/database_service.proto
+++ b/proto/v1/v1/database_service.proto
@@ -1383,13 +1383,15 @@ message ListChangelogsRequest {
   // The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
   //
   // Supported filter:
-  // status: the changelog status, support "==" operation. check Changelog.Status for available values.
-  // type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+  // - status: the changelog status, support "==" operation. check Changelog.Status for available values.
+  // - type: the changelog type, support "in" and "==" operation. check Changelog.Type for available values.
+  // - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
   //
   // Example:
   // status == "DONE"
   // type in ["BASELINE", "MIGRATE"]
   // status == "FAILED" && type == "SDL"
+  // create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
   string filter = 5;
 }
 


### PR DESCRIPTION
## Summary
- Add support for `create_time` filter in the ListChangelogs API using `>=` and `<=` operators
- Enables users to query changelogs within a specific time range for custom notification workflows

## Test plan
- [x] Unit tests added for filter parsing (`TestParseChangelogFilter`)
- [x] Tests cover valid filters, invalid formats, and combined filters
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)