### PR TITLE
feat(ha): persist task run scheduler info in database

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -6426,7 +6426,6 @@ components:
           description: |-
             The default schema to execute the statement. Equals to the current schema
              in Oracle and search path in Postgres.
-          nullable: true
         container:
           type:
             - string
@@ -6435,7 +6434,6 @@ components:
           description: |-
             Container is the container name to execute the query against, used for
              CosmosDB only.
-          nullable: true
       title: AdminExecuteRequest
       additionalProperties: false
     bytebase.v1.AdminExecuteResponse:
@@ -7192,7 +7190,6 @@ components:
         runTime:
           title: run_time
           description: The task run should run after run_time.
-          nullable: true
           $ref: '#/components/schemas/google.protobuf.Timestamp'
       title: BatchRunTasksRequest
       additionalProperties: false
@@ -7676,7 +7673,6 @@ components:
         objectSchema:
           title: object_schema
           description: Object schema for complex column types like JSON.
-          nullable: true
           $ref: '#/components/schemas/bytebase.v1.ObjectSchema'
       title: ColumnCatalog
       additionalProperties: false
@@ -8049,7 +8045,6 @@ components:
              Format: environments/{environment}
              If unspecified, all stages are created.
              If set to "", no stages are created.
-          nullable: true
       title: CreateRolloutRequest
       additionalProperties: false
     bytebase.v1.CreateSheetRequest:
@@ -8153,7 +8148,6 @@ components:
             - string
             - "null"
           title: level_id
-          nullable: true
       title: DataClassification
       additionalProperties: false
     bytebase.v1.DataClassificationSetting.DataClassificationConfig.Level:
@@ -8631,7 +8625,6 @@ components:
           description: |-
             The environment resource.
              Format: environments/prod where prod is the environment resource ID.
-          nullable: true
         effectiveEnvironment:
           type:
             - string
@@ -8641,7 +8634,6 @@ components:
             The effective environment based on environment tag above and environment
              tag on the instance. Inheritance follows
              https://cloud.google.com/resource-manager/docs/tags/tags-overview.
-          nullable: true
         labels:
           type: object
           title: labels
@@ -9436,7 +9428,6 @@ components:
           description: |-
             The default schema to search objects. Equals to the current schema in
              Oracle and search path in Postgres.
-          nullable: true
       title: ExportRequest
       additionalProperties: false
     bytebase.v1.ExportResponse:
@@ -10417,7 +10408,6 @@ components:
           description: |-
             The environment resource.
              Format: environments/prod where prod is the environment resource ID.
-          nullable: true
         activation:
           type: boolean
           title: activation
@@ -10505,7 +10495,6 @@ components:
           description: |-
             The environment resource.
              Format: environments/prod where prod is the environment resource ID.
-          nullable: true
       title: InstanceResource
       additionalProperties: false
     bytebase.v1.InstanceRole:
@@ -10528,7 +10517,6 @@ components:
             - "null"
           title: password
           description: The role password.
-          nullable: true
         connectionLimit:
           type:
             - integer
@@ -10536,14 +10524,12 @@ components:
           title: connection_limit
           format: int32
           description: The connection count limit for this role.
-          nullable: true
         validUntil:
           type:
             - string
             - "null"
           title: valid_until
           description: The expiration for the role's password.
-          nullable: true
         attribute:
           type:
             - string
@@ -10553,7 +10539,6 @@ components:
             The role attribute.
              For PostgreSQL, it contains super_user, no_inherit, create_role, create_db, can_login, replication, and bypass_rls. Docs: https://www.postgresql.org/docs/current/role-attributes.html
              For MySQL, it's the global privileges as GRANT statements, which means it only contains "GRANT ... ON *.* TO ...". Docs: https://dev.mysql.com/doc/refman/8.0/en/grant.html
-          nullable: true
       title: InstanceRole
       additionalProperties: false
       description: InstanceRole is the API message for instance role.
@@ -10753,32 +10738,26 @@ components:
             - string
             - "null"
           title: from_title
-          nullable: true
         toTitle:
           type:
             - string
             - "null"
           title: to_title
-          nullable: true
         fromDescription:
           type:
             - string
             - "null"
           title: from_description
