### PR TITLE
refactor: group MCP and IM routes under /integration/ path

### DIFF
--- a/frontend/src/router/dashboard/workspace.ts
+++ b/frontend/src/router/dashboard/workspace.ts
@@ -313,6 +313,22 @@ const workspaceRoutes: RouteRecordRaw[] = [
         component: () => import("@/views/SettingWorkspaceRole.vue"),
         props: true,
       },
+    ],
+  },
+  {
+    path: "integration",
+    meta: {
+      title: () => t("settings.sidebar.integration"),
+    },
+    components: {
+      content: () => import("@/layouts/SettingLayout.vue"),
+      leftSidebar: () => import("@/views/DashboardSidebar.vue"),
+    },
+    props: {
+      content: true,
+      leftSidebar: true,
+    },
+    children: [
       {
         path: "im",
         name: WORKSPACE_ROUTE_IM,

--- a/frontend/src/router/dashboard/workspaceRoutes.ts
+++ b/frontend/src/router/dashboard/workspaceRoutes.ts
@@ -28,8 +28,9 @@ export const WORKSPACE_ROUTE_IDENTITY_PROVIDERS =
   "workspace.identity-providers";
 export const WORKSPACE_ROUTE_IDENTITY_PROVIDER_DETAIL = `${WORKSPACE_ROUTE_IDENTITY_PROVIDERS}.detail`;
 
-export const WORKSPACE_ROUTE_IM = "workspace.im";
-export const WORKSPACE_ROUTE_MCP = "workspace.mcp";
+export const WORKSPACE_ROUTE_INTEGRATION = "workspace.integration";
+export const WORKSPACE_ROUTE_IM = `${WORKSPACE_ROUTE_INTEGRATION}.im`;
+export const WORKSPACE_ROUTE_MCP = `${WORKSPACE_ROUTE_INTEGRATION}.mcp`;
 
 export const WORKSPACE_ROUTE_403 = "error.403";
 export const WORKSPACE_ROUTE_404 = "error.404";


### PR DESCRIPTION
Close BYT-8706

## Summary
- Move MCP and IM routes from `/mcp` and `/im` to `/integration/mcp` and `/integration/im`
- Add `WORKSPACE_ROUTE_INTEGRATION` constant for the parent route
- Create dedicated integration parent route with proper layout components

## Test plan
- [ ] Verify `/integration/mcp` loads MCP settings page
- [ ] Verify `/integration/im` loads IM settings page
- [ ] Verify sidebar navigation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)