### PR TITLE
refactor(parser): remove Parse function, use ParseStatements

### DIFF
--- a/backend/plugin/parser/cassandra/cassandra.go
+++ b/backend/plugin/parser/cassandra/cassandra.go
@@ -12,22 +12,7 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_CASSANDRA, parseCassandraForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_CASSANDRA, parseCassandraStatements)
-}
-
-// parseCassandraForRegistry is the ParseFunc for Cassandra.
-// Returns []base.AST with *ANTLRAST instances.
-func parseCassandraForRegistry(statement string) ([]base.AST, error) {
-	parseResults, err := ParseCassandraSQL(statement)
-	if err != nil {
-		return nil, err
-	}
-	asts := make([]base.AST, len(parseResults))
-	for i, r := range parseResults {
-		asts[i] = r
-	}
-	return asts, nil
 }
 
 // parseCassandraStatements is the ParseStatementsFunc for Cassandra.

--- a/backend/plugin/parser/doris/doris.go
+++ b/backend/plugin/parser/doris/doris.go
@@ -9,22 +9,7 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_DORIS, parseDorisForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_DORIS, parseDorisStatements)
-}
-
-// parseDorisForRegistry is the ParseFunc for Doris.
-// Returns []base.AST with *ANTLRAST instances.
-func parseDorisForRegistry(statement string) ([]base.AST, error) {
-	antlrASTs, err := ParseDorisSQL(statement)
-	if err != nil {
-		return nil, err
-	}
-	var asts []base.AST
-	for _, ast := range antlrASTs {
-		asts = append(asts, ast)
-	}
-	return asts, nil
 }
 
 // parseDorisStatements is the ParseStatementsFunc for Doris.

--- a/backend/plugin/parser/mysql/mysql.go
+++ b/backend/plugin/parser/mysql/mysql.go
@@ -16,29 +16,12 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_MYSQL, parseMySQLForRegistry)
-	base.RegisterParseFunc(storepb.Engine_MARIADB, parseMySQLForRegistry)
-	base.RegisterParseFunc(storepb.Engine_OCEANBASE, parseMySQLForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_MYSQL, parseMySQLStatements)
 	base.RegisterParseStatementsFunc(storepb.Engine_MARIADB, parseMySQLStatements)
 	base.RegisterParseStatementsFunc(storepb.Engine_OCEANBASE, parseMySQLStatements)
 	base.RegisterGetStatementTypes(storepb.Engine_MYSQL, GetStatementTypes)
 	base.RegisterGetStatementTypes(storepb.Engine_MARIADB, GetStatementTypes)
 	base.RegisterGetStatementTypes(storepb.Engine_OCEANBASE, GetStatementTypes)
-}
-
-// parseMySQLForRegistry is the ParseFunc for MySQL, MariaDB, and OceanBase.
-// Returns []base.AST with *ANTLRAST instances.
-func parseMySQLForRegistry(statement string) ([]base.AST, error) {
-	parseResults, err := ParseMySQL(statement)
-	if err != nil {
-		return nil, err
-	}
-	asts := make([]base.AST, len(parseResults))
-	for i, r := range parseResults {
-		asts[i] = r
-	}
-	return asts, nil
 }
 
 // parseMySQLStatements is the ParseStatementsFunc for MySQL, MariaDB, and OceanBase.

--- a/backend/plugin/parser/mysql/resource_change_test.go
+++ b/backend/plugin/parser/mysql/resource_change_test.go
@@ -45,8 +45,9 @@ func TestExtractChangedResources(t *testing.T) {
 		InsertCount: 2,
 	}
 
-	asts, err := base.Parse(storepb.Engine_MYSQL, statement)
+	stmts, err := base.ParseStatements(storepb.Engine_MYSQL, statement)
 	require.NoError(t, err)
+	asts := base.ExtractASTs(stmts)
 	got, err := extractChangedResources("db", "", nil /* dbMetadata */, asts, statement)
 	require.NoError(t, err)
 	require.Equal(t, want, got)

