### PR TITLE
refactor: update UI wording for database release and changelog fields

### DIFF
--- a/frontend/src/components/SyncDatabaseSchemaV1/DatabaseSchemaSelector.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/DatabaseSchemaSelector.vue
@@ -27,7 +27,7 @@
       class="w-full flex flex-col gap-y-2"
     >
       <div class="text-sm">
-        {{ $t("database.sync-schema.schema-version.self") }}
+        {{ $t("common.changelog") }}
         <div class="textinfolabel">
         {{ t("changelog.select") }}
       </div>

--- a/frontend/src/components/SyncDatabaseSchemaV1/index.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/index.vue
@@ -34,7 +34,7 @@
           >
             <NRadio
               :value="SourceSchemaType.SCHEMA_HISTORY_VERSION"
-              :label="$t('database.sync-schema.schema-history-version')"
+              :label="$t('common.changelog')"
             />
             <NRadio
               :value="SourceSchemaType.RAW_SQL"

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseV1Table.vue
@@ -128,8 +128,8 @@ const columnList = computed((): DatabaseDataTableColumn[] => {
     ),
   };
   const SCHEMA_VERSION: DatabaseDataTableColumn = {
-    key: "schema-version",
-    title: t("common.schema-version"),
+    key: "release",
+    title: t("common.release"),
     minWidth: 140,
     resizable: true,
     hide: props.schemaless,

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -109,7 +109,7 @@
     "confirm": "Confirm",
     "learn-more": "Learn more",
     "troubleshoot": "Troubleshoot",
-    "schema-version": "Schema version",
+    "release": "Release",
     "Default": "Default",
     "definition": "Definition",
     "empty": "Empty",
@@ -1703,14 +1703,10 @@
     "sync-schema": {
       "title": "Sync Schema",
       "description": "Bytebase supports synchronizing a schema to one or multiple target databases. (MySQL, PostgreSQL, Oracle, MSSQL, TiDB only)",
-      "schema-history-version": "Schema History Version",
       "copy-schema": "Copy schema",
       "select-source-schema": "Select source schema",
       "select-target-databases": "Select target databases",
       "source-schema": "Source schema",
-      "schema-version": {
-        "self": "Schema version"
-      },
       "target-databases": "Target databases",
       "with-diff": "With diff",
       "no-diff": "No diff",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -109,7 +109,7 @@
     "confirm": "Confirmar",
     "learn-more": "Aprender más",
     "troubleshoot": "Solucionar problemas",
-    "schema-version": "Versión de esquema",
+    "release": "Release",
     "Default": "Predeterminado",
     "definition": "Definición",
     "empty": "Vacío",
@@ -1703,14 +1703,10 @@
     "sync-schema": {
       "title": "Sincronizar esquema",
       "description": "Bytebase admite la sincronización de un esquema con una o varias bases de datos de destino. (Solo MySQL, PostgreSQL, Oracle, MSSQL, TiDB)",
-      "schema-history-version": "Versión del historial de esquema",
       "copy-schema": "Copiar esquema",
       "select-source-schema": "Seleccione el esquema de origen",
       "select-target-databases": "Seleccione las bases de datos de destino",
       "source-schema": "Esquema de origen",
-      "schema-version": {
-        "self": "Versión de esquema"
-      },
       "target-databases": "Bases de datos de destino",
       "with-diff": "Con diff",
       "no-diff": "Sin diff",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -109,7 +109,7 @@
     "confirm": "確認する",
     "learn-more": "もっと詳しく知る",
     "troubleshoot": "トラブルシューティング",
-    "schema-version": "スキーマのバージョン",
+    "release": "リリース",
     "Default": "デフォルト",
     "definition": "意味",
     "empty": "空欄",
@@ -1703,14 +1703,10 @@
     "sync-schema": {
       "title": "データベーステーブルの同期",
       "description": "Bytebase は、スキーマを 1 つまたは複数のターゲット データベースに同期することをサポートします。(MySQL, PostgreSQL, Oracle, MSSQL, TiDB のみ)",
-      "schema-history-version": "スキーマの履歴バージョン",
       "copy-schema": "スキーマテキストを貼り付け",
       "select-source-schema": "ソーススキーマの選択",
       "select-target-databases": "ターゲットデータベースを選択してください",
       "source-schema": "ソーススキーマ",
-      "schema-version": {
-        "self": "スキーマのバージョン"
-      },
       "target-databases": "ターゲットデータベース",
       "with-diff": "違い",
       "no-diff": "変わりはない",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -109,7 +109,7 @@
     "confirm": "Xác nhận",
     "learn-more": "Tìm hiểu thêm",
     "troubleshoot": "Khắc phục sự cố",
-    "schema-version": "Phiên bản lược đồ",
+    "release": "Release",
     "Default": "Mặc định",
     "definition": "Định nghĩa",
     "empty": "Trống",
@@ -1703,14 +1703,10 @@
     "sync-schema": {
       "title": "Đồng bộ lược đồ",
       "description": "Bytebase hỗ trợ đồng bộ hóa một lược đồ với một hoặc nhiều cơ sở dữ liệu đích. (Chỉ MySQL, PostgreSQL, Oracle, MSSQL, TiDB)",
-      "schema-history-version": "Phiên bản lịch sử lược đồ",
       "copy-schema": "Sao chép lược đồ",
       "select-source-schema": "Chọn lược đồ nguồn",
       "select-target-databases": "Chọn cơ sở dữ liệu đích",
       "source-schema": "Lược đồ nguồn",
-      "schema-version": {
-        "self": "Phiên bản lược đồ"
-      },
       "target-databases": "Cơ sở dữ liệu đích",
       "with-diff": "Với khác biệt",
       "no-diff": "Không có khác biệt",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -109,7 +109,7 @@
     "confirm": "确认",
     "learn-more": "了解更多",
     "troubleshoot": "排查问题",
-    "schema-version": "Schema 版本",
+    "release": "Release",
     "Default": "默认",
     "definition": "定义",
     "empty": "空",
@@ -1703,14 +1703,10 @@
     "sync-schema": {
       "title": "库表同步",
       "description": "Bytebase 支持将一个指定的 Schema 同步到一个或多个目标数据库。（支持 MySQL, PostgreSQL, Oracle, MSSQL 以及 TiDB）",
-      "schema-history-version": "Schema 历史版本",
       "copy-schema": "粘贴 Schema 文本",
       "select-source-schema": "选择源 Schema",
       "select-target-databases": "选择目标数据库",
       "source-schema": "源 Schema",
-      "schema-version": {
-        "self": "Schema 版本"
-      },
       "target-databases": "目标数据库",
       "with-diff": "有差异",
       "no-diff": "无差异",

--- a/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
@@ -67,14 +67,14 @@
               <InstanceV1Name :instance="database.instanceResource" />
             </dd>
             <dt v-if="database.release" class="sr-only">
-              {{ $t("common.version") }}
+              {{ $t("common.release") }}
             </dt>
             <dd
               v-if="database.release"
               class="flex items-center text-sm md:mr-4"
             >
               <span class="ml-1 textlabel"
-                >{{ $t("common.version") }}&nbsp;-&nbsp;</span
+                >{{ $t("common.release") }}&nbsp;-&nbsp;</span
               >
               <span>{{ extractReleaseUID(database.release) }}</span>
             </dd>


### PR DESCRIPTION
## Summary

Replace misleading "schema version" terminology with accurate "release" and "changelog" labels in the UI:

- Change `common.schema-version` → `common.release` for database release field display
- Reuse existing `common.changelog` for changelog selection (remove redundant keys)
- Update DatabaseV1Table column key from `"schema-version"` to `"release"`
- Remove nested i18n structures (flatten `schema-version.self` → `changelog`)

## Changes

**Locale keys updated (all 5 languages):**
- `common.schema-version` → `common.release`
- `database.sync-schema.schema-version.self` → use `common.changelog` (reuse existing)
- `database.sync-schema.changelog-history-version` → use `common.changelog` (reuse existing)

**Components updated:**
- DatabaseV1Table.vue - column key and title
- DatabaseSchemaSelector.vue - changelog label
- SyncDatabaseSchemaV1/index.vue - changelog option label
- DatabaseDetail.vue - release display labels

## Test plan

- [x] Frontend checks passed (ESLint + Biome)
- [x] TypeScript type checking passed
- [ ] Verify database table shows "Release" column instead of "Schema version"
- [ ] Verify sync schema UI shows "Changelog" option
- [ ] Verify database detail page shows "Release" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)