### PR TITLE
fix(frontend): move approval title to risk level icon tooltip

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalFlowSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalFlowSection.vue
@@ -2,14 +2,11 @@
   <div>
     <div class="w-full flex flex-row items-center gap-2">
       <h3 class="textlabel">{{ $t("issue.approval-flow.self") }}</h3>
-      <span
-        v-if="approvalTemplate?.title?.trim()"
-        class="text-sm text-control-placeholder"
-      >
-        · {{ approvalTemplate.title }}
-      </span>
       <FeatureBadge :feature="PlanFeature.FEATURE_APPROVAL_WORKFLOW" />
-      <RiskLevelIcon :risk-level="issue.riskLevel" />
+      <RiskLevelIcon
+        :risk-level="issue.riskLevel"
+        :title="approvalTemplate?.title?.trim()"
+      />
     </div>
 
     <div class="mt-2">

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/RiskLevelIcon.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/RiskLevelIcon.vue
@@ -14,8 +14,13 @@
         class="w-4 h-4 text-error"
       />
     </template>
-    <span>{{ riskLevelText }}</span>
-    <span class="opacity-60 ml-1">({{ $t("issue.risk-level.self") }})</span>
+    <div class="flex flex-col gap-1">
+      <div>
+        <span>{{ riskLevelText }}</span>
+        <span class="opacity-60 ml-1">({{ $t("issue.risk-level.self") }})</span>
+      </div>
+      <div v-if="title" class="text-sm opacity-80">{{ title }}</div>
+    </div>
   </NTooltip>
 </template>
 
@@ -28,6 +33,7 @@ import { RiskLevel } from "@/types/proto-es/v1/common_pb";
 
 const props = defineProps<{
   riskLevel: RiskLevel;
+  title?: string;
 }>();
 
 const { t } = useI18n();


### PR DESCRIPTION
Move the matched approval template title from inline display to the RiskLevelIcon tooltip to prevent text overflow in the narrow sidebar.