### PR TITLE
feat(store): add LRU cache with TTL for IAM policies

### DIFF
--- a/backend/component/iam/manager.go
+++ b/backend/component/iam/manager.go
@@ -40,7 +40,7 @@ func (m *Manager) CheckPermission(ctx context.Context, p permission.Permission, 
 		return members
 	}
 
-	policyMessage, err := m.store.GetWorkspaceIamPolicy(ctx)
+	policyMessage, err := m.store.GetWorkspaceIamPolicySnapshot(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -61,7 +61,7 @@ func (m *Manager) CheckPermission(ctx context.Context, p permission.Permission, 
 			if project == nil {
 				return false, errors.Errorf("project %q not found", projectID)
 			}
-			policyMessage, err := m.store.GetProjectIamPolicy(ctx, project.ResourceID)
+			policyMessage, err := m.store.GetProjectIamPolicySnapshot(ctx, project.ResourceID)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
## Summary
- Add expirable LRU cache (1024 entries, 1 minute TTL) for IAM policies following the strongread + snapshot pattern
- Add `GetWorkspaceIamPolicySnapshot` and `GetProjectIamPolicySnapshot` methods that check cache before database
- Update `CheckPermission` to use snapshot methods for better performance in hot paths

## Test plan
- [ ] Verify permission checks work correctly with cached policies
- [ ] Verify cache invalidation on policy mutations
- [ ] Verify TTL expiration behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)