--- a/backend/plugin/parser/mysql/statement_type_test.go
+++ b/backend/plugin/parser/mysql/statement_type_test.go
@@ -38,8 +38,9 @@ func TestGetStatementType(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for i, test := range tests {
-		asts, err := base.Parse(storepb.Engine_MYSQL, test.Statement)
+		stmts, err := base.ParseStatements(storepb.Engine_MYSQL, test.Statement)
 		a.NoError(err)
+		asts := base.ExtractASTs(stmts)
 
 		sqlType, err := GetStatementTypes(asts)
 		a.NoError(err)

--- a/backend/plugin/parser/partiql/partiql.go
+++ b/backend/plugin/parser/partiql/partiql.go
@@ -13,22 +13,7 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_DYNAMODB, parsePartiQLForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_DYNAMODB, parsePartiQLStatements)
-}
-
-// parsePartiQLForRegistry is the ParseFunc for PartiQL.
-// Returns []base.AST with *ANTLRAST instances.
-func parsePartiQLForRegistry(statement string) ([]base.AST, error) {
-	parseResults, err := ParsePartiQL(statement)
-	if err != nil {
-		return nil, err
-	}
-	asts := make([]base.AST, len(parseResults))
-	for i, r := range parseResults {
-		asts[i] = r
-	}
-	return asts, nil
 }
 
 // parsePartiQLStatements is the ParseStatementsFunc for PartiQL (DynamoDB).