-          nullable: true
         toDescription:
           type:
             - string
             - "null"
           title: to_description
-          nullable: true
         fromStatus:
           title: from_status
-          nullable: true
           $ref: '#/components/schemas/bytebase.v1.IssueStatus'
         toStatus:
           title: to_status
-          nullable: true
           $ref: '#/components/schemas/bytebase.v1.IssueStatus'
         fromLabels:
           type: array
@@ -10810,7 +10789,6 @@ components:
           description: |-
             The previous sheet.
              Format: projects/{project}/sheets/{sheet}
-          nullable: true
         toSheet:
           type:
             - string
@@ -10819,7 +10797,6 @@ components:
           description: |-
             The new sheet.
              Format: projects/{project}/sheets/{sheet}
-          nullable: true
       title: PlanSpecUpdate
       additionalProperties: false
       description: Plan spec update event information (tracks sheet changes to plan specs).
@@ -11223,7 +11200,6 @@ components:
         instance:
           title: instance
           description: The target instance. We need to set this field if the target instance is not created yet.
-          nullable: true
           $ref: '#/components/schemas/bytebase.v1.Instance'
       title: ListInstanceDatabaseRequest
       additionalProperties: false
@@ -11580,7 +11556,6 @@ components:
         policyType:
           title: policy_type
           description: Filter by specific policy type.
-          nullable: true
           $ref: '#/components/schemas/bytebase.v1.PolicyType'
         showDeleted:
           type: boolean
@@ -11989,21 +11964,18 @@ components:
             - "null"
           title: otp_code
           description: The otp_code is used to verify the user's identity by MFA.
-          nullable: true
         recoveryCode:
           type:
             - string
             - "null"
           title: recovery_code
           description: The recovery_code is used to recovery the user's identity with MFA.
-          nullable: true
         mfaTempToken:
           type:
             - string
             - "null"
           title: mfa_temp_token
           description: The mfa_temp_token is used to verify the user's identity by MFA.
-          nullable: true
       title: LoginRequest
       additionalProperties: false
     bytebase.v1.LoginResponse:
@@ -12021,7 +11993,6 @@ components:
             - "null"
           title: mfa_temp_token
           description: Temporary token for MFA verification.
-          nullable: true
         requireResetPassword:
           type: boolean
           title: require_reset_password
@@ -12648,7 +12619,6 @@ components:
           description: |-
             The zip password provide by users.
              Leave it empty if no needs to encrypt the zip file.
-          nullable: true
       title: ExportDataConfig
       additionalProperties: false
     bytebase.v1.Plan.PlanCheckRunStatusCountEntry:
@@ -13317,7 +13287,6 @@ components:
             - string
             - "null"
           title: error
-          nullable: true
         duration:
           title: duration
           $ref: '#/components/schemas/google.protobuf.Duration'
@@ -13396,7 +13365,6 @@ components:
           description: |-
             The default schema to search objects. Equals to the current schema in
              Oracle and search path in Postgres.
-          nullable: true
         queryOption:
           title: query_option
           $ref: '#/components/schemas/bytebase.v1.QueryOption'
@@ -13408,7 +13376,6 @@ components:
           description: |-
             Container is the container name to execute the query against, used for
              CosmosDB only.
-          nullable: true
       title: QueryRequest
       additionalProperties: false
     bytebase.v1.QueryResponse:
@@ -14221,7 +14188,6 @@ components:
             The UUID of the specific spec to run plan checks for.
              This should match the spec.id field in Plan.Spec.
              If not set, all specs in the plan will be used.
-          nullable: true
       title: RunPlanChecksRequest
       additionalProperties: false
     bytebase.v1.RunPlanChecksResponse:
@@ -15731,14 +15697,12 @@ components:
               description: |-
                 The update_time is the update time of latest task run.
                  If there are no task runs, it will be empty.
-              nullable: true
               $ref: '#/components/schemas/google.protobuf.Timestamp'
             runTime:
               title: run_time
               description: |-
                 The run_time is the scheduled run time of latest task run.
                  If there are no task runs or the task run is not scheduled, it will be empty.
