### PR TITLE
fix(frontend): treat empty approval flow as no approval required

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/context.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/context.ts
@@ -136,6 +136,13 @@ function computeExportArchiveReady(
   return true;
 }
 
+// Check if issue has no approval required (empty approval flow)
+function hasNoApprovalRequired(issue: Issue | undefined): boolean {
+  if (!issue) return false;
+  const roles = issue.approvalTemplate?.flow?.roles ?? [];
+  return roles.length === 0;
+}
+
 export function buildActionContext(input: ContextBuilderInput): ActionContext {
   const {
     plan,
@@ -220,9 +227,13 @@ export function buildActionContext(input: ContextBuilderInput): ActionContext {
   );
 
   // Compute approval status
+  // Issue is considered approved if:
+  // - Status is APPROVED or SKIPPED, OR
+  // - Approval template has no roles (no approval required)
   const issueApproved =
     issue?.approvalStatus === Issue_ApprovalStatus.APPROVED ||
-    issue?.approvalStatus === Issue_ApprovalStatus.SKIPPED;
+    issue?.approvalStatus === Issue_ApprovalStatus.SKIPPED ||
+    hasNoApprovalRequired(issue);
 
   return {
     plan,

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/IssueStatusSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/IssueStatusSection.vue
@@ -38,9 +38,13 @@ const issueStatusText = computed(() => {
     return "";
   }
 
+  // Issue is rollout-ready if approved, skipped, or has no approval required (empty flow)
+  const roles = issueValue.approvalTemplate?.flow?.roles ?? [];
+  const noApprovalRequired = roles.length === 0;
   const rolloutReady =
     issueValue.approvalStatus === Issue_ApprovalStatus.APPROVED ||
-    issueValue.approvalStatus === Issue_ApprovalStatus.SKIPPED;
+    issueValue.approvalStatus === Issue_ApprovalStatus.SKIPPED ||
+    noApprovalRequired;
   if (rolloutReady) {
     return t("issue.review.approved");
   }

--- a/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
+++ b/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
@@ -89,10 +89,13 @@ export const useRolloutReadyLink = () => {
 
     // For OPEN issues, check if approved and has actionable tasks
     if (issue.value.status === IssueStatus.OPEN) {
-      // Check if issue is approved
+      // Check if issue is approved or has no approval required (empty flow)
+      const roles = issue.value.approvalTemplate?.flow?.roles ?? [];
+      const noApprovalRequired = roles.length === 0;
       if (
         issue.value.approvalStatus !== Issue_ApprovalStatus.APPROVED &&
-        issue.value.approvalStatus !== Issue_ApprovalStatus.SKIPPED
+        issue.value.approvalStatus !== Issue_ApprovalStatus.SKIPPED &&
+        !noApprovalRequired
       ) {
         return false;
       }


### PR DESCRIPTION
When an approval template has an empty flow (no roles), treat it as "no approval required" - same as skipped approval. This affects:

- Create rollout action visibility and primary state
- Issue status section showing "Approved" instead of "Under review"
- Rollout ready link visibility for OPEN issues