### PR TITLE
refactor(parser): eliminate internal double-splitting in MySQL and PostgreSQL parsers

### DIFF
--- a/backend/plugin/parser/pg/pg.go
+++ b/backend/plugin/parser/pg/pg.go
@@ -18,14 +18,14 @@ func init() {
 // parsePgStatements is the ParseStatementsFunc for PostgreSQL.
 // Returns []ParsedStatement with both text and AST populated.
 func parsePgStatements(statement string) ([]base.ParsedStatement, error) {
-	// First split to get Statement with text and positions
+	// Split once to get Statement with text and positions
 	stmts, err := SplitSQL(statement)
 	if err != nil {
 		return nil, err
 	}
 
-	// Then parse to get ASTs
-	parseResults, err := ParsePostgreSQL(statement)
+	// Parse using the pre-split statements to avoid double-splitting
+	parseResults, err := parsePostgreSQLStatements(stmts)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,12 @@ func ParsePostgreSQL(sql string) ([]*base.ANTLRAST, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parsePostgreSQLStatements(stmts)
+}
 
+// parsePostgreSQLStatements parses pre-split statements without re-splitting.
+// This is the internal implementation used by both ParsePostgreSQL and parsePgStatements.
+func parsePostgreSQLStatements(stmts []base.Statement) ([]*base.ANTLRAST, error) {
 	var results []*base.ANTLRAST
 	for _, stmt := range stmts {
 		if stmt.Empty {


### PR DESCRIPTION
## Summary

- Eliminate redundant SQL splitting in the parser layer by introducing internal functions that accept pre-split statements
- Both `parsePgStatements()` and `parseMySQLStatements()` were calling `SplitSQL()` and then `ParsePostgreSQL()`/`ParseMySQL()`, which internally split again
- This reduces the number of split operations from 2 to 1 per parse call

## Changes

- Add `parsePostgreSQLStatements()` internal function that accepts pre-split statements
- Add `parseMySQLStatementsInternal()` internal function that accepts pre-split statements  
- Refactor `ParsePostgreSQL()` and `ParseMySQL()` to use the internal functions
- Remove unused `parseInputStream()` function from MySQL parser

## Test plan

- [x] Run `go test ./backend/plugin/parser/pg/...` - all tests pass
- [x] Run `go test ./backend/plugin/parser/mysql/...` - all tests pass
- [x] Run `golangci-lint run --allow-parallel-runners` - no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)