--- a/backend/plugin/parser/pg/parser_integration_test.go
+++ b/backend/plugin/parser/pg/parser_integration_test.go
@@ -47,7 +47,7 @@ FRAM t1;`,
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := base.Parse(storepb.Engine_POSTGRES, test.statement)
+			_, err := base.ParseStatements(storepb.Engine_POSTGRES, test.statement)
 			require.Error(t, err)
 			syntaxErr, ok := err.(*base.SyntaxError)
 			require.True(t, ok, "expected *base.SyntaxError, got %T", err)

--- a/backend/plugin/parser/pg/pg.go
+++ b/backend/plugin/parser/pg/pg.go
@@ -11,23 +11,8 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_POSTGRES, parsePostgreSQLForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_POSTGRES, parsePgStatements)
 	base.RegisterGetStatementTypes(storepb.Engine_POSTGRES, GetStatementTypesForRegistry)
-}
-
-// parsePostgreSQLForRegistry is the ParseFunc for PostgreSQL.
-// Returns []base.AST with *ANTLRAST instances.
-func parsePostgreSQLForRegistry(statement string) ([]base.AST, error) {
-	parseResults, err := ParsePostgreSQL(statement)
-	if err != nil {
-		return nil, err
-	}
-	asts := make([]base.AST, len(parseResults))
-	for i, r := range parseResults {
-		asts[i] = r
-	}
-	return asts, nil
 }
 
 // parsePgStatements is the ParseStatementsFunc for PostgreSQL.

--- a/backend/plugin/parser/pg/resource_change_test.go
+++ b/backend/plugin/parser/pg/resource_change_test.go
@@ -54,8 +54,9 @@ func TestExtractChangedResources(t *testing.T) {
 		InsertCount:      2,
 	}
 
-	asts, err := base.Parse(storepb.Engine_POSTGRES, statement)
+	stmts, err := base.ParseStatements(storepb.Engine_POSTGRES, statement)
 	require.NoError(t, err)
+	asts := base.ExtractASTs(stmts)
 	got, err := extractChangedResources("db", "public", dbMetadata, asts, statement)
 	require.NoError(t, err)
 	require.Equal(t, want, got)

--- a/backend/plugin/parser/plsql/plsql.go
+++ b/backend/plugin/parser/plsql/plsql.go
@@ -15,23 +15,8 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_ORACLE, parsePLSQLForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_ORACLE, parsePLSQLStatements)
 	base.RegisterGetStatementTypes(storepb.Engine_ORACLE, GetStatementTypes)
-}
-
-// parsePLSQLForRegistry is the ParseFunc for PL/SQL.
-// Returns []base.AST with *ANTLRAST instances.
-func parsePLSQLForRegistry(statement string) ([]base.AST, error) {
-	parseResults, err := ParsePLSQL(statement + ";")
-	if err != nil {
-		return nil, err
-	}
-	asts := make([]base.AST, len(parseResults))
-	for i, r := range parseResults {
-		asts[i] = r
-	}
-	return asts, nil
 }
 
 // parsePLSQLStatements is the ParseStatementsFunc for Oracle (PL/SQL).

--- a/backend/plugin/parser/plsql/resource_change_test.go
+++ b/backend/plugin/parser/plsql/resource_change_test.go
@@ -29,8 +29,9 @@ func TestExtractChangedResources(t *testing.T) {
 		InsertCount:      1,
 	}
 
-	asts, err := base.Parse(storepb.Engine_ORACLE, statement)
+	stmts, err := base.ParseStatements(storepb.Engine_ORACLE, statement)
 	require.NoError(t, err)
+	asts := base.ExtractASTs(stmts)
 	require.NotEmpty(t, asts)
 
 	// Pass the full asts array to extractChangedResources

--- a/backend/plugin/parser/plsql/statement_type_test.go
+++ b/backend/plugin/parser/plsql/statement_type_test.go
@@ -33,8 +33,9 @@ func TestGetStatementType(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for _, test := range tests {
-		asts, err := base.Parse(storepb.Engine_ORACLE, test.Statement)
+		stmts, err := base.ParseStatements(storepb.Engine_ORACLE, test.Statement)
 		a.NoError(err)
+		asts := base.ExtractASTs(stmts)
 		a.NotEmpty(asts)
 		sqlType, err := GetStatementTypes(asts)
 		a.NoError(err)

--- a/backend/plugin/parser/redshift/redshift.go
+++ b/backend/plugin/parser/redshift/redshift.go
@@ -13,23 +13,8 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_REDSHIFT, parseRedshiftForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_REDSHIFT, parseRedshiftStatements)
 	base.RegisterGetStatementTypes(storepb.Engine_REDSHIFT, GetStatementTypes)
-}
-
-// parseRedshiftForRegistry is the ParseFunc for Redshift.
-// Returns []base.AST with *ANTLRAST instances.
-func parseRedshiftForRegistry(statement string) ([]base.AST, error) {
-	parseResults, err := ParseRedshift(statement)
-	if err != nil {
-		return nil, err
-	}
-	asts := make([]base.AST, len(parseResults))
-	for i, r := range parseResults {
-		asts[i] = r
-	}
-	return asts, nil
 }
 
 // parseRedshiftStatements is the ParseStatementsFunc for Redshift.

--- a/backend/plugin/parser/snowflake/snowflake.go
+++ b/backend/plugin/parser/snowflake/snowflake.go
@@ -13,22 +13,7 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_SNOWFLAKE, parseSnowflakeForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_SNOWFLAKE, parseSnowflakeStatements)
-}
-
-// parseSnowflakeForRegistry is the ParseFunc for Snowflake.
-// Returns []base.AST with *ANTLRAST instances.
-func parseSnowflakeForRegistry(statement string) ([]base.AST, error) {
-	parseResults, err := ParseSnowSQL(statement)
-	if err != nil {
-		return nil, err
-	}
-	asts := make([]base.AST, len(parseResults))
-	for i, r := range parseResults {
-		asts[i] = r
-	}
-	return asts, nil
 }
 
 // parseSnowflakeStatements is the ParseStatementsFunc for Snowflake.

--- a/backend/plugin/parser/tidb/resource_change_test.go
+++ b/backend/plugin/parser/tidb/resource_change_test.go
@@ -44,8 +44,9 @@ func TestExtractChangedResources(t *testing.T) {
 		InsertCount: 2,
 	}
 
-	asts, err := base.Parse(storepb.Engine_TIDB, statement)
+	stmts, err := base.ParseStatements(storepb.Engine_TIDB, statement)
 	require.NoError(t, err)
+	asts := base.ExtractASTs(stmts)
 	got, err := extractChangedResources("db", "", nil /* dbMetadata */, asts, statement)
 	require.NoError(t, err)
 	require.Equal(t, want, got)

--- a/backend/plugin/parser/tidb/statement_type_test.go
+++ b/backend/plugin/parser/tidb/statement_type_test.go
@@ -38,8 +38,9 @@ func TestGetStatementType(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for i, test := range tests {
-		asts, err := base.Parse(storepb.Engine_TIDB, test.Statement)
+		stmts, err := base.ParseStatements(storepb.Engine_TIDB, test.Statement)
 		a.NoError(err)
+		asts := base.ExtractASTs(stmts)
 
 		sqlType, err := GetStatementTypes(asts)
 		a.NoError(err)

--- a/backend/plugin/parser/tidb/tidb.go
+++ b/backend/plugin/parser/tidb/tidb.go
@@ -20,7 +20,6 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_TIDB, ParseTiDBForSyntaxCheck)
 	base.RegisterParseStatementsFunc(storepb.Engine_TIDB, parseTiDBStatements)
 	base.RegisterGetStatementTypes(storepb.Engine_TIDB, GetStatementTypes)
 }

--- a/backend/plugin/parser/tsql/resource_change_test.go
+++ b/backend/plugin/parser/tsql/resource_change_test.go
@@ -35,8 +35,9 @@ func TestExtractChangedResources(t *testing.T) {
 		InsertCount: 2,
 	}
 
-	asts, err := base.Parse(storepb.Engine_MSSQL, statement)
+	stmts, err := base.ParseStatements(storepb.Engine_MSSQL, statement)
 	require.NoError(t, err)
+	asts := base.ExtractASTs(stmts)
 	require.Len(t, asts, 5)
 	got, err := extractChangedResources("DB", "dbo", nil /* dbMetadata */, asts, statement)
 	require.NoError(t, err)

--- a/backend/plugin/parser/tsql/statement_type_test.go
+++ b/backend/plugin/parser/tsql/statement_type_test.go
@@ -33,8 +33,9 @@ func TestGetStatementType(t *testing.T) {
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
 	for _, test := range tests {
-		asts, err := base.Parse(storepb.Engine_MSSQL, test.Statement)
+		stmts, err := base.ParseStatements(storepb.Engine_MSSQL, test.Statement)
 		a.NoError(err)
+		asts := base.ExtractASTs(stmts)
 		a.NotEmpty(asts)
 		sqlType, err := GetStatementTypes(asts)
 		a.NoError(err)

--- a/backend/plugin/parser/tsql/tsql.go
+++ b/backend/plugin/parser/tsql/tsql.go
@@ -14,23 +14,8 @@ import (
 )
 
 func init() {
-	base.RegisterParseFunc(storepb.Engine_MSSQL, parseTSQLForRegistry)
 	base.RegisterParseStatementsFunc(storepb.Engine_MSSQL, parseTSQLStatements)
 	base.RegisterGetStatementTypes(storepb.Engine_MSSQL, GetStatementTypes)
-}
-
-// parseTSQLForRegistry is the ParseFunc for T-SQL.
-// Returns []base.AST with *ANTLRAST instances.
-func parseTSQLForRegistry(statement string) ([]base.AST, error) {
-	antlrASTs, err := ParseTSQL(statement)
-	if err != nil {
-		return nil, err
-	}
-	var asts []base.AST
-	for _, a := range antlrASTs {
-		asts = append(asts, a)
-	}
-	return asts, nil
 }
 
 // parseTSQLStatements is the ParseStatementsFunc for T-SQL (MSSQL).

--- a/backend/plugin/schema/pg/walk_through_test.go
+++ b/backend/plugin/schema/pg/walk_through_test.go
@@ -188,14 +188,14 @@ func TestWalkThroughANTLR(t *testing.T) {
 		// Create DatabaseMetadata for walk-through
 		state := model.NewDatabaseMetadata(protoData, nil, nil, storepb.Engine_POSTGRES, !test.IgnoreCaseSensitive)
 
-		// Parse using base.Parse to get AST
-		unifiedASTs, parseErr := base.Parse(storepb.Engine_POSTGRES, test.Statement)
+		// Parse using base.ParseStatements to get AST
+		stmts, parseErr := base.ParseStatements(storepb.Engine_POSTGRES, test.Statement)
 		if parseErr != nil {
 			t.Fatalf("Failed to parse SQL: %v\nSQL: %s", parseErr, test.Statement)
 		}
 
 		// Call WalkThrough with AST
-		advice := WalkThrough(state, unifiedASTs)
+		advice := WalkThrough(state, base.ExtractASTs(stmts))
 		if advice != nil {
 			// Compare the advice fields
 			require.Equal(t, test.Advice.Code, advice.Code)


### PR DESCRIPTION
## Summary

- Remove the deprecated `Parse()` function from the parser base package and migrate all usages to `ParseStatements()` + `ExtractASTs()`
- The `Parse()` function was only used in tests and by `isAllDMLImpl()`. `ParseStatements()` is the preferred unified API that returns complete `ParsedStatement` objects with both text and AST
- Remove `ParseFunc` type, `parsers` map, `RegisterParseFunc()`, and `Parse()` from `backend/plugin/parser/base/interface.go`
- Update `isAllDMLImpl()` to use `ParseStatements()` + `ExtractASTs()`
- Migrate 12 test files to use `ParseStatements()` + `ExtractASTs()`
- Remove `RegisterParseFunc()` calls and `xxxForRegistry` wrapper functions from 11 parser packages (pg, mysql, tidb, plsql, tsql, snowflake, redshift, doris, cockroachdb, cassandra, partiql)

## Test plan

- [x] `golangci-lint run --allow-parallel-runners` passes with 0 issues
- [x] All relevant parser tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)