### PR TITLE
fix: display release ID instead of full path

### DIFF
--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
@@ -34,6 +34,7 @@ import {
 } from "@/components/v2/Model/cells";
 import type { ComposedDatabase } from "@/types";
 import { hostPortOfInstanceV1 } from "@/utils";
+import { extractReleaseUID } from "@/utils/v1/release";
 import { mapSorterStatus } from "../utils";
 
 type DatabaseDataTableColumn = DataTableColumn<ComposedDatabase> & {
@@ -132,7 +133,10 @@ const columnList = computed((): DatabaseDataTableColumn[] => {
     minWidth: 140,
     resizable: true,
     hide: props.schemaless,
-    render: (data) => (data as ComposedDatabase).release || "-",
+    render: (data) => {
+      const release = (data as ComposedDatabase).release;
+      return release ? extractReleaseUID(release) : "-";
+    },
   };
   const PROJECT: DatabaseDataTableColumn = {
     key: "project",

--- a/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
@@ -76,7 +76,7 @@
               <span class="ml-1 textlabel"
                 >{{ $t("common.version") }}&nbsp;-&nbsp;</span
               >
-              <span>{{ database.release }}</span>
+              <span>{{ extractReleaseUID(database.release) }}</span>
             </dd>
             <SQLEditorButtonV1
               v-if="allowQuery"
@@ -260,6 +260,7 @@ import {
   isDatabaseV1Queryable,
   PERMISSIONS_FOR_DATABASE_CHANGE_ISSUE,
 } from "@/utils";
+import { extractReleaseUID } from "@/utils/v1/release";
 
 const databaseHashList = [
   "overview",


### PR DESCRIPTION
Extract just the release ID (e.g., release_20250127-RC00) from the full release path (projects/bbdev/releases/release_20250127-RC00) when displaying the schema version in the database detail view.