### PR TITLE
fix(store): remove nested transaction patterns to prevent deadlock

### DIFF
--- a/backend/store/group.go
+++ b/backend/store/group.go
@@ -57,17 +57,8 @@ func (s *Store) GetGroup(ctx context.Context, find *FindGroupMessage) (*GroupMes
 		}
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	groups, err := s.ListGroups(ctx, find)
 	if err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 

--- a/backend/store/idp.go
+++ b/backend/store/idp.go
@@ -98,17 +98,8 @@ func (s *Store) CreateIdentityProvider(ctx context.Context, create *IdentityProv
 
 // GetIdentityProvider gets an identity provider.
 func (s *Store) GetIdentityProvider(ctx context.Context, find *FindIdentityProviderMessage) (*IdentityProviderMessage, error) {
-	tx, err := s.GetDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	identityProviders, err := s.ListIdentityProviders(ctx, find)
 	if err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 

--- a/backend/store/instance.go
+++ b/backend/store/instance.go
@@ -173,12 +173,6 @@ func (s *Store) CreateInstance(ctx context.Context, instanceCreate *InstanceMess
 		return nil, err
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	redacted, err := s.obfuscateInstance(ctx, instanceCreate.Metadata)
 	if err != nil {
 		return nil, err
@@ -191,6 +185,13 @@ func (s *Store) CreateInstance(ctx context.Context, instanceCreate *InstanceMess
 	if instanceCreate.EnvironmentID != nil && *instanceCreate.EnvironmentID != "" {
 		environment = instanceCreate.EnvironmentID
 	}
+
+	tx, err := s.GetDB().BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
 	q := qb.Q().Space(`
 			INSERT INTO instance (
 				resource_id,

--- a/backend/store/policy.go
+++ b/backend/store/policy.go
@@ -453,12 +453,6 @@ func (s *Store) GetPolicy(ctx context.Context, find *FindPolicyMessage) (*Policy
 		}
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	// We will always return the resource regardless of its deleted state.
 	find.ShowAll = true
 	policies, err := s.ListPolicies(ctx, find)
@@ -476,10 +470,6 @@ func (s *Store) GetPolicy(ctx context.Context, find *FindPolicyMessage) (*Policy
 		return nil, &common.Error{Code: common.Conflict, Err: errors.Errorf("found %d policies with filter %+v, expect 1", len(policies), find)}
 	}
 	policy := policies[0]
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
 
 	s.policyCache.Add(getPolicyCacheKey(policy.ResourceType, policy.Resource, policy.Type), policy)
 


### PR DESCRIPTION
## Summary

- Remove unnecessary transactions in `GetPolicy()`, `GetGroup()`, and `GetIdentityProvider()` that just delegate to their respective `List*` functions (which already manage their own transactions)
- Move `obfuscateInstance()` call outside the transaction in `CreateInstance()` to avoid nested connection acquisition

These patterns caused the same issue as #18904 - holding a transaction connection while calling another function that needs its own connection, which can deadlock when the connection pool is exhausted under high concurrency.

## Test plan

- [ ] Verify `GetPolicy`, `GetGroup`, `GetIdentityProvider` still work correctly
- [ ] Verify `CreateInstance` still creates instances properly
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)