### PR TITLE
fix(frontend): redirect to new UI when issue has no rollout

### DIFF
--- a/frontend/src/utils/v1/issue/issue.ts
+++ b/frontend/src/utils/v1/issue/issue.ts
@@ -109,11 +109,12 @@ export const generateIssueTitle = (
  * - Grant request issues: ALWAYS use new layout
  * - Create database issues: ALWAYS use new layout
  * - Data export issues: ALWAYS use new layout
+ * - Issues without rollout: ALWAYS use new layout (legacy UI cannot display them)
  * - Database changing issues: Use new layout ONLY when enabledNewLayout is true
  */
 export const shouldUseNewIssueLayout = (
   issue: { type?: Issue_Type; name?: string },
-  plan?: Plan | { specs?: Array<{ config?: { case?: string } }> },
+  plan?: Plan,
   enabledNewLayout = true
 ): boolean => {
   // Grant request issues always use new layout
@@ -140,6 +141,11 @@ export const shouldUseNewIssueLayout = (
     return true;
   }
 
+  // Issues without rollout must use new layout (legacy UI cannot display them)
+  if (plan && plan.hasRollout === false) {
+    return true;
+  }
+
   // For database changing issues, respect the layout preference
   return enabledNewLayout;
 };
@@ -154,7 +160,7 @@ export const shouldUseNewIssueLayout = (
  */
 export const getIssueRoute = (
   issue: { type?: Issue_Type; name: string; title?: string },
-  plan?: Plan | { specs?: Array<{ config?: { case?: string } }> },
+  plan?: Plan,
   enabledNewLayout = true
 ): {
   name: string;

--- a/frontend/src/views/project/IssueDetailV1View.vue
+++ b/frontend/src/views/project/IssueDetailV1View.vue
@@ -71,7 +71,11 @@ onMounted(() => {
     issueType.value === IssueType.EXPORT_DATA ||
     issueType.value === IssueType.GRANT_REQUEST;
 
-  if (!enabledNewLayout.value && !usesNewLayoutOnly) {
+  // Only redirect to legacy UI if:
+  // 1. New layout is disabled
+  // 2. Issue type is not new-layout-only
+  // 3. Rollout exists (legacy UI cannot display issues without rollout)
+  if (!enabledNewLayout.value && !usesNewLayoutOnly && plan.value.hasRollout) {
     router.replace({
       name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
       params: {


### PR DESCRIPTION
Legacy issue UI cannot display issues with plan but no rollout. This redirects users to the new Plan UI in such cases.