### PR TITLE
fix(migration): nest APP_IM payload fields under oneof keys

### DIFF
--- a/backend/migrator/migration/3.13/0032##fix_app_im_setting_format.sql
+++ b/backend/migrator/migration/3.13/0032##fix_app_im_setting_format.sql
@@ -1,0 +1,101 @@
+-- Fix APP_IM setting format: nest payload fields under their respective oneof keys
+-- The migration 3.12/0000##migrate_app_im_to_array.sql created flat structures like:
+--   { "type": "WECOM", "corpId": "...", "agentId": "...", "secret": "..." }
+-- But protojson expects nested structures for oneof fields:
+--   { "type": "WECOM", "wecom": { "corpId": "...", "agentId": "...", "secret": "..." } }
+
+DO $$
+DECLARE
+    old_val jsonb;
+    new_settings jsonb := '[]'::jsonb;
+    setting jsonb;
+    setting_type text;
+    new_setting jsonb;
+BEGIN
+    -- Get the current value
+    SELECT value INTO old_val FROM setting WHERE name = 'APP_IM';
+
+    -- Return early if no APP_IM setting exists
+    IF old_val IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Return early if no settings array
+    IF NOT old_val ? 'settings' THEN
+        RETURN;
+    END IF;
+
+    -- Process each setting in the array
+    FOR setting IN SELECT * FROM jsonb_array_elements(old_val->'settings')
+    LOOP
+        setting_type := setting->>'type';
+
+        -- Check if already in correct format (has nested payload)
+        IF setting ? 'slack' OR setting ? 'feishu' OR setting ? 'wecom' OR
+           setting ? 'lark' OR setting ? 'dingtalk' OR setting ? 'teams' THEN
+            -- Already in correct format, keep as is
+            new_settings := new_settings || jsonb_build_array(setting);
+        ELSE
+            -- Convert flat format to nested format
+            CASE setting_type
+                WHEN 'SLACK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'SLACK',
+                        'slack', jsonb_build_object(
+                            'token', setting->>'token'
+                        )
+                    );
+                WHEN 'FEISHU' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'FEISHU',
+                        'feishu', jsonb_build_object(
+                            'appId', setting->>'appId',
+                            'appSecret', setting->>'appSecret'
+                        )
+                    );
+                WHEN 'WECOM' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'WECOM',
+                        'wecom', jsonb_build_object(
+                            'corpId', setting->>'corpId',
+                            'agentId', setting->>'agentId',
+                            'secret', setting->>'secret'
+                        )
+                    );
+                WHEN 'LARK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'LARK',
+                        'lark', jsonb_build_object(
+                            'appId', setting->>'appId',
+                            'appSecret', setting->>'appSecret'
+                        )
+                    );
+                WHEN 'DINGTALK' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'DINGTALK',
+                        'dingtalk', jsonb_build_object(
+                            'clientId', setting->>'clientId',
+                            'clientSecret', setting->>'clientSecret',
+                            'robotCode', setting->>'robotCode'
+                        )
+                    );
+                WHEN 'TEAMS' THEN
+                    new_setting := jsonb_build_object(
+                        'type', 'TEAMS',
+                        'teams', jsonb_build_object(
+                            'tenantId', setting->>'tenantId',
+                            'clientId', setting->>'clientId',
+                            'clientSecret', setting->>'clientSecret'
+                        )
+                    );
+                ELSE
+                    -- Unknown type, keep as is
+                    new_setting := setting;
+            END CASE;
+            new_settings := new_settings || jsonb_build_array(new_setting);
+        END IF;
+    END LOOP;
+
+    -- Update the setting with the corrected format
+    UPDATE setting SET value = jsonb_build_object('settings', new_settings) WHERE name = 'APP_IM';
+END $$;

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,7 +12,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.13.31"), *files[len(files)-1].version)
+	require.Equal(t, semver.MustParse("3.13.32"), *files[len(files)-1].version)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds migration `3.13/0032##fix_app_im_setting_format.sql` to fix APP_IM setting format by properly nesting payload fields under their respective oneof keys as expected by protojson.

## Context

The previous migration `3.12/0000##migrate_app_im_to_array.sql` created flat JSON structures like:
```json
{ "type": "WECOM", "corpId": "...", "agentId": "...", "secret": "..." }
```

However, protojson expects nested structures for oneof fields:
```json
{ "type": "WECOM", "wecom": { "corpId": "...", "agentId": "...", "secret": "..." } }
```

## Changes

- Added migration to convert flat APP_IM settings to nested format
- Handles all IM types: Slack, Feishu, WeCom, Lark, DingTalk, Teams
- Skips settings already in correct format (idempotent)
- Updated `TestLatestVersion` to expect version 3.13.32

## Test Plan

- [ ] Verify migration runs successfully on database with flat APP_IM settings
- [ ] Verify migration is idempotent (can run multiple times safely)
- [ ] Verify `TestLatestVersion` test passes
- [ ] Verify APP_IM functionality works correctly after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)