### PR TITLE
fix(webhook): fix IM direct message not working due to incorrect JSON format

### DIFF
--- a/backend/migrator/migration/3.12/0000##migrate_app_im_to_array.sql
+++ b/backend/migrator/migration/3.12/0000##migrate_app_im_to_array.sql
@@ -1,6 +1,7 @@
 -- Migrate APP_IM setting from object format to array format
 -- Old format: { "slack": { "enabled": true, "token": "..." }, "feishu": { ... }, ... }
--- New format: { "settings": [ { "type": "SLACK", "token": "..." }, { "type": "FEISHU", "appId": "...", "appSecret": "..." }, ... ] }
+-- New format: { "settings": [ { "type": "SLACK", "slack": {"token": "..."} }, { "type": "FEISHU", "feishu": {"appId": "...", "appSecret": "..."} }, ... ] }
+-- Note: Each setting must have nested payload under its type key (e.g., "slack", "wecom") for protojson oneof deserialization.
 
 DO $$
 DECLARE
@@ -25,7 +26,9 @@ BEGIN
         settings_array := settings_array || jsonb_build_array(
             jsonb_build_object(
                 'type', 'SLACK',
-                'token', old_val->'slack'->>'token'
+                'slack', jsonb_build_object(
+                    'token', old_val->'slack'->>'token'
+                )
             )
         );
     END IF;
@@ -35,8 +38,10 @@ BEGIN
         settings_array := settings_array || jsonb_build_array(
             jsonb_build_object(
                 'type', 'FEISHU',
-                'appId', old_val->'feishu'->>'appId',
-                'appSecret', old_val->'feishu'->>'appSecret'
+                'feishu', jsonb_build_object(
+                    'appId', old_val->'feishu'->>'appId',
+                    'appSecret', old_val->'feishu'->>'appSecret'
+                )
             )
         );
     END IF;
@@ -46,9 +51,11 @@ BEGIN
         settings_array := settings_array || jsonb_build_array(
             jsonb_build_object(
                 'type', 'WECOM',
-                'corpId', old_val->'wecom'->>'corpId',
-                'agentId', old_val->'wecom'->>'agentId',
-                'secret', old_val->'wecom'->>'secret'
+                'wecom', jsonb_build_object(
+                    'corpId', old_val->'wecom'->>'corpId',
+                    'agentId', old_val->'wecom'->>'agentId',
+                    'secret', old_val->'wecom'->>'secret'
+                )
             )
         );
     END IF;
@@ -58,8 +65,10 @@ BEGIN
         settings_array := settings_array || jsonb_build_array(
             jsonb_build_object(
                 'type', 'LARK',
-                'appId', old_val->'lark'->>'appId',
-                'appSecret', old_val->'lark'->>'appSecret'
+                'lark', jsonb_build_object(
+                    'appId', old_val->'lark'->>'appId',
+                    'appSecret', old_val->'lark'->>'appSecret'
+                )
             )
         );
     END IF;
@@ -69,9 +78,11 @@ BEGIN
         settings_array := settings_array || jsonb_build_array(
             jsonb_build_object(
                 'type', 'DINGTALK',
-                'clientId', old_val->'dingtalk'->>'clientId',
-                'clientSecret', old_val->'dingtalk'->>'clientSecret',
-                'robotCode', old_val->'dingtalk'->>'robotCode'
+                'dingtalk', jsonb_build_object(
+                    'clientId', old_val->'dingtalk'->>'clientId',
+                    'clientSecret', old_val->'dingtalk'->>'clientSecret',
+                    'robotCode', old_val->'dingtalk'->>'robotCode'
+                )
             )
         );
     END IF;

