### PR TITLE
fix: error 'unexpected size format: "1.6tb"' when syncing Elasticsearch

### DIFF
--- a/backend/plugin/db/elasticsearch/sync.go
+++ b/backend/plugin/db/elasticsearch/sync.go
@@ -245,7 +245,7 @@ func unitConversion(sizeWithUnit string) (int64, error) {
 	}
 
 	sizeWithUnit = strings.ToLower(sizeWithUnit)
-	sizeRe := regexp.MustCompile("([0-9.]+)([gmk]?b)")
+	sizeRe := regexp.MustCompile("([0-9.]+)([kmgtpe]?b)")
 	match := sizeRe.FindSubmatch([]byte(sizeWithUnit))
 
 	// Non-empty string that doesn't match expected format is unexpected
@@ -267,6 +267,12 @@ func unitConversion(sizeWithUnit string) (int64, error) {
 		size *= 1024 * 1024
 	case "gb":
 		size *= 1024 * 1024 * 1024
+	case "tb":
+		size *= 1024 * 1024 * 1024 * 1024
+	case "pb":
+		size *= 1024 * 1024 * 1024 * 1024 * 1024
+	case "eb":
+		size *= 1024 * 1024 * 1024 * 1024 * 1024 * 1024
 	default:
 		// For "b" (bytes) or any other unit, keep the size as-is
 	}


### PR DESCRIPTION
This PR fix the error 'unexpected size format: "1.6tb"' when syncing Elasticsearch