### PR TITLE
fix(oauth2): allow custom URL schemes in redirect URIs

### DIFF
--- a/backend/api/oauth2/register.go
+++ b/backend/api/oauth2/register.go
@@ -49,9 +49,9 @@ func (s *Service) handleRegister(c echo.Context) error {
 		if err != nil {
 			return oauth2Error(c, http.StatusBadRequest, "invalid_redirect_uri", "invalid redirect URI format")
 		}
-		// Require HTTPS except for localhost
-		if parsed.Scheme != "https" && !isLocalhostURI(uri) {
-			return oauth2Error(c, http.StatusBadRequest, "invalid_redirect_uri", "redirect URI must use HTTPS (except localhost)")
+		// Reject plain HTTP except for localhost (allow HTTPS and custom schemes like cursor://, vscode://)
+		if parsed.Scheme == "http" && !isLocalhostURI(uri) {
+			return oauth2Error(c, http.StatusBadRequest, "invalid_redirect_uri", "http:// redirect URIs are only allowed for localhost")
 		}
 	}
 


### PR DESCRIPTION
Close BYT-8705

## Summary
- Allow custom URL schemes (e.g., `cursor://`, `vscode://`) in OAuth2 redirect URIs for native applications
- Changed validation to only reject plain `http://` (except localhost), allowing both `https://` and custom schemes
- Per RFC 8252 (OAuth 2.0 for Native Apps), private-use URI schemes are valid for native app callbacks

## Test plan
- [ ] Register OAuth2 client with `cursor://callback` redirect URI - should succeed
- [ ] Register OAuth2 client with `https://example.com/callback` - should succeed
- [ ] Register OAuth2 client with `http://localhost/callback` - should succeed
- [ ] Register OAuth2 client with `http://example.com/callback` - should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)