### PR TITLE
fix(store): remove nested transaction patterns to prevent deadlock

### DIFF
--- a/backend/store/database.go
+++ b/backend/store/database.go
@@ -82,12 +82,6 @@ func (s *Store) GetDatabase(ctx context.Context, find *FindDatabaseMessage) (*Da
 		}
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	databases, err := s.ListDatabases(ctx, find)
 	if err != nil {
 		return nil, err
@@ -99,10 +93,6 @@ func (s *Store) GetDatabase(ctx context.Context, find *FindDatabaseMessage) (*Da
 		return nil, &common.Error{Code: common.Conflict, Err: errors.Errorf("found %d database with filter %+v, expect 1", len(databases), find)}
 	}
 	database := databases[0]
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
 
 	s.databaseCache.Add(getDatabaseCacheKey(database.InstanceID, database.DatabaseName), database)
 	return database, nil

--- a/backend/store/database_group.go
+++ b/backend/store/database_group.go
@@ -124,21 +124,10 @@ func (s *Store) ListDatabaseGroups(ctx context.Context, find *FindDatabaseGroupM
 
 // GetDatabaseGroup gets a database group.
 func (s *Store) GetDatabaseGroup(ctx context.Context, find *FindDatabaseGroupMessage) (*DatabaseGroupMessage, error) {
-	tx, err := s.GetDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	databaseGroups, err := s.ListDatabaseGroups(ctx, find)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit transaction")
-	}
-
 	if len(databaseGroups) == 0 {
 		return nil, nil
 	}

--- a/backend/store/project_webhook.go
+++ b/backend/store/project_webhook.go
@@ -171,27 +171,16 @@ func (s *Store) ListProjectWebhooks(ctx context.Context, find *FindProjectWebhoo
 
 // GetProjectWebhook gets an instance of ProjectWebhook.
 func (s *Store) GetProjectWebhook(ctx context.Context, find *FindProjectWebhookMessage) (*ProjectWebhookMessage, error) {
-	tx, err := s.GetDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to begin transaction")
-	}
-
 	webhooks, err := s.ListProjectWebhooks(ctx, find)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit transaction")
-	}
-
 	if len(webhooks) == 0 {
 		return nil, nil
 	}
 	if len(webhooks) > 1 {
 		return nil, errors.Errorf("expected find one project webhook wit %+v, but found %d", find, len(webhooks))
 	}
-
 	return webhooks[0], nil
 }
 


### PR DESCRIPTION
## Summary

- Remove nested transaction patterns that can cause deadlocks when the connection pool is exhausted under high concurrency
- The problematic pattern: holding a transaction while calling another Store method that opens its own transaction
- Follow-up to #18904 and #18906

## Fixed Functions

| File | Function | Fix |
|------|----------|-----|
| `project.go` | `GetProject` | Removed unnecessary tx wrapper (just delegates to `ListProjects`) |
| `project.go` | `ListProjects` | Moved `ListProjectWebhooks` call after `tx.Commit()` |
| `project_webhook.go` | `GetProjectWebhook` | Removed unnecessary tx wrapper (just delegates to `ListProjectWebhooks`) |
| `database.go` | `GetDatabase` | Removed unnecessary tx wrapper (just delegates to `ListDatabases`) |
| `database_group.go` | `GetDatabaseGroup` | Removed unnecessary tx wrapper (just delegates to `ListDatabaseGroups`) |

## Test plan

- [ ] Verify existing tests pass
- [ ] Verify no regressions in project/database list/get operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)