### PR TITLE
fix(store): initialize internalIndexes map for partition table metadata

### DIFF
--- a/backend/store/model/database.go
+++ b/backend/store/model/database.go
@@ -769,9 +769,11 @@ func buildTablesMetadataRecursive(originalColumn []*storepb.ColumnMetadata, colu
 
 	for _, partition := range partitions {
 		partitionMetadata := &TableMetadata{
-			partitionOf:    root,
-			internalColumn: make(map[string]*ColumnMetadata),
-			proto:          proto,
+			partitionOf:           root,
+			isDetailCaseSensitive: isDetailCaseSensitive,
+			internalColumn:        make(map[string]*ColumnMetadata),
+			internalIndexes:       make(map[string]*IndexMetadata),
+			proto:                 proto,
 		}
 		for _, column := range originalColumn {
 			columnCatalog := columnCatalogMap[column.Name]


### PR DESCRIPTION
Close BYT-8718

## Summary
- Fix nil map panic when `CreateIndex` is called on partition tables
- Partition tables created via `buildTablesMetadata` were missing `internalIndexes` map initialization
- Also added missing `isDetailCaseSensitive` field for consistency

## Test plan
- [x] Added `TestPartitionTable_CreateIndex` test that verifies indexes can be created on partition tables
- [x] Verified test fails without the fix (nil map panic)
- [x] All existing model tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)