### PR TITLE
fix(fe): disable Monaco Editor read-only tooltip

### DIFF
--- a/frontend/src/components/MonacoEditor/editor.ts
+++ b/frontend/src/components/MonacoEditor/editor.ts
@@ -41,9 +41,7 @@ export const createMonacoEditor = async (config: {
 
   // Disable "Cannot edit in read-only editor" tooltip
   // https://github.com/microsoft/monaco-editor/discussions/4156
-  editor
-    .getContribution("editor.contrib.readOnlyMessageController")
-    ?.dispose();
+  editor.getContribution("editor.contrib.readOnlyMessageController")?.dispose();
 
   MonacoEditorReadyDefer.resolve(undefined);
 


### PR DESCRIPTION
Dispose the readOnlyMessageController to prevent the "Cannot edit in read-only editor" tooltip from appearing.