### PR TITLE
fix(elasticsearch): handle closed indices with null size/count values

### DIFF
--- a/backend/plugin/db/elasticsearch/elasticsearch.go
+++ b/backend/plugin/db/elasticsearch/elasticsearch.go
@@ -354,8 +354,13 @@ func (d *Driver) Ping(_ context.Context) error {
 
 	// Use Elasticsearch client
 	if d.typedClient != nil {
-		if _, err := d.typedClient.Ping(); err != nil {
+		res, err := d.typedClient.Ping()
+		if err != nil {
 			return errors.Wrapf(err, "failed to ping db")
+		}
+		defer res.Body.Close()
+		if res.IsError() {
+			return errors.Errorf("ping failed: %s", res.String())
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary
- Fix panic when syncing Elasticsearch instances with closed indices
- Closed indices return `null` for `store.size` and `docs.count`, causing index out of range error
- Also fix `Ping` to properly check HTTP status codes (was ignoring 401 errors)

## Changes
- Add empty string check in `unitConversion` for null `store.size`
- Add `parseDocCount` helper to handle null `docs.count`
- Fix `Ping` to check `res.IsError()` instead of discarding response

## Test plan
- [x] Create ES instance with fine-grained access control
- [x] Create and close an index: `PUT /test-closed-index` then `POST /test-closed-index/_close`
- [x] Verify closed index returns `store.size: null` and `docs.count: null`
- [x] Sync instance in Bytebase - should succeed without panic

Fixes #18821

🤖 Generated with [Claude Code](https://claude.com/claude-code)