### PR TITLE
refactor(frontend): standardize issue status terminology and remove resolve action

### DIFF
--- a/frontend/src/components/IssueV1/components/BatchIssueActionsV1.vue
+++ b/frontend/src/components/IssueV1/components/BatchIssueActionsV1.vue
@@ -1,25 +1,5 @@
 <template>
   <TooltipButton
-    type="primary"
-    :disabled="!isActionApplicableForAllIssues('RESOLVE')"
-    tooltip-mode="DISABLED-ONLY"
-    @click="startBatchIssueStatusAction('RESOLVE')"
-  >
-    <template #default>
-      {{ $t("issue.batch-transition.resolve") }}
-    </template>
-    <template #tooltip>
-      <div class="whitespace-nowrap">
-        {{
-          $t("issue.batch-transition.not-allowed-tips", {
-            operation: $t("issue.batch-transition.resolved"),
-          })
-        }}
-      </div>
-    </template>
-  </TooltipButton>
-
-  <TooltipButton
     :disabled="!isActionApplicableForAllIssues('CLOSE')"
     tooltip-mode="DISABLED-ONLY"
     @click="startBatchIssueStatusAction('CLOSE')"

--- a/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
+++ b/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
@@ -134,7 +134,7 @@ export const useIssueSearchScopeOptions = (
           {
             value: IssueStatus[IssueStatus.CANCELED],
             keywords: ["closed", "canceled"],
-            render: () => renderSpan(t("common.canceled")),
+            render: () => renderSpan(t("common.closed")),
           },
         ],
       },

--- a/frontend/src/components/IssueV1/components/IssueStatusIcon.vue
+++ b/frontend/src/components/IssueV1/components/IssueStatusIcon.vue
@@ -117,7 +117,7 @@ const stringifyIssueStatus = (issueStatus: IssueStatus): string => {
   } else if (issueStatus === IssueStatus.DONE) {
     return t("common.done");
   } else if (issueStatus === IssueStatus.CANCELED) {
-    return t("common.canceled");
+    return t("common.closed");
   }
   return "";
 };