-              nullable: true
               $ref: '#/components/schemas/google.protobuf.Timestamp'
         - oneOf:
             - properties:
@@ -15936,7 +15900,6 @@ components:
           description: |-
             The task run should run after run_time.
              This can only be set when creating the task run calling BatchRunTasks.
-          nullable: true
           $ref: '#/components/schemas/google.protobuf.Timestamp'
       title: TaskRun
       additionalProperties: false
@@ -16372,35 +16335,30 @@ components:
             - "null"
           title: state
           description: Session state (active, idle, etc.).
-          nullable: true
         waitEventType:
           type:
             - string
             - "null"
           title: wait_event_type
           description: Wait event type if session is waiting.
-          nullable: true
         waitEvent:
           type:
             - string
             - "null"
           title: wait_event
           description: Specific wait event if session is waiting.
-          nullable: true
         datname:
           type:
             - string
             - "null"
           title: datname
           description: Database name.
-          nullable: true
         usename:
           type:
             - string
             - "null"
           title: usename
           description: User name.
-          nullable: true
         applicationName:
           type: string
           title: application_name
@@ -16411,14 +16369,12 @@ components:
             - "null"
           title: client_addr
           description: Client IP address.
-          nullable: true
         clientPort:
           type:
             - string
             - "null"
           title: client_port
           description: Client port number.
-          nullable: true
         backendStart:
           title: backend_start
           description: When the backend process started.
@@ -16426,12 +16382,10 @@ components:
         xactStart:
           title: xact_start
           description: When the current transaction started.
-          nullable: true
           $ref: '#/components/schemas/google.protobuf.Timestamp'
         queryStart:
           title: query_start
           description: When the current query started.
-          nullable: true
           $ref: '#/components/schemas/google.protobuf.Timestamp'
       title: Session
       additionalProperties: false
@@ -17059,7 +17013,6 @@ components:
             - "null"
           title: otp_code
           description: The otp_code is used to verify the user's identity by MFA.
-          nullable: true
         regenerateTempMfaSecret:
           type: boolean
           title: regenerate_temp_mfa_secret

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -323,7 +323,7 @@ func (s *RolloutService) ListTaskRuns(ctx context.Context, req *connect.Request[
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to list task runs"))
 	}
 
-	taskRunsV1, err := convertToTaskRuns(ctx, s.store, s.bus, taskRuns)
+	taskRunsV1, err := convertToTaskRuns(ctx, s.store, taskRuns)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to task runs"))
 	}
@@ -467,7 +467,7 @@ func (s *RolloutService) GetTaskRun(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("task run %d not found in rollout %d", taskRunUID, planID))
 	}
 
-	taskRunV1, err := convertToTaskRun(ctx, s.store, s.bus, taskRun)
+	taskRunV1, err := convertToTaskRun(ctx, s.store, taskRun)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to task run"))
 	}

