### PR TITLE
fix(backend): handle role prefix in GetUsersByRoleInIAMPolicy

### DIFF
--- a/backend/utils/member.go
+++ b/backend/utils/member.go
@@ -32,8 +32,12 @@ func FormatGroupName(group *store.GroupMessage) string {
 }
 
 // GetUsersByRoleInIAMPolicy gets users in the iam policy.
+// The role can be either with or without the "roles/" prefix.
 func GetUsersByRoleInIAMPolicy(ctx context.Context, stores *store.Store, role string, policies ...*storepb.IamPolicy) []*store.UserMessage {
-	roleFullName := common.FormatRole(role)
+	roleFullName := role
+	if !strings.HasPrefix(role, common.RolePrefix) {
+		roleFullName = common.FormatRole(role)
+	}
 	var users []*store.UserMessage
 
 	seen := map[string]bool{}


### PR DESCRIPTION
## Summary
- Make `GetUsersByRoleInIAMPolicy` idempotent by checking if the role already has the `roles/` prefix before adding it
- Fixes the bug where approval flow roles (stored with prefix in proto) resulted in double-prefixed role names like `roles/roles/projectOwner` that never matched IAM policy bindings
- Approvers for pending approval stages were not being found, causing empty `users=[]` in webhook notifications

## Test plan
- [ ] Verify approval flow notifications now correctly identify project owners
- [ ] Verify workspace admin check in `SetIamPolicy` still works (passes role without prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)