--- a/frontend/src/components/IssueV1/components/Panel/IssueStatusActionPanel.vue
+++ b/frontend/src/components/IssueV1/components/Panel/IssueStatusActionPanel.vue
@@ -131,8 +131,6 @@ const title = computed(() => {
   const { action } = props;
 
   switch (action) {
-    case "RESOLVE":
-      return t("issue.status-transition.modal.resolve");
     case "CLOSE":
       return t("issue.status-transition.modal.close");
     case "REOPEN":

--- a/frontend/src/components/IssueV1/logic/action/issue.ts
+++ b/frontend/src/components/IssueV1/logic/action/issue.ts
@@ -7,13 +7,12 @@ import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import {
   flattenTaskV1List,
   hasProjectPermissionV2,
-  isDatabaseChangeRelatedIssue,
   isDatabaseDataExportIssue,
   isGrantRequestIssue,
 } from "@/utils";
-import { isTaskFinished, projectOfIssue } from "..";
+import { projectOfIssue } from "..";
 
-export type IssueStatusAction = "RESOLVE" | "CLOSE" | "REOPEN";
+export type IssueStatusAction = "CLOSE" | "REOPEN";
 
 export const IssueStatusActionToIssueStatusMap: Record<
   IssueStatusAction,
@@ -21,12 +20,12 @@ export const IssueStatusActionToIssueStatusMap: Record<
 > = {
   CLOSE: IssueStatus.CANCELED,
   REOPEN: IssueStatus.OPEN,
-  RESOLVE: IssueStatus.DONE,
 };
 
 const PossibleIssueStatusActionMap: Record<IssueStatus, IssueStatusAction[]> = {
-  [IssueStatus.OPEN]: ["RESOLVE", "CLOSE"],
-  [IssueStatus.DONE]: ["REOPEN"],
+  [IssueStatus.OPEN]: ["CLOSE"],
+  // Done/resolved issues cannot be reopened
+  [IssueStatus.DONE]: [],
   [IssueStatus.CANCELED]: ["REOPEN"],
 
   // Only to make TypeScript compiler happy
@@ -39,15 +38,8 @@ export const getApplicableIssueStatusActionList = (
   const list = PossibleIssueStatusActionMap[issue.status];
   return list.filter((action) => {
     if (isGrantRequestIssue(issue) || isDatabaseDataExportIssue(issue)) {
-      // Don't show RESOLVE or REOPEN for grantRequest/dataExport issues.
-      if (action === "RESOLVE" || action === "REOPEN") {
-        return false;
-      }
-    }
-    if (isDatabaseChangeRelatedIssue(issue) && action === "RESOLVE") {
-      const tasks = flattenTaskV1List(issue.rolloutEntity);
-      // Ths issue cannot be resolved if some tasks are not finished yet.
-      if (tasks.some((task) => !isTaskFinished(task))) {
+      // Don't show REOPEN for grantRequest/dataExport issues.
+      if (action === "REOPEN") {
         return false;
       }
     }
@@ -61,9 +53,6 @@ export const issueStatusActionDisplayName = (
 ) => {
   let actionText = "";
   switch (action) {
-    case "RESOLVE":
-      actionText = t("issue.batch-transition.resolve");
-      break;
     case "CLOSE":
       actionText = t("issue.batch-transition.close");
       break;
@@ -86,10 +75,6 @@ export const issueStatusActionButtonProps = (
   action: IssueStatusAction
 ): ButtonProps => {
   switch (action) {
-    case "RESOLVE":
-      return {
-        type: "success",
-      };
     case "CLOSE":
       return {
         type: "default",

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/ACTIONS.md
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/ACTIONS.md
@@ -35,7 +35,7 @@ Actions/
 
 **hasDeferredRollout**: Plans where rollout is created on-demand (export, create database). For these plans:
 - ROLLOUT_CREATE is hidden; ROLLOUT_START creates rollout and runs tasks in one step
-- ISSUE_STATUS_RESOLVE is hidden (issues auto-resolve when task completes)
+- Issues auto-resolve when task completes
 
 **ActionDefinition**: Declarative action with pure functions:
 ```typescript
@@ -117,21 +117,6 @@ interface ActionDefinition {
 ---
 
 ### Issue Status Actions
-
-#### `ISSUE_STATUS_RESOLVE` (Primary, Priority: 50)
-**Label**: "Resolve"
-
-**Description**: Marks the issue as resolved (DONE).
-
-**Visibility**:
-- Issue exists and is OPEN
-- Issue approval status is APPROVED or SKIPPED
-- All tasks in the rollout are finished (DONE or SKIPPED)
-- Rollout exists (`plan.hasRollout`)
-- Not a deferred rollout plan (export/create database plans auto-resolve when task completes)
-- User has `bb.issues.update` permission
-
----
 
 #### `ISSUE_STATUS_CLOSE` (Secondary, Priority: 90)
 **Label**: "Close"
@@ -272,7 +257,6 @@ Actions are sorted by priority (lower number = higher priority). The first visib
 | 10 | PLAN_REOPEN | primary |
 | 20 | ISSUE_STATUS_REOPEN | primary |
 | 30 | ISSUE_REVIEW | primary |
-| 50 | ISSUE_STATUS_RESOLVE | primary |
 | 55 | ROLLOUT_CREATE | primary |
 | 60 | ROLLOUT_START | primary |
 | 80 | ROLLOUT_CANCEL | secondary |
@@ -288,7 +272,7 @@ Actions are sorted by priority (lower number = higher priority). The first visib
 - `bb.issues.create`: Create issues from plans
 
 ### Issue Permissions
-- `bb.issues.update`: Close, reopen, or resolve issues
+- `bb.issues.update`: Close or reopen issues
 
 ### Rollout Permissions
 - `bb.rollouts.create`: Create rollouts

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
@@ -147,7 +147,6 @@ const handlePerformAction = async (action: UnifiedAction) => {
   switch (action) {
     case "ISSUE_STATUS_CLOSE":
     case "ISSUE_STATUS_REOPEN":
-    case "ISSUE_STATUS_RESOLVE":
       await handleIssueStatusChange(action as IssueStatusAction);
       break;
     case "PLAN_CLOSE":
@@ -187,11 +186,6 @@ const handleIssueStatusChange = async (action: IssueStatusAction) => {
       title: t("common.reopen"),
       content: t("issue.status-transition.modal.reopen"),
       status: IssueStatus.OPEN,
-    },
-    ISSUE_STATUS_RESOLVE: {
-      title: t("issue.batch-transition.resolve"),
-      content: t("issue.status-transition.modal.resolve"),
-      status: IssueStatus.DONE,
     },
   }[action];
 

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/issue.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/actions/issue.ts
@@ -69,38 +69,6 @@ export const ISSUE_REVIEW: ActionDefinition = {
   executeType: "popover:review",
 };
 
-export const ISSUE_STATUS_RESOLVE: ActionDefinition = {
-  id: "ISSUE_STATUS_RESOLVE",
-  label: () => t("issue.batch-transition.resolve"),
-  buttonType: "success",
-  category: "primary",
-  priority: 50,
-
-  isVisible: (ctx) => {
-    // Deferred rollout plans auto-resolve when task completes, never show manual resolve
-    if (ctx.hasDeferredRollout) return false;
-    return (
-      ctx.issueStatus === IssueStatus.OPEN &&
-      (ctx.approvalStatus === Issue_ApprovalStatus.APPROVED ||
-        ctx.approvalStatus === Issue_ApprovalStatus.SKIPPED) &&
-      ctx.allTasksFinished &&
-      ctx.plan.hasRollout
-    );
-  },
-
-  isDisabled: (ctx) => !ctx.permissions.updateIssue,
-  disabledReason: (ctx) => {
-    if (!ctx.permissions.updateIssue) {
-      return t("common.missing-required-permission", {
-        permissions: "bb.issues.update",
-      });
-    }
-    return undefined;
-  },
-
-  executeType: "panel:issue-status",
-};
-
 export const ISSUE_STATUS_CLOSE: ActionDefinition = {
   id: "ISSUE_STATUS_CLOSE",
   label: () => t("issue.batch-transition.close"),
@@ -150,7 +118,6 @@ export const ISSUE_STATUS_REOPEN: ActionDefinition = {
 export const issueActions: ActionDefinition[] = [
   ISSUE_CREATE,
   ISSUE_REVIEW,
-  ISSUE_STATUS_RESOLVE,
   ISSUE_STATUS_CLOSE,
   ISSUE_STATUS_REOPEN,
 ];

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/types.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/types.ts
@@ -12,10 +12,7 @@ import type { Rollout } from "@/types/proto-es/v1/rollout_service_pb";
 // Action type definitions
 export type IssueReviewAction = "ISSUE_REVIEW";
 
-export type IssueStatusAction =
-  | "ISSUE_STATUS_CLOSE"
-  | "ISSUE_STATUS_REOPEN"
-  | "ISSUE_STATUS_RESOLVE";
+export type IssueStatusAction = "ISSUE_STATUS_CLOSE" | "ISSUE_STATUS_REOPEN";
 
 export type IssueAction =
   | IssueReviewAction

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -935,8 +935,8 @@
       "changed-labels": "changed labels",
       "changed-from-to": "changed {name} from \"{oldValue}\" to \"{newValue}\"",
       "reopened-issue": "reopened issue",
-      "resolved-issue": "resolved issue",
-      "canceled-issue": "canceled issue",
+      "resolved-issue": "completed the issue",
+      "canceled-issue": "closed the issue",
       "xxx-automatically": "{verb} automatically"
     }
   },
@@ -948,7 +948,6 @@
     "create-rollout": "Create Rollout",
     "status-transition": {
       "modal": {
-        "resolve": "Resolve issue?",
         "reopen": "Reopen issue?",
         "close": "Close issue?"
       },
@@ -1056,8 +1055,6 @@
     },
     "batch-transition": {
       "not-allowed-tips": "Some of selected issues cannot be {operation}",
-      "resolve": "Resolve",
-      "resolved": "resolved",
       "reopen": "Reopen",
       "reopened": "reopened",
       "action-n-issues": "{action} {n} issue | {action} {n} issues",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -935,8 +935,8 @@
       "changed-labels": "etiquetas cambiadas",
       "changed-from-to": "cambio de {name} de \"{oldValue}\" a \"{newValue}\"",
       "reopened-issue": "incidencia reabierta",
-      "resolved-issue": "incidencia resuelta",
-      "canceled-issue": "incidencia cancelada",
+      "resolved-issue": "completó la incidencia",
+      "canceled-issue": "cerró la incidencia",
       "xxx-automatically": "{verb} automáticamente"
     }
   },
@@ -948,7 +948,6 @@
     "create-rollout": "Crear despliegue",
     "status-transition": {
       "modal": {
-        "resolve": "¿Resolver incidencia?",
         "reopen": "¿Reabrir incidencia?",
         "close": "¿Cerrar el problema?"
       },
@@ -1056,8 +1055,6 @@
     },
     "batch-transition": {
       "not-allowed-tips": "Algunos de las incidencias seleccionadas no se pueden {operation}",
-      "resolve": "Resolver",
-      "resolved": "resuelto",
       "reopen": "Reabrir",
       "reopened": "reabierto",
       "action-n-issues": "{action} {n} incidencia | {action} {n} incidencias",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -936,7 +936,7 @@
       "changed-from-to": "{name} を「{oldValue}」から「{newValue}」に変更します",
       "reopened-issue": "イシューを再開する",
       "resolved-issue": "イシューを完了する",
-      "canceled-issue": "イシューをキャンセルする",
+      "canceled-issue": "イシューを閉じた",
       "xxx-automatically": "自動{verb}"
     }
   },
@@ -948,7 +948,6 @@
     "create-rollout": "ロールアウトを作成",
     "status-transition": {
       "modal": {
-        "resolve": "イシューは完了しましたか?",
         "reopen": "イシューを再開しますか?",
         "close": "問題を閉じますか?"
       },
@@ -1056,8 +1055,6 @@
     },
     "batch-transition": {
       "not-allowed-tips": "選択したイシューの一部を {operation} にすることはできません",
-      "resolve": "仕上げる",
-      "resolved": "仕上げる",
       "reopen": "再開",
       "reopened": "再開",
       "action-n-issues": "{action} {n} 個のイシュー",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -935,8 +935,8 @@
       "changed-labels": "đã thay đổi nhãn",
       "changed-from-to": "đã thay đổi {name} từ \"{oldValue}\" thành \"{newValue}\"",
       "reopened-issue": "đã mở lại vấn đề",
-      "resolved-issue": "đã giải quyết vấn đề",
-      "canceled-issue": "đã hủy vấn đề",
+      "resolved-issue": "đã hoàn tất vấn đề",
+      "canceled-issue": "đã đóng vấn đề",
       "xxx-automatically": "{verb} tự động"
     }
   },
@@ -948,7 +948,6 @@
     "create-rollout": "Tạo triển khai",
     "status-transition": {
       "modal": {
-        "resolve": "Giải quyết vấn đề?",
         "reopen": "Mở lại vấn đề?",
         "close": "Đóng vấn đề?"
       },
@@ -1056,8 +1055,6 @@
     },
     "batch-transition": {
       "not-allowed-tips": "Một số vấn đề đã chọn không thể {operation}",
-      "resolve": "Giải quyết",
-      "resolved": "đã giải quyết",
       "reopen": "Mở lại",
       "reopened": "đã mở lại",
       "action-n-issues": "{action} {n} vấn đề | {action} {n} vấn đề",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -936,7 +936,7 @@
       "changed-from-to": "将 {name} 从 \"{oldValue}\" 修改为 \"{newValue}\"",
       "reopened-issue": "重开工单",
       "resolved-issue": "完成工单",
-      "canceled-issue": "取消工单",
+      "canceled-issue": "关闭工单",
       "xxx-automatically": "自动{verb}"
     }
   },
@@ -948,7 +948,6 @@
     "create-rollout": "创建发布",
     "status-transition": {
       "modal": {
-        "resolve": "完成工单?",
         "reopen": "重开工单？",
         "close": "关闭工单？"
       },
@@ -1056,8 +1055,6 @@
     },
     "batch-transition": {
       "not-allowed-tips": "部分选中的工单无法被{operation}",
-      "resolve": "完成",
-      "resolved": "完成",
       "reopen": "重开",
       "reopened": "重开",
       "action-n-issues": "{action} {n} 个工单",


### PR DESCRIPTION

- Remove manual "Resolve" action from issue workflow (issues auto-complete)
- Standardize terminology: "resolved" → "completed", "canceled" → "closed"
- Remove REOPEN action for DONE issues (only CANCELED can be reopened)
- Update all 5 locale files (en-US, zh-CN, ja-JP, vi-VN, es-ES)
- Remove unused i18n keys for resolve action
- Update ACTIONS.md documentation