### PR TITLE
fix(frontend): fix IM settings page not showing configured data

### DIFF
--- a/frontend/src/views/SettingWorkspaceIM.vue
+++ b/frontend/src/views/SettingWorkspaceIM.vue
@@ -669,7 +669,7 @@ watch(
   (setting) => {
     state.setting = clone(AppIMSettingSchema, setting);
   },
-  { once: true, immediate: true }
+  { immediate: true }
 );
 
 const isDataChanged = (


### PR DESCRIPTION
## Summary
- Fix race condition in `SettingWorkspaceIM.vue` where configured IM integrations were not displayed
- Remove `once: true` from watch options that prevented re-rendering when API data arrived

## Root Cause
The watch was configured with `{ once: true, immediate: true }`:
1. `immediate: true` caused the watch to run during component setup (before `onMounted`)
2. At that point, API data hadn't been fetched yet, so `imSetting.value` returned empty settings
3. `once: true` meant the watch only fired once and then disposed itself
4. When data finally loaded in `onMounted`, the watch never ran again

## Test plan
- [ ] Navigate to Workspace Settings > IM Integration
- [ ] Verify that configured IM integrations (Slack, Feishu, etc.) are displayed correctly
- [ ] Verify adding/editing/deleting IM integrations still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)