### PR TITLE
fix: add SettingSchema to protobuf type registry

### DIFF
--- a/frontend/src/connect/index.ts
+++ b/frontend/src/connect/index.ts
@@ -24,7 +24,10 @@ import { ReviewConfigService } from "@/types/proto-es/v1/review_config_service_p
 import { RevisionService } from "@/types/proto-es/v1/revision_service_pb";
 import { RoleService } from "@/types/proto-es/v1/role_service_pb";
 import { RolloutService } from "@/types/proto-es/v1/rollout_service_pb";
-import { SettingService } from "@/types/proto-es/v1/setting_service_pb";
+import {
+  SettingSchema,
+  SettingService,
+} from "@/types/proto-es/v1/setting_service_pb";
 import { SheetService } from "@/types/proto-es/v1/sheet_service_pb";
 import { SQLService } from "@/types/proto-es/v1/sql_service_pb";
 import { SubscriptionService } from "@/types/proto-es/v1/subscription_service_pb";
@@ -41,7 +44,7 @@ import { isDev } from "@/utils";
 const address = import.meta.env.BB_GRPC_LOCAL || window.location.origin;
 
 // Registry for decoding google.protobuf.Any fields in JSON responses
-const registry = createRegistry(AuditDataSchema);
+const registry = createRegistry(AuditDataSchema, SettingSchema);
 
 const transport = createConnectTransport({
   baseUrl: address,


### PR DESCRIPTION
The AuditLog message has a google.protobuf.Any service_data field that can contain Setting messages. When using JSON format, the type registry must include SettingSchema to properly deserialize these messages.