### PR TITLE
refactor(iam): move group caches to store with LRU+TTL

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -785,7 +785,11 @@ func (s *AuthService) finalizeLogin(ctx context.Context, req *connect.Request[v1
 		slog.Error("failed to update user profile", log.BBError(err), slog.String("user", user.Email))
 	}
 
-	response.User = convertToUser(ctx, s.iamManager, user)
+	v1User, err := convertToUser(ctx, s.iamManager, user)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert user"))
+	}
+	response.User = v1User
 	return resp, nil
 }
 

--- a/backend/component/iam/manager_test.go
+++ b/backend/component/iam/manager_test.go
@@ -102,7 +102,13 @@ func TestCheck(t *testing.T) {
 		}}
 
 	for i, test := range tests {
-		got := check(testUser, test.permission, test.policy, getPermissions, test.groupMembers)
+		getGroupMembers := func(groupName string) map[string]bool {
+			if test.groupMembers == nil {
+				return nil
+			}
+			return test.groupMembers[groupName]
+		}
+		got := check(testUser, test.permission, test.policy, getPermissions, getGroupMembers)
 		if got != test.want {
 			require.Equal(t, test.want, got, i)
 		}

--- a/backend/store/group.go
+++ b/backend/store/group.go
@@ -311,6 +311,7 @@ func (s *Store) UpdateGroup(ctx context.Context, patch *UpdateGroupMessage) (*Gr
 
 	if group.Email != "" {
 		s.groupCache.Add(group.Email, &group)
+		s.groupMembersCache.Remove("groups/" + group.Email)
 	}
 	return &group, nil
 }
@@ -340,8 +341,65 @@ func (s *Store) DeleteGroup(ctx context.Context, id string) error {
 
 	if email.Valid && email.String != "" {
 		s.groupCache.Remove(email.String)
+		s.groupMembersCache.Remove("groups/" + email.String)
 	}
 	return nil
+}
+
+// GetUserGroupsSnapshot returns groups for a user with snapshot reads (with cache).
+// userName format is "users/{email}".
+// Trades consistency for performance.
+func (s *Store) GetUserGroupsSnapshot(ctx context.Context, userName string) ([]string, error) {
+	if v, ok := s.memberGroupsCache.Get(userName); ok {
+		return v, nil
+	}
+
+	groups, err := s.ListGroups(ctx, &FindGroupMessage{})
+	if err != nil {
+		return nil, err
+	}
+
+	var userGroups []string
+	for _, group := range groups {
+		for _, m := range group.Payload.GetMembers() {
+			if m.Member == userName {
+				groupName := common.FormatGroupEmail(group.Email)
+				if group.Email == "" {
+					groupName = common.FormatGroupEmail(group.ID)
+				}
+				userGroups = append(userGroups, groupName)
+				break
+			}
+		}
+	}
+	s.memberGroupsCache.Add(userName, userGroups)
+	return userGroups, nil
+}
+
+// GetGroupMembersSnapshot returns group members with snapshot reads (with cache).
+// groupName format is "groups/{email}".
+// Trades consistency for performance.
+func (s *Store) GetGroupMembersSnapshot(ctx context.Context, groupName string) (map[string]bool, error) {
+	if v, ok := s.groupMembersCache.Get(groupName); ok {
+		return v, nil
+	}
+
+	// Extract email from group name "groups/{email}"
+	email := strings.TrimPrefix(groupName, "groups/")
+	group, err := s.GetGroup(ctx, &FindGroupMessage{Email: &email})
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return nil, nil
+	}
+
+	members := make(map[string]bool)
+	for _, m := range group.Payload.GetMembers() {
+		members[m.Member] = true
+	}
+	s.groupMembersCache.Add(groupName, members)
+	return members, nil
 }
 
 func GetListGroupFilter(find *FindGroupMessage, filter string) (*qb.Query, error) {

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -19,15 +19,17 @@ type Store struct {
 	enableCache   bool
 
 	// Cache.
-	Secret         string
-	userEmailCache *lru.Cache[string, *UserMessage]
-	instanceCache  *lru.Cache[string, *InstanceMessage]
-	databaseCache  *lru.Cache[string, *DatabaseMessage]
-	projectCache   *lru.Cache[string, *ProjectMessage]
-	policyCache    *lru.Cache[string, *PolicyMessage]
-	settingCache   *lru.Cache[storepb.SettingName, *SettingMessage]
-	rolesCache     *expirable.LRU[string, *RoleMessage]
-	groupCache     *lru.Cache[string, *GroupMessage]
+	Secret            string
+	userEmailCache    *lru.Cache[string, *UserMessage]
+	instanceCache     *lru.Cache[string, *InstanceMessage]
+	databaseCache     *lru.Cache[string, *DatabaseMessage]
+	projectCache      *lru.Cache[string, *ProjectMessage]
+	policyCache       *lru.Cache[string, *PolicyMessage]
+	settingCache      *lru.Cache[storepb.SettingName, *SettingMessage]
+	rolesCache        *expirable.LRU[string, *RoleMessage]
+	groupCache        *expirable.LRU[string, *GroupMessage]
+	groupMembersCache *expirable.LRU[string, map[string]bool]
+	memberGroupsCache *expirable.LRU[string, []string]
 
 	// Large objects.
 	sheetFullCache *lru.Cache[string, *SheetMessage]
@@ -65,10 +67,9 @@ func New(ctx context.Context, pgURL string, enableCache bool) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	groupCache, err := lru.New[string, *GroupMessage](1024)
-	if err != nil {
-		return nil, err
-	}
+	groupCache := expirable.NewLRU[string, *GroupMessage](1024, nil, time.Minute)
+	groupMembersCache := expirable.NewLRU[string, map[string]bool](1024, nil, time.Minute)
+	memberGroupsCache := expirable.NewLRU[string, []string](4096, nil, time.Minute)
 
 	// Initialize database connection (handles both direct URL and file-based)
 	dbConnManager := NewDBConnectionManager(pgURL)
@@ -81,15 +82,17 @@ func New(ctx context.Context, pgURL string, enableCache bool) (*Store, error) {
 		enableCache:   enableCache,
 
 		// Cache.
-		userEmailCache: userEmailCache,
-		instanceCache:  instanceCache,
-		databaseCache:  databaseCache,
-		projectCache:   projectCache,
-		policyCache:    policyCache,
-		settingCache:   settingCache,
-		rolesCache:     rolesCache,
-		sheetFullCache: sheetFullCache,
-		groupCache:     groupCache,
+		userEmailCache:    userEmailCache,
+		instanceCache:     instanceCache,
+		databaseCache:     databaseCache,
+		projectCache:      projectCache,
+		policyCache:       policyCache,
+		settingCache:      settingCache,
+		rolesCache:        rolesCache,
+		sheetFullCache:    sheetFullCache,
+		groupCache:        groupCache,
+		groupMembersCache: groupMembersCache,
+		memberGroupsCache: memberGroupsCache,
 	}
 
 	return s, nil
@@ -109,6 +112,13 @@ func (s *Store) DeleteCache() {
 	s.settingCache.Purge()
 	s.policyCache.Purge()
 	s.userEmailCache.Purge()
+}
+
+// PurgeGroupCaches purges all group-related caches.
+func (s *Store) PurgeGroupCaches() {
+	s.groupCache.Purge()
+	s.groupMembersCache.Purge()
+	s.memberGroupsCache.Purge()
 }
 
 func getInstanceCacheKey(instanceID string) string {


### PR DESCRIPTION
## Summary
- Move all group-related caches from IAM Manager to Store layer with expirable LRU caches (1-minute TTL) for better HA support
- Add `GetGroupMembersSnapshot()` and `GetUserGroupsSnapshot()` methods for lazy-loaded cached lookups
- Add `PurgeGroupCaches()` method for explicit cache invalidation when groups are modified

## Changes

### Store Layer (`backend/store/`)
| Cache | Type | Capacity | TTL |
|-------|------|----------|-----|
| `groupCache` | `expirable.LRU[string, *GroupMessage]` | 1024 | 1 min |
| `groupMembersCache` | `expirable.LRU[string, map[string]bool]` | 1024 | 1 min |
| `memberGroupsCache` | `expirable.LRU[string, []string]` | 4096 | 1 min |

### IAM Manager (`backend/component/iam/`)
- Removed `groupMembers` and `memberGroups` maps
- `GetUserGroups()` now delegates to Store and returns error
- `ReloadCache()` now calls `PurgeGroupCaches()` instead of rebuilding maps

### API Layer (`backend/api/v1/`)
- Updated `convertToUser()` to handle error from `GetUserGroups()`
- Updated all callers to properly handle the new error return

## Test plan
- [x] `go test ./backend/component/iam/...` passes
- [x] `golangci-lint run --allow-parallel-runners` passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)