### PR TITLE
fix(api): include tasks with empty environment in rollout response

### DIFF
--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -173,14 +173,23 @@ func convertToRollout(project *store.ProjectMessage, plan *store.PlanMessage, ta
 	}
 
 	// Collect environments that have tasks and are in the environment order map.
+	// Also include empty environment (for tasks without environment assignment).
 	var envs []string
 	for env := range tasksByEnv {
-		if _, exists := environmentOrderMap[env]; exists {
+		if env == "" {
+			envs = append(envs, env)
+		} else if _, exists := environmentOrderMap[env]; exists {
 			envs = append(envs, env)
 		}
 	}
-	// Sort environments by their order.
+	// Sort environments by their order. Empty environment goes first.
 	slices.SortFunc(envs, func(a, b string) int {
+		if a == "" {
+			return -1
+		}
+		if b == "" {
+			return 1
+		}
 		return environmentOrderMap[a] - environmentOrderMap[b]
 	})
 


### PR DESCRIPTION
Tasks without an assigned environment were being filtered out because the empty string wasn't present in the environmentOrderMap. This fix explicitly includes empty environment tasks and sorts them to appear first using the EmptyStageID placeholder.