--- a/backend/migrator/migration/3.13/0032##fix_app_im_setting_format.sql
+++ b/backend/migrator/migration/3.13/0032##fix_app_im_setting_format.sql
@@ -1,0 +1,101 @@
+-- Fix APP_IM setting format: nest payload fields under their respective oneof keys
+-- The migration 3.12/0000##migrate_app_im_to_array.sql created flat structures like:
+--   { "type": "WECOM", "corpId": "...", "agentId": "...", "secret": "..." }
+-- But protojson expects nested structures for oneof fields:
+--   { "type": "WECOM", "wecom": { "corpId": "...", "agentId": "...", "secret": "..." } }
+
+DO $$
+DECLARE
+    old_val jsonb;
+    new_settings jsonb := '[]'::jsonb;
+    setting jsonb;
+    setting_type text;
+    new_setting jsonb;
+BEGIN
+    -- Get the current value
+    SELECT value INTO old_val FROM setting WHERE name = 'APP_IM';
+
+    -- Return early if no APP_IM setting exists
+    IF old_val IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Return early if no settings array
+    IF NOT old_val ? 'settings' THEN
+        RETURN;
+    END IF;
+
+    -- Process each setting in the array
+    FOR setting IN SELECT * FROM jsonb_array_elements(old_val->'settings')
+    LOOP
+        setting_type := setting->>'type';
+
+        -- Check if already in correct format (has nested payload)
+        IF setting ? 'slack' OR setting ? 'feishu' OR setting ? 'wecom' OR
+           setting ? 'lark' OR setting ? 'dingtalk' OR setting ? 'teams' THEN
+            -- Already in correct format, keep as is
+            new_settings := new_settings || jsonb_build_array(setting);
+        ELSE
+            -- Convert flat format to nested format
+            CASE setting_type
+                WHEN 'SLACK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'SLACK',
+                        'slack', jsonb_build_object(
+                            'token', setting->>'token'
+                        )
+                    );
+                WHEN 'FEISHU' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'FEISHU',
+                        'feishu', jsonb_build_object(
+                            'appId', setting->>'appId',
+                            'appSecret', setting->>'appSecret'
+                        )
+                    );
+                WHEN 'WECOM' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'WECOM',
+                        'wecom', jsonb_build_object(
+                            'corpId', setting->>'corpId',
+                            'agentId', setting->>'agentId',
+                            'secret', setting->>'secret'
+                        )
+                    );
+                WHEN 'LARK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'LARK',
+                        'lark', jsonb_build_object(
+                            'appId', setting->>'appId',
+                            'appSecret', setting->>'appSecret'
+                        )
+                    );
+                WHEN 'DINGTALK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'DINGTALK',
+                        'dingtalk', jsonb_build_object(
+                            'clientId', setting->>'clientId',
+                            'clientSecret', setting->>'clientSecret',
+                            'robotCode', setting->>'robotCode'
+                        )
+                    );
+                WHEN 'TEAMS' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'TEAMS',
+                        'teams', jsonb_build_object(
+                            'tenantId', setting->>'tenantId',
+                            'clientId', setting->>'clientId',
+                            'clientSecret', setting->>'clientSecret'
+                        )
+                    );
+                ELSE
+                    -- Unknown type, keep as is
+                    new_setting := setting;
+            END CASE;
+            new_settings := new_settings || jsonb_build_array(new_setting);
+        END IF;
+    END LOOP;
+
+    -- Update the setting with the corrected format
+    UPDATE setting SET value = jsonb_build_object('settings', new_settings) WHERE name = 'APP_IM';
+END $$;

