### PR TITLE
fix(i18n): unify reject terminology in issue review UI

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentView/ActionSentence.vue
+++ b/frontend/src/components/IssueV1/components/IssueCommentSection/IssueCommentView/ActionSentence.vue
@@ -57,7 +57,7 @@ const renderActionSentence = () => {
     if (status === IssueComment_Approval_Status.APPROVED) {
       verb = t("custom-approval.issue-review.approved-issue");
     } else if (status === IssueComment_Approval_Status.REJECTED) {
-      verb = t("custom-approval.issue-review.sent-back-issue");
+      verb = t("custom-approval.issue-review.rejected-issue");
     } else if (status === IssueComment_Approval_Status.PENDING) {
       verb = t("custom-approval.issue-review.re-requested-review");
     }

--- a/frontend/src/components/IssueV1/logic/action/review.ts
+++ b/frontend/src/components/IssueV1/logic/action/review.ts
@@ -7,7 +7,7 @@ export const issueReviewActionDisplayName = (action: IssueReviewAction) => {
     case "APPROVE":
       return t("common.approve");
     case "SEND_BACK":
-      return t("custom-approval.issue-review.send-back");
+      return t("common.reject");
     case "RE_REQUEST":
       return t("custom-approval.issue-review.re-request-review");
   }

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue
@@ -57,7 +57,7 @@ const renderActionSentence = () => {
     if (status === IssueComment_Approval_Status.APPROVED) {
       verb = t("custom-approval.issue-review.approved-issue");
     } else if (status === IssueComment_Approval_Status.REJECTED) {
-      verb = t("custom-approval.issue-review.sent-back-issue");
+      verb = t("custom-approval.issue-review.rejected-issue");
     } else if (status === IssueComment_Approval_Status.PENDING) {
       verb = t("custom-approval.issue-review.re-requested-review");
     }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2673,17 +2673,16 @@
       "approve-issue": "Approve issue?",
       "generating-approval-flow": "Generating approval flow",
       "approved-issue": "approved issue",
+      "rejected-issue": "rejected issue",
       "disallow-approve-reason": {
         "some-task-checks-didnt-pass": "Some task checks didn't pass.",
         "some-task-checks-are-still-running": "Some task checks are still running.",
         "x-field-is-required": "{field} is required"
       },
-      "send-back": "Send back",
       "send-back-issue": "Send back issue?",
       "re-request-review": "Re-request review",
       "re-request-review-issue": "Re-request review issue?",
       "re-request-review-success": "Review re-requested successfully",
-      "sent-back-issue": "Sent back issue",
       "re-requested-review": "re-requested issue review",
       "approved-by": "Approved by",
       "rejected-by": "Rejected by",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2673,17 +2673,16 @@
       "approve-issue": "¿Aprobar incidencia?",
       "generating-approval-flow": "Generando flujo de aprobación",
       "approved-issue": "incidencia aprobada",
+      "rejected-issue": "incidencia rechazada",
       "disallow-approve-reason": {
         "some-task-checks-didnt-pass": "Algunas comprobaciones de tareas no pasaron",
         "some-task-checks-are-still-running": "Algunas comprobaciones de tareas aún se están ejecutando",
         "x-field-is-required": "{field} se requiere"
       },
-      "send-back": "Enviar de vuelta",
       "send-back-issue": "¿Devolver el problema?",
       "re-request-review": "Volver a solicitar revisión",
       "re-request-review-issue": "¿Volver a solicitar revisión?",
       "re-request-review-success": "Revisión solicitada nuevamente con éxito",
-      "sent-back-issue": "Problema devuelto",
       "re-requested-review": "revisión de problema nuevamente solicitada",
       "approved-by": "Aprobado por",
       "rejected-by": "Rechazado por",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2673,17 +2673,16 @@
       "approve-issue": "イシューを承認しますか?",
       "generating-approval-flow": "承認フローが生成されています",
       "approved-issue": "イシューを承認する",
+      "rejected-issue": "イシューを却下した",
       "disallow-approve-reason": {
         "some-task-checks-didnt-pass": "失敗したタスクチェックがまだあります",
         "some-task-checks-are-still-running": "確認すべき実行中のタスクがまだあります",
         "x-field-is-required": "{field}は必須です"
       },
-      "send-back": "戻る",
       "send-back-issue": "イシューを却下しますか?",
       "re-request-review": "再度承認をリクエストする",
       "re-request-review-issue": "イシューの承認を再度リクエストしますか?",
       "re-request-review-success": "レビューの再リクエストが完了しました",
-      "sent-back-issue": "イシューを却下する",
       "re-requested-review": "イシューの承認を再度リクエストします",
       "approved-by": "承認者",
       "rejected-by": "拒否された",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2673,17 +2673,16 @@
       "approve-issue": "Phê duyệt vấn đề?",
       "generating-approval-flow": "Đang tạo quy trình phê duyệt",
       "approved-issue": "đã phê duyệt vấn đề",
+      "rejected-issue": "đã từ chối vấn đề",
       "disallow-approve-reason": {
         "some-task-checks-didnt-pass": "Một số kiểm tra tác vụ không vượt qua",
         "some-task-checks-are-still-running": "Một số kiểm tra tác vụ vẫn đang chạy",
         "x-field-is-required": "{field} là bắt buộc"
       },
-      "send-back": "Gửi lại",
       "send-back-issue": "Gửi lại vấn đề?",
       "re-request-review": "Yêu cầu xem xét lại",
       "re-request-review-issue": "Yêu cầu xem xét lại vấn đề?",
       "re-request-review-success": "Yêu cầu xem xét lại đã được thực hiện thành công.",
-      "sent-back-issue": "Đã gửi lại vấn đề",
       "re-requested-review": "đã yêu cầu xem xét lại vấn đề",
       "approved-by": "Được chấp thuận bởi",
       "rejected-by": "Bị từ chối bởi",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2673,17 +2673,16 @@
       "approve-issue": "批准工单？",
       "generating-approval-flow": "正在生成审批流",
       "approved-issue": "批准工单",
+      "rejected-issue": "驳回工单",
       "disallow-approve-reason": {
         "some-task-checks-didnt-pass": "尚有未通过的任务检查项。",
         "some-task-checks-are-still-running": "尚有运行中的任务检查项。",
         "x-field-is-required": "{field}为必填项"
       },
-      "send-back": "退回",
       "send-back-issue": "退回工单？",
       "re-request-review": "请求再次审批",
       "re-request-review-issue": "请求再次审批工单？",
       "re-request-review-success": "已成功请求再次审批",
-      "sent-back-issue": "退回工单",
       "re-requested-review": "再次请求审批工单",
       "approved-by": "已批准",
       "rejected-by": "被拒绝",


### PR DESCRIPTION
Standardize terminology from "Send back" to "Reject" across all issue review components for consistency:

- Update button label in old IssueV1 UI to use "Reject"
- Update activity log to show "rejected issue" instead of "Sent back issue"
- Add rejected-issue i18n key to all locale files

Fixes BYT-8693