### PR TITLE
fix: set PrincipalType for webhook mention users in approval events

### DIFF
--- a/backend/component/webhook/manager.go
+++ b/backend/component/webhook/manager.go
@@ -104,6 +104,7 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 				mentionUsers = append(mentionUsers, &store.UserMessage{
 					Name:  user.Name,
 					Email: user.Email,
+					Type:  storepb.PrincipalType_END_USER,
 				})
 			}
 		}
@@ -121,6 +122,7 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 				{
 					Name:  e.SentBack.Creator.Name,
 					Email: e.SentBack.Creator.Email,
+					Type:  storepb.PrincipalType_END_USER,
 				},
 			}
 		}


### PR DESCRIPTION
## Summary
- Fix WeCom direct messages not being sent to individuals
- Set `Type: PrincipalType_END_USER` when creating UserMessage objects for approval events

## Root Cause
In the webhook redesign (commit a5de11313b from Dec 30, 2025), UserMessage objects were created manually for approval request and sent-back events, but the `Type` field was not set. This caused it to default to `0` (PRINCIPAL_TYPE_UNSPECIFIED) instead of `1` (END_USER).

The filter at `manager.go:157` checks `if u.Type == storepb.PrincipalType_END_USER`, which excluded all users with Type=0, resulting in an empty `MentionEndUsers` list. This caused the WeCom direct message logic to be skipped, falling back to group messages.

## Changes
Set `Type: storepb.PrincipalType_END_USER` for:
- Approvers in `ISSUE_APPROVAL_REQUESTED` events (line 107)
- Creator in `ISSUE_SENT_BACK` events (line 125)

## Test Plan
- [x] Code compiles successfully
- [x] golangci-lint clean (0 issues)
- [ ] Manual testing: Create approval request and verify WeCom DM is sent

Fixes https://linear.app/bytebase/issue/BYT-8720/wecom-dm-might-have-some-issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)