--- a/backend/component/bus/bus.go
+++ b/backend/component/bus/bus.go
@@ -11,8 +11,6 @@ type Bus struct {
 	// Triggered by plan check completion, issue creation (if checks already done).
 	ApprovalCheckChan chan int64 // issue UID
 
-	TaskRunSchedulerInfo sync.Map // map[taskRunID]*storepb.SchedulerInfo
-
 	// RunningTaskRunsCancelFunc is the cancelFunc of running taskruns.
 	RunningTaskRunsCancelFunc sync.Map // map[taskRunID]context.CancelFunc
 

--- a/backend/generated-go/store/task_run.pb.go
+++ b/backend/generated-go/store/task_run.pb.go
@@ -256,6 +256,54 @@ func (x *SchedulerInfo) GetWaitingCause() *SchedulerInfo_WaitingCause {
 	return nil
 }
 
+// TaskRunPayload contains extensible runtime data for a task run.
+// Stored in the payload JSONB column. New fields can be added here
+// without database schema changes.
+type TaskRunPayload struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Scheduler information about why a task is waiting.
+	SchedulerInfo *SchedulerInfo `protobuf:"bytes,1,opt,name=scheduler_info,json=schedulerInfo,proto3" json:"scheduler_info,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaskRunPayload) Reset() {
+	*x = TaskRunPayload{}
+	mi := &file_store_task_run_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaskRunPayload) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaskRunPayload) ProtoMessage() {}
+
+func (x *TaskRunPayload) ProtoReflect() protoreflect.Message {
+	mi := &file_store_task_run_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaskRunPayload.ProtoReflect.Descriptor instead.
+func (*TaskRunPayload) Descriptor() ([]byte, []int) {
+	return file_store_task_run_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *TaskRunPayload) GetSchedulerInfo() *SchedulerInfo {
+	if x != nil {
+		return x.SchedulerInfo
+	}
+	return nil
+}
+
 // WaitingCause indicates why a task run is waiting to execute.
 type SchedulerInfo_WaitingCause struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -269,7 +317,7 @@ type SchedulerInfo_WaitingCause struct {
 
 func (x *SchedulerInfo_WaitingCause) Reset() {
 	*x = SchedulerInfo_WaitingCause{}
-	mi := &file_store_task_run_proto_msgTypes[3]
+	mi := &file_store_task_run_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -281,7 +329,7 @@ func (x *SchedulerInfo_WaitingCause) String() string {
 func (*SchedulerInfo_WaitingCause) ProtoMessage() {}
 
 func (x *SchedulerInfo_WaitingCause) ProtoReflect() protoreflect.Message {
-	mi := &file_store_task_run_proto_msgTypes[3]
+	mi := &file_store_task_run_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -351,7 +399,9 @@ const file_store_task_run_proto_rawDesc = "" +
 	"\rwaiting_cause\x18\x02 \x01(\v2*.bytebase.store.SchedulerInfo.WaitingCauseR\fwaitingCause\x1aK\n" +
 	"\fWaitingCause\x122\n" +
 	"\x14parallel_tasks_limit\x18\x03 \x01(\bH\x00R\x12parallelTasksLimitB\a\n" +
-	"\x05causeB\x8f\x01\n" +
+	"\x05cause\"V\n" +
+	"\x0eTaskRunPayload\x12D\n" +
+	"\x0escheduler_info\x18\x01 \x01(\v2\x1d.bytebase.store.SchedulerInfoR\rschedulerInfoB\x8f\x01\n" +
 	"\x12com.bytebase.storeB\fTaskRunProtoP\x01Z\x12generated-go/store\xa2\x02\x03BSX\xaa\x02\x0eBytebase.Store\xca\x02\x0eBytebase\\Store\xe2\x02\x1aBytebase\\Store\\GPBMetadata\xea\x02\x0fBytebase::Storeb\x06proto3"
 
 var (
@@ -367,23 +417,25 @@ func file_store_task_run_proto_rawDescGZIP() []byte {
 }
 
 var file_store_task_run_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_store_task_run_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_store_task_run_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_store_task_run_proto_goTypes = []any{
 	(TaskRun_Status)(0),                // 0: bytebase.store.TaskRun.Status
 	(*TaskRun)(nil),                    // 1: bytebase.store.TaskRun
 	(*TaskRunResult)(nil),              // 2: bytebase.store.TaskRunResult
 	(*SchedulerInfo)(nil),              // 3: bytebase.store.SchedulerInfo
-	(*SchedulerInfo_WaitingCause)(nil), // 4: bytebase.store.SchedulerInfo.WaitingCause
-	(*timestamppb.Timestamp)(nil),      // 5: google.protobuf.Timestamp
+	(*TaskRunPayload)(nil),             // 4: bytebase.store.TaskRunPayload
+	(*SchedulerInfo_WaitingCause)(nil), // 5: bytebase.store.SchedulerInfo.WaitingCause
+	(*timestamppb.Timestamp)(nil),      // 6: google.protobuf.Timestamp
 }
 var file_store_task_run_proto_depIdxs = []int32{
-	5, // 0: bytebase.store.SchedulerInfo.report_time:type_name -> google.protobuf.Timestamp
-	4, // 1: bytebase.store.SchedulerInfo.waiting_cause:type_name -> bytebase.store.SchedulerInfo.WaitingCause
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	6, // 0: bytebase.store.SchedulerInfo.report_time:type_name -> google.protobuf.Timestamp
+	5, // 1: bytebase.store.SchedulerInfo.waiting_cause:type_name -> bytebase.store.SchedulerInfo.WaitingCause
+	3, // 2: bytebase.store.TaskRunPayload.scheduler_info:type_name -> bytebase.store.SchedulerInfo
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_store_task_run_proto_init() }
@@ -391,7 +443,7 @@ func file_store_task_run_proto_init() {
 	if File_store_task_run_proto != nil {
 		return
 	}
-	file_store_task_run_proto_msgTypes[3].OneofWrappers = []any{
+	file_store_task_run_proto_msgTypes[4].OneofWrappers = []any{
 		(*SchedulerInfo_WaitingCause_ParallelTasksLimit)(nil),
 	}
 	type x struct{}
@@ -400,7 +452,7 @@ func file_store_task_run_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_store_task_run_proto_rawDesc), len(file_store_task_run_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/backend/generated-go/store/task_run_equal.pb.go
+++ b/backend/generated-go/store/task_run_equal.pb.go
@@ -60,3 +60,16 @@ func (x *SchedulerInfo) Equal(y *SchedulerInfo) bool {
 	}
 	return true
 }
+
+func (x *TaskRunPayload) Equal(y *TaskRunPayload) bool {
+	if x == y {
+		return true
+	}
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	if !x.SchedulerInfo.Equal(y.SchedulerInfo) {
+		return false
+	}
+	return true
+}

--- a/backend/migrator/migration/3.14/0032##task_run_payload.sql
+++ b/backend/migrator/migration/3.14/0032##task_run_payload.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task_run ADD COLUMN payload jsonb NOT NULL DEFAULT '{}';

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -265,7 +265,9 @@ CREATE TABLE task_run (
     -- result saves the task run result in json format
     -- Stored as TaskRunResult (proto/store/store/task_run.proto)
     result jsonb NOT NULL DEFAULT '{}',
-    replica_id TEXT
+    replica_id TEXT,
+    -- Stored as TaskRunPayload (proto/store/store/task_run.proto)
+    payload jsonb NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX idx_task_run_task_id ON task_run(task_id);

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,8 +12,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.14.31"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.14/0031##normalize_statement_types.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.14.32"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.14/0032##task_run_payload.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/docs/plans/2026-01-13-task-run-payload-ha-design.md
+++ b/docs/plans/2026-01-13-task-run-payload-ha-design.md
@@ -1,0 +1,67 @@
+# Task Run Payload for HA Scheduler State
+
+## Problem
+
+`TaskRunSchedulerInfo` is stored in-memory in `Bus.sync.Map`. This breaks HA:
+- Lost on replica crash
+- Not shared across replicas
+- UI can't show why a task is waiting if the tracking replica dies
+
+## Solution
+
+Add a `payload` JSONB column to `task_run` table, storing a `TaskRunPayload` proto that contains `SchedulerInfo`. Future fields can be added to the proto without schema changes.
+
+## Design
+
+### Proto
+
+`proto/store/store/task_run.proto`:
+```protobuf
+message TaskRunPayload {
+  SchedulerInfo scheduler_info = 1;
+  // Future fields added here without schema changes
+}
+```
+
+### Schema
+
+Migration `backend/migrator/migration/3.14/0032##task_run_payload.sql`:
+```sql
+ALTER TABLE task_run ADD COLUMN payload jsonb NOT NULL DEFAULT '{}';
+```
+
+### Store Layer
+
+`backend/store/task_run.go`:
+- Add `PayloadProto *storepb.TaskRunPayload` to `TaskRunMessage`
+- Read: Add `payload` to SELECT, unmarshal with `protojson`
+- Write: `UpdateTaskRunPayload(ctx, taskRunID, payload)` method
+
+### Scheduler
+
+`backend/runner/taskrun/pending_scheduler.go`:
+- `storeParallelLimitCause()`: Write `TaskRunPayload{SchedulerInfo: ...}` to DB
+- `promoteTaskRun()`: Write empty `TaskRunPayload{}` to clear
+
+### API
+
+`backend/api/v1/rollout_service_converter.go`:
+- Remove `bus *bus.Bus` parameter
+- Read `SchedulerInfo` from `taskRun.PayloadProto.SchedulerInfo`
+
+### Cleanup
+
+`backend/component/bus/bus.go`:
+- Remove `TaskRunSchedulerInfo sync.Map`
+
+## Files to Modify
+
+1. `proto/store/store/task_run.proto` - Add `TaskRunPayload`
+2. `backend/migrator/migration/3.14/0032##task_run_payload.sql` - New
+3. `backend/migrator/migration/LATEST.sql` - Add column
+4. `backend/migrator/migrator_test.go` - Update version
+5. `backend/store/task_run.go` - Add field and methods
+6. `backend/runner/taskrun/pending_scheduler.go` - Use store
+7. `backend/api/v1/rollout_service_converter.go` - Remove Bus
+8. `backend/api/v1/rollout_service.go` - Update converter calls
+9. `backend/component/bus/bus.go` - Remove field

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -289,6 +289,7 @@
     - [SchedulerInfo](#bytebase-store-SchedulerInfo)
     - [SchedulerInfo.WaitingCause](#bytebase-store-SchedulerInfo-WaitingCause)
     - [TaskRun](#bytebase-store-TaskRun)
+    - [TaskRunPayload](#bytebase-store-TaskRunPayload)
     - [TaskRunResult](#bytebase-store-TaskRunResult)
   
     - [TaskRun.Status](#bytebase-store-TaskRun-Status)
@@ -4755,6 +4756,23 @@ WaitingCause indicates why a task run is waiting to execute.
 
 ### TaskRun
 TaskRun represents an execution attempt of a task.
+
+
+
+
+
+
+<a name="bytebase-store-TaskRunPayload"></a>
+
+### TaskRunPayload
+TaskRunPayload contains extensible runtime data for a task run.
+Stored in the payload JSONB column. New fields can be added here
+without database schema changes.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| scheduler_info | [SchedulerInfo](#bytebase-store-SchedulerInfo) |  | Scheduler information about why a task is waiting. |
 
 
 

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -1329,6 +1329,10 @@
                 </li>
               
                 <li>
+                  <a href="#bytebase.store.TaskRunPayload"><span class="badge">M</span>TaskRunPayload</a>
+                </li>
+              
+                <li>
                   <a href="#bytebase.store.TaskRunResult"><span class="badge">M</span>TaskRunResult</a>
                 </li>
               
@@ -12967,6 +12971,30 @@ or sheet content for non-release tasks.</p></td>
         <p>TaskRun represents an execution attempt of a task.</p>
 
         
+
+        
+      
+        <h3 id="bytebase.store.TaskRunPayload">TaskRunPayload</h3>
+        <p>TaskRunPayload contains extensible runtime data for a task run.</p><p>Stored in the payload JSONB column. New fields can be added here</p><p>without database schema changes.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>scheduler_info</td>
+                  <td><a href="#bytebase.store.SchedulerInfo">SchedulerInfo</a></td>
+                  <td></td>
+                  <td><p>Scheduler information about why a task is waiting. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
 
         
       

--- a/proto/store/store/task_run.proto
+++ b/proto/store/store/task_run.proto
@@ -59,3 +59,11 @@ message SchedulerInfo {
   // Reason why the task run is currently waiting.
   WaitingCause waiting_cause = 2;
 }
+
+// TaskRunPayload contains extensible runtime data for a task run.
+// Stored in the payload JSONB column. New fields can be added here
+// without database schema changes.
+message TaskRunPayload {
+  // Scheduler information about why a task is waiting.
+  SchedulerInfo scheduler_info = 1;
+}


### PR DESCRIPTION
## Summary
- Add `payload` JSONB column to `task_run` table for extensible runtime data
- Move `TaskRunSchedulerInfo` from in-memory Bus to database for HA support
- Define `TaskRunPayload` proto wrapper so future fields can be added without schema changes

## Test plan
- [ ] Deploy to staging with multiple replicas
- [ ] Create a rollout with parallel task limit < number of tasks
- [ ] Verify scheduler info shows in UI when tasks are blocked
- [ ] Kill one replica and verify the other replica still shows scheduler info

🤖 Generated with [Claude Code](https://claude.com/claude-code)