### PR TITLE
fix: use pre-fetched matched databases on database group detail page

### DIFF
--- a/frontend/src/components/DatabaseGroup/DatabaseGroupForm.vue
+++ b/frontend/src/components/DatabaseGroup/DatabaseGroupForm.vue
@@ -40,7 +40,11 @@
           />
         </div>
         <div class="col-span-2">
-          <MatchedDatabaseView :project="project.name" :expr="state.expr" />
+          <MatchedDatabaseView
+            :project="project.name"
+            :expr="state.expr"
+            :matched-database-names="readonly ? matchedDatabaseNames : undefined"
+          />
         </div>
       </div>
     </div>
@@ -123,6 +127,10 @@ const state = reactive<LocalState>({
 const resourceIdField = ref<InstanceType<typeof ResourceIdField>>();
 
 const isCreating = computed(() => props.databaseGroup === undefined);
+
+const matchedDatabaseNames = computed(() => {
+  return props.databaseGroup?.matchedDatabases.map((db) => db.name) ?? [];
+});
 
 watchEffect(async () => {
   const databaseGroup = props.databaseGroup;


### PR DESCRIPTION
On the detail page (readonly mode), matched databases were fetched via getDatabaseGroup with FULL view but then MatchedDatabaseView would redundantly call createDatabaseGroup with validateOnly to fetch the same data. 

Now in readonly mode, the pre-fetched matched databases are passed directly, avoiding the unnecessary API call.