--- a/backend/migrator/migration/3.14/0033##fix_app_im_setting_format.sql
+++ b/backend/migrator/migration/3.14/0033##fix_app_im_setting_format.sql
@@ -1,0 +1,101 @@
+-- Fix APP_IM setting format: nest payload fields under their respective oneof keys
+-- The migration 3.12/0000##migrate_app_im_to_array.sql created flat structures like:
+--   { "type": "WECOM", "corpId": "...", "agentId": "...", "secret": "..." }
+-- But protojson expects nested structures for oneof fields:
+--   { "type": "WECOM", "wecom": { "corpId": "...", "agentId": "...", "secret": "..." } }
+
+DO $$
+DECLARE
+    old_val jsonb;
+    new_settings jsonb := '[]'::jsonb;
+    setting jsonb;
+    setting_type text;
+    new_setting jsonb;
+BEGIN
+    -- Get the current value
+    SELECT value INTO old_val FROM setting WHERE name = 'APP_IM';
+
+    -- Return early if no APP_IM setting exists
+    IF old_val IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Return early if no settings array
+    IF NOT old_val ? 'settings' THEN
+        RETURN;
+    END IF;
+
+    -- Process each setting in the array
+    FOR setting IN SELECT * FROM jsonb_array_elements(old_val->'settings')
+    LOOP
+        setting_type := setting->>'type';
+
+        -- Check if already in correct format (has nested payload)
+        IF setting ? 'slack' OR setting ? 'feishu' OR setting ? 'wecom' OR
+           setting ? 'lark' OR setting ? 'dingtalk' OR setting ? 'teams' THEN
+            -- Already in correct format, keep as is
+            new_settings := new_settings || jsonb_build_array(setting);
+        ELSE
+            -- Convert flat format to nested format
+            CASE setting_type
+                WHEN 'SLACK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'SLACK',
+                        'slack', jsonb_build_object(
+                            'token', setting->>'token'
+                        )
+                    );
+                WHEN 'FEISHU' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'FEISHU',
+                        'feishu', jsonb_build_object(
+                            'appId', setting->>'appId',
+                            'appSecret', setting->>'appSecret'
+                        )
+                    );
+                WHEN 'WECOM' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'WECOM',
+                        'wecom', jsonb_build_object(
+                            'corpId', setting->>'corpId',
+                            'agentId', setting->>'agentId',
+                            'secret', setting->>'secret'
+                        )
+                    );
+                WHEN 'LARK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'LARK',
+                        'lark', jsonb_build_object(
+                            'appId', setting->>'appId',
+                            'appSecret', setting->>'appSecret'
+                        )
+                    );
+                WHEN 'DINGTALK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'DINGTALK',
+                        'dingtalk', jsonb_build_object(
+                            'clientId', setting->>'clientId',
+                            'clientSecret', setting->>'clientSecret',
+                            'robotCode', setting->>'robotCode'
+                        )
+                    );
+                WHEN 'TEAMS' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'TEAMS',
+                        'teams', jsonb_build_object(
+                            'tenantId', setting->>'tenantId',
+                            'clientId', setting->>'clientId',
+                            'clientSecret', setting->>'clientSecret'
+                        )
+                    );
+                ELSE
+                    -- Unknown type, keep as is
+                    new_setting := setting;
+            END CASE;
+            new_settings := new_settings || jsonb_build_array(new_setting);
+        END IF;
+    END LOOP;
+
+    -- Update the setting with the corrected format
+    UPDATE setting SET value = jsonb_build_object('settings', new_settings) WHERE name = 'APP_IM';
+END $$;

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,8 +12,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.14.32"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.14/0032##task_run_payload.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.14.33"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.14/0033##fix_app_im_setting_format.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
Close BYT-8720

## Summary

Fix WeCom (and other IM) direct messaging not working - it was always falling back to group webhook.

**Root cause:** The migration `3.12/0000##migrate_app_im_to_array.sql` created flat JSON structures, but `protojson` expects nested structures for oneof fields.

- **Wrong format (flat):** `{"type": "WECOM", "corpId": "...", "agentId": "...", "secret": "..."}`
- **Correct format (nested):** `{"type": "WECOM", "wecom": {"corpId": "...", "agentId": "...", "secret": "..."}}`

With `DiscardUnknown: true` in the unmarshaler, the flat fields are silently discarded, causing `GetWecom()` to return `nil`, which makes direct message fail and fall back to group webhook.

**Changes:**
1. Fix `3.12/0000` to create correct nested structure for new installations
2. Add `3.14/0033` to fix existing data for users who already ran the wrong migration (handles both correct and incorrect formats)

## Test plan

- [x] Verified with Go test that flat format causes `GetWecom()` to return `nil`
- [x] Verified with Go test that nested format correctly parses
- [x] Migration tests pass (`TestLatestVersion`, `TestVersionUnique`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)